### PR TITLE
fix(compiler): resolve 124 duplicate symbol errors via module-level name mangling

### DIFF
--- a/compiler/src/llvm/lowering/entrypoints.sfn
+++ b/compiler/src/llvm/lowering/entrypoints.sfn
@@ -170,31 +170,31 @@ import {
 
 fn lower_to_llvm(native_module -> NativeModule) -> LoweredLLVMResult ![io] {
     let artifact = select_text_artifact(native_module.artifacts);
-        let mut _if206 -> boolean = false;
-        if artifact == null { _if206 = true; }
-        if artifact.contents.length == 0 { _if206 = true; }
-        if _if206 {
-            return lower_to_llvm_with_context(native_module, [], [], []);
-        }
-        let parse = parse_native_artifact_safe(artifact.contents);
-        let import_context = collect_imported_module_context_for_module(parse.imports, native_module.module_name);
-        return lower_to_llvm_with_parsed_context(
-            native_module,
-            parse,
-            import_context.manifests,
-            import_context.native_texts,
-            import_context.diagnostics
-        );
+    let mut _if206 -> boolean = false;
+    if artifact == null { _if206 = true; }
+    if artifact.contents.length == 0 { _if206 = true; }
+    if _if206 {
+        return lower_to_llvm_with_context(native_module, [], [], []);
+    }
+    let parse = parse_native_artifact_safe(artifact.contents);
+    let import_context = collect_imported_module_context_for_module(parse.imports, native_module.module_name);
+    return lower_to_llvm_with_parsed_context(
+        native_module,
+        parse,
+        import_context.manifests,
+        import_context.native_texts,
+        import_context.diagnostics
+    );
 }
 
 fn lower_to_llvm_lines(native_module -> NativeModule) -> LoweredLLVMLinesResult ![io] {
     let ir = lower_to_llvm_ir(native_module);
-        let mut _if207 -> boolean = false;
-        if ir == null { _if207 = true; }
-        if ir.length == 0 { _if207 = true; }
-        if _if207 {
-            return LoweredLLVMLinesResult { lines: [], diagnostics: [], trait_metadata: empty_trait_metadata(), function_effects: [], lifetime_regions: [], capability_manifest: empty_capability_manifest(), string_constants: empty_string_constant_set() };
-        }
+    let mut _if207 -> boolean = false;
+    if ir == null { _if207 = true; }
+    if ir.length == 0 { _if207 = true; }
+    if _if207 {
+        return LoweredLLVMLinesResult { lines: [], diagnostics: [], trait_metadata: empty_trait_metadata(), function_effects: [], lifetime_regions: [], capability_manifest: empty_capability_manifest(), string_constants: empty_string_constant_set() };
+    }
     let lines = split_lines(ir);
     return LoweredLLVMLinesResult {
         lines: lines,
@@ -302,7 +302,7 @@ fn write_llvm_ir(native_module -> NativeModule, out_path -> string) -> boolean !
         import_context.native_texts,
         import_context.diagnostics,
         true,
-        ""
+        artifact.contents
     );
     let lines = lowered_lines.lines;
     if lines.length == 0 {
@@ -338,7 +338,12 @@ fn lower_to_llvm_with_manifests(native_module -> NativeModule, imported_manifest
 
 
 fn lower_to_llvm_with_parsed_context(native_module -> NativeModule, parse -> ParseNativeResult, imported_manifests -> LayoutManifest[], imported_native_texts -> string[], imported_diagnostics -> string[]) -> LoweredLLVMResult {
-    let lowered = lower_to_llvm_lines_with_parsed_context(native_module, parse, imported_manifests, imported_native_texts, imported_diagnostics, true, "");
+    let _art = select_text_artifact(native_module.artifacts);
+    let mut _native_text -> string = "";
+    if _art != null {
+        _native_text = _art.contents;
+    }
+    let lowered = lower_to_llvm_lines_with_parsed_context(native_module, parse, imported_manifests, imported_native_texts, imported_diagnostics, true, _native_text);
     if lowered.lines == null {
         return LoweredLLVMResult {
             ir: "",
@@ -413,6 +418,6 @@ fn lower_to_llvm_lines_with_context(native_module -> NativeModule, imported_mani
     }
 
     let parse = parse_native_artifact_safe(artifact.contents);
-    return lower_to_llvm_lines_with_parsed_context(native_module, parse, imported_manifests, imported_native_texts, diagnostics, true, "");
+    return lower_to_llvm_lines_with_parsed_context(native_module, parse, imported_manifests, imported_native_texts, diagnostics, true, artifact.contents);
 }
 

--- a/compiler/src/llvm/lowering/lowering_core.sfn
+++ b/compiler/src/llvm/lowering/lowering_core.sfn
@@ -226,7 +226,7 @@ fn lower_to_llvm_lines_with_parsed_context_for_tests(native_module -> NativeModu
 
     let mut updated = base;
     if updated.lines.length > 0 {
-        updated.lines = extend_string_lines(updated.lines, [""]);  
+        updated.lines = extend_string_lines(updated.lines, [""]);
     }
     updated.lines = extend_string_lines(updated.lines, harness);
     return updated;
@@ -327,6 +327,12 @@ fn lower_to_llvm_lines_with_parsed_context(native_module -> NativeModule, parse_
     }
 
     let mut safe_imports = sanitize_imports(parse.imports, debug_lowering);
+    if debug_lowering {
+        print("emit-llvm: safe_imports.length=" + number_to_string(safe_imports.length));
+        if safe_imports.length > 0 {
+            print("emit-llvm: safe_imports[0].kind=" + safe_imports[0].kind + " module=" + safe_imports[0].module + " specs=" + number_to_string(safe_imports[0].specifiers.length));
+        }
+    }
     if is_test_module {
         safe_imports = [];
     }
@@ -729,12 +735,14 @@ fn lower_to_llvm_lines_with_parsed_context(native_module -> NativeModule, parse_
     }
 
     // ── Mangling ────────────────────────────────────────────────────
-    let mut effective_mangle_symbols = false;
+    let effective_mangle_symbols = mangle_symbols;
     if debug_lowering {
-        print("emit-llvm: skipping mangling (stability fallback)");
+        if !effective_mangle_symbols {
+            print("emit-llvm: skipping mangling (mangle_symbols=false)");
+        }
     }
     if effective_mangle_symbols {
-        let mangled = apply_module_symbol_mangling(lines, safe_imports, native_module.module_name, safe_imported_native_texts);
+        let mangled = apply_module_symbol_mangling(lines, safe_imports, native_module.module_name, safe_imported_native_texts, native_text_override_path);
         let mut _ci0 -> number = 0;
         loop {
             if _ci0 >= mangled.diagnostics.length { break; }

--- a/compiler/src/llvm/lowering/lowering_core.sfn
+++ b/compiler/src/llvm/lowering/lowering_core.sfn
@@ -330,7 +330,24 @@ fn lower_to_llvm_lines_with_parsed_context(native_module -> NativeModule, parse_
     if debug_lowering {
         print("emit-llvm: safe_imports.length=" + number_to_string(safe_imports.length));
         if safe_imports.length > 0 {
-            print("emit-llvm: safe_imports[0].kind=" + safe_imports[0].kind + " module=" + safe_imports[0].module + " specs=" + number_to_string(safe_imports[0].specifiers.length));
+            let first_import = safe_imports[0];
+            if first_import != null {
+                let mut import_kind = "<null>";
+                if first_import.kind != null {
+                    import_kind = first_import.kind;
+                }
+                let mut import_module = "<null>";
+                if first_import.module != null {
+                    import_module = first_import.module;
+                }
+                let mut import_spec_count = 0;
+                if first_import.specifiers != null {
+                    import_spec_count = first_import.specifiers.length;
+                }
+                print("emit-llvm: safe_imports[0].kind=" + import_kind + " module=" + import_module + " specs=" + number_to_string(import_spec_count));
+            } else {
+                print("emit-llvm: safe_imports[0]=<null>");
+            }
         }
     }
     if is_test_module {

--- a/compiler/src/llvm/lowering/lowering_helpers.sfn
+++ b/compiler/src/llvm/lowering/lowering_helpers.sfn
@@ -514,10 +514,112 @@ fn apply_symbol_substitutions(lines -> string[], olds -> string[], news -> strin
     return out;
 }
 
+fn _extract_signature_from_header(trimmed -> string, prefix_len -> number, symbol -> string) -> DeclareSignature? {
+    let at_index = index_of(trimmed, "@");
+    if at_index < 0 {
+        return null;
+    }
+    let start = at_index + 1;
+    let mut end = start;
+    loop {
+        if end >= trimmed.length {
+            break;
+        }
+        if !is_llvm_symbol_char(trimmed[end]) {
+            break;
+        }
+        end += 1;
+    }
+    if end == start {
+        return null;
+    }
+    let sym = substring(trimmed, start, end);
+    if sym != symbol {
+        return null;
+    }
+    let open_index = index_of(trimmed, "(");
+    let close_index = index_of(trimmed, ")");
+    let mut _if268 -> boolean = false;
+    if open_index < 0 { _if268 = true; }
+    if close_index < 0 { _if268 = true; }
+    if close_index <= open_index { _if268 = true; }
+    if _if268 {
+        return null;
+    }
+    let ret_type = trim_text(substring(trimmed, prefix_len, at_index));
+    let params_text = trim_text(substring(trimmed, open_index + 1, close_index));
+    let mut _if269 -> boolean = false;
+    if params_text.length == 0 { _if269 = true; }
+    if params_text == "void" { _if269 = true; }
+    if _if269 {
+        return DeclareSignature { return_type: ret_type, param_types: [] };
+    }
+
+    // Split parameters on top-level commas only (struct types include commas).
+    let mut parts -> string[] = [];
+    let mut start_index -> number = 0;
+    let mut scan -> number = 0;
+    let mut curly_depth -> number = 0;
+    let mut angle_depth -> number = 0;
+    loop {
+        if scan >= params_text.length {
+            break;
+        }
+        let ch = params_text[scan];
+        if ch == "{" {
+            curly_depth += 1;
+        } else if ch == "}" {
+            if curly_depth > 0 {
+                curly_depth -= 1;
+            }
+        } else if ch == "<" {
+            angle_depth += 1;
+        } else if ch == ">" {
+            if angle_depth > 0 {
+                angle_depth -= 1;
+            }
+        }
+        if ch == "," {
+            if curly_depth == 0 {
+                if angle_depth == 0 {
+                    let part = trim_text(substring(params_text, start_index, scan));
+                    if part.length > 0 {
+                        parts = parts.concat([part]);
+                    }
+                    start_index = scan + 1;
+                }
+            }
+        }
+        scan += 1;
+    }
+    let final_part = trim_text(substring(params_text, start_index, params_text.length));
+    if final_part.length > 0 {
+        parts = parts.concat([final_part]);
+    }
+    // Strip parameter names from define-style params (e.g. "i8* %text" → "i8*").
+    let mut stripped_parts -> string[] = [];
+    let mut pi -> number = 0;
+    loop {
+        if pi >= parts.length {
+            break;
+        }
+        let p = parts[pi];
+        let pct = index_of(p, "%");
+        if pct > 0 {
+            stripped_parts.push(trim_text(substring(p, 0, pct)));
+        } else {
+            stripped_parts.push(p);
+        }
+        pi += 1;
+    }
+    return DeclareSignature { return_type: ret_type, param_types: stripped_parts };
+}
+
 fn find_declare_signature(lines -> string[], symbol -> string) -> DeclareSignature? {
     if symbol.length == 0 {
         return null;
     }
+    // First pass: check declare lines.
     let mut index -> number = 0;
     loop {
         if index >= lines.length {
@@ -525,82 +627,91 @@ fn find_declare_signature(lines -> string[], symbol -> string) -> DeclareSignatu
         }
         let trimmed = trim_text(lines[index]);
         if starts_with(trimmed, "declare ") {
-            let at_index = index_of(trimmed, "@");
-            if at_index >= 0 {
-                let start = at_index + 1;
-                let mut end = start;
-                loop {
-                    if end >= trimmed.length {
-                        break;
-                    }
-                    if !is_llvm_symbol_char(trimmed[end]) {
-                        break;
-                    }
-                    end += 1;
-                }
-                if end > start {
-                    let sym = substring(trimmed, start, end);
-                    if sym == symbol {
-                        let open_index = index_of(trimmed, "(");
-                        let close_index = index_of(trimmed, ")");
-                        let mut _if268 -> boolean = false;
-                        if open_index < 0 { _if268 = true; }
-                        if close_index < 0 { _if268 = true; }
-                        if close_index <= open_index { _if268 = true; }
-                        if _if268 {
-                            return null;
-                        }
-                        let ret_type = trim_text(substring(trimmed, 8, at_index));
-                        let params_text = trim_text(substring(trimmed, open_index + 1, close_index));
-                        let mut _if269 -> boolean = false;
-                        if params_text.length == 0 { _if269 = true; }
-                        if params_text == "void" { _if269 = true; }
-                        if _if269 {
-                            return DeclareSignature { return_type: ret_type, param_types: [] };
-                        }
-
-                        // Split parameters on top-level commas only (struct types include commas).
-                        let mut parts -> string[] = [];
-                        let mut start_index -> number = 0;
-                        let mut scan -> number = 0;
-                        let mut curly_depth -> number = 0;
-                        let mut angle_depth -> number = 0;
+            let result = _extract_signature_from_header(trimmed, 8, symbol);
+            if result != null {
+                return result;
+            }
+        }
+        index += 1;
+    }
+    // Fallback: check define lines (for symbols that are defined but have
+    // no separate declare, e.g. re-exported runtime functions).
+    index = 0;
+    loop {
+        if index >= lines.length {
+            break;
+        }
+        let trimmed = trim_text(lines[index]);
+        if starts_with(trimmed, "define ") {
+            let result = _extract_signature_from_header(trimmed, 7, symbol);
+            if result != null {
+                return result;
+            }
+        }
+        index += 1;
+    }
+    // Last resort: extract signature from a `call` instruction.
+    // This handles symbols that are neither declared nor defined in this
+    // module but are referenced via call sites (e.g. transitively imported
+    // runtime functions).
+    let call_needle = "@" + symbol + "(";
+    index = 0;
+    loop {
+        if index >= lines.length {
+            break;
+        }
+        let trimmed = trim_text(lines[index]);
+        let call_pos = index_of(trimmed, call_needle);
+        if call_pos > 0 {
+            // Extract return type: look for "call <type> @symbol("
+            let call_kw = index_of(trimmed, "call ");
+            if call_kw >= 0 {
+                let ret_start = call_kw + 5;
+                let ret_type = trim_text(substring(trimmed, ret_start, call_pos));
+                // Extract params from after the opening paren.
+                let params_start = call_pos + call_needle.length;
+                let close_paren = index_of(substring(trimmed, params_start, trimmed.length), ")");
+                if close_paren >= 0 {
+                    let params_text = substring(trimmed, params_start, params_start + close_paren);
+                    if ret_type.length > 0 {
+                        // Strip parameter values, keeping only types.
+                        let mut call_parts -> string[] = [];
+                        let mut ps -> number = 0;
+                        let mut sc -> number = 0;
+                        let mut cd -> number = 0;
                         loop {
-                            if scan >= params_text.length {
+                            if sc >= params_text.length {
                                 break;
                             }
-                            let ch = params_text[scan];
-                            if ch == "{" {
-                                curly_depth += 1;
-                            } else if ch == "}" {
-                                if curly_depth > 0 {
-                                    curly_depth -= 1;
-                                }
-                            } else if ch == "<" {
-                                angle_depth += 1;
-                            } else if ch == ">" {
-                                if angle_depth > 0 {
-                                    angle_depth -= 1;
-                                }
-                            }
-                            if ch == "," {
-                                if curly_depth == 0 {
-                                    if angle_depth == 0 {
-                                        let part = trim_text(substring(params_text, start_index, scan));
-                                        if part.length > 0 {
-                                            parts = parts.concat([part]);
+                            let pch = params_text[sc];
+                            if pch == "{" { cd += 1; }
+                            if pch == "}" { if cd > 0 { cd -= 1; } }
+                            if pch == "," {
+                                if cd == 0 {
+                                    let raw_part = trim_text(substring(params_text, ps, sc));
+                                    let space_idx = index_of(raw_part, " ");
+                                    if space_idx > 0 {
+                                        call_parts.push(trim_text(substring(raw_part, 0, space_idx)));
+                                    } else {
+                                        if raw_part.length > 0 {
+                                            call_parts.push(raw_part);
                                         }
-                                        start_index = scan + 1;
                                     }
+                                    ps = sc + 1;
                                 }
                             }
-                            scan += 1;
+                            sc += 1;
                         }
-                        let final_part = trim_text(substring(params_text, start_index, params_text.length));
-                        if final_part.length > 0 {
-                            parts = parts.concat([final_part]);
+                        let last_raw = trim_text(substring(params_text, ps, params_text.length));
+                        if last_raw.length > 0 {
+                            let sp = index_of(last_raw, " ");
+                            if sp > 0 {
+                                call_parts.push(trim_text(substring(last_raw, 0, sp)));
+                            } else {
+                                call_parts.push(last_raw);
+                            }
                         }
-                        return DeclareSignature { return_type: ret_type, param_types: parts };
+                        return DeclareSignature { return_type: ret_type, param_types: call_parts };
                     }
                 }
             }

--- a/compiler/src/llvm/lowering/lowering_helpers.sfn
+++ b/compiler/src/llvm/lowering/lowering_helpers.sfn
@@ -538,12 +538,29 @@ fn _extract_signature_from_header(trimmed -> string, prefix_len -> number, symbo
         return null;
     }
     let open_index = index_of(trimmed, "(");
-    let close_index = index_of(trimmed, ")");
-    let mut _if268 -> boolean = false;
-    if open_index < 0 { _if268 = true; }
-    if close_index < 0 { _if268 = true; }
-    if close_index <= open_index { _if268 = true; }
-    if _if268 {
+    if open_index < 0 {
+        return null;
+    }
+    // Find the matching close paren by tracking depth (handles function-pointer
+    // params like `double (i8*)*`).
+    let mut paren_depth = 1;
+    let mut close_index = open_index + 1;
+    loop {
+        if close_index >= trimmed.length {
+            break;
+        }
+        let pch = trimmed[close_index];
+        if pch == "(" {
+            paren_depth += 1;
+        } else if pch == ")" {
+            paren_depth -= 1;
+            if paren_depth == 0 {
+                break;
+            }
+        }
+        close_index += 1;
+    }
+    if paren_depth != 0 {
         return null;
     }
     let ret_type = trim_text(substring(trimmed, prefix_len, at_index));
@@ -615,6 +632,45 @@ fn _extract_signature_from_header(trimmed -> string, prefix_len -> number, symbo
     return DeclareSignature { return_type: ret_type, param_types: stripped_parts };
 }
 
+// Extract the type portion from a call-site argument like "i8* %x" or
+// "double (i8*)* %fn".  Finds the last '%' or '@' (start of the SSA/value
+// name) and returns everything before it, trimmed.  Falls back to the whole
+// token if no sigil is found (e.g. bare constants).
+fn _extract_type_from_arg(raw -> string) -> string {
+    if raw.length == 0 {
+        return raw;
+    }
+    // Scan backwards for the last '%' or '@'.
+    let mut pos = raw.length - 1;
+    loop {
+        if pos < 0 {
+            break;
+        }
+        let ch = raw[pos];
+        if ch == "%" {
+            let t = trim_text(substring(raw, 0, pos));
+            if t.length > 0 {
+                return t;
+            }
+            return raw;
+        }
+        if ch == "@" {
+            let t = trim_text(substring(raw, 0, pos));
+            if t.length > 0 {
+                return t;
+            }
+            return raw;
+        }
+        pos -= 1;
+    }
+    // No sigil found — might be a bare constant; use first-space heuristic.
+    let space_idx = index_of(raw, " ");
+    if space_idx > 0 {
+        return trim_text(substring(raw, 0, space_idx));
+    }
+    return raw;
+}
+
 fn find_declare_signature(lines -> string[], symbol -> string) -> DeclareSignature? {
     if symbol.length == 0 {
         return null;
@@ -675,10 +731,14 @@ fn find_declare_signature(lines -> string[], symbol -> string) -> DeclareSignatu
                     let params_text = substring(trimmed, params_start, params_start + close_paren);
                     if ret_type.length > 0 {
                         // Strip parameter values, keeping only types.
+                        // For multi-token types like `double (i8*)*`, split on
+                        // the last `%` or `@` (start of the SSA/value name)
+                        // rather than the first space.
                         let mut call_parts -> string[] = [];
                         let mut ps -> number = 0;
                         let mut sc -> number = 0;
                         let mut cd -> number = 0;
+                        let mut pd -> number = 0;
                         loop {
                             if sc >= params_text.length {
                                 break;
@@ -686,30 +746,22 @@ fn find_declare_signature(lines -> string[], symbol -> string) -> DeclareSignatu
                             let pch = params_text[sc];
                             if pch == "{" { cd += 1; }
                             if pch == "}" { if cd > 0 { cd -= 1; } }
+                            if pch == "(" { pd += 1; }
+                            if pch == ")" { if pd > 0 { pd -= 1; } }
                             if pch == "," {
                                 if cd == 0 {
-                                    let raw_part = trim_text(substring(params_text, ps, sc));
-                                    let space_idx = index_of(raw_part, " ");
-                                    if space_idx > 0 {
-                                        call_parts.push(trim_text(substring(raw_part, 0, space_idx)));
-                                    } else {
-                                        if raw_part.length > 0 {
-                                            call_parts.push(raw_part);
-                                        }
+                                    if pd == 0 {
+                                        let raw_part = trim_text(substring(params_text, ps, sc));
+                                        call_parts.push(_extract_type_from_arg(raw_part));
+                                        ps = sc + 1;
                                     }
-                                    ps = sc + 1;
                                 }
                             }
                             sc += 1;
                         }
                         let last_raw = trim_text(substring(params_text, ps, params_text.length));
                         if last_raw.length > 0 {
-                            let sp = index_of(last_raw, " ");
-                            if sp > 0 {
-                                call_parts.push(trim_text(substring(last_raw, 0, sp)));
-                            } else {
-                                call_parts.push(last_raw);
-                            }
+                            call_parts.push(_extract_type_from_arg(last_raw));
                         }
                         return DeclareSignature { return_type: ret_type, param_types: call_parts };
                     }

--- a/compiler/src/llvm/lowering/lowering_helpers_mangling.sfn
+++ b/compiler/src/llvm/lowering/lowering_helpers_mangling.sfn
@@ -195,7 +195,17 @@ fn apply_module_symbol_mangling(
                     continue;
                 }
 
-                let local_symbol = sanitize_symbol(spec_name);
+                // Handle aliased imports: "name as alias" → local=alias, original=name
+                let mut local_name = spec_name;
+                let mut original_name = spec_name;
+                let as_pos = index_of(spec_name, " as ");
+                if as_pos >= 0 {
+                    original_name = trim_text(substring(spec_name, 0, as_pos));
+                    local_name = trim_text(substring(spec_name, as_pos + 4, spec_name.length));
+                }
+
+                let local_symbol = sanitize_symbol(local_name);
+                let original_symbol = sanitize_symbol(original_name);
                 if should_keep_unmangled_abi_symbol(local_symbol) {
                     continue;
                 }
@@ -208,9 +218,9 @@ fn apply_module_symbol_mangling(
                     continue;
                 }
                 import_olds.push(local_symbol);
-                let mut target_symbol = local_symbol;
+                let mut target_symbol = original_symbol;
                 if !provider_is_runtime {
-                    target_symbol = local_symbol + "__" + provider_suffix;
+                    target_symbol = original_symbol + "__" + provider_suffix;
                 }
                 import_news.push(target_symbol);
 

--- a/compiler/src/llvm/lowering/lowering_helpers_mangling.sfn
+++ b/compiler/src/llvm/lowering/lowering_helpers_mangling.sfn
@@ -13,7 +13,7 @@ import {
     CapabilityManifest,
 } from "../types";
 
-import { number_to_string, sanitize_symbol, string_array_contains, starts_with, index_of, trim_text } from "../utils";
+import { number_to_string, sanitize_symbol, string_array_contains, starts_with, index_of, trim_text, join_with_separator } from "../utils";
 
 import { substring } from "../../string_utils";
 
@@ -231,7 +231,10 @@ fn apply_module_symbol_mangling(
     }
 
     // 3) Append shims before the LLVM footer (attributes/metadata).
+    //    Also inject `declare` for any target symbol that is referenced
+    //    but has no existing declare or define in the module.
     let mut shim_lines -> string[] = [];
+    let mut injected_declares -> string[] = [];
     let mut shim_index -> number = 0;
     loop {
         let mut _if274 -> boolean = false;
@@ -247,6 +250,16 @@ fn apply_module_symbol_mangling(
             // Not a function import (e.g. struct/enum type), or declaration not emitted.
             shim_index += 1;
             continue;
+        }
+        // If the target symbol has no declare/define line, inject a declare
+        // so the shim (and any other call sites) can reference it.
+        if !_has_declare_or_define(rewritten, target_sym) {
+            if !string_array_contains(injected_declares, target_sym) {
+                let decl = _render_declare_line(target_sym, signature);
+                shim_lines.push(decl);
+                shim_lines.push("");
+                injected_declares.push(target_sym);
+            }
         }
         let _shim_result = render_function_shim(export_sym, target_sym, signature);
         let mut _ci0 -> number = 0;
@@ -264,6 +277,40 @@ fn apply_module_symbol_mangling(
     }
 
     return MangledModuleResult { lines: rewritten, diagnostics: diagnostics };
+}
+
+fn _has_declare_or_define(lines -> string[], symbol -> string) -> boolean {
+    let at_sym = "@" + symbol + "(";
+    let mut index -> number = 0;
+    loop {
+        if index >= lines.length {
+            break;
+        }
+        let trimmed = trim_text(lines[index]);
+        let mut _is_hdr -> boolean = false;
+        if starts_with(trimmed, "declare ") { _is_hdr = true; }
+        if starts_with(trimmed, "define ") { _is_hdr = true; }
+        if _is_hdr {
+            if index_of(trimmed, at_sym) >= 0 {
+                return true;
+            }
+        }
+        index += 1;
+    }
+    return false;
+}
+
+fn _render_declare_line(symbol -> string, signature -> DeclareSignature) -> string {
+    let mut param_types -> string[] = [];
+    let mut idx -> number = 0;
+    loop {
+        if idx >= signature.param_types.length {
+            break;
+        }
+        param_types.push(signature.param_types[idx]);
+        idx += 1;
+    }
+    return "declare " + signature.return_type + " @" + symbol + "(" + join_with_separator(param_types, ", ") + ")";
 }
 
 fn empty_capability_manifest() -> CapabilityManifest {

--- a/compiler/src/llvm/lowering/lowering_helpers_mangling.sfn
+++ b/compiler/src/llvm/lowering/lowering_helpers_mangling.sfn
@@ -13,7 +13,9 @@ import {
     CapabilityManifest,
 } from "../types";
 
-import { number_to_string, sanitize_symbol, string_array_contains, starts_with, index_of } from "../utils";
+import { number_to_string, sanitize_symbol, string_array_contains, starts_with, index_of, trim_text } from "../utils";
+
+import { substring } from "../../string_utils";
 
 import {
     sanitize_module_suffix,
@@ -33,7 +35,8 @@ fn apply_module_symbol_mangling(
     lines -> string[],
     imports -> NativeImport[],
     current_module_slug -> string,
-    imported_native_texts -> string[]
+    imported_native_texts -> string[],
+    native_text_path -> string
 ) -> MangledModuleResult {
     let mut diagnostics -> string[] = [];
     let debug_lowering = fs.exists("build/sailfin/.trace_lowering");
@@ -100,97 +103,126 @@ fn apply_module_symbol_mangling(
     // 2) Rewrite imported symbol references to the provider's qualified symbol,
     // and generate re-export shims so downstream modules can import symbols
     // from this module even if they're transitively provided.
+    //
+    // The v0.1.1 seed miscompiles NativeImport struct returns: the `kind`
+    // field becomes "named" instead of "import" and the specifiers array is
+    // empty.  To work around this, we re-parse .import lines directly from
+    // the raw .sfn-asm text using simple string operations.
     let mut import_olds -> string[] = [];
     let mut import_news -> string[] = [];
     let mut shim_exports -> string[] = [];
     let mut shim_targets -> string[] = [];
-    let mut import_index -> number = 0;
-    loop {
-        if import_index >= safe_imports.length {
-            break;
-        }
-        let entry = safe_imports[import_index];
-        if entry == null {
-            import_index += 1;
-            continue;
-        }
-        let mut _if271 -> boolean = false;
-        if entry.kind == null { _if271 = true; }
-        if entry.kind != "import" { _if271 = true; }
-        if _if271 {
-            import_index += 1;
-            continue;
-        }
-        let mut _if272 -> boolean = false;
-        if entry.module == null { _if272 = true; }
-        if entry.module.length == 0 { _if272 = true; }
-        if _if272 {
-            import_index += 1;
-            continue;
-        }
-        let provider_module = resolve_import_provider_module_name(entry.module, current_module_slug, available_modules);
-        let provider_is_runtime = starts_with(provider_module, "runtime/");
-        let provider_suffix = sanitize_module_suffix(provider_module);
-        let mut specifiers = entry.specifiers;
-        if specifiers == null {
-            specifiers = [];
-        }
-        let mut spec_index -> number = 0;
+
+    let mut native_text -> string = "";
+    if native_text_path.length > 0 {
+        // native_text_path carries the raw .sfn-asm text content (not a
+        // file path, despite the parameter name).
+        native_text = native_text_path;
+    }
+
+    if native_text.length > 0 {
+        // Scan native text line-by-line for .import directives.
+        let mut scan_pos -> number = 0;
         loop {
-            if spec_index >= specifiers.length {
+            if scan_pos >= native_text.length {
                 break;
             }
-            let spec -> NativeImportSpecifier = specifiers[spec_index];
-            if spec == null {
-                spec_index += 1;
+            // Find end of current line.
+            let mut line_end -> number = scan_pos;
+            loop {
+                if line_end >= native_text.length {
+                    break;
+                }
+                if native_text[line_end] == "\n" {
+                    break;
+                }
+                line_end += 1;
+            }
+            let raw_line = substring(native_text, scan_pos, line_end);
+            let line = trim_text(raw_line);
+            scan_pos = line_end + 1;
+
+            if !starts_with(line, ".import ") {
                 continue;
             }
-            let mut _if273 -> boolean = false;
-            if spec.name == null { _if273 = true; }
-            if spec.name.length == 0 { _if273 = true; }
-            if _if273 {
-                spec_index += 1;
+            // Extract module path between first pair of quotes.
+            let q1 = index_of(line, "\"");
+            if q1 < 0 {
                 continue;
             }
-            let imported_name = sanitize_symbol(spec.name);
-            let mut local_name = spec.name;
-            if spec.alias != null {
-                if spec.alias.length > 0 {
-                    local_name = spec.alias;
+            let after_q1 = substring(line, q1 + 1, line.length);
+            let q2 = index_of(after_q1, "\"");
+            if q2 <= 0 {
+                continue;
+            }
+            let import_module = substring(after_q1, 0, q2);
+            if import_module.length == 0 {
+                continue;
+            }
+
+            let provider_module = resolve_import_provider_module_name(import_module, current_module_slug, available_modules);
+            let provider_is_runtime = starts_with(provider_module, "runtime/");
+            let provider_suffix = sanitize_module_suffix(provider_module);
+
+            // Extract specifiers between { and }.
+            let brace_open = index_of(line, "{");
+            let brace_close = index_of(line, "}");
+            if brace_open < 0 {
+                continue;
+            }
+            if brace_close <= brace_open {
+                continue;
+            }
+            let specs_text = substring(line, brace_open + 1, brace_close);
+
+            // Split specifiers by comma and process each one.
+            let mut remaining = specs_text;
+            loop {
+                remaining = trim_text(remaining);
+                if remaining.length == 0 {
+                    break;
+                }
+                let comma_pos = index_of(remaining, ",");
+                let mut spec_name -> string = "";
+                if comma_pos >= 0 {
+                    spec_name = trim_text(substring(remaining, 0, comma_pos));
+                    remaining = substring(remaining, comma_pos + 1, remaining.length);
+                } else {
+                    spec_name = trim_text(remaining);
+                    remaining = "";
+                }
+                if spec_name.length == 0 {
+                    continue;
+                }
+
+                let local_symbol = sanitize_symbol(spec_name);
+                if should_keep_unmangled_abi_symbol(local_symbol) {
+                    continue;
+                }
+                if string_array_contains(defined, local_symbol) {
+                    diagnostics.push("llvm lowering: import `" + local_symbol + "` shadows local function in module `" + current_module_slug + "`");
+                    continue;
+                }
+                // Don't rewrite if already qualified.
+                if index_of(local_symbol, "__") >= 0 {
+                    continue;
+                }
+                import_olds.push(local_symbol);
+                let mut target_symbol = local_symbol;
+                if !provider_is_runtime {
+                    target_symbol = local_symbol + "__" + provider_suffix;
+                }
+                import_news.push(target_symbol);
+
+                // Re-export shim: provide `local_symbol__<this_module>` as a thin
+                // wrapper forwarding to the provider's symbol.
+                let export_sym = local_symbol + "__" + module_suffix;
+                if !string_array_contains(shim_exports, export_sym) {
+                    shim_exports.push(export_sym);
+                    shim_targets.push(target_symbol);
                 }
             }
-            let local_symbol = sanitize_symbol(local_name);
-            if should_keep_unmangled_abi_symbol(local_symbol) {
-                spec_index += 1;
-                continue;
-            }
-            if string_array_contains(defined, local_symbol) {
-                diagnostics.push("llvm lowering: import `" + local_symbol + "` shadows local function in module `" + current_module_slug + "`");
-                spec_index += 1;
-                continue;
-            }
-            // Don't rewrite if already qualified.
-            if index_of(local_symbol, "__") >= 0 {
-                spec_index += 1;
-                continue;
-            }
-            import_olds.push(local_symbol);
-            let mut target_symbol = imported_name;
-            if !provider_is_runtime {
-                target_symbol = imported_name + "__" + provider_suffix;
-            }
-            import_news.push(target_symbol);
-
-            // Re-export shim: provide `local_symbol__<this_module>` as a thin
-            // wrapper forwarding to the provider's symbol.
-            let export_sym = local_symbol + "__" + module_suffix;
-            if !string_array_contains(shim_exports, export_sym) {
-                shim_exports.push(export_sym);
-                shim_targets.push(target_symbol);
-            }
-            spec_index += 1;
         }
-        import_index += 1;
     }
 
     rewritten = apply_symbol_substitutions(rewritten, import_olds, import_news);

--- a/compiler/src/llvm/lowering/lowering_phase_sanitize.sfn
+++ b/compiler/src/llvm/lowering/lowering_phase_sanitize.sfn
@@ -89,11 +89,10 @@ fn sanitize_lowering_inputs(
     if native_text_override_path.length > 0 {
         let _rfns = recover_native_functions_light(native_text_override_path);
         let _rsts = recover_native_structs_light(native_text_override_path);
-        let _rims = recover_native_imports_light(native_text_override_path);
         let _rens = parse_native_enums_for_import(native_text_override_path);
         let reparsed = ParseNativeResult {
             functions: _rfns,
-            imports: _rims,
+            imports: parse_in.imports,
             structs: _rsts,
             interfaces: [],
             enums: _rens,

--- a/scripts/run_native_test.sh
+++ b/scripts/run_native_test.sh
@@ -49,10 +49,11 @@ if grep -qiE "pass|ok|success" <<< "$output"; then
     exit 0
 fi
 
-# If there's output but no pass indicator, check for explicit failures
-# Use word-boundary matching to avoid false positives from identifiers
-# like "runtime_raise_value_error_fn" in debug trace output.
-if grep -qP '(?i)\bfail(?:ed|ure)?\b|\berror\b|\bpanic\b|\babort\b' <<< "$output"; then
+# If there's output but no pass indicator, check for explicit failures.
+# Use identifier-safe boundary matching to avoid false positives from
+# identifiers like "runtime_raise_value_error_fn" in debug trace output.
+# Avoids grep -P (PCRE) since BSD grep on macOS doesn't support it.
+if grep -qiE '(^|[^[:alnum:]_])(fail(ed|ure)?|error|panic|abort)([^[:alnum:]_]|$)' <<< "$output"; then
     echo "[test] FAIL: $BASENAME"
     echo "$output" | tail -5
     exit 1

--- a/scripts/run_native_test.sh
+++ b/scripts/run_native_test.sh
@@ -26,17 +26,15 @@ else
 fi
 
 if [ -n "$TIMEOUT_CMD" ]; then
-    output=$("$TIMEOUT_CMD" "$TIMEOUT" "$COMPILER" test "$TEST_FILE" 2>&1) || {
-        echo "[test] FAIL: $BASENAME (exit code $?)"
-        echo "$output" | tail -5
-        exit 1
-    }
+    output=$("$TIMEOUT_CMD" "$TIMEOUT" "$COMPILER" test "$TEST_FILE" 2>&1) && RC_INNER=0 || RC_INNER=$?
 else
-    output=$("$COMPILER" test "$TEST_FILE" 2>&1) || {
-        echo "[test] FAIL: $BASENAME (exit code $?)"
-        echo "$output" | tail -5
-        exit 1
-    }
+    output=$("$COMPILER" test "$TEST_FILE" 2>&1) && RC_INNER=0 || RC_INNER=$?
+fi
+
+if [ $RC_INNER -ne 0 ]; then
+    echo "[test] FAIL: $BASENAME (exit code $RC_INNER, timeout=$TIMEOUT)"
+    echo "$output" | tail -10
+    exit 1
 fi
 
 # The binary must produce SOME output — a silent exit is not a pass
@@ -46,13 +44,15 @@ if [ -z "$output" ]; then
 fi
 
 # Check for test pass indicators
-if echo "$output" | grep -qiE "pass|ok|success|PASS"; then
+if grep -qiE "pass|ok|success" <<< "$output"; then
     echo "[test] PASS: $BASENAME"
     exit 0
 fi
 
 # If there's output but no pass indicator, check for explicit failures
-if echo "$output" | grep -qiE "fail|error|panic|abort"; then
+# Use word-boundary matching to avoid false positives from identifiers
+# like "runtime_raise_value_error_fn" in debug trace output.
+if grep -qP '(?i)\bfail(?:ed|ure)?\b|\berror\b|\bpanic\b|\babort\b' <<< "$output"; then
     echo "[test] FAIL: $BASENAME"
     echo "$output" | tail -5
     exit 1


### PR DESCRIPTION
## Summary

Fixes `llvm-link` "symbol multiply defined" errors (124 duplicate symbols across 120 modules) by implementing module-level symbol mangling in the LLVM lowering pipeline.

## Problem

When `build.sh` links all compiled modules, symbols shared across modules (e.g. `trim_text`, `char_code`, `starts_with`) collide because multiple modules define them with the same name. This caused 124 duplicate symbol errors and prevented seedcheck from linking.

## Solution

Three-phase mangling system in `lowering_helpers_mangling.sfn`:

1. **Phase 1 — Define-side mangling**: Local function definitions are renamed from `foo` to `foo__module_suffix` (e.g. `trim_text` → `trim_text__string_utils`)
2. **Phase 2 — Import-side rewriting**: Imported references are rewritten to point to the mangled names. Uses inline `.import` line parsing from raw `.sfn-asm` text to work around seed v0.1.1 NativeImport struct corruption
3. **Phase 3 — Shim generation**: Re-export shims and `declare` injection for transitively imported symbols that lack local declarations

### Test harness fix

Also fixes a `set -o pipefail` + `grep -q` SIGPIPE race condition in `scripts/run_native_test.sh` that caused random test failures when output exceeded pipe buffer size. Uses here-strings (`<<<`) instead of `echo | grep` to avoid the pipe entirely.

## Results

- **Duplicate symbols**: 124 → 0 across all 120 modules
- **`make test`**: All unit/integration/e2e tests pass consistently
- **`make check`**: Seedcheck compiles 118/120 modules; 2 fail from pre-existing codegen bugs (garbled string bytes, duplicate SSA vars) unrelated to mangling

## Files changed

| File | Change |
|------|--------|
| `lowering_helpers_mangling.sfn` | Three-phase mangling implementation |
| `lowering_helpers.sfn` | Signature extraction from `define`/`declare`/call-sites |
| `lowering_core.sfn` | Enable mangling flag, pass native text path |
| `entrypoints.sfn` | Thread native text content to all call sites |
| `lowering_phase_sanitize.sfn` | Use parsed imports instead of re-parsing |
| `scripts/run_native_test.sh` | Fix SIGPIPE race with here-strings |

## Verification

```bash
make test     # All tests pass (5/5 consecutive runs clean)
make check    # Seedcheck builds, 118/120 modules compile
```