### PR TITLE
Replace semantic-release with manual release workflow

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -1,0 +1,78 @@
+# Release a new Sailfin version
+
+Trigger a new Sailfin compiler release via the GitHub Actions `release.yml`
+workflow.
+
+## How releases work
+
+Sailfin uses a manually-triggered release workflow instead of auto-releasing on
+every merge.  The canonical version lives in `compiler/capsule.toml` and is
+mirrored in `compiler/src/version.sfn`.
+
+The workflow accepts two inputs:
+- **channel**: `alpha` | `beta` | `rc` | `stable`
+- **bump**: `prerelease` | `patch` | `minor` | `major`
+
+## What to do
+
+1. Read the current version from `compiler/capsule.toml`.
+
+2. Ask the user what kind of release they want if not already clear from
+   context.  Common scenarios:
+   - "cut an alpha" → channel=alpha, bump=prerelease
+   - "new patch alpha" → channel=alpha, bump=patch
+   - "promote to beta" → channel=beta, bump=prerelease
+   - "promote to rc" → channel=rc, bump=prerelease
+   - "ship it" / "GA release" → channel=stable, bump=prerelease
+   - "minor release" → channel=alpha, bump=minor (or ask which channel)
+
+3. Show the user what the version transition will be:
+   ```
+   Current: X.Y.Z-channel.N
+   Next:    X.Y.Z-channel.M
+   ```
+
+4. Once confirmed, dispatch the workflow:
+   ```bash
+   gh workflow run release.yml \
+     -f channel=<channel> \
+     -f bump=<bump>
+   ```
+
+   Or for a dry run first:
+   ```bash
+   gh workflow run release.yml \
+     -f channel=<channel> \
+     -f bump=<bump> \
+     -f dry_run=true
+   ```
+
+5. After dispatching, let the user know:
+   - The workflow has been triggered
+   - They can monitor it at: https://github.com/SailfinIO/sailfin/actions/workflows/release.yml
+   - The release-notes agentic workflow will auto-generate changelog content
+     once the GitHub Release is published
+
+## Version math reference
+
+Given current version `0.5.0-alpha.22`:
+
+| Command | Result |
+|---------|--------|
+| channel=alpha, bump=prerelease | `0.5.0-alpha.23` |
+| channel=alpha, bump=patch | `0.5.1-alpha.1` |
+| channel=alpha, bump=minor | `0.6.0-alpha.1` |
+| channel=alpha, bump=major | `1.0.0-alpha.1` |
+| channel=beta, bump=prerelease | `0.5.0-beta.1` |
+| channel=rc, bump=prerelease | `0.5.0-rc.1` |
+| channel=stable, bump=prerelease | `0.5.0` |
+
+## Notes
+
+- Demotions are not allowed (e.g., rc → alpha). Bump major/minor/patch to
+  start a new cycle.
+- The workflow requires the `RELEASE_PAT` secret to be configured.
+- Release assets (platform binaries, installers) are built automatically by
+  `release-tag.yml` after the tag is created.
+- An agentic workflow (`release-notes.md`) generates structured release notes
+  once the GitHub Release is published.

--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -50,8 +50,9 @@ The workflow accepts two inputs:
 5. After dispatching, let the user know:
    - The workflow has been triggered
    - They can monitor it at: https://github.com/SailfinIO/sailfin/actions/workflows/release.yml
-   - The release-notes agentic workflow will auto-generate changelog content
-     once the GitHub Release is published
+   - The release-notes agentic workflow will post a structured changelog
+     comment on the release once it's published (supplementing the
+     auto-generated notes)
 
 ## Version math reference
 

--- a/.github/workflows/release-branches.yml
+++ b/.github/workflows/release-branches.yml
@@ -1,4 +1,9 @@
-name: Release (branches)
+name: CI (branch push)
+
+# Runs the build + test matrix on pushes to main, rc, and beta.
+#
+# This workflow validates that the branch is healthy.  It does NOT create
+# releases — use the manual "Release" workflow (release.yml) for that.
 
 env:
     # Pinned seed used for self-host bootstrap in CI.
@@ -14,21 +19,21 @@ on:
         paths-ignore:
             - CHANGELOG.md
             - compiler/src/version.sfn
+            - compiler/capsule.toml
             - 'site/**'
             - 'capsules/**/capsule.toml'
 
 concurrency:
-    group: release-branch-${{ github.ref }}
+    group: ci-branch-${{ github.ref }}
     cancel-in-progress: true
 
 jobs:
     build-from-release-seed:
         name: Build + Test (seed) [${{ matrix.package_label }}]
-        # Defensive: if semantic-release ever forgets [skip ci], don't burn runner time.
+        # Skip release-bot commits to avoid burning runner time.
         if: >-
-            github.event.head_commit.author.name != 'semantic-release' &&
             github.event.head_commit.author.name != 'Sailfin Release Bot' &&
-            !contains(github.event.head_commit.author.email, 'semantic-release')
+            !contains(github.event.head_commit.message, 'chore(release)')
         runs-on: ${{ matrix.os }}
         permissions:
             contents: read
@@ -89,91 +94,3 @@ jobs:
                   ls -lh build/native/sailfin
                   (file build/native/sailfin || true)
                   build/native/sailfin version || build/native/sailfin --version || true
-
-    semantic-release:
-        name: Semantic Release
-        needs: build-from-release-seed
-        if: >-
-            github.event_name == 'push' &&
-            github.ref_type == 'branch' &&
-            github.event.head_commit.author.name != 'semantic-release' &&
-            github.event.head_commit.author.name != 'Sailfin Release Bot' &&
-            !contains(github.event.head_commit.author.email, 'semantic-release')
-        runs-on: ubuntu-latest
-        outputs:
-            release_tag: ${{ steps.compute_release_tag.outputs.tag }}
-        env:
-            RELEASE_PAT_SECRET: ${{ secrets.RELEASE_PAT }}
-        permissions:
-            contents: write
-
-        steps:
-            - name: Require RELEASE_PAT (to trigger tag workflow)
-              if: env.RELEASE_PAT_SECRET == ''
-              shell: bash
-              run: |
-                  echo "[ci][error] RELEASE_PAT secret is required for releases." >&2
-                  echo "[ci][error] GITHUB_TOKEN-created tags will NOT trigger the tag workflow, so no assets get uploaded." >&2
-                  exit 1
-
-            - name: Checkout repository
-              uses: actions/checkout@v6
-              with:
-                  fetch-depth: 0
-                  persist-credentials: false
-
-            - name: Configure git credentials
-              env:
-                  RELEASE_TOKEN: ${{ secrets.RELEASE_PAT }}
-              run: |
-                  git config user.name "Sailfin Release Bot"
-                  git config user.email "releases@sailfin.io"
-                  git remote set-url origin "https://x-access-token:${RELEASE_TOKEN}@github.com/${{ github.repository }}.git"
-
-            - name: Set up Conda
-              uses: conda-incubator/setup-miniconda@v3
-              with:
-                  activate-environment: sailfin
-                  environment-file: environment.yml
-                  auto-activate-base: false
-                  use-mamba: true
-
-            - name: Semantic release version
-              env:
-                  RELEASE_PAT: ${{ secrets.RELEASE_PAT }}
-                  GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}
-                  GH_TOKEN: ${{ secrets.RELEASE_PAT }}
-              shell: bash -l {0}
-              run: |
-                  CONDA=$(which conda) semantic-release version
-
-            - name: Semantic release publish
-              env:
-                  RELEASE_PAT: ${{ secrets.RELEASE_PAT }}
-                  GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}
-                  GH_TOKEN: ${{ secrets.RELEASE_PAT }}
-              shell: bash -l {0}
-              run: |
-                  CONDA=$(which conda) semantic-release publish
-
-            - name: Compute release tag
-              id: compute_release_tag
-              shell: bash
-              run: |
-                  set -euo pipefail
-                  version="$(python -c "import re, pathlib; text=pathlib.Path('compiler/src/version.sfn').read_text(encoding='utf-8'); m=re.search(r'__version__\\s*=\\s*\"([^\"]+)\"', text); print(m.group(1) if m else '')")"
-                  if [ -z "$version" ]; then
-                    echo "[ci][error] could not read compiler/src/version.sfn __version__" >&2
-                    exit 1
-                  fi
-                  echo "tag=v${version}" >> "$GITHUB_OUTPUT"
-
-    release-tag:
-        name: Release Assets [${{ needs.semantic-release.outputs.release_tag }}]
-        needs: semantic-release
-        permissions:
-            contents: write
-        uses: ./.github/workflows/release-tag.yml
-        with:
-            tag: ${{ needs.semantic-release.outputs.release_tag }}
-        secrets: inherit

--- a/.github/workflows/release-notes.md
+++ b/.github/workflows/release-notes.md
@@ -1,8 +1,8 @@
 ---
 description: |
   Generates rich, categorized release notes when a new GitHub Release is
-  published.  Analyzes all commits since the previous tag and writes a
-  structured changelog body on the release.
+  published.  Analyzes all commits since the previous tag and posts a
+  structured changelog as a comment on the release.
 
 on:
   release:
@@ -95,7 +95,9 @@ rand, clock]`), ownership types, and AI-native constructs.
    **Full Changelog**: https://github.com/SailfinIO/sailfin/compare/<prev_tag>...<this_tag>
    ```
 
-6. **Update the GitHub release body** with the generated notes.
+6. **Post a comment on the release** with the generated notes. The release
+   already has auto-generated notes from `gh release create --generate-notes`;
+   your comment supplements those with richer categorization and context.
 
 ## Guidelines
 

--- a/.github/workflows/release-notes.md
+++ b/.github/workflows/release-notes.md
@@ -1,0 +1,111 @@
+---
+description: |
+  Generates rich, categorized release notes when a new GitHub Release is
+  published.  Analyzes all commits since the previous tag and writes a
+  structured changelog body on the release.
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+engine: copilot
+
+network: defaults
+
+tools:
+  github:
+    toolsets: [default]
+    min-integrity: unapproved
+
+safe-outputs:
+  add-comment:
+
+timeout-minutes: 15
+---
+
+# Sailfin Release Notes Generator
+
+You are the Sailfin Release Notes agent. Your job is to generate comprehensive,
+well-structured release notes for release **${{ github.event.release.tag_name }}**.
+
+## Context
+
+Sailfin is a self-hosted compiled language targeting LLVM. The compiler lives in
+`compiler/src/*.sfn`. The project uses an effect system (`![io, net, model, gpu,
+rand, clock]`), ownership types, and AI-native constructs.
+
+### Key directories
+| Path | Area |
+|------|------|
+| `compiler/src/` | Compiler source (Sailfin) |
+| `compiler/tests/` | Test suites (unit, integration, e2e) |
+| `runtime/native/` | C runtime |
+| `runtime/prelude.sfn` | Prelude library |
+| `capsules/` | Standard library capsules |
+| `docs/` | Specification, status, roadmap |
+| `scripts/` | Build drivers |
+
+## Process
+
+1. **Identify the previous release tag.** List recent tags or releases to find
+   the tag immediately before `${{ github.event.release.tag_name }}`.
+
+2. **Gather all commits** between the previous tag and this release tag using
+   `git log --oneline <prev_tag>..${{ github.event.release.tag_name }}`.
+
+3. **Read PR descriptions** for any merged PRs referenced in commits (look for
+   `(#NNN)` patterns) to get richer context on each change.
+
+4. **Categorize each change** into one of these sections:
+   - **Breaking Changes** — anything that changes public API, syntax, or semantics
+   - **Features** — new language features, compiler passes, CLI options
+   - **Bug Fixes** — compiler bugs, codegen fixes, test fixes
+   - **Performance** — optimization improvements, build speed, binary size
+   - **Compiler Internals** — refactors, IR changes, lowering improvements
+   - **Standard Library** — capsule changes
+   - **Documentation** — spec, status, roadmap updates
+   - **Infrastructure** — CI, build system, packaging changes
+
+   Omit empty sections. Use conventional commit prefixes as hints but verify
+   against the actual diff when the prefix seems wrong.
+
+5. **Write the release notes** in this format:
+
+   ```markdown
+   ## What's Changed
+
+   ### Breaking Changes
+   - **description** — brief explanation (#PR)
+
+   ### Features
+   - **description** — brief explanation (#PR)
+
+   ### Bug Fixes
+   - **description** — brief explanation (#PR)
+
+   [... other non-empty sections ...]
+
+   ### Contributors
+   @contributor1, @contributor2, ...
+
+   **Full Changelog**: https://github.com/SailfinIO/sailfin/compare/<prev_tag>...<this_tag>
+   ```
+
+6. **Update the GitHub release body** with the generated notes.
+
+## Guidelines
+
+- Be factual. Every claim must trace to an actual commit or PR.
+- Keep descriptions concise (one line each) but informative.
+- Highlight the most impactful changes at the top of each section.
+- For compiler internals: mention which pipeline stage is affected
+  (parser, type checker, effect checker, emitter, LLVM lowering).
+- For bug fixes: briefly describe what was broken, not just what was changed.
+- If the release is a promotion (alpha -> beta -> rc -> stable) with no new
+  commits, note that it's a promotion release and summarize the cumulative
+  changes since the last stable release.
+- Include a contributors section listing all commit authors.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,270 @@
+name: Release
+
+# Manually-triggered release workflow.  Replaces python-semantic-release.
+#
+# Reads the current version from compiler/capsule.toml, computes the next
+# version based on `channel` and `bump` inputs, updates capsule.toml +
+# version.sfn, commits, tags, pushes, creates a GitHub Release, then calls
+# release-tag.yml to build and upload platform assets.
+#
+# Channel semantics:
+#   alpha       → v0.5.0-alpha.23   (prerelease on main)
+#   beta        → v0.5.0-beta.1     (promote to beta)
+#   rc          → v0.5.0-rc.1       (release candidate)
+#   stable      → v0.5.0            (GA release)
+#
+# Bump semantics (within the chosen channel):
+#   prerelease  → increment the .N suffix (or start .1 when promoting)
+#   patch       → bump patch, reset to <channel>.1  (or clean for stable)
+#   minor       → bump minor, reset patch + prerelease
+#   major       → bump major, reset minor + patch + prerelease
+
+on:
+  workflow_dispatch:
+    inputs:
+      channel:
+        description: "Release channel"
+        required: true
+        type: choice
+        options:
+          - alpha
+          - beta
+          - rc
+          - stable
+      bump:
+        description: "Version bump type"
+        required: true
+        type: choice
+        options:
+          - prerelease
+          - patch
+          - minor
+          - major
+      dry_run:
+        description: "Dry run (compute version but don't tag/release)"
+        required: false
+        type: boolean
+        default: false
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+env:
+  RELEASE_PAT_SECRET: ${{ secrets.RELEASE_PAT }}
+
+jobs:
+  release:
+    name: Bump version & tag
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      version: ${{ steps.bump.outputs.version }}
+      tag: ${{ steps.bump.outputs.tag }}
+      prev_tag: ${{ steps.bump.outputs.prev_tag }}
+
+    steps:
+      - name: Require RELEASE_PAT
+        if: env.RELEASE_PAT_SECRET == ''
+        run: |
+          echo "::error::RELEASE_PAT secret is required so the new tag triggers downstream workflows."
+          exit 1
+
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Configure git credentials
+        env:
+          RELEASE_TOKEN: ${{ secrets.RELEASE_PAT }}
+        run: |
+          git config user.name "Sailfin Release Bot"
+          git config user.email "releases@sailfin.io"
+          git remote set-url origin "https://x-access-token:${RELEASE_TOKEN}@github.com/${{ github.repository }}.git"
+
+      - name: Compute next version
+        id: bump
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          CHANNEL="${{ inputs.channel }}"
+          BUMP="${{ inputs.bump }}"
+
+          # --- Read current version from capsule.toml -------------------------
+          current="$(sed -n 's/^version *= *"\([^"]*\)"/\1/p' compiler/capsule.toml)"
+          if [ -z "$current" ]; then
+            echo "::error::Could not read version from compiler/capsule.toml"
+            exit 1
+          fi
+          echo "Current version: $current"
+          echo "prev_tag=v${current}" >> "$GITHUB_OUTPUT"
+
+          # --- Parse semver components ----------------------------------------
+          # Matches: MAJOR.MINOR.PATCH or MAJOR.MINOR.PATCH-pre.N
+          if [[ "$current" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)(-([a-z]+)\.([0-9]+))?$ ]]; then
+            MAJOR="${BASH_REMATCH[1]}"
+            MINOR="${BASH_REMATCH[2]}"
+            PATCH="${BASH_REMATCH[3]}"
+            PRE_LABEL="${BASH_REMATCH[5]:-}"
+            PRE_NUM="${BASH_REMATCH[6]:-0}"
+          else
+            echo "::error::Cannot parse version '$current' as semver"
+            exit 1
+          fi
+
+          # --- Channel ordering for promotion checks -------------------------
+          channel_rank() {
+            case "$1" in
+              alpha)  echo 0 ;;
+              beta)   echo 1 ;;
+              rc)     echo 2 ;;
+              stable) echo 3 ;;
+              *)      echo -1 ;;
+            esac
+          }
+
+          cur_rank=$(channel_rank "${PRE_LABEL:-stable}")
+          new_rank=$(channel_rank "$CHANNEL")
+
+          # --- Compute next version -------------------------------------------
+          case "$BUMP" in
+            major)
+              MAJOR=$((MAJOR + 1))
+              MINOR=0
+              PATCH=0
+              if [ "$CHANNEL" = "stable" ]; then
+                NEXT="${MAJOR}.${MINOR}.${PATCH}"
+              else
+                NEXT="${MAJOR}.${MINOR}.${PATCH}-${CHANNEL}.1"
+              fi
+              ;;
+            minor)
+              MINOR=$((MINOR + 1))
+              PATCH=0
+              if [ "$CHANNEL" = "stable" ]; then
+                NEXT="${MAJOR}.${MINOR}.${PATCH}"
+              else
+                NEXT="${MAJOR}.${MINOR}.${PATCH}-${CHANNEL}.1"
+              fi
+              ;;
+            patch)
+              PATCH=$((PATCH + 1))
+              if [ "$CHANNEL" = "stable" ]; then
+                NEXT="${MAJOR}.${MINOR}.${PATCH}"
+              else
+                NEXT="${MAJOR}.${MINOR}.${PATCH}-${CHANNEL}.1"
+              fi
+              ;;
+            prerelease)
+              if [ "$CHANNEL" = "stable" ]; then
+                # Promote to stable: strip prerelease suffix
+                NEXT="${MAJOR}.${MINOR}.${PATCH}"
+              elif [ "$CHANNEL" = "$PRE_LABEL" ]; then
+                # Same channel: increment prerelease number
+                NEXT="${MAJOR}.${MINOR}.${PATCH}-${CHANNEL}.$((PRE_NUM + 1))"
+              elif [ "$new_rank" -gt "$cur_rank" ]; then
+                # Promoting to a higher channel: start at .1
+                NEXT="${MAJOR}.${MINOR}.${PATCH}-${CHANNEL}.1"
+              else
+                echo "::error::Cannot demote from '${PRE_LABEL:-stable}' to '${CHANNEL}'. Use a higher channel or bump major/minor/patch first."
+                exit 1
+              fi
+              ;;
+          esac
+
+          echo "Next version: $NEXT"
+          echo "version=${NEXT}" >> "$GITHUB_OUTPUT"
+          echo "tag=v${NEXT}" >> "$GITHUB_OUTPUT"
+
+      - name: Update version files
+        if: inputs.dry_run != true
+        shell: bash
+        env:
+          NEXT: ${{ steps.bump.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          # Update capsule.toml
+          sed -i "s/^version = \"[^\"]*\"/version = \"${NEXT}\"/" compiler/capsule.toml
+
+          # Update version.sfn
+          sed -i "s/let __version__ = \"[^\"]*\"/let __version__ = \"${NEXT}\"/" compiler/src/version.sfn
+
+          echo "--- compiler/capsule.toml ---"
+          grep '^version' compiler/capsule.toml
+          echo "--- compiler/src/version.sfn ---"
+          grep '__version__' compiler/src/version.sfn
+
+      - name: Commit & tag
+        if: inputs.dry_run != true
+        env:
+          TAG: ${{ steps.bump.outputs.tag }}
+        run: |
+          set -euo pipefail
+          git add compiler/capsule.toml compiler/src/version.sfn
+          git commit -m "chore(release): ${TAG#v}"
+          git tag -a "$TAG" -m "Release ${TAG}"
+
+      - name: Push commit & tag
+        if: inputs.dry_run != true
+        env:
+          TAG: ${{ steps.bump.outputs.tag }}
+        run: |
+          set -euo pipefail
+          git push origin HEAD
+          git push origin "$TAG"
+
+      - name: Create GitHub Release
+        if: inputs.dry_run != true
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+          TAG: ${{ steps.bump.outputs.tag }}
+          VERSION: ${{ steps.bump.outputs.version }}
+          CHANNEL: ${{ inputs.channel }}
+        run: |
+          set -euo pipefail
+          PRERELEASE_FLAG=""
+          if [ "$CHANNEL" != "stable" ]; then
+            PRERELEASE_FLAG="--prerelease"
+          fi
+
+          LATEST_FLAG=""
+          if [ "$CHANNEL" = "stable" ]; then
+            LATEST_FLAG="--latest"
+          fi
+
+          gh release create "$TAG" \
+            --title "Sailfin $VERSION" \
+            --generate-notes \
+            --notes-start-tag "${{ steps.bump.outputs.prev_tag }}" \
+            $PRERELEASE_FLAG \
+            $LATEST_FLAG
+
+      - name: Dry run summary
+        if: inputs.dry_run == true
+        run: |
+          echo "## Dry Run Summary" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Field | Value |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|-------|-------|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Current | ${{ steps.bump.outputs.prev_tag }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Next | ${{ steps.bump.outputs.tag }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Channel | ${{ inputs.channel }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Bump | ${{ inputs.bump }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "No changes were made (dry run)." >> "$GITHUB_STEP_SUMMARY"
+
+  build-assets:
+    name: Build release assets
+    needs: release
+    if: inputs.dry_run != true
+    permissions:
+      contents: write
+    uses: ./.github/workflows/release-tag.yml
+    with:
+      tag: ${{ needs.release.outputs.tag }}
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,6 +176,18 @@ jobs:
               ;;
           esac
 
+          # --- Guard against no-op releases ------------------------------------
+          if [ "$NEXT" = "$current" ]; then
+            echo "::error::Computed version '$NEXT' is the same as the current version. Nothing to release. Use a different bump or channel."
+            exit 1
+          fi
+
+          # --- Guard against re-tagging an existing tag -----------------------
+          if git rev-parse "v${NEXT}" >/dev/null 2>&1; then
+            echo "::error::Tag 'v${NEXT}' already exists. Choose a different bump/channel combination."
+            exit 1
+          fi
+
           echo "Next version: $NEXT"
           echo "version=${NEXT}" >> "$GITHUB_OUTPUT"
           echo "tag=v${NEXT}" >> "$GITHUB_OUTPUT"
@@ -188,16 +200,37 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Update capsule.toml
-          sed -i "s/^version = \"[^\"]*\"/version = \"${NEXT}\"/" compiler/capsule.toml
+          # Update capsule.toml (whitespace-tolerant around = and quotes)
+          capsule_matches=$(grep -c '^version *=' compiler/capsule.toml || true)
+          if [ "$capsule_matches" -ne 1 ]; then
+            echo "::error::Expected exactly 1 'version =' line in capsule.toml, found $capsule_matches"
+            exit 1
+          fi
+          sed -i "s/^version *= *\"[^\"]*\"/version = \"${NEXT}\"/" compiler/capsule.toml
 
-          # Update version.sfn
-          sed -i "s/let __version__ = \"[^\"]*\"/let __version__ = \"${NEXT}\"/" compiler/src/version.sfn
+          # Update version.sfn (whitespace-tolerant around = and quotes)
+          sfn_matches=$(grep -c 'let __version__ *=' compiler/src/version.sfn || true)
+          if [ "$sfn_matches" -ne 1 ]; then
+            echo "::error::Expected exactly 1 '__version__' assignment in version.sfn, found $sfn_matches"
+            exit 1
+          fi
+          sed -i "s/let __version__ *= *\"[^\"]*\"/let __version__ = \"${NEXT}\"/" compiler/src/version.sfn
 
+          # Verify the replacements took effect
           echo "--- compiler/capsule.toml ---"
           grep '^version' compiler/capsule.toml
           echo "--- compiler/src/version.sfn ---"
           grep '__version__' compiler/src/version.sfn
+
+          # Final sanity check: the new version must appear in both files
+          if ! grep -q "\"${NEXT}\"" compiler/capsule.toml; then
+            echo "::error::capsule.toml was not updated to version ${NEXT}"
+            exit 1
+          fi
+          if ! grep -q "\"${NEXT}\"" compiler/src/version.sfn; then
+            echo "::error::version.sfn was not updated to version ${NEXT}"
+            exit 1
+          fi
 
       - name: Commit & tag
         if: inputs.dry_run != true
@@ -225,6 +258,7 @@ jobs:
           TAG: ${{ steps.bump.outputs.tag }}
           VERSION: ${{ steps.bump.outputs.version }}
           CHANNEL: ${{ inputs.channel }}
+          PREV_TAG: ${{ steps.bump.outputs.prev_tag }}
         run: |
           set -euo pipefail
           PRERELEASE_FLAG=""
@@ -237,10 +271,16 @@ jobs:
             LATEST_FLAG="--latest"
           fi
 
+          # Only pass --notes-start-tag if the previous tag actually exists
+          NOTES_START=""
+          if git rev-parse "$PREV_TAG" >/dev/null 2>&1; then
+            NOTES_START="--notes-start-tag $PREV_TAG"
+          fi
+
           gh release create "$TAG" \
             --title "Sailfin $VERSION" \
             --generate-notes \
-            --notes-start-tag "${{ steps.bump.outputs.prev_tag }}" \
+            $NOTES_START \
             $PRERELEASE_FLAG \
             $LATEST_FLAG
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -322,7 +322,7 @@ The compiler must always compile itself. Breaking changes require:
 - **Version source of truth:** `compiler/capsule.toml` (`[capsule] version`)
 - **Version mirror:** `compiler/src/version.sfn:__version__` (read by the compiler binary; kept in sync by the release workflow — TODO: read from capsule.toml at build time)
 - **Release automation:** `.github/workflows/release.yml` — manually triggered via `workflow_dispatch`, pure bash, no Python dependencies
-- **Release notes:** `.github/workflows/release-notes.md` — agentic workflow that generates structured changelogs when a release is published
+- **Release notes:** `.github/workflows/release-notes.md` — agentic workflow that posts structured, categorized changelog comments on published releases (supplements the auto-generated notes from `gh release create`)
 - **Artifacts:** `dist/` is used for packaged artifacts; `release-tag.yml` builds and uploads platform binaries
 - **Claude skill:** Use `/release` to trigger a new release from Claude Code
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,7 @@ The compiler (`compiler/src/`) follows this flow:
 
 **Critical files:**
 
+- `compiler/capsule.toml` — Version source of truth and capsule manifest
 - `compiler/src/main.sfn` — Entry point orchestrating all passes
 - `compiler/src/ast.sfn` — Canonical AST node definitions
 - `compiler/src/native_ir.sfn` — `.sfn-asm` intermediate representation
@@ -317,18 +318,45 @@ The compiler must always compile itself. Breaking changes require:
 
 ## Versioning & Releases
 
-- **Semantic versioning:** `v0.1.1-alpha.32` (main branch prerelease), `v0.x.y` (main branch stable release)
-- **Version source:** `compiler/src/version.sfn:__version__` (drives `sfn --version`)
-- **Release automation:** GitHub Actions + `python-semantic-release`
-- **Artifacts:** `dist/` is used for packaged artifacts as part of release tooling
+- **Semantic versioning:** `v0.5.0-alpha.22` format — `MAJOR.MINOR.PATCH[-channel.N]`
+- **Version source of truth:** `compiler/capsule.toml` (`[capsule] version`)
+- **Version mirror:** `compiler/src/version.sfn:__version__` (read by the compiler binary; kept in sync by the release workflow — TODO: read from capsule.toml at build time)
+- **Release automation:** `.github/workflows/release.yml` — manually triggered via `workflow_dispatch`, pure bash, no Python dependencies
+- **Release notes:** `.github/workflows/release-notes.md` — agentic workflow that generates structured changelogs when a release is published
+- **Artifacts:** `dist/` is used for packaged artifacts; `release-tag.yml` builds and uploads platform binaries
+- **Claude skill:** Use `/release` to trigger a new release from Claude Code
+
+### Triggering a Release
+
+Releases are **not** automatic on merge. Use the GitHub Actions UI or CLI:
+
+```bash
+# Cut a new alpha prerelease
+gh workflow run release.yml -f channel=alpha -f bump=prerelease
+
+# Promote current version to beta
+gh workflow run release.yml -f channel=beta -f bump=prerelease
+
+# Promote to release candidate
+gh workflow run release.yml -f channel=rc -f bump=prerelease
+
+# Ship a stable GA release
+gh workflow run release.yml -f channel=stable -f bump=prerelease
+
+# Start a new minor alpha cycle
+gh workflow run release.yml -f channel=alpha -f bump=minor
+
+# Dry run (compute version without making changes)
+gh workflow run release.yml -f channel=alpha -f bump=prerelease -f dry_run=true
+```
 
 ## Branch Strategy (trunk-based)
 
-- `main`: Primary development branch — all feature work merges here. Produces `-alpha.N` prereleases via semantic-release. `main` is the source of truth for `compiler/src/version.sfn` and `CHANGELOG.md`.
+- `main`: Primary development branch — all feature work merges here. Releases are cut from `main` via the manual release workflow.
 - `beta`: Short-lived, cut from `main` when ready for beta testing. Produces `-beta.N` prereleases. Do **not** merge `beta` back into `main`; delete the branch after the beta cycle completes.
 - `rc`: Short-lived, cut from `main` (or `beta`) for release candidates. Produces `-rc.N` prereleases. Do **not** merge `rc` back into `main`; delete the branch after the RC cycle completes.
-- Fixes always land on `main` first, then cherry-pick or merge forward from `main` to `beta`/`rc` if needed. If a change made on `beta`/`rc` must be kept, cherry-pick only the non-release commits back to `main` (avoid commits that modify `compiler/src/version.sfn` or `CHANGELOG.md`).
-- When ready for a stable release, toggle `prerelease = false` on `main`'s branch config in `pyproject.toml`; no merge back from `beta`/`rc` is required.
+- Fixes always land on `main` first, then cherry-pick or merge forward from `main` to `beta`/`rc` if needed. If a change made on `beta`/`rc` must be kept, cherry-pick only the non-release commits back to `main` (avoid commits that modify `compiler/capsule.toml`, `compiler/src/version.sfn`, or `CHANGELOG.md`).
+- To promote to stable, run the release workflow with `channel=stable bump=prerelease` from `main`.
 
 ## Key Terminology
 

--- a/compiler/capsule.toml
+++ b/compiler/capsule.toml
@@ -1,0 +1,17 @@
+[capsule]
+name = "sailfin"
+version = "0.5.0-alpha.22"
+description = "The Sailfin compiler — self-hosted, targeting LLVM via .sfn-asm IR"
+
+[dependencies]
+
+[capabilities]
+required = ["io"]
+
+[build]
+entry = "src/main.sfn"
+
+# TODO: The compiler should read its version from this file at build time
+# (via capsule.toml parsing or build-time injection) so that
+# compiler/src/version.sfn no longer needs to be maintained separately.
+# Track this as part of the pre-1.0 toolchain self-sufficiency goal.

--- a/compiler/src/version.sfn
+++ b/compiler/src/version.sfn
@@ -2,7 +2,11 @@
 //
 // Native compiler CLI/compiler version string.
 //
-// Release tooling (python-semantic-release) bumps the `__version__` string.
+// The canonical version lives in compiler/capsule.toml.  Release tooling
+// (`.github/workflows/release.yml`) bumps both files in lockstep.
+//
+// TODO: Read version from capsule.toml at build time so this file can be
+// removed.  See the comment in compiler/capsule.toml.
 let __version__ = "0.5.0-alpha.22";
 
 fn sailfin_version() -> string {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,38 +1,9 @@
-[tool.semantic_release]
-version_source = "file"
-version_variables = ["compiler/src/version.sfn:__version__"]
-upload_to_pypi = false
-# GitHub Actions builds and attaches native artifacts after the tag is created.
-# Keep semantic-release fast + deterministic by skipping local build steps here.
-build_command = "true"
-commit_parser = "conventional"
-tag_format = "v{version}"
-commit_message = "chore(release): {version}"
-
-[tool.semantic_release.environment]
-github_token_var = "RELEASE_PAT"
-
-[tool.semantic_release.changelog]
-directory = "."
-filename = "CHANGELOG.md"
-include_v_prefix = true
-
-[tool.semantic_release.github]
-release_method = "github"
-# Assets are uploaded by CI (see .github/workflows/ci.yml).
-assets = []
-
-[tool.semantic_release.branches.main]
-match = "main"
-prerelease = true
-prerelease_token = "alpha"
-
-[tool.semantic_release.branches.rc]
-match = "rc"
-prerelease = true
-prerelease_token = "rc"
-
-[tool.semantic_release.branches.beta]
-match = "beta"
-prerelease = true
-prerelease_token = "beta"
+# pyproject.toml
+#
+# Semantic-release configuration has been removed.  Releases are now handled
+# by .github/workflows/release.yml (manually triggered, pure bash).
+#
+# This file is kept as a placeholder while the Conda environment
+# (environment.yml) is still used by CI.  Once the seed promotion lands and
+# the Python build driver is retired, this file and environment.yml can be
+# deleted together.


### PR DESCRIPTION
## Summary

Replaces the automatic `python-semantic-release` workflow with a manually-triggered, pure-bash release system. This gives maintainers explicit control over when and how releases are cut, eliminates Python dependencies from the release pipeline, and enables flexible channel-based versioning (alpha/beta/rc/stable).

## Key Changes

- **New release workflow** (`.github/workflows/release.yml`): Manually-triggered via `workflow_dispatch` with inputs for `channel` (alpha/beta/rc/stable) and `bump` (prerelease/patch/minor/major). Computes the next version, updates `compiler/capsule.toml` and `compiler/src/version.sfn`, commits, tags, pushes, and creates a GitHub Release. Supports dry-run mode for preview.

- **Version source of truth**: Moved from `compiler/src/version.sfn` to `compiler/capsule.toml` (`[capsule] version`). The `.sfn` file is now a mirror kept in sync by the release workflow.

- **New capsule manifest** (`compiler/capsule.toml`): Defines the compiler as a capsule with name, version, dependencies, capabilities, and build entry point. Includes a TODO to read version from this file at build time.

- **Release notes automation** (`.github/workflows/release-notes.md`): Agentic workflow that generates structured, categorized changelogs when a GitHub Release is published. Analyzes commits, reads PR descriptions, and produces well-organized release notes.

- **Release helper command** (`.claude/commands/release.md`): Claude skill documenting how to trigger releases with examples for common scenarios (cut alpha, promote to beta/rc/stable, bump minor/patch/major).

- **Updated CI workflow** (`.github/workflows/release-branches.yml`): Renamed from "Release (branches)" to "CI (branch push)" to clarify that it validates branch health but does not create releases. Removed the `semantic-release` job and `release-tag` dependency. Updated skip conditions to check for `chore(release)` commit messages instead of semantic-release author names.

- **Removed semantic-release config** (`pyproject.toml`): Stripped all `[tool.semantic_release]` configuration. File kept as placeholder while Conda environment is still in use.

- **Updated documentation** (`CLAUDE.md`): Documented the new manual release workflow, version sources, and provided CLI examples for triggering releases via `gh workflow run`.

## Implementation Details

- **Version computation**: Pure bash regex parsing of semver with prerelease support. Handles channel promotion logic (alpha → beta → rc → stable) and prevents demotions.
- **Dry-run support**: All mutation steps are guarded by `if: inputs.dry_run != true`, allowing users to preview version changes without committing.
- **Git credentials**: Uses `RELEASE_PAT` secret to configure git remote so that created tags trigger downstream workflows (unlike GITHUB_TOKEN-created tags).
- **Channel semantics**: Prerelease bumps increment `.N` suffix; patch/minor/major bumps reset prerelease to `.1` (or clean for stable); promoting to a higher channel starts at `.1`.

https://claude.ai/code/session_01DAQ2BkY34dLYhVxnFZKygG