### PR TITLE
fix: reconcile capsule.toml manifest format with spec

### DIFF
--- a/capsules/sfn/cli/capsule.toml
+++ b/capsules/sfn/cli/capsule.toml
@@ -1,10 +1,12 @@
-[package]
+[capsule]
 name = "sfn/cli"
 version = "0.1.1"
 description = "CLI argument parsing and terminal output for Sailfin"
-entry = "src/mod.sfn"
 
 [dependencies]
 
 [capabilities]
-allow = ["io"]
+required = ["io"]
+
+[build]
+entry = "src/mod.sfn"

--- a/capsules/sfn/crypto/capsule.toml
+++ b/capsules/sfn/crypto/capsule.toml
@@ -1,10 +1,12 @@
-[package]
+[capsule]
 name = "sfn/crypto"
 version = "0.1.1"
 description = "Cryptographic hashing and digest functions for Sailfin"
-entry = "src/mod.sfn"
 
 [dependencies]
 
 [capabilities]
-allow = []
+required = []
+
+[build]
+entry = "src/mod.sfn"

--- a/capsules/sfn/fmt/capsule.toml
+++ b/capsules/sfn/fmt/capsule.toml
@@ -1,10 +1,12 @@
-[package]
+[capsule]
 name = "sfn/fmt"
 version = "0.1.1"
 description = "String formatting and manipulation for Sailfin"
-entry = "src/mod.sfn"
 
 [dependencies]
 
 [capabilities]
-allow = []
+required = []
+
+[build]
+entry = "src/mod.sfn"

--- a/capsules/sfn/fs/capsule.toml
+++ b/capsules/sfn/fs/capsule.toml
@@ -1,10 +1,12 @@
-[package]
+[capsule]
 name = "sfn/fs"
 version = "0.1.1"
 description = "Filesystem operations for Sailfin"
-entry = "src/mod.sfn"
 
 [dependencies]
 
 [capabilities]
-allow = ["io"]
+required = ["io"]
+
+[build]
+entry = "src/mod.sfn"

--- a/capsules/sfn/http/capsule.toml
+++ b/capsules/sfn/http/capsule.toml
@@ -1,10 +1,12 @@
-[package]
+[capsule]
 name = "sfn/http"
 version = "0.2.1"
 description = "HTTP client and server for Sailfin"
-entry = "src/mod.sfn"
 
 [dependencies]
 
 [capabilities]
-allow = ["io", "net"]
+required = ["io", "net"]
+
+[build]
+entry = "src/mod.sfn"

--- a/capsules/sfn/json/capsule.toml
+++ b/capsules/sfn/json/capsule.toml
@@ -1,10 +1,12 @@
-[package]
+[capsule]
 name = "sfn/json"
 version = "0.1.1"
 description = "JSON parsing and serialization for Sailfin"
-entry = "src/mod.sfn"
 
 [dependencies]
 
 [capabilities]
-allow = []
+required = []
+
+[build]
+entry = "src/mod.sfn"

--- a/capsules/sfn/layers/capsule.toml
+++ b/capsules/sfn/layers/capsule.toml
@@ -1,10 +1,12 @@
-[package]
+[capsule]
 name = "sfn/layers"
 version = "0.1.1"
 description = "Neural network layer building blocks for Sailfin"
-entry = "src/mod.sfn"
 
 [dependencies]
 
 [capabilities]
-allow = ["gpu"]
+required = ["gpu"]
+
+[build]
+entry = "src/mod.sfn"

--- a/capsules/sfn/log/capsule.toml
+++ b/capsules/sfn/log/capsule.toml
@@ -1,10 +1,12 @@
-[package]
+[capsule]
 name = "sfn/log"
 version = "0.2.1"
 description = "Structured, leveled logging for Sailfin"
-entry = "src/mod.sfn"
 
 [dependencies]
 
 [capabilities]
-allow = ["io", "clock"]
+required = ["io", "clock"]
+
+[build]
+entry = "src/mod.sfn"

--- a/capsules/sfn/losses/capsule.toml
+++ b/capsules/sfn/losses/capsule.toml
@@ -1,10 +1,12 @@
-[package]
+[capsule]
 name = "sfn/losses"
 version = "0.1.1"
 description = "Loss functions for neural network training in Sailfin"
-entry = "src/mod.sfn"
 
 [dependencies]
 
 [capabilities]
-allow = []
+required = []
+
+[build]
+entry = "src/mod.sfn"

--- a/capsules/sfn/math/capsule.toml
+++ b/capsules/sfn/math/capsule.toml
@@ -1,10 +1,12 @@
-[package]
+[capsule]
 name = "sfn/math"
 version = "0.1.1"
 description = "Mathematical functions and numeric utilities for Sailfin"
-entry = "src/mod.sfn"
 
 [dependencies]
 
 [capabilities]
-allow = []
+required = []
+
+[build]
+entry = "src/mod.sfn"

--- a/capsules/sfn/net/capsule.toml
+++ b/capsules/sfn/net/capsule.toml
@@ -1,10 +1,12 @@
-[package]
+[capsule]
 name = "sfn/net"
 version = "0.1.1"
 description = "Low-level networking primitives for Sailfin"
-entry = "src/mod.sfn"
 
 [dependencies]
 
 [capabilities]
-allow = ["net", "io"]
+required = ["net", "io"]
+
+[build]
+entry = "src/mod.sfn"

--- a/capsules/sfn/nn/capsule.toml
+++ b/capsules/sfn/nn/capsule.toml
@@ -1,10 +1,12 @@
-[package]
+[capsule]
 name = "sfn/nn"
 version = "0.1.1"
 description = "Neural network training and inference utilities for Sailfin"
-entry = "src/mod.sfn"
 
 [dependencies]
 
 [capabilities]
-allow = ["gpu"]
+required = ["gpu"]
+
+[build]
+entry = "src/mod.sfn"

--- a/capsules/sfn/os/capsule.toml
+++ b/capsules/sfn/os/capsule.toml
@@ -1,10 +1,12 @@
-[package]
+[capsule]
 name = "sfn/os"
 version = "0.1.1"
 description = "Environment, process, and OS interaction for Sailfin"
-entry = "src/mod.sfn"
 
 [dependencies]
 
 [capabilities]
-allow = ["io"]
+required = ["io"]
+
+[build]
+entry = "src/mod.sfn"

--- a/capsules/sfn/path/capsule.toml
+++ b/capsules/sfn/path/capsule.toml
@@ -1,10 +1,12 @@
-[package]
+[capsule]
 name = "sfn/path"
 version = "0.1.1"
 description = "File path manipulation utilities for Sailfin"
-entry = "src/mod.sfn"
 
 [dependencies]
 
 [capabilities]
-allow = []
+required = []
+
+[build]
+entry = "src/mod.sfn"

--- a/capsules/sfn/sync/capsule.toml
+++ b/capsules/sfn/sync/capsule.toml
@@ -1,10 +1,12 @@
-[package]
+[capsule]
 name = "sfn/sync"
 version = "0.1.1"
 description = "Concurrency and synchronization primitives for Sailfin"
-entry = "src/mod.sfn"
 
 [dependencies]
 
 [capabilities]
-allow = ["io"]
+required = ["io"]
+
+[build]
+entry = "src/mod.sfn"

--- a/capsules/sfn/tensor/capsule.toml
+++ b/capsules/sfn/tensor/capsule.toml
@@ -1,10 +1,12 @@
-[package]
+[capsule]
 name = "sfn/tensor"
 version = "0.1.1"
 description = "Tensor primitives and operations for Sailfin"
-entry = "src/mod.sfn"
 
 [dependencies]
 
 [capabilities]
-allow = ["gpu"]
+required = ["gpu"]
+
+[build]
+entry = "src/mod.sfn"

--- a/capsules/sfn/test/capsule.toml
+++ b/capsules/sfn/test/capsule.toml
@@ -1,10 +1,12 @@
-[package]
+[capsule]
 name = "sfn/test"
 version = "0.1.0"
 description = "Test assertion helpers and utilities for Sailfin"
-entry = "src/mod.sfn"
 
 [dependencies]
 
 [capabilities]
-allow = ["io"]
+required = ["io"]
+
+[build]
+entry = "src/mod.sfn"

--- a/capsules/sfn/time/capsule.toml
+++ b/capsules/sfn/time/capsule.toml
@@ -1,10 +1,12 @@
-[package]
+[capsule]
 name = "sfn/time"
 version = "0.1.1"
 description = "Time and scheduling primitives for Sailfin"
-entry = "src/mod.sfn"
 
 [dependencies]
 
 [capabilities]
-allow = ["clock"]
+required = ["clock"]
+
+[build]
+entry = "src/mod.sfn"

--- a/capsules/sfn/toml/capsule.toml
+++ b/capsules/sfn/toml/capsule.toml
@@ -1,10 +1,12 @@
-[package]
+[capsule]
 name = "sfn/toml"
 version = "0.1.1"
 description = "TOML parsing and serialization for Sailfin"
-entry = "src/mod.sfn"
 
 [dependencies]
 
 [capabilities]
-allow = []
+required = []
+
+[build]
+entry = "src/mod.sfn"

--- a/compiler/src/cli_commands.sfn
+++ b/compiler/src/cli_commands.sfn
@@ -490,11 +490,11 @@ fn handle_publish_command(args -> string[]) -> number ![io] {
     let pkg_name = toml_get_name(toml_text);
     let pkg_version = toml_get_version(toml_text);
     if pkg_name.length == 0 {
-        print("capsule.toml: missing package name");
+        print("capsule.toml: missing capsule name");
         return 1;
     }
     if pkg_version.length == 0 {
-        print("capsule.toml: missing package version");
+        print("capsule.toml: missing capsule version");
         return 1;
     }
 

--- a/compiler/src/toml_parser.sfn
+++ b/compiler/src/toml_parser.sfn
@@ -254,6 +254,8 @@ fn toml_generate(name -> string, version -> string, description -> string, entry
         out = out + "description = \"" + description + "\"\n";
     }
     out = out + "\n[dependencies]\n";
+    out = out + "\n[capabilities]\n";
+    out = out + "required = []\n";
     out = out + "\n[build]\n";
     out = out + "entry = \"" + entry + "\"\n";
     return out;
@@ -324,18 +326,16 @@ fn _write_toml(toml -> SailToml) -> string {
             j += 1;
         }
     }
-    if toml.capabilities.length > 0 {
-        out = out + "\n[capabilities]\n";
-        out = out + "required = [";
-        let mut k -> number = 0;
-        loop {
-            if k >= toml.capabilities.length { break; }
-            if k > 0 { out = out + ", "; }
-            out = out + "\"" + toml.capabilities[k] + "\"";
-            k += 1;
-        }
-        out = out + "]\n";
+    out = out + "\n[capabilities]\n";
+    out = out + "required = [";
+    let mut k -> number = 0;
+    loop {
+        if k >= toml.capabilities.length { break; }
+        if k > 0 { out = out + ", "; }
+        out = out + "\"" + toml.capabilities[k] + "\"";
+        k += 1;
     }
+    out = out + "]\n";
     out = out + "\n[build]\n";
     out = out + "entry = \"" + toml.entry + "\"\n";
     return out;

--- a/compiler/src/toml_parser.sfn
+++ b/compiler/src/toml_parser.sfn
@@ -200,10 +200,12 @@ fn _parse_toml_internal(text -> string) -> SailToml {
         let value = _toml_trim(substring(line, eq_pos + 1, line.length));
         let stripped_key = _toml_strip_quotes(key);
         let stripped_value = _toml_strip_quotes(value);
-        if strings_equal(section, "package") {
+        if strings_equal(section, "capsule") {
             if strings_equal(stripped_key, "name") { toml.name = stripped_value; }
             if strings_equal(stripped_key, "version") { toml.version = stripped_value; }
             if strings_equal(stripped_key, "description") { toml.description = stripped_value; }
+        }
+        if strings_equal(section, "build") {
             if strings_equal(stripped_key, "entry") { toml.entry = stripped_value; }
         }
         if strings_equal(section, "dependencies") {
@@ -213,7 +215,7 @@ fn _parse_toml_internal(text -> string) -> SailToml {
             toml.dev_dependencies = toml.dev_dependencies.concat([TomlDependency { capsule: stripped_key, version: stripped_value }]);
         }
         if strings_equal(section, "capabilities") {
-            if strings_equal(stripped_key, "allow") {
+            if strings_equal(stripped_key, "required") {
                 toml.capabilities = _toml_parse_string_array(value);
             }
         }
@@ -245,14 +247,15 @@ fn toml_get_description(text -> string) -> string {
 
 // Generate a capsule.toml string from individual fields
 fn toml_generate(name -> string, version -> string, description -> string, entry -> string) -> string {
-    let mut out -> string = "[package]\n";
+    let mut out -> string = "[capsule]\n";
     out = out + "name = \"" + name + "\"\n";
     out = out + "version = \"" + version + "\"\n";
     if description.length > 0 {
         out = out + "description = \"" + description + "\"\n";
     }
-    out = out + "entry = \"" + entry + "\"\n";
     out = out + "\n[dependencies]\n";
+    out = out + "\n[build]\n";
+    out = out + "entry = \"" + entry + "\"\n";
     return out;
 }
 
@@ -297,13 +300,12 @@ fn toml_add_dev_dependency(toml_text -> string, capsule -> string, version -> st
 
 // Write a SailToml back to string (internal)
 fn _write_toml(toml -> SailToml) -> string {
-    let mut out -> string = "[package]\n";
+    let mut out -> string = "[capsule]\n";
     out = out + "name = \"" + toml.name + "\"\n";
     out = out + "version = \"" + toml.version + "\"\n";
     if toml.description.length > 0 {
         out = out + "description = \"" + toml.description + "\"\n";
     }
-    out = out + "entry = \"" + toml.entry + "\"\n";
     out = out + "\n[dependencies]\n";
     let mut i -> number = 0;
     loop {
@@ -324,7 +326,7 @@ fn _write_toml(toml -> SailToml) -> string {
     }
     if toml.capabilities.length > 0 {
         out = out + "\n[capabilities]\n";
-        out = out + "allow = [";
+        out = out + "required = [";
         let mut k -> number = 0;
         loop {
             if k >= toml.capabilities.length { break; }
@@ -334,5 +336,7 @@ fn _write_toml(toml -> SailToml) -> string {
         }
         out = out + "]\n";
     }
+    out = out + "\n[build]\n";
+    out = out + "entry = \"" + toml.entry + "\"\n";
     return out;
 }

--- a/compiler/tests/unit/toml_test.sfn
+++ b/compiler/tests/unit/toml_test.sfn
@@ -150,11 +150,11 @@ test "toml: table with simple keys" {
 }
 
 test "toml: nested table access via dotted path" {
-    // Simulate [package] section: { package: { name: "foo", version: "1.0" } }
+    // Simulate [capsule] section: { capsule: { name: "foo", version: "1.0" } }
     let pkg = _table_val(["name", "version"], [_string_val("foo"), _string_val("1.0")]);
-    let root = _table_val(["package"], [pkg]);
-    assert strings_equal(_get_string(root, "package.name"), "foo");
-    assert strings_equal(_get_string(root, "package.version"), "1.0");
+    let root = _table_val(["capsule"], [pkg]);
+    assert strings_equal(_get_string(root, "capsule.name"), "foo");
+    assert strings_equal(_get_string(root, "capsule.version"), "1.0");
 }
 
 test "toml: has_key" {

--- a/docs/proposals/package-management.md
+++ b/docs/proposals/package-management.md
@@ -40,11 +40,10 @@ sfn add --dev test bench
 Every capsule contains a `capsule.toml` descriptor:
 
 ```toml
-[package]
+[capsule]
 name = "my-sailfin-project"
 version = "1.0.0"
 description = "A simple Sailfin capsule"
-entry = "src/main.sfn"
 
 [dependencies]
 "http" = "^1.0.0"
@@ -52,6 +51,9 @@ entry = "src/main.sfn"
 
 [dev-dependencies]
 "test" = "^0.1.0"
+
+[build]
+entry = "src/main.sfn"
 
 [capabilities]
 allow = ["io", "net", "model"]

--- a/docs/proposals/package-management.md
+++ b/docs/proposals/package-management.md
@@ -56,7 +56,7 @@ description = "A simple Sailfin capsule"
 entry = "src/main.sfn"
 
 [capabilities]
-allow = ["io", "net", "model"]
+required = ["io", "net", "model"]
 
 [models]
 "openai.summarizer" = "gpt-foo@2.3.1"

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,6 +1,6 @@
 # Sailfin Roadmap
 
-Updated: March 31, 2026
+Updated: April 11, 2026
 Owners: Sailfin Core Team
 
 This roadmap pairs with `docs/status.md`. Update status first, then record
@@ -117,7 +117,51 @@ or C runtime**. All items below are hard requirements, not stretch goals.
    - [ ] Document artifact layout, supported platforms, and upgrade expectations.
    - [ ] Verify build/release workflows only use self-hosted compiler artifacts.
 
-6. **Documentation for public release**
+6. **Capsule and workspace manifest system (hard 1.0 prerequisite)**
+
+   The capsule manifest (`capsule.toml`) and workspace manifest (`workspace.toml`)
+   are the foundation of Sailfin's packaging, dependency resolution, and
+   capability-based security model. All three of Sailfin's differentiators —
+   the effect system, capability-based security, and structured concurrency —
+   depend on capsules being the unit of trust and compilation. Shipping 1.0
+   without this means shipping without the security story.
+
+   **Capsule manifests** — every Sailfin project (including the compiler itself)
+   must be described by a `capsule.toml` that declares its name, version,
+   dependencies, required capabilities, and build entry point.
+
+   **Workspace manifests** — multi-capsule projects (like the Sailfin repo itself,
+   which contains the compiler and 19 stdlib capsules) use a root `workspace.toml`
+   to coordinate shared dependency resolution and enforce capability policies
+   across member capsules. This is analogous to `go.work`, Cargo workspaces, or
+   npm workspaces.
+
+   **The compiler as a capsule** — the compiler (`compiler/src/`) must get its own
+   `capsule.toml` as an application capsule. This validates the manifest format at
+   scale and eliminates the special-case build path. The compiler's version
+   (currently in `compiler/src/version.sfn`) should be sourced from or synchronized
+   with its `capsule.toml` manifest.
+
+   - [ ] Add `capsule.toml` to the compiler (`compiler/`) as an application
+         capsule with `entry = "src/main.sfn"` and `required = ["io"]`.
+   - [ ] Add `workspace.toml` at the repository root listing the compiler and all
+         stdlib capsules as workspace members.
+   - [ ] Implement `[policies.<capability>]` enforcement in workspace builds —
+         reject capsules that declare capabilities not allowed by workspace policy.
+   - [ ] Wire the build system to read `capsule.toml` entry points and version
+         instead of hardcoding paths in `build.sh`.
+   - [ ] Implement capsule-scoped capability auditing — the compiler rejects
+         capsule builds that use effects not listed in `[capabilities] required`.
+   - [ ] Implement `workspace.toml` parsing in the compiler (extend `toml_parser.sfn`).
+   - [ ] Implement intra-workspace `path` dependency resolution
+         (`"core" = { path = "../core" }`).
+   - [ ] Implement `[shared-dependencies]` version pinning across workspace members.
+   - [ ] Finalize `sfn init`, `sfn add`, and `sfn publish` CLI commands.
+   - [ ] Stand up registry auth/signing for `registry.sailfin.dev`.
+   - [ ] Source the compiler version from `capsule.toml` (retire standalone
+         `version.sfn` or generate it from the manifest).
+
+7. **Documentation for public release**
    - [ ] Remove legacy compiler-stage references across docs and examples.
    - [ ] Refresh `docs/spec.md` and `docs/keywords.md` to reflect shipped syntax.
    - [ ] Ensure `docs/status.md` and `README.md` match installer defaults and CLI usage.
@@ -168,8 +212,6 @@ The AI-native features are central to Sailfin's long-term vision but ship after
       concurrency work).
 - [ ] **Runtime diagnostics** — structured tracing, allocation telemetry, and
       performance profiling hooks.
-- [ ] **Package registry workflow** — finalize manifests, implement
-      `sfn init/add/publish`, and stand up registry auth/signing.
 - [ ] **Native test framework** — golden/adversarial/replay workflows in
       `sfn test`; CI reporting.
 - [ ] **Tensor/GPU effects** — `Vector<N>`, `Tensor<Shape, DType>`, GPU batching,

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -717,7 +717,7 @@ The `unsafe` capability must be declared in the capsule manifest before any unsa
 
 ```toml
 # capsule.toml
-[package]
+[capsule]
 name = "my-native-lib"
 version = "0.1.0"
 


### PR DESCRIPTION
All 19 stdlib capsule.toml files used [package]/allow which diverged
from the documented spec ([capsule]/required/[build]). This reconciles
the entire codebase to the canonical format:

- [package] → [capsule] in all capsule.toml manifests
- [capabilities] allow → [capabilities] required
- entry moved from [capsule] to [build] section per spec
- TOML parser updated to parse [capsule], [build], and required
- toml_generate() and _write_toml() emit canonical format
- CLI error messages updated (package → capsule)
- toml_test.sfn updated to use [capsule]
- docs/spec.md and docs/proposals/package-management.md updated

Also promotes capsule/workspace manifest system to a hard pre-1.0
requirement in docs/roadmap.md, covering: compiler as a capsule,
workspace.toml at repo root, capability policy enforcement, and
registry workflow.

https://claude.ai/code/session_01Dzggvk27HvYsiaqQzMaHts