### PR TITLE
fix(workflows): add explicit noop instructions to all agentic workflows

### DIFF
--- a/.github/workflows/architect-review.md
+++ b/.github/workflows/architect-review.md
@@ -36,7 +36,8 @@ timeout-minutes: 15
 
 You are the Sailfin Architect. Your role is to review design proposals on issues labeled `needs-design` and determine whether they are ready for implementation.
 
-**Only proceed if** issue #${{ github.event.issue.number }} has the `needs-design` label. If not, exit immediately.
+**Only proceed if** issue #${{ github.event.issue.number }} has the `needs-design` label. If not, you MUST call the `noop` tool with a message explaining why no action was taken:
+`{"noop": {"message": "No action needed: issue does not have needs-design label"}}`
 
 ## Context
 

--- a/.github/workflows/engineer.md
+++ b/.github/workflows/engineer.md
@@ -35,7 +35,8 @@ timeout-minutes: 30
 
 You are the Sailfin Engineer agent. Your role is to implement features and fix bugs in the Sailfin compiler and runtime.
 
-**Only proceed if** issue #${{ github.event.issue.number }} has the `design-approved` label OR the `bug` label (without `needs-design`). If neither condition is met, exit immediately.
+**Only proceed if** issue #${{ github.event.issue.number }} has the `design-approved` label OR the `bug` label (without `needs-design`). If neither condition is met, you MUST call the `noop` tool with a message explaining why no action was taken:
+`{"noop": {"message": "No action needed: issue does not have design-approved or bug label"}}`
 
 ## Context
 

--- a/.github/workflows/engineer.md
+++ b/.github/workflows/engineer.md
@@ -36,7 +36,7 @@ timeout-minutes: 30
 You are the Sailfin Engineer agent. Your role is to implement features and fix bugs in the Sailfin compiler and runtime.
 
 **Only proceed if** issue #${{ github.event.issue.number }} has the `design-approved` label OR the `bug` label (without `needs-design`). If neither condition is met, you MUST call the `noop` tool with a message explaining why no action was taken:
-`{"noop": {"message": "No action needed: issue does not have design-approved or bug label"}}`
+`{"noop": {"message": "No action needed: issue does not meet required label criteria"}}`
 
 ## Context
 

--- a/.github/workflows/issue-triage.md
+++ b/.github/workflows/issue-triage.md
@@ -102,7 +102,7 @@ Key terminology: capsule (package), fleet (workspace), generation card (model pr
 You MUST always call at least one safe output tool. If the issue requires no triage action (e.g., already triaged, or is a workflow-generated `[aw]` failure issue), call the `noop` tool:
 `{"noop": {"message": "No action needed: [brief explanation]"}}`
 
-Do NOT finish without calling a safe output tool — the workflow will fail silently.
+Do NOT finish without calling a safe output tool — the workflow will fail with a `No Safe Outputs Generated` error.
 
 ## Important Notes
 

--- a/.github/workflows/issue-triage.md
+++ b/.github/workflows/issue-triage.md
@@ -97,6 +97,13 @@ Key terminology: capsule (package), fleet (workspace), generation card (model pr
    [If applicable, brief notes on how this might be addressed]
    ```
 
+## Important: Always Produce Output
+
+You MUST always call at least one safe output tool. If the issue requires no triage action (e.g., already triaged, or is a workflow-generated `[aw]` failure issue), call the `noop` tool:
+`{"noop": {"message": "No action needed: [brief explanation]"}}`
+
+Do NOT finish without calling a safe output tool — the workflow will fail silently.
+
 ## Important Notes
 
 - Reference `docs/status.md` for current feature implementation status

--- a/.github/workflows/pr-review.md
+++ b/.github/workflows/pr-review.md
@@ -100,10 +100,14 @@ Verify code quality, test coverage, and project standards.
 
 ## Important: Always Produce Output
 
-You MUST always call at least one safe output tool. If the PR has no findings or you cannot complete the review, call the `noop` tool:
+You MUST always call at least one safe output tool.
+
+If the PR has no blocking issues, still submit a PR review with **Approve**.
+
+Only call the `noop` tool when you cannot complete the review or cannot produce a real review output:
 `{"noop": {"message": "No action needed: [brief explanation]"}}`
 
-Do NOT finish without calling a safe output tool — the workflow will fail silently.
+Do NOT finish without calling a safe output tool — the workflow will fail with a `No Safe Outputs Generated` error.
 
 ---
 

--- a/.github/workflows/pr-review.md
+++ b/.github/workflows/pr-review.md
@@ -98,6 +98,13 @@ Verify code quality, test coverage, and project standards.
 - New fixup passes in the build script
 - New dependencies on Python bootstrap
 
+## Important: Always Produce Output
+
+You MUST always call at least one safe output tool. If the PR has no findings or you cannot complete the review, call the `noop` tool:
+`{"noop": {"message": "No action needed: [brief explanation]"}}`
+
+Do NOT finish without calling a safe output tool — the workflow will fail silently.
+
 ---
 
 ## Security Review

--- a/.github/workflows/release-notes.md
+++ b/.github/workflows/release-notes.md
@@ -99,6 +99,13 @@ rand, clock]`), ownership types, and AI-native constructs.
    already has auto-generated notes from `gh release create --generate-notes`;
    your comment supplements those with richer categorization and context.
 
+## Important: Always Produce Output
+
+You MUST always call at least one safe output tool. If you cannot generate release notes (e.g., no previous tag found, no commits between tags), call the `noop` tool:
+`{"noop": {"message": "No action needed: [brief explanation]"}}`
+
+Do NOT finish without calling a safe output tool — the workflow will fail silently.
+
 ## Guidelines
 
 - Be factual. Every claim must trace to an actual commit or PR.

--- a/.github/workflows/release-notes.md
+++ b/.github/workflows/release-notes.md
@@ -104,7 +104,7 @@ rand, clock]`), ownership types, and AI-native constructs.
 You MUST always call at least one safe output tool. If you cannot generate release notes (e.g., no previous tag found, no commits between tags), call the `noop` tool:
 `{"noop": {"message": "No action needed: [brief explanation]"}}`
 
-Do NOT finish without calling a safe output tool — the workflow will fail silently.
+Do NOT finish without calling a safe output tool — the workflow will fail with a `No Safe Outputs Generated` error.
 
 ## Guidelines
 


### PR DESCRIPTION
## Summary

All 5 agentic workflows were failing with **"No Safe Outputs Generated"** because the agent would finish without calling any safe-output tool. Per [gh-aw docs](https://github.github.com/gh-aw/reference/safe-outputs/#no-op-logging-noop), this is the #1 runtime failure mode for safe-output workflows.

## Changes

| Workflow | Fix |
|---|---|
| `engineer.md` | "exit immediately" → explicit `noop` call when issue lacks required labels |
| `architect-review.md` | "exit immediately" → explicit `noop` call when issue lacks `needs-design` label |
| `pr-review.md` | Added "Always Produce Output" section with `noop` fallback |
| `release-notes.md` | Added "Always Produce Output" section with `noop` fallback |
| `issue-triage.md` | Added "Always Produce Output" section with `noop` fallback |

No `.lock.yml` recompilation needed — prompt body is loaded at runtime.

## Verification

After merge, trigger each workflow and verify the failure issues stop recurring.

Fixes #130 #131 #133 #134 #135 #146