### PR TITLE
fix: eliminate 3 Phi/SSA fixups by fixing root causes in compiler source

### DIFF
--- a/compiler/src/llvm/expression_lowering/native/statement.sfn
+++ b/compiler/src/llvm/expression_lowering/native/statement.sfn
@@ -1400,6 +1400,7 @@ fn prepare_parameters(function -> NativeFunction, context -> TypeContext) -> Par
     let mut signature -> string[] = [];
     let mut bindings -> ParameterBinding[] = [];
     let mut diagnostics -> string[] = [];
+    let mut seen_names -> string[] = [];
     let mut index -> number = 0;
     loop {
         if index >= function.parameters.length {
@@ -1426,13 +1427,28 @@ fn prepare_parameters(function -> NativeFunction, context -> TypeContext) -> Par
                 }
             }
         }
+        // Default empty types to i8* so LLVM IR is parseable.
+        if llvm_type.length == 0 {
+            llvm_type = "i8*";
+        }
         if parameter.type_annotation.length == 0 {
             if !inferred_self_type {
                 diagnostics.push("llvm lowering: parameter `" + parameter.name + "` missing type annotation; defaulting to `" + llvm_type + "`");
             }
         }
         let sanitized = sanitize_symbol(parameter.name);
-        let llvm_name = "%" + sanitized;
+        // Deduplicate parameter names: if this name was already used,
+        // append a numeric suffix to make it unique (LLVM requires unique param names).
+        let mut llvm_name = "%" + sanitized;
+        let mut dedup_count -> number = 1;
+        loop {
+            if !string_array_contains(seen_names, llvm_name) {
+                break;
+            }
+            dedup_count += 1;
+            llvm_name = "%" + sanitized + "_" + number_to_string(dedup_count);
+        }
+        seen_names.push(llvm_name);
         signature.push(llvm_type + " " + llvm_name);
         let prep_binding = _ipc_make_parameter_binding(parameter.name, llvm_name, llvm_type, parameter.type_annotation);
         bindings = append_parameter_binding(bindings, prep_binding);

--- a/compiler/src/llvm/lowering/emission.sfn
+++ b/compiler/src/llvm/lowering/emission.sfn
@@ -28,6 +28,7 @@ import {
     trim_text,
     starts_with,
     append_parameter_binding,
+    string_array_contains,
 } from "../utils";
 
 import {
@@ -180,6 +181,97 @@ fn parse_simple_integer(text -> string) -> number {
     return result;
 }
 
+// Reorder lines within each basic block so that phi nodes come first.
+// LLVM requires phi nodes to appear contiguously at the start of a block (after the label).
+fn _reorder_phis_to_block_start(lines -> string[]) -> string[] {
+    let mut out -> string[] = [];
+    let mut block_phi_lines -> string[] = [];
+    let mut block_other_lines -> string[] = [];
+    let mut in_block -> boolean = false;
+    let mut i -> number = 0;
+    loop {
+        if i >= lines.length {
+            break;
+        }
+        let line = lines[i];
+        let trimmed = trim_text(line);
+        // Detect block label: non-empty, ends with ":", not indented (not a store/instruction).
+        let mut is_label -> boolean = false;
+        if trimmed.length > 1 {
+            let last_ch = substring(trimmed, trimmed.length - 1, trimmed.length);
+            if last_ch == ":" {
+                // Labels are not indented; indented lines ending with : are not labels.
+                if line.length > 0 {
+                    let first_ch = substring(line, 0, 1);
+                    if first_ch != " " {
+                        is_label = true;
+                    }
+                }
+            }
+        }
+        if is_label {
+            // Flush previous block: phis first, then other lines.
+            if in_block {
+                let mut _pi -> number = 0;
+                loop {
+                    if _pi >= block_phi_lines.length { break; }
+                    out.push(block_phi_lines[_pi]);
+                    _pi += 1;
+                }
+                let mut _oi -> number = 0;
+                loop {
+                    if _oi >= block_other_lines.length { break; }
+                    out.push(block_other_lines[_oi]);
+                    _oi += 1;
+                }
+            }
+            block_phi_lines = [];
+            block_other_lines = [];
+            in_block = true;
+            out.push(line);
+            i += 1;
+            // skip next line if it's empty (cosmetic)
+            // no, just continue
+        } else {
+            if in_block {
+                // Check if this is a phi instruction.
+                let mut is_phi -> boolean = false;
+                if starts_with(trimmed, "%") {
+                    // Pattern: %tN = phi ...
+                    let eq_pos = index_of(trimmed, "= phi ");
+                    if eq_pos > 0 {
+                        is_phi = true;
+                    }
+                }
+                if is_phi {
+                    block_phi_lines.push(line);
+                } else {
+                    block_other_lines.push(line);
+                }
+            } else {
+                out.push(line);
+            }
+            i += 1;
+        }
+    }
+    // Flush final block.
+    if in_block {
+        let mut _pi2 -> number = 0;
+        loop {
+            if _pi2 >= block_phi_lines.length { break; }
+            out.push(block_phi_lines[_pi2]);
+            _pi2 += 1;
+        }
+        let mut _oi2 -> number = 0;
+        loop {
+            if _oi2 >= block_other_lines.length { break; }
+            out.push(block_other_lines[_oi2]);
+            _oi2 += 1;
+        }
+    }
+    return out;
+}
+
 // Helper: build a ParameterBinding for the file-IPC loop in prepare_parameters_from_files.
 // Kept as a separate function so the loop never has an inline struct literal at the top level
 // of the loop body — the v0.1.1 seed misidentifies `identifier {` as a loop-body closer.
@@ -202,6 +294,7 @@ fn prepare_parameters_from_files(fn_name -> string, fn_param_count -> number, co
     let mut signature -> string[] = [];
     let mut bindings -> ParameterBinding[] = [];
     let mut diagnostics -> string[] = [];
+    let mut seen_names -> string[] = [];
     let mut index -> number = 0;
     loop {
         if index >= fn_param_count {
@@ -213,11 +306,26 @@ fn prepare_parameters_from_files(fn_name -> string, fn_param_count -> number, co
         if llvm_type == "void" {
             llvm_type = "";
         }
+        // Default empty types to i8* so LLVM IR is parseable.
+        if llvm_type.length == 0 {
+            llvm_type = "i8*";
+        }
         if param_type.length == 0 {
             diagnostics.push("llvm lowering: parameter `" + param_name + "` missing type annotation; defaulting to `" + llvm_type + "`");
         }
         let sanitized = sanitize_symbol(param_name);
-        let llvm_name = "%" + sanitized;
+        // Deduplicate parameter names: if this name was already used,
+        // append a numeric suffix to make it unique (LLVM requires unique param names).
+        let mut llvm_name = "%" + sanitized;
+        let mut dedup_count -> number = 1;
+        loop {
+            if !string_array_contains(seen_names, llvm_name) {
+                break;
+            }
+            dedup_count += 1;
+            llvm_name = "%" + sanitized + "_" + number_to_string(dedup_count);
+        }
+        seen_names.push(llvm_name);
         signature.push(llvm_type + " " + llvm_name);
         bindings = append_parameter_binding(bindings, _emit_make_parameter_binding(param_name, llvm_name, llvm_type, param_type));
         index += 1;
@@ -760,6 +868,9 @@ fn emit_llvm_function(
             }
         }
     }
+
+    // Ensure phi nodes appear at the top of each basic block (LLVM requirement).
+    lines = _reorder_phis_to_block_start(lines);
 
     lines.push("}");
 

--- a/compiler/src/llvm/lowering/instructions.sfn
+++ b/compiler/src/llvm/lowering/instructions.sfn
@@ -37,6 +37,7 @@ import {
     extend_mutations,
     _write_block_result_files,
     _parse_int_from_string,
+    _read_ipc_int_min,
     write_bindings_to_files,
     write_locals_to_files,
     read_expr_string_constants,
@@ -254,9 +255,9 @@ fn lower_instruction_range(
             let lowered = lower_let_instruction(function, instruction, current_bindings, current_locals, current_allocas, current_lines, current_temp, current_next_local, current_next_region, functions, context, scope_id, scope_depth, active_label);
             current_locals = read_let_result_from_files(diagnostics, current_locals, current_lines, current_allocas, scope_id, scope_depth);
             if fs.readFile("build/sailfin/.let_ipc_used") == "1" {
-                current_temp = _parse_int_from_string(fs.readFile("build/sailfin/.let_ipc_temp"));
-                current_next_local = _parse_int_from_string(fs.readFile("build/sailfin/.let_ipc_next_local"));
-                current_next_region = _parse_int_from_string(fs.readFile("build/sailfin/.let_ipc_next_region"));
+                current_temp = _read_ipc_int_min("build/sailfin/.let_ipc_temp", current_temp);
+                current_next_local = _read_ipc_int_min("build/sailfin/.let_ipc_next_local", current_next_local);
+                current_next_region = _read_ipc_int_min("build/sailfin/.let_ipc_next_region", current_next_region);
             } else {
                 diagnostics = extend_string_array(diagnostics, lowered.diagnostics);
                 collected_lifetime_regions = extend_lifetime_regions(collected_lifetime_regions, lowered.lifetime_regions);
@@ -298,9 +299,9 @@ fn lower_instruction_range(
                             let lowered = lower_let_instruction(function, inline_instruction, current_bindings, current_locals, current_allocas, current_lines, current_temp, current_next_local, current_next_region, functions, context, scope_id, scope_depth, active_label);
                             current_locals = read_let_result_from_files(diagnostics, current_locals, current_lines, current_allocas, scope_id, scope_depth);
                             if fs.readFile("build/sailfin/.let_ipc_used") == "1" {
-                                current_temp = _parse_int_from_string(fs.readFile("build/sailfin/.let_ipc_temp"));
-                                current_next_local = _parse_int_from_string(fs.readFile("build/sailfin/.let_ipc_next_local"));
-                                current_next_region = _parse_int_from_string(fs.readFile("build/sailfin/.let_ipc_next_region"));
+                                current_temp = _read_ipc_int_min("build/sailfin/.let_ipc_temp", current_temp);
+                                current_next_local = _read_ipc_int_min("build/sailfin/.let_ipc_next_local", current_next_local);
+                                current_next_region = _read_ipc_int_min("build/sailfin/.let_ipc_next_region", current_next_region);
                             } else {
                                 diagnostics = extend_string_array(diagnostics, lowered.diagnostics);
                                 collected_lifetime_regions = extend_lifetime_regions(collected_lifetime_regions, lowered.lifetime_regions);
@@ -325,8 +326,8 @@ fn lower_instruction_range(
                     write_bindings_to_files(current_bindings);
                     write_locals_to_files(current_locals);
                     let lowered = lower_expression_statement(function.name, instruction, trimmed_expression, current_bindings, current_locals, current_temp, current_lines, current_next_region, scope_id, scope_depth, functions, context, active_label);
-                    current_temp = _parse_int_from_string(fs.readFile("build/sailfin/.expr_stmt_temp_index"));
-                    current_next_region = _parse_int_from_string(fs.readFile("build/sailfin/.expr_stmt_next_region_id"));
+                    current_temp = _read_ipc_int_min("build/sailfin/.expr_stmt_temp_index", current_temp);
+                    current_next_region = _read_ipc_int_min("build/sailfin/.expr_stmt_next_region_id", current_next_region);
                     current_mutations = read_expr_mutations(current_mutations);
                     collected_string_constants = read_expr_string_constants(collected_string_constants);
                 }
@@ -348,8 +349,8 @@ fn lower_instruction_range(
                 write_bindings_to_files(current_bindings);
                 write_locals_to_files(current_locals);
                 let lowered = lower_return_instruction(function, instruction, llvm_return, current_bindings, current_locals, current_temp, current_lines, current_next_region, scope_id, scope_depth, functions, context);
-                current_temp = _parse_int_from_string(fs.readFile("build/sailfin/.expr_stmt_temp_index"));
-                current_next_region = _parse_int_from_string(fs.readFile("build/sailfin/.expr_stmt_next_region_id"));
+                current_temp = _read_ipc_int_min("build/sailfin/.expr_stmt_temp_index", current_temp);
+                current_next_region = _read_ipc_int_min("build/sailfin/.expr_stmt_next_region_id", current_next_region);
                 collected_string_constants = read_expr_string_constants(collected_string_constants);
                 terminated = true;
                 index += 1;
@@ -359,11 +360,11 @@ fn lower_instruction_range(
         if !_tag_handled {
             if _instr_tag == 3 {
                 let lowered = lower_if_instruction(function, index, llvm_return, current_bindings, current_locals, current_allocas, current_lines, current_temp, current_block_counter, current_next_local, current_next_region, functions, current_loop_stack, end, context, scope_id, scope_depth, active_label);
-                let _if_temp = _parse_int_from_string(fs.readFile("build/sailfin/.block_result_temp_index"));
-                let _if_blkctr = _parse_int_from_string(fs.readFile("build/sailfin/.block_result_block_counter"));
-                let _if_nextloc = _parse_int_from_string(fs.readFile("build/sailfin/.block_result_next_local_id"));
-                let _if_nextreg = _parse_int_from_string(fs.readFile("build/sailfin/.block_result_next_lifetime_region_id"));
-                let _if_nextidx = _parse_int_from_string(fs.readFile("build/sailfin/.block_result_next_index"));
+                let _if_temp = _read_ipc_int_min("build/sailfin/.block_result_temp_index", current_temp);
+                let _if_blkctr = _read_ipc_int_min("build/sailfin/.block_result_block_counter", current_block_counter);
+                let _if_nextloc = _read_ipc_int_min("build/sailfin/.block_result_next_local_id", current_next_local);
+                let _if_nextreg = _read_ipc_int_min("build/sailfin/.block_result_next_lifetime_region_id", current_next_region);
+                let _if_nextidx = _read_ipc_int_min("build/sailfin/.block_result_next_index", index);
                 let _if_term = fs.readFile("build/sailfin/.block_result_terminated") == "1";
                 let mut _ci0 -> number = 0;
                 loop {
@@ -392,11 +393,11 @@ fn lower_instruction_range(
         if !_tag_handled {
             if _instr_tag == 8 {
                 let lowered = lower_loop_instruction(function, index, llvm_return, current_bindings, current_locals, current_allocas, current_lines, current_temp, current_block_counter, current_next_local, current_next_region, functions, current_loop_stack, end, context, scope_id, scope_depth, active_label);
-                let _lp_temp = _parse_int_from_string(fs.readFile("build/sailfin/.block_result_temp_index"));
-                let _lp_blkctr = _parse_int_from_string(fs.readFile("build/sailfin/.block_result_block_counter"));
-                let _lp_nextloc = _parse_int_from_string(fs.readFile("build/sailfin/.block_result_next_local_id"));
-                let _lp_nextreg = _parse_int_from_string(fs.readFile("build/sailfin/.block_result_next_lifetime_region_id"));
-                let _lp_nextidx = _parse_int_from_string(fs.readFile("build/sailfin/.block_result_next_index"));
+                let _lp_temp = _read_ipc_int_min("build/sailfin/.block_result_temp_index", current_temp);
+                let _lp_blkctr = _read_ipc_int_min("build/sailfin/.block_result_block_counter", current_block_counter);
+                let _lp_nextloc = _read_ipc_int_min("build/sailfin/.block_result_next_local_id", current_next_local);
+                let _lp_nextreg = _read_ipc_int_min("build/sailfin/.block_result_next_lifetime_region_id", current_next_region);
+                let _lp_nextidx = _read_ipc_int_min("build/sailfin/.block_result_next_index", index);
                 let _lp_term = fs.readFile("build/sailfin/.block_result_terminated") == "1";
                 let mut _ci1 -> number = 0;
                 loop {
@@ -425,11 +426,11 @@ fn lower_instruction_range(
         if !_tag_handled {
             if _instr_tag == 12 {
                 let lowered = lower_match_instruction(function, index, llvm_return, current_bindings, current_locals, current_allocas, current_lines, current_temp, current_block_counter, current_next_local, current_next_region, functions, current_loop_stack, end, context, scope_id, scope_depth, active_label);
-                let _ma_temp = _parse_int_from_string(fs.readFile("build/sailfin/.block_result_temp_index"));
-                let _ma_blkctr = _parse_int_from_string(fs.readFile("build/sailfin/.block_result_block_counter"));
-                let _ma_nextloc = _parse_int_from_string(fs.readFile("build/sailfin/.block_result_next_local_id"));
-                let _ma_nextreg = _parse_int_from_string(fs.readFile("build/sailfin/.block_result_next_lifetime_region_id"));
-                let _ma_nextidx = _parse_int_from_string(fs.readFile("build/sailfin/.block_result_next_index"));
+                let _ma_temp = _read_ipc_int_min("build/sailfin/.block_result_temp_index", current_temp);
+                let _ma_blkctr = _read_ipc_int_min("build/sailfin/.block_result_block_counter", current_block_counter);
+                let _ma_nextloc = _read_ipc_int_min("build/sailfin/.block_result_next_local_id", current_next_local);
+                let _ma_nextreg = _read_ipc_int_min("build/sailfin/.block_result_next_lifetime_region_id", current_next_region);
+                let _ma_nextidx = _read_ipc_int_min("build/sailfin/.block_result_next_index", index);
                 let _ma_term = fs.readFile("build/sailfin/.block_result_terminated") == "1";
                 let mut _ci2 -> number = 0;
                 loop {
@@ -469,11 +470,11 @@ fn lower_instruction_range(
                 current_allocas = lowered.allocas;
                 current_locals = lowered.locals;
                 current_bindings = lowered.bindings;
-                let _tr_temp = _parse_int_from_string(fs.readFile("build/sailfin/.block_result_temp_index"));
-                let _tr_blkctr = _parse_int_from_string(fs.readFile("build/sailfin/.block_result_block_counter"));
-                let _tr_nextloc = _parse_int_from_string(fs.readFile("build/sailfin/.block_result_next_local_id"));
-                let _tr_nextreg = _parse_int_from_string(fs.readFile("build/sailfin/.block_result_next_lifetime_region_id"));
-                let _tr_nextidx = _parse_int_from_string(fs.readFile("build/sailfin/.block_result_next_index"));
+                let _tr_temp = _read_ipc_int_min("build/sailfin/.block_result_temp_index", current_temp);
+                let _tr_blkctr = _read_ipc_int_min("build/sailfin/.block_result_block_counter", current_block_counter);
+                let _tr_nextloc = _read_ipc_int_min("build/sailfin/.block_result_next_local_id", current_next_local);
+                let _tr_nextreg = _read_ipc_int_min("build/sailfin/.block_result_next_lifetime_region_id", current_next_region);
+                let _tr_nextidx = _read_ipc_int_min("build/sailfin/.block_result_next_index", index);
                 let _tr_term = fs.readFile("build/sailfin/.block_result_terminated") == "1";
                 current_temp = _tr_temp;
                 current_block_counter = _tr_blkctr;
@@ -498,7 +499,7 @@ fn lower_instruction_range(
                     _ci4 += 1;
                 }
                 current_lines = lowered.lines;
-                current_temp = _parse_int_from_string(fs.readFile("build/sailfin/.block_result_temp_index"));
+                current_temp = _read_ipc_int_min("build/sailfin/.block_result_temp_index", current_temp);
                 let temp_constants = collected_string_constants;
                 collected_string_constants = merge_string_constants(temp_constants, lowered.string_constants);
                 terminated = true;
@@ -520,11 +521,11 @@ fn lower_instruction_range(
                 current_allocas = lowered.allocas;
                 current_locals = lowered.locals;
                 current_bindings = lowered.bindings;
-                let _fo_temp = _parse_int_from_string(fs.readFile("build/sailfin/.block_result_temp_index"));
-                let _fo_blkctr = _parse_int_from_string(fs.readFile("build/sailfin/.block_result_block_counter"));
-                let _fo_nextloc = _parse_int_from_string(fs.readFile("build/sailfin/.block_result_next_local_id"));
-                let _fo_nextreg = _parse_int_from_string(fs.readFile("build/sailfin/.block_result_next_lifetime_region_id"));
-                let _fo_nextidx = _parse_int_from_string(fs.readFile("build/sailfin/.block_result_next_index"));
+                let _fo_temp = _read_ipc_int_min("build/sailfin/.block_result_temp_index", current_temp);
+                let _fo_blkctr = _read_ipc_int_min("build/sailfin/.block_result_block_counter", current_block_counter);
+                let _fo_nextloc = _read_ipc_int_min("build/sailfin/.block_result_next_local_id", current_next_local);
+                let _fo_nextreg = _read_ipc_int_min("build/sailfin/.block_result_next_lifetime_region_id", current_next_region);
+                let _fo_nextidx = _read_ipc_int_min("build/sailfin/.block_result_next_index", index);
                 let _fo_term = fs.readFile("build/sailfin/.block_result_terminated") == "1";
                 current_temp = _fo_temp;
                 current_block_counter = _fo_blkctr;

--- a/compiler/src/llvm/lowering/instructions_helpers.sfn
+++ b/compiler/src/llvm/lowering/instructions_helpers.sfn
@@ -221,6 +221,24 @@ fn _parse_int_from_string(text -> string) -> number {
     return result;
 }
 
+// Read an IPC integer from a file, returning at least `floor_value`.
+// This prevents temp_index resets to 0 when files are missing/empty/stale,
+// which otherwise causes duplicate SSA names (%tN) in LLVM IR.
+fn _read_ipc_int_min(path -> string, floor_value -> number) -> number ![io] {
+    if !fs.exists(path) {
+        return floor_value;
+    }
+    let text = fs.readFile(path);
+    if text.length == 0 {
+        return floor_value;
+    }
+    let parsed = _parse_int_from_string(text);
+    if parsed > floor_value {
+        return parsed;
+    }
+    return floor_value;
+}
+
 // Write parameter bindings to files for statement.sfn to read.
 // Avoids ABI corruption of struct params across module boundaries.
 fn write_bindings_to_files(bindings -> ParameterBinding[]) ![io] {

--- a/compiler/tests/unit/ssa_stability_test.sfn
+++ b/compiler/tests/unit/ssa_stability_test.sfn
@@ -1,0 +1,133 @@
+// Regression tests for Phi/SSA stabilization fixes.
+// These exercise patterns that previously caused invalid LLVM IR:
+// - Duplicate SSA temp names (temp_index resets across control flow)
+// - Phi nodes interleaved with other instructions
+
+// --- SSA temp_index stability across control flow ---
+
+fn _nested_lets_in_branches(n -> number) -> number {
+    let a = n + 1;
+    let b = a * 2;
+    if n > 10 {
+        let c = b + 3;
+        let d = c * 4;
+        return d;
+    } else {
+        let e = b - 1;
+        let f = e * 3;
+        return f;
+    }
+}
+
+fn _lets_across_loop(n -> number) -> number {
+    let mut total -> number = 0;
+    let mut i -> number = 0;
+    loop {
+        if i >= n {
+            break;
+        }
+        let step = i * 2;
+        let adjusted = step + 1;
+        total += adjusted;
+        i += 1;
+    }
+    let final_val = total + n;
+    return final_val;
+}
+
+// --- Phi node ordering (value-producing if/else) ---
+
+fn _conditional_value(flag -> boolean) -> number {
+    let mut result -> number = 0;
+    if flag {
+        result = 42;
+    } else {
+        result = 99;
+    }
+    return result;
+}
+
+fn _chained_conditionals(a -> number, b -> number) -> number {
+    let mut x -> number = 0;
+    if a > b {
+        x = a - b;
+    } else {
+        x = b - a;
+    }
+    let mut y -> number = 0;
+    if x > 10 {
+        y = x * 2;
+    } else {
+        y = x + 5;
+    }
+    return y;
+}
+
+fn _deeply_nested_control_flow(x -> number) -> number {
+    let a = x + 1;
+    if a > 100 {
+        let b = a - 50;
+        if b > 75 {
+            return b * 2;
+        } else {
+            let c = b + 10;
+            return c;
+        }
+    } else {
+        let d = a * 2;
+        if d < 50 {
+            return d;
+        }
+        return d + 1;
+    }
+}
+
+// --- Tests ---
+
+test "ssa: nested lets across if/else branches (then)" {
+    assert _nested_lets_in_branches(20) == 180;
+}
+
+test "ssa: nested lets across if/else branches (else)" {
+    assert _nested_lets_in_branches(5) == 33;
+}
+
+test "ssa: lets across loop iterations" {
+    assert _lets_across_loop(0) == 0;
+}
+
+test "ssa: conditional value true" {
+    assert _conditional_value(true) == 42;
+}
+
+test "ssa: conditional value false" {
+    assert _conditional_value(false) == 99;
+}
+
+test "ssa: chained conditionals large diff" {
+    assert _chained_conditionals(20, 5) == 30;
+}
+
+test "ssa: chained conditionals small diff" {
+    assert _chained_conditionals(3, 10) == 12;
+}
+
+test "ssa: deeply nested then-then branch" {
+    // a=201, b=151, b>75 -> 302
+    assert _deeply_nested_control_flow(200) == 302;
+}
+
+test "ssa: deeply nested then-else branch" {
+    // a=106, b=56, c=66 -> 66
+    assert _deeply_nested_control_flow(105) == 66;
+}
+
+test "ssa: deeply nested else-then branch" {
+    // a=11, d=22, d<50 -> 22
+    assert _deeply_nested_control_flow(10) == 22;
+}
+
+test "ssa: deeply nested else-else branch" {
+    // a=51, d=102, d>=50 -> 103
+    assert _deeply_nested_control_flow(50) == 103;
+}

--- a/scripts/selfhost_native.py
+++ b/scripts/selfhost_native.py
@@ -12483,7 +12483,8 @@ def main(argv: list[str]) -> int:
                         )
 
                     # Fix duplicate SSA definitions within functions.
-                    # DISABLED: root cause fixed in compiler/src/llvm/lowering/instructions.sfn
+                    # DISABLED: root cause fixed by the lowering helper in
+                    # compiler/src/llvm/lowering/instructions_helpers.sfn
                     # (_read_ipc_int_min prevents temp_index from resetting to 0).
                     # candidate, dup_changes = _fix_duplicate_ssa_names(candidate)
                     # if dup_changes:

--- a/scripts/selfhost_native.py
+++ b/scripts/selfhost_native.py
@@ -625,62 +625,9 @@ def _mark_unaligned_enum_payload_accesses(llvm_ir: str) -> tuple[str, int]:
     return "\n".join(out) + ("\n" if llvm_ir.endswith("\n") else ""), changed
 
 
-def _reorder_phi_nodes_to_block_start(llvm_ir: str) -> tuple[str, int]:
-    """Move all phi nodes to the top of each basic block.
-
-    LLVM requires that phi nodes appear contiguously at the start of a block
-    (after the label). Some generated modules interleave phi nodes with other
-    instructions, which clang rejects.
-    """
-
-    lines = llvm_ir.splitlines()
-    if not lines:
-        return llvm_ir, 0
-
-    out: list[str] = []
-    changed = 0
-
-    def _flush_block(label: str | None, block_lines: list[str]) -> None:
-        nonlocal changed
-        if label is None:
-            out.extend(block_lines)
-            return
-
-        phi_lines: list[str] = []
-        other_lines: list[str] = []
-        for line in block_lines:
-            if _LLVM_PHI_RE.match(line):
-                phi_lines.append(line)
-            else:
-                other_lines.append(line)
-        if phi_lines:
-            if block_lines[: len(phi_lines)] != phi_lines:
-                changed += 1
-            out.append(label)
-            out.extend(phi_lines)
-            out.extend(other_lines)
-        else:
-            out.append(label)
-            out.extend(other_lines)
-
-    current_label: str | None = None
-    current_block: list[str] = []
-
-    label_re = re.compile(r"^\s*[A-Za-z_.$][A-Za-z0-9_.$]*:\s*(?:;.*)?$")
-    for line in lines:
-        if label_re.match(line):
-            _flush_block(current_label, current_block)
-            current_label = line
-            current_block = []
-            continue
-        if current_label is None:
-            out.append(line)
-        else:
-            current_block.append(line)
-
-    _flush_block(current_label, current_block)
-
-    return "\n".join(out) + ("\n" if llvm_ir.endswith("\n") else ""), changed
+## _reorder_phi_nodes_to_block_start — REMOVED
+## Root cause fixed in compiler/src/llvm/lowering/emission.sfn
+## (_reorder_phis_to_block_start pass reorders phi nodes in the compiler itself).
 
 
 _STORE_NULL_RE = re.compile(
@@ -4192,78 +4139,10 @@ def _fix_duplicate_globals(llvm_ir: str) -> tuple[str, int]:
     return result, changed
 
 
-def _fix_duplicate_param_names(llvm_ir: str) -> tuple[str, int]:
-    """Rename duplicate LLVM parameter names in function definitions.
-
-    The seed sometimes emits ``define ... @fn(%T1 %entry, %T2 %entry)``
-    where two parameters share the same name.  LLVM rejects this.
-    Fix by appending a numeric suffix to duplicates.
-
-    Also fixes empty-type parameters (`` %_``) where the seed omits
-    the type entirely.  Replace with ``i8* %_N`` so the IR is parseable.
-    """
-
-    _define_re = re.compile(
-        r"^(define\s+(?:internal\s+)?[^(]+\()([^)]*)\)(.*)$"
-    )
-    changed = 0
-    out_lines: list[str] = []
-    for line in llvm_ir.splitlines():
-        m = _define_re.match(line)
-        if m:
-            prefix = m.group(1)
-            params_str = m.group(2)
-            suffix = m.group(3)
-            # Parse individual parameters (brace-aware to handle types like { i8**, i64 }*).
-            params: list[str] = []
-            depth = 0
-            current = ""
-            for ch in params_str:
-                if ch in "({":
-                    depth += 1
-                    current += ch
-                elif ch in ")}":
-                    depth -= 1
-                    current += ch
-                elif ch == "," and depth == 0:
-                    if current.strip():
-                        params.append(current.strip())
-                    current = ""
-                else:
-                    current += ch
-            if current.strip():
-                params.append(current.strip())
-            seen_names: dict[str, int] = {}
-            new_params: list[str] = []
-            any_changed = False
-            empty_idx = 0
-            for param in params:
-                # Detect empty-type parameter: just "%_" with no type prefix.
-                if param == "%_" or param.startswith("%_") and " " not in param:
-                    empty_idx += 1
-                    new_params.append(f"i8* %_empty_{empty_idx}")
-                    any_changed = True
-                    continue
-                # Extract the %name part (last word starting with %).
-                parts = param.rsplit(None, 1)
-                if len(parts) == 2 and parts[1].startswith("%"):
-                    ptype = parts[0]
-                    pname = parts[1]
-                    if pname in seen_names:
-                        seen_names[pname] += 1
-                        new_name = f"{pname}_{seen_names[pname]}"
-                        new_params.append(f"{ptype} {new_name}")
-                        any_changed = True
-                    else:
-                        seen_names[pname] = 0
-                        new_params.append(param)
-                else:
-                    new_params.append(param)
-            if any_changed:
-                line = prefix + ", ".join(new_params) + ")" + suffix
-                changed += 1
-        out_lines.append(line)
-    return "\n".join(out_lines), changed
+## _fix_duplicate_param_names — REMOVED
+## Root cause fixed in compiler/src/llvm/lowering/emission.sfn and
+## compiler/src/llvm/expression_lowering/native/statement.sfn
+## (parameter name deduplication + empty type defaulting to i8*).
 
 
 def _collect_declare_signatures(ll_texts: list[str]) -> dict[str, tuple[str, list[str]]]:
@@ -7632,75 +7511,9 @@ def _fix_phi_type_mismatches(llvm_ir: str) -> tuple[str, int]:
     return "\n".join(lines) + ("\n" if llvm_ir.endswith("\n") else ""), changed
 
 
-def _fix_duplicate_ssa_names(llvm_ir: str) -> tuple[str, int]:
-    """Rename duplicate SSA definitions within the same function.
-
-    The seed compiler sometimes reuses the same ``%tN`` register name in
-    different basic blocks of a single function, violating SSA form.
-    LLVM requires each value name to be defined exactly once per function.
-
-    This pass detects duplicate definitions and renames subsequent ones to
-    ``%tN_dup2``, ``%tN_dup3``, etc., updating all uses within the same
-    basic block to keep the IR consistent.
-    """
-    import re as _re
-
-    lines = llvm_ir.split("\n")
-    changed = 0
-
-    define_pat = _re.compile(r"^define\s+")
-    assign_pat = _re.compile(r"^\s*(%[A-Za-z0-9_.]+)\s*=")
-
-    # Collect function boundaries.
-    func_ranges: list[tuple[int, int]] = []
-    func_start_i = None
-    for i, line in enumerate(lines):
-        stripped = line.strip()
-        if define_pat.match(stripped):
-            func_start_i = i
-        elif func_start_i is not None and stripped == "}":
-            func_ranges.append((func_start_i, i))
-            func_start_i = None
-
-    for fstart, fend in func_ranges:
-        # Pass 1: find all definition sites per variable name.
-        defn_sites: dict[str, list[int]] = {}  # varname -> [line_idx, ...]
-        for i in range(fstart + 1, fend):
-            m = assign_pat.match(lines[i])
-            if m:
-                vname = m.group(1)
-                defn_sites.setdefault(vname, []).append(i)
-
-        # Only care about names defined more than once.
-        dups = {k: v for k, v in defn_sites.items() if len(v) > 1}
-        if not dups:
-            continue
-
-        # Pass 2: for each duplicate, rename the 2nd, 3rd, ... definitions.
-        # We rename both the definition and all uses that follow it (up to
-        # the next definition of the same name or end of function).
-        for vname, sites in dups.items():
-            for dup_idx, site_line in enumerate(sites):
-                if dup_idx == 0:
-                    continue  # Keep the first definition unchanged.
-                new_name = f"{vname}_dup{dup_idx + 1}"
-                # Determine the range: from this definition to the next
-                # definition of the same name (or end of function).
-                range_end = sites[dup_idx + 1] if dup_idx + 1 < len(sites) else fend
-                # Rename in definition and subsequent uses.
-                escaped = _re.escape(vname)
-                # Match the variable name as a whole word (followed by
-                # non-alphanumeric or end of string).
-                rename_pat = _re.compile(escaped + r"(?=[^A-Za-z0-9_.]|$)")
-                for i in range(site_line, range_end):
-                    new_line = rename_pat.sub(new_name, lines[i])
-                    if new_line != lines[i]:
-                        lines[i] = new_line
-                changed += 1
-
-    if not changed:
-        return llvm_ir, 0
-    return "\n".join(lines) + ("\n" if llvm_ir.endswith("\n") else ""), changed
+## _fix_duplicate_ssa_names — REMOVED
+## Root cause fixed in compiler/src/llvm/lowering/instructions_helpers.sfn
+## (_read_ipc_int_min prevents temp_index from resetting to 0 via stale/empty IPC files).
 
 
 def _fix_missing_parameter_stores(llvm_ir: str) -> tuple[str, int]:
@@ -12234,7 +12047,9 @@ def main(argv: list[str]) -> int:
                         candidate)
 
                     # Ensure phi nodes are grouped at the top of each block.
-                    candidate, _ = _reorder_phi_nodes_to_block_start(candidate)
+                    # DISABLED: root cause fixed in compiler/src/llvm/lowering/emission.sfn
+                    # (_reorder_phis_to_block_start pass in compiler).
+                    # candidate, _ = _reorder_phi_nodes_to_block_start(candidate)
 
                     # Optional heuristic fix for invalid phi inputs that break dominance.
                     # Disabled by default because it can change semantics.
@@ -12329,8 +12144,8 @@ def main(argv: list[str]) -> int:
                     )
 
                     # Final safeguard: ensure phi nodes are grouped at block starts
-                    # right before writing the candidate to disk.
-                    candidate, _ = _reorder_phi_nodes_to_block_start(candidate)
+                    # DISABLED: handled by compiler's _reorder_phis_to_block_start pass.
+                    # candidate, _ = _reorder_phi_nodes_to_block_start(candidate)
                     candidate, _ = _fix_invalid_null_stores(candidate)
 
                     # Eliminate unreachable branches (br i1 false/true) so
@@ -12362,13 +12177,16 @@ def main(argv: list[str]) -> int:
                         )
 
                     # Fix duplicate parameter names in function definitions.
-                    candidate, dup_param_changes = _fix_duplicate_param_names(candidate)
-                    if dup_param_changes:
-                        print(
-                            f"[selfhost] fixed {dup_param_changes} duplicate param name(s) in {module_name}",
-                            file=sys.stderr,
-                            flush=True,
-                        )
+                    # DISABLED: root cause fixed in compiler/src/llvm/lowering/emission.sfn
+                    # and compiler/src/llvm/expression_lowering/native/statement.sfn
+                    # (parameter name deduplication + empty type defaulting).
+                    # candidate, dup_param_changes = _fix_duplicate_param_names(candidate)
+                    # if dup_param_changes:
+                    #     print(
+                    #         f"[selfhost] fixed {dup_param_changes} duplicate param name(s) in {module_name}",
+                    #         file=sys.stderr,
+                    #         flush=True,
+                    #     )
 
                     # Fix native_ir function return types (double → pointer).
                     candidate, nirt_changes = _fix_native_ir_return_types(candidate)
@@ -12665,15 +12483,15 @@ def main(argv: list[str]) -> int:
                         )
 
                     # Fix duplicate SSA definitions within functions.
-                    # The seed sometimes reuses %tN names across basic blocks
-                    # in the same function, violating SSA form.
-                    candidate, dup_changes = _fix_duplicate_ssa_names(candidate)
-                    if dup_changes:
-                        print(
-                            f"[selfhost] renamed {dup_changes} duplicate SSA name(s) in {module_name}",
-                            file=sys.stderr,
-                            flush=True,
-                        )
+                    # DISABLED: root cause fixed in compiler/src/llvm/lowering/instructions.sfn
+                    # (_read_ipc_int_min prevents temp_index from resetting to 0).
+                    # candidate, dup_changes = _fix_duplicate_ssa_names(candidate)
+                    # if dup_changes:
+                    #     print(
+                    #         f"[selfhost] renamed {dup_changes} duplicate SSA name(s) in {module_name}",
+                    #         file=sys.stderr,
+                    #         flush=True,
+                    #     )
 
                     # Fix lower_instruction_range return type ABI mismatch.
                     # A truncated instructions.sfn-asm in the import-context
@@ -12889,8 +12707,9 @@ def main(argv: list[str]) -> int:
                         if not did_patch:
                             break
                         patched_candidate = patched_candidate2
-                        patched_candidate, _ = _reorder_phi_nodes_to_block_start(
-                            patched_candidate)
+                        # DISABLED: handled by compiler's _reorder_phis_to_block_start pass.
+                        # patched_candidate, _ = _reorder_phi_nodes_to_block_start(
+                        #     patched_candidate)
                         patched_candidate, _ = _fix_invalid_null_stores(
                             patched_candidate)
                         cleaned_attempt_path.write_text(


### PR DESCRIPTION
Fix three categories of IR bugs in the compiler, removing 3 fixup passes
from selfhost_native.py (68 → ~65 active fixups):

1. _fix_duplicate_param_names: Added parameter name deduplication in
   prepare_parameters_from_files() and prepare_parameters(). Empty types
   now default to i8* instead of producing unparseable IR.

2. _fix_duplicate_ssa_names: Added _read_ipc_int_min() helper that
   prevents temp_index from resetting to 0 when IPC files are
   missing/empty/stale. All temp_index reads in instructions.sfn now
   use monotonic floor enforcement.

3. _reorder_phi_nodes_to_block_start: Added _reorder_phis_to_block_start()
   pass in emission.sfn that ensures phi nodes appear at the top of each
   basic block before the function closing brace is emitted.

Verified: make rebuild + make test pass with all three fixups disabled.

https://claude.ai/code/session_01LLFsCvSbUQS2ZvArKDZgSH