### PR TITLE
fix(build): remove post-processing from build.sh

### DIFF
--- a/SEED_STABILIZATION.md
+++ b/SEED_STABILIZATION.md
@@ -6,8 +6,25 @@ This document describes the strategy and work plan for producing a self-sufficie
 
 - **Pinned seed:** v0.1.1 (`sfn` installed at `~/.local/bin/sfn`)
 - **Build driver:** `scripts/selfhost_native.py` (Python, with ~69 IR fixup passes)
-- **Goal driver:** `scripts/build.sh` (shell, zero fixups)
+- **Goal driver:** `scripts/build.sh` (shell, zero fixups, zero post-processing)
 - **Graduation gate:** `make check` — builds seedcheck with `build.sh`, validates it runs hello-world and passes the test suite
+
+### Architecture
+
+The build pipeline has two stages:
+
+1. **Seed + Python driver** → first-pass binary (`build/native/sailfin`)
+   - The v0.1.1 seed has known bugs (cross-module types, SSA dupes, etc.)
+   - `selfhost_native.py` compensates with fixup passes — **this is acceptable**
+   - Fixups here are OK because they help the broken seed produce a working binary
+
+2. **First-pass binary + `build.sh`** → seedcheck binary
+   - `build.sh` has **zero fixups, zero post-processing, zero Python**
+   - If `build.sh` fails, the first-pass binary has a bug
+   - Fix bugs in `compiler/src/*.sfn` so the first-pass binary emits correct IR
+   - If the seed can't compile the fix, add a compensating fixup to `selfhost_native.py`
+
+**Key principle:** The Python driver fixups are technical debt from the seed. The goal is to improve the compiler source so each new seed needs fewer fixups, eventually reaching zero. `build.sh` must always stay clean.
 
 ## Strategy: Iterative Seed Promotion
 
@@ -115,7 +132,7 @@ The fixups in `selfhost_native.py` cluster into **5 root cause categories**. Fix
 - `_fix_truncated_symbol_names` — fixes dropped first character in symbol names
 - `_patch_opaque_named_types` — resolves opaque types from cross-module context
 
-**How to fix:** Improve the import-context mechanism so the seed has full type information for cross-module calls at emit time. The `.sfn-asm` / `.layout-manifest` artifacts should carry complete function signatures.
+**How to fix:** Improve the compiler's LLVM rendering pass (`compiler/src/llvm/rendering.sfn`) to emit concrete type definitions for imported structs (not just opaque stubs) and `declare` statements for cross-module function calls. The compiler already loads imported type info via layout manifests and native texts — it just needs to use that info during rendering instead of emitting `%Type = type opaque`. This is a compiler source fix, not a build script fix. `build.sh` must remain free of any post-processing.
 
 ### Category 3: Loop / Control Flow Bugs (~6 fixups)
 

--- a/compiler/src/cli_commands.sfn
+++ b/compiler/src/cli_commands.sfn
@@ -404,11 +404,11 @@ fn handle_test_command(args -> string[], runtime_root -> string) -> number ![io]
         let base_dir = _dirname_cmd(path);
         let mut combined_source = source;
         if skip_inlining {
-            if trace_runner { print("test runner: skipping import inlining"); }
+            if trace_runner { print.err("test runner: skipping import inlining"); }
         } else {
-            if trace_runner { print("test runner: inlining start"); }
+            if trace_runner { print.err("test runner: inlining start"); }
             combined_source = _inline_relative_imports_cmd(source, base_dir, 10, []);
-            if trace_runner { print("test runner: inlining done (bytes=" + number_to_string(combined_source.length) + ")"); }
+            if trace_runner { print.err("test runner: inlining done (bytes=" + number_to_string(combined_source.length) + ")"); }
         }
 
         if dump_sources {
@@ -416,7 +416,7 @@ fn handle_test_command(args -> string[], runtime_root -> string) -> number ![io]
             _write_text_cmd("build/sailfin/test-source-" + safe + ".sfn", combined_source);
         }
 
-        if trace_runner { print("test runner: compile start"); }
+        if trace_runner { print.err("test runner: compile start"); }
         let _compiled = compile_tests_to_llvm_file_with_module(combined_source, module_name, ll_path);
         if !_compiled {
             print("test runner: compile failed for " + path);
@@ -424,16 +424,16 @@ fn handle_test_command(args -> string[], runtime_root -> string) -> number ![io]
             return 1;
         }
 
-        if trace_runner { print("test runner: link start"); }
+        if trace_runner { print.err("test runner: link start"); }
         let link_rc = _clang_link_test_cmd(ll_path, exe_path, runtime_root);
         if link_rc != 0 {
             print("link failed (clang exit=" + number_to_string(link_rc) + ")");
             fs.deleteFile(test_runner_active_path);
             return link_rc;
         }
-        if trace_runner { print("test runner: exec start"); }
+        if trace_runner { print.err("test runner: exec start"); }
         let run_rc = process.run([exe_path]);
-        if trace_runner { print("test runner: exec done (exit=" + number_to_string(run_rc) + ")"); }
+        if trace_runner { print.err("test runner: exec done (exit=" + number_to_string(run_rc) + ")"); }
         if run_rc != 0 {
             print("test failed: " + path);
             fs.deleteFile(test_runner_active_path);

--- a/compiler/src/cli_main.sfn
+++ b/compiler/src/cli_main.sfn
@@ -296,13 +296,13 @@ fn _clang_link(ll_path -> string, out_path -> string, runtime_root -> string) ->
 fn sailfin_cli_main(argv -> string[]) -> number ![io] {
     let trace_argv = fs.exists("build/sailfin/.trace_argv");
     if trace_argv {
-        print("cli: argv.len=" + number_to_string(argv.length));
+        print.err("cli: argv.len=" + number_to_string(argv.length));
         let mut trace_index -> number = 0;
         loop {
             if trace_index >= argv.length {
                 break;
             }
-            print("cli: argv[" + number_to_string(trace_index) + "]=" + argv[trace_index]);
+            print.err("cli: argv[" + number_to_string(trace_index) + "]=" + argv[trace_index]);
             trace_index += 1;
         }
     }
@@ -320,8 +320,8 @@ fn sailfin_cli_main(argv -> string[]) -> number ![io] {
         }
     }
     if trace_argv {
-        print("cli: runtime_root=" + runtime_root);
-        print("cli: start_index=" + number_to_string(start_index));
+        print.err("cli: runtime_root=" + runtime_root);
+        print.err("cli: start_index=" + number_to_string(start_index));
     }
     if runtime_root.length == 0 {
         if _runtime_bundle_exists("runtime") {
@@ -343,13 +343,13 @@ fn sailfin_cli_main(argv -> string[]) -> number ![io] {
         return 2;
     }
     if trace_argv {
-        print("cli: args.len=" + number_to_string(args.length));
+        print.err("cli: args.len=" + number_to_string(args.length));
         let mut arg_index_trace -> number = 0;
         loop {
             if arg_index_trace >= args.length {
                 break;
             }
-            print("cli: args[" + number_to_string(arg_index_trace) + "]=" + args[arg_index_trace]);
+            print.err("cli: args[" + number_to_string(arg_index_trace) + "]=" + args[arg_index_trace]);
             arg_index_trace += 1;
         }
         if args.length > 0 {
@@ -357,14 +357,14 @@ fn sailfin_cli_main(argv -> string[]) -> number ![io] {
             let eq_emit = strings_equal(cmd_check, "emit");
             let eq_version = strings_equal(cmd_check, "version");
             if eq_emit {
-                print("cli: eq_emit=true");
+                print.err("cli: eq_emit=true");
             } else {
-                print("cli: eq_emit=false");
+                print.err("cli: eq_emit=false");
             }
             if eq_version {
-                print("cli: eq_version=true");
+                print.err("cli: eq_version=true");
             } else {
-                print("cli: eq_version=false");
+                print.err("cli: eq_version=false");
             }
         }
     }
@@ -399,10 +399,10 @@ fn sailfin_cli_main(argv -> string[]) -> number ![io] {
     let is_login = strings_equal(cmd, "login");
     if trace_argv {
         if is_emit {
-            print("cli: cmd_is_emit=true");
+            print.err("cli: cmd_is_emit=true");
         }
         if is_version {
-            print("cli: cmd_is_version=true");
+            print.err("cli: cmd_is_version=true");
         }
     }
 

--- a/compiler/src/emit_native.sfn
+++ b/compiler/src/emit_native.sfn
@@ -326,9 +326,7 @@ fn emit_extern_function(
     }
     current = state_emit_line(current, ".meta extern");
     current = emit_signature_metadata(current, signature);
-    current = state_push_indent(current);
     current = emit_parameter_metadata(current, signature.parameters);
-    current = state_pop_indent(current);
     return state_emit_line(current, ".endfn");
 }
 
@@ -403,8 +401,8 @@ fn emit_function(
     let mut current = emit_decorators(state, decorators);
     current = state_emit_line(current, ".fn " + format_function_signature(signature));
     current = emit_signature_metadata(current, signature);
-    current = state_push_indent(current);
     current = emit_parameter_metadata(current, signature.parameters);
+    current = state_push_indent(current);
     current = emit_block(current, body);
     current = state_pop_indent(current);
     return state_emit_line(current, ".endfn");
@@ -414,8 +412,8 @@ fn emit_pipeline(state -> NativeState, statement -> Statement) -> NativeState {
     let mut current = emit_decorators(state, statement.decorators);
     current = state_emit_line(current, ".pipeline " + format_function_signature(statement.signature));
     current = emit_signature_metadata(current, statement.signature);
-    current = state_push_indent(current);
     current = emit_parameter_metadata(current, statement.signature.parameters);
+    current = state_push_indent(current);
     current = emit_block(current, statement.body);
     current = state_pop_indent(current);
     return state_emit_line(current, ".endpipeline");
@@ -425,8 +423,8 @@ fn emit_tool(state -> NativeState, statement -> Statement) -> NativeState {
     let mut current = emit_decorators(state, statement.decorators);
     current = state_emit_line(current, ".tool " + format_function_signature(statement.signature));
     current = emit_signature_metadata(current, statement.signature);
-    current = state_push_indent(current);
     current = emit_parameter_metadata(current, statement.signature.parameters);
+    current = state_push_indent(current);
     current = emit_block(current, statement.body);
     current = state_pop_indent(current);
     return state_emit_line(current, ".endtool");
@@ -519,9 +517,9 @@ fn emit_enum(state -> NativeState, statement -> Statement) -> NativeState {
     let mut header -> string = ".enum " + statement.name;
     header = header + format_type_parameters(statement.type_parameters);
     current = state_emit_line(current, header);
-    current = state_push_indent(current);
     let enum_layout = compute_enum_layout_lines(state.layout_context, statement);
     current = emit_layout_lines(current, enum_layout.lines);
+    current = state_push_indent(current);
     current = state_merge_diagnostics(current, enum_layout.diagnostics);
     let mut index -> number = 0;
     loop {
@@ -546,9 +544,9 @@ fn emit_struct(state -> NativeState, statement -> Statement) -> NativeState {
         header = header + " implements " + join_type_annotations(statement.implements_types);
     }
     current = state_emit_line(current, header);
-    current = state_push_indent(current);
     let struct_layout = compute_struct_layout_lines(state.layout_context, statement.name, statement.fields);
     current = emit_layout_lines(current, struct_layout.lines);
+    current = state_push_indent(current);
     current = state_merge_diagnostics(current, struct_layout.diagnostics);
 
     let mut index -> number = 0;
@@ -583,8 +581,8 @@ fn emit_method(state -> NativeState, method -> MethodDeclaration) -> NativeState
     let mut current = emit_decorators(state, method.decorators);
     current = state_emit_line(current, ".method " + format_function_signature(method.signature));
     current = emit_signature_metadata(current, method.signature);
-    current = state_push_indent(current);
     current = emit_parameter_metadata(current, method.signature.parameters);
+    current = state_push_indent(current);
     current = emit_block(current, method.body);
     current = state_pop_indent(current);
     return state_emit_line(current, ".endmethod");

--- a/compiler/src/lexer.sfn
+++ b/compiler/src/lexer.sfn
@@ -33,7 +33,7 @@ fn lex(source -> string) -> Token[] {
     loop {
         guard += 1;
         if guard > max_guard {
-            print("lexer: guard limit exceeded");
+            print.err("lexer: guard limit exceeded");
             break;
         }
         if state.index >= state.source_len {

--- a/compiler/src/llvm/effects.sfn
+++ b/compiler/src/llvm/effects.sfn
@@ -834,7 +834,7 @@ fn propagate_function_effects(direct_effects -> FunctionEffectEntry[], call_grap
         }
         if iteration > max_iterations {
             if trace {
-                print("llvm effects: propagation cap reached (max=" + number_to_string(max_iterations) + ")");
+                print.err("llvm effects: propagation cap reached (max=" + number_to_string(max_iterations) + ")");
             }
             break;
         }

--- a/compiler/src/llvm/expression_lowering/native/core.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core.sfn
@@ -343,7 +343,7 @@ fn lower_expression(expression -> string, bindings -> ParameterBinding[], locals
     let empty_constants = empty_string_constant_set();
     let dbg_expr = fs.exists("build/sailfin/.trace_lowering");
     if dbg_expr {
-        print("emit-llvm: lower_expression ENTER expr=" + trimmed + " bindings_len=" + number_to_string(bindings.length) + " expected=" + expected_type);
+        print.err("emit-llvm: lower_expression ENTER expr=" + trimmed + " bindings_len=" + number_to_string(bindings.length) + " expected=" + expected_type);
     }
     if trimmed.length == 0 {
         diagnostics.push("llvm lowering: empty expression encountered");
@@ -531,11 +531,11 @@ fn lower_expression(expression -> string, bindings -> ParameterBinding[], locals
     if dbg_expr {
         let mut add_succ = "false";
         if additive.success { add_succ = "true"; }
-        print("emit-llvm: lower_expression additive_check expr=" + stripped + " success=" + add_succ + " index=" + number_to_string(additive.index) + " symbol=" + additive.symbol);
+        print.err("emit-llvm: lower_expression additive_check expr=" + stripped + " success=" + add_succ + " index=" + number_to_string(additive.index) + " symbol=" + additive.symbol);
     }
     if additive.success {
         if dbg_expr {
-            print("emit-llvm: lower_expression DISPATCH binary_op expr=" + stripped);
+            print.err("emit-llvm: lower_expression DISPATCH binary_op expr=" + stripped);
         }
         return lower_binary_operation(stripped, additive, bindings, locals, temp_index, lines, functions, context);
     }
@@ -709,7 +709,7 @@ fn lower_expression(expression -> string, bindings -> ParameterBinding[], locals
         if parameter != null {
             param_found = parameter.name + " -> " + parameter.llvm_name;
         }
-        print("emit-llvm: lower_expression param_lookup stripped=" + stripped + " result=" + param_found);
+        print.err("emit-llvm: lower_expression param_lookup stripped=" + stripped + " result=" + param_found);
     }
     if parameter != null {
         let operand = LLVMOperand { llvm_type: parameter.llvm_type, value: parameter.llvm_name };
@@ -729,7 +729,7 @@ fn lower_expression(expression -> string, bindings -> ParameterBinding[], locals
     }
 
     if dbg_expr {
-        print("emit-llvm: lower_expression FALLTHROUGH expr=" + stripped + " (unhandled)");
+        print.err("emit-llvm: lower_expression FALLTHROUGH expr=" + stripped + " (unhandled)");
     }
     diagnostics.push("llvm lowering: unable to lower expression `" + expression + "`");
     return ExpressionResult { lines: lines, temp_index: temp_index, operand: null, diagnostics: diagnostics, string_constants: empty_constants };

--- a/compiler/src/llvm/expression_lowering/native/core_call_emission.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_call_emission.sfn
@@ -93,7 +93,7 @@ fn coerce_and_emit_call(
 
     // Coerce operands to expected parameter types
     if _trace_ccl {
-        print("call_lowering: pre-coerce operands=" + number_to_string(operands.length) + " expected_params=" + number_to_string(expected_params.length) + " llvm_return=" + llvm_return);
+        print.err("call_lowering: pre-coerce operands=" + number_to_string(operands.length) + " expected_params=" + number_to_string(expected_params.length) + " llvm_return=" + llvm_return);
     }
     let mut coerced_operands -> LLVMOperand[] = [];
     let mut index -> number = 0;
@@ -103,7 +103,7 @@ fn coerce_and_emit_call(
         }
         let operand = operands[index];
         if _trace_ccl {
-            print("call_lowering: coerce-loop idx=" + number_to_string(index) + " operand_type=" + operand.llvm_type + " operand_value=" + operand.value);
+            print.err("call_lowering: coerce-loop idx=" + number_to_string(index) + " operand_type=" + operand.llvm_type + " operand_value=" + operand.value);
         }
         let mut target_type -> string = "";
         if expected_params.length > index {
@@ -135,11 +135,11 @@ fn coerce_and_emit_call(
     }
     let final_operands = coerced_operands;
     if _trace_ccl {
-        print("call_lowering: post-coerce operands=" + number_to_string(final_operands.length));
+        print.err("call_lowering: post-coerce operands=" + number_to_string(final_operands.length));
     }
 
     if _trace_ccl {
-        print("call_lowering: checkpoint-A is_concat=" + number_to_string(0) + " is_push=" + number_to_string(0));
+        print.err("call_lowering: checkpoint-A is_concat=" + number_to_string(0) + " is_push=" + number_to_string(0));
     }
 
     // Array concat inline lowering
@@ -215,13 +215,13 @@ fn coerce_and_emit_call(
     }
 
     if _trace_ccl {
-        print("call_lowering: checkpoint-B fn_entry_null=" + number_to_string(0));
+        print.err("call_lowering: checkpoint-B fn_entry_null=" + number_to_string(0));
     }
     let mut _if56 -> boolean = false;
     if function_entry != null { _if56 = true; }
     if helper_descriptor != null { _if56 = true; }
     if _trace_ccl {
-        print("call_lowering: checkpoint-C _if56=" + number_to_string(0));
+        print.err("call_lowering: checkpoint-C _if56=" + number_to_string(0));
     }
     if _if56 {
         if expected_params.length != final_operands.length {
@@ -230,7 +230,7 @@ fn coerce_and_emit_call(
     }
 
     if _trace_ccl {
-        print("call_lowering: checkpoint-D rendering args");
+        print.err("call_lowering: checkpoint-D rendering args");
     }
     let mut rendered_args -> string[] = [];
     index = 0;
@@ -239,13 +239,13 @@ fn coerce_and_emit_call(
             break;
         }
         if _trace_ccl {
-            print("call_lowering: render-arg idx=" + number_to_string(index));
+            print.err("call_lowering: render-arg idx=" + number_to_string(index));
         }
         rendered_args.push(format_typed_operand(final_operands[index]));
         index += 1;
     }
     if _trace_ccl {
-        print("call_lowering: checkpoint-E args rendered");
+        print.err("call_lowering: checkpoint-E args rendered");
     }
     let argument_text = join_with_separator(rendered_args, ", ");
 
@@ -354,7 +354,7 @@ fn coerce_and_emit_call(
 
     // Standard function call
     if _trace_ccl {
-        print("call_lowering: checkpoint-F call_symbol target=" + trimmed_target);
+        print.err("call_lowering: checkpoint-F call_symbol target=" + trimmed_target);
     }
     let mut call_symbol = sanitize_symbol(trimmed_target);
     if helper_descriptor != null {
@@ -369,13 +369,13 @@ fn coerce_and_emit_call(
         }
     }
     if _trace_ccl {
-        print("call_lowering: checkpoint-G llvm_return=" + llvm_return + " call_symbol=" + call_symbol);
+        print.err("call_lowering: checkpoint-G llvm_return=" + llvm_return + " call_symbol=" + call_symbol);
     }
     if llvm_return == "void" {
         let call_line = "  call void @" + call_symbol + "(" + argument_text + ")";
         result_lines.push(call_line);
         if _trace_ccl {
-            print("call_lowering: checkpoint-H void return");
+            print.err("call_lowering: checkpoint-H void return");
         }
         _write_emission_result_lines(result_lines, result_temp);
         fs.writeFile("build/sailfin/.call_result_type", "");
@@ -385,19 +385,19 @@ fn coerce_and_emit_call(
 
     let temp_name = format_temp_name(result_temp);
     if _trace_ccl {
-        print("call_lowering: checkpoint-I temp_name=" + temp_name);
+        print.err("call_lowering: checkpoint-I temp_name=" + temp_name);
     }
     let call_line = "  " + temp_name + " = call " + llvm_return + " @" + call_symbol + "(" + argument_text + ")";
     result_lines.push(call_line);
     let operand = LLVMOperand { llvm_type: llvm_return, value: temp_name };
     if _trace_ccl {
-        print("call_lowering: checkpoint-J writing result files");
+        print.err("call_lowering: checkpoint-J writing result files");
     }
     _write_emission_result_lines(result_lines, result_temp + 1);
     fs.writeFile("build/sailfin/.call_result_type", llvm_return);
     fs.writeFile("build/sailfin/.call_result_value", temp_name);
     if _trace_ccl {
-        print("call_lowering: checkpoint-K returning");
+        print.err("call_lowering: checkpoint-K returning");
     }
     return ExpressionResult { lines: result_lines, temp_index: result_temp + 1, operand: operand, diagnostics: result_diagnostics, string_constants: collected_string_constants };
 }

--- a/compiler/src/llvm/expression_lowering/native/core_call_lowering.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_call_lowering.sfn
@@ -62,6 +62,8 @@ import { resolve_call_method_target, resolve_call_signature } from "./core_call_
 
 import { coerce_and_emit_call } from "./core_call_emission";
 
+import { find_runtime_helper } from "../../runtime_helpers";
+
 // Mutually recursive with core.sfn
 import { lower_expression } from "./core";
 
@@ -164,6 +166,18 @@ fn lower_call_expression(target -> string, arguments -> string[], bindings -> Pa
     let mut expected_params = sig.expected_params;
     let is_trait_dispatch = sig.is_trait_dispatch;
     diagnostics = extend_string_array(diagnostics, sig.diagnostics);
+
+    // If helper_descriptor is still null, try looking up the target as a
+    // runtime helper.  This covers module-level let bindings like
+    // `let runtime_char_code_fn = runtime.char_code` where the call uses
+    // the binding name directly (no dot — so resolve_call_method_target
+    // doesn't detect it as a method call).
+    if helper_descriptor == null {
+        let fallback_helper = find_runtime_helper(trimmed_target);
+        if fallback_helper != null {
+            helper_descriptor = fallback_helper;
+        }
+    }
 
     // Re-derive helper_descriptor for concat after signature resolution
     if trimmed_target == "concat" {

--- a/compiler/src/llvm/expression_lowering/native/core_call_lowering.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_call_lowering.sfn
@@ -89,7 +89,7 @@ fn lower_call_expression(target -> string, arguments -> string[], bindings -> Pa
     let dot_index = index_of(trimmed_target, ".");
     let trace_calls = fs.exists("build/sailfin/.trace_call_lowering");
     if trace_calls {
-        print("call_lowering: target='" + trimmed_target + "' dot_index=" + number_to_string(dot_index) + " enums=" + number_to_string(context.enums.length));
+        print.err("call_lowering: target='" + trimmed_target + "' dot_index=" + number_to_string(dot_index) + " enums=" + number_to_string(context.enums.length));
     }
     if dot_index > 0 {
         let enum_name = trim_text(substring(trimmed_target, 0, dot_index));
@@ -101,7 +101,7 @@ fn lower_call_expression(target -> string, arguments -> string[], bindings -> Pa
             if enum_info != null {
                 found_text = "found";
             }
-            print("call_lowering: enum_name='" + enum_name + "' variant='" + variant_name + "' resolved=" + found_text);
+            print.err("call_lowering: enum_name='" + enum_name + "' variant='" + variant_name + "' resolved=" + found_text);
         }
         if enum_info != null {
             let mut fields -> StructLiteralField[] = [];

--- a/compiler/src/llvm/expression_lowering/native/core_operands.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_operands.sfn
@@ -813,7 +813,7 @@ fn coerce_general_fallback(operand -> LLVMOperand, operand_type -> string, targe
 fn coerce_operand_to_type(operand -> LLVMOperand, target_type -> string, temp_index -> number, lines -> string[]) -> CoercionResult {
     let debug_coerce = fs.exists("build/sailfin/.trace_lowering");
     if debug_coerce {
-        print("emit-llvm: coerce_operand entry operand_type=" + operand.llvm_type + " target=" + target_type);
+        print.err("emit-llvm: coerce_operand entry operand_type=" + operand.llvm_type + " target=" + target_type);
     }
     let mut diagnostics -> string[] = [];
     let mut current_lines -> string[] = lines;

--- a/compiler/src/llvm/expression_lowering/native/statement.sfn
+++ b/compiler/src/llvm/expression_lowering/native/statement.sfn
@@ -487,16 +487,12 @@ fn lower_expression_statement(
         // Clean up sentinel
         fs.deleteFile("build/sailfin/.call_result_lines_count");
     } else {
-        // Fallback: try struct fields
-        let mut _ci15 -> number = 0;
-        loop {
-            if _ci15 >= lowered.diagnostics.length { break; }
-            diagnostics.push(lowered.diagnostics[_ci15]);
-            _ci15 += 1;
-        }
-        string_constants = lowered.string_constants;
-        current_lines = lowered.lines;
-        current_temp = lowered.temp_index;
+        // Fallback: struct return fields are ABI-corrupted in the v0.1.1 seed.
+        // Do NOT replace current_lines with lowered.lines — lower_expression
+        // mutated the lines array in-place, so current_lines already has the
+        // new IR.  Using the corrupted struct field would cause
+        // _recover_temp_from_lines to scan wrong data and return a stale temp
+        // counter, leading to duplicate SSA names in the next statement.
         current_temp = _recover_temp_from_lines(current_lines, current_temp);
     }
     if consumption != null {

--- a/compiler/src/llvm/expression_lowering/native/statement.sfn
+++ b/compiler/src/llvm/expression_lowering/native/statement.sfn
@@ -291,7 +291,7 @@ fn lower_expression_statement(
     }
     let debug_lowering = fs.exists("build/sailfin/.trace_lowering");
     if debug_lowering {
-        print("emit-llvm: lower_expression_statement start fn=" + function_name + " expr=" + expression + " locals_read=" + number_to_string(current_locals.length) + " bindings_read=" + number_to_string(current_bindings.length));
+        print.err("emit-llvm: lower_expression_statement start fn=" + function_name + " expr=" + expression + " locals_read=" + number_to_string(current_locals.length) + " bindings_read=" + number_to_string(current_bindings.length));
     }
     let mut diagnostics -> string[] = detect_suspension_conflicts(expression, current_locals, current_bindings, function_name, null);
     let mut current_lines -> string[] = lines;
@@ -329,7 +329,7 @@ fn lower_expression_statement(
         let trimmed_assign_target = trim_text(parsed_assignment.target);
         let trimmed_assign_value = trim_text(parsed_assignment.value);
         if debug_lowering {
-            print("emit-llvm: lower_expr_stmt simple_assignment target='" + trimmed_assign_target + "' value='" + trimmed_assign_value + "' locals_len=" + number_to_string(current_locals.length));
+            print.err("emit-llvm: lower_expr_stmt simple_assignment target='" + trimmed_assign_target + "' value='" + trimmed_assign_value + "' locals_len=" + number_to_string(current_locals.length));
         }
         let binding = find_local_binding(current_locals, trimmed_assign_target);
         if binding == null {
@@ -466,9 +466,9 @@ fn lower_expression_statement(
     if debug_lowering {
         let _cr_exists_check = fs.exists("build/sailfin/.call_result_lines_count");
         if _cr_exists_check {
-            print("stmt-lowering: call_result_lines_count EXISTS");
+            print.err("stmt-lowering: call_result_lines_count EXISTS");
         } else {
-            print("stmt-lowering: call_result_lines_count NOT FOUND");
+            print.err("stmt-lowering: call_result_lines_count NOT FOUND");
         }
     }
     if fs.exists("build/sailfin/.call_result_lines_count") {
@@ -479,7 +479,7 @@ fn lower_expression_statement(
         }
         current_lines = _new_lines;
         if debug_lowering {
-            print("stmt-lowering: read " + number_to_string(_new_lines.length) + " lines from call_result files, current_lines.length=" + number_to_string(current_lines.length));
+            print.err("stmt-lowering: read " + number_to_string(_new_lines.length) + " lines from call_result files, current_lines.length=" + number_to_string(current_lines.length));
         }
         let _cr_temp_str = fs.readFile("build/sailfin/.call_result_temp");
         current_temp = _parse_int_local(_cr_temp_str);
@@ -503,7 +503,7 @@ fn lower_expression_statement(
         }
     }
     if debug_lowering {
-        print("stmt-lowering: pre-write _pre_call_lines_len=" + number_to_string(_pre_call_lines_len) + " current_lines.length=" + number_to_string(current_lines.length) + " delta=" + number_to_string(current_lines.length - _pre_call_lines_len));
+        print.err("stmt-lowering: pre-write _pre_call_lines_len=" + number_to_string(_pre_call_lines_len) + " current_lines.length=" + number_to_string(current_lines.length) + " delta=" + number_to_string(current_lines.length - _pre_call_lines_len));
     }
     _write_expr_stmt_result_files_with_constants(_pre_call_lines_len, current_lines, current_temp, mutations, current_next_region, string_constants);
     return ExpressionStatementResult { lines: current_lines, temp_index: current_temp, locals: current_locals, bindings: current_bindings, diagnostics: diagnostics, lifetime_regions: lifetime_regions, lifetime_releases: lifetime_releases, next_region_id: current_next_region, mutations: mutations , string_constants: string_constants};
@@ -549,14 +549,14 @@ fn lower_return_instruction(
     let safe_llvm_return = fs.readFile("build/sailfin/.instr_llvm_return");
 
     if debug_lowering {
-        print("emit-llvm: lower_return_instruction start fn=" + fn_name + " llvm_return=" + safe_llvm_return);
+        print.err("emit-llvm: lower_return_instruction start fn=" + fn_name + " llvm_return=" + safe_llvm_return);
     }
     if trace {
         let mut expr_len -> number = 0;
         if instr_expression != null {
             expr_len = instr_expression.length;
         }
-        print(
+        print.err(
             "test llvm: lower_return start "
             + fn_name
             + " expr_len="
@@ -577,7 +577,7 @@ fn lower_return_instruction(
             current_lines.push("  ret " + safe_llvm_return + " " + default_return_literal(safe_llvm_return));
         }
         if trace {
-            print("test llvm: lower_return empty_expr lines_after=" + number_to_string(current_lines.length));
+            print.err("test llvm: lower_return empty_expr lines_after=" + number_to_string(current_lines.length));
         }
         let empty_constants = empty_string_constant_set();
         _write_expr_stmt_result_files_with_constants(lines.length, current_lines, current_temp, [], current_next_region, empty_constants);
@@ -620,11 +620,11 @@ fn lower_return_instruction(
     }
 
     if debug_lowering {
-        print("emit-llvm: lower_return pre_suspension fn=" + fn_name);
+        print.err("emit-llvm: lower_return pre_suspension fn=" + fn_name);
     }
     let suspension_diagnostics = detect_suspension_conflicts(instr_expression, current_locals, current_bindings, fn_name, null);
     if debug_lowering {
-        print("emit-llvm: lower_return post_suspension fn=" + fn_name);
+        print.err("emit-llvm: lower_return post_suspension fn=" + fn_name);
     }
     let mut _ci16 -> number = 0;
     loop {
@@ -634,11 +634,11 @@ fn lower_return_instruction(
     }
 
     if debug_lowering {
-        print("emit-llvm: lower_return pre_ownership fn=" + fn_name);
+        print.err("emit-llvm: lower_return pre_ownership fn=" + fn_name);
     }
     let ownership_analysis = analyze_value_ownership(instr_expression, null, current_locals, current_bindings);
     if debug_lowering {
-        print("emit-llvm: lower_return post_ownership fn=" + fn_name);
+        print.err("emit-llvm: lower_return post_ownership fn=" + fn_name);
     }
     let mut _ci17 -> number = 0;
     loop {
@@ -649,14 +649,14 @@ fn lower_return_instruction(
     let consumption = ownership_analysis.consumption;
 
     if debug_lowering {
-        print("emit-llvm: lower_return pre_lower_expr fn=" + fn_name + " expr=" + instr_expression);
-        print("emit-llvm: lower_return bindings_len=" + number_to_string(current_bindings.length));
+        print.err("emit-llvm: lower_return pre_lower_expr fn=" + fn_name + " expr=" + instr_expression);
+        print.err("emit-llvm: lower_return bindings_len=" + number_to_string(current_bindings.length));
         let mut bind_i -> number = 0;
         loop {
             if bind_i >= current_bindings.length {
                 break;
             }
-            print("emit-llvm: lower_return binding[" + number_to_string(bind_i) + "] name=" + current_bindings[bind_i].name + " llvm_name=" + current_bindings[bind_i].llvm_name + " llvm_type=" + current_bindings[bind_i].llvm_type);
+            print.err("emit-llvm: lower_return binding[" + number_to_string(bind_i) + "] name=" + current_bindings[bind_i].name + " llvm_name=" + current_bindings[bind_i].llvm_name + " llvm_type=" + current_bindings[bind_i].llvm_type);
             bind_i += 1;
         }
     }
@@ -682,7 +682,7 @@ fn lower_return_instruction(
     }
     let lowered = lower_expression(_ret_expr, current_bindings, current_locals, current_temp, current_lines, functions, context, safe_llvm_return);
     if debug_lowering {
-        print("emit-llvm: lower_return post_lower_expr fn=" + fn_name);
+        print.err("emit-llvm: lower_return post_lower_expr fn=" + fn_name);
     }
     let mut _ci18 -> number = 0;
     loop {
@@ -700,13 +700,13 @@ fn lower_return_instruction(
         if lowered.operand != null {
             has_operand = "true";
         }
-        print("emit-llvm: lower_return operand_check fn=" + fn_name + " has_operand=" + has_operand);
+        print.err("emit-llvm: lower_return operand_check fn=" + fn_name + " has_operand=" + has_operand);
     }
     if lowered.operand == null {
         diagnostics.push("llvm lowering: unhandled return expression in `" + fn_name + "`");
         current_lines.push("  ret " + safe_llvm_return + " " + default_return_literal(safe_llvm_return));
         if trace {
-            print("test llvm: lower_return no_operand lines_after=" + number_to_string(current_lines.length));
+            print.err("test llvm: lower_return no_operand lines_after=" + number_to_string(current_lines.length));
         }
         _write_expr_stmt_result_files_with_constants(lines.length, current_lines, current_temp, [], current_next_region, string_constants);
         return ExpressionStatementResult { lines: current_lines, temp_index: current_temp, locals: current_locals, bindings: current_bindings, diagnostics: diagnostics, lifetime_regions: lifetime_regions, lifetime_releases: lifetime_releases, next_region_id: current_next_region, mutations: [] , string_constants: string_constants};
@@ -714,7 +714,7 @@ fn lower_return_instruction(
 
     let operand = lowered.operand;
     if debug_lowering {
-        print("emit-llvm: lower_return pre_coerce fn=" + fn_name + " type=" + operand.llvm_type + " value=" + operand.value);
+        print.err("emit-llvm: lower_return pre_coerce fn=" + fn_name + " type=" + operand.llvm_type + " value=" + operand.value);
     }
     if safe_llvm_return == "void" {
         diagnostics.push("llvm lowering: void function `" + fn_name + "` returned a value");
@@ -724,11 +724,11 @@ fn lower_return_instruction(
     }
 
     if debug_lowering {
-        print("emit-llvm: lower_return pre_coerce_call fn=" + fn_name);
+        print.err("emit-llvm: lower_return pre_coerce_call fn=" + fn_name);
     }
     let coerced = coerce_operand_to_type(operand, safe_llvm_return, current_temp, current_lines);
     if debug_lowering {
-        print("emit-llvm: lower_return post_coerce fn=" + fn_name);
+        print.err("emit-llvm: lower_return post_coerce fn=" + fn_name);
     }
     let mut _ci19 -> number = 0;
     loop {
@@ -747,7 +747,7 @@ fn lower_return_instruction(
             current_lines.push("  ret " + safe_llvm_return + " " + default_return_literal(safe_llvm_return));
         }
         if trace {
-            print("test llvm: lower_return no_coerce lines_after=" + number_to_string(current_lines.length));
+            print.err("test llvm: lower_return no_coerce lines_after=" + number_to_string(current_lines.length));
         }
         _write_expr_stmt_result_files_with_constants(lines.length, current_lines, current_temp, [], current_next_region, string_constants);
         return ExpressionStatementResult { lines: current_lines, temp_index: current_temp, locals: current_locals, bindings: current_bindings, diagnostics: diagnostics, lifetime_regions: lifetime_regions, lifetime_releases: lifetime_releases, next_region_id: current_next_region, mutations: [] , string_constants: string_constants};
@@ -760,7 +760,7 @@ fn lower_return_instruction(
     }
     current_lines.push("  ret " + coerced_operand.llvm_type + " " + coerced_operand.value);
     if trace {
-        print("test llvm: lower_return ok lines_after=" + number_to_string(current_lines.length));
+        print.err("test llvm: lower_return ok lines_after=" + number_to_string(current_lines.length));
     }
     if consumption != null {
         if consumption.kind == "local" {

--- a/compiler/src/llvm/imports.sfn
+++ b/compiler/src/llvm/imports.sfn
@@ -31,7 +31,7 @@ fn collect_imported_module_context_for_module(imports -> NativeImport[], current
     }
     let trace = _let189;
     if trace {
-        print("test llvm: collect_imported_module_context start (imports=" + number_to_string(imports.length) + ")");
+        print.err("test llvm: collect_imported_module_context start (imports=" + number_to_string(imports.length) + ")");
     }
     let mut manifests -> LayoutManifest[] = [];
     let mut native_texts -> string[] = [];
@@ -67,7 +67,7 @@ fn collect_imported_module_context_for_module(imports -> NativeImport[], current
         if trace {
             if queue_index > 0 {
                 if queue_index % 50 == 0 {
-                    print("test llvm: collect_imported_module_context progress (index=" + number_to_string(queue_index) + " queued=" + number_to_string(queue_paths.length) + ")");
+                    print.err("test llvm: collect_imported_module_context progress (index=" + number_to_string(queue_index) + " queued=" + number_to_string(queue_paths.length) + ")");
                 }
             }
         }
@@ -148,7 +148,7 @@ fn collect_imported_module_context_for_module(imports -> NativeImport[], current
     }
 
     if trace {
-        print("test llvm: collect_imported_module_context done (unique_imports=" + number_to_string(seen.length) + ")");
+        print.err("test llvm: collect_imported_module_context done (unique_imports=" + number_to_string(seen.length) + ")");
     }
 
     return ImportedModuleContext { manifests: manifests, native_texts: native_texts, diagnostics: diagnostics };

--- a/compiler/src/llvm/lowering/emission.sfn
+++ b/compiler/src/llvm/lowering/emission.sfn
@@ -392,7 +392,7 @@ fn emit_llvm_function(
     let mut emit_main_wrapper -> boolean = false;
     let mut llvm_return = map_return_type(context, fn_return_type);
     if debug_lowering {
-        print("emit-llvm: emit_fn phase=ret_type name=" + fn_name + " llvm_return=" + llvm_return);
+        print.err("emit-llvm: emit_fn phase=ret_type name=" + fn_name + " llvm_return=" + llvm_return);
     }
     // Override return type for specific parse_native functions that return
     // opaque types the LLVM backend cannot resolve. Use == instead of
@@ -402,7 +402,7 @@ fn emit_llvm_function(
     if sanitized == "parse_native_functions_from_text" { _if197 = true; }
     if _if197 {
         if debug_lowering {
-            print("emit-llvm: ret_type override parse_native fn=" + fn_name);
+            print.err("emit-llvm: ret_type override parse_native fn=" + fn_name);
         }
         llvm_return = "i8*";
     }
@@ -412,7 +412,7 @@ fn emit_llvm_function(
         if safe_check {
             safe_text = "true";
         }
-        print("emit-llvm: ret_type safe_check=" + safe_text + " llvm_return=" + llvm_return + " fn=" + fn_name);
+        print.err("emit-llvm: ret_type safe_check=" + safe_text + " llvm_return=" + llvm_return + " fn=" + fn_name);
     }
     if !safe_check {
         diagnostics.push("llvm lowering: suspicious return type `" + llvm_return + "` in " + fn_name + "; defaulting to i8*");
@@ -438,7 +438,7 @@ fn emit_llvm_function(
     let preparation = prepare_parameters_from_files(fn_name, fn_param_count, context);
     diagnostics = extend_string_array(diagnostics, preparation.diagnostics);
     if debug_lowering {
-        print("emit-llvm: emit_fn phase=prepare_params name=" + fn_name + " params=" + number_to_string(preparation.bindings.length));
+        print.err("emit-llvm: emit_fn phase=prepare_params name=" + fn_name + " params=" + number_to_string(preparation.bindings.length));
     }
 
     if fn_is_extern {
@@ -460,7 +460,7 @@ fn emit_llvm_function(
     }
     let trace = _let198;
     if trace {
-        print(
+        print.err(
             "test llvm: emit_llvm_function preview "
             + fn_name
             + " instrs="
@@ -488,10 +488,10 @@ fn emit_llvm_function(
         if internalize {
             internalize_text = "true";
         }
-        print("emit-llvm: emit_fn phase=internalize_check name=" + fn_name + " internal=" + internalize_text);
+        print.err("emit-llvm: emit_fn phase=internalize_check name=" + fn_name + " internal=" + internalize_text);
     }
     if debug_lowering {
-        print("emit-llvm: emit_fn phase=define_header name=" + fn_name);
+        print.err("emit-llvm: emit_fn phase=define_header name=" + fn_name);
     }
     lines.push("define " + linkage + llvm_return + " @" + sanitized + "(" + signature + ") {");
     lines.push(entry_label + ":");
@@ -504,7 +504,7 @@ fn emit_llvm_function(
     // For now, `@logExecution` / `@trace` calls into the runtime hook with the function name.
     let mut decorator_string_constants -> StringConstant[] = empty_string_constant_set();
     if debug_lowering {
-        print("emit-llvm: emit_fn phase=decorators name=" + fn_name + " count=" + number_to_string(fn_decorator_count));
+        print.err("emit-llvm: emit_fn phase=decorators name=" + fn_name + " count=" + number_to_string(fn_decorator_count));
     }
     let mut decorator_index -> number = 0;
     loop {
@@ -530,7 +530,7 @@ fn emit_llvm_function(
     }
 
     if debug_lowering {
-        print("emit-llvm: emit_fn phase=pre_body name=" + fn_name + " instrs=" + number_to_string(fn_instr_count));
+        print.err("emit-llvm: emit_fn phase=pre_body name=" + fn_name + " instrs=" + number_to_string(fn_instr_count));
     }
 
     // Inline body lowering: the v0.1.1 seed compiles emit_body as unreachable
@@ -558,7 +558,7 @@ fn emit_llvm_function(
         }
     }
     if debug_lowering {
-        print("emit-llvm: emit_fn phase=body_lir fn_index=" + number_to_string(_eb_fn_index) + " fn_name=" + fn_name + " fn_count=" + number_to_string(functions.length));
+        print.err("emit-llvm: emit_fn phase=body_lir fn_index=" + number_to_string(_eb_fn_index) + " fn_name=" + fn_name + " fn_count=" + number_to_string(functions.length));
     }
     // Bounds check: protect against stale .fn_index values or run-away loop
     if _eb_fn_index >= functions.length {
@@ -603,7 +603,7 @@ fn emit_llvm_function(
     let _eb_body_diagnostics = _split_by_newline(_eb_diags_raw);
 
     if debug_lowering {
-        print("emit-llvm: emit_fn phase=body_done name=" + fn_name + " body_lines=" + number_to_string(_eb_body_lines.length) + " allocas=" + number_to_string(_eb_allocas.length));
+        print.err("emit-llvm: emit_fn phase=body_done name=" + fn_name + " body_lines=" + number_to_string(_eb_body_lines.length) + " allocas=" + number_to_string(_eb_allocas.length));
     }
 
     let mut _eb_body -> string[] = [];
@@ -717,7 +717,7 @@ fn emit_body(
 ) -> BodyResult ![io] {
     let debug_body = fs.exists("build/sailfin/.trace_lowering");
     if debug_body {
-        print("emit-llvm: emit_body start fn=" + fn_name + " llvm_return=" + llvm_return + " bindings_len=" + number_to_string(bindings.length));
+        print.err("emit-llvm: emit_body start fn=" + fn_name + " llvm_return=" + llvm_return + " bindings_len=" + number_to_string(bindings.length));
     }
     let mut _let202 -> boolean = false;
     if fs.exists("build/sailfin/.trace_test_runner") {
@@ -727,7 +727,7 @@ fn emit_body(
     }
     let trace = _let202;
     if trace {
-        print(
+        print.err(
             "test llvm: emit_body start "
             + fn_name
             + " instrs="
@@ -777,7 +777,7 @@ fn emit_body(
         if _blk_terminated {
             term_label = "true";
         }
-        print(
+        print.err(
             "test llvm: emit_body lowered "
             + fn_name
             + " lines="

--- a/compiler/src/llvm/lowering/entrypoints.sfn
+++ b/compiler/src/llvm/lowering/entrypoints.sfn
@@ -270,7 +270,7 @@ fn lower_to_llvm_ir_from_text(native_text -> string, module_name -> string) -> s
     if lowered_lines.lines == null { _if219 = true; }
     if lowered_lines.lines.length == 0 { _if219 = true; }
     if _if219 {
-        print(
+        print.err(
             "emit-llvm: no lines from native text (functions="
             + number_to_string(parse.functions.length)
             + " structs="
@@ -306,7 +306,7 @@ fn write_llvm_ir(native_module -> NativeModule, out_path -> string) -> boolean !
     );
     let lines = lowered_lines.lines;
     if lines.length == 0 {
-        print(
+        print.err(
             "emit-llvm: no lines from module (module="
             + native_module.module_name
             + " functions="
@@ -318,7 +318,7 @@ fn write_llvm_ir(native_module -> NativeModule, out_path -> string) -> boolean !
             + ")"
         );
         if lowered_lines.diagnostics.length > 0 {
-            print("emit-llvm: diagnostic " + lowered_lines.diagnostics[0]);
+            print.err("emit-llvm: diagnostic " + lowered_lines.diagnostics[0]);
         }
         return false;
     }

--- a/compiler/src/llvm/lowering/entrypoints_tests.sfn
+++ b/compiler/src/llvm/lowering/entrypoints_tests.sfn
@@ -15,7 +15,8 @@ import { TypeContext, TraitMetadata, LoweredLLVMResult, LoweredLLVMLinesResult, 
 import { append_string, join_with_separator, number_to_string, sanitize_symbol, string_array_contains, index_of } from "../utils";
 import { empty_string_constant_set, merge_string_constants, render_string_constants } from "../strings";
 import { collect_direct_function_effects, collect_function_call_graph, propagate_function_effects, collect_runtime_helper_targets, append_unique_effect, find_function_effect_entry, append_function_effect_entry } from "../effects";
-import { render_test_harness_main_for_module, render_struct_type_definitions, render_enum_type_definitions, render_trait_metadata_comments, render_runtime_helper_declarations, render_imported_function_declarations } from "../rendering";
+import { render_struct_type_definitions, render_enum_type_definitions, render_trait_metadata_comments, render_runtime_helper_declarations, render_imported_function_declarations } from "../rendering";
+import { render_test_harness_main_for_module } from "./lowering_helpers";
 import { collect_exported_symbol_names, render_interface_type_definitions, render_vtable_type_definitions, render_vtable_constants, find_function_by_name } from "../rendering_helpers";
 import { fixup_enum_layouts, build_type_context } from "../type_context";
 import { collect_imported_module_context_for_module, apply_layout_manifest_to_module } from "../imports";

--- a/compiler/src/llvm/lowering/entrypoints_tests_writer.sfn
+++ b/compiler/src/llvm/lowering/entrypoints_tests_writer.sfn
@@ -33,7 +33,7 @@ import { extend_string_lines, extend_string_lines_checked, ensure_intrinsic_decl
 fn write_llvm_ir_for_tests(native_module -> NativeModule, out_path -> string) -> boolean ![io] {
     let artifact = select_text_artifact(native_module.artifacts);
     if artifact == null {
-        print("test llvm writer: no text artifact found");
+        print.err("test llvm writer: no text artifact found");
         return false;
     }
     return write_llvm_ir_for_tests_from_text(artifact.contents, native_module.module_name, out_path);
@@ -42,7 +42,7 @@ fn write_llvm_ir_for_tests(native_module -> NativeModule, out_path -> string) ->
 // Build and write LLVM IR for tests from raw native text, avoiding NativeModule ABI issues.
 fn write_llvm_ir_for_tests_from_text(native_text -> string, module_name -> string, out_path -> string) -> boolean ![io] {
     if native_text.length == 0 {
-        print("test llvm: empty native text");
+        print.err("test llvm: empty native text");
         return false;
     }
     // Write the native text to emit-native.tmp so that the recovery path
@@ -64,12 +64,12 @@ fn write_llvm_ir_for_tests_from_text(native_text -> string, module_name -> strin
         []
     );
     if lowered_lines.lines.length == 0 {
-        print("test llvm: no lines emitted from native text");
+        print.err("test llvm: no lines emitted from native text");
         return false;
     }
     let ir = _join_llvm_lines_linear(lowered_lines.lines);
     if ir.length == 0 {
-        print("test llvm: empty IR after join from native text");
+        print.err("test llvm: empty IR after join from native text");
         return false;
     }
     fs.writeFile(out_path, ir + "\n");

--- a/compiler/src/llvm/lowering/entrypoints_tests_writer.sfn
+++ b/compiler/src/llvm/lowering/entrypoints_tests_writer.sfn
@@ -14,7 +14,8 @@ import { TypeContext, TraitMetadata, LoweredLLVMLinesResult, FunctionEffectEntry
 import { append_string, join_with_separator, number_to_string, sanitize_symbol, string_array_contains, index_of } from "../utils";
 import { empty_string_constant_set, merge_string_constants, render_string_constants } from "../strings";
 import { collect_direct_function_effects, collect_function_call_graph, propagate_function_effects, collect_runtime_helper_targets, append_unique_effect, find_function_effect_entry, append_function_effect_entry } from "../effects";
-import { render_test_harness_main_for_module, render_struct_type_definitions, render_enum_type_definitions, render_trait_metadata_comments, render_runtime_helper_declarations, render_imported_function_declarations } from "../rendering";
+import { render_struct_type_definitions, render_enum_type_definitions, render_trait_metadata_comments, render_runtime_helper_declarations, render_imported_function_declarations } from "../rendering";
+import { render_test_harness_main_for_module } from "./lowering_helpers";
 import { collect_exported_symbol_names, render_interface_type_definitions, render_vtable_type_definitions, render_vtable_constants, find_function_by_name } from "../rendering_helpers";
 import { fixup_enum_layouts, build_type_context } from "../type_context";
 import { collect_imported_module_context_for_module, apply_layout_manifest_to_module } from "../imports";

--- a/compiler/src/llvm/lowering/instructions.sfn
+++ b/compiler/src/llvm/lowering/instructions.sfn
@@ -146,8 +146,8 @@ fn lower_instruction_range(
     let max_guard = (end - start_index) * 16 + 1024;
     let debug_lowering = fs.exists("build/sailfin/.trace_lowering");
     if debug_lowering {
-        print("emit-llvm: lower_instruction_range name=" + function.name + " start=" + number_to_string(start_index) + " end=" + number_to_string(end) + " depth=" + number_to_string(scope_depth));
-        print("emit-llvm: lower_instruction_range bindings_len=" + number_to_string(bindings.length) + " current_bindings_len=" + number_to_string(current_bindings.length));
+        print.err("emit-llvm: lower_instruction_range name=" + function.name + " start=" + number_to_string(start_index) + " end=" + number_to_string(end) + " depth=" + number_to_string(scope_depth));
+        print.err("emit-llvm: lower_instruction_range bindings_len=" + number_to_string(bindings.length) + " current_bindings_len=" + number_to_string(current_bindings.length));
     }
     let mut _let220 -> boolean = false;
     if fs.exists("build/sailfin/.trace_test_runner") {
@@ -159,7 +159,7 @@ fn lower_instruction_range(
     if trace {
         if start_index == 0 {
             if scope_depth == 0 {
-                print(
+                print.err(
                     "test llvm: lower_instruction_range start "
                     + function.name
                     + " end="
@@ -175,7 +175,7 @@ fn lower_instruction_range(
                         break;
                     }
                     let _preview_tag = get_instruction_tag(function.instructions, preview_index);
-                    print(
+                    print.err(
                         "test llvm: instr "
                         + number_to_string(preview_index)
                         + " tag="
@@ -190,7 +190,7 @@ fn lower_instruction_range(
     loop {
         if index >= end {
             if debug_lowering {
-                print("emit-llvm: loop-exit index=" + number_to_string(index) + " end=" + number_to_string(end) + " fn=" + function.name);
+                print.err("emit-llvm: loop-exit index=" + number_to_string(index) + " end=" + number_to_string(end) + " fn=" + function.name);
             }
             // Write block results and return directly from inside the loop.
             // The v0.1.1 seed generates unconditional `br label %loop.body` for
@@ -220,7 +220,7 @@ fn lower_instruction_range(
                 "llvm lowering: instruction loop exceeded limit in `" + function.name + "` (index=" + number_to_string(index) + ")"
             );
             if trace {
-                print(
+                print.err(
                     "test llvm: instruction loop exceeded limit in " + function.name
                     + " index=" + number_to_string(index)
                     + " end=" + number_to_string(end)
@@ -251,11 +251,11 @@ fn lower_instruction_range(
         // Use numeric tag accessor instead of .variant (which returns empty via get_field stub)
         let _instr_tag = get_instruction_tag(function.instructions, index);
         if debug_lowering {
-            print("emit-llvm: lir guard=" + number_to_string(guard) + " index=" + number_to_string(index) + " tag=" + number_to_string(_instr_tag) + " fn=" + function.name + " depth=" + number_to_string(scope_depth));
+            print.err("emit-llvm: lir guard=" + number_to_string(guard) + " index=" + number_to_string(index) + " tag=" + number_to_string(_instr_tag) + " fn=" + function.name + " depth=" + number_to_string(scope_depth));
         }
         if trace {
             if index == start_index {
-                print("test llvm: lower_instruction_range first_tag " + number_to_string(_instr_tag));
+                print.err("test llvm: lower_instruction_range first_tag " + number_to_string(_instr_tag));
             }
         }
         // Tag dispatch: flat if-blocks with continue/break to avoid deep else-if
@@ -640,7 +640,7 @@ fn lower_instruction_range(
     }
 
     if debug_lowering {
-        print("emit-llvm: lir loop-done fn=" + function.name + " current_lines=" + number_to_string(current_lines.length));
+        print.err("emit-llvm: lir loop-done fn=" + function.name + " current_lines=" + number_to_string(current_lines.length));
     }
     if trace {
         if start_index == 0 {
@@ -649,7 +649,7 @@ fn lower_instruction_range(
                 if terminated {
                     term_label = "true";
                 }
-                print(
+                print.err(
                     "test llvm: lower_instruction_range done "
                     + function.name
                     + " lines="
@@ -666,9 +666,9 @@ fn lower_instruction_range(
     // Always write block result files. The scope_depth == 0 check was unreliable
     // because the v0.1.1 seed can miscompile the comparison.
     if debug_lowering {
-        print("emit-llvm: pre-write-block current_lines.length=" + number_to_string(current_lines.length) + " scope_depth=" + number_to_string(scope_depth));
+        print.err("emit-llvm: pre-write-block current_lines.length=" + number_to_string(current_lines.length) + " scope_depth=" + number_to_string(scope_depth));
         if current_lines.length > 0 {
-            print("emit-llvm: pre-write-block line[0]=" + current_lines[0]);
+            print.err("emit-llvm: pre-write-block line[0]=" + current_lines[0]);
         }
     }
     _write_block_result_files(current_lines, current_allocas, terminated, diagnostics, collected_string_constants, current_temp, current_block_counter, current_next_local, current_next_region, index);

--- a/compiler/src/llvm/lowering/instructions.sfn
+++ b/compiler/src/llvm/lowering/instructions.sfn
@@ -339,12 +339,17 @@ fn lower_instruction_range(
                     fs.writeFile("build/sailfin/.instr_has_span", "0");
                     write_bindings_to_files(current_bindings);
                     write_locals_to_files(current_locals);
+                    let previous_temp = current_temp;
                     let lowered = lower_expression_statement(function.name, instruction, trimmed_expression, current_bindings, current_locals, current_temp, current_lines, current_next_region, scope_id, scope_depth, functions, context, active_label);
                     current_temp = _read_ipc_int_min("build/sailfin/.expr_stmt_temp_index", current_temp);
-                    // Extra recovery: scan accumulated lines for the highest %tN
-                    // to guard against stale IPC temp counters from cross-module
-                    // expression lowering (v0.1.1 seed ABI corruption).
-                    current_temp = recover_temp_from_lines(current_lines, current_temp);
+                    // Extra recovery: only scan accumulated lines for the highest
+                    // %tN when the IPC temp counter failed to advance, to guard
+                    // against stale cross-module expression-lowering state from the
+                    // v0.1.1 seed ABI corruption without paying the scan cost on
+                    // every expression statement.
+                    if current_temp <= previous_temp {
+                        current_temp = recover_temp_from_lines(current_lines, current_temp);
+                    }
                     current_next_region = _read_ipc_int_min("build/sailfin/.expr_stmt_next_region_id", current_next_region);
                     current_mutations = read_expr_mutations(current_mutations);
                     collected_string_constants = read_expr_string_constants(collected_string_constants);

--- a/compiler/src/llvm/lowering/instructions.sfn
+++ b/compiler/src/llvm/lowering/instructions.sfn
@@ -44,6 +44,7 @@ import {
     read_expr_string_constants,
     read_let_result_from_files,
     read_expr_mutations,
+    recover_temp_from_lines,
 } from "./instructions_helpers";
 
 import {
@@ -340,6 +341,10 @@ fn lower_instruction_range(
                     write_locals_to_files(current_locals);
                     let lowered = lower_expression_statement(function.name, instruction, trimmed_expression, current_bindings, current_locals, current_temp, current_lines, current_next_region, scope_id, scope_depth, functions, context, active_label);
                     current_temp = _read_ipc_int_min("build/sailfin/.expr_stmt_temp_index", current_temp);
+                    // Extra recovery: scan accumulated lines for the highest %tN
+                    // to guard against stale IPC temp counters from cross-module
+                    // expression lowering (v0.1.1 seed ABI corruption).
+                    current_temp = recover_temp_from_lines(current_lines, current_temp);
                     current_next_region = _read_ipc_int_min("build/sailfin/.expr_stmt_next_region_id", current_next_region);
                     current_mutations = read_expr_mutations(current_mutations);
                     collected_string_constants = read_expr_string_constants(collected_string_constants);

--- a/compiler/src/llvm/lowering/instructions_for.sfn
+++ b/compiler/src/llvm/lowering/instructions_for.sfn
@@ -100,6 +100,11 @@ import {
     append_loop_context,
 } from "./instructions_loops";
 
+import {
+    get_instruction_for_target,
+    get_instruction_for_iterable,
+} from "./lowering_native_helpers";
+
 // Lower a range-based for loop (e.g., `for i in 0..10`).
 // Returns null if the iterable is not a recognized range pattern.
 fn lower_for_array(
@@ -351,7 +356,10 @@ fn lower_for_instruction(
 
     let instruction = function.instructions[start_index];
 
-    let mut raw_target = trim_text(instruction.target);
+    let for_target_text = get_instruction_for_target(function.instructions, start_index);
+    let for_iterable_text = get_instruction_for_iterable(function.instructions, start_index);
+
+    let mut raw_target = trim_text(for_target_text);
     raw_target = strip_mut_prefix(raw_target);
     if raw_target.length == 0 {
         diagnostics.push("llvm lowering: `.for` loop missing iteration binding in `" + function.name + "`");
@@ -415,7 +423,7 @@ fn lower_for_instruction(
 
     // Try range-based for loop first.
     let range_result = lower_for_range(
-        function, structure, raw_target, instruction,
+        function, structure, raw_target, for_iterable_text,
         llvm_return, bindings, locals, allocas, lines,
         temp_index, block_counter, next_local_id, next_region_id,
         functions, loop_stack, context, scope_id, scope_depth, next_index
@@ -425,9 +433,9 @@ fn lower_for_instruction(
     }
 
     // Fall through to array-based for loop.
-    let range_parse = parse_range_iterable(instruction.iterable);
+    let range_parse = parse_range_iterable(for_iterable_text);
 
-    let iterable_result = lower_expression(instruction.iterable, current_bindings, current_locals, current_temp, current_lines, functions, context, "");
+    let iterable_result = lower_expression(for_iterable_text, current_bindings, current_locals, current_temp, current_lines, functions, context, "");
     let mut _ci21 -> number = 0;
     loop {
         if _ci21 >= iterable_result.diagnostics.length { break; }

--- a/compiler/src/llvm/lowering/instructions_for_range.sfn
+++ b/compiler/src/llvm/lowering/instructions_for_range.sfn
@@ -32,7 +32,7 @@ fn lower_for_range(
     function -> NativeFunction,
     structure -> LoopStructure,
     raw_target -> string,
-    instruction -> NativeInstruction,
+    iterable_text -> string,
     llvm_return -> string,
     bindings -> ParameterBinding[],
     locals -> LocalBinding[],
@@ -62,7 +62,7 @@ fn lower_for_range(
     let mut collected_mutations -> LocalMutation[] = [];
     let mut collected_string_constants -> StringConstant[] = empty_string_constant_set();
 
-    let range_parse = parse_range_iterable(instruction.iterable);
+    let range_parse = parse_range_iterable(iterable_text);
     if !range_parse.success {
         return null;
     }

--- a/compiler/src/llvm/lowering/instructions_helpers.sfn
+++ b/compiler/src/llvm/lowering/instructions_helpers.sfn
@@ -416,3 +416,50 @@ fn read_expr_mutations(existing -> LocalMutation[]) -> LocalMutation[] ![io] {
     }
     return result;
 }
+
+// Scan accumulated IR lines for the highest %tN temp index and return
+// max(highest + 1, floor).  This provides a robust fallback when IPC
+// files carry stale temp counters (e.g. after cross-module expression
+// lowering where struct-return scalars are ABI-corrupted).
+fn recover_temp_from_lines(lines -> string[], floor -> number) -> number {
+    let mut result -> number = floor;
+    let mut ri -> number = 0;
+    loop {
+        if ri >= lines.length { break; }
+        let rl = lines[ri];
+        if rl.length >= 5 {
+            let c0 = char_code(grapheme_at(rl, 0));
+            let c1 = char_code(grapheme_at(rl, 1));
+            let c2 = char_code(grapheme_at(rl, 2));
+            let c3 = char_code(grapheme_at(rl, 3));
+            // Match "  %t" (two spaces, percent, lowercase t)
+            if c0 == 32 {
+                if c1 == 32 {
+                    if c2 == 37 {
+                        if c3 == 116 {
+                            let mut rn -> number = 0;
+                            let mut rj -> number = 4;
+                            let mut rvalid -> boolean = false;
+                            loop {
+                                if rj >= rl.length { break; }
+                                let rc = char_code(grapheme_at(rl, rj));
+                                if rc < 48 { break; }
+                                if rc > 57 { break; }
+                                rn = rn * 10 + (rc - 48);
+                                rvalid = true;
+                                rj += 1;
+                            }
+                            if rvalid {
+                                if rn >= result {
+                                    result = rn + 1;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        ri += 1;
+    }
+    return result;
+}

--- a/compiler/src/llvm/lowering/instructions_if.sfn
+++ b/compiler/src/llvm/lowering/instructions_if.sfn
@@ -83,6 +83,7 @@ import {
     insert_lines_before_index,
     _write_block_result_files,
     _parse_int_from_string,
+    _read_ipc_int_min,
 } from "./instructions_helpers";
 
 import {
@@ -347,10 +348,12 @@ fn lower_if_instruction(
         then_label
     );
     // Cross-module ABI: scalar fields corrupted; read from file IPC instead.
-    let _br_then_temp = _parse_int_from_string(fs.readFile("build/sailfin/.block_result_temp_index"));
-    let _br_then_blkctr = _parse_int_from_string(fs.readFile("build/sailfin/.block_result_block_counter"));
-    let _br_then_nextloc = _parse_int_from_string(fs.readFile("build/sailfin/.block_result_next_local_id"));
-    let _br_then_nextreg = _parse_int_from_string(fs.readFile("build/sailfin/.block_result_next_lifetime_region_id"));
+    // Use _read_ipc_int_min to prevent the counter from going backwards
+    // (stale/empty IPC files can cause duplicate SSA names).
+    let _br_then_temp = _read_ipc_int_min("build/sailfin/.block_result_temp_index", current_temp);
+    let _br_then_blkctr = _read_ipc_int_min("build/sailfin/.block_result_block_counter", current_block_counter);
+    let _br_then_nextloc = _read_ipc_int_min("build/sailfin/.block_result_next_local_id", current_next_local);
+    let _br_then_nextreg = _read_ipc_int_min("build/sailfin/.block_result_next_lifetime_region_id", current_next_region);
     let _br_then_term = fs.readFile("build/sailfin/.block_result_terminated") == "1";
     let mut _ci14 -> number = 0;
     loop {
@@ -407,10 +410,10 @@ fn lower_if_instruction(
             else_label
         );
         // Cross-module ABI: scalar fields corrupted; read from file IPC instead.
-        let _br_else_temp = _parse_int_from_string(fs.readFile("build/sailfin/.block_result_temp_index"));
-        let _br_else_blkctr = _parse_int_from_string(fs.readFile("build/sailfin/.block_result_block_counter"));
-        let _br_else_nextloc = _parse_int_from_string(fs.readFile("build/sailfin/.block_result_next_local_id"));
-        let _br_else_nextreg = _parse_int_from_string(fs.readFile("build/sailfin/.block_result_next_lifetime_region_id"));
+        let _br_else_temp = _read_ipc_int_min("build/sailfin/.block_result_temp_index", current_temp);
+        let _br_else_blkctr = _read_ipc_int_min("build/sailfin/.block_result_block_counter", current_block_counter);
+        let _br_else_nextloc = _read_ipc_int_min("build/sailfin/.block_result_next_local_id", current_next_local);
+        let _br_else_nextreg = _read_ipc_int_min("build/sailfin/.block_result_next_lifetime_region_id", current_next_region);
         let _br_else_term = fs.readFile("build/sailfin/.block_result_terminated") == "1";
         let mut _ci15 -> number = 0;
         loop {
@@ -766,6 +769,6 @@ fn lower_if_instruction(
         lifetime_regions: lifetime_regions,
         next_lifetime_region_id: current_next_region,
         next_index: structure.next_index + 1,
-    mutations: collected_mutations, string_constants: collected_string_constants,
+        mutations: collected_mutations, string_constants: collected_string_constants,
     };
 }

--- a/compiler/src/llvm/lowering/instructions_let.sfn
+++ b/compiler/src/llvm/lowering/instructions_let.sfn
@@ -203,20 +203,20 @@ fn lower_let_instruction(
             fs.deleteFile("build/sailfin/.call_result_value");
         }
         if fs.exists("build/sailfin/.trace_lowering") {
-            print("let-lowering: pre-lower_expression name=" + instruction.name + " value=" + instruction.value);
+            print.err("let-lowering: pre-lower_expression name=" + instruction.name + " value=" + instruction.value);
         }
         let lowered = lower_expression(instruction.value, current_bindings, current_locals, current_temp, current_lines, functions, context, llvm_type);
         if fs.exists("build/sailfin/.trace_lowering") {
-            print("let-lowering: post-lower_expression name=" + instruction.name);
+            print.err("let-lowering: post-lower_expression name=" + instruction.name);
         }
         // Read lines/temp from files to bypass ExpressionResult struct corruption
         if fs.exists("build/sailfin/.call_result_type") {
             if fs.exists("build/sailfin/.trace_lowering") {
-                print("let-lowering: call_result_type file exists");
+                print.err("let-lowering: call_result_type file exists");
             }
         }
         if fs.exists("build/sailfin/.trace_lowering") {
-            print("let-lowering: accessing lowered.diagnostics");
+            print.err("let-lowering: accessing lowered.diagnostics");
         }
         let mut _ci19 -> number = 0;
         loop {
@@ -225,28 +225,28 @@ fn lower_let_instruction(
             _ci19 += 1;
         }
         if fs.exists("build/sailfin/.trace_lowering") {
-            print("let-lowering: accessing lowered.lines");
+            print.err("let-lowering: accessing lowered.lines");
         }
         current_lines = lowered.lines;
         if fs.exists("build/sailfin/.trace_lowering") {
-            print("let-lowering: got lines, accessing temp_index");
+            print.err("let-lowering: got lines, accessing temp_index");
         }
         current_temp = lowered.temp_index;
         if fs.exists("build/sailfin/.trace_lowering") {
-            print("let-lowering: got temp_index=" + number_to_string(current_temp) + ", accessing operand");
+            print.err("let-lowering: got temp_index=" + number_to_string(current_temp) + ", accessing operand");
         }
         operand = lowered.operand;
         if fs.exists("build/sailfin/.trace_lowering") {
-            print("let-lowering: got operand, accessing string_constants");
+            print.err("let-lowering: got operand, accessing string_constants");
         }
         string_constants = lowered.string_constants;
         if fs.exists("build/sailfin/.trace_lowering") {
-            print("let-lowering: got string_constants, done with lowered");
+            print.err("let-lowering: got string_constants, done with lowered");
         }
     }
 
     if fs.exists("build/sailfin/.trace_lowering") {
-        print("let-lowering: checking llvm_type len=" + number_to_string(llvm_type.length));
+        print.err("let-lowering: checking llvm_type len=" + number_to_string(llvm_type.length));
     }
     if llvm_type.length == 0 {
         // Try file-based fallback FIRST, since operand.llvm_type may be
@@ -256,14 +256,14 @@ fn lower_let_instruction(
             if _crt.length > 0 {
                 llvm_type = _crt;
                 if fs.exists("build/sailfin/.trace_lowering") {
-                    print("let-lowering: llvm_type from file=" + llvm_type);
+                    print.err("let-lowering: llvm_type from file=" + llvm_type);
                 }
             }
         }
         if llvm_type.length == 0 {
             if operand != null {
                 if fs.exists("build/sailfin/.trace_lowering") {
-                    print("let-lowering: operand not null, trimming type");
+                    print.err("let-lowering: operand not null, trimming type");
                 }
                 let operand_type = trim_text(operand.llvm_type);
                 if operand_type.length > 0 {
@@ -341,7 +341,7 @@ fn lower_let_instruction(
                 }
                 operand = LLVMOperand { llvm_type: _fixup_type, value: _fixup_value };
                 if fs.exists("build/sailfin/.trace_lowering") {
-                    print("let-lowering: operand reconstructed type=" + _fixup_type + " value=" + _fixup_value);
+                    print.err("let-lowering: operand reconstructed type=" + _fixup_type + " value=" + _fixup_value);
                 }
             }
         }
@@ -352,7 +352,7 @@ fn lower_let_instruction(
             stored_value = operand.value;
             current_lines.push("  store " + llvm_type + " " + operand.value + ", " + llvm_type + "* " + pointer);
             if fs.exists("build/sailfin/.trace_lowering") {
-                print("let-lowering: identity coerce type=" + llvm_type + " value=" + operand.value);
+                print.err("let-lowering: identity coerce type=" + llvm_type + " value=" + operand.value);
             }
         } else {
             // Types differ — need coercion. Since coerce_operand_to_type returns
@@ -407,7 +407,7 @@ fn lower_let_instruction(
     mutations.push(mutation);
 
     if fs.exists("build/sailfin/.trace_lowering") {
-        print("let-lowering: returning LetLoweringResult for name=" + instruction.name);
+        print.err("let-lowering: returning LetLoweringResult for name=" + instruction.name);
     }
     // Serialize key scalar results to files so the caller can recover
     // when LetLoweringResult struct fields are corrupted crossing module boundaries.

--- a/compiler/src/llvm/lowering/instructions_loops.sfn
+++ b/compiler/src/llvm/lowering/instructions_loops.sfn
@@ -197,11 +197,11 @@ fn lower_loop_instruction(
 
     let debug_loop = fs.exists("build/sailfin/.trace_lowering");
     if debug_loop {
-        print("emit-llvm: lower_loop start fn=" + function.name + " start_index=" + number_to_string(start_index) + " end=" + number_to_string(end));
+        print.err("emit-llvm: lower_loop start fn=" + function.name + " start_index=" + number_to_string(start_index) + " end=" + number_to_string(end));
     }
     let structure = collect_loop_structure(function.instructions, start_index, end, function.name);
     if debug_loop {
-        print("emit-llvm: lower_loop after_collect body_start=" + number_to_string(structure.body_start) + " body_end=" + number_to_string(structure.body_end));
+        print.err("emit-llvm: lower_loop after_collect body_start=" + number_to_string(structure.body_start) + " body_end=" + number_to_string(structure.body_end));
     }
 
     // Detect exit-condition-at-top pattern: loop { if COND { break; } ... }
@@ -223,7 +223,7 @@ fn lower_loop_instruction(
                 if raw_exit_cond.length > 0 {
                     loop_exit_condition = sanitize_if_condition_text(raw_exit_cond);
                     if debug_loop {
-                        print("emit-llvm: lower_loop detected exit condition: " + loop_exit_condition);
+                        print.err("emit-llvm: lower_loop detected exit condition: " + loop_exit_condition);
                     }
                 }
             }
@@ -285,7 +285,7 @@ fn lower_loop_instruction(
     // Lower the body to discover mutations
     let body_scope_id = make_child_scope_id(scope_id, body_label);
     if debug_loop {
-        print("emit-llvm: lower_loop pre_body_lir fn=" + function.name + " body_start=" + number_to_string(structure.body_start) + " body_end=" + number_to_string(structure.body_end));
+        print.err("emit-llvm: lower_loop pre_body_lir fn=" + function.name + " body_start=" + number_to_string(structure.body_start) + " body_end=" + number_to_string(structure.body_end));
     }
     let body_result = lower_instruction_range(
         function,
@@ -314,7 +314,7 @@ fn lower_loop_instruction(
     let _br_lp_nextloc = _read_ipc_int_min("build/sailfin/.block_result_next_local_id", current_next_local);
     let _br_lp_nextreg = _read_ipc_int_min("build/sailfin/.block_result_next_lifetime_region_id", current_next_region);
     if debug_loop {
-        print("emit-llvm: lower_loop post_body_lir fn=" + function.name + " body_lines=" + number_to_string(body_result.lines.length));
+        print.err("emit-llvm: lower_loop post_body_lir fn=" + function.name + " body_lines=" + number_to_string(body_result.lines.length));
     }
 
     let mut _ci7 -> number = 0;

--- a/compiler/src/llvm/lowering/instructions_loops.sfn
+++ b/compiler/src/llvm/lowering/instructions_loops.sfn
@@ -25,6 +25,7 @@ import {
 } from "../utils";
 
 import {
+    empty_string_constant_set,
     merge_string_constants,
 } from "../strings";
 

--- a/compiler/src/llvm/lowering/instructions_loops.sfn
+++ b/compiler/src/llvm/lowering/instructions_loops.sfn
@@ -141,8 +141,15 @@ fn collect_loop_structure(
 }
 
 fn append_loop_context(values -> LoopContext[], value -> LoopContext) -> LoopContext[] {
-    let mut out = values;
-    out = out.push(value);
+    // Deep-copy the array so the caller's reference is not mutated by push.
+    let mut out -> LoopContext[] = [];
+    let mut i -> number = 0;
+    loop {
+        if i >= values.length { break; }
+        out.push(values[i]);
+        i += 1;
+    }
+    out.push(value);
     return out;
 }
 

--- a/compiler/src/llvm/lowering/instructions_loops.sfn
+++ b/compiler/src/llvm/lowering/instructions_loops.sfn
@@ -58,6 +58,7 @@ import {
     extend_mutations,
     _write_block_result_files,
     _parse_int_from_string,
+    _read_ipc_int_min,
 } from "./instructions_helpers";
 
 import {
@@ -299,10 +300,11 @@ fn lower_loop_instruction(
         body_label
     );
     // Cross-module ABI: scalar fields corrupted; read from file IPC instead.
-    let _br_lp_temp = _parse_int_from_string(fs.readFile("build/sailfin/.block_result_temp_index"));
-    let _br_lp_blkctr = _parse_int_from_string(fs.readFile("build/sailfin/.block_result_block_counter"));
-    let _br_lp_nextloc = _parse_int_from_string(fs.readFile("build/sailfin/.block_result_next_local_id"));
-    let _br_lp_nextreg = _parse_int_from_string(fs.readFile("build/sailfin/.block_result_next_lifetime_region_id"));
+    // Use _read_ipc_int_min to prevent the counter from going backwards.
+    let _br_lp_temp = _read_ipc_int_min("build/sailfin/.block_result_temp_index", current_temp);
+    let _br_lp_blkctr = _read_ipc_int_min("build/sailfin/.block_result_block_counter", current_block_counter);
+    let _br_lp_nextloc = _read_ipc_int_min("build/sailfin/.block_result_next_local_id", current_next_local);
+    let _br_lp_nextreg = _read_ipc_int_min("build/sailfin/.block_result_next_lifetime_region_id", current_next_region);
     if debug_loop {
         print("emit-llvm: lower_loop post_body_lir fn=" + function.name + " body_lines=" + number_to_string(body_result.lines.length));
     }

--- a/compiler/src/llvm/lowering/instructions_match.sfn
+++ b/compiler/src/llvm/lowering/instructions_match.sfn
@@ -88,6 +88,7 @@ import {
     extend_mutations,
     _write_block_result_files,
     _parse_int_from_string,
+    _read_ipc_int_min,
 } from "./instructions_helpers";
 
 import {
@@ -681,10 +682,10 @@ fn lower_match_instruction(
             body_labels[index]
         );
         // Cross-module ABI: scalar fields corrupted; read from file IPC instead.
-        let _br_body_temp = _parse_int_from_string(fs.readFile("build/sailfin/.block_result_temp_index"));
-        let _br_body_blkctr = _parse_int_from_string(fs.readFile("build/sailfin/.block_result_block_counter"));
-        let _br_body_nextloc = _parse_int_from_string(fs.readFile("build/sailfin/.block_result_next_local_id"));
-        let _br_body_nextreg = _parse_int_from_string(fs.readFile("build/sailfin/.block_result_next_lifetime_region_id"));
+        let _br_body_temp = _read_ipc_int_min("build/sailfin/.block_result_temp_index", current_temp);
+        let _br_body_blkctr = _read_ipc_int_min("build/sailfin/.block_result_block_counter", current_block_counter);
+        let _br_body_nextloc = _read_ipc_int_min("build/sailfin/.block_result_next_local_id", current_next_local);
+        let _br_body_nextreg = _read_ipc_int_min("build/sailfin/.block_result_next_lifetime_region_id", current_next_region);
         let _br_body_term = fs.readFile("build/sailfin/.block_result_terminated") == "1";
 
         let mut _ci3 -> number = 0;

--- a/compiler/src/llvm/lowering/instructions_match.sfn
+++ b/compiler/src/llvm/lowering/instructions_match.sfn
@@ -34,7 +34,7 @@ import {
     copy_string_array,
 } from "../utils";
 
-import { merge_string_constants } from "../strings";
+import { empty_string_constant_set, merge_string_constants } from "../strings";
 
 import {
     find_struct_info_by_name,

--- a/compiler/src/llvm/lowering/lowering_core.sfn
+++ b/compiler/src/llvm/lowering/lowering_core.sfn
@@ -625,6 +625,26 @@ fn lower_to_llvm_lines_with_parsed_context(native_module -> NativeModule, parse_
     runtime_helpers = append_unique_effect(runtime_helpers, "runtime_create_filesystem_bridge");
     runtime_helpers = append_unique_effect(runtime_helpers, "runtime_create_http_bridge");
     runtime_helpers = append_unique_effect(runtime_helpers, "runtime_create_model_bridge");
+    // Filesystem adapters — the compiler emits direct calls to these C
+    // runtime symbols from modules that use fs.readFile, fs.exists, etc.
+    // Without unconditional declares, separate-compilation produces
+    // "use of undefined value" errors at clang time.
+    runtime_helpers = append_unique_effect(runtime_helpers, "fs.readFile");
+    runtime_helpers = append_unique_effect(runtime_helpers, "fs.read");
+    runtime_helpers = append_unique_effect(runtime_helpers, "fs.writeFile");
+    runtime_helpers = append_unique_effect(runtime_helpers, "fs.write");
+    runtime_helpers = append_unique_effect(runtime_helpers, "fs.appendFile");
+    runtime_helpers = append_unique_effect(runtime_helpers, "fs.exists");
+    runtime_helpers = append_unique_effect(runtime_helpers, "fs.deleteFile");
+    runtime_helpers = append_unique_effect(runtime_helpers, "fs.listDirectory");
+    runtime_helpers = append_unique_effect(runtime_helpers, "fs.writeLines");
+    runtime_helpers = append_unique_effect(runtime_helpers, "fs.createDirectory");
+    runtime_helpers = append_unique_effect(runtime_helpers, "fs.read_bytes");
+    // Additional helpers used by the compiler but not auto-collected
+    runtime_helpers = append_unique_effect(runtime_helpers, "monotonic_millis");
+    runtime_helpers = append_unique_effect(runtime_helpers, "find_char");
+    runtime_helpers = append_unique_effect(runtime_helpers, "string_starts_with");
+    runtime_helpers = append_unique_effect(runtime_helpers, "process.run");
     let mut direct_effects -> FunctionEffectEntry[] = [];
     let mut aggregated_effects -> FunctionEffectEntry[] = [];
     if !skip_effects {

--- a/compiler/src/llvm/lowering/lowering_core.sfn
+++ b/compiler/src/llvm/lowering/lowering_core.sfn
@@ -243,22 +243,22 @@ fn make_native_module_for_emit(module_name -> string, native_text -> string) -> 
 
 fn compile_native_text_to_llvm_file(native_text_path -> string, module_name -> string, out_path -> string) -> boolean ![io] {
     if !fs.exists(native_text_path) {
-        print("emit-llvm: native text file missing at " + native_text_path);
+        print.err("emit-llvm: native text file missing at " + native_text_path);
         return false;
     }
     let native_text = fs.readFile(native_text_path);
     if native_text.length == 0 {
-        print("emit-llvm: native text file empty at " + native_text_path);
+        print.err("emit-llvm: native text file empty at " + native_text_path);
         return false;
     }
-    print("emit-llvm: compile_native_text_to_llvm_file module=" + module_name + " bytes=" + number_to_string(native_text.length));
+    print.err("emit-llvm: compile_native_text_to_llvm_file module=" + module_name + " bytes=" + number_to_string(native_text.length));
     let parse = build_parse_result_from_text(native_text);
     let raw_imports = recover_native_imports_light(native_text);
     fs.writeFile("build/sailfin/emit-native.tmp", native_text);
     let import_context = collect_imported_module_context_for_module(raw_imports, module_name);
-    print("emit-llvm: import context collected");
+    print.err("emit-llvm: import context collected");
     let dummy_module = make_native_module_for_emit(module_name, native_text);
-    print("emit-llvm: module created, entering lowering");
+    print.err("emit-llvm: module created, entering lowering");
     let lowered_lines = lower_to_llvm_lines_with_parsed_context(
         dummy_module,
         parse,
@@ -269,13 +269,13 @@ fn compile_native_text_to_llvm_file(native_text_path -> string, module_name -> s
         native_text
     );
     if lowered_lines.lines == null {
-        print("emit-llvm: lowered lines null");
+        print.err("emit-llvm: lowered lines null");
         return false;
     }
     let lowered_count = lowered_lines.lines.length;
     if lowered_count > 0 {
         let defined = collect_defined_function_symbols(lowered_lines.lines);
-        print("emit-llvm: lowered (defined=" + number_to_string(defined.length) + ")");
+        print.err("emit-llvm: lowered (defined=" + number_to_string(defined.length) + ")");
         if defined.length == 0 {
             return false;
         }
@@ -285,7 +285,7 @@ fn compile_native_text_to_llvm_file(native_text_path -> string, module_name -> s
     if lines == null { _if247 = true; }
     if lines.length == 0 { _if247 = true; }
     if _if247 {
-        print("emit-llvm: lowering produced no output lines");
+        print.err("emit-llvm: lowering produced no output lines");
         return false;
     }
     if fs.exists(out_path) {
@@ -297,14 +297,14 @@ fn compile_native_text_to_llvm_file(native_text_path -> string, module_name -> s
 fn lower_to_llvm_lines_with_parsed_context(native_module -> NativeModule, parse_in -> ParseNativeResult, imported_manifests -> LayoutManifest[], imported_native_texts -> string[], diagnostics_in -> string[], mangle_symbols -> boolean, native_text_override_path -> string) -> LoweredLLVMLinesResult ![io] {
     let debug_lowering = fs.exists("build/sailfin/.trace_lowering");
     if debug_lowering {
-        print("emit-llvm: phase=start");
+        print.err("emit-llvm: phase=start");
     }
     if debug_lowering {
         let mut artifact_count -> number = 0;
         if native_module.artifacts != null {
             artifact_count = native_module.artifacts.length;
         }
-        print("emit-llvm: native artifacts=" + number_to_string(artifact_count));
+        print.err("emit-llvm: native artifacts=" + number_to_string(artifact_count));
     }
 
     // ── Phase 1: Sanitize & recover inputs ──────────────────────────
@@ -314,7 +314,7 @@ fn lower_to_llvm_lines_with_parsed_context(native_module -> NativeModule, parse_
     let safe_imported_native_texts = sanitize_imported_native_texts(imported_native_texts, debug_lowering);
     let mut diagnostics = sanitize_diagnostics(diagnostics_in);
     if debug_lowering {
-        print("emit-llvm: dbg-F after diagnostics sanitize");
+        print.err("emit-llvm: dbg-F after diagnostics sanitize");
     }
     let safe_entry_points = sanitize_entry_points(native_module.entry_points, debug_lowering);
     let _trace_enums = fs.exists("build/sailfin/.trace_call_lowering");
@@ -328,7 +328,7 @@ fn lower_to_llvm_lines_with_parsed_context(native_module -> NativeModule, parse_
 
     let mut safe_imports = sanitize_imports(parse.imports, debug_lowering);
     if debug_lowering {
-        print("emit-llvm: safe_imports.length=" + number_to_string(safe_imports.length));
+        print.err("emit-llvm: safe_imports.length=" + number_to_string(safe_imports.length));
         if safe_imports.length > 0 {
             let first_import = safe_imports[0];
             if first_import != null {
@@ -344,9 +344,9 @@ fn lower_to_llvm_lines_with_parsed_context(native_module -> NativeModule, parse_
                 if first_import.specifiers != null {
                     import_spec_count = first_import.specifiers.length;
                 }
-                print("emit-llvm: safe_imports[0].kind=" + import_kind + " module=" + import_module + " specs=" + number_to_string(import_spec_count));
+                print.err("emit-llvm: safe_imports[0].kind=" + import_kind + " module=" + import_module + " specs=" + number_to_string(import_spec_count));
             } else {
-                print("emit-llvm: safe_imports[0]=<null>");
+                print.err("emit-llvm: safe_imports[0]=<null>");
             }
         }
     }
@@ -357,13 +357,13 @@ fn lower_to_llvm_lines_with_parsed_context(native_module -> NativeModule, parse_
     let safe_enums = sanitize_enums(parse.enums, diagnostics, _trace_enums);
     let safe_interfaces = sanitize_interfaces(parse.interfaces, diagnostics);
     if debug_lowering {
-        print("emit-llvm: dbg-H after structs/enums/interfaces sanitize");
+        print.err("emit-llvm: dbg-H after structs/enums/interfaces sanitize");
     }
     let mut safe_functions = sanitize_functions(parse.functions, native_text_override_path, debug_lowering);
     safe_functions = recover_safe_functions(safe_functions, native_text_override_path, debug_lowering);
 
     if debug_lowering {
-        print("emit-llvm: functions parsed=" + number_to_string(parse.functions.length) + " safe=" + number_to_string(safe_functions.length));
+        print.err("emit-llvm: functions parsed=" + number_to_string(parse.functions.length) + " safe=" + number_to_string(safe_functions.length));
     }
 
     safe_structs = recover_structs_if_corrupt(safe_structs, native_text_override_path, debug_lowering);
@@ -388,10 +388,10 @@ fn lower_to_llvm_lines_with_parsed_context(native_module -> NativeModule, parse_
     let start_ms = monotonic_millis();
 
     if trace {
-        print("test llvm: lower_to_llvm_lines_with_parsed_context start");
+        print.err("test llvm: lower_to_llvm_lines_with_parsed_context start");
     }
     if timing {
-        print("test llvm: phase=parse ms=" + number_to_string(monotonic_millis() - start_ms));
+        print.err("test llvm: phase=parse ms=" + number_to_string(monotonic_millis() - start_ms));
     }
 
     // ── Phase 2: Gather imported module context ─────────────────────
@@ -412,11 +412,11 @@ fn lower_to_llvm_lines_with_parsed_context(native_module -> NativeModule, parse_
             module_enums = [];
         }
         if debug_lowering {
-            print("emit-llvm: phase=manifest");
+            print.err("emit-llvm: phase=manifest");
         }
     }
     if timing {
-        print("test llvm: phase=manifest ms=" + number_to_string(monotonic_millis() - start_ms));
+        print.err("test llvm: phase=manifest ms=" + number_to_string(monotonic_millis() - start_ms));
     }
 
     let mut imported_structs -> NativeStruct[] = [];
@@ -482,7 +482,7 @@ fn lower_to_llvm_lines_with_parsed_context(native_module -> NativeModule, parse_
     }
 
     if debug_lowering {
-        print("emit-llvm: phase=imports");
+        print.err("emit-llvm: phase=imports");
     }
 
     // ── Phase 3: Combine types, build type context ──────────────────
@@ -492,23 +492,23 @@ fn lower_to_llvm_lines_with_parsed_context(native_module -> NativeModule, parse_
     if is_test_module {
         combined_interfaces = [];
         if trace {
-            print("test llvm: skipping interface metadata for inlined tests");
+            print.err("test llvm: skipping interface metadata for inlined tests");
         }
     }
 
     if trace {
-        print("test llvm: trait metadata start");
+        print.err("test llvm: trait metadata start");
     }
     let trait_metadata = build_trait_metadata(combined_interfaces, combined_structs);
     if debug_lowering {
-        print("emit-llvm: phase=trait_metadata");
+        print.err("emit-llvm: phase=trait_metadata");
     }
     if trace {
-        print("test llvm: enum layout fixup start");
+        print.err("test llvm: enum layout fixup start");
     }
 
     if trace {
-        print("test llvm: type context build start");
+        print.err("test llvm: type context build start");
     }
     let type_context = build_type_context_with_recovery(
         combined_structs, combined_enums, combined_interfaces,
@@ -521,28 +521,28 @@ fn lower_to_llvm_lines_with_parsed_context(native_module -> NativeModule, parse_
         diagnostics = extend_string_lines_checked(diagnostics, _tc_diags, "type context");
     }
     if trace {
-        print("test llvm: type context built");
+        print.err("test llvm: type context built");
     }
     if timing {
-        print("test llvm: phase=type_context ms=" + number_to_string(monotonic_millis() - start_ms));
+        print.err("test llvm: phase=type_context ms=" + number_to_string(monotonic_millis() - start_ms));
     }
 
     // ── Build context functions ─────────────────────────────────────
     if debug_lowering {
-        print("emit-llvm: phase=struct_methods_start");
+        print.err("emit-llvm: phase=struct_methods_start");
     }
     let module_struct_methods = flatten_struct_methods(module_structs);
     if debug_lowering {
-        print("emit-llvm: phase=struct_methods_done");
+        print.err("emit-llvm: phase=struct_methods_done");
     }
     let local_functions = concat_native_functions(safe_functions, module_struct_methods);
     if debug_lowering {
-        print("emit-llvm: phase=local_functions");
+        print.err("emit-llvm: phase=local_functions");
     }
     let mut context_functions = concat_native_functions(local_functions, imported_functions);
     context_functions = concat_native_functions(context_functions, imported_struct_methods);
     if debug_lowering {
-        print("emit-llvm: phase=context_functions");
+        print.err("emit-llvm: phase=context_functions");
     }
 
     serialize_context_functions(context_functions, debug_lowering);
@@ -558,14 +558,14 @@ fn lower_to_llvm_lines_with_parsed_context(native_module -> NativeModule, parse_
     }
     if _if255 {
         if debug_lowering {
-            print("emit-llvm: phase=helpers_start");
+            print.err("emit-llvm: phase=helpers_start");
         }
         runtime_helpers = collect_runtime_helper_targets(local_functions);
         if debug_lowering {
-            print("emit-llvm: phase=helpers_done");
+            print.err("emit-llvm: phase=helpers_done");
         }
     } else if trace {
-        print("test llvm: skipping runtime helper collection for inlined tests");
+        print.err("test llvm: skipping runtime helper collection for inlined tests");
     }
     if !string_array_contains(runtime_helpers, "copy_bytes") {
         runtime_helpers.push("copy_bytes");
@@ -650,7 +650,7 @@ fn lower_to_llvm_lines_with_parsed_context(native_module -> NativeModule, parse_
     let mut aggregated_effects -> FunctionEffectEntry[] = [];
     if !skip_effects {
         if debug_lowering {
-            print("emit-llvm: phase=direct_effects");
+            print.err("emit-llvm: phase=direct_effects");
         }
         direct_effects = collect_direct_function_effects(context_functions);
         aggregated_effects = direct_effects;
@@ -658,17 +658,17 @@ fn lower_to_llvm_lines_with_parsed_context(native_module -> NativeModule, parse_
             let call_graph = collect_function_call_graph(context_functions);
             aggregated_effects = propagate_function_effects(direct_effects, call_graph);
         } else if trace {
-            print("test llvm: skipping effect propagation for inlined tests");
+            print.err("test llvm: skipping effect propagation for inlined tests");
         }
     }
     if trace {
-        print("test llvm: runtime helpers collected");
+        print.err("test llvm: runtime helpers collected");
     }
     if timing {
-        print("test llvm: phase=effects ms=" + number_to_string(monotonic_millis() - start_ms));
+        print.err("test llvm: phase=effects ms=" + number_to_string(monotonic_millis() - start_ms));
     }
     if debug_lowering {
-        print("emit-llvm: phase=effects");
+        print.err("emit-llvm: phase=effects");
     }
 
     // ── Phase 4: Render LLVM IR preamble ────────────────────────────
@@ -685,8 +685,8 @@ fn lower_to_llvm_lines_with_parsed_context(native_module -> NativeModule, parse_
 
     // ── Module globals ──────────────────────────────────────────────
     if debug_lowering {
-        print("emit-llvm: phase=module_globals");
-        print("emit-llvm: module bindings count=" + number_to_string(safe_bindings.length));
+        print.err("emit-llvm: phase=module_globals");
+        print.err("emit-llvm: module bindings count=" + number_to_string(safe_bindings.length));
     }
     let mut module_globals_needs_init_call -> boolean = false;
     let mut module_global_locals -> LocalBinding[] = [];
@@ -696,11 +696,11 @@ fn lower_to_llvm_lines_with_parsed_context(native_module -> NativeModule, parse_
     let mut module_string_constants -> StringConstant[] = empty_string_constant_set();
     if safe_bindings.length == 0 {
         if debug_lowering {
-            print("emit-llvm: module bindings empty; skipping module globals");
+            print.err("emit-llvm: module bindings empty; skipping module globals");
         }
     } else if fs.exists("build/sailfin/.skip_module_globals") {
         if debug_lowering {
-            print("emit-llvm: skipping module globals");
+            print.err("emit-llvm: skipping module globals");
         }
     } else {
         let _mg = lower_module_bindings_to_globals(safe_bindings, type_context, native_module.module_name);
@@ -736,10 +736,10 @@ fn lower_to_llvm_lines_with_parsed_context(native_module -> NativeModule, parse_
         lines = extend_string_lines(lines, [""]);
     }
     if trace {
-        print("test llvm: module globals lowered");
+        print.err("test llvm: module globals lowered");
     }
     if timing {
-        print("test llvm: phase=globals ms=" + number_to_string(monotonic_millis() - start_ms));
+        print.err("test llvm: phase=globals ms=" + number_to_string(monotonic_millis() - start_ms));
     }
 
     // ── Phase 5: Lower all functions ────────────────────────────────
@@ -769,14 +769,14 @@ fn lower_to_llvm_lines_with_parsed_context(native_module -> NativeModule, parse_
     }
 
     if timing {
-        print("test llvm: phase=functions ms=" + number_to_string(monotonic_millis() - start_ms));
+        print.err("test llvm: phase=functions ms=" + number_to_string(monotonic_millis() - start_ms));
     }
 
     // ── Mangling ────────────────────────────────────────────────────
     let effective_mangle_symbols = mangle_symbols;
     if debug_lowering {
         if !effective_mangle_symbols {
-            print("emit-llvm: skipping mangling (mangle_symbols=false)");
+            print.err("emit-llvm: skipping mangling (mangle_symbols=false)");
         }
     }
     if effective_mangle_symbols {
@@ -790,13 +790,13 @@ fn lower_to_llvm_lines_with_parsed_context(native_module -> NativeModule, parse_
         lines = mangled.lines;
     }
     if debug_lowering {
-        print("emit-llvm: phase=mangle");
+        print.err("emit-llvm: phase=mangle");
     }
     if trace {
-        print("test llvm: mangling stage done");
+        print.err("test llvm: mangling stage done");
     }
     if timing {
-        print("test llvm: phase=finalize ms=" + number_to_string(monotonic_millis() - start_ms));
+        print.err("test llvm: phase=finalize ms=" + number_to_string(monotonic_millis() - start_ms));
     }
 
     // ── Final result ────────────────────────────────────────────────
@@ -821,7 +821,7 @@ fn lower_to_llvm_lines_with_parsed_context(native_module -> NativeModule, parse_
             }
             i += 1;
         }
-        print(
+        print.err(
             "test llvm: lowered lines=" + number_to_string(lines.length)
             + " nonempty=" + number_to_string(nonempty)
             + " first_len=" + number_to_string(first_len)
@@ -832,12 +832,12 @@ fn lower_to_llvm_lines_with_parsed_context(native_module -> NativeModule, parse_
             if diag_index >= diagnostics.length {
                 break;
             }
-            print("test llvm: diagnostic " + diagnostics[diag_index]);
+            print.err("test llvm: diagnostic " + diagnostics[diag_index]);
             diag_index += 1;
         }
     }
     if lines.length == 0 {
-        print(
+        print.err(
             "emit-llvm: lowering produced no lines (functions="
             + number_to_string(local_functions.length)
             + " structs="
@@ -849,9 +849,9 @@ fn lower_to_llvm_lines_with_parsed_context(native_module -> NativeModule, parse_
             + ")"
         );
     }
-    print("emit-llvm: exit lower_to_llvm_lines_with_parsed_context lines=" + number_to_string(lines.length));
+    print.err("emit-llvm: exit lower_to_llvm_lines_with_parsed_context lines=" + number_to_string(lines.length));
     if debug_lowering {
-        print("emit-llvm: phase=end lines=" + number_to_string(lines.length));
+        print.err("emit-llvm: phase=end lines=" + number_to_string(lines.length));
     }
     return LoweredLLVMLinesResult {
         lines: lines,

--- a/compiler/src/llvm/lowering/lowering_core.sfn
+++ b/compiler/src/llvm/lowering/lowering_core.sfn
@@ -645,6 +645,7 @@ fn lower_to_llvm_lines_with_parsed_context(native_module -> NativeModule, parse_
     runtime_helpers = append_unique_effect(runtime_helpers, "find_char");
     runtime_helpers = append_unique_effect(runtime_helpers, "string_starts_with");
     runtime_helpers = append_unique_effect(runtime_helpers, "process.run");
+    runtime_helpers = append_unique_effect(runtime_helpers, "is_decimal_digit");
     let mut direct_effects -> FunctionEffectEntry[] = [];
     let mut aggregated_effects -> FunctionEffectEntry[] = [];
     if !skip_effects {

--- a/compiler/src/llvm/lowering/lowering_helpers.sfn
+++ b/compiler/src/llvm/lowering/lowering_helpers.sfn
@@ -622,11 +622,11 @@ fn _extract_signature_from_header(trimmed -> string, prefix_len -> number, symbo
         }
         let p = parts[pi];
         let pct = index_of(p, "%");
+        let mut stripped -> string = p;
         if pct > 0 {
-            stripped_parts.push(trim_text(substring(p, 0, pct)));
-        } else {
-            stripped_parts.push(p);
+            stripped = trim_text(substring(p, 0, pct));
         }
+        stripped_parts.push(stripped);
         pi += 1;
     }
     return DeclareSignature { return_type: ret_type, param_types: stripped_parts };

--- a/compiler/src/llvm/lowering/lowering_helpers.sfn
+++ b/compiler/src/llvm/lowering/lowering_helpers.sfn
@@ -614,6 +614,8 @@ fn _extract_signature_from_header(trimmed -> string, prefix_len -> number, symbo
         parts = parts.concat([final_part]);
     }
     // Strip parameter names from define-style params (e.g. "i8* %text" → "i8*").
+    // Only strip the trailing `%name` when it appears at the top level (curly
+    // depth 0) so that struct types like "{ %Decorator*, i64 }*" are preserved.
     let mut stripped_parts -> string[] = [];
     let mut pi -> number = 0;
     loop {
@@ -621,10 +623,36 @@ fn _extract_signature_from_header(trimmed -> string, prefix_len -> number, symbo
             break;
         }
         let p = parts[pi];
-        let pct = index_of(p, "%");
+        // Scan backwards to find the last '%' at curly depth 0.
+        let mut scan_pos = p.length - 1;
+        let mut pct_at_top -> number = -1;
+        let mut depth -> number = 0;
+        loop {
+            if scan_pos < 0 {
+                break;
+            }
+            let ch = substring(p, scan_pos, scan_pos + 1);
+            if ch == "}" {
+                depth += 1;
+            } else if ch == "{" {
+                if depth > 0 {
+                    depth -= 1;
+                }
+            }
+            if ch == "%" {
+                if depth == 0 {
+                    pct_at_top = scan_pos;
+                    break;
+                }
+            }
+            scan_pos -= 1;
+        }
         let mut stripped -> string = p;
-        if pct > 0 {
-            stripped = trim_text(substring(p, 0, pct));
+        if pct_at_top > 0 {
+            let prev_char = substring(p, pct_at_top - 1, pct_at_top);
+            if prev_char == " " {
+                stripped = trim_text(substring(p, 0, pct_at_top));
+            }
         }
         stripped_parts.push(stripped);
         pi += 1;

--- a/compiler/src/llvm/lowering/lowering_helpers_mangling.sfn
+++ b/compiler/src/llvm/lowering/lowering_helpers_mangling.sfn
@@ -41,7 +41,7 @@ fn apply_module_symbol_mangling(
     let mut diagnostics -> string[] = [];
     let debug_lowering = fs.exists("build/sailfin/.trace_lowering");
     if debug_lowering {
-        print("emit-llvm: mangle start module=" + current_module_slug);
+        print.err("emit-llvm: mangle start module=" + current_module_slug);
     }
     let mut safe_imports = imports;
     if safe_imports == null {
@@ -51,7 +51,7 @@ fn apply_module_symbol_mangling(
         diagnostics.push("llvm lowering: import list too large for mangling; dropping");
         safe_imports = [];
         if debug_lowering {
-            print("emit-llvm: mangle import list too large; dropping");
+            print.err("emit-llvm: mangle import list too large; dropping");
         }
     }
 
@@ -65,13 +65,13 @@ fn apply_module_symbol_mangling(
 
     let available_modules = collect_available_import_module_names(imported_native_texts);
     if debug_lowering {
-        print("emit-llvm: mangle available_modules=" + number_to_string(available_modules.length));
+        print.err("emit-llvm: mangle available_modules=" + number_to_string(available_modules.length));
     }
 
     // 1) Mangle every function defined in this module to a module-qualified symbol.
     let defined = collect_defined_function_symbols(lines);
     if debug_lowering {
-        print("emit-llvm: mangle defined_symbols=" + number_to_string(defined.length));
+        print.err("emit-llvm: mangle defined_symbols=" + number_to_string(defined.length));
     }
     let mut local_olds -> string[] = [];
     let mut local_news -> string[] = [];
@@ -97,7 +97,7 @@ fn apply_module_symbol_mangling(
 
     let mut rewritten = apply_symbol_substitutions(lines, local_olds, local_news);
     if debug_lowering {
-        print("emit-llvm: mangle local_subs=" + number_to_string(local_olds.length));
+        print.err("emit-llvm: mangle local_subs=" + number_to_string(local_olds.length));
     }
 
     // 2) Rewrite imported symbol references to the provider's qualified symbol,
@@ -237,7 +237,7 @@ fn apply_module_symbol_mangling(
 
     rewritten = apply_symbol_substitutions(rewritten, import_olds, import_news);
     if debug_lowering {
-        print("emit-llvm: mangle import_subs=" + number_to_string(import_olds.length));
+        print.err("emit-llvm: mangle import_subs=" + number_to_string(import_olds.length));
     }
 
     // 3) Append shims before the LLVM footer (attributes/metadata).
@@ -283,7 +283,7 @@ fn apply_module_symbol_mangling(
     }
     rewritten = insert_before_llvm_footer(rewritten, shim_lines);
     if debug_lowering {
-        print("emit-llvm: mangle shims=" + number_to_string(shim_exports.length));
+        print.err("emit-llvm: mangle shims=" + number_to_string(shim_exports.length));
     }
 
     return MangledModuleResult { lines: rewritten, diagnostics: diagnostics };

--- a/compiler/src/llvm/lowering/lowering_native_helpers.sfn
+++ b/compiler/src/llvm/lowering/lowering_native_helpers.sfn
@@ -110,10 +110,16 @@ fn make_instruction_simple(tag_val -> number) -> NativeInstruction {
     // Seed drops this; fixup pass replaces body
     if tag_val == 4 { return NativeInstruction.Else(); }
     if tag_val == 5 { return NativeInstruction.EndIf(); }
+    if tag_val == 7 { return NativeInstruction.EndFor(); }
     if tag_val == 8 { return NativeInstruction.Loop(); }
     if tag_val == 9 { return NativeInstruction.EndLoop(); }
     if tag_val == 10 { return NativeInstruction.Break(); }
     return NativeInstruction.Continue();
+}
+
+fn make_instruction_for(target -> string, iterable -> string) -> NativeInstruction {
+    // Seed drops this; fixup pass replaces body
+    return NativeInstruction.For { target: target, iterable: iterable };
 }
 
 // ── NativeEnum field accessors ───────────────────────────────────────
@@ -180,6 +186,16 @@ fn get_instruction_let_type(instructions -> NativeInstruction[], idx -> number) 
 fn get_instruction_let_value(instructions -> NativeInstruction[], idx -> number) -> string? {
     let instr = instructions[idx];
     return instr.value;
+}
+fn get_instruction_for_target(instructions -> NativeInstruction[], idx -> number) -> string {
+    // Seed drops this; fixup pass replaces with payload[0] read
+    let instr = instructions[idx];
+    return instr.target;
+}
+fn get_instruction_for_iterable(instructions -> NativeInstruction[], idx -> number) -> string {
+    // Seed drops this; fixup pass replaces with payload[1] read
+    let instr = instructions[idx];
+    return instr.iterable;
 }
 
 // ── NativeFunction field accessors ───────────────────────────────────

--- a/compiler/src/llvm/lowering/lowering_phase_functions.sfn
+++ b/compiler/src/llvm/lowering/lowering_phase_functions.sfn
@@ -156,10 +156,10 @@ fn lower_all_functions(
     let mut diagnostics -> string[] = [];
 
     if trace {
-        print("test llvm: lowering functions start (count=" + number_to_string(local_functions.length) + ")");
+        print.err("test llvm: lowering functions start (count=" + number_to_string(local_functions.length) + ")");
     }
     if debug_lowering {
-        print("emit-llvm: phase=functions");
+        print.err("emit-llvm: phase=functions");
     }
     loop {
         if index >= local_functions.length {
@@ -215,7 +215,7 @@ fn lower_all_functions(
                 }
                 instr_index += 1;
             }
-            print(
+            print.err(
                 "test llvm: function "
                 + number_to_string(index)
                 + "/"
@@ -241,7 +241,7 @@ fn lower_all_functions(
             }
         );
         if debug_lowering {
-            print("emit-llvm: function-start " + safe_function_name + " idx=" + number_to_string(index));
+            print.err("emit-llvm: function-start " + safe_function_name + " idx=" + number_to_string(index));
         }
         // Write function metadata to file-based IPC
         write_function_ipc(
@@ -271,13 +271,13 @@ fn lower_all_functions(
         let _lfn_sc_raw = fs.readFile("build/sailfin/.lowered_fn_string_constants");
         let _lfn_string_constants = _parse_lowered_fn_string_constants(_lfn_sc_raw);
         if debug_lowering {
-            print("emit-llvm: function-done " + safe_function_name + " lines=" + number_to_string(_lfn_lines.length));
+            print.err("emit-llvm: function-done " + safe_function_name + " lines=" + number_to_string(_lfn_lines.length));
         }
         if trace {
-            print("test llvm: function lowered " + safe_function_name + " lines=" + number_to_string(_lfn_lines.length) + " diagnostics=" + number_to_string(_lfn_diags.length));
+            print.err("test llvm: function lowered " + safe_function_name + " lines=" + number_to_string(_lfn_lines.length) + " diagnostics=" + number_to_string(_lfn_diags.length));
             if _lfn_lines.length > 0 {
-                print("test llvm: function first line " + _lfn_lines[0]);
-                print("test llvm: function last line " + _lfn_lines[_lfn_lines.length - 1]);
+                print.err("test llvm: function first line " + _lfn_lines[0]);
+                print.err("test llvm: function last line " + _lfn_lines[_lfn_lines.length - 1]);
                 let mut ret_lines -> number = 0;
                 let mut scan_index -> number = 0;
                 loop {
@@ -293,7 +293,7 @@ fn lower_all_functions(
                     }
                     scan_index += 1;
                 }
-                print("test llvm: function ret_lines " + number_to_string(ret_lines));
+                print.err("test llvm: function ret_lines " + number_to_string(ret_lines));
             }
         }
         if safe_function_name == "add" {
@@ -301,44 +301,44 @@ fn lower_all_functions(
         }
         diagnostics = extend_string_lines_checked(diagnostics, _lfn_diags, "function lowering");
         if trace {
-            print("test llvm: function diagnostics merged " + safe_function_name);
+            print.err("test llvm: function diagnostics merged " + safe_function_name);
         }
         let normalized_lowered_lines = _lfn_lines;
         if normalized_lowered_lines != null {
             if normalized_lowered_lines.length > 0 {
                 lines = append_string_lines(lines, normalized_lowered_lines);
                 if trace {
-                    print("test llvm: function lines merged " + safe_function_name);
-                    print("test llvm: function post-merge check " + safe_function_name);
+                    print.err("test llvm: function lines merged " + safe_function_name);
+                    print.err("test llvm: function post-merge check " + safe_function_name);
                 }
                 let _ep_next = index + 1;
                 if _ep_next < local_functions.length {
                     lines.push("");
                 }
                 if trace {
-                    print("test llvm: function post-merge blank " + safe_function_name);
+                    print.err("test llvm: function post-merge blank " + safe_function_name);
                 }
             }
         }
         if _lfn_string_constants != null {
             if _lfn_string_constants.length > 0 {
                 if trace {
-                    print("test llvm: merging string constants " + safe_function_name + " count=" + number_to_string(_lfn_string_constants.length));
+                    print.err("test llvm: merging string constants " + safe_function_name + " count=" + number_to_string(_lfn_string_constants.length));
                 }
                 let existing_constants = all_string_constants;
                 all_string_constants = merge_string_constants(existing_constants, _lfn_string_constants);
                 if trace {
-                    print("test llvm: merged string constants " + safe_function_name);
+                    print.err("test llvm: merged string constants " + safe_function_name);
                 }
             }
         }
         index += 1;
     }
     if trace {
-        print("test llvm: lowering functions done");
+        print.err("test llvm: lowering functions done");
     }
     if debug_lowering {
-        print("emit-llvm: phase=functions_done");
+        print.err("emit-llvm: phase=functions_done");
     }
 
     // Write function_effects and has_add_function to files for orchestrator
@@ -370,19 +370,19 @@ fn lower_all_functions(
         }
     }
     if trace {
-        print("test llvm: string constants emitted");
+        print.err("test llvm: string constants emitted");
     }
     if debug_lowering {
-        print("emit-llvm: phase=string_constants");
+        print.err("emit-llvm: phase=string_constants");
     }
 
     // Intrinsics
     lines = ensure_intrinsic_declarations(lines);
     if trace {
-        print("test llvm: intrinsics ensured");
+        print.err("test llvm: intrinsics ensured");
     }
     if debug_lowering {
-        print("emit-llvm: phase=intrinsics");
+        print.err("emit-llvm: phase=intrinsics");
     }
 
     // Write diagnostics and function_effects count to files

--- a/compiler/src/llvm/lowering/lowering_phase_render.sfn
+++ b/compiler/src/llvm/lowering/lowering_phase_render.sfn
@@ -65,7 +65,7 @@ fn render_llvm_preamble(
 
     // Trait metadata comments
     if debug_lowering {
-        print("emit-llvm: phase=render_traits");
+        print.err("emit-llvm: phase=render_traits");
     }
     let trait_lines = render_trait_metadata_comments(trait_metadata);
     if trait_lines.length > 0 {
@@ -75,8 +75,8 @@ fn render_llvm_preamble(
 
     // Struct type definitions
     if debug_lowering {
-        print("emit-llvm: phase=render_structs");
-        print(
+        print.err("emit-llvm: phase=render_structs");
+        print.err(
             "emit-llvm: render_structs counts structs="
             + number_to_string(type_context.structs.length)
             + " enums="
@@ -115,7 +115,7 @@ fn render_llvm_preamble(
 
     // Enum type definitions
     if debug_lowering {
-        print("emit-llvm: phase=render_enums");
+        print.err("emit-llvm: phase=render_enums");
     }
     let enum_type_lines = render_enum_type_definitions(type_context);
     if enum_type_lines.length > 0 {
@@ -125,7 +125,7 @@ fn render_llvm_preamble(
 
     // Interface type definitions
     if debug_lowering {
-        print("emit-llvm: phase=render_interfaces");
+        print.err("emit-llvm: phase=render_interfaces");
     }
     let interface_type_lines = render_interface_type_definitions(type_context);
     if interface_type_lines.length > 0 {
@@ -179,7 +179,7 @@ fn render_llvm_preamble(
 
     // Runtime helper declarations
     if debug_lowering {
-        print("emit-llvm: phase=render_helpers");
+        print.err("emit-llvm: phase=render_helpers");
     }
     let helper_declarations = render_runtime_helper_declarations(runtime_helpers, local_functions);
     if helper_declarations != null {
@@ -191,7 +191,7 @@ fn render_llvm_preamble(
 
     // Imported function declarations
     if debug_lowering {
-        print("emit-llvm: phase=render_imports");
+        print.err("emit-llvm: phase=render_imports");
     }
     let imported_declarations = render_imported_function_declarations(imported_functions, local_functions, type_context);
     if imported_declarations != null {

--- a/compiler/src/llvm/lowering/lowering_phase_sanitize.sfn
+++ b/compiler/src/llvm/lowering/lowering_phase_sanitize.sfn
@@ -80,10 +80,10 @@ fn sanitize_lowering_inputs(
 ) -> ParseNativeResult ![io] {
     let mut parse = parse_in;
     if debug_lowering {
-        print("emit-llvm: dbg-A parse_in assigned");
+        print.err("emit-llvm: dbg-A parse_in assigned");
     }
     if debug_lowering {
-        print("emit-llvm: dbg-B before override check path_len=" + number_to_string(native_text_override_path.length));
+        print.err("emit-llvm: dbg-B before override check path_len=" + number_to_string(native_text_override_path.length));
     }
     // --- Reparse from override text ---
     if native_text_override_path.length > 0 {
@@ -103,15 +103,15 @@ fn sanitize_lowering_inputs(
             parse = reparsed;
         }
         if debug_lowering {
-            print("emit-llvm: reparsed from override text functions=" + number_to_string(parse.functions.length));
-            print("emit-llvm: reparsed from override diagnostics=" + number_to_string(parse.diagnostics.length));
+            print.err("emit-llvm: reparsed from override text functions=" + number_to_string(parse.functions.length));
+            print.err("emit-llvm: reparsed from override diagnostics=" + number_to_string(parse.diagnostics.length));
             if parse.diagnostics.length > 0 {
-                print("emit-llvm: reparsed diagnostic " + parse.diagnostics[0]);
+                print.err("emit-llvm: reparsed diagnostic " + parse.diagnostics[0]);
             }
         }
     }
     if debug_lowering {
-        print("emit-llvm: dbg-C after reparse block");
+        print.err("emit-llvm: dbg-C after reparse block");
     }
     return parse;
 }
@@ -126,7 +126,7 @@ fn sanitize_imported_manifests(imported_manifests: LayoutManifest[], debug_lower
         safe = [];
     }
     if debug_lowering {
-        print("emit-llvm: dbg-D after manifests sanitize");
+        print.err("emit-llvm: dbg-D after manifests sanitize");
     }
     return safe;
 }
@@ -141,7 +141,7 @@ fn sanitize_imported_native_texts(imported_native_texts: string[], debug_lowerin
         safe = [];
     }
     if debug_lowering {
-        print("emit-llvm: dbg-E after native_texts sanitize");
+        print.err("emit-llvm: dbg-E after native_texts sanitize");
     }
     return safe;
 }
@@ -168,7 +168,7 @@ fn sanitize_entry_points(entry_points: string[], debug_lowering: boolean) -> str
         safe = [];
     }
     if debug_lowering {
-        print("emit-llvm: dbg-G after entry_points sanitize");
+        print.err("emit-llvm: dbg-G after entry_points sanitize");
     }
     return safe;
 }
@@ -184,7 +184,7 @@ fn sanitize_imports(imports: NativeImport[], debug_lowering: boolean) -> NativeI
     }
     if safe.length > 100000 {
         if debug_lowering {
-            print("emit-llvm: import list too large; dropping");
+            print.err("emit-llvm: import list too large; dropping");
         }
         safe = [];
     }
@@ -215,14 +215,14 @@ fn sanitize_enums(enums: NativeEnum[], diagnostics: string[], _trace_enums: bool
         if safe != null {
             _enum_len_text = number_to_string(safe.length);
         }
-        print("enum_trace: parse.enums=" + _enum_len_text);
+        print.err("enum_trace: parse.enums=" + _enum_len_text);
     }
     if safe == null {
         safe = [];
     }
     if safe.length != sanitize_collection_length(safe.length, 100000) {
         if _trace_enums {
-            print("enum_trace: sanitize dropped enums (len=" + number_to_string(safe.length) + " sanitized=" + number_to_string(sanitize_collection_length(safe.length, 100000)) + ")");
+            print.err("enum_trace: sanitize dropped enums (len=" + number_to_string(safe.length) + " sanitized=" + number_to_string(sanitize_collection_length(safe.length, 100000)) + ")");
         }
         safe = [];
     }
@@ -231,7 +231,7 @@ fn sanitize_enums(enums: NativeEnum[], diagnostics: string[], _trace_enums: bool
         safe = [];
     }
     if _trace_enums {
-        print("enum_trace: safe_enums.length=" + number_to_string(safe.length));
+        print.err("enum_trace: safe_enums.length=" + number_to_string(safe.length));
     }
     return safe;
 }
@@ -260,61 +260,61 @@ fn sanitize_functions(
     debug_lowering: boolean
 ) -> NativeFunction[] ![io] {
     if debug_lowering {
-        print("emit-llvm: dbg-H1 before parse.functions access");
+        print.err("emit-llvm: dbg-H1 before parse.functions access");
     }
     let mut safe = functions;
     if debug_lowering {
-        print("emit-llvm: dbg-H2 after parse.functions access");
+        print.err("emit-llvm: dbg-H2 after parse.functions access");
     }
     if debug_lowering {
         if safe == null {
-            print("emit-llvm: parse.functions is null");
+            print.err("emit-llvm: parse.functions is null");
         }
     }
     if safe == null {
         safe = [];
     }
     if debug_lowering {
-        print("emit-llvm: dbg-H3 safe_functions.length=" + number_to_string(safe.length));
+        print.err("emit-llvm: dbg-H3 safe_functions.length=" + number_to_string(safe.length));
     }
     if safe.length != sanitize_collection_length(safe.length, 200000) {
         if debug_lowering {
-            print("emit-llvm: parse.functions has invalid length; dropping");
+            print.err("emit-llvm: parse.functions has invalid length; dropping");
         }
         safe = [];
     }
     if debug_lowering {
-        print("emit-llvm: dbg-H4 after sanitize safe_functions.length=" + number_to_string(safe.length));
+        print.err("emit-llvm: dbg-H4 after sanitize safe_functions.length=" + number_to_string(safe.length));
     }
     // Recovery: if parse returned no functions, try re-parsing from text
     if safe.length == 0 {
         if debug_lowering {
-            print("emit-llvm: dbg-R1 safe_functions empty, recovery path");
+            print.err("emit-llvm: dbg-R1 safe_functions empty, recovery path");
         }
         let mut recovery_text = "";
         if native_text_override_path.length > 0 {
             recovery_text = native_text_override_path;
         }
         if debug_lowering {
-            print("emit-llvm: dbg-R2 recovery_text.length=" + number_to_string(recovery_text.length));
+            print.err("emit-llvm: dbg-R2 recovery_text.length=" + number_to_string(recovery_text.length));
         }
         if recovery_text.length == 0 {
             if fs.exists("build/sailfin/emit-native.tmp") {
                 if debug_lowering {
-                    print("emit-llvm: dbg-R3 reading emit-native.tmp");
+                    print.err("emit-llvm: dbg-R3 reading emit-native.tmp");
                 }
                 recovery_text = fs.readFile("build/sailfin/emit-native.tmp");
                 if debug_lowering {
-                    print("emit-llvm: dbg-R4 read emit-native.tmp bytes=" + number_to_string(recovery_text.length));
+                    print.err("emit-llvm: dbg-R4 read emit-native.tmp bytes=" + number_to_string(recovery_text.length));
                 }
             }
         }
         if debug_lowering {
-            print("emit-llvm: dbg-R5 before parse recovery_text.length=" + number_to_string(recovery_text.length));
+            print.err("emit-llvm: dbg-R5 before parse recovery_text.length=" + number_to_string(recovery_text.length));
         }
         if recovery_text.length > 0 {
             if debug_lowering {
-                print("emit-llvm: dbg-R6 calling parse_native_functions_from_text");
+                print.err("emit-llvm: dbg-R6 calling parse_native_functions_from_text");
             }
             let mut recovered_functions = parse_native_functions_from_text(recovery_text);
             let mut recovered_has_body = false;
@@ -366,7 +366,7 @@ fn sanitize_functions(
             if recovered_functions.length > 0 {
                 safe = recovered_functions;
                 if debug_lowering {
-                    print("emit-llvm: recovered empty parse.functions from artifact text count=" + number_to_string(safe.length));
+                    print.err("emit-llvm: recovered empty parse.functions from artifact text count=" + number_to_string(safe.length));
                 }
             }
         }
@@ -384,12 +384,12 @@ fn recover_safe_functions(
     debug_lowering: boolean
 ) -> NativeFunction[] ![io] {
     if debug_lowering {
-        print("emit-llvm: phase=recover_functions_start current=" + number_to_string(safe_functions.length));
+        print.err("emit-llvm: phase=recover_functions_start current=" + number_to_string(safe_functions.length));
     }
     let artifact_text = "";
     let recovered_safe = recover_functions_for_lowering(safe_functions, native_text_override_path, artifact_text, debug_lowering);
     if debug_lowering {
-        print("emit-llvm: phase=recover_functions_done current=" + number_to_string(recovered_safe.length));
+        print.err("emit-llvm: phase=recover_functions_done current=" + number_to_string(recovered_safe.length));
     }
     return recovered_safe;
 }

--- a/compiler/src/llvm/lowering/lowering_phase_types.sfn
+++ b/compiler/src/llvm/lowering/lowering_phase_types.sfn
@@ -138,7 +138,7 @@ fn serialize_enum_info(enums: NativeEnum[], _trace_enums: boolean) -> string ![i
     }
     fs.writeLines("build/sailfin/.enum_info", lines);
     if _trace_enums {
-        print("enum_trace: wrote .enum_info lines=" + number_to_string(lines.length));
+        print.err("enum_trace: wrote .enum_info lines=" + number_to_string(lines.length));
     }
     return "";
 }
@@ -160,7 +160,7 @@ fn build_type_context_with_recovery(
     // (No diagnostics from skipped fixup.)
 
     if debug_lowering {
-        print("emit-llvm: about to fixup_enum_layouts enums=" + number_to_string(combined_enums.length));
+        print.err("emit-llvm: about to fixup_enum_layouts enums=" + number_to_string(combined_enums.length));
     }
 
     // Serialize struct/enum info BEFORE the cross-module build_type_context call.
@@ -168,7 +168,7 @@ fn build_type_context_with_recovery(
     serialize_enum_info(fixed_enums_list, _trace_enums);
 
     if _trace_enums {
-        print("enum_trace: combined_enums=" + number_to_string(combined_enums.length) + " fixed_enums=" + number_to_string(fixed_enums_list.length));
+        print.err("enum_trace: combined_enums=" + number_to_string(combined_enums.length) + " fixed_enums=" + number_to_string(fixed_enums_list.length));
     }
 
     let type_build = build_type_context(combined_structs, fixed_enums_list, combined_interfaces);
@@ -217,10 +217,10 @@ fn build_type_context_with_recovery(
         }
     }
     if _trace_enums {
-        print("enum_trace: type_context.enums=" + number_to_string(type_context.enums.length));
+        print.err("enum_trace: type_context.enums=" + number_to_string(type_context.enums.length));
     }
     if debug_lowering {
-        print("emit-llvm: phase=type_context");
+        print.err("emit-llvm: phase=type_context");
     }
     return type_context;
 }
@@ -290,7 +290,7 @@ fn recover_enums_from_file(_trace_enums: boolean) -> EnumTypeInfo[] ![io] {
     }
     if recovered.length > 0 {
         if _trace_enums {
-            print("enum_trace: recovered " + number_to_string(recovered.length) + " enum(s) from .enum_info");
+            print.err("enum_trace: recovered " + number_to_string(recovered.length) + " enum(s) from .enum_info");
         }
     }
     return recovered;
@@ -386,7 +386,7 @@ fn serialize_context_functions(context_functions: NativeFunction[], debug_loweri
         cfw_i += 1;
     }
     if debug_lowering {
-        print("emit-llvm: serialized context_functions count=" + number_to_string(context_functions.length));
+        print.err("emit-llvm: serialized context_functions count=" + number_to_string(context_functions.length));
     }
     return context_functions.length;
 }

--- a/compiler/src/llvm/lowering/lowering_recovery.sfn
+++ b/compiler/src/llvm/lowering/lowering_recovery.sfn
@@ -53,6 +53,7 @@ import {
     make_native_struct_layout_field,
     make_instruction_text,
     make_instruction_simple,
+    make_instruction_for,
     update_function_return_type,
     update_function_effects,
     append_param_to_function,
@@ -149,6 +150,8 @@ fn recover_native_functions_light(native_text -> string) -> NativeFunction[] {
         let is_if_kw = starts_with_local(line, ".if ");
         let is_loop_kw = line == ".loop";
         let is_endloop_kw = line == ".endloop";
+        let is_for_kw = starts_with_local(line, ".for ");
+        let is_endfor_kw = line == ".endfor";
         let is_break_kw = line == "break";
         let is_continue_kw = line == "continue";
 
@@ -164,6 +167,12 @@ fn recover_native_functions_light(native_text -> string) -> NativeFunction[] {
         let param_arrow_idx = index_of(param_text_raw, " -> ");
         let param_name_raw = trim_text_local(substring(param_text_raw, 0, param_arrow_idx));
         let param_type_raw = trim_text_local(substring(param_text_raw, param_arrow_idx + 4, param_text_raw.length));
+
+        // Pre-compute .for target/iterable extraction.
+        let for_body_raw = trim_text_local(substring(line, 5, line.length));
+        let for_in_idx = index_of(for_body_raw, " in ");
+        let for_target_raw = trim_text_local(substring(for_body_raw, 0, for_in_idx));
+        let for_iterable_raw = trim_text_local(substring(for_body_raw, for_in_idx + 4, for_body_raw.length));
 
         // --- Struct tracking ---
         if is_struct_start {
@@ -390,6 +399,14 @@ fn recover_native_functions_light(native_text -> string) -> NativeFunction[] {
         }
         if is_endloop_kw {
             next_instruction = make_instruction_simple(9);
+        }
+        if is_for_kw {
+            if for_in_idx >= 0 {
+                next_instruction = make_instruction_for(for_target_raw, for_iterable_raw);
+            }
+        }
+        if is_endfor_kw {
+            next_instruction = make_instruction_simple(7);
         }
         if is_break_kw {
             next_instruction = make_instruction_simple(10);

--- a/compiler/src/llvm/lowering/lowering_recovery.sfn
+++ b/compiler/src/llvm/lowering/lowering_recovery.sfn
@@ -102,9 +102,9 @@ fn recover_native_functions_light(native_text -> string) -> NativeFunction[] {
     // FLAT: no nested ifs, no else-if chains.
     // Seed degenerate-if bug drops ALL nested conditions and else-if branches.
     // Every condition check must be a top-level if in the loop body.
-    print("DIAG: recover_native_functions_light input length=" + number_to_string(native_text.length));
+    print.err("DIAG: recover_native_functions_light input length=" + number_to_string(native_text.length));
     let lines = split_lines_local(native_text);
-    print("DIAG: split_lines_local returned lines=" + number_to_string(lines.length));
+    print.err("DIAG: split_lines_local returned lines=" + number_to_string(lines.length));
     let mut functions -> NativeFunction[] = [];
     let mut current -> NativeFunction? = null;
     let mut current_struct_name -> string = "";
@@ -189,9 +189,9 @@ fn recover_native_functions_light(native_text -> string) -> NativeFunction[] {
         // --- Flush current on function/method boundaries (FLAT — no nesting) ---
         if is_fn_start {
             if current != null {
-                print("DIAG: flush fn-start current=" + current.name + " functions.len=" + number_to_string(functions.length));
+                print.err("DIAG: flush fn-start current=" + current.name + " functions.len=" + number_to_string(functions.length));
                 functions = append_native_function(functions, current);
-                print("DIAG: after append functions.len=" + number_to_string(functions.length));
+                print.err("DIAG: after append functions.len=" + number_to_string(functions.length));
                 current = null;
             }
         }
@@ -205,9 +205,9 @@ fn recover_native_functions_light(native_text -> string) -> NativeFunction[] {
         }
         if is_fn_end {
             if current != null {
-                print("DIAG: flush fn-end current=" + current.name + " functions.len=" + number_to_string(functions.length));
+                print.err("DIAG: flush fn-end current=" + current.name + " functions.len=" + number_to_string(functions.length));
                 functions = append_native_function(functions, current);
-                print("DIAG: after append functions.len=" + number_to_string(functions.length));
+                print.err("DIAG: after append functions.len=" + number_to_string(functions.length));
                 current = null;
                 index += 1;
                 continue;
@@ -270,7 +270,7 @@ fn recover_native_functions_light(native_text -> string) -> NativeFunction[] {
             let fn_is_async = recover_function_is_async_from_header(line);
             current = make_native_function_basic(name, fn_is_async);
             fn_count += 1;
-            print("DIAG: found .fn #" + number_to_string(fn_count) + " name=" + name);
+            print.err("DIAG: found .fn #" + number_to_string(fn_count) + " name=" + name);
             index += 1;
             continue;
         }
@@ -421,7 +421,7 @@ fn recover_native_functions_light(native_text -> string) -> NativeFunction[] {
     if current != null {
         functions = append_native_function(functions, current);
     }
-    print("DIAG: recover_native_functions_light returning " + number_to_string(functions.length) + " functions");
+    print.err("DIAG: recover_native_functions_light returning " + number_to_string(functions.length) + " functions");
     return functions;
 }
 
@@ -639,7 +639,7 @@ fn recover_functions_for_lowering(current_functions -> NativeFunction[], native_
     let initial_function_count = sanitize_collection_length(safe_functions.length, 200000);
     if safe_functions.length != initial_function_count {
         if debug_lowering {
-            print("emit-llvm: invalid function list length; dropping current parsed functions");
+            print.err("emit-llvm: invalid function list length; dropping current parsed functions");
         }
         safe_functions = [];
     }
@@ -739,7 +739,7 @@ fn recover_functions_for_lowering(current_functions -> NativeFunction[], native_
                         replacement_functions = light_functions;
                     }
                     if debug_lowering {
-                        print(
+                        print.err(
                             "emit-llvm: replacing suspicious parsed functions with stable function parse"
                         );
                     }
@@ -767,7 +767,7 @@ fn recover_functions_for_lowering(current_functions -> NativeFunction[], native_
 
     let direct_count = parse_native_function_count_from_text(recovery_text);
     if debug_lowering {
-        print("emit-llvm: recovery source direct count=" + number_to_string(direct_count));
+        print.err("emit-llvm: recovery source direct count=" + number_to_string(direct_count));
     }
     if direct_count == 0 {
         if fs.exists("build/sailfin/emit-native.tmp") {
@@ -780,7 +780,7 @@ fn recover_functions_for_lowering(current_functions -> NativeFunction[], native_
     if parsed_recovery.length == recovered_count {
         if parsed_recovery.length > 0 {
             if debug_lowering {
-                print("emit-llvm: recovered functions via parse_native_functions_from_text=" + number_to_string(parsed_recovery.length));
+                print.err("emit-llvm: recovered functions via parse_native_functions_from_text=" + number_to_string(parsed_recovery.length));
             }
             return parsed_recovery;
         }
@@ -791,7 +791,7 @@ fn recover_functions_for_lowering(current_functions -> NativeFunction[], native_
     if light_recovery.length == light_recovered_count {
         if light_recovery.length > 0 {
             if debug_lowering {
-                print("emit-llvm: recovered functions via light parser=" + number_to_string(light_recovery.length));
+                print.err("emit-llvm: recovered functions via light parser=" + number_to_string(light_recovery.length));
             }
             return light_recovery;
         }

--- a/compiler/src/llvm/runtime_helpers.sfn
+++ b/compiler/src/llvm/runtime_helpers.sfn
@@ -30,10 +30,10 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
             effects: ["io"],
     });
 
-    // Legacy prefixed print variants — kept for backward compatibility with
-    // older compiled binaries and examples. New compiler code should use print().
-    // These will be removed once the log capsule is the recommended path and
-    // print.* is formally deprecated.
+    // Prefixed print variants — print.err/print.warn/print.error write to
+    // stderr; print.info writes to stdout with an [info] prefix.
+    // Compiler diagnostics should use print.err() so they do not pollute
+    // stdout (LLVM IR output, program output, etc.).
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
             target: "print.info",
             symbol: "sailfin_runtime_print_info",

--- a/compiler/src/llvm/runtime_helpers.sfn
+++ b/compiler/src/llvm/runtime_helpers.sfn
@@ -805,6 +805,32 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
             parameter_types: ["i8*", "i8*"],
             effects: ["io"],
     });
+    // Prelude functions called directly by their original name.
+    // These are defined in runtime/prelude.sfn and compiled into
+    // runtime__prelude.ll.  Cross-module calls reference them as
+    // @monotonic_millis, @find_char, etc. — they need declares in
+    // every module that calls them.
+    descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
+            target: "monotonic_millis",
+            symbol: "monotonic_millis",
+            return_type: "double",
+            parameter_types: [],
+            effects: ["clock"],
+    });
+    descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
+            target: "find_char",
+            symbol: "find_char",
+            return_type: "double",
+            parameter_types: ["i8*", "i8*", "double"],
+            effects: [],
+    });
+    descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
+            target: "string_starts_with",
+            symbol: "string_starts_with",
+            return_type: "i1",
+            parameter_types: ["i8*", "i8*"],
+            effects: [],
+    });
 
     return descriptors;
 }

--- a/compiler/src/llvm/runtime_helpers.sfn
+++ b/compiler/src/llvm/runtime_helpers.sfn
@@ -808,15 +808,11 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
     // Prelude functions called directly by their original name.
     // These are defined in runtime/prelude.sfn and compiled into
     // runtime__prelude.ll.  Cross-module calls reference them as
-    // @monotonic_millis, @find_char, etc. — they need declares in
-    // every module that calls them.
-    descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "monotonic_millis",
-            symbol: "monotonic_millis",
-            return_type: "double",
-            parameter_types: [],
-            effects: ["clock"],
-    });
+    // @find_char, etc. — they need declares in every module that
+    // calls them.
+    // Note: monotonic_millis is already registered above (target:
+    // "monotonic_millis" → sailfin_runtime_monotonic_millis) so it
+    // is not duplicated here.
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
             target: "find_char",
             symbol: "find_char",

--- a/compiler/src/main.sfn
+++ b/compiler/src/main.sfn
@@ -35,7 +35,7 @@ fn _ms_since(start_ms -> number) -> number {
 
 fn _timing_line(module_name -> string, phase -> string, elapsed_ms -> number) -> string {
     // Format is stable and grep/awk-friendly.
-    // Emit to stderr via print.warn.
+    // Emitted to stderr via print.err by the caller.
     return "[timing] module=" + module_name + " phase=" + phase + " ms=" + number_to_string(elapsed_ms);
 }
 
@@ -161,19 +161,19 @@ fn compile_to_llvm(source -> string) -> string ![io] {
     let trace_emit = fs.exists("build/sailfin/.trace_emit");
     let native_text = emit_native_text_with_module_name(program, "main");
     if trace_emit {
-        print("emit-llvm: native text bytes=" + number_to_string(native_text.length));
+        print.err("emit-llvm: native text bytes=" + number_to_string(native_text.length));
         if native_text.length > 0 {
             fs.writeFile("build/sailfin/debug-emit-native.sfn-asm", native_text);
-            print("emit-llvm: wrote build/sailfin/debug-emit-native.sfn-asm");
+            print.err("emit-llvm: wrote build/sailfin/debug-emit-native.sfn-asm");
         }
     }
     if native_text.length > 0 {
         let ir = lower_to_llvm_ir_from_text(native_text, "main");
         if trace_emit {
-            print("emit-llvm: llvm bytes=" + number_to_string(ir.length));
+            print.err("emit-llvm: llvm bytes=" + number_to_string(ir.length));
             if ir.length > 0 {
                 fs.writeFile("build/sailfin/debug-emit-llvm.ll", ir);
-                print("emit-llvm: wrote build/sailfin/debug-emit-llvm.ll");
+                print.err("emit-llvm: wrote build/sailfin/debug-emit-llvm.ll");
             }
         }
         return ir;
@@ -181,10 +181,10 @@ fn compile_to_llvm(source -> string) -> string ![io] {
     let native_result = emit_native_with_module_name(program, "main");
     let ir = lower_to_llvm_ir(native_result.module);
     if trace_emit {
-        print("emit-llvm: llvm bytes=" + number_to_string(ir.length));
+        print.err("emit-llvm: llvm bytes=" + number_to_string(ir.length));
         if ir.length > 0 {
             fs.writeFile("build/sailfin/debug-emit-llvm.ll", ir);
-            print("emit-llvm: wrote build/sailfin/debug-emit-llvm.ll");
+            print.err("emit-llvm: wrote build/sailfin/debug-emit-llvm.ll");
         }
     }
     return ir;
@@ -200,15 +200,15 @@ fn compile_to_llvm_with_module(source -> string, module_name -> string) -> strin
             return "";
         }
     } else {
-        print("emit-llvm: skipping typecheck (build/sailfin/.skip_typecheck present)");
+        print.err("emit-llvm: skipping typecheck (build/sailfin/.skip_typecheck present)");
     }
     let trace_emit = fs.exists("build/sailfin/.trace_emit");
     let native_text = emit_native_text_with_module_name(program, module_name);
     if trace_emit {
-        print("emit-llvm: native text bytes=" + number_to_string(native_text.length));
+        print.err("emit-llvm: native text bytes=" + number_to_string(native_text.length));
         if native_text.length > 0 {
             fs.writeFile("build/sailfin/debug-emit-native.sfn-asm", native_text);
-            print("emit-llvm: wrote build/sailfin/debug-emit-native.sfn-asm");
+            print.err("emit-llvm: wrote build/sailfin/debug-emit-native.sfn-asm");
         }
     }
     let mut ir -> string = "";
@@ -223,10 +223,10 @@ fn compile_to_llvm_with_module(source -> string, module_name -> string) -> strin
         ir = lower_to_llvm_ir(native_result.module);
     }
     if trace_emit {
-        print("emit-llvm: llvm bytes=" + number_to_string(ir.length));
+        print.err("emit-llvm: llvm bytes=" + number_to_string(ir.length));
         if ir.length > 0 {
             fs.writeFile("build/sailfin/debug-emit-llvm.ll", ir);
-            print("emit-llvm: wrote build/sailfin/debug-emit-llvm.ll");
+            print.err("emit-llvm: wrote build/sailfin/debug-emit-llvm.ll");
         }
     }
     return ir;
@@ -245,23 +245,23 @@ fn compile_to_llvm_with_module_timed(source -> string, module_name -> string) ->
         if typecheck_has_errors(program) {
             let diagnostics = typecheck_diagnostics(program);
             report_typecheck_errors(diagnostics, source);
-            print(_timing_line(module_name, "parse", t_parse));
-            print(_timing_line(module_name, "typecheck", t_typecheck));
+            print.err(_timing_line(module_name, "parse", t_parse));
+            print.err(_timing_line(module_name, "typecheck", t_typecheck));
             return "";
         }
     } else {
         t_typecheck = _ms_since(t1);
-        print("emit-llvm: skipping typecheck (build/sailfin/.skip_typecheck present)");
+        print.err("emit-llvm: skipping typecheck (build/sailfin/.skip_typecheck present)");
     }
 
     let t2 = monotonic_millis();
     let trace_emit = fs.exists("build/sailfin/.trace_emit");
     let native_text = emit_native_text_with_module_name(program, module_name);
     if trace_emit {
-        print("emit-llvm: native text bytes=" + number_to_string(native_text.length));
+        print.err("emit-llvm: native text bytes=" + number_to_string(native_text.length));
         if native_text.length > 0 {
             fs.writeFile("build/sailfin/debug-emit-native.sfn-asm", native_text);
-            print("emit-llvm: wrote build/sailfin/debug-emit-native.sfn-asm");
+            print.err("emit-llvm: wrote build/sailfin/debug-emit-native.sfn-asm");
         }
     }
     let t_emit_native = _ms_since(t2);
@@ -275,19 +275,19 @@ fn compile_to_llvm_with_module_timed(source -> string, module_name -> string) ->
         ir = lower_to_llvm_ir(native_result.module);
     }
     if trace_emit {
-        print("emit-llvm: llvm bytes=" + number_to_string(ir.length));
+        print.err("emit-llvm: llvm bytes=" + number_to_string(ir.length));
         if ir.length > 0 {
             fs.writeFile("build/sailfin/debug-emit-llvm.ll", ir);
-            print("emit-llvm: wrote build/sailfin/debug-emit-llvm.ll");
+            print.err("emit-llvm: wrote build/sailfin/debug-emit-llvm.ll");
         }
     }
     let t_lower_llvm = _ms_since(t3);
 
-    print(_timing_line(module_name, "parse", t_parse));
-    print(_timing_line(module_name, "typecheck", t_typecheck));
-    print(_timing_line(module_name, "emit_native", t_emit_native));
-    print(_timing_line(module_name, "lower_llvm", t_lower_llvm));
-    print(_timing_line(module_name, "total", _ms_since(t0)));
+    print.err(_timing_line(module_name, "parse", t_parse));
+    print.err(_timing_line(module_name, "typecheck", t_typecheck));
+    print.err(_timing_line(module_name, "emit_native", t_emit_native));
+    print.err(_timing_line(module_name, "lower_llvm", t_lower_llvm));
+    print.err(_timing_line(module_name, "total", _ms_since(t0)));
     return ir;
 }
 
@@ -306,7 +306,7 @@ fn compile_tests_to_llvm_file_with_module(source -> string, module_name -> strin
     if active_file { _if346 = true; }
     if _if346 {
         if trace {
-            print("test compiler: trace enabled (trace_file=true, active_file=true)");
+            print.err("test compiler: trace enabled (trace_file=true, active_file=true)");
         } else {
             let mut trace_text -> string = "false";
             if trace_file {
@@ -316,7 +316,7 @@ fn compile_tests_to_llvm_file_with_module(source -> string, module_name -> strin
             if active_file {
                 active_text = "true";
             }
-            print(
+            print.err(
                 "test compiler: trace disabled (trace_file="
                 + trace_text
                 + ", active_file="
@@ -326,7 +326,7 @@ fn compile_tests_to_llvm_file_with_module(source -> string, module_name -> strin
         }
     }
     if trace {
-        print("test compiler: parse_program start");
+        print.err("test compiler: parse_program start");
     }
     let program -> Program = parse_program(source);
     if typecheck_has_errors(program) {
@@ -335,12 +335,12 @@ fn compile_tests_to_llvm_file_with_module(source -> string, module_name -> strin
         return false;
     }
     if trace {
-        print("test compiler: emit_native_with_module_name start (module=" + module_name + ")");
+        print.err("test compiler: emit_native_with_module_name start (module=" + module_name + ")");
     }
     let native_text = emit_native_text_with_module_name(program, module_name);
     if trace {
-        print("test compiler: native text bytes=" + number_to_string(native_text.length));
-        print("test compiler: lower_to_llvm_for_tests start");
+        print.err("test compiler: native text bytes=" + number_to_string(native_text.length));
+        print.err("test compiler: lower_to_llvm_for_tests start");
     }
     if fs.exists(out_path) {
         fs.deleteFile(out_path);
@@ -348,7 +348,7 @@ fn compile_tests_to_llvm_file_with_module(source -> string, module_name -> strin
     if trace {
         if native_text.length > 0 {
             fs.writeFile("build/sailfin/debug-test-native.sfn-asm", native_text);
-            print("test compiler: wrote build/sailfin/debug-test-native.sfn-asm");
+            print.err("test compiler: wrote build/sailfin/debug-test-native.sfn-asm");
         }
     }
 
@@ -358,11 +358,11 @@ fn compile_tests_to_llvm_file_with_module(source -> string, module_name -> strin
     }
     let content = fs.readFile(out_path);
     if trace {
-        print("test compiler: write_llvm_ir_for_tests bytes=" + number_to_string(content.length));
+        print.err("test compiler: write_llvm_ir_for_tests bytes=" + number_to_string(content.length));
     }
     if content.length <= 4 {
         if trace {
-            print("test compiler: suspiciously short llvm output (len=" + number_to_string(content.length) + ")");
+            print.err("test compiler: suspiciously short llvm output (len=" + number_to_string(content.length) + ")");
         }
         return false;
     }
@@ -379,10 +379,10 @@ fn compile_to_native_text_with_module(source -> string, module_name -> string) -
     let trace_emit = fs.exists("build/sailfin/.trace_emit");
     let text = emit_native_text_with_module_name(program, module_name);
     if trace_emit {
-        print("emit-native: native text bytes=" + number_to_string(text.length));
+        print.err("emit-native: native text bytes=" + number_to_string(text.length));
         if text.length > 0 {
             fs.writeFile("build/sailfin/debug-emit-native.sfn-asm", text);
-            print("emit-native: wrote build/sailfin/debug-emit-native.sfn-asm");
+            print.err("emit-native: wrote build/sailfin/debug-emit-native.sfn-asm");
         }
     }
     return text;
@@ -496,7 +496,7 @@ fn compile_to_llvm_file_with_module(source -> string, module_name -> string, out
             return false;
         }
     } else {
-        print("emit-llvm-file: skipping typecheck (build/sailfin/.skip_typecheck present)");
+        print.err("emit-llvm-file: skipping typecheck (build/sailfin/.skip_typecheck present)");
     }
 
     let native_text_path = "build/sailfin/emit-native.tmp";
@@ -505,7 +505,7 @@ fn compile_to_llvm_file_with_module(source -> string, module_name -> string, out
     }
     let native_ok = emit_native_text_to_file_with_module_name(program, module_name, native_text_path);
     if !native_ok {
-        print("emit-llvm-file: empty native output for module " + module_name);
+        print.err("emit-llvm-file: empty native output for module " + module_name);
         let cached_native_path = "build/native/import-context/" + module_name + ".sfn-asm";
         if fs.exists(cached_native_path) {
             let cached_ok = write_llvm_ir_from_native_text_file(cached_native_path, module_name, out_path);
@@ -513,7 +513,7 @@ fn compile_to_llvm_file_with_module(source -> string, module_name -> string, out
                 if fs.exists(out_path) {
                     let cached_contents = fs.readFile(out_path);
                     if _looks_like_llvm_text(cached_contents) {
-                        print("emit-llvm-file: used cached native artifact fallback for module " + module_name);
+                        print.err("emit-llvm-file: used cached native artifact fallback for module " + module_name);
                         return true;
                     }
                 }
@@ -569,16 +569,16 @@ fn compile_to_llvm_file_with_module(source -> string, module_name -> string, out
                 let header = "source_filename = \"" + module_name + ".sfn\"\n\n";
                 fs.writeFile(out_path, header + written);
                 output_valid = true;
-                print("emit-llvm-file: prepended header for module " + module_name);
+                print.err("emit-llvm-file: prepended header for module " + module_name);
             }
         }
         if !output_valid {
-            print("emit-llvm-file: malformed llvm output for module " + module_name + "; falling back");
+            print.err("emit-llvm-file: malformed llvm output for module " + module_name + "; falling back");
         }
     }
     if !output_valid {
         if !ok {
-            print("emit-llvm-file: empty llvm output for module " + module_name);
+            print.err("emit-llvm-file: empty llvm output for module " + module_name);
         }
         let llvm_text = compile_to_llvm_with_module(source, module_name);
         if _looks_like_llvm_text(llvm_text) {
@@ -626,7 +626,7 @@ fn report_typecheck_errors(entries -> Diagnostic[], source -> string) ![io] {
         let message = formatted[index];
         let lines = split_source_lines(message);
         if lines.length == 0 {
-            print(prefix);
+            print.err(prefix);
             index += 1;
             continue;
         }
@@ -636,9 +636,9 @@ fn report_typecheck_errors(entries -> Diagnostic[], source -> string) ![io] {
                 break;
             }
             if line_index == 0 {
-                print(prefix + lines[line_index]);
+                print.err(prefix + lines[line_index]);
             } else {
-                print(padding + lines[line_index]);
+                print.err(padding + lines[line_index]);
             }
             line_index += 1;
         }

--- a/compiler/src/parser/mod.sfn
+++ b/compiler/src/parser/mod.sfn
@@ -61,7 +61,7 @@ fn parse_tokens(tokens -> Token[]) -> Program {
         statements = append_statement(statements, result.statement);
         parser = skip_trivia(parser);
         if parser.index == prev_index {
-            print("parser: no progress; aborting to avoid infinite loop");
+            print.err("parser: no progress; aborting to avoid infinite loop");
             break;
         }
     }

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -428,39 +428,8 @@ stage_import_context() {
 
     echo "$native_text" > "$asm_dest"
 
-    # Extract .layout lines for the manifest.
-    # The native emitter may indent .layout lines (e.g. inside struct blocks),
-    # so match with optional leading whitespace.
-    grep '\.layout ' "$asm_dest" > "$manifest_dest" 2>/dev/null || true
-
-    # Reduce native text to a lightweight skeleton that retains module
-    # metadata, import declarations, and function signatures but strips
-    # function instruction bodies.  The full native text causes OOM in
-    # early seed compilers because the transitive import BFS loads all
-    # texts into memory.  The skeleton keeps the BFS working (imports
-    # are preserved) while drastically reducing memory pressure.
-    local full_dest="${asm_dest}.full"
-    mv "$asm_dest" "$full_dest"
-    awk '
-    # Always keep module, import, struct, enum, layout declarations
-    /^\.(module|import|struct|enum|end-struct|end-enum|endenum|endstruct|layout|end-layout)/ { print; next }
-    # Keep indented .layout lines (inside struct/enum blocks)
-    /^[[:space:]]+\.layout / { print; next }
-    # Keep .field and .variant lines (struct/enum body declarations)
-    /^[[:space:]]+\.(field|variant) / { print; next }
-    # Keep function signature line (.fn) and end marker (.endfn)
-    /^\.fn / { print; infn=1; next }
-    /^\.endfn/ { print; infn=0; next }
-    # Inside a function keep metadata but skip body instructions
-    # Note: .meta lines are unindented but .param/.span lines may be indented
-    infn && /^[[:space:]]*\.(meta|param|return)/ { print; next }
-    infn { next }
-    # Keep top-level let bindings (module bindings)
-    /^\.let / { print; next }
-    # Skip everything else
-    { next }
-    ' "$full_dest" > "$asm_dest"
-    rm -f "$full_dest"
+    # Extract .layout lines for the manifest
+    grep '^\.\(layout\)' "$asm_dest" > "$manifest_dest" 2>/dev/null || true
 }
 
 # Stage import context (sequential for safety with older seeds)

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -128,43 +128,6 @@ seed_run() {
     fi
 }
 
-# Strip CLI log prefixes from LLVM IR output and trim to module start.
-# Legacy seed compilers (< v0.5) prefix lines with "[info] ", "[warn] ", etc.
-# because they used print.info() instead of raw print(). This can be removed
-# once the seed is built from a version that uses raw print().
-strip_log_prefixes() {
-    local input="$1"
-    local output="$2"
-
-    # Step 1: strip [level] prefixes (e.g. "[info] source_filename" → "source_filename")
-    # Step 2: find first LLVM top-level line and drop everything before it
-    awk '
-    {
-        line = $0
-        # Strip log prefixes like [info], [debug], [warn]
-        if (substr(line, 1, 1) == "[") {
-            idx = index(line, "] ")
-            if (idx > 0) {
-                line = substr(line, idx + 2)
-            }
-        }
-
-        # Once we find the first LLVM top-level entity, start outputting
-        if (!started) {
-            trimmed = line
-            gsub(/^[[:space:]]+/, "", trimmed)
-            if (trimmed == "") next
-            if (trimmed ~ /^(source_filename =|; ModuleID =|target |declare |define |%|@|;|!|attributes )/) {
-                started = 1
-            } else {
-                next
-            }
-        }
-        print line
-    }
-    ' "$input" > "$output"
-}
-
 # ---------------------------------------------------------------------------
 # Find llvm-link
 # ---------------------------------------------------------------------------
@@ -330,14 +293,14 @@ build_module() {
     local abs_ll_raw="${abs_ll_path}.raw"
 
     # Prefer emit-llvm-file if available (produces link-safe IR)
-    # Run from module_cwd so the seed picks up staged import-context
+    # Run from module_cwd so the seed picks up staged import-context.
+    # Diagnostics go to stderr (via print.err) so stdout/file output is clean LLVM IR.
     local emit_ok=0
     if "$SEED" emit-llvm-file --help &>/dev/null 2>&1 || "$SEED" help 2>&1 | grep -q "emit-llvm-file"; then
         # Tolerate segfault during cleanup if the output file was written
         (cd "$module_cwd" && seed_run "$SEED" emit-llvm-file "$abs_src" "$abs_ll_raw") 2>/dev/null || true
         if [[ -s "$abs_ll_raw" ]]; then
-            strip_log_prefixes "$abs_ll_raw" "$ll_path"
-            rm -f "$abs_ll_raw"
+            mv "$abs_ll_raw" "$ll_path"
             emit_ok=1
         fi
     fi
@@ -351,10 +314,7 @@ build_module() {
             echo "[build] FAIL: seed emit produced no output for $module_name" >&2
             return 1
         fi
-        # Strip CLI log prefixes (e.g. "[info] source_filename = ...")
-        # and trim to the first LLVM top-level entity
-        strip_log_prefixes "$abs_ll_raw" "$ll_path"
-        rm -f "$abs_ll_raw"
+        mv "$abs_ll_raw" "$ll_path"
     fi
 
     # Validate: output must look like LLVM IR

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -6,9 +6,11 @@
 #
 #   1. Enumerate compiler/src/**/*.sfn + runtime/**/*.sfn
 #   2. Stage import-context artifacts (seed emit native → .sfn-asm + .layout-manifest)
-#   3. Per-module: seed emit llvm → .ll, clang compile → .o
-#   4. llvm-link all modules (except prelude) → linked bitcode
-#   5. Compile C runtime, link everything → final binary
+#   3. Per-module: seed emit llvm → .ll
+#   4. Compile each .ll → .o with clang
+#   5. llvm-link all modules (except prelude) → linked bitcode
+#   6. Compile C runtime
+#   7. Link everything → final binary
 #
 # NO fixup passes. If the compiler emits broken LLVM IR, the build fails.
 # Fix the compiler, not the build script.
@@ -509,309 +511,7 @@ log "compiled ${#MODULE_NAMES[@]} modules"
 printf '%s\n' "${MODULE_NAMES[@]}" > "$RAW_DIR/modules.txt"
 
 # ---------------------------------------------------------------------------
-# Step 3.4: Cross-module type resolution
-# ---------------------------------------------------------------------------
-# When modules are compiled separately, imported struct types appear as
-# `%Name = type opaque` because the compiler doesn't have a header/metadata
-# system.  This step collects all concrete (non-opaque) type definitions from
-# every module and replaces opaque stubs where a concrete definition exists.
-# This is standard separate-compilation infrastructure (analogous to C headers
-# or Rust .rmeta files), not a fixup for broken IR.
-log "resolving cross-module types..."
-
-# Build global type table: %TypeName -> full definition line
-TYPETAB="$RAW_DIR/.typetab"
-> "$TYPETAB"
-for ll in "$RAW_DIR"/*.ll; do
-    # Collect concrete type definitions (lines like: %Foo = type { ... })
-    grep -P '^%[A-Z]\w+ = type \{' "$ll" >> "$TYPETAB" 2>/dev/null || true
-done
-# Deduplicate, keeping first occurrence (most specific)
-awk -F' = ' '!seen[$1]++' "$TYPETAB" > "${TYPETAB}.dedup"
-mv "${TYPETAB}.dedup" "$TYPETAB"
-
-# Use a Python helper for iterative type resolution (handles cascading
-# dependencies where injecting a concrete type introduces references to
-# other types not yet declared in the module).
-_type_output=$(python3 - "$RAW_DIR" "$TYPETAB" <<'PYEOF'
-import sys, os, re
-
-raw_dir = sys.argv[1]
-typetab_path = sys.argv[2]
-
-# Load global type table
-type_defs = {}  # %Name -> full line
-with open(typetab_path) as f:
-    for line in f:
-        line = line.rstrip("\n")
-        m = re.match(r'^(%\w+) = type \{', line)
-        if m:
-            type_defs[m.group(1)] = line
-
-# Legitimately opaque types (runtime internals)
-SKIP_TYPES = {"%SailfinFutureNumber", "%SailfinFutureBool", "%SailfinFuturePtr",
-              "%SailfinFutureVoid", "%SailfinFutureString",
-              "%SailfinChannelNumber", "%SailfinChannelBool", "%SailfinChannelPtr",
-              "%SailfinChannelVoid", "%SailfinChannelString"}
-
-total_fixes = 0
-
-for fname in sorted(os.listdir(raw_dir)):
-    if not fname.endswith(".ll"):
-        continue
-    fpath = os.path.join(raw_dir, fname)
-    with open(fpath) as f:
-        text = f.read()
-    lines = text.split("\n")
-
-    # Iterate until stable (cascading type deps)
-    changed = True
-    passes = 0
-    while changed and passes < 20:
-        changed = False
-        passes += 1
-
-        # Build set of types declared/defined in this module
-        declared_types = set()
-        for ln in lines:
-            m = re.match(r'^(%\w+) = type ', ln)
-            if m:
-                declared_types.add(m.group(1))
-
-        # Phase 1: Replace opaque stubs with concrete defs
-        new_lines = []
-        for ln in lines:
-            m = re.match(r'^(%\w+) = type opaque$', ln)
-            if m:
-                tname = m.group(1)
-                if tname not in SKIP_TYPES and tname in type_defs:
-                    new_lines.append(type_defs[tname])
-                    total_fixes += 1
-                    changed = True
-                    continue
-            new_lines.append(ln)
-        lines = new_lines
-
-        # Phase 2: Find ALL type references (in type defs, signatures, and body)
-        all_refs = set()
-        for ln in lines:
-            for ref in re.findall(r'%[A-Z]\w+', ln):
-                all_refs.add(ref)
-
-        # Rebuild declared types set after phase 1
-        declared_types = set()
-        for ln in lines:
-            m = re.match(r'^(%\w+) = type ', ln)
-            if m:
-                declared_types.add(m.group(1))
-
-        missing = all_refs - declared_types
-        if missing:
-            # Find insertion point (after last type def line, or at line 1)
-            insert_idx = 0
-            for i, ln in enumerate(lines):
-                if re.match(r'^%\w+ = type ', ln):
-                    insert_idx = i + 1
-            inject = []
-            for tname in sorted(missing):
-                if tname in SKIP_TYPES:
-                    continue
-                if tname in type_defs:
-                    inject.append(type_defs[tname])
-                    total_fixes += 1
-                else:
-                    # No concrete def known — insert opaque stub so LLVM can parse
-                    inject.append(f"{tname} = type opaque")
-                changed = changed or bool(inject)
-            if inject:
-                for j, inj_line in enumerate(inject):
-                    lines.insert(insert_idx + j, inj_line)
-
-    # Phase 3: Fix `store %Struct null` → `store %Struct zeroinitializer`
-    # When types are resolved from opaque to concrete, `null` is no longer
-    # valid for aggregate (non-pointer) types.
-    concrete_types = set()
-    for ln in lines:
-        m = re.match(r'^(%\w+) = type \{', ln)
-        if m:
-            concrete_types.add(m.group(1))
-    new_lines = []
-    for ln in lines:
-        m = re.match(r'^(\s+store )(%\w+)( null,)(.+)$', ln)
-        if m and m.group(2) in concrete_types:
-            new_lines.append(m.group(1) + m.group(2) + " zeroinitializer," + m.group(4))
-            total_fixes += 1
-        else:
-            new_lines.append(ln)
-    lines = new_lines
-
-    with open(fpath, "w") as f:
-        f.write("\n".join(lines))
-
-print(total_fixes, flush=True)
-PYEOF
-)
-log "cross-module type resolution: ${_type_output} fix(es)"
-
-# ---------------------------------------------------------------------------
-# Step 3.5: Cross-module symbol resolution
-# ---------------------------------------------------------------------------
-# The seed compiler may not emit `declare` statements for functions defined
-# in other modules.  This step collects all `define` signatures across modules
-# and injects matching `declare` statements where a function is called but
-# neither defined nor declared.  This is analogous to what a linker does —
-# it is NOT a fixup for broken IR.
-log "resolving cross-module symbols..."
-
-# Build a global symbol table: symbol -> declare line
-SYMTAB="$RAW_DIR/.symtab"
-> "$SYMTAB"
-for ll in "$RAW_DIR"/*.ll; do
-    grep '^define ' "$ll" | sed 's/^define /declare /; s/ internal / /; s/ {$//' >> "$SYMTAB"
-done
-sort -t'@' -k2,2 -u "$SYMTAB" -o "$SYMTAB"
-
-# Add C runtime functions that the compiler references but are defined in
-# the C runtime library (linked at the final step, not in any .ll module).
-# These declarations match runtime/native/include/sailfin_runtime.h.
-cat >> "$SYMTAB" <<'RUNTIME_DECLS'
-declare double @print(i8*)
-declare i8* @calloc(i64, i64)
-declare void @sailfin_runtime_set_exception(i8*)
-declare i8* @sailfin_runtime_take_exception()
-declare i1 @sailfin_runtime_has_exception()
-declare void @sailfin_runtime_clear_exception()
-declare double @sailfin_runtime_string_to_number(i8*)
-declare void @sailfin_runtime_log_execution(i8*, i8*)
-declare i1 @sailfin_intrinsic_fs_exists(i8*)
-declare i8* @sailfin_adapter_fs_read_file(i8*)
-declare void @sailfin_adapter_fs_write_file(i8*, i8*)
-declare void @sailfin_adapter_fs_append_file(i8*, i8*)
-declare void @sailfin_adapter_fs_write_lines(i8*, { i8**, i64 }*)
-declare { i8**, i64 }* @sailfin_adapter_fs_list_directory(i8*)
-declare i1 @sailfin_adapter_fs_delete_file(i8*)
-declare i1 @sailfin_adapter_fs_create_directory(i8*, i1)
-declare double @sailfin_runtime_process_run({ i8**, i64 }*)
-declare { i8**, i64 }* @sailfin_runtime_concat({ i8**, i64 }*, { i8**, i64 }*)
-RUNTIME_DECLS
-
-# For each module, find called-but-undeclared symbols and inject declares.
-# Uses comm(1) + grep -f for fast batch lookup (avoids O(n*m) bash loops).
-for ll in "$RAW_DIR"/*.ll; do
-    called_f="$(mktemp)"
-    known_f="$(mktemp)"
-    missing_f="$(mktemp)"
-    # Extract called symbols (|| true: grep returns 1 when no matches, which kills pipefail)
-    { grep -oP '(?<=@)[a-zA-Z_][a-zA-Z0-9_]*(?=\()' "$ll" 2>/dev/null || true; } | sort -u > "$called_f"
-    # Extract declared/defined symbols
-    { grep -P '^(declare|define) ' "$ll" || true; } | { grep -oP '(?<=@)[a-zA-Z_][a-zA-Z0-9_]*(?=\()' || true; } | sort -u > "$known_f"
-    # Set difference
-    comm -23 "$called_f" "$known_f" > "$missing_f"
-    rm -f "$called_f" "$known_f"
-
-    if [[ -s "$missing_f" ]]; then
-        # Build grep patterns for batch symtab lookup
-        inject_f="$(mktemp)"
-        while IFS= read -r sym; do
-            grep -m1 "@${sym}(" "$SYMTAB" >> "$inject_f" 2>/dev/null || true
-        done < "$missing_f"
-
-        if [[ -s "$inject_f" ]]; then
-            # Insert after the last `declare` line, or before first `define`
-            last_declare=$(grep -n '^declare ' "$ll" | tail -1 | cut -d: -f1 || true)
-            if [[ -n "$last_declare" ]]; then
-                sed -i "${last_declare}r ${inject_f}" "$ll"
-            else
-                first_define=$(grep -n '^define ' "$ll" | head -1 | cut -d: -f1 || true)
-                if [[ -n "$first_define" ]]; then
-                    sed -i "$((first_define-1))r ${inject_f}" "$ll"
-                fi
-            fi
-        fi
-        rm -f "$inject_f"
-    fi
-    rm -f "$missing_f"
-done
-log "cross-module symbol resolution complete"
-
-# ---------------------------------------------------------------------------
-# Step 3.55: Second type resolution pass
-# ---------------------------------------------------------------------------
-# Symbol resolution may have injected `declare` lines referencing types not
-# yet present in the module. Run the type resolver again to pick these up.
-log "resolving cross-module types (pass 2)..."
-_type_output2=$(python3 - "$RAW_DIR" "$TYPETAB" <<'PYEOF2'
-import sys, os, re
-
-raw_dir = sys.argv[1]
-typetab_path = sys.argv[2]
-
-type_defs = {}
-with open(typetab_path) as f:
-    for line in f:
-        line = line.rstrip("\n")
-        m = re.match(r'^(%\w+) = type \{', line)
-        if m:
-            type_defs[m.group(1)] = line
-
-SKIP_TYPES = {"%SailfinFutureNumber", "%SailfinFutureBool", "%SailfinFuturePtr",
-              "%SailfinFutureVoid", "%SailfinFutureString",
-              "%SailfinChannelNumber", "%SailfinChannelBool", "%SailfinChannelPtr",
-              "%SailfinChannelVoid", "%SailfinChannelString"}
-
-total_fixes = 0
-
-for fname in sorted(os.listdir(raw_dir)):
-    if not fname.endswith(".ll"):
-        continue
-    fpath = os.path.join(raw_dir, fname)
-    with open(fpath) as f:
-        lines = f.read().split("\n")
-
-    changed = True
-    while changed:
-        changed = False
-        declared_types = set()
-        for ln in lines:
-            m = re.match(r'^(%\w+) = type ', ln)
-            if m:
-                declared_types.add(m.group(1))
-
-        all_refs = set()
-        for ln in lines:
-            for ref in re.findall(r'%[A-Z]\w+', ln):
-                all_refs.add(ref)
-
-        missing = all_refs - declared_types
-        if not missing:
-            break
-        insert_idx = 0
-        for i, ln in enumerate(lines):
-            if re.match(r'^%\w+ = type ', ln):
-                insert_idx = i + 1
-        inject = []
-        for tname in sorted(missing):
-            if tname in SKIP_TYPES:
-                continue
-            if tname in type_defs:
-                inject.append(type_defs[tname])
-                total_fixes += 1
-            else:
-                inject.append(f"{tname} = type opaque")
-            changed = True
-        for j, inj_line in enumerate(inject):
-            lines.insert(insert_idx + j, inj_line)
-
-    with open(fpath, "w") as f:
-        f.write("\n".join(lines))
-
-print(total_fixes, flush=True)
-PYEOF2
-)
-log "cross-module type resolution (pass 2): ${_type_output2} fix(es)"
-
-# ---------------------------------------------------------------------------
-# Step 3.6: Compile all modules with clang
+# Step 4: Compile all modules with clang
 # ---------------------------------------------------------------------------
 log "compiling ${#MODULE_NAMES[@]} modules with clang..."
 FAILED=0
@@ -824,7 +524,7 @@ done
 [[ "$FAILED" -eq 0 ]] || die "clang compilation failed (see errors above)"
 
 # ---------------------------------------------------------------------------
-# Step 4: llvm-link all modules (except prelude)
+# Step 5: llvm-link all modules (except prelude)
 # ---------------------------------------------------------------------------
 log "linking LLVM IR modules..."
 LLVM_LINK="$(find_llvm_link)"
@@ -864,7 +564,7 @@ mkdir -p "$OBJ_DIR/runtime"
 run "$CLANG" $CLANG_FLAGS -fPIC -c "$PRELUDE_LL" -o "$PRELUDE_O"
 
 # ---------------------------------------------------------------------------
-# Step 5: Compile C runtime
+# Step 6: Compile C runtime
 # ---------------------------------------------------------------------------
 log "compiling C runtime..."
 INCLUDE_DIR="$REPO_ROOT/runtime/native/include"
@@ -881,7 +581,7 @@ run "$CLANG" $CLANG_FLAGS -I "$INCLUDE_DIR" -c runtime/native/src/native_driver.
 run "$CLANG" $CLANG_FLAGS -c runtime/native/ir/runtime_globals.ll -o "$OBJ_DIR/runtime_globals.o"
 
 # ---------------------------------------------------------------------------
-# Step 6: Link final binary
+# Step 7: Link final binary
 # ---------------------------------------------------------------------------
 log "linking final binary..."
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -296,11 +296,13 @@ build_module() {
     # Run from module_cwd so the seed picks up staged import-context.
     # Diagnostics go to stderr (via print.err) so stdout/file output is clean LLVM IR.
     local emit_ok=0
+    local stderr_log="${abs_ll_path}.stderr"
     if "$SEED" emit-llvm-file --help &>/dev/null 2>&1 || "$SEED" help 2>&1 | grep -q "emit-llvm-file"; then
         # Tolerate segfault during cleanup if the output file was written
-        (cd "$module_cwd" && seed_run "$SEED" emit-llvm-file "$abs_src" "$abs_ll_raw") 2>/dev/null || true
+        (cd "$module_cwd" && seed_run "$SEED" emit-llvm-file "$abs_src" "$abs_ll_raw") 2>"$stderr_log" || true
         if [[ -s "$abs_ll_raw" ]]; then
             mv "$abs_ll_raw" "$ll_path"
+            rm -f "$stderr_log"
             emit_ok=1
         fi
     fi
@@ -309,9 +311,11 @@ build_module() {
     if [[ "$emit_ok" -eq 0 ]]; then
         # The first-pass binary may segfault during cleanup after writing valid LLVM IR.
         # Tolerate non-zero exit if the output file contains valid LLVM IR.
-        (cd "$module_cwd" && seed_run "$SEED" emit llvm "$abs_src") > "$abs_ll_raw" 2>/dev/null || true
+        (cd "$module_cwd" && seed_run "$SEED" emit llvm "$abs_src") > "$abs_ll_raw" 2>"$stderr_log" || true
         if [[ ! -s "$abs_ll_raw" ]]; then
             echo "[build] FAIL: seed emit produced no output for $module_name" >&2
+            [[ -s "$stderr_log" ]] && cat "$stderr_log" >&2
+            rm -f "$stderr_log"
             return 1
         fi
         mv "$abs_ll_raw" "$ll_path"
@@ -321,8 +325,11 @@ build_module() {
     if ! head -20 "$ll_path" | grep -qE "define|declare|target|source_filename|ModuleID"; then
         echo "[build] FAIL: seed output for $module_name is not valid LLVM IR" >&2
         head -5 "$ll_path" >&2
+        [[ -s "$stderr_log" ]] && cat "$stderr_log" >&2
+        rm -f "$stderr_log"
         return 1
     fi
+    rm -f "$stderr_log"
 
     echo "$module_name"
     return 0

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -428,8 +428,10 @@ stage_import_context() {
 
     echo "$native_text" > "$asm_dest"
 
-    # Extract .layout lines for the manifest
-    grep '^\.\(layout\)' "$asm_dest" > "$manifest_dest" 2>/dev/null || true
+    # Extract .layout lines for the manifest.
+    # The native emitter may indent .layout lines (e.g. inside struct blocks),
+    # so match with optional leading whitespace.
+    grep '\.layout ' "$asm_dest" > "$manifest_dest" 2>/dev/null || true
 
     # Reduce native text to a lightweight skeleton that retains module
     # metadata, import declarations, and function signatures but strips

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -452,7 +452,8 @@ stage_import_context() {
     /^\.fn / { print; infn=1; next }
     /^\.endfn/ { print; infn=0; next }
     # Inside a function keep metadata but skip body instructions
-    infn && /^\.(meta|param|return)/ { print; next }
+    # Note: .meta lines are unindented but .param/.span lines may be indented
+    infn && /^[[:space:]]*\.(meta|param|return)/ { print; next }
     infn { next }
     # Keep top-level let bindings (module bindings)
     /^\.let / { print; next }

--- a/scripts/selfhost_native.py
+++ b/scripts/selfhost_native.py
@@ -10242,7 +10242,7 @@ def _prepare_seed_import_context(
             if idx % 10 == 0 or idx + 1 == len(sources):
                 print(
                     f"[selfhost] staging {idx + 1}/{len(sources)} import artifact(s)...",
-                    flush=True,
+                    file=sys.stderr, flush=True,
                 )
             _emit_one(p)
         return
@@ -10258,7 +10258,7 @@ def _prepare_seed_import_context(
             if completed % 10 == 0 or completed == len(sources):
                 print(
                     f"[selfhost] staged {completed}/{len(sources)} import artifact(s)...",
-                    flush=True,
+                    file=sys.stderr, flush=True,
                 )
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=jobs) as pool:
@@ -10495,7 +10495,7 @@ def main(argv: list[str]) -> int:
             resolved = seed
 
         if resolved == default_seed.resolve() and asan_seed.exists():
-            print(f"[selfhost] using ASAN seed: {asan_seed}")
+            print(f"[selfhost] using ASAN seed: {asan_seed}", file=sys.stderr)
             seed = asan_seed
 
     # Default timeouts: ASAN seeds can be much slower and may spuriously hit the
@@ -10547,7 +10547,7 @@ def main(argv: list[str]) -> int:
                 return out.splitlines()[0]
         return "(unknown version)"
 
-    print(f"[selfhost] seed: {seed} ({_seed_version(seed)})", flush=True)
+    print(f"[selfhost] seed: {seed} ({_seed_version(seed)})", file=sys.stderr, flush=True)
 
     seed_supports_emit_llvm_file = _seed_supports_emit_llvm_file(seed)
     # Default behaviour: prefer emit-llvm-file when the seed supports it.
@@ -10592,26 +10592,26 @@ def main(argv: list[str]) -> int:
             return False
 
         def _print_timing_summary(*, header: str, module_list: list[str]) -> None:
-            print(f"[selfhost] ({pass_name}) {header}:", flush=True)
+            print(f"[selfhost] ({pass_name}) {header}:", file=sys.stderr, flush=True)
             print(
                 "[selfhost] "
                 f"timing_enabled={bool(args.timing)} timed_modules={len(timing_by_module)}",
-                flush=True,
+                file=sys.stderr, flush=True,
             )
             print(
                 "[selfhost] "
                 f"attempts={seed_attempts_total} retried_modules={modules_retried} "
                 f"timeouts={seed_timeouts} seed_failures={seed_failures} "
                 f"clang_validations={clang_validations} clang_validation_failures={clang_validation_failures}",
-                flush=True,
+                file=sys.stderr, flush=True,
             )
-            print(f"[selfhost] seed emit: {seed_emit_s:.2f}s", flush=True)
+            print(f"[selfhost] seed emit: {seed_emit_s:.2f}s", file=sys.stderr, flush=True)
             print(
-                f"[selfhost] clang module compile: {clang_validate_s:.2f}s", flush=True
+                f"[selfhost] clang module compile: {clang_validate_s:.2f}s", file=sys.stderr, flush=True
             )
             print(
-                f"[selfhost] clang compile: {clang_compile_s:.2f}s", flush=True)
-            print(f"[selfhost] clang link: {clang_link_s:.2f}s", flush=True)
+                f"[selfhost] clang compile: {clang_compile_s:.2f}s", file=sys.stderr, flush=True)
+            print(f"[selfhost] clang link: {clang_link_s:.2f}s", file=sys.stderr, flush=True)
 
             if args.timing and timing_by_module and module_list:
                 def _phase_ms(name: str, phase: str) -> int:
@@ -10624,7 +10624,7 @@ def main(argv: list[str]) -> int:
                 )
 
                 print(
-                    f"[selfhost] ({pass_name}) slowest modules by lower_llvm (ms):", flush=True)
+                    f"[selfhost] ({pass_name}) slowest modules by lower_llvm (ms):", file=sys.stderr, flush=True)
                 for name in ranked[:20]:
                     phases = timing_by_module.get(name, {})
                     parse_ms = phases.get("parse", 0)
@@ -10635,7 +10635,7 @@ def main(argv: list[str]) -> int:
                     print(
                         "[selfhost] "
                         f"{name} parse={parse_ms} typecheck={type_ms} emit_native={emit_ms} lower_llvm={lower_ms} total={total_ms}",
-                        flush=True,
+                        file=sys.stderr, flush=True,
                     )
 
         work_dir = args.work_dir.resolve()
@@ -10745,7 +10745,7 @@ def main(argv: list[str]) -> int:
         }
         # Populate an isolated import-context cache for the seed compiler.
         print(
-            f"[selfhost] ({pass_name}) staging import artifacts...", flush=True)
+            f"[selfhost] ({pass_name}) staging import artifacts...", file=sys.stderr, flush=True)
         _prepare_seed_import_context(
             seed_bin=seed_bin,
             sources=sources,
@@ -10784,7 +10784,7 @@ def main(argv: list[str]) -> int:
                 if _candidate_src is not None:
                     print(
                         f"[selfhost][warn] ({pass_name}) truncated import-context artifact: {_rel} – regenerating",
-                        flush=True,
+                        file=sys.stderr, flush=True,
                     )
                     try:
                         _seed_emit_native_text(
@@ -10804,7 +10804,7 @@ def main(argv: list[str]) -> int:
         if _repaired_count:
             print(
                 f"[selfhost] ({pass_name}) repaired {_repaired_count} truncated import-context artifact(s)",
-                flush=True,
+                file=sys.stderr, flush=True,
             )
 
         # Pre-seed known enum types from layout manifests in the import-context.
@@ -10844,7 +10844,7 @@ def main(argv: list[str]) -> int:
         if known_named_type_defs:
             print(
                 f"[selfhost] ({pass_name}) pre-seeded {len(known_named_type_defs)} enum type(s) from layout manifests",
-                flush=True,
+                file=sys.stderr, flush=True,
             )
 
         try:
@@ -11013,7 +11013,7 @@ def main(argv: list[str]) -> int:
 
                     print(
                         f"[selfhost] ({pass_name}) module {idx + 1}/{len(sources)} {module_name} attempt {attempt}/{max_attempts}",
-                        flush=True,
+                        file=sys.stderr, flush=True,
                     )
 
                     attempt_path = raw_dir / \
@@ -12292,7 +12292,7 @@ def main(argv: list[str]) -> int:
             # Keep this as info/warn output rather than failing: this is often
             # recoverable (e.g. concrete vs opaque across modules).
             for w in canonical_warnings:
-                print(f"[selfhost][warn] ({pass_name}) {w}", flush=True)
+                print(f"[selfhost][warn] ({pass_name}) {w}", file=sys.stderr, flush=True)
 
         # Rewrite each module to:
         # - declare any missing referenced named types as opaque
@@ -12314,10 +12314,10 @@ def main(argv: list[str]) -> int:
         if pre_dedupe_changes > 0:
             print(
                 f"[selfhost] ({pass_name}) pre-link deduped {pre_dedupe_changes} duplicate public definitions",
-                flush=True,
+                file=sys.stderr, flush=True,
             )
         for warn_line in pre_dedupe_warnings[:40]:
-            print(f"[selfhost][warn] ({pass_name}) {warn_line}", flush=True)
+            print(f"[selfhost][warn] ({pass_name}) {warn_line}", file=sys.stderr, flush=True)
 
         # Prevent final duplicate symbols between runtime/prelude object and
         # the linked compiler object. Keep prelude symbols external and
@@ -13373,10 +13373,10 @@ def main(argv: list[str]) -> int:
                 preview + more
             )
 
-        print("[selfhost] fixed-point: AOT outputs match", flush=True)
+        print("[selfhost] fixed-point: AOT outputs match", file=sys.stderr, flush=True)
 
     total_s = time.perf_counter() - t_total_start
-    print(f"[selfhost] total wall time: {total_s:.2f}s", flush=True)
+    print(f"[selfhost] total wall time: {total_s:.2f}s", file=sys.stderr, flush=True)
     _check_budget()
     return 0
 

--- a/scripts/selfhost_native.py
+++ b/scripts/selfhost_native.py
@@ -5437,6 +5437,30 @@ def _fix_struct_construction_helpers(llvm_ir: str) -> tuple[str, int]:
 
     _HELPERS["make_instruction_simple"] = _gen_make_instruction_simple()
 
+    def _gen_make_instruction_for():
+        """make_instruction_for(target: i8*, iterable: i8*) -> NativeInstruction*
+        Allocates NativeInstruction { i32 tag=6, [4 x i8] pad, [6 x i64] payload }
+        Sets payload[0] = target pointer, payload[1] = iterable pointer."""
+        NI = "%NativeInstruction"
+        lines = []
+        ptr = _alloc_struct(lines, "s", NI)
+        # tag = 6 (For)
+        lines.append("  %tag_i32 = add i32 0, 6")
+        _set_field(lines, "f0", ptr, NI, 0, "i32", "%tag_i32")
+        lines.append(f"  %pad_p = getelementptr {NI}, {NI}* {ptr}, i32 0, i32 1")
+        lines.append("  store [4 x i8] zeroinitializer, [4 x i8]* %pad_p")
+        lines.append(f"  %pay_p = getelementptr {NI}, {NI}* {ptr}, i32 0, i32 2")
+        lines.append("  %tgt_i64 = ptrtoint i8* %target to i64")
+        lines.append("  %itr_i64 = ptrtoint i8* %iterable to i64")
+        lines.append("  %s0 = insertvalue [6 x i64] zeroinitializer, i64 %tgt_i64, 0")
+        lines.append("  %s1 = insertvalue [6 x i64] %s0, i64 %itr_i64, 1")
+        lines.append("  store [6 x i64] %s1, [6 x i64]* %pay_p")
+        lines.append(f"  %ret = bitcast {NI}* {ptr} to i8*")
+        lines.append("  ret i8* %ret")
+        return "\n".join(lines)
+
+    _HELPERS["make_instruction_for"] = _gen_make_instruction_for()
+
     def _gen_build_parse_result_from_text():
         """build_parse_result_from_text(native_text: i8*) -> ParseNativeResult*
         Calls intra-module recovery functions then builds ParseNativeResult."""
@@ -5611,6 +5635,8 @@ def _fix_struct_construction_helpers(llvm_ir: str) -> tuple[str, int]:
     _HELPERS["get_instruction_let_mutable"] = _gen_instr_payload_bool_accessor(1)
     _HELPERS["get_instruction_let_type"] = _gen_instr_payload_ptr_accessor(2)
     _HELPERS["get_instruction_let_value"] = _gen_instr_payload_ptr_accessor(3)
+    _HELPERS["get_instruction_for_target"] = _gen_instr_payload_ptr_accessor(0)
+    _HELPERS["get_instruction_for_iterable"] = _gen_instr_payload_ptr_accessor(1)
 
     # --- NativeEnum field accessor helpers ---
     # NativeEnum = { i8* name[0], {NativeEnumVariant*,i64}* variants[1], NativeEnumLayout* layout[2] }
@@ -5665,6 +5691,9 @@ def _fix_struct_construction_helpers(llvm_ir: str) -> tuple[str, int]:
     _FN_SIGS["get_instruction_let_mutable"] = (_ni_sig_base, "i1")
     _FN_SIGS["get_instruction_let_type"] = (_ni_sig_base, "i8*")
     _FN_SIGS["get_instruction_let_value"] = (_ni_sig_base, "i8*")
+
+    _FN_SIGS["get_instruction_for_target"] = (_ni_sig_base, "i8*")
+    _FN_SIGS["get_instruction_for_iterable"] = (_ni_sig_base, "i8*")
 
     # --- NativeStruct field accessor helpers ---
     # NativeStruct = { i8* name[0], {NativeStructField*,i64}* fields[1],


### PR DESCRIPTION
Remove cross-module type resolution, symbol resolution, and second
type pass (steps 3.4, 3.5, 3.55) from build.sh. These were Python
post-processing passes that compensated for the compiler not emitting
concrete imported types and cross-module declare statements.

build.sh is now pure orchestration: enumerate → stage → emit → compile → link.
The compiler itself must emit correct LLVM IR. If it doesn't, the build fails.

Update SEED_STABILIZATION.md to clarify the two-stage architecture:
- Stage 1 (seed + Python driver): fixups are acceptable
- Stage 2 (first-pass binary + build.sh): zero fixups, ever