### PR TITLE
feat: add GPLv2 license, runtime exception, trademark policy, and site legal pages

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -14,6 +14,10 @@ to the GPL. See RUNTIME_LIBRARY_EXCEPTION for details.
 The full text of the GNU General Public License version 2 is in the file
 LICENSE.
 
+The Sailfin name, logo, and mascot ("Guillermo") are trademarks of
+Sailfin, LLC and are NOT covered by the GPL. Forks must rebrand. See
+TRADEMARKS for the full policy.
+
 You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.

--- a/COPYING
+++ b/COPYING
@@ -1,0 +1,19 @@
+Sailfin - An AI-native, systems-friendly programming language
+Copyright (C) 2026 Michael Curtis <michael@sailfin.io>
+
+The Sailfin compiler is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License as published
+by the Free Software Foundation; version 2 of the License.
+
+The Sailfin runtime libraries (runtime/) are distributed under the same
+license with an additional permission described in the file
+RUNTIME_LIBRARY_EXCEPTION. This exception allows programs compiled by
+Sailfin to link against the runtime without those programs being subject
+to the GPL. See RUNTIME_LIBRARY_EXCEPTION for details.
+
+The full text of the GNU General Public License version 2 is in the file
+LICENSE.
+
+You should have received a copy of the GNU General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.

--- a/COPYING
+++ b/COPYING
@@ -8,8 +8,8 @@ by the Free Software Foundation; version 2 of the License.
 The Sailfin runtime libraries (runtime/) are distributed under the same
 license with an additional permission described in the file
 RUNTIME_LIBRARY_EXCEPTION. This exception allows programs compiled by
-Sailfin to link against the runtime without those programs being subject
-to the GPL. See RUNTIME_LIBRARY_EXCEPTION for details.
+Sailfin to link against the runtime libraries without those programs
+being subject to the GPL. See RUNTIME_LIBRARY_EXCEPTION for details.
 
 The full text of the GNU General Public License version 2 is in the file
 LICENSE.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,339 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held to be invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and understanding of software generally.
+
+                            NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Ty Coon>, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.

--- a/RUNTIME_LIBRARY_EXCEPTION
+++ b/RUNTIME_LIBRARY_EXCEPTION
@@ -9,9 +9,8 @@ license document, but changing it is not allowed.
 
 This Sailfin Runtime Library Exception ("Exception") is an additional
 permission granted by the copyright holder of the Sailfin compiler and
-runtime libraries. It applies to files in the runtime/ directory of the
-Sailfin source distribution (the "Runtime Library") that bear a notice
-stating that they are subject to this Exception.
+runtime libraries. It applies to the source files in the runtime/
+directory of the Sailfin source distribution (the "Runtime Library").
 
 The purpose of this Exception is to allow compilation of non-GPL
 (including proprietary) programs using the Sailfin compiler, so that

--- a/RUNTIME_LIBRARY_EXCEPTION
+++ b/RUNTIME_LIBRARY_EXCEPTION
@@ -1,0 +1,73 @@
+SAILFIN RUNTIME LIBRARY EXCEPTION
+
+Version 1.0, 11 April 2026
+
+Copyright (C) 2026 Michael Curtis <michael@sailfin.io>
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+This Sailfin Runtime Library Exception ("Exception") is an additional
+permission granted by the copyright holder of the Sailfin compiler and
+runtime libraries. It applies to files in the runtime/ directory of the
+Sailfin source distribution (the "Runtime Library") that bear a notice
+stating that they are subject to this Exception.
+
+The purpose of this Exception is to allow compilation of non-GPL
+(including proprietary) programs using the Sailfin compiler, so that
+such programs may use the header files, prelude, and runtime libraries
+covered by this Exception without being subject to the copyleft
+requirements of the GNU General Public License, version 2.
+
+0. Definitions.
+
+"Sailfin" means the Sailfin compiler, with or without modifications,
+distributed under the terms of the GNU General Public License version 2.
+
+"Target Code" refers to output from the Sailfin compiler for a real or
+virtual target processor architecture, in executable form or suitable
+for input to an assembler, linker, loader, and/or execution phase.
+Target Code does not include data in any format used as a compiler
+intermediate representation, or used for producing a compiler
+intermediate representation.
+
+An "Independent Module" is a program or library that either requires the
+Runtime Library for execution after compilation, or makes use of an
+interface provided by the Runtime Library, but is not otherwise based on
+or derived from the Runtime Library or the Sailfin compiler.
+
+An "Eligible Compilation Process" is a compilation performed using
+Sailfin, alone or together with other GPL-compatible software.
+
+1. Grant of Additional Permission.
+
+As a special exception to the GNU General Public License version 2, the
+copyright holder of the Runtime Library gives you permission to combine
+the Runtime Library with Independent Modules to produce an executable,
+and to copy and distribute the resulting executable under terms of your
+choice, provided that:
+
+  a) The Target Code was generated through an Eligible Compilation
+  Process; and
+
+  b) You also meet, for each linked Independent Module, the terms and
+  conditions of the license of that module.
+
+An Independent Module that uses the Runtime Library's interfaces
+(including the prelude, standard library functions, and runtime support
+routines) does not, by itself, become a work based on the Runtime
+Library, and is therefore not subject to the GNU General Public License
+version 2.
+
+2. No Weakening of Sailfin Copyleft.
+
+The availability of this Exception does not imply any general
+presumption that third-party software is unaffected by the copyleft
+requirements of the GNU General Public License version 2 as applied to
+the Sailfin compiler.
+
+This Exception applies only to the Runtime Library and only in the
+context described above. The Sailfin compiler itself, and any
+modifications to the compiler or to the Runtime Library source code,
+remain subject to the full terms of the GNU General Public License
+version 2.

--- a/TRADEMARKS
+++ b/TRADEMARKS
@@ -1,0 +1,73 @@
+SAILFIN TRADEMARK POLICY
+
+The Sailfin programming language is open-source software licensed under the
+GNU General Public License v2. However, the brand assets described below are
+NOT covered by the GPL and are not licensed for unrestricted use.
+
+Trademarks
+----------
+
+The following are trademarks of Sailfin, LLC:
+
+  - The name "Sailfin"
+  - The abbreviation "sfn"
+  - The Sailfin logo and mascot ("Guillermo")
+  - The domain names sailfin.dev and sfn.dev
+
+These marks identify the official Sailfin project and distinguish it from
+derivative works or forks.
+
+Brand Assets
+------------
+
+The following files in this repository are brand assets owned by Sailfin, LLC
+and are NOT licensed under the GPLv2:
+
+  - site/public/images/sfn_lang_logo_256.svg
+  - site/public/images/sfn_lang_logo_256.png
+  - site/public/favicon.svg
+  - Any other files containing the Sailfin logo or mascot
+
+These assets are copyrighted by Sailfin, LLC and may not be used, modified,
+or distributed except as described below.
+
+Permitted Uses
+--------------
+
+You MAY:
+
+  - Use the name "Sailfin" or "sfn" to refer to the official project in a
+    factual, non-misleading way (e.g., "compatible with Sailfin",
+    "written in Sailfin", "a fork of Sailfin")
+  - Link to the Sailfin logo when referring to the official project
+  - Use screenshots of Sailfin for reviews, articles, or educational content
+
+You MAY NOT:
+
+  - Use the Sailfin name, logo, or mascot in a way that suggests your project
+    is the official Sailfin or is endorsed by Sailfin, LLC
+  - Use the logo or mascot in a fork or derivative work — forks must rebrand
+    with their own name and visual identity
+  - Use the logo or mascot on merchandise, products, or services without
+    prior written permission from Sailfin, LLC
+  - Modify the logo or mascot and present the modified version as an official
+    Sailfin mark
+
+Forks and Derivative Works
+--------------------------
+
+If you fork the Sailfin compiler or runtime, you are free to do so under the
+GPLv2. However, your fork must use a different name and must not include the
+Sailfin logo, mascot, or favicon. This ensures users can distinguish official
+releases from community forks.
+
+This is the same approach used by Mozilla (Firefox/Iceweasel), Red Hat
+(RHEL/CentOS), and other major open-source projects.
+
+Contact
+-------
+
+For trademark usage questions or permission requests, contact Sailfin, LLC
+at legal@sailfin.dev or open an issue at:
+
+  https://github.com/SailfinIO/sailfin/issues

--- a/site/src/components/Footer.astro
+++ b/site/src/components/Footer.astro
@@ -66,8 +66,9 @@ const columns = [
 
   <div class="footer-bottom">
     <div class="footer-bottom-inner">
-      <p>&copy; {new Date().getFullYear()} Sailfin. All rights reserved.</p>
+      <p>&copy; {new Date().getFullYear()} Sailfin, LLC. All rights reserved.</p>
       <div class="footer-bottom-links">
+        <a href="/license">License</a>
         <a href="/privacy">Privacy</a>
         <a href="/terms">Terms</a>
       </div>

--- a/site/src/content/docs/contributing/guide.md
+++ b/site/src/content/docs/contributing/guide.md
@@ -74,3 +74,9 @@ make test      # Full test suite
 2. Open a PR against the `alpha` branch
 3. Include test coverage for new features or bug fixes
 4. Update documentation if the change affects language behavior
+
+## License
+
+Sailfin is licensed under the [GNU General Public License v2](https://github.com/SailfinIO/sailfin/blob/main/LICENSE). By submitting a contribution, you agree that your work will be distributed under the same license.
+
+The runtime libraries include a [Runtime Library Exception](https://github.com/SailfinIO/sailfin/blob/main/RUNTIME_LIBRARY_EXCEPTION) so that programs compiled by Sailfin are not subject to the GPL — users can license their own programs however they choose.

--- a/site/src/pages/community.astro
+++ b/site/src/pages/community.astro
@@ -30,6 +30,11 @@ import BaseLayout from "../layouts/BaseLayout.astro";
           <h3>Roadmap</h3>
           <p>See what's planned for Sailfin and where the language is heading.</p>
         </a>
+
+        <a href="/license" class="community-card">
+          <h3>License</h3>
+          <p>Sailfin is open source under the GNU General Public License v2 with a runtime library exception for compiled programs.</p>
+        </a>
       </div>
     </div>
   </div>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -11,7 +11,7 @@ const features = [
   },
   {
     title: "Self-Hosted Compiler",
-    description: "Sailfin compiles itself via LLVM. A real systems language with a real native toolchain, not an interpreter wrapper.",
+    description: "Sailfin compiles itself via LLVM. An open-source systems language with a real native toolchain, not an interpreter wrapper.",
     icon: "terminal",
     href: "/docs/contributing/architecture",
   },

--- a/site/src/pages/license.astro
+++ b/site/src/pages/license.astro
@@ -1,0 +1,223 @@
+---
+import BaseLayout from "../layouts/BaseLayout.astro";
+---
+
+<BaseLayout title="License" description="Sailfin is open source under the GNU General Public License v2 with a runtime library exception.">
+  <div class="page">
+    <div class="container">
+      <h1>License</h1>
+      <p class="lead">
+        Sailfin is free and open-source software maintained by <a href="https://sailfin.dev">Sailfin, LLC</a>.
+      </p>
+
+      <section class="license-section">
+        <h2>The Compiler and Runtime</h2>
+        <p>
+          The Sailfin compiler, runtime, standard library, and all supporting
+          tooling in the
+          <a href="https://github.com/SailfinIO/sailfin">SailfinIO/sailfin</a>
+          repository are licensed under the
+          <strong>GNU General Public License, version 2</strong> (GPLv2).
+        </p>
+        <p>
+          This means you are free to use, study, modify, and redistribute
+          Sailfin. If you distribute a modified version of the compiler or
+          runtime, your modifications must also be made available under the
+          GPLv2. This ensures that Sailfin and all derivative works remain
+          open source.
+        </p>
+        <div class="file-link">
+          <a href="https://github.com/SailfinIO/sailfin/blob/main/LICENSE">
+            Read the full license text (LICENSE)
+          </a>
+        </div>
+      </section>
+
+      <section class="license-section">
+        <h2>Your Programs Are Yours</h2>
+        <p>
+          The Sailfin runtime libraries include a
+          <strong>Runtime Library Exception</strong> modeled after the approach
+          used by GCC. This exception means that programs you compile with
+          Sailfin are <strong>not</strong> subject to the GPL.
+        </p>
+        <p>
+          You can write Sailfin programs, compile them, and distribute the
+          resulting binaries under any license you choose — including
+          proprietary licenses. The runtime exception ensures that linking
+          against the Sailfin prelude and standard library does not create a
+          copyleft obligation on your code.
+        </p>
+        <div class="file-link">
+          <a href="https://github.com/SailfinIO/sailfin/blob/main/RUNTIME_LIBRARY_EXCEPTION">
+            Read the runtime library exception (RUNTIME_LIBRARY_EXCEPTION)
+          </a>
+        </div>
+      </section>
+
+      <section class="license-section">
+        <h2>What This Means in Practice</h2>
+        <div class="summary-grid">
+          <div class="summary-card allowed">
+            <h3>You can</h3>
+            <ul>
+              <li>Use Sailfin for any purpose, commercial or personal</li>
+              <li>Write proprietary programs in Sailfin and sell them</li>
+              <li>Fork the compiler and modify it</li>
+              <li>Distribute the compiler and runtime</li>
+              <li>Contribute to the project</li>
+            </ul>
+          </div>
+          <div class="summary-card required">
+            <h3>You must</h3>
+            <ul>
+              <li>Keep the GPL license on the compiler and runtime source</li>
+              <li>Share source code if you distribute a modified compiler or runtime</li>
+              <li>Preserve copyright notices and attribution</li>
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      <section class="license-section">
+        <h2>Contributing</h2>
+        <p>
+          By contributing to Sailfin, you agree that your contributions will be
+          licensed under the GPLv2. See the
+          <a href="/docs/contributing/guide">contributor guide</a> for details.
+        </p>
+      </section>
+
+      <section class="license-section">
+        <h2>Questions</h2>
+        <p>
+          If you have questions about Sailfin's licensing, please
+          <a href="https://github.com/SailfinIO/sailfin/issues">open an issue</a>
+          on GitHub.
+        </p>
+      </section>
+    </div>
+  </div>
+</BaseLayout>
+
+<style>
+  .page {
+    padding: 3rem 0 5rem;
+  }
+
+  h1 {
+    font-size: 2.5rem;
+    margin-bottom: 1rem;
+  }
+
+  .lead {
+    font-size: 1.2rem;
+    color: var(--color-text-secondary);
+    margin-bottom: 3rem;
+  }
+
+  .lead a {
+    color: var(--color-primary);
+    text-decoration: none;
+  }
+
+  .lead a:hover {
+    text-decoration: underline;
+  }
+
+  .license-section {
+    margin-bottom: 2.5rem;
+  }
+
+  .license-section h2 {
+    font-size: 1.5rem;
+    margin-bottom: 1rem;
+  }
+
+  .license-section p {
+    font-size: 1rem;
+    line-height: 1.7;
+    color: var(--color-text-secondary);
+    margin-bottom: 1rem;
+  }
+
+  .license-section a {
+    color: var(--color-primary);
+    text-decoration: none;
+  }
+
+  .license-section a:hover {
+    text-decoration: underline;
+  }
+
+  .file-link {
+    margin-top: 0.5rem;
+  }
+
+  .file-link a {
+    font-size: 0.925rem;
+    font-weight: 500;
+  }
+
+  .summary-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 1.5rem;
+    margin-top: 1rem;
+  }
+
+  .summary-card {
+    padding: 1.75rem;
+    border-radius: 10px;
+    border: 1px solid var(--color-border);
+  }
+
+  .summary-card h3 {
+    font-size: 1.1rem;
+    margin-bottom: 0.75rem;
+  }
+
+  .summary-card.allowed h3 {
+    color: #28c840;
+  }
+
+  .summary-card.required h3 {
+    color: var(--color-primary);
+  }
+
+  .summary-card ul {
+    list-style: none;
+    padding: 0;
+  }
+
+  .summary-card li {
+    font-size: 0.925rem;
+    color: var(--color-text-secondary);
+    line-height: 1.6;
+    padding-left: 1.25rem;
+    position: relative;
+    margin-bottom: 0.35rem;
+  }
+
+  .summary-card.allowed li::before {
+    content: "+";
+    position: absolute;
+    left: 0;
+    color: #28c840;
+    font-weight: 700;
+  }
+
+  .summary-card.required li::before {
+    content: "*";
+    position: absolute;
+    left: 0;
+    color: var(--color-primary);
+    font-weight: 700;
+  }
+
+  @media (max-width: 600px) {
+    .summary-grid {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>

--- a/site/src/pages/license.astro
+++ b/site/src/pages/license.astro
@@ -13,11 +13,14 @@ import BaseLayout from "../layouts/BaseLayout.astro";
       <section class="license-section">
         <h2>The Compiler and Runtime</h2>
         <p>
-          The Sailfin compiler, runtime, standard library, and all supporting
-          tooling in the
+          The Sailfin compiler, runtime, standard library, and supporting
+          tooling code in the
           <a href="https://github.com/SailfinIO/sailfin">SailfinIO/sailfin</a>
           repository are licensed under the
           <strong>GNU General Public License, version 2</strong> (GPLv2).
+          Trademarked brand assets (such as the logo, mascot, and favicon)
+          are not covered by the GPLv2 and are governed by the
+          <a href="https://github.com/SailfinIO/sailfin/blob/main/TRADEMARKS">Trademark Policy</a>.
         </p>
         <p>
           This means you are free to use, study, modify, and redistribute

--- a/site/src/pages/privacy.astro
+++ b/site/src/pages/privacy.astro
@@ -1,0 +1,143 @@
+---
+import BaseLayout from "../layouts/BaseLayout.astro";
+---
+
+<BaseLayout title="Privacy Policy" description="Privacy policy for sailfin.dev.">
+  <div class="page">
+    <div class="container">
+      <h1>Privacy Policy</h1>
+      <p class="updated">Last updated: April 11, 2026</p>
+
+      <section>
+        <h2>Overview</h2>
+        <p>
+          This privacy policy describes how Sailfin, LLC ("we", "us", "our")
+          handles information when you visit <strong>sailfin.dev</strong> and
+          <strong>sfn.dev</strong> (the "Sites"). We are committed to
+          protecting your privacy and being transparent about what data is
+          collected.
+        </p>
+      </section>
+
+      <section>
+        <h2>Information We Collect</h2>
+        <p>
+          The Sites are static documentation and marketing websites. We do not
+          require user accounts, collect personal information through forms, or
+          set first-party cookies.
+        </p>
+
+        <h3>Hosting and Analytics</h3>
+        <p>
+          The Sites are hosted on <strong>Cloudflare Pages</strong>. Cloudflare
+          may collect standard web server logs including IP addresses, browser
+          user-agent strings, referring pages, and pages visited. This data is
+          used for security, performance, and aggregate analytics purposes.
+          See <a href="https://www.cloudflare.com/privacypolicy/">Cloudflare's
+          Privacy Policy</a> for details.
+        </p>
+
+        <h3>Fonts</h3>
+        <p>
+          The Sites load fonts from <strong>Google Fonts</strong>. When you
+          visit a page, your browser makes a request to Google's servers to
+          retrieve font files. Google may log this request. See
+          <a href="https://policies.google.com/privacy">Google's Privacy
+          Policy</a> for details.
+        </p>
+      </section>
+
+      <section>
+        <h2>Cookies</h2>
+        <p>
+          The Sites do not set first-party cookies. Cloudflare may set
+          cookies for security purposes (such as bot detection). These are
+          strictly necessary cookies and do not track you across websites.
+        </p>
+      </section>
+
+      <section>
+        <h2>Third-Party Links</h2>
+        <p>
+          The Sites contain links to third-party websites such as GitHub. We
+          are not responsible for the privacy practices of those sites. We
+          encourage you to review their privacy policies.
+        </p>
+      </section>
+
+      <section>
+        <h2>Children's Privacy</h2>
+        <p>
+          The Sites are not directed at children under 13. We do not knowingly
+          collect personal information from children.
+        </p>
+      </section>
+
+      <section>
+        <h2>Changes</h2>
+        <p>
+          We may update this privacy policy from time to time. Changes will be
+          posted on this page with an updated revision date.
+        </p>
+      </section>
+
+      <section>
+        <h2>Contact</h2>
+        <p>
+          If you have questions about this privacy policy, please
+          <a href="https://github.com/SailfinIO/sailfin/issues">open an
+          issue</a> on GitHub or contact us at
+          <a href="mailto:privacy@sailfin.dev">privacy@sailfin.dev</a>.
+        </p>
+      </section>
+    </div>
+  </div>
+</BaseLayout>
+
+<style>
+  .page {
+    padding: 3rem 0 5rem;
+  }
+
+  h1 {
+    font-size: 2.5rem;
+    margin-bottom: 0.5rem;
+  }
+
+  .updated {
+    font-size: 0.9rem;
+    color: var(--color-text-secondary);
+    margin-bottom: 2.5rem;
+  }
+
+  section {
+    margin-bottom: 2rem;
+  }
+
+  h2 {
+    font-size: 1.35rem;
+    margin-bottom: 0.75rem;
+  }
+
+  h3 {
+    font-size: 1.1rem;
+    margin-top: 1rem;
+    margin-bottom: 0.5rem;
+  }
+
+  p {
+    font-size: 1rem;
+    line-height: 1.7;
+    color: var(--color-text-secondary);
+    margin-bottom: 0.75rem;
+  }
+
+  a {
+    color: var(--color-primary);
+    text-decoration: none;
+  }
+
+  a:hover {
+    text-decoration: underline;
+  }
+</style>

--- a/site/src/pages/terms.astro
+++ b/site/src/pages/terms.astro
@@ -1,0 +1,147 @@
+---
+import BaseLayout from "../layouts/BaseLayout.astro";
+---
+
+<BaseLayout title="Terms of Use" description="Terms of use for sailfin.dev.">
+  <div class="page">
+    <div class="container">
+      <h1>Terms of Use</h1>
+      <p class="updated">Last updated: April 11, 2026</p>
+
+      <section>
+        <h2>Acceptance</h2>
+        <p>
+          By accessing <strong>sailfin.dev</strong> or
+          <strong>sfn.dev</strong> (the "Sites"), you agree to these terms of
+          use. If you do not agree, please do not use the Sites.
+        </p>
+      </section>
+
+      <section>
+        <h2>The Sites</h2>
+        <p>
+          The Sites are operated by Sailfin, LLC. They provide documentation,
+          blog posts, and marketing materials for the Sailfin programming
+          language and related tools.
+        </p>
+      </section>
+
+      <section>
+        <h2>Software License</h2>
+        <p>
+          The Sailfin compiler, runtime, and tooling are licensed under the
+          <a href="/license">GNU General Public License v2</a> with a Runtime
+          Library Exception. See the <a href="/license">License</a> page for
+          details. These terms of use govern the Sites themselves, not the
+          software.
+        </p>
+      </section>
+
+      <section>
+        <h2>Site Content</h2>
+        <p>
+          Documentation and other written content on the Sites is provided for
+          informational purposes. We make reasonable efforts to keep it
+          accurate and up to date, but make no guarantees that all content is
+          complete, current, or error-free.
+        </p>
+        <p>
+          Code examples in the documentation are provided under the same
+          <a href="/license">GPLv2 license</a> as the Sailfin project unless
+          otherwise noted.
+        </p>
+      </section>
+
+      <section>
+        <h2>Trademarks</h2>
+        <p>
+          "Sailfin", "sfn", the Sailfin logo, and related marks are
+          trademarks of Sailfin, LLC. You may use these marks to refer to the
+          Sailfin programming language in a factual, non-misleading way. You
+          may not use them in a way that suggests endorsement by or
+          affiliation with Sailfin, LLC without prior written permission.
+        </p>
+      </section>
+
+      <section>
+        <h2>Disclaimer of Warranties</h2>
+        <p>
+          The Sites and their content are provided "as is" without warranties
+          of any kind, either express or implied. Sailfin, LLC does not
+          warrant that the Sites will be uninterrupted, error-free, or free of
+          harmful components.
+        </p>
+      </section>
+
+      <section>
+        <h2>Limitation of Liability</h2>
+        <p>
+          To the fullest extent permitted by law, Sailfin, LLC shall not be
+          liable for any indirect, incidental, special, consequential, or
+          punitive damages arising from your use of the Sites.
+        </p>
+      </section>
+
+      <section>
+        <h2>Changes</h2>
+        <p>
+          We may update these terms from time to time. Changes will be posted
+          on this page with an updated revision date. Continued use of the
+          Sites after changes constitutes acceptance of the updated terms.
+        </p>
+      </section>
+
+      <section>
+        <h2>Contact</h2>
+        <p>
+          If you have questions about these terms, please
+          <a href="https://github.com/SailfinIO/sailfin/issues">open an
+          issue</a> on GitHub or contact us at
+          <a href="mailto:legal@sailfin.dev">legal@sailfin.dev</a>.
+        </p>
+      </section>
+    </div>
+  </div>
+</BaseLayout>
+
+<style>
+  .page {
+    padding: 3rem 0 5rem;
+  }
+
+  h1 {
+    font-size: 2.5rem;
+    margin-bottom: 0.5rem;
+  }
+
+  .updated {
+    font-size: 0.9rem;
+    color: var(--color-text-secondary);
+    margin-bottom: 2.5rem;
+  }
+
+  section {
+    margin-bottom: 2rem;
+  }
+
+  h2 {
+    font-size: 1.35rem;
+    margin-bottom: 0.75rem;
+  }
+
+  p {
+    font-size: 1rem;
+    line-height: 1.7;
+    color: var(--color-text-secondary);
+    margin-bottom: 0.75rem;
+  }
+
+  a {
+    color: var(--color-primary);
+    text-decoration: none;
+  }
+
+  a:hover {
+    text-decoration: underline;
+  }
+</style>

--- a/site/src/pages/terms.astro
+++ b/site/src/pages/terms.astro
@@ -55,11 +55,23 @@ import BaseLayout from "../layouts/BaseLayout.astro";
       <section>
         <h2>Trademarks</h2>
         <p>
-          "Sailfin", "sfn", the Sailfin logo, and related marks are
-          trademarks of Sailfin, LLC. You may use these marks to refer to the
-          Sailfin programming language in a factual, non-misleading way. You
-          may not use them in a way that suggests endorsement by or
-          affiliation with Sailfin, LLC without prior written permission.
+          "Sailfin", "sfn", the Sailfin logo, the Sailfin mascot
+          ("Guillermo"), and related marks are trademarks of Sailfin, LLC.
+          These brand assets are <strong>not</strong> covered by the GPLv2
+          license that applies to the source code.
+        </p>
+        <p>
+          You may use these marks to refer to the Sailfin programming
+          language in a factual, non-misleading way. You may not use them in a
+          way that suggests endorsement by or affiliation with Sailfin, LLC
+          without prior written permission. Forks or derivative works of the
+          Sailfin compiler must rebrand with their own name and visual
+          identity.
+        </p>
+        <p>
+          See the full
+          <a href="https://github.com/SailfinIO/sailfin/blob/main/TRADEMARKS">
+          Trademark Policy</a> for details.
         </p>
       </section>
 


### PR DESCRIPTION
## Summary

Establishes the full legal framework for the Sailfin project:

- **GPLv2** for the compiler, runtime, and all source code
- **Runtime Library Exception** so programs compiled by Sailfin are not subject to the GPL
- **Trademark Policy** protecting the Sailfin name, "sfn" abbreviation, logo, and mascot ("Guillermo") — forks must rebrand
- **Site updates** reflecting the license across the public website

## Files added (repo root)

| File | Purpose |
|---|---|
| `LICENSE` | Full GPLv2 text |
| `COPYING` | Project-level notice tying together GPL, runtime exception, and trademarks |
| `RUNTIME_LIBRARY_EXCEPTION` | Exception allowing compiled Sailfin programs to be distributed under any license |
| `TRADEMARKS` | Trademark policy for name, logo, and mascot — explicitly excluded from the GPL |

## Site changes

| File | Change |
|---|---|
| `site/src/pages/license.astro` | New `/license` page — plain-language explanation of GPLv2 + runtime exception with "you can" / "you must" cards |
| `site/src/pages/privacy.astro` | New `/privacy` page — covers Cloudflare hosting and Google Fonts |
| `site/src/pages/terms.astro` | New `/terms` page — includes trademarks section for Sailfin/sfn/Guillermo |
| `site/src/components/Footer.astro` | Copyright updated to Sailfin, LLC; added License link |
| `site/src/pages/community.astro` | Added License card to the community grid |
| `site/src/pages/index.astro` | Self-Hosted Compiler feature card now mentions "open-source" |
| `site/src/content/docs/contributing/guide.md` | Added License section for contributors |

## Notes

- Privacy/terms pages reference `privacy@sailfin.dev` and `legal@sailfin.dev` — those addresses need to be set up
- All legal documents should get a lawyer review ahead of 1.0

https://claude.ai/code/session_01QYZ1okRfBvMgbDqddXK4rT