### PR TITLE
fix: use Bearer auth in install.sh, drop token from seed fetch

### DIFF
--- a/.github/actions/sailfin-build/action.yml
+++ b/.github/actions/sailfin-build/action.yml
@@ -32,8 +32,6 @@ runs:
   steps:
     - name: Fetch released seed compiler
       shell: bash -l {0}
-      env:
-        GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
       run: |
         set -euo pipefail
         seed_version="${{ inputs.seed_version }}"

--- a/install.sh
+++ b/install.sh
@@ -83,7 +83,7 @@ api() {
   # $1 = url
   local auth_args=()
   if [ -n "${GITHUB_TOKEN:-}" ]; then
-    auth_args=(-H "Authorization: token ${GITHUB_TOKEN}")
+    auth_args=(-H "Authorization: Bearer ${GITHUB_TOKEN}")
   fi
   curl --fail -sSL \
     "${auth_args[@]}" \
@@ -150,7 +150,7 @@ log "Downloading asset via GitHub API (id=${asset_id})…"
 
 DL_AUTH_ARGS=()
 if [ -n "${GITHUB_TOKEN:-}" ]; then
-  DL_AUTH_ARGS=(-H "Authorization: token ${GITHUB_TOKEN}")
+  DL_AUTH_ARGS=(-H "Authorization: Bearer ${GITHUB_TOKEN}")
 fi
 curl --fail -sSL \
   "${DL_AUTH_ARGS[@]}" \


### PR DESCRIPTION
## Summary
- **install.sh**: Switch `Authorization: token` to `Authorization: Bearer` — works with classic PATs, fine-grained PATs, and `GITHUB_TOKEN` installation tokens
- **sailfin-build action**: Remove `GITHUB_TOKEN` from seed fetch step — public repo doesn't need auth for release asset downloads, and passing a bad-format token was causing 401s

## Why
After switching to a fine-grained PAT for `RELEASE_PAT`, the `Authorization: token` header format caused the GitHub API to reject the request with a 401 instead of falling through to anonymous access.

## Test plan
- [ ] CI build fetches seed without 401
- [ ] `install.sh` still works with no token (anonymous, public repo)
- [ ] `install.sh` still works with a fine-grained PAT if `GITHUB_TOKEN` is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)