### PR TITLE
fix(test-runner): filter diagnostic lines and add word boundaries to pass check

### DIFF
--- a/scripts/run_native_test.sh
+++ b/scripts/run_native_test.sh
@@ -43,8 +43,15 @@ if [ -z "$output" ]; then
     exit 1
 fi
 
-# Check for test pass indicators
-if grep -qiE "pass|ok|success" <<< "$output"; then
+# Strip [info] and [warn] diagnostic lines before keyword matching.
+# These lines contain file paths (e.g. error_handling_test.sfn) and internal
+# identifiers that trigger false positives.  See issue #55.
+filtered_output=$(grep -vE '^\[info\]|^\[warn\]' <<< "$output" || true)
+
+# Check for test pass indicators.
+# Word-boundary matching avoids false positives from identifiers that contain
+# "ok" (token, book), "pass" (bypass, password), etc.
+if grep -qiE '(^|[^[:alnum:]_])(pass(ed)?|ok|success)([^[:alnum:]_]|$)' <<< "$filtered_output"; then
     echo "[test] PASS: $BASENAME"
     exit 0
 fi
@@ -53,7 +60,7 @@ fi
 # Use identifier-safe boundary matching to avoid false positives from
 # identifiers like "runtime_raise_value_error_fn" in debug trace output.
 # Avoids grep -P (PCRE) since BSD grep on macOS doesn't support it.
-if grep -qiE '(^|[^[:alnum:]_])(fail(ed|ure)?|error|panic|abort)([^[:alnum:]_]|$)' <<< "$output"; then
+if grep -qiE '(^|[^[:alnum:]_])(fail(ed|ure)?|error|panic|abort)([^[:alnum:]_]|$)' <<< "$filtered_output"; then
     echo "[test] FAIL: $BASENAME"
     echo "$output" | tail -5
     exit 1


### PR DESCRIPTION
## Summary

- Strip `[info]` and `[warn]` diagnostic lines from compiler output before keyword matching — these contain file paths (e.g. `error_handling_test.sfn`) and internal identifiers that trigger false positives
- Add word-boundary matching to the pass-indicator grep (`pass|ok|success`), consistent with the failure-indicator grep that already had it — prevents "ok" matching inside "token", "pass" matching inside "password", etc.
- Both pass and fail keyword checks now operate on the filtered output

## Context

The failure-side grep (line 56) was previously fixed with word-boundary matching, but the pass-side grep (line 47) still used bare `grep -qiE "pass|ok|success"`. Neither check filtered out `[info]`/`[warn]` diagnostic lines, which was the root cause described in issue #55.

## Test plan

- [x] Verified `error_handling_test.sfn` correctly reports PASS (the exact reproduction case from #55)
- [x] Verified genuinely failing tests still report FAIL (exit code path)
- [x] Verified word-boundary matching with synthetic inputs: "token" does not match "ok", "password" does not match "pass", standalone "ok"/"passed" still match
- [x] Ran `match_statement_test.sfn`, `enum_complex_test.sfn`, `string_stress_test.sfn` — all PASS

Fixes #55

https://claude.ai/code/session_01581tG9ACWxpTSUzAVDCjkT