### PR TITLE
fix: publish digest format, path arg, error surfacing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,13 +109,13 @@ test: test-unit test-integration test-e2e
 # Install a released seed compiler into the workspace.
 # Requires a GitHub token in GITHUB_TOKEN.
 SEED_REPO ?= SailfinIO/sailfin
-SEED_VERSION ?= 0.5.0-alpha.22
+SEED_VERSION ?= 0.5.0-alpha.24
 SEED_EXCLUDE_TAG ?=
 SEED_INSTALL_BASE ?= build/seed/versions
 SEED_GLOBAL_BIN_DIR ?= build/seed/bin
 
 # Default seed compiler used for self-hosting.
-# Points to the fetched seed binary (0.5.0-alpha.22+).
+# Points to the fetched seed binary (0.5.0-alpha.24+).
 SEED ?= build/seed/bin/sailfin
 
 FETCHED_SEED ?= $(SEED_GLOBAL_BIN_DIR)/sailfin$(EXE_EXT)
@@ -328,7 +328,7 @@ check:
 				h2=$$(sha256sum "$$f" | awk '{print $$1}'); \
 				h3=$$(sha256sum "$$s3f" | awk '{print $$1}'); \
 				if [ "$$h2" != "$$h3" ]; then \
-					echo "[check][WARN]   $$base (stage2=$${h2:0:12}... stage3=$${h3:0:12}...)"; \
+					echo "[check][WARN]   $$base (stage2=$$(printf '%.12s' "$$h2")... stage3=$$(printf '%.12s' "$$h3")...)"; \
 				fi; \
 			else \
 				echo "[check][WARN]   $$base (missing in stage3)"; \

--- a/compiler/src/cli_commands.sfn
+++ b/compiler/src/cli_commands.sfn
@@ -575,7 +575,7 @@ fn handle_publish_command(args -> string[]) -> number ![io] {
             + "\",\"version\":\"" + pkg_version
             + "\",\"digest\":\"" + digest
             + "\",\"content_b64\":\"' > " + body_tmp
-            + " && base64 -w0 '" + payload_tmp + "' >> " + body_tmp
+            + " && base64 < '" + payload_tmp + "' | tr -d '\\n' >> " + body_tmp
             + " && printf '\",\"meta\":{}}' >> " + body_tmp
     ]);
     if build_json_rc != 0 {

--- a/compiler/src/cli_commands.sfn
+++ b/compiler/src/cli_commands.sfn
@@ -478,15 +478,30 @@ fn handle_test_command(args -> string[], runtime_root -> string) -> number ![io]
 }
 
 fn handle_publish_command(args -> string[]) -> number ![io] {
-    if args.length != 1 {
-        print("usage: sfn publish");
+    if args.length > 2 {
+        print("usage: sfn publish [path]");
         return 2;
     }
-    if !fs.exists("capsule.toml") {
+    let mut capsule_dir -> string = "";
+    if args.length == 2 {
+        capsule_dir = args[1];
+        if capsule_dir.length > 0 {
+            if substring(capsule_dir, capsule_dir.length - 1, capsule_dir.length) == "/" {
+                capsule_dir = substring(capsule_dir, 0, capsule_dir.length - 1);
+            }
+        }
+    }
+    let mut toml_path -> string = "capsule.toml";
+    let mut src_dir -> string = "src";
+    if capsule_dir.length > 0 {
+        toml_path = capsule_dir + "/capsule.toml";
+        src_dir = capsule_dir + "/src";
+    }
+    if !fs.exists(toml_path) {
         print("no capsule.toml found — run `sfn init` first");
         return 1;
     }
-    let toml_text = fs.readFile("capsule.toml");
+    let toml_text = fs.readFile(toml_path);
     let pkg_name = toml_get_name(toml_text);
     let pkg_version = toml_get_version(toml_text);
     if pkg_name.length == 0 {
@@ -521,24 +536,29 @@ fn handle_publish_command(args -> string[]) -> number ![io] {
     let mut payload -> string = "SFNPKG/1\n";
     payload = payload + "--- path: capsule.toml\n" + toml_text + "\n";
 
-    let src_files = _collect_sfn_files_cmd("src", 10);
+    let src_files = _collect_sfn_files_cmd(src_dir, 10);
     let mut fi -> number = 0;
     loop {
         if fi >= src_files.length { break; }
         let file_path = src_files[fi];
         let content = fs.readFile(file_path);
-        payload = payload + "--- path: " + file_path + "\n" + content + "\n";
+        let mut rel_path -> string = file_path;
+        if capsule_dir.length > 0 {
+            rel_path = substring(file_path, capsule_dir.length + 1, file_path.length);
+        }
+        payload = payload + "--- path: " + rel_path + "\n" + content + "\n";
         fi += 1;
     }
 
     let payload_tmp = "/tmp/.sfn_payload_tmp";
     fs.writeFile(payload_tmp, payload);
-    let digest = _sha256_of_file_cmd(payload_tmp);
-    if digest.length == 0 {
+    let raw_digest = _sha256_of_file_cmd(payload_tmp);
+    if raw_digest.length == 0 {
         print("failed to compute digest");
         process.run(["rm", "-f", payload_tmp]);
         return 1;
     }
+    let digest = "sha256:" + raw_digest;
 
     let body_tmp = "/tmp/.sfn_publish_body_tmp";
     let build_json_rc = process.run(["sh", "-c",
@@ -558,12 +578,40 @@ fn handle_publish_command(args -> string[]) -> number ![io] {
     let auth_header = "Bearer " + token;
     let registry_url = "https://registry.sailfin.dev/api/publish";
     print("publishing to " + registry_url + "...");
-    let response = _curl_post_json_cmd(registry_url, body_tmp, auth_header);
+    let response_tmp = "/tmp/.sfn_publish_response_tmp";
+    let status_tmp = "/tmp/.sfn_publish_status_tmp";
+    let curl_rc = process.run(["sh", "-c",
+        "curl -sS -X POST"
+        + " -H 'Content-Type: application/json'"
+        + " -H 'Authorization: " + auth_header + "'"
+        + " -d @" + body_tmp
+        + " -o " + response_tmp
+        + " -w '%{http_code}' " + registry_url
+        + " > " + status_tmp
+    ]);
     process.run(["rm", "-f", payload_tmp]);
     process.run(["rm", "-f", body_tmp]);
-    if response.length == 0 {
-        print("publish failed — check your token and network connection");
+    let mut response -> string = "";
+    if fs.exists(response_tmp) {
+        response = _toml_trim_cmd(fs.readFile(response_tmp));
+        process.run(["rm", "-f", response_tmp]);
+    }
+    let mut status -> string = "";
+    if fs.exists(status_tmp) {
+        status = _toml_trim_cmd(fs.readFile(status_tmp));
+        process.run(["rm", "-f", status_tmp]);
+    }
+    if curl_rc != 0 {
+        print("publish failed — could not reach registry");
+        if response.length > 0 { print("server: " + response); }
         return 1;
+    }
+    if status.length >= 1 {
+        if substring(status, 0, 1) != "2" {
+            print("publish failed (HTTP " + status + ")");
+            if response.length > 0 { print("server: " + response); }
+            return 1;
+        }
     }
     print(response);
     return 0;

--- a/compiler/src/cli_commands.sfn
+++ b/compiler/src/cli_commands.sfn
@@ -550,7 +550,11 @@ fn handle_publish_command(args -> string[]) -> number ![io] {
         fi += 1;
     }
 
-    let payload_tmp = "/tmp/.sfn_payload_tmp";
+    let payload_tmp = _shell_read_cmd("mktemp /tmp/.sfn_pub_XXXXXX");
+    if payload_tmp.length == 0 {
+        print("failed to create temp file");
+        return 1;
+    }
     fs.writeFile(payload_tmp, payload);
     let raw_digest = _sha256_of_file_cmd(payload_tmp);
     if raw_digest.length == 0 {
@@ -560,7 +564,12 @@ fn handle_publish_command(args -> string[]) -> number ![io] {
     }
     let digest = "sha256:" + raw_digest;
 
-    let body_tmp = "/tmp/.sfn_publish_body_tmp";
+    let body_tmp = _shell_read_cmd("mktemp /tmp/.sfn_pub_XXXXXX");
+    if body_tmp.length == 0 {
+        print("failed to create temp file");
+        process.run(["rm", "-f", payload_tmp]);
+        return 1;
+    }
     let build_json_rc = process.run(["sh", "-c",
             "printf '{\"type\":\"capsule\",\"capsule\":\"" + pkg_name
             + "\",\"version\":\"" + pkg_version
@@ -572,22 +581,22 @@ fn handle_publish_command(args -> string[]) -> number ![io] {
     if build_json_rc != 0 {
         print("failed to build publish payload");
         process.run(["rm", "-f", payload_tmp]);
+        process.run(["rm", "-f", body_tmp]);
         return 1;
     }
 
     let auth_header = "Bearer " + token;
     let registry_url = "https://registry.sailfin.dev/api/publish";
     print("publishing to " + registry_url + "...");
-    let response_tmp = "/tmp/.sfn_publish_response_tmp";
-    let status_tmp = "/tmp/.sfn_publish_status_tmp";
-    let curl_rc = process.run(["sh", "-c",
-        "curl -sS -X POST"
-        + " -H 'Content-Type: application/json'"
-        + " -H 'Authorization: " + auth_header + "'"
-        + " -d @" + body_tmp
-        + " -o " + response_tmp
-        + " -w '%{http_code}' " + registry_url
-        + " > " + status_tmp
+    let response_tmp = _shell_read_cmd("mktemp /tmp/.sfn_pub_XXXXXX");
+    let header_tmp = _shell_read_cmd("mktemp /tmp/.sfn_pub_XXXXXX");
+    let curl_rc = process.run(["curl", "-sS", "-X", "POST",
+        "-H", "Content-Type: application/json",
+        "-H", "Authorization: " + auth_header,
+        "-d", "@" + body_tmp,
+        "-o", response_tmp,
+        "-D", header_tmp,
+        registry_url
     ]);
     process.run(["rm", "-f", payload_tmp]);
     process.run(["rm", "-f", body_tmp]);
@@ -597,9 +606,15 @@ fn handle_publish_command(args -> string[]) -> number ![io] {
         process.run(["rm", "-f", response_tmp]);
     }
     let mut status -> string = "";
-    if fs.exists(status_tmp) {
-        status = _toml_trim_cmd(fs.readFile(status_tmp));
-        process.run(["rm", "-f", status_tmp]);
+    if fs.exists(header_tmp) {
+        let headers = fs.readFile(header_tmp);
+        process.run(["rm", "-f", header_tmp]);
+        let sp = find_char(headers, " ", 0);
+        if sp >= 0 {
+            if headers.length >= sp + 4 {
+                status = substring(headers, sp + 1, sp + 4);
+            }
+        }
     }
     if curl_rc != 0 {
         print("publish failed — could not reach registry");

--- a/compiler/src/cli_main.sfn
+++ b/compiler/src/cli_main.sfn
@@ -32,7 +32,7 @@ fn _usage() -> string {
     "  sfn run <exe>\n" +
     "  sfn test [path]\n" +
     "  sfn init\n" +
-    "  sfn publish\n" +
+    "  sfn publish [path]\n" +
     "  sfn add [--dev] <capsule>\n" +
     "  sfn login [token]\n" +
     "\n" +
@@ -44,7 +44,7 @@ fn _usage() -> string {
     "  sfn run build/native/examples/hello\n" +
     "  sfn test .\n" +
     "  sfn init\n" +
-    "  sfn publish\n" +
+    "  sfn publish [path]\n" +
     "  sfn add http\n" +
     "  sfn add --dev test\n" +
     "  sfn add acme/router\n" +

--- a/compiler/tests/e2e/test_publish.sh
+++ b/compiler/tests/e2e/test_publish.sh
@@ -10,13 +10,17 @@
 
 set -euo pipefail
 
-BINARY="$(realpath "${1:?usage: test_publish.sh <compiler-binary>}")"
+BINARY="$(cd "$(dirname "${1:?usage: test_publish.sh <compiler-binary>}")" && pwd)/$(basename "$1")"
 PASS=0
 FAIL=0
 
 # Prevent the real SFN_TOKEN from leaking into tests — each test that needs
 # a token provides one explicitly via credentials file or env override.
 unset SFN_TOKEN 2>/dev/null || true
+
+# Portable sha256 and base64 helpers (GNU vs macOS)
+_sha256() { sha256sum "$@" 2>/dev/null || shasum -a 256 "$@"; }
+_b64decode() { base64 -d 2>/dev/null || base64 -D; }
 
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT
@@ -162,15 +166,15 @@ $(cat "$workdir/capsule.toml")
 $(cat "$workdir/src/mod.sfn")
 "
     local expected_hex
-    expected_hex="$(printf '%s' "$payload_content" | sha256sum | cut -d' ' -f1)"
+    expected_hex="$(printf '%s' "$payload_content" | _sha256 | cut -d' ' -f1)"
     local expected_digest="sha256:$expected_hex"
 
     # Now verify the format by checking what the binary would produce.
-    # Write the same payload to a temp file and confirm sha256sum output.
+    # Write the same payload to a temp file and confirm sha256 output.
     local verify_tmp="$tmpdir/t7_verify"
     printf '%s' "$payload_content" > "$verify_tmp"
     local actual_hex
-    actual_hex="$(sha256sum "$verify_tmp" | cut -d' ' -f1)"
+    actual_hex="$(_sha256 "$verify_tmp" | cut -d' ' -f1)"
     [ "$actual_hex" = "$expected_hex" ] \
         || { echo "digest hex mismatch: expected $expected_hex, got $actual_hex"; return 1; }
     # The key assertion: the code prepends "sha256:" — we can verify this by
@@ -250,7 +254,7 @@ SHIM
     content_b64="$(grep -o '"content_b64":"[^"]*"' "$captured_body" \
         | sed 's/"content_b64":"//;s/"$//')"
     local decoded
-    decoded="$(echo "$content_b64" | base64 -d)"
+    decoded="$(echo "$content_b64" | _b64decode)"
     # Should contain "--- path: src/mod.sfn", not the absolute/prefixed path
     echo "$decoded" | grep -q "^--- path: src/mod.sfn" \
         || { echo "expected relative path 'src/mod.sfn' in SFNPKG, got:"; echo "$decoded" | grep "^--- path:"; return 1; }
@@ -271,25 +275,24 @@ test_publish_surfaces_http_error() {
 
     local shim_dir="$tmpdir/t9_shim"
     mkdir -p "$shim_dir"
-    # Create a curl shim that writes a 400 response with an error body
+    # Create a curl shim that writes a 400 response body and header
     cat > "$shim_dir/curl" <<'SHIM'
 #!/usr/bin/env bash
-# Parse -o and -w flags to write response and status
+# Parse -o and -D flags to write response body and headers
 out_file=""
-status_redir=""
+hdr_file=""
 prev=""
 for arg in "$@"; do
-    if [ "$prev" = "-o" ]; then
-        out_file="$arg"
-    fi
+    if [ "$prev" = "-o" ]; then out_file="$arg"; fi
+    if [ "$prev" = "-D" ]; then hdr_file="$arg"; fi
     prev="$arg"
 done
-# Write error JSON to the -o file
 if [ -n "$out_file" ]; then
     echo '{"error":"Digest mismatch: expected sha256:abc, got sha256:def"}' > "$out_file"
 fi
-# -w '%{http_code}' output goes to stdout (which the caller redirects)
-printf '400'
+if [ -n "$hdr_file" ]; then
+    printf 'HTTP/1.1 400 Bad Request\r\nContent-Type: application/json\r\n\r\n' > "$hdr_file"
+fi
 exit 0
 SHIM
     chmod +x "$shim_dir/curl"

--- a/compiler/tests/e2e/test_publish.sh
+++ b/compiler/tests/e2e/test_publish.sh
@@ -1,0 +1,316 @@
+#!/usr/bin/env bash
+# End-to-end tests for `sfn publish`.
+#
+# Usage:
+#   compiler/tests/e2e/test_publish.sh <compiler-binary>
+#
+# Tests argument handling, capsule discovery, SFNPKG packaging, and digest
+# format.  Network-dependent tests use a tiny HTTP stub so the real registry
+# is never contacted.
+
+set -euo pipefail
+
+BINARY="$(realpath "${1:?usage: test_publish.sh <compiler-binary>}")"
+PASS=0
+FAIL=0
+
+# Prevent the real SFN_TOKEN from leaking into tests — each test that needs
+# a token provides one explicitly via credentials file or env override.
+unset SFN_TOKEN 2>/dev/null || true
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+run_test() {
+    local name="$1"
+    shift
+    if "$@"; then
+        echo "[test] PASS: $name"
+        PASS=$((PASS + 1))
+    else
+        echo "[test] FAIL: $name"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# Helper: create a minimal capsule directory
+make_capsule() {
+    local dir="$1"
+    local name="${2:-test/pkg}"
+    local version="${3:-1.0.0}"
+    mkdir -p "$dir/src"
+    cat > "$dir/capsule.toml" <<EOF
+[capsule]
+name = "$name"
+version = "$version"
+
+[dependencies]
+
+[capabilities]
+required = ["io"]
+
+[build]
+entry = "src/mod.sfn"
+EOF
+    cat > "$dir/src/mod.sfn" <<'EOF'
+fn hello() -> string {
+    return "hello";
+}
+EOF
+}
+
+# ---- Test 1: publish with too many args shows usage ----
+test_publish_too_many_args() {
+    local home="$tmpdir/t1"
+    mkdir -p "$home"
+    local output
+    output="$(HOME="$home" "$BINARY" publish a b 2>&1 || true)"
+    echo "$output" | grep -qi "usage" || { echo "expected usage message, got: $output"; return 1; }
+}
+
+# ---- Test 2: publish with no capsule.toml fails ----
+test_publish_no_capsule_toml() {
+    local home="$tmpdir/t2"
+    local workdir="$tmpdir/t2_work"
+    mkdir -p "$home/.sfn" "$workdir"
+    echo "fake-token" > "$home/.sfn/credentials"
+    local output
+    output="$(cd "$workdir" && HOME="$home" "$BINARY" publish 2>&1 || true)"
+    echo "$output" | grep -q "no capsule.toml found" || { echo "expected 'no capsule.toml found', got: $output"; return 1; }
+}
+
+# ---- Test 3: publish with path arg finds capsule.toml ----
+test_publish_path_finds_capsule() {
+    local home="$tmpdir/t3"
+    local workdir="$tmpdir/t3_work"
+    mkdir -p "$home/.sfn" "$workdir"
+    echo "fake-token" > "$home/.sfn/credentials"
+    make_capsule "$workdir/my/capsule"
+    # Run from tmpdir — not inside the capsule — with a path arg.
+    # It will fail at the curl step (no registry), but the output should show
+    # the packaging message which proves it found capsule.toml via the path.
+    local output
+    output="$(cd "$tmpdir" && HOME="$home" "$BINARY" publish "$workdir/my/capsule" 2>&1 || true)"
+    echo "$output" | grep -q "packaging test/pkg@1.0.0" \
+        || { echo "expected 'packaging test/pkg@1.0.0', got: $output"; return 1; }
+}
+
+# ---- Test 4: publish with trailing-slash path still works ----
+test_publish_trailing_slash() {
+    local home="$tmpdir/t4"
+    local workdir="$tmpdir/t4_work"
+    mkdir -p "$home/.sfn" "$workdir"
+    echo "fake-token" > "$home/.sfn/credentials"
+    make_capsule "$workdir/cap"
+    local output
+    output="$(cd "$tmpdir" && HOME="$home" "$BINARY" publish "$workdir/cap/" 2>&1 || true)"
+    echo "$output" | grep -q "packaging test/pkg@1.0.0" \
+        || { echo "expected packaging message with trailing slash path, got: $output"; return 1; }
+}
+
+# ---- Test 5: publish without path uses cwd ----
+test_publish_cwd() {
+    local home="$tmpdir/t5"
+    local workdir="$tmpdir/t5_work"
+    mkdir -p "$home/.sfn"
+    echo "fake-token" > "$home/.sfn/credentials"
+    make_capsule "$workdir" "my/cap" "2.0.0"
+    local output
+    output="$(cd "$workdir" && HOME="$home" "$BINARY" publish 2>&1 || true)"
+    echo "$output" | grep -q "packaging my/cap@2.0.0" \
+        || { echo "expected 'packaging my/cap@2.0.0', got: $output"; return 1; }
+}
+
+# ---- Test 6: publish with no token fails ----
+test_publish_no_token() {
+    local home="$tmpdir/t6"
+    local workdir="$tmpdir/t6_work"
+    mkdir -p "$home"
+    make_capsule "$workdir"
+    local output
+    output="$(cd "$workdir" && HOME="$home" "$BINARY" publish 2>&1 || true)"
+    echo "$output" | grep -q "no auth token found" \
+        || { echo "expected 'no auth token found', got: $output"; return 1; }
+}
+
+# ---- Test 7: digest in payload has sha256: prefix ----
+test_publish_digest_format() {
+    local home="$tmpdir/t7"
+    local workdir="$tmpdir/t7_work"
+    mkdir -p "$home/.sfn"
+    echo "fake-token" > "$home/.sfn/credentials"
+    make_capsule "$workdir"
+    # Run publish — it will build the JSON payload then fail at curl.
+    # Inspect the payload temp file before cleanup by racing it.
+    # Safer approach: just check that /tmp/.sfn_publish_body_tmp was written
+    # with the correct digest prefix by pausing curl with a bogus URL.
+    #
+    # We override the registry URL by pointing curl at localhost:0 which
+    # will fail fast but the body file is written before curl runs.
+    # Actually, the body file is cleaned up after curl. Instead, copy it
+    # in a wrapper.
+    #
+    # Simplest: build the payload ourselves and verify the format.
+    (cd "$workdir" && HOME="$home" "$BINARY" publish 2>&1 || true)
+    # The temp files are cleaned up, so instead we reconstruct and verify
+    # the digest computation matches what the code would produce.
+    local payload_content
+    payload_content="SFNPKG/1
+--- path: capsule.toml
+$(cat "$workdir/capsule.toml")
+--- path: src/mod.sfn
+$(cat "$workdir/src/mod.sfn")
+"
+    local expected_hex
+    expected_hex="$(printf '%s' "$payload_content" | sha256sum | cut -d' ' -f1)"
+    local expected_digest="sha256:$expected_hex"
+
+    # Now verify the format by checking what the binary would produce.
+    # Write the same payload to a temp file and confirm sha256sum output.
+    local verify_tmp="$tmpdir/t7_verify"
+    printf '%s' "$payload_content" > "$verify_tmp"
+    local actual_hex
+    actual_hex="$(sha256sum "$verify_tmp" | cut -d' ' -f1)"
+    [ "$actual_hex" = "$expected_hex" ] \
+        || { echo "digest hex mismatch: expected $expected_hex, got $actual_hex"; return 1; }
+    # The key assertion: the code prepends "sha256:" — we can verify this by
+    # intercepting the body file. Use a shim that copies it before cleanup.
+    local shim_dir="$tmpdir/t7_shim"
+    local captured_body="$tmpdir/t7_body"
+    mkdir -p "$shim_dir"
+    # Create a curl shim that captures the body file before the real curl runs
+    cat > "$shim_dir/curl" <<'SHIM'
+#!/usr/bin/env bash
+# Extract -d @<path> argument and copy the body
+for i in "${!args[@]}"; do : ; done
+body_file=""
+for arg in "$@"; do
+    if [[ "$arg" == @* ]]; then
+        body_file="${arg#@}"
+        break
+    fi
+done
+if [ -n "$body_file" ] && [ -f "$body_file" ]; then
+    cp "$body_file" "${CAPTURE_BODY_TO}"
+fi
+# Fail so publish doesn't actually succeed
+exit 1
+SHIM
+    chmod +x "$shim_dir/curl"
+    CAPTURE_BODY_TO="$captured_body" PATH="$shim_dir:$PATH" \
+        HOME="$home" "$BINARY" publish "$workdir" 2>&1 || true
+    if [ ! -f "$captured_body" ]; then
+        echo "curl shim did not capture request body"
+        return 1
+    fi
+    # Check digest field in the JSON payload
+    if ! grep -qo '"digest":"sha256:[0-9a-f]\{64\}"' "$captured_body"; then
+        local got
+        got="$(grep -o '"digest":"[^"]*"' "$captured_body" || echo '<not found>')"
+        echo "expected digest with sha256: prefix, got: $got"
+        return 1
+    fi
+}
+
+# ---- Test 8: SFNPKG paths are relative even with path arg ----
+test_publish_relative_paths_in_payload() {
+    local home="$tmpdir/t8"
+    local workdir="$tmpdir/t8_work"
+    mkdir -p "$home/.sfn"
+    echo "fake-token" > "$home/.sfn/credentials"
+    make_capsule "$workdir/nested/cap"
+
+    local shim_dir="$tmpdir/t8_shim"
+    local captured_body="$tmpdir/t8_body"
+    mkdir -p "$shim_dir"
+    cat > "$shim_dir/curl" <<'SHIM'
+#!/usr/bin/env bash
+body_file=""
+for arg in "$@"; do
+    if [[ "$arg" == @* ]]; then
+        body_file="${arg#@}"
+        break
+    fi
+done
+if [ -n "$body_file" ] && [ -f "$body_file" ]; then
+    cp "$body_file" "${CAPTURE_BODY_TO}"
+fi
+exit 1
+SHIM
+    chmod +x "$shim_dir/curl"
+    CAPTURE_BODY_TO="$captured_body" PATH="$shim_dir:$PATH" \
+        HOME="$home" "$BINARY" publish "$workdir/nested/cap" 2>&1 || true
+
+    if [ ! -f "$captured_body" ]; then
+        echo "curl shim did not capture request body"
+        return 1
+    fi
+    # Decode content_b64 from the JSON and check paths are relative
+    local content_b64
+    content_b64="$(grep -o '"content_b64":"[^"]*"' "$captured_body" \
+        | sed 's/"content_b64":"//;s/"$//')"
+    local decoded
+    decoded="$(echo "$content_b64" | base64 -d)"
+    # Should contain "--- path: src/mod.sfn", not the absolute/prefixed path
+    echo "$decoded" | grep -q "^--- path: src/mod.sfn" \
+        || { echo "expected relative path 'src/mod.sfn' in SFNPKG, got:"; echo "$decoded" | grep "^--- path:"; return 1; }
+    # Should NOT contain the workdir prefix in any path entry
+    if echo "$decoded" | grep "^--- path:.*nested/cap"; then
+        echo "SFNPKG contains absolute/prefixed path — should be relative"
+        return 1
+    fi
+}
+
+# ---- Test 9: publish surfaces HTTP error details ----
+test_publish_surfaces_http_error() {
+    local home="$tmpdir/t9"
+    local workdir="$tmpdir/t9_work"
+    mkdir -p "$home/.sfn"
+    echo "fake-token" > "$home/.sfn/credentials"
+    make_capsule "$workdir"
+
+    local shim_dir="$tmpdir/t9_shim"
+    mkdir -p "$shim_dir"
+    # Create a curl shim that writes a 400 response with an error body
+    cat > "$shim_dir/curl" <<'SHIM'
+#!/usr/bin/env bash
+# Parse -o and -w flags to write response and status
+out_file=""
+status_redir=""
+prev=""
+for arg in "$@"; do
+    if [ "$prev" = "-o" ]; then
+        out_file="$arg"
+    fi
+    prev="$arg"
+done
+# Write error JSON to the -o file
+if [ -n "$out_file" ]; then
+    echo '{"error":"Digest mismatch: expected sha256:abc, got sha256:def"}' > "$out_file"
+fi
+# -w '%{http_code}' output goes to stdout (which the caller redirects)
+printf '400'
+exit 0
+SHIM
+    chmod +x "$shim_dir/curl"
+    local output
+    output="$(cd "$workdir" && PATH="$shim_dir:$PATH" HOME="$home" "$BINARY" publish 2>&1 || true)"
+    echo "$output" | grep -q "HTTP 400" \
+        || { echo "expected 'HTTP 400' in output, got: $output"; return 1; }
+    echo "$output" | grep -q "Digest mismatch" \
+        || { echo "expected 'Digest mismatch' in server error, got: $output"; return 1; }
+}
+
+run_test "publish too many args shows usage" test_publish_too_many_args
+run_test "publish with no capsule.toml fails" test_publish_no_capsule_toml
+run_test "publish with path arg finds capsule" test_publish_path_finds_capsule
+run_test "publish with trailing slash works" test_publish_trailing_slash
+run_test "publish without path uses cwd" test_publish_cwd
+run_test "publish with no token fails" test_publish_no_token
+run_test "publish digest has sha256: prefix" test_publish_digest_format
+run_test "publish paths are relative with path arg" test_publish_relative_paths_in_payload
+run_test "publish surfaces HTTP error details" test_publish_surfaces_http_error
+
+echo ""
+echo "publish tests: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary
- **Digest format**: prepend `sha256:` to the SHA256 hex digest sent to the registry — the server expects Content-Addressable Storage format but the client was sending bare hex, causing every publish to fail with a 400 Digest mismatch
- **Path argument**: `sfn publish [path]` now accepts an optional capsule directory so you don't have to `cd` into it first; trailing slashes are stripped and SFNPKG paths remain relative
- **Error surfacing**: replace the silent `-f` curl flag with status code + response body capture, so failures show `publish failed (HTTP 400) / server: {"error":"Digest mismatch: ..."}` instead of the generic "check your token and network connection"
- **Makefile**: fix POSIX-incompatible `${var:0:12}` bash substring in the fixed-point check (dash doesn't support it), bump seed version pin to 0.5.0-alpha.24

## Test plan
- [x] 9 new e2e tests in `test_publish.sh` covering argument parsing, capsule discovery, digest format, relative SFNPKG paths, token guards, and HTTP error display
- [x] All existing tests pass (46 unit, 17 integration, 4 e2e suites)
- [x] `make check` passes through seedcheck build and stage3 comparison
- [ ] Manual smoke test: `sfn publish capsules/sfn/cli` against the Pi registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)