### PR TITLE
docs: align README, status, roadmap, and spec with current compiler state

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,74 +1,92 @@
 # Sailfin
 
-Sailfin is an AI-native, systems-friendly programming language designed for precision, safety, and introspection.  
+Sailfin is an AI-native, systems-friendly programming language designed for precision, safety, and introspection.
 Its type system unifies deterministic computation, effect isolation, and capability-aware security to make large-scale model-driven software reliable by default.
 
 ## Why Sailfin
 
 - **Safety without friction** — Algebraic data types, ownership-aware linear typing, and pattern matching keep data pipelines fast and correct without manual memory management.
 - **Deterministic where it counts** — Effects such as `io`, `net`, `model`, `gpu`, `rand`, and `clock` are explicit in type signatures, enabling reproducible builds, replayable model calls, and compile-time guarantees.
-- **AI first-class** — Models, prompts, schemas, embeddings, and retrieval indices are native concepts. The runtime tracks latency, cost, and provenance for every generation automatically.
-- **Capability-oriented security** — Secrets, PII, and data egress policies are enforced through the type system and runtime guards.
+- **AI first-class (planned)** — Models, prompts, schemas, embeddings, and retrieval indices are designed as native concepts. The runtime will track latency, cost, and provenance for every generation automatically. See _What's Coming_ below.
+- **Capability-oriented security** — Secrets, PII, and data egress policies will be enforced through the type system and runtime guards.
 - **Interoperable by design** — Sailfin integrates safely with native binaries and sandboxed adapters while maintaining strong typing and effect boundaries.
 
-## Snapshot
+## What Works Today
+
+The self-hosted native compiler (`build/native/sailfin`) supports:
+
+- Functions, structs, enums, interfaces, type aliases, and generics (parsed; inference is limited)
+- `let`/`let mut` variables, pattern matching (`match`), `if`/`else`, `for`, `while`, `try`/`catch`
+- Effect annotations (`![io, net, model, ...]`) — the effect checker enforces `io`, `net`, and `model` (for `prompt` blocks)
+- String interpolation (`{{ expression }}`), decorators, `async fn`
+- `model` and `prompt` blocks — parsed and emitted to `.sfn-asm` IR; **no runtime model execution yet**
+- `pipeline` declarations — parsed as plain functions; the `|>` operator is not yet implemented
+- `tool` declarations — parsed and recorded; dispatcher is not yet implemented
+- `Affine<T>`, `Linear<T>`, `PII<T>`, `Secret<T>` — parsed; ownership and taint enforcement are not yet active
+- The `sfn/log` capsule for structured logging
+- `print(value)` / `print.err(value)` for stdout/stderr output
+- `sfn test` for running `*_test.sfn` files
 
 ```sfn
-model Summarizer : Model<Text, Summary> {
-  engine     = "gpt-neo@3.1"
-  schema     = Summary
-  max_tok    = 2000
-  cost_cap   = 0.05  // USD (currency literal — planned)
-  evaluators = [ Faithfulness, LatencyBudget(150ms) ]
+struct User {
+  id   -> number;
+  name -> string;
 }
 
-struct Summary {
-  title   -> string;
-  bullets -> Vec<string>;
-  risks?  -> Vec<string>;
+fn greet(user: User) -> string ![io] {
+  let msg = "Hello, {{ user.name }}!";
+  print(msg);
+  return msg;
 }
 
-fn summarize_doc(doc: Text) -> Summary ![io, model] {
-  prompt system {
-    "You are a careful technical summarizer. Output matches `Summary`."
-  }
-  prompt user {
-    "Summarize:\n{{ doc }}"
-  }
-
-  let generation = Summarizer.call()
-  print.info(generation.card)      // provenance metadata
-  generation.output                // typed `Summary`
-}
-Prompt evaluation order: prompts execute in source order; the common sequence is
-system → user → assistant → tool.
-
-Typed prompts (planned): `prompt user<SummaryRequest> { ... }` is design-stage
-syntax for shape-checked prompts and is not yet accepted by the compiler.
-
-pipeline index_corpus(docs: Seq<Text>) ![io, gpu] {
-  // Future syntax note: the `|>` operator is planned and not yet accepted by
-  // the compiler. Use ordinary function calls until the operator lands.
-  docs
-    |> chunk(by: "semantic", target_tokens: 512)
-    |> embed(with: "e5-large")
-    |> upsert(index: "docs_idx")
+test "greet produces correct output" {
+  let u = User { id: 1, name: "Alice" };
+  let result = greet(u);
+  assert(result == "Hello, Alice!");
 }
 ```
 
+## What's Coming
+
+Sailfin is working toward a 1.0 release with a fully self-hosted toolchain — no Python build scripts, no C runtime. Key upcoming milestones:
+
+- **Compiler stabilization** — eliminating the Python post-processing fixup script; `build.sh` becomes the sole build path
+- **Sailfin-native runtime** — replacing the current C runtime; a hard prerequisite for 1.0
+- **Concurrency primitives** — `await`, `routine { }` blocks, and `channel()` as first-class constructs
+- **Full ownership enforcement** — move semantics, borrow checking, use-after-move errors
+
+After 1.0, the focus shifts to making AI constructs fully functional:
+
+```sfn
+// Future: model execution, typed prompt blocks, generation cards, and provenance metadata
+model Summarizer : Model<Text, Summary> {
+  engine    = "gpt-neo@3.1"
+  schema    = Summary
+  max_tok   = 2000
+  // cost_cap = 0.05  // USD — currency literal syntax planned
+}
+
+fn summarize_doc(doc: Text) -> Summary ![io, model] {
+  prompt system { "You are a careful technical summarizer." }
+  prompt user   { "Summarize:\n{{ doc }}" }
+  let generation = Summarizer.call()
+  print(generation.card)    // provenance metadata
+  return generation.output  // typed Summary
+}
+```
+
+See `docs/status.md` for a detailed feature matrix and `docs/roadmap.md` for sequencing.
+
 ## Current Status
 
-Sailfin is under active design and self-hosting. The self-hosted native compiler
-is the primary toolchain today. The runtime currently ships as C and will move
-to a Sailfin-native runtime before the 1.0 release, alongside removing any
-Python tooling from the production pipeline.
+Sailfin is under active development targeting a 1.0 release. The recommended compiler is `v0.1.1` (pinned in CI); releases past that point are built with the Python stabilization script and are pre-stabilization artifacts.
 
-- `docs/status.md` — source of truth for what the compiler enforces versus what is still planned.
-- `docs/spec.md` — language reference with design-preview callouts.
-- `docs/enbf.md` — grammar sketch aligned to the current parser.
-- `docs/keywords.md` — reserved words and runtime notes.
+- `docs/status.md` — source of truth for what the compiler enforces versus what is still planned
+- `docs/spec.md` — language reference with design-preview callouts
+- `docs/roadmap.md` — milestones and sequencing toward 1.0
+- `docs/enbf.md` — grammar sketch aligned to the current parser
 
-## Installing the compiler
+## Installing the Compiler
 
 The compiler is published as per-OS/arch release assets and can be installed via
 the curlable `install.sh` script (Linux/macOS) or `install.ps1` (Windows).
@@ -114,18 +132,7 @@ runtime, and tooling capsules. The current repository hosts the native compiler
 (under `build/native`) alongside the Sailfin runtime (`runtime/`). Future capsule
 manifests and fleet layout are tracked in `docs/roadmap.md`.
 
-## Roadmap Highlights
-
-Major milestones and sequencing are captured in `docs/roadmap.md`. Consult the
-status page before editing documentation or examples to confirm whether a
-feature has shipped.
-
-## Contributing
-
-Sailfin is evolving quickly. See `CONTRIBUTING.md` (coming soon) and join the discussion in issues once the repository is public.  
-For now, experiment, record findings, and propose ideas through pull requests.
-
-### Local Development
+## Local Development
 
 - `make env` — create or update the `sailfin` Conda environment defined in `environment.yml`. Only needed for `BUILD_DRIVER=py`; the default shell driver has no Conda requirement.
 - `make compile` — build the native compiler by self-hosting from a released seed.
@@ -142,6 +149,7 @@ sfn --version
 sfn test .
 ```
 
-The Sailfin registry at `registry.sailfin.dev` is live for experiments; manifest
-workflows are still in progress, so treat registry examples in the docs as design
-previews.
+## Contributing
+
+Sailfin is evolving quickly. See `CONTRIBUTING.md` and join the discussion in issues.
+For experiments, record findings and propose ideas through pull requests.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,63 +1,122 @@
 # Sailfin Roadmap
 
-Updated: January 19, 2026  
+Updated: March 31, 2026
 Owners: Sailfin Core Team
 
 This roadmap pairs with `docs/status.md`. Update status first, then record
-strategy changes here. The focus is the 1.0 public release and the immediate
-work after launch. Legacy compiler stages are no longer tracked in this plan.
+strategy changes here. The focus is the 1.0 public release and the work after
+launch. Legacy compiler stage references are no longer tracked in this plan.
 
 ## Release 1.0 Priorities (Do Now)
 
-1. **Release pipeline and distribution hardening**
-   - [ ] Publish signed checksums and provenance metadata alongside release artifacts.
-   - [ ] Add installer CI that validates `install.sh` against staging artifacts.
-   - [ ] Document artifact layout, supported platforms, and upgrade expectations in `docs/README.md`.
-   - [ ] Verify build/release workflows only use self-hosted compiler artifacts.
+The 1.0 release requires a **fully self-hosted toolchain with no Python scripts
+or C runtime**. All items below are hard requirements, not stretch goals.
 
-2. **Compiler stability and diagnostics**
+1. **Compiler stabilization (build pipeline)**
+   - [ ] Eliminate the Python fixup script (`scripts/selfhost_native.py`) as a
+         build requirement. Every fixup it applies must become a compiler fix in
+         `compiler/src/*.sfn`.
+   - [ ] Make `scripts/build.sh` the sole clean build path (no post-processing).
+   - [ ] Pass `make check` using the shell driver: seedcheck binary compiles
+         `examples/basics/hello-world.sfn` and passes the full test suite with no
+         Python fallbacks.
+   - [ ] Stabilize control-flow LLVM lowering (`.loop` / `.if` / `.break`
+         headers) so the seedcheck binary does not hang.
+
+2. **Language feature completeness**
+   - [ ] Implement `await` expression parsing and lowering.
+   - [ ] Implement `routine { }` block parsing and lowering (concurrent tasks).
+   - [ ] Implement `channel()` as a concurrency primitive (not just prompt syntax).
+   - [ ] Implement `spawn` expression.
    - [ ] Complete generic type inference for functions, structs, and enums.
    - [ ] Finish interface conformance validation, including variance checks.
+   - [ ] Enforce `Affine<T>` / `Linear<T>` move and consume rules.
    - [ ] Implement richer diagnostics (multi-span snippets, severity, suggested fixes).
    - [ ] Add `--fix` workflow for missing effect annotations with safe rewrite guards.
+   - [ ] Enforce `gpu`, `rand`, and hierarchical effect names (`io.fs`, `net.http`).
 
-3. **Sailfin-native runtime for 1.0**
+3. **Sailfin-native runtime (hard 1.0 prerequisite)**
+   - The C runtime (`runtime/native/`) must be replaced by a Sailfin-native
+     runtime before 1.0. This is a breaking change and the right moment to make
+     it is at 1.0, not after.
    - [ ] Execute the Sailfin runtime migration plan in `docs/runtime_audit.md`.
    - [ ] Finalize the Sailfin-native ABI spec in `docs/runtime_abi.md`.
    - [ ] Implement the Sailfin-native ABI and versioned layouts.
    - [ ] Define the runtime ownership/memory model and update lowering to match.
    - [ ] Port core runtime helpers (strings, arrays, exceptions, type metadata).
-   - [ ] Replace the current exception plumbing with a structured model supported by the native runtime.
+   - [ ] Replace exception plumbing with a structured model in the native runtime.
    - [ ] Remove the C runtime once parity and performance gates are satisfied.
-   - [ ] Ship Sailfin-native filesystem, HTTP, and model adapters.
-   - [ ] Document capability adapter behavior and platform requirements in `docs/runtime_audit.md`.
+   - [ ] Ship Sailfin-native filesystem, HTTP, and clock adapters.
+   - [ ] Document capability adapter behavior and platform requirements in
+         `docs/runtime_audit.md`.
 
 4. **Tooling and developer workflow**
    - [ ] Replace the current `sfn` shell wrapper with a Sailfin-native CLI binary.
    - [ ] Replace the C `native_driver` with a Sailfin-native CLI entrypoint.
-   - [ ] Remove Python tooling/scripts from the release pipeline and developer entrypoints.
-   - [x] Remove Python runtime shims (`runtime/runtime_support.py`, `runtime/native_runner*.py`).
-   - [ ] Remove Python-generated compiler artifacts (`compiler/build/**`) from the 1.0 toolchain.
+   - [ ] Remove Python tooling/scripts from the release pipeline and developer
+         entrypoints entirely.
+   - [x] Remove Python runtime shims (`runtime/runtime_support.py`,
+         `runtime/native_runner*.py`).
+   - [ ] Remove Python-generated compiler artifacts from the 1.0 toolchain.
 
-5. **Documentation for public release**
+5. **Release pipeline and distribution hardening**
+   - [ ] Publish signed checksums and provenance metadata alongside release artifacts.
+   - [ ] Add installer CI that validates `install.sh` against staging artifacts.
+   - [ ] Document artifact layout, supported platforms, and upgrade expectations.
+   - [ ] Verify build/release workflows only use self-hosted compiler artifacts.
+
+6. **Documentation for public release**
    - [ ] Remove legacy compiler-stage references across docs and examples.
    - [ ] Refresh `docs/spec.md` and `docs/keywords.md` to reflect shipped syntax.
    - [ ] Ensure `docs/status.md` and `README.md` match installer defaults and CLI usage.
 
-## Post-1.0 (Immediate Follow-On)
+## Post-1.0 — AI / Model Execution (First Major Follow-On)
 
-- [ ] **Async runtime** — Ship a Sailfin-native event loop, task scheduler, and channel primitives once coroutine lowering is stable.
-- [ ] **Runtime diagnostics** — Add structured tracing, allocation telemetry, and performance profiling hooks.
-- [ ] **Package registry workflow** — Finalize manifests, implement `sfn init/add/publish`, and stand up registry auth/signing.
-- [ ] **Native test framework** — Replace pytest suites with Sailfin-native tests and CI reporting.
+The AI-native features are central to Sailfin's design and fully specified, but
+require a stable self-hosted runtime and toolchain as a foundation. They ship
+after 1.0 as the first major milestone.
+
+- [ ] **Model runtime** — implement `Model<I, O>.call()` execution; wire `model`
+      blocks to provider adapters (OpenAI-compatible, local, etc.).
+- [ ] **Generation cards** — produce signed provenance metadata (engine, params,
+      seeds, input hashes, latency, cost) for every model call.
+- [ ] **Prompt dispatch** — implement the prompt channel execution pipeline
+      (`system` → `user` → `assistant` → `tool`).
+- [ ] **Tool dispatcher** — implement model-invocable typed capabilities with
+      capability and taint policy enforcement before execution.
+- [ ] **Typed prompt channels** — `prompt user<SummaryRequest> { }` with
+      shape-checked prompts.
+- [ ] **Evaluators** — `Faithfulness`, `LatencyBudget(...)`, and the evaluator
+      suite framework.
+- [ ] **`PII<T>` / `Secret<T>` enforcement** — runtime taint tracking, egress
+      guards, and redaction transformers.
+- [ ] **Model evaluators and replay** — golden tests, adversarial suites,
+      generation card replay.
+- [ ] **Sailfin-native model adapters** — HTTP/gRPC adapters for model providers.
+
+## Post-1.0 — Platform and Ecosystem
+
+- [ ] **Async runtime** — ship a Sailfin-native event loop, task scheduler, and
+      channel primitives once coroutine lowering is stable (builds on the 1.0
+      concurrency work).
+- [ ] **Runtime diagnostics** — structured tracing, allocation telemetry, and
+      performance profiling hooks.
+- [ ] **Package registry workflow** — finalize manifests, implement
+      `sfn init/add/publish`, and stand up registry auth/signing.
+- [ ] **Native test framework** — golden/adversarial/replay workflows in
+      `sfn test`; CI reporting.
+- [ ] **Tensor/GPU effects** — `Vector<N>`, `Tensor<Shape, DType>`, GPU batching,
+      and the `gpu` effect runtime.
+- [ ] **`|>` pipeline operator** — implement parsing and lowering of the pipe
+      operator; enable async/lazy pipelines with backpressure.
 
 ## Exploration Backlog (Research / Design)
 
 - [ ] WebAssembly emission once LLVM backend coverage is complete.
-- [ ] `unsafe` capability design for explicit FFI boundaries.
-- [ ] Model engines & training workflow (see `docs/proposals/model-engines-and-training.md`).
-- [ ] Tensor/GPU effects and `Tensor<T>` primitives.
-- [ ] Notebook, LSP, and interactive tooling.
+- [ ] `unsafe` capability enforcement for explicit FFI boundaries.
+- [ ] Currency literals (`$0.05`) and time literals (`1s`, `150ms`).
+- [ ] Notebook, LSP, and interactive tooling with live cost/latency overlays.
+- [ ] Training workflow (see `docs/proposals/model-engines-and-training.md`).
 
 ## Completed Items
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1,7 +1,7 @@
 # Sailfin Language Specification
 
-Version: 0.2.1 (design preview)
-Date: October 2025
+Version: 0.2.2 (design preview)
+Date: March 2026
 
 Sailfin is an AI-native, expression-oriented programming language that combines
 Rust-grade safety, Swift-like ergonomics, and runtime observability. This
@@ -227,6 +227,12 @@ type Result<T> = Response | T;
 
 ### 3.6 Model Declarations
 
+> **Current status**: `model` blocks are parsed and emit a `.model` directive in
+> `.sfn-asm` IR. However, **model execution is not yet implemented** — `.call()`
+> parses as a method call but no model runtime exists. Generation cards and
+> evaluators are design-stage. This entire section describes the planned
+> semantics; see `docs/status.md` for implementation state.
+
 Models are first-class program artefacts. A `model` block declares metadata,
 versions, schemas, and evaluator suites, producing a `Model<Input, Output>`
 value.
@@ -243,7 +249,8 @@ model Summarizer : Model<Text, Summary> {
 
 Calling a model requires the `model` effect, returns a typed output, and yields
 a signed **generation card** containing provenance (engine, params, seeds,
-input hashes, latency, cost).
+input hashes, latency, cost). Both the call mechanism and generation cards are
+planned for the post-1.0 AI milestone.
 
 ### 3.6.1 Model Block Schema
 
@@ -381,18 +388,26 @@ adapter boundaries.
 
 ## 5. Concurrency and Performance
 
-- **Async & routines** – `async fn` enables `await`; `routine { … }` launches a
-  concurrent task. The current runtime maps routines to the runtime scheduler.
-- **Structured scopes** – The design introduces `scope` values that carry
-  cancellation, deadlines, and determinism knobs (`seed`, `temperature`). These
-  are partially stubbed today and will be fully enforced in the native runtime.
-- **Channels** – In the current runtime, channels are unbounded by default
-  unless a capacity is provided. Use `channel(capacity: N)` to enable
-  backpressure. The native runtime will prefer bounded channels by default.
-- **Accelerators** – Operations requiring GPUs/TPUs must declare the `gpu`
-  effect. The runtime batches compatible tensor work automatically.
+> **Current status**: Concurrency primitives are in progress. `async fn` is
+> parsed and the `is_async` flag is recorded on function declarations, but
+> `await`, `routine { }` blocks, `spawn`, and `channel()` as a concurrency
+> primitive are **not yet implemented** in the parser or lowering. The design
+> below describes the planned semantics; use ordinary function calls in current
+> code.
+
+- **Async & routines (planned)** – `async fn` will enable `await`; `routine { … }` will launch a
+  concurrent task mapped to the runtime scheduler.
+- **Structured scopes (planned)** – `scope` values will carry cancellation, deadlines, and
+  determinism knobs (`seed`, `temperature`).
+- **Channels (planned)** – `channel(capacity: N)` will create a bounded channel with backpressure.
+  The native runtime will prefer bounded channels by default.
+- **Accelerators (planned)** – Operations requiring GPUs/TPUs must declare the `gpu`
+  effect. The runtime will batch compatible tensor work automatically.
+
+Planned syntax (not accepted by the current compiler):
 
 ```sfn
+// Planned concurrency syntax — not yet implemented
 async fn main() ![io, model] {
   // Planned: `1s` time literal and `scope.with_timeout(...)` API.
   let scope = scope.with_timeout(1s);
@@ -403,9 +418,8 @@ async fn main() ![io, model] {
   }
 
   let result = await messages.receive();
-  print.info("Received: {{ result }}");
+  print("Received: {{ result }}");
 }
-
 ```
 
 ### 5.1 is operator (type / pattern guard)

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,39 +1,129 @@
 # Status
 
-This document tracks what works today and what is in progress.
+Updated: March 31, 2026
+
+This document tracks what works today and what is in progress. It is the source
+of truth — consult it before editing docs, examples, or making claims about
+feature availability.
+
+## Build Pipeline (Current)
+
+- CI pins to `v0.1.1` as the seed compiler. Releases past that version are built
+  with the Python stabilization script (`scripts/selfhost_native.py`) and are
+  pre-stabilization artifacts with known issues.
+- `scripts/selfhost_native.py` (~13,000 lines) applies post-processing fixups to
+  generated LLVM IR to work around current compiler bugs. This is build debt.
+- `scripts/build.sh` is the clean target — no fixups. It does not yet succeed;
+  eliminating the Python script is a hard 1.0 requirement.
+- `make compile` (default `BUILD_DRIVER=py`) uses the Python script. `make check`
+  validates the seedcheck binary can run `hello-world.sfn` and pass the test suite.
 
 ## Compiler Pipeline (Current)
 
-- The self-hosted native compiler in `compiler/src/` is the primary toolchain; `make compile` produces `build/native/sailfin`.
-- Experimental LLVM JIT execution remains available for targeted backend coverage.
-- CI uses the native build workflow (`.github/workflows/ci.yml`) to build, test, and attach release assets.
-- Native compiler tests live in `compiler/tests/{unit,integration,e2e}` and run via `sfn test` (build output: `build/native/sailfin test .`; installed: `sfn test .`; `make test-unit`, `make test-integration`, `make test-e2e`).
-- The test runner inlines relative imports (including `compiler/src/*`) into a single compilation unit to avoid missing symbols when executing `sfn test`.
-- Native AOT builds do not rely on any `aot-prepare` text rewrite step; the native compiler emits link-safe LLVM IR directly.
+- The self-hosted native compiler in `compiler/src/` is the primary toolchain;
+  `make compile` produces `build/native/sailfin`.
+- Pipeline: Lexer → Parser → Type Checker → Effect Checker → Native Emitter
+  (`.sfn-asm` IR) → LLVM Lowering.
+- Experimental LLVM JIT execution is available for targeted backend coverage.
+- CI uses the native build workflow (`.github/workflows/ci.yml`) to build, test,
+  and attach release assets.
+- Native compiler tests live in `compiler/tests/{unit,integration,e2e}` and run
+  via `sfn test` or `make test-unit`, `make test-integration`, `make test-e2e`.
+
+## Feature Matrix
+
+| Feature | Status | Notes |
+|---|---|---|
+| `let` / `let mut` variables | Shipped | Type annotations optional; limited inference |
+| Functions (`fn`) | Shipped | Including generics, default params, decorators |
+| `async fn` | Parsed | `await` is **not** parsed; async is structural only |
+| Structs | Shipped | Including generic params, `implements` clause |
+| Interfaces | Shipped | Trait-style method signatures |
+| Enums / ADTs | Shipped | Variants with payloads |
+| Type aliases | Shipped | Including generic params |
+| `if`/`else` | Shipped | |
+| `for` / `while` loops | Shipped | |
+| `match` | Shipped | Literals, `_` wildcard, guards; destructuring enum variants |
+| `try`/`catch`/`finally` | Shipped | Maps to runtime exceptions |
+| String interpolation (`{{ }}`) | Shipped | |
+| Pattern matching exhaustiveness | Partial | Runtime backstop via `match_exhaustive_failed` |
+| Effect annotations (`![...]`) | Shipped | Parsing and declaration |
+| Effect enforcement — `io` | Shipped | `print.*`, `console.*`, `fs.*`, `@logExecution` |
+| Effect enforcement — `net` | Shipped | `http.*`, `websocket.*`, `serve` |
+| Effect enforcement — `model` | Shipped | Required for any `prompt` block |
+| Effect enforcement — `clock` | Partial | `sleep`/`runtime.sleep` checked; hierarchical names not enforced |
+| Effect enforcement — `gpu`, `rand` | Parsed only | Accepted syntactically; not validated |
+| Generic type inference | Partial | Type params captured; inference coverage is limited |
+| Interface conformance validation | Partial | Basic checks; variance not yet enforced |
+| `Affine<T>` / `Linear<T>` | Parsed only | Ownership wrappers accepted; move/consume rules not enforced |
+| `&T` / `&mut T` borrows | Parsed only | Accepted syntactically; exclusivity not checked |
+| `PII<T>` / `Secret<T>` | Parsed only | Parsed as nominal types; no taint enforcement |
+| `model` declarations | Parsed + IR | Emits `.model` directive in `.sfn-asm`; **no runtime execution** |
+| `prompt` blocks | Parsed + IR | Emits `.prompt` directive; **no runtime execution** |
+| `pipeline` declarations | Parsed + IR | Parsed as plain functions; `\|>` operator **not implemented** |
+| `tool` declarations | Parsed + IR | Recorded as metadata; no dispatcher |
+| `routine { }` blocks | **Not implemented** | Not parsed |
+| `await` | **Not implemented** | Not parsed |
+| `channel()` concurrency | **Not implemented** | Not parsed as concurrency primitive |
+| `spawn` | **Not implemented** | Not parsed |
+| Model execution (`.call()`) | **Not implemented** | Parses as method call; no model runtime |
+| Generation cards / provenance | **Not implemented** | Planned alongside model execution |
+| Typed prompt channels | **Not implemented** | `prompt user<T> { }` is design-stage syntax |
+| `\|>` pipeline operator | **Not implemented** | |
+| Currency literals (`$0.05`) | **Not implemented** | Use numeric literal + comment |
+| Time literals (`1s`, `150ms`) | **Not implemented** | Use numeric literals |
+| `scope.with_timeout(...)` | **Not implemented** | |
+| `unsafe` / `extern` | Parsed only | Syntax accepted; enforcement not active |
+| Policy decorators (`@policy(...)`) | Parsed only | No compiler or runtime effect |
+| LSP / notebook support | Not started | Post-1.0 |
+| Package registry (`sfn add/publish`) | Not started | Post-1.0 |
 
 ## Print API (Current)
 
-- `print(value)` is the canonical output builtin (stdout, no prefix). `print.err(value)` writes to stderr.
-- `print.info`/`print.warn`/`print.error` are deprecated legacy variants kept for backward compatibility; new code should use `print()` and `print.err()`.
-- The `sfn/log` capsule provides structured logging (`log.info`, `log.warn`, `log.error`, `log.debug`) with named loggers and fields. `log.warn` and `log.error` route to stderr via `print.err()`.
+- `print(value)` is the canonical output builtin (stdout, no prefix).
+- `print.err(value)` writes to stderr.
+- `print.info`/`print.warn`/`print.error` are deprecated legacy variants kept for
+  backward compatibility; new code should use `print()` and `print.err()`.
+- The `sfn/log` capsule provides structured logging (`log.info`, `log.warn`,
+  `log.error`, `log.debug`) with named loggers and fields. `log.warn` and
+  `log.error` route to stderr via `print.err()`.
 
 ## Runtime (Current)
 
-- The runtime is implemented in C under `runtime/native/` and linked into the native compiler binary.
-- The native CLI locates a bundled runtime next to the executable (override with `SAILFIN_RUNTIME_ROOT`) when building or running programs.
-- Legacy Python runtime shims have been removed; the 1.0 toolchain does not rely on `runtime/*.py` helpers.
-- The native filesystem adapter supports `readFile`, `writeFile`, `appendFile`, `writeLines`, and directory helpers.
-- The runtime will be reimplemented in Sailfin before the 1.0 release.
+- The runtime is implemented in C under `runtime/native/` and linked into the
+  native compiler binary.
+- The native CLI locates a bundled runtime next to the executable (override with
+  `SAILFIN_RUNTIME_ROOT`).
+- Legacy Python runtime shims have been removed; the toolchain does not rely on
+  `runtime/*.py` helpers.
+- The native filesystem adapter supports `readFile`, `writeFile`, `appendFile`,
+  `writeLines`, and directory helpers.
+- **The C runtime will be replaced by a Sailfin-native runtime before 1.0.** This
+  is a hard prerequisite for the 1.0 release, not a post-1.0 item. See
+  `docs/roadmap.md` and `docs/runtime_audit.md`.
 
 ## Installer (Current)
 
-- The installer defaults to `~/.local/bin` on all platforms (override with `GLOBAL_BIN_DIR`).
+- The installer defaults to `~/.local/bin` on all platforms (override with
+  `GLOBAL_BIN_DIR`).
+- Pinned stable version for development: `v0.1.1-alpha.135`.
 
-## Near-Term Goals
+## AI / Model Features (Design Preview)
 
-- Keep the native compiler stable as the primary compiler.
-- Deliver the Sailfin-native runtime and remove C runtime dependencies before 1.0.
-- Ship Sailfin-native filesystem, HTTP, and model adapters before 1.0.
-- Finalize the Sailfin-native ABI spec in `docs/runtime_abi.md`.
-- Remove all Python tooling/shims from production pipelines and release artifacts.
-- Remove Python-generated compiler artifacts from the 1.0 toolchain.
+The following features are central to Sailfin's AI-native vision and are fully
+designed. They are tracked in the spec (`docs/spec.md` Part B) and proposals
+(`docs/proposals/`) but are **not yet functional** in the current compiler or
+runtime:
+
+- `model` blocks declare metadata and are emitted to `.sfn-asm`, but `.call()`
+  performs no actual model invocation.
+- `prompt` blocks emit IR directives but do not dispatch to any model API.
+- Generation cards (provenance metadata: engine, params, seeds, input hashes,
+  latency, cost) are not yet produced.
+- Model evaluators (`Faithfulness`, `LatencyBudget(...)`) are design-stage.
+- `tool` dispatcher (model-invocable typed capabilities) is not yet implemented.
+- Tensor/GPU workloads (`Vector<N>`, `Tensor<Shape, DType>`, GPU batching) are
+  not yet implemented.
+
+These features are tracked as a post-1.0 milestone. The design is preserved in
+`docs/spec.md` §3.6–§3.9 and `docs/proposals/model-engines-and-training.md`.


### PR DESCRIPTION
- README: replace AI-model snapshot with working code; add honest "What
  Works Today" and "What's Coming" sections; mark model/AI features as
  planned; note v0.1.1 is the pinned stable release
- docs/status.md: expand to a full feature matrix distinguishing shipped,
  partial, parsed-only, and not-yet-implemented features; call out that
  routine/await/channel/spawn are not parsed; document model/prompt blocks
  as parse+IR only with no runtime execution; note Python fixup script debt
- docs/roadmap.md: add Compiler Stabilization as a hard 1.0 priority
  (eliminate Python fixup script); move Sailfin-native runtime rewrite up
  as a hard 1.0 prerequisite; add language feature completeness (await,
  routine, channel, spawn, ownership enforcement) as 1.0 items; move all
  AI/model execution to a dedicated post-1.0 milestone
- docs/spec.md: add explicit "not yet implemented" callouts to §3.6 model
  declarations and §5 concurrency; mark planned concurrency code blocks as
  not accepted by the current compiler; bump version date

https://claude.ai/code/session_017nyy9cYcDDZ1mwrWybZoRj