### PR TITLE
ci: fix sfn token name

### DIFF
--- a/.github/workflows/capsule-release.yml
+++ b/.github/workflows/capsule-release.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Detect changed capsules and publish
         env:
-          SAILFIN_REGISTRY_PUBLISH_TOKEN: ${{ secrets.SAILFIN_REGISTRY_PUBLISH_TOKEN }}
+          SFN_TOKEN: ${{ secrets.SFN_TOKEN }}
         run: |
           set -euo pipefail
 


### PR DESCRIPTION
CI publish workflow was using a token name that the cli doesnt recognize. Added SFN_TOKEN to the GitHub actions secrets and adjust workflow to point to it.