### PR TITLE
chore: add Claude Code config for cloud sessions

### DIFF
--- a/.claude/commands/add-feature.md
+++ b/.claude/commands/add-feature.md
@@ -1,0 +1,29 @@
+# Add a Language Feature
+
+Walk through the full pipeline for adding a new language feature to Sailfin. This follows the checklist from CLAUDE.md.
+
+## Feature: $ARGUMENTS
+
+Before writing any code, create a plan covering each stage of the compiler pipeline:
+
+1. **Parser** (`compiler/src/parser.sfn`) — What new syntax needs to be recognized?
+2. **AST** (`compiler/src/ast.sfn`) — What new node types are needed?
+3. **Type Checker** (`compiler/src/typecheck.sfn`) — Any new type rules or constraints?
+4. **Effect Checker** (`compiler/src/effect_checker.sfn`) — Does this involve effects?
+5. **Native Emitter** (`compiler/src/emit_native.sfn`) — How does this emit to `.sfn-asm`?
+6. **LLVM Lowering** (`compiler/src/llvm/lowering/entrypoints.sfn`) — How does this lower to LLVM IR?
+7. **Tests** — Unit tests in `compiler/tests/unit/`, integration tests in `compiler/tests/integration/`
+
+## Workflow
+
+1. Present the plan and wait for approval before writing code.
+2. Implement one pipeline stage at a time, running `make test-unit` after each stage.
+3. After all stages are done, run `make test` to verify nothing is broken.
+4. Run `make compile` to verify the compiler still self-hosts.
+5. Update `docs/spec.md` and `docs/status.md` if the feature is shipping.
+
+## Constraints
+
+- The compiler must still self-host after your changes (`make compile` must pass).
+- Do not refactor surrounding code — keep changes minimal and focused.
+- Always apply `ulimit -v 8388608` before running the compiler.

--- a/.claude/commands/check.md
+++ b/.claude/commands/check.md
@@ -1,0 +1,21 @@
+# Full Compiler Validation
+
+Run the full `make check` validation pipeline for the Sailfin compiler. This validates that the compiler can self-host and pass all tests.
+
+## Steps
+
+1. Set a memory cap to protect against runaway compilation: `ulimit -v 8388608`
+2. Run `make clean-build` to ensure a fresh build state
+3. Run `make check` which:
+   - Builds the compiler from the seed
+   - Runs the full test suite on the first-pass binary
+   - Builds seedcheck from the first-pass binary
+   - Validates seedcheck can run `examples/basics/hello-world.sfn`
+   - Runs the full test suite using the seedcheck binary
+4. If any step fails, diagnose the failure — read the error output carefully, identify the failing module/test, and report what went wrong with the relevant source location.
+
+## Important
+
+- Always apply `ulimit -v 8388608` before invoking the compiler.
+- If the build runs longer than 20 minutes, something is likely wrong — investigate.
+- If `make check` fails, the compiler has a bug. Do not work around it in the build script.

--- a/.claude/commands/debug-compile.md
+++ b/.claude/commands/debug-compile.md
@@ -1,0 +1,36 @@
+# Debug a Compilation Failure
+
+Systematically diagnose why a Sailfin source file fails to compile.
+
+## Target: $ARGUMENTS
+
+## Diagnostic Steps
+
+1. **Isolate** — Run the failing file directly:
+   ```
+   ulimit -v 8388608
+   timeout 60 build/native/sailfin emit native <file>
+   ```
+   Read the diagnostic output carefully — Sailfin emits source spans and fix-it hints.
+
+2. **Narrow the stage** — Determine which compiler pass fails:
+   - Parse error → check `compiler/src/parser.sfn`
+   - Type error → check `compiler/src/typecheck.sfn`
+   - Effect error → check `compiler/src/effect_checker.sfn`
+   - Emit error → check `compiler/src/emit_native.sfn`
+   - LLVM error → check `compiler/src/llvm/lowering/`
+
+3. **Inspect IR** — If the error is in lowering, emit intermediate representations:
+   ```
+   timeout 60 build/native/sailfin emit native <file>   # .sfn-asm
+   timeout 60 build/native/sailfin emit llvm <file>     # LLVM IR
+   ```
+
+4. **Compare** — If a similar feature works, compare the working and broken IR to spot the divergence.
+
+5. **Report** — Summarize: which pass fails, the error message, the relevant source location, and a proposed fix.
+
+## Important
+
+- Always use `ulimit -v 8388608` and `timeout` when running the compiler.
+- Never run the compiler without a memory cap.

--- a/.claude/commands/test-feature.md
+++ b/.claude/commands/test-feature.md
@@ -1,0 +1,30 @@
+# Test a Specific Feature
+
+Run targeted tests for a specific compiler feature or area.
+
+## Feature: $ARGUMENTS
+
+## Steps
+
+1. Find relevant test files:
+   - Search `compiler/tests/unit/` for tests matching the feature name
+   - Search `compiler/tests/integration/` for integration tests
+   - Search `compiler/tests/e2e/` for end-to-end tests
+
+2. Run the targeted tests:
+   ```
+   ulimit -v 8388608
+   timeout 60 build/native/sailfin test <test_file>
+   ```
+
+3. If tests pass, also run the full suite to check for regressions:
+   ```
+   make test-unit
+   ```
+
+4. Report results: which tests passed, which failed, and for failures include the diagnostic output with source locations.
+
+## Important
+
+- Always use `ulimit -v 8388608` before running the compiler.
+- If you can't find tests for the feature, say so — don't skip this step silently.

--- a/.claude/rules/change-discipline.md
+++ b/.claude/rules/change-discipline.md
@@ -1,0 +1,6 @@
+When making changes to the Sailfin codebase:
+
+- Plan before implementing: for any change touching more than one compiler pass, present the plan and get approval before writing code
+- Work in small, verified steps: implement one pipeline stage at a time and test after each
+- Keep changes minimal and focused: do not refactor surrounding code, add comments to unchanged code, or "improve" adjacent logic
+- If a test fails after your change, diagnose the root cause before trying a different approach

--- a/.claude/rules/compiler-safety.md
+++ b/.claude/rules/compiler-safety.md
@@ -1,0 +1,5 @@
+When running the Sailfin compiler (build/native/sailfin) or any make target that invokes it:
+
+- Always set `ulimit -v 8388608` before the command to cap memory at 8GB
+- Always wrap compiler invocations with `timeout` (60s for single files, no limit needed for make targets which handle their own timeouts)
+- Never run the compiler without a memory cap — runaway compilation can crash the entire WSL instance and IDE

--- a/.claude/rules/selfhost-invariant.md
+++ b/.claude/rules/selfhost-invariant.md
@@ -1,0 +1,5 @@
+The Sailfin compiler must always be able to compile itself. Before committing any change to compiler source files (compiler/src/*.sfn):
+
+1. Run `make test` (not just a version check) to verify the test suite passes
+2. If the change is structural (file splits, new modules, renamed exports), run `make clean-build` before rebuilding
+3. Fix the compiler source, never the build script — `scripts/build.sh` is pure orchestration with no fixups

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,21 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(make *)",
+      "Bash(build/native/sailfin *)",
+      "Bash(timeout * build/native/sailfin *)",
+      "Bash(ulimit *)",
+      "Bash(git status*)",
+      "Bash(git log*)",
+      "Bash(git diff*)",
+      "Bash(git branch*)",
+      "Bash(git show*)",
+      "Bash(gh pr *)",
+      "Bash(gh issue *)",
+      "Bash(gh run *)",
+      "Bash(gh api *)",
+      "Bash(ls *)",
+      "Bash(wc *)"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- Adds committed `.claude/settings.json` with clean, broad permission patterns (replaces 59 ad-hoc local-only rules) — these now carry to cloud sessions
- Adds 4 custom slash commands (`/project:check`, `/project:add-feature`, `/project:debug-compile`, `/project:test-feature`) for common compiler workflows
- Adds 3 rules (compiler safety, selfhost invariant, change discipline) that load automatically as contextual guidance

## What this enables

Previously, all Claude Code configuration lived in `settings.local.json` (local-only, not committed). Cloud sessions got nothing besides CLAUDE.md. With this change:

| Feature | Before | After |
|---|---|---|
| Permissions | Local only, 59 narrow rules | Committed, 15 broad patterns |
| Custom commands | None | 4 workflow commands |
| Rules | None | 3 safety/workflow rules |
| Cloud sessions | Only CLAUDE.md | Full config |

## Test plan

- [ ] Verify `settings.json` does not conflict with `settings.local.json` overrides
- [ ] Test `/project:check` command runs `make check` with memory cap
- [ ] Test `/project:add-feature` command enters plan mode for a feature
- [ ] Verify rules load and are followed (e.g., memory cap applied automatically)
- [ ] Spin up a cloud session and confirm config carries over

🤖 Generated with [Claude Code](https://claude.com/claude-code)