### PR TITLE
fix(test-runner): filter [info]/[warn] lines before error keyword grep

### DIFF
--- a/scripts/run_native_test.sh
+++ b/scripts/run_native_test.sh
@@ -50,10 +50,11 @@ if grep -qiE "pass|ok|success" <<< "$output"; then
 fi
 
 # If there's output but no pass indicator, check for explicit failures.
-# Use identifier-safe boundary matching to avoid false positives from
-# identifiers like "runtime_raise_value_error_fn" in debug trace output.
-# Avoids grep -P (PCRE) since BSD grep on macOS doesn't support it.
-if grep -qiE '(^|[^[:alnum:]_])(fail(ed|ure)?|error|panic|abort)([^[:alnum:]_]|$)' <<< "$output"; then
+# First, strip [info] and [warn] lines — they often contain file paths
+# (e.g., error_handling_test.sfn) or debug context with error keywords
+# that would cause false positives. Genuine errors use [error] or no prefix.
+filtered_output=$(grep -viE '^\[(info|warn(ing)?)\]' <<< "$output" || true)
+if [ -n "$filtered_output" ] && grep -qiE '(^|[^[:alnum:]_])(fail(ed|ure)?|error|panic|abort)([^[:alnum:]_]|$)' <<< "$filtered_output"; then
     echo "[test] FAIL: $BASENAME"
     echo "$output" | tail -5
     exit 1

--- a/scripts/run_native_test.sh
+++ b/scripts/run_native_test.sh
@@ -53,7 +53,12 @@ fi
 # First, strip [info] and [warn] lines — they often contain file paths
 # (e.g., error_handling_test.sfn) or debug context with error keywords
 # that would cause false positives. Genuine errors use [error] or no prefix.
-filtered_output=$(grep -viE '^\[(info|warn(ing)?)\]' <<< "$output" || true)
+grep_rc=0
+filtered_output=$(grep -viE '^\[(info|warn(ing)?)\]' <<< "$output") || grep_rc=$?
+if [ "$grep_rc" -gt 1 ]; then
+    echo "[test] FAIL: $BASENAME (failed to filter test output)"
+    exit "$grep_rc"
+fi
 if [ -n "$filtered_output" ] && grep -qiE '(^|[^[:alnum:]_])(fail(ed|ure)?|error|panic|abort)([^[:alnum:]_]|$)' <<< "$filtered_output"; then
     echo "[test] FAIL: $BASENAME"
     echo "$output" | tail -5


### PR DESCRIPTION
## Summary

- Fixes #55 — test runner `grep` matches error keywords in `[info]`/`[warn]` log lines, causing false FAILs when file paths or debug context contain words like "error" or "panic"
- Strips `[info]` and `[warn]` prefixed lines from compiler output before running the failure-keyword grep, so only genuine error output (`[error]` prefix or unprefixed) is inspected
- Keeps the existing word-boundary matching as a second layer of defense

## Details

The test runner checks compiler output for keywords like `error`, `fail`, `panic`, `abort` to detect failures. The compiler emits `[info]` lines containing file paths (e.g., `[info] test: compiler/tests/integration/error_handling_test.sfn`) and debug context that can contain these keywords innocuously.

A prior fix added POSIX word-boundary matching, which handles the `error_handling` case (underscore is treated as a word character). However, standalone keywords in info/warn lines still trigger false positives — for example, `[info] checking error diagnostics` or `[warn] checking for panic handlers`.

The fix filters out `[info]` and `[warn]` lines before the keyword check. This is safe because genuine errors use `[error]` prefix or no prefix, both of which are preserved.

## Test plan

- [x] Verified `error_handling_test.sfn` passes with the fixed script (was the original reproduction case)
- [x] Verified genuine failures are still detected (assertion failure → exit code 134 → FAIL)
- [x] Tested synthetic edge cases: `[info]` with error in path, `[warn]` with panic keyword, `[error]` prefix preserved, unprefixed `panic:` preserved
- [x] Ran the fixed script against 4 test files (`error_handling_test`, `match_statement_test`, `enum_complex_test`, `loop_edge_cases_test`) — all PASS

https://claude.ai/code/session_01AmcMAdM93iwhvaLSNTWpqm