### PR TITLE
feat(compiler): colon type annotations — Phases 5 & 6 (emitter update + parser split)

### DIFF
--- a/compiler/src/emit_native.sfn
+++ b/compiler/src/emit_native.sfn
@@ -796,7 +796,7 @@ fn emit_parameter_metadata(state: NativeState, parameters: Parameter[]) -> Nativ
         }
         line = line + parameter.name;
         if parameter.type_annotation != null {
-            line = line + " -> " + parameter.type_annotation.text;
+            line = line + ": " + parameter.type_annotation.text;
         }
         if parameter.default_value != null {
             line = line + " = " + format_optional_expression(parameter.default_value);

--- a/compiler/src/emit_native_format.sfn
+++ b/compiler/src/emit_native_format.sfn
@@ -276,7 +276,7 @@ fn format_parameters(parameters: Parameter[]) -> string {
             entry = parameter.name;
         }
         if parameter.type_annotation != null {
-            entry = entry + " -> " + parameter.type_annotation.text;
+            entry = entry + ": " + parameter.type_annotation.text;
         }
         if parameter.default_value != null {
             entry = entry + " = " + format_optional_expression(parameter.default_value);
@@ -315,7 +315,7 @@ fn format_field(field: FieldDeclaration) -> string {
     if field.mutable {
         line = line + "mut ";
     }
-    line = line + field.name + " -> " + field.type_annotation.text;
+    line = line + field.name + ": " + field.type_annotation.text;
     return line;
 }
 
@@ -364,12 +364,12 @@ fn format_decorator(decorator: Decorator) -> string {
 
 fn format_span(span: SourceSpan) -> string {
     return number_to_string(span.start_line)
-        + " "
-        + number_to_string(span.start_column)
-        + " "
-        + number_to_string(span.end_line)
-        + " "
-        + number_to_string(span.end_column);
+    + " "
+    + number_to_string(span.start_column)
+    + " "
+    + number_to_string(span.end_line)
+    + " "
+    + number_to_string(span.end_column);
 }
 
 // ── Specifier formatting ─────────────────────────────────────────────

--- a/compiler/src/emitter_sailfin.sfn
+++ b/compiler/src/emitter_sailfin.sfn
@@ -418,11 +418,11 @@ fn emit_block_body(builder: TextBuilder, block: Block) -> TextBuilder {
 
 fn emit_block_statement(builder: TextBuilder, statement: Statement) -> TextBuilder {
     if statement.variant == "ReturnStatement" {
-            let rendered = format_optional_expression(statement.expression);
-            if rendered.length == 0 {
-                return builder_emit_line(builder, "return;");
-            }
-            return builder_emit_line(builder, "return " + rendered + ";");
+        let rendered = format_optional_expression(statement.expression);
+        if rendered.length == 0 {
+            return builder_emit_line(builder, "return;");
+        }
+        return builder_emit_line(builder, "return " + rendered + ";");
     }
     if statement.variant == "LoopStatement" {
         let mut current = emit_decorators(builder, statement.decorators);
@@ -679,7 +679,7 @@ fn format_field(field: FieldDeclaration) -> string {
         line = line + "mut ";
     }
     line = line + field.name;
-    line = line + " -> " + field.type_annotation.text;
+    line = line + ": " + field.type_annotation.text;
     return line;
 }
 
@@ -723,7 +723,7 @@ fn format_parameter(parameter: Parameter) -> string {
         line = parameter.name;
     }
     if parameter.type_annotation != null {
-        line = line + " -> " + parameter.type_annotation.text;
+        line = line + ": " + parameter.type_annotation.text;
     }
     if parameter.default_value != null {
         line = line + " = " + format_optional_expression(parameter.default_value);

--- a/compiler/src/emitter_sailfin_expr.sfn
+++ b/compiler/src/emitter_sailfin_expr.sfn
@@ -22,6 +22,13 @@ fn format_type_annotation(annotation: TypeAnnotation?) -> string {
     if annotation == null {
         return "";
     }
+    return ": " + annotation.text;
+}
+
+fn format_return_type_annotation(annotation: TypeAnnotation?) -> string {
+    if annotation == null {
+        return "";
+    }
     return " -> " + annotation.text;
 }
 
@@ -146,7 +153,7 @@ fn format_expression(expression: Expression) -> string {
 fn format_lambda_expression(expression: Expression) -> string {
     let params = format_lambda_parameters(expression.parameters);
     let mut header: string = "fn " + params;
-    header = header + format_type_annotation(expression.return_type);
+    header = header + format_return_type_annotation(expression.return_type);
 
     let body = format_lambda_body(expression.body);
     return header + " " + body;

--- a/compiler/src/llvm/lowering/lowering_recovery.sfn
+++ b/compiler/src/llvm/lowering/lowering_recovery.sfn
@@ -192,9 +192,14 @@ fn recover_native_functions_light(native_text: string) -> NativeFunction[] {
         let ret_type_raw = trim_text_local(substring(line, 13, line.length));
         let effects_text_raw = trim_text_local(substring(line, 14, line.length));
         let param_text_raw = trim_text_local(substring(line, 7, line.length));
-        let param_arrow_idx = index_of(param_text_raw, " -> ");
+        let mut param_arrow_idx: number = index_of(param_text_raw, ": ");
+        let mut param_sep_len: number = 2;
+        if param_arrow_idx < 0 {
+            param_arrow_idx = index_of(param_text_raw, " -> ");
+            param_sep_len = 4;
+        }
         let param_name_raw = trim_text_local(substring(param_text_raw, 0, param_arrow_idx));
-        let param_type_raw = trim_text_local(substring(param_text_raw, param_arrow_idx + 4, param_text_raw.length));
+        let param_type_raw = trim_text_local(substring(param_text_raw, param_arrow_idx + param_sep_len, param_text_raw.length));
 
         // Pre-compute .for target/iterable extraction.
         let for_body_raw = trim_text_local(substring(line, 5, line.length));
@@ -576,9 +581,14 @@ fn recover_native_structs_light(native_text: string) -> NativeStruct[] {
         let is_method_line = _let241;
 
         let field_text = trim_text_local(substring(line, 7, line.length));
-        let field_arrow_idx = index_of(field_text, " -> ");
+        let mut field_arrow_idx: number = index_of(field_text, ": ");
+        let mut field_sep_len: number = 2;
+        if field_arrow_idx < 0 {
+            field_arrow_idx = index_of(field_text, " -> ");
+            field_sep_len = 4;
+        }
         let f_name = trim_text_local(substring(field_text, 0, field_arrow_idx));
-        let f_type = trim_text_local(substring(field_text, field_arrow_idx + 4, field_text.length));
+        let f_type = trim_text_local(substring(field_text, field_arrow_idx + field_sep_len, field_text.length));
 
         let ls_text = trim_text_local(substring(line, 15, line.length));
         let ls_size_idx = index_of(ls_text, "size=");

--- a/compiler/src/llvm/lowering/lowering_recovery.sfn
+++ b/compiler/src/llvm/lowering/lowering_recovery.sfn
@@ -192,11 +192,24 @@ fn recover_native_functions_light(native_text: string) -> NativeFunction[] {
         let ret_type_raw = trim_text_local(substring(line, 13, line.length));
         let effects_text_raw = trim_text_local(substring(line, 14, line.length));
         let param_text_raw = trim_text_local(substring(line, 7, line.length));
-        let mut param_arrow_idx: number = index_of(param_text_raw, ": ");
+        let param_colon_idx = index_of(param_text_raw, ": ");
+        let param_legacy_arrow_idx = index_of(param_text_raw, " -> ");
+        let mut param_arrow_idx: number = -1;
         let mut param_sep_len: number = 2;
-        if param_arrow_idx < 0 {
-            param_arrow_idx = index_of(param_text_raw, " -> ");
-            param_sep_len = 4;
+        if param_colon_idx >= 0 {
+            param_arrow_idx = param_colon_idx;
+            param_sep_len = 2;
+        }
+        if param_legacy_arrow_idx >= 0 {
+            let mut _use_param_arrow: boolean = false;
+            if param_arrow_idx < 0 { _use_param_arrow = true; }
+            if param_arrow_idx >= 0 {
+                if param_legacy_arrow_idx < param_arrow_idx { _use_param_arrow = true; }
+            }
+            if _use_param_arrow {
+                param_arrow_idx = param_legacy_arrow_idx;
+                param_sep_len = 4;
+            }
         }
         let param_name_raw = trim_text_local(substring(param_text_raw, 0, param_arrow_idx));
         let param_type_raw = trim_text_local(substring(param_text_raw, param_arrow_idx + param_sep_len, param_text_raw.length));
@@ -581,11 +594,24 @@ fn recover_native_structs_light(native_text: string) -> NativeStruct[] {
         let is_method_line = _let241;
 
         let field_text = trim_text_local(substring(line, 7, line.length));
-        let mut field_arrow_idx: number = index_of(field_text, ": ");
+        let field_colon_idx = index_of(field_text, ": ");
+        let field_legacy_arrow_idx = index_of(field_text, " -> ");
+        let mut field_arrow_idx: number = -1;
         let mut field_sep_len: number = 2;
-        if field_arrow_idx < 0 {
-            field_arrow_idx = index_of(field_text, " -> ");
-            field_sep_len = 4;
+        if field_colon_idx >= 0 {
+            field_arrow_idx = field_colon_idx;
+            field_sep_len = 2;
+        }
+        if field_legacy_arrow_idx >= 0 {
+            let mut _use_field_arrow: boolean = false;
+            if field_arrow_idx < 0 { _use_field_arrow = true; }
+            if field_arrow_idx >= 0 {
+                if field_legacy_arrow_idx < field_arrow_idx { _use_field_arrow = true; }
+            }
+            if _use_field_arrow {
+                field_arrow_idx = field_legacy_arrow_idx;
+                field_sep_len = 4;
+            }
         }
         let f_name = trim_text_local(substring(field_text, 0, field_arrow_idx));
         let f_type = trim_text_local(substring(field_text, field_arrow_idx + field_sep_len, field_text.length));

--- a/compiler/src/llvm/rendering_helpers.sfn
+++ b/compiler/src/llvm/rendering_helpers.sfn
@@ -262,7 +262,7 @@ fn render_interface_parameters(parameters: NativeParameter[]) -> string {
             entry = "mut " + entry;
         }
         if parameter.type_annotation.length > 0 {
-            entry = entry + " -> " + parameter.type_annotation;
+            entry = entry + ": " + parameter.type_annotation;
         }
         if parameter.default_value != null {
             entry = entry + " = " + parameter.default_value;

--- a/compiler/src/native_ir_utils_parse.sfn
+++ b/compiler/src/native_ir_utils_parse.sfn
@@ -593,7 +593,12 @@ fn parse_enum_variant_field(text: string) -> NativeEnumVariantField? {
         is_mutable = true;
         trimmed = trim_text(strip_prefix(trimmed, "mut "));
     }
-    let arrow_index = index_of(trimmed, "->");
+    let mut arrow_index: number = index_of(trimmed, ":");
+    let mut sep_len: number = 1;
+    if arrow_index < 0 {
+        arrow_index = index_of(trimmed, "->");
+        sep_len = 2;
+    }
     if arrow_index < 0 {
         return null;
     }
@@ -601,7 +606,7 @@ fn parse_enum_variant_field(text: string) -> NativeEnumVariantField? {
     if name.length == 0 {
         return null;
     }
-    let type_text = trim_text(substring(trimmed, arrow_index + 2, trimmed.length));
+    let type_text = trim_text(substring(trimmed, arrow_index + sep_len, trimmed.length));
     return NativeEnumVariantField { name: name, type_annotation: type_text, mutable: is_mutable };
 }
 
@@ -615,7 +620,12 @@ fn parse_struct_field_line(text: string) -> NativeStructField? {
         is_mutable = true;
         trimmed = trim_text(strip_prefix(trimmed, "mut "));
     }
-    let arrow_index = index_of(trimmed, "->");
+    let mut arrow_index: number = index_of(trimmed, ":");
+    let mut sep_len: number = 1;
+    if arrow_index < 0 {
+        arrow_index = index_of(trimmed, "->");
+        sep_len = 2;
+    }
     if arrow_index < 0 {
         return null;
     }
@@ -623,7 +633,7 @@ fn parse_struct_field_line(text: string) -> NativeStructField? {
     if name.length == 0 {
         return null;
     }
-    let type_text = trim_text(substring(trimmed, arrow_index + 2, trimmed.length));
+    let type_text = trim_text(substring(trimmed, arrow_index + sep_len, trimmed.length));
     return NativeStructField { name: name, type_annotation: type_text, mutable: is_mutable };
 }
 
@@ -744,6 +754,7 @@ fn parse_parameter_entry(body: string, span: NativeSourceSpan?) -> NativeParamet
         if ch == " " { _if381 = true; }
         if ch == "-" { _if381 = true; }
         if ch == "=" { _if381 = true; }
+        if ch == ":" { _if381 = true; }
         if _if381 {
             break;
         }
@@ -758,7 +769,19 @@ fn parse_parameter_entry(body: string, span: NativeSourceSpan?) -> NativeParamet
     let mut default_value: string? = null;
     let mut remainder = trim_text(substring(trimmed, index, trimmed.length));
     if remainder.length > 0 {
-        if starts_with(remainder, "->") {
+        if starts_with(remainder, ":") {
+            remainder = trim_text(strip_prefix(remainder, ":"));
+            let assign_index = index_of(remainder, "=");
+            if assign_index >= 0 {
+                type_annotation = trim_text(substring(remainder, 0, assign_index));
+                let default_text = trim_text(substring(remainder, assign_index + 1, remainder.length));
+                if default_text.length > 0 {
+                    default_value = default_text;
+                }
+            } else {
+                type_annotation = trim_text(remainder);
+            }
+        } else if starts_with(remainder, "->") {
             remainder = trim_text(strip_prefix(remainder, "->"));
             let assign_index = index_of(remainder, "=");
             if assign_index >= 0 {
@@ -798,8 +821,20 @@ fn line_looks_like_parameter_entry(text: string) -> boolean {
         return false;
     }
     let arrow_index = index_of(trimmed, "->");
+    let colon_index = index_of(trimmed, ":");
+    let mut sep_index: number = -1;
+    if colon_index >= 0 {
+        sep_index = colon_index;
+    }
     if arrow_index >= 0 {
-        let mut head = trim_text(substring(trimmed, 0, arrow_index));
+        if sep_index < 0 {
+            sep_index = arrow_index;
+        } else if arrow_index < sep_index {
+            sep_index = arrow_index;
+        }
+    }
+    if sep_index >= 0 {
+        let mut head = trim_text(substring(trimmed, 0, sep_index));
         if head.length == 0 {
             return false;
         }

--- a/compiler/src/native_ir_utils_parse.sfn
+++ b/compiler/src/native_ir_utils_parse.sfn
@@ -593,11 +593,24 @@ fn parse_enum_variant_field(text: string) -> NativeEnumVariantField? {
         is_mutable = true;
         trimmed = trim_text(strip_prefix(trimmed, "mut "));
     }
-    let mut arrow_index: number = index_of(trimmed, ":");
-    let mut sep_len: number = 1;
-    if arrow_index < 0 {
-        arrow_index = index_of(trimmed, "->");
+    let colon_idx = index_of(trimmed, ": ");
+    let legacy_arrow_idx = index_of(trimmed, " -> ");
+    let mut arrow_index: number = -1;
+    let mut sep_len: number = 2;
+    if colon_idx >= 0 {
+        arrow_index = colon_idx;
         sep_len = 2;
+    }
+    if legacy_arrow_idx >= 0 {
+        let mut use_arrow: boolean = false;
+        if arrow_index < 0 { use_arrow = true; }
+        if arrow_index >= 0 {
+            if legacy_arrow_idx < arrow_index { use_arrow = true; }
+        }
+        if use_arrow {
+            arrow_index = legacy_arrow_idx;
+            sep_len = 4;
+        }
     }
     if arrow_index < 0 {
         return null;
@@ -620,11 +633,24 @@ fn parse_struct_field_line(text: string) -> NativeStructField? {
         is_mutable = true;
         trimmed = trim_text(strip_prefix(trimmed, "mut "));
     }
-    let mut arrow_index: number = index_of(trimmed, ":");
-    let mut sep_len: number = 1;
-    if arrow_index < 0 {
-        arrow_index = index_of(trimmed, "->");
+    let colon_idx = index_of(trimmed, ": ");
+    let legacy_arrow_idx = index_of(trimmed, " -> ");
+    let mut arrow_index: number = -1;
+    let mut sep_len: number = 2;
+    if colon_idx >= 0 {
+        arrow_index = colon_idx;
         sep_len = 2;
+    }
+    if legacy_arrow_idx >= 0 {
+        let mut use_arrow: boolean = false;
+        if arrow_index < 0 { use_arrow = true; }
+        if arrow_index >= 0 {
+            if legacy_arrow_idx < arrow_index { use_arrow = true; }
+        }
+        if use_arrow {
+            arrow_index = legacy_arrow_idx;
+            sep_len = 4;
+        }
     }
     if arrow_index < 0 {
         return null;

--- a/compiler/src/parser/declarations.sfn
+++ b/compiler/src/parser/declarations.sfn
@@ -85,12 +85,17 @@ import { parse_block } from "./statements";
 // Type Separator
 // ============================================================================
 
-fn consume_type_separator(parser: Parser) -> TypeSeparatorParseResult {
+fn consume_annotation_separator(parser: Parser) -> TypeSeparatorParseResult {
     let token = parser_peek_raw(parser);
-    let mut _if394: boolean = false;
-    if symbol_matches(token, ":") { _if394 = true; }
-    if symbol_matches(token, "->") { _if394 = true; }
-    if _if394 {
+    if symbol_matches(token, ":") {
+        return TypeSeparatorParseResult { parser: parser_advance_raw(parser), found: true };
+    }
+    return TypeSeparatorParseResult { parser: parser, found: false };
+}
+
+fn consume_return_type_separator(parser: Parser) -> TypeSeparatorParseResult {
+    let token = parser_peek_raw(parser);
+    if symbol_matches(token, "->") {
         return TypeSeparatorParseResult { parser: parser_advance_raw(parser), found: true };
     }
     // Tolerate a lexer/runtime bug where `->` is split into `-` and `>`.
@@ -489,7 +494,7 @@ fn parse_single_parameter(initial_parser: Parser) -> ParameterParseResult {
 
     let mut type_annotation: TypeAnnotation? = null;
     parser = skip_trivia(parser);
-    let separator_result = consume_type_separator(parser);
+    let separator_result = consume_annotation_separator(parser);
     if separator_result.found {
         parser = separator_result.parser;
         let capture = collect_until(skip_trivia(parser), ["=", ",", ")"]);
@@ -748,7 +753,7 @@ fn parse_variable(initial_parser: Parser) -> StatementParseResult {
     let mut type_annotation: TypeAnnotation? = null;
     parser = skip_trivia(parser);
     let separator_token = parser_peek_raw(parser);
-    let separator_result = consume_type_separator(parser);
+    let separator_result = consume_annotation_separator(parser);
     if separator_result.found {
         statement_tokens = append_token(statement_tokens, separator_token);
         parser = separator_result.parser;
@@ -856,7 +861,7 @@ fn parse_function(initial_parser: Parser, starts_with_async: boolean, decorators
 
     parser = skip_trivia(parser);
     let mut return_type: TypeAnnotation? = null;
-    let sep_result = consume_type_separator(parser);
+    let sep_result = consume_return_type_separator(parser);
     if sep_result.found {
         parser = sep_result.parser;
         let capture = collect_until(skip_trivia(parser), ["!", "{"]);
@@ -875,7 +880,7 @@ fn parse_function(initial_parser: Parser, starts_with_async: boolean, decorators
     // Allow `fn foo() ![effects] -> T {}` ordering.
     if return_type == null {
         parser = skip_trivia(parser);
-        let late_sep = consume_type_separator(parser);
+        let late_sep = consume_return_type_separator(parser);
         if late_sep.found {
             parser = late_sep.parser;
             let capture = collect_until(skip_trivia(parser), ["{"]);
@@ -942,7 +947,7 @@ fn parse_extern_function(initial_parser: Parser, starts_with_unsafe: boolean, de
 
     parser = skip_trivia(parser);
     let mut return_type: TypeAnnotation? = null;
-    let sep_result = consume_type_separator(parser);
+    let sep_result = consume_return_type_separator(parser);
     if sep_result.found {
         parser = sep_result.parser;
         let capture = collect_until(skip_trivia(parser), ["!", ";"]);
@@ -961,7 +966,7 @@ fn parse_extern_function(initial_parser: Parser, starts_with_unsafe: boolean, de
     // Allow `extern fn foo() ![effects] -> T;` ordering.
     if return_type == null {
         parser = skip_trivia(parser);
-        let late_sep = consume_type_separator(parser);
+        let late_sep = consume_return_type_separator(parser);
         if late_sep.found {
             parser = late_sep.parser;
             let capture = collect_until(skip_trivia(parser), [";"]);
@@ -1099,7 +1104,7 @@ fn parse_struct_field(parser: Parser) -> StructFieldParseResult {
     current = parser_advance_raw(current);
 
     current = skip_trivia(current);
-    let separator_result = consume_type_separator(current);
+    let separator_result = consume_annotation_separator(current);
     current = separator_result.parser;
     if !separator_result.found {
         return StructFieldParseResult { parser: parser, field: null, success: false };
@@ -1173,7 +1178,7 @@ fn parse_struct_method(parser: Parser, decorators: Decorator[]) -> MethodParseRe
 
     current = skip_trivia(current);
     let mut return_type: TypeAnnotation? = null;
-    let sep_result = consume_type_separator(current);
+    let sep_result = consume_return_type_separator(current);
     if sep_result.found {
         current = sep_result.parser;
         let capture = collect_until(skip_trivia(current), ["!", "{"]);
@@ -1361,7 +1366,7 @@ fn parse_enum_variant_field(parser: Parser) -> StructFieldParseResult {
     current = parser_advance_raw(current);
 
     current = skip_trivia(current);
-    let sep_result = consume_type_separator(current);
+    let sep_result = consume_annotation_separator(current);
     if !sep_result.found {
         return StructFieldParseResult { parser: parser, field: null, success: false };
     }
@@ -1520,7 +1525,7 @@ fn parse_interface_member(parser: Parser, decorators: Decorator[]) -> InterfaceM
 
     current = skip_trivia(current);
     let mut return_type: TypeAnnotation? = null;
-    let separator_result = consume_type_separator(current);
+    let separator_result = consume_return_type_separator(current);
     if separator_result.found {
         current = separator_result.parser;
         let capture = collect_until(skip_trivia(current), ["!", ";", "{" ]);
@@ -1759,7 +1764,7 @@ fn parse_pipeline(initial_parser: Parser, decorators: Decorator[]) -> StatementP
 
     parser = skip_trivia(parser);
     let mut return_type: TypeAnnotation? = null;
-    let sep_result = consume_type_separator(parser);
+    let sep_result = consume_return_type_separator(parser);
     if sep_result.found {
         parser = sep_result.parser;
         let capture = collect_until(skip_trivia(parser), ["!", "{"]);
@@ -1778,7 +1783,7 @@ fn parse_pipeline(initial_parser: Parser, decorators: Decorator[]) -> StatementP
     // Allow `pipeline foo() ![effects] -> T {}` ordering.
     if return_type == null {
         parser = skip_trivia(parser);
-        let late_sep = consume_type_separator(parser);
+        let late_sep = consume_return_type_separator(parser);
         if late_sep.found {
             parser = late_sep.parser;
             let capture = collect_until(skip_trivia(parser), ["{"]);
@@ -1835,7 +1840,7 @@ fn parse_tool(initial_parser: Parser, decorators: Decorator[]) -> StatementParse
 
     parser = skip_trivia(parser);
     let mut return_type: TypeAnnotation? = null;
-    let sep_result = consume_type_separator(parser);
+    let sep_result = consume_return_type_separator(parser);
     if sep_result.found {
         parser = sep_result.parser;
         let capture = collect_until(skip_trivia(parser), ["!", "{"]);
@@ -1854,7 +1859,7 @@ fn parse_tool(initial_parser: Parser, decorators: Decorator[]) -> StatementParse
     // Allow `tool foo() ![effects] -> T {}` ordering.
     if return_type == null {
         parser = skip_trivia(parser);
-        let late_sep = consume_type_separator(parser);
+        let late_sep = consume_return_type_separator(parser);
         if late_sep.found {
             parser = late_sep.parser;
             let capture = collect_until(skip_trivia(parser), ["{"]);

--- a/compiler/src/parser/expressions.sfn
+++ b/compiler/src/parser/expressions.sfn
@@ -842,7 +842,7 @@ fn parse_lambda_expression(state: ExpressionTokens) -> ExpressionParseResult {
 
     let mut return_type: TypeAnnotation? = null;
     if !expression_tokens_is_at_end(current) {
-        let sep_result = expression_tokens_consume_type_separator(current, true, true);
+        let sep_result = expression_tokens_consume_type_separator(current, false, true);
         if sep_result.found {
             current = sep_result.state;
             let capture = expression_tokens_collect_until(current, ["{"]);
@@ -869,10 +869,10 @@ fn parse_lambda_expression(state: ExpressionTokens) -> ExpressionParseResult {
 
     let mut block_tokens = block_result.tokens;
     block_tokens = append_token(block_tokens, Token {
-        kind: TokenKind.EndOfFile(),
-        lexeme: "",
-        line: 0,
-        column: 0,
+            kind: TokenKind.EndOfFile(),
+            lexeme: "",
+            line: 0,
+            column: 0,
     });
     let block_parser = Parser { tokens: block_tokens, index: 0 };
     let parsed_block = parse_block_for_lambda(block_parser);
@@ -917,7 +917,7 @@ fn parse_lambda_parameter(state: ExpressionTokens) -> LambdaParameterParseResult
 
     let mut type_annotation: TypeAnnotation? = null;
     if !expression_tokens_is_at_end(current) {
-        let sep_result = expression_tokens_consume_type_separator(current, true, true);
+        let sep_result = expression_tokens_consume_type_separator(current, true, false);
         if sep_result.found {
             current = sep_result.state;
             let capture = expression_tokens_collect_until(current, ["=", ",", ")"]);

--- a/compiler/src/parser/mod.sfn
+++ b/compiler/src/parser/mod.sfn
@@ -395,8 +395,9 @@ export {
 
 // Re-export declaration parsing functions
 export {
-    // Type separator
-    consume_type_separator,
+    // Type separators
+    consume_annotation_separator,
+    consume_return_type_separator,
 
     // Decorator parsing
     parse_decorators,

--- a/compiler/tests/unit/data/stage2/metadata.sfn-asm
+++ b/compiler/tests/unit/data/stage2/metadata.sfn-asm
@@ -2,18 +2,18 @@
 .module main
 
 .interface Meter
-    .sig total(self -> Meter) -> number
+    .sig total(self: Meter) -> number
 .endinterface
 
 .struct Person implements Meter
     .layout struct name=Person size=8 align=8
     .layout field years type=number offset=0 size=8 align=8
-    .field years -> number
-    .method total(self -> Person) -> number
+    .field years: number
+    .method total(self: Person) -> number
     .meta return number
     .meta effects none
         .span 8 14 8 28
-        .param self -> Person
+        .param self: Person
         .span 9 9 9 27
         ret self.years
     .endmethod
@@ -26,13 +26,13 @@
     ret [#element:Person, Person { years: 36 }, Person { years: 42 }]
 .endfn
 
-.fn total_years(values -> Person[]) -> number
+.fn total_years(values: Person[]) -> number
 .meta return number
 .meta effects none
     .span 17 16 17 34
-    .param values -> Person[]
+    .param values: Person[]
     .span 18 5 18 33
-    eval let mut total -> number = 0
+    eval let mut total: number = 0
     .for person in values
         .span 20 9 20 38
         eval total = total + person.years

--- a/compiler/tests/unit/emit_native_format_test.sfn
+++ b/compiler/tests/unit/emit_native_format_test.sfn
@@ -144,14 +144,14 @@ test "format: type parameter with bound" {
 test "format: immutable field" {
     let name = "x";
     let type_text = "number";
-    assert name + " -> " + type_text == "x -> number";
+    assert name + ": " + type_text == "x: number";
 }
 
 test "format: mutable field" {
     let prefix = "mut ";
     let name = "x";
     let type_text = "number";
-    assert prefix + name + " -> " + type_text == "mut x -> number";
+    assert prefix + name + ": " + type_text == "mut x: number";
 }
 
 // ── Enum variant formatting tests ────────────────────────────────────
@@ -163,8 +163,8 @@ test "format: enum variant no fields" {
 
 test "format: enum variant with fields" {
     let name = "Some";
-    let fields = _join(["value -> number"], "; ");
-    assert name + " { " + fields + " }" == "Some { value -> number }";
+    let fields = _join(["value: number"], "; ");
+    assert name + " { " + fields + " }" == "Some { value: number }";
 }
 
 // ── Decorator formatting tests ───────────────────────────────────────

--- a/compiler/tests/unit/ir_parse_separator_test.sfn
+++ b/compiler/tests/unit/ir_parse_separator_test.sfn
@@ -1,0 +1,140 @@
+// Regression tests for IR separator backward compatibility.
+// Cached IR may use "->" as the annotation separator while the type text
+// contains ":" (e.g. function types like fn(x: number) -> Response).
+// The parser must pick the earliest valid separator to avoid mis-splits.
+// See: docs/proposals/colon-type-annotations.md, Phase 5.
+
+// ── Minimal helpers ──────────────────────────────────────────────────
+
+fn _index_of(haystack: string, needle: string) -> number {
+    let mut i: number = 0;
+    loop {
+        if i + needle.length > haystack.length { break; }
+        let slice = substring(haystack, i, i + needle.length);
+        if slice == needle { return i; }
+        i += 1;
+    }
+    return -1;
+}
+
+fn _trim(text: string) -> string {
+    let mut start: number = 0;
+    loop {
+        if start >= text.length { break; }
+        let ch = text[start];
+        let mut is_ws: boolean = false;
+        if ch == " " { is_ws = true; }
+        if ch == "\t" { is_ws = true; }
+        if ch == "\n" { is_ws = true; }
+        if !is_ws { break; }
+        start += 1;
+    }
+    let mut end: number = text.length;
+    loop {
+        if end <= start { break; }
+        let ch = text[end - 1];
+        let mut is_ws: boolean = false;
+        if ch == " " { is_ws = true; }
+        if ch == "\t" { is_ws = true; }
+        if ch == "\n" { is_ws = true; }
+        if !is_ws { break; }
+        end -= 1;
+    }
+    return substring(text, start, end);
+}
+
+// Mirrors the earliest-separator logic used in parse_struct_field_line,
+// parse_enum_variant_field, and the lowering recovery parsers.
+fn _pick_separator(text: string) -> number[] {
+    let colon_idx = _index_of(text, ": ");
+    let arrow_idx = _index_of(text, " -> ");
+    let mut sep_idx: number = -1;
+    let mut sep_len: number = 0;
+    if colon_idx >= 0 {
+        sep_idx = colon_idx;
+        sep_len = 2;
+    }
+    if arrow_idx >= 0 {
+        let mut use_arrow: boolean = false;
+        if sep_idx < 0 { use_arrow = true; }
+        if sep_idx >= 0 {
+            if arrow_idx < sep_idx { use_arrow = true; }
+        }
+        if use_arrow {
+            sep_idx = arrow_idx;
+            sep_len = 4;
+        }
+    }
+    return [sep_idx, sep_len];
+}
+
+fn _split_field(text: string) -> string[] {
+    let result = _pick_separator(text);
+    let sep_idx = result[0];
+    let sep_len = result[1];
+    if sep_idx < 0 { return ["", ""]; }
+    let name = _trim(substring(text, 0, sep_idx));
+    let type_text = _trim(substring(text, sep_idx + sep_len, text.length));
+    return [name, type_text];
+}
+
+// ── New format: colon separator ──────────────────────────────────────
+
+test "ir-parse: simple field with colon separator" {
+    let parts = _split_field("x: number");
+    assert parts[0] == "x";
+    assert parts[1] == "number";
+}
+
+test "ir-parse: field with colon and function type containing arrow" {
+    let parts = _split_field("handler: fn(req: Request) -> Response");
+    assert parts[0] == "handler";
+    assert parts[1] == "fn(req: Request) -> Response";
+}
+
+test "ir-parse: field with colon and nested colons in type" {
+    let parts = _split_field("cb: fn(x: number, y: string) -> boolean");
+    assert parts[0] == "cb";
+    assert parts[1] == "fn(x: number, y: string) -> boolean";
+}
+
+// ── Legacy format: arrow separator (cached IR backward compat) ──────
+
+test "ir-parse: simple field with legacy arrow separator" {
+    let parts = _split_field("x -> number");
+    assert parts[0] == "x";
+    assert parts[1] == "number";
+}
+
+test "ir-parse: legacy arrow with colon inside type text" {
+    // Cached IR: field uses -> but type contains : from source migration
+    let parts = _split_field("handler -> fn(req: Request) -> Response");
+    assert parts[0] == "handler";
+    assert parts[1] == "fn(req: Request) -> Response";
+}
+
+test "ir-parse: legacy arrow with multiple colons inside type" {
+    let parts = _split_field("cb -> fn(x: number, y: string) -> boolean");
+    assert parts[0] == "cb";
+    assert parts[1] == "fn(x: number, y: string) -> boolean";
+}
+
+// ── Edge cases ───────────────────────────────────────────────────────
+
+test "ir-parse: no separator returns empty" {
+    let parts = _split_field("noseparator");
+    assert parts[0] == "";
+    assert parts[1] == "";
+}
+
+test "ir-parse: parameter with colon separator" {
+    let parts = _split_field("name: string");
+    assert parts[0] == "name";
+    assert parts[1] == "string";
+}
+
+test "ir-parse: parameter with legacy arrow separator" {
+    let parts = _split_field("name -> string");
+    assert parts[0] == "name";
+    assert parts[1] == "string";
+}

--- a/docs/proposals/colon-type-annotations.md
+++ b/docs/proposals/colon-type-annotations.md
@@ -1,7 +1,6 @@
 # Colon Type Annotations Migration Plan
 
-**Status:** Phases 1–5 implemented (source-level migration and emitter update complete).
-Phase 6 (parser split) deferred to follow-up branch.
+**Status:** Phases 1–6 implemented (migration complete).
 **Roadmap ref:** `docs/roadmap.md` Section 0 — Syntax reform (breaking, do first)
 **Date:** 2026-04-15
 

--- a/docs/proposals/colon-type-annotations.md
+++ b/docs/proposals/colon-type-annotations.md
@@ -1,7 +1,7 @@
 # Colon Type Annotations Migration Plan
 
-**Status:** Phases 1–4 implemented (source-level migration complete).
-Phases 5 (emitter update) and 6 (parser split) deferred to follow-up branches.
+**Status:** Phases 1–5 implemented (source-level migration and emitter update complete).
+Phase 6 (parser split) deferred to follow-up branch.
 **Roadmap ref:** `docs/roadmap.md` Section 0 — Syntax reform (breaking, do first)
 **Date:** 2026-04-15
 

--- a/docs/proposals/colon-type-annotations.md
+++ b/docs/proposals/colon-type-annotations.md
@@ -44,17 +44,19 @@ struct Point {
 
 ## Current State
 
-### Parser already accepts both forms
+### Parser enforces separator roles
 
-`consume_type_separator()` in `compiler/src/parser/declarations.sfn:88` and
-`expression_tokens_consume_type_separator()` in
-`compiler/src/parser/expressions.sfn:78` both accept `:` and `->` interchangeably
-via the shared `TypeSep = "->" | ":"` rule.
+`consume_annotation_separator()` in `compiler/src/parser/declarations.sfn`
+accepts only `:` for parameter, variable, and field annotations.
+`consume_return_type_separator()` in the same file accepts only `->` for
+function return types. `expression_tokens_consume_type_separator()` in
+`compiler/src/parser/expressions.sfn` uses boolean flags `accept_colon` and
+`accept_arrow` to select the correct separator per context.
 
 The AST does not store which separator was parsed — it is discarded at parse
-time. This means both forms produce identical ASTs and the rest of the pipeline
-(type checker, effect checker, emitter, LLVM lowering) is agnostic to the
-separator.
+time. Both annotation and return-type positions produce identical ASTs and
+the rest of the pipeline (type checker, effect checker, emitter, LLVM
+lowering) is agnostic to the separator.
 
 ### Three files already migrated
 
@@ -143,63 +145,44 @@ fn foo() ![io] -> Type  # after effect annotation
    c. If it matches `) -> <Type>` or `] -> <Type>` or effect list `-> <Type>` — keep as `->`
 4. Report a summary of changes per file
 
-## Emitter Updates (Phase 5 — Deferred to Follow-up Branch)
+## Emitter Updates (Phase 5 — Complete)
 
-After all source files are migrated, update the emitters to output `:` for
-annotation positions. The actual surface is larger than the original three call
-sites and must be changed atomically with the IR parser to preserve
-self-hosting:
+All emitters now output `:` for annotation positions. The IR parsers accept
+both `:` (preferred) and `->` (fallback) for backward compatibility with any
+cached IR. The earliest valid separator is selected to handle function types
+containing `:` in cached `->` IR (e.g., `handler -> fn(req: Request) -> Response`).
 
-**Sailfin source emitter** (`fn`/struct rendering for diagnostics, formatter, etc.):
+**Sailfin source emitter:**
 
-- `compiler/src/emitter_sailfin_expr.sfn:25` — `format_type_annotation()`. Used
-  for both annotations (params/vars) and return types; needs to be split into
-  `format_type_annotation` (`:`) and `format_return_type_annotation` (`->`),
-  with the lambda return-type call site (line 149) updated.
-- `compiler/src/emitter_sailfin.sfn:682,726` — field and parameter rendering.
-  Line 667 is a return type and stays as `->`.
+- `compiler/src/emitter_sailfin_expr.sfn` — `format_type_annotation()` returns
+  `": " + text`; `format_return_type_annotation()` returns `" -> " + text`.
+- `compiler/src/emitter_sailfin.sfn` — field and parameter rendering uses `": "`.
 
-**Native IR emitter** (`.sfn-asm` text format):
+**Native IR emitter:**
 
-- `compiler/src/emit_native_format.sfn:279,318` — parameter and field
-  declarations in the IR. Line 253 is a return type and stays as `->`.
-- `compiler/src/emit_native.sfn:799` — parameter declaration in the alternate
-  IR emitter.
-- `compiler/src/llvm/rendering_helpers.sfn:265` — parameter rendering used
-  during LLVM lowering. Line 237 is a return type and stays as `->`.
+- `compiler/src/emit_native_format.sfn` — parameter and field in `.sfn-asm`.
+- `compiler/src/emit_native.sfn` — `.param` metadata.
+- `compiler/src/llvm/rendering_helpers.sfn` — interface parameter rendering.
 
-**Native IR parsers** (must accept the new `:` form, ideally tolerating `->`
-for any cached IR):
+**Native IR parsers** (accept both, earliest wins):
 
-- `compiler/src/native_ir_utils_parse.sfn:761` — main `.sfn-asm` parameter
-  parser.
-- `compiler/src/llvm/lowering/lowering_recovery.sfn:178,195,579` — recovery
-  parser used when the structured parser bails out. Method/parameter/field
-  arrow lookups must accept both separators.
+- `compiler/src/native_ir_utils_parse.sfn` — `parse_struct_field_line`,
+  `parse_enum_variant_field`, `parse_parameter_entry`.
+- `compiler/src/llvm/lowering/lowering_recovery.sfn` — recovery parser for
+  `.param` and `.field` lines.
 
-**Test fixtures and assertions** that currently embed the IR text format:
+## Parser Finalization (Phase 6 — Complete)
 
-- `compiler/tests/unit/data/stage2/metadata.sfn-asm` — golden IR fixture.
-- `compiler/tests/unit/emit_native_format_test.sfn:147,154` — hardcoded
-  `"x -> number"` and `"mut x -> number"` assertions.
+The shared `consume_type_separator()` was split into:
 
-Self-hosting validation: emitter and parser changes must be in the same
-commit, validated by `make clean-build && make check`. Because the IR is
-regenerated from source on each build (not persisted across builds), the
-new emitter/parser pair only needs to be self-consistent — there is no
-on-disk legacy IR to migrate.
+- `consume_annotation_separator()` — accepts only `:` (parameters, variables,
+  struct/enum fields)
+- `consume_return_type_separator()` — accepts only `->` (function, pipeline,
+  tool return types)
 
-## Parser Finalization (Optional, Separate PR)
-
-After migration is complete and all source uses `:`, split the shared
-`TypeSep` rule:
-
-- `AnnotationSep = ":"` — for parameters, variables, fields
-- `ReturnSep = "->"` — for function return types
-- Make `->` a parse error in annotation position
-- Make `:` a parse error in return-type position
-
-This is a cleanup step, not a prerequisite for migration.
+All 14 call sites in `declarations.sfn` and 2 in `expressions.sfn` were
+updated. `->` is now a parse error in annotation position and `:` is a parse
+error in return-type position.
 
 ## Execution Plan
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -27,9 +27,9 @@ or C runtime**. All items below are hard requirements, not stretch goals.
          Python, Kotlin, Swift, Zig) uses `:` for annotations. The current
          syntax is the single most likely reason a new user bounces.
          Source migration complete (compiler, runtime, capsules, tests,
-         examples, docs). Emitter update (Phase 5) complete — all emitters
-         and IR parsers now use `:` for annotation positions. Parser split
-         (Phase 6) tracked separately; see
+         examples, docs). Emitter update (Phase 5) and parser split
+         (Phase 6) complete — the parser now enforces `:` for annotations
+         and `->` for return types. See
          `docs/proposals/colon-type-annotations.md`.
    - [ ] **String interpolation delimiters** — replace `{{ expr }}` with
          `${ expr }`.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -27,8 +27,9 @@ or C runtime**. All items below are hard requirements, not stretch goals.
          Python, Kotlin, Swift, Zig) uses `:` for annotations. The current
          syntax is the single most likely reason a new user bounces.
          Source migration complete (compiler, runtime, capsules, tests,
-         examples, docs). Emitter update (Phase 5) and parser split
-         (Phase 6) are tracked separately; see
+         examples, docs). Emitter update (Phase 5) complete — all emitters
+         and IR parsers now use `:` for annotation positions. Parser split
+         (Phase 6) tracked separately; see
          `docs/proposals/colon-type-annotations.md`.
    - [ ] **String interpolation delimiters** — replace `{{ expr }}` with
          `${ expr }`.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -92,10 +92,8 @@ let name: string = "Sailfin";
 let mut counter: number = 0;
 ```
 
-Type annotations use `:`; function return types use `->`. The parser still
-accepts `->` in annotation positions for backward compatibility, but new code
-should use `:`. The grammar will split `TypeSep` into separate `AnnotationSep`
-and `ReturnSep` rules before 1.0; see `docs/roadmap.md` §0.
+Type annotations use `:`; function return types use `->`. The parser enforces
+`:` in annotation positions and `->` in return-type positions.
 
 Type annotations are optional; the current compiler performs limited
 inference. Initialisers may be omitted; the compiler emits `null` when a

--- a/docs/status.md
+++ b/docs/status.md
@@ -158,10 +158,8 @@ let name: string = "Sailfin";
 struct User { id: number; name: string; }
 ```
 
-**Remaining work**:
-- Parser still accepts both `->` and `:` via the shared `TypeSep` rule;
-  splitting into `AnnotationSep = ":"` and `ReturnSep = "->"` is tracked as
-  Phase 6 of the same epic.
+**Remaining work**: None — migration complete. The parser now enforces
+`:` in annotation positions and `->` in return-type positions.
 
 ### String interpolation (`{{ }}` vs `${ }`)
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -159,8 +159,6 @@ struct User { id: number; name: string; }
 ```
 
 **Remaining work**:
-- Emitters still output `->` in annotation positions (tracked under roadmap §0
-  Phase 5); will be updated to `:` so generated/printed code matches source.
 - Parser still accepts both `->` and `:` via the shared `TypeSep` rule;
   splitting into `AnnotationSep = ":"` and `ReturnSep = "->"` is tracked as
   Phase 6 of the same epic.


### PR DESCRIPTION
## Summary

Completes the colon type annotation migration (roadmap §0). Phases 1–4 (source-level migration of ~7,100 annotations across ~241 files) were completed in prior PRs.

### Phase 5 — Emitter & IR parser update
- All emitters (`emitter_sailfin.sfn`, `emitter_sailfin_expr.sfn`, `emit_native.sfn`, `emit_native_format.sfn`, `rendering_helpers.sfn`) now emit `:` for annotation positions
- IR parsers (`native_ir_utils_parse.sfn`, `lowering_recovery.sfn`) accept both `:` (preferred) and `->` (fallback) for backward compatibility with cached IR
- Test fixtures updated to match

### Phase 6 — Parser split
- Split `consume_type_separator()` into two functions:
  - `consume_annotation_separator()`: accepts only `:` (params, variables, struct/enum fields)
  - `consume_return_type_separator()`: accepts only `->` (function, pipeline, tool return types)
- Updated all 14 call sites in `declarations.sfn` and 2 in `expressions.sfn`
- Updated `mod.sfn` exports

### Validation
- `make compile` — selfhost succeeded for both phases
- `make test` — 71/71 passed (48 unit, 17 integration, 6 e2e)

### Docs
- `docs/proposals/colon-type-annotations.md` — marked complete
- `docs/status.md` — removed remaining work items
- `docs/roadmap.md` — updated to reflect full completion
- `docs/spec.md` — updated grammar description (enforcement, not backward compat)