### PR TITLE
feat(compiler): wire up compile-time dependency resolution from capsule.toml

### DIFF
--- a/compiler/src/cli_commands.sfn
+++ b/compiler/src/cli_commands.sfn
@@ -211,8 +211,12 @@ fn _collect_relative_import_spans_cmd(source: string) -> _RelativeImportSpanCmd[
                         } else {
                             // Non-stdlib scoped import (e.g. "sfn/cli", "acme/router") —
                             // may be a cached capsule dependency declared in capsule.toml.
+                            // Exclude runtime/* imports which are pre-built and handled
+                            // separately by the linker.
                             if _has_slash_cmd(spec) {
-                                spans.push(_RelativeImportSpanCmd { start: stmt_start, end: stmt_end, spec: spec });
+                                if !_has_prefix_cmd(spec, "runtime/") {
+                                    spans.push(_RelativeImportSpanCmd { start: stmt_start, end: stmt_end, spec: spec });
+                                }
                             }
                         }
                     }
@@ -306,21 +310,52 @@ fn _lookup_dep_version_cmd(deps: string, name: string) -> string {
     return "";
 }
 
+// Validate a path segment (scope, name) contains no traversal or illegal chars.
+fn _is_safe_capsule_segment_cmd(value: string) -> boolean {
+    if value.length == 0 { return false; }
+    if strings_equal(value, ".") { return false; }
+    if strings_equal(value, "..") { return false; }
+    if find_char(value, "/", 0) >= 0 { return false; }
+    if find_char(value, "\\", 0) >= 0 { return false; }
+    return true;
+}
+
+// Validate a version string contains no traversal sequences.
+fn _is_safe_capsule_version_cmd(value: string) -> boolean {
+    if value.length == 0 { return false; }
+    if strings_equal(value, ".") { return false; }
+    if strings_equal(value, "..") { return false; }
+    if find_char(value, "/", 0) >= 0 { return false; }
+    if find_char(value, "\\", 0) >= 0 { return false; }
+    if _string_contains_cmd(value, "..") { return false; }
+    return true;
+}
+
 // Resolve a capsule import spec (e.g. "sfn/cli") to the cached source path
 // using the dependency version from capsule.toml. Returns "" if not found.
+// Validates that spec is exactly "scope/name" (single slash) and that all
+// path segments are safe to prevent directory traversal.
 fn _resolve_cached_capsule_path_cmd(spec: string, deps: string) -> string ![io] {
     if deps.length == 0 { return ""; }
+    // Require exactly one slash (scope/name format)
+    let slash_pos = find_char(spec, "/", 0);
+    if slash_pos <= 0 { return ""; }
+    if slash_pos >= spec.length - 1 { return ""; }
+    // Reject specs with more than one slash
+    let second_slash = find_char(spec, "/", slash_pos + 1);
+    if second_slash >= 0 { return ""; }
+    let scope = substring(spec, 0, slash_pos);
+    let name = substring(spec, slash_pos + 1, spec.length);
+    if !_is_safe_capsule_segment_cmd(scope) { return ""; }
+    if !_is_safe_capsule_segment_cmd(name) { return ""; }
     // Convert spec to the display name used in capsule.toml
     let display_name = _display_capsule_name_cmd(spec);
     let version = _lookup_dep_version_cmd(deps, display_name);
     if version.length == 0 { return ""; }
+    if !_is_safe_capsule_version_cmd(version) { return ""; }
     // Build cache path: ~/.sfn/cache/capsules/{scope}/{name}/{version}/src/mod.sfn
     let home = _get_home_cmd();
     if home.length == 0 { return ""; }
-    let slash_pos = find_char(spec, "/", 0);
-    if slash_pos < 0 { return ""; }
-    let scope = substring(spec, 0, slash_pos);
-    let name = substring(spec, slash_pos + 1, spec.length);
     return home + "/.sfn/cache/capsules/" + scope + "/" + name + "/" + version + "/src/mod.sfn";
 }
 
@@ -333,11 +368,41 @@ fn _inline_relative_imports_cmd(source: string, base_dir: string, depth: number,
     let mut next_visited = visited;
     let mut remove: _RelativeImportSpanCmd[] = [];
 
-    // Read project dependencies once for cached capsule resolution
+    // Read project dependencies once for cached capsule resolution.
+    // Try capsule.toml in base_dir first, then CWD as fallback, then
+    // walk up from base_dir to find the nearest capsule.toml.
     let mut project_deps: string = "";
-    if fs.exists("capsule.toml") {
-        let toml_text = fs.readFile("capsule.toml");
-        project_deps = toml_get_dependencies(toml_text);
+    let mut toml_found: boolean = false;
+    if base_dir.length > 0 {
+        let base_toml = _path_join_cmd(base_dir, "capsule.toml");
+        if fs.exists(base_toml) {
+            project_deps = toml_get_dependencies(fs.readFile(base_toml));
+            toml_found = true;
+        }
+        if !toml_found {
+            // Walk up parent directories from base_dir
+            let mut search_dir = _dirname_cmd(base_dir);
+            let mut walk_depth: number = 0;
+            loop {
+                if walk_depth >= 10 { break; }
+                if search_dir.length == 0 { break; }
+                let parent_toml = _path_join_cmd(search_dir, "capsule.toml");
+                if fs.exists(parent_toml) {
+                    project_deps = toml_get_dependencies(fs.readFile(parent_toml));
+                    toml_found = true;
+                    break;
+                }
+                let next_dir = _dirname_cmd(search_dir);
+                if strings_equal(next_dir, search_dir) { break; }
+                search_dir = next_dir;
+                walk_depth += 1;
+            }
+        }
+    }
+    if !toml_found {
+        if fs.exists("capsule.toml") {
+            project_deps = toml_get_dependencies(fs.readFile("capsule.toml"));
+        }
     }
 
     let mut index: number = 0;
@@ -370,12 +435,15 @@ fn _inline_relative_imports_cmd(source: string, base_dir: string, depth: number,
             }
         }
         if !is_capsule_import {
-            // Scoped import not found in capsule.toml — hard error
+            // Scoped import not found in capsule.toml — hard error.
+            // Exclude runtime/* (pre-built) and relative imports.
             if _has_slash_cmd(spec) {
                 if !_has_prefix_cmd(spec, "./") {
                     if !_has_prefix_cmd(spec, "../") {
-                        print.err("error: dependency \"" + spec + "\" is not declared in capsule.toml — run `sfn add " + spec + "` first");
-                        return "";
+                        if !_has_prefix_cmd(spec, "runtime/") {
+                            print.err("error: dependency \"" + spec + "\" is not declared in capsule.toml — run `sfn add " + spec + "` first");
+                            return "";
+                        }
                     }
                 }
             }

--- a/compiler/src/cli_commands.sfn
+++ b/compiler/src/cli_commands.sfn
@@ -12,6 +12,7 @@ import {
 import {
     toml_get_name,
     toml_get_version,
+    toml_get_dependencies,
     toml_generate,
     toml_add_dependency,
     toml_add_dev_dependency,
@@ -207,6 +208,12 @@ fn _collect_relative_import_spans_cmd(source: string) -> _RelativeImportSpanCmd[
                         }
                         if is_capsule {
                             spans.push(_RelativeImportSpanCmd { start: stmt_start, end: stmt_end, spec: spec });
+                        } else {
+                            // Non-stdlib scoped import (e.g. "sfn/cli", "acme/router") —
+                            // may be a cached capsule dependency declared in capsule.toml.
+                            if _has_slash_cmd(spec) {
+                                spans.push(_RelativeImportSpanCmd { start: stmt_start, end: stmt_end, spec: spec });
+                            }
                         }
                     }
                 }
@@ -259,6 +266,64 @@ fn _strip_relative_import_lines_cmd(source: string) -> string {
     return out;
 }
 
+// Look up a dependency version from the deps string returned by
+// toml_get_dependencies(). The deps string has the format
+// "name=version\nname=version\n...". Returns the version string
+// if found, or "" if not.
+fn _lookup_dep_version_cmd(deps: string, name: string) -> string {
+    if deps.length == 0 { return ""; }
+    if name.length == 0 { return ""; }
+    let mut start: number = 0;
+    let len = deps.length;
+    loop {
+        if start >= len { break; }
+        // Find end of current line
+        let mut end: number = start;
+        loop {
+            if end >= len { break; }
+            if deps[end] == "\n" { break; }
+            end += 1;
+        }
+        // Parse "capsule=version" from this line
+        let mut eq_pos: number = -1;
+        let mut ei: number = start;
+        loop {
+            if ei >= end { break; }
+            if deps[ei] == "=" {
+                eq_pos = ei;
+                break;
+            }
+            ei += 1;
+        }
+        if eq_pos > start {
+            let dep_name = substring(deps, start, eq_pos);
+            if strings_equal(dep_name, name) {
+                return substring(deps, eq_pos + 1, end);
+            }
+        }
+        start = end + 1;
+    }
+    return "";
+}
+
+// Resolve a capsule import spec (e.g. "sfn/cli") to the cached source path
+// using the dependency version from capsule.toml. Returns "" if not found.
+fn _resolve_cached_capsule_path_cmd(spec: string, deps: string) -> string ![io] {
+    if deps.length == 0 { return ""; }
+    // Convert spec to the display name used in capsule.toml
+    let display_name = _display_capsule_name_cmd(spec);
+    let version = _lookup_dep_version_cmd(deps, display_name);
+    if version.length == 0 { return ""; }
+    // Build cache path: ~/.sfn/cache/capsules/{scope}/{name}/{version}/src/mod.sfn
+    let home = _get_home_cmd();
+    if home.length == 0 { return ""; }
+    let slash_pos = find_char(spec, "/", 0);
+    if slash_pos < 0 { return ""; }
+    let scope = substring(spec, 0, slash_pos);
+    let name = substring(spec, slash_pos + 1, spec.length);
+    return home + "/.sfn/cache/capsules/" + scope + "/" + name + "/" + version + "/src/mod.sfn";
+}
+
 fn _inline_relative_imports_cmd(source: string, base_dir: string, depth: number, visited: string[]) -> string ![io] {
     if depth <= 0 {
         return _strip_relative_import_lines_cmd(source);
@@ -267,6 +332,14 @@ fn _inline_relative_imports_cmd(source: string, base_dir: string, depth: number,
     let mut combined: string = "";
     let mut next_visited = visited;
     let mut remove: _RelativeImportSpanCmd[] = [];
+
+    // Read project dependencies once for cached capsule resolution
+    let mut project_deps: string = "";
+    if fs.exists("capsule.toml") {
+        let toml_text = fs.readFile("capsule.toml");
+        project_deps = toml_get_dependencies(toml_text);
+    }
+
     let mut index: number = 0;
     loop {
         if index >= spans.length { break; }
@@ -286,7 +359,26 @@ fn _inline_relative_imports_cmd(source: string, base_dir: string, depth: number,
                 is_capsule_import = true;
             }
         }
+        // Check cached capsule dependencies from capsule.toml
         if !is_capsule_import {
+            if _has_slash_cmd(spec) {
+                let cached_path = _resolve_cached_capsule_path_cmd(spec, project_deps);
+                if cached_path.length > 0 {
+                    dep_path = cached_path;
+                    is_capsule_import = true;
+                }
+            }
+        }
+        if !is_capsule_import {
+            // Scoped import not found in capsule.toml — hard error
+            if _has_slash_cmd(spec) {
+                if !_has_prefix_cmd(spec, "./") {
+                    if !_has_prefix_cmd(spec, "../") {
+                        print.err("error: dependency \"" + spec + "\" is not declared in capsule.toml — run `sfn add " + spec + "` first");
+                        return "";
+                    }
+                }
+            }
             dep_path = _resolve_import_path_cmd(base_dir, spec);
         }
 
@@ -299,7 +391,11 @@ fn _inline_relative_imports_cmd(source: string, base_dir: string, depth: number,
                     if fs.exists(mod_fallback) {
                         dep_path = mod_fallback;
                     } else {
-                        print("test import inlining: missing dependency: " + dep_path);
+                        if is_capsule_import {
+                            print.err("error: cached capsule not found: " + dep_path + " — run `sfn add " + spec + "` to download it");
+                        } else {
+                            print.err("import inlining: missing dependency: " + dep_path);
+                        }
                         index += 1;
                         continue;
                     }
@@ -884,4 +980,11 @@ fn handle_guillermo_command() -> number ![io] {
     return 0;
 }
 
-export { handle_test_command, handle_publish_command, handle_add_command, handle_init_command, handle_login_command, handle_guillermo_command };
+// Inline all imports (relative, stdlib, and cached capsule deps) for a
+// source file.  Exposed so `sfn run` can resolve capsule deps before
+// compilation.
+fn inline_imports_for_source(source: string, base_dir: string) -> string ![io] {
+    return _inline_relative_imports_cmd(source, base_dir, 10, []);
+}
+
+export { handle_test_command, handle_publish_command, handle_add_command, handle_init_command, handle_login_command, handle_guillermo_command, inline_imports_for_source };

--- a/compiler/src/cli_main.sfn
+++ b/compiler/src/cli_main.sfn
@@ -19,6 +19,7 @@ import {
     handle_init_command,
     handle_login_command,
     handle_guillermo_command,
+    inline_imports_for_source,
 } from "./cli_commands";
 import { resolve_compiler_version } from "./version";
 
@@ -582,8 +583,11 @@ fn sailfin_cli_main(argv: string[]) -> number ![io] {
         let ll_path = "build/sailfin/run.ll";
         let exe_path = "build/sailfin/run";
 
-        // compile + link into build/sailfin/run then execute
-        let source = fs.readFile(input_path);
+        // Inline imports (relative, stdlib, and capsule deps from capsule.toml)
+        // before compilation so dependency sources are available.
+        let raw_source = fs.readFile(input_path);
+        let base_dir = _dirname(input_path);
+        let source = inline_imports_for_source(raw_source, base_dir);
         let module_name = module_name_from_path(input_path);
         let ok = compile_to_llvm_file_with_module(source, module_name, ll_path);
         if !ok {

--- a/compiler/src/llvm/imports.sfn
+++ b/compiler/src/llvm/imports.sfn
@@ -104,7 +104,9 @@ fn collect_imported_module_context_for_module(imports: NativeImport[], current_m
             if index_of(module_path, "/") >= 0 {
                 if !starts_with(module_path, "./") {
                     if !starts_with(module_path, "../") {
-                        is_cached_capsule = true;
+                        if !starts_with(module_path, "runtime/") {
+                            is_cached_capsule = true;
+                        }
                     }
                 }
             }
@@ -436,13 +438,27 @@ fn resolve_cached_capsule_source(module: string, deps: string, home_dir: string)
     if module.length == 0 { return ""; }
     if home_dir.length == 0 { return ""; }
     // Only handle scoped imports (containing "/") that aren't relative
+    // or runtime-internal
     let slash = index_of(module, "/");
-    if slash < 0 { return ""; }
+    if slash <= 0 { return ""; }
     if starts_with(module, "./") { return ""; }
     if starts_with(module, "../") { return ""; }
+    if starts_with(module, "runtime/") { return ""; }
+    // Require exactly scope/name (no extra slashes)
+    let slash2 = index_of(substring(module, slash + 1, module.length), "/");
+    if slash2 >= 0 { return ""; }
+    if slash >= module.length - 1 { return ""; }
 
     let scope = substring(module, 0, slash);
     let name = substring(module, slash + 1, module.length);
+
+    // Reject path traversal in segments
+    let mut _safe: boolean = true;
+    if scope == "." { _safe = false; }
+    if scope == ".." { _safe = false; }
+    if name == "." { _safe = false; }
+    if name == ".." { _safe = false; }
+    if !_safe { return ""; }
 
     // Look up the display name in deps. For sfn-scoped capsules, the dep
     // key is the bare name (e.g. "cli" for "sfn/cli").  For third-party
@@ -486,6 +502,13 @@ fn resolve_cached_capsule_source(module: string, deps: string, home_dir: string)
         start = end + 1;
     }
     if version.length == 0 { return ""; }
+    // Reject path traversal in version
+    let mut _version_safe: boolean = true;
+    if version == "." { _version_safe = false; }
+    if version == ".." { _version_safe = false; }
+    if index_of(version, "/") >= 0 { _version_safe = false; }
+    if index_of(version, "\\") >= 0 { _version_safe = false; }
+    if !_version_safe { return ""; }
 
     // Construct cache path
     let cached_path = home_dir + "/.sfn/cache/capsules/" + scope + "/" + name + "/" + version + "/src/mod.sfn";

--- a/compiler/src/llvm/imports.sfn
+++ b/compiler/src/llvm/imports.sfn
@@ -98,7 +98,21 @@ fn collect_imported_module_context_for_module(imports: NativeImport[], current_m
             manifest_structs = parsed_manifest.structs;
             manifest_enums = parsed_manifest.enums;
         } else {
-            diagnostics.push("layout manifest: missing artifact for import `" + module_path + "` (expected " + manifest_path + ")");
+            // Check if this is a cached capsule dependency whose source
+            // exists but hasn't been pre-compiled to artifacts.
+            let mut is_cached_capsule: boolean = false;
+            if index_of(module_path, "/") >= 0 {
+                if !starts_with(module_path, "./") {
+                    if !starts_with(module_path, "../") {
+                        is_cached_capsule = true;
+                    }
+                }
+            }
+            if is_cached_capsule {
+                diagnostics.push("layout manifest: missing artifact for capsule import `" + module_path + "` — ensure imports are inlined before LLVM lowering");
+            } else {
+                diagnostics.push("layout manifest: missing artifact for import `" + module_path + "` (expected " + manifest_path + ")");
+            }
         }
 
         // Load the full native text for direct imports (depth 0) so the
@@ -405,6 +419,80 @@ fn normalize_import_module_path(value: string) -> string {
         index += 1;
     }
     return result;
+}
+
+// =============================================================================
+// Cached Capsule Resolution
+// =============================================================================
+
+// Check whether a module path (e.g. "sfn/cli") corresponds to a cached
+// capsule dependency.  `deps` is a newline-separated "name=version" string
+// from toml_get_dependencies().  `home_dir` is the user's home directory
+// (e.g. "/home/user").  Returns the path to the cached source
+// (e.g. /home/user/.sfn/cache/capsules/sfn/cli/0.1.0/src/mod.sfn) or ""
+// if not found.
+fn resolve_cached_capsule_source(module: string, deps: string, home_dir: string) -> string ![io] {
+    if deps.length == 0 { return ""; }
+    if module.length == 0 { return ""; }
+    if home_dir.length == 0 { return ""; }
+    // Only handle scoped imports (containing "/") that aren't relative
+    let slash = index_of(module, "/");
+    if slash < 0 { return ""; }
+    if starts_with(module, "./") { return ""; }
+    if starts_with(module, "../") { return ""; }
+
+    let scope = substring(module, 0, slash);
+    let name = substring(module, slash + 1, module.length);
+
+    // Look up the display name in deps. For sfn-scoped capsules, the dep
+    // key is the bare name (e.g. "cli" for "sfn/cli").  For third-party
+    // capsules, the key is the full scoped name (e.g. "acme/router").
+    let mut dep_name: string = module;
+    if starts_with(module, "sfn/") {
+        dep_name = name;
+    }
+
+    // Search deps for the matching entry
+    let mut version: string = "";
+    let mut start: number = 0;
+    let dep_len = deps.length;
+    loop {
+        if start >= dep_len { break; }
+        let mut end: number = start;
+        loop {
+            if end >= dep_len { break; }
+            let ch = substring(deps, end, end + 1);
+            if ch == "\n" { break; }
+            end += 1;
+        }
+        let mut eq_pos: number = -1;
+        let mut ei: number = start;
+        loop {
+            if ei >= end { break; }
+            let ch = substring(deps, ei, ei + 1);
+            if ch == "=" {
+                eq_pos = ei;
+                break;
+            }
+            ei += 1;
+        }
+        if eq_pos > start {
+            let entry_name = substring(deps, start, eq_pos);
+            if entry_name == dep_name {
+                version = substring(deps, eq_pos + 1, end);
+                break;
+            }
+        }
+        start = end + 1;
+    }
+    if version.length == 0 { return ""; }
+
+    // Construct cache path
+    let cached_path = home_dir + "/.sfn/cache/capsules/" + scope + "/" + name + "/" + version + "/src/mod.sfn";
+    if fs.exists(cached_path) {
+        return cached_path;
+    }
+    return "";
 }
 
 // =============================================================================

--- a/compiler/src/main.sfn
+++ b/compiler/src/main.sfn
@@ -22,6 +22,7 @@ import {
 import { split_lines } from "./native_ir_utils_text";
 import { substring } from "./string_utils";
 import { Token } from "./token";
+import { toml_get_dependencies } from "./toml_parser";
 import { typecheck_diagnostics, typecheck_has_errors } from "./typecheck";
 
 fn _ms_since(start_ms: number) -> number {
@@ -835,5 +836,16 @@ fn repeat_character(ch: string, count: number) -> string {
         index += 1;
     }
     return result;
+}
+
+// Read the project's capsule.toml and return dependencies as a
+// newline-separated "name=version" string. Returns "" if no capsule.toml
+// is found in the current directory.
+fn read_project_dependencies() -> string ![io] {
+    if !fs.exists("capsule.toml") {
+        return "";
+    }
+    let text = fs.readFile("capsule.toml");
+    return toml_get_dependencies(text);
 }
 

--- a/compiler/src/toml_parser.sfn
+++ b/compiler/src/toml_parser.sfn
@@ -245,6 +245,22 @@ fn toml_get_description(text: string) -> string {
     return t.description;
 }
 
+// Return dependencies as a newline-separated string of "capsule=version" pairs.
+// Callers can split on "\n" and "=" to recover individual entries without
+// needing the SailToml struct across module boundaries.
+fn toml_get_dependencies(text: string) -> string {
+    let t = _parse_toml_internal(text);
+    let mut out: string = "";
+    let mut i: number = 0;
+    loop {
+        if i >= t.dependencies.length { break; }
+        if i > 0 { out = out + "\n"; }
+        out = out + t.dependencies[i].capsule + "=" + t.dependencies[i].version;
+        i += 1;
+    }
+    return out;
+}
+
 // Generate a capsule.toml string from individual fields
 fn toml_generate(name: string, version: string, description: string, entry: string) -> string {
     let mut out: string = "[capsule]\n";

--- a/compiler/tests/unit/capsule_dep_resolution_test.sfn
+++ b/compiler/tests/unit/capsule_dep_resolution_test.sfn
@@ -86,20 +86,38 @@ fn _display_capsule_name(name: string) -> string {
 
 fn _resolve_cached_path(spec: string, deps: string, home: string) -> string {
     if deps.length == 0 { return ""; }
-    let display_name = _display_capsule_name(spec);
-    let version = _lookup_dep_version(deps, display_name);
-    if version.length == 0 { return ""; }
     if home.length == 0 { return ""; }
+    // Require exactly one slash (scope/name)
     let mut slash_pos: number = -1;
+    let mut slash_count: number = 0;
     let mut i: number = 0;
     loop {
         if i >= spec.length { break; }
-        if spec[i] == "/" { slash_pos = i; break; }
+        if spec[i] == "/" {
+            if slash_pos < 0 { slash_pos = i; }
+            slash_count += 1;
+        }
         i += 1;
     }
-    if slash_pos < 0 { return ""; }
+    if slash_pos <= 0 { return ""; }
+    if slash_pos >= spec.length - 1 { return ""; }
+    if slash_count != 1 { return ""; }
     let scope = substring(spec, 0, slash_pos);
     let name = substring(spec, slash_pos + 1, spec.length);
+    // Reject traversal segments
+    if _str_eq(scope, ".") { return ""; }
+    if _str_eq(scope, "..") { return ""; }
+    if _str_eq(name, ".") { return ""; }
+    if _str_eq(name, "..") { return ""; }
+    // Exclude runtime/* (pre-built, not capsules)
+    if _has_prefix(spec, "runtime/") { return ""; }
+    let display_name = _display_capsule_name(spec);
+    let version = _lookup_dep_version(deps, display_name);
+    if version.length == 0 { return ""; }
+    // Reject traversal in version
+    if _str_eq(version, ".") { return ""; }
+    if _str_eq(version, "..") { return ""; }
+    if _has_slash(version) { return ""; }
     return home + "/.sfn/cache/capsules/" + scope + "/" + name + "/" + version + "/src/mod.sfn";
 }
 
@@ -204,4 +222,38 @@ test "import span: relative imports not treated as capsule" {
     assert _has_prefix("./local", "./") == true;
     assert _has_prefix("../parent", "../") == true;
     // These should NOT be treated as capsule deps
+}
+
+test "import span: runtime/* imports not treated as capsule" {
+    // runtime/prelude and other runtime/* imports must pass through
+    // to the linker, NOT be treated as capsule dependencies.
+    let spec = "runtime/prelude";
+    assert _has_prefix(spec, "runtime/") == true;
+    // The capsule span collector must skip runtime/* imports
+}
+
+test "cached path: rejects path traversal in spec" {
+    let deps = "../evil=1.0.0";
+    // spec with ".." should not resolve
+    let p1 = _resolve_cached_path("../evil", deps, "/home/user");
+    assert _str_eq(p1, "");
+    // spec with extra slashes should not resolve
+    let p2 = _resolve_cached_path("a/b/c", "b/c=1.0.0", "/home/user");
+    assert _str_eq(p2, "");
+}
+
+test "cached path: rejects empty scope or name" {
+    // slash at start (empty scope)
+    let p1 = _resolve_cached_path("/name", "name=1.0.0", "/home/user");
+    assert _str_eq(p1, "");
+    // slash at end (empty name)
+    let p2 = _resolve_cached_path("scope/", "=1.0.0", "/home/user");
+    assert _str_eq(p2, "");
+}
+
+test "cached path: runtime prefix excluded" {
+    let deps = "prelude=1.0.0";
+    let path = _resolve_cached_path("runtime/prelude", deps, "/home/user");
+    // runtime/* should never resolve as a cached capsule
+    assert _str_eq(path, "");
 }

--- a/compiler/tests/unit/capsule_dep_resolution_test.sfn
+++ b/compiler/tests/unit/capsule_dep_resolution_test.sfn
@@ -1,0 +1,207 @@
+// Regression tests for compile-time capsule dependency resolution.
+// Tests the dependency lookup helper, capsule name resolution, and
+// import span collection for non-stdlib scoped imports.
+
+// -- String helpers --
+
+fn _str_eq(a: string, b: string) -> boolean {
+    return strings_equal(a, b);
+}
+
+fn _has_prefix(value: string, prefix: string) -> boolean {
+    if prefix.length > value.length { return false; }
+    let mut i: number = 0;
+    loop {
+        if i >= prefix.length { break; }
+        if value[i] != prefix[i] { return false; }
+        i += 1;
+    }
+    return true;
+}
+
+fn _has_slash(name: string) -> boolean {
+    let mut i: number = 0;
+    loop {
+        if i >= name.length { break; }
+        if name[i] == "/" { return true; }
+        i += 1;
+    }
+    return false;
+}
+
+// -- Duplicated resolution helpers for standalone testing --
+
+fn _lookup_dep_version(deps: string, name: string) -> string {
+    if deps.length == 0 { return ""; }
+    if name.length == 0 { return ""; }
+    let mut start: number = 0;
+    let len = deps.length;
+    loop {
+        if start >= len { break; }
+        let mut end: number = start;
+        loop {
+            if end >= len { break; }
+            if deps[end] == "\n" { break; }
+            end += 1;
+        }
+        let mut eq_pos: number = -1;
+        let mut ei: number = start;
+        loop {
+            if ei >= end { break; }
+            if deps[ei] == "=" {
+                eq_pos = ei;
+                break;
+            }
+            ei += 1;
+        }
+        if eq_pos > start {
+            let dep_name = substring(deps, start, eq_pos);
+            if strings_equal(dep_name, name) {
+                return substring(deps, eq_pos + 1, end);
+            }
+        }
+        start = end + 1;
+    }
+    return "";
+}
+
+fn _display_capsule_name(name: string) -> string {
+    if _has_slash(name) {
+        let mut slash: number = -1;
+        let mut i: number = 0;
+        loop {
+            if i >= name.length { break; }
+            if name[i] == "/" { slash = i; break; }
+            i += 1;
+        }
+        if slash >= 0 {
+            let scope = substring(name, 0, slash);
+            if _str_eq(scope, "sfn") {
+                return substring(name, slash + 1, name.length);
+            }
+        }
+    }
+    return name;
+}
+
+fn _resolve_cached_path(spec: string, deps: string, home: string) -> string {
+    if deps.length == 0 { return ""; }
+    let display_name = _display_capsule_name(spec);
+    let version = _lookup_dep_version(deps, display_name);
+    if version.length == 0 { return ""; }
+    if home.length == 0 { return ""; }
+    let mut slash_pos: number = -1;
+    let mut i: number = 0;
+    loop {
+        if i >= spec.length { break; }
+        if spec[i] == "/" { slash_pos = i; break; }
+        i += 1;
+    }
+    if slash_pos < 0 { return ""; }
+    let scope = substring(spec, 0, slash_pos);
+    let name = substring(spec, slash_pos + 1, spec.length);
+    return home + "/.sfn/cache/capsules/" + scope + "/" + name + "/" + version + "/src/mod.sfn";
+}
+
+// -- Tests --
+
+test "dep lookup: single entry found" {
+    let deps = "cli=0.2.0";
+    assert _str_eq(_lookup_dep_version(deps, "cli"), "0.2.0");
+}
+
+test "dep lookup: single entry not found" {
+    let deps = "cli=0.2.0";
+    assert _str_eq(_lookup_dep_version(deps, "http"), "");
+}
+
+test "dep lookup: multiple entries" {
+    let deps = "cli=0.2.0\nhttp=0.3.1\nacme/router=2.0.0";
+    assert _str_eq(_lookup_dep_version(deps, "cli"), "0.2.0");
+    assert _str_eq(_lookup_dep_version(deps, "http"), "0.3.1");
+    assert _str_eq(_lookup_dep_version(deps, "acme/router"), "2.0.0");
+}
+
+test "dep lookup: empty deps returns empty" {
+    assert _str_eq(_lookup_dep_version("", "cli"), "");
+}
+
+test "dep lookup: empty name returns empty" {
+    assert _str_eq(_lookup_dep_version("cli=0.2.0", ""), "");
+}
+
+test "dep lookup: exact match only" {
+    let deps = "cli=0.2.0\nclient=1.0.0";
+    assert _str_eq(_lookup_dep_version(deps, "cli"), "0.2.0");
+    assert _str_eq(_lookup_dep_version(deps, "client"), "1.0.0");
+    assert _str_eq(_lookup_dep_version(deps, "cl"), "");
+}
+
+test "display name: sfn-scoped strips prefix" {
+    assert _str_eq(_display_capsule_name("sfn/cli"), "cli");
+    assert _str_eq(_display_capsule_name("sfn/http"), "http");
+}
+
+test "display name: third-party unchanged" {
+    assert _str_eq(_display_capsule_name("acme/router"), "acme/router");
+}
+
+test "display name: bare name unchanged" {
+    assert _str_eq(_display_capsule_name("cli"), "cli");
+}
+
+test "cached path: sfn-scoped capsule" {
+    let deps = "cli=0.2.0";
+    let path = _resolve_cached_path("sfn/cli", deps, "/home/user");
+    assert _str_eq(path, "/home/user/.sfn/cache/capsules/sfn/cli/0.2.0/src/mod.sfn");
+}
+
+test "cached path: third-party capsule" {
+    let deps = "acme/router=1.0.0";
+    let path = _resolve_cached_path("acme/router", deps, "/home/user");
+    assert _str_eq(path, "/home/user/.sfn/cache/capsules/acme/router/1.0.0/src/mod.sfn");
+}
+
+test "cached path: not in deps returns empty" {
+    let deps = "cli=0.2.0";
+    let path = _resolve_cached_path("sfn/missing", deps, "/home/user");
+    assert _str_eq(path, "");
+}
+
+test "cached path: empty deps returns empty" {
+    let path = _resolve_cached_path("sfn/cli", "", "/home/user");
+    assert _str_eq(path, "");
+}
+
+test "cached path: empty home returns empty" {
+    let deps = "cli=0.2.0";
+    let path = _resolve_cached_path("sfn/cli", deps, "");
+    assert _str_eq(path, "");
+}
+
+test "cached path: multiple deps correct lookup" {
+    let deps = "cli=0.2.0\nhttp=0.3.1\nacme/router=2.0.0";
+    let p1 = _resolve_cached_path("sfn/cli", deps, "/home/user");
+    let p2 = _resolve_cached_path("sfn/http", deps, "/home/user");
+    let p3 = _resolve_cached_path("acme/router", deps, "/home/user");
+    assert _str_eq(p1, "/home/user/.sfn/cache/capsules/sfn/cli/0.2.0/src/mod.sfn");
+    assert _str_eq(p2, "/home/user/.sfn/cache/capsules/sfn/http/0.3.1/src/mod.sfn");
+    assert _str_eq(p3, "/home/user/.sfn/cache/capsules/acme/router/2.0.0/src/mod.sfn");
+}
+
+test "import span: scoped non-relative import detected" {
+    // Verify that scoped import specs are recognized as potential capsule deps
+    let spec = "sfn/cli";
+    let is_scoped = _has_slash(spec);
+    let not_relative = !_has_prefix(spec, "./");
+    let not_parent = !_has_prefix(spec, "../");
+    assert is_scoped == true;
+    assert not_relative == true;
+    assert not_parent == true;
+}
+
+test "import span: relative imports not treated as capsule" {
+    assert _has_prefix("./local", "./") == true;
+    assert _has_prefix("../parent", "../") == true;
+    // These should NOT be treated as capsule deps
+}

--- a/compiler/tests/unit/toml_dependencies_test.sfn
+++ b/compiler/tests/unit/toml_dependencies_test.sfn
@@ -1,0 +1,136 @@
+// Regression tests for toml_get_dependencies() and capsule dependency
+// resolution helpers used by compile-time dependency resolution.
+
+import { toml_get_dependencies } from "../../src/toml_parser";
+
+// -- Local helpers for string assertions --
+
+fn _str_eq(a: string, b: string) -> boolean {
+    return strings_equal(a, b);
+}
+
+fn _contains(haystack: string, needle: string) -> boolean {
+    if needle.length == 0 { return true; }
+    if haystack.length < needle.length { return false; }
+    let mut i: number = 0;
+    loop {
+        if i + needle.length > haystack.length { break; }
+        let mut j: number = 0;
+        let mut matches: boolean = true;
+        loop {
+            if j >= needle.length { break; }
+            if haystack[i + j] != needle[j] {
+                matches = false;
+                break;
+            }
+            j += 1;
+        }
+        if matches { return true; }
+        i += 1;
+    }
+    return false;
+}
+
+fn _starts_with(value: string, prefix: string) -> boolean {
+    if prefix.length > value.length { return false; }
+    let mut i: number = 0;
+    loop {
+        if i >= prefix.length { break; }
+        if value[i] != prefix[i] { return false; }
+        i += 1;
+    }
+    return true;
+}
+
+// Lookup a dep version from the newline-separated deps string.
+// Duplicated here to test the format contract independently.
+fn _test_lookup_dep(deps: string, name: string) -> string {
+    if deps.length == 0 { return ""; }
+    let mut start: number = 0;
+    let len = deps.length;
+    loop {
+        if start >= len { break; }
+        let mut end: number = start;
+        loop {
+            if end >= len { break; }
+            if deps[end] == "\n" { break; }
+            end += 1;
+        }
+        let mut eq_pos: number = -1;
+        let mut ei: number = start;
+        loop {
+            if ei >= end { break; }
+            if deps[ei] == "=" {
+                eq_pos = ei;
+                break;
+            }
+            ei += 1;
+        }
+        if eq_pos > start {
+            let dep_name = substring(deps, start, eq_pos);
+            if strings_equal(dep_name, name) {
+                return substring(deps, eq_pos + 1, end);
+            }
+        }
+        start = end + 1;
+    }
+    return "";
+}
+
+// -- Tests --
+
+test "toml_get_dependencies: empty toml returns empty string" {
+    let toml = "[capsule]\nname = \"test\"\nversion = \"0.1.0\"\n";
+    let deps = toml_get_dependencies(toml);
+    assert _str_eq(deps, "");
+}
+
+test "toml_get_dependencies: empty deps section returns empty string" {
+    let toml = "[capsule]\nname = \"test\"\n\n[dependencies]\n\n[build]\nentry = \"src/main.sfn\"\n";
+    let deps = toml_get_dependencies(toml);
+    assert _str_eq(deps, "");
+}
+
+test "toml_get_dependencies: single dependency" {
+    let toml = "[capsule]\nname = \"myapp\"\nversion = \"0.1.0\"\n\n[dependencies]\n\"cli\" = \"0.2.0\"\n";
+    let deps = toml_get_dependencies(toml);
+    assert _str_eq(deps, "cli=0.2.0");
+}
+
+test "toml_get_dependencies: multiple dependencies" {
+    let toml = "[capsule]\nname = \"myapp\"\nversion = \"0.1.0\"\n\n[dependencies]\n\"cli\" = \"0.2.0\"\n\"acme/router\" = \"1.0.0\"\n";
+    let deps = toml_get_dependencies(toml);
+    assert _contains(deps, "cli=0.2.0");
+    assert _contains(deps, "acme/router=1.0.0");
+    // Should be newline-separated
+    assert _contains(deps, "\n");
+}
+
+test "toml_get_dependencies: round-trip lookup" {
+    let toml = "[capsule]\nname = \"app\"\nversion = \"1.0.0\"\n\n[dependencies]\n\"cli\" = \"0.2.0\"\n\"http\" = \"0.3.1\"\n\"acme/router\" = \"2.0.0\"\n";
+    let deps = toml_get_dependencies(toml);
+
+    // Lookup each dependency by name
+    assert _str_eq(_test_lookup_dep(deps, "cli"), "0.2.0");
+    assert _str_eq(_test_lookup_dep(deps, "http"), "0.3.1");
+    assert _str_eq(_test_lookup_dep(deps, "acme/router"), "2.0.0");
+
+    // Non-existent dependency returns ""
+    assert _str_eq(_test_lookup_dep(deps, "nonexistent"), "");
+    assert _str_eq(_test_lookup_dep(deps, ""), "");
+}
+
+test "toml_get_dependencies: dev-deps are excluded" {
+    let toml = "[capsule]\nname = \"app\"\nversion = \"1.0.0\"\n\n[dependencies]\n\"cli\" = \"0.2.0\"\n\n[dev-dependencies]\n\"test\" = \"0.1.0\"\n";
+    let deps = toml_get_dependencies(toml);
+    assert _str_eq(_test_lookup_dep(deps, "cli"), "0.2.0");
+    // dev-deps should NOT appear
+    assert _str_eq(_test_lookup_dep(deps, "test"), "");
+}
+
+test "toml_get_dependencies: quoted keys preserved" {
+    let toml = "[capsule]\nname = \"app\"\nversion = \"1.0.0\"\n\n[dependencies]\n\"sfn/special\" = \"0.5.0\"\n";
+    let deps = toml_get_dependencies(toml);
+    // The toml parser strips quotes, so the key should be "sfn/special"
+    assert _str_eq(_test_lookup_dep(deps, "sfn/special"), "0.5.0");
+}


### PR DESCRIPTION
Enable the compiler to discover and resolve imports from dependencies
declared in capsule.toml, so that `sfn add sfn/cli` followed by
`import { parse } from "sfn/cli"` works at compile time.

Changes:
- toml_parser.sfn: export toml_get_dependencies() returning deps as
  newline-separated "name=version" pairs
- main.sfn: add read_project_dependencies() to read capsule.toml
- cli_commands.sfn: extend _collect_relative_import_spans_cmd to
  capture scoped non-stdlib imports; extend _inline_relative_imports_cmd
  to resolve cached capsule deps from ~/.sfn/cache/capsules/; add
  _lookup_dep_version_cmd and _resolve_cached_capsule_path_cmd helpers;
  export inline_imports_for_source for use by sfn run
- cli_main.sfn: wire import inlining into sfn run so capsule deps are
  resolved before compilation
- llvm/imports.sfn: add resolve_cached_capsule_source for LLVM-level
  capsule path resolution; improve diagnostics for missing capsule
  import artifacts

Error handling:
- Undeclared scoped deps produce a hard error pointing to `sfn add`
- Missing cached capsule source produces a clear error with remediation
- All error messages use print.err (stderr)

Tests:
- toml_dependencies_test.sfn: round-trip tests for toml_get_dependencies
  format contract and dep lookup
- capsule_dep_resolution_test.sfn: dep version lookup, display name
  mapping, cached path construction, import span classification

Closes #138

https://claude.ai/code/session_01Hb9GyoafPg7bjh6656D4Bd