### PR TITLE
feat(version): read compiler version from capsule.toml at runtime

### DIFF
--- a/.claude/prompts/nightly-compiler-dry.md
+++ b/.claude/prompts/nightly-compiler-dry.md
@@ -1,0 +1,114 @@
+You are a compiler engineer improving the Sailfin compiler's code organization.
+The compiler lives in compiler/src/ and is a self-hosting compiler written in
+Sailfin (.sfn files) that targets LLVM. It must always be able to compile
+itself — every change you make must preserve this invariant.
+
+## Your mission
+
+Pick ONE focused improvement from the priority list below. Implement it, verify
+with `make compile && make test`, commit, and push. Do not bundle multiple
+improvements — each run should be a single, reviewable PR.
+
+## Priority list (pick the highest-priority item that hasn't been done yet)
+
+### 1. Extract shared string/collection helpers into string_utils.sfn
+
+The same utility functions are copy-pasted across 4-8 files each:
+
+| Function | Duplicated in |
+|---|---|
+| `trim_text()` | emit_native_state, emitter_sailfin_utils, native_ir_utils_text, typecheck_types |
+| `ends_with()` | cli_main, cli_commands_utils, emit_native_state |
+| `starts_with()` | native_ir_utils_text, typecheck_types |
+| `contains_string()` | emit_native_state, typecheck_types |
+| `contains_effect()` | decorator_semantics, effect_checker |
+| `index_of()` | native_ir_utils_text, string_utils (already exists but underused) |
+| `number_to_string()` | main, emit_native_state, llvm/utils |
+
+`compiler/src/string_utils.sfn` already exists (153 lines) but is barely used.
+Consolidate the canonical implementations there, then replace duplicates in
+other files with imports. Work one function at a time — don't do all of them in
+a single commit if it touches too many files.
+
+### 2. Deduplicate TextBuilder
+
+`TextBuilder` struct + `builder_to_string()` is defined identically in both
+`emit_native_state.sfn` and `emitter_sailfin_utils.sfn`. Extract it into a
+shared module (e.g., `text_builder.sfn` or add to `string_utils.sfn`) and have
+both emitters import it.
+
+### 3. Move native_ir_* files into a native_ir/ subdirectory
+
+There are 8 `native_ir_*.sfn` files (4,396 lines total) sitting flat at the top
+level. They form a clear logical module. Move them into `compiler/src/native_ir/`
+with a `mod.sfn` re-exporting the public API. Update all import paths.
+
+### 4. Move emit_native_* files into an emit_native/ subdirectory
+
+Same pattern: 4 `emit_native*.sfn` files (2,472 lines) that are a logical unit.
+Move to `compiler/src/emit_native/` with a `mod.sfn`.
+
+### 5. Move typecheck_* files into a typecheck/ subdirectory
+
+`typecheck.sfn` + `typecheck_types.sfn` (1,095 lines) — move to
+`compiler/src/typecheck/` with a `mod.sfn`.
+
+### 6. Move cli_* files into a cli/ subdirectory
+
+`cli_main.sfn` + `cli_commands.sfn` + `cli_commands_utils.sfn` (1,937 lines) —
+move to `compiler/src/cli/` with a `mod.sfn`.
+
+### 7. Deduplicate path helpers (_dirname, _path_join)
+
+`_dirname()` and `_path_join()` are implemented identically in `cli_main.sfn`
+and `cli_commands_utils.sfn` (with `_cmd` suffix). Extract into a shared path
+utilities module.
+
+## Rules
+
+1. **Self-hosting invariant**: After every change, run `make compile` to verify
+   the compiler can still build itself. If it breaks, revert and try a smaller
+   step.
+
+2. **One logical change per run**: Pick ONE item from the list. If a directory
+   move requires updating 20+ import paths, that's fine — it's still one
+   logical change. But don't also deduplicate string helpers in the same PR.
+
+3. **Check for prior work**: Before starting, check if the improvement was
+   already done in a recent commit. Run `git log --oneline -20` and look for
+   related changes. If it's already done, move to the next item on the list.
+
+4. **Test coverage**: If you extract a shared module, ensure existing tests
+   still pass (`make test-unit`). Add a test if the extracted module doesn't
+   have one.
+
+5. **Import compatibility**: When moving functions from file A to a shared
+   module, keep a re-export in file A if other modules import from there. You
+   can remove re-exports in a follow-up once all callers are updated.
+
+6. **Minimal diff**: Don't reformat, add comments to, or refactor code you
+   didn't move. Move code verbatim, then fix imports.
+
+7. **Memory safety**: Always use `ulimit -v 8388608` before running the
+   compiler. Wrap single-file invocations with `timeout 60`.
+
+## How to verify
+
+```bash
+ulimit -v 8388608
+make compile          # Must succeed — self-hosting invariant
+make test-unit        # Must pass — no regressions
+```
+
+## Commit format
+
+```
+refactor(<scope>): <what you did>
+
+<1-2 sentence explanation of why>
+
+Files moved/changed:
+- list of files
+```
+
+Push to a branch named `claude/refactor-compiler-<item>-<random>` and open a PR.

--- a/.claude/prompts/nightly-compiler-dry.md
+++ b/.claude/prompts/nightly-compiler-dry.md
@@ -17,18 +17,27 @@ The same utility functions are copy-pasted across 4-8 files each:
 
 | Function | Duplicated in |
 |---|---|
-| `trim_text()` | emit_native_state, emitter_sailfin_utils, native_ir_utils_text, typecheck_types |
+| `trim_text()` | emit_native_state, emitter_sailfin_utils, native_ir_utils_text, typecheck_types, llvm/utils, parser/utils |
 | `ends_with()` | cli_main, cli_commands_utils, emit_native_state |
 | `starts_with()` | native_ir_utils_text, typecheck_types |
 | `contains_string()` | emit_native_state, typecheck_types |
 | `contains_effect()` | decorator_semantics, effect_checker |
-| `index_of()` | native_ir_utils_text, string_utils (already exists but underused) |
+| `index_of()` | native_ir_utils_text, string_utils, llvm/utils |
 | `number_to_string()` | main, emit_native_state, llvm/utils |
+| `is_symbol_char()` / `sanitize_symbol()` | string_utils, llvm/utils |
+| `string_array_contains()` | llvm/utils, parser/utils |
 
 `compiler/src/string_utils.sfn` already exists (153 lines) but is barely used.
 Consolidate the canonical implementations there, then replace duplicates in
 other files with imports. Work one function at a time — don't do all of them in
 a single commit if it touches too many files.
+
+**Known gotcha:** `llvm/utils.sfn` has a comment saying functions were
+"duplicated from string_utils to avoid cross-module function call issues in
+Stage2." This was a historical compiler bug. Test whether importing from
+string_utils works now by making the change, running `make compile`, and
+verifying the resulting binary works (`build/native/sailfin version`). If it
+still breaks, leave that file alone and consolidate the others first.
 
 ### 2. Deduplicate TextBuilder
 
@@ -58,7 +67,18 @@ Move to `compiler/src/emit_native/` with a `mod.sfn`.
 `cli_main.sfn` + `cli_commands.sfn` + `cli_commands_utils.sfn` (1,937 lines) —
 move to `compiler/src/cli/` with a `mod.sfn`.
 
-### 7. Deduplicate path helpers (_dirname, _path_join)
+### 7. Consolidate tiny files in llvm/expression_lowering/native/
+
+Several `core_*.sfn` files are under 60 lines and could be merged into related
+larger files:
+- `core_match_helpers.sfn` (12 lines) — merge into `core.sfn` or `core_parse.sfn`
+- `core_bindings.sfn` (33 lines) — merge into `core.sfn`
+- `core_borrow_lowering.sfn` (53 lines) — merge into `core_ownership.sfn`
+- `core_addressing.sfn` (57 lines) — merge into `core.sfn`
+
+Each merge reduces the module count that build.sh must compile (currently 121).
+
+### 8. Deduplicate path helpers (_dirname, _path_join)
 
 `_dirname()` and `_path_join()` are implemented identically in `cli_main.sfn`
 and `cli_commands_utils.sfn` (with `_cmd` suffix). Extract into a shared path

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -208,19 +208,22 @@ jobs:
           fi
           sed -i "s/^version *= *\"[^\"]*\"/version = \"${NEXT}\"/" compiler/capsule.toml
 
-          # Update version.sfn (whitespace-tolerant around = and quotes)
-          sfn_matches=$(grep -c 'let __version__ *=' compiler/src/version.sfn || true)
+          # Update version.sfn fallback (whitespace-tolerant around = and quotes).
+          # The compiler reads its version from capsule.toml at runtime, but
+          # installed binaries fall back to __version_fallback__ when capsule.toml
+          # is not on disk.
+          sfn_matches=$(grep -c 'let __version_fallback__ *=' compiler/src/version.sfn || true)
           if [ "$sfn_matches" -ne 1 ]; then
-            echo "::error::Expected exactly 1 '__version__' assignment in version.sfn, found $sfn_matches"
+            echo "::error::Expected exactly 1 '__version_fallback__' assignment in version.sfn, found $sfn_matches"
             exit 1
           fi
-          sed -i "s/let __version__ *= *\"[^\"]*\"/let __version__ = \"${NEXT}\"/" compiler/src/version.sfn
+          sed -i "s/let __version_fallback__ *= *\"[^\"]*\"/let __version_fallback__ = \"${NEXT}\"/" compiler/src/version.sfn
 
           # Verify the replacements took effect
           echo "--- compiler/capsule.toml ---"
           grep '^version' compiler/capsule.toml
           echo "--- compiler/src/version.sfn ---"
-          grep '__version__' compiler/src/version.sfn
+          grep '__version_fallback__' compiler/src/version.sfn
 
           # Final sanity check: the new version must appear in both files
           if ! grep -q "\"${NEXT}\"" compiler/capsule.toml; then

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -440,7 +440,8 @@ The compiler must always compile itself. Breaking changes require:
 
 - **Semantic versioning:** `v0.5.0-alpha.22` format — `MAJOR.MINOR.PATCH[-channel.N]`
 - **Version source of truth:** `compiler/capsule.toml` (`[capsule] version`)
-- **Version mirror:** `compiler/src/version.sfn:__version__` (read by the compiler binary; kept in sync by the release workflow — TODO: read from capsule.toml at build time)
+- **Version resolution:** `compiler/src/version.sfn:resolve_compiler_version()` reads `capsule.toml` at runtime; falls back to `__version_fallback__` for installed binaries where `capsule.toml` is not on disk
+- **Dev build stamps:** `build.sh` writes `build/native/.build-stamp` with `<version>+dev.<hash>` — the resolver reads this first for local dev builds
 - **Release automation:** `.github/workflows/release.yml` — manually triggered via `workflow_dispatch`, pure bash, no Python dependencies
 - **Release notes:** `.github/workflows/release-notes.md` — agentic workflow that posts structured, categorized changelog comments on published releases (supplements the auto-generated notes from `gh release create`)
 - **Artifacts:** `dist/` is used for packaged artifacts; `release-tag.yml` builds and uploads platform binaries

--- a/compiler/capsule.toml
+++ b/compiler/capsule.toml
@@ -11,7 +11,8 @@ required = ["io"]
 [build]
 entry = "src/main.sfn"
 
-# TODO: The compiler should read its version from this file at build time
-# (via capsule.toml parsing or build-time injection) so that
-# compiler/src/version.sfn no longer needs to be maintained separately.
-# Track this as part of the pre-1.0 toolchain self-sufficiency goal.
+# The compiler reads its version from this file at runtime via
+# resolve_compiler_version() in compiler/src/version.sfn.
+# For installed binaries, __version_fallback__ in version.sfn is used.
+# Release CI updates both files; build.sh writes a .build-stamp with
+# the capsule version + git hash for dev builds.

--- a/compiler/src/cli_main.sfn
+++ b/compiler/src/cli_main.sfn
@@ -20,7 +20,7 @@ import {
     handle_login_command,
     handle_guillermo_command,
 } from "./cli_commands";
-import { sailfin_version } from "./version";
+import { resolve_compiler_version } from "./version";
 
 fn _usage() -> string {
     return "usage:\n" +
@@ -411,7 +411,7 @@ fn sailfin_cli_main(argv -> string[]) -> number ![io] {
 
             return 2;
         }
-        print("sfn " + sailfin_version());
+        print("sfn " + resolve_compiler_version());
         return 0;
     }
 

--- a/compiler/src/version.sfn
+++ b/compiler/src/version.sfn
@@ -1,14 +1,94 @@
 // compiler/src/version.sfn
 //
-// Native compiler CLI/compiler version string.
+// Compiler version resolution.
 //
-// The canonical version lives in compiler/capsule.toml.  Release tooling
-// (`.github/workflows/release.yml`) bumps both files in lockstep.
+// The canonical version lives in compiler/capsule.toml.  At runtime the
+// compiler tries to read that file (or a build stamp written by build.sh)
+// so that the reported version always matches the capsule manifest.
 //
-// TODO: Read version from capsule.toml at build time so this file can be
-// removed.  See the comment in compiler/capsule.toml.
-let __version__ = "0.5.1";
+// For installed binaries where capsule.toml isn't on disk, the hardcoded
+// __version_fallback__ is returned instead.  Release CI keeps it in sync.
 
+import { toml_get_version } from "./toml_parser";
+
+// Hardcoded fallback for installed binaries where capsule.toml is not
+// available on disk.  Release CI updates this alongside capsule.toml.
+let __version_fallback__ = "0.5.1";
+
+// Pure version accessor — returns the baked-in fallback.  Use this when
+// IO is unavailable or when you just need "some version string".
 fn sailfin_version() -> string {
-    return __version__;
+    return __version_fallback__;
+}
+
+// Read a version string from a raw capsule.toml text blob.
+fn version_from_capsule_toml(toml_text -> string) -> string {
+    let ver = toml_get_version(toml_text);
+    if ver.length > 0 {
+        return ver;
+    }
+    return __version_fallback__;
+}
+
+// Try to read the first non-empty line from a file.
+fn _read_stamp(path -> string) -> string ![io] {
+    if fs.exists(path) {
+        let content = fs.readFile(path);
+        if content.length > 0 {
+            // Return the first line (strip trailing newline if present).
+            let mut end -> number = 0;
+            loop {
+                if end >= content.length { break; }
+                if content[end] == "\n" { break; }
+                if content[end] == "\r" { break; }
+                end += 1;
+            }
+            if end > 0 {
+                return substring(content, 0, end);
+            }
+        }
+    }
+    return "";
+}
+
+// Try to read capsule.toml from a list of candidate paths.
+fn _read_capsule_version(paths -> string[]) -> string ![io] {
+    let mut i -> number = 0;
+    loop {
+        if i >= paths.length { break; }
+        if fs.exists(paths[i]) {
+            let text = fs.readFile(paths[i]);
+            let ver = toml_get_version(text);
+            if ver.length > 0 {
+                return ver;
+            }
+        }
+        i += 1;
+    }
+    return "";
+}
+
+// Resolve the compiler version using the best available source:
+//
+//   1. build/native/.build-stamp  — written by build.sh, includes +dev.<hash>
+//   2. compiler/capsule.toml      — canonical version (dev builds from repo root)
+//   3. capsule.toml               — when CWD is inside compiler/
+//   4. __version_fallback__       — baked-in default for installed binaries
+//
+fn resolve_compiler_version() -> string ![io] {
+    // 1. Build stamp takes priority (includes git hash for dev builds).
+    let stamp = _read_stamp("build/native/.build-stamp");
+    if stamp.length > 0 {
+        return stamp;
+    }
+
+    // 2. Try capsule.toml at known relative paths.
+    let capsule_paths -> string[] = ["compiler/capsule.toml", "capsule.toml"];
+    let capsule_ver = _read_capsule_version(capsule_paths);
+    if capsule_ver.length > 0 {
+        return capsule_ver;
+    }
+
+    // 3. Fallback to the baked-in version.
+    return __version_fallback__;
 }

--- a/compiler/src/version.sfn
+++ b/compiler/src/version.sfn
@@ -22,12 +22,69 @@ fn sailfin_version() -> string {
 }
 
 // Read a version string from a raw capsule.toml text blob.
+// Returns the fallback if the TOML text doesn't contain an explicit
+// version key under [capsule] (toml_get_version defaults to "0.1.0"
+// for missing keys, which we must not treat as a real version).
 fn version_from_capsule_toml(toml_text -> string) -> string {
-    let ver = toml_get_version(toml_text);
+    let ver = _strict_capsule_version(toml_text);
     if ver.length > 0 {
         return ver;
     }
     return __version_fallback__;
+}
+
+// Extract version only when the key is explicitly present in a
+// [capsule] section.  Returns "" if the key is missing or the
+// TOML text is empty/malformed.
+fn _strict_capsule_version(toml_text -> string) -> string {
+    if toml_text.length == 0 {
+        return "";
+    }
+    // Quick check: the text must contain a 'version' key line.
+    // This avoids returning the parser's "0.1.0" default.
+    let mut has_version_key -> boolean = false;
+    let mut i -> number = 0;
+    loop {
+        if i >= toml_text.length { break; }
+        if toml_text[i] == "v" {
+            // Check if this could be "version"
+            let remaining = toml_text.length - i;
+            if remaining >= 7 {
+                if substring(toml_text, i, i + 7) == "version" {
+                    has_version_key = true;
+                    break;
+                }
+            }
+        }
+        i += 1;
+    }
+    if !has_version_key {
+        return "";
+    }
+    let ver = toml_get_version(toml_text);
+    // Reject the parser's default "0.1.0" if that's not what the file says.
+    if strings_equal(ver, "0.1.0") {
+        // Double-check: does the file actually say version = "0.1.0"?
+        let mut j -> number = 0;
+        let mut found_literal -> boolean = false;
+        loop {
+            if j >= toml_text.length { break; }
+            if toml_text[j] == "0" {
+                let rem = toml_text.length - j;
+                if rem >= 5 {
+                    if substring(toml_text, j, j + 5) == "0.1.0" {
+                        found_literal = true;
+                        break;
+                    }
+                }
+            }
+            j += 1;
+        }
+        if !found_literal {
+            return "";
+        }
+    }
+    return ver;
 }
 
 // Try to read the first non-empty line from a file.
@@ -52,13 +109,15 @@ fn _read_stamp(path -> string) -> string ![io] {
 }
 
 // Try to read capsule.toml from a list of candidate paths.
+// Uses the strict extractor so a file without an explicit version key
+// doesn't shadow the fallback with the parser's "0.1.0" default.
 fn _read_capsule_version(paths -> string[]) -> string ![io] {
     let mut i -> number = 0;
     loop {
         if i >= paths.length { break; }
         if fs.exists(paths[i]) {
             let text = fs.readFile(paths[i]);
-            let ver = toml_get_version(text);
+            let ver = _strict_capsule_version(text);
             if ver.length > 0 {
                 return ver;
             }

--- a/compiler/tests/unit/version_resolution_test.sfn
+++ b/compiler/tests/unit/version_resolution_test.sfn
@@ -83,12 +83,13 @@ test "version: version_from_capsule_toml returns fallback for empty input" {
     assert _contains(v, ".");
 }
 
-test "version: version_from_capsule_toml returns fallback for missing version" {
+test "version: version_from_capsule_toml returns fallback for missing version key" {
     let toml = "[capsule]\nname = \"test\"\n";
     let v = version_from_capsule_toml(toml);
-    // toml_get_version returns "0.1.0" default when version key is missing,
-    // which is non-empty, so version_from_capsule_toml returns it.
-    assert v.length > 0;
+    // No explicit version key → strict extractor returns "", so we get
+    // the baked-in fallback (which is sailfin_version()).
+    let fallback = sailfin_version();
+    assert strings_equal(v, fallback);
 }
 
 test "version: version_from_capsule_toml handles extra fields" {
@@ -109,13 +110,18 @@ test "version: resolve_compiler_version returns non-empty string" ![io] {
 }
 
 test "version: resolve_compiler_version matches capsule.toml when available" ![io] {
-    // When running from the repo root, compiler/capsule.toml should exist
-    // and the resolved version should contain the capsule version.
+    // When running from the repo root, compiler/capsule.toml should exist.
+    // Read it directly and verify the resolved version starts with the
+    // capsule version (it may have a +dev.<hash> suffix from the build stamp).
+    let toml_path = "compiler/capsule.toml";
+    assert fs.exists(toml_path);
+    let toml_text = fs.readFile(toml_path);
+    let capsule_ver = version_from_capsule_toml(toml_text);
+
     let v = resolve_compiler_version();
-    // The version should be semver-ish (MAJOR.MINOR.PATCH with optional suffix)
-    assert _contains(v, ".");
-    assert _starts_with_digit(v);
-    // It should not be empty or "unknown"
-    assert !strings_equal(v, "");
-    assert !strings_equal(v, "unknown");
+    // The resolved version must start with the capsule version.
+    // It may be exactly the capsule version, or <capsule_ver>+dev.<hash>.
+    assert v.length >= capsule_ver.length;
+    let prefix = substring(v, 0, capsule_ver.length);
+    assert strings_equal(prefix, capsule_ver);
 }

--- a/compiler/tests/unit/version_resolution_test.sfn
+++ b/compiler/tests/unit/version_resolution_test.sfn
@@ -1,0 +1,121 @@
+// Tests for the capsule.toml-based version resolution system.
+//
+// These tests verify that:
+//   1. version_from_capsule_toml() correctly parses a version from TOML text
+//   2. sailfin_version() returns a valid semver-ish fallback
+//   3. resolve_compiler_version() finds capsule.toml from the repo root
+
+import {
+    sailfin_version,
+    version_from_capsule_toml,
+    resolve_compiler_version,
+} from "../../src/version";
+
+fn _index_of(haystack -> string, needle -> string) -> number {
+    if needle.length == 0 {
+        return 0;
+    }
+    if haystack.length < needle.length {
+        return -1;
+    }
+    let mut i -> number = 0;
+    loop {
+        if i + needle.length > haystack.length {
+            break;
+        }
+        let mut j -> number = 0;
+        let mut matches -> boolean = true;
+        loop {
+            if j >= needle.length {
+                break;
+            }
+            if haystack[i + j] != needle[j] {
+                matches = false;
+                break;
+            }
+            j += 1;
+        }
+        if matches {
+            return i;
+        }
+        i += 1;
+    }
+    return -1;
+}
+
+fn _contains(haystack -> string, needle -> string) -> boolean {
+    return _index_of(haystack, needle) >= 0;
+}
+
+fn _starts_with_digit(s -> string) -> boolean {
+    if s.length == 0 { return false; }
+    return _contains("0123456789", s[0]);
+}
+
+// ---------------------------------------------------------------------------
+// Pure function tests (no IO needed)
+// ---------------------------------------------------------------------------
+
+test "version: fallback returns valid semver-ish string" {
+    let v = sailfin_version();
+    assert v.length > 0;
+    assert _contains(v, ".");
+    assert !_contains(v, " ");
+    assert _starts_with_digit(v);
+}
+
+test "version: version_from_capsule_toml parses version" {
+    let toml = "[capsule]\nname = \"test\"\nversion = \"1.2.3\"\n";
+    let v = version_from_capsule_toml(toml);
+    assert strings_equal(v, "1.2.3");
+}
+
+test "version: version_from_capsule_toml parses prerelease version" {
+    let toml = "[capsule]\nname = \"test\"\nversion = \"0.5.1-alpha.3\"\n";
+    let v = version_from_capsule_toml(toml);
+    assert strings_equal(v, "0.5.1-alpha.3");
+}
+
+test "version: version_from_capsule_toml returns fallback for empty input" {
+    let v = version_from_capsule_toml("");
+    // Should return the fallback version (non-empty, semver-ish)
+    assert v.length > 0;
+    assert _contains(v, ".");
+}
+
+test "version: version_from_capsule_toml returns fallback for missing version" {
+    let toml = "[capsule]\nname = \"test\"\n";
+    let v = version_from_capsule_toml(toml);
+    // toml_get_version returns "0.1.0" default when version key is missing,
+    // which is non-empty, so version_from_capsule_toml returns it.
+    assert v.length > 0;
+}
+
+test "version: version_from_capsule_toml handles extra fields" {
+    let toml = "[capsule]\nname = \"myapp\"\nversion = \"2.0.0\"\ndescription = \"A test app\"\n\n[build]\nentry = \"src/main.sfn\"\n";
+    let v = version_from_capsule_toml(toml);
+    assert strings_equal(v, "2.0.0");
+}
+
+// ---------------------------------------------------------------------------
+// IO-based tests (require capsule.toml on disk — run from repo root)
+// ---------------------------------------------------------------------------
+
+test "version: resolve_compiler_version returns non-empty string" ![io] {
+    let v = resolve_compiler_version();
+    assert v.length > 0;
+    assert _contains(v, ".");
+    assert _starts_with_digit(v);
+}
+
+test "version: resolve_compiler_version matches capsule.toml when available" ![io] {
+    // When running from the repo root, compiler/capsule.toml should exist
+    // and the resolved version should contain the capsule version.
+    let v = resolve_compiler_version();
+    // The version should be semver-ish (MAJOR.MINOR.PATCH with optional suffix)
+    assert _contains(v, ".");
+    assert _starts_with_digit(v);
+    // It should not be empty or "unknown"
+    assert !strings_equal(v, "");
+    assert !strings_equal(v, "unknown");
+}

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -817,6 +817,37 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# Write build stamp (version + git hash for dev builds)
+# ---------------------------------------------------------------------------
+CAPSULE_TOML="$REPO_ROOT/compiler/capsule.toml"
+BUILD_STAMP_PATH="$(dirname "$OUT")/.build-stamp"
+if [[ -f "$CAPSULE_TOML" ]]; then
+    CAPSULE_VERSION="$(sed -n 's/^version *= *"\([^"]*\)"/\1/p' "$CAPSULE_TOML")"
+    # Check if HEAD is an exact tagged release (e.g. v0.5.1).
+    GIT_TAG="$(cd "$REPO_ROOT" && git describe --exact-match --tags HEAD 2>/dev/null || echo "")"
+    if [[ -n "$GIT_TAG" ]]; then
+        # Tagged release — clean version, no dev suffix.
+        BUILD_VERSION="$CAPSULE_VERSION"
+    else
+        # Dev build — append +dev.<hash>[.dirty].
+        GIT_HASH="$(cd "$REPO_ROOT" && git rev-parse --short HEAD 2>/dev/null || echo "")"
+        GIT_DIRTY=""
+        if [[ -n "$GIT_HASH" ]]; then
+            if ! (cd "$REPO_ROOT" && git diff --quiet HEAD -- 2>/dev/null); then
+                GIT_DIRTY=".dirty"
+            fi
+            BUILD_VERSION="${CAPSULE_VERSION}+dev.${GIT_HASH}${GIT_DIRTY}"
+        else
+            BUILD_VERSION="${CAPSULE_VERSION}+dev"
+        fi
+    fi
+    echo "$BUILD_VERSION" > "$BUILD_STAMP_PATH"
+    log "build stamp: $BUILD_VERSION → $BUILD_STAMP_PATH"
+else
+    warn "capsule.toml not found; skipping build stamp"
+fi
+
+# ---------------------------------------------------------------------------
 # Build metrics
 # ---------------------------------------------------------------------------
 BINARY_SIZE="$(du -h "$OUT" | cut -f1)"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -823,26 +823,30 @@ CAPSULE_TOML="$REPO_ROOT/compiler/capsule.toml"
 BUILD_STAMP_PATH="$(dirname "$OUT")/.build-stamp"
 if [[ -f "$CAPSULE_TOML" ]]; then
     CAPSULE_VERSION="$(sed -n 's/^version *= *"\([^"]*\)"/\1/p' "$CAPSULE_TOML")"
-    # Check if HEAD is an exact tagged release (e.g. v0.5.1).
-    GIT_TAG="$(cd "$REPO_ROOT" && git describe --exact-match --tags HEAD 2>/dev/null || echo "")"
-    if [[ -n "$GIT_TAG" ]]; then
-        # Tagged release — clean version, no dev suffix.
-        BUILD_VERSION="$CAPSULE_VERSION"
-    else
-        # Dev build — append +dev.<hash>[.dirty].
-        GIT_HASH="$(cd "$REPO_ROOT" && git rev-parse --short HEAD 2>/dev/null || echo "")"
-        GIT_DIRTY=""
-        if [[ -n "$GIT_HASH" ]]; then
-            if ! (cd "$REPO_ROOT" && git diff --quiet HEAD -- 2>/dev/null); then
-                GIT_DIRTY=".dirty"
-            fi
-            BUILD_VERSION="${CAPSULE_VERSION}+dev.${GIT_HASH}${GIT_DIRTY}"
+    if [[ -n "$CAPSULE_VERSION" ]]; then
+        # Check if HEAD is an exact tagged release (e.g. v0.5.1).
+        GIT_TAG="$(cd "$REPO_ROOT" && git describe --exact-match --tags HEAD 2>/dev/null || echo "")"
+        if [[ -n "$GIT_TAG" ]]; then
+            # Tagged release — clean version, no dev suffix.
+            BUILD_VERSION="$CAPSULE_VERSION"
         else
-            BUILD_VERSION="${CAPSULE_VERSION}+dev"
+            # Dev build — append +dev.<hash>[.dirty].
+            GIT_HASH="$(cd "$REPO_ROOT" && git rev-parse --short HEAD 2>/dev/null || echo "")"
+            GIT_DIRTY=""
+            if [[ -n "$GIT_HASH" ]]; then
+                if ! (cd "$REPO_ROOT" && git diff --quiet HEAD -- 2>/dev/null); then
+                    GIT_DIRTY=".dirty"
+                fi
+                BUILD_VERSION="${CAPSULE_VERSION}+dev.${GIT_HASH}${GIT_DIRTY}"
+            else
+                BUILD_VERSION="${CAPSULE_VERSION}+dev"
+            fi
         fi
+        echo "$BUILD_VERSION" > "$BUILD_STAMP_PATH"
+        log "build stamp: $BUILD_VERSION → $BUILD_STAMP_PATH"
+    else
+        warn "could not extract version from $CAPSULE_TOML; skipping build stamp"
     fi
-    echo "$BUILD_VERSION" > "$BUILD_STAMP_PATH"
-    log "build stamp: $BUILD_VERSION → $BUILD_STAMP_PATH"
 else
     warn "capsule.toml not found; skipping build stamp"
 fi

--- a/site/src/content/docs/reference/cli.md
+++ b/site/src/content/docs/reference/cli.md
@@ -130,10 +130,12 @@ sfn --version
 **Example output:**
 
 ```
-sfn 0.4.0
+sfn 0.5.1
 ```
 
-The version string follows semantic versioning: `<major>.<minor>.<patch>` for stable releases, `<major>.<minor>.<patch>-alpha.<n>` for pre-releases.
+The version string follows semantic versioning: `<major>.<minor>.<patch>` for stable releases, `<major>.<minor>.<patch>-alpha.<n>` for pre-releases. Local dev builds include a git hash suffix: `<version>+dev.<hash>` (e.g. `sfn 0.5.1+dev.abc1234`).
+
+The version is read from `compiler/capsule.toml` at runtime. For installed binaries where that file is not available, a baked-in fallback is used.
 
 ---
 

--- a/tools/package.sh
+++ b/tools/package.sh
@@ -51,10 +51,10 @@ if [[ ! -x "$COMPILER_BIN" ]]; then
     exit 1
 fi
 
-# Extract version from compiler/src/version.sfn
-VERSION="$(sed -n 's/.*__version__.*=.*"\([^"]*\)".*/\1/p' compiler/src/version.sfn)"
+# Extract version from capsule.toml (canonical source of truth)
+VERSION="$(sed -n 's/^version *= *"\([^"]*\)"/\1/p' compiler/capsule.toml)"
 if [[ -z "$VERSION" ]]; then
-    echo "[package] error: could not extract version from compiler/src/version.sfn" >&2
+    echo "[package] error: could not extract version from compiler/capsule.toml" >&2
     exit 1
 fi
 


### PR DESCRIPTION
Replace the hardcoded __version__ string with a runtime version
resolution system that reads from capsule.toml (canonical source of
truth), with a build stamp for dev builds and a baked-in fallback for
installed binaries.

Changes:
- version.sfn: add resolve_compiler_version() ![io] that checks
  build stamp → capsule.toml → fallback; keep sailfin_version() as
  pure fallback; add version_from_capsule_toml() for TOML parsing
- cli_main.sfn: use resolve_compiler_version() for `sfn version`
- build.sh: write .build-stamp with version+dev.<hash>[.dirty] after
  build (clean version for tagged releases)
- release.yml: update sed target from __version__ to __version_fallback__
- tools/package.sh: read version from capsule.toml instead of version.sfn
- New test: version_resolution_test.sfn (8 tests covering pure and IO paths)
- Updated docs: CLAUDE.md, capsule.toml, site CLI reference

Dev builds now report: sfn 0.5.1+dev.abc1234
Tagged releases report: sfn 0.5.1

https://claude.ai/code/session_01GLNHFJ5MynyaBzQMHhRKuZ