### PR TITLE
docs: add pre-1.0 syntax reform plan and known design issues

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -217,6 +217,43 @@ make rebuild BUILD_DRIVER=sh    # Shell, no fixups (needs clean seed)
 
 If `make check` fails, it means the compiler has a bug. Fix the compiler.
 
+## Pre-1.0 Syntax Reform (Active)
+
+The following breaking syntax changes are planned before 1.0. All new code
+written by agents or humans should prefer the new forms where the parser already
+accepts them. See `docs/roadmap.md` §0 for the full plan and rationale.
+
+1. **Type annotations: `:` not `->`** — Use `x: number` not `x -> number` for
+   parameters, variables, and fields. Return types keep `->`. The parser already
+   accepts both via `TypeSep = "->" | ":"`.
+2. **String interpolation: `${ }` not `{{ }}`** — Target delimiter is `${ expr }`.
+   Parser change pending; continue using `{{ }}` until the parser is updated.
+3. **Integer types** — `int` (i64) and `float` (f64) will replace the single
+   `number` type. `number` becomes an alias for `float`. Not yet in parser.
+4. **`Result<T, E>` + `?` operator** — Typed error handling to complement
+   `try`/`catch`. Not yet in parser.
+5. **Closures with capture** — Lambdas must capture enclosing variables.
+
+### Design Decision Framework
+
+When adding features or making design choices, apply these principles:
+
+- **Boring syntax wins.** Every deviation from mainstream conventions adds
+  learning curve with zero expressiveness gain. Match TypeScript/Rust/Python
+  conventions unless there's a compelling semantic reason not to.
+- **AI agents are users.** LLMs have zero `.sfn` training data. Conventional
+  syntax reduces error rates in generated code. Unusual choices cause systematic
+  LLM failures.
+- **Pick 3 differentiators.** Sailfin's top 3 are: (1) effect system,
+  (2) capability-based security, (3) structured concurrency. Don't dilute these
+  with half-finished ownership, AI constructs, or GPU features.
+- **Don't ship unfinished safety claims.** "Parsed but not enforced" is worse
+  than not having the syntax at all — it teaches users to ignore the feature.
+- **Keywords are expensive.** A keyword can never become a variable name. Only
+  add keywords for constructs that can't be expressed as library functions.
+- **Fix the foundation first.** Integer types, `Result<T, E>`, and generic
+  constraints are prerequisites for everything else.
+
 ## Important Constraints
 
 ### Bootstrap Limitations

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ Its type system unifies deterministic computation, effect isolation, and capabil
 
 ## Why Sailfin
 
-- **Safety without friction** — Algebraic data types, ownership-aware linear typing, and pattern matching keep data pipelines fast and correct without manual memory management.
-- **Deterministic where it counts** — Effects such as `io`, `net`, `model`, `gpu`, `rand`, and `clock` are explicit in type signatures, enabling reproducible builds, replayable model calls, and compile-time guarantees.
-- **AI first-class (planned)** — Models, prompts, schemas, embeddings, and retrieval indices are designed as native concepts. The runtime will track latency, cost, and provenance for every generation automatically. See _What's Coming_ below.
-- **Capability-oriented security** — Secrets, PII, and data egress policies will be enforced through the type system and runtime guards.
+- **Effect system** — Effects such as `io`, `net`, `model`, `gpu`, `rand`, and `clock` are explicit in function signatures. You can look at a function and know exactly what capabilities it uses — no hidden side effects. The compiler enforces these at compile time.
+- **Capability-based security** — Capsules declare what effects they need in their manifest. Undeclared capabilities are compile-time errors. Secrets, PII, and data egress policies are designed for enforcement through the type system and runtime guards.
+- **Structured concurrency (planned)** — Routines, channels, and parallel blocks as first-class language constructs with determinism controls.
+- **AI-native vision (post-1.0)** — Models, prompts, and generation provenance are designed as language concepts. The focus is shipping a solid foundation first; AI constructs ship after the core is stable. See _What's Coming_ below.
 - **Interoperable by design** — Sailfin integrates safely with native binaries and sandboxed adapters while maintaining strong typing and effect boundaries.
 
 ## What Works Today
@@ -29,8 +29,8 @@ The self-hosted native compiler (`build/native/sailfin`) supports:
 
 ```sfn
 struct User {
-  id   -> number;
-  name -> string;
+  id:   number;
+  name: string;
 }
 
 fn greet(user: User) -> string ![io] {
@@ -46,14 +46,20 @@ test "greet produces correct output" {
 }
 ```
 
+> **Note:** The language is undergoing a [syntax reform](docs/roadmap.md) before
+> 1.0. The `:` type annotation style shown above is the preferred form (the
+> parser also accepts `->` in type positions, but this is being deprecated).
+> String interpolation (`{{ }}`) will change to `${ }` in a future release.
+
 ## What's Coming
 
 Sailfin is working toward a 1.0 release with a fully self-hosted toolchain — no Python build scripts, no C runtime. Key upcoming milestones:
 
+- **Syntax reform** — colon type annotations (`:` instead of `->`), `${}` string interpolation, `int`/`float` numeric types, `Result<T, E>` + `?` error handling
 - **Compiler stabilization** — eliminating the Python post-processing fixup script; `build.sh` becomes the sole build path
 - **Sailfin-native runtime** — replacing the current C runtime; a hard prerequisite for 1.0
 - **Concurrency primitives** — `await`, `routine { }` blocks, and `channel()` as first-class constructs
-- **Full ownership enforcement** — move semantics, borrow checking, use-after-move errors
+- **Ownership enforcement** — move semantics, borrow checking, use-after-move errors (if ready for 1.0; otherwise deferred to avoid shipping unenforced guarantees)
 
 After 1.0, the focus shifts to making AI constructs fully functional:
 

--- a/docs/enbf.md
+++ b/docs/enbf.md
@@ -38,8 +38,13 @@ StructMember       = FieldDeclaration | MethodDeclaration ;
 
 // REFORM: TypeSep currently accepts both "->" and ":". Pre-1.0, "->" will be
 // deprecated in type-annotation positions (parameters, variables, fields).
-// "->" remains the return-type separator in function signatures.
-// New code should use ":" exclusively for type annotations.
+// The target end state is two distinct separators:
+//   AnnotationSep = ":"         (parameters, variables, fields)
+//   ReturnSep     = "->"        (function return types)
+// Today the shared TypeSep rule means ":" also parses in return-type position.
+// This is unintentional — ":" for return types is discouraged and will become
+// a parse error once the grammar is split. New code should use ":" for
+// annotations and "->" for return types.
 TypeSep            = "->" | ":" ;
 FieldDeclaration   = [ "mut" ] Identifier TypeSep Type ";" ;
 

--- a/docs/enbf.md
+++ b/docs/enbf.md
@@ -36,6 +36,10 @@ StructDeclaration  = "struct" Identifier [ TypeParameters ]
 
 StructMember       = FieldDeclaration | MethodDeclaration ;
 
+// REFORM: TypeSep currently accepts both "->" and ":". Pre-1.0, "->" will be
+// deprecated in type-annotation positions (parameters, variables, fields).
+// "->" remains the return-type separator in function signatures.
+// New code should use ":" exclusively for type annotations.
 TypeSep            = "->" | ":" ;
 FieldDeclaration   = [ "mut" ] Identifier TypeSep Type ";" ;
 
@@ -260,12 +264,23 @@ BooleanLiteral     = "true" | "false" ;
 Identifier         = Letter { Letter | Digit | '_' } ;
 ```
 
+> **REFORM (pre-1.0):** `NumberLiteral` currently compiles to a single `number`
+> type (f64). Pre-1.0 will introduce `int` (i64) and `float` (f64) as distinct
+> types. Integer literals (no decimal point) will default to `int`; decimal
+> literals default to `float`. `number` becomes an alias for `float`.
+> See `docs/roadmap.md` §0.
+
 ### String Interpolation
 
 String literals support lightweight interpolation using double braces. Any
 occurrence of `{{ expression }}` is evaluated at runtime against the current
 scope. Whitespace at the edges of the expression is ignored (`{{name}}` == `{{ name }}`).
 For example `"Hello, {{ name }}!"` becomes a formatted string.
+
+> **REFORM (pre-1.0):** The `{{ expr }}` delimiter will change to `${ expr }`.
+> `{{ }}` universally means "escape interpolation / literal braces" in template
+> languages and Rust's `format!`. Using it for the opposite meaning confuses
+> both humans and LLM code generators. See `docs/roadmap.md` §0.
 
 Named arguments appear in both function calls and pipeline stages:
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -12,6 +12,53 @@ launch. Legacy compiler stage references are no longer tracked in this plan.
 The 1.0 release requires a **fully self-hosted toolchain with no Python scripts
 or C runtime**. All items below are hard requirements, not stretch goals.
 
+0. **Syntax reform (breaking, do first)**
+
+   These changes alter surface syntax and must land before 1.0 to avoid breaking
+   a public API. They are cheaper to make now with zero external users than after
+   launch. Each item is independent and can be shipped incrementally.
+
+   - [ ] **Colon type annotations** — replace `->` in parameter and variable
+         type positions with `:`. Function return types keep `->`.
+         Before: `fn add(x -> number, y -> number) -> number`
+         After:  `fn add(x: number, y: number) -> number`
+         Rationale: `->` for "has type" conflicts with its universal meaning of
+         "returns/maps-to." Every mainstream typed language (TypeScript, Rust,
+         Python, Kotlin, Swift, Zig) uses `:` for annotations. The current
+         syntax is the single most likely reason a new user bounces.
+   - [ ] **String interpolation delimiters** — replace `{{ expr }}` with
+         `${ expr }`.
+         Before: `"Hello, {{ name }}!"`
+         After:  `"Hello, ${ name }!"`
+         Rationale: `{{ }}` universally means "escape interpolation / literal
+         braces" (Jinja2, Handlebars, Mustache, Angular, Rust `format!`). Using
+         it for the opposite meaning guarantees confusion for humans and will
+         cause systematic errors in LLM-generated code, since models are trained
+         on billions of lines where `{{ }}` means "don't interpolate."
+   - [ ] **Integer numeric types** — introduce `int` (default signed 64-bit
+         integer) alongside `float` (64-bit IEEE 754). Keep `number` as an alias
+         for `float` for backward compatibility, but make `int` the default for
+         integer literals and array indexing.
+         Rationale: a single `number` (f64) type causes precision loss above
+         2^53, makes bit operations unreliable, makes array indexing semantically
+         wrong, and is the root cause of the "double-encoded pointers" fixup
+         category (~12 of ~69 compiler fixups). This is JavaScript's worst
+         design decision; a compiled systems language must not inherit it.
+   - [ ] **Error handling reform** — add `Result<T, E>` to the type system and
+         a `?` propagation operator. Complement (don't replace) `try`/`catch`
+         for truly exceptional cases.
+         Rationale: current error handling is invisible in function signatures.
+         Union return types (`number | DivisionError`) require manual `match` at
+         every call site with no compiler enforcement. `Result<T, E>` + `?` is
+         the industry standard for typed error propagation (Rust, Swift `throws`,
+         even Go's explicit `if err`). This pairs naturally with the effect system.
+   - [ ] **Closures with capture** — ensure lambdas can capture variables from
+         enclosing scopes. This is table-stakes for idiomatic `.map()`,
+         `.filter()`, `.reduce()` usage and functional patterns.
+
+   **Migration**: update the parser, EBNF, spec, examples, and compiler source
+   for each item. Track each as a separate PR so progress is visible.
+
 1. **Compiler stabilization (build pipeline)**
    - [ ] Eliminate the Python fixup script (`scripts/selfhost_native.py`) as a
          build requirement. Every fixup it applies must become a compiler fix in
@@ -30,10 +77,15 @@ or C runtime**. All items below are hard requirements, not stretch goals.
    - [ ] Implement `spawn` expression.
    - [ ] Complete generic type inference for functions, structs, and enums.
    - [ ] Finish interface conformance validation, including variance checks.
-   - [ ] Enforce `Affine<T>` / `Linear<T>` move and consume rules.
+   - [ ] Implement generic trait/interface constraints (`fn sort<T: Comparable>`).
+   - [ ] Enforce `Affine<T>` / `Linear<T>` move and consume rules — or remove the
+         syntax if enforcement won't land by 1.0. Claiming Rust-grade safety with
+         parse-only ownership is a credibility issue.
    - [ ] Implement richer diagnostics (multi-span snippets, severity, suggested fixes).
    - [ ] Add `--fix` workflow for missing effect annotations with safe rewrite guards.
    - [ ] Enforce `gpu`, `rand`, and hierarchical effect names (`io.fs`, `net.http`).
+   - [ ] Add destructuring assignments (`let { name, age } = user;`).
+   - [ ] Add enum methods (associated functions on enum types).
 
 3. **Sailfin-native runtime (hard 1.0 prerequisite)**
    - The C runtime (`runtime/native/`) must be replaced by a Sailfin-native
@@ -72,9 +124,24 @@ or C runtime**. All items below are hard requirements, not stretch goals.
 
 ## Post-1.0 — AI / Model Execution (First Major Follow-On)
 
-The AI-native features are central to Sailfin's design and fully specified, but
-require a stable self-hosted runtime and toolchain as a foundation. They ship
-after 1.0 as the first major milestone.
+The AI-native features are central to Sailfin's long-term vision but ship after
+1.0. This is a deliberate prioritization, not a concession:
+
+- **Ship what works first.** No one adopts a language for features that don't
+  work yet. They adopt it for features that work *better* than alternatives.
+  The effect system + capability model is that feature for Sailfin.
+- **Language constructs vs. library constructs.** `model`, `prompt`, `pipeline`,
+  and `tool` keywords bake API-level details (token limits, temperature, engine
+  names) into the language grammar. These details change monthly as AI providers
+  update their APIs. Consider whether these should be **standard library
+  capsules** rather than grammar-level keywords — language constructs should be
+  reserved for things that genuinely can't be expressed as libraries. Keep the
+  `![model]` effect annotation (that's valuable); provide AI capabilities via
+  `sfn/model`, `sfn/prompt` capsules.
+- **Competitive reality.** Every major language now has excellent typed AI SDKs.
+  The bar for "what does a language keyword give me that a library can't?" is
+  high. Earn the right to add keywords by shipping a library first and finding
+  the pain points that only syntax can solve.
 
 - [ ] **Model runtime** — implement `Model<I, O>.call()` execution; wire `model`
       blocks to provider adapters (OpenAI-compatible, local, etc.).
@@ -117,6 +184,31 @@ after 1.0 as the first major milestone.
 - [ ] Currency literals (`$0.05`) and time literals (`1s`, `150ms`).
 - [ ] Notebook, LSP, and interactive tooling with live cost/latency overlays.
 - [ ] Training workflow (see `docs/proposals/model-engines-and-training.md`).
+
+## Design Principles (Pre-1.0 Decision Framework)
+
+When evaluating features, apply these filters:
+
+1. **Pick 3 differentiators, ship those well.** Sailfin's top 3 are: (1) the
+   effect system, (2) capability-based security, (3) structured concurrency.
+   Everything else is a nice-to-have that should not block or dilute these.
+2. **Boring syntax wins.** Every deviation from mainstream conventions (`:` for
+   types, `${}` for interpolation) adds learning curve with zero expressiveness
+   gain. Make the syntax boring and familiar so the *semantics* can be novel.
+3. **Don't ship unfinished safety claims.** "Parsed but not enforced" ownership
+   is worse than no ownership syntax — it teaches users to ignore the feature.
+   Either enforce it or remove the syntax until enforcement lands.
+4. **AI agents are users too.** LLMs have zero training data for `.sfn` files.
+   Conventional syntax reduces LLM error rates. Unusual choices (`{{ }}` for
+   interpolation) cause systematic failures in generated code.
+5. **Language keywords are expensive.** A keyword can never become a variable
+   name. Only add keywords for constructs that genuinely can't be expressed as
+   library functions. `model { engine = "..." }` can be a library; `![io]` on
+   function signatures cannot.
+6. **Fix the type system foundation first.** Integer vs float distinction, proper
+   `Result<T, E>`, and generic constraints are prerequisites for everything else.
+   Building AI constructs on a type system that encodes pointers as doubles is
+   building on sand.
 
 ## Completed Items
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -92,6 +92,18 @@ let name -> string = "Sailfin";
 let mut counter -> number = 0;
 ```
 
+> **Syntax reform (pre-1.0):** The `->` type annotation separator will be
+> replaced with `:` in variable declarations, parameters, and field
+> declarations. Function return types keep `->`. The parser already accepts `:`
+> as an alternative (`TypeSep = "->" | ":"`). New code should prefer `:`.
+> See `docs/roadmap.md` §0 and `docs/status.md` §Known Design Issues.
+>
+> ```sfn
+> // Preferred (new)
+> let name: string = "Sailfin";
+> let mut counter: number = 0;
+> ```
+
 Type annotations are optional; the current compiler performs limited
 inference. Initialisers may be omitted; the compiler emits `null` when a
 binding lacks an explicit expression.
@@ -106,6 +118,15 @@ fn add(x -> number, y -> number) -> number {
     return x + y;
 }
 ```
+
+> **Syntax reform (pre-1.0):** Parameter type annotations will use `:` instead
+> of `->`. Return types keep `->`. New code should prefer the colon form:
+>
+> ```sfn
+> fn add(x: number, y: number) -> number {
+>     return x + y;
+> }
+> ```
 
 `async fn` enables `await` inside the body. Decorators (`@identifier`) are
 parsed and captured as metadata for later semantic passes.
@@ -232,6 +253,16 @@ type Result<T> = Response | T;
 > parses as a method call but no model runtime exists. Generation cards and
 > evaluators are design-stage. This entire section describes the planned
 > semantics; see `docs/status.md` for implementation state.
+>
+> **Design question (open):** Should `model`, `prompt`, `pipeline`, and `tool`
+> be language-level keywords or standard library constructs? Language keywords
+> bake API-level details (token limits, temperature, engine names) into the
+> grammar — details that change monthly as AI providers update their APIs. The
+> `![model]` effect annotation is valuable and should remain a language feature,
+> but the declaration syntax could potentially be expressed as library types
+> (e.g., `sfn/model` capsule) without losing safety or expressiveness. This
+> question should be resolved before these features ship. See `docs/roadmap.md`
+> §Post-1.0 AI section for discussion.
 
 Models are first-class program artefacts. A `model` block declares metadata,
 versions, schemas, and evaluator suites, producing a `Model<Input, Output>`
@@ -386,6 +417,13 @@ adapter boundaries.
 - **Error handling** – `try`/`catch`/`finally` blocks and `throw` statements map
   onto runtime exceptions.
 
+> **Design gap (pre-1.0):** Errors are invisible in function signatures. Union
+> return types (`number | DivisionError`) require manual `match` at every call
+> site with no compiler enforcement or propagation operator. Pre-1.0 will add
+> `Result<T, E>` to the type system and a `?` propagation operator. `try`/`catch`
+> remains for truly exceptional / unrecoverable errors.
+> See `docs/roadmap.md` §0.
+
 ## 5. Concurrency and Performance
 
 > **Current status**: Concurrency primitives are in progress. `async fn` is
@@ -451,6 +489,13 @@ is limited to ergonomic runtime type guards.
 | `boolean` | Truth values                  |
 | `void`    | No return value               |
 | `null`    | Explicit absence of a value   |
+
+> **Type reform (pre-1.0):** `number` as the sole numeric type is a known
+> design issue. Pre-1.0 will introduce `int` (signed 64-bit integer) and
+> `float` (64-bit IEEE 754). `number` will become an alias for `float`.
+> Integer literals will default to `int`; array indexing will require `int`.
+> This change also resolves the "double-encoded pointers" compiler fixup
+> category. See `docs/roadmap.md` §0 and `docs/status.md` §Known Design Issues.
 
 Composite types include structs, enums, generics (e.g. `Vec<T>`, `Seq<T>`),
 optionals (`T?`), and unions (`A | B`). The array sugar `Type[]` is deprecated
@@ -921,6 +966,23 @@ mandatory double braces. Whitespace inside braces is ignored at the edges, so
 `{{name}}` and `{{ name }}` are equivalent. The compiler lowers interpolated
 strings into segment arrays and calls `runtime.format_interpolated`, evaluating
 each embedded expression directly.
+
+> **Syntax reform (pre-1.0):** The `{{ }}` interpolation delimiter will be
+> replaced with `${ }` (single dollar-brace).
+>
+> ```sfn
+> // Current
+> let msg = "Hello, {{ name }}!";
+> // Target
+> let msg = "Hello, ${ name }!";
+> ```
+>
+> Rationale: `{{ }}` universally means "escape interpolation / literal braces"
+> in template languages (Jinja2, Handlebars, Mustache, Angular) and in Rust's
+> `format!`. Using it for the opposite meaning guarantees confusion. LLMs
+> trained on billions of lines where `{{ }}` means "don't interpolate" will
+> produce systematically wrong code.
+> See `docs/roadmap.md` §0 and `docs/status.md` §Known Design Issues.
 
 ## 10. Runtime Semantics
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -94,8 +94,12 @@ let mut counter -> number = 0;
 
 > **Syntax reform (pre-1.0):** The `->` type annotation separator will be
 > replaced with `:` in variable declarations, parameters, and field
-> declarations. Function return types keep `->`. The parser already accepts `:`
-> as an alternative (`TypeSep = "->" | ":"`). New code should prefer `:`.
+> declarations. Function return types keep `->`. The parser currently accepts
+> `:` in all type-separator positions (including return types) because it
+> shares a single `TypeSep = "->" | ":"` rule. This is unintentional — `:` in
+> return-type position is discouraged and will become a parse error once the
+> grammar is split into separate annotation and return-type separators. New
+> code should use `:` for annotations and `->` for return types.
 > See `docs/roadmap.md` §0 and `docs/status.md` §Known Design Issues.
 >
 > ```sfn

--- a/docs/status.md
+++ b/docs/status.md
@@ -133,6 +133,88 @@ The following capsules ship as part of the Sailfin standard library under
   `GLOBAL_BIN_DIR`).
 - Pinned stable version for development: `v0.1.1-alpha.135`.
 
+## Known Design Issues (Pre-1.0 Syntax Reform)
+
+The following design issues have been identified through external review and must
+be resolved before 1.0 to avoid breaking a public API. Each is tracked in
+`docs/roadmap.md` §0 (Syntax Reform). This section records the *problem*; the
+roadmap records the *plan*.
+
+### Type annotation syntax (`->` vs `:`)
+
+**Problem**: `->` is used for both "has type" (parameters, variables) and
+"returns" (function return type). This conflicts with the universal meaning of
+`->` as "maps to / returns" in every typed language (Rust, TypeScript, Haskell,
+Kotlin, Swift, Python).
+
+```sfn
+// Current — three arrows, two meanings
+fn add(x -> number, y -> number) -> number { ... }
+// Target
+fn add(x: number, y: number) -> number { ... }
+```
+
+**Impact**: High. This is the first syntax new users see. It will cause
+immediate confusion and is the most likely reason someone trying the language
+will stop.
+
+**Status**: Parser already accepts `:` as `TypeSep` alongside `->` (see EBNF
+`TypeSep = "->" | ":"`). Migration: deprecate `->` in type positions, then
+remove.
+
+### String interpolation (`{{ }}` vs `${ }`)
+
+**Problem**: `{{ }}` universally means "escape interpolation" in template
+languages (Jinja2, Handlebars, Mustache, Angular) and "literal braces" in
+Rust's `format!`. Sailfin uses it for the *opposite* meaning.
+
+**Impact**: Medium-high. Every developer will be confused. LLM code generators
+trained on billions of lines of `{{ }}` = "literal braces" will systematically
+produce wrong Sailfin code.
+
+### Numeric type system (`number` = f64 only)
+
+**Problem**: The sole numeric type is `number` (64-bit float). This causes:
+- Precision loss for integers above 2^53
+- Semantically wrong array indexing (floats as indices)
+- Unreliable bit operations
+- The "double-encoded pointers" fixup category (~12 of ~69 compiler fixups) —
+  pointers are encoded as doubles because that's what `number` compiles to
+
+**Impact**: High. This is a systems language targeting LLVM. JavaScript made
+this choice and added BigInt 25 years later to compensate. Don't repeat it.
+
+### Error handling gaps
+
+**Problem**: Errors are invisible in function signatures. `try`/`catch` is the
+only structured mechanism, supplemented by ad-hoc union return types
+(`number | DivisionError`) with no propagation operator.
+
+**Impact**: Medium. No `Result<T, E>` or `?` operator means every error-handling
+call site requires manual `match`. Error types proliferate across module
+boundaries with no composition mechanism.
+
+### Unfinished safety claims
+
+**Problem**: `Affine<T>`, `Linear<T>`, `&T`, `&mut T`, `PII<T>`, `Secret<T>`
+are all parsed but not enforced. Claiming "Rust-grade safety" or
+"ownership-aware" in marketing materials while these are purely syntactic is a
+credibility risk.
+
+**Impact**: Medium. Users who come for the safety story will discover it doesn't
+work and leave. Better to remove unfinished syntax than to advertise unenforced
+guarantees.
+
+### Scope creep risk
+
+**Problem**: The spec describes Rust-grade ownership, Swift-like ergonomics,
+AI-native constructs, effect types, capability security, taint tracking, GPU
+acceleration, structured concurrency, policy DSLs, generation cards, and tensor
+types. This is a feature list for five different languages.
+
+**Recommendation**: Pick 3 differentiators (effect system, capability security,
+structured concurrency) and ship those well. Defer everything else ruthlessly.
+
 ## AI / Model Features (Design Preview)
 
 The following features are central to Sailfin's AI-native vision and are fully

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -112,6 +112,30 @@ import { parse_expression } from "./parser/mod";
 - Use `CamelCase` for models/capsules and `snake_case` for locals.
 - Note currency or latency literals as comments until syntax lands.
 
+### Syntax Reform (Pre-1.0)
+
+The following syntax changes are active. See `docs/roadmap.md` §0 for rationale.
+
+- **Type annotations**: Use `:` (colon), not `->` (arrow), for parameter types,
+  variable types, and struct field types. The parser accepts both; prefer `:` in
+  all new code. Return types continue to use `->`.
+
+  ```sfn
+  // Preferred
+  fn add(x: number, y: number) -> number { return x + y; }
+  let name: string = "Sailfin";
+  struct User { id: number; name: string; }
+
+  // Deprecated (still accepted)
+  fn add(x -> number, y -> number) -> number { return x + y; }
+  ```
+
+- **String interpolation**: Current syntax is `{{ expr }}`. This will change to
+  `${ expr }` before 1.0. Continue using `{{ }}` until the parser change lands.
+
+- **Numeric types**: `int` and `float` will replace the single `number` type.
+  Until this lands, use `number` and add comments where integer semantics matter.
+
 ## Comments and Docstrings
 
 - Use `///` doc comments for public items; keep the first sentence a summary.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -117,8 +117,11 @@ import { parse_expression } from "./parser/mod";
 The following syntax changes are active. See `docs/roadmap.md` §0 for rationale.
 
 - **Type annotations**: Use `:` (colon), not `->` (arrow), for parameter types,
-  variable types, and struct field types. The parser accepts both; prefer `:` in
-  all new code. Return types continue to use `->`.
+  variable types, and struct field types. The parser currently accepts both in
+  all positions (including return types) because it shares a single `TypeSep`
+  rule. However, `:` in return-type position is unintentional, discouraged, and
+  will become a parse error once the grammar is split. New code should use `:`
+  for annotations and `->` for return types.
 
   ```sfn
   // Preferred

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,6 +2,12 @@
 
 This directory showcases the evolving Sailfin language surface implemented by the bootstrap compiler. Each subfolder groups small, focused programs illustrating syntax, type constructs, effects, concurrency primitives, and forthcoming AI-native features described in `docs/spec.md`.
 
+> **Syntax reform notice:** These examples use pre-reform syntax (`->` for type
+> annotations, `{{ }}` for string interpolation). A pre-1.0 syntax reform is
+> underway that will migrate to `:` for type annotations and `${ }` for
+> interpolation. The parser already accepts `:` — see `docs/roadmap.md` §0 for
+> the full plan. Examples will be migrated as each reform item lands.
+
 Always check `docs/status.md` before relying on an example in production code. Examples stay limited to the bootstrap feature set unless noted; future-facing snippets include inline comments.
 
 Where you see effect lists (e.g. `![io,model]`) or model/pipeline declarations, remember these are partially stubbed in the current Python runtime: semantics (capability enforcement, provenance, determinism) will harden in the self-hosted toolchain.


### PR DESCRIPTION
Integrates findings from an external language design review across all
working documentation to ensure issues are tracked where they'll influence
day-to-day decisions rather than sitting in a standalone proposal.

Changes across 8 files:
- roadmap.md: Add §0 Syntax Reform (colon types, ${} interpolation,
  int/float types, Result<T,E>, closures) as highest-priority 1.0 work;
  add design principles section; add honest rationale for deferring AI
  constructs to post-1.0
- status.md: Add Known Design Issues section documenting type annotation
  syntax, interpolation delimiters, number-only numerics, error handling
  gaps, unfinished safety claims, and scope creep risk
- spec.md: Add migration notices at variable declarations, function
  signatures, type system overview, string interpolation, error handling,
  and model declarations
- enbf.md: Annotate TypeSep, string interpolation, and literal rules
  with planned changes
- CLAUDE.md: Add syntax reform guidance and design decision framework
  so AI agents writing new code prefer the target syntax
- README.md: Reposition value props around effect system and capability
  security; update code example to use colon syntax; add reform notice
- style-guide.md: Add syntax reform section with preferred forms
- examples/README.md: Add notice that examples use pre-reform syntax

https://claude.ai/code/session_017LeZvyYGq4w8iqu4hL2FCy