### PR TITLE
feat(fmt): step 5 — format all compiler sources, CI enforcement, documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,9 @@ name: CI (PR)
 
 env:
   # Pinned seed used for self-host bootstrap in CI.
-  # 0.5.2-alpha.1: Phase 1 accumulator sweep (in-place extend_string_lines,
-  # .concat([x]) → push([x])); includes 220c8b7 aliasing revert for
-  # concat_native_functions / append_local_binding.
-  SEED_VERSION: 0.5.2-alpha.1
+  # 0.5.3-alpha.1: Step-5 formatter changes (unary ops, optional suffix,
+  # declaration inlining guard, import specifier sorting).
+  SEED_VERSION: 0.5.3-alpha.1
 
 permissions:
   contents: read
@@ -82,6 +81,25 @@ jobs:
           ls -lh build/native/sailfin
           (file build/native/sailfin || true)
           build/native/sailfin version || build/native/sailfin --version || true
+
+      - name: Check formatting (sfn fmt --check)
+        shell: bash {0}
+        run: |
+          set -euo pipefail
+          fail=0
+          # Per-file loop to avoid OOM on bulk --check
+          while IFS= read -r f; do
+            if ! build/native/sailfin fmt --check "$f" > /dev/null 2>&1; then
+              echo "[fmt] needs formatting: $f"
+              fail=$((fail + 1))
+            fi
+          done < <(find compiler/src runtime -name '*.sfn' -print | sort)
+          if [ "$fail" -gt 0 ]; then
+            echo ""
+            echo "[fmt] $fail file(s) need formatting. Run: sfn fmt --write compiler/src/"
+            exit 1
+          fi
+          echo "[fmt] all files formatted"
 
       - name: Enable test runner trace (macOS)
         if: runner.os == 'macOS'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
           done < <(find compiler/src runtime -name '*.sfn' -print | sort)
           if [ "$fail" -gt 0 ]; then
             echo ""
-            echo "[fmt] $fail file(s) need formatting. Run: sfn fmt --write compiler/src/"
+            echo "[fmt] $fail file(s) need formatting. Run: sfn fmt --write compiler/src/ runtime/"
             exit 1
           fi
           echo "[fmt] all files formatted"

--- a/compiler/src/ast.sfn
+++ b/compiler/src/ast.sfn
@@ -52,7 +52,7 @@ enum Expression {
         return_type: TypeAnnotation?
     },
     Range { start: Expression, end: Expression },
-    Raw { text: string },
+    Raw { text: string }
 }
 
 struct Parameter {
@@ -323,5 +323,5 @@ enum Statement {
     Unknown {
         tokens: Token[];
         text: string;
-    },
+    }
 }

--- a/compiler/src/ast.sfn
+++ b/compiler/src/ast.sfn
@@ -3,7 +3,6 @@
 // Shared abstract syntax tree definitions for the Sailfin self-hosting effort.
 // The structures mirror a pragmatic subset of the bootstrap compiler AST so we
 // can progressively port parsing and analysis logic into Sailfin.
-
 import { Token } from "./token";
 
 struct Program {
@@ -47,7 +46,11 @@ enum Expression {
     Array { elements: Expression[] },
     Object { fields: ObjectField[] },
     Struct { type_name: string[], fields: ObjectField[] },
-    Lambda { parameters: Parameter[], body: Block, return_type: TypeAnnotation? },
+    Lambda {
+        parameters: Parameter[],
+        body: Block,
+        return_type: TypeAnnotation?
+    },
     Range { start: Expression, end: Expression },
     Raw { text: string },
 }
@@ -162,9 +165,7 @@ fn decorator_names(decorators: Decorator[]) -> string[] {
     let mut names: string[] = [];
     let mut index: number = 0;
     loop {
-        if index >= decorators.length {
-            break;
-        }
+        if index >= decorators.length { break; }
         names.push(decorators[index].name);
         index += 1;
     }

--- a/compiler/src/cli_commands.sfn
+++ b/compiler/src/cli_commands.sfn
@@ -31,18 +31,14 @@ import {
     _toml_trim_cmd,
     _word_matches_cmd,
     _write_text_cmd,
-    find_char,
+    find_char
 } from "./cli_commands_utils";
-import {
-    lock_add_entry,
-    lock_get_version,
-    lock_get_versions,
-} from "./lock";
+import { lock_add_entry, lock_get_version, lock_get_versions } from "./lock";
 import {
     compile_tests_to_llvm_file_with_module,
     compile_to_llvm_file_with_module,
     module_name_from_path,
-    number_to_string,
+    number_to_string
 } from "./main";
 import { substring } from "./string_utils";
 import {
@@ -51,7 +47,7 @@ import {
     toml_generate,
     toml_get_dependencies,
     toml_get_name,
-    toml_get_version,
+    toml_get_version
 } from "./toml_parser";
 import { format_source } from "./tools/fmt";
 
@@ -437,7 +433,8 @@ fn _resolve_cached_capsule_path_cmd(spec: string, deps: string) -> string ![io] 
     // Build cache path: ~/.sfn/cache/capsules/{scope}/{name}/{version}/src/mod.sfn
     let home = _get_home_cmd();
     if home.length == 0 { return ""; }
-    return home + "/.sfn/cache/capsules/" + scope + "/" + name + "/" + version + "/src/mod.sfn";
+    return home + "/.sfn/cache/capsules/" + scope + "/" + name + "/" + version
+        + "/src/mod.sfn";
 }
 
 fn _inline_relative_imports_cmd(source: string, base_dir: string, depth: number, visited: string[]) -> string ![io] {
@@ -530,7 +527,10 @@ fn _inline_relative_imports_cmd(source: string, base_dir: string, depth: number,
                         // Not in lockfile — fall back to capsule.toml and warn
                         cached_path = _resolve_cached_capsule_path_cmd(spec, project_deps);
                         if cached_path.length > 0 {
-                            print.err("warning: dependency \"" + spec + "\" is not in capsule.lock — run `sfn add " + spec + "` to lock it");
+                            print.err("warning: dependency \"" + spec
+                                + "\" is not in capsule.lock — run `sfn add "
+                                + spec
+                                + "` to lock it");
                         }
                     }
                 } else {
@@ -549,7 +549,10 @@ fn _inline_relative_imports_cmd(source: string, base_dir: string, depth: number,
                 if !_has_prefix_cmd(spec, "./") {
                     if !_has_prefix_cmd(spec, "../") {
                         if !_has_prefix_cmd(spec, "runtime/") {
-                            print.err("error: dependency \"" + spec + "\" is not declared in capsule.toml — run `sfn add " + spec + "` first");
+                            print.err("error: dependency \"" + spec
+                                + "\" is not declared in capsule.toml — run `sfn add "
+                                + spec
+                                + "` first");
                             return "";
                         }
                     }
@@ -563,12 +566,18 @@ fn _inline_relative_imports_cmd(source: string, base_dir: string, depth: number,
             if !_string_list_contains_cmd(next_visited, dep_path) {
                 if !fs.exists(dep_path) {
                     // Directory import fallback: ./dir -> dir/mod.sfn
-                    let mod_fallback = substring(dep_path, 0, dep_path.length - 4) + "/mod.sfn";
+                    let mod_fallback = substring(dep_path, 0, dep_path.length - 4)
+                        + "/mod.sfn";
                     if fs.exists(mod_fallback) { dep_path = mod_fallback; } else {
                         if is_capsule_import {
-                            print.err("error: cached capsule not found: " + dep_path + " — run `sfn add " + spec + "` to download it");
+                            print.err("error: cached capsule not found: "
+                                + dep_path
+                                + " — run `sfn add "
+                                + spec
+                                + "` to download it");
                         } else {
-                            print.err("import inlining: missing dependency: " + dep_path);
+                            print.err("import inlining: missing dependency: "
+                                + dep_path);
                         }
                         index += 1;
                         continue;
@@ -630,7 +639,9 @@ fn _clang_link_test_cmd(ll_path: string, out_path: string, runtime_root: string)
         let globals_ll = runtime_root + "/native/ir/runtime_globals.ll";
         if fs.exists(globals_ll) { args.push(globals_ll); }
         // Link prelude object — check known locations
-        let prelude_paths: string[] = ["build/selfhost/native/obj/runtime/prelude.o", "build/native/obj/runtime/prelude.o", "build/native/obj/prelude.o", runtime_root + "/native/obj/runtime/prelude.o", runtime_root + "/native/obj/prelude.o",];
+        let prelude_paths: string[] = ["build/selfhost/native/obj/runtime/prelude.o", "build/native/obj/runtime/prelude.o", "build/native/obj/prelude.o", runtime_root
+            + "/native/obj/runtime/prelude.o", runtime_root
+            + "/native/obj/prelude.o",];
         let mut pi: number = 0;
         loop {
             if pi >= prelude_paths.length { break; }
@@ -704,7 +715,9 @@ fn handle_test_command(args: string[], runtime_root: string) -> number ![io] {
             if trace_runner { print.err("test runner: inlining start"); }
             combined_source = _inline_relative_imports_cmd(source, base_dir, 10, []);
             if trace_runner {
-                print.err("test runner: inlining done (bytes=" + number_to_string(combined_source.length) + ")");
+                print.err("test runner: inlining done (bytes="
+                    + number_to_string(combined_source.length)
+                    + ")");
             }
         }
 
@@ -731,7 +744,8 @@ fn handle_test_command(args: string[], runtime_root: string) -> number ![io] {
         if trace_runner { print.err("test runner: exec start"); }
         let run_rc = process.run([exe_path]);
         if trace_runner {
-            print.err("test runner: exec done (exit=" + number_to_string(run_rc) + ")");
+            print.err("test runner: exec done (exit=" + number_to_string(run_rc)
+                + ")");
         }
         if run_rc != 0 {
             print("test failed: " + path);
@@ -835,7 +849,20 @@ fn handle_publish_command(args: string[]) -> number ![io] {
         process.run(["rm", "-f", payload_tmp]);
         return 1;
     }
-    let build_json_rc = process.run(["sh", "-c", "printf '{\"type\":\"capsule\",\"capsule\":\"" + pkg_name + "\",\"version\":\"" + pkg_version + "\",\"digest\":\"" + digest + "\",\"content_b64\":\"' > " + body_tmp + " && base64 < '" + payload_tmp + "' | tr -d '\\n' >> " + body_tmp + " && printf '\",\"meta\":{}}' >> " + body_tmp]);
+    let build_json_rc = process.run(["sh", "-c", "printf '{\"type\":\"capsule\",\"capsule\":\""
+        + pkg_name
+        + "\",\"version\":\""
+        + pkg_version
+        + "\",\"digest\":\""
+        + digest
+        + "\",\"content_b64\":\"' > "
+        + body_tmp
+        + " && base64 < '"
+        + payload_tmp
+        + "' | tr -d '\\n' >> "
+        + body_tmp
+        + " && printf '\",\"meta\":{}}' >> "
+        + body_tmp]);
     if build_json_rc != 0 {
         print("failed to build publish payload");
         process.run(["rm", "-f", payload_tmp]);
@@ -848,7 +875,9 @@ fn handle_publish_command(args: string[]) -> number ![io] {
     print("publishing to " + registry_url + "...");
     let response_tmp = _shell_read_cmd("mktemp /tmp/.sfn_pub_XXXXXX");
     let header_tmp = _shell_read_cmd("mktemp /tmp/.sfn_pub_XXXXXX");
-    let curl_rc = process.run(["curl", "-sS", "-X", "POST", "-H", "Content-Type: application/json", "-H", "Authorization: " + auth_header, "-d", "@" + body_tmp, "-o", response_tmp, "-D", header_tmp, registry_url]);
+    let curl_rc = process.run(["curl", "-sS", "-X", "POST", "-H", "Content-Type: application/json", "-H", "Authorization: "
+        + auth_header, "-d", "@"
+        + body_tmp, "-o", response_tmp, "-D", header_tmp, registry_url]);
     process.run(["rm", "-f", payload_tmp]);
     process.run(["rm", "-f", body_tmp]);
     let mut response: string = "";
@@ -933,7 +962,10 @@ fn handle_add_command(args: string[]) -> number ![io] {
         print("using locked version: " + display_name + "@" + resolved_version);
     } else {
         print("fetching registry index...");
-        resolved_version = _shell_read_cmd("curl -sfS 'https://registry.sailfin.dev/api/index.json'" + " | python3 -c \"import json,sys; d=json.load(sys.stdin); c=d.get('capsules',{}).get('" + registry_name + "',{}); print(c.get('latest',''))\" 2>/dev/null");
+        resolved_version = _shell_read_cmd("curl -sfS 'https://registry.sailfin.dev/api/index.json'"
+            + " | python3 -c \"import json,sys; d=json.load(sys.stdin); c=d.get('capsules',{}).get('"
+            + registry_name
+            + "',{}); print(c.get('latest',''))\" 2>/dev/null");
         if resolved_version.length == 0 {
             print("capsule not found in registry: " + registry_name);
             return 1;
@@ -942,7 +974,8 @@ fn handle_add_command(args: string[]) -> number ![io] {
 
     let slash_pos = find_char(registry_name, "/", 0);
     if slash_pos < 0 {
-        print("invalid capsule id — expected scope/name format: " + registry_name);
+        print("invalid capsule id — expected scope/name format: "
+            + registry_name);
         return 1;
     }
     let scope = substring(registry_name, 0, slash_pos);
@@ -967,16 +1000,23 @@ fn handle_add_command(args: string[]) -> number ![io] {
         print("could not determine home directory");
         return 1;
     }
-    let cache_base = home + "/.sfn/cache/capsules/" + scope + "/" + name + "/" + resolved_version;
+    let cache_base = home + "/.sfn/cache/capsules/" + scope + "/" + name + "/"
+        + resolved_version;
     _ensure_dir_recursive_cmd(home + "/.sfn");
     _ensure_dir_recursive_cmd(home + "/.sfn/cache");
     _ensure_dir_recursive_cmd(home + "/.sfn/cache/capsules");
     _ensure_dir_recursive_cmd(home + "/.sfn/cache/capsules/" + scope);
-    _ensure_dir_recursive_cmd(home + "/.sfn/cache/capsules/" + scope + "/" + name);
+    _ensure_dir_recursive_cmd(home + "/.sfn/cache/capsules/" + scope + "/"
+        + name);
     _ensure_dir_recursive_cmd(cache_base);
 
     let pkg_path = cache_base + "/" + resolved_version + ".sfnpkg";
-    let download_url = "https://registry.sailfin.dev/api/capsules/" + scope + "/" + name + "/" + resolved_version + ".sfnpkg";
+    let download_url = "https://registry.sailfin.dev/api/capsules/" + scope
+        + "/"
+        + name
+        + "/"
+        + resolved_version
+        + ".sfnpkg";
     print("downloading " + display_name + "@" + resolved_version + "...");
     let dl_rc = _curl_download_cmd(download_url, pkg_path);
     if dl_rc != 0 {
@@ -999,7 +1039,8 @@ fn handle_add_command(args: string[]) -> number ![io] {
     // Compute integrity hash of the downloaded package and write capsule.lock
     let raw_hash = _sha256_of_file_cmd(pkg_path);
     if raw_hash.length == 0 {
-        print("warning: could not compute integrity hash for " + pkg_path + " — lockfile entry will have no hash");
+        print("warning: could not compute integrity hash for " + pkg_path
+            + " — lockfile entry will have no hash");
     }
     let mut pkg_hash: string = "";
     if raw_hash.length > 0 { pkg_hash = "sha256:" + raw_hash; }

--- a/compiler/src/cli_commands.sfn
+++ b/compiler/src/cli_commands.sfn
@@ -2,60 +2,58 @@
 //
 // CLI command handlers extracted from cli_main.sfn to keep
 // sailfin_cli_main under ~500 .sfn-asm instructions (avoids seed OOM).
-
 import {
-    compile_to_llvm_file_with_module,
-    compile_tests_to_llvm_file_with_module,
-    number_to_string,
-    module_name_from_path,
-} from "./main";
-import {
-    toml_get_name,
-    toml_get_version,
-    toml_get_dependencies,
-    toml_generate,
-    toml_add_dependency,
-    toml_add_dev_dependency,
-} from "./toml_parser";
-import {
-    lock_get_versions,
-    lock_get_version,
-    lock_add_entry,
-} from "./lock";
-import { substring } from "./string_utils";
-import { format_source } from "./tools/fmt";
-
-import {
-    _ends_with_cmd,
+    _byte_at_cmd,
+    _collect_sfn_files_cmd,
+    _collect_test_files_cmd,
+    _curl_download_cmd,
+    _curl_post_json_cmd,
     _dirname_cmd,
-    find_char,
-    _toml_trim_cmd,
-    _shell_read_cmd,
-    _get_env_cmd,
-    _get_home_cmd,
+    _display_capsule_name_cmd,
+    _ends_with_cmd,
     _ensure_dir_cmd,
     _ensure_dir_recursive_cmd,
-    _sanitize_filename_cmd,
-    _write_text_cmd,
-    _looks_like_test_file_cmd,
-    _collect_test_files_cmd,
-    _collect_sfn_files_cmd,
-    _curl_post_json_cmd,
-    _curl_download_cmd,
-    _sha256_of_file_cmd,
     _extract_sfnpkg_cmd,
-    _is_stdlib_capsule_cmd,
-    _has_slash_cmd,
-    _resolve_capsule_name_cmd,
-    _display_capsule_name_cmd,
+    _get_env_cmd,
+    _get_home_cmd,
     _has_prefix_cmd,
-    _path_join_cmd,
-    _string_contains_cmd,
+    _has_slash_cmd,
     _is_ident_char_cmd,
-    _byte_at_cmd,
-    _word_matches_cmd,
+    _is_stdlib_capsule_cmd,
+    _looks_like_test_file_cmd,
+    _path_join_cmd,
+    _resolve_capsule_name_cmd,
+    _sanitize_filename_cmd,
+    _sha256_of_file_cmd,
+    _shell_read_cmd,
+    _string_contains_cmd,
     _string_list_contains_cmd,
+    _toml_trim_cmd,
+    _word_matches_cmd,
+    _write_text_cmd,
+    find_char,
 } from "./cli_commands_utils";
+import {
+    lock_add_entry,
+    lock_get_version,
+    lock_get_versions,
+} from "./lock";
+import {
+    compile_tests_to_llvm_file_with_module,
+    compile_to_llvm_file_with_module,
+    module_name_from_path,
+    number_to_string,
+} from "./main";
+import { substring } from "./string_utils";
+import {
+    toml_add_dependency,
+    toml_add_dev_dependency,
+    toml_generate,
+    toml_get_dependencies,
+    toml_get_name,
+    toml_get_version,
+} from "./toml_parser";
+import { format_source } from "./tools/fmt";
 
 struct _RelativeImportSpanCmd {
     start: number;
@@ -99,20 +97,44 @@ fn _collect_relative_import_spans_cmd(source: string) -> _RelativeImportSpanCmd[
             continue;
         }
         if in_string {
-            if escaping { escaping = false; i += 1; continue; }
-            if ch == "\\" { escaping = true; i += 1; continue; }
-            if ch == "\"" { in_string = false; i += 1; continue; }
+            if escaping {
+                escaping = false;
+                i += 1;
+                continue;
+            }
+            if ch == "\\" {
+                escaping = true;
+                i += 1;
+                continue;
+            }
+            if ch == "\"" {
+                in_string = false;
+                i += 1;
+                continue;
+            }
             i += 1;
             continue;
         }
         if ch == "/" {
             if i + 1 < source_len {
                 let next = _byte_at_cmd(source, i + 1);
-                if next == "/" { in_line_comment = true; i += 2; continue; }
-                if next == "*" { in_block_comment = true; i += 2; continue; }
+                if next == "/" {
+                    in_line_comment = true;
+                    i += 2;
+                    continue;
+                }
+                if next == "*" {
+                    in_block_comment = true;
+                    i += 2;
+                    continue;
+                }
             }
         }
-        if ch == "\"" { in_string = true; i += 1; continue; }
+        if ch == "\"" {
+            in_string = true;
+            i += 1;
+            continue;
+        }
 
         if _word_matches_cmd(source, i, "import") {
             let stmt_start = i;
@@ -131,33 +153,61 @@ fn _collect_relative_import_spans_cmd(source: string) -> _RelativeImportSpanCmd[
                 let cj = _byte_at_cmd(source, j);
                 if s_in_line_comment {
                     if cj == "\n" { s_in_line_comment = false; }
-                    j += 1; continue;
+                    j += 1;
+                    continue;
                 }
                 if s_in_block_comment {
                     if cj == "*" {
                         if j + 1 < source_len {
                             if _byte_at_cmd(source, j + 1) == "/" {
                                 s_in_block_comment = false;
-                                j += 2; continue;
+                                j += 2;
+                                continue;
                             }
                         }
                     }
-                    j += 1; continue;
+                    j += 1;
+                    continue;
                 }
                 if s_in_string {
-                    if s_escaping { s_escaping = false; j += 1; continue; }
-                    if cj == "\\" { s_escaping = true; j += 1; continue; }
-                    if cj == "\"" { s_in_string = false; j += 1; continue; }
-                    j += 1; continue;
+                    if s_escaping {
+                        s_escaping = false;
+                        j += 1;
+                        continue;
+                    }
+                    if cj == "\\" {
+                        s_escaping = true;
+                        j += 1;
+                        continue;
+                    }
+                    if cj == "\"" {
+                        s_in_string = false;
+                        j += 1;
+                        continue;
+                    }
+                    j += 1;
+                    continue;
                 }
                 if cj == "/" {
                     if j + 1 < source_len {
                         let nj = _byte_at_cmd(source, j + 1);
-                        if nj == "/" { s_in_line_comment = true; j += 2; continue; }
-                        if nj == "*" { s_in_block_comment = true; j += 2; continue; }
+                        if nj == "/" {
+                            s_in_line_comment = true;
+                            j += 2;
+                            continue;
+                        }
+                        if nj == "*" {
+                            s_in_block_comment = true;
+                            j += 2;
+                            continue;
+                        }
                     }
                 }
-                if cj == "\"" { s_in_string = true; j += 1; continue; }
+                if cj == "\"" {
+                    s_in_string = true;
+                    j += 1;
+                    continue;
+                }
                 if spec.length == 0 {
                     if _word_matches_cmd(source, j, "from") {
                         let mut k = j + 4;
@@ -169,7 +219,10 @@ fn _collect_relative_import_spans_cmd(source: string) -> _RelativeImportSpanCmd[
                             if wk == "\t" { ws = true; }
                             if wk == "\n" { ws = true; }
                             if wk == "\r" { ws = true; }
-                            if ws { k += 1; continue; }
+                            if ws {
+                                k += 1;
+                                continue;
+                            }
                             break;
                         }
                         if k < source_len {
@@ -180,8 +233,16 @@ fn _collect_relative_import_spans_cmd(source: string) -> _RelativeImportSpanCmd[
                                 loop {
                                     if k >= source_len { break; }
                                     let sk = _byte_at_cmd(source, k);
-                                    if esc { esc = false; k += 1; continue; }
-                                    if sk == "\\" { esc = true; k += 1; continue; }
+                                    if esc {
+                                        esc = false;
+                                        k += 1;
+                                        continue;
+                                    }
+                                    if sk == "\\" {
+                                        esc = true;
+                                        k += 1;
+                                        continue;
+                                    }
                                     if sk == "\"" {
                                         spec = substring(source, start, k);
                                         break;
@@ -192,7 +253,10 @@ fn _collect_relative_import_spans_cmd(source: string) -> _RelativeImportSpanCmd[
                         }
                     }
                 }
-                if cj == ";" { stmt_end = j + 1; break; }
+                if cj == ";" {
+                    stmt_end = j + 1;
+                    break;
+                }
                 j += 1;
             }
             if stmt_end > 0 {
@@ -201,7 +265,9 @@ fn _collect_relative_import_spans_cmd(source: string) -> _RelativeImportSpanCmd[
                     if _has_prefix_cmd(spec, "./") { is_relative = true; }
                     if _has_prefix_cmd(spec, "../") { is_relative = true; }
                     if is_relative {
-                        spans.push(_RelativeImportSpanCmd { start: stmt_start, end: stmt_end, spec: spec });
+                        spans.push(_RelativeImportSpanCmd {
+                            start: stmt_start, end: stmt_end, spec: spec
+                        });
                     } else {
                         // Check for capsule imports: bare name ("test") or scoped ("sfn/test")
                         let mut is_capsule: boolean = false;
@@ -209,11 +275,15 @@ fn _collect_relative_import_spans_cmd(source: string) -> _RelativeImportSpanCmd[
                         if !is_capsule {
                             if _has_prefix_cmd(spec, "sfn/") {
                                 let capsule_suffix = substring(spec, 4, spec.length);
-                                if _is_stdlib_capsule_cmd(capsule_suffix) { is_capsule = true; }
+                                if _is_stdlib_capsule_cmd(capsule_suffix) {
+                                    is_capsule = true;
+                                }
                             }
                         }
                         if is_capsule {
-                            spans.push(_RelativeImportSpanCmd { start: stmt_start, end: stmt_end, spec: spec });
+                            spans.push(_RelativeImportSpanCmd {
+                                start: stmt_start, end: stmt_end, spec: spec
+                            });
                         } else {
                             // Non-stdlib scoped import (e.g. "sfn/cli", "acme/router") —
                             // may be a cached capsule dependency declared in capsule.toml.
@@ -221,14 +291,19 @@ fn _collect_relative_import_spans_cmd(source: string) -> _RelativeImportSpanCmd[
                             // separately by the linker.
                             if _has_slash_cmd(spec) {
                                 if !_has_prefix_cmd(spec, "runtime/") {
-                                    spans.push(_RelativeImportSpanCmd { start: stmt_start, end: stmt_end, spec: spec });
+                                    spans.push(_RelativeImportSpanCmd {
+                                        start: stmt_start, end: stmt_end, spec: spec
+                                    });
                                 }
                             }
                         }
                     }
                 }
             }
-            if stmt_end > 0 { i = stmt_end; continue; }
+            if stmt_end > 0 {
+                i = stmt_end;
+                continue;
+            }
         }
         i += 1;
     }
@@ -366,9 +441,7 @@ fn _resolve_cached_capsule_path_cmd(spec: string, deps: string) -> string ![io] 
 }
 
 fn _inline_relative_imports_cmd(source: string, base_dir: string, depth: number, visited: string[]) -> string ![io] {
-    if depth <= 0 {
-        return _strip_relative_import_lines_cmd(source);
-    }
+    if depth <= 0 { return _strip_relative_import_lines_cmd(source); }
     let spans = _collect_relative_import_spans_cmd(source);
     let mut combined: string = "";
     let mut next_visited = visited;
@@ -491,9 +564,7 @@ fn _inline_relative_imports_cmd(source: string, base_dir: string, depth: number,
                 if !fs.exists(dep_path) {
                     // Directory import fallback: ./dir -> dir/mod.sfn
                     let mod_fallback = substring(dep_path, 0, dep_path.length - 4) + "/mod.sfn";
-                    if fs.exists(mod_fallback) {
-                        dep_path = mod_fallback;
-                    } else {
+                    if fs.exists(mod_fallback) { dep_path = mod_fallback; } else {
                         if is_capsule_import {
                             print.err("error: cached capsule not found: " + dep_path + " — run `sfn add " + spec + "` to download it");
                         } else {
@@ -542,9 +613,7 @@ fn _clang_link_test_cmd(ll_path: string, out_path: string, runtime_root: string)
         let src_dir = runtime_root + "/native/src";
         let include_dir = runtime_root + "/native/include";
         if fs.exists(src_dir) {
-            if fs.exists(include_dir) {
-                args.push("-I" + include_dir);
-            }
+            if fs.exists(include_dir) { args.push("-I" + include_dir); }
             let entries = fs.listDirectory(src_dir);
             let mut i: number = 0;
             loop {
@@ -559,17 +628,9 @@ fn _clang_link_test_cmd(ll_path: string, out_path: string, runtime_root: string)
         }
         // Link runtime globals (IR)
         let globals_ll = runtime_root + "/native/ir/runtime_globals.ll";
-        if fs.exists(globals_ll) {
-            args.push(globals_ll);
-        }
+        if fs.exists(globals_ll) { args.push(globals_ll); }
         // Link prelude object — check known locations
-        let prelude_paths: string[] = [
-            "build/selfhost/native/obj/runtime/prelude.o",
-            "build/native/obj/runtime/prelude.o",
-            "build/native/obj/prelude.o",
-            runtime_root + "/native/obj/runtime/prelude.o",
-            runtime_root + "/native/obj/prelude.o",
-        ];
+        let prelude_paths: string[] = ["build/selfhost/native/obj/runtime/prelude.o", "build/native/obj/runtime/prelude.o", "build/native/obj/prelude.o", runtime_root + "/native/obj/runtime/prelude.o", runtime_root + "/native/obj/prelude.o",];
         let mut pi: number = 0;
         loop {
             if pi >= prelude_paths.length { break; }
@@ -590,9 +651,7 @@ fn _clang_link_test_cmd(ll_path: string, out_path: string, runtime_root: string)
         process.run(["llvm-objcopy", "--weaken", weak_path]);
         args.push(weak_path);
         let shim_path = "build/selfhost/native/obj/cross_module_shim.o";
-        if fs.exists(shim_path) {
-            args.push(shim_path);
-        }
+        if fs.exists(shim_path) { args.push(shim_path); }
     }
     args.push("-lm");
     args.push("-pthread");
@@ -600,12 +659,9 @@ fn _clang_link_test_cmd(ll_path: string, out_path: string, runtime_root: string)
 }
 
 // ---- Exported command handlers ----
-
 fn handle_test_command(args: string[], runtime_root: string) -> number ![io] {
     let mut root: string = ".";
-    if args.length == 2 {
-        root = args[1];
-    } else if args.length != 1 {
+    if args.length == 2 { root = args[1]; } else if args.length != 1 {
         print("usage: sfn test [path]");
         return 2;
     }
@@ -641,11 +697,15 @@ fn handle_test_command(args: string[], runtime_root: string) -> number ![io] {
         let base_dir = _dirname_cmd(path);
         let mut combined_source = source;
         if skip_inlining {
-            if trace_runner { print.err("test runner: skipping import inlining"); }
+            if trace_runner {
+                print.err("test runner: skipping import inlining");
+            }
         } else {
             if trace_runner { print.err("test runner: inlining start"); }
             combined_source = _inline_relative_imports_cmd(source, base_dir, 10, []);
-            if trace_runner { print.err("test runner: inlining done (bytes=" + number_to_string(combined_source.length) + ")"); }
+            if trace_runner {
+                print.err("test runner: inlining done (bytes=" + number_to_string(combined_source.length) + ")");
+            }
         }
 
         if dump_sources {
@@ -670,7 +730,9 @@ fn handle_test_command(args: string[], runtime_root: string) -> number ![io] {
         }
         if trace_runner { print.err("test runner: exec start"); }
         let run_rc = process.run([exe_path]);
-        if trace_runner { print.err("test runner: exec done (exit=" + number_to_string(run_rc) + ")"); }
+        if trace_runner {
+            print.err("test runner: exec done (exit=" + number_to_string(run_rc) + ")");
+        }
         if run_rc != 0 {
             print("test failed: " + path);
             fs.deleteFile(test_runner_active_path);
@@ -720,9 +782,7 @@ fn handle_publish_command(args: string[]) -> number ![io] {
 
     let mut token: string = "";
     let env_token = _get_env_cmd("SFN_TOKEN");
-    if env_token.length > 0 {
-        token = env_token;
-    } else {
+    if env_token.length > 0 { token = env_token; } else {
         let home = _get_home_cmd();
         if home.length > 0 {
             let cred_path = home + "/.sfn/credentials";
@@ -775,14 +835,7 @@ fn handle_publish_command(args: string[]) -> number ![io] {
         process.run(["rm", "-f", payload_tmp]);
         return 1;
     }
-    let build_json_rc = process.run(["sh", "-c",
-            "printf '{\"type\":\"capsule\",\"capsule\":\"" + pkg_name
-            + "\",\"version\":\"" + pkg_version
-            + "\",\"digest\":\"" + digest
-            + "\",\"content_b64\":\"' > " + body_tmp
-            + " && base64 < '" + payload_tmp + "' | tr -d '\\n' >> " + body_tmp
-            + " && printf '\",\"meta\":{}}' >> " + body_tmp
-    ]);
+    let build_json_rc = process.run(["sh", "-c", "printf '{\"type\":\"capsule\",\"capsule\":\"" + pkg_name + "\",\"version\":\"" + pkg_version + "\",\"digest\":\"" + digest + "\",\"content_b64\":\"' > " + body_tmp + " && base64 < '" + payload_tmp + "' | tr -d '\\n' >> " + body_tmp + " && printf '\",\"meta\":{}}' >> " + body_tmp]);
     if build_json_rc != 0 {
         print("failed to build publish payload");
         process.run(["rm", "-f", payload_tmp]);
@@ -795,14 +848,7 @@ fn handle_publish_command(args: string[]) -> number ![io] {
     print("publishing to " + registry_url + "...");
     let response_tmp = _shell_read_cmd("mktemp /tmp/.sfn_pub_XXXXXX");
     let header_tmp = _shell_read_cmd("mktemp /tmp/.sfn_pub_XXXXXX");
-    let curl_rc = process.run(["curl", "-sS", "-X", "POST",
-            "-H", "Content-Type: application/json",
-            "-H", "Authorization: " + auth_header,
-            "-d", "@" + body_tmp,
-            "-o", response_tmp,
-            "-D", header_tmp,
-            registry_url
-    ]);
+    let curl_rc = process.run(["curl", "-sS", "-X", "POST", "-H", "Content-Type: application/json", "-H", "Authorization: " + auth_header, "-d", "@" + body_tmp, "-o", response_tmp, "-D", header_tmp, registry_url]);
     process.run(["rm", "-f", payload_tmp]);
     process.run(["rm", "-f", body_tmp]);
     let mut response: string = "";
@@ -845,9 +891,7 @@ fn handle_add_command(args: string[]) -> number ![io] {
     let mut argi: number = 1;
     loop {
         if argi >= args.length { break; }
-        if strings_equal(args[argi], "--dev") {
-            is_dev = true;
-        } else if strings_equal(args[argi], "--update") {
+        if strings_equal(args[argi], "--dev") { is_dev = true; } else if strings_equal(args[argi], "--update") {
             is_update = true;
         } else {
             if capsule_arg.length > 0 {
@@ -879,9 +923,7 @@ fn handle_add_command(args: string[]) -> number ![io] {
         if fs.exists("capsule.lock") {
             let lock_text = fs.readFile("capsule.lock");
             locked_version = lock_get_version(lock_text, display_name);
-            if locked_version.length > 0 {
-                use_locked = true;
-            }
+            if locked_version.length > 0 { use_locked = true; }
         }
     }
 
@@ -891,10 +933,7 @@ fn handle_add_command(args: string[]) -> number ![io] {
         print("using locked version: " + display_name + "@" + resolved_version);
     } else {
         print("fetching registry index...");
-        resolved_version = _shell_read_cmd(
-            "curl -sfS 'https://registry.sailfin.dev/api/index.json'"
-            + " | python3 -c \"import json,sys; d=json.load(sys.stdin); c=d.get('capsules',{}).get('" + registry_name + "',{}); print(c.get('latest',''))\" 2>/dev/null"
-        );
+        resolved_version = _shell_read_cmd("curl -sfS 'https://registry.sailfin.dev/api/index.json'" + " | python3 -c \"import json,sys; d=json.load(sys.stdin); c=d.get('capsules',{}).get('" + registry_name + "',{}); print(c.get('latest',''))\" 2>/dev/null");
         if resolved_version.length == 0 {
             print("capsule not found in registry: " + registry_name);
             return 1;
@@ -963,9 +1002,7 @@ fn handle_add_command(args: string[]) -> number ![io] {
         print("warning: could not compute integrity hash for " + pkg_path + " — lockfile entry will have no hash");
     }
     let mut pkg_hash: string = "";
-    if raw_hash.length > 0 {
-        pkg_hash = "sha256:" + raw_hash;
-    }
+    if raw_hash.length > 0 { pkg_hash = "sha256:" + raw_hash; }
     let mut existing_lock: string = "";
     if fs.exists("capsule.lock") {
         existing_lock = fs.readFile("capsule.lock");
@@ -975,12 +1012,8 @@ fn handle_add_command(args: string[]) -> number ![io] {
 
     if is_dev {
         print("added dev dependency: " + display_name + "@" + resolved_version);
-    } else {
-        print("added " + display_name + "@" + resolved_version);
-    }
-    if is_update {
-        print("lock entry updated for " + display_name);
-    }
+    } else { print("added " + display_name + "@" + resolved_version); }
+    if is_update { print("lock entry updated for " + display_name); }
     return 0;
 }
 
@@ -1000,9 +1033,7 @@ fn handle_init_command(args: string[]) -> number ![io] {
         let mut si: number = 0;
         loop {
             if si >= cwd.length { break; }
-            if substring(cwd, si, si + 1) == "/" {
-                last_slash = si;
-            }
+            if substring(cwd, si, si + 1) == "/" { last_slash = si; }
             si += 1;
         }
         if last_slash >= 0 {
@@ -1013,9 +1044,7 @@ fn handle_init_command(args: string[]) -> number ![io] {
     }
     let toml_text = toml_generate(pkg_name, "0.1.0", "", "src/main.sfn");
     fs.writeFile("capsule.toml", toml_text);
-    if !fs.exists("src") {
-        fs.createDirectory("src", true);
-    }
+    if !fs.exists("src") { fs.createDirectory("src", true); }
     if !fs.exists("src/main.sfn") {
         fs.writeFile("src/main.sfn", "fn main() ![io] {\n    print(\"Hello, Sailfin!\");\n}\n");
     }
@@ -1030,9 +1059,7 @@ fn handle_login_command(args: string[]) -> number ![io] {
     }
 
     let mut token: string = "";
-    if args.length == 2 {
-        token = _toml_trim_cmd(args[1]);
-    } else {
+    if args.length == 2 { token = _toml_trim_cmd(args[1]); } else {
         print("enter your registry token:");
         let tmp = _shell_read_cmd("mktemp /tmp/.sfn_login_XXXXXX");
         if tmp.length == 0 {
@@ -1045,9 +1072,7 @@ fn handle_login_command(args: string[]) -> number ![io] {
             print("error: failed to read token");
             return 1;
         }
-        if fs.exists(tmp) {
-            token = _toml_trim_cmd(fs.readFile(tmp));
-        }
+        if fs.exists(tmp) { token = _toml_trim_cmd(fs.readFile(tmp)); }
         process.run(["rm", "-f", tmp]);
     }
 
@@ -1148,7 +1173,6 @@ fn handle_guillermo_command() -> number ![io] {
 // ═══════════════════════════════════════════════════════════════════
 // sfn fmt — canonical formatter
 // ═══════════════════════════════════════════════════════════════════
-
 fn handle_fmt_command(args: string[]) -> number ![io] {
     let mut check_mode = false;
     let mut write_mode = false;
@@ -1158,13 +1182,9 @@ fn handle_fmt_command(args: string[]) -> number ![io] {
     loop {
         if i >= args.length { break; }
         let arg = args[i];
-        if strings_equal(arg, "--check") {
-            check_mode = true;
-        } else if strings_equal(arg, "--write") {
+        if strings_equal(arg, "--check") { check_mode = true; } else if strings_equal(arg, "--write") {
             write_mode = true;
-        } else {
-            paths.push(arg);
-        }
+        } else { paths.push(arg); }
         i += 1;
     }
 
@@ -1222,18 +1242,14 @@ fn handle_fmt_command(args: string[]) -> number ![io] {
             if formatted.length > 0 {
                 if strings_equal(substring(formatted, formatted.length - 1, formatted.length), "\n") {
                     print(substring(formatted, 0, formatted.length - 1));
-                } else {
-                    print(formatted);
-                }
+                } else { print(formatted); }
             }
         }
         fi += 1;
     }
 
     if check_mode {
-        if would_change > 0 {
-            return 1;
-        }
+        if would_change > 0 { return 1; }
     }
 
     return 0;
@@ -1246,4 +1262,13 @@ fn inline_imports_for_source(source: string, base_dir: string) -> string ![io] {
     return _inline_relative_imports_cmd(source, base_dir, 10, []);
 }
 
-export { handle_test_command, handle_publish_command, handle_add_command, handle_init_command, handle_login_command, handle_guillermo_command, handle_fmt_command, inline_imports_for_source };
+export {
+    handle_test_command,
+    handle_publish_command,
+    handle_add_command,
+    handle_init_command,
+    handle_login_command,
+    handle_guillermo_command,
+    handle_fmt_command,
+    inline_imports_for_source
+};

--- a/compiler/src/cli_commands_utils.sfn
+++ b/compiler/src/cli_commands_utils.sfn
@@ -2,7 +2,6 @@
 //
 // Utility functions for CLI command handlers: path, string, file, and
 // network operations.
-
 import { substring } from "./string_utils";
 
 export {
@@ -49,17 +48,11 @@ fn _dirname_cmd(path: string) -> string {
     let mut i: number = 0;
     loop {
         if i >= path.length { break; }
-        if substring(path, i, i + 1) == "/" {
-            last_slash = i;
-        }
+        if substring(path, i, i + 1) == "/" { last_slash = i; }
         i += 1;
     }
-    if last_slash < 0 {
-        return ".";
-    }
-    if last_slash == 0 {
-        return "/";
-    }
+    if last_slash < 0 { return "."; }
+    if last_slash == 0 { return "/"; }
     return substring(path, 0, last_slash);
 }
 
@@ -67,9 +60,7 @@ fn find_char(text: string, ch: string, start: number) -> number {
     let mut i: number = start;
     loop {
         if i >= text.length { break; }
-        if substring(text, i, i + 1) == ch {
-            return i;
-        }
+        if substring(text, i, i + 1) == ch { return i; }
         i += 1;
     }
     return -1;
@@ -106,12 +97,8 @@ fn _toml_trim_cmd(text: string) -> string {
 fn _shell_read_cmd(cmd: string) -> string ![io] {
     let tmp = "/tmp/.sfn_shell_read_cmd_tmp";
     let rc = process.run(["sh", "-c", cmd + " > " + tmp + " 2>/dev/null"]);
-    if rc != 0 {
-        return "";
-    }
-    if !fs.exists(tmp) {
-        return "";
-    }
+    if rc != 0 { return ""; }
+    if !fs.exists(tmp) { return ""; }
     let raw = fs.readFile(tmp);
     process.run(["rm", "-f", tmp]);
     return _toml_trim_cmd(raw);
@@ -121,20 +108,14 @@ fn _get_env_cmd(name: string) -> string ![io] {
     return _shell_read_cmd("printf '%s' \"$" + name + "\"");
 }
 
-fn _get_home_cmd() -> string ![io] {
-    return _get_env_cmd("HOME");
-}
+fn _get_home_cmd() -> string ![io] { return _get_env_cmd("HOME"); }
 
 fn _ensure_dir_cmd(path: string) ![io] {
-    if !fs.exists(path) {
-        process.run(["mkdir", "-p", path]);
-    }
+    if !fs.exists(path) { process.run(["mkdir", "-p", path]); }
 }
 
 fn _ensure_dir_recursive_cmd(path: string) -> void ![io] {
-    if !fs.exists(path) {
-        process.run(["mkdir", "-p", path]);
-    }
+    if !fs.exists(path) { process.run(["mkdir", "-p", path]); }
 }
 
 fn _sanitize_filename_cmd(value: string) -> string {
@@ -147,11 +128,7 @@ fn _sanitize_filename_cmd(value: string) -> string {
         if ch == "/" { safe = false; }
         if ch == " " { safe = false; }
         if ch == "." { safe = false; }
-        if safe {
-            result = result + ch;
-        } else {
-            result = result + "_";
-        }
+        if safe { result = result + ch; } else { result = result + "_"; }
         i += 1;
     }
     return result;
@@ -167,9 +144,7 @@ fn _looks_like_test_file_cmd(name: string) -> boolean {
 
 fn _collect_test_files_cmd(root: string, max_depth: number) -> string[] ![io] {
     let mut results: string[] = [];
-    if _ends_with_cmd(root, ".sfn") {
-        return [root];
-    }
+    if _ends_with_cmd(root, ".sfn") { return [root]; }
     let mut queue: string[] = [root];
     let mut depth: number = 0;
     loop {
@@ -206,9 +181,7 @@ fn _collect_test_files_cmd(root: string, max_depth: number) -> string[] ![io] {
 
 fn _collect_sfn_files_cmd(root: string, max_depth: number) -> string[] ![io] {
     let mut results: string[] = [];
-    if _ends_with_cmd(root, ".sfn") {
-        return [root];
-    }
+    if _ends_with_cmd(root, ".sfn") { return [root]; }
     let mut queue: string[] = [root];
     let mut depth: number = 0;
     loop {
@@ -219,7 +192,10 @@ fn _collect_sfn_files_cmd(root: string, max_depth: number) -> string[] ![io] {
         loop {
             if qi >= queue.length { break; }
             let dir = queue[qi];
-            if !fs.exists(dir) { qi += 1; continue; }
+            if !fs.exists(dir) {
+                qi += 1;
+                continue;
+            }
             let entries = fs.listDirectory(dir);
             let mut ei: number = 0;
             loop {
@@ -246,13 +222,7 @@ fn _collect_sfn_files_cmd(root: string, max_depth: number) -> string[] ![io] {
 
 fn _curl_post_json_cmd(url: string, body_path: string, auth_header: string) -> string ![io] {
     let tmp = "/tmp/.sfn_curl_response_cmd_tmp";
-    let rc = process.run(["curl", "-sfS", "-X", "POST",
-        "-H", "Content-Type: application/json",
-        "-H", "Authorization: " + auth_header,
-        "-d", "@" + body_path,
-        "-o", tmp,
-        url
-    ]);
+    let rc = process.run(["curl", "-sfS", "-X", "POST", "-H", "Content-Type: application/json", "-H", "Authorization: " + auth_header, "-d", "@" + body_path, "-o", tmp, url]);
     if rc != 0 { return ""; }
     if !fs.exists(tmp) { return ""; }
     let response = fs.readFile(tmp);
@@ -278,7 +248,10 @@ fn _extract_sfnpkg_cmd(content: string, dest_dir: string) -> void ![io] {
         if pos >= content.length { break; }
         let remaining = substring(content, pos, content.length);
         if remaining.length < marker.length { break; }
-        if substring(remaining, 0, marker.length) != marker { pos += 1; continue; }
+        if substring(remaining, 0, marker.length) != marker {
+            pos += 1;
+            continue;
+        }
         let after_marker = substring(remaining, marker.length, remaining.length);
         let nl_idx = find_char(after_marker, "\n", 0);
         if nl_idx < 0 { break; }

--- a/compiler/src/cli_commands_utils.sfn
+++ b/compiler/src/cli_commands_utils.sfn
@@ -33,7 +33,7 @@ export {
     _is_ident_char_cmd,
     _byte_at_cmd,
     _word_matches_cmd,
-    _string_list_contains_cmd,
+    _string_list_contains_cmd
 };
 
 fn _ends_with_cmd(value: string, suffix: string) -> boolean {
@@ -222,7 +222,9 @@ fn _collect_sfn_files_cmd(root: string, max_depth: number) -> string[] ![io] {
 
 fn _curl_post_json_cmd(url: string, body_path: string, auth_header: string) -> string ![io] {
     let tmp = "/tmp/.sfn_curl_response_cmd_tmp";
-    let rc = process.run(["curl", "-sfS", "-X", "POST", "-H", "Content-Type: application/json", "-H", "Authorization: " + auth_header, "-d", "@" + body_path, "-o", tmp, url]);
+    let rc = process.run(["curl", "-sfS", "-X", "POST", "-H", "Content-Type: application/json", "-H", "Authorization: "
+        + auth_header, "-d", "@"
+        + body_path, "-o", tmp, url]);
     if rc != 0 { return ""; }
     if !fs.exists(tmp) { return ""; }
     let response = fs.readFile(tmp);

--- a/compiler/src/cli_main.sfn
+++ b/compiler/src/cli_main.sfn
@@ -1,112 +1,69 @@
 // compiler/src/cli_main.sfn
 //
 // Sailfin-native CLI entrypoint invoked by the native C shim.
-
 import {
-    compile_to_llvm_with_module,
-    compile_to_llvm_with_module_timed,
-    compile_to_llvm_file_with_module,
-    compile_to_native_text_with_module,
-    write_native_text_file_with_module,
-    compile_to_sailfin,
-    number_to_string,
-    module_name_from_path,
-} from "./main";
-import {
-    handle_test_command,
-    handle_publish_command,
     handle_add_command,
+    handle_fmt_command,
+    handle_guillermo_command,
     handle_init_command,
     handle_login_command,
-    handle_guillermo_command,
-    handle_fmt_command,
+    handle_publish_command,
+    handle_test_command,
     inline_imports_for_source,
 } from "./cli_commands";
+import {
+    compile_to_llvm_file_with_module,
+    compile_to_llvm_with_module,
+    compile_to_llvm_with_module_timed,
+    compile_to_native_text_with_module,
+    compile_to_sailfin,
+    module_name_from_path,
+    number_to_string,
+    write_native_text_file_with_module,
+} from "./main";
 import { resolve_compiler_version } from "./version";
 
 fn _usage() -> string {
-    return "usage:\n" +
-    "  sfn --version\n" +
-    "  sfn version\n" +
-    "  sfn emit [--timing] [-o OUTPUT] llvm|sailfin|native <file.sfn>\n" +
-    "  sfn build [-o OUTPUT] <file.sfn>\n" +
-    "  sfn run <file.sfn>\n" +
-    "  sfn run <exe>\n" +
-    "  sfn test [path]\n" +
-    "  sfn fmt [--check] [--write] [path...]\n" +
-    "  sfn init\n" +
-    "  sfn publish [path]\n" +
-    "  sfn add [--dev] <capsule>\n" +
-    "  sfn login [token]\n" +
-    "\n" +
-    "examples:\n" +
-    "  sfn emit llvm examples/basics/hello-world.sfn\n" +
-    "  sfn emit -o hello.ll llvm examples/basics/hello-world.sfn\n" +
-    "  sfn build -o build/native/examples/hello examples/basics/hello-world.sfn\n" +
-    "  sfn run examples/basics/hello-world.sfn\n" +
-    "  sfn run build/native/examples/hello\n" +
-    "  sfn test .\n" +
-    "  sfn init\n" +
-    "  sfn publish [path]\n" +
-    "  sfn add http\n" +
-    "  sfn add --dev test\n" +
-    "  sfn add acme/router\n" +
-    "  sfn login\n";
+    return "usage:\n" + "  sfn --version\n" + "  sfn version\n" + "  sfn emit [--timing] [-o OUTPUT] llvm|sailfin|native <file.sfn>\n" + "  sfn build [-o OUTPUT] <file.sfn>\n" + "  sfn run <file.sfn>\n" + "  sfn run <exe>\n" + "  sfn test [path]\n" + "  sfn fmt [--check] [--write] [path...]\n" + "  sfn init\n" + "  sfn publish [path]\n" + "  sfn add [--dev] <capsule>\n" + "  sfn login [token]\n" + "\n" + "examples:\n" + "  sfn emit llvm examples/basics/hello-world.sfn\n" + "  sfn emit -o hello.ll llvm examples/basics/hello-world.sfn\n" + "  sfn build -o build/native/examples/hello examples/basics/hello-world.sfn\n" + "  sfn run examples/basics/hello-world.sfn\n" + "  sfn run build/native/examples/hello\n" + "  sfn test .\n" + "  sfn init\n" + "  sfn publish [path]\n" + "  sfn add http\n" + "  sfn add --dev test\n" + "  sfn add acme/router\n" + "  sfn login\n";
 }
 
 fn _ends_with(value: string, suffix: string) -> boolean {
-    if suffix.length == 0 {
-        return true;
-    }
-    if value.length < suffix.length {
-        return false;
-    }
+    if suffix.length == 0 { return true; }
+    if value.length < suffix.length { return false; }
     let start = value.length - suffix.length;
     return substring(value, start, value.length) == suffix;
 }
 
 fn _path_join(base: string, name: string) -> string {
-    if base.length == 0 {
-        return name;
-    }
-    if base[base.length - 1] == "/" {
-        return base + name;
-    }
+    if base.length == 0 { return name; }
+    if base[base.length - 1] == "/" { return base + name; }
     return base + "/" + name;
 }
 
 fn _emit_llvm_text_via_file(source: string, module_name: string) -> string ![io] {
     let out_path = "build/sailfin/emit-llvm.tmp";
-    if fs.exists(out_path) {
-        fs.deleteFile(out_path);
-    }
+    if fs.exists(out_path) { fs.deleteFile(out_path); }
     // Call file-based emit. The return value may be corrupted across module
     // boundaries in the seedcheck binary, so we ignore it and just check
     // whether the output file was created.
     compile_to_llvm_file_with_module(source, module_name, out_path);
     if fs.exists(out_path) {
         let content = fs.readFile(out_path);
-        if content.length > 0 {
-            return content;
-        }
+        if content.length > 0 { return content; }
     }
     return compile_to_llvm_with_module(source, module_name);
 }
 
 fn _emit_native_text_via_file(source: string, module_name: string) -> string ![io] {
     let out_path = "build/sailfin/emit-native.tmp";
-    if fs.exists(out_path) {
-        fs.deleteFile(out_path);
-    }
+    if fs.exists(out_path) { fs.deleteFile(out_path); }
     // Call file-based emit. The return value may be corrupted across module
     // boundaries in the seedcheck binary, so we ignore it and just check
     // whether the output file was created.
     write_native_text_file_with_module(source, module_name, out_path);
     if fs.exists(out_path) {
         let content = fs.readFile(out_path);
-        if content.length > 0 {
-            return content;
-        }
+        if content.length > 0 { return content; }
     }
     return compile_to_native_text_with_module(source, module_name);
 }
@@ -115,20 +72,12 @@ fn _dirname(path: string) -> string {
     let mut last_slash: number = -1;
     let mut index: number = 0;
     loop {
-        if index >= path.length {
-            break;
-        }
-        if path[index] == "/" {
-            last_slash = index;
-        }
+        if index >= path.length { break; }
+        if path[index] == "/" { last_slash = index; }
         index += 1;
     }
-    if last_slash < 0 {
-        return ".";
-    }
-    if last_slash == 0 {
-        return "/";
-    }
+    if last_slash < 0 { return "."; }
+    if last_slash == 0 { return "/"; }
     return substring(path, 0, last_slash);
 }
 
@@ -145,9 +94,7 @@ fn _ensure_dir(path: string) ![io] {
 }
 
 fn _runtime_bundle_exists(root: string) -> boolean ![io] {
-    if root.length == 0 {
-        return false;
-    }
+    if root.length == 0 { return false; }
     let include_dir = _path_join(root, "native/include");
     let runtime_src = _path_join(root, "native/src/sailfin_runtime.c");
     let runtime_ir = _path_join(root, "native/ir/runtime_globals.ll");
@@ -156,9 +103,7 @@ fn _runtime_bundle_exists(root: string) -> boolean ![io] {
     if fs.exists(include_dir) {
         if fs.exists(runtime_src) {
             if fs.exists(runtime_ir) {
-                if prelude_obj.length > 0 {
-                    _bundle_ok = true;
-                }
+                if prelude_obj.length > 0 { _bundle_ok = true; }
             }
         }
     }
@@ -167,42 +112,26 @@ fn _runtime_bundle_exists(root: string) -> boolean ![io] {
 
 fn _runtime_prelude_path(root: string) -> string ![io] {
     let bundled = _path_join(root, "native/obj/prelude.o");
-    if fs.exists(bundled) {
-        return bundled;
-    }
+    if fs.exists(bundled) { return bundled; }
     let bundled_nested = _path_join(root, "native/obj/runtime/prelude.o");
-    if fs.exists(bundled_nested) {
-        return bundled_nested;
-    }
+    if fs.exists(bundled_nested) { return bundled_nested; }
     let parent = _dirname(root);
     let fallback = _path_join(parent, "build/native/obj/prelude.o");
-    if fs.exists(fallback) {
-        return fallback;
-    }
+    if fs.exists(fallback) { return fallback; }
     let fallback_nested = _path_join(parent, "build/native/obj/runtime/prelude.o");
-    if fs.exists(fallback_nested) {
-        return fallback_nested;
-    }
+    if fs.exists(fallback_nested) { return fallback_nested; }
     let selfhost_fallback = _path_join(parent, "build/selfhost/native/obj/prelude.o");
-    if fs.exists(selfhost_fallback) {
-        return selfhost_fallback;
-    }
+    if fs.exists(selfhost_fallback) { return selfhost_fallback; }
     let selfhost_fallback_nested = _path_join(parent, "build/selfhost/native/obj/runtime/prelude.o");
-    if fs.exists(selfhost_fallback_nested) {
-        return selfhost_fallback_nested;
-    }
+    if fs.exists(selfhost_fallback_nested) { return selfhost_fallback_nested; }
     return "";
 }
 
 fn _clang_compile_runtime_objects(runtime_root: string, out_dir: string, opt_flag: string) -> string[] ![io] {
     // Build (or reuse) cached runtime object files so repeated `test` invocations
     // don't recompile the runtime C sources per test file.
-    if runtime_root.length == 0 {
-        return ["", "", ""];
-    }
-    if !_runtime_bundle_exists(runtime_root) {
-        return ["", "", ""];
-    }
+    if runtime_root.length == 0 { return ["", "", ""]; }
+    if !_runtime_bundle_exists(runtime_root) { return ["", "", ""]; }
 
     let include_dir = _path_join(runtime_root, "native/include");
     let runtime_src = _path_join(runtime_root, "native/src/sailfin_runtime.c");
@@ -213,34 +142,13 @@ fn _clang_compile_runtime_objects(runtime_root: string, out_dir: string, opt_fla
     let globals_obj = _path_join(out_dir, "runtime_globals" + opt_flag + ".o");
 
     if !fs.exists(runtime_obj) {
-        let rc = process.run([
-                "clang",
-                opt_flag,
-                "-Wno-override-module",
-                "-I" + include_dir,
-                "-c",
-                runtime_src,
-                "-o",
-                runtime_obj,
-        ]);
-        if rc != 0 {
-            return ["", "", ""];
-        }
+        let rc = process.run(["clang", opt_flag, "-Wno-override-module", "-I" + include_dir, "-c", runtime_src, "-o", runtime_obj,]);
+        if rc != 0 { return ["", "", ""]; }
     }
 
     if !fs.exists(globals_obj) {
-        let rc2 = process.run([
-                "clang",
-                opt_flag,
-                "-Wno-override-module",
-                "-c",
-                runtime_ir,
-                "-o",
-                globals_obj,
-        ]);
-        if rc2 != 0 {
-            return ["", "", ""];
-        }
+        let rc2 = process.run(["clang", opt_flag, "-Wno-override-module", "-c", runtime_ir, "-o", globals_obj,]);
+        if rc2 != 0 { return ["", "", ""]; }
     }
 
     return [runtime_obj, globals_obj, prelude_obj];
@@ -276,18 +184,7 @@ fn _clang_link_with_opt(ll_path: string, out_path: string, runtime_root: string,
         return 1;
     }
 
-    let args: string[] = [
-        "clang",
-        opt_flag,
-        "-Wno-override-module",
-        runtime_obj,
-        globals_obj,
-        prelude_obj,
-        ll_path,
-        "-o",
-        out_path,
-        "-lm",
-    ];
+    let args: string[] = ["clang", opt_flag, "-Wno-override-module", runtime_obj, globals_obj, prelude_obj, ll_path, "-o", out_path, "-lm",];
     return process.run(args);
 }
 
@@ -302,9 +199,7 @@ fn sailfin_cli_main(argv: string[]) -> number ![io] {
         print.err("cli: argv.len=" + number_to_string(argv.length));
         let mut trace_index: number = 0;
         loop {
-            if trace_index >= argv.length {
-                break;
-            }
+            if trace_index >= argv.length { break; }
             print.err("cli: argv[" + number_to_string(trace_index) + "]=" + argv[trace_index]);
             trace_index += 1;
         }
@@ -327,17 +222,13 @@ fn sailfin_cli_main(argv: string[]) -> number ![io] {
         print.err("cli: start_index=" + number_to_string(start_index));
     }
     if runtime_root.length == 0 {
-        if _runtime_bundle_exists("runtime") {
-            runtime_root = "runtime";
-        }
+        if _runtime_bundle_exists("runtime") { runtime_root = "runtime"; }
     }
 
     let mut args: string[] = [];
     let mut arg_index: number = start_index;
     loop {
-        if arg_index >= argv.length {
-            break;
-        }
+        if arg_index >= argv.length { break; }
         args.push(argv[arg_index]);
         arg_index += 1;
     }
@@ -349,9 +240,7 @@ fn sailfin_cli_main(argv: string[]) -> number ![io] {
         print.err("cli: args.len=" + number_to_string(args.length));
         let mut arg_index_trace: number = 0;
         loop {
-            if arg_index_trace >= args.length {
-                break;
-            }
+            if arg_index_trace >= args.length { break; }
             print.err("cli: args[" + number_to_string(arg_index_trace) + "]=" + args[arg_index_trace]);
             arg_index_trace += 1;
         }
@@ -359,14 +248,10 @@ fn sailfin_cli_main(argv: string[]) -> number ![io] {
             let cmd_check = args[0];
             let eq_emit = strings_equal(cmd_check, "emit");
             let eq_version = strings_equal(cmd_check, "version");
-            if eq_emit {
-                print.err("cli: eq_emit=true");
-            } else {
+            if eq_emit { print.err("cli: eq_emit=true"); } else {
                 print.err("cli: eq_emit=false");
             }
-            if eq_version {
-                print.err("cli: eq_version=true");
-            } else {
+            if eq_version { print.err("cli: eq_version=true"); } else {
                 print.err("cli: eq_version=false");
             }
         }
@@ -401,12 +286,8 @@ fn sailfin_cli_main(argv: string[]) -> number ![io] {
     let is_login = strings_equal(cmd, "login");
     let is_fmt = strings_equal(cmd, "fmt");
     if trace_argv {
-        if is_emit {
-            print.err("cli: cmd_is_emit=true");
-        }
-        if is_version {
-            print.err("cli: cmd_is_version=true");
-        }
+        if is_emit { print.err("cli: cmd_is_emit=true"); }
+        if is_version { print.err("cli: cmd_is_version=true"); }
     }
 
     if is_version {
@@ -472,9 +353,7 @@ fn sailfin_cli_main(argv: string[]) -> number ![io] {
                     _write_llvm_text(out_path, llvm);
                 } else {
                     let ok = compile_to_llvm_file_with_module(source, module_name, out_path);
-                    if !ok {
-                        return 1;
-                    }
+                    if !ok { return 1; }
                 }
             } else {
                 if timing {
@@ -488,17 +367,13 @@ fn sailfin_cli_main(argv: string[]) -> number ![io] {
         if strings_equal(mode, "sailfin") {
             if has_out {
                 fs.writeFile(out_path, compile_to_sailfin(source));
-            } else {
-                print(compile_to_sailfin(source));
-            }
+            } else { print(compile_to_sailfin(source)); }
             return 0;
         }
         if strings_equal(mode, "native") {
             if has_out {
                 let ok = write_native_text_file_with_module(source, module_name, out_path);
-                if !ok {
-                    return 1;
-                }
+                if !ok { return 1; }
             } else {
                 print(_emit_native_text_via_file(source, module_name));
             }
@@ -605,9 +480,7 @@ fn sailfin_cli_main(argv: string[]) -> number ![io] {
             print("run: native link failed; attempting seed fallback via `sfn run`");
 
             let fallback_rc = process.run(["sfn", "run", input_path]);
-            if fallback_rc == 0 {
-                return 0;
-            }
+            if fallback_rc == 0 { return 0; }
             return link_rc;
         }
 
@@ -615,9 +488,7 @@ fn sailfin_cli_main(argv: string[]) -> number ![io] {
         return run_rc;
     }
 
-    if is_test {
-        return handle_test_command(args, runtime_root);
-    }
+    if is_test { return handle_test_command(args, runtime_root); }
 
     if is_help {
         print(_usage());
@@ -625,30 +496,17 @@ fn sailfin_cli_main(argv: string[]) -> number ![io] {
     }
 
     // ---- Package management commands ----
+    if is_init { return handle_init_command(args); }
 
-    if is_init {
-        return handle_init_command(args);
-    }
+    if is_publish { return handle_publish_command(args); }
 
-    if is_publish {
-        return handle_publish_command(args);
-    }
+    if is_add { return handle_add_command(args); }
 
-    if is_add {
-        return handle_add_command(args);
-    }
+    if is_login { return handle_login_command(args); }
 
-    if is_login {
-        return handle_login_command(args);
-    }
+    if is_fmt { return handle_fmt_command(args); }
 
-    if is_fmt {
-        return handle_fmt_command(args);
-    }
-
-    if strings_equal(cmd, "guillermo") {
-        return handle_guillermo_command();
-    }
+    if strings_equal(cmd, "guillermo") { return handle_guillermo_command(); }
 
     print("unknown command: " + cmd);
     print(_usage());
@@ -660,4 +518,3 @@ fn sailfin_cli_main(argv: string[]) -> number ![io] {
 fn native_cli_main(argv: string[]) -> number ![io] {
     return sailfin_cli_main(argv);
 }
-

--- a/compiler/src/cli_main.sfn
+++ b/compiler/src/cli_main.sfn
@@ -9,7 +9,7 @@ import {
     handle_login_command,
     handle_publish_command,
     handle_test_command,
-    inline_imports_for_source,
+    inline_imports_for_source
 } from "./cli_commands";
 import {
     compile_to_llvm_file_with_module,
@@ -19,12 +19,36 @@ import {
     compile_to_sailfin,
     module_name_from_path,
     number_to_string,
-    write_native_text_file_with_module,
+    write_native_text_file_with_module
 } from "./main";
 import { resolve_compiler_version } from "./version";
 
 fn _usage() -> string {
-    return "usage:\n" + "  sfn --version\n" + "  sfn version\n" + "  sfn emit [--timing] [-o OUTPUT] llvm|sailfin|native <file.sfn>\n" + "  sfn build [-o OUTPUT] <file.sfn>\n" + "  sfn run <file.sfn>\n" + "  sfn run <exe>\n" + "  sfn test [path]\n" + "  sfn fmt [--check] [--write] [path...]\n" + "  sfn init\n" + "  sfn publish [path]\n" + "  sfn add [--dev] <capsule>\n" + "  sfn login [token]\n" + "\n" + "examples:\n" + "  sfn emit llvm examples/basics/hello-world.sfn\n" + "  sfn emit -o hello.ll llvm examples/basics/hello-world.sfn\n" + "  sfn build -o build/native/examples/hello examples/basics/hello-world.sfn\n" + "  sfn run examples/basics/hello-world.sfn\n" + "  sfn run build/native/examples/hello\n" + "  sfn test .\n" + "  sfn init\n" + "  sfn publish [path]\n" + "  sfn add http\n" + "  sfn add --dev test\n" + "  sfn add acme/router\n" + "  sfn login\n";
+    return "usage:\n" + "  sfn --version\n" + "  sfn version\n"
+        + "  sfn emit [--timing] [-o OUTPUT] llvm|sailfin|native <file.sfn>\n"
+        + "  sfn build [-o OUTPUT] <file.sfn>\n"
+        + "  sfn run <file.sfn>\n"
+        + "  sfn run <exe>\n"
+        + "  sfn test [path]\n"
+        + "  sfn fmt [--check] [--write] [path...]\n"
+        + "  sfn init\n"
+        + "  sfn publish [path]\n"
+        + "  sfn add [--dev] <capsule>\n"
+        + "  sfn login [token]\n"
+        + "\n"
+        + "examples:\n"
+        + "  sfn emit llvm examples/basics/hello-world.sfn\n"
+        + "  sfn emit -o hello.ll llvm examples/basics/hello-world.sfn\n"
+        + "  sfn build -o build/native/examples/hello examples/basics/hello-world.sfn\n"
+        + "  sfn run examples/basics/hello-world.sfn\n"
+        + "  sfn run build/native/examples/hello\n"
+        + "  sfn test .\n"
+        + "  sfn init\n"
+        + "  sfn publish [path]\n"
+        + "  sfn add http\n"
+        + "  sfn add --dev test\n"
+        + "  sfn add acme/router\n"
+        + "  sfn login\n";
 }
 
 fn _ends_with(value: string, suffix: string) -> boolean {
@@ -142,7 +166,8 @@ fn _clang_compile_runtime_objects(runtime_root: string, out_dir: string, opt_fla
     let globals_obj = _path_join(out_dir, "runtime_globals" + opt_flag + ".o");
 
     if !fs.exists(runtime_obj) {
-        let rc = process.run(["clang", opt_flag, "-Wno-override-module", "-I" + include_dir, "-c", runtime_src, "-o", runtime_obj,]);
+        let rc = process.run(["clang", opt_flag, "-Wno-override-module", "-I"
+            + include_dir, "-c", runtime_src, "-o", runtime_obj,]);
         if rc != 0 { return ["", "", ""]; }
     }
 
@@ -241,7 +266,8 @@ fn sailfin_cli_main(argv: string[]) -> number ![io] {
         let mut arg_index_trace: number = 0;
         loop {
             if arg_index_trace >= args.length { break; }
-            print.err("cli: args[" + number_to_string(arg_index_trace) + "]=" + args[arg_index_trace]);
+            print.err("cli: args[" + number_to_string(arg_index_trace) + "]="
+                + args[arg_index_trace]);
             arg_index_trace += 1;
         }
         if args.length > 0 {

--- a/compiler/src/decorator_semantics.sfn
+++ b/compiler/src/decorator_semantics.sfn
@@ -8,33 +8,22 @@
 // `Decorator[]` invalid in LLVM (requires a sized element type). Keep this
 // module free of `Decorator` indexing so self-host-from-release-seed remains
 // reliable.
-
 fn infer_effects(existing: string[], decorator_names: string[]) -> string[] {
     let mut effects = clone_effects(existing);
     let mut requires_io: boolean = contains_effect(effects, "io");
 
     let mut index: number = 0;
     loop {
-        if index >= decorator_names.length {
-            break;
-        }
+        if index >= decorator_names.length { break; }
         let name = decorator_names[index];
-        if name == "trace" {
-            requires_io = true;
-        }
-        if name == "logExecution" {
-            requires_io = true;
-        }
-        if name == "logexecution" {
-            requires_io = true;
-        }
+        if name == "trace" { requires_io = true; }
+        if name == "logExecution" { requires_io = true; }
+        if name == "logexecution" { requires_io = true; }
         index += 1;
     }
 
     if requires_io {
-        if !contains_effect(effects, "io") {
-            effects.push("io");
-        }
+        if !contains_effect(effects, "io") { effects.push("io"); }
     }
 
     return effects;
@@ -49,9 +38,7 @@ fn clone_effects(effects: string[]) -> string[] {
     let mut clone: string[] = [];
     let mut index: number = 0;
     loop {
-        if index >= effects.length {
-            break;
-        }
+        if index >= effects.length { break; }
         clone.push(effects[index]);
         index += 1;
     }
@@ -61,15 +48,9 @@ fn clone_effects(effects: string[]) -> string[] {
 fn contains_effect(effects: string[], effect: string) -> boolean {
     let mut index: number = 0;
     loop {
-        if index >= effects.length {
-            break;
-        }
-        if effects[index] == effect {
-            return true;
-        }
+        if index >= effects.length { break; }
+        if effects[index] == effect { return true; }
         index += 1;
     }
     return false;
 }
-
-

--- a/compiler/src/effect_checker.sfn
+++ b/compiler/src/effect_checker.sfn
@@ -3,14 +3,13 @@
 // Minimal effect validation for the Sailfin self-hosted compiler. This mirrors
 // the bootstrap checker by scanning routine bodies for constructs that require
 // explicit capability declarations.
-
 import {
     Block,
     Decorator,
     ElseBranch,
     Expression,
-    MatchCase,
     FunctionSignature,
+    MatchCase,
     MethodDeclaration,
     Program,
     Statement,
@@ -33,9 +32,7 @@ fn validate_effects(program: Program) -> EffectViolation[] {
     let mut violations: EffectViolation[] = [];
     let mut index: number = 0;
     loop {
-        if index >= program.statements.length {
-            break;
-        }
+        if index >= program.statements.length { break; }
         violations = append_violations(violations, analyze_statement(program.statements[index]));
         index += 1;
     }
@@ -73,15 +70,10 @@ fn analyze_statement(statement: Statement) -> EffectViolation[] {
         let mut issues: EffectViolation[] = [];
         let mut index: number = 0;
         loop {
-            if index >= statement.methods.length {
-                break;
-            }
+            if index >= statement.methods.length { break; }
             let method = statement.methods[index];
             let qualified = statement.name + "." + method.signature.name;
-            issues = append_violations(
-                issues,
-                analyze_routine(method.signature, method.body, method.decorators, qualified)
-            );
+            issues = append_violations(issues, analyze_routine(method.signature, method.body, method.decorators, qualified));
             index += 1;
         }
         return issues;
@@ -89,28 +81,19 @@ fn analyze_statement(statement: Statement) -> EffectViolation[] {
     return [];
 }
 
-fn analyze_routine(
-    signature: FunctionSignature,
-    body: Block,
-    decorators: Decorator[],
-    name: string
-) -> EffectViolation[] {
+fn analyze_routine(signature: FunctionSignature, body: Block, decorators: Decorator[], name: string) -> EffectViolation[] {
     let names = decorator_names(decorators);
     let mut declared: string[] = [];
     let mut declared_index: number = 0;
     loop {
-        if declared_index >= signature.effects.length {
-            break;
-        }
+        if declared_index >= signature.effects.length { break; }
         declared = append_unique_effect(declared, signature.effects[declared_index]);
         declared_index += 1;
     }
     let mut requires_io_from_decorators: boolean = false;
     let mut decorator_index: number = 0;
     loop {
-        if decorator_index >= names.length {
-            break;
-        }
+        if decorator_index >= names.length { break; }
         let decorator_name = names[decorator_index];
         let mut _if15: boolean = false;
         if decorator_name == "trace" { _if15 = true; }
@@ -130,9 +113,7 @@ fn analyze_routine(
     let mut missing_requirements: EffectRequirement[] = [];
     let mut index: number = 0;
     loop {
-        if index >= required.length {
-            break;
-        }
+        if index >= required.length { break; }
         let requirement = required[index];
         let effect = requirement.effect;
         if effect == "io" {
@@ -151,18 +132,11 @@ fn analyze_routine(
         }
         index += 1;
     }
-    if missing.length == 0 {
-        return [];
-    }
+    if missing.length == 0 { return []; }
     let mut result: EffectViolation[] = [];
-    result = append_violation(
-        result,
-        EffectViolation {
-            routine_name: name,
-            missing_effects: missing,
-            requirements: missing_requirements,
-        }
-    );
+    result = append_violation(result, EffectViolation {
+        routine_name: name, missing_effects: missing, requirements: missing_requirements,
+    });
     return result;
 }
 
@@ -174,9 +148,7 @@ fn collect_effects_from_block(block: Block) -> EffectRequirement[] {
     let mut required: EffectRequirement[] = [];
     let mut index: number = 0;
     loop {
-        if index >= block.statements.length {
-            break;
-        }
+        if index >= block.statements.length { break; }
         required = merge_requirements(required, collect_effects_from_statement(block.statements[index]));
         index += 1;
     }
@@ -184,38 +156,28 @@ fn collect_effects_from_block(block: Block) -> EffectRequirement[] {
 }
 
 fn collect_effects_from_optional_block(block: Block?) -> EffectRequirement[] {
-    if block == null {
-        return [];
-    }
+    if block == null { return []; }
     return collect_effects_from_block(block);
 }
 
 fn collect_effects_from_optional_statement(statement: Statement?) -> EffectRequirement[] {
-    if statement == null {
-        return [];
-    }
+    if statement == null { return []; }
     return collect_effects_from_statement(statement);
 }
 
 fn collect_effects_from_statement(statement: Statement) -> EffectRequirement[] {
     if statement.variant == "PromptStatement" {
         let mut required = collect_effects_from_block(statement.body);
-        required = append_requirement(
-            required,
-            EffectRequirement {
-                effect: "model",
-                description: "prompt \"" + statement.channel + "\"",
-            }
-        );
+        required = append_requirement(required, EffectRequirement {
+            effect: "model", description: "prompt \"" + statement.channel + "\"",
+        });
         return required;
     }
     if statement.variant == "WithStatement" {
         let mut required = collect_effects_from_block(statement.body);
         let mut clause_index: number = 0;
         loop {
-            if clause_index >= statement.clauses.length {
-                break;
-            }
+            if clause_index >= statement.clauses.length { break; }
             let clause = statement.clauses[clause_index];
             required = merge_requirements(required, collect_effects_from_expression(clause.expression));
             clause_index += 1;
@@ -235,9 +197,7 @@ fn collect_effects_from_statement(statement: Statement) -> EffectRequirement[] {
         let mut required = collect_effects_from_expression(statement.expression);
         let mut case_index: number = 0;
         loop {
-            if case_index >= statement.cases.length {
-                break;
-            }
+            if case_index >= statement.cases.length { break; }
             required = merge_requirements(required, collect_effects_from_match_case(statement.cases[case_index]));
             case_index += 1;
         }
@@ -247,9 +207,7 @@ fn collect_effects_from_statement(statement: Statement) -> EffectRequirement[] {
         let mut required = collect_effects_from_expression(statement.condition);
         required = merge_requirements(required, collect_effects_from_block(statement.then_block));
         let else_branch = statement.else_branch;
-        if else_branch == null {
-            return required;
-        }
+        if else_branch == null { return required; }
         required = merge_requirements(required, collect_effects_from_else_branch(else_branch));
         return required;
     }
@@ -278,9 +236,7 @@ fn collect_effects_from_statement(statement: Statement) -> EffectRequirement[] {
         let mut required: EffectRequirement[] = [];
         let mut method_index: number = 0;
         loop {
-            if method_index >= statement.methods.length {
-                break;
-            }
+            if method_index >= statement.methods.length { break; }
             required = merge_requirements(required, collect_effects_from_block(statement.methods[method_index].body));
             method_index += 1;
         }
@@ -290,9 +246,7 @@ fn collect_effects_from_statement(statement: Statement) -> EffectRequirement[] {
         let mut required: EffectRequirement[] = [];
         let mut property_index: number = 0;
         loop {
-            if property_index >= statement.properties.length {
-                break;
-            }
+            if property_index >= statement.properties.length { break; }
             required = merge_requirements(required, collect_effects_from_expression(statement.properties[property_index].value));
             property_index += 1;
         }
@@ -319,9 +273,7 @@ fn collect_effects_from_match_case(case: MatchCase) -> EffectRequirement[] {
 }
 
 fn collect_effects_from_expression(expression: Expression?) -> EffectRequirement[] {
-    if expression == null {
-        return [];
-    }
+    if expression == null { return []; }
     if expression.variant == "Call" {
         let mut required = collect_effects_from_expression(expression.callee);
 
@@ -329,13 +281,19 @@ fn collect_effects_from_expression(expression: Expression?) -> EffectRequirement
         if expression.callee.variant == "Identifier" {
             let name = expression.callee.name;
             if name == "spawn" {
-                required = append_requirement(required, EffectRequirement { effect: "io", description: "spawn call" });
+                required = append_requirement(required, EffectRequirement {
+                    effect: "io", description: "spawn call"
+                });
             }
             if name == "sleep" {
-                required = append_requirement(required, EffectRequirement { effect: "clock", description: "sleep call" });
+                required = append_requirement(required, EffectRequirement {
+                    effect: "clock", description: "sleep call"
+                });
             }
             if name == "serve" {
-                required = append_requirement(required, EffectRequirement { effect: "net", description: "serve call" });
+                required = append_requirement(required, EffectRequirement {
+                    effect: "net", description: "serve call"
+                });
             }
         }
         if expression.callee.variant == "Member" {
@@ -345,9 +303,7 @@ fn collect_effects_from_expression(expression: Expression?) -> EffectRequirement
 
         let mut argument_index: number = 0;
         loop {
-            if argument_index >= expression.arguments.length {
-                break;
-            }
+            if argument_index >= expression.arguments.length { break; }
             required = merge_requirements(required, collect_effects_from_expression(expression.arguments[argument_index]));
             argument_index += 1;
         }
@@ -358,19 +314,25 @@ fn collect_effects_from_expression(expression: Expression?) -> EffectRequirement
         if expression.object.variant == "Identifier" {
             let root = expression.object.name;
             if root == "fs" {
-                required = append_requirement(required, EffectRequirement { effect: "io", description: "filesystem helper usage" });
+                required = append_requirement(required, EffectRequirement {
+                    effect: "io", description: "filesystem helper usage"
+                });
             }
             let mut _if16: boolean = false;
             if root == "print" { _if16 = true; }
             if root == "console" { _if16 = true; }
             if _if16 {
-                required = append_requirement(required, EffectRequirement { effect: "io", description: "print/console helper usage" });
+                required = append_requirement(required, EffectRequirement {
+                    effect: "io", description: "print/console helper usage"
+                });
             }
             let mut _if17: boolean = false;
             if root == "http" { _if17 = true; }
             if root == "websocket" { _if17 = true; }
             if _if17 {
-                required = append_requirement(required, EffectRequirement { effect: "net", description: "network helper usage" });
+                required = append_requirement(required, EffectRequirement {
+                    effect: "net", description: "network helper usage"
+                });
             }
         }
         return required;
@@ -387,9 +349,7 @@ fn collect_effects_from_expression(expression: Expression?) -> EffectRequirement
         let mut required: EffectRequirement[] = [];
         let mut element_index: number = 0;
         loop {
-            if element_index >= expression.elements.length {
-                break;
-            }
+            if element_index >= expression.elements.length { break; }
             required = merge_requirements(required, collect_effects_from_expression(expression.elements[element_index]));
             element_index += 1;
         }
@@ -399,9 +359,7 @@ fn collect_effects_from_expression(expression: Expression?) -> EffectRequirement
         let mut required: EffectRequirement[] = [];
         let mut field_index: number = 0;
         loop {
-            if field_index >= expression.fields.length {
-                break;
-            }
+            if field_index >= expression.fields.length { break; }
             required = merge_requirements(required, collect_effects_from_expression(expression.fields[field_index].value));
             field_index += 1;
         }
@@ -411,9 +369,7 @@ fn collect_effects_from_expression(expression: Expression?) -> EffectRequirement
         let mut required: EffectRequirement[] = [];
         let mut field_index: number = 0;
         loop {
-            if field_index >= expression.fields.length {
-                break;
-            }
+            if field_index >= expression.fields.length { break; }
             required = merge_requirements(required, collect_effects_from_expression(expression.fields[field_index].value));
             field_index += 1;
         }
@@ -444,67 +400,55 @@ fn collect_effects_from_text(text: string) -> EffectRequirement[] {
     // Keep this conservative: false positives are worse than missing a hint.
     // This checker exists to produce friendly diagnostics, not enforce soundness.
     if contains_code(text, "fs.") {
-        required = append_requirement(
-            required,
-            EffectRequirement { effect: "io", description: "filesystem helper usage" }
-        );
+        required = append_requirement(required, EffectRequirement {
+            effect: "io", description: "filesystem helper usage"
+        });
     }
     let mut _if18: boolean = false;
     if contains_code(text, "print(") { _if18 = true; }
     if contains_code(text, "print.") { _if18 = true; }
     if _if18 {
-        required = append_requirement(
-            required,
-            EffectRequirement { effect: "io", description: "print helper usage" }
-        );
+        required = append_requirement(required, EffectRequirement {
+            effect: "io", description: "print helper usage"
+        });
     }
     if contains_code(text, "console.") {
-        required = append_requirement(
-            required,
-            EffectRequirement { effect: "io", description: "console helper usage" }
-        );
+        required = append_requirement(required, EffectRequirement {
+            effect: "io", description: "console helper usage"
+        });
     }
     if contains_code(text, "http.") {
-        required = append_requirement(
-            required,
-            EffectRequirement { effect: "net", description: "http helper usage" }
-        );
+        required = append_requirement(required, EffectRequirement {
+            effect: "net", description: "http helper usage"
+        });
     }
     if contains_code(text, "websocket.") {
-        required = append_requirement(
-            required,
-            EffectRequirement { effect: "net", description: "websocket helper usage" }
-        );
+        required = append_requirement(required, EffectRequirement {
+            effect: "net", description: "websocket helper usage"
+        });
     }
     if contains_code(text, "spawn(") {
-        required = append_requirement(
-            required,
-            EffectRequirement { effect: "io", description: "spawn call" }
-        );
+        required = append_requirement(required, EffectRequirement {
+            effect: "io", description: "spawn call"
+        });
     }
     if contains_code(text, "serve(") {
-        required = append_requirement(
-            required,
-            EffectRequirement { effect: "net", description: "serve call" }
-        );
+        required = append_requirement(required, EffectRequirement {
+            effect: "net", description: "serve call"
+        });
     }
     if contains_code(text, "sleep(") {
-        required = append_requirement(
-            required,
-            EffectRequirement { effect: "clock", description: "sleep call" }
-        );
+        required = append_requirement(required, EffectRequirement {
+            effect: "clock", description: "sleep call"
+        });
     }
 
     return required;
 }
 
 fn contains_code(text: string, needle: string) -> boolean {
-    if needle.length == 0 {
-        return true;
-    }
-    if text.length < needle.length {
-        return false;
-    }
+    if needle.length == 0 { return true; }
+    if text.length < needle.length { return false; }
 
     let mut index: number = 0;
     let mut in_line_comment: boolean = false;
@@ -513,9 +457,7 @@ fn contains_code(text: string, needle: string) -> boolean {
     let mut escaped: boolean = false;
 
     loop {
-        if index >= text.length {
-            break;
-        }
+        if index >= text.length { break; }
 
         let _ec_next = index + 1;
         let ch = substring(text, index, _ec_next);
@@ -546,9 +488,7 @@ fn contains_code(text: string, needle: string) -> boolean {
         }
 
         if in_line_comment {
-            if ch == "\n" {
-                in_line_comment = false;
-            }
+            if ch == "\n" { in_line_comment = false; }
             index += 1;
             continue;
         }
@@ -585,9 +525,7 @@ fn contains_code(text: string, needle: string) -> boolean {
 
         let _end_pos = index + needle.length;
         if _end_pos <= text.length {
-            if substring(text, index, _end_pos) == needle {
-                return true;
-            }
+            if substring(text, index, _end_pos) == needle { return true; }
         }
         index += 1;
     }
@@ -599,9 +537,7 @@ fn append_violations(violations: EffectViolation[], new_violations: EffectViolat
     let mut result = violations;
     let mut index: number = 0;
     loop {
-        if index >= new_violations.length {
-            break;
-        }
+        if index >= new_violations.length { break; }
         result.push(new_violations[index]);
         index += 1;
     }
@@ -614,9 +550,7 @@ fn append_violation(collection: EffectViolation[], item: EffectViolation) -> Eff
 }
 
 fn append_unique_effect(effects: string[], effect: string) -> string[] {
-    if contains_effect(effects, effect) {
-        return effects;
-    }
+    if contains_effect(effects, effect) { return effects; }
     effects.push(effect);
     return effects;
 }
@@ -624,12 +558,8 @@ fn append_unique_effect(effects: string[], effect: string) -> string[] {
 fn contains_effect(effects: string[], effect: string) -> boolean {
     let mut index: number = 0;
     loop {
-        if index >= effects.length {
-            break;
-        }
-        if effects[index] == effect {
-            return true;
-        }
+        if index >= effects.length { break; }
+        if effects[index] == effect { return true; }
         index += 1;
     }
     return false;
@@ -644,9 +574,7 @@ fn merge_requirements(base: EffectRequirement[], additions: EffectRequirement[])
     let mut result = base;
     let mut index: number = 0;
     loop {
-        if index >= additions.length {
-            break;
-        }
+        if index >= additions.length { break; }
         result.push(additions[index]);
         index += 1;
     }
@@ -656,12 +584,8 @@ fn merge_requirements(base: EffectRequirement[], additions: EffectRequirement[])
 fn contains_requirement_for_effect(requirements: EffectRequirement[], effect: string) -> boolean {
     let mut index: number = 0;
     loop {
-        if index >= requirements.length {
-            break;
-        }
-        if requirements[index].effect == effect {
-            return true;
-        }
+        if index >= requirements.length { break; }
+        if requirements[index].effect == effect { return true; }
         index += 1;
     }
     return false;

--- a/compiler/src/effect_checker.sfn
+++ b/compiler/src/effect_checker.sfn
@@ -13,7 +13,7 @@ import {
     MethodDeclaration,
     Program,
     Statement,
-    decorator_names,
+    decorator_names
 } from "./ast";
 import { substring } from "./string_utils";
 
@@ -61,7 +61,7 @@ fn analyze_statement(statement: Statement) -> EffectViolation[] {
             return_type: null,
             effects: statement.effects,
             type_parameters: [],
-            name_span: null,
+            name_span: null
         };
         let qualified = "test " + statement.name;
         return analyze_routine(signature, statement.body, statement.decorators, qualified);
@@ -135,7 +135,7 @@ fn analyze_routine(signature: FunctionSignature, body: Block, decorators: Decora
     if missing.length == 0 { return []; }
     let mut result: EffectViolation[] = [];
     result = append_violation(result, EffectViolation {
-        routine_name: name, missing_effects: missing, requirements: missing_requirements,
+        routine_name: name, missing_effects: missing, requirements: missing_requirements
     });
     return result;
 }
@@ -169,7 +169,7 @@ fn collect_effects_from_statement(statement: Statement) -> EffectRequirement[] {
     if statement.variant == "PromptStatement" {
         let mut required = collect_effects_from_block(statement.body);
         required = append_requirement(required, EffectRequirement {
-            effect: "model", description: "prompt \"" + statement.channel + "\"",
+            effect: "model", description: "prompt \"" + statement.channel + "\""
         });
         return required;
     }

--- a/compiler/src/emit_native.sfn
+++ b/compiler/src/emit_native.sfn
@@ -10,7 +10,6 @@
 //   emit_native_state.sfn  — TextBuilder, NativeState, shared utilities
 //   emit_native_format.sfn — expression/signature/specifier formatting
 //   emit_native_layout.sfn — struct/enum layout computation & manifest
-
 import {
     Block,
     Decorator,
@@ -22,54 +21,53 @@ import {
     MethodDeclaration,
     Parameter,
     Program,
+    SourceSpan,
     Statement,
     TypeAnnotation,
-    SourceSpan,
 } from "./ast";
-import { char_code } from "./string_utils";
 import {
-    LayoutContext,
-    NativeState,
-    StatementDispatchResult,
-    state_new,
-    state_emit_line,
-    state_emit_blank,
-    state_push_indent,
-    state_pop_indent,
-    state_add_diagnostic,
-    state_merge_diagnostics,
-    builder_to_string,
-    append_unique,
-    join_with_separator,
-    join_type_annotations,
-} from "./emit_native_state";
-import {
-    format_expression,
-    format_optional_expression,
-    format_function_signature,
-    format_type_parameters,
-    format_field,
-    format_enum_variant,
-    format_decorator,
-    format_span,
-    render_native_specifiers,
-    render_export_specifiers,
-    append_optional_type_annotation,
     append_optional_initializer,
-    format_match_case_head,
+    append_optional_type_annotation,
+    format_decorator,
+    format_enum_variant,
+    format_expression,
+    format_field,
+    format_function_signature,
     format_inline_case_body,
+    format_match_case_head,
+    format_optional_expression,
+    format_span,
+    format_type_parameters,
+    render_export_specifiers,
+    render_native_specifiers,
 } from "./emit_native_format";
 import {
     NativeArtifact,
     build_layout_context,
-    compute_struct_layout_lines,
     compute_enum_layout_lines,
+    compute_struct_layout_lines,
     emit_layout_lines,
     generate_layout_manifest,
 } from "./emit_native_layout";
+import {
+    LayoutContext,
+    NativeState,
+    StatementDispatchResult,
+    append_unique,
+    builder_to_string,
+    join_type_annotations,
+    join_with_separator,
+    state_add_diagnostic,
+    state_emit_blank,
+    state_emit_line,
+    state_merge_diagnostics,
+    state_new,
+    state_pop_indent,
+    state_push_indent,
+} from "./emit_native_state";
+import { char_code } from "./string_utils";
 
 // ── Public data structures ───────────────────────────────────────────
-
 struct NativeModule {
     module_name: string;
     artifacts: NativeArtifact[];
@@ -83,7 +81,6 @@ struct EmitNativeResult {
 }
 
 // ── Entry points ─────────────────────────────────────────────────────
-
 fn emit_native(program: Program) -> EmitNativeResult {
     return emit_native_with_module_name(program, "main");
 }
@@ -93,21 +90,15 @@ fn emit_native_with_module_name(program: Program, module_name: string) -> EmitNa
     let mut state: NativeState = state_new(layout_context);
     state = state_emit_line(state, "; Sailfin Native Prototype");
     let mut module_line = ".module ";
-    if module_name.length == 0 {
-        module_line = module_line + "main";
-    } else {
+    if module_name.length == 0 { module_line = module_line + "main"; } else {
         module_line = module_line + module_name;
     }
     state = state_emit_line(state, module_line);
-    if program.statements.length > 0 {
-        state = state_emit_blank(state);
-    }
+    if program.statements.length > 0 { state = state_emit_blank(state); }
 
     let mut index: number = 0;
     loop {
-        if index >= program.statements.length {
-            break;
-        }
+        if index >= program.statements.length { break; }
         state = emit_statement(state, program.statements[index]);
         let _next_stmt = index + 1;
         if _next_stmt < program.statements.length {
@@ -143,21 +134,15 @@ fn emit_native_text_with_module_name(program: Program, module_name: string) -> s
     let mut state: NativeState = state_new(layout_context);
     state = state_emit_line(state, "; Sailfin Native Prototype");
     let mut module_line = ".module ";
-    if module_name.length == 0 {
-        module_line = module_line + "main";
-    } else {
+    if module_name.length == 0 { module_line = module_line + "main"; } else {
         module_line = module_line + module_name;
     }
     state = state_emit_line(state, module_line);
-    if program.statements.length > 0 {
-        state = state_emit_blank(state);
-    }
+    if program.statements.length > 0 { state = state_emit_blank(state); }
 
     let mut index: number = 0;
     loop {
-        if index >= program.statements.length {
-            break;
-        }
+        if index >= program.statements.length { break; }
         state = emit_statement(state, program.statements[index]);
         let _next_stmt2 = index + 1;
         if _next_stmt2 < program.statements.length {
@@ -166,21 +151,15 @@ fn emit_native_text_with_module_name(program: Program, module_name: string) -> s
         index += 1;
     }
     let text = builder_to_string(state.builder);
-    if text == null {
-        return "";
-    }
+    if text == null { return ""; }
     return text;
 }
 
 // Emit native text directly to a file to avoid returning large strings across ABI boundaries.
 fn emit_native_text_to_file_with_module_name(program: Program, module_name: string, out_path: string) -> boolean ![io] {
     let text = emit_native_text_with_module_name(program, module_name);
-    if text.length == 0 {
-        return false;
-    }
-    if fs.exists(out_path) {
-        fs.deleteFile(out_path);
-    }
+    if text.length == 0 { return false; }
+    if fs.exists(out_path) { fs.deleteFile(out_path); }
     fs.writeFile(out_path, text);
     return fs.exists(out_path);
 }
@@ -191,18 +170,13 @@ fn emit_native_module_with_module_name(program: Program, module_name: string) ->
 }
 
 // ── Statement dispatch ───────────────────────────────────────────────
-
 fn emit_statement(state: NativeState, statement: Statement) -> NativeState {
     // Split into smaller dispatch functions so the first-pass binary
     // can compile each successfully (large if-chains get truncated).
     let result_decl = emit_statement_declarations(state, statement);
-    if result_decl.handled {
-        return result_decl.state;
-    }
+    if result_decl.handled { return result_decl.state; }
     let result_type = emit_statement_type_decls(result_decl.state, statement);
-    if result_type.handled {
-        return result_type.state;
-    }
+    if result_type.handled { return result_type.state; }
     return emit_statement_control_flow(result_type.state, statement);
 }
 
@@ -210,70 +184,120 @@ fn emit_statement_declarations(state: NativeState, statement: Statement) -> Stat
     if statement.variant == "ImportDeclaration" {
         let mut line: string = ".import \"" + statement.source + "\"";
         let rendered = render_native_specifiers(statement.import_specifiers);
-        if rendered.length > 0 {
-            line = line + " { " + rendered + " }";
-        }
-        return StatementDispatchResult { state: state_emit_line(state, line), handled: true };
+        if rendered.length > 0 { line = line + " { " + rendered + " }"; }
+        return StatementDispatchResult {
+            state: state_emit_line(state, line),
+            handled: true
+        };
     }
     if statement.variant == "ExportDeclaration" {
         let mut line: string = ".export \"" + statement.source + "\"";
         let rendered = render_export_specifiers(statement.export_specifiers);
-        if rendered.length > 0 {
-            line = line + " { " + rendered + " }";
-        }
-        return StatementDispatchResult { state: state_emit_line(state, line), handled: true };
+        if rendered.length > 0 { line = line + " { " + rendered + " }"; }
+        return StatementDispatchResult {
+            state: state_emit_line(state, line),
+            handled: true
+        };
     }
     if statement.variant == "VariableDeclaration" {
-        return StatementDispatchResult { state: emit_variable(state, statement), handled: true };
+        return StatementDispatchResult {
+            state: emit_variable(state, statement),
+            handled: true
+        };
     }
     if statement.variant == "FunctionDeclaration" {
-        return StatementDispatchResult { state: emit_function(state, statement.signature, statement.body, statement.decorators), handled: true };
+        return StatementDispatchResult {
+            state: emit_function(state, statement.signature, statement.body, statement.decorators),
+            handled: true
+        };
     }
     if statement.variant == "ExternFunctionDeclaration" {
-        return StatementDispatchResult { state: emit_extern_function(state, statement.signature, statement.unsafe, statement.decorators), handled: true };
+        return StatementDispatchResult {
+            state: emit_extern_function(state, statement.signature, statement.unsafe, statement.decorators),
+            handled: true
+        };
     }
     if statement.variant == "StructDeclaration" {
-        return StatementDispatchResult { state: emit_struct(state, statement), handled: true };
+        return StatementDispatchResult {
+            state: emit_struct(state, statement),
+            handled: true
+        };
     }
     if statement.variant == "PipelineDeclaration" {
-        return StatementDispatchResult { state: emit_pipeline(state, statement), handled: true };
+        return StatementDispatchResult {
+            state: emit_pipeline(state, statement),
+            handled: true
+        };
     }
     if statement.variant == "ToolDeclaration" {
-        return StatementDispatchResult { state: emit_tool(state, statement), handled: true };
+        return StatementDispatchResult {
+            state: emit_tool(state, statement),
+            handled: true
+        };
     }
     if statement.variant == "TestDeclaration" {
-        return StatementDispatchResult { state: emit_test(state, statement), handled: true };
+        return StatementDispatchResult {
+            state: emit_test(state, statement),
+            handled: true
+        };
     }
     return StatementDispatchResult { state: state, handled: false };
 }
 
 fn emit_statement_type_decls(state: NativeState, statement: Statement) -> StatementDispatchResult {
     if statement.variant == "ModelDeclaration" {
-        return StatementDispatchResult { state: emit_model(state, statement), handled: true };
+        return StatementDispatchResult {
+            state: emit_model(state, statement),
+            handled: true
+        };
     }
     if statement.variant == "TypeAliasDeclaration" {
-        return StatementDispatchResult { state: emit_type_alias(state, statement), handled: true };
+        return StatementDispatchResult {
+            state: emit_type_alias(state, statement),
+            handled: true
+        };
     }
     if statement.variant == "InterfaceDeclaration" {
-        return StatementDispatchResult { state: emit_interface(state, statement), handled: true };
+        return StatementDispatchResult {
+            state: emit_interface(state, statement),
+            handled: true
+        };
     }
     if statement.variant == "EnumDeclaration" {
-        return StatementDispatchResult { state: emit_enum(state, statement), handled: true };
+        return StatementDispatchResult {
+            state: emit_enum(state, statement),
+            handled: true
+        };
     }
     if statement.variant == "PromptStatement" {
-        return StatementDispatchResult { state: emit_prompt(state, statement), handled: true };
+        return StatementDispatchResult {
+            state: emit_prompt(state, statement),
+            handled: true
+        };
     }
     if statement.variant == "WithStatement" {
-        return StatementDispatchResult { state: emit_with(state, statement), handled: true };
+        return StatementDispatchResult {
+            state: emit_with(state, statement),
+            handled: true
+        };
     }
     if statement.variant == "ForStatement" {
-        return StatementDispatchResult { state: emit_for(state, statement), handled: true };
+        return StatementDispatchResult {
+            state: emit_for(state, statement),
+            handled: true
+        };
     }
     if statement.variant == "MatchStatement" {
-        return StatementDispatchResult { state: emit_match(state, statement), handled: true };
+        return StatementDispatchResult {
+            state: emit_match(state, statement),
+            handled: true
+        };
     }
     if statement.variant == "LoopStatement" {
-        return StatementDispatchResult { state: emit_loop(state, statement), handled: true };
+        return StatementDispatchResult {
+            state: emit_loop(state, statement),
+            handled: true
+        };
     }
     return StatementDispatchResult { state: state, handled: false };
 }
@@ -312,18 +336,10 @@ fn emit_statement_control_flow(state: NativeState, statement: Statement) -> Nati
 }
 
 // ── Statement emitters ───────────────────────────────────────────────
-
-fn emit_extern_function(
-    state: NativeState,
-    signature: FunctionSignature,
-    unsafe_flag: boolean,
-    decorators: Decorator[]
-) -> NativeState {
+fn emit_extern_function(state: NativeState, signature: FunctionSignature, unsafe_flag: boolean, decorators: Decorator[]) -> NativeState {
     let mut current = emit_decorators(state, decorators);
     current = state_emit_line(current, ".fn " + format_function_signature(signature));
-    if unsafe_flag {
-        current = state_emit_line(current, ".meta unsafe");
-    }
+    if unsafe_flag { current = state_emit_line(current, ".meta unsafe"); }
     current = state_emit_line(current, ".meta extern");
     current = emit_signature_metadata(current, signature);
     current = emit_parameter_metadata(current, signature.parameters);
@@ -365,16 +381,12 @@ fn emit_try(state: NativeState, statement: Statement) -> NativeState {
 }
 
 fn emit_span_if_present(state: NativeState, span: SourceSpan?) -> NativeState {
-    if span == null {
-        return state;
-    }
+    if span == null { return state; }
     return state_emit_line(state, ".span " + format_span(span));
 }
 
 fn emit_initializer_span_if_present(state: NativeState, span: SourceSpan?) -> NativeState {
-    if span == null {
-        return state;
-    }
+    if span == null { return state; }
     return state_emit_line(state, ".init-span " + format_span(span));
 }
 
@@ -383,21 +395,14 @@ fn emit_variable(state: NativeState, statement: Statement) -> NativeState {
     current = emit_initializer_span_if_present(current, statement.initializer_span);
 
     let mut line: string = ".let ";
-    if statement.mutable {
-        line = line + "mut ";
-    }
+    if statement.mutable { line = line + "mut "; }
     line = line + statement.name;
     line = append_optional_type_annotation(line, statement.type_annotation);
     line = append_optional_initializer(line, statement.initializer);
     return state_emit_line(current, line);
 }
 
-fn emit_function(
-    state: NativeState,
-    signature: FunctionSignature,
-    body: Block,
-    decorators: Decorator[]
-) -> NativeState {
+fn emit_function(state: NativeState, signature: FunctionSignature, body: Block, decorators: Decorator[]) -> NativeState {
     let mut current = emit_decorators(state, decorators);
     current = state_emit_line(current, ".fn " + format_function_signature(signature));
     current = emit_signature_metadata(current, signature);
@@ -438,20 +443,9 @@ fn emit_test(state: NativeState, statement: Statement) -> NativeState {
     // directives in the native IR parser, causing tests to be dropped before
     // LLVM lowering and resulting in missing `main` at link time.
     let test_symbol = test_function_symbol(statement.name);
-    return emit_function(
-        state,
-        FunctionSignature {
-            name: test_symbol,
-            is_async: false,
-            parameters: [],
-            return_type: null,
-            effects: statement.effects,
-            type_parameters: [],
-            name_span: statement.name_span,
-        },
-        statement.body,
-        statement.decorators
-    );
+    return emit_function(state, FunctionSignature {
+        name: test_symbol, is_async: false, parameters: [], return_type: null, effects: statement.effects, type_parameters: [], name_span: statement.name_span,
+    }, statement.body, statement.decorators);
 }
 
 fn emit_model(state: NativeState, statement: Statement) -> NativeState {
@@ -464,9 +458,7 @@ fn emit_model(state: NativeState, statement: Statement) -> NativeState {
     current = state_push_indent(current);
     let mut index: number = 0;
     loop {
-        if index >= statement.properties.length {
-            break;
-        }
+        if index >= statement.properties.length { break; }
         let property = statement.properties[index];
         let line = ".property " + property.name + " = " + format_expression(property.value);
         current = state_emit_line(current, line);
@@ -498,9 +490,7 @@ fn emit_interface(state: NativeState, statement: Statement) -> NativeState {
     current = state_push_indent(current);
     let mut index: number = 0;
     loop {
-        if index >= statement.members.length {
-            break;
-        }
+        if index >= statement.members.length { break; }
         let signature = statement.members[index];
         current = state_emit_line(current, ".sig " + format_function_signature(signature));
         index += 1;
@@ -523,9 +513,7 @@ fn emit_enum(state: NativeState, statement: Statement) -> NativeState {
     current = state_merge_diagnostics(current, enum_layout.diagnostics);
     let mut index: number = 0;
     loop {
-        if index >= statement.variants.length {
-            break;
-        }
+        if index >= statement.variants.length { break; }
         current = state_emit_line(current, ".variant " + format_enum_variant(statement.variants[index]));
         index += 1;
     }
@@ -551,18 +539,14 @@ fn emit_struct(state: NativeState, statement: Statement) -> NativeState {
 
     let mut index: number = 0;
     loop {
-        if index >= statement.fields.length {
-            break;
-        }
+        if index >= statement.fields.length { break; }
         current = state_emit_line(current, ".field " + format_field(statement.fields[index]));
         index += 1;
     }
 
     let mut method_index: number = 0;
     loop {
-        if method_index >= statement.methods.length {
-            break;
-        }
+        if method_index >= statement.methods.length { break; }
         current = emit_method(current, statement.methods[method_index]);
         method_index += 1;
     }
@@ -602,12 +586,8 @@ fn emit_with(state: NativeState, statement: Statement) -> NativeState {
     let mut line: string = ".with ";
     let mut index: number = 0;
     loop {
-        if index >= statement.clauses.length {
-            break;
-        }
-        if index > 0 {
-            line = line + ", ";
-        }
+        if index >= statement.clauses.length { break; }
+        if index > 0 { line = line + ", "; }
         line = line + format_expression(statement.clauses[index].expression);
         index += 1;
     }
@@ -643,9 +623,7 @@ fn emit_match(state: NativeState, statement: Statement) -> NativeState {
     current = state_push_indent(current);
     let mut index: number = 0;
     loop {
-        if index >= statement.cases.length {
-            break;
-        }
+        if index >= statement.cases.length { break; }
         current = emit_match_case(current, statement.cases[index]);
         index += 1;
     }
@@ -670,16 +648,10 @@ fn emit_match_case(state: NativeState, case: MatchCase) -> NativeState {
 }
 
 fn select_inline_match_case_statement(block: Block) -> Statement? {
-    if block.statements.length != 1 {
-        return null;
-    }
+    if block.statements.length != 1 { return null; }
     let statement = block.statements[0];
-    if statement.variant == "ExpressionStatement" {
-        return statement;
-    }
-    if statement.variant == "ReturnStatement" {
-        return statement;
-    }
+    if statement.variant == "ExpressionStatement" { return statement; }
+    if statement.variant == "ReturnStatement" { return statement; }
     return null;
 }
 
@@ -695,9 +667,7 @@ fn emit_if(state: NativeState, statement: Statement) -> NativeState {
     current = emit_block(current, statement.then_block);
     current = state_pop_indent(current);
     let else_branch = statement.else_branch;
-    if else_branch == null {
-        return state_emit_line(current, ".endif");
-    }
+    if else_branch == null { return state_emit_line(current, ".endif"); }
     current = emit_else_branch(current, else_branch);
     return state_emit_line(current, ".endif");
 }
@@ -708,14 +678,10 @@ fn emit_else_branch(state: NativeState, branch: ElseBranch) -> NativeState {
     let body = branch.body;
     if body == null {
         let nested = branch.statement;
-        if nested == null {
-            current = state_emit_line(current, "noop");
-        } else {
+        if nested == null { current = state_emit_line(current, "noop"); } else {
             current = emit_statement(current, nested);
         }
-    } else {
-        current = emit_block(current, body);
-    }
+    } else { current = emit_block(current, body); }
     current = state_pop_indent(current);
     return current;
 }
@@ -723,9 +689,7 @@ fn emit_else_branch(state: NativeState, branch: ElseBranch) -> NativeState {
 fn emit_return(state: NativeState, statement: Statement) -> NativeState {
     let mut current = emit_span_if_present(state, statement.span);
     let rendered = format_optional_expression(statement.expression);
-    if rendered.length == 0 {
-        return state_emit_line(current, "ret");
-    }
+    if rendered.length == 0 { return state_emit_line(current, "ret"); }
     return state_emit_line(current, "ret " + rendered);
 }
 
@@ -741,9 +705,7 @@ fn emit_block(state: NativeState, block: Block) -> NativeState {
     let mut current = state;
     let mut index: number = 0;
     loop {
-        if index >= block.statements.length {
-            break;
-        }
+        if index >= block.statements.length { break; }
         current = emit_statement(current, block.statements[index]);
         index += 1;
     }
@@ -754,9 +716,7 @@ fn emit_decorators(state: NativeState, decorators: Decorator[]) -> NativeState {
     let mut current = state;
     let mut index: number = 0;
     loop {
-        if index >= decorators.length {
-            break;
-        }
+        if index >= decorators.length { break; }
         current = state_emit_line(current, ".decorator " + format_decorator(decorators[index]));
         index += 1;
     }
@@ -767,14 +727,10 @@ fn emit_signature_metadata(state: NativeState, signature: FunctionSignature) -> 
     let mut current = state;
     if signature.return_type != null {
         current = state_emit_line(current, ".meta return " + signature.return_type.text);
-    } else {
-        current = state_emit_line(current, ".meta return void");
-    }
+    } else { current = state_emit_line(current, ".meta return void"); }
     if signature.effects.length > 0 {
         current = state_emit_line(current, ".meta effects " + join_with_separator(signature.effects, ", "));
-    } else {
-        current = state_emit_line(current, ".meta effects none");
-    }
+    } else { current = state_emit_line(current, ".meta effects none"); }
     if signature.type_parameters.length > 0 {
         current = state_emit_line(current, ".meta generics " + format_type_parameters(signature.type_parameters));
     }
@@ -785,15 +741,11 @@ fn emit_parameter_metadata(state: NativeState, parameters: Parameter[]) -> Nativ
     let mut current = state;
     let mut index: number = 0;
     loop {
-        if index >= parameters.length {
-            break;
-        }
+        if index >= parameters.length { break; }
         let parameter = parameters[index];
         current = emit_span_if_present(current, parameter.span);
         let mut line: string = ".param ";
-        if parameter.mutable {
-            line = line + "mut ";
-        }
+        if parameter.mutable { line = line + "mut "; }
         line = line + parameter.name;
         if parameter.type_annotation != null {
             line = line + ": " + parameter.type_annotation.text;
@@ -808,14 +760,11 @@ fn emit_parameter_metadata(state: NativeState, parameters: Parameter[]) -> Nativ
 }
 
 // ── Symbol helpers ───────────────────────────────────────────────────
-
 fn collect_entry_points(program: Program) -> string[] {
     let mut entries: string[] = [];
     let mut index: number = 0;
     loop {
-        if index >= program.statements.length {
-            break;
-        }
+        if index >= program.statements.length { break; }
         let statement = program.statements[index];
         if statement.variant == "FunctionDeclaration" {
             entries = append_unique(entries, statement.signature.name);
@@ -829,63 +778,43 @@ fn collect_entry_points(program: Program) -> string[] {
 }
 
 fn is_test_symbol_char(ch: string) -> boolean {
-    if ch.length == 0 {
-        return false;
-    }
-    if ch == "_" {
-        return true;
-    }
+    if ch.length == 0 { return false; }
+    if ch == "_" { return true; }
     let code = char_code(ch);
     let lower_a = char_code("a");
     let lower_z = char_code("z");
     if code >= lower_a {
-        if code <= lower_z {
-            return true;
-        }
+        if code <= lower_z { return true; }
     }
     let upper_a = char_code("A");
     let upper_z = char_code("Z");
     if code >= upper_a {
-        if code <= upper_z {
-            return true;
-        }
+        if code <= upper_z { return true; }
     }
     let zero = char_code("0");
     let nine = char_code("9");
     if code >= zero {
-        if code <= nine {
-            return true;
-        }
+        if code <= nine { return true; }
     }
     return false;
 }
 
 fn sanitize_test_name_for_symbol(name: string) -> string {
-    if name.length == 0 {
-        return "unnamed";
-    }
+    if name.length == 0 { return "unnamed"; }
     let mut out: string = "";
     let mut index: number = 0;
     loop {
-        if index >= name.length {
-            break;
-        }
+        if index >= name.length { break; }
         let ch = name[index];
-        if is_test_symbol_char(ch) {
-            out = out + ch;
-        }
+        if is_test_symbol_char(ch) { out = out + ch; }
         index += 1;
     }
-    if out.length == 0 {
-        return "unnamed";
-    }
+    if out.length == 0 { return "unnamed"; }
     // Ensure the name is not purely numeric / doesn't start with a digit.
     let first = out[0];
     let code = char_code(first);
     if code >= char_code("0") {
-        if code <= char_code("9") {
-            return "_" + out;
-        }
+        if code <= char_code("9") { return "_" + out; }
     }
     return out;
 }
@@ -900,9 +829,7 @@ fn count_exported_symbols(program: Program) -> number {
     let mut count: number = 0;
     let mut index: number = 0;
     loop {
-        if index >= program.statements.length {
-            break;
-        }
+        if index >= program.statements.length { break; }
         let stmt = program.statements[index];
         let mut _if24: boolean = false;
         if stmt.variant == "FunctionDeclaration" { _if24 = true; }
@@ -914,9 +841,7 @@ fn count_exported_symbols(program: Program) -> number {
         if stmt.variant == "TestDeclaration" { _if24 = true; }
         if stmt.variant == "TypeAliasDeclaration" { _if24 = true; }
         if stmt.variant == "InterfaceDeclaration" { _if24 = true; }
-        if _if24 {
-            count += 1;
-        }
+        if _if24 { count += 1; }
         index += 1;
     }
     return count;

--- a/compiler/src/emit_native.sfn
+++ b/compiler/src/emit_native.sfn
@@ -23,7 +23,7 @@ import {
     Program,
     SourceSpan,
     Statement,
-    TypeAnnotation,
+    TypeAnnotation
 } from "./ast";
 import {
     append_optional_initializer,
@@ -39,7 +39,7 @@ import {
     format_span,
     format_type_parameters,
     render_export_specifiers,
-    render_native_specifiers,
+    render_native_specifiers
 } from "./emit_native_format";
 import {
     NativeArtifact,
@@ -47,7 +47,7 @@ import {
     compute_enum_layout_lines,
     compute_struct_layout_lines,
     emit_layout_lines,
-    generate_layout_manifest,
+    generate_layout_manifest
 } from "./emit_native_layout";
 import {
     LayoutContext,
@@ -63,7 +63,7 @@ import {
     state_merge_diagnostics,
     state_new,
     state_pop_indent,
-    state_push_indent,
+    state_push_indent
 } from "./emit_native_state";
 import { char_code } from "./string_utils";
 
@@ -110,7 +110,7 @@ fn emit_native_with_module_name(program: Program, module_name: string) -> EmitNa
     let artifact = NativeArtifact {
         name: "module.sfn-asm",
         format: "sailfin-native-text",
-        contents: builder_to_string(state.builder),
+        contents: builder_to_string(state.builder)
     };
 
     let manifest_artifact = generate_layout_manifest(program, layout_context);
@@ -119,12 +119,12 @@ fn emit_native_with_module_name(program: Program, module_name: string) -> EmitNa
         module_name: module_name,
         artifacts: [artifact, manifest_artifact],
         entry_points: collect_entry_points(program),
-        symbol_count: count_exported_symbols(program),
+        symbol_count: count_exported_symbols(program)
     };
 
     return EmitNativeResult {
         module: module,
-        diagnostics: state.diagnostics,
+        diagnostics: state.diagnostics
     };
 }
 
@@ -331,7 +331,8 @@ fn emit_statement_control_flow(state: NativeState, statement: Statement) -> Nati
     if statement.variant == "ExpressionStatement" {
         return emit_expression_statement(state, statement);
     }
-    let message = "native backend: unsupported statement `" + statement.variant + "`";
+    let message = "native backend: unsupported statement `" + statement.variant
+        + "`";
     return state_add_diagnostic(state, message);
 }
 
@@ -444,7 +445,7 @@ fn emit_test(state: NativeState, statement: Statement) -> NativeState {
     // LLVM lowering and resulting in missing `main` at link time.
     let test_symbol = test_function_symbol(statement.name);
     return emit_function(state, FunctionSignature {
-        name: test_symbol, is_async: false, parameters: [], return_type: null, effects: statement.effects, type_parameters: [], name_span: statement.name_span,
+        name: test_symbol, is_async: false, parameters: [], return_type: null, effects: statement.effects, type_parameters: [], name_span: statement.name_span
     }, statement.body, statement.decorators);
 }
 
@@ -452,7 +453,8 @@ fn emit_model(state: NativeState, statement: Statement) -> NativeState {
     let mut current = emit_decorators(state, statement.decorators);
     let mut header: string = ".model " + statement.name + " : " + statement.model_type.text;
     if statement.effects.length > 0 {
-        header = header + " ![" + join_with_separator(statement.effects, ", ") + "]";
+        header = header + " ![" + join_with_separator(statement.effects, ", ")
+            + "]";
     }
     current = state_emit_line(current, header);
     current = state_push_indent(current);
@@ -600,7 +602,8 @@ fn emit_with(state: NativeState, statement: Statement) -> NativeState {
 
 fn emit_for(state: NativeState, statement: Statement) -> NativeState {
     let mut current = emit_decorators(state, statement.decorators);
-    let line = ".for " + format_expression(statement.clause.target) + " in " + format_expression(statement.clause.iterable);
+    let line = ".for " + format_expression(statement.clause.target) + " in "
+        + format_expression(statement.clause.iterable);
     current = state_emit_line(current, line);
     current = state_push_indent(current);
     current = emit_block(current, statement.body);
@@ -656,7 +659,8 @@ fn select_inline_match_case_statement(block: Block) -> Statement? {
 }
 
 fn emit_inline_match_case(state: NativeState, case: MatchCase, statement: Statement) -> NativeState {
-    let mut line: string = format_match_case_head(case) + " => " + format_inline_case_body(statement);
+    let mut line: string = format_match_case_head(case) + " => "
+        + format_inline_case_body(statement);
     return state_emit_line(state, line + ",");
 }
 
@@ -729,10 +733,12 @@ fn emit_signature_metadata(state: NativeState, signature: FunctionSignature) -> 
         current = state_emit_line(current, ".meta return " + signature.return_type.text);
     } else { current = state_emit_line(current, ".meta return void"); }
     if signature.effects.length > 0 {
-        current = state_emit_line(current, ".meta effects " + join_with_separator(signature.effects, ", "));
+        current = state_emit_line(current, ".meta effects "
+            + join_with_separator(signature.effects, ", "));
     } else { current = state_emit_line(current, ".meta effects none"); }
     if signature.type_parameters.length > 0 {
-        current = state_emit_line(current, ".meta generics " + format_type_parameters(signature.type_parameters));
+        current = state_emit_line(current, ".meta generics "
+            + format_type_parameters(signature.type_parameters));
     }
     return current;
 }

--- a/compiler/src/emit_native_format.sfn
+++ b/compiler/src/emit_native_format.sfn
@@ -3,45 +3,37 @@
 // Formatting helpers for the native emitter: expression rendering, type
 // inference, function-signature formatting, and specifier rendering.
 // Extracted from emit_native.sfn to reduce per-file memory footprint.
-
 import {
     Decorator,
     EnumVariant,
+    ExportSpecifier,
     Expression,
     FieldDeclaration,
     FunctionSignature,
     ImportSpecifier,
-    ExportSpecifier,
     MatchCase,
     Parameter,
+    SourceSpan,
     Statement,
     TypeAnnotation,
     TypeParameter,
-    SourceSpan,
 } from "./ast";
 import {
     join_with_separator,
+    number_to_string,
     quote_string,
     trim_text,
-    number_to_string,
 } from "./emit_native_state";
 
 // ── Expression formatting ────────────────────────────────────────────
-
 fn format_expression(expression: Expression) -> string {
     if expression.variant == "Identifier" {
         let name = expression.name;
         return name;
     }
-    if expression.variant == "NumberLiteral" {
-        return expression.value;
-    }
-    if expression.variant == "BooleanLiteral" {
-        return expression.value;
-    }
-    if expression.variant == "NullLiteral" {
-        return "null";
-    }
+    if expression.variant == "NumberLiteral" { return expression.value; }
+    if expression.variant == "BooleanLiteral" { return expression.value; }
+    if expression.variant == "NullLiteral" { return "null"; }
     if expression.variant == "StringLiteral" {
         return quote_string(expression.value);
     }
@@ -60,9 +52,7 @@ fn format_expression(expression: Expression) -> string {
         let mut rendered: string[] = [];
         let mut index: number = 0;
         loop {
-            if index >= expression.arguments.length {
-                break;
-            }
+            if index >= expression.arguments.length { break; }
             rendered.push(format_expression(expression.arguments[index]));
             index += 1;
         }
@@ -79,9 +69,7 @@ fn format_expression(expression: Expression) -> string {
         let mut rendered: string[] = [];
         let mut index: number = 0;
         loop {
-            if index >= expression.fields.length {
-                break;
-            }
+            if index >= expression.fields.length { break; }
             let field = expression.fields[index];
             rendered.push(field.name + ": " + format_expression(field.value));
             index += 1;
@@ -92,9 +80,7 @@ fn format_expression(expression: Expression) -> string {
         let mut rendered: string[] = [];
         let mut index: number = 0;
         loop {
-            if index >= expression.fields.length {
-                break;
-            }
+            if index >= expression.fields.length { break; }
             let field = expression.fields[index];
             rendered.push(field.name + ": " + format_expression(field.value));
             index += 1;
@@ -105,9 +91,7 @@ fn format_expression(expression: Expression) -> string {
     if expression.variant == "Range" {
         return format_expression(expression.start) + ".." + format_expression(expression.end);
     }
-    if expression.variant == "Lambda" {
-        return "<lambda>";
-    }
+    if expression.variant == "Lambda" { return "<lambda>"; }
     if expression.variant == "Raw" {
         let raw_text = trim_text(expression.text);
         // Normalize multi-line raw expressions to single line so that
@@ -122,9 +106,7 @@ fn format_expression(expression: Expression) -> string {
             let mut is_nl: boolean = false;
             if rch == "\n" { is_nl = true; }
             if rch == "\r" { is_nl = true; }
-            if is_nl {
-                normalized = normalized + " ";
-            } else {
+            if is_nl { normalized = normalized + " "; } else {
                 normalized = normalized + rch;
             }
             ri += 1;
@@ -139,42 +121,28 @@ fn format_array_expression(elements: Expression[]) -> string {
     let mut rendered: string[] = [];
     let mut index: number = 0;
     loop {
-        if index >= elements.length {
-            break;
-        }
+        if index >= elements.length { break; }
         rendered.push(format_expression(elements[index]));
         index += 1;
     }
     if rendered.length == 0 {
-        if annotation.length == 0 {
-            return "[]";
-        }
+        if annotation.length == 0 { return "[]"; }
         return "[#element:" + annotation + "]";
     }
     let body = join_with_separator(rendered, ", ");
-    if annotation.length == 0 {
-        return "[" + body + "]";
-    }
+    if annotation.length == 0 { return "[" + body + "]"; }
     return "[#element:" + annotation + ", " + body + "]";
 }
 
 fn infer_array_element_type(elements: Expression[]) -> string {
-    if elements.length == 0 {
-        return "";
-    }
+    if elements.length == 0 { return ""; }
     let mut candidate: string = "";
     let mut index: number = 0;
     loop {
-        if index >= elements.length {
-            break;
-        }
+        if index >= elements.length { break; }
         let element_type = infer_expression_type(elements[index]);
-        if element_type.length == 0 {
-            return "";
-        }
-        if candidate.length == 0 {
-            candidate = element_type;
-        } else if candidate != element_type {
+        if element_type.length == 0 { return ""; }
+        if candidate.length == 0 { candidate = element_type; } else if candidate != element_type {
             return "";
         }
         index += 1;
@@ -183,19 +151,11 @@ fn infer_array_element_type(elements: Expression[]) -> string {
 }
 
 fn infer_expression_type(expression: Expression) -> string {
-    if expression.variant == "NumberLiteral" {
-        return "number";
-    }
-    if expression.variant == "BooleanLiteral" {
-        return "boolean";
-    }
-    if expression.variant == "StringLiteral" {
-        return "string";
-    }
+    if expression.variant == "NumberLiteral" { return "number"; }
+    if expression.variant == "BooleanLiteral" { return "boolean"; }
+    if expression.variant == "StringLiteral" { return "string"; }
     if expression.variant == "Struct" {
-        if expression.type_name.length == 0 {
-            return "";
-        }
+        if expression.type_name.length == 0 { return ""; }
         // For enum variants (e.g., Color.Red), type_name is ["Color", "Red"].
         // For struct literals (e.g., Person { ... }), type_name is ["Person"].
         // When inferring array element types, we want just the enum name (first component)
@@ -223,29 +183,22 @@ fn infer_expression_type(expression: Expression) -> string {
     }
     if expression.variant == "Array" {
         let nested = infer_array_element_type(expression.elements);
-        if nested.length == 0 {
-            return "";
-        }
+        if nested.length == 0 { return ""; }
         return nested + "[]";
     }
     return "";
 }
 
 fn format_optional_expression(expression: Expression?) -> string {
-    if expression == null {
-        return "";
-    }
+    if expression == null { return ""; }
     let value: Expression = expression;
     return format_expression(value);
 }
 
 // ── Signature / parameter formatting ─────────────────────────────────
-
 fn format_function_signature(signature: FunctionSignature) -> string {
     let mut prefix: string = "";
-    if signature.is_async {
-        prefix = "async ";
-    }
+    if signature.is_async { prefix = "async "; }
     let mut line: string = prefix + signature.name;
     line = line + format_type_parameters(signature.type_parameters);
     line = line + "(" + format_parameters(signature.parameters) + ")";
@@ -259,20 +212,14 @@ fn format_function_signature(signature: FunctionSignature) -> string {
 }
 
 fn format_parameters(parameters: Parameter[]) -> string {
-    if parameters.length == 0 {
-        return "";
-    }
+    if parameters.length == 0 { return ""; }
     let mut parts: string[] = [];
     let mut index: number = 0;
     loop {
-        if index >= parameters.length {
-            break;
-        }
+        if index >= parameters.length { break; }
         let parameter = parameters[index];
         let mut entry: string = "";
-        if parameter.mutable {
-            entry = "mut " + parameter.name;
-        } else {
+        if parameter.mutable { entry = "mut " + parameter.name; } else {
             entry = parameter.name;
         }
         if parameter.type_annotation != null {
@@ -288,15 +235,11 @@ fn format_parameters(parameters: Parameter[]) -> string {
 }
 
 fn format_type_parameters(parameters: TypeParameter[]) -> string {
-    if parameters.length == 0 {
-        return "";
-    }
+    if parameters.length == 0 { return ""; }
     let mut parts: string[] = [];
     let mut index: number = 0;
     loop {
-        if index >= parameters.length {
-            break;
-        }
+        if index >= parameters.length { break; }
         let parameter = parameters[index];
         let mut entry: string = parameter.name;
         if parameter.bound != null {
@@ -309,26 +252,19 @@ fn format_type_parameters(parameters: TypeParameter[]) -> string {
 }
 
 // ── Field / variant formatting ───────────────────────────────────────
-
 fn format_field(field: FieldDeclaration) -> string {
     let mut line: string = "";
-    if field.mutable {
-        line = line + "mut ";
-    }
+    if field.mutable { line = line + "mut "; }
     line = line + field.name + ": " + field.type_annotation.text;
     return line;
 }
 
 fn format_enum_variant(variant: EnumVariant) -> string {
-    if variant.fields.length == 0 {
-        return variant.name;
-    }
+    if variant.fields.length == 0 { return variant.name; }
     let mut parts: string[] = [];
     let mut index: number = 0;
     loop {
-        if index >= variant.fields.length {
-            break;
-        }
+        if index >= variant.fields.length { break; }
         parts.push(format_field(variant.fields[index]));
         index += 1;
     }
@@ -336,51 +272,34 @@ fn format_enum_variant(variant: EnumVariant) -> string {
 }
 
 // ── Decorator formatting ─────────────────────────────────────────────
-
 fn format_decorator(decorator: Decorator) -> string {
     let mut line: string = "@" + decorator.name;
-    if decorator.arguments.length == 0 {
-        return line;
-    }
+    if decorator.arguments.length == 0 { return line; }
     let mut parts: string[] = [];
     let mut index: number = 0;
     loop {
-        if index >= decorator.arguments.length {
-            break;
-        }
+        if index >= decorator.arguments.length { break; }
         let argument = decorator.arguments[index];
         let value = format_expression(argument.expression);
         if argument.name != null {
             parts.push(argument.name + "=" + value);
-        } else {
-            parts.push(value);
-        }
+        } else { parts.push(value); }
         index += 1;
     }
     return line + "(" + join_with_separator(parts, ", ") + ")";
 }
 
 // ── Span formatting ──────────────────────────────────────────────────
-
 fn format_span(span: SourceSpan) -> string {
-    return number_to_string(span.start_line)
-    + " "
-    + number_to_string(span.start_column)
-    + " "
-    + number_to_string(span.end_line)
-    + " "
-    + number_to_string(span.end_column);
+    return number_to_string(span.start_line) + " " + number_to_string(span.start_column) + " " + number_to_string(span.end_line) + " " + number_to_string(span.end_column);
 }
 
 // ── Specifier formatting ─────────────────────────────────────────────
-
 fn format_native_specifier(name: string, alias: string?) -> string {
     let mut _if20: boolean = false;
     if alias == null { _if20 = true; }
     if alias.length == 0 { _if20 = true; }
-    if _if20 {
-        return name;
-    }
+    if _if20 { return name; }
     return name + " as " + alias;
 }
 
@@ -388,9 +307,7 @@ fn render_native_specifiers(specifiers: ImportSpecifier[]) -> string {
     let mut parts: string[] = [];
     let mut index: number = 0;
     loop {
-        if index >= specifiers.length {
-            break;
-        }
+        if index >= specifiers.length { break; }
         parts.push(format_native_specifier(specifiers[index].name, specifiers[index].alias));
         index += 1;
     }
@@ -401,9 +318,7 @@ fn render_export_specifiers(specifiers: ExportSpecifier[]) -> string {
     let mut parts: string[] = [];
     let mut index: number = 0;
     loop {
-        if index >= specifiers.length {
-            break;
-        }
+        if index >= specifiers.length { break; }
         parts.push(format_native_specifier(specifiers[index].name, specifiers[index].alias));
         index += 1;
     }
@@ -411,33 +326,23 @@ fn render_export_specifiers(specifiers: ExportSpecifier[]) -> string {
 }
 
 // ── Optional annotation / initializer helpers ────────────────────────
-
 fn append_optional_type_annotation(line: string, annotation: TypeAnnotation?) -> string {
-    if annotation == null {
-        return line;
-    }
+    if annotation == null { return line; }
     return line + " : " + annotation.text;
 }
 
 fn append_optional_initializer(line: string, initializer: Expression?) -> string {
-    if initializer == null {
-        return line;
-    }
+    if initializer == null { return line; }
     let rendered = format_optional_expression(initializer);
-    if rendered.length == 0 {
-        return line;
-    }
+    if rendered.length == 0 { return line; }
     return line + " = " + rendered;
 }
 
 // ── Match-case formatting helpers ────────────────────────────────────
-
 fn format_match_case_head(case: MatchCase) -> string {
     let mut head: string = format_expression(case.pattern);
     let guard = case.guard;
-    if guard == null {
-        return head;
-    }
+    if guard == null { return head; }
     return head + " if " + format_optional_expression(guard);
 }
 
@@ -447,9 +352,7 @@ fn format_inline_case_body(statement: Statement) -> string {
     }
     if statement.variant == "ReturnStatement" {
         let rendered = format_optional_expression(statement.expression);
-        if rendered.length == 0 {
-            return "return";
-        }
+        if rendered.length == 0 { return "return"; }
         return "return " + rendered;
     }
     return "";

--- a/compiler/src/emit_native_format.sfn
+++ b/compiler/src/emit_native_format.sfn
@@ -16,13 +16,13 @@ import {
     SourceSpan,
     Statement,
     TypeAnnotation,
-    TypeParameter,
+    TypeParameter
 } from "./ast";
 import {
     join_with_separator,
     number_to_string,
     quote_string,
-    trim_text,
+    trim_text
 } from "./emit_native_state";
 
 // ── Expression formatting ────────────────────────────────────────────
@@ -60,7 +60,8 @@ fn format_expression(expression: Expression) -> string {
         return format_expression(expression.callee) + "(" + args + ")";
     }
     if expression.variant == "Index" {
-        return format_expression(expression.sequence) + "[" + format_expression(expression.index) + "]";
+        return format_expression(expression.sequence) + "[" + format_expression(expression.index)
+            + "]";
     }
     if expression.variant == "Array" {
         return format_array_expression(expression.elements);
@@ -291,7 +292,11 @@ fn format_decorator(decorator: Decorator) -> string {
 
 // ── Span formatting ──────────────────────────────────────────────────
 fn format_span(span: SourceSpan) -> string {
-    return number_to_string(span.start_line) + " " + number_to_string(span.start_column) + " " + number_to_string(span.end_line) + " " + number_to_string(span.end_column);
+    return number_to_string(span.start_line) + " " + number_to_string(span.start_column)
+        + " "
+        + number_to_string(span.end_line)
+        + " "
+        + number_to_string(span.end_column);
 }
 
 // ── Specifier formatting ─────────────────────────────────────────────

--- a/compiler/src/emit_native_layout.sfn
+++ b/compiler/src/emit_native_layout.sfn
@@ -7,7 +7,7 @@ import {
     EnumVariant,
     FieldDeclaration,
     Program,
-    Statement,
+    Statement
 } from "./ast";
 import {
     LayoutContext,
@@ -27,7 +27,7 @@ import {
     number_to_string,
     state_emit_line,
     strip_optional_suffix,
-    trim_text,
+    trim_text
 } from "./emit_native_state";
 
 // ── Layout-specific data structures ──────────────────────────────────
@@ -127,7 +127,10 @@ fn compute_struct_layout_lines(context: LayoutContext, struct_name: string, fiel
     let inputs = convert_struct_fields(fields);
     let layout = calculate_record_layout(context, inputs, "struct", struct_name, append_string([], struct_name));
     let mut lines: string[] = [];
-    lines.push(".layout struct name=" + struct_name + " size=" + number_to_string(layout.size) + " align=" + number_to_string(layout.align));
+    lines.push(".layout struct name=" + struct_name + " size="
+        + number_to_string(layout.size)
+        + " align="
+        + number_to_string(layout.align));
     let mut index: number = 0;
     loop {
         if index >= layout.fields.length { break; }
@@ -160,8 +163,13 @@ fn compute_enum_layout_lines(context: LayoutContext, statement: Statement) -> La
     }
     let layout = infer_enum_aggregate_layout(context, statement.name, layout_variants, append_string([], statement.name));
     let mut lines: string[] = [];
-    let mut header: string = ".layout enum name=" + statement.name + " size=" + number_to_string(layout.size) + " align=" + number_to_string(layout.align);
-    header = header + " tag_type=i32 tag_size=" + number_to_string(layout.tag_size) + " tag_align=" + number_to_string(layout.tag_align);
+    let mut header: string = ".layout enum name=" + statement.name + " size="
+        + number_to_string(layout.size)
+        + " align="
+        + number_to_string(layout.align);
+    header = header + " tag_type=i32 tag_size=" + number_to_string(layout.tag_size)
+        + " tag_align="
+        + number_to_string(layout.tag_align);
     lines.push(header);
     let mut variant_index: number = 0;
     loop {
@@ -177,7 +185,9 @@ fn compute_enum_layout_lines(context: LayoutContext, statement: Statement) -> La
         loop {
             if payload_index >= descriptor.fields.length { break; }
             let payload = descriptor.fields[payload_index];
-            let mut payload_line: string = ".layout payload " + descriptor.name + "." + payload.name;
+            let mut payload_line: string = ".layout payload " + descriptor.name
+                + "."
+                + payload.name;
             payload_line = payload_line + " type=" + payload.type_annotation;
             payload_line = payload_line + " offset=" + number_to_string(payload.offset);
             payload_line = payload_line + " size=" + number_to_string(payload.size);
@@ -226,7 +236,7 @@ fn infer_enum_aggregate_layout(context: LayoutContext, enum_name: string, varian
                 type_annotation: field.type_annotation,
                 offset: payload_offset + field.offset,
                 size: field.size,
-                align: field.align,
+                align: field.align
             };
             absolute_fields = append_struct_field_layout(absolute_fields, absolute);
             field_index += 1;
@@ -234,7 +244,7 @@ fn infer_enum_aggregate_layout(context: LayoutContext, enum_name: string, varian
         let variant_size = payload_offset + record.size;
         if variant_size > union_size { union_size = variant_size; }
         descriptors = append_enum_variant_layout(descriptors, EnumVariantLayoutDescriptor {
-            name: variant.name, tag: index, offset: payload_offset, size: record.size, align: variant_align, fields: absolute_fields,
+            name: variant.name, tag: index, offset: payload_offset, size: record.size, align: variant_align, fields: absolute_fields
         });
         index += 1;
     }
@@ -252,7 +262,7 @@ fn infer_enum_aggregate_layout(context: LayoutContext, enum_name: string, varian
         tag_size: tag_size,
         tag_align: tag_align,
         variants: descriptors,
-        diagnostics: diagnostics,
+        diagnostics: diagnostics
     };
 }
 
@@ -280,7 +290,7 @@ fn calculate_record_layout(context: LayoutContext, inputs: LayoutFieldInput[], c
             type_annotation: trim_text(input.type_annotation),
             offset: offset,
             size: layout.size,
-            align: field_align,
+            align: field_align
         };
         fields = append_struct_field_layout(fields, descriptor);
         offset += layout.size;
@@ -304,7 +314,11 @@ fn analyze_type_layout(context: LayoutContext, visiting: string[], type_annotati
     let trimmed = trim_text(type_annotation);
     let mut diagnostics: string[] = [];
     if trimmed.length == 0 {
-        diagnostics.push("native layout: " + container_kind + " `" + container_name + "` field `" + field_name + "` missing type annotation; defaulting to pointer layout");
+        diagnostics.push("native layout: " + container_kind + " `"
+            + container_name
+            + "` field `"
+            + field_name
+            + "` missing type annotation; defaulting to pointer layout");
         return TypeLayoutInfo {
             size: 8,
             align: 8,
@@ -370,7 +384,11 @@ fn analyze_type_layout(context: LayoutContext, visiting: string[], type_annotati
     if is_optional_annotation(trimmed) {
         let inner = trim_text(strip_optional_suffix(trimmed));
         if inner.length == 0 {
-            diagnostics.push("native layout: " + container_kind + " `" + container_name + "` field `" + field_name + "` optional type missing inner annotation; defaulting to pointer layout");
+            diagnostics.push("native layout: " + container_kind + " `"
+                + container_name
+                + "` field `"
+                + field_name
+                + "` optional type missing inner annotation; defaulting to pointer layout");
         }
         return TypeLayoutInfo {
             size: 8,
@@ -431,7 +449,12 @@ fn analyze_type_layout(context: LayoutContext, visiting: string[], type_annotati
             diagnostics: diagnostics
         };
     }
-    diagnostics.push("native layout: " + container_kind + " `" + container_name + "` field `" + field_name + "` uses unsupported type `" + trimmed + "`; defaulting to pointer layout");
+    diagnostics.push("native layout: " + container_kind + " `" + container_name
+        + "` field `"
+        + field_name
+        + "` uses unsupported type `"
+        + trimmed
+        + "`; defaulting to pointer layout");
     return TypeLayoutInfo { size: 8, align: 8, diagnostics: diagnostics };
 }
 
@@ -691,7 +714,7 @@ fn generate_layout_manifest(program: Program, context: LayoutContext) -> NativeA
     return NativeArtifact {
         name: "module.layout-manifest",
         format: "sailfin-layout-manifest",
-        contents: builder_to_string(builder),
+        contents: builder_to_string(builder)
     };
 }
 

--- a/compiler/src/emit_native_layout.sfn
+++ b/compiler/src/emit_native_layout.sfn
@@ -3,7 +3,6 @@
 // Struct / enum layout computation and manifest generation for the
 // native emitter.  Extracted from emit_native.sfn to reduce per-file
 // memory footprint during self-hosting compilation.
-
 import {
     EnumVariant,
     FieldDeclaration,
@@ -12,27 +11,26 @@ import {
 } from "./ast";
 import {
     LayoutContext,
-    LayoutStructDefinition,
-    LayoutFieldInput,
-    LayoutEnumVariantDefinition,
     LayoutEnumDefinition,
+    LayoutEnumVariantDefinition,
+    LayoutFieldInput,
+    LayoutStructDefinition,
     NativeState,
     append_string,
+    builder_emit_blank,
+    builder_emit_line,
+    builder_new,
+    builder_to_string,
     contains_string,
-    number_to_string,
-    trim_text,
     is_array_type,
     is_optional_annotation,
-    strip_optional_suffix,
-    builder_new,
-    builder_emit_line,
-    builder_emit_blank,
-    builder_to_string,
+    number_to_string,
     state_emit_line,
+    strip_optional_suffix,
+    trim_text,
 } from "./emit_native_state";
 
 // ── Layout-specific data structures ──────────────────────────────────
-
 struct LayoutEmitResult {
     lines: string[];
     diagnostics: string[];
@@ -90,33 +88,34 @@ struct NativeArtifact {
 }
 
 // ── Context construction ─────────────────────────────────────────────
-
 fn build_layout_context(program: Program) -> LayoutContext {
     let mut structs: LayoutStructDefinition[] = [];
     let mut enums: LayoutEnumDefinition[] = [];
     let mut index: number = 0;
     loop {
-        if index >= program.statements.length {
-            break;
-        }
+        if index >= program.statements.length { break; }
         let statement = program.statements[index];
         if statement.variant == "StructDeclaration" {
             let inputs = convert_struct_fields(statement.fields);
-            structs = append_layout_struct_definition(structs, LayoutStructDefinition { name: statement.name, fields: inputs });
+            structs = append_layout_struct_definition(structs, LayoutStructDefinition {
+                name: statement.name, fields: inputs
+            });
         }
         if statement.variant == "EnumDeclaration" {
             let mut variants: LayoutEnumVariantDefinition[] = [];
             let mut variant_index: number = 0;
             loop {
-                if variant_index >= statement.variants.length {
-                    break;
-                }
+                if variant_index >= statement.variants.length { break; }
                 let variant = statement.variants[variant_index];
                 let inputs = convert_variant_fields(variant);
-                variants = append_layout_enum_variant_definition(variants, LayoutEnumVariantDefinition { name: variant.name, fields: inputs });
+                variants = append_layout_enum_variant_definition(variants, LayoutEnumVariantDefinition {
+                    name: variant.name, fields: inputs
+                });
                 variant_index += 1;
             }
-            enums = append_layout_enum_definition(enums, LayoutEnumDefinition { name: statement.name, variants: variants });
+            enums = append_layout_enum_definition(enums, LayoutEnumDefinition {
+                name: statement.name, variants: variants
+            });
         }
         index += 1;
     }
@@ -124,7 +123,6 @@ fn build_layout_context(program: Program) -> LayoutContext {
 }
 
 // ── Layout computation ───────────────────────────────────────────────
-
 fn compute_struct_layout_lines(context: LayoutContext, struct_name: string, fields: FieldDeclaration[]) -> LayoutEmitResult {
     let inputs = convert_struct_fields(fields);
     let layout = calculate_record_layout(context, inputs, "struct", struct_name, append_string([], struct_name));
@@ -132,9 +130,7 @@ fn compute_struct_layout_lines(context: LayoutContext, struct_name: string, fiel
     lines.push(".layout struct name=" + struct_name + " size=" + number_to_string(layout.size) + " align=" + number_to_string(layout.align));
     let mut index: number = 0;
     loop {
-        if index >= layout.fields.length {
-            break;
-        }
+        if index >= layout.fields.length { break; }
         let field = layout.fields[index];
         let mut line: string = ".layout field " + field.name;
         line = line + " type=" + field.type_annotation;
@@ -144,19 +140,22 @@ fn compute_struct_layout_lines(context: LayoutContext, struct_name: string, fiel
         lines.push(line);
         index += 1;
     }
-    return LayoutEmitResult { lines: lines, diagnostics: layout.diagnostics };
+    return LayoutEmitResult {
+        lines: lines,
+        diagnostics: layout.diagnostics
+    };
 }
 
 fn compute_enum_layout_lines(context: LayoutContext, statement: Statement) -> LayoutEmitResult {
     let mut layout_variants: LayoutEnumVariantDefinition[] = [];
     let mut index: number = 0;
     loop {
-        if index >= statement.variants.length {
-            break;
-        }
+        if index >= statement.variants.length { break; }
         let variant = statement.variants[index];
         let inputs = convert_variant_fields(variant);
-        layout_variants = append_layout_enum_variant_definition(layout_variants, LayoutEnumVariantDefinition { name: variant.name, fields: inputs });
+        layout_variants = append_layout_enum_variant_definition(layout_variants, LayoutEnumVariantDefinition {
+            name: variant.name, fields: inputs
+        });
         index += 1;
     }
     let layout = infer_enum_aggregate_layout(context, statement.name, layout_variants, append_string([], statement.name));
@@ -166,9 +165,7 @@ fn compute_enum_layout_lines(context: LayoutContext, statement: Statement) -> La
     lines.push(header);
     let mut variant_index: number = 0;
     loop {
-        if variant_index >= layout.variants.length {
-            break;
-        }
+        if variant_index >= layout.variants.length { break; }
         let descriptor = layout.variants[variant_index];
         let mut line: string = ".layout variant " + descriptor.name;
         line = line + " tag=" + number_to_string(descriptor.tag);
@@ -178,9 +175,7 @@ fn compute_enum_layout_lines(context: LayoutContext, statement: Statement) -> La
         lines.push(line);
         let mut payload_index: number = 0;
         loop {
-            if payload_index >= descriptor.fields.length {
-                break;
-            }
+            if payload_index >= descriptor.fields.length { break; }
             let payload = descriptor.fields[payload_index];
             let mut payload_line: string = ".layout payload " + descriptor.name + "." + payload.name;
             payload_line = payload_line + " type=" + payload.type_annotation;
@@ -192,7 +187,10 @@ fn compute_enum_layout_lines(context: LayoutContext, statement: Statement) -> La
         }
         variant_index += 1;
     }
-    return LayoutEmitResult { lines: lines, diagnostics: layout.diagnostics };
+    return LayoutEmitResult {
+        lines: lines,
+        diagnostics: layout.diagnostics
+    };
 }
 
 fn infer_enum_aggregate_layout(context: LayoutContext, enum_name: string, variants: LayoutEnumVariantDefinition[], visiting: string[]) -> EnumAggregateLayout {
@@ -204,34 +202,24 @@ fn infer_enum_aggregate_layout(context: LayoutContext, enum_name: string, varian
     let mut descriptors: EnumVariantLayoutDescriptor[] = [];
     let mut index: number = 0;
     loop {
-        if index >= variants.length {
-            break;
-        }
+        if index >= variants.length { break; }
         let variant = variants[index];
         let container_name = enum_name + "." + variant.name;
         let record = calculate_record_layout(context, variant.fields, "variant", container_name, visiting);
         let mut _ci: number = 0;
         loop {
-            if _ci >= record.diagnostics.length {
-                break;
-            }
+            if _ci >= record.diagnostics.length { break; }
             diagnostics.push(record.diagnostics[_ci]);
             _ci += 1;
         }
         let mut variant_align: number = record.align;
-        if variant_align <= 0 {
-            variant_align = 1;
-        }
+        if variant_align <= 0 { variant_align = 1; }
         let payload_offset = align_to(tag_size, variant_align);
-        if variant_align > union_align {
-            union_align = variant_align;
-        }
+        if variant_align > union_align { union_align = variant_align; }
         let mut absolute_fields: StructFieldLayoutDescriptor[] = [];
         let mut field_index: number = 0;
         loop {
-            if field_index >= record.fields.length {
-                break;
-            }
+            if field_index >= record.fields.length { break; }
             let field = record.fields[field_index];
             let absolute = StructFieldLayoutDescriptor {
                 name: field.name,
@@ -244,16 +232,9 @@ fn infer_enum_aggregate_layout(context: LayoutContext, enum_name: string, varian
             field_index += 1;
         }
         let variant_size = payload_offset + record.size;
-        if variant_size > union_size {
-            union_size = variant_size;
-        }
+        if variant_size > union_size { union_size = variant_size; }
         descriptors = append_enum_variant_layout(descriptors, EnumVariantLayoutDescriptor {
-            name: variant.name,
-            tag: index,
-            offset: payload_offset,
-            size: record.size,
-            align: variant_align,
-            fields: absolute_fields,
+            name: variant.name, tag: index, offset: payload_offset, size: record.size, align: variant_align, fields: absolute_fields,
         });
         index += 1;
     }
@@ -262,13 +243,9 @@ fn infer_enum_aggregate_layout(context: LayoutContext, enum_name: string, varian
         union_size = tag_size;
     }
     let mut final_align: number = union_align;
-    if final_align <= 0 {
-        final_align = 1;
-    }
+    if final_align <= 0 { final_align = 1; }
     let mut aligned_size: number = union_size;
-    if final_align > 1 {
-        aligned_size = align_to(union_size, final_align);
-    }
+    if final_align > 1 { aligned_size = align_to(union_size, final_align); }
     return EnumAggregateLayout {
         size: aligned_size,
         align: final_align,
@@ -286,23 +263,17 @@ fn calculate_record_layout(context: LayoutContext, inputs: LayoutFieldInput[], c
     let mut max_align: number = 1;
     let mut index: number = 0;
     loop {
-        if index >= inputs.length {
-            break;
-        }
+        if index >= inputs.length { break; }
         let input = inputs[index];
         let layout = analyze_type_layout(context, visiting, input.type_annotation, container_kind, container_name, input.name);
         let mut _ci: number = 0;
         loop {
-            if _ci >= layout.diagnostics.length {
-                break;
-            }
+            if _ci >= layout.diagnostics.length { break; }
             diagnostics.push(layout.diagnostics[_ci]);
             _ci += 1;
         }
         let mut field_align: number = layout.align;
-        if field_align <= 0 {
-            field_align = 1;
-        }
+        if field_align <= 0 { field_align = 1; }
         offset = align_to(offset, field_align);
         let descriptor = StructFieldLayoutDescriptor {
             name: input.name,
@@ -313,23 +284,20 @@ fn calculate_record_layout(context: LayoutContext, inputs: LayoutFieldInput[], c
         };
         fields = append_struct_field_layout(fields, descriptor);
         offset += layout.size;
-        if field_align > max_align {
-            max_align = field_align;
-        }
+        if field_align > max_align { max_align = field_align; }
         index += 1;
     }
     let mut final_align: number = max_align;
-    if inputs.length == 0 {
-        final_align = 1;
-    }
-    if final_align <= 0 {
-        final_align = 1;
-    }
+    if inputs.length == 0 { final_align = 1; }
+    if final_align <= 0 { final_align = 1; }
     let mut total_size: number = offset;
-    if final_align > 1 {
-        total_size = align_to(offset, final_align);
-    }
-    return RecordLayoutResult { size: total_size, align: final_align, fields: fields, diagnostics: diagnostics };
+    if final_align > 1 { total_size = align_to(offset, final_align); }
+    return RecordLayoutResult {
+        size: total_size,
+        align: final_align,
+        fields: fields,
+        diagnostics: diagnostics
+    };
 }
 
 fn analyze_type_layout(context: LayoutContext, visiting: string[], type_annotation: string, container_kind: string, container_name: string, field_name: string) -> TypeLayoutInfo {
@@ -337,45 +305,85 @@ fn analyze_type_layout(context: LayoutContext, visiting: string[], type_annotati
     let mut diagnostics: string[] = [];
     if trimmed.length == 0 {
         diagnostics.push("native layout: " + container_kind + " `" + container_name + "` field `" + field_name + "` missing type annotation; defaulting to pointer layout");
-        return TypeLayoutInfo { size: 8, align: 8, diagnostics: diagnostics };
+        return TypeLayoutInfo {
+            size: 8,
+            align: 8,
+            diagnostics: diagnostics
+        };
     }
     if trimmed == "number" {
-        return TypeLayoutInfo { size: 8, align: 8, diagnostics: diagnostics };
+        return TypeLayoutInfo {
+            size: 8,
+            align: 8,
+            diagnostics: diagnostics
+        };
     }
     let mut _if21: boolean = false;
     if trimmed == "int" { _if21 = true; }
     if trimmed == "i64" { _if21 = true; }
     if _if21 {
-        return TypeLayoutInfo { size: 8, align: 8, diagnostics: diagnostics };
+        return TypeLayoutInfo {
+            size: 8,
+            align: 8,
+            diagnostics: diagnostics
+        };
     }
     if trimmed == "i32" {
-        return TypeLayoutInfo { size: 4, align: 4, diagnostics: diagnostics };
+        return TypeLayoutInfo {
+            size: 4,
+            align: 4,
+            diagnostics: diagnostics
+        };
     }
     let mut _if22: boolean = false;
     if trimmed == "boolean" { _if22 = true; }
     if trimmed == "bool" { _if22 = true; }
     if trimmed == "i1" { _if22 = true; }
     if _if22 {
-        return TypeLayoutInfo { size: 1, align: 1, diagnostics: diagnostics };
+        return TypeLayoutInfo {
+            size: 1,
+            align: 1,
+            diagnostics: diagnostics
+        };
     }
     if trimmed == "any" {
-        return TypeLayoutInfo { size: 8, align: 8, diagnostics: diagnostics };
+        return TypeLayoutInfo {
+            size: 8,
+            align: 8,
+            diagnostics: diagnostics
+        };
     }
     if is_array_type(trimmed) {
-        return TypeLayoutInfo { size: 8, align: 8, diagnostics: diagnostics };
+        return TypeLayoutInfo {
+            size: 8,
+            align: 8,
+            diagnostics: diagnostics
+        };
     }
     if trimmed == "string" {
-        return TypeLayoutInfo { size: 8, align: 8, diagnostics: diagnostics };
+        return TypeLayoutInfo {
+            size: 8,
+            align: 8,
+            diagnostics: diagnostics
+        };
     }
     if is_optional_annotation(trimmed) {
         let inner = trim_text(strip_optional_suffix(trimmed));
         if inner.length == 0 {
             diagnostics.push("native layout: " + container_kind + " `" + container_name + "` field `" + field_name + "` optional type missing inner annotation; defaulting to pointer layout");
         }
-        return TypeLayoutInfo { size: 8, align: 8, diagnostics: diagnostics };
+        return TypeLayoutInfo {
+            size: 8,
+            align: 8,
+            diagnostics: diagnostics
+        };
     }
     if contains_string(visiting, trimmed) {
-        return TypeLayoutInfo { size: 8, align: 8, diagnostics: diagnostics };
+        return TypeLayoutInfo {
+            size: 8,
+            align: 8,
+            diagnostics: diagnostics
+        };
     }
 
     // Prefer canonical layouts for well-known compiler/runtime types.
@@ -384,7 +392,11 @@ fn analyze_type_layout(context: LayoutContext, visiting: string[], type_annotati
     // placeholders for by-value fields.
     let canonical = lookup_canonical_type_layout(trimmed);
     if canonical != null {
-        return TypeLayoutInfo { size: canonical.size, align: canonical.align, diagnostics: diagnostics };
+        return TypeLayoutInfo {
+            size: canonical.size,
+            align: canonical.align,
+            diagnostics: diagnostics
+        };
     }
 
     let struct_definition = find_layout_struct_definition(context, trimmed);
@@ -393,13 +405,15 @@ fn analyze_type_layout(context: LayoutContext, visiting: string[], type_annotati
         let record = calculate_record_layout(context, struct_definition.fields, "struct", trimmed, nested_visiting);
         let mut _ci0: number = 0;
         loop {
-            if _ci0 >= record.diagnostics.length {
-                break;
-            }
+            if _ci0 >= record.diagnostics.length { break; }
             diagnostics.push(record.diagnostics[_ci0]);
             _ci0 += 1;
         }
-        return TypeLayoutInfo { size: record.size, align: record.align, diagnostics: diagnostics };
+        return TypeLayoutInfo {
+            size: record.size,
+            align: record.align,
+            diagnostics: diagnostics
+        };
     }
     let enum_definition = find_layout_enum_definition(context, trimmed);
     if enum_definition != null {
@@ -407,30 +421,31 @@ fn analyze_type_layout(context: LayoutContext, visiting: string[], type_annotati
         let aggregate = infer_enum_aggregate_layout(context, trimmed, enum_definition.variants, nested_visiting);
         let mut _ci1: number = 0;
         loop {
-            if _ci1 >= aggregate.diagnostics.length {
-                break;
-            }
+            if _ci1 >= aggregate.diagnostics.length { break; }
             diagnostics.push(aggregate.diagnostics[_ci1]);
             _ci1 += 1;
         }
-        return TypeLayoutInfo { size: aggregate.size, align: aggregate.align, diagnostics: diagnostics };
+        return TypeLayoutInfo {
+            size: aggregate.size,
+            align: aggregate.align,
+            diagnostics: diagnostics
+        };
     }
     diagnostics.push("native layout: " + container_kind + " `" + container_name + "` field `" + field_name + "` uses unsupported type `" + trimmed + "`; defaulting to pointer layout");
     return TypeLayoutInfo { size: 8, align: 8, diagnostics: diagnostics };
 }
 
 // ── Field conversion helpers ─────────────────────────────────────────
-
 fn convert_struct_fields(fields: FieldDeclaration[]) -> LayoutFieldInput[] {
     let mut inputs: LayoutFieldInput[] = [];
     let mut index: number = 0;
     loop {
-        if index >= fields.length {
-            break;
-        }
+        if index >= fields.length { break; }
         let field = fields[index];
         let type_text = field.type_annotation.text;
-        inputs = append_layout_field_input(inputs, LayoutFieldInput { name: field.name, type_annotation: type_text });
+        inputs = append_layout_field_input(inputs, LayoutFieldInput {
+            name: field.name, type_annotation: type_text
+        });
         index += 1;
     }
     return inputs;
@@ -441,7 +456,6 @@ fn convert_variant_fields(variant: EnumVariant) -> LayoutFieldInput[] {
 }
 
 // ── Array append helpers ─────────────────────────────────────────────
-
 fn append_struct_field_layout(values: StructFieldLayoutDescriptor[], value: StructFieldLayoutDescriptor) -> StructFieldLayoutDescriptor[] {
     values.push(value);
     return values;
@@ -478,17 +492,12 @@ fn append_canonical_type_layout(values: CanonicalTypeLayout[], value: CanonicalT
 }
 
 // ── Lookup helpers ───────────────────────────────────────────────────
-
 fn find_layout_struct_definition(context: LayoutContext, name: string) -> LayoutStructDefinition? {
     let mut index: number = 0;
     loop {
-        if index >= context.structs.length {
-            break;
-        }
+        if index >= context.structs.length { break; }
         let definition = context.structs[index];
-        if definition.name == name {
-            return definition;
-        }
+        if definition.name == name { return definition; }
         index += 1;
     }
     return null;
@@ -497,57 +506,118 @@ fn find_layout_struct_definition(context: LayoutContext, name: string) -> Layout
 fn find_layout_enum_definition(context: LayoutContext, name: string) -> LayoutEnumDefinition? {
     let mut index: number = 0;
     loop {
-        if index >= context.enums.length {
-            break;
-        }
+        if index >= context.enums.length { break; }
         let definition = context.enums[index];
-        if definition.name == name {
-            return definition;
-        }
+        if definition.name == name { return definition; }
         index += 1;
     }
     return null;
 }
 
 // ── Canonical type layouts ───────────────────────────────────────────
-
 fn canonical_type_layouts() -> CanonicalTypeLayout[] {
     let mut layouts: CanonicalTypeLayout[] = [];
-    layouts = append_canonical_type_layout(layouts, CanonicalTypeLayout { name: "Token", size: 40, align: 8 });
-    layouts = append_canonical_type_layout(layouts, CanonicalTypeLayout { name: "TokenKind", size: 4, align: 4 });
-    layouts = append_canonical_type_layout(layouts, CanonicalTypeLayout { name: "Program", size: 8, align: 8 });
-    layouts = append_canonical_type_layout(layouts, CanonicalTypeLayout { name: "TypeAnnotation", size: 8, align: 8 });
-    layouts = append_canonical_type_layout(layouts, CanonicalTypeLayout { name: "TypeParameter", size: 24, align: 8 });
-    layouts = append_canonical_type_layout(layouts, CanonicalTypeLayout { name: "Block", size: 24, align: 8 });
-    layouts = append_canonical_type_layout(layouts, CanonicalTypeLayout { name: "SourceSpan", size: 32, align: 8 });
-    layouts = append_canonical_type_layout(layouts, CanonicalTypeLayout { name: "Expression", size: 48, align: 8 });
-    layouts = append_canonical_type_layout(layouts, CanonicalTypeLayout { name: "Parameter", size: 40, align: 8 });
-    layouts = append_canonical_type_layout(layouts, CanonicalTypeLayout { name: "WithClause", size: 48, align: 8 });
-    layouts = append_canonical_type_layout(layouts, CanonicalTypeLayout { name: "ObjectField", size: 56, align: 8 });
-    layouts = append_canonical_type_layout(layouts, CanonicalTypeLayout { name: "ElseBranch", size: 16, align: 8 });
-    layouts = append_canonical_type_layout(layouts, CanonicalTypeLayout { name: "ForClause", size: 104, align: 8 });
-    layouts = append_canonical_type_layout(layouts, CanonicalTypeLayout { name: "MatchCase", size: 80, align: 8 });
-    layouts = append_canonical_type_layout(layouts, CanonicalTypeLayout { name: "ModelProperty", size: 64, align: 8 });
-    layouts = append_canonical_type_layout(layouts, CanonicalTypeLayout { name: "FieldDeclaration", size: 32, align: 8 });
-    layouts = append_canonical_type_layout(layouts, CanonicalTypeLayout { name: "MethodDeclaration", size: 88, align: 8 });
-    layouts = append_canonical_type_layout(layouts, CanonicalTypeLayout { name: "EnumVariant", size: 24, align: 8 });
-    layouts = append_canonical_type_layout(layouts, CanonicalTypeLayout { name: "FunctionSignature", size: 56, align: 8 });
-    layouts = append_canonical_type_layout(layouts, CanonicalTypeLayout { name: "PipelineDeclaration", size: 88, align: 8 });
-    layouts = append_canonical_type_layout(layouts, CanonicalTypeLayout { name: "ToolDeclaration", size: 88, align: 8 });
-    layouts = append_canonical_type_layout(layouts, CanonicalTypeLayout { name: "TestDeclaration", size: 48, align: 8 });
-    layouts = append_canonical_type_layout(layouts, CanonicalTypeLayout { name: "ModelDeclaration", size: 40, align: 8 });
-    layouts = append_canonical_type_layout(layouts, CanonicalTypeLayout { name: "Decorator", size: 16, align: 8 });
-    layouts = append_canonical_type_layout(layouts, CanonicalTypeLayout { name: "DecoratorArgument", size: 56, align: 8 });
-    layouts = append_canonical_type_layout(layouts, CanonicalTypeLayout { name: "NamedSpecifier", size: 8, align: 8 });
+    layouts = append_canonical_type_layout(layouts, CanonicalTypeLayout {
+        name: "Token", size: 40, align: 8
+    });
+    layouts = append_canonical_type_layout(layouts, CanonicalTypeLayout {
+        name: "TokenKind", size: 4, align: 4
+    });
+    layouts = append_canonical_type_layout(layouts, CanonicalTypeLayout {
+        name: "Program", size: 8, align: 8
+    });
+    layouts = append_canonical_type_layout(layouts, CanonicalTypeLayout {
+        name: "TypeAnnotation", size: 8, align: 8
+    });
+    layouts = append_canonical_type_layout(layouts, CanonicalTypeLayout {
+        name: "TypeParameter", size: 24, align: 8
+    });
+    layouts = append_canonical_type_layout(layouts, CanonicalTypeLayout {
+        name: "Block", size: 24, align: 8
+    });
+    layouts = append_canonical_type_layout(layouts, CanonicalTypeLayout {
+        name: "SourceSpan", size: 32, align: 8
+    });
+    layouts = append_canonical_type_layout(layouts, CanonicalTypeLayout {
+        name: "Expression", size: 48, align: 8
+    });
+    layouts = append_canonical_type_layout(layouts, CanonicalTypeLayout {
+        name: "Parameter", size: 40, align: 8
+    });
+    layouts = append_canonical_type_layout(layouts, CanonicalTypeLayout {
+        name: "WithClause", size: 48, align: 8
+    });
+    layouts = append_canonical_type_layout(layouts, CanonicalTypeLayout {
+        name: "ObjectField", size: 56, align: 8
+    });
+    layouts = append_canonical_type_layout(layouts, CanonicalTypeLayout {
+        name: "ElseBranch", size: 16, align: 8
+    });
+    layouts = append_canonical_type_layout(layouts, CanonicalTypeLayout {
+        name: "ForClause", size: 104, align: 8
+    });
+    layouts = append_canonical_type_layout(layouts, CanonicalTypeLayout {
+        name: "MatchCase", size: 80, align: 8
+    });
+    layouts = append_canonical_type_layout(layouts, CanonicalTypeLayout {
+        name: "ModelProperty", size: 64, align: 8
+    });
+    layouts = append_canonical_type_layout(layouts, CanonicalTypeLayout {
+        name: "FieldDeclaration", size: 32, align: 8
+    });
+    layouts = append_canonical_type_layout(layouts, CanonicalTypeLayout {
+        name: "MethodDeclaration", size: 88, align: 8
+    });
+    layouts = append_canonical_type_layout(layouts, CanonicalTypeLayout {
+        name: "EnumVariant", size: 24, align: 8
+    });
+    layouts = append_canonical_type_layout(layouts, CanonicalTypeLayout {
+        name: "FunctionSignature", size: 56, align: 8
+    });
+    layouts = append_canonical_type_layout(layouts, CanonicalTypeLayout {
+        name: "PipelineDeclaration", size: 88, align: 8
+    });
+    layouts = append_canonical_type_layout(layouts, CanonicalTypeLayout {
+        name: "ToolDeclaration", size: 88, align: 8
+    });
+    layouts = append_canonical_type_layout(layouts, CanonicalTypeLayout {
+        name: "TestDeclaration", size: 48, align: 8
+    });
+    layouts = append_canonical_type_layout(layouts, CanonicalTypeLayout {
+        name: "ModelDeclaration", size: 40, align: 8
+    });
+    layouts = append_canonical_type_layout(layouts, CanonicalTypeLayout {
+        name: "Decorator", size: 16, align: 8
+    });
+    layouts = append_canonical_type_layout(layouts, CanonicalTypeLayout {
+        name: "DecoratorArgument", size: 56, align: 8
+    });
+    layouts = append_canonical_type_layout(layouts, CanonicalTypeLayout {
+        name: "NamedSpecifier", size: 8, align: 8
+    });
     // NOTE: `Statement` is an enum; its size is driven by the largest payload variant.
     // Keep this in sync with the stage2 LLVM ABI and `ast.layout-manifest`.
-    layouts = append_canonical_type_layout(layouts, CanonicalTypeLayout { name: "Statement", size: 144, align: 8 });
-    layouts = append_canonical_type_layout(layouts, CanonicalTypeLayout { name: "EnumField", size: 8, align: 8 });
-    layouts = append_canonical_type_layout(layouts, CanonicalTypeLayout { name: "EnumVariantDefinition", size: 8, align: 8 });
-    layouts = append_canonical_type_layout(layouts, CanonicalTypeLayout { name: "EnumType", size: 8, align: 8 });
-    layouts = append_canonical_type_layout(layouts, CanonicalTypeLayout { name: "EnumInstance", size: 8, align: 8 });
-    layouts = append_canonical_type_layout(layouts, CanonicalTypeLayout { name: "StructField", size: 8, align: 8 });
-    layouts = append_canonical_type_layout(layouts, CanonicalTypeLayout { name: "TypeDescriptor", size: 8, align: 8 });
+    layouts = append_canonical_type_layout(layouts, CanonicalTypeLayout {
+        name: "Statement", size: 144, align: 8
+    });
+    layouts = append_canonical_type_layout(layouts, CanonicalTypeLayout {
+        name: "EnumField", size: 8, align: 8
+    });
+    layouts = append_canonical_type_layout(layouts, CanonicalTypeLayout {
+        name: "EnumVariantDefinition", size: 8, align: 8
+    });
+    layouts = append_canonical_type_layout(layouts, CanonicalTypeLayout {
+        name: "EnumType", size: 8, align: 8
+    });
+    layouts = append_canonical_type_layout(layouts, CanonicalTypeLayout {
+        name: "EnumInstance", size: 8, align: 8
+    });
+    layouts = append_canonical_type_layout(layouts, CanonicalTypeLayout {
+        name: "StructField", size: 8, align: 8
+    });
+    layouts = append_canonical_type_layout(layouts, CanonicalTypeLayout {
+        name: "TypeDescriptor", size: 8, align: 8
+    });
     return layouts;
 }
 
@@ -555,39 +625,27 @@ fn lookup_canonical_type_layout(name: string) -> CanonicalTypeLayout? {
     let layouts = canonical_type_layouts();
     let mut index: number = 0;
     loop {
-        if index >= layouts.length {
-            break;
-        }
+        if index >= layouts.length { break; }
         let layout = layouts[index];
-        if layout.name == name {
-            return layout;
-        }
+        if layout.name == name { return layout; }
         index += 1;
     }
     return null;
 }
 
 // ── Alignment arithmetic ─────────────────────────────────────────────
-
 fn align_to(value: number, alignment: number) -> number {
-    if alignment <= 1 {
-        return value;
-    }
+    if alignment <= 1 { return value; }
     let mut remainder: number = value;
     loop {
-        if remainder < alignment {
-            break;
-        }
+        if remainder < alignment { break; }
         remainder -= alignment;
     }
-    if remainder == 0 {
-        return value;
-    }
+    if remainder == 0 { return value; }
     return value + (alignment - remainder);
 }
 
 // ── Manifest generation ──────────────────────────────────────────────
-
 fn generate_layout_manifest(program: Program, context: LayoutContext) -> NativeArtifact {
     let mut builder = builder_new();
     builder = builder_emit_line(builder, "; Sailfin Layout Manifest");
@@ -597,17 +655,13 @@ fn generate_layout_manifest(program: Program, context: LayoutContext) -> NativeA
     // Emit struct layouts
     let mut index: number = 0;
     loop {
-        if index >= program.statements.length {
-            break;
-        }
+        if index >= program.statements.length { break; }
         let statement = program.statements[index];
         if statement.variant == "StructDeclaration" {
             let result = compute_struct_layout_lines(context, statement.name, statement.fields);
             let mut line_index: number = 0;
             loop {
-                if line_index >= result.lines.length {
-                    break;
-                }
+                if line_index >= result.lines.length { break; }
                 builder = builder_emit_line(builder, result.lines[line_index]);
                 line_index += 1;
             }
@@ -619,17 +673,13 @@ fn generate_layout_manifest(program: Program, context: LayoutContext) -> NativeA
     // Emit enum layouts
     index = 0;
     loop {
-        if index >= program.statements.length {
-            break;
-        }
+        if index >= program.statements.length { break; }
         let statement = program.statements[index];
         if statement.variant == "EnumDeclaration" {
             let result = compute_enum_layout_lines(context, statement);
             let mut line_index: number = 0;
             loop {
-                if line_index >= result.lines.length {
-                    break;
-                }
+                if line_index >= result.lines.length { break; }
                 builder = builder_emit_line(builder, result.lines[line_index]);
                 line_index += 1;
             }
@@ -646,15 +696,11 @@ fn generate_layout_manifest(program: Program, context: LayoutContext) -> NativeA
 }
 
 fn emit_layout_lines(state: NativeState, lines: string[]) -> NativeState {
-    if lines.length == 0 {
-        return state;
-    }
+    if lines.length == 0 { return state; }
     let mut current = state;
     let mut index: number = 0;
     loop {
-        if index >= lines.length {
-            break;
-        }
+        if index >= lines.length { break; }
         current = state_emit_line(current, lines[index]);
         index += 1;
     }

--- a/compiler/src/emit_native_state.sfn
+++ b/compiler/src/emit_native_state.sfn
@@ -3,12 +3,10 @@
 // State management, text builder, and shared utility functions for the
 // native emitter.  Extracted from emit_native.sfn to reduce per-file
 // memory footprint during self-hosting compilation.
-
 import { TypeAnnotation } from "./ast";
 import { substring } from "./string_utils";
 
 // ── Data structures ──────────────────────────────────────────────────
-
 struct TextBuilder {
     lines: string[];
     indent: number;
@@ -53,7 +51,6 @@ struct LayoutEnumDefinition {
 }
 
 // ── Builder functions ────────────────────────────────────────────────
-
 fn builder_new() -> TextBuilder {
     return TextBuilder { lines: [], indent: 0 };
 }
@@ -62,9 +59,7 @@ fn builder_emit_line(builder: TextBuilder, line: string) -> TextBuilder {
     let mut prefix: string = "";
     let mut count: number = 0;
     loop {
-        if count >= builder.indent {
-            break;
-        }
+        if count >= builder.indent { break; }
         prefix = prefix + "    ";
         count += 1;
     }
@@ -79,32 +74,32 @@ fn builder_emit_blank(builder: TextBuilder) -> TextBuilder {
 }
 
 fn builder_push_indent(builder: TextBuilder) -> TextBuilder {
-    return TextBuilder { lines: builder.lines, indent: builder.indent + 1 };
+    return TextBuilder {
+        lines: builder.lines,
+        indent: builder.indent + 1
+    };
 }
 
 fn builder_pop_indent(builder: TextBuilder) -> TextBuilder {
     let mut indent = builder.indent;
-    if indent > 0 {
-        indent -= 1;
-    }
+    if indent > 0 { indent -= 1; }
     return TextBuilder { lines: builder.lines, indent: indent };
 }
 
 fn builder_to_string(builder: TextBuilder) -> string {
-    if builder.lines == null {
-        return "";
-    }
+    if builder.lines == null { return ""; }
     let content = join_with_separator(builder.lines, "\n");
-    if content.length == 0 {
-        return "";
-    }
+    if content.length == 0 { return ""; }
     return content + "\n";
 }
 
 // ── State functions ──────────────────────────────────────────────────
-
 fn state_new(context: LayoutContext) -> NativeState {
-    return NativeState { builder: builder_new(), diagnostics: [], layout_context: context };
+    return NativeState {
+        builder: builder_new(),
+        diagnostics: [],
+        layout_context: context
+    };
 }
 
 fn state_emit_line(state: NativeState, line: string) -> NativeState {
@@ -149,30 +144,27 @@ fn state_add_diagnostic(state: NativeState, message: string) -> NativeState {
 }
 
 fn state_merge_diagnostics(state: NativeState, entries: string[]) -> NativeState {
-    if entries.length == 0 {
-        return state;
-    }
+    if entries.length == 0 { return state; }
     let mut combined: string[] = state.diagnostics;
     let mut index: number = 0;
     loop {
-        if index >= entries.length {
-            break;
-        }
+        if index >= entries.length { break; }
         combined.push(entries[index]);
         index += 1;
     }
-    return NativeState { builder: state.builder, diagnostics: combined, layout_context: state.layout_context };
+    return NativeState {
+        builder: state.builder,
+        diagnostics: combined,
+        layout_context: state.layout_context
+    };
 }
 
 // ── String / array utility functions ─────────────────────────────────
-
 fn trim_text(value: string) -> string {
     let mut start: number = 0;
     let mut end: number = value.length;
     loop {
-        if start >= end {
-            break;
-        }
+        if start >= end { break; }
         let ch = value[start];
         if is_trim_char(ch) {
             start += 1;
@@ -181,9 +173,7 @@ fn trim_text(value: string) -> string {
         break;
     }
     loop {
-        if end <= start {
-            break;
-        }
+        if end <= start { break; }
         let ch = value[end - 1];
         if is_trim_char(ch) {
             end -= 1;
@@ -191,12 +181,10 @@ fn trim_text(value: string) -> string {
         }
         break;
     }
-        if start == 0 {
-            if end == value.length {
-                return value;
-            }
-        }
-        return substring(value, start, end);
+    if start == 0 {
+        if end == value.length { return value; }
+    }
+    return substring(value, start, end);
 }
 
 fn is_trim_char(ch: string) -> boolean {
@@ -211,9 +199,7 @@ fn is_trim_char(ch: string) -> boolean {
 fn trim_right(value: string) -> string {
     let mut end: number = value.length;
     loop {
-        if end <= 0 {
-            break;
-        }
+        if end <= 0 { break; }
         let ch = value[end - 1];
         let mut _if25: boolean = false;
         if ch == " " { _if25 = true; }
@@ -224,51 +210,35 @@ fn trim_right(value: string) -> string {
         }
         break;
     }
-    if end == value.length {
-        return value;
-    }
+    if end == value.length { return value; }
     return substring(value, 0, end);
 }
 
 fn ends_with(value: string, suffix: string) -> boolean {
-    if suffix.length == 0 {
-        return true;
-    }
-    if value.length < suffix.length {
-        return false;
-    }
+    if suffix.length == 0 { return true; }
+    if value.length < suffix.length { return false; }
     let start = value.length - suffix.length;
     let mut index: number = 0;
     loop {
-        if index >= suffix.length {
-            break;
-        }
+        if index >= suffix.length { break; }
         let _cmp_pos = start + index;
-        if value[_cmp_pos] != suffix[index] {
-            return false;
-        }
+        if value[_cmp_pos] != suffix[index] { return false; }
         index += 1;
     }
     return true;
 }
 
 fn number_to_string(value: number) -> string {
-    if value == 0 {
-        return "0";
-    }
+    if value == 0 { return "0"; }
     let mut remaining: number = value;
     let mut output: string = "";
     let digits = "0123456789";
     loop {
-        if remaining <= 0 {
-            break;
-        }
+        if remaining <= 0 { break; }
         let mut temp: number = remaining;
         let mut quotient: number = 0;
         loop {
-            if temp < 10 {
-                break;
-            }
+            if temp < 10 { break; }
             temp -= 10;
             quotient += 1;
         }
@@ -290,20 +260,12 @@ fn quote_string(value: string) -> string {
     let mut chunk_start: number = 0;
     let mut index: number = 0;
     loop {
-        if index >= value.length {
-            break;
-        }
+        if index >= value.length { break; }
         let ch = substring(value, index, index + 1);
         let mut esc: string = "";
-        if ch == "\"" {
-            esc = "\\\"";
-        } else if ch == "\\" {
-            esc = "\\\\";
-        } else if ch == "\n" {
+        if ch == "\"" { esc = "\\\""; } else if ch == "\\" { esc = "\\\\"; } else if ch == "\n" {
             esc = "\\n";
-        } else if ch == "\r" {
-            esc = "\\r";
-        } else if ch == "\t" {
+        } else if ch == "\r" { esc = "\\r"; } else if ch == "\t" {
             esc = "\\t";
         }
         if esc.length > 0 {
@@ -322,9 +284,7 @@ fn quote_string(value: string) -> string {
     let mut result: string = chunks[0];
     let mut i: number = 1;
     loop {
-        if i >= chunks.length {
-            break;
-        }
+        if i >= chunks.length { break; }
         result = result + chunks[i];
         i += 1;
     }
@@ -332,46 +292,28 @@ fn quote_string(value: string) -> string {
 }
 
 fn escape_string_char(ch: string) -> string {
-    if ch == "\"" {
-        return "\\\"";
-    }
-    if ch == "\\" {
-        return "\\\\";
-    }
-    if ch == "\n" {
-        return "\\n";
-    }
-    if ch == "\r" {
-        return "\\r";
-    }
-    if ch == "\t" {
-        return "\\t";
-    }
+    if ch == "\"" { return "\\\""; }
+    if ch == "\\" { return "\\\\"; }
+    if ch == "\n" { return "\\n"; }
+    if ch == "\r" { return "\\r"; }
+    if ch == "\t" { return "\\t"; }
     return ch;
 }
 
 fn append_string(values: string[], value: string) -> string[] {
     let mut out = values;
-    if out == null {
-        out = [];
-    }
+    if out == null { out = []; }
     out.push(value);
     return out;
 }
 
 fn join_with_separator(values: string[], separator: string) -> string {
-    if values == null {
-        return "";
-    }
-    if values.length == 0 {
-        return "";
-    }
+    if values == null { return ""; }
+    if values.length == 0 { return ""; }
     let mut result: string = values[0];
     let mut index: number = 1;
     loop {
-        if index >= values.length {
-            break;
-        }
+        if index >= values.length { break; }
         result = result + separator + values[index];
         index += 1;
     }
@@ -379,15 +321,11 @@ fn join_with_separator(values: string[], separator: string) -> string {
 }
 
 fn join_type_annotations(values: TypeAnnotation[]) -> string {
-    if values.length == 0 {
-        return "";
-    }
+    if values.length == 0 { return ""; }
     let mut parts: string[] = [];
     let mut index: number = 0;
     loop {
-        if index >= values.length {
-            break;
-        }
+        if index >= values.length { break; }
         parts.push(values[index].text);
         index += 1;
     }
@@ -397,21 +335,15 @@ fn join_type_annotations(values: TypeAnnotation[]) -> string {
 fn contains_string(values: string[], target: string) -> boolean {
     let mut index: number = 0;
     loop {
-        if index >= values.length {
-            break;
-        }
-        if values[index] == target {
-            return true;
-        }
+        if index >= values.length { break; }
+        if values[index] == target { return true; }
         index += 1;
     }
     return false;
 }
 
 fn append_unique(values: string[], value: string) -> string[] {
-    if contains_string(values, value) {
-        return values;
-    }
+    if contains_string(values, value) { return values; }
     return append_string(values, value);
 }
 
@@ -424,8 +356,6 @@ fn is_optional_annotation(type_annotation: string) -> boolean {
 }
 
 fn strip_optional_suffix(type_annotation: string) -> string {
-    if type_annotation.length == 0 {
-        return type_annotation;
-    }
+    if type_annotation.length == 0 { return type_annotation; }
     return substring(type_annotation, 0, type_annotation.length - 1);
 }

--- a/compiler/src/emit_native_state.sfn
+++ b/compiler/src/emit_native_state.sfn
@@ -106,7 +106,7 @@ fn state_emit_line(state: NativeState, line: string) -> NativeState {
     return NativeState {
         builder: builder_emit_line(state.builder, line),
         diagnostics: state.diagnostics,
-        layout_context: state.layout_context,
+        layout_context: state.layout_context
     };
 }
 
@@ -114,7 +114,7 @@ fn state_emit_blank(state: NativeState) -> NativeState {
     return NativeState {
         builder: builder_emit_blank(state.builder),
         diagnostics: state.diagnostics,
-        layout_context: state.layout_context,
+        layout_context: state.layout_context
     };
 }
 
@@ -122,7 +122,7 @@ fn state_push_indent(state: NativeState) -> NativeState {
     return NativeState {
         builder: builder_push_indent(state.builder),
         diagnostics: state.diagnostics,
-        layout_context: state.layout_context,
+        layout_context: state.layout_context
     };
 }
 
@@ -130,7 +130,7 @@ fn state_pop_indent(state: NativeState) -> NativeState {
     return NativeState {
         builder: builder_pop_indent(state.builder),
         diagnostics: state.diagnostics,
-        layout_context: state.layout_context,
+        layout_context: state.layout_context
     };
 }
 
@@ -139,7 +139,7 @@ fn state_add_diagnostic(state: NativeState, message: string) -> NativeState {
     return NativeState {
         builder: builder_emit_line(state.builder, "; " + message),
         diagnostics: diagnostics,
-        layout_context: state.layout_context,
+        layout_context: state.layout_context
     };
 }
 

--- a/compiler/src/emitter_sailfin.sfn
+++ b/compiler/src/emitter_sailfin.sfn
@@ -5,63 +5,58 @@
 // code. The intent is to make the self-hosted compiler capable of emitting
 // Sailfin that can be re-ingested by the bootstrap stage0 toolchain while we
 // close the bootstrap loop.
-
 import {
     Block,
     Decorator,
     DecoratorArgument,
+    ElseBranch,
     EnumVariant,
+    ExportSpecifier,
     Expression,
     FieldDeclaration,
     ForClause,
     FunctionSignature,
+    ImportSpecifier,
     MatchCase,
     MethodDeclaration,
     ModelProperty,
     Parameter,
     Program,
     Statement,
-    ImportSpecifier,
-    ExportSpecifier,
     TypeAnnotation,
     TypeParameter,
     WithClause,
-    ElseBranch,
 } from "./ast";
-import { Token } from "./token";
+import {
+    format_expression,
+    format_initializer,
+    format_optional_expression,
+    format_type_annotation,
+} from "./emitter_sailfin_expr";
 import {
     TextBuilder,
-    builder_new,
-    builder_emit_line,
     builder_emit_blank,
-    builder_push_indent,
+    builder_emit_line,
+    builder_new,
     builder_pop_indent,
+    builder_push_indent,
     builder_to_string,
-    join_with_separator,
-    format_test_name,
-    trim_block_body,
     collapse_whitespace,
+    format_test_name,
+    join_with_separator,
     tokens_to_source,
+    trim_block_body,
 } from "./emitter_sailfin_utils";
-import {
-    format_expression, format_optional_expression,
-    format_type_annotation, format_initializer,
-} from "./emitter_sailfin_expr";
+import { Token } from "./token";
 
 fn is_import_like(statement: Statement) -> boolean {
-    if statement.variant == "ImportDeclaration" {
-        return true;
-    }
-    if statement.variant == "ExportDeclaration" {
-        return true;
-    }
+    if statement.variant == "ImportDeclaration" { return true; }
+    if statement.variant == "ExportDeclaration" { return true; }
     return false;
 }
 
 fn maybe_emit_blank(builder: TextBuilder, should_emit: boolean) -> TextBuilder {
-    if should_emit {
-        return builder_emit_blank(builder);
-    }
+    if should_emit { return builder_emit_blank(builder); }
     return builder;
 }
 
@@ -75,9 +70,7 @@ fn emit_program(program: Program) -> string {
     let mut has_runtime_import: boolean = false;
     let mut scan: number = 0;
     loop {
-        if scan >= program.statements.length {
-            break;
-        }
+        if scan >= program.statements.length { break; }
         let statement = program.statements[scan];
         if statement.variant == "ImportDeclaration" {
             if statement.source == "sailfin/runtime" {
@@ -97,9 +90,7 @@ fn emit_program(program: Program) -> string {
 
     let mut index: number = 0;
     loop {
-        if index >= program.statements.length {
-            break;
-        }
+        if index >= program.statements.length { break; }
 
         let statement = program.statements[index];
         let is_import = is_import_like(statement);
@@ -113,9 +104,7 @@ fn emit_program(program: Program) -> string {
         let already_emitted_something = _let26;
         let mut _let27: boolean = false;
         if already_emitted_something {
-            if !last_emitted_was_import {
-                _let27 = true;
-            } else if !is_import {
+            if !last_emitted_was_import { _let27 = true; } else if !is_import {
                 _let27 = true;
             }
         }
@@ -194,33 +183,20 @@ fn emit_export(builder: TextBuilder, specifiers: ExportSpecifier[], source: stri
 
 fn emit_variable(builder: TextBuilder, statement: Statement) -> TextBuilder {
     let mut prefix: string = "let ";
-    if statement.mutable {
-        prefix = prefix + "mut ";
-    }
+    if statement.mutable { prefix = prefix + "mut "; }
     prefix = prefix + statement.name;
     prefix = prefix + format_type_annotation(statement.type_annotation);
     prefix = prefix + format_initializer(statement.initializer);
     return builder_emit_line(builder, prefix + ";");
 }
 
-fn emit_function(
-    builder: TextBuilder,
-    signature: FunctionSignature,
-    body: Block,
-    decorators: Decorator[]
-) -> TextBuilder {
+fn emit_function(builder: TextBuilder, signature: FunctionSignature, body: Block, decorators: Decorator[]) -> TextBuilder {
     let mut current = emit_decorators(builder, decorators);
     let header = format_function_header(signature);
     return emit_block_with_header(current, header, body);
 }
 
-fn emit_callable(
-    builder: TextBuilder,
-    keyword: string,
-    signature: FunctionSignature,
-    body: Block,
-    decorators: Decorator[]
-) -> TextBuilder {
+fn emit_callable(builder: TextBuilder, keyword: string, signature: FunctionSignature, body: Block, decorators: Decorator[]) -> TextBuilder {
     let mut current = emit_decorators(builder, decorators);
     let header = format_callable_header(keyword, signature);
     return emit_block_with_header(current, header, body);
@@ -231,9 +207,7 @@ fn emit_test(builder: TextBuilder, statement: Statement) -> TextBuilder {
     let name = format_test_name(statement.name);
     let effects = format_effects(statement.effects);
     let mut header: string = "test " + name;
-    if effects.length > 0 {
-        header = header + " " + effects;
-    }
+    if effects.length > 0 { header = header + " " + effects; }
     return emit_block_with_header(current, header, statement.body);
 }
 
@@ -241,15 +215,11 @@ fn emit_model(builder: TextBuilder, statement: Statement) -> TextBuilder {
     let mut current = emit_decorators(builder, statement.decorators);
     let mut header: string = "model " + statement.name + " : " + statement.model_type.text;
     let effects = format_effects(statement.effects);
-    if effects.length > 0 {
-        header = header + " " + effects;
-    }
+    if effects.length > 0 { header = header + " " + effects; }
     current = emit_block_header(current, header);
     let mut index: number = 0;
     loop {
-        if index >= statement.properties.length {
-            break;
-        }
+        if index >= statement.properties.length { break; }
         let property = statement.properties[index];
         let line = property.name + " = " + format_expression(property.value) + ";";
         current = builder_emit_line(current, line);
@@ -266,9 +236,7 @@ fn format_import_specifiers(specifiers: ImportSpecifier[]) -> string {
     let mut parts: string[] = [];
     let mut index: number = 0;
     loop {
-        if index >= specifiers.length {
-            break;
-        }
+        if index >= specifiers.length { break; }
         let entry = format_specifier_entry(specifiers[index].name, specifiers[index].alias);
         parts.push(entry);
         index += 1;
@@ -280,9 +248,7 @@ fn format_export_specifiers(specifiers: ExportSpecifier[]) -> string {
     let mut parts: string[] = [];
     let mut index: number = 0;
     loop {
-        if index >= specifiers.length {
-            break;
-        }
+        if index >= specifiers.length { break; }
         let entry = format_specifier_entry(specifiers[index].name, specifiers[index].alias);
         parts.push(entry);
         index += 1;
@@ -294,9 +260,7 @@ fn format_specifier_entry(name: string, alias: string?) -> string {
     let mut _if28: boolean = false;
     if alias == null { _if28 = true; }
     if alias.length == 0 { _if28 = true; }
-    if _if28 {
-        return name;
-    }
+    if _if28 { return name; }
     return name + " as " + alias;
 }
 
@@ -315,9 +279,7 @@ fn emit_interface(builder: TextBuilder, statement: Statement) -> TextBuilder {
     current = emit_block_start(current);
     let mut index: number = 0;
     loop {
-        if index >= statement.members.length {
-            break;
-        }
+        if index >= statement.members.length { break; }
         let signature = statement.members[index];
         let line = format_signature_line("fn", signature) + ";";
         current = builder_emit_line(current, line);
@@ -334,9 +296,7 @@ fn emit_enum(builder: TextBuilder, statement: Statement) -> TextBuilder {
     current = emit_block_header(current, header);
     let mut index: number = 0;
     loop {
-        if index >= statement.variants.length {
-            break;
-        }
+        if index >= statement.variants.length { break; }
         let variant = statement.variants[index];
         current = builder_emit_line(current, format_enum_variant(variant) + ";");
         index += 1;
@@ -356,18 +316,14 @@ fn emit_struct(builder: TextBuilder, statement: Statement) -> TextBuilder {
 
     let mut field_index: number = 0;
     loop {
-        if field_index >= statement.fields.length {
-            break;
-        }
+        if field_index >= statement.fields.length { break; }
         current = builder_emit_line(current, format_field(statement.fields[field_index]) + ";");
         field_index += 1;
     }
 
     let mut method_index: number = 0;
     loop {
-        if method_index >= statement.methods.length {
-            break;
-        }
+        if method_index >= statement.methods.length { break; }
         let method = statement.methods[method_index];
         current = emit_decorators(current, method.decorators);
         current = emit_block_with_header(current, format_method_header(method.signature), method.body);
@@ -407,9 +363,7 @@ fn emit_block_body(builder: TextBuilder, block: Block) -> TextBuilder {
     let mut current = builder;
     let mut index: number = 0;
     loop {
-        if index >= block.statements.length {
-            break;
-        }
+        if index >= block.statements.length { break; }
         current = emit_block_statement(current, block.statements[index]);
         index += 1;
     }
@@ -483,12 +437,8 @@ fn emit_with(builder: TextBuilder, statement: Statement) -> TextBuilder {
     let mut line: string = "with ";
     let mut index: number = 0;
     loop {
-        if index >= statement.clauses.length {
-            break;
-        }
-        if index > 0 {
-            line = line + ", ";
-        }
+        if index >= statement.clauses.length { break; }
+        if index > 0 { line = line + ", "; }
         line = line + format_expression(statement.clauses[index].expression);
         index += 1;
     }
@@ -501,9 +451,7 @@ fn emit_if(builder: TextBuilder, statement: Statement) -> TextBuilder {
     let line = "if " + format_expression(statement.condition);
     current = emit_block_with_header(current, line, statement.then_block);
     let else_branch = statement.else_branch;
-    if else_branch == null {
-        return current;
-    }
+    if else_branch == null { return current; }
     return emit_else_branch(current, else_branch);
 }
 
@@ -511,15 +459,11 @@ fn emit_else_branch(builder: TextBuilder, branch: ElseBranch) -> TextBuilder {
     let body = branch.body;
     if body == null {
         let nested = branch.statement;
-        if nested == null {
-            return builder;
-        }
+        if nested == null { return builder; }
         if nested.variant == "IfStatement" {
             let after = emit_block_with_header(builder, "else if " + format_expression(nested.condition), nested.then_block);
             let nested_else = nested.else_branch;
-            if nested_else == null {
-                return after;
-            }
+            if nested_else == null { return after; }
             return emit_else_branch(after, nested_else);
         }
         let current = builder_emit_line(builder, "else");
@@ -540,9 +484,7 @@ fn emit_match(builder: TextBuilder, statement: Statement) -> TextBuilder {
     current = emit_block_header(current, header);
     let mut index: number = 0;
     loop {
-        if index >= statement.cases.length {
-            break;
-        }
+        if index >= statement.cases.length { break; }
         current = emit_match_case(current, statement.cases[index]);
         index += 1;
     }
@@ -552,9 +494,7 @@ fn emit_match(builder: TextBuilder, statement: Statement) -> TextBuilder {
 fn emit_match_case(builder: TextBuilder, case: MatchCase) -> TextBuilder {
     let mut line: string = "case " + format_expression(case.pattern);
     let guard = case.guard;
-    if guard == null {
-        line = line + " => {";
-    } else {
+    if guard == null { line = line + " => {"; } else {
         line = line + " if " + format_optional_expression(guard) + " => {";
     }
     let mut current = builder_emit_line(builder, line);
@@ -597,9 +537,7 @@ fn emit_decorators(builder: TextBuilder, decorators: Decorator[]) -> TextBuilder
     let mut current = builder;
     let mut index: number = 0;
     loop {
-        if index >= decorators.length {
-            break;
-        }
+        if index >= decorators.length { break; }
         current = builder_emit_line(current, format_decorator(decorators[index]));
         index += 1;
     }
@@ -608,15 +546,11 @@ fn emit_decorators(builder: TextBuilder, decorators: Decorator[]) -> TextBuilder
 
 fn format_decorator(decorator: Decorator) -> string {
     let mut line: string = "@" + decorator.name;
-    if decorator.arguments.length == 0 {
-        return line;
-    }
+    if decorator.arguments.length == 0 { return line; }
     let mut parts: string[] = [];
     let mut index: number = 0;
     loop {
-        if index >= decorator.arguments.length {
-            break;
-        }
+        if index >= decorator.arguments.length { break; }
         parts.push(format_decorator_argument(decorator.arguments[index]));
         index += 1;
     }
@@ -625,9 +559,7 @@ fn format_decorator(decorator: Decorator) -> string {
 
 fn format_decorator_argument(argument: DecoratorArgument) -> string {
     let value = format_expression(argument.expression);
-    if argument.name == null {
-        return value;
-    }
+    if argument.name == null { return value; }
     return argument.name + ": " + value;
 }
 
@@ -637,9 +569,7 @@ fn format_for_clause(clause: ForClause) -> string {
     let mut _if29: boolean = false;
     if target.length == 0 { _if29 = true; }
     if iterable.length == 0 { _if29 = true; }
-    if _if29 {
-        return tokens_to_source(clause.tokens);
-    }
+    if _if29 { return tokens_to_source(clause.tokens); }
     return target + " in " + iterable;
 }
 
@@ -657,9 +587,7 @@ fn format_callable_header(keyword: string, signature: FunctionSignature) -> stri
 
 fn format_signature_line(keyword: string, signature: FunctionSignature) -> string {
     let mut prefix: string = "";
-    if signature.is_async {
-        prefix = "async ";
-    }
+    if signature.is_async { prefix = "async "; }
     let mut line: string = prefix + keyword + " " + signature.name;
     line = line + format_type_parameters(signature.type_parameters);
     line = line + "(" + format_parameters(signature.parameters) + ")";
@@ -667,32 +595,24 @@ fn format_signature_line(keyword: string, signature: FunctionSignature) -> strin
         line = line + " -> " + signature.return_type.text;
     }
     let effects = format_effects(signature.effects);
-    if effects.length > 0 {
-        line = line + " " + effects;
-    }
+    if effects.length > 0 { line = line + " " + effects; }
     return line;
 }
 
 fn format_field(field: FieldDeclaration) -> string {
     let mut line: string = "";
-    if field.mutable {
-        line = line + "mut ";
-    }
+    if field.mutable { line = line + "mut "; }
     line = line + field.name;
     line = line + ": " + field.type_annotation.text;
     return line;
 }
 
 fn format_enum_variant(variant: EnumVariant) -> string {
-    if variant.fields.length == 0 {
-        return variant.name;
-    }
+    if variant.fields.length == 0 { return variant.name; }
     let mut parts: string[] = [];
     let mut index: number = 0;
     loop {
-        if index >= variant.fields.length {
-            break;
-        }
+        if index >= variant.fields.length { break; }
         parts.push(format_field(variant.fields[index]));
         index += 1;
     }
@@ -700,15 +620,11 @@ fn format_enum_variant(variant: EnumVariant) -> string {
 }
 
 fn format_parameters(parameters: Parameter[]) -> string {
-    if parameters.length == 0 {
-        return "";
-    }
+    if parameters.length == 0 { return ""; }
     let mut parts: string[] = [];
     let mut index: number = 0;
     loop {
-        if index >= parameters.length {
-            break;
-        }
+        if index >= parameters.length { break; }
         parts.push(format_parameter(parameters[index]));
         index += 1;
     }
@@ -717,9 +633,7 @@ fn format_parameters(parameters: Parameter[]) -> string {
 
 fn format_parameter(parameter: Parameter) -> string {
     let mut line: string = "";
-    if parameter.mutable {
-        line = "mut " + parameter.name;
-    } else {
+    if parameter.mutable { line = "mut " + parameter.name; } else {
         line = parameter.name;
     }
     if parameter.type_annotation != null {
@@ -732,15 +646,11 @@ fn format_parameter(parameter: Parameter) -> string {
 }
 
 fn format_type_parameters(parameters: TypeParameter[]) -> string {
-    if parameters.length == 0 {
-        return "";
-    }
+    if parameters.length == 0 { return ""; }
     let mut names: string[] = [];
     let mut index: number = 0;
     loop {
-        if index >= parameters.length {
-            break;
-        }
+        if index >= parameters.length { break; }
         let parameter = parameters[index];
         let mut part: string = parameter.name;
         if parameter.bound != null {
@@ -753,25 +663,18 @@ fn format_type_parameters(parameters: TypeParameter[]) -> string {
 }
 
 fn format_effects(effects: string[]) -> string {
-    if effects.length == 0 {
-        return "";
-    }
+    if effects.length == 0 { return ""; }
     return "![" + join_with_separator(effects, ", ") + "]";
 }
 
 fn join_type_annotations(values: TypeAnnotation[]) -> string {
-    if values.length == 0 {
-        return "";
-    }
+    if values.length == 0 { return ""; }
     let mut parts: string[] = [];
     let mut index: number = 0;
     loop {
-        if index >= values.length {
-            break;
-        }
+        if index >= values.length { break; }
         parts.push(values[index].text);
         index += 1;
     }
     return join_with_separator(parts, ", ");
 }
-

--- a/compiler/src/emitter_sailfin.sfn
+++ b/compiler/src/emitter_sailfin.sfn
@@ -25,13 +25,13 @@ import {
     Statement,
     TypeAnnotation,
     TypeParameter,
-    WithClause,
+    WithClause
 } from "./ast";
 import {
     format_expression,
     format_initializer,
     format_optional_expression,
-    format_type_annotation,
+    format_type_annotation
 } from "./emitter_sailfin_expr";
 import {
     TextBuilder,
@@ -45,7 +45,7 @@ import {
     format_test_name,
     join_with_separator,
     tokens_to_source,
-    trim_block_body,
+    trim_block_body
 } from "./emitter_sailfin_utils";
 import { Token } from "./token";
 
@@ -160,7 +160,8 @@ fn emit_statement(builder: TextBuilder, statement: Statement) -> TextBuilder {
         let comment = "// original: " + collapse_whitespace(statement.text);
         return builder_emit_line(builder, comment);
     }
-    return builder_emit_line(builder, "// TODO: unsupported statement: " + statement.variant);
+    return builder_emit_line(builder, "// TODO: unsupported statement: "
+        + statement.variant);
 }
 
 fn emit_import(builder: TextBuilder, specifiers: ImportSpecifier[], source: string) -> TextBuilder {
@@ -221,7 +222,8 @@ fn emit_model(builder: TextBuilder, statement: Statement) -> TextBuilder {
     loop {
         if index >= statement.properties.length { break; }
         let property = statement.properties[index];
-        let line = property.name + " = " + format_expression(property.value) + ";";
+        let line = property.name + " = " + format_expression(property.value)
+            + ";";
         current = builder_emit_line(current, line);
         index += 1;
     }
@@ -317,7 +319,8 @@ fn emit_struct(builder: TextBuilder, statement: Statement) -> TextBuilder {
     let mut field_index: number = 0;
     loop {
         if field_index >= statement.fields.length { break; }
-        current = builder_emit_line(current, format_field(statement.fields[field_index]) + ";");
+        current = builder_emit_line(current, format_field(statement.fields[field_index])
+            + ";");
         field_index += 1;
     }
 
@@ -389,7 +392,8 @@ fn emit_block_statement(builder: TextBuilder, statement: Statement) -> TextBuild
         return builder_emit_line(builder, "continue;");
     }
     if statement.variant == "ExpressionStatement" {
-        return builder_emit_line(builder, format_expression(statement.expression) + ";");
+        return builder_emit_line(builder, format_expression(statement.expression)
+            + ";");
     }
     if statement.variant == "VariableDeclaration" {
         return emit_variable(builder, statement);
@@ -422,7 +426,8 @@ fn emit_block_statement(builder: TextBuilder, statement: Statement) -> TextBuild
     if statement.variant == "MatchStatement" {
         return emit_match(builder, statement);
     }
-    return builder_emit_line(builder, "// TODO: unsupported block statement: " + statement.variant);
+    return builder_emit_line(builder, "// TODO: unsupported block statement: "
+        + statement.variant);
 }
 
 fn emit_prompt(builder: TextBuilder, statement: Statement) -> TextBuilder {
@@ -461,7 +466,8 @@ fn emit_else_branch(builder: TextBuilder, branch: ElseBranch) -> TextBuilder {
         let nested = branch.statement;
         if nested == null { return builder; }
         if nested.variant == "IfStatement" {
-            let after = emit_block_with_header(builder, "else if " + format_expression(nested.condition), nested.then_block);
+            let after = emit_block_with_header(builder, "else if "
+                + format_expression(nested.condition), nested.then_block);
             let nested_else = nested.else_branch;
             if nested_else == null { return after; }
             return emit_else_branch(after, nested_else);

--- a/compiler/src/emitter_sailfin_expr.sfn
+++ b/compiler/src/emitter_sailfin_expr.sfn
@@ -2,65 +2,53 @@
 //
 // Expression formatting helpers for the Sailfin-to-Sailfin code emitter.
 // Extracted from emitter_sailfin.sfn to keep modules focused and under size.
-
 import {
-    Expression, Parameter, Statement, Block, TypeAnnotation,
+    Block,
+    Expression,
+    Parameter,
+    Statement,
+    TypeAnnotation,
 } from "./ast";
 import {
-    join_with_separator, quote_string, trim_text, collapse_whitespace,
+    collapse_whitespace,
+    join_with_separator,
+    quote_string,
+    trim_text,
 } from "./emitter_sailfin_utils";
 
 fn format_optional_expression(expression: Expression?) -> string {
-    if expression == null {
-        return "";
-    }
+    if expression == null { return ""; }
     let value: Expression = expression;
     return format_expression(value);
 }
 
 fn format_type_annotation(annotation: TypeAnnotation?) -> string {
-    if annotation == null {
-        return "";
-    }
+    if annotation == null { return ""; }
     return ": " + annotation.text;
 }
 
 fn format_return_type_annotation(annotation: TypeAnnotation?) -> string {
-    if annotation == null {
-        return "";
-    }
+    if annotation == null { return ""; }
     return " -> " + annotation.text;
 }
 
 fn format_initializer(initializer: Expression?) -> string {
     let value = format_optional_expression(initializer);
-    if value.length == 0 {
-        return "";
-    }
+    if value.length == 0 { return ""; }
     return " = " + value;
 }
 
 fn format_expression(expression: Expression) -> string {
-    if expression.variant == "Identifier" {
-        return expression.name;
-    }
-    if expression.variant == "NumberLiteral" {
-        return expression.value;
-    }
-    if expression.variant == "BooleanLiteral" {
-        return expression.value;
-    }
-    if expression.variant == "NullLiteral" {
-        return "null";
-    }
+    if expression.variant == "Identifier" { return expression.name; }
+    if expression.variant == "NumberLiteral" { return expression.value; }
+    if expression.variant == "BooleanLiteral" { return expression.value; }
+    if expression.variant == "NullLiteral" { return "null"; }
     if expression.variant == "StringLiteral" {
         return quote_string(expression.value);
     }
     if expression.variant == "Unary" {
         let operand = format_expression(expression.operand);
-        if expression.operator == "!" {
-            return "!" + operand;
-        }
+        if expression.operator == "!" { return "!" + operand; }
         return expression.operator + operand;
     }
     if expression.variant == "Binary" {
@@ -77,9 +65,7 @@ fn format_expression(expression: Expression) -> string {
         let mut rendered: string[] = [];
         let mut index: number = 0;
         loop {
-            if index >= expression.arguments.length {
-                break;
-            }
+            if index >= expression.arguments.length { break; }
             rendered.push(format_expression(expression.arguments[index]));
             index += 1;
         }
@@ -95,9 +81,7 @@ fn format_expression(expression: Expression) -> string {
         let mut rendered: string[] = [];
         let mut index: number = 0;
         loop {
-            if index >= expression.elements.length {
-                break;
-            }
+            if index >= expression.elements.length { break; }
             rendered.push(format_expression(expression.elements[index]));
             index += 1;
         }
@@ -108,9 +92,7 @@ fn format_expression(expression: Expression) -> string {
         let mut rendered: string[] = [];
         let mut index: number = 0;
         loop {
-            if index >= expression.fields.length {
-                break;
-            }
+            if index >= expression.fields.length { break; }
             let field = expression.fields[index];
             let value = format_expression(field.value);
             rendered.push(field.name + ": " + value);
@@ -124,9 +106,7 @@ fn format_expression(expression: Expression) -> string {
         let mut rendered: string[] = [];
         let mut index: number = 0;
         loop {
-            if index >= expression.fields.length {
-                break;
-            }
+            if index >= expression.fields.length { break; }
             let field = expression.fields[index];
             let value = format_expression(field.value);
             rendered.push(field.name + ": " + value);
@@ -144,9 +124,7 @@ fn format_expression(expression: Expression) -> string {
     if expression.variant == "Lambda" {
         return format_lambda_expression(expression);
     }
-    if expression.variant == "Raw" {
-        return trim_text(expression.text);
-    }
+    if expression.variant == "Raw" { return trim_text(expression.text); }
     return "";
 }
 
@@ -163,9 +141,7 @@ fn format_lambda_parameters(parameters: Parameter[]) -> string {
     let mut rendered: string[] = [];
     let mut index: number = 0;
     loop {
-        if index >= parameters.length {
-            break;
-        }
+        if index >= parameters.length { break; }
         let param = parameters[index];
         let mut entry: string = param.name;
         entry = entry + format_type_annotation(param.type_annotation);
@@ -178,14 +154,10 @@ fn format_lambda_parameters(parameters: Parameter[]) -> string {
 
 fn format_lambda_body(body: Block) -> string {
     let mut lines: string[] = [];
-    if body.statements.length == 0 {
-        lines.push("// empty body");
-    } else {
+    if body.statements.length == 0 { lines.push("// empty body"); } else {
         let mut index: number = 0;
         loop {
-            if index >= body.statements.length {
-                break;
-            }
+            if index >= body.statements.length { break; }
             lines.push(format_lambda_statement(body.statements[index]));
             index += 1;
         }
@@ -198,9 +170,7 @@ fn format_lambda_body(body: Block) -> string {
 fn format_lambda_statement(statement: Statement) -> string {
     if statement.variant == "ReturnStatement" {
         let rendered = format_optional_expression(statement.expression);
-        if rendered.length == 0 {
-            return "return;";
-        }
+        if rendered.length == 0 { return "return;"; }
         return "return " + rendered + ";";
     }
     if statement.variant == "ExpressionStatement" {
@@ -208,9 +178,7 @@ fn format_lambda_statement(statement: Statement) -> string {
     }
     if statement.variant == "VariableDeclaration" {
         let mut line: string = "let ";
-        if statement.mutable {
-            line = line + "mut ";
-        }
+        if statement.mutable { line = line + "mut "; }
         line = line + statement.name;
         line = line + format_type_annotation(statement.type_annotation);
         line = line + format_initializer(statement.initializer);
@@ -226,15 +194,11 @@ fn indent_lines(lines: string[], depth: number) -> string[] {
     let mut result: string[] = [];
     let mut index: number = 0;
     loop {
-        if index >= lines.length {
-            break;
-        }
+        if index >= lines.length { break; }
         let mut prefix: string = "";
         let mut count: number = 0;
         loop {
-            if count >= depth {
-                break;
-            }
+            if count >= depth { break; }
             prefix = prefix + "    ";
             count += 1;
         }

--- a/compiler/src/emitter_sailfin_expr.sfn
+++ b/compiler/src/emitter_sailfin_expr.sfn
@@ -7,13 +7,13 @@ import {
     Expression,
     Parameter,
     Statement,
-    TypeAnnotation,
+    TypeAnnotation
 } from "./ast";
 import {
     collapse_whitespace,
     join_with_separator,
     quote_string,
-    trim_text,
+    trim_text
 } from "./emitter_sailfin_utils";
 
 fn format_optional_expression(expression: Expression?) -> string {

--- a/compiler/src/emitter_sailfin_utils.sfn
+++ b/compiler/src/emitter_sailfin_utils.sfn
@@ -2,7 +2,6 @@
 //
 // Text utilities and TextBuilder for the Sailfin-to-Sailfin code emitter.
 // Extracted from emitter_sailfin.sfn to keep modules focused and under size.
-
 export {
     TextBuilder,
     builder_new,
@@ -23,8 +22,8 @@ export {
     tokens_to_source,
 };
 
+import { char_at, substring } from "./string_utils";
 import { Token } from "./token";
-import { substring, char_at } from "./string_utils";
 
 struct TextBuilder {
     lines: string[];
@@ -35,9 +34,7 @@ fn quote_string(value: string) -> string {
     let mut result: string = "\"";
     let mut index: number = 0;
     loop {
-        if index >= value.length {
-            break;
-        }
+        if index >= value.length { break; }
         result = result + escape_string_char(char_at(value, index));
         index += 1;
     }
@@ -46,33 +43,19 @@ fn quote_string(value: string) -> string {
 }
 
 fn escape_string_char(ch: string) -> string {
-    if ch == "\"" {
-        return "\\\"";
-    }
-    if ch == "\\" {
-        return "\\\\";
-    }
-    if ch == "\n" {
-        return "\\n";
-    }
-    if ch == "\r" {
-        return "\\r";
-    }
-    if ch == "\t" {
-        return "\\t";
-    }
+    if ch == "\"" { return "\\\""; }
+    if ch == "\\" { return "\\\\"; }
+    if ch == "\n" { return "\\n"; }
+    if ch == "\r" { return "\\r"; }
+    if ch == "\t" { return "\\t"; }
     return ch;
 }
 
-fn format_test_name(name: string) -> string {
-    return quote_string(name);
-}
+fn format_test_name(name: string) -> string { return quote_string(name); }
 
 fn trim_block_body(text: string) -> string {
     let trimmed = trim_text(text);
-    if trimmed.length == 0 {
-        return trimmed;
-    }
+    if trimmed.length == 0 { return trimmed; }
     if char_at(trimmed, 0) == "{" {
         if char_at(trimmed, trimmed.length - 1) == "}" {
             return trim_text(substring(trimmed, 1, trimmed.length - 1));
@@ -86,9 +69,7 @@ fn collapse_whitespace(value: string) -> string {
     let mut index: number = 0;
     let mut last_space: boolean = false;
     loop {
-        if index >= value.length {
-            break;
-        }
+        if index >= value.length { break; }
         let ch = char_at(value, index);
         let mut _let32: boolean = false;
         if ch == " " { _let32 = true; }
@@ -111,15 +92,11 @@ fn collapse_whitespace(value: string) -> string {
 }
 
 fn tokens_to_source(tokens: Token[]) -> string {
-    if tokens.length == 0 {
-        return "";
-    }
+    if tokens.length == 0 { return ""; }
     let mut parts: string[] = [];
     let mut index: number = 0;
     loop {
-        if index >= tokens.length {
-            break;
-        }
+        if index >= tokens.length { break; }
         parts.push(tokens[index].lexeme);
         index += 1;
     }
@@ -134,9 +111,7 @@ fn builder_emit_line(builder: TextBuilder, line: string) -> TextBuilder {
     let mut prefix: string = "";
     let mut count: number = 0;
     loop {
-        if count >= builder.indent {
-            break;
-        }
+        if count >= builder.indent { break; }
         prefix = prefix + "    ";
         count += 1;
     }
@@ -153,31 +128,28 @@ fn builder_emit_blank(builder: TextBuilder) -> TextBuilder {
 }
 
 fn builder_push_indent(builder: TextBuilder) -> TextBuilder {
-    return TextBuilder { lines: builder.lines, indent: builder.indent + 1 };
+    return TextBuilder {
+        lines: builder.lines,
+        indent: builder.indent + 1
+    };
 }
 
 fn builder_pop_indent(builder: TextBuilder) -> TextBuilder {
     let mut indent = builder.indent;
-    if indent > 0 {
-        indent -= 1;
-    }
+    if indent > 0 { indent -= 1; }
     return TextBuilder { lines: builder.lines, indent: indent };
 }
 
 fn builder_to_string(builder: TextBuilder) -> string {
     let content = join_with_separator(builder.lines, "\n");
-    if content.length == 0 {
-        return "";
-    }
+    if content.length == 0 { return ""; }
     return content + "\n";
 }
 
 fn trim_right(value: string) -> string {
     let mut end: number = value.length;
     loop {
-        if end <= 0 {
-            break;
-        }
+        if end <= 0 { break; }
         let ch = char_at(value, end - 1);
         let mut _if33: boolean = false;
         if ch == " " { _if33 = true; }
@@ -188,22 +160,16 @@ fn trim_right(value: string) -> string {
         }
         break;
     }
-    if end == value.length {
-        return value;
-    }
+    if end == value.length { return value; }
     return substring(value, 0, end);
 }
 
 fn join_with_separator(values: string[], separator: string) -> string {
-    if values.length == 0 {
-        return "";
-    }
+    if values.length == 0 { return ""; }
     let mut result: string = values[0];
     let mut index: number = 1;
     loop {
-        if index >= values.length {
-            break;
-        }
+        if index >= values.length { break; }
         result = result + separator + values[index];
         index += 1;
     }
@@ -214,9 +180,7 @@ fn trim_text(value: string) -> string {
     let mut start: number = 0;
     let mut end: number = value.length;
     loop {
-        if start >= end {
-            break;
-        }
+        if start >= end { break; }
         let ch = char_at(value, start);
         if is_trim_char(ch) {
             start += 1;
@@ -225,9 +189,7 @@ fn trim_text(value: string) -> string {
         break;
     }
     loop {
-        if end <= start {
-            break;
-        }
+        if end <= start { break; }
         let ch = char_at(value, end - 1);
         if is_trim_char(ch) {
             end -= 1;
@@ -236,9 +198,7 @@ fn trim_text(value: string) -> string {
         break;
     }
     if start == 0 {
-        if end == value.length {
-            return value;
-        }
+        if end == value.length { return value; }
     }
     return substring(value, start, end);
 }

--- a/compiler/src/emitter_sailfin_utils.sfn
+++ b/compiler/src/emitter_sailfin_utils.sfn
@@ -19,7 +19,7 @@ export {
     format_test_name,
     trim_block_body,
     collapse_whitespace,
-    tokens_to_source,
+    tokens_to_source
 };
 
 import { char_at, substring } from "./string_utils";

--- a/compiler/src/lexer.sfn
+++ b/compiler/src/lexer.sfn
@@ -22,7 +22,7 @@ fn lex(source: string) -> Token[] {
         source_len: length,
         index: 0,
         line: 1,
-        column: 1,
+        column: 1
     };
 
     let tokens: Token[] = [];
@@ -57,7 +57,7 @@ fn lex(source: string) -> Token[] {
             }
             let lexeme = slice(state.source, start_index, state.index);
             tokens = append(tokens, Token {
-                kind: TokenKind.Whitespace(), lexeme: lexeme, line: start_line, column: start_column,
+                kind: TokenKind.Whitespace(), lexeme: lexeme, line: start_line, column: start_column
             });
             continue;
         }
@@ -94,7 +94,7 @@ fn lex(source: string) -> Token[] {
                     state.index = comment_end;
                     state.column += consumed_columns;
                     tokens = append(tokens, Token {
-                        kind: TokenKind.Comment(), lexeme: lexeme, line: start_line, column: start_column,
+                        kind: TokenKind.Comment(), lexeme: lexeme, line: start_line, column: start_column
                     });
                     continue;
                 }
@@ -130,7 +130,7 @@ fn lex(source: string) -> Token[] {
 
                     let lexeme = slice(state.source, start_index, state.index);
                     tokens = append(tokens, Token {
-                        kind: TokenKind.Comment(), lexeme: lexeme, line: start_line, column: start_column,
+                        kind: TokenKind.Comment(), lexeme: lexeme, line: start_line, column: start_column
                     });
                     continue;
                 }
@@ -182,7 +182,7 @@ fn lex(source: string) -> Token[] {
 
             let lexeme = slice(state.source, start_index, state.index);
             tokens = append(tokens, Token {
-                kind: TokenKind.StringLiteral(), lexeme: lexeme, line: start_line, column: start_column,
+                kind: TokenKind.StringLiteral(), lexeme: lexeme, line: start_line, column: start_column
             });
             continue;
         }
@@ -228,7 +228,7 @@ fn lex(source: string) -> Token[] {
 
             let lexeme = slice(state.source, start_index, state.index);
             tokens = append(tokens, Token {
-                kind: TokenKind.NumberLiteral(), lexeme: lexeme, line: start_line, column: start_column,
+                kind: TokenKind.NumberLiteral(), lexeme: lexeme, line: start_line, column: start_column
             });
             continue;
         }
@@ -253,11 +253,11 @@ fn lex(source: string) -> Token[] {
             if value == "false" { _if36 = true; }
             if _if36 {
                 tokens = append(tokens, Token {
-                    kind: TokenKind.BooleanLiteral(), lexeme: value, line: start_line, column: start_column,
+                    kind: TokenKind.BooleanLiteral(), lexeme: value, line: start_line, column: start_column
                 });
             } else {
                 tokens = append(tokens, Token {
-                    kind: TokenKind.Identifier(), lexeme: value, line: start_line, column: start_column,
+                    kind: TokenKind.Identifier(), lexeme: value, line: start_line, column: start_column
                 });
             }
             continue;
@@ -279,7 +279,7 @@ fn lex(source: string) -> Token[] {
                 state.index += 2;
                 state.column += 2;
                 tokens = append(tokens, Token {
-                    kind: TokenKind.Symbol(), lexeme: lexeme, line: start_line, column: start_column,
+                    kind: TokenKind.Symbol(), lexeme: lexeme, line: start_line, column: start_column
                 });
                 continue;
             }
@@ -288,7 +288,7 @@ fn lex(source: string) -> Token[] {
                 state.index += 2;
                 state.column += 2;
                 tokens = append(tokens, Token {
-                    kind: TokenKind.Symbol(), lexeme: lexeme, line: start_line, column: start_column,
+                    kind: TokenKind.Symbol(), lexeme: lexeme, line: start_line, column: start_column
                 });
                 continue;
             }
@@ -301,7 +301,7 @@ fn lex(source: string) -> Token[] {
         } else { state.column += 1; }
 
         tokens = append(tokens, Token {
-            kind: TokenKind.Symbol(), lexeme: lexeme, line: start_line, column: start_column,
+            kind: TokenKind.Symbol(), lexeme: lexeme, line: start_line, column: start_column
         });
     }
 

--- a/compiler/src/lexer.sfn
+++ b/compiler/src/lexer.sfn
@@ -4,9 +4,8 @@
 // implementation is intentionally modest: it tokenises identifier-like runs and
 // individual punctuation characters, preserving whitespace and comments so the
 // parser can decide what to ignore.
-
-import { Token, TokenKind, eof_token } from "./token";
 import { char_code } from "./string_utils";
+import { Token, TokenKind, eof_token } from "./token";
 
 struct LexerState {
     source: string;
@@ -36,9 +35,7 @@ fn lex(source: string) -> Token[] {
             print.err("lexer: guard limit exceeded");
             break;
         }
-        if state.index >= state.source_len {
-            break;
-        }
+        if state.index >= state.source_len { break; }
 
         let ch = byte_at(state.source, state.index);
 
@@ -47,12 +44,8 @@ fn lex(source: string) -> Token[] {
             let start_line = state.line;
             let start_column = state.column;
             loop {
-                if state.index >= state.source_len {
-                    break;
-                }
-                if !is_whitespace(byte_at(state.source, state.index)) {
-                    break;
-                }
+                if state.index >= state.source_len { break; }
+                if !is_whitespace(byte_at(state.source, state.index)) { break; }
                 if byte_at(state.source, state.index) == "\n" {
                     state.index += 1;
                     state.line += 1;
@@ -64,10 +57,7 @@ fn lex(source: string) -> Token[] {
             }
             let lexeme = slice(state.source, start_index, state.index);
             tokens = append(tokens, Token {
-                kind: TokenKind.Whitespace(),
-                lexeme: lexeme,
-                line: start_line,
-                column: start_column,
+                kind: TokenKind.Whitespace(), lexeme: lexeme, line: start_line, column: start_column,
             });
             continue;
         }
@@ -77,82 +67,72 @@ fn lex(source: string) -> Token[] {
             if has_next {
                 let next = byte_at(state.source, state.index + 1);
                 if next == "/" {
-                let start_index = state.index;
-                let start_line = state.line;
-                let start_column = state.column;
+                    let start_index = state.index;
+                    let start_line = state.line;
+                    let start_column = state.column;
 
-                state.index += 2;
-                state.column += 2;
+                    state.index += 2;
+                    state.column += 2;
 
-                let mut comment_end: number = state.source_len;
-                let mut scan_index: number = state.index;
-                loop {
-                    if scan_index >= state.source_len {
-                        break;
+                    let mut comment_end: number = state.source_len;
+                    let mut scan_index: number = state.index;
+                    loop {
+                        if scan_index >= state.source_len { break; }
+                        let scan_character = byte_at(state.source, scan_index);
+                        let mut _if35: boolean = false;
+                        if scan_character == "\n" { _if35 = true; }
+                        if scan_character == "\r" { _if35 = true; }
+                        if _if35 {
+                            comment_end = scan_index;
+                            break;
+                        }
+                        scan_index += 1;
                     }
-                    let scan_character = byte_at(state.source, scan_index);
-                    let mut _if35: boolean = false;
-                    if scan_character == "\n" { _if35 = true; }
-                    if scan_character == "\r" { _if35 = true; }
-                    if _if35 {
-                        comment_end = scan_index;
-                        break;
-                    }
-                    scan_index += 1;
-                }
 
-                let lexeme = slice(state.source, start_index, comment_end);
-                let consumed_columns: number = comment_end - state.index;
-                state.index = comment_end;
-                state.column += consumed_columns;
-                tokens = append(tokens, Token {
-                    kind: TokenKind.Comment(),
-                    lexeme: lexeme,
-                    line: start_line,
-                    column: start_column,
-                });
-                continue;
+                    let lexeme = slice(state.source, start_index, comment_end);
+                    let consumed_columns: number = comment_end - state.index;
+                    state.index = comment_end;
+                    state.column += consumed_columns;
+                    tokens = append(tokens, Token {
+                        kind: TokenKind.Comment(), lexeme: lexeme, line: start_line, column: start_column,
+                    });
+                    continue;
                 }
                 if next == "*" {
-                let start_index = state.index;
-                let start_line = state.line;
-                let start_column = state.column;
+                    let start_index = state.index;
+                    let start_line = state.line;
+                    let start_column = state.column;
 
-                state.index += 2;
-                state.column += 2;
+                    state.index += 2;
+                    state.column += 2;
 
-                loop {
-                    if state.index >= state.source_len {
-                        break;
-                    }
-                    let _next_idx = state.index + 1;
-                    if byte_at(state.source, state.index) == "*" {
-                        if _next_idx < state.source_len {
-                            if byte_at(state.source, _next_idx) == "/" {
-                                state.index += 2;
-                                state.column += 2;
-                                break;
+                    loop {
+                        if state.index >= state.source_len { break; }
+                        let _next_idx = state.index + 1;
+                        if byte_at(state.source, state.index) == "*" {
+                            if _next_idx < state.source_len {
+                                if byte_at(state.source, _next_idx) == "/" {
+                                    state.index += 2;
+                                    state.column += 2;
+                                    break;
+                                }
                             }
                         }
+                        if byte_at(state.source, state.index) == "\n" {
+                            state.index += 1;
+                            state.line += 1;
+                            state.column = 1;
+                        } else {
+                            state.index += 1;
+                            state.column += 1;
+                        }
                     }
-                    if byte_at(state.source, state.index) == "\n" {
-                        state.index += 1;
-                        state.line += 1;
-                        state.column = 1;
-                    } else {
-                        state.index += 1;
-                        state.column += 1;
-                    }
-                }
 
-                let lexeme = slice(state.source, start_index, state.index);
-                tokens = append(tokens, Token {
-                    kind: TokenKind.Comment(),
-                    lexeme: lexeme,
-                    line: start_line,
-                    column: start_column,
-                });
-                continue;
+                    let lexeme = slice(state.source, start_index, state.index);
+                    tokens = append(tokens, Token {
+                        kind: TokenKind.Comment(), lexeme: lexeme, line: start_line, column: start_column,
+                    });
+                    continue;
                 }
             }
         }
@@ -171,9 +151,7 @@ fn lex(source: string) -> Token[] {
             let escaped: boolean = false;
 
             loop {
-                if state.index >= state.source_len {
-                    break;
-                }
+                if state.index >= state.source_len { break; }
                 let current = byte_at(state.source, state.index);
                 if !escaped {
                     if is_double_quote(current) {
@@ -190,9 +168,7 @@ fn lex(source: string) -> Token[] {
                         continue;
                     }
                 }
-                if escaped {
-                    escaped = false;
-                }
+                if escaped { escaped = false; }
 
                 if current == "\n" {
                     state.index += 1;
@@ -205,11 +181,8 @@ fn lex(source: string) -> Token[] {
             }
 
             let lexeme = slice(state.source, start_index, state.index);
-                tokens = append(tokens, Token {
-                    kind: TokenKind.StringLiteral(),
-                lexeme: lexeme,
-                line: start_line,
-                column: start_column,
+            tokens = append(tokens, Token {
+                kind: TokenKind.StringLiteral(), lexeme: lexeme, line: start_line, column: start_column,
             });
             continue;
         }
@@ -223,12 +196,8 @@ fn lex(source: string) -> Token[] {
             state.column += 1;
 
             loop {
-                if state.index >= state.source_len {
-                    break;
-                }
-                if !is_digit(byte_at(state.source, state.index)) {
-                    break;
-                }
+                if state.index >= state.source_len { break; }
+                if !is_digit(byte_at(state.source, state.index)) { break; }
                 state.index += 1;
                 state.column += 1;
             }
@@ -246,9 +215,7 @@ fn lex(source: string) -> Token[] {
                         state.index += 1;
                         state.column += 1;
                         loop {
-                            if state.index >= state.source_len {
-                                break;
-                            }
+                            if state.index >= state.source_len { break; }
                             if !is_digit(byte_at(state.source, state.index)) {
                                 break;
                             }
@@ -261,10 +228,7 @@ fn lex(source: string) -> Token[] {
 
             let lexeme = slice(state.source, start_index, state.index);
             tokens = append(tokens, Token {
-                kind: TokenKind.NumberLiteral(),
-                lexeme: lexeme,
-                line: start_line,
-                column: start_column,
+                kind: TokenKind.NumberLiteral(), lexeme: lexeme, line: start_line, column: start_column,
             });
             continue;
         }
@@ -276,9 +240,7 @@ fn lex(source: string) -> Token[] {
             state.index += 1;
             state.column += 1;
             loop {
-                if state.index >= state.source_len {
-                    break;
-                }
+                if state.index >= state.source_len { break; }
                 if !is_identifier_part(byte_at(state.source, state.index)) {
                     break;
                 }
@@ -291,17 +253,11 @@ fn lex(source: string) -> Token[] {
             if value == "false" { _if36 = true; }
             if _if36 {
                 tokens = append(tokens, Token {
-                    kind: TokenKind.BooleanLiteral(),
-                    lexeme: value,
-                    line: start_line,
-                    column: start_column,
+                    kind: TokenKind.BooleanLiteral(), lexeme: value, line: start_line, column: start_column,
                 });
             } else {
                 tokens = append(tokens, Token {
-                    kind: TokenKind.Identifier(),
-                    lexeme: value,
-                    line: start_line,
-                    column: start_column,
+                    kind: TokenKind.Identifier(), lexeme: value, line: start_line, column: start_column,
                 });
             }
             continue;
@@ -323,10 +279,7 @@ fn lex(source: string) -> Token[] {
                 state.index += 2;
                 state.column += 2;
                 tokens = append(tokens, Token {
-                    kind: TokenKind.Symbol(),
-                    lexeme: lexeme,
-                    line: start_line,
-                    column: start_column,
+                    kind: TokenKind.Symbol(), lexeme: lexeme, line: start_line, column: start_column,
                 });
                 continue;
             }
@@ -335,10 +288,7 @@ fn lex(source: string) -> Token[] {
                 state.index += 2;
                 state.column += 2;
                 tokens = append(tokens, Token {
-                    kind: TokenKind.Symbol(),
-                    lexeme: lexeme,
-                    line: start_line,
-                    column: start_column,
+                    kind: TokenKind.Symbol(), lexeme: lexeme, line: start_line, column: start_column,
                 });
                 continue;
             }
@@ -348,15 +298,10 @@ fn lex(source: string) -> Token[] {
         if ch == "\n" {
             state.line += 1;
             state.column = 1;
-        } else {
-            state.column += 1;
-        }
+        } else { state.column += 1; }
 
         tokens = append(tokens, Token {
-            kind: TokenKind.Symbol(),
-            lexeme: lexeme,
-            line: start_line,
-            column: start_column,
+            kind: TokenKind.Symbol(), lexeme: lexeme, line: start_line, column: start_column,
         });
     }
 
@@ -391,14 +336,10 @@ fn is_letter(ch: string) -> boolean {
     let c = char_code(ch);
     let mut _ret41: boolean = false;
     if c >= 65 {
-        if c <= 90 {
-            _ret41 = true;
-        }
+        if c <= 90 { _ret41 = true; }
     }
     if c >= 97 {
-        if c <= 122 {
-            _ret41 = true;
-        }
+        if c <= 122 { _ret41 = true; }
     }
     return _ret41;
 }
@@ -407,51 +348,31 @@ fn is_digit(ch: string) -> boolean {
     let c = char_code(ch);
     let mut _ret42: boolean = false;
     if c >= 48 {
-        if c <= 57 {
-            _ret42 = true;
-        }
+        if c <= 57 { _ret42 = true; }
     }
     return _ret42;
 }
 
-fn is_double_quote(ch: string) -> boolean {
-    return ch == "\"";
-}
+fn is_double_quote(ch: string) -> boolean { return ch == "\""; }
 
-fn is_backslash(ch: string) -> boolean {
-    return ch == "\\";
-}
+fn is_backslash(ch: string) -> boolean { return ch == "\\"; }
 
 fn slice(text: string, start: number, end: number) -> string {
     let text_len = text.length;
     let mut safe_start = start;
     let mut safe_end = end;
-    if safe_start < 0 {
-        safe_start = 0;
-    }
-    if safe_end < safe_start {
-        safe_end = safe_start;
-    }
-    if safe_start > text_len {
-        safe_start = text_len;
-    }
-    if safe_end > text_len {
-        safe_end = text_len;
-    }
+    if safe_start < 0 { safe_start = 0; }
+    if safe_end < safe_start { safe_end = safe_start; }
+    if safe_start > text_len { safe_start = text_len; }
+    if safe_end > text_len { safe_end = text_len; }
     return substring_unchecked(text, safe_start, safe_end);
 }
 
 fn byte_at(text: string, index: number) -> string {
     let text_len = text.length;
-    if text_len == 0 {
-        return "";
-    }
-    if index < 0 {
-        return "";
-    }
-    if index >= text_len {
-        return "";
-    }
+    if text_len == 0 { return ""; }
+    if index < 0 { return ""; }
+    if index >= text_len { return ""; }
     return substring_unchecked(text, index, index + 1);
 }
 
@@ -461,32 +382,14 @@ fn append(tokens: Token[], token: Token) -> Token[] {
 }
 
 fn is_two_char_symbol(value: string) -> boolean {
-    if value == "->" {
-        return true;
-    }
-    if value == "=>" {
-        return true;
-    }
-    if value == "==" {
-        return true;
-    }
-    if value == "!=" {
-        return true;
-    }
-    if value == "<=" {
-        return true;
-    }
-    if value == ">=" {
-        return true;
-    }
-    if value == "&&" {
-        return true;
-    }
-    if value == "||" {
-        return true;
-    }
-    if value == ".." {
-        return true;
-    }
+    if value == "->" { return true; }
+    if value == "=>" { return true; }
+    if value == "==" { return true; }
+    if value == "!=" { return true; }
+    if value == "<=" { return true; }
+    if value == ">=" { return true; }
+    if value == "&&" { return true; }
+    if value == "||" { return true; }
+    if value == ".." { return true; }
     return false;
 }

--- a/compiler/src/llvm/effects.sfn
+++ b/compiler/src/llvm/effects.sfn
@@ -2,41 +2,43 @@
 //
 // Effect system analysis for LLVM lowering. Collects and propagates effects
 // through the function call graph to build capability manifests.
-
 import { NativeFunction, NativeInstruction } from "../native_ir";
-import { substring, char_at } from "../string_utils";
-import { FunctionEffectEntry, FunctionCallEntry, CapabilityManifest, CapabilityManifestEntry, RuntimeHelperDescriptor } from "./types";
+import { char_at, substring } from "../string_utils";
+import { find_runtime_helper } from "./runtime_helpers";
 import {
-    trim_text,
+    CapabilityManifest,
+    CapabilityManifestEntry,
+    FunctionCallEntry,
+    FunctionEffectEntry,
+    RuntimeHelperDescriptor
+} from "./types";
+import {
     append_string,
     copy_string_array,
-    string_array_contains,
-    string_arrays_equal,
-    number_to_string,
-    is_identifier_start_char,
-    is_identifier_part_char,
-    is_trim_char,
-    is_effect_prefix_char,
-    is_effect_delimiter,
-    index_of,
     find_last_index_of_char,
+    index_of,
+    is_effect_delimiter,
+    is_effect_prefix_char,
+    is_identifier_part_char,
+    is_identifier_start_char,
+    is_trim_char,
     matches_case_insensitive,
     matches_keyword,
-    skip_string_literal
+    number_to_string,
+    skip_string_literal,
+    string_array_contains,
+    string_arrays_equal,
+    trim_text
 } from "./utils";
-import { find_runtime_helper } from "./runtime_helpers";
 
 // =============================================================================
 // Effect Collection
 // =============================================================================
-
 fn collect_direct_function_effects(functions: NativeFunction[]) -> FunctionEffectEntry[] {
     let mut entries: FunctionEffectEntry[] = [];
     let mut index: number = 0;
     loop {
-        if index >= functions.length {
-            break;
-        }
+        if index >= functions.length { break; }
         let fun = functions[index];
         if fun != null {
             let entry = collect_function_effect_entry(fun);
@@ -66,33 +68,23 @@ fn append_function_effect_entry(values: FunctionEffectEntry[], entry: FunctionEf
 
 fn merge_effect_lists(base: string[], extras: string[]) -> string[] {
     if base == null {
-        if extras == null {
-            return [];
-        }
+        if extras == null { return []; }
     }
-    if base == null {
-        return copy_string_array(extras);
-    }
-    if extras == null {
-        return copy_string_array(base);
-    }
+    if base == null { return copy_string_array(extras); }
+    if extras == null { return copy_string_array(base); }
     let mut result: string[] = [];
 
     // Copy existing effects first so we preserve order before appending extras.
     let mut index: number = 0;
     loop {
-        if index >= base.length {
-            break;
-        }
+        if index >= base.length { break; }
         result = append_unique_effect(result, base[index]);
         index += 1;
     }
 
     index = 0;
     loop {
-        if index >= extras.length {
-            break;
-        }
+        if index >= extras.length { break; }
         result = append_unique_effect(result, extras[index]);
         index += 1;
     }
@@ -101,15 +93,9 @@ fn merge_effect_lists(base: string[], extras: string[]) -> string[] {
 }
 
 fn append_unique_effect(effects: string[], effect: string) -> string[] {
-    if effect == null {
-        return effects;
-    }
-    if effect.length == 0 {
-        return effects;
-    }
-    if string_array_contains(effects, effect) {
-        return effects;
-    }
+    if effect == null { return effects; }
+    if effect.length == 0 { return effects; }
+    if string_array_contains(effects, effect) { return effects; }
     effects.push(effect);
     return effects;
 }
@@ -117,21 +103,14 @@ fn append_unique_effect(effects: string[], effect: string) -> string[] {
 // =============================================================================
 // Borrow Effect Collection
 // =============================================================================
-
 fn collect_function_borrow_effects(function: NativeFunction) -> string[] {
     let mut effects: string[] = [];
     let mut instructions = function.instructions;
-    if instructions == null {
-        return effects;
-    }
-    if instructions.length > 1000000 {
-        return effects;
-    }
+    if instructions == null { return effects; }
+    if instructions.length > 1000000 { return effects; }
     let mut index: number = 0;
     loop {
-        if index >= instructions.length {
-            break;
-        }
+        if index >= instructions.length { break; }
         let instruction = instructions[index];
         if instruction == null {
             index += 1;
@@ -160,15 +139,11 @@ fn collect_function_borrow_effects(function: NativeFunction) -> string[] {
 
 fn collect_expression_borrow_effects(expression: string) -> string[] {
     let trimmed = trim_text(expression);
-    if trimmed.length == 0 {
-        return [];
-    }
+    if trimmed.length == 0 { return []; }
     let mut effects: string[] = [];
     let mut index: number = 0;
     loop {
-        if index >= trimmed.length {
-            break;
-        }
+        if index >= trimmed.length { break; }
         let ch = substring(trimmed, index, index + 1);
         if ch == "\"" {
             index = skip_string_literal(trimmed, index + 1);
@@ -200,7 +175,9 @@ fn collect_expression_borrow_effects(expression: string) -> string[] {
                     let _after_mut_next = after_mut_index + 1;
                     let mut _if44: boolean = false;
                     if after_mut_index >= trimmed.length { _if44 = true; }
-                    if is_effect_delimiter(substring(trimmed, after_mut_index, _after_mut_next)) { _if44 = true; }
+                    if is_effect_delimiter(substring(trimmed, after_mut_index, _after_mut_next)) {
+                        _if44 = true;
+                    }
                     if _if44 {
                         mutable_flag = true;
                         cursor = after_mut_index;
@@ -208,13 +185,9 @@ fn collect_expression_borrow_effects(expression: string) -> string[] {
                 }
             }
             loop {
-                if cursor >= trimmed.length {
-                    break;
-                }
+                if cursor >= trimmed.length { break; }
                 let current = substring(trimmed, cursor, cursor + 1);
-                if !is_trim_char(current) {
-                    break;
-                }
+                if !is_trim_char(current) { break; }
                 cursor += 1;
             }
             if cursor < trimmed.length {
@@ -236,7 +209,9 @@ fn collect_expression_borrow_effects(expression: string) -> string[] {
                 let _before_next = before_index + 1;
                 let mut _if45: boolean = false;
                 if before_index < 0 { _if45 = true; }
-                if is_effect_prefix_char(substring(trimmed, before_index, _before_next)) { _if45 = true; }
+                if is_effect_prefix_char(substring(trimmed, before_index, _before_next)) {
+                    _if45 = true;
+                }
                 if _if45 {
                     effects = append_unique_effect(effects, "read");
                     index += 6;
@@ -252,15 +227,12 @@ fn collect_expression_borrow_effects(expression: string) -> string[] {
 // =============================================================================
 // Call Graph Construction
 // =============================================================================
-
 fn collect_function_call_graph(functions: NativeFunction[]) -> FunctionCallEntry[] {
     let mut entries: FunctionCallEntry[] = [];
     let function_names = collect_function_names(functions);
     let mut index: number = 0;
     loop {
-        if index >= functions.length {
-            break;
-        }
+        if index >= functions.length { break; }
         let call_entry = collect_function_call_entry(functions[index], function_names);
         entries = append_function_call_entry(entries, call_entry);
         index += 1;
@@ -279,9 +251,7 @@ fn collect_function_call_entry(function: NativeFunction, function_names: string[
     }
     let mut index: number = 0;
     loop {
-        if index >= instructions.length {
-            break;
-        }
+        if index >= instructions.length { break; }
         let instruction = instructions[index];
         if instruction == null {
             index += 1;
@@ -297,13 +267,9 @@ fn collect_function_names(functions: NativeFunction[]) -> string[] {
     let mut names: string[] = [];
     let mut index: number = 0;
     loop {
-        if index >= functions.length {
-            break;
-        }
+        if index >= functions.length { break; }
         let mut name = functions[index].name;
-        if name == null {
-            name = "";
-        }
+        if name == null { name = ""; }
         names.push(name);
         index += 1;
     }
@@ -318,7 +284,6 @@ fn append_function_call_entry(entries: FunctionCallEntry[], entry: FunctionCallE
 // =============================================================================
 // Instruction Call Collection
 // =============================================================================
-
 fn collect_instruction_calls(instruction: NativeInstruction, function_names: string[]) -> string[] {
     let mut callees: string[] = [];
     if instruction.variant == "Let" {
@@ -367,14 +332,10 @@ fn collect_instruction_calls(instruction: NativeInstruction, function_names: str
 fn extract_call_targets(expression: string, function_names: string[]) -> string[] {
     let mut results: string[] = [];
     let expression_len = expression.length;
-    if expression_len == 0 {
-        return results;
-    }
+    if expression_len == 0 { return results; }
     let mut index: number = 0;
     loop {
-        if index >= expression_len {
-            break;
-        }
+        if index >= expression_len { break; }
         let ch = substring(expression, index, index + 1);
         if ch == "\"" {
             index = skip_string_literal(expression, index + 1);
@@ -384,9 +345,7 @@ fn extract_call_targets(expression: string, function_names: string[]) -> string[
             let start_index = index;
             index += 1;
             loop {
-                if index >= expression_len {
-                    break;
-                }
+                if index >= expression_len { break; }
                 let current = substring(expression, index, index + 1);
                 if is_identifier_part_char(current) {
                     index += 1;
@@ -402,16 +361,12 @@ fn extract_call_targets(expression: string, function_names: string[]) -> string[
             if candidate.length > 0 {
                 loop {
                     let dot_index = index_of(candidate, ".");
-                    if dot_index == -1 {
-                        break;
-                    }
+                    if dot_index == -1 { break; }
                     candidate = substring(candidate, dot_index + 1, candidate.length);
                 }
                 let mut cursor: number = index;
                 loop {
-                    if cursor >= expression_len {
-                        break;
-                    }
+                    if cursor >= expression_len { break; }
                     let next = substring(expression, cursor, cursor + 1);
                     if is_trim_char(next) {
                         cursor += 1;
@@ -435,14 +390,10 @@ fn extract_call_targets(expression: string, function_names: string[]) -> string[
 fn extract_all_call_targets(expression: string) -> string[] {
     let mut results: string[] = [];
     let expression_len = expression.length;
-    if expression_len == 0 {
-        return results;
-    }
+    if expression_len == 0 { return results; }
     let mut index: number = 0;
     loop {
-        if index >= expression_len {
-            break;
-        }
+        if index >= expression_len { break; }
         let ch = substring(expression, index, index + 1);
         if ch == "\"" {
             index = skip_string_literal(expression, index + 1);
@@ -452,9 +403,7 @@ fn extract_all_call_targets(expression: string) -> string[] {
             let start_index = index;
             index += 1;
             loop {
-                if index >= expression_len {
-                    break;
-                }
+                if index >= expression_len { break; }
                 let current = substring(expression, index, index + 1);
                 if is_identifier_part_char(current) {
                     index += 1;
@@ -473,9 +422,7 @@ fn extract_all_call_targets(expression: string) -> string[] {
             if candidate.length > 0 {
                 let mut cursor: number = index;
                 loop {
-                    if cursor >= expression_len {
-                        break;
-                    }
+                    if cursor >= expression_len { break; }
                     let next = substring(expression, cursor, cursor + 1);
                     if is_trim_char(next) {
                         cursor += 1;
@@ -497,17 +444,12 @@ fn extract_all_call_targets(expression: string) -> string[] {
 // =============================================================================
 // Runtime Helper Target Collection
 // =============================================================================
-
 fn collect_runtime_helper_targets(functions: NativeFunction[]) -> string[] {
-    if functions.length > 100000 {
-        return [];
-    }
+    if functions.length > 100000 { return []; }
     let mut used: string[] = [];
     let mut index: number = 0;
     loop {
-        if index >= functions.length {
-            break;
-        }
+        if index >= functions.length { break; }
         let helpers = collect_function_runtime_helper_targets(functions[index]);
         used = merge_effect_lists(used, helpers);
         index += 1;
@@ -520,21 +462,19 @@ fn collect_function_runtime_helper_targets(function: NativeFunction) -> string[]
 
     // Decorator-driven runtime hooks.
     let mut decorators = function.decorators;
-    if decorators == null {
-        decorators = [];
-    }
-    if decorators.length > 100000 {
-        return used;
-    }
+    if decorators == null { decorators = []; }
+    if decorators.length > 100000 { return used; }
     let mut decorator_index: number = 0;
     loop {
-        if decorator_index >= decorators.length {
-            break;
-        }
+        if decorator_index >= decorators.length { break; }
         let decorator_name = decorators[decorator_index];
         let mut _if47: boolean = false;
-        if matches_case_insensitive(decorator_name, "logExecution") { _if47 = true; }
-        if matches_case_insensitive(decorator_name, "logexecution") { _if47 = true; }
+        if matches_case_insensitive(decorator_name, "logExecution") {
+            _if47 = true;
+        }
+        if matches_case_insensitive(decorator_name, "logexecution") {
+            _if47 = true;
+        }
         if matches_case_insensitive(decorator_name, "trace") { _if47 = true; }
         if _if47 {
             used = append_unique_effect(used, "runtime_log_execution_fn");
@@ -543,17 +483,11 @@ fn collect_function_runtime_helper_targets(function: NativeFunction) -> string[]
     }
 
     let mut instructions = function.instructions;
-    if instructions == null {
-        instructions = [];
-    }
-    if instructions.length > 1000000 {
-        return used;
-    }
+    if instructions == null { instructions = []; }
+    if instructions.length > 1000000 { return used; }
     let mut index: number = 0;
     loop {
-        if index >= instructions.length {
-            break;
-        }
+        if index >= instructions.length { break; }
         let instruction = instructions[index];
         let instruction_helpers = collect_instruction_runtime_helper_targets(instruction);
         used = merge_effect_lists(used, instruction_helpers);
@@ -614,9 +548,7 @@ fn collect_instruction_runtime_helper_targets(instruction: NativeInstruction) ->
     if instruction.variant == "Try" {
         return ["clear_exception", "has_exception", "take_exception"];
     }
-    if instruction.variant == "Throw" {
-        return ["set_exception"];
-    }
+    if instruction.variant == "Throw" { return ["set_exception"]; }
     return [];
 }
 
@@ -624,9 +556,7 @@ fn filter_runtime_helper_targets(targets: string[]) -> string[] {
     let mut results: string[] = [];
     let mut index: number = 0;
     loop {
-        if index >= targets.length {
-            break;
-        }
+        if index >= targets.length { break; }
         let trimmed = trim_text(targets[index]);
         let mut helper = find_runtime_helper(trimmed);
         if helper == null {
@@ -680,9 +610,7 @@ fn filter_runtime_helper_targets(targets: string[]) -> string[] {
 
 fn collect_runtime_property_targets(expression: string) -> string[] {
     let trimmed = trim_text(expression);
-    if trimmed.length == 0 {
-        return [];
-    }
+    if trimmed.length == 0 { return []; }
     let mut results: string[] = [];
     if contains_dot_property(trimmed, "length") {
         results = append_unique_effect(results, "string.length");
@@ -696,37 +624,25 @@ fn contains_dot_property(expression: string, name: string) -> boolean {
     let mut _if48: boolean = false;
     if suffix_length == 0 { _if48 = true; }
     if expression.length < suffix_length { _if48 = true; }
-    if _if48 {
-        return false;
-    }
+    if _if48 { return false; }
     let mut index: number = 0;
     let mut in_single: boolean = false;
     let mut in_double: boolean = false;
     let mut escape_next: boolean = false;
     loop {
-        if index >= expression.length {
-            break;
-        }
+        if index >= expression.length { break; }
         let ch = substring(expression, index, index + 1);
         if in_double {
-            if escape_next {
-                escape_next = false;
-            } else if ch == "\\" {
+            if escape_next { escape_next = false; } else if ch == "\\" {
                 escape_next = true;
-            } else if ch == "\"" {
-                in_double = false;
-            }
+            } else if ch == "\"" { in_double = false; }
             index += 1;
             continue;
         }
         if in_single {
-            if escape_next {
-                escape_next = false;
-            } else if ch == "\\" {
+            if escape_next { escape_next = false; } else if ch == "\\" {
                 escape_next = true;
-            } else if ch == "'" {
-                in_single = false;
-            }
+            } else if ch == "'" { in_single = false; }
             index += 1;
             continue;
         }
@@ -745,9 +661,7 @@ fn contains_dot_property(expression: string, name: string) -> boolean {
             let mut match_index: number = 0;
             let mut matches: boolean = true;
             loop {
-                if match_index >= suffix_length {
-                    break;
-                }
+                if match_index >= suffix_length { break; }
                 let _expr_pos = index + match_index;
                 let expr_char = char_at(expression, _expr_pos);
                 let suffix_char = char_at(suffix, match_index);
@@ -764,12 +678,8 @@ fn contains_dot_property(expression: string, name: string) -> boolean {
             if matches {
                 let after_index = _sfx_end;
                 let after_char = char_at(expression, after_index);
-                if after_char.length == 0 {
-                    return true;
-                }
-                if !is_identifier_part_char(after_char) {
-                    return true;
-                }
+                if after_char.length == 0 { return true; }
+                if !is_identifier_part_char(after_char) { return true; }
             }
         }
         index += 1;
@@ -780,23 +690,20 @@ fn contains_dot_property(expression: string, name: string) -> boolean {
 // =============================================================================
 // Effect Propagation
 // =============================================================================
-
 fn propagate_function_effects(direct_effects: FunctionEffectEntry[], call_graph: FunctionCallEntry[]) -> FunctionEffectEntry[] ![io] {
     let mut aggregated: FunctionEffectEntry[] = [];
     let mut index: number = 0;
     loop {
-        if index >= direct_effects.length {
-            break;
-        }
-        aggregated.push(FunctionEffectEntry { name: direct_effects[index].name, effects: copy_string_array(direct_effects[index].effects) });
+        if index >= direct_effects.length { break; }
+        aggregated.push(FunctionEffectEntry {
+            name: direct_effects[index].name, effects: copy_string_array(direct_effects[index].effects)
+        });
         index += 1;
     }
 
     let mut _let50: boolean = false;
     if fs.exists("build/sailfin/.trace_test_runner") {
-        if fs.exists("build/sailfin/.test_runner_active") {
-            _let50 = true;
-        }
+        if fs.exists("build/sailfin/.test_runner_active") { _let50 = true; }
     }
     let trace = _let50;
     let mut iteration: number = 0;
@@ -808,18 +715,14 @@ fn propagate_function_effects(direct_effects: FunctionEffectEntry[], call_graph:
     let mut call_callee_indices: number[][] = [];
     let mut call_index: number = 0;
     loop {
-        if call_index >= call_graph.length {
-            break;
-        }
+        if call_index >= call_graph.length { break; }
         let call_entry = call_graph[call_index];
         call_targets.push(find_function_effect_entry_index(aggregated, call_entry.name));
 
         let mut callees: number[] = [];
         let mut callee_index: number = 0;
         loop {
-            if callee_index >= call_entry.callees.length {
-                break;
-            }
+            if callee_index >= call_entry.callees.length { break; }
             callees.push(find_function_effect_entry_index(aggregated, call_entry.callees[callee_index]));
             callee_index += 1;
         }
@@ -829,9 +732,7 @@ fn propagate_function_effects(direct_effects: FunctionEffectEntry[], call_graph:
 
     let mut changed: boolean = true;
     loop {
-        if !changed {
-            break;
-        }
+        if !changed { break; }
         if iteration > max_iterations {
             if trace {
                 print.err("llvm effects: propagation cap reached (max=" + number_to_string(max_iterations) + ")");
@@ -842,9 +743,7 @@ fn propagate_function_effects(direct_effects: FunctionEffectEntry[], call_graph:
         changed = false;
         call_index = 0;
         loop {
-            if call_index >= call_graph.length {
-                break;
-            }
+            if call_index >= call_graph.length { break; }
             let target_index = call_targets[call_index];
             if target_index >= 0 {
                 let target_entry = aggregated[target_index];
@@ -853,9 +752,7 @@ fn propagate_function_effects(direct_effects: FunctionEffectEntry[], call_graph:
                 let callees = call_callee_indices[call_index];
                 let mut callee_index: number = 0;
                 loop {
-                    if callee_index >= callees.length {
-                        break;
-                    }
+                    if callee_index >= callees.length { break; }
                     let callee_pos = callees[callee_index];
                     if callee_pos >= 0 {
                         let callee_entry = aggregated[callee_pos];
@@ -872,7 +769,10 @@ fn propagate_function_effects(direct_effects: FunctionEffectEntry[], call_graph:
                 }
 
                 if !string_arrays_equal(merged, target_entry.effects) {
-                    aggregated[target_index] = FunctionEffectEntry { name: target_entry.name, effects: merged };
+                    aggregated[target_index] = FunctionEffectEntry {
+                        name: target_entry.name,
+                        effects: merged
+                    };
                     changed = true;
                 }
             }
@@ -886,12 +786,8 @@ fn propagate_function_effects(direct_effects: FunctionEffectEntry[], call_graph:
 fn find_function_effect_entry_index(entries: FunctionEffectEntry[], name: string) -> number {
     let mut index: number = 0;
     loop {
-        if index >= entries.length {
-            break;
-        }
-        if entries[index].name == name {
-            return index;
-        }
+        if index >= entries.length { break; }
+        if entries[index].name == name { return index; }
         index += 1;
     }
     return -1;
@@ -899,9 +795,7 @@ fn find_function_effect_entry_index(entries: FunctionEffectEntry[], name: string
 
 fn find_function_effect_entry(entries: FunctionEffectEntry[], name: string) -> FunctionEffectEntry? {
     let index = find_function_effect_entry_index(entries, name);
-    if index >= 0 {
-        return entries[index];
-    }
+    if index >= 0 { return entries[index]; }
     return null;
 }
 
@@ -909,12 +803,8 @@ fn replace_function_effect_entry(entries: FunctionEffectEntry[], position: numbe
     let mut result: FunctionEffectEntry[] = [];
     let mut index: number = 0;
     loop {
-        if index >= entries.length {
-            break;
-        }
-        if index == position {
-            result.push(entry);
-        } else {
+        if index >= entries.length { break; }
+        if index == position { result.push(entry); } else {
             result.push(entries[index]);
         }
         index += 1;
@@ -925,21 +815,18 @@ fn replace_function_effect_entry(entries: FunctionEffectEntry[], position: numbe
 // =============================================================================
 // Capability Manifest Building
 // =============================================================================
-
 fn build_capability_manifest(entry_points: string[], function_effects: FunctionEffectEntry[]) -> CapabilityManifest {
     let mut entries: CapabilityManifestEntry[] = [];
     let mut index: number = 0;
     loop {
-        if index >= entry_points.length {
-            break;
-        }
+        if index >= entry_points.length { break; }
         let symbol = entry_points[index];
         let effect_entry = find_function_effect_entry(function_effects, symbol);
         let mut effects: string[] = [];
-        if effect_entry != null {
-            effects = effect_entry.effects;
-        }
-        entries = append_manifest_entry(entries, CapabilityManifestEntry { symbol: symbol, effects: effects });
+        if effect_entry != null { effects = effect_entry.effects; }
+        entries = append_manifest_entry(entries, CapabilityManifestEntry {
+            symbol: symbol, effects: effects
+        });
         index += 1;
     }
     return CapabilityManifest { entries: entries };

--- a/compiler/src/llvm/effects.sfn
+++ b/compiler/src/llvm/effects.sfn
@@ -735,7 +735,9 @@ fn propagate_function_effects(direct_effects: FunctionEffectEntry[], call_graph:
         if !changed { break; }
         if iteration > max_iterations {
             if trace {
-                print.err("llvm effects: propagation cap reached (max=" + number_to_string(max_iterations) + ")");
+                print.err("llvm effects: propagation cap reached (max="
+                    + number_to_string(max_iterations)
+                    + ")");
             }
             break;
         }

--- a/compiler/src/llvm/expression_lowering/arrays.sfn
+++ b/compiler/src/llvm/expression_lowering/arrays.sfn
@@ -5,31 +5,16 @@
 // Implements LLVM IR generation for array operations: concatenation
 // (`lower_struct_array_concat`), element type extraction from array pointer
 // types, and array struct type mapping.
-
 import { substring } from "../../string_utils";
-
+import { format_temp_name, } from "../expressions_helpers";
+import { strip_pointer_suffix, } from "../type_mapping";
+import { array_struct_type_for_element, } from "../type_mapping";
+import { ExpressionResult, LLVMOperand, } from "../types";
 import {
-    LLVMOperand,
-    ExpressionResult,
-} from "../types";
-
-import {
-    trim_text,
     append_string,
     ends_with,
+    trim_text,
 } from "../utils";
-
-import {
-    strip_pointer_suffix,
-} from "../type_mapping";
-
-import {
-    format_temp_name,
-} from "../expressions_helpers";
-
-import {
-    array_struct_type_for_element,
-} from "../type_mapping";
 
 fn lower_struct_array_concat(lhs: LLVMOperand, rhs: LLVMOperand, element_type: string, lines: string[], temp_index: number) -> ExpressionResult {
     let mut current_lines = lines;
@@ -37,13 +22,25 @@ fn lower_struct_array_concat(lhs: LLVMOperand, rhs: LLVMOperand, element_type: s
     let mut diagnostics: string[] = [];
     if element_type.length == 0 {
         diagnostics.push("llvm lowering: concat requires a concrete element type");
-        return ExpressionResult { lines: current_lines, temp_index: current_temp, operand: null, diagnostics: diagnostics, string_constants: [] };
+        return ExpressionResult {
+            lines: current_lines,
+            temp_index: current_temp,
+            operand: null,
+            diagnostics: diagnostics,
+            string_constants: []
+        };
     }
 
     let array_struct_type = array_struct_type_for_element(element_type);
     if array_struct_type.length == 0 {
         diagnostics.push("llvm lowering: unsupported concat element type `" + element_type + "`");
-        return ExpressionResult { lines: current_lines, temp_index: current_temp, operand: null, diagnostics: diagnostics, string_constants: [] };
+        return ExpressionResult {
+            lines: current_lines,
+            temp_index: current_temp,
+            operand: null,
+            diagnostics: diagnostics,
+            string_constants: []
+        };
     }
 
     let data_pointer_type = element_type + "*";
@@ -143,8 +140,17 @@ fn lower_struct_array_concat(lhs: LLVMOperand, rhs: LLVMOperand, element_type: s
     current_lines.push("  " + new_len_field + " = getelementptr " + array_struct_type + ", " + array_struct_type + "* " + new_struct_ptr + ", i32 0, i32 1");
     current_lines.push("  store i64 " + total_length + ", i64* " + new_len_field);
 
-    let result_operand = LLVMOperand { llvm_type: lhs.llvm_type, value: new_struct_ptr };
-    return ExpressionResult { lines: current_lines, temp_index: current_temp, operand: result_operand, diagnostics: diagnostics, string_constants: [] };
+    let result_operand = LLVMOperand {
+        llvm_type: lhs.llvm_type,
+        value: new_struct_ptr
+    };
+    return ExpressionResult {
+        lines: current_lines,
+        temp_index: current_temp,
+        operand: result_operand,
+        diagnostics: diagnostics,
+        string_constants: []
+    };
 }
 
 fn lower_array_push_in_place(array: LLVMOperand, value: LLVMOperand, element_type: string, lines: string[], temp_index: number) -> ExpressionResult {
@@ -153,7 +159,13 @@ fn lower_array_push_in_place(array: LLVMOperand, value: LLVMOperand, element_typ
     let mut diagnostics: string[] = [];
     if element_type.length == 0 {
         diagnostics.push("llvm lowering: push requires a concrete element type");
-        return ExpressionResult { lines: current_lines, temp_index: current_temp, operand: null, diagnostics: diagnostics, string_constants: [] };
+        return ExpressionResult {
+            lines: current_lines,
+            temp_index: current_temp,
+            operand: null,
+            diagnostics: diagnostics,
+            string_constants: []
+        };
     }
 
     // IMPORTANT: `i8*` arrays are the runtime's "string array" ABI and are
@@ -166,14 +178,29 @@ fn lower_array_push_in_place(array: LLVMOperand, value: LLVMOperand, element_typ
         // NOTE: Do not embed `{ ... }` literally in Sailfin strings; braces are
         // treated as interpolation markers. Use `array.llvm_type` instead.
         current_lines.push("  " + pushed + " = call " + array.llvm_type + " @sailfin_runtime_append_string(" + array.llvm_type + " " + array.value + ", i8* " + value.value + ")");
-        let result_operand = LLVMOperand { llvm_type: array.llvm_type, value: pushed };
-        return ExpressionResult { lines: current_lines, temp_index: current_temp, operand: result_operand, diagnostics: diagnostics, string_constants: [] };
+        let result_operand = LLVMOperand {
+            llvm_type: array.llvm_type,
+            value: pushed
+        };
+        return ExpressionResult {
+            lines: current_lines,
+            temp_index: current_temp,
+            operand: result_operand,
+            diagnostics: diagnostics,
+            string_constants: []
+        };
     }
 
     let array_struct_type = array_struct_type_for_element(element_type);
     if array_struct_type.length == 0 {
         diagnostics.push("llvm lowering: unsupported push element type `" + element_type + "`");
-        return ExpressionResult { lines: current_lines, temp_index: current_temp, operand: null, diagnostics: diagnostics, string_constants: [] };
+        return ExpressionResult {
+            lines: current_lines,
+            temp_index: current_temp,
+            operand: null,
+            diagnostics: diagnostics,
+            string_constants: []
+        };
     }
 
     let data_pointer_type = element_type + "*";
@@ -224,7 +251,13 @@ fn lower_array_push_in_place(array: LLVMOperand, value: LLVMOperand, element_typ
     }
     current_lines.push("  store " + element_type + " " + store_value + ", " + element_type + "* " + slot_typed);
 
-    return ExpressionResult { lines: current_lines, temp_index: current_temp, operand: array, diagnostics: diagnostics, string_constants: [] };
+    return ExpressionResult {
+        lines: current_lines,
+        temp_index: current_temp,
+        operand: array,
+        diagnostics: diagnostics,
+        string_constants: []
+    };
 }
 
 // Find the top-level comma in an LLVM type string, respecting nested braces.
@@ -234,9 +267,7 @@ fn find_top_level_comma_in_llvm_type(text: string) -> number {
     let mut brace_depth: number = 0;
     let mut index: number = 0;
     loop {
-        if index >= text.length {
-            break;
-        }
+        if index >= text.length { break; }
         let ch = substring(text, index, index + 1);
         if ch == "{" {
             brace_depth += 1;
@@ -244,16 +275,12 @@ fn find_top_level_comma_in_llvm_type(text: string) -> number {
             continue;
         }
         if ch == "}" {
-            if brace_depth > 0 {
-                brace_depth -= 1;
-            }
+            if brace_depth > 0 { brace_depth -= 1; }
             index += 1;
             continue;
         }
         if ch == "," {
-            if brace_depth == 0 {
-                return index;
-            }
+            if brace_depth == 0 { return index; }
         }
         index += 1;
     }
@@ -262,40 +289,26 @@ fn find_top_level_comma_in_llvm_type(text: string) -> number {
 
 fn array_pointer_element_type(llvm_type: string) -> string {
     let trimmed = trim_text(llvm_type);
-    if trimmed.length == 0 {
-        return "";
-    }
+    if trimmed.length == 0 { return ""; }
     if substring(trimmed, trimmed.length - 1, trimmed.length) != "*" {
         return "";
     }
     let without_pointer = trim_text(substring(trimmed, 0, trimmed.length - 1));
-    if without_pointer.length < 2 {
-        return "";
-    }
-    if substring(without_pointer, 0, 1) != "{" {
-        return "";
-    }
+    if without_pointer.length < 2 { return ""; }
+    if substring(without_pointer, 0, 1) != "{" { return ""; }
     if substring(without_pointer, without_pointer.length - 1, without_pointer.length) != "}" {
         return "";
     }
     let inner = trim_text(substring(without_pointer, 1, without_pointer.length - 1));
-    if inner.length == 0 {
-        return "";
-    }
+    if inner.length == 0 { return ""; }
     let comma_index = find_top_level_comma_in_llvm_type(inner);
-    if comma_index < 0 {
-        return "";
-    }
+    if comma_index < 0 { return ""; }
     let first_segment = trim_text(substring(inner, 0, comma_index));
-    if first_segment.length == 0 {
-        return "";
-    }
+    if first_segment.length == 0 { return ""; }
     if substring(first_segment, first_segment.length - 1, first_segment.length) != "*" {
         return "";
     }
     let element = trim_text(substring(first_segment, 0, first_segment.length - 1));
-    if element.length == 0 {
-        return "";
-    }
+    if element.length == 0 { return ""; }
     return element;
 }

--- a/compiler/src/llvm/expression_lowering/arrays.sfn
+++ b/compiler/src/llvm/expression_lowering/arrays.sfn
@@ -6,15 +6,11 @@
 // (`lower_struct_array_concat`), element type extraction from array pointer
 // types, and array struct type mapping.
 import { substring } from "../../string_utils";
-import { format_temp_name, } from "../expressions_helpers";
-import { strip_pointer_suffix, } from "../type_mapping";
-import { array_struct_type_for_element, } from "../type_mapping";
-import { ExpressionResult, LLVMOperand, } from "../types";
-import {
-    append_string,
-    ends_with,
-    trim_text,
-} from "../utils";
+import { format_temp_name } from "../expressions_helpers";
+import { strip_pointer_suffix } from "../type_mapping";
+import { array_struct_type_for_element } from "../type_mapping";
+import { ExpressionResult, LLVMOperand } from "../types";
+import { append_string, ends_with, trim_text } from "../utils";
 
 fn lower_struct_array_concat(lhs: LLVMOperand, rhs: LLVMOperand, element_type: string, lines: string[], temp_index: number) -> ExpressionResult {
     let mut current_lines = lines;
@@ -33,7 +29,9 @@ fn lower_struct_array_concat(lhs: LLVMOperand, rhs: LLVMOperand, element_type: s
 
     let array_struct_type = array_struct_type_for_element(element_type);
     if array_struct_type.length == 0 {
-        diagnostics.push("llvm lowering: unsupported concat element type `" + element_type + "`");
+        diagnostics.push("llvm lowering: unsupported concat element type `"
+            + element_type
+            + "`");
         return ExpressionResult {
             lines: current_lines,
             temp_index: current_temp,
@@ -48,96 +46,208 @@ fn lower_struct_array_concat(lhs: LLVMOperand, rhs: LLVMOperand, element_type: s
 
     let lhs_data_ptr = format_temp_name(current_temp);
     current_temp += 1;
-    current_lines.push("  " + lhs_data_ptr + " = getelementptr " + array_struct_type + ", " + lhs.llvm_type + " " + lhs.value + ", i32 0, i32 0");
+    current_lines.push("  " + lhs_data_ptr + " = getelementptr "
+        + array_struct_type
+        + ", "
+        + lhs.llvm_type
+        + " "
+        + lhs.value
+        + ", i32 0, i32 0");
     let lhs_data_value = format_temp_name(current_temp);
     current_temp += 1;
-    current_lines.push("  " + lhs_data_value + " = load " + data_pointer_type + ", " + data_pointer_pointer_type + " " + lhs_data_ptr);
+    current_lines.push("  " + lhs_data_value + " = load " + data_pointer_type
+        + ", "
+        + data_pointer_pointer_type
+        + " "
+        + lhs_data_ptr);
     let lhs_len_ptr = format_temp_name(current_temp);
     current_temp += 1;
-    current_lines.push("  " + lhs_len_ptr + " = getelementptr " + array_struct_type + ", " + lhs.llvm_type + " " + lhs.value + ", i32 0, i32 1");
+    current_lines.push("  " + lhs_len_ptr + " = getelementptr "
+        + array_struct_type
+        + ", "
+        + lhs.llvm_type
+        + " "
+        + lhs.value
+        + ", i32 0, i32 1");
     let lhs_len_value = format_temp_name(current_temp);
     current_temp += 1;
     current_lines.push("  " + lhs_len_value + " = load i64, i64* " + lhs_len_ptr);
 
     let rhs_data_ptr = format_temp_name(current_temp);
     current_temp += 1;
-    current_lines.push("  " + rhs_data_ptr + " = getelementptr " + array_struct_type + ", " + rhs.llvm_type + " " + rhs.value + ", i32 0, i32 0");
+    current_lines.push("  " + rhs_data_ptr + " = getelementptr "
+        + array_struct_type
+        + ", "
+        + rhs.llvm_type
+        + " "
+        + rhs.value
+        + ", i32 0, i32 0");
     let rhs_data_value = format_temp_name(current_temp);
     current_temp += 1;
-    current_lines.push("  " + rhs_data_value + " = load " + data_pointer_type + ", " + data_pointer_pointer_type + " " + rhs_data_ptr);
+    current_lines.push("  " + rhs_data_value + " = load " + data_pointer_type
+        + ", "
+        + data_pointer_pointer_type
+        + " "
+        + rhs_data_ptr);
     let rhs_len_ptr = format_temp_name(current_temp);
     current_temp += 1;
-    current_lines.push("  " + rhs_len_ptr + " = getelementptr " + array_struct_type + ", " + rhs.llvm_type + " " + rhs.value + ", i32 0, i32 1");
+    current_lines.push("  " + rhs_len_ptr + " = getelementptr "
+        + array_struct_type
+        + ", "
+        + rhs.llvm_type
+        + " "
+        + rhs.value
+        + ", i32 0, i32 1");
     let rhs_len_value = format_temp_name(current_temp);
     current_temp += 1;
     current_lines.push("  " + rhs_len_value + " = load i64, i64* " + rhs_len_ptr);
 
     let element_size_ptr = format_temp_name(current_temp);
     current_temp += 1;
-    current_lines.push("  " + element_size_ptr + " = getelementptr [1 x " + element_type + "], [1 x " + element_type + "]* null, i32 0, i32 1");
+    current_lines.push("  " + element_size_ptr + " = getelementptr [1 x "
+        + element_type
+        + "], [1 x "
+        + element_type
+        + "]* null, i32 0, i32 1");
     let element_size_value = format_temp_name(current_temp);
     current_temp += 1;
-    current_lines.push("  " + element_size_value + " = ptrtoint " + element_type + "* " + element_size_ptr + " to i64");
+    current_lines.push("  " + element_size_value + " = ptrtoint " + element_type
+        + "* "
+        + element_size_ptr
+        + " to i64");
 
     let total_length = format_temp_name(current_temp);
     current_temp += 1;
-    current_lines.push("  " + total_length + " = add i64 " + lhs_len_value + ", " + rhs_len_value);
+    current_lines.push("  " + total_length + " = add i64 " + lhs_len_value
+        + ", "
+        + rhs_len_value);
     let total_bytes = format_temp_name(current_temp);
     current_temp += 1;
-    current_lines.push("  " + total_bytes + " = mul i64 " + element_size_value + ", " + total_length);
+    current_lines.push("  " + total_bytes + " = mul i64 " + element_size_value
+        + ", "
+        + total_length);
 
     let new_raw_buffer = format_temp_name(current_temp);
     current_temp += 1;
-    current_lines.push("  " + new_raw_buffer + " = call noalias i8* @calloc(i64 1, i64 " + total_bytes + ")");
+    current_lines.push("  " + new_raw_buffer
+        + " = call noalias i8* @calloc(i64 1, i64 "
+        + total_bytes
+        + ")");
     let new_data_ptr = format_temp_name(current_temp);
     current_temp += 1;
-    current_lines.push("  " + new_data_ptr + " = bitcast i8* " + new_raw_buffer + " to " + data_pointer_type);
+    current_lines.push("  " + new_data_ptr + " = bitcast i8* " + new_raw_buffer
+        + " to "
+        + data_pointer_type);
     let new_data_i8 = format_temp_name(current_temp);
     current_temp += 1;
-    current_lines.push("  " + new_data_i8 + " = bitcast " + data_pointer_type + " " + new_data_ptr + " to i8*");
+    current_lines.push("  " + new_data_i8 + " = bitcast " + data_pointer_type
+        + " "
+        + new_data_ptr
+        + " to i8*");
 
     let lhs_bytes = format_temp_name(current_temp);
     current_temp += 1;
-    current_lines.push("  " + lhs_bytes + " = mul i64 " + element_size_value + ", " + lhs_len_value);
+    current_lines.push("  " + lhs_bytes + " = mul i64 " + element_size_value
+        + ", "
+        + lhs_len_value);
     let lhs_src_i8 = format_temp_name(current_temp);
     current_temp += 1;
-    current_lines.push("  " + lhs_src_i8 + " = bitcast " + data_pointer_type + " " + lhs_data_value + " to i8*");
-    current_lines.push("  call void @sailfin_runtime_copy_bytes(i8* " + new_data_i8 + ", i8* " + lhs_src_i8 + ", i64 " + lhs_bytes + ")");
+    current_lines.push("  " + lhs_src_i8 + " = bitcast " + data_pointer_type
+        + " "
+        + lhs_data_value
+        + " to i8*");
+    current_lines.push("  call void @sailfin_runtime_copy_bytes(i8* "
+        + new_data_i8
+        + ", i8* "
+        + lhs_src_i8
+        + ", i64 "
+        + lhs_bytes
+        + ")");
 
     let rhs_bytes = format_temp_name(current_temp);
     current_temp += 1;
-    current_lines.push("  " + rhs_bytes + " = mul i64 " + element_size_value + ", " + rhs_len_value);
+    current_lines.push("  " + rhs_bytes + " = mul i64 " + element_size_value
+        + ", "
+        + rhs_len_value);
     let rhs_src_i8 = format_temp_name(current_temp);
     current_temp += 1;
-    current_lines.push("  " + rhs_src_i8 + " = bitcast " + data_pointer_type + " " + rhs_data_value + " to i8*");
+    current_lines.push("  " + rhs_src_i8 + " = bitcast " + data_pointer_type
+        + " "
+        + rhs_data_value
+        + " to i8*");
     let rhs_dest_ptr = format_temp_name(current_temp);
     current_temp += 1;
-    current_lines.push("  " + rhs_dest_ptr + " = getelementptr " + element_type + ", " + data_pointer_type + " " + new_data_ptr + ", i64 " + lhs_len_value);
+    current_lines.push("  " + rhs_dest_ptr + " = getelementptr " + element_type
+        + ", "
+        + data_pointer_type
+        + " "
+        + new_data_ptr
+        + ", i64 "
+        + lhs_len_value);
     let rhs_dest_i8 = format_temp_name(current_temp);
     current_temp += 1;
-    current_lines.push("  " + rhs_dest_i8 + " = bitcast " + data_pointer_type + " " + rhs_dest_ptr + " to i8*");
-    current_lines.push("  call void @sailfin_runtime_copy_bytes(i8* " + rhs_dest_i8 + ", i8* " + rhs_src_i8 + ", i64 " + rhs_bytes + ")");
+    current_lines.push("  " + rhs_dest_i8 + " = bitcast " + data_pointer_type
+        + " "
+        + rhs_dest_ptr
+        + " to i8*");
+    current_lines.push("  call void @sailfin_runtime_copy_bytes(i8* "
+        + rhs_dest_i8
+        + ", i8* "
+        + rhs_src_i8
+        + ", i64 "
+        + rhs_bytes
+        + ")");
 
     let struct_size_ptr = format_temp_name(current_temp);
     current_temp += 1;
-    current_lines.push("  " + struct_size_ptr + " = getelementptr " + array_struct_type + ", " + array_struct_type + "* null, i32 1");
+    current_lines.push("  " + struct_size_ptr + " = getelementptr "
+        + array_struct_type
+        + ", "
+        + array_struct_type
+        + "* null, i32 1");
     let struct_size_value = format_temp_name(current_temp);
     current_temp += 1;
-    current_lines.push("  " + struct_size_value + " = ptrtoint " + array_struct_type + "* " + struct_size_ptr + " to i64");
+    current_lines.push("  " + struct_size_value + " = ptrtoint "
+        + array_struct_type
+        + "* "
+        + struct_size_ptr
+        + " to i64");
 
     let new_struct_raw = format_temp_name(current_temp);
     current_temp += 1;
-    current_lines.push("  " + new_struct_raw + " = call i8* @calloc(i64 1, i64 " + struct_size_value + ")");
+    current_lines.push("  " + new_struct_raw + " = call i8* @calloc(i64 1, i64 "
+        + struct_size_value
+        + ")");
     let new_struct_ptr = format_temp_name(current_temp);
     current_temp += 1;
-    current_lines.push("  " + new_struct_ptr + " = bitcast i8* " + new_struct_raw + " to " + array_struct_type + "*");
+    current_lines.push("  " + new_struct_ptr + " = bitcast i8* "
+        + new_struct_raw
+        + " to "
+        + array_struct_type
+        + "*");
     let new_data_field = format_temp_name(current_temp);
     current_temp += 1;
-    current_lines.push("  " + new_data_field + " = getelementptr " + array_struct_type + ", " + array_struct_type + "* " + new_struct_ptr + ", i32 0, i32 0");
-    current_lines.push("  store " + data_pointer_type + " " + new_data_ptr + ", " + data_pointer_pointer_type + " " + new_data_field);
+    current_lines.push("  " + new_data_field + " = getelementptr "
+        + array_struct_type
+        + ", "
+        + array_struct_type
+        + "* "
+        + new_struct_ptr
+        + ", i32 0, i32 0");
+    current_lines.push("  store " + data_pointer_type + " " + new_data_ptr
+        + ", "
+        + data_pointer_pointer_type
+        + " "
+        + new_data_field);
     let new_len_field = format_temp_name(current_temp);
     current_temp += 1;
-    current_lines.push("  " + new_len_field + " = getelementptr " + array_struct_type + ", " + array_struct_type + "* " + new_struct_ptr + ", i32 0, i32 1");
+    current_lines.push("  " + new_len_field + " = getelementptr "
+        + array_struct_type
+        + ", "
+        + array_struct_type
+        + "* "
+        + new_struct_ptr
+        + ", i32 0, i32 1");
     current_lines.push("  store i64 " + total_length + ", i64* " + new_len_field);
 
     let result_operand = LLVMOperand {
@@ -177,7 +287,14 @@ fn lower_array_push_in_place(array: LLVMOperand, value: LLVMOperand, element_typ
         current_temp += 1;
         // NOTE: Do not embed `{ ... }` literally in Sailfin strings; braces are
         // treated as interpolation markers. Use `array.llvm_type` instead.
-        current_lines.push("  " + pushed + " = call " + array.llvm_type + " @sailfin_runtime_append_string(" + array.llvm_type + " " + array.value + ", i8* " + value.value + ")");
+        current_lines.push("  " + pushed + " = call " + array.llvm_type
+            + " @sailfin_runtime_append_string("
+            + array.llvm_type
+            + " "
+            + array.value
+            + ", i8* "
+            + value.value
+            + ")");
         let result_operand = LLVMOperand {
             llvm_type: array.llvm_type,
             value: pushed
@@ -193,7 +310,9 @@ fn lower_array_push_in_place(array: LLVMOperand, value: LLVMOperand, element_typ
 
     let array_struct_type = array_struct_type_for_element(element_type);
     if array_struct_type.length == 0 {
-        diagnostics.push("llvm lowering: unsupported push element type `" + element_type + "`");
+        diagnostics.push("llvm lowering: unsupported push element type `"
+            + element_type
+            + "`");
         return ExpressionResult {
             lines: current_lines,
             temp_index: current_temp,
@@ -209,32 +328,63 @@ fn lower_array_push_in_place(array: LLVMOperand, value: LLVMOperand, element_typ
     // Read current array fields.
     let data_ptr_gep = format_temp_name(current_temp);
     current_temp += 1;
-    current_lines.push("  " + data_ptr_gep + " = getelementptr " + array_struct_type + ", " + array.llvm_type + " " + array.value + ", i32 0, i32 0");
+    current_lines.push("  " + data_ptr_gep + " = getelementptr "
+        + array_struct_type
+        + ", "
+        + array.llvm_type
+        + " "
+        + array.value
+        + ", i32 0, i32 0");
     let len_ptr = format_temp_name(current_temp);
     current_temp += 1;
-    current_lines.push("  " + len_ptr + " = getelementptr " + array_struct_type + ", " + array.llvm_type + " " + array.value + ", i32 0, i32 1");
+    current_lines.push("  " + len_ptr + " = getelementptr " + array_struct_type
+        + ", "
+        + array.llvm_type
+        + " "
+        + array.value
+        + ", i32 0, i32 1");
     // Compute element size in bytes.
     let element_size_ptr = format_temp_name(current_temp);
     current_temp += 1;
-    current_lines.push("  " + element_size_ptr + " = getelementptr [1 x " + element_type + "], [1 x " + element_type + "]* null, i32 0, i32 1");
+    current_lines.push("  " + element_size_ptr + " = getelementptr [1 x "
+        + element_type
+        + "], [1 x "
+        + element_type
+        + "]* null, i32 0, i32 1");
     let element_size_value = format_temp_name(current_temp);
     current_temp += 1;
-    current_lines.push("  " + element_size_value + " = ptrtoint " + element_type + "* " + element_size_ptr + " to i64");
+    current_lines.push("  " + element_size_value + " = ptrtoint " + element_type
+        + "* "
+        + element_size_ptr
+        + " to i64");
 
     // Ask the runtime to grow backing storage (realloc) and return a writable
     // slot pointer. This avoids per-push malloc+copy, which is quadratic for
     // large struct arrays (e.g., Token[] during lexing).
     let data_ptr_i8 = format_temp_name(current_temp);
     current_temp += 1;
-    current_lines.push("  " + data_ptr_i8 + " = bitcast " + data_pointer_pointer_type + " " + data_ptr_gep + " to i8**");
+    current_lines.push("  " + data_ptr_i8 + " = bitcast "
+        + data_pointer_pointer_type
+        + " "
+        + data_ptr_gep
+        + " to i8**");
 
     let slot_i8 = format_temp_name(current_temp);
     current_temp += 1;
-    current_lines.push("  " + slot_i8 + " = call i8* @sailfin_runtime_array_push_slot(i8** " + data_ptr_i8 + ", i64* " + len_ptr + ", i64 " + element_size_value + ")");
+    current_lines.push("  " + slot_i8
+        + " = call i8* @sailfin_runtime_array_push_slot(i8** "
+        + data_ptr_i8
+        + ", i64* "
+        + len_ptr
+        + ", i64 "
+        + element_size_value
+        + ")");
 
     let slot_typed = format_temp_name(current_temp);
     current_temp += 1;
-    current_lines.push("  " + slot_typed + " = bitcast i8* " + slot_i8 + " to " + element_type + "*");
+    current_lines.push("  " + slot_typed + " = bitcast i8* " + slot_i8 + " to "
+        + element_type
+        + "*");
 
     // When the value operand is a pointer to the element type (common for
     // nullable struct fields like `coerced.operand` of type `LLVMOperand?`),
@@ -245,11 +395,18 @@ fn lower_array_push_in_place(array: LLVMOperand, value: LLVMOperand, element_typ
         if deref_base == element_type {
             let deref_temp = format_temp_name(current_temp);
             current_temp += 1;
-            current_lines.push("  " + deref_temp + " = load " + element_type + ", " + value.llvm_type + " " + value.value);
+            current_lines.push("  " + deref_temp + " = load " + element_type
+                + ", "
+                + value.llvm_type
+                + " "
+                + value.value);
             store_value = deref_temp;
         }
     }
-    current_lines.push("  store " + element_type + " " + store_value + ", " + element_type + "* " + slot_typed);
+    current_lines.push("  store " + element_type + " " + store_value + ", "
+        + element_type
+        + "* "
+        + slot_typed);
 
     return ExpressionResult {
         lines: current_lines,

--- a/compiler/src/llvm/expression_lowering/bindings.sfn
+++ b/compiler/src/llvm/expression_lowering/bindings.sfn
@@ -5,7 +5,6 @@
 // Provides lookup and mutation helpers for parameter/local bindings during
 // expression lowering: finding bindings by name, marking consumption state,
 // resetting consumption, and updating ownership metadata.
-
 import {
     LocalBinding,
     ParameterBinding,
@@ -15,13 +14,9 @@ import {
 fn bindings_find_parameter_binding(bindings: ParameterBinding[], name: string) -> ParameterBinding? {
     let mut index: number = 0;
     loop {
-        if index >= bindings.length {
-            break;
-        }
+        if index >= bindings.length { break; }
         let binding = bindings[index];
-        if binding.name == name {
-            return binding;
-        }
+        if binding.name == name { return binding; }
         index += 1;
     }
     return null;
@@ -31,9 +26,7 @@ fn bindings_mark_parameter_consumed(bindings: ParameterBinding[], name: string) 
     let mut result: ParameterBinding[] = [];
     let mut index: number = 0;
     loop {
-        if index >= bindings.length {
-            break;
-        }
+        if index >= bindings.length { break; }
         let binding = bindings[index];
         if binding.name == name {
             let updated = ParameterBinding {
@@ -45,9 +38,7 @@ fn bindings_mark_parameter_consumed(bindings: ParameterBinding[], name: string) 
                 span: binding.span,
             };
             result.push(updated);
-        } else {
-            result.push(binding);
-        }
+        } else { result.push(binding); }
         index += 1;
     }
     return result;
@@ -57,9 +48,7 @@ fn bindings_mark_local_consumed(locals: LocalBinding[], name: string) -> LocalBi
     let mut result: LocalBinding[] = [];
     let mut index: number = 0;
     loop {
-        if index >= locals.length {
-            break;
-        }
+        if index >= locals.length { break; }
         let entry = locals[index];
         if entry.name == name {
             let updated = LocalBinding {
@@ -73,9 +62,7 @@ fn bindings_mark_local_consumed(locals: LocalBinding[], name: string) -> LocalBi
                 scope_depth: entry.scope_depth,
             };
             result.push(updated);
-        } else {
-            result.push(entry);
-        }
+        } else { result.push(entry); }
         index += 1;
     }
     return result;
@@ -85,9 +72,7 @@ fn bindings_reset_local_consumption(locals: LocalBinding[], name: string) -> Loc
     let mut result: LocalBinding[] = [];
     let mut index: number = 0;
     loop {
-        if index >= locals.length {
-            break;
-        }
+        if index >= locals.length { break; }
         let entry = locals[index];
         if entry.name == name {
             let updated = LocalBinding {
@@ -101,9 +86,7 @@ fn bindings_reset_local_consumption(locals: LocalBinding[], name: string) -> Loc
                 scope_depth: entry.scope_depth,
             };
             result.push(updated);
-        } else {
-            result.push(entry);
-        }
+        } else { result.push(entry); }
         index += 1;
     }
     return result;
@@ -113,9 +96,7 @@ fn bindings_update_local_ownership(locals: LocalBinding[], name: string, ownersh
     let mut result: LocalBinding[] = [];
     let mut index: number = 0;
     loop {
-        if index >= locals.length {
-            break;
-        }
+        if index >= locals.length { break; }
         let entry = locals[index];
         if entry.name == name {
             let updated = LocalBinding {
@@ -129,9 +110,7 @@ fn bindings_update_local_ownership(locals: LocalBinding[], name: string, ownersh
                 scope_depth: entry.scope_depth,
             };
             result.push(updated);
-        } else {
-            result.push(entry);
-        }
+        } else { result.push(entry); }
         index += 1;
     }
     return result;

--- a/compiler/src/llvm/expression_lowering/bindings.sfn
+++ b/compiler/src/llvm/expression_lowering/bindings.sfn
@@ -5,11 +5,7 @@
 // Provides lookup and mutation helpers for parameter/local bindings during
 // expression lowering: finding bindings by name, marking consumption state,
 // resetting consumption, and updating ownership metadata.
-import {
-    LocalBinding,
-    ParameterBinding,
-    OwnershipInfo,
-} from "../types";
+import { LocalBinding, ParameterBinding, OwnershipInfo } from "../types";
 
 fn bindings_find_parameter_binding(bindings: ParameterBinding[], name: string) -> ParameterBinding? {
     let mut index: number = 0;
@@ -35,7 +31,7 @@ fn bindings_mark_parameter_consumed(bindings: ParameterBinding[], name: string) 
                 llvm_type: binding.llvm_type,
                 type_annotation: binding.type_annotation,
                 consumed: true,
-                span: binding.span,
+                span: binding.span
             };
             result.push(updated);
         } else { result.push(binding); }
@@ -59,7 +55,7 @@ fn bindings_mark_local_consumed(locals: LocalBinding[], name: string) -> LocalBi
                 ownership: entry.ownership,
                 consumed: true,
                 scope_id: entry.scope_id,
-                scope_depth: entry.scope_depth,
+                scope_depth: entry.scope_depth
             };
             result.push(updated);
         } else { result.push(entry); }
@@ -83,7 +79,7 @@ fn bindings_reset_local_consumption(locals: LocalBinding[], name: string) -> Loc
                 ownership: entry.ownership,
                 consumed: false,
                 scope_id: entry.scope_id,
-                scope_depth: entry.scope_depth,
+                scope_depth: entry.scope_depth
             };
             result.push(updated);
         } else { result.push(entry); }
@@ -107,7 +103,7 @@ fn bindings_update_local_ownership(locals: LocalBinding[], name: string, ownersh
                 ownership: ownership,
                 consumed: entry.consumed,
                 scope_id: entry.scope_id,
-                scope_depth: entry.scope_depth,
+                scope_depth: entry.scope_depth
             };
             result.push(updated);
         } else { result.push(entry); }

--- a/compiler/src/llvm/expression_lowering/native/core.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core.sfn
@@ -112,7 +112,7 @@ import {
     matches_keyword,
     merge_parameter_bindings,
     is_effect_delimiter,
-    extend_string_array,
+    extend_string_array
 } from "../../utils";
 
 import {
@@ -146,7 +146,7 @@ import {
     encode_string_literal_for_sailfin,
     escape_string_for_sailfin_literal,
     unescape_string_literal,
-    sanitize_symbol,
+    sanitize_symbol
 } from "./core_text";
 
 export {
@@ -155,7 +155,7 @@ export {
     extract_simple_identifier,
     unescape_string_literal,
     make_string_constant_name,
-    make_string_constant_name_for_module,
+    make_string_constant_name_for_module
 } from "./core_text";
 
 import {
@@ -164,7 +164,7 @@ import {
     parse_enum_literal,
     parse_member_access,
     parse_index_expression,
-    parse_range_iterable,
+    parse_range_iterable
 } from "./core_parse";
 
 export {
@@ -173,7 +173,7 @@ export {
     parse_enum_literal,
     parse_member_access,
     parse_index_expression,
-    parse_range_iterable,
+    parse_range_iterable
 } from "./core_parse";
 
 import {
@@ -183,7 +183,7 @@ import {
     coerce_operand_to_type,
     dominant_type,
     is_string_pointer_type,
-    harmonise_operands,
+    harmonise_operands
 } from "./core_operands";
 
 export {
@@ -193,7 +193,7 @@ export {
     coerce_operand_to_type,
     dominant_type,
     is_string_pointer_type,
-    harmonise_operands,
+    harmonise_operands
 } from "./core_operands";
 
 import {
@@ -211,7 +211,7 @@ import {
     append_struct_literal_field,
     append_native_struct,
     append_native_enum,
-    replace_llvm_operand,
+    replace_llvm_operand
 } from "./core_scopes";
 
 export {
@@ -229,7 +229,7 @@ export {
     append_struct_literal_field,
     append_native_struct,
     append_native_enum,
-    replace_llvm_operand,
+    replace_llvm_operand
 } from "./core_scopes";
 
 import {
@@ -251,7 +251,7 @@ import {
     annotation_is_array,
     layout_annotation_represents_user_value,
     is_copy_type,
-    array_struct_type_for_element,
+    array_struct_type_for_element
 } from "../../type_mapping";
 
 import { fixup_enum_layouts } from "../../type_context";
@@ -273,9 +273,9 @@ import {
     find_variant_field_info
 } from "../../type_context_queries";
 
-import { find_function_by_name, } from "../../rendering";
+import { find_function_by_name } from "../../rendering";
 
-import { find_runtime_helper, } from "../../runtime_helpers";
+import { find_runtime_helper } from "../../runtime_helpers";
 
 import {
     format_temp_name,
@@ -283,7 +283,7 @@ import {
     format_typed_operand,
     default_return_literal,
     strip_mut_prefix,
-    is_simple_identifier,
+    is_simple_identifier
 } from "../../expressions_helpers";
 
 import {
@@ -291,7 +291,7 @@ import {
     mark_parameter_consumed,
     mark_local_consumed,
     reset_local_consumption,
-    update_local_ownership,
+    update_local_ownership
 } from "./core_bindings";
 
 import {
@@ -311,7 +311,7 @@ import {
     map_return_type,
     future_pointer_type_for_return_type,
     await_symbol_for_future_pointer_type,
-    map_parameter_type,
+    map_parameter_type
 } from "./core_type_mapping";
 
 import {
@@ -323,7 +323,7 @@ import {
     parse_raw_address_expression,
     parse_cast_expression,
     parse_array_literal_metadata,
-    map_metadata_annotation,
+    map_metadata_annotation
 } from "./core_parsing";
 
 import {
@@ -331,35 +331,31 @@ import {
     find_top_level_operator,
     find_comparison_operator,
     find_logical_operator,
-    lines_end_with_terminator,
+    lines_end_with_terminator
 } from "./core_operators";
 
-import {
-    lower_string_literal,
-    emit_string_concat,
-    coerce_operand_to_string,
-} from "./core_strings";
+import { lower_string_literal, emit_string_concat, coerce_operand_to_string } from "./core_strings";
 
-import { find_call_site, split_call_arguments, } from "./core_calls";
+import { find_call_site, split_call_arguments } from "./core_calls";
 
-import { lower_raw_address_expression, } from "./core_addressing";
+import { lower_raw_address_expression } from "./core_addressing";
 
 import {
     analyze_value_ownership_impl,
     detect_borrow_conflicts_impl,
     format_suspension_location_impl,
-    resolve_borrow_base_impl,
+    resolve_borrow_base_impl
 } from "./core_ownership";
 
-import { split_array_elements, } from "../splitting";
+import { split_array_elements } from "../splitting";
 
-import { collect_parameter_types, operation_name_for_symbol, } from "./core_helpers";
+import { collect_parameter_types, operation_name_for_symbol } from "./core_helpers";
 
 import {
     lower_struct_array_concat,
     lower_array_push_in_place,
     find_top_level_comma_in_llvm_type,
-    array_pointer_element_type,
+    array_pointer_element_type
 } from "../arrays";
 
 import {
@@ -369,7 +365,7 @@ import {
     lower_binary_operation,
     lower_comparison_operation,
     lower_logical_and,
-    lower_logical_or,
+    lower_logical_or
 } from "./core_ops_lowering";
 
 import { lower_borrow_expression } from "./core_borrow_lowering";
@@ -382,7 +378,7 @@ import {
     lower_struct_literal,
     lower_enum_literal,
     lower_cast_expression,
-    try_lower_interpolated_string_literal,
+    try_lower_interpolated_string_literal
 } from "./core_literals_lowering";
 
 fn analyze_value_ownership(initializer: string?, span: NativeSourceSpan?, locals: LocalBinding[], bindings: ParameterBinding[]) -> OwnershipAnalysis {
@@ -407,7 +403,11 @@ fn lower_expression(expression: string, bindings: ParameterBinding[], locals: Lo
     let empty_constants = empty_string_constant_set();
     let dbg_expr = fs.exists("build/sailfin/.trace_lowering");
     if dbg_expr {
-        print.err("emit-llvm: lower_expression ENTER expr=" + trimmed + " bindings_len=" + number_to_string(bindings.length) + " expected=" + expected_type);
+        print.err("emit-llvm: lower_expression ENTER expr=" + trimmed
+            + " bindings_len="
+            + number_to_string(bindings.length)
+            + " expected="
+            + expected_type);
     }
     if trimmed.length == 0 {
         diagnostics.push("llvm lowering: empty expression encountered");
@@ -562,7 +562,9 @@ fn lower_expression(expression: string, bindings: ParameterBinding[], locals: Lo
             let future_operand = lowered.operand;
             let await_symbol = await_symbol_for_future_pointer_type(future_operand.llvm_type);
             if await_symbol.length == 0 {
-                let with_issue = append_string(diagnostics, "llvm lowering: await expects a Future pointer, got `" + future_operand.llvm_type + "`");
+                let with_issue = append_string(diagnostics, "llvm lowering: await expects a Future pointer, got `"
+                    + future_operand.llvm_type
+                    + "`");
                 return ExpressionResult {
                     lines: lowered.lines,
                     temp_index: lowered.temp_index,
@@ -574,7 +576,11 @@ fn lower_expression(expression: string, bindings: ParameterBinding[], locals: Lo
 
             // Await returns a value whose type depends on the future kind.
             if future_operand.llvm_type == "%SailfinFutureVoid*" {
-                let mut awaited_lines = append_string(lowered.lines, "  call void @" + await_symbol + "(%SailfinFutureVoid* " + future_operand.value + ")");
+                let mut awaited_lines = append_string(lowered.lines, "  call void @"
+                    + await_symbol
+                    + "(%SailfinFutureVoid* "
+                    + future_operand.value
+                    + ")");
                 let out_operand = LLVMOperand {
                     llvm_type: "void",
                     value: ""
@@ -598,7 +604,14 @@ fn lower_expression(expression: string, bindings: ParameterBinding[], locals: Lo
                 result_type = "i1";
             }
             let result_temp = format_temp_name(lowered.temp_index);
-            let awaited_call = "  " + result_temp + " = call " + result_type + " @" + await_symbol + "(" + future_operand.llvm_type + " " + future_operand.value + ")";
+            let awaited_call = "  " + result_temp + " = call " + result_type
+                + " @"
+                + await_symbol
+                + "("
+                + future_operand.llvm_type
+                + " "
+                + future_operand.value
+                + ")";
             let mut awaited_lines2 = append_string(lowered.lines, awaited_call);
 
             // If we're awaiting an opaque pointer future in a typed context, try to unbox.
@@ -631,11 +644,25 @@ fn lower_expression(expression: string, bindings: ParameterBinding[], locals: Lo
                 if trimmed_expected.length > 0 {
                     if trimmed_expected != "i8*" {
                         if !ends_with_pointer_suffix(trimmed_expected) {
-                            let typed_ptr_temp = format_temp_name(lowered.temp_index + 1);
-                            let load_temp = format_temp_name(lowered.temp_index + 2);
-                            awaited_lines2.push("  " + typed_ptr_temp + " = bitcast i8* " + result_temp + " to " + trimmed_expected + "*");
-                            awaited_lines2.push("  " + load_temp + " = load " + trimmed_expected + ", " + trimmed_expected + "* " + typed_ptr_temp);
-                            awaited_lines2.push("  call void @free(i8* " + result_temp + ")");
+                            let typed_ptr_temp = format_temp_name(lowered.temp_index
+                                + 1);
+                            let load_temp = format_temp_name(lowered.temp_index
+                                + 2);
+                            awaited_lines2.push("  " + typed_ptr_temp
+                                + " = bitcast i8* "
+                                + result_temp
+                                + " to "
+                                + trimmed_expected
+                                + "*");
+                            awaited_lines2.push("  " + load_temp + " = load "
+                                + trimmed_expected
+                                + ", "
+                                + trimmed_expected
+                                + "* "
+                                + typed_ptr_temp);
+                            awaited_lines2.push("  call void @free(i8* "
+                                + result_temp
+                                + ")");
                             let out_operand_unboxed = LLVMOperand {
                                 llvm_type: trimmed_expected,
                                 value: load_temp
@@ -712,11 +739,18 @@ fn lower_expression(expression: string, bindings: ParameterBinding[], locals: Lo
     if dbg_expr {
         let mut add_succ = "false";
         if additive.success { add_succ = "true"; }
-        print.err("emit-llvm: lower_expression additive_check expr=" + stripped + " success=" + add_succ + " index=" + number_to_string(additive.index) + " symbol=" + additive.symbol);
+        print.err("emit-llvm: lower_expression additive_check expr=" + stripped
+            + " success="
+            + add_succ
+            + " index="
+            + number_to_string(additive.index)
+            + " symbol="
+            + additive.symbol);
     }
     if additive.success {
         if dbg_expr {
-            print.err("emit-llvm: lower_expression DISPATCH binary_op expr=" + stripped);
+            print.err("emit-llvm: lower_expression DISPATCH binary_op expr="
+                + stripped);
         }
         return lower_binary_operation(stripped, additive, bindings, locals, temp_index, lines, functions, context);
     }
@@ -767,7 +801,9 @@ fn lower_expression(expression: string, bindings: ParameterBinding[], locals: Lo
             }
             let ptr_operand = lowered_ptr.operand;
             if !ends_with_pointer_suffix(ptr_operand.llvm_type) {
-                let with_issue = append_string(diagnostics, "llvm lowering: cannot dereference non-pointer type `" + ptr_operand.llvm_type + "`");
+                let with_issue = append_string(diagnostics, "llvm lowering: cannot dereference non-pointer type `"
+                    + ptr_operand.llvm_type
+                    + "`");
                 return ExpressionResult {
                     lines: lowered_ptr.lines,
                     temp_index: lowered_ptr.temp_index,
@@ -778,7 +814,14 @@ fn lower_expression(expression: string, bindings: ParameterBinding[], locals: Lo
             }
             let element_type = strip_pointer_suffix(ptr_operand.llvm_type);
             let load_name = format_temp_name(lowered_ptr.temp_index);
-            let updated_lines = append_string(lowered_ptr.lines, "  " + load_name + " = load " + element_type + ", " + element_type + "* " + ptr_operand.value);
+            let updated_lines = append_string(lowered_ptr.lines, "  "
+                + load_name
+                + " = load "
+                + element_type
+                + ", "
+                + element_type
+                + "* "
+                + ptr_operand.value);
             let operand = LLVMOperand {
                 llvm_type: element_type,
                 value: load_name
@@ -935,7 +978,10 @@ fn lower_expression(expression: string, bindings: ParameterBinding[], locals: Lo
         if parameter != null {
             param_found = parameter.name + " -> " + parameter.llvm_name;
         }
-        print.err("emit-llvm: lower_expression param_lookup stripped=" + stripped + " result=" + param_found);
+        print.err("emit-llvm: lower_expression param_lookup stripped="
+            + stripped
+            + " result="
+            + param_found);
     }
     if parameter != null {
         let operand = LLVMOperand {
@@ -970,9 +1016,11 @@ fn lower_expression(expression: string, bindings: ParameterBinding[], locals: Lo
     }
 
     if dbg_expr {
-        print.err("emit-llvm: lower_expression FALLTHROUGH expr=" + stripped + " (unhandled)");
+        print.err("emit-llvm: lower_expression FALLTHROUGH expr=" + stripped
+            + " (unhandled)");
     }
-    diagnostics.push("llvm lowering: unable to lower expression `" + expression + "`");
+    diagnostics.push("llvm lowering: unable to lower expression `" + expression
+        + "`");
     return ExpressionResult {
         lines: lines,
         temp_index: temp_index,

--- a/compiler/src/llvm/expression_lowering/native/core.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core.sfn
@@ -6,35 +6,108 @@
 // transforms Sailfin expressions into LLVM IR. It handles ownership/borrow
 // analysis (`analyze_value_ownership`, `detect_borrow_conflicts`) and
 // orchestrates calls to helper modules for operands, scopes, parsing, and text.
-
-import { NativeFunction, NativeSourceSpan, NativeStruct, NativeEnum } from "../../../native_ir";
-import { substring, char_code, char_at, find_char, find_last_index_of_char, index_of } from "../../../string_utils";
+import {
+    NativeFunction,
+    NativeSourceSpan,
+    NativeStruct,
+    NativeEnum
+} from "../../../native_ir";
+import {
+    substring,
+    char_code,
+    char_at,
+    find_char,
+    find_last_index_of_char,
+    index_of
+} from "../../../string_utils";
 
 import {
-    TypeContext, StructTypeInfo, StructFieldInfo, EnumTypeInfo, EnumVariantInfo,
-    InterfaceTypeInfo, VTableInfo, VTableEntry, LocalBinding, ParameterBinding,
-    OwnershipInfo, OwnershipConsumption, OwnershipAnalysis, LifetimeRegionMetadata,
-    LifetimeReleaseEvent, ScopeMetadata, LLVMOperand, ExpressionResult, CoercionResult,
-    BlockLoweringResult, LoweredLLVMFunction, LoweredLLVMResult, LetLoweringResult,
-    ModuleGlobalLoweringResult, OperatorMatch, BorrowParseResult, BorrowArgumentParse,
-    TernaryParseResult, AssignmentParseResult, InlineLetParseResult, MemberAccessParse,
-    IndexExpressionParse, RawAddressParseResult, CastParseResult, TraitMetadata,
-    TraitDescriptor, TraitImplementationDescriptor, FunctionEffectEntry, RuntimeHelperDescriptor,
-    CapabilityManifest, CapabilityManifestEntry, StringConstant, LocalMutation, LoopContext,
-    ImportedModuleContext, LayoutManifestApplication, TypeContextBuild, FunctionCallEntry,
-    StringPointerResult, InterpolatedTemplateParse, BodyResult, ParameterPreparation,
-    ArrayLiteralMetadata, TypeAllocationInfo, HeapBoxResult, StructLiteralField,
-    StructLiteralParse, EnumLiteralParse, ExpressionStatementResult, BlockLabelResult,
-    IfStructure, LoopStructure, TryStructure, RangeIterableParse, MatchCaseStructure,
-    MatchStructure, MatchFieldBinding, MatchStructFieldBinding, MatchCaseCondition,
-    ConditionConversion, ComparisonEmission, BinaryAlignmentResult,
-    ThrowLoweringResult, PhiMergeResult, PhiInputEntry, MutationMaterializationResult,
-    PhiStoreEntry, MatchArmMutations, LoadLocalResult
+    TypeContext,
+    StructTypeInfo,
+    StructFieldInfo,
+    EnumTypeInfo,
+    EnumVariantInfo,
+    InterfaceTypeInfo,
+    VTableInfo,
+    VTableEntry,
+    LocalBinding,
+    ParameterBinding,
+    OwnershipInfo,
+    OwnershipConsumption,
+    OwnershipAnalysis,
+    LifetimeRegionMetadata,
+    LifetimeReleaseEvent,
+    ScopeMetadata,
+    LLVMOperand,
+    ExpressionResult,
+    CoercionResult,
+    BlockLoweringResult,
+    LoweredLLVMFunction,
+    LoweredLLVMResult,
+    LetLoweringResult,
+    ModuleGlobalLoweringResult,
+    OperatorMatch,
+    BorrowParseResult,
+    BorrowArgumentParse,
+    TernaryParseResult,
+    AssignmentParseResult,
+    InlineLetParseResult,
+    MemberAccessParse,
+    IndexExpressionParse,
+    RawAddressParseResult,
+    CastParseResult,
+    TraitMetadata,
+    TraitDescriptor,
+    TraitImplementationDescriptor,
+    FunctionEffectEntry,
+    RuntimeHelperDescriptor,
+    CapabilityManifest,
+    CapabilityManifestEntry,
+    StringConstant,
+    LocalMutation,
+    LoopContext,
+    ImportedModuleContext,
+    LayoutManifestApplication,
+    TypeContextBuild,
+    FunctionCallEntry,
+    StringPointerResult,
+    InterpolatedTemplateParse,
+    BodyResult,
+    ParameterPreparation,
+    ArrayLiteralMetadata,
+    TypeAllocationInfo,
+    HeapBoxResult,
+    StructLiteralField,
+    StructLiteralParse,
+    EnumLiteralParse,
+    ExpressionStatementResult,
+    BlockLabelResult,
+    IfStructure,
+    LoopStructure,
+    TryStructure,
+    RangeIterableParse,
+    MatchCaseStructure,
+    MatchStructure,
+    MatchFieldBinding,
+    MatchStructFieldBinding,
+    MatchCaseCondition,
+    ConditionConversion,
+    ComparisonEmission,
+    BinaryAlignmentResult,
+    ThrowLoweringResult,
+    PhiMergeResult,
+    PhiInputEntry,
+    MutationMaterializationResult,
+    PhiStoreEntry,
+    MatchArmMutations,
+    LoadLocalResult
 } from "../../types";
 
 import {
-    starts_with, ends_with,
-    is_identifier_start_char, is_identifier_part_char,
+    starts_with,
+    ends_with,
+    is_identifier_start_char,
+    is_identifier_part_char,
     contains_text,
     matches_keyword,
     merge_parameter_bindings,
@@ -160,8 +233,13 @@ export {
 } from "./core_scopes";
 
 import {
-    empty_string_constant_set, append_string_constant, merge_string_constants,
-    find_string_constant, find_string_constant_by_name, render_string_constants, escape_string_for_llvm
+    empty_string_constant_set,
+    append_string_constant,
+    merge_string_constants,
+    find_string_constant,
+    find_string_constant_by_name,
+    render_string_constants,
+    escape_string_for_llvm
 } from "../../strings";
 
 import {
@@ -195,13 +273,9 @@ import {
     find_variant_field_info
 } from "../../type_context_queries";
 
-import {
-    find_function_by_name,
-} from "../../rendering";
+import { find_function_by_name, } from "../../rendering";
 
-import {
-    find_runtime_helper,
-} from "../../runtime_helpers";
+import { find_runtime_helper, } from "../../runtime_helpers";
 
 import {
     format_temp_name,
@@ -266,14 +340,9 @@ import {
     coerce_operand_to_string,
 } from "./core_strings";
 
-import {
-    find_call_site,
-    split_call_arguments,
-} from "./core_calls";
+import { find_call_site, split_call_arguments, } from "./core_calls";
 
-import {
-    lower_raw_address_expression,
-} from "./core_addressing";
+import { lower_raw_address_expression, } from "./core_addressing";
 
 import {
     analyze_value_ownership_impl,
@@ -282,14 +351,9 @@ import {
     resolve_borrow_base_impl,
 } from "./core_ownership";
 
-import {
-    split_array_elements,
-} from "../splitting";
+import { split_array_elements, } from "../splitting";
 
-import {
-    collect_parameter_types,
-    operation_name_for_symbol,
-} from "./core_helpers";
+import { collect_parameter_types, operation_name_for_symbol, } from "./core_helpers";
 
 import {
     lower_struct_array_concat,
@@ -347,7 +411,13 @@ fn lower_expression(expression: string, bindings: ParameterBinding[], locals: Lo
     }
     if trimmed.length == 0 {
         diagnostics.push("llvm lowering: empty expression encountered");
-        return ExpressionResult { lines: lines, temp_index: temp_index, operand: null, diagnostics: diagnostics, string_constants: empty_constants };
+        return ExpressionResult {
+            lines: lines,
+            temp_index: temp_index,
+            operand: null,
+            diagnostics: diagnostics,
+            string_constants: empty_constants
+        };
     }
 
     let stripped = strip_enclosing_parentheses(trimmed);
@@ -362,7 +432,13 @@ fn lower_expression(expression: string, bindings: ParameterBinding[], locals: Lo
             value = "1";
         }
         let operand = LLVMOperand { llvm_type: "i1", value: value };
-        return ExpressionResult { lines: lines, temp_index: temp_index, operand: operand, diagnostics: diagnostics, string_constants: empty_constants };
+        return ExpressionResult {
+            lines: lines,
+            temp_index: temp_index,
+            operand: operand,
+            diagnostics: diagnostics,
+            string_constants: empty_constants
+        };
     }
     if is_null_literal(stripped) {
         let trimmed_expected = trim_text(expected_type);
@@ -373,7 +449,13 @@ fn lower_expression(expression: string, bindings: ParameterBinding[], locals: Lo
             }
         }
         let operand = LLVMOperand { llvm_type: null_type, value: "null" };
-        return ExpressionResult { lines: lines, temp_index: temp_index, operand: operand, diagnostics: diagnostics, string_constants: empty_constants };
+        return ExpressionResult {
+            lines: lines,
+            temp_index: temp_index,
+            operand: operand,
+            diagnostics: diagnostics,
+            string_constants: empty_constants
+        };
     }
     if is_number_literal(stripped) {
         let trimmed_expected = trim_text(expected_type);
@@ -382,35 +464,66 @@ fn lower_expression(expression: string, bindings: ParameterBinding[], locals: Lo
         if trimmed_expected == "i64" { _if53 = true; }
         if trimmed_expected == "i32" { _if53 = true; }
         if _if53 {
-            if is_integer_literal(stripped) {
-                _if51 = true;
-            }
+            if is_integer_literal(stripped) { _if51 = true; }
         }
         if _if51 {
-            let operand = LLVMOperand { llvm_type: trimmed_expected, value: trim_text(stripped) };
-            return ExpressionResult { lines: lines, temp_index: temp_index, operand: operand, diagnostics: diagnostics, string_constants: empty_constants };
+            let operand = LLVMOperand {
+                llvm_type: trimmed_expected,
+                value: trim_text(stripped)
+            };
+            return ExpressionResult {
+                lines: lines,
+                temp_index: temp_index,
+                operand: operand,
+                diagnostics: diagnostics,
+                string_constants: empty_constants
+            };
         }
         let normalized = normalise_number_literal(stripped);
         let operand = LLVMOperand { llvm_type: "double", value: normalized };
-        return ExpressionResult { lines: lines, temp_index: temp_index, operand: operand, diagnostics: diagnostics, string_constants: empty_constants };
+        return ExpressionResult {
+            lines: lines,
+            temp_index: temp_index,
+            operand: operand,
+            diagnostics: diagnostics,
+            string_constants: empty_constants
+        };
     }
     if is_string_literal(stripped) {
         let interpolated = try_lower_interpolated_string_literal(stripped, bindings, locals, temp_index, lines, functions, context);
         if interpolated != null {
             let result = interpolated;
             diagnostics = extend_string_array(diagnostics, result.diagnostics);
-            return ExpressionResult { lines: result.lines, temp_index: result.temp_index, operand: result.operand, diagnostics: diagnostics, string_constants: result.string_constants };
+            return ExpressionResult {
+                lines: result.lines,
+                temp_index: result.temp_index,
+                operand: result.operand,
+                diagnostics: diagnostics,
+                string_constants: result.string_constants
+            };
         }
         let literal_result = lower_string_literal(stripped, temp_index, lines);
         diagnostics = extend_string_array(diagnostics, literal_result.diagnostics);
-        return ExpressionResult { lines: literal_result.lines, temp_index: literal_result.temp_index, operand: literal_result.operand, diagnostics: diagnostics, string_constants: literal_result.string_constants };
+        return ExpressionResult {
+            lines: literal_result.lines,
+            temp_index: literal_result.temp_index,
+            operand: literal_result.operand,
+            diagnostics: diagnostics,
+            string_constants: literal_result.string_constants
+        };
     }
 
     // `await <expr>` joins a thread-backed future and extracts its value.
     if starts_with(stripped, "await") {
         if stripped.length == 5 {
             diagnostics.push("llvm lowering: await expression missing operand");
-            return ExpressionResult { lines: lines, temp_index: temp_index, operand: null, diagnostics: diagnostics, string_constants: empty_constants };
+            return ExpressionResult {
+                lines: lines,
+                temp_index: temp_index,
+                operand: null,
+                diagnostics: diagnostics,
+                string_constants: empty_constants
+            };
         }
         let next = char_at(stripped, 5);
         let mut _if52: boolean = false;
@@ -421,7 +534,13 @@ fn lower_expression(expression: string, bindings: ParameterBinding[], locals: Lo
             let remainder = trim_text(substring(stripped, 5, stripped.length));
             if remainder.length == 0 {
                 diagnostics.push("llvm lowering: await expression missing operand");
-                return ExpressionResult { lines: lines, temp_index: temp_index, operand: null, diagnostics: diagnostics, string_constants: empty_constants };
+                return ExpressionResult {
+                    lines: lines,
+                    temp_index: temp_index,
+                    operand: null,
+                    diagnostics: diagnostics,
+                    string_constants: empty_constants
+                };
             }
             let lowered = lower_expression(remainder, bindings, locals, temp_index, lines, functions, context, expected_type);
             let mut _ci0: number = 0;
@@ -431,24 +550,45 @@ fn lower_expression(expression: string, bindings: ParameterBinding[], locals: Lo
                 _ci0 += 1;
             }
             if lowered.operand == null {
-                return ExpressionResult { lines: lowered.lines, temp_index: lowered.temp_index, operand: null, diagnostics: diagnostics, string_constants: lowered.string_constants };
+                return ExpressionResult {
+                    lines: lowered.lines,
+                    temp_index: lowered.temp_index,
+                    operand: null,
+                    diagnostics: diagnostics,
+                    string_constants: lowered.string_constants
+                };
             }
 
             let future_operand = lowered.operand;
             let await_symbol = await_symbol_for_future_pointer_type(future_operand.llvm_type);
             if await_symbol.length == 0 {
                 let with_issue = append_string(diagnostics, "llvm lowering: await expects a Future pointer, got `" + future_operand.llvm_type + "`");
-                return ExpressionResult { lines: lowered.lines, temp_index: lowered.temp_index, operand: null, diagnostics: with_issue, string_constants: lowered.string_constants };
+                return ExpressionResult {
+                    lines: lowered.lines,
+                    temp_index: lowered.temp_index,
+                    operand: null,
+                    diagnostics: with_issue,
+                    string_constants: lowered.string_constants
+                };
             }
 
             // Await returns a value whose type depends on the future kind.
             if future_operand.llvm_type == "%SailfinFutureVoid*" {
                 let mut awaited_lines = append_string(lowered.lines, "  call void @" + await_symbol + "(%SailfinFutureVoid* " + future_operand.value + ")");
-                let out_operand = LLVMOperand { llvm_type: "void", value: "" };
+                let out_operand = LLVMOperand {
+                    llvm_type: "void",
+                    value: ""
+                };
                 // Overwrite stale call-result files from the inner spawn call
                 fs.writeFile("build/sailfin/.call_result_type", "void");
                 fs.writeFile("build/sailfin/.call_result_value", "");
-                return ExpressionResult { lines: awaited_lines, temp_index: lowered.temp_index, operand: out_operand, diagnostics: diagnostics, string_constants: lowered.string_constants };
+                return ExpressionResult {
+                    lines: awaited_lines,
+                    temp_index: lowered.temp_index,
+                    operand: out_operand,
+                    diagnostics: diagnostics,
+                    string_constants: lowered.string_constants
+                };
             }
 
             let mut result_type: string = "i8*";
@@ -496,21 +636,39 @@ fn lower_expression(expression: string, bindings: ParameterBinding[], locals: Lo
                             awaited_lines2.push("  " + typed_ptr_temp + " = bitcast i8* " + result_temp + " to " + trimmed_expected + "*");
                             awaited_lines2.push("  " + load_temp + " = load " + trimmed_expected + ", " + trimmed_expected + "* " + typed_ptr_temp);
                             awaited_lines2.push("  call void @free(i8* " + result_temp + ")");
-                            let out_operand_unboxed = LLVMOperand { llvm_type: trimmed_expected, value: load_temp };
+                            let out_operand_unboxed = LLVMOperand {
+                                llvm_type: trimmed_expected,
+                                value: load_temp
+                            };
                             // Overwrite stale call-result files from the inner spawn call
                             fs.writeFile("build/sailfin/.call_result_type", trimmed_expected);
                             fs.writeFile("build/sailfin/.call_result_value", load_temp);
-                            return ExpressionResult { lines: awaited_lines2, temp_index: lowered.temp_index + 3, operand: out_operand_unboxed, diagnostics: diagnostics, string_constants: lowered.string_constants };
+                            return ExpressionResult {
+                                lines: awaited_lines2,
+                                temp_index: lowered.temp_index + 3,
+                                operand: out_operand_unboxed,
+                                diagnostics: diagnostics,
+                                string_constants: lowered.string_constants
+                            };
                         }
                     }
                 }
             }
 
-            let out_operand2 = LLVMOperand { llvm_type: result_type, value: result_temp };
+            let out_operand2 = LLVMOperand {
+                llvm_type: result_type,
+                value: result_temp
+            };
             // Overwrite stale call-result files from the inner spawn call
             fs.writeFile("build/sailfin/.call_result_type", result_type);
             fs.writeFile("build/sailfin/.call_result_value", result_temp);
-            return ExpressionResult { lines: awaited_lines2, temp_index: lowered.temp_index + 1, operand: out_operand2, diagnostics: diagnostics, string_constants: lowered.string_constants };
+            return ExpressionResult {
+                lines: awaited_lines2,
+                temp_index: lowered.temp_index + 1,
+                operand: out_operand2,
+                diagnostics: diagnostics,
+                string_constants: lowered.string_constants
+            };
         }
     }
 
@@ -583,7 +741,13 @@ fn lower_expression(expression: string, bindings: ParameterBinding[], locals: Lo
             let operand_text = trim_text(substring(stripped, 1, stripped.length));
             if operand_text.length == 0 {
                 diagnostics.push("llvm lowering: deref expression missing operand");
-                return ExpressionResult { lines: lines, temp_index: temp_index, operand: null, diagnostics: diagnostics, string_constants: empty_constants };
+                return ExpressionResult {
+                    lines: lines,
+                    temp_index: temp_index,
+                    operand: null,
+                    diagnostics: diagnostics,
+                    string_constants: empty_constants
+                };
             }
             let lowered_ptr = lower_expression(operand_text, bindings, locals, temp_index, lines, functions, context, "");
             let mut _ci1: number = 0;
@@ -593,18 +757,39 @@ fn lower_expression(expression: string, bindings: ParameterBinding[], locals: Lo
                 _ci1 += 1;
             }
             if lowered_ptr.operand == null {
-                return ExpressionResult { lines: lowered_ptr.lines, temp_index: lowered_ptr.temp_index, operand: null, diagnostics: diagnostics, string_constants: lowered_ptr.string_constants };
+                return ExpressionResult {
+                    lines: lowered_ptr.lines,
+                    temp_index: lowered_ptr.temp_index,
+                    operand: null,
+                    diagnostics: diagnostics,
+                    string_constants: lowered_ptr.string_constants
+                };
             }
             let ptr_operand = lowered_ptr.operand;
             if !ends_with_pointer_suffix(ptr_operand.llvm_type) {
                 let with_issue = append_string(diagnostics, "llvm lowering: cannot dereference non-pointer type `" + ptr_operand.llvm_type + "`");
-                return ExpressionResult { lines: lowered_ptr.lines, temp_index: lowered_ptr.temp_index, operand: null, diagnostics: with_issue, string_constants: lowered_ptr.string_constants };
+                return ExpressionResult {
+                    lines: lowered_ptr.lines,
+                    temp_index: lowered_ptr.temp_index,
+                    operand: null,
+                    diagnostics: with_issue,
+                    string_constants: lowered_ptr.string_constants
+                };
             }
             let element_type = strip_pointer_suffix(ptr_operand.llvm_type);
             let load_name = format_temp_name(lowered_ptr.temp_index);
             let updated_lines = append_string(lowered_ptr.lines, "  " + load_name + " = load " + element_type + ", " + element_type + "* " + ptr_operand.value);
-            let operand = LLVMOperand { llvm_type: element_type, value: load_name };
-            return ExpressionResult { lines: updated_lines, temp_index: lowered_ptr.temp_index + 1, operand: operand, diagnostics: diagnostics, string_constants: lowered_ptr.string_constants };
+            let operand = LLVMOperand {
+                llvm_type: element_type,
+                value: load_name
+            };
+            return ExpressionResult {
+                lines: updated_lines,
+                temp_index: lowered_ptr.temp_index + 1,
+                operand: operand,
+                diagnostics: diagnostics,
+                string_constants: lowered_ptr.string_constants
+            };
         }
     }
 
@@ -688,7 +873,13 @@ fn lower_expression(expression: string, bindings: ParameterBinding[], locals: Lo
                     diagnostics.push(lowered_enum.diagnostics[_ci2]);
                     _ci2 += 1;
                 }
-                return ExpressionResult { lines: lowered_enum.lines, temp_index: lowered_enum.temp_index, operand: lowered_enum.operand, diagnostics: diagnostics, string_constants: lowered_enum.string_constants };
+                return ExpressionResult {
+                    lines: lowered_enum.lines,
+                    temp_index: lowered_enum.temp_index,
+                    operand: lowered_enum.operand,
+                    diagnostics: diagnostics,
+                    string_constants: lowered_enum.string_constants
+                };
             }
         }
     }
@@ -702,7 +893,13 @@ fn lower_expression(expression: string, bindings: ParameterBinding[], locals: Lo
                 diagnostics.push(struct_parse.diagnostics[_ci3]);
                 _ci3 += 1;
             }
-            return ExpressionResult { lines: lines, temp_index: temp_index, operand: null, diagnostics: diagnostics, string_constants: empty_constants };
+            return ExpressionResult {
+                lines: lines,
+                temp_index: temp_index,
+                operand: null,
+                diagnostics: diagnostics,
+                string_constants: empty_constants
+            };
         }
         let lowered_struct = lower_struct_literal(struct_parse, bindings, locals, temp_index, lines, functions, context, expected_type);
         let mut _ci4: number = 0;
@@ -711,7 +908,13 @@ fn lower_expression(expression: string, bindings: ParameterBinding[], locals: Lo
             diagnostics.push(lowered_struct.diagnostics[_ci4]);
             _ci4 += 1;
         }
-        return ExpressionResult { lines: lowered_struct.lines, temp_index: lowered_struct.temp_index, operand: lowered_struct.operand, diagnostics: diagnostics, string_constants: lowered_struct.string_constants };
+        return ExpressionResult {
+            lines: lowered_struct.lines,
+            temp_index: lowered_struct.temp_index,
+            operand: lowered_struct.operand,
+            diagnostics: diagnostics,
+            string_constants: lowered_struct.string_constants
+        };
     }
 
     // Try index expression before member access (array[index])
@@ -735,8 +938,17 @@ fn lower_expression(expression: string, bindings: ParameterBinding[], locals: Lo
         print.err("emit-llvm: lower_expression param_lookup stripped=" + stripped + " result=" + param_found);
     }
     if parameter != null {
-        let operand = LLVMOperand { llvm_type: parameter.llvm_type, value: parameter.llvm_name };
-        return ExpressionResult { lines: lines, temp_index: temp_index, operand: operand, diagnostics: diagnostics, string_constants: empty_constants };
+        let operand = LLVMOperand {
+            llvm_type: parameter.llvm_type,
+            value: parameter.llvm_name
+        };
+        return ExpressionResult {
+            lines: lines,
+            temp_index: temp_index,
+            operand: operand,
+            diagnostics: diagnostics,
+            string_constants: empty_constants
+        };
     }
 
     let local = find_local_binding(locals, stripped);
@@ -748,12 +960,24 @@ fn lower_expression(expression: string, bindings: ParameterBinding[], locals: Lo
             diagnostics.push(load_result.diagnostics[_ci5]);
             _ci5 += 1;
         }
-        return ExpressionResult { lines: load_result.lines, temp_index: load_result.temp_index, operand: load_result.operand, diagnostics: diagnostics, string_constants: empty_constants };
+        return ExpressionResult {
+            lines: load_result.lines,
+            temp_index: load_result.temp_index,
+            operand: load_result.operand,
+            diagnostics: diagnostics,
+            string_constants: empty_constants
+        };
     }
 
     if dbg_expr {
         print.err("emit-llvm: lower_expression FALLTHROUGH expr=" + stripped + " (unhandled)");
     }
     diagnostics.push("llvm lowering: unable to lower expression `" + expression + "`");
-    return ExpressionResult { lines: lines, temp_index: temp_index, operand: null, diagnostics: diagnostics, string_constants: empty_constants };
+    return ExpressionResult {
+        lines: lines,
+        temp_index: temp_index,
+        operand: null,
+        diagnostics: diagnostics,
+        string_constants: empty_constants
+    };
 }

--- a/compiler/src/llvm/expression_lowering/native/core_addressing.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_addressing.sfn
@@ -1,18 +1,18 @@
 // compiler/src/llvm/expression_lowering/native/core_addressing.sfn
 //
 // Addressing helpers for Stage2 expression lowering.
-import { is_simple_identifier, } from "../../expressions_helpers";
-import { empty_string_constant_set, } from "../../strings";
+import { is_simple_identifier } from "../../expressions_helpers";
+import { empty_string_constant_set } from "../../strings";
 import {
     ExpressionResult,
     LLVMOperand,
     LocalBinding,
     ParameterBinding,
-    RawAddressParseResult,
+    RawAddressParseResult
 } from "../../types";
-import { append_string, trim_text, } from "../../utils";
-import { find_parameter_binding, } from "./core_bindings";
-import { find_local_binding, } from "./core_scopes";
+import { append_string, trim_text } from "../../utils";
+import { find_parameter_binding } from "./core_bindings";
+import { find_local_binding } from "./core_scopes";
 
 fn lower_raw_address_expression(parse: RawAddressParseResult, bindings: ParameterBinding[], locals: LocalBinding[], temp_index: number, lines: string[]) -> ExpressionResult {
     let mut diagnostics = parse.diagnostics;
@@ -28,7 +28,9 @@ fn lower_raw_address_expression(parse: RawAddressParseResult, bindings: Paramete
     }
     let target = trim_text(parse.target);
     if !is_simple_identifier(target) {
-        diagnostics.push("llvm lowering: &raw currently supports only simple identifiers (got `" + target + "`)");
+        diagnostics.push("llvm lowering: &raw currently supports only simple identifiers (got `"
+            + target
+            + "`)");
         return ExpressionResult {
             lines: lines,
             temp_index: temp_index,
@@ -53,7 +55,9 @@ fn lower_raw_address_expression(parse: RawAddressParseResult, bindings: Paramete
     }
     let param = find_parameter_binding(bindings, target);
     if param != null {
-        diagnostics.push("llvm lowering: cannot take raw address of parameter `" + target + "` yet");
+        diagnostics.push("llvm lowering: cannot take raw address of parameter `"
+            + target
+            + "` yet");
         return ExpressionResult {
             lines: lines,
             temp_index: temp_index,
@@ -62,7 +66,8 @@ fn lower_raw_address_expression(parse: RawAddressParseResult, bindings: Paramete
             string_constants: empty_constants
         };
     }
-    diagnostics.push("llvm lowering: &raw target `" + target + "` is not a local");
+    diagnostics.push("llvm lowering: &raw target `" + target
+        + "` is not a local");
     return ExpressionResult {
         lines: lines,
         temp_index: temp_index,

--- a/compiler/src/llvm/expression_lowering/native/core_addressing.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_addressing.sfn
@@ -1,57 +1,73 @@
 // compiler/src/llvm/expression_lowering/native/core_addressing.sfn
 //
 // Addressing helpers for Stage2 expression lowering.
-
+import { is_simple_identifier, } from "../../expressions_helpers";
+import { empty_string_constant_set, } from "../../strings";
 import {
-    ParameterBinding,
-    LocalBinding,
-    RawAddressParseResult,
-    LLVMOperand,
     ExpressionResult,
+    LLVMOperand,
+    LocalBinding,
+    ParameterBinding,
+    RawAddressParseResult,
 } from "../../types";
-
-import {
-    trim_text,
-    append_string,
-} from "../../utils";
-
-import {
-    empty_string_constant_set,
-} from "../../strings";
-
-import {
-    is_simple_identifier,
-} from "../../expressions_helpers";
-
-import {
-    find_local_binding,
-} from "./core_scopes";
-
-import {
-    find_parameter_binding,
-} from "./core_bindings";
+import { append_string, trim_text, } from "../../utils";
+import { find_parameter_binding, } from "./core_bindings";
+import { find_local_binding, } from "./core_scopes";
 
 fn lower_raw_address_expression(parse: RawAddressParseResult, bindings: ParameterBinding[], locals: LocalBinding[], temp_index: number, lines: string[]) -> ExpressionResult {
     let mut diagnostics = parse.diagnostics;
     let empty_constants = empty_string_constant_set();
     if !parse.success {
-        return ExpressionResult { lines: lines, temp_index: temp_index, operand: null, diagnostics: diagnostics, string_constants: empty_constants };
+        return ExpressionResult {
+            lines: lines,
+            temp_index: temp_index,
+            operand: null,
+            diagnostics: diagnostics,
+            string_constants: empty_constants
+        };
     }
     let target = trim_text(parse.target);
     if !is_simple_identifier(target) {
         diagnostics.push("llvm lowering: &raw currently supports only simple identifiers (got `" + target + "`)");
-        return ExpressionResult { lines: lines, temp_index: temp_index, operand: null, diagnostics: diagnostics, string_constants: empty_constants };
+        return ExpressionResult {
+            lines: lines,
+            temp_index: temp_index,
+            operand: null,
+            diagnostics: diagnostics,
+            string_constants: empty_constants
+        };
     }
     let local = find_local_binding(locals, target);
     if local != null {
-        let operand = LLVMOperand { llvm_type: local.llvm_type + "*", value: local.pointer };
-        return ExpressionResult { lines: lines, temp_index: temp_index, operand: operand, diagnostics: diagnostics, string_constants: empty_constants };
+        let operand = LLVMOperand {
+            llvm_type: local.llvm_type + "*",
+            value: local.pointer
+        };
+        return ExpressionResult {
+            lines: lines,
+            temp_index: temp_index,
+            operand: operand,
+            diagnostics: diagnostics,
+            string_constants: empty_constants
+        };
     }
     let param = find_parameter_binding(bindings, target);
     if param != null {
         diagnostics.push("llvm lowering: cannot take raw address of parameter `" + target + "` yet");
-        return ExpressionResult { lines: lines, temp_index: temp_index, operand: null, diagnostics: diagnostics, string_constants: empty_constants };
+        return ExpressionResult {
+            lines: lines,
+            temp_index: temp_index,
+            operand: null,
+            diagnostics: diagnostics,
+            string_constants: empty_constants
+        };
     }
     diagnostics.push("llvm lowering: &raw target `" + target + "` is not a local");
-    return ExpressionResult { lines: lines, temp_index: temp_index, operand: null, diagnostics: diagnostics, string_constants: empty_constants };
+    return ExpressionResult {
+        lines: lines,
+        temp_index: temp_index,
+        operand: null,
+        diagnostics: diagnostics,
+        string_constants: empty_constants
+    };
 }

--- a/compiler/src/llvm/expression_lowering/native/core_bindings.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_bindings.sfn
@@ -1,13 +1,11 @@
 // compiler/src/llvm/expression_lowering/native/core_bindings.sfn
 //
 // Small Stage2-specific binding helpers extracted from core.sfn.
-
-import { LocalBinding, ParameterBinding, OwnershipInfo } from "../../types";
-
+import { LocalBinding, OwnershipInfo, ParameterBinding } from "../../types";
 import {
     bindings_find_parameter_binding,
-    bindings_mark_parameter_consumed,
     bindings_mark_local_consumed,
+    bindings_mark_parameter_consumed,
     bindings_reset_local_consumption,
     bindings_update_local_ownership,
 } from "../bindings";

--- a/compiler/src/llvm/expression_lowering/native/core_bindings.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_bindings.sfn
@@ -7,7 +7,7 @@ import {
     bindings_mark_local_consumed,
     bindings_mark_parameter_consumed,
     bindings_reset_local_consumption,
-    bindings_update_local_ownership,
+    bindings_update_local_ownership
 } from "../bindings";
 
 fn find_parameter_binding(bindings: ParameterBinding[], name: string) -> ParameterBinding? {

--- a/compiler/src/llvm/expression_lowering/native/core_borrow_lowering.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_borrow_lowering.sfn
@@ -1,30 +1,43 @@
 // compiler/src/llvm/expression_lowering/native/core_borrow_lowering.sfn
 //
 // Borrow-expression lowering extracted from core.sfn.
-
-import { ParameterBinding, LocalBinding, BorrowParseResult, ExpressionResult, LLVMOperand } from "../../types";
-
-import { trim_text, append_string, ends_with } from "../../utils";
-
-import { strip_enclosing_parentheses } from "./core_operators";
-
 import { empty_string_constant_set } from "../../strings";
-
+import {
+    BorrowParseResult,
+    ExpressionResult,
+    LLVMOperand,
+    LocalBinding,
+    ParameterBinding
+} from "../../types";
+import { append_string, ends_with, trim_text } from "../../utils";
 import { find_parameter_binding } from "./core_bindings";
+import { strip_enclosing_parentheses } from "./core_operators";
 import { find_local_binding } from "./core_scopes";
 
 fn lower_borrow_expression(parse: BorrowParseResult, bindings: ParameterBinding[], locals: LocalBinding[], temp_index: number, lines: string[]) -> ExpressionResult {
     let mut diagnostics: string[] = parse.diagnostics;
     let empty_constants = empty_string_constant_set();
     if !parse.success {
-        return ExpressionResult { lines: lines, temp_index: temp_index, operand: null, diagnostics: diagnostics, string_constants: empty_constants };
+        return ExpressionResult {
+            lines: lines,
+            temp_index: temp_index,
+            operand: null,
+            diagnostics: diagnostics,
+            string_constants: empty_constants
+        };
     }
 
     let mut target = strip_enclosing_parentheses(parse.target);
     target = trim_text(target);
     if target.length == 0 {
         diagnostics.push("llvm lowering: borrow expression missing target");
-        return ExpressionResult { lines: lines, temp_index: temp_index, operand: null, diagnostics: diagnostics, string_constants: empty_constants };
+        return ExpressionResult {
+            lines: lines,
+            temp_index: temp_index,
+            operand: null,
+            diagnostics: diagnostics,
+            string_constants: empty_constants
+        };
     }
 
     let local = find_local_binding(locals, target);
@@ -32,22 +45,52 @@ fn lower_borrow_expression(parse: BorrowParseResult, bindings: ParameterBinding[
         let parameter = find_parameter_binding(bindings, target);
         if parameter == null {
             diagnostics.push("llvm lowering: borrow target `" + target + "` not found");
-            return ExpressionResult { lines: lines, temp_index: temp_index, operand: null, diagnostics: diagnostics, string_constants: empty_constants };
+            return ExpressionResult {
+                lines: lines,
+                temp_index: temp_index,
+                operand: null,
+                diagnostics: diagnostics,
+                string_constants: empty_constants
+            };
         }
 
         // If the parameter is already a reference/pointer type, borrowing it is an identity.
         if ends_with(parameter.llvm_type, "*") {
-            let operand = LLVMOperand { llvm_type: parameter.llvm_type, value: parameter.llvm_name };
-            return ExpressionResult { lines: lines, temp_index: temp_index, operand: operand, diagnostics: diagnostics, string_constants: empty_constants };
+            let operand = LLVMOperand {
+                llvm_type: parameter.llvm_type,
+                value: parameter.llvm_name
+            };
+            return ExpressionResult {
+                lines: lines,
+                temp_index: temp_index,
+                operand: operand,
+                diagnostics: diagnostics,
+                string_constants: empty_constants
+            };
         }
 
         diagnostics.push("llvm lowering: cannot borrow non-addressable parameter `" + target + "` (type `" + parameter.llvm_type + "`)");
-        return ExpressionResult { lines: lines, temp_index: temp_index, operand: null, diagnostics: diagnostics, string_constants: empty_constants };
+        return ExpressionResult {
+            lines: lines,
+            temp_index: temp_index,
+            operand: null,
+            diagnostics: diagnostics,
+            string_constants: empty_constants
+        };
     }
 
     let pointer_type = local.llvm_type + "*";
-    let operand = LLVMOperand { llvm_type: pointer_type, value: local.pointer };
-    return ExpressionResult { lines: lines, temp_index: temp_index, operand: operand, diagnostics: diagnostics, string_constants: empty_constants };
+    let operand = LLVMOperand {
+        llvm_type: pointer_type,
+        value: local.pointer
+    };
+    return ExpressionResult {
+        lines: lines,
+        temp_index: temp_index,
+        operand: operand,
+        diagnostics: diagnostics,
+        string_constants: empty_constants
+    };
 }
 
 export { lower_borrow_expression };

--- a/compiler/src/llvm/expression_lowering/native/core_borrow_lowering.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_borrow_lowering.sfn
@@ -44,7 +44,8 @@ fn lower_borrow_expression(parse: BorrowParseResult, bindings: ParameterBinding[
     if local == null {
         let parameter = find_parameter_binding(bindings, target);
         if parameter == null {
-            diagnostics.push("llvm lowering: borrow target `" + target + "` not found");
+            diagnostics.push("llvm lowering: borrow target `" + target
+                + "` not found");
             return ExpressionResult {
                 lines: lines,
                 temp_index: temp_index,
@@ -69,7 +70,11 @@ fn lower_borrow_expression(parse: BorrowParseResult, bindings: ParameterBinding[
             };
         }
 
-        diagnostics.push("llvm lowering: cannot borrow non-addressable parameter `" + target + "` (type `" + parameter.llvm_type + "`)");
+        diagnostics.push("llvm lowering: cannot borrow non-addressable parameter `"
+            + target
+            + "` (type `"
+            + parameter.llvm_type
+            + "`)");
         return ExpressionResult {
             lines: lines,
             temp_index: temp_index,

--- a/compiler/src/llvm/expression_lowering/native/core_call_emission.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_call_emission.sfn
@@ -6,8 +6,8 @@ import { NativeFunction } from "../../../native_ir";
 import { find_last_index_of_char, substring } from "../../../string_utils";
 import { format_temp_name, format_typed_operand } from "../../expressions_helpers";
 import { merge_string_constants } from "../../strings";
-import { find_interface_info_by_name, } from "../../type_context_queries";
-import { ends_with_pointer_suffix, strip_pointer_suffix, } from "../../type_mapping";
+import { find_interface_info_by_name } from "../../type_context_queries";
+import { ends_with_pointer_suffix, strip_pointer_suffix } from "../../type_mapping";
 import {
     ExpressionResult,
     LLVMOperand,
@@ -16,23 +16,23 @@ import {
     ParameterBinding,
     RuntimeHelperDescriptor,
     StringConstant,
-    TypeContext,
+    TypeContext
 } from "../../types";
 import {
     extend_string_array,
     join_with_separator,
     number_to_string,
     starts_with,
-    trim_text,
+    trim_text
 } from "../../utils";
 import {
     array_pointer_element_type,
     lower_array_push_in_place,
-    lower_struct_array_concat,
+    lower_struct_array_concat
 } from "../arrays";
 import { coerce_operand_to_type } from "./core_operands";
-import { parse_member_access, } from "./core_parse";
-import { find_local_binding, } from "./core_scopes";
+import { parse_member_access } from "./core_parse";
+import { find_local_binding } from "./core_scopes";
 import { sanitize_symbol } from "./core_text";
 
 fn _write_emission_result_lines(result_lines: string[], result_temp: number) -> void ![io] {
@@ -49,7 +49,11 @@ fn coerce_and_emit_call(trimmed_target: string, operands: LLVMOperand[], expecte
 
     // Coerce operands to expected parameter types
     if _trace_ccl {
-        print.err("call_lowering: pre-coerce operands=" + number_to_string(operands.length) + " expected_params=" + number_to_string(expected_params.length) + " llvm_return=" + llvm_return);
+        print.err("call_lowering: pre-coerce operands=" + number_to_string(operands.length)
+            + " expected_params="
+            + number_to_string(expected_params.length)
+            + " llvm_return="
+            + llvm_return);
     }
     let mut coerced_operands: LLVMOperand[] = [];
     let mut index: number = 0;
@@ -57,7 +61,11 @@ fn coerce_and_emit_call(trimmed_target: string, operands: LLVMOperand[], expecte
         if index >= operands.length { break; }
         let operand = operands[index];
         if _trace_ccl {
-            print.err("call_lowering: coerce-loop idx=" + number_to_string(index) + " operand_type=" + operand.llvm_type + " operand_value=" + operand.value);
+            print.err("call_lowering: coerce-loop idx=" + number_to_string(index)
+                + " operand_type="
+                + operand.llvm_type
+                + " operand_value="
+                + operand.value);
         }
         let mut target_type: string = "";
         if expected_params.length > index {
@@ -75,7 +83,11 @@ fn coerce_and_emit_call(trimmed_target: string, operands: LLVMOperand[], expecte
             result_lines = coerced.lines;
             result_temp = coerced.temp_index;
             if coerced.operand == null {
-                result_diagnostics.push("llvm lowering: unable to coerce argument " + number_to_string(index) + " for call to `" + trimmed_target + "`: passing original operand");
+                result_diagnostics.push("llvm lowering: unable to coerce argument "
+                    + number_to_string(index)
+                    + " for call to `"
+                    + trimmed_target
+                    + "`: passing original operand");
                 coerced_operands.push(operand);
             } else { coerced_operands.push(coerced.operand); }
         }
@@ -87,7 +99,9 @@ fn coerce_and_emit_call(trimmed_target: string, operands: LLVMOperand[], expecte
     }
 
     if _trace_ccl {
-        print.err("call_lowering: checkpoint-A is_concat=" + number_to_string(0) + " is_push=" + number_to_string(0));
+        print.err("call_lowering: checkpoint-A is_concat=" + number_to_string(0)
+            + " is_push="
+            + number_to_string(0));
     }
 
     // Array concat inline lowering
@@ -171,7 +185,13 @@ fn coerce_and_emit_call(trimmed_target: string, operands: LLVMOperand[], expecte
                         let push_receiver_name = trim_text(method_parse.base);
                         let push_receiver_local = find_local_binding(locals, push_receiver_name);
                         if push_receiver_local != null {
-                            result_lines.push("  store " + push_result.operand.llvm_type + " " + push_result.operand.value + ", " + push_result.operand.llvm_type + "* " + push_receiver_local.pointer);
+                            result_lines.push("  store " + push_result.operand.llvm_type
+                                + " "
+                                + push_result.operand.value
+                                + ", "
+                                + push_result.operand.llvm_type
+                                + "* "
+                                + push_receiver_local.pointer);
                         }
                     }
                 }
@@ -199,7 +219,8 @@ fn coerce_and_emit_call(trimmed_target: string, operands: LLVMOperand[], expecte
     }
 
     if _trace_ccl {
-        print.err("call_lowering: checkpoint-B fn_entry_null=" + number_to_string(0));
+        print.err("call_lowering: checkpoint-B fn_entry_null="
+            + number_to_string(0));
     }
     let mut _if56: boolean = false;
     if function_entry != null { _if56 = true; }
@@ -209,7 +230,11 @@ fn coerce_and_emit_call(trimmed_target: string, operands: LLVMOperand[], expecte
     }
     if _if56 {
         if expected_params.length != final_operands.length {
-            result_diagnostics.push("llvm lowering: call to `" + trimmed_target + "` expected " + number_to_string(expected_params.length) + " arguments but received " + number_to_string(final_operands.length));
+            result_diagnostics.push("llvm lowering: call to `" + trimmed_target
+                + "` expected "
+                + number_to_string(expected_params.length)
+                + " arguments but received "
+                + number_to_string(final_operands.length));
         }
     }
 
@@ -253,11 +278,19 @@ fn coerce_and_emit_call(trimmed_target: string, operands: LLVMOperand[], expecte
 
                 let data_ptr_temp = "%t" + number_to_string(result_temp);
                 result_temp += 1;
-                result_lines.push("  " + data_ptr_temp + " = extractvalue " + trait_object.llvm_type + " " + trait_object.value + ", 0");
+                result_lines.push("  " + data_ptr_temp + " = extractvalue "
+                    + trait_object.llvm_type
+                    + " "
+                    + trait_object.value
+                    + ", 0");
 
                 let vtable_ptr_temp = "%t" + number_to_string(result_temp);
                 result_temp += 1;
-                result_lines.push("  " + vtable_ptr_temp + " = extractvalue " + trait_object.llvm_type + " " + trait_object.value + ", 1");
+                result_lines.push("  " + vtable_ptr_temp + " = extractvalue "
+                    + trait_object.llvm_type
+                    + " "
+                    + trait_object.value
+                    + ", 1");
 
                 let interface_info3 = find_interface_info_by_name(context, interface_name);
                 if interface_info3 != null {
@@ -283,23 +316,37 @@ fn coerce_and_emit_call(trimmed_target: string, operands: LLVMOperand[], expecte
                             arg_idx += 1;
                         }
                         let fp_params = join_with_separator(fp_param_types, ", ");
-                        let function_type = llvm_return + " (" + fp_params + ")*";
+                        let function_type = llvm_return + " (" + fp_params
+                            + ")*";
 
                         let vtable_slots_temp = "%t" + number_to_string(result_temp);
                         result_temp += 1;
-                        result_lines.push("  " + vtable_slots_temp + " = bitcast i8* " + vtable_ptr_temp + " to i8**");
+                        result_lines.push("  " + vtable_slots_temp
+                            + " = bitcast i8* "
+                            + vtable_ptr_temp
+                            + " to i8**");
 
                         let slot_ptr_temp = "%t" + number_to_string(result_temp);
                         result_temp += 1;
-                        result_lines.push("  " + slot_ptr_temp + " = getelementptr i8*, i8** " + vtable_slots_temp + ", i64 " + number_to_string(method_index));
+                        result_lines.push("  " + slot_ptr_temp
+                            + " = getelementptr i8*, i8** "
+                            + vtable_slots_temp
+                            + ", i64 "
+                            + number_to_string(method_index));
 
                         let raw_ptr_temp = "%t" + number_to_string(result_temp);
                         result_temp += 1;
-                        result_lines.push("  " + raw_ptr_temp + " = load i8*, i8** " + slot_ptr_temp);
+                        result_lines.push("  " + raw_ptr_temp
+                            + " = load i8*, i8** "
+                            + slot_ptr_temp);
 
                         let method_ptr_temp = "%t" + number_to_string(result_temp);
                         result_temp += 1;
-                        result_lines.push("  " + method_ptr_temp + " = bitcast i8* " + raw_ptr_temp + " to " + function_type);
+                        result_lines.push("  " + method_ptr_temp
+                            + " = bitcast i8* "
+                            + raw_ptr_temp
+                            + " to "
+                            + function_type);
 
                         let mut call_args: string[] = ["i8* " + data_ptr_temp];
                         arg_idx = 1;
@@ -311,7 +358,10 @@ fn coerce_and_emit_call(trimmed_target: string, operands: LLVMOperand[], expecte
                         let call_arg_text = join_with_separator(call_args, ", ");
 
                         if llvm_return == "void" {
-                            result_lines.push("  call void " + method_ptr_temp + "(" + call_arg_text + ")");
+                            result_lines.push("  call void " + method_ptr_temp
+                                + "("
+                                + call_arg_text
+                                + ")");
                             return ExpressionResult {
                                 lines: result_lines,
                                 temp_index: result_temp,
@@ -321,7 +371,14 @@ fn coerce_and_emit_call(trimmed_target: string, operands: LLVMOperand[], expecte
                             };
                         } else {
                             let result_temp_name = format_temp_name(result_temp);
-                            result_lines.push("  " + result_temp_name + " = call " + llvm_return + " " + method_ptr_temp + "(" + call_arg_text + ")");
+                            result_lines.push("  " + result_temp_name
+                                + " = call "
+                                + llvm_return
+                                + " "
+                                + method_ptr_temp
+                                + "("
+                                + call_arg_text
+                                + ")");
                             let result_operand = LLVMOperand {
                                 llvm_type: llvm_return,
                                 value: result_temp_name
@@ -335,22 +392,31 @@ fn coerce_and_emit_call(trimmed_target: string, operands: LLVMOperand[], expecte
                             };
                         }
                     } else {
-                        result_diagnostics.push("llvm lowering: method `" + method_name + "` not found in interface `" + interface_name + "`");
+                        result_diagnostics.push("llvm lowering: method `"
+                            + method_name
+                            + "` not found in interface `"
+                            + interface_name
+                            + "`");
                     }
                 } else {
-                    result_diagnostics.push("llvm lowering: interface `" + interface_name + "` not found for trait dispatch");
+                    result_diagnostics.push("llvm lowering: interface `"
+                        + interface_name
+                        + "` not found for trait dispatch");
                 }
             } else {
                 result_diagnostics.push("llvm lowering: trait dispatch requires at least one argument (the trait object)");
             }
         } else {
-            result_diagnostics.push("llvm lowering: malformed trait dispatch target `" + trimmed_target + "`");
+            result_diagnostics.push("llvm lowering: malformed trait dispatch target `"
+                + trimmed_target
+                + "`");
         }
     }
 
     // Standard function call
     if _trace_ccl {
-        print.err("call_lowering: checkpoint-F call_symbol target=" + trimmed_target);
+        print.err("call_lowering: checkpoint-F call_symbol target="
+            + trimmed_target);
     }
     let mut call_symbol = sanitize_symbol(trimmed_target);
     if helper_descriptor != null { call_symbol = helper_descriptor.symbol; }
@@ -361,10 +427,13 @@ fn coerce_and_emit_call(trimmed_target: string, operands: LLVMOperand[], expecte
         if call_symbol == "concat" { call_symbol = "sailfin_runtime_concat"; }
     }
     if _trace_ccl {
-        print.err("call_lowering: checkpoint-G llvm_return=" + llvm_return + " call_symbol=" + call_symbol);
+        print.err("call_lowering: checkpoint-G llvm_return=" + llvm_return
+            + " call_symbol="
+            + call_symbol);
     }
     if llvm_return == "void" {
-        let call_line = "  call void @" + call_symbol + "(" + argument_text + ")";
+        let call_line = "  call void @" + call_symbol + "(" + argument_text
+            + ")";
         result_lines.push(call_line);
         if _trace_ccl {
             print.err("call_lowering: checkpoint-H void return");
@@ -385,7 +454,11 @@ fn coerce_and_emit_call(trimmed_target: string, operands: LLVMOperand[], expecte
     if _trace_ccl {
         print.err("call_lowering: checkpoint-I temp_name=" + temp_name);
     }
-    let call_line = "  " + temp_name + " = call " + llvm_return + " @" + call_symbol + "(" + argument_text + ")";
+    let call_line = "  " + temp_name + " = call " + llvm_return + " @"
+        + call_symbol
+        + "("
+        + argument_text
+        + ")";
     result_lines.push(call_line);
     let operand = LLVMOperand { llvm_type: llvm_return, value: temp_name };
     if _trace_ccl {

--- a/compiler/src/llvm/expression_lowering/native/core_call_emission.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_call_emission.sfn
@@ -2,60 +2,38 @@
 //
 // Call emission extracted from core_call_lowering.sfn to keep
 // each function under ~500 .sfn-asm instructions (avoids seed OOM).
-
 import { NativeFunction } from "../../../native_ir";
-
+import { find_last_index_of_char, substring } from "../../../string_utils";
+import { format_temp_name, format_typed_operand } from "../../expressions_helpers";
+import { merge_string_constants } from "../../strings";
+import { find_interface_info_by_name, } from "../../type_context_queries";
+import { ends_with_pointer_suffix, strip_pointer_suffix, } from "../../type_mapping";
 import {
-    TypeContext,
-    ParameterBinding,
-    LocalBinding,
     ExpressionResult,
     LLVMOperand,
-    StringConstant,
-    RuntimeHelperDescriptor,
+    LocalBinding,
     MemberAccessParse,
+    ParameterBinding,
+    RuntimeHelperDescriptor,
+    StringConstant,
+    TypeContext,
 } from "../../types";
-
 import {
-    trim_text,
-    starts_with,
-    number_to_string,
-    join_with_separator,
     extend_string_array,
+    join_with_separator,
+    number_to_string,
+    starts_with,
+    trim_text,
 } from "../../utils";
-
-import { substring, find_last_index_of_char } from "../../../string_utils";
-
-import { merge_string_constants } from "../../strings";
-
-import { format_temp_name, format_typed_operand } from "../../expressions_helpers";
-
-import {
-    ends_with_pointer_suffix,
-    strip_pointer_suffix,
-} from "../../type_mapping";
-
-import {
-    find_interface_info_by_name,
-} from "../../type_context_queries";
-
 import {
     array_pointer_element_type,
-    lower_struct_array_concat,
     lower_array_push_in_place,
+    lower_struct_array_concat,
 } from "../arrays";
-
-import {
-    parse_member_access,
-} from "./core_parse";
-
-import {
-    find_local_binding,
-} from "./core_scopes";
-
-import { sanitize_symbol } from "./core_text";
-
 import { coerce_operand_to_type } from "./core_operands";
+import { parse_member_access, } from "./core_parse";
+import { find_local_binding, } from "./core_scopes";
+import { sanitize_symbol } from "./core_text";
 
 fn _write_emission_result_lines(result_lines: string[], result_temp: number) -> void ![io] {
     // Dead IPC files removed — .call_result_line_count and .call_result_temp_index have no reader.
@@ -63,27 +41,7 @@ fn _write_emission_result_lines(result_lines: string[], result_temp: number) -> 
 
 // Coerce operands to expected types and emit the final call instruction.
 // Handles array concat/push, trait dispatch, and normal function calls.
-fn coerce_and_emit_call(
-    trimmed_target: string,
-    operands: LLVMOperand[],
-    expected_params: string[],
-    llvm_return: string,
-    is_trait_dispatch: boolean,
-    is_array_concat: boolean,
-    array_concat_element_type: string,
-    is_array_push: boolean,
-    array_push_element_type: string,
-    method_operand: LLVMOperand?,
-    helper_descriptor: RuntimeHelperDescriptor?,
-    function_entry: NativeFunction?,
-    current_temp: number,
-    current_lines: string[],
-    diagnostics: string[],
-    collected_string_constants: StringConstant[],
-    bindings: ParameterBinding[],
-    locals: LocalBinding[],
-    context: TypeContext
-) -> ExpressionResult ![io] {
+fn coerce_and_emit_call(trimmed_target: string, operands: LLVMOperand[], expected_params: string[], llvm_return: string, is_trait_dispatch: boolean, is_array_concat: boolean, array_concat_element_type: string, is_array_push: boolean, array_push_element_type: string, method_operand: LLVMOperand?, helper_descriptor: RuntimeHelperDescriptor?, function_entry: NativeFunction?, current_temp: number, current_lines: string[], diagnostics: string[], collected_string_constants: StringConstant[], bindings: ParameterBinding[], locals: LocalBinding[], context: TypeContext) -> ExpressionResult ![io] {
     let mut result_lines = current_lines;
     let mut result_temp: number = current_temp;
     let mut result_diagnostics = diagnostics;
@@ -96,9 +54,7 @@ fn coerce_and_emit_call(
     let mut coerced_operands: LLVMOperand[] = [];
     let mut index: number = 0;
     loop {
-        if index >= operands.length {
-            break;
-        }
+        if index >= operands.length { break; }
         let operand = operands[index];
         if _trace_ccl {
             print.err("call_lowering: coerce-loop idx=" + number_to_string(index) + " operand_type=" + operand.llvm_type + " operand_value=" + operand.value);
@@ -109,13 +65,9 @@ fn coerce_and_emit_call(
         }
         let mut _if55: boolean = false;
         if is_trait_dispatch {
-            if index == 0 {
-                _if55 = true;
-            }
+            if index == 0 { _if55 = true; }
         }
-        if _if55 {
-            coerced_operands.push(operand);
-        } else if target_type.length == 0 {
+        if _if55 { coerced_operands.push(operand); } else if target_type.length == 0 {
             coerced_operands.push(operand);
         } else {
             let coerced = coerce_operand_to_type(operand, target_type, result_temp, result_lines);
@@ -125,9 +77,7 @@ fn coerce_and_emit_call(
             if coerced.operand == null {
                 result_diagnostics.push("llvm lowering: unable to coerce argument " + number_to_string(index) + " for call to `" + trimmed_target + "`: passing original operand");
                 coerced_operands.push(operand);
-            } else {
-                coerced_operands.push(coerced.operand);
-            }
+            } else { coerced_operands.push(coerced.operand); }
         }
         index += 1;
     }
@@ -158,15 +108,33 @@ fn coerce_and_emit_call(
                         _write_emission_result_lines(result_lines, result_temp);
                         fs.writeFile("build/sailfin/.call_result_type", "");
                         fs.writeFile("build/sailfin/.call_result_value", "");
-                        return ExpressionResult { lines: result_lines, temp_index: result_temp, operand: null, diagnostics: result_diagnostics, string_constants: collected_string_constants };
+                        return ExpressionResult {
+                            lines: result_lines,
+                            temp_index: result_temp,
+                            operand: null,
+                            diagnostics: result_diagnostics,
+                            string_constants: collected_string_constants
+                        };
                     }
                     _write_emission_result_lines(result_lines, result_temp);
                     fs.writeFile("build/sailfin/.call_result_type", concat_result.operand.llvm_type);
                     fs.writeFile("build/sailfin/.call_result_value", concat_result.operand.value);
-                    return ExpressionResult { lines: result_lines, temp_index: result_temp, operand: concat_result.operand, diagnostics: result_diagnostics, string_constants: collected_string_constants };
+                    return ExpressionResult {
+                        lines: result_lines,
+                        temp_index: result_temp,
+                        operand: concat_result.operand,
+                        diagnostics: result_diagnostics,
+                        string_constants: collected_string_constants
+                    };
                 } else {
                     result_diagnostics.push("llvm lowering: concat requires two operands");
-                    return ExpressionResult { lines: result_lines, temp_index: result_temp, operand: null, diagnostics: result_diagnostics, string_constants: collected_string_constants };
+                    return ExpressionResult {
+                        lines: result_lines,
+                        temp_index: result_temp,
+                        operand: null,
+                        diagnostics: result_diagnostics,
+                        string_constants: collected_string_constants
+                    };
                 }
             }
         }
@@ -189,7 +157,13 @@ fn coerce_and_emit_call(
                     _write_emission_result_lines(result_lines, result_temp);
                     fs.writeFile("build/sailfin/.call_result_type", "");
                     fs.writeFile("build/sailfin/.call_result_value", "");
-                    return ExpressionResult { lines: result_lines, temp_index: result_temp, operand: null, diagnostics: result_diagnostics, string_constants: collected_string_constants };
+                    return ExpressionResult {
+                        lines: result_lines,
+                        temp_index: result_temp,
+                        operand: null,
+                        diagnostics: result_diagnostics,
+                        string_constants: collected_string_constants
+                    };
                 }
                 if array_push_element_type == "i8*" {
                     let method_parse = parse_member_access(trimmed_target);
@@ -204,10 +178,22 @@ fn coerce_and_emit_call(
                 _write_emission_result_lines(result_lines, result_temp);
                 fs.writeFile("build/sailfin/.call_result_type", push_result.operand.llvm_type);
                 fs.writeFile("build/sailfin/.call_result_value", push_result.operand.value);
-                return ExpressionResult { lines: result_lines, temp_index: result_temp, operand: push_result.operand, diagnostics: result_diagnostics, string_constants: collected_string_constants };
+                return ExpressionResult {
+                    lines: result_lines,
+                    temp_index: result_temp,
+                    operand: push_result.operand,
+                    diagnostics: result_diagnostics,
+                    string_constants: collected_string_constants
+                };
             } else {
                 result_diagnostics.push("llvm lowering: push requires two operands");
-                return ExpressionResult { lines: result_lines, temp_index: result_temp, operand: null, diagnostics: result_diagnostics, string_constants: collected_string_constants };
+                return ExpressionResult {
+                    lines: result_lines,
+                    temp_index: result_temp,
+                    operand: null,
+                    diagnostics: result_diagnostics,
+                    string_constants: collected_string_constants
+                };
             }
         }
     }
@@ -233,9 +219,7 @@ fn coerce_and_emit_call(
     let mut rendered_args: string[] = [];
     index = 0;
     loop {
-        if index >= final_operands.length {
-            break;
-        }
+        if index >= final_operands.length { break; }
         if _trace_ccl {
             print.err("call_lowering: render-arg idx=" + number_to_string(index));
         }
@@ -294,9 +278,7 @@ fn coerce_and_emit_call(
                         let mut fp_param_types: string[] = ["i8*"];
                         let mut arg_idx: number = 1;
                         loop {
-                            if arg_idx >= final_operands.length {
-                                break;
-                            }
+                            if arg_idx >= final_operands.length { break; }
                             fp_param_types.push(final_operands[arg_idx].llvm_type);
                             arg_idx += 1;
                         }
@@ -322,9 +304,7 @@ fn coerce_and_emit_call(
                         let mut call_args: string[] = ["i8* " + data_ptr_temp];
                         arg_idx = 1;
                         loop {
-                            if arg_idx >= rendered_args.length {
-                                break;
-                            }
+                            if arg_idx >= rendered_args.length { break; }
                             call_args.push(rendered_args[arg_idx]);
                             arg_idx += 1;
                         }
@@ -332,12 +312,27 @@ fn coerce_and_emit_call(
 
                         if llvm_return == "void" {
                             result_lines.push("  call void " + method_ptr_temp + "(" + call_arg_text + ")");
-                            return ExpressionResult { lines: result_lines, temp_index: result_temp, operand: null, diagnostics: result_diagnostics, string_constants: collected_string_constants };
+                            return ExpressionResult {
+                                lines: result_lines,
+                                temp_index: result_temp,
+                                operand: null,
+                                diagnostics: result_diagnostics,
+                                string_constants: collected_string_constants
+                            };
                         } else {
                             let result_temp_name = format_temp_name(result_temp);
                             result_lines.push("  " + result_temp_name + " = call " + llvm_return + " " + method_ptr_temp + "(" + call_arg_text + ")");
-                            let result_operand = LLVMOperand { llvm_type: llvm_return, value: result_temp_name };
-                            return ExpressionResult { lines: result_lines, temp_index: result_temp + 1, operand: result_operand, diagnostics: result_diagnostics, string_constants: collected_string_constants };
+                            let result_operand = LLVMOperand {
+                                llvm_type: llvm_return,
+                                value: result_temp_name
+                            };
+                            return ExpressionResult {
+                                lines: result_lines,
+                                temp_index: result_temp + 1,
+                                operand: result_operand,
+                                diagnostics: result_diagnostics,
+                                string_constants: collected_string_constants
+                            };
                         }
                     } else {
                         result_diagnostics.push("llvm lowering: method `" + method_name + "` not found in interface `" + interface_name + "`");
@@ -358,16 +353,12 @@ fn coerce_and_emit_call(
         print.err("call_lowering: checkpoint-F call_symbol target=" + trimmed_target);
     }
     let mut call_symbol = sanitize_symbol(trimmed_target);
-    if helper_descriptor != null {
-        call_symbol = helper_descriptor.symbol;
-    }
+    if helper_descriptor != null { call_symbol = helper_descriptor.symbol; }
     // When concat resolves with no helper_descriptor (common for method
     // dispatch paths that set helper_descriptor: null), fall back to the
     // canonical runtime symbol so we don't emit a bare @concat.
     if trimmed_target == "concat" {
-        if call_symbol == "concat" {
-            call_symbol = "sailfin_runtime_concat";
-        }
+        if call_symbol == "concat" { call_symbol = "sailfin_runtime_concat"; }
     }
     if _trace_ccl {
         print.err("call_lowering: checkpoint-G llvm_return=" + llvm_return + " call_symbol=" + call_symbol);
@@ -381,7 +372,13 @@ fn coerce_and_emit_call(
         _write_emission_result_lines(result_lines, result_temp);
         fs.writeFile("build/sailfin/.call_result_type", "");
         fs.writeFile("build/sailfin/.call_result_value", "");
-        return ExpressionResult { lines: result_lines, temp_index: result_temp, operand: null, diagnostics: result_diagnostics, string_constants: collected_string_constants };
+        return ExpressionResult {
+            lines: result_lines,
+            temp_index: result_temp,
+            operand: null,
+            diagnostics: result_diagnostics,
+            string_constants: collected_string_constants
+        };
     }
 
     let temp_name = format_temp_name(result_temp);
@@ -397,10 +394,14 @@ fn coerce_and_emit_call(
     _write_emission_result_lines(result_lines, result_temp + 1);
     fs.writeFile("build/sailfin/.call_result_type", llvm_return);
     fs.writeFile("build/sailfin/.call_result_value", temp_name);
-    if _trace_ccl {
-        print.err("call_lowering: checkpoint-K returning");
-    }
-    return ExpressionResult { lines: result_lines, temp_index: result_temp + 1, operand: operand, diagnostics: result_diagnostics, string_constants: collected_string_constants };
+    if _trace_ccl { print.err("call_lowering: checkpoint-K returning"); }
+    return ExpressionResult {
+        lines: result_lines,
+        temp_index: result_temp + 1,
+        operand: operand,
+        diagnostics: result_diagnostics,
+        string_constants: collected_string_constants
+    };
 }
 
 export { coerce_and_emit_call };

--- a/compiler/src/llvm/expression_lowering/native/core_call_lowering.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_call_lowering.sfn
@@ -7,8 +7,8 @@ import { format_temp_name } from "../../expressions_helpers";
 import { is_simple_identifier } from "../../expressions_helpers";
 import { find_runtime_helper } from "../../runtime_helpers";
 import { empty_string_constant_set, merge_string_constants } from "../../strings";
-import { resolve_enum_info_for_literal, resolve_enum_variant_info, } from "../../type_context_queries";
-import { ends_with_pointer_suffix, strip_pointer_suffix, } from "../../type_mapping";
+import { resolve_enum_info_for_literal, resolve_enum_variant_info } from "../../type_context_queries";
+import { ends_with_pointer_suffix, strip_pointer_suffix } from "../../type_mapping";
 import {
     EnumLiteralParse,
     ExpressionResult,
@@ -18,27 +18,23 @@ import {
     RuntimeHelperDescriptor,
     StringConstant,
     StructLiteralField,
-    TypeContext,
+    TypeContext
 } from "../../types";
 import {
     ends_with,
     extend_string_array,
     number_to_string,
     starts_with,
-    trim_text,
+    trim_text
 } from "../../utils";
-import { array_pointer_element_type, } from "../arrays";
+import { array_pointer_element_type } from "../arrays";
 // Mutually recursive with core.sfn
 import { lower_expression } from "./core";
 import { coerce_and_emit_call } from "./core_call_emission";
 import { resolve_call_method_target, resolve_call_signature } from "./core_call_resolution";
 import { lower_enum_literal } from "./core_literals_lowering";
-import { parse_member_access, } from "./core_parse";
-import {
-    find_local_binding,
-    find_parameter_binding,
-    replace_llvm_operand,
-} from "./core_scopes";
+import { parse_member_access } from "./core_parse";
+import { find_local_binding, find_parameter_binding, replace_llvm_operand } from "./core_scopes";
 
 // Helper to access a string array element.
 // The seed compiler (v0.1.1) has a bug where `arr[idx]` inside complex loops
@@ -66,7 +62,10 @@ fn lower_call_expression(target: string, arguments: string[], bindings: Paramete
     let dot_index = index_of(trimmed_target, ".");
     let trace_calls = fs.exists("build/sailfin/.trace_call_lowering");
     if trace_calls {
-        print.err("call_lowering: target='" + trimmed_target + "' dot_index=" + number_to_string(dot_index) + " enums=" + number_to_string(context.enums.length));
+        print.err("call_lowering: target='" + trimmed_target + "' dot_index="
+            + number_to_string(dot_index)
+            + " enums="
+            + number_to_string(context.enums.length));
     }
     if dot_index > 0 {
         let enum_name = trim_text(substring(trimmed_target, 0, dot_index));
@@ -76,7 +75,10 @@ fn lower_call_expression(target: string, arguments: string[], bindings: Paramete
         if trace_calls {
             let mut found_text: string = "null";
             if enum_info != null { found_text = "found"; }
-            print.err("call_lowering: enum_name='" + enum_name + "' variant='" + variant_name + "' resolved=" + found_text);
+            print.err("call_lowering: enum_name='" + enum_name + "' variant='"
+                + variant_name
+                + "' resolved="
+                + found_text);
         }
         if enum_info != null {
             let mut fields: StructLiteralField[] = [];
@@ -166,7 +168,7 @@ fn lower_call_expression(target: string, arguments: string[], bindings: Paramete
                         symbol: "",
                         return_type: receiver_type,
                         parameter_types: expected_params,
-                        effects: [],
+                        effects: []
                     };
                     function_entry = null;
                 }
@@ -181,7 +183,9 @@ fn lower_call_expression(target: string, arguments: string[], bindings: Paramete
         if index >= arguments.length { break; }
         let argument_text = trim_text(get_string_at(arguments, index));
         if argument_text.length == 0 {
-            diagnostics.push("llvm lowering: empty argument in call to `" + trimmed_target + "`");
+            diagnostics.push("llvm lowering: empty argument in call to `"
+                + trimmed_target
+                + "`");
         }
         let mut argument_expected_type: string = "";
         let parameter_index = index + injected_argument_count;
@@ -194,7 +198,11 @@ fn lower_call_expression(target: string, arguments: string[], bindings: Paramete
         current_lines = lowered.lines;
         current_temp = lowered.temp_index;
         if lowered.operand != null { operands.push(lowered.operand); } else {
-            diagnostics.push("llvm lowering: failed to lower argument " + number_to_string(index) + " for call to `" + trimmed_target + "`");
+            diagnostics.push("llvm lowering: failed to lower argument "
+                + number_to_string(index)
+                + " for call to `"
+                + trimmed_target
+                + "`");
         }
         index += 1;
     }
@@ -215,7 +223,9 @@ fn lower_call_expression(target: string, arguments: string[], bindings: Paramete
 
     let expected_operand_count = arguments.length + injected_argument_count;
     if operands.length != expected_operand_count {
-        diagnostics.push("llvm lowering: unable to emit call to `" + trimmed_target + "` due to argument errors");
+        diagnostics.push("llvm lowering: unable to emit call to `"
+            + trimmed_target
+            + "` due to argument errors");
         return ExpressionResult {
             lines: current_lines,
             temp_index: current_temp,
@@ -241,7 +251,7 @@ fn lower_call_expression(target: string, arguments: string[], bindings: Paramete
                         symbol: "",
                         return_type: operands[0].llvm_type,
                         parameter_types: expected_params,
-                        effects: [],
+                        effects: []
                     };
                 }
             }
@@ -264,7 +274,11 @@ fn lower_call_expression(target: string, arguments: string[], bindings: Paramete
                 current_lines = lowered_default.lines;
                 current_temp = lowered_default.temp_index;
                 if lowered_default.operand == null {
-                    diagnostics.push("llvm lowering: failed to lower default argument for parameter `" + param.name + "` in call to `" + trimmed_target + "`");
+                    diagnostics.push("llvm lowering: failed to lower default argument for parameter `"
+                        + param.name
+                        + "` in call to `"
+                        + trimmed_target
+                        + "`");
                     break;
                 }
                 operands.push(lowered_default.operand);
@@ -285,7 +299,12 @@ fn lower_call_expression(target: string, arguments: string[], bindings: Paramete
                             let stripped = strip_pointer_suffix(self_operand.llvm_type);
                             if stripped == expected_self_type {
                                 let load_name = format_temp_name(current_temp);
-                                current_lines.push("  " + load_name + " = load " + expected_self_type + ", " + expected_self_type + "* " + self_operand.value);
+                                current_lines.push("  " + load_name + " = load "
+                                    + expected_self_type
+                                    + ", "
+                                    + expected_self_type
+                                    + "* "
+                                    + self_operand.value);
                                 current_temp += 1;
                                 let updated_operand = LLVMOperand {
                                     llvm_type: expected_self_type,
@@ -293,7 +312,11 @@ fn lower_call_expression(target: string, arguments: string[], bindings: Paramete
                                 };
                                 operands = replace_llvm_operand(operands, 0, updated_operand);
                             } else {
-                                diagnostics.push("llvm lowering: method call expects `" + expected_self_type + "` but base `" + self_operand.llvm_type + "` is incompatible");
+                                diagnostics.push("llvm lowering: method call expects `"
+                                    + expected_self_type
+                                    + "` but base `"
+                                    + self_operand.llvm_type
+                                    + "` is incompatible");
                             }
                         } else if ends_with_pointer_suffix(expected_self_type) {
                             let method_parse = parse_member_access(trimmed_target);
@@ -336,7 +359,11 @@ fn lower_call_expression(target: string, arguments: string[], bindings: Paramete
                                         if _elif66 {
                                             // avoid warning
                                         } else {
-                                            diagnostics.push("llvm lowering: method call expects `" + expected_self_type + "` but base `" + self_operand.llvm_type + "` is incompatible");
+                                            diagnostics.push("llvm lowering: method call expects `"
+                                                + expected_self_type
+                                                + "` but base `"
+                                                + self_operand.llvm_type
+                                                + "` is incompatible");
                                         }
                                     }
                                 }
@@ -356,11 +383,19 @@ fn lower_call_expression(target: string, arguments: string[], bindings: Paramete
                                 if _if63 {
                                     // ok
                                 } else {
-                                    diagnostics.push("llvm lowering: method call expects `" + expected_self_type + "` but base `" + self_operand.llvm_type + "` is incompatible");
+                                    diagnostics.push("llvm lowering: method call expects `"
+                                        + expected_self_type
+                                        + "` but base `"
+                                        + self_operand.llvm_type
+                                        + "` is incompatible");
                                 }
                             }
                         } else {
-                            diagnostics.push("llvm lowering: method call expects `" + expected_self_type + "` but base `" + self_operand.llvm_type + "` is incompatible");
+                            diagnostics.push("llvm lowering: method call expects `"
+                                + expected_self_type
+                                + "` but base `"
+                                + self_operand.llvm_type
+                                + "` is incompatible");
                         }
                     }
                 }

--- a/compiler/src/llvm/expression_lowering/native/core_call_lowering.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_call_lowering.sfn
@@ -1,79 +1,50 @@
 // compiler/src/llvm/expression_lowering/native/core_call_lowering.sfn
 //
 // Call lowering extracted from core.sfn.
-
 import { NativeFunction } from "../../../native_ir";
-
+import { index_of, substring } from "../../../string_utils";
+import { format_temp_name } from "../../expressions_helpers";
+import { is_simple_identifier } from "../../expressions_helpers";
+import { find_runtime_helper } from "../../runtime_helpers";
+import { empty_string_constant_set, merge_string_constants } from "../../strings";
+import { resolve_enum_info_for_literal, resolve_enum_variant_info, } from "../../type_context_queries";
+import { ends_with_pointer_suffix, strip_pointer_suffix, } from "../../type_mapping";
 import {
-    TypeContext,
-    ParameterBinding,
-    LocalBinding,
+    EnumLiteralParse,
     ExpressionResult,
     LLVMOperand,
+    LocalBinding,
+    ParameterBinding,
+    RuntimeHelperDescriptor,
     StringConstant,
     StructLiteralField,
-    EnumLiteralParse,
-    RuntimeHelperDescriptor,
+    TypeContext,
 } from "../../types";
-
 import {
-    trim_text,
-    starts_with,
     ends_with,
     extend_string_array,
     number_to_string,
+    starts_with,
+    trim_text,
 } from "../../utils";
-
-import { substring, index_of } from "../../../string_utils";
-
-import { empty_string_constant_set, merge_string_constants } from "../../strings";
-
-import { format_temp_name } from "../../expressions_helpers";
-
-import { is_simple_identifier } from "../../expressions_helpers";
-
-import {
-    ends_with_pointer_suffix,
-    strip_pointer_suffix,
-} from "../../type_mapping";
-
-import {
-    resolve_enum_info_for_literal,
-    resolve_enum_variant_info,
-} from "../../type_context_queries";
-
-import {
-    array_pointer_element_type,
-} from "../arrays";
-
-import {
-    parse_member_access,
-} from "./core_parse";
-
+import { array_pointer_element_type, } from "../arrays";
+// Mutually recursive with core.sfn
+import { lower_expression } from "./core";
+import { coerce_and_emit_call } from "./core_call_emission";
+import { resolve_call_method_target, resolve_call_signature } from "./core_call_resolution";
+import { lower_enum_literal } from "./core_literals_lowering";
+import { parse_member_access, } from "./core_parse";
 import {
     find_local_binding,
     find_parameter_binding,
     replace_llvm_operand,
 } from "./core_scopes";
 
-import { lower_enum_literal } from "./core_literals_lowering";
-
-import { resolve_call_method_target, resolve_call_signature } from "./core_call_resolution";
-
-import { coerce_and_emit_call } from "./core_call_emission";
-
-import { find_runtime_helper } from "../../runtime_helpers";
-
-// Mutually recursive with core.sfn
-import { lower_expression } from "./core";
-
 // Helper to access a string array element.
 // The seed compiler (v0.1.1) has a bug where `arr[idx]` inside complex loops
 // compiles as substring() on the wrong local variable.  Extracting the access
 // into a tiny function produces correct array-element-load LLVM IR.
-fn get_string_at(arr: string[], idx: number) -> string {
-    return arr[idx];
-}
+fn get_string_at(arr: string[], idx: number) -> string { return arr[idx]; }
 
 fn lower_call_expression(target: string, arguments: string[], bindings: ParameterBinding[], locals: LocalBinding[], temp_index: number, lines: string[], functions: NativeFunction[], context: TypeContext) -> ExpressionResult ![io] {
     let mut diagnostics: string[] = [];
@@ -82,7 +53,13 @@ fn lower_call_expression(target: string, arguments: string[], bindings: Paramete
     let mut trimmed_target = trim_text(target);
     if trimmed_target.length == 0 {
         diagnostics.push("llvm lowering: call target missing");
-        return ExpressionResult { lines: lines, temp_index: temp_index, operand: null, diagnostics: diagnostics, string_constants: empty_constants };
+        return ExpressionResult {
+            lines: lines,
+            temp_index: temp_index,
+            operand: null,
+            diagnostics: diagnostics,
+            string_constants: empty_constants
+        };
     }
 
     // Check if this is an enum variant constructor call (e.g., LiteralValue.Null())
@@ -98,9 +75,7 @@ fn lower_call_expression(target: string, arguments: string[], bindings: Paramete
         let enum_info = resolve_enum_info_for_literal(context, enum_name);
         if trace_calls {
             let mut found_text: string = "null";
-            if enum_info != null {
-                found_text = "found";
-            }
+            if enum_info != null { found_text = "found"; }
             print.err("call_lowering: enum_name='" + enum_name + "' variant='" + variant_name + "' resolved=" + found_text);
         }
         if enum_info != null {
@@ -117,13 +92,10 @@ fn lower_call_expression(target: string, arguments: string[], bindings: Paramete
                 if _if54 {
                     let mut arg_index: number = 0;
                     loop {
-                        if arg_index >= arguments.length {
-                            break;
-                        }
+                        if arg_index >= arguments.length { break; }
                         let field_info = variant_info.fields[arg_index];
                         fields.push(StructLiteralField {
-                                name: field_info.name,
-                                value: arguments[arg_index]
+                            name: field_info.name, value: arguments[arg_index]
                         });
                         arg_index += 1;
                     }
@@ -174,9 +146,7 @@ fn lower_call_expression(target: string, arguments: string[], bindings: Paramete
     // doesn't detect it as a method call).
     if helper_descriptor == null {
         let fallback_helper = find_runtime_helper(trimmed_target);
-        if fallback_helper != null {
-            helper_descriptor = fallback_helper;
-        }
+        if fallback_helper != null { helper_descriptor = fallback_helper; }
     }
 
     // Re-derive helper_descriptor for concat after signature resolution
@@ -208,9 +178,7 @@ fn lower_call_expression(target: string, arguments: string[], bindings: Paramete
     let mut operands: LLVMOperand[] = [];
     let mut index: number = 0;
     loop {
-        if index >= arguments.length {
-            break;
-        }
+        if index >= arguments.length { break; }
         let argument_text = trim_text(get_string_at(arguments, index));
         if argument_text.length == 0 {
             diagnostics.push("llvm lowering: empty argument in call to `" + trimmed_target + "`");
@@ -225,9 +193,7 @@ fn lower_call_expression(target: string, arguments: string[], bindings: Paramete
         collected_string_constants = merge_string_constants(collected_string_constants, lowered.string_constants);
         current_lines = lowered.lines;
         current_temp = lowered.temp_index;
-        if lowered.operand != null {
-            operands.push(lowered.operand);
-        } else {
+        if lowered.operand != null { operands.push(lowered.operand); } else {
             diagnostics.push("llvm lowering: failed to lower argument " + number_to_string(index) + " for call to `" + trimmed_target + "`");
         }
         index += 1;
@@ -240,9 +206,7 @@ fn lower_call_expression(target: string, arguments: string[], bindings: Paramete
         combined_operands.push(operand_value);
         let mut operand_index: number = 0;
         loop {
-            if operand_index >= operands.length {
-                break;
-            }
+            if operand_index >= operands.length { break; }
             combined_operands.push(operands[operand_index]);
             operand_index += 1;
         }
@@ -252,7 +216,13 @@ fn lower_call_expression(target: string, arguments: string[], bindings: Paramete
     let expected_operand_count = arguments.length + injected_argument_count;
     if operands.length != expected_operand_count {
         diagnostics.push("llvm lowering: unable to emit call to `" + trimmed_target + "` due to argument errors");
-        return ExpressionResult { lines: current_lines, temp_index: current_temp, operand: null, diagnostics: diagnostics, string_constants: collected_string_constants };
+        return ExpressionResult {
+            lines: current_lines,
+            temp_index: current_temp,
+            operand: null,
+            diagnostics: diagnostics,
+            string_constants: collected_string_constants
+        };
     }
 
     // Re-check concat element type from actual operands
@@ -283,16 +253,10 @@ fn lower_call_expression(target: string, arguments: string[], bindings: Paramete
         if operands.length < expected_params.length {
             let mut param_index: number = operands.length;
             loop {
-                if param_index >= expected_params.length {
-                    break;
-                }
-                if param_index >= function_entry.parameters.length {
-                    break;
-                }
+                if param_index >= expected_params.length { break; }
+                if param_index >= function_entry.parameters.length { break; }
                 let param = function_entry.parameters[param_index];
-                if param.default_value == null {
-                    break;
-                }
+                if param.default_value == null { break; }
                 let expected_type = expected_params[param_index];
                 let lowered_default = lower_expression(param.default_value, bindings, locals, current_temp, current_lines, functions, context, expected_type);
                 diagnostics = extend_string_array(diagnostics, lowered_default.diagnostics);
@@ -323,7 +287,10 @@ fn lower_call_expression(target: string, arguments: string[], bindings: Paramete
                                 let load_name = format_temp_name(current_temp);
                                 current_lines.push("  " + load_name + " = load " + expected_self_type + ", " + expected_self_type + "* " + self_operand.value);
                                 current_temp += 1;
-                                let updated_operand = LLVMOperand { llvm_type: expected_self_type, value: load_name };
+                                let updated_operand = LLVMOperand {
+                                    llvm_type: expected_self_type,
+                                    value: load_name
+                                };
                                 operands = replace_llvm_operand(operands, 0, updated_operand);
                             } else {
                                 diagnostics.push("llvm lowering: method call expects `" + expected_self_type + "` but base `" + self_operand.llvm_type + "` is incompatible");
@@ -340,7 +307,10 @@ fn lower_call_expression(target: string, arguments: string[], bindings: Paramete
                                     }
                                 }
                                 if _if62 {
-                                    let updated_operand = LLVMOperand { llvm_type: expected_self_type, value: local_pointer.pointer };
+                                    let updated_operand = LLVMOperand {
+                                        llvm_type: expected_self_type,
+                                        value: local_pointer.pointer
+                                    };
                                     operands = replace_llvm_operand(operands, 0, updated_operand);
                                 } else {
                                     let parameter_pointer = find_parameter_binding(bindings, base_name);
@@ -351,7 +321,10 @@ fn lower_call_expression(target: string, arguments: string[], bindings: Paramete
                                         }
                                     }
                                     if _if64 {
-                                        let updated_operand = LLVMOperand { llvm_type: expected_self_type, value: parameter_pointer.llvm_name };
+                                        let updated_operand = LLVMOperand {
+                                            llvm_type: expected_self_type,
+                                            value: parameter_pointer.llvm_name
+                                        };
                                         operands = replace_llvm_operand(operands, 0, updated_operand);
                                     } else {
                                         let mut _elif66: boolean = false;
@@ -372,11 +345,13 @@ fn lower_call_expression(target: string, arguments: string[], bindings: Paramete
                                 let mut _if63: boolean = false;
                                 if self_operand.llvm_type == receiver_base {
                                     let mut _if65: boolean = false;
-                                    if starts_with(receiver_base, "%") { _if65 = true; }
-                                    if starts_with(receiver_base, "{") { _if65 = true; }
-                                    if _if65 {
-                                        _if63 = true;
+                                    if starts_with(receiver_base, "%") {
+                                        _if65 = true;
                                     }
+                                    if starts_with(receiver_base, "{") {
+                                        _if65 = true;
+                                    }
+                                    if _if65 { _if63 = true; }
                                 }
                                 if _if63 {
                                     // ok
@@ -394,14 +369,7 @@ fn lower_call_expression(target: string, arguments: string[], bindings: Paramete
     }
 
     // Phase 4: Coerce operands and emit the call (delegated to core_call_emission)
-    return coerce_and_emit_call(
-        trimmed_target, operands, expected_params, llvm_return,
-        is_trait_dispatch, is_array_concat, array_concat_element_type,
-        is_array_push, array_push_element_type,
-        method_operand, helper_descriptor, function_entry,
-        current_temp, current_lines, diagnostics, collected_string_constants,
-        bindings, locals, context
-    );
+    return coerce_and_emit_call(trimmed_target, operands, expected_params, llvm_return, is_trait_dispatch, is_array_concat, array_concat_element_type, is_array_push, array_push_element_type, method_operand, helper_descriptor, function_entry, current_temp, current_lines, diagnostics, collected_string_constants, bindings, locals, context);
 }
 
 export { lower_call_expression };

--- a/compiler/src/llvm/expression_lowering/native/core_call_resolution.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_call_resolution.sfn
@@ -2,97 +2,61 @@
 //
 // Call target resolution extracted from core_call_lowering.sfn to keep
 // each function under ~500 .sfn-asm instructions (avoids seed OOM).
-
 import { NativeFunction, NativeParameter } from "../../../native_ir";
-
 import {
-    TypeContext,
-    ParameterBinding,
-    LocalBinding,
-    ExpressionResult,
-    LLVMOperand,
-    StringConstant,
-    RuntimeHelperDescriptor,
-    CallTargetResolution,
-    CallSignatureResolution,
-    MemberAccessParse,
-    StructTypeInfo,
-} from "../../types";
-
-import {
-    trim_text,
-    starts_with,
-    ends_with,
-    number_to_string,
-} from "../../utils";
-
-import { substring, index_of, find_last_index_of_char, char_at, char_code } from "../../../string_utils";
-
+    char_at,
+    char_code,
+    find_last_index_of_char,
+    index_of,
+    substring
+} from "../../../string_utils";
+import { is_simple_identifier } from "../../expressions_helpers";
+import { find_function_by_name } from "../../rendering_helpers";
+import { find_runtime_helper } from "../../runtime_helpers";
 import { empty_string_constant_set, merge_string_constants } from "../../strings";
-
-import {
-    ends_with_pointer_suffix,
-} from "../../type_mapping";
-
 import {
     find_interface_info_by_name,
-    resolve_struct_info_for_method_target,
     resolve_interface_info_for_method_target,
+    resolve_struct_info_for_method_target,
 } from "../../type_context_queries";
-
-import { find_function_by_name } from "../../rendering_helpers";
-
-import { find_runtime_helper } from "../../runtime_helpers";
-
+import { ends_with_pointer_suffix, } from "../../type_mapping";
 import {
-    collect_parameter_types,
-} from "./core_helpers";
-
+    CallSignatureResolution,
+    CallTargetResolution,
+    ExpressionResult,
+    LLVMOperand,
+    LocalBinding,
+    MemberAccessParse,
+    ParameterBinding,
+    RuntimeHelperDescriptor,
+    StringConstant,
+    StructTypeInfo,
+    TypeContext,
+} from "../../types";
 import {
-    map_return_type,
-    map_parameter_type,
-    future_pointer_type_for_return_type,
-} from "./core_type_mapping";
-
-import { is_simple_identifier } from "../../expressions_helpers";
-
-import {
-    array_pointer_element_type,
-} from "../arrays";
-
-import {
-    parse_member_access,
-} from "./core_parse";
-
-import {
-    find_local_binding,
-    find_parameter_binding,
-} from "./core_scopes";
-
-import {
-    load_local_operand,
-} from "./core_operands";
-
-import { sanitize_symbol } from "./core_text";
-
+    ends_with,
+    number_to_string,
+    starts_with,
+    trim_text,
+} from "../../utils";
+import { array_pointer_element_type, } from "../arrays";
 // Mutually recursive with core.sfn
 import { lower_expression } from "./core";
+import { collect_parameter_types, } from "./core_helpers";
+import { load_local_operand, } from "./core_operands";
+import { parse_member_access, } from "./core_parse";
+import { find_local_binding, find_parameter_binding, } from "./core_scopes";
+import { sanitize_symbol } from "./core_text";
+import {
+    future_pointer_type_for_return_type,
+    map_parameter_type,
+    map_return_type,
+} from "./core_type_mapping";
 
 // Resolve fused concat/push targets (e.g. `valuesconcat(xs)` → `concat`).
 // Also handles file-based method resolution and parse_member_access dispatch.
 // Returns a CallTargetResolution with the resolved target, method operand, etc.
-fn resolve_call_method_target(
-    trimmed_target: string,
-    arguments: string[],
-    bindings: ParameterBinding[],
-    locals: LocalBinding[],
-    current_temp: number,
-    current_lines: string[],
-    functions: NativeFunction[],
-    context: TypeContext,
-    diagnostics: string[],
-    collected_string_constants: StringConstant[]
-) -> CallTargetResolution ![io] {
+fn resolve_call_method_target(trimmed_target: string, arguments: string[], bindings: ParameterBinding[], locals: LocalBinding[], current_temp: number, current_lines: string[], functions: NativeFunction[], context: TypeContext, diagnostics: string[], collected_string_constants: StringConstant[]) -> CallTargetResolution ![io] {
     let mut result_target = trimmed_target;
     let mut result_lines = current_lines;
     let mut result_temp: number = current_temp;
@@ -136,7 +100,10 @@ fn resolve_call_method_target(
                         result_temp = load_result.temp_index;
                         receiver_operand = load_result.operand;
                     } else if parameter != null {
-                        receiver_operand = LLVMOperand { llvm_type: parameter.llvm_type, value: parameter.llvm_name };
+                        receiver_operand = LLVMOperand {
+                            llvm_type: parameter.llvm_type,
+                            value: parameter.llvm_name
+                        };
                     }
 
                     if receiver_operand != null {
@@ -202,7 +169,10 @@ fn resolve_call_method_target(
     }
     if _push_param != null {
         if _push_receiver_operand == null {
-            _push_receiver_operand = LLVMOperand { llvm_type: _push_param.llvm_type, value: _push_param.llvm_name };
+            _push_receiver_operand = LLVMOperand {
+                llvm_type: _push_param.llvm_type,
+                value: _push_param.llvm_name
+            };
         }
     }
     if _push_receiver_operand != null {
@@ -235,7 +205,9 @@ fn resolve_call_method_target(
                                         let mut _pre_pos: number = 0;
                                         let mut _pre_struct: string = "";
                                         loop {
-                                            if _pre_pos >= _pre_raw.length { break; }
+                                            if _pre_pos >= _pre_raw.length {
+                                                break;
+                                            }
                                             let _pre_nl = index_of(substring(_pre_raw, _pre_pos, _pre_raw.length), "\n");
                                             let mut _pre_line: string = "";
                                             if _pre_nl < 0 {
@@ -245,11 +217,15 @@ fn resolve_call_method_target(
                                                 _pre_line = substring(_pre_raw, _pre_pos, _pre_pos + _pre_nl);
                                                 _pre_pos = _pre_pos + _pre_nl + 1;
                                             }
-                                            if _pre_line.length == 0 { continue; }
+                                            if _pre_line.length == 0 {
+                                                continue;
+                                            }
                                             let _pre_t1 = index_of(_pre_line, "\t");
                                             if _pre_t1 < 0 { continue; }
                                             let _pre_name = substring(_pre_line, 0, _pre_t1);
-                                            if _pre_name != _pre_base { continue; }
+                                            if _pre_name != _pre_base {
+                                                continue;
+                                            }
                                             let _pre_rest = substring(_pre_line, _pre_t1 + 1, _pre_line.length);
                                             let _pre_t2 = index_of(_pre_rest, "\t");
                                             if _pre_t2 < 0 { continue; }
@@ -260,7 +236,9 @@ fn resolve_call_method_target(
                                             let _pre_lowered = lower_expression(_pre_base, bindings, locals, result_temp, result_lines, functions, context, "");
                                             let mut _ci1: number = 0;
                                             loop {
-                                                if _ci1 >= _pre_lowered.diagnostics.length { break; }
+                                                if _ci1 >= _pre_lowered.diagnostics.length {
+                                                    break;
+                                                }
                                                 result_diagnostics.push(_pre_lowered.diagnostics[_ci1]);
                                                 _ci1 += 1;
                                             }
@@ -285,35 +263,12 @@ fn resolve_call_method_target(
 
     // Delegate parse_member_access dispatch to a separate function to keep
     // each function under ~500 .sfn-asm instructions.
-    return resolve_parsed_method_dispatch(
-        result_target, arguments, bindings, locals, result_temp, result_lines,
-        functions, context, result_diagnostics, result_string_constants,
-        method_operand, helper_descriptor, injected_argument_count,
-        is_array_concat, array_concat_element_type, is_array_push, array_push_element_type
-    );
+    return resolve_parsed_method_dispatch(result_target, arguments, bindings, locals, result_temp, result_lines, functions, context, result_diagnostics, result_string_constants, method_operand, helper_descriptor, injected_argument_count, is_array_concat, array_concat_element_type, is_array_push, array_push_element_type);
 }
 
 // Resolves method calls via parse_member_access (struct methods, interface dispatch,
 // runtime helpers, array concat/push).
-fn resolve_parsed_method_dispatch(
-    result_target: string,
-    arguments: string[],
-    bindings: ParameterBinding[],
-    locals: LocalBinding[],
-    result_temp: number,
-    result_lines: string[],
-    functions: NativeFunction[],
-    context: TypeContext,
-    result_diagnostics: string[],
-    result_string_constants: StringConstant[],
-    method_operand: LLVMOperand?,
-    helper_descriptor: RuntimeHelperDescriptor?,
-    injected_argument_count: number,
-    is_array_concat: boolean,
-    array_concat_element_type: string,
-    is_array_push: boolean,
-    array_push_element_type: string
-) -> CallTargetResolution ![io] {
+fn resolve_parsed_method_dispatch(result_target: string, arguments: string[], bindings: ParameterBinding[], locals: LocalBinding[], result_temp: number, result_lines: string[], functions: NativeFunction[], context: TypeContext, result_diagnostics: string[], result_string_constants: StringConstant[], method_operand: LLVMOperand?, helper_descriptor: RuntimeHelperDescriptor?, injected_argument_count: number, is_array_concat: boolean, array_concat_element_type: string, is_array_push: boolean, array_push_element_type: string) -> CallTargetResolution ![io] {
     let mut r_target = result_target;
     let mut r_lines = result_lines;
     let mut r_temp: number = result_temp;
@@ -347,11 +302,18 @@ fn resolve_parsed_method_dispatch(
                 if lowered_self.operand == null {
                     r_diagnostics.push("llvm lowering: method call base `" + method_parse.base + "` produced no value");
                     return CallTargetResolution {
-                        trimmed_target: r_target, method_operand: null, helper_descriptor: null,
-                        injected_argument_count: 0, is_array_concat: false, array_concat_element_type: "",
-                        is_array_push: false, array_push_element_type: "",
-                        current_lines: r_lines, current_temp: r_temp,
-                        diagnostics: r_diagnostics, string_constants: r_string_constants,
+                        trimmed_target: r_target,
+                        method_operand: null,
+                        helper_descriptor: null,
+                        injected_argument_count: 0,
+                        is_array_concat: false,
+                        array_concat_element_type: "",
+                        is_array_push: false,
+                        array_push_element_type: "",
+                        current_lines: r_lines,
+                        current_temp: r_temp,
+                        diagnostics: r_diagnostics,
+                        string_constants: r_string_constants,
                     };
                 }
 
@@ -402,9 +364,7 @@ fn resolve_parsed_method_dispatch(
                     let bound_param = find_parameter_binding(bindings, base_name);
                     let mut _if59: boolean = false;
                     if bound_local == null {
-                        if bound_param == null {
-                            _if59 = true;
-                        }
+                        if bound_param == null { _if59 = true; }
                     }
                     if _if59 {
                         r_target = method_info.name + method_parse.field;
@@ -413,7 +373,9 @@ fn resolve_parsed_method_dispatch(
                         let lowered_self = lower_expression(method_parse.base, bindings, locals, r_temp, r_lines, functions, context, "");
                         let mut _ci3: number = 0;
                         loop {
-                            if _ci3 >= lowered_self.diagnostics.length { break; }
+                            if _ci3 >= lowered_self.diagnostics.length {
+                                break;
+                            }
                             r_diagnostics.push(lowered_self.diagnostics[_ci3]);
                             _ci3 += 1;
                         }
@@ -427,11 +389,18 @@ fn resolve_parsed_method_dispatch(
                         } else {
                             r_diagnostics.push("llvm lowering: method call base `" + method_parse.base + "` produced no value");
                             return CallTargetResolution {
-                                trimmed_target: r_target, method_operand: null, helper_descriptor: null,
-                                injected_argument_count: 0, is_array_concat: false, array_concat_element_type: "",
-                                is_array_push: false, array_push_element_type: "",
-                                current_lines: r_lines, current_temp: r_temp,
-                                diagnostics: r_diagnostics, string_constants: r_string_constants,
+                                trimmed_target: r_target,
+                                method_operand: null,
+                                helper_descriptor: null,
+                                injected_argument_count: 0,
+                                is_array_concat: false,
+                                array_concat_element_type: "",
+                                is_array_push: false,
+                                array_push_element_type: "",
+                                current_lines: r_lines,
+                                current_temp: r_temp,
+                                diagnostics: r_diagnostics,
+                                string_constants: r_string_constants,
                             };
                         }
                     }
@@ -453,11 +422,18 @@ fn resolve_parsed_method_dispatch(
                     } else {
                         r_diagnostics.push("llvm lowering: method call base `" + method_parse.base + "` produced no value");
                         return CallTargetResolution {
-                            trimmed_target: r_target, method_operand: null, helper_descriptor: null,
-                            injected_argument_count: 0, is_array_concat: false, array_concat_element_type: "",
-                            is_array_push: false, array_push_element_type: "",
-                            current_lines: r_lines, current_temp: r_temp,
-                            diagnostics: r_diagnostics, string_constants: r_string_constants,
+                            trimmed_target: r_target,
+                            method_operand: null,
+                            helper_descriptor: null,
+                            injected_argument_count: 0,
+                            is_array_concat: false,
+                            array_concat_element_type: "",
+                            is_array_push: false,
+                            array_push_element_type: "",
+                            current_lines: r_lines,
+                            current_temp: r_temp,
+                            diagnostics: r_diagnostics,
+                            string_constants: r_string_constants,
                         };
                     }
                 }
@@ -479,11 +455,18 @@ fn resolve_parsed_method_dispatch(
                 } else {
                     r_diagnostics.push("llvm lowering: method call base `" + method_parse.base + "` produced no value");
                     return CallTargetResolution {
-                        trimmed_target: r_target, method_operand: null, helper_descriptor: null,
-                        injected_argument_count: 0, is_array_concat: false, array_concat_element_type: "",
-                        is_array_push: false, array_push_element_type: "",
-                        current_lines: r_lines, current_temp: r_temp,
-                        diagnostics: r_diagnostics, string_constants: r_string_constants,
+                        trimmed_target: r_target,
+                        method_operand: null,
+                        helper_descriptor: null,
+                        injected_argument_count: 0,
+                        is_array_concat: false,
+                        array_concat_element_type: "",
+                        is_array_push: false,
+                        array_push_element_type: "",
+                        current_lines: r_lines,
+                        current_temp: r_temp,
+                        diagnostics: r_diagnostics,
+                        string_constants: r_string_constants,
                     };
                 }
             } else {
@@ -524,11 +507,18 @@ fn resolve_parsed_method_dispatch(
                     } else {
                         r_diagnostics.push("llvm lowering: method call base `" + method_parse.base + "` produced no value");
                         return CallTargetResolution {
-                            trimmed_target: r_target, method_operand: null, helper_descriptor: null,
-                            injected_argument_count: 0, is_array_concat: false, array_concat_element_type: "",
-                            is_array_push: false, array_push_element_type: "",
-                            current_lines: r_lines, current_temp: r_temp,
-                            diagnostics: r_diagnostics, string_constants: r_string_constants,
+                            trimmed_target: r_target,
+                            method_operand: null,
+                            helper_descriptor: null,
+                            injected_argument_count: 0,
+                            is_array_concat: false,
+                            array_concat_element_type: "",
+                            is_array_push: false,
+                            array_push_element_type: "",
+                            current_lines: r_lines,
+                            current_temp: r_temp,
+                            diagnostics: r_diagnostics,
+                            string_constants: r_string_constants,
                         };
                     }
                 } else {
@@ -540,7 +530,9 @@ fn resolve_parsed_method_dispatch(
                         let lowered_self = lower_expression(method_parse.base, bindings, locals, r_temp, r_lines, functions, context, "");
                         let mut _ci6: number = 0;
                         loop {
-                            if _ci6 >= lowered_self.diagnostics.length { break; }
+                            if _ci6 >= lowered_self.diagnostics.length {
+                                break;
+                            }
                             r_diagnostics.push(lowered_self.diagnostics[_ci6]);
                             _ci6 += 1;
                         }
@@ -550,11 +542,18 @@ fn resolve_parsed_method_dispatch(
                         if lowered_self.operand == null {
                             r_diagnostics.push("llvm lowering: method call base `" + method_parse.base + "` produced no value");
                             return CallTargetResolution {
-                                trimmed_target: r_target, method_operand: null, helper_descriptor: null,
-                                injected_argument_count: 0, is_array_concat: false, array_concat_element_type: "",
-                                is_array_push: false, array_push_element_type: "",
-                                current_lines: r_lines, current_temp: r_temp,
-                                diagnostics: r_diagnostics, string_constants: r_string_constants,
+                                trimmed_target: r_target,
+                                method_operand: null,
+                                helper_descriptor: null,
+                                injected_argument_count: 0,
+                                is_array_concat: false,
+                                array_concat_element_type: "",
+                                is_array_push: false,
+                                array_push_element_type: "",
+                                current_lines: r_lines,
+                                current_temp: r_temp,
+                                diagnostics: r_diagnostics,
+                                string_constants: r_string_constants,
                             };
                         }
 
@@ -569,9 +568,7 @@ fn resolve_parsed_method_dispatch(
                         let array_element_type = array_pointer_element_type(base_operand.llvm_type);
                         let mut _if60: boolean = false;
                         if array_element_type.length > 0 {
-                            if method_parse.field == "concat" {
-                                _if60 = true;
-                            }
+                            if method_parse.field == "concat" { _if60 = true; }
                         }
                         if _if60 {
                             r_method_operand = base_operand;
@@ -614,7 +611,7 @@ fn resolve_parsed_method_dispatch(
                         }
                     }
                 }
-            } // close struct fallback else
+            }  // close struct fallback else
         }
     }
 
@@ -644,9 +641,7 @@ fn _parse_int_res(text: string) -> number {
         let ch = char_at(text, i);
         let code = char_code(ch);
         if code >= 48 {
-            if code <= 57 {
-                result = result * 10 + (code - 48);
-            }
+            if code <= 57 { result = result * 10 + (code - 48); }
         }
         i = i + 1;
     }
@@ -654,9 +649,7 @@ fn _parse_int_res(text: string) -> number {
 }
 
 fn _find_function_from_files_res(target: string) -> NativeFunction? ![io] {
-    if !fs.exists("build/sailfin/.ctx_func_count") {
-        return null;
-    }
+    if !fs.exists("build/sailfin/.ctx_func_count") { return null; }
     let count_str = fs.readFile("build/sailfin/.ctx_func_count");
     let count = _parse_int_res(count_str);
     let mut suffix_match: NativeFunction? = null;
@@ -682,15 +675,18 @@ fn _find_function_from_files_res(target: string) -> NativeFunction? ![io] {
                 let pname = fs.readFile(pp + "_name");
                 let ptype = fs.readFile(pp + "_type");
                 params.push(NativeParameter {
-                            name: pname, type_annotation: ptype,
-                            mutable: false, default_value: null, span: null,
+                    name: pname, type_annotation: ptype, mutable: false, default_value: null, span: null,
                 });
                 j += 1;
             }
             return NativeFunction {
-                name: fname, return_type: ret_type,
-                is_async: is_async, parameters: params,
-                effects: [], decorators: [], is_extern: false,
+                name: fname,
+                return_type: ret_type,
+                is_async: is_async,
+                parameters: params,
+                effects: [],
+                decorators: [],
+                is_extern: false,
                 instructions: [],
             };
         }
@@ -710,36 +706,33 @@ fn _find_function_from_files_res(target: string) -> NativeFunction? ![io] {
                     let pname = fs.readFile(pp + "_name");
                     let ptype = fs.readFile(pp + "_type");
                     params.push(NativeParameter {
-                                name: pname, type_annotation: ptype,
-                                mutable: false, default_value: null, span: null,
+                        name: pname, type_annotation: ptype, mutable: false, default_value: null, span: null,
                     });
                     j += 1;
                 }
                 suffix_match = NativeFunction {
-                    name: fname, return_type: ret_type,
-                    is_async: is_async, parameters: params,
-                    effects: [], decorators: [], is_extern: false,
+                    name: fname,
+                    return_type: ret_type,
+                    is_async: is_async,
+                    parameters: params,
+                    effects: [],
+                    decorators: [],
+                    is_extern: false,
                     instructions: [],
                 };
             }
         }
         idx += 1;
     }
-    if suffix_match_count == 1 {
-        return suffix_match;
-    }
+    if suffix_match_count == 1 { return suffix_match; }
     return null;
 }
 
 fn _find_function_by_name_or_import(functions: NativeFunction[], target: string) -> NativeFunction? ![io] {
     let file_result = _find_function_from_files_res(target);
-    if file_result != null {
-        return file_result;
-    }
+    if file_result != null { return file_result; }
     let exact = find_function_by_name(functions, target);
-    if exact != null {
-        return exact;
-    }
+    if exact != null { return exact; }
     let suffix_prefix = target + "__";
     let mut match_result: NativeFunction? = null;
     let mut idx: number = 0;
@@ -747,9 +740,7 @@ fn _find_function_by_name_or_import(functions: NativeFunction[], target: string)
         if idx >= functions.length { break; }
         let candidate = functions[idx];
         if starts_with(candidate.name, suffix_prefix) {
-            if match_result != null {
-                return null;
-            }
+            if match_result != null { return null; }
             match_result = candidate;
         }
         idx += 1;
@@ -759,15 +750,7 @@ fn _find_function_by_name_or_import(functions: NativeFunction[], target: string)
 
 // Resolve the function signature for a call target: return type, expected parameter
 // types, whether it's a trait dispatch, and the resolved function entry.
-fn resolve_call_signature(
-    trimmed_target: string,
-    helper_descriptor: RuntimeHelperDescriptor?,
-    method_operand: LLVMOperand?,
-    is_array_concat: boolean,
-    array_concat_element_type: string,
-    functions: NativeFunction[],
-    context: TypeContext
-) -> CallSignatureResolution ![io] {
+fn resolve_call_signature(trimmed_target: string, helper_descriptor: RuntimeHelperDescriptor?, method_operand: LLVMOperand?, is_array_concat: boolean, array_concat_element_type: string, functions: NativeFunction[], context: TypeContext) -> CallSignatureResolution ![io] {
     let mut result_target = trimmed_target;
     let mut function_entry: NativeFunction? = null;
     let mut llvm_return: string = "i8*";
@@ -804,9 +787,7 @@ fn resolve_call_signature(
                         let sig = interface_info2.signatures[sig_idx];
                         if sig.name == method_name {
                             llvm_return = map_return_type(context, sig.return_type);
-                            if llvm_return.length == 0 {
-                                llvm_return = "i8*";
-                            }
+                            if llvm_return.length == 0 { llvm_return = "i8*"; }
                             expected_params = ["i8*"];
                             break;
                         }
@@ -905,9 +886,7 @@ fn resolve_call_signature(
                 if future_return.length == 0 {
                     result_diagnostics.push("llvm lowering: async function `" + result_target + "` has unsupported return type `" + _file_fn_return_type + "`");
                     llvm_return = "i8*";
-                } else {
-                    llvm_return = future_return;
-                }
+                } else { llvm_return = future_return; }
                 // Store the underlying return type so await can unbox structs
                 fs.writeFile("build/sailfin/.async_inner_return_type", _file_fn_return_type);
                 expected_params = _file_fn_param_types;
@@ -926,9 +905,7 @@ fn resolve_call_signature(
                 if future_return.length == 0 {
                     result_diagnostics.push("llvm lowering: async function `" + result_target + "` has unsupported return type `" + function_entry.return_type + "`");
                     llvm_return = "i8*";
-                } else {
-                    llvm_return = future_return;
-                }
+                } else { llvm_return = future_return; }
                 // Store the underlying return type so await can unbox structs
                 fs.writeFile("build/sailfin/.async_inner_return_type", function_entry.return_type);
                 expected_params = collect_parameter_types(context, function_entry.parameters, result_target);
@@ -971,4 +948,8 @@ fn resolve_call_signature(
     };
 }
 
-export { resolve_call_method_target, resolve_parsed_method_dispatch, resolve_call_signature };
+export {
+    resolve_call_method_target,
+    resolve_parsed_method_dispatch,
+    resolve_call_signature
+};

--- a/compiler/src/llvm/expression_lowering/native/core_call_resolution.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_call_resolution.sfn
@@ -17,9 +17,9 @@ import { empty_string_constant_set, merge_string_constants } from "../../strings
 import {
     find_interface_info_by_name,
     resolve_interface_info_for_method_target,
-    resolve_struct_info_for_method_target,
+    resolve_struct_info_for_method_target
 } from "../../type_context_queries";
-import { ends_with_pointer_suffix, } from "../../type_mapping";
+import { ends_with_pointer_suffix } from "../../type_mapping";
 import {
     CallSignatureResolution,
     CallTargetResolution,
@@ -31,26 +31,26 @@ import {
     RuntimeHelperDescriptor,
     StringConstant,
     StructTypeInfo,
-    TypeContext,
+    TypeContext
 } from "../../types";
 import {
     ends_with,
     number_to_string,
     starts_with,
-    trim_text,
+    trim_text
 } from "../../utils";
-import { array_pointer_element_type, } from "../arrays";
+import { array_pointer_element_type } from "../arrays";
 // Mutually recursive with core.sfn
 import { lower_expression } from "./core";
-import { collect_parameter_types, } from "./core_helpers";
-import { load_local_operand, } from "./core_operands";
-import { parse_member_access, } from "./core_parse";
-import { find_local_binding, find_parameter_binding, } from "./core_scopes";
+import { collect_parameter_types } from "./core_helpers";
+import { load_local_operand } from "./core_operands";
+import { parse_member_access } from "./core_parse";
+import { find_local_binding, find_parameter_binding } from "./core_scopes";
 import { sanitize_symbol } from "./core_text";
 import {
     future_pointer_type_for_return_type,
     map_parameter_type,
-    map_return_type,
+    map_return_type
 } from "./core_type_mapping";
 
 // Resolve fused concat/push targets (e.g. `valuesconcat(xs)` → `concat`).
@@ -123,7 +123,7 @@ fn resolve_call_method_target(trimmed_target: string, arguments: string[], bindi
                                     symbol: "",
                                     return_type: receiver_operand.llvm_type,
                                     parameter_types: [receiver_operand.llvm_type, receiver_operand.llvm_type],
-                                    effects: [],
+                                    effects: []
                                 };
                             }
                         }
@@ -214,8 +214,10 @@ fn resolve_call_method_target(trimmed_target: string, arguments: string[], bindi
                                                 _pre_line = substring(_pre_raw, _pre_pos, _pre_raw.length);
                                                 _pre_pos = _pre_raw.length;
                                             } else {
-                                                _pre_line = substring(_pre_raw, _pre_pos, _pre_pos + _pre_nl);
-                                                _pre_pos = _pre_pos + _pre_nl + 1;
+                                                _pre_line = substring(_pre_raw, _pre_pos, _pre_pos
+                                                    + _pre_nl);
+                                                _pre_pos = _pre_pos + _pre_nl
+                                                    + 1;
                                             }
                                             if _pre_line.length == 0 {
                                                 continue;
@@ -226,7 +228,8 @@ fn resolve_call_method_target(trimmed_target: string, arguments: string[], bindi
                                             if _pre_name != _pre_base {
                                                 continue;
                                             }
-                                            let _pre_rest = substring(_pre_line, _pre_t1 + 1, _pre_line.length);
+                                            let _pre_rest = substring(_pre_line, _pre_t1
+                                                + 1, _pre_line.length);
                                             let _pre_t2 = index_of(_pre_rest, "\t");
                                             if _pre_t2 < 0 { continue; }
                                             _pre_struct = substring(_pre_rest, 0, _pre_t2);
@@ -247,7 +250,8 @@ fn resolve_call_method_target(trimmed_target: string, arguments: string[], bindi
                                             result_temp = _pre_lowered.temp_index;
                                             if _pre_lowered.operand != null {
                                                 method_operand = _pre_lowered.operand;
-                                                result_target = _pre_struct + _pre_field;
+                                                result_target = _pre_struct
+                                                    + _pre_field;
                                                 injected_argument_count = 1;
                                             }
                                         }
@@ -300,7 +304,9 @@ fn resolve_parsed_method_dispatch(result_target: string, arguments: string[], bi
                 r_lines = lowered_self.lines;
                 r_temp = lowered_self.temp_index;
                 if lowered_self.operand == null {
-                    r_diagnostics.push("llvm lowering: method call base `" + method_parse.base + "` produced no value");
+                    r_diagnostics.push("llvm lowering: method call base `"
+                        + method_parse.base
+                        + "` produced no value");
                     return CallTargetResolution {
                         trimmed_target: r_target,
                         method_operand: null,
@@ -313,7 +319,7 @@ fn resolve_parsed_method_dispatch(result_target: string, arguments: string[], bi
                         current_lines: r_lines,
                         current_temp: r_temp,
                         diagnostics: r_diagnostics,
-                        string_constants: r_string_constants,
+                        string_constants: r_string_constants
                     };
                 }
 
@@ -333,7 +339,7 @@ fn resolve_parsed_method_dispatch(result_target: string, arguments: string[], bi
                                 symbol: "",
                                 return_type: base_operand.llvm_type,
                                 parameter_types: [base_operand.llvm_type, base_operand.llvm_type],
-                                effects: [],
+                                effects: []
                             };
                         }
                     } else {
@@ -347,7 +353,7 @@ fn resolve_parsed_method_dispatch(result_target: string, arguments: string[], bi
                             symbol: "",
                             return_type: base_operand.llvm_type,
                             parameter_types: [base_operand.llvm_type, array_element_type],
-                            effects: [],
+                            effects: []
                         };
                     }
                 }
@@ -387,7 +393,9 @@ fn resolve_parsed_method_dispatch(result_target: string, arguments: string[], bi
                             r_target = method_info.name + method_parse.field;
                             r_injected_count = 1;
                         } else {
-                            r_diagnostics.push("llvm lowering: method call base `" + method_parse.base + "` produced no value");
+                            r_diagnostics.push("llvm lowering: method call base `"
+                                + method_parse.base
+                                + "` produced no value");
                             return CallTargetResolution {
                                 trimmed_target: r_target,
                                 method_operand: null,
@@ -400,7 +408,7 @@ fn resolve_parsed_method_dispatch(result_target: string, arguments: string[], bi
                                 current_lines: r_lines,
                                 current_temp: r_temp,
                                 diagnostics: r_diagnostics,
-                                string_constants: r_string_constants,
+                                string_constants: r_string_constants
                             };
                         }
                     }
@@ -420,7 +428,9 @@ fn resolve_parsed_method_dispatch(result_target: string, arguments: string[], bi
                         r_target = method_info.name + method_parse.field;
                         r_injected_count = 1;
                     } else {
-                        r_diagnostics.push("llvm lowering: method call base `" + method_parse.base + "` produced no value");
+                        r_diagnostics.push("llvm lowering: method call base `"
+                            + method_parse.base
+                            + "` produced no value");
                         return CallTargetResolution {
                             trimmed_target: r_target,
                             method_operand: null,
@@ -433,7 +443,7 @@ fn resolve_parsed_method_dispatch(result_target: string, arguments: string[], bi
                             current_lines: r_lines,
                             current_temp: r_temp,
                             diagnostics: r_diagnostics,
-                            string_constants: r_string_constants,
+                            string_constants: r_string_constants
                         };
                     }
                 }
@@ -450,10 +460,13 @@ fn resolve_parsed_method_dispatch(result_target: string, arguments: string[], bi
                 r_temp = lowered_self.temp_index;
                 if lowered_self.operand != null {
                     r_method_operand = lowered_self.operand;
-                    r_target = "trait_dispatch__" + interface_info.name + "__" + method_parse.field;
+                    r_target = "trait_dispatch__" + interface_info.name + "__"
+                        + method_parse.field;
                     r_injected_count = 1;
                 } else {
-                    r_diagnostics.push("llvm lowering: method call base `" + method_parse.base + "` produced no value");
+                    r_diagnostics.push("llvm lowering: method call base `"
+                        + method_parse.base
+                        + "` produced no value");
                     return CallTargetResolution {
                         trimmed_target: r_target,
                         method_operand: null,
@@ -466,7 +479,7 @@ fn resolve_parsed_method_dispatch(result_target: string, arguments: string[], bi
                         current_lines: r_lines,
                         current_temp: r_temp,
                         diagnostics: r_diagnostics,
-                        string_constants: r_string_constants,
+                        string_constants: r_string_constants
                     };
                 }
             } else {
@@ -505,7 +518,9 @@ fn resolve_parsed_method_dispatch(result_target: string, arguments: string[], bi
                         r_target = _struct_fallback_info.name + method_parse.field;
                         r_injected_count = 1;
                     } else {
-                        r_diagnostics.push("llvm lowering: method call base `" + method_parse.base + "` produced no value");
+                        r_diagnostics.push("llvm lowering: method call base `"
+                            + method_parse.base
+                            + "` produced no value");
                         return CallTargetResolution {
                             trimmed_target: r_target,
                             method_operand: null,
@@ -518,7 +533,7 @@ fn resolve_parsed_method_dispatch(result_target: string, arguments: string[], bi
                             current_lines: r_lines,
                             current_temp: r_temp,
                             diagnostics: r_diagnostics,
-                            string_constants: r_string_constants,
+                            string_constants: r_string_constants
                         };
                     }
                 } else {
@@ -540,7 +555,9 @@ fn resolve_parsed_method_dispatch(result_target: string, arguments: string[], bi
                         r_lines = lowered_self.lines;
                         r_temp = lowered_self.temp_index;
                         if lowered_self.operand == null {
-                            r_diagnostics.push("llvm lowering: method call base `" + method_parse.base + "` produced no value");
+                            r_diagnostics.push("llvm lowering: method call base `"
+                                + method_parse.base
+                                + "` produced no value");
                             return CallTargetResolution {
                                 trimmed_target: r_target,
                                 method_operand: null,
@@ -553,7 +570,7 @@ fn resolve_parsed_method_dispatch(result_target: string, arguments: string[], bi
                                 current_lines: r_lines,
                                 current_temp: r_temp,
                                 diagnostics: r_diagnostics,
-                                string_constants: r_string_constants,
+                                string_constants: r_string_constants
                             };
                         }
 
@@ -583,7 +600,7 @@ fn resolve_parsed_method_dispatch(result_target: string, arguments: string[], bi
                                     symbol: "",
                                     return_type: base_operand.llvm_type,
                                     parameter_types: [base_operand.llvm_type, base_operand.llvm_type],
-                                    effects: [],
+                                    effects: []
                                 };
                             }
                         } else {
@@ -605,7 +622,7 @@ fn resolve_parsed_method_dispatch(result_target: string, arguments: string[], bi
                                     symbol: "",
                                     return_type: base_operand.llvm_type,
                                     parameter_types: [base_operand.llvm_type, array_element_type],
-                                    effects: [],
+                                    effects: []
                                 };
                             }
                         }
@@ -627,7 +644,7 @@ fn resolve_parsed_method_dispatch(result_target: string, arguments: string[], bi
         current_lines: r_lines,
         current_temp: r_temp,
         diagnostics: r_diagnostics,
-        string_constants: r_string_constants,
+        string_constants: r_string_constants
     };
 }
 
@@ -675,7 +692,7 @@ fn _find_function_from_files_res(target: string) -> NativeFunction? ![io] {
                 let pname = fs.readFile(pp + "_name");
                 let ptype = fs.readFile(pp + "_type");
                 params.push(NativeParameter {
-                    name: pname, type_annotation: ptype, mutable: false, default_value: null, span: null,
+                    name: pname, type_annotation: ptype, mutable: false, default_value: null, span: null
                 });
                 j += 1;
             }
@@ -687,7 +704,7 @@ fn _find_function_from_files_res(target: string) -> NativeFunction? ![io] {
                 effects: [],
                 decorators: [],
                 is_extern: false,
-                instructions: [],
+                instructions: []
             };
         }
         if starts_with(fname, suffix_prefix) {
@@ -706,7 +723,7 @@ fn _find_function_from_files_res(target: string) -> NativeFunction? ![io] {
                     let pname = fs.readFile(pp + "_name");
                     let ptype = fs.readFile(pp + "_type");
                     params.push(NativeParameter {
-                        name: pname, type_annotation: ptype, mutable: false, default_value: null, span: null,
+                        name: pname, type_annotation: ptype, mutable: false, default_value: null, span: null
                     });
                     j += 1;
                 }
@@ -718,7 +735,7 @@ fn _find_function_from_files_res(target: string) -> NativeFunction? ![io] {
                     effects: [],
                     decorators: [],
                     is_extern: false,
-                    instructions: [],
+                    instructions: []
                 };
             }
         }
@@ -821,12 +838,14 @@ fn resolve_call_signature(trimmed_target: string, helper_descriptor: RuntimeHelp
                 let mut _fl_i: number = 0;
                 loop {
                     if _fl_i >= _fl_count { break; }
-                    let _fl_prefix = "build/sailfin/.ctx_func_" + number_to_string(_fl_i);
+                    let _fl_prefix = "build/sailfin/.ctx_func_"
+                        + number_to_string(_fl_i);
                     if !fs.exists(_fl_prefix + "_name") { break; }
                     let _fl_name = fs.readFile(_fl_prefix + "_name");
                     if _fl_name == result_target {
                         _file_fn_name = _fl_name;
-                        _file_fn_return_type = fs.readFile(_fl_prefix + "_return_type");
+                        _file_fn_return_type = fs.readFile(_fl_prefix
+                            + "_return_type");
                         let _fl_async_str = fs.readFile(_fl_prefix + "_is_async");
                         _file_fn_is_async = _fl_async_str == "1";
                         let _fl_pc_str = fs.readFile(_fl_prefix + "_param_count");
@@ -834,7 +853,9 @@ fn resolve_call_signature(trimmed_target: string, helper_descriptor: RuntimeHelp
                         let mut _fl_j: number = 0;
                         loop {
                             if _fl_j >= _fl_pc { break; }
-                            let _fl_ptype = fs.readFile(_fl_prefix + "_param_" + number_to_string(_fl_j) + "_type");
+                            let _fl_ptype = fs.readFile(_fl_prefix + "_param_"
+                                + number_to_string(_fl_j)
+                                + "_type");
                             let _fl_mapped = map_parameter_type(context, _fl_ptype);
                             _file_fn_param_types.push(_fl_mapped);
                             _fl_j += 1;
@@ -850,9 +871,11 @@ fn resolve_call_signature(trimmed_target: string, helper_descriptor: RuntimeHelp
                 }
                 if !_file_fn_found {
                     if _fl_suffix_count == 1 {
-                        let _fl_prefix = "build/sailfin/.ctx_func_" + number_to_string(_fl_suffix_idx);
+                        let _fl_prefix = "build/sailfin/.ctx_func_"
+                            + number_to_string(_fl_suffix_idx);
                         _file_fn_name = fs.readFile(_fl_prefix + "_name");
-                        _file_fn_return_type = fs.readFile(_fl_prefix + "_return_type");
+                        _file_fn_return_type = fs.readFile(_fl_prefix
+                            + "_return_type");
                         let _fl_async_str = fs.readFile(_fl_prefix + "_is_async");
                         _file_fn_is_async = _fl_async_str == "1";
                         let _fl_pc_str = fs.readFile(_fl_prefix + "_param_count");
@@ -860,7 +883,9 @@ fn resolve_call_signature(trimmed_target: string, helper_descriptor: RuntimeHelp
                         let mut _fl_j: number = 0;
                         loop {
                             if _fl_j >= _fl_pc { break; }
-                            let _fl_ptype = fs.readFile(_fl_prefix + "_param_" + number_to_string(_fl_j) + "_type");
+                            let _fl_ptype = fs.readFile(_fl_prefix + "_param_"
+                                + number_to_string(_fl_j)
+                                + "_type");
                             let _fl_mapped = map_parameter_type(context, _fl_ptype);
                             _file_fn_param_types.push(_fl_mapped);
                             _fl_j += 1;
@@ -884,7 +909,11 @@ fn resolve_call_signature(trimmed_target: string, helper_descriptor: RuntimeHelp
             if _file_fn_is_async {
                 let future_return = future_pointer_type_for_return_type(_file_fn_return_type);
                 if future_return.length == 0 {
-                    result_diagnostics.push("llvm lowering: async function `" + result_target + "` has unsupported return type `" + _file_fn_return_type + "`");
+                    result_diagnostics.push("llvm lowering: async function `"
+                        + result_target
+                        + "` has unsupported return type `"
+                        + _file_fn_return_type
+                        + "`");
                     llvm_return = "i8*";
                 } else { llvm_return = future_return; }
                 // Store the underlying return type so await can unbox structs
@@ -893,7 +922,9 @@ fn resolve_call_signature(trimmed_target: string, helper_descriptor: RuntimeHelp
             } else {
                 llvm_return = map_return_type(context, _file_fn_return_type);
                 if llvm_return.length == 0 {
-                    result_diagnostics.push("llvm lowering: unsupported return type in call to `" + result_target + "`");
+                    result_diagnostics.push("llvm lowering: unsupported return type in call to `"
+                        + result_target
+                        + "`");
                     llvm_return = "i8*";
                 }
                 expected_params = _file_fn_param_types;
@@ -903,7 +934,11 @@ fn resolve_call_signature(trimmed_target: string, helper_descriptor: RuntimeHelp
             if function_entry.is_async {
                 let future_return = future_pointer_type_for_return_type(function_entry.return_type);
                 if future_return.length == 0 {
-                    result_diagnostics.push("llvm lowering: async function `" + result_target + "` has unsupported return type `" + function_entry.return_type + "`");
+                    result_diagnostics.push("llvm lowering: async function `"
+                        + result_target
+                        + "` has unsupported return type `"
+                        + function_entry.return_type
+                        + "`");
                     llvm_return = "i8*";
                 } else { llvm_return = future_return; }
                 // Store the underlying return type so await can unbox structs
@@ -912,13 +947,17 @@ fn resolve_call_signature(trimmed_target: string, helper_descriptor: RuntimeHelp
             } else {
                 llvm_return = map_return_type(context, function_entry.return_type);
                 if llvm_return.length == 0 {
-                    result_diagnostics.push("llvm lowering: unsupported return type in call to `" + result_target + "`");
+                    result_diagnostics.push("llvm lowering: unsupported return type in call to `"
+                        + result_target
+                        + "`");
                     llvm_return = "i8*";
                 }
                 expected_params = collect_parameter_types(context, function_entry.parameters, result_target);
             }
         } else {
-            result_diagnostics.push("llvm lowering: call to unknown function `" + result_target + "`");
+            result_diagnostics.push("llvm lowering: call to unknown function `"
+                + result_target
+                + "`");
         }
     }
 
@@ -944,7 +983,7 @@ fn resolve_call_signature(trimmed_target: string, helper_descriptor: RuntimeHelp
         llvm_return: llvm_return,
         expected_params: expected_params,
         is_trait_dispatch: is_trait_dispatch,
-        diagnostics: result_diagnostics,
+        diagnostics: result_diagnostics
     };
 }
 

--- a/compiler/src/llvm/expression_lowering/native/core_calls.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_calls.sfn
@@ -1,13 +1,8 @@
 // compiler/src/llvm/expression_lowering/native/core_calls.sfn
 //
 // Call parsing helpers for expression lowering.
-
 import { char_at } from "../../../string_utils";
-
-import {
-    trim_text,
-    append_string,
-} from "../../utils";
+import { append_string, trim_text, } from "../../utils";
 
 fn find_call_site(expression: string) -> number {
     // Find the opening paren of the outermost (last) call in a chained
@@ -23,29 +18,19 @@ fn find_call_site(expression: string) -> number {
     let mut last_top_level_open: number = -1;
     let mut index: number = 0;
     loop {
-        if index >= expression.length {
-            break;
-        }
+        if index >= expression.length { break; }
         let ch = char_at(expression, index);
         if in_double {
-            if escape_next {
-                escape_next = false;
-            } else if ch == "\\" {
+            if escape_next { escape_next = false; } else if ch == "\\" {
                 escape_next = true;
-            } else if ch == "\"" {
-                in_double = false;
-            }
+            } else if ch == "\"" { in_double = false; }
             index += 1;
             continue;
         }
         if in_single {
-            if escape_next {
-                escape_next = false;
-            } else if ch == "\\" {
+            if escape_next { escape_next = false; } else if ch == "\\" {
                 escape_next = true;
-            } else if ch == "'" {
-                in_single = false;
-            }
+            } else if ch == "'" { in_single = false; }
             index += 1;
             continue;
         }
@@ -59,27 +44,19 @@ fn find_call_site(expression: string) -> number {
             index += 1;
             continue;
         }
-        if ch == "{" {
-            brace_depth += 1;
-        } else if ch == "}" {
+        if ch == "{" { brace_depth += 1; } else if ch == "}" {
             if brace_depth > 0 { brace_depth -= 1; }
-        } else if ch == "[" {
-            bracket_depth += 1;
-        } else if ch == "]" {
+        } else if ch == "[" { bracket_depth += 1; } else if ch == "]" {
             if bracket_depth > 0 { bracket_depth -= 1; }
         } else if ch == "(" {
             if paren_depth == 0 {
                 if brace_depth == 0 {
-                    if bracket_depth == 0 {
-                        last_top_level_open = index;
-                    }
+                    if bracket_depth == 0 { last_top_level_open = index; }
                 }
             }
             paren_depth += 1;
         } else if ch == ")" {
-            if paren_depth > 0 {
-                paren_depth -= 1;
-            }
+            if paren_depth > 0 { paren_depth -= 1; }
         }
         index += 1;
     }
@@ -88,9 +65,7 @@ fn find_call_site(expression: string) -> number {
 
 fn split_call_arguments(text: string) -> string[] {
     let trimmed = trim_text(text);
-    if trimmed.length == 0 {
-        return [];
-    }
+    if trimmed.length == 0 { return []; }
     let mut entries: string[] = [];
     let mut current: string = "";
     let mut paren_depth: number = 0;
@@ -101,17 +76,11 @@ fn split_call_arguments(text: string) -> string[] {
     let mut escape: boolean = false;
     let mut index: number = 0;
     loop {
-        if index >= text.length {
-            break;
-        }
+        if index >= text.length { break; }
         let ch = char_at(text, index);
         if in_double {
             current = current + ch;
-            if escape {
-                escape = false;
-            } else if ch == "\\" {
-                escape = true;
-            } else if ch == "\"" {
+            if escape { escape = false; } else if ch == "\\" { escape = true; } else if ch == "\"" {
                 in_double = false;
             }
             index += 1;
@@ -119,11 +88,7 @@ fn split_call_arguments(text: string) -> string[] {
         }
         if in_single {
             current = current + ch;
-            if escape {
-                escape = false;
-            } else if ch == "\\" {
-                escape = true;
-            } else if ch == "'" {
+            if escape { escape = false; } else if ch == "\\" { escape = true; } else if ch == "'" {
                 in_single = false;
             }
             index += 1;
@@ -145,43 +110,33 @@ fn split_call_arguments(text: string) -> string[] {
             paren_depth += 1;
             current = current + ch;
         } else if ch == ")" {
-            if paren_depth > 0 {
-                paren_depth -= 1;
-            }
+            if paren_depth > 0 { paren_depth -= 1; }
             current = current + ch;
         } else if ch == "[" {
             bracket_depth += 1;
             current = current + ch;
         } else if ch == "]" {
-            if bracket_depth > 0 {
-                bracket_depth -= 1;
-            }
+            if bracket_depth > 0 { bracket_depth -= 1; }
             current = current + ch;
         } else if ch == "{" {
             brace_depth += 1;
             current = current + ch;
         } else if ch == "}" {
-            if brace_depth > 0 {
-                brace_depth -= 1;
-            }
+            if brace_depth > 0 { brace_depth -= 1; }
             current = current + ch;
         } else {
             let mut _elif67: boolean = false;
             if ch == "," {
                 if paren_depth == 0 {
                     if bracket_depth == 0 {
-                        if brace_depth == 0 {
-                            _elif67 = true;
-                        }
+                        if brace_depth == 0 { _elif67 = true; }
                     }
                 }
             }
             if _elif67 {
                 entries.push(trim_text(current));
                 current = "";
-            } else {
-                current = current + ch;
-            }
+            } else { current = current + ch; }
         }
         index += 1;
     }

--- a/compiler/src/llvm/expression_lowering/native/core_calls.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_calls.sfn
@@ -2,7 +2,7 @@
 //
 // Call parsing helpers for expression lowering.
 import { char_at } from "../../../string_utils";
-import { append_string, trim_text, } from "../../utils";
+import { append_string, trim_text } from "../../utils";
 
 fn find_call_site(expression: string) -> number {
     // Find the opening paren of the outermost (last) call in a chained

--- a/compiler/src/llvm/expression_lowering/native/core_helpers.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_helpers.sfn
@@ -1,10 +1,9 @@
 // compiler/src/llvm/expression_lowering/native/core_helpers.sfn
 //
 // Small helper utilities extracted from core.sfn to reduce file size.
-
 import { NativeParameter } from "../../../native_ir";
+import { find_last_index_of_char, substring } from "../../../string_utils";
 import { TypeContext } from "../../types";
-import { substring, find_last_index_of_char } from "../../../string_utils";
 import { append_string } from "../../utils";
 import { map_parameter_type, map_struct_type_annotation_ctx } from "./core_type_mapping";
 
@@ -12,9 +11,7 @@ fn collect_parameter_types(context: TypeContext, parameters: NativeParameter[], 
     let mut types: string[] = [];
     let mut index: number = 0;
     loop {
-        if index >= parameters.length {
-            break;
-        }
+        if index >= parameters.length { break; }
         let parameter = parameters[index];
         let mut llvm_type = map_parameter_type(context, parameter.type_annotation);
 
@@ -28,9 +25,7 @@ fn collect_parameter_types(context: TypeContext, parameters: NativeParameter[], 
                 }
             }
         }
-        if llvm_type.length == 0 {
-            types.push("double");
-        } else {
+        if llvm_type.length == 0 { types.push("double"); } else {
             types.push(llvm_type);
         }
         index += 1;
@@ -40,37 +35,17 @@ fn collect_parameter_types(context: TypeContext, parameters: NativeParameter[], 
 
 fn operation_name_for_symbol(symbol: string, llvm_type: string) -> string {
     if llvm_type == "double" {
-        if symbol == "+" {
-            return "fadd";
-        }
-        if symbol == "-" {
-            return "fsub";
-        }
-        if symbol == "*" {
-            return "fmul";
-        }
-        if symbol == "/" {
-            return "fdiv";
-        }
-        if symbol == "%" {
-            return "frem";
-        }
+        if symbol == "+" { return "fadd"; }
+        if symbol == "-" { return "fsub"; }
+        if symbol == "*" { return "fmul"; }
+        if symbol == "/" { return "fdiv"; }
+        if symbol == "%" { return "frem"; }
     }
-    if symbol == "+" {
-        return "add";
-    }
-    if symbol == "-" {
-        return "sub";
-    }
-    if symbol == "*" {
-        return "mul";
-    }
-    if symbol == "/" {
-        return "sdiv";
-    }
-    if symbol == "%" {
-        return "srem";
-    }
+    if symbol == "+" { return "add"; }
+    if symbol == "-" { return "sub"; }
+    if symbol == "*" { return "mul"; }
+    if symbol == "/" { return "sdiv"; }
+    if symbol == "%" { return "srem"; }
     return "add";
 }
 

--- a/compiler/src/llvm/expression_lowering/native/core_index_lowering.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_index_lowering.sfn
@@ -13,13 +13,13 @@ import {
     LocalBinding,
     ParameterBinding,
     StringConstant,
-    TypeContext,
+    TypeContext
 } from "../../types";
 import {
     append_string,
     number_to_string,
     starts_with,
-    trim_text,
+    trim_text
 } from "../../utils";
 // Mutually recursive with core.sfn
 import { lower_expression } from "./core";
@@ -150,7 +150,9 @@ fn lower_index_expression(parse: IndexExpressionParse, bindings: ParameterBindin
     }
 
     if element_type.length == 0 {
-        diagnostics.push("llvm lowering: unable to determine element type for array indexing on type `" + array_type + "`");
+        diagnostics.push("llvm lowering: unable to determine element type for array indexing on type `"
+            + array_type
+            + "`");
         return ExpressionResult {
             lines: current_lines,
             temp_index: current_temp,
@@ -182,7 +184,12 @@ fn lower_index_expression(parse: IndexExpressionParse, bindings: ParameterBindin
         }
 
         let call_temp = format_temp_name(current_temp);
-        current_lines = append_string(current_lines, "  " + call_temp + " = call i8* @sailfin_runtime_grapheme_at(i8* " + base_operand.value + ", double " + index_as_double.operand.value + ")");
+        current_lines = append_string(current_lines, "  " + call_temp
+            + " = call i8* @sailfin_runtime_grapheme_at(i8* "
+            + base_operand.value
+            + ", double "
+            + index_as_double.operand.value
+            + ")");
         current_temp += 1;
         let operand = LLVMOperand { llvm_type: "i8*", value: call_temp };
         return ExpressionResult {
@@ -200,31 +207,62 @@ fn lower_index_expression(parse: IndexExpressionParse, bindings: ParameterBindin
 
         let array_struct_type = strip_pointer_suffix(array_type);
         let loaded_array = format_temp_name(current_temp);
-        current_lines.push("  " + loaded_array + " = load " + array_struct_type + ", " + array_type + " " + base_operand.value);
+        current_lines.push("  " + loaded_array + " = load " + array_struct_type
+            + ", "
+            + array_type
+            + " "
+            + base_operand.value);
         current_temp += 1;
 
         let data_ptr_extracted = format_temp_name(current_temp);
-        current_lines.push("  " + data_ptr_extracted + " = extractvalue " + array_struct_type + " " + loaded_array + ", 0");
+        current_lines.push("  " + data_ptr_extracted + " = extractvalue "
+            + array_struct_type
+            + " "
+            + loaded_array
+            + ", 0");
         current_temp += 1;
         data_ptr = data_ptr_extracted;
 
         let length_temp = format_temp_name(current_temp);
-        current_lines.push("  " + length_temp + " = extractvalue " + array_struct_type + " " + loaded_array + ", 1");
+        current_lines.push("  " + length_temp + " = extractvalue "
+            + array_struct_type
+            + " "
+            + loaded_array
+            + ", 1");
         current_temp += 1;
         length_value = length_temp;
 
         let bounds_check = format_temp_name(current_temp);
-        current_lines.push("  " + bounds_check + " = icmp uge i64 " + coerced_index.value + ", " + length_value);
+        current_lines.push("  " + bounds_check + " = icmp uge i64 "
+            + coerced_index.value
+            + ", "
+            + length_value);
         current_temp += 1;
-        current_lines.push("  ; bounds check: " + bounds_check + " (if true, out of bounds)");
-        current_lines.push("  call void @sailfin_runtime_bounds_check(i64 " + coerced_index.value + ", i64 " + length_value + ")");
+        current_lines.push("  ; bounds check: " + bounds_check
+            + " (if true, out of bounds)");
+        current_lines.push("  call void @sailfin_runtime_bounds_check(i64 "
+            + coerced_index.value
+            + ", i64 "
+            + length_value
+            + ")");
 
         let element_ptr = format_temp_name(current_temp);
-        current_lines.push("  " + element_ptr + " = getelementptr " + element_type + ", " + element_type + "* " + data_ptr + ", i64 " + coerced_index.value);
+        current_lines.push("  " + element_ptr + " = getelementptr "
+            + element_type
+            + ", "
+            + element_type
+            + "* "
+            + data_ptr
+            + ", i64 "
+            + coerced_index.value);
         current_temp += 1;
 
         let element_value = format_temp_name(current_temp);
-        current_lines.push("  " + element_value + " = load " + element_type + ", " + element_type + "* " + element_ptr);
+        current_lines.push("  " + element_value + " = load " + element_type
+            + ", "
+            + element_type
+            + "* "
+            + element_ptr);
         current_temp += 1;
 
         let operand = LLVMOperand {
@@ -240,7 +278,9 @@ fn lower_index_expression(parse: IndexExpressionParse, bindings: ParameterBindin
         };
     }
 
-    diagnostics.push("llvm lowering: unsupported array type for indexing: `" + array_type + "`");
+    diagnostics.push("llvm lowering: unsupported array type for indexing: `"
+        + array_type
+        + "`");
     return ExpressionResult {
         lines: current_lines,
         temp_index: current_temp,

--- a/compiler/src/llvm/expression_lowering/native/core_index_lowering.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_index_lowering.sfn
@@ -1,38 +1,29 @@
 // compiler/src/llvm/expression_lowering/native/core_index_lowering.sfn
 //
 // Indexing expression lowering extracted from core.sfn.
-
 import { NativeFunction } from "../../../native_ir";
-
+import { substring } from "../../../string_utils";
+import { format_temp_name } from "../../expressions_helpers";
+import { merge_string_constants } from "../../strings";
+import { ends_with_pointer_suffix, strip_pointer_suffix } from "../../type_mapping";
 import {
-    TypeContext,
-    ParameterBinding,
-    LocalBinding,
-    IndexExpressionParse,
     ExpressionResult,
+    IndexExpressionParse,
     LLVMOperand,
+    LocalBinding,
+    ParameterBinding,
     StringConstant,
+    TypeContext,
 } from "../../types";
-
 import {
-    trim_text,
     append_string,
     number_to_string,
     starts_with,
+    trim_text,
 } from "../../utils";
-
-import { substring } from "../../../string_utils";
-
-import { merge_string_constants } from "../../strings";
-
-import { format_temp_name } from "../../expressions_helpers";
-
-import { ends_with_pointer_suffix, strip_pointer_suffix } from "../../type_mapping";
-
-import { coerce_operand_to_type } from "./core_operands";
-
 // Mutually recursive with core.sfn
 import { lower_expression } from "./core";
+import { coerce_operand_to_type } from "./core_operands";
 
 fn lower_index_expression(parse: IndexExpressionParse, bindings: ParameterBinding[], locals: LocalBinding[], temp_index: number, lines: string[], functions: NativeFunction[], context: TypeContext) -> ExpressionResult {
     let base_result = lower_expression(parse.base, bindings, locals, temp_index, lines, functions, context, "");
@@ -40,7 +31,13 @@ fn lower_index_expression(parse: IndexExpressionParse, bindings: ParameterBindin
     let mut collected_string_constants: StringConstant[] = base_result.string_constants;
 
     if base_result.operand == null {
-        return ExpressionResult { lines: base_result.lines, temp_index: base_result.temp_index, operand: null, diagnostics: diagnostics, string_constants: collected_string_constants };
+        return ExpressionResult {
+            lines: base_result.lines,
+            temp_index: base_result.temp_index,
+            operand: null,
+            diagnostics: diagnostics,
+            string_constants: collected_string_constants
+        };
     }
 
     let mut current_lines: string[] = base_result.lines;
@@ -60,7 +57,13 @@ fn lower_index_expression(parse: IndexExpressionParse, bindings: ParameterBindin
 
     if index_result.operand == null {
         diagnostics.push("llvm lowering: index expression produced no value");
-        return ExpressionResult { lines: current_lines, temp_index: current_temp, operand: null, diagnostics: diagnostics, string_constants: collected_string_constants };
+        return ExpressionResult {
+            lines: current_lines,
+            temp_index: current_temp,
+            operand: null,
+            diagnostics: diagnostics,
+            string_constants: collected_string_constants
+        };
     }
 
     let index_operand = index_result.operand;
@@ -76,7 +79,13 @@ fn lower_index_expression(parse: IndexExpressionParse, bindings: ParameterBindin
     current_temp = index_coercion.temp_index;
     if index_coercion.operand == null {
         diagnostics.push("llvm lowering: unable to coerce index expression to i64");
-        return ExpressionResult { lines: current_lines, temp_index: current_temp, operand: null, diagnostics: diagnostics, string_constants: collected_string_constants };
+        return ExpressionResult {
+            lines: current_lines,
+            temp_index: current_temp,
+            operand: null,
+            diagnostics: diagnostics,
+            string_constants: collected_string_constants
+        };
     }
     let coerced_index = index_coercion.operand;
 
@@ -95,7 +104,7 @@ fn lower_index_expression(parse: IndexExpressionParse, bindings: ParameterBindin
             if inner_type.length > 0 {
                 if substring(inner_type, inner_type.length - 1, inner_type.length) == "}" {
                     let struct_inner = trim_text(substring(inner_type, 1, inner_type.length - 1));
-        
+
                     let mut comma_pos: number = -1;
                     let mut brace_depth: number = 0;
                     let mut bracket_depth: number = 0;
@@ -103,34 +112,16 @@ fn lower_index_expression(parse: IndexExpressionParse, bindings: ParameterBindin
                     let mut angle_depth: number = 0;
                     let mut i: number = 0;
                     loop {
-                        if i >= struct_inner.length {
-                            break;
-                        }
+                        if i >= struct_inner.length { break; }
                         let ch = substring(struct_inner, i, i + 1);
-                        if ch == "{" {
-                            brace_depth += 1;
-                        } else if ch == "}" {
-                            if brace_depth > 0 {
-                                brace_depth -= 1;
-                            }
-                        } else if ch == "[" {
-                            bracket_depth += 1;
-                        } else if ch == "]" {
-                            if bracket_depth > 0 {
-                                bracket_depth -= 1;
-                            }
-                        } else if ch == "(" {
-                            paren_depth += 1;
-                        } else if ch == ")" {
-                            if paren_depth > 0 {
-                                paren_depth -= 1;
-                            }
-                        } else if ch == "<" {
-                            angle_depth += 1;
-                        } else if ch == ">" {
-                            if angle_depth > 0 {
-                                angle_depth -= 1;
-                            }
+                        if ch == "{" { brace_depth += 1; } else if ch == "}" {
+                            if brace_depth > 0 { brace_depth -= 1; }
+                        } else if ch == "[" { bracket_depth += 1; } else if ch == "]" {
+                            if bracket_depth > 0 { bracket_depth -= 1; }
+                        } else if ch == "(" { paren_depth += 1; } else if ch == ")" {
+                            if paren_depth > 0 { paren_depth -= 1; }
+                        } else if ch == "<" { angle_depth += 1; } else if ch == ">" {
+                            if angle_depth > 0 { angle_depth -= 1; }
                         } else if ch == "," {
                             if brace_depth == 0 {
                                 if bracket_depth == 0 {
@@ -145,7 +136,7 @@ fn lower_index_expression(parse: IndexExpressionParse, bindings: ParameterBindin
                         }
                         i += 1;
                     }
-        
+
                     if comma_pos >= 0 {
                         let first_field = trim_text(substring(struct_inner, 0, comma_pos));
                         if ends_with_pointer_suffix(first_field) {
@@ -160,7 +151,13 @@ fn lower_index_expression(parse: IndexExpressionParse, bindings: ParameterBindin
 
     if element_type.length == 0 {
         diagnostics.push("llvm lowering: unable to determine element type for array indexing on type `" + array_type + "`");
-        return ExpressionResult { lines: current_lines, temp_index: current_temp, operand: null, diagnostics: diagnostics, string_constants: collected_string_constants };
+        return ExpressionResult {
+            lines: current_lines,
+            temp_index: current_temp,
+            operand: null,
+            diagnostics: diagnostics,
+            string_constants: collected_string_constants
+        };
     }
 
     if is_string {
@@ -175,17 +172,26 @@ fn lower_index_expression(parse: IndexExpressionParse, bindings: ParameterBindin
         current_temp = index_as_double.temp_index;
         if index_as_double.operand == null {
             diagnostics.push("llvm lowering: unable to coerce string index expression to double");
-            return ExpressionResult { lines: current_lines, temp_index: current_temp, operand: null, diagnostics: diagnostics, string_constants: collected_string_constants };
+            return ExpressionResult {
+                lines: current_lines,
+                temp_index: current_temp,
+                operand: null,
+                diagnostics: diagnostics,
+                string_constants: collected_string_constants
+            };
         }
 
         let call_temp = format_temp_name(current_temp);
-        current_lines = append_string(
-            current_lines,
-            "  " + call_temp + " = call i8* @sailfin_runtime_grapheme_at(i8* " + base_operand.value + ", double " + index_as_double.operand.value + ")"
-        );
+        current_lines = append_string(current_lines, "  " + call_temp + " = call i8* @sailfin_runtime_grapheme_at(i8* " + base_operand.value + ", double " + index_as_double.operand.value + ")");
         current_temp += 1;
         let operand = LLVMOperand { llvm_type: "i8*", value: call_temp };
-        return ExpressionResult { lines: current_lines, temp_index: current_temp, operand: operand, diagnostics: diagnostics, string_constants: collected_string_constants };
+        return ExpressionResult {
+            lines: current_lines,
+            temp_index: current_temp,
+            operand: operand,
+            diagnostics: diagnostics,
+            string_constants: collected_string_constants
+        };
     }
 
     if is_heap_array {
@@ -221,12 +227,27 @@ fn lower_index_expression(parse: IndexExpressionParse, bindings: ParameterBindin
         current_lines.push("  " + element_value + " = load " + element_type + ", " + element_type + "* " + element_ptr);
         current_temp += 1;
 
-        let operand = LLVMOperand { llvm_type: element_type, value: element_value };
-        return ExpressionResult { lines: current_lines, temp_index: current_temp, operand: operand, diagnostics: diagnostics, string_constants: collected_string_constants };
+        let operand = LLVMOperand {
+            llvm_type: element_type,
+            value: element_value
+        };
+        return ExpressionResult {
+            lines: current_lines,
+            temp_index: current_temp,
+            operand: operand,
+            diagnostics: diagnostics,
+            string_constants: collected_string_constants
+        };
     }
 
     diagnostics.push("llvm lowering: unsupported array type for indexing: `" + array_type + "`");
-    return ExpressionResult { lines: current_lines, temp_index: current_temp, operand: null, diagnostics: diagnostics, string_constants: collected_string_constants };
+    return ExpressionResult {
+        lines: current_lines,
+        temp_index: current_temp,
+        operand: null,
+        diagnostics: diagnostics,
+        string_constants: collected_string_constants
+    };
 }
 
 export { lower_index_expression };

--- a/compiler/src/llvm/expression_lowering/native/core_literals_lowering.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_literals_lowering.sfn
@@ -9,14 +9,14 @@ import {
     lookup_allocation_info,
     resolve_enum_info_for_literal,
     resolve_enum_variant_info,
-    resolve_struct_info_for_literal,
+    resolve_struct_info_for_literal
 } from "../../type_context_queries";
 import {
     array_struct_type_for_element,
     ends_with_pointer_suffix,
     layout_annotation_represents_user_value,
     map_type_annotation,
-    strip_pointer_suffix,
+    strip_pointer_suffix
 } from "../../type_mapping";
 import {
     CastParseResult,
@@ -32,7 +32,7 @@ import {
     StructLiteralField,
     StructLiteralParse,
     StructTypeInfo,
-    TypeContext,
+    TypeContext
 } from "../../types";
 import {
     append_string,
@@ -41,24 +41,20 @@ import {
     number_to_string,
     starts_with,
     string_array_contains,
-    trim_text,
+    trim_text
 } from "../../utils";
 import { array_pointer_element_type } from "../arrays";
-import { split_array_elements, } from "../splitting";
+import { split_array_elements } from "../splitting";
 // Mutually recursive with core.sfn
 import { lower_expression } from "./core";
-import { coerce_operand_to_type, dominant_type, } from "./core_operands";
-import { parse_array_literal_metadata, } from "./core_parsing";
-import {
-    coerce_operand_to_string,
-    emit_string_concat,
-    lower_string_literal,
-} from "./core_strings";
+import { coerce_operand_to_type, dominant_type } from "./core_operands";
+import { parse_array_literal_metadata } from "./core_parsing";
+import { coerce_operand_to_string, emit_string_concat, lower_string_literal } from "./core_strings";
 import {
     encode_string_literal_for_sailfin,
     find_substring_from,
     parse_interpolated_template,
-    unescape_string_literal,
+    unescape_string_literal
 } from "./core_text";
 
 fn lower_array_literal(text: string, bindings: ParameterBinding[], locals: LocalBinding[], temp_index: number, lines: string[], functions: NativeFunction[], context: TypeContext, expected_type: string) -> ExpressionResult {
@@ -317,7 +313,9 @@ fn lower_array_literal(text: string, bindings: ParameterBinding[], locals: Local
                     current_lines = boxed.lines;
                     current_temp = boxed.temp_index;
                     if boxed.operand == null {
-                        diagnostics.push("llvm lowering: array literal element could not be boxed to `" + element_type + "`");
+                        diagnostics.push("llvm lowering: array literal element could not be boxed to `"
+                            + element_type
+                            + "`");
                         return ExpressionResult {
                             lines: current_lines,
                             temp_index: current_temp,
@@ -335,7 +333,9 @@ fn lower_array_literal(text: string, bindings: ParameterBinding[], locals: Local
         current_lines = coerced.lines;
         current_temp = coerced.temp_index;
         if coerced.operand == null {
-            diagnostics.push("llvm lowering: array literal element could not be coerced to `" + element_type + "`");
+            diagnostics.push("llvm lowering: array literal element could not be coerced to `"
+                + element_type
+                + "`");
             return ExpressionResult {
                 lines: current_lines,
                 temp_index: current_temp,
@@ -354,43 +354,78 @@ fn lower_array_literal(text: string, bindings: ParameterBinding[], locals: Local
     let array_type = "[" + length_text + " x " + element_type + "]";
 
     let array_size_ptr = format_temp_name(current_temp);
-    current_lines.push("  " + array_size_ptr + " = getelementptr " + array_type + ", " + array_type + "* null, i32 1");
+    current_lines.push("  " + array_size_ptr + " = getelementptr " + array_type
+        + ", "
+        + array_type
+        + "* null, i32 1");
     current_temp += 1;
 
     let array_bytes = format_temp_name(current_temp);
-    current_lines.push("  " + array_bytes + " = ptrtoint " + array_type + "* " + array_size_ptr + " to i64");
+    current_lines.push("  " + array_bytes + " = ptrtoint " + array_type + "* "
+        + array_size_ptr
+        + " to i64");
     current_temp += 1;
 
     let array_bytes_is_zero = format_temp_name(current_temp);
-    current_lines.push("  " + array_bytes_is_zero + " = icmp eq i64 " + array_bytes + ", 0");
+    current_lines.push("  " + array_bytes_is_zero + " = icmp eq i64 "
+        + array_bytes
+        + ", 0");
     current_temp += 1;
 
     let element_size_ptr = format_temp_name(current_temp);
     current_temp += 1;
-    current_lines.push("  " + element_size_ptr + " = getelementptr [1 x " + element_type + "], [1 x " + element_type + "]* null, i32 0, i32 1");
+    current_lines.push("  " + element_size_ptr + " = getelementptr [1 x "
+        + element_type
+        + "], [1 x "
+        + element_type
+        + "]* null, i32 0, i32 1");
     let element_size_value = format_temp_name(current_temp);
     current_temp += 1;
-    current_lines.push("  " + element_size_value + " = ptrtoint " + element_type + "* " + element_size_ptr + " to i64");
+    current_lines.push("  " + element_size_value + " = ptrtoint " + element_type
+        + "* "
+        + element_size_ptr
+        + " to i64");
 
     let adjusted_array_bytes = format_temp_name(current_temp);
-    current_lines.push("  " + adjusted_array_bytes + " = select i1 " + array_bytes_is_zero + ", i64 " + element_size_value + ", i64 " + array_bytes);
+    current_lines.push("  " + adjusted_array_bytes + " = select i1 "
+        + array_bytes_is_zero
+        + ", i64 "
+        + element_size_value
+        + ", i64 "
+        + array_bytes);
     current_temp += 1;
 
     let raw_array_ptr = format_temp_name(current_temp);
-    current_lines.push("  " + raw_array_ptr + " = call i8* @calloc(i64 1, i64 " + adjusted_array_bytes + ")");
+    current_lines.push("  " + raw_array_ptr + " = call i8* @calloc(i64 1, i64 "
+        + adjusted_array_bytes
+        + ")");
     current_temp += 1;
 
     let data_pointer = format_temp_name(current_temp);
-    current_lines.push("  " + data_pointer + " = bitcast i8* " + raw_array_ptr + " to " + element_type + "*");
+    current_lines.push("  " + data_pointer + " = bitcast i8* " + raw_array_ptr
+        + " to "
+        + element_type
+        + "*");
     current_temp += 1;
 
     index = 0;
     loop {
         if index >= operands.length { break; }
         let element_pointer = format_temp_name(current_temp);
-        current_lines.push("  " + element_pointer + " = getelementptr " + element_type + ", " + element_type + "* " + data_pointer + ", i64 " + number_to_string(index));
+        current_lines.push("  " + element_pointer + " = getelementptr "
+            + element_type
+            + ", "
+            + element_type
+            + "* "
+            + data_pointer
+            + ", i64 "
+            + number_to_string(index));
         current_temp += 1;
-        current_lines.push("  store " + element_type + " " + operands[index].value + ", " + element_type + "* " + element_pointer);
+        current_lines.push("  store " + element_type + " " + operands[index].value
+            + ", "
+            + element_type
+            + "* "
+            + element_pointer);
         index += 1;
     }
 
@@ -401,32 +436,61 @@ fn lower_array_literal(text: string, bindings: ParameterBinding[], locals: Local
         }
     }
     let struct_size_ptr = format_temp_name(current_temp);
-    current_lines.push("  " + struct_size_ptr + " = getelementptr " + struct_type + ", " + struct_type + "* null, i32 1");
+    current_lines.push("  " + struct_size_ptr + " = getelementptr "
+        + struct_type
+        + ", "
+        + struct_type
+        + "* null, i32 1");
     current_temp += 1;
 
     let struct_bytes = format_temp_name(current_temp);
-    current_lines.push("  " + struct_bytes + " = ptrtoint " + struct_type + "* " + struct_size_ptr + " to i64");
+    current_lines.push("  " + struct_bytes + " = ptrtoint " + struct_type + "* "
+        + struct_size_ptr
+        + " to i64");
     current_temp += 1;
 
     let raw_struct_ptr = format_temp_name(current_temp);
-    current_lines.push("  " + raw_struct_ptr + " = call i8* @calloc(i64 1, i64 " + struct_bytes + ")");
+    current_lines.push("  " + raw_struct_ptr + " = call i8* @calloc(i64 1, i64 "
+        + struct_bytes
+        + ")");
     current_temp += 1;
 
     let struct_pointer = format_temp_name(current_temp);
-    current_lines.push("  " + struct_pointer + " = bitcast i8* " + raw_struct_ptr + " to " + struct_type + "*");
+    current_lines.push("  " + struct_pointer + " = bitcast i8* "
+        + raw_struct_ptr
+        + " to "
+        + struct_type
+        + "*");
     current_temp += 1;
 
     let data_field_pointer = format_temp_name(current_temp);
-    current_lines.push("  " + data_field_pointer + " = getelementptr " + struct_type + ", " + struct_type + "* " + struct_pointer + ", i32 0, i32 0");
+    current_lines.push("  " + data_field_pointer + " = getelementptr "
+        + struct_type
+        + ", "
+        + struct_type
+        + "* "
+        + struct_pointer
+        + ", i32 0, i32 0");
     current_temp += 1;
     let data_pointer_type = element_type + "*";
     let data_pointer_pointer_type = data_pointer_type + "*";
-    current_lines.push("  store " + data_pointer_type + " " + data_pointer + ", " + data_pointer_pointer_type + " " + data_field_pointer);
+    current_lines.push("  store " + data_pointer_type + " " + data_pointer
+        + ", "
+        + data_pointer_pointer_type
+        + " "
+        + data_field_pointer);
 
     let length_field_pointer = format_temp_name(current_temp);
-    current_lines.push("  " + length_field_pointer + " = getelementptr " + struct_type + ", " + struct_type + "* " + struct_pointer + ", i32 0, i32 1");
+    current_lines.push("  " + length_field_pointer + " = getelementptr "
+        + struct_type
+        + ", "
+        + struct_type
+        + "* "
+        + struct_pointer
+        + ", i32 0, i32 1");
     current_temp += 1;
-    current_lines.push("  store i64 " + length_text + ", i64* " + length_field_pointer);
+    current_lines.push("  store i64 " + length_text + ", i64* "
+        + length_field_pointer);
 
     let operand = LLVMOperand {
         llvm_type: struct_type + "*",
@@ -467,7 +531,8 @@ fn lower_struct_literal(parse: StructLiteralParse, bindings: ParameterBinding[],
                             _si_line = substring(_si_raw, _si_pos, _si_raw.length);
                             _si_pos = _si_raw.length;
                         } else {
-                            _si_line = substring(_si_raw, _si_pos, _si_pos + _si_nl);
+                            _si_line = substring(_si_raw, _si_pos, _si_pos
+                                + _si_nl);
                             _si_pos = _si_pos + _si_nl + 1;
                         }
                         if _si_line.length == 0 { continue; }
@@ -494,7 +559,8 @@ fn lower_struct_literal(parse: StructLiteralParse, bindings: ParameterBinding[],
                                     _f_entry = substring(_si_fields_str, _fp, _si_fields_str.length);
                                     _fp = _si_fields_str.length;
                                 } else {
-                                    _f_entry = substring(_si_fields_str, _fp, _fp + _fc);
+                                    _f_entry = substring(_si_fields_str, _fp, _fp
+                                        + _fc);
                                     _fp = _fp + _fc + 1;
                                 }
                                 if _f_entry.length == 0 {
@@ -509,7 +575,7 @@ fn lower_struct_literal(parse: StructLiteralParse, bindings: ParameterBinding[],
                                 let _f_name = substring(_f_entry, 0, _colon);
                                 let _f_type = substring(_f_entry, _colon + 1, _f_entry.length);
                                 _si_fields.push(StructFieldInfo {
-                                    name: _f_name, llvm_type: _f_type, type_annotation: "", index: _fi, offset: 0,
+                                    name: _f_name, llvm_type: _f_type, type_annotation: "", index: _fi, offset: 0
                                 });
                                 _fi += 1;
                             }
@@ -519,7 +585,7 @@ fn lower_struct_literal(parse: StructLiteralParse, bindings: ParameterBinding[],
                             llvm_name: _si_llvm,
                             fields: _si_fields,
                             size: 0,
-                            align: 0,
+                            align: 0
                         };
                         break;
                     }
@@ -529,7 +595,9 @@ fn lower_struct_literal(parse: StructLiteralParse, bindings: ParameterBinding[],
     }
     if info == null {
         if parse.type_name.length > 0 {
-            diagnostics.push("llvm lowering: struct literal references unknown struct `" + parse.type_name + "`");
+            diagnostics.push("llvm lowering: struct literal references unknown struct `"
+                + parse.type_name
+                + "`");
         } else {
             diagnostics.push("llvm lowering: struct literal references unknown struct");
         }
@@ -611,7 +679,10 @@ fn lower_struct_literal(parse: StructLiteralParse, bindings: ParameterBinding[],
                 used_names.push(expected.name);
             }
         } else {
-            diagnostics.push("llvm lowering: struct literal for `" + info.name + "` missing field `" + expected.name + "`");
+            diagnostics.push("llvm lowering: struct literal for `" + info.name
+                + "` missing field `"
+                + expected.name
+                + "`");
         }
 
         let mut value_text: string = default_return_literal(expected.llvm_type);
@@ -621,7 +692,15 @@ fn lower_struct_literal(parse: StructLiteralParse, bindings: ParameterBinding[],
         if field_index > 0 { aggregate_source = previous_value; }
 
         let temp_name = format_temp_name(current_temp);
-        current_lines.push("  " + temp_name + " = insertvalue " + info.llvm_name + " " + aggregate_source + ", " + expected.llvm_type + " " + value_text + ", " + number_to_string(field_index));
+        current_lines.push("  " + temp_name + " = insertvalue " + info.llvm_name
+            + " "
+            + aggregate_source
+            + ", "
+            + expected.llvm_type
+            + " "
+            + value_text
+            + ", "
+            + number_to_string(field_index));
         current_temp += 1;
         previous_value = temp_name;
 
@@ -633,7 +712,10 @@ fn lower_struct_literal(parse: StructLiteralParse, bindings: ParameterBinding[],
         if extra_index >= parse.fields.length { break; }
         let literal_field = parse.fields[extra_index];
         if !string_array_contains(used_names, literal_field.name) {
-            diagnostics.push("llvm lowering: struct literal for `" + info.name + "` provides unknown field `" + literal_field.name + "`");
+            diagnostics.push("llvm lowering: struct literal for `" + info.name
+                + "` provides unknown field `"
+                + literal_field.name
+                + "`");
         }
         extra_index += 1;
     }
@@ -676,7 +758,11 @@ fn box_aggregate_operand(operand: LLVMOperand, expected_pointer_type: string, te
 
     let allocation = lookup_allocation_info(context, operand.llvm_type);
     if allocation == null {
-        diagnostics.push("llvm lowering: unable to allocate heap storage for `" + operand.llvm_type + "` when assigning to `" + expected_pointer_type + "`");
+        diagnostics.push("llvm lowering: unable to allocate heap storage for `"
+            + operand.llvm_type
+            + "` when assigning to `"
+            + expected_pointer_type
+            + "`");
         return HeapBoxResult {
             lines: current_lines,
             temp_index: current_temp,
@@ -685,7 +771,9 @@ fn box_aggregate_operand(operand: LLVMOperand, expected_pointer_type: string, te
         };
     }
     if allocation.size <= 0 {
-        diagnostics.push("llvm lowering: computed heap allocation size for `" + operand.llvm_type + "` is zero");
+        diagnostics.push("llvm lowering: computed heap allocation size for `"
+            + operand.llvm_type
+            + "` is zero");
         return HeapBoxResult {
             lines: current_lines,
             temp_index: current_temp,
@@ -696,13 +784,23 @@ fn box_aggregate_operand(operand: LLVMOperand, expected_pointer_type: string, te
 
     let malloc_temp = format_temp_name(current_temp);
     current_temp += 1;
-    current_lines.push("  " + malloc_temp + " = call noalias i8* @calloc(i64 1, i64 " + number_to_string(allocation.size) + ")");
+    current_lines.push("  " + malloc_temp
+        + " = call noalias i8* @calloc(i64 1, i64 "
+        + number_to_string(allocation.size)
+        + ")");
 
     let typed_ptr_temp = format_temp_name(current_temp);
     current_temp += 1;
-    current_lines.push("  " + typed_ptr_temp + " = bitcast i8* " + malloc_temp + " to " + operand.llvm_type + "*");
+    current_lines.push("  " + typed_ptr_temp + " = bitcast i8* " + malloc_temp
+        + " to "
+        + operand.llvm_type
+        + "*");
 
-    current_lines.push("  store " + operand.llvm_type + " " + operand.value + ", " + operand.llvm_type + "* " + typed_ptr_temp);
+    current_lines.push("  store " + operand.llvm_type + " " + operand.value
+        + ", "
+        + operand.llvm_type
+        + "* "
+        + typed_ptr_temp);
 
     let mut pointer_operand = LLVMOperand {
         llvm_type: "i8*",
@@ -713,7 +811,10 @@ fn box_aggregate_operand(operand: LLVMOperand, expected_pointer_type: string, te
         if trimmed_expected != "i8*" {
             let cast_temp = format_temp_name(current_temp);
             current_temp += 1;
-            current_lines.push("  " + cast_temp + " = bitcast i8* " + malloc_temp + " to " + trimmed_expected);
+            current_lines.push("  " + cast_temp + " = bitcast i8* "
+                + malloc_temp
+                + " to "
+                + trimmed_expected);
             pointer_operand = LLVMOperand {
                 llvm_type: trimmed_expected,
                 value: cast_temp
@@ -738,7 +839,9 @@ fn lower_enum_literal(parse: EnumLiteralParse, bindings: ParameterBinding[], loc
     let enum_info = resolve_enum_info_for_literal(context, parse.enum_name);
     if enum_info == null {
         if parse.enum_name.length > 0 {
-            diagnostics.push("llvm lowering: enum literal references unknown enum `" + parse.enum_name + "`");
+            diagnostics.push("llvm lowering: enum literal references unknown enum `"
+                + parse.enum_name
+                + "`");
         } else {
             diagnostics.push("llvm lowering: enum literal references unknown enum");
         }
@@ -753,7 +856,10 @@ fn lower_enum_literal(parse: EnumLiteralParse, bindings: ParameterBinding[], loc
 
     let variant_info = resolve_enum_variant_info(enum_info, parse.variant_name);
     if variant_info == null {
-        diagnostics.push("llvm lowering: enum `" + parse.enum_name + "` has no variant `" + parse.variant_name + "`");
+        diagnostics.push("llvm lowering: enum `" + parse.enum_name
+            + "` has no variant `"
+            + parse.variant_name
+            + "`");
         return ExpressionResult {
             lines: current_lines,
             temp_index: current_temp,
@@ -780,11 +886,28 @@ fn lower_enum_literal(parse: EnumLiteralParse, bindings: ParameterBinding[], loc
 
         let tag_ptr_temp = format_temp_name(current_temp);
         current_temp += 1;
-        current_lines.push("  " + tag_ptr_temp + " = getelementptr inbounds " + enum_info.llvm_name + ", " + enum_info.llvm_name + "* " + alloca_temp + ", i32 0, i32 0");
-        current_lines.push("  store " + tag_llvm_type + " " + number_to_string(variant_info.tag) + ", " + tag_llvm_type + "* " + tag_ptr_temp);
+        current_lines.push("  " + tag_ptr_temp + " = getelementptr inbounds "
+            + enum_info.llvm_name
+            + ", "
+            + enum_info.llvm_name
+            + "* "
+            + alloca_temp
+            + ", i32 0, i32 0");
+        current_lines.push("  store " + tag_llvm_type + " " + number_to_string(variant_info.tag)
+            + ", "
+            + tag_llvm_type
+            + "* "
+            + tag_ptr_temp);
     } else {
         let tag_temp = format_temp_name(current_temp);
-        current_lines.push("  " + tag_temp + " = insertvalue " + enum_info.llvm_name + " " + enum_value + ", " + tag_llvm_type + " " + number_to_string(variant_info.tag) + ", 0");
+        current_lines.push("  " + tag_temp + " = insertvalue " + enum_info.llvm_name
+            + " "
+            + enum_value
+            + ", "
+            + tag_llvm_type
+            + " "
+            + number_to_string(variant_info.tag)
+            + ", 0");
         current_temp += 1;
         enum_value = tag_temp;
     }
@@ -859,11 +982,22 @@ fn lower_enum_literal(parse: EnumLiteralParse, bindings: ParameterBinding[], loc
                                     payload_field_index = 2;
                                 }
                             }
-                            current_lines.push("  " + payload_ptr_temp + " = getelementptr inbounds " + enum_info.llvm_name + ", " + enum_info.llvm_name + "* " + alloca_ptr + ", i32 0, i32 " + number_to_string(payload_field_index));
+                            current_lines.push("  " + payload_ptr_temp
+                                + " = getelementptr inbounds "
+                                + enum_info.llvm_name
+                                + ", "
+                                + enum_info.llvm_name
+                                + "* "
+                                + alloca_ptr
+                                + ", i32 0, i32 "
+                                + number_to_string(payload_field_index));
 
                             let byte_array_ptr_temp = format_temp_name(current_temp);
                             current_temp += 1;
-                            current_lines.push("  " + byte_array_ptr_temp + " = bitcast ptr " + payload_ptr_temp + " to ptr");
+                            current_lines.push("  " + byte_array_ptr_temp
+                                + " = bitcast ptr "
+                                + payload_ptr_temp
+                                + " to ptr");
 
                             let field_absolute_offset = variant_info.fields[field_index].offset;
                             let field_offset_in_payload = field_absolute_offset - variant_info.offset;
@@ -871,15 +1005,26 @@ fn lower_enum_literal(parse: EnumLiteralParse, bindings: ParameterBinding[], loc
                             if field_offset_in_payload > 0 {
                                 let offset_ptr_temp = format_temp_name(current_temp);
                                 current_temp += 1;
-                                current_lines.push("  " + offset_ptr_temp + " = getelementptr inbounds i8, ptr " + byte_array_ptr_temp + ", i64 " + number_to_string(field_offset_in_payload));
+                                current_lines.push("  " + offset_ptr_temp
+                                    + " = getelementptr inbounds i8, ptr "
+                                    + byte_array_ptr_temp
+                                    + ", i64 "
+                                    + number_to_string(field_offset_in_payload));
                                 field_byte_ptr_temp = offset_ptr_temp;
                             }
 
                             let field_ptr_temp = format_temp_name(current_temp);
                             current_temp += 1;
-                            current_lines.push("  " + field_ptr_temp + " = bitcast ptr " + field_byte_ptr_temp + " to ptr");
+                            current_lines.push("  " + field_ptr_temp
+                                + " = bitcast ptr "
+                                + field_byte_ptr_temp
+                                + " to ptr");
 
-                            current_lines.push("  store " + expected.llvm_type + " " + coerced.operand.value + ", ptr " + field_ptr_temp);
+                            current_lines.push("  store " + expected.llvm_type
+                                + " "
+                                + coerced.operand.value
+                                + ", ptr "
+                                + field_ptr_temp);
                         }
                     }
                 }
@@ -887,7 +1032,12 @@ fn lower_enum_literal(parse: EnumLiteralParse, bindings: ParameterBinding[], loc
                     used_names.push(expected.name);
                 }
             } else {
-                diagnostics.push("llvm lowering: enum literal for `" + parse.enum_name + "." + parse.variant_name + "` missing field `" + expected.name + "`");
+                diagnostics.push("llvm lowering: enum literal for `" + parse.enum_name
+                    + "."
+                    + parse.variant_name
+                    + "` missing field `"
+                    + expected.name
+                    + "`");
             }
 
             field_index += 1;
@@ -898,7 +1048,12 @@ fn lower_enum_literal(parse: EnumLiteralParse, bindings: ParameterBinding[], loc
             if extra_index >= parse.fields.length { break; }
             let literal_field = parse.fields[extra_index];
             if !string_array_contains(used_names, literal_field.name) {
-                diagnostics.push("llvm lowering: enum literal for `" + parse.enum_name + "." + parse.variant_name + "` provides unknown field `" + literal_field.name + "`");
+                diagnostics.push("llvm lowering: enum literal for `" + parse.enum_name
+                    + "."
+                    + parse.variant_name
+                    + "` provides unknown field `"
+                    + literal_field.name
+                    + "`");
             }
             extra_index += 1;
         }
@@ -906,7 +1061,11 @@ fn lower_enum_literal(parse: EnumLiteralParse, bindings: ParameterBinding[], loc
         if alloca_ptr != null {
             let load_temp = format_temp_name(current_temp);
             current_temp += 1;
-            current_lines.push("  " + load_temp + " = load " + enum_info.llvm_name + ", " + enum_info.llvm_name + "* " + alloca_ptr);
+            current_lines.push("  " + load_temp + " = load " + enum_info.llvm_name
+                + ", "
+                + enum_info.llvm_name
+                + "* "
+                + alloca_ptr);
             enum_value = load_temp;
         }
     }
@@ -938,7 +1097,8 @@ fn lower_cast_expression(parse: CastParseResult, bindings: ParameterBinding[], l
     }
     let target_type = map_type_annotation(parse.type_annotation);
     if target_type.length == 0 {
-        diagnostics.push("llvm lowering: unsupported cast target type `" + parse.type_annotation + "`");
+        diagnostics.push("llvm lowering: unsupported cast target type `" + parse.type_annotation
+            + "`");
         return ExpressionResult {
             lines: lines,
             temp_index: temp_index,
@@ -981,7 +1141,11 @@ fn lower_cast_expression(parse: CastParseResult, bindings: ParameterBinding[], l
 
     if ends_with_pointer_suffix(operand.llvm_type) {
         if ends_with_pointer_suffix(target_type) {
-            current_lines.push("  " + cast_name + " = bitcast " + operand.llvm_type + " " + operand.value + " to " + target_type);
+            current_lines.push("  " + cast_name + " = bitcast " + operand.llvm_type
+                + " "
+                + operand.value
+                + " to "
+                + target_type);
             let casted = LLVMOperand {
                 llvm_type: target_type,
                 value: cast_name
@@ -999,7 +1163,11 @@ fn lower_cast_expression(parse: CastParseResult, bindings: ParameterBinding[], l
     if !ends_with_pointer_suffix(operand.llvm_type) {
         if ends_with_pointer_suffix(target_type) {
             if starts_with(operand.llvm_type, "i") {
-                current_lines.push("  " + cast_name + " = inttoptr " + operand.llvm_type + " " + operand.value + " to " + target_type);
+                current_lines.push("  " + cast_name + " = inttoptr " + operand.llvm_type
+                    + " "
+                    + operand.value
+                    + " to "
+                    + target_type);
                 let casted = LLVMOperand {
                     llvm_type: target_type,
                     value: cast_name
@@ -1018,7 +1186,11 @@ fn lower_cast_expression(parse: CastParseResult, bindings: ParameterBinding[], l
     if ends_with_pointer_suffix(operand.llvm_type) {
         if !ends_with_pointer_suffix(target_type) {
             if starts_with(target_type, "i") {
-                current_lines.push("  " + cast_name + " = ptrtoint " + operand.llvm_type + " " + operand.value + " to " + target_type);
+                current_lines.push("  " + cast_name + " = ptrtoint " + operand.llvm_type
+                    + " "
+                    + operand.value
+                    + " to "
+                    + target_type);
                 let casted = LLVMOperand {
                     llvm_type: target_type,
                     value: cast_name
@@ -1034,7 +1206,10 @@ fn lower_cast_expression(parse: CastParseResult, bindings: ParameterBinding[], l
         }
     }
 
-    diagnostics.push("llvm lowering: unsupported cast from `" + operand.llvm_type + "` to `" + target_type + "`");
+    diagnostics.push("llvm lowering: unsupported cast from `" + operand.llvm_type
+        + "` to `"
+        + target_type
+        + "`");
     return ExpressionResult {
         lines: current_lines,
         temp_index: current_temp,
@@ -1091,7 +1266,9 @@ fn try_lower_interpolated_string_literal(literal: string, bindings: ParameterBin
         collected_string_constants = merge_string_constants(collected_string_constants, lowered_expr.string_constants);
 
         if lowered_expr.operand == null {
-            diagnostics.push("llvm lowering: unable to lower interpolated expression `" + expr_text + "`");
+            diagnostics.push("llvm lowering: unable to lower interpolated expression `"
+                + expr_text
+                + "`");
             return ExpressionResult {
                 lines: current_lines,
                 temp_index: current_temp,
@@ -1111,7 +1288,9 @@ fn try_lower_interpolated_string_literal(literal: string, bindings: ParameterBin
         current_temp = coerced.temp_index;
         collected_string_constants = merge_string_constants(collected_string_constants, coerced.string_constants);
         if coerced.operand == null {
-            diagnostics.push("llvm lowering: unable to stringify interpolated expression `" + expr_text + "`");
+            diagnostics.push("llvm lowering: unable to stringify interpolated expression `"
+                + expr_text
+                + "`");
             return ExpressionResult {
                 lines: current_lines,
                 temp_index: current_temp,
@@ -1140,7 +1319,8 @@ fn try_lower_interpolated_string_literal(literal: string, bindings: ParameterBin
         }
         current_operand = concat1.operand;
 
-        let part_literal = encode_string_literal_for_sailfin(parsed.parts[index + 1]);
+        let part_literal = encode_string_literal_for_sailfin(parsed.parts[index
+            + 1]);
         let part_value = lower_string_literal(part_literal, current_temp, current_lines);
         current_lines = part_value.lines;
         current_temp = part_value.temp_index;
@@ -1181,7 +1361,7 @@ fn try_lower_interpolated_string_literal(literal: string, bindings: ParameterBin
         temp_index: current_temp,
         operand: current_operand,
         diagnostics: diagnostics,
-        string_constants: collected_string_constants,
+        string_constants: collected_string_constants
     };
 }
 
@@ -1191,5 +1371,5 @@ export {
     lower_enum_literal,
     box_aggregate_operand,
     lower_cast_expression,
-    try_lower_interpolated_string_literal,
+    try_lower_interpolated_string_literal
 };

--- a/compiler/src/llvm/expression_lowering/native/core_literals_lowering.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_literals_lowering.sfn
@@ -1,87 +1,65 @@
 // compiler/src/llvm/expression_lowering/native/core_literals_lowering.sfn
 //
 // Literal/cast/interpolation lowering extracted from core.sfn.
-
 import { NativeFunction } from "../../../native_ir";
-
-import {
-    TypeContext,
-    ParameterBinding,
-    LocalBinding,
-    ExpressionResult,
-    LLVMOperand,
-    StringConstant,
-    CastParseResult,
-    StructLiteralParse,
-    StructLiteralField,
-    EnumLiteralParse,
-    HeapBoxResult,
-    InterpolatedTemplateParse,
-    StructTypeInfo,
-    StructFieldInfo,
-} from "../../types";
-
-import {
-    trim_text,
-    starts_with,
-    append_string,
-    number_to_string,
-    extend_string_array,
-    join_with_separator,
-    string_array_contains,
-} from "../../utils";
-
-import { substring, index_of } from "../../../string_utils";
-
+import { index_of, substring } from "../../../string_utils";
+import { default_return_literal, format_temp_name } from "../../expressions_helpers";
 import { empty_string_constant_set, merge_string_constants } from "../../strings";
-
-import { format_temp_name, default_return_literal } from "../../expressions_helpers";
-
 import {
-    map_type_annotation,
-    ends_with_pointer_suffix,
-    strip_pointer_suffix,
-    layout_annotation_represents_user_value,
-    array_struct_type_for_element,
-} from "../../type_mapping";
-
-import {
-    resolve_struct_info_for_literal,
+    lookup_allocation_info,
     resolve_enum_info_for_literal,
     resolve_enum_variant_info,
-    lookup_allocation_info,
+    resolve_struct_info_for_literal,
 } from "../../type_context_queries";
-
 import {
-    coerce_operand_to_type,
-    dominant_type,
-} from "./core_operands";
-
+    array_struct_type_for_element,
+    ends_with_pointer_suffix,
+    layout_annotation_represents_user_value,
+    map_type_annotation,
+    strip_pointer_suffix,
+} from "../../type_mapping";
 import {
-    lower_string_literal,
-    emit_string_concat,
-    coerce_operand_to_string,
-} from "./core_strings";
-
+    CastParseResult,
+    EnumLiteralParse,
+    ExpressionResult,
+    HeapBoxResult,
+    InterpolatedTemplateParse,
+    LLVMOperand,
+    LocalBinding,
+    ParameterBinding,
+    StringConstant,
+    StructFieldInfo,
+    StructLiteralField,
+    StructLiteralParse,
+    StructTypeInfo,
+    TypeContext,
+} from "../../types";
 import {
-    split_array_elements,
-} from "../splitting";
-
+    append_string,
+    extend_string_array,
+    join_with_separator,
+    number_to_string,
+    starts_with,
+    string_array_contains,
+    trim_text,
+} from "../../utils";
 import { array_pointer_element_type } from "../arrays";
-
-import {
-    parse_array_literal_metadata,
-} from "./core_parsing";
-
-import {
-    unescape_string_literal,
-    parse_interpolated_template,
-    encode_string_literal_for_sailfin,
-    find_substring_from,
-} from "./core_text";
-
+import { split_array_elements, } from "../splitting";
 // Mutually recursive with core.sfn
 import { lower_expression } from "./core";
+import { coerce_operand_to_type, dominant_type, } from "./core_operands";
+import { parse_array_literal_metadata, } from "./core_parsing";
+import {
+    coerce_operand_to_string,
+    emit_string_concat,
+    lower_string_literal,
+} from "./core_strings";
+import {
+    encode_string_literal_for_sailfin,
+    find_substring_from,
+    parse_interpolated_template,
+    unescape_string_literal,
+} from "./core_text";
 
 fn lower_array_literal(text: string, bindings: ParameterBinding[], locals: LocalBinding[], temp_index: number, lines: string[], functions: NativeFunction[], context: TypeContext, expected_type: string) -> ExpressionResult {
     let mut diagnostics: string[] = [];
@@ -93,23 +71,25 @@ fn lower_array_literal(text: string, bindings: ParameterBinding[], locals: Local
     if trimmed_expected == "i8*" {
         let inner = trim_text(substring(text, 1, text.length - 1));
         let mut elements: string[] = [];
-        if inner.length > 0 {
-            elements = split_array_elements(inner);
-        }
+        if inner.length > 0 { elements = split_array_elements(inner); }
 
         let open = lower_string_literal("\"[\"", current_temp, current_lines);
         current_lines = open.lines;
         current_temp = open.temp_index;
         if open.operand == null {
-            return ExpressionResult { lines: current_lines, temp_index: current_temp, operand: null, diagnostics: diagnostics, string_constants: collected_string_constants };
+            return ExpressionResult {
+                lines: current_lines,
+                temp_index: current_temp,
+                operand: null,
+                diagnostics: diagnostics,
+                string_constants: collected_string_constants
+            };
         }
         let mut current_operand: LLVMOperand = open.operand;
 
         let mut index: number = 0;
         loop {
-            if index >= elements.length {
-                break;
-            }
+            if index >= elements.length { break; }
             let element_text = trim_text(elements[index]);
             if element_text.length == 0 {
                 diagnostics.push("llvm lowering: empty element in array literal");
@@ -122,7 +102,13 @@ fn lower_array_literal(text: string, bindings: ParameterBinding[], locals: Local
                 current_lines = sep.lines;
                 current_temp = sep.temp_index;
                 if sep.operand == null {
-                    return ExpressionResult { lines: current_lines, temp_index: current_temp, operand: null, diagnostics: diagnostics, string_constants: collected_string_constants };
+                    return ExpressionResult {
+                        lines: current_lines,
+                        temp_index: current_temp,
+                        operand: null,
+                        diagnostics: diagnostics,
+                        string_constants: collected_string_constants
+                    };
                 }
                 let with_sep = emit_string_concat(current_operand, sep.operand, current_temp, current_lines);
                 let _ci0 = 0;
@@ -133,7 +119,13 @@ fn lower_array_literal(text: string, bindings: ParameterBinding[], locals: Local
                 current_lines = with_sep.lines;
                 current_temp = with_sep.temp_index;
                 if with_sep.operand == null {
-                    return ExpressionResult { lines: current_lines, temp_index: current_temp, operand: null, diagnostics: diagnostics, string_constants: collected_string_constants };
+                    return ExpressionResult {
+                        lines: current_lines,
+                        temp_index: current_temp,
+                        operand: null,
+                        diagnostics: diagnostics,
+                        string_constants: collected_string_constants
+                    };
                 }
                 current_operand = with_sep.operand;
             }
@@ -149,7 +141,13 @@ fn lower_array_literal(text: string, bindings: ParameterBinding[], locals: Local
             current_temp = lowered.temp_index;
             if lowered.operand == null {
                 diagnostics.push("llvm lowering: array literal element produced no value");
-                return ExpressionResult { lines: current_lines, temp_index: current_temp, operand: null, diagnostics: diagnostics, string_constants: collected_string_constants };
+                return ExpressionResult {
+                    lines: current_lines,
+                    temp_index: current_temp,
+                    operand: null,
+                    diagnostics: diagnostics,
+                    string_constants: collected_string_constants
+                };
             }
 
             let as_string = coerce_operand_to_string(lowered.operand, current_temp, current_lines);
@@ -163,7 +161,13 @@ fn lower_array_literal(text: string, bindings: ParameterBinding[], locals: Local
             current_temp = as_string.temp_index;
             if as_string.operand == null {
                 diagnostics.push("llvm lowering: unable to stringify array literal element");
-                return ExpressionResult { lines: current_lines, temp_index: current_temp, operand: null, diagnostics: diagnostics, string_constants: collected_string_constants };
+                return ExpressionResult {
+                    lines: current_lines,
+                    temp_index: current_temp,
+                    operand: null,
+                    diagnostics: diagnostics,
+                    string_constants: collected_string_constants
+                };
             }
 
             let appended = emit_string_concat(current_operand, as_string.operand, current_temp, current_lines);
@@ -175,7 +179,13 @@ fn lower_array_literal(text: string, bindings: ParameterBinding[], locals: Local
             current_lines = appended.lines;
             current_temp = appended.temp_index;
             if appended.operand == null {
-                return ExpressionResult { lines: current_lines, temp_index: current_temp, operand: null, diagnostics: diagnostics, string_constants: collected_string_constants };
+                return ExpressionResult {
+                    lines: current_lines,
+                    temp_index: current_temp,
+                    operand: null,
+                    diagnostics: diagnostics,
+                    string_constants: collected_string_constants
+                };
             }
             current_operand = appended.operand;
 
@@ -186,7 +196,13 @@ fn lower_array_literal(text: string, bindings: ParameterBinding[], locals: Local
         current_lines = close.lines;
         current_temp = close.temp_index;
         if close.operand == null {
-            return ExpressionResult { lines: current_lines, temp_index: current_temp, operand: null, diagnostics: diagnostics, string_constants: collected_string_constants };
+            return ExpressionResult {
+                lines: current_lines,
+                temp_index: current_temp,
+                operand: null,
+                diagnostics: diagnostics,
+                string_constants: collected_string_constants
+            };
         }
         let finished = emit_string_concat(current_operand, close.operand, current_temp, current_lines);
         let _ci4 = 0;
@@ -200,7 +216,13 @@ fn lower_array_literal(text: string, bindings: ParameterBinding[], locals: Local
             fs.writeFile("build/sailfin/.call_result_type", finished.operand.llvm_type);
             fs.writeFile("build/sailfin/.call_result_value", finished.operand.value);
         }
-        return ExpressionResult { lines: current_lines, temp_index: current_temp, operand: finished.operand, diagnostics: diagnostics, string_constants: collected_string_constants };
+        return ExpressionResult {
+            lines: current_lines,
+            temp_index: current_temp,
+            operand: finished.operand,
+            diagnostics: diagnostics,
+            string_constants: collected_string_constants
+        };
     }
 
     let mut expected_element_type: string = "";
@@ -225,9 +247,7 @@ fn lower_array_literal(text: string, bindings: ParameterBinding[], locals: Local
     }
     let mut index: number = metadata.start_index;
     loop {
-        if index >= elements.length {
-            break;
-        }
+        if index >= elements.length { break; }
         let element_text = trim_text(elements[index]);
         if element_text.length == 0 {
             diagnostics.push("llvm lowering: empty element in array literal");
@@ -241,7 +261,13 @@ fn lower_array_literal(text: string, bindings: ParameterBinding[], locals: Local
         current_temp = lowered.temp_index;
         if lowered.operand == null {
             diagnostics.push("llvm lowering: array literal element produced no value");
-            return ExpressionResult { lines: current_lines, temp_index: current_temp, operand: null, diagnostics: diagnostics, string_constants: collected_string_constants };
+            return ExpressionResult {
+                lines: current_lines,
+                temp_index: current_temp,
+                operand: null,
+                diagnostics: diagnostics,
+                string_constants: collected_string_constants
+            };
         }
         operands.push(lowered.operand);
         inferred_element_type = dominant_type(inferred_element_type, lowered.operand.llvm_type);
@@ -261,7 +287,13 @@ fn lower_array_literal(text: string, bindings: ParameterBinding[], locals: Local
 
     if inferred_element_type.length == 0 {
         diagnostics.push("llvm lowering: unsupported array literal element type");
-        return ExpressionResult { lines: current_lines, temp_index: current_temp, operand: null, diagnostics: diagnostics, string_constants: collected_string_constants };
+        return ExpressionResult {
+            lines: current_lines,
+            temp_index: current_temp,
+            operand: null,
+            diagnostics: diagnostics,
+            string_constants: collected_string_constants
+        };
     }
 
     let element_type = inferred_element_type;
@@ -269,9 +301,7 @@ fn lower_array_literal(text: string, bindings: ParameterBinding[], locals: Local
     let mut coerced_operands: LLVMOperand[] = [];
     index = 0;
     loop {
-        if index >= operands.length {
-            break;
-        }
+        if index >= operands.length { break; }
         let operand = operands[index];
         let mut prepared_operand = operand;
         let trimmed_operand_type = trim_text(operand.llvm_type);
@@ -288,7 +318,13 @@ fn lower_array_literal(text: string, bindings: ParameterBinding[], locals: Local
                     current_temp = boxed.temp_index;
                     if boxed.operand == null {
                         diagnostics.push("llvm lowering: array literal element could not be boxed to `" + element_type + "`");
-                        return ExpressionResult { lines: current_lines, temp_index: current_temp, operand: null, diagnostics: diagnostics, string_constants: collected_string_constants };
+                        return ExpressionResult {
+                            lines: current_lines,
+                            temp_index: current_temp,
+                            operand: null,
+                            diagnostics: diagnostics,
+                            string_constants: collected_string_constants
+                        };
                     }
                     prepared_operand = boxed.operand;
                 }
@@ -300,7 +336,13 @@ fn lower_array_literal(text: string, bindings: ParameterBinding[], locals: Local
         current_temp = coerced.temp_index;
         if coerced.operand == null {
             diagnostics.push("llvm lowering: array literal element could not be coerced to `" + element_type + "`");
-            return ExpressionResult { lines: current_lines, temp_index: current_temp, operand: null, diagnostics: diagnostics, string_constants: collected_string_constants };
+            return ExpressionResult {
+                lines: current_lines,
+                temp_index: current_temp,
+                operand: null,
+                diagnostics: diagnostics,
+                string_constants: collected_string_constants
+            };
         }
         coerced_operands.push(coerced.operand);
         index += 1;
@@ -344,9 +386,7 @@ fn lower_array_literal(text: string, bindings: ParameterBinding[], locals: Local
 
     index = 0;
     loop {
-        if index >= operands.length {
-            break;
-        }
+        if index >= operands.length { break; }
         let element_pointer = format_temp_name(current_temp);
         current_lines.push("  " + element_pointer + " = getelementptr " + element_type + ", " + element_type + "* " + data_pointer + ", i64 " + number_to_string(index));
         current_temp += 1;
@@ -388,10 +428,19 @@ fn lower_array_literal(text: string, bindings: ParameterBinding[], locals: Local
     current_temp += 1;
     current_lines.push("  store i64 " + length_text + ", i64* " + length_field_pointer);
 
-    let operand = LLVMOperand { llvm_type: struct_type + "*", value: struct_pointer };
+    let operand = LLVMOperand {
+        llvm_type: struct_type + "*",
+        value: struct_pointer
+    };
     fs.writeFile("build/sailfin/.call_result_type", struct_type + "*");
     fs.writeFile("build/sailfin/.call_result_value", struct_pointer);
-    return ExpressionResult { lines: current_lines, temp_index: current_temp, operand: operand, diagnostics: diagnostics, string_constants: collected_string_constants };
+    return ExpressionResult {
+        lines: current_lines,
+        temp_index: current_temp,
+        operand: operand,
+        diagnostics: diagnostics,
+        string_constants: collected_string_constants
+    };
 }
 
 fn lower_struct_literal(parse: StructLiteralParse, bindings: ParameterBinding[], locals: LocalBinding[], temp_index: number, lines: string[], functions: NativeFunction[], context: TypeContext, expected_type: string) -> ExpressionResult ![io] {
@@ -448,17 +497,19 @@ fn lower_struct_literal(parse: StructLiteralParse, bindings: ParameterBinding[],
                                     _f_entry = substring(_si_fields_str, _fp, _fp + _fc);
                                     _fp = _fp + _fc + 1;
                                 }
-                                if _f_entry.length == 0 { _fi += 1; continue; }
+                                if _f_entry.length == 0 {
+                                    _fi += 1;
+                                    continue;
+                                }
                                 let _colon = index_of(_f_entry, ":");
-                                if _colon < 0 { _fi += 1; continue; }
+                                if _colon < 0 {
+                                    _fi += 1;
+                                    continue;
+                                }
                                 let _f_name = substring(_f_entry, 0, _colon);
                                 let _f_type = substring(_f_entry, _colon + 1, _f_entry.length);
                                 _si_fields.push(StructFieldInfo {
-                                        name: _f_name,
-                                        llvm_type: _f_type,
-                                        type_annotation: "",
-                                        index: _fi,
-                                        offset: 0,
+                                    name: _f_name, llvm_type: _f_type, type_annotation: "", index: _fi, offset: 0,
                                 });
                                 _fi += 1;
                             }
@@ -482,30 +533,41 @@ fn lower_struct_literal(parse: StructLiteralParse, bindings: ParameterBinding[],
         } else {
             diagnostics.push("llvm lowering: struct literal references unknown struct");
         }
-        return ExpressionResult { lines: current_lines, temp_index: current_temp, operand: null, diagnostics: diagnostics, string_constants: collected_string_constants };
+        return ExpressionResult {
+            lines: current_lines,
+            temp_index: current_temp,
+            operand: null,
+            diagnostics: diagnostics,
+            string_constants: collected_string_constants
+        };
     }
 
     if info.fields.length == 0 {
-        let operand = LLVMOperand { llvm_type: info.llvm_name, value: "zeroinitializer" };
+        let operand = LLVMOperand {
+            llvm_type: info.llvm_name,
+            value: "zeroinitializer"
+        };
         fs.writeFile("build/sailfin/.call_result_type", info.llvm_name);
         fs.writeFile("build/sailfin/.call_result_value", "zeroinitializer");
-        return ExpressionResult { lines: current_lines, temp_index: current_temp, operand: operand, diagnostics: diagnostics, string_constants: collected_string_constants };
+        return ExpressionResult {
+            lines: current_lines,
+            temp_index: current_temp,
+            operand: operand,
+            diagnostics: diagnostics,
+            string_constants: collected_string_constants
+        };
     }
 
     let mut used_names: string[] = [];
     let mut previous_value: string = "";
     let mut field_index: number = 0;
     loop {
-        if field_index >= info.fields.length {
-            break;
-        }
+        if field_index >= info.fields.length { break; }
         let expected = info.fields[field_index];
         let mut literal_index: number = -1;
         let mut literal_lookup_index: number = 0;
         loop {
-            if literal_lookup_index >= parse.fields.length {
-                break;
-            }
+            if literal_lookup_index >= parse.fields.length { break; }
             if parse.fields[literal_lookup_index].name == expected.name {
                 literal_index = literal_lookup_index;
                 break;
@@ -553,14 +615,10 @@ fn lower_struct_literal(parse: StructLiteralParse, bindings: ParameterBinding[],
         }
 
         let mut value_text: string = default_return_literal(expected.llvm_type);
-        if value_operand != null {
-            value_text = value_operand.value;
-        }
+        if value_operand != null { value_text = value_operand.value; }
 
         let mut aggregate_source: string = "undef";
-        if field_index > 0 {
-            aggregate_source = previous_value;
-        }
+        if field_index > 0 { aggregate_source = previous_value; }
 
         let temp_name = format_temp_name(current_temp);
         current_lines.push("  " + temp_name + " = insertvalue " + info.llvm_name + " " + aggregate_source + ", " + expected.llvm_type + " " + value_text + ", " + number_to_string(field_index));
@@ -572,9 +630,7 @@ fn lower_struct_literal(parse: StructLiteralParse, bindings: ParameterBinding[],
 
     let mut extra_index: number = 0;
     loop {
-        if extra_index >= parse.fields.length {
-            break;
-        }
+        if extra_index >= parse.fields.length { break; }
         let literal_field = parse.fields[extra_index];
         if !string_array_contains(used_names, literal_field.name) {
             diagnostics.push("llvm lowering: struct literal for `" + info.name + "` provides unknown field `" + literal_field.name + "`");
@@ -583,16 +639,34 @@ fn lower_struct_literal(parse: StructLiteralParse, bindings: ParameterBinding[],
     }
 
     if previous_value.length == 0 {
-        let operand = LLVMOperand { llvm_type: info.llvm_name, value: "zeroinitializer" };
+        let operand = LLVMOperand {
+            llvm_type: info.llvm_name,
+            value: "zeroinitializer"
+        };
         fs.writeFile("build/sailfin/.call_result_type", info.llvm_name);
         fs.writeFile("build/sailfin/.call_result_value", "zeroinitializer");
-        return ExpressionResult { lines: current_lines, temp_index: current_temp, operand: operand, diagnostics: diagnostics, string_constants: collected_string_constants };
+        return ExpressionResult {
+            lines: current_lines,
+            temp_index: current_temp,
+            operand: operand,
+            diagnostics: diagnostics,
+            string_constants: collected_string_constants
+        };
     }
 
-    let operand = LLVMOperand { llvm_type: info.llvm_name, value: previous_value };
+    let operand = LLVMOperand {
+        llvm_type: info.llvm_name,
+        value: previous_value
+    };
     fs.writeFile("build/sailfin/.call_result_type", info.llvm_name);
     fs.writeFile("build/sailfin/.call_result_value", previous_value);
-    return ExpressionResult { lines: current_lines, temp_index: current_temp, operand: operand, diagnostics: diagnostics, string_constants: collected_string_constants };
+    return ExpressionResult {
+        lines: current_lines,
+        temp_index: current_temp,
+        operand: operand,
+        diagnostics: diagnostics,
+        string_constants: collected_string_constants
+    };
 }
 
 fn box_aggregate_operand(operand: LLVMOperand, expected_pointer_type: string, temp_index: number, lines: string[], context: TypeContext) -> HeapBoxResult {
@@ -603,11 +677,21 @@ fn box_aggregate_operand(operand: LLVMOperand, expected_pointer_type: string, te
     let allocation = lookup_allocation_info(context, operand.llvm_type);
     if allocation == null {
         diagnostics.push("llvm lowering: unable to allocate heap storage for `" + operand.llvm_type + "` when assigning to `" + expected_pointer_type + "`");
-        return HeapBoxResult { lines: current_lines, temp_index: current_temp, operand: null, diagnostics: diagnostics };
+        return HeapBoxResult {
+            lines: current_lines,
+            temp_index: current_temp,
+            operand: null,
+            diagnostics: diagnostics
+        };
     }
     if allocation.size <= 0 {
         diagnostics.push("llvm lowering: computed heap allocation size for `" + operand.llvm_type + "` is zero");
-        return HeapBoxResult { lines: current_lines, temp_index: current_temp, operand: null, diagnostics: diagnostics };
+        return HeapBoxResult {
+            lines: current_lines,
+            temp_index: current_temp,
+            operand: null,
+            diagnostics: diagnostics
+        };
     }
 
     let malloc_temp = format_temp_name(current_temp);
@@ -620,18 +704,29 @@ fn box_aggregate_operand(operand: LLVMOperand, expected_pointer_type: string, te
 
     current_lines.push("  store " + operand.llvm_type + " " + operand.value + ", " + operand.llvm_type + "* " + typed_ptr_temp);
 
-    let mut pointer_operand = LLVMOperand { llvm_type: "i8*", value: malloc_temp };
+    let mut pointer_operand = LLVMOperand {
+        llvm_type: "i8*",
+        value: malloc_temp
+    };
     let trimmed_expected = trim_text(expected_pointer_type);
     if trimmed_expected.length > 0 {
         if trimmed_expected != "i8*" {
             let cast_temp = format_temp_name(current_temp);
             current_temp += 1;
             current_lines.push("  " + cast_temp + " = bitcast i8* " + malloc_temp + " to " + trimmed_expected);
-            pointer_operand = LLVMOperand { llvm_type: trimmed_expected, value: cast_temp };
+            pointer_operand = LLVMOperand {
+                llvm_type: trimmed_expected,
+                value: cast_temp
+            };
         }
     }
 
-    return HeapBoxResult { lines: current_lines, temp_index: current_temp, operand: pointer_operand, diagnostics: diagnostics };
+    return HeapBoxResult {
+        lines: current_lines,
+        temp_index: current_temp,
+        operand: pointer_operand,
+        diagnostics: diagnostics
+    };
 }
 
 fn lower_enum_literal(parse: EnumLiteralParse, bindings: ParameterBinding[], locals: LocalBinding[], temp_index: number, lines: string[], functions: NativeFunction[], context: TypeContext, expected_type: string) -> ExpressionResult {
@@ -647,28 +742,32 @@ fn lower_enum_literal(parse: EnumLiteralParse, bindings: ParameterBinding[], loc
         } else {
             diagnostics.push("llvm lowering: enum literal references unknown enum");
         }
-        return ExpressionResult { lines: current_lines, temp_index: current_temp, operand: null, diagnostics: diagnostics, string_constants: collected_string_constants };
+        return ExpressionResult {
+            lines: current_lines,
+            temp_index: current_temp,
+            operand: null,
+            diagnostics: diagnostics,
+            string_constants: collected_string_constants
+        };
     }
 
     let variant_info = resolve_enum_variant_info(enum_info, parse.variant_name);
     if variant_info == null {
         diagnostics.push("llvm lowering: enum `" + parse.enum_name + "` has no variant `" + parse.variant_name + "`");
-        return ExpressionResult { lines: current_lines, temp_index: current_temp, operand: null, diagnostics: diagnostics, string_constants: collected_string_constants };
+        return ExpressionResult {
+            lines: current_lines,
+            temp_index: current_temp,
+            operand: null,
+            diagnostics: diagnostics,
+            string_constants: collected_string_constants
+        };
     }
 
     let mut tag_llvm_type: string = "i32";
-    if enum_info.tag_type == "i8" {
-        tag_llvm_type = "i8";
-    }
-    if enum_info.tag_type == "i16" {
-        tag_llvm_type = "i16";
-    }
-    if enum_info.tag_type == "i32" {
-        tag_llvm_type = "i32";
-    }
-    if enum_info.tag_type == "i64" {
-        tag_llvm_type = "i64";
-    }
+    if enum_info.tag_type == "i8" { tag_llvm_type = "i8"; }
+    if enum_info.tag_type == "i16" { tag_llvm_type = "i16"; }
+    if enum_info.tag_type == "i32" { tag_llvm_type = "i32"; }
+    if enum_info.tag_type == "i64" { tag_llvm_type = "i64"; }
 
     let mut enum_value: string = "undef";
     let mut enum_alloca: string? = null;
@@ -695,16 +794,12 @@ fn lower_enum_literal(parse: EnumLiteralParse, bindings: ParameterBinding[], loc
         let mut used_names: string[] = [];
         let mut field_index: number = 0;
         loop {
-            if field_index >= variant_info.fields.length {
-                break;
-            }
+            if field_index >= variant_info.fields.length { break; }
             let expected = variant_info.fields[field_index];
             let mut literal_index: number = -1;
             let mut literal_lookup_index: number = 0;
             loop {
-                if literal_lookup_index >= parse.fields.length {
-                    break;
-                }
+                if literal_lookup_index >= parse.fields.length { break; }
                 if parse.fields[literal_lookup_index].name == expected.name {
                     literal_index = literal_lookup_index;
                     break;
@@ -800,9 +895,7 @@ fn lower_enum_literal(parse: EnumLiteralParse, bindings: ParameterBinding[], loc
 
         let mut extra_index: number = 0;
         loop {
-            if extra_index >= parse.fields.length {
-                break;
-            }
+            if extra_index >= parse.fields.length { break; }
             let literal_field = parse.fields[extra_index];
             if !string_array_contains(used_names, literal_field.name) {
                 diagnostics.push("llvm lowering: enum literal for `" + parse.enum_name + "." + parse.variant_name + "` provides unknown field `" + literal_field.name + "`");
@@ -818,20 +911,41 @@ fn lower_enum_literal(parse: EnumLiteralParse, bindings: ParameterBinding[], loc
         }
     }
 
-    let operand = LLVMOperand { llvm_type: enum_info.llvm_name, value: enum_value };
-    return ExpressionResult { lines: current_lines, temp_index: current_temp, operand: operand, diagnostics: diagnostics, string_constants: collected_string_constants };
+    let operand = LLVMOperand {
+        llvm_type: enum_info.llvm_name,
+        value: enum_value
+    };
+    return ExpressionResult {
+        lines: current_lines,
+        temp_index: current_temp,
+        operand: operand,
+        diagnostics: diagnostics,
+        string_constants: collected_string_constants
+    };
 }
 
 fn lower_cast_expression(parse: CastParseResult, bindings: ParameterBinding[], locals: LocalBinding[], temp_index: number, lines: string[], functions: NativeFunction[], context: TypeContext) -> ExpressionResult {
     let mut diagnostics = parse.diagnostics;
     let empty_constants = empty_string_constant_set();
     if !parse.success {
-        return ExpressionResult { lines: lines, temp_index: temp_index, operand: null, diagnostics: diagnostics, string_constants: empty_constants };
+        return ExpressionResult {
+            lines: lines,
+            temp_index: temp_index,
+            operand: null,
+            diagnostics: diagnostics,
+            string_constants: empty_constants
+        };
     }
     let target_type = map_type_annotation(parse.type_annotation);
     if target_type.length == 0 {
         diagnostics.push("llvm lowering: unsupported cast target type `" + parse.type_annotation + "`");
-        return ExpressionResult { lines: lines, temp_index: temp_index, operand: null, diagnostics: diagnostics, string_constants: empty_constants };
+        return ExpressionResult {
+            lines: lines,
+            temp_index: temp_index,
+            operand: null,
+            diagnostics: diagnostics,
+            string_constants: empty_constants
+        };
     }
 
     let lowered = lower_expression(parse.value, bindings, locals, temp_index, lines, functions, context, "");
@@ -841,11 +955,23 @@ fn lower_cast_expression(parse: CastParseResult, bindings: ParameterBinding[], l
         _ci10 += 1;
     }
     if lowered.operand == null {
-        return ExpressionResult { lines: lowered.lines, temp_index: lowered.temp_index, operand: null, diagnostics: diagnostics, string_constants: lowered.string_constants };
+        return ExpressionResult {
+            lines: lowered.lines,
+            temp_index: lowered.temp_index,
+            operand: null,
+            diagnostics: diagnostics,
+            string_constants: lowered.string_constants
+        };
     }
     let operand = lowered.operand;
     if operand.llvm_type == target_type {
-        return ExpressionResult { lines: lowered.lines, temp_index: lowered.temp_index, operand: operand, diagnostics: diagnostics, string_constants: lowered.string_constants };
+        return ExpressionResult {
+            lines: lowered.lines,
+            temp_index: lowered.temp_index,
+            operand: operand,
+            diagnostics: diagnostics,
+            string_constants: lowered.string_constants
+        };
     }
 
     let mut current_lines = lowered.lines;
@@ -856,8 +982,17 @@ fn lower_cast_expression(parse: CastParseResult, bindings: ParameterBinding[], l
     if ends_with_pointer_suffix(operand.llvm_type) {
         if ends_with_pointer_suffix(target_type) {
             current_lines.push("  " + cast_name + " = bitcast " + operand.llvm_type + " " + operand.value + " to " + target_type);
-            let casted = LLVMOperand { llvm_type: target_type, value: cast_name };
-            return ExpressionResult { lines: current_lines, temp_index: current_temp, operand: casted, diagnostics: diagnostics, string_constants: lowered.string_constants };
+            let casted = LLVMOperand {
+                llvm_type: target_type,
+                value: cast_name
+            };
+            return ExpressionResult {
+                lines: current_lines,
+                temp_index: current_temp,
+                operand: casted,
+                diagnostics: diagnostics,
+                string_constants: lowered.string_constants
+            };
         }
     }
 
@@ -865,8 +1000,17 @@ fn lower_cast_expression(parse: CastParseResult, bindings: ParameterBinding[], l
         if ends_with_pointer_suffix(target_type) {
             if starts_with(operand.llvm_type, "i") {
                 current_lines.push("  " + cast_name + " = inttoptr " + operand.llvm_type + " " + operand.value + " to " + target_type);
-                let casted = LLVMOperand { llvm_type: target_type, value: cast_name };
-                return ExpressionResult { lines: current_lines, temp_index: current_temp, operand: casted, diagnostics: diagnostics, string_constants: lowered.string_constants };
+                let casted = LLVMOperand {
+                    llvm_type: target_type,
+                    value: cast_name
+                };
+                return ExpressionResult {
+                    lines: current_lines,
+                    temp_index: current_temp,
+                    operand: casted,
+                    diagnostics: diagnostics,
+                    string_constants: lowered.string_constants
+                };
             }
         }
     }
@@ -875,35 +1019,40 @@ fn lower_cast_expression(parse: CastParseResult, bindings: ParameterBinding[], l
         if !ends_with_pointer_suffix(target_type) {
             if starts_with(target_type, "i") {
                 current_lines.push("  " + cast_name + " = ptrtoint " + operand.llvm_type + " " + operand.value + " to " + target_type);
-                let casted = LLVMOperand { llvm_type: target_type, value: cast_name };
-                return ExpressionResult { lines: current_lines, temp_index: current_temp, operand: casted, diagnostics: diagnostics, string_constants: lowered.string_constants };
+                let casted = LLVMOperand {
+                    llvm_type: target_type,
+                    value: cast_name
+                };
+                return ExpressionResult {
+                    lines: current_lines,
+                    temp_index: current_temp,
+                    operand: casted,
+                    diagnostics: diagnostics,
+                    string_constants: lowered.string_constants
+                };
             }
         }
     }
 
     diagnostics.push("llvm lowering: unsupported cast from `" + operand.llvm_type + "` to `" + target_type + "`");
-    return ExpressionResult { lines: current_lines, temp_index: current_temp, operand: null, diagnostics: diagnostics, string_constants: lowered.string_constants };
+    return ExpressionResult {
+        lines: current_lines,
+        temp_index: current_temp,
+        operand: null,
+        diagnostics: diagnostics,
+        string_constants: lowered.string_constants
+    };
 }
 
 fn try_lower_interpolated_string_literal(literal: string, bindings: ParameterBinding[], locals: LocalBinding[], temp_index: number, lines: string[], functions: NativeFunction[], context: TypeContext) -> ExpressionResult? {
     let content = unescape_string_literal(literal);
-    if find_substring_from(content, "{{", 0) < 0 {
-        return null;
-    }
-    if find_substring_from(content, "}}", 0) < 0 {
-        return null;
-    }
+    if find_substring_from(content, "{{", 0) < 0 { return null; }
+    if find_substring_from(content, "}}", 0) < 0 { return null; }
 
     let parsed = parse_interpolated_template(content);
-    if !parsed.success {
-        return null;
-    }
-    if parsed.expressions.length == 0 {
-        return null;
-    }
-    if parsed.parts.length != parsed.expressions.length + 1 {
-        return null;
-    }
+    if !parsed.success { return null; }
+    if parsed.expressions.length == 0 { return null; }
+    if parsed.parts.length != parsed.expressions.length + 1 { return null; }
 
     let mut current_lines: string[] = lines;
     let mut current_temp: number = temp_index;
@@ -916,15 +1065,19 @@ fn try_lower_interpolated_string_literal(literal: string, bindings: ParameterBin
     current_temp = first.temp_index;
 
     if first.operand == null {
-        return ExpressionResult { lines: current_lines, temp_index: current_temp, operand: null, diagnostics: diagnostics, string_constants: collected_string_constants };
+        return ExpressionResult {
+            lines: current_lines,
+            temp_index: current_temp,
+            operand: null,
+            diagnostics: diagnostics,
+            string_constants: collected_string_constants
+        };
     }
     let mut current_operand: LLVMOperand = first.operand;
 
     let mut index: number = 0;
     loop {
-        if index >= parsed.expressions.length {
-            break;
-        }
+        if index >= parsed.expressions.length { break; }
 
         let expr_text = parsed.expressions[index];
         let lowered_expr = lower_expression(expr_text, bindings, locals, current_temp, current_lines, functions, context, "i8*");
@@ -939,7 +1092,13 @@ fn try_lower_interpolated_string_literal(literal: string, bindings: ParameterBin
 
         if lowered_expr.operand == null {
             diagnostics.push("llvm lowering: unable to lower interpolated expression `" + expr_text + "`");
-            return ExpressionResult { lines: current_lines, temp_index: current_temp, operand: null, diagnostics: diagnostics, string_constants: collected_string_constants };
+            return ExpressionResult {
+                lines: current_lines,
+                temp_index: current_temp,
+                operand: null,
+                diagnostics: diagnostics,
+                string_constants: collected_string_constants
+            };
         }
 
         let coerced = coerce_operand_to_string(lowered_expr.operand, current_temp, current_lines);
@@ -953,7 +1112,13 @@ fn try_lower_interpolated_string_literal(literal: string, bindings: ParameterBin
         collected_string_constants = merge_string_constants(collected_string_constants, coerced.string_constants);
         if coerced.operand == null {
             diagnostics.push("llvm lowering: unable to stringify interpolated expression `" + expr_text + "`");
-            return ExpressionResult { lines: current_lines, temp_index: current_temp, operand: null, diagnostics: diagnostics, string_constants: collected_string_constants };
+            return ExpressionResult {
+                lines: current_lines,
+                temp_index: current_temp,
+                operand: null,
+                diagnostics: diagnostics,
+                string_constants: collected_string_constants
+            };
         }
 
         let concat1 = emit_string_concat(current_operand, coerced.operand, current_temp, current_lines);
@@ -965,7 +1130,13 @@ fn try_lower_interpolated_string_literal(literal: string, bindings: ParameterBin
         current_lines = concat1.lines;
         current_temp = concat1.temp_index;
         if concat1.operand == null {
-            return ExpressionResult { lines: current_lines, temp_index: current_temp, operand: null, diagnostics: diagnostics, string_constants: collected_string_constants };
+            return ExpressionResult {
+                lines: current_lines,
+                temp_index: current_temp,
+                operand: null,
+                diagnostics: diagnostics,
+                string_constants: collected_string_constants
+            };
         }
         current_operand = concat1.operand;
 
@@ -974,7 +1145,13 @@ fn try_lower_interpolated_string_literal(literal: string, bindings: ParameterBin
         current_lines = part_value.lines;
         current_temp = part_value.temp_index;
         if part_value.operand == null {
-            return ExpressionResult { lines: current_lines, temp_index: current_temp, operand: null, diagnostics: diagnostics, string_constants: collected_string_constants };
+            return ExpressionResult {
+                lines: current_lines,
+                temp_index: current_temp,
+                operand: null,
+                diagnostics: diagnostics,
+                string_constants: collected_string_constants
+            };
         }
 
         let concat2 = emit_string_concat(current_operand, part_value.operand, current_temp, current_lines);
@@ -986,7 +1163,13 @@ fn try_lower_interpolated_string_literal(literal: string, bindings: ParameterBin
         current_lines = concat2.lines;
         current_temp = concat2.temp_index;
         if concat2.operand == null {
-            return ExpressionResult { lines: current_lines, temp_index: current_temp, operand: null, diagnostics: diagnostics, string_constants: collected_string_constants };
+            return ExpressionResult {
+                lines: current_lines,
+                temp_index: current_temp,
+                operand: null,
+                diagnostics: diagnostics,
+                string_constants: collected_string_constants
+            };
         }
         current_operand = concat2.operand;
 

--- a/compiler/src/llvm/expression_lowering/native/core_match_helpers.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_match_helpers.sfn
@@ -1,7 +1,6 @@
 // compiler/src/llvm/expression_lowering/native/core_match_helpers.sfn
 //
 // Small helpers used by match lowering that historically lived in core.sfn.
-
 import { MatchArmMutations } from "../../types";
 
 fn append_match_arm_mutations(list: MatchArmMutations[], arm: MatchArmMutations) -> MatchArmMutations[] {

--- a/compiler/src/llvm/expression_lowering/native/core_member_helpers.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_member_helpers.sfn
@@ -2,41 +2,23 @@
 //
 // Inline GEP field access helper extracted from core_member_lowering.sfn
 // to keep each function under ~500 .sfn-asm instructions (avoids seed OOM).
-
+import { index_of, substring } from "../../../string_utils";
+import { format_temp_name } from "../../expressions_helpers";
 import {
-    TypeContext,
-    ParameterBinding,
-    LocalBinding,
     ExpressionResult,
     LLVMOperand,
+    LocalBinding,
+    ParameterBinding,
     StringConstant,
+    TypeContext,
 } from "../../types";
-
-import {
-    trim_text,
-    number_to_string,
-} from "../../utils";
-
-import { substring, index_of } from "../../../string_utils";
-
-import { format_temp_name } from "../../expressions_helpers";
+import { number_to_string, trim_text, } from "../../utils";
 
 // Try to resolve a struct field access via file-based struct info when the
 // base type is i8* (opaque pointer). Returns an ExpressionResult with the
 // loaded field value, or null if resolution fails.
-fn lower_inline_gep_field_access(
-    base_name: string,
-    field_name: string,
-    base_operand: LLVMOperand,
-    bindings: ParameterBinding[],
-    temp_index: number,
-    lines: string[],
-    diagnostics: string[],
-    string_constants: StringConstant[]
-) -> ExpressionResult? ![io] {
-    if !fs.exists("build/sailfin/.struct_info") {
-        return null;
-    }
+fn lower_inline_gep_field_access(base_name: string, field_name: string, base_operand: LLVMOperand, bindings: ParameterBinding[], temp_index: number, lines: string[], diagnostics: string[], string_constants: StringConstant[]) -> ExpressionResult? ![io] {
+    if !fs.exists("build/sailfin/.struct_info") { return null; }
 
     let _igep_base = trim_text(base_name);
     let mut _igep_struct: string = "";
@@ -64,8 +46,13 @@ fn lower_inline_gep_field_access(
                         if _igep_sp >= _igep_si.length { break; }
                         let _igep_nl = index_of(substring(_igep_si, _igep_sp, _igep_si.length), "\n");
                         let mut _igep_ln: string = "";
-                        if _igep_nl < 0 { _igep_ln = substring(_igep_si, _igep_sp, _igep_si.length); _igep_sp = _igep_si.length; }
-                        else { _igep_ln = substring(_igep_si, _igep_sp, _igep_sp + _igep_nl); _igep_sp = _igep_sp + _igep_nl + 1; }
+                        if _igep_nl < 0 {
+                            _igep_ln = substring(_igep_si, _igep_sp, _igep_si.length);
+                            _igep_sp = _igep_si.length;
+                        } else {
+                            _igep_ln = substring(_igep_si, _igep_sp, _igep_sp + _igep_nl);
+                            _igep_sp = _igep_sp + _igep_nl + 1;
+                        }
                         if _igep_ln.length == 0 { continue; }
                         let _igep_t = index_of(_igep_ln, "\t");
                         if _igep_t < 0 { continue; }
@@ -93,24 +80,29 @@ fn lower_inline_gep_field_access(
                 if _igep_cp >= _igep_cl.length { break; }
                 let _igep_cnl = index_of(substring(_igep_cl, _igep_cp, _igep_cl.length), "\n");
                 let mut _igep_cln: string = "";
-                if _igep_cnl < 0 { _igep_cln = substring(_igep_cl, _igep_cp, _igep_cl.length); _igep_cp = _igep_cl.length; }
-                else { _igep_cln = substring(_igep_cl, _igep_cp, _igep_cp + _igep_cnl); _igep_cp = _igep_cp + _igep_cnl + 1; }
+                if _igep_cnl < 0 {
+                    _igep_cln = substring(_igep_cl, _igep_cp, _igep_cl.length);
+                    _igep_cp = _igep_cl.length;
+                } else {
+                    _igep_cln = substring(_igep_cl, _igep_cp, _igep_cp + _igep_cnl);
+                    _igep_cp = _igep_cp + _igep_cnl + 1;
+                }
                 if _igep_cln.length == 0 { continue; }
                 let _igep_ct = index_of(_igep_cln, "\t");
                 if _igep_ct < 0 { continue; }
                 if substring(_igep_cln, 0, _igep_ct) == _igep_base {
                     let _igep_cr = substring(_igep_cln, _igep_ct + 1, _igep_cln.length);
                     let _igep_ct2 = index_of(_igep_cr, "\t");
-                    if _igep_ct2 > 0 { _igep_struct = substring(_igep_cr, 0, _igep_ct2); }
+                    if _igep_ct2 > 0 {
+                        _igep_struct = substring(_igep_cr, 0, _igep_ct2);
+                    }
                     break;
                 }
             }
         }
     }
 
-    if _igep_struct.length == 0 {
-        return null;
-    }
+    if _igep_struct.length == 0 { return null; }
 
     // Look up struct in .struct_info and find field
     let _igep_raw = fs.readFile("build/sailfin/.struct_info");
@@ -122,8 +114,13 @@ fn lower_inline_gep_field_access(
         if _igep_rp >= _igep_raw.length { break; }
         let _igep_rnl = index_of(substring(_igep_raw, _igep_rp, _igep_raw.length), "\n");
         let mut _igep_rln: string = "";
-        if _igep_rnl < 0 { _igep_rln = substring(_igep_raw, _igep_rp, _igep_raw.length); _igep_rp = _igep_raw.length; }
-        else { _igep_rln = substring(_igep_raw, _igep_rp, _igep_rp + _igep_rnl); _igep_rp = _igep_rp + _igep_rnl + 1; }
+        if _igep_rnl < 0 {
+            _igep_rln = substring(_igep_raw, _igep_rp, _igep_raw.length);
+            _igep_rp = _igep_raw.length;
+        } else {
+            _igep_rln = substring(_igep_raw, _igep_rp, _igep_rp + _igep_rnl);
+            _igep_rp = _igep_rp + _igep_rnl + 1;
+        }
         if _igep_rln.length == 0 { continue; }
         let _igep_rt = index_of(_igep_rln, "\t");
         if _igep_rt < 0 { continue; }
@@ -139,10 +136,18 @@ fn lower_inline_gep_field_access(
             if _igep_fp >= _igep_fs.length { break; }
             let _igep_fc = index_of(substring(_igep_fs, _igep_fp, _igep_fs.length), ",");
             let mut _igep_fe: string = "";
-            if _igep_fc < 0 { _igep_fe = substring(_igep_fs, _igep_fp, _igep_fs.length); _igep_fp = _igep_fs.length; }
-            else { _igep_fe = substring(_igep_fs, _igep_fp, _igep_fp + _igep_fc); _igep_fp = _igep_fp + _igep_fc + 1; }
+            if _igep_fc < 0 {
+                _igep_fe = substring(_igep_fs, _igep_fp, _igep_fs.length);
+                _igep_fp = _igep_fs.length;
+            } else {
+                _igep_fe = substring(_igep_fs, _igep_fp, _igep_fp + _igep_fc);
+                _igep_fp = _igep_fp + _igep_fc + 1;
+            }
             let _igep_fk = index_of(_igep_fe, ":");
-            if _igep_fk < 0 { _igep_fi += 1; continue; }
+            if _igep_fk < 0 {
+                _igep_fi += 1;
+                continue;
+            }
             if substring(_igep_fe, 0, _igep_fk) == field_name {
                 _igep_fidx = _igep_fi;
                 _igep_ftype = substring(_igep_fe, _igep_fk + 1, _igep_fe.length);
@@ -153,15 +158,9 @@ fn lower_inline_gep_field_access(
         break;
     }
 
-    if _igep_llvm.length == 0 {
-        return null;
-    }
-    if _igep_fidx < 0 {
-        return null;
-    }
-    if _igep_ftype.length == 0 {
-        return null;
-    }
+    if _igep_llvm.length == 0 { return null; }
+    if _igep_fidx < 0 { return null; }
+    if _igep_ftype.length == 0 { return null; }
 
     // Emit bitcast + GEP + load
     let mut current_lines = lines;
@@ -176,7 +175,13 @@ fn lower_inline_gep_field_access(
     current_lines.push("  " + _igep_ct3 + " = load " + _igep_ftype + ", " + _igep_ftype + "* " + _igep_ct2_name);
     current_temp += 1;
     let _igep_op = LLVMOperand { llvm_type: _igep_ftype, value: _igep_ct3 };
-    return ExpressionResult { lines: current_lines, temp_index: current_temp, operand: _igep_op, diagnostics: diagnostics, string_constants: string_constants };
+    return ExpressionResult {
+        lines: current_lines,
+        temp_index: current_temp,
+        operand: _igep_op,
+        diagnostics: diagnostics,
+        string_constants: string_constants
+    };
 }
 
 export { lower_inline_gep_field_access };

--- a/compiler/src/llvm/expression_lowering/native/core_member_helpers.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_member_helpers.sfn
@@ -10,9 +10,9 @@ import {
     LocalBinding,
     ParameterBinding,
     StringConstant,
-    TypeContext,
+    TypeContext
 } from "../../types";
-import { number_to_string, trim_text, } from "../../utils";
+import { number_to_string, trim_text } from "../../utils";
 
 // Try to resolve a struct field access via file-based struct info when the
 // base type is i8* (opaque pointer). Returns an ExpressionResult with the
@@ -50,7 +50,8 @@ fn lower_inline_gep_field_access(base_name: string, field_name: string, base_ope
                             _igep_ln = substring(_igep_si, _igep_sp, _igep_si.length);
                             _igep_sp = _igep_si.length;
                         } else {
-                            _igep_ln = substring(_igep_si, _igep_sp, _igep_sp + _igep_nl);
+                            _igep_ln = substring(_igep_si, _igep_sp, _igep_sp
+                                + _igep_nl);
                             _igep_sp = _igep_sp + _igep_nl + 1;
                         }
                         if _igep_ln.length == 0 { continue; }
@@ -84,7 +85,8 @@ fn lower_inline_gep_field_access(base_name: string, field_name: string, base_ope
                     _igep_cln = substring(_igep_cl, _igep_cp, _igep_cl.length);
                     _igep_cp = _igep_cl.length;
                 } else {
-                    _igep_cln = substring(_igep_cl, _igep_cp, _igep_cp + _igep_cnl);
+                    _igep_cln = substring(_igep_cl, _igep_cp, _igep_cp
+                        + _igep_cnl);
                     _igep_cp = _igep_cp + _igep_cnl + 1;
                 }
                 if _igep_cln.length == 0 { continue; }
@@ -166,13 +168,26 @@ fn lower_inline_gep_field_access(base_name: string, field_name: string, base_ope
     let mut current_lines = lines;
     let mut current_temp: number = temp_index;
     let _igep_ct1 = format_temp_name(current_temp);
-    current_lines.push("  " + _igep_ct1 + " = bitcast i8* " + base_operand.value + " to " + _igep_llvm + "*");
+    current_lines.push("  " + _igep_ct1 + " = bitcast i8* " + base_operand.value
+        + " to "
+        + _igep_llvm
+        + "*");
     current_temp += 1;
     let _igep_ct2_name = format_temp_name(current_temp);
-    current_lines.push("  " + _igep_ct2_name + " = getelementptr inbounds " + _igep_llvm + ", " + _igep_llvm + "* " + _igep_ct1 + ", i32 0, i32 " + number_to_string(_igep_fidx));
+    current_lines.push("  " + _igep_ct2_name + " = getelementptr inbounds "
+        + _igep_llvm
+        + ", "
+        + _igep_llvm
+        + "* "
+        + _igep_ct1
+        + ", i32 0, i32 "
+        + number_to_string(_igep_fidx));
     current_temp += 1;
     let _igep_ct3 = format_temp_name(current_temp);
-    current_lines.push("  " + _igep_ct3 + " = load " + _igep_ftype + ", " + _igep_ftype + "* " + _igep_ct2_name);
+    current_lines.push("  " + _igep_ct3 + " = load " + _igep_ftype + ", "
+        + _igep_ftype
+        + "* "
+        + _igep_ct2_name);
     current_temp += 1;
     let _igep_op = LLVMOperand { llvm_type: _igep_ftype, value: _igep_ct3 };
     return ExpressionResult {

--- a/compiler/src/llvm/expression_lowering/native/core_member_lowering.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_member_lowering.sfn
@@ -1,66 +1,55 @@
 // compiler/src/llvm/expression_lowering/native/core_member_lowering.sfn
 //
 // Member access lowering extracted from core.sfn.
-
 import { NativeFunction } from "../../../native_ir";
-
+import { index_of, substring } from "../../../string_utils";
+import { default_return_literal, format_temp_name } from "../../expressions_helpers";
 import {
-    TypeContext,
-    StructTypeInfo,
-    StructFieldInfo,
-    EnumTypeInfo,
-    EnumVariantInfo,
-    ParameterBinding,
-    LocalBinding,
-    MemberAccessParse,
-    ExpressionResult,
-    LLVMOperand,
-    StringConstant,
-    StringPointerResult,
-} from "../../types";
-
-import {
-    trim_text,
-    append_string,
-    starts_with,
-    contains_text,
-    number_to_string,
-} from "../../utils";
-
-import { substring, index_of } from "../../../string_utils";
-
-import {
-    empty_string_constant_set,
     append_string_constant,
+    empty_string_constant_set,
     find_string_constant_by_name,
 } from "../../strings";
-
+import {
+    find_enum_info_by_llvm_type,
+    find_interface_info_by_name,
+    find_struct_field_info,
+    find_struct_info_by_llvm_type,
+    find_struct_info_by_name,
+    find_variant_field_info,
+    resolve_enum_info_for_literal,
+} from "../../type_context_queries";
 import {
     ends_with_pointer_suffix,
-    strip_pointer_suffix,
     layout_annotation_base_type,
     layout_annotation_represents_user_value,
     map_type_annotation,
+    strip_pointer_suffix,
 } from "../../type_mapping";
-
 import {
-    find_struct_info_by_llvm_type,
-    find_struct_field_info,
-    find_enum_info_by_llvm_type,
-    resolve_enum_info_for_literal,
-    find_struct_info_by_name,
-    find_interface_info_by_name,
-    find_variant_field_info,
-} from "../../type_context_queries";
-
-import { format_temp_name, default_return_literal } from "../../expressions_helpers";
-
-import { sanitize_symbol } from "./core_text";
-
-import { lower_inline_gep_field_access } from "./core_member_helpers";
-
+    EnumTypeInfo,
+    EnumVariantInfo,
+    ExpressionResult,
+    LLVMOperand,
+    LocalBinding,
+    MemberAccessParse,
+    ParameterBinding,
+    StringConstant,
+    StringPointerResult,
+    StructFieldInfo,
+    StructTypeInfo,
+    TypeContext,
+} from "../../types";
+import {
+    append_string,
+    contains_text,
+    number_to_string,
+    starts_with,
+    trim_text,
+} from "../../utils";
 // Mutually recursive with core.sfn
 import { lower_expression } from "./core";
+import { lower_inline_gep_field_access } from "./core_member_helpers";
+import { sanitize_symbol } from "./core_text";
 
 fn make_expression_result(lines: string[], temp_index: number, operand: LLVMOperand?, diagnostics: string[], string_constants: StringConstant[]) -> ExpressionResult {
     return ExpressionResult {
@@ -78,7 +67,11 @@ fn emit_string_constant_pointer(constant: StringConstant, temp_index: number, li
     let array_type = "[" + number_to_string(array_length) + " x i8]";
     let temp_name = format_temp_name(temp_index);
     current_lines.push("  " + temp_name + " = getelementptr inbounds " + array_type + ", " + array_type + "* " + constant.name + ", i32 0, i32 0");
-    return StringPointerResult { lines: current_lines, temp_index: temp_index + 1, pointer: temp_name };
+    return StringPointerResult {
+        lines: current_lines,
+        temp_index: temp_index + 1,
+        pointer: temp_name
+    };
 }
 
 fn lower_dynamic_member_access(field: string, base_operand: LLVMOperand, temp_index: number, lines: string[], diagnostics: string[], string_constants: StringConstant[]) -> ExpressionResult {
@@ -92,10 +85,12 @@ fn lower_dynamic_member_access(field: string, base_operand: LLVMOperand, temp_in
     let _rf_prefix = "@.runtime" + ".field.";
     let constant_name = _rf_prefix + sanitized_field;
     let existing_constant = find_string_constant_by_name(dynamic_string_constants, constant_name);
-    let mut field_constant: StringConstant = StringConstant { name: constant_name, content: field, byte_count: field.length };
-    if existing_constant != null {
-        field_constant = existing_constant;
-    } else {
+    let mut field_constant: StringConstant = StringConstant {
+        name: constant_name,
+        content: field,
+        byte_count: field.length
+    };
+    if existing_constant != null { field_constant = existing_constant; } else {
         dynamic_string_constants = append_string_constant(dynamic_string_constants, field_constant);
     }
 
@@ -137,7 +132,13 @@ fn lower_runtime_global_reference(temp_index: number, lines: string[]) -> Expres
     current_lines.push("  " + runtime_temp + " = load i8*, i8** @runtime");
     let operand = LLVMOperand { llvm_type: "i8*", value: runtime_temp };
     let empty_constants = empty_string_constant_set();
-    return ExpressionResult { lines: current_lines, temp_index: temp_index + 1, operand: operand, diagnostics: [], string_constants: empty_constants };
+    return ExpressionResult {
+        lines: current_lines,
+        temp_index: temp_index + 1,
+        operand: operand,
+        diagnostics: [],
+        string_constants: empty_constants
+    };
 }
 
 fn lower_enum_member_access(parse: MemberAccessParse, enum_info: EnumTypeInfo, base_operand: LLVMOperand, pointer_available: boolean, temp_index: number, lines: string[], diagnostics: string[], string_constants: StringConstant[], expected_type: string) -> ExpressionResult {
@@ -146,7 +147,10 @@ fn lower_enum_member_access(parse: MemberAccessParse, enum_info: EnumTypeInfo, b
     let mut enum_string_constants: StringConstant[] = string_constants;
     let mut messages: string[] = diagnostics;
 
-    let mut tag_operand: LLVMOperand = LLVMOperand { llvm_type: enum_info.tag_type, value: "" };
+    let mut tag_operand: LLVMOperand = LLVMOperand {
+        llvm_type: enum_info.tag_type,
+        value: ""
+    };
     if pointer_available {
         let tag_ptr = format_temp_name(current_temp);
         current_lines.push("  " + tag_ptr + " = getelementptr inbounds " + enum_info.llvm_name + ", " + enum_info.llvm_name + "* " + base_operand.value + ", i32 0, i32 0");
@@ -154,23 +158,35 @@ fn lower_enum_member_access(parse: MemberAccessParse, enum_info: EnumTypeInfo, b
         let tag_temp = format_temp_name(current_temp);
         current_lines.push("  " + tag_temp + " = load " + enum_info.tag_type + ", " + enum_info.tag_type + "* " + tag_ptr);
         current_temp += 1;
-        tag_operand = LLVMOperand { llvm_type: enum_info.tag_type, value: tag_temp };
+        tag_operand = LLVMOperand {
+            llvm_type: enum_info.tag_type,
+            value: tag_temp
+        };
     } else {
         let tag_temp = format_temp_name(current_temp);
         current_lines.push("  " + tag_temp + " = extractvalue " + enum_info.llvm_name + " " + base_operand.value + ", 0");
         current_temp += 1;
-        tag_operand = LLVMOperand { llvm_type: enum_info.tag_type, value: tag_temp };
+        tag_operand = LLVMOperand {
+            llvm_type: enum_info.tag_type,
+            value: tag_temp
+        };
     }
 
     if parse.field == "variant" {
         let sanitized_enum = sanitize_symbol(enum_info.name);
         let default_constant_name = "@.enum." + sanitized_enum + ".variant.default";
         let existing_default = find_string_constant_by_name(enum_string_constants, default_constant_name);
-        let mut default_constant: StringConstant = StringConstant { name: default_constant_name, content: "", byte_count: 0 };
-        if existing_default != null {
-            default_constant = existing_default;
-        } else {
-            default_constant = StringConstant { name: default_constant_name, content: "", byte_count: 0 };
+        let mut default_constant: StringConstant = StringConstant {
+            name: default_constant_name,
+            content: "",
+            byte_count: 0
+        };
+        if existing_default != null { default_constant = existing_default; } else {
+            default_constant = StringConstant {
+                name: default_constant_name,
+                content: "",
+                byte_count: 0
+            };
             enum_string_constants = append_string_constant(enum_string_constants, default_constant);
         }
 
@@ -181,18 +197,22 @@ fn lower_enum_member_access(parse: MemberAccessParse, enum_info: EnumTypeInfo, b
 
         let mut variant_index: number = 0;
         loop {
-            if variant_index >= enum_info.variants.length {
-                break;
-            }
+            if variant_index >= enum_info.variants.length { break; }
             let variant_info = enum_info.variants[variant_index];
             let sanitized_variant = sanitize_symbol(variant_info.name);
             let constant_name = "@.enum." + sanitized_enum + "." + sanitized_variant + ".variant";
             let existing_variant = find_string_constant_by_name(enum_string_constants, constant_name);
-            let mut variant_constant: StringConstant = StringConstant { name: constant_name, content: "", byte_count: 0 };
-            if existing_variant != null {
-                variant_constant = existing_variant;
-            } else {
-                variant_constant = StringConstant { name: constant_name, content: variant_info.name, byte_count: variant_info.name.length };
+            let mut variant_constant: StringConstant = StringConstant {
+                name: constant_name,
+                content: "",
+                byte_count: 0
+            };
+            if existing_variant != null { variant_constant = existing_variant; } else {
+                variant_constant = StringConstant {
+                    name: constant_name,
+                    content: variant_info.name,
+                    byte_count: variant_info.name.length
+                };
                 enum_string_constants = append_string_constant(enum_string_constants, variant_constant);
             }
 
@@ -213,7 +233,10 @@ fn lower_enum_member_access(parse: MemberAccessParse, enum_info: EnumTypeInfo, b
             variant_index += 1;
         }
 
-        let operand = LLVMOperand { llvm_type: "i8*", value: current_pointer };
+        let operand = LLVMOperand {
+            llvm_type: "i8*",
+            value: current_pointer
+        };
         return make_expression_result(current_lines, current_temp, operand, messages, enum_string_constants);
     }
 
@@ -221,27 +244,19 @@ fn lower_enum_member_access(parse: MemberAccessParse, enum_info: EnumTypeInfo, b
     let mut matched_fields: StructFieldInfo[] = [];
     let mut variant_check_index: number = 0;
     loop {
-        if variant_check_index >= enum_info.variants.length {
-            break;
-        }
+        if variant_check_index >= enum_info.variants.length { break; }
         let candidate_variant = enum_info.variants[variant_check_index];
         let candidate_field = find_variant_field_info(candidate_variant, parse.field);
         if candidate_field != null {
             let mut resolved_field = candidate_field;
             if resolved_field.llvm_type.length == 0 {
                 let mut mapped = map_type_annotation(resolved_field.type_annotation);
-                if mapped == "void" {
-                    mapped = "";
-                }
-                if mapped.length == 0 {
-                    mapped = "i8*";
-                }
+                if mapped == "void" { mapped = ""; }
+                if mapped.length == 0 { mapped = "i8*"; }
                 if layout_annotation_represents_user_value(resolved_field.type_annotation) {
                     if ends_with_pointer_suffix(mapped) {
                         let stripped = strip_pointer_suffix(mapped);
-                        if stripped.length > 0 {
-                            mapped = stripped;
-                        }
+                        if stripped.length > 0 { mapped = stripped; }
                     }
                 }
                 resolved_field = StructFieldInfo {
@@ -271,9 +286,7 @@ fn lower_enum_member_access(parse: MemberAccessParse, enum_info: EnumTypeInfo, b
         let mut filtered_fields: StructFieldInfo[] = [];
         let mut selection_index: number = 0;
         loop {
-            if selection_index >= matched_fields.length {
-                break;
-            }
+            if selection_index >= matched_fields.length { break; }
             let candidate_field = matched_fields[selection_index];
             if candidate_field.llvm_type == expected_type {
                 filtered_variants.push(matched_variants[selection_index]);
@@ -300,9 +313,7 @@ fn lower_enum_member_access(parse: MemberAccessParse, enum_info: EnumTypeInfo, b
     let mut base_type: string = first_type;
     let mut first_pointer_depth: number = 0;
     loop {
-        if !ends_with_pointer_suffix(base_type) {
-            break;
-        }
+        if !ends_with_pointer_suffix(base_type) { break; }
         base_type = strip_pointer_suffix(base_type);
         first_pointer_depth += 1;
     }
@@ -313,16 +324,12 @@ fn lower_enum_member_access(parse: MemberAccessParse, enum_info: EnumTypeInfo, b
     let mut pointer_depth_mismatch: boolean = false;
     let mut type_index: number = 1;
     loop {
-        if type_index >= selected_fields.length {
-            break;
-        }
+        if type_index >= selected_fields.length { break; }
         let candidate_type = selected_fields[type_index].llvm_type;
         let mut candidate_base: string = candidate_type;
         let mut candidate_depth: number = 0;
         loop {
-            if !ends_with_pointer_suffix(candidate_base) {
-                break;
-            }
+            if !ends_with_pointer_suffix(candidate_base) { break; }
             candidate_base = strip_pointer_suffix(candidate_base);
             candidate_depth += 1;
         }
@@ -350,18 +357,12 @@ fn lower_enum_member_access(parse: MemberAccessParse, enum_info: EnumTypeInfo, b
     let mut field_type: string = selected_fields[0].llvm_type;
     if field_type.length == 0 {
         let mut mapped = map_type_annotation(selected_fields[0].type_annotation);
-        if mapped == "void" {
-            mapped = "";
-        }
-        if mapped.length == 0 {
-            mapped = "i8*";
-        }
+        if mapped == "void" { mapped = ""; }
+        if mapped.length == 0 { mapped = "i8*"; }
         if layout_annotation_represents_user_value(selected_fields[0].type_annotation) {
             if ends_with_pointer_suffix(mapped) {
                 let stripped = strip_pointer_suffix(mapped);
-                if stripped.length > 0 {
-                    mapped = stripped;
-                }
+                if stripped.length > 0 { mapped = stripped; }
             }
         }
         field_type = mapped;
@@ -371,9 +372,7 @@ fn lower_enum_member_access(parse: MemberAccessParse, enum_info: EnumTypeInfo, b
         let mut _if71: boolean = false;
         if max_pointer_depth - min_pointer_depth == 1 {
             if base_type.length > 0 {
-                if substring(base_type, 0, 1) == "%" {
-                    _if71 = true;
-                }
+                if substring(base_type, 0, 1) == "%" { _if71 = true; }
             }
         }
         if _if71 {
@@ -398,18 +397,14 @@ fn lower_enum_member_access(parse: MemberAccessParse, enum_info: EnumTypeInfo, b
     let mut current_value_text: string = default_literal;
     let mut match_index: number = 0;
     loop {
-        if match_index >= selected_variants.length {
-            break;
-        }
+        if match_index >= selected_variants.length { break; }
         let variant_info = selected_variants[match_index];
         let field_info = selected_fields[match_index];
 
         let payload_ptr_temp = format_temp_name(current_temp);
         let mut payload_field_index: number = 1;
         if enum_info.max_payload_size > 0 {
-            if enum_info.align > enum_info.tag_size {
-                payload_field_index = 2;
-            }
+            if enum_info.align > enum_info.tag_size { payload_field_index = 2; }
         }
         current_lines.push("  " + payload_ptr_temp + " = getelementptr inbounds " + enum_info.llvm_name + ", " + enum_info.llvm_name + "* " + enum_pointer_value + ", i32 0, i32 " + number_to_string(payload_field_index));
         current_temp += 1;
@@ -430,18 +425,12 @@ fn lower_enum_member_access(parse: MemberAccessParse, enum_info: EnumTypeInfo, b
         let mut storage_type = field_info.llvm_type;
         if storage_type.length == 0 {
             let mut mapped = map_type_annotation(field_info.type_annotation);
-            if mapped == "void" {
-                mapped = "";
-            }
-            if mapped.length == 0 {
-                mapped = "i8*";
-            }
+            if mapped == "void" { mapped = ""; }
+            if mapped.length == 0 { mapped = "i8*"; }
             if layout_annotation_represents_user_value(field_info.type_annotation) {
                 if ends_with_pointer_suffix(mapped) {
                     let stripped = strip_pointer_suffix(mapped);
-                    if stripped.length > 0 {
-                        mapped = stripped;
-                    }
+                    if stripped.length > 0 { mapped = stripped; }
                 }
             }
             storage_type = mapped;
@@ -475,7 +464,10 @@ fn lower_enum_member_access(parse: MemberAccessParse, enum_info: EnumTypeInfo, b
         match_index += 1;
     }
 
-    let operand = LLVMOperand { llvm_type: field_type, value: current_value_text };
+    let operand = LLVMOperand {
+        llvm_type: field_type,
+        value: current_value_text
+    };
     return make_expression_result(current_lines, current_temp, operand, messages, enum_string_constants);
 }
 
@@ -484,7 +476,13 @@ fn lower_member_access(parse: MemberAccessParse, bindings: ParameterBinding[], l
     let mut diagnostics: string[] = base_result.diagnostics;
     let mut collected_string_constants: StringConstant[] = base_result.string_constants;
     if base_result.operand == null {
-        return ExpressionResult { lines: base_result.lines, temp_index: base_result.temp_index, operand: null, diagnostics: diagnostics, string_constants: collected_string_constants };
+        return ExpressionResult {
+            lines: base_result.lines,
+            temp_index: base_result.temp_index,
+            operand: null,
+            diagnostics: diagnostics,
+            string_constants: collected_string_constants
+        };
     }
 
     let mut current_lines: string[] = base_result.lines;
@@ -502,13 +500,22 @@ fn lower_member_access(parse: MemberAccessParse, bindings: ParameterBinding[], l
                             let loaded_array = format_temp_name(current_temp);
                             current_lines.push("  " + loaded_array + " = load " + inner_type + ", " + base_operand.llvm_type + " " + base_operand.value);
                             current_temp += 1;
-            
+
                             let length_temp = format_temp_name(current_temp);
                             current_lines.push("  " + length_temp + " = extractvalue " + inner_type + " " + loaded_array + ", 1");
                             current_temp += 1;
-            
-                            let operand = LLVMOperand { llvm_type: "i64", value: length_temp };
-                            return ExpressionResult { lines: current_lines, temp_index: current_temp, operand: operand, diagnostics: diagnostics, string_constants: collected_string_constants };
+
+                            let operand = LLVMOperand {
+                                llvm_type: "i64",
+                                value: length_temp
+                            };
+                            return ExpressionResult {
+                                lines: current_lines,
+                                temp_index: current_temp,
+                                operand: operand,
+                                diagnostics: diagnostics,
+                                string_constants: collected_string_constants
+                            };
                         }
                     }
                 }
@@ -521,8 +528,17 @@ fn lower_member_access(parse: MemberAccessParse, bindings: ParameterBinding[], l
             let length_temp = format_temp_name(current_temp);
             current_lines.push("  " + length_temp + " = call i64 @sailfin_runtime_string_length(i8* " + base_operand.value + ")");
             current_temp += 1;
-            let operand = LLVMOperand { llvm_type: "i64", value: length_temp };
-            return ExpressionResult { lines: current_lines, temp_index: current_temp, operand: operand, diagnostics: diagnostics, string_constants: collected_string_constants };
+            let operand = LLVMOperand {
+                llvm_type: "i64",
+                value: length_temp
+            };
+            return ExpressionResult {
+                lines: current_lines,
+                temp_index: current_temp,
+                operand: operand,
+                diagnostics: diagnostics,
+                string_constants: collected_string_constants
+            };
         }
     }
 
@@ -531,9 +547,7 @@ fn lower_member_access(parse: MemberAccessParse, bindings: ParameterBinding[], l
     let pointer_operand = base_operand;
     let mut base_type_trimmed: string = base_operand.llvm_type;
     loop {
-        if !starts_with(base_type_trimmed, " ") {
-            break;
-        }
+        if !starts_with(base_type_trimmed, " ") { break; }
         base_type_trimmed = substring(base_type_trimmed, 1, base_type_trimmed.length);
     }
 
@@ -547,9 +561,7 @@ fn lower_member_access(parse: MemberAccessParse, bindings: ParameterBinding[], l
             }
             if base_type_trimmed == "i8*" {
                 let _igep_result = lower_inline_gep_field_access(parse.base, parse.field, base_operand, bindings, current_temp, current_lines, diagnostics, collected_string_constants);
-                if _igep_result != null {
-                    return _igep_result;
-                }
+                if _igep_result != null { return _igep_result; }
                 return lower_dynamic_member_access(parse.field, base_operand, current_temp, current_lines, diagnostics, collected_string_constants);
             }
 
@@ -558,7 +570,13 @@ fn lower_member_access(parse: MemberAccessParse, bindings: ParameterBinding[], l
                     diagnostics.push("llvm lowering: member access base `" + base_type_trimmed + "` lacks struct metadata");
                 }
             }
-            return ExpressionResult { lines: current_lines, temp_index: current_temp, operand: null, diagnostics: diagnostics, string_constants: collected_string_constants };
+            return ExpressionResult {
+                lines: current_lines,
+                temp_index: current_temp,
+                operand: null,
+                diagnostics: diagnostics,
+                string_constants: collected_string_constants
+            };
         }
         pointer_available = true;
     } else {
@@ -570,9 +588,7 @@ fn lower_member_access(parse: MemberAccessParse, bindings: ParameterBinding[], l
             }
             if base_type_trimmed == "i8*" {
                 let _igep2_result = lower_inline_gep_field_access(parse.base, parse.field, base_operand, bindings, current_temp, current_lines, diagnostics, collected_string_constants);
-                if _igep2_result != null {
-                    return _igep2_result;
-                }
+                if _igep2_result != null { return _igep2_result; }
                 return lower_dynamic_member_access(parse.field, base_operand, current_temp, current_lines, diagnostics, collected_string_constants);
             }
             if base_type_trimmed != "double" {
@@ -580,7 +596,13 @@ fn lower_member_access(parse: MemberAccessParse, bindings: ParameterBinding[], l
                     diagnostics.push("llvm lowering: member access base `" + base_type_trimmed + "` lacks struct metadata");
                 }
             }
-            return ExpressionResult { lines: current_lines, temp_index: current_temp, operand: null, diagnostics: diagnostics, string_constants: collected_string_constants };
+            return ExpressionResult {
+                lines: current_lines,
+                temp_index: current_temp,
+                operand: null,
+                diagnostics: diagnostics,
+                string_constants: collected_string_constants
+            };
         }
     }
 
@@ -588,7 +610,13 @@ fn lower_member_access(parse: MemberAccessParse, bindings: ParameterBinding[], l
     let field_info = find_struct_field_info(info, parse.field);
     if field_info == null {
         diagnostics.push("llvm lowering: struct `" + info.name + "` has no field `" + parse.field + "`");
-        return ExpressionResult { lines: current_lines, temp_index: current_temp, operand: null, diagnostics: diagnostics, string_constants: collected_string_constants };
+        return ExpressionResult {
+            lines: current_lines,
+            temp_index: current_temp,
+            operand: null,
+            diagnostics: diagnostics,
+            string_constants: collected_string_constants
+        };
     }
 
     if pointer_available {
@@ -608,23 +636,50 @@ fn lower_member_access(parse: MemberAccessParse, bindings: ParameterBinding[], l
                     let cast_name = format_temp_name(current_temp);
                     current_lines.push("  " + cast_name + " = bitcast i8* " + load_name + " to " + enum_info.llvm_name + "*");
                     current_temp += 1;
-                    let typed_operand = LLVMOperand { llvm_type: enum_info.llvm_name + "*", value: cast_name };
-                    return ExpressionResult { lines: current_lines, temp_index: current_temp, operand: typed_operand, diagnostics: diagnostics, string_constants: collected_string_constants };
+                    let typed_operand = LLVMOperand {
+                        llvm_type: enum_info.llvm_name + "*",
+                        value: cast_name
+                    };
+                    return ExpressionResult {
+                        lines: current_lines,
+                        temp_index: current_temp,
+                        operand: typed_operand,
+                        diagnostics: diagnostics,
+                        string_constants: collected_string_constants
+                    };
                 }
-    
+
                 let struct_info_candidate = find_struct_info_by_name(context, base_type);
                 if struct_info_candidate != null {
                     let cast_name = format_temp_name(current_temp);
                     current_lines.push("  " + cast_name + " = bitcast i8* " + load_name + " to " + struct_info_candidate.llvm_name + "*");
                     current_temp += 1;
-                    let typed_operand = LLVMOperand { llvm_type: struct_info_candidate.llvm_name + "*", value: cast_name };
-                    return ExpressionResult { lines: current_lines, temp_index: current_temp, operand: typed_operand, diagnostics: diagnostics, string_constants: collected_string_constants };
+                    let typed_operand = LLVMOperand {
+                        llvm_type: struct_info_candidate.llvm_name + "*",
+                        value: cast_name
+                    };
+                    return ExpressionResult {
+                        lines: current_lines,
+                        temp_index: current_temp,
+                        operand: typed_operand,
+                        diagnostics: diagnostics,
+                        string_constants: collected_string_constants
+                    };
                 }
             }
         }
 
-        let operand = LLVMOperand { llvm_type: field_info.llvm_type, value: load_name };
-        return ExpressionResult { lines: current_lines, temp_index: current_temp, operand: operand, diagnostics: diagnostics, string_constants: collected_string_constants };
+        let operand = LLVMOperand {
+            llvm_type: field_info.llvm_type,
+            value: load_name
+        };
+        return ExpressionResult {
+            lines: current_lines,
+            temp_index: current_temp,
+            operand: operand,
+            diagnostics: diagnostics,
+            string_constants: collected_string_constants
+        };
     }
 
     let extract_name = format_temp_name(current_temp);
@@ -639,23 +694,50 @@ fn lower_member_access(parse: MemberAccessParse, bindings: ParameterBinding[], l
                 let cast_name = format_temp_name(current_temp);
                 current_lines.push("  " + cast_name + " = bitcast i8* " + extract_name + " to " + enum_info.llvm_name + "*");
                 current_temp += 1;
-                let typed_operand = LLVMOperand { llvm_type: enum_info.llvm_name + "*", value: cast_name };
-                return ExpressionResult { lines: current_lines, temp_index: current_temp, operand: typed_operand, diagnostics: diagnostics, string_constants: collected_string_constants };
+                let typed_operand = LLVMOperand {
+                    llvm_type: enum_info.llvm_name + "*",
+                    value: cast_name
+                };
+                return ExpressionResult {
+                    lines: current_lines,
+                    temp_index: current_temp,
+                    operand: typed_operand,
+                    diagnostics: diagnostics,
+                    string_constants: collected_string_constants
+                };
             }
-    
+
             let struct_info_candidate = find_struct_info_by_name(context, base_type);
             if struct_info_candidate != null {
                 let cast_name = format_temp_name(current_temp);
                 current_lines.push("  " + cast_name + " = bitcast i8* " + extract_name + " to " + struct_info_candidate.llvm_name + "*");
                 current_temp += 1;
-                let typed_operand = LLVMOperand { llvm_type: struct_info_candidate.llvm_name + "*", value: cast_name };
-                return ExpressionResult { lines: current_lines, temp_index: current_temp, operand: typed_operand, diagnostics: diagnostics, string_constants: collected_string_constants };
+                let typed_operand = LLVMOperand {
+                    llvm_type: struct_info_candidate.llvm_name + "*",
+                    value: cast_name
+                };
+                return ExpressionResult {
+                    lines: current_lines,
+                    temp_index: current_temp,
+                    operand: typed_operand,
+                    diagnostics: diagnostics,
+                    string_constants: collected_string_constants
+                };
             }
         }
     }
 
-    let operand = LLVMOperand { llvm_type: field_info.llvm_type, value: extract_name };
-    return ExpressionResult { lines: current_lines, temp_index: current_temp, operand: operand, diagnostics: diagnostics, string_constants: collected_string_constants };
+    let operand = LLVMOperand {
+        llvm_type: field_info.llvm_type,
+        value: extract_name
+    };
+    return ExpressionResult {
+        lines: current_lines,
+        temp_index: current_temp,
+        operand: operand,
+        diagnostics: diagnostics,
+        string_constants: collected_string_constants
+    };
 }
 
 // File-based struct field access: when the TypeContext is corrupted (v0.1.1 seed ABI),
@@ -663,10 +745,14 @@ fn lower_member_access(parse: MemberAccessParse, bindings: ParameterBinding[], l
 // instead of sailfin_runtime_get_field.
 fn try_file_based_struct_field_access(base_name: string, field_name: string, base_operand: LLVMOperand, bindings: ParameterBinding[], locals: LocalBinding[], temp_index: number, lines: string[], diagnostics: string[], string_constants: StringConstant[]) -> ExpressionResult ![io] {
     let empty_constants = empty_string_constant_set();
-    let null_result = ExpressionResult { lines: lines, temp_index: temp_index, operand: null, diagnostics: diagnostics, string_constants: string_constants };
-    if !fs.exists("build/sailfin/.struct_info") {
-        return null_result;
-    }
+    let null_result = ExpressionResult {
+        lines: lines,
+        temp_index: temp_index,
+        operand: null,
+        diagnostics: diagnostics,
+        string_constants: string_constants
+    };
+    if !fs.exists("build/sailfin/.struct_info") { return null_result; }
     // Find the struct type annotation for this base from bindings or locals.
     let mut struct_type_ann: string = "";
     let trimmed_base = trim_text(base_name);
@@ -750,14 +836,10 @@ fn try_file_based_struct_field_access(base_name: string, field_name: string, bas
             }
         }
     }
-    if struct_type_ann.length == 0 {
-        return null_result;
-    }
+    if struct_type_ann.length == 0 { return null_result; }
     // Look up struct in .struct_info
     let _si_raw = fs.readFile("build/sailfin/.struct_info");
-    if _si_raw.length == 0 {
-        return null_result;
-    }
+    if _si_raw.length == 0 { return null_result; }
     let mut _si_llvm: string = "";
     let mut _si_field_idx: number = -1;
     let mut _si_field_type: string = "";
@@ -798,7 +880,10 @@ fn try_file_based_struct_field_access(base_name: string, field_name: string, bas
                 _fpos = _fpos + _fcomma + 1;
             }
             let _fcolon = index_of(_fentry, ":");
-            if _fcolon < 0 { _fi += 1; continue; }
+            if _fcolon < 0 {
+                _fi += 1;
+                continue;
+            }
             let _fname = substring(_fentry, 0, _fcolon);
             let _ftype = substring(_fentry, _fcolon + 1, _fentry.length);
             if _fname == field_name {
@@ -814,9 +899,7 @@ fn try_file_based_struct_field_access(base_name: string, field_name: string, bas
     if _si_llvm.length == 0 { _if72 = true; }
     if _si_field_idx < 0 { _if72 = true; }
     if _si_field_type.length == 0 { _if72 = true; }
-    if _if72 {
-        return null_result;
-    }
+    if _if72 { return null_result; }
     // Emit: bitcast i8* to %Struct*, then GEP, then load
     let mut _out_lines = lines;
     let mut _out_temp = temp_index;
@@ -831,7 +914,13 @@ fn try_file_based_struct_field_access(base_name: string, field_name: string, bas
     _out_lines.push("  " + load_temp + " = load " + _si_field_type + ", " + field_ptr_type + " " + gep_temp);
     _out_temp += 1;
     let operand = LLVMOperand { llvm_type: _si_field_type, value: load_temp };
-    return ExpressionResult { lines: _out_lines, temp_index: _out_temp, operand: operand, diagnostics: diagnostics, string_constants: string_constants };
+    return ExpressionResult {
+        lines: _out_lines,
+        temp_index: _out_temp,
+        operand: operand,
+        diagnostics: diagnostics,
+        string_constants: string_constants
+    };
 }
 
 export {

--- a/compiler/src/llvm/expression_lowering/native/core_member_lowering.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_member_lowering.sfn
@@ -7,7 +7,7 @@ import { default_return_literal, format_temp_name } from "../../expressions_help
 import {
     append_string_constant,
     empty_string_constant_set,
-    find_string_constant_by_name,
+    find_string_constant_by_name
 } from "../../strings";
 import {
     find_enum_info_by_llvm_type,
@@ -16,14 +16,14 @@ import {
     find_struct_info_by_llvm_type,
     find_struct_info_by_name,
     find_variant_field_info,
-    resolve_enum_info_for_literal,
+    resolve_enum_info_for_literal
 } from "../../type_context_queries";
 import {
     ends_with_pointer_suffix,
     layout_annotation_base_type,
     layout_annotation_represents_user_value,
     map_type_annotation,
-    strip_pointer_suffix,
+    strip_pointer_suffix
 } from "../../type_mapping";
 import {
     EnumTypeInfo,
@@ -37,14 +37,14 @@ import {
     StringPointerResult,
     StructFieldInfo,
     StructTypeInfo,
-    TypeContext,
+    TypeContext
 } from "../../types";
 import {
     append_string,
     contains_text,
     number_to_string,
     starts_with,
-    trim_text,
+    trim_text
 } from "../../utils";
 // Mutually recursive with core.sfn
 import { lower_expression } from "./core";
@@ -57,7 +57,7 @@ fn make_expression_result(lines: string[], temp_index: number, operand: LLVMOper
         temp_index: temp_index,
         operand: operand,
         diagnostics: diagnostics,
-        string_constants: string_constants,
+        string_constants: string_constants
     };
 }
 
@@ -66,7 +66,13 @@ fn emit_string_constant_pointer(constant: StringConstant, temp_index: number, li
     let array_length = constant.byte_count + 1;
     let array_type = "[" + number_to_string(array_length) + " x i8]";
     let temp_name = format_temp_name(temp_index);
-    current_lines.push("  " + temp_name + " = getelementptr inbounds " + array_type + ", " + array_type + "* " + constant.name + ", i32 0, i32 0");
+    current_lines.push("  " + temp_name + " = getelementptr inbounds "
+        + array_type
+        + ", "
+        + array_type
+        + "* "
+        + constant.name
+        + ", i32 0, i32 0");
     return StringPointerResult {
         lines: current_lines,
         temp_index: temp_index + 1,
@@ -100,7 +106,12 @@ fn lower_dynamic_member_access(field: string, base_operand: LLVMOperand, temp_in
     let field_pointer = pointer_result.pointer;
 
     let call_temp = format_temp_name(current_temp);
-    current_lines.push("  " + call_temp + " = call i8* @sailfin_runtime_get_field(i8* " + base_operand.value + ", i8* " + field_pointer + ")");
+    current_lines.push("  " + call_temp
+        + " = call i8* @sailfin_runtime_get_field(i8* "
+        + base_operand.value
+        + ", i8* "
+        + field_pointer
+        + ")");
     current_temp += 1;
 
     let mut _if70: boolean = false;
@@ -116,7 +127,10 @@ fn lower_dynamic_member_access(field: string, base_operand: LLVMOperand, temp_in
     if field == "length" { _if70 = true; }
     if _if70 {
         let number_temp = format_temp_name(current_temp);
-        current_lines.push("  " + number_temp + " = call double @sailfin_runtime_string_to_number(i8* " + call_temp + ")");
+        current_lines.push("  " + number_temp
+            + " = call double @sailfin_runtime_string_to_number(i8* "
+            + call_temp
+            + ")");
         current_temp += 1;
         let operand = LLVMOperand { llvm_type: "double", value: number_temp };
         return make_expression_result(current_lines, current_temp, operand, diagnostics, dynamic_string_constants);
@@ -153,10 +167,20 @@ fn lower_enum_member_access(parse: MemberAccessParse, enum_info: EnumTypeInfo, b
     };
     if pointer_available {
         let tag_ptr = format_temp_name(current_temp);
-        current_lines.push("  " + tag_ptr + " = getelementptr inbounds " + enum_info.llvm_name + ", " + enum_info.llvm_name + "* " + base_operand.value + ", i32 0, i32 0");
+        current_lines.push("  " + tag_ptr + " = getelementptr inbounds "
+            + enum_info.llvm_name
+            + ", "
+            + enum_info.llvm_name
+            + "* "
+            + base_operand.value
+            + ", i32 0, i32 0");
         current_temp += 1;
         let tag_temp = format_temp_name(current_temp);
-        current_lines.push("  " + tag_temp + " = load " + enum_info.tag_type + ", " + enum_info.tag_type + "* " + tag_ptr);
+        current_lines.push("  " + tag_temp + " = load " + enum_info.tag_type
+            + ", "
+            + enum_info.tag_type
+            + "* "
+            + tag_ptr);
         current_temp += 1;
         tag_operand = LLVMOperand {
             llvm_type: enum_info.tag_type,
@@ -164,7 +188,10 @@ fn lower_enum_member_access(parse: MemberAccessParse, enum_info: EnumTypeInfo, b
         };
     } else {
         let tag_temp = format_temp_name(current_temp);
-        current_lines.push("  " + tag_temp + " = extractvalue " + enum_info.llvm_name + " " + base_operand.value + ", 0");
+        current_lines.push("  " + tag_temp + " = extractvalue " + enum_info.llvm_name
+            + " "
+            + base_operand.value
+            + ", 0");
         current_temp += 1;
         tag_operand = LLVMOperand {
             llvm_type: enum_info.tag_type,
@@ -174,7 +201,8 @@ fn lower_enum_member_access(parse: MemberAccessParse, enum_info: EnumTypeInfo, b
 
     if parse.field == "variant" {
         let sanitized_enum = sanitize_symbol(enum_info.name);
-        let default_constant_name = "@.enum." + sanitized_enum + ".variant.default";
+        let default_constant_name = "@.enum." + sanitized_enum
+            + ".variant.default";
         let existing_default = find_string_constant_by_name(enum_string_constants, default_constant_name);
         let mut default_constant: StringConstant = StringConstant {
             name: default_constant_name,
@@ -200,7 +228,9 @@ fn lower_enum_member_access(parse: MemberAccessParse, enum_info: EnumTypeInfo, b
             if variant_index >= enum_info.variants.length { break; }
             let variant_info = enum_info.variants[variant_index];
             let sanitized_variant = sanitize_symbol(variant_info.name);
-            let constant_name = "@.enum." + sanitized_enum + "." + sanitized_variant + ".variant";
+            let constant_name = "@.enum." + sanitized_enum + "."
+                + sanitized_variant
+                + ".variant";
             let existing_variant = find_string_constant_by_name(enum_string_constants, constant_name);
             let mut variant_constant: StringConstant = StringConstant {
                 name: constant_name,
@@ -222,11 +252,20 @@ fn lower_enum_member_access(parse: MemberAccessParse, enum_info: EnumTypeInfo, b
             let variant_pointer = pointer_result.pointer;
 
             let compare_temp = format_temp_name(current_temp);
-            current_lines.push("  " + compare_temp + " = icmp eq " + tag_operand.llvm_type + " " + tag_operand.value + ", " + number_to_string(variant_info.tag));
+            current_lines.push("  " + compare_temp + " = icmp eq " + tag_operand.llvm_type
+                + " "
+                + tag_operand.value
+                + ", "
+                + number_to_string(variant_info.tag));
             current_temp += 1;
 
             let select_temp = format_temp_name(current_temp);
-            current_lines.push("  " + select_temp + " = select i1 " + compare_temp + ", i8* " + variant_pointer + ", i8* " + current_pointer);
+            current_lines.push("  " + select_temp + " = select i1 "
+                + compare_temp
+                + ", i8* "
+                + variant_pointer
+                + ", i8* "
+                + current_pointer);
             current_temp += 1;
 
             current_pointer = select_temp;
@@ -264,7 +303,7 @@ fn lower_enum_member_access(parse: MemberAccessParse, enum_info: EnumTypeInfo, b
                     llvm_type: mapped,
                     type_annotation: resolved_field.type_annotation,
                     index: resolved_field.index,
-                    offset: resolved_field.offset,
+                    offset: resolved_field.offset
                 };
             }
             matched_variants.push(candidate_variant);
@@ -274,7 +313,10 @@ fn lower_enum_member_access(parse: MemberAccessParse, enum_info: EnumTypeInfo, b
     }
 
     if matched_variants.length == 0 {
-        messages.push("llvm lowering: enum `" + enum_info.name + "` has no field `" + parse.field + "` on any variant");
+        messages.push("llvm lowering: enum `" + enum_info.name
+            + "` has no field `"
+            + parse.field
+            + "` on any variant");
         return make_expression_result(current_lines, current_temp, null, messages, enum_string_constants);
     }
 
@@ -302,9 +344,17 @@ fn lower_enum_member_access(parse: MemberAccessParse, enum_info: EnumTypeInfo, b
 
     if selected_variants.length == 0 {
         if expected_type.length > 0 {
-            messages.push("llvm lowering: enum `" + enum_info.name + "` has no field `" + parse.field + "` compatible with expected type `" + expected_type + "`");
+            messages.push("llvm lowering: enum `" + enum_info.name
+                + "` has no field `"
+                + parse.field
+                + "` compatible with expected type `"
+                + expected_type
+                + "`");
         } else {
-            messages.push("llvm lowering: enum member access for `" + enum_info.name + "." + parse.field + "` uses incompatible field types across variants");
+            messages.push("llvm lowering: enum member access for `" + enum_info.name
+                + "."
+                + parse.field
+                + "` uses incompatible field types across variants");
         }
         return make_expression_result(current_lines, current_temp, null, messages, enum_string_constants);
     }
@@ -350,7 +400,10 @@ fn lower_enum_member_access(parse: MemberAccessParse, enum_info: EnumTypeInfo, b
     }
 
     if !consistent_base {
-        messages.push("llvm lowering: enum member access for `" + enum_info.name + "." + parse.field + "` uses incompatible field types across variants");
+        messages.push("llvm lowering: enum member access for `" + enum_info.name
+            + "."
+            + parse.field
+            + "` uses incompatible field types across variants");
         return make_expression_result(current_lines, current_temp, null, messages, enum_string_constants);
     }
 
@@ -379,7 +432,10 @@ fn lower_enum_member_access(parse: MemberAccessParse, enum_info: EnumTypeInfo, b
             pointer_coercion = true;
             field_type = base_type + "*";
         } else {
-            messages.push("llvm lowering: enum member access for `" + enum_info.name + "." + parse.field + "` uses incompatible field types across variants");
+            messages.push("llvm lowering: enum member access for `" + enum_info.name
+                + "."
+                + parse.field
+                + "` uses incompatible field types across variants");
             return make_expression_result(current_lines, current_temp, null, messages, enum_string_constants);
         }
     }
@@ -389,7 +445,11 @@ fn lower_enum_member_access(parse: MemberAccessParse, enum_info: EnumTypeInfo, b
         let alloca_temp = format_temp_name(current_temp);
         current_lines.push("  " + alloca_temp + " = alloca " + enum_info.llvm_name);
         current_temp += 1;
-        current_lines.push("  store " + enum_info.llvm_name + " " + base_operand.value + ", " + enum_info.llvm_name + "* " + alloca_temp);
+        current_lines.push("  store " + enum_info.llvm_name + " " + base_operand.value
+            + ", "
+            + enum_info.llvm_name
+            + "* "
+            + alloca_temp);
         enum_pointer_value = alloca_temp;
     }
 
@@ -406,18 +466,32 @@ fn lower_enum_member_access(parse: MemberAccessParse, enum_info: EnumTypeInfo, b
         if enum_info.max_payload_size > 0 {
             if enum_info.align > enum_info.tag_size { payload_field_index = 2; }
         }
-        current_lines.push("  " + payload_ptr_temp + " = getelementptr inbounds " + enum_info.llvm_name + ", " + enum_info.llvm_name + "* " + enum_pointer_value + ", i32 0, i32 " + number_to_string(payload_field_index));
+        current_lines.push("  " + payload_ptr_temp
+            + " = getelementptr inbounds "
+            + enum_info.llvm_name
+            + ", "
+            + enum_info.llvm_name
+            + "* "
+            + enum_pointer_value
+            + ", i32 0, i32 "
+            + number_to_string(payload_field_index));
         current_temp += 1;
 
         let byte_ptr_temp = format_temp_name(current_temp);
-        current_lines.push("  " + byte_ptr_temp + " = bitcast ptr " + payload_ptr_temp + " to ptr");
+        current_lines.push("  " + byte_ptr_temp + " = bitcast ptr "
+            + payload_ptr_temp
+            + " to ptr");
         current_temp += 1;
 
         let field_offset_in_payload = field_info.offset - variant_info.offset;
         let mut field_ptr_temp: string = byte_ptr_temp;
         if field_offset_in_payload > 0 {
             let offset_ptr_temp = format_temp_name(current_temp);
-            current_lines.push("  " + offset_ptr_temp + " = getelementptr inbounds i8, ptr " + byte_ptr_temp + ", i64 " + number_to_string(field_offset_in_payload));
+            current_lines.push("  " + offset_ptr_temp
+                + " = getelementptr inbounds i8, ptr "
+                + byte_ptr_temp
+                + ", i64 "
+                + number_to_string(field_offset_in_payload));
             current_temp += 1;
             field_ptr_temp = offset_ptr_temp;
         }
@@ -436,28 +510,46 @@ fn lower_enum_member_access(parse: MemberAccessParse, enum_info: EnumTypeInfo, b
             storage_type = mapped;
         }
         let typed_ptr_temp = format_temp_name(current_temp);
-        current_lines.push("  " + typed_ptr_temp + " = bitcast ptr " + field_ptr_temp + " to ptr");
+        current_lines.push("  " + typed_ptr_temp + " = bitcast ptr "
+            + field_ptr_temp
+            + " to ptr");
         current_temp += 1;
 
         let mut value_temp: string = typed_ptr_temp;
         if pointer_coercion {
             if ends_with_pointer_suffix(storage_type) {
                 value_temp = format_temp_name(current_temp);
-                current_lines.push("  " + value_temp + " = load " + storage_type + ", ptr " + typed_ptr_temp);
+                current_lines.push("  " + value_temp + " = load " + storage_type
+                    + ", ptr "
+                    + typed_ptr_temp);
                 current_temp += 1;
             }
         } else {
             value_temp = format_temp_name(current_temp);
-            current_lines.push("  " + value_temp + " = load " + storage_type + ", ptr " + typed_ptr_temp);
+            current_lines.push("  " + value_temp + " = load " + storage_type
+                + ", ptr "
+                + typed_ptr_temp);
             current_temp += 1;
         }
 
         let compare_temp = format_temp_name(current_temp);
-        current_lines.push("  " + compare_temp + " = icmp eq " + tag_operand.llvm_type + " " + tag_operand.value + ", " + number_to_string(variant_info.tag));
+        current_lines.push("  " + compare_temp + " = icmp eq " + tag_operand.llvm_type
+            + " "
+            + tag_operand.value
+            + ", "
+            + number_to_string(variant_info.tag));
         current_temp += 1;
 
         let select_temp = format_temp_name(current_temp);
-        current_lines.push("  " + select_temp + " = select i1 " + compare_temp + ", " + field_type + " " + value_temp + ", " + field_type + " " + current_value_text);
+        current_lines.push("  " + select_temp + " = select i1 " + compare_temp
+            + ", "
+            + field_type
+            + " "
+            + value_temp
+            + ", "
+            + field_type
+            + " "
+            + current_value_text);
         current_temp += 1;
 
         current_value_text = select_temp;
@@ -498,11 +590,21 @@ fn lower_member_access(parse: MemberAccessParse, bindings: ParameterBinding[], l
                         let struct_inner = trim_text(substring(inner_type, 1, inner_type.length - 1));
                         if contains_text(struct_inner, ", i64") {
                             let loaded_array = format_temp_name(current_temp);
-                            current_lines.push("  " + loaded_array + " = load " + inner_type + ", " + base_operand.llvm_type + " " + base_operand.value);
+                            current_lines.push("  " + loaded_array + " = load "
+                                + inner_type
+                                + ", "
+                                + base_operand.llvm_type
+                                + " "
+                                + base_operand.value);
                             current_temp += 1;
 
                             let length_temp = format_temp_name(current_temp);
-                            current_lines.push("  " + length_temp + " = extractvalue " + inner_type + " " + loaded_array + ", 1");
+                            current_lines.push("  " + length_temp
+                                + " = extractvalue "
+                                + inner_type
+                                + " "
+                                + loaded_array
+                                + ", 1");
                             current_temp += 1;
 
                             let operand = LLVMOperand {
@@ -526,7 +628,10 @@ fn lower_member_access(parse: MemberAccessParse, bindings: ParameterBinding[], l
     if parse.field == "length" {
         if base_operand.llvm_type == "i8*" {
             let length_temp = format_temp_name(current_temp);
-            current_lines.push("  " + length_temp + " = call i64 @sailfin_runtime_string_length(i8* " + base_operand.value + ")");
+            current_lines.push("  " + length_temp
+                + " = call i64 @sailfin_runtime_string_length(i8* "
+                + base_operand.value
+                + ")");
             current_temp += 1;
             let operand = LLVMOperand {
                 llvm_type: "i64",
@@ -567,7 +672,9 @@ fn lower_member_access(parse: MemberAccessParse, bindings: ParameterBinding[], l
 
             if base_type_trimmed != "double" {
                 if base_type_trimmed != "i8" {
-                    diagnostics.push("llvm lowering: member access base `" + base_type_trimmed + "` lacks struct metadata");
+                    diagnostics.push("llvm lowering: member access base `"
+                        + base_type_trimmed
+                        + "` lacks struct metadata");
                 }
             }
             return ExpressionResult {
@@ -593,7 +700,9 @@ fn lower_member_access(parse: MemberAccessParse, bindings: ParameterBinding[], l
             }
             if base_type_trimmed != "double" {
                 if base_type_trimmed != "i8" {
-                    diagnostics.push("llvm lowering: member access base `" + base_type_trimmed + "` lacks struct metadata");
+                    diagnostics.push("llvm lowering: member access base `"
+                        + base_type_trimmed
+                        + "` lacks struct metadata");
                 }
             }
             return ExpressionResult {
@@ -609,7 +718,10 @@ fn lower_member_access(parse: MemberAccessParse, bindings: ParameterBinding[], l
     let info = struct_info;
     let field_info = find_struct_field_info(info, parse.field);
     if field_info == null {
-        diagnostics.push("llvm lowering: struct `" + info.name + "` has no field `" + parse.field + "`");
+        diagnostics.push("llvm lowering: struct `" + info.name
+            + "` has no field `"
+            + parse.field
+            + "`");
         return ExpressionResult {
             lines: current_lines,
             temp_index: current_temp,
@@ -622,10 +734,20 @@ fn lower_member_access(parse: MemberAccessParse, bindings: ParameterBinding[], l
     if pointer_available {
         let struct_type = info.llvm_name;
         let gep_name = format_temp_name(current_temp);
-        current_lines.push("  " + gep_name + " = getelementptr " + struct_type + ", " + struct_type + "* " + pointer_operand.value + ", i32 0, i32 " + number_to_string(field_info.index));
+        current_lines.push("  " + gep_name + " = getelementptr " + struct_type
+            + ", "
+            + struct_type
+            + "* "
+            + pointer_operand.value
+            + ", i32 0, i32 "
+            + number_to_string(field_info.index));
         current_temp += 1;
         let load_name = format_temp_name(current_temp);
-        current_lines.push("  " + load_name + " = load " + field_info.llvm_type + ", " + field_info.llvm_type + "* " + gep_name);
+        current_lines.push("  " + load_name + " = load " + field_info.llvm_type
+            + ", "
+            + field_info.llvm_type
+            + "* "
+            + gep_name);
         current_temp += 1;
 
         if field_info.llvm_type == "i8*" {
@@ -634,7 +756,11 @@ fn lower_member_access(parse: MemberAccessParse, bindings: ParameterBinding[], l
                 let enum_info = resolve_enum_info_for_literal(context, base_type);
                 if enum_info != null {
                     let cast_name = format_temp_name(current_temp);
-                    current_lines.push("  " + cast_name + " = bitcast i8* " + load_name + " to " + enum_info.llvm_name + "*");
+                    current_lines.push("  " + cast_name + " = bitcast i8* "
+                        + load_name
+                        + " to "
+                        + enum_info.llvm_name
+                        + "*");
                     current_temp += 1;
                     let typed_operand = LLVMOperand {
                         llvm_type: enum_info.llvm_name + "*",
@@ -652,7 +778,11 @@ fn lower_member_access(parse: MemberAccessParse, bindings: ParameterBinding[], l
                 let struct_info_candidate = find_struct_info_by_name(context, base_type);
                 if struct_info_candidate != null {
                     let cast_name = format_temp_name(current_temp);
-                    current_lines.push("  " + cast_name + " = bitcast i8* " + load_name + " to " + struct_info_candidate.llvm_name + "*");
+                    current_lines.push("  " + cast_name + " = bitcast i8* "
+                        + load_name
+                        + " to "
+                        + struct_info_candidate.llvm_name
+                        + "*");
                     current_temp += 1;
                     let typed_operand = LLVMOperand {
                         llvm_type: struct_info_candidate.llvm_name + "*",
@@ -683,7 +813,11 @@ fn lower_member_access(parse: MemberAccessParse, bindings: ParameterBinding[], l
     }
 
     let extract_name = format_temp_name(current_temp);
-    current_lines.push("  " + extract_name + " = extractvalue " + info.llvm_name + " " + base_operand.value + ", " + number_to_string(field_info.index));
+    current_lines.push("  " + extract_name + " = extractvalue " + info.llvm_name
+        + " "
+        + base_operand.value
+        + ", "
+        + number_to_string(field_info.index));
     current_temp += 1;
 
     if field_info.llvm_type == "i8*" {
@@ -692,7 +826,11 @@ fn lower_member_access(parse: MemberAccessParse, bindings: ParameterBinding[], l
             let enum_info = resolve_enum_info_for_literal(context, base_type);
             if enum_info != null {
                 let cast_name = format_temp_name(current_temp);
-                current_lines.push("  " + cast_name + " = bitcast i8* " + extract_name + " to " + enum_info.llvm_name + "*");
+                current_lines.push("  " + cast_name + " = bitcast i8* "
+                    + extract_name
+                    + " to "
+                    + enum_info.llvm_name
+                    + "*");
                 current_temp += 1;
                 let typed_operand = LLVMOperand {
                     llvm_type: enum_info.llvm_name + "*",
@@ -710,7 +848,11 @@ fn lower_member_access(parse: MemberAccessParse, bindings: ParameterBinding[], l
             let struct_info_candidate = find_struct_info_by_name(context, base_type);
             if struct_info_candidate != null {
                 let cast_name = format_temp_name(current_temp);
-                current_lines.push("  " + cast_name + " = bitcast i8* " + extract_name + " to " + struct_info_candidate.llvm_name + "*");
+                current_lines.push("  " + cast_name + " = bitcast i8* "
+                    + extract_name
+                    + " to "
+                    + struct_info_candidate.llvm_name
+                    + "*");
                 current_temp += 1;
                 let typed_operand = LLVMOperand {
                     llvm_type: struct_info_candidate.llvm_name + "*",
@@ -815,7 +957,8 @@ fn try_file_based_struct_field_access(base_name: string, field_name: string, bas
                             _sf_line = substring(_sf_raw, _sf_pos, _sf_raw.length);
                             _sf_pos = _sf_raw.length;
                         } else {
-                            _sf_line = substring(_sf_raw, _sf_pos, _sf_pos + _sf_nl);
+                            _sf_line = substring(_sf_raw, _sf_pos, _sf_pos
+                                + _sf_nl);
                             _sf_pos = _sf_pos + _sf_nl + 1;
                         }
                         if _sf_line.length == 0 { continue; }
@@ -904,14 +1047,26 @@ fn try_file_based_struct_field_access(base_name: string, field_name: string, bas
     let mut _out_lines = lines;
     let mut _out_temp = temp_index;
     let cast_temp = format_temp_name(_out_temp);
-    _out_lines.push("  " + cast_temp + " = bitcast i8* " + base_operand.value + " to " + _si_llvm + "*");
+    _out_lines.push("  " + cast_temp + " = bitcast i8* " + base_operand.value
+        + " to "
+        + _si_llvm
+        + "*");
     _out_temp += 1;
     let gep_temp = format_temp_name(_out_temp);
-    _out_lines.push("  " + gep_temp + " = getelementptr inbounds " + _si_llvm + ", " + _si_llvm + "* " + cast_temp + ", i32 0, i32 " + number_to_string(_si_field_idx));
+    _out_lines.push("  " + gep_temp + " = getelementptr inbounds " + _si_llvm
+        + ", "
+        + _si_llvm
+        + "* "
+        + cast_temp
+        + ", i32 0, i32 "
+        + number_to_string(_si_field_idx));
     _out_temp += 1;
     let load_temp = format_temp_name(_out_temp);
     let field_ptr_type = _si_field_type + "*";
-    _out_lines.push("  " + load_temp + " = load " + _si_field_type + ", " + field_ptr_type + " " + gep_temp);
+    _out_lines.push("  " + load_temp + " = load " + _si_field_type + ", "
+        + field_ptr_type
+        + " "
+        + gep_temp);
     _out_temp += 1;
     let operand = LLVMOperand { llvm_type: _si_field_type, value: load_temp };
     return ExpressionResult {
@@ -927,5 +1082,5 @@ export {
     lower_member_access,
     lower_dynamic_member_access,
     lower_enum_member_access,
-    lower_runtime_global_reference,
+    lower_runtime_global_reference
 };

--- a/compiler/src/llvm/expression_lowering/native/core_operands.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_operands.sfn
@@ -6,41 +6,28 @@
 // `harmonise_operands`), emits comparison instructions for equality and
 // relational operators (`emit_comparison_instruction`, `emit_boolean_and`),
 // and provides local variable loading (`load_local_operand`).
-
 import { char_code } from "../../../string_utils";
-
+import { default_return_literal, format_temp_name, } from "../../expressions_helpers";
+import { ends_with_pointer_suffix, strip_pointer_suffix, } from "../../type_mapping";
 import {
-    number_to_string,
-    trim_text,
+    BinaryAlignmentResult,
+    CoercionResult,
+    ComparisonEmission,
+    LLVMOperand,
+    LoadLocalResult,
+    LocalBinding,
+} from "../../types";
+import { starts_with } from "../../utils";
+import { array_pointer_element_type } from "../arrays";
+import {
     append_string,
     char_code_at_text,
-    is_union_llvm_type,
-    parse_union_payload_types,
     find_substring_from,
+    is_union_llvm_type,
+    number_to_string,
+    parse_union_payload_types,
+    trim_text,
 } from "./core_text";
-
-import { starts_with } from "../../utils";
-
-import {
-    ends_with_pointer_suffix,
-    strip_pointer_suffix,
-} from "../../type_mapping";
-
-import {
-    format_temp_name,
-    default_return_literal,
-} from "../../expressions_helpers";
-
-import { array_pointer_element_type } from "../arrays";
-
-import {
-    LocalBinding,
-    LLVMOperand,
-    ComparisonEmission,
-    LoadLocalResult,
-    CoercionResult,
-    BinaryAlignmentResult,
-} from "../../types";
 
 fn emit_comparison_instruction(symbol: string, left_operand: LLVMOperand, right_operand: LLVMOperand, temp_index: number, lines: string[]) -> ComparisonEmission {
     let mut diagnostics: string[] = [];
@@ -52,9 +39,7 @@ fn emit_comparison_instruction(symbol: string, left_operand: LLVMOperand, right_
     let mut _if73: boolean = false;
     if symbol == "==" { _if73 = true; }
     if symbol == "!=" { _if73 = true; }
-    if _if73 {
-        symbol_is_equality = true;
-    }
+    if _if73 { symbol_is_equality = true; }
     let left_is_string = is_string_pointer_type(left_operand.llvm_type);
     let right_is_string = is_string_pointer_type(right_operand.llvm_type);
     let left_is_null = left_operand.value == "null";
@@ -67,14 +52,25 @@ fn emit_comparison_instruction(symbol: string, left_operand: LLVMOperand, right_
                         let compare_temp = format_temp_name(temp_index);
                         current_lines.push("  " + compare_temp + " = call i1 @strings_equal(i8* " + left_operand.value + ", i8* " + right_operand.value + ")");
                         let mut next_index = temp_index + 1;
-                        let mut operand = LLVMOperand { llvm_type: "i1", value: compare_temp };
+                        let mut operand = LLVMOperand {
+                            llvm_type: "i1",
+                            value: compare_temp
+                        };
                         if symbol == "!=" {
                             let inverted_temp = format_temp_name(next_index);
                             current_lines.push("  " + inverted_temp + " = xor i1 " + compare_temp + ", true");
-                            operand = LLVMOperand { llvm_type: "i1", value: inverted_temp };
+                            operand = LLVMOperand {
+                                llvm_type: "i1",
+                                value: inverted_temp
+                            };
                             next_index += 1;
                         }
-                        return ComparisonEmission { lines: current_lines, temp_index: next_index, operand: operand, diagnostics: diagnostics };
+                        return ComparisonEmission {
+                            lines: current_lines,
+                            temp_index: next_index,
+                            operand: operand,
+                            diagnostics: diagnostics
+                        };
                     }
                 }
             }
@@ -84,12 +80,22 @@ fn emit_comparison_instruction(symbol: string, left_operand: LLVMOperand, right_
     let predicate = comparison_predicate_for_symbol(symbol, llvm_type);
     if predicate.length == 0 {
         diagnostics.push("llvm lowering: unsupported comparison operator `" + symbol + "` for type `" + llvm_type + "`");
-        return ComparisonEmission { lines: current_lines, temp_index: temp_index, operand: null, diagnostics: diagnostics };
+        return ComparisonEmission {
+            lines: current_lines,
+            temp_index: temp_index,
+            operand: null,
+            diagnostics: diagnostics
+        };
     }
     let temp_name = format_temp_name(temp_index);
     current_lines.push("  " + temp_name + " = " + predicate + " " + llvm_type + " " + left_operand.value + ", " + right_operand.value);
     let operand = LLVMOperand { llvm_type: "i1", value: temp_name };
-    return ComparisonEmission { lines: current_lines, temp_index: temp_index + 1, operand: operand, diagnostics: diagnostics };
+    return ComparisonEmission {
+        lines: current_lines,
+        temp_index: temp_index + 1,
+        operand: operand,
+        diagnostics: diagnostics
+    };
 }
 
 fn emit_boolean_and(left_operand: LLVMOperand, right_operand: LLVMOperand, temp_index: number, lines: string[]) -> ComparisonEmission {
@@ -104,7 +110,12 @@ fn emit_boolean_and(left_operand: LLVMOperand, right_operand: LLVMOperand, temp_
     let temp_name = format_temp_name(temp_index);
     current_lines.push("  " + temp_name + " = and i1 " + left_operand.value + ", " + right_operand.value);
     let operand = LLVMOperand { llvm_type: "i1", value: temp_name };
-    return ComparisonEmission { lines: current_lines, temp_index: temp_index + 1, operand: operand, diagnostics: diagnostics };
+    return ComparisonEmission {
+        lines: current_lines,
+        temp_index: temp_index + 1,
+        operand: operand,
+        diagnostics: diagnostics
+    };
 }
 
 fn comparison_predicate_for_symbol(symbol: string, llvm_type: string) -> string {
@@ -161,9 +172,7 @@ fn comparison_predicate_for_symbol(symbol: string, llvm_type: string) -> string 
 }
 
 fn is_string_pointer_type(llvm_type: string) -> boolean {
-    if llvm_type == "i8*" {
-        return true;
-    }
+    if llvm_type == "i8*" { return true; }
     return false;
 }
 
@@ -172,8 +181,16 @@ fn load_local_operand(local: LocalBinding, temp_index: number, lines: string[]) 
     let load_name = format_temp_name(temp_index);
     let mut current_lines: string[] = lines;
     current_lines.push("  " + load_name + " = load " + local.llvm_type + ", " + local.llvm_type + "* " + local.pointer);
-    let operand = LLVMOperand { llvm_type: local.llvm_type, value: load_name };
-    return LoadLocalResult { lines: current_lines, temp_index: temp_index + 1, operand: operand, diagnostics: diagnostics };
+    let operand = LLVMOperand {
+        llvm_type: local.llvm_type,
+        value: load_name
+    };
+    return LoadLocalResult {
+        lines: current_lines,
+        temp_index: temp_index + 1,
+        operand: operand,
+        diagnostics: diagnostics
+    };
 }
 
 // Collapse runs of consecutive spaces to a single space inside LLVM type strings.
@@ -183,9 +200,7 @@ fn collapse_type_spaces(value: string) -> string {
     let mut result = value;
     loop {
         let idx = find_substring_from(result, "  ", 0);
-        if idx < 0 {
-            break;
-        }
+        if idx < 0 { break; }
         result = substring(result, 0, idx) + " " + substring(result, idx + 2, result.length);
     }
     return result;
@@ -201,40 +216,80 @@ fn coerce_numeric_primitive(operand: LLVMOperand, operand_type: string, target: 
         if operand_type == "i64" {
             let temp_name = format_temp_name(temp_index);
             current_lines.push("  " + temp_name + " = sitofp i64 " + operand.value + " to double");
-            let coerced = LLVMOperand { llvm_type: "double", value: temp_name };
-            return CoercionResult { lines: current_lines, temp_index: temp_index + 1, operand: coerced, diagnostics: diagnostics };
+            let coerced = LLVMOperand {
+                llvm_type: "double",
+                value: temp_name
+            };
+            return CoercionResult {
+                lines: current_lines,
+                temp_index: temp_index + 1,
+                operand: coerced,
+                diagnostics: diagnostics
+            };
         }
     }
     if target == "double" {
         if operand_type == "i32" {
             let temp_name = format_temp_name(temp_index);
             current_lines.push("  " + temp_name + " = sitofp i32 " + operand.value + " to double");
-            let coerced = LLVMOperand { llvm_type: "double", value: temp_name };
-            return CoercionResult { lines: current_lines, temp_index: temp_index + 1, operand: coerced, diagnostics: diagnostics };
+            let coerced = LLVMOperand {
+                llvm_type: "double",
+                value: temp_name
+            };
+            return CoercionResult {
+                lines: current_lines,
+                temp_index: temp_index + 1,
+                operand: coerced,
+                diagnostics: diagnostics
+            };
         }
     }
     if target == "double" {
         if operand_type == "i1" {
             let temp_name = format_temp_name(temp_index);
             current_lines.push("  " + temp_name + " = uitofp i1 " + operand.value + " to double");
-            let coerced = LLVMOperand { llvm_type: "double", value: temp_name };
-            return CoercionResult { lines: current_lines, temp_index: temp_index + 1, operand: coerced, diagnostics: diagnostics };
+            let coerced = LLVMOperand {
+                llvm_type: "double",
+                value: temp_name
+            };
+            return CoercionResult {
+                lines: current_lines,
+                temp_index: temp_index + 1,
+                operand: coerced,
+                diagnostics: diagnostics
+            };
         }
     }
     if target == "double" {
         if operand_type == "i8" {
             let temp_name = format_temp_name(temp_index);
             current_lines.push("  " + temp_name + " = sitofp i8 " + operand.value + " to double");
-            let coerced = LLVMOperand { llvm_type: "double", value: temp_name };
-            return CoercionResult { lines: current_lines, temp_index: temp_index + 1, operand: coerced, diagnostics: diagnostics };
+            let coerced = LLVMOperand {
+                llvm_type: "double",
+                value: temp_name
+            };
+            return CoercionResult {
+                lines: current_lines,
+                temp_index: temp_index + 1,
+                operand: coerced,
+                diagnostics: diagnostics
+            };
         }
     }
     if target == "double" {
         if operand_type == "i8*" {
             let temp_name = format_temp_name(temp_index);
             current_lines.push("  " + temp_name + " = call double @sailfin_runtime_string_to_number(i8* " + operand.value + ")");
-            let coerced = LLVMOperand { llvm_type: "double", value: temp_name };
-            return CoercionResult { lines: current_lines, temp_index: temp_index + 1, operand: coerced, diagnostics: diagnostics };
+            let coerced = LLVMOperand {
+                llvm_type: "double",
+                value: temp_name
+            };
+            return CoercionResult {
+                lines: current_lines,
+                temp_index: temp_index + 1,
+                operand: coerced,
+                diagnostics: diagnostics
+            };
         }
     }
     if target == "i64" {
@@ -243,8 +298,16 @@ fn coerce_numeric_primitive(operand: LLVMOperand, operand_type: string, target: 
             let convert_temp = format_temp_name(temp_index + 1);
             current_lines.push("  " + round_temp + " = call double @round(double " + operand.value + ")");
             current_lines.push("  " + convert_temp + " = fptosi double " + round_temp + " to i64");
-            let coerced = LLVMOperand { llvm_type: "i64", value: convert_temp };
-            return CoercionResult { lines: current_lines, temp_index: temp_index + 2, operand: coerced, diagnostics: diagnostics };
+            let coerced = LLVMOperand {
+                llvm_type: "i64",
+                value: convert_temp
+            };
+            return CoercionResult {
+                lines: current_lines,
+                temp_index: temp_index + 2,
+                operand: coerced,
+                diagnostics: diagnostics
+            };
         }
     }
     if target == "i64" {
@@ -252,7 +315,12 @@ fn coerce_numeric_primitive(operand: LLVMOperand, operand_type: string, target: 
             let temp_name = format_temp_name(temp_index);
             current_lines.push("  " + temp_name + " = sext i32 " + operand.value + " to i64");
             let coerced = LLVMOperand { llvm_type: "i64", value: temp_name };
-            return CoercionResult { lines: current_lines, temp_index: temp_index + 1, operand: coerced, diagnostics: diagnostics };
+            return CoercionResult {
+                lines: current_lines,
+                temp_index: temp_index + 1,
+                operand: coerced,
+                diagnostics: diagnostics
+            };
         }
     }
     if target == "i64" {
@@ -260,7 +328,12 @@ fn coerce_numeric_primitive(operand: LLVMOperand, operand_type: string, target: 
             let temp_name = format_temp_name(temp_index);
             current_lines.push("  " + temp_name + " = sext i8 " + operand.value + " to i64");
             let coerced = LLVMOperand { llvm_type: "i64", value: temp_name };
-            return CoercionResult { lines: current_lines, temp_index: temp_index + 1, operand: coerced, diagnostics: diagnostics };
+            return CoercionResult {
+                lines: current_lines,
+                temp_index: temp_index + 1,
+                operand: coerced,
+                diagnostics: diagnostics
+            };
         }
     }
     if target == "i64" {
@@ -268,7 +341,12 @@ fn coerce_numeric_primitive(operand: LLVMOperand, operand_type: string, target: 
             let temp_name = format_temp_name(temp_index);
             current_lines.push("  " + temp_name + " = zext i1 " + operand.value + " to i64");
             let coerced = LLVMOperand { llvm_type: "i64", value: temp_name };
-            return CoercionResult { lines: current_lines, temp_index: temp_index + 1, operand: coerced, diagnostics: diagnostics };
+            return CoercionResult {
+                lines: current_lines,
+                temp_index: temp_index + 1,
+                operand: coerced,
+                diagnostics: diagnostics
+            };
         }
     }
     if target == "i32" {
@@ -276,7 +354,12 @@ fn coerce_numeric_primitive(operand: LLVMOperand, operand_type: string, target: 
             let temp_name = format_temp_name(temp_index);
             current_lines.push("  " + temp_name + " = trunc i64 " + operand.value + " to i32");
             let coerced = LLVMOperand { llvm_type: "i32", value: temp_name };
-            return CoercionResult { lines: current_lines, temp_index: temp_index + 1, operand: coerced, diagnostics: diagnostics };
+            return CoercionResult {
+                lines: current_lines,
+                temp_index: temp_index + 1,
+                operand: coerced,
+                diagnostics: diagnostics
+            };
         }
     }
     if target == "i32" {
@@ -284,7 +367,12 @@ fn coerce_numeric_primitive(operand: LLVMOperand, operand_type: string, target: 
             let temp_name = format_temp_name(temp_index);
             current_lines.push("  " + temp_name + " = sext i8 " + operand.value + " to i32");
             let coerced = LLVMOperand { llvm_type: "i32", value: temp_name };
-            return CoercionResult { lines: current_lines, temp_index: temp_index + 1, operand: coerced, diagnostics: diagnostics };
+            return CoercionResult {
+                lines: current_lines,
+                temp_index: temp_index + 1,
+                operand: coerced,
+                diagnostics: diagnostics
+            };
         }
     }
     if target == "i32" {
@@ -292,7 +380,12 @@ fn coerce_numeric_primitive(operand: LLVMOperand, operand_type: string, target: 
             let temp_name = format_temp_name(temp_index);
             current_lines.push("  " + temp_name + " = zext i1 " + operand.value + " to i32");
             let coerced = LLVMOperand { llvm_type: "i32", value: temp_name };
-            return CoercionResult { lines: current_lines, temp_index: temp_index + 1, operand: coerced, diagnostics: diagnostics };
+            return CoercionResult {
+                lines: current_lines,
+                temp_index: temp_index + 1,
+                operand: coerced,
+                diagnostics: diagnostics
+            };
         }
     }
     if target == "i32" {
@@ -301,8 +394,16 @@ fn coerce_numeric_primitive(operand: LLVMOperand, operand_type: string, target: 
             let convert_temp = format_temp_name(temp_index + 1);
             current_lines.push("  " + round_temp + " = call double @round(double " + operand.value + ")");
             current_lines.push("  " + convert_temp + " = fptosi double " + round_temp + " to i32");
-            let coerced = LLVMOperand { llvm_type: "i32", value: convert_temp };
-            return CoercionResult { lines: current_lines, temp_index: temp_index + 2, operand: coerced, diagnostics: diagnostics };
+            let coerced = LLVMOperand {
+                llvm_type: "i32",
+                value: convert_temp
+            };
+            return CoercionResult {
+                lines: current_lines,
+                temp_index: temp_index + 2,
+                operand: coerced,
+                diagnostics: diagnostics
+            };
         }
     }
     if target == "i8" {
@@ -310,7 +411,12 @@ fn coerce_numeric_primitive(operand: LLVMOperand, operand_type: string, target: 
             let temp_name = format_temp_name(temp_index);
             current_lines.push("  " + temp_name + " = trunc i64 " + operand.value + " to i8");
             let coerced = LLVMOperand { llvm_type: "i8", value: temp_name };
-            return CoercionResult { lines: current_lines, temp_index: temp_index + 1, operand: coerced, diagnostics: diagnostics };
+            return CoercionResult {
+                lines: current_lines,
+                temp_index: temp_index + 1,
+                operand: coerced,
+                diagnostics: diagnostics
+            };
         }
     }
     if target == "i8" {
@@ -318,7 +424,12 @@ fn coerce_numeric_primitive(operand: LLVMOperand, operand_type: string, target: 
             let temp_name = format_temp_name(temp_index);
             current_lines.push("  " + temp_name + " = trunc i32 " + operand.value + " to i8");
             let coerced = LLVMOperand { llvm_type: "i8", value: temp_name };
-            return CoercionResult { lines: current_lines, temp_index: temp_index + 1, operand: coerced, diagnostics: diagnostics };
+            return CoercionResult {
+                lines: current_lines,
+                temp_index: temp_index + 1,
+                operand: coerced,
+                diagnostics: diagnostics
+            };
         }
     }
     if target == "i8" {
@@ -326,7 +437,12 @@ fn coerce_numeric_primitive(operand: LLVMOperand, operand_type: string, target: 
             let temp_name = format_temp_name(temp_index);
             current_lines.push("  " + temp_name + " = zext i1 " + operand.value + " to i8");
             let coerced = LLVMOperand { llvm_type: "i8", value: temp_name };
-            return CoercionResult { lines: current_lines, temp_index: temp_index + 1, operand: coerced, diagnostics: diagnostics };
+            return CoercionResult {
+                lines: current_lines,
+                temp_index: temp_index + 1,
+                operand: coerced,
+                diagnostics: diagnostics
+            };
         }
     }
     if target == "i8" {
@@ -335,8 +451,16 @@ fn coerce_numeric_primitive(operand: LLVMOperand, operand_type: string, target: 
             let convert_temp = format_temp_name(temp_index + 1);
             current_lines.push("  " + round_temp + " = call double @round(double " + operand.value + ")");
             current_lines.push("  " + convert_temp + " = fptosi double " + round_temp + " to i8");
-            let coerced = LLVMOperand { llvm_type: "i8", value: convert_temp };
-            return CoercionResult { lines: current_lines, temp_index: temp_index + 2, operand: coerced, diagnostics: diagnostics };
+            let coerced = LLVMOperand {
+                llvm_type: "i8",
+                value: convert_temp
+            };
+            return CoercionResult {
+                lines: current_lines,
+                temp_index: temp_index + 2,
+                operand: coerced,
+                diagnostics: diagnostics
+            };
         }
     }
     if target == "i8" {
@@ -345,8 +469,16 @@ fn coerce_numeric_primitive(operand: LLVMOperand, operand_type: string, target: 
             let char_value_temp = format_temp_name(temp_index + 1);
             current_lines.push("  " + char_ptr_temp + " = getelementptr i8, i8* " + operand.value + ", i64 0");
             current_lines.push("  " + char_value_temp + " = load i8, i8* " + char_ptr_temp);
-            let coerced = LLVMOperand { llvm_type: "i8", value: char_value_temp };
-            return CoercionResult { lines: current_lines, temp_index: temp_index + 2, operand: coerced, diagnostics: diagnostics };
+            let coerced = LLVMOperand {
+                llvm_type: "i8",
+                value: char_value_temp
+            };
+            return CoercionResult {
+                lines: current_lines,
+                temp_index: temp_index + 2,
+                operand: coerced,
+                diagnostics: diagnostics
+            };
         }
     }
     if target == "i1" {
@@ -354,7 +486,12 @@ fn coerce_numeric_primitive(operand: LLVMOperand, operand_type: string, target: 
             let temp_name = format_temp_name(temp_index);
             current_lines.push("  " + temp_name + " = fcmp one double " + operand.value + ", 0.0");
             let coerced = LLVMOperand { llvm_type: "i1", value: temp_name };
-            return CoercionResult { lines: current_lines, temp_index: temp_index + 1, operand: coerced, diagnostics: diagnostics };
+            return CoercionResult {
+                lines: current_lines,
+                temp_index: temp_index + 1,
+                operand: coerced,
+                diagnostics: diagnostics
+            };
         }
     }
     if target == "i1" {
@@ -362,7 +499,12 @@ fn coerce_numeric_primitive(operand: LLVMOperand, operand_type: string, target: 
             let temp_name = format_temp_name(temp_index);
             current_lines.push("  " + temp_name + " = icmp ne i64 " + operand.value + ", 0");
             let coerced = LLVMOperand { llvm_type: "i1", value: temp_name };
-            return CoercionResult { lines: current_lines, temp_index: temp_index + 1, operand: coerced, diagnostics: diagnostics };
+            return CoercionResult {
+                lines: current_lines,
+                temp_index: temp_index + 1,
+                operand: coerced,
+                diagnostics: diagnostics
+            };
         }
     }
     if target == "i1" {
@@ -370,7 +512,12 @@ fn coerce_numeric_primitive(operand: LLVMOperand, operand_type: string, target: 
             let temp_name = format_temp_name(temp_index);
             current_lines.push("  " + temp_name + " = icmp ne i32 " + operand.value + ", 0");
             let coerced = LLVMOperand { llvm_type: "i1", value: temp_name };
-            return CoercionResult { lines: current_lines, temp_index: temp_index + 1, operand: coerced, diagnostics: diagnostics };
+            return CoercionResult {
+                lines: current_lines,
+                temp_index: temp_index + 1,
+                operand: coerced,
+                diagnostics: diagnostics
+            };
         }
     }
     if target == "i8*" {
@@ -378,7 +525,12 @@ fn coerce_numeric_primitive(operand: LLVMOperand, operand_type: string, target: 
             let temp_name = format_temp_name(temp_index);
             current_lines.push("  " + temp_name + " = call i8* @sailfin_runtime_number_to_string(double " + operand.value + ")");
             let coerced = LLVMOperand { llvm_type: "i8*", value: temp_name };
-            return CoercionResult { lines: current_lines, temp_index: temp_index + 1, operand: coerced, diagnostics: diagnostics };
+            return CoercionResult {
+                lines: current_lines,
+                temp_index: temp_index + 1,
+                operand: coerced,
+                diagnostics: diagnostics
+            };
         }
     }
     if target == "i8*" {
@@ -388,7 +540,12 @@ fn coerce_numeric_primitive(operand: LLVMOperand, operand_type: string, target: 
             current_lines.push("  " + as_double + " = sitofp i64 " + operand.value + " to double");
             current_lines.push("  " + as_string + " = call i8* @sailfin_runtime_number_to_string(double " + as_double + ")");
             let coerced = LLVMOperand { llvm_type: "i8*", value: as_string };
-            return CoercionResult { lines: current_lines, temp_index: temp_index + 2, operand: coerced, diagnostics: diagnostics };
+            return CoercionResult {
+                lines: current_lines,
+                temp_index: temp_index + 2,
+                operand: coerced,
+                diagnostics: diagnostics
+            };
         }
     }
     if target == "i8*" {
@@ -401,8 +558,16 @@ fn coerce_numeric_primitive(operand: LLVMOperand, operand_type: string, target: 
             let null_ptr = format_temp_name(temp_index + 2);
             current_lines.push("  " + null_ptr + " = getelementptr i8, i8* " + malloc_temp + ", i64 1");
             current_lines.push("  store i8 0, i8* " + null_ptr);
-            let coerced = LLVMOperand { llvm_type: "i8*", value: malloc_temp };
-            return CoercionResult { lines: current_lines, temp_index: temp_index + 3, operand: coerced, diagnostics: diagnostics };
+            let coerced = LLVMOperand {
+                llvm_type: "i8*",
+                value: malloc_temp
+            };
+            return CoercionResult {
+                lines: current_lines,
+                temp_index: temp_index + 3,
+                operand: coerced,
+                diagnostics: diagnostics
+            };
         }
     }
     return null;
@@ -419,8 +584,16 @@ fn coerce_pointer_or_struct(operand: LLVMOperand, operand_type: string, target: 
             if ends_with_pointer_suffix(operand_type) {
                 let temp_name = format_temp_name(temp_index);
                 current_lines.push("  " + temp_name + " = bitcast " + operand_type + " " + operand.value + " to i8*");
-                let coerced = LLVMOperand { llvm_type: "i8*", value: temp_name };
-                return CoercionResult { lines: current_lines, temp_index: temp_index + 1, operand: coerced, diagnostics: diagnostics };
+                let coerced = LLVMOperand {
+                    llvm_type: "i8*",
+                    value: temp_name
+                };
+                return CoercionResult {
+                    lines: current_lines,
+                    temp_index: temp_index + 1,
+                    operand: coerced,
+                    diagnostics: diagnostics
+                };
             }
         }
     }
@@ -429,8 +602,16 @@ fn coerce_pointer_or_struct(operand: LLVMOperand, operand_type: string, target: 
             if ends_with_pointer_suffix(target) {
                 let temp_name = format_temp_name(temp_index);
                 current_lines.push("  " + temp_name + " = bitcast i8* " + operand.value + " to " + target);
-                let coerced = LLVMOperand { llvm_type: target, value: temp_name };
-                return CoercionResult { lines: current_lines, temp_index: temp_index + 1, operand: coerced, diagnostics: diagnostics };
+                let coerced = LLVMOperand {
+                    llvm_type: target,
+                    value: temp_name
+                };
+                return CoercionResult {
+                    lines: current_lines,
+                    temp_index: temp_index + 1,
+                    operand: coerced,
+                    diagnostics: diagnostics
+                };
             }
         }
     }
@@ -441,8 +622,16 @@ fn coerce_pointer_or_struct(operand: LLVMOperand, operand_type: string, target: 
             if op_base == target {
                 let temp_name = format_temp_name(temp_index);
                 current_lines.push("  " + temp_name + " = load " + target + ", " + operand_type + " " + operand.value);
-                let coerced = LLVMOperand { llvm_type: target, value: temp_name };
-                return CoercionResult { lines: current_lines, temp_index: temp_index + 1, operand: coerced, diagnostics: diagnostics };
+                let coerced = LLVMOperand {
+                    llvm_type: target,
+                    value: temp_name
+                };
+                return CoercionResult {
+                    lines: current_lines,
+                    temp_index: temp_index + 1,
+                    operand: coerced,
+                    diagnostics: diagnostics
+                };
             }
         }
     }
@@ -465,8 +654,16 @@ fn coerce_pointer_or_struct(operand: LLVMOperand, operand_type: string, target: 
                     current_lines.push("  " + typed_ptr_temp + " = bitcast i8* " + malloc_temp + " to " + operand_type + "*");
                     current_lines.push("  store " + operand_type + " " + operand.value + ", " + operand_type + "* " + typed_ptr_temp);
                     current_lines.push("  call void @sailfin_runtime_mark_persistent(i8* " + malloc_temp + ")");
-                    let boxed = LLVMOperand { llvm_type: target, value: typed_ptr_temp };
-                    return CoercionResult { lines: current_lines, temp_index: temp_index + 4, operand: boxed, diagnostics: diagnostics };
+                    let boxed = LLVMOperand {
+                        llvm_type: target,
+                        value: typed_ptr_temp
+                    };
+                    return CoercionResult {
+                        lines: current_lines,
+                        temp_index: temp_index + 4,
+                        operand: boxed,
+                        diagnostics: diagnostics
+                    };
                 }
             }
         }
@@ -480,8 +677,16 @@ fn coerce_pointer_or_struct(operand: LLVMOperand, operand_type: string, target: 
                     if operand_type != target {
                         let temp_name = format_temp_name(temp_index);
                         current_lines.push("  " + temp_name + " = bitcast " + operand_type + " " + operand.value + " to " + target);
-                        let coerced = LLVMOperand { llvm_type: target, value: temp_name };
-                        return CoercionResult { lines: current_lines, temp_index: temp_index + 1, operand: coerced, diagnostics: diagnostics };
+                        let coerced = LLVMOperand {
+                            llvm_type: target,
+                            value: temp_name
+                        };
+                        return CoercionResult {
+                            lines: current_lines,
+                            temp_index: temp_index + 1,
+                            operand: coerced,
+                            diagnostics: diagnostics
+                        };
                     }
                 }
             }
@@ -492,9 +697,7 @@ fn coerce_pointer_or_struct(operand: LLVMOperand, operand_type: string, target: 
         let mut _if83: boolean = false;
         if starts_with(operand_type, "%") { _if83 = true; }
         if starts_with(operand_type, "{") { _if83 = true; }
-        if _if83 {
-            _if76 = true;
-        }
+        if _if83 { _if76 = true; }
     }
     if _if76 {
         let size_ptr_temp = format_temp_name(temp_index);
@@ -508,16 +711,19 @@ fn coerce_pointer_or_struct(operand: LLVMOperand, operand_type: string, target: 
         current_lines.push("  store " + operand_type + " " + operand.value + ", " + operand_type + "* " + typed_ptr_temp);
         current_lines.push("  call void @sailfin_runtime_mark_persistent(i8* " + malloc_temp + ")");
         let boxed = LLVMOperand { llvm_type: "i8*", value: malloc_temp };
-        return CoercionResult { lines: current_lines, temp_index: temp_index + 4, operand: boxed, diagnostics: diagnostics };
+        return CoercionResult {
+            lines: current_lines,
+            temp_index: temp_index + 4,
+            operand: boxed,
+            diagnostics: diagnostics
+        };
     }
     let mut _if77: boolean = false;
     if operand_type == "i8*" {
         let mut _if84: boolean = false;
         if starts_with(target, "%") { _if84 = true; }
         if starts_with(target, "{") { _if84 = true; }
-        if _if84 {
-            _if77 = true;
-        }
+        if _if84 { _if77 = true; }
     }
     if _if77 {
         let typed_ptr_temp = format_temp_name(temp_index);
@@ -525,7 +731,12 @@ fn coerce_pointer_or_struct(operand: LLVMOperand, operand_type: string, target: 
         current_lines.push("  " + typed_ptr_temp + " = bitcast i8* " + operand.value + " to " + target + "*");
         current_lines.push("  " + loaded_temp + " = load " + target + ", " + target + "* " + typed_ptr_temp);
         let coerced = LLVMOperand { llvm_type: target, value: loaded_temp };
-        return CoercionResult { lines: current_lines, temp_index: temp_index + 2, operand: coerced, diagnostics: diagnostics };
+        return CoercionResult {
+            lines: current_lines,
+            temp_index: temp_index + 2,
+            operand: coerced,
+            diagnostics: diagnostics
+        };
     }
     return null;
 }
@@ -553,8 +764,16 @@ fn coerce_general_fallback(operand: LLVMOperand, operand_type: string, target: s
                     current_lines.push("  " + typed_ptr_temp + " = bitcast i8* " + malloc_temp + " to " + operand_type + "*");
                     current_lines.push("  store " + operand_type + " " + operand.value + ", " + operand_type + "* " + typed_ptr_temp);
                     current_lines.push("  call void @sailfin_runtime_mark_persistent(i8* " + malloc_temp + ")");
-                    let boxed = LLVMOperand { llvm_type: target, value: typed_ptr_temp };
-                    return CoercionResult { lines: current_lines, temp_index: temp_index + 4, operand: boxed, diagnostics: diagnostics };
+                    let boxed = LLVMOperand {
+                        llvm_type: target,
+                        value: typed_ptr_temp
+                    };
+                    return CoercionResult {
+                        lines: current_lines,
+                        temp_index: temp_index + 4,
+                        operand: boxed,
+                        diagnostics: diagnostics
+                    };
                 }
             }
         }
@@ -563,9 +782,7 @@ fn coerce_general_fallback(operand: LLVMOperand, operand_type: string, target: s
         let variants = parse_union_payload_types(target);
         let mut variant_index: number = 0;
         loop {
-            if variant_index >= variants.length {
-                break;
-            }
+            if variant_index >= variants.length { break; }
             let variant_type = variants[variant_index];
             let mut has_value: boolean = false;
             let mut value_text: string = "";
@@ -632,8 +849,16 @@ fn coerce_general_fallback(operand: LLVMOperand, operand_type: string, target: s
                 let union_temp = format_temp_name(local_temp + 1);
                 local_lines.push("  " + tag_temp + " = insertvalue " + target + " undef, i32 " + number_to_string(variant_index) + ", 0");
                 local_lines.push("  " + union_temp + " = insertvalue " + target + " " + tag_temp + ", " + variant_type + " " + value_text + ", " + number_to_string(variant_index + 1));
-                let coerced = LLVMOperand { llvm_type: target, value: union_temp };
-                return CoercionResult { lines: local_lines, temp_index: local_temp + 2, operand: coerced, diagnostics: diagnostics };
+                let coerced = LLVMOperand {
+                    llvm_type: target,
+                    value: union_temp
+                };
+                return CoercionResult {
+                    lines: local_lines,
+                    temp_index: local_temp + 2,
+                    operand: coerced,
+                    diagnostics: diagnostics
+                };
             }
             variant_index += 1;
         }
@@ -644,8 +869,16 @@ fn coerce_general_fallback(operand: LLVMOperand, operand_type: string, target: s
             if source_base == target {
                 let temp_name = format_temp_name(temp_index);
                 current_lines.push("  " + temp_name + " = load " + target + ", " + operand.llvm_type + " " + operand.value);
-                let coerced = LLVMOperand { llvm_type: target, value: temp_name };
-                return CoercionResult { lines: current_lines, temp_index: temp_index + 1, operand: coerced, diagnostics: diagnostics };
+                let coerced = LLVMOperand {
+                    llvm_type: target,
+                    value: temp_name
+                };
+                return CoercionResult {
+                    lines: current_lines,
+                    temp_index: temp_index + 1,
+                    operand: coerced,
+                    diagnostics: diagnostics
+                };
             }
         }
     }
@@ -658,15 +891,31 @@ fn coerce_general_fallback(operand: LLVMOperand, operand_type: string, target: s
                 // When the operand is null, use zeroinitializer instead of
                 // bitcast-null-to-ptr + load (which is a null dereference / UB).
                 if operand.value == "null" {
-                    let coerced = LLVMOperand { llvm_type: target, value: "zeroinitializer" };
-                    return CoercionResult { lines: current_lines, temp_index: temp_index, operand: coerced, diagnostics: diagnostics };
+                    let coerced = LLVMOperand {
+                        llvm_type: target,
+                        value: "zeroinitializer"
+                    };
+                    return CoercionResult {
+                        lines: current_lines,
+                        temp_index: temp_index,
+                        operand: coerced,
+                        diagnostics: diagnostics
+                    };
                 }
                 let typed_ptr_temp = format_temp_name(temp_index);
                 let load_temp = format_temp_name(temp_index + 1);
                 current_lines.push("  " + typed_ptr_temp + " = bitcast i8* " + operand.value + " to " + target + "*");
                 current_lines.push("  " + load_temp + " = load " + target + ", " + target + "* " + typed_ptr_temp);
-                let coerced = LLVMOperand { llvm_type: target, value: load_temp };
-                return CoercionResult { lines: current_lines, temp_index: temp_index + 2, operand: coerced, diagnostics: diagnostics };
+                let coerced = LLVMOperand {
+                    llvm_type: target,
+                    value: load_temp
+                };
+                return CoercionResult {
+                    lines: current_lines,
+                    temp_index: temp_index + 2,
+                    operand: coerced,
+                    diagnostics: diagnostics
+                };
             }
         }
     }
@@ -675,7 +924,12 @@ fn coerce_general_fallback(operand: LLVMOperand, operand_type: string, target: s
             let temp_name = format_temp_name(temp_index);
             current_lines.push("  " + temp_name + " = bitcast " + operand.llvm_type + " " + operand.value + " to i8*");
             let coerced = LLVMOperand { llvm_type: "i8*", value: temp_name };
-            return CoercionResult { lines: current_lines, temp_index: temp_index + 1, operand: coerced, diagnostics: diagnostics };
+            return CoercionResult {
+                lines: current_lines,
+                temp_index: temp_index + 1,
+                operand: coerced,
+                diagnostics: diagnostics
+            };
         }
     }
     if target == "i8*" {
@@ -694,8 +948,16 @@ fn coerce_general_fallback(operand: LLVMOperand, operand_type: string, target: s
                 current_lines.push("  " + typed_ptr_temp + " = bitcast i8* " + malloc_temp + " to " + operand.llvm_type + "*");
                 current_lines.push("  store " + operand.llvm_type + " " + operand.value + ", " + operand.llvm_type + "* " + typed_ptr_temp);
                 current_lines.push("  call void @sailfin_runtime_mark_persistent(i8* " + malloc_temp + ")");
-                let coerced = LLVMOperand { llvm_type: "i8*", value: malloc_temp };
-                return CoercionResult { lines: current_lines, temp_index: temp_index + 4, operand: coerced, diagnostics: diagnostics };
+                let coerced = LLVMOperand {
+                    llvm_type: "i8*",
+                    value: malloc_temp
+                };
+                return CoercionResult {
+                    lines: current_lines,
+                    temp_index: temp_index + 4,
+                    operand: coerced,
+                    diagnostics: diagnostics
+                };
             }
         }
     }
@@ -704,7 +966,12 @@ fn coerce_general_fallback(operand: LLVMOperand, operand_type: string, target: s
             let temp_name = format_temp_name(temp_index);
             current_lines.push("  " + temp_name + " = bitcast i8* " + operand.value + " to " + target);
             let coerced = LLVMOperand { llvm_type: target, value: temp_name };
-            return CoercionResult { lines: current_lines, temp_index: temp_index + 1, operand: coerced, diagnostics: diagnostics };
+            return CoercionResult {
+                lines: current_lines,
+                temp_index: temp_index + 1,
+                operand: coerced,
+                diagnostics: diagnostics
+            };
         }
     }
     if !ends_with_pointer_suffix(operand.llvm_type) {
@@ -730,8 +997,16 @@ fn coerce_general_fallback(operand: LLVMOperand, operand_type: string, target: s
                     pointer_value = cast_temp;
                     next_index += 1;
                 }
-                let coerced = LLVMOperand { llvm_type: target, value: pointer_value };
-                return CoercionResult { lines: current_lines, temp_index: next_index, operand: coerced, diagnostics: diagnostics };
+                let coerced = LLVMOperand {
+                    llvm_type: target,
+                    value: pointer_value
+                };
+                return CoercionResult {
+                    lines: current_lines,
+                    temp_index: next_index,
+                    operand: coerced,
+                    diagnostics: diagnostics
+                };
             }
         }
     }
@@ -751,8 +1026,16 @@ fn coerce_general_fallback(operand: LLVMOperand, operand_type: string, target: s
                     pointer_value = bitcast_temp;
                     next_index += 1;
                 }
-                let coerced = LLVMOperand { llvm_type: target, value: pointer_value };
-                return CoercionResult { lines: current_lines, temp_index: next_index, operand: coerced, diagnostics: diagnostics };
+                let coerced = LLVMOperand {
+                    llvm_type: target,
+                    value: pointer_value
+                };
+                return CoercionResult {
+                    lines: current_lines,
+                    temp_index: next_index,
+                    operand: coerced,
+                    diagnostics: diagnostics
+                };
             }
         }
     }
@@ -764,27 +1047,50 @@ fn coerce_general_fallback(operand: LLVMOperand, operand_type: string, target: s
                 if target_element.length > 0 {
                     let temp_name = format_temp_name(temp_index);
                     current_lines.push("  " + temp_name + " = bitcast " + operand.llvm_type + " " + operand.value + " to " + target);
-                    let coerced = LLVMOperand { llvm_type: target, value: temp_name };
-                    return CoercionResult { lines: current_lines, temp_index: temp_index + 1, operand: coerced, diagnostics: diagnostics };
+                    let coerced = LLVMOperand {
+                        llvm_type: target,
+                        value: temp_name
+                    };
+                    return CoercionResult {
+                        lines: current_lines,
+                        temp_index: temp_index + 1,
+                        operand: coerced,
+                        diagnostics: diagnostics
+                    };
                 }
             }
             let temp_name = format_temp_name(temp_index);
             current_lines.push("  " + temp_name + " = bitcast " + operand.llvm_type + " " + operand.value + " to " + target);
             let coerced = LLVMOperand { llvm_type: target, value: temp_name };
-            return CoercionResult { lines: current_lines, temp_index: temp_index + 1, operand: coerced, diagnostics: diagnostics };
+            return CoercionResult {
+                lines: current_lines,
+                temp_index: temp_index + 1,
+                operand: coerced,
+                diagnostics: diagnostics
+            };
         }
     }
     if operand.value == "null" {
         if ends_with_pointer_suffix(target) {
             let coerced = LLVMOperand { llvm_type: target, value: "null" };
-            return CoercionResult { lines: current_lines, temp_index: temp_index, operand: coerced, diagnostics: diagnostics };
+            return CoercionResult {
+                lines: current_lines,
+                temp_index: temp_index,
+                operand: coerced,
+                diagnostics: diagnostics
+            };
         }
     }
     if operand.value == "null" {
         if !ends_with_pointer_suffix(target) {
             let literal = default_return_literal(target);
             let coerced = LLVMOperand { llvm_type: target, value: literal };
-            return CoercionResult { lines: current_lines, temp_index: temp_index, operand: coerced, diagnostics: diagnostics };
+            return CoercionResult {
+                lines: current_lines,
+                temp_index: temp_index,
+                operand: coerced,
+                diagnostics: diagnostics
+            };
         }
     }
     if !ends_with_pointer_suffix(target) {
@@ -804,7 +1110,12 @@ fn coerce_general_fallback(operand: LLVMOperand, operand_type: string, target: s
             let load_temp = format_temp_name(pointer_temp_index);
             current_lines.push("  " + load_temp + " = load " + target + ", " + pointer_type + " " + pointer_value);
             let coerced = LLVMOperand { llvm_type: target, value: load_temp };
-            return CoercionResult { lines: current_lines, temp_index: pointer_temp_index + 1, operand: coerced, diagnostics: diagnostics };
+            return CoercionResult {
+                lines: current_lines,
+                temp_index: pointer_temp_index + 1,
+                operand: coerced,
+                diagnostics: diagnostics
+            };
         }
     }
     return null;
@@ -820,88 +1131,73 @@ fn coerce_operand_to_type(operand: LLVMOperand, target_type: string, temp_index:
     let operand_type = collapse_type_spaces(trim_text(operand.llvm_type));
     let target = collapse_type_spaces(trim_text(target_type));
     if target.length == 0 {
-        return CoercionResult { lines: current_lines, temp_index: temp_index, operand: operand, diagnostics: diagnostics };
+        return CoercionResult {
+            lines: current_lines,
+            temp_index: temp_index,
+            operand: operand,
+            diagnostics: diagnostics
+        };
     }
     if operand_type == target {
-        return CoercionResult { lines: current_lines, temp_index: temp_index, operand: operand, diagnostics: diagnostics };
+        return CoercionResult {
+            lines: current_lines,
+            temp_index: temp_index,
+            operand: operand,
+            diagnostics: diagnostics
+        };
     }
 
     let numeric = coerce_numeric_primitive(operand, operand_type, target, temp_index, current_lines);
-    if numeric != null {
-        return numeric;
-    }
+    if numeric != null { return numeric; }
     let pointer = coerce_pointer_or_struct(operand, operand_type, target, temp_index, current_lines);
-    if pointer != null {
-        return pointer;
-    }
+    if pointer != null { return pointer; }
     let general = coerce_general_fallback(operand, operand_type, target, temp_index, current_lines);
-    if general != null {
-        return general;
-    }
+    if general != null { return general; }
     diagnostics.push("llvm lowering: unable to coerce operand of type `" + operand.llvm_type + "` to `" + target_type + "`");
-    return CoercionResult { lines: current_lines, temp_index: temp_index, operand: null, diagnostics: diagnostics };
+    return CoercionResult {
+        lines: current_lines,
+        temp_index: temp_index,
+        operand: null,
+        diagnostics: diagnostics
+    };
 }
 
 fn dominant_type(first: string, second: string) -> string {
-    if first.length == 0 {
-        return second;
-    }
-    if second.length == 0 {
-        return first;
-    }
-    if first == second {
-        return first;
-    }
+    if first.length == 0 { return second; }
+    if second.length == 0 { return first; }
+    if first == second { return first; }
     let first_is_pointer = ends_with_pointer_suffix(first);
     let second_is_pointer = ends_with_pointer_suffix(second);
     if first_is_pointer {
-        if !second_is_pointer {
-            return first;
-        }
+        if !second_is_pointer { return first; }
     }
     if second_is_pointer {
-        if !first_is_pointer {
-            return second;
-        }
+        if !first_is_pointer { return second; }
     }
     if first_is_pointer {
-        if second_is_pointer {
-            return first;
-        }
+        if second_is_pointer { return first; }
     }
     let mut _if79: boolean = false;
     if first == "double" { _if79 = true; }
     if second == "double" { _if79 = true; }
-    if _if79 {
-        return "double";
-    }
+    if _if79 { return "double"; }
     let mut _if80: boolean = false;
     if first == "i64" { _if80 = true; }
     if second == "i64" { _if80 = true; }
-    if _if80 {
-        return "i64";
-    }
+    if _if80 { return "i64"; }
     // i8 is narrower than i64, so i64 dominates
     let mut _if81: boolean = false;
     if first == "i8" {
-        if second == "i64" {
-            _if81 = true;
-        }
+        if second == "i64" { _if81 = true; }
     }
     if first == "i64" {
-        if second == "i8" {
-            _if81 = true;
-        }
+        if second == "i8" { _if81 = true; }
     }
-    if _if81 {
-        return "i64";
-    }
+    if _if81 { return "i64"; }
     let mut _if82: boolean = false;
     if first == "i1" { _if82 = true; }
     if second == "i1" { _if82 = true; }
-    if _if82 {
-        return "i1";
-    }
+    if _if82 { return "i1"; }
     return first;
 }
 
@@ -913,12 +1209,18 @@ fn harmonise_operands(left: LLVMOperand, right: LLVMOperand, temp_index: number,
     let mut right_operand = right;
     if left_operand.value == "null" {
         if ends_with_pointer_suffix(right_operand.llvm_type) {
-            left_operand = LLVMOperand { llvm_type: right_operand.llvm_type, value: "null" };
+            left_operand = LLVMOperand {
+                llvm_type: right_operand.llvm_type,
+                value: "null"
+            };
         }
     }
     if right_operand.value == "null" {
         if ends_with_pointer_suffix(left_operand.llvm_type) {
-            right_operand = LLVMOperand { llvm_type: left_operand.llvm_type, value: "null" };
+            right_operand = LLVMOperand {
+                llvm_type: left_operand.llvm_type,
+                value: "null"
+            };
         }
     }
     if left_operand.llvm_type == right_operand.llvm_type {

--- a/compiler/src/llvm/expression_lowering/native/core_operands.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_operands.sfn
@@ -7,15 +7,15 @@
 // relational operators (`emit_comparison_instruction`, `emit_boolean_and`),
 // and provides local variable loading (`load_local_operand`).
 import { char_code } from "../../../string_utils";
-import { default_return_literal, format_temp_name, } from "../../expressions_helpers";
-import { ends_with_pointer_suffix, strip_pointer_suffix, } from "../../type_mapping";
+import { default_return_literal, format_temp_name } from "../../expressions_helpers";
+import { ends_with_pointer_suffix, strip_pointer_suffix } from "../../type_mapping";
 import {
     BinaryAlignmentResult,
     CoercionResult,
     ComparisonEmission,
     LLVMOperand,
     LoadLocalResult,
-    LocalBinding,
+    LocalBinding
 } from "../../types";
 import { starts_with } from "../../utils";
 import { array_pointer_element_type } from "../arrays";
@@ -26,14 +26,18 @@ import {
     is_union_llvm_type,
     number_to_string,
     parse_union_payload_types,
-    trim_text,
+    trim_text
 } from "./core_text";
 
 fn emit_comparison_instruction(symbol: string, left_operand: LLVMOperand, right_operand: LLVMOperand, temp_index: number, lines: string[]) -> ComparisonEmission {
     let mut diagnostics: string[] = [];
     let mut current_lines: string[] = lines;
     if left_operand.llvm_type != right_operand.llvm_type {
-        diagnostics.push("llvm lowering: comparison operands have mismatched types `" + left_operand.llvm_type + "` and `" + right_operand.llvm_type + "`");
+        diagnostics.push("llvm lowering: comparison operands have mismatched types `"
+            + left_operand.llvm_type
+            + "` and `"
+            + right_operand.llvm_type
+            + "`");
     }
     let mut symbol_is_equality: boolean = false;
     let mut _if73: boolean = false;
@@ -50,7 +54,12 @@ fn emit_comparison_instruction(symbol: string, left_operand: LLVMOperand, right_
                 if !left_is_null {
                     if !right_is_null {
                         let compare_temp = format_temp_name(temp_index);
-                        current_lines.push("  " + compare_temp + " = call i1 @strings_equal(i8* " + left_operand.value + ", i8* " + right_operand.value + ")");
+                        current_lines.push("  " + compare_temp
+                            + " = call i1 @strings_equal(i8* "
+                            + left_operand.value
+                            + ", i8* "
+                            + right_operand.value
+                            + ")");
                         let mut next_index = temp_index + 1;
                         let mut operand = LLVMOperand {
                             llvm_type: "i1",
@@ -58,7 +67,10 @@ fn emit_comparison_instruction(symbol: string, left_operand: LLVMOperand, right_
                         };
                         if symbol == "!=" {
                             let inverted_temp = format_temp_name(next_index);
-                            current_lines.push("  " + inverted_temp + " = xor i1 " + compare_temp + ", true");
+                            current_lines.push("  " + inverted_temp
+                                + " = xor i1 "
+                                + compare_temp
+                                + ", true");
                             operand = LLVMOperand {
                                 llvm_type: "i1",
                                 value: inverted_temp
@@ -79,7 +91,11 @@ fn emit_comparison_instruction(symbol: string, left_operand: LLVMOperand, right_
     let llvm_type = left_operand.llvm_type;
     let predicate = comparison_predicate_for_symbol(symbol, llvm_type);
     if predicate.length == 0 {
-        diagnostics.push("llvm lowering: unsupported comparison operator `" + symbol + "` for type `" + llvm_type + "`");
+        diagnostics.push("llvm lowering: unsupported comparison operator `"
+            + symbol
+            + "` for type `"
+            + llvm_type
+            + "`");
         return ComparisonEmission {
             lines: current_lines,
             temp_index: temp_index,
@@ -88,7 +104,11 @@ fn emit_comparison_instruction(symbol: string, left_operand: LLVMOperand, right_
         };
     }
     let temp_name = format_temp_name(temp_index);
-    current_lines.push("  " + temp_name + " = " + predicate + " " + llvm_type + " " + left_operand.value + ", " + right_operand.value);
+    current_lines.push("  " + temp_name + " = " + predicate + " " + llvm_type
+        + " "
+        + left_operand.value
+        + ", "
+        + right_operand.value);
     let operand = LLVMOperand { llvm_type: "i1", value: temp_name };
     return ComparisonEmission {
         lines: current_lines,
@@ -102,13 +122,19 @@ fn emit_boolean_and(left_operand: LLVMOperand, right_operand: LLVMOperand, temp_
     let mut diagnostics: string[] = [];
     let mut current_lines: string[] = lines;
     if left_operand.llvm_type != "i1" {
-        diagnostics.push("llvm lowering: expected boolean operand for `and`, found `" + left_operand.llvm_type + "`");
+        diagnostics.push("llvm lowering: expected boolean operand for `and`, found `"
+            + left_operand.llvm_type
+            + "`");
     }
     if right_operand.llvm_type != "i1" {
-        diagnostics.push("llvm lowering: expected boolean operand for `and`, found `" + right_operand.llvm_type + "`");
+        diagnostics.push("llvm lowering: expected boolean operand for `and`, found `"
+            + right_operand.llvm_type
+            + "`");
     }
     let temp_name = format_temp_name(temp_index);
-    current_lines.push("  " + temp_name + " = and i1 " + left_operand.value + ", " + right_operand.value);
+    current_lines.push("  " + temp_name + " = and i1 " + left_operand.value
+        + ", "
+        + right_operand.value);
     let operand = LLVMOperand { llvm_type: "i1", value: temp_name };
     return ComparisonEmission {
         lines: current_lines,
@@ -180,7 +206,10 @@ fn load_local_operand(local: LocalBinding, temp_index: number, lines: string[]) 
     let mut diagnostics: string[] = [];
     let load_name = format_temp_name(temp_index);
     let mut current_lines: string[] = lines;
-    current_lines.push("  " + load_name + " = load " + local.llvm_type + ", " + local.llvm_type + "* " + local.pointer);
+    current_lines.push("  " + load_name + " = load " + local.llvm_type + ", "
+        + local.llvm_type
+        + "* "
+        + local.pointer);
     let operand = LLVMOperand {
         llvm_type: local.llvm_type,
         value: load_name
@@ -215,7 +244,8 @@ fn coerce_numeric_primitive(operand: LLVMOperand, operand_type: string, target: 
     if target == "double" {
         if operand_type == "i64" {
             let temp_name = format_temp_name(temp_index);
-            current_lines.push("  " + temp_name + " = sitofp i64 " + operand.value + " to double");
+            current_lines.push("  " + temp_name + " = sitofp i64 " + operand.value
+                + " to double");
             let coerced = LLVMOperand {
                 llvm_type: "double",
                 value: temp_name
@@ -231,7 +261,8 @@ fn coerce_numeric_primitive(operand: LLVMOperand, operand_type: string, target: 
     if target == "double" {
         if operand_type == "i32" {
             let temp_name = format_temp_name(temp_index);
-            current_lines.push("  " + temp_name + " = sitofp i32 " + operand.value + " to double");
+            current_lines.push("  " + temp_name + " = sitofp i32 " + operand.value
+                + " to double");
             let coerced = LLVMOperand {
                 llvm_type: "double",
                 value: temp_name
@@ -247,7 +278,8 @@ fn coerce_numeric_primitive(operand: LLVMOperand, operand_type: string, target: 
     if target == "double" {
         if operand_type == "i1" {
             let temp_name = format_temp_name(temp_index);
-            current_lines.push("  " + temp_name + " = uitofp i1 " + operand.value + " to double");
+            current_lines.push("  " + temp_name + " = uitofp i1 " + operand.value
+                + " to double");
             let coerced = LLVMOperand {
                 llvm_type: "double",
                 value: temp_name
@@ -263,7 +295,8 @@ fn coerce_numeric_primitive(operand: LLVMOperand, operand_type: string, target: 
     if target == "double" {
         if operand_type == "i8" {
             let temp_name = format_temp_name(temp_index);
-            current_lines.push("  " + temp_name + " = sitofp i8 " + operand.value + " to double");
+            current_lines.push("  " + temp_name + " = sitofp i8 " + operand.value
+                + " to double");
             let coerced = LLVMOperand {
                 llvm_type: "double",
                 value: temp_name
@@ -279,7 +312,10 @@ fn coerce_numeric_primitive(operand: LLVMOperand, operand_type: string, target: 
     if target == "double" {
         if operand_type == "i8*" {
             let temp_name = format_temp_name(temp_index);
-            current_lines.push("  " + temp_name + " = call double @sailfin_runtime_string_to_number(i8* " + operand.value + ")");
+            current_lines.push("  " + temp_name
+                + " = call double @sailfin_runtime_string_to_number(i8* "
+                + operand.value
+                + ")");
             let coerced = LLVMOperand {
                 llvm_type: "double",
                 value: temp_name
@@ -296,8 +332,13 @@ fn coerce_numeric_primitive(operand: LLVMOperand, operand_type: string, target: 
         if operand_type == "double" {
             let round_temp = format_temp_name(temp_index);
             let convert_temp = format_temp_name(temp_index + 1);
-            current_lines.push("  " + round_temp + " = call double @round(double " + operand.value + ")");
-            current_lines.push("  " + convert_temp + " = fptosi double " + round_temp + " to i64");
+            current_lines.push("  " + round_temp
+                + " = call double @round(double "
+                + operand.value
+                + ")");
+            current_lines.push("  " + convert_temp + " = fptosi double "
+                + round_temp
+                + " to i64");
             let coerced = LLVMOperand {
                 llvm_type: "i64",
                 value: convert_temp
@@ -313,7 +354,8 @@ fn coerce_numeric_primitive(operand: LLVMOperand, operand_type: string, target: 
     if target == "i64" {
         if operand_type == "i32" {
             let temp_name = format_temp_name(temp_index);
-            current_lines.push("  " + temp_name + " = sext i32 " + operand.value + " to i64");
+            current_lines.push("  " + temp_name + " = sext i32 " + operand.value
+                + " to i64");
             let coerced = LLVMOperand { llvm_type: "i64", value: temp_name };
             return CoercionResult {
                 lines: current_lines,
@@ -326,7 +368,8 @@ fn coerce_numeric_primitive(operand: LLVMOperand, operand_type: string, target: 
     if target == "i64" {
         if operand_type == "i8" {
             let temp_name = format_temp_name(temp_index);
-            current_lines.push("  " + temp_name + " = sext i8 " + operand.value + " to i64");
+            current_lines.push("  " + temp_name + " = sext i8 " + operand.value
+                + " to i64");
             let coerced = LLVMOperand { llvm_type: "i64", value: temp_name };
             return CoercionResult {
                 lines: current_lines,
@@ -339,7 +382,8 @@ fn coerce_numeric_primitive(operand: LLVMOperand, operand_type: string, target: 
     if target == "i64" {
         if operand_type == "i1" {
             let temp_name = format_temp_name(temp_index);
-            current_lines.push("  " + temp_name + " = zext i1 " + operand.value + " to i64");
+            current_lines.push("  " + temp_name + " = zext i1 " + operand.value
+                + " to i64");
             let coerced = LLVMOperand { llvm_type: "i64", value: temp_name };
             return CoercionResult {
                 lines: current_lines,
@@ -352,7 +396,8 @@ fn coerce_numeric_primitive(operand: LLVMOperand, operand_type: string, target: 
     if target == "i32" {
         if operand_type == "i64" {
             let temp_name = format_temp_name(temp_index);
-            current_lines.push("  " + temp_name + " = trunc i64 " + operand.value + " to i32");
+            current_lines.push("  " + temp_name + " = trunc i64 " + operand.value
+                + " to i32");
             let coerced = LLVMOperand { llvm_type: "i32", value: temp_name };
             return CoercionResult {
                 lines: current_lines,
@@ -365,7 +410,8 @@ fn coerce_numeric_primitive(operand: LLVMOperand, operand_type: string, target: 
     if target == "i32" {
         if operand_type == "i8" {
             let temp_name = format_temp_name(temp_index);
-            current_lines.push("  " + temp_name + " = sext i8 " + operand.value + " to i32");
+            current_lines.push("  " + temp_name + " = sext i8 " + operand.value
+                + " to i32");
             let coerced = LLVMOperand { llvm_type: "i32", value: temp_name };
             return CoercionResult {
                 lines: current_lines,
@@ -378,7 +424,8 @@ fn coerce_numeric_primitive(operand: LLVMOperand, operand_type: string, target: 
     if target == "i32" {
         if operand_type == "i1" {
             let temp_name = format_temp_name(temp_index);
-            current_lines.push("  " + temp_name + " = zext i1 " + operand.value + " to i32");
+            current_lines.push("  " + temp_name + " = zext i1 " + operand.value
+                + " to i32");
             let coerced = LLVMOperand { llvm_type: "i32", value: temp_name };
             return CoercionResult {
                 lines: current_lines,
@@ -392,8 +439,13 @@ fn coerce_numeric_primitive(operand: LLVMOperand, operand_type: string, target: 
         if operand_type == "double" {
             let round_temp = format_temp_name(temp_index);
             let convert_temp = format_temp_name(temp_index + 1);
-            current_lines.push("  " + round_temp + " = call double @round(double " + operand.value + ")");
-            current_lines.push("  " + convert_temp + " = fptosi double " + round_temp + " to i32");
+            current_lines.push("  " + round_temp
+                + " = call double @round(double "
+                + operand.value
+                + ")");
+            current_lines.push("  " + convert_temp + " = fptosi double "
+                + round_temp
+                + " to i32");
             let coerced = LLVMOperand {
                 llvm_type: "i32",
                 value: convert_temp
@@ -409,7 +461,8 @@ fn coerce_numeric_primitive(operand: LLVMOperand, operand_type: string, target: 
     if target == "i8" {
         if operand_type == "i64" {
             let temp_name = format_temp_name(temp_index);
-            current_lines.push("  " + temp_name + " = trunc i64 " + operand.value + " to i8");
+            current_lines.push("  " + temp_name + " = trunc i64 " + operand.value
+                + " to i8");
             let coerced = LLVMOperand { llvm_type: "i8", value: temp_name };
             return CoercionResult {
                 lines: current_lines,
@@ -422,7 +475,8 @@ fn coerce_numeric_primitive(operand: LLVMOperand, operand_type: string, target: 
     if target == "i8" {
         if operand_type == "i32" {
             let temp_name = format_temp_name(temp_index);
-            current_lines.push("  " + temp_name + " = trunc i32 " + operand.value + " to i8");
+            current_lines.push("  " + temp_name + " = trunc i32 " + operand.value
+                + " to i8");
             let coerced = LLVMOperand { llvm_type: "i8", value: temp_name };
             return CoercionResult {
                 lines: current_lines,
@@ -435,7 +489,8 @@ fn coerce_numeric_primitive(operand: LLVMOperand, operand_type: string, target: 
     if target == "i8" {
         if operand_type == "i1" {
             let temp_name = format_temp_name(temp_index);
-            current_lines.push("  " + temp_name + " = zext i1 " + operand.value + " to i8");
+            current_lines.push("  " + temp_name + " = zext i1 " + operand.value
+                + " to i8");
             let coerced = LLVMOperand { llvm_type: "i8", value: temp_name };
             return CoercionResult {
                 lines: current_lines,
@@ -449,8 +504,13 @@ fn coerce_numeric_primitive(operand: LLVMOperand, operand_type: string, target: 
         if operand_type == "double" {
             let round_temp = format_temp_name(temp_index);
             let convert_temp = format_temp_name(temp_index + 1);
-            current_lines.push("  " + round_temp + " = call double @round(double " + operand.value + ")");
-            current_lines.push("  " + convert_temp + " = fptosi double " + round_temp + " to i8");
+            current_lines.push("  " + round_temp
+                + " = call double @round(double "
+                + operand.value
+                + ")");
+            current_lines.push("  " + convert_temp + " = fptosi double "
+                + round_temp
+                + " to i8");
             let coerced = LLVMOperand {
                 llvm_type: "i8",
                 value: convert_temp
@@ -467,8 +527,12 @@ fn coerce_numeric_primitive(operand: LLVMOperand, operand_type: string, target: 
         if operand_type == "i8*" {
             let char_ptr_temp = format_temp_name(temp_index);
             let char_value_temp = format_temp_name(temp_index + 1);
-            current_lines.push("  " + char_ptr_temp + " = getelementptr i8, i8* " + operand.value + ", i64 0");
-            current_lines.push("  " + char_value_temp + " = load i8, i8* " + char_ptr_temp);
+            current_lines.push("  " + char_ptr_temp
+                + " = getelementptr i8, i8* "
+                + operand.value
+                + ", i64 0");
+            current_lines.push("  " + char_value_temp + " = load i8, i8* "
+                + char_ptr_temp);
             let coerced = LLVMOperand {
                 llvm_type: "i8",
                 value: char_value_temp
@@ -484,7 +548,9 @@ fn coerce_numeric_primitive(operand: LLVMOperand, operand_type: string, target: 
     if target == "i1" {
         if operand_type == "double" {
             let temp_name = format_temp_name(temp_index);
-            current_lines.push("  " + temp_name + " = fcmp one double " + operand.value + ", 0.0");
+            current_lines.push("  " + temp_name + " = fcmp one double "
+                + operand.value
+                + ", 0.0");
             let coerced = LLVMOperand { llvm_type: "i1", value: temp_name };
             return CoercionResult {
                 lines: current_lines,
@@ -497,7 +563,8 @@ fn coerce_numeric_primitive(operand: LLVMOperand, operand_type: string, target: 
     if target == "i1" {
         if operand_type == "i64" {
             let temp_name = format_temp_name(temp_index);
-            current_lines.push("  " + temp_name + " = icmp ne i64 " + operand.value + ", 0");
+            current_lines.push("  " + temp_name + " = icmp ne i64 " + operand.value
+                + ", 0");
             let coerced = LLVMOperand { llvm_type: "i1", value: temp_name };
             return CoercionResult {
                 lines: current_lines,
@@ -510,7 +577,8 @@ fn coerce_numeric_primitive(operand: LLVMOperand, operand_type: string, target: 
     if target == "i1" {
         if operand_type == "i32" {
             let temp_name = format_temp_name(temp_index);
-            current_lines.push("  " + temp_name + " = icmp ne i32 " + operand.value + ", 0");
+            current_lines.push("  " + temp_name + " = icmp ne i32 " + operand.value
+                + ", 0");
             let coerced = LLVMOperand { llvm_type: "i1", value: temp_name };
             return CoercionResult {
                 lines: current_lines,
@@ -523,7 +591,10 @@ fn coerce_numeric_primitive(operand: LLVMOperand, operand_type: string, target: 
     if target == "i8*" {
         if operand_type == "double" {
             let temp_name = format_temp_name(temp_index);
-            current_lines.push("  " + temp_name + " = call i8* @sailfin_runtime_number_to_string(double " + operand.value + ")");
+            current_lines.push("  " + temp_name
+                + " = call i8* @sailfin_runtime_number_to_string(double "
+                + operand.value
+                + ")");
             let coerced = LLVMOperand { llvm_type: "i8*", value: temp_name };
             return CoercionResult {
                 lines: current_lines,
@@ -537,8 +608,12 @@ fn coerce_numeric_primitive(operand: LLVMOperand, operand_type: string, target: 
         if operand_type == "i64" {
             let as_double = format_temp_name(temp_index);
             let as_string = format_temp_name(temp_index + 1);
-            current_lines.push("  " + as_double + " = sitofp i64 " + operand.value + " to double");
-            current_lines.push("  " + as_string + " = call i8* @sailfin_runtime_number_to_string(double " + as_double + ")");
+            current_lines.push("  " + as_double + " = sitofp i64 " + operand.value
+                + " to double");
+            current_lines.push("  " + as_string
+                + " = call i8* @sailfin_runtime_number_to_string(double "
+                + as_double
+                + ")");
             let coerced = LLVMOperand { llvm_type: "i8*", value: as_string };
             return CoercionResult {
                 lines: current_lines,
@@ -551,12 +626,18 @@ fn coerce_numeric_primitive(operand: LLVMOperand, operand_type: string, target: 
     if target == "i8*" {
         if operand_type == "i8" {
             let malloc_temp = format_temp_name(temp_index);
-            current_lines.push("  " + malloc_temp + " = call noalias i8* @calloc(i64 1, i64 2)");
+            current_lines.push("  " + malloc_temp
+                + " = call noalias i8* @calloc(i64 1, i64 2)");
             let char_ptr = format_temp_name(temp_index + 1);
-            current_lines.push("  " + char_ptr + " = getelementptr i8, i8* " + malloc_temp + ", i64 0");
-            current_lines.push("  store i8 " + operand.value + ", i8* " + char_ptr);
+            current_lines.push("  " + char_ptr + " = getelementptr i8, i8* "
+                + malloc_temp
+                + ", i64 0");
+            current_lines.push("  store i8 " + operand.value + ", i8* "
+                + char_ptr);
             let null_ptr = format_temp_name(temp_index + 2);
-            current_lines.push("  " + null_ptr + " = getelementptr i8, i8* " + malloc_temp + ", i64 1");
+            current_lines.push("  " + null_ptr + " = getelementptr i8, i8* "
+                + malloc_temp
+                + ", i64 1");
             current_lines.push("  store i8 0, i8* " + null_ptr);
             let coerced = LLVMOperand {
                 llvm_type: "i8*",
@@ -583,7 +664,11 @@ fn coerce_pointer_or_struct(operand: LLVMOperand, operand_type: string, target: 
         if operand_type != "i8*" {
             if ends_with_pointer_suffix(operand_type) {
                 let temp_name = format_temp_name(temp_index);
-                current_lines.push("  " + temp_name + " = bitcast " + operand_type + " " + operand.value + " to i8*");
+                current_lines.push("  " + temp_name + " = bitcast "
+                    + operand_type
+                    + " "
+                    + operand.value
+                    + " to i8*");
                 let coerced = LLVMOperand {
                     llvm_type: "i8*",
                     value: temp_name
@@ -601,7 +686,10 @@ fn coerce_pointer_or_struct(operand: LLVMOperand, operand_type: string, target: 
         if target != "i8*" {
             if ends_with_pointer_suffix(target) {
                 let temp_name = format_temp_name(temp_index);
-                current_lines.push("  " + temp_name + " = bitcast i8* " + operand.value + " to " + target);
+                current_lines.push("  " + temp_name + " = bitcast i8* "
+                    + operand.value
+                    + " to "
+                    + target);
                 let coerced = LLVMOperand {
                     llvm_type: target,
                     value: temp_name
@@ -621,7 +709,10 @@ fn coerce_pointer_or_struct(operand: LLVMOperand, operand_type: string, target: 
             let op_base = trim_text(substring(operand_type, 0, operand_type.length - 1));
             if op_base == target {
                 let temp_name = format_temp_name(temp_index);
-                current_lines.push("  " + temp_name + " = load " + target + ", " + operand_type + " " + operand.value);
+                current_lines.push("  " + temp_name + " = load " + target + ", "
+                    + operand_type
+                    + " "
+                    + operand.value);
                 let coerced = LLVMOperand {
                     llvm_type: target,
                     value: temp_name
@@ -648,12 +739,34 @@ fn coerce_pointer_or_struct(operand: LLVMOperand, operand_type: string, target: 
                     let size_temp = format_temp_name(temp_index + 1);
                     let malloc_temp = format_temp_name(temp_index + 2);
                     let typed_ptr_temp = format_temp_name(temp_index + 3);
-                    current_lines.push("  " + size_ptr_temp + " = getelementptr " + operand_type + ", " + operand_type + "* null, i32 1");
-                    current_lines.push("  " + size_temp + " = ptrtoint " + operand_type + "* " + size_ptr_temp + " to i64");
-                    current_lines.push("  " + malloc_temp + " = call noalias i8* @calloc(i64 1, i64 " + size_temp + ")");
-                    current_lines.push("  " + typed_ptr_temp + " = bitcast i8* " + malloc_temp + " to " + operand_type + "*");
-                    current_lines.push("  store " + operand_type + " " + operand.value + ", " + operand_type + "* " + typed_ptr_temp);
-                    current_lines.push("  call void @sailfin_runtime_mark_persistent(i8* " + malloc_temp + ")");
+                    current_lines.push("  " + size_ptr_temp
+                        + " = getelementptr "
+                        + operand_type
+                        + ", "
+                        + operand_type
+                        + "* null, i32 1");
+                    current_lines.push("  " + size_temp + " = ptrtoint "
+                        + operand_type
+                        + "* "
+                        + size_ptr_temp
+                        + " to i64");
+                    current_lines.push("  " + malloc_temp
+                        + " = call noalias i8* @calloc(i64 1, i64 "
+                        + size_temp
+                        + ")");
+                    current_lines.push("  " + typed_ptr_temp + " = bitcast i8* "
+                        + malloc_temp
+                        + " to "
+                        + operand_type
+                        + "*");
+                    current_lines.push("  store " + operand_type + " " + operand.value
+                        + ", "
+                        + operand_type
+                        + "* "
+                        + typed_ptr_temp);
+                    current_lines.push("  call void @sailfin_runtime_mark_persistent(i8* "
+                        + malloc_temp
+                        + ")");
                     let boxed = LLVMOperand {
                         llvm_type: target,
                         value: typed_ptr_temp
@@ -676,7 +789,12 @@ fn coerce_pointer_or_struct(operand: LLVMOperand, operand_type: string, target: 
                 if tgt_last2 == "*" {
                     if operand_type != target {
                         let temp_name = format_temp_name(temp_index);
-                        current_lines.push("  " + temp_name + " = bitcast " + operand_type + " " + operand.value + " to " + target);
+                        current_lines.push("  " + temp_name + " = bitcast "
+                            + operand_type
+                            + " "
+                            + operand.value
+                            + " to "
+                            + target);
                         let coerced = LLVMOperand {
                             llvm_type: target,
                             value: temp_name
@@ -704,12 +822,32 @@ fn coerce_pointer_or_struct(operand: LLVMOperand, operand_type: string, target: 
         let size_temp = format_temp_name(temp_index + 1);
         let malloc_temp = format_temp_name(temp_index + 2);
         let typed_ptr_temp = format_temp_name(temp_index + 3);
-        current_lines.push("  " + size_ptr_temp + " = getelementptr " + operand_type + ", " + operand_type + "* null, i32 1");
-        current_lines.push("  " + size_temp + " = ptrtoint " + operand_type + "* " + size_ptr_temp + " to i64");
-        current_lines.push("  " + malloc_temp + " = call noalias i8* @calloc(i64 1, i64 " + size_temp + ")");
-        current_lines.push("  " + typed_ptr_temp + " = bitcast i8* " + malloc_temp + " to " + operand_type + "*");
-        current_lines.push("  store " + operand_type + " " + operand.value + ", " + operand_type + "* " + typed_ptr_temp);
-        current_lines.push("  call void @sailfin_runtime_mark_persistent(i8* " + malloc_temp + ")");
+        current_lines.push("  " + size_ptr_temp + " = getelementptr "
+            + operand_type
+            + ", "
+            + operand_type
+            + "* null, i32 1");
+        current_lines.push("  " + size_temp + " = ptrtoint " + operand_type
+            + "* "
+            + size_ptr_temp
+            + " to i64");
+        current_lines.push("  " + malloc_temp
+            + " = call noalias i8* @calloc(i64 1, i64 "
+            + size_temp
+            + ")");
+        current_lines.push("  " + typed_ptr_temp + " = bitcast i8* "
+            + malloc_temp
+            + " to "
+            + operand_type
+            + "*");
+        current_lines.push("  store " + operand_type + " " + operand.value
+            + ", "
+            + operand_type
+            + "* "
+            + typed_ptr_temp);
+        current_lines.push("  call void @sailfin_runtime_mark_persistent(i8* "
+            + malloc_temp
+            + ")");
         let boxed = LLVMOperand { llvm_type: "i8*", value: malloc_temp };
         return CoercionResult {
             lines: current_lines,
@@ -728,8 +866,14 @@ fn coerce_pointer_or_struct(operand: LLVMOperand, operand_type: string, target: 
     if _if77 {
         let typed_ptr_temp = format_temp_name(temp_index);
         let loaded_temp = format_temp_name(temp_index + 1);
-        current_lines.push("  " + typed_ptr_temp + " = bitcast i8* " + operand.value + " to " + target + "*");
-        current_lines.push("  " + loaded_temp + " = load " + target + ", " + target + "* " + typed_ptr_temp);
+        current_lines.push("  " + typed_ptr_temp + " = bitcast i8* " + operand.value
+            + " to "
+            + target
+            + "*");
+        current_lines.push("  " + loaded_temp + " = load " + target + ", "
+            + target
+            + "* "
+            + typed_ptr_temp);
         let coerced = LLVMOperand { llvm_type: target, value: loaded_temp };
         return CoercionResult {
             lines: current_lines,
@@ -758,12 +902,34 @@ fn coerce_general_fallback(operand: LLVMOperand, operand_type: string, target: s
                     let size_temp = format_temp_name(temp_index + 1);
                     let malloc_temp = format_temp_name(temp_index + 2);
                     let typed_ptr_temp = format_temp_name(temp_index + 3);
-                    current_lines.push("  " + size_ptr_temp + " = getelementptr " + operand_type + ", " + operand_type + "* null, i32 1");
-                    current_lines.push("  " + size_temp + " = ptrtoint " + operand_type + "* " + size_ptr_temp + " to i64");
-                    current_lines.push("  " + malloc_temp + " = call noalias i8* @calloc(i64 1, i64 " + size_temp + ")");
-                    current_lines.push("  " + typed_ptr_temp + " = bitcast i8* " + malloc_temp + " to " + operand_type + "*");
-                    current_lines.push("  store " + operand_type + " " + operand.value + ", " + operand_type + "* " + typed_ptr_temp);
-                    current_lines.push("  call void @sailfin_runtime_mark_persistent(i8* " + malloc_temp + ")");
+                    current_lines.push("  " + size_ptr_temp
+                        + " = getelementptr "
+                        + operand_type
+                        + ", "
+                        + operand_type
+                        + "* null, i32 1");
+                    current_lines.push("  " + size_temp + " = ptrtoint "
+                        + operand_type
+                        + "* "
+                        + size_ptr_temp
+                        + " to i64");
+                    current_lines.push("  " + malloc_temp
+                        + " = call noalias i8* @calloc(i64 1, i64 "
+                        + size_temp
+                        + ")");
+                    current_lines.push("  " + typed_ptr_temp + " = bitcast i8* "
+                        + malloc_temp
+                        + " to "
+                        + operand_type
+                        + "*");
+                    current_lines.push("  store " + operand_type + " " + operand.value
+                        + ", "
+                        + operand_type
+                        + "* "
+                        + typed_ptr_temp);
+                    current_lines.push("  call void @sailfin_runtime_mark_persistent(i8* "
+                        + malloc_temp
+                        + ")");
                     let boxed = LLVMOperand {
                         llvm_type: target,
                         value: typed_ptr_temp
@@ -805,12 +971,36 @@ fn coerce_general_fallback(operand: LLVMOperand, operand_type: string, target: s
                         let size_temp = format_temp_name(local_temp + 1);
                         let malloc_temp = format_temp_name(local_temp + 2);
                         let typed_ptr_temp = format_temp_name(local_temp + 3);
-                        local_lines.push("  " + size_ptr_temp + " = getelementptr " + operand_type + ", " + operand_type + "* null, i32 1");
-                        local_lines.push("  " + size_temp + " = ptrtoint " + operand_type + "* " + size_ptr_temp + " to i64");
-                        local_lines.push("  " + malloc_temp + " = call noalias i8* @calloc(i64 1, i64 " + size_temp + ")");
-                        local_lines.push("  " + typed_ptr_temp + " = bitcast i8* " + malloc_temp + " to " + operand_type + "*");
-                        local_lines.push("  store " + operand_type + " " + operand.value + ", " + operand_type + "* " + typed_ptr_temp);
-                        local_lines.push("  call void @sailfin_runtime_mark_persistent(i8* " + malloc_temp + ")");
+                        local_lines.push("  " + size_ptr_temp
+                            + " = getelementptr "
+                            + operand_type
+                            + ", "
+                            + operand_type
+                            + "* null, i32 1");
+                        local_lines.push("  " + size_temp + " = ptrtoint "
+                            + operand_type
+                            + "* "
+                            + size_ptr_temp
+                            + " to i64");
+                        local_lines.push("  " + malloc_temp
+                            + " = call noalias i8* @calloc(i64 1, i64 "
+                            + size_temp
+                            + ")");
+                        local_lines.push("  " + typed_ptr_temp
+                            + " = bitcast i8* "
+                            + malloc_temp
+                            + " to "
+                            + operand_type
+                            + "*");
+                        local_lines.push("  store " + operand_type + " "
+                            + operand.value
+                            + ", "
+                            + operand_type
+                            + "* "
+                            + typed_ptr_temp);
+                        local_lines.push("  call void @sailfin_runtime_mark_persistent(i8* "
+                            + malloc_temp
+                            + ")");
                         has_value = true;
                         value_text = typed_ptr_temp;
                         local_temp += 4;
@@ -831,12 +1021,36 @@ fn coerce_general_fallback(operand: LLVMOperand, operand_type: string, target: s
                             let size_temp = format_temp_name(local_temp + 1);
                             let malloc_temp = format_temp_name(local_temp + 2);
                             let typed_ptr_temp = format_temp_name(local_temp + 3);
-                            local_lines.push("  " + size_ptr_temp + " = getelementptr " + operand_type + ", " + operand_type + "* null, i32 1");
-                            local_lines.push("  " + size_temp + " = ptrtoint " + operand_type + "* " + size_ptr_temp + " to i64");
-                            local_lines.push("  " + malloc_temp + " = call noalias i8* @calloc(i64 1, i64 " + size_temp + ")");
-                            local_lines.push("  " + typed_ptr_temp + " = bitcast i8* " + malloc_temp + " to " + operand_type + "*");
-                            local_lines.push("  store " + operand_type + " " + operand.value + ", " + operand_type + "* " + typed_ptr_temp);
-                            local_lines.push("  call void @sailfin_runtime_mark_persistent(i8* " + malloc_temp + ")");
+                            local_lines.push("  " + size_ptr_temp
+                                + " = getelementptr "
+                                + operand_type
+                                + ", "
+                                + operand_type
+                                + "* null, i32 1");
+                            local_lines.push("  " + size_temp + " = ptrtoint "
+                                + operand_type
+                                + "* "
+                                + size_ptr_temp
+                                + " to i64");
+                            local_lines.push("  " + malloc_temp
+                                + " = call noalias i8* @calloc(i64 1, i64 "
+                                + size_temp
+                                + ")");
+                            local_lines.push("  " + typed_ptr_temp
+                                + " = bitcast i8* "
+                                + malloc_temp
+                                + " to "
+                                + operand_type
+                                + "*");
+                            local_lines.push("  store " + operand_type + " "
+                                + operand.value
+                                + ", "
+                                + operand_type
+                                + "* "
+                                + typed_ptr_temp);
+                            local_lines.push("  call void @sailfin_runtime_mark_persistent(i8* "
+                                + malloc_temp
+                                + ")");
                             has_value = true;
                             value_text = malloc_temp;
                             local_temp += 4;
@@ -847,8 +1061,20 @@ fn coerce_general_fallback(operand: LLVMOperand, operand_type: string, target: s
             if has_value {
                 let tag_temp = format_temp_name(local_temp);
                 let union_temp = format_temp_name(local_temp + 1);
-                local_lines.push("  " + tag_temp + " = insertvalue " + target + " undef, i32 " + number_to_string(variant_index) + ", 0");
-                local_lines.push("  " + union_temp + " = insertvalue " + target + " " + tag_temp + ", " + variant_type + " " + value_text + ", " + number_to_string(variant_index + 1));
+                local_lines.push("  " + tag_temp + " = insertvalue " + target
+                    + " undef, i32 "
+                    + number_to_string(variant_index)
+                    + ", 0");
+                local_lines.push("  " + union_temp + " = insertvalue " + target
+                    + " "
+                    + tag_temp
+                    + ", "
+                    + variant_type
+                    + " "
+                    + value_text
+                    + ", "
+                    + number_to_string(variant_index
+                    + 1));
                 let coerced = LLVMOperand {
                     llvm_type: target,
                     value: union_temp
@@ -868,7 +1094,10 @@ fn coerce_general_fallback(operand: LLVMOperand, operand_type: string, target: s
             let source_base = strip_pointer_suffix(operand.llvm_type);
             if source_base == target {
                 let temp_name = format_temp_name(temp_index);
-                current_lines.push("  " + temp_name + " = load " + target + ", " + operand.llvm_type + " " + operand.value);
+                current_lines.push("  " + temp_name + " = load " + target + ", "
+                    + operand.llvm_type
+                    + " "
+                    + operand.value);
                 let coerced = LLVMOperand {
                     llvm_type: target,
                     value: temp_name
@@ -904,8 +1133,15 @@ fn coerce_general_fallback(operand: LLVMOperand, operand_type: string, target: s
                 }
                 let typed_ptr_temp = format_temp_name(temp_index);
                 let load_temp = format_temp_name(temp_index + 1);
-                current_lines.push("  " + typed_ptr_temp + " = bitcast i8* " + operand.value + " to " + target + "*");
-                current_lines.push("  " + load_temp + " = load " + target + ", " + target + "* " + typed_ptr_temp);
+                current_lines.push("  " + typed_ptr_temp + " = bitcast i8* "
+                    + operand.value
+                    + " to "
+                    + target
+                    + "*");
+                current_lines.push("  " + load_temp + " = load " + target + ", "
+                    + target
+                    + "* "
+                    + typed_ptr_temp);
                 let coerced = LLVMOperand {
                     llvm_type: target,
                     value: load_temp
@@ -922,7 +1158,10 @@ fn coerce_general_fallback(operand: LLVMOperand, operand_type: string, target: s
     if target == "i8*" {
         if ends_with_pointer_suffix(operand.llvm_type) {
             let temp_name = format_temp_name(temp_index);
-            current_lines.push("  " + temp_name + " = bitcast " + operand.llvm_type + " " + operand.value + " to i8*");
+            current_lines.push("  " + temp_name + " = bitcast " + operand.llvm_type
+                + " "
+                + operand.value
+                + " to i8*");
             let coerced = LLVMOperand { llvm_type: "i8*", value: temp_name };
             return CoercionResult {
                 lines: current_lines,
@@ -942,12 +1181,33 @@ fn coerce_general_fallback(operand: LLVMOperand, operand_type: string, target: s
                 let size_temp = format_temp_name(temp_index + 1);
                 let malloc_temp = format_temp_name(temp_index + 2);
                 let typed_ptr_temp = format_temp_name(temp_index + 3);
-                current_lines.push("  " + size_ptr_temp + " = getelementptr " + operand.llvm_type + ", " + operand.llvm_type + "* null, i32 1");
-                current_lines.push("  " + size_temp + " = ptrtoint " + operand.llvm_type + "* " + size_ptr_temp + " to i64");
-                current_lines.push("  " + malloc_temp + " = call noalias i8* @calloc(i64 1, i64 " + size_temp + ")");
-                current_lines.push("  " + typed_ptr_temp + " = bitcast i8* " + malloc_temp + " to " + operand.llvm_type + "*");
-                current_lines.push("  store " + operand.llvm_type + " " + operand.value + ", " + operand.llvm_type + "* " + typed_ptr_temp);
-                current_lines.push("  call void @sailfin_runtime_mark_persistent(i8* " + malloc_temp + ")");
+                current_lines.push("  " + size_ptr_temp + " = getelementptr "
+                    + operand.llvm_type
+                    + ", "
+                    + operand.llvm_type
+                    + "* null, i32 1");
+                current_lines.push("  " + size_temp + " = ptrtoint " + operand.llvm_type
+                    + "* "
+                    + size_ptr_temp
+                    + " to i64");
+                current_lines.push("  " + malloc_temp
+                    + " = call noalias i8* @calloc(i64 1, i64 "
+                    + size_temp
+                    + ")");
+                current_lines.push("  " + typed_ptr_temp + " = bitcast i8* "
+                    + malloc_temp
+                    + " to "
+                    + operand.llvm_type
+                    + "*");
+                current_lines.push("  store " + operand.llvm_type + " "
+                    + operand.value
+                    + ", "
+                    + operand.llvm_type
+                    + "* "
+                    + typed_ptr_temp);
+                current_lines.push("  call void @sailfin_runtime_mark_persistent(i8* "
+                    + malloc_temp
+                    + ")");
                 let coerced = LLVMOperand {
                     llvm_type: "i8*",
                     value: malloc_temp
@@ -964,7 +1224,9 @@ fn coerce_general_fallback(operand: LLVMOperand, operand_type: string, target: s
     if operand.llvm_type == "i8*" {
         if ends_with_pointer_suffix(target) {
             let temp_name = format_temp_name(temp_index);
-            current_lines.push("  " + temp_name + " = bitcast i8* " + operand.value + " to " + target);
+            current_lines.push("  " + temp_name + " = bitcast i8* " + operand.value
+                + " to "
+                + target);
             let coerced = LLVMOperand { llvm_type: target, value: temp_name };
             return CoercionResult {
                 lines: current_lines,
@@ -982,18 +1244,44 @@ fn coerce_general_fallback(operand: LLVMOperand, operand_type: string, target: s
                 let size_temp = format_temp_name(temp_index + 1);
                 let malloc_temp = format_temp_name(temp_index + 2);
                 let typed_ptr_temp = format_temp_name(temp_index + 3);
-                current_lines.push("  " + size_ptr_temp + " = getelementptr " + operand.llvm_type + ", " + operand.llvm_type + "* null, i32 1");
-                current_lines.push("  " + size_temp + " = ptrtoint " + operand.llvm_type + "* " + size_ptr_temp + " to i64");
-                current_lines.push("  " + malloc_temp + " = call noalias i8* @calloc(i64 1, i64 " + size_temp + ")");
-                current_lines.push("  " + typed_ptr_temp + " = bitcast i8* " + malloc_temp + " to " + operand.llvm_type + "*");
-                current_lines.push("  store " + operand.llvm_type + " " + operand.value + ", " + operand.llvm_type + "* " + typed_ptr_temp);
-                current_lines.push("  call void @sailfin_runtime_mark_persistent(i8* " + malloc_temp + ")");
+                current_lines.push("  " + size_ptr_temp + " = getelementptr "
+                    + operand.llvm_type
+                    + ", "
+                    + operand.llvm_type
+                    + "* null, i32 1");
+                current_lines.push("  " + size_temp + " = ptrtoint " + operand.llvm_type
+                    + "* "
+                    + size_ptr_temp
+                    + " to i64");
+                current_lines.push("  " + malloc_temp
+                    + " = call noalias i8* @calloc(i64 1, i64 "
+                    + size_temp
+                    + ")");
+                current_lines.push("  " + typed_ptr_temp + " = bitcast i8* "
+                    + malloc_temp
+                    + " to "
+                    + operand.llvm_type
+                    + "*");
+                current_lines.push("  store " + operand.llvm_type + " "
+                    + operand.value
+                    + ", "
+                    + operand.llvm_type
+                    + "* "
+                    + typed_ptr_temp);
+                current_lines.push("  call void @sailfin_runtime_mark_persistent(i8* "
+                    + malloc_temp
+                    + ")");
                 let mut pointer_value: string = typed_ptr_temp;
                 let mut next_index: number = temp_index + 4;
                 let typed_pointer_type = operand.llvm_type + "*";
                 if typed_pointer_type != target {
                     let cast_temp = format_temp_name(next_index);
-                    current_lines.push("  " + cast_temp + " = bitcast " + typed_pointer_type + " " + typed_ptr_temp + " to " + target);
+                    current_lines.push("  " + cast_temp + " = bitcast "
+                        + typed_pointer_type
+                        + " "
+                        + typed_ptr_temp
+                        + " to "
+                        + target);
                     pointer_value = cast_temp;
                     next_index += 1;
                 }
@@ -1012,17 +1300,28 @@ fn coerce_general_fallback(operand: LLVMOperand, operand_type: string, target: s
     }
     if !ends_with_pointer_suffix(operand.llvm_type) {
         if ends_with_pointer_suffix(target) {
-            let operand_array_element = array_pointer_element_type(operand.llvm_type + "*");
+            let operand_array_element = array_pointer_element_type(operand.llvm_type
+                + "*");
             if operand_array_element.length > 0 {
                 let alloca_temp = format_temp_name(temp_index);
                 current_lines.push("  " + alloca_temp + " = alloca " + operand.llvm_type);
-                current_lines.push("  store " + operand.llvm_type + " " + operand.value + ", " + operand.llvm_type + "* " + alloca_temp);
+                current_lines.push("  store " + operand.llvm_type + " "
+                    + operand.value
+                    + ", "
+                    + operand.llvm_type
+                    + "* "
+                    + alloca_temp);
                 let mut next_index: number = temp_index + 1;
                 let mut pointer_value: string = alloca_temp;
                 let operand_pointer_type = operand.llvm_type + "*";
                 if operand_pointer_type != target {
                     let bitcast_temp = format_temp_name(next_index);
-                    current_lines.push("  " + bitcast_temp + " = bitcast " + operand_pointer_type + " " + alloca_temp + " to " + target);
+                    current_lines.push("  " + bitcast_temp + " = bitcast "
+                        + operand_pointer_type
+                        + " "
+                        + alloca_temp
+                        + " to "
+                        + target);
                     pointer_value = bitcast_temp;
                     next_index += 1;
                 }
@@ -1046,7 +1345,12 @@ fn coerce_general_fallback(operand: LLVMOperand, operand_type: string, target: s
             if source_element.length > 0 {
                 if target_element.length > 0 {
                     let temp_name = format_temp_name(temp_index);
-                    current_lines.push("  " + temp_name + " = bitcast " + operand.llvm_type + " " + operand.value + " to " + target);
+                    current_lines.push("  " + temp_name + " = bitcast "
+                        + operand.llvm_type
+                        + " "
+                        + operand.value
+                        + " to "
+                        + target);
                     let coerced = LLVMOperand {
                         llvm_type: target,
                         value: temp_name
@@ -1060,7 +1364,11 @@ fn coerce_general_fallback(operand: LLVMOperand, operand_type: string, target: s
                 }
             }
             let temp_name = format_temp_name(temp_index);
-            current_lines.push("  " + temp_name + " = bitcast " + operand.llvm_type + " " + operand.value + " to " + target);
+            current_lines.push("  " + temp_name + " = bitcast " + operand.llvm_type
+                + " "
+                + operand.value
+                + " to "
+                + target);
             let coerced = LLVMOperand { llvm_type: target, value: temp_name };
             return CoercionResult {
                 lines: current_lines,
@@ -1102,13 +1410,21 @@ fn coerce_general_fallback(operand: LLVMOperand, operand_type: string, target: s
             if base_type != target {
                 let desired_pointer_type = target + "*";
                 let bitcast_temp = format_temp_name(pointer_temp_index);
-                current_lines.push("  " + bitcast_temp + " = bitcast " + pointer_type + " " + pointer_value + " to " + desired_pointer_type);
+                current_lines.push("  " + bitcast_temp + " = bitcast "
+                    + pointer_type
+                    + " "
+                    + pointer_value
+                    + " to "
+                    + desired_pointer_type);
                 pointer_type = desired_pointer_type;
                 pointer_value = bitcast_temp;
                 pointer_temp_index += 1;
             }
             let load_temp = format_temp_name(pointer_temp_index);
-            current_lines.push("  " + load_temp + " = load " + target + ", " + pointer_type + " " + pointer_value);
+            current_lines.push("  " + load_temp + " = load " + target + ", "
+                + pointer_type
+                + " "
+                + pointer_value);
             let coerced = LLVMOperand { llvm_type: target, value: load_temp };
             return CoercionResult {
                 lines: current_lines,
@@ -1124,7 +1440,9 @@ fn coerce_general_fallback(operand: LLVMOperand, operand_type: string, target: s
 fn coerce_operand_to_type(operand: LLVMOperand, target_type: string, temp_index: number, lines: string[]) -> CoercionResult {
     let debug_coerce = fs.exists("build/sailfin/.trace_lowering");
     if debug_coerce {
-        print.err("emit-llvm: coerce_operand entry operand_type=" + operand.llvm_type + " target=" + target_type);
+        print.err("emit-llvm: coerce_operand entry operand_type=" + operand.llvm_type
+            + " target="
+            + target_type);
     }
     let mut diagnostics: string[] = [];
     let mut current_lines: string[] = lines;
@@ -1153,7 +1471,11 @@ fn coerce_operand_to_type(operand: LLVMOperand, target_type: string, temp_index:
     if pointer != null { return pointer; }
     let general = coerce_general_fallback(operand, operand_type, target, temp_index, current_lines);
     if general != null { return general; }
-    diagnostics.push("llvm lowering: unable to coerce operand of type `" + operand.llvm_type + "` to `" + target_type + "`");
+    diagnostics.push("llvm lowering: unable to coerce operand of type `"
+        + operand.llvm_type
+        + "` to `"
+        + target_type
+        + "`");
     return CoercionResult {
         lines: current_lines,
         temp_index: temp_index,
@@ -1230,7 +1552,7 @@ fn harmonise_operands(left: LLVMOperand, right: LLVMOperand, temp_index: number,
             left: left_operand,
             right: right_operand,
             diagnostics: diagnostics,
-            result_type: left_operand.llvm_type,
+            result_type: left_operand.llvm_type
         };
     }
     let target_type = dominant_type(left_operand.llvm_type, right_operand.llvm_type);
@@ -1242,14 +1564,18 @@ fn harmonise_operands(left: LLVMOperand, right: LLVMOperand, temp_index: number,
         _ci0 += 1;
     }
     if left_coercion.operand == null {
-        diagnostics.push("llvm lowering: unable to convert left operand from `" + left_operand.llvm_type + "` to `" + target_type + "`");
+        diagnostics.push("llvm lowering: unable to convert left operand from `"
+            + left_operand.llvm_type
+            + "` to `"
+            + target_type
+            + "`");
         return BinaryAlignmentResult {
             lines: left_coercion.lines,
             temp_index: left_coercion.temp_index,
             left: null,
             right: null,
             diagnostics: diagnostics,
-            result_type: target_type,
+            result_type: target_type
         };
     }
     left_operand = left_coercion.operand;
@@ -1264,14 +1590,18 @@ fn harmonise_operands(left: LLVMOperand, right: LLVMOperand, temp_index: number,
         _ci1 += 1;
     }
     if right_coercion.operand == null {
-        diagnostics.push("llvm lowering: unable to convert right operand from `" + right_operand.llvm_type + "` to `" + target_type + "`");
+        diagnostics.push("llvm lowering: unable to convert right operand from `"
+            + right_operand.llvm_type
+            + "` to `"
+            + target_type
+            + "`");
         return BinaryAlignmentResult {
             lines: right_coercion.lines,
             temp_index: right_coercion.temp_index,
             left: null,
             right: null,
             diagnostics: diagnostics,
-            result_type: target_type,
+            result_type: target_type
         };
     }
     right_operand = right_coercion.operand;
@@ -1284,6 +1614,6 @@ fn harmonise_operands(left: LLVMOperand, right: LLVMOperand, temp_index: number,
         left: left_operand,
         right: right_operand,
         diagnostics: diagnostics,
-        result_type: target_type,
+        result_type: target_type
     };
 }

--- a/compiler/src/llvm/expression_lowering/native/core_operators.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_operators.sfn
@@ -2,13 +2,9 @@
 //
 // Operator and expression-shape helpers extracted from core.sfn.
 import { char_at, char_code, substring } from "../../../string_utils";
-import { OperatorMatch, } from "../../types";
-import {
-    contains_text,
-    starts_with,
-    trim_text,
-} from "../../utils";
-import { char_code_at_text, is_trim_char, } from "./core_text";
+import { OperatorMatch } from "../../types";
+import { contains_text, starts_with, trim_text } from "../../utils";
+import { char_code_at_text, is_trim_char } from "./core_text";
 
 fn lines_end_with_terminator(lines: string[]) -> boolean {
     let mut index: number = lines.length - 1;
@@ -160,16 +156,19 @@ fn find_top_level_operator(expression: string, operators: string) -> OperatorMat
                             if ch == "-" {
                                 if is_binary_minus(expression, index) {
                                     candidate_index = index;
-                                    candidate_symbol = substring(expression, index, index + 1);
+                                    candidate_symbol = substring(expression, index, index
+                                        + 1);
                                 }
                             } else if ch == "*" {
                                 if is_binary_star(expression, index) {
                                     candidate_index = index;
-                                    candidate_symbol = substring(expression, index, index + 1);
+                                    candidate_symbol = substring(expression, index, index
+                                        + 1);
                                 }
                             } else {
                                 candidate_index = index;
-                                candidate_symbol = substring(expression, index, index + 1);
+                                candidate_symbol = substring(expression, index, index
+                                    + 1);
                             }
                         }
                     }

--- a/compiler/src/llvm/expression_lowering/native/core_operators.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_operators.sfn
@@ -1,50 +1,29 @@
 // compiler/src/llvm/expression_lowering/native/core_operators.sfn
 //
 // Operator and expression-shape helpers extracted from core.sfn.
-
-import { substring, char_at, char_code } from "../../../string_utils";
-
+import { char_at, char_code, substring } from "../../../string_utils";
+import { OperatorMatch, } from "../../types";
 import {
-    OperatorMatch,
-} from "../../types";
-
-import {
-    trim_text,
-    starts_with,
     contains_text,
+    starts_with,
+    trim_text,
 } from "../../utils";
-
-import {
-    char_code_at_text,
-    is_trim_char,
-} from "./core_text";
+import { char_code_at_text, is_trim_char, } from "./core_text";
 
 fn lines_end_with_terminator(lines: string[]) -> boolean {
     let mut index: number = lines.length - 1;
     loop {
-        if lines.length == 0 {
-            return false;
-        }
-        if index < 0 {
-            break;
-        }
+        if lines.length == 0 { return false; }
+        if index < 0 { break; }
         let line = trim_text(lines[index]);
         if line.length == 0 {
             index -= 1;
             continue;
         }
-        if starts_with(line, "ret") {
-            return true;
-        }
-        if starts_with(line, "br ") {
-            return true;
-        }
-        if starts_with(line, "switch ") {
-            return true;
-        }
-        if line == "unreachable" {
-            return true;
-        }
+        if starts_with(line, "ret") { return true; }
+        if starts_with(line, "br ") { return true; }
+        if starts_with(line, "switch ") { return true; }
+        if line == "unreachable" { return true; }
         return false;
     }
     return false;
@@ -52,25 +31,19 @@ fn lines_end_with_terminator(lines: string[]) -> boolean {
 
 fn strip_enclosing_parentheses(expression: string) -> string {
     let trimmed = trim_text(expression);
-    if trimmed.length < 2 {
-        return trimmed;
-    }
+    if trimmed.length < 2 { return trimmed; }
     let mut _if90: boolean = false;
     if substring(trimmed, 0, 1) != "(" { _if90 = true; }
-    if substring(trimmed, trimmed.length - 1, trimmed.length) != ")" { _if90 = true; }
-    if _if90 {
-        return trimmed;
+    if substring(trimmed, trimmed.length - 1, trimmed.length) != ")" {
+        _if90 = true;
     }
+    if _if90 { return trimmed; }
     let mut depth: number = 0;
     let mut index: number = 0;
     loop {
-        if index >= trimmed.length {
-            break;
-        }
+        if index >= trimmed.length { break; }
         let ch = char_at(trimmed, index);
-        if ch == "(" {
-            depth += 1;
-        } else if ch == ")" {
+        if ch == "(" { depth += 1; } else if ch == ")" {
             depth -= 1;
             if depth == 0 {
                 if index == trimmed.length - 1 {
@@ -97,9 +70,7 @@ fn find_top_level_operator(expression: string, operators: string) -> OperatorMat
     let mut candidate_symbol: string = "";
     let mut index: number = 0;
     loop {
-        if index >= expression.length {
-            break;
-        }
+        if index >= expression.length { break; }
         let ch = char_at(expression, index);
         if in_double {
             if escape_next {
@@ -112,9 +83,7 @@ fn find_top_level_operator(expression: string, operators: string) -> OperatorMat
                 index += 1;
                 continue;
             }
-            if ch == "\"" {
-                in_double = false;
-            }
+            if ch == "\"" { in_double = false; }
             index += 1;
             continue;
         }
@@ -129,9 +98,7 @@ fn find_top_level_operator(expression: string, operators: string) -> OperatorMat
                 index += 1;
                 continue;
             }
-            if ch == "'" {
-                in_single = false;
-            }
+            if ch == "'" { in_single = false; }
             index += 1;
             continue;
         }
@@ -151,9 +118,7 @@ fn find_top_level_operator(expression: string, operators: string) -> OperatorMat
             continue;
         }
         if ch == ")" {
-            if paren_depth > 0 {
-                paren_depth -= 1;
-            }
+            if paren_depth > 0 { paren_depth -= 1; }
             index += 1;
             continue;
         }
@@ -163,9 +128,7 @@ fn find_top_level_operator(expression: string, operators: string) -> OperatorMat
             continue;
         }
         if ch == "]" {
-            if bracket_depth > 0 {
-                bracket_depth -= 1;
-            }
+            if bracket_depth > 0 { bracket_depth -= 1; }
             index += 1;
             continue;
         }
@@ -175,9 +138,7 @@ fn find_top_level_operator(expression: string, operators: string) -> OperatorMat
             continue;
         }
         if ch == "}" {
-            if brace_depth > 0 {
-                brace_depth -= 1;
-            }
+            if brace_depth > 0 { brace_depth -= 1; }
             index += 1;
             continue;
         }
@@ -187,9 +148,7 @@ fn find_top_level_operator(expression: string, operators: string) -> OperatorMat
             continue;
         }
         if ch == ">" {
-            if angle_depth > 0 {
-                angle_depth -= 1;
-            }
+            if angle_depth > 0 { angle_depth -= 1; }
             index += 1;
             continue;
         }
@@ -220,7 +179,11 @@ fn find_top_level_operator(expression: string, operators: string) -> OperatorMat
         index += 1;
     }
     if candidate_index >= 0 {
-        return OperatorMatch { index: candidate_index, symbol: candidate_symbol, success: true };
+        return OperatorMatch {
+            index: candidate_index,
+            symbol: candidate_symbol,
+            success: true
+        };
     }
     return OperatorMatch { index: -1, symbol: "", success: false };
 }
@@ -233,9 +196,7 @@ fn find_comparison_operator(expression: string) -> OperatorMatch {
     let mut in_string: boolean = false;
     let mut escape_next: boolean = false;
     loop {
-        if index >= expression.length {
-            break;
-        }
+        if index >= expression.length { break; }
         let ch = substring(expression, index, index + 1);
         if in_string {
             if escape_next {
@@ -248,9 +209,7 @@ fn find_comparison_operator(expression: string) -> OperatorMatch {
                 index += 1;
                 continue;
             }
-            if ch == "\"" {
-                in_string = false;
-            }
+            if ch == "\"" { in_string = false; }
             index += 1;
             continue;
         }
@@ -265,9 +224,7 @@ fn find_comparison_operator(expression: string) -> OperatorMatch {
             continue;
         }
         if ch == ")" {
-            if depth > 0 {
-                depth -= 1;
-            }
+            if depth > 0 { depth -= 1; }
             index += 1;
             continue;
         }
@@ -277,9 +234,7 @@ fn find_comparison_operator(expression: string) -> OperatorMatch {
             continue;
         }
         if ch == "}" {
-            if brace_depth > 0 {
-                brace_depth -= 1;
-            }
+            if brace_depth > 0 { brace_depth -= 1; }
             index += 1;
             continue;
         }
@@ -289,9 +244,7 @@ fn find_comparison_operator(expression: string) -> OperatorMatch {
             continue;
         }
         if ch == "]" {
-            if bracket_depth > 0 {
-                bracket_depth -= 1;
-            }
+            if bracket_depth > 0 { bracket_depth -= 1; }
             index += 1;
             continue;
         }
@@ -314,23 +267,47 @@ fn find_comparison_operator(expression: string) -> OperatorMatch {
         if _co_next < expression.length {
             let two_char = substring(expression, index, _co_next2);
             if two_char == "==" {
-                return OperatorMatch { index: index, symbol: "==", success: true };
+                return OperatorMatch {
+                    index: index,
+                    symbol: "==",
+                    success: true
+                };
             }
             if two_char == "!=" {
-                return OperatorMatch { index: index, symbol: "!=", success: true };
+                return OperatorMatch {
+                    index: index,
+                    symbol: "!=",
+                    success: true
+                };
             }
             if two_char == "<=" {
-                return OperatorMatch { index: index, symbol: "<=", success: true };
+                return OperatorMatch {
+                    index: index,
+                    symbol: "<=",
+                    success: true
+                };
             }
             if two_char == ">=" {
-                return OperatorMatch { index: index, symbol: ">=", success: true };
+                return OperatorMatch {
+                    index: index,
+                    symbol: ">=",
+                    success: true
+                };
             }
         }
         if ch == "<" {
-            return OperatorMatch { index: index, symbol: "<", success: true };
+            return OperatorMatch {
+                index: index,
+                symbol: "<",
+                success: true
+            };
         }
         if ch == ">" {
-            return OperatorMatch { index: index, symbol: ">", success: true };
+            return OperatorMatch {
+                index: index,
+                symbol: ">",
+                success: true
+            };
         }
         index += 1;
     }
@@ -347,9 +324,7 @@ fn find_logical_operator(expression: string) -> OperatorMatch {
 
     let _lo_limit = expression.length - 1;
     loop {
-        if index >= _lo_limit {
-            break;
-        }
+        if index >= _lo_limit { break; }
         let _lo_next = index + 1;
         let ch = substring(expression, index, _lo_next);
         if in_string {
@@ -363,9 +338,7 @@ fn find_logical_operator(expression: string) -> OperatorMatch {
                 index += 1;
                 continue;
             }
-            if ch == "\"" {
-                in_string = false;
-            }
+            if ch == "\"" { in_string = false; }
             index += 1;
             continue;
         }
@@ -380,9 +353,7 @@ fn find_logical_operator(expression: string) -> OperatorMatch {
             continue;
         }
         if ch == ")" {
-            if depth > 0 {
-                depth -= 1;
-            }
+            if depth > 0 { depth -= 1; }
             index += 1;
             continue;
         }
@@ -392,9 +363,7 @@ fn find_logical_operator(expression: string) -> OperatorMatch {
             continue;
         }
         if ch == "}" {
-            if brace_depth > 0 {
-                brace_depth -= 1;
-            }
+            if brace_depth > 0 { brace_depth -= 1; }
             index += 1;
             continue;
         }
@@ -404,9 +373,7 @@ fn find_logical_operator(expression: string) -> OperatorMatch {
             continue;
         }
         if ch == "]" {
-            if bracket_depth > 0 {
-                bracket_depth -= 1;
-            }
+            if bracket_depth > 0 { bracket_depth -= 1; }
             index += 1;
             continue;
         }
@@ -416,7 +383,11 @@ fn find_logical_operator(expression: string) -> OperatorMatch {
                     let _lo_next2 = index + 2;
                     let two = substring(expression, index, _lo_next2);
                     if two == "||" {
-                        return OperatorMatch { index: index, symbol: "||", success: true };
+                        return OperatorMatch {
+                            index: index,
+                            symbol: "||",
+                            success: true
+                        };
                     }
                 }
             }
@@ -431,9 +402,7 @@ fn find_logical_operator(expression: string) -> OperatorMatch {
     in_string = false;
     escape_next = false;
     loop {
-        if index >= _lo_limit {
-            break;
-        }
+        if index >= _lo_limit { break; }
         let _lo2_next = index + 1;
         let ch = substring(expression, index, _lo2_next);
         if in_string {
@@ -447,9 +416,7 @@ fn find_logical_operator(expression: string) -> OperatorMatch {
                 index += 1;
                 continue;
             }
-            if ch == "\"" {
-                in_string = false;
-            }
+            if ch == "\"" { in_string = false; }
             index += 1;
             continue;
         }
@@ -464,9 +431,7 @@ fn find_logical_operator(expression: string) -> OperatorMatch {
             continue;
         }
         if ch == ")" {
-            if depth > 0 {
-                depth -= 1;
-            }
+            if depth > 0 { depth -= 1; }
             index += 1;
             continue;
         }
@@ -476,9 +441,7 @@ fn find_logical_operator(expression: string) -> OperatorMatch {
             continue;
         }
         if ch == "}" {
-            if brace_depth > 0 {
-                brace_depth -= 1;
-            }
+            if brace_depth > 0 { brace_depth -= 1; }
             index += 1;
             continue;
         }
@@ -488,9 +451,7 @@ fn find_logical_operator(expression: string) -> OperatorMatch {
             continue;
         }
         if ch == "]" {
-            if bracket_depth > 0 {
-                bracket_depth -= 1;
-            }
+            if bracket_depth > 0 { bracket_depth -= 1; }
             index += 1;
             continue;
         }
@@ -500,7 +461,11 @@ fn find_logical_operator(expression: string) -> OperatorMatch {
                     let _lo2_next2 = index + 2;
                     let two = substring(expression, index, _lo2_next2);
                     if two == "&&" {
-                        return OperatorMatch { index: index, symbol: "&&", success: true };
+                        return OperatorMatch {
+                            index: index,
+                            symbol: "&&",
+                            success: true
+                        };
                     }
                 }
             }
@@ -511,18 +476,12 @@ fn find_logical_operator(expression: string) -> OperatorMatch {
 }
 
 fn contains_char(set: string, ch: string) -> boolean {
-    if ch.length == 0 {
-        return false;
-    }
+    if ch.length == 0 { return false; }
     let mut index: number = 0;
     loop {
-        if index >= set.length {
-            break;
-        }
+        if index >= set.length { break; }
         let set_ch = substring(set, index, index + 1);
-        if set_ch == ch {
-            return true;
-        }
+        if set_ch == ch { return true; }
         index += 1;
     }
     return false;
@@ -531,9 +490,7 @@ fn contains_char(set: string, ch: string) -> boolean {
 fn is_binary_minus(expression: string, index: number) -> boolean {
     let previous = find_previous_non_space_char(expression, index);
     let next = find_next_non_space_char(expression, index);
-    if previous == null {
-        return false;
-    }
+    if previous == null { return false; }
     let prev_char = previous;
     let mut _if91: boolean = false;
     if prev_char == "+" { _if91 = true; }
@@ -542,12 +499,8 @@ fn is_binary_minus(expression: string, index: number) -> boolean {
     if prev_char == "/" { _if91 = true; }
     if prev_char == "(" { _if91 = true; }
     if prev_char == "," { _if91 = true; }
-    if _if91 {
-        return false;
-    }
-    if next == null {
-        return false;
-    }
+    if _if91 { return false; }
+    if next == null { return false; }
     let next_char = next;
     let mut _if92: boolean = false;
     if next_char == "+" { _if92 = true; }
@@ -556,18 +509,14 @@ fn is_binary_minus(expression: string, index: number) -> boolean {
     if next_char == "/" { _if92 = true; }
     if next_char == ")" { _if92 = true; }
     if next_char == "," { _if92 = true; }
-    if _if92 {
-        return false;
-    }
+    if _if92 { return false; }
     return true;
 }
 
 fn is_binary_star(expression: string, index: number) -> boolean {
     let previous = find_previous_non_space_char(expression, index);
     let next = find_next_non_space_char(expression, index);
-    if previous == null {
-        return false;
-    }
+    if previous == null { return false; }
     let prev_char = previous;
     let mut _if93: boolean = false;
     if prev_char == "+" { _if93 = true; }
@@ -576,12 +525,8 @@ fn is_binary_star(expression: string, index: number) -> boolean {
     if prev_char == "/" { _if93 = true; }
     if prev_char == "(" { _if93 = true; }
     if prev_char == "," { _if93 = true; }
-    if _if93 {
-        return false;
-    }
-    if next == null {
-        return false;
-    }
+    if _if93 { return false; }
+    if next == null { return false; }
     let next_char = next;
     let mut _if94: boolean = false;
     if next_char == "+" { _if94 = true; }
@@ -590,23 +535,17 @@ fn is_binary_star(expression: string, index: number) -> boolean {
     if next_char == "/" { _if94 = true; }
     if next_char == ")" { _if94 = true; }
     if next_char == "," { _if94 = true; }
-    if _if94 {
-        return false;
-    }
+    if _if94 { return false; }
     return true;
 }
 
 fn find_previous_non_space_char(value: string, index: number) -> string? {
     let mut position: number = index;
     loop {
-        if position <= 0 {
-            break;
-        }
+        if position <= 0 { break; }
         position -= 1;
         let ch = char_at(value, position);
-        if !is_trim_char(ch) {
-            return ch;
-        }
+        if !is_trim_char(ch) { return ch; }
     }
     return null;
 }
@@ -614,13 +553,9 @@ fn find_previous_non_space_char(value: string, index: number) -> string? {
 fn find_next_non_space_char(value: string, index: number) -> string? {
     let mut position: number = index + 1;
     loop {
-        if position >= value.length {
-            break;
-        }
+        if position >= value.length { break; }
         let ch = char_at(value, position);
-        if !is_trim_char(ch) {
-            return ch;
-        }
+        if !is_trim_char(ch) { return ch; }
         position += 1;
     }
     return null;

--- a/compiler/src/llvm/expression_lowering/native/core_ops_lowering.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_ops_lowering.sfn
@@ -15,7 +15,7 @@ import {
     ParameterBinding,
     StringConstant,
     TernaryParseResult,
-    TypeContext,
+    TypeContext
 } from "../../types";
 import {
     append_string,
@@ -28,7 +28,7 @@ import {
     number_to_string,
     starts_with,
     string_array_contains,
-    trim_text,
+    trim_text
 } from "../../utils";
 // NOTE: this module imports lower_expression from core.sfn; this is mutually recursive.
 import { lower_expression } from "./core";
@@ -36,7 +36,7 @@ import { operation_name_for_symbol } from "./core_helpers";
 import {
     coerce_operand_to_type,
     emit_comparison_instruction,
-    harmonise_operands,
+    harmonise_operands
 } from "./core_operands";
 import { lines_end_with_terminator, strip_enclosing_parentheses } from "./core_operators";
 
@@ -54,7 +54,8 @@ fn lower_logical_not_with_operand(operand: LLVMOperand, temp_index: number, line
     if coerced.operand != null {
         let bool_operand = coerced.operand;
         let result_temp = format_temp_name(current_temp);
-        current_lines.push("  " + result_temp + " = xor i1 " + bool_operand.value + ", 1");
+        current_lines.push("  " + result_temp + " = xor i1 " + bool_operand.value
+            + ", 1");
         current_temp += 1;
         let result_operand = LLVMOperand {
             llvm_type: "i1",
@@ -138,7 +139,10 @@ fn lower_ternary_expression(parse: TernaryParseResult, bindings: ParameterBindin
     current_lines.push("  br label %" + cond_label);
     current_lines.push("");
     current_lines.push(cond_label + ":");
-    current_lines.push("  br i1 " + cond_bool.operand.value + ", label %" + then_label + ", label %" + else_label);
+    current_lines.push("  br i1 " + cond_bool.operand.value + ", label %"
+        + then_label
+        + ", label %"
+        + else_label);
 
     current_lines.push("");
     current_lines.push(then_label + ":");
@@ -188,7 +192,11 @@ fn lower_ternary_expression(parse: TernaryParseResult, bindings: ParameterBindin
     current_lines.push(merge_label + ":");
 
     if then_result.operand.llvm_type != else_result.operand.llvm_type {
-        diagnostics.push("llvm lowering: ternary expression branches have incompatible types: `" + then_result.operand.llvm_type + "` vs `" + else_result.operand.llvm_type + "`");
+        diagnostics.push("llvm lowering: ternary expression branches have incompatible types: `"
+            + then_result.operand.llvm_type
+            + "` vs `"
+            + else_result.operand.llvm_type
+            + "`");
         return ExpressionResult {
             lines: current_lines,
             temp_index: else_result.temp_index,
@@ -200,7 +208,15 @@ fn lower_ternary_expression(parse: TernaryParseResult, bindings: ParameterBindin
 
     let result_temp = format_temp_name(else_result.temp_index);
     let result_type = then_result.operand.llvm_type;
-    current_lines.push("  " + result_temp + " = phi " + result_type + " [ " + then_result.operand.value + ", %" + then_end_label + " ], [ " + else_result.operand.value + ", %" + else_end_label + " ]");
+    current_lines.push("  " + result_temp + " = phi " + result_type + " [ "
+        + then_result.operand.value
+        + ", %"
+        + then_end_label
+        + " ], [ "
+        + else_result.operand.value
+        + ", %"
+        + else_end_label
+        + " ]");
 
     let operand = LLVMOperand { llvm_type: result_type, value: result_temp };
     return ExpressionResult {
@@ -220,7 +236,9 @@ fn lower_binary_operation(expression: string, match: OperatorMatch, bindings: Pa
     if left_text.length == 0 { _if95 = true; }
     if right_text.length == 0 { _if95 = true; }
     if _if95 {
-        diagnostics.push("llvm lowering: malformed binary expression `" + expression + "`");
+        diagnostics.push("llvm lowering: malformed binary expression `"
+            + expression
+            + "`");
         let empty_constants = empty_string_constant_set();
         return ExpressionResult {
             lines: lines,
@@ -268,7 +286,12 @@ fn lower_binary_operation(expression: string, match: OperatorMatch, bindings: Pa
                 let mut current_temp = right_result.temp_index;
                 let concat_name = format_temp_name(current_temp);
                 current_temp += 1;
-                current_lines.push("  " + concat_name + " = call i8* @sailfin_runtime_string_concat(i8* " + lhs.value + ", i8* " + rhs.value + ")");
+                current_lines.push("  " + concat_name
+                    + " = call i8* @sailfin_runtime_string_concat(i8* "
+                    + lhs.value
+                    + ", i8* "
+                    + rhs.value
+                    + ")");
                 let operand = LLVMOperand {
                     llvm_type: "i8*",
                     value: concat_name
@@ -302,7 +325,12 @@ fn lower_binary_operation(expression: string, match: OperatorMatch, bindings: Pa
 
                 let concat_name = format_temp_name(current_temp);
                 current_temp += 1;
-                current_lines.push("  " + concat_name + " = call i8* @sailfin_runtime_string_concat(i8* " + lhs.value + ", i8* " + coerced.operand.value + ")");
+                current_lines.push("  " + concat_name
+                    + " = call i8* @sailfin_runtime_string_concat(i8* "
+                    + lhs.value
+                    + ", i8* "
+                    + coerced.operand.value
+                    + ")");
 
                 let operand = LLVMOperand {
                     llvm_type: "i8*",
@@ -337,7 +365,12 @@ fn lower_binary_operation(expression: string, match: OperatorMatch, bindings: Pa
 
                 let concat_name = format_temp_name(current_temp);
                 current_temp += 1;
-                current_lines.push("  " + concat_name + " = call i8* @sailfin_runtime_string_concat(i8* " + coerced.operand.value + ", i8* " + rhs.value + ")");
+                current_lines.push("  " + concat_name
+                    + " = call i8* @sailfin_runtime_string_concat(i8* "
+                    + coerced.operand.value
+                    + ", i8* "
+                    + rhs.value
+                    + ")");
 
                 let operand = LLVMOperand {
                     llvm_type: "i8*",
@@ -388,7 +421,12 @@ fn lower_binary_operation(expression: string, match: OperatorMatch, bindings: Pa
 
                 let concat_name = format_temp_name(current_temp);
                 current_temp += 1;
-                current_lines.push("  " + concat_name + " = call i8* @sailfin_runtime_string_concat(i8* " + lhs_coerced.operand.value + ", i8* " + rhs_coerced.operand.value + ")");
+                current_lines.push("  " + concat_name
+                    + " = call i8* @sailfin_runtime_string_concat(i8* "
+                    + lhs_coerced.operand.value
+                    + ", i8* "
+                    + rhs_coerced.operand.value
+                    + ")");
 
                 let operand = LLVMOperand {
                     llvm_type: "i8*",
@@ -441,7 +479,12 @@ fn lower_binary_operation(expression: string, match: OperatorMatch, bindings: Pa
 
             let concat_name = format_temp_name(current_temp);
             current_temp += 1;
-            current_lines.push("  " + concat_name + " = call i8* @sailfin_runtime_string_concat(i8* " + lhs_coerced.operand.value + ", i8* " + rhs_coerced.operand.value + ")");
+            current_lines.push("  " + concat_name
+                + " = call i8* @sailfin_runtime_string_concat(i8* "
+                + lhs_coerced.operand.value
+                + ", i8* "
+                + rhs_coerced.operand.value
+                + ")");
             let operand = LLVMOperand {
                 llvm_type: "i8*",
                 value: concat_name
@@ -501,7 +544,11 @@ fn lower_binary_operation(expression: string, match: OperatorMatch, bindings: Pa
 
                 let operation = operation_name_for_symbol(match.symbol, "double");
                 let temp_name = format_temp_name(current_temp);
-                current_lines.push("  " + temp_name + " = " + operation + " double " + lhs_coerced.operand.value + ", " + rhs_coerced.operand.value);
+                current_lines.push("  " + temp_name + " = " + operation
+                    + " double "
+                    + lhs_coerced.operand.value
+                    + ", "
+                    + rhs_coerced.operand.value);
                 let operand = LLVMOperand {
                     llvm_type: "double",
                     value: temp_name
@@ -561,14 +608,22 @@ fn lower_binary_operation(expression: string, match: OperatorMatch, bindings: Pa
                     if match.symbol == "-" {
                         let neg_name = format_temp_name(current_temp);
                         current_temp += 1;
-                        current_lines.push("  " + neg_name + " = sub i64 0, " + rhs_i64.value);
+                        current_lines.push("  " + neg_name + " = sub i64 0, "
+                            + rhs_i64.value);
                         index_value = neg_name;
                     }
 
                     let element_type = strip_pointer_suffix(left_type);
                     let gep_name = format_temp_name(current_temp);
                     current_temp += 1;
-                    current_lines.push("  " + gep_name + " = getelementptr " + element_type + ", " + left_type + " " + left_result.operand.value + ", i64 " + index_value);
+                    current_lines.push("  " + gep_name + " = getelementptr "
+                        + element_type
+                        + ", "
+                        + left_type
+                        + " "
+                        + left_result.operand.value
+                        + ", i64 "
+                        + index_value);
                     let operand = LLVMOperand {
                         llvm_type: left_type,
                         value: gep_name
@@ -606,7 +661,12 @@ fn lower_binary_operation(expression: string, match: OperatorMatch, bindings: Pa
     if match.symbol == "+" {
         if result_type == "i8*" {
             let temp_name = format_temp_name(harmonised.temp_index);
-            let line = "  " + temp_name + " = call i8* @sailfin_runtime_string_concat(i8* " + left_aligned.value + ", i8* " + right_aligned.value + ")";
+            let line = "  " + temp_name
+                + " = call i8* @sailfin_runtime_string_concat(i8* "
+                + left_aligned.value
+                + ", i8* "
+                + right_aligned.value
+                + ")";
             let updated_lines = append_string(harmonised.lines, line);
             let operand = LLVMOperand { llvm_type: "i8*", value: temp_name };
             return ExpressionResult {
@@ -620,7 +680,10 @@ fn lower_binary_operation(expression: string, match: OperatorMatch, bindings: Pa
     }
     let operation = operation_name_for_symbol(match.symbol, result_type);
     let temp_name = format_temp_name(harmonised.temp_index);
-    let line = "  " + temp_name + " = " + operation + " " + result_type + " " + left_aligned.value + ", " + right_aligned.value;
+    let line = "  " + temp_name + " = " + operation + " " + result_type + " "
+        + left_aligned.value
+        + ", "
+        + right_aligned.value;
     let updated_lines = append_string(harmonised.lines, line);
     let operand = LLVMOperand { llvm_type: result_type, value: temp_name };
     return ExpressionResult {
@@ -652,7 +715,9 @@ fn lower_comparison_operation(expression: string, match: OperatorMatch, bindings
     if match.symbol == null { _if101 = true; }
     if match.symbol.length == 0 { _if101 = true; }
     if _if101 {
-        diagnostics.push("llvm lowering: comparison operator missing in `" + expression + "`");
+        diagnostics.push("llvm lowering: comparison operator missing in `"
+            + expression
+            + "`");
         let empty_constants = empty_string_constant_set();
         return ExpressionResult {
             lines: lines,
@@ -666,7 +731,9 @@ fn lower_comparison_operation(expression: string, match: OperatorMatch, bindings
     if match.index < 0 { _if102 = true; }
     if match.index >= expression.length { _if102 = true; }
     if _if102 {
-        diagnostics.push("llvm lowering: comparison operator index out of bounds in `" + expression + "`");
+        diagnostics.push("llvm lowering: comparison operator index out of bounds in `"
+            + expression
+            + "`");
         let empty_constants = empty_string_constant_set();
         return ExpressionResult {
             lines: lines,
@@ -679,12 +746,15 @@ fn lower_comparison_operation(expression: string, match: OperatorMatch, bindings
 
     let operator_length = match.symbol.length;
     let left_text = trim_text(substring(expression, 0, match.index));
-    let right_text = trim_text(substring(expression, match.index + operator_length, expression.length));
+    let right_text = trim_text(substring(expression, match.index
+        + operator_length, expression.length));
     let mut _if103: boolean = false;
     if left_text.length == 0 { _if103 = true; }
     if right_text.length == 0 { _if103 = true; }
     if _if103 {
-        diagnostics.push("llvm lowering: malformed comparison expression `" + expression + "`");
+        diagnostics.push("llvm lowering: malformed comparison expression `"
+            + expression
+            + "`");
         let empty_constants = empty_string_constant_set();
         return ExpressionResult {
             lines: lines,
@@ -752,17 +822,34 @@ fn lower_comparison_operation(expression: string, match: OperatorMatch, bindings
 
                         let left_tag_temp = format_temp_name(alignment_temp);
                         alignment_temp += 1;
-                        alignment_lines.push("  " + left_tag_temp + " = extractvalue " + left_operand.llvm_type + " " + left_operand.value + ", 0");
+                        alignment_lines.push("  " + left_tag_temp
+                            + " = extractvalue "
+                            + left_operand.llvm_type
+                            + " "
+                            + left_operand.value
+                            + ", 0");
 
                         let right_tag_temp = format_temp_name(alignment_temp);
                         alignment_temp += 1;
-                        alignment_lines.push("  " + right_tag_temp + " = extractvalue " + right_operand.llvm_type + " " + right_operand.value + ", 0");
+                        alignment_lines.push("  " + right_tag_temp
+                            + " = extractvalue "
+                            + right_operand.llvm_type
+                            + " "
+                            + right_operand.value
+                            + ", 0");
 
                         let compare_temp = format_temp_name(alignment_temp);
                         alignment_temp += 1;
                         let mut predicate: string = "icmp eq";
                         if match.symbol == "!=" { predicate = "icmp ne"; }
-                        alignment_lines.push("  " + compare_temp + " = " + predicate + " " + tag_llvm_type + " " + left_tag_temp + ", " + right_tag_temp);
+                        alignment_lines.push("  " + compare_temp + " = "
+                            + predicate
+                            + " "
+                            + tag_llvm_type
+                            + " "
+                            + left_tag_temp
+                            + ", "
+                            + right_tag_temp);
                         let operand = LLVMOperand {
                             llvm_type: "i1",
                             value: compare_temp
@@ -872,7 +959,8 @@ fn lower_logical_and(expression: string, match: OperatorMatch, bindings: Paramet
     if left_text.length == 0 { _if106 = true; }
     if right_text.length == 0 { _if106 = true; }
     if _if106 {
-        diagnostics.push("llvm lowering: malformed && expression `" + expression + "`");
+        diagnostics.push("llvm lowering: malformed && expression `" + expression
+            + "`");
         return ExpressionResult {
             lines: lines,
             temp_index: temp_index,
@@ -921,7 +1009,10 @@ fn lower_logical_and(expression: string, match: OperatorMatch, bindings: Paramet
     current_lines.push("");
     current_lines.push(entry_label + ":");
 
-    current_lines.push("  br i1 " + left_bool.operand.value + ", label %" + check_right_label + ", label %" + merge_label);
+    current_lines.push("  br i1 " + left_bool.operand.value + ", label %"
+        + check_right_label
+        + ", label %"
+        + merge_label);
     current_lines.push("");
     current_lines.push(check_right_label + ":");
 
@@ -929,7 +1020,9 @@ fn lower_logical_and(expression: string, match: OperatorMatch, bindings: Paramet
     diagnostics = extend_string_array(diagnostics, right_result.diagnostics);
     string_constants = merge_string_constants(string_constants, right_result.string_constants);
     if right_result.operand == null {
-        diagnostics.push("llvm lowering: unable to lower && RHS in `" + expression + "`");
+        diagnostics.push("llvm lowering: unable to lower && RHS in `"
+            + expression
+            + "`");
 
         let mut fallback_lines = right_result.lines;
         if !lines_end_with_terminator(fallback_lines) {
@@ -970,7 +1063,12 @@ fn lower_logical_and(expression: string, match: OperatorMatch, bindings: Paramet
     current_lines.push(merge_label + ":");
 
     let result_temp = format_temp_name(right_bool.temp_index);
-    current_lines.push("  " + result_temp + " = phi i1 [ false, %" + entry_label + " ], [ " + right_bool.operand.value + ", %" + right_end_label + " ]");
+    current_lines.push("  " + result_temp + " = phi i1 [ false, %" + entry_label
+        + " ], [ "
+        + right_bool.operand.value
+        + ", %"
+        + right_end_label
+        + " ]");
 
     let operand = LLVMOperand { llvm_type: "i1", value: result_temp };
     return ExpressionResult {
@@ -992,7 +1090,8 @@ fn lower_logical_or(expression: string, match: OperatorMatch, bindings: Paramete
     if left_text.length == 0 { _if107 = true; }
     if right_text.length == 0 { _if107 = true; }
     if _if107 {
-        diagnostics.push("llvm lowering: malformed || expression `" + expression + "`");
+        diagnostics.push("llvm lowering: malformed || expression `" + expression
+            + "`");
         return ExpressionResult {
             lines: lines,
             temp_index: temp_index,
@@ -1041,7 +1140,10 @@ fn lower_logical_or(expression: string, match: OperatorMatch, bindings: Paramete
     current_lines.push("");
     current_lines.push(entry_label + ":");
 
-    current_lines.push("  br i1 " + left_bool.operand.value + ", label %" + merge_label + ", label %" + check_right_label);
+    current_lines.push("  br i1 " + left_bool.operand.value + ", label %"
+        + merge_label
+        + ", label %"
+        + check_right_label);
     current_lines.push("");
     current_lines.push(check_right_label + ":");
 
@@ -1049,7 +1151,9 @@ fn lower_logical_or(expression: string, match: OperatorMatch, bindings: Paramete
     diagnostics = extend_string_array(diagnostics, right_result.diagnostics);
     string_constants = merge_string_constants(string_constants, right_result.string_constants);
     if right_result.operand == null {
-        diagnostics.push("llvm lowering: unable to lower || RHS in `" + expression + "`");
+        diagnostics.push("llvm lowering: unable to lower || RHS in `"
+            + expression
+            + "`");
 
         let mut fallback_lines = right_result.lines;
         if !lines_end_with_terminator(fallback_lines) {
@@ -1093,7 +1197,12 @@ fn lower_logical_or(expression: string, match: OperatorMatch, bindings: Paramete
     current_lines.push(merge_label + ":");
 
     let result_temp = format_temp_name(right_bool.temp_index);
-    current_lines.push("  " + result_temp + " = phi i1 [ true, %" + entry_label + " ], [ " + right_bool.operand.value + ", %" + right_end_label + " ]");
+    current_lines.push("  " + result_temp + " = phi i1 [ true, %" + entry_label
+        + " ], [ "
+        + right_bool.operand.value
+        + ", %"
+        + right_end_label
+        + " ]");
 
     let operand = LLVMOperand { llvm_type: "i1", value: result_temp };
     return ExpressionResult {
@@ -1112,5 +1221,5 @@ export {
     lower_binary_operation,
     lower_comparison_operation,
     lower_logical_and,
-    lower_logical_or,
+    lower_logical_or
 };

--- a/compiler/src/llvm/expression_lowering/native/core_ops_lowering.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_ops_lowering.sfn
@@ -1,56 +1,44 @@
 // compiler/src/llvm/expression_lowering/native/core_ops_lowering.sfn
 //
 // Lowering for operators and control-flow expressions (ternary, logical, arithmetic).
-
 import { NativeFunction } from "../../../native_ir";
-
+import { substring } from "../../../string_utils";
+import { default_return_literal, format_temp_name } from "../../expressions_helpers";
+import { empty_string_constant_set, merge_string_constants } from "../../strings";
+import { find_enum_info_by_llvm_type } from "../../type_context_queries";
+import { ends_with_pointer_suffix, strip_pointer_suffix } from "../../type_mapping";
 import {
-    TypeContext,
-    ParameterBinding,
-    LocalBinding,
-    OperatorMatch,
-    TernaryParseResult,
     ExpressionResult,
     LLVMOperand,
+    LocalBinding,
+    OperatorMatch,
+    ParameterBinding,
     StringConstant,
+    TernaryParseResult,
+    TypeContext,
 } from "../../types";
-
 import {
-    trim_text,
     append_string,
-    number_to_string,
-    starts_with,
-    ends_with,
-    char_code_at_text,
     char_code,
+    char_code_at_text,
     contains_text,
+    ends_with,
     extend_string_array,
     join_with_separator,
+    number_to_string,
+    starts_with,
     string_array_contains,
+    trim_text,
 } from "../../utils";
-
-import { substring } from "../../../string_utils";
-
-import { empty_string_constant_set, merge_string_constants } from "../../strings";
-
-import { format_temp_name, default_return_literal } from "../../expressions_helpers";
-
-import { strip_pointer_suffix, ends_with_pointer_suffix } from "../../type_mapping";
-
-import { find_enum_info_by_llvm_type } from "../../type_context_queries";
-
-import {
-    coerce_operand_to_type,
-    harmonise_operands,
-    emit_comparison_instruction,
-} from "./core_operands";
-
-import { strip_enclosing_parentheses, lines_end_with_terminator } from "./core_operators";
-
-import { operation_name_for_symbol } from "./core_helpers";
-
 // NOTE: this module imports lower_expression from core.sfn; this is mutually recursive.
 import { lower_expression } from "./core";
+import { operation_name_for_symbol } from "./core_helpers";
+import {
+    coerce_operand_to_type,
+    emit_comparison_instruction,
+    harmonise_operands,
+} from "./core_operands";
+import { lines_end_with_terminator, strip_enclosing_parentheses } from "./core_operators";
 
 fn lower_logical_not_with_operand(operand: LLVMOperand, temp_index: number, lines: string[], diagnostics: string[], string_constants: StringConstant[]) -> ExpressionResult {
     let coerced = coerce_operand_to_type(operand, "i1", temp_index, lines);
@@ -68,10 +56,25 @@ fn lower_logical_not_with_operand(operand: LLVMOperand, temp_index: number, line
         let result_temp = format_temp_name(current_temp);
         current_lines.push("  " + result_temp + " = xor i1 " + bool_operand.value + ", 1");
         current_temp += 1;
-        let result_operand = LLVMOperand { llvm_type: "i1", value: result_temp };
-        return ExpressionResult { lines: current_lines, temp_index: current_temp, operand: result_operand, diagnostics: current_diagnostics, string_constants: string_constants };
+        let result_operand = LLVMOperand {
+            llvm_type: "i1",
+            value: result_temp
+        };
+        return ExpressionResult {
+            lines: current_lines,
+            temp_index: current_temp,
+            operand: result_operand,
+            diagnostics: current_diagnostics,
+            string_constants: string_constants
+        };
     }
-    return ExpressionResult { lines: current_lines, temp_index: current_temp, operand: null, diagnostics: current_diagnostics, string_constants: string_constants };
+    return ExpressionResult {
+        lines: current_lines,
+        temp_index: current_temp,
+        operand: null,
+        diagnostics: current_diagnostics,
+        string_constants: string_constants
+    };
 }
 
 fn lower_logical_not_result(result: ExpressionResult, base_diagnostics: string[]) -> ExpressionResult {
@@ -83,7 +86,13 @@ fn lower_logical_not_result(result: ExpressionResult, base_diagnostics: string[]
         _ci0 += 1;
     }
     if result.operand == null {
-        return ExpressionResult { lines: result.lines, temp_index: result.temp_index, operand: null, diagnostics: combined, string_constants: result.string_constants };
+        return ExpressionResult {
+            lines: result.lines,
+            temp_index: result.temp_index,
+            operand: null,
+            diagnostics: combined,
+            string_constants: result.string_constants
+        };
     }
     return lower_logical_not_with_operand(result.operand, result.temp_index, result.lines, combined, result.string_constants);
 }
@@ -104,13 +113,25 @@ fn lower_ternary_expression(parse: TernaryParseResult, bindings: ParameterBindin
     diagnostics = extend_string_array(diagnostics, cond_result.diagnostics);
     string_constants = cond_result.string_constants;
     if cond_result.operand == null {
-        return ExpressionResult { lines: cond_result.lines, temp_index: cond_result.temp_index, operand: null, diagnostics: diagnostics, string_constants: string_constants };
+        return ExpressionResult {
+            lines: cond_result.lines,
+            temp_index: cond_result.temp_index,
+            operand: null,
+            diagnostics: diagnostics,
+            string_constants: string_constants
+        };
     }
 
     let cond_bool = coerce_operand_to_type(cond_result.operand, "i1", cond_result.temp_index, cond_result.lines);
     diagnostics = extend_string_array(diagnostics, cond_bool.diagnostics);
     if cond_bool.operand == null {
-        return ExpressionResult { lines: cond_bool.lines, temp_index: cond_bool.temp_index, operand: null, diagnostics: diagnostics, string_constants: string_constants };
+        return ExpressionResult {
+            lines: cond_bool.lines,
+            temp_index: cond_bool.temp_index,
+            operand: null,
+            diagnostics: diagnostics,
+            string_constants: string_constants
+        };
     }
 
     let mut current_lines = cond_bool.lines;
@@ -125,7 +146,13 @@ fn lower_ternary_expression(parse: TernaryParseResult, bindings: ParameterBindin
     diagnostics = extend_string_array(diagnostics, then_result.diagnostics);
     string_constants = merge_string_constants(string_constants, then_result.string_constants);
     if then_result.operand == null {
-        return ExpressionResult { lines: then_result.lines, temp_index: then_result.temp_index, operand: null, diagnostics: diagnostics, string_constants: string_constants };
+        return ExpressionResult {
+            lines: then_result.lines,
+            temp_index: then_result.temp_index,
+            operand: null,
+            diagnostics: diagnostics,
+            string_constants: string_constants
+        };
     }
 
     let then_end_label = "ternary_then_end_" + label_id;
@@ -141,7 +168,13 @@ fn lower_ternary_expression(parse: TernaryParseResult, bindings: ParameterBindin
     diagnostics = extend_string_array(diagnostics, else_result.diagnostics);
     string_constants = merge_string_constants(string_constants, else_result.string_constants);
     if else_result.operand == null {
-        return ExpressionResult { lines: else_result.lines, temp_index: else_result.temp_index, operand: null, diagnostics: diagnostics, string_constants: string_constants };
+        return ExpressionResult {
+            lines: else_result.lines,
+            temp_index: else_result.temp_index,
+            operand: null,
+            diagnostics: diagnostics,
+            string_constants: string_constants
+        };
     }
 
     let else_end_label = "ternary_else_end_" + label_id;
@@ -156,7 +189,13 @@ fn lower_ternary_expression(parse: TernaryParseResult, bindings: ParameterBindin
 
     if then_result.operand.llvm_type != else_result.operand.llvm_type {
         diagnostics.push("llvm lowering: ternary expression branches have incompatible types: `" + then_result.operand.llvm_type + "` vs `" + else_result.operand.llvm_type + "`");
-        return ExpressionResult { lines: current_lines, temp_index: else_result.temp_index, operand: null, diagnostics: diagnostics, string_constants: string_constants };
+        return ExpressionResult {
+            lines: current_lines,
+            temp_index: else_result.temp_index,
+            operand: null,
+            diagnostics: diagnostics,
+            string_constants: string_constants
+        };
     }
 
     let result_temp = format_temp_name(else_result.temp_index);
@@ -164,7 +203,13 @@ fn lower_ternary_expression(parse: TernaryParseResult, bindings: ParameterBindin
     current_lines.push("  " + result_temp + " = phi " + result_type + " [ " + then_result.operand.value + ", %" + then_end_label + " ], [ " + else_result.operand.value + ", %" + else_end_label + " ]");
 
     let operand = LLVMOperand { llvm_type: result_type, value: result_temp };
-    return ExpressionResult { lines: current_lines, temp_index: else_result.temp_index + 1, operand: operand, diagnostics: diagnostics, string_constants: string_constants };
+    return ExpressionResult {
+        lines: current_lines,
+        temp_index: else_result.temp_index + 1,
+        operand: operand,
+        diagnostics: diagnostics,
+        string_constants: string_constants
+    };
 }
 
 fn lower_binary_operation(expression: string, match: OperatorMatch, bindings: ParameterBinding[], locals: LocalBinding[], temp_index: number, lines: string[], functions: NativeFunction[], context: TypeContext) -> ExpressionResult {
@@ -177,21 +222,39 @@ fn lower_binary_operation(expression: string, match: OperatorMatch, bindings: Pa
     if _if95 {
         diagnostics.push("llvm lowering: malformed binary expression `" + expression + "`");
         let empty_constants = empty_string_constant_set();
-        return ExpressionResult { lines: lines, temp_index: temp_index, operand: null, diagnostics: diagnostics, string_constants: empty_constants };
+        return ExpressionResult {
+            lines: lines,
+            temp_index: temp_index,
+            operand: null,
+            diagnostics: diagnostics,
+            string_constants: empty_constants
+        };
     }
 
     let left_result = lower_expression(left_text, bindings, locals, temp_index, lines, functions, context, "");
     diagnostics = extend_string_array(diagnostics, left_result.diagnostics);
     let mut string_constants: StringConstant[] = left_result.string_constants;
     if left_result.operand == null {
-        return ExpressionResult { lines: left_result.lines, temp_index: left_result.temp_index, operand: null, diagnostics: diagnostics, string_constants: string_constants };
+        return ExpressionResult {
+            lines: left_result.lines,
+            temp_index: left_result.temp_index,
+            operand: null,
+            diagnostics: diagnostics,
+            string_constants: string_constants
+        };
     }
 
     let right_result = lower_expression(right_text, bindings, locals, left_result.temp_index, left_result.lines, functions, context, "");
     diagnostics = extend_string_array(diagnostics, right_result.diagnostics);
     string_constants = merge_string_constants(string_constants, right_result.string_constants);
     if right_result.operand == null {
-        return ExpressionResult { lines: right_result.lines, temp_index: right_result.temp_index, operand: null, diagnostics: diagnostics, string_constants: string_constants };
+        return ExpressionResult {
+            lines: right_result.lines,
+            temp_index: right_result.temp_index,
+            operand: null,
+            diagnostics: diagnostics,
+            string_constants: string_constants
+        };
     }
 
     if match.symbol == "+" {
@@ -206,8 +269,17 @@ fn lower_binary_operation(expression: string, match: OperatorMatch, bindings: Pa
                 let concat_name = format_temp_name(current_temp);
                 current_temp += 1;
                 current_lines.push("  " + concat_name + " = call i8* @sailfin_runtime_string_concat(i8* " + lhs.value + ", i8* " + rhs.value + ")");
-                let operand = LLVMOperand { llvm_type: "i8*", value: concat_name };
-                return ExpressionResult { lines: current_lines, temp_index: current_temp, operand: operand, diagnostics: diagnostics, string_constants: string_constants };
+                let operand = LLVMOperand {
+                    llvm_type: "i8*",
+                    value: concat_name
+                };
+                return ExpressionResult {
+                    lines: current_lines,
+                    temp_index: current_temp,
+                    operand: operand,
+                    diagnostics: diagnostics,
+                    string_constants: string_constants
+                };
             }
         }
         if lhs_type == "i8*" {
@@ -219,15 +291,30 @@ fn lower_binary_operation(expression: string, match: OperatorMatch, bindings: Pa
                 current_lines = coerced.lines;
                 current_temp = coerced.temp_index;
                 if coerced.operand == null {
-                    return ExpressionResult { lines: current_lines, temp_index: current_temp, operand: null, diagnostics: diagnostics, string_constants: string_constants };
+                    return ExpressionResult {
+                        lines: current_lines,
+                        temp_index: current_temp,
+                        operand: null,
+                        diagnostics: diagnostics,
+                        string_constants: string_constants
+                    };
                 }
 
                 let concat_name = format_temp_name(current_temp);
                 current_temp += 1;
                 current_lines.push("  " + concat_name + " = call i8* @sailfin_runtime_string_concat(i8* " + lhs.value + ", i8* " + coerced.operand.value + ")");
 
-                let operand = LLVMOperand { llvm_type: "i8*", value: concat_name };
-                return ExpressionResult { lines: current_lines, temp_index: current_temp, operand: operand, diagnostics: diagnostics, string_constants: string_constants };
+                let operand = LLVMOperand {
+                    llvm_type: "i8*",
+                    value: concat_name
+                };
+                return ExpressionResult {
+                    lines: current_lines,
+                    temp_index: current_temp,
+                    operand: operand,
+                    diagnostics: diagnostics,
+                    string_constants: string_constants
+                };
             }
         }
         if lhs_type == "i8" {
@@ -239,15 +326,30 @@ fn lower_binary_operation(expression: string, match: OperatorMatch, bindings: Pa
                 current_lines = coerced.lines;
                 current_temp = coerced.temp_index;
                 if coerced.operand == null {
-                    return ExpressionResult { lines: current_lines, temp_index: current_temp, operand: null, diagnostics: diagnostics, string_constants: string_constants };
+                    return ExpressionResult {
+                        lines: current_lines,
+                        temp_index: current_temp,
+                        operand: null,
+                        diagnostics: diagnostics,
+                        string_constants: string_constants
+                    };
                 }
 
                 let concat_name = format_temp_name(current_temp);
                 current_temp += 1;
                 current_lines.push("  " + concat_name + " = call i8* @sailfin_runtime_string_concat(i8* " + coerced.operand.value + ", i8* " + rhs.value + ")");
 
-                let operand = LLVMOperand { llvm_type: "i8*", value: concat_name };
-                return ExpressionResult { lines: current_lines, temp_index: current_temp, operand: operand, diagnostics: diagnostics, string_constants: string_constants };
+                let operand = LLVMOperand {
+                    llvm_type: "i8*",
+                    value: concat_name
+                };
+                return ExpressionResult {
+                    lines: current_lines,
+                    temp_index: current_temp,
+                    operand: operand,
+                    diagnostics: diagnostics,
+                    string_constants: string_constants
+                };
             }
         }
 
@@ -261,7 +363,13 @@ fn lower_binary_operation(expression: string, match: OperatorMatch, bindings: Pa
                 current_lines = lhs_coerced.lines;
                 current_temp = lhs_coerced.temp_index;
                 if lhs_coerced.operand == null {
-                    return ExpressionResult { lines: current_lines, temp_index: current_temp, operand: null, diagnostics: diagnostics, string_constants: string_constants };
+                    return ExpressionResult {
+                        lines: current_lines,
+                        temp_index: current_temp,
+                        operand: null,
+                        diagnostics: diagnostics,
+                        string_constants: string_constants
+                    };
                 }
 
                 let rhs_coerced = coerce_operand_to_type(rhs, "i8*", current_temp, current_lines);
@@ -269,15 +377,30 @@ fn lower_binary_operation(expression: string, match: OperatorMatch, bindings: Pa
                 current_lines = rhs_coerced.lines;
                 current_temp = rhs_coerced.temp_index;
                 if rhs_coerced.operand == null {
-                    return ExpressionResult { lines: current_lines, temp_index: current_temp, operand: null, diagnostics: diagnostics, string_constants: string_constants };
+                    return ExpressionResult {
+                        lines: current_lines,
+                        temp_index: current_temp,
+                        operand: null,
+                        diagnostics: diagnostics,
+                        string_constants: string_constants
+                    };
                 }
 
                 let concat_name = format_temp_name(current_temp);
                 current_temp += 1;
                 current_lines.push("  " + concat_name + " = call i8* @sailfin_runtime_string_concat(i8* " + lhs_coerced.operand.value + ", i8* " + rhs_coerced.operand.value + ")");
 
-                let operand = LLVMOperand { llvm_type: "i8*", value: concat_name };
-                return ExpressionResult { lines: current_lines, temp_index: current_temp, operand: operand, diagnostics: diagnostics, string_constants: string_constants };
+                let operand = LLVMOperand {
+                    llvm_type: "i8*",
+                    value: concat_name
+                };
+                return ExpressionResult {
+                    lines: current_lines,
+                    temp_index: current_temp,
+                    operand: operand,
+                    diagnostics: diagnostics,
+                    string_constants: string_constants
+                };
             }
         }
 
@@ -293,7 +416,13 @@ fn lower_binary_operation(expression: string, match: OperatorMatch, bindings: Pa
             current_lines = lhs_coerced.lines;
             current_temp = lhs_coerced.temp_index;
             if lhs_coerced.operand == null {
-                return ExpressionResult { lines: current_lines, temp_index: current_temp, operand: null, diagnostics: diagnostics, string_constants: string_constants };
+                return ExpressionResult {
+                    lines: current_lines,
+                    temp_index: current_temp,
+                    operand: null,
+                    diagnostics: diagnostics,
+                    string_constants: string_constants
+                };
             }
 
             let rhs_coerced = coerce_operand_to_type(rhs, "i8*", current_temp, current_lines);
@@ -301,14 +430,29 @@ fn lower_binary_operation(expression: string, match: OperatorMatch, bindings: Pa
             current_lines = rhs_coerced.lines;
             current_temp = rhs_coerced.temp_index;
             if rhs_coerced.operand == null {
-                return ExpressionResult { lines: current_lines, temp_index: current_temp, operand: null, diagnostics: diagnostics, string_constants: string_constants };
+                return ExpressionResult {
+                    lines: current_lines,
+                    temp_index: current_temp,
+                    operand: null,
+                    diagnostics: diagnostics,
+                    string_constants: string_constants
+                };
             }
 
             let concat_name = format_temp_name(current_temp);
             current_temp += 1;
             current_lines.push("  " + concat_name + " = call i8* @sailfin_runtime_string_concat(i8* " + lhs_coerced.operand.value + ", i8* " + rhs_coerced.operand.value + ")");
-            let operand = LLVMOperand { llvm_type: "i8*", value: concat_name };
-            return ExpressionResult { lines: current_lines, temp_index: current_temp, operand: operand, diagnostics: diagnostics, string_constants: string_constants };
+            let operand = LLVMOperand {
+                llvm_type: "i8*",
+                value: concat_name
+            };
+            return ExpressionResult {
+                lines: current_lines,
+                temp_index: current_temp,
+                operand: operand,
+                diagnostics: diagnostics,
+                string_constants: string_constants
+            };
         }
     }
 
@@ -326,28 +470,49 @@ fn lower_binary_operation(expression: string, match: OperatorMatch, bindings: Pa
             if rhs_type == "i8*" {
                 let mut current_lines = right_result.lines;
                 let mut current_temp = right_result.temp_index;
-    
+
                 let lhs_coerced = coerce_operand_to_type(lhs, "double", current_temp, current_lines);
                 diagnostics = extend_string_array(diagnostics, lhs_coerced.diagnostics);
                 current_lines = lhs_coerced.lines;
                 current_temp = lhs_coerced.temp_index;
                 if lhs_coerced.operand == null {
-                    return ExpressionResult { lines: current_lines, temp_index: current_temp, operand: null, diagnostics: diagnostics, string_constants: string_constants };
+                    return ExpressionResult {
+                        lines: current_lines,
+                        temp_index: current_temp,
+                        operand: null,
+                        diagnostics: diagnostics,
+                        string_constants: string_constants
+                    };
                 }
-    
+
                 let rhs_coerced = coerce_operand_to_type(rhs, "double", current_temp, current_lines);
                 diagnostics = extend_string_array(diagnostics, rhs_coerced.diagnostics);
                 current_lines = rhs_coerced.lines;
                 current_temp = rhs_coerced.temp_index;
                 if rhs_coerced.operand == null {
-                    return ExpressionResult { lines: current_lines, temp_index: current_temp, operand: null, diagnostics: diagnostics, string_constants: string_constants };
+                    return ExpressionResult {
+                        lines: current_lines,
+                        temp_index: current_temp,
+                        operand: null,
+                        diagnostics: diagnostics,
+                        string_constants: string_constants
+                    };
                 }
-    
+
                 let operation = operation_name_for_symbol(match.symbol, "double");
                 let temp_name = format_temp_name(current_temp);
                 current_lines.push("  " + temp_name + " = " + operation + " double " + lhs_coerced.operand.value + ", " + rhs_coerced.operand.value);
-                let operand = LLVMOperand { llvm_type: "double", value: temp_name };
-                return ExpressionResult { lines: current_lines, temp_index: current_temp + 1, operand: operand, diagnostics: diagnostics, string_constants: string_constants };
+                let operand = LLVMOperand {
+                    llvm_type: "double",
+                    value: temp_name
+                };
+                return ExpressionResult {
+                    lines: current_lines,
+                    temp_index: current_temp + 1,
+                    operand: operand,
+                    diagnostics: diagnostics,
+                    string_constants: string_constants
+                };
             }
         }
     }
@@ -368,9 +533,7 @@ fn lower_binary_operation(expression: string, match: OperatorMatch, bindings: Pa
                 if rhs_type == "int" { _if110 = true; }
                 if _if110 {
                     if rhs_type != "i8" {
-                        if rhs_type != "i1" {
-                            _if108 = true;
-                        }
+                        if rhs_type != "i1" { _if108 = true; }
                     }
                 }
                 if _if108 {
@@ -383,7 +546,13 @@ fn lower_binary_operation(expression: string, match: OperatorMatch, bindings: Pa
                         current_lines = coerced.lines;
                         current_temp = coerced.temp_index;
                         if coerced.operand == null {
-                            return ExpressionResult { lines: current_lines, temp_index: current_temp, operand: null, diagnostics: diagnostics, string_constants: string_constants };
+                            return ExpressionResult {
+                                lines: current_lines,
+                                temp_index: current_temp,
+                                operand: null,
+                                diagnostics: diagnostics,
+                                string_constants: string_constants
+                            };
                         }
                         rhs_i64 = coerced.operand;
                     }
@@ -400,8 +569,17 @@ fn lower_binary_operation(expression: string, match: OperatorMatch, bindings: Pa
                     let gep_name = format_temp_name(current_temp);
                     current_temp += 1;
                     current_lines.push("  " + gep_name + " = getelementptr " + element_type + ", " + left_type + " " + left_result.operand.value + ", i64 " + index_value);
-                    let operand = LLVMOperand { llvm_type: left_type, value: gep_name };
-                    return ExpressionResult { lines: current_lines, temp_index: current_temp, operand: operand, diagnostics: diagnostics, string_constants: string_constants };
+                    let operand = LLVMOperand {
+                        llvm_type: left_type,
+                        value: gep_name
+                    };
+                    return ExpressionResult {
+                        lines: current_lines,
+                        temp_index: current_temp,
+                        operand: operand,
+                        diagnostics: diagnostics,
+                        string_constants: string_constants
+                    };
                 }
             }
         }
@@ -413,7 +591,13 @@ fn lower_binary_operation(expression: string, match: OperatorMatch, bindings: Pa
     if harmonised.left == null { _if99 = true; }
     if harmonised.right == null { _if99 = true; }
     if _if99 {
-        return ExpressionResult { lines: harmonised.lines, temp_index: harmonised.temp_index, operand: null, diagnostics: diagnostics, string_constants: string_constants };
+        return ExpressionResult {
+            lines: harmonised.lines,
+            temp_index: harmonised.temp_index,
+            operand: null,
+            diagnostics: diagnostics,
+            string_constants: string_constants
+        };
     }
 
     let left_aligned = harmonised.left;
@@ -425,7 +609,13 @@ fn lower_binary_operation(expression: string, match: OperatorMatch, bindings: Pa
             let line = "  " + temp_name + " = call i8* @sailfin_runtime_string_concat(i8* " + left_aligned.value + ", i8* " + right_aligned.value + ")";
             let updated_lines = append_string(harmonised.lines, line);
             let operand = LLVMOperand { llvm_type: "i8*", value: temp_name };
-            return ExpressionResult { lines: updated_lines, temp_index: harmonised.temp_index + 1, operand: operand, diagnostics: diagnostics, string_constants: string_constants };
+            return ExpressionResult {
+                lines: updated_lines,
+                temp_index: harmonised.temp_index + 1,
+                operand: operand,
+                diagnostics: diagnostics,
+                string_constants: string_constants
+            };
         }
     }
     let operation = operation_name_for_symbol(match.symbol, result_type);
@@ -433,7 +623,13 @@ fn lower_binary_operation(expression: string, match: OperatorMatch, bindings: Pa
     let line = "  " + temp_name + " = " + operation + " " + result_type + " " + left_aligned.value + ", " + right_aligned.value;
     let updated_lines = append_string(harmonised.lines, line);
     let operand = LLVMOperand { llvm_type: result_type, value: temp_name };
-    return ExpressionResult { lines: updated_lines, temp_index: harmonised.temp_index + 1, operand: operand, diagnostics: diagnostics, string_constants: string_constants };
+    return ExpressionResult {
+        lines: updated_lines,
+        temp_index: harmonised.temp_index + 1,
+        operand: operand,
+        diagnostics: diagnostics,
+        string_constants: string_constants
+    };
 }
 
 fn lower_comparison_operation(expression: string, match: OperatorMatch, bindings: ParameterBinding[], locals: LocalBinding[], temp_index: number, lines: string[], functions: NativeFunction[], context: TypeContext) -> ExpressionResult {
@@ -444,7 +640,13 @@ fn lower_comparison_operation(expression: string, match: OperatorMatch, bindings
     if _if100 {
         diagnostics.push("llvm lowering: empty comparison expression");
         let empty_constants = empty_string_constant_set();
-        return ExpressionResult { lines: lines, temp_index: temp_index, operand: null, diagnostics: diagnostics, string_constants: empty_constants };
+        return ExpressionResult {
+            lines: lines,
+            temp_index: temp_index,
+            operand: null,
+            diagnostics: diagnostics,
+            string_constants: empty_constants
+        };
     }
     let mut _if101: boolean = false;
     if match.symbol == null { _if101 = true; }
@@ -452,7 +654,13 @@ fn lower_comparison_operation(expression: string, match: OperatorMatch, bindings
     if _if101 {
         diagnostics.push("llvm lowering: comparison operator missing in `" + expression + "`");
         let empty_constants = empty_string_constant_set();
-        return ExpressionResult { lines: lines, temp_index: temp_index, operand: null, diagnostics: diagnostics, string_constants: empty_constants };
+        return ExpressionResult {
+            lines: lines,
+            temp_index: temp_index,
+            operand: null,
+            diagnostics: diagnostics,
+            string_constants: empty_constants
+        };
     }
     let mut _if102: boolean = false;
     if match.index < 0 { _if102 = true; }
@@ -460,7 +668,13 @@ fn lower_comparison_operation(expression: string, match: OperatorMatch, bindings
     if _if102 {
         diagnostics.push("llvm lowering: comparison operator index out of bounds in `" + expression + "`");
         let empty_constants = empty_string_constant_set();
-        return ExpressionResult { lines: lines, temp_index: temp_index, operand: null, diagnostics: diagnostics, string_constants: empty_constants };
+        return ExpressionResult {
+            lines: lines,
+            temp_index: temp_index,
+            operand: null,
+            diagnostics: diagnostics,
+            string_constants: empty_constants
+        };
     }
 
     let operator_length = match.symbol.length;
@@ -472,21 +686,39 @@ fn lower_comparison_operation(expression: string, match: OperatorMatch, bindings
     if _if103 {
         diagnostics.push("llvm lowering: malformed comparison expression `" + expression + "`");
         let empty_constants = empty_string_constant_set();
-        return ExpressionResult { lines: lines, temp_index: temp_index, operand: null, diagnostics: diagnostics, string_constants: empty_constants };
+        return ExpressionResult {
+            lines: lines,
+            temp_index: temp_index,
+            operand: null,
+            diagnostics: diagnostics,
+            string_constants: empty_constants
+        };
     }
 
     let left_result = lower_expression(left_text, bindings, locals, temp_index, lines, functions, context, "");
     diagnostics = extend_string_array(diagnostics, left_result.diagnostics);
     let mut string_constants: StringConstant[] = left_result.string_constants;
     if left_result.operand == null {
-        return ExpressionResult { lines: left_result.lines, temp_index: left_result.temp_index, operand: null, diagnostics: diagnostics, string_constants: string_constants };
+        return ExpressionResult {
+            lines: left_result.lines,
+            temp_index: left_result.temp_index,
+            operand: null,
+            diagnostics: diagnostics,
+            string_constants: string_constants
+        };
     }
 
     let right_result = lower_expression(right_text, bindings, locals, left_result.temp_index, left_result.lines, functions, context, "");
     diagnostics = extend_string_array(diagnostics, right_result.diagnostics);
     string_constants = merge_string_constants(string_constants, right_result.string_constants);
     if right_result.operand == null {
-        return ExpressionResult { lines: right_result.lines, temp_index: right_result.temp_index, operand: null, diagnostics: diagnostics, string_constants: string_constants };
+        return ExpressionResult {
+            lines: right_result.lines,
+            temp_index: right_result.temp_index,
+            operand: null,
+            diagnostics: diagnostics,
+            string_constants: string_constants
+        };
     }
 
     let mut alignment_lines: string[] = right_result.lines;
@@ -497,9 +729,7 @@ fn lower_comparison_operation(expression: string, match: OperatorMatch, bindings
     let mut _if104: boolean = false;
     if match.symbol == "==" { _if104 = true; }
     if match.symbol == "!=" { _if104 = true; }
-    if _if104 {
-        is_equality = true;
-    }
+    if _if104 { is_equality = true; }
 
     if is_equality {
         if left_operand != null {
@@ -509,9 +739,7 @@ fn lower_comparison_operation(expression: string, match: OperatorMatch, bindings
                     let enum_info = find_enum_info_by_llvm_type(context, left_operand.llvm_type);
                     if enum_info != null {
                         let mut tag_llvm_type: string = "i32";
-                        if enum_info.tag_type == "i8" {
-                            tag_llvm_type = "i8";
-                        }
+                        if enum_info.tag_type == "i8" { tag_llvm_type = "i8"; }
                         if enum_info.tag_type == "i16" {
                             tag_llvm_type = "i16";
                         }
@@ -521,42 +749,53 @@ fn lower_comparison_operation(expression: string, match: OperatorMatch, bindings
                         if enum_info.tag_type == "i64" {
                             tag_llvm_type = "i64";
                         }
-        
+
                         let left_tag_temp = format_temp_name(alignment_temp);
                         alignment_temp += 1;
                         alignment_lines.push("  " + left_tag_temp + " = extractvalue " + left_operand.llvm_type + " " + left_operand.value + ", 0");
-        
+
                         let right_tag_temp = format_temp_name(alignment_temp);
                         alignment_temp += 1;
                         alignment_lines.push("  " + right_tag_temp + " = extractvalue " + right_operand.llvm_type + " " + right_operand.value + ", 0");
-        
+
                         let compare_temp = format_temp_name(alignment_temp);
                         alignment_temp += 1;
                         let mut predicate: string = "icmp eq";
-                        if match.symbol == "!=" {
-                            predicate = "icmp ne";
-                        }
+                        if match.symbol == "!=" { predicate = "icmp ne"; }
                         alignment_lines.push("  " + compare_temp + " = " + predicate + " " + tag_llvm_type + " " + left_tag_temp + ", " + right_tag_temp);
-                        let operand = LLVMOperand { llvm_type: "i1", value: compare_temp };
-                        return ExpressionResult { lines: alignment_lines, temp_index: alignment_temp, operand: operand, diagnostics: diagnostics, string_constants: string_constants };
+                        let operand = LLVMOperand {
+                            llvm_type: "i1",
+                            value: compare_temp
+                        };
+                        return ExpressionResult {
+                            lines: alignment_lines,
+                            temp_index: alignment_temp,
+                            operand: operand,
+                            diagnostics: diagnostics,
+                            string_constants: string_constants
+                        };
                     }
                 }
-        
+
                 let left_is_char = left_operand.llvm_type == "i8";
                 let right_is_char = right_operand.llvm_type == "i8";
                 let left_is_pointer = ends_with_pointer_suffix(left_operand.llvm_type);
                 let right_is_pointer = ends_with_pointer_suffix(right_operand.llvm_type);
                 let mut _if109: boolean = false;
                 if left_is_char {
-                    if right_is_pointer {
-                        _if109 = true;
-                    }
+                    if right_is_pointer { _if109 = true; }
                 }
                 if _if109 {
                     let coercion = coerce_operand_to_type(right_operand, "i8", alignment_temp, alignment_lines);
                     diagnostics = extend_string_array(diagnostics, coercion.diagnostics);
                     if coercion.operand == null {
-                        return ExpressionResult { lines: coercion.lines, temp_index: coercion.temp_index, operand: null, diagnostics: diagnostics, string_constants: string_constants };
+                        return ExpressionResult {
+                            lines: coercion.lines,
+                            temp_index: coercion.temp_index,
+                            operand: null,
+                            diagnostics: diagnostics,
+                            string_constants: string_constants
+                        };
                     }
                     right_operand = coercion.operand;
                     alignment_lines = coercion.lines;
@@ -564,15 +803,19 @@ fn lower_comparison_operation(expression: string, match: OperatorMatch, bindings
                 } else {
                     let mut _elif111: boolean = false;
                     if right_is_char {
-                        if left_is_pointer {
-                            _elif111 = true;
-                        }
+                        if left_is_pointer { _elif111 = true; }
                     }
                     if _elif111 {
                         let coercion = coerce_operand_to_type(left_operand, "i8", alignment_temp, alignment_lines);
                         diagnostics = extend_string_array(diagnostics, coercion.diagnostics);
                         if coercion.operand == null {
-                            return ExpressionResult { lines: coercion.lines, temp_index: coercion.temp_index, operand: null, diagnostics: diagnostics, string_constants: string_constants };
+                            return ExpressionResult {
+                                lines: coercion.lines,
+                                temp_index: coercion.temp_index,
+                                operand: null,
+                                diagnostics: diagnostics,
+                                string_constants: string_constants
+                            };
                         }
                         left_operand = coercion.operand;
                         alignment_lines = coercion.lines;
@@ -589,16 +832,34 @@ fn lower_comparison_operation(expression: string, match: OperatorMatch, bindings
     if harmonised.left == null { _if105 = true; }
     if harmonised.right == null { _if105 = true; }
     if _if105 {
-        return ExpressionResult { lines: harmonised.lines, temp_index: harmonised.temp_index, operand: null, diagnostics: diagnostics, string_constants: string_constants };
+        return ExpressionResult {
+            lines: harmonised.lines,
+            temp_index: harmonised.temp_index,
+            operand: null,
+            diagnostics: diagnostics,
+            string_constants: string_constants
+        };
     }
 
     let comparison = emit_comparison_instruction(match.symbol, harmonised.left, harmonised.right, harmonised.temp_index, harmonised.lines);
     diagnostics = extend_string_array(diagnostics, comparison.diagnostics);
     if comparison.operand == null {
-        return ExpressionResult { lines: comparison.lines, temp_index: comparison.temp_index, operand: null, diagnostics: diagnostics, string_constants: string_constants };
+        return ExpressionResult {
+            lines: comparison.lines,
+            temp_index: comparison.temp_index,
+            operand: null,
+            diagnostics: diagnostics,
+            string_constants: string_constants
+        };
     }
 
-    return ExpressionResult { lines: comparison.lines, temp_index: comparison.temp_index, operand: comparison.operand, diagnostics: diagnostics, string_constants: string_constants };
+    return ExpressionResult {
+        lines: comparison.lines,
+        temp_index: comparison.temp_index,
+        operand: comparison.operand,
+        diagnostics: diagnostics,
+        string_constants: string_constants
+    };
 }
 
 fn lower_logical_and(expression: string, match: OperatorMatch, bindings: ParameterBinding[], locals: LocalBinding[], temp_index: number, lines: string[], functions: NativeFunction[], context: TypeContext) -> ExpressionResult {
@@ -612,7 +873,13 @@ fn lower_logical_and(expression: string, match: OperatorMatch, bindings: Paramet
     if right_text.length == 0 { _if106 = true; }
     if _if106 {
         diagnostics.push("llvm lowering: malformed && expression `" + expression + "`");
-        return ExpressionResult { lines: lines, temp_index: temp_index, operand: null, diagnostics: diagnostics, string_constants: string_constants };
+        return ExpressionResult {
+            lines: lines,
+            temp_index: temp_index,
+            operand: null,
+            diagnostics: diagnostics,
+            string_constants: string_constants
+        };
     }
 
     let label_id = number_to_string(temp_index);
@@ -627,14 +894,26 @@ fn lower_logical_and(expression: string, match: OperatorMatch, bindings: Paramet
     diagnostics = extend_string_array(diagnostics, left_result.diagnostics);
     string_constants = left_result.string_constants;
     if left_result.operand == null {
-        return ExpressionResult { lines: left_result.lines, temp_index: left_result.temp_index, operand: null, diagnostics: diagnostics, string_constants: string_constants };
+        return ExpressionResult {
+            lines: left_result.lines,
+            temp_index: left_result.temp_index,
+            operand: null,
+            diagnostics: diagnostics,
+            string_constants: string_constants
+        };
     }
 
     let left_bool = coerce_operand_to_type(left_result.operand, "i1", left_result.temp_index, left_result.lines);
     diagnostics = extend_string_array(diagnostics, left_bool.diagnostics);
     string_constants = merge_string_constants(string_constants, left_result.string_constants);
     if left_bool.operand == null {
-        return ExpressionResult { lines: left_bool.lines, temp_index: left_bool.temp_index, operand: null, diagnostics: diagnostics, string_constants: string_constants };
+        return ExpressionResult {
+            lines: left_bool.lines,
+            temp_index: left_bool.temp_index,
+            operand: null,
+            diagnostics: diagnostics,
+            string_constants: string_constants
+        };
     }
 
     let mut current_lines = left_bool.lines;
@@ -659,14 +938,26 @@ fn lower_logical_and(expression: string, match: OperatorMatch, bindings: Paramet
         fallback_lines.push("");
         fallback_lines.push(merge_label + ":");
         let operand = LLVMOperand { llvm_type: "i1", value: "false" };
-        return ExpressionResult { lines: fallback_lines, temp_index: right_result.temp_index, operand: operand, diagnostics: diagnostics, string_constants: string_constants };
+        return ExpressionResult {
+            lines: fallback_lines,
+            temp_index: right_result.temp_index,
+            operand: operand,
+            diagnostics: diagnostics,
+            string_constants: string_constants
+        };
     }
 
     let right_bool = coerce_operand_to_type(right_result.operand, "i1", right_result.temp_index, right_result.lines);
     diagnostics = extend_string_array(diagnostics, right_bool.diagnostics);
     string_constants = merge_string_constants(string_constants, right_result.string_constants);
     if right_bool.operand == null {
-        return ExpressionResult { lines: right_bool.lines, temp_index: right_bool.temp_index, operand: null, diagnostics: diagnostics, string_constants: string_constants };
+        return ExpressionResult {
+            lines: right_bool.lines,
+            temp_index: right_bool.temp_index,
+            operand: null,
+            diagnostics: diagnostics,
+            string_constants: string_constants
+        };
     }
 
     current_lines = right_bool.lines;
@@ -682,7 +973,13 @@ fn lower_logical_and(expression: string, match: OperatorMatch, bindings: Paramet
     current_lines.push("  " + result_temp + " = phi i1 [ false, %" + entry_label + " ], [ " + right_bool.operand.value + ", %" + right_end_label + " ]");
 
     let operand = LLVMOperand { llvm_type: "i1", value: result_temp };
-    return ExpressionResult { lines: current_lines, temp_index: right_bool.temp_index + 1, operand: operand, diagnostics: diagnostics, string_constants: string_constants };
+    return ExpressionResult {
+        lines: current_lines,
+        temp_index: right_bool.temp_index + 1,
+        operand: operand,
+        diagnostics: diagnostics,
+        string_constants: string_constants
+    };
 }
 
 fn lower_logical_or(expression: string, match: OperatorMatch, bindings: ParameterBinding[], locals: LocalBinding[], temp_index: number, lines: string[], functions: NativeFunction[], context: TypeContext) -> ExpressionResult {
@@ -696,7 +993,13 @@ fn lower_logical_or(expression: string, match: OperatorMatch, bindings: Paramete
     if right_text.length == 0 { _if107 = true; }
     if _if107 {
         diagnostics.push("llvm lowering: malformed || expression `" + expression + "`");
-        return ExpressionResult { lines: lines, temp_index: temp_index, operand: null, diagnostics: diagnostics, string_constants: string_constants };
+        return ExpressionResult {
+            lines: lines,
+            temp_index: temp_index,
+            operand: null,
+            diagnostics: diagnostics,
+            string_constants: string_constants
+        };
     }
 
     let label_id = number_to_string(temp_index);
@@ -711,14 +1014,26 @@ fn lower_logical_or(expression: string, match: OperatorMatch, bindings: Paramete
     diagnostics = extend_string_array(diagnostics, left_result.diagnostics);
     string_constants = left_result.string_constants;
     if left_result.operand == null {
-        return ExpressionResult { lines: left_result.lines, temp_index: left_result.temp_index, operand: null, diagnostics: diagnostics, string_constants: string_constants };
+        return ExpressionResult {
+            lines: left_result.lines,
+            temp_index: left_result.temp_index,
+            operand: null,
+            diagnostics: diagnostics,
+            string_constants: string_constants
+        };
     }
 
     let left_bool = coerce_operand_to_type(left_result.operand, "i1", left_result.temp_index, left_result.lines);
     diagnostics = extend_string_array(diagnostics, left_bool.diagnostics);
     string_constants = merge_string_constants(string_constants, left_result.string_constants);
     if left_bool.operand == null {
-        return ExpressionResult { lines: left_bool.lines, temp_index: left_bool.temp_index, operand: null, diagnostics: diagnostics, string_constants: string_constants };
+        return ExpressionResult {
+            lines: left_bool.lines,
+            temp_index: left_bool.temp_index,
+            operand: null,
+            diagnostics: diagnostics,
+            string_constants: string_constants
+        };
     }
 
     let mut current_lines = left_bool.lines;
@@ -742,15 +1057,30 @@ fn lower_logical_or(expression: string, match: OperatorMatch, bindings: Paramete
         }
         fallback_lines.push("");
         fallback_lines.push(merge_label + ":");
-        let operand = LLVMOperand { llvm_type: "i1", value: left_bool.operand.value };
-        return ExpressionResult { lines: fallback_lines, temp_index: right_result.temp_index, operand: operand, diagnostics: diagnostics, string_constants: string_constants };
+        let operand = LLVMOperand {
+            llvm_type: "i1",
+            value: left_bool.operand.value
+        };
+        return ExpressionResult {
+            lines: fallback_lines,
+            temp_index: right_result.temp_index,
+            operand: operand,
+            diagnostics: diagnostics,
+            string_constants: string_constants
+        };
     }
 
     let right_bool = coerce_operand_to_type(right_result.operand, "i1", right_result.temp_index, right_result.lines);
     diagnostics = extend_string_array(diagnostics, right_bool.diagnostics);
     string_constants = merge_string_constants(string_constants, right_result.string_constants);
     if right_bool.operand == null {
-        return ExpressionResult { lines: right_bool.lines, temp_index: right_bool.temp_index, operand: null, diagnostics: diagnostics, string_constants: string_constants };
+        return ExpressionResult {
+            lines: right_bool.lines,
+            temp_index: right_bool.temp_index,
+            operand: null,
+            diagnostics: diagnostics,
+            string_constants: string_constants
+        };
     }
 
     current_lines = right_bool.lines;
@@ -766,7 +1096,13 @@ fn lower_logical_or(expression: string, match: OperatorMatch, bindings: Paramete
     current_lines.push("  " + result_temp + " = phi i1 [ true, %" + entry_label + " ], [ " + right_bool.operand.value + ", %" + right_end_label + " ]");
 
     let operand = LLVMOperand { llvm_type: "i1", value: result_temp };
-    return ExpressionResult { lines: current_lines, temp_index: right_bool.temp_index + 1, operand: operand, diagnostics: diagnostics, string_constants: string_constants };
+    return ExpressionResult {
+        lines: current_lines,
+        temp_index: right_bool.temp_index + 1,
+        operand: operand,
+        diagnostics: diagnostics,
+        string_constants: string_constants
+    };
 }
 
 export {

--- a/compiler/src/llvm/expression_lowering/native/core_ownership.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_ownership.sfn
@@ -1,65 +1,73 @@
 // compiler/src/llvm/expression_lowering/native/core_ownership.sfn
 //
 // Ownership/borrow analysis helpers extracted from core.sfn.
-
 import { NativeSourceSpan } from "../../../native_ir";
-
+import { is_simple_identifier, } from "../../expressions_helpers";
+import { is_copy_type, } from "../../type_mapping";
 import {
     LocalBinding,
-    ParameterBinding,
     OwnershipAnalysis,
-    OwnershipInfo,
     OwnershipConsumption,
+    OwnershipInfo,
+    ParameterBinding,
 } from "../../types";
-
 import {
-    trim_text,
     append_string,
     number_to_string,
+    trim_text,
 } from "../../utils";
-
-import {
-    is_copy_type,
-} from "../../type_mapping";
-
-import {
-    is_simple_identifier,
-} from "../../expressions_helpers";
-
-import {
-    find_local_binding,
-} from "./core_scopes";
-
-import {
-    find_parameter_binding,
-} from "./core_bindings";
-
-import {
-    parse_borrow_expression,
-} from "./core_parsing";
+import { find_parameter_binding, } from "./core_bindings";
+import { parse_borrow_expression, } from "./core_parsing";
+import { find_local_binding, } from "./core_scopes";
 
 fn analyze_value_ownership_impl(initializer: string?, span: NativeSourceSpan?, locals: LocalBinding[], bindings: ParameterBinding[]) -> OwnershipAnalysis {
     if initializer == null {
-        return OwnershipAnalysis { ownership: null, consumption: null, diagnostics: [] };
+        return OwnershipAnalysis {
+            ownership: null,
+            consumption: null,
+            diagnostics: []
+        };
     }
     let trimmed = trim_text(initializer);
     if trimmed.length == 0 {
-        return OwnershipAnalysis { ownership: null, consumption: null, diagnostics: [] };
+        return OwnershipAnalysis {
+            ownership: null,
+            consumption: null,
+            diagnostics: []
+        };
     }
 
     let parse = parse_borrow_expression(trimmed);
     let mut diagnostics: string[] = parse.diagnostics;
     if parse.recognized {
         if !parse.success {
-            return OwnershipAnalysis { ownership: null, consumption: null, diagnostics: diagnostics };
+            return OwnershipAnalysis {
+                ownership: null,
+                consumption: null,
+                diagnostics: diagnostics
+            };
         }
         let resolved_base = resolve_borrow_base_impl(parse.target, locals);
         if resolved_base.length == 0 {
             diagnostics.push("llvm lowering: borrow expression missing target");
-            return OwnershipAnalysis { ownership: null, consumption: null, diagnostics: diagnostics };
+            return OwnershipAnalysis {
+                ownership: null,
+                consumption: null,
+                diagnostics: diagnostics
+            };
         }
-        let ownership = OwnershipInfo { variant: "Borrow", base: resolved_base, mutable: parse.mutable, span: span, region_id: -1 };
-        return OwnershipAnalysis { ownership: ownership, consumption: null, diagnostics: diagnostics };
+        let ownership = OwnershipInfo {
+            variant: "Borrow",
+            base: resolved_base,
+            mutable: parse.mutable,
+            span: span,
+            region_id: -1
+        };
+        return OwnershipAnalysis {
+            ownership: ownership,
+            consumption: null,
+            diagnostics: diagnostics
+        };
     }
 
     if is_simple_identifier(trimmed) {
@@ -68,30 +76,64 @@ fn analyze_value_ownership_impl(initializer: string?, span: NativeSourceSpan?, l
         if local != null {
             if local.consumed {
                 diagnostics.push(format_use_after_move_message(name, span));
-                return OwnershipAnalysis { ownership: null, consumption: null, diagnostics: diagnostics };
+                return OwnershipAnalysis {
+                    ownership: null,
+                    consumption: null,
+                    diagnostics: diagnostics
+                };
             }
             if is_copy_type(local.type_annotation, local.llvm_type) {
-                return OwnershipAnalysis { ownership: null, consumption: null, diagnostics: diagnostics };
+                return OwnershipAnalysis {
+                    ownership: null,
+                    consumption: null,
+                    diagnostics: diagnostics
+                };
             }
-            let consumption = OwnershipConsumption { kind: "local", name: name };
-            return OwnershipAnalysis { ownership: null, consumption: consumption, diagnostics: diagnostics };
+            let consumption = OwnershipConsumption {
+                kind: "local",
+                name: name
+            };
+            return OwnershipAnalysis {
+                ownership: null,
+                consumption: consumption,
+                diagnostics: diagnostics
+            };
         }
 
         let parameter = find_parameter_binding(bindings, name);
         if parameter != null {
             if parameter.consumed {
                 diagnostics.push(format_use_after_move_message(name, span));
-                return OwnershipAnalysis { ownership: null, consumption: null, diagnostics: diagnostics };
+                return OwnershipAnalysis {
+                    ownership: null,
+                    consumption: null,
+                    diagnostics: diagnostics
+                };
             }
             if is_copy_type(parameter.type_annotation, parameter.llvm_type) {
-                return OwnershipAnalysis { ownership: null, consumption: null, diagnostics: diagnostics };
+                return OwnershipAnalysis {
+                    ownership: null,
+                    consumption: null,
+                    diagnostics: diagnostics
+                };
             }
-            let consumption = OwnershipConsumption { kind: "parameter", name: name };
-            return OwnershipAnalysis { ownership: null, consumption: consumption, diagnostics: diagnostics };
+            let consumption = OwnershipConsumption {
+                kind: "parameter",
+                name: name
+            };
+            return OwnershipAnalysis {
+                ownership: null,
+                consumption: consumption,
+                diagnostics: diagnostics
+            };
         }
     }
 
-    return OwnershipAnalysis { ownership: null, consumption: null, diagnostics: diagnostics };
+    return OwnershipAnalysis {
+        ownership: null,
+        consumption: null,
+        diagnostics: diagnostics
+    };
 }
 
 fn format_use_after_move_message(name: string, span: NativeSourceSpan?) -> string {
@@ -116,37 +158,25 @@ fn format_suspension_location_impl(keyword: string, borrow_span: NativeSourceSpa
     }
     if suspension_span != null {
         let mut label: string = keyword;
-        if label.length == 0 {
-            label = "suspend";
-        }
+        if label.length == 0 { label = "suspend"; }
         let segment = label + " at " + format_span_location(suspension_span);
-        if has_segment {
-            combined = combined + "; " + segment;
-        } else {
+        if has_segment { combined = combined + "; " + segment; } else {
             combined = segment;
             has_segment = true;
         }
     }
-    if !has_segment {
-        return "";
-    }
+    if !has_segment { return ""; }
     return " (" + combined + ")";
 }
 
 fn detect_borrow_conflicts_impl(ownership: OwnershipInfo?, locals: LocalBinding[], binding_name: string, function_name: string) -> string[] {
     let mut diagnostics: string[] = [];
-    if ownership == null {
-        return diagnostics;
-    }
-    if ownership.variant != "Borrow" {
-        return diagnostics;
-    }
+    if ownership == null { return diagnostics; }
+    if ownership.variant != "Borrow" { return diagnostics; }
     let base = trim_text(ownership.base);
     let mut index: number = 0;
     loop {
-        if index >= locals.length {
-            break;
-        }
+        if index >= locals.length { break; }
         let existing = locals[index];
         if existing.ownership != null {
             let details = existing.ownership;
@@ -178,25 +208,13 @@ fn resolve_borrow_base_impl(target: string, locals: LocalBinding[]) -> string {
 
 fn resolve_borrow_base_inner(target: string, locals: LocalBinding[], depth: number) -> string {
     let trimmed = trim_text(target);
-    if trimmed.length == 0 {
-        return trimmed;
-    }
-    if depth >= 8 {
-        return trimmed;
-    }
-    if !is_simple_identifier(trimmed) {
-        return trimmed;
-    }
+    if trimmed.length == 0 { return trimmed; }
+    if depth >= 8 { return trimmed; }
+    if !is_simple_identifier(trimmed) { return trimmed; }
     let binding = find_local_binding(locals, trimmed);
-    if binding == null {
-        return trimmed;
-    }
-    if binding.ownership == null {
-        return trimmed;
-    }
+    if binding == null { return trimmed; }
+    if binding.ownership == null { return trimmed; }
     let details = binding.ownership;
-    if details.variant != "Borrow" {
-        return trimmed;
-    }
+    if details.variant != "Borrow" { return trimmed; }
     return resolve_borrow_base_inner(details.base, locals, depth + 1);
 }

--- a/compiler/src/llvm/expression_lowering/native/core_ownership.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_ownership.sfn
@@ -2,23 +2,19 @@
 //
 // Ownership/borrow analysis helpers extracted from core.sfn.
 import { NativeSourceSpan } from "../../../native_ir";
-import { is_simple_identifier, } from "../../expressions_helpers";
-import { is_copy_type, } from "../../type_mapping";
+import { is_simple_identifier } from "../../expressions_helpers";
+import { is_copy_type } from "../../type_mapping";
 import {
     LocalBinding,
     OwnershipAnalysis,
     OwnershipConsumption,
     OwnershipInfo,
-    ParameterBinding,
+    ParameterBinding
 } from "../../types";
-import {
-    append_string,
-    number_to_string,
-    trim_text,
-} from "../../utils";
-import { find_parameter_binding, } from "./core_bindings";
-import { parse_borrow_expression, } from "./core_parsing";
-import { find_local_binding, } from "./core_scopes";
+import { append_string, number_to_string, trim_text } from "../../utils";
+import { find_parameter_binding } from "./core_bindings";
+import { parse_borrow_expression } from "./core_parsing";
+import { find_local_binding } from "./core_scopes";
 
 fn analyze_value_ownership_impl(initializer: string?, span: NativeSourceSpan?, locals: LocalBinding[], bindings: ParameterBinding[]) -> OwnershipAnalysis {
     if initializer == null {
@@ -140,7 +136,8 @@ fn format_use_after_move_message(name: string, span: NativeSourceSpan?) -> strin
     if span == null {
         return "llvm lowering: use-after-move of `" + name + "`";
     }
-    return "llvm lowering: use-after-move of `" + name + "` at " + format_span_location(span);
+    return "llvm lowering: use-after-move of `" + name + "` at "
+        + format_span_location(span);
 }
 
 fn format_span_location(span: NativeSourceSpan) -> string {
@@ -185,13 +182,37 @@ fn detect_borrow_conflicts_impl(ownership: OwnershipInfo?, locals: LocalBinding[
                 if existing_base == base {
                     if ownership.mutable {
                         if details.mutable {
-                            diagnostics.push("llvm lowering: mutable borrow `" + binding_name + "` conflicts with active mutable borrow `" + existing.name + "` of `" + base + "` in `" + function_name + "`");
+                            diagnostics.push("llvm lowering: mutable borrow `"
+                                + binding_name
+                                + "` conflicts with active mutable borrow `"
+                                + existing.name
+                                + "` of `"
+                                + base
+                                + "` in `"
+                                + function_name
+                                + "`");
                         } else {
-                            diagnostics.push("llvm lowering: mutable borrow `" + binding_name + "` conflicts with active shared borrow `" + existing.name + "` of `" + base + "` in `" + function_name + "`");
+                            diagnostics.push("llvm lowering: mutable borrow `"
+                                + binding_name
+                                + "` conflicts with active shared borrow `"
+                                + existing.name
+                                + "` of `"
+                                + base
+                                + "` in `"
+                                + function_name
+                                + "`");
                         }
                     } else {
                         if details.mutable {
-                            diagnostics.push("llvm lowering: shared borrow `" + binding_name + "` conflicts with active mutable borrow `" + existing.name + "` of `" + base + "` in `" + function_name + "`");
+                            diagnostics.push("llvm lowering: shared borrow `"
+                                + binding_name
+                                + "` conflicts with active mutable borrow `"
+                                + existing.name
+                                + "` of `"
+                                + base
+                                + "` in `"
+                                + function_name
+                                + "`");
                         }
                     }
                 }

--- a/compiler/src/llvm/expression_lowering/native/core_parse.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_parse.sfn
@@ -6,34 +6,26 @@
 // struct/enum literal parsing, member access (`parse_member_access`),
 // index expressions (`parse_index_expression`), range iterables, and
 // brace/bracket/paren balancing utilities.
-
-import { substring, char_code, char_at } from "../../../string_utils";
-
-import {
-    trim_text,
-    append_string,
-    string_array_contains,
-    index_of,
-    char_code_at_text,
-    is_digit_char,
-} from "./core_text";
-
-import { ends_with, is_identifier_start_char } from "../../utils";
-
+import { char_at, char_code, substring } from "../../../string_utils";
 import { is_simple_identifier } from "../../expressions_helpers";
-
-import { split_array_elements } from "../splitting";
-
 import {
-    StructLiteralParse,
-    StructLiteralField,
     EnumLiteralParse,
-    MemberAccessParse,
     IndexExpressionParse,
+    MemberAccessParse,
     RangeIterableParse,
+    StructLiteralField,
+    StructLiteralParse,
 } from "../../types";
-
-
+import { ends_with, is_identifier_start_char } from "../../utils";
+import { split_array_elements } from "../splitting";
+import {
+    append_string,
+    char_code_at_text,
+    index_of,
+    is_digit_char,
+    string_array_contains,
+    trim_text,
+} from "./core_text";
 
 fn find_matching_closing_brace(text: string, open_index: number) -> number {
     let mut depth: number = 0;
@@ -42,27 +34,17 @@ fn find_matching_closing_brace(text: string, open_index: number) -> number {
     let mut in_double: boolean = false;
     let mut escape: boolean = false;
     loop {
-        if index >= text.length {
-            break;
-        }
+        if index >= text.length { break; }
         let ch = substring(text, index, index + 1);
         if in_double {
-            if escape {
-                escape = false;
-            } else if ch == "\\" {
-                escape = true;
-            } else if ch == "\"" {
+            if escape { escape = false; } else if ch == "\\" { escape = true; } else if ch == "\"" {
                 in_double = false;
             }
             index += 1;
             continue;
         }
         if in_single {
-            if escape {
-                escape = false;
-            } else if ch == "\\" {
-                escape = true;
-            } else if ch == "'" {
+            if escape { escape = false; } else if ch == "\\" { escape = true; } else if ch == "'" {
                 in_single = false;
             }
             index += 1;
@@ -78,14 +60,10 @@ fn find_matching_closing_brace(text: string, open_index: number) -> number {
             index += 1;
             continue;
         }
-        if ch == "{" {
-            depth += 1;
-        } else if ch == "}" {
+        if ch == "{" { depth += 1; } else if ch == "}" {
             if depth > 0 {
                 depth -= 1;
-                if depth == 0 {
-                    return index;
-                }
+                if depth == 0 { return index; }
             }
         }
         index += 1;
@@ -103,27 +81,17 @@ fn find_top_level_colon(text: string) -> number {
     let mut escape: boolean = false;
     let mut index: number = 0;
     loop {
-        if index >= text.length {
-            break;
-        }
+        if index >= text.length { break; }
         let ch = substring(text, index, index + 1);
         if in_double {
-            if escape {
-                escape = false;
-            } else if ch == "\\" {
-                escape = true;
-            } else if ch == "\"" {
+            if escape { escape = false; } else if ch == "\\" { escape = true; } else if ch == "\"" {
                 in_double = false;
             }
             index += 1;
             continue;
         }
         if in_single {
-            if escape {
-                escape = false;
-            } else if ch == "\\" {
-                escape = true;
-            } else if ch == "'" {
+            if escape { escape = false; } else if ch == "\\" { escape = true; } else if ch == "'" {
                 in_single = false;
             }
             index += 1;
@@ -145,9 +113,7 @@ fn find_top_level_colon(text: string) -> number {
             continue;
         }
         if ch == ")" {
-            if paren_depth > 0 {
-                paren_depth -= 1;
-            }
+            if paren_depth > 0 { paren_depth -= 1; }
             index += 1;
             continue;
         }
@@ -157,9 +123,7 @@ fn find_top_level_colon(text: string) -> number {
             continue;
         }
         if ch == "]" {
-            if bracket_depth > 0 {
-                bracket_depth -= 1;
-            }
+            if bracket_depth > 0 { bracket_depth -= 1; }
             index += 1;
             continue;
         }
@@ -169,9 +133,7 @@ fn find_top_level_colon(text: string) -> number {
             continue;
         }
         if ch == "}" {
-            if brace_depth > 0 {
-                brace_depth -= 1;
-            }
+            if brace_depth > 0 { brace_depth -= 1; }
             index += 1;
             continue;
         }
@@ -181,9 +143,7 @@ fn find_top_level_colon(text: string) -> number {
             continue;
         }
         if ch == ">" {
-            if angle_depth > 0 {
-                angle_depth -= 1;
-            }
+            if angle_depth > 0 { angle_depth -= 1; }
             index += 1;
             continue;
         }
@@ -191,9 +151,7 @@ fn find_top_level_colon(text: string) -> number {
             if paren_depth == 0 {
                 if bracket_depth == 0 {
                     if brace_depth == 0 {
-                        if angle_depth == 0 {
-                            return index;
-                        }
+                        if angle_depth == 0 { return index; }
                     }
                 }
             }
@@ -207,12 +165,24 @@ fn parse_struct_literal(text: string) -> StructLiteralParse {
     let trimmed = trim_text(text);
     let mut diagnostics: string[] = [];
     if trimmed.length == 0 {
-        return StructLiteralParse { recognized: false, success: false, type_name: "", fields: [], diagnostics: diagnostics };
+        return StructLiteralParse {
+            recognized: false,
+            success: false,
+            type_name: "",
+            fields: [],
+            diagnostics: diagnostics
+        };
     }
 
     let first = substring(trimmed, 0, 1);
     if !is_identifier_start_char(first) {
-        return StructLiteralParse { recognized: false, success: false, type_name: "", fields: [], diagnostics: diagnostics };
+        return StructLiteralParse {
+            recognized: false,
+            success: false,
+            type_name: "",
+            fields: [],
+            diagnostics: diagnostics
+        };
     }
 
     let mut paren_depth: number = 0;
@@ -224,27 +194,17 @@ fn parse_struct_literal(text: string) -> StructLiteralParse {
     let mut in_double: boolean = false;
     let mut escape: boolean = false;
     loop {
-        if index >= trimmed.length {
-            break;
-        }
+        if index >= trimmed.length { break; }
         let ch = substring(trimmed, index, index + 1);
         if in_double {
-            if escape {
-                escape = false;
-            } else if ch == "\\" {
-                escape = true;
-            } else if ch == "\"" {
+            if escape { escape = false; } else if ch == "\\" { escape = true; } else if ch == "\"" {
                 in_double = false;
             }
             index += 1;
             continue;
         }
         if in_single {
-            if escape {
-                escape = false;
-            } else if ch == "\\" {
-                escape = true;
-            } else if ch == "'" {
+            if escape { escape = false; } else if ch == "\\" { escape = true; } else if ch == "'" {
                 in_single = false;
             }
             index += 1;
@@ -260,24 +220,12 @@ fn parse_struct_literal(text: string) -> StructLiteralParse {
             index += 1;
             continue;
         }
-        if ch == "(" {
-            paren_depth += 1;
-        } else if ch == ")" {
-            if paren_depth > 0 {
-                paren_depth -= 1;
-            }
-        } else if ch == "[" {
-            bracket_depth += 1;
-        } else if ch == "]" {
-            if bracket_depth > 0 {
-                bracket_depth -= 1;
-            }
-        } else if ch == "<" {
-            angle_depth += 1;
-        } else if ch == ">" {
-            if angle_depth > 0 {
-                angle_depth -= 1;
-            }
+        if ch == "(" { paren_depth += 1; } else if ch == ")" {
+            if paren_depth > 0 { paren_depth -= 1; }
+        } else if ch == "[" { bracket_depth += 1; } else if ch == "]" {
+            if bracket_depth > 0 { bracket_depth -= 1; }
+        } else if ch == "<" { angle_depth += 1; } else if ch == ">" {
+            if angle_depth > 0 { angle_depth -= 1; }
         } else if ch == "{" {
             if paren_depth == 0 {
                 if bracket_depth == 0 {
@@ -292,7 +240,13 @@ fn parse_struct_literal(text: string) -> StructLiteralParse {
     }
 
     if open_index < 0 {
-        return StructLiteralParse { recognized: false, success: false, type_name: "", fields: [], diagnostics: diagnostics };
+        return StructLiteralParse {
+            recognized: false,
+            success: false,
+            type_name: "",
+            fields: [],
+            diagnostics: diagnostics
+        };
     }
 
     let mut fatal: boolean = false;
@@ -321,14 +275,10 @@ fn parse_struct_literal(text: string) -> StructLiteralParse {
             let mut seen: string[] = [];
             let mut entry_index: number = 0;
             loop {
-                if entry_index >= entries.length {
-                    break;
-                }
+                if entry_index >= entries.length { break; }
                 let entry = trim_text(entries[entry_index]);
                 entry_index += 1;
-                if entry.length == 0 {
-                    continue;
-                }
+                if entry.length == 0 { continue; }
                 let colon_index = find_top_level_colon(entry);
                 if colon_index < 0 {
                     diagnostics.push("llvm lowering: struct literal field `" + entry + "` missing `:`");
@@ -349,7 +299,9 @@ fn parse_struct_literal(text: string) -> StructLiteralParse {
                     continue;
                 }
                 seen.push(field_name);
-                fields.push(StructLiteralField { name: field_name, value: value_text });
+                fields.push(StructLiteralField {
+                    name: field_name, value: value_text
+                });
             }
         }
     }
@@ -364,23 +316,39 @@ fn parse_struct_literal(text: string) -> StructLiteralParse {
         }
     }
 
-    if fatal {
-        fields = [];
-    }
+    if fatal { fields = []; }
 
-    return StructLiteralParse { recognized: true, success: !fatal, type_name: type_name, fields: fields, diagnostics: diagnostics };
+    return StructLiteralParse {
+        recognized: true,
+        success: !fatal,
+        type_name: type_name,
+        fields: fields,
+        diagnostics: diagnostics
+    };
 }
 
 fn parse_struct_pattern(text: string) -> StructLiteralParse {
     let trimmed = trim_text(text);
     let mut diagnostics: string[] = [];
     if trimmed.length == 0 {
-        return StructLiteralParse { recognized: false, success: false, type_name: "", fields: [], diagnostics: diagnostics };
+        return StructLiteralParse {
+            recognized: false,
+            success: false,
+            type_name: "",
+            fields: [],
+            diagnostics: diagnostics
+        };
     }
 
     let first = substring(trimmed, 0, 1);
     if !is_identifier_start_char(first) {
-        return StructLiteralParse { recognized: false, success: false, type_name: "", fields: [], diagnostics: diagnostics };
+        return StructLiteralParse {
+            recognized: false,
+            success: false,
+            type_name: "",
+            fields: [],
+            diagnostics: diagnostics
+        };
     }
 
     let mut paren_depth: number = 0;
@@ -392,27 +360,17 @@ fn parse_struct_pattern(text: string) -> StructLiteralParse {
     let mut in_double: boolean = false;
     let mut escape: boolean = false;
     loop {
-        if index >= trimmed.length {
-            break;
-        }
+        if index >= trimmed.length { break; }
         let ch = substring(trimmed, index, index + 1);
         if in_double {
-            if escape {
-                escape = false;
-            } else if ch == "\\" {
-                escape = true;
-            } else if ch == "\"" {
+            if escape { escape = false; } else if ch == "\\" { escape = true; } else if ch == "\"" {
                 in_double = false;
             }
             index += 1;
             continue;
         }
         if in_single {
-            if escape {
-                escape = false;
-            } else if ch == "\\" {
-                escape = true;
-            } else if ch == "'" {
+            if escape { escape = false; } else if ch == "\\" { escape = true; } else if ch == "'" {
                 in_single = false;
             }
             index += 1;
@@ -428,24 +386,12 @@ fn parse_struct_pattern(text: string) -> StructLiteralParse {
             index += 1;
             continue;
         }
-        if ch == "(" {
-            paren_depth += 1;
-        } else if ch == ")" {
-            if paren_depth > 0 {
-                paren_depth -= 1;
-            }
-        } else if ch == "[" {
-            bracket_depth += 1;
-        } else if ch == "]" {
-            if bracket_depth > 0 {
-                bracket_depth -= 1;
-            }
-        } else if ch == "<" {
-            angle_depth += 1;
-        } else if ch == ">" {
-            if angle_depth > 0 {
-                angle_depth -= 1;
-            }
+        if ch == "(" { paren_depth += 1; } else if ch == ")" {
+            if paren_depth > 0 { paren_depth -= 1; }
+        } else if ch == "[" { bracket_depth += 1; } else if ch == "]" {
+            if bracket_depth > 0 { bracket_depth -= 1; }
+        } else if ch == "<" { angle_depth += 1; } else if ch == ">" {
+            if angle_depth > 0 { angle_depth -= 1; }
         } else if ch == "{" {
             if paren_depth == 0 {
                 if bracket_depth == 0 {
@@ -460,19 +406,21 @@ fn parse_struct_pattern(text: string) -> StructLiteralParse {
     }
 
     if open_index < 0 {
-        return StructLiteralParse { recognized: false, success: false, type_name: "", fields: [], diagnostics: diagnostics };
+        return StructLiteralParse {
+            recognized: false,
+            success: false,
+            type_name: "",
+            fields: [],
+            diagnostics: diagnostics
+        };
     }
 
     let mut fatal: boolean = false;
     let close_index = find_matching_closing_brace(trimmed, open_index);
-    if close_index < 0 {
-        fatal = true;
-    }
+    if close_index < 0 { fatal = true; }
 
     let mut type_name: string = trim_text(substring(trimmed, 0, open_index));
-    if type_name.length == 0 {
-        fatal = true;
-    }
+    if type_name.length == 0 { fatal = true; }
 
     let mut fields: StructLiteralField[] = [];
     if !fatal {
@@ -482,73 +430,95 @@ fn parse_struct_pattern(text: string) -> StructLiteralParse {
             let mut seen: string[] = [];
             let mut entry_index: number = 0;
             loop {
-                if entry_index >= entries.length {
-                    break;
-                }
+                if entry_index >= entries.length { break; }
                 let entry = trim_text(entries[entry_index]);
                 entry_index += 1;
-                if entry.length == 0 {
-                    continue;
-                }
+                if entry.length == 0 { continue; }
                 let colon_index = find_top_level_colon(entry);
                 if colon_index < 0 {
                     let field_name = trim_text(entry);
-                    if field_name.length == 0 {
-                        continue;
-                    }
-                    if string_array_contains(seen, field_name) {
-                        continue;
-                    }
+                    if field_name.length == 0 { continue; }
+                    if string_array_contains(seen, field_name) { continue; }
                     seen.push(field_name);
                     // Empty value indicates a binding pattern.
-                    fields.push(StructLiteralField { name: field_name, value: "" });
+                    fields.push(StructLiteralField {
+                        name: field_name, value: ""
+                    });
                     continue;
                 }
                 let field_name = trim_text(substring(entry, 0, colon_index));
                 let value_text = trim_text(substring(entry, colon_index + 1, entry.length));
-                if field_name.length == 0 {
-                    continue;
-                }
-                if string_array_contains(seen, field_name) {
-                    continue;
-                }
-                if value_text.length == 0 {
-                    continue;
-                }
+                if field_name.length == 0 { continue; }
+                if string_array_contains(seen, field_name) { continue; }
+                if value_text.length == 0 { continue; }
                 seen.push(field_name);
-                fields.push(StructLiteralField { name: field_name, value: value_text });
+                fields.push(StructLiteralField {
+                    name: field_name, value: value_text
+                });
             }
         }
     }
 
-    if fatal {
-        fields = [];
-    }
+    if fatal { fields = []; }
 
-    return StructLiteralParse { recognized: true, success: !fatal, type_name: type_name, fields: fields, diagnostics: diagnostics };
+    return StructLiteralParse {
+        recognized: true,
+        success: !fatal,
+        type_name: type_name,
+        fields: fields,
+        diagnostics: diagnostics
+    };
 }
 
 fn parse_enum_literal(text: string) -> EnumLiteralParse {
     let trimmed = trim_text(text);
     let mut diagnostics: string[] = [];
     if trimmed.length == 0 {
-        return EnumLiteralParse { recognized: false, success: false, enum_name: "", variant_name: "", fields: [], diagnostics: diagnostics };
+        return EnumLiteralParse {
+            recognized: false,
+            success: false,
+            enum_name: "",
+            variant_name: "",
+            fields: [],
+            diagnostics: diagnostics
+        };
     }
 
     let first = substring(trimmed, 0, 1);
     if !is_identifier_start_char(first) {
-        return EnumLiteralParse { recognized: false, success: false, enum_name: "", variant_name: "", fields: [], diagnostics: diagnostics };
+        return EnumLiteralParse {
+            recognized: false,
+            success: false,
+            enum_name: "",
+            variant_name: "",
+            fields: [],
+            diagnostics: diagnostics
+        };
     }
 
     // Look for EnumName.VariantName pattern
     let dot_index = index_of(trimmed, ".");
     if dot_index < 0 {
-        return EnumLiteralParse { recognized: false, success: false, enum_name: "", variant_name: "", fields: [], diagnostics: diagnostics };
+        return EnumLiteralParse {
+            recognized: false,
+            success: false,
+            enum_name: "",
+            variant_name: "",
+            fields: [],
+            diagnostics: diagnostics
+        };
     }
 
     let enum_name_part = trim_text(substring(trimmed, 0, dot_index));
     if enum_name_part.length == 0 {
-        return EnumLiteralParse { recognized: false, success: false, enum_name: "", variant_name: "", fields: [], diagnostics: diagnostics };
+        return EnumLiteralParse {
+            recognized: false,
+            success: false,
+            enum_name: "",
+            variant_name: "",
+            fields: [],
+            diagnostics: diagnostics
+        };
     }
 
     let mut paren_depth: number = 0;
@@ -560,27 +530,17 @@ fn parse_enum_literal(text: string) -> EnumLiteralParse {
     let mut in_double: boolean = false;
     let mut escape: boolean = false;
     loop {
-        if index >= trimmed.length {
-            break;
-        }
+        if index >= trimmed.length { break; }
         let ch = substring(trimmed, index, index + 1);
         if in_double {
-            if escape {
-                escape = false;
-            } else if ch == "\\" {
-                escape = true;
-            } else if ch == "\"" {
+            if escape { escape = false; } else if ch == "\\" { escape = true; } else if ch == "\"" {
                 in_double = false;
             }
             index += 1;
             continue;
         }
         if in_single {
-            if escape {
-                escape = false;
-            } else if ch == "\\" {
-                escape = true;
-            } else if ch == "'" {
+            if escape { escape = false; } else if ch == "\\" { escape = true; } else if ch == "'" {
                 in_single = false;
             }
             index += 1;
@@ -596,24 +556,12 @@ fn parse_enum_literal(text: string) -> EnumLiteralParse {
             index += 1;
             continue;
         }
-        if ch == "(" {
-            paren_depth += 1;
-        } else if ch == ")" {
-            if paren_depth > 0 {
-                paren_depth -= 1;
-            }
-        } else if ch == "[" {
-            bracket_depth += 1;
-        } else if ch == "]" {
-            if bracket_depth > 0 {
-                bracket_depth -= 1;
-            }
-        } else if ch == "<" {
-            angle_depth += 1;
-        } else if ch == ">" {
-            if angle_depth > 0 {
-                angle_depth -= 1;
-            }
+        if ch == "(" { paren_depth += 1; } else if ch == ")" {
+            if paren_depth > 0 { paren_depth -= 1; }
+        } else if ch == "[" { bracket_depth += 1; } else if ch == "]" {
+            if bracket_depth > 0 { bracket_depth -= 1; }
+        } else if ch == "<" { angle_depth += 1; } else if ch == ">" {
+            if angle_depth > 0 { angle_depth -= 1; }
         } else if ch == "{" {
             if paren_depth == 0 {
                 if bracket_depth == 0 {
@@ -632,7 +580,14 @@ fn parse_enum_literal(text: string) -> EnumLiteralParse {
     if open_index < 0 {
         let mut variant_name_part = trim_text(substring(trimmed, dot_index + 1, trimmed.length));
         if variant_name_part.length == 0 {
-            return EnumLiteralParse { recognized: false, success: false, enum_name: "", variant_name: "", fields: [], diagnostics: diagnostics };
+            return EnumLiteralParse {
+                recognized: false,
+                success: false,
+                enum_name: "",
+                variant_name: "",
+                fields: [],
+                diagnostics: diagnostics
+            };
         }
 
         // Reject member-access chains like Enum.Variant().field so they can be
@@ -646,29 +601,19 @@ fn parse_enum_literal(text: string) -> EnumLiteralParse {
         let mut dot_seen: boolean = false;
         let mut scan_index: number = 0;
         loop {
-            if scan_index >= variant_name_part.length {
-                break;
-            }
+            if scan_index >= variant_name_part.length { break; }
             let ch = variant_name_part[scan_index];
             if in_double {
-                if escape {
-                    escape = false;
-                } else if ch == "\\" {
+                if escape { escape = false; } else if ch == "\\" {
                     escape = true;
-                } else if ch == "\"" {
-                    in_double = false;
-                }
+                } else if ch == "\"" { in_double = false; }
                 scan_index += 1;
                 continue;
             }
             if in_single {
-                if escape {
-                    escape = false;
-                } else if ch == "\\" {
+                if escape { escape = false; } else if ch == "\\" {
                     escape = true;
-                } else if ch == "'" {
-                    in_single = false;
-                }
+                } else if ch == "'" { in_single = false; }
                 scan_index += 1;
                 continue;
             }
@@ -682,24 +627,12 @@ fn parse_enum_literal(text: string) -> EnumLiteralParse {
                 scan_index += 1;
                 continue;
             }
-            if ch == "(" {
-                paren_depth += 1;
-            } else if ch == ")" {
-                if paren_depth > 0 {
-                    paren_depth -= 1;
-                }
-            } else if ch == "[" {
-                bracket_depth += 1;
-            } else if ch == "]" {
-                if bracket_depth > 0 {
-                    bracket_depth -= 1;
-                }
-            } else if ch == "<" {
-                angle_depth += 1;
-            } else if ch == ">" {
-                if angle_depth > 0 {
-                    angle_depth -= 1;
-                }
+            if ch == "(" { paren_depth += 1; } else if ch == ")" {
+                if paren_depth > 0 { paren_depth -= 1; }
+            } else if ch == "[" { bracket_depth += 1; } else if ch == "]" {
+                if bracket_depth > 0 { bracket_depth -= 1; }
+            } else if ch == "<" { angle_depth += 1; } else if ch == ">" {
+                if angle_depth > 0 { angle_depth -= 1; }
             } else if ch == "." {
                 if paren_depth == 0 {
                     if bracket_depth == 0 {
@@ -714,7 +647,14 @@ fn parse_enum_literal(text: string) -> EnumLiteralParse {
         }
 
         if dot_seen {
-            return EnumLiteralParse { recognized: false, success: false, enum_name: "", variant_name: "", fields: [], diagnostics: diagnostics };
+            return EnumLiteralParse {
+                recognized: false,
+                success: false,
+                enum_name: "",
+                variant_name: "",
+                fields: [],
+                diagnostics: diagnostics
+            };
         }
 
         // Accept empty-argument unit-variant constructors like Enum.Variant()
@@ -723,15 +663,36 @@ fn parse_enum_literal(text: string) -> EnumLiteralParse {
         }
 
         if variant_name_part.length == 0 {
-            return EnumLiteralParse { recognized: false, success: false, enum_name: "", variant_name: "", fields: [], diagnostics: diagnostics };
+            return EnumLiteralParse {
+                recognized: false,
+                success: false,
+                enum_name: "",
+                variant_name: "",
+                fields: [],
+                diagnostics: diagnostics
+            };
         }
 
         if !is_simple_identifier(variant_name_part) {
-            return EnumLiteralParse { recognized: false, success: false, enum_name: "", variant_name: "", fields: [], diagnostics: diagnostics };
+            return EnumLiteralParse {
+                recognized: false,
+                success: false,
+                enum_name: "",
+                variant_name: "",
+                fields: [],
+                diagnostics: diagnostics
+            };
         }
 
         // This is a unit variant - no payload fields
-        return EnumLiteralParse { recognized: true, success: true, enum_name: enum_name_part, variant_name: variant_name_part, fields: [], diagnostics: diagnostics };
+        return EnumLiteralParse {
+            recognized: true,
+            success: true,
+            enum_name: enum_name_part,
+            variant_name: variant_name_part,
+            fields: [],
+            diagnostics: diagnostics
+        };
     }
 
     let mut fatal: boolean = false;
@@ -755,14 +716,10 @@ fn parse_enum_literal(text: string) -> EnumLiteralParse {
             let mut seen: string[] = [];
             let mut entry_index: number = 0;
             loop {
-                if entry_index >= entries.length {
-                    break;
-                }
+                if entry_index >= entries.length { break; }
                 let entry = trim_text(entries[entry_index]);
                 entry_index += 1;
-                if entry.length == 0 {
-                    continue;
-                }
+                if entry.length == 0 { continue; }
                 let colon_index = find_top_level_colon(entry);
                 if colon_index < 0 {
                     // No colon - this might be shorthand syntax for match patterns like { radius }
@@ -778,7 +735,9 @@ fn parse_enum_literal(text: string) -> EnumLiteralParse {
                     }
                     seen.push(field_name);
                     // Use empty string as value to indicate this is a binding pattern (not a literal value)
-                    fields.push(StructLiteralField { name: field_name, value: "" });
+                    fields.push(StructLiteralField {
+                        name: field_name, value: ""
+                    });
                     continue;
                 }
                 let field_name = trim_text(substring(entry, 0, colon_index));
@@ -796,7 +755,9 @@ fn parse_enum_literal(text: string) -> EnumLiteralParse {
                     continue;
                 }
                 seen.push(field_name);
-                fields.push(StructLiteralField { name: field_name, value: value_text });
+                fields.push(StructLiteralField {
+                    name: field_name, value: value_text
+                });
             }
         }
     }
@@ -811,11 +772,16 @@ fn parse_enum_literal(text: string) -> EnumLiteralParse {
         }
     }
 
-    if fatal {
-        fields = [];
-    }
+    if fatal { fields = []; }
 
-    return EnumLiteralParse { recognized: true, success: !fatal, enum_name: enum_name_part, variant_name: variant_name_part, fields: fields, diagnostics: diagnostics };
+    return EnumLiteralParse {
+        recognized: true,
+        success: !fatal,
+        enum_name: enum_name_part,
+        variant_name: variant_name_part,
+        fields: fields,
+        diagnostics: diagnostics
+    };
 }
 
 fn find_top_level_range_separator(value: string) -> number {
@@ -824,9 +790,7 @@ fn find_top_level_range_separator(value: string) -> number {
     let mut brace_depth: number = 0;
     let mut index: number = 0;
     loop {
-        if index >= value.length {
-            break;
-        }
+        if index >= value.length { break; }
         let ch = substring(value, index, index + 1);
         if ch == "(" {
             paren_depth += 1;
@@ -834,9 +798,7 @@ fn find_top_level_range_separator(value: string) -> number {
             continue;
         }
         if ch == ")" {
-            if paren_depth > 0 {
-                paren_depth -= 1;
-            }
+            if paren_depth > 0 { paren_depth -= 1; }
             index += 1;
             continue;
         }
@@ -846,9 +808,7 @@ fn find_top_level_range_separator(value: string) -> number {
             continue;
         }
         if ch == "]" {
-            if bracket_depth > 0 {
-                bracket_depth -= 1;
-            }
+            if bracket_depth > 0 { bracket_depth -= 1; }
             index += 1;
             continue;
         }
@@ -858,9 +818,7 @@ fn find_top_level_range_separator(value: string) -> number {
             continue;
         }
         if ch == "}" {
-            if brace_depth > 0 {
-                brace_depth -= 1;
-            }
+            if brace_depth > 0 { brace_depth -= 1; }
             index += 1;
             continue;
         }
@@ -871,9 +829,7 @@ fn find_top_level_range_separator(value: string) -> number {
                 if substring(value, _cp_dot_next, _cp_dot_next2) == "." {
                     if paren_depth == 0 {
                         if bracket_depth == 0 {
-                            if brace_depth == 0 {
-                                return index;
-                            }
+                            if brace_depth == 0 { return index; }
                         }
                     }
                 }
@@ -890,29 +846,15 @@ fn find_top_level_range_separator_from(value: string, start_index: number) -> nu
     let mut brace_depth: number = 0;
     let mut index: number = 0;
     loop {
-        if index >= value.length {
-            break;
-        }
+        if index >= value.length { break; }
         let _cp_rng_next = index + 1;
         let ch = substring(value, index, _cp_rng_next);
-        if ch == "(" {
-            paren_depth += 1;
-        } else if ch == ")" {
-            if paren_depth > 0 {
-                paren_depth -= 1;
-            }
-        } else if ch == "[" {
-            bracket_depth += 1;
-        } else if ch == "]" {
-            if bracket_depth > 0 {
-                bracket_depth -= 1;
-            }
-        } else if ch == "{" {
-            brace_depth += 1;
-        } else if ch == "}" {
-            if brace_depth > 0 {
-                brace_depth -= 1;
-            }
+        if ch == "(" { paren_depth += 1; } else if ch == ")" {
+            if paren_depth > 0 { paren_depth -= 1; }
+        } else if ch == "[" { bracket_depth += 1; } else if ch == "]" {
+            if bracket_depth > 0 { bracket_depth -= 1; }
+        } else if ch == "{" { brace_depth += 1; } else if ch == "}" {
+            if brace_depth > 0 { brace_depth -= 1; }
         }
         if index >= start_index {
             if ch == "." {
@@ -922,9 +864,7 @@ fn find_top_level_range_separator_from(value: string, start_index: number) -> nu
                     if substring(value, _cp_rng2_next, _cp_rng2_next2) == "." {
                         if paren_depth == 0 {
                             if bracket_depth == 0 {
-                                if brace_depth == 0 {
-                                    return index;
-                                }
+                                if brace_depth == 0 { return index; }
                             }
                         }
                     }
@@ -946,27 +886,17 @@ fn find_member_access_separator(value: string) -> number {
     let mut index: number = 0;
     let mut last_index: number = -1;
     loop {
-        if index >= value.length {
-            break;
-        }
+        if index >= value.length { break; }
         let ch = char_at(value, index);
         if in_single {
-            if escape {
-                escape = false;
-            } else if ch == "\\" {
-                escape = true;
-            } else if ch == "'" {
+            if escape { escape = false; } else if ch == "\\" { escape = true; } else if ch == "'" {
                 in_single = false;
             }
             index += 1;
             continue;
         }
         if in_double {
-            if escape {
-                escape = false;
-            } else if ch == "\\" {
-                escape = true;
-            } else if ch == "\"" {
+            if escape { escape = false; } else if ch == "\\" { escape = true; } else if ch == "\"" {
                 in_double = false;
             }
             index += 1;
@@ -988,9 +918,7 @@ fn find_member_access_separator(value: string) -> number {
             continue;
         }
         if ch == ")" {
-            if paren_depth > 0 {
-                paren_depth -= 1;
-            }
+            if paren_depth > 0 { paren_depth -= 1; }
             index += 1;
             continue;
         }
@@ -1000,9 +928,7 @@ fn find_member_access_separator(value: string) -> number {
             continue;
         }
         if ch == "]" {
-            if bracket_depth > 0 {
-                bracket_depth -= 1;
-            }
+            if bracket_depth > 0 { bracket_depth -= 1; }
             index += 1;
             continue;
         }
@@ -1012,9 +938,7 @@ fn find_member_access_separator(value: string) -> number {
             continue;
         }
         if ch == "}" {
-            if brace_depth > 0 {
-                brace_depth -= 1;
-            }
+            if brace_depth > 0 { brace_depth -= 1; }
             index += 1;
             continue;
         }
@@ -1085,28 +1009,24 @@ fn parse_index_expression(expression: string) -> IndexExpressionParse {
     if trimmed.length == 0 {
         return IndexExpressionParse { success: false, base: "", index: "" };
     }
-    
+
     // Look for the last '[' that is not inside nested brackets
     let mut bracket_depth: number = 0;
     let mut index_position: number = -1;
     let mut i: number = trimmed.length - 1;
-    
+
     // Start from the end to find the outermost closing bracket
     if substring(trimmed, trimmed.length - 1, trimmed.length) != "]" {
         return IndexExpressionParse { success: false, base: "", index: "" };
     }
-    
+
     // Now walk backwards to find the matching opening bracket
     bracket_depth = 1;
     i = trimmed.length - 2;
     loop {
-        if i < 0 {
-            break;
-        }
+        if i < 0 { break; }
         let ch = char_at(trimmed, i);
-        if ch == "]" {
-            bracket_depth += 1;
-        }
+        if ch == "]" { bracket_depth += 1; }
         if ch == "[" {
             bracket_depth -= 1;
             if bracket_depth == 0 {
@@ -1116,21 +1036,21 @@ fn parse_index_expression(expression: string) -> IndexExpressionParse {
         }
         i -= 1;
     }
-    
+
     if index_position < 0 {
         return IndexExpressionParse { success: false, base: "", index: "" };
     }
-    
+
     let base = trim_text(substring(trimmed, 0, index_position));
     let index = trim_text(substring(trimmed, index_position + 1, trimmed.length - 1));
-    
+
     let mut _if113: boolean = false;
     if base.length == 0 { _if113 = true; }
     if index.length == 0 { _if113 = true; }
     if _if113 {
         return IndexExpressionParse { success: false, base: "", index: "" };
     }
-    
+
     return IndexExpressionParse { success: true, base: base, index: index };
 }
 
@@ -1139,14 +1059,26 @@ fn parse_range_iterable(iterable: string) -> RangeIterableParse {
     let mut diagnostics: string[] = [];
     if trimmed.length == 0 {
         diagnostics.push("llvm lowering: `.for` iterable expression is empty");
-        return RangeIterableParse { success: false, start: "", end: "", stride: "", diagnostics: diagnostics };
+        return RangeIterableParse {
+            success: false,
+            start: "",
+            end: "",
+            stride: "",
+            diagnostics: diagnostics
+        };
     }
     let first_separator = find_top_level_range_separator(trimmed);
     let mut has_stride: boolean = false;
     let mut stride_text: string = "";
     if first_separator < 0 {
         diagnostics.push("llvm lowering: `.for` iterable must use `start..end` range syntax");
-        return RangeIterableParse { success: false, start: "", end: "", stride: "", diagnostics: diagnostics };
+        return RangeIterableParse {
+            success: false,
+            start: "",
+            end: "",
+            stride: "",
+            diagnostics: diagnostics
+        };
     }
     let second_separator = find_top_level_range_separator_from(trimmed, first_separator + 2);
     let start_text = trim_text(substring(trimmed, 0, first_separator));
@@ -1173,11 +1105,15 @@ fn parse_range_iterable(iterable: string) -> RangeIterableParse {
             let mut _if115: boolean = false;
             if !has_stride { _if115 = true; }
             if stride_text.length > 0 { _if115 = true; }
-            if _if115 {
-                _let114 = true;
-            }
+            if _if115 { _let114 = true; }
         }
     }
     let success = _let114;
-    return RangeIterableParse { success: success, start: start_text, end: end_text, stride: stride_text, diagnostics: diagnostics };
+    return RangeIterableParse {
+        success: success,
+        start: start_text,
+        end: end_text,
+        stride: stride_text,
+        diagnostics: diagnostics
+    };
 }

--- a/compiler/src/llvm/expression_lowering/native/core_parse.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_parse.sfn
@@ -14,7 +14,7 @@ import {
     MemberAccessParse,
     RangeIterableParse,
     StructLiteralField,
-    StructLiteralParse,
+    StructLiteralParse
 } from "../../types";
 import { ends_with, is_identifier_start_char } from "../../utils";
 import { split_array_elements } from "../splitting";
@@ -24,7 +24,7 @@ import {
     index_of,
     is_digit_char,
     string_array_contains,
-    trim_text,
+    trim_text
 } from "./core_text";
 
 fn find_matching_closing_brace(text: string, open_index: number) -> number {
@@ -257,7 +257,8 @@ fn parse_struct_literal(text: string) -> StructLiteralParse {
         if snippet.length > 120 {
             snippet = substring(snippet, 0, 117) + "...";
         }
-        diagnostics.push("llvm lowering: struct literal context `" + snippet + "`");
+        diagnostics.push("llvm lowering: struct literal context `" + snippet
+            + "`");
         fatal = true;
     }
 
@@ -281,7 +282,9 @@ fn parse_struct_literal(text: string) -> StructLiteralParse {
                 if entry.length == 0 { continue; }
                 let colon_index = find_top_level_colon(entry);
                 if colon_index < 0 {
-                    diagnostics.push("llvm lowering: struct literal field `" + entry + "` missing `:`");
+                    diagnostics.push("llvm lowering: struct literal field `"
+                        + entry
+                        + "` missing `:`");
                     continue;
                 }
                 let field_name = trim_text(substring(entry, 0, colon_index));
@@ -291,11 +294,15 @@ fn parse_struct_literal(text: string) -> StructLiteralParse {
                     continue;
                 }
                 if string_array_contains(seen, field_name) {
-                    diagnostics.push("llvm lowering: struct literal field `" + field_name + "` repeated");
+                    diagnostics.push("llvm lowering: struct literal field `"
+                        + field_name
+                        + "` repeated");
                     continue;
                 }
                 if value_text.length == 0 {
-                    diagnostics.push("llvm lowering: struct literal field `" + field_name + "` missing value");
+                    diagnostics.push("llvm lowering: struct literal field `"
+                        + field_name
+                        + "` missing value");
                     continue;
                 }
                 seen.push(field_name);
@@ -310,7 +317,9 @@ fn parse_struct_literal(text: string) -> StructLiteralParse {
         if close_index >= 0 {
             let remainder = trim_text(substring(trimmed, close_index + 1, trimmed.length));
             if remainder.length > 0 {
-                diagnostics.push("llvm lowering: struct literal trailing content `" + remainder + "`");
+                diagnostics.push("llvm lowering: struct literal trailing content `"
+                    + remainder
+                    + "`");
                 fatal = true;
             }
         }
@@ -730,7 +739,9 @@ fn parse_enum_literal(text: string) -> EnumLiteralParse {
                         continue;
                     }
                     if string_array_contains(seen, field_name) {
-                        diagnostics.push("llvm lowering: enum literal field `" + field_name + "` repeated");
+                        diagnostics.push("llvm lowering: enum literal field `"
+                            + field_name
+                            + "` repeated");
                         continue;
                     }
                     seen.push(field_name);
@@ -747,11 +758,15 @@ fn parse_enum_literal(text: string) -> EnumLiteralParse {
                     continue;
                 }
                 if string_array_contains(seen, field_name) {
-                    diagnostics.push("llvm lowering: enum literal field `" + field_name + "` repeated");
+                    diagnostics.push("llvm lowering: enum literal field `"
+                        + field_name
+                        + "` repeated");
                     continue;
                 }
                 if value_text.length == 0 {
-                    diagnostics.push("llvm lowering: enum literal field `" + field_name + "` missing value");
+                    diagnostics.push("llvm lowering: enum literal field `"
+                        + field_name
+                        + "` missing value");
                     continue;
                 }
                 seen.push(field_name);
@@ -766,7 +781,9 @@ fn parse_enum_literal(text: string) -> EnumLiteralParse {
         if close_index >= 0 {
             let remainder = trim_text(substring(trimmed, close_index + 1, trimmed.length));
             if remainder.length > 0 {
-                diagnostics.push("llvm lowering: enum literal trailing content `" + remainder + "`");
+                diagnostics.push("llvm lowering: enum literal trailing content `"
+                    + remainder
+                    + "`");
                 fatal = true;
             }
         }
@@ -1080,7 +1097,8 @@ fn parse_range_iterable(iterable: string) -> RangeIterableParse {
             diagnostics: diagnostics
         };
     }
-    let second_separator = find_top_level_range_separator_from(trimmed, first_separator + 2);
+    let second_separator = find_top_level_range_separator_from(trimmed, first_separator
+        + 2);
     let start_text = trim_text(substring(trimmed, 0, first_separator));
     let mut end_text = trim_text(substring(trimmed, first_separator + 2, trimmed.length));
     if second_separator >= 0 {

--- a/compiler/src/llvm/expression_lowering/native/core_parsing.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_parsing.sfn
@@ -3,7 +3,7 @@
 // Parsing helpers for expression lowering extracted from core.sfn.
 import { char_at, substring } from "../../../string_utils";
 import { array_struct_type_for_element } from "../../type_mapping";
-import { map_type_annotation, } from "../../type_mapping";
+import { map_type_annotation } from "../../type_mapping";
 import {
     ArrayLiteralMetadata,
     BorrowArgumentParse,
@@ -11,7 +11,7 @@ import {
     CastParseResult,
     RawAddressParseResult,
     TernaryParseResult,
-    TypeContext,
+    TypeContext
 } from "../../types";
 import {
     append_string,
@@ -19,9 +19,9 @@ import {
     is_identifier_part_char,
     is_identifier_start_char,
     starts_with,
-    trim_text,
+    trim_text
 } from "../../utils";
-import { map_primitive_type, } from "./core_type_mapping";
+import { map_primitive_type } from "./core_type_mapping";
 
 fn parse_borrow_expression(expression: string) -> BorrowParseResult {
     let trimmed = trim_text(expression);
@@ -234,7 +234,9 @@ fn extract_borrow_argument(text: string) -> BorrowArgumentParse {
     let inner = substring(text, 1, closing_index);
     let remainder = trim_text(substring(text, closing_index + 1, text.length));
     if remainder.length > 0 {
-        diagnostics.push("llvm lowering: borrow expression trailing content `" + remainder + "`");
+        diagnostics.push("llvm lowering: borrow expression trailing content `"
+            + remainder
+            + "`");
         return BorrowArgumentParse {
             success: false,
             argument: "",
@@ -277,7 +279,9 @@ fn extract_simple_borrow_target(text: string) -> BorrowArgumentParse {
     }
     let remainder = trim_text(substring(trimmed, index, trimmed.length));
     if remainder.length > 0 {
-        diagnostics.push("llvm lowering: borrow expression trailing content `" + remainder + "`");
+        diagnostics.push("llvm lowering: borrow expression trailing content `"
+            + remainder
+            + "`");
         return BorrowArgumentParse {
             success: false,
             argument: target,
@@ -650,7 +654,8 @@ fn parse_cast_expression(text: string) -> CastParseResult {
     if value.length == 0 { _if120 = true; }
     if annotation.length == 0 { _if120 = true; }
     if _if120 {
-        diagnostics.push("llvm lowering: malformed cast expression `" + text + "`");
+        diagnostics.push("llvm lowering: malformed cast expression `" + text
+            + "`");
         return CastParseResult {
             recognized: true,
             success: false,

--- a/compiler/src/llvm/expression_lowering/native/core_parsing.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_parsing.sfn
@@ -1,43 +1,39 @@
 // compiler/src/llvm/expression_lowering/native/core_parsing.sfn
 //
 // Parsing helpers for expression lowering extracted from core.sfn.
-
-import { substring, char_at } from "../../../string_utils";
-
+import { char_at, substring } from "../../../string_utils";
+import { array_struct_type_for_element } from "../../type_mapping";
+import { map_type_annotation, } from "../../type_mapping";
 import {
-    TypeContext,
-    BorrowParseResult,
-    BorrowArgumentParse,
-    TernaryParseResult,
-    RawAddressParseResult,
-    CastParseResult,
     ArrayLiteralMetadata,
+    BorrowArgumentParse,
+    BorrowParseResult,
+    CastParseResult,
+    RawAddressParseResult,
+    TernaryParseResult,
+    TypeContext,
 } from "../../types";
-
 import {
-    trim_text,
-    starts_with,
     append_string,
     is_effect_delimiter,
-    is_identifier_start_char,
     is_identifier_part_char,
+    is_identifier_start_char,
+    starts_with,
+    trim_text,
 } from "../../utils";
-
-import { array_struct_type_for_element } from "../../type_mapping";
-
-import {
-    map_type_annotation,
-} from "../../type_mapping";
-
-import {
-    map_primitive_type,
-} from "./core_type_mapping";
+import { map_primitive_type, } from "./core_type_mapping";
 
 fn parse_borrow_expression(expression: string) -> BorrowParseResult {
     let trimmed = trim_text(expression);
     let mut diagnostics: string[] = [];
     if trimmed.length == 0 {
-        return BorrowParseResult { recognized: false, success: false, target: "", mutable: false, diagnostics: diagnostics };
+        return BorrowParseResult {
+            recognized: false,
+            success: false,
+            target: "",
+            mutable: false,
+            diagnostics: diagnostics
+        };
     }
     // Support both prefix borrows (`&x`, `&mut x`) and the historical built-in
     // call forms (`borrow(x)`, `borrow_mut(x)`).
@@ -47,7 +43,13 @@ fn parse_borrow_expression(expression: string) -> BorrowParseResult {
 
     if starts_with(trimmed, "&") {
         if starts_with(trimmed, "&&") {
-            return BorrowParseResult { recognized: false, success: false, target: "", mutable: false, diagnostics: diagnostics };
+            return BorrowParseResult {
+                recognized: false,
+                success: false,
+                target: "",
+                mutable: false,
+                diagnostics: diagnostics
+            };
         }
         is_prefix_form = true;
         remainder = trim_text(substring(trimmed, 1, trimmed.length));
@@ -61,13 +63,25 @@ fn parse_borrow_expression(expression: string) -> BorrowParseResult {
         } else if starts_with(trimmed, "borrow") {
             after_keyword = trim_text(substring(trimmed, 6, trimmed.length));
         } else {
-            return BorrowParseResult { recognized: false, success: false, target: "", mutable: false, diagnostics: diagnostics };
+            return BorrowParseResult {
+                recognized: false,
+                success: false,
+                target: "",
+                mutable: false,
+                diagnostics: diagnostics
+            };
         }
         let mut _if116: boolean = false;
         if after_keyword.length == 0 { _if116 = true; }
         if substring(after_keyword, 0, 1) != "(" { _if116 = true; }
         if _if116 {
-            return BorrowParseResult { recognized: false, success: false, target: "", mutable: false, diagnostics: diagnostics };
+            return BorrowParseResult {
+                recognized: false,
+                success: false,
+                target: "",
+                mutable: false,
+                diagnostics: diagnostics
+            };
         }
         remainder = after_keyword;
     }
@@ -82,7 +96,13 @@ fn parse_borrow_expression(expression: string) -> BorrowParseResult {
     }
     if remainder.length == 0 {
         let issue = append_string(diagnostics, "llvm lowering: borrow expression missing target");
-        return BorrowParseResult { recognized: true, success: false, target: "", mutable: mutable_flag, diagnostics: issue };
+        return BorrowParseResult {
+            recognized: true,
+            success: false,
+            target: "",
+            mutable: mutable_flag,
+            diagnostics: issue
+        };
     }
 
     if remainder.length > 0 {
@@ -96,7 +116,13 @@ fn parse_borrow_expression(expression: string) -> BorrowParseResult {
                 _ci0 += 1;
             }
             if !argument_parse.success {
-                return BorrowParseResult { recognized: true, success: false, target: "", mutable: mutable_flag, diagnostics: messages };
+                return BorrowParseResult {
+                    recognized: true,
+                    success: false,
+                    target: "",
+                    mutable: mutable_flag,
+                    diagnostics: messages
+                };
             }
             let mut argument_text: string = argument_parse.argument;
             if starts_with(argument_text, "mut") {
@@ -109,23 +135,59 @@ fn parse_borrow_expression(expression: string) -> BorrowParseResult {
             }
             if argument_text.length == 0 {
                 messages.push("llvm lowering: borrow expression missing target");
-                return BorrowParseResult { recognized: true, success: false, target: "", mutable: mutable_flag, diagnostics: messages };
+                return BorrowParseResult {
+                    recognized: true,
+                    success: false,
+                    target: "",
+                    mutable: mutable_flag,
+                    diagnostics: messages
+                };
             }
             if !is_valid_borrow_target(argument_text) {
-                return BorrowParseResult { recognized: false, success: false, target: "", mutable: mutable_flag, diagnostics: diagnostics };
+                return BorrowParseResult {
+                    recognized: false,
+                    success: false,
+                    target: "",
+                    mutable: mutable_flag,
+                    diagnostics: diagnostics
+                };
             }
-            return BorrowParseResult { recognized: true, success: true, target: argument_text, mutable: mutable_flag, diagnostics: messages };
+            return BorrowParseResult {
+                recognized: true,
+                success: true,
+                target: argument_text,
+                mutable: mutable_flag,
+                diagnostics: messages
+            };
         }
     }
 
     let simple_parse = extract_simple_borrow_target(remainder);
     if !simple_parse.success {
-        return BorrowParseResult { recognized: false, success: false, target: "", mutable: mutable_flag, diagnostics: diagnostics };
+        return BorrowParseResult {
+            recognized: false,
+            success: false,
+            target: "",
+            mutable: mutable_flag,
+            diagnostics: diagnostics
+        };
     }
     if !is_valid_borrow_target(simple_parse.argument) {
-        return BorrowParseResult { recognized: false, success: false, target: "", mutable: mutable_flag, diagnostics: diagnostics };
+        return BorrowParseResult {
+            recognized: false,
+            success: false,
+            target: "",
+            mutable: mutable_flag,
+            diagnostics: diagnostics
+        };
     }
-    return BorrowParseResult { recognized: true, success: true, target: simple_parse.argument, mutable: mutable_flag, diagnostics: diagnostics };
+    return BorrowParseResult {
+        recognized: true,
+        success: true,
+        target: simple_parse.argument,
+        mutable: mutable_flag,
+        diagnostics: diagnostics
+    };
 }
 
 fn extract_borrow_argument(text: string) -> BorrowArgumentParse {
@@ -134,9 +196,7 @@ fn extract_borrow_argument(text: string) -> BorrowArgumentParse {
     let mut index: number = 0;
     let mut closing_index: number = -1;
     loop {
-        if index >= text.length {
-            break;
-        }
+        if index >= text.length { break; }
         let ch = substring(text, index, index + 1);
         if ch == "(" {
             depth += 1;
@@ -146,7 +206,11 @@ fn extract_borrow_argument(text: string) -> BorrowArgumentParse {
         if ch == ")" {
             if depth == 0 {
                 diagnostics.push("llvm lowering: borrow expression missing opening `(`");
-                return BorrowArgumentParse { success: false, argument: "", diagnostics: diagnostics };
+                return BorrowArgumentParse {
+                    success: false,
+                    argument: "",
+                    diagnostics: diagnostics
+                };
             }
             depth -= 1;
             let current_index = index;
@@ -161,15 +225,27 @@ fn extract_borrow_argument(text: string) -> BorrowArgumentParse {
     }
     if closing_index < 0 {
         diagnostics.push("llvm lowering: borrow expression missing closing `)`");
-        return BorrowArgumentParse { success: false, argument: "", diagnostics: diagnostics };
+        return BorrowArgumentParse {
+            success: false,
+            argument: "",
+            diagnostics: diagnostics
+        };
     }
     let inner = substring(text, 1, closing_index);
     let remainder = trim_text(substring(text, closing_index + 1, text.length));
     if remainder.length > 0 {
         diagnostics.push("llvm lowering: borrow expression trailing content `" + remainder + "`");
-        return BorrowArgumentParse { success: false, argument: "", diagnostics: diagnostics };
+        return BorrowArgumentParse {
+            success: false,
+            argument: "",
+            diagnostics: diagnostics
+        };
     }
-    return BorrowArgumentParse { success: true, argument: trim_text(inner), diagnostics: diagnostics };
+    return BorrowArgumentParse {
+        success: true,
+        argument: trim_text(inner),
+        diagnostics: diagnostics
+    };
 }
 
 fn extract_simple_borrow_target(text: string) -> BorrowArgumentParse {
@@ -177,55 +253,59 @@ fn extract_simple_borrow_target(text: string) -> BorrowArgumentParse {
     let trimmed = trim_text(text);
     if trimmed.length == 0 {
         diagnostics.push("llvm lowering: borrow expression missing target");
-        return BorrowArgumentParse { success: false, argument: "", diagnostics: diagnostics };
+        return BorrowArgumentParse {
+            success: false,
+            argument: "",
+            diagnostics: diagnostics
+        };
     }
     let mut index: number = 0;
     loop {
-        if index >= trimmed.length {
-            break;
-        }
+        if index >= trimmed.length { break; }
         let ch = substring(trimmed, index, index + 1);
-        if is_effect_delimiter(ch) {
-            break;
-        }
+        if is_effect_delimiter(ch) { break; }
         index += 1;
     }
     let target = trim_text(substring(trimmed, 0, index));
     if target.length == 0 {
         diagnostics.push("llvm lowering: borrow expression missing target");
-        return BorrowArgumentParse { success: false, argument: "", diagnostics: diagnostics };
+        return BorrowArgumentParse {
+            success: false,
+            argument: "",
+            diagnostics: diagnostics
+        };
     }
     let remainder = trim_text(substring(trimmed, index, trimmed.length));
     if remainder.length > 0 {
         diagnostics.push("llvm lowering: borrow expression trailing content `" + remainder + "`");
-        return BorrowArgumentParse { success: false, argument: target, diagnostics: diagnostics };
+        return BorrowArgumentParse {
+            success: false,
+            argument: target,
+            diagnostics: diagnostics
+        };
     }
-    return BorrowArgumentParse { success: true, argument: target, diagnostics: diagnostics };
+    return BorrowArgumentParse {
+        success: true,
+        argument: target,
+        diagnostics: diagnostics
+    };
 }
 
 fn is_valid_borrow_target(text: string) -> boolean {
     let trimmed = trim_text(text);
-    if trimmed.length == 0 {
-        return false;
-    }
+    if trimmed.length == 0 { return false; }
     let mut index: number = 0;
     loop {
-        if index >= trimmed.length {
-            break;
-        }
+        if index >= trimmed.length { break; }
         let ch = substring(trimmed, index, index + 1);
         if ch == "." {
             index += 1;
             continue;
         }
         if index == 0 {
-            if !is_identifier_start_char(ch) {
-                return false;
-            }
+            if !is_identifier_start_char(ch) { return false; }
         } else {
-            if !is_identifier_part_char(ch) {
-                return false;
-            }
+            if !is_identifier_part_char(ch) { return false; }
         }
         index += 1;
     }
@@ -235,23 +315,27 @@ fn is_valid_borrow_target(text: string) -> boolean {
 fn parse_ternary_expression(text: string) -> TernaryParseResult {
     let mut diagnostics: string[] = [];
     let trimmed = trim_text(text);
-    
+
     if trimmed.length == 0 {
-        return TernaryParseResult { success: false, condition: "", true_value: "", false_value: "", diagnostics: diagnostics };
+        return TernaryParseResult {
+            success: false,
+            condition: "",
+            true_value: "",
+            false_value: "",
+            diagnostics: diagnostics
+        };
     }
-    
+
     // Find '?' and ':' at the same nesting level (depth 0)
     let mut depth: number = 0;
     let mut question_index: number = -1;
     let mut colon_index: number = -1;
     let mut index: number = 0;
-    
+
     loop {
-        if index >= trimmed.length {
-            break;
-        }
+        if index >= trimmed.length { break; }
         let ch = substring(trimmed, index, index + 1);
-        
+
         let mut _if117: boolean = false;
         if ch == "(" { _if117 = true; }
         if ch == "[" { _if117 = true; }
@@ -270,7 +354,7 @@ fn parse_ternary_expression(text: string) -> TernaryParseResult {
             index += 1;
             continue;
         }
-        
+
         if depth == 0 {
             if ch == "?" {
                 if question_index < 0 {
@@ -289,59 +373,115 @@ fn parse_ternary_expression(text: string) -> TernaryParseResult {
                 }
             }
         }
-        
+
         index += 1;
     }
-    
+
     let mut _if119: boolean = false;
     if question_index < 0 { _if119 = true; }
     if colon_index < 0 { _if119 = true; }
     if _if119 {
-        return TernaryParseResult { success: false, condition: "", true_value: "", false_value: "", diagnostics: diagnostics };
+        return TernaryParseResult {
+            success: false,
+            condition: "",
+            true_value: "",
+            false_value: "",
+            diagnostics: diagnostics
+        };
     }
-    
+
     if question_index >= colon_index {
         diagnostics.push("llvm lowering: malformed ternary expression - `:` before `?`");
-        return TernaryParseResult { success: false, condition: "", true_value: "", false_value: "", diagnostics: diagnostics };
+        return TernaryParseResult {
+            success: false,
+            condition: "",
+            true_value: "",
+            false_value: "",
+            diagnostics: diagnostics
+        };
     }
-    
+
     let condition = trim_text(substring(trimmed, 0, question_index));
     let true_value = trim_text(substring(trimmed, question_index + 1, colon_index));
     let false_value = trim_text(substring(trimmed, colon_index + 1, trimmed.length));
-    
+
     if condition.length == 0 {
         diagnostics.push("llvm lowering: ternary expression missing condition");
-        return TernaryParseResult { success: false, condition: "", true_value: "", false_value: "", diagnostics: diagnostics };
+        return TernaryParseResult {
+            success: false,
+            condition: "",
+            true_value: "",
+            false_value: "",
+            diagnostics: diagnostics
+        };
     }
     if true_value.length == 0 {
         diagnostics.push("llvm lowering: ternary expression missing true branch value");
-        return TernaryParseResult { success: false, condition: "", true_value: "", false_value: "", diagnostics: diagnostics };
+        return TernaryParseResult {
+            success: false,
+            condition: "",
+            true_value: "",
+            false_value: "",
+            diagnostics: diagnostics
+        };
     }
     if false_value.length == 0 {
         diagnostics.push("llvm lowering: ternary expression missing false branch value");
-        return TernaryParseResult { success: false, condition: "", true_value: "", false_value: "", diagnostics: diagnostics };
+        return TernaryParseResult {
+            success: false,
+            condition: "",
+            true_value: "",
+            false_value: "",
+            diagnostics: diagnostics
+        };
     }
-    
-    return TernaryParseResult { success: true, condition: condition, true_value: true_value, false_value: false_value, diagnostics: diagnostics };
+
+    return TernaryParseResult {
+        success: true,
+        condition: condition,
+        true_value: true_value,
+        false_value: false_value,
+        diagnostics: diagnostics
+    };
 }
 
 fn parse_raw_address_expression(text: string) -> RawAddressParseResult {
     let trimmed = trim_text(text);
     let mut diagnostics: string[] = [];
     if trimmed.length == 0 {
-        return RawAddressParseResult { recognized: false, success: false, target: "", diagnostics: diagnostics };
+        return RawAddressParseResult {
+            recognized: false,
+            success: false,
+            target: "",
+            diagnostics: diagnostics
+        };
     }
     if !starts_with(trimmed, "&") {
-        return RawAddressParseResult { recognized: false, success: false, target: "", diagnostics: diagnostics };
+        return RawAddressParseResult {
+            recognized: false,
+            success: false,
+            target: "",
+            diagnostics: diagnostics
+        };
     }
     // Support `&raw x` and `& raw x`.
     if starts_with(trimmed, "&raw") {
         let remainder = trim_text(substring(trimmed, 4, trimmed.length));
         if remainder.length == 0 {
             diagnostics.push("llvm lowering: &raw expression missing target");
-            return RawAddressParseResult { recognized: true, success: false, target: "", diagnostics: diagnostics };
+            return RawAddressParseResult {
+                recognized: true,
+                success: false,
+                target: "",
+                diagnostics: diagnostics
+            };
         }
-        return RawAddressParseResult { recognized: true, success: true, target: remainder, diagnostics: diagnostics };
+        return RawAddressParseResult {
+            recognized: true,
+            success: true,
+            target: remainder,
+            diagnostics: diagnostics
+        };
     }
     if starts_with(trimmed, "&") {
         let after_amp = trim_text(substring(trimmed, 1, trimmed.length));
@@ -349,19 +489,40 @@ fn parse_raw_address_expression(text: string) -> RawAddressParseResult {
             let remainder = trim_text(substring(after_amp, 3, after_amp.length));
             if remainder.length == 0 {
                 diagnostics.push("llvm lowering: &raw expression missing target");
-                return RawAddressParseResult { recognized: true, success: false, target: "", diagnostics: diagnostics };
+                return RawAddressParseResult {
+                    recognized: true,
+                    success: false,
+                    target: "",
+                    diagnostics: diagnostics
+                };
             }
-            return RawAddressParseResult { recognized: true, success: true, target: remainder, diagnostics: diagnostics };
+            return RawAddressParseResult {
+                recognized: true,
+                success: true,
+                target: remainder,
+                diagnostics: diagnostics
+            };
         }
     }
-    return RawAddressParseResult { recognized: false, success: false, target: "", diagnostics: diagnostics };
+    return RawAddressParseResult {
+        recognized: false,
+        success: false,
+        target: "",
+        diagnostics: diagnostics
+    };
 }
 
 fn parse_cast_expression(text: string) -> CastParseResult {
     let trimmed = trim_text(text);
     let mut diagnostics: string[] = [];
     if trimmed.length == 0 {
-        return CastParseResult { recognized: false, success: false, value: "", type_annotation: "", diagnostics: diagnostics };
+        return CastParseResult {
+            recognized: false,
+            success: false,
+            value: "",
+            type_annotation: "",
+            diagnostics: diagnostics
+        };
     }
 
     // Scan for a top-level ` as ` outside of brackets/strings.
@@ -375,9 +536,7 @@ fn parse_cast_expression(text: string) -> CastParseResult {
     let mut index: number = 0;
     let mut match_index: number = -1;
     loop {
-        if index >= trimmed.length {
-            break;
-        }
+        if index >= trimmed.length { break; }
         let ch = char_at(trimmed, index);
         if in_double {
             if escape_next {
@@ -390,9 +549,7 @@ fn parse_cast_expression(text: string) -> CastParseResult {
                 index += 1;
                 continue;
             }
-            if ch == "\"" {
-                in_double = false;
-            }
+            if ch == "\"" { in_double = false; }
             index += 1;
             continue;
         }
@@ -407,9 +564,7 @@ fn parse_cast_expression(text: string) -> CastParseResult {
                 index += 1;
                 continue;
             }
-            if ch == "'" {
-                in_single = false;
-            }
+            if ch == "'" { in_single = false; }
             index += 1;
             continue;
         }
@@ -429,9 +584,7 @@ fn parse_cast_expression(text: string) -> CastParseResult {
             continue;
         }
         if ch == ")" {
-            if paren_depth > 0 {
-                paren_depth -= 1;
-            }
+            if paren_depth > 0 { paren_depth -= 1; }
             index += 1;
             continue;
         }
@@ -441,9 +594,7 @@ fn parse_cast_expression(text: string) -> CastParseResult {
             continue;
         }
         if ch == "]" {
-            if bracket_depth > 0 {
-                bracket_depth -= 1;
-            }
+            if bracket_depth > 0 { bracket_depth -= 1; }
             index += 1;
             continue;
         }
@@ -453,9 +604,7 @@ fn parse_cast_expression(text: string) -> CastParseResult {
             continue;
         }
         if ch == "}" {
-            if brace_depth > 0 {
-                brace_depth -= 1;
-            }
+            if brace_depth > 0 { brace_depth -= 1; }
             index += 1;
             continue;
         }
@@ -465,9 +614,7 @@ fn parse_cast_expression(text: string) -> CastParseResult {
             continue;
         }
         if ch == ">" {
-            if angle_depth > 0 {
-                angle_depth -= 1;
-            }
+            if angle_depth > 0 { angle_depth -= 1; }
             index += 1;
             continue;
         }
@@ -479,9 +626,7 @@ fn parse_cast_expression(text: string) -> CastParseResult {
                         let _as_end = index + 4;
                         if _as_end <= trimmed.length {
                             let window = substring(trimmed, index, _as_end);
-                            if window == " as " {
-                                match_index = index;
-                            }
+                            if window == " as " { match_index = index; }
                         }
                     }
                 }
@@ -491,7 +636,13 @@ fn parse_cast_expression(text: string) -> CastParseResult {
     }
 
     if match_index < 0 {
-        return CastParseResult { recognized: false, success: false, value: "", type_annotation: "", diagnostics: diagnostics };
+        return CastParseResult {
+            recognized: false,
+            success: false,
+            value: "",
+            type_annotation: "",
+            diagnostics: diagnostics
+        };
     }
     let value = trim_text(substring(trimmed, 0, match_index));
     let annotation = trim_text(substring(trimmed, match_index + 4, trimmed.length));
@@ -500,9 +651,21 @@ fn parse_cast_expression(text: string) -> CastParseResult {
     if annotation.length == 0 { _if120 = true; }
     if _if120 {
         diagnostics.push("llvm lowering: malformed cast expression `" + text + "`");
-        return CastParseResult { recognized: true, success: false, value: value, type_annotation: annotation, diagnostics: diagnostics };
+        return CastParseResult {
+            recognized: true,
+            success: false,
+            value: value,
+            type_annotation: annotation,
+            diagnostics: diagnostics
+        };
     }
-    return CastParseResult { recognized: true, success: true, value: value, type_annotation: annotation, diagnostics: diagnostics };
+    return CastParseResult {
+        recognized: true,
+        success: true,
+        value: value,
+        type_annotation: annotation,
+        diagnostics: diagnostics
+    };
 }
 
 fn parse_array_literal_metadata(entries: string[], context: TypeContext) -> ArrayLiteralMetadata {
@@ -527,22 +690,16 @@ fn parse_array_literal_metadata(entries: string[], context: TypeContext) -> Arra
 
 fn map_metadata_annotation(context: TypeContext, annotation: string) -> string {
     let trimmed = trim_text(annotation);
-    if trimmed.length == 0 {
-        return "";
-    }
+    if trimmed.length == 0 { return ""; }
     let primitive = map_primitive_type(context, trimmed);
-    if primitive.length > 0 {
-        return primitive;
-    }
+    if primitive.length > 0 { return primitive; }
     // Check if this is an array type annotation (e.g., "Color[]")
     if trimmed.length > 2 {
         let suffix = substring(trimmed, trimmed.length - 2, trimmed.length);
         if suffix == "[]" {
             let inner_annotation = trim_text(substring(trimmed, 0, trimmed.length - 2));
             let inner_type = map_metadata_annotation(context, inner_annotation);
-            if inner_type.length == 0 {
-                return "";
-            }
+            if inner_type.length == 0 { return ""; }
             let struct_type = array_struct_type_for_element(inner_type);
             return struct_type + "*";
         }

--- a/compiler/src/llvm/expression_lowering/native/core_scopes.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_scopes.sfn
@@ -6,25 +6,20 @@
 // `find_local_binding`, `find_parameter_binding`, `append_local_binding`,
 // `infer_borrow_base_scope`, lifetime region creation/release, and scope ID
 // construction (`format_root_scope_id`, `make_child_scope_id`).
-
-import { NativeStruct, NativeEnum } from "../../../native_ir";
-
+import { NativeEnum, NativeStruct } from "../../../native_ir";
 import {
-    OwnershipInfo,
+    LLVMOperand,
     LifetimeRegionMetadata,
     LifetimeReleaseEvent,
-    ScopeMetadata,
     LocalBinding,
+    OwnershipInfo,
     ParameterBinding,
-    LLVMOperand,
+    ScopeMetadata,
     StructLiteralField,
 } from "../../types";
-
 import { starts_with } from "../../utils";
-
-import { sanitize_symbol } from "./core_text";
-
 import { bindings_find_parameter_binding } from "../bindings";
+import { sanitize_symbol } from "./core_text";
 
 fn find_parameter_binding(bindings: ParameterBinding[], name: string) -> ParameterBinding? {
     return bindings_find_parameter_binding(bindings, name);
@@ -33,14 +28,10 @@ fn find_parameter_binding(bindings: ParameterBinding[], name: string) -> Paramet
 fn find_local_binding(locals: LocalBinding[], name: string) -> LocalBinding? {
     let mut index: number = locals.length;
     loop {
-        if index <= 0 {
-            break;
-        }
+        if index <= 0 { break; }
         index -= 1;
         let entry = locals[index];
-        if entry.name == name {
-            return entry;
-        }
+        if entry.name == name { return entry; }
     }
     return null;
 }
@@ -48,13 +39,22 @@ fn find_local_binding(locals: LocalBinding[], name: string) -> LocalBinding? {
 fn infer_borrow_base_scope(base: string, locals: LocalBinding[], bindings: ParameterBinding[], function_name: string) -> ScopeMetadata {
     let local = find_local_binding(locals, base);
     if local != null {
-        return ScopeMetadata { scope_id: local.scope_id, scope_depth: local.scope_depth };
+        return ScopeMetadata {
+            scope_id: local.scope_id,
+            scope_depth: local.scope_depth
+        };
     }
     let parameter = find_parameter_binding(bindings, base);
     if parameter != null {
-        return ScopeMetadata { scope_id: format_root_scope_id(function_name), scope_depth: 0 };
+        return ScopeMetadata {
+            scope_id: format_root_scope_id(function_name),
+            scope_depth: 0
+        };
     }
-    return ScopeMetadata { scope_id: format_root_scope_id(function_name), scope_depth: 0 };
+    return ScopeMetadata {
+        scope_id: format_root_scope_id(function_name),
+        scope_depth: 0
+    };
 }
 
 fn append_lifetime_region(values: LifetimeRegionMetadata[], value: LifetimeRegionMetadata) -> LifetimeRegionMetadata[] {
@@ -73,9 +73,7 @@ fn mark_lifetime_region_released(regions: LifetimeRegionMetadata[], region_id: n
     let mut result: LifetimeRegionMetadata[] = [];
     let mut index: number = 0;
     loop {
-        if index >= regions.length {
-            break;
-        }
+        if index >= regions.length { break; }
         let entry = regions[index];
         if entry.id == region_id {
             let updated = LifetimeRegionMetadata {
@@ -93,24 +91,18 @@ fn mark_lifetime_region_released(regions: LifetimeRegionMetadata[], region_id: n
                 released: true,
             };
             result.push(updated);
-        } else {
-            result.push(entry);
-        }
+        } else { result.push(entry); }
         index += 1;
     }
     return result;
 }
 
 fn apply_lifetime_release_events(regions: LifetimeRegionMetadata[], releases: LifetimeReleaseEvent[]) -> LifetimeRegionMetadata[] {
-    if releases.length == 0 {
-        return regions;
-    }
+    if releases.length == 0 { return regions; }
     let mut current_regions: LifetimeRegionMetadata[] = regions;
     let mut index: number = 0;
     loop {
-        if index >= releases.length {
-            break;
-        }
+        if index >= releases.length { break; }
         let release = releases[index];
         current_regions = mark_lifetime_region_released(current_regions, release.region_id, release.scope_id, release.scope_depth);
         index += 1;
@@ -137,37 +129,23 @@ fn make_lifetime_region_metadata(id: number, binding: string, ownership: Ownersh
 
 fn format_root_scope_id(function_name: string) -> string {
     let mut sanitized: string = sanitize_symbol(function_name);
-    if sanitized.length == 0 {
-        sanitized = "fn";
-    }
+    if sanitized.length == 0 { sanitized = "fn"; }
     return "fn:" + sanitized;
 }
 
 fn make_child_scope_id(parent: string, child: string) -> string {
     let mut sanitized_child: string = sanitize_symbol(child);
-    if sanitized_child.length == 0 {
-        sanitized_child = "scope";
-    }
-    if parent.length == 0 {
-        return sanitized_child;
-    }
+    if sanitized_child.length == 0 { sanitized_child = "scope"; }
+    if parent.length == 0 { return sanitized_child; }
     return parent + "__" + sanitized_child;
 }
 
 fn is_scope_descendant(parent: string, candidate: string) -> boolean {
-    if parent.length == 0 {
-        return true;
-    }
-    if candidate.length == 0 {
-        return false;
-    }
-    if candidate == parent {
-        return true;
-    }
+    if parent.length == 0 { return true; }
+    if candidate.length == 0 { return false; }
+    if candidate == parent { return true; }
     let prefix = parent + "__";
-    if candidate.length <= prefix.length {
-        return false;
-    }
+    if candidate.length <= prefix.length { return false; }
     return starts_with(candidate, prefix);
 }
 
@@ -175,9 +153,7 @@ fn append_local_binding(values: LocalBinding[], value: LocalBinding) -> LocalBin
     let mut out: LocalBinding[] = [];
     let mut index: number = 0;
     loop {
-        if index >= values.length {
-            break;
-        }
+        if index >= values.length { break; }
         out.push(values[index]);
         index += 1;
     }
@@ -213,12 +189,8 @@ fn replace_llvm_operand(values: LLVMOperand[], index: number, value: LLVMOperand
     let mut result: LLVMOperand[] = [];
     let mut current: number = 0;
     loop {
-        if current >= values.length {
-            break;
-        }
-        if current == index {
-            result.push(value);
-        } else {
+        if current >= values.length { break; }
+        if current == index { result.push(value); } else {
             result.push(values[current]);
         }
         current += 1;

--- a/compiler/src/llvm/expression_lowering/native/core_scopes.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_scopes.sfn
@@ -15,7 +15,7 @@ import {
     OwnershipInfo,
     ParameterBinding,
     ScopeMetadata,
-    StructLiteralField,
+    StructLiteralField
 } from "../../types";
 import { starts_with } from "../../utils";
 import { bindings_find_parameter_binding } from "../bindings";
@@ -88,7 +88,7 @@ fn mark_lifetime_region_released(regions: LifetimeRegionMetadata[], region_id: n
                 base_scope_depth: entry.base_scope_depth,
                 end_scope_id: scope_id,
                 end_scope_depth: scope_depth,
-                released: true,
+                released: true
             };
             result.push(updated);
         } else { result.push(entry); }
@@ -123,7 +123,7 @@ fn make_lifetime_region_metadata(id: number, binding: string, ownership: Ownersh
         base_scope_depth: base_scope_depth,
         end_scope_id: "",
         end_scope_depth: 0,
-        released: false,
+        released: false
     };
 }
 

--- a/compiler/src/llvm/expression_lowering/native/core_strings.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_strings.sfn
@@ -1,35 +1,16 @@
 // compiler/src/llvm/expression_lowering/native/core_strings.sfn
 //
 // String lowering helpers for expression lowering extracted from core.sfn.
-
+import { format_temp_name, } from "../../expressions_helpers";
+import { empty_string_constant_set, escape_string_for_llvm, } from "../../strings";
 import {
-    LLVMOperand,
     ExpressionResult,
+    LLVMOperand,
     StringConstant,
 } from "../../types";
-
-import {
-    append_string,
-    number_to_string,
-} from "../../utils";
-
-import {
-    empty_string_constant_set,
-    escape_string_for_llvm,
-} from "../../strings";
-
-import {
-    format_temp_name,
-} from "../../expressions_helpers";
-
-import {
-    unescape_string_literal,
-} from "./core_text";
-
-import {
-    harmonise_operands,
-    coerce_operand_to_type,
-} from "./core_operands";
+import { append_string, number_to_string, } from "../../utils";
+import { coerce_operand_to_type, harmonise_operands, } from "./core_operands";
+import { unescape_string_literal, } from "./core_text";
 
 fn lower_string_literal(literal: string, temp_index: number, lines: string[]) -> ExpressionResult {
     // Stage2-native note:
@@ -67,7 +48,13 @@ fn emit_string_concat(left: LLVMOperand, right: LLVMOperand, temp_index: number,
     if harmonised.left == null { _if121 = true; }
     if harmonised.right == null { _if121 = true; }
     if _if121 {
-        return ExpressionResult { lines: harmonised.lines, temp_index: harmonised.temp_index, operand: null, diagnostics: harmonised.diagnostics, string_constants: empty_string_constant_set() };
+        return ExpressionResult {
+            lines: harmonised.lines,
+            temp_index: harmonised.temp_index,
+            operand: null,
+            diagnostics: harmonised.diagnostics,
+            string_constants: empty_string_constant_set()
+        };
     }
     let left_aligned = coerce_operand_to_type(harmonised.left, "i8*", harmonised.temp_index, harmonised.lines);
     let mut diagnostics: string[] = harmonised.diagnostics;
@@ -88,7 +75,13 @@ fn emit_string_concat(left: LLVMOperand, right: LLVMOperand, temp_index: number,
     if left_aligned.operand == null { _if122 = true; }
     if right_aligned.operand == null { _if122 = true; }
     if _if122 {
-        return ExpressionResult { lines: right_aligned.lines, temp_index: right_aligned.temp_index, operand: null, diagnostics: diagnostics, string_constants: empty_string_constant_set() };
+        return ExpressionResult {
+            lines: right_aligned.lines,
+            temp_index: right_aligned.temp_index,
+            operand: null,
+            diagnostics: diagnostics,
+            string_constants: empty_string_constant_set()
+        };
     }
     let temp_name = format_temp_name(right_aligned.temp_index);
     let line = "  " + temp_name + " = call i8* @sailfin_runtime_string_concat(i8* " + left_aligned.operand.value + ", i8* " + right_aligned.operand.value + ")";
@@ -99,20 +92,38 @@ fn emit_string_concat(left: LLVMOperand, right: LLVMOperand, temp_index: number,
     // (e.g., number_to_string used within a string concat chain).
     fs.writeFile("build/sailfin/.call_result_type", "i8*");
     fs.writeFile("build/sailfin/.call_result_value", temp_name);
-    return ExpressionResult { lines: out_lines, temp_index: right_aligned.temp_index + 1, operand: operand, diagnostics: diagnostics, string_constants: empty_string_constant_set() };
+    return ExpressionResult {
+        lines: out_lines,
+        temp_index: right_aligned.temp_index + 1,
+        operand: operand,
+        diagnostics: diagnostics,
+        string_constants: empty_string_constant_set()
+    };
 }
 
 fn coerce_operand_to_string(operand: LLVMOperand, temp_index: number, lines: string[]) -> ExpressionResult {
     let empty_constants = empty_string_constant_set();
     if operand.llvm_type == "i8*" {
-        return ExpressionResult { lines: lines, temp_index: temp_index, operand: operand, diagnostics: [], string_constants: empty_constants };
+        return ExpressionResult {
+            lines: lines,
+            temp_index: temp_index,
+            operand: operand,
+            diagnostics: [],
+            string_constants: empty_constants
+        };
     }
 
     if operand.llvm_type == "double" {
         let temp_name = format_temp_name(temp_index);
         let mut out_lines = append_string(lines, "  " + temp_name + " = call i8* @sailfin_runtime_number_to_string(double " + operand.value + ")");
         let out_operand = LLVMOperand { llvm_type: "i8*", value: temp_name };
-        return ExpressionResult { lines: out_lines, temp_index: temp_index + 1, operand: out_operand, diagnostics: [], string_constants: empty_constants };
+        return ExpressionResult {
+            lines: out_lines,
+            temp_index: temp_index + 1,
+            operand: out_operand,
+            diagnostics: [],
+            string_constants: empty_constants
+        };
     }
 
     if operand.llvm_type == "i64" {
@@ -121,7 +132,13 @@ fn coerce_operand_to_string(operand: LLVMOperand, temp_index: number, lines: str
         let call_temp = format_temp_name(temp_index + 1);
         out_lines.push("  " + call_temp + " = call i8* @sailfin_runtime_number_to_string(double " + cast_temp + ")");
         let out_operand = LLVMOperand { llvm_type: "i8*", value: call_temp };
-        return ExpressionResult { lines: out_lines, temp_index: temp_index + 2, operand: out_operand, diagnostics: [], string_constants: empty_constants };
+        return ExpressionResult {
+            lines: out_lines,
+            temp_index: temp_index + 2,
+            operand: out_operand,
+            diagnostics: [],
+            string_constants: empty_constants
+        };
     }
 
     if operand.llvm_type == "i32" {
@@ -130,7 +147,13 @@ fn coerce_operand_to_string(operand: LLVMOperand, temp_index: number, lines: str
         let call_temp = format_temp_name(temp_index + 1);
         out_lines.push("  " + call_temp + " = call i8* @sailfin_runtime_number_to_string(double " + cast_temp + ")");
         let out_operand = LLVMOperand { llvm_type: "i8*", value: call_temp };
-        return ExpressionResult { lines: out_lines, temp_index: temp_index + 2, operand: out_operand, diagnostics: [], string_constants: empty_constants };
+        return ExpressionResult {
+            lines: out_lines,
+            temp_index: temp_index + 2,
+            operand: out_operand,
+            diagnostics: [],
+            string_constants: empty_constants
+        };
     }
 
     if operand.llvm_type == "i8" {
@@ -141,24 +164,57 @@ fn coerce_operand_to_string(operand: LLVMOperand, temp_index: number, lines: str
         out_lines.push("  " + as_double + " = sitofp i64 " + as_i64 + " to double");
         out_lines.push("  " + as_string + " = call i8* @sailfin_runtime_number_to_string(double " + as_double + ")");
         let out_operand = LLVMOperand { llvm_type: "i8*", value: as_string };
-        return ExpressionResult { lines: out_lines, temp_index: temp_index + 3, operand: out_operand, diagnostics: [], string_constants: empty_constants };
+        return ExpressionResult {
+            lines: out_lines,
+            temp_index: temp_index + 3,
+            operand: out_operand,
+            diagnostics: [],
+            string_constants: empty_constants
+        };
     }
 
     if operand.llvm_type == "i1" {
         let true_lit = lower_string_literal("\"true\"", temp_index, lines);
         if true_lit.operand == null {
-            return ExpressionResult { lines: true_lit.lines, temp_index: true_lit.temp_index, operand: null, diagnostics: [], string_constants: empty_constants };
+            return ExpressionResult {
+                lines: true_lit.lines,
+                temp_index: true_lit.temp_index,
+                operand: null,
+                diagnostics: [],
+                string_constants: empty_constants
+            };
         }
         let false_lit = lower_string_literal("\"false\"", true_lit.temp_index, true_lit.lines);
         if false_lit.operand == null {
-            return ExpressionResult { lines: false_lit.lines, temp_index: false_lit.temp_index, operand: null, diagnostics: [], string_constants: empty_constants };
+            return ExpressionResult {
+                lines: false_lit.lines,
+                temp_index: false_lit.temp_index,
+                operand: null,
+                diagnostics: [],
+                string_constants: empty_constants
+            };
         }
         let select_temp = format_temp_name(false_lit.temp_index);
         let mut out_lines = append_string(false_lit.lines, "  " + select_temp + " = select i1 " + operand.value + ", i8* " + true_lit.operand.value + ", i8* " + false_lit.operand.value);
-        let out_operand = LLVMOperand { llvm_type: "i8*", value: select_temp };
-        return ExpressionResult { lines: out_lines, temp_index: false_lit.temp_index + 1, operand: out_operand, diagnostics: [], string_constants: empty_constants };
+        let out_operand = LLVMOperand {
+            llvm_type: "i8*",
+            value: select_temp
+        };
+        return ExpressionResult {
+            lines: out_lines,
+            temp_index: false_lit.temp_index + 1,
+            operand: out_operand,
+            diagnostics: [],
+            string_constants: empty_constants
+        };
     }
 
     let diagnostics: string[] = ["llvm lowering: unable to convert `" + operand.llvm_type + "` to string"];
-    return ExpressionResult { lines: lines, temp_index: temp_index, operand: null, diagnostics: diagnostics, string_constants: empty_constants };
+    return ExpressionResult {
+        lines: lines,
+        temp_index: temp_index,
+        operand: null,
+        diagnostics: diagnostics,
+        string_constants: empty_constants
+    };
 }

--- a/compiler/src/llvm/expression_lowering/native/core_strings.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_strings.sfn
@@ -1,16 +1,12 @@
 // compiler/src/llvm/expression_lowering/native/core_strings.sfn
 //
 // String lowering helpers for expression lowering extracted from core.sfn.
-import { format_temp_name, } from "../../expressions_helpers";
-import { empty_string_constant_set, escape_string_for_llvm, } from "../../strings";
-import {
-    ExpressionResult,
-    LLVMOperand,
-    StringConstant,
-} from "../../types";
-import { append_string, number_to_string, } from "../../utils";
-import { coerce_operand_to_type, harmonise_operands, } from "./core_operands";
-import { unescape_string_literal, } from "./core_text";
+import { format_temp_name } from "../../expressions_helpers";
+import { empty_string_constant_set, escape_string_for_llvm } from "../../strings";
+import { ExpressionResult, LLVMOperand, StringConstant } from "../../types";
+import { append_string, number_to_string } from "../../utils";
+import { coerce_operand_to_type, harmonise_operands } from "./core_operands";
+import { unescape_string_literal } from "./core_text";
 
 fn lower_string_literal(literal: string, temp_index: number, lines: string[]) -> ExpressionResult {
     // Stage2-native note:
@@ -26,10 +22,18 @@ fn lower_string_literal(literal: string, temp_index: number, lines: string[]) ->
 
     let mut current_lines: string[] = lines;
     let malloc_temp = format_temp_name(temp_index);
-    current_lines.push("  " + malloc_temp + " = call i8* @calloc(i64 1, i64 " + number_to_string(array_length) + ")");
+    current_lines.push("  " + malloc_temp + " = call i8* @calloc(i64 1, i64 "
+        + number_to_string(array_length)
+        + ")");
     let cast_temp = format_temp_name(temp_index + 1);
-    current_lines.push("  " + cast_temp + " = bitcast i8* " + malloc_temp + " to " + array_type + "*");
-    current_lines.push("  store " + array_type + " c\"" + escaped + "\\00\", " + array_type + "* " + cast_temp);
+    current_lines.push("  " + cast_temp + " = bitcast i8* " + malloc_temp
+        + " to "
+        + array_type
+        + "*");
+    current_lines.push("  store " + array_type + " c\"" + escaped + "\\00\", "
+        + array_type
+        + "* "
+        + cast_temp);
 
     let operand = LLVMOperand { llvm_type: "i8*", value: malloc_temp };
     let empty_constants = empty_string_constant_set();
@@ -84,7 +88,12 @@ fn emit_string_concat(left: LLVMOperand, right: LLVMOperand, temp_index: number,
         };
     }
     let temp_name = format_temp_name(right_aligned.temp_index);
-    let line = "  " + temp_name + " = call i8* @sailfin_runtime_string_concat(i8* " + left_aligned.operand.value + ", i8* " + right_aligned.operand.value + ")";
+    let line = "  " + temp_name
+        + " = call i8* @sailfin_runtime_string_concat(i8* "
+        + left_aligned.operand.value
+        + ", i8* "
+        + right_aligned.operand.value
+        + ")";
     let mut out_lines = append_string(right_aligned.lines, line);
     let operand = LLVMOperand { llvm_type: "i8*", value: temp_name };
     // Write result to IPC files so let-lowering picks up the latest value
@@ -115,7 +124,10 @@ fn coerce_operand_to_string(operand: LLVMOperand, temp_index: number, lines: str
 
     if operand.llvm_type == "double" {
         let temp_name = format_temp_name(temp_index);
-        let mut out_lines = append_string(lines, "  " + temp_name + " = call i8* @sailfin_runtime_number_to_string(double " + operand.value + ")");
+        let mut out_lines = append_string(lines, "  " + temp_name
+            + " = call i8* @sailfin_runtime_number_to_string(double "
+            + operand.value
+            + ")");
         let out_operand = LLVMOperand { llvm_type: "i8*", value: temp_name };
         return ExpressionResult {
             lines: out_lines,
@@ -128,9 +140,15 @@ fn coerce_operand_to_string(operand: LLVMOperand, temp_index: number, lines: str
 
     if operand.llvm_type == "i64" {
         let cast_temp = format_temp_name(temp_index);
-        let mut out_lines = append_string(lines, "  " + cast_temp + " = sitofp i64 " + operand.value + " to double");
+        let mut out_lines = append_string(lines, "  " + cast_temp
+            + " = sitofp i64 "
+            + operand.value
+            + " to double");
         let call_temp = format_temp_name(temp_index + 1);
-        out_lines.push("  " + call_temp + " = call i8* @sailfin_runtime_number_to_string(double " + cast_temp + ")");
+        out_lines.push("  " + call_temp
+            + " = call i8* @sailfin_runtime_number_to_string(double "
+            + cast_temp
+            + ")");
         let out_operand = LLVMOperand { llvm_type: "i8*", value: call_temp };
         return ExpressionResult {
             lines: out_lines,
@@ -143,9 +161,15 @@ fn coerce_operand_to_string(operand: LLVMOperand, temp_index: number, lines: str
 
     if operand.llvm_type == "i32" {
         let cast_temp = format_temp_name(temp_index);
-        let mut out_lines = append_string(lines, "  " + cast_temp + " = sitofp i32 " + operand.value + " to double");
+        let mut out_lines = append_string(lines, "  " + cast_temp
+            + " = sitofp i32 "
+            + operand.value
+            + " to double");
         let call_temp = format_temp_name(temp_index + 1);
-        out_lines.push("  " + call_temp + " = call i8* @sailfin_runtime_number_to_string(double " + cast_temp + ")");
+        out_lines.push("  " + call_temp
+            + " = call i8* @sailfin_runtime_number_to_string(double "
+            + cast_temp
+            + ")");
         let out_operand = LLVMOperand { llvm_type: "i8*", value: call_temp };
         return ExpressionResult {
             lines: out_lines,
@@ -160,9 +184,15 @@ fn coerce_operand_to_string(operand: LLVMOperand, temp_index: number, lines: str
         let as_i64 = format_temp_name(temp_index);
         let as_double = format_temp_name(temp_index + 1);
         let as_string = format_temp_name(temp_index + 2);
-        let mut out_lines = append_string(lines, "  " + as_i64 + " = sext i8 " + operand.value + " to i64");
-        out_lines.push("  " + as_double + " = sitofp i64 " + as_i64 + " to double");
-        out_lines.push("  " + as_string + " = call i8* @sailfin_runtime_number_to_string(double " + as_double + ")");
+        let mut out_lines = append_string(lines, "  " + as_i64 + " = sext i8 "
+            + operand.value
+            + " to i64");
+        out_lines.push("  " + as_double + " = sitofp i64 " + as_i64
+            + " to double");
+        out_lines.push("  " + as_string
+            + " = call i8* @sailfin_runtime_number_to_string(double "
+            + as_double
+            + ")");
         let out_operand = LLVMOperand { llvm_type: "i8*", value: as_string };
         return ExpressionResult {
             lines: out_lines,
@@ -195,7 +225,13 @@ fn coerce_operand_to_string(operand: LLVMOperand, temp_index: number, lines: str
             };
         }
         let select_temp = format_temp_name(false_lit.temp_index);
-        let mut out_lines = append_string(false_lit.lines, "  " + select_temp + " = select i1 " + operand.value + ", i8* " + true_lit.operand.value + ", i8* " + false_lit.operand.value);
+        let mut out_lines = append_string(false_lit.lines, "  " + select_temp
+            + " = select i1 "
+            + operand.value
+            + ", i8* "
+            + true_lit.operand.value
+            + ", i8* "
+            + false_lit.operand.value);
         let out_operand = LLVMOperand {
             llvm_type: "i8*",
             value: select_temp
@@ -209,7 +245,8 @@ fn coerce_operand_to_string(operand: LLVMOperand, temp_index: number, lines: str
         };
     }
 
-    let diagnostics: string[] = ["llvm lowering: unable to convert `" + operand.llvm_type + "` to string"];
+    let diagnostics: string[] = ["llvm lowering: unable to convert `" + operand.llvm_type
+        + "` to string"];
     return ExpressionResult {
         lines: lines,
         temp_index: temp_index,

--- a/compiler/src/llvm/expression_lowering/native/core_text.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_text.sfn
@@ -6,46 +6,19 @@
 // pipeline: `number_to_string`, `trim_text`, `matches_case_insensitive`,
 // `sanitize_symbol`, character classification, and LLVM type string inspection
 // (e.g., `is_union_llvm_type`, `parse_union_payload_types`).
-
-import { substring, char_code, char_at } from "../../../string_utils";
-
+import { char_at, char_code, substring } from "../../../string_utils";
+import { InterpolatedTemplateParse, } from "../../types";
 import {
-    InterpolatedTemplateParse,
-} from "../../types";
-
-import {
-    starts_with,
-    is_identifier_start_char,
     is_identifier_part_char,
+    is_identifier_start_char,
+    starts_with,
 } from "../../utils";
-
-import {
-    split_array_elements,
-} from "../splitting";
+import { split_array_elements, } from "../splitting";
 
 fn number_to_string(value: number) -> string {
-    if value == 0 {
-        return "0";
-    }
+    if value == 0 { return "0"; }
     let digits = "0123456789";
-    let powers: number[] = [
-        1000000000000000,
-        100000000000000,
-        10000000000000,
-        1000000000000,
-        100000000000,
-        10000000000,
-        1000000000,
-        100000000,
-        10000000,
-        1000000,
-        100000,
-        10000,
-        1000,
-        100,
-        10,
-        1
-    ];
+    let powers: number[] = [1000000000000000, 100000000000000, 10000000000000, 1000000000000, 100000000000, 10000000000, 1000000000, 100000000, 10000000, 1000000, 100000, 10000, 1000, 100, 10, 1];
     let mut remaining: number = value;
     let mut is_negative: boolean = false;
     if remaining < 0 {
@@ -56,15 +29,11 @@ fn number_to_string(value: number) -> string {
     let mut index: number = 0;
     let mut started: boolean = false;
     loop {
-        if index >= powers.length {
-            break;
-        }
+        if index >= powers.length { break; }
         let power = powers[index];
         let mut count: number = 0;
         loop {
-            if remaining < power {
-                break;
-            }
+            if remaining < power { break; }
             remaining -= power;
             count += 1;
         }
@@ -78,12 +47,8 @@ fn number_to_string(value: number) -> string {
         }
         index += 1;
     }
-    if output.length == 0 {
-        output = "0";
-    }
-    if is_negative {
-        return "-" + output;
-    }
+    if output.length == 0 { output = "0"; }
+    if is_negative { return "-" + output; }
     return output;
 }
 
@@ -100,21 +65,15 @@ fn lower_char_code(code: number) -> number {
 }
 
 fn matches_case_insensitive(value: string, expected: string) -> boolean {
-    if value.length != expected.length {
-        return false;
-    }
+    if value.length != expected.length { return false; }
     let mut index: number = 0;
     loop {
-        if index >= value.length {
-            break;
-        }
+        if index >= value.length { break; }
         let value_ch = substring(value, index, index + 1);
         let expected_ch = substring(expected, index, index + 1);
         let value_code = lower_char_code(char_code(value_ch));
         let expected_code = lower_char_code(char_code(expected_ch));
-        if value_code != expected_code {
-            return false;
-        }
+        if value_code != expected_code { return false; }
         index += 1;
     }
     return true;
@@ -124,9 +83,7 @@ fn trim_text(value: string) -> string {
     let mut start: number = 0;
     let mut end: number = value.length;
     loop {
-        if start >= end {
-            break;
-        }
+        if start >= end { break; }
         let ch = char_at(value, start);
         if is_trim_char(ch) {
             start += 1;
@@ -135,9 +92,7 @@ fn trim_text(value: string) -> string {
         break;
     }
     loop {
-        if end <= start {
-            break;
-        }
+        if end <= start { break; }
         let ch = char_at(value, end - 1);
         if is_trim_char(ch) {
             end -= 1;
@@ -146,9 +101,7 @@ fn trim_text(value: string) -> string {
         break;
     }
     if start == 0 {
-        if end == value.length {
-            return value;
-        }
+        if end == value.length { return value; }
     }
     return substring(value, start, end);
 }
@@ -164,42 +117,30 @@ fn is_trim_char(ch: string) -> boolean {
 }
 
 fn index_of(value: string, target: string) -> number {
-    if target.length == 0 {
-        return 0;
-    }
+    if target.length == 0 { return 0; }
     // Use substring + == instead of char_code_at_text comparisons.
     // char_code_at_text is miscompiled by older seeds, but substring
     // (backed by the C runtime grapheme_at) and == both work correctly.
     let _search_limit = value.length - target.length;
     let mut index: number = 0;
     loop {
-        if index > _search_limit {
-            break;
-        }
+        if index > _search_limit { break; }
         let candidate = substring(value, index, index + target.length);
-        if candidate == target {
-            return index;
-        }
+        if candidate == target { return index; }
         index += 1;
     }
     return -1;
 }
 
 fn find_last_index_of_char(value: string, target: string) -> number {
-    if target.length != 1 {
-        return -1;
-    }
+    if target.length != 1 { return -1; }
     // Use substring + == instead of char_code_at_text.
     let mut index: number = value.length;
     loop {
-        if index <= 0 {
-            break;
-        }
+        if index <= 0 { break; }
         index -= 1;
         let ch = substring(value, index, index + 1);
-        if ch == target {
-            return index;
-        }
+        if ch == target { return index; }
     }
     return -1;
 }
@@ -212,40 +153,28 @@ fn append_string(values: string[], value: string) -> string[] {
 fn string_array_contains(values: string[], target: string) -> boolean {
     let mut index: number = 0;
     loop {
-        if index >= values.length {
-            break;
-        }
-        if values[index] == target {
-            return true;
-        }
+        if index >= values.length { break; }
+        if values[index] == target { return true; }
         index += 1;
     }
     return false;
 }
 
 fn join_with_separator(values: string[], separator: string) -> string {
-    if values.length == 0 {
-        return "";
-    }
-    if values.length == 1 {
-        return values[0];
-    }
+    if values.length == 0 { return ""; }
+    if values.length == 1 { return values[0]; }
 
     // Balanced join to avoid repeatedly concatenating an ever-growing prefix.
     // This keeps intermediate strings smaller and prevents runtime corruption
     // observed in large LLVM IR modules (notably the test harness build).
     let mut parts: string[] = values;
     loop {
-        if parts.length <= 1 {
-            break;
-        }
+        if parts.length <= 1 { break; }
 
         let mut next: string[] = [];
         let mut index: number = 0;
         loop {
-            if index >= parts.length {
-                break;
-            }
+            if index >= parts.length { break; }
             let _ct_next = index + 1;
             if _ct_next < parts.length {
                 let combined = parts[index] + separator + parts[_ct_next];
@@ -263,23 +192,15 @@ fn join_with_separator(values: string[], separator: string) -> string {
 }
 
 fn find_substring_from(value: string, target: string, start: number) -> number {
-    if target.length == 0 {
-        return start;
-    }
+    if target.length == 0 { return start; }
     let mut index: number = start;
-    if index < 0 {
-        index = 0;
-    }
+    if index < 0 { index = 0; }
     // Use substring + == instead of char_code_at_text comparisons.
     let _search_limit = value.length - target.length;
     loop {
-        if index > _search_limit {
-            break;
-        }
+        if index > _search_limit { break; }
         let candidate = substring(value, index, index + target.length);
-        if candidate == target {
-            return index;
-        }
+        if candidate == target { return index; }
         index += 1;
     }
     return -1;
@@ -287,12 +208,8 @@ fn find_substring_from(value: string, target: string, start: number) -> number {
 
 fn is_union_llvm_type(llvm_type: string) -> boolean {
     let trimmed = trim_text(llvm_type);
-    if !starts_with(trimmed, "{") {
-        return false;
-    }
-    if find_substring_from(trimmed, "i32", 0) < 0 {
-        return false;
-    }
+    if !starts_with(trimmed, "{") { return false; }
+    if find_substring_from(trimmed, "i32", 0) < 0 { return false; }
     // Heuristic: our union layout always starts with an i32 tag.
     // (Arrays are "{ T*, i64 }*" and won't match.)
     return starts_with(trim_text(trimmed), "{ i32,");
@@ -300,22 +217,16 @@ fn is_union_llvm_type(llvm_type: string) -> boolean {
 
 fn parse_union_payload_types(union_llvm_type: string) -> string[] {
     let trimmed = trim_text(union_llvm_type);
-    if !is_union_llvm_type(trimmed) {
-        return [];
-    }
+    if !is_union_llvm_type(trimmed) { return []; }
     // Remove outer braces.
     let inner = trim_text(substring(trimmed, 1, trimmed.length - 1));
     let fields = split_array_elements(inner);
     // Expect first entry to be i32 tag.
-    if fields.length < 2 {
-        return [];
-    }
+    if fields.length < 2 { return []; }
     let mut result: string[] = [];
     let mut index: number = 1;
     loop {
-        if index >= fields.length {
-            break;
-        }
+        if index >= fields.length { break; }
         result.push(trim_text(fields[index]));
         index += 1;
     }
@@ -324,22 +235,14 @@ fn parse_union_payload_types(union_llvm_type: string) -> string[] {
 
 fn extract_simple_identifier(text: string) -> string {
     let trimmed = trim_text(text);
-    if trimmed.length == 0 {
-        return "";
-    }
+    if trimmed.length == 0 { return ""; }
     let first = substring(trimmed, 0, 1);
-    if !is_identifier_start_char(first) {
-        return "";
-    }
+    if !is_identifier_start_char(first) { return ""; }
     let mut index: number = 0;
     loop {
-        if index >= trimmed.length {
-            break;
-        }
+        if index >= trimmed.length { break; }
         let ch = substring(trimmed, index, index + 1);
-        if !is_identifier_part_char(ch) {
-            return "";
-        }
+        if !is_identifier_part_char(ch) { return ""; }
         index += 1;
     }
     return trimmed;
@@ -347,20 +250,14 @@ fn extract_simple_identifier(text: string) -> string {
 
 fn is_boolean_literal(text: string) -> boolean {
     let trimmed = trim_text(text);
-    if matches_case_insensitive(trimmed, "true") {
-        return true;
-    }
-    if matches_case_insensitive(trimmed, "false") {
-        return true;
-    }
+    if matches_case_insensitive(trimmed, "true") { return true; }
+    if matches_case_insensitive(trimmed, "false") { return true; }
     return false;
 }
 
 fn is_null_literal(text: string) -> boolean {
     let trimmed = trim_text(text);
-    if matches_case_insensitive(trimmed, "null") {
-        return true;
-    }
+    if matches_case_insensitive(trimmed, "null") { return true; }
     return false;
 }
 
@@ -370,9 +267,7 @@ fn is_digit_char(ch: string) -> boolean {
     let nine = char_code("9");
     let mut _ret125: boolean = false;
     if code >= zero {
-        if code <= nine {
-            _ret125 = true;
-        }
+        if code <= nine { _ret125 = true; }
     }
     return _ret125;
 }
@@ -383,21 +278,15 @@ fn char_code_at_text(text: string, index: number) -> number {
 
 fn is_integer_literal(text: string) -> boolean {
     let trimmed = trim_text(text);
-    if trimmed.length == 0 {
-        return false;
-    }
+    if trimmed.length == 0 { return false; }
     let mut index: number = 0;
     if substring(trimmed, 0, 1) == "-" {
-        if trimmed.length == 1 {
-            return false;
-        }
+        if trimmed.length == 1 { return false; }
         index = 1;
     }
     let mut has_digit: boolean = false;
     loop {
-        if index >= trimmed.length {
-            break;
-        }
+        if index >= trimmed.length { break; }
         let ch = substring(trimmed, index, index + 1);
         let mut _if126: boolean = false;
         if ch == "0" { _if126 = true; }
@@ -425,19 +314,13 @@ fn is_number_literal(text: string) -> boolean {
     let mut has_digit: boolean = false;
     let mut has_decimal: boolean = false;
     let trimmed = trim_text(text);
-    if trimmed.length == 0 {
-        return false;
-    }
+    if trimmed.length == 0 { return false; }
     if substring(trimmed, 0, 1) == "-" {
-        if trimmed.length == 1 {
-            return false;
-        }
+        if trimmed.length == 1 { return false; }
         index = 1;
     }
     loop {
-        if index >= trimmed.length {
-            break;
-        }
+        if index >= trimmed.length { break; }
         let ch = substring(trimmed, index, index + 1);
         let mut _if127: boolean = false;
         if ch == "0" { _if127 = true; }
@@ -456,9 +339,7 @@ fn is_number_literal(text: string) -> boolean {
             continue;
         }
         if ch == "." {
-            if has_decimal {
-                return false;
-            }
+            if has_decimal { return false; }
             has_decimal = true;
             index += 1;
             continue;
@@ -470,20 +351,14 @@ fn is_number_literal(text: string) -> boolean {
 
 fn normalise_number_literal(text: string) -> string {
     let trimmed = trim_text(text);
-    if index_of(trimmed, ".") >= 0 {
-        return trimmed;
-    }
+    if index_of(trimmed, ".") >= 0 { return trimmed; }
     return trimmed + ".0";
 }
 
 fn is_string_literal(text: string) -> boolean {
     let trimmed = trim_text(text);
-    if trimmed.length < 2 {
-        return false;
-    }
-    if substring(trimmed, 0, 1) != "\"" {
-        return false;
-    }
+    if trimmed.length < 2 { return false; }
+    if substring(trimmed, 0, 1) != "\"" { return false; }
     if substring(trimmed, trimmed.length - 1, trimmed.length) != "\"" {
         return false;
     }
@@ -493,9 +368,7 @@ fn is_string_literal(text: string) -> boolean {
     let mut escape: boolean = false;
     let mut index: number = 1;
     loop {
-        if index >= trimmed.length - 1 {
-            break;
-        }
+        if index >= trimmed.length - 1 { break; }
         let ch = char_at(trimmed, index);
         if escape {
             escape = false;
@@ -507,35 +380,25 @@ fn is_string_literal(text: string) -> boolean {
             index += 1;
             continue;
         }
-        if ch == "\"" {
-            return false;
-        }
+        if ch == "\"" { return false; }
         index += 1;
     }
     // A trailing backslash would escape the closing quote, so reject.
-    if escape {
-        return false;
-    }
+    if escape { return false; }
     return true;
 }
 
 fn is_character_literal(text: string) -> boolean {
     // Check if this is a single-character string literal like "a", "t", "\n"
-    if text.length < 2 {
-        return false;
-    }
+    if text.length < 2 { return false; }
     let mut _if128: boolean = false;
     if substring(text, 0, 1) != "\"" { _if128 = true; }
     if substring(text, text.length - 1, text.length) != "\"" { _if128 = true; }
-    if _if128 {
-        return false;
-    }
+    if _if128 { return false; }
     let inner = substring(text, 1, text.length - 1);
     // Handle escape sequences
     if inner.length == 2 {
-        if substring(inner, 0, 1) == "\\" {
-            return true;
-        }
+        if substring(inner, 0, 1) == "\\" { return true; }
     }
     // Single character
     return inner.length == 1;
@@ -543,17 +406,13 @@ fn is_character_literal(text: string) -> boolean {
 
 fn get_character_literal_value(text: string) -> number {
     let inner = substring(text, 1, text.length - 1);
-    if inner.length == 0 {
-        return 0;
-    }
+    if inner.length == 0 { return 0; }
     // Handle escape sequences
     if inner.length == 2 {
         if substring(inner, 0, 1) == "\\" {
             let escape = char_at(inner, 1);
             let escape_code = char_code(escape);
-            if escape_code == char_code("n") {
-                return char_code("\n");
-            } else if escape_code == char_code("r") {
+            if escape_code == char_code("n") { return char_code("\n"); } else if escape_code == char_code("r") {
                 return char_code("\r");
             } else if escape_code == char_code("t") {
                 return char_code("\t");
@@ -581,9 +440,7 @@ fn make_string_constant_name_for_module(module_name: string, content: string) ->
     let mut _if129: boolean = false;
     if tag.length == 0 { _if129 = true; }
     if tag == "_" { _if129 = true; }
-    if _if129 {
-        return base;
-    }
+    if _if129 { return base; }
     // base is @.str.len<LEN>.h<HASH>
     return "@.str." + tag + substring(base, 5, base.length);
 }
@@ -594,24 +451,18 @@ fn compute_string_constant_hash(content: string) -> number {
     let modulus: number = 2147483647;
     let mut index: number = 0;
     loop {
-        if index >= content.length {
-            break;
-        }
+        if index >= content.length { break; }
         let code = char_code(char_at(content, index));
         hash = hash * 33 + code;
         loop {
-            if hash < modulus {
-                break;
-            }
+            if hash < modulus { break; }
             hash -= modulus;
         }
         index += 1;
     }
     hash = hash * 33 + content.length;
     loop {
-        if hash < modulus {
-            break;
-        }
+        if hash < modulus { break; }
         hash -= modulus;
     }
     return hash;
@@ -622,9 +473,7 @@ fn parse_interpolated_template(content: string) -> InterpolatedTemplateParse {
     let mut expressions: string[] = [];
     let mut index: number = 0;
     loop {
-        if index > content.length {
-            break;
-        }
+        if index > content.length { break; }
         let start = find_substring_from(content, "{{", index);
         if start < 0 {
             parts.push(substring(content, index, content.length));
@@ -633,16 +482,28 @@ fn parse_interpolated_template(content: string) -> InterpolatedTemplateParse {
         parts.push(substring(content, index, start));
         let end = find_substring_from(content, "}}", start + 2);
         if end < 0 {
-            return InterpolatedTemplateParse { parts: [], expressions: [], success: false };
+            return InterpolatedTemplateParse {
+                parts: [],
+                expressions: [],
+                success: false
+            };
         }
         let expr_text = trim_text(substring(content, start + 2, end));
         if expr_text.length == 0 {
-            return InterpolatedTemplateParse { parts: [], expressions: [], success: false };
+            return InterpolatedTemplateParse {
+                parts: [],
+                expressions: [],
+                success: false
+            };
         }
         expressions.push(expr_text);
         index = end + 2;
     }
-    return InterpolatedTemplateParse { parts: parts, expressions: expressions, success: true };
+    return InterpolatedTemplateParse {
+        parts: parts,
+        expressions: expressions,
+        success: true
+    };
 }
 
 fn encode_string_literal_for_sailfin(content: string) -> string {
@@ -661,20 +522,12 @@ fn escape_string_for_sailfin_literal(content: string) -> string {
     let mut chunk_start: number = 0;
     let mut index: number = 0;
     loop {
-        if index >= content.length {
-            break;
-        }
+        if index >= content.length { break; }
         let ch = substring(content, index, index + 1);
         let mut esc: string = "";
-        if ch == "\\" {
-            esc = "\\\\";
-        } else if ch == "\"" {
-            esc = "\\\"";
-        } else if ch == "\n" {
+        if ch == "\\" { esc = "\\\\"; } else if ch == "\"" { esc = "\\\""; } else if ch == "\n" {
             esc = "\\n";
-        } else if ch == "\r" {
-            esc = "\\r";
-        } else if ch == "\t" {
+        } else if ch == "\r" { esc = "\\r"; } else if ch == "\t" {
             esc = "\\t";
         }
         if esc.length > 0 {
@@ -689,18 +542,12 @@ fn escape_string_for_sailfin_literal(content: string) -> string {
     if chunk_start < content.length {
         chunks.push(substring(content, chunk_start, content.length));
     }
-    if chunks.length == 0 {
-        return "";
-    }
-    if chunks.length == 1 {
-        return chunks[0];
-    }
+    if chunks.length == 0 { return ""; }
+    if chunks.length == 1 { return chunks[0]; }
     let mut result: string = chunks[0];
     let mut i: number = 1;
     loop {
-        if i >= chunks.length {
-            break;
-        }
+        if i >= chunks.length { break; }
         result = result + chunks[i];
         i += 1;
     }
@@ -708,9 +555,7 @@ fn escape_string_for_sailfin_literal(content: string) -> string {
 }
 
 fn unescape_string_literal(literal: string) -> string {
-    if literal.length < 2 {
-        return "";
-    }
+    if literal.length < 2 { return ""; }
     let start_index = 1;
     let end_index = literal.length - 1;
     let inner = substring(literal, start_index, end_index);
@@ -718,9 +563,7 @@ fn unescape_string_literal(literal: string) -> string {
     let mut result: string = "";
     let mut index: number = 0;
     loop {
-        if index >= inner.length {
-            break;
-        }
+        if index >= inner.length { break; }
         let ch = char_at(inner, index);
         let _esc_next = index + 1;
         if char_code(ch) == char_code("\\") {
@@ -761,64 +604,44 @@ fn unescape_string_literal(literal: string) -> string {
 
 // Duplicated from string_utils to avoid cross-module function call issues in Stage2
 fn is_symbol_char(ch: string) -> boolean {
-    if ch.length == 0 {
-        return false;
-    }
-    if ch == "_" {
-        return true;
-    }
+    if ch.length == 0 { return false; }
+    if ch == "_" { return true; }
     let code = char_code(ch);
     let lower_a = char_code("a");
     let lower_z = char_code("z");
     if code >= lower_a {
-        if code <= lower_z {
-            return true;
-        }
+        if code <= lower_z { return true; }
     }
     let upper_a = char_code("A");
     let upper_z = char_code("Z");
     if code >= upper_a {
-        if code <= upper_z {
-            return true;
-        }
+        if code <= upper_z { return true; }
     }
     let zero = char_code("0");
     let nine = char_code("9");
     if code >= zero {
-        if code <= nine {
-            return true;
-        }
+        if code <= nine { return true; }
     }
     return false;
 }
 
 fn sanitize_symbol(name: string) -> string {
-    if name.length == 0 {
-        return "_";
-    }
+    if name.length == 0 { return "_"; }
     let mut result: string = "";
     let mut index: number = 0;
     loop {
-        if index >= name.length {
-            break;
-        }
+        if index >= name.length { break; }
         let ch = substring(name, index, index + 1);
-        if is_symbol_char(ch) {
-            result = result + ch;
-        }
+        if is_symbol_char(ch) { result = result + ch; }
         index += 1;
     }
-    if result.length == 0 {
-        return "_";
-    }
+    if result.length == 0 { return "_"; }
     let first = substring(result, 0, 1);
     let first_code = char_code(first);
     let zero = char_code("0");
     let nine = char_code("9");
     if first_code >= zero {
-        if first_code <= nine {
-            result = "_" + result;
-        }
+        if first_code <= nine { result = "_" + result; }
     }
     return result;
 }

--- a/compiler/src/llvm/expression_lowering/native/core_text.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_text.sfn
@@ -7,13 +7,9 @@
 // `sanitize_symbol`, character classification, and LLVM type string inspection
 // (e.g., `is_union_llvm_type`, `parse_union_payload_types`).
 import { char_at, char_code, substring } from "../../../string_utils";
-import { InterpolatedTemplateParse, } from "../../types";
-import {
-    is_identifier_part_char,
-    is_identifier_start_char,
-    starts_with,
-} from "../../utils";
-import { split_array_elements, } from "../splitting";
+import { InterpolatedTemplateParse } from "../../types";
+import { is_identifier_part_char, is_identifier_start_char, starts_with } from "../../utils";
+import { split_array_elements } from "../splitting";
 
 fn number_to_string(value: number) -> string {
     if value == 0 { return "0"; }

--- a/compiler/src/llvm/expression_lowering/native/core_type_mapping.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_type_mapping.sfn
@@ -2,22 +2,22 @@
 //
 // Expression lowering type-mapping helpers extracted from core.sfn.
 import { substring } from "../../../string_utils";
-import { find_interface_info_by_name, find_struct_info_by_name, } from "../../type_context_queries";
+import { find_interface_info_by_name, find_struct_info_by_name } from "../../type_context_queries";
 import {
     annotation_is_array,
     array_struct_type_for_element,
     ends_with_pointer_suffix,
     layout_annotation_represents_user_value,
     map_type_annotation,
-    strip_pointer_suffix,
+    strip_pointer_suffix
 } from "../../type_mapping";
-import { TypeContext, } from "../../types";
+import { TypeContext } from "../../types";
 import {
     append_string,
     index_of,
     join_with_separator,
     starts_with,
-    trim_text,
+    trim_text
 } from "../../utils";
 
 fn map_struct_type_annotation_ctx(context: TypeContext, annotation: string) -> string {

--- a/compiler/src/llvm/expression_lowering/native/core_type_mapping.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_type_mapping.sfn
@@ -1,57 +1,39 @@
 // compiler/src/llvm/expression_lowering/native/core_type_mapping.sfn
 //
 // Expression lowering type-mapping helpers extracted from core.sfn.
-
 import { substring } from "../../../string_utils";
-
+import { find_interface_info_by_name, find_struct_info_by_name, } from "../../type_context_queries";
 import {
-    TypeContext,
-} from "../../types";
-
-import {
-    trim_text,
-    starts_with,
-    index_of,
-    append_string,
-    join_with_separator,
-} from "../../utils";
-
-import {
-    map_type_annotation,
-    ends_with_pointer_suffix,
-    strip_pointer_suffix,
     annotation_is_array,
-    layout_annotation_represents_user_value,
     array_struct_type_for_element,
+    ends_with_pointer_suffix,
+    layout_annotation_represents_user_value,
+    map_type_annotation,
+    strip_pointer_suffix,
 } from "../../type_mapping";
-
+import { TypeContext, } from "../../types";
 import {
-    find_struct_info_by_name,
-    find_interface_info_by_name,
-} from "../../type_context_queries";
+    append_string,
+    index_of,
+    join_with_separator,
+    starts_with,
+    trim_text,
+} from "../../utils";
 
 fn map_struct_type_annotation_ctx(context: TypeContext, annotation: string) -> string {
     let info = find_struct_info_by_name(context, annotation);
-    if info != null {
-        return info.llvm_name;
-    }
+    if info != null { return info.llvm_name; }
     return "";
 }
 
 fn map_enum_type_annotation(context: TypeContext, annotation: string) -> string {
     let trimmed = trim_text(annotation);
-    if trimmed.length == 0 {
-        return "";
-    }
+    if trimmed.length == 0 { return ""; }
     let mut index: number = 0;
     loop {
-        if index >= context.enums.length {
-            break;
-        }
+        if index >= context.enums.length { break; }
         let enum_info = context.enums[index];
-        if enum_info.name == trimmed {
-            return enum_info.llvm_name;
-        }
+        if enum_info.name == trimmed { return enum_info.llvm_name; }
         index += 1;
     }
     return "";
@@ -59,73 +41,45 @@ fn map_enum_type_annotation(context: TypeContext, annotation: string) -> string 
 
 fn map_interface_type_annotation(context: TypeContext, annotation: string) -> string {
     let trimmed = trim_text(annotation);
-    if trimmed.length == 0 {
-        return "";
-    }
+    if trimmed.length == 0 { return ""; }
     let interface_info = find_interface_info_by_name(context, trimmed);
-    if interface_info != null {
-        return interface_info.llvm_name;
-    }
+    if interface_info != null { return interface_info.llvm_name; }
     return "";
 }
 
 fn map_primitive_type(context: TypeContext, annotation: string) -> string {
-    if annotation == "number" {
-        return "double";
-    }
+    if annotation == "number" { return "double"; }
     let mut _if130: boolean = false;
     if annotation == "boolean" { _if130 = true; }
     if annotation == "bool" { _if130 = true; }
-    if _if130 {
-        return "i1";
-    }
-    if annotation == "usize" {
-        return "i64";
-    }
+    if _if130 { return "i1"; }
+    if annotation == "usize" { return "i64"; }
     let mut _if131: boolean = false;
     if annotation == "int" { _if131 = true; }
     if annotation == "i64" { _if131 = true; }
-    if _if131 {
-        return "i64";
-    }
-    if annotation == "i32" {
-        return "i32";
-    }
-    if annotation == "u8" {
-        return "i8";
-    }
+    if _if131 { return "i64"; }
+    if annotation == "i32" { return "i32"; }
+    if annotation == "u8" { return "i8"; }
     let struct_type = map_struct_type_annotation_ctx(context, annotation);
-    if struct_type.length > 0 {
-        return struct_type;
-    }
+    if struct_type.length > 0 { return struct_type; }
     let enum_type = map_enum_type_annotation(context, annotation);
-    if enum_type.length > 0 {
-        return enum_type;
-    }
+    if enum_type.length > 0 { return enum_type; }
     let interface_type = map_interface_type_annotation(context, annotation);
-    if interface_type.length > 0 {
-        return interface_type;
-    }
-    if annotation == "string" {
-        return "i8*";
-    }
+    if interface_type.length > 0 { return interface_type; }
+    if annotation == "string" { return "i8*"; }
     return "";
 }
 
 fn map_optional_type(context: TypeContext, annotation: string) -> string {
     let trimmed = trim_text(annotation);
-    if trimmed.length == 0 {
-        return "";
-    }
+    if trimmed.length == 0 { return ""; }
     // Check if this is an optional type (ends with ?)
     if substring(trimmed, trimmed.length - 1, trimmed.length) != "?" {
         return "";
     }
     // Extract the inner type (everything before the ?)
     let inner_annotation = trim_text(substring(trimmed, 0, trimmed.length - 1));
-    if inner_annotation.length == 0 {
-        return "";
-    }
+    if inner_annotation.length == 0 { return ""; }
     // For optional types, try the context-aware mapping first for structs/enums
     let struct_type = map_struct_type_annotation_ctx(context, inner_annotation);
     if struct_type.length > 0 {
@@ -133,21 +87,15 @@ fn map_optional_type(context: TypeContext, annotation: string) -> string {
         return struct_type + "*";
     }
     let enum_type = map_enum_type_annotation(context, inner_annotation);
-    if enum_type.length > 0 {
-        return enum_type + "*";
-    }
+    if enum_type.length > 0 { return enum_type + "*"; }
     let interface_type = map_interface_type_annotation(context, inner_annotation);
-    if interface_type.length > 0 {
-        return interface_type + "*";
-    }
+    if interface_type.length > 0 { return interface_type + "*"; }
     // For primitive types and others, use the simple mapper
     let inner_type = map_type_annotation(inner_annotation);
     let mut _if132: boolean = false;
     if inner_type.length == 0 { _if132 = true; }
     if inner_type == "void" { _if132 = true; }
-    if _if132 {
-        return "i8*";
-    }
+    if _if132 { return "i8*"; }
     // If already a pointer, return as-is, otherwise make it a pointer
     if substring(inner_type, inner_type.length - 1, inner_type.length) == "*" {
         return inner_type;
@@ -157,60 +105,40 @@ fn map_optional_type(context: TypeContext, annotation: string) -> string {
 
 fn map_reference_inner_type(context: TypeContext, annotation: string) -> string {
     let trimmed = trim_text(annotation);
-    if trimmed.length == 0 {
-        return "";
-    }
+    if trimmed.length == 0 { return ""; }
     let nested_reference = map_reference_type(context, trimmed);
-    if nested_reference.length > 0 {
-        return nested_reference;
-    }
+    if nested_reference.length > 0 { return nested_reference; }
     let array_type = map_array_pointer_type(context, trimmed);
-    if array_type.length > 0 {
-        return array_type;
-    }
+    if array_type.length > 0 { return array_type; }
     return map_primitive_type(context, trimmed);
 }
 
 fn map_reference_type(context: TypeContext, annotation: string) -> string {
     let trimmed = trim_text(annotation);
-    if trimmed.length == 0 {
-        return "";
-    }
-    if !starts_with(trimmed, "&") {
-        return "";
-    }
-    if starts_with(trimmed, "&&") {
-        return "";
-    }
+    if trimmed.length == 0 { return ""; }
+    if !starts_with(trimmed, "&") { return ""; }
+    if starts_with(trimmed, "&&") { return ""; }
     let mut remainder: string = trim_text(substring(trimmed, 1, trimmed.length));
     if starts_with(remainder, "mut") {
         let after_mut = substring(remainder, 3, remainder.length);
         remainder = trim_text(after_mut);
     }
-    if remainder.length == 0 {
-        return "";
-    }
+    if remainder.length == 0 { return ""; }
     if substring(remainder, 0, 1) == "(" {
         if substring(remainder, remainder.length - 1, remainder.length) == ")" {
             remainder = trim_text(substring(remainder, 1, remainder.length - 1));
         }
     }
     let inner_type = map_reference_inner_type(context, remainder);
-    if inner_type.length == 0 {
-        return "";
-    }
+    if inner_type.length == 0 { return ""; }
     return inner_type + "*";
 }
 
 fn map_array_pointer_type(context: TypeContext, annotation: string) -> string {
     let trimmed = trim_text(annotation);
-    if trimmed.length < 3 {
-        return "";
-    }
+    if trimmed.length < 3 { return ""; }
     let suffix = substring(trimmed, trimmed.length - 2, trimmed.length);
-    if suffix != "[]" {
-        return "";
-    }
+    if suffix != "[]" { return ""; }
     let element_annotation = trim_text(substring(trimmed, 0, trimmed.length - 2));
     let mut element_type = map_primitive_type(context, element_annotation);
     if element_type.length == 0 {
@@ -235,9 +163,7 @@ fn map_array_pointer_type(context: TypeContext, annotation: string) -> string {
 
 fn unwrap_move_wrapper(annotation: string) -> string {
     let trimmed = trim_text(annotation);
-    if trimmed.length == 0 {
-        return trimmed;
-    }
+    if trimmed.length == 0 { return trimmed; }
     let mut _if133: boolean = false;
     if starts_with(trimmed, "Affine<") { _if133 = true; }
     if starts_with(trimmed, "Linear<") { _if133 = true; }
@@ -263,35 +189,21 @@ fn find_top_level_union_separator(text: string) -> number {
     let mut escape: boolean = false;
     let mut index: number = 0;
     loop {
-        if index >= text.length {
-            break;
-        }
+        if index >= text.length { break; }
         let ch = substring(text, index, index + 1);
         if in_double {
-            if escape {
-                escape = false;
-            } else {
-                if ch == "\\" {
-                    escape = true;
-                } else {
-                    if ch == "\"" {
-                        in_double = false;
-                    }
+            if escape { escape = false; } else {
+                if ch == "\\" { escape = true; } else {
+                    if ch == "\"" { in_double = false; }
                 }
             }
             index += 1;
             continue;
         }
         if in_single {
-            if escape {
-                escape = false;
-            } else {
-                if ch == "\\" {
-                    escape = true;
-                } else {
-                    if ch == "'" {
-                        in_single = false;
-                    }
+            if escape { escape = false; } else {
+                if ch == "\\" { escape = true; } else {
+                    if ch == "'" { in_single = false; }
                 }
             }
             index += 1;
@@ -315,9 +227,7 @@ fn find_top_level_union_separator(text: string) -> number {
             continue;
         }
         if ch == ")" {
-            if paren_depth > 0 {
-                paren_depth -= 1;
-            }
+            if paren_depth > 0 { paren_depth -= 1; }
             index += 1;
             continue;
         }
@@ -327,9 +237,7 @@ fn find_top_level_union_separator(text: string) -> number {
             continue;
         }
         if ch == "}" {
-            if brace_depth > 0 {
-                brace_depth -= 1;
-            }
+            if brace_depth > 0 { brace_depth -= 1; }
             index += 1;
             continue;
         }
@@ -339,9 +247,7 @@ fn find_top_level_union_separator(text: string) -> number {
             continue;
         }
         if ch == "]" {
-            if bracket_depth > 0 {
-                bracket_depth -= 1;
-            }
+            if bracket_depth > 0 { bracket_depth -= 1; }
             index += 1;
             continue;
         }
@@ -351,9 +257,7 @@ fn find_top_level_union_separator(text: string) -> number {
             continue;
         }
         if ch == ">" {
-            if angle_depth > 0 {
-                angle_depth -= 1;
-            }
+            if angle_depth > 0 { angle_depth -= 1; }
             index += 1;
             continue;
         }
@@ -362,9 +266,7 @@ fn find_top_level_union_separator(text: string) -> number {
             if brace_depth == 0 {
                 if bracket_depth == 0 {
                     if angle_depth == 0 {
-                        if ch == "|" {
-                            return index;
-                        }
+                        if ch == "|" { return index; }
                     }
                 }
             }
@@ -381,15 +283,11 @@ fn split_union_annotations(text: string) -> string[] {
         let index = find_top_level_union_separator(remaining);
         if index < 0 {
             let tail = trim_text(remaining);
-            if tail.length > 0 {
-                result.push(tail);
-            }
+            if tail.length > 0 { result.push(tail); }
             break;
         }
         let left = trim_text(substring(remaining, 0, index));
-        if left.length > 0 {
-            result.push(left);
-        }
+        if left.length > 0 { result.push(left); }
         remaining = trim_text(substring(remaining, index + 1, remaining.length));
     }
     return result;
@@ -397,38 +295,26 @@ fn split_union_annotations(text: string) -> string[] {
 
 fn is_union_annotation(annotation: string) -> boolean {
     let trimmed = trim_text(annotation);
-    if trimmed.length == 0 {
-        return false;
-    }
+    if trimmed.length == 0 { return false; }
     return find_top_level_union_separator(trimmed) >= 0;
 }
 
 fn map_union_type(context: TypeContext, annotation: string) -> string {
     let normalized = unwrap_move_wrapper(trim_text(annotation));
-    if !is_union_annotation(normalized) {
-        return "";
-    }
+    if !is_union_annotation(normalized) { return ""; }
     let parts = split_union_annotations(normalized);
-    if parts.length < 2 {
-        return "";
-    }
+    if parts.length < 2 { return ""; }
     let mut llvm_parts: string[] = [];
     let mut index: number = 0;
     loop {
-        if index >= parts.length {
-            break;
-        }
+        if index >= parts.length { break; }
         let part = trim_text(parts[index]);
-        if part.length == 0 {
-            return "";
-        }
+        if part.length == 0 { return ""; }
         let mapped = map_type_annotation(part);
         let mut _if134: boolean = false;
         if mapped.length == 0 { _if134 = true; }
         if mapped == "void" { _if134 = true; }
-        if _if134 {
-            return "";
-        }
+        if _if134 { return ""; }
         llvm_parts.push(mapped);
         index += 1;
     }
@@ -442,9 +328,7 @@ fn map_return_type(context: TypeContext, return_type: string) -> string {
     let mut _if135: boolean = false;
     if trimmed.length == 0 { _if135 = true; }
     if trimmed == "void" { _if135 = true; }
-    if _if135 {
-        return "void";
-    }
+    if _if135 { return "void"; }
     let normalized = unwrap_move_wrapper(trimmed);
 
     // Raw pointer types: `*T`, `*mut T`, `*opaque`.
@@ -456,43 +340,27 @@ fn map_return_type(context: TypeContext, return_type: string) -> string {
         let mut _if136: boolean = false;
         if remainder == "opaque" { _if136 = true; }
         if remainder.length == 0 { _if136 = true; }
-        if _if136 {
-            return "i8*";
-        }
+        if _if136 { return "i8*"; }
         let inner = map_return_type(context, remainder);
-        if ends_with_pointer_suffix(inner) {
-            return inner;
-        }
+        if ends_with_pointer_suffix(inner) { return inner; }
         let mut _if137: boolean = false;
         if inner.length == 0 { _if137 = true; }
         if inner == "void" { _if137 = true; }
-        if _if137 {
-            return "i8*";
-        }
+        if _if137 { return "i8*"; }
         return inner + "*";
     }
 
     let union_type = map_union_type(context, normalized);
-    if union_type.length > 0 {
-        return union_type;
-    }
+    if union_type.length > 0 { return union_type; }
     // Try optional type first
     let optional_type = map_optional_type(context, normalized);
-    if optional_type.length > 0 {
-        return optional_type;
-    }
+    if optional_type.length > 0 { return optional_type; }
     let reference_type = map_reference_type(context, normalized);
-    if reference_type.length > 0 {
-        return reference_type;
-    }
+    if reference_type.length > 0 { return reference_type; }
     let array_type = map_array_pointer_type(context, normalized);
-    if array_type.length > 0 {
-        return array_type;
-    }
+    if array_type.length > 0 { return array_type; }
     let primitive_type = map_primitive_type(context, normalized);
-    if primitive_type.length > 0 {
-        return primitive_type;
-    }
+    if primitive_type.length > 0 { return primitive_type; }
     // Fallback to opaque pointer for unrecognised return types (`any`, user structs, etc.)
     return "i8*";
 }
@@ -502,22 +370,14 @@ fn future_pointer_type_for_return_type(return_type: string) -> string {
     let mut _if138: boolean = false;
     if trimmed.length == 0 { _if138 = true; }
     if trimmed == "void" { _if138 = true; }
-    if _if138 {
-        return "%SailfinFutureVoid*";
-    }
+    if _if138 { return "%SailfinFutureVoid*"; }
     let normalized = unwrap_move_wrapper(trimmed);
-    if normalized == "number" {
-        return "%SailfinFutureNumber*";
-    }
+    if normalized == "number" { return "%SailfinFutureNumber*"; }
     let mut _if139: boolean = false;
     if normalized == "boolean" { _if139 = true; }
     if normalized == "bool" { _if139 = true; }
-    if _if139 {
-        return "%SailfinFutureBool*";
-    }
-    if normalized == "string" {
-        return "%SailfinFutureString*";
-    }
+    if _if139 { return "%SailfinFutureBool*"; }
+    if normalized == "string" { return "%SailfinFutureString*"; }
     // Default: treat unknown/user types as an opaque pointer.
     return "%SailfinFuturePtr*";
 }
@@ -543,9 +403,7 @@ fn await_symbol_for_future_pointer_type(future_ptr_type: string) -> string {
 
 fn map_parameter_type(context: TypeContext, parameter_type: string) -> string {
     let trimmed = trim_text(parameter_type);
-    if trimmed.length == 0 {
-        return "double";
-    }
+    if trimmed.length == 0 { return "double"; }
     let normalized = unwrap_move_wrapper(trimmed);
 
     // Raw pointer types: `*T`, `*mut T`, `*opaque`.
@@ -557,40 +415,24 @@ fn map_parameter_type(context: TypeContext, parameter_type: string) -> string {
         let mut _if140: boolean = false;
         if remainder == "opaque" { _if140 = true; }
         if remainder.length == 0 { _if140 = true; }
-        if _if140 {
-            return "i8*";
-        }
+        if _if140 { return "i8*"; }
         let inner = map_parameter_type(context, remainder);
-        if ends_with_pointer_suffix(inner) {
-            return inner;
-        }
-        if inner.length == 0 {
-            return "i8*";
-        }
+        if ends_with_pointer_suffix(inner) { return inner; }
+        if inner.length == 0 { return "i8*"; }
         return inner + "*";
     }
 
     let union_type = map_union_type(context, normalized);
-    if union_type.length > 0 {
-        return union_type;
-    }
+    if union_type.length > 0 { return union_type; }
     // Try optional type first
     let optional_type = map_optional_type(context, normalized);
-    if optional_type.length > 0 {
-        return optional_type;
-    }
+    if optional_type.length > 0 { return optional_type; }
     let reference_type = map_reference_type(context, normalized);
-    if reference_type.length > 0 {
-        return reference_type;
-    }
+    if reference_type.length > 0 { return reference_type; }
     let array_type = map_array_pointer_type(context, normalized);
-    if array_type.length > 0 {
-        return array_type;
-    }
+    if array_type.length > 0 { return array_type; }
     let primitive_type = map_primitive_type(context, normalized);
-    if primitive_type.length > 0 {
-        return primitive_type;
-    }
+    if primitive_type.length > 0 { return primitive_type; }
     // Fallback to generic pointer for unresolved types (e.g., imported structs/enums not in type context)
     return "i8*";
 }

--- a/compiler/src/llvm/expression_lowering/native/mod.sfn
+++ b/compiler/src/llvm/expression_lowering/native/mod.sfn
@@ -7,7 +7,6 @@
 //
 // This module re-exports the stable surface area used by the rest of the
 // compiler.
-
 export {
     // Statement + entrypoint helpers
     lower_expression_statement,
@@ -40,7 +39,6 @@ export {
     // Ownership/borrow analysis helpers used across lowering
     analyze_value_ownership,
     detect_borrow_conflicts,
-
 } from "./core";
 
 export {

--- a/compiler/src/llvm/expression_lowering/native/mod.sfn
+++ b/compiler/src/llvm/expression_lowering/native/mod.sfn
@@ -11,13 +11,13 @@ export {
     // Statement + entrypoint helpers
     lower_expression_statement,
     lower_return_instruction,
-    prepare_parameters,
+    prepare_parameters
 } from "./statement";
 
 export {
     // Expression parsing
     parse_assignment_expression,
-    parse_inline_let_expression,
+    parse_inline_let_expression
 } from "./statement_parsing";
 
 export {
@@ -25,12 +25,12 @@ export {
     detect_suspension_conflicts,
     future_pointer_type_for_return_type,
     spawn_symbol_for_return_type,
-    spawn_ctx_symbol_for_return_type,
+    spawn_ctx_symbol_for_return_type
 } from "./statement_suspension";
 
 export {
     // Type mapping helper consumed by instruction lowering
-    map_local_type,
+    map_local_type
 } from "./statement_type_mapping";
 
 export {
@@ -38,7 +38,7 @@ export {
     lower_expression,
     // Ownership/borrow analysis helpers used across lowering
     analyze_value_ownership,
-    detect_borrow_conflicts,
+    detect_borrow_conflicts
 } from "./core";
 
 export {
@@ -46,20 +46,12 @@ export {
     harmonise_operands,
     emit_boolean_and,
     emit_comparison_instruction,
-    load_local_operand,
+    load_local_operand
 } from "./core_operands";
 
-export {
-    append_local_binding,
-    find_local_binding,
-    append_llvm_operand,
-} from "./core_scopes";
+export { append_local_binding, find_local_binding, append_llvm_operand } from "./core_scopes";
 
-export {
-    parse_enum_literal,
-    parse_struct_pattern,
-    parse_range_iterable,
-} from "./core_parse";
+export { parse_enum_literal, parse_struct_pattern, parse_range_iterable } from "./core_parse";
 
 export {
     // Union helpers shared across lowering
@@ -70,7 +62,7 @@ export {
     // String helpers used by bootstrap shims
     unescape_string_literal,
     make_string_constant_name,
-    make_string_constant_name_for_module,
+    make_string_constant_name_for_module
 } from "./core_text";
 
 // Historically consumers imported these via expression_lowering_stage2.

--- a/compiler/src/llvm/expression_lowering/native/statement.sfn
+++ b/compiler/src/llvm/expression_lowering/native/statement.sfn
@@ -5,62 +5,63 @@
 // Implements `lower_expression_statement`, `lower_return_instruction`, and
 // `prepare_parameters`.  Type mapping, suspension detection, async ABI helpers,
 // and expression parsing live in sibling submodules.
-
 import { NativeFunction, NativeInstruction, NativeSourceSpan } from "../../../native_ir";
-import { substring, char_code, char_at, find_last_index_of_char } from "../../../string_utils";
-
-// Core lowering / analysis lives in ./core; split helpers live in submodules.
-import { lower_expression, analyze_value_ownership } from "./core";
-import { lower_lvalue_assignment_stmt, preprocess_self_field_access } from "./statement_assignment";
-import { coerce_operand_to_type } from "./core_operands";
-import { parse_member_access, parse_index_expression } from "./core_parse";
 import {
-    find_local_binding,
-    append_local_binding,
-    infer_borrow_base_scope,
+    char_at,
+    char_code,
+    find_last_index_of_char,
+    substring
+} from "../../../string_utils";
+import { default_return_literal, } from "../../expressions_helpers";
+import { split_lines_local, } from "../../lowering/lowering_text_utils";
+// Import string constant management
+import { empty_string_constant_set } from "../../strings";
+// Import types from modular structure
+import {
+    ExpressionStatementResult,
+    LifetimeRegionMetadata,
+    LifetimeReleaseEvent,
+    LocalBinding,
+    LocalMutation,
+    OwnershipInfo,
+    ParameterBinding,
+    ParameterPreparation,
+    StringConstant,
+    TypeContext,
+} from "../../types";
+// Import utilities
+import {
+    append_parameter_binding,
+    number_to_string,
+    sanitize_symbol,
+    starts_with,
+    string_array_contains,
+    trim_text
+} from "../../utils";
+import {
+    bindings_find_parameter_binding,
+    bindings_mark_local_consumed,
+    bindings_mark_parameter_consumed,
+    bindings_reset_local_consumption,
+    bindings_update_local_ownership,
+} from "../bindings";
+// Core lowering / analysis lives in ./core; split helpers live in submodules.
+import { analyze_value_ownership, lower_expression } from "./core";
+import { coerce_operand_to_type } from "./core_operands";
+import { parse_index_expression, parse_member_access } from "./core_parse";
+import {
     append_lifetime_region,
     append_lifetime_release_event,
+    append_local_binding,
+    find_local_binding,
+    infer_borrow_base_scope,
     make_lifetime_region_metadata,
 } from "./core_scopes";
-
+import { lower_lvalue_assignment_stmt, preprocess_self_field_access } from "./statement_assignment";
 // Submodules extracted from this file
 import { parse_assignment_expression, parse_inline_let_expression } from "./statement_parsing";
 import { detect_suspension_conflicts } from "./statement_suspension";
 import { map_parameter_type, map_struct_type_annotation } from "./statement_type_mapping";
-
-// Import types from modular structure
-import {
-    TypeContext, LocalBinding, ParameterBinding,
-    OwnershipInfo, LifetimeRegionMetadata,
-    LifetimeReleaseEvent, StringConstant, LocalMutation,
-    ParameterPreparation, ExpressionStatementResult,
-} from "../../types";
-
-// Import utilities
-import {
-    trim_text, starts_with,
-    string_array_contains, sanitize_symbol, number_to_string,
-    append_parameter_binding
-} from "../../utils";
-
-// Import string constant management
-import { empty_string_constant_set } from "../../strings";
-
-import {
-    default_return_literal,
-} from "../../expressions_helpers";
-
-import {
-    bindings_find_parameter_binding,
-    bindings_mark_parameter_consumed,
-    bindings_mark_local_consumed,
-    bindings_reset_local_consumption,
-    bindings_update_local_ownership,
-} from "../bindings";
-
-import {
-    split_lines_local,
-} from "../../lowering/lowering_text_utils";
 
 fn find_parameter_binding(bindings: ParameterBinding[], name: string) -> ParameterBinding? {
     return bindings_find_parameter_binding(bindings, name);
@@ -82,11 +83,9 @@ fn update_local_ownership(locals: LocalBinding[], name: string, ownership: Owner
     return bindings_update_local_ownership(locals, name, ownership);
 }
 
-
 // ---------------------------------------------------------------------------
 // SSA temp counter recovery
 // ---------------------------------------------------------------------------
-
 // Recover from v0.1.1 seed ABI corruption: lowered.temp_index may be 0
 // when returned from cross-module calls (e.g. lower_expression,
 // coerce_operand_to_type). Scan emitted lines for the highest %tN
@@ -111,9 +110,7 @@ fn _recover_temp_from_lines(lines: string[], floor: number) -> number {
                 rj += 1;
             }
             if rvalid {
-                if rn >= result {
-                    result = rn + 1;
-                }
+                if rn >= result { result = rn + 1; }
             }
         }
         ri += 1;
@@ -124,17 +121,10 @@ fn _recover_temp_from_lines(lines: string[], floor: number) -> number {
 // ---------------------------------------------------------------------------
 // IPC file helpers
 // ---------------------------------------------------------------------------
-
 // Helper: write expression statement result to files so cross-module
 // callers can read them even when struct return ABI is broken (v0.1.1 seed
 // compiles ExpressionStatementResult as i8* null for cross-module returns).
-fn _write_expr_stmt_result_files(
-    input_lines_len: number,
-    current_lines: string[],
-    current_temp: number,
-    mutations: LocalMutation[],
-    current_next_region: number
-) ![io] {
+fn _write_expr_stmt_result_files(input_lines_len: number, current_lines: string[], current_temp: number, mutations: LocalMutation[], current_next_region: number) ![io] {
     fs.writeFile("build/sailfin/.expr_stmt_temp_index", number_to_string(current_temp));
     fs.writeFile("build/sailfin/.expr_stmt_next_region_id", number_to_string(current_next_region));
     let mut_count = mutations.length;
@@ -148,23 +138,14 @@ fn _write_expr_stmt_result_files(
         fs.writeFile(prefix + "_type", m.llvm_type);
         fs.writeFile(prefix + "_value", m.value_name);
         let mut label_val: string = "";
-        if m.originating_label != null {
-            label_val = m.originating_label;
-        }
+        if m.originating_label != null { label_val = m.originating_label; }
         fs.writeFile(prefix + "_label", label_val);
         mut_i += 1;
     }
 }
 
 // Variant that also serializes string constants to a file.
-fn _write_expr_stmt_result_files_with_constants(
-    input_lines_len: number,
-    current_lines: string[],
-    current_temp: number,
-    mutations: LocalMutation[],
-    current_next_region: number,
-    string_constants: StringConstant[]
-) ![io] {
+fn _write_expr_stmt_result_files_with_constants(input_lines_len: number, current_lines: string[], current_temp: number, mutations: LocalMutation[], current_next_region: number, string_constants: StringConstant[]) ![io] {
     _write_expr_stmt_result_files(input_lines_len, current_lines, current_temp, mutations, current_next_region);
     // Write string constants as tab-separated lines: name\tcontent\tbyte_count
     let mut sc_lines: string[] = [];
@@ -187,9 +168,7 @@ fn _parse_int_local(text: string) -> number {
         let ch = char_at(text, i);
         let code = char_code(ch);
         if code >= 48 {
-            if code <= 57 {
-                result = result * 10 + (code - 48);
-            }
+            if code <= 57 { result = result * 10 + (code - 48); }
         }
         i = i + 1;
     }
@@ -224,32 +203,15 @@ fn _ipc_make_local_binding(name: string, pointer: string, llvm_type: string, typ
     };
 }
 
-
 // ---------------------------------------------------------------------------
 // Core lowering functions
 // ---------------------------------------------------------------------------
-
-fn lower_expression_statement(
-    function_name: string,
-    instruction: NativeInstruction,
-    expression: string,
-    bindings: ParameterBinding[],
-    locals: LocalBinding[],
-    temp_index: number,
-    lines: string[],
-    next_region_id: number,
-    scope_id: string,
-    scope_depth: number,
-    functions: NativeFunction[],
-    context: TypeContext,
-    current_label: string
-) -> ExpressionStatementResult ![io] {
+fn lower_expression_statement(function_name: string, instruction: NativeInstruction, expression: string, bindings: ParameterBinding[], locals: LocalBinding[], temp_index: number, lines: string[], next_region_id: number, scope_id: string, scope_depth: number, functions: NativeFunction[], context: TypeContext, current_label: string) -> ExpressionStatementResult ![io] {
     // The v0.1.1 seed compiles instruction as i8*, making field access via
     // sailfin_runtime_get_field return garbage. Skip span extraction (only
     // used for suspension diagnostics) to avoid the broken field access.
     //
     // Read bindings and locals from files written by instructions.sfn.
-
     // Use parameters directly instead of file IPC. The v0.1.1 seed ABI
     // corruption that required file-based binding/local reads is not present
     // in the 0.5.0-alpha.22 seed.
@@ -283,12 +245,7 @@ fn lower_expression_statement(
             if index_check.success { is_lvalue = true; }
         }
         if is_lvalue {
-            return lower_lvalue_assignment_stmt(
-                parsed_assignment.target, parsed_assignment.value, parsed_assignment.operator,
-                current_bindings, current_locals, current_temp, current_lines,
-                lines.length, current_next_region, scope_id, scope_depth,
-                functions, context, current_label
-            );
+            return lower_lvalue_assignment_stmt(parsed_assignment.target, parsed_assignment.value, parsed_assignment.operator, current_bindings, current_locals, current_temp, current_lines, lines.length, current_next_region, scope_id, scope_depth, functions, context, current_label);
         }
 
         // Simple local assignment
@@ -364,7 +321,11 @@ fn lower_expression_statement(
             if previous_ownership != null {
                 if previous_ownership.variant == "Borrow" {
                     if previous_ownership.region_id >= 0 {
-                        let release_event = LifetimeReleaseEvent { region_id: previous_ownership.region_id, scope_id: scope_id, scope_depth: scope_depth };
+                        let release_event = LifetimeReleaseEvent {
+                            region_id: previous_ownership.region_id,
+                            scope_id: scope_id,
+                            scope_depth: scope_depth
+                        };
                         lifetime_releases = append_lifetime_release_event(lifetime_releases, release_event);
                     }
                 }
@@ -413,7 +374,18 @@ fn lower_expression_statement(
             mutations.push(mutation);
         }
         _write_expr_stmt_result_files_with_constants(lines.length, current_lines, current_temp, mutations, current_next_region, string_constants);
-        return ExpressionStatementResult { lines: current_lines, temp_index: current_temp, locals: current_locals, bindings: current_bindings, diagnostics: diagnostics, lifetime_regions: lifetime_regions, lifetime_releases: lifetime_releases, next_region_id: current_next_region, mutations: mutations , string_constants: string_constants};
+        return ExpressionStatementResult {
+            lines: current_lines,
+            temp_index: current_temp,
+            locals: current_locals,
+            bindings: current_bindings,
+            diagnostics: diagnostics,
+            lifetime_regions: lifetime_regions,
+            lifetime_releases: lifetime_releases,
+            next_region_id: current_next_region,
+            mutations: mutations,
+            string_constants: string_constants
+        };
     }
 
     let ownership_analysis = analyze_value_ownership(expression, null, current_locals, current_bindings);
@@ -463,9 +435,7 @@ fn lower_expression_statement(
         // %tN in the next emission. Never let the counter go below its
         // current value; _recover_temp_from_lines below also bumps past any
         // %tN already present in `current_lines`.
-        if _cr_parsed > current_temp {
-            current_temp = _cr_parsed;
-        }
+        if _cr_parsed > current_temp { current_temp = _cr_parsed; }
         current_temp = _recover_temp_from_lines(current_lines, current_temp);
         // Clean up sentinel
         fs.deleteFile("build/sailfin/.call_result_lines_count");
@@ -489,24 +459,21 @@ fn lower_expression_statement(
         print.err("stmt-lowering: pre-write _pre_call_lines_len=" + number_to_string(_pre_call_lines_len) + " current_lines.length=" + number_to_string(current_lines.length) + " delta=" + number_to_string(current_lines.length - _pre_call_lines_len));
     }
     _write_expr_stmt_result_files_with_constants(_pre_call_lines_len, current_lines, current_temp, mutations, current_next_region, string_constants);
-    return ExpressionStatementResult { lines: current_lines, temp_index: current_temp, locals: current_locals, bindings: current_bindings, diagnostics: diagnostics, lifetime_regions: lifetime_regions, lifetime_releases: lifetime_releases, next_region_id: current_next_region, mutations: mutations , string_constants: string_constants};
+    return ExpressionStatementResult {
+        lines: current_lines,
+        temp_index: current_temp,
+        locals: current_locals,
+        bindings: current_bindings,
+        diagnostics: diagnostics,
+        lifetime_regions: lifetime_regions,
+        lifetime_releases: lifetime_releases,
+        next_region_id: current_next_region,
+        mutations: mutations,
+        string_constants: string_constants
+    };
 }
 
-
-fn lower_return_instruction(
-    function: NativeFunction,
-    instruction: NativeInstruction,
-    llvm_return: string,
-    bindings: ParameterBinding[],
-    locals: LocalBinding[],
-    temp_index: number,
-    lines: string[],
-    next_region_id: number,
-    scope_id: string,
-    scope_depth: number,
-    functions: NativeFunction[],
-    context: TypeContext
-) -> ExpressionStatementResult ![io] {
+fn lower_return_instruction(function: NativeFunction, instruction: NativeInstruction, llvm_return: string, bindings: ParameterBinding[], locals: LocalBinding[], temp_index: number, lines: string[], next_region_id: number, scope_id: string, scope_depth: number, functions: NativeFunction[], context: TypeContext) -> ExpressionStatementResult ![io] {
     let mut diagnostics: string[] = [];
     let mut current_lines: string[] = lines;
     let mut current_temp: number = temp_index;
@@ -516,9 +483,7 @@ fn lower_return_instruction(
     let debug_lowering = fs.exists("build/sailfin/.trace_lowering");
     let mut _let147: boolean = false;
     if fs.exists("build/sailfin/.trace_test_runner") {
-        if fs.exists("build/sailfin/.test_runner_active") {
-            _let147 = true;
-        }
+        if fs.exists("build/sailfin/.test_runner_active") { _let147 = true; }
     }
     let trace = _let147;
 
@@ -535,26 +500,15 @@ fn lower_return_instruction(
 
     if trace {
         let mut expr_len: number = 0;
-        if instr_expression != null {
-            expr_len = instr_expression.length;
-        }
-        print.err(
-            "test llvm: lower_return start "
-            + fn_name
-            + " expr_len="
-            + number_to_string(expr_len)
-            + " lines_before="
-            + number_to_string(current_lines.length)
-        );
+        if instr_expression != null { expr_len = instr_expression.length; }
+        print.err("test llvm: lower_return start " + fn_name + " expr_len=" + number_to_string(expr_len) + " lines_before=" + number_to_string(current_lines.length));
     }
 
     let mut _if148: boolean = false;
     if instr_expression == null { _if148 = true; }
     if instr_expression.length == 0 { _if148 = true; }
     if _if148 {
-        if safe_llvm_return == "void" {
-            current_lines.push("  ret void");
-        } else {
+        if safe_llvm_return == "void" { current_lines.push("  ret void"); } else {
             diagnostics.push("llvm lowering: missing return value in `" + fn_name + "`");
             current_lines.push("  ret " + safe_llvm_return + " " + default_return_literal(safe_llvm_return));
         }
@@ -563,7 +517,18 @@ fn lower_return_instruction(
         }
         let empty_constants = empty_string_constant_set();
         _write_expr_stmt_result_files_with_constants(lines.length, current_lines, current_temp, [], current_next_region, empty_constants);
-        return ExpressionStatementResult { lines: current_lines, temp_index: current_temp, locals: locals, bindings: bindings, diagnostics: diagnostics, lifetime_regions: lifetime_regions, lifetime_releases: lifetime_releases, next_region_id: current_next_region, mutations: [] , string_constants: empty_constants };
+        return ExpressionStatementResult {
+            lines: current_lines,
+            temp_index: current_temp,
+            locals: locals,
+            bindings: bindings,
+            diagnostics: diagnostics,
+            lifetime_regions: lifetime_regions,
+            lifetime_releases: lifetime_releases,
+            next_region_id: current_next_region,
+            mutations: [],
+            string_constants: empty_constants
+        };
     }
 
     // Use parameters directly instead of file IPC.
@@ -604,9 +569,7 @@ fn lower_return_instruction(
         print.err("emit-llvm: lower_return bindings_len=" + number_to_string(current_bindings.length));
         let mut bind_i: number = 0;
         loop {
-            if bind_i >= current_bindings.length {
-                break;
-            }
+            if bind_i >= current_bindings.length { break; }
             print.err("emit-llvm: lower_return binding[" + number_to_string(bind_i) + "] name=" + current_bindings[bind_i].name + " llvm_name=" + current_bindings[bind_i].llvm_name + " llvm_type=" + current_bindings[bind_i].llvm_type);
             bind_i += 1;
         }
@@ -648,9 +611,7 @@ fn lower_return_instruction(
 
     if debug_lowering {
         let mut has_operand = "false";
-        if lowered.operand != null {
-            has_operand = "true";
-        }
+        if lowered.operand != null { has_operand = "true"; }
         print.err("emit-llvm: lower_return operand_check fn=" + fn_name + " has_operand=" + has_operand);
     }
     if lowered.operand == null {
@@ -660,7 +621,18 @@ fn lower_return_instruction(
             print.err("test llvm: lower_return no_operand lines_after=" + number_to_string(current_lines.length));
         }
         _write_expr_stmt_result_files_with_constants(lines.length, current_lines, current_temp, [], current_next_region, string_constants);
-        return ExpressionStatementResult { lines: current_lines, temp_index: current_temp, locals: current_locals, bindings: current_bindings, diagnostics: diagnostics, lifetime_regions: lifetime_regions, lifetime_releases: lifetime_releases, next_region_id: current_next_region, mutations: [] , string_constants: string_constants};
+        return ExpressionStatementResult {
+            lines: current_lines,
+            temp_index: current_temp,
+            locals: current_locals,
+            bindings: current_bindings,
+            diagnostics: diagnostics,
+            lifetime_regions: lifetime_regions,
+            lifetime_releases: lifetime_releases,
+            next_region_id: current_next_region,
+            mutations: [],
+            string_constants: string_constants
+        };
     }
 
     let operand = lowered.operand;
@@ -671,7 +643,18 @@ fn lower_return_instruction(
         diagnostics.push("llvm lowering: void function `" + fn_name + "` returned a value");
         current_lines.push("  ret void");
         _write_expr_stmt_result_files_with_constants(lines.length, current_lines, current_temp, [], current_next_region, string_constants);
-        return ExpressionStatementResult { lines: current_lines, temp_index: current_temp, locals: current_locals, bindings: current_bindings, diagnostics: diagnostics, lifetime_regions: lifetime_regions, lifetime_releases: lifetime_releases, next_region_id: current_next_region, mutations: [] , string_constants: string_constants};
+        return ExpressionStatementResult {
+            lines: current_lines,
+            temp_index: current_temp,
+            locals: current_locals,
+            bindings: current_bindings,
+            diagnostics: diagnostics,
+            lifetime_regions: lifetime_regions,
+            lifetime_releases: lifetime_releases,
+            next_region_id: current_next_region,
+            mutations: [],
+            string_constants: string_constants
+        };
     }
 
     if debug_lowering {
@@ -692,16 +675,25 @@ fn lower_return_instruction(
     current_temp = _recover_temp_from_lines(current_lines, current_temp);
     if coerced.operand == null {
         diagnostics.push("llvm lowering: unable to coerce return expression to `" + safe_llvm_return + "` in `" + fn_name + "`");
-        if safe_llvm_return == "void" {
-            current_lines.push("  ret void");
-        } else {
+        if safe_llvm_return == "void" { current_lines.push("  ret void"); } else {
             current_lines.push("  ret " + safe_llvm_return + " " + default_return_literal(safe_llvm_return));
         }
         if trace {
             print.err("test llvm: lower_return no_coerce lines_after=" + number_to_string(current_lines.length));
         }
         _write_expr_stmt_result_files_with_constants(lines.length, current_lines, current_temp, [], current_next_region, string_constants);
-        return ExpressionStatementResult { lines: current_lines, temp_index: current_temp, locals: current_locals, bindings: current_bindings, diagnostics: diagnostics, lifetime_regions: lifetime_regions, lifetime_releases: lifetime_releases, next_region_id: current_next_region, mutations: [] , string_constants: string_constants};
+        return ExpressionStatementResult {
+            lines: current_lines,
+            temp_index: current_temp,
+            locals: current_locals,
+            bindings: current_bindings,
+            diagnostics: diagnostics,
+            lifetime_regions: lifetime_regions,
+            lifetime_releases: lifetime_releases,
+            next_region_id: current_next_region,
+            mutations: [],
+            string_constants: string_constants
+        };
     }
 
     let coerced_operand = coerced.operand;
@@ -721,9 +713,19 @@ fn lower_return_instruction(
         }
     }
     _write_expr_stmt_result_files_with_constants(lines.length, current_lines, current_temp, [], current_next_region, string_constants);
-    return ExpressionStatementResult { lines: current_lines, temp_index: current_temp, locals: current_locals, bindings: current_bindings, diagnostics: diagnostics, lifetime_regions: lifetime_regions, lifetime_releases: lifetime_releases, next_region_id: current_next_region, mutations: [] , string_constants: string_constants};
+    return ExpressionStatementResult {
+        lines: current_lines,
+        temp_index: current_temp,
+        locals: current_locals,
+        bindings: current_bindings,
+        diagnostics: diagnostics,
+        lifetime_regions: lifetime_regions,
+        lifetime_releases: lifetime_releases,
+        next_region_id: current_next_region,
+        mutations: [],
+        string_constants: string_constants
+    };
 }
-
 
 fn prepare_parameters(function: NativeFunction, context: TypeContext) -> ParameterPreparation {
     let mut signature: string[] = [];
@@ -732,9 +734,7 @@ fn prepare_parameters(function: NativeFunction, context: TypeContext) -> Paramet
     let mut seen_names: string[] = [];
     let mut index: number = 0;
     loop {
-        if index >= function.parameters.length {
-            break;
-        }
+        if index >= function.parameters.length { break; }
         let parameter = function.parameters[index];
         let mut llvm_type = map_parameter_type(context, parameter.type_annotation);
         let mut inferred_self_type: boolean = false;
@@ -749,9 +749,7 @@ fn prepare_parameters(function: NativeFunction, context: TypeContext) -> Paramet
             }
         }
         // Default empty types to i8* so LLVM IR is parseable.
-        if llvm_type.length == 0 {
-            llvm_type = "i8*";
-        }
+        if llvm_type.length == 0 { llvm_type = "i8*"; }
         if parameter.type_annotation.length == 0 {
             if !inferred_self_type {
                 diagnostics.push("llvm lowering: parameter `" + parameter.name + "` missing type annotation; defaulting to `" + llvm_type + "`");
@@ -763,9 +761,7 @@ fn prepare_parameters(function: NativeFunction, context: TypeContext) -> Paramet
         let mut llvm_name = "%" + sanitized;
         let mut dedup_count: number = 1;
         loop {
-            if !string_array_contains(seen_names, llvm_name) {
-                break;
-            }
+            if !string_array_contains(seen_names, llvm_name) { break; }
             dedup_count += 1;
             llvm_name = "%" + sanitized + "_" + number_to_string(dedup_count);
         }
@@ -775,5 +771,9 @@ fn prepare_parameters(function: NativeFunction, context: TypeContext) -> Paramet
         bindings = append_parameter_binding(bindings, prep_binding);
         index += 1;
     }
-    return ParameterPreparation { signature: signature, bindings: bindings, diagnostics: diagnostics };
+    return ParameterPreparation {
+        signature: signature,
+        bindings: bindings,
+        diagnostics: diagnostics
+    };
 }

--- a/compiler/src/llvm/expression_lowering/native/statement.sfn
+++ b/compiler/src/llvm/expression_lowering/native/statement.sfn
@@ -12,8 +12,8 @@ import {
     find_last_index_of_char,
     substring
 } from "../../../string_utils";
-import { default_return_literal, } from "../../expressions_helpers";
-import { split_lines_local, } from "../../lowering/lowering_text_utils";
+import { default_return_literal } from "../../expressions_helpers";
+import { split_lines_local } from "../../lowering/lowering_text_utils";
 // Import string constant management
 import { empty_string_constant_set } from "../../strings";
 // Import types from modular structure
@@ -27,7 +27,7 @@ import {
     ParameterBinding,
     ParameterPreparation,
     StringConstant,
-    TypeContext,
+    TypeContext
 } from "../../types";
 // Import utilities
 import {
@@ -43,7 +43,7 @@ import {
     bindings_mark_local_consumed,
     bindings_mark_parameter_consumed,
     bindings_reset_local_consumption,
-    bindings_update_local_ownership,
+    bindings_update_local_ownership
 } from "../bindings";
 // Core lowering / analysis lives in ./core; split helpers live in submodules.
 import { analyze_value_ownership, lower_expression } from "./core";
@@ -55,7 +55,7 @@ import {
     append_local_binding,
     find_local_binding,
     infer_borrow_base_scope,
-    make_lifetime_region_metadata,
+    make_lifetime_region_metadata
 } from "./core_scopes";
 import { lower_lvalue_assignment_stmt, preprocess_self_field_access } from "./statement_assignment";
 // Submodules extracted from this file
@@ -152,7 +152,9 @@ fn _write_expr_stmt_result_files_with_constants(input_lines_len: number, current
     let mut si: number = 0;
     loop {
         if si >= string_constants.length { break; }
-        sc_lines.push(string_constants[si].name + "\t" + string_constants[si].content + "\t" + number_to_string(string_constants[si].byte_count));
+        sc_lines.push(string_constants[si].name + "\t" + string_constants[si].content
+            + "\t"
+            + number_to_string(string_constants[si].byte_count));
         si = si + 1;
     }
     fs.writeLines("build/sailfin/.expr_stmt_string_constants", sc_lines);
@@ -186,7 +188,7 @@ fn _ipc_make_parameter_binding(name: string, llvm_name: string, llvm_type: strin
         llvm_type: llvm_type,
         type_annotation: type_annotation,
         consumed: false,
-        span: null,
+        span: null
     };
 }
 
@@ -199,7 +201,7 @@ fn _ipc_make_local_binding(name: string, pointer: string, llvm_type: string, typ
         ownership: null,
         consumed: false,
         scope_id: scope_id,
-        scope_depth: scope_depth,
+        scope_depth: scope_depth
     };
 }
 
@@ -219,7 +221,14 @@ fn lower_expression_statement(function_name: string, instruction: NativeInstruct
     let mut current_locals = locals;
     let debug_lowering = fs.exists("build/sailfin/.trace_lowering");
     if debug_lowering {
-        print.err("emit-llvm: lower_expression_statement start fn=" + function_name + " expr=" + expression + " locals=" + number_to_string(current_locals.length) + " bindings=" + number_to_string(current_bindings.length));
+        print.err("emit-llvm: lower_expression_statement start fn="
+            + function_name
+            + " expr="
+            + expression
+            + " locals="
+            + number_to_string(current_locals.length)
+            + " bindings="
+            + number_to_string(current_bindings.length));
     }
     let mut diagnostics: string[] = detect_suspension_conflicts(expression, current_locals, current_bindings, function_name, null);
     let mut current_lines: string[] = lines;
@@ -252,16 +261,26 @@ fn lower_expression_statement(function_name: string, instruction: NativeInstruct
         let trimmed_assign_target = trim_text(parsed_assignment.target);
         let trimmed_assign_value = trim_text(parsed_assignment.value);
         if debug_lowering {
-            print.err("emit-llvm: lower_expr_stmt simple_assignment target='" + trimmed_assign_target + "' value='" + trimmed_assign_value + "' locals_len=" + number_to_string(current_locals.length));
+            print.err("emit-llvm: lower_expr_stmt simple_assignment target='"
+                + trimmed_assign_target
+                + "' value='"
+                + trimmed_assign_value
+                + "' locals_len="
+                + number_to_string(current_locals.length));
         }
         let binding = find_local_binding(current_locals, trimmed_assign_target);
         if binding == null {
-            diagnostics.push("llvm lowering: assignment to unknown local `" + trimmed_assign_target + "`");
+            diagnostics.push("llvm lowering: assignment to unknown local `"
+                + trimmed_assign_target
+                + "`");
         } else {
             // Desugar compound assignments: "x += y" becomes "x = x + y"
             let mut effective_value: string = trimmed_assign_value;
             if parsed_assignment.operator.length > 0 {
-                effective_value = trimmed_assign_target + " " + parsed_assignment.operator + " " + trimmed_assign_value;
+                effective_value = trimmed_assign_target + " "
+                    + parsed_assignment.operator
+                    + " "
+                    + trimmed_assign_value;
             }
 
             let previous_ownership: OwnershipInfo? = binding.ownership;
@@ -288,7 +307,9 @@ fn lower_expression_statement(function_name: string, instruction: NativeInstruct
             current_temp = lowered.temp_index;
             current_temp = _recover_temp_from_lines(current_lines, current_temp);
             if lowered.operand == null {
-                diagnostics.push("llvm lowering: failed to lower assignment expression for `" + trimmed_assign_target + "`");
+                diagnostics.push("llvm lowering: failed to lower assignment expression for `"
+                    + trimmed_assign_target
+                    + "`");
             } else {
                 let coerced = coerce_operand_to_type(lowered.operand, binding.llvm_type, current_temp, current_lines);
                 let mut _ci13: number = 0;
@@ -301,12 +322,24 @@ fn lower_expression_statement(function_name: string, instruction: NativeInstruct
                 current_temp = coerced.temp_index;
                 current_temp = _recover_temp_from_lines(current_lines, current_temp);
                 if coerced.operand == null {
-                    diagnostics.push("llvm lowering: unable to coerce assignment value for `" + trimmed_assign_target + "`");
-                    current_lines.push("  store " + binding.llvm_type + " " + default_return_literal(binding.llvm_type) + ", " + binding.llvm_type + "* " + binding.pointer);
+                    diagnostics.push("llvm lowering: unable to coerce assignment value for `"
+                        + trimmed_assign_target
+                        + "`");
+                    current_lines.push("  store " + binding.llvm_type + " "
+                        + default_return_literal(binding.llvm_type)
+                        + ", "
+                        + binding.llvm_type
+                        + "* "
+                        + binding.pointer);
                 } else {
                     let operand = coerced.operand;
                     stored_value = operand.value;
-                    current_lines.push("  store " + binding.llvm_type + " " + operand.value + ", " + binding.llvm_type + "* " + binding.pointer);
+                    current_lines.push("  store " + binding.llvm_type + " "
+                        + operand.value
+                        + ", "
+                        + binding.llvm_type
+                        + "* "
+                        + binding.pointer);
                 }
             }
 
@@ -340,7 +373,7 @@ fn lower_expression_statement(function_name: string, instruction: NativeInstruct
                         base: assignment_ownership.base,
                         mutable: assignment_ownership.mutable,
                         span: assignment_ownership.span,
-                        region_id: region_id,
+                        region_id: region_id
                     };
                 } else {
                     assignment_ownership = OwnershipInfo {
@@ -348,7 +381,7 @@ fn lower_expression_statement(function_name: string, instruction: NativeInstruct
                         base: assignment_ownership.base,
                         mutable: assignment_ownership.mutable,
                         span: assignment_ownership.span,
-                        region_id: -1,
+                        region_id: -1
                     };
                 }
             }
@@ -369,7 +402,7 @@ fn lower_expression_statement(function_name: string, instruction: NativeInstruct
                 llvm_type: binding.llvm_type,
                 value_name: stored_value,
                 span: null,
-                originating_label: current_label,
+                originating_label: current_label
             };
             mutations.push(mutation);
         }
@@ -425,7 +458,9 @@ fn lower_expression_statement(function_name: string, instruction: NativeInstruct
         }
         current_lines = _new_lines;
         if debug_lowering {
-            print.err("stmt-lowering: read " + number_to_string(_new_lines.length) + " lines from call_result files, current_lines.length=" + number_to_string(current_lines.length));
+            print.err("stmt-lowering: read " + number_to_string(_new_lines.length)
+                + " lines from call_result files, current_lines.length="
+                + number_to_string(current_lines.length));
         }
         let _cr_temp_str = fs.readFile("build/sailfin/.call_result_temp");
         let _cr_parsed = _parse_int_local(_cr_temp_str);
@@ -456,7 +491,12 @@ fn lower_expression_statement(function_name: string, instruction: NativeInstruct
         }
     }
     if debug_lowering {
-        print.err("stmt-lowering: pre-write _pre_call_lines_len=" + number_to_string(_pre_call_lines_len) + " current_lines.length=" + number_to_string(current_lines.length) + " delta=" + number_to_string(current_lines.length - _pre_call_lines_len));
+        print.err("stmt-lowering: pre-write _pre_call_lines_len="
+            + number_to_string(_pre_call_lines_len)
+            + " current_lines.length="
+            + number_to_string(current_lines.length)
+            + " delta="
+            + number_to_string(current_lines.length - _pre_call_lines_len));
     }
     _write_expr_stmt_result_files_with_constants(_pre_call_lines_len, current_lines, current_temp, mutations, current_next_region, string_constants);
     return ExpressionStatementResult {
@@ -492,7 +532,9 @@ fn lower_return_instruction(function: NativeFunction, instruction: NativeInstruc
     let safe_llvm_return = llvm_return;
 
     if debug_lowering {
-        print.err("emit-llvm: lower_return_instruction start fn=" + fn_name + " llvm_return=" + safe_llvm_return);
+        print.err("emit-llvm: lower_return_instruction start fn=" + fn_name
+            + " llvm_return="
+            + safe_llvm_return);
     }
 
     // Get the return expression from the instruction
@@ -501,7 +543,10 @@ fn lower_return_instruction(function: NativeFunction, instruction: NativeInstruc
     if trace {
         let mut expr_len: number = 0;
         if instr_expression != null { expr_len = instr_expression.length; }
-        print.err("test llvm: lower_return start " + fn_name + " expr_len=" + number_to_string(expr_len) + " lines_before=" + number_to_string(current_lines.length));
+        print.err("test llvm: lower_return start " + fn_name + " expr_len="
+            + number_to_string(expr_len)
+            + " lines_before="
+            + number_to_string(current_lines.length));
     }
 
     let mut _if148: boolean = false;
@@ -509,11 +554,15 @@ fn lower_return_instruction(function: NativeFunction, instruction: NativeInstruc
     if instr_expression.length == 0 { _if148 = true; }
     if _if148 {
         if safe_llvm_return == "void" { current_lines.push("  ret void"); } else {
-            diagnostics.push("llvm lowering: missing return value in `" + fn_name + "`");
-            current_lines.push("  ret " + safe_llvm_return + " " + default_return_literal(safe_llvm_return));
+            diagnostics.push("llvm lowering: missing return value in `"
+                + fn_name
+                + "`");
+            current_lines.push("  ret " + safe_llvm_return + " "
+                + default_return_literal(safe_llvm_return));
         }
         if trace {
-            print.err("test llvm: lower_return empty_expr lines_after=" + number_to_string(current_lines.length));
+            print.err("test llvm: lower_return empty_expr lines_after="
+                + number_to_string(current_lines.length));
         }
         let empty_constants = empty_string_constant_set();
         _write_expr_stmt_result_files_with_constants(lines.length, current_lines, current_temp, [], current_next_region, empty_constants);
@@ -565,12 +614,20 @@ fn lower_return_instruction(function: NativeFunction, instruction: NativeInstruc
     let consumption = ownership_analysis.consumption;
 
     if debug_lowering {
-        print.err("emit-llvm: lower_return pre_lower_expr fn=" + fn_name + " expr=" + instr_expression);
+        print.err("emit-llvm: lower_return pre_lower_expr fn=" + fn_name
+            + " expr="
+            + instr_expression);
         print.err("emit-llvm: lower_return bindings_len=" + number_to_string(current_bindings.length));
         let mut bind_i: number = 0;
         loop {
             if bind_i >= current_bindings.length { break; }
-            print.err("emit-llvm: lower_return binding[" + number_to_string(bind_i) + "] name=" + current_bindings[bind_i].name + " llvm_name=" + current_bindings[bind_i].llvm_name + " llvm_type=" + current_bindings[bind_i].llvm_type);
+            print.err("emit-llvm: lower_return binding[" + number_to_string(bind_i)
+                + "] name="
+                + current_bindings[bind_i].name
+                + " llvm_name="
+                + current_bindings[bind_i].llvm_name
+                + " llvm_type="
+                + current_bindings[bind_i].llvm_type);
             bind_i += 1;
         }
     }
@@ -612,13 +669,19 @@ fn lower_return_instruction(function: NativeFunction, instruction: NativeInstruc
     if debug_lowering {
         let mut has_operand = "false";
         if lowered.operand != null { has_operand = "true"; }
-        print.err("emit-llvm: lower_return operand_check fn=" + fn_name + " has_operand=" + has_operand);
+        print.err("emit-llvm: lower_return operand_check fn=" + fn_name
+            + " has_operand="
+            + has_operand);
     }
     if lowered.operand == null {
-        diagnostics.push("llvm lowering: unhandled return expression in `" + fn_name + "`");
-        current_lines.push("  ret " + safe_llvm_return + " " + default_return_literal(safe_llvm_return));
+        diagnostics.push("llvm lowering: unhandled return expression in `"
+            + fn_name
+            + "`");
+        current_lines.push("  ret " + safe_llvm_return + " "
+            + default_return_literal(safe_llvm_return));
         if trace {
-            print.err("test llvm: lower_return no_operand lines_after=" + number_to_string(current_lines.length));
+            print.err("test llvm: lower_return no_operand lines_after="
+                + number_to_string(current_lines.length));
         }
         _write_expr_stmt_result_files_with_constants(lines.length, current_lines, current_temp, [], current_next_region, string_constants);
         return ExpressionStatementResult {
@@ -637,10 +700,14 @@ fn lower_return_instruction(function: NativeFunction, instruction: NativeInstruc
 
     let operand = lowered.operand;
     if debug_lowering {
-        print.err("emit-llvm: lower_return pre_coerce fn=" + fn_name + " type=" + operand.llvm_type + " value=" + operand.value);
+        print.err("emit-llvm: lower_return pre_coerce fn=" + fn_name + " type="
+            + operand.llvm_type
+            + " value="
+            + operand.value);
     }
     if safe_llvm_return == "void" {
-        diagnostics.push("llvm lowering: void function `" + fn_name + "` returned a value");
+        diagnostics.push("llvm lowering: void function `" + fn_name
+            + "` returned a value");
         current_lines.push("  ret void");
         _write_expr_stmt_result_files_with_constants(lines.length, current_lines, current_temp, [], current_next_region, string_constants);
         return ExpressionStatementResult {
@@ -674,12 +741,18 @@ fn lower_return_instruction(function: NativeFunction, instruction: NativeInstruc
     current_temp = coerced.temp_index;
     current_temp = _recover_temp_from_lines(current_lines, current_temp);
     if coerced.operand == null {
-        diagnostics.push("llvm lowering: unable to coerce return expression to `" + safe_llvm_return + "` in `" + fn_name + "`");
+        diagnostics.push("llvm lowering: unable to coerce return expression to `"
+            + safe_llvm_return
+            + "` in `"
+            + fn_name
+            + "`");
         if safe_llvm_return == "void" { current_lines.push("  ret void"); } else {
-            current_lines.push("  ret " + safe_llvm_return + " " + default_return_literal(safe_llvm_return));
+            current_lines.push("  ret " + safe_llvm_return + " "
+                + default_return_literal(safe_llvm_return));
         }
         if trace {
-            print.err("test llvm: lower_return no_coerce lines_after=" + number_to_string(current_lines.length));
+            print.err("test llvm: lower_return no_coerce lines_after="
+                + number_to_string(current_lines.length));
         }
         _write_expr_stmt_result_files_with_constants(lines.length, current_lines, current_temp, [], current_next_region, string_constants);
         return ExpressionStatementResult {
@@ -699,9 +772,12 @@ fn lower_return_instruction(function: NativeFunction, instruction: NativeInstruc
     let coerced_operand = coerced.operand;
     // STAGE2 FIX: Mark string pointers as persistent before returning
     if coerced_operand.llvm_type == "i8*" {
-        current_lines.push("  call void @sailfin_runtime_mark_persistent(i8* " + coerced_operand.value + ")");
+        current_lines.push("  call void @sailfin_runtime_mark_persistent(i8* "
+            + coerced_operand.value
+            + ")");
     }
-    current_lines.push("  ret " + coerced_operand.llvm_type + " " + coerced_operand.value);
+    current_lines.push("  ret " + coerced_operand.llvm_type + " "
+        + coerced_operand.value);
     if trace {
         print.err("test llvm: lower_return ok lines_after=" + number_to_string(current_lines.length));
     }
@@ -752,7 +828,10 @@ fn prepare_parameters(function: NativeFunction, context: TypeContext) -> Paramet
         if llvm_type.length == 0 { llvm_type = "i8*"; }
         if parameter.type_annotation.length == 0 {
             if !inferred_self_type {
-                diagnostics.push("llvm lowering: parameter `" + parameter.name + "` missing type annotation; defaulting to `" + llvm_type + "`");
+                diagnostics.push("llvm lowering: parameter `" + parameter.name
+                    + "` missing type annotation; defaulting to `"
+                    + llvm_type
+                    + "`");
             }
         }
         let sanitized = sanitize_symbol(parameter.name);

--- a/compiler/src/llvm/expression_lowering/native/statement_assignment.sfn
+++ b/compiler/src/llvm/expression_lowering/native/statement_assignment.sfn
@@ -2,66 +2,58 @@
 //
 // Assignment handling extracted from statement.sfn to keep each function
 // under ~500 .sfn-asm instructions (avoids seed OOM).
-
 import { NativeFunction, NativeInstruction, NativeSourceSpan } from "../../../native_ir";
-import { substring, index_of } from "../../../string_utils";
-
-import { lower_expression, analyze_value_ownership } from "./core";
-import { coerce_operand_to_type } from "./core_operands";
-import { parse_member_access, parse_index_expression } from "./core_parse";
+import { index_of, substring } from "../../../string_utils";
 import {
-    find_local_binding,
-    infer_borrow_base_scope,
-    append_lifetime_region,
-    append_lifetime_release_event,
-    make_lifetime_region_metadata,
-} from "./core_scopes";
-
-import {
-    TypeContext, LocalBinding, ParameterBinding,
-    OwnershipInfo, LifetimeRegionMetadata,
-    LifetimeReleaseEvent, LLVMOperand, ExpressionResult,
-    AssignmentParseResult, StringConstant, LocalMutation,
-    ExpressionStatementResult,
-} from "../../types";
-
-import {
-    trim_text, starts_with, number_to_string,
-    append_parameter_binding, find_parameter_binding,
-} from "../../utils";
-
-import {
-    empty_string_constant_set, merge_string_constants,
-} from "../../strings";
-
-import {
-    format_temp_name,
     default_return_literal,
+    format_temp_name,
     is_simple_identifier,
 } from "../../expressions_helpers";
-
+import { empty_string_constant_set, merge_string_constants, } from "../../strings";
+import { find_struct_field_index, find_struct_info_by_llvm_type, } from "../../type_context_queries";
 import {
-    ends_with_pointer_suffix, strip_pointer_suffix,
     array_struct_type_for_element,
+    ends_with_pointer_suffix,
+    strip_pointer_suffix,
 } from "../../type_mapping";
-
 import {
-    find_struct_info_by_llvm_type,
-    find_struct_field_index,
-} from "../../type_context_queries";
-
-
-
+    AssignmentParseResult,
+    ExpressionResult,
+    ExpressionStatementResult,
+    LLVMOperand,
+    LifetimeRegionMetadata,
+    LifetimeReleaseEvent,
+    LocalBinding,
+    LocalMutation,
+    OwnershipInfo,
+    ParameterBinding,
+    StringConstant,
+    TypeContext,
+} from "../../types";
 import {
-    array_pointer_element_type,
-} from "../arrays";
-
+    append_parameter_binding,
+    find_parameter_binding,
+    number_to_string,
+    starts_with,
+    trim_text,
+} from "../../utils";
+import { array_pointer_element_type, } from "../arrays";
 import {
-    bindings_mark_parameter_consumed,
     bindings_mark_local_consumed,
+    bindings_mark_parameter_consumed,
     bindings_reset_local_consumption,
     bindings_update_local_ownership,
 } from "../bindings";
+import { analyze_value_ownership, lower_expression } from "./core";
+import { coerce_operand_to_type } from "./core_operands";
+import { parse_index_expression, parse_member_access } from "./core_parse";
+import {
+    append_lifetime_region,
+    append_lifetime_release_event,
+    find_local_binding,
+    infer_borrow_base_scope,
+    make_lifetime_region_metadata,
+} from "./core_scopes";
 
 // Recover from v0.1.1 seed ABI corruption: lowered.temp_index may be 0
 // when returned from cross-module calls. Scan lines for the highest %tN
@@ -78,9 +70,7 @@ fn _recover_assign_temp(lines: string[], floor: number) -> number {
             if space > 0 {
                 let num_str = substring(after_t, 0, space);
                 let rn = _assign_parse_int(num_str);
-                if rn >= result {
-                    result = rn + 1;
-                }
+                if rn >= result { result = rn + 1; }
             }
         }
         ri += 1;
@@ -114,14 +104,7 @@ fn _assign_parse_int(text: string) -> number {
     return result;
 }
 
-fn _write_assign_result_files(
-    pre_lines_count: number,
-    lines: string[],
-    temp_index: number,
-    mutations: LocalMutation[],
-    next_region_id: number,
-    string_constants: StringConstant[]
-) ![io] {
+fn _write_assign_result_files(pre_lines_count: number, lines: string[], temp_index: number, mutations: LocalMutation[], next_region_id: number, string_constants: StringConstant[]) ![io] {
     let new_count = lines.length - pre_lines_count;
     fs.writeFile("build/sailfin/.call_result_lines_count", number_to_string(lines.length));
     // Write all lines as bulk array
@@ -137,22 +120,7 @@ fn _write_assign_result_files(
 
 // Handles deref (*ptr = value), member access (obj.field = value), and
 // array index (arr[i] = value) assignments. Returns ExpressionStatementResult.
-fn lower_lvalue_assignment_stmt(
-    assign_target: string,
-    assign_value: string,
-    assign_operator: string,
-    current_bindings: ParameterBinding[],
-    current_locals: LocalBinding[],
-    temp_index: number,
-    lines: string[],
-    pre_lines_count: number,
-    next_region_id: number,
-    scope_id: string,
-    scope_depth: number,
-    functions: NativeFunction[],
-    context: TypeContext,
-    current_label: string
-) -> ExpressionStatementResult ![io] {
+fn lower_lvalue_assignment_stmt(assign_target: string, assign_value: string, assign_operator: string, current_bindings: ParameterBinding[], current_locals: LocalBinding[], temp_index: number, lines: string[], pre_lines_count: number, next_region_id: number, scope_id: string, scope_depth: number, functions: NativeFunction[], context: TypeContext, current_label: string) -> ExpressionStatementResult ![io] {
     let mut diagnostics: string[] = [];
     let mut current_lines: string[] = lines;
     let mut current_temp: number = temp_index;
@@ -184,13 +152,35 @@ fn lower_lvalue_assignment_stmt(
         if lowered_value.operand == null {
             diagnostics.push("llvm lowering: failed to lower assignment value for deref target `" + assign_target + "`");
             _write_assign_result_files(pre_lines_count, current_lines, current_temp, mutations, current_next_region, string_constants);
-            return ExpressionStatementResult { lines: current_lines, temp_index: current_temp, locals: current_locals, bindings: current_bindings, diagnostics: diagnostics, lifetime_regions: lifetime_regions, lifetime_releases: lifetime_releases, next_region_id: current_next_region, mutations: mutations, string_constants: string_constants };
+            return ExpressionStatementResult {
+                lines: current_lines,
+                temp_index: current_temp,
+                locals: current_locals,
+                bindings: current_bindings,
+                diagnostics: diagnostics,
+                lifetime_regions: lifetime_regions,
+                lifetime_releases: lifetime_releases,
+                next_region_id: current_next_region,
+                mutations: mutations,
+                string_constants: string_constants
+            };
         }
         let pointer_text = trim_text(substring(trimmed_target, 1, trimmed_target.length));
         if pointer_text.length == 0 {
             diagnostics.push("llvm lowering: deref assignment missing pointer operand");
             _write_assign_result_files(pre_lines_count, current_lines, current_temp, mutations, current_next_region, string_constants);
-            return ExpressionStatementResult { lines: current_lines, temp_index: current_temp, locals: current_locals, bindings: current_bindings, diagnostics: diagnostics, lifetime_regions: lifetime_regions, lifetime_releases: lifetime_releases, next_region_id: current_next_region, mutations: mutations, string_constants: string_constants };
+            return ExpressionStatementResult {
+                lines: current_lines,
+                temp_index: current_temp,
+                locals: current_locals,
+                bindings: current_bindings,
+                diagnostics: diagnostics,
+                lifetime_regions: lifetime_regions,
+                lifetime_releases: lifetime_releases,
+                next_region_id: current_next_region,
+                mutations: mutations,
+                string_constants: string_constants
+            };
         }
         let lowered_ptr = lower_expression(pointer_text, current_bindings, current_locals, current_temp, current_lines, functions, context, "");
         let mut _ci1: number = 0;
@@ -205,12 +195,34 @@ fn lower_lvalue_assignment_stmt(
         if lowered_ptr.operand == null {
             diagnostics.push("llvm lowering: deref assignment pointer `" + pointer_text + "` produced no value");
             _write_assign_result_files(pre_lines_count, current_lines, current_temp, mutations, current_next_region, string_constants);
-            return ExpressionStatementResult { lines: current_lines, temp_index: current_temp, locals: current_locals, bindings: current_bindings, diagnostics: diagnostics, lifetime_regions: lifetime_regions, lifetime_releases: lifetime_releases, next_region_id: current_next_region, mutations: mutations, string_constants: string_constants };
+            return ExpressionStatementResult {
+                lines: current_lines,
+                temp_index: current_temp,
+                locals: current_locals,
+                bindings: current_bindings,
+                diagnostics: diagnostics,
+                lifetime_regions: lifetime_regions,
+                lifetime_releases: lifetime_releases,
+                next_region_id: current_next_region,
+                mutations: mutations,
+                string_constants: string_constants
+            };
         }
         if !ends_with_pointer_suffix(lowered_ptr.operand.llvm_type) {
             diagnostics.push("llvm lowering: deref assignment target is not a pointer (got `" + lowered_ptr.operand.llvm_type + "`)");
             _write_assign_result_files(pre_lines_count, current_lines, current_temp, mutations, current_next_region, string_constants);
-            return ExpressionStatementResult { lines: current_lines, temp_index: current_temp, locals: current_locals, bindings: current_bindings, diagnostics: diagnostics, lifetime_regions: lifetime_regions, lifetime_releases: lifetime_releases, next_region_id: current_next_region, mutations: mutations, string_constants: string_constants };
+            return ExpressionStatementResult {
+                lines: current_lines,
+                temp_index: current_temp,
+                locals: current_locals,
+                bindings: current_bindings,
+                diagnostics: diagnostics,
+                lifetime_regions: lifetime_regions,
+                lifetime_releases: lifetime_releases,
+                next_region_id: current_next_region,
+                mutations: mutations,
+                string_constants: string_constants
+            };
         }
         let element_type = strip_pointer_suffix(lowered_ptr.operand.llvm_type);
         let coerced = coerce_operand_to_type(lowered_value.operand, element_type, current_temp, current_lines);
@@ -226,11 +238,33 @@ fn lower_lvalue_assignment_stmt(
         if coerced.operand == null {
             diagnostics.push("llvm lowering: unable to coerce deref assignment value to `" + element_type + "`");
             _write_assign_result_files(pre_lines_count, current_lines, current_temp, mutations, current_next_region, string_constants);
-            return ExpressionStatementResult { lines: current_lines, temp_index: current_temp, locals: current_locals, bindings: current_bindings, diagnostics: diagnostics, lifetime_regions: lifetime_regions, lifetime_releases: lifetime_releases, next_region_id: current_next_region, mutations: mutations, string_constants: string_constants };
+            return ExpressionStatementResult {
+                lines: current_lines,
+                temp_index: current_temp,
+                locals: current_locals,
+                bindings: current_bindings,
+                diagnostics: diagnostics,
+                lifetime_regions: lifetime_regions,
+                lifetime_releases: lifetime_releases,
+                next_region_id: current_next_region,
+                mutations: mutations,
+                string_constants: string_constants
+            };
         }
         current_lines.push("  store " + element_type + " " + coerced.operand.value + ", " + element_type + "* " + lowered_ptr.operand.value);
         _write_assign_result_files(pre_lines_count, current_lines, current_temp, mutations, current_next_region, string_constants);
-        return ExpressionStatementResult { lines: current_lines, temp_index: current_temp, locals: current_locals, bindings: current_bindings, diagnostics: diagnostics, lifetime_regions: lifetime_regions, lifetime_releases: lifetime_releases, next_region_id: current_next_region, mutations: mutations, string_constants: string_constants };
+        return ExpressionStatementResult {
+            lines: current_lines,
+            temp_index: current_temp,
+            locals: current_locals,
+            bindings: current_bindings,
+            diagnostics: diagnostics,
+            lifetime_regions: lifetime_regions,
+            lifetime_releases: lifetime_releases,
+            next_region_id: current_next_region,
+            mutations: mutations,
+            string_constants: string_constants
+        };
     }
 
     // Member access assignment: base.field = value
@@ -291,7 +325,18 @@ fn lower_lvalue_assignment_stmt(
                 if !ends_with_pointer_suffix(base_pointer_type) {
                     diagnostics.push("llvm lowering: member access assignment base `" + member_parse.base + "` is not addressable");
                     _write_assign_result_files(pre_lines_count, current_lines, current_temp, mutations, current_next_region, string_constants);
-                    return ExpressionStatementResult { lines: current_lines, temp_index: current_temp, locals: current_locals, bindings: current_bindings, diagnostics: diagnostics, lifetime_regions: lifetime_regions, lifetime_releases: lifetime_releases, next_region_id: current_next_region, mutations: mutations, string_constants: string_constants };
+                    return ExpressionStatementResult {
+                        lines: current_lines,
+                        temp_index: current_temp,
+                        locals: current_locals,
+                        bindings: current_bindings,
+                        diagnostics: diagnostics,
+                        lifetime_regions: lifetime_regions,
+                        lifetime_releases: lifetime_releases,
+                        next_region_id: current_next_region,
+                        mutations: mutations,
+                        string_constants: string_constants
+                    };
                 }
                 let struct_llvm_name = strip_pointer_suffix(base_pointer_type);
                 let struct_info = find_struct_info_by_llvm_type(context, struct_llvm_name);
@@ -324,7 +369,18 @@ fn lower_lvalue_assignment_stmt(
             }
         }
         _write_assign_result_files(pre_lines_count, current_lines, current_temp, mutations, current_next_region, string_constants);
-        return ExpressionStatementResult { lines: current_lines, temp_index: current_temp, locals: current_locals, bindings: current_bindings, diagnostics: diagnostics, lifetime_regions: lifetime_regions, lifetime_releases: lifetime_releases, next_region_id: current_next_region, mutations: mutations, string_constants: string_constants };
+        return ExpressionStatementResult {
+            lines: current_lines,
+            temp_index: current_temp,
+            locals: current_locals,
+            bindings: current_bindings,
+            diagnostics: diagnostics,
+            lifetime_regions: lifetime_regions,
+            lifetime_releases: lifetime_releases,
+            next_region_id: current_next_region,
+            mutations: mutations,
+            string_constants: string_constants
+        };
     }
 
     // Array index assignment: arr[i] = value
@@ -392,7 +448,9 @@ fn lower_lvalue_assignment_stmt(
                             let coerced_index = coerce_operand_to_type(index_result.operand, "i64", current_temp, current_lines);
                             let mut _ci10: number = 0;
                             loop {
-                                if _ci10 >= coerced_index.diagnostics.length { break; }
+                                if _ci10 >= coerced_index.diagnostics.length {
+                                    break;
+                                }
                                 diagnostics.push(coerced_index.diagnostics[_ci10]);
                                 _ci10 += 1;
                             }
@@ -402,7 +460,18 @@ fn lower_lvalue_assignment_stmt(
                             if coerced_index.operand == null {
                                 diagnostics.push("llvm lowering: unable to coerce array index to i64 for `" + assign_target + "`");
                                 _write_assign_result_files(pre_lines_count, current_lines, current_temp, mutations, current_next_region, string_constants);
-                                return ExpressionStatementResult { lines: current_lines, temp_index: current_temp, locals: current_locals, bindings: current_bindings, diagnostics: diagnostics, lifetime_regions: lifetime_regions, lifetime_releases: lifetime_releases, next_region_id: current_next_region, mutations: mutations, string_constants: string_constants };
+                                return ExpressionStatementResult {
+                                    lines: current_lines,
+                                    temp_index: current_temp,
+                                    locals: current_locals,
+                                    bindings: current_bindings,
+                                    diagnostics: diagnostics,
+                                    lifetime_regions: lifetime_regions,
+                                    lifetime_releases: lifetime_releases,
+                                    next_region_id: current_next_region,
+                                    mutations: mutations,
+                                    string_constants: string_constants
+                                };
                             }
                             let data_ptr_temp = format_temp_name(current_temp);
                             current_temp += 1;
@@ -420,12 +489,34 @@ fn lower_lvalue_assignment_stmt(
             }
         }
         _write_assign_result_files(pre_lines_count, current_lines, current_temp, mutations, current_next_region, string_constants);
-        return ExpressionStatementResult { lines: current_lines, temp_index: current_temp, locals: current_locals, bindings: current_bindings, diagnostics: diagnostics, lifetime_regions: lifetime_regions, lifetime_releases: lifetime_releases, next_region_id: current_next_region, mutations: mutations, string_constants: string_constants };
+        return ExpressionStatementResult {
+            lines: current_lines,
+            temp_index: current_temp,
+            locals: current_locals,
+            bindings: current_bindings,
+            diagnostics: diagnostics,
+            lifetime_regions: lifetime_regions,
+            lifetime_releases: lifetime_releases,
+            next_region_id: current_next_region,
+            mutations: mutations,
+            string_constants: string_constants
+        };
     }
 
     // Not a complex lvalue — should not reach here; caller dispatches simple local separately.
     _write_assign_result_files(pre_lines_count, current_lines, current_temp, mutations, current_next_region, string_constants);
-    return ExpressionStatementResult { lines: current_lines, temp_index: current_temp, locals: current_locals, bindings: current_bindings, diagnostics: diagnostics, lifetime_regions: lifetime_regions, lifetime_releases: lifetime_releases, next_region_id: current_next_region, mutations: mutations, string_constants: string_constants };
+    return ExpressionStatementResult {
+        lines: current_lines,
+        temp_index: current_temp,
+        locals: current_locals,
+        bindings: current_bindings,
+        diagnostics: diagnostics,
+        lifetime_regions: lifetime_regions,
+        lifetime_releases: lifetime_releases,
+        next_region_id: current_next_region,
+        mutations: mutations,
+        string_constants: string_constants
+    };
 }
 
 // Pre-process self.field patterns in return expressions: emit GEP instructions
@@ -433,11 +524,7 @@ fn lower_lvalue_assignment_stmt(
 // lower_return_instruction to keep it under ~500 instructions.
 // Writes result to build/sailfin/.self_field_expr and .self_field_temp files,
 // and appends GEP lines to the provided lines array.
-fn preprocess_self_field_access(
-    expression: string,
-    current_temp: number,
-    current_lines: string[]
-) ![io] {
+fn preprocess_self_field_access(expression: string, current_temp: number, current_lines: string[]) ![io] {
     let mut result_expr: string = expression;
     let mut result_temp: number = current_temp;
     let mut result_lines: string[] = current_lines;
@@ -471,8 +558,13 @@ fn preprocess_self_field_access(
         if _ret_sp >= _ret_si.length { break; }
         let _ret_nl = index_of(substring(_ret_si, _ret_sp, _ret_si.length), "\n");
         let mut _ret_ln: string = "";
-        if _ret_nl < 0 { _ret_ln = substring(_ret_si, _ret_sp, _ret_si.length); _ret_sp = _ret_si.length; }
-        else { _ret_ln = substring(_ret_si, _ret_sp, _ret_sp + _ret_nl); _ret_sp = _ret_sp + _ret_nl + 1; }
+        if _ret_nl < 0 {
+            _ret_ln = substring(_ret_si, _ret_sp, _ret_si.length);
+            _ret_sp = _ret_si.length;
+        } else {
+            _ret_ln = substring(_ret_si, _ret_sp, _ret_sp + _ret_nl);
+            _ret_sp = _ret_sp + _ret_nl + 1;
+        }
         if _ret_ln.length == 0 { continue; }
         let _ret_t1 = index_of(_ret_ln, "\t");
         if _ret_t1 < 0 { continue; }
@@ -517,28 +609,33 @@ fn preprocess_self_field_access(
             let _ret_ch = substring(result_expr, _ret_end, _ret_end + 1);
             if _ret_ch >= "a" {
                 if _ret_ch <= "z" { _ret_end += 1; }
-            }
-            else if _ret_ch >= "A" {
+            } else if _ret_ch >= "A" {
                 if _ret_ch <= "Z" { _ret_end += 1; }
-            }
-            else if _ret_ch >= "0" {
+            } else if _ret_ch >= "0" {
                 if _ret_ch <= "9" { _ret_end += 1; }
-            }
-            else if _ret_ch == "_" { _ret_end += 1; }
-            else { break; }
+            } else if _ret_ch == "_" { _ret_end += 1; } else { break; }
         }
-        if _ret_end <= _ret_after { _ret_scan = _ret_end + 1; continue; }
+        if _ret_end <= _ret_after {
+            _ret_scan = _ret_end + 1;
+            continue;
+        }
         let _ret_field = substring(result_expr, _ret_after, _ret_end);
         let mut _ret_is_call: boolean = false;
         let mut _ret_peek: number = _ret_end;
         loop {
             if _ret_peek >= result_expr.length { break; }
             let _ret_pk = substring(result_expr, _ret_peek, _ret_peek + 1);
-            if _ret_pk == " " { _ret_peek += 1; continue; }
+            if _ret_pk == " " {
+                _ret_peek += 1;
+                continue;
+            }
             if _ret_pk == "(" { _ret_is_call = true; }
             break;
         }
-        if _ret_is_call { _ret_scan = _ret_end + 1; continue; }
+        if _ret_is_call {
+            _ret_scan = _ret_end + 1;
+            continue;
+        }
         let mut _ret_fidx: number = -1;
         let mut _ret_ftype: string = "";
         let mut _ret_fi: number = 0;
@@ -547,10 +644,18 @@ fn preprocess_self_field_access(
             if _ret_fp >= _ret_sfields.length { break; }
             let _ret_fc = index_of(substring(_ret_sfields, _ret_fp, _ret_sfields.length), ",");
             let mut _ret_fe: string = "";
-            if _ret_fc < 0 { _ret_fe = substring(_ret_sfields, _ret_fp, _ret_sfields.length); _ret_fp = _ret_sfields.length; }
-            else { _ret_fe = substring(_ret_sfields, _ret_fp, _ret_fp + _ret_fc); _ret_fp = _ret_fp + _ret_fc + 1; }
+            if _ret_fc < 0 {
+                _ret_fe = substring(_ret_sfields, _ret_fp, _ret_sfields.length);
+                _ret_fp = _ret_sfields.length;
+            } else {
+                _ret_fe = substring(_ret_sfields, _ret_fp, _ret_fp + _ret_fc);
+                _ret_fp = _ret_fp + _ret_fc + 1;
+            }
             let _ret_fk = index_of(_ret_fe, ":");
-            if _ret_fk < 0 { _ret_fi += 1; continue; }
+            if _ret_fk < 0 {
+                _ret_fi += 1;
+                continue;
+            }
             if substring(_ret_fe, 0, _ret_fk) == _ret_field {
                 _ret_fidx = _ret_fi;
                 _ret_ftype = substring(_ret_fe, _ret_fk + 1, _ret_fe.length);
@@ -558,7 +663,10 @@ fn preprocess_self_field_access(
             }
             _ret_fi += 1;
         }
-        if _ret_fidx < 0 { _ret_scan = _ret_end + 1; continue; }
+        if _ret_fidx < 0 {
+            _ret_scan = _ret_end + 1;
+            continue;
+        }
         let _ret_ct1 = format_temp_name(result_temp);
         result_lines.push("  " + _ret_ct1 + " = bitcast i8* %self to " + _ret_sllvm + "*");
         result_temp += 1;

--- a/compiler/src/llvm/expression_lowering/native/statement_assignment.sfn
+++ b/compiler/src/llvm/expression_lowering/native/statement_assignment.sfn
@@ -4,17 +4,13 @@
 // under ~500 .sfn-asm instructions (avoids seed OOM).
 import { NativeFunction, NativeInstruction, NativeSourceSpan } from "../../../native_ir";
 import { index_of, substring } from "../../../string_utils";
-import {
-    default_return_literal,
-    format_temp_name,
-    is_simple_identifier,
-} from "../../expressions_helpers";
-import { empty_string_constant_set, merge_string_constants, } from "../../strings";
-import { find_struct_field_index, find_struct_info_by_llvm_type, } from "../../type_context_queries";
+import { default_return_literal, format_temp_name, is_simple_identifier } from "../../expressions_helpers";
+import { empty_string_constant_set, merge_string_constants } from "../../strings";
+import { find_struct_field_index, find_struct_info_by_llvm_type } from "../../type_context_queries";
 import {
     array_struct_type_for_element,
     ends_with_pointer_suffix,
-    strip_pointer_suffix,
+    strip_pointer_suffix
 } from "../../type_mapping";
 import {
     AssignmentParseResult,
@@ -28,21 +24,21 @@ import {
     OwnershipInfo,
     ParameterBinding,
     StringConstant,
-    TypeContext,
+    TypeContext
 } from "../../types";
 import {
     append_parameter_binding,
     find_parameter_binding,
     number_to_string,
     starts_with,
-    trim_text,
+    trim_text
 } from "../../utils";
-import { array_pointer_element_type, } from "../arrays";
+import { array_pointer_element_type } from "../arrays";
 import {
     bindings_mark_local_consumed,
     bindings_mark_parameter_consumed,
     bindings_reset_local_consumption,
-    bindings_update_local_ownership,
+    bindings_update_local_ownership
 } from "../bindings";
 import { analyze_value_ownership, lower_expression } from "./core";
 import { coerce_operand_to_type } from "./core_operands";
@@ -52,7 +48,7 @@ import {
     append_lifetime_release_event,
     find_local_binding,
     infer_borrow_base_scope,
-    make_lifetime_region_metadata,
+    make_lifetime_region_metadata
 } from "./core_scopes";
 
 // Recover from v0.1.1 seed ABI corruption: lowered.temp_index may be 0
@@ -136,7 +132,8 @@ fn lower_lvalue_assignment_stmt(assign_target: string, assign_value: string, ass
     if starts_with(trimmed_target, "*") {
         let mut effective_value: string = assign_value;
         if assign_operator.length > 0 {
-            effective_value = trimmed_target + " " + assign_operator + " " + assign_value;
+            effective_value = trimmed_target + " " + assign_operator + " "
+                + assign_value;
         }
         let lowered_value = lower_expression(effective_value, current_bindings, current_locals, current_temp, current_lines, functions, context, "");
         let mut _ci0: number = 0;
@@ -150,7 +147,9 @@ fn lower_lvalue_assignment_stmt(assign_target: string, assign_value: string, ass
         current_temp = lowered_value.temp_index;
         current_temp = _recover_assign_temp(current_lines, current_temp);
         if lowered_value.operand == null {
-            diagnostics.push("llvm lowering: failed to lower assignment value for deref target `" + assign_target + "`");
+            diagnostics.push("llvm lowering: failed to lower assignment value for deref target `"
+                + assign_target
+                + "`");
             _write_assign_result_files(pre_lines_count, current_lines, current_temp, mutations, current_next_region, string_constants);
             return ExpressionStatementResult {
                 lines: current_lines,
@@ -193,7 +192,9 @@ fn lower_lvalue_assignment_stmt(assign_target: string, assign_value: string, ass
         current_temp = lowered_ptr.temp_index;
         current_temp = _recover_assign_temp(current_lines, current_temp);
         if lowered_ptr.operand == null {
-            diagnostics.push("llvm lowering: deref assignment pointer `" + pointer_text + "` produced no value");
+            diagnostics.push("llvm lowering: deref assignment pointer `"
+                + pointer_text
+                + "` produced no value");
             _write_assign_result_files(pre_lines_count, current_lines, current_temp, mutations, current_next_region, string_constants);
             return ExpressionStatementResult {
                 lines: current_lines,
@@ -209,7 +210,9 @@ fn lower_lvalue_assignment_stmt(assign_target: string, assign_value: string, ass
             };
         }
         if !ends_with_pointer_suffix(lowered_ptr.operand.llvm_type) {
-            diagnostics.push("llvm lowering: deref assignment target is not a pointer (got `" + lowered_ptr.operand.llvm_type + "`)");
+            diagnostics.push("llvm lowering: deref assignment target is not a pointer (got `"
+                + lowered_ptr.operand.llvm_type
+                + "`)");
             _write_assign_result_files(pre_lines_count, current_lines, current_temp, mutations, current_next_region, string_constants);
             return ExpressionStatementResult {
                 lines: current_lines,
@@ -236,7 +239,9 @@ fn lower_lvalue_assignment_stmt(assign_target: string, assign_value: string, ass
         current_temp = coerced.temp_index;
         current_temp = _recover_assign_temp(current_lines, current_temp);
         if coerced.operand == null {
-            diagnostics.push("llvm lowering: unable to coerce deref assignment value to `" + element_type + "`");
+            diagnostics.push("llvm lowering: unable to coerce deref assignment value to `"
+                + element_type
+                + "`");
             _write_assign_result_files(pre_lines_count, current_lines, current_temp, mutations, current_next_region, string_constants);
             return ExpressionStatementResult {
                 lines: current_lines,
@@ -251,7 +256,11 @@ fn lower_lvalue_assignment_stmt(assign_target: string, assign_value: string, ass
                 string_constants: string_constants
             };
         }
-        current_lines.push("  store " + element_type + " " + coerced.operand.value + ", " + element_type + "* " + lowered_ptr.operand.value);
+        current_lines.push("  store " + element_type + " " + coerced.operand.value
+            + ", "
+            + element_type
+            + "* "
+            + lowered_ptr.operand.value);
         _write_assign_result_files(pre_lines_count, current_lines, current_temp, mutations, current_next_region, string_constants);
         return ExpressionStatementResult {
             lines: current_lines,
@@ -272,7 +281,8 @@ fn lower_lvalue_assignment_stmt(assign_target: string, assign_value: string, ass
     if member_parse.success {
         let mut effective_value: string = assign_value;
         if assign_operator.length > 0 {
-            effective_value = assign_target + " " + assign_operator + " " + assign_value;
+            effective_value = assign_target + " " + assign_operator + " "
+                + assign_value;
         }
         let lowered = lower_expression(effective_value, current_bindings, current_locals, current_temp, current_lines, functions, context, "");
         let mut _ci3: number = 0;
@@ -286,7 +296,9 @@ fn lower_lvalue_assignment_stmt(assign_target: string, assign_value: string, ass
         current_temp = lowered.temp_index;
         current_temp = _recover_assign_temp(current_lines, current_temp);
         if lowered.operand == null {
-            diagnostics.push("llvm lowering: failed to lower assignment value for member `" + assign_target + "`");
+            diagnostics.push("llvm lowering: failed to lower assignment value for member `"
+                + assign_target
+                + "`");
         } else {
             let base_result = lower_expression(member_parse.base, current_bindings, current_locals, current_temp, current_lines, functions, context, "");
             let mut _ci4: number = 0;
@@ -299,7 +311,9 @@ fn lower_lvalue_assignment_stmt(assign_target: string, assign_value: string, ass
             current_temp = base_result.temp_index;
             current_temp = _recover_assign_temp(current_lines, current_temp);
             if base_result.operand == null {
-                diagnostics.push("llvm lowering: member access assignment base `" + member_parse.base + "` produced no value");
+                diagnostics.push("llvm lowering: member access assignment base `"
+                    + member_parse.base
+                    + "` produced no value");
             } else {
                 let base_operand = base_result.operand;
                 let mut base_pointer_type: string = base_operand.llvm_type;
@@ -323,7 +337,9 @@ fn lower_lvalue_assignment_stmt(assign_target: string, assign_value: string, ass
                     }
                 }
                 if !ends_with_pointer_suffix(base_pointer_type) {
-                    diagnostics.push("llvm lowering: member access assignment base `" + member_parse.base + "` is not addressable");
+                    diagnostics.push("llvm lowering: member access assignment base `"
+                        + member_parse.base
+                        + "` is not addressable");
                     _write_assign_result_files(pre_lines_count, current_lines, current_temp, mutations, current_next_region, string_constants);
                     return ExpressionStatementResult {
                         lines: current_lines,
@@ -341,11 +357,16 @@ fn lower_lvalue_assignment_stmt(assign_target: string, assign_value: string, ass
                 let struct_llvm_name = strip_pointer_suffix(base_pointer_type);
                 let struct_info = find_struct_info_by_llvm_type(context, struct_llvm_name);
                 if struct_info == null {
-                    diagnostics.push("llvm lowering: member access assignment on non-struct type `" + base_result.operand.llvm_type + "`");
+                    diagnostics.push("llvm lowering: member access assignment on non-struct type `"
+                        + base_result.operand.llvm_type
+                        + "`");
                 } else {
                     let field_index = find_struct_field_index(struct_info, member_parse.field);
                     if field_index < 0 {
-                        diagnostics.push("llvm lowering: struct `" + struct_info.name + "` has no field `" + member_parse.field + "`");
+                        diagnostics.push("llvm lowering: struct `" + struct_info.name
+                            + "` has no field `"
+                            + member_parse.field
+                            + "`");
                     } else {
                         let field_info = struct_info.fields[field_index];
                         let coerced = coerce_operand_to_type(lowered.operand, field_info.llvm_type, current_temp, current_lines);
@@ -361,8 +382,22 @@ fn lower_lvalue_assignment_stmt(assign_target: string, assign_value: string, ass
                         if coerced.operand != null {
                             let field_ptr_temp = format_temp_name(current_temp);
                             current_temp += 1;
-                            current_lines.push("  " + field_ptr_temp + " = getelementptr " + struct_info.llvm_name + ", " + base_pointer_type + " " + base_pointer_value + ", i32 0, i32 " + number_to_string(field_index));
-                            current_lines.push("  store " + coerced.operand.llvm_type + " " + coerced.operand.value + ", " + coerced.operand.llvm_type + "* " + field_ptr_temp);
+                            current_lines.push("  " + field_ptr_temp
+                                + " = getelementptr "
+                                + struct_info.llvm_name
+                                + ", "
+                                + base_pointer_type
+                                + " "
+                                + base_pointer_value
+                                + ", i32 0, i32 "
+                                + number_to_string(field_index));
+                            current_lines.push("  store " + coerced.operand.llvm_type
+                                + " "
+                                + coerced.operand.value
+                                + ", "
+                                + coerced.operand.llvm_type
+                                + "* "
+                                + field_ptr_temp);
                         }
                     }
                 }
@@ -388,7 +423,8 @@ fn lower_lvalue_assignment_stmt(assign_target: string, assign_value: string, ass
     if index_parse.success {
         let mut effective_value: string = assign_value;
         if assign_operator.length > 0 {
-            effective_value = assign_target + " " + assign_operator + " " + assign_value;
+            effective_value = assign_target + " " + assign_operator + " "
+                + assign_value;
         }
         let lowered = lower_expression(effective_value, current_bindings, current_locals, current_temp, current_lines, functions, context, "");
         let mut _ci6: number = 0;
@@ -402,7 +438,9 @@ fn lower_lvalue_assignment_stmt(assign_target: string, assign_value: string, ass
         current_temp = lowered.temp_index;
         current_temp = _recover_assign_temp(current_lines, current_temp);
         if lowered.operand == null {
-            diagnostics.push("llvm lowering: failed to lower assignment value for array index `" + assign_target + "`");
+            diagnostics.push("llvm lowering: failed to lower assignment value for array index `"
+                + assign_target
+                + "`");
         } else {
             let base_result = lower_expression(index_parse.base, current_bindings, current_locals, current_temp, current_lines, functions, context, "");
             let mut _ci7: number = 0;
@@ -415,7 +453,9 @@ fn lower_lvalue_assignment_stmt(assign_target: string, assign_value: string, ass
             current_temp = base_result.temp_index;
             current_temp = _recover_assign_temp(current_lines, current_temp);
             if base_result.operand == null {
-                diagnostics.push("llvm lowering: array index assignment base `" + index_parse.base + "` produced no value");
+                diagnostics.push("llvm lowering: array index assignment base `"
+                    + index_parse.base
+                    + "` produced no value");
             } else {
                 let index_result = lower_expression(index_parse.index, current_bindings, current_locals, current_temp, current_lines, functions, context, "");
                 let mut _ci8: number = 0;
@@ -428,11 +468,15 @@ fn lower_lvalue_assignment_stmt(assign_target: string, assign_value: string, ass
                 current_temp = index_result.temp_index;
                 current_temp = _recover_assign_temp(current_lines, current_temp);
                 if index_result.operand == null {
-                    diagnostics.push("llvm lowering: array index `" + index_parse.index + "` produced no value");
+                    diagnostics.push("llvm lowering: array index `"
+                        + index_parse.index
+                        + "` produced no value");
                 } else {
                     let element_type = array_pointer_element_type(base_result.operand.llvm_type);
                     if element_type.length == 0 {
-                        diagnostics.push("llvm lowering: cannot determine element type for array assignment `" + base_result.operand.llvm_type + "`");
+                        diagnostics.push("llvm lowering: cannot determine element type for array assignment `"
+                            + base_result.operand.llvm_type
+                            + "`");
                     } else {
                         let coerced = coerce_operand_to_type(lowered.operand, element_type, current_temp, current_lines);
                         let mut _ci9: number = 0;
@@ -458,7 +502,9 @@ fn lower_lvalue_assignment_stmt(assign_target: string, assign_value: string, ass
                             current_temp = coerced_index.temp_index;
                             current_temp = _recover_assign_temp(current_lines, current_temp);
                             if coerced_index.operand == null {
-                                diagnostics.push("llvm lowering: unable to coerce array index to i64 for `" + assign_target + "`");
+                                diagnostics.push("llvm lowering: unable to coerce array index to i64 for `"
+                                    + assign_target
+                                    + "`");
                                 _write_assign_result_files(pre_lines_count, current_lines, current_temp, mutations, current_next_region, string_constants);
                                 return ExpressionStatementResult {
                                     lines: current_lines,
@@ -477,12 +523,39 @@ fn lower_lvalue_assignment_stmt(assign_target: string, assign_value: string, ass
                             current_temp += 1;
                             let elem_ptr_temp = format_temp_name(current_temp);
                             current_temp += 1;
-                            current_lines.push("  " + data_ptr_temp + " = getelementptr " + array_struct_type_for_element(element_type) + ", " + base_result.operand.llvm_type + " " + base_result.operand.value + ", i32 0, i32 0");
+                            current_lines.push("  " + data_ptr_temp
+                                + " = getelementptr "
+                                + array_struct_type_for_element(element_type)
+                                + ", "
+                                + base_result.operand.llvm_type
+                                + " "
+                                + base_result.operand.value
+                                + ", i32 0, i32 0");
                             let data_ptr_loaded = format_temp_name(current_temp);
                             current_temp += 1;
-                            current_lines.push("  " + data_ptr_loaded + " = load " + element_type + "*, " + element_type + "** " + data_ptr_temp);
-                            current_lines.push("  " + elem_ptr_temp + " = getelementptr " + element_type + ", " + element_type + "* " + data_ptr_loaded + ", i64 " + coerced_index.operand.value);
-                            current_lines.push("  store " + coerced.operand.llvm_type + " " + coerced.operand.value + ", " + coerced.operand.llvm_type + "* " + elem_ptr_temp);
+                            current_lines.push("  " + data_ptr_loaded
+                                + " = load "
+                                + element_type
+                                + "*, "
+                                + element_type
+                                + "** "
+                                + data_ptr_temp);
+                            current_lines.push("  " + elem_ptr_temp
+                                + " = getelementptr "
+                                + element_type
+                                + ", "
+                                + element_type
+                                + "* "
+                                + data_ptr_loaded
+                                + ", i64 "
+                                + coerced_index.operand.value);
+                            current_lines.push("  store " + coerced.operand.llvm_type
+                                + " "
+                                + coerced.operand.value
+                                + ", "
+                                + coerced.operand.llvm_type
+                                + "* "
+                                + elem_ptr_temp);
                         }
                     }
                 }
@@ -668,13 +741,25 @@ fn preprocess_self_field_access(expression: string, current_temp: number, curren
             continue;
         }
         let _ret_ct1 = format_temp_name(result_temp);
-        result_lines.push("  " + _ret_ct1 + " = bitcast i8* %self to " + _ret_sllvm + "*");
+        result_lines.push("  " + _ret_ct1 + " = bitcast i8* %self to "
+            + _ret_sllvm
+            + "*");
         result_temp += 1;
         let _ret_ct2 = format_temp_name(result_temp);
-        result_lines.push("  " + _ret_ct2 + " = getelementptr inbounds " + _ret_sllvm + ", " + _ret_sllvm + "* " + _ret_ct1 + ", i32 0, i32 " + number_to_string(_ret_fidx));
+        result_lines.push("  " + _ret_ct2 + " = getelementptr inbounds "
+            + _ret_sllvm
+            + ", "
+            + _ret_sllvm
+            + "* "
+            + _ret_ct1
+            + ", i32 0, i32 "
+            + number_to_string(_ret_fidx));
         result_temp += 1;
         let _ret_ct3 = format_temp_name(result_temp);
-        result_lines.push("  " + _ret_ct3 + " = load " + _ret_ftype + ", " + _ret_ftype + "* " + _ret_ct2);
+        result_lines.push("  " + _ret_ct3 + " = load " + _ret_ftype + ", "
+            + _ret_ftype
+            + "* "
+            + _ret_ct2);
         result_temp += 1;
         let _ret_before = substring(result_expr, 0, _ret_abs);
         let _ret_rest = substring(result_expr, _ret_end, result_expr.length);

--- a/compiler/src/llvm/expression_lowering/native/statement_parsing.sfn
+++ b/compiler/src/llvm/expression_lowering/native/statement_parsing.sfn
@@ -6,8 +6,8 @@
 // assignments like `x += y`) and `parse_inline_let_expression` (parses
 // `let [mut] name [: type] = init`).
 import { substring } from "../../../string_utils";
-import { AssignmentParseResult, InlineLetParseResult, } from "../../types";
-import { index_of, trim_text, } from "../../utils";
+import { AssignmentParseResult, InlineLetParseResult } from "../../types";
+import { index_of, trim_text } from "../../utils";
 
 fn parse_assignment_expression(expression: string) -> AssignmentParseResult {
     let trimmed = trim_text(expression);
@@ -138,7 +138,9 @@ fn parse_inline_let_expression(expression: string) -> InlineLetParseResult {
     let mut diagnostics: string[] = [];
     let trimmed = trim_text(expression);
     if trimmed.length < 4 {
-        diagnostics.push("llvm lowering: malformed let expression `" + expression + "`");
+        diagnostics.push("llvm lowering: malformed let expression `"
+            + expression
+            + "`");
         return InlineLetParseResult {
             success: false,
             name: "",
@@ -169,7 +171,9 @@ fn parse_inline_let_expression(expression: string) -> InlineLetParseResult {
         }
     }
     if remainder.length == 0 {
-        diagnostics.push("llvm lowering: let expression missing binding name in `" + expression + "`");
+        diagnostics.push("llvm lowering: let expression missing binding name in `"
+            + expression
+            + "`");
         return InlineLetParseResult {
             success: false,
             name: "",
@@ -195,7 +199,9 @@ fn parse_inline_let_expression(expression: string) -> InlineLetParseResult {
     }
     name = trim_text(name);
     if name.length == 0 {
-        diagnostics.push("llvm lowering: let expression missing binding name in `" + expression + "`");
+        diagnostics.push("llvm lowering: let expression missing binding name in `"
+            + expression
+            + "`");
         return InlineLetParseResult {
             success: false,
             name: "",
@@ -245,7 +251,9 @@ fn parse_inline_let_expression(expression: string) -> InlineLetParseResult {
         }
     }
     if initializer == null {
-        diagnostics.push("llvm lowering: let expression missing initializer for `" + name + "`");
+        diagnostics.push("llvm lowering: let expression missing initializer for `"
+            + name
+            + "`");
         return InlineLetParseResult {
             success: false,
             name: name,

--- a/compiler/src/llvm/expression_lowering/native/statement_parsing.sfn
+++ b/compiler/src/llvm/expression_lowering/native/statement_parsing.sfn
@@ -5,18 +5,9 @@
 // Contains `parse_assignment_expression` (splits `target = value` and compound
 // assignments like `x += y`) and `parse_inline_let_expression` (parses
 // `let [mut] name [: type] = init`).
-
-import {
-    AssignmentParseResult, InlineLetParseResult,
-} from "../../types";
-
-import {
-    trim_text,
-    index_of,
-} from "../../utils";
-
 import { substring } from "../../../string_utils";
-
+import { AssignmentParseResult, InlineLetParseResult, } from "../../types";
+import { index_of, trim_text, } from "../../utils";
 
 fn parse_assignment_expression(expression: string) -> AssignmentParseResult {
     let trimmed = trim_text(expression);
@@ -24,9 +15,7 @@ fn parse_assignment_expression(expression: string) -> AssignmentParseResult {
     let mut bracket_depth: number = 0;
     let mut index: number = 0;
     loop {
-        if index >= trimmed.length {
-            break;
-        }
+        if index >= trimmed.length { break; }
         let ch = substring(trimmed, index, index + 1);
         if ch == "(" {
             paren_depth += 1;
@@ -34,9 +23,7 @@ fn parse_assignment_expression(expression: string) -> AssignmentParseResult {
             continue;
         }
         if ch == ")" {
-            if paren_depth > 0 {
-                paren_depth -= 1;
-            }
+            if paren_depth > 0 { paren_depth -= 1; }
             index += 1;
             continue;
         }
@@ -46,9 +33,7 @@ fn parse_assignment_expression(expression: string) -> AssignmentParseResult {
             continue;
         }
         if ch == "]" {
-            if bracket_depth > 0 {
-                bracket_depth -= 1;
-            }
+            if bracket_depth > 0 { bracket_depth -= 1; }
             index += 1;
             continue;
         }
@@ -85,9 +70,19 @@ fn parse_assignment_expression(expression: string) -> AssignmentParseResult {
                 if target.length == 0 { _if165 = true; }
                 if value.length == 0 { _if165 = true; }
                 if _if165 {
-                    return AssignmentParseResult { success: false, target: "", value: "", operator: "" };
+                    return AssignmentParseResult {
+                        success: false,
+                        target: "",
+                        value: "",
+                        operator: ""
+                    };
                 }
-                return AssignmentParseResult { success: true, target: target, value: value, operator: previous };
+                return AssignmentParseResult {
+                    success: true,
+                    target: target,
+                    value: value,
+                    operator: previous
+                };
             }
 
             // Skip comparison operators and other non-assignment uses of =
@@ -115,13 +110,28 @@ fn parse_assignment_expression(expression: string) -> AssignmentParseResult {
             if target.length == 0 { _if145 = true; }
             if value.length == 0 { _if145 = true; }
             if _if145 {
-                return AssignmentParseResult { success: false, target: "", value: "", operator: "" };
+                return AssignmentParseResult {
+                    success: false,
+                    target: "",
+                    value: "",
+                    operator: ""
+                };
             }
-            return AssignmentParseResult { success: true, target: target, value: value, operator: "" };
+            return AssignmentParseResult {
+                success: true,
+                target: target,
+                value: value,
+                operator: ""
+            };
         }
         index += 1;
     }
-    return AssignmentParseResult { success: false, target: "", value: "", operator: "" };
+    return AssignmentParseResult {
+        success: false,
+        target: "",
+        value: "",
+        operator: ""
+    };
 }
 
 fn parse_inline_let_expression(expression: string) -> InlineLetParseResult {
@@ -129,11 +139,25 @@ fn parse_inline_let_expression(expression: string) -> InlineLetParseResult {
     let trimmed = trim_text(expression);
     if trimmed.length < 4 {
         diagnostics.push("llvm lowering: malformed let expression `" + expression + "`");
-        return InlineLetParseResult { success: false, name: "", mutable: false, type_annotation: "", initializer: null, diagnostics: diagnostics };
+        return InlineLetParseResult {
+            success: false,
+            name: "",
+            mutable: false,
+            type_annotation: "",
+            initializer: null,
+            diagnostics: diagnostics
+        };
     }
     let prefix = substring(trimmed, 0, 4);
     if prefix != "let " {
-        return InlineLetParseResult { success: false, name: "", mutable: false, type_annotation: "", initializer: null, diagnostics: diagnostics };
+        return InlineLetParseResult {
+            success: false,
+            name: "",
+            mutable: false,
+            type_annotation: "",
+            initializer: null,
+            diagnostics: diagnostics
+        };
     }
     let mut remainder: string = trim_text(substring(trimmed, 4, trimmed.length));
     let mut is_mutable: boolean = false;
@@ -146,30 +170,40 @@ fn parse_inline_let_expression(expression: string) -> InlineLetParseResult {
     }
     if remainder.length == 0 {
         diagnostics.push("llvm lowering: let expression missing binding name in `" + expression + "`");
-        return InlineLetParseResult { success: false, name: "", mutable: is_mutable, type_annotation: "", initializer: null, diagnostics: diagnostics };
+        return InlineLetParseResult {
+            success: false,
+            name: "",
+            mutable: is_mutable,
+            type_annotation: "",
+            initializer: null,
+            diagnostics: diagnostics
+        };
     }
     let mut name: string = "";
     let mut index: number = 0;
     loop {
-        if index >= remainder.length {
-            break;
-        }
+        if index >= remainder.length { break; }
         let ch = substring(remainder, index, index + 1);
         let mut _if146: boolean = false;
         if ch == " " { _if146 = true; }
         if ch == ":" { _if146 = true; }
         if ch == "-" { _if146 = true; }
         if ch == "=" { _if146 = true; }
-        if _if146 {
-            break;
-        }
+        if _if146 { break; }
         name = name + ch;
         index += 1;
     }
     name = trim_text(name);
     if name.length == 0 {
         diagnostics.push("llvm lowering: let expression missing binding name in `" + expression + "`");
-        return InlineLetParseResult { success: false, name: "", mutable: is_mutable, type_annotation: "", initializer: null, diagnostics: diagnostics };
+        return InlineLetParseResult {
+            success: false,
+            name: "",
+            mutable: is_mutable,
+            type_annotation: "",
+            initializer: null,
+            diagnostics: diagnostics
+        };
     }
     let mut tail: string = trim_text(substring(remainder, index, remainder.length));
     let mut type_annotation: string = "";
@@ -183,52 +217,50 @@ fn parse_inline_let_expression(expression: string) -> InlineLetParseResult {
                 if assign_index >= 0 {
                     type_annotation = trim_text(substring(tail, 0, assign_index));
                     let value_text = trim_text(substring(tail, assign_index + 1, tail.length));
-                    if value_text.length > 0 {
-                        initializer = value_text;
-                    }
-                } else {
-                    type_annotation = trim_text(tail);
-                }
+                    if value_text.length > 0 { initializer = value_text; }
+                } else { type_annotation = trim_text(tail); }
             } else if substring(tail, 0, 1) == ":" {
                 tail = trim_text(substring(tail, 1, tail.length));
                 let assign_index = index_of(tail, "=");
                 if assign_index >= 0 {
                     type_annotation = trim_text(substring(tail, 0, assign_index));
                     let value_text = trim_text(substring(tail, assign_index + 1, tail.length));
-                    if value_text.length > 0 {
-                        initializer = value_text;
-                    }
-                } else {
-                    type_annotation = trim_text(tail);
-                }
+                    if value_text.length > 0 { initializer = value_text; }
+                } else { type_annotation = trim_text(tail); }
             } else if substring(tail, 0, 1) == "=" {
                 let value_text = trim_text(substring(tail, 1, tail.length));
-                if value_text.length > 0 {
-                    initializer = value_text;
-                }
+                if value_text.length > 0 { initializer = value_text; }
             } else {
                 let value_text = trim_text(tail);
-                if value_text.length > 0 {
-                    initializer = value_text;
-                }
+                if value_text.length > 0 { initializer = value_text; }
             }
         } else {
             if substring(tail, 0, 1) == "=" {
                 let value_text = trim_text(substring(tail, 1, tail.length));
-                if value_text.length > 0 {
-                    initializer = value_text;
-                }
+                if value_text.length > 0 { initializer = value_text; }
             } else {
                 let value_text = trim_text(tail);
-                if value_text.length > 0 {
-                    initializer = value_text;
-                }
+                if value_text.length > 0 { initializer = value_text; }
             }
         }
     }
     if initializer == null {
         diagnostics.push("llvm lowering: let expression missing initializer for `" + name + "`");
-        return InlineLetParseResult { success: false, name: name, mutable: is_mutable, type_annotation: type_annotation, initializer: null, diagnostics: diagnostics };
+        return InlineLetParseResult {
+            success: false,
+            name: name,
+            mutable: is_mutable,
+            type_annotation: type_annotation,
+            initializer: null,
+            diagnostics: diagnostics
+        };
     }
-    return InlineLetParseResult { success: true, name: name, mutable: is_mutable, type_annotation: type_annotation, initializer: initializer, diagnostics: diagnostics };
+    return InlineLetParseResult {
+        success: true,
+        name: name,
+        mutable: is_mutable,
+        type_annotation: type_annotation,
+        initializer: initializer,
+        diagnostics: diagnostics
+    };
 }

--- a/compiler/src/llvm/expression_lowering/native/statement_suspension.sfn
+++ b/compiler/src/llvm/expression_lowering/native/statement_suspension.sfn
@@ -6,12 +6,12 @@
 // points, and provides future type / spawn symbol mapping for the async runtime.
 import { NativeSourceSpan } from "../../../native_ir";
 import { substring } from "../../../string_utils";
-import { LocalBinding, ParameterBinding, } from "../../types";
+import { LocalBinding, ParameterBinding } from "../../types";
 import {
     is_identifier_part_char,
     matches_keyword,
     starts_with,
-    trim_text,
+    trim_text
 } from "../../utils";
 import { format_suspension_location } from "./core";
 import { unwrap_move_wrapper } from "./statement_type_mapping";
@@ -125,7 +125,15 @@ fn collect_suspension_conflicts(keyword: string, locals: LocalBinding[], binding
                     if details.mutable {
                         let base_name = normalise_borrow_base(details.base);
                         let location = format_suspension_location(keyword, details.span, suspension_span);
-                        diagnostics.push("llvm lowering: " + keyword + " suspends while mutable borrow `" + local.name + "` of `" + base_name + "` remains active in `" + function_name + "`" + location);
+                        diagnostics.push("llvm lowering: " + keyword
+                            + " suspends while mutable borrow `"
+                            + local.name
+                            + "` of `"
+                            + base_name
+                            + "` remains active in `"
+                            + function_name
+                            + "`"
+                            + location);
                     }
                 }
             }
@@ -139,7 +147,13 @@ fn collect_suspension_conflicts(keyword: string, locals: LocalBinding[], binding
         if !binding.consumed {
             if is_mutable_borrow_annotation(binding.type_annotation) {
                 let location = format_suspension_location(keyword, binding.span, suspension_span);
-                diagnostics.push("llvm lowering: " + keyword + " suspends while mutable borrow parameter `" + binding.name + "` remains active in `" + function_name + "`" + location);
+                diagnostics.push("llvm lowering: " + keyword
+                    + " suspends while mutable borrow parameter `"
+                    + binding.name
+                    + "` remains active in `"
+                    + function_name
+                    + "`"
+                    + location);
             }
         }
         parameter_index += 1;

--- a/compiler/src/llvm/expression_lowering/native/statement_suspension.sfn
+++ b/compiler/src/llvm/expression_lowering/native/statement_suspension.sfn
@@ -4,59 +4,39 @@
 //
 // Detects when mutable borrows remain active across `await`/`yield` suspension
 // points, and provides future type / spawn symbol mapping for the async runtime.
-
 import { NativeSourceSpan } from "../../../native_ir";
-
+import { substring } from "../../../string_utils";
+import { LocalBinding, ParameterBinding, } from "../../types";
 import {
-    LocalBinding, ParameterBinding,
-} from "../../types";
-
-import {
-    trim_text, starts_with,
     is_identifier_part_char,
     matches_keyword,
+    starts_with,
+    trim_text,
 } from "../../utils";
-
-import { substring } from "../../../string_utils";
-
 import { format_suspension_location } from "./core";
 import { unwrap_move_wrapper } from "./statement_type_mapping";
-
 
 // ---------------------------------------------------------------------------
 // Keyword scanning
 // ---------------------------------------------------------------------------
-
 fn contains_keyword_outside_strings(value: string, keyword: string) -> boolean {
-    if value.length == 0 {
-        return false;
-    }
+    if value.length == 0 { return false; }
     let mut index: number = 0;
     let mut in_single: boolean = false;
     let mut in_double: boolean = false;
     let mut escape: boolean = false;
     loop {
-        if index >= value.length {
-            break;
-        }
+        if index >= value.length { break; }
         let ch = substring(value, index, index + 1);
         if in_single {
-            if escape {
-                escape = false;
-            } else if ch == "\\" {
-                escape = true;
-            } else if ch == "'" {
+            if escape { escape = false; } else if ch == "\\" { escape = true; } else if ch == "'" {
                 in_single = false;
             }
             index += 1;
             continue;
         }
         if in_double {
-            if escape {
-                escape = false;
-            } else if ch == "\\" {
-                escape = true;
-            } else if ch == "\"" {
+            if escape { escape = false; } else if ch == "\\" { escape = true; } else if ch == "\"" {
                 in_double = false;
             }
             index += 1;
@@ -80,9 +60,7 @@ fn contains_keyword_outside_strings(value: string, keyword: string) -> boolean {
                     continue;
                 }
             }
-            if matches_keyword(value, index, keyword) {
-                return true;
-            }
+            if matches_keyword(value, index, keyword) { return true; }
         }
         index += 1;
     }
@@ -90,48 +68,30 @@ fn contains_keyword_outside_strings(value: string, keyword: string) -> boolean {
 }
 
 fn find_suspension_keyword(expression: string) -> string {
-    if contains_keyword_outside_strings(expression, "await") {
-        return "await";
-    }
-    if contains_keyword_outside_strings(expression, "yield") {
-        return "yield";
-    }
+    if contains_keyword_outside_strings(expression, "await") { return "await"; }
+    if contains_keyword_outside_strings(expression, "yield") { return "yield"; }
     return "";
 }
-
 
 // ---------------------------------------------------------------------------
 // Borrow annotation helpers
 // ---------------------------------------------------------------------------
-
 fn is_mutable_borrow_annotation(annotation: string) -> boolean {
     let trimmed = trim_text(annotation);
-    if trimmed.length == 0 {
-        return false;
-    }
+    if trimmed.length == 0 { return false; }
     let normalized = unwrap_move_wrapper(trimmed);
-    if normalized.length == 0 {
-        return false;
-    }
-    if substring(normalized, 0, 1) != "&" {
-        return false;
-    }
+    if normalized.length == 0 { return false; }
+    if substring(normalized, 0, 1) != "&" { return false; }
     let remainder = trim_text(substring(normalized, 1, normalized.length));
-    if remainder.length == 0 {
-        return false;
-    }
-    if starts_with(remainder, "mut") {
-        return true;
-    }
+    if remainder.length == 0 { return false; }
+    if starts_with(remainder, "mut") { return true; }
     return false;
 }
 
 fn normalise_borrow_base(raw_base: string) -> string {
     let mut trimmed = trim_text(raw_base);
     loop {
-        if trimmed.length == 0 {
-            break;
-        }
+        if trimmed.length == 0 { break; }
         if substring(trimmed, 0, 1) == "*" {
             trimmed = trim_text(substring(trimmed, 1, trimmed.length));
             continue;
@@ -142,27 +102,21 @@ fn normalise_borrow_base(raw_base: string) -> string {
         if substring(trimmed, 0, 1) == "(" {
             if substring(trimmed, trimmed.length - 1, trimmed.length) == ")" {
                 let inner = trim_text(substring(trimmed, 1, trimmed.length - 1));
-                if inner.length > 0 {
-                    return inner;
-                }
+                if inner.length > 0 { return inner; }
             }
         }
     }
     return trimmed;
 }
 
-
 // ---------------------------------------------------------------------------
 // Suspension conflict detection
 // ---------------------------------------------------------------------------
-
 fn collect_suspension_conflicts(keyword: string, locals: LocalBinding[], bindings: ParameterBinding[], function_name: string, suspension_span: NativeSourceSpan?) -> string[] {
     let mut diagnostics: string[] = [];
     let mut index: number = 0;
     loop {
-        if index >= locals.length {
-            break;
-        }
+        if index >= locals.length { break; }
         let local = locals[index];
         if !local.consumed {
             if local.ownership != null {
@@ -180,9 +134,7 @@ fn collect_suspension_conflicts(keyword: string, locals: LocalBinding[], binding
     }
     let mut parameter_index: number = 0;
     loop {
-        if parameter_index >= bindings.length {
-            break;
-        }
+        if parameter_index >= bindings.length { break; }
         let binding = bindings[parameter_index];
         if !binding.consumed {
             if is_mutable_borrow_annotation(binding.type_annotation) {
@@ -196,46 +148,30 @@ fn collect_suspension_conflicts(keyword: string, locals: LocalBinding[], binding
 }
 
 fn detect_suspension_conflicts(expression: string?, locals: LocalBinding[], bindings: ParameterBinding[], function_name: string, suspension_span: NativeSourceSpan?) -> string[] {
-    if expression == null {
-        return [];
-    }
+    if expression == null { return []; }
     let trimmed = trim_text(expression);
-    if trimmed.length == 0 {
-        return [];
-    }
+    if trimmed.length == 0 { return []; }
     let keyword = find_suspension_keyword(trimmed);
-    if keyword.length == 0 {
-        return [];
-    }
+    if keyword.length == 0 { return []; }
     return collect_suspension_conflicts(keyword, locals, bindings, function_name, suspension_span);
 }
-
 
 // ---------------------------------------------------------------------------
 // Async ABI helpers
 // ---------------------------------------------------------------------------
-
 fn future_pointer_type_for_return_type(return_type: string) -> string {
     let trimmed = trim_text(return_type);
     let mut _if157: boolean = false;
     if trimmed.length == 0 { _if157 = true; }
     if trimmed == "void" { _if157 = true; }
-    if _if157 {
-        return "%SailfinFutureVoid*";
-    }
+    if _if157 { return "%SailfinFutureVoid*"; }
     let normalized = unwrap_move_wrapper(trimmed);
-    if normalized == "number" {
-        return "%SailfinFutureNumber*";
-    }
+    if normalized == "number" { return "%SailfinFutureNumber*"; }
     let mut _if158: boolean = false;
     if normalized == "boolean" { _if158 = true; }
     if normalized == "bool" { _if158 = true; }
-    if _if158 {
-        return "%SailfinFutureBool*";
-    }
-    if normalized == "string" {
-        return "%SailfinFutureString*";
-    }
+    if _if158 { return "%SailfinFutureBool*"; }
+    if normalized == "string" { return "%SailfinFutureString*"; }
     // Default: treat unknown/user types as an opaque pointer.
     return "%SailfinFuturePtr*";
 }
@@ -245,22 +181,14 @@ fn spawn_symbol_for_return_type(return_type: string) -> string {
     let mut _if159: boolean = false;
     if trimmed.length == 0 { _if159 = true; }
     if trimmed == "void" { _if159 = true; }
-    if _if159 {
-        return "sailfin_runtime_spawn_void";
-    }
+    if _if159 { return "sailfin_runtime_spawn_void"; }
     let normalized = unwrap_move_wrapper(trimmed);
-    if normalized == "number" {
-        return "sailfin_runtime_spawn_number";
-    }
+    if normalized == "number" { return "sailfin_runtime_spawn_number"; }
     let mut _if160: boolean = false;
     if normalized == "boolean" { _if160 = true; }
     if normalized == "bool" { _if160 = true; }
-    if _if160 {
-        return "sailfin_runtime_spawn_bool";
-    }
-    if normalized == "string" {
-        return "sailfin_runtime_spawn_string";
-    }
+    if _if160 { return "sailfin_runtime_spawn_bool"; }
+    if normalized == "string" { return "sailfin_runtime_spawn_string"; }
     return "sailfin_runtime_spawn_ptr";
 }
 
@@ -269,22 +197,14 @@ fn spawn_ctx_symbol_for_return_type(return_type: string) -> string {
     let mut _if161: boolean = false;
     if trimmed.length == 0 { _if161 = true; }
     if trimmed == "void" { _if161 = true; }
-    if _if161 {
-        return "sailfin_runtime_spawn_void_ctx";
-    }
+    if _if161 { return "sailfin_runtime_spawn_void_ctx"; }
     let normalized = unwrap_move_wrapper(trimmed);
-    if normalized == "number" {
-        return "sailfin_runtime_spawn_number_ctx";
-    }
+    if normalized == "number" { return "sailfin_runtime_spawn_number_ctx"; }
     let mut _if162: boolean = false;
     if normalized == "boolean" { _if162 = true; }
     if normalized == "bool" { _if162 = true; }
-    if _if162 {
-        return "sailfin_runtime_spawn_bool_ctx";
-    }
-    if normalized == "string" {
-        return "sailfin_runtime_spawn_string_ctx";
-    }
+    if _if162 { return "sailfin_runtime_spawn_bool_ctx"; }
+    if normalized == "string" { return "sailfin_runtime_spawn_string_ctx"; }
     return "sailfin_runtime_spawn_ptr_ctx";
 }
 

--- a/compiler/src/llvm/expression_lowering/native/statement_type_mapping.sfn
+++ b/compiler/src/llvm/expression_lowering/native/statement_type_mapping.sfn
@@ -6,38 +6,29 @@
 // reference types, array types, union types, raw pointers, etc.) to their LLVM
 // IR type representations.  Used by statement lowering for return types,
 // parameter types, and local variable types.
-
-import { TypeContext } from "../../types";
-
-import {
-    trim_text, starts_with,
-    join_with_separator,
-    index_of,
-} from "../../utils";
-
-import {
-    map_type_annotation,
-    ends_with_pointer_suffix, strip_pointer_suffix,
-    annotation_is_array, layout_annotation_represents_user_value,
-} from "../../type_mapping";
-
-import {
-    find_struct_info_by_name,
-    find_interface_info_by_name,
-} from "../../type_context_queries";
-
 import { substring } from "../../../string_utils";
-
+import { find_interface_info_by_name, find_struct_info_by_name, } from "../../type_context_queries";
+import {
+    annotation_is_array,
+    ends_with_pointer_suffix,
+    layout_annotation_represents_user_value,
+    map_type_annotation,
+    strip_pointer_suffix,
+} from "../../type_mapping";
+import { TypeContext } from "../../types";
+import {
+    index_of,
+    join_with_separator,
+    starts_with,
+    trim_text,
+} from "../../utils";
 
 // ---------------------------------------------------------------------------
 // Ownership wrapper stripping
 // ---------------------------------------------------------------------------
-
 fn unwrap_move_wrapper(annotation: string) -> string {
     let trimmed = trim_text(annotation);
-    if trimmed.length == 0 {
-        return trimmed;
-    }
+    if trimmed.length == 0 { return trimmed; }
     let mut _if152: boolean = false;
     if starts_with(trimmed, "Affine<") { _if152 = true; }
     if starts_with(trimmed, "Linear<") { _if152 = true; }
@@ -53,33 +44,23 @@ fn unwrap_move_wrapper(annotation: string) -> string {
     return trimmed;
 }
 
-
 // ---------------------------------------------------------------------------
 // Primitive / named type helpers
 // ---------------------------------------------------------------------------
-
 fn map_struct_type_annotation(context: TypeContext, annotation: string) -> string {
     let info = find_struct_info_by_name(context, annotation);
-    if info != null {
-        return info.llvm_name;
-    }
+    if info != null { return info.llvm_name; }
     return "";
 }
 
 fn map_enum_type_annotation(context: TypeContext, annotation: string) -> string {
     let trimmed = trim_text(annotation);
-    if trimmed.length == 0 {
-        return "";
-    }
+    if trimmed.length == 0 { return ""; }
     let mut index: number = 0;
     loop {
-        if index >= context.enums.length {
-            break;
-        }
+        if index >= context.enums.length { break; }
         let enum_info = context.enums[index];
-        if enum_info.name == trimmed {
-            return enum_info.llvm_name;
-        }
+        if enum_info.name == trimmed { return enum_info.llvm_name; }
         index += 1;
     }
     return "";
@@ -87,78 +68,48 @@ fn map_enum_type_annotation(context: TypeContext, annotation: string) -> string 
 
 fn map_interface_type_annotation(context: TypeContext, annotation: string) -> string {
     let trimmed = trim_text(annotation);
-    if trimmed.length == 0 {
-        return "";
-    }
+    if trimmed.length == 0 { return ""; }
     let interface_info = find_interface_info_by_name(context, trimmed);
-    if interface_info != null {
-        return interface_info.llvm_name;
-    }
+    if interface_info != null { return interface_info.llvm_name; }
     return "";
 }
 
 fn map_primitive_type(context: TypeContext, annotation: string) -> string {
-    if annotation == "number" {
-        return "double";
-    }
+    if annotation == "number" { return "double"; }
     let mut _if149: boolean = false;
     if annotation == "boolean" { _if149 = true; }
     if annotation == "bool" { _if149 = true; }
-    if _if149 {
-        return "i1";
-    }
-    if annotation == "usize" {
-        return "i64";
-    }
+    if _if149 { return "i1"; }
+    if annotation == "usize" { return "i64"; }
     let mut _if150: boolean = false;
     if annotation == "int" { _if150 = true; }
     if annotation == "i64" { _if150 = true; }
-    if _if150 {
-        return "i64";
-    }
-    if annotation == "i32" {
-        return "i32";
-    }
-    if annotation == "u8" {
-        return "i8";
-    }
+    if _if150 { return "i64"; }
+    if annotation == "i32" { return "i32"; }
+    if annotation == "u8" { return "i8"; }
     let struct_type = map_struct_type_annotation(context, annotation);
-    if struct_type.length > 0 {
-        return struct_type;
-    }
+    if struct_type.length > 0 { return struct_type; }
     let enum_type = map_enum_type_annotation(context, annotation);
-    if enum_type.length > 0 {
-        return enum_type;
-    }
+    if enum_type.length > 0 { return enum_type; }
     let interface_type = map_interface_type_annotation(context, annotation);
-    if interface_type.length > 0 {
-        return interface_type;
-    }
-    if annotation == "string" {
-        return "i8*";
-    }
+    if interface_type.length > 0 { return interface_type; }
+    if annotation == "string" { return "i8*"; }
     return "";
 }
-
 
 // ---------------------------------------------------------------------------
 // Optional types
 // ---------------------------------------------------------------------------
-
 fn map_optional_type(context: TypeContext, annotation: string) -> string {
     let trimmed = trim_text(annotation);
-    if trimmed.length == 0 {
-        return "";
-    }
+    if trimmed.length == 0 { return ""; }
     // Check if this is an optional type (ends with ?)
     if substring(trimmed, trimmed.length - 1, trimmed.length) != "?" {
         return "";
     }
     // Extract the inner type (everything before the ?)
     let inner_annotation = trim_text(substring(trimmed, 0, trimmed.length - 1));
-    if inner_annotation.length == 0 {
-        return "";
-    }
+    if inner_annotation.length == 0 { return ""; }
     // For optional types, try the context-aware mapping first for structs/enums
     let struct_type = map_struct_type_annotation(context, inner_annotation);
     if struct_type.length > 0 {
@@ -166,21 +117,15 @@ fn map_optional_type(context: TypeContext, annotation: string) -> string {
         return struct_type + "*";
     }
     let enum_type = map_enum_type_annotation(context, inner_annotation);
-    if enum_type.length > 0 {
-        return enum_type + "*";
-    }
+    if enum_type.length > 0 { return enum_type + "*"; }
     let interface_type = map_interface_type_annotation(context, inner_annotation);
-    if interface_type.length > 0 {
-        return interface_type + "*";
-    }
+    if interface_type.length > 0 { return interface_type + "*"; }
     // For primitive types and others, use the simple mapper
     let inner_type = map_type_annotation(inner_annotation);
     let mut _if151: boolean = false;
     if inner_type.length == 0 { _if151 = true; }
     if inner_type == "void" { _if151 = true; }
-    if _if151 {
-        return "i8*";
-    }
+    if _if151 { return "i8*"; }
     // If already a pointer, return as-is, otherwise make it a pointer
     if substring(inner_type, inner_type.length - 1, inner_type.length) == "*" {
         return inner_type;
@@ -188,72 +133,48 @@ fn map_optional_type(context: TypeContext, annotation: string) -> string {
     return inner_type + "*";
 }
 
-
 // ---------------------------------------------------------------------------
 // Reference types
 // ---------------------------------------------------------------------------
-
 fn map_reference_inner_type(context: TypeContext, annotation: string) -> string {
     let trimmed = trim_text(annotation);
-    if trimmed.length == 0 {
-        return "";
-    }
+    if trimmed.length == 0 { return ""; }
     let nested_reference = map_reference_type(context, trimmed);
-    if nested_reference.length > 0 {
-        return nested_reference;
-    }
+    if nested_reference.length > 0 { return nested_reference; }
     let array_type = map_array_pointer_type(context, trimmed);
-    if array_type.length > 0 {
-        return array_type;
-    }
+    if array_type.length > 0 { return array_type; }
     return map_primitive_type(context, trimmed);
 }
 
 fn map_reference_type(context: TypeContext, annotation: string) -> string {
     let trimmed = trim_text(annotation);
-    if trimmed.length == 0 {
-        return "";
-    }
-    if !starts_with(trimmed, "&") {
-        return "";
-    }
-    if starts_with(trimmed, "&&") {
-        return "";
-    }
+    if trimmed.length == 0 { return ""; }
+    if !starts_with(trimmed, "&") { return ""; }
+    if starts_with(trimmed, "&&") { return ""; }
     let mut remainder: string = trim_text(substring(trimmed, 1, trimmed.length));
     if starts_with(remainder, "mut") {
         let after_mut = substring(remainder, 3, remainder.length);
         remainder = trim_text(after_mut);
     }
-    if remainder.length == 0 {
-        return "";
-    }
+    if remainder.length == 0 { return ""; }
     if substring(remainder, 0, 1) == "(" {
         if substring(remainder, remainder.length - 1, remainder.length) == ")" {
             remainder = trim_text(substring(remainder, 1, remainder.length - 1));
         }
     }
     let inner_type = map_reference_inner_type(context, remainder);
-    if inner_type.length == 0 {
-        return "";
-    }
+    if inner_type.length == 0 { return ""; }
     return inner_type + "*";
 }
-
 
 // ---------------------------------------------------------------------------
 // Array pointer types
 // ---------------------------------------------------------------------------
-
 fn map_array_pointer_type(context: TypeContext, annotation: string) -> string {
     let trimmed = trim_text(annotation);
-    if trimmed.length < 3 {
-        return "";
-    }
+    if trimmed.length < 3 { return ""; }
     let suffix = substring(trimmed, trimmed.length - 2, trimmed.length);
-    if suffix != "[]" {
-        return "";
-    }
+    if suffix != "[]" { return ""; }
     let element_annotation = trim_text(substring(trimmed, 0, trimmed.length - 2));
     let element_type = map_primitive_type(context, element_annotation);
     if element_type.length == 0 {
@@ -276,11 +197,9 @@ fn map_array_pointer_type(context: TypeContext, annotation: string) -> string {
     return "{ " + element_type + "*, i64 }*";
 }
 
-
 // ---------------------------------------------------------------------------
 // Union types
 // ---------------------------------------------------------------------------
-
 fn find_top_level_union_separator(text: string) -> number {
     let mut paren_depth: number = 0;
     let mut brace_depth: number = 0;
@@ -291,35 +210,21 @@ fn find_top_level_union_separator(text: string) -> number {
     let mut escape: boolean = false;
     let mut index: number = 0;
     loop {
-        if index >= text.length {
-            break;
-        }
+        if index >= text.length { break; }
         let ch = substring(text, index, index + 1);
         if in_double {
-            if escape {
-                escape = false;
-            } else {
-                if ch == "\\" {
-                    escape = true;
-                } else {
-                    if ch == "\"" {
-                        in_double = false;
-                    }
+            if escape { escape = false; } else {
+                if ch == "\\" { escape = true; } else {
+                    if ch == "\"" { in_double = false; }
                 }
             }
             index += 1;
             continue;
         }
         if in_single {
-            if escape {
-                escape = false;
-            } else {
-                if ch == "\\" {
-                    escape = true;
-                } else {
-                    if ch == "'" {
-                        in_single = false;
-                    }
+            if escape { escape = false; } else {
+                if ch == "\\" { escape = true; } else {
+                    if ch == "'" { in_single = false; }
                 }
             }
             index += 1;
@@ -343,9 +248,7 @@ fn find_top_level_union_separator(text: string) -> number {
             continue;
         }
         if ch == ")" {
-            if paren_depth > 0 {
-                paren_depth -= 1;
-            }
+            if paren_depth > 0 { paren_depth -= 1; }
             index += 1;
             continue;
         }
@@ -355,9 +258,7 @@ fn find_top_level_union_separator(text: string) -> number {
             continue;
         }
         if ch == "}" {
-            if brace_depth > 0 {
-                brace_depth -= 1;
-            }
+            if brace_depth > 0 { brace_depth -= 1; }
             index += 1;
             continue;
         }
@@ -367,9 +268,7 @@ fn find_top_level_union_separator(text: string) -> number {
             continue;
         }
         if ch == "]" {
-            if bracket_depth > 0 {
-                bracket_depth -= 1;
-            }
+            if bracket_depth > 0 { bracket_depth -= 1; }
             index += 1;
             continue;
         }
@@ -379,9 +278,7 @@ fn find_top_level_union_separator(text: string) -> number {
             continue;
         }
         if ch == ">" {
-            if angle_depth > 0 {
-                angle_depth -= 1;
-            }
+            if angle_depth > 0 { angle_depth -= 1; }
             index += 1;
             continue;
         }
@@ -390,9 +287,7 @@ fn find_top_level_union_separator(text: string) -> number {
             if brace_depth == 0 {
                 if bracket_depth == 0 {
                     if angle_depth == 0 {
-                        if ch == "|" {
-                            return index;
-                        }
+                        if ch == "|" { return index; }
                     }
                 }
             }
@@ -409,15 +304,11 @@ fn split_union_annotations(text: string) -> string[] {
         let index = find_top_level_union_separator(remaining);
         if index < 0 {
             let tail = trim_text(remaining);
-            if tail.length > 0 {
-                result.push(tail);
-            }
+            if tail.length > 0 { result.push(tail); }
             break;
         }
         let left = trim_text(substring(remaining, 0, index));
-        if left.length > 0 {
-            result.push(left);
-        }
+        if left.length > 0 { result.push(left); }
         remaining = trim_text(substring(remaining, index + 1, remaining.length));
     }
     return result;
@@ -425,38 +316,26 @@ fn split_union_annotations(text: string) -> string[] {
 
 fn is_union_annotation(annotation: string) -> boolean {
     let trimmed = trim_text(annotation);
-    if trimmed.length == 0 {
-        return false;
-    }
+    if trimmed.length == 0 { return false; }
     return find_top_level_union_separator(trimmed) >= 0;
 }
 
 fn map_union_type(context: TypeContext, annotation: string) -> string {
     let normalized = unwrap_move_wrapper(trim_text(annotation));
-    if !is_union_annotation(normalized) {
-        return "";
-    }
+    if !is_union_annotation(normalized) { return ""; }
     let parts = split_union_annotations(normalized);
-    if parts.length < 2 {
-        return "";
-    }
+    if parts.length < 2 { return ""; }
     let mut llvm_parts: string[] = [];
     let mut index: number = 0;
     loop {
-        if index >= parts.length {
-            break;
-        }
+        if index >= parts.length { break; }
         let part = trim_text(parts[index]);
-        if part.length == 0 {
-            return "";
-        }
+        if part.length == 0 { return ""; }
         let mapped = map_type_annotation(part);
         let mut _if153: boolean = false;
         if mapped.length == 0 { _if153 = true; }
         if mapped == "void" { _if153 = true; }
-        if _if153 {
-            return "";
-        }
+        if _if153 { return ""; }
         llvm_parts.push(mapped);
         index += 1;
     }
@@ -465,11 +344,9 @@ fn map_union_type(context: TypeContext, annotation: string) -> string {
     return "{ i32, " + join_with_separator(llvm_parts, ", ") + " }";
 }
 
-
 // ---------------------------------------------------------------------------
 // Core type-mapping dispatch (shared by return / parameter / local mappers)
 // ---------------------------------------------------------------------------
-
 // Internal: maps a normalised annotation using context-aware lookups in the
 // standard precedence order (union → optional → reference → array → primitive).
 // Returns "" when the annotation cannot be resolved.
@@ -483,88 +360,60 @@ fn _map_type_core(context: TypeContext, normalized: string) -> string {
         let mut _if_raw: boolean = false;
         if remainder == "opaque" { _if_raw = true; }
         if remainder.length == 0 { _if_raw = true; }
-        if _if_raw {
-            return "i8*";
-        }
+        if _if_raw { return "i8*"; }
         let inner = _map_type_core(context, unwrap_move_wrapper(remainder));
         if inner.length > 0 {
-            if ends_with_pointer_suffix(inner) {
-                return inner;
-            }
+            if ends_with_pointer_suffix(inner) { return inner; }
             return inner + "*";
         }
         return "i8*";
     }
 
     let union_type = map_union_type(context, normalized);
-    if union_type.length > 0 {
-        return union_type;
-    }
+    if union_type.length > 0 { return union_type; }
     let optional_type = map_optional_type(context, normalized);
-    if optional_type.length > 0 {
-        return optional_type;
-    }
+    if optional_type.length > 0 { return optional_type; }
     let reference_type = map_reference_type(context, normalized);
-    if reference_type.length > 0 {
-        return reference_type;
-    }
+    if reference_type.length > 0 { return reference_type; }
     let array_type = map_array_pointer_type(context, normalized);
-    if array_type.length > 0 {
-        return array_type;
-    }
+    if array_type.length > 0 { return array_type; }
     let primitive_type = map_primitive_type(context, normalized);
-    if primitive_type.length > 0 {
-        return primitive_type;
-    }
+    if primitive_type.length > 0 { return primitive_type; }
     return "";
 }
-
 
 // ---------------------------------------------------------------------------
 // Public type mappers
 // ---------------------------------------------------------------------------
-
 fn map_return_type(context: TypeContext, return_type: string) -> string {
     let trimmed = trim_text(return_type);
     let mut _if154: boolean = false;
     if trimmed.length == 0 { _if154 = true; }
     if trimmed == "void" { _if154 = true; }
-    if _if154 {
-        return "void";
-    }
+    if _if154 { return "void"; }
     let normalized = unwrap_move_wrapper(trimmed);
     let core = _map_type_core(context, normalized);
-    if core.length > 0 {
-        return core;
-    }
+    if core.length > 0 { return core; }
     // Fallback to opaque pointer for unrecognised return types (`any`, user structs, etc.)
     return "i8*";
 }
 
 fn map_parameter_type(context: TypeContext, parameter_type: string) -> string {
     let trimmed = trim_text(parameter_type);
-    if trimmed.length == 0 {
-        return "double";
-    }
+    if trimmed.length == 0 { return "double"; }
     let normalized = unwrap_move_wrapper(trimmed);
     let core = _map_type_core(context, normalized);
-    if core.length > 0 {
-        return core;
-    }
+    if core.length > 0 { return core; }
     // Fallback to generic pointer for unresolved types (e.g., imported structs/enums not in type context)
     return "i8*";
 }
 
 fn map_local_type(context: TypeContext, type_annotation: string) -> string {
     let trimmed = trim_text(type_annotation);
-    if trimmed.length == 0 {
-        return "double";
-    }
+    if trimmed.length == 0 { return "double"; }
     let normalized = unwrap_move_wrapper(trimmed);
     let core = _map_type_core(context, normalized);
-    if core.length > 0 {
-        return core;
-    }
+    if core.length > 0 { return core; }
     // Fallback to generic pointer for unresolved types (e.g., imported structs/enums not in type context)
     return "i8*";
 }

--- a/compiler/src/llvm/expression_lowering/native/statement_type_mapping.sfn
+++ b/compiler/src/llvm/expression_lowering/native/statement_type_mapping.sfn
@@ -7,20 +7,20 @@
 // IR type representations.  Used by statement lowering for return types,
 // parameter types, and local variable types.
 import { substring } from "../../../string_utils";
-import { find_interface_info_by_name, find_struct_info_by_name, } from "../../type_context_queries";
+import { find_interface_info_by_name, find_struct_info_by_name } from "../../type_context_queries";
 import {
     annotation_is_array,
     ends_with_pointer_suffix,
     layout_annotation_represents_user_value,
     map_type_annotation,
-    strip_pointer_suffix,
+    strip_pointer_suffix
 } from "../../type_mapping";
 import { TypeContext } from "../../types";
 import {
     index_of,
     join_with_separator,
     starts_with,
-    trim_text,
+    trim_text
 } from "../../utils";
 
 // ---------------------------------------------------------------------------

--- a/compiler/src/llvm/expression_lowering/splitting.sfn
+++ b/compiler/src/llvm/expression_lowering/splitting.sfn
@@ -6,7 +6,7 @@
 // parentheses, brackets, braces, and string literals. Used to parse array
 // elements, function arguments, and other comma-separated constructs.
 import { char_at } from "../../string_utils";
-import { append_string, trim_text, } from "../utils";
+import { append_string, trim_text } from "../utils";
 
 fn split_array_elements(text: string) -> string[] {
     let trimmed = trim_text(text);

--- a/compiler/src/llvm/expression_lowering/splitting.sfn
+++ b/compiler/src/llvm/expression_lowering/splitting.sfn
@@ -5,19 +5,12 @@
 // Provides delimiter-aware splitting of expression text, handling nested
 // parentheses, brackets, braces, and string literals. Used to parse array
 // elements, function arguments, and other comma-separated constructs.
-
 import { char_at } from "../../string_utils";
-
-import {
-    trim_text,
-    append_string,
-} from "../utils";
+import { append_string, trim_text, } from "../utils";
 
 fn split_array_elements(text: string) -> string[] {
     let trimmed = trim_text(text);
-    if trimmed.length == 0 {
-        return [];
-    }
+    if trimmed.length == 0 { return []; }
     let mut entries: string[] = [];
     let mut current: string = "";
     let mut paren_depth: number = 0;
@@ -28,17 +21,11 @@ fn split_array_elements(text: string) -> string[] {
     let mut in_double: boolean = false;
     let mut escape: boolean = false;
     loop {
-        if index >= text.length {
-            break;
-        }
+        if index >= text.length { break; }
         let ch = char_at(text, index);
         if in_double {
             current = current + ch;
-            if escape {
-                escape = false;
-            } else if ch == "\\" {
-                escape = true;
-            } else if ch == "\"" {
+            if escape { escape = false; } else if ch == "\\" { escape = true; } else if ch == "\"" {
                 in_double = false;
             }
             index += 1;
@@ -46,11 +33,7 @@ fn split_array_elements(text: string) -> string[] {
         }
         if in_single {
             current = current + ch;
-            if escape {
-                escape = false;
-            } else if ch == "\\" {
-                escape = true;
-            } else if ch == "'" {
+            if escape { escape = false; } else if ch == "\\" { escape = true; } else if ch == "'" {
                 in_single = false;
             }
             index += 1;
@@ -68,59 +51,37 @@ fn split_array_elements(text: string) -> string[] {
             index += 1;
             continue;
         }
-        if ch == "(" {
-            paren_depth += 1;
-        } else if ch == ")" {
-            if paren_depth > 0 {
-                paren_depth -= 1;
-            }
-        } else if ch == "[" {
-            bracket_depth += 1;
-        } else if ch == "]" {
-            if bracket_depth > 0 {
-                bracket_depth -= 1;
-            }
-        } else if ch == "{" {
-            brace_depth += 1;
-        } else if ch == "}" {
-            if brace_depth > 0 {
-                brace_depth -= 1;
-            }
+        if ch == "(" { paren_depth += 1; } else if ch == ")" {
+            if paren_depth > 0 { paren_depth -= 1; }
+        } else if ch == "[" { bracket_depth += 1; } else if ch == "]" {
+            if bracket_depth > 0 { bracket_depth -= 1; }
+        } else if ch == "{" { brace_depth += 1; } else if ch == "}" {
+            if brace_depth > 0 { brace_depth -= 1; }
         }
 
         let mut _if166: boolean = false;
         if ch == "," {
             if paren_depth == 0 {
                 if bracket_depth == 0 {
-                    if brace_depth == 0 {
-                        _if166 = true;
-                    }
+                    if brace_depth == 0 { _if166 = true; }
                 }
             }
         }
         if _if166 {
             entries.push(trim_text(current));
             current = "";
-        } else {
-            current = current + ch;
-        }
+        } else { current = current + ch; }
         index += 1;
     }
 
-    if current.length > 0 {
-        entries.push(trim_text(current));
-    }
+    if current.length > 0 { entries.push(trim_text(current)); }
 
     let mut filtered: string[] = [];
     index = 0;
     loop {
-        if index >= entries.length {
-            break;
-        }
+        if index >= entries.length { break; }
         let entry = trim_text(entries[index]);
-        if entry.length > 0 {
-            filtered.push(entry);
-        }
+        if entry.length > 0 { filtered.push(entry); }
         index += 1;
     }
     return filtered;

--- a/compiler/src/llvm/expressions.sfn
+++ b/compiler/src/llvm/expressions.sfn
@@ -9,7 +9,6 @@
 //   - expressions_helpers.sfn:   Identifier helpers, type helpers, operand formatting
 //   - expressions_operators.sfn: Operator finding, range/union separators
 //   - expressions_parsing.sfn:   Expression parsing (member access, index, assignment, etc.)
-
 // --- Binding lookup and mutation ---
 export {
     find_local_binding,

--- a/compiler/src/llvm/expressions.sfn
+++ b/compiler/src/llvm/expressions.sfn
@@ -15,7 +15,7 @@ export {
     find_parameter_binding,
     mark_parameter_consumed,
     mark_local_consumed,
-    reset_local_consumption,
+    reset_local_consumption
 } from "./expressions_bindings";
 
 // --- Literal detection ---
@@ -30,7 +30,7 @@ export {
     is_string_literal,
     is_character_literal,
     get_character_literal_value,
-    matches_case_insensitive,
+    matches_case_insensitive
 } from "./expressions_literals";
 
 // --- Identifier helpers, type helpers, and formatting ---
@@ -45,7 +45,7 @@ export {
     default_return_literal,
     format_temp_name,
     format_local_pointer_name,
-    format_typed_operand,
+    format_typed_operand
 } from "./expressions_helpers";
 
 // --- Operator finding and separators ---
@@ -54,7 +54,7 @@ export {
     is_binary_minus,
     is_binary_star,
     find_top_level_range_separator,
-    find_top_level_union_separator,
+    find_top_level_union_separator
 } from "./expressions_operators";
 
 // --- Expression parsing ---
@@ -65,5 +65,5 @@ export {
     parse_inline_let_expression,
     parse_ternary_expression,
     parse_raw_address_expression,
-    parse_cast_expression,
+    parse_cast_expression
 } from "./expressions_parsing";

--- a/compiler/src/llvm/expressions_bindings.sfn
+++ b/compiler/src/llvm/expressions_bindings.sfn
@@ -1,26 +1,18 @@
 // compiler/src/llvm/expressions_bindings.sfn
 //
 // Local and parameter binding lookup and mutation helpers.
-
-import {
-    LocalBinding, ParameterBinding,
-} from "./types";
+import { LocalBinding, ParameterBinding, } from "./types";
 
 // =============================================================================
 // Local and Parameter Binding Lookup
 // =============================================================================
-
 fn find_local_binding(locals: LocalBinding[], name: string) -> LocalBinding? {
     let mut index: number = locals.length;
     loop {
-        if index <= 0 {
-            break;
-        }
+        if index <= 0 { break; }
         index -= 1;
         let entry = locals[index];
-        if entry.name == name {
-            return entry;
-        }
+        if entry.name == name { return entry; }
     }
     return null;
 }
@@ -28,13 +20,9 @@ fn find_local_binding(locals: LocalBinding[], name: string) -> LocalBinding? {
 fn find_parameter_binding(bindings: ParameterBinding[], name: string) -> ParameterBinding? {
     let mut index: number = 0;
     loop {
-        if index >= bindings.length {
-            break;
-        }
+        if index >= bindings.length { break; }
         let binding = bindings[index];
-        if binding.name == name {
-            return binding;
-        }
+        if binding.name == name { return binding; }
         index += 1;
     }
     return null;
@@ -44,9 +32,7 @@ fn mark_parameter_consumed(bindings: ParameterBinding[], name: string) -> Parame
     let mut result: ParameterBinding[] = [];
     let mut index: number = 0;
     loop {
-        if index >= bindings.length {
-            break;
-        }
+        if index >= bindings.length { break; }
         let binding = bindings[index];
         if binding.name == name {
             let updated = ParameterBinding {
@@ -58,9 +44,7 @@ fn mark_parameter_consumed(bindings: ParameterBinding[], name: string) -> Parame
                 span: binding.span,
             };
             result.push(updated);
-        } else {
-            result.push(binding);
-        }
+        } else { result.push(binding); }
         index += 1;
     }
     return result;
@@ -70,9 +54,7 @@ fn mark_local_consumed(locals: LocalBinding[], name: string) -> LocalBinding[] {
     let mut result: LocalBinding[] = [];
     let mut index: number = 0;
     loop {
-        if index >= locals.length {
-            break;
-        }
+        if index >= locals.length { break; }
         let entry = locals[index];
         if entry.name == name {
             let updated = LocalBinding {
@@ -86,9 +68,7 @@ fn mark_local_consumed(locals: LocalBinding[], name: string) -> LocalBinding[] {
                 scope_depth: entry.scope_depth,
             };
             result.push(updated);
-        } else {
-            result.push(entry);
-        }
+        } else { result.push(entry); }
         index += 1;
     }
     return result;
@@ -98,9 +78,7 @@ fn reset_local_consumption(locals: LocalBinding[], name: string) -> LocalBinding
     let mut result: LocalBinding[] = [];
     let mut index: number = 0;
     loop {
-        if index >= locals.length {
-            break;
-        }
+        if index >= locals.length { break; }
         let entry = locals[index];
         if entry.name == name {
             let updated = LocalBinding {
@@ -114,9 +92,7 @@ fn reset_local_consumption(locals: LocalBinding[], name: string) -> LocalBinding
                 scope_depth: entry.scope_depth,
             };
             result.push(updated);
-        } else {
-            result.push(entry);
-        }
+        } else { result.push(entry); }
         index += 1;
     }
     return result;

--- a/compiler/src/llvm/expressions_bindings.sfn
+++ b/compiler/src/llvm/expressions_bindings.sfn
@@ -1,7 +1,7 @@
 // compiler/src/llvm/expressions_bindings.sfn
 //
 // Local and parameter binding lookup and mutation helpers.
-import { LocalBinding, ParameterBinding, } from "./types";
+import { LocalBinding, ParameterBinding } from "./types";
 
 // =============================================================================
 // Local and Parameter Binding Lookup
@@ -41,7 +41,7 @@ fn mark_parameter_consumed(bindings: ParameterBinding[], name: string) -> Parame
                 llvm_type: binding.llvm_type,
                 type_annotation: binding.type_annotation,
                 consumed: true,
-                span: binding.span,
+                span: binding.span
             };
             result.push(updated);
         } else { result.push(binding); }
@@ -65,7 +65,7 @@ fn mark_local_consumed(locals: LocalBinding[], name: string) -> LocalBinding[] {
                 ownership: entry.ownership,
                 consumed: true,
                 scope_id: entry.scope_id,
-                scope_depth: entry.scope_depth,
+                scope_depth: entry.scope_depth
             };
             result.push(updated);
         } else { result.push(entry); }
@@ -89,7 +89,7 @@ fn reset_local_consumption(locals: LocalBinding[], name: string) -> LocalBinding
                 ownership: entry.ownership,
                 consumed: false,
                 scope_id: entry.scope_id,
-                scope_depth: entry.scope_depth,
+                scope_depth: entry.scope_depth
             };
             result.push(updated);
         } else { result.push(entry); }

--- a/compiler/src/llvm/expressions_helpers.sfn
+++ b/compiler/src/llvm/expressions_helpers.sfn
@@ -1,30 +1,27 @@
 // compiler/src/llvm/expressions_helpers.sfn
 //
 // Identifier helpers, string manipulation, type helpers, and LLVM operand formatting.
-
-import { substring, char_at } from "../string_utils";
+import { char_at, substring } from "../string_utils";
 import { LLVMOperand } from "./types";
-import { trim_text, starts_with, sanitize_symbol, number_to_string } from "./utils";
+import {
+    number_to_string,
+    sanitize_symbol,
+    starts_with,
+    trim_text
+} from "./utils";
 
 // =============================================================================
 // Identifier and Expression Helpers
 // =============================================================================
-
 fn is_simple_identifier(value: string) -> boolean {
     let trimmed = trim_text(value);
-    if trimmed.length == 0 {
-        return false;
-    }
+    if trimmed.length == 0 { return false; }
     let first = substring(trimmed, 0, 1);
     if first >= "0" {
-        if first <= "9" {
-            return false;
-        }
+        if first <= "9" { return false; }
     }
     let sanitized = sanitize_symbol(trimmed);
-    if sanitized != trimmed {
-        return false;
-    }
+    if sanitized != trimmed { return false; }
     return true;
 }
 
@@ -32,33 +29,25 @@ fn is_effect_delimiter(ch: string) -> boolean {
     let mut _if171: boolean = false;
     if ch == "!" { _if171 = true; }
     if ch == "?" { _if171 = true; }
-    if _if171 {
-        return true;
-    }
+    if _if171 { return true; }
     return false;
 }
 
 fn strip_enclosing_parentheses(expression: string) -> string {
     let trimmed = trim_text(expression);
-    if trimmed.length < 2 {
-        return trimmed;
-    }
+    if trimmed.length < 2 { return trimmed; }
     let mut _if172: boolean = false;
     if substring(trimmed, 0, 1) != "(" { _if172 = true; }
-    if substring(trimmed, trimmed.length - 1, trimmed.length) != ")" { _if172 = true; }
-    if _if172 {
-        return trimmed;
+    if substring(trimmed, trimmed.length - 1, trimmed.length) != ")" {
+        _if172 = true;
     }
+    if _if172 { return trimmed; }
     let mut depth: number = 0;
     let mut index: number = 0;
     loop {
-        if index >= trimmed.length {
-            break;
-        }
+        if index >= trimmed.length { break; }
         let ch = char_at(trimmed, index);
-        if ch == "(" {
-            depth += 1;
-        } else if ch == ")" {
+        if ch == "(" { depth += 1; } else if ch == ")" {
             depth -= 1;
             if depth == 0 {
                 if index == trimmed.length - 1 {
@@ -75,9 +64,7 @@ fn strip_enclosing_parentheses(expression: string) -> string {
 
 fn strip_mut_prefix(value: string) -> string {
     let trimmed = trim_text(value);
-    if trimmed.length < 4 {
-        return trimmed;
-    }
+    if trimmed.length < 4 { return trimmed; }
     let prefix = substring(trimmed, 0, 4);
     if prefix == "mut " {
         return trim_text(substring(trimmed, 4, trimmed.length));
@@ -86,22 +73,14 @@ fn strip_mut_prefix(value: string) -> string {
 }
 
 fn contains_text(haystack: string, needle: string) -> boolean {
-    if needle.length == 0 {
-        return true;
-    }
-    if haystack.length < needle.length {
-        return false;
-    }
+    if needle.length == 0 { return true; }
+    if haystack.length < needle.length { return false; }
     let _search_limit = haystack.length - needle.length;
     let mut index: number = 0;
     loop {
-        if index > _search_limit {
-            break;
-        }
+        if index > _search_limit { break; }
         let candidate = substring(haystack, index, index + needle.length);
-        if candidate == needle {
-            return true;
-        }
+        if candidate == needle { return true; }
         index += 1;
     }
     return false;
@@ -110,12 +89,9 @@ fn contains_text(haystack: string, needle: string) -> boolean {
 // =============================================================================
 // Type Helpers
 // =============================================================================
-
 fn ends_with_pointer_suffix(value: string) -> boolean {
     let trimmed = trim_text(value);
-    if trimmed.length == 0 {
-        return false;
-    }
+    if trimmed.length == 0 { return false; }
     // Fast-path: well-known primitives that are never pointers.
     // Avoids character-level indexing which is miscompiled by older seeds.
     let mut _if175: boolean = false;
@@ -127,9 +103,7 @@ fn ends_with_pointer_suffix(value: string) -> boolean {
     if trimmed == "i64" { _if175 = true; }
     if trimmed == "void" { _if175 = true; }
     if trimmed == "float" { _if175 = true; }
-    if _if175 {
-        return false;
-    }
+    if _if175 { return false; }
     // Fast-path: well-known pointer types.
     let mut _if176: boolean = false;
     if trimmed == "i8*" { _if176 = true; }
@@ -138,9 +112,7 @@ fn ends_with_pointer_suffix(value: string) -> boolean {
     if trimmed == "i64*" { _if176 = true; }
     if trimmed == "double*" { _if176 = true; }
     if trimmed == "i1*" { _if176 = true; }
-    if _if176 {
-        return true;
-    }
+    if _if176 { return true; }
     // Fast-path: aggregate pointer types starting with { or % and ending with *.
     // Use starts_with (safe) instead of character indexing.
     let mut _if177: boolean = false;
@@ -148,9 +120,7 @@ fn ends_with_pointer_suffix(value: string) -> boolean {
     if starts_with(trimmed, "%") { _if177 = true; }
     if _if177 {
         let without_star = substring(trimmed, 0, trimmed.length - 1);
-        if without_star + "*" == trimmed {
-            return true;
-        }
+        if without_star + "*" == trimmed { return true; }
         return false;
     }
     return substring(trimmed, trimmed.length - 1, trimmed.length) == "*";
@@ -161,73 +131,40 @@ fn is_copy_type(type_annotation: string, llvm_type: string) -> boolean {
     let mut _if173: boolean = false;
     if starts_with(trimmed, "Affine<") { _if173 = true; }
     if starts_with(trimmed, "Linear<") { _if173 = true; }
-    if _if173 {
-        return false;
-    }
+    if _if173 { return false; }
     let mut _if174: boolean = false;
     if trimmed == "Affine" { _if174 = true; }
     if trimmed == "Linear" { _if174 = true; }
-    if _if174 {
-        return false;
-    }
-    if llvm_type == "double" {
-        return true;
-    }
-    if llvm_type == "i32" {
-        return true;
-    }
-    if llvm_type == "i64" {
-        return true;
-    }
-    if llvm_type == "i1" {
-        return true;
-    }
-    if ends_with_pointer_suffix(llvm_type) {
-        return true;
-    }
-    if trimmed.length == 0 {
-        return true;
-    }
-    if substring(trimmed, 0, 1) == "&" {
-        return true;
-    }
+    if _if174 { return false; }
+    if llvm_type == "double" { return true; }
+    if llvm_type == "i32" { return true; }
+    if llvm_type == "i64" { return true; }
+    if llvm_type == "i1" { return true; }
+    if ends_with_pointer_suffix(llvm_type) { return true; }
+    if trimmed.length == 0 { return true; }
+    if substring(trimmed, 0, 1) == "&" { return true; }
     if starts_with(trimmed, "mut ") {
         let stripped = strip_mut_prefix(trimmed);
         if stripped.length > 0 {
-            if substring(stripped, 0, 1) == "&" {
-                return true;
-            }
+            if substring(stripped, 0, 1) == "&" { return true; }
         }
     }
     return false;
 }
 
 fn default_return_literal(llvm_type: string) -> string {
-    if llvm_type == "void" {
-        return "";
-    }
-    if llvm_type == "double" {
-        return "0.0";
-    }
-    if llvm_type == "i32" {
-        return "0";
-    }
-    if llvm_type == "i64" {
-        return "0";
-    }
-    if llvm_type == "i1" {
-        return "false";
-    }
-    if ends_with_pointer_suffix(llvm_type) {
-        return "null";
-    }
+    if llvm_type == "void" { return ""; }
+    if llvm_type == "double" { return "0.0"; }
+    if llvm_type == "i32" { return "0"; }
+    if llvm_type == "i64" { return "0"; }
+    if llvm_type == "i1" { return "false"; }
+    if ends_with_pointer_suffix(llvm_type) { return "null"; }
     return "zeroinitializer";
 }
 
 // =============================================================================
 // LLVM Temp and Operand Formatting
 // =============================================================================
-
 fn format_temp_name(index: number) -> string {
     return "%t" + number_to_string(index);
 }

--- a/compiler/src/llvm/expressions_literals.sfn
+++ b/compiler/src/llvm/expressions_literals.sfn
@@ -1,40 +1,33 @@
 // compiler/src/llvm/expressions_literals.sfn
 //
 // Literal detection helpers: boolean, null, integer, number, string, character.
-
-import { substring, char_code, char_at, index_of } from "../string_utils";
+import {
+    char_at,
+    char_code,
+    index_of,
+    substring
+} from "../string_utils";
 import { trim_text } from "./utils";
 
 // =============================================================================
 // Case-Insensitive Matching
 // =============================================================================
-
 fn matches_case_insensitive(text: string, target: string) -> boolean {
-    if text.length != target.length {
-        return false;
-    }
+    if text.length != target.length { return false; }
     let mut index: number = 0;
     loop {
-        if index >= text.length {
-            break;
-        }
+        if index >= text.length { break; }
         let ch = char_code(char_at(text, index));
         let target_ch = char_code(char_at(target, index));
         let mut text_lower = ch;
         let mut target_lower = target_ch;
         if ch >= 65 {
-            if ch <= 90 {
-                text_lower = ch + 32;
-            }
+            if ch <= 90 { text_lower = ch + 32; }
         }
         if target_ch >= 65 {
-            if target_ch <= 90 {
-                target_lower = target_ch + 32;
-            }
+            if target_ch <= 90 { target_lower = target_ch + 32; }
         }
-        if text_lower != target_lower {
-            return false;
-        }
+        if text_lower != target_lower { return false; }
         index += 1;
     }
     return true;
@@ -43,23 +36,16 @@ fn matches_case_insensitive(text: string, target: string) -> boolean {
 // =============================================================================
 // Literal Detection
 // =============================================================================
-
 fn is_boolean_literal(text: string) -> boolean {
     let trimmed = trim_text(text);
-    if matches_case_insensitive(trimmed, "true") {
-        return true;
-    }
-    if matches_case_insensitive(trimmed, "false") {
-        return true;
-    }
+    if matches_case_insensitive(trimmed, "true") { return true; }
+    if matches_case_insensitive(trimmed, "false") { return true; }
     return false;
 }
 
 fn is_null_literal(text: string) -> boolean {
     let trimmed = trim_text(text);
-    if matches_case_insensitive(trimmed, "null") {
-        return true;
-    }
+    if matches_case_insensitive(trimmed, "null") { return true; }
     return false;
 }
 
@@ -69,9 +55,7 @@ fn is_digit_char(ch: string) -> boolean {
     let nine = char_code("9");
     let mut _ret167: boolean = false;
     if code >= zero {
-        if code <= nine {
-            _ret167 = true;
-        }
+        if code <= nine { _ret167 = true; }
     }
     return _ret167;
 }
@@ -82,21 +66,15 @@ fn char_code_at_text(text: string, index: number) -> number {
 
 fn is_integer_literal(text: string) -> boolean {
     let trimmed = trim_text(text);
-    if trimmed.length == 0 {
-        return false;
-    }
+    if trimmed.length == 0 { return false; }
     let mut index: number = 0;
     if substring(trimmed, 0, 1) == "-" {
-        if trimmed.length == 1 {
-            return false;
-        }
+        if trimmed.length == 1 { return false; }
         index = 1;
     }
     let mut has_digit: boolean = false;
     loop {
-        if index >= trimmed.length {
-            break;
-        }
+        if index >= trimmed.length { break; }
         let ch = substring(trimmed, index, index + 1);
         let mut _if168: boolean = false;
         if ch == "0" { _if168 = true; }
@@ -124,19 +102,13 @@ fn is_number_literal(text: string) -> boolean {
     let mut has_digit: boolean = false;
     let mut has_decimal: boolean = false;
     let trimmed = trim_text(text);
-    if trimmed.length == 0 {
-        return false;
-    }
+    if trimmed.length == 0 { return false; }
     if substring(trimmed, 0, 1) == "-" {
-        if trimmed.length == 1 {
-            return false;
-        }
+        if trimmed.length == 1 { return false; }
         index = 1;
     }
     loop {
-        if index >= trimmed.length {
-            break;
-        }
+        if index >= trimmed.length { break; }
         let ch = substring(trimmed, index, index + 1);
         let mut _if169: boolean = false;
         if ch == "0" { _if169 = true; }
@@ -155,9 +127,7 @@ fn is_number_literal(text: string) -> boolean {
             continue;
         }
         if ch == "." {
-            if has_decimal {
-                return false;
-            }
+            if has_decimal { return false; }
             has_decimal = true;
             index += 1;
             continue;
@@ -169,20 +139,14 @@ fn is_number_literal(text: string) -> boolean {
 
 fn normalise_number_literal(text: string) -> string {
     let trimmed = trim_text(text);
-    if index_of(trimmed, ".") >= 0 {
-        return trimmed;
-    }
+    if index_of(trimmed, ".") >= 0 { return trimmed; }
     return trimmed + ".0";
 }
 
 fn is_string_literal(text: string) -> boolean {
     let trimmed = trim_text(text);
-    if trimmed.length < 2 {
-        return false;
-    }
-    if substring(trimmed, 0, 1) != "\"" {
-        return false;
-    }
+    if trimmed.length < 2 { return false; }
+    if substring(trimmed, 0, 1) != "\"" { return false; }
     if substring(trimmed, trimmed.length - 1, trimmed.length) != "\"" {
         return false;
     }
@@ -192,9 +156,7 @@ fn is_string_literal(text: string) -> boolean {
     let mut escape: boolean = false;
     let mut index: number = 1;
     loop {
-        if index >= trimmed.length - 1 {
-            break;
-        }
+        if index >= trimmed.length - 1 { break; }
         let ch = char_at(trimmed, index);
         if escape {
             escape = false;
@@ -206,34 +168,24 @@ fn is_string_literal(text: string) -> boolean {
             index += 1;
             continue;
         }
-        if ch == "\"" {
-            return false;
-        }
+        if ch == "\"" { return false; }
         index += 1;
     }
-    if escape {
-        return false;
-    }
+    if escape { return false; }
     return true;
 }
 
 fn is_character_literal(text: string) -> boolean {
     // Check if this is a single-character string literal like "a", "t", "\n"
-    if text.length < 2 {
-        return false;
-    }
+    if text.length < 2 { return false; }
     let mut _if170: boolean = false;
     if substring(text, 0, 1) != "\"" { _if170 = true; }
     if substring(text, text.length - 1, text.length) != "\"" { _if170 = true; }
-    if _if170 {
-        return false;
-    }
+    if _if170 { return false; }
     let inner = substring(text, 1, text.length - 1);
     // Handle escape sequences
     if inner.length == 2 {
-        if substring(inner, 0, 1) == "\\" {
-            return true;
-        }
+        if substring(inner, 0, 1) == "\\" { return true; }
     }
     // Single character
     return inner.length == 1;
@@ -241,17 +193,13 @@ fn is_character_literal(text: string) -> boolean {
 
 fn get_character_literal_value(text: string) -> number {
     let inner = substring(text, 1, text.length - 1);
-    if inner.length == 0 {
-        return 0;
-    }
+    if inner.length == 0 { return 0; }
     // Handle escape sequences
     if inner.length == 2 {
         if substring(inner, 0, 1) == "\\" {
             let escape = char_at(inner, 1);
             let escape_code = char_code(escape);
-            if escape_code == char_code("n") {
-                return char_code("\n");
-            } else if escape_code == char_code("r") {
+            if escape_code == char_code("n") { return char_code("\n"); } else if escape_code == char_code("r") {
                 return char_code("\r");
             } else if escape_code == char_code("t") {
                 return char_code("\t");
@@ -259,9 +207,7 @@ fn get_character_literal_value(text: string) -> number {
                 return char_code("\"");
             } else if escape_code == char_code("\\") {
                 return char_code("\\");
-            } else if escape_code == char_code("0") {
-                return 0;
-            }
+            } else if escape_code == char_code("0") { return 0; }
             return escape_code;
         }
     }

--- a/compiler/src/llvm/expressions_operators.sfn
+++ b/compiler/src/llvm/expressions_operators.sfn
@@ -1,16 +1,14 @@
 // compiler/src/llvm/expressions_operators.sfn
 //
 // Top-level operator finding, binary operator detection, and separator scanning.
-
-import { substring, char_at } from "../string_utils";
+import { char_at, substring } from "../string_utils";
+import { contains_text } from "./expressions_helpers";
 import { OperatorMatch } from "./types";
 import { is_identifier_part_char } from "./utils";
-import { contains_text } from "./expressions_helpers";
 
 // =============================================================================
 // Operator Finding
 // =============================================================================
-
 fn find_top_level_operator(expression: string, operators: string) -> OperatorMatch {
     let mut paren_depth: number = 0;
     let mut bracket_depth: number = 0;
@@ -23,9 +21,7 @@ fn find_top_level_operator(expression: string, operators: string) -> OperatorMat
     let mut candidate_symbol: string = "";
     let mut index: number = 0;
     loop {
-        if index >= expression.length {
-            break;
-        }
+        if index >= expression.length { break; }
         let ch = char_at(expression, index);
         if in_double {
             if escape_next {
@@ -38,9 +34,7 @@ fn find_top_level_operator(expression: string, operators: string) -> OperatorMat
                 index += 1;
                 continue;
             }
-            if ch == "\"" {
-                in_double = false;
-            }
+            if ch == "\"" { in_double = false; }
             index += 1;
             continue;
         }
@@ -55,9 +49,7 @@ fn find_top_level_operator(expression: string, operators: string) -> OperatorMat
                 index += 1;
                 continue;
             }
-            if ch == "'" {
-                in_single = false;
-            }
+            if ch == "'" { in_single = false; }
             index += 1;
             continue;
         }
@@ -77,9 +69,7 @@ fn find_top_level_operator(expression: string, operators: string) -> OperatorMat
             continue;
         }
         if ch == ")" {
-            if paren_depth > 0 {
-                paren_depth -= 1;
-            }
+            if paren_depth > 0 { paren_depth -= 1; }
             index += 1;
             continue;
         }
@@ -89,9 +79,7 @@ fn find_top_level_operator(expression: string, operators: string) -> OperatorMat
             continue;
         }
         if ch == "]" {
-            if bracket_depth > 0 {
-                bracket_depth -= 1;
-            }
+            if bracket_depth > 0 { bracket_depth -= 1; }
             index += 1;
             continue;
         }
@@ -101,9 +89,7 @@ fn find_top_level_operator(expression: string, operators: string) -> OperatorMat
             continue;
         }
         if ch == "}" {
-            if brace_depth > 0 {
-                brace_depth -= 1;
-            }
+            if brace_depth > 0 { brace_depth -= 1; }
             index += 1;
             continue;
         }
@@ -113,9 +99,7 @@ fn find_top_level_operator(expression: string, operators: string) -> OperatorMat
             continue;
         }
         if ch == ">" {
-            if angle_depth > 0 {
-                angle_depth -= 1;
-            }
+            if angle_depth > 0 { angle_depth -= 1; }
             index += 1;
             continue;
         }
@@ -149,68 +133,53 @@ fn find_top_level_operator(expression: string, operators: string) -> OperatorMat
     // Keep struct literal values simple; our stage2 LLVM lowering has a
     // lightweight struct-literal parser that can get confused by comparisons.
     let success = candidate_index >= 0;
-    return OperatorMatch { success: success, index: candidate_index, symbol: candidate_symbol };
+    return OperatorMatch {
+        success: success,
+        index: candidate_index,
+        symbol: candidate_symbol
+    };
 }
 
 fn is_binary_minus(expression: string, index: number) -> boolean {
-    if index == 0 {
-        return false;
-    }
+    if index == 0 { return false; }
     let prev_char = char_at(expression, index - 1);
     let mut _if178: boolean = false;
     if prev_char == " " { _if178 = true; }
     if prev_char == "\t" { _if178 = true; }
-    if _if178 {
-        return true;
-    }
-    if is_identifier_part_char(prev_char) {
-        return true;
-    }
+    if _if178 { return true; }
+    if is_identifier_part_char(prev_char) { return true; }
     let mut _if179: boolean = false;
     if prev_char == ")" { _if179 = true; }
     if prev_char == "]" { _if179 = true; }
-    if _if179 {
-        return true;
-    }
+    if _if179 { return true; }
     return false;
 }
 
 fn is_binary_star(expression: string, index: number) -> boolean {
-    if index == 0 {
-        return false;
-    }
+    if index == 0 { return false; }
     let prev_char = char_at(expression, index - 1);
     let mut _if180: boolean = false;
     if prev_char == " " { _if180 = true; }
     if prev_char == "\t" { _if180 = true; }
-    if _if180 {
-        return true;
-    }
-    if is_identifier_part_char(prev_char) {
-        return true;
-    }
+    if _if180 { return true; }
+    if is_identifier_part_char(prev_char) { return true; }
     let mut _if181: boolean = false;
     if prev_char == ")" { _if181 = true; }
     if prev_char == "]" { _if181 = true; }
-    if _if181 {
-        return true;
-    }
+    if _if181 { return true; }
     return false;
 }
 
 // =============================================================================
 // Range and Separator Finding
 // =============================================================================
-
 fn find_top_level_range_separator(value: string) -> number {
     let mut paren_depth: number = 0;
     let mut bracket_depth: number = 0;
     let mut brace_depth: number = 0;
     let mut index: number = 0;
     loop {
-        if index >= value.length {
-            break;
-        }
+        if index >= value.length { break; }
         let ch = substring(value, index, index + 1);
         if ch == "(" {
             paren_depth += 1;
@@ -218,9 +187,7 @@ fn find_top_level_range_separator(value: string) -> number {
             continue;
         }
         if ch == ")" {
-            if paren_depth > 0 {
-                paren_depth -= 1;
-            }
+            if paren_depth > 0 { paren_depth -= 1; }
             index += 1;
             continue;
         }
@@ -230,9 +197,7 @@ fn find_top_level_range_separator(value: string) -> number {
             continue;
         }
         if ch == "]" {
-            if bracket_depth > 0 {
-                bracket_depth -= 1;
-            }
+            if bracket_depth > 0 { bracket_depth -= 1; }
             index += 1;
             continue;
         }
@@ -242,9 +207,7 @@ fn find_top_level_range_separator(value: string) -> number {
             continue;
         }
         if ch == "}" {
-            if brace_depth > 0 {
-                brace_depth -= 1;
-            }
+            if brace_depth > 0 { brace_depth -= 1; }
             index += 1;
             continue;
         }
@@ -255,9 +218,7 @@ fn find_top_level_range_separator(value: string) -> number {
                 if substring(value, _dot_next, _dot_next2) == "." {
                     if paren_depth == 0 {
                         if bracket_depth == 0 {
-                            if brace_depth == 0 {
-                                return index;
-                            }
+                            if brace_depth == 0 { return index; }
                         }
                     }
                 }
@@ -278,17 +239,11 @@ fn find_top_level_union_separator(text: string) -> number {
     let mut escape: boolean = false;
     let mut index: number = 0;
     loop {
-        if index >= text.length {
-            break;
-        }
+        if index >= text.length { break; }
         let ch = substring(text, index, index + 1);
         if in_double {
-            if escape {
-                escape = false;
-            } else {
-                if ch == "\\" {
-                    escape = true;
-                } else if ch == "\"" {
+            if escape { escape = false; } else {
+                if ch == "\\" { escape = true; } else if ch == "\"" {
                     in_double = false;
                 }
             }
@@ -296,12 +251,8 @@ fn find_top_level_union_separator(text: string) -> number {
             continue;
         }
         if in_single {
-            if escape {
-                escape = false;
-            } else {
-                if ch == "\\" {
-                    escape = true;
-                } else if ch == "'" {
+            if escape { escape = false; } else {
+                if ch == "\\" { escape = true; } else if ch == "'" {
                     in_single = false;
                 }
             }
@@ -318,37 +269,19 @@ fn find_top_level_union_separator(text: string) -> number {
             index += 1;
             continue;
         }
-        if ch == "(" {
-            paren_depth += 1;
-        } else if ch == ")" {
-            if paren_depth > 0 {
-                paren_depth -= 1;
-            }
-        } else if ch == "[" {
-            bracket_depth += 1;
-        } else if ch == "]" {
-            if bracket_depth > 0 {
-                bracket_depth -= 1;
-            }
-        } else if ch == "{" {
-            brace_depth += 1;
-        } else if ch == "}" {
-            if brace_depth > 0 {
-                brace_depth -= 1;
-            }
-        } else if ch == "<" {
-            angle_depth += 1;
-        } else if ch == ">" {
-            if angle_depth > 0 {
-                angle_depth -= 1;
-            }
+        if ch == "(" { paren_depth += 1; } else if ch == ")" {
+            if paren_depth > 0 { paren_depth -= 1; }
+        } else if ch == "[" { bracket_depth += 1; } else if ch == "]" {
+            if bracket_depth > 0 { bracket_depth -= 1; }
+        } else if ch == "{" { brace_depth += 1; } else if ch == "}" {
+            if brace_depth > 0 { brace_depth -= 1; }
+        } else if ch == "<" { angle_depth += 1; } else if ch == ">" {
+            if angle_depth > 0 { angle_depth -= 1; }
         } else if ch == "|" {
             if paren_depth == 0 {
                 if brace_depth == 0 {
                     if bracket_depth == 0 {
-                        if angle_depth == 0 {
-                            return index;
-                        }
+                        if angle_depth == 0 { return index; }
                     }
                 }
             }

--- a/compiler/src/llvm/expressions_parsing.sfn
+++ b/compiler/src/llvm/expressions_parsing.sfn
@@ -2,19 +2,21 @@
 //
 // Expression parsing helpers: member access, index expressions, assignments,
 // inline let, ternary, cast, and raw address parsing.
-
-import { substring, char_at, index_of } from "../string_utils";
+import { char_at, index_of, substring } from "../string_utils";
 import {
-    MemberAccessParse, IndexExpressionParse,
-    AssignmentParseResult, InlineLetParseResult,
-    TernaryParseResult, RawAddressParseResult, CastParseResult,
+    AssignmentParseResult,
+    CastParseResult,
+    IndexExpressionParse,
+    InlineLetParseResult,
+    MemberAccessParse,
+    RawAddressParseResult,
+    TernaryParseResult,
 } from "./types";
-import { trim_text, starts_with, ends_with } from "./utils";
+import { ends_with, starts_with, trim_text } from "./utils";
 
 // =============================================================================
 // Expression Parsing Helpers
 // =============================================================================
-
 fn parse_member_access(expression: string) -> MemberAccessParse {
     let trimmed = trim_text(expression);
     let mut paren_depth: number = 0;
@@ -26,9 +28,7 @@ fn parse_member_access(expression: string) -> MemberAccessParse {
     let mut last_dot: number = -1;
     let mut index: number = 0;
     loop {
-        if index >= trimmed.length {
-            break;
-        }
+        if index >= trimmed.length { break; }
         let ch = char_at(trimmed, index);
         if in_double {
             if escape_next {
@@ -41,9 +41,7 @@ fn parse_member_access(expression: string) -> MemberAccessParse {
                 index += 1;
                 continue;
             }
-            if ch == "\"" {
-                in_double = false;
-            }
+            if ch == "\"" { in_double = false; }
             index += 1;
             continue;
         }
@@ -58,9 +56,7 @@ fn parse_member_access(expression: string) -> MemberAccessParse {
                 index += 1;
                 continue;
             }
-            if ch == "'" {
-                in_single = false;
-            }
+            if ch == "'" { in_single = false; }
             index += 1;
             continue;
         }
@@ -80,9 +76,7 @@ fn parse_member_access(expression: string) -> MemberAccessParse {
             continue;
         }
         if ch == ")" {
-            if paren_depth > 0 {
-                paren_depth -= 1;
-            }
+            if paren_depth > 0 { paren_depth -= 1; }
             index += 1;
             continue;
         }
@@ -92,9 +86,7 @@ fn parse_member_access(expression: string) -> MemberAccessParse {
             continue;
         }
         if ch == "]" {
-            if bracket_depth > 0 {
-                bracket_depth -= 1;
-            }
+            if bracket_depth > 0 { bracket_depth -= 1; }
             index += 1;
             continue;
         }
@@ -104,9 +96,7 @@ fn parse_member_access(expression: string) -> MemberAccessParse {
             continue;
         }
         if ch == "}" {
-            if brace_depth > 0 {
-                brace_depth -= 1;
-            }
+            if brace_depth > 0 { brace_depth -= 1; }
             index += 1;
             continue;
         }
@@ -154,9 +144,7 @@ fn parse_index_expression(expression: string) -> IndexExpressionParse {
     let mut open_bracket: number = -1;
     let mut index: number = trimmed.length - 1;
     loop {
-        if index < 0 {
-            break;
-        }
+        if index < 0 { break; }
         let ch = char_at(trimmed, index);
         if in_double {
             if escape_next {
@@ -169,9 +157,7 @@ fn parse_index_expression(expression: string) -> IndexExpressionParse {
                 index -= 1;
                 continue;
             }
-            if ch == "\"" {
-                in_double = false;
-            }
+            if ch == "\"" { in_double = false; }
             index -= 1;
             continue;
         }
@@ -186,9 +172,7 @@ fn parse_index_expression(expression: string) -> IndexExpressionParse {
                 index -= 1;
                 continue;
             }
-            if ch == "'" {
-                in_single = false;
-            }
+            if ch == "'" { in_single = false; }
             index -= 1;
             continue;
         }
@@ -208,9 +192,7 @@ fn parse_index_expression(expression: string) -> IndexExpressionParse {
             continue;
         }
         if ch == "(" {
-            if paren_depth > 0 {
-                paren_depth -= 1;
-            }
+            if paren_depth > 0 { paren_depth -= 1; }
             index -= 1;
             continue;
         }
@@ -220,9 +202,7 @@ fn parse_index_expression(expression: string) -> IndexExpressionParse {
             continue;
         }
         if ch == "{" {
-            if brace_depth > 0 {
-                brace_depth -= 1;
-            }
+            if brace_depth > 0 { brace_depth -= 1; }
             index -= 1;
             continue;
         }
@@ -253,13 +233,16 @@ fn parse_index_expression(expression: string) -> IndexExpressionParse {
     }
     let base = trim_text(substring(trimmed, 0, open_bracket));
     let index_value = trim_text(substring(trimmed, open_bracket + 1, trimmed.length - 1));
-    return IndexExpressionParse { success: true, base: base, index: index_value };
+    return IndexExpressionParse {
+        success: true,
+        base: base,
+        index: index_value
+    };
 }
 
 // =============================================================================
 // Assignment and Inline Let Parsing
 // =============================================================================
-
 fn parse_assignment_expression(expression: string) -> AssignmentParseResult {
     let trimmed = trim_text(expression);
     let mut paren_depth: number = 0;
@@ -271,9 +254,7 @@ fn parse_assignment_expression(expression: string) -> AssignmentParseResult {
     let mut equals_index: number = -1;
     let mut index: number = 0;
     loop {
-        if index >= trimmed.length {
-            break;
-        }
+        if index >= trimmed.length { break; }
         let ch = char_at(trimmed, index);
         if in_double {
             if escape_next {
@@ -286,9 +267,7 @@ fn parse_assignment_expression(expression: string) -> AssignmentParseResult {
                 index += 1;
                 continue;
             }
-            if ch == "\"" {
-                in_double = false;
-            }
+            if ch == "\"" { in_double = false; }
             index += 1;
             continue;
         }
@@ -303,9 +282,7 @@ fn parse_assignment_expression(expression: string) -> AssignmentParseResult {
                 index += 1;
                 continue;
             }
-            if ch == "'" {
-                in_single = false;
-            }
+            if ch == "'" { in_single = false; }
             index += 1;
             continue;
         }
@@ -325,9 +302,7 @@ fn parse_assignment_expression(expression: string) -> AssignmentParseResult {
             continue;
         }
         if ch == ")" {
-            if paren_depth > 0 {
-                paren_depth -= 1;
-            }
+            if paren_depth > 0 { paren_depth -= 1; }
             index += 1;
             continue;
         }
@@ -337,9 +312,7 @@ fn parse_assignment_expression(expression: string) -> AssignmentParseResult {
             continue;
         }
         if ch == "]" {
-            if bracket_depth > 0 {
-                bracket_depth -= 1;
-            }
+            if bracket_depth > 0 { bracket_depth -= 1; }
             index += 1;
             continue;
         }
@@ -349,9 +322,7 @@ fn parse_assignment_expression(expression: string) -> AssignmentParseResult {
             continue;
         }
         if ch == "}" {
-            if brace_depth > 0 {
-                brace_depth -= 1;
-            }
+            if brace_depth > 0 { brace_depth -= 1; }
             index += 1;
             continue;
         }
@@ -389,11 +360,21 @@ fn parse_assignment_expression(expression: string) -> AssignmentParseResult {
         index += 1;
     }
     if equals_index < 0 {
-        return AssignmentParseResult { success: false, target: "", value: "", operator: "" };
+        return AssignmentParseResult {
+            success: false,
+            target: "",
+            value: "",
+            operator: ""
+        };
     }
     let target = trim_text(substring(trimmed, 0, equals_index));
     let value = trim_text(substring(trimmed, equals_index + 1, trimmed.length));
-    return AssignmentParseResult { success: true, target: target, value: value, operator: "" };
+    return AssignmentParseResult {
+        success: true,
+        target: target,
+        value: value,
+        operator: ""
+    };
 }
 
 fn parse_inline_let_expression(expression: string) -> InlineLetParseResult {
@@ -401,7 +382,14 @@ fn parse_inline_let_expression(expression: string) -> InlineLetParseResult {
     let mut diagnostics: string[] = [];
 
     if !starts_with(trimmed, "let ") {
-        return InlineLetParseResult { success: false, name: "", mutable: false, type_annotation: "", initializer: "", diagnostics: diagnostics };
+        return InlineLetParseResult {
+            success: false,
+            name: "",
+            mutable: false,
+            type_annotation: "",
+            initializer: "",
+            diagnostics: diagnostics
+        };
     }
 
     let remainder = trim_text(substring(trimmed, 4, trimmed.length));
@@ -416,7 +404,14 @@ fn parse_inline_let_expression(expression: string) -> InlineLetParseResult {
     let assignment = parse_assignment_expression(after_mut);
     if !assignment.success {
         diagnostics.push("llvm lowering: inline let expression missing initializer");
-        return InlineLetParseResult { success: false, name: "", mutable: is_mutable, type_annotation: "", initializer: "", diagnostics: diagnostics };
+        return InlineLetParseResult {
+            success: false,
+            name: "",
+            mutable: is_mutable,
+            type_annotation: "",
+            initializer: "",
+            diagnostics: diagnostics
+        };
     }
 
     let lhs = trim_text(assignment.target);
@@ -430,28 +425,45 @@ fn parse_inline_let_expression(expression: string) -> InlineLetParseResult {
     if arrow_index >= 0 {
         name = trim_text(substring(lhs, 0, arrow_index));
         type_annotation = trim_text(substring(lhs, arrow_index + 2, lhs.length));
-    } else {
-        name = lhs;
-    }
+    } else { name = lhs; }
 
     if name.length == 0 {
         diagnostics.push("llvm lowering: inline let expression missing variable name");
-        return InlineLetParseResult { success: false, name: "", mutable: is_mutable, type_annotation: type_annotation, initializer: initializer, diagnostics: diagnostics };
+        return InlineLetParseResult {
+            success: false,
+            name: "",
+            mutable: is_mutable,
+            type_annotation: type_annotation,
+            initializer: initializer,
+            diagnostics: diagnostics
+        };
     }
 
-    return InlineLetParseResult { success: true, name: name, mutable: is_mutable, type_annotation: type_annotation, initializer: initializer, diagnostics: diagnostics };
+    return InlineLetParseResult {
+        success: true,
+        name: name,
+        mutable: is_mutable,
+        type_annotation: type_annotation,
+        initializer: initializer,
+        diagnostics: diagnostics
+    };
 }
 
 // =============================================================================
 // Ternary Expression Parsing
 // =============================================================================
-
 fn parse_ternary_expression(text: string) -> TernaryParseResult {
     let mut diagnostics: string[] = [];
     let trimmed = trim_text(text);
 
     if trimmed.length == 0 {
-        return TernaryParseResult { success: false, condition: "", true_value: "", false_value: "", diagnostics: diagnostics };
+        return TernaryParseResult {
+            success: false,
+            condition: "",
+            true_value: "",
+            false_value: "",
+            diagnostics: diagnostics
+        };
     }
 
     // Find '?' and ':' at the same nesting level (depth 0)
@@ -464,9 +476,7 @@ fn parse_ternary_expression(text: string) -> TernaryParseResult {
     let mut escape_next: boolean = false;
 
     loop {
-        if index >= trimmed.length {
-            break;
-        }
+        if index >= trimmed.length { break; }
         let ch = char_at(trimmed, index);
         if in_double {
             if escape_next {
@@ -479,9 +489,7 @@ fn parse_ternary_expression(text: string) -> TernaryParseResult {
                 index += 1;
                 continue;
             }
-            if ch == "\"" {
-                in_double = false;
-            }
+            if ch == "\"" { in_double = false; }
             index += 1;
             continue;
         }
@@ -496,9 +504,7 @@ fn parse_ternary_expression(text: string) -> TernaryParseResult {
                 index += 1;
                 continue;
             }
-            if ch == "'" {
-                in_single = false;
-            }
+            if ch == "'" { in_single = false; }
             index += 1;
             continue;
         }
@@ -526,28 +532,20 @@ fn parse_ternary_expression(text: string) -> TernaryParseResult {
         if ch == "]" { _if183 = true; }
         if ch == "}" { _if183 = true; }
         if _if183 {
-            if depth > 0 {
-                depth -= 1;
-            }
+            if depth > 0 { depth -= 1; }
             index += 1;
             continue;
         }
         if depth == 0 {
             let mut _if184: boolean = false;
             if ch == "?" {
-                if question_index < 0 {
-                    _if184 = true;
-                }
+                if question_index < 0 { _if184 = true; }
             }
-            if _if184 {
-                question_index = index;
-            } else {
+            if _if184 { question_index = index; } else {
                 let mut _elif188: boolean = false;
                 if ch == ":" {
                     if question_index >= 0 {
-                        if colon_index < 0 {
-                            _elif188 = true;
-                        }
+                        if colon_index < 0 { _elif188 = true; }
                     }
                 }
                 if _elif188 {
@@ -563,42 +561,79 @@ fn parse_ternary_expression(text: string) -> TernaryParseResult {
     if question_index < 0 { _if185 = true; }
     if colon_index < 0 { _if185 = true; }
     if _if185 {
-        return TernaryParseResult { success: false, condition: "", true_value: "", false_value: "", diagnostics: diagnostics };
+        return TernaryParseResult {
+            success: false,
+            condition: "",
+            true_value: "",
+            false_value: "",
+            diagnostics: diagnostics
+        };
     }
 
     let condition = trim_text(substring(trimmed, 0, question_index));
     let true_value = trim_text(substring(trimmed, question_index + 1, colon_index));
     let false_value = trim_text(substring(trimmed, colon_index + 1, trimmed.length));
 
-    return TernaryParseResult { success: true, condition: condition, true_value: true_value, false_value: false_value, diagnostics: diagnostics };
+    return TernaryParseResult {
+        success: true,
+        condition: condition,
+        true_value: true_value,
+        false_value: false_value,
+        diagnostics: diagnostics
+    };
 }
 
 // =============================================================================
 // Cast and Raw Address Parsing
 // =============================================================================
-
 fn parse_raw_address_expression(text: string) -> RawAddressParseResult {
     let trimmed = trim_text(text);
     if !starts_with(trimmed, "raw_address(") {
-        return RawAddressParseResult { recognized: false, success: false, target: "", diagnostics: [] };
+        return RawAddressParseResult {
+            recognized: false,
+            success: false,
+            target: "",
+            diagnostics: []
+        };
     }
     if !ends_with(trimmed, ")") {
         let diagnostics: string[] = ["llvm lowering: raw_address expression missing closing `)`"];
-        return RawAddressParseResult { recognized: true, success: false, target: "", diagnostics: diagnostics };
+        return RawAddressParseResult {
+            recognized: true,
+            success: false,
+            target: "",
+            diagnostics: diagnostics
+        };
     }
     let inner = trim_text(substring(trimmed, 12, trimmed.length - 1));
     if inner.length == 0 {
         let diagnostics: string[] = ["llvm lowering: raw_address expression missing target"];
-        return RawAddressParseResult { recognized: true, success: false, target: "", diagnostics: diagnostics };
+        return RawAddressParseResult {
+            recognized: true,
+            success: false,
+            target: "",
+            diagnostics: diagnostics
+        };
     }
-    return RawAddressParseResult { recognized: true, success: true, target: inner, diagnostics: [] };
+    return RawAddressParseResult {
+        recognized: true,
+        success: true,
+        target: inner,
+        diagnostics: []
+    };
 }
 
 fn parse_cast_expression(text: string) -> CastParseResult {
     let trimmed = trim_text(text);
     let mut diagnostics: string[] = [];
     if trimmed.length == 0 {
-        return CastParseResult { recognized: false, success: false, value: "", type_annotation: "", diagnostics: diagnostics };
+        return CastParseResult {
+            recognized: false,
+            success: false,
+            value: "",
+            type_annotation: "",
+            diagnostics: diagnostics
+        };
     }
 
     // Scan for a top-level ` as ` outside of brackets/strings.
@@ -613,9 +648,7 @@ fn parse_cast_expression(text: string) -> CastParseResult {
     let mut index: number = 0;
 
     loop {
-        if index >= trimmed.length {
-            break;
-        }
+        if index >= trimmed.length { break; }
         let ch = char_at(trimmed, index);
         if in_double {
             if escape_next {
@@ -628,9 +661,7 @@ fn parse_cast_expression(text: string) -> CastParseResult {
                 index += 1;
                 continue;
             }
-            if ch == "\"" {
-                in_double = false;
-            }
+            if ch == "\"" { in_double = false; }
             index += 1;
             continue;
         }
@@ -645,9 +676,7 @@ fn parse_cast_expression(text: string) -> CastParseResult {
                 index += 1;
                 continue;
             }
-            if ch == "'" {
-                in_single = false;
-            }
+            if ch == "'" { in_single = false; }
             index += 1;
             continue;
         }
@@ -667,9 +696,7 @@ fn parse_cast_expression(text: string) -> CastParseResult {
             continue;
         }
         if ch == ")" {
-            if paren_depth > 0 {
-                paren_depth -= 1;
-            }
+            if paren_depth > 0 { paren_depth -= 1; }
             index += 1;
             continue;
         }
@@ -679,9 +706,7 @@ fn parse_cast_expression(text: string) -> CastParseResult {
             continue;
         }
         if ch == "]" {
-            if bracket_depth > 0 {
-                bracket_depth -= 1;
-            }
+            if bracket_depth > 0 { bracket_depth -= 1; }
             index += 1;
             continue;
         }
@@ -691,9 +716,7 @@ fn parse_cast_expression(text: string) -> CastParseResult {
             continue;
         }
         if ch == "}" {
-            if brace_depth > 0 {
-                brace_depth -= 1;
-            }
+            if brace_depth > 0 { brace_depth -= 1; }
             index += 1;
             continue;
         }
@@ -703,9 +726,7 @@ fn parse_cast_expression(text: string) -> CastParseResult {
             continue;
         }
         if ch == ">" {
-            if angle_depth > 0 {
-                angle_depth -= 1;
-            }
+            if angle_depth > 0 { angle_depth -= 1; }
             index += 1;
             continue;
         }
@@ -717,9 +738,7 @@ fn parse_cast_expression(text: string) -> CastParseResult {
                         let _as_end = index + 4;
                         if _as_end <= trimmed.length {
                             let window = substring(trimmed, index, _as_end);
-                            if window == " as " {
-                                match_index = index;
-                            }
+                            if window == " as " { match_index = index; }
                         }
                     }
                 }
@@ -729,7 +748,13 @@ fn parse_cast_expression(text: string) -> CastParseResult {
     }
 
     if match_index < 0 {
-        return CastParseResult { recognized: false, success: false, value: "", type_annotation: "", diagnostics: diagnostics };
+        return CastParseResult {
+            recognized: false,
+            success: false,
+            value: "",
+            type_annotation: "",
+            diagnostics: diagnostics
+        };
     }
 
     let value = trim_text(substring(trimmed, 0, match_index));
@@ -739,7 +764,19 @@ fn parse_cast_expression(text: string) -> CastParseResult {
     if annotation.length == 0 { _if186 = true; }
     if _if186 {
         diagnostics.push("llvm lowering: malformed cast expression `" + text + "`");
-        return CastParseResult { recognized: true, success: false, value: value, type_annotation: annotation, diagnostics: diagnostics };
+        return CastParseResult {
+            recognized: true,
+            success: false,
+            value: value,
+            type_annotation: annotation,
+            diagnostics: diagnostics
+        };
     }
-    return CastParseResult { recognized: true, success: true, value: value, type_annotation: annotation, diagnostics: diagnostics };
+    return CastParseResult {
+        recognized: true,
+        success: true,
+        value: value,
+        type_annotation: annotation,
+        diagnostics: diagnostics
+    };
 }

--- a/compiler/src/llvm/expressions_parsing.sfn
+++ b/compiler/src/llvm/expressions_parsing.sfn
@@ -10,7 +10,7 @@ import {
     InlineLetParseResult,
     MemberAccessParse,
     RawAddressParseResult,
-    TernaryParseResult,
+    TernaryParseResult
 } from "./types";
 import { ends_with, starts_with, trim_text } from "./utils";
 
@@ -763,7 +763,8 @@ fn parse_cast_expression(text: string) -> CastParseResult {
     if value.length == 0 { _if186 = true; }
     if annotation.length == 0 { _if186 = true; }
     if _if186 {
-        diagnostics.push("llvm lowering: malformed cast expression `" + text + "`");
+        diagnostics.push("llvm lowering: malformed cast expression `" + text
+            + "`");
         return CastParseResult {
             recognized: true,
             success: false,

--- a/compiler/src/llvm/imports.sfn
+++ b/compiler/src/llvm/imports.sfn
@@ -41,7 +41,9 @@ fn collect_imported_module_context_for_module(imports: NativeImport[], current_m
     }
     let trace = _let189;
     if trace {
-        print.err("test llvm: collect_imported_module_context start (imports=" + number_to_string(imports.length) + ")");
+        print.err("test llvm: collect_imported_module_context start (imports="
+            + number_to_string(imports.length)
+            + ")");
     }
     let mut manifests: LayoutManifest[] = [];
     let mut native_texts: string[] = [];
@@ -73,7 +75,11 @@ fn collect_imported_module_context_for_module(imports: NativeImport[], current_m
         if trace {
             if queue_index > 0 {
                 if queue_index % 50 == 0 {
-                    print.err("test llvm: collect_imported_module_context progress (index=" + number_to_string(queue_index) + " queued=" + number_to_string(queue_paths.length) + ")");
+                    print.err("test llvm: collect_imported_module_context progress (index="
+                        + number_to_string(queue_index)
+                        + " queued="
+                        + number_to_string(queue_paths.length)
+                        + ")");
                 }
             }
         }
@@ -113,9 +119,15 @@ fn collect_imported_module_context_for_module(imports: NativeImport[], current_m
                 }
             }
             if is_cached_capsule {
-                diagnostics.push("layout manifest: missing artifact for capsule import `" + module_path + "` — ensure imports are inlined before LLVM lowering");
+                diagnostics.push("layout manifest: missing artifact for capsule import `"
+                    + module_path
+                    + "` — ensure imports are inlined before LLVM lowering");
             } else {
-                diagnostics.push("layout manifest: missing artifact for import `" + module_path + "` (expected " + manifest_path + ")");
+                diagnostics.push("layout manifest: missing artifact for import `"
+                    + module_path
+                    + "` (expected "
+                    + manifest_path
+                    + ")");
             }
         }
 
@@ -135,13 +147,17 @@ fn collect_imported_module_context_for_module(imports: NativeImport[], current_m
             }
         } else {
             if depth == 0 {
-                diagnostics.push("native lowering: missing native text artifact for import `" + module_path + "` (expected " + native_text_path + ")");
+                diagnostics.push("native lowering: missing native text artifact for import `"
+                    + module_path
+                    + "` (expected "
+                    + native_text_path
+                    + ")");
             }
         }
 
         let mut updated_manifests = manifests;
         updated_manifests = updated_manifests.push(LayoutManifest {
-            structs: manifest_structs, enums: manifest_enums, diagnostics: [],
+            structs: manifest_structs, enums: manifest_enums, diagnostics: []
         });
         manifests = updated_manifests;
         let mut updated_texts = native_texts;
@@ -170,7 +186,9 @@ fn collect_imported_module_context_for_module(imports: NativeImport[], current_m
     }
 
     if trace {
-        print.err("test llvm: collect_imported_module_context done (unique_imports=" + number_to_string(seen.length) + ")");
+        print.err("test llvm: collect_imported_module_context done (unique_imports="
+            + number_to_string(seen.length)
+            + ")");
     }
 
     return ImportedModuleContext {
@@ -345,11 +363,13 @@ fn native_text_path_for_slug(slug: string) -> string {
 }
 
 fn _selfhost_layout_manifest_path_for_slug(slug: string) -> string {
-    return "build/selfhost/native/seed_cwd/build/native/import-context/" + slug + ".layout-manifest";
+    return "build/selfhost/native/seed_cwd/build/native/import-context/" + slug
+        + ".layout-manifest";
 }
 
 fn _selfhost_native_text_path_for_slug(slug: string) -> string {
-    return "build/selfhost/native/seed_cwd/build/native/import-context/" + slug + ".sfn-asm";
+    return "build/selfhost/native/seed_cwd/build/native/import-context/" + slug
+        + ".sfn-asm";
 }
 
 fn _resolve_layout_manifest_path_for_slug(slug: string) -> string ![io] {
@@ -465,7 +485,10 @@ fn resolve_cached_capsule_source(module: string, deps: string, home_dir: string)
     if !_version_safe { return ""; }
 
     // Construct cache path
-    let cached_path = home_dir + "/.sfn/cache/capsules/" + scope + "/" + name + "/" + version + "/src/mod.sfn";
+    let cached_path = home_dir + "/.sfn/cache/capsules/" + scope + "/" + name
+        + "/"
+        + version
+        + "/src/mod.sfn";
     if fs.exists(cached_path) { return cached_path; }
     return "";
 }
@@ -494,7 +517,8 @@ fn apply_layout_manifest_entries(structs: NativeStruct[], enums: NativeEnum[], m
         let layout_struct = manifest.structs[struct_index];
         let target_index = find_struct_index(updated_structs, layout_struct.name);
         if target_index < 0 {
-            diagnostics.push("layout manifest: struct `" + layout_struct.name + "` missing from native module");
+            diagnostics.push("layout manifest: struct `" + layout_struct.name
+                + "` missing from native module");
         } else {
             let target = updated_structs[target_index];
             let replaced = NativeStruct {
@@ -502,7 +526,7 @@ fn apply_layout_manifest_entries(structs: NativeStruct[], enums: NativeEnum[], m
                 fields: target.fields,
                 methods: target.methods,
                 implements: target.implements,
-                layout: layout_struct.layout,
+                layout: layout_struct.layout
             };
             updated_structs = replace_native_struct(updated_structs, target_index, replaced);
         }
@@ -516,13 +540,14 @@ fn apply_layout_manifest_entries(structs: NativeStruct[], enums: NativeEnum[], m
         let layout_enum = manifest.enums[enum_index];
         let target_index = find_enum_index(updated_enums, layout_enum.name);
         if target_index < 0 {
-            diagnostics.push("layout manifest: enum `" + layout_enum.name + "` missing from native module");
+            diagnostics.push("layout manifest: enum `" + layout_enum.name
+                + "` missing from native module");
         } else {
             let target = updated_enums[target_index];
             let replaced = NativeEnum {
                 name: target.name,
                 variants: target.variants,
-                layout: layout_enum.layout,
+                layout: layout_enum.layout
             };
             updated_enums = replace_native_enum(updated_enums, target_index, replaced);
         }
@@ -532,7 +557,7 @@ fn apply_layout_manifest_entries(structs: NativeStruct[], enums: NativeEnum[], m
     return LayoutManifestApplication {
         structs: updated_structs,
         enums: updated_enums,
-        diagnostics: diagnostics,
+        diagnostics: diagnostics
     };
 }
 

--- a/compiler/src/llvm/imports.sfn
+++ b/compiler/src/llvm/imports.sfn
@@ -2,17 +2,29 @@
 //
 // Import handling and layout manifest management for LLVM lowering.
 // Resolves imported module paths and applies layout metadata.
-
-import { NativeImport, NativeStruct, NativeEnum, LayoutManifest } from "../native_ir";
+import {
+    LayoutManifest,
+    NativeEnum,
+    NativeImport,
+    NativeStruct
+} from "../native_ir";
 import { parse_layout_manifest, parse_native_imports_for_import } from "../native_ir_api";
 import { substring } from "../string_utils";
 import { ImportedModuleContext, LayoutManifestApplication } from "./types";
-import { trim_text, append_string, string_array_contains, number_to_string, starts_with, ends_with, join_with_separator, index_of } from "./utils";
+import {
+    append_string,
+    ends_with,
+    index_of,
+    join_with_separator,
+    number_to_string,
+    starts_with,
+    string_array_contains,
+    trim_text
+} from "./utils";
 
 // =============================================================================
 // Import Context Collection
 // =============================================================================
-
 fn load_imported_layout_manifests(imports: NativeImport[]) -> LayoutManifest[] ![io] {
     let context = collect_imported_module_context(imports);
     return context.manifests;
@@ -25,9 +37,7 @@ fn collect_imported_module_context(imports: NativeImport[]) -> ImportedModuleCon
 fn collect_imported_module_context_for_module(imports: NativeImport[], current_module_slug: string) -> ImportedModuleContext ![io] {
     let mut _let189: boolean = false;
     if fs.exists("build/sailfin/.trace_test_runner") {
-        if fs.exists("build/sailfin/.test_runner_active") {
-            _let189 = true;
-        }
+        if fs.exists("build/sailfin/.test_runner_active") { _let189 = true; }
     }
     let trace = _let189;
     if trace {
@@ -48,9 +58,7 @@ fn collect_imported_module_context_for_module(imports: NativeImport[], current_m
 
     let mut init_index: number = 0;
     loop {
-        if init_index >= imports.length {
-            break;
-        }
+        if init_index >= imports.length { break; }
         queue_paths.push(imports[init_index].module);
         queue_parent_slugs.push(current_module_slug);
         queue_depths.push(0);
@@ -61,9 +69,7 @@ fn collect_imported_module_context_for_module(imports: NativeImport[], current_m
 
     let mut queue_index: number = 0;
     loop {
-        if queue_index >= queue_paths.length {
-            break;
-        }
+        if queue_index >= queue_paths.length { break; }
         if trace {
             if queue_index > 0 {
                 if queue_index % 50 == 0 {
@@ -79,12 +85,8 @@ fn collect_imported_module_context_for_module(imports: NativeImport[], current_m
 
         let base_slug = resolve_import_module_slug_for_module(module_path, parent_slug);
         let slug = resolve_import_artifact_slug(base_slug);
-        if slug.length == 0 {
-            continue;
-        }
-        if string_array_contains(seen, slug) {
-            continue;
-        }
+        if slug.length == 0 { continue; }
+        if string_array_contains(seen, slug) { continue; }
         seen.push(slug);
 
         let manifest_path = _resolve_layout_manifest_path_for_slug(slug);
@@ -127,9 +129,7 @@ fn collect_imported_module_context_for_module(imports: NativeImport[], current_m
         let mut native_text_for_discovery: string = "";
         if fs.exists(native_text_path) {
             let file_contents = fs.readFile(native_text_path);
-            if depth == 0 {
-                native_text = file_contents;
-            }
+            if depth == 0 { native_text = file_contents; }
             if depth < max_transitive_depth {
                 native_text_for_discovery = file_contents;
             }
@@ -141,9 +141,7 @@ fn collect_imported_module_context_for_module(imports: NativeImport[], current_m
 
         let mut updated_manifests = manifests;
         updated_manifests = updated_manifests.push(LayoutManifest {
-                structs: manifest_structs,
-                enums: manifest_enums,
-                diagnostics: [],
+            structs: manifest_structs, enums: manifest_enums, diagnostics: [],
         });
         manifests = updated_manifests;
         let mut updated_texts = native_texts;
@@ -159,9 +157,7 @@ fn collect_imported_module_context_for_module(imports: NativeImport[], current_m
             let mut ti: number = 0;
             let next_depth = depth + 1;
             loop {
-                if ti >= transitive_imports.length {
-                    break;
-                }
+                if ti >= transitive_imports.length { break; }
                 let ti_entry = transitive_imports[ti];
                 if ti_entry.kind == "import" {
                     queue_paths.push(ti_entry.module);
@@ -177,18 +173,18 @@ fn collect_imported_module_context_for_module(imports: NativeImport[], current_m
         print.err("test llvm: collect_imported_module_context done (unique_imports=" + number_to_string(seen.length) + ")");
     }
 
-    return ImportedModuleContext { manifests: manifests, native_texts: native_texts, diagnostics: diagnostics };
+    return ImportedModuleContext {
+        manifests: manifests,
+        native_texts: native_texts,
+        diagnostics: diagnostics
+    };
 }
 
 fn resolve_import_artifact_slug(slug: string) -> string ![io] {
-    if slug.length == 0 {
-        return slug;
-    }
+    if slug.length == 0 { return slug; }
 
     // Prefer the direct slug if it exists.
-    if fs.exists(_resolve_layout_manifest_path_for_slug(slug)) {
-        return slug;
-    }
+    if fs.exists(_resolve_layout_manifest_path_for_slug(slug)) { return slug; }
 
     // Directory imports (e.g. "./parser") resolve to `parser` but the actual
     // module is typically `parser/mod`. Fall back to that layout.
@@ -205,7 +201,6 @@ fn resolve_import_artifact_slug(slug: string) -> string ![io] {
 // =============================================================================
 // Module Path Resolution
 // =============================================================================
-
 fn resolve_import_module_slug(module: string) -> string {
     return resolve_import_module_slug_for_module(module, "");
 }
@@ -214,26 +209,18 @@ fn dirname_for_module_slug(slug: string) -> string {
     let mut last_slash: number = -1;
     let mut index: number = 0;
     loop {
-        if index >= slug.length {
-            break;
-        }
+        if index >= slug.length { break; }
         let _sl_end = index + 1;
-        if substring(slug, index, _sl_end) == "/" {
-            last_slash = index;
-        }
+        if substring(slug, index, _sl_end) == "/" { last_slash = index; }
         index += 1;
     }
-    if last_slash < 0 {
-        return "";
-    }
+    if last_slash < 0 { return ""; }
     return substring(slug, 0, last_slash);
 }
 
 fn resolve_import_module_slug_for_module(module: string, current_module_slug: string) -> string {
     let trimmed = trim_text(module);
-    if trimmed.length == 0 {
-        return "";
-    }
+    if trimmed.length == 0 { return ""; }
 
     let mut normalized = normalize_import_module_path(trimmed);
     let mut current_slug = normalize_import_module_path(current_module_slug);
@@ -252,9 +239,7 @@ fn resolve_import_module_slug_for_module(module: string, current_module_slug: st
                 let mut rebuilt: string = "";
                 let mut idx: number = 0;
                 loop {
-                    if idx >= current_slug.length {
-                        break;
-                    }
+                    if idx >= current_slug.length { break; }
                     let _imp_next = idx + 1;
                     let ch = substring(current_slug, idx, _imp_next);
                     let _imp_next2 = idx + 2;
@@ -283,9 +268,7 @@ fn resolve_import_module_slug_for_module(module: string, current_module_slug: st
     if starts_with(normalized, "../") { _if190 = true; }
     if _if190 {
         let base_dir = dirname_for_module_slug(current_slug);
-        if base_dir.length > 0 {
-            normalized = base_dir + "/" + normalized;
-        }
+        if base_dir.length > 0 { normalized = base_dir + "/" + normalized; }
     }
 
     // Normalize relative module specifiers (./foo, ../bar, foo/../baz) into
@@ -297,30 +280,20 @@ fn resolve_import_module_slug_for_module(module: string, current_module_slug: st
     let mut segment: string = "";
     let mut index: number = 0;
     loop {
-        if index >= normalized.length {
-            break;
-        }
+        if index >= normalized.length { break; }
         let ch = substring(normalized, index, index + 1);
         if ch == "/" {
-            if segment.length > 0 {
-                parts.push(segment);
-            }
+            if segment.length > 0 { parts.push(segment); }
             segment = "";
-        } else {
-            segment = segment + ch;
-        }
+        } else { segment = segment + ch; }
         index += 1;
     }
-    if segment.length > 0 {
-        parts.push(segment);
-    }
+    if segment.length > 0 { parts.push(segment); }
 
     let mut resolved: string[] = [];
     index = 0;
     loop {
-        if index >= parts.length {
-            break;
-        }
+        if index >= parts.length { break; }
         let part = parts[index];
         let mut _if191: boolean = false;
         if part.length == 0 { _if191 = true; }
@@ -335,9 +308,7 @@ fn resolve_import_module_slug_for_module(module: string, current_module_slug: st
                 let mut drop_index: number = 0;
                 let limit = resolved.length - 1;
                 loop {
-                    if drop_index >= limit {
-                        break;
-                    }
+                    if drop_index >= limit { break; }
                     shortened.push(resolved[drop_index]);
                     drop_index += 1;
                 }
@@ -383,25 +354,17 @@ fn _selfhost_native_text_path_for_slug(slug: string) -> string {
 
 fn _resolve_layout_manifest_path_for_slug(slug: string) -> string ![io] {
     let primary = layout_manifest_path_for_slug(slug);
-    if fs.exists(primary) {
-        return primary;
-    }
+    if fs.exists(primary) { return primary; }
     let fallback = _selfhost_layout_manifest_path_for_slug(slug);
-    if fs.exists(fallback) {
-        return fallback;
-    }
+    if fs.exists(fallback) { return fallback; }
     return primary;
 }
 
 fn _resolve_native_text_path_for_slug(slug: string) -> string ![io] {
     let primary = native_text_path_for_slug(slug);
-    if fs.exists(primary) {
-        return primary;
-    }
+    if fs.exists(primary) { return primary; }
     let fallback = _selfhost_native_text_path_for_slug(slug);
-    if fs.exists(fallback) {
-        return fallback;
-    }
+    if fs.exists(fallback) { return fallback; }
     return primary;
 }
 
@@ -409,15 +372,9 @@ fn normalize_import_module_path(value: string) -> string {
     let mut result: string = "";
     let mut index: number = 0;
     loop {
-        if index >= value.length {
-            break;
-        }
+        if index >= value.length { break; }
         let ch = substring(value, index, index + 1);
-        if ch == "\\" {
-            result = result + "/";
-        } else {
-            result = result + ch;
-        }
+        if ch == "\\" { result = result + "/"; } else { result = result + ch; }
         index += 1;
     }
     return result;
@@ -426,7 +383,6 @@ fn normalize_import_module_path(value: string) -> string {
 // =============================================================================
 // Cached Capsule Resolution
 // =============================================================================
-
 // Check whether a module path (e.g. "sfn/cli") corresponds to a cached
 // capsule dependency.  `deps` is a newline-separated "name=version" string
 // from toml_get_dependencies().  `home_dir` is the user's home directory
@@ -464,9 +420,7 @@ fn resolve_cached_capsule_source(module: string, deps: string, home_dir: string)
     // key is the bare name (e.g. "cli" for "sfn/cli").  For third-party
     // capsules, the key is the full scoped name (e.g. "acme/router").
     let mut dep_name: string = module;
-    if starts_with(module, "sfn/") {
-        dep_name = name;
-    }
+    if starts_with(module, "sfn/") { dep_name = name; }
 
     // Search deps for the matching entry
     let mut version: string = "";
@@ -512,19 +466,20 @@ fn resolve_cached_capsule_source(module: string, deps: string, home_dir: string)
 
     // Construct cache path
     let cached_path = home_dir + "/.sfn/cache/capsules/" + scope + "/" + name + "/" + version + "/src/mod.sfn";
-    if fs.exists(cached_path) {
-        return cached_path;
-    }
+    if fs.exists(cached_path) { return cached_path; }
     return "";
 }
 
 // =============================================================================
 // Layout Manifest Application
 // =============================================================================
-
 fn apply_layout_manifest_to_module(structs: NativeStruct[], enums: NativeEnum[], manifest: LayoutManifest?) -> LayoutManifestApplication {
     if manifest == null {
-        return LayoutManifestApplication { structs: structs, enums: enums, diagnostics: [] };
+        return LayoutManifestApplication {
+            structs: structs,
+            enums: enums,
+            diagnostics: []
+        };
     }
     return apply_layout_manifest_entries(structs, enums, manifest);
 }
@@ -535,9 +490,7 @@ fn apply_layout_manifest_entries(structs: NativeStruct[], enums: NativeEnum[], m
     let mut updated_structs: NativeStruct[] = structs;
     let mut struct_index: number = 0;
     loop {
-        if struct_index >= manifest.structs.length {
-            break;
-        }
+        if struct_index >= manifest.structs.length { break; }
         let layout_struct = manifest.structs[struct_index];
         let target_index = find_struct_index(updated_structs, layout_struct.name);
         if target_index < 0 {
@@ -559,9 +512,7 @@ fn apply_layout_manifest_entries(structs: NativeStruct[], enums: NativeEnum[], m
     let mut updated_enums: NativeEnum[] = enums;
     let mut enum_index: number = 0;
     loop {
-        if enum_index >= manifest.enums.length {
-            break;
-        }
+        if enum_index >= manifest.enums.length { break; }
         let layout_enum = manifest.enums[enum_index];
         let target_index = find_enum_index(updated_enums, layout_enum.name);
         if target_index < 0 {
@@ -588,16 +539,11 @@ fn apply_layout_manifest_entries(structs: NativeStruct[], enums: NativeEnum[], m
 // =============================================================================
 // Helper Functions
 // =============================================================================
-
 fn find_struct_index(structs: NativeStruct[], name: string) -> number {
     let mut index: number = 0;
     loop {
-        if index >= structs.length {
-            break;
-        }
-        if structs[index].name == name {
-            return index;
-        }
+        if index >= structs.length { break; }
+        if structs[index].name == name { return index; }
         index += 1;
     }
     return -1;
@@ -606,12 +552,8 @@ fn find_struct_index(structs: NativeStruct[], name: string) -> number {
 fn find_enum_index(enums: NativeEnum[], name: string) -> number {
     let mut index: number = 0;
     loop {
-        if index >= enums.length {
-            break;
-        }
-        if enums[index].name == name {
-            return index;
-        }
+        if index >= enums.length { break; }
+        if enums[index].name == name { return index; }
         index += 1;
     }
     return -1;
@@ -621,12 +563,8 @@ fn replace_native_struct(structs: NativeStruct[], index: number, replacement: Na
     let mut result: NativeStruct[] = [];
     let mut i: number = 0;
     loop {
-        if i >= structs.length {
-            break;
-        }
-        if i == index {
-            result.push(replacement);
-        } else {
+        if i >= structs.length { break; }
+        if i == index { result.push(replacement); } else {
             result.push(structs[i]);
         }
         i += 1;
@@ -638,12 +576,8 @@ fn replace_native_enum(enums: NativeEnum[], index: number, replacement: NativeEn
     let mut result: NativeEnum[] = [];
     let mut i: number = 0;
     loop {
-        if i >= enums.length {
-            break;
-        }
-        if i == index {
-            result.push(replacement);
-        } else {
+        if i >= enums.length { break; }
+        if i == index { result.push(replacement); } else {
             result.push(enums[i]);
         }
         i += 1;

--- a/compiler/src/llvm/lifetime.sfn
+++ b/compiler/src/llvm/lifetime.sfn
@@ -271,7 +271,9 @@ fn extract_borrow_argument(text: string) -> BorrowArgumentParse {
     let inner = substring(text, 1, closing_index);
     let remainder = trim_text(substring(text, closing_index + 1, text.length));
     if remainder.length > 0 {
-        diagnostics.push("llvm lowering: borrow expression trailing content `" + remainder + "`");
+        diagnostics.push("llvm lowering: borrow expression trailing content `"
+            + remainder
+            + "`");
         return BorrowArgumentParse {
             success: false,
             argument: "",
@@ -314,7 +316,9 @@ fn extract_simple_borrow_target(text: string) -> BorrowArgumentParse {
     }
     let remainder = trim_text(substring(trimmed, index, trimmed.length));
     if remainder.length > 0 {
-        diagnostics.push("llvm lowering: borrow expression trailing content `" + remainder + "`");
+        diagnostics.push("llvm lowering: borrow expression trailing content `"
+            + remainder
+            + "`");
         return BorrowArgumentParse {
             success: false,
             argument: target,
@@ -382,7 +386,8 @@ fn lower_borrow_expression(parse: BorrowParseResult, bindings: ParameterBinding[
     if local == null {
         let parameter = find_parameter_binding(bindings, target);
         if parameter == null {
-            diagnostics.push("llvm lowering: borrow target `" + target + "` not found");
+            diagnostics.push("llvm lowering: borrow target `" + target
+                + "` not found");
             return ExpressionResult {
                 lines: lines,
                 temp_index: temp_index,
@@ -407,7 +412,11 @@ fn lower_borrow_expression(parse: BorrowParseResult, bindings: ParameterBinding[
             };
         }
 
-        diagnostics.push("llvm lowering: cannot borrow non-addressable parameter `" + target + "` (type `" + parameter.llvm_type + "`)");
+        diagnostics.push("llvm lowering: cannot borrow non-addressable parameter `"
+            + target
+            + "` (type `"
+            + parameter.llvm_type
+            + "`)");
         return ExpressionResult {
             lines: lines,
             temp_index: temp_index,
@@ -565,7 +574,7 @@ fn update_local_ownership(locals: LocalBinding[], name: string, ownership: Owner
                 ownership: ownership,
                 consumed: entry.consumed,
                 scope_id: entry.scope_id,
-                scope_depth: entry.scope_depth,
+                scope_depth: entry.scope_depth
             };
             result.push(updated);
         } else { result.push(entry); }
@@ -593,13 +602,37 @@ fn detect_borrow_conflicts(ownership: OwnershipInfo?, locals: LocalBinding[], bi
                 if existing_base == base {
                     if ownership.mutable {
                         if details.mutable {
-                            diagnostics.push("llvm lowering: mutable borrow `" + binding_name + "` conflicts with active mutable borrow `" + existing.name + "` of `" + base + "` in `" + function_name + "`");
+                            diagnostics.push("llvm lowering: mutable borrow `"
+                                + binding_name
+                                + "` conflicts with active mutable borrow `"
+                                + existing.name
+                                + "` of `"
+                                + base
+                                + "` in `"
+                                + function_name
+                                + "`");
                         } else {
-                            diagnostics.push("llvm lowering: mutable borrow `" + binding_name + "` conflicts with active shared borrow `" + existing.name + "` of `" + base + "` in `" + function_name + "`");
+                            diagnostics.push("llvm lowering: mutable borrow `"
+                                + binding_name
+                                + "` conflicts with active shared borrow `"
+                                + existing.name
+                                + "` of `"
+                                + base
+                                + "` in `"
+                                + function_name
+                                + "`");
                         }
                     } else {
                         if details.mutable {
-                            diagnostics.push("llvm lowering: shared borrow `" + binding_name + "` conflicts with active mutable borrow `" + existing.name + "` of `" + base + "` in `" + function_name + "`");
+                            diagnostics.push("llvm lowering: shared borrow `"
+                                + binding_name
+                                + "` conflicts with active mutable borrow `"
+                                + existing.name
+                                + "` of `"
+                                + base
+                                + "` in `"
+                                + function_name
+                                + "`");
                         }
                     }
                 }
@@ -694,7 +727,7 @@ fn mark_lifetime_region_released(regions: LifetimeRegionMetadata[], region_id: n
                 base_scope_depth: entry.base_scope_depth,
                 end_scope_id: scope_id,
                 end_scope_depth: scope_depth,
-                released: true,
+                released: true
             };
             result.push(updated);
         } else { result.push(entry); }
@@ -729,7 +762,7 @@ fn make_lifetime_region_metadata(id: number, binding: string, ownership: Ownersh
         base_scope_depth: base_scope_depth,
         end_scope_id: "",
         end_scope_depth: 0,
-        released: false,
+        released: false
     };
 }
 
@@ -761,7 +794,11 @@ fn validate_borrow_lifetimes(function: NativeFunction, regions: LifetimeRegionMe
     let mut diagnostics: string[] = [];
     if regions == null { return diagnostics; }
     if regions.length > 1000000 {
-        diagnostics.push("llvm lowering: lifetime region overflow in `" + function.name + "` (len=" + number_to_string(regions.length) + ")");
+        diagnostics.push("llvm lowering: lifetime region overflow in `"
+            + function.name
+            + "` (len="
+            + number_to_string(regions.length)
+            + ")");
         return diagnostics;
     }
     let mut index: number = 0;
@@ -790,7 +827,15 @@ fn validate_borrow_lifetimes(function: NativeFunction, regions: LifetimeRegionMe
             if region.start_span != null {
                 location = " at " + format_span_location(region.start_span);
             }
-            diagnostics.push("llvm lowering: borrow `" + region.binding + "` of `" + region.base + "` escapes lifetime of `" + region.base + "` in `" + function.name + "`" + location);
+            diagnostics.push("llvm lowering: borrow `" + region.binding
+                + "` of `"
+                + region.base
+                + "` escapes lifetime of `"
+                + region.base
+                + "` in `"
+                + function.name
+                + "`"
+                + location);
         }
         index += 1;
     }
@@ -813,7 +858,15 @@ fn collect_suspension_conflicts(keyword: string, locals: LocalBinding[], binding
                     if details.mutable {
                         let base_name = normalise_borrow_base(details.base);
                         let location = format_suspension_location(keyword, details.span, suspension_span);
-                        diagnostics.push("llvm lowering: " + keyword + " suspends while mutable borrow `" + local.name + "` of `" + base_name + "` remains active in `" + function_name + "`" + location);
+                        diagnostics.push("llvm lowering: " + keyword
+                            + " suspends while mutable borrow `"
+                            + local.name
+                            + "` of `"
+                            + base_name
+                            + "` remains active in `"
+                            + function_name
+                            + "`"
+                            + location);
                     }
                 }
             }
@@ -827,7 +880,13 @@ fn collect_suspension_conflicts(keyword: string, locals: LocalBinding[], binding
         if !binding.consumed {
             if is_mutable_borrow_annotation(binding.type_annotation) {
                 let location = format_suspension_location(keyword, binding.span, suspension_span);
-                diagnostics.push("llvm lowering: " + keyword + " suspends while mutable borrow parameter `" + binding.name + "` remains active in `" + function_name + "`" + location);
+                diagnostics.push("llvm lowering: " + keyword
+                    + " suspends while mutable borrow parameter `"
+                    + binding.name
+                    + "` remains active in `"
+                    + function_name
+                    + "`"
+                    + location);
             }
         }
         parameter_index += 1;
@@ -898,7 +957,8 @@ fn format_use_after_move_message(name: string, span: NativeSourceSpan?) -> strin
     if span == null {
         return "llvm lowering: use-after-move of `" + name + "`";
     }
-    return "llvm lowering: use-after-move of `" + name + "` at " + format_span_location(span);
+    return "llvm lowering: use-after-move of `" + name + "` at "
+        + format_span_location(span);
 }
 
 fn format_span_location(span: NativeSourceSpan) -> string {

--- a/compiler/src/llvm/lifetime.sfn
+++ b/compiler/src/llvm/lifetime.sfn
@@ -2,29 +2,58 @@
 //
 // Lifetime tracking, borrow checking, and ownership analysis for LLVM lowering.
 // Handles borrow expression parsing, lifetime region management, and conflict detection.
-
 import { NativeFunction, NativeSourceSpan } from "../native_ir";
-import { substring, find_char } from "../string_utils";
-import {
-    LocalBinding, ParameterBinding, OwnershipInfo, OwnershipConsumption, OwnershipAnalysis,
-    LifetimeRegionMetadata, LifetimeReleaseEvent, BorrowParseResult, BorrowArgumentParse,
-    ScopeMetadata, LLVMOperand, ExpressionResult, StringConstant
-} from "./types";
-import { trim_text, append_string, starts_with, ends_with, char_at, sanitize_symbol, is_identifier_start_char, is_identifier_part_char, number_to_string } from "./utils";
-import { empty_string_constant_set } from "./strings";
+import { find_char, substring } from "../string_utils";
 import { find_local_binding, find_parameter_binding } from "./expressions_bindings";
-import { is_simple_identifier, is_effect_delimiter, strip_enclosing_parentheses, is_copy_type } from "./expressions_helpers";
+import {
+    is_copy_type,
+    is_effect_delimiter,
+    is_simple_identifier,
+    strip_enclosing_parentheses
+} from "./expressions_helpers";
+import { empty_string_constant_set } from "./strings";
 import { unwrap_move_wrapper } from "./type_mapping";
+import {
+    BorrowArgumentParse,
+    BorrowParseResult,
+    ExpressionResult,
+    LLVMOperand,
+    LifetimeRegionMetadata,
+    LifetimeReleaseEvent,
+    LocalBinding,
+    OwnershipAnalysis,
+    OwnershipConsumption,
+    OwnershipInfo,
+    ParameterBinding,
+    ScopeMetadata,
+    StringConstant
+} from "./types";
+import {
+    append_string,
+    char_at,
+    ends_with,
+    is_identifier_part_char,
+    is_identifier_start_char,
+    number_to_string,
+    sanitize_symbol,
+    starts_with,
+    trim_text
+} from "./utils";
 
 // =============================================================================
 // Borrow Expression Parsing
 // =============================================================================
-
 fn parse_borrow_expression(text: string) -> BorrowParseResult {
     let trimmed = trim_text(text);
     let diagnostics: string[] = [];
     if trimmed.length == 0 {
-        return BorrowParseResult { recognized: false, success: false, target: "", mutable: false, diagnostics: diagnostics };
+        return BorrowParseResult {
+            recognized: false,
+            success: false,
+            target: "",
+            mutable: false,
+            diagnostics: diagnostics
+        };
     }
 
     if starts_with(trimmed, "borrow") {
@@ -35,7 +64,13 @@ fn parse_borrow_expression(text: string) -> BorrowParseResult {
             if next != " " {
                 if next != "\t" {
                     if next != "(" {
-                        return BorrowParseResult { recognized: false, success: false, target: "", mutable: false, diagnostics: diagnostics };
+                        return BorrowParseResult {
+                            recognized: false,
+                            success: false,
+                            target: "",
+                            mutable: false,
+                            diagnostics: diagnostics
+                        };
                     }
                 }
             }
@@ -43,7 +78,13 @@ fn parse_borrow_expression(text: string) -> BorrowParseResult {
         let mut remainder: string = trim_text(substring(trimmed, 6, trimmed.length));
         if remainder.length == 0 {
             let issue = append_string(diagnostics, "llvm lowering: borrow expression missing target");
-            return BorrowParseResult { recognized: true, success: false, target: "", mutable: false, diagnostics: issue };
+            return BorrowParseResult {
+                recognized: true,
+                success: false,
+                target: "",
+                mutable: false,
+                diagnostics: issue
+            };
         }
         let mut mutable_flag: boolean = false;
         if starts_with(remainder, "mut") {
@@ -68,7 +109,13 @@ fn parse_borrow_expression(text: string) -> BorrowParseResult {
                     _ci1 += 1;
                 }
                 if !argument_parse.success {
-                    return BorrowParseResult { recognized: true, success: false, target: "", mutable: mutable_flag, diagnostics: messages };
+                    return BorrowParseResult {
+                        recognized: true,
+                        success: false,
+                        target: "",
+                        mutable: mutable_flag,
+                        diagnostics: messages
+                    };
                 }
                 let mut argument_text: string = argument_parse.argument;
                 if starts_with(argument_text, "mut") {
@@ -81,30 +128,78 @@ fn parse_borrow_expression(text: string) -> BorrowParseResult {
                 }
                 if argument_text.length == 0 {
                     messages.push("llvm lowering: borrow expression missing target");
-                    return BorrowParseResult { recognized: true, success: false, target: "", mutable: mutable_flag, diagnostics: messages };
+                    return BorrowParseResult {
+                        recognized: true,
+                        success: false,
+                        target: "",
+                        mutable: mutable_flag,
+                        diagnostics: messages
+                    };
                 }
                 if !is_valid_borrow_target(argument_text) {
-                    return BorrowParseResult { recognized: false, success: false, target: "", mutable: mutable_flag, diagnostics: diagnostics };
+                    return BorrowParseResult {
+                        recognized: false,
+                        success: false,
+                        target: "",
+                        mutable: mutable_flag,
+                        diagnostics: diagnostics
+                    };
                 }
-                return BorrowParseResult { recognized: true, success: true, target: argument_text, mutable: mutable_flag, diagnostics: messages };
+                return BorrowParseResult {
+                    recognized: true,
+                    success: true,
+                    target: argument_text,
+                    mutable: mutable_flag,
+                    diagnostics: messages
+                };
             }
         }
 
         let simple_parse = extract_simple_borrow_target(remainder);
         if !simple_parse.success {
-            return BorrowParseResult { recognized: false, success: false, target: "", mutable: mutable_flag, diagnostics: diagnostics };
+            return BorrowParseResult {
+                recognized: false,
+                success: false,
+                target: "",
+                mutable: mutable_flag,
+                diagnostics: diagnostics
+            };
         }
         if !is_valid_borrow_target(simple_parse.argument) {
-            return BorrowParseResult { recognized: false, success: false, target: "", mutable: mutable_flag, diagnostics: diagnostics };
+            return BorrowParseResult {
+                recognized: false,
+                success: false,
+                target: "",
+                mutable: mutable_flag,
+                diagnostics: diagnostics
+            };
         }
-        return BorrowParseResult { recognized: true, success: true, target: simple_parse.argument, mutable: mutable_flag, diagnostics: diagnostics };
+        return BorrowParseResult {
+            recognized: true,
+            success: true,
+            target: simple_parse.argument,
+            mutable: mutable_flag,
+            diagnostics: diagnostics
+        };
     }
 
     if !starts_with(trimmed, "&") {
-        return BorrowParseResult { recognized: false, success: false, target: "", mutable: false, diagnostics: diagnostics };
+        return BorrowParseResult {
+            recognized: false,
+            success: false,
+            target: "",
+            mutable: false,
+            diagnostics: diagnostics
+        };
     }
     if starts_with(trimmed, "&&") {
-        return BorrowParseResult { recognized: false, success: false, target: "", mutable: false, diagnostics: diagnostics };
+        return BorrowParseResult {
+            recognized: false,
+            success: false,
+            target: "",
+            mutable: false,
+            diagnostics: diagnostics
+        };
     }
     let mut remainder: string = trim_text(substring(trimmed, 1, trimmed.length));
     let mut mutable_flag: boolean = false;
@@ -115,9 +210,21 @@ fn parse_borrow_expression(text: string) -> BorrowParseResult {
     }
     if remainder.length == 0 {
         let issue = append_string(diagnostics, "llvm lowering: borrow expression missing target");
-        return BorrowParseResult { recognized: true, success: false, target: "", mutable: mutable_flag, diagnostics: issue };
+        return BorrowParseResult {
+            recognized: true,
+            success: false,
+            target: "",
+            mutable: mutable_flag,
+            diagnostics: issue
+        };
     }
-    return BorrowParseResult { recognized: true, success: true, target: trim_text(remainder), mutable: mutable_flag, diagnostics: diagnostics };
+    return BorrowParseResult {
+        recognized: true,
+        success: true,
+        target: trim_text(remainder),
+        mutable: mutable_flag,
+        diagnostics: diagnostics
+    };
 }
 
 fn extract_borrow_argument(text: string) -> BorrowArgumentParse {
@@ -126,9 +233,7 @@ fn extract_borrow_argument(text: string) -> BorrowArgumentParse {
     let mut index: number = 0;
     let mut closing_index: number = -1;
     loop {
-        if index >= text.length {
-            break;
-        }
+        if index >= text.length { break; }
         let ch = substring(text, index, index + 1);
         if ch == "(" {
             depth += 1;
@@ -138,7 +243,11 @@ fn extract_borrow_argument(text: string) -> BorrowArgumentParse {
         if ch == ")" {
             if depth == 0 {
                 diagnostics.push("llvm lowering: borrow expression missing opening `(`");
-                return BorrowArgumentParse { success: false, argument: "", diagnostics: diagnostics };
+                return BorrowArgumentParse {
+                    success: false,
+                    argument: "",
+                    diagnostics: diagnostics
+                };
             }
             depth -= 1;
             let current_index = index;
@@ -153,15 +262,27 @@ fn extract_borrow_argument(text: string) -> BorrowArgumentParse {
     }
     if closing_index < 0 {
         diagnostics.push("llvm lowering: borrow expression missing closing `)`");
-        return BorrowArgumentParse { success: false, argument: "", diagnostics: diagnostics };
+        return BorrowArgumentParse {
+            success: false,
+            argument: "",
+            diagnostics: diagnostics
+        };
     }
     let inner = substring(text, 1, closing_index);
     let remainder = trim_text(substring(text, closing_index + 1, text.length));
     if remainder.length > 0 {
         diagnostics.push("llvm lowering: borrow expression trailing content `" + remainder + "`");
-        return BorrowArgumentParse { success: false, argument: "", diagnostics: diagnostics };
+        return BorrowArgumentParse {
+            success: false,
+            argument: "",
+            diagnostics: diagnostics
+        };
     }
-    return BorrowArgumentParse { success: true, argument: trim_text(inner), diagnostics: diagnostics };
+    return BorrowArgumentParse {
+        success: true,
+        argument: trim_text(inner),
+        diagnostics: diagnostics
+    };
 }
 
 fn extract_simple_borrow_target(text: string) -> BorrowArgumentParse {
@@ -169,55 +290,59 @@ fn extract_simple_borrow_target(text: string) -> BorrowArgumentParse {
     let trimmed = trim_text(text);
     if trimmed.length == 0 {
         diagnostics.push("llvm lowering: borrow expression missing target");
-        return BorrowArgumentParse { success: false, argument: "", diagnostics: diagnostics };
+        return BorrowArgumentParse {
+            success: false,
+            argument: "",
+            diagnostics: diagnostics
+        };
     }
     let mut index: number = 0;
     loop {
-        if index >= trimmed.length {
-            break;
-        }
+        if index >= trimmed.length { break; }
         let ch = substring(trimmed, index, index + 1);
-        if is_effect_delimiter(ch) {
-            break;
-        }
+        if is_effect_delimiter(ch) { break; }
         index += 1;
     }
     let target = trim_text(substring(trimmed, 0, index));
     if target.length == 0 {
         diagnostics.push("llvm lowering: borrow expression missing target");
-        return BorrowArgumentParse { success: false, argument: "", diagnostics: diagnostics };
+        return BorrowArgumentParse {
+            success: false,
+            argument: "",
+            diagnostics: diagnostics
+        };
     }
     let remainder = trim_text(substring(trimmed, index, trimmed.length));
     if remainder.length > 0 {
         diagnostics.push("llvm lowering: borrow expression trailing content `" + remainder + "`");
-        return BorrowArgumentParse { success: false, argument: target, diagnostics: diagnostics };
+        return BorrowArgumentParse {
+            success: false,
+            argument: target,
+            diagnostics: diagnostics
+        };
     }
-    return BorrowArgumentParse { success: true, argument: target, diagnostics: diagnostics };
+    return BorrowArgumentParse {
+        success: true,
+        argument: target,
+        diagnostics: diagnostics
+    };
 }
 
 fn is_valid_borrow_target(text: string) -> boolean {
     let trimmed = trim_text(text);
-    if trimmed.length == 0 {
-        return false;
-    }
+    if trimmed.length == 0 { return false; }
     let mut index: number = 0;
     loop {
-        if index >= trimmed.length {
-            break;
-        }
+        if index >= trimmed.length { break; }
         let ch = substring(trimmed, index, index + 1);
         if ch == "." {
             index += 1;
             continue;
         }
         if index == 0 {
-            if !is_identifier_start_char(ch) {
-                return false;
-            }
+            if !is_identifier_start_char(ch) { return false; }
         } else {
-            if !is_identifier_part_char(ch) {
-                return false;
-            }
+            if !is_identifier_part_char(ch) { return false; }
         }
         index += 1;
     }
@@ -227,19 +352,30 @@ fn is_valid_borrow_target(text: string) -> boolean {
 // =============================================================================
 // Borrow Expression Lowering
 // =============================================================================
-
 fn lower_borrow_expression(parse: BorrowParseResult, bindings: ParameterBinding[], locals: LocalBinding[], temp_index: number, lines: string[]) -> ExpressionResult {
     let mut diagnostics: string[] = parse.diagnostics;
     let empty_constants = empty_string_constant_set();
     if !parse.success {
-        return ExpressionResult { lines: lines, temp_index: temp_index, operand: null, diagnostics: diagnostics, string_constants: empty_constants };
+        return ExpressionResult {
+            lines: lines,
+            temp_index: temp_index,
+            operand: null,
+            diagnostics: diagnostics,
+            string_constants: empty_constants
+        };
     }
 
     let mut target = strip_enclosing_parentheses(parse.target);
     target = trim_text(target);
     if target.length == 0 {
         diagnostics.push("llvm lowering: borrow expression missing target");
-        return ExpressionResult { lines: lines, temp_index: temp_index, operand: null, diagnostics: diagnostics, string_constants: empty_constants };
+        return ExpressionResult {
+            lines: lines,
+            temp_index: temp_index,
+            operand: null,
+            diagnostics: diagnostics,
+            string_constants: empty_constants
+        };
     }
 
     let local = find_local_binding(locals, target);
@@ -247,50 +383,105 @@ fn lower_borrow_expression(parse: BorrowParseResult, bindings: ParameterBinding[
         let parameter = find_parameter_binding(bindings, target);
         if parameter == null {
             diagnostics.push("llvm lowering: borrow target `" + target + "` not found");
-            return ExpressionResult { lines: lines, temp_index: temp_index, operand: null, diagnostics: diagnostics, string_constants: empty_constants };
+            return ExpressionResult {
+                lines: lines,
+                temp_index: temp_index,
+                operand: null,
+                diagnostics: diagnostics,
+                string_constants: empty_constants
+            };
         }
 
         // If the parameter is already a reference/pointer type, borrowing it is an identity.
         if ends_with(parameter.llvm_type, "*") {
-            let operand = LLVMOperand { llvm_type: parameter.llvm_type, value: parameter.llvm_name };
-            return ExpressionResult { lines: lines, temp_index: temp_index, operand: operand, diagnostics: diagnostics, string_constants: empty_constants };
+            let operand = LLVMOperand {
+                llvm_type: parameter.llvm_type,
+                value: parameter.llvm_name
+            };
+            return ExpressionResult {
+                lines: lines,
+                temp_index: temp_index,
+                operand: operand,
+                diagnostics: diagnostics,
+                string_constants: empty_constants
+            };
         }
 
         diagnostics.push("llvm lowering: cannot borrow non-addressable parameter `" + target + "` (type `" + parameter.llvm_type + "`)");
-        return ExpressionResult { lines: lines, temp_index: temp_index, operand: null, diagnostics: diagnostics, string_constants: empty_constants };
+        return ExpressionResult {
+            lines: lines,
+            temp_index: temp_index,
+            operand: null,
+            diagnostics: diagnostics,
+            string_constants: empty_constants
+        };
     }
 
     let pointer_type = local.llvm_type + "*";
-    let operand = LLVMOperand { llvm_type: pointer_type, value: local.pointer };
-    return ExpressionResult { lines: lines, temp_index: temp_index, operand: operand, diagnostics: diagnostics, string_constants: empty_constants };
+    let operand = LLVMOperand {
+        llvm_type: pointer_type,
+        value: local.pointer
+    };
+    return ExpressionResult {
+        lines: lines,
+        temp_index: temp_index,
+        operand: operand,
+        diagnostics: diagnostics,
+        string_constants: empty_constants
+    };
 }
 
 // =============================================================================
 // Ownership Analysis
 // =============================================================================
-
 fn analyze_value_ownership(initializer: string?, span: NativeSourceSpan?, locals: LocalBinding[], bindings: ParameterBinding[]) -> OwnershipAnalysis {
     if initializer == null {
-        return OwnershipAnalysis { ownership: null, consumption: null, diagnostics: [] };
+        return OwnershipAnalysis {
+            ownership: null,
+            consumption: null,
+            diagnostics: []
+        };
     }
     let trimmed = trim_text(initializer);
     if trimmed.length == 0 {
-        return OwnershipAnalysis { ownership: null, consumption: null, diagnostics: [] };
+        return OwnershipAnalysis {
+            ownership: null,
+            consumption: null,
+            diagnostics: []
+        };
     }
 
     let parse = parse_borrow_expression(trimmed);
     let mut diagnostics: string[] = parse.diagnostics;
     if parse.recognized {
         if !parse.success {
-            return OwnershipAnalysis { ownership: null, consumption: null, diagnostics: diagnostics };
+            return OwnershipAnalysis {
+                ownership: null,
+                consumption: null,
+                diagnostics: diagnostics
+            };
         }
         let resolved_base = resolve_borrow_base(parse.target, locals);
         if resolved_base.length == 0 {
             diagnostics.push("llvm lowering: borrow expression missing target");
-            return OwnershipAnalysis { ownership: null, consumption: null, diagnostics: diagnostics };
+            return OwnershipAnalysis {
+                ownership: null,
+                consumption: null,
+                diagnostics: diagnostics
+            };
         }
-        let ownership = OwnershipInfo { variant: "Borrow", base: resolved_base, mutable: parse.mutable, span: span, region_id: -1 };
-        return OwnershipAnalysis { ownership: ownership, consumption: null, diagnostics: diagnostics };
+        let ownership = OwnershipInfo {
+            variant: "Borrow",
+            base: resolved_base,
+            mutable: parse.mutable,
+            span: span,
+            region_id: -1
+        };
+        return OwnershipAnalysis {
+            ownership: ownership,
+            consumption: null,
+            diagnostics: diagnostics
+        };
     }
 
     if is_simple_identifier(trimmed) {
@@ -299,39 +490,71 @@ fn analyze_value_ownership(initializer: string?, span: NativeSourceSpan?, locals
         if local != null {
             if local.consumed {
                 diagnostics.push(format_use_after_move_message(name, span));
-                return OwnershipAnalysis { ownership: null, consumption: null, diagnostics: diagnostics };
+                return OwnershipAnalysis {
+                    ownership: null,
+                    consumption: null,
+                    diagnostics: diagnostics
+                };
             }
             if is_copy_type(local.type_annotation, local.llvm_type) {
-                return OwnershipAnalysis { ownership: null, consumption: null, diagnostics: diagnostics };
+                return OwnershipAnalysis {
+                    ownership: null,
+                    consumption: null,
+                    diagnostics: diagnostics
+                };
             }
-            let consumption = OwnershipConsumption { kind: "local", name: name };
-            return OwnershipAnalysis { ownership: null, consumption: consumption, diagnostics: diagnostics };
+            let consumption = OwnershipConsumption {
+                kind: "local",
+                name: name
+            };
+            return OwnershipAnalysis {
+                ownership: null,
+                consumption: consumption,
+                diagnostics: diagnostics
+            };
         }
 
         let parameter = find_parameter_binding(bindings, name);
         if parameter != null {
             if parameter.consumed {
                 diagnostics.push(format_use_after_move_message(name, span));
-                return OwnershipAnalysis { ownership: null, consumption: null, diagnostics: diagnostics };
+                return OwnershipAnalysis {
+                    ownership: null,
+                    consumption: null,
+                    diagnostics: diagnostics
+                };
             }
             if is_copy_type(parameter.type_annotation, parameter.llvm_type) {
-                return OwnershipAnalysis { ownership: null, consumption: null, diagnostics: diagnostics };
+                return OwnershipAnalysis {
+                    ownership: null,
+                    consumption: null,
+                    diagnostics: diagnostics
+                };
             }
-            let consumption = OwnershipConsumption { kind: "parameter", name: name };
-            return OwnershipAnalysis { ownership: null, consumption: consumption, diagnostics: diagnostics };
+            let consumption = OwnershipConsumption {
+                kind: "parameter",
+                name: name
+            };
+            return OwnershipAnalysis {
+                ownership: null,
+                consumption: consumption,
+                diagnostics: diagnostics
+            };
         }
     }
 
-    return OwnershipAnalysis { ownership: null, consumption: null, diagnostics: diagnostics };
+    return OwnershipAnalysis {
+        ownership: null,
+        consumption: null,
+        diagnostics: diagnostics
+    };
 }
 
 fn update_local_ownership(locals: LocalBinding[], name: string, ownership: OwnershipInfo?) -> LocalBinding[] {
     let mut result: LocalBinding[] = [];
     let mut index: number = 0;
     loop {
-        if index >= locals.length {
-            break;
-        }
+        if index >= locals.length { break; }
         let entry = locals[index];
         if entry.name == name {
             let updated = LocalBinding {
@@ -345,9 +568,7 @@ fn update_local_ownership(locals: LocalBinding[], name: string, ownership: Owner
                 scope_depth: entry.scope_depth,
             };
             result.push(updated);
-        } else {
-            result.push(entry);
-        }
+        } else { result.push(entry); }
         index += 1;
     }
     return result;
@@ -356,21 +577,14 @@ fn update_local_ownership(locals: LocalBinding[], name: string, ownership: Owner
 // =============================================================================
 // Borrow Conflict Detection
 // =============================================================================
-
 fn detect_borrow_conflicts(ownership: OwnershipInfo?, locals: LocalBinding[], binding_name: string, function_name: string) -> string[] {
     let mut diagnostics: string[] = [];
-    if ownership == null {
-        return diagnostics;
-    }
-    if ownership.variant != "Borrow" {
-        return diagnostics;
-    }
+    if ownership == null { return diagnostics; }
+    if ownership.variant != "Borrow" { return diagnostics; }
     let base = trim_text(ownership.base);
     let mut index: number = 0;
     loop {
-        if index >= locals.length {
-            break;
-        }
+        if index >= locals.length { break; }
         let existing = locals[index];
         if existing.ownership != null {
             let details = existing.ownership;
@@ -402,35 +616,21 @@ fn resolve_borrow_base(target: string, locals: LocalBinding[]) -> string {
 
 fn resolve_borrow_base_inner(target: string, locals: LocalBinding[], depth: number) -> string {
     let trimmed = trim_text(target);
-    if trimmed.length == 0 {
-        return trimmed;
-    }
-    if depth >= 8 {
-        return trimmed;
-    }
-    if !is_simple_identifier(trimmed) {
-        return trimmed;
-    }
+    if trimmed.length == 0 { return trimmed; }
+    if depth >= 8 { return trimmed; }
+    if !is_simple_identifier(trimmed) { return trimmed; }
     let binding = find_local_binding(locals, trimmed);
-    if binding == null {
-        return trimmed;
-    }
-    if binding.ownership == null {
-        return trimmed;
-    }
+    if binding == null { return trimmed; }
+    if binding.ownership == null { return trimmed; }
     let details = binding.ownership;
-    if details.variant != "Borrow" {
-        return trimmed;
-    }
+    if details.variant != "Borrow" { return trimmed; }
     return resolve_borrow_base_inner(details.base, locals, depth + 1);
 }
 
 fn normalise_borrow_base(raw_base: string) -> string {
     let mut trimmed = trim_text(raw_base);
     loop {
-        if trimmed.length == 0 {
-            break;
-        }
+        if trimmed.length == 0 { break; }
         if substring(trimmed, 0, 1) == "*" {
             trimmed = trim_text(substring(trimmed, 1, trimmed.length));
             continue;
@@ -441,9 +641,7 @@ fn normalise_borrow_base(raw_base: string) -> string {
         if substring(trimmed, 0, 1) == "(" {
             if substring(trimmed, trimmed.length - 1, trimmed.length) == ")" {
                 let inner = trim_text(substring(trimmed, 1, trimmed.length - 1));
-                if inner.length > 0 {
-                    return inner;
-                }
+                if inner.length > 0 { return inner; }
             }
         }
     }
@@ -452,30 +650,19 @@ fn normalise_borrow_base(raw_base: string) -> string {
 
 fn is_mutable_borrow_annotation(annotation: string) -> boolean {
     let trimmed = trim_text(annotation);
-    if trimmed.length == 0 {
-        return false;
-    }
+    if trimmed.length == 0 { return false; }
     let normalized = unwrap_move_wrapper(trimmed);
-    if normalized.length == 0 {
-        return false;
-    }
-    if substring(normalized, 0, 1) != "&" {
-        return false;
-    }
+    if normalized.length == 0 { return false; }
+    if substring(normalized, 0, 1) != "&" { return false; }
     let remainder = trim_text(substring(normalized, 1, normalized.length));
-    if remainder.length == 0 {
-        return false;
-    }
-    if starts_with(remainder, "mut") {
-        return true;
-    }
+    if remainder.length == 0 { return false; }
+    if starts_with(remainder, "mut") { return true; }
     return false;
 }
 
 // =============================================================================
 // Lifetime Region Management
 // =============================================================================
-
 fn append_lifetime_region(values: LifetimeRegionMetadata[], value: LifetimeRegionMetadata) -> LifetimeRegionMetadata[] {
     let mut out = values;
     out = out.push(value);
@@ -492,9 +679,7 @@ fn mark_lifetime_region_released(regions: LifetimeRegionMetadata[], region_id: n
     let mut result: LifetimeRegionMetadata[] = [];
     let mut index: number = 0;
     loop {
-        if index >= regions.length {
-            break;
-        }
+        if index >= regions.length { break; }
         let entry = regions[index];
         if entry.id == region_id {
             let updated = LifetimeRegionMetadata {
@@ -512,24 +697,18 @@ fn mark_lifetime_region_released(regions: LifetimeRegionMetadata[], region_id: n
                 released: true,
             };
             result.push(updated);
-        } else {
-            result.push(entry);
-        }
+        } else { result.push(entry); }
         index += 1;
     }
     return result;
 }
 
 fn apply_lifetime_release_events(regions: LifetimeRegionMetadata[], releases: LifetimeReleaseEvent[]) -> LifetimeRegionMetadata[] {
-    if releases.length == 0 {
-        return regions;
-    }
+    if releases.length == 0 { return regions; }
     let mut current_regions: LifetimeRegionMetadata[] = regions;
     let mut index: number = 0;
     loop {
-        if index >= releases.length {
-            break;
-        }
+        if index >= releases.length { break; }
         let release = releases[index];
         current_regions = mark_lifetime_region_released(current_regions, release.region_id, release.scope_id, release.scope_depth);
         index += 1;
@@ -557,24 +736,30 @@ fn make_lifetime_region_metadata(id: number, binding: string, ownership: Ownersh
 fn infer_borrow_base_scope(base: string, locals: LocalBinding[], bindings: ParameterBinding[], function_name: string) -> ScopeMetadata {
     let local = find_local_binding(locals, base);
     if local != null {
-        return ScopeMetadata { scope_id: local.scope_id, scope_depth: local.scope_depth };
+        return ScopeMetadata {
+            scope_id: local.scope_id,
+            scope_depth: local.scope_depth
+        };
     }
     let parameter = find_parameter_binding(bindings, base);
     if parameter != null {
-        return ScopeMetadata { scope_id: format_root_scope_id(function_name), scope_depth: 0 };
+        return ScopeMetadata {
+            scope_id: format_root_scope_id(function_name),
+            scope_depth: 0
+        };
     }
-    return ScopeMetadata { scope_id: format_root_scope_id(function_name), scope_depth: 0 };
+    return ScopeMetadata {
+        scope_id: format_root_scope_id(function_name),
+        scope_depth: 0
+    };
 }
 
 // =============================================================================
 // Lifetime Validation
 // =============================================================================
-
 fn validate_borrow_lifetimes(function: NativeFunction, regions: LifetimeRegionMetadata[]) -> string[] {
     let mut diagnostics: string[] = [];
-    if regions == null {
-        return diagnostics;
-    }
+    if regions == null { return diagnostics; }
     if regions.length > 1000000 {
         diagnostics.push("llvm lowering: lifetime region overflow in `" + function.name + "` (len=" + number_to_string(regions.length) + ")");
         return diagnostics;
@@ -582,9 +767,7 @@ fn validate_borrow_lifetimes(function: NativeFunction, regions: LifetimeRegionMe
     let mut index: number = 0;
     let root_scope = format_root_scope_id(function.name);
     loop {
-        if index >= regions.length {
-            break;
-        }
+        if index >= regions.length { break; }
         let region = regions[index];
         let mut base_scope_id = region.base_scope_id;
         let mut base_scope_depth = region.base_scope_depth;
@@ -594,15 +777,11 @@ fn validate_borrow_lifetimes(function: NativeFunction, regions: LifetimeRegionMe
         }
         let mut violation: boolean = false;
         if region.released {
-            if region.end_scope_id.length == 0 {
-                violation = true;
-            } else if !is_scope_descendant(base_scope_id, region.end_scope_id) {
+            if region.end_scope_id.length == 0 { violation = true; } else if !is_scope_descendant(base_scope_id, region.end_scope_id) {
                 violation = true;
             }
         } else {
-            if region.scope_depth < base_scope_depth {
-                violation = true;
-            } else if !is_scope_descendant(base_scope_id, region.scope_id) {
+            if region.scope_depth < base_scope_depth { violation = true; } else if !is_scope_descendant(base_scope_id, region.scope_id) {
                 violation = true;
             }
         }
@@ -621,14 +800,11 @@ fn validate_borrow_lifetimes(function: NativeFunction, regions: LifetimeRegionMe
 // =============================================================================
 // Suspension Conflict Detection (for async/await)
 // =============================================================================
-
 fn collect_suspension_conflicts(keyword: string, locals: LocalBinding[], bindings: ParameterBinding[], function_name: string, suspension_span: NativeSourceSpan?) -> string[] {
     let mut diagnostics: string[] = [];
     let mut index: number = 0;
     loop {
-        if index >= locals.length {
-            break;
-        }
+        if index >= locals.length { break; }
         let local = locals[index];
         if !local.consumed {
             if local.ownership != null {
@@ -646,9 +822,7 @@ fn collect_suspension_conflicts(keyword: string, locals: LocalBinding[], binding
     }
     let mut parameter_index: number = 0;
     loop {
-        if parameter_index >= bindings.length {
-            break;
-        }
+        if parameter_index >= bindings.length { break; }
         let binding = bindings[parameter_index];
         if !binding.consumed {
             if is_mutable_borrow_annotation(binding.type_annotation) {
@@ -662,46 +836,32 @@ fn collect_suspension_conflicts(keyword: string, locals: LocalBinding[], binding
 }
 
 fn detect_suspension_conflicts(expression: string?, locals: LocalBinding[], bindings: ParameterBinding[], function_name: string, suspension_span: NativeSourceSpan?) -> string[] {
-    if expression == null {
-        return [];
-    }
+    if expression == null { return []; }
     let trimmed = trim_text(expression);
-    if trimmed.length == 0 {
-        return [];
-    }
+    if trimmed.length == 0 { return []; }
     let keyword = find_suspension_keyword(trimmed);
-    if keyword.length == 0 {
-        return [];
-    }
+    if keyword.length == 0 { return []; }
     return collect_suspension_conflicts(keyword, locals, bindings, function_name, suspension_span);
 }
 
 fn find_suspension_keyword(text: string) -> string {
     if starts_with(text, "await") {
-        if text.length == 5 {
-            return "await";
-        }
+        if text.length == 5 { return "await"; }
         let next = char_at(text, 5);
         let mut _if192: boolean = false;
         if next == " " { _if192 = true; }
         if next == "\t" { _if192 = true; }
         if next == "(" { _if192 = true; }
-        if _if192 {
-            return "await";
-        }
+        if _if192 { return "await"; }
     }
     if starts_with(text, "yield") {
-        if text.length == 5 {
-            return "yield";
-        }
+        if text.length == 5 { return "yield"; }
         let next = char_at(text, 5);
         let mut _if193: boolean = false;
         if next == " " { _if193 = true; }
         if next == "\t" { _if193 = true; }
         if next == "(" { _if193 = true; }
-        if _if193 {
-            return "yield";
-        }
+        if _if193 { return "yield"; }
     }
     return "";
 }
@@ -709,47 +869,31 @@ fn find_suspension_keyword(text: string) -> string {
 // =============================================================================
 // Scope ID Helpers
 // =============================================================================
-
 fn format_root_scope_id(function_name: string) -> string {
     let mut sanitized: string = sanitize_symbol(function_name);
-    if sanitized.length == 0 {
-        sanitized = "fn";
-    }
+    if sanitized.length == 0 { sanitized = "fn"; }
     return "fn:" + sanitized;
 }
 
 fn make_child_scope_id(parent: string, child: string) -> string {
     let mut sanitized_child: string = sanitize_symbol(child);
-    if sanitized_child.length == 0 {
-        sanitized_child = "scope";
-    }
-    if parent.length == 0 {
-        return sanitized_child;
-    }
+    if sanitized_child.length == 0 { sanitized_child = "scope"; }
+    if parent.length == 0 { return sanitized_child; }
     return parent + "__" + sanitized_child;
 }
 
 fn is_scope_descendant(parent: string, candidate: string) -> boolean {
-    if parent.length == 0 {
-        return true;
-    }
-    if candidate.length == 0 {
-        return false;
-    }
-    if candidate == parent {
-        return true;
-    }
+    if parent.length == 0 { return true; }
+    if candidate.length == 0 { return false; }
+    if candidate == parent { return true; }
     let prefix = parent + "__";
-    if candidate.length <= prefix.length {
-        return false;
-    }
+    if candidate.length <= prefix.length { return false; }
     return starts_with(candidate, prefix);
 }
 
 // =============================================================================
 // Formatting Helpers
 // =============================================================================
-
 fn format_use_after_move_message(name: string, span: NativeSourceSpan?) -> string {
     if span == null {
         return "llvm lowering: use-after-move of `" + name + "`";
@@ -772,19 +916,13 @@ fn format_suspension_location(keyword: string, borrow_span: NativeSourceSpan?, s
     }
     if suspension_span != null {
         let mut label: string = keyword;
-        if label.length == 0 {
-            label = "suspend";
-        }
+        if label.length == 0 { label = "suspend"; }
         let segment = label + " at " + format_span_location(suspension_span);
-        if has_segment {
-            combined = combined + "; " + segment;
-        } else {
+        if has_segment { combined = combined + "; " + segment; } else {
             combined = segment;
             has_segment = true;
         }
     }
-    if !has_segment {
-        return "";
-    }
+    if !has_segment { return ""; }
     return " (" + combined + ")";
 }

--- a/compiler/src/llvm/lowering/emission.sfn
+++ b/compiler/src/llvm/lowering/emission.sfn
@@ -10,93 +10,52 @@
 // at link time via symbol mangling. This cycle is intentional: async emission
 // needs the main emit_llvm_function for the inner body, while the main
 // emitter delegates async wrapper generation to the async module.
-
 import { NativeFunction } from "../../native_ir";
-import { substring, find_char } from "../../string_utils";
-
+import { find_char, substring } from "../../string_utils";
+import { lower_expression, } from "../expression_lowering/native/core";
+import { append_llvm_operand, } from "../expression_lowering/native/core_scopes";
+import { make_string_constant_name_for_module, } from "../expression_lowering/native/core_text";
+import { prepare_parameters, } from "../expression_lowering/native/statement";
+import { default_return_literal, format_temp_name, } from "../expressions_helpers";
+import { format_root_scope_id, validate_borrow_lifetimes, } from "../lifetime";
+import { should_internalize_function, } from "../rendering_helpers";
 import {
-    TypeContext,
-    LocalBinding,
-    ParameterBinding,
-    LoweredLLVMFunction,
-    StringConstant,
-    BodyResult,
-    ParameterPreparation,
-    LifetimeRegionMetadata,
-} from "../types";
-
-import {
-    append_string,
-    extend_string_array,
-    join_with_separator,
-    sanitize_symbol,
-    number_to_string,
-    matches_case_insensitive,
-    index_of,
-    trim_text,
-    starts_with,
-    append_parameter_binding,
-    string_array_contains,
-} from "../utils";
-
-import {
-    empty_string_constant_set,
     append_string_constant,
+    empty_string_constant_set,
     merge_string_constants,
 } from "../strings";
-
+import { map_return_type, } from "../type_mapping";
 import {
-    map_return_type,
-} from "../type_mapping";
-
+    BodyResult,
+    LifetimeRegionMetadata,
+    LocalBinding,
+    LoweredLLVMFunction,
+    ParameterBinding,
+    ParameterPreparation,
+    StringConstant,
+    TypeContext,
+} from "../types";
 import {
-    should_internalize_function,
-} from "../rendering_helpers";
-
-import {
-    prepare_parameters,
-} from "../expression_lowering/native/statement";
-
-import {
-    append_llvm_operand,
-} from "../expression_lowering/native/core_scopes";
-
-import {
-    lower_expression,
-} from "../expression_lowering/native/core";
-
-import {
-    make_string_constant_name_for_module,
-} from "../expression_lowering/native/core_text";
-
-
-import {
-    default_return_literal,
-    format_temp_name,
-} from "../expressions_helpers";
-
-import {
-    validate_borrow_lifetimes,
-    format_root_scope_id,
-} from "../lifetime";
-
+    append_parameter_binding,
+    append_string,
+    extend_string_array,
+    index_of,
+    join_with_separator,
+    matches_case_insensitive,
+    number_to_string,
+    sanitize_symbol,
+    starts_with,
+    string_array_contains,
+    trim_text,
+} from "../utils";
 import { emit_async_function } from "./emission_async";
-
 import { build_define_header_line } from "./emission_header";
-
-import {
-    lower_instruction_range,
-} from "./instructions";
-
-import {
-    module_user_main_symbol,
-} from "./module_globals";
+import { lower_instruction_range, } from "./instructions";
+import { module_user_main_symbol, } from "./module_globals";
 
 fn _split_by_newline(content: string) -> string[] {
     let mut result: string[] = [];
-    if content.length == 0 {
-        return result;
-    }
+    if content.length == 0 { return result; }
     let mut start: number = 0;
     loop {
         if start >= content.length { break; }
@@ -112,16 +71,12 @@ fn _split_by_newline(content: string) -> string[] {
 }
 
 fn is_safe_llvm_type_text(value: string) -> boolean {
-    if value == null {
-        return false;
-    }
+    if value == null { return false; }
     let trimmed = trim_text(value);
     let mut _if194: boolean = false;
     if trimmed.length == 0 { _if194 = true; }
     if trimmed.length > 256 { _if194 = true; }
-    if _if194 {
-        return false;
-    }
+    if _if194 { return false; }
     // Fast-path for well-known primitive types.
     // The character-level check below relies on single-char indexing + index_of
     // which can be miscompiled by older seeds. These explicit checks bypass the
@@ -136,27 +91,19 @@ fn is_safe_llvm_type_text(value: string) -> boolean {
     if trimmed == "i8" { _if195 = true; }
     if trimmed == "i16" { _if195 = true; }
     if trimmed == "float" { _if195 = true; }
-    if _if195 {
-        return true;
-    }
+    if _if195 { return true; }
     // Also accept pointer-to-named-struct patterns (%Foo*) and common aggregate
     // syntax so that complex return types are not rejected.
     let mut _if196: boolean = false;
     if starts_with(trimmed, "%") { _if196 = true; }
     if starts_with(trimmed, "{") { _if196 = true; }
-    if _if196 {
-        return true;
-    }
+    if _if196 { return true; }
     let allowed = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_%*{}[],(). x-";
     let mut index: number = 0;
     loop {
-        if index >= trimmed.length {
-            break;
-        }
+        if index >= trimmed.length { break; }
         let ch = substring(trimmed, index, index + 1);
-        if index_of(allowed, ch) < 0 {
-            return false;
-        }
+        if index_of(allowed, ch) < 0 { return false; }
         index += 1;
     }
     return true;
@@ -166,9 +113,7 @@ fn parse_simple_integer(text: string) -> number {
     let mut result: number = 0;
     let mut i: number = 0;
     loop {
-        if i >= text.length {
-            break;
-        }
+        if i >= text.length { break; }
         let ch = substring(text, i, i + 1);
         let mut digit: number = -1;
         if ch == "0" { digit = 0; }
@@ -181,9 +126,7 @@ fn parse_simple_integer(text: string) -> number {
         if ch == "7" { digit = 7; }
         if ch == "8" { digit = 8; }
         if ch == "9" { digit = 9; }
-        if digit >= 0 {
-            result = result * 10 + digit;
-        }
+        if digit >= 0 { result = result * 10 + digit; }
         i += 1;
     }
     return result;
@@ -198,9 +141,7 @@ fn _reorder_phis_to_block_start(lines: string[]) -> string[] {
     let mut in_block: boolean = false;
     let mut i: number = 0;
     loop {
-        if i >= lines.length {
-            break;
-        }
+        if i >= lines.length { break; }
         let line = lines[i];
         let trimmed = trim_text(line);
         // Detect block label: non-empty, ends with ":", not indented (not a store/instruction).
@@ -211,9 +152,7 @@ fn _reorder_phis_to_block_start(lines: string[]) -> string[] {
                 // Labels are not indented; indented lines ending with : are not labels.
                 if line.length > 0 {
                     let first_ch = substring(line, 0, 1);
-                    if first_ch != " " {
-                        is_label = true;
-                    }
+                    if first_ch != " " { is_label = true; }
                 }
             }
         }
@@ -247,18 +186,12 @@ fn _reorder_phis_to_block_start(lines: string[]) -> string[] {
                 if starts_with(trimmed, "%") {
                     // Pattern: %tN = phi ...
                     let eq_pos = index_of(trimmed, "= phi ");
-                    if eq_pos > 0 {
-                        is_phi = true;
-                    }
+                    if eq_pos > 0 { is_phi = true; }
                 }
-                if is_phi {
-                    block_phi_lines = block_phi_lines.push(line);
-                } else {
+                if is_phi { block_phi_lines = block_phi_lines.push(line); } else {
                     block_other_lines = block_other_lines.push(line);
                 }
-            } else {
-                out = out.push(line);
-            }
+            } else { out = out.push(line); }
             i += 1;
         }
     }
@@ -305,9 +238,7 @@ fn prepare_parameters_from_files(fn_name: string, fn_param_count: number, contex
     let mut seen_names: string[] = [];
     let mut index: number = 0;
     loop {
-        if index >= fn_param_count {
-            break;
-        }
+        if index >= fn_param_count { break; }
         let param_name = fs.readFile("build/sailfin/.fn_param_" + number_to_string(index) + "_name");
         let raw_param_type = fs.readFile("build/sailfin/.fn_param_" + number_to_string(index) + "_type");
         // Strip default value from type annotations like "number = 0".
@@ -320,13 +251,9 @@ fn prepare_parameters_from_files(fn_name: string, fn_param_count: number, contex
             param_type = trim_text(substring(raw_param_type, 0, eq_idx));
         }
         let mut llvm_type = map_return_type(context, param_type);
-        if llvm_type == "void" {
-            llvm_type = "";
-        }
+        if llvm_type == "void" { llvm_type = ""; }
         // Default empty types to i8* so LLVM IR is parseable.
-        if llvm_type.length == 0 {
-            llvm_type = "i8*";
-        }
+        if llvm_type.length == 0 { llvm_type = "i8*"; }
         if param_type.length == 0 {
             let param_diag = "llvm lowering: parameter `" + param_name + "` missing type annotation; defaulting to `" + llvm_type + "`";
             diagnostics = append_string(diagnostics, param_diag);
@@ -337,9 +264,7 @@ fn prepare_parameters_from_files(fn_name: string, fn_param_count: number, contex
         let mut llvm_name = "%" + sanitized;
         let mut dedup_count: number = 1;
         loop {
-            if !string_array_contains(seen_names, llvm_name) {
-                break;
-            }
+            if !string_array_contains(seen_names, llvm_name) { break; }
             dedup_count += 1;
             llvm_name = "%" + sanitized + "_" + number_to_string(dedup_count);
         }
@@ -348,22 +273,14 @@ fn prepare_parameters_from_files(fn_name: string, fn_param_count: number, contex
         bindings = append_parameter_binding(bindings, _emit_make_parameter_binding(param_name, llvm_name, llvm_type, param_type));
         index += 1;
     }
-    return ParameterPreparation { signature: signature, bindings: bindings, diagnostics: diagnostics };
+    return ParameterPreparation {
+        signature: signature,
+        bindings: bindings,
+        diagnostics: diagnostics
+    };
 }
 
-fn emit_llvm_function(
-    function_name_hint: string,
-    functions: NativeFunction[],
-    effects: string[],
-    context: TypeContext,
-    module_name: string,
-    entry_points: string[],
-    exported_symbols: string[],
-    imported_functions: NativeFunction[],
-    module_globals: LocalBinding[],
-    module_init_symbol: string,
-    needs_module_init_call: boolean
-) -> LoweredLLVMFunction ![io] {
+fn emit_llvm_function(function_name_hint: string, functions: NativeFunction[], effects: string[], context: TypeContext, module_name: string, entry_points: string[], exported_symbols: string[], imported_functions: NativeFunction[], module_globals: LocalBinding[], module_init_symbol: string, needs_module_init_call: boolean) -> LoweredLLVMFunction ![io] {
     let mut diagnostics: string[] = [];
     let debug_lowering = fs.exists("build/sailfin/.trace_lowering");
 
@@ -388,13 +305,7 @@ fn emit_llvm_function(
     if fn_is_async {
         if !fn_is_extern {
             if fn_name != "main" {
-                return emit_async_function(
-                    fn_name, fn_return_type, fn_param_count,
-                    function_name_hint, functions, effects, context,
-                    module_name, entry_points, exported_symbols,
-                    imported_functions, module_globals,
-                    module_init_symbol, needs_module_init_call
-                );
+                return emit_async_function(fn_name, fn_return_type, fn_param_count, function_name_hint, functions, effects, context, module_name, entry_points, exported_symbols, imported_functions, module_globals, module_init_symbol, needs_module_init_call);
             }
         }
     }
@@ -420,9 +331,7 @@ fn emit_llvm_function(
     let safe_check = is_safe_llvm_type_text(llvm_return);
     if debug_lowering {
         let mut safe_text = "false";
-        if safe_check {
-            safe_text = "true";
-        }
+        if safe_check { safe_text = "true"; }
         print.err("emit-llvm: ret_type safe_check=" + safe_text + " llvm_return=" + llvm_return + " fn=" + fn_name);
     }
     if !safe_check {
@@ -434,7 +343,12 @@ fn emit_llvm_function(
         let unsupported_diag = "llvm lowering: unsupported return type `" + fn_return_type + "` in " + fn_name;
         diagnostics = append_string(diagnostics, unsupported_diag);
         let empty_constants = empty_string_constant_set();
-        return LoweredLLVMFunction { lines: [], diagnostics: diagnostics, lifetime_regions: [], string_constants: empty_constants };
+        return LoweredLLVMFunction {
+            lines: [],
+            diagnostics: diagnostics,
+            lifetime_regions: [],
+            string_constants: empty_constants
+        };
     }
 
     if !fn_is_extern {
@@ -454,28 +368,24 @@ fn emit_llvm_function(
 
     if fn_is_extern {
         let mut signature: string = join_with_separator(preparation.signature, ", ");
-        if signature.length == 0 {
-            signature = "";
-        }
+        if signature.length == 0 { signature = ""; }
         let empty_constants = empty_string_constant_set();
         let lines: string[] = ["declare " + llvm_return + " @" + sanitized + "(" + signature + ")"];
-        return LoweredLLVMFunction { lines: lines, diagnostics: diagnostics, lifetime_regions: [], string_constants: empty_constants };
+        return LoweredLLVMFunction {
+            lines: lines,
+            diagnostics: diagnostics,
+            lifetime_regions: [],
+            string_constants: empty_constants
+        };
     }
 
     let mut _let198: boolean = false;
     if fs.exists("build/sailfin/.trace_test_runner") {
-        if fs.exists("build/sailfin/.test_runner_active") {
-            _let198 = true;
-        }
+        if fs.exists("build/sailfin/.test_runner_active") { _let198 = true; }
     }
     let trace = _let198;
     if trace {
-        print.err(
-            "test llvm: emit_llvm_function preview "
-            + fn_name
-            + " instrs="
-            + number_to_string(fn_instr_count)
-        );
+        print.err("test llvm: emit_llvm_function preview " + fn_name + " instrs=" + number_to_string(fn_instr_count));
     }
 
     let mut lines: string[] = [];
@@ -484,21 +394,15 @@ fn emit_llvm_function(
         lines = append_string(lines, effects_comment);
     }
     let mut signature: string = join_with_separator(preparation.signature, ", ");
-    if signature.length == 0 {
-        signature = "";
-    }
+    if signature.length == 0 { signature = ""; }
 
     let entry_label: string = "block.entry";
     let mut linkage: string = "";
     let internalize = should_internalize_function(function, entry_points, exported_symbols, imported_functions);
-    if internalize {
-        linkage = "internal ";
-    }
+    if internalize { linkage = "internal "; }
     if debug_lowering {
         let mut internalize_text = "false";
-        if internalize {
-            internalize_text = "true";
-        }
+        if internalize { internalize_text = "true"; }
         print.err("emit-llvm: emit_fn phase=internalize_check name=" + fn_name + " internal=" + internalize_text);
         print.err("emit-llvm: emit_fn phase=define_header name=" + fn_name);
     }
@@ -520,18 +424,24 @@ fn emit_llvm_function(
     }
     let mut decorator_index: number = 0;
     loop {
-        if decorator_index >= fn_decorator_count {
-            break;
-        }
+        if decorator_index >= fn_decorator_count { break; }
         let decorator_name = fs.readFile("build/sailfin/.fn_decorator_" + number_to_string(decorator_index));
         let mut _if199: boolean = false;
-        if matches_case_insensitive(decorator_name, "logExecution") { _if199 = true; }
-        if matches_case_insensitive(decorator_name, "logexecution") { _if199 = true; }
+        if matches_case_insensitive(decorator_name, "logExecution") {
+            _if199 = true;
+        }
+        if matches_case_insensitive(decorator_name, "logexecution") {
+            _if199 = true;
+        }
         if matches_case_insensitive(decorator_name, "trace") { _if199 = true; }
         if _if199 {
             let content = fn_name;
             let constant_name = make_string_constant_name_for_module(module_name, content);
-            let constant = StringConstant { name: constant_name, content: content, byte_count: content.length };
+            let constant = StringConstant {
+                name: constant_name,
+                content: content,
+                byte_count: content.length
+            };
             decorator_string_constants = append_string_constant(decorator_string_constants, constant);
             let array_length = content.length + 1;
             let array_type = "[" + number_to_string(array_length) + " x i8]";
@@ -577,29 +487,15 @@ fn emit_llvm_function(
         lines = append_string(lines, "}");
         let empty_constants = empty_string_constant_set();
         let _empty_lifetime_regions: LifetimeRegionMetadata[] = [];
-        return LoweredLLVMFunction { lines: lines, diagnostics: diagnostics, lifetime_regions: _empty_lifetime_regions, string_constants: empty_constants };
+        return LoweredLLVMFunction {
+            lines: lines,
+            diagnostics: diagnostics,
+            lifetime_regions: _empty_lifetime_regions,
+            string_constants: empty_constants
+        };
     }
     let _eb_function = functions[_eb_fn_index];
-    let _eb_result = lower_instruction_range(
-        _eb_function,
-        0,
-        fn_instr_count,
-        llvm_return,
-        preparation.bindings,
-        module_globals,
-        [],
-        [],
-        0,
-        0,
-        0,
-        0,
-        functions,
-        [],
-        context,
-        format_root_scope_id(fn_name),
-        0,
-        entry_label
-    );
+    let _eb_result = lower_instruction_range(_eb_function, 0, fn_instr_count, llvm_return, preparation.bindings, module_globals, [], [], 0, 0, 0, 0, functions, [], context, format_root_scope_id(fn_name), 0, entry_label);
 
     let _eb_body_lines = _eb_result.lines;
     let _eb_allocas = _eb_result.allocas;
@@ -660,50 +556,31 @@ fn emit_llvm_function(
 
     if emit_main_wrapper {
         // C ABI wrapper. Always returns 0 (success) after invoking the Sailfin main.
-        lines = extend_string_array(lines, [
-            "",
-            "define i32 @main(i32 %argc, i8** %argv) {",
-            "entry:",
-            "  call void @" + sanitized + "()",
-            "  ret i32 0",
-            "}",
-        ]);
+        lines = extend_string_array(lines, ["", "define i32 @main(i32 %argc, i8** %argv) {", "entry:", "  call void @" + sanitized + "()", "  ret i32 0", "}",]);
     }
 
     let merged_constants = merge_string_constants(_eb_string_constants, decorator_string_constants);
     let _empty_lifetime_regions: LifetimeRegionMetadata[] = [];
-    return LoweredLLVMFunction { lines: lines, diagnostics: diagnostics, lifetime_regions: _empty_lifetime_regions, string_constants: merged_constants };
+    return LoweredLLVMFunction {
+        lines: lines,
+        diagnostics: diagnostics,
+        lifetime_regions: _empty_lifetime_regions,
+        string_constants: merged_constants
+    };
 }
 
-fn emit_body(
-    function_unused: string,
-    fn_name: string,
-    fn_instr_count: number,
-    llvm_return: string,
-    bindings: ParameterBinding[],
-    module_globals: LocalBinding[],
-    functions: NativeFunction[],
-    context: TypeContext,
-    entry_label: string
-) -> BodyResult ![io] {
+fn emit_body(function_unused: string, fn_name: string, fn_instr_count: number, llvm_return: string, bindings: ParameterBinding[], module_globals: LocalBinding[], functions: NativeFunction[], context: TypeContext, entry_label: string) -> BodyResult ![io] {
     let debug_body = fs.exists("build/sailfin/.trace_lowering");
     if debug_body {
         print.err("emit-llvm: emit_body start fn=" + fn_name + " llvm_return=" + llvm_return + " bindings_len=" + number_to_string(bindings.length));
     }
     let mut _let202: boolean = false;
     if fs.exists("build/sailfin/.trace_test_runner") {
-        if fs.exists("build/sailfin/.test_runner_active") {
-            _let202 = true;
-        }
+        if fs.exists("build/sailfin/.test_runner_active") { _let202 = true; }
     }
     let trace = _let202;
     if trace {
-        print.err(
-            "test llvm: emit_body start "
-            + fn_name
-            + " instrs="
-            + number_to_string(fn_instr_count)
-        );
+        print.err("test llvm: emit_body start " + fn_name + " instrs=" + number_to_string(fn_instr_count));
     }
     // Load the NativeFunction from the functions array by index,
     // avoiding the cross-module ABI issue where NativeFunction is
@@ -711,45 +588,15 @@ fn emit_body(
     let fn_index_text = fs.readFile("build/sailfin/.fn_index");
     let fn_index = parse_simple_integer(fn_index_text);
     let function = functions[fn_index];
-    let lowered = lower_instruction_range(
-        function,
-        0,
-        fn_instr_count,
-        llvm_return,
-        bindings,
-        module_globals,
-        [],
-        [],
-        0,
-        0,
-        0,
-        0,
-        functions,
-        [],
-        context,
-        format_root_scope_id(fn_name),
-        0,
-        entry_label
-    );
+    let lowered = lower_instruction_range(function, 0, fn_instr_count, llvm_return, bindings, module_globals, [], [], 0, 0, 0, 0, functions, [], context, format_root_scope_id(fn_name), 0, entry_label);
 
     let _blk_body_lines = lowered.lines;
     let _blk_allocas = lowered.allocas;
     let _blk_terminated = lowered.terminated;
     if trace {
         let mut term_label: string = "false";
-        if _blk_terminated {
-            term_label = "true";
-        }
-        print.err(
-            "test llvm: emit_body lowered "
-            + fn_name
-            + " lines="
-            + number_to_string(_blk_body_lines.length)
-            + " allocas="
-            + number_to_string(_blk_allocas.length)
-            + " terminated="
-            + term_label
-        );
+        if _blk_terminated { term_label = "true"; }
+        print.err("test llvm: emit_body lowered " + fn_name + " lines=" + number_to_string(_blk_body_lines.length) + " allocas=" + number_to_string(_blk_allocas.length) + " terminated=" + term_label);
     }
     let mut diagnostics: string[] = lowered.diagnostics;
     let mut lines: string[] = [];
@@ -759,9 +606,7 @@ fn emit_body(
     let mut has_terminator: boolean = false;
     let mut terminator_index: number = 0;
     loop {
-        if terminator_index >= lines.length {
-            break;
-        }
+        if terminator_index >= lines.length { break; }
         let trimmed_line = trim_text(lines[terminator_index]);
         let mut _if203: boolean = false;
         if starts_with(trimmed_line, "ret ") { _if203 = true; }
@@ -791,9 +636,13 @@ fn emit_body(
     }
 
     let _empty_lifetime_regions: LifetimeRegionMetadata[] = [];
-    return BodyResult { lines: lines, diagnostics: diagnostics, lifetime_regions: _empty_lifetime_regions, string_constants: lowered.string_constants };
+    return BodyResult {
+        lines: lines,
+        diagnostics: diagnostics,
+        lifetime_regions: _empty_lifetime_regions,
+        string_constants: lowered.string_constants
+    };
 }
-
 
 // Parse serialized string constants from the file written by _write_block_result_files.
 // Format: one constant per line as "name\tcontent\tbyte_count".
@@ -802,9 +651,7 @@ fn _parse_string_constants_from_file(raw: string) -> StringConstant[] {
     let lines = _split_by_newline(raw);
     let mut i: number = 0;
     loop {
-        if i >= lines.length {
-            break;
-        }
+        if i >= lines.length { break; }
         let line = lines[i];
         if line.length == 0 {
             i += 1;
@@ -826,9 +673,7 @@ fn _parse_string_constants_from_file(raw: string) -> StringConstant[] {
         let byte_count_text = substring(rest, tab2 + 1, rest.length);
         let byte_count = parse_simple_integer(byte_count_text);
         result = append_string_constant(result, StringConstant {
-            name: name,
-            content: content,
-            byte_count: byte_count,
+            name: name, content: content, byte_count: byte_count,
         });
         i += 1;
     }

--- a/compiler/src/llvm/lowering/emission.sfn
+++ b/compiler/src/llvm/lowering/emission.sfn
@@ -12,19 +12,19 @@
 // emitter delegates async wrapper generation to the async module.
 import { NativeFunction } from "../../native_ir";
 import { find_char, substring } from "../../string_utils";
-import { lower_expression, } from "../expression_lowering/native/core";
-import { append_llvm_operand, } from "../expression_lowering/native/core_scopes";
-import { make_string_constant_name_for_module, } from "../expression_lowering/native/core_text";
-import { prepare_parameters, } from "../expression_lowering/native/statement";
-import { default_return_literal, format_temp_name, } from "../expressions_helpers";
-import { format_root_scope_id, validate_borrow_lifetimes, } from "../lifetime";
-import { should_internalize_function, } from "../rendering_helpers";
+import { lower_expression } from "../expression_lowering/native/core";
+import { append_llvm_operand } from "../expression_lowering/native/core_scopes";
+import { make_string_constant_name_for_module } from "../expression_lowering/native/core_text";
+import { prepare_parameters } from "../expression_lowering/native/statement";
+import { default_return_literal, format_temp_name } from "../expressions_helpers";
+import { format_root_scope_id, validate_borrow_lifetimes } from "../lifetime";
+import { should_internalize_function } from "../rendering_helpers";
 import {
     append_string_constant,
     empty_string_constant_set,
-    merge_string_constants,
+    merge_string_constants
 } from "../strings";
-import { map_return_type, } from "../type_mapping";
+import { map_return_type } from "../type_mapping";
 import {
     BodyResult,
     LifetimeRegionMetadata,
@@ -33,7 +33,7 @@ import {
     ParameterBinding,
     ParameterPreparation,
     StringConstant,
-    TypeContext,
+    TypeContext
 } from "../types";
 import {
     append_parameter_binding,
@@ -46,12 +46,12 @@ import {
     sanitize_symbol,
     starts_with,
     string_array_contains,
-    trim_text,
+    trim_text
 } from "../utils";
 import { emit_async_function } from "./emission_async";
 import { build_define_header_line } from "./emission_header";
-import { lower_instruction_range, } from "./instructions";
-import { module_user_main_symbol, } from "./module_globals";
+import { lower_instruction_range } from "./instructions";
+import { module_user_main_symbol } from "./module_globals";
 
 fn _split_by_newline(content: string) -> string[] {
     let mut result: string[] = [];
@@ -223,7 +223,7 @@ fn _emit_make_parameter_binding(name: string, llvm_name: string, llvm_type: stri
         llvm_type: llvm_type,
         type_annotation: type_annotation,
         consumed: false,
-        span: null,
+        span: null
     };
 }
 
@@ -239,8 +239,12 @@ fn prepare_parameters_from_files(fn_name: string, fn_param_count: number, contex
     let mut index: number = 0;
     loop {
         if index >= fn_param_count { break; }
-        let param_name = fs.readFile("build/sailfin/.fn_param_" + number_to_string(index) + "_name");
-        let raw_param_type = fs.readFile("build/sailfin/.fn_param_" + number_to_string(index) + "_type");
+        let param_name = fs.readFile("build/sailfin/.fn_param_"
+            + number_to_string(index)
+            + "_name");
+        let raw_param_type = fs.readFile("build/sailfin/.fn_param_"
+            + number_to_string(index)
+            + "_type");
         // Strip default value from type annotations like "number = 0".
         // The native IR emitter includes default values in .param annotations;
         // map_return_type cannot parse "number = 0" and falls back to i8*,
@@ -255,7 +259,10 @@ fn prepare_parameters_from_files(fn_name: string, fn_param_count: number, contex
         // Default empty types to i8* so LLVM IR is parseable.
         if llvm_type.length == 0 { llvm_type = "i8*"; }
         if param_type.length == 0 {
-            let param_diag = "llvm lowering: parameter `" + param_name + "` missing type annotation; defaulting to `" + llvm_type + "`";
+            let param_diag = "llvm lowering: parameter `" + param_name
+                + "` missing type annotation; defaulting to `"
+                + llvm_type
+                + "`";
             diagnostics = append_string(diagnostics, param_diag);
         }
         let sanitized = sanitize_symbol(param_name);
@@ -314,7 +321,9 @@ fn emit_llvm_function(function_name_hint: string, functions: NativeFunction[], e
     let mut emit_main_wrapper: boolean = false;
     let mut llvm_return = map_return_type(context, fn_return_type);
     if debug_lowering {
-        print.err("emit-llvm: emit_fn phase=ret_type name=" + fn_name + " llvm_return=" + llvm_return);
+        print.err("emit-llvm: emit_fn phase=ret_type name=" + fn_name
+            + " llvm_return="
+            + llvm_return);
     }
     // Override return type for specific parse_native functions that return
     // opaque types the LLVM backend cannot resolve. Use == instead of
@@ -332,15 +341,26 @@ fn emit_llvm_function(function_name_hint: string, functions: NativeFunction[], e
     if debug_lowering {
         let mut safe_text = "false";
         if safe_check { safe_text = "true"; }
-        print.err("emit-llvm: ret_type safe_check=" + safe_text + " llvm_return=" + llvm_return + " fn=" + fn_name);
+        print.err("emit-llvm: ret_type safe_check=" + safe_text
+            + " llvm_return="
+            + llvm_return
+            + " fn="
+            + fn_name);
     }
     if !safe_check {
-        let suspicious_diag = "llvm lowering: suspicious return type `" + llvm_return + "` in " + fn_name + "; defaulting to i8*";
+        let suspicious_diag = "llvm lowering: suspicious return type `"
+            + llvm_return
+            + "` in "
+            + fn_name
+            + "; defaulting to i8*";
         diagnostics = append_string(diagnostics, suspicious_diag);
         llvm_return = "i8*";
     }
     if llvm_return.length == 0 {
-        let unsupported_diag = "llvm lowering: unsupported return type `" + fn_return_type + "` in " + fn_name;
+        let unsupported_diag = "llvm lowering: unsupported return type `"
+            + fn_return_type
+            + "` in "
+            + fn_name;
         diagnostics = append_string(diagnostics, unsupported_diag);
         let empty_constants = empty_string_constant_set();
         return LoweredLLVMFunction {
@@ -363,14 +383,18 @@ fn emit_llvm_function(function_name_hint: string, functions: NativeFunction[], e
     let preparation = prepare_parameters_from_files(fn_name, fn_param_count, context);
     diagnostics = extend_string_array(diagnostics, preparation.diagnostics);
     if debug_lowering {
-        print.err("emit-llvm: emit_fn phase=prepare_params name=" + fn_name + " params=" + number_to_string(preparation.bindings.length));
+        print.err("emit-llvm: emit_fn phase=prepare_params name=" + fn_name
+            + " params="
+            + number_to_string(preparation.bindings.length));
     }
 
     if fn_is_extern {
         let mut signature: string = join_with_separator(preparation.signature, ", ");
         if signature.length == 0 { signature = ""; }
         let empty_constants = empty_string_constant_set();
-        let lines: string[] = ["declare " + llvm_return + " @" + sanitized + "(" + signature + ")"];
+        let lines: string[] = ["declare " + llvm_return + " @" + sanitized + "("
+            + signature
+            + ")"];
         return LoweredLLVMFunction {
             lines: lines,
             diagnostics: diagnostics,
@@ -385,12 +409,16 @@ fn emit_llvm_function(function_name_hint: string, functions: NativeFunction[], e
     }
     let trace = _let198;
     if trace {
-        print.err("test llvm: emit_llvm_function preview " + fn_name + " instrs=" + number_to_string(fn_instr_count));
+        print.err("test llvm: emit_llvm_function preview " + fn_name
+            + " instrs="
+            + number_to_string(fn_instr_count));
     }
 
     let mut lines: string[] = [];
     if effects.length > 0 {
-        let effects_comment = "; fn " + fn_name + " effects: ![" + join_with_separator(effects, ", ") + "]";
+        let effects_comment = "; fn " + fn_name + " effects: !["
+            + join_with_separator(effects, ", ")
+            + "]";
         lines = append_string(lines, effects_comment);
     }
     let mut signature: string = join_with_separator(preparation.signature, ", ");
@@ -403,7 +431,9 @@ fn emit_llvm_function(function_name_hint: string, functions: NativeFunction[], e
     if debug_lowering {
         let mut internalize_text = "false";
         if internalize { internalize_text = "true"; }
-        print.err("emit-llvm: emit_fn phase=internalize_check name=" + fn_name + " internal=" + internalize_text);
+        print.err("emit-llvm: emit_fn phase=internalize_check name=" + fn_name
+            + " internal="
+            + internalize_text);
         print.err("emit-llvm: emit_fn phase=define_header name=" + fn_name);
     }
     let define_header: string = build_define_header_line(linkage, llvm_return, sanitized, signature);
@@ -420,12 +450,15 @@ fn emit_llvm_function(function_name_hint: string, functions: NativeFunction[], e
     // For now, `@logExecution` / `@trace` calls into the runtime hook with the function name.
     let mut decorator_string_constants: StringConstant[] = empty_string_constant_set();
     if debug_lowering {
-        print.err("emit-llvm: emit_fn phase=decorators name=" + fn_name + " count=" + number_to_string(fn_decorator_count));
+        print.err("emit-llvm: emit_fn phase=decorators name=" + fn_name
+            + " count="
+            + number_to_string(fn_decorator_count));
     }
     let mut decorator_index: number = 0;
     loop {
         if decorator_index >= fn_decorator_count { break; }
-        let decorator_name = fs.readFile("build/sailfin/.fn_decorator_" + number_to_string(decorator_index));
+        let decorator_name = fs.readFile("build/sailfin/.fn_decorator_"
+            + number_to_string(decorator_index));
         let mut _if199: boolean = false;
         if matches_case_insensitive(decorator_name, "logExecution") {
             _if199 = true;
@@ -445,14 +478,22 @@ fn emit_llvm_function(function_name_hint: string, functions: NativeFunction[], e
             decorator_string_constants = append_string_constant(decorator_string_constants, constant);
             let array_length = content.length + 1;
             let array_type = "[" + number_to_string(array_length) + " x i8]";
-            let call_line = "  call i8* @sailfin_runtime_log_execution(i8* getelementptr inbounds (" + array_type + ", " + array_type + "* " + constant_name + ", i32 0, i32 0))";
+            let call_line = "  call i8* @sailfin_runtime_log_execution(i8* getelementptr inbounds ("
+                + array_type
+                + ", "
+                + array_type
+                + "* "
+                + constant_name
+                + ", i32 0, i32 0))";
             lines = append_string(lines, call_line);
         }
         decorator_index += 1;
     }
 
     if debug_lowering {
-        print.err("emit-llvm: emit_fn phase=pre_body name=" + fn_name + " instrs=" + number_to_string(fn_instr_count));
+        print.err("emit-llvm: emit_fn phase=pre_body name=" + fn_name
+            + " instrs="
+            + number_to_string(fn_instr_count));
     }
 
     // Read .fn_index with fallback: the first-pass binary may fail to write it.
@@ -476,11 +517,21 @@ fn emit_llvm_function(function_name_hint: string, functions: NativeFunction[], e
         }
     }
     if debug_lowering {
-        print.err("emit-llvm: emit_fn phase=body_lir fn_index=" + number_to_string(_eb_fn_index) + " fn_name=" + fn_name + " fn_count=" + number_to_string(functions.length));
+        print.err("emit-llvm: emit_fn phase=body_lir fn_index="
+            + number_to_string(_eb_fn_index)
+            + " fn_name="
+            + fn_name
+            + " fn_count="
+            + number_to_string(functions.length));
     }
     // Bounds check: protect against stale .fn_index values or run-away loop
     if _eb_fn_index >= functions.length {
-        let bounds_diag = "llvm lowering: fn_index " + number_to_string(_eb_fn_index) + " out of range (max " + number_to_string(functions.length) + ") for `" + fn_name + "`";
+        let bounds_diag = "llvm lowering: fn_index " + number_to_string(_eb_fn_index)
+            + " out of range (max "
+            + number_to_string(functions.length)
+            + ") for `"
+            + fn_name
+            + "`";
         diagnostics = append_string(diagnostics, bounds_diag);
         let ret_fallback = "  ret " + llvm_return + " " + default_return_literal(llvm_return);
         lines = append_string(lines, ret_fallback);
@@ -503,7 +554,11 @@ fn emit_llvm_function(function_name_hint: string, functions: NativeFunction[], e
     let _eb_body_diagnostics = _eb_result.diagnostics;
 
     if debug_lowering {
-        print.err("emit-llvm: emit_fn phase=body_done name=" + fn_name + " body_lines=" + number_to_string(_eb_body_lines.length) + " allocas=" + number_to_string(_eb_allocas.length));
+        print.err("emit-llvm: emit_fn phase=body_done name=" + fn_name
+            + " body_lines="
+            + number_to_string(_eb_body_lines.length)
+            + " allocas="
+            + number_to_string(_eb_allocas.length));
     }
 
     let mut _eb_body: string[] = [];
@@ -540,7 +595,9 @@ fn emit_llvm_function(function_name_hint: string, functions: NativeFunction[], e
         if llvm_return == "void" {
             lines = append_string(lines, "  ret void");
         } else {
-            let missing_ret_diag = "llvm lowering: missing return in function `" + fn_name + "`";
+            let missing_ret_diag = "llvm lowering: missing return in function `"
+                + fn_name
+                + "`";
             diagnostics = append_string(diagnostics, missing_ret_diag);
             let ret_line = "  ret " + llvm_return + " " + default_return_literal(llvm_return);
             lines = append_string(lines, ret_line);
@@ -556,7 +613,9 @@ fn emit_llvm_function(function_name_hint: string, functions: NativeFunction[], e
 
     if emit_main_wrapper {
         // C ABI wrapper. Always returns 0 (success) after invoking the Sailfin main.
-        lines = extend_string_array(lines, ["", "define i32 @main(i32 %argc, i8** %argv) {", "entry:", "  call void @" + sanitized + "()", "  ret i32 0", "}",]);
+        lines = extend_string_array(lines, ["", "define i32 @main(i32 %argc, i8** %argv) {", "entry:", "  call void @"
+            + sanitized
+            + "()", "  ret i32 0", "}",]);
     }
 
     let merged_constants = merge_string_constants(_eb_string_constants, decorator_string_constants);
@@ -572,7 +631,10 @@ fn emit_llvm_function(function_name_hint: string, functions: NativeFunction[], e
 fn emit_body(function_unused: string, fn_name: string, fn_instr_count: number, llvm_return: string, bindings: ParameterBinding[], module_globals: LocalBinding[], functions: NativeFunction[], context: TypeContext, entry_label: string) -> BodyResult ![io] {
     let debug_body = fs.exists("build/sailfin/.trace_lowering");
     if debug_body {
-        print.err("emit-llvm: emit_body start fn=" + fn_name + " llvm_return=" + llvm_return + " bindings_len=" + number_to_string(bindings.length));
+        print.err("emit-llvm: emit_body start fn=" + fn_name + " llvm_return="
+            + llvm_return
+            + " bindings_len="
+            + number_to_string(bindings.length));
     }
     let mut _let202: boolean = false;
     if fs.exists("build/sailfin/.trace_test_runner") {
@@ -580,7 +642,8 @@ fn emit_body(function_unused: string, fn_name: string, fn_instr_count: number, l
     }
     let trace = _let202;
     if trace {
-        print.err("test llvm: emit_body start " + fn_name + " instrs=" + number_to_string(fn_instr_count));
+        print.err("test llvm: emit_body start " + fn_name + " instrs="
+            + number_to_string(fn_instr_count));
     }
     // Load the NativeFunction from the functions array by index,
     // avoiding the cross-module ABI issue where NativeFunction is
@@ -596,7 +659,12 @@ fn emit_body(function_unused: string, fn_name: string, fn_instr_count: number, l
     if trace {
         let mut term_label: string = "false";
         if _blk_terminated { term_label = "true"; }
-        print.err("test llvm: emit_body lowered " + fn_name + " lines=" + number_to_string(_blk_body_lines.length) + " allocas=" + number_to_string(_blk_allocas.length) + " terminated=" + term_label);
+        print.err("test llvm: emit_body lowered " + fn_name + " lines="
+            + number_to_string(_blk_body_lines.length)
+            + " allocas="
+            + number_to_string(_blk_allocas.length)
+            + " terminated="
+            + term_label);
     }
     let mut diagnostics: string[] = lowered.diagnostics;
     let mut lines: string[] = [];
@@ -628,9 +696,12 @@ fn emit_body(function_unused: string, fn_name: string, fn_instr_count: number, l
         if llvm_return == "void" {
             lines = append_string(lines, "  ret void");
         } else {
-            let missing_ret_diag2 = "llvm lowering: missing return in function `" + fn_name + "`";
+            let missing_ret_diag2 = "llvm lowering: missing return in function `"
+                + fn_name
+                + "`";
             diagnostics = append_string(diagnostics, missing_ret_diag2);
-            let ret_line2 = "  ret " + llvm_return + " " + default_return_literal(llvm_return);
+            let ret_line2 = "  ret " + llvm_return + " "
+                + default_return_literal(llvm_return);
             lines = append_string(lines, ret_line2);
         }
     }
@@ -673,7 +744,7 @@ fn _parse_string_constants_from_file(raw: string) -> StringConstant[] {
         let byte_count_text = substring(rest, tab2 + 1, rest.length);
         let byte_count = parse_simple_integer(byte_count_text);
         result = append_string_constant(result, StringConstant {
-            name: name, content: content, byte_count: byte_count,
+            name: name, content: content, byte_count: byte_count
         });
         i += 1;
     }

--- a/compiler/src/llvm/lowering/emission_async.sfn
+++ b/compiler/src/llvm/lowering/emission_async.sfn
@@ -4,67 +4,36 @@
 // emit_llvm_function under ~500 .sfn-asm instructions (avoids seed OOM).
 //
 // NOTE: Mutual import with emission.sfn — see comment there for rationale.
-
 import { NativeFunction } from "../../native_ir";
-
 import {
-    TypeContext,
-    LocalBinding,
-    ParameterBinding,
-    LoweredLLVMFunction,
+    future_pointer_type_for_return_type,
+    spawn_ctx_symbol_for_return_type,
+    spawn_symbol_for_return_type,
+} from "../expression_lowering/native/statement_suspension";
+import { format_temp_name, } from "../expressions_helpers";
+import { empty_string_constant_set, merge_string_constants, } from "../strings";
+import { map_return_type, } from "../type_mapping";
+import {
     LLVMOperand,
-    StringConstant,
-    ParameterPreparation,
     LifetimeRegionMetadata,
+    LocalBinding,
+    LoweredLLVMFunction,
+    ParameterBinding,
+    ParameterPreparation,
+    StringConstant,
+    TypeContext,
 } from "../types";
-
 import {
     extend_string_array,
     join_with_separator,
-    sanitize_symbol,
     number_to_string,
+    sanitize_symbol,
 } from "../utils";
-
-import {
-    empty_string_constant_set,
-    merge_string_constants,
-} from "../strings";
-
-import {
-    format_temp_name,
-} from "../expressions_helpers";
-
-import {
-    future_pointer_type_for_return_type,
-    spawn_symbol_for_return_type,
-    spawn_ctx_symbol_for_return_type,
-} from "../expression_lowering/native/statement_suspension";
-
-import {
-    map_return_type,
-} from "../type_mapping";
-
 import { emit_llvm_function } from "./emission";
-
 import { prepare_parameters_from_files } from "./emission";
 
 // Emit async wrapper + impl for an async function. Returns LoweredLLVMFunction.
-fn emit_async_function(
-    fn_name: string,
-    fn_return_type: string,
-    fn_param_count: number,
-    function_name_hint: string,
-    functions: NativeFunction[],
-    effects: string[],
-    context: TypeContext,
-    module_name: string,
-    entry_points: string[],
-    exported_symbols: string[],
-    imported_functions: NativeFunction[],
-    module_globals: LocalBinding[],
-    module_init_symbol: string,
-    needs_module_init_call: boolean
-) -> LoweredLLVMFunction ![io] {
+fn emit_async_function(fn_name: string, fn_return_type: string, fn_param_count: number, function_name_hint: string, functions: NativeFunction[], effects: string[], context: TypeContext, module_name: string, entry_points: string[], exported_symbols: string[], imported_functions: NativeFunction[], module_globals: LocalBinding[], module_init_symbol: string, needs_module_init_call: boolean) -> LoweredLLVMFunction ![io] {
     let mut diagnostics: string[] = [];
     let future_return = future_pointer_type_for_return_type(fn_return_type);
     let mut impl_return = map_return_type(context, fn_return_type);
@@ -74,7 +43,12 @@ fn emit_async_function(
     if _if205 {
         diagnostics.push("llvm lowering: async fn `" + fn_name + "` has unsupported return type `" + fn_return_type + "`");
         let empty_constants = empty_string_constant_set();
-        return LoweredLLVMFunction { lines: [], diagnostics: diagnostics, lifetime_regions: [], string_constants: empty_constants };
+        return LoweredLLVMFunction {
+            lines: [],
+            diagnostics: diagnostics,
+            lifetime_regions: [],
+            string_constants: empty_constants
+        };
     }
 
     let mut impl_return_type_annotation: string = fn_return_type;
@@ -87,19 +61,7 @@ fn emit_async_function(
     fs.writeFile("build/sailfin/.fn_name", impl_name);
     fs.writeFile("build/sailfin/.fn_return_type", impl_return_type_annotation);
     fs.writeFile("build/sailfin/.fn_is_async", "0");
-    let impl_lowered = emit_llvm_function(
-        function_name_hint,
-        functions,
-        effects,
-        context,
-        module_name,
-        entry_points,
-        exported_symbols,
-        imported_functions,
-        module_globals,
-        module_init_symbol,
-        needs_module_init_call
-    );
+    let impl_lowered = emit_llvm_function(function_name_hint, functions, effects, context, module_name, entry_points, exported_symbols, imported_functions, module_globals, module_init_symbol, needs_module_init_call);
 
     diagnostics = extend_string_array(diagnostics, impl_lowered.diagnostics);
 
@@ -112,16 +74,19 @@ fn emit_async_function(
     let wrapper_symbol = sanitize_symbol(fn_name);
     let impl_symbol = sanitize_symbol(impl_name);
     let mut signature: string = join_with_separator(preparation.signature, ", ");
-    if signature.length == 0 {
-        signature = "";
-    }
+    if signature.length == 0 { signature = ""; }
 
     if fn_param_count == 0 {
         let spawn_symbol = spawn_symbol_for_return_type(fn_return_type);
         if spawn_symbol.length == 0 {
             diagnostics.push("llvm lowering: async fn `" + fn_name + "` has unsupported return type `" + fn_return_type + "`");
             let empty_constants = empty_string_constant_set();
-                    return LoweredLLVMFunction { lines: [], diagnostics: diagnostics, lifetime_regions: [], string_constants: empty_constants };
+            return LoweredLLVMFunction {
+                lines: [],
+                diagnostics: diagnostics,
+                lifetime_regions: [],
+                string_constants: empty_constants
+            };
         }
         wrapper_lines.push("define " + linkage + future_return + " @" + wrapper_symbol + "(" + signature + ") {");
         wrapper_lines.push("block.entry:");
@@ -134,7 +99,12 @@ fn emit_async_function(
         if spawn_symbol.length == 0 {
             diagnostics.push("llvm lowering: async fn `" + fn_name + "` has unsupported return type `" + fn_return_type + "`");
             let empty_constants = empty_string_constant_set();
-                    return LoweredLLVMFunction { lines: [], diagnostics: diagnostics, lifetime_regions: [], string_constants: empty_constants };
+            return LoweredLLVMFunction {
+                lines: [],
+                diagnostics: diagnostics,
+                lifetime_regions: [],
+                string_constants: empty_constants
+            };
         }
 
         let ctx_type = "%SailfinAsyncCtx." + wrapper_symbol;

--- a/compiler/src/llvm/lowering/emission_async.sfn
+++ b/compiler/src/llvm/lowering/emission_async.sfn
@@ -8,11 +8,11 @@ import { NativeFunction } from "../../native_ir";
 import {
     future_pointer_type_for_return_type,
     spawn_ctx_symbol_for_return_type,
-    spawn_symbol_for_return_type,
+    spawn_symbol_for_return_type
 } from "../expression_lowering/native/statement_suspension";
-import { format_temp_name, } from "../expressions_helpers";
-import { empty_string_constant_set, merge_string_constants, } from "../strings";
-import { map_return_type, } from "../type_mapping";
+import { format_temp_name } from "../expressions_helpers";
+import { empty_string_constant_set, merge_string_constants } from "../strings";
+import { map_return_type } from "../type_mapping";
 import {
     LLVMOperand,
     LifetimeRegionMetadata,
@@ -21,13 +21,13 @@ import {
     ParameterBinding,
     ParameterPreparation,
     StringConstant,
-    TypeContext,
+    TypeContext
 } from "../types";
 import {
     extend_string_array,
     join_with_separator,
     number_to_string,
-    sanitize_symbol,
+    sanitize_symbol
 } from "../utils";
 import { emit_llvm_function } from "./emission";
 import { prepare_parameters_from_files } from "./emission";
@@ -41,7 +41,10 @@ fn emit_async_function(fn_name: string, fn_return_type: string, fn_param_count: 
     if future_return.length == 0 { _if205 = true; }
     if impl_return.length == 0 { _if205 = true; }
     if _if205 {
-        diagnostics.push("llvm lowering: async fn `" + fn_name + "` has unsupported return type `" + fn_return_type + "`");
+        diagnostics.push("llvm lowering: async fn `" + fn_name
+            + "` has unsupported return type `"
+            + fn_return_type
+            + "`");
         let empty_constants = empty_string_constant_set();
         return LoweredLLVMFunction {
             lines: [],
@@ -79,7 +82,10 @@ fn emit_async_function(fn_name: string, fn_return_type: string, fn_param_count: 
     if fn_param_count == 0 {
         let spawn_symbol = spawn_symbol_for_return_type(fn_return_type);
         if spawn_symbol.length == 0 {
-            diagnostics.push("llvm lowering: async fn `" + fn_name + "` has unsupported return type `" + fn_return_type + "`");
+            diagnostics.push("llvm lowering: async fn `" + fn_name
+                + "` has unsupported return type `"
+                + fn_return_type
+                + "`");
             let empty_constants = empty_string_constant_set();
             return LoweredLLVMFunction {
                 lines: [],
@@ -88,16 +94,29 @@ fn emit_async_function(fn_name: string, fn_return_type: string, fn_param_count: 
                 string_constants: empty_constants
             };
         }
-        wrapper_lines.push("define " + linkage + future_return + " @" + wrapper_symbol + "(" + signature + ") {");
+        wrapper_lines.push("define " + linkage + future_return + " @"
+            + wrapper_symbol
+            + "("
+            + signature
+            + ") {");
         wrapper_lines.push("block.entry:");
         let t0 = format_temp_name(0);
-        wrapper_lines.push("  " + t0 + " = call " + future_return + " @" + spawn_symbol + "(" + impl_return + " ()* @" + impl_symbol + ")");
+        wrapper_lines.push("  " + t0 + " = call " + future_return + " @"
+            + spawn_symbol
+            + "("
+            + impl_return
+            + " ()* @"
+            + impl_symbol
+            + ")");
         wrapper_lines.push("  ret " + future_return + " " + t0);
         wrapper_lines.push("}");
     } else {
         let spawn_symbol = spawn_ctx_symbol_for_return_type(fn_return_type);
         if spawn_symbol.length == 0 {
-            diagnostics.push("llvm lowering: async fn `" + fn_name + "` has unsupported return type `" + fn_return_type + "`");
+            diagnostics.push("llvm lowering: async fn `" + fn_name
+                + "` has unsupported return type `"
+                + fn_return_type
+                + "`");
             let empty_constants = empty_string_constant_set();
             return LoweredLLVMFunction {
                 lines: [],
@@ -118,16 +137,20 @@ fn emit_async_function(fn_name: string, fn_return_type: string, fn_param_count: 
             param_llvm_types.push(preparation.bindings[param_index].llvm_type);
             param_index += 1;
         }
-        wrapper_lines.push(ctx_type + " = type { " + join_with_separator(param_llvm_types, ", ") + " }");
+        wrapper_lines.push(ctx_type + " = type { " + join_with_separator(param_llvm_types, ", ")
+            + " }");
         wrapper_lines.push("");
 
-        wrapper_lines.push("define internal " + impl_return + " @" + trampoline_symbol + "(i8* %ctx_raw) {");
+        wrapper_lines.push("define internal " + impl_return + " @"
+            + trampoline_symbol
+            + "(i8* %ctx_raw) {");
         wrapper_lines.push("block.entry:");
 
         let mut tramp_temp: number = 0;
         let tramp_ctx = format_temp_name(tramp_temp);
         tramp_temp += 1;
-        wrapper_lines.push("  " + tramp_ctx + " = bitcast i8* %ctx_raw to " + ctx_ptr_type);
+        wrapper_lines.push("  " + tramp_ctx + " = bitcast i8* %ctx_raw to "
+            + ctx_ptr_type);
 
         let mut arg_texts: string[] = [];
         let mut load_index: number = 0;
@@ -136,44 +159,76 @@ fn emit_async_function(fn_name: string, fn_return_type: string, fn_param_count: 
             let binding = preparation.bindings[load_index];
             let field_ptr = format_temp_name(tramp_temp);
             tramp_temp += 1;
-            wrapper_lines.push("  " + field_ptr + " = getelementptr inbounds " + ctx_type + ", " + ctx_ptr_type + " " + tramp_ctx + ", i32 0, i32 " + number_to_string(load_index));
+            wrapper_lines.push("  " + field_ptr + " = getelementptr inbounds "
+                + ctx_type
+                + ", "
+                + ctx_ptr_type
+                + " "
+                + tramp_ctx
+                + ", i32 0, i32 "
+                + number_to_string(load_index));
             let loaded = format_temp_name(tramp_temp);
             tramp_temp += 1;
-            wrapper_lines.push("  " + loaded + " = load " + binding.llvm_type + ", " + binding.llvm_type + "* " + field_ptr);
+            wrapper_lines.push("  " + loaded + " = load " + binding.llvm_type
+                + ", "
+                + binding.llvm_type
+                + "* "
+                + field_ptr);
             arg_texts.push(binding.llvm_type + " " + loaded);
             load_index += 1;
         }
         let call_args = join_with_separator(arg_texts, ", ");
 
         if impl_return == "void" {
-            wrapper_lines.push("  call void @" + impl_symbol + "(" + call_args + ")");
+            wrapper_lines.push("  call void @" + impl_symbol + "(" + call_args
+                + ")");
             wrapper_lines.push("  call void @free(i8* %ctx_raw)");
             wrapper_lines.push("  ret void");
         } else {
             let tramp_result = format_temp_name(tramp_temp);
             tramp_temp += 1;
-            wrapper_lines.push("  " + tramp_result + " = call " + impl_return + " @" + impl_symbol + "(" + call_args + ")");
+            wrapper_lines.push("  " + tramp_result + " = call " + impl_return
+                + " @"
+                + impl_symbol
+                + "("
+                + call_args
+                + ")");
             wrapper_lines.push("  call void @free(i8* %ctx_raw)");
             wrapper_lines.push("  ret " + impl_return + " " + tramp_result);
         }
         wrapper_lines.push("}");
         wrapper_lines.push("");
 
-        wrapper_lines.push("define " + linkage + future_return + " @" + wrapper_symbol + "(" + signature + ") {");
+        wrapper_lines.push("define " + linkage + future_return + " @"
+            + wrapper_symbol
+            + "("
+            + signature
+            + ") {");
         wrapper_lines.push("block.entry:");
         let mut wrap_temp: number = 0;
         let size_ptr = format_temp_name(wrap_temp);
         wrap_temp += 1;
-        wrapper_lines.push("  " + size_ptr + " = getelementptr inbounds " + ctx_type + ", " + ctx_ptr_type + " null, i32 1");
+        wrapper_lines.push("  " + size_ptr + " = getelementptr inbounds "
+            + ctx_type
+            + ", "
+            + ctx_ptr_type
+            + " null, i32 1");
         let size_i64 = format_temp_name(wrap_temp);
         wrap_temp += 1;
-        wrapper_lines.push("  " + size_i64 + " = ptrtoint " + ctx_ptr_type + " " + size_ptr + " to i64");
+        wrapper_lines.push("  " + size_i64 + " = ptrtoint " + ctx_ptr_type + " "
+            + size_ptr
+            + " to i64");
         let ctx_raw = format_temp_name(wrap_temp);
         wrap_temp += 1;
-        wrapper_lines.push("  " + ctx_raw + " = call noalias i8* @calloc(i64 1, i64 " + size_i64 + ")");
+        wrapper_lines.push("  " + ctx_raw
+            + " = call noalias i8* @calloc(i64 1, i64 "
+            + size_i64
+            + ")");
         let ctx_typed = format_temp_name(wrap_temp);
         wrap_temp += 1;
-        wrapper_lines.push("  " + ctx_typed + " = bitcast i8* " + ctx_raw + " to " + ctx_ptr_type);
+        wrapper_lines.push("  " + ctx_typed + " = bitcast i8* " + ctx_raw
+            + " to "
+            + ctx_ptr_type);
 
         let mut store_index: number = 0;
         loop {
@@ -181,14 +236,33 @@ fn emit_async_function(fn_name: string, fn_return_type: string, fn_param_count: 
             let binding = preparation.bindings[store_index];
             let field_ptr = format_temp_name(wrap_temp);
             wrap_temp += 1;
-            wrapper_lines.push("  " + field_ptr + " = getelementptr inbounds " + ctx_type + ", " + ctx_ptr_type + " " + ctx_typed + ", i32 0, i32 " + number_to_string(store_index));
-            wrapper_lines.push("  store " + binding.llvm_type + " " + binding.llvm_name + ", " + binding.llvm_type + "* " + field_ptr);
+            wrapper_lines.push("  " + field_ptr + " = getelementptr inbounds "
+                + ctx_type
+                + ", "
+                + ctx_ptr_type
+                + " "
+                + ctx_typed
+                + ", i32 0, i32 "
+                + number_to_string(store_index));
+            wrapper_lines.push("  store " + binding.llvm_type + " " + binding.llvm_name
+                + ", "
+                + binding.llvm_type
+                + "* "
+                + field_ptr);
             store_index += 1;
         }
 
         let out_future = format_temp_name(wrap_temp);
         wrap_temp += 1;
-        wrapper_lines.push("  " + out_future + " = call " + future_return + " @" + spawn_symbol + "(" + impl_return + " (i8*)* @" + trampoline_symbol + ", i8* " + ctx_raw + ")");
+        wrapper_lines.push("  " + out_future + " = call " + future_return + " @"
+            + spawn_symbol
+            + "("
+            + impl_return
+            + " (i8*)* @"
+            + trampoline_symbol
+            + ", i8* "
+            + ctx_raw
+            + ")");
         wrapper_lines.push("  ret " + future_return + " " + out_future);
         wrapper_lines.push("}");
     }
@@ -204,7 +278,7 @@ fn emit_async_function(fn_name: string, fn_return_type: string, fn_param_count: 
         lines: merged_lines,
         diagnostics: diagnostics,
         lifetime_regions: impl_lowered.lifetime_regions,
-        string_constants: merged_constants,
+        string_constants: merged_constants
     };
 }
 

--- a/compiler/src/llvm/lowering/emission_header.sfn
+++ b/compiler/src/llvm/lowering/emission_header.sfn
@@ -8,7 +8,6 @@
 // value in code compiled by the first-pass binary — the lowering silently drops
 // all subsequent instructions.  We extract `{` at runtime via substring() from
 // a simple assignment (which the lowering handles correctly).
-
 import { trim_text, substring } from "../utils";
 
 fn build_define_header_line(linkage: string, llvm_return: string, sanitized: string, signature: string) -> string {

--- a/compiler/src/llvm/lowering/entrypoints.sfn
+++ b/compiler/src/llvm/lowering/entrypoints.sfn
@@ -16,7 +16,7 @@ import {
     NativeStructField,
     NativeStructLayout,
     NativeStructLayoutField,
-    ParseNativeResult,
+    ParseNativeResult
 } from "../../native_ir";
 import {
     parse_layout_manifest,
@@ -35,7 +35,7 @@ import {
     parse_native_structs_for_import,
     parse_native_structs_from_text,
     select_layout_manifest_artifact,
-    select_text_artifact,
+    select_text_artifact
 } from "../../native_ir_api";
 import { split_lines } from "../../native_ir_utils_text";
 import { char_code, substring } from "../../string_utils";
@@ -47,20 +47,20 @@ import {
     collect_function_call_graph,
     collect_runtime_helper_targets,
     find_function_effect_entry,
-    propagate_function_effects,
+    propagate_function_effects
 } from "../effects";
 import {
     apply_layout_manifest_to_module,
     collect_imported_module_context_for_module,
     resolve_import_artifact_slug,
-    resolve_import_module_slug_for_module,
+    resolve_import_module_slug_for_module
 } from "../imports";
 import {
     render_enum_type_definitions,
     render_imported_function_declarations,
     render_runtime_helper_declarations,
     render_struct_type_definitions,
-    render_trait_metadata_comments,
+    render_trait_metadata_comments
 } from "../rendering";
 import {
     collect_exported_symbol_names,
@@ -69,14 +69,14 @@ import {
     render_test_harness_main,
     render_vtable_constants,
     render_vtable_type_definitions,
-    should_internalize_function,
+    should_internalize_function
 } from "../rendering_helpers";
 import {
     empty_string_constant_set,
     merge_string_constants,
-    render_string_constants,
+    render_string_constants
 } from "../strings";
-import { build_type_context, fixup_enum_layouts, } from "../type_context";
+import { build_type_context, fixup_enum_layouts } from "../type_context";
 import {
     CapabilityManifest,
     EnumTypeInfo,
@@ -90,7 +90,7 @@ import {
     TraitDescriptor,
     TraitImplementationDescriptor,
     TraitMetadata,
-    TypeContext,
+    TypeContext
 } from "../types";
 import {
     append_string,
@@ -100,13 +100,13 @@ import {
     sanitize_symbol,
     starts_with,
     string_array_contains,
-    trim_text,
+    trim_text
 } from "../utils";
-import { emit_llvm_function, } from "./emission";
+import { emit_llvm_function } from "./emission";
 import {
     compile_native_text_to_llvm_file,
     lower_to_llvm_lines_with_parsed_context,
-    lower_to_llvm_lines_with_parsed_context_for_tests,
+    lower_to_llvm_lines_with_parsed_context_for_tests
 } from "./lowering_core";
 import {
     DeclareSignature,
@@ -124,7 +124,7 @@ import {
     render_function_shim,
     render_test_harness_main_for_module,
     resolve_import_provider_module_name,
-    sanitize_collection_length,
+    sanitize_collection_length
 } from "./lowering_helpers";
 import {
     _join_llvm_lines_linear,
@@ -133,7 +133,7 @@ import {
     build_trait_metadata,
     concat_native_functions,
     empty_capability_manifest,
-    flatten_struct_methods,
+    flatten_struct_methods
 } from "./lowering_helpers_mangling";
 import {
     append_string_lines,
@@ -142,16 +142,16 @@ import {
     extend_string_lines,
     extend_string_lines_checked,
     module_source_filename,
-    write_llvm_lines_chunked,
+    write_llvm_lines_chunked
 } from "./lowering_io";
 import {
     parse_native_artifact_safe,
     recover_functions_for_lowering,
     recover_native_functions_light,
     recover_native_imports_light,
-    recover_native_structs_light,
+    recover_native_structs_light
 } from "./lowering_recovery";
-import { lower_module_bindings_to_globals, } from "./module_globals";
+import { lower_module_bindings_to_globals } from "./module_globals";
 
 fn lower_to_llvm(native_module: NativeModule) -> LoweredLLVMResult ![io] {
     let artifact = select_text_artifact(native_module.artifacts);
@@ -190,7 +190,7 @@ fn lower_to_llvm_lines(native_module: NativeModule) -> LoweredLLVMLinesResult ![
         function_effects: [],
         lifetime_regions: [],
         capability_manifest: empty_capability_manifest(),
-        string_constants: empty_string_constant_set(),
+        string_constants: empty_string_constant_set()
     };
 }
 
@@ -234,14 +234,22 @@ fn lower_to_llvm_ir_from_text(native_text: string, module_name: string) -> strin
             name: module_name, format: "sailfin-native-text", contents: native_text
         }],
         entry_points: [],
-        symbol_count: 0,
+        symbol_count: 0
     };
     let lowered_lines = lower_to_llvm_lines_with_parsed_context(dummy_module, parse, import_context.manifests, import_context.native_texts, import_context.diagnostics, true, native_text);
     let mut _if219: boolean = false;
     if lowered_lines.lines == null { _if219 = true; }
     if lowered_lines.lines.length == 0 { _if219 = true; }
     if _if219 {
-        print.err("emit-llvm: no lines from native text (functions=" + number_to_string(parse.functions.length) + " structs=" + number_to_string(parse.structs.length) + " enums=" + number_to_string(parse.enums.length) + " diagnostics=" + number_to_string(parse.diagnostics.length) + ")");
+        print.err("emit-llvm: no lines from native text (functions="
+            + number_to_string(parse.functions.length)
+            + " structs="
+            + number_to_string(parse.structs.length)
+            + " enums="
+            + number_to_string(parse.enums.length)
+            + " diagnostics="
+            + number_to_string(parse.diagnostics.length)
+            + ")");
         return "";
     }
     return _join_llvm_lines_linear(lowered_lines.lines);
@@ -257,7 +265,14 @@ fn write_llvm_ir(native_module: NativeModule, out_path: string) -> boolean ![io]
     let lowered_lines = lower_to_llvm_lines_with_parsed_context(native_module, parse, import_context.manifests, import_context.native_texts, import_context.diagnostics, true, artifact.contents);
     let lines = lowered_lines.lines;
     if lines.length == 0 {
-        print.err("emit-llvm: no lines from module (module=" + native_module.module_name + " functions=" + number_to_string(parse.functions.length) + " imports=" + number_to_string(parse.imports.length) + " diagnostics=" + number_to_string(lowered_lines.diagnostics.length) + ")");
+        print.err("emit-llvm: no lines from module (module=" + native_module.module_name
+            + " functions="
+            + number_to_string(parse.functions.length)
+            + " imports="
+            + number_to_string(parse.imports.length)
+            + " diagnostics="
+            + number_to_string(lowered_lines.diagnostics.length)
+            + ")");
         if lowered_lines.diagnostics.length > 0 {
             print.err("emit-llvm: diagnostic " + lowered_lines.diagnostics[0]);
         }
@@ -290,7 +305,7 @@ fn lower_to_llvm_with_parsed_context(native_module: NativeModule, parse: ParseNa
             function_effects: lowered.function_effects,
             lifetime_regions: lowered.lifetime_regions,
             capability_manifest: lowered.capability_manifest,
-            string_constants: lowered.string_constants,
+            string_constants: lowered.string_constants
         };
     }
     let ir = _join_llvm_lines_linear(lowered.lines);
@@ -303,7 +318,7 @@ fn lower_to_llvm_with_parsed_context(native_module: NativeModule, parse: ParseNa
         function_effects: lowered.function_effects,
         lifetime_regions: lowered.lifetime_regions,
         capability_manifest: lowered.capability_manifest,
-        string_constants: lowered.string_constants,
+        string_constants: lowered.string_constants
     };
 }
 
@@ -319,7 +334,7 @@ fn lower_to_llvm_with_context(native_module: NativeModule, imported_manifests: L
         function_effects: lowered.function_effects,
         lifetime_regions: lowered.lifetime_regions,
         capability_manifest: lowered.capability_manifest,
-        string_constants: lowered.string_constants,
+        string_constants: lowered.string_constants
     };
 }
 
@@ -344,7 +359,7 @@ fn lower_to_llvm_lines_with_context(native_module: NativeModule, imported_manife
             function_effects: [],
             lifetime_regions: [],
             capability_manifest: empty_capability_manifest(),
-            string_constants: empty_constants,
+            string_constants: empty_constants
         };
     }
 

--- a/compiler/src/llvm/lowering/entrypoints.sfn
+++ b/compiler/src/llvm/lowering/entrypoints.sfn
@@ -1,171 +1,157 @@
 // compiler/src/llvm/lowering/entrypoints.sfn
 //
 // LLVM IR lowering entrypoints — public API surface.
-
 import { NativeArtifact, NativeModule } from "../../emit_native";
 import {
+    LayoutManifest,
+    NativeBinding,
+    NativeEnum,
+    NativeFunction,
     NativeImport,
     NativeImportSpecifier,
-    NativeFunction,
-    NativeParameter,
     NativeInstruction,
     NativeInterface,
+    NativeParameter,
     NativeStruct,
     NativeStructField,
     NativeStructLayout,
     NativeStructLayoutField,
-    NativeEnum,
-    LayoutManifest,
     ParseNativeResult,
-    NativeBinding,
 } from "../../native_ir";
 import {
-    select_text_artifact,
-    select_layout_manifest_artifact,
+    parse_layout_manifest,
     parse_native_artifact,
-    parse_native_function_count_from_text,
-    parse_native_functions_from_text,
-    parse_native_structs_from_text,
-    parse_native_imports_from_text,
-    parse_native_interfaces_from_text,
-    parse_native_enums_from_text,
+    parse_native_artifact_for_import_context,
     parse_native_bindings_from_text,
     parse_native_diagnostics_from_text,
-    parse_native_structs_for_import,
-    parse_native_imports_for_import,
-    parse_native_interfaces_for_import,
+    parse_native_enums_from_text,
+    parse_native_function_count_from_text,
     parse_native_functions_for_import,
-    parse_native_artifact_for_import_context,
-    parse_layout_manifest,
+    parse_native_functions_from_text,
+    parse_native_imports_for_import,
+    parse_native_imports_from_text,
+    parse_native_interfaces_for_import,
+    parse_native_interfaces_from_text,
+    parse_native_structs_for_import,
+    parse_native_structs_from_text,
+    select_layout_manifest_artifact,
+    select_text_artifact,
 } from "../../native_ir_api";
 import { split_lines } from "../../native_ir_utils_text";
-import { substring, char_code } from "../../string_utils";
-
+import { char_code, substring } from "../../string_utils";
 import {
-    TypeContext,
-    TraitMetadata,
-    TraitDescriptor,
-    TraitImplementationDescriptor,
-    ImportedModuleContext,
-    LoweredLLVMResult,
-    LoweredLLVMLinesResult,
-    FunctionEffectEntry,
-    LifetimeRegionMetadata,
-    StringConstant,
-    CapabilityManifest,
-    EnumTypeInfo,
-    EnumVariantInfo,
-} from "../types";
-
+    append_function_effect_entry,
+    append_unique_effect,
+    build_capability_manifest,
+    collect_direct_function_effects,
+    collect_function_call_graph,
+    collect_runtime_helper_targets,
+    find_function_effect_entry,
+    propagate_function_effects,
+} from "../effects";
 import {
-    append_string,
-    join_with_separator,
-    number_to_string,
-    sanitize_symbol,
-    string_array_contains,
-    starts_with,
-    trim_text,
-    index_of,
-} from "../utils";
-
+    apply_layout_manifest_to_module,
+    collect_imported_module_context_for_module,
+    resolve_import_artifact_slug,
+    resolve_import_module_slug_for_module,
+} from "../imports";
+import {
+    render_enum_type_definitions,
+    render_imported_function_declarations,
+    render_runtime_helper_declarations,
+    render_struct_type_definitions,
+    render_trait_metadata_comments,
+} from "../rendering";
+import {
+    collect_exported_symbol_names,
+    find_function_by_name,
+    render_interface_type_definitions,
+    render_test_harness_main,
+    render_vtable_constants,
+    render_vtable_type_definitions,
+    should_internalize_function,
+} from "../rendering_helpers";
 import {
     empty_string_constant_set,
     merge_string_constants,
     render_string_constants,
 } from "../strings";
-
+import { build_type_context, fixup_enum_layouts, } from "../type_context";
 import {
-    collect_direct_function_effects,
-    collect_function_call_graph,
-    propagate_function_effects,
-    build_capability_manifest,
-    collect_runtime_helper_targets,
-    append_unique_effect,
-    find_function_effect_entry,
-    append_function_effect_entry,
-} from "../effects";
-
+    CapabilityManifest,
+    EnumTypeInfo,
+    EnumVariantInfo,
+    FunctionEffectEntry,
+    ImportedModuleContext,
+    LifetimeRegionMetadata,
+    LoweredLLVMLinesResult,
+    LoweredLLVMResult,
+    StringConstant,
+    TraitDescriptor,
+    TraitImplementationDescriptor,
+    TraitMetadata,
+    TypeContext,
+} from "../types";
 import {
-    render_struct_type_definitions, render_enum_type_definitions,
-    render_trait_metadata_comments, render_runtime_helper_declarations,
-    render_imported_function_declarations,
-} from "../rendering";
+    append_string,
+    index_of,
+    join_with_separator,
+    number_to_string,
+    sanitize_symbol,
+    starts_with,
+    string_array_contains,
+    trim_text,
+} from "../utils";
+import { emit_llvm_function, } from "./emission";
 import {
-    render_test_harness_main, collect_exported_symbol_names,
-    render_interface_type_definitions, render_vtable_type_definitions,
-    render_vtable_constants, should_internalize_function, find_function_by_name,
-} from "../rendering_helpers";
-
-import {
-    fixup_enum_layouts,
-    build_type_context,
-} from "../type_context";
-
-import {
-    collect_imported_module_context_for_module,
-    apply_layout_manifest_to_module,
-    resolve_import_module_slug_for_module,
-    resolve_import_artifact_slug,
-} from "../imports";
-
-import {
-    lower_module_bindings_to_globals,
-} from "./module_globals";
-
-import {
-    emit_llvm_function,
-} from "./emission";
-
-import {
-    empty_trait_metadata,
-    sanitize_collection_length,
-    is_test_module_slug,
-    render_test_harness_main_for_module,
-    extend_native_structs,
-    extend_native_enums,
-    extend_native_interfaces,
-    extend_native_functions,
-    collect_defined_function_symbols,
-    collect_available_import_module_names,
-    resolve_import_provider_module_name,
-    find_declare_signature,
-    render_function_shim,
-    insert_before_llvm_footer,
-    DeclareSignature,
-    MangledModuleResult,
-} from "./lowering_helpers";
-
-import {
-    empty_capability_manifest,
-    _join_llvm_lines_linear,
-    build_trait_metadata,
-    flatten_struct_methods,
-    concat_native_functions,
-    append_native_function,
-    apply_module_symbol_mangling,
-} from "./lowering_helpers_mangling";
-
-import {
+    compile_native_text_to_llvm_file,
     lower_to_llvm_lines_with_parsed_context,
     lower_to_llvm_lines_with_parsed_context_for_tests,
-    compile_native_text_to_llvm_file,
 } from "./lowering_core";
 import {
-    recover_functions_for_lowering,
-    recover_native_functions_light,
-    recover_native_structs_light,
-    recover_native_imports_light,
-    parse_native_artifact_safe,
-} from "./lowering_recovery";
+    DeclareSignature,
+    MangledModuleResult,
+    collect_available_import_module_names,
+    collect_defined_function_symbols,
+    empty_trait_metadata,
+    extend_native_enums,
+    extend_native_functions,
+    extend_native_interfaces,
+    extend_native_structs,
+    find_declare_signature,
+    insert_before_llvm_footer,
+    is_test_module_slug,
+    render_function_shim,
+    render_test_harness_main_for_module,
+    resolve_import_provider_module_name,
+    sanitize_collection_length,
+} from "./lowering_helpers";
 import {
+    _join_llvm_lines_linear,
+    append_native_function,
+    apply_module_symbol_mangling,
+    build_trait_metadata,
+    concat_native_functions,
+    empty_capability_manifest,
+    flatten_struct_methods,
+} from "./lowering_helpers_mangling";
+import {
+    append_string_lines,
+    ensure_intrinsic_declarations,
+    extend_lifetime_regions_checked,
     extend_string_lines,
     extend_string_lines_checked,
-    write_llvm_lines_chunked,
-    ensure_intrinsic_declarations,
     module_source_filename,
-    append_string_lines,
-    extend_lifetime_regions_checked,
+    write_llvm_lines_chunked,
 } from "./lowering_io";
+import {
+    parse_native_artifact_safe,
+    recover_functions_for_lowering,
+    recover_native_functions_light,
+    recover_native_imports_light,
+    recover_native_structs_light,
+} from "./lowering_recovery";
+import { lower_module_bindings_to_globals, } from "./module_globals";
 
 fn lower_to_llvm(native_module: NativeModule) -> LoweredLLVMResult ![io] {
     let artifact = select_text_artifact(native_module.artifacts);
@@ -177,13 +163,7 @@ fn lower_to_llvm(native_module: NativeModule) -> LoweredLLVMResult ![io] {
     }
     let parse = parse_native_artifact_safe(artifact.contents);
     let import_context = collect_imported_module_context_for_module(parse.imports, native_module.module_name);
-    return lower_to_llvm_with_parsed_context(
-        native_module,
-        parse,
-        import_context.manifests,
-        import_context.native_texts,
-        import_context.diagnostics
-    );
+    return lower_to_llvm_with_parsed_context(native_module, parse, import_context.manifests, import_context.native_texts, import_context.diagnostics);
 }
 
 fn lower_to_llvm_lines(native_module: NativeModule) -> LoweredLLVMLinesResult ![io] {
@@ -192,7 +172,15 @@ fn lower_to_llvm_lines(native_module: NativeModule) -> LoweredLLVMLinesResult ![
     if ir == null { _if207 = true; }
     if ir.length == 0 { _if207 = true; }
     if _if207 {
-        return LoweredLLVMLinesResult { lines: [], diagnostics: [], trait_metadata: empty_trait_metadata(), function_effects: [], lifetime_regions: [], capability_manifest: empty_capability_manifest(), string_constants: empty_string_constant_set() };
+        return LoweredLLVMLinesResult {
+            lines: [],
+            diagnostics: [],
+            trait_metadata: empty_trait_metadata(),
+            function_effects: [],
+            lifetime_regions: [],
+            capability_manifest: empty_capability_manifest(),
+            string_constants: empty_string_constant_set()
+        };
     }
     let lines = split_lines(ir);
     return LoweredLLVMLinesResult {
@@ -211,9 +199,7 @@ fn lower_to_llvm_lines_only(native_module: NativeModule) -> string[] ![io] {
     let mut _if208: boolean = false;
     if ir == null { _if208 = true; }
     if ir.length == 0 { _if208 = true; }
-    if _if208 {
-        return [];
-    }
+    if _if208 { return []; }
     return split_lines(ir);
 }
 
@@ -233,53 +219,29 @@ fn lower_to_llvm_ir(native_module: NativeModule) -> string ![io] {
     // Parse once and reuse throughout lowering; parsing the native artifact is expensive.
     let parse = parse_native_artifact_safe(artifact.contents);
     let import_context = collect_imported_module_context_for_module(parse.imports, native_module.module_name);
-    let lowered = lower_to_llvm_with_parsed_context(
-        native_module,
-        parse,
-        import_context.manifests,
-        import_context.native_texts,
-        import_context.diagnostics
-    );
+    let lowered = lower_to_llvm_with_parsed_context(native_module, parse, import_context.manifests, import_context.native_texts, import_context.diagnostics);
     return lowered.ir;
 }
 
 // Build LLVM IR from raw native text (non-test path), avoiding NativeModule ABI issues.
 fn lower_to_llvm_ir_from_text(native_text: string, module_name: string) -> string ![io] {
-    if native_text.length == 0 {
-        return "";
-    }
+    if native_text.length == 0 { return ""; }
     let parse = parse_native_artifact_safe(native_text);
     let import_context = collect_imported_module_context_for_module(parse.imports, module_name);
     let dummy_module = NativeModule {
         module_name: module_name,
-        artifacts: [NativeArtifact { name: module_name, format: "sailfin-native-text", contents: native_text }],
+        artifacts: [NativeArtifact {
+            name: module_name, format: "sailfin-native-text", contents: native_text
+        }],
         entry_points: [],
         symbol_count: 0,
     };
-    let lowered_lines = lower_to_llvm_lines_with_parsed_context(
-        dummy_module,
-        parse,
-        import_context.manifests,
-        import_context.native_texts,
-        import_context.diagnostics,
-        true,
-        native_text
-    );
+    let lowered_lines = lower_to_llvm_lines_with_parsed_context(dummy_module, parse, import_context.manifests, import_context.native_texts, import_context.diagnostics, true, native_text);
     let mut _if219: boolean = false;
     if lowered_lines.lines == null { _if219 = true; }
     if lowered_lines.lines.length == 0 { _if219 = true; }
     if _if219 {
-        print.err(
-            "emit-llvm: no lines from native text (functions="
-            + number_to_string(parse.functions.length)
-            + " structs="
-            + number_to_string(parse.structs.length)
-            + " enums="
-            + number_to_string(parse.enums.length)
-            + " diagnostics="
-            + number_to_string(parse.diagnostics.length)
-            + ")"
-        );
+        print.err("emit-llvm: no lines from native text (functions=" + number_to_string(parse.functions.length) + " structs=" + number_to_string(parse.structs.length) + " enums=" + number_to_string(parse.enums.length) + " diagnostics=" + number_to_string(parse.diagnostics.length) + ")");
         return "";
     }
     return _join_llvm_lines_linear(lowered_lines.lines);
@@ -289,33 +251,13 @@ fn lower_to_llvm_ir_from_text(native_text: string, module_name: string) -> strin
 // Avoids returning large structs/arrays across boundaries.
 fn write_llvm_ir(native_module: NativeModule, out_path: string) -> boolean ![io] {
     let artifact = select_text_artifact(native_module.artifacts);
-    if artifact == null {
-        return false;
-    }
+    if artifact == null { return false; }
     let parse = parse_native_artifact_safe(artifact.contents);
     let import_context = collect_imported_module_context_for_module(parse.imports, native_module.module_name);
-    let lowered_lines = lower_to_llvm_lines_with_parsed_context(
-        native_module,
-        parse,
-        import_context.manifests,
-        import_context.native_texts,
-        import_context.diagnostics,
-        true,
-        artifact.contents
-    );
+    let lowered_lines = lower_to_llvm_lines_with_parsed_context(native_module, parse, import_context.manifests, import_context.native_texts, import_context.diagnostics, true, artifact.contents);
     let lines = lowered_lines.lines;
     if lines.length == 0 {
-        print.err(
-            "emit-llvm: no lines from module (module="
-            + native_module.module_name
-            + " functions="
-            + number_to_string(parse.functions.length)
-            + " imports="
-            + number_to_string(parse.imports.length)
-            + " diagnostics="
-            + number_to_string(lowered_lines.diagnostics.length)
-            + ")"
-        );
+        print.err("emit-llvm: no lines from module (module=" + native_module.module_name + " functions=" + number_to_string(parse.functions.length) + " imports=" + number_to_string(parse.imports.length) + " diagnostics=" + number_to_string(lowered_lines.diagnostics.length) + ")");
         if lowered_lines.diagnostics.length > 0 {
             print.err("emit-llvm: diagnostic " + lowered_lines.diagnostics[0]);
         }
@@ -335,13 +277,10 @@ fn lower_to_llvm_with_manifests(native_module: NativeModule, imported_manifests:
     return lower_to_llvm_with_context(native_module, imported_manifests, [], []);
 }
 
-
 fn lower_to_llvm_with_parsed_context(native_module: NativeModule, parse: ParseNativeResult, imported_manifests: LayoutManifest[], imported_native_texts: string[], imported_diagnostics: string[]) -> LoweredLLVMResult {
     let _art = select_text_artifact(native_module.artifacts);
     let mut _native_text: string = "";
-    if _art != null {
-        _native_text = _art.contents;
-    }
+    if _art != null { _native_text = _art.contents; }
     let lowered = lower_to_llvm_lines_with_parsed_context(native_module, parse, imported_manifests, imported_native_texts, imported_diagnostics, true, _native_text);
     if lowered.lines == null {
         return LoweredLLVMResult {
@@ -356,9 +295,7 @@ fn lower_to_llvm_with_parsed_context(native_module: NativeModule, parse: ParseNa
     }
     let ir = _join_llvm_lines_linear(lowered.lines);
     let mut output: string = ir;
-    if output.length > 0 {
-        output = output + "\n";
-    }
+    if output.length > 0 { output = output + "\n"; }
     return LoweredLLVMResult {
         ir: output,
         diagnostics: lowered.diagnostics,
@@ -369,16 +306,12 @@ fn lower_to_llvm_with_parsed_context(native_module: NativeModule, parse: ParseNa
         string_constants: lowered.string_constants,
     };
 }
-
-
 
 fn lower_to_llvm_with_context(native_module: NativeModule, imported_manifests: LayoutManifest[], imported_native_texts: string[], imported_diagnostics: string[]) -> LoweredLLVMResult {
     let lowered = lower_to_llvm_lines_with_context(native_module, imported_manifests, imported_native_texts, imported_diagnostics);
     let ir = _join_llvm_lines_linear(lowered.lines);
     let mut output: string = ir;
-    if output.length > 0 {
-        output = output + "\n";
-    }
+    if output.length > 0 { output = output + "\n"; }
     return LoweredLLVMResult {
         ir: output,
         diagnostics: lowered.diagnostics,
@@ -389,7 +322,6 @@ fn lower_to_llvm_with_context(native_module: NativeModule, imported_manifests: L
         string_constants: lowered.string_constants,
     };
 }
-
 
 fn lower_to_llvm_lines_with_context(native_module: NativeModule, imported_manifests: LayoutManifest[], imported_native_texts: string[], imported_diagnostics: string[]) -> LoweredLLVMLinesResult {
     let mut diagnostics: string[] = [];
@@ -419,4 +351,3 @@ fn lower_to_llvm_lines_with_context(native_module: NativeModule, imported_manife
     let parse = parse_native_artifact_safe(artifact.contents);
     return lower_to_llvm_lines_with_parsed_context(native_module, parse, imported_manifests, imported_native_texts, diagnostics, true, artifact.contents);
 }
-

--- a/compiler/src/llvm/lowering/entrypoints_tests.sfn
+++ b/compiler/src/llvm/lowering/entrypoints_tests.sfn
@@ -111,7 +111,7 @@ fn lower_to_llvm_for_tests(native_module: NativeModule) -> LoweredLLVMResult ![i
             function_effects: [],
             lifetime_regions: [],
             capability_manifest: empty_capability_manifest(),
-            string_constants: empty_string_constant_set(),
+            string_constants: empty_string_constant_set()
         };
     }
     let parse = parse_native_artifact_safe(artifact.contents);

--- a/compiler/src/llvm/lowering/entrypoints_tests.sfn
+++ b/compiler/src/llvm/lowering/entrypoints_tests.sfn
@@ -5,29 +5,100 @@
 // Dead function bodies were removed to fix OOM during selfhost.
 // Imports are preserved — the seed linker needs the full import graph
 // for correct cross-module symbol resolution.
-
 import { NativeArtifact, NativeModule } from "../../emit_native";
-import { NativeFunction, NativeStruct, NativeEnum, NativeInterface, LayoutManifest, ParseNativeResult } from "../../native_ir";
-import { select_text_artifact, parse_native_structs_for_import, parse_native_interfaces_for_import, parse_native_enums_for_import, parse_native_functions_for_import } from "../../native_ir_api";
+import {
+    LayoutManifest,
+    NativeEnum,
+    NativeFunction,
+    NativeInterface,
+    NativeStruct,
+    ParseNativeResult
+} from "../../native_ir";
+import {
+    parse_native_enums_for_import,
+    parse_native_functions_for_import,
+    parse_native_interfaces_for_import,
+    parse_native_structs_for_import,
+    select_text_artifact
+} from "../../native_ir_api";
 import { split_lines } from "../../native_ir_utils_text";
 import { substring } from "../../string_utils";
-import { TypeContext, TraitMetadata, LoweredLLVMResult, LoweredLLVMLinesResult, FunctionEffectEntry, LifetimeRegionMetadata, StringConstant } from "../types";
-import { append_string, join_with_separator, number_to_string, sanitize_symbol, string_array_contains, index_of } from "../utils";
-import { empty_string_constant_set, merge_string_constants, render_string_constants } from "../strings";
-import { collect_direct_function_effects, collect_function_call_graph, propagate_function_effects, collect_runtime_helper_targets, append_unique_effect, find_function_effect_entry, append_function_effect_entry } from "../effects";
-import { render_struct_type_definitions, render_enum_type_definitions, render_trait_metadata_comments, render_runtime_helper_declarations, render_imported_function_declarations } from "../rendering";
-import { render_test_harness_main_for_module } from "./lowering_helpers";
-import { collect_exported_symbol_names, render_interface_type_definitions, render_vtable_type_definitions, render_vtable_constants, find_function_by_name } from "../rendering_helpers";
-import { fixup_enum_layouts, build_type_context } from "../type_context";
-import { collect_imported_module_context_for_module, apply_layout_manifest_to_module } from "../imports";
-import { lower_module_bindings_to_globals } from "./module_globals";
+import {
+    append_function_effect_entry,
+    append_unique_effect,
+    collect_direct_function_effects,
+    collect_function_call_graph,
+    collect_runtime_helper_targets,
+    find_function_effect_entry,
+    propagate_function_effects
+} from "../effects";
+import {
+    apply_layout_manifest_to_module,
+    collect_imported_module_context_for_module
+} from "../imports";
+import {
+    render_enum_type_definitions,
+    render_imported_function_declarations,
+    render_runtime_helper_declarations,
+    render_struct_type_definitions,
+    render_trait_metadata_comments
+} from "../rendering";
+import {
+    collect_exported_symbol_names,
+    find_function_by_name,
+    render_interface_type_definitions,
+    render_vtable_constants,
+    render_vtable_type_definitions
+} from "../rendering_helpers";
+import {
+    empty_string_constant_set,
+    merge_string_constants,
+    render_string_constants
+} from "../strings";
+import { build_type_context, fixup_enum_layouts } from "../type_context";
+import {
+    FunctionEffectEntry,
+    LifetimeRegionMetadata,
+    LoweredLLVMLinesResult,
+    LoweredLLVMResult,
+    StringConstant,
+    TraitMetadata,
+    TypeContext
+} from "../types";
+import {
+    append_string,
+    index_of,
+    join_with_separator,
+    number_to_string,
+    sanitize_symbol,
+    string_array_contains
+} from "../utils";
 import { emit_llvm_function } from "./emission";
-import { empty_trait_metadata, is_test_module_slug, extend_native_structs, extend_native_enums, extend_native_interfaces, extend_native_functions } from "./lowering_helpers";
-import { empty_capability_manifest, _join_llvm_lines_linear, concat_native_functions, flatten_struct_methods } from "./lowering_helpers_mangling";
-import { lower_to_llvm_lines_with_parsed_context_for_tests } from "./lowering_core";
-import { parse_native_artifact_safe } from "./lowering_recovery";
-import { extend_string_lines, extend_string_lines_checked, ensure_intrinsic_declarations, module_source_filename } from "./lowering_io";
 import { lower_to_llvm_with_context, lower_to_llvm_with_parsed_context } from "./entrypoints";
+import { lower_to_llvm_lines_with_parsed_context_for_tests } from "./lowering_core";
+import { render_test_harness_main_for_module } from "./lowering_helpers";
+import {
+    empty_trait_metadata,
+    extend_native_enums,
+    extend_native_functions,
+    extend_native_interfaces,
+    extend_native_structs,
+    is_test_module_slug
+} from "./lowering_helpers";
+import {
+    _join_llvm_lines_linear,
+    concat_native_functions,
+    empty_capability_manifest,
+    flatten_struct_methods
+} from "./lowering_helpers_mangling";
+import {
+    ensure_intrinsic_declarations,
+    extend_string_lines,
+    extend_string_lines_checked,
+    module_source_filename
+} from "./lowering_io";
+import { parse_native_artifact_safe } from "./lowering_recovery";
+import { lower_module_bindings_to_globals } from "./module_globals";
 
 // Stub: kept for import-graph compatibility (main.sfn imports this symbol).
 fn lower_to_llvm_for_tests(native_module: NativeModule) -> LoweredLLVMResult ![io] {
@@ -48,4 +119,3 @@ fn lower_to_llvm_for_tests(native_module: NativeModule) -> LoweredLLVMResult ![i
     let base = lower_to_llvm_with_parsed_context(native_module, parse, import_context.manifests, import_context.native_texts, import_context.diagnostics);
     return base;
 }
-

--- a/compiler/src/llvm/lowering/entrypoints_tests_writer.sfn
+++ b/compiler/src/llvm/lowering/entrypoints_tests_writer.sfn
@@ -137,7 +137,7 @@ fn write_llvm_ir_for_tests_from_text(native_text: string, module_name: string, o
             name: module_name, format: "sailfin-native-text", contents: native_text
         }],
         entry_points: [],
-        symbol_count: 0,
+        symbol_count: 0
     };
     let lowered_lines = lower_to_llvm_lines_with_parsed_context_for_tests(dummy_module, parse, [], [], []);
     if lowered_lines.lines.length == 0 {

--- a/compiler/src/llvm/lowering/entrypoints_tests_writer.sfn
+++ b/compiler/src/llvm/lowering/entrypoints_tests_writer.sfn
@@ -5,27 +5,100 @@
 // The original write_llvm_ir_for_tests function (~600 lines duplicating
 // the entire lowering pipeline) was removed to fix OOM during selfhost.
 // Imports are preserved — the seed linker needs the full import graph.
-
 import { NativeArtifact, NativeModule } from "../../emit_native";
-import { NativeFunction, NativeStruct, NativeEnum, NativeInterface, LayoutManifest, ParseNativeResult } from "../../native_ir";
-import { select_text_artifact, parse_native_structs_for_import, parse_native_interfaces_for_import, parse_native_enums_for_import, parse_native_functions_for_import } from "../../native_ir_api";
+import {
+    LayoutManifest,
+    NativeEnum,
+    NativeFunction,
+    NativeInterface,
+    NativeStruct,
+    ParseNativeResult
+} from "../../native_ir";
+import {
+    parse_native_enums_for_import,
+    parse_native_functions_for_import,
+    parse_native_interfaces_for_import,
+    parse_native_structs_for_import,
+    select_text_artifact
+} from "../../native_ir_api";
 import { substring } from "../../string_utils";
-import { TypeContext, TraitMetadata, LoweredLLVMLinesResult, FunctionEffectEntry, LifetimeRegionMetadata, StringConstant } from "../types";
-import { append_string, join_with_separator, number_to_string, sanitize_symbol, string_array_contains, index_of } from "../utils";
-import { empty_string_constant_set, merge_string_constants, render_string_constants } from "../strings";
-import { collect_direct_function_effects, collect_function_call_graph, propagate_function_effects, collect_runtime_helper_targets, append_unique_effect, find_function_effect_entry, append_function_effect_entry } from "../effects";
-import { render_struct_type_definitions, render_enum_type_definitions, render_trait_metadata_comments, render_runtime_helper_declarations, render_imported_function_declarations } from "../rendering";
-import { render_test_harness_main_for_module } from "./lowering_helpers";
-import { collect_exported_symbol_names, render_interface_type_definitions, render_vtable_type_definitions, render_vtable_constants, find_function_by_name } from "../rendering_helpers";
-import { fixup_enum_layouts, build_type_context } from "../type_context";
-import { collect_imported_module_context_for_module, apply_layout_manifest_to_module } from "../imports";
-import { lower_module_bindings_to_globals } from "./module_globals";
+import {
+    append_function_effect_entry,
+    append_unique_effect,
+    collect_direct_function_effects,
+    collect_function_call_graph,
+    collect_runtime_helper_targets,
+    find_function_effect_entry,
+    propagate_function_effects
+} from "../effects";
+import {
+    apply_layout_manifest_to_module,
+    collect_imported_module_context_for_module
+} from "../imports";
+import {
+    render_enum_type_definitions,
+    render_imported_function_declarations,
+    render_runtime_helper_declarations,
+    render_struct_type_definitions,
+    render_trait_metadata_comments
+} from "../rendering";
+import {
+    collect_exported_symbol_names,
+    find_function_by_name,
+    render_interface_type_definitions,
+    render_vtable_constants,
+    render_vtable_type_definitions
+} from "../rendering_helpers";
+import {
+    empty_string_constant_set,
+    merge_string_constants,
+    render_string_constants
+} from "../strings";
+import { build_type_context, fixup_enum_layouts } from "../type_context";
+import {
+    FunctionEffectEntry,
+    LifetimeRegionMetadata,
+    LoweredLLVMLinesResult,
+    StringConstant,
+    TraitMetadata,
+    TypeContext
+} from "../types";
+import {
+    append_string,
+    index_of,
+    join_with_separator,
+    number_to_string,
+    sanitize_symbol,
+    string_array_contains
+} from "../utils";
 import { emit_llvm_function } from "./emission";
-import { empty_trait_metadata, is_test_module_slug, extend_native_structs, extend_native_enums, extend_native_interfaces, extend_native_functions } from "./lowering_helpers";
-import { empty_capability_manifest, _join_llvm_lines_linear, concat_native_functions, flatten_struct_methods } from "./lowering_helpers_mangling";
-import { lower_to_llvm_lines_with_parsed_context_for_tests, build_parse_result_from_text } from "./lowering_core";
+import {
+    build_parse_result_from_text,
+    lower_to_llvm_lines_with_parsed_context_for_tests
+} from "./lowering_core";
+import { render_test_harness_main_for_module } from "./lowering_helpers";
+import {
+    empty_trait_metadata,
+    extend_native_enums,
+    extend_native_functions,
+    extend_native_interfaces,
+    extend_native_structs,
+    is_test_module_slug
+} from "./lowering_helpers";
+import {
+    _join_llvm_lines_linear,
+    concat_native_functions,
+    empty_capability_manifest,
+    flatten_struct_methods
+} from "./lowering_helpers_mangling";
+import {
+    ensure_intrinsic_declarations,
+    extend_string_lines,
+    extend_string_lines_checked,
+    module_source_filename
+} from "./lowering_io";
 import { parse_native_artifact_safe } from "./lowering_recovery";
-import { extend_string_lines, extend_string_lines_checked, ensure_intrinsic_declarations, module_source_filename } from "./lowering_io";
+import { lower_module_bindings_to_globals } from "./module_globals";
 
 // Stub: kept for import-graph compatibility (main.sfn imports this symbol).
 // The full implementation (~600 lines duplicating the entire lowering pipeline)
@@ -60,17 +133,13 @@ fn write_llvm_ir_for_tests_from_text(native_text: string, module_name: string, o
     let parse = build_parse_result_from_text(native_text);
     let dummy_module = NativeModule {
         module_name: module_name,
-        artifacts: [NativeArtifact { name: module_name, format: "sailfin-native-text", contents: native_text }],
+        artifacts: [NativeArtifact {
+            name: module_name, format: "sailfin-native-text", contents: native_text
+        }],
         entry_points: [],
         symbol_count: 0,
     };
-    let lowered_lines = lower_to_llvm_lines_with_parsed_context_for_tests(
-        dummy_module,
-        parse,
-        [],
-        [],
-        []
-    );
+    let lowered_lines = lower_to_llvm_lines_with_parsed_context_for_tests(dummy_module, parse, [], [], []);
     if lowered_lines.lines.length == 0 {
         print.err("test llvm: no lines emitted from native text");
         return false;

--- a/compiler/src/llvm/lowering/instructions.sfn
+++ b/compiler/src/llvm/lowering/instructions.sfn
@@ -9,11 +9,11 @@
 // seed's per-module streaming emission limit.
 import { NativeFunction, NativeInstruction } from "../../native_ir";
 import { substring } from "../../string_utils";
-import { append_local_binding, } from "../expression_lowering/native/core_scopes";
-import { lower_expression_statement, lower_return_instruction, } from "../expression_lowering/native/statement";
-import { parse_inline_let_expression, } from "../expression_lowering/native/statement_parsing";
-import { apply_lifetime_release_events, } from "../lifetime";
-import { empty_string_constant_set, merge_string_constants, } from "../strings";
+import { append_local_binding } from "../expression_lowering/native/core_scopes";
+import { lower_expression_statement, lower_return_instruction } from "../expression_lowering/native/statement";
+import { parse_inline_let_expression } from "../expression_lowering/native/statement_parsing";
+import { apply_lifetime_release_events } from "../lifetime";
+import { empty_string_constant_set, merge_string_constants } from "../strings";
 import {
     BlockLoweringResult,
     LLVMOperand,
@@ -24,36 +24,28 @@ import {
     LoopContext,
     ParameterBinding,
     StringConstant,
-    TypeContext,
+    TypeContext
 } from "../types";
 import {
     append_string,
     extend_string_array,
     index_of,
     number_to_string,
-    trim_text,
+    trim_text
 } from "../utils";
-import { lower_for_instruction, } from "./instructions_for";
-import {
-    _parse_int_from_string,
-    extend_lifetime_regions,
-    extend_mutations,
-} from "./instructions_helpers";
-import { lower_if_instruction, } from "./instructions_if";
-import { lower_let_instruction, } from "./instructions_let";
-import {
-    append_loop_context,
-    last_loop_context,
-    lower_loop_instruction,
-} from "./instructions_loops";
-import { lower_match_instruction, } from "./instructions_match";
-import { lower_throw_instruction, lower_try_instruction, } from "./instructions_try";
+import { lower_for_instruction } from "./instructions_for";
+import { _parse_int_from_string, extend_lifetime_regions, extend_mutations } from "./instructions_helpers";
+import { lower_if_instruction } from "./instructions_if";
+import { lower_let_instruction } from "./instructions_let";
+import { append_loop_context, last_loop_context, lower_loop_instruction } from "./instructions_loops";
+import { lower_match_instruction } from "./instructions_match";
+import { lower_throw_instruction, lower_try_instruction } from "./instructions_try";
 import {
     get_instruction_condition,
     get_instruction_tag,
-    get_instruction_text,
+    get_instruction_text
 } from "./lowering_native_helpers";
-import { find_last_label, } from "./phi";
+import { find_last_label } from "./phi";
 
 fn lower_instruction_range(function: NativeFunction, start_index: number, end: number, llvm_return: string, bindings: ParameterBinding[], locals: LocalBinding[], allocas: string[], lines: string[], temp_index: number, block_counter: number, next_local_id: number, next_region_id: number, functions: NativeFunction[], loop_stack: LoopContext[], context: TypeContext, scope_id: string, scope_depth: number, current_label: string) -> BlockLoweringResult ![io] {
     let mut diagnostics: string[] = [];
@@ -76,8 +68,17 @@ fn lower_instruction_range(function: NativeFunction, start_index: number, end: n
     let max_guard = (end - start_index) * 16 + 1024;
     let debug_lowering = fs.exists("build/sailfin/.trace_lowering");
     if debug_lowering {
-        print.err("emit-llvm: lower_instruction_range name=" + function.name + " start=" + number_to_string(start_index) + " end=" + number_to_string(end) + " depth=" + number_to_string(scope_depth));
-        print.err("emit-llvm: lower_instruction_range bindings_len=" + number_to_string(bindings.length) + " current_bindings_len=" + number_to_string(current_bindings.length));
+        print.err("emit-llvm: lower_instruction_range name=" + function.name
+            + " start="
+            + number_to_string(start_index)
+            + " end="
+            + number_to_string(end)
+            + " depth="
+            + number_to_string(scope_depth));
+        print.err("emit-llvm: lower_instruction_range bindings_len="
+            + number_to_string(bindings.length)
+            + " current_bindings_len="
+            + number_to_string(current_bindings.length));
     }
     let mut _let220: boolean = false;
     if fs.exists("build/sailfin/.trace_test_runner") {
@@ -87,14 +88,18 @@ fn lower_instruction_range(function: NativeFunction, start_index: number, end: n
     if trace {
         if start_index == 0 {
             if scope_depth == 0 {
-                print.err("test llvm: lower_instruction_range start " + function.name + " end=" + number_to_string(end));
+                print.err("test llvm: lower_instruction_range start " + function.name
+                    + " end="
+                    + number_to_string(end));
                 let mut preview_index: number = start_index;
                 let mut preview_limit: number = start_index + 5;
                 if preview_limit > end { preview_limit = end; }
                 loop {
                     if preview_index >= preview_limit { break; }
                     let _preview_tag = get_instruction_tag(function.instructions, preview_index);
-                    print.err("test llvm: instr " + number_to_string(preview_index) + " tag=" + number_to_string(_preview_tag));
+                    print.err("test llvm: instr " + number_to_string(preview_index)
+                        + " tag="
+                        + number_to_string(_preview_tag));
                     preview_index += 1;
                 }
             }
@@ -104,7 +109,11 @@ fn lower_instruction_range(function: NativeFunction, start_index: number, end: n
     loop {
         if index >= end {
             if debug_lowering {
-                print.err("emit-llvm: loop-exit index=" + number_to_string(index) + " end=" + number_to_string(end) + " fn=" + function.name);
+                print.err("emit-llvm: loop-exit index=" + number_to_string(index)
+                    + " end="
+                    + number_to_string(end)
+                    + " fn="
+                    + function.name);
             }
             // Write block results and return directly from inside the loop.
             // The v0.1.1 seed generates unconditional `br label %loop.body` for
@@ -124,13 +133,22 @@ fn lower_instruction_range(function: NativeFunction, start_index: number, end: n
                 next_lifetime_region_id: current_next_region,
                 next_index: index,
                 mutations: current_mutations,
-                string_constants: collected_string_constants,
+                string_constants: collected_string_constants
             };
         }
         if guard > max_guard {
-            diagnostics = append_string(diagnostics, "llvm lowering: instruction loop exceeded limit in `" + function.name + "` (index=" + number_to_string(index) + ")");
+            diagnostics = append_string(diagnostics, "llvm lowering: instruction loop exceeded limit in `"
+                + function.name
+                + "` (index="
+                + number_to_string(index)
+                + ")");
             if trace {
-                print.err("test llvm: instruction loop exceeded limit in " + function.name + " index=" + number_to_string(index) + " end=" + number_to_string(end));
+                print.err("test llvm: instruction loop exceeded limit in "
+                    + function.name
+                    + " index="
+                    + number_to_string(index)
+                    + " end="
+                    + number_to_string(end));
             }
             // Return directly (same loop-break workaround as index>=end case)
             return BlockLoweringResult {
@@ -147,7 +165,7 @@ fn lower_instruction_range(function: NativeFunction, start_index: number, end: n
                 next_lifetime_region_id: current_next_region,
                 next_index: index,
                 mutations: current_mutations,
-                string_constants: collected_string_constants,
+                string_constants: collected_string_constants
             };
         }
         guard += 1;
@@ -156,11 +174,20 @@ fn lower_instruction_range(function: NativeFunction, start_index: number, end: n
         // Use numeric tag accessor instead of .variant (which returns empty via get_field stub)
         let _instr_tag = get_instruction_tag(function.instructions, index);
         if debug_lowering {
-            print.err("emit-llvm: lir guard=" + number_to_string(guard) + " index=" + number_to_string(index) + " tag=" + number_to_string(_instr_tag) + " fn=" + function.name + " depth=" + number_to_string(scope_depth));
+            print.err("emit-llvm: lir guard=" + number_to_string(guard)
+                + " index="
+                + number_to_string(index)
+                + " tag="
+                + number_to_string(_instr_tag)
+                + " fn="
+                + function.name
+                + " depth="
+                + number_to_string(scope_depth));
         }
         if trace {
             if index == start_index {
-                print.err("test llvm: lower_instruction_range first_tag " + number_to_string(_instr_tag));
+                print.err("test llvm: lower_instruction_range first_tag "
+                    + number_to_string(_instr_tag));
             }
         }
         // Tag dispatch: flat if-blocks with continue/break to avoid deep else-if
@@ -205,7 +232,7 @@ fn lower_instruction_range(function: NativeFunction, start_index: number, end: n
                                 type_annotation: inline_parse.type_annotation,
                                 value: inline_parse.initializer,
                                 span: null,
-                                value_span: null,
+                                value_span: null
                             };
                             let lowered = lower_let_instruction(function, inline_instruction, current_bindings, current_locals, current_allocas, current_lines, current_temp, current_next_local, current_next_region, functions, context, scope_id, scope_depth, active_label);
                             diagnostics = extend_string_array(diagnostics, lowered.diagnostics);
@@ -398,7 +425,9 @@ fn lower_instruction_range(function: NativeFunction, start_index: number, end: n
         if !_tag_handled {
             if _instr_tag == 10 {
                 if current_loop_stack.length == 0 {
-                    diagnostics.push("llvm lowering: `break` outside loop in `" + function.name + "`");
+                    diagnostics.push("llvm lowering: `break` outside loop in `"
+                        + function.name
+                        + "`");
                 } else {
                     let loop_context = last_loop_context(current_loop_stack);
                     current_lines.push("  br label %" + loop_context.break_label);
@@ -411,7 +440,9 @@ fn lower_instruction_range(function: NativeFunction, start_index: number, end: n
         if !_tag_handled {
             if _instr_tag == 11 {
                 if current_loop_stack.length == 0 {
-                    diagnostics.push("llvm lowering: `continue` outside loop in `" + function.name + "`");
+                    diagnostics.push("llvm lowering: `continue` outside loop in `"
+                        + function.name
+                        + "`");
                 } else {
                     let loop_context = last_loop_context(current_loop_stack);
                     current_lines.push("  br label %" + loop_context.continue_label);
@@ -445,7 +476,7 @@ fn lower_instruction_range(function: NativeFunction, start_index: number, end: n
                     next_lifetime_region_id: current_next_region,
                     next_index: index,
                     mutations: current_mutations,
-                    string_constants: collected_string_constants,
+                    string_constants: collected_string_constants
                 };
             }
         }
@@ -496,7 +527,7 @@ fn lower_instruction_range(function: NativeFunction, start_index: number, end: n
                                         type_annotation: inline_parse.type_annotation,
                                         value: inline_parse.initializer,
                                         span: null,
-                                        value_span: null,
+                                        value_span: null
                                     };
                                     let lowered = lower_let_instruction(function, inline_instruction, current_bindings, current_locals, current_allocas, current_lines, current_temp, current_next_local, current_next_region, functions, context, scope_id, scope_depth, active_label);
                                     diagnostics = extend_string_array(diagnostics, lowered.diagnostics);
@@ -531,7 +562,11 @@ fn lower_instruction_range(function: NativeFunction, start_index: number, end: n
         }
         if !_tag_handled {
             if _instr_tag != 20 {
-                diagnostics.push("llvm lowering: unsupported instruction tag=" + number_to_string(_instr_tag) + " in `" + function.name + "`");
+                diagnostics.push("llvm lowering: unsupported instruction tag="
+                    + number_to_string(_instr_tag)
+                    + " in `"
+                    + function.name
+                    + "`");
             }
         }
         // For terminated instructions (return, throw, break, continue), exit loop.
@@ -551,21 +586,29 @@ fn lower_instruction_range(function: NativeFunction, start_index: number, end: n
                 next_lifetime_region_id: current_next_region,
                 next_index: index,
                 mutations: current_mutations,
-                string_constants: collected_string_constants,
+                string_constants: collected_string_constants
             };
         }
         if !_tag_handled { index += 1; }
     }
 
     if debug_lowering {
-        print.err("emit-llvm: lir loop-done fn=" + function.name + " current_lines=" + number_to_string(current_lines.length));
+        print.err("emit-llvm: lir loop-done fn=" + function.name
+            + " current_lines="
+            + number_to_string(current_lines.length));
     }
     if trace {
         if start_index == 0 {
             if scope_depth == 0 {
                 let mut term_label: string = "false";
                 if terminated { term_label = "true"; }
-                print.err("test llvm: lower_instruction_range done " + function.name + " lines=" + number_to_string(current_lines.length) + " allocas=" + number_to_string(current_allocas.length) + " terminated=" + term_label);
+                print.err("test llvm: lower_instruction_range done " + function.name
+                    + " lines="
+                    + number_to_string(current_lines.length)
+                    + " allocas="
+                    + number_to_string(current_allocas.length)
+                    + " terminated="
+                    + term_label);
             }
         }
     }
@@ -573,7 +616,10 @@ fn lower_instruction_range(function: NativeFunction, start_index: number, end: n
     // Always write block result files. The scope_depth == 0 check was unreliable
     // because the v0.1.1 seed can miscompile the comparison.
     if debug_lowering {
-        print.err("emit-llvm: pre-write-block current_lines.length=" + number_to_string(current_lines.length) + " scope_depth=" + number_to_string(scope_depth));
+        print.err("emit-llvm: pre-write-block current_lines.length="
+            + number_to_string(current_lines.length)
+            + " scope_depth="
+            + number_to_string(scope_depth));
         if current_lines.length > 0 {
             print.err("emit-llvm: pre-write-block line[0]=" + current_lines[0]);
         }
@@ -593,6 +639,6 @@ fn lower_instruction_range(function: NativeFunction, start_index: number, end: n
         next_lifetime_region_id: current_next_region,
         next_index: index,
         mutations: current_mutations,
-        string_constants: collected_string_constants,
+        string_constants: collected_string_constants
     };
 }

--- a/compiler/src/llvm/lowering/instructions.sfn
+++ b/compiler/src/llvm/lowering/instructions.sfn
@@ -7,116 +7,55 @@
 // _parse_int_from_string) live in instructions_helpers.sfn so that
 // lower_instruction_range is at source position 1 — within the v0.1.1
 // seed's per-module streaming emission limit.
-
 import { NativeFunction, NativeInstruction } from "../../native_ir";
 import { substring } from "../../string_utils";
-
+import { append_local_binding, } from "../expression_lowering/native/core_scopes";
+import { lower_expression_statement, lower_return_instruction, } from "../expression_lowering/native/statement";
+import { parse_inline_let_expression, } from "../expression_lowering/native/statement_parsing";
+import { apply_lifetime_release_events, } from "../lifetime";
+import { empty_string_constant_set, merge_string_constants, } from "../strings";
 import {
-    TypeContext,
-    LocalBinding,
-    ParameterBinding,
-    LLVMOperand,
     BlockLoweringResult,
+    LLVMOperand,
     LetLoweringResult,
-    LoopContext,
     LifetimeRegionMetadata,
+    LocalBinding,
     LocalMutation,
+    LoopContext,
+    ParameterBinding,
     StringConstant,
+    TypeContext,
 } from "../types";
-
 import {
-    trim_text,
     append_string,
     extend_string_array,
-    number_to_string,
     index_of,
+    number_to_string,
+    trim_text,
 } from "../utils";
-
+import { lower_for_instruction, } from "./instructions_for";
 import {
+    _parse_int_from_string,
     extend_lifetime_regions,
     extend_mutations,
-    _parse_int_from_string,
 } from "./instructions_helpers";
-
-import {
-    empty_string_constant_set,
-    merge_string_constants,
-} from "../strings";
-
-import {
-    append_local_binding,
-} from "../expression_lowering/native/core_scopes";
-
-import {
-    lower_expression_statement,
-    lower_return_instruction,
-} from "../expression_lowering/native/statement";
-
-import {
-    parse_inline_let_expression,
-} from "../expression_lowering/native/statement_parsing";
-
-import {
-    apply_lifetime_release_events,
-} from "../lifetime";
-
-import {
-    find_last_label,
-} from "./phi";
-
+import { lower_if_instruction, } from "./instructions_if";
+import { lower_let_instruction, } from "./instructions_let";
 import {
     append_loop_context,
     last_loop_context,
     lower_loop_instruction,
 } from "./instructions_loops";
-
+import { lower_match_instruction, } from "./instructions_match";
+import { lower_throw_instruction, lower_try_instruction, } from "./instructions_try";
 import {
-    lower_for_instruction,
-} from "./instructions_for";
-
-import {
-    lower_throw_instruction,
-    lower_try_instruction,
-} from "./instructions_try";
-
-import {
-    lower_match_instruction,
-} from "./instructions_match";
-
-import {
-    lower_if_instruction,
-} from "./instructions_if";
-
-import {
-    lower_let_instruction,
-} from "./instructions_let";
-
-import {
+    get_instruction_condition,
     get_instruction_tag,
     get_instruction_text,
-    get_instruction_condition,
 } from "./lowering_native_helpers";
+import { find_last_label, } from "./phi";
 
-fn lower_instruction_range(
-    function: NativeFunction,
-    start_index: number,
-    end: number,
-    llvm_return: string,
-    bindings: ParameterBinding[],
-    locals: LocalBinding[],
-    allocas: string[],
-    lines: string[],
-    temp_index: number,
-    block_counter: number,
-    next_local_id: number,
-    next_region_id: number,
-    functions: NativeFunction[],
-    loop_stack: LoopContext[],
-    context: TypeContext,
-    scope_id: string,
-    scope_depth: number,
-    current_label: string
-) -> BlockLoweringResult ![io] {
+fn lower_instruction_range(function: NativeFunction, start_index: number, end: number, llvm_return: string, bindings: ParameterBinding[], locals: LocalBinding[], allocas: string[], lines: string[], temp_index: number, block_counter: number, next_local_id: number, next_region_id: number, functions: NativeFunction[], loop_stack: LoopContext[], context: TypeContext, scope_id: string, scope_depth: number, current_label: string) -> BlockLoweringResult ![io] {
     let mut diagnostics: string[] = [];
     let mut current_lines: string[] = lines;
     let mut current_allocas: string[] = allocas;
@@ -142,36 +81,20 @@ fn lower_instruction_range(
     }
     let mut _let220: boolean = false;
     if fs.exists("build/sailfin/.trace_test_runner") {
-        if fs.exists("build/sailfin/.test_runner_active") {
-            _let220 = true;
-        }
+        if fs.exists("build/sailfin/.test_runner_active") { _let220 = true; }
     }
     let trace = _let220;
     if trace {
         if start_index == 0 {
             if scope_depth == 0 {
-                print.err(
-                    "test llvm: lower_instruction_range start "
-                    + function.name
-                    + " end="
-                    + number_to_string(end)
-                );
+                print.err("test llvm: lower_instruction_range start " + function.name + " end=" + number_to_string(end));
                 let mut preview_index: number = start_index;
                 let mut preview_limit: number = start_index + 5;
-                if preview_limit > end {
-                    preview_limit = end;
-                }
+                if preview_limit > end { preview_limit = end; }
                 loop {
-                    if preview_index >= preview_limit {
-                        break;
-                    }
+                    if preview_index >= preview_limit { break; }
                     let _preview_tag = get_instruction_tag(function.instructions, preview_index);
-                    print.err(
-                        "test llvm: instr "
-                        + number_to_string(preview_index)
-                        + " tag="
-                        + number_to_string(_preview_tag)
-                    );
+                    print.err("test llvm: instr " + number_to_string(preview_index) + " tag=" + number_to_string(_preview_tag));
                     preview_index += 1;
                 }
             }
@@ -205,16 +128,9 @@ fn lower_instruction_range(
             };
         }
         if guard > max_guard {
-            diagnostics = append_string(
-                diagnostics,
-                "llvm lowering: instruction loop exceeded limit in `" + function.name + "` (index=" + number_to_string(index) + ")"
-            );
+            diagnostics = append_string(diagnostics, "llvm lowering: instruction loop exceeded limit in `" + function.name + "` (index=" + number_to_string(index) + ")");
             if trace {
-                print.err(
-                    "test llvm: instruction loop exceeded limit in " + function.name
-                    + " index=" + number_to_string(index)
-                    + " end=" + number_to_string(end)
-                );
+                print.err("test llvm: instruction loop exceeded limit in " + function.name + " index=" + number_to_string(index) + " end=" + number_to_string(end));
             }
             // Return directly (same loop-break workaround as index>=end case)
             return BlockLoweringResult {
@@ -546,7 +462,9 @@ fn lower_instruction_range(
                 // Detect return instructions that the tag couldn't distinguish
                 let mut _is_ret_21: boolean = false;
                 if trimmed_21.length >= 4 {
-                    if substring(trimmed_21, 0, 4) == "ret " { _is_ret_21 = true; }
+                    if substring(trimmed_21, 0, 4) == "ret " {
+                        _is_ret_21 = true;
+                    }
                 }
                 if trimmed_21 == "ret" { _is_ret_21 = true; }
                 if _is_ret_21 {
@@ -636,9 +554,7 @@ fn lower_instruction_range(
                 string_constants: collected_string_constants,
             };
         }
-        if !_tag_handled {
-            index += 1;
-        }
+        if !_tag_handled { index += 1; }
     }
 
     if debug_lowering {
@@ -648,19 +564,8 @@ fn lower_instruction_range(
         if start_index == 0 {
             if scope_depth == 0 {
                 let mut term_label: string = "false";
-                if terminated {
-                    term_label = "true";
-                }
-                print.err(
-                    "test llvm: lower_instruction_range done "
-                    + function.name
-                    + " lines="
-                    + number_to_string(current_lines.length)
-                    + " allocas="
-                    + number_to_string(current_allocas.length)
-                    + " terminated="
-                    + term_label
-                );
+                if terminated { term_label = "true"; }
+                print.err("test llvm: lower_instruction_range done " + function.name + " lines=" + number_to_string(current_lines.length) + " allocas=" + number_to_string(current_allocas.length) + " terminated=" + term_label);
             }
         }
     }

--- a/compiler/src/llvm/lowering/instructions_condition.sfn
+++ b/compiler/src/llvm/lowering/instructions_condition.sfn
@@ -3,11 +3,11 @@
 // Shared condition-lowering utilities used by if, loop, and match instruction handlers.
 import { NativeFunction, NativeInstruction, NativeSourceSpan } from "../../native_ir";
 import { char_code, grapheme_at, substring } from "../../string_utils";
-import { lower_expression, } from "../expression_lowering/native/core";
-import { detect_suspension_conflicts, } from "../expression_lowering/native/statement_suspension";
-import { find_local_binding, find_parameter_binding, } from "../expressions_bindings";
-import { default_return_literal, format_temp_name, } from "../expressions_helpers";
-import { is_number_literal, normalise_number_literal, } from "../expressions_literals";
+import { lower_expression } from "../expression_lowering/native/core";
+import { detect_suspension_conflicts } from "../expression_lowering/native/statement_suspension";
+import { find_local_binding, find_parameter_binding } from "../expressions_bindings";
+import { default_return_literal, format_temp_name } from "../expressions_helpers";
+import { is_number_literal, normalise_number_literal } from "../expressions_literals";
 import {
     BlockLabelResult,
     ConditionConversion,
@@ -15,15 +15,15 @@ import {
     LocalBinding,
     ParameterBinding,
     StringConstant,
-    TypeContext,
+    TypeContext
 } from "../types";
 import {
     index_of,
     number_to_string,
     starts_with,
-    trim_text,
+    trim_text
 } from "../utils";
-import { _parse_int_from_string, } from "./instructions_helpers";
+import { _parse_int_from_string } from "./instructions_helpers";
 
 fn allocate_block_label(prefix: string, counter: number) -> BlockLabelResult {
     return BlockLabelResult {
@@ -50,7 +50,8 @@ fn lower_condition_to_i1(function_name: string, expression: string, bindings: Pa
         if _lta_llvm == null { _lta_llvm = ""; }
         let mut _lta_ptr = locals[_lta_i].pointer;
         if _lta_ptr == null { _lta_ptr = ""; }
-        _lta_lines.push(_lta_name + "\t" + _lta_type + "\t" + _lta_llvm + "\t" + _lta_ptr);
+        _lta_lines.push(_lta_name + "\t" + _lta_type + "\t" + _lta_llvm + "\t"
+            + _lta_ptr);
         _lta_i += 1;
     }
     fs.writeLines("build/sailfin/.condition_locals", _lta_lines);
@@ -88,9 +89,15 @@ fn lower_condition_to_i1(function_name: string, expression: string, bindings: Pa
     if lowered.operand == null {
         let rendered_condition = trim_text(expression);
         if rendered_condition.length == 0 {
-            diagnostics.push("llvm lowering: condition produced no value in `" + function_name + "`");
+            diagnostics.push("llvm lowering: condition produced no value in `"
+                + function_name
+                + "`");
         } else {
-            diagnostics.push("llvm lowering: condition produced no value in `" + function_name + "` for `" + rendered_condition + "`");
+            diagnostics.push("llvm lowering: condition produced no value in `"
+                + function_name
+                + "` for `"
+                + rendered_condition
+                + "`");
         }
         return ConditionConversion {
             lines: current_lines,
@@ -114,7 +121,8 @@ fn lower_condition_to_i1(function_name: string, expression: string, bindings: Pa
 
     if operand.llvm_type == "double" {
         let temp_name = format_temp_name(current_temp);
-        current_lines.push("  " + temp_name + " = fcmp one double " + operand.value + ", 0.0");
+        current_lines.push("  " + temp_name + " = fcmp one double " + operand.value
+            + ", 0.0");
         let converted = LLVMOperand { llvm_type: "i1", value: temp_name };
         return ConditionConversion {
             lines: current_lines,
@@ -130,7 +138,12 @@ fn lower_condition_to_i1(function_name: string, expression: string, bindings: Pa
     if operand.llvm_type == "i64" { _if226 = true; }
     if _if226 {
         let temp_name = format_temp_name(current_temp);
-        current_lines.push("  " + temp_name + " = icmp ne " + operand.llvm_type + " " + operand.value + ", " + default_return_literal(operand.llvm_type) + "");
+        current_lines.push("  " + temp_name + " = icmp ne " + operand.llvm_type
+            + " "
+            + operand.value
+            + ", "
+            + default_return_literal(operand.llvm_type)
+            + "");
         let converted = LLVMOperand { llvm_type: "i1", value: temp_name };
         return ConditionConversion {
             lines: current_lines,
@@ -141,7 +154,10 @@ fn lower_condition_to_i1(function_name: string, expression: string, bindings: Pa
         };
     }
 
-    diagnostics.push("llvm lowering: unsupported condition type `" + operand.llvm_type + "` in `" + function_name + "`");
+    diagnostics.push("llvm lowering: unsupported condition type `" + operand.llvm_type
+        + "` in `"
+        + function_name
+        + "`");
     return ConditionConversion {
         lines: current_lines,
         temp_index: current_temp,

--- a/compiler/src/llvm/lowering/instructions_condition.sfn
+++ b/compiler/src/llvm/lowering/instructions_condition.sfn
@@ -1,68 +1,38 @@
 // compiler/src/llvm/lowering/instructions_condition.sfn
 //
 // Shared condition-lowering utilities used by if, loop, and match instruction handlers.
-
 import { NativeFunction, NativeInstruction, NativeSourceSpan } from "../../native_ir";
-import { substring, char_code, grapheme_at } from "../../string_utils";
-
+import { char_code, grapheme_at, substring } from "../../string_utils";
+import { lower_expression, } from "../expression_lowering/native/core";
+import { detect_suspension_conflicts, } from "../expression_lowering/native/statement_suspension";
+import { find_local_binding, find_parameter_binding, } from "../expressions_bindings";
+import { default_return_literal, format_temp_name, } from "../expressions_helpers";
+import { is_number_literal, normalise_number_literal, } from "../expressions_literals";
 import {
-    TypeContext,
+    BlockLabelResult,
+    ConditionConversion,
+    LLVMOperand,
     LocalBinding,
     ParameterBinding,
-    LLVMOperand,
-    ConditionConversion,
-    BlockLabelResult,
     StringConstant,
+    TypeContext,
 } from "../types";
-
 import {
-    trim_text,
-    number_to_string,
     index_of,
+    number_to_string,
     starts_with,
+    trim_text,
 } from "../utils";
-
-import {
-    find_local_binding,
-    find_parameter_binding,
-} from "../expressions_bindings";
-
-import {
-    is_number_literal,
-    normalise_number_literal,
-} from "../expressions_literals";
-
-import {
-    default_return_literal,
-    format_temp_name,
-} from "../expressions_helpers";
-
-import {
-    lower_expression,
-} from "../expression_lowering/native/core";
-
-import {
-    detect_suspension_conflicts,
-} from "../expression_lowering/native/statement_suspension";
-
-import {
-    _parse_int_from_string,
-} from "./instructions_helpers";
+import { _parse_int_from_string, } from "./instructions_helpers";
 
 fn allocate_block_label(prefix: string, counter: number) -> BlockLabelResult {
-    return BlockLabelResult { label: prefix + number_to_string(counter), next_counter: counter + 1 };
+    return BlockLabelResult {
+        label: prefix + number_to_string(counter),
+        next_counter: counter + 1
+    };
 }
 
-fn lower_condition_to_i1(
-    function_name: string,
-    expression: string,
-    bindings: ParameterBinding[],
-    locals: LocalBinding[],
-    temp_index: number,
-    lines: string[],
-    functions: NativeFunction[],
-    context: TypeContext
-) -> ConditionConversion {
+fn lower_condition_to_i1(function_name: string, expression: string, bindings: ParameterBinding[], locals: LocalBinding[], temp_index: number, lines: string[], functions: NativeFunction[], context: TypeContext) -> ConditionConversion {
     let mut diagnostics: string[] = detect_suspension_conflicts(expression, locals, bindings, function_name, null);
     // Write local type annotations to a file so the cross-module expression
     // lowering can resolve struct types for method calls.  The v0.1.1 seed
@@ -106,9 +76,7 @@ fn lower_condition_to_i1(
                 if _space > 0 {
                     let _num_str = substring(_after_t, 0, _space);
                     let _num = _parse_int_from_string(_num_str);
-                    if _num >= current_temp {
-                        current_temp = _num + 1;
-                    }
+                    if _num >= current_temp { current_temp = _num + 1; }
                 }
             }
             _scan_i += 1;
@@ -124,19 +92,37 @@ fn lower_condition_to_i1(
         } else {
             diagnostics.push("llvm lowering: condition produced no value in `" + function_name + "` for `" + rendered_condition + "`");
         }
-        return ConditionConversion { lines: current_lines, temp_index: current_temp, operand: null, diagnostics: diagnostics, string_constants: string_constants };
+        return ConditionConversion {
+            lines: current_lines,
+            temp_index: current_temp,
+            operand: null,
+            diagnostics: diagnostics,
+            string_constants: string_constants
+        };
     }
 
     let operand = lowered.operand;
     if operand.llvm_type == "i1" {
-        return ConditionConversion { lines: current_lines, temp_index: current_temp, operand: operand, diagnostics: diagnostics, string_constants: string_constants };
+        return ConditionConversion {
+            lines: current_lines,
+            temp_index: current_temp,
+            operand: operand,
+            diagnostics: diagnostics,
+            string_constants: string_constants
+        };
     }
 
     if operand.llvm_type == "double" {
         let temp_name = format_temp_name(current_temp);
         current_lines.push("  " + temp_name + " = fcmp one double " + operand.value + ", 0.0");
         let converted = LLVMOperand { llvm_type: "i1", value: temp_name };
-        return ConditionConversion { lines: current_lines, temp_index: current_temp + 1, operand: converted, diagnostics: diagnostics, string_constants: string_constants };
+        return ConditionConversion {
+            lines: current_lines,
+            temp_index: current_temp + 1,
+            operand: converted,
+            diagnostics: diagnostics,
+            string_constants: string_constants
+        };
     }
 
     let mut _if226: boolean = false;
@@ -146,24 +132,32 @@ fn lower_condition_to_i1(
         let temp_name = format_temp_name(current_temp);
         current_lines.push("  " + temp_name + " = icmp ne " + operand.llvm_type + " " + operand.value + ", " + default_return_literal(operand.llvm_type) + "");
         let converted = LLVMOperand { llvm_type: "i1", value: temp_name };
-        return ConditionConversion { lines: current_lines, temp_index: current_temp + 1, operand: converted, diagnostics: diagnostics, string_constants: string_constants };
+        return ConditionConversion {
+            lines: current_lines,
+            temp_index: current_temp + 1,
+            operand: converted,
+            diagnostics: diagnostics,
+            string_constants: string_constants
+        };
     }
 
     diagnostics.push("llvm lowering: unsupported condition type `" + operand.llvm_type + "` in `" + function_name + "`");
-    return ConditionConversion { lines: current_lines, temp_index: current_temp, operand: null, diagnostics: diagnostics, string_constants: string_constants };
+    return ConditionConversion {
+        lines: current_lines,
+        temp_index: current_temp,
+        operand: null,
+        diagnostics: diagnostics,
+        string_constants: string_constants
+    };
 }
 
 fn sanitize_if_condition_text(condition: string) -> string {
     let trimmed = trim_text(condition);
-    if trimmed.length == 0 {
-        return trimmed;
-    }
+    if trimmed.length == 0 { return trimmed; }
 
     // If the condition starts with a brace, it's likely an expression (e.g. struct literal)
     // rather than an if-block opener.
-    if starts_with(trimmed, "{") {
-        return trimmed;
-    }
+    if starts_with(trimmed, "{") { return trimmed; }
 
     // Scan for a top-level `{` that appears after some expression content; treat it as the
     // start of the if body and truncate.
@@ -175,9 +169,7 @@ fn sanitize_if_condition_text(condition: string) -> string {
     let mut index: number = 0;
 
     loop {
-        if index >= trimmed.length {
-            break;
-        }
+        if index >= trimmed.length { break; }
         let ch = substring(trimmed, index, index + 1);
         if in_string {
             if escape_next {
@@ -190,9 +182,7 @@ fn sanitize_if_condition_text(condition: string) -> string {
                 index += 1;
                 continue;
             }
-            if ch == "\"" {
-                in_string = false;
-            }
+            if ch == "\"" { in_string = false; }
             index += 1;
             continue;
         }
@@ -209,9 +199,7 @@ fn sanitize_if_condition_text(condition: string) -> string {
             continue;
         }
         if ch == ")" {
-            if paren_depth > 0 {
-                paren_depth -= 1;
-            }
+            if paren_depth > 0 { paren_depth -= 1; }
             index += 1;
             continue;
         }
@@ -221,9 +209,7 @@ fn sanitize_if_condition_text(condition: string) -> string {
             continue;
         }
         if ch == "]" {
-            if bracket_depth > 0 {
-                bracket_depth -= 1;
-            }
+            if bracket_depth > 0 { bracket_depth -= 1; }
             index += 1;
             continue;
         }
@@ -243,9 +229,7 @@ fn sanitize_if_condition_text(condition: string) -> string {
             continue;
         }
         if ch == "}" {
-            if brace_depth > 0 {
-                brace_depth -= 1;
-            }
+            if brace_depth > 0 { brace_depth -= 1; }
             index += 1;
             continue;
         }

--- a/compiler/src/llvm/lowering/instructions_dispatch.sfn
+++ b/compiler/src/llvm/lowering/instructions_dispatch.sfn
@@ -6,88 +6,49 @@
 // within the v0.1.1 seed's per-function LLVM IR emission threshold.
 //
 // Each handler writes results to file IPC so the caller can read them back.
-
 import { NativeFunction, NativeInstruction, NativeSourceSpan } from "../../native_ir";
-import { substring, char_code, grapheme_at } from "../../string_utils";
-
+import { char_code, grapheme_at, substring } from "../../string_utils";
+import { lower_expression, } from "../expression_lowering/native/core";
+import { append_local_binding, } from "../expression_lowering/native/core_scopes";
+import { lower_expression_statement, lower_return_instruction, } from "../expression_lowering/native/statement";
+import { parse_inline_let_expression, } from "../expression_lowering/native/statement_parsing";
+import { detect_suspension_conflicts, } from "../expression_lowering/native/statement_suspension";
+import { map_local_type, } from "../expression_lowering/native/statement_type_mapping";
+import { apply_lifetime_release_events, } from "../lifetime";
+import { merge_string_constants, } from "../strings";
 import {
-    TypeContext,
-    LocalBinding,
-    ParameterBinding,
-    LLVMOperand,
     BlockLoweringResult,
+    LLVMOperand,
     LetLoweringResult,
-    LoopContext,
     LifetimeRegionMetadata,
+    LocalBinding,
     LocalMutation,
+    LoopContext,
+    ParameterBinding,
     StringConstant,
+    TypeContext,
 } from "../types";
-
 import {
-    trim_text,
     append_string,
     extend_string_array,
-    number_to_string,
     index_of,
+    number_to_string,
     starts_with,
+    trim_text,
 } from "../utils";
-
-import {
-    merge_string_constants,
-} from "../strings";
-
 import {
     _parse_int_from_string,
     _read_ipc_int_min,
     extend_mutations,
 } from "./instructions_helpers";
-
+import { extend_lifetime_regions, } from "./instructions_helpers";
+import { lower_let_instruction, } from "./instructions_let";
 import {
-    split_lines_local,
-} from "./lowering_text_utils";
-
-import {
-    lower_expression,
-} from "../expression_lowering/native/core";
-
-import {
-    lower_expression_statement,
-    lower_return_instruction,
-} from "../expression_lowering/native/statement";
-
-import {
-    detect_suspension_conflicts,
-} from "../expression_lowering/native/statement_suspension";
-
-import {
-    map_local_type,
-} from "../expression_lowering/native/statement_type_mapping";
-
-import {
-    parse_inline_let_expression,
-} from "../expression_lowering/native/statement_parsing";
-
-import {
-    append_local_binding,
-} from "../expression_lowering/native/core_scopes";
-
-import {
-    lower_let_instruction,
-} from "./instructions_let";
-
-import {
-    extend_lifetime_regions,
-} from "./instructions_helpers";
-
-import {
-    apply_lifetime_release_events,
-} from "../lifetime";
-
-import {
+    get_instruction_condition,
     get_instruction_tag,
     get_instruction_text,
-    get_instruction_condition,
 } from "./lowering_native_helpers";
+import { split_lines_local, } from "./lowering_text_utils";
 
 // Write bindings to files for statement.sfn to read.
 // Extracted from the Expression and Return handlers where this pattern
@@ -172,7 +133,9 @@ fn _read_expr_string_constants(existing: StringConstant[]) -> StringConstant[] !
                 let _ct = substring(_r2, 0, _t2);
                 let _bct = substring(_r2, _t2 + 1, _r2.length);
                 let _bc = _parse_int_from_string(_bct);
-                result = merge_string_constants(result, [StringConstant { name: _nm, content: _ct, byte_count: _bc }]);
+                result = merge_string_constants(result, [StringConstant {
+                    name: _nm, content: _ct, byte_count: _bc
+                }]);
             }
         }
         fs.writeFile("build/sailfin/.expr_stmt_string_constants", "");
@@ -183,12 +146,7 @@ fn _read_expr_string_constants(existing: StringConstant[]) -> StringConstant[] !
 // Read Let result from files and apply to caller's state.
 // Sets file IPC markers for the caller to detect.
 // Writes updated temp/local/region to dispatch_* files.
-fn _apply_let_result_from_files(
-    diagnostics: string[],
-    current_locals: LocalBinding[],
-    scope_id: string,
-    scope_depth: number
-) -> LocalBinding[] ![io] {
+fn _apply_let_result_from_files(diagnostics: string[], current_locals: LocalBinding[], scope_id: string, scope_depth: number) -> LocalBinding[] ![io] {
     let mut result_locals = current_locals;
     if fs.exists("build/sailfin/.let_result_temp_index") {
         // Read diagnostics from bulk file
@@ -228,42 +186,22 @@ fn _apply_let_result_from_files(
             let _pointer = fs.readFile("build/sailfin/.let_result_local_pointer");
             let _type = fs.readFile("build/sailfin/.let_result_local_llvm_type");
             let _ann = fs.readFile("build/sailfin/.let_result_local_type_ann");
-            result_locals = append_local_binding(result_locals, LocalBinding { name: _name, pointer: _pointer, llvm_type: _type, type_annotation: _ann, ownership: null, consumed: false, scope_id: scope_id, scope_depth: scope_depth });
+            result_locals = append_local_binding(result_locals, LocalBinding {
+                name: _name, pointer: _pointer, llvm_type: _type, type_annotation: _ann, ownership: null, consumed: false, scope_id: scope_id, scope_depth: scope_depth
+            });
         }
         // Clean up
         fs.deleteFile("build/sailfin/.let_result_temp_index");
         if fs.exists("build/sailfin/.let_result_local_name") {
             fs.deleteFile("build/sailfin/.let_result_local_name");
         }
-    } else {
-        fs.writeFile("build/sailfin/.dispatch_used_file_ipc", "0");
-    }
+    } else { fs.writeFile("build/sailfin/.dispatch_used_file_ipc", "0"); }
     return result_locals;
 }
 
 // Handle Expression instruction (tag 1).
 // Writes results via file IPC for the caller to read back.
-fn dispatch_expression_instruction(
-    function: NativeFunction,
-    index: number,
-    instruction: NativeInstruction,
-    bindings: ParameterBinding[],
-    locals: LocalBinding[],
-    lines: string[],
-    allocas: string[],
-    temp_index: number,
-    next_region_id: number,
-    scope_id: string,
-    scope_depth: number,
-    functions: NativeFunction[],
-    context: TypeContext,
-    active_label: string,
-    diagnostics: string[],
-    string_constants: StringConstant[],
-    mutations: LocalMutation[],
-    lifetime_regions: LifetimeRegionMetadata[],
-    debug_lowering: boolean
-) -> LocalBinding[] ![io] {
+fn dispatch_expression_instruction(function: NativeFunction, index: number, instruction: NativeInstruction, bindings: ParameterBinding[], locals: LocalBinding[], lines: string[], allocas: string[], temp_index: number, next_region_id: number, scope_id: string, scope_depth: number, functions: NativeFunction[], context: TypeContext, active_label: string, diagnostics: string[], string_constants: StringConstant[], mutations: LocalMutation[], lifetime_regions: LifetimeRegionMetadata[], debug_lowering: boolean) -> LocalBinding[] ![io] {
     let mut result_locals = locals;
     let mut current_mutations = mutations;
     let mut current_string_constants = string_constants;
@@ -321,7 +259,7 @@ fn dispatch_expression_instruction(
             let _mv = fs.readFile(_mp + "_value");
             let _ml = fs.readFile(_mp + "_label");
             current_mutations = extend_mutations(current_mutations, [LocalMutation {
-                        name: _mn, llvm_type: _mt, value_name: _mv, span: null, originating_label: _ml,
+                name: _mn, llvm_type: _mt, value_name: _mv, span: null, originating_label: _ml,
             }]);
             _mi += 1;
         }
@@ -344,28 +282,10 @@ fn dispatch_expression_instruction(
 
 // Handle Return instruction (tag 0).
 // Writes results via file IPC.
-fn dispatch_return_instruction(
-    function: NativeFunction,
-    index: number,
-    instruction: NativeInstruction,
-    bindings: ParameterBinding[],
-    locals: LocalBinding[],
-    lines: string[],
-    temp_index: number,
-    next_region_id: number,
-    scope_id: string,
-    scope_depth: number,
-    llvm_return: string,
-    functions: NativeFunction[],
-    context: TypeContext,
-    string_constants: StringConstant[],
-    debug_lowering: boolean
-) ![io] {
+fn dispatch_return_instruction(function: NativeFunction, index: number, instruction: NativeInstruction, bindings: ParameterBinding[], locals: LocalBinding[], lines: string[], temp_index: number, next_region_id: number, scope_id: string, scope_depth: number, llvm_return: string, functions: NativeFunction[], context: TypeContext, string_constants: StringConstant[], debug_lowering: boolean) ![io] {
     let _ret_expr = get_instruction_text(function.instructions, index);
     let mut safe_instr_expr: string = "";
-    if _ret_expr != null {
-        safe_instr_expr = _ret_expr;
-    }
+    if _ret_expr != null { safe_instr_expr = _ret_expr; }
     fs.writeFile("build/sailfin/.instr_fn_name", function.name);
     fs.writeFile("build/sailfin/.instr_expression", safe_instr_expr);
     fs.writeFile("build/sailfin/.instr_llvm_return", llvm_return);

--- a/compiler/src/llvm/lowering/instructions_dispatch.sfn
+++ b/compiler/src/llvm/lowering/instructions_dispatch.sfn
@@ -8,14 +8,14 @@
 // Each handler writes results to file IPC so the caller can read them back.
 import { NativeFunction, NativeInstruction, NativeSourceSpan } from "../../native_ir";
 import { char_code, grapheme_at, substring } from "../../string_utils";
-import { lower_expression, } from "../expression_lowering/native/core";
-import { append_local_binding, } from "../expression_lowering/native/core_scopes";
-import { lower_expression_statement, lower_return_instruction, } from "../expression_lowering/native/statement";
-import { parse_inline_let_expression, } from "../expression_lowering/native/statement_parsing";
-import { detect_suspension_conflicts, } from "../expression_lowering/native/statement_suspension";
-import { map_local_type, } from "../expression_lowering/native/statement_type_mapping";
-import { apply_lifetime_release_events, } from "../lifetime";
-import { merge_string_constants, } from "../strings";
+import { lower_expression } from "../expression_lowering/native/core";
+import { append_local_binding } from "../expression_lowering/native/core_scopes";
+import { lower_expression_statement, lower_return_instruction } from "../expression_lowering/native/statement";
+import { parse_inline_let_expression } from "../expression_lowering/native/statement_parsing";
+import { detect_suspension_conflicts } from "../expression_lowering/native/statement_suspension";
+import { map_local_type } from "../expression_lowering/native/statement_type_mapping";
+import { apply_lifetime_release_events } from "../lifetime";
+import { merge_string_constants } from "../strings";
 import {
     BlockLoweringResult,
     LLVMOperand,
@@ -26,7 +26,7 @@ import {
     LoopContext,
     ParameterBinding,
     StringConstant,
-    TypeContext,
+    TypeContext
 } from "../types";
 import {
     append_string,
@@ -34,21 +34,17 @@ import {
     index_of,
     number_to_string,
     starts_with,
-    trim_text,
+    trim_text
 } from "../utils";
-import {
-    _parse_int_from_string,
-    _read_ipc_int_min,
-    extend_mutations,
-} from "./instructions_helpers";
-import { extend_lifetime_regions, } from "./instructions_helpers";
-import { lower_let_instruction, } from "./instructions_let";
+import { _parse_int_from_string, _read_ipc_int_min, extend_mutations } from "./instructions_helpers";
+import { extend_lifetime_regions } from "./instructions_helpers";
+import { lower_let_instruction } from "./instructions_let";
 import {
     get_instruction_condition,
     get_instruction_tag,
-    get_instruction_text,
+    get_instruction_text
 } from "./lowering_native_helpers";
-import { split_lines_local, } from "./lowering_text_utils";
+import { split_lines_local } from "./lowering_text_utils";
 
 // Write bindings to files for statement.sfn to read.
 // Extracted from the Expression and Return handlers where this pattern
@@ -221,7 +217,7 @@ fn dispatch_expression_instruction(function: NativeFunction, index: number, inst
                     type_annotation: inline_parse.type_annotation,
                     value: inline_parse.initializer,
                     span: null,
-                    value_span: null,
+                    value_span: null
                 };
                 let lowered = lower_let_instruction(function, inline_instruction, bindings, result_locals, allocas, lines, temp_index, next_region_id, next_region_id, functions, context, scope_id, scope_depth, active_label);
                 result_locals = _apply_let_result_from_files(diagnostics, result_locals, scope_id, scope_depth);
@@ -259,7 +255,7 @@ fn dispatch_expression_instruction(function: NativeFunction, index: number, inst
             let _mv = fs.readFile(_mp + "_value");
             let _ml = fs.readFile(_mp + "_label");
             current_mutations = extend_mutations(current_mutations, [LocalMutation {
-                name: _mn, llvm_type: _mt, value_name: _mv, span: null, originating_label: _ml,
+                name: _mn, llvm_type: _mt, value_name: _mv, span: null, originating_label: _ml
             }]);
             _mi += 1;
         }
@@ -305,7 +301,9 @@ fn dispatch_return_instruction(function: NativeFunction, index: number, instruct
     loop {
         if _si >= result_sc.length { break; }
         if _si > 0 { _joined_sc = _joined_sc + "\n"; }
-        _joined_sc = _joined_sc + result_sc[_si].name + "\t" + result_sc[_si].content + "\t" + number_to_string(result_sc[_si].byte_count);
+        _joined_sc = _joined_sc + result_sc[_si].name + "\t" + result_sc[_si].content
+            + "\t"
+            + number_to_string(result_sc[_si].byte_count);
         _si += 1;
     }
     fs.writeFile("build/sailfin/.dispatch_string_constants", _joined_sc);

--- a/compiler/src/llvm/lowering/instructions_for.sfn
+++ b/compiler/src/llvm/lowering/instructions_for.sfn
@@ -3,24 +3,20 @@
 // Control flow handler: for-loop instruction lowering (range and array iteration).
 import { NativeFunction, NativeInstruction, NativeSourceSpan } from "../../native_ir";
 import { char_code, grapheme_at, substring } from "../../string_utils";
-import { array_pointer_element_type, } from "../expression_lowering/arrays";
-import { lower_expression, } from "../expression_lowering/native/core";
+import { array_pointer_element_type } from "../expression_lowering/arrays";
+import { lower_expression } from "../expression_lowering/native/core";
 import {
     coerce_operand_to_type,
     emit_comparison_instruction,
-    load_local_operand,
+    load_local_operand
 } from "../expression_lowering/native/core_operands";
-import { parse_range_iterable, } from "../expression_lowering/native/core_parse";
-import { append_local_binding, } from "../expression_lowering/native/core_scopes";
-import { find_local_binding, } from "../expressions_bindings";
-import {
-    default_return_literal,
-    format_local_pointer_name,
-    format_temp_name,
-} from "../expressions_helpers";
-import { is_number_literal, normalise_number_literal, } from "../expressions_literals";
-import { make_child_scope_id, } from "../lifetime";
-import { empty_string_constant_set, merge_string_constants, } from "../strings";
+import { parse_range_iterable } from "../expression_lowering/native/core_parse";
+import { append_local_binding } from "../expression_lowering/native/core_scopes";
+import { find_local_binding } from "../expressions_bindings";
+import { default_return_literal, format_local_pointer_name, format_temp_name } from "../expressions_helpers";
+import { is_number_literal, normalise_number_literal } from "../expressions_literals";
+import { make_child_scope_id } from "../lifetime";
+import { empty_string_constant_set, merge_string_constants } from "../strings";
 import { array_struct_type_for_element } from "../type_mapping";
 import {
     BlockLoweringResult,
@@ -32,26 +28,22 @@ import {
     LoopStructure,
     ParameterBinding,
     StringConstant,
-    TypeContext,
+    TypeContext
 } from "../types";
 import {
     extend_string_array,
     is_simple_identifier,
     number_to_string,
     strip_mut_prefix,
-    trim_text,
+    trim_text
 } from "../utils";
-import { lower_instruction_range, } from "./instructions";
-import { allocate_block_label, } from "./instructions_condition";
+import { lower_instruction_range } from "./instructions";
+import { allocate_block_label } from "./instructions_condition";
 import { build_loop_exit_mutations, lower_for_range } from "./instructions_for_range";
-import {
-    _parse_int_from_string,
-    extend_lifetime_regions,
-    extend_mutations,
-} from "./instructions_helpers";
-import { append_loop_context, collect_loop_structure, } from "./instructions_loops";
-import { get_instruction_for_iterable, get_instruction_for_target, } from "./lowering_native_helpers";
-import { collect_mutation_names, find_mutation_for_name, } from "./phi";
+import { _parse_int_from_string, extend_lifetime_regions, extend_mutations } from "./instructions_helpers";
+import { append_loop_context, collect_loop_structure } from "./instructions_loops";
+import { get_instruction_for_iterable, get_instruction_for_target } from "./lowering_native_helpers";
+import { collect_mutation_names, find_mutation_for_name } from "./phi";
 
 // Lower a range-based for loop (e.g., `for i in 0..10`).
 // Returns null if the iterable is not a recognized range pattern.
@@ -75,11 +67,18 @@ fn lower_for_array(function: NativeFunction, structure: LoopStructure, raw_targe
     let data_pointer_pointer_type = data_pointer_type + "*";
 
     let length_pointer_name = format_temp_name(current_temp);
-    current_lines.push("  " + length_pointer_name + " = getelementptr " + array_struct_type + ", " + array_struct_type + "* " + iterable_operand.value + ", i32 0, i32 1");
+    current_lines.push("  " + length_pointer_name + " = getelementptr "
+        + array_struct_type
+        + ", "
+        + array_struct_type
+        + "* "
+        + iterable_operand.value
+        + ", i32 0, i32 1");
     current_temp += 1;
 
     let length_load_name = format_temp_name(current_temp);
-    current_lines.push("  " + length_load_name + " = load i64, i64* " + length_pointer_name);
+    current_lines.push("  " + length_load_name + " = load i64, i64* "
+        + length_pointer_name);
     current_temp += 1;
     let length_operand = LLVMOperand {
         llvm_type: "i64",
@@ -87,11 +86,21 @@ fn lower_for_array(function: NativeFunction, structure: LoopStructure, raw_targe
     };
 
     let data_pointer_name = format_temp_name(current_temp);
-    current_lines.push("  " + data_pointer_name + " = getelementptr " + array_struct_type + ", " + array_struct_type + "* " + iterable_operand.value + ", i32 0, i32 0");
+    current_lines.push("  " + data_pointer_name + " = getelementptr "
+        + array_struct_type
+        + ", "
+        + array_struct_type
+        + "* "
+        + iterable_operand.value
+        + ", i32 0, i32 0");
     current_temp += 1;
 
     let data_load_name = format_temp_name(current_temp);
-    current_lines.push("  " + data_load_name + " = load " + data_pointer_type + ", " + data_pointer_pointer_type + " " + data_pointer_name);
+    current_lines.push("  " + data_load_name + " = load " + data_pointer_type
+        + ", "
+        + data_pointer_pointer_type
+        + " "
+        + data_pointer_name);
     current_temp += 1;
     let data_operand = LLVMOperand {
         llvm_type: data_pointer_type,
@@ -122,34 +131,61 @@ fn lower_for_array(function: NativeFunction, structure: LoopStructure, raw_targe
     let iteration_pointer = format_local_pointer_name(current_next_local);
     current_next_local += 1;
     current_allocas.push("  " + iteration_pointer + " = alloca " + element_type);
-    current_lines.push("  store " + element_type + " " + default_return_literal(element_type) + ", " + element_type + "* " + iteration_pointer);
+    current_lines.push("  store " + element_type + " " + default_return_literal(element_type)
+        + ", "
+        + element_type
+        + "* "
+        + iteration_pointer);
 
     current_lines.push("  br label %" + loop_header_label);
     current_lines.push(loop_header_label + ":");
 
     let header_index_name = format_temp_name(current_temp);
-    current_lines.push("  " + header_index_name + " = load i64, i64* " + index_pointer);
+    current_lines.push("  " + header_index_name + " = load i64, i64* "
+        + index_pointer);
     current_temp += 1;
 
     let comparison_name = format_temp_name(current_temp);
-    current_lines.push("  " + comparison_name + " = icmp slt i64 " + header_index_name + ", " + length_operand.value);
+    current_lines.push("  " + comparison_name + " = icmp slt i64 "
+        + header_index_name
+        + ", "
+        + length_operand.value);
     current_temp += 1;
-    current_lines.push("  br i1 " + comparison_name + ", label %" + loop_body_label + ", label %" + loop_exit_label);
+    current_lines.push("  br i1 " + comparison_name + ", label %"
+        + loop_body_label
+        + ", label %"
+        + loop_exit_label);
     current_lines.push(loop_body_label + ":");
 
     let body_index_name = format_temp_name(current_temp);
-    current_lines.push("  " + body_index_name + " = load i64, i64* " + index_pointer);
+    current_lines.push("  " + body_index_name + " = load i64, i64* "
+        + index_pointer);
     current_temp += 1;
 
     let element_pointer_name = format_temp_name(current_temp);
-    current_lines.push("  " + element_pointer_name + " = getelementptr " + element_type + ", " + element_type + "* " + data_operand.value + ", i64 " + body_index_name);
+    current_lines.push("  " + element_pointer_name + " = getelementptr "
+        + element_type
+        + ", "
+        + element_type
+        + "* "
+        + data_operand.value
+        + ", i64 "
+        + body_index_name);
     current_temp += 1;
 
     let element_load_name = format_temp_name(current_temp);
-    current_lines.push("  " + element_load_name + " = load " + element_type + ", " + element_type + "* " + element_pointer_name);
+    current_lines.push("  " + element_load_name + " = load " + element_type
+        + ", "
+        + element_type
+        + "* "
+        + element_pointer_name);
     current_temp += 1;
 
-    current_lines.push("  store " + element_type + " " + element_load_name + ", " + element_type + "* " + iteration_pointer);
+    current_lines.push("  store " + element_type + " " + element_load_name
+        + ", "
+        + element_type
+        + "* "
+        + iteration_pointer);
 
     let loop_context = LoopContext {
         break_label: loop_exit_label,
@@ -169,7 +205,8 @@ fn lower_for_array(function: NativeFunction, structure: LoopStructure, raw_targe
         scope_depth: scope_depth + 1
     };
     let body_locals = append_local_binding(current_locals, iteration_binding);
-    let body_result = lower_instruction_range(function, structure.body_start, structure.body_end, llvm_return, current_bindings, body_locals, current_allocas, [], current_temp, current_block_counter, current_next_local, current_next_region, functions, stacked, context, element_loop_scope_id, scope_depth + 1, loop_body_label);
+    let body_result = lower_instruction_range(function, structure.body_start, structure.body_end, llvm_return, current_bindings, body_locals, current_allocas, [], current_temp, current_block_counter, current_next_local, current_next_region, functions, stacked, context, element_loop_scope_id, scope_depth
+        + 1, loop_body_label);
     let mut _ci24: number = 0;
     loop {
         if _ci24 >= body_result.diagnostics.length { break; }
@@ -194,14 +231,18 @@ fn lower_for_array(function: NativeFunction, structure: LoopStructure, raw_targe
     current_lines.push(loop_increment_label + ":");
 
     let increment_index_name = format_temp_name(current_temp);
-    current_lines.push("  " + increment_index_name + " = load i64, i64* " + index_pointer);
+    current_lines.push("  " + increment_index_name + " = load i64, i64* "
+        + index_pointer);
     current_temp += 1;
 
     let next_index_name = format_temp_name(current_temp);
-    current_lines.push("  " + next_index_name + " = add i64 " + increment_index_name + ", 1");
+    current_lines.push("  " + next_index_name + " = add i64 "
+        + increment_index_name
+        + ", 1");
     current_temp += 1;
 
-    current_lines.push("  store i64 " + next_index_name + ", i64* " + index_pointer);
+    current_lines.push("  store i64 " + next_index_name + ", i64* "
+        + index_pointer);
     current_lines.push("  br label %" + loop_header_label);
     current_lines.push(loop_exit_label + ":");
 
@@ -226,7 +267,7 @@ fn lower_for_array(function: NativeFunction, structure: LoopStructure, raw_targe
         next_lifetime_region_id: current_next_region,
         next_index: next_index,
         mutations: collected_mutations,
-        string_constants: collected_string_constants,
+        string_constants: collected_string_constants
     };
 }
 
@@ -262,7 +303,9 @@ fn lower_for_instruction(function: NativeFunction, start_index: number, llvm_ret
     let mut raw_target = trim_text(for_target_text);
     raw_target = strip_mut_prefix(raw_target);
     if raw_target.length == 0 {
-        diagnostics.push("llvm lowering: `.for` loop missing iteration binding in `" + function.name + "`");
+        diagnostics.push("llvm lowering: `.for` loop missing iteration binding in `"
+            + function.name
+            + "`");
         return BlockLoweringResult {
             lines: current_lines,
             allocas: current_allocas,
@@ -277,12 +320,15 @@ fn lower_for_instruction(function: NativeFunction, start_index: number, llvm_ret
             next_lifetime_region_id: current_next_region,
             next_index: next_index,
             mutations: collected_mutations,
-            string_constants: collected_string_constants,
+            string_constants: collected_string_constants
         };
     }
 
     if !is_simple_identifier(raw_target) {
-        diagnostics.push("llvm lowering: `.for` loop target `" + raw_target + "` is not a simple identifier in `" + function.name + "`");
+        diagnostics.push("llvm lowering: `.for` loop target `" + raw_target
+            + "` is not a simple identifier in `"
+            + function.name
+            + "`");
         return BlockLoweringResult {
             lines: current_lines,
             allocas: current_allocas,
@@ -297,12 +343,15 @@ fn lower_for_instruction(function: NativeFunction, start_index: number, llvm_ret
             next_lifetime_region_id: current_next_region,
             next_index: next_index,
             mutations: collected_mutations,
-            string_constants: collected_string_constants,
+            string_constants: collected_string_constants
         };
     }
 
     if find_local_binding(current_locals, raw_target) != null {
-        diagnostics.push("llvm lowering: `.for` loop target `" + raw_target + "` shadows existing local in `" + function.name + "`");
+        diagnostics.push("llvm lowering: `.for` loop target `" + raw_target
+            + "` shadows existing local in `"
+            + function.name
+            + "`");
         return BlockLoweringResult {
             lines: current_lines,
             allocas: current_allocas,
@@ -317,7 +366,7 @@ fn lower_for_instruction(function: NativeFunction, start_index: number, llvm_ret
             next_lifetime_region_id: current_next_region,
             next_index: next_index,
             mutations: collected_mutations,
-            string_constants: collected_string_constants,
+            string_constants: collected_string_constants
         };
     }
 
@@ -345,7 +394,9 @@ fn lower_for_instruction(function: NativeFunction, start_index: number, llvm_ret
             diagnostics.push(range_parse.diagnostics[_ci22]);
             _ci22 += 1;
         }
-        diagnostics.push("llvm lowering: unable to lower `.for` iterable in `" + function.name + "`");
+        diagnostics.push("llvm lowering: unable to lower `.for` iterable in `"
+            + function.name
+            + "`");
         return BlockLoweringResult {
             lines: current_lines,
             allocas: current_allocas,
@@ -360,7 +411,7 @@ fn lower_for_instruction(function: NativeFunction, start_index: number, llvm_ret
             next_lifetime_region_id: current_next_region,
             next_index: next_index,
             mutations: collected_mutations,
-            string_constants: collected_string_constants,
+            string_constants: collected_string_constants
         };
     }
 
@@ -373,7 +424,9 @@ fn lower_for_instruction(function: NativeFunction, start_index: number, llvm_ret
             diagnostics.push(range_parse.diagnostics[_ci23]);
             _ci23 += 1;
         }
-        diagnostics.push("llvm lowering: `.for` iterable must resolve to an array value in `" + function.name + "`");
+        diagnostics.push("llvm lowering: `.for` iterable must resolve to an array value in `"
+            + function.name
+            + "`");
         return BlockLoweringResult {
             lines: current_lines,
             allocas: current_allocas,
@@ -388,7 +441,7 @@ fn lower_for_instruction(function: NativeFunction, start_index: number, llvm_ret
             next_lifetime_region_id: current_next_region,
             next_index: next_index,
             mutations: collected_mutations,
-            string_constants: collected_string_constants,
+            string_constants: collected_string_constants
         };
     }
 

--- a/compiler/src/llvm/lowering/instructions_for.sfn
+++ b/compiler/src/llvm/lowering/instructions_for.sfn
@@ -1,133 +1,61 @@
 // compiler/src/llvm/lowering/instructions_for.sfn
 //
 // Control flow handler: for-loop instruction lowering (range and array iteration).
-
 import { NativeFunction, NativeInstruction, NativeSourceSpan } from "../../native_ir";
-import { lower_for_range, build_loop_exit_mutations } from "./instructions_for_range";
-import { substring, char_code, grapheme_at } from "../../string_utils";
-
-import {
-    TypeContext,
-    LocalBinding,
-    ParameterBinding,
-    LLVMOperand,
-    BlockLoweringResult,
-    LoopContext,
-    LifetimeRegionMetadata,
-    LocalMutation,
-    StringConstant,
-    LoopStructure,
-} from "../types";
-
-import {
-    trim_text,
-    extend_string_array,
-    number_to_string,
-    strip_mut_prefix,
-    is_simple_identifier,
-} from "../utils";
-
-import {
-    empty_string_constant_set,
-    merge_string_constants,
-} from "../strings";
-
-import { array_struct_type_for_element } from "../type_mapping";
-
-import {
-    find_local_binding,
-} from "../expressions_bindings";
-
-import {
-    is_number_literal,
-    normalise_number_literal,
-} from "../expressions_literals";
-
-import {
-    default_return_literal,
-    format_local_pointer_name,
-    format_temp_name,
-} from "../expressions_helpers";
-
-import {
-    lower_expression,
-} from "../expression_lowering/native/core";
-
+import { char_code, grapheme_at, substring } from "../../string_utils";
+import { array_pointer_element_type, } from "../expression_lowering/arrays";
+import { lower_expression, } from "../expression_lowering/native/core";
 import {
     coerce_operand_to_type,
     emit_comparison_instruction,
     load_local_operand,
 } from "../expression_lowering/native/core_operands";
-
+import { parse_range_iterable, } from "../expression_lowering/native/core_parse";
+import { append_local_binding, } from "../expression_lowering/native/core_scopes";
+import { find_local_binding, } from "../expressions_bindings";
 import {
-    append_local_binding,
-} from "../expression_lowering/native/core_scopes";
-
+    default_return_literal,
+    format_local_pointer_name,
+    format_temp_name,
+} from "../expressions_helpers";
+import { is_number_literal, normalise_number_literal, } from "../expressions_literals";
+import { make_child_scope_id, } from "../lifetime";
+import { empty_string_constant_set, merge_string_constants, } from "../strings";
+import { array_struct_type_for_element } from "../type_mapping";
 import {
-    parse_range_iterable,
-} from "../expression_lowering/native/core_parse";
-
+    BlockLoweringResult,
+    LLVMOperand,
+    LifetimeRegionMetadata,
+    LocalBinding,
+    LocalMutation,
+    LoopContext,
+    LoopStructure,
+    ParameterBinding,
+    StringConstant,
+    TypeContext,
+} from "../types";
 import {
-    array_pointer_element_type,
-} from "../expression_lowering/arrays";
-
+    extend_string_array,
+    is_simple_identifier,
+    number_to_string,
+    strip_mut_prefix,
+    trim_text,
+} from "../utils";
+import { lower_instruction_range, } from "./instructions";
+import { allocate_block_label, } from "./instructions_condition";
+import { build_loop_exit_mutations, lower_for_range } from "./instructions_for_range";
 import {
-    make_child_scope_id,
-} from "../lifetime";
-
-import {
-    collect_mutation_names,
-    find_mutation_for_name,
-} from "./phi";
-
-import {
-    lower_instruction_range,
-} from "./instructions";
-
-import {
+    _parse_int_from_string,
     extend_lifetime_regions,
     extend_mutations,
-    _parse_int_from_string,
 } from "./instructions_helpers";
-
-import {
-    allocate_block_label,
-} from "./instructions_condition";
-
-import {
-    collect_loop_structure,
-    append_loop_context,
-} from "./instructions_loops";
-
-import {
-    get_instruction_for_target,
-    get_instruction_for_iterable,
-} from "./lowering_native_helpers";
+import { append_loop_context, collect_loop_structure, } from "./instructions_loops";
+import { get_instruction_for_iterable, get_instruction_for_target, } from "./lowering_native_helpers";
+import { collect_mutation_names, find_mutation_for_name, } from "./phi";
 
 // Lower a range-based for loop (e.g., `for i in 0..10`).
 // Returns null if the iterable is not a recognized range pattern.
-fn lower_for_array(
-    function: NativeFunction,
-    structure: LoopStructure,
-    raw_target: string,
-    instruction: NativeInstruction,
-    iterable_operand: LLVMOperand,
-    llvm_return: string,
-    bindings: ParameterBinding[],
-    locals: LocalBinding[],
-    allocas: string[],
-    lines: string[],
-    temp_index: number,
-    block_counter: number,
-    next_local_id: number,
-    next_region_id: number,
-    functions: NativeFunction[],
-    loop_stack: LoopContext[],
-    context: TypeContext,
-    scope_id: string,
-    scope_depth: number,
-    next_index: number
-) -> BlockLoweringResult {
+fn lower_for_array(function: NativeFunction, structure: LoopStructure, raw_target: string, instruction: NativeInstruction, iterable_operand: LLVMOperand, llvm_return: string, bindings: ParameterBinding[], locals: LocalBinding[], allocas: string[], lines: string[], temp_index: number, block_counter: number, next_local_id: number, next_region_id: number, functions: NativeFunction[], loop_stack: LoopContext[], context: TypeContext, scope_id: string, scope_depth: number, next_index: number) -> BlockLoweringResult {
     let mut diagnostics: string[] = [];
     let mut current_lines: string[] = lines;
     let mut current_allocas: string[] = allocas;
@@ -153,7 +81,10 @@ fn lower_for_array(
     let length_load_name = format_temp_name(current_temp);
     current_lines.push("  " + length_load_name + " = load i64, i64* " + length_pointer_name);
     current_temp += 1;
-    let length_operand = LLVMOperand { llvm_type: "i64", value: length_load_name };
+    let length_operand = LLVMOperand {
+        llvm_type: "i64",
+        value: length_load_name
+    };
 
     let data_pointer_name = format_temp_name(current_temp);
     current_lines.push("  " + data_pointer_name + " = getelementptr " + array_struct_type + ", " + array_struct_type + "* " + iterable_operand.value + ", i32 0, i32 0");
@@ -162,7 +93,10 @@ fn lower_for_array(
     let data_load_name = format_temp_name(current_temp);
     current_lines.push("  " + data_load_name + " = load " + data_pointer_type + ", " + data_pointer_pointer_type + " " + data_pointer_name);
     current_temp += 1;
-    let data_operand = LLVMOperand { llvm_type: data_pointer_type, value: data_load_name };
+    let data_operand = LLVMOperand {
+        llvm_type: data_pointer_type,
+        value: data_load_name
+    };
 
     let loop_header_alloc = allocate_block_label("for", current_block_counter);
     let loop_header_label = loop_header_alloc.label;
@@ -217,32 +151,25 @@ fn lower_for_array(
 
     current_lines.push("  store " + element_type + " " + element_load_name + ", " + element_type + "* " + iteration_pointer);
 
-    let loop_context = LoopContext { break_label: loop_exit_label, continue_label: loop_increment_label };
+    let loop_context = LoopContext {
+        break_label: loop_exit_label,
+        continue_label: loop_increment_label
+    };
     let stacked = append_loop_context(loop_stack, loop_context);
 
     let element_loop_scope_id = make_child_scope_id(scope_id, loop_body_label);
-    let iteration_binding = LocalBinding { name: raw_target, pointer: iteration_pointer, llvm_type: element_type, type_annotation: "", ownership: null, consumed: false, scope_id: element_loop_scope_id, scope_depth: scope_depth + 1 };
+    let iteration_binding = LocalBinding {
+        name: raw_target,
+        pointer: iteration_pointer,
+        llvm_type: element_type,
+        type_annotation: "",
+        ownership: null,
+        consumed: false,
+        scope_id: element_loop_scope_id,
+        scope_depth: scope_depth + 1
+    };
     let body_locals = append_local_binding(current_locals, iteration_binding);
-    let body_result = lower_instruction_range(
-        function,
-        structure.body_start,
-        structure.body_end,
-        llvm_return,
-        current_bindings,
-        body_locals,
-        current_allocas,
-        [],
-        current_temp,
-        current_block_counter,
-        current_next_local,
-        current_next_region,
-        functions,
-        stacked,
-        context,
-        element_loop_scope_id,
-        scope_depth + 1,
-        loop_body_label
-    );
+    let body_result = lower_instruction_range(function, structure.body_start, structure.body_end, llvm_return, current_bindings, body_locals, current_allocas, [], current_temp, current_block_counter, current_next_local, current_next_region, functions, stacked, context, element_loop_scope_id, scope_depth + 1, loop_body_label);
     let mut _ci24: number = 0;
     loop {
         if _ci24 >= body_result.diagnostics.length { break; }
@@ -275,15 +202,15 @@ fn lower_for_array(
     current_temp += 1;
 
     current_lines.push("  store i64 " + next_index_name + ", i64* " + index_pointer);
-        current_lines.push("  br label %" + loop_header_label);
-        current_lines.push(loop_exit_label + ":");
+    current_lines.push("  br label %" + loop_header_label);
+    current_lines.push(loop_exit_label + ":");
 
     let exit_result = build_loop_exit_mutations(collected_mutations, locals, current_lines, current_temp, loop_exit_label);
     current_lines = exit_result.lines;
     current_temp = exit_result.temp_index;
     collected_mutations = exit_result.mutations;
 
-        current_locals = locals;
+    current_locals = locals;
 
     return BlockLoweringResult {
         lines: current_lines,
@@ -298,31 +225,13 @@ fn lower_for_array(
         lifetime_regions: lifetime_regions,
         next_lifetime_region_id: current_next_region,
         next_index: next_index,
-        mutations: collected_mutations, string_constants: collected_string_constants,
+        mutations: collected_mutations,
+        string_constants: collected_string_constants,
     };
 }
 
 // Shared helper: build exit mutations for loop locals after the loop exit label.
-fn lower_for_instruction(
-    function: NativeFunction,
-    start_index: number,
-    llvm_return: string,
-    bindings: ParameterBinding[],
-    locals: LocalBinding[],
-    allocas: string[],
-    lines: string[],
-    temp_index: number,
-    block_counter: number,
-    next_local_id: number,
-    next_region_id: number,
-    functions: NativeFunction[],
-    loop_stack: LoopContext[],
-    end: number,
-    context: TypeContext,
-    scope_id: string,
-    scope_depth: number,
-    current_label: string
-) -> BlockLoweringResult {
+fn lower_for_instruction(function: NativeFunction, start_index: number, llvm_return: string, bindings: ParameterBinding[], locals: LocalBinding[], allocas: string[], lines: string[], temp_index: number, block_counter: number, next_local_id: number, next_region_id: number, functions: NativeFunction[], loop_stack: LoopContext[], end: number, context: TypeContext, scope_id: string, scope_depth: number, current_label: string) -> BlockLoweringResult {
     let mut diagnostics: string[] = [];
     let mut current_lines: string[] = lines;
     let mut current_allocas: string[] = allocas;
@@ -367,7 +276,8 @@ fn lower_for_instruction(
             lifetime_regions: lifetime_regions,
             next_lifetime_region_id: current_next_region,
             next_index: next_index,
-            mutations: collected_mutations, string_constants: collected_string_constants,
+            mutations: collected_mutations,
+            string_constants: collected_string_constants,
         };
     }
 
@@ -386,7 +296,8 @@ fn lower_for_instruction(
             lifetime_regions: lifetime_regions,
             next_lifetime_region_id: current_next_region,
             next_index: next_index,
-            mutations: collected_mutations, string_constants: collected_string_constants,
+            mutations: collected_mutations,
+            string_constants: collected_string_constants,
         };
     }
 
@@ -405,20 +316,14 @@ fn lower_for_instruction(
             lifetime_regions: lifetime_regions,
             next_lifetime_region_id: current_next_region,
             next_index: next_index,
-            mutations: collected_mutations, string_constants: collected_string_constants,
+            mutations: collected_mutations,
+            string_constants: collected_string_constants,
         };
     }
 
     // Try range-based for loop first.
-    let range_result = lower_for_range(
-        function, structure, raw_target, for_iterable_text,
-        llvm_return, bindings, locals, allocas, lines,
-        temp_index, block_counter, next_local_id, next_region_id,
-        functions, loop_stack, context, scope_id, scope_depth, next_index
-    );
-    if range_result != null {
-        return range_result;
-    }
+    let range_result = lower_for_range(function, structure, raw_target, for_iterable_text, llvm_return, bindings, locals, allocas, lines, temp_index, block_counter, next_local_id, next_region_id, functions, loop_stack, context, scope_id, scope_depth, next_index);
+    if range_result != null { return range_result; }
 
     // Fall through to array-based for loop.
     let range_parse = parse_range_iterable(for_iterable_text);
@@ -454,7 +359,8 @@ fn lower_for_instruction(
             lifetime_regions: lifetime_regions,
             next_lifetime_region_id: current_next_region,
             next_index: next_index,
-            mutations: collected_mutations, string_constants: collected_string_constants,
+            mutations: collected_mutations,
+            string_constants: collected_string_constants,
         };
     }
 
@@ -481,14 +387,10 @@ fn lower_for_instruction(
             lifetime_regions: lifetime_regions,
             next_lifetime_region_id: current_next_region,
             next_index: next_index,
-            mutations: collected_mutations, string_constants: collected_string_constants,
+            mutations: collected_mutations,
+            string_constants: collected_string_constants,
         };
     }
 
-    return lower_for_array(
-        function, structure, raw_target, instruction, iterable_operand,
-        llvm_return, bindings, locals, allocas, current_lines,
-        current_temp, current_block_counter, current_next_local, current_next_region,
-        functions, loop_stack, context, scope_id, scope_depth, next_index
-    );
+    return lower_for_array(function, structure, raw_target, instruction, iterable_operand, llvm_return, bindings, locals, allocas, current_lines, current_temp, current_block_counter, current_next_local, current_next_region, functions, loop_stack, context, scope_id, scope_depth, next_index);
 }

--- a/compiler/src/llvm/lowering/instructions_for_range.sfn
+++ b/compiler/src/llvm/lowering/instructions_for_range.sfn
@@ -25,7 +25,7 @@ import {
     LoopStructure,
     ParameterBinding,
     StringConstant,
-    TypeContext,
+    TypeContext
 } from "../types";
 import { extend_string_array, trim_text } from "../utils";
 import { lower_instruction_range } from "./instructions";
@@ -71,7 +71,9 @@ fn lower_for_range(function: NativeFunction, structure: LoopStructure, raw_targe
     current_temp = start_result.temp_index;
 
     if start_result.operand == null {
-        diagnostics.push("llvm lowering: unable to lower `.for` range start in `" + function.name + "`");
+        diagnostics.push("llvm lowering: unable to lower `.for` range start in `"
+            + function.name
+            + "`");
         return BlockLoweringResult {
             lines: current_lines,
             allocas: current_allocas,
@@ -86,7 +88,7 @@ fn lower_for_range(function: NativeFunction, structure: LoopStructure, raw_targe
             next_lifetime_region_id: current_next_region,
             next_index: next_index,
             mutations: collected_mutations,
-            string_constants: collected_string_constants,
+            string_constants: collected_string_constants
         };
     }
 
@@ -101,7 +103,9 @@ fn lower_for_range(function: NativeFunction, structure: LoopStructure, raw_targe
     current_temp = end_result.temp_index;
 
     if end_result.operand == null {
-        diagnostics.push("llvm lowering: unable to lower `.for` range end in `" + function.name + "`");
+        diagnostics.push("llvm lowering: unable to lower `.for` range end in `"
+            + function.name
+            + "`");
         return BlockLoweringResult {
             lines: current_lines,
             allocas: current_allocas,
@@ -116,7 +120,7 @@ fn lower_for_range(function: NativeFunction, structure: LoopStructure, raw_targe
             next_lifetime_region_id: current_next_region,
             next_index: next_index,
             mutations: collected_mutations,
-            string_constants: collected_string_constants,
+            string_constants: collected_string_constants
         };
     }
 
@@ -130,7 +134,9 @@ fn lower_for_range(function: NativeFunction, structure: LoopStructure, raw_targe
     current_lines = start_coerced.lines;
     current_temp = start_coerced.temp_index;
     if start_coerced.operand == null {
-        diagnostics.push("llvm lowering: `.for` start expression must evaluate to `number` in `" + function.name + "`");
+        diagnostics.push("llvm lowering: `.for` start expression must evaluate to `number` in `"
+            + function.name
+            + "`");
         return BlockLoweringResult {
             lines: current_lines,
             allocas: current_allocas,
@@ -145,7 +151,7 @@ fn lower_for_range(function: NativeFunction, structure: LoopStructure, raw_targe
             next_lifetime_region_id: current_next_region,
             next_index: next_index,
             mutations: collected_mutations,
-            string_constants: collected_string_constants,
+            string_constants: collected_string_constants
         };
     }
     let start_operand = start_coerced.operand;
@@ -160,7 +166,9 @@ fn lower_for_range(function: NativeFunction, structure: LoopStructure, raw_targe
     current_lines = end_coerced.lines;
     current_temp = end_coerced.temp_index;
     if end_coerced.operand == null {
-        diagnostics.push("llvm lowering: `.for` end expression must evaluate to `number` in `" + function.name + "`");
+        diagnostics.push("llvm lowering: `.for` end expression must evaluate to `number` in `"
+            + function.name
+            + "`");
         return BlockLoweringResult {
             lines: current_lines,
             allocas: current_allocas,
@@ -175,7 +183,7 @@ fn lower_for_range(function: NativeFunction, structure: LoopStructure, raw_targe
             next_lifetime_region_id: current_next_region,
             next_index: next_index,
             mutations: collected_mutations,
-            string_constants: collected_string_constants,
+            string_constants: collected_string_constants
         };
     }
     let end_operand = end_coerced.operand;
@@ -197,7 +205,9 @@ fn lower_for_range(function: NativeFunction, structure: LoopStructure, raw_targe
         current_temp = stride_result.temp_index;
 
         if stride_result.operand == null {
-            diagnostics.push("llvm lowering: `.for` stride expression did not produce a value in `" + function.name + "`");
+            diagnostics.push("llvm lowering: `.for` stride expression did not produce a value in `"
+                + function.name
+                + "`");
             return BlockLoweringResult {
                 lines: current_lines,
                 allocas: current_allocas,
@@ -212,7 +222,7 @@ fn lower_for_range(function: NativeFunction, structure: LoopStructure, raw_targe
                 next_lifetime_region_id: current_next_region,
                 next_index: next_index,
                 mutations: collected_mutations,
-                string_constants: collected_string_constants,
+                string_constants: collected_string_constants
             };
         }
 
@@ -226,7 +236,9 @@ fn lower_for_range(function: NativeFunction, structure: LoopStructure, raw_targe
         current_lines = stride_coerced.lines;
         current_temp = stride_coerced.temp_index;
         if stride_coerced.operand == null {
-            diagnostics.push("llvm lowering: `.for` stride expression must evaluate to `number` in `" + function.name + "`");
+            diagnostics.push("llvm lowering: `.for` stride expression must evaluate to `number` in `"
+                + function.name
+                + "`");
             return BlockLoweringResult {
                 lines: current_lines,
                 allocas: current_allocas,
@@ -241,7 +253,7 @@ fn lower_for_range(function: NativeFunction, structure: LoopStructure, raw_targe
                 next_lifetime_region_id: current_next_region,
                 next_index: next_index,
                 mutations: collected_mutations,
-                string_constants: collected_string_constants,
+                string_constants: collected_string_constants
             };
         }
         stride_operand = stride_coerced.operand;
@@ -249,7 +261,9 @@ fn lower_for_range(function: NativeFunction, structure: LoopStructure, raw_targe
         if is_number_literal(stride_text) {
             let normalised_stride = normalise_number_literal(stride_text);
             if normalised_stride == "0.0" {
-                diagnostics.push("llvm lowering: `.for` stride must not be zero in `" + function.name + "`");
+                diagnostics.push("llvm lowering: `.for` stride must not be zero in `"
+                    + function.name
+                    + "`");
             }
         }
     }
@@ -257,7 +271,8 @@ fn lower_for_range(function: NativeFunction, structure: LoopStructure, raw_targe
     let stride_pointer = format_local_pointer_name(current_next_local);
     current_next_local += 1;
     current_allocas.push("  " + stride_pointer + " = alloca double");
-    current_lines.push("  store double " + stride_operand.value + ", double* " + stride_pointer);
+    current_lines.push("  store double " + stride_operand.value + ", double* "
+        + stride_pointer);
 
     let loop_header_alloc = allocate_block_label("for", current_block_counter);
     let loop_header_label = loop_header_alloc.label;
@@ -278,7 +293,8 @@ fn lower_for_range(function: NativeFunction, structure: LoopStructure, raw_targe
     let iteration_pointer = format_local_pointer_name(current_next_local);
     current_next_local += 1;
     current_allocas.push("  " + iteration_pointer + " = alloca double");
-    current_lines.push("  store double " + start_operand.value + ", double* " + iteration_pointer);
+    current_lines.push("  store double " + start_operand.value + ", double* "
+        + iteration_pointer);
 
     current_lines.push("  br label %" + loop_header_label);
     current_lines.push(loop_header_label + ":");
@@ -304,7 +320,9 @@ fn lower_for_range(function: NativeFunction, structure: LoopStructure, raw_targe
     current_temp = header_load.temp_index;
 
     if header_load.operand == null {
-        diagnostics.push("llvm lowering: internal error loading `.for` iteration value in `" + function.name + "`");
+        diagnostics.push("llvm lowering: internal error loading `.for` iteration value in `"
+            + function.name
+            + "`");
         current_lines.push("  br label %" + loop_exit_label);
         current_lines.push(loop_exit_label + ":");
         return BlockLoweringResult {
@@ -321,20 +339,25 @@ fn lower_for_range(function: NativeFunction, structure: LoopStructure, raw_targe
             next_lifetime_region_id: current_next_region,
             next_index: next_index,
             mutations: collected_mutations,
-            string_constants: collected_string_constants,
+            string_constants: collected_string_constants
         };
     }
 
     let stride_header_name = format_temp_name(current_temp);
-    current_lines.push("  " + stride_header_name + " = load double, double* " + stride_pointer);
+    current_lines.push("  " + stride_header_name + " = load double, double* "
+        + stride_pointer);
     current_temp += 1;
 
     let stride_positive_name = format_temp_name(current_temp);
-    current_lines.push("  " + stride_positive_name + " = fcmp ogt double " + stride_header_name + ", 0.0");
+    current_lines.push("  " + stride_positive_name + " = fcmp ogt double "
+        + stride_header_name
+        + ", 0.0");
     current_temp += 1;
 
     let stride_negative_name = format_temp_name(current_temp);
-    current_lines.push("  " + stride_negative_name + " = fcmp olt double " + stride_header_name + ", 0.0");
+    current_lines.push("  " + stride_negative_name + " = fcmp olt double "
+        + stride_header_name
+        + ", 0.0");
     current_temp += 1;
 
     let ascending_comparison = emit_comparison_instruction("<", header_load.operand, end_operand, current_temp, current_lines);
@@ -348,7 +371,9 @@ fn lower_for_range(function: NativeFunction, structure: LoopStructure, raw_targe
     current_temp = ascending_comparison.temp_index;
 
     if ascending_comparison.operand == null {
-        diagnostics.push("llvm lowering: unable to compare `.for` range bounds in `" + function.name + "`");
+        diagnostics.push("llvm lowering: unable to compare `.for` range bounds in `"
+            + function.name
+            + "`");
         current_lines.push("  br label %" + loop_exit_label);
         current_lines.push(loop_exit_label + ":");
         return BlockLoweringResult {
@@ -365,7 +390,7 @@ fn lower_for_range(function: NativeFunction, structure: LoopStructure, raw_targe
             next_lifetime_region_id: current_next_region,
             next_index: next_index,
             mutations: collected_mutations,
-            string_constants: collected_string_constants,
+            string_constants: collected_string_constants
         };
     }
 
@@ -380,7 +405,9 @@ fn lower_for_range(function: NativeFunction, structure: LoopStructure, raw_targe
     current_temp = descending_comparison.temp_index;
 
     if descending_comparison.operand == null {
-        diagnostics.push("llvm lowering: unable to compare descending `.for` range bounds in `" + function.name + "`");
+        diagnostics.push("llvm lowering: unable to compare descending `.for` range bounds in `"
+            + function.name
+            + "`");
         current_lines.push("  br label %" + loop_exit_label);
         current_lines.push(loop_exit_label + ":");
         return BlockLoweringResult {
@@ -397,23 +424,35 @@ fn lower_for_range(function: NativeFunction, structure: LoopStructure, raw_targe
             next_lifetime_region_id: current_next_region,
             next_index: next_index,
             mutations: collected_mutations,
-            string_constants: collected_string_constants,
+            string_constants: collected_string_constants
         };
     }
 
     let ascending_active_name = format_temp_name(current_temp);
-    current_lines.push("  " + ascending_active_name + " = and i1 " + stride_positive_name + ", " + ascending_comparison.operand.value);
+    current_lines.push("  " + ascending_active_name + " = and i1 "
+        + stride_positive_name
+        + ", "
+        + ascending_comparison.operand.value);
     current_temp += 1;
 
     let descending_active_name = format_temp_name(current_temp);
-    current_lines.push("  " + descending_active_name + " = and i1 " + stride_negative_name + ", " + descending_comparison.operand.value);
+    current_lines.push("  " + descending_active_name + " = and i1 "
+        + stride_negative_name
+        + ", "
+        + descending_comparison.operand.value);
     current_temp += 1;
 
     let continue_name = format_temp_name(current_temp);
-    current_lines.push("  " + continue_name + " = or i1 " + ascending_active_name + ", " + descending_active_name);
+    current_lines.push("  " + continue_name + " = or i1 "
+        + ascending_active_name
+        + ", "
+        + descending_active_name);
     current_temp += 1;
 
-    current_lines.push("  br i1 " + continue_name + ", label %" + loop_body_label + ", label %" + loop_exit_label);
+    current_lines.push("  br i1 " + continue_name + ", label %"
+        + loop_body_label
+        + ", label %"
+        + loop_exit_label);
     current_lines.push(loop_body_label + ":");
 
     let loop_context = LoopContext {
@@ -423,7 +462,8 @@ fn lower_for_range(function: NativeFunction, structure: LoopStructure, raw_targe
     let stacked = append_loop_context(loop_stack, loop_context);
 
     let body_locals = append_local_binding(current_locals, iteration_binding);
-    let body_result = lower_instruction_range(function, structure.body_start, structure.body_end, llvm_return, current_bindings, body_locals, current_allocas, [], current_temp, current_block_counter, current_next_local, current_next_region, functions, stacked, context, loop_body_scope_id, scope_depth + 1, loop_body_label);
+    let body_result = lower_instruction_range(function, structure.body_start, structure.body_end, llvm_return, current_bindings, body_locals, current_allocas, [], current_temp, current_block_counter, current_next_local, current_next_region, functions, stacked, context, loop_body_scope_id, scope_depth
+        + 1, loop_body_label);
     let mut _ci19: number = 0;
     loop {
         if _ci19 >= body_result.diagnostics.length { break; }
@@ -459,15 +499,23 @@ fn lower_for_range(function: NativeFunction, structure: LoopStructure, raw_targe
 
     if increment_load.operand != null {
         let increment_stride_name = format_temp_name(current_temp);
-        current_lines.push("  " + increment_stride_name + " = load double, double* " + stride_pointer);
+        current_lines.push("  " + increment_stride_name
+            + " = load double, double* "
+            + stride_pointer);
         current_temp += 1;
 
         let next_value_name = format_temp_name(current_temp);
-        current_lines.push("  " + next_value_name + " = fadd double " + increment_load.operand.value + ", " + increment_stride_name);
+        current_lines.push("  " + next_value_name + " = fadd double "
+            + increment_load.operand.value
+            + ", "
+            + increment_stride_name);
         current_temp += 1;
-        current_lines.push("  store double " + next_value_name + ", double* " + iteration_pointer);
+        current_lines.push("  store double " + next_value_name + ", double* "
+            + iteration_pointer);
     } else {
-        diagnostics.push("llvm lowering: unable to increment `.for` iterator in `" + function.name + "`");
+        diagnostics.push("llvm lowering: unable to increment `.for` iterator in `"
+            + function.name
+            + "`");
     }
 
     current_lines.push("  br label %" + loop_header_label);
@@ -494,7 +542,7 @@ fn lower_for_range(function: NativeFunction, structure: LoopStructure, raw_targe
         next_lifetime_region_id: current_next_region,
         next_index: next_index,
         mutations: collected_mutations,
-        string_constants: collected_string_constants,
+        string_constants: collected_string_constants
     };
 }
 
@@ -513,7 +561,11 @@ fn build_loop_exit_mutations(collected_mutations: LocalMutation[], locals: Local
         if local != null {
             let exit_load_temp = format_temp_name(current_temp);
             current_temp += 1;
-            current_lines.push("  " + exit_load_temp + " = load " + local.llvm_type + ", " + local.llvm_type + "* " + local.pointer);
+            current_lines.push("  " + exit_load_temp + " = load " + local.llvm_type
+                + ", "
+                + local.llvm_type
+                + "* "
+                + local.pointer);
             exit_loads.push(exit_load_temp);
         } else { exit_loads.push(""); }
         load_idx += 1;
@@ -546,7 +598,7 @@ fn build_loop_exit_mutations(collected_mutations: LocalMutation[], locals: Local
                 llvm_type: llvm_type,
                 value_name: exit_value,
                 span: original_span,
-                originating_label: exit_label,
+                originating_label: exit_label
             };
             exit_mutations.push(exit_mutation);
         }
@@ -567,6 +619,6 @@ fn build_loop_exit_mutations(collected_mutations: LocalMutation[], locals: Local
         next_lifetime_region_id: 0,
         next_index: 0,
         mutations: exit_mutations,
-        string_constants: empty_string_constant_set(),
+        string_constants: empty_string_constant_set()
     };
 }

--- a/compiler/src/llvm/lowering/instructions_for_range.sfn
+++ b/compiler/src/llvm/lowering/instructions_for_range.sfn
@@ -1,54 +1,42 @@
 // compiler/src/llvm/lowering/instructions_for_range.sfn
 //
 // Control flow handler: range-based for-loop instruction lowering.
-
 import { NativeFunction, NativeInstruction, NativeSourceSpan } from "../../native_ir";
-
-import {
-    TypeContext, LocalBinding, ParameterBinding, LLVMOperand,
-    BlockLoweringResult, LoopContext, LifetimeRegionMetadata,
-    LocalMutation, StringConstant, LoopStructure,
-} from "../types";
-
-import { trim_text, extend_string_array } from "../utils";
-import { empty_string_constant_set, merge_string_constants } from "../strings";
-import { find_local_binding } from "../expressions_bindings";
-import { is_number_literal, normalise_number_literal } from "../expressions_literals";
-import { format_local_pointer_name, format_temp_name } from "../expressions_helpers";
 import { lower_expression } from "../expression_lowering/native/core";
-import { coerce_operand_to_type, emit_comparison_instruction, load_local_operand } from "../expression_lowering/native/core_operands";
-import { append_local_binding } from "../expression_lowering/native/core_scopes";
+import {
+    coerce_operand_to_type,
+    emit_comparison_instruction,
+    load_local_operand
+} from "../expression_lowering/native/core_operands";
 import { parse_range_iterable } from "../expression_lowering/native/core_parse";
+import { append_local_binding } from "../expression_lowering/native/core_scopes";
+import { find_local_binding } from "../expressions_bindings";
+import { format_local_pointer_name, format_temp_name } from "../expressions_helpers";
+import { is_number_literal, normalise_number_literal } from "../expressions_literals";
 import { make_child_scope_id } from "../lifetime";
-import { collect_mutation_names, find_mutation_for_name } from "./phi";
+import { empty_string_constant_set, merge_string_constants } from "../strings";
+import {
+    BlockLoweringResult,
+    LLVMOperand,
+    LifetimeRegionMetadata,
+    LocalBinding,
+    LocalMutation,
+    LoopContext,
+    LoopStructure,
+    ParameterBinding,
+    StringConstant,
+    TypeContext,
+} from "../types";
+import { extend_string_array, trim_text } from "../utils";
 import { lower_instruction_range } from "./instructions";
-import { extend_lifetime_regions, extend_mutations, _parse_int_from_string } from "./instructions_helpers";
 import { allocate_block_label } from "./instructions_condition";
+import { _parse_int_from_string, extend_lifetime_regions, extend_mutations } from "./instructions_helpers";
 import { append_loop_context } from "./instructions_loops";
+import { collect_mutation_names, find_mutation_for_name } from "./phi";
 
 // Lower a range-based for loop (e.g., `for i in 0..10`).
 // Returns null if the iterable is not a recognized range pattern.
-fn lower_for_range(
-    function: NativeFunction,
-    structure: LoopStructure,
-    raw_target: string,
-    iterable_text: string,
-    llvm_return: string,
-    bindings: ParameterBinding[],
-    locals: LocalBinding[],
-    allocas: string[],
-    lines: string[],
-    temp_index: number,
-    block_counter: number,
-    next_local_id: number,
-    next_region_id: number,
-    functions: NativeFunction[],
-    loop_stack: LoopContext[],
-    context: TypeContext,
-    scope_id: string,
-    scope_depth: number,
-    next_index: number
-) -> BlockLoweringResult? {
+fn lower_for_range(function: NativeFunction, structure: LoopStructure, raw_target: string, iterable_text: string, llvm_return: string, bindings: ParameterBinding[], locals: LocalBinding[], allocas: string[], lines: string[], temp_index: number, block_counter: number, next_local_id: number, next_region_id: number, functions: NativeFunction[], loop_stack: LoopContext[], context: TypeContext, scope_id: string, scope_depth: number, next_index: number) -> BlockLoweringResult? {
     let mut diagnostics: string[] = [];
     let mut current_lines: string[] = lines;
     let mut current_allocas: string[] = allocas;
@@ -63,9 +51,7 @@ fn lower_for_range(
     let mut collected_string_constants: StringConstant[] = empty_string_constant_set();
 
     let range_parse = parse_range_iterable(iterable_text);
-    if !range_parse.success {
-        return null;
-    }
+    if !range_parse.success { return null; }
 
     let mut _ci9: number = 0;
     loop {
@@ -99,7 +85,8 @@ fn lower_for_range(
             lifetime_regions: lifetime_regions,
             next_lifetime_region_id: current_next_region,
             next_index: next_index,
-            mutations: collected_mutations, string_constants: collected_string_constants,
+            mutations: collected_mutations,
+            string_constants: collected_string_constants,
         };
     }
 
@@ -128,7 +115,8 @@ fn lower_for_range(
             lifetime_regions: lifetime_regions,
             next_lifetime_region_id: current_next_region,
             next_index: next_index,
-            mutations: collected_mutations, string_constants: collected_string_constants,
+            mutations: collected_mutations,
+            string_constants: collected_string_constants,
         };
     }
 
@@ -156,7 +144,8 @@ fn lower_for_range(
             lifetime_regions: lifetime_regions,
             next_lifetime_region_id: current_next_region,
             next_index: next_index,
-            mutations: collected_mutations, string_constants: collected_string_constants,
+            mutations: collected_mutations,
+            string_constants: collected_string_constants,
         };
     }
     let start_operand = start_coerced.operand;
@@ -185,12 +174,16 @@ fn lower_for_range(
             lifetime_regions: lifetime_regions,
             next_lifetime_region_id: current_next_region,
             next_index: next_index,
-            mutations: collected_mutations, string_constants: collected_string_constants,
+            mutations: collected_mutations,
+            string_constants: collected_string_constants,
         };
     }
     let end_operand = end_coerced.operand;
 
-    let mut stride_operand = LLVMOperand { llvm_type: "double", value: "1.0" };
+    let mut stride_operand = LLVMOperand {
+        llvm_type: "double",
+        value: "1.0"
+    };
     let stride_text = trim_text(range_parse.stride);
     if stride_text.length > 0 {
         let stride_result = lower_expression(stride_text, current_bindings, current_locals, current_temp, current_lines, functions, context, "");
@@ -218,7 +211,8 @@ fn lower_for_range(
                 lifetime_regions: lifetime_regions,
                 next_lifetime_region_id: current_next_region,
                 next_index: next_index,
-                mutations: collected_mutations, string_constants: collected_string_constants,
+                mutations: collected_mutations,
+                string_constants: collected_string_constants,
             };
         }
 
@@ -246,7 +240,8 @@ fn lower_for_range(
                 lifetime_regions: lifetime_regions,
                 next_lifetime_region_id: current_next_region,
                 next_index: next_index,
-                mutations: collected_mutations, string_constants: collected_string_constants,
+                mutations: collected_mutations,
+                string_constants: collected_string_constants,
             };
         }
         stride_operand = stride_coerced.operand;
@@ -288,7 +283,16 @@ fn lower_for_range(
     current_lines.push("  br label %" + loop_header_label);
     current_lines.push(loop_header_label + ":");
     let loop_body_scope_id = make_child_scope_id(scope_id, loop_body_label);
-    let iteration_binding = LocalBinding { name: raw_target, pointer: iteration_pointer, llvm_type: "double", type_annotation: "number", ownership: null, consumed: false, scope_id: loop_body_scope_id, scope_depth: scope_depth + 1 };
+    let iteration_binding = LocalBinding {
+        name: raw_target,
+        pointer: iteration_pointer,
+        llvm_type: "double",
+        type_annotation: "number",
+        ownership: null,
+        consumed: false,
+        scope_id: loop_body_scope_id,
+        scope_depth: scope_depth + 1
+    };
     let header_load = load_local_operand(iteration_binding, current_temp, current_lines);
     let mut _ci16: number = 0;
     loop {
@@ -316,7 +320,8 @@ fn lower_for_range(
             lifetime_regions: lifetime_regions,
             next_lifetime_region_id: current_next_region,
             next_index: next_index,
-            mutations: collected_mutations, string_constants: collected_string_constants,
+            mutations: collected_mutations,
+            string_constants: collected_string_constants,
         };
     }
 
@@ -359,7 +364,8 @@ fn lower_for_range(
             lifetime_regions: lifetime_regions,
             next_lifetime_region_id: current_next_region,
             next_index: next_index,
-            mutations: collected_mutations, string_constants: collected_string_constants,
+            mutations: collected_mutations,
+            string_constants: collected_string_constants,
         };
     }
 
@@ -390,7 +396,8 @@ fn lower_for_range(
             lifetime_regions: lifetime_regions,
             next_lifetime_region_id: current_next_region,
             next_index: next_index,
-            mutations: collected_mutations, string_constants: collected_string_constants,
+            mutations: collected_mutations,
+            string_constants: collected_string_constants,
         };
     }
 
@@ -409,30 +416,14 @@ fn lower_for_range(
     current_lines.push("  br i1 " + continue_name + ", label %" + loop_body_label + ", label %" + loop_exit_label);
     current_lines.push(loop_body_label + ":");
 
-    let loop_context = LoopContext { break_label: loop_exit_label, continue_label: loop_increment_label };
+    let loop_context = LoopContext {
+        break_label: loop_exit_label,
+        continue_label: loop_increment_label
+    };
     let stacked = append_loop_context(loop_stack, loop_context);
 
     let body_locals = append_local_binding(current_locals, iteration_binding);
-    let body_result = lower_instruction_range(
-        function,
-        structure.body_start,
-        structure.body_end,
-        llvm_return,
-        current_bindings,
-        body_locals,
-        current_allocas,
-        [],
-        current_temp,
-        current_block_counter,
-        current_next_local,
-        current_next_region,
-        functions,
-        stacked,
-        context,
-        loop_body_scope_id,
-        scope_depth + 1,
-        loop_body_label
-    );
+    let body_result = lower_instruction_range(function, structure.body_start, structure.body_end, llvm_return, current_bindings, body_locals, current_allocas, [], current_temp, current_block_counter, current_next_local, current_next_region, functions, stacked, context, loop_body_scope_id, scope_depth + 1, loop_body_label);
     let mut _ci19: number = 0;
     loop {
         if _ci19 >= body_result.diagnostics.length { break; }
@@ -502,18 +493,13 @@ fn lower_for_range(
         lifetime_regions: lifetime_regions,
         next_lifetime_region_id: current_next_region,
         next_index: next_index,
-        mutations: collected_mutations, string_constants: collected_string_constants,
+        mutations: collected_mutations,
+        string_constants: collected_string_constants,
     };
 }
 
 // Shared helper: build exit mutations for loop locals after the loop exit label.
-fn build_loop_exit_mutations(
-    collected_mutations: LocalMutation[],
-    locals: LocalBinding[],
-    lines: string[],
-    temp_index: number,
-    exit_label: string
-) -> BlockLoweringResult {
+fn build_loop_exit_mutations(collected_mutations: LocalMutation[], locals: LocalBinding[], lines: string[], temp_index: number, exit_label: string) -> BlockLoweringResult {
     let mut current_lines: string[] = lines;
     let mut current_temp: number = temp_index;
 
@@ -521,9 +507,7 @@ fn build_loop_exit_mutations(
     let mut exit_loads: string[] = [];
     let mut load_idx: number = 0;
     loop {
-        if load_idx >= mutated_names.length {
-            break;
-        }
+        if load_idx >= mutated_names.length { break; }
         let name = mutated_names[load_idx];
         let local = find_local_binding(locals, name);
         if local != null {
@@ -531,18 +515,14 @@ fn build_loop_exit_mutations(
             current_temp += 1;
             current_lines.push("  " + exit_load_temp + " = load " + local.llvm_type + ", " + local.llvm_type + "* " + local.pointer);
             exit_loads.push(exit_load_temp);
-        } else {
-            exit_loads.push("");
-        }
+        } else { exit_loads.push(""); }
         load_idx += 1;
     }
 
     let mut exit_mutations: LocalMutation[] = [];
     let mut exit_idx: number = 0;
     loop {
-        if exit_idx >= mutated_names.length {
-            break;
-        }
+        if exit_idx >= mutated_names.length { break; }
         let name = mutated_names[exit_idx];
         let mut exit_value: string = "";
         if exit_idx < exit_loads.length {
@@ -558,13 +538,9 @@ fn build_loop_exit_mutations(
             }
             if llvm_type.length == 0 {
                 let local = find_local_binding(locals, name);
-                if local != null {
-                    llvm_type = local.llvm_type;
-                }
+                if local != null { llvm_type = local.llvm_type; }
             }
-            if llvm_type.length == 0 {
-                llvm_type = "double";
-            }
+            if llvm_type.length == 0 { llvm_type = "double"; }
             let exit_mutation = LocalMutation {
                 name: name,
                 llvm_type: llvm_type,

--- a/compiler/src/llvm/lowering/instructions_helpers.sfn
+++ b/compiler/src/llvm/lowering/instructions_helpers.sfn
@@ -3,55 +3,41 @@
 // Shared helper utilities extracted from instructions.sfn so that
 // lower_instruction_range occupies position 1 in its module -- within
 // the v0.1.1 seed's per-module streaming emission limit.
-
 import { NativeFunction, NativeInstruction, NativeSourceSpan } from "../../native_ir";
-import { substring, char_code, grapheme_at } from "../../string_utils";
-
+import { char_code, grapheme_at, substring } from "../../string_utils";
+import { append_local_binding, } from "../expression_lowering/native/core_scopes";
+import { merge_string_constants, } from "../strings";
 import {
-    TypeContext,
-    LocalBinding,
-    ParameterBinding,
-    LLVMOperand,
     BlockLoweringResult,
+    LLVMOperand,
     LetLoweringResult,
-    LoopContext,
     LifetimeRegionMetadata,
     LifetimeReleaseEvent,
-    OwnershipInfo,
-    OwnershipConsumption,
-    ScopeMetadata,
+    LocalBinding,
     LocalMutation,
+    LoopContext,
+    OwnershipConsumption,
+    OwnershipInfo,
+    ParameterBinding,
+    ScopeMetadata,
     StringConstant,
+    TypeContext,
 } from "../types";
-
 import {
-    trim_text,
     append_string,
     extend_string_array,
-    number_to_string,
     index_of,
+    number_to_string,
     starts_with,
+    trim_text,
 } from "../utils";
-
-import {
-    merge_string_constants,
-} from "../strings";
-
-import {
-    append_local_binding,
-} from "../expression_lowering/native/core_scopes";
-
-import {
-    split_lines_local,
-} from "./lowering_text_utils";
+import { split_lines_local, } from "./lowering_text_utils";
 
 fn clone_local_bindings(values: LocalBinding[]) -> LocalBinding[] {
     let mut result: LocalBinding[] = [];
     let mut index: number = 0;
     loop {
-        if index >= values.length {
-            break;
-        }
+        if index >= values.length { break; }
         result.push(values[index]);
         index += 1;
     }
@@ -59,15 +45,11 @@ fn clone_local_bindings(values: LocalBinding[]) -> LocalBinding[] {
 }
 
 fn extend_lifetime_regions(values: LifetimeRegionMetadata[], extras: LifetimeRegionMetadata[]) -> LifetimeRegionMetadata[] {
-    if extras.length == 0 {
-        return values;
-    }
+    if extras.length == 0 { return values; }
     let mut out = values;
     let mut index: number = 0;
     loop {
-        if index >= extras.length {
-            break;
-        }
+        if index >= extras.length { break; }
         out = out.push(extras[index]);
         index += 1;
     }
@@ -75,15 +57,11 @@ fn extend_lifetime_regions(values: LifetimeRegionMetadata[], extras: LifetimeReg
 }
 
 fn extend_mutations(values: LocalMutation[], extras: LocalMutation[]) -> LocalMutation[] {
-    if extras.length == 0 {
-        return values;
-    }
+    if extras.length == 0 { return values; }
     let mut out = values;
     let mut index: number = 0;
     loop {
-        if index >= extras.length {
-            break;
-        }
+        if index >= extras.length { break; }
         out = out.push(extras[index]);
         index += 1;
     }
@@ -91,17 +69,13 @@ fn extend_mutations(values: LocalMutation[], extras: LocalMutation[]) -> LocalMu
 }
 
 fn insert_lines_before_index(lines: string[], index: number, insert_lines: string[]) -> string[] {
-    if insert_lines.length == 0 {
-        return lines;
-    }
+    if insert_lines.length == 0 { return lines; }
 
     let mut result: string[] = [];
     let mut line_idx: number = 0;
     let mut inserted: boolean = false;
     loop {
-        if line_idx >= lines.length {
-            break;
-        }
+        if line_idx >= lines.length { break; }
         if !inserted {
             if line_idx == index {
                 result = extend_string_array(result, insert_lines);
@@ -112,30 +86,15 @@ fn insert_lines_before_index(lines: string[], index: number, insert_lines: strin
         line_idx += 1;
     }
 
-    if !inserted {
-        result = extend_string_array(result, insert_lines);
-    }
+    if !inserted { result = extend_string_array(result, insert_lines); }
 
     return result;
 }
 
-fn _write_block_result_files(
-    lines: string[],
-    allocas: string[],
-    terminated: boolean,
-    diagnostics: string[],
-    string_constants: StringConstant[],
-    temp_index: number,
-    block_counter: number,
-    next_local_id: number,
-    next_lifetime_region_id: number,
-    next_index: number
-) ![io] {
+fn _write_block_result_files(lines: string[], allocas: string[], terminated: boolean, diagnostics: string[], string_constants: StringConstant[], temp_index: number, block_counter: number, next_local_id: number, next_lifetime_region_id: number, next_index: number) ![io] {
     // Only write the two IPC files that still have live readers.
     let mut term_val: string = "0";
-    if terminated {
-        term_val = "1";
-    }
+    if terminated { term_val = "1"; }
     fs.writeFile("build/sailfin/.block_result_terminated", term_val);
 
     let mut sc_lines: string[] = [];
@@ -156,13 +115,9 @@ fn _write_block_result_files(
 // corruption entirely.
 fn _read_ipc_terminated() -> boolean ![io] {
     let content = fs.readFile("build/sailfin/.block_result_terminated");
-    if content.length == 0 {
-        return false;
-    }
+    if content.length == 0 { return false; }
     let first_char = grapheme_at(content, 0);
-    if first_char == "1" {
-        return true;
-    }
+    if first_char == "1" { return true; }
     return false;
 }
 
@@ -172,24 +127,18 @@ fn _parse_int_from_string(text: string) -> number {
     let mut result: number = 0;
     let mut i: number = 0;
     let first_ch = grapheme_at(text, 0);
-    if first_ch == "-" {
-        i = 1;
-    }
+    if first_ch == "-" { i = 1; }
     loop {
         if i >= len { break; }
         let ch = grapheme_at(text, i);
         if ch == "." { break; }
         let code = char_code(ch);
         if code >= 48 {
-            if code <= 57 {
-                result = result * 10 + (code - 48);
-            }
+            if code <= 57 { result = result * 10 + (code - 48); }
         }
         i = i + 1;
     }
-    if first_ch == "-" {
-        return 0 - result;
-    }
+    if first_ch == "-" { return 0 - result; }
     return result;
 }
 
@@ -197,17 +146,11 @@ fn _parse_int_from_string(text: string) -> number {
 // This prevents temp_index resets to 0 when files are missing/empty/stale,
 // which otherwise causes duplicate SSA names (%tN) in LLVM IR.
 fn _read_ipc_int_min(path: string, floor_value: number) -> number ![io] {
-    if !fs.exists(path) {
-        return floor_value;
-    }
+    if !fs.exists(path) { return floor_value; }
     let text = fs.readFile(path);
-    if text.length == 0 {
-        return floor_value;
-    }
+    if text.length == 0 { return floor_value; }
     let parsed = _parse_int_from_string(text);
-    if parsed > floor_value {
-        return parsed;
-    }
+    if parsed > floor_value { return parsed; }
     return floor_value;
 }
 
@@ -293,7 +236,9 @@ fn read_block_result_string_constants(existing: StringConstant[]) -> StringConst
                 let _ct = substring(_r2, 0, _t2);
                 let _bct = substring(_r2, _t2 + 1, _r2.length);
                 let _bc = _parse_int_from_string(_bct);
-                result = merge_string_constants(result, [StringConstant { name: _nm, content: _ct, byte_count: _bc }]);
+                result = merge_string_constants(result, [StringConstant {
+                    name: _nm, content: _ct, byte_count: _bc
+                }]);
             }
         }
     }
@@ -329,7 +274,9 @@ fn read_expr_string_constants(existing: StringConstant[]) -> StringConstant[] ![
                 let _ct = substring(_r2, 0, _t2);
                 let _bct = substring(_r2, _t2 + 1, _r2.length);
                 let _bc = _parse_int_from_string(_bct);
-                result = merge_string_constants(result, [StringConstant { name: _nm, content: _ct, byte_count: _bc }]);
+                result = merge_string_constants(result, [StringConstant {
+                    name: _nm, content: _ct, byte_count: _bc
+                }]);
             }
         }
         fs.writeFile("build/sailfin/.expr_stmt_string_constants", "");
@@ -366,7 +313,9 @@ fn read_let_result_string_constants(existing: StringConstant[]) -> StringConstan
                 let _ct = substring(_r2, 0, _t2);
                 let _bct = substring(_r2, _t2 + 1, _r2.length);
                 let _bc = _parse_int_from_string(_bct);
-                result = merge_string_constants(result, [StringConstant { name: _nm, content: _ct, byte_count: _bc }]);
+                result = merge_string_constants(result, [StringConstant {
+                    name: _nm, content: _ct, byte_count: _bc
+                }]);
             }
         }
     }
@@ -376,14 +325,7 @@ fn read_let_result_string_constants(existing: StringConstant[]) -> StringConstan
 // Read let-lowering result from file IPC and update state.
 // Returns updated locals array.
 // Writes lines/allocas/scalar results to .let_ipc_* files for caller.
-fn read_let_result_from_files(
-    diagnostics: string[],
-    current_locals: LocalBinding[],
-    current_lines: string[],
-    current_allocas: string[],
-    scope_id: string,
-    scope_depth: number
-) -> LocalBinding[] ![io] {
+fn read_let_result_from_files(diagnostics: string[], current_locals: LocalBinding[], current_lines: string[], current_allocas: string[], scope_id: string, scope_depth: number) -> LocalBinding[] ![io] {
     let mut result_locals = current_locals;
     if fs.exists("build/sailfin/.let_result_temp_index") {
         // Read diagnostics from bulk file
@@ -421,15 +363,15 @@ fn read_let_result_from_files(
             let _pointer = fs.readFile("build/sailfin/.let_result_local_pointer");
             let _type = fs.readFile("build/sailfin/.let_result_local_llvm_type");
             let _ann = fs.readFile("build/sailfin/.let_result_local_type_ann");
-            result_locals = append_local_binding(result_locals, LocalBinding { name: _name, pointer: _pointer, llvm_type: _type, type_annotation: _ann, ownership: null, consumed: false, scope_id: scope_id, scope_depth: scope_depth });
+            result_locals = append_local_binding(result_locals, LocalBinding {
+                name: _name, pointer: _pointer, llvm_type: _type, type_annotation: _ann, ownership: null, consumed: false, scope_id: scope_id, scope_depth: scope_depth
+            });
         }
         fs.deleteFile("build/sailfin/.let_result_temp_index");
         if fs.exists("build/sailfin/.let_result_local_name") {
             fs.deleteFile("build/sailfin/.let_result_local_name");
         }
-    } else {
-        fs.writeFile("build/sailfin/.let_ipc_used", "0");
-    }
+    } else { fs.writeFile("build/sailfin/.let_ipc_used", "0"); }
     return result_locals;
 }
 
@@ -446,7 +388,7 @@ fn read_expr_mutations(existing: LocalMutation[]) -> LocalMutation[] ![io] {
         let _mv = fs.readFile(_mp + "_value");
         let _ml = fs.readFile(_mp + "_label");
         result = extend_mutations(result, [LocalMutation {
-                    name: _mn, llvm_type: _mt, value_name: _mv, span: null, originating_label: _ml,
+            name: _mn, llvm_type: _mt, value_name: _mv, span: null, originating_label: _ml,
         }]);
         _mi += 1;
     }
@@ -486,9 +428,7 @@ fn recover_temp_from_lines(lines: string[], floor: number) -> number {
                                 rj += 1;
                             }
                             if rvalid {
-                                if rn >= result {
-                                    result = rn + 1;
-                                }
+                                if rn >= result { result = rn + 1; }
                             }
                         }
                     }

--- a/compiler/src/llvm/lowering/instructions_helpers.sfn
+++ b/compiler/src/llvm/lowering/instructions_helpers.sfn
@@ -5,8 +5,8 @@
 // the v0.1.1 seed's per-module streaming emission limit.
 import { NativeFunction, NativeInstruction, NativeSourceSpan } from "../../native_ir";
 import { char_code, grapheme_at, substring } from "../../string_utils";
-import { append_local_binding, } from "../expression_lowering/native/core_scopes";
-import { merge_string_constants, } from "../strings";
+import { append_local_binding } from "../expression_lowering/native/core_scopes";
+import { merge_string_constants } from "../strings";
 import {
     BlockLoweringResult,
     LLVMOperand,
@@ -21,7 +21,7 @@ import {
     ParameterBinding,
     ScopeMetadata,
     StringConstant,
-    TypeContext,
+    TypeContext
 } from "../types";
 import {
     append_string,
@@ -29,9 +29,9 @@ import {
     index_of,
     number_to_string,
     starts_with,
-    trim_text,
+    trim_text
 } from "../utils";
-import { split_lines_local, } from "./lowering_text_utils";
+import { split_lines_local } from "./lowering_text_utils";
 
 fn clone_local_bindings(values: LocalBinding[]) -> LocalBinding[] {
     let mut result: LocalBinding[] = [];
@@ -101,7 +101,9 @@ fn _write_block_result_files(lines: string[], allocas: string[], terminated: boo
     let mut si: number = 0;
     loop {
         if si >= string_constants.length { break; }
-        sc_lines.push(string_constants[si].name + "\t" + string_constants[si].content + "\t" + number_to_string(string_constants[si].byte_count));
+        sc_lines.push(string_constants[si].name + "\t" + string_constants[si].content
+            + "\t"
+            + number_to_string(string_constants[si].byte_count));
         si = si + 1;
     }
     fs.writeLines("build/sailfin/.block_result_string_constants", sc_lines);
@@ -388,7 +390,7 @@ fn read_expr_mutations(existing: LocalMutation[]) -> LocalMutation[] ![io] {
         let _mv = fs.readFile(_mp + "_value");
         let _ml = fs.readFile(_mp + "_label");
         result = extend_mutations(result, [LocalMutation {
-            name: _mn, llvm_type: _mt, value_name: _mv, span: null, originating_label: _ml,
+            name: _mn, llvm_type: _mt, value_name: _mv, span: null, originating_label: _ml
         }]);
         _mi += 1;
     }

--- a/compiler/src/llvm/lowering/instructions_if.sfn
+++ b/compiler/src/llvm/lowering/instructions_if.sfn
@@ -3,16 +3,12 @@
 // Control flow handlers: if/else instruction lowering.
 import { NativeFunction, NativeInstruction, NativeSourceSpan } from "../../native_ir";
 import { char_code, grapheme_at, substring } from "../../string_utils";
-import { lower_expression, } from "../expression_lowering/native/core";
-import {
-    format_scope_id,
-    pop_scope_metadata,
-    push_scope_metadata,
-} from "../expression_lowering/native/core_scopes";
-import { find_local_binding, find_parameter_binding, } from "../expressions_bindings";
-import { default_return_literal, format_temp_name, } from "../expressions_helpers";
-import { make_child_scope_id, } from "../lifetime";
-import { append_string_constant, merge_string_constants, } from "../strings";
+import { lower_expression } from "../expression_lowering/native/core";
+import { format_scope_id, pop_scope_metadata, push_scope_metadata } from "../expression_lowering/native/core_scopes";
+import { find_local_binding, find_parameter_binding } from "../expressions_bindings";
+import { default_return_literal, format_temp_name } from "../expressions_helpers";
+import { make_child_scope_id } from "../lifetime";
+import { append_string_constant, merge_string_constants } from "../strings";
 import {
     BlockLoweringResult,
     IfStructure,
@@ -25,7 +21,7 @@ import {
     ParameterBinding,
     ScopeMetadata,
     StringConstant,
-    TypeContext,
+    TypeContext
 } from "../types";
 import {
     append_string,
@@ -37,22 +33,22 @@ import {
     number_to_string,
     starts_with,
     strip_mut_prefix,
-    trim_text,
+    trim_text
 } from "../utils";
-import { lower_instruction_range, } from "./instructions";
+import { lower_instruction_range } from "./instructions";
 import {
     allocate_block_label,
     lower_condition_to_i1,
-    sanitize_if_condition_text,
+    sanitize_if_condition_text
 } from "./instructions_condition";
 import {
     _parse_int_from_string,
     clone_local_bindings,
     extend_lifetime_regions,
     extend_mutations,
-    insert_lines_before_index,
+    insert_lines_before_index
 } from "./instructions_helpers";
-import { get_instruction_tag, } from "./lowering_native_helpers";
+import { get_instruction_tag } from "./lowering_native_helpers";
 import {
     collect_mutation_names,
     emit_phi_merges_for_if_else,
@@ -60,7 +56,7 @@ import {
     find_last_label,
     find_mutation_for_name,
     materialize_mutation_values_at_label,
-    retarget_recent_mutations,
+    retarget_recent_mutations
 } from "./phi";
 
 fn collect_if_structure(instructions: NativeInstruction[], start_index: number, end: number, function_name: string) -> IfStructure {
@@ -76,7 +72,9 @@ fn collect_if_structure(instructions: NativeInstruction[], start_index: number, 
     if limit > instructions.length { limit = instructions.length; }
     loop {
         if index >= limit {
-            diagnostics.push("llvm lowering: unterminated `.if` in `" + function_name + "`");
+            diagnostics.push("llvm lowering: unterminated `.if` in `"
+                + function_name
+                + "`");
             return IfStructure {
                 then_start: then_start,
                 then_end: limit,
@@ -84,7 +82,7 @@ fn collect_if_structure(instructions: NativeInstruction[], start_index: number, 
                 else_end: else_end,
                 has_else: has_else,
                 next_index: limit - 1,
-                diagnostics: diagnostics,
+                diagnostics: diagnostics
             };
         }
         let _cur_tag = get_instruction_tag(instructions, index);
@@ -103,7 +101,7 @@ fn collect_if_structure(instructions: NativeInstruction[], start_index: number, 
                     else_end: else_end,
                     has_else: has_else,
                     next_index: index,
-                    diagnostics: diagnostics,
+                    diagnostics: diagnostics
                 };
             }
             depth -= 1;
@@ -113,7 +111,9 @@ fn collect_if_structure(instructions: NativeInstruction[], start_index: number, 
         if _cur_tag == 4 {  // Else
             if depth == 0 {
                 if has_else {
-                    diagnostics.push("llvm lowering: duplicate `.else` in `.if` within `" + function_name + "`");
+                    diagnostics.push("llvm lowering: duplicate `.else` in `.if` within `"
+                        + function_name
+                        + "`");
                 } else {
                     has_else = true;
                     then_end = index;
@@ -133,7 +133,7 @@ fn collect_if_structure(instructions: NativeInstruction[], start_index: number, 
         else_end: else_end,
         has_else: has_else,
         next_index: limit,
-        diagnostics: diagnostics,
+        diagnostics: diagnostics
     };
 }
 
@@ -182,9 +182,15 @@ fn lower_if_instruction(function: NativeFunction, start_index: number, llvm_retu
     if condition.operand == null {
         let rendered_condition = sanitized_condition_source;
         if rendered_condition.length == 0 {
-            diagnostics.push("llvm lowering: unable to lower if condition in `" + function.name + "`");
+            diagnostics.push("llvm lowering: unable to lower if condition in `"
+                + function.name
+                + "`");
         } else {
-            diagnostics.push("llvm lowering: unable to lower if condition in `" + function.name + "` for `" + rendered_condition + "`");
+            diagnostics.push("llvm lowering: unable to lower if condition in `"
+                + function.name
+                + "` for `"
+                + rendered_condition
+                + "`");
         }
         return BlockLoweringResult {
             lines: current_lines,
@@ -200,7 +206,7 @@ fn lower_if_instruction(function: NativeFunction, start_index: number, llvm_retu
             next_lifetime_region_id: current_next_region,
             next_index: structure.next_index + 1,
             mutations: [],
-            string_constants: collected_string_constants,
+            string_constants: collected_string_constants
         };
     }
 
@@ -230,13 +236,20 @@ fn lower_if_instruction(function: NativeFunction, start_index: number, llvm_retu
         let local = current_locals[preload_index];
         let preload_temp = format_temp_name(current_temp);
         current_temp += 1;
-        let preload_line = "  " + preload_temp + " = load " + local.llvm_type + ", " + local.llvm_type + "* " + local.pointer;
+        let preload_line = "  " + preload_temp + " = load " + local.llvm_type
+            + ", "
+            + local.llvm_type
+            + "* "
+            + local.pointer;
         current_lines.push(preload_line);
         preloaded_locals.push(preload_temp);
         preload_index += 1;
     }
 
-    current_lines.push("  br i1 " + condition.operand.value + ", label %" + then_label + ", label %" + false_target);
+    current_lines.push("  br i1 " + condition.operand.value + ", label %"
+        + then_label
+        + ", label %"
+        + false_target);
 
     // Track the actual source block for the conditional branch so downstream phi nodes
     // reference the correct predecessor even when the condition introduced helper blocks
@@ -250,7 +263,8 @@ fn lower_if_instruction(function: NativeFunction, start_index: number, llvm_retu
 
     current_lines.push(then_label + ":");
     let then_scope_id = make_child_scope_id(scope_id, then_label);
-    let then_result = lower_instruction_range(function, structure.then_start, structure.then_end, llvm_return, bindings, base_locals, base_allocas, [], base_temp, base_block_counter, base_local_id, current_next_region, functions, loop_stack, context, then_scope_id, scope_depth + 1, then_label);
+    let then_result = lower_instruction_range(function, structure.then_start, structure.then_end, llvm_return, bindings, base_locals, base_allocas, [], base_temp, base_block_counter, base_local_id, current_next_region, functions, loop_stack, context, then_scope_id, scope_depth
+        + 1, then_label);
     let mut _ci14: number = 0;
     loop {
         if _ci14 >= then_result.diagnostics.length { break; }
@@ -285,7 +299,8 @@ fn lower_if_instruction(function: NativeFunction, start_index: number, llvm_retu
     if structure.has_else {
         current_lines.push(else_label + ":");
         let else_scope_id = make_child_scope_id(scope_id, else_label);
-        let else_result = lower_instruction_range(function, structure.else_start, structure.else_end, llvm_return, bindings, base_locals, current_allocas, [], current_temp, current_block_counter, current_next_local, current_next_region, functions, loop_stack, context, else_scope_id, scope_depth + 1, else_label);
+        let else_result = lower_instruction_range(function, structure.else_start, structure.else_end, llvm_return, bindings, base_locals, current_allocas, [], current_temp, current_block_counter, current_next_local, current_next_region, functions, loop_stack, context, else_scope_id, scope_depth
+            + 1, else_label);
         let mut _ci15: number = 0;
         loop {
             if _ci15 >= else_result.diagnostics.length { break; }
@@ -355,7 +370,14 @@ fn lower_if_instruction(function: NativeFunction, start_index: number, llvm_retu
                 if local != null {
                     let load_temp = format_temp_name(current_temp);
                     current_temp += 1;
-                    then_exit_loads = append_string(then_exit_loads, "  " + load_temp + " = load " + local.llvm_type + ", " + local.llvm_type + "* " + local.pointer);
+                    then_exit_loads = append_string(then_exit_loads, "  "
+                        + load_temp
+                        + " = load "
+                        + local.llvm_type
+                        + ", "
+                        + local.llvm_type
+                        + "* "
+                        + local.pointer);
                     let original = find_mutation_for_name(then_mutations, name);
                     let mut original_span: NativeSourceSpan? = null;
                     if original != null { original_span = original.span; }
@@ -364,7 +386,7 @@ fn lower_if_instruction(function: NativeFunction, start_index: number, llvm_retu
                         llvm_type: local.llvm_type,
                         value_name: load_temp,
                         span: original_span,
-                        originating_label: then_exit_label,
+                        originating_label: then_exit_label
                     };
                     then_added.push(exit_mutation);
                 }
@@ -384,7 +406,14 @@ fn lower_if_instruction(function: NativeFunction, start_index: number, llvm_retu
                     if local != null {
                         let load_temp = format_temp_name(current_temp);
                         current_temp += 1;
-                        else_exit_loads = append_string(else_exit_loads, "  " + load_temp + " = load " + local.llvm_type + ", " + local.llvm_type + "* " + local.pointer);
+                        else_exit_loads = append_string(else_exit_loads, "  "
+                            + load_temp
+                            + " = load "
+                            + local.llvm_type
+                            + ", "
+                            + local.llvm_type
+                            + "* "
+                            + local.pointer);
                         let original = find_mutation_for_name(else_mutations, name);
                         let mut original_span: NativeSourceSpan? = null;
                         if original != null { original_span = original.span; }
@@ -393,7 +422,7 @@ fn lower_if_instruction(function: NativeFunction, start_index: number, llvm_retu
                             llvm_type: local.llvm_type,
                             value_name: load_temp,
                             span: original_span,
-                            originating_label: else_exit_label,
+                            originating_label: else_exit_label
                         };
                         else_added.push(exit_mutation);
                     }
@@ -468,7 +497,14 @@ fn lower_if_instruction(function: NativeFunction, start_index: number, llvm_retu
                 if local != null {
                     let load_temp = format_temp_name(current_temp);
                     current_temp += 1;
-                    then_exit_loads = append_string(then_exit_loads, "  " + load_temp + " = load " + local.llvm_type + ", " + local.llvm_type + "* " + local.pointer);
+                    then_exit_loads = append_string(then_exit_loads, "  "
+                        + load_temp
+                        + " = load "
+                        + local.llvm_type
+                        + ", "
+                        + local.llvm_type
+                        + "* "
+                        + local.pointer);
                     let original = find_mutation_for_name(then_mutations, name);
                     let mut original_span: NativeSourceSpan? = null;
                     if original != null { original_span = original.span; }
@@ -477,7 +513,7 @@ fn lower_if_instruction(function: NativeFunction, start_index: number, llvm_retu
                         llvm_type: local.llvm_type,
                         value_name: load_temp,
                         span: original_span,
-                        originating_label: then_exit_label,
+                        originating_label: then_exit_label
                     };
                     then_added.push(exit_mutation);
                 }
@@ -573,6 +609,6 @@ fn lower_if_instruction(function: NativeFunction, start_index: number, llvm_retu
         next_lifetime_region_id: current_next_region,
         next_index: structure.next_index + 1,
         mutations: collected_mutations,
-        string_constants: collected_string_constants,
+        string_constants: collected_string_constants
     };
 }

--- a/compiler/src/llvm/lowering/instructions_if.sfn
+++ b/compiler/src/llvm/lowering/instructions_if.sfn
@@ -1,105 +1,69 @@
 // compiler/src/llvm/lowering/instructions_if.sfn
 //
 // Control flow handlers: if/else instruction lowering.
-
 import { NativeFunction, NativeInstruction, NativeSourceSpan } from "../../native_ir";
-import { substring, char_code, grapheme_at } from "../../string_utils";
-
-import {
-    TypeContext,
-    LocalBinding,
-    ParameterBinding,
-    LLVMOperand,
-    BlockLoweringResult,
-    LoopContext,
-    LifetimeRegionMetadata,
-    OwnershipInfo,
-    ScopeMetadata,
-    LocalMutation,
-    StringConstant,
-    IfStructure,
-} from "../types";
-
-import {
-    trim_text,
-    append_string,
-    extend_string_array,
-    number_to_string,
-    index_of,
-    starts_with,
-    strip_mut_prefix,
-    is_simple_identifier,
-    merge_parameter_bindings,
-    copy_string_array,
-} from "../utils";
-
-import {
-    append_string_constant,
-    merge_string_constants,
-} from "../strings";
-
-import {
-    find_local_binding,
-    find_parameter_binding,
-} from "../expressions_bindings";
-
-import {
-    default_return_literal,
-    format_temp_name,
-} from "../expressions_helpers";
-
-import {
-    lower_expression,
-} from "../expression_lowering/native/core";
-
+import { char_code, grapheme_at, substring } from "../../string_utils";
+import { lower_expression, } from "../expression_lowering/native/core";
 import {
     format_scope_id,
-    push_scope_metadata,
     pop_scope_metadata,
+    push_scope_metadata,
 } from "../expression_lowering/native/core_scopes";
-
+import { find_local_binding, find_parameter_binding, } from "../expressions_bindings";
+import { default_return_literal, format_temp_name, } from "../expressions_helpers";
+import { make_child_scope_id, } from "../lifetime";
+import { append_string_constant, merge_string_constants, } from "../strings";
 import {
-    make_child_scope_id,
-} from "../lifetime";
-
+    BlockLoweringResult,
+    IfStructure,
+    LLVMOperand,
+    LifetimeRegionMetadata,
+    LocalBinding,
+    LocalMutation,
+    LoopContext,
+    OwnershipInfo,
+    ParameterBinding,
+    ScopeMetadata,
+    StringConstant,
+    TypeContext,
+} from "../types";
 import {
-    emit_phi_merges_for_straight_if,
-    emit_phi_merges_for_if_else,
-    find_last_label,
-    retarget_recent_mutations,
-    materialize_mutation_values_at_label,
-    collect_mutation_names,
-    find_mutation_for_name,
-} from "./phi";
-
-import {
-    lower_instruction_range,
-} from "./instructions";
-
-import {
-    clone_local_bindings,
-    extend_lifetime_regions,
-    extend_mutations,
-    insert_lines_before_index,
-    _parse_int_from_string,
-} from "./instructions_helpers";
-
+    append_string,
+    copy_string_array,
+    extend_string_array,
+    index_of,
+    is_simple_identifier,
+    merge_parameter_bindings,
+    number_to_string,
+    starts_with,
+    strip_mut_prefix,
+    trim_text,
+} from "../utils";
+import { lower_instruction_range, } from "./instructions";
 import {
     allocate_block_label,
     lower_condition_to_i1,
     sanitize_if_condition_text,
 } from "./instructions_condition";
-
 import {
-    get_instruction_tag,
-} from "./lowering_native_helpers";
+    _parse_int_from_string,
+    clone_local_bindings,
+    extend_lifetime_regions,
+    extend_mutations,
+    insert_lines_before_index,
+} from "./instructions_helpers";
+import { get_instruction_tag, } from "./lowering_native_helpers";
+import {
+    collect_mutation_names,
+    emit_phi_merges_for_if_else,
+    emit_phi_merges_for_straight_if,
+    find_last_label,
+    find_mutation_for_name,
+    materialize_mutation_values_at_label,
+    retarget_recent_mutations,
+} from "./phi";
 
-fn collect_if_structure(
-    instructions: NativeInstruction[],
-    start_index: number,
-    end: number,
-    function_name: string
-) -> IfStructure {
+fn collect_if_structure(instructions: NativeInstruction[], start_index: number, end: number, function_name: string) -> IfStructure {
     let mut diagnostics: string[] = [];
     let then_start = start_index + 1;
     let mut then_end = end;
@@ -109,9 +73,7 @@ fn collect_if_structure(
     let mut depth: number = 0;
     let mut index: number = then_start;
     let mut limit: number = end;
-    if limit > instructions.length {
-        limit = instructions.length;
-    }
+    if limit > instructions.length { limit = instructions.length; }
     loop {
         if index >= limit {
             diagnostics.push("llvm lowering: unterminated `.if` in `" + function_name + "`");
@@ -133,11 +95,7 @@ fn collect_if_structure(
         }
         if _cur_tag == 5 {  // EndIf
             if depth == 0 {
-                if !has_else {
-                    then_end = index;
-                } else {
-                    else_end = index;
-                }
+                if !has_else { then_end = index; } else { else_end = index; }
                 return IfStructure {
                     then_start: then_start,
                     then_end: then_end,
@@ -179,26 +137,7 @@ fn collect_if_structure(
     };
 }
 
-fn lower_if_instruction(
-    function: NativeFunction,
-    start_index: number,
-    llvm_return: string,
-    bindings: ParameterBinding[],
-    locals: LocalBinding[],
-    allocas: string[],
-    lines: string[],
-    temp_index: number,
-    block_counter: number,
-    next_local_id: number,
-    next_region_id: number,
-    functions: NativeFunction[],
-    loop_stack: LoopContext[],
-    end: number,
-    context: TypeContext,
-    scope_id: string,
-    scope_depth: number,
-    current_label: string
-) -> BlockLoweringResult {
+fn lower_if_instruction(function: NativeFunction, start_index: number, llvm_return: string, bindings: ParameterBinding[], locals: LocalBinding[], allocas: string[], lines: string[], temp_index: number, block_counter: number, next_local_id: number, next_region_id: number, functions: NativeFunction[], loop_stack: LoopContext[], end: number, context: TypeContext, scope_id: string, scope_depth: number, current_label: string) -> BlockLoweringResult {
     let mut current_lines: string[] = lines;
     let base_lines_snapshot = copy_string_array(lines);
     let mut current_allocas: string[] = allocas;
@@ -229,16 +168,7 @@ fn lower_if_instruction(
     let rendered_condition_source = trim_text(function.instructions[start_index].condition);
     let sanitized_condition_source = sanitize_if_condition_text(rendered_condition_source);
 
-    let condition = lower_condition_to_i1(
-        function.name,
-        sanitized_condition_source,
-        bindings,
-        current_locals,
-        current_temp,
-        current_lines,
-        functions,
-        context
-    );
+    let condition = lower_condition_to_i1(function.name, sanitized_condition_source, bindings, current_locals, current_temp, current_lines, functions, context);
     let mut _ci13: number = 0;
     loop {
         if _ci13 >= condition.diagnostics.length { break; }
@@ -290,17 +220,13 @@ fn lower_if_instruction(
     current_block_counter = merge_alloc.next_counter;
 
     let mut false_target: string = merge_label;
-    if structure.has_else {
-        false_target = else_label;
-    }
+    if structure.has_else { false_target = else_label; }
 
     // Preload all locals before the branch (needed for phi nodes in both straight-line and if/else cases)
     let mut preloaded_locals: string[] = [];
     let mut preload_index: number = 0;
     loop {
-        if preload_index >= current_locals.length {
-            break;
-        }
+        if preload_index >= current_locals.length { break; }
         let local = current_locals[preload_index];
         let preload_temp = format_temp_name(current_temp);
         current_temp += 1;
@@ -324,26 +250,7 @@ fn lower_if_instruction(
 
     current_lines.push(then_label + ":");
     let then_scope_id = make_child_scope_id(scope_id, then_label);
-    let then_result = lower_instruction_range(
-        function,
-        structure.then_start,
-        structure.then_end,
-        llvm_return,
-        bindings,
-        base_locals,
-        base_allocas,
-        [],
-        base_temp,
-        base_block_counter,
-        base_local_id,
-        current_next_region,
-        functions,
-        loop_stack,
-        context,
-        then_scope_id,
-        scope_depth + 1,
-        then_label
-    );
+    let then_result = lower_instruction_range(function, structure.then_start, structure.then_end, llvm_return, bindings, base_locals, base_allocas, [], base_temp, base_block_counter, base_local_id, current_next_region, functions, loop_stack, context, then_scope_id, scope_depth + 1, then_label);
     let mut _ci14: number = 0;
     loop {
         if _ci14 >= then_result.diagnostics.length { break; }
@@ -378,26 +285,7 @@ fn lower_if_instruction(
     if structure.has_else {
         current_lines.push(else_label + ":");
         let else_scope_id = make_child_scope_id(scope_id, else_label);
-        let else_result = lower_instruction_range(
-            function,
-            structure.else_start,
-            structure.else_end,
-            llvm_return,
-            bindings,
-            base_locals,
-            current_allocas,
-            [],
-            current_temp,
-            current_block_counter,
-            current_next_local,
-            current_next_region,
-            functions,
-            loop_stack,
-            context,
-            else_scope_id,
-            scope_depth + 1,
-            else_label
-        );
+        let else_result = lower_instruction_range(function, structure.else_start, structure.else_end, llvm_return, bindings, base_locals, current_allocas, [], current_temp, current_block_counter, current_next_local, current_next_region, functions, loop_stack, context, else_scope_id, scope_depth + 1, else_label);
         let mut _ci15: number = 0;
         loop {
             if _ci15 >= else_result.diagnostics.length { break; }
@@ -432,9 +320,7 @@ fn lower_if_instruction(
         let mut _if232: boolean = false;
         if !then_terminated { _if232 = true; }
         if !else_terminated { _if232 = true; }
-        if _if232 {
-            _if227 = true;
-        }
+        if _if232 { _if227 = true; }
     }
     if _if227 {
         let then_names = collect_mutation_names(then_mutations);
@@ -442,25 +328,19 @@ fn lower_if_instruction(
         let mut mutated_names: string[] = then_names;
         let mut else_idx: number = 0;
         loop {
-            if else_idx >= else_names.length {
-                break;
-            }
+            if else_idx >= else_names.length { break; }
             let else_name = else_names[else_idx];
             let mut already_added: boolean = false;
             let mut check_idx: number = 0;
             loop {
-                if check_idx >= mutated_names.length {
-                    break;
-                }
+                if check_idx >= mutated_names.length { break; }
                 if mutated_names[check_idx] == else_name {
                     already_added = true;
                     break;
                 }
                 check_idx += 1;
             }
-            if !already_added {
-                mutated_names.push(else_name);
-            }
+            if !already_added { mutated_names.push(else_name); }
             else_idx += 1;
         }
 
@@ -469,23 +349,16 @@ fn lower_if_instruction(
         if !then_terminated {
             let mut name_idx: number = 0;
             loop {
-                if name_idx >= mutated_names.length {
-                    break;
-                }
+                if name_idx >= mutated_names.length { break; }
                 let name = mutated_names[name_idx];
                 let local = find_local_binding(base_locals, name);
                 if local != null {
                     let load_temp = format_temp_name(current_temp);
                     current_temp += 1;
-                    then_exit_loads = append_string(
-                        then_exit_loads,
-                        "  " + load_temp + " = load " + local.llvm_type + ", " + local.llvm_type + "* " + local.pointer
-                    );
+                    then_exit_loads = append_string(then_exit_loads, "  " + load_temp + " = load " + local.llvm_type + ", " + local.llvm_type + "* " + local.pointer);
                     let original = find_mutation_for_name(then_mutations, name);
                     let mut original_span: NativeSourceSpan? = null;
-                    if original != null {
-                        original_span = original.span;
-                    }
+                    if original != null { original_span = original.span; }
                     let exit_mutation = LocalMutation {
                         name: name,
                         llvm_type: local.llvm_type,
@@ -505,23 +378,16 @@ fn lower_if_instruction(
             if !else_terminated {
                 let mut name_idx: number = 0;
                 loop {
-                    if name_idx >= mutated_names.length {
-                        break;
-                    }
+                    if name_idx >= mutated_names.length { break; }
                     let name = mutated_names[name_idx];
                     let local = find_local_binding(base_locals, name);
                     if local != null {
                         let load_temp = format_temp_name(current_temp);
                         current_temp += 1;
-                        else_exit_loads = append_string(
-                            else_exit_loads,
-                            "  " + load_temp + " = load " + local.llvm_type + ", " + local.llvm_type + "* " + local.pointer
-                        );
+                        else_exit_loads = append_string(else_exit_loads, "  " + load_temp + " = load " + local.llvm_type + ", " + local.llvm_type + "* " + local.pointer);
                         let original = find_mutation_for_name(else_mutations, name);
                         let mut original_span: NativeSourceSpan? = null;
-                        if original != null {
-                            original_span = original.span;
-                        }
+                        if original != null { original_span = original.span; }
                         let exit_mutation = LocalMutation {
                             name: name,
                             llvm_type: local.llvm_type,
@@ -596,23 +462,16 @@ fn lower_if_instruction(
             let mut then_added: LocalMutation[] = [];
             let mut name_idx: number = 0;
             loop {
-                if name_idx >= mutated_names.length {
-                    break;
-                }
+                if name_idx >= mutated_names.length { break; }
                 let name = mutated_names[name_idx];
                 let local = find_local_binding(base_locals, name);
                 if local != null {
                     let load_temp = format_temp_name(current_temp);
                     current_temp += 1;
-                    then_exit_loads = append_string(
-                        then_exit_loads,
-                        "  " + load_temp + " = load " + local.llvm_type + ", " + local.llvm_type + "* " + local.pointer
-                    );
+                    then_exit_loads = append_string(then_exit_loads, "  " + load_temp + " = load " + local.llvm_type + ", " + local.llvm_type + "* " + local.pointer);
                     let original = find_mutation_for_name(then_mutations, name);
                     let mut original_span: NativeSourceSpan? = null;
-                    if original != null {
-                        original_span = original.span;
-                    }
+                    if original != null { original_span = original.span; }
                     let exit_mutation = LocalMutation {
                         name: name,
                         llvm_type: local.llvm_type,
@@ -638,9 +497,7 @@ fn lower_if_instruction(
     if structure.has_else {
         let mut _asgn228: boolean = false;
         if then_terminated {
-            if else_terminated {
-                _asgn228 = true;
-            }
+            if else_terminated { _asgn228 = true; }
         }
         terminated = _asgn228;
     }
@@ -659,34 +516,13 @@ fn lower_if_instruction(
             if !then_terminated { _if235 = true; }
             if !else_terminated { _if235 = true; }
             if _if235 {
-                if collected_mutations.length > 0 {
-                    _if233 = true;
-                }
+                if collected_mutations.length > 0 { _if233 = true; }
             }
             if _if233 {
-                let phi_result = emit_phi_merges_for_if_else(
-                    then_mutations,
-                    else_mutations,
-                    base_locals,
-                    preloaded_locals,
-                    then_label,
-                    else_label,
-                    then_exit_label,
-                    else_exit_label,
-                    then_terminated,
-                    else_terminated,
-                    current_lines,
-                    current_temp
-                );
+                let phi_result = emit_phi_merges_for_if_else(then_mutations, else_mutations, base_locals, preloaded_locals, then_label, else_label, then_exit_label, else_exit_label, then_terminated, else_terminated, current_lines, current_temp);
                 current_lines = phi_result.lines;
                 current_temp = phi_result.temp_index;
-                let materialized = materialize_mutation_values_at_label(
-                    collected_mutations,
-                    base_locals,
-                    current_lines,
-                    current_temp,
-                    merge_label
-                );
+                let materialized = materialize_mutation_values_at_label(collected_mutations, base_locals, current_lines, current_temp, merge_label);
                 current_lines = materialized.lines;
                 current_temp = materialized.temp_index;
                 collected_mutations = materialized.mutations;
@@ -695,25 +531,10 @@ fn lower_if_instruction(
             // Straight-line if: emit phi nodes merging then branch with base
             if !then_terminated {
                 if collected_mutations.length > 0 {
-                    let phi_result = emit_phi_merges_for_straight_if(
-                        collected_mutations,
-                        base_locals,
-                        preloaded_locals,
-                        branch_label,
-                        then_label,
-                        then_exit_label,
-                        current_lines,
-                        current_temp
-                    );
+                    let phi_result = emit_phi_merges_for_straight_if(collected_mutations, base_locals, preloaded_locals, branch_label, then_label, then_exit_label, current_lines, current_temp);
                     current_lines = phi_result.lines;
                     current_temp = phi_result.temp_index;
-                    let materialized = materialize_mutation_values_at_label(
-                        collected_mutations,
-                        base_locals,
-                        current_lines,
-                        current_temp,
-                        merge_label
-                    );
+                    let materialized = materialize_mutation_values_at_label(collected_mutations, base_locals, current_lines, current_temp, merge_label);
                     current_lines = materialized.lines;
                     current_temp = materialized.temp_index;
                     collected_mutations = materialized.mutations;
@@ -751,6 +572,7 @@ fn lower_if_instruction(
         lifetime_regions: lifetime_regions,
         next_lifetime_region_id: current_next_region,
         next_index: structure.next_index + 1,
-        mutations: collected_mutations, string_constants: collected_string_constants,
+        mutations: collected_mutations,
+        string_constants: collected_string_constants,
     };
 }

--- a/compiler/src/llvm/lowering/instructions_let.sfn
+++ b/compiler/src/llvm/lowering/instructions_let.sfn
@@ -2,32 +2,24 @@
 //
 // Let binding instruction lowering.
 import { NativeFunction, NativeInstruction, NativeSourceSpan } from "../../native_ir";
-import {
-    analyze_value_ownership,
-    detect_borrow_conflicts,
-    lower_expression,
-} from "../expression_lowering/native/core";
-import { coerce_operand_to_type, } from "../expression_lowering/native/core_operands";
-import { append_local_binding, } from "../expression_lowering/native/core_scopes";
-import { detect_suspension_conflicts, } from "../expression_lowering/native/statement_suspension";
-import { map_local_type, } from "../expression_lowering/native/statement_type_mapping";
-import {
-    find_local_binding,
-    mark_local_consumed,
-    mark_parameter_consumed,
-} from "../expressions_bindings";
-import { default_return_literal, format_local_pointer_name, } from "../expressions_helpers";
+import { analyze_value_ownership, detect_borrow_conflicts, lower_expression } from "../expression_lowering/native/core";
+import { coerce_operand_to_type } from "../expression_lowering/native/core_operands";
+import { append_local_binding } from "../expression_lowering/native/core_scopes";
+import { detect_suspension_conflicts } from "../expression_lowering/native/statement_suspension";
+import { map_local_type } from "../expression_lowering/native/statement_type_mapping";
+import { find_local_binding, mark_local_consumed, mark_parameter_consumed } from "../expressions_bindings";
+import { default_return_literal, format_local_pointer_name } from "../expressions_helpers";
 import {
     append_lifetime_region,
     append_lifetime_release_event,
     infer_borrow_base_scope,
-    make_lifetime_region_metadata,
+    make_lifetime_region_metadata
 } from "../lifetime";
-import { empty_string_constant_set, merge_string_constants, } from "../strings";
+import { empty_string_constant_set, merge_string_constants } from "../strings";
 import {
     find_interface_info_by_name,
     find_struct_info_by_llvm_type,
-    find_vtable_for_struct_interface,
+    find_vtable_for_struct_interface
 } from "../type_context_queries";
 import {
     LLVMOperand,
@@ -40,9 +32,9 @@ import {
     OwnershipInfo,
     ParameterBinding,
     StringConstant,
-    TypeContext,
+    TypeContext
 } from "../types";
-import { number_to_string, trim_text, } from "../utils";
+import { number_to_string, trim_text } from "../utils";
 
 fn lower_let_instruction(function: NativeFunction, instruction: NativeInstruction, bindings: ParameterBinding[], locals: LocalBinding[], allocas: string[], lines: string[], temp_index: number, next_local_id: number, next_region_id: number, functions: NativeFunction[], context: TypeContext, scope_id: string, scope_depth: number, current_label: string) -> LetLoweringResult ![io] {
     let mut diagnostics: string[] = [];
@@ -91,7 +83,11 @@ fn lower_let_instruction(function: NativeFunction, instruction: NativeInstructio
     if trimmed_annotation.length > 0 {
         llvm_type = map_local_type(context, instruction.type_annotation);
         if llvm_type.length == 0 {
-            diagnostics.push("llvm lowering: unsupported local type for `" + instruction.name + "` in `" + function.name + "`");
+            diagnostics.push("llvm lowering: unsupported local type for `"
+                + instruction.name
+                + "` in `"
+                + function.name
+                + "`");
         }
     }
 
@@ -122,7 +118,7 @@ fn lower_let_instruction(function: NativeFunction, instruction: NativeInstructio
                 base: ownership.base,
                 mutable: ownership.mutable,
                 span: ownership.span,
-                region_id: region_id,
+                region_id: region_id
             };
             let region = make_lifetime_region_metadata(region_id, instruction.name, ownership, scope_id, scope_depth, base_scope.scope_id, base_scope.scope_depth);
             lifetime_regions = append_lifetime_region(lifetime_regions, region);
@@ -132,7 +128,7 @@ fn lower_let_instruction(function: NativeFunction, instruction: NativeInstructio
                 base: ownership.base,
                 mutable: ownership.mutable,
                 span: ownership.span,
-                region_id: -1,
+                region_id: -1
             };
         }
     }
@@ -150,7 +146,10 @@ fn lower_let_instruction(function: NativeFunction, instruction: NativeInstructio
     if instruction.value == null { _if230 = true; }
     if instruction.value.length == 0 { _if230 = true; }
     if _if230 {
-        diagnostics.push("llvm lowering: let `" + instruction.name + "` missing initializer in `" + function.name + "`");
+        diagnostics.push("llvm lowering: let `" + instruction.name
+            + "` missing initializer in `"
+            + function.name
+            + "`");
     } else {
         // Clear stale call-result files before expression lowering so that only
         // a call from THIS let's initializer can populate them.
@@ -161,7 +160,9 @@ fn lower_let_instruction(function: NativeFunction, instruction: NativeInstructio
             fs.deleteFile("build/sailfin/.call_result_value");
         }
         if fs.exists("build/sailfin/.trace_lowering") {
-            print.err("let-lowering: pre-lower_expression name=" + instruction.name + " value=" + instruction.value);
+            print.err("let-lowering: pre-lower_expression name=" + instruction.name
+                + " value="
+                + instruction.value);
         }
         let _pre_expr_line_count = current_lines.length;
         let lowered = lower_expression(instruction.value, current_bindings, current_locals, current_temp, current_lines, functions, context, llvm_type);
@@ -192,7 +193,8 @@ fn lower_let_instruction(function: NativeFunction, instruction: NativeInstructio
         }
         current_temp = lowered.temp_index;
         if fs.exists("build/sailfin/.trace_lowering") {
-            print.err("let-lowering: got temp_index=" + number_to_string(current_temp) + ", accessing operand");
+            print.err("let-lowering: got temp_index=" + number_to_string(current_temp)
+                + ", accessing operand");
         }
         operand = lowered.operand;
         if fs.exists("build/sailfin/.trace_lowering") {
@@ -261,17 +263,42 @@ fn lower_let_instruction(function: NativeFunction, instruction: NativeInstructio
                     current_temp += 1;
 
                     // Allocate space for the struct on the stack
-                    current_lines.push("  " + struct_ptr_temp + " = alloca " + struct_info.llvm_name);
+                    current_lines.push("  " + struct_ptr_temp + " = alloca "
+                        + struct_info.llvm_name);
                     // Store the struct value
-                    current_lines.push("  store " + operand.llvm_type + " " + operand.value + ", " + operand.llvm_type + "* " + struct_ptr_temp);
+                    current_lines.push("  store " + operand.llvm_type + " "
+                        + operand.value
+                        + ", "
+                        + operand.llvm_type
+                        + "* "
+                        + struct_ptr_temp);
                     // Cast struct pointer to i8*
-                    current_lines.push("  " + data_ptr_temp + " = bitcast " + struct_info.llvm_name + "* " + struct_ptr_temp + " to i8*");
+                    current_lines.push("  " + data_ptr_temp + " = bitcast "
+                        + struct_info.llvm_name
+                        + "* "
+                        + struct_ptr_temp
+                        + " to i8*");
                     // Get vtable pointer (bitcast global vtable constant to i8*)
-                    current_lines.push("  " + vtable_ptr_temp + " = bitcast " + vtable.llvm_type_name + "* " + vtable.llvm_global_name + " to i8*");
+                    current_lines.push("  " + vtable_ptr_temp + " = bitcast "
+                        + vtable.llvm_type_name
+                        + "* "
+                        + vtable.llvm_global_name
+                        + " to i8*");
                     // Build trait object: insert data pointer
-                    current_lines.push("  " + with_data_temp + " = insertvalue " + interface_info.llvm_name + " undef, i8* " + data_ptr_temp + ", 0");
+                    current_lines.push("  " + with_data_temp + " = insertvalue "
+                        + interface_info.llvm_name
+                        + " undef, i8* "
+                        + data_ptr_temp
+                        + ", 0");
                     // Insert vtable pointer
-                    current_lines.push("  " + with_vtable_temp + " = insertvalue " + interface_info.llvm_name + " " + with_data_temp + ", i8* " + vtable_ptr_temp + ", 1");
+                    current_lines.push("  " + with_vtable_temp
+                        + " = insertvalue "
+                        + interface_info.llvm_name
+                        + " "
+                        + with_data_temp
+                        + ", i8* "
+                        + vtable_ptr_temp
+                        + ", 1");
                     // Update operand to the boxed trait object
                     operand = LLVMOperand {
                         llvm_type: interface_info.llvm_name,
@@ -279,7 +306,10 @@ fn lower_let_instruction(function: NativeFunction, instruction: NativeInstructio
                     };
                     llvm_type = interface_info.llvm_name;
                 } else {
-                    diagnostics.push("llvm lowering: struct `" + struct_info.name + "` does not implement interface `" + interface_info.name + "`");
+                    diagnostics.push("llvm lowering: struct `" + struct_info.name
+                        + "` does not implement interface `"
+                        + interface_info.name
+                        + "`");
                 }
             }
         }
@@ -314,7 +344,10 @@ fn lower_let_instruction(function: NativeFunction, instruction: NativeInstructio
                         value: _fixup_value
                     };
                     if fs.exists("build/sailfin/.trace_lowering") {
-                        print.err("let-lowering: operand reconstructed type=" + _fixup_type + " value=" + _fixup_value);
+                        print.err("let-lowering: operand reconstructed type="
+                            + _fixup_type
+                            + " value="
+                            + _fixup_value);
                     }
                 }
             }
@@ -324,9 +357,15 @@ fn lower_let_instruction(function: NativeFunction, instruction: NativeInstructio
         if operand.llvm_type == llvm_type {
             // Identity coercion — use operand directly
             stored_value = operand.value;
-            current_lines.push("  store " + llvm_type + " " + operand.value + ", " + llvm_type + "* " + pointer);
+            current_lines.push("  store " + llvm_type + " " + operand.value
+                + ", "
+                + llvm_type
+                + "* "
+                + pointer);
             if fs.exists("build/sailfin/.trace_lowering") {
-                print.err("let-lowering: identity coerce type=" + llvm_type + " value=" + operand.value);
+                print.err("let-lowering: identity coerce type=" + llvm_type
+                    + " value="
+                    + operand.value);
             }
         } else {
             // Types differ — need coercion. Since coerce_operand_to_type returns
@@ -339,10 +378,23 @@ fn lower_let_instruction(function: NativeFunction, instruction: NativeInstructio
                 let _cr_value = fs.readFile("build/sailfin/.coerce_result_value");
                 if _cr_type.length > 0 {
                     stored_value = _cr_value;
-                    current_lines.push("  store " + llvm_type + " " + _cr_value + ", " + llvm_type + "* " + pointer);
+                    current_lines.push("  store " + llvm_type + " " + _cr_value
+                        + ", "
+                        + llvm_type
+                        + "* "
+                        + pointer);
                 } else {
-                    diagnostics.push("llvm lowering: unable to coerce initializer for `" + instruction.name + "` to `" + llvm_type + "`");
-                    current_lines.push("  store " + llvm_type + " " + default_return_literal(llvm_type) + ", " + llvm_type + "* " + pointer);
+                    diagnostics.push("llvm lowering: unable to coerce initializer for `"
+                        + instruction.name
+                        + "` to `"
+                        + llvm_type
+                        + "`");
+                    current_lines.push("  store " + llvm_type + " "
+                        + default_return_literal(llvm_type)
+                        + ", "
+                        + llvm_type
+                        + "* "
+                        + pointer);
                 }
                 fs.deleteFile("build/sailfin/.coerce_result_type");
             } else {
@@ -356,17 +408,34 @@ fn lower_let_instruction(function: NativeFunction, instruction: NativeInstructio
                 current_lines = coerced.lines;
                 current_temp = coerced.temp_index;
                 if coerced.operand == null {
-                    diagnostics.push("llvm lowering: unable to coerce initializer for `" + instruction.name + "` to `" + llvm_type + "`");
-                    current_lines.push("  store " + llvm_type + " " + default_return_literal(llvm_type) + ", " + llvm_type + "* " + pointer);
+                    diagnostics.push("llvm lowering: unable to coerce initializer for `"
+                        + instruction.name
+                        + "` to `"
+                        + llvm_type
+                        + "`");
+                    current_lines.push("  store " + llvm_type + " "
+                        + default_return_literal(llvm_type)
+                        + ", "
+                        + llvm_type
+                        + "* "
+                        + pointer);
                 } else {
                     let stored = coerced.operand;
                     stored_value = stored.value;
-                    current_lines.push("  store " + llvm_type + " " + stored.value + ", " + llvm_type + "* " + pointer);
+                    current_lines.push("  store " + llvm_type + " " + stored.value
+                        + ", "
+                        + llvm_type
+                        + "* "
+                        + pointer);
                 }
             }
         }
     } else {
-        current_lines.push("  store " + llvm_type + " " + default_return_literal(llvm_type) + ", " + llvm_type + "* " + pointer);
+        current_lines.push("  store " + llvm_type + " " + default_return_literal(llvm_type)
+            + ", "
+            + llvm_type
+            + "* "
+            + pointer);
     }
 
     // For locals that hold async futures, store the underlying return type
@@ -388,12 +457,13 @@ fn lower_let_instruction(function: NativeFunction, instruction: NativeInstructio
         llvm_type: llvm_type,
         value_name: stored_value,
         span: initializer_span,
-        originating_label: current_label,
+        originating_label: current_label
     };
     mutations.push(mutation);
 
     if fs.exists("build/sailfin/.trace_lowering") {
-        print.err("let-lowering: returning LetLoweringResult for name=" + instruction.name);
+        print.err("let-lowering: returning LetLoweringResult for name="
+            + instruction.name);
     }
     return LetLoweringResult {
         lines: current_lines,
@@ -407,7 +477,7 @@ fn lower_let_instruction(function: NativeFunction, instruction: NativeInstructio
         lifetime_releases: lifetime_releases,
         next_region_id: current_next_region,
         mutations: mutations,
-        string_constants: string_constants,
+        string_constants: string_constants
     };
 }
 
@@ -431,7 +501,8 @@ fn _infer_field_constants_from_lines(lines: string[], start_offset: number) -> S
             let mut ci: number = 0;
             loop {
                 if ci >= marker_len { break; }
-                if substring(line, pos + ci, pos + ci + 1) != substring(marker, ci, ci + 1) {
+                if substring(line, pos + ci, pos + ci + 1) != substring(marker, ci, ci
+                    + 1) {
                     matches = false;
                     break;
                 }

--- a/compiler/src/llvm/lowering/instructions_let.sfn
+++ b/compiler/src/llvm/lowering/instructions_let.sfn
@@ -1,95 +1,50 @@
 // compiler/src/llvm/lowering/instructions_let.sfn
 //
 // Let binding instruction lowering.
-
 import { NativeFunction, NativeInstruction, NativeSourceSpan } from "../../native_ir";
-
 import {
-    TypeContext,
-    LocalBinding,
-    ParameterBinding,
-    LLVMOperand,
-    LetLoweringResult,
-    LifetimeRegionMetadata,
-    LifetimeReleaseEvent,
-    OwnershipInfo,
-    OwnershipConsumption,
-    LocalMutation,
-    StringConstant,
-} from "../types";
-
-import {
-    trim_text,
-    number_to_string,
-} from "../utils";
-
-import {
-    empty_string_constant_set,
-    merge_string_constants,
-} from "../strings";
-
-import {
-    find_interface_info_by_name,
-    find_struct_info_by_llvm_type,
-    find_vtable_for_struct_interface,
-} from "../type_context_queries";
-
+    analyze_value_ownership,
+    detect_borrow_conflicts,
+    lower_expression,
+} from "../expression_lowering/native/core";
+import { coerce_operand_to_type, } from "../expression_lowering/native/core_operands";
+import { append_local_binding, } from "../expression_lowering/native/core_scopes";
+import { detect_suspension_conflicts, } from "../expression_lowering/native/statement_suspension";
+import { map_local_type, } from "../expression_lowering/native/statement_type_mapping";
 import {
     find_local_binding,
     mark_local_consumed,
     mark_parameter_consumed,
 } from "../expressions_bindings";
-
+import { default_return_literal, format_local_pointer_name, } from "../expressions_helpers";
 import {
-    default_return_literal,
-    format_local_pointer_name,
-} from "../expressions_helpers";
-
-import {
-    lower_expression,
-    analyze_value_ownership,
-    detect_borrow_conflicts,
-} from "../expression_lowering/native/core";
-
-import {
-    coerce_operand_to_type,
-} from "../expression_lowering/native/core_operands";
-
-import {
-    append_local_binding,
-} from "../expression_lowering/native/core_scopes";
-
-import {
-    detect_suspension_conflicts,
-} from "../expression_lowering/native/statement_suspension";
-
-import {
-    map_local_type,
-} from "../expression_lowering/native/statement_type_mapping";
-
-import {
-    infer_borrow_base_scope,
     append_lifetime_region,
     append_lifetime_release_event,
+    infer_borrow_base_scope,
     make_lifetime_region_metadata,
 } from "../lifetime";
+import { empty_string_constant_set, merge_string_constants, } from "../strings";
+import {
+    find_interface_info_by_name,
+    find_struct_info_by_llvm_type,
+    find_vtable_for_struct_interface,
+} from "../type_context_queries";
+import {
+    LLVMOperand,
+    LetLoweringResult,
+    LifetimeRegionMetadata,
+    LifetimeReleaseEvent,
+    LocalBinding,
+    LocalMutation,
+    OwnershipConsumption,
+    OwnershipInfo,
+    ParameterBinding,
+    StringConstant,
+    TypeContext,
+} from "../types";
+import { number_to_string, trim_text, } from "../utils";
 
-fn lower_let_instruction(
-    function: NativeFunction,
-    instruction: NativeInstruction,
-    bindings: ParameterBinding[],
-    locals: LocalBinding[],
-    allocas: string[],
-    lines: string[],
-    temp_index: number,
-    next_local_id: number,
-    next_region_id: number,
-    functions: NativeFunction[],
-    context: TypeContext,
-    scope_id: string,
-    scope_depth: number,
-    current_label: string
-) -> LetLoweringResult ![io] {
+fn lower_let_instruction(function: NativeFunction, instruction: NativeInstruction, bindings: ParameterBinding[], locals: LocalBinding[], allocas: string[], lines: string[], temp_index: number, next_local_id: number, next_region_id: number, functions: NativeFunction[], context: TypeContext, scope_id: string, scope_depth: number, current_label: string) -> LetLoweringResult ![io] {
     let mut diagnostics: string[] = [];
     let mut current_lines: string[] = lines;
     let mut current_allocas: string[] = allocas;
@@ -103,9 +58,7 @@ fn lower_let_instruction(
     let mut lifetime_releases: LifetimeReleaseEvent[] = [];
     let mut current_next_region: number = next_region_id;
     let mut mutations: LocalMutation[] = [];
-    if initializer_span == null {
-        initializer_span = instruction.span;
-    }
+    if initializer_span == null { initializer_span = instruction.span; }
 
     let suspension_diagnostics = detect_suspension_conflicts(instruction.value, current_locals, current_bindings, function.name, initializer_span);
     let mut _ci16: number = 0;
@@ -122,7 +75,11 @@ fn lower_let_instruction(
         if previous_ownership != null {
             if previous_ownership.variant == "Borrow" {
                 if previous_ownership.region_id >= 0 {
-                    let release_event = LifetimeReleaseEvent { region_id: previous_ownership.region_id, scope_id: scope_id, scope_depth: scope_depth };
+                    let release_event = LifetimeReleaseEvent {
+                        region_id: previous_ownership.region_id,
+                        scope_id: scope_id,
+                        scope_depth: scope_depth
+                    };
                     lifetime_releases = append_lifetime_release_event(lifetime_releases, release_event);
                 }
             }
@@ -271,9 +228,7 @@ fn lower_let_instruction(
                     print.err("let-lowering: operand not null, trimming type");
                 }
                 let operand_type = trim_text(operand.llvm_type);
-                if operand_type.length > 0 {
-                    llvm_type = operand_type;
-                }
+                if operand_type.length > 0 { llvm_type = operand_type; }
             }
         }
     }
@@ -281,9 +236,7 @@ fn lower_let_instruction(
     // Only default to double as a last resort.  Struct and pointer types from
     // the operand must be preserved to avoid the double-encoding corruption
     // chain (ptrtoint→sitofp precision loss on struct pointers).
-    if llvm_type.length == 0 {
-        llvm_type = "double";
-    }
+    if llvm_type.length == 0 { llvm_type = "double"; }
 
     // Check if we need to box a concrete struct into a trait object
     let interface_info = find_interface_info_by_name(context, instruction.type_annotation);
@@ -320,7 +273,10 @@ fn lower_let_instruction(
                     // Insert vtable pointer
                     current_lines.push("  " + with_vtable_temp + " = insertvalue " + interface_info.llvm_name + " " + with_data_temp + ", i8* " + vtable_ptr_temp + ", 1");
                     // Update operand to the boxed trait object
-                    operand = LLVMOperand { llvm_type: interface_info.llvm_name, value: with_vtable_temp };
+                    operand = LLVMOperand {
+                        llvm_type: interface_info.llvm_name,
+                        value: with_vtable_temp
+                    };
                     llvm_type = interface_info.llvm_name;
                 } else {
                     diagnostics.push("llvm lowering: struct `" + struct_info.name + "` does not implement interface `" + interface_info.name + "`");
@@ -343,9 +299,7 @@ fn lower_let_instruction(
         let _op_type = trim_text(operand.llvm_type);
         if _op_type.length == 0 { _use_ipc_override = true; }
         if _op_type != llvm_type {
-            if llvm_type.length > 0 {
-                _use_ipc_override = true;
-            }
+            if llvm_type.length > 0 { _use_ipc_override = true; }
         }
         if _use_ipc_override {
             if fs.exists("build/sailfin/.call_result_type") {
@@ -355,7 +309,10 @@ fn lower_let_instruction(
                     if fs.exists("build/sailfin/.call_result_value") {
                         _fixup_value = fs.readFile("build/sailfin/.call_result_value");
                     }
-                    operand = LLVMOperand { llvm_type: _fixup_type, value: _fixup_value };
+                    operand = LLVMOperand {
+                        llvm_type: _fixup_type,
+                        value: _fixup_value
+                    };
                     if fs.exists("build/sailfin/.trace_lowering") {
                         print.err("let-lowering: operand reconstructed type=" + _fixup_type + " value=" + _fixup_value);
                     }
@@ -418,13 +375,13 @@ fn lower_let_instruction(
     if llvm_type == "%SailfinFuturePtr*" {
         if fs.exists("build/sailfin/.async_inner_return_type") {
             let async_inner = fs.readFile("build/sailfin/.async_inner_return_type");
-            if async_inner.length > 0 {
-                local_type_annotation = async_inner;
-            }
+            if async_inner.length > 0 { local_type_annotation = async_inner; }
             fs.deleteFile("build/sailfin/.async_inner_return_type");
         }
     }
-    current_locals = append_local_binding(current_locals, LocalBinding { name: instruction.name, pointer: pointer, llvm_type: llvm_type, type_annotation: local_type_annotation, ownership: ownership, consumed: false, scope_id: scope_id, scope_depth: scope_depth });
+    current_locals = append_local_binding(current_locals, LocalBinding {
+        name: instruction.name, pointer: pointer, llvm_type: llvm_type, type_annotation: local_type_annotation, ownership: ownership, consumed: false, scope_id: scope_id, scope_depth: scope_depth
+    });
 
     let mutation = LocalMutation {
         name: instruction.name,
@@ -499,19 +456,21 @@ fn _infer_field_constants_from_lines(lines: string[], start_offset: number) -> S
                 let mut ri: number = 0;
                 loop {
                     if ri >= result.length { break; }
-                    if result[ri].name == full_name { already = true; break; }
+                    if result[ri].name == full_name {
+                        already = true;
+                        break;
+                    }
                     ri += 1;
                 }
                 if !already {
-                    result.push(StringConstant { name: full_name, content: field_name, byte_count: field_name.length });
+                    result.push(StringConstant {
+                        name: full_name, content: field_name, byte_count: field_name.length
+                    });
                 }
                 pos = field_end;
-            } else {
-                pos += 1;
-            }
+            } else { pos += 1; }
         }
         i += 1;
     }
     return result;
 }
-

--- a/compiler/src/llvm/lowering/instructions_loops.sfn
+++ b/compiler/src/llvm/lowering/instructions_loops.sfn
@@ -3,11 +3,11 @@
 // Control flow handler: loop instruction lowering (infinite loops with break/continue).
 import { NativeFunction, NativeInstruction, NativeSourceSpan } from "../../native_ir";
 import { char_code, grapheme_at, substring } from "../../string_utils";
-import { lower_expression, } from "../expression_lowering/native/core";
-import { find_local_binding, } from "../expressions_bindings";
-import { format_temp_name, } from "../expressions_helpers";
-import { make_child_scope_id, } from "../lifetime";
-import { empty_string_constant_set, merge_string_constants, } from "../strings";
+import { lower_expression } from "../expression_lowering/native/core";
+import { find_local_binding } from "../expressions_bindings";
+import { format_temp_name } from "../expressions_helpers";
+import { make_child_scope_id } from "../lifetime";
+import { empty_string_constant_set, merge_string_constants } from "../strings";
 import {
     BlockLoweringResult,
     LLVMOperand,
@@ -18,26 +18,18 @@ import {
     LoopStructure,
     ParameterBinding,
     StringConstant,
-    TypeContext,
+    TypeContext
 } from "../types";
-import {
-    extend_string_array,
-    number_to_string,
-    trim_text,
-} from "../utils";
-import { lower_instruction_range, } from "./instructions";
+import { extend_string_array, number_to_string, trim_text } from "../utils";
+import { lower_instruction_range } from "./instructions";
 import {
     allocate_block_label,
     lower_condition_to_i1,
-    sanitize_if_condition_text,
+    sanitize_if_condition_text
 } from "./instructions_condition";
-import {
-    _parse_int_from_string,
-    extend_lifetime_regions,
-    extend_mutations,
-} from "./instructions_helpers";
-import { get_instruction_condition, get_instruction_tag, } from "./lowering_native_helpers";
-import { collect_mutation_names, find_mutation_for_name, } from "./phi";
+import { _parse_int_from_string, extend_lifetime_regions, extend_mutations } from "./instructions_helpers";
+import { get_instruction_condition, get_instruction_tag } from "./lowering_native_helpers";
+import { collect_mutation_names, find_mutation_for_name } from "./phi";
 
 fn collect_loop_structure(instructions: NativeInstruction[], start_index: number, end: number, function_name: string) -> LoopStructure {
     let mut diagnostics: string[] = [];
@@ -50,12 +42,14 @@ fn collect_loop_structure(instructions: NativeInstruction[], start_index: number
     loop {
         if index >= limit {
             if limit <= 0 { limit = 0; }
-            diagnostics.push("llvm lowering: unterminated `.loop` in `" + function_name + "`");
+            diagnostics.push("llvm lowering: unterminated `.loop` in `"
+                + function_name
+                + "`");
             return LoopStructure {
                 body_start: body_start,
                 body_end: limit,
                 next_index: limit - 1,
-                diagnostics: diagnostics,
+                diagnostics: diagnostics
             };
         }
         let _loop_tag = get_instruction_tag(instructions, index);
@@ -77,7 +71,7 @@ fn collect_loop_structure(instructions: NativeInstruction[], start_index: number
                     body_start: body_start,
                     body_end: body_end,
                     next_index: index,
-                    diagnostics: diagnostics,
+                    diagnostics: diagnostics
                 };
             }
             if depth > 0 { depth -= 1; }
@@ -91,7 +85,7 @@ fn collect_loop_structure(instructions: NativeInstruction[], start_index: number
         body_start: body_start,
         body_end: body_end,
         next_index: limit,
-        diagnostics: diagnostics,
+        diagnostics: diagnostics
     };
 }
 
@@ -133,11 +127,18 @@ fn lower_loop_instruction(function: NativeFunction, start_index: number, llvm_re
 
     let debug_loop = fs.exists("build/sailfin/.trace_lowering");
     if debug_loop {
-        print.err("emit-llvm: lower_loop start fn=" + function.name + " start_index=" + number_to_string(start_index) + " end=" + number_to_string(end));
+        print.err("emit-llvm: lower_loop start fn=" + function.name
+            + " start_index="
+            + number_to_string(start_index)
+            + " end="
+            + number_to_string(end));
     }
     let structure = collect_loop_structure(function.instructions, start_index, end, function.name);
     if debug_loop {
-        print.err("emit-llvm: lower_loop after_collect body_start=" + number_to_string(structure.body_start) + " body_end=" + number_to_string(structure.body_end));
+        print.err("emit-llvm: lower_loop after_collect body_start="
+            + number_to_string(structure.body_start)
+            + " body_end="
+            + number_to_string(structure.body_end));
     }
 
     // Detect exit-condition-at-top pattern: loop { if COND { break; } ... }
@@ -151,15 +152,18 @@ fn lower_loop_instruction(function: NativeFunction, start_index: number, llvm_re
     // first instruction. If it's non-empty, we have the pattern.
     let mut loop_exit_condition: string = "";
     if structure.body_start + 2 <= structure.body_end {
-        let second_body_tag = get_instruction_tag(function.instructions, structure.body_start + 1);
+        let second_body_tag = get_instruction_tag(function.instructions, structure.body_start
+            + 1);
         if second_body_tag == 10 {
-            let third_body_tag = get_instruction_tag(function.instructions, structure.body_start + 2);
+            let third_body_tag = get_instruction_tag(function.instructions, structure.body_start
+                + 2);
             if third_body_tag == 5 {
                 let raw_exit_cond = trim_text(get_instruction_condition(function.instructions, structure.body_start));
                 if raw_exit_cond.length > 0 {
                     loop_exit_condition = sanitize_if_condition_text(raw_exit_cond);
                     if debug_loop {
-                        print.err("emit-llvm: lower_loop detected exit condition: " + loop_exit_condition);
+                        print.err("emit-llvm: lower_loop detected exit condition: "
+                            + loop_exit_condition);
                     }
                 }
             }
@@ -181,7 +185,11 @@ fn lower_loop_instruction(function: NativeFunction, start_index: number, llvm_re
         let local = current_locals[preload_index];
         let preload_temp = format_temp_name(current_temp);
         current_temp += 1;
-        let preload_line = "  " + preload_temp + " = load " + local.llvm_type + ", " + local.llvm_type + "* " + local.pointer;
+        let preload_line = "  " + preload_temp + " = load " + local.llvm_type
+            + ", "
+            + local.llvm_type
+            + "* "
+            + local.pointer;
         current_lines.push(preload_line);
         preloaded_locals.push(preload_temp);
         preload_index += 1;
@@ -231,7 +239,11 @@ fn lower_loop_instruction(function: NativeFunction, start_index: number, llvm_re
     // Lower the body to discover mutations
     let body_scope_id = make_child_scope_id(scope_id, body_label);
     if debug_loop {
-        print.err("emit-llvm: lower_loop pre_body_lir fn=" + function.name + " body_start=" + number_to_string(body_start_effective) + " body_end=" + number_to_string(structure.body_end));
+        print.err("emit-llvm: lower_loop pre_body_lir fn=" + function.name
+            + " body_start="
+            + number_to_string(body_start_effective)
+            + " body_end="
+            + number_to_string(structure.body_end));
     }
 
     // Lower the body, resuming after premature block terminators.
@@ -259,7 +271,8 @@ fn lower_loop_instruction(function: NativeFunction, start_index: number, llvm_re
         if _body_cursor >= structure.body_end { break; }
         if _body_terminated { break; }
         if _body_resume_iters > 20 { break; }
-        let _seg_result = lower_instruction_range(function, _body_cursor, structure.body_end, llvm_return, _body_bindings, _body_locals, _body_allocas, [], _body_temp, _body_blkctr, _body_nextloc, _body_nextreg, functions, stacked, context, body_scope_id, scope_depth + 1, _body_active_label);
+        let _seg_result = lower_instruction_range(function, _body_cursor, structure.body_end, llvm_return, _body_bindings, _body_locals, _body_allocas, [], _body_temp, _body_blkctr, _body_nextloc, _body_nextreg, functions, stacked, context, body_scope_id, scope_depth
+            + 1, _body_active_label);
         // Merge segment results
         _body_lines = extend_string_array(_body_lines, _seg_result.lines);
         _body_allocas = _seg_result.allocas;
@@ -331,7 +344,7 @@ fn lower_loop_instruction(function: NativeFunction, start_index: number, llvm_re
         next_lifetime_region_id: _body_nextreg,
         next_index: _body_cursor,
         mutations: _body_mutations,
-        string_constants: _body_string_constants,
+        string_constants: _body_string_constants
     };
     // Cross-module ABI: scalar fields corrupted; read from file IPC instead.
     // Use _read_ipc_int_min to prevent the counter from going backwards.
@@ -340,7 +353,9 @@ fn lower_loop_instruction(function: NativeFunction, start_index: number, llvm_re
     let _br_lp_nextloc = _body_nextloc;
     let _br_lp_nextreg = _body_nextreg;
     if debug_loop {
-        print.err("emit-llvm: lower_loop post_body_lir fn=" + function.name + " body_lines=" + number_to_string(body_result.lines.length));
+        print.err("emit-llvm: lower_loop post_body_lir fn=" + function.name
+            + " body_lines="
+            + number_to_string(body_result.lines.length));
     }
 
     let mut _ci7: number = 0;
@@ -399,7 +414,11 @@ fn lower_loop_instruction(function: NativeFunction, start_index: number, llvm_re
         }
 
         if header_cond.operand != null {
-            current_lines.push("  br i1 " + header_cond.operand.value + ", label %" + exit_label + ", label %" + body_label);
+            current_lines.push("  br i1 " + header_cond.operand.value
+                + ", label %"
+                + exit_label
+                + ", label %"
+                + body_label);
         } else {
             // Condition lowering failed — fall back to unconditional
             current_lines.push("  br label %" + body_label);
@@ -432,7 +451,11 @@ fn lower_loop_instruction(function: NativeFunction, start_index: number, llvm_re
         if local != null {
             let load_temp = format_temp_name(current_temp);
             current_temp += 1;
-            let load_line = "  " + load_temp + " = load " + local.llvm_type + ", " + local.llvm_type + "* " + local.pointer;
+            let load_line = "  " + load_temp + " = load " + local.llvm_type
+                + ", "
+                + local.llvm_type
+                + "* "
+                + local.pointer;
             current_lines.push(load_line);
             latch_loads.push(load_temp);
         } else { latch_loads.push(""); }
@@ -472,10 +495,24 @@ fn lower_loop_instruction(function: NativeFunction, start_index: number, llvm_re
                         let phi_temp = format_temp_name(current_temp);
                         current_temp += 1;
 
-                        let phi_line = "  " + phi_temp + " = phi " + local.llvm_type + " [ " + preload_value + ", %" + current_label + " ], [ " + latch_value + ", %" + latch_label + " ]";
+                        let phi_line = "  " + phi_temp + " = phi " + local.llvm_type
+                            + " [ "
+                            + preload_value
+                            + ", %"
+                            + current_label
+                            + " ], [ "
+                            + latch_value
+                            + ", %"
+                            + latch_label
+                            + " ]";
                         header_phis.push(phi_line);
 
-                        let store_line = "  store " + local.llvm_type + " " + phi_temp + ", " + local.llvm_type + "* " + local.pointer;
+                        let store_line = "  store " + local.llvm_type + " "
+                            + phi_temp
+                            + ", "
+                            + local.llvm_type
+                            + "* "
+                            + local.pointer;
                         phi_stores.push(store_line);
                     }
                 }
@@ -523,7 +560,11 @@ fn lower_loop_instruction(function: NativeFunction, start_index: number, llvm_re
         if local != null {
             let exit_load_temp = format_temp_name(current_temp);
             current_temp += 1;
-            current_lines.push("  " + exit_load_temp + " = load " + local.llvm_type + ", " + local.llvm_type + "* " + local.pointer);
+            current_lines.push("  " + exit_load_temp + " = load " + local.llvm_type
+                + ", "
+                + local.llvm_type
+                + "* "
+                + local.pointer);
             exit_loads.push(exit_load_temp);
         } else { exit_loads.push(""); }
         exit_load_idx += 1;
@@ -556,7 +597,7 @@ fn lower_loop_instruction(function: NativeFunction, start_index: number, llvm_re
                 llvm_type: llvm_type,
                 value_name: exit_value,
                 span: original_span,
-                originating_label: exit_label,
+                originating_label: exit_label
             };
             exit_mutations.push(exit_mutation);
         }
@@ -603,6 +644,6 @@ fn lower_loop_instruction(function: NativeFunction, start_index: number, llvm_re
         next_lifetime_region_id: current_next_region,
         next_index: structure.next_index + 1,
         mutations: collected_mutations,
-        string_constants: collected_string_constants,
+        string_constants: collected_string_constants
     };
 }

--- a/compiler/src/llvm/lowering/instructions_loops.sfn
+++ b/compiler/src/llvm/lowering/instructions_loops.sfn
@@ -1,96 +1,55 @@
 // compiler/src/llvm/lowering/instructions_loops.sfn
 //
 // Control flow handler: loop instruction lowering (infinite loops with break/continue).
-
 import { NativeFunction, NativeInstruction, NativeSourceSpan } from "../../native_ir";
-import { substring, char_code, grapheme_at } from "../../string_utils";
-
+import { char_code, grapheme_at, substring } from "../../string_utils";
+import { lower_expression, } from "../expression_lowering/native/core";
+import { find_local_binding, } from "../expressions_bindings";
+import { format_temp_name, } from "../expressions_helpers";
+import { make_child_scope_id, } from "../lifetime";
+import { empty_string_constant_set, merge_string_constants, } from "../strings";
 import {
-    TypeContext,
-    LocalBinding,
-    ParameterBinding,
-    LLVMOperand,
     BlockLoweringResult,
-    LoopContext,
+    LLVMOperand,
     LifetimeRegionMetadata,
+    LocalBinding,
     LocalMutation,
-    StringConstant,
+    LoopContext,
     LoopStructure,
+    ParameterBinding,
+    StringConstant,
+    TypeContext,
 } from "../types";
-
 import {
-    trim_text,
     extend_string_array,
     number_to_string,
+    trim_text,
 } from "../utils";
-
-import {
-    empty_string_constant_set,
-    merge_string_constants,
-} from "../strings";
-
-import {
-    find_local_binding,
-} from "../expressions_bindings";
-
-import {
-    format_temp_name,
-} from "../expressions_helpers";
-
-import {
-    lower_expression,
-} from "../expression_lowering/native/core";
-
-import {
-    make_child_scope_id,
-} from "../lifetime";
-
-import {
-    find_mutation_for_name,
-    collect_mutation_names,
-} from "./phi";
-
-import {
-    lower_instruction_range,
-} from "./instructions";
-
-import {
-    extend_lifetime_regions,
-    extend_mutations,
-    _parse_int_from_string,
-} from "./instructions_helpers";
-
+import { lower_instruction_range, } from "./instructions";
 import {
     allocate_block_label,
     lower_condition_to_i1,
     sanitize_if_condition_text,
 } from "./instructions_condition";
-
 import {
-    get_instruction_tag,
-    get_instruction_condition,
-} from "./lowering_native_helpers";
+    _parse_int_from_string,
+    extend_lifetime_regions,
+    extend_mutations,
+} from "./instructions_helpers";
+import { get_instruction_condition, get_instruction_tag, } from "./lowering_native_helpers";
+import { collect_mutation_names, find_mutation_for_name, } from "./phi";
 
-fn collect_loop_structure(
-    instructions: NativeInstruction[],
-    start_index: number,
-    end: number,
-    function_name: string
-) -> LoopStructure {
+fn collect_loop_structure(instructions: NativeInstruction[], start_index: number, end: number, function_name: string) -> LoopStructure {
     let mut diagnostics: string[] = [];
     let body_start = start_index + 1;
     let mut body_end = end;
     let mut depth: number = 0;
     let mut index: number = body_start;
     let mut limit: number = end;
-    if limit > instructions.length {
-        limit = instructions.length;
-    }
+    if limit > instructions.length { limit = instructions.length; }
     loop {
         if index >= limit {
-            if limit <= 0 {
-                limit = 0;
-            }
+            if limit <= 0 { limit = 0; }
             diagnostics.push("llvm lowering: unterminated `.loop` in `" + function_name + "`");
             return LoopStructure {
                 body_start: body_start,
@@ -121,9 +80,7 @@ fn collect_loop_structure(
                     diagnostics: diagnostics,
                 };
             }
-            if depth > 0 {
-                depth -= 1;
-            }
+            if depth > 0 { depth -= 1; }
             index += 1;
             continue;
         }
@@ -160,26 +117,7 @@ fn last_loop_context(values: LoopContext[]) -> LoopContext {
     return values[index];
 }
 
-fn lower_loop_instruction(
-    function: NativeFunction,
-    start_index: number,
-    llvm_return: string,
-    bindings: ParameterBinding[],
-    locals: LocalBinding[],
-    allocas: string[],
-    lines: string[],
-    temp_index: number,
-    block_counter: number,
-    next_local_id: number,
-    next_region_id: number,
-    functions: NativeFunction[],
-    loop_stack: LoopContext[],
-    end: number,
-    context: TypeContext,
-    scope_id: string,
-    scope_depth: number,
-    current_label: string
-) -> BlockLoweringResult {
+fn lower_loop_instruction(function: NativeFunction, start_index: number, llvm_return: string, bindings: ParameterBinding[], locals: LocalBinding[], allocas: string[], lines: string[], temp_index: number, block_counter: number, next_local_id: number, next_region_id: number, functions: NativeFunction[], loop_stack: LoopContext[], end: number, context: TypeContext, scope_id: string, scope_depth: number, current_label: string) -> BlockLoweringResult {
     let mut diagnostics: string[] = [];
     let mut current_lines: string[] = lines;
     let mut current_allocas: string[] = allocas;
@@ -239,9 +177,7 @@ fn lower_loop_instruction(
     let mut preloaded_locals: string[] = [];
     let mut preload_index: number = 0;
     loop {
-        if preload_index >= current_locals.length {
-            break;
-        }
+        if preload_index >= current_locals.length { break; }
         let local = current_locals[preload_index];
         let preload_temp = format_temp_name(current_temp);
         current_temp += 1;
@@ -273,7 +209,10 @@ fn lower_loop_instruction(
     current_lines.push(header_label + ":");
 
     // Update loop context: break goes to exit, continue goes to latch
-    let loop_context = LoopContext { break_label: exit_label, continue_label: latch_label };
+    let loop_context = LoopContext {
+        break_label: exit_label,
+        continue_label: latch_label
+    };
     let stacked = append_loop_context(loop_stack, loop_context);
 
     let base_locals = current_locals;
@@ -320,26 +259,7 @@ fn lower_loop_instruction(
         if _body_cursor >= structure.body_end { break; }
         if _body_terminated { break; }
         if _body_resume_iters > 20 { break; }
-        let _seg_result = lower_instruction_range(
-            function,
-            _body_cursor,
-            structure.body_end,
-            llvm_return,
-            _body_bindings,
-            _body_locals,
-            _body_allocas,
-            [],
-            _body_temp,
-            _body_blkctr,
-            _body_nextloc,
-            _body_nextreg,
-            functions,
-            stacked,
-            context,
-            body_scope_id,
-            scope_depth + 1,
-            _body_active_label
-        );
+        let _seg_result = lower_instruction_range(function, _body_cursor, structure.body_end, llvm_return, _body_bindings, _body_locals, _body_allocas, [], _body_temp, _body_blkctr, _body_nextloc, _body_nextreg, functions, stacked, context, body_scope_id, scope_depth + 1, _body_active_label);
         // Merge segment results
         _body_lines = extend_string_array(_body_lines, _seg_result.lines);
         _body_allocas = _seg_result.allocas;
@@ -385,9 +305,7 @@ fn lower_loop_instruction(
                         }
                         if _skip_i < structure.body_end {
                             _body_cursor = _skip_i + 1;
-                        } else {
-                            _body_cursor = structure.body_end;
-                        }
+                        } else { _body_cursor = structure.body_end; }
                     } else {
                         // Other terminator (EndLoop, EndMatch, EndFor) — stop
                         _body_cursor = structure.body_end;
@@ -449,43 +367,27 @@ fn lower_loop_instruction(
     let mut mutated_names: string[] = [];
     let mut mut_idx: number = 0;
     loop {
-        if mut_idx >= body_result.mutations.length {
-            break;
-        }
+        if mut_idx >= body_result.mutations.length { break; }
         let mutation = body_result.mutations[mut_idx];
         let mut already_added: boolean = false;
         let mut check_idx: number = 0;
         loop {
-            if check_idx >= mutated_names.length {
-                break;
-            }
+            if check_idx >= mutated_names.length { break; }
             if mutated_names[check_idx] == mutation.name {
                 already_added = true;
                 break;
             }
             check_idx += 1;
         }
-        if !already_added {
-            mutated_names.push(mutation.name);
-        }
+        if !already_added { mutated_names.push(mutation.name); }
         mut_idx += 1;
     }
 
     // Note: We'll generate phi nodes after we know the latch load values
-
     // Emit header branch: conditional if we detected an exit condition at the
     // top of the loop body, otherwise fall back to unconditional (original behavior).
     if loop_exit_condition.length > 0 {
-        let header_cond = lower_condition_to_i1(
-            function.name,
-            loop_exit_condition,
-            bindings,
-            current_locals,
-            current_temp,
-            current_lines,
-            functions,
-            context
-        );
+        let header_cond = lower_condition_to_i1(function.name, loop_exit_condition, bindings, current_locals, current_temp, current_lines, functions, context);
         current_lines = header_cond.lines;
         current_temp = header_cond.temp_index;
         collected_string_constants = merge_string_constants(collected_string_constants, header_cond.string_constants);
@@ -523,9 +425,7 @@ fn lower_loop_instruction(
     let mut latch_loads: string[] = [];
     let mut load_idx: number = 0;
     loop {
-        if load_idx >= mutated_names.length {
-            break;
-        }
+        if load_idx >= mutated_names.length { break; }
         let name = mutated_names[load_idx];
         let local = find_local_binding(base_locals, name);
 
@@ -535,9 +435,7 @@ fn lower_loop_instruction(
             let load_line = "  " + load_temp + " = load " + local.llvm_type + ", " + local.llvm_type + "* " + local.pointer;
             current_lines.push(load_line);
             latch_loads.push(load_temp);
-        } else {
-            latch_loads.push("");
-        }
+        } else { latch_loads.push(""); }
 
         load_idx += 1;
     }
@@ -547,9 +445,7 @@ fn lower_loop_instruction(
     // Generate phi nodes using the latch load values.
     let mut name_idx: number = 0;
     loop {
-        if name_idx >= mutated_names.length {
-            break;
-        }
+        if name_idx >= mutated_names.length { break; }
         let name = mutated_names[name_idx];
         let local = find_local_binding(base_locals, name);
 
@@ -562,9 +458,7 @@ fn lower_loop_instruction(
                     let mut preload_value: string = "";
                     let mut local_idx: number = 0;
                     loop {
-                        if local_idx >= base_locals.length {
-                            break;
-                        }
+                        if local_idx >= base_locals.length { break; }
                         if base_locals[local_idx].name == name {
                             if local_idx < preloaded_locals.length {
                                 preload_value = preloaded_locals[local_idx];
@@ -597,9 +491,7 @@ fn lower_loop_instruction(
     let mut line_idx: number = 0;
     let mut found_header: boolean = false;
     loop {
-        if line_idx >= current_lines.length {
-            break;
-        }
+        if line_idx >= current_lines.length { break; }
         let line = current_lines[line_idx];
         final_lines.push(line);
 
@@ -625,9 +517,7 @@ fn lower_loop_instruction(
     let mut exit_loads: string[] = [];
     let mut exit_load_idx: number = 0;
     loop {
-        if exit_load_idx >= mutated_names.length {
-            break;
-        }
+        if exit_load_idx >= mutated_names.length { break; }
         let name = mutated_names[exit_load_idx];
         let local = find_local_binding(base_locals, name);
         if local != null {
@@ -635,18 +525,14 @@ fn lower_loop_instruction(
             current_temp += 1;
             current_lines.push("  " + exit_load_temp + " = load " + local.llvm_type + ", " + local.llvm_type + "* " + local.pointer);
             exit_loads.push(exit_load_temp);
-        } else {
-            exit_loads.push("");
-        }
+        } else { exit_loads.push(""); }
         exit_load_idx += 1;
     }
 
     let mut exit_mutations: LocalMutation[] = [];
     let mut name_idx: number = 0;
     loop {
-        if name_idx >= mutated_names.length {
-            break;
-        }
+        if name_idx >= mutated_names.length { break; }
         let name = mutated_names[name_idx];
         let mut exit_value: string = "";
         if name_idx < exit_loads.length {
@@ -662,13 +548,9 @@ fn lower_loop_instruction(
             }
             if llvm_type.length == 0 {
                 let local = find_local_binding(base_locals, name);
-                if local != null {
-                    llvm_type = local.llvm_type;
-                }
+                if local != null { llvm_type = local.llvm_type; }
             }
-            if llvm_type.length == 0 {
-                llvm_type = "double";
-            }
+            if llvm_type.length == 0 { llvm_type = "double"; }
             let exit_mutation = LocalMutation {
                 name: name,
                 llvm_type: llvm_type,
@@ -687,26 +569,20 @@ fn lower_loop_instruction(
     let mut body_scoped_mutations: LocalMutation[] = [];
     let mut body_mut_idx: number = 0;
     loop {
-        if body_mut_idx >= body_result.mutations.length {
-            break;
-        }
+        if body_mut_idx >= body_result.mutations.length { break; }
         let mutation = body_result.mutations[body_mut_idx];
         if find_local_binding(base_locals, mutation.name) == null {
             let mut already_added: boolean = false;
             let mut seen_idx: number = 0;
             loop {
-                if seen_idx >= body_scoped_mutations.length {
-                    break;
-                }
+                if seen_idx >= body_scoped_mutations.length { break; }
                 if body_scoped_mutations[seen_idx].name == mutation.name {
                     already_added = true;
                     break;
                 }
                 seen_idx += 1;
             }
-            if !already_added {
-                body_scoped_mutations.push(mutation);
-            }
+            if !already_added { body_scoped_mutations.push(mutation); }
         }
         body_mut_idx += 1;
     }

--- a/compiler/src/llvm/lowering/instructions_match.sfn
+++ b/compiler/src/llvm/lowering/instructions_match.sfn
@@ -1,100 +1,74 @@
 // compiler/src/llvm/lowering/instructions_match.sfn
 //
 // Control flow handler: match instruction lowering.
-
 import { NativeFunction, NativeInstruction, NativeSourceSpan } from "../../native_ir";
-
-import {
-    TypeContext,
-    LocalBinding,
-    ParameterBinding,
-    LLVMOperand,
-    BlockLoweringResult,
-    LoopContext,
-    LifetimeRegionMetadata,
-    LocalMutation,
-    StringConstant,
-    MatchStructure,
-    MatchCaseStructure,
-    MatchCaseCondition,
-    MatchFieldBinding,
-    MatchStructFieldBinding,
-    EnumTypeInfo,
-    EnumVariantInfo,
-    StructTypeInfo,
-    StructFieldInfo,
-    MatchArmMutations,
-} from "../types";
-
-import {
-    trim_text,
-    extend_string_array,
-    number_to_string,
-    merge_parameter_bindings,
-    copy_string_array,
-} from "../utils";
-
-import { empty_string_constant_set, merge_string_constants } from "../strings";
-
-import {
-    find_struct_info_by_name,
-    find_enum_info_by_llvm_type,
-    resolve_enum_info_for_literal,
-    resolve_enum_variant_info,
-} from "../type_context_queries";
-
-import {
-    ends_with_pointer_suffix,
-    strip_pointer_suffix,
-    layout_annotation_represents_user_value,
-    map_struct_field_annotation,
-} from "../type_mapping";
-
-import { find_local_binding } from "../expressions_bindings";
-
-import { format_temp_name } from "../expressions_helpers";
-
-import {
-    lower_expression,
-} from "../expression_lowering/native/core";
-
+import { lower_expression, } from "../expression_lowering/native/core";
 import { append_match_arm_mutations } from "../expression_lowering/native/core_match_helpers";
-
 import {
     emit_boolean_and,
     emit_comparison_instruction,
     harmonise_operands,
 } from "../expression_lowering/native/core_operands";
-
 import { parse_enum_literal, parse_struct_pattern } from "../expression_lowering/native/core_parse";
-
 import {
     extract_simple_identifier,
     is_union_llvm_type,
     parse_union_payload_types,
 } from "../expression_lowering/native/core_text";
-
+import { find_local_binding } from "../expressions_bindings";
+import { format_temp_name } from "../expressions_helpers";
 import { make_child_scope_id } from "../lifetime";
-
-import { emit_phi_merges_for_match, materialize_mutation_values_at_label } from "./phi";
-
+import { empty_string_constant_set, merge_string_constants } from "../strings";
 import {
-    lower_instruction_range,
-} from "./instructions";
-
+    find_enum_info_by_llvm_type,
+    find_struct_info_by_name,
+    resolve_enum_info_for_literal,
+    resolve_enum_variant_info,
+} from "../type_context_queries";
 import {
+    ends_with_pointer_suffix,
+    layout_annotation_represents_user_value,
+    map_struct_field_annotation,
+    strip_pointer_suffix,
+} from "../type_mapping";
+import {
+    BlockLoweringResult,
+    EnumTypeInfo,
+    EnumVariantInfo,
+    LLVMOperand,
+    LifetimeRegionMetadata,
+    LocalBinding,
+    LocalMutation,
+    LoopContext,
+    MatchArmMutations,
+    MatchCaseCondition,
+    MatchCaseStructure,
+    MatchFieldBinding,
+    MatchStructFieldBinding,
+    MatchStructure,
+    ParameterBinding,
+    StringConstant,
+    StructFieldInfo,
+    StructTypeInfo,
+    TypeContext,
+} from "../types";
+import {
+    copy_string_array,
+    extend_string_array,
+    merge_parameter_bindings,
+    number_to_string,
+    trim_text,
+} from "../utils";
+import { lower_instruction_range, } from "./instructions";
+import { allocate_block_label, lower_condition_to_i1, } from "./instructions_condition";
+import {
+    _parse_int_from_string,
     clone_local_bindings,
     extend_lifetime_regions,
     extend_mutations,
-    _parse_int_from_string,
 } from "./instructions_helpers";
-
-import {
-    allocate_block_label,
-    lower_condition_to_i1,
-} from "./instructions_condition";
-
 import { lower_match_case_condition } from "./instructions_match_condition";
+import { emit_phi_merges_for_match, materialize_mutation_values_at_label } from "./phi";
 
 // Helper: build a LocalBinding for match arm payload extraction.
 // Kept as a separate function so loops never have inline struct literals at the loop
@@ -112,21 +86,14 @@ fn _match_make_local_binding(name: string, pointer: string, llvm_type: string, s
     };
 }
 
-fn collect_match_structure(
-    instructions: NativeInstruction[],
-    start_index: number,
-    end: number,
-    function_name: string
-) -> MatchStructure {
+fn collect_match_structure(instructions: NativeInstruction[], start_index: number, end: number, function_name: string) -> MatchStructure {
     let mut diagnostics: string[] = [];
     let mut cases: MatchCaseStructure[] = [];
     let mut current_case: MatchCaseStructure? = null;
     let mut index: number = start_index + 1;
     let mut depth: number = 0;
     let mut limit: number = end;
-    if limit > instructions.length {
-        limit = instructions.length;
-    }
+    if limit > instructions.length { limit = instructions.length; }
     loop {
         if index >= limit {
             diagnostics.push("llvm lowering: unterminated `.match` in `" + function_name + "`");
@@ -134,7 +101,11 @@ fn collect_match_structure(
                 let finished = finalize_match_case(current_case, limit);
                 cases = append_match_case(cases, finished);
             }
-            return MatchStructure { cases: cases, end_index: limit - 1, diagnostics: diagnostics };
+            return MatchStructure {
+                cases: cases,
+                end_index: limit - 1,
+                diagnostics: diagnostics
+            };
         }
         let instruction = instructions[index];
         if instruction.variant == "Match" {
@@ -149,7 +120,11 @@ fn collect_match_structure(
                     cases = append_match_case(cases, finished);
                     current_case = null;
                 }
-                return MatchStructure { cases: cases, end_index: index, diagnostics: diagnostics };
+                return MatchStructure {
+                    cases: cases,
+                    end_index: index,
+                    diagnostics: diagnostics
+                };
             }
             depth -= 1;
             index += 1;
@@ -165,9 +140,7 @@ fn collect_match_structure(
                 cases = append_match_case(cases, finished);
             }
             let mut guard_text: string? = null;
-            if instruction.guard != null {
-                guard_text = instruction.guard;
-            }
+            if instruction.guard != null { guard_text = instruction.guard; }
             current_case = MatchCaseStructure {
                 pattern: instruction.pattern,
                 guard: guard_text,
@@ -181,7 +154,11 @@ fn collect_match_structure(
         index += 1;
     }
 
-    return MatchStructure { cases: cases, end_index: limit, diagnostics: diagnostics };
+    return MatchStructure {
+        cases: cases,
+        end_index: limit,
+        diagnostics: diagnostics
+    };
 }
 
 fn append_match_case(cases: MatchCaseStructure[], value: MatchCaseStructure) -> MatchCaseStructure[] {
@@ -203,35 +180,12 @@ fn finalize_match_case(case: MatchCaseStructure?, body_end: number) -> MatchCase
 
 fn is_default_pattern(pattern: string) -> boolean {
     let trimmed = trim_text(pattern);
-    if trimmed.length == 0 {
-        return true;
-    }
-    if trimmed == "_" {
-        return true;
-    }
+    if trimmed.length == 0 { return true; }
+    if trimmed == "_" { return true; }
     return false;
 }
 
-fn lower_match_instruction(
-    function: NativeFunction,
-    start_index: number,
-    llvm_return: string,
-    bindings: ParameterBinding[],
-    locals: LocalBinding[],
-    allocas: string[],
-    lines: string[],
-    temp_index: number,
-    block_counter: number,
-    next_local_id: number,
-    next_region_id: number,
-    functions: NativeFunction[],
-    loop_stack: LoopContext[],
-    end: number,
-    context: TypeContext,
-    scope_id: string,
-    scope_depth: number,
-    current_label: string
-) -> BlockLoweringResult {
+fn lower_match_instruction(function: NativeFunction, start_index: number, llvm_return: string, bindings: ParameterBinding[], locals: LocalBinding[], allocas: string[], lines: string[], temp_index: number, block_counter: number, next_local_id: number, next_region_id: number, functions: NativeFunction[], loop_stack: LoopContext[], end: number, context: TypeContext, scope_id: string, scope_depth: number, current_label: string) -> BlockLoweringResult {
     let mut diagnostics: string[] = [];
     let mut current_lines: string[] = lines;
     let base_lines_snapshot = copy_string_array(lines);
@@ -283,7 +237,8 @@ fn lower_match_instruction(
             lifetime_regions: lifetime_regions,
             next_lifetime_region_id: current_next_region,
             next_index: structure.end_index + 1,
-            mutations: collected_mutations, string_constants: collected_string_constants,
+            mutations: collected_mutations,
+            string_constants: collected_string_constants,
         };
     }
 
@@ -314,7 +269,8 @@ fn lower_match_instruction(
             lifetime_regions: lifetime_regions,
             next_lifetime_region_id: current_next_region,
             next_index: structure.end_index + 1,
-            mutations: collected_mutations, string_constants: collected_string_constants,
+            mutations: collected_mutations,
+            string_constants: collected_string_constants,
         };
     }
 
@@ -322,9 +278,7 @@ fn lower_match_instruction(
     let mut body_labels: string[] = [];
     let mut index: number = 0;
     loop {
-        if index >= structure.cases.length {
-            break;
-        }
+        if index >= structure.cases.length { break; }
         let test_alloc = allocate_block_label("matchcase", current_block_counter);
         let body_alloc = allocate_block_label("matchbody", test_alloc.next_counter);
         test_labels.push(test_alloc.label);
@@ -341,9 +295,7 @@ fn lower_match_instruction(
     let mut preloaded_locals: string[] = [];
     let mut preload_index: number = 0;
     loop {
-        if preload_index >= current_locals.length {
-            break;
-        }
+        if preload_index >= current_locals.length { break; }
         let local = current_locals[preload_index];
         let preload_temp = format_temp_name(current_temp);
         current_temp += 1;
@@ -362,9 +314,7 @@ fn lower_match_instruction(
 
     index = 0;
     loop {
-        if index >= structure.cases.length {
-            break;
-        }
+        if index >= structure.cases.length { break; }
         let case = structure.cases[index];
 
         let mut guard_has_text: boolean = false;
@@ -383,17 +333,7 @@ fn lower_match_instruction(
         }
 
         current_lines.push(test_labels[index] + ":");
-        let lowered_condition = lower_match_case_condition(
-            function.name,
-            subject_operand,
-            case,
-            bindings,
-            current_locals,
-            current_temp,
-            current_lines,
-            functions,
-            context
-        );
+        let lowered_condition = lower_match_case_condition(function.name, subject_operand, case, bindings, current_locals, current_temp, current_lines, functions, context);
         let mut _ci2: number = 0;
         loop {
             if _ci2 >= lowered_condition.diagnostics.length { break; }
@@ -409,9 +349,7 @@ fn lower_match_instruction(
                 let mut seen: boolean = false;
                 let mut seen_index: number = 0;
                 loop {
-                    if seen_index >= matched_union_variants.length {
-                        break;
-                    }
+                    if seen_index >= matched_union_variants.length { break; }
                     if matched_union_variants[seen_index] == lowered_condition.union_variant_index {
                         seen = true;
                         break;
@@ -458,9 +396,7 @@ fn lower_match_instruction(
             current_lines.push("  br label %" + body_labels[index]);
         } else if lowered_condition.operand != null {
             current_lines.push("  br i1 " + lowered_condition.operand.value + ", label %" + body_labels[index] + ", label %" + failure_target);
-        } else {
-            current_lines.push("  br label %" + failure_target);
-        }
+        } else { current_lines.push("  br label %" + failure_target); }
 
         current_lines.push(body_labels[index] + ":");
 
@@ -481,8 +417,8 @@ fn lower_match_instruction(
                         current_temp += 1;
                         current_lines.push("  " + subject_alloca_temp + " = alloca " + subject_operand.llvm_type);
                         current_lines.push("  store " + subject_operand.llvm_type + " " + subject_operand.value + ", " + subject_operand.llvm_type + "* " + subject_alloca_temp);
-                        // Note: NOT added to base_allocas since this allocation happens in the match body, not at function entry
 
+                        // Note: NOT added to base_allocas since this allocation happens in the match body, not at function entry
                         let mut binding_idx: number = 0;
                         loop {
                             if binding_idx >= lowered_condition.field_bindings.length {
@@ -608,24 +544,18 @@ fn lower_match_instruction(
                     let mut remaining: number[] = [];
                     let mut v: number = 0;
                     loop {
-                        if v >= union_payload_types.length {
-                            break;
-                        }
+                        if v >= union_payload_types.length { break; }
                         let mut is_matched: boolean = false;
                         let mut mi: number = 0;
                         loop {
-                            if mi >= matched_union_variants.length {
-                                break;
-                            }
+                            if mi >= matched_union_variants.length { break; }
                             if matched_union_variants[mi] == v {
                                 is_matched = true;
                                 break;
                             }
                             mi += 1;
                         }
-                        if !is_matched {
-                            remaining.push(v);
-                        }
+                        if !is_matched { remaining.push(v); }
                         v += 1;
                     }
                     if remaining.length == 1 {
@@ -642,14 +572,7 @@ fn lower_match_instruction(
                         current_lines.push("  store " + payload_type + " " + payload_temp + ", " + payload_type + "* " + local_alloca_temp);
 
                         base_locals.push(LocalBinding {
-                                name: subject_name,
-                                pointer: local_alloca_temp,
-                                llvm_type: payload_type,
-                                type_annotation: "",
-                                ownership: null,
-                                consumed: false,
-                                scope_id: make_child_scope_id(scope_id, body_labels[index]),
-                                scope_depth: scope_depth + 1,
+                            name: subject_name, pointer: local_alloca_temp, llvm_type: payload_type, type_annotation: "", ownership: null, consumed: false, scope_id: make_child_scope_id(scope_id, body_labels[index]), scope_depth: scope_depth + 1,
                         });
                         base_local_id += 1;
                     }
@@ -657,26 +580,7 @@ fn lower_match_instruction(
             }
         }
 
-        let body_result = lower_instruction_range(
-            function,
-            case.body_start,
-            case.body_end,
-            llvm_return,
-            bindings,
-            base_locals,
-            base_allocas,
-            [],
-            current_temp,
-            current_block_counter,
-            base_local_id,
-            current_next_region,
-            functions,
-            loop_stack,
-            context,
-            make_child_scope_id(scope_id, body_labels[index]),
-            scope_depth + 1,
-            body_labels[index]
-        );
+        let body_result = lower_instruction_range(function, case.body_start, case.body_end, llvm_return, bindings, base_locals, base_allocas, [], current_temp, current_block_counter, base_local_id, current_next_region, functions, loop_stack, context, make_child_scope_id(scope_id, body_labels[index]), scope_depth + 1, body_labels[index]);
         let mut _ci3: number = 0;
         loop {
             if _ci3 >= body_result.diagnostics.length { break; }
@@ -695,14 +599,9 @@ fn lower_match_instruction(
         collected_string_constants = merge_string_constants(collected_string_constants, body_result.string_constants);
 
         // Track mutations per arm for phi node emission
-        arm_mutations_list = append_match_arm_mutations(
-            arm_mutations_list,
-            MatchArmMutations {
-                mutations: body_result.mutations,
-                label: body_labels[index],
-                terminated: body_result.terminated,
-            }
-        );
+        arm_mutations_list = append_match_arm_mutations(arm_mutations_list, MatchArmMutations {
+            mutations: body_result.mutations, label: body_labels[index], terminated: body_result.terminated,
+        });
 
         if !body_result.terminated {
             merged_bindings = merge_parameter_bindings(merged_bindings, body_result.bindings);
@@ -711,9 +610,7 @@ fn lower_match_instruction(
         } else {
             let mut _asgn223: boolean = false;
             if all_terminated {
-                if true {
-                    _asgn223 = true;
-                }
+                if true { _asgn223 = true; }
             }
             all_terminated = _asgn223;
         }
@@ -734,35 +631,19 @@ fn lower_match_instruction(
 
     let mut _let224: boolean = false;
     if all_terminated {
-        if match_exhaustive {
-            _let224 = true;
-        }
+        if match_exhaustive { _let224 = true; }
     }
     let terminated = _let224;
 
     // Always emit the merge label so any generated failure branches have a target.
     current_lines.push(merge_label + ":");
-    if terminated {
-        current_lines.push("  unreachable");
-    } else {
+    if terminated { current_lines.push("  unreachable"); } else {
         // Emit phi nodes for all mutated locals across all arms
-        let phi_result = emit_phi_merges_for_match(
-            arm_mutations_list,
-            current_locals,
-            preloaded_locals,
-            current_lines,
-            current_temp
-        );
+        let phi_result = emit_phi_merges_for_match(arm_mutations_list, current_locals, preloaded_locals, current_lines, current_temp);
         current_lines = phi_result.lines;
         current_temp = phi_result.temp_index;
         if collected_mutations.length > 0 {
-            let materialized = materialize_mutation_values_at_label(
-                collected_mutations,
-                current_locals,
-                current_lines,
-                current_temp,
-                merge_label
-            );
+            let materialized = materialize_mutation_values_at_label(collected_mutations, current_locals, current_lines, current_temp, merge_label);
             current_lines = materialized.lines;
             current_temp = materialized.temp_index;
             collected_mutations = materialized.mutations;
@@ -788,6 +669,7 @@ fn lower_match_instruction(
         lifetime_regions: lifetime_regions,
         next_lifetime_region_id: current_next_region,
         next_index: structure.end_index + 1,
-        mutations: collected_mutations, string_constants: result_string_constants,
+        mutations: collected_mutations,
+        string_constants: result_string_constants,
     };
 }

--- a/compiler/src/llvm/lowering/instructions_match.sfn
+++ b/compiler/src/llvm/lowering/instructions_match.sfn
@@ -2,18 +2,14 @@
 //
 // Control flow handler: match instruction lowering.
 import { NativeFunction, NativeInstruction, NativeSourceSpan } from "../../native_ir";
-import { lower_expression, } from "../expression_lowering/native/core";
+import { lower_expression } from "../expression_lowering/native/core";
 import { append_match_arm_mutations } from "../expression_lowering/native/core_match_helpers";
-import {
-    emit_boolean_and,
-    emit_comparison_instruction,
-    harmonise_operands,
-} from "../expression_lowering/native/core_operands";
+import { emit_boolean_and, emit_comparison_instruction, harmonise_operands } from "../expression_lowering/native/core_operands";
 import { parse_enum_literal, parse_struct_pattern } from "../expression_lowering/native/core_parse";
 import {
     extract_simple_identifier,
     is_union_llvm_type,
-    parse_union_payload_types,
+    parse_union_payload_types
 } from "../expression_lowering/native/core_text";
 import { find_local_binding } from "../expressions_bindings";
 import { format_temp_name } from "../expressions_helpers";
@@ -23,13 +19,13 @@ import {
     find_enum_info_by_llvm_type,
     find_struct_info_by_name,
     resolve_enum_info_for_literal,
-    resolve_enum_variant_info,
+    resolve_enum_variant_info
 } from "../type_context_queries";
 import {
     ends_with_pointer_suffix,
     layout_annotation_represents_user_value,
     map_struct_field_annotation,
-    strip_pointer_suffix,
+    strip_pointer_suffix
 } from "../type_mapping";
 import {
     BlockLoweringResult,
@@ -50,22 +46,22 @@ import {
     StringConstant,
     StructFieldInfo,
     StructTypeInfo,
-    TypeContext,
+    TypeContext
 } from "../types";
 import {
     copy_string_array,
     extend_string_array,
     merge_parameter_bindings,
     number_to_string,
-    trim_text,
+    trim_text
 } from "../utils";
-import { lower_instruction_range, } from "./instructions";
-import { allocate_block_label, lower_condition_to_i1, } from "./instructions_condition";
+import { lower_instruction_range } from "./instructions";
+import { allocate_block_label, lower_condition_to_i1 } from "./instructions_condition";
 import {
     _parse_int_from_string,
     clone_local_bindings,
     extend_lifetime_regions,
-    extend_mutations,
+    extend_mutations
 } from "./instructions_helpers";
 import { lower_match_case_condition } from "./instructions_match_condition";
 import { emit_phi_merges_for_match, materialize_mutation_values_at_label } from "./phi";
@@ -82,7 +78,7 @@ fn _match_make_local_binding(name: string, pointer: string, llvm_type: string, s
         ownership: null,
         consumed: false,
         scope_id: scope_id,
-        scope_depth: scope_depth,
+        scope_depth: scope_depth
     };
 }
 
@@ -96,7 +92,9 @@ fn collect_match_structure(instructions: NativeInstruction[], start_index: numbe
     if limit > instructions.length { limit = instructions.length; }
     loop {
         if index >= limit {
-            diagnostics.push("llvm lowering: unterminated `.match` in `" + function_name + "`");
+            diagnostics.push("llvm lowering: unterminated `.match` in `"
+                + function_name
+                + "`");
             if current_case != null {
                 let finished = finalize_match_case(current_case, limit);
                 cases = append_match_case(cases, finished);
@@ -146,7 +144,7 @@ fn collect_match_structure(instructions: NativeInstruction[], start_index: numbe
                 guard: guard_text,
                 body_start: index + 1,
                 body_end: index + 1,
-                is_default: is_default_pattern(instruction.pattern),
+                is_default: is_default_pattern(instruction.pattern)
             };
             index += 1;
             continue;
@@ -174,7 +172,7 @@ fn finalize_match_case(case: MatchCaseStructure?, body_end: number) -> MatchCase
         guard: value.guard,
         body_start: value.body_start,
         body_end: body_end,
-        is_default: value.is_default,
+        is_default: value.is_default
     };
 }
 
@@ -223,7 +221,9 @@ fn lower_match_instruction(function: NativeFunction, start_index: number, llvm_r
     collected_string_constants = merge_string_constants(collected_string_constants, subject_result.string_constants);
 
     if subject_result.operand == null {
-        diagnostics.push("llvm lowering: unable to lower match subject in `" + function.name + "`");
+        diagnostics.push("llvm lowering: unable to lower match subject in `"
+            + function.name
+            + "`");
         return BlockLoweringResult {
             lines: current_lines,
             allocas: current_allocas,
@@ -238,7 +238,7 @@ fn lower_match_instruction(function: NativeFunction, start_index: number, llvm_r
             next_lifetime_region_id: current_next_region,
             next_index: structure.end_index + 1,
             mutations: collected_mutations,
-            string_constants: collected_string_constants,
+            string_constants: collected_string_constants
         };
     }
 
@@ -250,7 +250,8 @@ fn lower_match_instruction(function: NativeFunction, start_index: number, llvm_r
     let mut matched_enum_tags: number[] = [];
 
     if structure.cases.length == 0 {
-        diagnostics.push("llvm lowering: match without cases in `" + function.name + "`");
+        diagnostics.push("llvm lowering: match without cases in `" + function.name
+            + "`");
         let merge_alloc = allocate_block_label("matchmerge", current_block_counter);
         let merge_label = merge_alloc.label;
         current_block_counter = merge_alloc.next_counter;
@@ -270,7 +271,7 @@ fn lower_match_instruction(function: NativeFunction, start_index: number, llvm_r
             next_lifetime_region_id: current_next_region,
             next_index: structure.end_index + 1,
             mutations: collected_mutations,
-            string_constants: collected_string_constants,
+            string_constants: collected_string_constants
         };
     }
 
@@ -299,7 +300,11 @@ fn lower_match_instruction(function: NativeFunction, start_index: number, llvm_r
         let local = current_locals[preload_index];
         let preload_temp = format_temp_name(current_temp);
         current_temp += 1;
-        let preload_line = "  " + preload_temp + " = load " + local.llvm_type + ", " + local.llvm_type + "* " + local.pointer;
+        let preload_line = "  " + preload_temp + " = load " + local.llvm_type
+            + ", "
+            + local.llvm_type
+            + "* "
+            + local.pointer;
         current_lines.push(preload_line);
         preloaded_locals.push(preload_temp);
         preload_index += 1;
@@ -395,7 +400,11 @@ fn lower_match_instruction(function: NativeFunction, start_index: number, llvm_r
             has_unconditional_default = true;
             current_lines.push("  br label %" + body_labels[index]);
         } else if lowered_condition.operand != null {
-            current_lines.push("  br i1 " + lowered_condition.operand.value + ", label %" + body_labels[index] + ", label %" + failure_target);
+            current_lines.push("  br i1 " + lowered_condition.operand.value
+                + ", label %"
+                + body_labels[index]
+                + ", label %"
+                + failure_target);
         } else { current_lines.push("  br label %" + failure_target); }
 
         current_lines.push(body_labels[index] + ":");
@@ -415,8 +424,16 @@ fn lower_match_instruction(function: NativeFunction, start_index: number, llvm_r
                         // Allocate subject on stack for field extraction
                         let subject_alloca_temp = format_temp_name(current_temp);
                         current_temp += 1;
-                        current_lines.push("  " + subject_alloca_temp + " = alloca " + subject_operand.llvm_type);
-                        current_lines.push("  store " + subject_operand.llvm_type + " " + subject_operand.value + ", " + subject_operand.llvm_type + "* " + subject_alloca_temp);
+                        current_lines.push("  " + subject_alloca_temp
+                            + " = alloca "
+                            + subject_operand.llvm_type);
+                        current_lines.push("  store " + subject_operand.llvm_type
+                            + " "
+                            + subject_operand.value
+                            + ", "
+                            + subject_operand.llvm_type
+                            + "* "
+                            + subject_alloca_temp);
 
                         // Note: NOT added to base_allocas since this allocation happens in the match body, not at function entry
                         let mut binding_idx: number = 0;
@@ -436,12 +453,23 @@ fn lower_match_instruction(function: NativeFunction, start_index: number, llvm_r
                                     payload_field_index = 2;
                                 }
                             }
-                            current_lines.push("  " + payload_ptr_temp + " = getelementptr inbounds " + enum_info_val.llvm_name + ", " + enum_info_val.llvm_name + "* " + subject_alloca_temp + ", i32 0, i32 " + number_to_string(payload_field_index));
+                            current_lines.push("  " + payload_ptr_temp
+                                + " = getelementptr inbounds "
+                                + enum_info_val.llvm_name
+                                + ", "
+                                + enum_info_val.llvm_name
+                                + "* "
+                                + subject_alloca_temp
+                                + ", i32 0, i32 "
+                                + number_to_string(payload_field_index));
 
                             // 2. Treat payload as a raw byte pointer (opaque pointers)
                             let byte_ptr_temp = format_temp_name(current_temp);
                             current_temp += 1;
-                            current_lines.push("  " + byte_ptr_temp + " = bitcast ptr " + payload_ptr_temp + " to ptr");
+                            current_lines.push("  " + byte_ptr_temp
+                                + " = bitcast ptr "
+                                + payload_ptr_temp
+                                + " to ptr");
 
                             // 3. Offset to field position
                             let field_offset_in_payload = field_binding.field_offset - variant_info_val.offset;
@@ -449,30 +477,49 @@ fn lower_match_instruction(function: NativeFunction, start_index: number, llvm_r
                             if field_offset_in_payload > 0 {
                                 let offset_ptr_temp = format_temp_name(current_temp);
                                 current_temp += 1;
-                                current_lines.push("  " + offset_ptr_temp + " = getelementptr inbounds i8, ptr " + byte_ptr_temp + ", i64 " + number_to_string(field_offset_in_payload));
+                                current_lines.push("  " + offset_ptr_temp
+                                    + " = getelementptr inbounds i8, ptr "
+                                    + byte_ptr_temp
+                                    + ", i64 "
+                                    + number_to_string(field_offset_in_payload));
                                 field_ptr_temp = offset_ptr_temp;
                             }
 
                             // 4. Cast to field type pointer (opaque pointers)
                             let typed_ptr_temp = format_temp_name(current_temp);
                             current_temp += 1;
-                            current_lines.push("  " + typed_ptr_temp + " = bitcast ptr " + field_ptr_temp + " to ptr");
+                            current_lines.push("  " + typed_ptr_temp
+                                + " = bitcast ptr "
+                                + field_ptr_temp
+                                + " to ptr");
 
                             // 5. Load the field value
                             let value_temp = format_temp_name(current_temp);
                             current_temp += 1;
-                            current_lines.push("  " + value_temp + " = load " + field_binding.field_type + ", ptr " + typed_ptr_temp);
+                            current_lines.push("  " + value_temp + " = load "
+                                + field_binding.field_type
+                                + ", ptr "
+                                + typed_ptr_temp);
 
                             // 6. Allocate a local for this binding
                             let local_alloca_temp = format_temp_name(current_temp);
                             current_temp += 1;
-                            current_lines.push("  " + local_alloca_temp + " = alloca " + field_binding.field_type);
+                            current_lines.push("  " + local_alloca_temp
+                                + " = alloca "
+                                + field_binding.field_type);
 
                             // 7. Store the value into the local
-                            current_lines.push("  store " + field_binding.field_type + " " + value_temp + ", " + field_binding.field_type + "* " + local_alloca_temp);
+                            current_lines.push("  store " + field_binding.field_type
+                                + " "
+                                + value_temp
+                                + ", "
+                                + field_binding.field_type
+                                + "* "
+                                + local_alloca_temp);
 
                             // 8. Add to locals so the match arm body can reference it
-                            base_locals.push(_match_make_local_binding(field_binding.field_name, local_alloca_temp, field_binding.field_type, make_child_scope_id(scope_id, body_labels[index]), scope_depth + 1));
+                            base_locals.push(_match_make_local_binding(field_binding.field_name, local_alloca_temp, field_binding.field_type, make_child_scope_id(scope_id, body_labels[index]), scope_depth
+                                + 1));
 
                             base_local_id += 1;
                             binding_idx += 1;
@@ -494,7 +541,12 @@ fn lower_match_instruction(function: NativeFunction, start_index: number, llvm_r
                     let payload_temp = format_temp_name(current_temp);
                     current_temp += 1;
                     let payload_type = union_payload_types[variant_index];
-                    current_lines.push("  " + payload_temp + " = extractvalue " + subject_operand.llvm_type + " " + subject_operand.value + ", " + number_to_string(payload_index));
+                    current_lines.push("  " + payload_temp + " = extractvalue "
+                        + subject_operand.llvm_type
+                        + " "
+                        + subject_operand.value
+                        + ", "
+                        + number_to_string(payload_index));
 
                     let typed_payload_ptr = payload_temp;
                     // If the payload is an opaque pointer, try to preserve the expected struct pointer type.
@@ -502,7 +554,10 @@ fn lower_match_instruction(function: NativeFunction, start_index: number, llvm_r
                     if payload_type == "i8*" {
                         let cast_temp = format_temp_name(current_temp);
                         current_temp += 1;
-                        current_lines.push("  " + cast_temp + " = bitcast i8* " + payload_temp + " to " + expected_ptr_type);
+                        current_lines.push("  " + cast_temp + " = bitcast i8* "
+                            + payload_temp
+                            + " to "
+                            + expected_ptr_type);
                         typed_payload_ptr = cast_temp;
                     }
 
@@ -516,18 +571,38 @@ fn lower_match_instruction(function: NativeFunction, start_index: number, llvm_r
                         // Compute field pointer and load.
                         let gep_temp = format_temp_name(current_temp);
                         current_temp += 1;
-                        current_lines.push("  " + gep_temp + " = getelementptr " + struct_info_val.llvm_name + ", " + expected_ptr_type + " " + typed_payload_ptr + ", i32 0, i32 " + number_to_string(binding.field_index));
+                        current_lines.push("  " + gep_temp + " = getelementptr "
+                            + struct_info_val.llvm_name
+                            + ", "
+                            + expected_ptr_type
+                            + " "
+                            + typed_payload_ptr
+                            + ", i32 0, i32 "
+                            + number_to_string(binding.field_index));
                         let load_temp = format_temp_name(current_temp);
                         current_temp += 1;
-                        current_lines.push("  " + load_temp + " = load " + binding.field_type + ", " + binding.field_type + "* " + gep_temp);
+                        current_lines.push("  " + load_temp + " = load "
+                            + binding.field_type
+                            + ", "
+                            + binding.field_type
+                            + "* "
+                            + gep_temp);
 
                         // Allocate a local for this binding.
                         let local_alloca_temp = format_temp_name(current_temp);
                         current_temp += 1;
-                        current_lines.push("  " + local_alloca_temp + " = alloca " + binding.field_type);
-                        current_lines.push("  store " + binding.field_type + " " + load_temp + ", " + binding.field_type + "* " + local_alloca_temp);
+                        current_lines.push("  " + local_alloca_temp
+                            + " = alloca "
+                            + binding.field_type);
+                        current_lines.push("  store " + binding.field_type + " "
+                            + load_temp
+                            + ", "
+                            + binding.field_type
+                            + "* "
+                            + local_alloca_temp);
 
-                        base_locals.push(_match_make_local_binding(binding.field_name, local_alloca_temp, binding.field_type, make_child_scope_id(scope_id, body_labels[index]), scope_depth + 1));
+                        base_locals.push(_match_make_local_binding(binding.field_name, local_alloca_temp, binding.field_type, make_child_scope_id(scope_id, body_labels[index]), scope_depth
+                            + 1));
                         base_local_id += 1;
                         binding_idx += 1;
                     }
@@ -564,15 +639,29 @@ fn lower_match_instruction(function: NativeFunction, start_index: number, llvm_r
                         let payload_type = union_payload_types[remaining_index];
                         let payload_temp = format_temp_name(current_temp);
                         current_temp += 1;
-                        current_lines.push("  " + payload_temp + " = extractvalue " + subject_operand.llvm_type + " " + subject_operand.value + ", " + number_to_string(payload_index));
+                        current_lines.push("  " + payload_temp
+                            + " = extractvalue "
+                            + subject_operand.llvm_type
+                            + " "
+                            + subject_operand.value
+                            + ", "
+                            + number_to_string(payload_index));
 
                         let local_alloca_temp = format_temp_name(current_temp);
                         current_temp += 1;
-                        current_lines.push("  " + local_alloca_temp + " = alloca " + payload_type);
-                        current_lines.push("  store " + payload_type + " " + payload_temp + ", " + payload_type + "* " + local_alloca_temp);
+                        current_lines.push("  " + local_alloca_temp
+                            + " = alloca "
+                            + payload_type);
+                        current_lines.push("  store " + payload_type + " "
+                            + payload_temp
+                            + ", "
+                            + payload_type
+                            + "* "
+                            + local_alloca_temp);
 
                         base_locals.push(LocalBinding {
-                            name: subject_name, pointer: local_alloca_temp, llvm_type: payload_type, type_annotation: "", ownership: null, consumed: false, scope_id: make_child_scope_id(scope_id, body_labels[index]), scope_depth: scope_depth + 1,
+                            name: subject_name, pointer: local_alloca_temp, llvm_type: payload_type, type_annotation: "", ownership: null, consumed: false, scope_id: make_child_scope_id(scope_id, body_labels[index]), scope_depth: scope_depth
+                                + 1
                         });
                         base_local_id += 1;
                     }
@@ -580,7 +669,8 @@ fn lower_match_instruction(function: NativeFunction, start_index: number, llvm_r
             }
         }
 
-        let body_result = lower_instruction_range(function, case.body_start, case.body_end, llvm_return, bindings, base_locals, base_allocas, [], current_temp, current_block_counter, base_local_id, current_next_region, functions, loop_stack, context, make_child_scope_id(scope_id, body_labels[index]), scope_depth + 1, body_labels[index]);
+        let body_result = lower_instruction_range(function, case.body_start, case.body_end, llvm_return, bindings, base_locals, base_allocas, [], current_temp, current_block_counter, base_local_id, current_next_region, functions, loop_stack, context, make_child_scope_id(scope_id, body_labels[index]), scope_depth
+            + 1, body_labels[index]);
         let mut _ci3: number = 0;
         loop {
             if _ci3 >= body_result.diagnostics.length { break; }
@@ -600,7 +690,7 @@ fn lower_match_instruction(function: NativeFunction, start_index: number, llvm_r
 
         // Track mutations per arm for phi node emission
         arm_mutations_list = append_match_arm_mutations(arm_mutations_list, MatchArmMutations {
-            mutations: body_result.mutations, label: body_labels[index], terminated: body_result.terminated,
+            mutations: body_result.mutations, label: body_labels[index], terminated: body_result.terminated
         });
 
         if !body_result.terminated {
@@ -670,6 +760,6 @@ fn lower_match_instruction(function: NativeFunction, start_index: number, llvm_r
         next_lifetime_region_id: current_next_region,
         next_index: structure.end_index + 1,
         mutations: collected_mutations,
-        string_constants: result_string_constants,
+        string_constants: result_string_constants
     };
 }

--- a/compiler/src/llvm/lowering/instructions_match_condition.sfn
+++ b/compiler/src/llvm/lowering/instructions_match_condition.sfn
@@ -32,7 +32,7 @@ import {
     StringConstant,
     StructFieldInfo,
     StructTypeInfo,
-    TypeContext,
+    TypeContext
 } from "../types";
 import { number_to_string, trim_text } from "../utils";
 import { lower_condition_to_i1 } from "./instructions_condition";
@@ -62,11 +62,16 @@ fn lower_match_case_condition(function_name: string, subject_operand: LLVMOperan
             // This is an enum pattern - extract tag and compare
             let enum_info = resolve_enum_info_for_literal(context, enum_parse.enum_name);
             if enum_info == null {
-                diagnostics.push("llvm lowering: match pattern references unknown enum `" + enum_parse.enum_name + "`");
+                diagnostics.push("llvm lowering: match pattern references unknown enum `"
+                    + enum_parse.enum_name
+                    + "`");
             } else {
                 let variant_info = resolve_enum_variant_info(enum_info, enum_parse.variant_name);
                 if variant_info == null {
-                    diagnostics.push("llvm lowering: enum `" + enum_parse.enum_name + "` has no variant `" + enum_parse.variant_name + "`");
+                    diagnostics.push("llvm lowering: enum `" + enum_parse.enum_name
+                        + "` has no variant `"
+                        + enum_parse.variant_name
+                        + "`");
                 } else {
                     // Map tag type to LLVM integer type
                     let mut tag_llvm_type: string = "i32";
@@ -78,7 +83,11 @@ fn lower_match_case_condition(function_name: string, subject_operand: LLVMOperan
                     // Extract the tag from the subject enum value using extractvalue
                     let tag_temp = format_temp_name(current_temp);
                     current_temp += 1;
-                    current_lines.push("  " + tag_temp + " = extractvalue " + subject_operand.llvm_type + " " + subject_operand.value + ", 0");
+                    current_lines.push("  " + tag_temp + " = extractvalue "
+                        + subject_operand.llvm_type
+                        + " "
+                        + subject_operand.value
+                        + ", 0");
 
                     // Compare the extracted tag with the variant's tag
                     let tag_operand = LLVMOperand {
@@ -138,11 +147,17 @@ fn lower_match_case_condition(function_name: string, subject_operand: LLVMOperan
                                 }
                                 let mut updated_fields = field_bindings;
                                 updated_fields = updated_fields.push(MatchFieldBinding {
-                                    field_name: pattern_field.name, field_type: llvm_field_type, field_offset: found_field.offset,
+                                    field_name: pattern_field.name, field_type: llvm_field_type, field_offset: found_field.offset
                                 });
                                 field_bindings = updated_fields;
                             } else {
-                                diagnostics.push("llvm lowering: match pattern field `" + pattern_field.name + "` not found in variant `" + enum_parse.enum_name + "." + enum_parse.variant_name + "`");
+                                diagnostics.push("llvm lowering: match pattern field `"
+                                    + pattern_field.name
+                                    + "` not found in variant `"
+                                    + enum_parse.enum_name
+                                    + "."
+                                    + enum_parse.variant_name
+                                    + "`");
                             }
 
                             field_idx += 1;
@@ -184,7 +199,12 @@ fn lower_match_case_condition(function_name: string, subject_operand: LLVMOperan
                                 // Extract and compare tag.
                                 let tag_temp = format_temp_name(current_temp);
                                 current_temp += 1;
-                                current_lines.push("  " + tag_temp + " = extractvalue " + subject_operand.llvm_type + " " + subject_operand.value + ", 0");
+                                current_lines.push("  " + tag_temp
+                                    + " = extractvalue "
+                                    + subject_operand.llvm_type
+                                    + " "
+                                    + subject_operand.value
+                                    + ", 0");
                                 let tag_operand = LLVMOperand {
                                     llvm_type: "i32",
                                     value: tag_temp
@@ -229,14 +249,20 @@ fn lower_match_case_condition(function_name: string, subject_operand: LLVMOperan
                                         if field_info != null {
                                             let mut updated_structs = union_struct_bindings;
                                             updated_structs = updated_structs.push(MatchStructFieldBinding {
-                                                field_name: pattern_field.name, field_type: field_info.llvm_type, field_index: field_info.index,
+                                                field_name: pattern_field.name, field_type: field_info.llvm_type, field_index: field_info.index
                                             });
                                             union_struct_bindings = updated_structs;
                                         } else {
-                                            diagnostics.push("llvm lowering: match pattern field `" + pattern_field.name + "` not found in struct `" + struct_parse.type_name + "`");
+                                            diagnostics.push("llvm lowering: match pattern field `"
+                                                + pattern_field.name
+                                                + "` not found in struct `"
+                                                + struct_parse.type_name
+                                                + "`");
                                         }
                                     } else {
-                                        diagnostics.push("llvm lowering: match struct field literal patterns are not supported for `" + pattern_field.name + "`");
+                                        diagnostics.push("llvm lowering: match struct field literal patterns are not supported for `"
+                                            + pattern_field.name
+                                            + "`");
                                     }
                                     fidx += 1;
                                 }
@@ -244,10 +270,16 @@ fn lower_match_case_condition(function_name: string, subject_operand: LLVMOperan
                                 union_variant_index = found_index;
                                 union_struct_info = info;
                             } else {
-                                diagnostics.push("llvm lowering: match struct pattern `" + struct_parse.type_name + "` does not match union type `" + subject_operand.llvm_type + "`");
+                                diagnostics.push("llvm lowering: match struct pattern `"
+                                    + struct_parse.type_name
+                                    + "` does not match union type `"
+                                    + subject_operand.llvm_type
+                                    + "`");
                             }
                         } else {
-                            diagnostics.push("llvm lowering: match pattern references unknown struct `" + struct_parse.type_name + "`");
+                            diagnostics.push("llvm lowering: match pattern references unknown struct `"
+                                + struct_parse.type_name
+                                + "`");
                         }
                     }
                 }
@@ -295,7 +327,9 @@ fn lower_match_case_condition(function_name: string, subject_operand: LLVMOperan
                         current_temp = harmonised.temp_index;
                     }
                 } else {
-                    diagnostics.push("llvm lowering: unable to lower match case pattern in `" + function_name + "`");
+                    diagnostics.push("llvm lowering: unable to lower match case pattern in `"
+                        + function_name
+                        + "`");
                 }
             }
         }
@@ -330,7 +364,9 @@ fn lower_match_case_condition(function_name: string, subject_operand: LLVMOperan
                     condition_operand = merged.operand;
                 }
             } else {
-                diagnostics.push("llvm lowering: unable to lower guard in match case for `" + function_name + "`");
+                diagnostics.push("llvm lowering: unable to lower guard in match case for `"
+                    + function_name
+                    + "`");
             }
         }
     }
@@ -355,6 +391,6 @@ fn lower_match_case_condition(function_name: string, subject_operand: LLVMOperan
         union_variant_index: union_variant_index,
         union_struct_info: union_struct_info,
         union_struct_bindings: union_struct_bindings,
-        string_constants: collected_string_constants,
+        string_constants: collected_string_constants
     };
 }

--- a/compiler/src/llvm/lowering/instructions_match_condition.sfn
+++ b/compiler/src/llvm/lowering/instructions_match_condition.sfn
@@ -1,38 +1,43 @@
 // compiler/src/llvm/lowering/instructions_match_condition.sfn
 //
 // Match case condition lowering (split from instructions_match.sfn).
-
 import { NativeFunction } from "../../native_ir";
-
-import {
-    TypeContext, LocalBinding, ParameterBinding, LLVMOperand,
-    MatchCaseStructure, MatchCaseCondition, MatchFieldBinding,
-    MatchStructFieldBinding, EnumTypeInfo, EnumVariantInfo,
-    StructTypeInfo, StructFieldInfo, StringConstant,
-} from "../types";
-
-import { trim_text, number_to_string } from "../utils";
-import { merge_string_constants, empty_string_constant_set } from "../strings";
-import { find_struct_info_by_name, resolve_enum_info_for_literal, resolve_enum_variant_info } from "../type_context_queries";
-import { ends_with_pointer_suffix, strip_pointer_suffix, layout_annotation_represents_user_value, map_struct_field_annotation } from "../type_mapping";
-import { format_temp_name } from "../expressions_helpers";
 import { lower_expression } from "../expression_lowering/native/core";
 import { emit_boolean_and, emit_comparison_instruction, harmonise_operands } from "../expression_lowering/native/core_operands";
 import { parse_enum_literal, parse_struct_pattern } from "../expression_lowering/native/core_parse";
 import { is_union_llvm_type, parse_union_payload_types } from "../expression_lowering/native/core_text";
+import { format_temp_name } from "../expressions_helpers";
+import { empty_string_constant_set, merge_string_constants } from "../strings";
+import {
+    find_struct_info_by_name,
+    resolve_enum_info_for_literal,
+    resolve_enum_variant_info
+} from "../type_context_queries";
+import {
+    ends_with_pointer_suffix,
+    layout_annotation_represents_user_value,
+    map_struct_field_annotation,
+    strip_pointer_suffix
+} from "../type_mapping";
+import {
+    EnumTypeInfo,
+    EnumVariantInfo,
+    LLVMOperand,
+    LocalBinding,
+    MatchCaseCondition,
+    MatchCaseStructure,
+    MatchFieldBinding,
+    MatchStructFieldBinding,
+    ParameterBinding,
+    StringConstant,
+    StructFieldInfo,
+    StructTypeInfo,
+    TypeContext,
+} from "../types";
+import { number_to_string, trim_text } from "../utils";
 import { lower_condition_to_i1 } from "./instructions_condition";
 
-fn lower_match_case_condition(
-    function_name: string,
-    subject_operand: LLVMOperand,
-    case: MatchCaseStructure,
-    bindings: ParameterBinding[],
-    locals: LocalBinding[],
-    temp_index: number,
-    lines: string[],
-    functions: NativeFunction[],
-    context: TypeContext
-) -> MatchCaseCondition {
+fn lower_match_case_condition(function_name: string, subject_operand: LLVMOperand, case: MatchCaseStructure, bindings: ParameterBinding[], locals: LocalBinding[], temp_index: number, lines: string[], functions: NativeFunction[], context: TypeContext) -> MatchCaseCondition {
     let mut diagnostics: string[] = [];
     let mut current_lines: string[] = lines;
     let mut current_temp: number = temp_index;
@@ -51,9 +56,7 @@ fn lower_match_case_condition(
 
         let mut _if225: boolean = false;
         if enum_parse.recognized {
-            if enum_parse.success {
-                _if225 = true;
-            }
+            if enum_parse.success { _if225 = true; }
         }
         if _if225 {
             // This is an enum pattern - extract tag and compare
@@ -67,18 +70,10 @@ fn lower_match_case_condition(
                 } else {
                     // Map tag type to LLVM integer type
                     let mut tag_llvm_type: string = "i32";
-                    if enum_info.tag_type == "i8" {
-                        tag_llvm_type = "i8";
-                    }
-                    if enum_info.tag_type == "i16" {
-                        tag_llvm_type = "i16";
-                    }
-                    if enum_info.tag_type == "i32" {
-                        tag_llvm_type = "i32";
-                    }
-                    if enum_info.tag_type == "i64" {
-                        tag_llvm_type = "i64";
-                    }
+                    if enum_info.tag_type == "i8" { tag_llvm_type = "i8"; }
+                    if enum_info.tag_type == "i16" { tag_llvm_type = "i16"; }
+                    if enum_info.tag_type == "i32" { tag_llvm_type = "i32"; }
+                    if enum_info.tag_type == "i64" { tag_llvm_type = "i64"; }
 
                     // Extract the tag from the subject enum value using extractvalue
                     let tag_temp = format_temp_name(current_temp);
@@ -86,8 +81,14 @@ fn lower_match_case_condition(
                     current_lines.push("  " + tag_temp + " = extractvalue " + subject_operand.llvm_type + " " + subject_operand.value + ", 0");
 
                     // Compare the extracted tag with the variant's tag
-                    let tag_operand = LLVMOperand { llvm_type: tag_llvm_type, value: tag_temp };
-                    let variant_tag_operand = LLVMOperand { llvm_type: tag_llvm_type, value: number_to_string(variant_info.tag) };
+                    let tag_operand = LLVMOperand {
+                        llvm_type: tag_llvm_type,
+                        value: tag_temp
+                    };
+                    let variant_tag_operand = LLVMOperand {
+                        llvm_type: tag_llvm_type,
+                        value: number_to_string(variant_info.tag)
+                    };
 
                     let comparison = emit_comparison_instruction("==", tag_operand, variant_tag_operand, current_temp, current_lines);
                     let mut _ci4: number = 0;
@@ -104,9 +105,7 @@ fn lower_match_case_condition(
                     if variant_info.fields.length > 0 {
                         let mut field_idx: number = 0;
                         loop {
-                            if field_idx >= enum_parse.fields.length {
-                                break;
-                            }
+                            if field_idx >= enum_parse.fields.length { break; }
                             let pattern_field = enum_parse.fields[field_idx];
                             let mut variant_field_idx: number = 0;
                             let mut found_field: StructFieldInfo? = null;
@@ -139,9 +138,7 @@ fn lower_match_case_condition(
                                 }
                                 let mut updated_fields = field_bindings;
                                 updated_fields = updated_fields.push(MatchFieldBinding {
-                                    field_name: pattern_field.name,
-                                    field_type: llvm_field_type,
-                                    field_offset: found_field.offset,
+                                    field_name: pattern_field.name, field_type: llvm_field_type, field_offset: found_field.offset,
                                 });
                                 field_bindings = updated_fields;
                             } else {
@@ -170,12 +167,12 @@ fn lower_match_case_condition(
                             let mut idx: number = 0;
                             let mut found_index: number = -1;
                             loop {
-                                if idx >= union_parts.length {
-                                    break;
-                                }
+                                if idx >= union_parts.length { break; }
                                 let part = union_parts[idx];
                                 let mut _if234: boolean = false;
-                                if part == info.llvm_name + "*" { _if234 = true; }
+                                if part == info.llvm_name + "*" {
+                                    _if234 = true;
+                                }
                                 if part == info.llvm_name { _if234 = true; }
                                 if _if234 {
                                     found_index = idx;
@@ -188,12 +185,20 @@ fn lower_match_case_condition(
                                 let tag_temp = format_temp_name(current_temp);
                                 current_temp += 1;
                                 current_lines.push("  " + tag_temp + " = extractvalue " + subject_operand.llvm_type + " " + subject_operand.value + ", 0");
-                                let tag_operand = LLVMOperand { llvm_type: "i32", value: tag_temp };
-                                let expected_tag = LLVMOperand { llvm_type: "i32", value: number_to_string(found_index) };
+                                let tag_operand = LLVMOperand {
+                                    llvm_type: "i32",
+                                    value: tag_temp
+                                };
+                                let expected_tag = LLVMOperand {
+                                    llvm_type: "i32",
+                                    value: number_to_string(found_index)
+                                };
                                 let comparison = emit_comparison_instruction("==", tag_operand, expected_tag, current_temp, current_lines);
                                 let mut _ci5: number = 0;
                                 loop {
-                                    if _ci5 >= comparison.diagnostics.length { break; }
+                                    if _ci5 >= comparison.diagnostics.length {
+                                        break;
+                                    }
                                     diagnostics.push(comparison.diagnostics[_ci5]);
                                     _ci5 += 1;
                                 }
@@ -224,9 +229,7 @@ fn lower_match_case_condition(
                                         if field_info != null {
                                             let mut updated_structs = union_struct_bindings;
                                             updated_structs = updated_structs.push(MatchStructFieldBinding {
-                                                field_name: pattern_field.name,
-                                                field_type: field_info.llvm_type,
-                                                field_index: field_info.index,
+                                                field_name: pattern_field.name, field_type: field_info.llvm_type, field_index: field_info.index,
                                             });
                                             union_struct_bindings = updated_structs;
                                         } else {
@@ -272,9 +275,7 @@ fn lower_match_case_condition(
                     }
                     let mut _if231: boolean = false;
                     if harmonised.left != null {
-                        if harmonised.right != null {
-                            _if231 = true;
-                        }
+                        if harmonised.right != null { _if231 = true; }
                     }
                     if _if231 {
                         current_lines = harmonised.lines;
@@ -336,13 +337,9 @@ fn lower_match_case_condition(
 
     let mut is_unconditional_default: boolean = false;
     if case.is_default {
-        if case.guard == null {
-            is_unconditional_default = true;
-        } else {
+        if case.guard == null { is_unconditional_default = true; } else {
             let guard_trimmed = trim_text(case.guard);
-            if guard_trimmed.length == 0 {
-                is_unconditional_default = true;
-            }
+            if guard_trimmed.length == 0 { is_unconditional_default = true; }
         }
     }
 
@@ -358,6 +355,6 @@ fn lower_match_case_condition(
         union_variant_index: union_variant_index,
         union_struct_info: union_struct_info,
         union_struct_bindings: union_struct_bindings,
-    string_constants: collected_string_constants,
+        string_constants: collected_string_constants,
     };
 }

--- a/compiler/src/llvm/lowering/instructions_try.sfn
+++ b/compiler/src/llvm/lowering/instructions_try.sfn
@@ -1,79 +1,46 @@
 // compiler/src/llvm/lowering/instructions_try.sfn
 //
 // Control flow handlers: try/catch/finally/throw instruction lowering.
-
 import { NativeFunction, NativeInstruction, NativeSourceSpan } from "../../native_ir";
-import { substring, char_code, grapheme_at } from "../../string_utils";
-
-import {
-    TypeContext,
-    LocalBinding,
-    ParameterBinding,
-    LLVMOperand,
-    BlockLoweringResult,
-    LetLoweringResult,
-    ThrowLoweringResult,
-    LoopContext,
-    LifetimeRegionMetadata,
-    LifetimeReleaseEvent,
-    OwnershipInfo,
-    OwnershipConsumption,
-    ScopeMetadata,
-    LocalMutation,
-    StringConstant,
-    TryStructure,
-} from "../types";
-
-import {
-    trim_text,
-    append_string,
-    extend_string_array,
-    number_to_string,
-} from "../utils";
-
-import {
-    empty_string_constant_set,
-    merge_string_constants,
-} from "../strings";
-
+import { char_code, grapheme_at, substring } from "../../string_utils";
+import { lower_expression, } from "../expression_lowering/native/core";
+import { coerce_operand_to_type, } from "../expression_lowering/native/core_operands";
+import { append_local_binding, } from "../expression_lowering/native/core_scopes";
 import {
     default_return_literal,
     format_local_pointer_name,
     format_temp_name,
 } from "../expressions_helpers";
-
+import { make_child_scope_id, } from "../lifetime";
+import { empty_string_constant_set, merge_string_constants, } from "../strings";
 import {
-    lower_expression,
-} from "../expression_lowering/native/core";
-
+    BlockLoweringResult,
+    LLVMOperand,
+    LetLoweringResult,
+    LifetimeRegionMetadata,
+    LifetimeReleaseEvent,
+    LocalBinding,
+    LocalMutation,
+    LoopContext,
+    OwnershipConsumption,
+    OwnershipInfo,
+    ParameterBinding,
+    ScopeMetadata,
+    StringConstant,
+    ThrowLoweringResult,
+    TryStructure,
+    TypeContext,
+} from "../types";
 import {
-    coerce_operand_to_type,
-} from "../expression_lowering/native/core_operands";
-
-import {
-    append_local_binding,
-} from "../expression_lowering/native/core_scopes";
-
-import {
-    make_child_scope_id,
-} from "../lifetime";
-
-import {
-    lower_instruction_range,
-} from "./instructions";
-
-import {
-    extend_lifetime_regions,
-    _parse_int_from_string,
-} from "./instructions_helpers";
-
-import {
-    allocate_block_label,
-} from "./instructions_condition";
-
-import {
-    get_instruction_tag,
-} from "./lowering_native_helpers";
+    append_string,
+    extend_string_array,
+    number_to_string,
+    trim_text,
+} from "../utils";
+import { lower_instruction_range, } from "./instructions";
+import { allocate_block_label, } from "./instructions_condition";
+import { _parse_int_from_string, extend_lifetime_regions, } from "./instructions_helpers";
+import { get_instruction_tag, } from "./lowering_native_helpers";
 
 fn collect_try_structure(instructions: NativeInstruction[], start_index: number, end: number, function_name: string) -> TryStructure {
     let mut diagnostics: string[] = [];
@@ -85,9 +52,7 @@ fn collect_try_structure(instructions: NativeInstruction[], start_index: number,
     let mut end_index: number = -1;
 
     loop {
-        if index >= end {
-            break;
-        }
+        if index >= end { break; }
         let _try_tag = get_instruction_tag(instructions, index);
         if _try_tag == 15 {  // Try
             depth += 1;
@@ -107,9 +72,7 @@ fn collect_try_structure(instructions: NativeInstruction[], start_index: number,
             }
         } else if _try_tag == 17 {  // Finally
             if depth == 1 {
-                if finally_index == -1 {
-                    finally_index = index;
-                }
+                if finally_index == -1 { finally_index = index; }
             }
         }
         index += 1;
@@ -122,9 +85,7 @@ fn collect_try_structure(instructions: NativeInstruction[], start_index: number,
 
     let try_start = start_index + 1;
     let mut try_end: number = end_index;
-    if catch_index != -1 {
-        try_end = catch_index;
-    } else if finally_index != -1 {
+    if catch_index != -1 { try_end = catch_index; } else if finally_index != -1 {
         try_end = finally_index;
     }
 
@@ -133,9 +94,7 @@ fn collect_try_structure(instructions: NativeInstruction[], start_index: number,
     if catch_index != -1 {
         catch_start = catch_index + 1;
         catch_end = end_index;
-        if finally_index != -1 {
-            catch_end = finally_index;
-        }
+        if finally_index != -1 { catch_end = finally_index; }
     }
 
     let mut finally_start: number = -1;
@@ -161,32 +120,13 @@ fn collect_try_structure(instructions: NativeInstruction[], start_index: number,
     };
 }
 
-fn lower_throw_instruction(
-    function_name: string,
-    instruction: NativeInstruction,
-    llvm_return: string,
-    bindings: ParameterBinding[],
-    locals: LocalBinding[],
-    temp_index: number,
-    lines: string[],
-    functions: NativeFunction[],
-    context: TypeContext
-) -> ThrowLoweringResult ![io] {
+fn lower_throw_instruction(function_name: string, instruction: NativeInstruction, llvm_return: string, bindings: ParameterBinding[], locals: LocalBinding[], temp_index: number, lines: string[], functions: NativeFunction[], context: TypeContext) -> ThrowLoweringResult ![io] {
     let mut diagnostics: string[] = [];
     let mut current_lines: string[] = lines;
     let mut current_temp: number = temp_index;
     let mut collected_string_constants: StringConstant[] = empty_string_constant_set();
 
-    let lowered_expr = lower_expression(
-        instruction.expression,
-        bindings,
-        locals,
-        current_temp,
-        current_lines,
-        functions,
-        context,
-        "i8*"
-    );
+    let lowered_expr = lower_expression(instruction.expression, bindings, locals, current_temp, current_lines, functions, context, "i8*");
     let mut _ci0: number = 0;
     loop {
         if _ci0 >= lowered_expr.diagnostics.length { break; }
@@ -200,7 +140,13 @@ fn lower_throw_instruction(
     if lowered_expr.operand == null {
         diagnostics.push("llvm lowering: unsupported throw expression in `" + function_name + "`");
         current_lines.push("  unreachable");
-        return ThrowLoweringResult { lines: current_lines, temp_index: current_temp, diagnostics: diagnostics, terminated: true, string_constants: collected_string_constants };
+        return ThrowLoweringResult {
+            lines: current_lines,
+            temp_index: current_temp,
+            diagnostics: diagnostics,
+            terminated: true,
+            string_constants: collected_string_constants
+        };
     }
 
     let coerced = coerce_operand_to_type(lowered_expr.operand, "i8*", current_temp, current_lines);
@@ -215,40 +161,31 @@ fn lower_throw_instruction(
     if coerced.operand == null {
         diagnostics.push("llvm lowering: unable to coerce throw value to string in `" + function_name + "`");
         current_lines.push("  unreachable");
-        return ThrowLoweringResult { lines: current_lines, temp_index: current_temp, diagnostics: diagnostics, terminated: true, string_constants: collected_string_constants };
+        return ThrowLoweringResult {
+            lines: current_lines,
+            temp_index: current_temp,
+            diagnostics: diagnostics,
+            terminated: true,
+            string_constants: collected_string_constants
+        };
     }
 
     current_lines.push("  call void @sailfin_runtime_set_exception(i8* " + coerced.operand.value + ")");
-    if llvm_return == "void" {
-        current_lines.push("  ret void");
-    } else {
+    if llvm_return == "void" { current_lines.push("  ret void"); } else {
         current_lines.push("  ret " + llvm_return + " " + default_return_literal(llvm_return));
     }
-    return ThrowLoweringResult { lines: current_lines, temp_index: current_temp, diagnostics: diagnostics, terminated: true, string_constants: collected_string_constants };
+    return ThrowLoweringResult {
+        lines: current_lines,
+        temp_index: current_temp,
+        diagnostics: diagnostics,
+        terminated: true,
+        string_constants: collected_string_constants
+    };
 }
 
 // Read all BlockLoweringResult fields from the file IPC written by _write_block_result_files.
 // Same-module struct return avoids the v0.1.1 seed ABI corruption for cross-module returns.
-fn lower_try_instruction(
-    function: NativeFunction,
-    start_index: number,
-    llvm_return: string,
-    bindings: ParameterBinding[],
-    locals: LocalBinding[],
-    allocas: string[],
-    lines: string[],
-    temp_index: number,
-    block_counter: number,
-    next_local_id: number,
-    next_region_id: number,
-    functions: NativeFunction[],
-    loop_stack: LoopContext[],
-    end: number,
-    context: TypeContext,
-    scope_id: string,
-    scope_depth: number,
-    current_label: string
-) -> BlockLoweringResult {
+fn lower_try_instruction(function: NativeFunction, start_index: number, llvm_return: string, bindings: ParameterBinding[], locals: LocalBinding[], allocas: string[], lines: string[], temp_index: number, block_counter: number, next_local_id: number, next_region_id: number, functions: NativeFunction[], loop_stack: LoopContext[], end: number, context: TypeContext, scope_id: string, scope_depth: number, current_label: string) -> BlockLoweringResult {
     let mut diagnostics: string[] = [];
     let structure = collect_try_structure(function.instructions, start_index, end, function.name);
     let mut _ci2: number = 0;
@@ -299,26 +236,7 @@ fn lower_try_instruction(
     // Try block
     current_lines.push(try_label + ":");
     let try_scope_id = make_child_scope_id(scope_id, try_label);
-    let try_result = lower_instruction_range(
-        function,
-        structure.try_start,
-        structure.try_end,
-        llvm_return,
-        current_bindings,
-        current_locals,
-        current_allocas,
-        [],
-        current_temp,
-        current_block_counter,
-        current_next_local,
-        current_next_region,
-        functions,
-        loop_stack,
-        context,
-        try_scope_id,
-        scope_depth + 1,
-        try_label
-    );
+    let try_result = lower_instruction_range(function, structure.try_start, structure.try_end, llvm_return, current_bindings, current_locals, current_allocas, [], current_temp, current_block_counter, current_next_local, current_next_region, functions, loop_stack, context, try_scope_id, scope_depth + 1, try_label);
     let mut _ci3: number = 0;
     loop {
         if _ci3 >= try_result.diagnostics.length { break; }
@@ -339,9 +257,7 @@ fn lower_try_instruction(
         current_temp += 1;
         current_lines.push("  " + has_exc + " = call i1 @sailfin_runtime_has_exception()");
         let normal_target = merge_label;
-        if structure.finally_index != -1 {
-            normal_target = finally_label;
-        }
+        if structure.finally_index != -1 { normal_target = finally_label; }
         if structure.catch_index != -1 {
             current_lines.push("  br i1 " + has_exc + ", label %" + catch_label + ", label %" + normal_target);
         } else {
@@ -367,42 +283,13 @@ fn lower_try_instruction(
                 current_next_local += 1;
                 current_allocas.push("  " + err_slot + " = alloca i8*");
                 current_lines.push("  store i8* " + exception_temp + ", i8** " + err_slot);
-                catch_locals = append_local_binding(
-                    catch_locals,
-                    LocalBinding {
-                        name: trimmed_name,
-                        pointer: err_slot,
-                        llvm_type: "i8*",
-                        type_annotation: "string",
-                        ownership: null,
-                        consumed: false,
-                        scope_id: catch_scope_id,
-                        scope_depth: scope_depth + 1,
-                    }
-                );
+                catch_locals = append_local_binding(catch_locals, LocalBinding {
+                    name: trimmed_name, pointer: err_slot, llvm_type: "i8*", type_annotation: "string", ownership: null, consumed: false, scope_id: catch_scope_id, scope_depth: scope_depth + 1,
+                });
             }
         }
 
-        let catch_result = lower_instruction_range(
-            function,
-            structure.catch_start,
-            structure.catch_end,
-            llvm_return,
-            current_bindings,
-            catch_locals,
-            current_allocas,
-            [],
-            current_temp,
-            current_block_counter,
-            current_next_local,
-            current_next_region,
-            functions,
-            loop_stack,
-            context,
-            catch_scope_id,
-            scope_depth + 1,
-            catch_label
-        );
+        let catch_result = lower_instruction_range(function, structure.catch_start, structure.catch_end, llvm_return, current_bindings, catch_locals, current_allocas, [], current_temp, current_block_counter, current_next_local, current_next_region, functions, loop_stack, context, catch_scope_id, scope_depth + 1, catch_label);
         let mut _ci4: number = 0;
         loop {
             if _ci4 >= catch_result.diagnostics.length { break; }
@@ -420,9 +307,7 @@ fn lower_try_instruction(
 
         if !catch_result.terminated {
             let target = merge_label;
-            if structure.finally_index != -1 {
-                target = finally_label;
-            }
+            if structure.finally_index != -1 { target = finally_label; }
             current_lines.push("  br label %" + target);
         }
     }
@@ -430,26 +315,7 @@ fn lower_try_instruction(
     if structure.finally_index != -1 {
         current_lines.push(finally_label + ":");
         let finally_scope_id = make_child_scope_id(scope_id, finally_label);
-        let finally_result = lower_instruction_range(
-            function,
-            structure.finally_start,
-            structure.finally_end,
-            llvm_return,
-            current_bindings,
-            current_locals,
-            current_allocas,
-            [],
-            current_temp,
-            current_block_counter,
-            current_next_local,
-            current_next_region,
-            functions,
-            loop_stack,
-            context,
-            finally_scope_id,
-            scope_depth + 1,
-            finally_label
-        );
+        let finally_result = lower_instruction_range(function, structure.finally_start, structure.finally_end, llvm_return, current_bindings, current_locals, current_allocas, [], current_temp, current_block_counter, current_next_local, current_next_region, functions, loop_stack, context, finally_scope_id, scope_depth + 1, finally_label);
         let mut _ci5: number = 0;
         loop {
             if _ci5 >= finally_result.diagnostics.length { break; }
@@ -484,9 +350,7 @@ fn lower_try_instruction(
     current_block_counter = continue_label_alloc.next_counter;
     current_lines.push("  br i1 " + has_exc_after + ", label %" + propagate_label + ", label %" + continue_label);
     current_lines.push(propagate_label + ":");
-    if llvm_return == "void" {
-        current_lines.push("  ret void");
-    } else {
+    if llvm_return == "void" { current_lines.push("  ret void"); } else {
         current_lines.push("  ret " + llvm_return + " " + default_return_literal(llvm_return));
     }
     current_lines.push(continue_label + ":");

--- a/compiler/src/llvm/lowering/instructions_try.sfn
+++ b/compiler/src/llvm/lowering/instructions_try.sfn
@@ -3,16 +3,12 @@
 // Control flow handlers: try/catch/finally/throw instruction lowering.
 import { NativeFunction, NativeInstruction, NativeSourceSpan } from "../../native_ir";
 import { char_code, grapheme_at, substring } from "../../string_utils";
-import { lower_expression, } from "../expression_lowering/native/core";
-import { coerce_operand_to_type, } from "../expression_lowering/native/core_operands";
-import { append_local_binding, } from "../expression_lowering/native/core_scopes";
-import {
-    default_return_literal,
-    format_local_pointer_name,
-    format_temp_name,
-} from "../expressions_helpers";
-import { make_child_scope_id, } from "../lifetime";
-import { empty_string_constant_set, merge_string_constants, } from "../strings";
+import { lower_expression } from "../expression_lowering/native/core";
+import { coerce_operand_to_type } from "../expression_lowering/native/core_operands";
+import { append_local_binding } from "../expression_lowering/native/core_scopes";
+import { default_return_literal, format_local_pointer_name, format_temp_name } from "../expressions_helpers";
+import { make_child_scope_id } from "../lifetime";
+import { empty_string_constant_set, merge_string_constants } from "../strings";
 import {
     BlockLoweringResult,
     LLVMOperand,
@@ -29,18 +25,18 @@ import {
     StringConstant,
     ThrowLoweringResult,
     TryStructure,
-    TypeContext,
+    TypeContext
 } from "../types";
 import {
     append_string,
     extend_string_array,
     number_to_string,
-    trim_text,
+    trim_text
 } from "../utils";
-import { lower_instruction_range, } from "./instructions";
-import { allocate_block_label, } from "./instructions_condition";
-import { _parse_int_from_string, extend_lifetime_regions, } from "./instructions_helpers";
-import { get_instruction_tag, } from "./lowering_native_helpers";
+import { lower_instruction_range } from "./instructions";
+import { allocate_block_label } from "./instructions_condition";
+import { _parse_int_from_string, extend_lifetime_regions } from "./instructions_helpers";
+import { get_instruction_tag } from "./lowering_native_helpers";
 
 fn collect_try_structure(instructions: NativeInstruction[], start_index: number, end: number, function_name: string) -> TryStructure {
     let mut diagnostics: string[] = [];
@@ -79,7 +75,9 @@ fn collect_try_structure(instructions: NativeInstruction[], start_index: number,
     }
 
     if end_index == -1 {
-        diagnostics.push("llvm lowering: try without endtry in `" + function_name + "`");
+        diagnostics.push("llvm lowering: try without endtry in `"
+            + function_name
+            + "`");
         end_index = end - 1;
     }
 
@@ -116,7 +114,7 @@ fn collect_try_structure(instructions: NativeInstruction[], start_index: number,
         finally_end: finally_end,
         end_index: end_index,
         next_index: end_index + 1,
-        diagnostics: diagnostics,
+        diagnostics: diagnostics
     };
 }
 
@@ -138,7 +136,9 @@ fn lower_throw_instruction(function_name: string, instruction: NativeInstruction
     collected_string_constants = merge_string_constants(collected_string_constants, lowered_expr.string_constants);
 
     if lowered_expr.operand == null {
-        diagnostics.push("llvm lowering: unsupported throw expression in `" + function_name + "`");
+        diagnostics.push("llvm lowering: unsupported throw expression in `"
+            + function_name
+            + "`");
         current_lines.push("  unreachable");
         return ThrowLoweringResult {
             lines: current_lines,
@@ -159,7 +159,9 @@ fn lower_throw_instruction(function_name: string, instruction: NativeInstruction
     current_lines = coerced.lines;
     current_temp = coerced.temp_index;
     if coerced.operand == null {
-        diagnostics.push("llvm lowering: unable to coerce throw value to string in `" + function_name + "`");
+        diagnostics.push("llvm lowering: unable to coerce throw value to string in `"
+            + function_name
+            + "`");
         current_lines.push("  unreachable");
         return ThrowLoweringResult {
             lines: current_lines,
@@ -170,7 +172,9 @@ fn lower_throw_instruction(function_name: string, instruction: NativeInstruction
         };
     }
 
-    current_lines.push("  call void @sailfin_runtime_set_exception(i8* " + coerced.operand.value + ")");
+    current_lines.push("  call void @sailfin_runtime_set_exception(i8* "
+        + coerced.operand.value
+        + ")");
     if llvm_return == "void" { current_lines.push("  ret void"); } else {
         current_lines.push("  ret " + llvm_return + " " + default_return_literal(llvm_return));
     }
@@ -236,7 +240,8 @@ fn lower_try_instruction(function: NativeFunction, start_index: number, llvm_ret
     // Try block
     current_lines.push(try_label + ":");
     let try_scope_id = make_child_scope_id(scope_id, try_label);
-    let try_result = lower_instruction_range(function, structure.try_start, structure.try_end, llvm_return, current_bindings, current_locals, current_allocas, [], current_temp, current_block_counter, current_next_local, current_next_region, functions, loop_stack, context, try_scope_id, scope_depth + 1, try_label);
+    let try_result = lower_instruction_range(function, structure.try_start, structure.try_end, llvm_return, current_bindings, current_locals, current_allocas, [], current_temp, current_block_counter, current_next_local, current_next_region, functions, loop_stack, context, try_scope_id, scope_depth
+        + 1, try_label);
     let mut _ci3: number = 0;
     loop {
         if _ci3 >= try_result.diagnostics.length { break; }
@@ -255,11 +260,14 @@ fn lower_try_instruction(function: NativeFunction, start_index: number, llvm_ret
     if !try_result.terminated {
         let has_exc = format_temp_name(current_temp);
         current_temp += 1;
-        current_lines.push("  " + has_exc + " = call i1 @sailfin_runtime_has_exception()");
+        current_lines.push("  " + has_exc
+            + " = call i1 @sailfin_runtime_has_exception()");
         let normal_target = merge_label;
         if structure.finally_index != -1 { normal_target = finally_label; }
         if structure.catch_index != -1 {
-            current_lines.push("  br i1 " + has_exc + ", label %" + catch_label + ", label %" + normal_target);
+            current_lines.push("  br i1 " + has_exc + ", label %" + catch_label
+                + ", label %"
+                + normal_target);
         } else {
             // No catch: proceed to normal target; any pending exception will be propagated after finally/merge.
             current_lines.push("  br label %" + normal_target);
@@ -272,7 +280,8 @@ fn lower_try_instruction(function: NativeFunction, start_index: number, llvm_ret
         let catch_scope_id = make_child_scope_id(scope_id, catch_label);
         let exception_temp = format_temp_name(current_temp);
         current_temp += 1;
-        current_lines.push("  " + exception_temp + " = call i8* @sailfin_runtime_take_exception()");
+        current_lines.push("  " + exception_temp
+            + " = call i8* @sailfin_runtime_take_exception()");
 
         let mut catch_locals: LocalBinding[] = current_locals;
         let trimmed_name = trim_text(structure.catch_name);
@@ -282,14 +291,17 @@ fn lower_try_instruction(function: NativeFunction, start_index: number, llvm_ret
                 let err_slot = format_local_pointer_name(current_next_local);
                 current_next_local += 1;
                 current_allocas.push("  " + err_slot + " = alloca i8*");
-                current_lines.push("  store i8* " + exception_temp + ", i8** " + err_slot);
+                current_lines.push("  store i8* " + exception_temp + ", i8** "
+                    + err_slot);
                 catch_locals = append_local_binding(catch_locals, LocalBinding {
-                    name: trimmed_name, pointer: err_slot, llvm_type: "i8*", type_annotation: "string", ownership: null, consumed: false, scope_id: catch_scope_id, scope_depth: scope_depth + 1,
+                    name: trimmed_name, pointer: err_slot, llvm_type: "i8*", type_annotation: "string", ownership: null, consumed: false, scope_id: catch_scope_id, scope_depth: scope_depth
+                        + 1
                 });
             }
         }
 
-        let catch_result = lower_instruction_range(function, structure.catch_start, structure.catch_end, llvm_return, current_bindings, catch_locals, current_allocas, [], current_temp, current_block_counter, current_next_local, current_next_region, functions, loop_stack, context, catch_scope_id, scope_depth + 1, catch_label);
+        let catch_result = lower_instruction_range(function, structure.catch_start, structure.catch_end, llvm_return, current_bindings, catch_locals, current_allocas, [], current_temp, current_block_counter, current_next_local, current_next_region, functions, loop_stack, context, catch_scope_id, scope_depth
+            + 1, catch_label);
         let mut _ci4: number = 0;
         loop {
             if _ci4 >= catch_result.diagnostics.length { break; }
@@ -315,7 +327,8 @@ fn lower_try_instruction(function: NativeFunction, start_index: number, llvm_ret
     if structure.finally_index != -1 {
         current_lines.push(finally_label + ":");
         let finally_scope_id = make_child_scope_id(scope_id, finally_label);
-        let finally_result = lower_instruction_range(function, structure.finally_start, structure.finally_end, llvm_return, current_bindings, current_locals, current_allocas, [], current_temp, current_block_counter, current_next_local, current_next_region, functions, loop_stack, context, finally_scope_id, scope_depth + 1, finally_label);
+        let finally_result = lower_instruction_range(function, structure.finally_start, structure.finally_end, llvm_return, current_bindings, current_locals, current_allocas, [], current_temp, current_block_counter, current_next_local, current_next_region, functions, loop_stack, context, finally_scope_id, scope_depth
+            + 1, finally_label);
         let mut _ci5: number = 0;
         loop {
             if _ci5 >= finally_result.diagnostics.length { break; }
@@ -341,14 +354,18 @@ fn lower_try_instruction(function: NativeFunction, start_index: number, llvm_ret
     // If an exception is still pending after try/catch/finally, propagate it.
     let has_exc_after = format_temp_name(current_temp);
     current_temp += 1;
-    current_lines.push("  " + has_exc_after + " = call i1 @sailfin_runtime_has_exception()");
+    current_lines.push("  " + has_exc_after
+        + " = call i1 @sailfin_runtime_has_exception()");
     let propagate_label_alloc = allocate_block_label("try.propagate", current_block_counter);
     let propagate_label = propagate_label_alloc.label;
     current_block_counter = propagate_label_alloc.next_counter;
     let continue_label_alloc = allocate_block_label("try.continue", current_block_counter);
     let continue_label = continue_label_alloc.label;
     current_block_counter = continue_label_alloc.next_counter;
-    current_lines.push("  br i1 " + has_exc_after + ", label %" + propagate_label + ", label %" + continue_label);
+    current_lines.push("  br i1 " + has_exc_after + ", label %"
+        + propagate_label
+        + ", label %"
+        + continue_label);
     current_lines.push(propagate_label + ":");
     if llvm_return == "void" { current_lines.push("  ret void"); } else {
         current_lines.push("  ret " + llvm_return + " " + default_return_literal(llvm_return));
@@ -369,6 +386,6 @@ fn lower_try_instruction(function: NativeFunction, start_index: number, llvm_ret
         next_lifetime_region_id: current_next_region,
         next_index: structure.next_index,
         mutations: [],
-        string_constants: collected_string_constants,
+        string_constants: collected_string_constants
     };
 }

--- a/compiler/src/llvm/lowering/lowering_core.sfn
+++ b/compiler/src/llvm/lowering/lowering_core.sfn
@@ -25,13 +25,13 @@ import {
     NativeParameter,
     NativeStruct,
     NativeStructField,
-    ParseNativeResult,
+    ParseNativeResult
 } from "../../native_ir";
 import {
     parse_native_bindings_from_text,
     parse_native_function_count_from_text,
     parse_native_functions_from_text,
-    parse_native_structs_for_import,
+    parse_native_structs_for_import
 } from "../../native_ir_api";
 import { substring } from "../../string_utils";
 import {
@@ -39,14 +39,14 @@ import {
     collect_direct_function_effects,
     collect_function_call_graph,
     collect_runtime_helper_targets,
-    propagate_function_effects,
+    propagate_function_effects
 } from "../effects";
 import {
     apply_layout_manifest_to_module,
-    collect_imported_module_context_for_module,
+    collect_imported_module_context_for_module
 } from "../imports";
-import { collect_exported_symbol_names, } from "../rendering_helpers";
-import { empty_string_constant_set, escape_string_for_llvm, } from "../strings";
+import { collect_exported_symbol_names } from "../rendering_helpers";
+import { empty_string_constant_set, escape_string_for_llvm } from "../strings";
 import {
     FunctionEffectEntry,
     LifetimeRegionMetadata,
@@ -54,13 +54,13 @@ import {
     LoweredLLVMLinesResult,
     StringConstant,
     TraitMetadata,
-    TypeContext,
+    TypeContext
 } from "../types";
 import {
     index_of,
     number_to_string,
     sanitize_symbol,
-    string_array_contains,
+    string_array_contains
 } from "../utils";
 import {
     collect_defined_function_symbols,
@@ -69,7 +69,7 @@ import {
     extend_native_interfaces,
     extend_native_structs,
     is_test_module_slug,
-    render_test_harness_main_for_module,
+    render_test_harness_main_for_module
 } from "./lowering_helpers";
 import {
     apply_module_symbol_mangling,
@@ -77,22 +77,22 @@ import {
     concat_native_functions,
     empty_capability_manifest,
     extend_native_functions_inplace,
-    flatten_struct_methods,
+    flatten_struct_methods
 } from "./lowering_helpers_mangling";
 import {
     append_string_lines,
     extend_string_lines,
     extend_string_lines_checked,
     module_source_filename,
-    write_llvm_lines_chunked,
+    write_llvm_lines_chunked
 } from "./lowering_io";
-import { lower_all_functions, } from "./lowering_phase_functions";
+import { lower_all_functions } from "./lowering_phase_functions";
 import {
     extract_import_struct_methods,
     parse_single_import_functions,
-    parse_single_import_interfaces,
+    parse_single_import_interfaces
 } from "./lowering_phase_imports";
-import { render_llvm_preamble, } from "./lowering_phase_render";
+import { render_llvm_preamble } from "./lowering_phase_render";
 // Phase modules
 import {
     recover_safe_functions,
@@ -107,22 +107,22 @@ import {
     sanitize_imports,
     sanitize_interfaces,
     sanitize_lowering_inputs,
-    sanitize_structs,
+    sanitize_structs
 } from "./lowering_phase_sanitize";
-import { build_type_context_with_recovery, serialize_context_functions, } from "./lowering_phase_types";
+import { build_type_context_with_recovery, serialize_context_functions } from "./lowering_phase_types";
 import {
     recover_functions_for_lowering,
     recover_native_enums_light,
     recover_native_functions_light,
     recover_native_imports_light,
-    recover_native_structs_light,
+    recover_native_structs_light
 } from "./lowering_recovery";
 import {
     _parse_lowered_fn_string_constants,
     _parse_module_globals_locals,
-    split_lines_local,
+    split_lines_local
 } from "./lowering_text_utils";
-import { lower_module_bindings_to_globals, } from "./module_globals";
+import { lower_module_bindings_to_globals } from "./module_globals";
 
 // Consolidated: parse all structure from native text using light recovery.
 // Kept in lowering_core to preserve cross-module symbol mangling compatibility
@@ -139,7 +139,7 @@ fn build_parse_result_from_text(native_text: string) -> ParseNativeResult {
         interfaces: [],
         enums: recovered_enums,
         bindings: [],
-        diagnostics: [],
+        diagnostics: []
     };
 }
 
@@ -188,18 +188,44 @@ fn lower_to_llvm_lines_with_parsed_context_for_tests(native_module: NativeModule
                 let idx_s = number_to_string(test_idx);
                 let msg_arr_len = number_to_string(msg.length + 1);
                 let escaped = escape_string_for_llvm(msg);
-                harness_globals = extend_string_lines(harness_globals, ["@.tname." + idx_s + " = private unnamed_addr constant [" + msg_arr_len + " x i8] c\"" + escaped + "\\00\"",]);
-                harness = extend_string_lines(harness, ["  %tn" + idx_s + " = getelementptr [" + msg_arr_len + " x i8], [" + msg_arr_len + " x i8]* @.tname." + idx_s + ", i64 0, i64 0", "  call void @sailfin_runtime_print_err(i8* %tn" + idx_s + ")", "  call void @" + sym + "()",]);
+                harness_globals = extend_string_lines(harness_globals, ["@.tname."
+                    + idx_s
+                    + " = private unnamed_addr constant ["
+                    + msg_arr_len
+                    + " x i8] c\""
+                    + escaped
+                    + "\\00\"",]);
+                harness = extend_string_lines(harness, ["  %tn" + idx_s
+                    + " = getelementptr ["
+                    + msg_arr_len
+                    + " x i8], ["
+                    + msg_arr_len
+                    + " x i8]* @.tname."
+                    + idx_s
+                    + ", i64 0, i64 0", "  call void @sailfin_runtime_print_err(i8* %tn"
+                    + idx_s
+                    + ")", "  call void @"
+                    + sym
+                    + "()",]);
                 test_idx += 1;
             }
         }
         ti += 1;
     }
-    let pass_msg = "  PASS  (all " + number_to_string(test_idx) + " tests passed)";
+    let pass_msg = "  PASS  (all " + number_to_string(test_idx)
+        + " tests passed)";
     let pass_escaped = escape_string_for_llvm(pass_msg);
     let pass_len_s = number_to_string(pass_msg.length + 1);
-    harness_globals = extend_string_lines(harness_globals, ["@.tpass = private unnamed_addr constant [" + pass_len_s + " x i8] c\"" + pass_escaped + "\\00\"",]);
-    harness = extend_string_lines(harness, ["  %tp = getelementptr [" + pass_len_s + " x i8], [" + pass_len_s + " x i8]* @.tpass, i64 0, i64 0", "  call void @sailfin_runtime_print_err(i8* %tp)", "  ret i32 0", "}",]);
+    harness_globals = extend_string_lines(harness_globals, ["@.tpass = private unnamed_addr constant ["
+        + pass_len_s
+        + " x i8] c\""
+        + pass_escaped
+        + "\\00\"",]);
+    harness = extend_string_lines(harness, ["  %tp = getelementptr ["
+        + pass_len_s
+        + " x i8], ["
+        + pass_len_s
+        + " x i8]* @.tpass, i64 0, i64 0", "  call void @sailfin_runtime_print_err(i8* %tp)", "  ret i32 0", "}",]);
 
     let mut updated = base;
     if updated.lines.length > 0 {
@@ -218,7 +244,7 @@ fn make_native_module_for_emit(module_name: string, native_text: string) -> Nati
             name: module_name, format: "sailfin-native-text", contents: native_text
         }],
         entry_points: [],
-        symbol_count: 0,
+        symbol_count: 0
     };
 }
 
@@ -307,7 +333,11 @@ fn lower_to_llvm_lines_with_parsed_context(native_module: NativeModule, parse_in
                 if first_import.specifiers != null {
                     import_spec_count = first_import.specifiers.length;
                 }
-                print.err("emit-llvm: safe_imports[0].kind=" + import_kind + " module=" + import_module + " specs=" + number_to_string(import_spec_count));
+                print.err("emit-llvm: safe_imports[0].kind=" + import_kind
+                    + " module="
+                    + import_module
+                    + " specs="
+                    + number_to_string(import_spec_count));
             } else { print.err("emit-llvm: safe_imports[0]=<null>"); }
         }
     }
@@ -322,7 +352,9 @@ fn lower_to_llvm_lines_with_parsed_context(native_module: NativeModule, parse_in
     safe_functions = recover_safe_functions(safe_functions, native_text_override_path, debug_lowering);
 
     if debug_lowering {
-        print.err("emit-llvm: functions parsed=" + number_to_string(parse.functions.length) + " safe=" + number_to_string(safe_functions.length));
+        print.err("emit-llvm: functions parsed=" + number_to_string(parse.functions.length)
+            + " safe="
+            + number_to_string(safe_functions.length));
     }
 
     safe_structs = recover_structs_if_corrupt(safe_structs, native_text_override_path, debug_lowering);
@@ -706,7 +738,13 @@ fn lower_to_llvm_lines_with_parsed_context(native_module: NativeModule, parse_in
             }
             i += 1;
         }
-        print.err("test llvm: lowered lines=" + number_to_string(lines.length) + " nonempty=" + number_to_string(nonempty) + " first_len=" + number_to_string(first_len) + " diagnostics=" + number_to_string(diagnostics.length));
+        print.err("test llvm: lowered lines=" + number_to_string(lines.length)
+            + " nonempty="
+            + number_to_string(nonempty)
+            + " first_len="
+            + number_to_string(first_len)
+            + " diagnostics="
+            + number_to_string(diagnostics.length));
         let mut diag_index: number = 0;
         loop {
             if diag_index >= diagnostics.length { break; }
@@ -715,7 +753,15 @@ fn lower_to_llvm_lines_with_parsed_context(native_module: NativeModule, parse_in
         }
     }
     if lines.length == 0 {
-        print.err("emit-llvm: lowering produced no lines (functions=" + number_to_string(local_functions.length) + " structs=" + number_to_string(module_structs.length) + " enums=" + number_to_string(module_enums.length) + " diagnostics=" + number_to_string(diagnostics.length) + ")");
+        print.err("emit-llvm: lowering produced no lines (functions="
+            + number_to_string(local_functions.length)
+            + " structs="
+            + number_to_string(module_structs.length)
+            + " enums="
+            + number_to_string(module_enums.length)
+            + " diagnostics="
+            + number_to_string(diagnostics.length)
+            + ")");
     }
     if debug_lowering {
         print.err("emit-llvm: phase=end lines=" + number_to_string(lines.length));
@@ -727,6 +773,6 @@ fn lower_to_llvm_lines_with_parsed_context(native_module: NativeModule, parse_in
         function_effects: function_effects,
         lifetime_regions: lifetime_regions,
         capability_manifest: manifest,
-        string_constants: all_string_constants,
+        string_constants: all_string_constants
     };
 }

--- a/compiler/src/llvm/lowering/lowering_core.sfn
+++ b/compiler/src/llvm/lowering/lowering_core.sfn
@@ -12,149 +12,117 @@
 //   lowering_text_utils.sfn     — text processing and structured data parsers
 //   lowering_recovery.sfn       — light recovery parsers for functions/structs/imports
 //   lowering_io.sfn             — string array ops, file I/O, intrinsics
-
 import { NativeModule } from "../../emit_native";
 import { NativeArtifact } from "../../emit_native_layout";
 import {
-    NativeImport,
+    LayoutManifest,
+    NativeBinding,
+    NativeEnum,
     NativeFunction,
-    NativeParameter,
+    NativeImport,
     NativeInstruction,
     NativeInterface,
+    NativeParameter,
     NativeStruct,
     NativeStructField,
-    NativeEnum,
-    LayoutManifest,
     ParseNativeResult,
-    NativeBinding,
 } from "../../native_ir";
 import {
+    parse_native_bindings_from_text,
     parse_native_function_count_from_text,
     parse_native_functions_from_text,
-    parse_native_bindings_from_text,
     parse_native_structs_for_import,
 } from "../../native_ir_api";
 import { substring } from "../../string_utils";
-
 import {
-    TypeContext,
-    TraitMetadata,
-    LoweredLLVMLinesResult,
+    append_unique_effect,
+    collect_direct_function_effects,
+    collect_function_call_graph,
+    collect_runtime_helper_targets,
+    propagate_function_effects,
+} from "../effects";
+import {
+    apply_layout_manifest_to_module,
+    collect_imported_module_context_for_module,
+} from "../imports";
+import { collect_exported_symbol_names, } from "../rendering_helpers";
+import { empty_string_constant_set, escape_string_for_llvm, } from "../strings";
+import {
     FunctionEffectEntry,
     LifetimeRegionMetadata,
-    StringConstant,
     LocalBinding,
+    LoweredLLVMLinesResult,
+    StringConstant,
+    TraitMetadata,
+    TypeContext,
 } from "../types";
-
 import {
+    index_of,
     number_to_string,
     sanitize_symbol,
     string_array_contains,
-    index_of,
 } from "../utils";
-
 import {
-    empty_string_constant_set,
-    escape_string_for_llvm,
-} from "../strings";
-
-import {
-    collect_direct_function_effects,
-    collect_function_call_graph,
-    propagate_function_effects,
-    collect_runtime_helper_targets,
-    append_unique_effect,
-} from "../effects";
-
-import {
-    collect_exported_symbol_names,
-} from "../rendering_helpers";
-
-import {
-    collect_imported_module_context_for_module,
-    apply_layout_manifest_to_module,
-} from "../imports";
-
-import {
-    lower_module_bindings_to_globals,
-} from "./module_globals";
-
-import {
-    extend_native_structs,
+    collect_defined_function_symbols,
     extend_native_enums,
-    extend_native_interfaces,
     extend_native_functions,
+    extend_native_interfaces,
+    extend_native_structs,
     is_test_module_slug,
     render_test_harness_main_for_module,
-    collect_defined_function_symbols,
 } from "./lowering_helpers";
-
 import {
     apply_module_symbol_mangling,
     build_trait_metadata,
     concat_native_functions,
+    empty_capability_manifest,
     extend_native_functions_inplace,
     flatten_struct_methods,
-    empty_capability_manifest,
 } from "./lowering_helpers_mangling";
-
 import {
-    split_lines_local,
-    _parse_lowered_fn_string_constants,
-    _parse_module_globals_locals,
-} from "./lowering_text_utils";
-
-import {
-    recover_native_functions_light,
-    recover_native_imports_light,
-    recover_native_structs_light,
-    recover_native_enums_light,
-    recover_functions_for_lowering,
-} from "./lowering_recovery";
-
-import {
+    append_string_lines,
     extend_string_lines,
     extend_string_lines_checked,
-    append_string_lines,
-    write_llvm_lines_chunked,
     module_source_filename,
+    write_llvm_lines_chunked,
 } from "./lowering_io";
-
+import { lower_all_functions, } from "./lowering_phase_functions";
+import {
+    extract_import_struct_methods,
+    parse_single_import_functions,
+    parse_single_import_interfaces,
+} from "./lowering_phase_imports";
+import { render_llvm_preamble, } from "./lowering_phase_render";
 // Phase modules
 import {
-    sanitize_lowering_inputs,
-    sanitize_imported_manifests,
-    sanitize_imported_native_texts,
-    sanitize_diagnostics,
-    sanitize_entry_points,
-    sanitize_imports,
-    sanitize_structs,
-    sanitize_enums,
-    sanitize_interfaces,
-    sanitize_functions,
     recover_safe_functions,
     recover_structs_if_corrupt,
     sanitize_bindings,
+    sanitize_diagnostics,
+    sanitize_entry_points,
+    sanitize_enums,
+    sanitize_functions,
+    sanitize_imported_manifests,
+    sanitize_imported_native_texts,
+    sanitize_imports,
+    sanitize_interfaces,
+    sanitize_lowering_inputs,
+    sanitize_structs,
 } from "./lowering_phase_sanitize";
-
+import { build_type_context_with_recovery, serialize_context_functions, } from "./lowering_phase_types";
 import {
-    parse_single_import_interfaces,
-    parse_single_import_functions,
-    extract_import_struct_methods,
-} from "./lowering_phase_imports";
-
+    recover_functions_for_lowering,
+    recover_native_enums_light,
+    recover_native_functions_light,
+    recover_native_imports_light,
+    recover_native_structs_light,
+} from "./lowering_recovery";
 import {
-    build_type_context_with_recovery,
-    serialize_context_functions,
-} from "./lowering_phase_types";
-
-import {
-    render_llvm_preamble,
-} from "./lowering_phase_render";
-
-import {
-    lower_all_functions,
-} from "./lowering_phase_functions";
+    _parse_lowered_fn_string_constants,
+    _parse_module_globals_locals,
+    split_lines_local,
+} from "./lowering_text_utils";
+import { lower_module_bindings_to_globals, } from "./module_globals";
 
 // Consolidated: parse all structure from native text using light recovery.
 // Kept in lowering_core to preserve cross-module symbol mangling compatibility
@@ -177,21 +145,15 @@ fn build_parse_result_from_text(native_text: string) -> ParseNativeResult {
 
 fn lower_to_llvm_lines_with_parsed_context_for_tests(native_module: NativeModule, parse: ParseNativeResult, imported_manifests: LayoutManifest[], imported_native_texts: string[], imported_diagnostics: string[]) -> LoweredLLVMLinesResult {
     let base = lower_to_llvm_lines_with_parsed_context(native_module, parse, imported_manifests, imported_native_texts, imported_diagnostics, false, "");
-    if base.lines.length == 0 {
-        return base;
-    }
+    if base.lines.length == 0 { return base; }
 
     let mut test_count: number = 0;
     let mut has_main: boolean = false;
 
     let mut index: number = 0;
     loop {
-        if index >= parse.functions.length {
-            break;
-        }
-        if parse.functions[index].name == "main" {
-            has_main = true;
-        }
+        if index >= parse.functions.length { break; }
+        if parse.functions[index].name == "main" { has_main = true; }
         if parse.functions[index].name.length >= 5 {
             if substring(parse.functions[index].name, 0, 5) == "test:" {
                 test_count += 1;
@@ -200,9 +162,7 @@ fn lower_to_llvm_lines_with_parsed_context_for_tests(native_module: NativeModule
         index += 1;
     }
 
-    if test_count == 0 {
-        return base;
-    }
+    if test_count == 0 { return base; }
 
     if has_main {
         let mut updated = base;
@@ -228,14 +188,8 @@ fn lower_to_llvm_lines_with_parsed_context_for_tests(native_module: NativeModule
                 let idx_s = number_to_string(test_idx);
                 let msg_arr_len = number_to_string(msg.length + 1);
                 let escaped = escape_string_for_llvm(msg);
-                harness_globals = extend_string_lines(harness_globals, [
-                    "@.tname." + idx_s + " = private unnamed_addr constant [" + msg_arr_len + " x i8] c\"" + escaped + "\\00\"",
-                ]);
-                harness = extend_string_lines(harness, [
-                    "  %tn" + idx_s + " = getelementptr [" + msg_arr_len + " x i8], [" + msg_arr_len + " x i8]* @.tname." + idx_s + ", i64 0, i64 0",
-                    "  call void @sailfin_runtime_print_err(i8* %tn" + idx_s + ")",
-                    "  call void @" + sym + "()",
-                ]);
+                harness_globals = extend_string_lines(harness_globals, ["@.tname." + idx_s + " = private unnamed_addr constant [" + msg_arr_len + " x i8] c\"" + escaped + "\\00\"",]);
+                harness = extend_string_lines(harness, ["  %tn" + idx_s + " = getelementptr [" + msg_arr_len + " x i8], [" + msg_arr_len + " x i8]* @.tname." + idx_s + ", i64 0, i64 0", "  call void @sailfin_runtime_print_err(i8* %tn" + idx_s + ")", "  call void @" + sym + "()",]);
                 test_idx += 1;
             }
         }
@@ -244,15 +198,8 @@ fn lower_to_llvm_lines_with_parsed_context_for_tests(native_module: NativeModule
     let pass_msg = "  PASS  (all " + number_to_string(test_idx) + " tests passed)";
     let pass_escaped = escape_string_for_llvm(pass_msg);
     let pass_len_s = number_to_string(pass_msg.length + 1);
-    harness_globals = extend_string_lines(harness_globals, [
-        "@.tpass = private unnamed_addr constant [" + pass_len_s + " x i8] c\"" + pass_escaped + "\\00\"",
-    ]);
-    harness = extend_string_lines(harness, [
-        "  %tp = getelementptr [" + pass_len_s + " x i8], [" + pass_len_s + " x i8]* @.tpass, i64 0, i64 0",
-        "  call void @sailfin_runtime_print_err(i8* %tp)",
-        "  ret i32 0",
-        "}",
-    ]);
+    harness_globals = extend_string_lines(harness_globals, ["@.tpass = private unnamed_addr constant [" + pass_len_s + " x i8] c\"" + pass_escaped + "\\00\"",]);
+    harness = extend_string_lines(harness, ["  %tp = getelementptr [" + pass_len_s + " x i8], [" + pass_len_s + " x i8]* @.tpass, i64 0, i64 0", "  call void @sailfin_runtime_print_err(i8* %tp)", "  ret i32 0", "}",]);
 
     let mut updated = base;
     if updated.lines.length > 0 {
@@ -267,7 +214,9 @@ fn lower_to_llvm_lines_with_parsed_context_for_tests(native_module: NativeModule
 fn make_native_module_for_emit(module_name: string, native_text: string) -> NativeModule {
     return NativeModule {
         module_name: module_name,
-        artifacts: [NativeArtifact { name: module_name, format: "sailfin-native-text", contents: native_text }],
+        artifacts: [NativeArtifact {
+            name: module_name, format: "sailfin-native-text", contents: native_text
+        }],
         entry_points: [],
         symbol_count: 0,
     };
@@ -288,15 +237,7 @@ fn compile_native_text_to_llvm_file(native_text_path: string, module_name: strin
     fs.writeFile("build/sailfin/emit-native.tmp", native_text);
     let import_context = collect_imported_module_context_for_module(raw_imports, module_name);
     let dummy_module = make_native_module_for_emit(module_name, native_text);
-    let lowered_lines = lower_to_llvm_lines_with_parsed_context(
-        dummy_module,
-        parse,
-        import_context.manifests,
-        import_context.native_texts,
-        import_context.diagnostics,
-        true,
-        native_text
-    );
+    let lowered_lines = lower_to_llvm_lines_with_parsed_context(dummy_module, parse, import_context.manifests, import_context.native_texts, import_context.diagnostics, true, native_text);
     if lowered_lines.lines == null {
         print.err("emit-llvm: lowered lines null");
         return false;
@@ -304,9 +245,7 @@ fn compile_native_text_to_llvm_file(native_text_path: string, module_name: strin
     let lowered_count = lowered_lines.lines.length;
     if lowered_count > 0 {
         let defined = collect_defined_function_symbols(lowered_lines.lines);
-        if defined.length == 0 {
-            return false;
-        }
+        if defined.length == 0 { return false; }
     }
     let lines = lowered_lines.lines;
     let mut _if247: boolean = false;
@@ -316,17 +255,13 @@ fn compile_native_text_to_llvm_file(native_text_path: string, module_name: strin
         print.err("emit-llvm: lowering produced no output lines");
         return false;
     }
-    if fs.exists(out_path) {
-        fs.deleteFile(out_path);
-    }
+    if fs.exists(out_path) { fs.deleteFile(out_path); }
     return write_llvm_lines_chunked(out_path, lines);
 }
 
 fn lower_to_llvm_lines_with_parsed_context(native_module: NativeModule, parse_in: ParseNativeResult, imported_manifests: LayoutManifest[], imported_native_texts: string[], diagnostics_in: string[], mangle_symbols: boolean, native_text_override_path: string) -> LoweredLLVMLinesResult ![io] {
     let debug_lowering = fs.exists("build/sailfin/.trace_lowering");
-    if debug_lowering {
-        print.err("emit-llvm: phase=start");
-    }
+    if debug_lowering { print.err("emit-llvm: phase=start"); }
     if debug_lowering {
         let mut artifact_count: number = 0;
         if native_module.artifacts != null {
@@ -373,14 +308,10 @@ fn lower_to_llvm_lines_with_parsed_context(native_module: NativeModule, parse_in
                     import_spec_count = first_import.specifiers.length;
                 }
                 print.err("emit-llvm: safe_imports[0].kind=" + import_kind + " module=" + import_module + " specs=" + number_to_string(import_spec_count));
-            } else {
-                print.err("emit-llvm: safe_imports[0]=<null>");
-            }
+            } else { print.err("emit-llvm: safe_imports[0]=<null>"); }
         }
     }
-    if is_test_module {
-        safe_imports = [];
-    }
+    if is_test_module { safe_imports = []; }
     let mut safe_structs = sanitize_structs(parse.structs, diagnostics);
     let safe_enums = sanitize_enums(parse.enums, diagnostics, _trace_enums);
     let safe_interfaces = sanitize_interfaces(parse.interfaces, diagnostics);
@@ -399,17 +330,13 @@ fn lower_to_llvm_lines_with_parsed_context(native_module: NativeModule, parse_in
     let safe_bindings = sanitize_bindings(parse.bindings, diagnostics);
 
     let mut safe_parse_diagnostics = parse.diagnostics;
-    if safe_parse_diagnostics == null {
-        safe_parse_diagnostics = [];
-    }
+    if safe_parse_diagnostics == null { safe_parse_diagnostics = []; }
     diagnostics = extend_string_lines_checked(diagnostics, safe_parse_diagnostics, "parse");
 
     // ── Trace/timing setup ──────────────────────────────────────────
     let mut _let250: boolean = false;
     if fs.exists("build/sailfin/.trace_test_runner") {
-        if fs.exists("build/sailfin/.test_runner_active") {
-            _let250 = true;
-        }
+        if fs.exists("build/sailfin/.test_runner_active") { _let250 = true; }
     }
     let trace = _let250;
     let timing = fs.exists("build/sailfin/.test_runner_active");
@@ -432,16 +359,10 @@ fn lower_to_llvm_lines_with_parsed_context(native_module: NativeModule, parse_in
         let manifest_application = apply_layout_manifest_to_module(safe_structs, safe_enums, module_manifest);
         diagnostics = extend_string_lines_checked(diagnostics, manifest_application.diagnostics, "layout application");
         module_structs = manifest_application.structs;
-        if module_structs == null {
-            module_structs = [];
-        }
+        if module_structs == null { module_structs = []; }
         module_enums = manifest_application.enums;
-        if module_enums == null {
-            module_enums = [];
-        }
-        if debug_lowering {
-            print.err("emit-llvm: phase=manifest");
-        }
+        if module_enums == null { module_enums = []; }
+        if debug_lowering { print.err("emit-llvm: phase=manifest"); }
     }
     if timing {
         print.err("test llvm: phase=manifest ms=" + number_to_string(monotonic_millis() - start_ms));
@@ -456,9 +377,7 @@ fn lower_to_llvm_lines_with_parsed_context(native_module: NativeModule, parse_in
     let manifest_count = safe_imported_manifests.length;
     let mut text_index: number = 0;
     loop {
-        if text_index >= safe_imported_native_texts.length {
-            break;
-        }
+        if text_index >= safe_imported_native_texts.length { break; }
         let native_text = safe_imported_native_texts[text_index];
         let mut manifest_for_module: LayoutManifest? = null;
         if text_index < manifest_count {
@@ -478,13 +397,9 @@ fn lower_to_llvm_lines_with_parsed_context(native_module: NativeModule, parse_in
         let imported_enums_safe = recover_native_enums_light(native_text);
         let applied_import = apply_layout_manifest_to_module(imported_structs_safe, imported_enums_safe, manifest_for_module);
         let mut applied_structs = applied_import.structs;
-        if applied_structs == null {
-            applied_structs = [];
-        }
+        if applied_structs == null { applied_structs = []; }
         let mut applied_enums = applied_import.enums;
-        if applied_enums == null {
-            applied_enums = [];
-        }
+        if applied_enums == null { applied_enums = []; }
         let applied_interfaces = parse_single_import_interfaces(native_text);
         let applied_functions = parse_single_import_functions(native_text);
         imported_structs = extend_native_structs(imported_structs, applied_structs);
@@ -499,9 +414,7 @@ fn lower_to_llvm_lines_with_parsed_context(native_module: NativeModule, parse_in
     if safe_imported_native_texts.length < manifest_count {
         let mut manifest_index: number = safe_imported_native_texts.length;
         loop {
-            if manifest_index >= manifest_count {
-                break;
-            }
+            if manifest_index >= manifest_count { break; }
             let leftover_manifest = safe_imported_manifests[manifest_index];
             imported_structs = extend_native_structs(imported_structs, leftover_manifest.structs);
             imported_enums = extend_native_enums(imported_enums, leftover_manifest.enums);
@@ -509,9 +422,7 @@ fn lower_to_llvm_lines_with_parsed_context(native_module: NativeModule, parse_in
         }
     }
 
-    if debug_lowering {
-        print.err("emit-llvm: phase=imports");
-    }
+    if debug_lowering { print.err("emit-llvm: phase=imports"); }
 
     // ── Phase 3: Combine types, build type context ──────────────────
     let combined_structs = extend_native_structs(module_structs, imported_structs);
@@ -524,33 +435,20 @@ fn lower_to_llvm_lines_with_parsed_context(native_module: NativeModule, parse_in
         }
     }
 
-    if trace {
-        print.err("test llvm: trait metadata start");
-    }
+    if trace { print.err("test llvm: trait metadata start"); }
     let trait_metadata = build_trait_metadata(combined_interfaces, combined_structs);
-    if debug_lowering {
-        print.err("emit-llvm: phase=trait_metadata");
-    }
-    if trace {
-        print.err("test llvm: enum layout fixup start");
-    }
+    if debug_lowering { print.err("emit-llvm: phase=trait_metadata"); }
+    if trace { print.err("test llvm: enum layout fixup start"); }
 
-    if trace {
-        print.err("test llvm: type context build start");
-    }
-    let type_context = build_type_context_with_recovery(
-        combined_structs, combined_enums, combined_interfaces,
-        diagnostics, _trace_enums, debug_lowering
-    );
+    if trace { print.err("test llvm: type context build start"); }
+    let type_context = build_type_context_with_recovery(combined_structs, combined_enums, combined_interfaces, diagnostics, _trace_enums, debug_lowering);
     // Merge type-context diagnostics written by build_type_context_with_recovery
     let _tc_diags_raw = fs.readFile("build/sailfin/.phase_types_diagnostics");
     if _tc_diags_raw.length > 0 {
         let _tc_diags = split_lines_local(_tc_diags_raw);
         diagnostics = extend_string_lines_checked(diagnostics, _tc_diags, "type context");
     }
-    if trace {
-        print.err("test llvm: type context built");
-    }
+    if trace { print.err("test llvm: type context built"); }
     if timing {
         print.err("test llvm: phase=type_context ms=" + number_to_string(monotonic_millis() - start_ms));
     }
@@ -566,9 +464,7 @@ fn lower_to_llvm_lines_with_parsed_context(native_module: NativeModule, parse_in
     // Site 1 — safe in-place extend: safe_functions is not read after this
     // line; local_functions aliases safe_functions and is read downstream.
     let local_functions = extend_native_functions_inplace(safe_functions, module_struct_methods);
-    if debug_lowering {
-        print.err("emit-llvm: phase=local_functions");
-    }
+    if debug_lowering { print.err("emit-llvm: phase=local_functions"); }
     // Site 2 — must stay copying: local_functions is reused by
     // collect_runtime_helper_targets, render_llvm_preamble, and
     // lower_all_functions below, so context_functions must be a distinct
@@ -577,9 +473,7 @@ fn lower_to_llvm_lines_with_parsed_context(native_module: NativeModule, parse_in
     // Site 3 — safe in-place extend: context_functions is a fresh array from
     // site 2, no prior snapshot is aliased.
     context_functions = extend_native_functions_inplace(context_functions, imported_struct_methods);
-    if debug_lowering {
-        print.err("emit-llvm: phase=context_functions");
-    }
+    if debug_lowering { print.err("emit-llvm: phase=context_functions"); }
 
     serialize_context_functions(context_functions, debug_lowering);
 
@@ -588,18 +482,12 @@ fn lower_to_llvm_lines_with_parsed_context(native_module: NativeModule, parse_in
     let mut runtime_helpers: string[] = [];
     let mut _if255: boolean = false;
     if !is_test_module {
-        if !skip_effects {
-            _if255 = true;
-        }
+        if !skip_effects { _if255 = true; }
     }
     if _if255 {
-        if debug_lowering {
-            print.err("emit-llvm: phase=helpers_start");
-        }
+        if debug_lowering { print.err("emit-llvm: phase=helpers_start"); }
         runtime_helpers = collect_runtime_helper_targets(local_functions);
-        if debug_lowering {
-            print.err("emit-llvm: phase=helpers_done");
-        }
+        if debug_lowering { print.err("emit-llvm: phase=helpers_done"); }
     } else if trace {
         print.err("test llvm: skipping runtime helper collection for inlined tests");
     }
@@ -686,9 +574,7 @@ fn lower_to_llvm_lines_with_parsed_context(native_module: NativeModule, parse_in
     let mut direct_effects: FunctionEffectEntry[] = [];
     let mut aggregated_effects: FunctionEffectEntry[] = [];
     if !skip_effects {
-        if debug_lowering {
-            print.err("emit-llvm: phase=direct_effects");
-        }
+        if debug_lowering { print.err("emit-llvm: phase=direct_effects"); }
         direct_effects = collect_direct_function_effects(context_functions);
         aggregated_effects = direct_effects;
         if !is_test_module {
@@ -698,27 +584,14 @@ fn lower_to_llvm_lines_with_parsed_context(native_module: NativeModule, parse_in
             print.err("test llvm: skipping effect propagation for inlined tests");
         }
     }
-    if trace {
-        print.err("test llvm: runtime helpers collected");
-    }
+    if trace { print.err("test llvm: runtime helpers collected"); }
     if timing {
         print.err("test llvm: phase=effects ms=" + number_to_string(monotonic_millis() - start_ms));
     }
-    if debug_lowering {
-        print.err("emit-llvm: phase=effects");
-    }
+    if debug_lowering { print.err("emit-llvm: phase=effects"); }
 
     // ── Phase 4: Render LLVM IR preamble ────────────────────────────
-    let mut lines = render_llvm_preamble(
-        native_module.module_name,
-        type_context,
-        trait_metadata,
-        context_functions,
-        local_functions,
-        imported_functions,
-        runtime_helpers,
-        debug_lowering
-    );
+    let mut lines = render_llvm_preamble(native_module.module_name, type_context, trait_metadata, context_functions, local_functions, imported_functions, runtime_helpers, debug_lowering);
 
     // ── Module globals ──────────────────────────────────────────────
     if debug_lowering {
@@ -772,30 +645,13 @@ fn lower_to_llvm_lines_with_parsed_context(native_module: NativeModule, parse_in
         lines = extend_string_lines(lines, module_init_lines);
         lines = extend_string_lines(lines, [""]);
     }
-    if trace {
-        print.err("test llvm: module globals lowered");
-    }
+    if trace { print.err("test llvm: module globals lowered"); }
     if timing {
         print.err("test llvm: phase=globals ms=" + number_to_string(monotonic_millis() - start_ms));
     }
 
     // ── Phase 5: Lower all functions ────────────────────────────────
-    let function_lines = lower_all_functions(
-        local_functions,
-        context_functions,
-        aggregated_effects,
-        type_context,
-        native_module.module_name,
-        safe_entry_points,
-        exported_symbols,
-        imported_functions,
-        module_global_locals,
-        module_init_symbol,
-        module_globals_needs_init_call,
-        module_string_constants,
-        trace,
-        debug_lowering
-    );
+    let function_lines = lower_all_functions(local_functions, context_functions, aggregated_effects, type_context, native_module.module_name, safe_entry_points, exported_symbols, imported_functions, module_global_locals, module_init_symbol, module_globals_needs_init_call, module_string_constants, trace, debug_lowering);
     lines = extend_string_lines(lines, function_lines);
 
     // Read function phase diagnostics
@@ -826,12 +682,8 @@ fn lower_to_llvm_lines_with_parsed_context(native_module: NativeModule, parse_in
         }
         lines = mangled.lines;
     }
-    if debug_lowering {
-        print.err("emit-llvm: phase=mangle");
-    }
-    if trace {
-        print.err("test llvm: mangling stage done");
-    }
+    if debug_lowering { print.err("emit-llvm: phase=mangle"); }
+    if trace { print.err("test llvm: mangling stage done"); }
     if timing {
         print.err("test llvm: phase=finalize ms=" + number_to_string(monotonic_millis() - start_ms));
     }
@@ -847,44 +699,23 @@ fn lower_to_llvm_lines_with_parsed_context(native_module: NativeModule, parse_in
         let mut first_len: number = 0;
         let mut i: number = 0;
         loop {
-            if i >= lines.length {
-                break;
-            }
+            if i >= lines.length { break; }
             if lines[i].length > 0 {
                 nonempty += 1;
-                if first_len == 0 {
-                    first_len = lines[i].length;
-                }
+                if first_len == 0 { first_len = lines[i].length; }
             }
             i += 1;
         }
-        print.err(
-            "test llvm: lowered lines=" + number_to_string(lines.length)
-            + " nonempty=" + number_to_string(nonempty)
-            + " first_len=" + number_to_string(first_len)
-            + " diagnostics=" + number_to_string(diagnostics.length)
-        );
+        print.err("test llvm: lowered lines=" + number_to_string(lines.length) + " nonempty=" + number_to_string(nonempty) + " first_len=" + number_to_string(first_len) + " diagnostics=" + number_to_string(diagnostics.length));
         let mut diag_index: number = 0;
         loop {
-            if diag_index >= diagnostics.length {
-                break;
-            }
+            if diag_index >= diagnostics.length { break; }
             print.err("test llvm: diagnostic " + diagnostics[diag_index]);
             diag_index += 1;
         }
     }
     if lines.length == 0 {
-        print.err(
-            "emit-llvm: lowering produced no lines (functions="
-            + number_to_string(local_functions.length)
-            + " structs="
-            + number_to_string(module_structs.length)
-            + " enums="
-            + number_to_string(module_enums.length)
-            + " diagnostics="
-            + number_to_string(diagnostics.length)
-            + ")"
-        );
+        print.err("emit-llvm: lowering produced no lines (functions=" + number_to_string(local_functions.length) + " structs=" + number_to_string(module_structs.length) + " enums=" + number_to_string(module_enums.length) + " diagnostics=" + number_to_string(diagnostics.length) + ")");
     }
     if debug_lowering {
         print.err("emit-llvm: phase=end lines=" + number_to_string(lines.length));
@@ -899,4 +730,3 @@ fn lower_to_llvm_lines_with_parsed_context(native_module: NativeModule, parse_in
         string_constants: all_string_constants,
     };
 }
-

--- a/compiler/src/llvm/lowering/lowering_helpers.sfn
+++ b/compiler/src/llvm/lowering/lowering_helpers.sfn
@@ -1,103 +1,83 @@
 // compiler/src/llvm/lowering/lowering_helpers.sfn
 //
 // Shared utility functions for LLVM IR lowering.
-
 import { NativeArtifact, NativeModule } from "../../emit_native";
 import {
+    LayoutManifest,
+    NativeEnum,
+    NativeFunction,
     NativeImport,
     NativeImportSpecifier,
-    NativeFunction,
-    NativeParameter,
     NativeInstruction,
     NativeInterface,
+    NativeParameter,
     NativeStruct,
     NativeStructField,
     NativeStructLayout,
     NativeStructLayoutField,
-    NativeEnum,
-    LayoutManifest,
     ParseNativeResult,
 } from "../../native_ir";
 import {
-    select_text_artifact,
-    select_layout_manifest_artifact,
+    parse_layout_manifest,
     parse_native_artifact,
+    parse_native_artifact_for_import_context,
     parse_native_function_count_from_text,
     parse_native_functions_from_text,
-    parse_native_artifact_for_import_context,
-    parse_layout_manifest,
+    select_layout_manifest_artifact,
+    select_text_artifact,
 } from "../../native_ir_api";
 import { split_lines } from "../../native_ir_utils_text";
-import { substring, char_code } from "../../string_utils";
-import { extend_string_lines } from "./lowering_io";
-
+import { char_code, substring } from "../../string_utils";
 import {
-    TypeContext,
-    TraitMetadata,
-    TraitDescriptor,
-    TraitImplementationDescriptor,
-    ImportedModuleContext,
-    LoweredLLVMResult,
-    LoweredLLVMLinesResult,
-    FunctionEffectEntry,
-    LifetimeRegionMetadata,
-    StringConstant,
+    resolve_import_artifact_slug,
+    resolve_import_module_slug_for_module,
+} from "../imports";
+import { find_function_by_name, should_internalize_function, } from "../rendering";
+import {
     CapabilityManifest,
     EnumTypeInfo,
     EnumVariantInfo,
+    FunctionEffectEntry,
+    ImportedModuleContext,
+    LifetimeRegionMetadata,
+    LoweredLLVMLinesResult,
+    LoweredLLVMResult,
+    StringConstant,
+    TraitDescriptor,
+    TraitImplementationDescriptor,
+    TraitMetadata,
+    TypeContext,
 } from "../types";
-
 import {
     append_string,
+    index_of,
     join_with_separator,
     number_to_string,
     sanitize_symbol,
-    string_array_contains,
     starts_with,
+    string_array_contains,
     trim_text,
-    index_of,
 } from "../utils";
-
-import {
-    should_internalize_function,
-    find_function_by_name,
-} from "../rendering";
-
-import {
-    resolve_import_module_slug_for_module,
-    resolve_import_artifact_slug,
-} from "../imports";
+import { extend_string_lines } from "./lowering_io";
 
 fn empty_trait_metadata() -> TraitMetadata {
     return TraitMetadata { interfaces: [], implementations: [] };
 }
 
 fn sanitize_collection_length(value: number, max: number) -> number {
-    if value != value {
-        return 0;
-    }
-    if value < 0 {
-        return 0;
-    }
-    if value > max {
-        return max;
-    }
+    if value != value { return 0; }
+    if value < 0 { return 0; }
+    if value > max { return max; }
     return value;
 }
 
 fn extend_native_structs(values: NativeStruct[], extras: NativeStruct[]) -> NativeStruct[] {
     let mut out = values;
-    if out == null {
-        out = [];
-    }
-    if extras == null {
-        return out;
-    }
+    if out == null { out = []; }
+    if extras == null { return out; }
     let mut index: number = 0;
     loop {
-        if index >= extras.length {
-            break;
-        }
+        if index >= extras.length { break; }
         out = out.push(extras[index]);
         index += 1;
     }
@@ -106,17 +86,11 @@ fn extend_native_structs(values: NativeStruct[], extras: NativeStruct[]) -> Nati
 
 fn extend_native_enums(values: NativeEnum[], extras: NativeEnum[]) -> NativeEnum[] {
     let mut out = values;
-    if out == null {
-        out = [];
-    }
-    if extras == null {
-        return out;
-    }
+    if out == null { out = []; }
+    if extras == null { return out; }
     let mut index: number = 0;
     loop {
-        if index >= extras.length {
-            break;
-        }
+        if index >= extras.length { break; }
         out = out.push(extras[index]);
         index += 1;
     }
@@ -125,17 +99,11 @@ fn extend_native_enums(values: NativeEnum[], extras: NativeEnum[]) -> NativeEnum
 
 fn extend_native_interfaces(values: NativeInterface[], extras: NativeInterface[]) -> NativeInterface[] {
     let mut out = values;
-    if out == null {
-        out = [];
-    }
-    if extras == null {
-        return out;
-    }
+    if out == null { out = []; }
+    if extras == null { return out; }
     let mut index: number = 0;
     loop {
-        if index >= extras.length {
-            break;
-        }
+        if index >= extras.length { break; }
         out = out.push(extras[index]);
         index += 1;
     }
@@ -144,17 +112,11 @@ fn extend_native_interfaces(values: NativeInterface[], extras: NativeInterface[]
 
 fn extend_native_functions(values: NativeFunction[], extras: NativeFunction[]) -> NativeFunction[] {
     let mut out = values;
-    if out == null {
-        out = [];
-    }
-    if extras == null {
-        return out;
-    }
+    if out == null { out = []; }
+    if extras == null { return out; }
     let mut index: number = 0;
     loop {
-        if index >= extras.length {
-            break;
-        }
+        if index >= extras.length { break; }
         out = out.push(extras[index]);
         index += 1;
     }
@@ -162,18 +124,10 @@ fn extend_native_functions(values: NativeFunction[], extras: NativeFunction[]) -
 }
 
 fn is_test_module_slug(module_name: string) -> boolean {
-    if module_name.length == 0 {
-        return false;
-    }
-    if index_of(module_name, "build/sailfin/test") >= 0 {
-        return true;
-    }
-    if index_of(module_name, "compiler/tests/") >= 0 {
-        return true;
-    }
-    if index_of(module_name, "/compiler/tests/") >= 0 {
-        return true;
-    }
+    if module_name.length == 0 { return false; }
+    if index_of(module_name, "build/sailfin/test") >= 0 { return true; }
+    if index_of(module_name, "compiler/tests/") >= 0 { return true; }
+    if index_of(module_name, "/compiler/tests/") >= 0 { return true; }
     return false;
 }
 
@@ -187,11 +141,7 @@ fn _escape_llvm_string_h(text: string) -> string {
         if i >= text.length { break; }
         let ch = substring(text, i, i + 1);
         let mut esc: string = "";
-        if ch == "\"" {
-            esc = "\\22";
-        } else if ch == "\\" {
-            esc = "\\5C";
-        }
+        if ch == "\"" { esc = "\\22"; } else if ch == "\\" { esc = "\\5C"; }
         if esc.length > 0 {
             if i > chunk_start {
                 chunks.push(substring(text, chunk_start, i));
@@ -228,9 +178,7 @@ fn _test_label_from_name_h(raw_name: string) -> string {
     loop {
         if i >= name.length { break; }
         let ch = substring(name, i, i + 1);
-        if ch == "_" {
-            cleaned = cleaned + " ";
-        } else {
+        if ch == "_" { cleaned = cleaned + " "; } else {
             cleaned = cleaned + ch;
         }
         i += 1;
@@ -244,9 +192,7 @@ fn render_test_harness_main_for_module(tests: NativeFunction[], module_slug: str
 
     let mut _let264: boolean = false;
     if mangle_symbols {
-        if !starts_with(module_slug, "runtime/") {
-            _let264 = true;
-        }
+        if !starts_with(module_slug, "runtime/") { _let264 = true; }
     }
     let should_mangle = _let264;
     let module_suffix = sanitize_module_suffix(module_slug);
@@ -275,27 +221,16 @@ fn render_test_harness_main_for_module(tests: NativeFunction[], module_slug: str
         if index >= test_count { break; }
         let mut sym = sanitize_symbol(tests[index].name);
         if should_mangle {
-            if index_of(sym, "__") < 0 {
-                sym = sym + "__" + module_suffix;
-            }
+            if index_of(sym, "__") < 0 { sym = sym + "__" + module_suffix; }
         }
         let idx_str = number_to_string(index);
         let msg = "  RUN  " + _test_label_from_name_h(tests[index].name);
-        lines = extend_string_lines(lines, [
-            "  %name_ptr_" + idx_str + " = getelementptr [" + number_to_string(msg.length + 1) + " x i8], [" + number_to_string(msg.length + 1) + " x i8]* @.test_name_" + idx_str + ", i64 0, i64 0",
-            "  call i32 @puts(i8* %name_ptr_" + idx_str + ")",
-            "  call void @" + sym + "()",
-        ]);
+        lines = extend_string_lines(lines, ["  %name_ptr_" + idx_str + " = getelementptr [" + number_to_string(msg.length + 1) + " x i8], [" + number_to_string(msg.length + 1) + " x i8]* @.test_name_" + idx_str + ", i64 0, i64 0", "  call i32 @puts(i8* %name_ptr_" + idx_str + ")", "  call void @" + sym + "()",]);
         index += 1;
     }
 
     // Print summary
-    lines = extend_string_lines(lines, [
-        "  %pass_ptr = getelementptr [" + number_to_string(pass_msg.length + 1) + " x i8], [" + number_to_string(pass_msg.length + 1) + " x i8]* @.test_pass_msg, i64 0, i64 0",
-        "  call i32 @puts(i8* %pass_ptr)",
-        "  ret i32 0",
-        "}",
-    ]);
+    lines = extend_string_lines(lines, ["  %pass_ptr = getelementptr [" + number_to_string(pass_msg.length + 1) + " x i8], [" + number_to_string(pass_msg.length + 1) + " x i8]* @.test_pass_msg, i64 0, i64 0", "  call i32 @puts(i8* %pass_ptr)", "  ret i32 0", "}",]);
     return lines;
 }
 
@@ -310,96 +245,60 @@ struct DeclareSignature {
 }
 
 fn is_llvm_symbol_char(ch: string) -> boolean {
-    if ch.length == 0 {
-        return false;
-    }
-    if ch == "_" {
-        return true;
-    }
+    if ch.length == 0 { return false; }
+    if ch == "_" { return true; }
     let code = char_code(ch);
     let lower_a = char_code("a");
     let lower_z = char_code("z");
     if code >= lower_a {
-        if code <= lower_z {
-            return true;
-        }
+        if code <= lower_z { return true; }
     }
     let upper_a = char_code("A");
     let upper_z = char_code("Z");
     if code >= upper_a {
-        if code <= upper_z {
-            return true;
-        }
+        if code <= upper_z { return true; }
     }
     let zero = char_code("0");
     let nine = char_code("9");
     if code >= zero {
-        if code <= nine {
-            return true;
-        }
+        if code <= nine { return true; }
     }
     return false;
 }
 
 fn sanitize_module_suffix(module_name: string) -> string {
-    if module_name.length == 0 {
-        return "module";
-    }
+    if module_name.length == 0 { return "module"; }
     let mut out: string = "";
     let mut index: number = 0;
     loop {
-        if index >= module_name.length {
-            break;
-        }
+        if index >= module_name.length { break; }
         let ch = module_name[index];
-        if is_llvm_symbol_char(ch) {
-            out = out + ch;
-        } else {
-            if ch == "/" {
-                out = out + "__";
-            } else {
-                out = out + "_";
-            }
+        if is_llvm_symbol_char(ch) { out = out + ch; } else {
+            if ch == "/" { out = out + "__"; } else { out = out + "_"; }
         }
         index += 1;
     }
-    if out.length == 0 {
-        return "module";
-    }
+    if out.length == 0 { return "module"; }
     return out;
 }
 
 fn should_keep_unmangled_abi_symbol(symbol: string) -> boolean {
-    if symbol == "native_cli_main" {
-        return true;
-    }
-    if symbol == "compile_to_sailfin" {
-        return true;
-    }
-    if symbol == "compile_to_llvm" {
-        return true;
-    }
-    if symbol == "main" {
-        return true;
-    }
+    if symbol == "native_cli_main" { return true; }
+    if symbol == "compile_to_sailfin" { return true; }
+    if symbol == "compile_to_llvm" { return true; }
+    if symbol == "main" { return true; }
     return false;
 }
 
 fn extract_module_name_from_native_text(native_text: string) -> string {
-    if native_text.length == 0 {
-        return "";
-    }
+    if native_text.length == 0 { return ""; }
 
     let module_index = index_of(native_text, ".module ");
-    if module_index < 0 {
-        return "";
-    }
+    if module_index < 0 { return ""; }
 
     let mut start = module_index + 8;
     loop {
-        if start >= native_text.length {
-            break;
-        }
+        if start >= native_text.length { break; }
         let ch = native_text[start];
         let mut _if265: boolean = false;
         if ch == " " { _if265 = true; }
@@ -413,12 +312,8 @@ fn extract_module_name_from_native_text(native_text: string) -> string {
 
     let mut end = start;
     loop {
-        if end >= native_text.length {
-            break;
-        }
-        if native_text[end] == "\n" {
-            break;
-        }
+        if end >= native_text.length { break; }
+        if native_text[end] == "\n" { break; }
         end += 1;
     }
 
@@ -429,9 +324,7 @@ fn collect_available_import_module_names(imported_native_texts: string[]) -> str
     let mut names: string[] = [];
     let mut index: number = 0;
     loop {
-        if index >= imported_native_texts.length {
-            break;
-        }
+        if index >= imported_native_texts.length { break; }
         let text = imported_native_texts[index];
         let mut _if266: boolean = false;
         if text == null { _if266 = true; }
@@ -442,9 +335,7 @@ fn collect_available_import_module_names(imported_native_texts: string[]) -> str
         }
         let name = extract_module_name_from_native_text(text);
         if name.length > 0 {
-            if !string_array_contains(names, name) {
-                names.push(name);
-            }
+            if !string_array_contains(names, name) { names.push(name); }
         }
         index += 1;
     }
@@ -453,16 +344,10 @@ fn collect_available_import_module_names(imported_native_texts: string[]) -> str
 
 fn resolve_import_provider_module_name(import_path: string, current_module_slug: string, available_module_names: string[]) -> string {
     let base = resolve_import_module_slug_for_module(import_path, current_module_slug);
-    if base.length == 0 {
-        return base;
-    }
+    if base.length == 0 { return base; }
     let resolved = resolve_import_artifact_slug(base);
-    if resolved.length > 0 {
-        return resolved;
-    }
-    if string_array_contains(available_module_names, base) {
-        return base;
-    }
+    if resolved.length > 0 { return resolved; }
+    if string_array_contains(available_module_names, base) { return base; }
     let mod_slug = base + "/mod";
     if string_array_contains(available_module_names, mod_slug) {
         return mod_slug;
@@ -474,9 +359,7 @@ fn collect_defined_function_symbols(lines: string[]) -> string[] {
     let mut symbols: string[] = [];
     let mut index: number = 0;
     loop {
-        if index >= lines.length {
-            break;
-        }
+        if index >= lines.length { break; }
         let trimmed = trim_text(lines[index]);
         if starts_with(trimmed, "define ") {
             let mut at_index: number = index_of(trimmed, "@");
@@ -484,12 +367,8 @@ fn collect_defined_function_symbols(lines: string[]) -> string[] {
                 let mut start = at_index + 1;
                 let mut end = start;
                 loop {
-                    if end >= trimmed.length {
-                        break;
-                    }
-                    if !is_llvm_symbol_char(trimmed[end]) {
-                        break;
-                    }
+                    if end >= trimmed.length { break; }
+                    if !is_llvm_symbol_char(trimmed[end]) { break; }
                     end += 1;
                 }
                 if end > start {
@@ -511,31 +390,21 @@ fn find_substitution_index(olds: string[], news: string[], symbol: string) -> nu
         let mut _if267: boolean = false;
         if index >= olds.length { _if267 = true; }
         if index >= news.length { _if267 = true; }
-        if _if267 {
-            break;
-        }
-        if olds[index] == symbol {
-            return index;
-        }
+        if _if267 { break; }
+        if olds[index] == symbol { return index; }
         index += 1;
     }
     return -1;
 }
 
 fn replace_symbol_refs_in_line(line: string, olds: string[], news: string[]) -> string {
-    if olds.length == 0 {
-        return line;
-    }
-    if line.length == 0 {
-        return line;
-    }
+    if olds.length == 0 { return line; }
+    if line.length == 0 { return line; }
     let mut out: string = "";
     let mut index: number = 0;
     let mut in_string: boolean = false;
     loop {
-        if index >= line.length {
-            break;
-        }
+        if index >= line.length { break; }
         let ch = line[index];
         if ch == "\"" {
             in_string = !in_string;
@@ -563,12 +432,8 @@ fn replace_symbol_refs_in_line(line: string, olds: string[], news: string[]) -> 
 
         let mut end = start;
         loop {
-            if end >= line.length {
-                break;
-            }
-            if !is_llvm_symbol_char(line[end]) {
-                break;
-            }
+            if end >= line.length { break; }
+            if !is_llvm_symbol_char(line[end]) { break; }
             end += 1;
         }
         if end == start {
@@ -582,24 +447,18 @@ fn replace_symbol_refs_in_line(line: string, olds: string[], news: string[]) -> 
         let replacement_index = find_substitution_index(olds, news, sym);
         if replacement_index >= 0 {
             out = out + "@" + news[replacement_index];
-        } else {
-            out = out + "@" + sym;
-        }
+        } else { out = out + "@" + sym; }
         index = end;
     }
     return out;
 }
 
 fn apply_symbol_substitutions(lines: string[], olds: string[], news: string[]) -> string[] {
-    if olds.length == 0 {
-        return lines;
-    }
+    if olds.length == 0 { return lines; }
     let mut out = lines;
     let mut index: number = 0;
     loop {
-        if index >= out.length {
-            break;
-        }
+        if index >= out.length { break; }
         out[index] = replace_symbol_refs_in_line(out[index], olds, news);
         index += 1;
     }
@@ -608,53 +467,33 @@ fn apply_symbol_substitutions(lines: string[], olds: string[], news: string[]) -
 
 fn _extract_signature_from_header(trimmed: string, prefix_len: number, symbol: string) -> DeclareSignature? {
     let at_index = index_of(trimmed, "@");
-    if at_index < 0 {
-        return null;
-    }
+    if at_index < 0 { return null; }
     let start = at_index + 1;
     let mut end = start;
     loop {
-        if end >= trimmed.length {
-            break;
-        }
-        if !is_llvm_symbol_char(trimmed[end]) {
-            break;
-        }
+        if end >= trimmed.length { break; }
+        if !is_llvm_symbol_char(trimmed[end]) { break; }
         end += 1;
     }
-    if end == start {
-        return null;
-    }
+    if end == start { return null; }
     let sym = substring(trimmed, start, end);
-    if sym != symbol {
-        return null;
-    }
+    if sym != symbol { return null; }
     let open_index = index_of(trimmed, "(");
-    if open_index < 0 {
-        return null;
-    }
+    if open_index < 0 { return null; }
     // Find the matching close paren by tracking depth (handles function-pointer
     // params like `double (i8*)*`).
     let mut paren_depth = 1;
     let mut close_index = open_index + 1;
     loop {
-        if close_index >= trimmed.length {
-            break;
-        }
+        if close_index >= trimmed.length { break; }
         let pch = trimmed[close_index];
-        if pch == "(" {
-            paren_depth += 1;
-        } else if pch == ")" {
+        if pch == "(" { paren_depth += 1; } else if pch == ")" {
             paren_depth -= 1;
-            if paren_depth == 0 {
-                break;
-            }
+            if paren_depth == 0 { break; }
         }
         close_index += 1;
     }
-    if paren_depth != 0 {
-        return null;
-    }
+    if paren_depth != 0 { return null; }
     let ret_type = trim_text(substring(trimmed, prefix_len, at_index));
     let params_text = trim_text(substring(trimmed, open_index + 1, close_index));
     let mut _if269: boolean = false;
@@ -671,30 +510,18 @@ fn _extract_signature_from_header(trimmed: string, prefix_len: number, symbol: s
     let mut curly_depth: number = 0;
     let mut angle_depth: number = 0;
     loop {
-        if scan >= params_text.length {
-            break;
-        }
+        if scan >= params_text.length { break; }
         let ch = params_text[scan];
-        if ch == "{" {
-            curly_depth += 1;
-        } else if ch == "}" {
-            if curly_depth > 0 {
-                curly_depth -= 1;
-            }
-        } else if ch == "<" {
-            angle_depth += 1;
-        } else if ch == ">" {
-            if angle_depth > 0 {
-                angle_depth -= 1;
-            }
+        if ch == "{" { curly_depth += 1; } else if ch == "}" {
+            if curly_depth > 0 { curly_depth -= 1; }
+        } else if ch == "<" { angle_depth += 1; } else if ch == ">" {
+            if angle_depth > 0 { angle_depth -= 1; }
         }
         if ch == "," {
             if curly_depth == 0 {
                 if angle_depth == 0 {
                     let part = trim_text(substring(params_text, start_index, scan));
-                    if part.length > 0 {
-                        parts.push(part);
-                    }
+                    if part.length > 0 { parts.push(part); }
                     start_index = scan + 1;
                 }
             }
@@ -702,34 +529,24 @@ fn _extract_signature_from_header(trimmed: string, prefix_len: number, symbol: s
         scan += 1;
     }
     let final_part = trim_text(substring(params_text, start_index, params_text.length));
-    if final_part.length > 0 {
-        parts.push(final_part);
-    }
+    if final_part.length > 0 { parts.push(final_part); }
     // Strip parameter names from define-style params (e.g. "i8* %text" → "i8*").
     // Only strip the trailing `%name` when it appears at the top level (curly
     // depth 0) so that struct types like "{ %Decorator*, i64 }*" are preserved.
     let mut stripped_parts: string[] = [];
     let mut pi: number = 0;
     loop {
-        if pi >= parts.length {
-            break;
-        }
+        if pi >= parts.length { break; }
         let p = parts[pi];
         // Scan backwards to find the last '%' at curly depth 0.
         let mut scan_pos = p.length - 1;
         let mut pct_at_top: number = -1;
         let mut depth: number = 0;
         loop {
-            if scan_pos < 0 {
-                break;
-            }
+            if scan_pos < 0 { break; }
             let ch = substring(p, scan_pos, scan_pos + 1);
-            if ch == "}" {
-                depth += 1;
-            } else if ch == "{" {
-                if depth > 0 {
-                    depth -= 1;
-                }
+            if ch == "}" { depth += 1; } else if ch == "{" {
+                if depth > 0 { depth -= 1; }
             }
             if ch == "%" {
                 if depth == 0 {
@@ -749,7 +566,10 @@ fn _extract_signature_from_header(trimmed: string, prefix_len: number, symbol: s
         stripped_parts.push(stripped);
         pi += 1;
     }
-    return DeclareSignature { return_type: ret_type, param_types: stripped_parts };
+    return DeclareSignature {
+        return_type: ret_type,
+        param_types: stripped_parts
+    };
 }
 
 // Extract the type portion from a call-site argument like "i8* %x" or
@@ -757,56 +577,40 @@ fn _extract_signature_from_header(trimmed: string, prefix_len: number, symbol: s
 // name) and returns everything before it, trimmed.  Falls back to the whole
 // token if no sigil is found (e.g. bare constants).
 fn _extract_type_from_arg(raw: string) -> string {
-    if raw.length == 0 {
-        return raw;
-    }
+    if raw.length == 0 { return raw; }
     // Scan backwards for the last '%' or '@'.
     let mut pos = raw.length - 1;
     loop {
-        if pos < 0 {
-            break;
-        }
+        if pos < 0 { break; }
         let ch = raw[pos];
         if ch == "%" {
             let t = trim_text(substring(raw, 0, pos));
-            if t.length > 0 {
-                return t;
-            }
+            if t.length > 0 { return t; }
             return raw;
         }
         if ch == "@" {
             let t = trim_text(substring(raw, 0, pos));
-            if t.length > 0 {
-                return t;
-            }
+            if t.length > 0 { return t; }
             return raw;
         }
         pos -= 1;
     }
     // No sigil found — might be a bare constant; use first-space heuristic.
     let space_idx = index_of(raw, " ");
-    if space_idx > 0 {
-        return trim_text(substring(raw, 0, space_idx));
-    }
+    if space_idx > 0 { return trim_text(substring(raw, 0, space_idx)); }
     return raw;
 }
 
 fn find_declare_signature(lines: string[], symbol: string) -> DeclareSignature? {
-    if symbol.length == 0 {
-        return null;
-    }
+    if symbol.length == 0 { return null; }
     // First pass: check declare lines.
     let mut index: number = 0;
     loop {
-        if index >= lines.length {
-            break;
-        }
+        if index >= lines.length { break; }
         let trimmed = trim_text(lines[index]);
         if starts_with(trimmed, "declare ") {
             let result = _extract_signature_from_header(trimmed, 8, symbol);
-            if result != null {
-                return result;
-            }
+            if result != null { return result; }
         }
         index += 1;
     }
@@ -814,15 +618,11 @@ fn find_declare_signature(lines: string[], symbol: string) -> DeclareSignature? 
     // no separate declare, e.g. re-exported runtime functions).
     index = 0;
     loop {
-        if index >= lines.length {
-            break;
-        }
+        if index >= lines.length { break; }
         let trimmed = trim_text(lines[index]);
         if starts_with(trimmed, "define ") {
             let result = _extract_signature_from_header(trimmed, 7, symbol);
-            if result != null {
-                return result;
-            }
+            if result != null { return result; }
         }
         index += 1;
     }
@@ -833,9 +633,7 @@ fn find_declare_signature(lines: string[], symbol: string) -> DeclareSignature? 
     let call_needle = "@" + symbol + "(";
     index = 0;
     loop {
-        if index >= lines.length {
-            break;
-        }
+        if index >= lines.length { break; }
         let trimmed = trim_text(lines[index]);
         let call_pos = index_of(trimmed, call_needle);
         if call_pos > 0 {
@@ -860,14 +658,16 @@ fn find_declare_signature(lines: string[], symbol: string) -> DeclareSignature? 
                         let mut cd: number = 0;
                         let mut pd: number = 0;
                         loop {
-                            if sc >= params_text.length {
-                                break;
-                            }
+                            if sc >= params_text.length { break; }
                             let pch = params_text[sc];
                             if pch == "{" { cd += 1; }
-                            if pch == "}" { if cd > 0 { cd -= 1; } }
+                            if pch == "}" {
+                                if cd > 0 { cd -= 1; }
+                            }
                             if pch == "(" { pd += 1; }
-                            if pch == ")" { if pd > 0 { pd -= 1; } }
+                            if pch == ")" {
+                                if pd > 0 { pd -= 1; }
+                            }
                             if pch == "," {
                                 if cd == 0 {
                                     if pd == 0 {
@@ -883,7 +683,10 @@ fn find_declare_signature(lines: string[], symbol: string) -> DeclareSignature? 
                         if last_raw.length > 0 {
                             call_parts.push(_extract_type_from_arg(last_raw));
                         }
-                        return DeclareSignature { return_type: ret_type, param_types: call_parts };
+                        return DeclareSignature {
+                            return_type: ret_type,
+                            param_types: call_parts
+                        };
                     }
                 }
             }
@@ -898,9 +701,7 @@ fn render_function_shim(export_symbol: string, target_symbol: string, signature:
     let mut call_args: string[] = [];
     let mut idx: number = 0;
     loop {
-        if idx >= signature.param_types.length {
-            break;
-        }
+        if idx >= signature.param_types.length { break; }
         let ty = trim_text(signature.param_types[idx]);
         if ty == "..." {
             param_decls.push("...");
@@ -916,33 +717,17 @@ fn render_function_shim(export_symbol: string, target_symbol: string, signature:
 
     let header = "define " + signature.return_type + " @" + export_symbol + "(" + join_with_separator(param_decls, ", ") + ") {";
     if signature.return_type == "void" {
-        return [
-            header,
-            "entry:",
-            "  call void @" + target_symbol + "(" + join_with_separator(call_args, ", ") + ")",
-            "  ret void",
-            "}",
-        ];
+        return [header, "entry:", "  call void @" + target_symbol + "(" + join_with_separator(call_args, ", ") + ")", "  ret void", "}",];
     }
-    return [
-        header,
-        "entry:",
-        "  %t0 = call " + signature.return_type + " @" + target_symbol + "(" + join_with_separator(call_args, ", ") + ")",
-        "  ret " + signature.return_type + " %t0",
-        "}",
-    ];
+    return [header, "entry:", "  %t0 = call " + signature.return_type + " @" + target_symbol + "(" + join_with_separator(call_args, ", ") + ")", "  ret " + signature.return_type + " %t0", "}",];
 }
 
 fn insert_before_llvm_footer(lines: string[], inserted: string[]) -> string[] {
-    if inserted.length == 0 {
-        return lines;
-    }
+    if inserted.length == 0 { return lines; }
     let mut footer_index = lines.length;
     let mut index: number = 0;
     loop {
-        if index >= lines.length {
-            break;
-        }
+        if index >= lines.length { break; }
         let trimmed = trim_text(lines[index]);
         let mut _if270: boolean = false;
         if starts_with(trimmed, "attributes ") { _if270 = true; }
@@ -956,15 +741,11 @@ fn insert_before_llvm_footer(lines: string[], inserted: string[]) -> string[] {
     let mut out: string[] = [];
     let mut i: number = 0;
     loop {
-        if i >= lines.length {
-            break;
-        }
+        if i >= lines.length { break; }
         if i == footer_index {
             let mut j: number = 0;
             loop {
-                if j >= inserted.length {
-                    break;
-                }
+                if j >= inserted.length { break; }
                 out.push(inserted[j]);
                 j += 1;
             }
@@ -975,13 +756,10 @@ fn insert_before_llvm_footer(lines: string[], inserted: string[]) -> string[] {
     if footer_index == lines.length {
         let mut j: number = 0;
         loop {
-            if j >= inserted.length {
-                break;
-            }
+            if j >= inserted.length { break; }
             out.push(inserted[j]);
             j += 1;
         }
     }
     return out;
 }
-

--- a/compiler/src/llvm/lowering/lowering_helpers.sfn
+++ b/compiler/src/llvm/lowering/lowering_helpers.sfn
@@ -15,7 +15,7 @@ import {
     NativeStructField,
     NativeStructLayout,
     NativeStructLayoutField,
-    ParseNativeResult,
+    ParseNativeResult
 } from "../../native_ir";
 import {
     parse_layout_manifest,
@@ -24,15 +24,12 @@ import {
     parse_native_function_count_from_text,
     parse_native_functions_from_text,
     select_layout_manifest_artifact,
-    select_text_artifact,
+    select_text_artifact
 } from "../../native_ir_api";
 import { split_lines } from "../../native_ir_utils_text";
 import { char_code, substring } from "../../string_utils";
-import {
-    resolve_import_artifact_slug,
-    resolve_import_module_slug_for_module,
-} from "../imports";
-import { find_function_by_name, should_internalize_function, } from "../rendering";
+import { resolve_import_artifact_slug, resolve_import_module_slug_for_module } from "../imports";
+import { find_function_by_name, should_internalize_function } from "../rendering";
 import {
     CapabilityManifest,
     EnumTypeInfo,
@@ -46,7 +43,7 @@ import {
     TraitDescriptor,
     TraitImplementationDescriptor,
     TraitMetadata,
-    TypeContext,
+    TypeContext
 } from "../types";
 import {
     append_string,
@@ -56,7 +53,7 @@ import {
     sanitize_symbol,
     starts_with,
     string_array_contains,
-    trim_text,
+    trim_text
 } from "../utils";
 import { extend_string_lines } from "./lowering_io";
 
@@ -205,13 +202,25 @@ fn render_test_harness_main_for_module(tests: NativeFunction[], module_slug: str
         let msg = "  RUN  " + label;
         let escaped = _escape_llvm_string_h(msg);
         let idx_str = number_to_string(index);
-        lines = extend_string_lines(lines, ["@.test_name_" + idx_str + " = private unnamed_addr constant [" + number_to_string(msg.length + 1) + " x i8] c\"" + escaped + "\\00\""]);
+        lines = extend_string_lines(lines, ["@.test_name_" + idx_str
+            + " = private unnamed_addr constant ["
+            + number_to_string(msg.length
+            + 1)
+            + " x i8] c\""
+            + escaped
+            + "\\00\""]);
         index += 1;
     }
 
-    let pass_msg = "  PASS  (all " + number_to_string(test_count) + " tests passed)";
+    let pass_msg = "  PASS  (all " + number_to_string(test_count)
+        + " tests passed)";
     let pass_escaped = _escape_llvm_string_h(pass_msg);
-    lines = extend_string_lines(lines, ["@.test_pass_msg = private unnamed_addr constant [" + number_to_string(pass_msg.length + 1) + " x i8] c\"" + pass_escaped + "\\00\""]);
+    lines = extend_string_lines(lines, ["@.test_pass_msg = private unnamed_addr constant ["
+        + number_to_string(pass_msg.length
+        + 1)
+        + " x i8] c\""
+        + pass_escaped
+        + "\\00\""]);
     lines = extend_string_lines(lines, ["declare i32 @puts(i8*)"]);
 
     lines = extend_string_lines(lines, ["define i32 @main(i32 %argc, i8** %argv) {", "entry:"]);
@@ -225,12 +234,31 @@ fn render_test_harness_main_for_module(tests: NativeFunction[], module_slug: str
         }
         let idx_str = number_to_string(index);
         let msg = "  RUN  " + _test_label_from_name_h(tests[index].name);
-        lines = extend_string_lines(lines, ["  %name_ptr_" + idx_str + " = getelementptr [" + number_to_string(msg.length + 1) + " x i8], [" + number_to_string(msg.length + 1) + " x i8]* @.test_name_" + idx_str + ", i64 0, i64 0", "  call i32 @puts(i8* %name_ptr_" + idx_str + ")", "  call void @" + sym + "()",]);
+        lines = extend_string_lines(lines, ["  %name_ptr_" + idx_str
+            + " = getelementptr ["
+            + number_to_string(msg.length
+            + 1)
+            + " x i8], ["
+            + number_to_string(msg.length
+            + 1)
+            + " x i8]* @.test_name_"
+            + idx_str
+            + ", i64 0, i64 0", "  call i32 @puts(i8* %name_ptr_"
+            + idx_str
+            + ")", "  call void @"
+            + sym
+            + "()",]);
         index += 1;
     }
 
     // Print summary
-    lines = extend_string_lines(lines, ["  %pass_ptr = getelementptr [" + number_to_string(pass_msg.length + 1) + " x i8], [" + number_to_string(pass_msg.length + 1) + " x i8]* @.test_pass_msg, i64 0, i64 0", "  call i32 @puts(i8* %pass_ptr)", "  ret i32 0", "}",]);
+    lines = extend_string_lines(lines, ["  %pass_ptr = getelementptr ["
+        + number_to_string(pass_msg.length
+        + 1)
+        + " x i8], ["
+        + number_to_string(pass_msg.length
+        + 1)
+        + " x i8]* @.test_pass_msg, i64 0, i64 0", "  call i32 @puts(i8* %pass_ptr)", "  ret i32 0", "}",]);
     return lines;
 }
 
@@ -646,7 +674,8 @@ fn find_declare_signature(lines: string[], symbol: string) -> DeclareSignature? 
                 let params_start = call_pos + call_needle.length;
                 let close_paren = index_of(substring(trimmed, params_start, trimmed.length), ")");
                 if close_paren >= 0 {
-                    let params_text = substring(trimmed, params_start, params_start + close_paren);
+                    let params_text = substring(trimmed, params_start, params_start
+                        + close_paren);
                     if ret_type.length > 0 {
                         // Strip parameter values, keeping only types.
                         // For multi-token types like `double (i8*)*`, split on
@@ -715,11 +744,21 @@ fn render_function_shim(export_symbol: string, target_symbol: string, signature:
         idx += 1;
     }
 
-    let header = "define " + signature.return_type + " @" + export_symbol + "(" + join_with_separator(param_decls, ", ") + ") {";
+    let header = "define " + signature.return_type + " @" + export_symbol + "("
+        + join_with_separator(param_decls, ", ")
+        + ") {";
     if signature.return_type == "void" {
-        return [header, "entry:", "  call void @" + target_symbol + "(" + join_with_separator(call_args, ", ") + ")", "  ret void", "}",];
+        return [header, "entry:", "  call void @" + target_symbol + "("
+            + join_with_separator(call_args, ", ")
+            + ")", "  ret void", "}",];
     }
-    return [header, "entry:", "  %t0 = call " + signature.return_type + " @" + target_symbol + "(" + join_with_separator(call_args, ", ") + ")", "  ret " + signature.return_type + " %t0", "}",];
+    return [header, "entry:", "  %t0 = call " + signature.return_type + " @"
+        + target_symbol
+        + "("
+        + join_with_separator(call_args, ", ")
+        + ")", "  ret "
+        + signature.return_type
+        + " %t0", "}",];
 }
 
 fn insert_before_llvm_footer(lines: string[], inserted: string[]) -> string[] {

--- a/compiler/src/llvm/lowering/lowering_helpers_mangling.sfn
+++ b/compiler/src/llvm/lowering/lowering_helpers_mangling.sfn
@@ -16,7 +16,7 @@ import {
     CapabilityManifest,
     TraitDescriptor,
     TraitImplementationDescriptor,
-    TraitMetadata,
+    TraitMetadata
 } from "../types";
 import {
     index_of,
@@ -38,7 +38,7 @@ import {
     render_function_shim,
     resolve_import_provider_module_name,
     sanitize_module_suffix,
-    should_keep_unmangled_abi_symbol,
+    should_keep_unmangled_abi_symbol
 } from "./lowering_helpers";
 
 fn apply_module_symbol_mangling(lines: string[], imports: NativeImport[], current_module_slug: string, imported_native_texts: string[], native_text_path: string) -> MangledModuleResult {
@@ -186,7 +186,10 @@ fn apply_module_symbol_mangling(lines: string[], imports: NativeImport[], curren
                 let original_symbol = sanitize_symbol(original_name);
                 if should_keep_unmangled_abi_symbol(local_symbol) { continue; }
                 if string_array_contains(defined, local_symbol) {
-                    diagnostics.push("llvm lowering: import `" + local_symbol + "` shadows local function in module `" + current_module_slug + "`");
+                    diagnostics.push("llvm lowering: import `" + local_symbol
+                        + "` shadows local function in module `"
+                        + current_module_slug
+                        + "`");
                     continue;
                 }
                 // Don't rewrite if already qualified.
@@ -286,7 +289,9 @@ fn _render_declare_line(symbol: string, signature: DeclareSignature) -> string {
         param_types.push(signature.param_types[idx]);
         idx += 1;
     }
-    return "declare " + signature.return_type + " @" + symbol + "(" + join_with_separator(param_types, ", ") + ")";
+    return "declare " + signature.return_type + " @" + symbol + "("
+        + join_with_separator(param_types, ", ")
+        + ")";
 }
 
 fn empty_capability_manifest() -> CapabilityManifest {
@@ -307,7 +312,7 @@ fn build_trait_metadata(interfaces: NativeInterface[], structs: NativeStruct[]) 
         let interface = interfaces[index];
         let mut updated_interfaces = interface_descriptors;
         updated_interfaces = updated_interfaces.push(TraitDescriptor {
-            name: interface.name, type_parameters: interface.type_parameters, signatures: interface.signatures,
+            name: interface.name, type_parameters: interface.type_parameters, signatures: interface.signatures
         });
         interface_descriptors = updated_interfaces;
         index += 1;
@@ -447,7 +452,7 @@ fn flatten_struct_methods(structs: NativeStruct[]) -> NativeFunction[] {
                     type_annotation: p_type,
                     mutable: p.mutable,
                     default_value: p.default_value,
-                    span: p.span,
+                    span: p.span
                 };
                 fixed_params.push(fixed_p);
                 pi += 1;
@@ -460,7 +465,7 @@ fn flatten_struct_methods(structs: NativeStruct[]) -> NativeFunction[] {
                 effects: method.effects,
                 decorators: method.decorators,
                 instructions: method.instructions,
-                is_extern: false,
+                is_extern: false
             };
             result = append_native_function(result, qualified);
             method_index += 1;

--- a/compiler/src/llvm/lowering/lowering_helpers_mangling.sfn
+++ b/compiler/src/llvm/lowering/lowering_helpers_mangling.sfn
@@ -3,50 +3,52 @@
 // Module symbol mangling, trait metadata construction, and function
 // collection helpers.  Split from lowering_helpers.sfn to keep both
 // files under 1000 lines.
-
-import { NativeImport, NativeImportSpecifier, NativeFunction, NativeParameter, NativeInterface, NativeStruct } from "../../native_ir";
-
 import {
-    TraitMetadata,
+    NativeFunction,
+    NativeImport,
+    NativeImportSpecifier,
+    NativeInterface,
+    NativeParameter,
+    NativeStruct
+} from "../../native_ir";
+import { substring } from "../../string_utils";
+import {
+    CapabilityManifest,
     TraitDescriptor,
     TraitImplementationDescriptor,
-    CapabilityManifest,
+    TraitMetadata,
 } from "../types";
-
-import { number_to_string, sanitize_symbol, string_array_contains, starts_with, index_of, trim_text, join_with_separator } from "../utils";
-
-import { substring } from "../../string_utils";
-
 import {
-    sanitize_module_suffix,
-    should_keep_unmangled_abi_symbol,
+    index_of,
+    join_with_separator,
+    number_to_string,
+    sanitize_symbol,
+    starts_with,
+    string_array_contains,
+    trim_text
+} from "../utils";
+import {
+    DeclareSignature,
+    MangledModuleResult,
+    apply_symbol_substitutions,
     collect_available_import_module_names,
     collect_defined_function_symbols,
-    resolve_import_provider_module_name,
-    apply_symbol_substitutions,
     find_declare_signature,
-    render_function_shim,
     insert_before_llvm_footer,
-    MangledModuleResult,
-    DeclareSignature,
+    render_function_shim,
+    resolve_import_provider_module_name,
+    sanitize_module_suffix,
+    should_keep_unmangled_abi_symbol,
 } from "./lowering_helpers";
 
-fn apply_module_symbol_mangling(
-    lines: string[],
-    imports: NativeImport[],
-    current_module_slug: string,
-    imported_native_texts: string[],
-    native_text_path: string
-) -> MangledModuleResult {
+fn apply_module_symbol_mangling(lines: string[], imports: NativeImport[], current_module_slug: string, imported_native_texts: string[], native_text_path: string) -> MangledModuleResult {
     let mut diagnostics: string[] = [];
     let debug_lowering = fs.exists("build/sailfin/.trace_lowering");
     if debug_lowering {
         print.err("emit-llvm: mangle start module=" + current_module_slug);
     }
     let mut safe_imports = imports;
-    if safe_imports == null {
-        safe_imports = [];
-    }
+    if safe_imports == null { safe_imports = []; }
     if safe_imports.length > 100000 {
         diagnostics.push("llvm lowering: import list too large for mangling; dropping");
         safe_imports = [];
@@ -77,9 +79,7 @@ fn apply_module_symbol_mangling(
     let mut local_news: string[] = [];
     let mut def_index: number = 0;
     loop {
-        if def_index >= defined.length {
-            break;
-        }
+        if def_index >= defined.length { break; }
         let sym = defined[def_index];
         if should_keep_unmangled_abi_symbol(sym) {
             def_index += 1;
@@ -124,41 +124,27 @@ fn apply_module_symbol_mangling(
         // Scan native text line-by-line for .import directives.
         let mut scan_pos: number = 0;
         loop {
-            if scan_pos >= native_text.length {
-                break;
-            }
+            if scan_pos >= native_text.length { break; }
             // Find end of current line.
             let mut line_end: number = scan_pos;
             loop {
-                if line_end >= native_text.length {
-                    break;
-                }
-                if native_text[line_end] == "\n" {
-                    break;
-                }
+                if line_end >= native_text.length { break; }
+                if native_text[line_end] == "\n" { break; }
                 line_end += 1;
             }
             let raw_line = substring(native_text, scan_pos, line_end);
             let line = trim_text(raw_line);
             scan_pos = line_end + 1;
 
-            if !starts_with(line, ".import ") {
-                continue;
-            }
+            if !starts_with(line, ".import ") { continue; }
             // Extract module path between first pair of quotes.
             let q1 = index_of(line, "\"");
-            if q1 < 0 {
-                continue;
-            }
+            if q1 < 0 { continue; }
             let after_q1 = substring(line, q1 + 1, line.length);
             let q2 = index_of(after_q1, "\"");
-            if q2 <= 0 {
-                continue;
-            }
+            if q2 <= 0 { continue; }
             let import_module = substring(after_q1, 0, q2);
-            if import_module.length == 0 {
-                continue;
-            }
+            if import_module.length == 0 { continue; }
 
             let provider_module = resolve_import_provider_module_name(import_module, current_module_slug, available_modules);
             let provider_is_runtime = starts_with(provider_module, "runtime/");
@@ -167,21 +153,15 @@ fn apply_module_symbol_mangling(
             // Extract specifiers between { and }.
             let brace_open = index_of(line, "{");
             let brace_close = index_of(line, "}");
-            if brace_open < 0 {
-                continue;
-            }
-            if brace_close <= brace_open {
-                continue;
-            }
+            if brace_open < 0 { continue; }
+            if brace_close <= brace_open { continue; }
             let specs_text = substring(line, brace_open + 1, brace_close);
 
             // Split specifiers by comma and process each one.
             let mut remaining = specs_text;
             loop {
                 remaining = trim_text(remaining);
-                if remaining.length == 0 {
-                    break;
-                }
+                if remaining.length == 0 { break; }
                 let comma_pos = index_of(remaining, ",");
                 let mut spec_name: string = "";
                 if comma_pos >= 0 {
@@ -191,9 +171,7 @@ fn apply_module_symbol_mangling(
                     spec_name = trim_text(remaining);
                     remaining = "";
                 }
-                if spec_name.length == 0 {
-                    continue;
-                }
+                if spec_name.length == 0 { continue; }
 
                 // Handle aliased imports: "name as alias" → local=alias, original=name
                 let mut local_name = spec_name;
@@ -206,17 +184,13 @@ fn apply_module_symbol_mangling(
 
                 let local_symbol = sanitize_symbol(local_name);
                 let original_symbol = sanitize_symbol(original_name);
-                if should_keep_unmangled_abi_symbol(local_symbol) {
-                    continue;
-                }
+                if should_keep_unmangled_abi_symbol(local_symbol) { continue; }
                 if string_array_contains(defined, local_symbol) {
                     diagnostics.push("llvm lowering: import `" + local_symbol + "` shadows local function in module `" + current_module_slug + "`");
                     continue;
                 }
                 // Don't rewrite if already qualified.
-                if index_of(local_symbol, "__") >= 0 {
-                    continue;
-                }
+                if index_of(local_symbol, "__") >= 0 { continue; }
                 import_olds.push(local_symbol);
                 let mut target_symbol = original_symbol;
                 if !provider_is_runtime {
@@ -250,9 +224,7 @@ fn apply_module_symbol_mangling(
         let mut _if274: boolean = false;
         if shim_index >= shim_exports.length { _if274 = true; }
         if shim_index >= shim_targets.length { _if274 = true; }
-        if _if274 {
-            break;
-        }
+        if _if274 { break; }
         let export_sym = shim_exports[shim_index];
         let target_sym = shim_targets[shim_index];
         let signature = find_declare_signature(rewritten, target_sym);
@@ -293,17 +265,13 @@ fn _has_declare_or_define(lines: string[], symbol: string) -> boolean {
     let at_sym = "@" + symbol + "(";
     let mut index: number = 0;
     loop {
-        if index >= lines.length {
-            break;
-        }
+        if index >= lines.length { break; }
         let trimmed = trim_text(lines[index]);
         let mut _is_hdr: boolean = false;
         if starts_with(trimmed, "declare ") { _is_hdr = true; }
         if starts_with(trimmed, "define ") { _is_hdr = true; }
         if _is_hdr {
-            if index_of(trimmed, at_sym) >= 0 {
-                return true;
-            }
+            if index_of(trimmed, at_sym) >= 0 { return true; }
         }
         index += 1;
     }
@@ -314,9 +282,7 @@ fn _render_declare_line(symbol: string, signature: DeclareSignature) -> string {
     let mut param_types: string[] = [];
     let mut idx: number = 0;
     loop {
-        if idx >= signature.param_types.length {
-            break;
-        }
+        if idx >= signature.param_types.length { break; }
         param_types.push(signature.param_types[idx]);
         idx += 1;
     }
@@ -337,18 +303,12 @@ fn build_trait_metadata(interfaces: NativeInterface[], structs: NativeStruct[]) 
     let mut interface_descriptors: TraitDescriptor[] = [];
     let mut index: number = 0;
     loop {
-        if index >= interfaces.length {
-            break;
-        }
+        if index >= interfaces.length { break; }
         let interface = interfaces[index];
         let mut updated_interfaces = interface_descriptors;
-        updated_interfaces = updated_interfaces.push(
-            TraitDescriptor {
-                name: interface.name,
-                type_parameters: interface.type_parameters,
-                signatures: interface.signatures,
-            }
-        );
+        updated_interfaces = updated_interfaces.push(TraitDescriptor {
+            name: interface.name, type_parameters: interface.type_parameters, signatures: interface.signatures,
+        });
         interface_descriptors = updated_interfaces;
         index += 1;
     }
@@ -356,32 +316,29 @@ fn build_trait_metadata(interfaces: NativeInterface[], structs: NativeStruct[]) 
     let mut implementation_descriptors: TraitImplementationDescriptor[] = [];
     index = 0;
     loop {
-        if index >= structs.length {
-            break;
-        }
+        if index >= structs.length { break; }
         let definition = structs[index];
         let mut impls = definition.implements;
-        if impls == null {
-            impls = [];
-        }
+        if impls == null { impls = []; }
         if impls.length > 0 {
             let mut updated_impls = implementation_descriptors;
-            updated_impls = updated_impls.push(
-                TraitImplementationDescriptor { struct_name: definition.name, interfaces: impls }
-            );
+            updated_impls = updated_impls.push(TraitImplementationDescriptor {
+                struct_name: definition.name, interfaces: impls
+            });
             implementation_descriptors = updated_impls;
         }
         index += 1;
     }
 
-    return TraitMetadata { interfaces: interface_descriptors, implementations: implementation_descriptors };
+    return TraitMetadata {
+        interfaces: interface_descriptors,
+        implementations: implementation_descriptors
+    };
 }
 
 fn append_native_function(values: NativeFunction[], value: NativeFunction) -> NativeFunction[] {
     let mut out = values;
-    if out == null {
-        out = [];
-    }
+    if out == null { out = []; }
     out = out.push(value);
     return out;
 }
@@ -389,32 +346,20 @@ fn append_native_function(values: NativeFunction[], value: NativeFunction) -> Na
 fn concat_native_functions(first: NativeFunction[], second: NativeFunction[]) -> NativeFunction[] {
     let mut result: NativeFunction[] = [];
     let mut safe_first = first;
-    if safe_first == null {
-        safe_first = [];
-    }
-    if safe_first.length > 200000 {
-        return result;
-    }
+    if safe_first == null { safe_first = []; }
+    if safe_first.length > 200000 { return result; }
     let mut safe_second = second;
-    if safe_second == null {
-        safe_second = [];
-    }
-    if safe_second.length > 200000 {
-        return result;
-    }
+    if safe_second == null { safe_second = []; }
+    if safe_second.length > 200000 { return result; }
     let mut index: number = 0;
     loop {
-        if index >= safe_first.length {
-            break;
-        }
+        if index >= safe_first.length { break; }
         result = append_native_function(result, safe_first[index]);
         index += 1;
     }
     index = 0;
     loop {
-        if index >= safe_second.length {
-            break;
-        }
+        if index >= safe_second.length { break; }
         result = append_native_function(result, safe_second[index]);
         index += 1;
     }
@@ -443,21 +388,13 @@ fn concat_native_functions(first: NativeFunction[], second: NativeFunction[]) ->
 // the safe call sites.
 fn extend_native_functions_inplace(dst: NativeFunction[], src: NativeFunction[]) -> NativeFunction[] {
     let mut out = dst;
-    if out == null {
-        out = [];
-    }
+    if out == null { out = []; }
     let mut safe_src = src;
-    if safe_src == null {
-        safe_src = [];
-    }
-    if safe_src.length > 200000 {
-        return out;
-    }
+    if safe_src == null { safe_src = []; }
+    if safe_src.length > 200000 { return out; }
     let mut index: number = 0;
     loop {
-        if index >= safe_src.length {
-            break;
-        }
+        if index >= safe_src.length { break; }
         out = append_native_function(out, safe_src[index]);
         index += 1;
     }
@@ -465,15 +402,11 @@ fn extend_native_functions_inplace(dst: NativeFunction[], src: NativeFunction[])
 }
 
 fn flatten_struct_methods(structs: NativeStruct[]) -> NativeFunction[] {
-    if structs.length > 100000 {
-        return [];
-    }
+    if structs.length > 100000 { return []; }
     let mut result: NativeFunction[] = [];
     let mut index: number = 0;
     loop {
-        if index >= structs.length {
-            break;
-        }
+        if index >= structs.length { break; }
         let definition = structs[index];
         let mut methods = definition.methods;
         if methods == null {
@@ -486,9 +419,7 @@ fn flatten_struct_methods(structs: NativeStruct[]) -> NativeFunction[] {
         }
         let mut method_index: number = 0;
         loop {
-            if method_index >= methods.length {
-                break;
-            }
+            if method_index >= methods.length { break; }
             let method = methods[method_index];
             let qualified_name = definition.name + method.name;
             // Rebuild parameters so that the `self` parameter always carries
@@ -497,29 +428,19 @@ fn flatten_struct_methods(structs: NativeStruct[]) -> NativeFunction[] {
             // empty strings, producing `define ... @Fn( %self)` in LLVM IR.
             let mut fixed_params: NativeParameter[] = [];
             let mut raw_params = method.parameters;
-            if raw_params == null {
-                raw_params = [];
-            }
+            if raw_params == null { raw_params = []; }
             let mut pi: number = 0;
             loop {
-                if pi >= raw_params.length {
-                    break;
-                }
+                if pi >= raw_params.length { break; }
                 let p = raw_params[pi];
                 let mut p_name = p.name;
-                if p_name == null {
-                    p_name = "";
-                }
+                if p_name == null { p_name = ""; }
                 let mut p_type = p.type_annotation;
-                if p_type == null {
-                    p_type = "";
-                }
+                if p_type == null { p_type = ""; }
                 // If this is the self parameter and type is empty, fill it
                 // with the struct name so type mapping resolves correctly.
                 if p_name == "self" {
-                    if p_type.length == 0 {
-                        p_type = definition.name;
-                    }
+                    if p_type.length == 0 { p_type = definition.name; }
                 }
                 let fixed_p = NativeParameter {
                     name: p_name,
@@ -549,17 +470,10 @@ fn flatten_struct_methods(structs: NativeStruct[]) -> NativeFunction[] {
     return result;
 }
 
-
 fn _join_llvm_lines_linear(lines: string[]) -> string {
-    if lines == null {
-        return "";
-    }
-    if lines.length == 0 {
-        return "";
-    }
-    if lines.length == 1 {
-        return lines[0];
-    }
+    if lines == null { return ""; }
+    if lines.length == 0 { return ""; }
+    if lines.length == 1 { return lines[0]; }
     // Pair-wise merge: each pass halves the working array. O(N log N) memory
     // total instead of the O(N^2) accumulation of `out = out + line` in a
     // loop. For emit_native.sfn this is the difference between blowing the
@@ -570,20 +484,14 @@ fn _join_llvm_lines_linear(lines: string[]) -> string {
     // string_append peephole (b3b6dad) reuses the buffer in place.
     let mut current = lines;
     loop {
-        if current.length <= 1 {
-            break;
-        }
+        if current.length <= 1 { break; }
         let mut next: string[] = [];
         let mut i: number = 0;
         loop {
-            if i >= current.length {
-                break;
-            }
+            if i >= current.length { break; }
             if i + 1 < current.length {
                 next.push(current[i] + "\n" + current[i + 1]);
-            } else {
-                next.push(current[i]);
-            }
+            } else { next.push(current[i]); }
             i += 2;
         }
         current = next;

--- a/compiler/src/llvm/lowering/lowering_io.sfn
+++ b/compiler/src/llvm/lowering/lowering_io.sfn
@@ -4,12 +4,12 @@
 // utilities.  Extracted from lowering_core.sfn to reduce per-file
 // memory footprint during self-hosting compilation.
 import { substring } from "../../string_utils";
-import { LifetimeRegionMetadata, StringConstant, } from "../types";
+import { LifetimeRegionMetadata, StringConstant } from "../types";
 import {
     index_of,
     number_to_string,
     starts_with,
-    trim_text,
+    trim_text
 } from "../utils";
 
 // ── String array operations ──────────────────────────────────────────
@@ -49,7 +49,10 @@ fn extend_string_lines_checked(values: string[], extras: string[], label: string
     if safe_extras.length == 0 { return safe_values; }
     if safe_extras.length > 1000000 {
         let mut out = safe_values;
-        out.push("llvm lowering: skipped oversized " + label + " diagnostics (len=" + number_to_string(extras.length) + ")");
+        out.push("llvm lowering: skipped oversized " + label
+            + " diagnostics (len="
+            + number_to_string(extras.length)
+            + ")");
         return out;
     }
     return extend_string_lines(safe_values, safe_extras);

--- a/compiler/src/llvm/lowering/lowering_io.sfn
+++ b/compiler/src/llvm/lowering/lowering_io.sfn
@@ -3,35 +3,24 @@
 // String array operations, file I/O helpers, and miscellaneous lowering
 // utilities.  Extracted from lowering_core.sfn to reduce per-file
 // memory footprint during self-hosting compilation.
-
 import { substring } from "../../string_utils";
+import { LifetimeRegionMetadata, StringConstant, } from "../types";
 import {
-    LifetimeRegionMetadata,
-    StringConstant,
-} from "../types";
-import {
+    index_of,
     number_to_string,
     starts_with,
     trim_text,
-    index_of,
 } from "../utils";
 
 // ── String array operations ──────────────────────────────────────────
-
 fn extend_string_lines(values: string[], extras: string[]) -> string[] {
     let mut out = values;
-    if out == null {
-        out = [];
-    }
+    if out == null { out = []; }
     let mut safe_extras = extras;
-    if safe_extras == null {
-        safe_extras = [];
-    }
+    if safe_extras == null { safe_extras = []; }
     let mut index: number = 0;
     loop {
-        if index >= safe_extras.length {
-            break;
-        }
+        if index >= safe_extras.length { break; }
         out.push(safe_extras[index]);
         index += 1;
     }
@@ -40,18 +29,12 @@ fn extend_string_lines(values: string[], extras: string[]) -> string[] {
 
 fn append_string_lines(values: string[], extras: string[]) -> string[] {
     let mut out = values;
-    if out == null {
-        out = [];
-    }
+    if out == null { out = []; }
     let mut safe_extras = extras;
-    if safe_extras == null {
-        safe_extras = [];
-    }
+    if safe_extras == null { safe_extras = []; }
     let mut index: number = 0;
     loop {
-        if index >= safe_extras.length {
-            break;
-        }
+        if index >= safe_extras.length { break; }
         out.push(safe_extras[index]);
         index += 1;
     }
@@ -60,16 +43,10 @@ fn append_string_lines(values: string[], extras: string[]) -> string[] {
 
 fn extend_string_lines_checked(values: string[], extras: string[], label: string) -> string[] {
     let mut safe_values = values;
-    if safe_values == null {
-        safe_values = [];
-    }
+    if safe_values == null { safe_values = []; }
     let mut safe_extras = extras;
-    if safe_extras == null {
-        safe_extras = [];
-    }
-    if safe_extras.length == 0 {
-        return safe_values;
-    }
+    if safe_extras == null { safe_extras = []; }
+    if safe_extras.length == 0 { return safe_values; }
     if safe_extras.length > 1000000 {
         let mut out = safe_values;
         out.push("llvm lowering: skipped oversized " + label + " diagnostics (len=" + number_to_string(extras.length) + ")");
@@ -79,18 +56,12 @@ fn extend_string_lines_checked(values: string[], extras: string[], label: string
 }
 
 fn extend_lifetime_regions_checked(values: LifetimeRegionMetadata[], extras: LifetimeRegionMetadata[]) -> LifetimeRegionMetadata[] {
-    if extras.length == 0 {
-        return values;
-    }
-    if extras.length > 1000000 {
-        return values;
-    }
+    if extras.length == 0 { return values; }
+    if extras.length > 1000000 { return values; }
     let mut out = values;
     let mut index: number = 0;
     loop {
-        if index >= extras.length {
-            break;
-        }
+        if index >= extras.length { break; }
         out = out.push(extras[index]);
         index += 1;
     }
@@ -101,23 +72,16 @@ fn insert_string_at(values: string[], insert_index: number, value: string) -> st
     let mut out: string[] = [];
     let mut index: number = 0;
     loop {
-        if index >= values.length {
-            break;
-        }
-        if index == insert_index {
-            out.push(value);
-        }
+        if index >= values.length { break; }
+        if index == insert_index { out.push(value); }
         out.push(values[index]);
         index += 1;
     }
-    if insert_index >= values.length {
-        out.push(value);
-    }
+    if insert_index >= values.length { out.push(value); }
     return out;
 }
 
 // ── File I/O helpers ─────────────────────────────────────────────────
-
 fn write_llvm_lines_chunked(path: string, lines: string[]) -> boolean ![io] {
     let mut _if257: boolean = false;
     if lines == null { _if257 = true; }
@@ -149,16 +113,12 @@ fn _write_llvm_lines_chunked_unused(path: string, lines: string[]) -> boolean ![
 
     let mut index2: number = 0;
     loop {
-        if index2 >= lines.length {
-            break;
-        }
+        if index2 >= lines.length { break; }
         let line2 = lines[index2] + "\n";
         let next_len = buffered + line2.length;
         if next_len > chunk_limit {
             if buffer.length > 0 {
-                if wrote {
-                    fs.appendFile(path, buffer);
-                } else {
+                if wrote { fs.appendFile(path, buffer); } else {
                     fs.writeFile(path, buffer);
                     wrote = true;
                 }
@@ -172,9 +132,7 @@ fn _write_llvm_lines_chunked_unused(path: string, lines: string[]) -> boolean ![
     }
 
     if buffer.length > 0 {
-        if wrote {
-            fs.appendFile(path, buffer);
-        } else {
+        if wrote { fs.appendFile(path, buffer); } else {
             fs.writeFile(path, buffer);
         }
     }
@@ -182,16 +140,11 @@ fn _write_llvm_lines_chunked_unused(path: string, lines: string[]) -> boolean ![
 }
 
 // ── Module helpers ───────────────────────────────────────────────────
-
 fn module_source_filename(module_name: string) -> string {
-    if module_name.length == 0 {
-        return "sailfin";
-    }
+    if module_name.length == 0 { return "sailfin"; }
     if module_name.length >= 4 {
         let suffix = substring(module_name, module_name.length - 4, module_name.length);
-        if suffix == ".sfn" {
-            return module_name;
-        }
+        if suffix == ".sfn" { return module_name; }
     }
     return module_name + ".sfn";
 }
@@ -201,13 +154,9 @@ fn ensure_intrinsic_declarations(lines: string[]) -> string[] {
     let mut has_round_decl: boolean = false;
     let mut index: number = 0;
     loop {
-        if index >= lines.length {
-            break;
-        }
+        if index >= lines.length { break; }
         let line = lines[index];
-        if index_of(line, "call double @round(") >= 0 {
-            uses_round = true;
-        }
+        if index_of(line, "call double @round(") >= 0 { uses_round = true; }
         let trimmed = trim_text(line);
         if starts_with(trimmed, "declare double @round(double)") {
             has_round_decl = true;
@@ -218,14 +167,10 @@ fn ensure_intrinsic_declarations(lines: string[]) -> string[] {
     let mut _if258: boolean = false;
     if !uses_round { _if258 = true; }
     if has_round_decl { _if258 = true; }
-    if _if258 {
-        return lines;
-    }
+    if _if258 { return lines; }
 
     let mut out = lines;
     out.push("");
     out.push("declare double @round(double)");
     return out;
-}
-
-// make_native_module_for_emit lives in lowering_core.sfn (used by compile_native_text_to_llvm_file)
+}  // make_native_module_for_emit lives in lowering_core.sfn (used by compile_native_text_to_llvm_file)

--- a/compiler/src/llvm/lowering/lowering_native_helpers.sfn
+++ b/compiler/src/llvm/lowering/lowering_native_helpers.sfn
@@ -16,7 +16,7 @@ import {
     NativeEnumVariant,
     NativeEnumVariantField,
     NativeEnumLayout,
-    NativeEnumVariantLayout,
+    NativeEnumVariantLayout
 } from "../../native_ir";
 
 // ── NativeFunction constructors ──────────────────────────────────────

--- a/compiler/src/llvm/lowering/lowering_native_helpers.sfn
+++ b/compiler/src/llvm/lowering/lowering_native_helpers.sfn
@@ -3,7 +3,6 @@
 // NativeFunction / NativeInstruction / NativeStruct constructors,
 // updaters, and field accessors.  Extracted from lowering_core.sfn to
 // reduce per-file memory footprint during self-hosting compilation.
-
 import {
     NativeImport,
     NativeFunction,
@@ -21,29 +20,71 @@ import {
 } from "../../native_ir";
 
 // ── NativeFunction constructors ──────────────────────────────────────
-
 // Helper: construct NativeFunction outside of if blocks.
 // The seed v0.1.1 drops struct literal constructions inside if blocks,
 // so we extract construction into standalone functions that get called.
 fn make_native_function_basic(name: string, is_async: boolean) -> NativeFunction {
-    return NativeFunction { name: name, is_async: is_async, parameters: [], return_type: "void", effects: [], decorators: [], is_extern: false, instructions: [] };
+    return NativeFunction {
+        name: name,
+        is_async: is_async,
+        parameters: [],
+        return_type: "void",
+        effects: [],
+        decorators: [],
+        is_extern: false,
+        instructions: []
+    };
 }
 
 fn make_native_function_with_return(name: string, is_async: boolean, ret_type: string) -> NativeFunction {
-    return NativeFunction { name: name, is_async: is_async, parameters: [], return_type: ret_type, effects: [], decorators: [], is_extern: false, instructions: [] };
+    return NativeFunction {
+        name: name,
+        is_async: is_async,
+        parameters: [],
+        return_type: ret_type,
+        effects: [],
+        decorators: [],
+        is_extern: false,
+        instructions: []
+    };
 }
 
 fn make_native_function_method(name: string, self_type: string, ret_type: string) -> NativeFunction {
-    let self_param = NativeParameter { name: "self", type_annotation: self_type, mutable: false, default_value: null, span: null };
-    return NativeFunction { name: name, is_async: false, parameters: [self_param], return_type: ret_type, effects: [], decorators: [], is_extern: false, instructions: [] };
+    let self_param = NativeParameter {
+        name: "self",
+        type_annotation: self_type,
+        mutable: false,
+        default_value: null,
+        span: null
+    };
+    return NativeFunction {
+        name: name,
+        is_async: false,
+        parameters: [self_param],
+        return_type: ret_type,
+        effects: [],
+        decorators: [],
+        is_extern: false,
+        instructions: []
+    };
 }
 
 fn make_native_parameter(pname: string, ptype: string) -> NativeParameter {
-    return NativeParameter { name: pname, type_annotation: ptype, mutable: false, default_value: null, span: null };
+    return NativeParameter {
+        name: pname,
+        type_annotation: ptype,
+        mutable: false,
+        default_value: null,
+        span: null
+    };
 }
 
 fn make_native_import(module_path: string) -> NativeImport {
-    return NativeImport { kind: "named", module: module_path, specifiers: [] };
+    return NativeImport {
+        kind: "named",
+        module: module_path,
+        specifiers: []
+    };
 }
 
 fn make_native_struct_layout(sz: number, al: number, flds: NativeStructLayoutField[]) -> NativeStructLayout {
@@ -51,19 +92,34 @@ fn make_native_struct_layout(sz: number, al: number, flds: NativeStructLayoutFie
 }
 
 fn make_native_struct(sname: string, sfields: NativeStructField[], smethods: NativeFunction[], slayout: NativeStructLayout?) -> NativeStruct {
-    return NativeStruct { name: sname, fields: sfields, methods: smethods, implements: [], layout: slayout };
+    return NativeStruct {
+        name: sname,
+        fields: sfields,
+        methods: smethods,
+        implements: [],
+        layout: slayout
+    };
 }
 
 fn make_native_struct_field(fname: string, ftype: string) -> NativeStructField {
-    return NativeStructField { name: fname, type_annotation: ftype, mutable: false };
+    return NativeStructField {
+        name: fname,
+        type_annotation: ftype,
+        mutable: false
+    };
 }
 
 fn make_native_struct_layout_field(lf_name: string, lf_type: string, lf_offset: number, lf_size: number, lf_align: number) -> NativeStructLayoutField {
-    return NativeStructLayoutField { name: lf_name, type_annotation: lf_type, offset: lf_offset, size: lf_size, align: lf_align };
+    return NativeStructLayoutField {
+        name: lf_name,
+        type_annotation: lf_type,
+        offset: lf_offset,
+        size: lf_size,
+        align: lf_align
+    };
 }
 
 // ── NativeEnum constructors ──────────────────────────────────────────
-
 fn make_native_enum(ename: string, evariants: NativeEnumVariant[], elayout: NativeEnumLayout?) -> NativeEnum {
     return NativeEnum { name: ename, variants: evariants, layout: elayout };
 }
@@ -73,33 +129,89 @@ fn make_native_enum_variant(vname: string) -> NativeEnumVariant {
 }
 
 fn make_native_enum_layout(esize: number, ealign: number, etag_type: string, etag_size: number, etag_align: number, evariants: NativeEnumVariantLayout[]) -> NativeEnumLayout {
-    return NativeEnumLayout { size: esize, align: ealign, tag_type: etag_type, tag_size: etag_size, tag_align: etag_align, variants: evariants };
+    return NativeEnumLayout {
+        size: esize,
+        align: ealign,
+        tag_type: etag_type,
+        tag_size: etag_size,
+        tag_align: etag_align,
+        variants: evariants
+    };
 }
 
 fn make_native_enum_variant_layout(vlname: string, vltag: number, vloffset: number, vlsize: number, vlalign: number) -> NativeEnumVariantLayout {
-    return NativeEnumVariantLayout { name: vlname, tag: vltag, offset: vloffset, size: vlsize, align: vlalign, fields: [] };
+    return NativeEnumVariantLayout {
+        name: vlname,
+        tag: vltag,
+        offset: vloffset,
+        size: vlsize,
+        align: vlalign,
+        fields: []
+    };
 }
 
 fn make_native_enum_variant_layout_with_fields(vlname: string, vltag: number, vloffset: number, vlsize: number, vlalign: number, vlfields: NativeStructLayoutField[]) -> NativeEnumVariantLayout {
-    return NativeEnumVariantLayout { name: vlname, tag: vltag, offset: vloffset, size: vlsize, align: vlalign, fields: vlfields };
+    return NativeEnumVariantLayout {
+        name: vlname,
+        tag: vltag,
+        offset: vloffset,
+        size: vlsize,
+        align: vlalign,
+        fields: vlfields
+    };
 }
 
 // ── NativeFunction updaters ──────────────────────────────────────────
-
 fn update_function_return_type(fn_val: NativeFunction, ret_type: string) -> NativeFunction {
-    return NativeFunction { name: fn_val.name, is_async: fn_val.is_async, parameters: fn_val.parameters, return_type: ret_type, effects: fn_val.effects, decorators: fn_val.decorators, is_extern: fn_val.is_extern, instructions: fn_val.instructions };
+    return NativeFunction {
+        name: fn_val.name,
+        is_async: fn_val.is_async,
+        parameters: fn_val.parameters,
+        return_type: ret_type,
+        effects: fn_val.effects,
+        decorators: fn_val.decorators,
+        is_extern: fn_val.is_extern,
+        instructions: fn_val.instructions
+    };
 }
 
 fn update_function_effects(fn_val: NativeFunction, effects: string[]) -> NativeFunction {
-    return NativeFunction { name: fn_val.name, is_async: fn_val.is_async, parameters: fn_val.parameters, return_type: fn_val.return_type, effects: effects, decorators: fn_val.decorators, is_extern: fn_val.is_extern, instructions: fn_val.instructions };
+    return NativeFunction {
+        name: fn_val.name,
+        is_async: fn_val.is_async,
+        parameters: fn_val.parameters,
+        return_type: fn_val.return_type,
+        effects: effects,
+        decorators: fn_val.decorators,
+        is_extern: fn_val.is_extern,
+        instructions: fn_val.instructions
+    };
 }
 
 fn update_function_params(fn_val: NativeFunction, params: NativeParameter[]) -> NativeFunction {
-    return NativeFunction { name: fn_val.name, is_async: fn_val.is_async, parameters: params, return_type: fn_val.return_type, effects: fn_val.effects, decorators: fn_val.decorators, is_extern: fn_val.is_extern, instructions: fn_val.instructions };
+    return NativeFunction {
+        name: fn_val.name,
+        is_async: fn_val.is_async,
+        parameters: params,
+        return_type: fn_val.return_type,
+        effects: fn_val.effects,
+        decorators: fn_val.decorators,
+        is_extern: fn_val.is_extern,
+        instructions: fn_val.instructions
+    };
 }
 
 fn update_function_instructions(fn_val: NativeFunction, instrs: NativeInstruction[]) -> NativeFunction {
-    return NativeFunction { name: fn_val.name, is_async: fn_val.is_async, parameters: fn_val.parameters, return_type: fn_val.return_type, effects: fn_val.effects, decorators: fn_val.decorators, is_extern: fn_val.is_extern, instructions: instrs };
+    return NativeFunction {
+        name: fn_val.name,
+        is_async: fn_val.is_async,
+        parameters: fn_val.parameters,
+        return_type: fn_val.return_type,
+        effects: fn_val.effects,
+        decorators: fn_val.decorators,
+        is_extern: fn_val.is_extern,
+        instructions: instrs
+    };
 }
 
 fn append_param_to_function(func: NativeFunction, param: NativeParameter) -> NativeFunction {
@@ -115,7 +227,6 @@ fn append_instruction_to_function(func: NativeFunction, instr: NativeInstruction
 }
 
 // ── NativeInstruction constructors ───────────────────────────────────
-
 // NativeInstruction construction helpers (seed v0.1.1 drops enum variant constructors)
 // Tags: Return=0, Expression=1, If=3, Else=4, EndIf=5, Loop=8, EndLoop=9, Break=10, Continue=11, Unknown=21
 fn make_instruction_text(tag_val: number, text: string) -> NativeInstruction {
@@ -156,7 +267,6 @@ fn make_instruction_for(target: string, iterable: string) -> NativeInstruction {
 }
 
 // ── NativeEnum field accessors ───────────────────────────────────────
-
 fn get_enum_name_at(enums: NativeEnum[], idx: number) -> string {
     let e = enums[idx];
     return e.name;
@@ -166,7 +276,6 @@ fn get_enum_name_at(enums: NativeEnum[], idx: number) -> string {
 // The seed v0.1.1 compiles enum field access as sailfin_runtime_get_field
 // which is a runtime stub returning empty data.  These helpers use
 // explicit array indexing; the fixup pass replaces their bodies.
-
 fn get_instruction_tag(instructions: NativeInstruction[], idx: number) -> number {
     // Enum tag accessor. The seed v0.1.1 can't compile this correctly;
     // _fix_struct_construction_helpers replaces the body for the first-pass
@@ -178,37 +287,45 @@ fn get_instruction_tag(instructions: NativeInstruction[], idx: number) -> number
     // from the array element's memory.
     return sailfin_enum_tag_from_instruction_array(instructions, idx);
 }
+
 fn get_instruction_text(instructions: NativeInstruction[], idx: number) -> string {
     // Seed drops this; fixup pass replaces with payload[0] read
     let instr = instructions[idx];
     return instr.expression;
 }
+
 fn get_instruction_condition(instructions: NativeInstruction[], idx: number) -> string {
     // Seed drops this; fixup pass replaces with payload[0] read
     let instr = instructions[idx];
     return instr.condition;
 }
+
 fn get_instruction_let_name(instructions: NativeInstruction[], idx: number) -> string {
     let instr = instructions[idx];
     return instr.name;
 }
+
 fn get_instruction_let_mutable(instructions: NativeInstruction[], idx: number) -> boolean {
     let instr = instructions[idx];
     return instr.mutable;
 }
+
 fn get_instruction_let_type(instructions: NativeInstruction[], idx: number) -> string {
     let instr = instructions[idx];
     return instr.type_annotation;
 }
+
 fn get_instruction_let_value(instructions: NativeInstruction[], idx: number) -> string? {
     let instr = instructions[idx];
     return instr.value;
 }
+
 fn get_instruction_for_target(instructions: NativeInstruction[], idx: number) -> string {
     // Seed drops this; fixup pass replaces with payload[0] read
     let instr = instructions[idx];
     return instr.target;
 }
+
 fn get_instruction_for_iterable(instructions: NativeInstruction[], idx: number) -> string {
     // Seed drops this; fixup pass replaces with payload[1] read
     let instr = instructions[idx];
@@ -216,68 +333,73 @@ fn get_instruction_for_iterable(instructions: NativeInstruction[], idx: number) 
 }
 
 // ── NativeFunction field accessors ───────────────────────────────────
-
 fn get_function_name_at(functions: NativeFunction[], idx: number) -> string {
     let f = functions[idx];
     return f.name;
 }
+
 fn get_function_return_type_at(functions: NativeFunction[], idx: number) -> string {
     let f = functions[idx];
     return f.return_type;
 }
+
 fn get_function_is_async_at(functions: NativeFunction[], idx: number) -> boolean {
     let f = functions[idx];
     return f.is_async;
 }
+
 fn get_function_is_extern_at(functions: NativeFunction[], idx: number) -> boolean {
     let f = functions[idx];
     return f.is_extern;
 }
+
 fn get_function_parameters_at(functions: NativeFunction[], idx: number) -> NativeParameter[] {
     let f = functions[idx];
     return f.parameters;
 }
+
 fn get_function_instructions_at(functions: NativeFunction[], idx: number) -> NativeInstruction[] {
     let f = functions[idx];
     return f.instructions;
 }
+
 fn get_function_effects_at(functions: NativeFunction[], idx: number) -> string[] {
     let f = functions[idx];
     return f.effects;
 }
+
 fn get_function_decorators_at(functions: NativeFunction[], idx: number) -> string[] {
     let f = functions[idx];
     return f.decorators;
 }
 
 // ── NativeStruct field accessors ─────────────────────────────────────
-
 fn get_struct_name_at(structs: NativeStruct[], idx: number) -> string {
     let s = structs[idx];
     return s.name;
 }
+
 fn get_struct_fields_at(structs: NativeStruct[], idx: number) -> NativeStructField[] {
     let s = structs[idx];
     return s.fields;
 }
+
 fn get_struct_field_name_at(fields: NativeStructField[], idx: number) -> string {
     let f = fields[idx];
     return f.name;
 }
+
 fn get_struct_field_type_at(fields: NativeStructField[], idx: number) -> string {
     let f = fields[idx];
     return f.type_annotation;
 }
 
 // ── Import append helper ─────────────────────────────────────────────
-
 fn append_native_import(arr: NativeImport[], item: NativeImport) -> NativeImport[] {
     let mut result: NativeImport[] = [];
     let mut i: number = 0;
     loop {
-        if i >= arr.length {
-            break;
-        }
+        if i >= arr.length { break; }
         result = result.push(arr[i]);
         i += 1;
     }

--- a/compiler/src/llvm/lowering/lowering_phase_functions.sfn
+++ b/compiler/src/llvm/lowering/lowering_phase_functions.sfn
@@ -6,37 +6,33 @@
 //
 // Extracted from lowering_core.sfn to reduce per-file memory footprint.
 import { NativeModule } from "../../emit_native";
-import {
-    NativeFunction,
-    NativeInstruction,
-    NativeParameter,
-} from "../../native_ir";
-import { append_function_effect_entry, find_function_effect_entry, } from "../effects";
-import { collect_exported_symbol_names, } from "../rendering_helpers";
+import { NativeFunction, NativeInstruction, NativeParameter } from "../../native_ir";
+import { append_function_effect_entry, find_function_effect_entry } from "../effects";
+import { collect_exported_symbol_names } from "../rendering_helpers";
 import {
     empty_string_constant_set,
     merge_string_constants,
-    render_string_constants,
+    render_string_constants
 } from "../strings";
 import {
     FunctionEffectEntry,
     LocalBinding,
     StringConstant,
-    TypeContext,
+    TypeContext
 } from "../types";
 import {
     number_to_string,
     sanitize_symbol,
     starts_with,
-    trim_text,
+    trim_text
 } from "../utils";
-import { emit_llvm_function, } from "./emission";
-import { apply_module_symbol_mangling, } from "./lowering_helpers_mangling";
+import { emit_llvm_function } from "./emission";
+import { apply_module_symbol_mangling } from "./lowering_helpers_mangling";
 import {
     append_string_lines,
     ensure_intrinsic_declarations,
     extend_string_lines,
-    extend_string_lines_checked,
+    extend_string_lines_checked
 } from "./lowering_io";
 import {
     get_function_decorators_at,
@@ -46,9 +42,9 @@ import {
     get_function_is_extern_at,
     get_function_name_at,
     get_function_parameters_at,
-    get_function_return_type_at,
+    get_function_return_type_at
 } from "./lowering_native_helpers";
-import { _parse_lowered_fn_string_constants, split_lines_local, } from "./lowering_text_utils";
+import { _parse_lowered_fn_string_constants, split_lines_local } from "./lowering_text_utils";
 
 // Write function metadata to file-based IPC channels for emit_llvm_function.
 // The v0.1.1 seed compiles emission.sfn with NativeFunction as i8*,
@@ -71,8 +67,10 @@ fn write_function_ipc(local_functions: NativeFunction[], index: number, safe_fun
     let mut param_write_i: number = 0;
     loop {
         if param_write_i >= safe_parameters.length { break; }
-        fs.writeFile("build/sailfin/.fn_param_" + number_to_string(param_write_i) + "_name", safe_parameters[param_write_i].name);
-        fs.writeFile("build/sailfin/.fn_param_" + number_to_string(param_write_i) + "_type", safe_parameters[param_write_i].type_annotation);
+        fs.writeFile("build/sailfin/.fn_param_" + number_to_string(param_write_i)
+            + "_name", safe_parameters[param_write_i].name);
+        fs.writeFile("build/sailfin/.fn_param_" + number_to_string(param_write_i)
+            + "_type", safe_parameters[param_write_i].type_annotation);
         param_write_i += 1;
     }
     let mut dec_write_i: number = 0;
@@ -100,7 +98,9 @@ fn lower_all_functions(local_functions: NativeFunction[], context_functions: Nat
     let mut diagnostics: string[] = [];
 
     if trace {
-        print.err("test llvm: lowering functions start (count=" + number_to_string(local_functions.length) + ")");
+        print.err("test llvm: lowering functions start (count="
+            + number_to_string(local_functions.length)
+            + ")");
     }
     if debug_lowering { print.err("emit-llvm: phase=functions"); }
     loop {
@@ -129,7 +129,7 @@ fn lower_all_functions(local_functions: NativeFunction[], context_functions: Nat
             effects: safe_effects,
             decorators: safe_decorators,
             instructions: safe_instructions,
-            is_extern: fn_is_extern,
+            is_extern: fn_is_extern
         };
         if trace {
             let mut return_count: number = 0;
@@ -141,7 +141,14 @@ fn lower_all_functions(local_functions: NativeFunction[], context_functions: Nat
                 }
                 instr_index += 1;
             }
-            print.err("test llvm: function " + number_to_string(index) + "/" + number_to_string(local_functions.length) + " " + safe_function_name + " instrs=" + number_to_string(safe_instructions.length) + " returns=" + number_to_string(return_count));
+            print.err("test llvm: function " + number_to_string(index) + "/"
+                + number_to_string(local_functions.length)
+                + " "
+                + safe_function_name
+                + " instrs="
+                + number_to_string(safe_instructions.length)
+                + " returns="
+                + number_to_string(return_count));
         }
         let aggregated_entry = find_function_effect_entry(aggregated_effects, safe_function_name);
         let mut effective_effects: string[] = [];
@@ -149,10 +156,12 @@ fn lower_all_functions(local_functions: NativeFunction[], context_functions: Nat
             effective_effects = aggregated_entry.effects;
         }
         function_effects = append_function_effect_entry(function_effects, FunctionEffectEntry {
-            name: safe_function_name, effects: effective_effects,
+            name: safe_function_name, effects: effective_effects
         });
         if debug_lowering {
-            print.err("emit-llvm: function-start " + safe_function_name + " idx=" + number_to_string(index));
+            print.err("emit-llvm: function-start " + safe_function_name
+                + " idx="
+                + number_to_string(index));
         }
         // Write function metadata to file-based IPC
         write_function_ipc(local_functions, index, safe_function_name, safe_return_type, safe_parameters, safe_instructions, safe_decorators, fn_is_async, fn_is_extern);
@@ -161,10 +170,16 @@ fn lower_all_functions(local_functions: NativeFunction[], context_functions: Nat
         let _lfn_diags = lowered.diagnostics;
         let _lfn_string_constants = lowered.string_constants;
         if debug_lowering {
-            print.err("emit-llvm: function-done " + safe_function_name + " lines=" + number_to_string(_lfn_lines.length));
+            print.err("emit-llvm: function-done " + safe_function_name
+                + " lines="
+                + number_to_string(_lfn_lines.length));
         }
         if trace {
-            print.err("test llvm: function lowered " + safe_function_name + " lines=" + number_to_string(_lfn_lines.length) + " diagnostics=" + number_to_string(_lfn_diags.length));
+            print.err("test llvm: function lowered " + safe_function_name
+                + " lines="
+                + number_to_string(_lfn_lines.length)
+                + " diagnostics="
+                + number_to_string(_lfn_diags.length));
             if _lfn_lines.length > 0 {
                 print.err("test llvm: function first line " + _lfn_lines[0]);
                 print.err("test llvm: function last line " + _lfn_lines[_lfn_lines.length - 1]);
@@ -185,32 +200,40 @@ fn lower_all_functions(local_functions: NativeFunction[], context_functions: Nat
         if safe_function_name == "add" { has_add_function = true; }
         diagnostics = extend_string_lines_checked(diagnostics, _lfn_diags, "function lowering");
         if trace {
-            print.err("test llvm: function diagnostics merged " + safe_function_name);
+            print.err("test llvm: function diagnostics merged "
+                + safe_function_name);
         }
         let normalized_lowered_lines = _lfn_lines;
         if normalized_lowered_lines != null {
             if normalized_lowered_lines.length > 0 {
                 lines = append_string_lines(lines, normalized_lowered_lines);
                 if trace {
-                    print.err("test llvm: function lines merged " + safe_function_name);
-                    print.err("test llvm: function post-merge check " + safe_function_name);
+                    print.err("test llvm: function lines merged "
+                        + safe_function_name);
+                    print.err("test llvm: function post-merge check "
+                        + safe_function_name);
                 }
                 let _ep_next = index + 1;
                 if _ep_next < local_functions.length { lines.push(""); }
                 if trace {
-                    print.err("test llvm: function post-merge blank " + safe_function_name);
+                    print.err("test llvm: function post-merge blank "
+                        + safe_function_name);
                 }
             }
         }
         if _lfn_string_constants != null {
             if _lfn_string_constants.length > 0 {
                 if trace {
-                    print.err("test llvm: merging string constants " + safe_function_name + " count=" + number_to_string(_lfn_string_constants.length));
+                    print.err("test llvm: merging string constants "
+                        + safe_function_name
+                        + " count="
+                        + number_to_string(_lfn_string_constants.length));
                 }
                 let existing_constants = all_string_constants;
                 all_string_constants = merge_string_constants(existing_constants, _lfn_string_constants);
                 if trace {
-                    print.err("test llvm: merged string constants " + safe_function_name);
+                    print.err("test llvm: merged string constants "
+                        + safe_function_name);
                 }
             }
         }

--- a/compiler/src/llvm/lowering/lowering_phase_functions.sfn
+++ b/compiler/src/llvm/lowering/lowering_phase_functions.sfn
@@ -5,96 +5,59 @@
 // calls emit_llvm_function, and merges results into the output lines.
 //
 // Extracted from lowering_core.sfn to reduce per-file memory footprint.
-
 import { NativeModule } from "../../emit_native";
 import {
     NativeFunction,
-    NativeParameter,
     NativeInstruction,
+    NativeParameter,
 } from "../../native_ir";
-
+import { append_function_effect_entry, find_function_effect_entry, } from "../effects";
+import { collect_exported_symbol_names, } from "../rendering_helpers";
 import {
-    TypeContext,
+    empty_string_constant_set,
+    merge_string_constants,
+    render_string_constants,
+} from "../strings";
+import {
     FunctionEffectEntry,
-    StringConstant,
     LocalBinding,
+    StringConstant,
+    TypeContext,
 } from "../types";
-
 import {
     number_to_string,
     sanitize_symbol,
     starts_with,
     trim_text,
 } from "../utils";
-
+import { emit_llvm_function, } from "./emission";
+import { apply_module_symbol_mangling, } from "./lowering_helpers_mangling";
 import {
-    empty_string_constant_set,
-    merge_string_constants,
-    render_string_constants,
-} from "../strings";
-
-import {
-    find_function_effect_entry,
-    append_function_effect_entry,
-} from "../effects";
-
-import {
-    collect_exported_symbol_names,
-} from "../rendering_helpers";
-
-import {
-    emit_llvm_function,
-} from "./emission";
-
-import {
-    extend_string_lines,
-    extend_string_lines_checked,
     append_string_lines,
     ensure_intrinsic_declarations,
+    extend_string_lines,
+    extend_string_lines_checked,
 } from "./lowering_io";
-
 import {
-    get_function_name_at,
-    get_function_return_type_at,
+    get_function_decorators_at,
+    get_function_effects_at,
+    get_function_instructions_at,
     get_function_is_async_at,
     get_function_is_extern_at,
+    get_function_name_at,
     get_function_parameters_at,
-    get_function_instructions_at,
-    get_function_effects_at,
-    get_function_decorators_at,
+    get_function_return_type_at,
 } from "./lowering_native_helpers";
-
-import {
-    split_lines_local,
-    _parse_lowered_fn_string_constants,
-} from "./lowering_text_utils";
-
-import {
-    apply_module_symbol_mangling,
-} from "./lowering_helpers_mangling";
+import { _parse_lowered_fn_string_constants, split_lines_local, } from "./lowering_text_utils";
 
 // Write function metadata to file-based IPC channels for emit_llvm_function.
 // The v0.1.1 seed compiles emission.sfn with NativeFunction as i8*,
 // making direct field access return garbage.
-fn write_function_ipc(
-    local_functions: NativeFunction[],
-    index: number,
-    safe_function_name: string,
-    safe_return_type: string,
-    safe_parameters: NativeParameter[],
-    safe_instructions: NativeInstruction[],
-    safe_decorators: string[],
-    fn_is_async: boolean,
-    fn_is_extern: boolean
-) -> boolean ![io] {
+fn write_function_ipc(local_functions: NativeFunction[], index: number, safe_function_name: string, safe_return_type: string, safe_parameters: NativeParameter[], safe_instructions: NativeInstruction[], safe_decorators: string[], fn_is_async: boolean, fn_is_extern: boolean) -> boolean ![io] {
     let mut is_async_flag = "0";
-    if fn_is_async {
-        is_async_flag = "1";
-    }
+    if fn_is_async { is_async_flag = "1"; }
     let mut is_extern_flag = "0";
-    if fn_is_extern {
-        is_extern_flag = "1";
-    }
+    if fn_is_extern { is_extern_flag = "1"; }
     fs.writeFile("build/sailfin/.fn_name", safe_function_name);
     fs.writeFile("build/sailfin/.fn_return_type", safe_return_type);
     fs.writeFile("build/sailfin/.fn_is_async", is_async_flag);
@@ -107,18 +70,14 @@ fn write_function_ipc(
     fs.writeFile("build/sailfin/.fn_decorator_count", number_to_string(safe_decorators.length));
     let mut param_write_i: number = 0;
     loop {
-        if param_write_i >= safe_parameters.length {
-            break;
-        }
+        if param_write_i >= safe_parameters.length { break; }
         fs.writeFile("build/sailfin/.fn_param_" + number_to_string(param_write_i) + "_name", safe_parameters[param_write_i].name);
         fs.writeFile("build/sailfin/.fn_param_" + number_to_string(param_write_i) + "_type", safe_parameters[param_write_i].type_annotation);
         param_write_i += 1;
     }
     let mut dec_write_i: number = 0;
     loop {
-        if dec_write_i >= safe_decorators.length {
-            break;
-        }
+        if dec_write_i >= safe_decorators.length { break; }
         fs.writeFile("build/sailfin/.fn_decorator_" + number_to_string(dec_write_i), safe_decorators[dec_write_i]);
         dec_write_i += 1;
     }
@@ -132,22 +91,7 @@ fn write_function_ipc(
 //   .phase_functions_has_add     — "1" if an @add function was found
 //
 // Returns the total number of LLVM IR lines produced.
-fn lower_all_functions(
-    local_functions: NativeFunction[],
-    context_functions: NativeFunction[],
-    aggregated_effects: FunctionEffectEntry[],
-    type_context: TypeContext,
-    module_name: string,
-    safe_entry_points: string[],
-    exported_symbols: string[],
-    imported_functions: NativeFunction[],
-    module_global_locals: LocalBinding[],
-    module_init_symbol: string,
-    module_globals_needs_init_call: boolean,
-    module_string_constants: StringConstant[],
-    trace: boolean,
-    debug_lowering: boolean
-) -> string[] ![io] {
+fn lower_all_functions(local_functions: NativeFunction[], context_functions: NativeFunction[], aggregated_effects: FunctionEffectEntry[], type_context: TypeContext, module_name: string, safe_entry_points: string[], exported_symbols: string[], imported_functions: NativeFunction[], module_global_locals: LocalBinding[], module_init_symbol: string, module_globals_needs_init_call: boolean, module_string_constants: StringConstant[], trace: boolean, debug_lowering: boolean) -> string[] ![io] {
     let mut lines: string[] = [];
     let mut index: number = 0;
     let mut has_add_function: boolean = false;
@@ -158,38 +102,22 @@ fn lower_all_functions(
     if trace {
         print.err("test llvm: lowering functions start (count=" + number_to_string(local_functions.length) + ")");
     }
-    if debug_lowering {
-        print.err("emit-llvm: phase=functions");
-    }
+    if debug_lowering { print.err("emit-llvm: phase=functions"); }
     loop {
-        if index >= local_functions.length {
-            break;
-        }
+        if index >= local_functions.length { break; }
         let current_function = local_functions[index];
         let mut safe_function_name = get_function_name_at(local_functions, index);
-        if safe_function_name == null {
-            safe_function_name = "";
-        }
+        if safe_function_name == null { safe_function_name = ""; }
         let mut safe_parameters = get_function_parameters_at(local_functions, index);
-        if safe_parameters == null {
-            safe_parameters = [];
-        }
+        if safe_parameters == null { safe_parameters = []; }
         let mut safe_effects = get_function_effects_at(local_functions, index);
-        if safe_effects == null {
-            safe_effects = [];
-        }
+        if safe_effects == null { safe_effects = []; }
         let mut safe_decorators = get_function_decorators_at(local_functions, index);
-        if safe_decorators == null {
-            safe_decorators = [];
-        }
+        if safe_decorators == null { safe_decorators = []; }
         let mut safe_instructions = get_function_instructions_at(local_functions, index);
-        if safe_instructions == null {
-            safe_instructions = [];
-        }
+        if safe_instructions == null { safe_instructions = []; }
         let mut safe_return_type = get_function_return_type_at(local_functions, index);
-        if safe_return_type == null {
-            safe_return_type = "";
-        }
+        if safe_return_type == null { safe_return_type = ""; }
         let fn_is_async = get_function_is_async_at(local_functions, index);
         let fn_is_extern = get_function_is_extern_at(local_functions, index);
 
@@ -207,62 +135,28 @@ fn lower_all_functions(
             let mut return_count: number = 0;
             let mut instr_index: number = 0;
             loop {
-                if instr_index >= safe_instructions.length {
-                    break;
-                }
+                if instr_index >= safe_instructions.length { break; }
                 if safe_instructions[instr_index].variant == "Return" {
                     return_count += 1;
                 }
                 instr_index += 1;
             }
-            print.err(
-                "test llvm: function "
-                + number_to_string(index)
-                + "/"
-                + number_to_string(local_functions.length)
-                + " "
-                + safe_function_name
-                + " instrs="
-                + number_to_string(safe_instructions.length)
-                + " returns="
-                + number_to_string(return_count)
-            );
+            print.err("test llvm: function " + number_to_string(index) + "/" + number_to_string(local_functions.length) + " " + safe_function_name + " instrs=" + number_to_string(safe_instructions.length) + " returns=" + number_to_string(return_count));
         }
         let aggregated_entry = find_function_effect_entry(aggregated_effects, safe_function_name);
         let mut effective_effects: string[] = [];
         if aggregated_entry != null {
             effective_effects = aggregated_entry.effects;
         }
-        function_effects = append_function_effect_entry(
-            function_effects,
-            FunctionEffectEntry {
-                name: safe_function_name,
-                effects: effective_effects,
-            }
-        );
+        function_effects = append_function_effect_entry(function_effects, FunctionEffectEntry {
+            name: safe_function_name, effects: effective_effects,
+        });
         if debug_lowering {
             print.err("emit-llvm: function-start " + safe_function_name + " idx=" + number_to_string(index));
         }
         // Write function metadata to file-based IPC
-        write_function_ipc(
-            local_functions, index,
-            safe_function_name, safe_return_type,
-            safe_parameters, safe_instructions,
-            safe_decorators, fn_is_async, fn_is_extern
-        );
-        let lowered = emit_llvm_function(
-            safe_function_name,
-            context_functions,
-            effective_effects,
-            type_context,
-            module_name,
-            safe_entry_points,
-            exported_symbols,
-            imported_functions,
-            module_global_locals,
-            module_init_symbol,
-            module_globals_needs_init_call
-        );
+        write_function_ipc(local_functions, index, safe_function_name, safe_return_type, safe_parameters, safe_instructions, safe_decorators, fn_is_async, fn_is_extern);
+        let lowered = emit_llvm_function(safe_function_name, context_functions, effective_effects, type_context, module_name, safe_entry_points, exported_symbols, imported_functions, module_global_locals, module_init_symbol, module_globals_needs_init_call);
         let _lfn_lines = lowered.lines;
         let _lfn_diags = lowered.diagnostics;
         let _lfn_string_constants = lowered.string_constants;
@@ -277,24 +171,18 @@ fn lower_all_functions(
                 let mut ret_lines: number = 0;
                 let mut scan_index: number = 0;
                 loop {
-                    if scan_index >= _lfn_lines.length {
-                        break;
-                    }
+                    if scan_index >= _lfn_lines.length { break; }
                     let line = _lfn_lines[scan_index];
                     let mut _if256: boolean = false;
                     if starts_with(trim_text(line), "ret ") { _if256 = true; }
                     if trim_text(line) == "ret void" { _if256 = true; }
-                    if _if256 {
-                        ret_lines += 1;
-                    }
+                    if _if256 { ret_lines += 1; }
                     scan_index += 1;
                 }
                 print.err("test llvm: function ret_lines " + number_to_string(ret_lines));
             }
         }
-        if safe_function_name == "add" {
-            has_add_function = true;
-        }
+        if safe_function_name == "add" { has_add_function = true; }
         diagnostics = extend_string_lines_checked(diagnostics, _lfn_diags, "function lowering");
         if trace {
             print.err("test llvm: function diagnostics merged " + safe_function_name);
@@ -308,9 +196,7 @@ fn lower_all_functions(
                     print.err("test llvm: function post-merge check " + safe_function_name);
                 }
                 let _ep_next = index + 1;
-                if _ep_next < local_functions.length {
-                    lines.push("");
-                }
+                if _ep_next < local_functions.length { lines.push(""); }
                 if trace {
                     print.err("test llvm: function post-merge blank " + safe_function_name);
                 }
@@ -330,23 +216,13 @@ fn lower_all_functions(
         }
         index += 1;
     }
-    if trace {
-        print.err("test llvm: lowering functions done");
-    }
-    if debug_lowering {
-        print.err("emit-llvm: phase=functions_done");
-    }
+    if trace { print.err("test llvm: lowering functions done"); }
+    if debug_lowering { print.err("emit-llvm: phase=functions_done"); }
 
     // Append the add helper if not defined
     if !has_add_function {
         lines.push("");
-        lines = extend_string_lines(lines, [
-                "define internal double @add(double %a, double %b) {",
-                "entry:",
-                "  %t0 = fadd double %a, %b",
-                "  ret double %t0",
-                "}",
-        ]);
+        lines = extend_string_lines(lines, ["define internal double @add(double %a, double %b) {", "entry:", "  %t0 = fadd double %a, %b", "  ret double %t0", "}",]);
     }
 
     // String constants
@@ -358,21 +234,13 @@ fn lower_all_functions(
             lines.push("");
         }
     }
-    if trace {
-        print.err("test llvm: string constants emitted");
-    }
-    if debug_lowering {
-        print.err("emit-llvm: phase=string_constants");
-    }
+    if trace { print.err("test llvm: string constants emitted"); }
+    if debug_lowering { print.err("emit-llvm: phase=string_constants"); }
 
     // Intrinsics
     lines = ensure_intrinsic_declarations(lines);
-    if trace {
-        print.err("test llvm: intrinsics ensured");
-    }
-    if debug_lowering {
-        print.err("emit-llvm: phase=intrinsics");
-    }
+    if trace { print.err("test llvm: intrinsics ensured"); }
+    if debug_lowering { print.err("emit-llvm: phase=intrinsics"); }
 
     // Write diagnostics to file for lowering_core.sfn to read
     fs.writeLines("build/sailfin/.phase_functions_diagnostics", diagnostics);

--- a/compiler/src/llvm/lowering/lowering_phase_imports.sfn
+++ b/compiler/src/llvm/lowering/lowering_phase_imports.sfn
@@ -6,16 +6,12 @@
 // The main import gathering loop lives in lowering_core.sfn (orchestrator)
 // to avoid duplicate parsing.  This module provides thin wrappers used
 // by the orchestrator for individual parse operations.
-import {
-    NativeFunction,
-    NativeInterface,
-    NativeStruct,
-} from "../../native_ir";
+import { NativeFunction, NativeInterface, NativeStruct } from "../../native_ir";
 import {
     parse_native_functions_for_import,
-    parse_native_interfaces_for_import,
+    parse_native_interfaces_for_import
 } from "../../native_ir_api";
-import { flatten_struct_methods, } from "./lowering_helpers_mangling";
+import { flatten_struct_methods } from "./lowering_helpers_mangling";
 
 // Parse imported interfaces from a single import text.
 fn parse_single_import_interfaces(native_text: string) -> NativeInterface[] {

--- a/compiler/src/llvm/lowering/lowering_phase_imports.sfn
+++ b/compiler/src/llvm/lowering/lowering_phase_imports.sfn
@@ -6,20 +6,16 @@
 // The main import gathering loop lives in lowering_core.sfn (orchestrator)
 // to avoid duplicate parsing.  This module provides thin wrappers used
 // by the orchestrator for individual parse operations.
-
 import {
     NativeFunction,
-    NativeStruct,
     NativeInterface,
+    NativeStruct,
 } from "../../native_ir";
 import {
-    parse_native_interfaces_for_import,
     parse_native_functions_for_import,
+    parse_native_interfaces_for_import,
 } from "../../native_ir_api";
-
-import {
-    flatten_struct_methods,
-} from "./lowering_helpers_mangling";
+import { flatten_struct_methods, } from "./lowering_helpers_mangling";
 
 // Parse imported interfaces from a single import text.
 fn parse_single_import_interfaces(native_text: string) -> NativeInterface[] {

--- a/compiler/src/llvm/lowering/lowering_phase_render.sfn
+++ b/compiler/src/llvm/lowering/lowering_phase_render.sfn
@@ -6,29 +6,25 @@
 // and libc declarations.
 //
 // Extracted from lowering_core.sfn to reduce per-file memory footprint.
-import { NativeFunction, NativeStruct, } from "../../native_ir";
+import { NativeFunction, NativeStruct } from "../../native_ir";
 import { substring } from "../../string_utils";
 import {
     render_enum_type_definitions,
     render_imported_function_declarations,
     render_runtime_helper_declarations,
     render_struct_type_definitions,
-    render_trait_metadata_comments,
+    render_trait_metadata_comments
 } from "../rendering";
 import {
     find_function_by_name,
     render_interface_type_definitions,
     render_vtable_constants,
-    render_vtable_type_definitions,
+    render_vtable_type_definitions
 } from "../rendering_helpers";
-import { TraitMetadata, TypeContext, } from "../types";
-import {
-    index_of,
-    number_to_string,
-    starts_with,
-} from "../utils";
-import { extend_string_lines, module_source_filename, } from "./lowering_io";
-import { split_lines_local, } from "./lowering_text_utils";
+import { TraitMetadata, TypeContext } from "../types";
+import { index_of, number_to_string, starts_with } from "../utils";
+import { extend_string_lines, module_source_filename } from "./lowering_io";
+import { split_lines_local } from "./lowering_text_utils";
 
 // Render the LLVM IR preamble: source filename, trait metadata,
 // struct/enum/interface type definitions, async runtime types,
@@ -38,7 +34,8 @@ import { split_lines_local, } from "./lowering_text_utils";
 // Returns the preamble as a string[] of LLVM IR lines.
 fn render_llvm_preamble(module_name: string, type_context: TypeContext, trait_metadata: TraitMetadata, context_functions: NativeFunction[], local_functions: NativeFunction[], imported_functions: NativeFunction[], runtime_helpers: string[], debug_lowering: boolean) -> string[] ![io] {
     let mut lines: string[] = [];
-    lines.push("source_filename = \"" + module_source_filename(module_name) + "\"");
+    lines.push("source_filename = \"" + module_source_filename(module_name)
+        + "\"");
     lines.push("");
 
     // Trait metadata comments
@@ -52,7 +49,11 @@ fn render_llvm_preamble(module_name: string, type_context: TypeContext, trait_me
     // Struct type definitions
     if debug_lowering {
         print.err("emit-llvm: phase=render_structs");
-        print.err("emit-llvm: render_structs counts structs=" + number_to_string(type_context.structs.length) + " enums=" + number_to_string(type_context.enums.length) + " functions=" + number_to_string(context_functions.length));
+        print.err("emit-llvm: render_structs counts structs=" + number_to_string(type_context.structs.length)
+            + " enums="
+            + number_to_string(type_context.enums.length)
+            + " functions="
+            + number_to_string(context_functions.length));
     }
     let struct_type_lines = render_struct_type_definitions(type_context, context_functions);
     // Filter out corrupted struct type lines (empty name: "% = type ...").

--- a/compiler/src/llvm/lowering/lowering_phase_render.sfn
+++ b/compiler/src/llvm/lowering/lowering_phase_render.sfn
@@ -6,42 +6,29 @@
 // and libc declarations.
 //
 // Extracted from lowering_core.sfn to reduce per-file memory footprint.
-
-import {
-    NativeFunction,
-    NativeStruct,
-} from "../../native_ir";
+import { NativeFunction, NativeStruct, } from "../../native_ir";
 import { substring } from "../../string_utils";
-
 import {
-    TypeContext,
-    TraitMetadata,
-} from "../types";
-
-import {
-    number_to_string,
-    index_of,
-    starts_with,
-} from "../utils";
-
-import {
-    render_struct_type_definitions, render_enum_type_definitions,
-    render_trait_metadata_comments, render_runtime_helper_declarations,
+    render_enum_type_definitions,
     render_imported_function_declarations,
+    render_runtime_helper_declarations,
+    render_struct_type_definitions,
+    render_trait_metadata_comments,
 } from "../rendering";
 import {
-    render_interface_type_definitions, render_vtable_type_definitions,
-    render_vtable_constants, find_function_by_name,
+    find_function_by_name,
+    render_interface_type_definitions,
+    render_vtable_constants,
+    render_vtable_type_definitions,
 } from "../rendering_helpers";
-
+import { TraitMetadata, TypeContext, } from "../types";
 import {
-    extend_string_lines,
-    module_source_filename,
-} from "./lowering_io";
-
-import {
-    split_lines_local,
-} from "./lowering_text_utils";
+    index_of,
+    number_to_string,
+    starts_with,
+} from "../utils";
+import { extend_string_lines, module_source_filename, } from "./lowering_io";
+import { split_lines_local, } from "./lowering_text_utils";
 
 // Render the LLVM IR preamble: source filename, trait metadata,
 // struct/enum/interface type definitions, async runtime types,
@@ -49,24 +36,13 @@ import {
 // function declarations, and libc declarations.
 //
 // Returns the preamble as a string[] of LLVM IR lines.
-fn render_llvm_preamble(
-    module_name: string,
-    type_context: TypeContext,
-    trait_metadata: TraitMetadata,
-    context_functions: NativeFunction[],
-    local_functions: NativeFunction[],
-    imported_functions: NativeFunction[],
-    runtime_helpers: string[],
-    debug_lowering: boolean
-) -> string[] ![io] {
+fn render_llvm_preamble(module_name: string, type_context: TypeContext, trait_metadata: TraitMetadata, context_functions: NativeFunction[], local_functions: NativeFunction[], imported_functions: NativeFunction[], runtime_helpers: string[], debug_lowering: boolean) -> string[] ![io] {
     let mut lines: string[] = [];
     lines.push("source_filename = \"" + module_source_filename(module_name) + "\"");
     lines.push("");
 
     // Trait metadata comments
-    if debug_lowering {
-        print.err("emit-llvm: phase=render_traits");
-    }
+    if debug_lowering { print.err("emit-llvm: phase=render_traits"); }
     let trait_lines = render_trait_metadata_comments(trait_metadata);
     if trait_lines.length > 0 {
         lines = extend_string_lines(lines, trait_lines);
@@ -76,14 +52,7 @@ fn render_llvm_preamble(
     // Struct type definitions
     if debug_lowering {
         print.err("emit-llvm: phase=render_structs");
-        print.err(
-            "emit-llvm: render_structs counts structs="
-            + number_to_string(type_context.structs.length)
-            + " enums="
-            + number_to_string(type_context.enums.length)
-            + " functions="
-            + number_to_string(context_functions.length)
-        );
+        print.err("emit-llvm: render_structs counts structs=" + number_to_string(type_context.structs.length) + " enums=" + number_to_string(type_context.enums.length) + " functions=" + number_to_string(context_functions.length));
     }
     let struct_type_lines = render_struct_type_definitions(type_context, context_functions);
     // Filter out corrupted struct type lines (empty name: "% = type ...").
@@ -114,9 +83,7 @@ fn render_llvm_preamble(
     }
 
     // Enum type definitions
-    if debug_lowering {
-        print.err("emit-llvm: phase=render_enums");
-    }
+    if debug_lowering { print.err("emit-llvm: phase=render_enums"); }
     let enum_type_lines = render_enum_type_definitions(type_context);
     if enum_type_lines.length > 0 {
         lines = extend_string_lines(lines, enum_type_lines);
@@ -124,9 +91,7 @@ fn render_llvm_preamble(
     }
 
     // Interface type definitions
-    if debug_lowering {
-        print.err("emit-llvm: phase=render_interfaces");
-    }
+    if debug_lowering { print.err("emit-llvm: phase=render_interfaces"); }
     let interface_type_lines = render_interface_type_definitions(type_context);
     if interface_type_lines.length > 0 {
         lines = extend_string_lines(lines, interface_type_lines);
@@ -134,33 +99,7 @@ fn render_llvm_preamble(
     }
 
     // Async/future runtime types
-    lines = extend_string_lines(lines, [
-        "%SailfinFutureNumber = type opaque",
-        "%SailfinFutureBool = type opaque",
-        "%SailfinFuturePtr = type opaque",
-        "%SailfinFutureVoid = type opaque",
-        "%SailfinFutureString = type opaque",
-        "",
-        "declare %SailfinFutureNumber* @sailfin_runtime_spawn_number(double ()*)",
-        "declare %SailfinFutureNumber* @sailfin_runtime_spawn_number_ctx(double (i8*)*, i8*)",
-        "declare double @sailfin_runtime_await_number(%SailfinFutureNumber*)",
-        "declare %SailfinFutureBool* @sailfin_runtime_spawn_bool(i1 ()*)",
-        "declare %SailfinFutureBool* @sailfin_runtime_spawn_bool_ctx(i1 (i8*)*, i8*)",
-        "declare i1 @sailfin_runtime_await_bool(%SailfinFutureBool*)",
-        "declare %SailfinFuturePtr* @sailfin_runtime_spawn_ptr(i8* ()*)",
-        "declare %SailfinFuturePtr* @sailfin_runtime_spawn_ptr_ctx(i8* (i8*)*, i8*)",
-        "declare i8* @sailfin_runtime_await_ptr(%SailfinFuturePtr*)",
-        "declare %SailfinFutureVoid* @sailfin_runtime_spawn_void(void ()*)",
-        "declare %SailfinFutureVoid* @sailfin_runtime_spawn_void_ctx(void (i8*)*, i8*)",
-        "declare void @sailfin_runtime_await_void(%SailfinFutureVoid*)",
-        "declare %SailfinFutureString* @sailfin_runtime_spawn_string(i8* ()*)",
-        "declare %SailfinFutureString* @sailfin_runtime_spawn_string_ctx(i8* (i8*)*, i8*)",
-        "declare i8* @sailfin_runtime_await_string(%SailfinFutureString*)",
-        "",
-        "; Enum tag reader for seedcheck - reads i32 tag from NativeInstruction array",
-        "declare double @sailfin_enum_tag_from_instruction_array(i8*, double)",
-        "",
-    ]);
+    lines = extend_string_lines(lines, ["%SailfinFutureNumber = type opaque", "%SailfinFutureBool = type opaque", "%SailfinFuturePtr = type opaque", "%SailfinFutureVoid = type opaque", "%SailfinFutureString = type opaque", "", "declare %SailfinFutureNumber* @sailfin_runtime_spawn_number(double ()*)", "declare %SailfinFutureNumber* @sailfin_runtime_spawn_number_ctx(double (i8*)*, i8*)", "declare double @sailfin_runtime_await_number(%SailfinFutureNumber*)", "declare %SailfinFutureBool* @sailfin_runtime_spawn_bool(i1 ()*)", "declare %SailfinFutureBool* @sailfin_runtime_spawn_bool_ctx(i1 (i8*)*, i8*)", "declare i1 @sailfin_runtime_await_bool(%SailfinFutureBool*)", "declare %SailfinFuturePtr* @sailfin_runtime_spawn_ptr(i8* ()*)", "declare %SailfinFuturePtr* @sailfin_runtime_spawn_ptr_ctx(i8* (i8*)*, i8*)", "declare i8* @sailfin_runtime_await_ptr(%SailfinFuturePtr*)", "declare %SailfinFutureVoid* @sailfin_runtime_spawn_void(void ()*)", "declare %SailfinFutureVoid* @sailfin_runtime_spawn_void_ctx(void (i8*)*, i8*)", "declare void @sailfin_runtime_await_void(%SailfinFutureVoid*)", "declare %SailfinFutureString* @sailfin_runtime_spawn_string(i8* ()*)", "declare %SailfinFutureString* @sailfin_runtime_spawn_string_ctx(i8* (i8*)*, i8*)", "declare i8* @sailfin_runtime_await_string(%SailfinFutureString*)", "", "; Enum tag reader for seedcheck - reads i32 tag from NativeInstruction array", "declare double @sailfin_enum_tag_from_instruction_array(i8*, double)", "",]);
 
     // Vtable type definitions
     let vtable_type_lines = render_vtable_type_definitions(type_context);
@@ -181,9 +120,7 @@ fn render_llvm_preamble(
     }
 
     // Runtime helper declarations
-    if debug_lowering {
-        print.err("emit-llvm: phase=render_helpers");
-    }
+    if debug_lowering { print.err("emit-llvm: phase=render_helpers"); }
     let helper_declarations = render_runtime_helper_declarations(runtime_helpers, local_functions);
     if helper_declarations != null {
         if helper_declarations.length > 0 {
@@ -193,9 +130,7 @@ fn render_llvm_preamble(
     }
 
     // Imported function declarations
-    if debug_lowering {
-        print.err("emit-llvm: phase=render_imports");
-    }
+    if debug_lowering { print.err("emit-llvm: phase=render_imports"); }
     let imported_declarations = render_imported_function_declarations(imported_functions, local_functions, type_context);
     if imported_declarations != null {
         if imported_declarations.length > 0 {
@@ -227,13 +162,9 @@ fn render_llvm_preamble(
 // Used when render_struct_type_definitions produced corrupted output.
 fn recover_struct_types_from_file() -> string[] ![io] {
     let mut result: string[] = [];
-    if !fs.exists("build/sailfin/.struct_info") {
-        return result;
-    }
+    if !fs.exists("build/sailfin/.struct_info") { return result; }
     let raw = fs.readFile("build/sailfin/.struct_info");
-    if raw.length == 0 {
-        return result;
-    }
+    if raw.length == 0 { return result; }
     let mut pos: number = 0;
     loop {
         if pos >= raw.length { break; }

--- a/compiler/src/llvm/lowering/lowering_phase_sanitize.sfn
+++ b/compiler/src/llvm/lowering/lowering_phase_sanitize.sfn
@@ -14,20 +14,20 @@ import {
     NativeImport,
     NativeInterface,
     NativeStruct,
-    ParseNativeResult,
+    ParseNativeResult
 } from "../../native_ir";
-import { parse_native_bindings_from_text, parse_native_functions_from_text, } from "../../native_ir_api";
-import { number_to_string, } from "../utils";
-import { is_test_module_slug, sanitize_collection_length, } from "./lowering_helpers";
-import { extend_string_lines_checked, } from "./lowering_io";
-import { get_struct_fields_at, get_struct_name_at, } from "./lowering_native_helpers";
+import { parse_native_bindings_from_text, parse_native_functions_from_text } from "../../native_ir_api";
+import { number_to_string } from "../utils";
+import { is_test_module_slug, sanitize_collection_length } from "./lowering_helpers";
+import { extend_string_lines_checked } from "./lowering_io";
+import { get_struct_fields_at, get_struct_name_at } from "./lowering_native_helpers";
 import {
     parse_native_artifact_safe,
     recover_functions_for_lowering,
     recover_native_enums_light,
     recover_native_functions_light,
     recover_native_imports_light,
-    recover_native_structs_light,
+    recover_native_structs_light
 } from "./lowering_recovery";
 
 // Note: build_parse_result_from_text lives in lowering_core.sfn.
@@ -52,7 +52,8 @@ fn sanitize_lowering_inputs(parse_in: ParseNativeResult, native_text_override_pa
     let mut parse = parse_in;
     if debug_lowering { print.err("emit-llvm: dbg-A parse_in assigned"); }
     if debug_lowering {
-        print.err("emit-llvm: dbg-B before override check path_len=" + number_to_string(native_text_override_path.length));
+        print.err("emit-llvm: dbg-B before override check path_len="
+            + number_to_string(native_text_override_path.length));
     }
     // --- Reparse from override text ---
     if native_text_override_path.length > 0 {
@@ -66,14 +67,16 @@ fn sanitize_lowering_inputs(parse_in: ParseNativeResult, native_text_override_pa
             interfaces: [],
             enums: _rens,
             bindings: [],
-            diagnostics: [],
+            diagnostics: []
         };
         if reparsed.functions.length >= parse.functions.length {
             parse = reparsed;
         }
         if debug_lowering {
-            print.err("emit-llvm: reparsed from override text functions=" + number_to_string(parse.functions.length));
-            print.err("emit-llvm: reparsed from override diagnostics=" + number_to_string(parse.diagnostics.length));
+            print.err("emit-llvm: reparsed from override text functions="
+                + number_to_string(parse.functions.length));
+            print.err("emit-llvm: reparsed from override diagnostics="
+                + number_to_string(parse.diagnostics.length));
             if parse.diagnostics.length > 0 {
                 print.err("emit-llvm: reparsed diagnostic " + parse.diagnostics[0]);
             }
@@ -158,7 +161,9 @@ fn sanitize_structs(structs: NativeStruct[], diagnostics: string[]) -> NativeStr
         safe = [];
     }
     if safe.length > 100000 {
-        diagnostics.push("llvm lowering: struct list too large (" + number_to_string(safe.length) + "); dropping");
+        diagnostics.push("llvm lowering: struct list too large ("
+            + number_to_string(safe.length)
+            + "); dropping");
         safe = [];
     }
     return safe;
@@ -175,12 +180,18 @@ fn sanitize_enums(enums: NativeEnum[], diagnostics: string[], _trace_enums: bool
     if safe == null { safe = []; }
     if safe.length != sanitize_collection_length(safe.length, 100000) {
         if _trace_enums {
-            print.err("enum_trace: sanitize dropped enums (len=" + number_to_string(safe.length) + " sanitized=" + number_to_string(sanitize_collection_length(safe.length, 100000)) + ")");
+            print.err("enum_trace: sanitize dropped enums (len="
+                + number_to_string(safe.length)
+                + " sanitized="
+                + number_to_string(sanitize_collection_length(safe.length, 100000))
+                + ")");
         }
         safe = [];
     }
     if safe.length > 100000 {
-        diagnostics.push("llvm lowering: enum list too large (" + number_to_string(safe.length) + "); dropping");
+        diagnostics.push("llvm lowering: enum list too large ("
+            + number_to_string(safe.length)
+            + "); dropping");
         safe = [];
     }
     if _trace_enums {
@@ -197,7 +208,9 @@ fn sanitize_interfaces(interfaces: NativeInterface[], diagnostics: string[]) -> 
         safe = [];
     }
     if safe.length > 100000 {
-        diagnostics.push("llvm lowering: interface list too large (" + number_to_string(safe.length) + "); dropping");
+        diagnostics.push("llvm lowering: interface list too large ("
+            + number_to_string(safe.length)
+            + "); dropping");
         safe = [];
     }
     return safe;
@@ -229,7 +242,8 @@ fn sanitize_functions(functions: NativeFunction[], native_text_override_path: st
         safe = [];
     }
     if debug_lowering {
-        print.err("emit-llvm: dbg-H4 after sanitize safe_functions.length=" + number_to_string(safe.length));
+        print.err("emit-llvm: dbg-H4 after sanitize safe_functions.length="
+            + number_to_string(safe.length));
     }
     // Recovery: if parse returned no functions, try re-parsing from text
     if safe.length == 0 {
@@ -241,7 +255,8 @@ fn sanitize_functions(functions: NativeFunction[], native_text_override_path: st
             recovery_text = native_text_override_path;
         }
         if debug_lowering {
-            print.err("emit-llvm: dbg-R2 recovery_text.length=" + number_to_string(recovery_text.length));
+            print.err("emit-llvm: dbg-R2 recovery_text.length="
+                + number_to_string(recovery_text.length));
         }
         if recovery_text.length == 0 {
             if fs.exists("build/sailfin/emit-native.tmp") {
@@ -250,12 +265,14 @@ fn sanitize_functions(functions: NativeFunction[], native_text_override_path: st
                 }
                 recovery_text = fs.readFile("build/sailfin/emit-native.tmp");
                 if debug_lowering {
-                    print.err("emit-llvm: dbg-R4 read emit-native.tmp bytes=" + number_to_string(recovery_text.length));
+                    print.err("emit-llvm: dbg-R4 read emit-native.tmp bytes="
+                        + number_to_string(recovery_text.length));
                 }
             }
         }
         if debug_lowering {
-            print.err("emit-llvm: dbg-R5 before parse recovery_text.length=" + number_to_string(recovery_text.length));
+            print.err("emit-llvm: dbg-R5 before parse recovery_text.length="
+                + number_to_string(recovery_text.length));
         }
         if recovery_text.length > 0 {
             if debug_lowering {
@@ -305,7 +322,8 @@ fn sanitize_functions(functions: NativeFunction[], native_text_override_path: st
             if recovered_functions.length > 0 {
                 safe = recovered_functions;
                 if debug_lowering {
-                    print.err("emit-llvm: recovered empty parse.functions from artifact text count=" + number_to_string(safe.length));
+                    print.err("emit-llvm: recovered empty parse.functions from artifact text count="
+                        + number_to_string(safe.length));
                 }
             }
         }
@@ -317,12 +335,14 @@ fn sanitize_functions(functions: NativeFunction[], native_text_override_path: st
 // Recover safe_functions through the additional recovery pipeline.
 fn recover_safe_functions(safe_functions: NativeFunction[], native_text_override_path: string, debug_lowering: boolean) -> NativeFunction[] ![io] {
     if debug_lowering {
-        print.err("emit-llvm: phase=recover_functions_start current=" + number_to_string(safe_functions.length));
+        print.err("emit-llvm: phase=recover_functions_start current="
+            + number_to_string(safe_functions.length));
     }
     let artifact_text = "";
     let recovered_safe = recover_functions_for_lowering(safe_functions, native_text_override_path, artifact_text, debug_lowering);
     if debug_lowering {
-        print.err("emit-llvm: phase=recover_functions_done current=" + number_to_string(recovered_safe.length));
+        print.err("emit-llvm: phase=recover_functions_done current="
+            + number_to_string(recovered_safe.length));
     }
     return recovered_safe;
 }
@@ -376,7 +396,9 @@ fn sanitize_bindings(bindings: NativeBinding[], diagnostics: string[]) -> Native
         safe = [];
     }
     if safe.length > 200000 {
-        diagnostics.push("llvm lowering: binding list too large (" + number_to_string(safe.length) + "); dropping");
+        diagnostics.push("llvm lowering: binding list too large ("
+            + number_to_string(safe.length)
+            + "); dropping");
         safe = [];
     }
     // Recovery: if bindings empty, re-parse from emit-native.tmp

--- a/compiler/src/llvm/lowering/lowering_phase_sanitize.sfn
+++ b/compiler/src/llvm/lowering/lowering_phase_sanitize.sfn
@@ -5,61 +5,40 @@
 // recovery from native text when the ABI corrupts struct fields.
 //
 // Extracted from lowering_core.sfn to reduce per-file memory footprint.
-
 import { NativeModule } from "../../emit_native";
 import {
-    NativeImport,
-    NativeFunction,
-    NativeStruct,
-    NativeEnum,
-    NativeInterface,
-    NativeBinding,
     LayoutManifest,
+    NativeBinding,
+    NativeEnum,
+    NativeFunction,
+    NativeImport,
+    NativeInterface,
+    NativeStruct,
     ParseNativeResult,
 } from "../../native_ir";
+import { parse_native_bindings_from_text, parse_native_functions_from_text, } from "../../native_ir_api";
+import { number_to_string, } from "../utils";
+import { is_test_module_slug, sanitize_collection_length, } from "./lowering_helpers";
+import { extend_string_lines_checked, } from "./lowering_io";
+import { get_struct_fields_at, get_struct_name_at, } from "./lowering_native_helpers";
 import {
-    parse_native_functions_from_text,
-    parse_native_bindings_from_text,
-} from "../../native_ir_api";
-
-import {
-    number_to_string,
-} from "../utils";
-
-import {
-    extend_string_lines_checked,
-} from "./lowering_io";
-
-import {
-    sanitize_collection_length,
-    is_test_module_slug,
-} from "./lowering_helpers";
-
-import {
-    get_struct_name_at,
-    get_struct_fields_at,
-} from "./lowering_native_helpers";
-
-import {
-    recover_native_functions_light,
-    recover_native_structs_light,
-    recover_native_imports_light,
-    recover_native_enums_light,
-    recover_functions_for_lowering,
     parse_native_artifact_safe,
+    recover_functions_for_lowering,
+    recover_native_enums_light,
+    recover_native_functions_light,
+    recover_native_imports_light,
+    recover_native_structs_light,
 } from "./lowering_recovery";
 
 // Note: build_parse_result_from_text lives in lowering_core.sfn.
 // We inline its logic here to avoid a circular import
 // (lowering_core imports from this file).
-
 // Sanitize a single collection: null-check + length guard.
 // Returns the sanitized array length (0 if dropped).
 // The caller must handle setting the variable; this function writes
 // the decision to a file so the caller can read it.
 // (Kept inline because the pattern is simple and cross-module array
 // return is unreliable with the v0.1.1 seed.)
-
 // Sanitize and recover all parsed inputs for the lowering pipeline.
 // Recovery happens in memory because the v0.1.1 seed may corrupt
 // cross-module struct returns. This function does not write
@@ -69,19 +48,9 @@ import {
 // returned through a ParseNativeResult struct. Callers should read
 // the returned struct fields cautiously and use their own recovery
 // path if later phases detect corrupted data.
-fn sanitize_lowering_inputs(
-    parse_in: ParseNativeResult,
-    native_text_override_path: string,
-    native_module: NativeModule,
-    imported_manifests_in: LayoutManifest[],
-    imported_native_texts_in: string[],
-    diagnostics_in: string[],
-    debug_lowering: boolean
-) -> ParseNativeResult ![io] {
+fn sanitize_lowering_inputs(parse_in: ParseNativeResult, native_text_override_path: string, native_module: NativeModule, imported_manifests_in: LayoutManifest[], imported_native_texts_in: string[], diagnostics_in: string[], debug_lowering: boolean) -> ParseNativeResult ![io] {
     let mut parse = parse_in;
-    if debug_lowering {
-        print.err("emit-llvm: dbg-A parse_in assigned");
-    }
+    if debug_lowering { print.err("emit-llvm: dbg-A parse_in assigned"); }
     if debug_lowering {
         print.err("emit-llvm: dbg-B before override check path_len=" + number_to_string(native_text_override_path.length));
     }
@@ -119,9 +88,7 @@ fn sanitize_lowering_inputs(
 // Sanitize imported manifests array: null-check + length guard.
 fn sanitize_imported_manifests(imported_manifests: LayoutManifest[], debug_lowering: boolean) -> LayoutManifest[] {
     let mut safe = imported_manifests;
-    if safe == null {
-        safe = [];
-    }
+    if safe == null { safe = []; }
     if safe.length != sanitize_collection_length(safe.length, 100000) {
         safe = [];
     }
@@ -134,9 +101,7 @@ fn sanitize_imported_manifests(imported_manifests: LayoutManifest[], debug_lower
 // Sanitize imported native texts array: null-check + length guard.
 fn sanitize_imported_native_texts(imported_native_texts: string[], debug_lowering: boolean) -> string[] {
     let mut safe = imported_native_texts;
-    if safe == null {
-        safe = [];
-    }
+    if safe == null { safe = []; }
     if safe.length != sanitize_collection_length(safe.length, 100000) {
         safe = [];
     }
@@ -149,9 +114,7 @@ fn sanitize_imported_native_texts(imported_native_texts: string[], debug_lowerin
 // Sanitize diagnostics array: null-check + length guard.
 fn sanitize_diagnostics(diagnostics_in: string[]) -> string[] {
     let mut safe = diagnostics_in;
-    if safe == null {
-        safe = [];
-    }
+    if safe == null { safe = []; }
     if safe.length != sanitize_collection_length(safe.length, 1000000) {
         safe = [];
     }
@@ -161,9 +124,7 @@ fn sanitize_diagnostics(diagnostics_in: string[]) -> string[] {
 // Sanitize entry points array: null-check + length guard.
 fn sanitize_entry_points(entry_points: string[], debug_lowering: boolean) -> string[] {
     let mut safe = entry_points;
-    if safe == null {
-        safe = [];
-    }
+    if safe == null { safe = []; }
     if safe.length != sanitize_collection_length(safe.length, 100000) {
         safe = [];
     }
@@ -176,9 +137,7 @@ fn sanitize_entry_points(entry_points: string[], debug_lowering: boolean) -> str
 // Sanitize imports array: null-check + length guard.
 fn sanitize_imports(imports: NativeImport[], debug_lowering: boolean) -> NativeImport[] {
     let mut safe = imports;
-    if safe == null {
-        safe = [];
-    }
+    if safe == null { safe = []; }
     if safe.length != sanitize_collection_length(safe.length, 100000) {
         safe = [];
     }
@@ -194,9 +153,7 @@ fn sanitize_imports(imports: NativeImport[], debug_lowering: boolean) -> NativeI
 // Sanitize structs array: null-check + length guard + diagnostics.
 fn sanitize_structs(structs: NativeStruct[], diagnostics: string[]) -> NativeStruct[] {
     let mut safe = structs;
-    if safe == null {
-        safe = [];
-    }
+    if safe == null { safe = []; }
     if safe.length != sanitize_collection_length(safe.length, 100000) {
         safe = [];
     }
@@ -212,14 +169,10 @@ fn sanitize_enums(enums: NativeEnum[], diagnostics: string[], _trace_enums: bool
     let mut safe = enums;
     if _trace_enums {
         let mut _enum_len_text: string = "null";
-        if safe != null {
-            _enum_len_text = number_to_string(safe.length);
-        }
+        if safe != null { _enum_len_text = number_to_string(safe.length); }
         print.err("enum_trace: parse.enums=" + _enum_len_text);
     }
-    if safe == null {
-        safe = [];
-    }
+    if safe == null { safe = []; }
     if safe.length != sanitize_collection_length(safe.length, 100000) {
         if _trace_enums {
             print.err("enum_trace: sanitize dropped enums (len=" + number_to_string(safe.length) + " sanitized=" + number_to_string(sanitize_collection_length(safe.length, 100000)) + ")");
@@ -239,9 +192,7 @@ fn sanitize_enums(enums: NativeEnum[], diagnostics: string[], _trace_enums: bool
 // Sanitize interfaces array: null-check + length guard + diagnostics.
 fn sanitize_interfaces(interfaces: NativeInterface[], diagnostics: string[]) -> NativeInterface[] {
     let mut safe = interfaces;
-    if safe == null {
-        safe = [];
-    }
+    if safe == null { safe = []; }
     if safe.length != sanitize_collection_length(safe.length, 100000) {
         safe = [];
     }
@@ -254,11 +205,7 @@ fn sanitize_interfaces(interfaces: NativeInterface[], diagnostics: string[]) -> 
 
 // Sanitize functions array: null-check + length guard + recovery.
 // Writes diagnostics to the diagnostics array parameter.
-fn sanitize_functions(
-    functions: NativeFunction[],
-    native_text_override_path: string,
-    debug_lowering: boolean
-) -> NativeFunction[] ![io] {
+fn sanitize_functions(functions: NativeFunction[], native_text_override_path: string, debug_lowering: boolean) -> NativeFunction[] ![io] {
     if debug_lowering {
         print.err("emit-llvm: dbg-H1 before parse.functions access");
     }
@@ -271,9 +218,7 @@ fn sanitize_functions(
             print.err("emit-llvm: parse.functions is null");
         }
     }
-    if safe == null {
-        safe = [];
-    }
+    if safe == null { safe = []; }
     if debug_lowering {
         print.err("emit-llvm: dbg-H3 safe_functions.length=" + number_to_string(safe.length));
     }
@@ -320,9 +265,7 @@ fn sanitize_functions(
             let mut recovered_has_body = false;
             let mut recovered_index: number = 0;
             loop {
-                if recovered_index >= recovered_functions.length {
-                    break;
-                }
+                if recovered_index >= recovered_functions.length { break; }
                 let recovered_function = recovered_functions[recovered_index];
                 if !recovered_function.is_extern {
                     if recovered_function.instructions != null {
@@ -342,9 +285,7 @@ fn sanitize_functions(
                 let mut light_has_body = false;
                 recovered_index = 0;
                 loop {
-                    if recovered_index >= light_recovered.length {
-                        break;
-                    }
+                    if recovered_index >= light_recovered.length { break; }
                     let recovered_function = light_recovered[recovered_index];
                     if !recovered_function.is_extern {
                         if recovered_function.instructions != null {
@@ -359,9 +300,7 @@ fn sanitize_functions(
                 let mut _if261: boolean = false;
                 if light_has_body { _if261 = true; }
                 if recovered_functions.length == 0 { _if261 = true; }
-                if _if261 {
-                    recovered_functions = light_recovered;
-                }
+                if _if261 { recovered_functions = light_recovered; }
             }
             if recovered_functions.length > 0 {
                 safe = recovered_functions;
@@ -371,18 +310,12 @@ fn sanitize_functions(
             }
         }
     }
-    if safe.length > 200000 {
-        safe = [];
-    }
+    if safe.length > 200000 { safe = []; }
     return safe;
 }
 
 // Recover safe_functions through the additional recovery pipeline.
-fn recover_safe_functions(
-    safe_functions: NativeFunction[],
-    native_text_override_path: string,
-    debug_lowering: boolean
-) -> NativeFunction[] ![io] {
+fn recover_safe_functions(safe_functions: NativeFunction[], native_text_override_path: string, debug_lowering: boolean) -> NativeFunction[] ![io] {
     if debug_lowering {
         print.err("emit-llvm: phase=recover_functions_start current=" + number_to_string(safe_functions.length));
     }
@@ -397,19 +330,13 @@ fn recover_safe_functions(
 // Recover struct definitions when the main parser returned corrupt results.
 // Validates each struct has a non-empty name; if any looks corrupt, replaces
 // with light recovery from native text.
-fn recover_structs_if_corrupt(
-    safe_structs: NativeStruct[],
-    native_text_override_path: string,
-    debug_lowering: boolean
-) -> NativeStruct[] ![io] {
+fn recover_structs_if_corrupt(safe_structs: NativeStruct[], native_text_override_path: string, debug_lowering: boolean) -> NativeStruct[] ![io] {
     let mut structs_look_corrupt: boolean = safe_structs.length == 0;
     if !structs_look_corrupt {
         if safe_structs.length > 0 {
             let mut check_i: number = 0;
             loop {
-                if check_i >= safe_structs.length {
-                    break;
-                }
+                if check_i >= safe_structs.length { break; }
                 let check_struct = safe_structs[check_i];
                 let mut _if262: boolean = false;
                 if check_struct.name == null { _if262 = true; }
@@ -435,9 +362,7 @@ fn recover_structs_if_corrupt(
         }
         if struct_recovery_text.length > 0 {
             let recovered_structs = recover_native_structs_light(struct_recovery_text);
-            if recovered_structs.length > 0 {
-                return recovered_structs;
-            }
+            if recovered_structs.length > 0 { return recovered_structs; }
         }
     }
     return safe_structs;
@@ -446,9 +371,7 @@ fn recover_structs_if_corrupt(
 // Sanitize and recover bindings array.
 fn sanitize_bindings(bindings: NativeBinding[], diagnostics: string[]) -> NativeBinding[] ![io] {
     let mut safe = bindings;
-    if safe == null {
-        safe = [];
-    }
+    if safe == null { safe = []; }
     if safe.length != sanitize_collection_length(safe.length, 200000) {
         safe = [];
     }

--- a/compiler/src/llvm/lowering/lowering_phase_types.sfn
+++ b/compiler/src/llvm/lowering/lowering_phase_types.sfn
@@ -13,29 +13,21 @@ import {
     NativeEnum,
     NativeFunction,
     NativeInterface,
-    NativeStruct,
+    NativeStruct
 } from "../../native_ir";
 import { substring } from "../../string_utils";
-import { build_type_context, fixup_enum_layouts, } from "../type_context";
-import {
-    EnumTypeInfo,
-    EnumVariantInfo,
-    TypeContext,
-} from "../types";
-import {
-    index_of,
-    number_to_string,
-    sanitize_symbol,
-} from "../utils";
-import { extend_string_lines_checked, } from "./lowering_io";
+import { build_type_context, fixup_enum_layouts } from "../type_context";
+import { EnumTypeInfo, EnumVariantInfo, TypeContext } from "../types";
+import { index_of, number_to_string, sanitize_symbol } from "../utils";
+import { extend_string_lines_checked } from "./lowering_io";
 import {
     get_enum_name_at,
     get_struct_field_name_at,
     get_struct_field_type_at,
     get_struct_fields_at,
-    get_struct_name_at,
+    get_struct_name_at
 } from "./lowering_native_helpers";
-import { parse_number_local, split_lines_local, } from "./lowering_text_utils";
+import { parse_number_local, split_lines_local } from "./lowering_text_utils";
 
 // Serialize struct info to build/sailfin/.struct_info for use by
 // build_type_context recovery.  Format per line:
@@ -107,7 +99,13 @@ fn serialize_enum_info(enums: NativeEnum[], _trace_enums: boolean) -> string ![i
         let tag_align = "4";
         let size = "4";
         let align = "4";
-        let mut line = name + "\t" + tag_type + "\t" + tag_size + "\t" + tag_align + "\t" + size + "\t" + align + "\t";
+        let mut line = name + "\t" + tag_type + "\t" + tag_size + "\t"
+            + tag_align
+            + "\t"
+            + size
+            + "\t"
+            + align
+            + "\t";
         let e = enums[idx];
         let variants = e.variants;
         let mut vi: number = 0;
@@ -115,7 +113,8 @@ fn serialize_enum_info(enums: NativeEnum[], _trace_enums: boolean) -> string ![i
             loop {
                 if vi >= variants.length { break; }
                 if vi > 0 { line = line + ","; }
-                line = line + "v" + number_to_string(vi) + "=" + number_to_string(vi);
+                line = line + "v" + number_to_string(vi) + "="
+                    + number_to_string(vi);
                 vi += 1;
             }
         }
@@ -139,7 +138,8 @@ fn build_type_context_with_recovery(combined_structs: NativeStruct[], combined_e
 
     // (No diagnostics from skipped fixup.)
     if debug_lowering {
-        print.err("emit-llvm: about to fixup_enum_layouts enums=" + number_to_string(combined_enums.length));
+        print.err("emit-llvm: about to fixup_enum_layouts enums="
+            + number_to_string(combined_enums.length));
     }
 
     // Serialize struct/enum info BEFORE the cross-module build_type_context call.
@@ -147,7 +147,9 @@ fn build_type_context_with_recovery(combined_structs: NativeStruct[], combined_e
     serialize_enum_info(fixed_enums_list, _trace_enums);
 
     if _trace_enums {
-        print.err("enum_trace: combined_enums=" + number_to_string(combined_enums.length) + " fixed_enums=" + number_to_string(fixed_enums_list.length));
+        print.err("enum_trace: combined_enums=" + number_to_string(combined_enums.length)
+            + " fixed_enums="
+            + number_to_string(fixed_enums_list.length));
     }
 
     let type_build = build_type_context(combined_structs, fixed_enums_list, combined_interfaces);
@@ -189,7 +191,7 @@ fn build_type_context_with_recovery(combined_structs: NativeStruct[], combined_e
                 structs: type_context.structs,
                 enums: recovered,
                 interfaces: type_context.interfaces,
-                vtables: type_context.vtables,
+                vtables: type_context.vtables
             };
         }
     }
@@ -262,13 +264,14 @@ fn recover_enums_from_file(_trace_enums: boolean) -> EnumTypeInfo[] ![io] {
         let mut max_ps: number = esize - etag_size;
         if max_ps < 0 { max_ps = 0; }
         recovered.push(EnumTypeInfo {
-            name: ename, llvm_name: ellvm, tag_type: etag_type, tag_size: etag_size, tag_align: etag_align, max_payload_size: max_ps, size: esize, align: ealign, variants: evariants,
+            name: ename, llvm_name: ellvm, tag_type: etag_type, tag_size: etag_size, tag_align: etag_align, max_payload_size: max_ps, size: esize, align: ealign, variants: evariants
         });
         eli += 1;
     }
     if recovered.length > 0 {
         if _trace_enums {
-            print.err("enum_trace: recovered " + number_to_string(recovered.length) + " enum(s) from .enum_info");
+            print.err("enum_trace: recovered " + number_to_string(recovered.length)
+                + " enum(s) from .enum_info");
         }
     }
     return recovered;
@@ -293,7 +296,7 @@ fn parse_enum_variants(variants_str: string) -> EnumVariantInfo[] {
         }
         if vname.length > 0 {
             result.push(EnumVariantInfo {
-                name: vname, tag: vtag, offset: 0, size: 0, align: 1, fields: [],
+                name: vname, tag: vtag, offset: 0, size: 0, align: 1, fields: []
             });
         }
         vtag += 1;
@@ -351,7 +354,8 @@ fn serialize_context_functions(context_functions: NativeFunction[], debug_loweri
         cfw_i += 1;
     }
     if debug_lowering {
-        print.err("emit-llvm: serialized context_functions count=" + number_to_string(context_functions.length));
+        print.err("emit-llvm: serialized context_functions count="
+            + number_to_string(context_functions.length));
     }
     return context_functions.length;
 }

--- a/compiler/src/llvm/lowering/lowering_phase_types.sfn
+++ b/compiler/src/llvm/lowering/lowering_phase_types.sfn
@@ -9,48 +9,33 @@
 // returned TypeContext has missing or empty enum names.
 //
 // Extracted from lowering_core.sfn to reduce per-file memory footprint.
-
 import {
-    NativeStruct,
     NativeEnum,
-    NativeInterface,
     NativeFunction,
+    NativeInterface,
+    NativeStruct,
 } from "../../native_ir";
 import { substring } from "../../string_utils";
-
+import { build_type_context, fixup_enum_layouts, } from "../type_context";
 import {
-    TypeContext,
     EnumTypeInfo,
     EnumVariantInfo,
+    TypeContext,
 } from "../types";
-
 import {
+    index_of,
     number_to_string,
     sanitize_symbol,
-    index_of,
 } from "../utils";
-
+import { extend_string_lines_checked, } from "./lowering_io";
 import {
-    fixup_enum_layouts,
-    build_type_context,
-} from "../type_context";
-
-import {
-    extend_string_lines_checked,
-} from "./lowering_io";
-
-import {
-    get_struct_name_at,
-    get_struct_fields_at,
+    get_enum_name_at,
     get_struct_field_name_at,
     get_struct_field_type_at,
-    get_enum_name_at,
+    get_struct_fields_at,
+    get_struct_name_at,
 } from "./lowering_native_helpers";
-
-import {
-    split_lines_local,
-    parse_number_local,
-} from "./lowering_text_utils";
+import { parse_number_local, split_lines_local, } from "./lowering_text_utils";
 
 // Serialize struct info to build/sailfin/.struct_info for use by
 // build_type_context recovery.  Format per line:
@@ -80,14 +65,15 @@ fn serialize_struct_info(combined_structs: NativeStruct[]) -> string ![io] {
                 if fn_name == null { fn_name = ""; }
                 let mut ft = "i8*";
                 let ann = get_struct_field_type_at(fields, fi);
-                if ann == "number" { ft = "double"; }
-                else if ann == "boolean" { ft = "i1"; }
-                else if ann == "bool" { ft = "i1"; }
-                else if ann == "i64" { ft = "i64"; }
-                else if ann == "int" { ft = "i64"; }
-                else if ann == "usize" { ft = "i64"; }
-                else if ann == "i32" { ft = "i32"; }
-                else if ann == "u8" { ft = "i8"; }
+                if ann == "number" { ft = "double"; } else if ann == "boolean" {
+                    ft = "i1";
+                } else if ann == "bool" { ft = "i1"; } else if ann == "i64" {
+                    ft = "i64";
+                } else if ann == "int" { ft = "i64"; } else if ann == "usize" {
+                    ft = "i64";
+                } else if ann == "i32" { ft = "i32"; } else if ann == "u8" {
+                    ft = "i8";
+                }
                 line = line + fn_name + ":" + ft;
                 fi += 1;
             }
@@ -146,19 +132,12 @@ fn serialize_enum_info(enums: NativeEnum[], _trace_enums: boolean) -> string ![i
 // Build the type context and recover enum info from file-based channel
 // if cross-module ABI corruption caused enums to arrive empty.
 // Returns the TypeContext (enums may be recovered from .enum_info).
-fn build_type_context_with_recovery(
-    combined_structs: NativeStruct[],
-    combined_enums: NativeEnum[],
-    combined_interfaces: NativeInterface[],
-    diagnostics: string[],
-    _trace_enums: boolean,
-    debug_lowering: boolean
-) -> TypeContext ![io] {
+fn build_type_context_with_recovery(combined_structs: NativeStruct[], combined_enums: NativeEnum[], combined_interfaces: NativeInterface[], diagnostics: string[], _trace_enums: boolean, debug_lowering: boolean) -> TypeContext ![io] {
     // Skip cross-module fixup_enum_layouts: the seed's struct-returning
     // cross-module ABI segfaults.  Pass enums through directly.
     let fixed_enums_list = combined_enums;
-    // (No diagnostics from skipped fixup.)
 
+    // (No diagnostics from skipped fixup.)
     if debug_lowering {
         print.err("emit-llvm: about to fixup_enum_layouts enums=" + number_to_string(combined_enums.length));
     }
@@ -201,9 +180,7 @@ fn build_type_context_with_recovery(
     if type_context.enums.length == 0 { _if263 = true; }
     if _enum_names_empty { _if263 = true; }
     if _if263 {
-        if fs.exists("build/sailfin/.enum_info") {
-            _needs_recovery = true;
-        }
+        if fs.exists("build/sailfin/.enum_info") { _needs_recovery = true; }
     }
     if _needs_recovery {
         let recovered = recover_enums_from_file(_trace_enums);
@@ -219,9 +196,7 @@ fn build_type_context_with_recovery(
     if _trace_enums {
         print.err("enum_trace: type_context.enums=" + number_to_string(type_context.enums.length));
     }
-    if debug_lowering {
-        print.err("emit-llvm: phase=type_context");
-    }
+    if debug_lowering { print.err("emit-llvm: phase=type_context"); }
     return type_context;
 }
 
@@ -229,9 +204,7 @@ fn build_type_context_with_recovery(
 // Returns an array of EnumTypeInfo parsed from the tab-delimited format.
 fn recover_enums_from_file(_trace_enums: boolean) -> EnumTypeInfo[] ![io] {
     let raw = fs.readFile("build/sailfin/.enum_info");
-    if raw.length == 0 {
-        return [];
-    }
+    if raw.length == 0 { return []; }
     let lines = split_lines_local(raw);
     let mut recovered: EnumTypeInfo[] = [];
     let mut eli: number = 0;
@@ -240,23 +213,38 @@ fn recover_enums_from_file(_trace_enums: boolean) -> EnumTypeInfo[] ![io] {
         let el = lines[eli];
         // Format: name\ttag_type\ttag_size\ttag_align\tsize\talign\tv0=t0,v1=t1,...
         let tab1 = index_of(el, "\t");
-        if tab1 < 0 { eli += 1; continue; }
+        if tab1 < 0 {
+            eli += 1;
+            continue;
+        }
         let ename = substring(el, 0, tab1);
         let rest1 = substring(el, tab1 + 1, el.length);
         let tab2 = index_of(rest1, "\t");
-        if tab2 < 0 { eli += 1; continue; }
+        if tab2 < 0 {
+            eli += 1;
+            continue;
+        }
         let etag_type = substring(rest1, 0, tab2);
         let rest2 = substring(rest1, tab2 + 1, rest1.length);
         let tab3 = index_of(rest2, "\t");
-        if tab3 < 0 { eli += 1; continue; }
+        if tab3 < 0 {
+            eli += 1;
+            continue;
+        }
         let etag_size = parse_number_local(substring(rest2, 0, tab3));
         let rest3 = substring(rest2, tab3 + 1, rest2.length);
         let tab4 = index_of(rest3, "\t");
-        if tab4 < 0 { eli += 1; continue; }
+        if tab4 < 0 {
+            eli += 1;
+            continue;
+        }
         let etag_align = parse_number_local(substring(rest3, 0, tab4));
         let rest4 = substring(rest3, tab4 + 1, rest3.length);
         let tab5 = index_of(rest4, "\t");
-        if tab5 < 0 { eli += 1; continue; }
+        if tab5 < 0 {
+            eli += 1;
+            continue;
+        }
         let esize = parse_number_local(substring(rest4, 0, tab5));
         let rest5 = substring(rest4, tab5 + 1, rest4.length);
         let tab6 = index_of(rest5, "\t");
@@ -265,9 +253,7 @@ fn recover_enums_from_file(_trace_enums: boolean) -> EnumTypeInfo[] ![io] {
         if tab6 >= 0 {
             ealign = parse_number_local(substring(rest5, 0, tab6));
             variants_str = substring(rest5, tab6 + 1, rest5.length);
-        } else {
-            ealign = parse_number_local(rest5);
-        }
+        } else { ealign = parse_number_local(rest5); }
 
         // Parse variants: v0=t0,v1=t1,...
         let evariants = parse_enum_variants(variants_str);
@@ -276,15 +262,7 @@ fn recover_enums_from_file(_trace_enums: boolean) -> EnumTypeInfo[] ![io] {
         let mut max_ps: number = esize - etag_size;
         if max_ps < 0 { max_ps = 0; }
         recovered.push(EnumTypeInfo {
-                name: ename,
-                llvm_name: ellvm,
-                tag_type: etag_type,
-                tag_size: etag_size,
-                tag_align: etag_align,
-                max_payload_size: max_ps,
-                size: esize,
-                align: ealign,
-                variants: evariants,
+            name: ename, llvm_name: ellvm, tag_type: etag_type, tag_size: etag_size, tag_align: etag_align, max_payload_size: max_ps, size: esize, align: ealign, variants: evariants,
         });
         eli += 1;
     }
@@ -299,17 +277,13 @@ fn recover_enums_from_file(_trace_enums: boolean) -> EnumTypeInfo[] ![io] {
 // Parse enum variant string "v0=0,v1=1,..." into EnumVariantInfo[].
 fn parse_enum_variants(variants_str: string) -> EnumVariantInfo[] {
     let mut result: EnumVariantInfo[] = [];
-    if variants_str.length == 0 {
-        return result;
-    }
+    if variants_str.length == 0 { return result; }
     let mut vpos: number = 0;
     let mut vtag: number = 0;
     loop {
         let comma = index_of(substring(variants_str, vpos, variants_str.length), ",");
         let mut vend: number = variants_str.length;
-        if comma >= 0 {
-            vend = vpos + comma;
-        }
+        if comma >= 0 { vend = vpos + comma; }
         let vpair = substring(variants_str, vpos, vend);
         let eq = index_of(vpair, "=");
         let mut vname: string = vpair;
@@ -319,12 +293,7 @@ fn parse_enum_variants(variants_str: string) -> EnumVariantInfo[] {
         }
         if vname.length > 0 {
             result.push(EnumVariantInfo {
-                    name: vname,
-                    tag: vtag,
-                    offset: 0,
-                    size: 0,
-                    align: 1,
-                    fields: [],
+                name: vname, tag: vtag, offset: 0, size: 0, align: 1, fields: [],
             });
         }
         vtag += 1;
@@ -366,14 +335,10 @@ fn serialize_context_functions(context_functions: NativeFunction[], debug_loweri
         fs.writeFile(cfw_prefix + "_name", cfw_fn.name);
         fs.writeFile(cfw_prefix + "_return_type", cfw_fn.return_type);
         let mut cfw_async_flag: string = "0";
-        if cfw_fn.is_async {
-            cfw_async_flag = "1";
-        }
+        if cfw_fn.is_async { cfw_async_flag = "1"; }
         fs.writeFile(cfw_prefix + "_is_async", cfw_async_flag);
         let mut cfw_params = cfw_fn.parameters;
-        if cfw_params == null {
-            cfw_params = [];
-        }
+        if cfw_params == null { cfw_params = []; }
         fs.writeFile(cfw_prefix + "_param_count", number_to_string(cfw_params.length));
         let mut cfw_j: number = 0;
         loop {

--- a/compiler/src/llvm/lowering/lowering_recovery.sfn
+++ b/compiler/src/llvm/lowering/lowering_recovery.sfn
@@ -19,7 +19,7 @@ import {
     NativeStructField,
     NativeStructLayout,
     NativeStructLayoutField,
-    ParseNativeResult,
+    ParseNativeResult
 } from "../../native_ir";
 import {
     parse_native_bindings_from_text,
@@ -29,12 +29,12 @@ import {
     parse_native_functions_from_text,
     parse_native_imports_from_text,
     parse_native_interfaces_from_text,
-    parse_native_structs_from_text,
+    parse_native_structs_from_text
 } from "../../native_ir_api";
 import { substring } from "../../string_utils";
-import { index_of, number_to_string, } from "../utils";
-import { sanitize_collection_length, } from "./lowering_helpers";
-import { append_native_function, } from "./lowering_helpers_mangling";
+import { index_of, number_to_string } from "../utils";
+import { sanitize_collection_length } from "./lowering_helpers";
+import { append_native_function } from "./lowering_helpers_mangling";
 import {
     append_instruction_to_function,
     append_native_import,
@@ -58,7 +58,7 @@ import {
     make_native_struct_layout_field,
     make_native_struct_layout_field,
     update_function_effects,
-    update_function_return_type,
+    update_function_return_type
 } from "./lowering_native_helpers";
 import {
     extract_kv_number,
@@ -69,7 +69,7 @@ import {
     recover_function_name_from_header,
     split_lines_local,
     starts_with_local,
-    trim_text_local,
+    trim_text_local
 } from "./lowering_text_utils";
 
 // ── Parse wrappers ───────────────────────────────────────────────────
@@ -93,7 +93,7 @@ fn parse_native_artifact_safe(text: string) -> ParseNativeResult {
         interfaces: interfaces,
         enums: enums,
         bindings: bindings,
-        diagnostics: diagnostics,
+        diagnostics: diagnostics
     };
     return result;
 }
@@ -162,7 +162,8 @@ fn recover_native_functions_light(native_text: string) -> NativeFunction[] {
         let method_paren_idx = index_of(method_header, "(");
         let method_name_from_paren = trim_text_local(substring(method_header, 0, method_paren_idx));
         let method_arrow_idx = index_of(method_header, " -> ");
-        let method_ret_from_arrow = trim_text_local(substring(method_header, method_arrow_idx + 4, method_header.length));
+        let method_ret_from_arrow = trim_text_local(substring(method_header, method_arrow_idx
+            + 4, method_header.length));
         // Check whether the method has a `self` parameter.  Static methods
         // (e.g. `fn new(w, h)`) must NOT get self injected.
         let mut method_has_self: boolean = false;
@@ -200,20 +201,23 @@ fn recover_native_functions_light(native_text: string) -> NativeFunction[] {
             }
         }
         let param_name_raw = trim_text_local(substring(param_text_raw, 0, param_arrow_idx));
-        let param_type_raw = trim_text_local(substring(param_text_raw, param_arrow_idx + param_sep_len, param_text_raw.length));
+        let param_type_raw = trim_text_local(substring(param_text_raw, param_arrow_idx
+            + param_sep_len, param_text_raw.length));
 
         // Pre-compute .for target/iterable extraction.
         let for_body_raw = trim_text_local(substring(line, 5, line.length));
         let for_in_idx = index_of(for_body_raw, " in ");
         let for_target_raw = trim_text_local(substring(for_body_raw, 0, for_in_idx));
-        let for_iterable_raw = trim_text_local(substring(for_body_raw, for_in_idx + 4, for_body_raw.length));
+        let for_iterable_raw = trim_text_local(substring(for_body_raw, for_in_idx
+            + 4, for_body_raw.length));
 
         // Pre-compute match/case extraction.
         let match_expr_raw = trim_text_local(substring(line, 7, line.length));
         let case_pattern_raw = trim_text_local(substring(line, 6, line.length));
         // Inline case: pattern => body,
         let inline_pattern_raw = trim_text_local(substring(line, 0, inline_arrow_idx));
-        let inline_body_full = trim_text_local(substring(line, inline_arrow_idx + 4, line.length));
+        let inline_body_full = trim_text_local(substring(line, inline_arrow_idx
+            + 4, line.length));
         // Strip trailing comma from inline body
         let mut inline_body_raw: string = inline_body_full;
         if inline_body_full.length > 0 {
@@ -282,7 +286,8 @@ fn recover_native_functions_light(native_text: string) -> NativeFunction[] {
             if current_struct_name.length > 0 {
                 if method_paren_idx >= 0 {
                     if method_arrow_idx >= 0 {
-                        let full_name = current_struct_name + method_name_from_paren;
+                        let full_name = current_struct_name
+                            + method_name_from_paren;
                         if method_has_self {
                             current = make_native_function_method(full_name, current_struct_name, method_ret_from_arrow);
                         }
@@ -584,7 +589,8 @@ fn recover_native_structs_light(native_text: string) -> NativeStruct[] {
             }
         }
         let f_name = trim_text_local(substring(field_text, 0, field_arrow_idx));
-        let f_type = trim_text_local(substring(field_text, field_arrow_idx + field_sep_len, field_text.length));
+        let f_type = trim_text_local(substring(field_text, field_arrow_idx
+            + field_sep_len, field_text.length));
 
         let ls_text = trim_text_local(substring(line, 15, line.length));
         let ls_size_idx = index_of(ls_text, "size=");
@@ -846,7 +852,8 @@ fn recover_functions_for_lowering(current_functions: NativeFunction[], native_te
     if parsed_recovery.length == recovered_count {
         if parsed_recovery.length > 0 {
             if debug_lowering {
-                print.err("emit-llvm: recovered functions via parse_native_functions_from_text=" + number_to_string(parsed_recovery.length));
+                print.err("emit-llvm: recovered functions via parse_native_functions_from_text="
+                    + number_to_string(parsed_recovery.length));
             }
             return parsed_recovery;
         }
@@ -857,7 +864,8 @@ fn recover_functions_for_lowering(current_functions: NativeFunction[], native_te
     if light_recovery.length == light_recovered_count {
         if light_recovery.length > 0 {
             if debug_lowering {
-                print.err("emit-llvm: recovered functions via light parser=" + number_to_string(light_recovery.length));
+                print.err("emit-llvm: recovered functions via light parser="
+                    + number_to_string(light_recovery.length));
             }
             return light_recovery;
         }

--- a/compiler/src/llvm/lowering/lowering_recovery.sfn
+++ b/compiler/src/llvm/lowering/lowering_recovery.sfn
@@ -6,82 +6,73 @@
 // that the v0.1.1 seed cannot compile correctly.
 //
 // Extracted from lowering_core.sfn to reduce per-file memory footprint.
-
-import { substring } from "../../string_utils";
 import {
-    NativeImport,
+    NativeEnum,
+    NativeEnumLayout,
+    NativeEnumVariant,
+    NativeEnumVariantField,
+    NativeEnumVariantLayout,
     NativeFunction,
+    NativeImport,
     NativeInstruction,
     NativeStruct,
     NativeStructField,
     NativeStructLayout,
     NativeStructLayoutField,
-    NativeEnum,
-    NativeEnumVariant,
-    NativeEnumVariantField,
-    NativeEnumLayout,
-    NativeEnumVariantLayout,
     ParseNativeResult,
 } from "../../native_ir";
 import {
-    parse_native_function_count_from_text,
-    parse_native_functions_from_text,
-    parse_native_structs_from_text,
-    parse_native_imports_from_text,
-    parse_native_interfaces_from_text,
-    parse_native_enums_from_text,
     parse_native_bindings_from_text,
     parse_native_diagnostics_from_text,
+    parse_native_enums_from_text,
+    parse_native_function_count_from_text,
+    parse_native_functions_from_text,
+    parse_native_imports_from_text,
+    parse_native_interfaces_from_text,
+    parse_native_structs_from_text,
 } from "../../native_ir_api";
+import { substring } from "../../string_utils";
+import { index_of, number_to_string, } from "../utils";
+import { sanitize_collection_length, } from "./lowering_helpers";
+import { append_native_function, } from "./lowering_helpers_mangling";
 import {
-    number_to_string,
-    index_of,
-} from "../utils";
-import {
-    split_lines_local,
-    starts_with_local,
-    trim_text_local,
-    index_of_char_local,
-    extract_kv_number,
-    extract_kv_string,
-    recover_function_name_from_header,
-    recover_function_is_async_from_header,
-    net_unquoted_brace_depth,
-} from "./lowering_text_utils";
-import {
+    append_instruction_to_function,
+    append_native_import,
+    append_param_to_function,
+    make_instruction_for,
+    make_instruction_simple,
+    make_instruction_text,
+    make_native_enum,
+    make_native_enum_layout,
+    make_native_enum_variant,
+    make_native_enum_variant_layout,
+    make_native_enum_variant_layout_with_fields,
     make_native_function_basic,
     make_native_function_method,
     make_native_function_with_return,
-    make_native_parameter,
     make_native_import,
-    make_native_struct_layout,
+    make_native_parameter,
     make_native_struct,
     make_native_struct_field,
+    make_native_struct_layout,
     make_native_struct_layout_field,
-    make_instruction_text,
-    make_instruction_simple,
-    make_instruction_for,
-    make_native_enum,
-    make_native_enum_variant,
-    make_native_enum_layout,
-    make_native_enum_variant_layout,
-    make_native_enum_variant_layout_with_fields,
     make_native_struct_layout_field,
-    update_function_return_type,
     update_function_effects,
-    append_param_to_function,
-    append_instruction_to_function,
-    append_native_import,
+    update_function_return_type,
 } from "./lowering_native_helpers";
 import {
-    sanitize_collection_length,
-} from "./lowering_helpers";
-import {
-    append_native_function,
-} from "./lowering_helpers_mangling";
+    extract_kv_number,
+    extract_kv_string,
+    index_of_char_local,
+    net_unquoted_brace_depth,
+    recover_function_is_async_from_header,
+    recover_function_name_from_header,
+    split_lines_local,
+    starts_with_local,
+    trim_text_local,
+} from "./lowering_text_utils";
 
 // ── Parse wrappers ───────────────────────────────────────────────────
-
 // Construct a ParseNativeResult from individual field-extraction calls.
 // This avoids the seed v0.1.1 struct-return ABI bug: each extractor returns
 // an array (works through double→pointer shim), then we assemble locally.
@@ -107,10 +98,7 @@ fn parse_native_artifact_safe(text: string) -> ParseNativeResult {
     return result;
 }
 
-
-
 // ── Light function recovery ──────────────────────────────────────────
-
 fn recover_native_functions_light(native_text: string) -> NativeFunction[] {
     // FLAT: no nested ifs, no else-if chains.
     // Seed degenerate-if bug drops ALL nested conditions and else-if branches.
@@ -122,9 +110,7 @@ fn recover_native_functions_light(native_text: string) -> NativeFunction[] {
     let mut index: number = 0;
     let mut fn_count: number = 0;
     loop {
-        if index >= lines.length {
-            break;
-        }
+        if index >= lines.length { break; }
         let line = trim_text_local(lines[index]);
         let mut _if237: boolean = false;
         if line.length == 0 { _if237 = true; }
@@ -204,7 +190,9 @@ fn recover_native_functions_light(native_text: string) -> NativeFunction[] {
             let mut _use_param_arrow: boolean = false;
             if param_arrow_idx < 0 { _use_param_arrow = true; }
             if param_arrow_idx >= 0 {
-                if param_legacy_arrow_idx < param_arrow_idx { _use_param_arrow = true; }
+                if param_legacy_arrow_idx < param_arrow_idx {
+                    _use_param_arrow = true;
+                }
             }
             if _use_param_arrow {
                 param_arrow_idx = param_legacy_arrow_idx;
@@ -438,8 +426,12 @@ fn recover_native_functions_light(native_text: string) -> NativeFunction[] {
             let _cont = lines[_gi];
             let _cont_trimmed = trim_text_local(_cont);
             let mut _is_stop_directive: boolean = false;
-            if starts_with_local(_cont_trimmed, ".") { _is_stop_directive = true; }
-            if starts_with_local(_cont_trimmed, ".span") { _is_stop_directive = false; }
+            if starts_with_local(_cont_trimmed, ".") {
+                _is_stop_directive = true;
+            }
+            if starts_with_local(_cont_trimmed, ".span") {
+                _is_stop_directive = false;
+            }
             if _is_stop_directive { break; }
             _eval_gathered = _eval_gathered + "\n" + _cont;
             let _cont_depth = net_unquoted_brace_depth(_cont);
@@ -456,44 +448,26 @@ fn recover_native_functions_light(native_text: string) -> NativeFunction[] {
         if is_ret_space {
             next_instruction = make_instruction_text(0, trim_text_local(substring(line, 4, line.length)));
         }
-        if is_ret_bare {
-            next_instruction = make_instruction_text(0, "");
-        }
-        if is_else_kw {
-            next_instruction = make_instruction_simple(4);
-        }
-        if is_endif_kw {
-            next_instruction = make_instruction_simple(5);
-        }
+        if is_ret_bare { next_instruction = make_instruction_text(0, ""); }
+        if is_else_kw { next_instruction = make_instruction_simple(4); }
+        if is_endif_kw { next_instruction = make_instruction_simple(5); }
         if is_if_kw {
             next_instruction = make_instruction_text(3, trim_text_local(substring(line, 4, line.length)));
         }
-        if is_loop_kw {
-            next_instruction = make_instruction_simple(8);
-        }
-        if is_endloop_kw {
-            next_instruction = make_instruction_simple(9);
-        }
+        if is_loop_kw { next_instruction = make_instruction_simple(8); }
+        if is_endloop_kw { next_instruction = make_instruction_simple(9); }
         if is_for_kw {
             if for_in_idx >= 0 {
                 next_instruction = make_instruction_for(for_target_raw, for_iterable_raw);
             }
         }
-        if is_endfor_kw {
-            next_instruction = make_instruction_simple(7);
-        }
-        if is_break_kw {
-            next_instruction = make_instruction_simple(10);
-        }
-        if is_continue_kw {
-            next_instruction = make_instruction_simple(11);
-        }
+        if is_endfor_kw { next_instruction = make_instruction_simple(7); }
+        if is_break_kw { next_instruction = make_instruction_simple(10); }
+        if is_continue_kw { next_instruction = make_instruction_simple(11); }
         if is_match_kw {
             next_instruction = make_instruction_text(12, match_expr_raw);
         }
-        if is_endmatch_kw {
-            next_instruction = make_instruction_simple(14);
-        }
+        if is_endmatch_kw { next_instruction = make_instruction_simple(14); }
         if is_case_kw {
             next_instruction = make_instruction_text(13, case_pattern_raw);
         }
@@ -527,15 +501,12 @@ fn recover_native_functions_light(native_text: string) -> NativeFunction[] {
 }
 
 // ── Light import recovery ────────────────────────────────────────────
-
 fn recover_native_imports_light(native_text: string) -> NativeImport[] {
     let lines = split_lines_local(native_text);
     let mut imports: NativeImport[] = [];
     let mut index: number = 0;
     loop {
-        if index >= lines.length {
-            break;
-        }
+        if index >= lines.length { break; }
         let line = trim_text_local(lines[index]);
         let is_import = starts_with_local(line, ".import ");
         let rest = trim_text_local(substring(line, 8, line.length));
@@ -557,7 +528,6 @@ fn recover_native_imports_light(native_text: string) -> NativeImport[] {
 }
 
 // ── Light struct recovery ────────────────────────────────────────────
-
 fn recover_native_structs_light(native_text: string) -> NativeStruct[] {
     let lines = split_lines_local(native_text);
     let mut structs: NativeStruct[] = [];
@@ -572,9 +542,7 @@ fn recover_native_structs_light(native_text: string) -> NativeStruct[] {
 
     let mut index: number = 0;
     loop {
-        if index >= lines.length {
-            break;
-        }
+        if index >= lines.length { break; }
         let line = trim_text_local(lines[index]);
         let mut _if240: boolean = false;
         if line.length == 0 { _if240 = true; }
@@ -606,7 +574,9 @@ fn recover_native_structs_light(native_text: string) -> NativeStruct[] {
             let mut _use_field_arrow: boolean = false;
             if field_arrow_idx < 0 { _use_field_arrow = true; }
             if field_arrow_idx >= 0 {
-                if field_legacy_arrow_idx < field_arrow_idx { _use_field_arrow = true; }
+                if field_legacy_arrow_idx < field_arrow_idx {
+                    _use_field_arrow = true;
+                }
             }
             if _use_field_arrow {
                 field_arrow_idx = field_legacy_arrow_idx;
@@ -649,9 +619,7 @@ fn recover_native_structs_light(native_text: string) -> NativeStruct[] {
                 let mut _if259: boolean = false;
                 if layout_size > 0 { _if259 = true; }
                 if layout_fields.length > 0 { _if259 = true; }
-                if _if259 {
-                    _if242 = true;
-                }
+                if _if259 { _if242 = true; }
             }
         }
         if _if242 {
@@ -692,14 +660,10 @@ fn recover_native_structs_light(native_text: string) -> NativeStruct[] {
         }
 
         if is_layout_struct {
-            if ls_size_idx >= 0 {
-                layout_size = ls_size_val;
-            }
+            if ls_size_idx >= 0 { layout_size = ls_size_val; }
         }
         if is_layout_struct {
-            if ls_align_idx >= 0 {
-                layout_align = ls_align_val;
-            }
+            if ls_align_idx >= 0 { layout_align = ls_align_val; }
         }
         if is_layout_struct {
             index += 1;
@@ -730,9 +694,7 @@ fn recover_native_structs_light(native_text: string) -> NativeStruct[] {
         let mut _if260: boolean = false;
         if layout_size > 0 { _if260 = true; }
         if layout_fields.length > 0 { _if260 = true; }
-        if _if260 {
-            _if243 = true;
-        }
+        if _if260 { _if243 = true; }
     }
     if _if243 {
         struct_layout = make_native_struct_layout(layout_size, layout_align, layout_fields);
@@ -749,12 +711,9 @@ fn recover_native_structs_light(native_text: string) -> NativeStruct[] {
 }
 
 // ── Higher-level recovery ────────────────────────────────────────────
-
 fn recover_functions_for_lowering(current_functions: NativeFunction[], native_text_override_path: string, artifact_text: string, debug_lowering: boolean) -> NativeFunction[] ![io] {
     let mut safe_functions = current_functions;
-    if safe_functions == null {
-        safe_functions = [];
-    }
+    if safe_functions == null { safe_functions = []; }
     let initial_function_count = sanitize_collection_length(safe_functions.length, 200000);
     if safe_functions.length != initial_function_count {
         if debug_lowering {
@@ -787,9 +746,7 @@ fn recover_functions_for_lowering(current_functions: NativeFunction[], native_te
                 let mut has_body_instructions = false;
                 let mut body_index: number = 0;
                 loop {
-                    if body_index >= initial_function_count {
-                        break;
-                    }
+                    if body_index >= initial_function_count { break; }
                     let function = safe_functions[body_index];
                     if !function.is_extern {
                         if function.instructions != null {
@@ -801,18 +758,14 @@ fn recover_functions_for_lowering(current_functions: NativeFunction[], native_te
                     }
                     body_index += 1;
                 }
-                if !has_body_instructions {
-                    use_expected = true;
-                }
+                if !has_body_instructions { use_expected = true; }
 
                 let mut index: number = 0;
                 loop {
                     let mut _if245: boolean = false;
                     if index >= initial_function_count { _if245 = true; }
                     if index >= expected_count { _if245 = true; }
-                    if _if245 {
-                        break;
-                    }
+                    if _if245 { break; }
                     let safe_name = trim_text_local(safe_functions[index].name);
                     let expected_name = trim_text_local(expected_functions[index].name);
                     let mut _if246: boolean = false;
@@ -840,9 +793,7 @@ fn recover_functions_for_lowering(current_functions: NativeFunction[], native_te
                     let mut light_has_body = false;
                     let mut light_index: number = 0;
                     loop {
-                        if light_index >= light_count {
-                            break;
-                        }
+                        if light_index >= light_count { break; }
                         let function = light_functions[light_index];
                         if !function.is_extern {
                             if function.instructions != null {
@@ -858,9 +809,7 @@ fn recover_functions_for_lowering(current_functions: NativeFunction[], native_te
                         replacement_functions = light_functions;
                     }
                     if debug_lowering {
-                        print.err(
-                            "emit-llvm: replacing suspicious parsed functions with stable function parse"
-                        );
+                        print.err("emit-llvm: replacing suspicious parsed functions with stable function parse");
                     }
                     safe_functions = replacement_functions;
                 }
@@ -874,9 +823,7 @@ fn recover_functions_for_lowering(current_functions: NativeFunction[], native_te
         recovery_text = native_text_override_path;
     }
     if recovery_text.length == 0 {
-        if artifact_text.length > 0 {
-            recovery_text = artifact_text;
-        }
+        if artifact_text.length > 0 { recovery_text = artifact_text; }
     }
     if recovery_text.length == 0 {
         if fs.exists("build/sailfin/emit-native.tmp") {
@@ -919,21 +866,17 @@ fn recover_functions_for_lowering(current_functions: NativeFunction[], native_te
     if fs.exists("build/sailfin/emit-native.tmp") {
         let disk_recovery_text = fs.readFile("build/sailfin/emit-native.tmp");
         let disk_recovery = recover_native_functions_light(disk_recovery_text);
-        if disk_recovery.length > 0 {
-            return disk_recovery;
-        }
+        if disk_recovery.length > 0 { return disk_recovery; }
     }
     return [];
 }
 
 // build_parse_result_from_text lives in lowering_core.sfn to preserve
 // cross-module symbol mangling compatibility with the v0.1.1 seed shims.
-
 // ── Enum recovery ───────────────────────────────────────────────────
 // Light line-scanner for .enum/.endenum blocks, analogous to
 // recover_native_structs_light.  Avoids the cross-module ABI corruption
 // that makes parse_native_enums_for_import return empty arrays.
-
 fn recover_native_enums_light(native_text: string) -> NativeEnum[] {
     let lines = split_lines_local(native_text);
     let mut enums: NativeEnum[] = [];
@@ -959,9 +902,7 @@ fn recover_native_enums_light(native_text: string) -> NativeEnum[] {
 
     let mut index: number = 0;
     loop {
-        if index >= lines.length {
-            break;
-        }
+        if index >= lines.length { break; }
         let line = trim_text_local(lines[index]);
         let mut _skip: boolean = false;
         if line.length == 0 { _skip = true; }

--- a/compiler/src/llvm/lowering/lowering_text_utils.sfn
+++ b/compiler/src/llvm/lowering/lowering_text_utils.sfn
@@ -3,13 +3,11 @@
 // Text processing utilities and structured data parsers used by the
 // LLVM lowering recovery code.  Extracted from lowering_core.sfn to
 // reduce per-file memory footprint during self-hosting compilation.
-
-import { substring, char_code } from "../../string_utils";
+import { char_code, substring } from "../../string_utils";
+import { LocalBinding, StringConstant } from "../types";
 import { index_of } from "../utils";
-import { StringConstant, LocalBinding } from "../types";
 
 // ── Character / string utilities ─────────────────────────────────────
-
 fn is_trim_char_local(ch: string) -> boolean {
     let code = char_code(ch);
     let mut _ret236: boolean = false;
@@ -21,67 +19,41 @@ fn is_trim_char_local(ch: string) -> boolean {
 }
 
 fn trim_text_local(value: string) -> string {
-    if value.length == 0 {
-        return "";
-    }
+    if value.length == 0 { return ""; }
     let mut start: number = 0;
     let mut end = value.length;
     loop {
-        if start >= end {
-            break;
-        }
-        if !is_trim_char_local(value[start]) {
-            break;
-        }
+        if start >= end { break; }
+        if !is_trim_char_local(value[start]) { break; }
         start += 1;
     }
     loop {
-        if end <= start {
-            break;
-        }
-        if !is_trim_char_local(value[end - 1]) {
-            break;
-        }
+        if end <= start { break; }
+        if !is_trim_char_local(value[end - 1]) { break; }
         end -= 1;
     }
-    if end <= start {
-        return "";
-    }
+    if end <= start { return ""; }
     return substring(value, start, end);
 }
 
 fn starts_with_local(value: string, prefix: string) -> boolean {
-    if prefix.length == 0 {
-        return true;
-    }
-    if value.length < prefix.length {
-        return false;
-    }
+    if prefix.length == 0 { return true; }
+    if value.length < prefix.length { return false; }
     let mut index: number = 0;
     loop {
-        if index >= prefix.length {
-            break;
-        }
-        if value[index] != prefix[index] {
-            return false;
-        }
+        if index >= prefix.length { break; }
+        if value[index] != prefix[index] { return false; }
         index += 1;
     }
     return true;
 }
 
 fn index_of_char_local(value: string, needle: string) -> number {
-    if needle.length == 0 {
-        return 0;
-    }
+    if needle.length == 0 { return 0; }
     let mut index: number = 0;
     loop {
-        if index >= value.length {
-            break;
-        }
-        if value[index] == needle {
-            return index;
-        }
+        if index >= value.length { break; }
+        if value[index] == needle { return index; }
         index += 1;
     }
     return -1;
@@ -93,9 +65,7 @@ fn split_lines_local(value: string) -> string[] {
     let mut start: number = 0;
     let mut index: number = 0;
     loop {
-        if index >= value_len {
-            break;
-        }
+        if index >= value_len { break; }
         let ch = value[index];
         if ch == "\n" {
             lines = lines.push(substring(value, start, index));
@@ -108,27 +78,20 @@ fn split_lines_local(value: string) -> string[] {
 }
 
 // ── Number / key-value parsing ───────────────────────────────────────
-
 fn parse_number_local(text: string) -> number {
     let trimmed = trim_text_local(text);
-    if trimmed.length == 0 {
-        return 0;
-    }
+    if trimmed.length == 0 { return 0; }
     let mut result: number = 0;
     let mut i: number = 0;
     loop {
-        if i >= trimmed.length {
-            break;
-        }
+        if i >= trimmed.length { break; }
         let ch = trimmed[i];
         let code = char_code(ch);
         let digit = code - char_code("0");
         let mut _if244: boolean = false;
         if digit < 0 { _if244 = true; }
         if digit > 9 { _if244 = true; }
-        if _if244 {
-            break;
-        }
+        if _if244 { break; }
         result = result * 10 + digit;
         i += 1;
     }
@@ -139,50 +102,37 @@ fn parse_number_local(text: string) -> number {
 // key_prefix is e.g. "size=", prefix_len is its length (e.g. 5).
 fn extract_kv_number(text: string, key_prefix: string, prefix_len: number) -> number {
     let key_idx = index_of(text, key_prefix);
-    if key_idx < 0 {
-        return 0;
-    }
+    if key_idx < 0 { return 0; }
     let val_start = key_idx + prefix_len;
     let rest = substring(text, val_start, text.length);
     let space_idx = index_of(rest, " ");
     let val_text_no_space = substring(text, val_start, text.length);
     let val_text_with_space = substring(text, val_start, val_start + space_idx);
-    if space_idx < 0 {
-        return parse_number_local(val_text_no_space);
-    }
+    if space_idx < 0 { return parse_number_local(val_text_no_space); }
     return parse_number_local(val_text_with_space);
 }
 
 // Extract a string value from "key=value" pattern in text.
 fn extract_kv_string(text: string, key_prefix: string, prefix_len: number) -> string {
     let key_idx = index_of(text, key_prefix);
-    if key_idx < 0 {
-        return "";
-    }
+    if key_idx < 0 { return ""; }
     let val_start = key_idx + prefix_len;
     let rest = substring(text, val_start, text.length);
     let space_idx = index_of(rest, " ");
-    if space_idx < 0 {
-        return substring(text, val_start, text.length);
-    }
+    if space_idx < 0 { return substring(text, val_start, text.length); }
     return substring(text, val_start, val_start + space_idx);
 }
 
 // ── Structured data parsers ──────────────────────────────────────────
-
 // Parse the tab-separated string constants file written by _write_lowered_function_files.
 // Format: one constant per line as "name\tcontent\tbyte_count".
 fn _parse_lowered_fn_string_constants(raw: string) -> StringConstant[] {
     let mut result: StringConstant[] = [];
-    if raw.length == 0 {
-        return result;
-    }
+    if raw.length == 0 { return result; }
     let file_lines = split_lines_local(raw);
     let mut i: number = 0;
     loop {
-        if i >= file_lines.length {
-            break;
-        }
+        if i >= file_lines.length { break; }
         let line = file_lines[i];
         if line.length == 0 {
             i += 1;
@@ -203,7 +153,9 @@ fn _parse_lowered_fn_string_constants(raw: string) -> StringConstant[] {
         let content = substring(rest, 0, tab2);
         let byte_text = substring(rest, tab2 + 1, rest.length);
         let byte_count = parse_number_local(byte_text);
-        result = result.push(StringConstant { name: name, content: content, byte_count: byte_count });
+        result = result.push(StringConstant {
+            name: name, content: content, byte_count: byte_count
+        });
         i += 1;
     }
     return result;
@@ -213,42 +165,28 @@ fn _parse_lowered_fn_string_constants(raw: string) -> StringConstant[] {
 // Format: name\tpointer\tllvm_type\ttype_annotation\tscope_id
 fn _parse_module_globals_locals(raw: string) -> LocalBinding[] {
     let mut result: LocalBinding[] = [];
-    if raw.length == 0 {
-        return result;
-    }
+    if raw.length == 0 { return result; }
     let file_lines = split_lines_local(raw);
     let mut i: number = 0;
     loop {
-        if i >= file_lines.length {
-            break;
-        }
+        if i >= file_lines.length { break; }
         let line = file_lines[i];
         i += 1;
-        if line.length == 0 {
-            continue;
-        }
+        if line.length == 0 { continue; }
         let tab1 = index_of_char_local(line, "\t");
-        if tab1 < 0 {
-            continue;
-        }
+        if tab1 < 0 { continue; }
         let name = substring(line, 0, tab1);
         let rest1 = substring(line, tab1 + 1, line.length);
         let tab2 = index_of_char_local(rest1, "\t");
-        if tab2 < 0 {
-            continue;
-        }
+        if tab2 < 0 { continue; }
         let pointer = substring(rest1, 0, tab2);
         let rest2 = substring(rest1, tab2 + 1, rest1.length);
         let tab3 = index_of_char_local(rest2, "\t");
-        if tab3 < 0 {
-            continue;
-        }
+        if tab3 < 0 { continue; }
         let llvm_type = substring(rest2, 0, tab3);
         let rest3 = substring(rest2, tab3 + 1, rest2.length);
         let tab4 = index_of_char_local(rest3, "\t");
-        if tab4 < 0 {
-            continue;
-        }
+        if tab4 < 0 { continue; }
         let type_annotation = substring(rest3, 0, tab4);
         let scope_id = substring(rest3, tab4 + 1, rest3.length);
         let binding = LocalBinding {
@@ -267,7 +205,6 @@ fn _parse_module_globals_locals(raw: string) -> LocalBinding[] {
 }
 
 // ── Quote-aware brace counting ───────────────────────────────────────
-
 // Return the net brace depth of `text` counting only `{` and `}` that
 // appear outside of double-quoted string literals.  For example:
 //   `collect_until(p, ["!", "{"])` → 0  (the `{` is inside quotes)
@@ -302,26 +239,19 @@ fn net_unquoted_brace_depth(text: string) -> number {
 }
 
 // ── Header recovery helpers ──────────────────────────────────────────
-
 fn recover_function_name_from_header(line: string) -> string {
-    if !starts_with_local(line, ".fn ") {
-        return "";
-    }
+    if !starts_with_local(line, ".fn ") { return ""; }
     let mut header = trim_text_local(substring(line, 4, line.length));
     if starts_with_local(header, "async ") {
         header = trim_text_local(substring(header, 6, header.length));
     }
     let open_paren = index_of_char_local(header, "(");
-    if open_paren < 0 {
-        return header;
-    }
+    if open_paren < 0 { return header; }
     return trim_text_local(substring(header, 0, open_paren));
 }
 
 fn recover_function_is_async_from_header(line: string) -> boolean {
-    if !starts_with_local(line, ".fn ") {
-        return false;
-    }
+    if !starts_with_local(line, ".fn ") { return false; }
     let header = trim_text_local(substring(line, 4, line.length));
     return starts_with_local(header, "async ");
 }

--- a/compiler/src/llvm/lowering/lowering_text_utils.sfn
+++ b/compiler/src/llvm/lowering/lowering_text_utils.sfn
@@ -197,7 +197,7 @@ fn _parse_module_globals_locals(raw: string) -> LocalBinding[] {
             ownership: null,
             consumed: false,
             scope_id: scope_id,
-            scope_depth: 0,
+            scope_depth: 0
         };
         result = result.push(binding);
     }

--- a/compiler/src/llvm/lowering/module_globals.sfn
+++ b/compiler/src/llvm/lowering/module_globals.sfn
@@ -6,53 +6,32 @@
 // AND at the end of loop bodies (places it in the afterloop block).
 // Therefore, every function with a loop MUST NOT have significant code
 // after the loop or at the end of the loop body.
-
 import { NativeBinding, NativeFunction } from "../../native_ir";
-
-import {
-    TypeContext,
-    LocalBinding,
-    ParameterBinding,
-    ModuleGlobalLoweringResult,
-    StringConstant,
-} from "../types";
-
-import {
-    append_string,
-    trim_text,
-    number_to_string,
-    matches_case_insensitive,
-    is_number_literal,
-    is_integer_literal,
-    is_boolean_literal,
-    sanitize_symbol,
-} from "../utils";
-
-import {
-    is_string_literal,
-    normalise_number_literal,
-} from "../expressions_literals";
-
-import {
-    default_return_literal,
-} from "../expressions_helpers";
-
-import {
-    empty_string_constant_set,
-    merge_string_constants,
-} from "../strings";
-
-import {
-    map_local_type,
-} from "../type_mapping";
-
 import { lower_expression } from "../expression_lowering/native/core";
 import { coerce_operand_to_type } from "../expression_lowering/native/core_operands";
 import { append_local_binding, find_local_binding } from "../expression_lowering/native/core_scopes";
-
+import { default_return_literal, } from "../expressions_helpers";
+import { is_string_literal, normalise_number_literal, } from "../expressions_literals";
+import { format_root_scope_id, } from "../lifetime";
+import { empty_string_constant_set, merge_string_constants, } from "../strings";
+import { map_local_type, } from "../type_mapping";
 import {
-    format_root_scope_id,
-} from "../lifetime";
+    LocalBinding,
+    ModuleGlobalLoweringResult,
+    ParameterBinding,
+    StringConstant,
+    TypeContext,
+} from "../types";
+import {
+    append_string,
+    is_boolean_literal,
+    is_integer_literal,
+    is_number_literal,
+    matches_case_insensitive,
+    number_to_string,
+    sanitize_symbol,
+    trim_text,
+} from "../utils";
 
 fn module_global_symbol(name: string) -> string {
     return "@global." + sanitize_symbol(name);
@@ -68,24 +47,18 @@ fn module_user_main_symbol(module_name: string) -> string {
 
 // Strip surrounding quotes from a string literal (e.g., `"hello"` -> `hello`).
 fn _strip_string_quotes(s: string) -> string {
-    if s.length < 2 {
-        return s;
-    }
+    if s.length < 2 { return s; }
     let first = s[0];
     let last = s[s.length - 1];
     let mut _is_quoted: boolean = false;
     if first == "\"" {
-        if last == "\"" {
-            _is_quoted = true;
-        }
+        if last == "\"" { _is_quoted = true; }
     }
     if _is_quoted {
         let mut result: string = "";
         let mut i: number = 1;
         loop {
-            if i >= s.length - 1 {
-                break;
-            }
+            if i >= s.length - 1 { break; }
             result = result + s[i];
             i += 1;
         }
@@ -99,20 +72,12 @@ fn _strip_string_quotes(s: string) -> string {
 // It appends preamble lines and local entries to accumulation files.
 // Returns "init" if the binding needs runtime initialization, "" otherwise.
 fn _process_one_binding(binding: NativeBinding, context: TypeContext, scope_id: string) -> string ![io] {
-    if binding == null {
-        return "";
-    }
+    if binding == null { return ""; }
     let mut name = binding.name;
-    if name == null {
-        return "";
-    }
-    if name.length == 0 {
-        return "";
-    }
+    if name == null { return ""; }
+    if name.length == 0 { return ""; }
     let mut raw_type_annotation = binding.type_annotation;
-    if raw_type_annotation == null {
-        raw_type_annotation = "";
-    }
+    if raw_type_annotation == null { raw_type_annotation = ""; }
     let mut type_annotation = trim_text(raw_type_annotation);
     let mut effective_type_annotation = raw_type_annotation;
     if type_annotation.length == 0 {
@@ -124,30 +89,20 @@ fn _process_one_binding(binding: NativeBinding, context: TypeContext, scope_id: 
             }
         }
     }
-    if type_annotation.length == 0 {
-        return "";
-    }
+    if type_annotation.length == 0 { return ""; }
     let global_name = module_global_symbol(name);
     let mut llvm_type: string = "";
     // Fast-path common primitive types
-    if type_annotation == "string" {
-        llvm_type = "i8*";
-    } else if type_annotation == "number" {
+    if type_annotation == "string" { llvm_type = "i8*"; } else if type_annotation == "number" {
         llvm_type = "double";
-    } else if type_annotation == "boolean" {
+    } else if type_annotation == "boolean" { llvm_type = "i1"; } else if type_annotation == "bool" {
         llvm_type = "i1";
-    } else if type_annotation == "bool" {
-        llvm_type = "i1";
-    } else if type_annotation == "i64" {
-        llvm_type = "i64";
-    } else if type_annotation == "i32" {
+    } else if type_annotation == "i64" { llvm_type = "i64"; } else if type_annotation == "i32" {
         llvm_type = "i32";
     } else if type_annotation.length > 0 {
         llvm_type = map_local_type(context, type_annotation);
     }
-    if llvm_type.length == 0 {
-        llvm_type = "double";
-    }
+    if llvm_type.length == 0 { llvm_type = "double"; }
 
     // Build preamble line(s) and append to accumulation file
     let mut needs_init_result: string = "";
@@ -169,9 +124,7 @@ fn _process_one_binding(binding: NativeBinding, context: TypeContext, scope_id: 
         }
         if !string_handled {
             _append_to_file("build/sailfin/.module_globals_preamble", global_name + " = internal global i8* null");
-            if binding.value != null {
-                needs_init_result = "init";
-            }
+            if binding.value != null { needs_init_result = "init"; }
         }
     } else {
         let mut initializer_text: string = default_return_literal(llvm_type);
@@ -205,9 +158,7 @@ fn _process_one_binding(binding: NativeBinding, context: TypeContext, scope_id: 
                     is_const = true;
                 }
             }
-            if !is_const {
-                needs_init_result = "init";
-            }
+            if !is_const { needs_init_result = "init"; }
         }
         _append_to_file("build/sailfin/.module_globals_preamble", global_name + " = internal global " + llvm_type + " " + initializer_text);
     }
@@ -222,12 +173,8 @@ fn _process_one_binding(binding: NativeBinding, context: TypeContext, scope_id: 
 // Append a line to a file (read existing content, append newline + new line).
 fn _append_to_file(path: string, line: string) ![io] {
     let mut existing: string = "";
-    if fs.exists(path) {
-        existing = fs.readFile(path);
-    }
-    if existing.length == 0 {
-        fs.writeFile(path, line);
-    } else {
+    if fs.exists(path) { existing = fs.readFile(path); }
+    if existing.length == 0 { fs.writeFile(path, line); } else {
         fs.writeFile(path, existing + "\n" + line);
     }
 }
@@ -280,9 +227,7 @@ fn lower_module_bindings_to_globals(bindings: NativeBinding[], context: TypeCont
         let binding = bindings[index];
         index += 1;
         let result = _process_one_binding(binding, context, scope_id);
-        if result == "init" {
-            needs_init = true;
-        }
+        if result == "init" { needs_init = true; }
     }
 
     // NOTE: Code below is UNREACHABLE when compiled by the v0.1.1 seed.

--- a/compiler/src/llvm/lowering/module_globals.sfn
+++ b/compiler/src/llvm/lowering/module_globals.sfn
@@ -10,17 +10,17 @@ import { NativeBinding, NativeFunction } from "../../native_ir";
 import { lower_expression } from "../expression_lowering/native/core";
 import { coerce_operand_to_type } from "../expression_lowering/native/core_operands";
 import { append_local_binding, find_local_binding } from "../expression_lowering/native/core_scopes";
-import { default_return_literal, } from "../expressions_helpers";
-import { is_string_literal, normalise_number_literal, } from "../expressions_literals";
-import { format_root_scope_id, } from "../lifetime";
-import { empty_string_constant_set, merge_string_constants, } from "../strings";
-import { map_local_type, } from "../type_mapping";
+import { default_return_literal } from "../expressions_helpers";
+import { is_string_literal, normalise_number_literal } from "../expressions_literals";
+import { format_root_scope_id } from "../lifetime";
+import { empty_string_constant_set, merge_string_constants } from "../strings";
+import { map_local_type } from "../type_mapping";
 import {
     LocalBinding,
     ModuleGlobalLoweringResult,
     ParameterBinding,
     StringConstant,
-    TypeContext,
+    TypeContext
 } from "../types";
 import {
     append_string,
@@ -30,7 +30,7 @@ import {
     matches_case_insensitive,
     number_to_string,
     sanitize_symbol,
-    trim_text,
+    trim_text
 } from "../utils";
 
 fn module_global_symbol(name: string) -> string {
@@ -115,15 +115,27 @@ fn _process_one_binding(binding: NativeBinding, context: TypeContext, scope_id: 
                 let str_content = _strip_string_quotes(str_val);
                 let str_len = str_content.length + 1;
                 let str_const_name = "@str.global." + sanitize_symbol(name);
-                let line1 = str_const_name + " = private constant [" + number_to_string(str_len) + " x i8] c\"" + str_content + "\\00\"";
-                let line2 = global_name + " = internal global i8* getelementptr ([" + number_to_string(str_len) + " x i8], [" + number_to_string(str_len) + " x i8]* " + str_const_name + ", i32 0, i32 0)";
+                let line1 = str_const_name + " = private constant ["
+                    + number_to_string(str_len)
+                    + " x i8] c\""
+                    + str_content
+                    + "\\00\"";
+                let line2 = global_name
+                    + " = internal global i8* getelementptr (["
+                    + number_to_string(str_len)
+                    + " x i8], ["
+                    + number_to_string(str_len)
+                    + " x i8]* "
+                    + str_const_name
+                    + ", i32 0, i32 0)";
                 _append_to_file("build/sailfin/.module_globals_preamble", line1);
                 _append_to_file("build/sailfin/.module_globals_preamble", line2);
                 string_handled = true;
             }
         }
         if !string_handled {
-            _append_to_file("build/sailfin/.module_globals_preamble", global_name + " = internal global i8* null");
+            _append_to_file("build/sailfin/.module_globals_preamble", global_name
+                + " = internal global i8* null");
             if binding.value != null { needs_init_result = "init"; }
         }
     } else {
@@ -160,11 +172,18 @@ fn _process_one_binding(binding: NativeBinding, context: TypeContext, scope_id: 
             }
             if !is_const { needs_init_result = "init"; }
         }
-        _append_to_file("build/sailfin/.module_globals_preamble", global_name + " = internal global " + llvm_type + " " + initializer_text);
+        _append_to_file("build/sailfin/.module_globals_preamble", global_name
+            + " = internal global "
+            + llvm_type
+            + " "
+            + initializer_text);
     }
 
     // Append local binding entry (tab-separated)
-    let local_line = name + "\t" + global_name + "\t" + llvm_type + "\t" + effective_type_annotation + "\t" + scope_id;
+    let local_line = name + "\t" + global_name + "\t" + llvm_type + "\t"
+        + effective_type_annotation
+        + "\t"
+        + scope_id;
     _append_to_file("build/sailfin/.module_globals_locals", local_line);
 
     return needs_init_result;
@@ -196,7 +215,7 @@ fn lower_module_bindings_to_globals(bindings: NativeBinding[], context: TypeCont
             needs_init_call: false,
             locals: [],
             string_constants: empty_string_constant_set(),
-            diagnostics: [],
+            diagnostics: []
         };
     }
 
@@ -239,6 +258,6 @@ fn lower_module_bindings_to_globals(bindings: NativeBinding[], context: TypeCont
         needs_init_call: needs_init,
         locals: [],
         string_constants: empty_string_constant_set(),
-        diagnostics: [],
+        diagnostics: []
     };
 }

--- a/compiler/src/llvm/lowering/phi.sfn
+++ b/compiler/src/llvm/lowering/phi.sfn
@@ -1,35 +1,30 @@
 // compiler/src/llvm/lowering/phi.sfn
 //
 // Phi-node and mutation materialization helpers.
-
 import { substring } from "../../string_utils";
-
+import { find_local_binding, } from "../expressions_bindings";
+import { format_temp_name, } from "../expressions_helpers";
 import {
     LocalBinding,
     LocalMutation,
+    MatchArmMutations,
+    MutationMaterializationResult,
     PhiMergeResult,
     PhiStoreEntry,
-    MutationMaterializationResult,
-    MatchArmMutations,
 } from "../types";
-
-import { append_string, join_with_separator, trim_text, extend_string_array, starts_with } from "../utils";
-
 import {
-    find_local_binding,
-} from "../expressions_bindings";
-
-import {
-    format_temp_name,
-} from "../expressions_helpers";
+    append_string,
+    extend_string_array,
+    join_with_separator,
+    starts_with,
+    trim_text
+} from "../utils";
 
 // Helper: Find preloaded value for a local by name
 fn find_preloaded_value(locals: LocalBinding[], preloaded_values: string[], name: string) -> string? {
     let mut local_index: number = 0;
     loop {
-        if local_index >= locals.length {
-            break;
-        }
+        if local_index >= locals.length { break; }
         let check_local = locals[local_index];
         if check_local.name == name {
             if local_index < preloaded_values.length {
@@ -46,25 +41,19 @@ fn collect_mutation_names(mutations: LocalMutation[]) -> string[] {
     let mut names: string[] = [];
     let mut index: number = 0;
     loop {
-        if index >= mutations.length {
-            break;
-        }
+        if index >= mutations.length { break; }
         let mutation = mutations[index];
         let mut already_added: boolean = false;
         let mut check_index: number = 0;
         loop {
-            if check_index >= names.length {
-                break;
-            }
+            if check_index >= names.length { break; }
             if names[check_index] == mutation.name {
                 already_added = true;
                 break;
             }
             check_index += 1;
         }
-        if !already_added {
-            names.push(mutation.name);
-        }
+        if !already_added { names.push(mutation.name); }
         index += 1;
     }
     return names;
@@ -74,37 +63,23 @@ fn collect_mutation_names(mutations: LocalMutation[]) -> string[] {
 fn find_mutation_for_name(mutations: LocalMutation[], name: string) -> LocalMutation? {
     let mut index: number = mutations.length;
     loop {
-        if index <= 0 {
-            break;
-        }
+        if index <= 0 { break; }
         index -= 1;
-        if mutations[index].name == name {
-            return mutations[index];
-        }
+        if mutations[index].name == name { return mutations[index]; }
     }
     return null;
 }
 
-fn find_mutation_for_name_at_label(
-    mutations: LocalMutation[],
-    name: string,
-    label: string
-) -> LocalMutation? {
-    if label.length == 0 {
-        return find_mutation_for_name(mutations, name);
-    }
+fn find_mutation_for_name_at_label(mutations: LocalMutation[], name: string, label: string) -> LocalMutation? {
+    if label.length == 0 { return find_mutation_for_name(mutations, name); }
 
     let mut index: number = mutations.length;
     loop {
-        if index <= 0 {
-            break;
-        }
+        if index <= 0 { break; }
         index -= 1;
         let mutation = mutations[index];
         if mutation.name == name {
-            if mutation.originating_label == label {
-                return mutation;
-            }
+            if mutation.originating_label == label { return mutation; }
         }
     }
 
@@ -117,12 +92,7 @@ fn join_strings(strings: string[], separator: string) -> string {
 }
 
 // Helper: Create phi and store lines for a single local (returns both lines separately)
-fn build_phi_and_store(
-    local: LocalBinding,
-    llvm_type: string,
-    phi_inputs: string[],
-    temp_index: number
-) -> PhiStoreEntry {
+fn build_phi_and_store(local: LocalBinding, llvm_type: string, phi_inputs: string[], temp_index: number) -> PhiStoreEntry {
     let phi_temp = format_temp_name(temp_index);
     let phi_input_str = join_strings(phi_inputs, ", ");
     let phi_line = "  " + phi_temp + " = phi " + llvm_type + " " + phi_input_str;
@@ -134,14 +104,10 @@ fn build_phi_and_store(
 fn find_last_label(lines: string[], fallback: string) -> string {
     let mut index: number = lines.length;
     loop {
-        if index <= 0 {
-            break;
-        }
+        if index <= 0 { break; }
         index -= 1;
         let line = lines[index];
-        if line.length == 0 {
-            continue;
-        }
+        if line.length == 0 { continue; }
         if substring(line, line.length - 1, line.length) == ":" {
             return substring(line, 0, line.length - 1);
         }
@@ -151,42 +117,24 @@ fn find_last_label(lines: string[], fallback: string) -> string {
 
 fn is_terminator_line(line: string) -> boolean {
     let trimmed = trim_text(line);
-    if trimmed.length == 0 {
-        return false;
-    }
-    if starts_with(trimmed, "br ") {
-        return true;
-    }
-    if starts_with(trimmed, "ret ") {
-        return true;
-    }
-    if trimmed == "unreachable" {
-        return true;
-    }
-    if starts_with(trimmed, "switch ") {
-        return true;
-    }
-    if starts_with(trimmed, "resume ") {
-        return true;
-    }
-    if starts_with(trimmed, "invoke ") {
-        return true;
-    }
+    if trimmed.length == 0 { return false; }
+    if starts_with(trimmed, "br ") { return true; }
+    if starts_with(trimmed, "ret ") { return true; }
+    if trimmed == "unreachable" { return true; }
+    if starts_with(trimmed, "switch ") { return true; }
+    if starts_with(trimmed, "resume ") { return true; }
+    if starts_with(trimmed, "invoke ") { return true; }
     return false;
 }
 
 fn insert_lines_before_index(lines: string[], index: number, insert_lines: string[]) -> string[] {
-    if insert_lines.length == 0 {
-        return lines;
-    }
+    if insert_lines.length == 0 { return lines; }
 
     let mut result: string[] = [];
     let mut line_idx: number = 0;
     let mut inserted: boolean = false;
     loop {
-        if line_idx >= lines.length {
-            break;
-        }
+        if line_idx >= lines.length { break; }
         if !inserted {
             if line_idx == index {
                 result = extend_string_array(result, insert_lines);
@@ -197,9 +145,7 @@ fn insert_lines_before_index(lines: string[], index: number, insert_lines: strin
         line_idx += 1;
     }
 
-    if !inserted {
-        result = extend_string_array(result, insert_lines);
-    }
+    if !inserted { result = extend_string_array(result, insert_lines); }
 
     return result;
 }
@@ -207,40 +153,26 @@ fn insert_lines_before_index(lines: string[], index: number, insert_lines: strin
 fn find_last_terminator_index(lines: string[]) -> number {
     let mut index: number = lines.length;
     loop {
-        if index <= 0 {
-            break;
-        }
+        if index <= 0 { break; }
         index -= 1;
-        if is_terminator_line(lines[index]) {
-            return index;
-        }
+        if is_terminator_line(lines[index]) { return index; }
     }
     return -1;
 }
 
-fn retarget_recent_mutations(
-    mutations: LocalMutation[],
-    start_index: number,
-    target_label: string
-) -> LocalMutation[] {
-    if target_label.length == 0 {
-        return mutations;
-    }
+fn retarget_recent_mutations(mutations: LocalMutation[], start_index: number, target_label: string) -> LocalMutation[] {
+    if target_label.length == 0 { return mutations; }
 
     let mut index: number = 0;
     let mut result: LocalMutation[] = [];
 
     loop {
-        if index >= mutations.length {
-            break;
-        }
+        if index >= mutations.length { break; }
 
         let mutation = mutations[index];
         if index >= start_index {
             let mut label = mutation.originating_label;
-            if label.length == 0 {
-                label = target_label;
-            }
+            if label.length == 0 { label = target_label; }
             let updated = LocalMutation {
                 name: mutation.name,
                 llvm_type: mutation.llvm_type,
@@ -249,9 +181,7 @@ fn retarget_recent_mutations(
                 originating_label: label,
             };
             result.push(updated);
-        } else {
-            result.push(mutation);
-        }
+        } else { result.push(mutation); }
 
         index += 1;
     }
@@ -259,21 +189,14 @@ fn retarget_recent_mutations(
     return result;
 }
 
-fn materialize_mutation_values_at_exit(
-    mutations: LocalMutation[],
-    locals: LocalBinding[],
-    lines: string[],
-    temp_index: number
-) -> MutationMaterializationResult {
+fn materialize_mutation_values_at_exit(mutations: LocalMutation[], locals: LocalBinding[], lines: string[], temp_index: number) -> MutationMaterializationResult {
     let mut current_temp: number = temp_index;
     let mut updated_mutations: LocalMutation[] = [];
     let mut load_lines: string[] = [];
 
     let mut index: number = 0;
     loop {
-        if index >= mutations.length {
-            break;
-        }
+        if index >= mutations.length { break; }
 
         let mutation = mutations[index];
         let local = find_local_binding(locals, mutation.name);
@@ -292,9 +215,7 @@ fn materialize_mutation_values_at_exit(
                 originating_label: mutation.originating_label,
             };
             updated_mutations.push(updated);
-        } else {
-            updated_mutations.push(mutation);
-        }
+        } else { updated_mutations.push(mutation); }
 
         index += 1;
     }
@@ -307,9 +228,7 @@ fn materialize_mutation_values_at_exit(
         } else {
             let mut append_idx: number = 0;
             loop {
-                if append_idx >= load_lines.length {
-                    break;
-                }
+                if append_idx >= load_lines.length { break; }
                 updated_lines.push(load_lines[append_idx]);
                 append_idx += 1;
             }
@@ -323,22 +242,14 @@ fn materialize_mutation_values_at_exit(
     };
 }
 
-fn materialize_mutation_values_at_label(
-    mutations: LocalMutation[],
-    locals: LocalBinding[],
-    lines: string[],
-    temp_index: number,
-    target_label: string
-) -> MutationMaterializationResult {
+fn materialize_mutation_values_at_label(mutations: LocalMutation[], locals: LocalBinding[], lines: string[], temp_index: number, target_label: string) -> MutationMaterializationResult {
     let mut updated_lines: string[] = lines;
     let mut current_temp: number = temp_index;
     let mut updated_mutations: LocalMutation[] = [];
 
     let mut index: number = 0;
     loop {
-        if index >= mutations.length {
-            break;
-        }
+        if index >= mutations.length { break; }
 
         let mutation = mutations[index];
         let local = find_local_binding(locals, mutation.name);
@@ -378,16 +289,7 @@ fn materialize_mutation_values_at_label(
     };
 }
 
-fn emit_phi_merges_for_straight_if(
-    mutations: LocalMutation[],
-    locals: LocalBinding[],
-    preloaded_values: string[],
-    base_label: string,
-    then_label: string,
-    then_exit_label: string,
-    lines: string[],
-    temp_index: number
-) -> PhiMergeResult {
+fn emit_phi_merges_for_straight_if(mutations: LocalMutation[], locals: LocalBinding[], preloaded_values: string[], base_label: string, then_label: string, then_exit_label: string, lines: string[], temp_index: number) -> PhiMergeResult {
     let allow_preloaded_fallback: boolean = false;
     let mut phi_lines: string[] = [];
     let mut store_lines: string[] = [];
@@ -396,9 +298,7 @@ fn emit_phi_merges_for_straight_if(
     let mut index: number = 0;
 
     loop {
-        if index >= mutated_names.length {
-            break;
-        }
+        if index >= mutated_names.length { break; }
 
         let name = mutated_names[index];
         let local = find_local_binding(locals, name);
@@ -417,10 +317,7 @@ fn emit_phi_merges_for_straight_if(
                             if then_source_label.length == 0 {
                                 then_source_label = then_label;
                             }
-                            let phi_inputs: string[] = [
-                                "[ " + mutation.value_name + ", %" + then_source_label + " ]",
-                                "[ " + preloaded_value + ", %" + base_label + " ]",
-                            ];
+                            let phi_inputs: string[] = ["[ " + mutation.value_name + ", %" + then_source_label + " ]", "[ " + preloaded_value + ", %" + base_label + " ]",];
                             let entry = build_phi_and_store(local, mutation.llvm_type, phi_inputs, current_temp);
                             phi_lines.push(entry.phi_line);
                             store_lines.push(entry.store_line);
@@ -439,20 +336,7 @@ fn emit_phi_merges_for_straight_if(
     return PhiMergeResult { lines: combined_lines, temp_index: current_temp };
 }
 
-fn emit_phi_merges_for_if_else(
-    then_mutations: LocalMutation[],
-    else_mutations: LocalMutation[],
-    locals: LocalBinding[],
-    preloaded_values: string[],
-    then_label: string,
-    else_label: string,
-    then_exit_label: string,
-    else_exit_label: string,
-    then_terminated: boolean,
-    else_terminated: boolean,
-    lines: string[],
-    temp_index: number
-) -> PhiMergeResult {
+fn emit_phi_merges_for_if_else(then_mutations: LocalMutation[], else_mutations: LocalMutation[], locals: LocalBinding[], preloaded_values: string[], then_label: string, else_label: string, then_exit_label: string, else_exit_label: string, then_terminated: boolean, else_terminated: boolean, lines: string[], temp_index: number) -> PhiMergeResult {
     let allow_preloaded_fallback: boolean = false;
     let mut phi_lines: string[] = [];
     let mut store_lines: string[] = [];
@@ -466,34 +350,26 @@ fn emit_phi_merges_for_if_else(
     // Add unique names from else branch
     let mut else_idx: number = 0;
     loop {
-        if else_idx >= else_names.length {
-            break;
-        }
+        if else_idx >= else_names.length { break; }
         let else_name = else_names[else_idx];
         let mut already_added: boolean = false;
         let mut check_idx: number = 0;
         loop {
-            if check_idx >= mutated_names.length {
-                break;
-            }
+            if check_idx >= mutated_names.length { break; }
             if mutated_names[check_idx] == else_name {
                 already_added = true;
                 break;
             }
             check_idx += 1;
         }
-        if !already_added {
-            mutated_names.push(else_name);
-        }
+        if !already_added { mutated_names.push(else_name); }
         else_idx += 1;
     }
 
     // For each mutated name, emit a phi node
     let mut name_idx: number = 0;
     loop {
-        if name_idx >= mutated_names.length {
-            break;
-        }
+        if name_idx >= mutated_names.length { break; }
         let name = mutated_names[name_idx];
 
         let local = find_local_binding(locals, name);
@@ -510,9 +386,7 @@ fn emit_phi_merges_for_if_else(
 
             // Determine the LLVM type (prefer found mutation, fallback to local)
             let mut llvm_type: string = local.llvm_type;
-            if then_mutation != null {
-                llvm_type = then_mutation.llvm_type;
-            }
+            if then_mutation != null { llvm_type = then_mutation.llvm_type; }
             if else_mutation != null {
                 if else_mutation.llvm_type.length > 0 {
                     llvm_type = else_mutation.llvm_type;
@@ -528,17 +402,13 @@ fn emit_phi_merges_for_if_else(
                     if then_source_label.length == 0 {
                         if then_exit_label.length > 0 {
                             then_source_label = then_exit_label;
-                        } else {
-                            then_source_label = then_label;
-                        }
+                        } else { then_source_label = then_label; }
                     }
                     phi_inputs.push("[ " + then_mutation.value_name + ", %" + then_source_label + " ]");
                 } else {
                     let mut _elif282: boolean = false;
                     if preloaded_value != null {
-                        if allow_preloaded_fallback {
-                            _elif282 = true;
-                        }
+                        if allow_preloaded_fallback { _elif282 = true; }
                     }
                     if _elif282 {
                         let mut fallback_label: string = then_exit_label;
@@ -556,17 +426,13 @@ fn emit_phi_merges_for_if_else(
                     if else_source_label.length == 0 {
                         if else_exit_label.length > 0 {
                             else_source_label = else_exit_label;
-                        } else {
-                            else_source_label = else_label;
-                        }
+                        } else { else_source_label = else_label; }
                     }
                     phi_inputs.push("[ " + else_mutation.value_name + ", %" + else_source_label + " ]");
                 } else {
                     let mut _elif283: boolean = false;
                     if preloaded_value != null {
-                        if allow_preloaded_fallback {
-                            _elif283 = true;
-                        }
+                        if allow_preloaded_fallback { _elif283 = true; }
                     }
                     if _elif283 {
                         let mut fallback_label: string = else_exit_label;
@@ -577,7 +443,6 @@ fn emit_phi_merges_for_if_else(
                     }
                 }
             }
-
             // Skip phi emission — alloca-store approach is used instead.
             // The then/else blocks already store directly to allocas, so phi
             // nodes are redundant. Disabling them avoids broken phi output
@@ -592,13 +457,7 @@ fn emit_phi_merges_for_if_else(
     return PhiMergeResult { lines: combined_lines, temp_index: current_temp };
 }
 
-fn emit_phi_merges_for_match(
-    arm_mutations_list: MatchArmMutations[],
-    locals: LocalBinding[],
-    preloaded_values: string[],
-    lines: string[],
-    temp_index: number
-) -> PhiMergeResult {
+fn emit_phi_merges_for_match(arm_mutations_list: MatchArmMutations[], locals: LocalBinding[], preloaded_values: string[], lines: string[], temp_index: number) -> PhiMergeResult {
     // Phi emission disabled — alloca-store approach is used instead.
     // Each match arm already stores directly to allocas, so phi nodes are
     // redundant. Disabling avoids broken phi output from corrupted

--- a/compiler/src/llvm/lowering/phi.sfn
+++ b/compiler/src/llvm/lowering/phi.sfn
@@ -2,15 +2,15 @@
 //
 // Phi-node and mutation materialization helpers.
 import { substring } from "../../string_utils";
-import { find_local_binding, } from "../expressions_bindings";
-import { format_temp_name, } from "../expressions_helpers";
+import { find_local_binding } from "../expressions_bindings";
+import { format_temp_name } from "../expressions_helpers";
 import {
     LocalBinding,
     LocalMutation,
     MatchArmMutations,
     MutationMaterializationResult,
     PhiMergeResult,
-    PhiStoreEntry,
+    PhiStoreEntry
 } from "../types";
 import {
     append_string,
@@ -96,7 +96,9 @@ fn build_phi_and_store(local: LocalBinding, llvm_type: string, phi_inputs: strin
     let phi_temp = format_temp_name(temp_index);
     let phi_input_str = join_strings(phi_inputs, ", ");
     let phi_line = "  " + phi_temp + " = phi " + llvm_type + " " + phi_input_str;
-    let store_line = "  store " + llvm_type + " " + phi_temp + ", " + llvm_type + "* " + local.pointer;
+    let store_line = "  store " + llvm_type + " " + phi_temp + ", " + llvm_type
+        + "* "
+        + local.pointer;
     return PhiStoreEntry { phi_line: phi_line, store_line: store_line };
 }
 
@@ -178,7 +180,7 @@ fn retarget_recent_mutations(mutations: LocalMutation[], start_index: number, ta
                 llvm_type: mutation.llvm_type,
                 value_name: mutation.value_name,
                 span: mutation.span,
-                originating_label: label,
+                originating_label: label
             };
             result.push(updated);
         } else { result.push(mutation); }
@@ -204,7 +206,11 @@ fn materialize_mutation_values_at_exit(mutations: LocalMutation[], locals: Local
         if local != null {
             let load_temp = format_temp_name(current_temp);
             current_temp += 1;
-            let load_line = "  " + load_temp + " = load " + local.llvm_type + ", " + local.llvm_type + "* " + local.pointer;
+            let load_line = "  " + load_temp + " = load " + local.llvm_type
+                + ", "
+                + local.llvm_type
+                + "* "
+                + local.pointer;
             load_lines.push(load_line);
 
             let updated = LocalMutation {
@@ -212,7 +218,7 @@ fn materialize_mutation_values_at_exit(mutations: LocalMutation[], locals: Local
                 llvm_type: mutation.llvm_type,
                 value_name: load_temp,
                 span: mutation.span,
-                originating_label: mutation.originating_label,
+                originating_label: mutation.originating_label
             };
             updated_mutations.push(updated);
         } else { updated_mutations.push(mutation); }
@@ -238,7 +244,7 @@ fn materialize_mutation_values_at_exit(mutations: LocalMutation[], locals: Local
     return MutationMaterializationResult {
         mutations: updated_mutations,
         lines: updated_lines,
-        temp_index: current_temp,
+        temp_index: current_temp
     };
 }
 
@@ -257,7 +263,11 @@ fn materialize_mutation_values_at_label(mutations: LocalMutation[], locals: Loca
         if local != null {
             let load_temp = format_temp_name(current_temp);
             current_temp += 1;
-            let load_line = "  " + load_temp + " = load " + local.llvm_type + ", " + local.llvm_type + "* " + local.pointer;
+            let load_line = "  " + load_temp + " = load " + local.llvm_type
+                + ", "
+                + local.llvm_type
+                + "* "
+                + local.pointer;
             updated_lines.push(load_line);
 
             let updated = LocalMutation {
@@ -265,7 +275,7 @@ fn materialize_mutation_values_at_label(mutations: LocalMutation[], locals: Loca
                 llvm_type: local.llvm_type,
                 value_name: load_temp,
                 span: mutation.span,
-                originating_label: target_label,
+                originating_label: target_label
             };
             updated_mutations.push(updated);
         } else {
@@ -274,7 +284,7 @@ fn materialize_mutation_values_at_label(mutations: LocalMutation[], locals: Loca
                 llvm_type: mutation.llvm_type,
                 value_name: mutation.value_name,
                 span: mutation.span,
-                originating_label: target_label,
+                originating_label: target_label
             };
             updated_mutations.push(fallback);
         }
@@ -285,7 +295,7 @@ fn materialize_mutation_values_at_label(mutations: LocalMutation[], locals: Loca
     return MutationMaterializationResult {
         mutations: updated_mutations,
         lines: updated_lines,
-        temp_index: current_temp,
+        temp_index: current_temp
     };
 }
 
@@ -317,7 +327,14 @@ fn emit_phi_merges_for_straight_if(mutations: LocalMutation[], locals: LocalBind
                             if then_source_label.length == 0 {
                                 then_source_label = then_label;
                             }
-                            let phi_inputs: string[] = ["[ " + mutation.value_name + ", %" + then_source_label + " ]", "[ " + preloaded_value + ", %" + base_label + " ]",];
+                            let phi_inputs: string[] = ["[ " + mutation.value_name
+                                + ", %"
+                                + then_source_label
+                                + " ]", "[ "
+                                + preloaded_value
+                                + ", %"
+                                + base_label
+                                + " ]",];
                             let entry = build_phi_and_store(local, mutation.llvm_type, phi_inputs, current_temp);
                             phi_lines.push(entry.phi_line);
                             store_lines.push(entry.store_line);
@@ -404,7 +421,9 @@ fn emit_phi_merges_for_if_else(then_mutations: LocalMutation[], else_mutations: 
                             then_source_label = then_exit_label;
                         } else { then_source_label = then_label; }
                     }
-                    phi_inputs.push("[ " + then_mutation.value_name + ", %" + then_source_label + " ]");
+                    phi_inputs.push("[ " + then_mutation.value_name + ", %"
+                        + then_source_label
+                        + " ]");
                 } else {
                     let mut _elif282: boolean = false;
                     if preloaded_value != null {
@@ -415,7 +434,9 @@ fn emit_phi_merges_for_if_else(then_mutations: LocalMutation[], else_mutations: 
                         if fallback_label.length == 0 {
                             fallback_label = then_label;
                         }
-                        phi_inputs.push("[ " + preloaded_value + ", %" + fallback_label + " ]");
+                        phi_inputs.push("[ " + preloaded_value + ", %"
+                            + fallback_label
+                            + " ]");
                     }
                 }
             }
@@ -428,7 +449,9 @@ fn emit_phi_merges_for_if_else(then_mutations: LocalMutation[], else_mutations: 
                             else_source_label = else_exit_label;
                         } else { else_source_label = else_label; }
                     }
-                    phi_inputs.push("[ " + else_mutation.value_name + ", %" + else_source_label + " ]");
+                    phi_inputs.push("[ " + else_mutation.value_name + ", %"
+                        + else_source_label
+                        + " ]");
                 } else {
                     let mut _elif283: boolean = false;
                     if preloaded_value != null {
@@ -439,7 +462,9 @@ fn emit_phi_merges_for_if_else(then_mutations: LocalMutation[], else_mutations: 
                         if fallback_label.length == 0 {
                             fallback_label = else_label;
                         }
-                        phi_inputs.push("[ " + preloaded_value + ", %" + fallback_label + " ]");
+                        phi_inputs.push("[ " + preloaded_value + ", %"
+                            + fallback_label
+                            + " ]");
                     }
                 }
             }

--- a/compiler/src/llvm/mod.sfn
+++ b/compiler/src/llvm/mod.sfn
@@ -70,7 +70,7 @@ export {
 
     // Import types
     ImportedModuleContext,
-    LayoutManifestApplication,
+    LayoutManifestApplication
 } from "./types";
 
 // Re-export utility functions
@@ -88,7 +88,7 @@ export {
     is_identifier_start_char,
     is_identifier_part_char,
     find_parameter_binding as find_parameter_binding_util,
-    merge_parameter_bindings,
+    merge_parameter_bindings
 } from "./utils";
 
 // Re-export string constant management
@@ -98,7 +98,7 @@ export {
     merge_string_constants,
     find_string_constant,
     render_string_constants,
-    escape_string_for_llvm,
+    escape_string_for_llvm
 } from "./strings";
 
 // Re-export effect system functions
@@ -109,14 +109,14 @@ export {
     build_capability_manifest,
     collect_function_borrow_effects,
     collect_expression_borrow_effects,
-    collect_runtime_helper_targets,
+    collect_runtime_helper_targets
 } from "./effects";
 
 // Re-export runtime helper functions
 export {
     runtime_helper_descriptors,
     find_runtime_helper,
-    append_runtime_helper,
+    append_runtime_helper
 } from "./runtime_helpers";
 
 // Re-export type mapping functions
@@ -127,11 +127,11 @@ export {
     map_local_type,
     map_struct_type_annotation,
     map_struct_field_annotation,
-    unwrap_move_wrapper,
+    unwrap_move_wrapper
 } from "./type_mapping";
 
 // Re-export TypeContext building functions
-export { build_type_context, empty_type_context, } from "./type_context";
+export { build_type_context, empty_type_context } from "./type_context";
 
 // Re-export TypeContext query/lookup functions
 export {
@@ -139,7 +139,7 @@ export {
     find_struct_info_by_llvm_name,
     find_enum_info_by_llvm_type,
     find_interface_info_by_name,
-    resolve_struct_info_for_literal,
+    resolve_struct_info_for_literal
 } from "./type_context_queries";
 
 // Re-export import handling functions
@@ -147,7 +147,7 @@ export {
     load_imported_layout_manifests,
     collect_imported_module_context,
     resolve_import_module_slug,
-    apply_layout_manifest_to_module,
+    apply_layout_manifest_to_module
 } from "./imports";
 
 // Re-export rendering functions
@@ -156,7 +156,7 @@ export {
     render_runtime_helper_declarations,
     render_imported_function_declarations,
     render_struct_type_definitions,
-    render_enum_type_definitions,
+    render_enum_type_definitions
 } from "./rendering";
 
 // Re-export rendering helper functions
@@ -173,7 +173,7 @@ export {
     is_entry_point,
     collect_exported_symbol_names,
     is_exported_symbol,
-    should_internalize_function,
+    should_internalize_function
 } from "./rendering_helpers";
 
 // Re-export lifetime/borrow tracking functions
@@ -200,7 +200,7 @@ export {
     is_scope_descendant,
     format_use_after_move_message,
     format_span_location,
-    format_suspension_location,
+    format_suspension_location
 } from "./lifetime";
 
 // Re-export expression helper functions (from decomposed submodules)
@@ -209,7 +209,7 @@ export {
     find_parameter_binding,
     mark_parameter_consumed,
     mark_local_consumed,
-    reset_local_consumption,
+    reset_local_consumption
 } from "./expressions_bindings";
 
 export {
@@ -220,7 +220,7 @@ export {
     is_string_literal,
     is_character_literal,
     get_character_literal_value,
-    normalise_number_literal,
+    normalise_number_literal
 } from "./expressions_literals";
 
 export {
@@ -234,7 +234,7 @@ export {
     default_return_literal,
     format_temp_name,
     format_local_pointer_name,
-    format_typed_operand,
+    format_typed_operand
 } from "./expressions_helpers";
 
 export {
@@ -242,7 +242,7 @@ export {
     is_binary_minus,
     is_binary_star,
     find_top_level_range_separator,
-    find_top_level_union_separator,
+    find_top_level_union_separator
 } from "./expressions_operators";
 
 export {
@@ -252,5 +252,5 @@ export {
     parse_inline_let_expression,
     parse_ternary_expression,
     parse_raw_address_expression,
-    parse_cast_expression,
+    parse_cast_expression
 } from "./expressions_parsing";

--- a/compiler/src/llvm/mod.sfn
+++ b/compiler/src/llvm/mod.sfn
@@ -15,7 +15,6 @@
 //   - rendering.sfn:      LLVM IR rendering (types, declarations, metadata)
 //   - lifetime.sfn:       Lifetime/borrow tracking and validation
 //   - expressions.sfn:    Expression parsing and lowering helpers
-
 // Re-export all public types
 export {
     // Core types
@@ -132,10 +131,7 @@ export {
 } from "./type_mapping";
 
 // Re-export TypeContext building functions
-export {
-    build_type_context,
-    empty_type_context,
-} from "./type_context";
+export { build_type_context, empty_type_context, } from "./type_context";
 
 // Re-export TypeContext query/lookup functions
 export {

--- a/compiler/src/llvm/rendering.sfn
+++ b/compiler/src/llvm/rendering.sfn
@@ -40,7 +40,8 @@ fn render_trait_metadata_comments(metadata: TraitMetadata) -> string[] {
         let interface = metadata.interfaces[index];
         let mut header: string = "; interface " + interface.name;
         if interface.type_parameters.length > 0 {
-            header = header + "<" + join_with_separator(interface.type_parameters, ", ") + ">";
+            header = header + "<" + join_with_separator(interface.type_parameters, ", ")
+                + ">";
         }
         interface_lines.push(header);
 
@@ -63,7 +64,9 @@ fn render_trait_metadata_comments(metadata: TraitMetadata) -> string[] {
     loop {
         if index >= metadata.implementations.length { break; }
         let implementation = metadata.implementations[index];
-        let mut line: string = "; struct " + implementation.struct_name + " implements " + join_with_separator(implementation.interfaces, ", ");
+        let mut line: string = "; struct " + implementation.struct_name
+            + " implements "
+            + join_with_separator(implementation.interfaces, ", ");
         struct_lines.push(line);
         index += 1;
     }
@@ -129,13 +132,19 @@ fn render_runtime_helper_declarations(used_targets: string[], local_functions: N
             // Emit capability metadata comment if the intrinsic has effects
             if descriptor.effects.length > 0 {
                 let effects_text = join_with_separator(descriptor.effects, ", ");
-                lines.push("; intrinsic " + descriptor.symbol + " requires capabilities: ![" + effects_text + "]");
+                lines.push("; intrinsic " + descriptor.symbol
+                    + " requires capabilities: !["
+                    + effects_text
+                    + "]");
             }
             let mut parameter_text: string = "";
             if descriptor.parameter_types.length > 0 {
                 parameter_text = join_with_separator(descriptor.parameter_types, ", ");
             }
-            let line = "declare " + descriptor.return_type + " @" + descriptor.symbol + "(" + parameter_text + ")";
+            let line = "declare " + descriptor.return_type + " @" + descriptor.symbol
+                + "("
+                + parameter_text
+                + ")";
             lines.push(line);
             declared_symbols.push(descriptor.symbol);
             // Also declare the target name if it differs from the symbol.
@@ -146,7 +155,12 @@ fn render_runtime_helper_declarations(used_targets: string[], local_functions: N
                 if sanitized_target != descriptor.symbol {
                     if !string_array_contains(declared_symbols, sanitized_target) {
                         if !string_array_contains(local_symbols, sanitized_target) {
-                            let alias_line = "declare " + descriptor.return_type + " @" + sanitized_target + "(" + parameter_text + ")";
+                            let alias_line = "declare " + descriptor.return_type
+                                + " @"
+                                + sanitized_target
+                                + "("
+                                + parameter_text
+                                + ")";
                             lines.push(alias_line);
                             declared_symbols.push(sanitized_target);
                         }
@@ -218,7 +232,9 @@ fn render_imported_function_declarations(imported_functions: NativeFunction[], l
         }
         let param_types = collect_parameter_types(context, function.parameters, function.name);
         let param_text = join_with_separator(param_types, ", ");
-        let line = "declare " + return_type + " @" + sanitized_name + "(" + param_text + ")";
+        let line = "declare " + return_type + " @" + sanitized_name + "("
+            + param_text
+            + ")";
         lines.push(line);
         index += 1;
     }
@@ -490,7 +506,9 @@ fn render_enum_type_definitions(context: TypeContext) -> string[] {
                 payload_storage_size += (elem_size - remainder);
             }
             let elem_count = payload_storage_size / elem_size;
-            payload_repr = ", [" + number_to_string(elem_count) + " x " + elem_type + "]";
+            payload_repr = ", [" + number_to_string(elem_count) + " x "
+                + elem_type
+                + "]";
         }
 
         let body = "{ " + llvm_tag_type + pad_repr + payload_repr + " }";

--- a/compiler/src/llvm/rendering.sfn
+++ b/compiler/src/llvm/rendering.sfn
@@ -2,39 +2,41 @@
 //
 // LLVM IR rendering functions for declarations and metadata comments.
 // Handles trait metadata comments, runtime helper declarations, and function declarations.
-
 import { NativeFunction, NativeParameter } from "../native_ir";
 import { substring } from "../string_utils";
-import { TypeContext, TraitMetadata, RuntimeHelperDescriptor } from "./types";
-import { trim_text, append_string, join_with_separator, string_array_contains, sanitize_symbol, number_to_string, index_of } from "./utils";
+import {
+    collect_parameter_types,
+    extract_struct_type_from_llvm,
+    render_interface_signature
+} from "./rendering_helpers";
 import { runtime_helper_descriptors } from "./runtime_helpers";
-import { map_return_type, map_parameter_type } from "./type_mapping";
-import { render_interface_signature, collect_parameter_types, extract_struct_type_from_llvm } from "./rendering_helpers";
+import { map_parameter_type, map_return_type } from "./type_mapping";
+import { RuntimeHelperDescriptor, TraitMetadata, TypeContext } from "./types";
+import {
+    append_string,
+    index_of,
+    join_with_separator,
+    number_to_string,
+    sanitize_symbol,
+    string_array_contains,
+    trim_text
+} from "./utils";
 
 fn clamp_collection_length(value: number, max: number) -> number {
-    if value != value {
-        return 0;
-    }
-    if value < 0 {
-        return 0;
-    }
-    if value > max {
-        return max;
-    }
+    if value != value { return 0; }
+    if value < 0 { return 0; }
+    if value > max { return max; }
     return value;
 }
 
 // =============================================================================
 // Trait Metadata Comments
 // =============================================================================
-
 fn render_trait_metadata_comments(metadata: TraitMetadata) -> string[] {
     let mut interface_lines: string[] = [];
     let mut index: number = 0;
     loop {
-        if index >= metadata.interfaces.length {
-            break;
-        }
+        if index >= metadata.interfaces.length { break; }
         let interface = metadata.interfaces[index];
         let mut header: string = "; interface " + interface.name;
         if interface.type_parameters.length > 0 {
@@ -44,9 +46,7 @@ fn render_trait_metadata_comments(metadata: TraitMetadata) -> string[] {
 
         let mut signature_index: number = 0;
         loop {
-            if signature_index >= interface.signatures.length {
-                break;
-            }
+            if signature_index >= interface.signatures.length { break; }
             let signature = interface.signatures[signature_index];
             let rendered = render_interface_signature(signature);
             interface_lines.push(";   " + rendered);
@@ -61,9 +61,7 @@ fn render_trait_metadata_comments(metadata: TraitMetadata) -> string[] {
     let mut struct_lines: string[] = [];
     index = 0;
     loop {
-        if index >= metadata.implementations.length {
-            break;
-        }
+        if index >= metadata.implementations.length { break; }
         let implementation = metadata.implementations[index];
         let mut line: string = "; struct " + implementation.struct_name + " implements " + join_with_separator(implementation.interfaces, ", ");
         struct_lines.push(line);
@@ -71,9 +69,7 @@ fn render_trait_metadata_comments(metadata: TraitMetadata) -> string[] {
     }
 
     if interface_lines.length == 0 {
-        if struct_lines.length == 0 {
-            return [];
-        }
+        if struct_lines.length == 0 { return []; }
     }
 
     let mut lines: string[] = [];
@@ -85,9 +81,7 @@ fn render_trait_metadata_comments(metadata: TraitMetadata) -> string[] {
         _ci0 += 1;
     }
     if interface_lines.length > 0 {
-        if struct_lines.length > 0 {
-            lines.push(";");
-        }
+        if struct_lines.length > 0 { lines.push(";"); }
     }
     let mut _ci1: number = 0;
     loop {
@@ -102,18 +96,13 @@ fn render_trait_metadata_comments(metadata: TraitMetadata) -> string[] {
 // =============================================================================
 // Runtime Helper Declarations
 // =============================================================================
-
 fn render_runtime_helper_declarations(used_targets: string[], local_functions: NativeFunction[]) -> string[] {
-    if used_targets.length == 0 {
-        return [];
-    }
+    if used_targets.length == 0 { return []; }
     // Build list of local function symbols to avoid declaring helpers that are defined locally
     let mut local_symbols: string[] = [];
     let mut local_index: number = 0;
     loop {
-        if local_index >= local_functions.length {
-            break;
-        }
+        if local_index >= local_functions.length { break; }
         local_symbols.push(sanitize_symbol(local_functions[local_index].name));
         local_index += 1;
     }
@@ -123,9 +112,7 @@ fn render_runtime_helper_declarations(used_targets: string[], local_functions: N
     let descriptors = runtime_helper_descriptors();
     let mut index: number = 0;
     loop {
-        if index >= descriptors.length {
-            break;
-        }
+        if index >= descriptors.length { break; }
         let descriptor = descriptors[index];
         if string_array_contains(used_targets, descriptor.target) {
             // Skip if this helper is actually defined locally (not just a runtime intrinsic)
@@ -175,19 +162,14 @@ fn render_runtime_helper_declarations(used_targets: string[], local_functions: N
 // =============================================================================
 // Imported Function Declarations
 // =============================================================================
-
 fn render_imported_function_declarations(imported_functions: NativeFunction[], local_functions: NativeFunction[], context: TypeContext) -> string[] {
-    if imported_functions.length == 0 {
-        return [];
-    }
+    if imported_functions.length == 0 { return []; }
     // Get all runtime helper symbols to avoid duplicates
     let helper_descriptors = runtime_helper_descriptors();
     let mut helper_symbols: string[] = [];
     let mut helper_index: number = 0;
     loop {
-        if helper_index >= helper_descriptors.length {
-            break;
-        }
+        if helper_index >= helper_descriptors.length { break; }
         helper_symbols.push(helper_descriptors[helper_index].symbol);
         let helper_target = sanitize_symbol(helper_descriptors[helper_index].target);
         if !string_array_contains(helper_symbols, helper_target) {
@@ -200,9 +182,7 @@ fn render_imported_function_declarations(imported_functions: NativeFunction[], l
     let mut local_symbols: string[] = [];
     let mut local_index: number = 0;
     loop {
-        if local_index >= local_functions.length {
-            break;
-        }
+        if local_index >= local_functions.length { break; }
         local_symbols.push(sanitize_symbol(local_functions[local_index].name));
         local_index += 1;
     }
@@ -211,15 +191,17 @@ fn render_imported_function_declarations(imported_functions: NativeFunction[], l
     let mut emitted_declarations: string[] = [];
     let mut index: number = 0;
     loop {
-        if index >= imported_functions.length {
-            break;
-        }
+        if index >= imported_functions.length { break; }
         let function = imported_functions[index];
         let sanitized_name = sanitize_symbol(function.name);
         // Skip if this function is already declared as a runtime helper or defined locally
         let mut _if285: boolean = false;
-        if string_array_contains(helper_symbols, sanitized_name) { _if285 = true; }
-        if string_array_contains(local_symbols, sanitized_name) { _if285 = true; }
+        if string_array_contains(helper_symbols, sanitized_name) {
+            _if285 = true;
+        }
+        if string_array_contains(local_symbols, sanitized_name) {
+            _if285 = true;
+        }
         if _if285 {
             index += 1;
             continue;
@@ -246,44 +228,30 @@ fn render_imported_function_declarations(imported_functions: NativeFunction[], l
 // =============================================================================
 // Struct Type Definitions
 // =============================================================================
-
 fn render_struct_type_definitions(context: TypeContext, functions: NativeFunction[]) -> string[] {
     let mut _if286: boolean = false;
     if context.structs == null { _if286 = true; }
     if context.enums == null { _if286 = true; }
-    if _if286 {
-        return [];
-    }
+    if _if286 { return []; }
     let mut _if287: boolean = false;
     if context.structs.length > 10000 { _if287 = true; }
     if context.enums.length > 10000 { _if287 = true; }
-    if _if287 {
-        return [];
-    }
-    if functions == null {
-        return [];
-    }
-    if functions.length > 20000 {
-        return [];
-    }
+    if _if287 { return []; }
+    if functions == null { return []; }
+    if functions.length > 20000 { return []; }
     let mut lines: string[] = [];
-
 
     // First pass: collect all referenced struct types
     let mut referenced_types: string[] = [];
     let mut struct_index: number = 0;
     let struct_count = clamp_collection_length(context.structs.length, 10000);
     loop {
-        if struct_index >= struct_count {
-            break;
-        }
+        if struct_index >= struct_count { break; }
         let info = context.structs[struct_index];
         let mut field_index: number = 0;
         let field_count = clamp_collection_length(info.fields.length, 10000);
         loop {
-            if field_index >= field_count {
-                break;
-            }
+            if field_index >= field_count { break; }
             let field_type = info.fields[field_index].llvm_type;
             let extracted = extract_struct_type_from_llvm(field_type);
             if extracted.length > 0 {
@@ -300,24 +268,18 @@ fn render_struct_type_definitions(context: TypeContext, functions: NativeFunctio
     let mut enum_index: number = 0;
     let enum_count = clamp_collection_length(context.enums.length, 10000);
     loop {
-        if enum_index >= enum_count {
-            break;
-        }
+        if enum_index >= enum_count { break; }
         let enum_info = context.enums[enum_index];
         let mut variant_index: number = 0;
         let variant_count = clamp_collection_length(enum_info.variants.length, 10000);
         loop {
-            if variant_index >= variant_count {
-                break;
-            }
+            if variant_index >= variant_count { break; }
             let variant = enum_info.variants[variant_index];
             // Check each field in the variant for struct references
             let mut variant_field_index: number = 0;
             let variant_field_count = clamp_collection_length(variant.fields.length, 10000);
             loop {
-                if variant_field_index >= variant_field_count {
-                    break;
-                }
+                if variant_field_index >= variant_field_count { break; }
                 let field_type = variant.fields[variant_field_index].llvm_type;
                 let extracted = extract_struct_type_from_llvm(field_type);
                 if extracted.length > 0 {
@@ -336,22 +298,14 @@ fn render_struct_type_definitions(context: TypeContext, functions: NativeFunctio
     let mut func_index: number = 0;
     let function_count = clamp_collection_length(functions.length, 20000);
     loop {
-        if func_index >= function_count {
-            break;
-        }
+        if func_index >= function_count { break; }
         let func = functions[func_index];
         let mut safe_return_type = func.return_type;
-        if safe_return_type == null {
-            safe_return_type = "";
-        }
+        if safe_return_type == null { safe_return_type = ""; }
         let mut safe_params = func.parameters;
-        if safe_params == null {
-            safe_params = [];
-        }
+        if safe_params == null { safe_params = []; }
         let safe_param_count = clamp_collection_length(safe_params.length, 2000);
-        if safe_param_count == 0 {
-            safe_params = [];
-        }
+        if safe_param_count == 0 { safe_params = []; }
         // Check return type
         let return_llvm_type = map_return_type(context, safe_return_type);
         let extracted_return = extract_struct_type_from_llvm(return_llvm_type);
@@ -363,9 +317,7 @@ fn render_struct_type_definitions(context: TypeContext, functions: NativeFunctio
         // Check each parameter type
         let mut param_index: number = 0;
         loop {
-            if param_index >= safe_param_count {
-                break;
-            }
+            if param_index >= safe_param_count { break; }
             let param_llvm_type = map_parameter_type(context, safe_params[param_index].type_annotation);
             let extracted_param = extract_struct_type_from_llvm(param_llvm_type);
             if extracted_param.length > 0 {
@@ -382,17 +334,13 @@ fn render_struct_type_definitions(context: TypeContext, functions: NativeFunctio
     let mut ref_index: number = 0;
     let referenced_count = clamp_collection_length(referenced_types.length, 20000);
     loop {
-        if ref_index >= referenced_count {
-            break;
-        }
+        if ref_index >= referenced_count { break; }
         let ref_type = referenced_types[ref_index];
         // Check if this type is defined in our context (structs or enums)
         let mut is_defined: boolean = false;
         let mut check_index: number = 0;
         loop {
-            if check_index >= struct_count {
-                break;
-            }
+            if check_index >= struct_count { break; }
             if context.structs[check_index].llvm_name == ref_type {
                 is_defined = true;
                 break;
@@ -403,9 +351,7 @@ fn render_struct_type_definitions(context: TypeContext, functions: NativeFunctio
         if !is_defined {
             check_index = 0;
             loop {
-                if check_index >= enum_count {
-                    break;
-                }
+                if check_index >= enum_count { break; }
                 let enum_llvm_name = "%" + sanitize_symbol(context.enums[check_index].name);
                 if enum_llvm_name == ref_type {
                     is_defined = true;
@@ -425,9 +371,7 @@ fn render_struct_type_definitions(context: TypeContext, functions: NativeFunctio
     let mut index: number = 0;
     let mut emitted_types: string[] = [];
     loop {
-        if index >= struct_count {
-            break;
-        }
+        if index >= struct_count { break; }
         let info = context.structs[index];
         // Skip if we already emitted this type
         if string_array_contains(emitted_types, info.llvm_name) {
@@ -440,16 +384,12 @@ fn render_struct_type_definitions(context: TypeContext, functions: NativeFunctio
         let mut field_index: number = 0;
         let safe_field_count = clamp_collection_length(info.fields.length, 10000);
         loop {
-            if field_index >= safe_field_count {
-                break;
-            }
+            if field_index >= safe_field_count { break; }
             field_types.push(info.fields[field_index].llvm_type);
             field_index += 1;
         }
         let mut body: string = "";
-        if field_types.length == 0 {
-            body = "{}";
-        } else {
+        if field_types.length == 0 { body = "{}"; } else {
             body = "{ " + join_with_separator(field_types, ", ") + " }";
         }
         lines.push(info.llvm_name + " = type " + body);
@@ -461,16 +401,13 @@ fn render_struct_type_definitions(context: TypeContext, functions: NativeFunctio
 // =============================================================================
 // Enum Type Definitions
 // =============================================================================
-
 fn render_enum_type_definitions(context: TypeContext) -> string[] {
     let mut lines: string[] = [];
     let mut emitted_types: string[] = [];
     let mut index: number = 0;
     let enum_count = clamp_collection_length(context.enums.length, 10000);
     loop {
-        if index >= enum_count {
-            break;
-        }
+        if index >= enum_count { break; }
         let enum_info = context.enums[index];
         let enum_llvm_name = "%" + sanitize_symbol(enum_info.name);
 
@@ -483,27 +420,17 @@ fn render_enum_type_definitions(context: TypeContext) -> string[] {
 
         // Map tag type to LLVM type
         let mut llvm_tag_type: string = "i32";
-        if enum_info.tag_type == "i8" {
-            llvm_tag_type = "i8";
-        }
-        if enum_info.tag_type == "i16" {
-            llvm_tag_type = "i16";
-        }
-        if enum_info.tag_type == "i32" {
-            llvm_tag_type = "i32";
-        }
-        if enum_info.tag_type == "i64" {
-            llvm_tag_type = "i64";
-        }
+        if enum_info.tag_type == "i8" { llvm_tag_type = "i8"; }
+        if enum_info.tag_type == "i16" { llvm_tag_type = "i16"; }
+        if enum_info.tag_type == "i32" { llvm_tag_type = "i32"; }
+        if enum_info.tag_type == "i64" { llvm_tag_type = "i64"; }
 
         // Calculate the maximum payload size across all variants
         let mut max_payload_size: number = 0;
         let mut variant_idx: number = 0;
         let variant_count = clamp_collection_length(enum_info.variants.length, 10000);
         loop {
-            if variant_idx >= variant_count {
-                break;
-            }
+            if variant_idx >= variant_count { break; }
             let variant = enum_info.variants[variant_idx];
             if variant.size > max_payload_size {
                 max_payload_size = variant.size;
@@ -524,9 +451,7 @@ fn render_enum_type_definitions(context: TypeContext) -> string[] {
         let mut payload_repr: string = "";
         if max_payload_size > 0 {
             let mut enum_align = enum_info.align;
-            if enum_align <= 0 {
-                enum_align = 1;
-            }
+            if enum_align <= 0 { enum_align = 1; }
 
             // Payload offset = align_to(tag_size, enum_align)
             let mut payload_offset = enum_info.tag_size;

--- a/compiler/src/llvm/rendering_helpers.sfn
+++ b/compiler/src/llvm/rendering_helpers.sfn
@@ -2,38 +2,38 @@
 //
 // LLVM IR rendering helpers for interfaces, vtables, test harness, symbol visibility,
 // and utility functions for type extraction and parameter collection.
-
-import { NativeFunction, NativeParameter, NativeInterfaceSignature, NativeImport } from "../native_ir";
-import { substring, find_last_index_of_char } from "../string_utils";
-import { TypeContext } from "./types";
-import { join_with_separator, string_array_contains, sanitize_symbol, number_to_string } from "./utils";
+import {
+    NativeFunction,
+    NativeImport,
+    NativeInterfaceSignature,
+    NativeParameter
+} from "../native_ir";
+import { find_last_index_of_char, substring } from "../string_utils";
 import { map_parameter_type, map_struct_type_annotation } from "./type_mapping";
+import { TypeContext } from "./types";
+import {
+    join_with_separator,
+    number_to_string,
+    sanitize_symbol,
+    string_array_contains
+} from "./utils";
 
 fn clamp_collection_length(value: number, max: number) -> number {
-    if value != value {
-        return 0;
-    }
-    if value < 0 {
-        return 0;
-    }
-    if value > max {
-        return max;
-    }
+    if value != value { return 0; }
+    if value < 0 { return 0; }
+    if value > max { return max; }
     return value;
 }
 
 // =============================================================================
 // Interface Type Definitions
 // =============================================================================
-
 fn render_interface_type_definitions(context: TypeContext) -> string[] {
     let mut lines: string[] = [];
     let mut index: number = 0;
     let interface_count = clamp_collection_length(context.interfaces.length, 10000);
     loop {
-        if index >= interface_count {
-            break;
-        }
+        if index >= interface_count { break; }
         let interface_info = context.interfaces[index];
         // Trait object layout: { data_ptr, vtable_ptr }
         let body = "{ i8*, i8* }";
@@ -46,28 +46,21 @@ fn render_interface_type_definitions(context: TypeContext) -> string[] {
 // =============================================================================
 // VTable Type Definitions and Constants
 // =============================================================================
-
 fn render_vtable_type_definitions(context: TypeContext) -> string[] {
     let mut lines: string[] = [];
     let mut index: number = 0;
     loop {
-        if index >= context.vtables.length {
-            break;
-        }
+        if index >= context.vtables.length { break; }
         let vtable = context.vtables[index];
         let mut entry_types: string[] = [];
         let mut entry_index: number = 0;
         loop {
-            if entry_index >= vtable.entries.length {
-                break;
-            }
+            if entry_index >= vtable.entries.length { break; }
             entry_types.push(vtable.entries[entry_index].function_pointer_type);
             entry_index += 1;
         }
         let mut body: string = "";
-        if entry_types.length == 0 {
-            body = "{}";
-        } else {
+        if entry_types.length == 0 { body = "{}"; } else {
             body = "{ " + join_with_separator(entry_types, ", ") + " }";
         }
         lines.push(vtable.llvm_type_name + " = type " + body);
@@ -80,16 +73,12 @@ fn render_vtable_constants(context: TypeContext) -> string[] {
     let mut lines: string[] = [];
     let mut index: number = 0;
     loop {
-        if index >= context.vtables.length {
-            break;
-        }
+        if index >= context.vtables.length { break; }
         let vtable = context.vtables[index];
         let mut entry_values: string[] = [];
         let mut entry_index: number = 0;
         loop {
-            if entry_index >= vtable.entries.length {
-                break;
-            }
+            if entry_index >= vtable.entries.length { break; }
             let entry = vtable.entries[entry_index];
             let sanitized_method = sanitize_symbol(entry.method_name);
             // Cast the method to i8* function pointer type
@@ -99,9 +88,7 @@ fn render_vtable_constants(context: TypeContext) -> string[] {
             entry_index += 1;
         }
         let mut body: string = "";
-        if entry_values.length == 0 {
-            body = "zeroinitializer";
-        } else {
+        if entry_values.length == 0 { body = "zeroinitializer"; } else {
             body = "{ " + join_with_separator(entry_values, ", ") + " }";
         }
         // Vtable globals are safe to keep module-local.
@@ -116,7 +103,6 @@ fn render_vtable_constants(context: TypeContext) -> string[] {
 // =============================================================================
 // Test Harness Rendering
 // =============================================================================
-
 fn _escape_llvm_string(text: string) -> string {
     // Chunked: O(K) memory where K = number of escape chars, instead of
     // O(N^2) per-character `out = out + ch` accumulation.
@@ -127,11 +113,7 @@ fn _escape_llvm_string(text: string) -> string {
         if i >= text.length { break; }
         let ch = substring(text, i, i + 1);
         let mut esc: string = "";
-        if ch == "\"" {
-            esc = "\\22";
-        } else if ch == "\\" {
-            esc = "\\5C";
-        }
+        if ch == "\"" { esc = "\\22"; } else if ch == "\\" { esc = "\\5C"; }
         if esc.length > 0 {
             if i > chunk_start {
                 chunks.push(substring(text, chunk_start, i));
@@ -168,9 +150,7 @@ fn _test_label_from_name(raw_name: string) -> string {
     loop {
         if i >= name.length { break; }
         let ch = substring(name, i, i + 1);
-        if ch == "_" {
-            cleaned = cleaned + " ";
-        } else {
+        if ch == "_" { cleaned = cleaned + " "; } else {
             cleaned = cleaned + ch;
         }
         i += 1;
@@ -225,7 +205,6 @@ fn render_test_harness_main(tests: NativeFunction[]) -> string[] {
 // =============================================================================
 // Interface Signature Rendering
 // =============================================================================
-
 fn render_interface_signature(signature: NativeInterfaceSignature) -> string {
     let mut line: string = "fn " + signature.name;
     if signature.type_parameters.length > 0 {
@@ -240,27 +219,19 @@ fn render_interface_signature(signature: NativeInterfaceSignature) -> string {
     if signature.effects.length > 0 {
         line = line + " ![" + join_with_separator(signature.effects, ", ") + "]";
     }
-    if signature.is_async {
-        line = "async " + line;
-    }
+    if signature.is_async { line = "async " + line; }
     return line;
 }
 
 fn render_interface_parameters(parameters: NativeParameter[]) -> string {
-    if parameters.length == 0 {
-        return "";
-    }
+    if parameters.length == 0 { return ""; }
     let mut rendered: string[] = [];
     let mut index: number = 0;
     loop {
-        if index >= parameters.length {
-            break;
-        }
+        if index >= parameters.length { break; }
         let parameter = parameters[index];
         let mut entry: string = parameter.name;
-        if parameter.mutable {
-            entry = "mut " + entry;
-        }
+        if parameter.mutable { entry = "mut " + entry; }
         if parameter.type_annotation.length > 0 {
             entry = entry + ": " + parameter.type_annotation;
         }
@@ -276,27 +247,20 @@ fn render_interface_parameters(parameters: NativeParameter[]) -> string {
 // =============================================================================
 // Helper Functions
 // =============================================================================
-
 fn extract_struct_type_from_llvm(llvm_type: string) -> string {
     // Extract struct type name from LLVM type like "%Token**" or "{ %Token**, i64 }*"
     // Returns empty string if no struct type found
-    if llvm_type.length == 0 {
-        return "";
-    }
+    if llvm_type.length == 0 { return ""; }
     let mut result: string = "";
     let mut index: number = 0;
     loop {
-        if index >= llvm_type.length {
-            break;
-        }
+        if index >= llvm_type.length { break; }
         let ch = substring(llvm_type, index, index + 1);
         if ch == "%" {
             // Found a struct type reference, extract the name
             let mut end_index: number = index + 1;
             loop {
-                if end_index >= llvm_type.length {
-                    break;
-                }
+                if end_index >= llvm_type.length { break; }
                 let end_ch = substring(llvm_type, end_index, end_index + 1);
                 // Struct name ends at space, comma, *, }, or >
                 let mut _if288: boolean = false;
@@ -305,9 +269,7 @@ fn extract_struct_type_from_llvm(llvm_type: string) -> string {
                 if end_ch == "*" { _if288 = true; }
                 if end_ch == "}" { _if288 = true; }
                 if end_ch == ">" { _if288 = true; }
-                if _if288 {
-                    break;
-                }
+                if _if288 { break; }
                 end_index += 1;
             }
             let _ren_next = index + 1;
@@ -325,9 +287,7 @@ fn collect_parameter_types(context: TypeContext, parameters: NativeParameter[], 
     let mut types: string[] = [];
     let mut index: number = 0;
     loop {
-        if index >= parameters.length {
-            break;
-        }
+        if index >= parameters.length { break; }
         let parameter = parameters[index];
         let mut llvm_type = map_parameter_type(context, parameter.type_annotation);
 
@@ -342,9 +302,7 @@ fn collect_parameter_types(context: TypeContext, parameters: NativeParameter[], 
                 }
             }
         }
-        if llvm_type.length == 0 {
-            types.push("double");
-        } else {
+        if llvm_type.length == 0 { types.push("double"); } else {
             types.push(llvm_type);
         }
         index += 1;
@@ -355,12 +313,8 @@ fn collect_parameter_types(context: TypeContext, parameters: NativeParameter[], 
 fn find_function_by_name(functions: NativeFunction[], name: string) -> NativeFunction? {
     let mut index: number = 0;
     loop {
-        if index >= functions.length {
-            break;
-        }
-        if functions[index].name == name {
-            return functions[index];
-        }
+        if index >= functions.length { break; }
+        if functions[index].name == name { return functions[index]; }
         index += 1;
     }
     return null;
@@ -369,37 +323,24 @@ fn find_function_by_name(functions: NativeFunction[], name: string) -> NativeFun
 // =============================================================================
 // Symbol Visibility Helpers
 // =============================================================================
-
 fn is_entry_point(entry_points: string[], function_name: string) -> boolean {
-    if entry_points == null {
-        return false;
-    }
+    if entry_points == null { return false; }
     let mut index: number = 0;
     loop {
-        if index >= entry_points.length {
-            break;
-        }
-        if entry_points[index] == function_name {
-            return true;
-        }
+        if index >= entry_points.length { break; }
+        if entry_points[index] == function_name { return true; }
         index += 1;
     }
     return false;
 }
 
 fn collect_exported_symbol_names(imports: NativeImport[]) -> string[] {
-    if imports == null {
-        return [];
-    }
-    if imports.length > 10000 {
-        return [];
-    }
+    if imports == null { return []; }
+    if imports.length > 10000 { return []; }
     let mut names: string[] = [];
     let mut index: number = 0;
     loop {
-        if index >= imports.length {
-            break;
-        }
+        if index >= imports.length { break; }
         let entry = imports[index];
         if entry == null {
             index += 1;
@@ -413,9 +354,7 @@ fn collect_exported_symbol_names(imports: NativeImport[]) -> string[] {
             }
             let mut spec_index: number = 0;
             loop {
-                if spec_index >= specifiers.length {
-                    break;
-                }
+                if spec_index >= specifiers.length { break; }
                 let spec = specifiers[spec_index];
                 if spec != null {
                     let exported = spec.name;
@@ -438,12 +377,8 @@ fn collect_exported_symbol_names(imports: NativeImport[]) -> string[] {
 fn is_exported_symbol(exported_symbols: string[], function_name: string) -> boolean {
     let mut index: number = 0;
     loop {
-        if index >= exported_symbols.length {
-            break;
-        }
-        if exported_symbols[index] == function_name {
-            return true;
-        }
+        if index >= exported_symbols.length { break; }
+        if exported_symbols[index] == function_name { return true; }
         index += 1;
     }
     return false;
@@ -451,89 +386,61 @@ fn is_exported_symbol(exported_symbols: string[], function_name: string) -> bool
 
 fn should_internalize_function(function: NativeFunction, entry_points: string[], exported_symbols: string[], imported_functions: NativeFunction[]) -> boolean {
     // Externs are emitted as declarations.
-    if function.is_extern {
-        return false;
-    }
+    if function.is_extern { return false; }
 
     // Keep declared entry points externally visible.
-    if is_entry_point(entry_points, function.name) {
-        return false;
-    }
+    if is_entry_point(entry_points, function.name) { return false; }
 
     // Preserve explicitly exported symbols for cross-module linkage.
-    if is_exported_symbol(exported_symbols, function.name) {
-        return false;
-    }
+    if is_exported_symbol(exported_symbols, function.name) { return false; }
 
     // Preserve native driver API surface expected by selfhost/release linking.
     let sanitized = sanitize_symbol(function.name);
     let mut _if289: boolean = false;
     if function.name == "compile_to_llvm" { _if289 = true; }
     if sanitized == "compile_to_llvm" { _if289 = true; }
-    if _if289 {
-        return false;
-    }
+    if _if289 { return false; }
     let mut _if290: boolean = false;
     if function.name == "compile_to_sailfin" { _if290 = true; }
     if sanitized == "compile_to_sailfin" { _if290 = true; }
-    if _if290 {
-        return false;
-    }
+    if _if290 { return false; }
     let mut _if291: boolean = false;
     if function.name == "cli_main" { _if291 = true; }
     if sanitized == "sailfin_cli_main__cli_main" { _if291 = true; }
-    if _if291 {
-        return false;
-    }
+    if _if291 { return false; }
     let mut _if292: boolean = false;
     if function.name == "sailfin_cli_main" { _if292 = true; }
     if sanitized == "sailfin_cli_main" { _if292 = true; }
-    if _if292 {
-        return false;
-    }
+    if _if292 { return false; }
     let mut _if293: boolean = false;
     if function.name == "native_cli_main" { _if293 = true; }
     if sanitized == "native_cli_main" { _if293 = true; }
-    if _if293 {
-        return false;
-    }
+    if _if293 { return false; }
     let mut _if294: boolean = false;
     if function.name == "append_match_arm_mutations" { _if294 = true; }
     if sanitized == "append_match_arm_mutations" { _if294 = true; }
-    if _if294 {
-        return false;
-    }
+    if _if294 { return false; }
     let mut _if295: boolean = false;
     if function.name == "append_match_arm_mutations_impl" { _if295 = true; }
     if sanitized == "append_match_arm_mutations_impl" { _if295 = true; }
-    if _if295 {
-        return false;
-    }
+    if _if295 { return false; }
     let mut _if296: boolean = false;
     if function.name == "text_char_at" { _if296 = true; }
     if sanitized == "text_char_at" { _if296 = true; }
-    if _if296 {
-        return false;
-    }
+    if _if296 { return false; }
     let mut _if297: boolean = false;
     if function.name == "string_char_at" { _if297 = true; }
     if sanitized == "string_char_at" { _if297 = true; }
-    if _if297 {
-        return false;
-    }
+    if _if297 { return false; }
 
     // Treat leading-underscore helpers as module-local.
     if sanitized.length > 0 {
-        if substring(sanitized, 0, 1) == "_" {
-            return true;
-        }
+        if substring(sanitized, 0, 1) == "_" { return true; }
     }
 
     // Collision-prone local helper names observed across compiler modules.
     // Keep these module-local to avoid duplicate symbol definitions at final link.
-    if sanitized == "contains_effect" {
-        return true;
-    }
+    if sanitized == "contains_effect" { return true; }
 
     // Default: preserve existing cross-module linkage behavior.
     return false;

--- a/compiler/src/llvm/rendering_helpers.sfn
+++ b/compiler/src/llvm/rendering_helpers.sfn
@@ -82,7 +82,11 @@ fn render_vtable_constants(context: TypeContext) -> string[] {
             let entry = vtable.entries[entry_index];
             let sanitized_method = sanitize_symbol(entry.method_name);
             // Cast the method to i8* function pointer type
-            let cast_value = "bitcast (" + entry.function_pointer_type + " @" + sanitized_method + " to " + entry.function_pointer_type + ")";
+            let cast_value = "bitcast (" + entry.function_pointer_type + " @"
+                + sanitized_method
+                + " to "
+                + entry.function_pointer_type
+                + ")";
             let typed_value = entry.function_pointer_type + " " + cast_value;
             entry_values.push(typed_value);
             entry_index += 1;
@@ -94,7 +98,9 @@ fn render_vtable_constants(context: TypeContext) -> string[] {
         // Vtable globals are safe to keep module-local.
         // Marking them internal avoids duplicate symbol collisions when linking
         // multiple LLVM modules that share the same type context.
-        lines.push(vtable.llvm_global_name + " = internal constant " + vtable.llvm_type_name + " " + body);
+        lines.push(vtable.llvm_global_name + " = internal constant " + vtable.llvm_type_name
+            + " "
+            + body);
         index += 1;
     }
     return lines;
@@ -170,13 +176,25 @@ fn render_test_harness_main(tests: NativeFunction[]) -> string[] {
         let msg = "  RUN  " + label;
         let escaped = _escape_llvm_string(msg);
         let idx_str = number_to_string(index);
-        lines.push("@.test_name_" + idx_str + " = private unnamed_addr constant [" + number_to_string(msg.length + 1) + " x i8] c\"" + escaped + "\\00\"");
+        lines.push("@.test_name_" + idx_str
+            + " = private unnamed_addr constant ["
+            + number_to_string(msg.length
+            + 1)
+            + " x i8] c\""
+            + escaped
+            + "\\00\"");
         index += 1;
     }
 
-    let pass_msg = "  PASS  (all " + number_to_string(test_count) + " tests passed)";
+    let pass_msg = "  PASS  (all " + number_to_string(test_count)
+        + " tests passed)";
     let pass_escaped = _escape_llvm_string(pass_msg);
-    lines.push("@.test_pass_msg = private unnamed_addr constant [" + number_to_string(pass_msg.length + 1) + " x i8] c\"" + pass_escaped + "\\00\"");
+    lines.push("@.test_pass_msg = private unnamed_addr constant ["
+        + number_to_string(pass_msg.length
+        + 1)
+        + " x i8] c\""
+        + pass_escaped
+        + "\\00\"");
     lines.push("declare i32 @puts(i8*)");
 
     lines.push("define i32 @main(i32 %argc, i8** %argv) {");
@@ -188,14 +206,27 @@ fn render_test_harness_main(tests: NativeFunction[]) -> string[] {
         let sym = sanitize_symbol(tests[index].name);
         let idx_str = number_to_string(index);
         let msg = "  RUN  " + _test_label_from_name(tests[index].name);
-        lines.push("  %name_ptr_" + idx_str + " = getelementptr [" + number_to_string(msg.length + 1) + " x i8], [" + number_to_string(msg.length + 1) + " x i8]* @.test_name_" + idx_str + ", i64 0, i64 0");
+        lines.push("  %name_ptr_" + idx_str + " = getelementptr ["
+            + number_to_string(msg.length
+            + 1)
+            + " x i8], ["
+            + number_to_string(msg.length
+            + 1)
+            + " x i8]* @.test_name_"
+            + idx_str
+            + ", i64 0, i64 0");
         lines.push("  call i32 @puts(i8* %name_ptr_" + idx_str + ")");
         lines.push("  call void @" + sym + "()");
         index += 1;
     }
 
     // Print summary
-    lines.push("  %pass_ptr = getelementptr [" + number_to_string(pass_msg.length + 1) + " x i8], [" + number_to_string(pass_msg.length + 1) + " x i8]* @.test_pass_msg, i64 0, i64 0");
+    lines.push("  %pass_ptr = getelementptr [" + number_to_string(pass_msg.length
+        + 1)
+        + " x i8], ["
+        + number_to_string(pass_msg.length
+        + 1)
+        + " x i8]* @.test_pass_msg, i64 0, i64 0");
     lines.push("  call i32 @puts(i8* %pass_ptr)");
     lines.push("  ret i32 0");
     lines.push("}");
@@ -208,7 +239,8 @@ fn render_test_harness_main(tests: NativeFunction[]) -> string[] {
 fn render_interface_signature(signature: NativeInterfaceSignature) -> string {
     let mut line: string = "fn " + signature.name;
     if signature.type_parameters.length > 0 {
-        line = line + "<" + join_with_separator(signature.type_parameters, ", ") + ">";
+        line = line + "<" + join_with_separator(signature.type_parameters, ", ")
+            + ">";
     }
     line = line + "(" + render_interface_parameters(signature.parameters) + ")";
     if signature.return_type.length > 0 {

--- a/compiler/src/llvm/runtime_helpers.sfn
+++ b/compiler/src/llvm/runtime_helpers.sfn
@@ -13,11 +13,11 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
     // Raw print: writes to stdout with no prefix, no decoration.
     // Used by the compiler itself for artifact output and CLI messages.
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "print", symbol: "sailfin_runtime_print_raw", return_type: "void", parameter_types: ["i8*"], effects: ["io"],
+        target: "print", symbol: "sailfin_runtime_print_raw", return_type: "void", parameter_types: ["i8*"], effects: ["io"]
     });
     // Raw stderr print: writes to stderr with no prefix, no decoration.
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "print.err", symbol: "sailfin_runtime_print_err", return_type: "void", parameter_types: ["i8*"], effects: ["io"],
+        target: "print.err", symbol: "sailfin_runtime_print_err", return_type: "void", parameter_types: ["i8*"], effects: ["io"]
     });
 
     // Prefixed print variants — print.err/print.warn/print.error write to
@@ -25,365 +25,365 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
     // Compiler diagnostics should use print.err() so they do not pollute
     // stdout (LLVM IR output, program output, etc.).
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "print.info", symbol: "sailfin_runtime_print_info", return_type: "void", parameter_types: ["i8*"], effects: ["io"],
+        target: "print.info", symbol: "sailfin_runtime_print_info", return_type: "void", parameter_types: ["i8*"], effects: ["io"]
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "print.error", symbol: "sailfin_runtime_print_error", return_type: "void", parameter_types: ["i8*"], effects: ["io"],
+        target: "print.error", symbol: "sailfin_runtime_print_error", return_type: "void", parameter_types: ["i8*"], effects: ["io"]
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "print.warn", symbol: "sailfin_runtime_print_warn", return_type: "void", parameter_types: ["i8*"], effects: ["io"],
+        target: "print.warn", symbol: "sailfin_runtime_print_warn", return_type: "void", parameter_types: ["i8*"], effects: ["io"]
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "console.info", symbol: "sailfin_runtime_print_raw", return_type: "void", parameter_types: ["i8*"], effects: ["io"],
+        target: "console.info", symbol: "sailfin_runtime_print_raw", return_type: "void", parameter_types: ["i8*"], effects: ["io"]
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "console.log", symbol: "sailfin_runtime_print_raw", return_type: "void", parameter_types: ["i8*"], effects: ["io"],
+        target: "console.log", symbol: "sailfin_runtime_print_raw", return_type: "void", parameter_types: ["i8*"], effects: ["io"]
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "console.error", symbol: "sailfin_runtime_print_error", return_type: "void", parameter_types: ["i8*"], effects: ["io"],
+        target: "console.error", symbol: "sailfin_runtime_print_error", return_type: "void", parameter_types: ["i8*"], effects: ["io"]
     });
 
     // IO intrinsics
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "io_read", symbol: "sailfin_intrinsic_io_read", return_type: "i8*", parameter_types: ["i8*"], effects: ["io"],
+        target: "io_read", symbol: "sailfin_intrinsic_io_read", return_type: "i8*", parameter_types: ["i8*"], effects: ["io"]
     });
 
     // Filesystem intrinsics
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "fs.read", symbol: "sailfin_intrinsic_fs_read", return_type: "i8*", parameter_types: ["i8*"], effects: ["io"],
+        target: "fs.read", symbol: "sailfin_intrinsic_fs_read", return_type: "i8*", parameter_types: ["i8*"], effects: ["io"]
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "fs.write", symbol: "sailfin_intrinsic_fs_write", return_type: "void", parameter_types: ["i8*", "i8*"], effects: ["io"],
+        target: "fs.write", symbol: "sailfin_intrinsic_fs_write", return_type: "void", parameter_types: ["i8*", "i8*"], effects: ["io"]
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "fs.exists", symbol: "sailfin_intrinsic_fs_exists", return_type: "i1", parameter_types: ["i8*"], effects: ["io"],
+        target: "fs.exists", symbol: "sailfin_intrinsic_fs_exists", return_type: "i1", parameter_types: ["i8*"], effects: ["io"]
     });
 
     // Model intrinsics
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "model_invoke", symbol: "sailfin_intrinsic_model_invoke", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: ["model"],
+        target: "model_invoke", symbol: "sailfin_intrinsic_model_invoke", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: ["model"]
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "prompt", symbol: "sailfin_intrinsic_model_invoke", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: ["model"],
+        target: "prompt", symbol: "sailfin_intrinsic_model_invoke", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: ["model"]
     });
 
     // Network intrinsics
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "net_request", symbol: "sailfin_intrinsic_net_request", return_type: "i8*", parameter_types: ["i8*", "i8*", "i8*"], effects: ["net"],
+        target: "net_request", symbol: "sailfin_intrinsic_net_request", return_type: "i8*", parameter_types: ["i8*", "i8*", "i8*"], effects: ["net"]
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "http.get", symbol: "sailfin_intrinsic_http_get", return_type: "i8*", parameter_types: ["i8*"], effects: ["net"],
+        target: "http.get", symbol: "sailfin_intrinsic_http_get", return_type: "i8*", parameter_types: ["i8*"], effects: ["net"]
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "http.post", symbol: "sailfin_intrinsic_http_post", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: ["net"],
+        target: "http.post", symbol: "sailfin_intrinsic_http_post", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: ["net"]
     });
 
     // Concurrency intrinsics (sleep is existing)
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "sleep", symbol: "sailfin_runtime_sleep", return_type: "void", parameter_types: ["double"], effects: ["clock"],
+        target: "sleep", symbol: "sailfin_runtime_sleep", return_type: "void", parameter_types: ["double"], effects: ["clock"]
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "runtime_sleep_fn", symbol: "sailfin_runtime_sleep", return_type: "void", parameter_types: ["double"], effects: ["clock"],
+        target: "runtime_sleep_fn", symbol: "sailfin_runtime_sleep", return_type: "void", parameter_types: ["double"], effects: ["clock"]
     });
 
     // Monotonic clock for profiling/timing.
     // Support both the prelude binding name and direct calls.
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "runtime_monotonic_millis_fn", symbol: "sailfin_runtime_monotonic_millis", return_type: "double", parameter_types: [], effects: ["clock"],
+        target: "runtime_monotonic_millis_fn", symbol: "sailfin_runtime_monotonic_millis", return_type: "double", parameter_types: [], effects: ["clock"]
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "monotonic_millis", symbol: "sailfin_runtime_monotonic_millis", return_type: "double", parameter_types: [], effects: ["clock"],
+        target: "monotonic_millis", symbol: "sailfin_runtime_monotonic_millis", return_type: "double", parameter_types: [], effects: ["clock"]
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "runtime_channel_fn", symbol: "sailfin_runtime_channel", return_type: "i8*", parameter_types: ["double"], effects: ["io"],
+        target: "runtime_channel_fn", symbol: "sailfin_runtime_channel", return_type: "i8*", parameter_types: ["double"], effects: ["io"]
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "runtime_spawn_fn", symbol: "sailfin_runtime_spawn", return_type: "void", parameter_types: ["i8*", "i8*"], effects: ["io"],
+        target: "runtime_spawn_fn", symbol: "sailfin_runtime_spawn", return_type: "void", parameter_types: ["i8*", "i8*"], effects: ["io"]
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "runtime_parallel_fn", symbol: "sailfin_runtime_parallel", return_type: "i8*", parameter_types: ["i8*"], effects: ["io"],
+        target: "runtime_parallel_fn", symbol: "sailfin_runtime_parallel", return_type: "i8*", parameter_types: ["i8*"], effects: ["io"]
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "runtime_create_capability_grant", symbol: "sailfin_runtime_create_capability_grant", return_type: "i8*", parameter_types: ["i8*"], effects: [],
+        target: "runtime_create_capability_grant", symbol: "sailfin_runtime_create_capability_grant", return_type: "i8*", parameter_types: ["i8*"], effects: []
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "runtime_create_filesystem_bridge", symbol: "sailfin_runtime_create_filesystem_bridge", return_type: "i8*", parameter_types: ["i8*"], effects: ["io"],
+        target: "runtime_create_filesystem_bridge", symbol: "sailfin_runtime_create_filesystem_bridge", return_type: "i8*", parameter_types: ["i8*"], effects: ["io"]
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "runtime_create_http_bridge", symbol: "sailfin_runtime_create_http_bridge", return_type: "i8*", parameter_types: ["i8*"], effects: ["net"],
+        target: "runtime_create_http_bridge", symbol: "sailfin_runtime_create_http_bridge", return_type: "i8*", parameter_types: ["i8*"], effects: ["net"]
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "runtime_create_model_bridge", symbol: "sailfin_runtime_create_model_bridge", return_type: "i8*", parameter_types: ["i8*"], effects: ["model"],
+        target: "runtime_create_model_bridge", symbol: "sailfin_runtime_create_model_bridge", return_type: "i8*", parameter_types: ["i8*"], effects: ["model"]
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "runtime_log_execution_fn", symbol: "sailfin_runtime_log_execution", return_type: "i8*", parameter_types: ["i8*"], effects: ["io"],
+        target: "runtime_log_execution_fn", symbol: "sailfin_runtime_log_execution", return_type: "i8*", parameter_types: ["i8*"], effects: ["io"]
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "runtime_to_debug_string_fn", symbol: "sailfin_runtime_to_debug_string", return_type: "i8*", parameter_types: ["i8*"], effects: [],
+        target: "runtime_to_debug_string_fn", symbol: "sailfin_runtime_to_debug_string", return_type: "i8*", parameter_types: ["i8*"], effects: []
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "runtime_raise_value_error_fn", symbol: "sailfin_runtime_raise_value_error", return_type: "void", parameter_types: ["i8*"], effects: [],
+        target: "runtime_raise_value_error_fn", symbol: "sailfin_runtime_raise_value_error", return_type: "void", parameter_types: ["i8*"], effects: []
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "runtime_is_string_fn", symbol: "sailfin_runtime_is_string", return_type: "i1", parameter_types: ["i8*"], effects: [],
+        target: "runtime_is_string_fn", symbol: "sailfin_runtime_is_string", return_type: "i1", parameter_types: ["i8*"], effects: []
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "runtime_is_number_fn", symbol: "sailfin_runtime_is_number", return_type: "i1", parameter_types: ["i8*"], effects: [],
+        target: "runtime_is_number_fn", symbol: "sailfin_runtime_is_number", return_type: "i1", parameter_types: ["i8*"], effects: []
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "runtime_is_boolean_fn", symbol: "sailfin_runtime_is_boolean", return_type: "i1", parameter_types: ["i8*"], effects: [],
+        target: "runtime_is_boolean_fn", symbol: "sailfin_runtime_is_boolean", return_type: "i1", parameter_types: ["i8*"], effects: []
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "runtime_is_void_fn", symbol: "sailfin_runtime_is_void", return_type: "i1", parameter_types: ["i8*"], effects: [],
+        target: "runtime_is_void_fn", symbol: "sailfin_runtime_is_void", return_type: "i1", parameter_types: ["i8*"], effects: []
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "runtime.bounds_check", symbol: "sailfin_runtime_bounds_check", return_type: "void", parameter_types: ["i64", "i64"], effects: [],
+        target: "runtime.bounds_check", symbol: "sailfin_runtime_bounds_check", return_type: "void", parameter_types: ["i64", "i64"], effects: []
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "runtime_is_array_fn", symbol: "sailfin_runtime_is_array", return_type: "i1", parameter_types: ["i8*"], effects: [],
+        target: "runtime_is_array_fn", symbol: "sailfin_runtime_is_array", return_type: "i1", parameter_types: ["i8*"], effects: []
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "runtime_is_callable_fn", symbol: "sailfin_runtime_is_callable", return_type: "i1", parameter_types: ["i8*"], effects: [],
+        target: "runtime_is_callable_fn", symbol: "sailfin_runtime_is_callable", return_type: "i1", parameter_types: ["i8*"], effects: []
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "runtime_resolve_runtime_type_fn", symbol: "sailfin_runtime_resolve_type", return_type: "i8*", parameter_types: ["i8*"], effects: [],
+        target: "runtime_resolve_runtime_type_fn", symbol: "sailfin_runtime_resolve_type", return_type: "i8*", parameter_types: ["i8*"], effects: []
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "runtime_instance_of_fn", symbol: "sailfin_runtime_instance_of", return_type: "i1", parameter_types: ["i8*", "i8*"], effects: [],
+        target: "runtime_instance_of_fn", symbol: "sailfin_runtime_instance_of", return_type: "i1", parameter_types: ["i8*", "i8*"], effects: []
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "runtime_serve_fn", symbol: "sailfin_runtime_serve", return_type: "void", parameter_types: ["i8*", "i8*"], effects: ["io", "net"],
+        target: "runtime_serve_fn", symbol: "sailfin_runtime_serve", return_type: "void", parameter_types: ["i8*", "i8*"], effects: ["io", "net"]
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "runtime_char_code_fn", symbol: "sailfin_runtime_char_code", return_type: "double", parameter_types: ["i8*"], effects: [],
+        target: "runtime_char_code_fn", symbol: "sailfin_runtime_char_code", return_type: "double", parameter_types: ["i8*"], effects: []
     });
 
     // Process helpers
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "process.run", symbol: "sailfin_runtime_process_run", return_type: "double", parameter_types: ["{ i8**, i64 }*"], effects: ["io"],
+        target: "process.run", symbol: "sailfin_runtime_process_run", return_type: "double", parameter_types: ["{ i8**, i64 }*"], effects: ["io"]
     });
 
     // Filesystem adapters
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "fs_read_file", symbol: "sailfin_adapter_fs_read_file", return_type: "i8*", parameter_types: ["i8*"], effects: ["io"],
+        target: "fs_read_file", symbol: "sailfin_adapter_fs_read_file", return_type: "i8*", parameter_types: ["i8*"], effects: ["io"]
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "fs.readFile", symbol: "sailfin_adapter_fs_read_file", return_type: "i8*", parameter_types: ["i8*"], effects: ["io"],
+        target: "fs.readFile", symbol: "sailfin_adapter_fs_read_file", return_type: "i8*", parameter_types: ["i8*"], effects: ["io"]
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "fs_write_file", symbol: "sailfin_adapter_fs_write_file", return_type: "void", parameter_types: ["i8*", "i8*"], effects: ["io"],
+        target: "fs_write_file", symbol: "sailfin_adapter_fs_write_file", return_type: "void", parameter_types: ["i8*", "i8*"], effects: ["io"]
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "fs.writeFile", symbol: "sailfin_adapter_fs_write_file", return_type: "void", parameter_types: ["i8*", "i8*"], effects: ["io"],
+        target: "fs.writeFile", symbol: "sailfin_adapter_fs_write_file", return_type: "void", parameter_types: ["i8*", "i8*"], effects: ["io"]
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "fs_append_file", symbol: "sailfin_adapter_fs_append_file", return_type: "void", parameter_types: ["i8*", "i8*"], effects: ["io"],
+        target: "fs_append_file", symbol: "sailfin_adapter_fs_append_file", return_type: "void", parameter_types: ["i8*", "i8*"], effects: ["io"]
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "fs.appendFile", symbol: "sailfin_adapter_fs_append_file", return_type: "void", parameter_types: ["i8*", "i8*"], effects: ["io"],
+        target: "fs.appendFile", symbol: "sailfin_adapter_fs_append_file", return_type: "void", parameter_types: ["i8*", "i8*"], effects: ["io"]
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "fs_write_lines", symbol: "sailfin_adapter_fs_write_lines", return_type: "void", parameter_types: ["i8*", "{ i8**, i64 }*"], effects: ["io"],
+        target: "fs_write_lines", symbol: "sailfin_adapter_fs_write_lines", return_type: "void", parameter_types: ["i8*", "{ i8**, i64 }*"], effects: ["io"]
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "fs.writeLines", symbol: "sailfin_adapter_fs_write_lines", return_type: "void", parameter_types: ["i8*", "{ i8**, i64 }*"], effects: ["io"],
+        target: "fs.writeLines", symbol: "sailfin_adapter_fs_write_lines", return_type: "void", parameter_types: ["i8*", "{ i8**, i64 }*"], effects: ["io"]
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "fs_list_directory", symbol: "sailfin_adapter_fs_list_directory", return_type: "{ i8**, i64 }*", parameter_types: ["i8*"], effects: ["io"],
+        target: "fs_list_directory", symbol: "sailfin_adapter_fs_list_directory", return_type: "{ i8**, i64 }*", parameter_types: ["i8*"], effects: ["io"]
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "fs.listDirectory", symbol: "sailfin_adapter_fs_list_directory", return_type: "{ i8**, i64 }*", parameter_types: ["i8*"], effects: ["io"],
+        target: "fs.listDirectory", symbol: "sailfin_adapter_fs_list_directory", return_type: "{ i8**, i64 }*", parameter_types: ["i8*"], effects: ["io"]
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "fs_delete_file", symbol: "sailfin_adapter_fs_delete_file", return_type: "i1", parameter_types: ["i8*"], effects: ["io"],
+        target: "fs_delete_file", symbol: "sailfin_adapter_fs_delete_file", return_type: "i1", parameter_types: ["i8*"], effects: ["io"]
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "fs.deleteFile", symbol: "sailfin_adapter_fs_delete_file", return_type: "i1", parameter_types: ["i8*"], effects: ["io"],
+        target: "fs.deleteFile", symbol: "sailfin_adapter_fs_delete_file", return_type: "i1", parameter_types: ["i8*"], effects: ["io"]
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "fs_create_directory", symbol: "sailfin_adapter_fs_create_directory", return_type: "i1", parameter_types: ["i8*", "i1"], effects: ["io"],
+        target: "fs_create_directory", symbol: "sailfin_adapter_fs_create_directory", return_type: "i1", parameter_types: ["i8*", "i1"], effects: ["io"]
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "fs.createDirectory", symbol: "sailfin_adapter_fs_create_directory", return_type: "i1", parameter_types: ["i8*", "i1"], effects: ["io"],
+        target: "fs.createDirectory", symbol: "sailfin_adapter_fs_create_directory", return_type: "i1", parameter_types: ["i8*", "i1"], effects: ["io"]
     });
 
     // HTTP adapters (distinct from intrinsics for adapter infrastructure)
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "http_get", symbol: "sailfin_adapter_http_get", return_type: "i8*", parameter_types: ["i8*"], effects: ["net"],
+        target: "http_get", symbol: "sailfin_adapter_http_get", return_type: "i8*", parameter_types: ["i8*"], effects: ["net"]
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "http_post", symbol: "sailfin_adapter_http_post", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: ["net"],
+        target: "http_post", symbol: "sailfin_adapter_http_post", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: ["net"]
     });
 
     // Model adapter
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "model_invoke_with_prompt", symbol: "sailfin_adapter_model_invoke_with_prompt", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: ["model"],
+        target: "model_invoke_with_prompt", symbol: "sailfin_adapter_model_invoke_with_prompt", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: ["model"]
     });
 
     // Serve adapters
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "serve_start", symbol: "sailfin_adapter_serve_start", return_type: "void", parameter_types: ["i8*", "i32"], effects: ["net", "io"],
+        target: "serve_start", symbol: "sailfin_adapter_serve_start", return_type: "void", parameter_types: ["i8*", "i32"], effects: ["net", "io"]
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "serve_handler_dispatch", symbol: "sailfin_adapter_serve_handler_dispatch", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: ["net", "io"],
+        target: "serve_handler_dispatch", symbol: "sailfin_adapter_serve_handler_dispatch", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: ["net", "io"]
     });
 
     // Concurrency adapters
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "spawn_task", symbol: "sailfin_adapter_spawn_task", return_type: "i8*", parameter_types: ["i8*"], effects: ["spawn"],
+        target: "spawn_task", symbol: "sailfin_adapter_spawn_task", return_type: "i8*", parameter_types: ["i8*"], effects: ["spawn"]
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "channel_create", symbol: "sailfin_adapter_channel_create", return_type: "i8*", parameter_types: ["i32"], effects: [],
+        target: "channel_create", symbol: "sailfin_adapter_channel_create", return_type: "i8*", parameter_types: ["i32"], effects: []
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "channel_send", symbol: "sailfin_adapter_channel_send", return_type: "void", parameter_types: ["i8*", "i8*"], effects: ["channel"],
+        target: "channel_send", symbol: "sailfin_adapter_channel_send", return_type: "void", parameter_types: ["i8*", "i8*"], effects: ["channel"]
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "channel_receive", symbol: "sailfin_adapter_channel_receive", return_type: "i8*", parameter_types: ["i8*"], effects: ["channel"],
+        target: "channel_receive", symbol: "sailfin_adapter_channel_receive", return_type: "i8*", parameter_types: ["i8*"], effects: ["channel"]
     });
 
     // Collection helpers
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "runtime_array_map_fn", symbol: "sailfin_runtime_array_map", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: [],
+        target: "runtime_array_map_fn", symbol: "sailfin_runtime_array_map", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: []
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "runtime_array_filter_fn", symbol: "sailfin_runtime_array_filter", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: [],
+        target: "runtime_array_filter_fn", symbol: "sailfin_runtime_array_filter", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: []
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "runtime_array_reduce_fn", symbol: "sailfin_runtime_array_reduce", return_type: "i8*", parameter_types: ["i8*", "i8*", "i8*"], effects: [],
+        target: "runtime_array_reduce_fn", symbol: "sailfin_runtime_array_reduce", return_type: "i8*", parameter_types: ["i8*", "i8*", "i8*"], effects: []
     });
 
     // String utility helpers
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "substring", symbol: "substring", return_type: "i8*", parameter_types: ["i8*", "double", "double"], effects: [],
+        target: "substring", symbol: "substring", return_type: "i8*", parameter_types: ["i8*", "double", "double"], effects: []
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "substring_unchecked", symbol: "substring_unchecked", return_type: "i8*", parameter_types: ["i8*", "double", "double"], effects: [],
+        target: "substring_unchecked", symbol: "substring_unchecked", return_type: "i8*", parameter_types: ["i8*", "double", "double"], effects: []
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "string.length", symbol: "sailfin_runtime_string_length", return_type: "i64", parameter_types: ["i8*"], effects: [],
+        target: "string.length", symbol: "sailfin_runtime_string_length", return_type: "i64", parameter_types: ["i8*"], effects: []
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "string.concat", symbol: "sailfin_runtime_string_concat", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: [],
+        target: "string.concat", symbol: "sailfin_runtime_string_concat", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: []
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "string.append", symbol: "sailfin_runtime_string_append", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: [],
+        target: "string.append", symbol: "sailfin_runtime_string_append", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: []
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "string.drop", symbol: "sailfin_runtime_string_drop", return_type: "void", parameter_types: ["i8*"], effects: [],
+        target: "string.drop", symbol: "sailfin_runtime_string_drop", return_type: "void", parameter_types: ["i8*"], effects: []
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "number.to_string", symbol: "sailfin_runtime_number_to_string", return_type: "i8*", parameter_types: ["double"], effects: [],
+        target: "number.to_string", symbol: "sailfin_runtime_number_to_string", return_type: "i8*", parameter_types: ["double"], effects: []
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "string.to_number", symbol: "sailfin_runtime_string_to_number", return_type: "double", parameter_types: ["i8*"], effects: [],
+        target: "string.to_number", symbol: "sailfin_runtime_string_to_number", return_type: "double", parameter_types: ["i8*"], effects: []
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "strings_equal", symbol: "strings_equal", return_type: "i1", parameter_types: ["i8*", "i8*"], effects: [],
+        target: "strings_equal", symbol: "strings_equal", return_type: "i1", parameter_types: ["i8*", "i8*"], effects: []
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "char_code", symbol: "char_code", return_type: "double", parameter_types: ["i8*"], effects: [],
+        target: "char_code", symbol: "char_code", return_type: "double", parameter_types: ["i8*"], effects: []
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "runtime_grapheme_count_fn", symbol: "sailfin_runtime_grapheme_count", return_type: "double", parameter_types: ["i8*"], effects: [],
+        target: "runtime_grapheme_count_fn", symbol: "sailfin_runtime_grapheme_count", return_type: "double", parameter_types: ["i8*"], effects: []
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "runtime_grapheme_at_fn", symbol: "sailfin_runtime_grapheme_at", return_type: "i8*", parameter_types: ["i8*", "double"], effects: [],
+        target: "runtime_grapheme_at_fn", symbol: "sailfin_runtime_grapheme_at", return_type: "i8*", parameter_types: ["i8*", "double"], effects: []
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "grapheme_at", symbol: "sailfin_runtime_grapheme_at", return_type: "i8*", parameter_types: ["i8*", "double"], effects: [],
+        target: "grapheme_at", symbol: "sailfin_runtime_grapheme_at", return_type: "i8*", parameter_types: ["i8*", "double"], effects: []
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "is_whitespace_char", symbol: "sailfin_runtime_is_whitespace_char", return_type: "i1", parameter_types: ["i8"], effects: [],
+        target: "is_whitespace_char", symbol: "sailfin_runtime_is_whitespace_char", return_type: "i1", parameter_types: ["i8"], effects: []
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "is_decimal_digit", symbol: "sailfin_runtime_is_decimal_digit", return_type: "i1", parameter_types: ["i8"], effects: [],
+        target: "is_decimal_digit", symbol: "sailfin_runtime_is_decimal_digit", return_type: "i1", parameter_types: ["i8"], effects: []
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "is_alpha_char", symbol: "sailfin_runtime_is_alpha_char", return_type: "i1", parameter_types: ["i8"], effects: [],
+        target: "is_alpha_char", symbol: "sailfin_runtime_is_alpha_char", return_type: "i1", parameter_types: ["i8"], effects: []
     });
 
     // Array/collection helpers (generic using i8* for element type)
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "append_string", symbol: "sailfin_runtime_append_string", return_type: "{ i8**, i64 }*", parameter_types: ["{ i8**, i64 }*", "i8*"], effects: [],
+        target: "append_string", symbol: "sailfin_runtime_append_string", return_type: "{ i8**, i64 }*", parameter_types: ["{ i8**, i64 }*", "i8*"], effects: []
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "concat", symbol: "sailfin_runtime_concat", return_type: "{ i8**, i64 }*", parameter_types: ["{ i8**, i64 }*", "{ i8**, i64 }*"], effects: [],
+        target: "concat", symbol: "sailfin_runtime_concat", return_type: "{ i8**, i64 }*", parameter_types: ["{ i8**, i64 }*", "{ i8**, i64 }*"], effects: []
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "copy_bytes", symbol: "sailfin_runtime_copy_bytes", return_type: "void", parameter_types: ["i8*", "i8*", "i64"], effects: [],
+        target: "copy_bytes", symbol: "sailfin_runtime_copy_bytes", return_type: "void", parameter_types: ["i8*", "i8*", "i64"], effects: []
     });
 
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "array_push_slot", symbol: "sailfin_runtime_array_push_slot", return_type: "i8*", parameter_types: ["i8**", "i64*", "i64"], effects: [],
+        target: "array_push_slot", symbol: "sailfin_runtime_array_push_slot", return_type: "i8*", parameter_types: ["i8**", "i64*", "i64"], effects: []
     });
 
     // Generic field accessor for opaque imported types
     // Takes object pointer and field name, returns field value as i8*
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "get_field", symbol: "sailfin_runtime_get_field", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: [],
+        target: "get_field", symbol: "sailfin_runtime_get_field", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: []
     });
 
     // String persistence helper for Stage2 memory management
     // Marks string pointers as persistent so they survive across LLVM function boundaries
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "mark_persistent", symbol: "sailfin_runtime_mark_persistent", return_type: "void", parameter_types: ["i8*"], effects: [],
+        target: "mark_persistent", symbol: "sailfin_runtime_mark_persistent", return_type: "void", parameter_types: ["i8*"], effects: []
     });
 
     // Exceptions (stage2-native minimal)
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "set_exception", symbol: "sailfin_runtime_set_exception", return_type: "void", parameter_types: ["i8*"], effects: [],
+        target: "set_exception", symbol: "sailfin_runtime_set_exception", return_type: "void", parameter_types: ["i8*"], effects: []
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "clear_exception", symbol: "sailfin_runtime_clear_exception", return_type: "void", parameter_types: [], effects: [],
+        target: "clear_exception", symbol: "sailfin_runtime_clear_exception", return_type: "void", parameter_types: [], effects: []
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "has_exception", symbol: "sailfin_runtime_has_exception", return_type: "i1", parameter_types: [], effects: [],
+        target: "has_exception", symbol: "sailfin_runtime_has_exception", return_type: "i1", parameter_types: [], effects: []
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "try_enter", symbol: "sailfin_runtime_try_enter", return_type: "i32", parameter_types: ["i8**"], effects: [],
+        target: "try_enter", symbol: "sailfin_runtime_try_enter", return_type: "i32", parameter_types: ["i8**"], effects: []
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "try_leave", symbol: "sailfin_runtime_try_leave", return_type: "void", parameter_types: ["i8*"], effects: [],
+        target: "try_leave", symbol: "sailfin_runtime_try_leave", return_type: "void", parameter_types: ["i8*"], effects: []
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "throw", symbol: "sailfin_runtime_throw", return_type: "void", parameter_types: ["i8*"], effects: [],
+        target: "throw", symbol: "sailfin_runtime_throw", return_type: "void", parameter_types: ["i8*"], effects: []
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "take_exception", symbol: "sailfin_runtime_take_exception", return_type: "i8*", parameter_types: [], effects: [],
+        target: "take_exception", symbol: "sailfin_runtime_take_exception", return_type: "i8*", parameter_types: [], effects: []
     });
 
     // ---- Package-manager primitives ----
     // SHA-256 hashing
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "crypto.sha256", symbol: "sailfin_runtime_sha256_hex", return_type: "i8*", parameter_types: ["i8*", "i64"], effects: [],
+        target: "crypto.sha256", symbol: "sailfin_runtime_sha256_hex", return_type: "i8*", parameter_types: ["i8*", "i64"], effects: []
     });
 
     // Base64 encode/decode
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "base64.encode", symbol: "sailfin_runtime_base64_encode", return_type: "i8*", parameter_types: ["i8*", "i64"], effects: [],
+        target: "base64.encode", symbol: "sailfin_runtime_base64_encode", return_type: "i8*", parameter_types: ["i8*", "i64"], effects: []
     });
 
     // HTTP helpers (curl subprocess)
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "http.get_body", symbol: "sailfin_runtime_http_get", return_type: "i8*", parameter_types: ["i8*"], effects: ["net"],
+        target: "http.get_body", symbol: "sailfin_runtime_http_get", return_type: "i8*", parameter_types: ["i8*"], effects: ["net"]
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "http.post_json", symbol: "sailfin_runtime_http_post_json", return_type: "i8*", parameter_types: ["i8*", "i8*", "i8*"], effects: ["net"],
+        target: "http.post_json", symbol: "sailfin_runtime_http_post_json", return_type: "i8*", parameter_types: ["i8*", "i8*", "i8*"], effects: ["net"]
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "http.download", symbol: "sailfin_runtime_http_download", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: ["net", "io"],
+        target: "http.download", symbol: "sailfin_runtime_http_download", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: ["net", "io"]
     });
 
     // Environment & path helpers
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "env.get", symbol: "sailfin_runtime_getenv", return_type: "i8*", parameter_types: ["i8*"], effects: ["io"],
+        target: "env.get", symbol: "sailfin_runtime_getenv", return_type: "i8*", parameter_types: ["i8*"], effects: ["io"]
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "env.home", symbol: "sailfin_runtime_home_dir", return_type: "i8*", parameter_types: [], effects: ["io"],
+        target: "env.home", symbol: "sailfin_runtime_home_dir", return_type: "i8*", parameter_types: [], effects: ["io"]
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "fs.read_bytes", symbol: "sailfin_runtime_read_file_bytes", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: ["io"],
+        target: "fs.read_bytes", symbol: "sailfin_runtime_read_file_bytes", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: ["io"]
     });
     // Prelude functions called directly by their original name.
     // These are defined in runtime/prelude.sfn and compiled into
@@ -394,17 +394,17 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
     // "monotonic_millis" → sailfin_runtime_monotonic_millis) so it
     // is not duplicated here.
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "find_char", symbol: "find_char", return_type: "double", parameter_types: ["i8*", "i8*", "double"], effects: [],
+        target: "find_char", symbol: "find_char", return_type: "double", parameter_types: ["i8*", "i8*", "double"], effects: []
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "string_starts_with", symbol: "string_starts_with", return_type: "i1", parameter_types: ["i8*", "i8*"], effects: [],
+        target: "string_starts_with", symbol: "string_starts_with", return_type: "i1", parameter_types: ["i8*", "i8*"], effects: []
     });
 
     // Enum tag reader — reads the i32 tag from a NativeInstruction array element.
     // Used by get_instruction_tag in lowering_native_helpers.sfn for the seedcheck
     // binary which cannot use match or the fixup pass to read enum tags.
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "sailfin_enum_tag_from_instruction_array", symbol: "sailfin_enum_tag_from_instruction_array", return_type: "double", parameter_types: ["i8*", "double"], effects: [],
+        target: "sailfin_enum_tag_from_instruction_array", symbol: "sailfin_enum_tag_from_instruction_array", return_type: "double", parameter_types: ["i8*", "double"], effects: []
     });
 
     return descriptors;

--- a/compiler/src/llvm/runtime_helpers.sfn
+++ b/compiler/src/llvm/runtime_helpers.sfn
@@ -2,32 +2,22 @@
 //
 // Runtime helper descriptor definitions for LLVM lowering. These describe
 // the external C runtime functions that Sailfin code can call.
-
 import { RuntimeHelperDescriptor } from "./types";
 import { trim_text } from "./utils";
 
 // =============================================================================
 // Runtime Helper Registry
 // =============================================================================
-
 fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
     let mut descriptors: RuntimeHelperDescriptor[] = [];
     // Raw print: writes to stdout with no prefix, no decoration.
     // Used by the compiler itself for artifact output and CLI messages.
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "print",
-        symbol: "sailfin_runtime_print_raw",
-        return_type: "void",
-        parameter_types: ["i8*"],
-        effects: ["io"],
+        target: "print", symbol: "sailfin_runtime_print_raw", return_type: "void", parameter_types: ["i8*"], effects: ["io"],
     });
     // Raw stderr print: writes to stderr with no prefix, no decoration.
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "print.err",
-            symbol: "sailfin_runtime_print_err",
-            return_type: "void",
-            parameter_types: ["i8*"],
-            effects: ["io"],
+        target: "print.err", symbol: "sailfin_runtime_print_err", return_type: "void", parameter_types: ["i8*"], effects: ["io"],
     });
 
     // Prefixed print variants — print.err/print.warn/print.error write to
@@ -35,782 +25,365 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
     // Compiler diagnostics should use print.err() so they do not pollute
     // stdout (LLVM IR output, program output, etc.).
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "print.info",
-            symbol: "sailfin_runtime_print_info",
-            return_type: "void",
-            parameter_types: ["i8*"],
-            effects: ["io"],
+        target: "print.info", symbol: "sailfin_runtime_print_info", return_type: "void", parameter_types: ["i8*"], effects: ["io"],
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "print.error",
-            symbol: "sailfin_runtime_print_error",
-            return_type: "void",
-            parameter_types: ["i8*"],
-            effects: ["io"],
+        target: "print.error", symbol: "sailfin_runtime_print_error", return_type: "void", parameter_types: ["i8*"], effects: ["io"],
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "print.warn",
-            symbol: "sailfin_runtime_print_warn",
-            return_type: "void",
-            parameter_types: ["i8*"],
-            effects: ["io"],
+        target: "print.warn", symbol: "sailfin_runtime_print_warn", return_type: "void", parameter_types: ["i8*"], effects: ["io"],
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "console.info",
-            symbol: "sailfin_runtime_print_raw",
-            return_type: "void",
-            parameter_types: ["i8*"],
-            effects: ["io"],
+        target: "console.info", symbol: "sailfin_runtime_print_raw", return_type: "void", parameter_types: ["i8*"], effects: ["io"],
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "console.log",
-            symbol: "sailfin_runtime_print_raw",
-            return_type: "void",
-            parameter_types: ["i8*"],
-            effects: ["io"],
+        target: "console.log", symbol: "sailfin_runtime_print_raw", return_type: "void", parameter_types: ["i8*"], effects: ["io"],
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "console.error",
-            symbol: "sailfin_runtime_print_error",
-            return_type: "void",
-            parameter_types: ["i8*"],
-            effects: ["io"],
+        target: "console.error", symbol: "sailfin_runtime_print_error", return_type: "void", parameter_types: ["i8*"], effects: ["io"],
     });
 
     // IO intrinsics
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "io_read",
-            symbol: "sailfin_intrinsic_io_read",
-            return_type: "i8*",
-            parameter_types: ["i8*"],
-            effects: ["io"],
+        target: "io_read", symbol: "sailfin_intrinsic_io_read", return_type: "i8*", parameter_types: ["i8*"], effects: ["io"],
     });
 
     // Filesystem intrinsics
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "fs.read",
-            symbol: "sailfin_intrinsic_fs_read",
-            return_type: "i8*",
-            parameter_types: ["i8*"],
-            effects: ["io"],
+        target: "fs.read", symbol: "sailfin_intrinsic_fs_read", return_type: "i8*", parameter_types: ["i8*"], effects: ["io"],
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "fs.write",
-            symbol: "sailfin_intrinsic_fs_write",
-            return_type: "void",
-            parameter_types: ["i8*", "i8*"],
-            effects: ["io"],
+        target: "fs.write", symbol: "sailfin_intrinsic_fs_write", return_type: "void", parameter_types: ["i8*", "i8*"], effects: ["io"],
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "fs.exists",
-            symbol: "sailfin_intrinsic_fs_exists",
-            return_type: "i1",
-            parameter_types: ["i8*"],
-            effects: ["io"],
+        target: "fs.exists", symbol: "sailfin_intrinsic_fs_exists", return_type: "i1", parameter_types: ["i8*"], effects: ["io"],
     });
 
     // Model intrinsics
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "model_invoke",
-            symbol: "sailfin_intrinsic_model_invoke",
-            return_type: "i8*",
-            parameter_types: ["i8*", "i8*"],
-            effects: ["model"],
+        target: "model_invoke", symbol: "sailfin_intrinsic_model_invoke", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: ["model"],
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "prompt",
-            symbol: "sailfin_intrinsic_model_invoke",
-            return_type: "i8*",
-            parameter_types: ["i8*", "i8*"],
-            effects: ["model"],
+        target: "prompt", symbol: "sailfin_intrinsic_model_invoke", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: ["model"],
     });
 
     // Network intrinsics
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "net_request",
-            symbol: "sailfin_intrinsic_net_request",
-            return_type: "i8*",
-            parameter_types: ["i8*", "i8*", "i8*"],
-            effects: ["net"],
+        target: "net_request", symbol: "sailfin_intrinsic_net_request", return_type: "i8*", parameter_types: ["i8*", "i8*", "i8*"], effects: ["net"],
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "http.get",
-            symbol: "sailfin_intrinsic_http_get",
-            return_type: "i8*",
-            parameter_types: ["i8*"],
-            effects: ["net"],
+        target: "http.get", symbol: "sailfin_intrinsic_http_get", return_type: "i8*", parameter_types: ["i8*"], effects: ["net"],
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "http.post",
-            symbol: "sailfin_intrinsic_http_post",
-            return_type: "i8*",
-            parameter_types: ["i8*", "i8*"],
-            effects: ["net"],
+        target: "http.post", symbol: "sailfin_intrinsic_http_post", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: ["net"],
     });
 
     // Concurrency intrinsics (sleep is existing)
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "sleep",
-            symbol: "sailfin_runtime_sleep",
-            return_type: "void",
-            parameter_types: ["double"],
-            effects: ["clock"],
+        target: "sleep", symbol: "sailfin_runtime_sleep", return_type: "void", parameter_types: ["double"], effects: ["clock"],
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "runtime_sleep_fn",
-            symbol: "sailfin_runtime_sleep",
-            return_type: "void",
-            parameter_types: ["double"],
-            effects: ["clock"],
+        target: "runtime_sleep_fn", symbol: "sailfin_runtime_sleep", return_type: "void", parameter_types: ["double"], effects: ["clock"],
     });
 
     // Monotonic clock for profiling/timing.
     // Support both the prelude binding name and direct calls.
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "runtime_monotonic_millis_fn",
-            symbol: "sailfin_runtime_monotonic_millis",
-            return_type: "double",
-            parameter_types: [],
-            effects: ["clock"],
+        target: "runtime_monotonic_millis_fn", symbol: "sailfin_runtime_monotonic_millis", return_type: "double", parameter_types: [], effects: ["clock"],
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "monotonic_millis",
-            symbol: "sailfin_runtime_monotonic_millis",
-            return_type: "double",
-            parameter_types: [],
-            effects: ["clock"],
+        target: "monotonic_millis", symbol: "sailfin_runtime_monotonic_millis", return_type: "double", parameter_types: [], effects: ["clock"],
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "runtime_channel_fn",
-            symbol: "sailfin_runtime_channel",
-            return_type: "i8*",
-            parameter_types: ["double"],
-            effects: ["io"],
+        target: "runtime_channel_fn", symbol: "sailfin_runtime_channel", return_type: "i8*", parameter_types: ["double"], effects: ["io"],
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "runtime_spawn_fn",
-            symbol: "sailfin_runtime_spawn",
-            return_type: "void",
-            parameter_types: ["i8*", "i8*"],
-            effects: ["io"],
+        target: "runtime_spawn_fn", symbol: "sailfin_runtime_spawn", return_type: "void", parameter_types: ["i8*", "i8*"], effects: ["io"],
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "runtime_parallel_fn",
-            symbol: "sailfin_runtime_parallel",
-            return_type: "i8*",
-            parameter_types: ["i8*"],
-            effects: ["io"],
+        target: "runtime_parallel_fn", symbol: "sailfin_runtime_parallel", return_type: "i8*", parameter_types: ["i8*"], effects: ["io"],
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "runtime_create_capability_grant",
-            symbol: "sailfin_runtime_create_capability_grant",
-            return_type: "i8*",
-            parameter_types: ["i8*"],
-            effects: [],
+        target: "runtime_create_capability_grant", symbol: "sailfin_runtime_create_capability_grant", return_type: "i8*", parameter_types: ["i8*"], effects: [],
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "runtime_create_filesystem_bridge",
-            symbol: "sailfin_runtime_create_filesystem_bridge",
-            return_type: "i8*",
-            parameter_types: ["i8*"],
-            effects: ["io"],
+        target: "runtime_create_filesystem_bridge", symbol: "sailfin_runtime_create_filesystem_bridge", return_type: "i8*", parameter_types: ["i8*"], effects: ["io"],
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "runtime_create_http_bridge",
-            symbol: "sailfin_runtime_create_http_bridge",
-            return_type: "i8*",
-            parameter_types: ["i8*"],
-            effects: ["net"],
+        target: "runtime_create_http_bridge", symbol: "sailfin_runtime_create_http_bridge", return_type: "i8*", parameter_types: ["i8*"], effects: ["net"],
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "runtime_create_model_bridge",
-            symbol: "sailfin_runtime_create_model_bridge",
-            return_type: "i8*",
-            parameter_types: ["i8*"],
-            effects: ["model"],
+        target: "runtime_create_model_bridge", symbol: "sailfin_runtime_create_model_bridge", return_type: "i8*", parameter_types: ["i8*"], effects: ["model"],
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "runtime_log_execution_fn",
-            symbol: "sailfin_runtime_log_execution",
-            return_type: "i8*",
-            parameter_types: ["i8*"],
-            effects: ["io"],
+        target: "runtime_log_execution_fn", symbol: "sailfin_runtime_log_execution", return_type: "i8*", parameter_types: ["i8*"], effects: ["io"],
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "runtime_to_debug_string_fn",
-            symbol: "sailfin_runtime_to_debug_string",
-            return_type: "i8*",
-            parameter_types: ["i8*"],
-            effects: [],
+        target: "runtime_to_debug_string_fn", symbol: "sailfin_runtime_to_debug_string", return_type: "i8*", parameter_types: ["i8*"], effects: [],
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "runtime_raise_value_error_fn",
-            symbol: "sailfin_runtime_raise_value_error",
-            return_type: "void",
-            parameter_types: ["i8*"],
-            effects: [],
+        target: "runtime_raise_value_error_fn", symbol: "sailfin_runtime_raise_value_error", return_type: "void", parameter_types: ["i8*"], effects: [],
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "runtime_is_string_fn",
-            symbol: "sailfin_runtime_is_string",
-            return_type: "i1",
-            parameter_types: ["i8*"],
-            effects: [],
+        target: "runtime_is_string_fn", symbol: "sailfin_runtime_is_string", return_type: "i1", parameter_types: ["i8*"], effects: [],
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "runtime_is_number_fn",
-            symbol: "sailfin_runtime_is_number",
-            return_type: "i1",
-            parameter_types: ["i8*"],
-            effects: [],
+        target: "runtime_is_number_fn", symbol: "sailfin_runtime_is_number", return_type: "i1", parameter_types: ["i8*"], effects: [],
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "runtime_is_boolean_fn",
-            symbol: "sailfin_runtime_is_boolean",
-            return_type: "i1",
-            parameter_types: ["i8*"],
-            effects: [],
+        target: "runtime_is_boolean_fn", symbol: "sailfin_runtime_is_boolean", return_type: "i1", parameter_types: ["i8*"], effects: [],
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "runtime_is_void_fn",
-            symbol: "sailfin_runtime_is_void",
-            return_type: "i1",
-            parameter_types: ["i8*"],
-            effects: [],
+        target: "runtime_is_void_fn", symbol: "sailfin_runtime_is_void", return_type: "i1", parameter_types: ["i8*"], effects: [],
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "runtime.bounds_check",
-            symbol: "sailfin_runtime_bounds_check",
-            return_type: "void",
-            parameter_types: ["i64", "i64"],
-            effects: [],
+        target: "runtime.bounds_check", symbol: "sailfin_runtime_bounds_check", return_type: "void", parameter_types: ["i64", "i64"], effects: [],
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "runtime_is_array_fn",
-            symbol: "sailfin_runtime_is_array",
-            return_type: "i1",
-            parameter_types: ["i8*"],
-            effects: [],
+        target: "runtime_is_array_fn", symbol: "sailfin_runtime_is_array", return_type: "i1", parameter_types: ["i8*"], effects: [],
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "runtime_is_callable_fn",
-            symbol: "sailfin_runtime_is_callable",
-            return_type: "i1",
-            parameter_types: ["i8*"],
-            effects: [],
+        target: "runtime_is_callable_fn", symbol: "sailfin_runtime_is_callable", return_type: "i1", parameter_types: ["i8*"], effects: [],
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "runtime_resolve_runtime_type_fn",
-            symbol: "sailfin_runtime_resolve_type",
-            return_type: "i8*",
-            parameter_types: ["i8*"],
-            effects: [],
+        target: "runtime_resolve_runtime_type_fn", symbol: "sailfin_runtime_resolve_type", return_type: "i8*", parameter_types: ["i8*"], effects: [],
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "runtime_instance_of_fn",
-            symbol: "sailfin_runtime_instance_of",
-            return_type: "i1",
-            parameter_types: ["i8*", "i8*"],
-            effects: [],
+        target: "runtime_instance_of_fn", symbol: "sailfin_runtime_instance_of", return_type: "i1", parameter_types: ["i8*", "i8*"], effects: [],
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "runtime_serve_fn",
-            symbol: "sailfin_runtime_serve",
-            return_type: "void",
-            parameter_types: ["i8*", "i8*"],
-            effects: ["io", "net"],
+        target: "runtime_serve_fn", symbol: "sailfin_runtime_serve", return_type: "void", parameter_types: ["i8*", "i8*"], effects: ["io", "net"],
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "runtime_char_code_fn",
-            symbol: "sailfin_runtime_char_code",
-            return_type: "double",
-            parameter_types: ["i8*"],
-            effects: [],
+        target: "runtime_char_code_fn", symbol: "sailfin_runtime_char_code", return_type: "double", parameter_types: ["i8*"], effects: [],
     });
 
     // Process helpers
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "process.run",
-            symbol: "sailfin_runtime_process_run",
-            return_type: "double",
-            parameter_types: ["{ i8**, i64 }*"],
-            effects: ["io"],
+        target: "process.run", symbol: "sailfin_runtime_process_run", return_type: "double", parameter_types: ["{ i8**, i64 }*"], effects: ["io"],
     });
 
     // Filesystem adapters
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "fs_read_file",
-            symbol: "sailfin_adapter_fs_read_file",
-            return_type: "i8*",
-            parameter_types: ["i8*"],
-            effects: ["io"],
+        target: "fs_read_file", symbol: "sailfin_adapter_fs_read_file", return_type: "i8*", parameter_types: ["i8*"], effects: ["io"],
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "fs.readFile",
-            symbol: "sailfin_adapter_fs_read_file",
-            return_type: "i8*",
-            parameter_types: ["i8*"],
-            effects: ["io"],
+        target: "fs.readFile", symbol: "sailfin_adapter_fs_read_file", return_type: "i8*", parameter_types: ["i8*"], effects: ["io"],
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "fs_write_file",
-            symbol: "sailfin_adapter_fs_write_file",
-            return_type: "void",
-            parameter_types: ["i8*", "i8*"],
-            effects: ["io"],
+        target: "fs_write_file", symbol: "sailfin_adapter_fs_write_file", return_type: "void", parameter_types: ["i8*", "i8*"], effects: ["io"],
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "fs.writeFile",
-            symbol: "sailfin_adapter_fs_write_file",
-            return_type: "void",
-            parameter_types: ["i8*", "i8*"],
-            effects: ["io"],
+        target: "fs.writeFile", symbol: "sailfin_adapter_fs_write_file", return_type: "void", parameter_types: ["i8*", "i8*"], effects: ["io"],
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "fs_append_file",
-            symbol: "sailfin_adapter_fs_append_file",
-            return_type: "void",
-            parameter_types: ["i8*", "i8*"],
-            effects: ["io"],
+        target: "fs_append_file", symbol: "sailfin_adapter_fs_append_file", return_type: "void", parameter_types: ["i8*", "i8*"], effects: ["io"],
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "fs.appendFile",
-            symbol: "sailfin_adapter_fs_append_file",
-            return_type: "void",
-            parameter_types: ["i8*", "i8*"],
-            effects: ["io"],
+        target: "fs.appendFile", symbol: "sailfin_adapter_fs_append_file", return_type: "void", parameter_types: ["i8*", "i8*"], effects: ["io"],
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "fs_write_lines",
-            symbol: "sailfin_adapter_fs_write_lines",
-            return_type: "void",
-            parameter_types: ["i8*", "{ i8**, i64 }*"],
-            effects: ["io"],
+        target: "fs_write_lines", symbol: "sailfin_adapter_fs_write_lines", return_type: "void", parameter_types: ["i8*", "{ i8**, i64 }*"], effects: ["io"],
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "fs.writeLines",
-            symbol: "sailfin_adapter_fs_write_lines",
-            return_type: "void",
-            parameter_types: ["i8*", "{ i8**, i64 }*"],
-            effects: ["io"],
+        target: "fs.writeLines", symbol: "sailfin_adapter_fs_write_lines", return_type: "void", parameter_types: ["i8*", "{ i8**, i64 }*"], effects: ["io"],
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "fs_list_directory",
-            symbol: "sailfin_adapter_fs_list_directory",
-            return_type: "{ i8**, i64 }*",
-            parameter_types: ["i8*"],
-            effects: ["io"],
+        target: "fs_list_directory", symbol: "sailfin_adapter_fs_list_directory", return_type: "{ i8**, i64 }*", parameter_types: ["i8*"], effects: ["io"],
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "fs.listDirectory",
-            symbol: "sailfin_adapter_fs_list_directory",
-            return_type: "{ i8**, i64 }*",
-            parameter_types: ["i8*"],
-            effects: ["io"],
+        target: "fs.listDirectory", symbol: "sailfin_adapter_fs_list_directory", return_type: "{ i8**, i64 }*", parameter_types: ["i8*"], effects: ["io"],
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "fs_delete_file",
-            symbol: "sailfin_adapter_fs_delete_file",
-            return_type: "i1",
-            parameter_types: ["i8*"],
-            effects: ["io"],
+        target: "fs_delete_file", symbol: "sailfin_adapter_fs_delete_file", return_type: "i1", parameter_types: ["i8*"], effects: ["io"],
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "fs.deleteFile",
-            symbol: "sailfin_adapter_fs_delete_file",
-            return_type: "i1",
-            parameter_types: ["i8*"],
-            effects: ["io"],
+        target: "fs.deleteFile", symbol: "sailfin_adapter_fs_delete_file", return_type: "i1", parameter_types: ["i8*"], effects: ["io"],
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "fs_create_directory",
-            symbol: "sailfin_adapter_fs_create_directory",
-            return_type: "i1",
-            parameter_types: ["i8*", "i1"],
-            effects: ["io"],
+        target: "fs_create_directory", symbol: "sailfin_adapter_fs_create_directory", return_type: "i1", parameter_types: ["i8*", "i1"], effects: ["io"],
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "fs.createDirectory",
-            symbol: "sailfin_adapter_fs_create_directory",
-            return_type: "i1",
-            parameter_types: ["i8*", "i1"],
-            effects: ["io"],
+        target: "fs.createDirectory", symbol: "sailfin_adapter_fs_create_directory", return_type: "i1", parameter_types: ["i8*", "i1"], effects: ["io"],
     });
 
     // HTTP adapters (distinct from intrinsics for adapter infrastructure)
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "http_get",
-            symbol: "sailfin_adapter_http_get",
-            return_type: "i8*",
-            parameter_types: ["i8*"],
-            effects: ["net"],
+        target: "http_get", symbol: "sailfin_adapter_http_get", return_type: "i8*", parameter_types: ["i8*"], effects: ["net"],
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "http_post",
-            symbol: "sailfin_adapter_http_post",
-            return_type: "i8*",
-            parameter_types: ["i8*", "i8*"],
-            effects: ["net"],
+        target: "http_post", symbol: "sailfin_adapter_http_post", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: ["net"],
     });
 
     // Model adapter
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "model_invoke_with_prompt",
-            symbol: "sailfin_adapter_model_invoke_with_prompt",
-            return_type: "i8*",
-            parameter_types: ["i8*", "i8*"],
-            effects: ["model"],
+        target: "model_invoke_with_prompt", symbol: "sailfin_adapter_model_invoke_with_prompt", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: ["model"],
     });
 
     // Serve adapters
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "serve_start",
-            symbol: "sailfin_adapter_serve_start",
-            return_type: "void",
-            parameter_types: ["i8*", "i32"],
-            effects: ["net", "io"],
+        target: "serve_start", symbol: "sailfin_adapter_serve_start", return_type: "void", parameter_types: ["i8*", "i32"], effects: ["net", "io"],
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "serve_handler_dispatch",
-            symbol: "sailfin_adapter_serve_handler_dispatch",
-            return_type: "i8*",
-            parameter_types: ["i8*", "i8*"],
-            effects: ["net", "io"],
+        target: "serve_handler_dispatch", symbol: "sailfin_adapter_serve_handler_dispatch", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: ["net", "io"],
     });
 
     // Concurrency adapters
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "spawn_task",
-            symbol: "sailfin_adapter_spawn_task",
-            return_type: "i8*",
-            parameter_types: ["i8*"],
-            effects: ["spawn"],
+        target: "spawn_task", symbol: "sailfin_adapter_spawn_task", return_type: "i8*", parameter_types: ["i8*"], effects: ["spawn"],
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "channel_create",
-            symbol: "sailfin_adapter_channel_create",
-            return_type: "i8*",
-            parameter_types: ["i32"],
-            effects: [],
+        target: "channel_create", symbol: "sailfin_adapter_channel_create", return_type: "i8*", parameter_types: ["i32"], effects: [],
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "channel_send",
-            symbol: "sailfin_adapter_channel_send",
-            return_type: "void",
-            parameter_types: ["i8*", "i8*"],
-            effects: ["channel"],
+        target: "channel_send", symbol: "sailfin_adapter_channel_send", return_type: "void", parameter_types: ["i8*", "i8*"], effects: ["channel"],
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "channel_receive",
-            symbol: "sailfin_adapter_channel_receive",
-            return_type: "i8*",
-            parameter_types: ["i8*"],
-            effects: ["channel"],
+        target: "channel_receive", symbol: "sailfin_adapter_channel_receive", return_type: "i8*", parameter_types: ["i8*"], effects: ["channel"],
     });
 
     // Collection helpers
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "runtime_array_map_fn",
-            symbol: "sailfin_runtime_array_map",
-            return_type: "i8*",
-            parameter_types: ["i8*", "i8*"],
-            effects: [],
+        target: "runtime_array_map_fn", symbol: "sailfin_runtime_array_map", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: [],
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "runtime_array_filter_fn",
-            symbol: "sailfin_runtime_array_filter",
-            return_type: "i8*",
-            parameter_types: ["i8*", "i8*"],
-            effects: [],
+        target: "runtime_array_filter_fn", symbol: "sailfin_runtime_array_filter", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: [],
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "runtime_array_reduce_fn",
-            symbol: "sailfin_runtime_array_reduce",
-            return_type: "i8*",
-            parameter_types: ["i8*", "i8*", "i8*"],
-            effects: [],
+        target: "runtime_array_reduce_fn", symbol: "sailfin_runtime_array_reduce", return_type: "i8*", parameter_types: ["i8*", "i8*", "i8*"], effects: [],
     });
 
     // String utility helpers
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "substring",
-            symbol: "substring",
-            return_type: "i8*",
-            parameter_types: ["i8*", "double", "double"],
-            effects: [],
+        target: "substring", symbol: "substring", return_type: "i8*", parameter_types: ["i8*", "double", "double"], effects: [],
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "substring_unchecked",
-            symbol: "substring_unchecked",
-            return_type: "i8*",
-            parameter_types: ["i8*", "double", "double"],
-            effects: [],
+        target: "substring_unchecked", symbol: "substring_unchecked", return_type: "i8*", parameter_types: ["i8*", "double", "double"], effects: [],
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "string.length",
-            symbol: "sailfin_runtime_string_length",
-            return_type: "i64",
-            parameter_types: ["i8*"],
-            effects: [],
+        target: "string.length", symbol: "sailfin_runtime_string_length", return_type: "i64", parameter_types: ["i8*"], effects: [],
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "string.concat",
-            symbol: "sailfin_runtime_string_concat",
-            return_type: "i8*",
-            parameter_types: ["i8*", "i8*"],
-            effects: [],
+        target: "string.concat", symbol: "sailfin_runtime_string_concat", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: [],
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "string.append",
-            symbol: "sailfin_runtime_string_append",
-            return_type: "i8*",
-            parameter_types: ["i8*", "i8*"],
-            effects: [],
+        target: "string.append", symbol: "sailfin_runtime_string_append", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: [],
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "string.drop",
-            symbol: "sailfin_runtime_string_drop",
-            return_type: "void",
-            parameter_types: ["i8*"],
-            effects: [],
+        target: "string.drop", symbol: "sailfin_runtime_string_drop", return_type: "void", parameter_types: ["i8*"], effects: [],
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "number.to_string",
-            symbol: "sailfin_runtime_number_to_string",
-            return_type: "i8*",
-            parameter_types: ["double"],
-            effects: [],
+        target: "number.to_string", symbol: "sailfin_runtime_number_to_string", return_type: "i8*", parameter_types: ["double"], effects: [],
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "string.to_number",
-            symbol: "sailfin_runtime_string_to_number",
-            return_type: "double",
-            parameter_types: ["i8*"],
-            effects: [],
+        target: "string.to_number", symbol: "sailfin_runtime_string_to_number", return_type: "double", parameter_types: ["i8*"], effects: [],
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "strings_equal",
-            symbol: "strings_equal",
-            return_type: "i1",
-            parameter_types: ["i8*", "i8*"],
-            effects: [],
+        target: "strings_equal", symbol: "strings_equal", return_type: "i1", parameter_types: ["i8*", "i8*"], effects: [],
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "char_code",
-            symbol: "char_code",
-            return_type: "double",
-            parameter_types: ["i8*"],
-            effects: [],
+        target: "char_code", symbol: "char_code", return_type: "double", parameter_types: ["i8*"], effects: [],
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "runtime_grapheme_count_fn",
-            symbol: "sailfin_runtime_grapheme_count",
-            return_type: "double",
-            parameter_types: ["i8*"],
-            effects: [],
+        target: "runtime_grapheme_count_fn", symbol: "sailfin_runtime_grapheme_count", return_type: "double", parameter_types: ["i8*"], effects: [],
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "runtime_grapheme_at_fn",
-            symbol: "sailfin_runtime_grapheme_at",
-            return_type: "i8*",
-            parameter_types: ["i8*", "double"],
-            effects: [],
+        target: "runtime_grapheme_at_fn", symbol: "sailfin_runtime_grapheme_at", return_type: "i8*", parameter_types: ["i8*", "double"], effects: [],
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "grapheme_at",
-            symbol: "sailfin_runtime_grapheme_at",
-            return_type: "i8*",
-            parameter_types: ["i8*", "double"],
-            effects: [],
+        target: "grapheme_at", symbol: "sailfin_runtime_grapheme_at", return_type: "i8*", parameter_types: ["i8*", "double"], effects: [],
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "is_whitespace_char",
-            symbol: "sailfin_runtime_is_whitespace_char",
-            return_type: "i1",
-            parameter_types: ["i8"],
-            effects: [],
+        target: "is_whitespace_char", symbol: "sailfin_runtime_is_whitespace_char", return_type: "i1", parameter_types: ["i8"], effects: [],
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "is_decimal_digit",
-            symbol: "sailfin_runtime_is_decimal_digit",
-            return_type: "i1",
-            parameter_types: ["i8"],
-            effects: [],
+        target: "is_decimal_digit", symbol: "sailfin_runtime_is_decimal_digit", return_type: "i1", parameter_types: ["i8"], effects: [],
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "is_alpha_char",
-            symbol: "sailfin_runtime_is_alpha_char",
-            return_type: "i1",
-            parameter_types: ["i8"],
-            effects: [],
+        target: "is_alpha_char", symbol: "sailfin_runtime_is_alpha_char", return_type: "i1", parameter_types: ["i8"], effects: [],
     });
 
     // Array/collection helpers (generic using i8* for element type)
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "append_string",
-            symbol: "sailfin_runtime_append_string",
-            return_type: "{ i8**, i64 }*",
-            parameter_types: ["{ i8**, i64 }*", "i8*"],
-            effects: [],
+        target: "append_string", symbol: "sailfin_runtime_append_string", return_type: "{ i8**, i64 }*", parameter_types: ["{ i8**, i64 }*", "i8*"], effects: [],
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "concat",
-            symbol: "sailfin_runtime_concat",
-            return_type: "{ i8**, i64 }*",
-            parameter_types: ["{ i8**, i64 }*", "{ i8**, i64 }*"],
-            effects: [],
+        target: "concat", symbol: "sailfin_runtime_concat", return_type: "{ i8**, i64 }*", parameter_types: ["{ i8**, i64 }*", "{ i8**, i64 }*"], effects: [],
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "copy_bytes",
-            symbol: "sailfin_runtime_copy_bytes",
-            return_type: "void",
-            parameter_types: ["i8*", "i8*", "i64"],
-            effects: [],
+        target: "copy_bytes", symbol: "sailfin_runtime_copy_bytes", return_type: "void", parameter_types: ["i8*", "i8*", "i64"], effects: [],
     });
 
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "array_push_slot",
-            symbol: "sailfin_runtime_array_push_slot",
-            return_type: "i8*",
-            parameter_types: ["i8**", "i64*", "i64"],
-            effects: [],
+        target: "array_push_slot", symbol: "sailfin_runtime_array_push_slot", return_type: "i8*", parameter_types: ["i8**", "i64*", "i64"], effects: [],
     });
 
     // Generic field accessor for opaque imported types
     // Takes object pointer and field name, returns field value as i8*
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "get_field",
-            symbol: "sailfin_runtime_get_field",
-            return_type: "i8*",
-            parameter_types: ["i8*", "i8*"],
-            effects: [],
+        target: "get_field", symbol: "sailfin_runtime_get_field", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: [],
     });
 
     // String persistence helper for Stage2 memory management
     // Marks string pointers as persistent so they survive across LLVM function boundaries
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "mark_persistent",
-            symbol: "sailfin_runtime_mark_persistent",
-            return_type: "void",
-            parameter_types: ["i8*"],
-            effects: [],
+        target: "mark_persistent", symbol: "sailfin_runtime_mark_persistent", return_type: "void", parameter_types: ["i8*"], effects: [],
     });
 
     // Exceptions (stage2-native minimal)
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "set_exception",
-            symbol: "sailfin_runtime_set_exception",
-            return_type: "void",
-            parameter_types: ["i8*"],
-            effects: [],
+        target: "set_exception", symbol: "sailfin_runtime_set_exception", return_type: "void", parameter_types: ["i8*"], effects: [],
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "clear_exception",
-            symbol: "sailfin_runtime_clear_exception",
-            return_type: "void",
-            parameter_types: [],
-            effects: [],
+        target: "clear_exception", symbol: "sailfin_runtime_clear_exception", return_type: "void", parameter_types: [], effects: [],
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "has_exception",
-            symbol: "sailfin_runtime_has_exception",
-            return_type: "i1",
-            parameter_types: [],
-            effects: [],
+        target: "has_exception", symbol: "sailfin_runtime_has_exception", return_type: "i1", parameter_types: [], effects: [],
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "try_enter",
-            symbol: "sailfin_runtime_try_enter",
-            return_type: "i32",
-            parameter_types: ["i8**"],
-            effects: [],
+        target: "try_enter", symbol: "sailfin_runtime_try_enter", return_type: "i32", parameter_types: ["i8**"], effects: [],
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "try_leave",
-            symbol: "sailfin_runtime_try_leave",
-            return_type: "void",
-            parameter_types: ["i8*"],
-            effects: [],
+        target: "try_leave", symbol: "sailfin_runtime_try_leave", return_type: "void", parameter_types: ["i8*"], effects: [],
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "throw",
-            symbol: "sailfin_runtime_throw",
-            return_type: "void",
-            parameter_types: ["i8*"],
-            effects: [],
+        target: "throw", symbol: "sailfin_runtime_throw", return_type: "void", parameter_types: ["i8*"], effects: [],
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "take_exception",
-            symbol: "sailfin_runtime_take_exception",
-            return_type: "i8*",
-            parameter_types: [],
-            effects: [],
+        target: "take_exception", symbol: "sailfin_runtime_take_exception", return_type: "i8*", parameter_types: [], effects: [],
     });
 
     // ---- Package-manager primitives ----
-
     // SHA-256 hashing
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "crypto.sha256",
-            symbol: "sailfin_runtime_sha256_hex",
-            return_type: "i8*",
-            parameter_types: ["i8*", "i64"],
-            effects: [],
+        target: "crypto.sha256", symbol: "sailfin_runtime_sha256_hex", return_type: "i8*", parameter_types: ["i8*", "i64"], effects: [],
     });
 
     // Base64 encode/decode
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "base64.encode",
-            symbol: "sailfin_runtime_base64_encode",
-            return_type: "i8*",
-            parameter_types: ["i8*", "i64"],
-            effects: [],
+        target: "base64.encode", symbol: "sailfin_runtime_base64_encode", return_type: "i8*", parameter_types: ["i8*", "i64"], effects: [],
     });
 
     // HTTP helpers (curl subprocess)
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "http.get_body",
-            symbol: "sailfin_runtime_http_get",
-            return_type: "i8*",
-            parameter_types: ["i8*"],
-            effects: ["net"],
+        target: "http.get_body", symbol: "sailfin_runtime_http_get", return_type: "i8*", parameter_types: ["i8*"], effects: ["net"],
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "http.post_json",
-            symbol: "sailfin_runtime_http_post_json",
-            return_type: "i8*",
-            parameter_types: ["i8*", "i8*", "i8*"],
-            effects: ["net"],
+        target: "http.post_json", symbol: "sailfin_runtime_http_post_json", return_type: "i8*", parameter_types: ["i8*", "i8*", "i8*"], effects: ["net"],
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "http.download",
-            symbol: "sailfin_runtime_http_download",
-            return_type: "i8*",
-            parameter_types: ["i8*", "i8*"],
-            effects: ["net", "io"],
+        target: "http.download", symbol: "sailfin_runtime_http_download", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: ["net", "io"],
     });
 
     // Environment & path helpers
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "env.get",
-            symbol: "sailfin_runtime_getenv",
-            return_type: "i8*",
-            parameter_types: ["i8*"],
-            effects: ["io"],
+        target: "env.get", symbol: "sailfin_runtime_getenv", return_type: "i8*", parameter_types: ["i8*"], effects: ["io"],
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "env.home",
-            symbol: "sailfin_runtime_home_dir",
-            return_type: "i8*",
-            parameter_types: [],
-            effects: ["io"],
+        target: "env.home", symbol: "sailfin_runtime_home_dir", return_type: "i8*", parameter_types: [], effects: ["io"],
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "fs.read_bytes",
-            symbol: "sailfin_runtime_read_file_bytes",
-            return_type: "i8*",
-            parameter_types: ["i8*", "i8*"],
-            effects: ["io"],
+        target: "fs.read_bytes", symbol: "sailfin_runtime_read_file_bytes", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: ["io"],
     });
     // Prelude functions called directly by their original name.
     // These are defined in runtime/prelude.sfn and compiled into
@@ -821,29 +394,17 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
     // "monotonic_millis" → sailfin_runtime_monotonic_millis) so it
     // is not duplicated here.
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "find_char",
-            symbol: "find_char",
-            return_type: "double",
-            parameter_types: ["i8*", "i8*", "double"],
-            effects: [],
+        target: "find_char", symbol: "find_char", return_type: "double", parameter_types: ["i8*", "i8*", "double"], effects: [],
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "string_starts_with",
-            symbol: "string_starts_with",
-            return_type: "i1",
-            parameter_types: ["i8*", "i8*"],
-            effects: [],
+        target: "string_starts_with", symbol: "string_starts_with", return_type: "i1", parameter_types: ["i8*", "i8*"], effects: [],
     });
 
     // Enum tag reader — reads the i32 tag from a NativeInstruction array element.
     // Used by get_instruction_tag in lowering_native_helpers.sfn for the seedcheck
     // binary which cannot use match or the fixup pass to read enum tags.
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-            target: "sailfin_enum_tag_from_instruction_array",
-            symbol: "sailfin_enum_tag_from_instruction_array",
-            return_type: "double",
-            parameter_types: ["i8*", "double"],
-            effects: [],
+        target: "sailfin_enum_tag_from_instruction_array", symbol: "sailfin_enum_tag_from_instruction_array", return_type: "double", parameter_types: ["i8*", "double"], effects: [],
     });
 
     return descriptors;
@@ -860,9 +421,7 @@ fn find_runtime_helper(target: string) -> RuntimeHelperDescriptor? {
     let trimmed = trim_text(target);
     let mut index: number = 0;
     loop {
-        if index >= descriptors.length {
-            break;
-        }
+        if index >= descriptors.length { break; }
         if descriptors[index].target == trimmed {
             return descriptors[index];
         }

--- a/compiler/src/llvm/strings.sfn
+++ b/compiler/src/llvm/strings.sfn
@@ -97,7 +97,12 @@ fn render_string_constants(constants: StringConstant[]) -> string[] {
                 if constant.content != null {
                     let escaped = escape_string_for_llvm(constant.content);
                     let length_str = number_to_string(constant.byte_count + 1);
-                    let declaration = constant.name + " = private unnamed_addr constant [" + length_str + " x i8] c\"" + escaped + "\\00\"";
+                    let declaration = constant.name
+                        + " = private unnamed_addr constant ["
+                        + length_str
+                        + " x i8] c\""
+                        + escaped
+                        + "\\00\"";
                     lines.push(declaration);
                 }
             }

--- a/compiler/src/llvm/strings.sfn
+++ b/compiler/src/llvm/strings.sfn
@@ -2,59 +2,40 @@
 //
 // String constant management for LLVM IR generation. Handles deduplication,
 // escaping, and rendering of string constants in LLVM IR format.
-
 import { substring } from "../string_utils";
 import { StringConstant } from "./types";
-import { number_to_string, append_string } from "./utils";
+import { append_string, number_to_string } from "./utils";
 
 // =============================================================================
 // String Constant Set Operations
 // =============================================================================
-
-fn empty_string_constant_set() -> StringConstant[] {
-    return [];
-}
+fn empty_string_constant_set() -> StringConstant[] { return []; }
 
 fn string_constant_singleton(constant: StringConstant) -> StringConstant[] {
     return [constant];
 }
 
-
 fn append_string_constant(set: StringConstant[], constant: StringConstant) -> StringConstant[] {
     let mut out = set;
-    if out == null {
-        out = [];
-    }
-    if constant == null {
-        return out;
-    }
+    if out == null { out = []; }
+    if constant == null { return out; }
     out = out.push(constant);
     return out;
 }
 
 fn merge_string_constants(existing: StringConstant[], new_constants: StringConstant[]) -> StringConstant[] {
     let mut safe_existing = existing;
-    if safe_existing == null {
-        safe_existing = [];
-    }
+    if safe_existing == null { safe_existing = []; }
     let mut safe_new_constants = new_constants;
-    if safe_new_constants == null {
-        return safe_existing;
-    }
-    if safe_new_constants.length == 0 {
-        return safe_existing;
-    }
-    if safe_existing.length == 0 {
-        return safe_new_constants;
-    }
+    if safe_new_constants == null { return safe_existing; }
+    if safe_new_constants.length == 0 { return safe_existing; }
+    if safe_existing.length == 0 { return safe_new_constants; }
 
     // Append new constants directly onto the existing array (in-place via push)
     // to avoid cloning the entire set on every merge.
     let mut index: number = 0;
     loop {
-        if index >= safe_new_constants.length {
-            break;
-        }
+        if index >= safe_new_constants.length { break; }
         let candidate = safe_new_constants[index];
         let mut _if298: boolean = false;
         if candidate == null { _if298 = true; }
@@ -64,9 +45,7 @@ fn merge_string_constants(existing: StringConstant[], new_constants: StringConst
             continue;
         }
         let found_by_name = find_string_constant_by_name(safe_existing, candidate.name);
-        if found_by_name == null {
-            safe_existing.push(candidate);
-        }
+        if found_by_name == null { safe_existing.push(candidate); }
         index += 1;
     }
     return safe_existing;
@@ -75,21 +54,14 @@ fn merge_string_constants(existing: StringConstant[], new_constants: StringConst
 // =============================================================================
 // String Constant Lookup
 // =============================================================================
-
 fn find_string_constant(constants: StringConstant[], content: string) -> StringConstant? {
-    if constants == null {
-        return null;
-    }
+    if constants == null { return null; }
     let mut index: number = 0;
     loop {
-        if index >= constants.length {
-            break;
-        }
+        if index >= constants.length { break; }
         let candidate = constants[index];
         if candidate != null {
-            if candidate.content == content {
-                return candidate;
-            }
+            if candidate.content == content { return candidate; }
         }
         index += 1;
     }
@@ -97,19 +69,13 @@ fn find_string_constant(constants: StringConstant[], content: string) -> StringC
 }
 
 fn find_string_constant_by_name(constants: StringConstant[], name: string) -> StringConstant? {
-    if constants == null {
-        return null;
-    }
+    if constants == null { return null; }
     let mut index: number = 0;
     loop {
-        if index >= constants.length {
-            break;
-        }
+        if index >= constants.length { break; }
         let candidate = constants[index];
         if candidate != null {
-            if candidate.name == name {
-                return candidate;
-            }
+            if candidate.name == name { return candidate; }
         }
         index += 1;
     }
@@ -119,17 +85,12 @@ fn find_string_constant_by_name(constants: StringConstant[], name: string) -> St
 // =============================================================================
 // LLVM IR Rendering
 // =============================================================================
-
 fn render_string_constants(constants: StringConstant[]) -> string[] {
-    if constants == null {
-        return [];
-    }
+    if constants == null { return []; }
     let mut lines: string[] = [];
     let mut index: number = 0;
     loop {
-        if index >= constants.length {
-            break;
-        }
+        if index >= constants.length { break; }
         let constant = constants[index];
         if constant != null {
             if constant.name != null {
@@ -147,9 +108,7 @@ fn render_string_constants(constants: StringConstant[]) -> string[] {
 }
 
 fn escape_string_for_llvm(content: string) -> string {
-    if content == null {
-        return "";
-    }
+    if content == null { return ""; }
     // Build the result by collecting unchanged-text runs and escape sequences
     // as chunks, then assemble at the end. The previous implementation did
     // `result = result + ch` per character, which is O(N^2) in memory under
@@ -160,20 +119,12 @@ fn escape_string_for_llvm(content: string) -> string {
     let mut chunk_start: number = 0;
     let mut index: number = 0;
     loop {
-        if index >= content.length {
-            break;
-        }
+        if index >= content.length { break; }
         let ch = substring(content, index, index + 1);
         let mut esc: string = "";
-        if ch == "\n" {
-            esc = "\\0A";
-        } else if ch == "\r" {
-            esc = "\\0D";
-        } else if ch == "\t" {
+        if ch == "\n" { esc = "\\0A"; } else if ch == "\r" { esc = "\\0D"; } else if ch == "\t" {
             esc = "\\09";
-        } else if ch == "\"" {
-            esc = "\\22";
-        } else if ch == "\\" {
+        } else if ch == "\"" { esc = "\\22"; } else if ch == "\\" {
             esc = "\\5C";
         }
         if esc.length > 0 {
@@ -188,18 +139,12 @@ fn escape_string_for_llvm(content: string) -> string {
     if chunk_start < content.length {
         chunks.push(substring(content, chunk_start, content.length));
     }
-    if chunks.length == 0 {
-        return "";
-    }
-    if chunks.length == 1 {
-        return chunks[0];
-    }
+    if chunks.length == 0 { return ""; }
+    if chunks.length == 1 { return chunks[0]; }
     let mut result: string = chunks[0];
     let mut i: number = 1;
     loop {
-        if i >= chunks.length {
-            break;
-        }
+        if i >= chunks.length { break; }
         result = result + chunks[i];
         i += 1;
     }

--- a/compiler/src/llvm/type_context.sfn
+++ b/compiler/src/llvm/type_context.sfn
@@ -3,47 +3,57 @@
 // TypeContext building functions. Constructs type metadata from
 // NativeStruct/NativeEnum/NativeInterface definitions. Lookup and
 // query functions live in type_context_queries.sfn.
-
-import { NativeStruct, NativeEnum, NativeEnumLayout, NativeEnumVariantLayout, NativeInterface, NativeFunction, NativeInterfaceSignature } from "../native_ir";
+import {
+    NativeEnum,
+    NativeEnumLayout,
+    NativeEnumVariantLayout,
+    NativeFunction,
+    NativeInterface,
+    NativeInterfaceSignature,
+    NativeStruct
+} from "../native_ir";
 import { substring } from "../string_utils";
 import {
-    TypeContext,
-    TypeContextBuild,
-    StructTypeInfo,
-    StructFieldInfo,
+    join_with_separator,
+    struct_declares_interface,
+    struct_satisfies_interface_structurally
+} from "./type_context_queries";
+import {
+    ends_with_pointer_suffix,
+    layout_annotation_base_type,
+    layout_annotation_represents_user_value,
+    map_struct_field_annotation,
+    map_type_annotation,
+    strip_pointer_suffix
+} from "./type_mapping";
+import {
     EnumTypeInfo,
     EnumVariantInfo,
     InterfaceTypeInfo,
-    VTableInfo,
-    VTableEntry,
-    TypeAllocationInfo,
+    LocalBinding,
     ParameterBinding,
-    LocalBinding
+    StructFieldInfo,
+    StructTypeInfo,
+    TypeAllocationInfo,
+    TypeContext,
+    TypeContextBuild,
+    VTableEntry,
+    VTableInfo
 } from "./types";
 import {
-    trim_text,
     append_string,
-    sanitize_symbol,
-    is_simple_identifier,
     find_last_index_of_char,
     index_of,
+    is_simple_identifier,
+    number_to_string,
+    sanitize_symbol,
     string_array_contains,
-    number_to_string
+    trim_text
 } from "./utils";
-import {
-    map_type_annotation,
-    map_struct_field_annotation,
-    ends_with_pointer_suffix,
-    strip_pointer_suffix,
-    layout_annotation_base_type,
-    layout_annotation_represents_user_value
-} from "./type_mapping";
-import { struct_declares_interface, struct_satisfies_interface_structurally, join_with_separator } from "./type_context_queries";
 
 // =============================================================================
 // Enum Layout Fixups
 // =============================================================================
-
 struct EnumLayoutFixupResult {
     enums: NativeEnum[];
     diagnostics: string[];
@@ -52,13 +62,9 @@ struct EnumLayoutFixupResult {
 fn is_unit_enum(enum_def: NativeEnum) -> boolean {
     let mut index: number = 0;
     loop {
-        if index >= enum_def.variants.length {
-            break;
-        }
+        if index >= enum_def.variants.length { break; }
         let variant = enum_def.variants[index];
-        if variant.fields.length > 0 {
-            return false;
-        }
+        if variant.fields.length > 0 { return false; }
         index += 1;
     }
     return true;
@@ -70,17 +76,10 @@ fn synthesize_unit_enum_layout(enum_def: NativeEnum) -> NativeEnumLayout {
     let mut layouts: NativeEnumVariantLayout[] = [];
     let mut index: number = 0;
     loop {
-        if index >= enum_def.variants.length {
-            break;
-        }
+        if index >= enum_def.variants.length { break; }
         let variant = enum_def.variants[index];
         layouts.push(NativeEnumVariantLayout {
-                name: variant.name,
-                tag: index,
-                offset: 0,
-                size: tag_size,
-                align: tag_align,
-                fields: [],
+            name: variant.name, tag: index, offset: 0, size: tag_size, align: tag_align, fields: [],
         });
         index += 1;
     }
@@ -95,30 +94,22 @@ fn synthesize_unit_enum_layout(enum_def: NativeEnum) -> NativeEnumLayout {
 }
 
 fn enum_layout_matches_variants(enum_def: NativeEnum, layout: NativeEnumLayout) -> boolean {
-    if layout.variants.length != enum_def.variants.length {
-        return false;
-    }
+    if layout.variants.length != enum_def.variants.length { return false; }
     let mut index: number = 0;
     loop {
-        if index >= enum_def.variants.length {
-            break;
-        }
+        if index >= enum_def.variants.length { break; }
         let expected = enum_def.variants[index].name;
         let mut found: boolean = false;
         let mut layout_index: number = 0;
         loop {
-            if layout_index >= layout.variants.length {
-                break;
-            }
+            if layout_index >= layout.variants.length { break; }
             if layout.variants[layout_index].name == expected {
                 found = true;
                 break;
             }
             layout_index += 1;
         }
-        if !found {
-            return false;
-        }
+        if !found { return false; }
         index += 1;
     }
     return true;
@@ -135,15 +126,17 @@ fn fixup_enum_layouts(enums: NativeEnum[]) -> EnumLayoutFixupResult {
     let mut updated: NativeEnum[] = [];
     let mut index: number = 0;
     loop {
-        if index >= enums.length {
-            break;
-        }
+        if index >= enums.length { break; }
         let enum_def = enums[index];
         let mut fixed = enum_def;
 
         if enum_def.layout == null {
             if is_unit_enum(enum_def) {
-                fixed = NativeEnum { name: enum_def.name, variants: enum_def.variants, layout: synthesize_unit_enum_layout(enum_def) };
+                fixed = NativeEnum {
+                    name: enum_def.name,
+                    variants: enum_def.variants,
+                    layout: synthesize_unit_enum_layout(enum_def)
+                };
                 diagnostics.push("llvm lowering: enum `" + enum_def.name + "` missing layout metadata; synthesized unit-enum layout");
             }
             updated.push(fixed);
@@ -154,7 +147,11 @@ fn fixup_enum_layouts(enums: NativeEnum[]) -> EnumLayoutFixupResult {
         let layout = enum_def.layout;
         if !enum_layout_matches_variants(enum_def, layout) {
             if is_unit_enum(enum_def) {
-                fixed = NativeEnum { name: enum_def.name, variants: enum_def.variants, layout: synthesize_unit_enum_layout(enum_def) };
+                fixed = NativeEnum {
+                    name: enum_def.name,
+                    variants: enum_def.variants,
+                    layout: synthesize_unit_enum_layout(enum_def)
+                };
                 diagnostics.push("llvm lowering: enum `" + enum_def.name + "` layout variants incomplete/garbled; synthesized unit-enum layout");
             } else {
                 diagnostics.push("llvm lowering: enum `" + enum_def.name + "` layout variants incomplete/garbled; payload enums require full layout metadata");
@@ -171,9 +168,13 @@ fn fixup_enum_layouts(enums: NativeEnum[]) -> EnumLayoutFixupResult {
 // =============================================================================
 // TypeContext Construction
 // =============================================================================
-
 fn empty_type_context() -> TypeContext {
-    return TypeContext { structs: [], enums: [], interfaces: [], vtables: [] };
+    return TypeContext {
+        structs: [],
+        enums: [],
+        interfaces: [],
+        vtables: []
+    };
 }
 
 fn build_type_context(structs: NativeStruct[], enums: NativeEnum[], interfaces: NativeInterface[]) -> TypeContextBuild {
@@ -189,24 +190,14 @@ fn build_type_context(structs: NativeStruct[], enums: NativeEnum[], interfaces: 
     if _if300 {
         return TypeContextBuild {
             context: empty_type_context(),
-            diagnostics: [
-                "llvm lowering: type context build skipped (counts structs="
-                + number_to_string(structs.length)
-                + " enums="
-                + number_to_string(enums.length)
-                + " interfaces="
-                + number_to_string(interfaces.length)
-                + ")",
-            ],
+            diagnostics: ["llvm lowering: type context build skipped (counts structs=" + number_to_string(structs.length) + " enums=" + number_to_string(enums.length) + " interfaces=" + number_to_string(interfaces.length) + ")",],
         };
     }
     let mut diagnostics: string[] = [];
     let mut struct_entries: StructTypeInfo[] = [];
     let mut index: number = 0;
     loop {
-        if index >= structs.length {
-            break;
-        }
+        if index >= structs.length { break; }
         let definition = structs[index];
         if definition.layout == null {
             diagnostics.push("llvm lowering: struct `" + definition.name + "` missing layout metadata; skipping type emission");
@@ -219,9 +210,7 @@ fn build_type_context(structs: NativeStruct[], enums: NativeEnum[], interfaces: 
         let mut fields: StructFieldInfo[] = [];
         let mut field_index: number = 0;
         loop {
-            if field_index >= layout.fields.length {
-                break;
-            }
+            if field_index >= layout.fields.length { break; }
             let layout_field = layout.fields[field_index];
             let mapped = map_struct_field_annotation(layout_field.type_annotation);
             let mut llvm_field_type: string = mapped;
@@ -234,29 +223,27 @@ fn build_type_context(structs: NativeStruct[], enums: NativeEnum[], interfaces: 
                 if layout_annotation_represents_user_value(layout_field.type_annotation) {
                     if !references_self_type {
                         let stripped = strip_pointer_suffix(llvm_field_type);
-                        if stripped.length > 0 {
-                            llvm_field_type = stripped;
-                        }
+                        if stripped.length > 0 { llvm_field_type = stripped; }
                     }
                 }
             }
-            fields = append_struct_field_info(fields, StructFieldInfo { name: layout_field.name, llvm_type: llvm_field_type, type_annotation: layout_field.type_annotation, index: field_index, offset: layout_field.offset });
+            fields = append_struct_field_info(fields, StructFieldInfo {
+                name: layout_field.name, llvm_type: llvm_field_type, type_annotation: layout_field.type_annotation, index: field_index, offset: layout_field.offset
+            });
             field_index += 1;
         }
         let mut align_value: number = layout.align;
-        if align_value <= 0 {
-            align_value = 1;
-        }
-        struct_entries = append_struct_type_info(struct_entries, StructTypeInfo { name: definition.name, llvm_name: llvm_name, fields: fields, size: layout.size, align: align_value });
+        if align_value <= 0 { align_value = 1; }
+        struct_entries = append_struct_type_info(struct_entries, StructTypeInfo {
+            name: definition.name, llvm_name: llvm_name, fields: fields, size: layout.size, align: align_value
+        });
         index += 1;
     }
 
     let mut enum_entries: EnumTypeInfo[] = [];
     let mut enum_index: number = 0;
     loop {
-        if enum_index >= enums.length {
-            break;
-        }
+        if enum_index >= enums.length { break; }
         let enum_def = enums[enum_index];
         if enum_def.layout == null {
             diagnostics.push("llvm lowering: enum `" + enum_def.name + "` missing layout metadata; skipping type emission");
@@ -269,9 +256,7 @@ fn build_type_context(structs: NativeStruct[], enums: NativeEnum[], interfaces: 
         let mut variants: EnumVariantInfo[] = [];
         let mut variant_index: number = 0;
         loop {
-            if variant_index >= enum_layout.variants.length {
-                break;
-            }
+            if variant_index >= enum_layout.variants.length { break; }
             let variant_layout = enum_layout.variants[variant_index];
             let mut variant_fields: StructFieldInfo[] = [];
             let mut variant_field_index: number = 0;
@@ -297,29 +282,22 @@ fn build_type_context(structs: NativeStruct[], enums: NativeEnum[], interfaces: 
                         }
                     }
                 }
-                variant_fields = append_struct_field_info(variant_fields, StructFieldInfo { name: variant_field.name, llvm_type: llvm_variant_field_type, type_annotation: variant_field.type_annotation, index: variant_field_index, offset: variant_field.offset });
+                variant_fields = append_struct_field_info(variant_fields, StructFieldInfo {
+                    name: variant_field.name, llvm_type: llvm_variant_field_type, type_annotation: variant_field.type_annotation, index: variant_field_index, offset: variant_field.offset
+                });
                 variant_field_index += 1;
             }
             variants = append_enum_variant_info(variants, EnumVariantInfo {
-                    name: variant_layout.name,
-                    tag: variant_layout.tag,
-                    offset: variant_layout.offset,
-                    size: variant_layout.size,
-                    align: variant_layout.align,
-                    fields: variant_fields,
+                name: variant_layout.name, tag: variant_layout.tag, offset: variant_layout.offset, size: variant_layout.size, align: variant_layout.align, fields: variant_fields,
             });
             variant_index += 1;
         }
         let mut enum_align_value: number = enum_layout.align;
-        if enum_align_value <= 0 {
-            enum_align_value = 1;
-        }
+        if enum_align_value <= 0 { enum_align_value = 1; }
         let mut max_payload_size: number = 0;
         let mut payload_scan: number = 0;
         loop {
-            if payload_scan >= variants.length {
-                break;
-            }
+            if payload_scan >= variants.length { break; }
             let variant = variants[payload_scan];
             if variant.size > max_payload_size {
                 max_payload_size = variant.size;
@@ -327,15 +305,7 @@ fn build_type_context(structs: NativeStruct[], enums: NativeEnum[], interfaces: 
             payload_scan += 1;
         }
         enum_entries = append_enum_type_info(enum_entries, EnumTypeInfo {
-                name: enum_def.name,
-                llvm_name: llvm_enum_name,
-                tag_type: enum_layout.tag_type,
-                tag_size: enum_layout.tag_size,
-                tag_align: enum_layout.tag_align,
-                max_payload_size: max_payload_size,
-                size: enum_layout.size,
-                align: enum_align_value,
-                variants: variants,
+            name: enum_def.name, llvm_name: llvm_enum_name, tag_type: enum_layout.tag_type, tag_size: enum_layout.tag_size, tag_align: enum_layout.tag_align, max_payload_size: max_payload_size, size: enum_layout.size, align: enum_align_value, variants: variants,
         });
         enum_index += 1;
     }
@@ -344,17 +314,12 @@ fn build_type_context(structs: NativeStruct[], enums: NativeEnum[], interfaces: 
     let mut interface_entries: InterfaceTypeInfo[] = [];
     let mut interface_index: number = 0;
     loop {
-        if interface_index >= interfaces.length {
-            break;
-        }
+        if interface_index >= interfaces.length { break; }
         let interface_def = interfaces[interface_index];
         let sanitized_interface = sanitize_symbol(interface_def.name);
         let llvm_interface_name = "%trait." + sanitized_interface;
         interface_entries = append_interface_type_info(interface_entries, InterfaceTypeInfo {
-                name: interface_def.name,
-                llvm_name: llvm_interface_name,
-                type_parameters: interface_def.type_parameters,
-                signatures: interface_def.signatures,
+            name: interface_def.name, llvm_name: llvm_interface_name, type_parameters: interface_def.type_parameters, signatures: interface_def.signatures,
         });
         interface_index += 1;
     }
@@ -363,27 +328,19 @@ fn build_type_context(structs: NativeStruct[], enums: NativeEnum[], interfaces: 
     let mut vtable_entries: VTableInfo[] = [];
     let mut struct_vtable_index: number = 0;
     loop {
-        if struct_vtable_index >= structs.length {
-            break;
-        }
+        if struct_vtable_index >= structs.length { break; }
         let struct_def = structs[struct_vtable_index];
         let mut implements = struct_def.implements;
-        if implements == null {
-            implements = [];
-        }
+        if implements == null { implements = []; }
         let mut implements_index: number = 0;
         loop {
-            if implements_index >= implements.length {
-                break;
-            }
+            if implements_index >= implements.length { break; }
             let interface_name = implements[implements_index];
             // Find the interface definition
             let mut interface_def_opt: NativeInterface? = null;
             let mut search_idx: number = 0;
             loop {
-                if search_idx >= interfaces.length {
-                    break;
-                }
+                if search_idx >= interfaces.length { break; }
                 if interfaces[search_idx].name == interface_name {
                     interface_def_opt = interfaces[search_idx];
                     break;
@@ -407,17 +364,13 @@ fn build_type_context(structs: NativeStruct[], enums: NativeEnum[], interfaces: 
             let mut vtable_method_entries: VTableEntry[] = [];
             let mut sig_index: number = 0;
             loop {
-                if sig_index >= interface_def.signatures.length {
-                    break;
-                }
+                if sig_index >= interface_def.signatures.length { break; }
                 let signature = interface_def.signatures[sig_index];
                 // Build function pointer type: return_type (param_types...)*
                 let mut param_types: string[] = ["i8*"];  // First param is always self as i8*
                 let mut param_idx: number = 1;  // Skip self since we already added it
                 loop {
-                    if param_idx >= signature.parameters.length {
-                        break;
-                    }
+                    if param_idx >= signature.parameters.length { break; }
                     let param = signature.parameters[param_idx];
                     let mapped_type = map_type_annotation(param.type_annotation);
                     param_types.push(mapped_type);
@@ -427,19 +380,13 @@ fn build_type_context(structs: NativeStruct[], enums: NativeEnum[], interfaces: 
                 let func_ptr_type = return_type + " (" + join_with_separator(param_types, ", ") + ")*";
 
                 vtable_method_entries = append_vtable_entry(vtable_method_entries, VTableEntry {
-                        method_name: struct_def.name + signature.name,
-                        interface_method_name: signature.name,
-                        function_pointer_type: func_ptr_type,
+                    method_name: struct_def.name + signature.name, interface_method_name: signature.name, function_pointer_type: func_ptr_type,
                 });
                 sig_index += 1;
             }
 
             vtable_entries = append_vtable_info(vtable_entries, VTableInfo {
-                    struct_name: struct_def.name,
-                    interface_name: interface_name,
-                    llvm_type_name: vtable_type_name,
-                    llvm_global_name: vtable_global_name,
-                    entries: vtable_method_entries,
+                struct_name: struct_def.name, interface_name: interface_name, llvm_type_name: vtable_type_name, llvm_global_name: vtable_global_name, entries: vtable_method_entries,
             });
             implements_index += 1;
         }
@@ -448,9 +395,7 @@ fn build_type_context(structs: NativeStruct[], enums: NativeEnum[], interfaces: 
         // but does provide compatible methods, synthesize a vtable anyway.
         let mut interface_scan: number = 0;
         loop {
-            if interface_scan >= interfaces.length {
-                break;
-            }
+            if interface_scan >= interfaces.length { break; }
             let interface_def = interfaces[interface_scan];
             if !struct_declares_interface(struct_def, interface_def.name) {
                 if struct_satisfies_interface_structurally(struct_def, interface_def) {
@@ -481,19 +426,13 @@ fn build_type_context(structs: NativeStruct[], enums: NativeEnum[], interfaces: 
                         let return_type = map_type_annotation(signature.return_type);
                         let func_ptr_type = return_type + " (" + join_with_separator(param_types, ", ") + ")*";
                         vtable_method_entries = append_vtable_entry(vtable_method_entries, VTableEntry {
-                                method_name: struct_def.name + signature.name,
-                                interface_method_name: signature.name,
-                                function_pointer_type: func_ptr_type,
+                            method_name: struct_def.name + signature.name, interface_method_name: signature.name, function_pointer_type: func_ptr_type,
                         });
                         sig_index += 1;
                     }
 
                     vtable_entries = append_vtable_info(vtable_entries, VTableInfo {
-                            struct_name: struct_def.name,
-                            interface_name: interface_name,
-                            llvm_type_name: vtable_type_name,
-                            llvm_global_name: vtable_global_name,
-                            entries: vtable_method_entries,
+                        struct_name: struct_def.name, interface_name: interface_name, llvm_type_name: vtable_type_name, llvm_global_name: vtable_global_name, entries: vtable_method_entries,
                     });
                 }
             }
@@ -502,13 +441,20 @@ fn build_type_context(structs: NativeStruct[], enums: NativeEnum[], interfaces: 
         struct_vtable_index += 1;
     }
 
-    return TypeContextBuild { context: TypeContext { structs: struct_entries, enums: enum_entries, interfaces: interface_entries, vtables: vtable_entries }, diagnostics: diagnostics };
+    return TypeContextBuild {
+        context: TypeContext {
+            structs: struct_entries,
+            enums: enum_entries,
+            interfaces: interface_entries,
+            vtables: vtable_entries
+        },
+        diagnostics: diagnostics
+    };
 }
 
 // =============================================================================
 // Append Helpers
 // =============================================================================
-
 fn append_struct_type_info(values: StructTypeInfo[], value: StructTypeInfo) -> StructTypeInfo[] {
     let mut out = values;
     out = out.push(value);
@@ -550,4 +496,3 @@ fn append_vtable_entry(values: VTableEntry[], value: VTableEntry) -> VTableEntry
     out = out.push(value);
     return out;
 }
-

--- a/compiler/src/llvm/type_context.sfn
+++ b/compiler/src/llvm/type_context.sfn
@@ -79,7 +79,7 @@ fn synthesize_unit_enum_layout(enum_def: NativeEnum) -> NativeEnumLayout {
         if index >= enum_def.variants.length { break; }
         let variant = enum_def.variants[index];
         layouts.push(NativeEnumVariantLayout {
-            name: variant.name, tag: index, offset: 0, size: tag_size, align: tag_align, fields: [],
+            name: variant.name, tag: index, offset: 0, size: tag_size, align: tag_align, fields: []
         });
         index += 1;
     }
@@ -89,7 +89,7 @@ fn synthesize_unit_enum_layout(enum_def: NativeEnum) -> NativeEnumLayout {
         tag_type: "i32",
         tag_size: tag_size,
         tag_align: tag_align,
-        variants: layouts,
+        variants: layouts
     };
 }
 
@@ -119,7 +119,9 @@ fn fixup_enum_layouts(enums: NativeEnum[]) -> EnumLayoutFixupResult {
     if enums.length > 10000 {
         return EnumLayoutFixupResult {
             enums: [],
-            diagnostics: ["llvm lowering: enum layout fixup skipped (too many enums=" + number_to_string(enums.length) + ")"],
+            diagnostics: ["llvm lowering: enum layout fixup skipped (too many enums="
+                + number_to_string(enums.length)
+                + ")"]
         };
     }
     let mut diagnostics: string[] = [];
@@ -137,7 +139,8 @@ fn fixup_enum_layouts(enums: NativeEnum[]) -> EnumLayoutFixupResult {
                     variants: enum_def.variants,
                     layout: synthesize_unit_enum_layout(enum_def)
                 };
-                diagnostics.push("llvm lowering: enum `" + enum_def.name + "` missing layout metadata; synthesized unit-enum layout");
+                diagnostics.push("llvm lowering: enum `" + enum_def.name
+                    + "` missing layout metadata; synthesized unit-enum layout");
             }
             updated.push(fixed);
             index += 1;
@@ -152,9 +155,11 @@ fn fixup_enum_layouts(enums: NativeEnum[]) -> EnumLayoutFixupResult {
                     variants: enum_def.variants,
                     layout: synthesize_unit_enum_layout(enum_def)
                 };
-                diagnostics.push("llvm lowering: enum `" + enum_def.name + "` layout variants incomplete/garbled; synthesized unit-enum layout");
+                diagnostics.push("llvm lowering: enum `" + enum_def.name
+                    + "` layout variants incomplete/garbled; synthesized unit-enum layout");
             } else {
-                diagnostics.push("llvm lowering: enum `" + enum_def.name + "` layout variants incomplete/garbled; payload enums require full layout metadata");
+                diagnostics.push("llvm lowering: enum `" + enum_def.name
+                    + "` layout variants incomplete/garbled; payload enums require full layout metadata");
             }
         }
 
@@ -190,7 +195,13 @@ fn build_type_context(structs: NativeStruct[], enums: NativeEnum[], interfaces: 
     if _if300 {
         return TypeContextBuild {
             context: empty_type_context(),
-            diagnostics: ["llvm lowering: type context build skipped (counts structs=" + number_to_string(structs.length) + " enums=" + number_to_string(enums.length) + " interfaces=" + number_to_string(interfaces.length) + ")",],
+            diagnostics: ["llvm lowering: type context build skipped (counts structs="
+                + number_to_string(structs.length)
+                + " enums="
+                + number_to_string(enums.length)
+                + " interfaces="
+                + number_to_string(interfaces.length)
+                + ")",]
         };
     }
     let mut diagnostics: string[] = [];
@@ -200,7 +211,8 @@ fn build_type_context(structs: NativeStruct[], enums: NativeEnum[], interfaces: 
         if index >= structs.length { break; }
         let definition = structs[index];
         if definition.layout == null {
-            diagnostics.push("llvm lowering: struct `" + definition.name + "` missing layout metadata; skipping type emission");
+            diagnostics.push("llvm lowering: struct `" + definition.name
+                + "` missing layout metadata; skipping type emission");
             index += 1;
             continue;
         }
@@ -215,7 +227,12 @@ fn build_type_context(structs: NativeStruct[], enums: NativeEnum[], interfaces: 
             let mapped = map_struct_field_annotation(layout_field.type_annotation);
             let mut llvm_field_type: string = mapped;
             if llvm_field_type.length == 0 {
-                diagnostics.push("llvm lowering: struct `" + definition.name + "` field `" + layout_field.name + "` uses unsupported type `" + layout_field.type_annotation + "`; lowering as `i8*`");
+                diagnostics.push("llvm lowering: struct `" + definition.name
+                    + "` field `"
+                    + layout_field.name
+                    + "` uses unsupported type `"
+                    + layout_field.type_annotation
+                    + "`; lowering as `i8*`");
                 llvm_field_type = "i8*";
             } else if ends_with_pointer_suffix(llvm_field_type) {
                 let layout_base_type = layout_annotation_base_type(layout_field.type_annotation);
@@ -246,7 +263,8 @@ fn build_type_context(structs: NativeStruct[], enums: NativeEnum[], interfaces: 
         if enum_index >= enums.length { break; }
         let enum_def = enums[enum_index];
         if enum_def.layout == null {
-            diagnostics.push("llvm lowering: enum `" + enum_def.name + "` missing layout metadata; skipping type emission");
+            diagnostics.push("llvm lowering: enum `" + enum_def.name
+                + "` missing layout metadata; skipping type emission");
             enum_index += 1;
             continue;
         }
@@ -268,7 +286,14 @@ fn build_type_context(structs: NativeStruct[], enums: NativeEnum[], interfaces: 
                 let mapped_variant_type = map_struct_field_annotation(variant_field.type_annotation);
                 let mut llvm_variant_field_type: string = mapped_variant_type;
                 if llvm_variant_field_type.length == 0 {
-                    diagnostics.push("llvm lowering: enum `" + enum_def.name + "` variant `" + variant_layout.name + "` field `" + variant_field.name + "` uses unsupported type `" + variant_field.type_annotation + "`; lowering as `i8*`");
+                    diagnostics.push("llvm lowering: enum `" + enum_def.name
+                        + "` variant `"
+                        + variant_layout.name
+                        + "` field `"
+                        + variant_field.name
+                        + "` uses unsupported type `"
+                        + variant_field.type_annotation
+                        + "`; lowering as `i8*`");
                     llvm_variant_field_type = "i8*";
                 } else if ends_with_pointer_suffix(llvm_variant_field_type) {
                     let variant_base_type = layout_annotation_base_type(variant_field.type_annotation);
@@ -288,7 +313,7 @@ fn build_type_context(structs: NativeStruct[], enums: NativeEnum[], interfaces: 
                 variant_field_index += 1;
             }
             variants = append_enum_variant_info(variants, EnumVariantInfo {
-                name: variant_layout.name, tag: variant_layout.tag, offset: variant_layout.offset, size: variant_layout.size, align: variant_layout.align, fields: variant_fields,
+                name: variant_layout.name, tag: variant_layout.tag, offset: variant_layout.offset, size: variant_layout.size, align: variant_layout.align, fields: variant_fields
             });
             variant_index += 1;
         }
@@ -305,7 +330,7 @@ fn build_type_context(structs: NativeStruct[], enums: NativeEnum[], interfaces: 
             payload_scan += 1;
         }
         enum_entries = append_enum_type_info(enum_entries, EnumTypeInfo {
-            name: enum_def.name, llvm_name: llvm_enum_name, tag_type: enum_layout.tag_type, tag_size: enum_layout.tag_size, tag_align: enum_layout.tag_align, max_payload_size: max_payload_size, size: enum_layout.size, align: enum_align_value, variants: variants,
+            name: enum_def.name, llvm_name: llvm_enum_name, tag_type: enum_layout.tag_type, tag_size: enum_layout.tag_size, tag_align: enum_layout.tag_align, max_payload_size: max_payload_size, size: enum_layout.size, align: enum_align_value, variants: variants
         });
         enum_index += 1;
     }
@@ -319,7 +344,7 @@ fn build_type_context(structs: NativeStruct[], enums: NativeEnum[], interfaces: 
         let sanitized_interface = sanitize_symbol(interface_def.name);
         let llvm_interface_name = "%trait." + sanitized_interface;
         interface_entries = append_interface_type_info(interface_entries, InterfaceTypeInfo {
-            name: interface_def.name, llvm_name: llvm_interface_name, type_parameters: interface_def.type_parameters, signatures: interface_def.signatures,
+            name: interface_def.name, llvm_name: llvm_interface_name, type_parameters: interface_def.type_parameters, signatures: interface_def.signatures
         });
         interface_index += 1;
     }
@@ -349,7 +374,10 @@ fn build_type_context(structs: NativeStruct[], enums: NativeEnum[], interfaces: 
             }
 
             if interface_def_opt == null {
-                diagnostics.push("llvm lowering: struct `" + struct_def.name + "` implements unknown interface `" + interface_name + "`");
+                diagnostics.push("llvm lowering: struct `" + struct_def.name
+                    + "` implements unknown interface `"
+                    + interface_name
+                    + "`");
                 implements_index += 1;
                 continue;
             }
@@ -357,8 +385,11 @@ fn build_type_context(structs: NativeStruct[], enums: NativeEnum[], interfaces: 
             let interface_def = interface_def_opt;
             let sanitized_struct = sanitize_symbol(struct_def.name);
             let sanitized_iface = sanitize_symbol(interface_name);
-            let vtable_type_name = "%vtable." + sanitized_struct + "." + sanitized_iface;
-            let vtable_global_name = "@vtable." + sanitized_struct + "." + sanitized_iface + ".const";
+            let vtable_type_name = "%vtable." + sanitized_struct + "."
+                + sanitized_iface;
+            let vtable_global_name = "@vtable." + sanitized_struct + "."
+                + sanitized_iface
+                + ".const";
 
             // Build vtable entries for each method
             let mut vtable_method_entries: VTableEntry[] = [];
@@ -377,16 +408,17 @@ fn build_type_context(structs: NativeStruct[], enums: NativeEnum[], interfaces: 
                     param_idx += 1;
                 }
                 let return_type = map_type_annotation(signature.return_type);
-                let func_ptr_type = return_type + " (" + join_with_separator(param_types, ", ") + ")*";
+                let func_ptr_type = return_type + " (" + join_with_separator(param_types, ", ")
+                    + ")*";
 
                 vtable_method_entries = append_vtable_entry(vtable_method_entries, VTableEntry {
-                    method_name: struct_def.name + signature.name, interface_method_name: signature.name, function_pointer_type: func_ptr_type,
+                    method_name: struct_def.name + signature.name, interface_method_name: signature.name, function_pointer_type: func_ptr_type
                 });
                 sig_index += 1;
             }
 
             vtable_entries = append_vtable_info(vtable_entries, VTableInfo {
-                struct_name: struct_def.name, interface_name: interface_name, llvm_type_name: vtable_type_name, llvm_global_name: vtable_global_name, entries: vtable_method_entries,
+                struct_name: struct_def.name, interface_name: interface_name, llvm_type_name: vtable_type_name, llvm_global_name: vtable_global_name, entries: vtable_method_entries
             });
             implements_index += 1;
         }
@@ -402,8 +434,11 @@ fn build_type_context(structs: NativeStruct[], enums: NativeEnum[], interfaces: 
                     let interface_name = interface_def.name;
                     let sanitized_struct = sanitize_symbol(struct_def.name);
                     let sanitized_iface = sanitize_symbol(interface_name);
-                    let vtable_type_name = "%vtable." + sanitized_struct + "." + sanitized_iface;
-                    let vtable_global_name = "@vtable." + sanitized_struct + "." + sanitized_iface + ".const";
+                    let vtable_type_name = "%vtable." + sanitized_struct + "."
+                        + sanitized_iface;
+                    let vtable_global_name = "@vtable." + sanitized_struct + "."
+                        + sanitized_iface
+                        + ".const";
 
                     let mut vtable_method_entries: VTableEntry[] = [];
                     let mut sig_index: number = 0;
@@ -424,15 +459,17 @@ fn build_type_context(structs: NativeStruct[], enums: NativeEnum[], interfaces: 
                             param_idx += 1;
                         }
                         let return_type = map_type_annotation(signature.return_type);
-                        let func_ptr_type = return_type + " (" + join_with_separator(param_types, ", ") + ")*";
+                        let func_ptr_type = return_type + " ("
+                            + join_with_separator(param_types, ", ")
+                            + ")*";
                         vtable_method_entries = append_vtable_entry(vtable_method_entries, VTableEntry {
-                            method_name: struct_def.name + signature.name, interface_method_name: signature.name, function_pointer_type: func_ptr_type,
+                            method_name: struct_def.name + signature.name, interface_method_name: signature.name, function_pointer_type: func_ptr_type
                         });
                         sig_index += 1;
                     }
 
                     vtable_entries = append_vtable_info(vtable_entries, VTableInfo {
-                        struct_name: struct_def.name, interface_name: interface_name, llvm_type_name: vtable_type_name, llvm_global_name: vtable_global_name, entries: vtable_method_entries,
+                        struct_name: struct_def.name, interface_name: interface_name, llvm_type_name: vtable_type_name, llvm_global_name: vtable_global_name, entries: vtable_method_entries
                     });
                 }
             }

--- a/compiler/src/llvm/type_context_queries.sfn
+++ b/compiler/src/llvm/type_context_queries.sfn
@@ -2,30 +2,39 @@
 //
 // TypeContext lookup, query, and resolution functions. Split from
 // type_context.sfn to keep both files under 1000 lines.
-
-import { NativeStruct, NativeInterface, NativeFunction } from "../native_ir";
+import { NativeFunction, NativeInterface, NativeStruct } from "../native_ir";
 import { substring } from "../string_utils";
-import { TypeContext, StructTypeInfo, StructFieldInfo, EnumTypeInfo, EnumVariantInfo, InterfaceTypeInfo, VTableInfo, TypeAllocationInfo, ParameterBinding, LocalBinding } from "./types";
-import { trim_text, is_simple_identifier, find_last_index_of_char, index_of, string_array_contains } from "./utils";
-import { map_type_annotation, ends_with_pointer_suffix, strip_pointer_suffix } from "./type_mapping";
+import { ends_with_pointer_suffix, map_type_annotation, strip_pointer_suffix } from "./type_mapping";
+import {
+    EnumTypeInfo,
+    EnumVariantInfo,
+    InterfaceTypeInfo,
+    LocalBinding,
+    ParameterBinding,
+    StructFieldInfo,
+    StructTypeInfo,
+    TypeAllocationInfo,
+    TypeContext,
+    VTableInfo
+} from "./types";
+import {
+    find_last_index_of_char,
+    index_of,
+    is_simple_identifier,
+    string_array_contains,
+    trim_text
+} from "./utils";
 
 // =============================================================================
 // Interface Implementation Helpers
 // =============================================================================
-
 fn struct_declares_interface(struct_def: NativeStruct, interface_name: string) -> boolean {
     let mut implements = struct_def.implements;
-    if implements == null {
-        implements = [];
-    }
+    if implements == null { implements = []; }
     let mut index: number = 0;
     loop {
-        if index >= implements.length {
-            break;
-        }
-        if implements[index] == interface_name {
-            return true;
-        }
+        if index >= implements.length { break; }
+        if implements[index] == interface_name { return true; }
         index += 1;
     }
     return false;
@@ -33,18 +42,12 @@ fn struct_declares_interface(struct_def: NativeStruct, interface_name: string) -
 
 fn find_struct_method(struct_def: NativeStruct, method_name: string) -> NativeFunction? {
     let mut methods = struct_def.methods;
-    if methods == null {
-        return null;
-    }
+    if methods == null { return null; }
     let mut index: number = 0;
     loop {
-        if index >= methods.length {
-            break;
-        }
+        if index >= methods.length { break; }
         let method = methods[index];
-        if method.name == method_name {
-            return method;
-        }
+        if method.name == method_name { return method; }
         index += 1;
     }
     return null;
@@ -53,37 +56,27 @@ fn find_struct_method(struct_def: NativeStruct, method_name: string) -> NativeFu
 fn struct_satisfies_interface_structurally(struct_def: NativeStruct, interface_def: NativeInterface) -> boolean {
     let mut sig_index: number = 0;
     loop {
-        if sig_index >= interface_def.signatures.length {
-            break;
-        }
+        if sig_index >= interface_def.signatures.length { break; }
         let signature = interface_def.signatures[sig_index];
         let method = find_struct_method(struct_def, signature.name);
-        if method == null {
-            return false;
-        }
+        if method == null { return false; }
         if method.parameters.length != signature.parameters.length {
             return false;
         }
 
         let sig_return = map_type_annotation(signature.return_type);
         let method_return = map_type_annotation(method.return_type);
-        if sig_return != method_return {
-            return false;
-        }
+        if sig_return != method_return { return false; }
 
         // Skip the first parameter (`self`) which is always passed as `i8*` in trait calls.
         let mut param_index: number = 1;
         loop {
-            if param_index >= signature.parameters.length {
-                break;
-            }
+            if param_index >= signature.parameters.length { break; }
             let sig_param = signature.parameters[param_index];
             let method_param = method.parameters[param_index];
             let sig_ty = map_type_annotation(sig_param.type_annotation);
             let method_ty = map_type_annotation(method_param.type_annotation);
-            if sig_ty != method_ty {
-                return false;
-            }
+            if sig_ty != method_ty { return false; }
             param_index += 1;
         }
         sig_index += 1;
@@ -94,17 +87,12 @@ fn struct_satisfies_interface_structurally(struct_def: NativeStruct, interface_d
 // =============================================================================
 // TypeContext Lookup Functions
 // =============================================================================
-
 fn find_struct_info_by_name(context: TypeContext, name: string) -> StructTypeInfo? {
     let mut index: number = 0;
     loop {
-        if index >= context.structs.length {
-            break;
-        }
+        if index >= context.structs.length { break; }
         let info = context.structs[index];
-        if info.name == name {
-            return info;
-        }
+        if info.name == name { return info; }
         index += 1;
     }
     return null;
@@ -118,13 +106,9 @@ fn find_struct_info_by_llvm_name(context: TypeContext, llvm_name: string) -> Str
 fn find_interface_info_by_name(context: TypeContext, name: string) -> InterfaceTypeInfo? {
     let mut index: number = 0;
     loop {
-        if index >= context.interfaces.length {
-            break;
-        }
+        if index >= context.interfaces.length { break; }
         let info = context.interfaces[index];
-        if info.name == name {
-            return info;
-        }
+        if info.name == name { return info; }
         index += 1;
     }
     return null;
@@ -133,14 +117,10 @@ fn find_interface_info_by_name(context: TypeContext, name: string) -> InterfaceT
 fn find_vtable_for_struct_interface(context: TypeContext, struct_name: string, interface_name: string) -> VTableInfo? {
     let mut index: number = 0;
     loop {
-        if index >= context.vtables.length {
-            break;
-        }
+        if index >= context.vtables.length { break; }
         let vtable = context.vtables[index];
         if vtable.struct_name == struct_name {
-            if vtable.interface_name == interface_name {
-                return vtable;
-            }
+            if vtable.interface_name == interface_name { return vtable; }
         }
         index += 1;
     }
@@ -151,13 +131,9 @@ fn find_struct_info_by_llvm_type(context: TypeContext, llvm_type: string) -> Str
     let trimmed = trim_text(llvm_type);
     let mut index: number = 0;
     loop {
-        if index >= context.structs.length {
-            break;
-        }
+        if index >= context.structs.length { break; }
         let info = context.structs[index];
-        if info.llvm_name == trimmed {
-            return info;
-        }
+        if info.llvm_name == trimmed { return info; }
         index += 1;
     }
     return null;
@@ -166,13 +142,9 @@ fn find_struct_info_by_llvm_type(context: TypeContext, llvm_type: string) -> Str
 fn find_struct_field_index(struct_info: StructTypeInfo, field_name: string) -> number {
     let mut index: number = 0;
     loop {
-        if index >= struct_info.fields.length {
-            break;
-        }
+        if index >= struct_info.fields.length { break; }
         let field = struct_info.fields[index];
-        if field.name == field_name {
-            return index;
-        }
+        if field.name == field_name { return index; }
         index += 1;
     }
     return -1;
@@ -182,13 +154,9 @@ fn find_enum_info_by_llvm_type(context: TypeContext, llvm_type: string) -> EnumT
     let trimmed = trim_text(llvm_type);
     let mut index: number = 0;
     loop {
-        if index >= context.enums.length {
-            break;
-        }
+        if index >= context.enums.length { break; }
         let info = context.enums[index];
-        if info.llvm_name == trimmed {
-            return info;
-        }
+        if info.llvm_name == trimmed { return info; }
         index += 1;
     }
     return null;
@@ -196,9 +164,7 @@ fn find_enum_info_by_llvm_type(context: TypeContext, llvm_type: string) -> EnumT
 
 fn resolve_struct_info_from_llvm_type(context: TypeContext, llvm_type: string) -> StructTypeInfo? {
     let mut candidate = trim_text(llvm_type);
-    if candidate.length == 0 {
-        return null;
-    }
+    if candidate.length == 0 { return null; }
     if ends_with_pointer_suffix(candidate) {
         candidate = strip_pointer_suffix(candidate);
     }
@@ -207,12 +173,8 @@ fn resolve_struct_info_from_llvm_type(context: TypeContext, llvm_type: string) -
 
 fn lookup_allocation_info(context: TypeContext, llvm_type: string) -> TypeAllocationInfo? {
     let trimmed = trim_text(llvm_type);
-    if trimmed.length == 0 {
-        return null;
-    }
-    if ends_with_pointer_suffix(trimmed) {
-        return null;
-    }
+    if trimmed.length == 0 { return null; }
+    if ends_with_pointer_suffix(trimmed) { return null; }
     if trimmed == "double" {
         return TypeAllocationInfo { llvm_type: trimmed, size: 8, align: 8 };
     }
@@ -234,18 +196,22 @@ fn lookup_allocation_info(context: TypeContext, llvm_type: string) -> TypeAlloca
     let struct_info = find_struct_info_by_llvm_type(context, trimmed);
     if struct_info != null {
         let mut align_value = struct_info.align;
-        if align_value <= 0 {
-            align_value = 1;
-        }
-        return TypeAllocationInfo { llvm_type: struct_info.llvm_name, size: struct_info.size, align: align_value };
+        if align_value <= 0 { align_value = 1; }
+        return TypeAllocationInfo {
+            llvm_type: struct_info.llvm_name,
+            size: struct_info.size,
+            align: align_value
+        };
     }
     let enum_info = find_enum_info_by_llvm_type(context, trimmed);
     if enum_info != null {
         let mut align_value = enum_info.align;
-        if align_value <= 0 {
-            align_value = 1;
-        }
-        return TypeAllocationInfo { llvm_type: enum_info.llvm_name, size: enum_info.size, align: align_value };
+        if align_value <= 0 { align_value = 1; }
+        return TypeAllocationInfo {
+            llvm_type: enum_info.llvm_name,
+            size: enum_info.size,
+            align: align_value
+        };
     }
     return null;
 }
@@ -253,52 +219,39 @@ fn lookup_allocation_info(context: TypeContext, llvm_type: string) -> TypeAlloca
 // =============================================================================
 // Method Target Resolution
 // =============================================================================
-
 fn resolve_struct_info_for_method_target(base: string, bindings: ParameterBinding[], locals: LocalBinding[], context: TypeContext) -> StructTypeInfo? ![io] {
     let trimmed = trim_text(base);
-    if trimmed.length == 0 {
-        return null;
-    }
+    if trimmed.length == 0 { return null; }
     if is_simple_identifier(trimmed) {
         let parameter = find_parameter_binding(bindings, trimmed);
         if parameter != null {
             let info = resolve_struct_info_from_llvm_type(context, parameter.llvm_type);
-            if info != null {
-                return info;
-            }
+            if info != null { return info; }
             // Fallback: when the LLVM type is i8* (opaque pointer from async/await
             // or runtime functions), check the source type_annotation instead.
             if parameter.type_annotation != null {
                 if parameter.type_annotation.length > 0 {
                     let by_annotation = find_struct_info_by_name(context, parameter.type_annotation);
-                    if by_annotation != null {
-                        return by_annotation;
-                    }
+                    if by_annotation != null { return by_annotation; }
                 }
             }
         }
         let local = find_local_binding(locals, trimmed);
         if local != null {
             let info = resolve_struct_info_from_llvm_type(context, local.llvm_type);
-            if info != null {
-                return info;
-            }
+            if info != null { return info; }
             // Fallback: check source type_annotation when llvm_type is i8*.
             if local.type_annotation != null {
                 if local.type_annotation.length > 0 {
                     let by_annotation = find_struct_info_by_name(context, local.type_annotation);
-                    if by_annotation != null {
-                        return by_annotation;
-                    }
+                    if by_annotation != null { return by_annotation; }
                 }
             }
         }
     }
     // Allow static method calls on a struct type (e.g. `BankAccount.new(123)`).
     let by_name = find_struct_info_by_name(context, trimmed);
-    if by_name != null {
-        return by_name;
-    }
+    if by_name != null { return by_name; }
     // Last resort: read locals from the condition_locals file written by
     // instructions.sfn.  Cross-module ABI corruption in the v0.1.1 seed can
     // leave the in-memory `locals` array empty/corrupt, so this file-based
@@ -330,9 +283,7 @@ fn resolve_struct_info_for_method_target(base: string, bindings: ParameterBindin
                 let _cl_type_ann = substring(_cl_rest, 0, _ct2);
                 if _cl_type_ann.length > 0 {
                     let by_file_annotation = find_struct_info_by_name(context, _cl_type_ann);
-                    if by_file_annotation != null {
-                        return by_file_annotation;
-                    }
+                    if by_file_annotation != null { return by_file_annotation; }
                 }
             }
         }
@@ -342,9 +293,7 @@ fn resolve_struct_info_for_method_target(base: string, bindings: ParameterBindin
 
 fn resolve_interface_info_for_method_target(base: string, bindings: ParameterBinding[], locals: LocalBinding[], context: TypeContext) -> InterfaceTypeInfo? {
     let trimmed = trim_text(base);
-    if trimmed.length == 0 {
-        return null;
-    }
+    if trimmed.length == 0 { return null; }
     if is_simple_identifier(trimmed) {
         let parameter = find_parameter_binding(bindings, trimmed);
         if parameter != null {
@@ -352,14 +301,10 @@ fn resolve_interface_info_for_method_target(base: string, bindings: ParameterBin
             if substring(type_name, 0, 7) == "%trait." {
                 let interface_name = substring(type_name, 7, type_name.length);
                 let info = find_interface_info_by_name(context, interface_name);
-                if info != null {
-                    return info;
-                }
+                if info != null { return info; }
             }
             let info = find_interface_info_by_name(context, type_name);
-            if info != null {
-                return info;
-            }
+            if info != null { return info; }
         }
         let local = find_local_binding(locals, trimmed);
         if local != null {
@@ -367,14 +312,10 @@ fn resolve_interface_info_for_method_target(base: string, bindings: ParameterBin
             if substring(type_name, 0, 7) == "%trait." {
                 let interface_name = substring(type_name, 7, type_name.length);
                 let info = find_interface_info_by_name(context, interface_name);
-                if info != null {
-                    return info;
-                }
+                if info != null { return info; }
             }
             let info = find_interface_info_by_name(context, type_name);
-            if info != null {
-                return info;
-            }
+            if info != null { return info; }
         }
     }
     return null;
@@ -383,17 +324,12 @@ fn resolve_interface_info_for_method_target(base: string, bindings: ParameterBin
 // =============================================================================
 // Field Info Lookup
 // =============================================================================
-
 fn find_struct_field_info(info: StructTypeInfo, field_name: string) -> StructFieldInfo? {
     let mut index: number = 0;
     loop {
-        if index >= info.fields.length {
-            break;
-        }
+        if index >= info.fields.length { break; }
         let field = info.fields[index];
-        if field.name == field_name {
-            return field;
-        }
+        if field.name == field_name { return field; }
         index += 1;
     }
     return null;
@@ -402,13 +338,9 @@ fn find_struct_field_info(info: StructTypeInfo, field_name: string) -> StructFie
 fn find_variant_field_info(variant: EnumVariantInfo, field_name: string) -> StructFieldInfo? {
     let mut index: number = 0;
     loop {
-        if index >= variant.fields.length {
-            break;
-        }
+        if index >= variant.fields.length { break; }
         let field = variant.fields[index];
-        if field.name == field_name {
-            return field;
-        }
+        if field.name == field_name { return field; }
         index += 1;
     }
     return null;
@@ -417,12 +349,9 @@ fn find_variant_field_info(variant: EnumVariantInfo, field_name: string) -> Stru
 // =============================================================================
 // Literal Resolution
 // =============================================================================
-
 fn resolve_struct_info_for_literal(context: TypeContext, type_name: string) -> StructTypeInfo? {
     let trimmed = trim_text(type_name);
-    if trimmed.length == 0 {
-        return null;
-    }
+    if trimmed.length == 0 { return null; }
 
     let mut candidates: string[] = [trimmed];
     let generic_index = index_of(trimmed, "<");
@@ -456,14 +385,10 @@ fn resolve_struct_info_for_literal(context: TypeContext, type_name: string) -> S
 
     let mut index: number = 0;
     loop {
-        if index >= candidates.length {
-            break;
-        }
+        if index >= candidates.length { break; }
         let candidate = candidates[index];
         let info = find_struct_info_by_name(context, candidate);
-        if info != null {
-            return info;
-        }
+        if info != null { return info; }
         index += 1;
     }
 
@@ -472,19 +397,13 @@ fn resolve_struct_info_for_literal(context: TypeContext, type_name: string) -> S
 
 fn resolve_enum_info_for_literal(context: TypeContext, enum_name: string) -> EnumTypeInfo? {
     let trimmed = trim_text(enum_name);
-    if trimmed.length == 0 {
-        return null;
-    }
+    if trimmed.length == 0 { return null; }
 
     let mut index: number = 0;
     loop {
-        if index >= context.enums.length {
-            break;
-        }
+        if index >= context.enums.length { break; }
         let enum_info = context.enums[index];
-        if enum_info.name == trimmed {
-            return enum_info;
-        }
+        if enum_info.name == trimmed { return enum_info; }
         index += 1;
     }
 
@@ -493,19 +412,13 @@ fn resolve_enum_info_for_literal(context: TypeContext, enum_name: string) -> Enu
 
 fn resolve_enum_variant_info(enum_info: EnumTypeInfo, variant_name: string) -> EnumVariantInfo? {
     let trimmed = trim_text(variant_name);
-    if trimmed.length == 0 {
-        return null;
-    }
+    if trimmed.length == 0 { return null; }
 
     let mut index: number = 0;
     loop {
-        if index >= enum_info.variants.length {
-            break;
-        }
+        if index >= enum_info.variants.length { break; }
         let variant = enum_info.variants[index];
-        if variant.name == trimmed {
-            return variant;
-        }
+        if variant.name == trimmed { return variant; }
         index += 1;
     }
 
@@ -515,16 +428,11 @@ fn resolve_enum_variant_info(enum_info: EnumTypeInfo, variant_name: string) -> E
 // =============================================================================
 // Binding Lookup Helpers (needed for method resolution)
 // =============================================================================
-
 fn find_parameter_binding(bindings: ParameterBinding[], name: string) -> ParameterBinding? {
     let mut index: number = 0;
     loop {
-        if index >= bindings.length {
-            break;
-        }
-        if bindings[index].name == name {
-            return bindings[index];
-        }
+        if index >= bindings.length { break; }
+        if bindings[index].name == name { return bindings[index]; }
         index += 1;
     }
     return null;
@@ -533,12 +441,8 @@ fn find_parameter_binding(bindings: ParameterBinding[], name: string) -> Paramet
 fn find_local_binding(locals: LocalBinding[], name: string) -> LocalBinding? {
     let mut index: number = 0;
     loop {
-        if index >= locals.length {
-            break;
-        }
-        if locals[index].name == name {
-            return locals[index];
-        }
+        if index >= locals.length { break; }
+        if locals[index].name == name { return locals[index]; }
         index += 1;
     }
     return null;
@@ -547,25 +451,16 @@ fn find_local_binding(locals: LocalBinding[], name: string) -> LocalBinding? {
 // =============================================================================
 // String Join Helper (needed for vtable construction)
 // =============================================================================
-
 fn join_with_separator(values: string[], separator: string) -> string {
-    if values.length == 0 {
-        return "";
-    }
-    if values.length == 1 {
-        return values[0];
-    }
+    if values.length == 0 { return ""; }
+    if values.length == 1 { return values[0]; }
     let mut parts: string[] = values;
     loop {
-        if parts.length <= 1 {
-            break;
-        }
+        if parts.length <= 1 { break; }
         let mut next: string[] = [];
         let mut index: number = 0;
         loop {
-            if index >= parts.length {
-                break;
-            }
+            if index >= parts.length { break; }
             let _tc_next = index + 1;
             if _tc_next < parts.length {
                 let combined = parts[index] + separator + parts[_tc_next];

--- a/compiler/src/llvm/type_mapping.sfn
+++ b/compiler/src/llvm/type_mapping.sfn
@@ -2,31 +2,25 @@
 //
 // Type annotation mapping for LLVM lowering. Converts Sailfin type annotations
 // to their corresponding LLVM IR types.
-
-import { substring, char_code, char_at } from "../string_utils";
-import { TypeContext, TypeAllocationInfo } from "./types";
+import { char_at, char_code, substring } from "../string_utils";
+import { TypeAllocationInfo, TypeContext } from "./types";
 import {
-    trim_text,
-    starts_with,
     ends_with,
     index_of,
-    sanitize_symbol
+    sanitize_symbol,
+    starts_with,
+    trim_text
 } from "./utils";
 
 // =============================================================================
 // Character Classification
 // =============================================================================
-
 fn is_ascii_uppercase(ch: string) -> boolean {
-    if ch.length == 0 {
-        return false;
-    }
+    if ch.length == 0 { return false; }
     let code = char_code(ch);
     let mut _ret302: boolean = false;
     if code >= char_code("A") {
-        if code <= char_code("Z") {
-            _ret302 = true;
-        }
+        if code <= char_code("Z") { _ret302 = true; }
     }
     return _ret302;
 }
@@ -34,12 +28,9 @@ fn is_ascii_uppercase(ch: string) -> boolean {
 // =============================================================================
 // Pointer Operations
 // =============================================================================
-
 fn ends_with_pointer_suffix(value: string) -> boolean {
     let trimmed = trim_text(value);
-    if trimmed.length == 0 {
-        return false;
-    }
+    if trimmed.length == 0 { return false; }
     // Fast-path: well-known primitives that are never pointers.
     // Avoids character-level indexing which is miscompiled by older seeds.
     let mut _if303: boolean = false;
@@ -51,9 +42,7 @@ fn ends_with_pointer_suffix(value: string) -> boolean {
     if trimmed == "i64" { _if303 = true; }
     if trimmed == "void" { _if303 = true; }
     if trimmed == "float" { _if303 = true; }
-    if _if303 {
-        return false;
-    }
+    if _if303 { return false; }
     // Fast-path: well-known pointer types.
     let mut _if304: boolean = false;
     if trimmed == "i8*" { _if304 = true; }
@@ -62,9 +51,7 @@ fn ends_with_pointer_suffix(value: string) -> boolean {
     if trimmed == "i64*" { _if304 = true; }
     if trimmed == "double*" { _if304 = true; }
     if trimmed == "i1*" { _if304 = true; }
-    if _if304 {
-        return true;
-    }
+    if _if304 { return true; }
     // Fast-path: aggregate pointer types starting with { or % and ending with *.
     // Use starts_with (safe) instead of character indexing.
     let mut _if305: boolean = false;
@@ -75,9 +62,7 @@ fn ends_with_pointer_suffix(value: string) -> boolean {
         // We use a simple heuristic: if it starts with { or % AND
         // the string length > 1, check by building a test string without *.
         let without_star = substring(trimmed, 0, trimmed.length - 1);
-        if without_star + "*" == trimmed {
-            return true;
-        }
+        if without_star + "*" == trimmed { return true; }
         return false;
     }
     return substring(trimmed, trimmed.length - 1, trimmed.length) == "*";
@@ -85,25 +70,18 @@ fn ends_with_pointer_suffix(value: string) -> boolean {
 
 fn strip_pointer_suffix(value: string) -> string {
     let trimmed = trim_text(value);
-    if trimmed.length == 0 {
-        return trimmed;
-    }
+    if trimmed.length == 0 { return trimmed; }
     // Use ends_with_pointer_suffix (safe) instead of character indexing.
-    if !ends_with_pointer_suffix(trimmed) {
-        return trimmed;
-    }
+    if !ends_with_pointer_suffix(trimmed) { return trimmed; }
     return trim_text(substring(trimmed, 0, trimmed.length - 1));
 }
 
 // =============================================================================
 // Ownership Wrapper Unwrapping
 // =============================================================================
-
 fn unwrap_move_wrapper(annotation: string) -> string {
     let trimmed = trim_text(annotation);
-    if trimmed.length == 0 {
-        return trimmed;
-    }
+    if trimmed.length == 0 { return trimmed; }
     let mut _if306: boolean = false;
     if starts_with(trimmed, "Affine<") { _if306 = true; }
     if starts_with(trimmed, "Linear<") { _if306 = true; }
@@ -122,46 +100,33 @@ fn unwrap_move_wrapper(annotation: string) -> string {
 // =============================================================================
 // Type Classification
 // =============================================================================
-
 fn looks_like_user_type(annotation: string) -> boolean {
     let trimmed = trim_text(annotation);
-    if trimmed.length == 0 {
-        return false;
-    }
+    if trimmed.length == 0 { return false; }
     let first = substring(trimmed, 0, 1);
-    if is_ascii_uppercase(first) {
-        return true;
-    }
+    if is_ascii_uppercase(first) { return true; }
     // Allow internal/user types prefixed with an underscore, e.g. `_Foo`.
     if first == "_" {
         if trimmed.length > 1 {
             let second = substring(trimmed, 1, 2);
-            if is_ascii_uppercase(second) {
-                return true;
-            }
+            if is_ascii_uppercase(second) { return true; }
         }
     }
     let mut index: number = 1;
     loop {
-        if index >= trimmed.length {
-            break;
-        }
+        if index >= trimmed.length { break; }
         let _tm_next = index + 1;
         let current = substring(trimmed, index, _tm_next);
         if current == "." {
             if _tm_next < trimmed.length {
                 let _tm_next2 = index + 2;
                 let next = substring(trimmed, _tm_next, _tm_next2);
-                if is_ascii_uppercase(next) {
-                    return true;
-                }
+                if is_ascii_uppercase(next) { return true; }
                 let _tm_next3 = index + 3;
                 if next == "_" {
                     if _tm_next2 < trimmed.length {
                         let after = substring(trimmed, _tm_next2, _tm_next3);
-                        if is_ascii_uppercase(after) {
-                            return true;
-                        }
+                        if is_ascii_uppercase(after) { return true; }
                     }
                 }
             }
@@ -173,9 +138,7 @@ fn looks_like_user_type(annotation: string) -> boolean {
 
 fn annotation_is_array(annotation: string) -> boolean {
     let trimmed = trim_text(annotation);
-    if trimmed.length < 3 {
-        return false;
-    }
+    if trimmed.length < 3 { return false; }
     let suffix = substring(trimmed, trimmed.length - 2, trimmed.length);
     return suffix == "[]";
 }
@@ -185,89 +148,54 @@ fn is_copy_type(type_annotation: string, llvm_type: string) -> boolean {
     let mut _if307: boolean = false;
     if starts_with(trimmed, "Affine<") { _if307 = true; }
     if starts_with(trimmed, "Linear<") { _if307 = true; }
-    if _if307 {
-        return false;
-    }
+    if _if307 { return false; }
     let mut _if308: boolean = false;
     if trimmed == "Affine" { _if308 = true; }
     if trimmed == "Linear" { _if308 = true; }
-    if _if308 {
-        return false;
-    }
-    if llvm_type == "double" {
-        return true;
-    }
-    if llvm_type == "i32" {
-        return true;
-    }
-    if llvm_type == "i64" {
-        return true;
-    }
-    if llvm_type == "i1" {
-        return true;
-    }
-    if ends_with_pointer_suffix(llvm_type) {
-        return true;
-    }
-    if trimmed.length == 0 {
-        return true;
-    }
-    if substring(trimmed, 0, 1) == "&" {
-        return true;
-    }
+    if _if308 { return false; }
+    if llvm_type == "double" { return true; }
+    if llvm_type == "i32" { return true; }
+    if llvm_type == "i64" { return true; }
+    if llvm_type == "i1" { return true; }
+    if ends_with_pointer_suffix(llvm_type) { return true; }
+    if trimmed.length == 0 { return true; }
+    if substring(trimmed, 0, 1) == "&" { return true; }
     return false;
 }
 
 // =============================================================================
 // Layout Annotation Helpers
 // =============================================================================
-
 fn layout_annotation_requires_pointer(annotation: string) -> boolean {
     let trimmed = trim_text(annotation);
-    if trimmed.length == 0 {
-        return false;
-    }
+    if trimmed.length == 0 { return false; }
     let normalized = unwrap_move_wrapper(trimmed);
-    if normalized.length == 0 {
-        return false;
-    }
+    if normalized.length == 0 { return false; }
     if starts_with(normalized, "mut ") {
         let remainder = trim_text(substring(normalized, 4, normalized.length));
-        if remainder.length == 0 {
-            return false;
-        }
+        if remainder.length == 0 { return false; }
         return layout_annotation_requires_pointer(remainder);
     }
     if normalized.length > 0 {
         let first = substring(normalized, 0, 1);
-        if first == "&" {
-            return true;
-        }
+        if first == "&" { return true; }
     }
     if normalized.length > 0 {
         let last = substring(normalized, normalized.length - 1, normalized.length);
-        if last == "?" {
-            return true;
-        }
+        if last == "?" { return true; }
     }
     if normalized.length > 2 {
         let suffix = substring(normalized, normalized.length - 2, normalized.length);
-        if suffix == "[]" {
-            return true;
-        }
+        if suffix == "[]" { return true; }
     }
     return false;
 }
 
 fn layout_annotation_base_type(annotation: string) -> string {
     let trimmed = trim_text(annotation);
-    if trimmed.length == 0 {
-        return "";
-    }
+    if trimmed.length == 0 { return ""; }
     let normalized = unwrap_move_wrapper(trimmed);
-    if normalized.length == 0 {
-        return "";
-    }
+    if normalized.length == 0 { return ""; }
     if starts_with(normalized, "mut ") {
         let remainder = trim_text(substring(normalized, 4, normalized.length));
         return layout_annotation_base_type(remainder);
@@ -297,50 +225,31 @@ fn layout_annotation_base_type(annotation: string) -> string {
 }
 
 fn layout_annotation_represents_user_value(annotation: string) -> boolean {
-    if layout_annotation_requires_pointer(annotation) {
-        return false;
-    }
+    if layout_annotation_requires_pointer(annotation) { return false; }
     let base = layout_annotation_base_type(annotation);
-    if base.length == 0 {
-        return false;
-    }
-    if base == "number" {
-        return false;
-    }
+    if base.length == 0 { return false; }
+    if base == "number" { return false; }
     let mut _if309: boolean = false;
     if base == "boolean" { _if309 = true; }
     if base == "bool" { _if309 = true; }
-    if _if309 {
-        return false;
-    }
-    if base == "string" {
-        return false;
-    }
-    if base == "void" {
-        return false;
-    }
-    if base == "any" {
-        return false;
-    }
+    if _if309 { return false; }
+    if base == "string" { return false; }
+    if base == "void" { return false; }
+    if base == "any" { return false; }
     let mut _if310: boolean = false;
     if base == "i64" { _if310 = true; }
     if base == "i32" { _if310 = true; }
     if base == "i1" { _if310 = true; }
     if base == "i8" { _if310 = true; }
     if base == "usize" { _if310 = true; }
-    if _if310 {
-        return false;
-    }
-    if looks_like_user_type(base) {
-        return true;
-    }
+    if _if310 { return false; }
+    if looks_like_user_type(base) { return true; }
     return false;
 }
 
 // =============================================================================
 // Array Type Helpers
 // =============================================================================
-
 fn array_struct_type_for_element(element_type: string) -> string {
     return "{ " + element_type + "*, i64 }";
 }
@@ -352,12 +261,9 @@ fn array_pointer_type_for_element(element_type: string) -> string {
 // =============================================================================
 // Core Type Mapping
 // =============================================================================
-
 fn map_type_annotation(annotation: string) -> string {
     let trimmed = trim_text(annotation);
-    if trimmed.length == 0 {
-        return "void";
-    }
+    if trimmed.length == 0 { return "void"; }
     let normalized = unwrap_move_wrapper(trimmed);
 
     // Raw pointer types: `*T`, `*mut T`, `*opaque`.
@@ -369,19 +275,13 @@ fn map_type_annotation(annotation: string) -> string {
         if starts_with(remainder, "mut") {
             remainder = trim_text(substring(remainder, 3, remainder.length));
         }
-        if remainder == "opaque" {
-            return "i8*";
-        }
-        if remainder.length == 0 {
-            return "i8*";
-        }
+        if remainder == "opaque" { return "i8*"; }
+        if remainder.length == 0 { return "i8*"; }
         let inner = map_type_annotation(remainder);
         let mut _if311: boolean = false;
         if inner.length == 0 { _if311 = true; }
         if inner == "void" { _if311 = true; }
-        if _if311 {
-            return "i8*";
-        }
+        if _if311 { return "i8*"; }
         if substring(inner, inner.length - 1, inner.length) == "*" {
             return inner;
         }
@@ -392,16 +292,12 @@ fn map_type_annotation(annotation: string) -> string {
         let optional_marker = substring(normalized, normalized.length - 1, normalized.length);
         if optional_marker == "?" {
             let inner_annotation = trim_text(substring(normalized, 0, normalized.length - 1));
-            if inner_annotation.length == 0 {
-                return "i8*";
-            }
+            if inner_annotation.length == 0 { return "i8*"; }
             let inner_type = map_type_annotation(inner_annotation);
             let mut _if312: boolean = false;
             if inner_type.length == 0 { _if312 = true; }
             if inner_type == "void" { _if312 = true; }
-            if _if312 {
-                return "i8*";
-            }
+            if _if312 { return "i8*"; }
             if inner_type.length > 0 {
                 if substring(inner_type, inner_type.length - 1, inner_type.length) == "*" {
                     return inner_type;
@@ -410,44 +306,26 @@ fn map_type_annotation(annotation: string) -> string {
             return inner_type + "*";
         }
     }
-    if normalized == "number" {
-        return "double";
-    }
+    if normalized == "number" { return "double"; }
     let mut _if313: boolean = false;
     if normalized == "boolean" { _if313 = true; }
     if normalized == "bool" { _if313 = true; }
-    if _if313 {
-        return "i1";
-    }
-    if normalized == "usize" {
-        return "i64";
-    }
+    if _if313 { return "i1"; }
+    if normalized == "usize" { return "i64"; }
     let mut _if314: boolean = false;
     if normalized == "int" { _if314 = true; }
     if normalized == "i64" { _if314 = true; }
-    if _if314 {
-        return "i64";
-    }
-    if normalized == "i32" {
-        return "i32";
-    }
-    if normalized == "u8" {
-        return "i8";
-    }
-    if normalized == "string" {
-        return "i8*";
-    }
-    if normalized == "void" {
-        return "void";
-    }
+    if _if314 { return "i64"; }
+    if normalized == "i32" { return "i32"; }
+    if normalized == "u8" { return "i8"; }
+    if normalized == "string" { return "i8*"; }
+    if normalized == "void" { return "void"; }
     if normalized.length > 2 {
         let suffix = substring(normalized, normalized.length - 2, normalized.length);
         if suffix == "[]" {
             let element_annotation = trim_text(substring(normalized, 0, normalized.length - 2));
             let mut element_type = map_type_annotation(element_annotation);
-            if element_type.length == 0 {
-                return "i8*";
-            }
+            if element_type.length == 0 { return "i8*"; }
             // Arrays of user-value types (enums + inline structs) store the value inline.
             // `map_type_annotation` defaults user types to pointers, so strip that layer
             // when the surface syntax represents a value type.
@@ -470,17 +348,13 @@ fn map_type_annotation(annotation: string) -> string {
 
 fn map_struct_field_annotation(annotation: string) -> string {
     let result = map_type_annotation(annotation);
-    if result == "void" {
-        return "";
-    }
+    if result == "void" { return ""; }
     return result;
 }
 
 fn map_struct_type_annotation(annotation: string) -> string {
     let trimmed = trim_text(annotation);
-    if trimmed.length == 0 {
-        return "";
-    }
+    if trimmed.length == 0 { return ""; }
     let normalized = unwrap_move_wrapper(trimmed);
     if looks_like_user_type(normalized) {
         return "%" + sanitize_symbol(normalized);
@@ -488,9 +362,7 @@ fn map_struct_type_annotation(annotation: string) -> string {
     let mapped = map_type_annotation(normalized);
     if ends_with_pointer_suffix(mapped) {
         let stripped = strip_pointer_suffix(mapped);
-        if stripped.length > 0 {
-            return stripped;
-        }
+        if stripped.length > 0 { return stripped; }
     }
     return mapped;
 }
@@ -500,33 +372,26 @@ fn map_parameter_type(context: TypeContext, parameter_type: string) -> string {
     // Otherwise user-defined value types (like enums) can incorrectly become pointers,
     // causing ABI mismatches and memory corruption.
     let mapped = map_return_type(context, parameter_type);
-    if mapped == "void" {
-        return "";
-    }
+    if mapped == "void" { return ""; }
     return mapped;
 }
 
 fn map_local_type(context: TypeContext, annotation: string) -> string {
     // Locals should mirror the context-aware mapping used for returns.
     let mapped = map_return_type(context, annotation);
-    if mapped == "void" {
-        return "";
-    }
+    if mapped == "void" { return ""; }
     return mapped;
 }
 
 // =============================================================================
 // Return Type Mapping
 // =============================================================================
-
 fn map_return_type(context: TypeContext, return_type: string) -> string {
     let trimmed = trim_text(return_type);
     let mut _if315: boolean = false;
     if trimmed.length == 0 { _if315 = true; }
     if trimmed == "void" { _if315 = true; }
-    if _if315 {
-        return "void";
-    }
+    if _if315 { return "void"; }
     let normalized = unwrap_move_wrapper(trimmed);
 
     // Raw pointer types: `*T`, `*mut T`, `*opaque`.
@@ -538,43 +403,27 @@ fn map_return_type(context: TypeContext, return_type: string) -> string {
         let mut _if316: boolean = false;
         if remainder == "opaque" { _if316 = true; }
         if remainder.length == 0 { _if316 = true; }
-        if _if316 {
-            return "i8*";
-        }
+        if _if316 { return "i8*"; }
         let inner = map_return_type(context, remainder);
-        if ends_with_pointer_suffix(inner) {
-            return inner;
-        }
+        if ends_with_pointer_suffix(inner) { return inner; }
         let mut _if317: boolean = false;
         if inner.length == 0 { _if317 = true; }
         if inner == "void" { _if317 = true; }
-        if _if317 {
-            return "i8*";
-        }
+        if _if317 { return "i8*"; }
         return inner + "*";
     }
 
     let union_type = map_union_type(context, normalized);
-    if union_type.length > 0 {
-        return union_type;
-    }
+    if union_type.length > 0 { return union_type; }
     // Try optional type first
     let optional_type = map_optional_type(context, normalized);
-    if optional_type.length > 0 {
-        return optional_type;
-    }
+    if optional_type.length > 0 { return optional_type; }
     let reference_type = map_reference_type(context, normalized);
-    if reference_type.length > 0 {
-        return reference_type;
-    }
+    if reference_type.length > 0 { return reference_type; }
     let array_type = map_array_pointer_type(context, normalized);
-    if array_type.length > 0 {
-        return array_type;
-    }
+    if array_type.length > 0 { return array_type; }
     let primitive_type = map_primitive_type(context, normalized);
-    if primitive_type.length > 0 {
-        return primitive_type;
-    }
+    if primitive_type.length > 0 { return primitive_type; }
 
     // User-defined aggregates (structs/enums/interfaces) are returned by value *only*
     // when the type exists in the current type context.
@@ -582,37 +431,25 @@ fn map_return_type(context: TypeContext, return_type: string) -> string {
     if looks_like_user_type(normalized) {
         let mut i: number = 0;
         loop {
-            if i >= context.structs.length {
-                break;
-            }
+            if i >= context.structs.length { break; }
             let info = context.structs[i];
-            if info.name == normalized {
-                return info.llvm_name;
-            }
+            if info.name == normalized { return info.llvm_name; }
             i += 1;
         }
 
         i = 0;
         loop {
-            if i >= context.enums.length {
-                break;
-            }
+            if i >= context.enums.length { break; }
             let info = context.enums[i];
-            if info.name == normalized {
-                return info.llvm_name;
-            }
+            if info.name == normalized { return info.llvm_name; }
             i += 1;
         }
 
         i = 0;
         loop {
-            if i >= context.interfaces.length {
-                break;
-            }
+            if i >= context.interfaces.length { break; }
             let info = context.interfaces[i];
-            if info.name == normalized {
-                return info.llvm_name;
-            }
+            if info.name == normalized { return info.llvm_name; }
             i += 1;
         }
     }
@@ -623,13 +460,10 @@ fn map_return_type(context: TypeContext, return_type: string) -> string {
 // =============================================================================
 // Specialized Type Mapping
 // =============================================================================
-
 fn map_union_type(context: TypeContext, annotation: string) -> string {
     // Union types: `A | B | C` => tagged struct { i32, <A_llvm>, <B_llvm>, ... }
     let trimmed = trim_text(annotation);
-    if trimmed.length == 0 {
-        return "";
-    }
+    if trimmed.length == 0 { return ""; }
     // Split on top-level `|` separators (skip nested generics)
     let mut parts: string[] = [];
     let mut start: number = 0;
@@ -637,63 +471,45 @@ fn map_union_type(context: TypeContext, annotation: string) -> string {
     let mut depth: number = 0;
     let mut found_pipe: boolean = false;
     loop {
-        if index >= trimmed.length {
-            break;
-        }
+        if index >= trimmed.length { break; }
         let ch = substring(trimmed, index, index + 1);
         let mut _is_open: boolean = false;
         if ch == "<" { _is_open = true; }
         if ch == "(" { _is_open = true; }
         if ch == "[" { _is_open = true; }
-        if _is_open {
-            depth += 1;
-        }
+        if _is_open { depth += 1; }
         let mut _is_close: boolean = false;
         if ch == ">" { _is_close = true; }
         if ch == ")" { _is_close = true; }
         if ch == "]" { _is_close = true; }
         if _is_close {
-            if depth > 0 {
-                depth -= 1;
-            }
+            if depth > 0 { depth -= 1; }
         }
         if ch == "|" {
             if depth == 0 {
                 let part = trim_text(substring(trimmed, start, index));
-                if part.length > 0 {
-                    parts.push(part);
-                }
+                if part.length > 0 { parts.push(part); }
                 start = index + 1;
                 found_pipe = true;
             }
         }
         index += 1;
     }
-    if !found_pipe {
-        return "";
-    }
+    if !found_pipe { return ""; }
     // Collect the last part
     let last_part = trim_text(substring(trimmed, start, trimmed.length));
-    if last_part.length > 0 {
-        parts.push(last_part);
-    }
-    if parts.length < 2 {
-        return "";
-    }
+    if last_part.length > 0 { parts.push(last_part); }
+    if parts.length < 2 { return ""; }
     // Map each variant type and build the tagged struct
     let mut result: string = "{ i32";
     let mut pi: number = 0;
     loop {
-        if pi >= parts.length {
-            break;
-        }
+        if pi >= parts.length { break; }
         let mapped = map_type_annotation(parts[pi]);
         let mut _bad: boolean = false;
         if mapped.length == 0 { _bad = true; }
         if mapped == "void" { _bad = true; }
-        if _bad {
-            return "";
-        }
+        if _bad { return ""; }
         result = result + ", " + mapped;
         pi += 1;
     }
@@ -703,71 +519,47 @@ fn map_union_type(context: TypeContext, annotation: string) -> string {
 
 fn map_optional_type(context: TypeContext, annotation: string) -> string {
     let trimmed = trim_text(annotation);
-    if trimmed.length == 0 {
-        return "";
-    }
+    if trimmed.length == 0 { return ""; }
     if substring(trimmed, trimmed.length - 1, trimmed.length) != "?" {
         return "";
     }
     let inner = trim_text(substring(trimmed, 0, trimmed.length - 1));
-    if inner.length == 0 {
-        return "i8*";
-    }
+    if inner.length == 0 { return "i8*"; }
     let inner_type = map_type_annotation(inner);
     let mut _if319: boolean = false;
     if inner_type.length == 0 { _if319 = true; }
     if inner_type == "void" { _if319 = true; }
-    if _if319 {
-        return "i8*";
-    }
-    if ends_with_pointer_suffix(inner_type) {
-        return inner_type;
-    }
+    if _if319 { return "i8*"; }
+    if ends_with_pointer_suffix(inner_type) { return inner_type; }
     return inner_type + "*";
 }
 
 fn map_reference_type(context: TypeContext, annotation: string) -> string {
     let trimmed = trim_text(annotation);
-    if trimmed.length == 0 {
-        return "";
-    }
-    if substring(trimmed, 0, 1) != "&" {
-        return "";
-    }
+    if trimmed.length == 0 { return ""; }
+    if substring(trimmed, 0, 1) != "&" { return ""; }
     let mut remainder = trim_text(substring(trimmed, 1, trimmed.length));
     if starts_with(remainder, "mut") {
         remainder = trim_text(substring(remainder, 3, remainder.length));
     }
-    if remainder.length == 0 {
-        return "i8*";
-    }
+    if remainder.length == 0 { return "i8*"; }
     let inner_type = map_type_annotation(remainder);
     let mut _if320: boolean = false;
     if inner_type.length == 0 { _if320 = true; }
     if inner_type == "void" { _if320 = true; }
-    if _if320 {
-        return "i8*";
-    }
-    if ends_with_pointer_suffix(inner_type) {
-        return inner_type;
-    }
+    if _if320 { return "i8*"; }
+    if ends_with_pointer_suffix(inner_type) { return inner_type; }
     return inner_type + "*";
 }
 
 fn map_array_pointer_type(context: TypeContext, annotation: string) -> string {
     let trimmed = trim_text(annotation);
-    if trimmed.length < 3 {
-        return "";
-    }
+    if trimmed.length < 3 { return ""; }
     let suffix = substring(trimmed, trimmed.length - 2, trimmed.length);
-    if suffix != "[]" {
-        return "";
-    }
+    if suffix != "[]" { return ""; }
     let element_annotation = trim_text(substring(trimmed, 0, trimmed.length - 2));
     let mut element_type = map_type_annotation(element_annotation);
-    if element_type.length == 0 {
-        return "i8*";
-    }
+    if element_type.length == 0 { return "i8*"; }
     // Arrays of user-value types store the value inline.
     if layout_annotation_represents_user_value(element_annotation) {
         if ends_with_pointer_suffix(element_type) {
@@ -779,70 +571,43 @@ fn map_array_pointer_type(context: TypeContext, annotation: string) -> string {
 
 fn map_primitive_type(context: TypeContext, annotation: string) -> string {
     let trimmed = trim_text(annotation);
-    if trimmed == "number" {
-        return "double";
-    }
+    if trimmed == "number" { return "double"; }
     let mut _if321: boolean = false;
     if trimmed == "boolean" { _if321 = true; }
     if trimmed == "bool" { _if321 = true; }
-    if _if321 {
-        return "i1";
-    }
-    if trimmed == "string" {
-        return "i8*";
-    }
-    if trimmed == "void" {
-        return "void";
-    }
-    if trimmed == "any" {
-        return "i8*";
-    }
+    if _if321 { return "i1"; }
+    if trimmed == "string" { return "i8*"; }
+    if trimmed == "void" { return "void"; }
+    if trimmed == "any" { return "i8*"; }
     let mut _if322: boolean = false;
     if trimmed == "int" { _if322 = true; }
     if trimmed == "i64" { _if322 = true; }
-    if _if322 {
-        return "i64";
-    }
-    if trimmed == "i32" {
-        return "i32";
-    }
-    if trimmed == "usize" {
-        return "i64";
-    }
+    if _if322 { return "i64"; }
+    if trimmed == "i32" { return "i32"; }
+    if trimmed == "usize" { return "i64"; }
     let mut _if323: boolean = false;
     if trimmed == "u8" { _if323 = true; }
     if trimmed == "i8" { _if323 = true; }
-    if _if323 {
-        return "i8";
-    }
+    if _if323 { return "i8"; }
     return "";
 }
 
 // =============================================================================
 // Future/Async Type Mapping
 // =============================================================================
-
 fn future_pointer_type_for_return_type(return_type: string) -> string {
     let trimmed = trim_text(return_type);
     let mut _if324: boolean = false;
     if trimmed.length == 0 { _if324 = true; }
     if trimmed == "void" { _if324 = true; }
-    if _if324 {
-        return "%SailfinFutureVoid*";
-    }
+    if _if324 { return "%SailfinFutureVoid*"; }
     let normalized = unwrap_move_wrapper(trimmed);
-    if normalized == "number" {
-        return "%SailfinFutureNumber*";
-    }
+    if normalized == "number" { return "%SailfinFutureNumber*"; }
     let mut _if325: boolean = false;
     if normalized == "boolean" { _if325 = true; }
     if normalized == "bool" { _if325 = true; }
-    if _if325 {
-        return "%SailfinFutureBool*";
-    }
-    if normalized == "string" {
-        return "%SailfinFutureString*";
-    }
+    if _if325 { return "%SailfinFutureBool*"; }
+    if normalized == "string" { return "%SailfinFutureString*"; }
     // Default: treat unknown/user types as an opaque pointer.
     return "%SailfinFuturePtr*";
 }
@@ -852,22 +617,14 @@ fn spawn_symbol_for_return_type(return_type: string) -> string {
     let mut _if326: boolean = false;
     if trimmed.length == 0 { _if326 = true; }
     if trimmed == "void" { _if326 = true; }
-    if _if326 {
-        return "sailfin_runtime_spawn_void";
-    }
+    if _if326 { return "sailfin_runtime_spawn_void"; }
     let normalized = unwrap_move_wrapper(trimmed);
-    if normalized == "number" {
-        return "sailfin_runtime_spawn_number";
-    }
+    if normalized == "number" { return "sailfin_runtime_spawn_number"; }
     let mut _if327: boolean = false;
     if normalized == "boolean" { _if327 = true; }
     if normalized == "bool" { _if327 = true; }
-    if _if327 {
-        return "sailfin_runtime_spawn_bool";
-    }
-    if normalized == "string" {
-        return "sailfin_runtime_spawn_string";
-    }
+    if _if327 { return "sailfin_runtime_spawn_bool"; }
+    if normalized == "string" { return "sailfin_runtime_spawn_string"; }
     return "sailfin_runtime_spawn_ptr";
 }
 
@@ -876,44 +633,29 @@ fn spawn_ctx_symbol_for_return_type(return_type: string) -> string {
     let mut _if328: boolean = false;
     if trimmed.length == 0 { _if328 = true; }
     if trimmed == "void" { _if328 = true; }
-    if _if328 {
-        return "sailfin_runtime_spawn_void_ctx";
-    }
+    if _if328 { return "sailfin_runtime_spawn_void_ctx"; }
     let normalized = unwrap_move_wrapper(trimmed);
-    if normalized == "number" {
-        return "sailfin_runtime_spawn_number_ctx";
-    }
+    if normalized == "number" { return "sailfin_runtime_spawn_number_ctx"; }
     let mut _if329: boolean = false;
     if normalized == "boolean" { _if329 = true; }
     if normalized == "bool" { _if329 = true; }
-    if _if329 {
-        return "sailfin_runtime_spawn_bool_ctx";
-    }
-    if normalized == "string" {
-        return "sailfin_runtime_spawn_string_ctx";
-    }
+    if _if329 { return "sailfin_runtime_spawn_bool_ctx"; }
+    if normalized == "string" { return "sailfin_runtime_spawn_string_ctx"; }
     return "sailfin_runtime_spawn_ptr_ctx";
 }
 
 // =============================================================================
 // Default Value Helpers
 // =============================================================================
-
 fn default_value_for_llvm_type(llvm_type: string) -> string {
     let trimmed = trim_text(llvm_type);
-    if trimmed == "double" {
-        return "0.0";
-    }
+    if trimmed == "double" { return "0.0"; }
     let mut _if330: boolean = false;
     if trimmed == "i64" { _if330 = true; }
     if trimmed == "i32" { _if330 = true; }
     if trimmed == "i1" { _if330 = true; }
     if trimmed == "i8" { _if330 = true; }
-    if _if330 {
-        return "0";
-    }
-    if ends_with_pointer_suffix(llvm_type) {
-        return "null";
-    }
+    if _if330 { return "0"; }
+    if ends_with_pointer_suffix(llvm_type) { return "null"; }
     return "zeroinitializer";
 }

--- a/compiler/src/llvm/types.sfn
+++ b/compiler/src/llvm/types.sfn
@@ -3,13 +3,18 @@
 // Struct definitions for the LLVM lowering pass. These types represent
 // intermediate data structures used during the translation from .sfn-asm
 // to LLVM IR.
-
-import { NativeFunction, NativeInterfaceSignature, NativeSourceSpan, NativeEnum, NativeStruct, LayoutManifest } from "../native_ir";
+import {
+    NativeFunction,
+    NativeInterfaceSignature,
+    NativeSourceSpan,
+    NativeEnum,
+    NativeStruct,
+    LayoutManifest
+} from "../native_ir";
 
 // =============================================================================
 // Enum Layout Fixup
 // =============================================================================
-
 struct EnumLayoutFixupResult {
     enums: NativeEnum[];
     diagnostics: string[];
@@ -18,7 +23,6 @@ struct EnumLayoutFixupResult {
 // =============================================================================
 // Trait/Interface Metadata
 // =============================================================================
-
 struct TraitImplementationDescriptor {
     struct_name: string;
     interfaces: string[];
@@ -38,7 +42,6 @@ struct TraitMetadata {
 // =============================================================================
 // Effect System
 // =============================================================================
-
 struct FunctionEffectEntry {
     name: string;
     effects: string[];
@@ -61,7 +64,6 @@ struct FunctionCallEntry {
 // =============================================================================
 // Runtime Helpers
 // =============================================================================
-
 struct RuntimeHelperDescriptor {
     target: string;
     symbol: string;
@@ -73,7 +75,6 @@ struct RuntimeHelperDescriptor {
 // =============================================================================
 // String Constants
 // =============================================================================
-
 struct StringConstant {
     name: string;
     content: string;
@@ -95,7 +96,6 @@ struct InterpolatedTemplateParse {
 // =============================================================================
 // Lowering Results
 // =============================================================================
-
 struct LoweredLLVMResult {
     ir: string;
     diagnostics: string[];
@@ -145,7 +145,6 @@ struct BodyResult {
 // =============================================================================
 // Parameter/Local Bindings
 // =============================================================================
-
 struct ParameterBinding {
     name: string;
     llvm_name: string;
@@ -185,7 +184,6 @@ struct ModuleGlobalLoweringResult {
 // =============================================================================
 // LLVM Operands and Expression Results
 // =============================================================================
-
 struct LLVMOperand {
     llvm_type: string;
     value: string;
@@ -207,7 +205,6 @@ struct ArrayLiteralMetadata {
 // =============================================================================
 // Ownership and Lifetime Tracking
 // =============================================================================
-
 struct OwnershipInfo {
     variant: string;
     base: string;
@@ -256,7 +253,6 @@ struct OwnershipAnalysis {
 // =============================================================================
 // Type Context (struct/enum/interface metadata)
 // =============================================================================
-
 struct StructFieldInfo {
     name: string;
     llvm_type: string;
@@ -336,7 +332,6 @@ struct TypeAllocationInfo {
 // =============================================================================
 // Heap/Allocation Helpers
 // =============================================================================
-
 struct HeapBoxResult {
     lines: string[];
     temp_index: number;
@@ -347,7 +342,6 @@ struct HeapBoxResult {
 // =============================================================================
 // Literal Parsing
 // =============================================================================
-
 struct StructLiteralField {
     name: string;
     value: string;
@@ -385,7 +379,6 @@ struct IndexExpressionParse {
 // =============================================================================
 // Mutation Tracking
 // =============================================================================
-
 struct LocalMutation {
     name: string;
     llvm_type: string;
@@ -397,7 +390,6 @@ struct LocalMutation {
 // =============================================================================
 // Operator/Expression Parsing
 // =============================================================================
-
 struct OperatorMatch {
     index: number;
     symbol: string;
@@ -451,7 +443,6 @@ struct TernaryParseResult {
 // =============================================================================
 // Statement/Instruction Lowering Results
 // =============================================================================
-
 struct ExpressionStatementResult {
     lines: string[];
     temp_index: number;
@@ -492,7 +483,6 @@ struct InlineLetParseResult {
 // =============================================================================
 // Control Flow Structures
 // =============================================================================
-
 struct BlockLabelResult {
     label: string;
     next_counter: number;
@@ -546,7 +536,6 @@ struct RangeIterableParse {
 // =============================================================================
 // Match Expression Structures
 // =============================================================================
-
 struct MatchCaseStructure {
     pattern: string;
     guard: string?;
@@ -591,7 +580,6 @@ struct MatchCaseCondition {
 // =============================================================================
 // Condition/Comparison Helpers
 // =============================================================================
-
 struct ConditionConversion {
     lines: string[];
     temp_index: number;
@@ -626,7 +614,6 @@ struct BinaryAlignmentResult {
 // =============================================================================
 // Block Lowering Result
 // =============================================================================
-
 struct BlockLoweringResult {
     lines: string[];
     allocas: string[];
@@ -647,7 +634,6 @@ struct BlockLoweringResult {
 // =============================================================================
 // Throw/Exception Handling
 // =============================================================================
-
 struct ThrowLoweringResult {
     lines: string[];
     temp_index: number;
@@ -659,7 +645,6 @@ struct ThrowLoweringResult {
 // =============================================================================
 // PHI Node Merging
 // =============================================================================
-
 struct PhiMergeResult {
     lines: string[];
     temp_index: number;
@@ -690,7 +675,6 @@ struct MatchArmMutations {
 // =============================================================================
 // Local Loading
 // =============================================================================
-
 struct LoadLocalResult {
     lines: string[];
     temp_index: number;
@@ -701,7 +685,6 @@ struct LoadLocalResult {
 // =============================================================================
 // Call Resolution (split from core_call_lowering for OOM avoidance)
 // =============================================================================
-
 struct CallTargetResolution {
     trimmed_target: string;
     method_operand: LLVMOperand?;

--- a/compiler/src/llvm/utils.sfn
+++ b/compiler/src/llvm/utils.sfn
@@ -529,7 +529,7 @@ fn _merge_copy_parameter_binding(primary: ParameterBinding, consumed_flag: boole
         llvm_type: primary.llvm_type,
         type_annotation: primary.type_annotation,
         consumed: consumed_flag,
-        span: primary.span,
+        span: primary.span
     };
 }
 

--- a/compiler/src/llvm/utils.sfn
+++ b/compiler/src/llvm/utils.sfn
@@ -2,21 +2,17 @@
 //
 // General utility functions for the LLVM lowering pass. These are basic
 // string manipulation, array helpers, and parsing utilities.
-
-import { substring, char_code } from "../string_utils";
+import { char_code, substring } from "../string_utils";
 import { ParameterBinding } from "./types";
 
 // =============================================================================
 // String manipulation
 // =============================================================================
-
 fn trim_text(value: string) -> string {
     let mut start: number = 0;
     let mut end: number = value.length;
     loop {
-        if start >= end {
-            break;
-        }
+        if start >= end { break; }
         let ch = char_at(value, start);
         if is_trim_char(ch) {
             start += 1;
@@ -25,9 +21,7 @@ fn trim_text(value: string) -> string {
         break;
     }
     loop {
-        if end <= start {
-            break;
-        }
+        if end <= start { break; }
         let ch = char_at(value, end - 1);
         if is_trim_char(ch) {
             end -= 1;
@@ -36,9 +30,7 @@ fn trim_text(value: string) -> string {
         break;
     }
     if start == 0 {
-        if end == value.length {
-            return value;
-        }
+        if end == value.length { return value; }
     }
     return substring(value, start, end);
 }
@@ -62,87 +54,59 @@ fn is_trim_char(ch: string) -> boolean {
 }
 
 fn starts_with(value: string, prefix: string) -> boolean {
-    if prefix.length == 0 {
-        return true;
-    }
-    if value.length < prefix.length {
-        return false;
-    }
+    if prefix.length == 0 { return true; }
+    if value.length < prefix.length { return false; }
     let head = substring(value, 0, prefix.length);
     return head == prefix;
 }
 
 fn ends_with(value: string, suffix: string) -> boolean {
-    if suffix.length == 0 {
-        return true;
-    }
-    if value.length < suffix.length {
-        return false;
-    }
+    if suffix.length == 0 { return true; }
+    if value.length < suffix.length { return false; }
     let start_index = value.length - suffix.length;
     let tail = substring(value, start_index, value.length);
     return tail == suffix;
 }
 
 fn contains_text(haystack: string, needle: string) -> boolean {
-    if needle.length == 0 {
-        return true;
-    }
-    if haystack.length < needle.length {
-        return false;
-    }
+    if needle.length == 0 { return true; }
+    if haystack.length < needle.length { return false; }
     let _search_limit = haystack.length - needle.length;
     let mut index: number = 0;
     loop {
-        if index > _search_limit {
-            break;
-        }
+        if index > _search_limit { break; }
         let candidate = substring(haystack, index, index + needle.length);
-        if candidate == needle {
-            return true;
-        }
+        if candidate == needle { return true; }
         index += 1;
     }
     return false;
 }
 
 fn index_of(value: string, target: string) -> number {
-    if target.length == 0 {
-        return 0;
-    }
+    if target.length == 0 { return 0; }
     // Use substring + == instead of char_code_at_text comparisons.
     // char_code_at_text is miscompiled by older seeds, but substring
     // (backed by the C runtime grapheme_at) and == both work correctly.
     let _search_limit = value.length - target.length;
     let mut index: number = 0;
     loop {
-        if index > _search_limit {
-            break;
-        }
+        if index > _search_limit { break; }
         let candidate = substring(value, index, index + target.length);
-        if candidate == target {
-            return index;
-        }
+        if candidate == target { return index; }
         index += 1;
     }
     return -1;
 }
 
 fn find_last_index_of_char(value: string, target: string) -> number {
-    if target.length != 1 {
-        return -1;
-    }
+    if target.length != 1 { return -1; }
     // Use substring + == instead of char_code_at_text.
     let mut index: number = value.length;
     loop {
-        if index <= 0 {
-            break;
-        }
+        if index <= 0 { break; }
         index -= 1;
         let ch = substring(value, index, index + 1);
-        if ch == target {
-            return index;
-        }
+        if ch == target { return index; }
     }
     return -1;
 }
@@ -153,9 +117,7 @@ fn char_code_at_text(text: string, index: number) -> number {
 
 fn strip_mut_prefix(value: string) -> string {
     let trimmed = trim_text(value);
-    if trimmed.length < 4 {
-        return trimmed;
-    }
+    if trimmed.length < 4 { return trimmed; }
     let prefix = substring(trimmed, 0, 4);
     if prefix == "mut " {
         return trim_text(substring(trimmed, 4, trimmed.length));
@@ -166,30 +128,10 @@ fn strip_mut_prefix(value: string) -> string {
 // =============================================================================
 // Number utilities
 // =============================================================================
-
 fn number_to_string(value: number) -> string {
-    if value == 0 {
-        return "0";
-    }
+    if value == 0 { return "0"; }
     let digits = "0123456789";
-    let powers: number[] = [
-        1000000000000000,
-        100000000000000,
-        10000000000000,
-        1000000000000,
-        100000000000,
-        10000000000,
-        1000000000,
-        100000000,
-        10000000,
-        1000000,
-        100000,
-        10000,
-        1000,
-        100,
-        10,
-        1
-    ];
+    let powers: number[] = [1000000000000000, 100000000000000, 10000000000000, 1000000000000, 100000000000, 10000000000, 1000000000, 100000000, 10000000, 1000000, 100000, 10000, 1000, 100, 10, 1];
     let mut remaining: number = value;
     let mut is_negative: boolean = false;
     if remaining < 0 {
@@ -200,15 +142,11 @@ fn number_to_string(value: number) -> string {
     let mut index: number = 0;
     let mut started: boolean = false;
     loop {
-        if index >= powers.length {
-            break;
-        }
+        if index >= powers.length { break; }
         let power = powers[index];
         let mut count: number = 0;
         loop {
-            if remaining < power {
-                break;
-            }
+            if remaining < power { break; }
             remaining -= power;
             count += 1;
         }
@@ -222,12 +160,8 @@ fn number_to_string(value: number) -> string {
         }
         index += 1;
     }
-    if output.length == 0 {
-        output = "0";
-    }
-    if is_negative {
-        return "-" + output;
-    }
+    if output.length == 0 { output = "0"; }
+    if is_negative { return "-" + output; }
     return output;
 }
 
@@ -244,21 +178,15 @@ fn lower_char_code(code: number) -> number {
 }
 
 fn matches_case_insensitive(value: string, expected: string) -> boolean {
-    if value.length != expected.length {
-        return false;
-    }
+    if value.length != expected.length { return false; }
     let mut index: number = 0;
     loop {
-        if index >= value.length {
-            break;
-        }
+        if index >= value.length { break; }
         let value_ch = substring(value, index, index + 1);
         let expected_ch = substring(expected, index, index + 1);
         let value_code = lower_char_code(char_code(value_ch));
         let expected_code = lower_char_code(char_code(expected_ch));
-        if value_code != expected_code {
-            return false;
-        }
+        if value_code != expected_code { return false; }
         index += 1;
     }
     return true;
@@ -267,35 +195,24 @@ fn matches_case_insensitive(value: string, expected: string) -> boolean {
 // =============================================================================
 // Literal detection
 // =============================================================================
-
 fn is_boolean_literal(text: string) -> boolean {
     let trimmed = trim_text(text);
-    if matches_case_insensitive(trimmed, "true") {
-        return true;
-    }
-    if matches_case_insensitive(trimmed, "false") {
-        return true;
-    }
+    if matches_case_insensitive(trimmed, "true") { return true; }
+    if matches_case_insensitive(trimmed, "false") { return true; }
     return false;
 }
 
 fn is_integer_literal(text: string) -> boolean {
     let trimmed = trim_text(text);
-    if trimmed.length == 0 {
-        return false;
-    }
+    if trimmed.length == 0 { return false; }
     let mut index: number = 0;
     if substring(trimmed, 0, 1) == "-" {
-        if trimmed.length == 1 {
-            return false;
-        }
+        if trimmed.length == 1 { return false; }
         index = 1;
     }
     let mut has_digit: boolean = false;
     loop {
-        if index >= trimmed.length {
-            break;
-        }
+        if index >= trimmed.length { break; }
         let ch = substring(trimmed, index, index + 1);
         let mut _if335: boolean = false;
         if ch == "0" { _if335 = true; }
@@ -323,19 +240,13 @@ fn is_number_literal(text: string) -> boolean {
     let mut has_digit: boolean = false;
     let mut has_decimal: boolean = false;
     let trimmed = trim_text(text);
-    if trimmed.length == 0 {
-        return false;
-    }
+    if trimmed.length == 0 { return false; }
     if substring(trimmed, 0, 1) == "-" {
-        if trimmed.length == 1 {
-            return false;
-        }
+        if trimmed.length == 1 { return false; }
         index = 1;
     }
     loop {
-        if index >= trimmed.length {
-            break;
-        }
+        if index >= trimmed.length { break; }
         let ch = substring(trimmed, index, index + 1);
         let mut _if336: boolean = false;
         if ch == "0" { _if336 = true; }
@@ -354,9 +265,7 @@ fn is_number_literal(text: string) -> boolean {
             continue;
         }
         if ch == "." {
-            if has_decimal {
-                return false;
-            }
+            if has_decimal { return false; }
             has_decimal = true;
             index += 1;
             continue;
@@ -372,82 +281,53 @@ fn is_digit_char(ch: string) -> boolean {
     let nine = char_code("9");
     let mut _ret337: boolean = false;
     if code >= zero {
-        if code <= nine {
-            _ret337 = true;
-        }
+        if code <= nine { _ret337 = true; }
     }
     return _ret337;
 }
 
 fn is_simple_identifier(value: string) -> boolean {
     let trimmed = trim_text(value);
-    if trimmed.length == 0 {
-        return false;
-    }
+    if trimmed.length == 0 { return false; }
     let first = substring(trimmed, 0, 1);
     if first >= "0" {
-        if first <= "9" {
-            return false;
-        }
+        if first <= "9" { return false; }
     }
     let sanitized = sanitize_symbol(trimmed);
-    if sanitized != trimmed {
-        return false;
-    }
+    if sanitized != trimmed { return false; }
     return true;
 }
 
 // =============================================================================
 // Identifier and keyword helpers
 // =============================================================================
-
 fn is_identifier_start_char(ch: string) -> boolean {
-    if ch == "_" {
-        return true;
-    }
-    if index_of("abcdefghijklmnopqrstuvwxyz", ch) != -1 {
-        return true;
-    }
-    if index_of("ABCDEFGHIJKLMNOPQRSTUVWXYZ", ch) != -1 {
-        return true;
-    }
+    if ch == "_" { return true; }
+    if index_of("abcdefghijklmnopqrstuvwxyz", ch) != -1 { return true; }
+    if index_of("ABCDEFGHIJKLMNOPQRSTUVWXYZ", ch) != -1 { return true; }
     return false;
 }
 
 fn is_identifier_part_char(ch: string) -> boolean {
-    if is_identifier_start_char(ch) {
-        return true;
-    }
-    if index_of("0123456789", ch) != -1 {
-        return true;
-    }
+    if is_identifier_start_char(ch) { return true; }
+    if index_of("0123456789", ch) != -1 { return true; }
     return false;
 }
 
 fn matches_keyword(value: string, start_index: number, keyword: string) -> boolean {
     let remaining = value.length - start_index;
-    if remaining < keyword.length {
-        return false;
-    }
+    if remaining < keyword.length { return false; }
     let slice = substring(value, start_index, start_index + keyword.length);
-    if slice != keyword {
-        return false;
-    }
+    if slice != keyword { return false; }
     let _keyword_end = start_index + keyword.length;
-    if _keyword_end >= value.length {
-        return true;
-    }
+    if _keyword_end >= value.length { return true; }
     let next = substring(value, _keyword_end, _keyword_end + 1);
-    if is_identifier_part_char(next) {
-        return false;
-    }
+    if is_identifier_part_char(next) { return false; }
     return true;
 }
 
 fn is_effect_prefix_char(ch: string) -> boolean {
-    if is_trim_char(ch) {
-        return true;
-    }
+    if is_trim_char(ch) { return true; }
     let mut _ret338: boolean = false;
     if ch == "(" { _ret338 = true; }
     if ch == "," { _ret338 = true; }
@@ -459,9 +339,7 @@ fn is_effect_prefix_char(ch: string) -> boolean {
 }
 
 fn is_effect_delimiter(ch: string) -> boolean {
-    if is_trim_char(ch) {
-        return true;
-    }
+    if is_trim_char(ch) { return true; }
     let mut _ret339: boolean = false;
     if ch == "(" { _ret339 = true; }
     if ch == ")" { _ret339 = true; }
@@ -476,67 +354,46 @@ fn is_effect_delimiter(ch: string) -> boolean {
 // =============================================================================
 // Symbol sanitization
 // =============================================================================
-
 // Duplicated from string_utils to avoid cross-module function call issues in Stage2
 fn is_symbol_char(ch: string) -> boolean {
-    if ch.length == 0 {
-        return false;
-    }
-    if ch == "_" {
-        return true;
-    }
+    if ch.length == 0 { return false; }
+    if ch == "_" { return true; }
     let code = char_code(ch);
     let lower_a = char_code("a");
     let lower_z = char_code("z");
     if code >= lower_a {
-        if code <= lower_z {
-            return true;
-        }
+        if code <= lower_z { return true; }
     }
     let upper_a = char_code("A");
     let upper_z = char_code("Z");
     if code >= upper_a {
-        if code <= upper_z {
-            return true;
-        }
+        if code <= upper_z { return true; }
     }
     let zero = char_code("0");
     let nine = char_code("9");
     if code >= zero {
-        if code <= nine {
-            return true;
-        }
+        if code <= nine { return true; }
     }
     return false;
 }
 
 fn sanitize_symbol(name: string) -> string {
-    if name.length == 0 {
-        return "_";
-    }
+    if name.length == 0 { return "_"; }
     let mut result: string = "";
     let mut index: number = 0;
     loop {
-        if index >= name.length {
-            break;
-        }
+        if index >= name.length { break; }
         let ch = substring(name, index, index + 1);
-        if is_symbol_char(ch) {
-            result = result + ch;
-        }
+        if is_symbol_char(ch) { result = result + ch; }
         index += 1;
     }
-    if result.length == 0 {
-        return "_";
-    }
+    if result.length == 0 { return "_"; }
     let first = substring(result, 0, 1);
     let first_code = char_code(first);
     let zero = char_code("0");
     let nine = char_code("9");
     if first_code >= zero {
-        if first_code <= nine {
-            result = "_" + result;
-        }
+        if first_code <= nine { result = "_" + result; }
     }
     return result;
 }
@@ -544,30 +401,21 @@ fn sanitize_symbol(name: string) -> string {
 // =============================================================================
 // Array utilities
 // =============================================================================
-
 fn append_string(values: string[], value: string) -> string[] {
     let mut out = values;
-    if out == null {
-        out = [];
-    }
+    if out == null { out = []; }
     out = out.push(value);
     return out;
 }
 
 fn extend_string_array(values: string[], additions: string[]) -> string[] {
     let mut out = values;
-    if out == null {
-        out = [];
-    }
+    if out == null { out = []; }
     let mut safe_additions = additions;
-    if safe_additions == null {
-        safe_additions = [];
-    }
+    if safe_additions == null { safe_additions = []; }
     let mut index: number = 0;
     loop {
-        if index >= safe_additions.length {
-            break;
-        }
+        if index >= safe_additions.length { break; }
         out = out.push(safe_additions[index]);
         index += 1;
     }
@@ -577,14 +425,10 @@ fn extend_string_array(values: string[], additions: string[]) -> string[] {
 fn copy_string_array(values: string[]) -> string[] {
     let mut result: string[] = [];
     let mut safe_values = values;
-    if safe_values == null {
-        safe_values = [];
-    }
+    if safe_values == null { safe_values = []; }
     let mut index: number = 0;
     loop {
-        if index >= safe_values.length {
-            break;
-        }
+        if index >= safe_values.length { break; }
         result.push(safe_values[index]);
         index += 1;
     }
@@ -598,71 +442,47 @@ fn string_arrays_equal(first: string[], second: string[]) -> boolean {
     if _if340 {
         let mut _ret342: boolean = false;
         if first == null {
-            if second == null {
-                _ret342 = true;
-            }
+            if second == null { _ret342 = true; }
         }
         return _ret342;
     }
-    if first.length != second.length {
-        return false;
-    }
+    if first.length != second.length { return false; }
     let mut index: number = 0;
     loop {
-        if index >= first.length {
-            break;
-        }
-        if first[index] != second[index] {
-            return false;
-        }
+        if index >= first.length { break; }
+        if first[index] != second[index] { return false; }
         index += 1;
     }
     return true;
 }
 
 fn string_array_contains(values: string[], target: string) -> boolean {
-    if values == null {
-        return false;
-    }
+    if values == null { return false; }
     let mut index: number = 0;
     loop {
-        if index >= values.length {
-            break;
-        }
-        if values[index] == target {
-            return true;
-        }
+        if index >= values.length { break; }
+        if values[index] == target { return true; }
         index += 1;
     }
     return false;
 }
 
 fn join_with_separator(values: string[], separator: string) -> string {
-    if values == null {
-        return "";
-    }
-    if values.length == 0 {
-        return "";
-    }
-    if values.length == 1 {
-        return values[0];
-    }
+    if values == null { return ""; }
+    if values.length == 0 { return ""; }
+    if values.length == 1 { return values[0]; }
 
     // Balanced join to avoid repeatedly concatenating an ever-growing prefix.
     // This keeps intermediate strings smaller and prevents runtime corruption
     // observed in large LLVM IR modules (notably the test harness build).
     let mut parts: string[] = values;
     loop {
-        if parts.length <= 1 {
-            break;
-        }
+        if parts.length <= 1 { break; }
 
         let mut next: string[] = [];
         let mut index: number = 0;
         loop {
-            if index >= parts.length {
-                break;
-            }
+            if index >= parts.length { break; }
             let _jn_next = index + 1;
             if _jn_next < parts.length {
                 let combined = parts[index] + separator + parts[_jn_next];
@@ -682,16 +502,11 @@ fn join_with_separator(values: string[], separator: string) -> string {
 // =============================================================================
 // Parameter binding helpers
 // =============================================================================
-
 fn find_parameter_binding(bindings: ParameterBinding[], name: string) -> ParameterBinding? {
     let mut index: number = 0;
     loop {
-        if index >= bindings.length {
-            break;
-        }
-        if bindings[index].name == name {
-            return bindings[index];
-        }
+        if index >= bindings.length { break; }
+        if bindings[index].name == name { return bindings[index]; }
         index += 1;
     }
     return null;
@@ -722,9 +537,7 @@ fn merge_parameter_bindings(first: ParameterBinding[], second: ParameterBinding[
     let mut result: ParameterBinding[] = [];
     let mut index: number = 0;
     loop {
-        if index >= first.length {
-            break;
-        }
+        if index >= first.length { break; }
         let primary = first[index];
         let mut consumed_flag: boolean = primary.consumed;
         let counterpart = find_parameter_binding(second, primary.name);
@@ -743,21 +556,14 @@ fn merge_parameter_bindings(first: ParameterBinding[], second: ParameterBinding[
 // =============================================================================
 // Parsing helpers
 // =============================================================================
-
 fn skip_string_literal(text: string, start_index: number) -> number {
     let mut index: number = start_index;
     let mut escaped: boolean = false;
     loop {
-        if index >= text.length {
-            break;
-        }
+        if index >= text.length { break; }
         let current = substring(text, index, index + 1);
-        if escaped {
-            escaped = false;
-        } else {
-            if current == "\\" {
-                escaped = true;
-            } else if current == "\"" {
+        if escaped { escaped = false; } else {
+            if current == "\\" { escaped = true; } else if current == "\"" {
                 index += 1;
                 break;
             }

--- a/compiler/src/lock.sfn
+++ b/compiler/src/lock.sfn
@@ -13,9 +13,7 @@
 //
 // Each entry under [packages] maps a capsule display name to its locked
 // version and integrity hash, space-separated within the quoted value.
-
 // ---- Internal helpers ----
-
 fn _lock_trim(text: string) -> string {
     let mut start: number = 0;
     let mut end: number = text.length;
@@ -26,9 +24,7 @@ fn _lock_trim(text: string) -> string {
         if ch == " " { ws = true; }
         if ch == "\t" { ws = true; }
         if ch == "\r" { ws = true; }
-        if ws {
-            start += 1;
-        } else { break; }
+        if ws { start += 1; } else { break; }
     }
     loop {
         if end <= start { break; }
@@ -37,9 +33,7 @@ fn _lock_trim(text: string) -> string {
         if ch == " " { ws = true; }
         if ch == "\t" { ws = true; }
         if ch == "\r" { ws = true; }
-        if ws {
-            end -= 1;
-        } else { break; }
+        if ws { end -= 1; } else { break; }
     }
     return substring(text, start, end);
 }
@@ -68,9 +62,7 @@ fn _lock_split_lines(text: string) -> string[] {
         }
         i += 1;
     }
-    if start <= len {
-        lines.push(substring(text, start, len));
-    }
+    if start <= len { lines.push(substring(text, start, len)); }
     return lines;
 }
 
@@ -93,7 +85,9 @@ fn _lock_parse(text: string) -> _LockEntry[] {
         if line[0] == "#" { continue; }
         if line[0] == "[" {
             let close = find_char(line, "]", 0);
-            if close > 0 { section = _lock_trim(substring(line, 1, close)); }
+            if close > 0 {
+                section = _lock_trim(substring(line, 1, close));
+            }
             continue;
         }
         if !strings_equal(section, "packages") { continue; }
@@ -111,13 +105,14 @@ fn _lock_parse(text: string) -> _LockEntry[] {
             ver = substring(raw_value, 0, space_pos);
             integrity = substring(raw_value, space_pos + 1, raw_value.length);
         }
-        entries.push(_LockEntry { capsule: capsule_name, version: ver, hash: integrity });
+        entries.push(_LockEntry {
+            capsule: capsule_name, version: ver, hash: integrity
+        });
     }
     return entries;
 }
 
 // ---- Public API ----
-
 // Return locked dependency versions as a newline-separated string of
 // "capsule=version" pairs — same format as toml_get_dependencies() so
 // callers can use _lookup_dep_version_cmd directly.
@@ -179,7 +174,9 @@ fn lock_add_entry(lock_text: string, capsule: string, version: string, hash: str
         i += 1;
     }
     if !found {
-        entries.push(_LockEntry { capsule: capsule, version: version, hash: hash });
+        entries.push(_LockEntry {
+            capsule: capsule, version: version, hash: hash
+        });
     }
     return _lock_write(entries);
 }
@@ -194,9 +191,7 @@ fn _lock_write(entries: _LockEntry[]) -> string {
         if i >= entries.length { break; }
         let e = entries[i];
         let mut value: string = e.version;
-        if e.hash.length > 0 {
-            value = value + " " + e.hash;
-        }
+        if e.hash.length > 0 { value = value + " " + e.hash; }
         out = out + "\"" + e.capsule + "\" = \"" + value + "\"\n";
         i += 1;
     }

--- a/compiler/src/main.sfn
+++ b/compiler/src/main.sfn
@@ -1,25 +1,25 @@
 // compiler/src/main.sfn
 //
 // Sailfin compiler main module and compilation entry points.
-
-import { parse_program } from "./parser/mod";
 import { Program } from "./ast";
+import {
+    NativeModule,
+    emit_native,
+    emit_native_text_to_file_with_module_name,
+    emit_native_text_with_module_name,
+    emit_native_with_module_name
+} from "./emit_native";
 import { emit_program } from "./emitter_sailfin";
-import { emit_native, emit_native_with_module_name, emit_native_text_with_module_name, emit_native_text_to_file_with_module_name, NativeModule } from "./emit_native";
 import {
     lower_to_llvm_ir,
     lower_to_llvm_ir_from_text,
     write_llvm_ir,
     write_llvm_ir_from_native_text_file,
 } from "./llvm/lowering/entrypoints";
-import {
-    lower_to_llvm_for_tests,
-} from "./llvm/lowering/entrypoints_tests";
-import {
-    write_llvm_ir_for_tests,
-    write_llvm_ir_for_tests_from_text,
-} from "./llvm/lowering/entrypoints_tests_writer";
+import { lower_to_llvm_for_tests, } from "./llvm/lowering/entrypoints_tests";
+import { write_llvm_ir_for_tests, write_llvm_ir_for_tests_from_text, } from "./llvm/lowering/entrypoints_tests_writer";
 import { split_lines } from "./native_ir_utils_text";
+import { parse_program } from "./parser/mod";
 import { substring } from "./string_utils";
 import { Token } from "./token";
 import { toml_get_dependencies } from "./toml_parser";
@@ -28,9 +28,7 @@ import { typecheck_diagnostics, typecheck_has_errors } from "./typecheck";
 fn _ms_since(start_ms: number) -> number {
     let end_ms = monotonic_millis();
     let delta = end_ms - start_ms;
-    if delta < 0 {
-        return 0;
-    }
+    if delta < 0 { return 0; }
     return delta;
 }
 
@@ -51,21 +49,15 @@ fn compile_to_sailfin(source: string) -> string ![io] {
 }
 
 fn module_name_from_path(source_path: string) -> string {
-    if source_path.length == 0 {
-        return "main";
-    }
+    if source_path.length == 0 { return "main"; }
 
     // Normalize path separators so we can reason about prefixes.
     let mut normalized: string = "";
     let mut index: number = 0;
     loop {
-        if index >= source_path.length {
-            break;
-        }
+        if index >= source_path.length { break; }
         let ch = source_path[index];
-        if ch == "\\" {
-            normalized = normalized + "/";
-        } else {
+        if ch == "\\" { normalized = normalized + "/"; } else {
             normalized = normalized + ch;
         }
         index += 1;
@@ -82,24 +74,18 @@ fn module_name_from_path(source_path: string) -> string {
     let compiler_search_limit = normalized.length - compiler_prefix.length;
     index = 0;
     loop {
-        if index > compiler_search_limit {
-            break;
-        }
+        if index > compiler_search_limit { break; }
         if substring(normalized, index, index + compiler_prefix.length) == compiler_prefix {
             last_compiler = index;
         }
         index += 1;
     }
-    if last_compiler >= 0 {
-        start = last_compiler + compiler_prefix.length;
-    } else {
+    if last_compiler >= 0 { start = last_compiler + compiler_prefix.length; } else {
         let mut last_runtime: number = -1;
         let runtime_search_limit = normalized.length - runtime_prefix.length;
         index = 0;
         loop {
-            if index > runtime_search_limit {
-                break;
-            }
+            if index > runtime_search_limit { break; }
             if substring(normalized, index, index + runtime_prefix.length) == runtime_prefix {
                 last_runtime = index;
             }
@@ -116,12 +102,8 @@ fn module_name_from_path(source_path: string) -> string {
     let mut last_slash: number = -1;
     index = start;
     loop {
-        if index >= normalized.length {
-            break;
-        }
-        if normalized[index] == "/" {
-            last_slash = index;
-        }
+        if index >= normalized.length { break; }
+        if normalized[index] == "/" { last_slash = index; }
         index += 1;
     }
     let mut end: number = normalized.length;
@@ -129,26 +111,18 @@ fn module_name_from_path(source_path: string) -> string {
     index = normalized.length;
     let dot_limit = last_slash + 1;
     loop {
-        if index <= dot_limit {
-            break;
-        }
+        if index <= dot_limit { break; }
         index -= 1;
         if normalized[index] == "." {
             dot_index = index;
             break;
         }
     }
-    if dot_index >= 0 {
-        end = dot_index;
-    }
+    if dot_index >= 0 { end = dot_index; }
 
-    if end <= start {
-        return "main";
-    }
+    if end <= start { return "main"; }
     let base = substring(normalized, start, end);
-    if base.length == 0 {
-        return "main";
-    }
+    if base.length == 0 { return "main"; }
     return base;
 }
 
@@ -297,9 +271,7 @@ fn compile_tests_to_llvm_file_with_module(source: string, module_name: string, o
     let active_file = fs.exists("build/sailfin/.test_runner_active");
     let mut _let345: boolean = false;
     if trace_file {
-        if active_file {
-            _let345 = true;
-        }
+        if active_file { _let345 = true; }
     }
     let trace = _let345;
     let mut _if346: boolean = false;
@@ -310,25 +282,13 @@ fn compile_tests_to_llvm_file_with_module(source: string, module_name: string, o
             print.err("test compiler: trace enabled (trace_file=true, active_file=true)");
         } else {
             let mut trace_text: string = "false";
-            if trace_file {
-                trace_text = "true";
-            }
+            if trace_file { trace_text = "true"; }
             let mut active_text: string = "false";
-            if active_file {
-                active_text = "true";
-            }
-            print.err(
-                "test compiler: trace disabled (trace_file="
-                + trace_text
-                + ", active_file="
-                + active_text
-                + ")"
-            );
+            if active_file { active_text = "true"; }
+            print.err("test compiler: trace disabled (trace_file=" + trace_text + ", active_file=" + active_text + ")");
         }
     }
-    if trace {
-        print.err("test compiler: parse_program start");
-    }
+    if trace { print.err("test compiler: parse_program start"); }
     let program: Program = parse_program(source);
     if typecheck_has_errors(program) {
         let diagnostics = typecheck_diagnostics(program);
@@ -343,9 +303,7 @@ fn compile_tests_to_llvm_file_with_module(source: string, module_name: string, o
         print.err("test compiler: native text bytes=" + number_to_string(native_text.length));
         print.err("test compiler: lower_to_llvm_for_tests start");
     }
-    if fs.exists(out_path) {
-        fs.deleteFile(out_path);
-    }
+    if fs.exists(out_path) { fs.deleteFile(out_path); }
     if trace {
         if native_text.length > 0 {
             fs.writeFile("build/sailfin/debug-test-native.sfn-asm", native_text);
@@ -354,9 +312,7 @@ fn compile_tests_to_llvm_file_with_module(source: string, module_name: string, o
     }
 
     write_llvm_ir_for_tests_from_text(native_text, module_name, out_path);
-    if !fs.exists(out_path) {
-        return false;
-    }
+    if !fs.exists(out_path) { return false; }
     let content = fs.readFile(out_path);
     if trace {
         print.err("test compiler: write_llvm_ir_for_tests bytes=" + number_to_string(content.length));
@@ -401,17 +357,11 @@ fn write_native_text_file_with_module(source: string, module_name: string, out_p
 }
 
 fn _has_prefix(value: string, prefix: string) -> boolean {
-    if prefix.length > value.length {
-        return false;
-    }
+    if prefix.length > value.length { return false; }
     let mut index: number = 0;
     loop {
-        if index >= prefix.length {
-            break;
-        }
-        if value[index] != prefix[index] {
-            return false;
-        }
+        if index >= prefix.length { break; }
+        if value[index] != prefix[index] { return false; }
         index += 1;
     }
     return true;
@@ -424,31 +374,23 @@ fn _find_first_nonblank_line(text: string) -> string {
         let mut _if348: boolean = false;
         if index >= lines.length { _if348 = true; }
         if index >= 128 { _if348 = true; }
-        if _if348 {
-            break;
-        }
+        if _if348 { break; }
         let line = lines[index];
-        if line.length > 0 {
-            return line;
-        }
+        if line.length > 0 { return line; }
         index += 1;
     }
     return "";
 }
 
 fn _looks_like_llvm_text(text: string) -> boolean {
-    if text.length < 16 {
-        return false;
-    }
+    if text.length < 16 { return false; }
     let lines = split_lines(text);
     let mut index: number = 0;
     loop {
         let mut _if349: boolean = false;
         if index >= lines.length { _if349 = true; }
         if index >= 128 { _if349 = true; }
-        if _if349 {
-            break;
-        }
+        if _if349 { break; }
         let line = lines[index];
         if line.length == 0 {
             index += 1;
@@ -457,30 +399,20 @@ fn _looks_like_llvm_text(text: string) -> boolean {
         let mut _if350: boolean = false;
         if line[0] == " " { _if350 = true; }
         if line[0] == "\t" { _if350 = true; }
-        if _if350 {
-            return false;
-        }
-        if _has_prefix(line, "source_filename =") {
-            return true;
-        }
-        if _has_prefix(line, "; ModuleID =") {
-            return true;
-        }
+        if _if350 { return false; }
+        if _has_prefix(line, "source_filename =") { return true; }
+        if _has_prefix(line, "; ModuleID =") { return true; }
         let mut _if351: boolean = false;
         if _has_prefix(line, "target ") { _if351 = true; }
         if _has_prefix(line, "declare ") { _if351 = true; }
         if _has_prefix(line, "define ") { _if351 = true; }
-        if _if351 {
-            return true;
-        }
+        if _if351 { return true; }
         let mut _if352: boolean = false;
         if line[0] == "%" { _if352 = true; }
         if line[0] == "@" { _if352 = true; }
         if line[0] == "!" { _if352 = true; }
         if line[0] == ";" { _if352 = true; }
-        if _if352 {
-            return true;
-        }
+        if _if352 { return true; }
         return false;
     }
     return false;
@@ -501,9 +433,7 @@ fn compile_to_llvm_file_with_module(source: string, module_name: string, out_pat
     }
 
     let native_text_path = "build/sailfin/emit-native.tmp";
-    if fs.exists(native_text_path) {
-        fs.deleteFile(native_text_path);
-    }
+    if fs.exists(native_text_path) { fs.deleteFile(native_text_path); }
     let native_ok = emit_native_text_to_file_with_module_name(program, module_name, native_text_path);
     if !native_ok {
         print.err("emit-llvm-file: empty native output for module " + module_name);
@@ -525,16 +455,12 @@ fn compile_to_llvm_file_with_module(source: string, module_name: string, out_pat
         if fallback_ok {
             if fs.exists(out_path) {
                 let contents = fs.readFile(out_path);
-                if _looks_like_llvm_text(contents) {
-                    return true;
-                }
+                if _looks_like_llvm_text(contents) { return true; }
             }
         }
         return false;
     }
-    if fs.exists(out_path) {
-        fs.deleteFile(out_path);
-    }
+    if fs.exists(out_path) { fs.deleteFile(out_path); }
     let ok = write_llvm_ir_from_native_text_file(native_text_path, module_name, out_path);
     let mut output_valid: boolean = false;
     // Check file content regardless of return value — the boolean return from
@@ -546,9 +472,7 @@ fn compile_to_llvm_file_with_module(source: string, module_name: string, out_pat
         // comparison bugs).  Trust write_llvm_ir_from_native_text_file: if the
         // file exists and has reasonable length it is valid LLVM IR produced by
         // the lowering pipeline.
-        if written.length > 64 {
-            output_valid = true;
-        }
+        if written.length > 64 { output_valid = true; }
         if !output_valid {
             // Check if the content starts with a valid LLVM entity (just missing header).
             // If it starts with garbage (e.g. mid-instruction due to array offset corruption),
@@ -562,9 +486,7 @@ fn compile_to_llvm_file_with_module(source: string, module_name: string, out_pat
                 if _has_prefix(_first_nonblank, "declare ") { _if355 = true; }
                 if _has_prefix(_first_nonblank, "define ") { _if355 = true; }
                 if _has_prefix(_first_nonblank, "target ") { _if355 = true; }
-                if _if355 {
-                    _if353 = true;
-                }
+                if _if355 { _if353 = true; }
             }
             if _if353 {
                 let header = "source_filename = \"" + module_name + ".sfn\"\n\n";
@@ -586,9 +508,7 @@ fn compile_to_llvm_file_with_module(source: string, module_name: string, out_pat
             fs.writeFile(out_path, llvm_text);
             if fs.exists(out_path) {
                 let contents = fs.readFile(out_path);
-                if _looks_like_llvm_text(contents) {
-                    return true;
-                }
+                if _looks_like_llvm_text(contents) { return true; }
             }
         }
         return false;
@@ -599,15 +519,11 @@ fn compile_to_llvm_file_with_module(source: string, module_name: string, out_pat
 fn format_typecheck_diagnostics(entries: Diagnostic[], source: string) -> string[] {
     let lines = split_source_lines(source);
     let mut padding_width: number = number_to_string(lines.length).length;
-    if padding_width < 1 {
-        padding_width = 1;
-    }
+    if padding_width < 1 { padding_width = 1; }
     let mut messages: string[] = [];
     let mut index: number = 0;
     loop {
-        if index >= entries.length {
-            break;
-        }
+        if index >= entries.length { break; }
         let formatted = format_typecheck_diagnostic(entries[index], lines, padding_width);
         messages.push(formatted);
         index += 1;
@@ -621,9 +537,7 @@ fn report_typecheck_errors(entries: Diagnostic[], source: string) ![io] {
     let padding = repeat_character(" ", prefix.length);
     let mut index: number = 0;
     loop {
-        if index >= formatted.length {
-            break;
-        }
+        if index >= formatted.length { break; }
         let message = formatted[index];
         let lines = split_source_lines(message);
         if lines.length == 0 {
@@ -633,14 +547,10 @@ fn report_typecheck_errors(entries: Diagnostic[], source: string) ![io] {
         }
         let mut line_index: number = 0;
         loop {
-            if line_index >= lines.length {
-                break;
-            }
+            if line_index >= lines.length { break; }
             if line_index == 0 {
                 print.err(prefix + lines[line_index]);
-            } else {
-                print.err(padding + lines[line_index]);
-            }
+            } else { print.err(padding + lines[line_index]); }
             line_index += 1;
         }
         index += 1;
@@ -648,9 +558,7 @@ fn report_typecheck_errors(entries: Diagnostic[], source: string) ![io] {
 }
 
 fn format_typecheck_diagnostic(entry: Diagnostic, source_lines: string[], line_padding: number) -> string {
-    if entry.primary == null {
-        return entry.message;
-    }
+    if entry.primary == null { return entry.message; }
     let mut parts: string[] = [];
     parts.push(entry.message);
     let token: Token? = entry.primary;
@@ -661,21 +569,15 @@ fn format_typecheck_diagnostic(entry: Diagnostic, source_lines: string[], line_p
     let mut _if354: boolean = false;
     if line_number < 1 { _if354 = true; }
     if line_number > source_lines.length { _if354 = true; }
-    if _if354 {
-        return join_lines(parts);
-    }
+    if _if354 { return join_lines(parts); }
     let line_text = source_lines[line_number - 1];
     let gutter_spaces = repeat_character(" ", line_padding);
     parts.push(" " + gutter_spaces + " |");
     let line_number_text = number_to_string(line_number);
     let mut prefix_padding: string = "";
     let mut pad_count: number = line_padding - line_number_text.length;
-    if pad_count < 0 {
-        pad_count = 0;
-    }
-    if pad_count > 0 {
-        prefix_padding = repeat_character(" ", pad_count);
-    }
+    if pad_count < 0 { pad_count = 0; }
+    if pad_count > 0 { prefix_padding = repeat_character(" ", pad_count); }
     parts.push(" " + prefix_padding + line_number_text + " | " + line_text);
     let pointer = build_pointer_line(column_number, token.lexeme, line_text);
     parts.push(" " + gutter_spaces + " | " + pointer);
@@ -687,9 +589,7 @@ fn split_source_lines(source: string) -> string[] {
     let mut current: string = "";
     let mut index: number = 0;
     loop {
-        if index >= source.length {
-            break;
-        }
+        if index >= source.length { break; }
         let _ch_next = index + 1;
         let ch = substring(source, index, _ch_next);
         if ch == "\r" {
@@ -720,50 +620,30 @@ fn split_source_lines(source: string) -> string[] {
 }
 
 fn build_pointer_line(column: number, lexeme: string, line_text: string) -> string {
-    if line_text.length == 0 {
-        return "^";
-    }
+    if line_text.length == 0 { return "^"; }
     let mut start_column: number = column;
-    if start_column < 1 {
-        start_column = 1;
-    }
-    if start_column > line_text.length {
-        start_column = line_text.length;
-    }
+    if start_column < 1 { start_column = 1; }
+    if start_column > line_text.length { start_column = line_text.length; }
     let mut pointer: string = "";
     let mut index: number = 1;
     loop {
-        if index >= start_column {
-            break;
-        }
+        if index >= start_column { break; }
         if index <= line_text.length {
             let current = substring(line_text, index - 1, index);
-            if current == "\t" {
-                pointer = pointer + "\t";
-            } else {
+            if current == "\t" { pointer = pointer + "\t"; } else {
                 pointer = pointer + " ";
             }
-        } else {
-            pointer = pointer + " ";
-        }
+        } else { pointer = pointer + " "; }
         index += 1;
     }
     let mut highlight_length: number = lexeme.length;
-    if highlight_length <= 0 {
-        highlight_length = 1;
-    }
+    if highlight_length <= 0 { highlight_length = 1; }
     let mut remaining: number = line_text.length - (start_column - 1);
-    if remaining <= 0 {
-        remaining = 1;
-    }
-    if highlight_length > remaining {
-        highlight_length = remaining;
-    }
+    if remaining <= 0 { remaining = 1; }
+    if highlight_length > remaining { highlight_length = remaining; }
     let mut highlight_index: number = 0;
     loop {
-        if highlight_index >= highlight_length {
-            break;
-        }
+        if highlight_index >= highlight_length { break; }
         pointer = pointer + "^";
         highlight_index += 1;
     }
@@ -771,15 +651,11 @@ fn build_pointer_line(column: number, lexeme: string, line_text: string) -> stri
 }
 
 fn join_lines(lines: string[]) -> string {
-    if lines.length == 0 {
-        return "";
-    }
+    if lines.length == 0 { return ""; }
     let mut result: string = lines[0];
     let mut index: number = 1;
     loop {
-        if index >= lines.length {
-            break;
-        }
+        if index >= lines.length { break; }
         result = result + "\n" + lines[index];
         index += 1;
     }
@@ -787,9 +663,7 @@ fn join_lines(lines: string[]) -> string {
 }
 
 fn number_to_string(value: number) -> string {
-    if value == 0 {
-        return "0";
-    }
+    if value == 0 { return "0"; }
     let mut working: number = value;
     let mut negative: boolean = false;
     if working < 0 {
@@ -800,15 +674,11 @@ fn number_to_string(value: number) -> string {
     let mut remaining: number = working;
     let mut output: string = "";
     loop {
-        if remaining <= 0 {
-            break;
-        }
+        if remaining <= 0 { break; }
         let mut temp: number = remaining;
         let mut quotient: number = 0;
         loop {
-            if temp < 10 {
-                break;
-            }
+            if temp < 10 { break; }
             temp -= 10;
             quotient += 1;
         }
@@ -816,22 +686,16 @@ fn number_to_string(value: number) -> string {
         output = ch + output;
         remaining = quotient;
     }
-    if negative {
-        output = "-" + output;
-    }
+    if negative { output = "-" + output; }
     return output;
 }
 
 fn repeat_character(ch: string, count: number) -> string {
-    if count <= 0 {
-        return "";
-    }
+    if count <= 0 { return ""; }
     let mut index: number = 0;
     let mut result: string = "";
     loop {
-        if index >= count {
-            break;
-        }
+        if index >= count { break; }
         result = result + ch;
         index += 1;
     }
@@ -842,10 +706,7 @@ fn repeat_character(ch: string, count: number) -> string {
 // newline-separated "name=version" string. Returns "" if no capsule.toml
 // is found in the current directory.
 fn read_project_dependencies() -> string ![io] {
-    if !fs.exists("capsule.toml") {
-        return "";
-    }
+    if !fs.exists("capsule.toml") { return ""; }
     let text = fs.readFile("capsule.toml");
     return toml_get_dependencies(text);
 }
-

--- a/compiler/src/main.sfn
+++ b/compiler/src/main.sfn
@@ -14,10 +14,10 @@ import {
     lower_to_llvm_ir,
     lower_to_llvm_ir_from_text,
     write_llvm_ir,
-    write_llvm_ir_from_native_text_file,
+    write_llvm_ir_from_native_text_file
 } from "./llvm/lowering/entrypoints";
-import { lower_to_llvm_for_tests, } from "./llvm/lowering/entrypoints_tests";
-import { write_llvm_ir_for_tests, write_llvm_ir_for_tests_from_text, } from "./llvm/lowering/entrypoints_tests_writer";
+import { lower_to_llvm_for_tests } from "./llvm/lowering/entrypoints_tests";
+import { write_llvm_ir_for_tests, write_llvm_ir_for_tests_from_text } from "./llvm/lowering/entrypoints_tests_writer";
 import { split_lines } from "./native_ir_utils_text";
 import { parse_program } from "./parser/mod";
 import { substring } from "./string_utils";
@@ -35,7 +35,8 @@ fn _ms_since(start_ms: number) -> number {
 fn _timing_line(module_name: string, phase: string, elapsed_ms: number) -> string {
     // Format is stable and grep/awk-friendly.
     // Emitted to stderr via print.err by the caller.
-    return "[timing] module=" + module_name + " phase=" + phase + " ms=" + number_to_string(elapsed_ms);
+    return "[timing] module=" + module_name + " phase=" + phase + " ms="
+        + number_to_string(elapsed_ms);
 }
 
 fn compile_to_sailfin(source: string) -> string ![io] {
@@ -285,7 +286,10 @@ fn compile_tests_to_llvm_file_with_module(source: string, module_name: string, o
             if trace_file { trace_text = "true"; }
             let mut active_text: string = "false";
             if active_file { active_text = "true"; }
-            print.err("test compiler: trace disabled (trace_file=" + trace_text + ", active_file=" + active_text + ")");
+            print.err("test compiler: trace disabled (trace_file=" + trace_text
+                + ", active_file="
+                + active_text
+                + ")");
         }
     }
     if trace { print.err("test compiler: parse_program start"); }
@@ -296,7 +300,9 @@ fn compile_tests_to_llvm_file_with_module(source: string, module_name: string, o
         return false;
     }
     if trace {
-        print.err("test compiler: emit_native_with_module_name start (module=" + module_name + ")");
+        print.err("test compiler: emit_native_with_module_name start (module="
+            + module_name
+            + ")");
     }
     let native_text = emit_native_text_with_module_name(program, module_name);
     if trace {
@@ -315,11 +321,14 @@ fn compile_tests_to_llvm_file_with_module(source: string, module_name: string, o
     if !fs.exists(out_path) { return false; }
     let content = fs.readFile(out_path);
     if trace {
-        print.err("test compiler: write_llvm_ir_for_tests bytes=" + number_to_string(content.length));
+        print.err("test compiler: write_llvm_ir_for_tests bytes="
+            + number_to_string(content.length));
     }
     if content.length <= 4 {
         if trace {
-            print.err("test compiler: suspiciously short llvm output (len=" + number_to_string(content.length) + ")");
+            print.err("test compiler: suspiciously short llvm output (len="
+                + number_to_string(content.length)
+                + ")");
         }
         return false;
     }
@@ -436,15 +445,18 @@ fn compile_to_llvm_file_with_module(source: string, module_name: string, out_pat
     if fs.exists(native_text_path) { fs.deleteFile(native_text_path); }
     let native_ok = emit_native_text_to_file_with_module_name(program, module_name, native_text_path);
     if !native_ok {
-        print.err("emit-llvm-file: empty native output for module " + module_name);
-        let cached_native_path = "build/native/import-context/" + module_name + ".sfn-asm";
+        print.err("emit-llvm-file: empty native output for module "
+            + module_name);
+        let cached_native_path = "build/native/import-context/" + module_name
+            + ".sfn-asm";
         if fs.exists(cached_native_path) {
             let cached_ok = write_llvm_ir_from_native_text_file(cached_native_path, module_name, out_path);
             if cached_ok {
                 if fs.exists(out_path) {
                     let cached_contents = fs.readFile(out_path);
                     if _looks_like_llvm_text(cached_contents) {
-                        print.err("emit-llvm-file: used cached native artifact fallback for module " + module_name);
+                        print.err("emit-llvm-file: used cached native artifact fallback for module "
+                            + module_name);
                         return true;
                     }
                 }
@@ -492,16 +504,20 @@ fn compile_to_llvm_file_with_module(source: string, module_name: string, out_pat
                 let header = "source_filename = \"" + module_name + ".sfn\"\n\n";
                 fs.writeFile(out_path, header + written);
                 output_valid = true;
-                print.err("emit-llvm-file: prepended header for module " + module_name);
+                print.err("emit-llvm-file: prepended header for module "
+                    + module_name);
             }
         }
         if !output_valid {
-            print.err("emit-llvm-file: malformed llvm output for module " + module_name + "; falling back");
+            print.err("emit-llvm-file: malformed llvm output for module "
+                + module_name
+                + "; falling back");
         }
     }
     if !output_valid {
         if !ok {
-            print.err("emit-llvm-file: empty llvm output for module " + module_name);
+            print.err("emit-llvm-file: empty llvm output for module "
+                + module_name);
         }
         let llvm_text = compile_to_llvm_with_module(source, module_name);
         if _looks_like_llvm_text(llvm_text) {
@@ -564,7 +580,8 @@ fn format_typecheck_diagnostic(entry: Diagnostic, source_lines: string[], line_p
     let token: Token? = entry.primary;
     let line_number = token.line;
     let column_number = token.column;
-    let location = "  --> line " + number_to_string(line_number) + ", column " + number_to_string(column_number);
+    let location = "  --> line " + number_to_string(line_number) + ", column "
+        + number_to_string(column_number);
     parts.push(location);
     let mut _if354: boolean = false;
     if line_number < 1 { _if354 = true; }

--- a/compiler/src/native_ir.sfn
+++ b/compiler/src/native_ir.sfn
@@ -3,7 +3,6 @@
 // Type definitions for the textual `.sfn-asm` IR. The parsing logic lives in
 // native_ir_parser.sfn; this module exists purely so that downstream modules
 // can import the types without pulling in the heavy parser code.
-
 enum NativeInstruction {
     Return {
         expression: string;

--- a/compiler/src/native_ir.sfn
+++ b/compiler/src/native_ir.sfn
@@ -49,7 +49,7 @@ enum NativeInstruction {
         span: NativeSourceSpan?;
     },
     Noop,
-    Unknown { text: string },
+    Unknown { text: string }
 }
 
 struct NativeSourceSpan {

--- a/compiler/src/native_ir_api.sfn
+++ b/compiler/src/native_ir_api.sfn
@@ -3,98 +3,73 @@
 // Public API entry points for `.sfn-asm` parsing.
 // Thin wrappers around parse_native_artifact_impl (in native_ir_parser)
 // plus the layout-manifest parser.
-
 import { NativeArtifact } from "./emit_native_layout";
-
 import {
-    NativeFunction,
-    NativeStruct,
-    NativeImport,
-    NativeInterface,
-    NativeEnum,
-    NativeBinding,
-    ParseNativeResult,
+    EnumLayoutHeaderParse,
+    EnumLayoutPayloadParse,
+    EnumLayoutVariantParse,
     LayoutManifest,
-    NativeStructLayout,
-    NativeStructLayoutField,
+    NativeBinding,
+    NativeEnum,
     NativeEnumLayout,
     NativeEnumVariantLayout,
-    StructLayoutHeaderParse,
+    NativeFunction,
+    NativeImport,
+    NativeInterface,
+    NativeStruct,
+    NativeStructLayout,
+    NativeStructLayoutField,
+    ParseNativeResult,
     StructLayoutFieldParse,
-    EnumLayoutHeaderParse,
-    EnumLayoutVariantParse,
-    EnumLayoutPayloadParse,
+    StructLayoutHeaderParse,
 } from "./native_ir";
-
 import { parse_native_artifact_impl } from "./native_ir_parser";
-
 import {
+    parse_enum_layout_header,
+    parse_enum_payload_layout,
+    parse_enum_variant_layout,
+    parse_struct_layout_field,
+    parse_struct_layout_header,
+} from "./native_ir_utils_layout";
+import {
+    is_trim_char,
     split_lines,
-    trim_text,
     starts_with,
     strip_prefix,
-    is_trim_char,
+    trim_text,
 } from "./native_ir_utils_text";
 
-import {
-    parse_struct_layout_header,
-    parse_struct_layout_field,
-    parse_enum_layout_header,
-    parse_enum_variant_layout,
-    parse_enum_payload_layout,
-} from "./native_ir_utils_layout";
-
 fn select_text_artifact(artifacts: NativeArtifact[]) -> NativeArtifact? {
-    if artifacts == null {
-        return null;
-    }
+    if artifacts == null { return null; }
     let mut max_items: number = artifacts.length;
     let mut _if356: boolean = false;
     if max_items != max_items { _if356 = true; }
     if max_items < 0 { _if356 = true; }
-    if _if356 {
-        return null;
-    }
-    if max_items > 10000 {
-        max_items = 10000;
-    }
+    if _if356 { return null; }
+    if max_items > 10000 { max_items = 10000; }
     let mut index: number = 0;
     loop {
-        if index >= max_items {
-            break;
-        }
+        if index >= max_items { break; }
         let artifact = artifacts[index];
-        if artifact.format == "sailfin-native-text" {
-            return artifact;
-        }
+        if artifact.format == "sailfin-native-text" { return artifact; }
         index += 1;
     }
     return null;
 }
 
 fn select_layout_manifest_artifact(artifacts: NativeArtifact[]) -> NativeArtifact? {
-    if artifacts == null {
-        return null;
-    }
+    if artifacts == null { return null; }
     let mut max_items: number = artifacts.length;
     let mut _if357: boolean = false;
     if max_items != max_items { _if357 = true; }
     if max_items < 0 { _if357 = true; }
-    if _if357 {
-        return null;
-    }
-    if max_items > 10000 {
-        max_items = 10000;
-    }
+    if _if357 { return null; }
+    if max_items > 10000 { max_items = 10000; }
     let mut index: number = 0;
     loop {
-        if index >= max_items {
-            break;
-        }
+        if index >= max_items { break; }
         let artifact = artifacts[index];
-        if artifact.format == "sailfin-layout-manifest" {
-            return artifact;
-        }
+        if artifact.format == "sailfin-layout-manifest" { return artifact; }
         index += 1;
     }
     return null;
@@ -106,105 +81,79 @@ fn parse_native_artifact(text: string) -> ParseNativeResult {
 
 fn parse_native_function_count_from_text(text: string) -> number {
     let parsed = parse_native_artifact_impl(text, false, false);
-    if parsed.functions == null {
-        return -1;
-    }
+    if parsed.functions == null { return -1; }
     return parsed.functions.length;
 }
 
 fn parse_native_functions_from_text(text: string) -> NativeFunction[] {
     let parsed = parse_native_artifact_impl(text, true, true);
-    if parsed.functions == null {
-        return [];
-    }
+    if parsed.functions == null { return []; }
     return parsed.functions;
 }
 
 fn parse_native_structs_from_text(text: string) -> NativeStruct[] {
     let parsed = parse_native_artifact_impl(text, true, true);
-    if parsed.structs == null {
-        return [];
-    }
+    if parsed.structs == null { return []; }
     return parsed.structs;
 }
 
 fn parse_native_imports_from_text(text: string) -> NativeImport[] {
     let parsed = parse_native_artifact_impl(text, true, true);
-    if parsed.imports == null {
-        return [];
-    }
+    if parsed.imports == null { return []; }
     return parsed.imports;
 }
 
 fn parse_native_interfaces_from_text(text: string) -> NativeInterface[] {
     let parsed = parse_native_artifact_impl(text, true, true);
-    if parsed.interfaces == null {
-        return [];
-    }
+    if parsed.interfaces == null { return []; }
     return parsed.interfaces;
 }
 
 fn parse_native_enums_from_text(text: string) -> NativeEnum[] {
     let parsed = parse_native_artifact_impl(text, true, true);
-    if parsed.enums == null {
-        return [];
-    }
+    if parsed.enums == null { return []; }
     return parsed.enums;
 }
 
 fn parse_native_bindings_from_text(text: string) -> NativeBinding[] {
     let parsed = parse_native_artifact_impl(text, true, true);
-    if parsed.bindings == null {
-        return [];
-    }
+    if parsed.bindings == null { return []; }
     return parsed.bindings;
 }
 
 fn parse_native_diagnostics_from_text(text: string) -> string[] {
     let parsed = parse_native_artifact_impl(text, true, true);
-    if parsed.diagnostics == null {
-        return [];
-    }
+    if parsed.diagnostics == null { return []; }
     return parsed.diagnostics;
 }
 
 fn parse_native_structs_for_import(text: string) -> NativeStruct[] {
     let parsed = parse_native_artifact_impl(text, false, false);
-    if parsed.structs == null {
-        return [];
-    }
+    if parsed.structs == null { return []; }
     return parsed.structs;
 }
 
 fn parse_native_imports_for_import(text: string) -> NativeImport[] {
     let parsed = parse_native_artifact_impl(text, false, false);
-    if parsed.imports == null {
-        return [];
-    }
+    if parsed.imports == null { return []; }
     return parsed.imports;
 }
 
 fn parse_native_interfaces_for_import(text: string) -> NativeInterface[] {
     let parsed = parse_native_artifact_impl(text, false, false);
-    if parsed.interfaces == null {
-        return [];
-    }
+    if parsed.interfaces == null { return []; }
     return parsed.interfaces;
 }
 
 fn parse_native_enums_for_import(text: string) -> NativeEnum[] {
     let parsed = parse_native_artifact_impl(text, false, false);
-    if parsed.enums == null {
-        return [];
-    }
+    if parsed.enums == null { return []; }
     return parsed.enums;
 }
 
 fn parse_native_functions_for_import(text: string) -> NativeFunction[] {
     let parsed = parse_native_artifact_impl(text, false, false);
-    if parsed.functions == null {
-        return [];
-    }
+    if parsed.functions == null { return []; }
     return parsed.functions;
 }
 
@@ -241,9 +190,7 @@ fn parse_layout_manifest(text: string) -> LayoutManifest {
     let mut index: number = 0;
 
     loop {
-        if index >= lines.length {
-            break;
-        }
+        if index >= lines.length { break; }
         let raw_line = lines[index];
         let mut line = trim_text(raw_line);
         if line.length == 0 {
@@ -263,13 +210,9 @@ fn parse_layout_manifest(text: string) -> LayoutManifest {
             let tail = trim_text(strip_prefix(line, ".layout field "));
             let mut is_struct_header: boolean = false;
             if starts_with(tail, "struct") {
-                if tail.length == 6 {
-                    is_struct_header = true;
-                } else if tail.length > 6 {
+                if tail.length == 6 { is_struct_header = true; } else if tail.length > 6 {
                     let after = tail[6];
-                    if is_trim_char(after) {
-                        is_struct_header = true;
-                    }
+                    if is_trim_char(after) { is_struct_header = true; }
                 }
             }
             if is_struct_header {
@@ -295,9 +238,7 @@ fn parse_layout_manifest(text: string) -> LayoutManifest {
 
                 index += 1;
                 loop {
-                    if index >= lines.length {
-                        break;
-                    }
+                    if index >= lines.length { break; }
                     let field_line = trim_text(lines[index]);
 
                     if field_line.length == 0 {
@@ -306,31 +247,25 @@ fn parse_layout_manifest(text: string) -> LayoutManifest {
                     }
 
                     let mut _if387: boolean = false;
-                    if starts_with(field_line, ".layout struct ") { _if387 = true; }
-                    if starts_with(field_line, ".layout enum ") { _if387 = true; }
-                    if _if387 {
-                        break;
+                    if starts_with(field_line, ".layout struct ") {
+                        _if387 = true;
                     }
+                    if starts_with(field_line, ".layout enum ") {
+                        _if387 = true;
+                    }
+                    if _if387 { break; }
 
-                    if !starts_with(field_line, ".layout field ") {
-                        break;
-                    }
+                    if !starts_with(field_line, ".layout field ") { break; }
 
                     let tail = trim_text(strip_prefix(field_line, ".layout field "));
                     let mut is_struct_header: boolean = false;
                     if starts_with(tail, "struct") {
-                        if tail.length == 6 {
-                            is_struct_header = true;
-                        } else if tail.length > 6 {
+                        if tail.length == 6 { is_struct_header = true; } else if tail.length > 6 {
                             let after = tail[6];
-                            if is_trim_char(after) {
-                                is_struct_header = true;
-                            }
+                            if is_trim_char(after) { is_struct_header = true; }
                         }
                     }
-                    if is_struct_header {
-                        break;
-                    }
+                    if is_struct_header { break; }
 
                     let field_result = parse_struct_layout_field(tail, struct_name);
                     let mut _ci: number = 0;
@@ -379,9 +314,7 @@ fn parse_layout_manifest(text: string) -> LayoutManifest {
                 index += 1;
 
                 loop {
-                    if index >= lines.length {
-                        break;
-                    }
+                    if index >= lines.length { break; }
                     let variant_line = trim_text(lines[index]);
                     if variant_line.length == 0 {
                         index += 1;
@@ -403,7 +336,9 @@ fn parse_layout_manifest(text: string) -> LayoutManifest {
                         let variant_result = parse_enum_variant_layout(variant_text, enum_name);
                         let mut _ci: number = 0;
                         loop {
-                            if _ci >= variant_result.diagnostics.length { break; }
+                            if _ci >= variant_result.diagnostics.length {
+                                break;
+                            }
                             diagnostics.push(variant_result.diagnostics[_ci]);
                             _ci += 1;
                         }
@@ -417,7 +352,9 @@ fn parse_layout_manifest(text: string) -> LayoutManifest {
                         let payload_result = parse_enum_payload_layout(payload_text, enum_name);
                         let mut _ci: number = 0;
                         loop {
-                            if _ci >= payload_result.diagnostics.length { break; }
+                            if _ci >= payload_result.diagnostics.length {
+                                break;
+                            }
                             diagnostics.push(payload_result.diagnostics[_ci]);
                             _ci += 1;
                         }
@@ -455,9 +392,7 @@ fn parse_layout_manifest(text: string) -> LayoutManifest {
                     },
                 };
                 enums.push(enum_def);
-            } else {
-                index += 1;
-            }
+            } else { index += 1; }
             continue;
         }
 

--- a/compiler/src/native_ir_api.sfn
+++ b/compiler/src/native_ir_api.sfn
@@ -21,7 +21,7 @@ import {
     NativeStructLayoutField,
     ParseNativeResult,
     StructLayoutFieldParse,
-    StructLayoutHeaderParse,
+    StructLayoutHeaderParse
 } from "./native_ir";
 import { parse_native_artifact_impl } from "./native_ir_parser";
 import {
@@ -29,14 +29,14 @@ import {
     parse_enum_payload_layout,
     parse_enum_variant_layout,
     parse_struct_layout_field,
-    parse_struct_layout_header,
+    parse_struct_layout_header
 } from "./native_ir_utils_layout";
 import {
     is_trim_char,
     split_lines,
     starts_with,
     strip_prefix,
-    trim_text,
+    trim_text
 } from "./native_ir_utils_text";
 
 fn select_text_artifact(artifacts: NativeArtifact[]) -> NativeArtifact? {
@@ -179,7 +179,7 @@ export {
     parse_native_enums_for_import,
     parse_native_functions_for_import,
     parse_native_artifact_for_import_context,
-    parse_layout_manifest,
+    parse_layout_manifest
 };
 
 fn parse_layout_manifest(text: string) -> LayoutManifest {
@@ -289,8 +289,8 @@ fn parse_layout_manifest(text: string) -> LayoutManifest {
                     layout: NativeStructLayout {
                         size: header_result.size,
                         align: header_result.align,
-                        fields: fields,
-                    },
+                        fields: fields
+                    }
                 };
                 structs.push(struct_def);
             }
@@ -371,7 +371,7 @@ fn parse_layout_manifest(text: string) -> LayoutManifest {
                                     offset: last_variant.offset,
                                     size: last_variant.size,
                                     align: last_variant.align,
-                                    fields: updated_fields,
+                                    fields: updated_fields
                                 };
                             }
                         }
@@ -388,8 +388,8 @@ fn parse_layout_manifest(text: string) -> LayoutManifest {
                         tag_type: header_result.tag_type,
                         tag_size: header_result.tag_size,
                         tag_align: header_result.tag_align,
-                        variants: variants,
-                    },
+                        variants: variants
+                    }
                 };
                 enums.push(enum_def);
             } else { index += 1; }
@@ -402,6 +402,6 @@ fn parse_layout_manifest(text: string) -> LayoutManifest {
     return LayoutManifest {
         structs: structs,
         enums: enums,
-        diagnostics: diagnostics,
+        diagnostics: diagnostics
     };
 }

--- a/compiler/src/native_ir_parser.sfn
+++ b/compiler/src/native_ir_parser.sfn
@@ -11,7 +11,7 @@ import {
     NativeInterface,
     NativeSourceSpan,
     NativeStruct,
-    ParseNativeResult,
+    ParseNativeResult
 } from "./native_ir";
 import {
     append_instruction,
@@ -19,9 +19,9 @@ import {
     apply_meta,
     parse_enum_definition,
     parse_source_span,
-    parse_struct_definition,
+    parse_struct_definition
 } from "./native_ir_parser_defs";
-import { gather_instruction, parse_instruction, } from "./native_ir_parser_instructions";
+import { gather_instruction, parse_instruction } from "./native_ir_parser_instructions";
 import { parse_decimal_number } from "./native_ir_utils_layout";
 import {
     line_looks_like_parameter_entry,
@@ -30,7 +30,7 @@ import {
     parse_import_entry,
     parse_interface_definition,
     parse_parameter_entry,
-    split_parameter_entries,
+    split_parameter_entries
 } from "./native_ir_utils_parse";
 import {
     index_of,
@@ -38,7 +38,7 @@ import {
     starts_with,
     strip_prefix,
     strip_quotes,
-    trim_text,
+    trim_text
 } from "./native_ir_utils_text";
 import { char_code, substring } from "./string_utils";
 
@@ -100,7 +100,8 @@ fn parse_native_artifact_impl(text: string, include_instructions: boolean, inclu
         if starts_with(line, ".init-span ") {
             let parsed_init_span = parse_source_span(strip_prefix(line, ".init-span "));
             if parsed_init_span == null {
-                diagnostics.push("unable to parse initializer span metadata: " + line);
+                diagnostics.push("unable to parse initializer span metadata: "
+                    + line);
             } else { pending_value_span = parsed_init_span; }
             index += 1;
             continue;
@@ -161,11 +162,13 @@ fn parse_native_artifact_impl(text: string, include_instructions: boolean, inclu
         }
         if starts_with(line, ".decorator") {
             if current != null {
-                diagnostics.push("decorator directive encountered inside function body: " + line);
+                diagnostics.push("decorator directive encountered inside function body: "
+                    + line);
             } else {
                 let decorator_name = parse_decorator_name(line);
                 if decorator_name == null {
-                    diagnostics.push("unable to parse decorator directive: " + line);
+                    diagnostics.push("unable to parse decorator directive: "
+                        + line);
                 } else { pending_decorators.push(decorator_name); }
             }
             index += 1;
@@ -187,7 +190,7 @@ fn parse_native_artifact_impl(text: string, include_instructions: boolean, inclu
                 effects: [],
                 decorators: pending_decorators,
                 is_extern: false,
-                instructions: [],
+                instructions: []
             };
             pending_decorators = [];
             index += 1;
@@ -260,7 +263,7 @@ fn parse_native_artifact_impl(text: string, include_instructions: boolean, inclu
                 effects: [],
                 decorators: [],
                 is_extern: false,
-                instructions: [],
+                instructions: []
             };
             index += 1;
             continue;
@@ -328,7 +331,8 @@ fn parse_native_artifact_impl(text: string, include_instructions: boolean, inclu
                         if span_consumed { parameter_span = null; }
                         let parameter = parse_parameter_entry(entry, parameter_span);
                         if parameter == null {
-                            diagnostics.push("unable to parse parameter entry: " + entry);
+                            diagnostics.push("unable to parse parameter entry: "
+                                + entry);
                         } else {
                             current = append_parameter(current, parameter);
                             if parameter.span != null { span_consumed = true; }
@@ -382,7 +386,8 @@ fn parse_native_artifact_impl(text: string, include_instructions: boolean, inclu
             pending_span = null;
         }
         if instruction_result.value_span_consumed { pending_value_span = null; } else if pending_value_span != null {
-            diagnostics.push("unused initializer span metadata before: " + gathered_line);
+            diagnostics.push("unused initializer span metadata before: "
+                + gathered_line);
             pending_value_span = null;
         }
 
@@ -395,7 +400,8 @@ fn parse_native_artifact_impl(text: string, include_instructions: boolean, inclu
                 if _if359 {
                     bindings.push(binding_from_instruction(instructions[0]));
                 } else {
-                    diagnostics.push("top-level directive not supported in lowering: " + gathered_line);
+                    diagnostics.push("top-level directive not supported in lowering: "
+                        + gathered_line);
                 }
             }
             continue;
@@ -434,7 +440,7 @@ fn binding_from_instruction(instruction: NativeInstruction) -> NativeBinding {
         name: instruction.name,
         mutable: instruction.mutable,
         type_annotation: instruction.type_annotation,
-        value: instruction.value,
+        value: instruction.value
     };
 }
 

--- a/compiler/src/native_ir_parser.sfn
+++ b/compiler/src/native_ir_parser.sfn
@@ -2,32 +2,27 @@
 //
 // Parser for textual `.sfn-asm` artifacts. Type definitions live in
 // native_ir.sfn; utilities and layout parsers in native_ir_utils.sfn.
-
-import { substring, char_code } from "./string_utils";
-
 import {
-    NativeInstruction,
-    NativeSourceSpan,
+    NativeBinding,
+    NativeEnum,
     NativeFunction,
     NativeImport,
-    NativeStruct,
+    NativeInstruction,
     NativeInterface,
-    NativeEnum,
-    NativeBinding,
+    NativeSourceSpan,
+    NativeStruct,
     ParseNativeResult,
 } from "./native_ir";
-
 import {
-    index_of,
-    split_lines,
-    starts_with,
-    strip_prefix,
-    strip_quotes,
-    trim_text,
-} from "./native_ir_utils_text";
-
+    append_instruction,
+    append_parameter,
+    apply_meta,
+    parse_enum_definition,
+    parse_source_span,
+    parse_struct_definition,
+} from "./native_ir_parser_defs";
+import { gather_instruction, parse_instruction, } from "./native_ir_parser_instructions";
 import { parse_decimal_number } from "./native_ir_utils_layout";
-
 import {
     line_looks_like_parameter_entry,
     parse_decorator_name,
@@ -37,20 +32,15 @@ import {
     parse_parameter_entry,
     split_parameter_entries,
 } from "./native_ir_utils_parse";
-
 import {
-    parse_instruction,
-    gather_instruction,
-} from "./native_ir_parser_instructions";
-
-import {
-    parse_struct_definition,
-    parse_enum_definition,
-    parse_source_span,
-    apply_meta,
-    append_parameter,
-    append_instruction,
-} from "./native_ir_parser_defs";
+    index_of,
+    split_lines,
+    starts_with,
+    strip_prefix,
+    strip_quotes,
+    trim_text,
+} from "./native_ir_utils_text";
+import { char_code, substring } from "./string_utils";
 
 fn parse_native_artifact_impl(text: string, include_instructions: boolean, include_top_level_bindings: boolean) -> ParseNativeResult {
     let lines = split_lines(text);
@@ -68,9 +58,7 @@ fn parse_native_artifact_impl(text: string, include_instructions: boolean, inclu
 
     let mut index: number = 0;
     loop {
-        if index >= lines.length {
-            break;
-        }
+        if index >= lines.length { break; }
         let raw_line = lines[index];
         let line = trim_text(raw_line);
         if line.length == 0 {
@@ -89,9 +77,7 @@ fn parse_native_artifact_impl(text: string, include_instructions: boolean, inclu
             let parsed_import = parse_import_entry("import", strip_prefix(line, ".import "));
             if parsed_import == null {
                 diagnostics.push("unable to parse import: " + line);
-            } else {
-                imports.push(parsed_import);
-            }
+            } else { imports.push(parsed_import); }
             index += 1;
             continue;
         }
@@ -99,9 +85,7 @@ fn parse_native_artifact_impl(text: string, include_instructions: boolean, inclu
             let parsed_export = parse_import_entry("export", strip_prefix(line, ".export "));
             if parsed_export == null {
                 diagnostics.push("unable to parse export: " + line);
-            } else {
-                imports.push(parsed_export);
-            }
+            } else { imports.push(parsed_export); }
             index += 1;
             continue;
         }
@@ -109,9 +93,7 @@ fn parse_native_artifact_impl(text: string, include_instructions: boolean, inclu
             let parsed_span = parse_source_span(strip_prefix(line, ".span "));
             if parsed_span == null {
                 diagnostics.push("unable to parse span metadata: " + line);
-            } else {
-                pending_span = parsed_span;
-            }
+            } else { pending_span = parsed_span; }
             index += 1;
             continue;
         }
@@ -119,9 +101,7 @@ fn parse_native_artifact_impl(text: string, include_instructions: boolean, inclu
             let parsed_init_span = parse_source_span(strip_prefix(line, ".init-span "));
             if parsed_init_span == null {
                 diagnostics.push("unable to parse initializer span metadata: " + line);
-            } else {
-                pending_value_span = parsed_init_span;
-            }
+            } else { pending_value_span = parsed_init_span; }
             index += 1;
             continue;
         }
@@ -186,9 +166,7 @@ fn parse_native_artifact_impl(text: string, include_instructions: boolean, inclu
                 let decorator_name = parse_decorator_name(line);
                 if decorator_name == null {
                     diagnostics.push("unable to parse decorator directive: " + line);
-                } else {
-                    pending_decorators.push(decorator_name);
-                }
+                } else { pending_decorators.push(decorator_name); }
             }
             index += 1;
             continue;
@@ -200,9 +178,7 @@ fn parse_native_artifact_impl(text: string, include_instructions: boolean, inclu
             let header = strip_prefix(line, ".fn ");
             let mut is_async: boolean = false;
             let trimmed_header = trim_text(header);
-            if starts_with(trimmed_header, "async ") {
-                is_async = true;
-            }
+            if starts_with(trimmed_header, "async ") { is_async = true; }
             current = NativeFunction {
                 name: parse_function_name(header),
                 is_async: is_async,
@@ -244,9 +220,7 @@ fn parse_native_artifact_impl(text: string, include_instructions: boolean, inclu
                 let mut scan: number = 1;
                 let mut escaping: boolean = false;
                 loop {
-                    if scan >= trimmed.length {
-                        break;
-                    }
+                    if scan >= trimmed.length { break; }
                     let ch = trimmed[scan];
                     if escaping {
                         escaping = false;
@@ -266,9 +240,7 @@ fn parse_native_artifact_impl(text: string, include_instructions: boolean, inclu
                 }
             } else {
                 let space_index = index_of(trimmed, " ");
-                if space_index < 0 {
-                    raw_name = trimmed;
-                } else {
+                if space_index < 0 { raw_name = trimmed; } else {
                     raw_name = trim_text(substring(trimmed, 0, space_index));
                 }
             }
@@ -327,13 +299,9 @@ fn parse_native_artifact_impl(text: string, include_instructions: boolean, inclu
                 let mut combined: string = strip_prefix(line, ".param ");
                 let mut lookahead: number = index + 1;
                 loop {
-                    if lookahead >= lines.length {
-                        break;
-                    }
+                    if lookahead >= lines.length { break; }
                     let continuation_raw = lines[lookahead];
-                    if continuation_raw.length == 0 {
-                        break;
-                    }
+                    if continuation_raw.length == 0 { break; }
                     let continuation_trimmed = trim_text(continuation_raw);
                     if continuation_trimmed.length == 0 {
                         lookahead += 1;
@@ -354,22 +322,16 @@ fn parse_native_artifact_impl(text: string, include_instructions: boolean, inclu
                     let mut entry_index: number = 0;
                     let mut span_consumed: boolean = false;
                     loop {
-                        if entry_index >= entries.length {
-                            break;
-                        }
+                        if entry_index >= entries.length { break; }
                         let entry = entries[entry_index];
                         let mut parameter_span: NativeSourceSpan? = pending_span;
-                        if span_consumed {
-                            parameter_span = null;
-                        }
+                        if span_consumed { parameter_span = null; }
                         let parameter = parse_parameter_entry(entry, parameter_span);
                         if parameter == null {
                             diagnostics.push("unable to parse parameter entry: " + entry);
                         } else {
                             current = append_parameter(current, parameter);
-                            if parameter.span != null {
-                                span_consumed = true;
-                            }
+                            if parameter.span != null { span_consumed = true; }
                         }
                         entry_index += 1;
                     }
@@ -394,24 +356,20 @@ fn parse_native_artifact_impl(text: string, include_instructions: boolean, inclu
                 pending_value_span = null;
                 let mut scan = index;
                 loop {
-                    if scan >= lines.length {
-                        break;
-                    }
+                    if scan >= lines.length { break; }
                     let candidate = trim_text(lines[scan]);
                     let mut _if392: boolean = false;
                     if starts_with(candidate, ".endfn") { _if392 = true; }
                     if starts_with(candidate, ".endtest") { _if392 = true; }
-                    if _if392 {
-                        break;
-                    }
+                    if _if392 { break; }
                     scan += 1;
                 }
                 index = scan;
                 continue;
             }
         }
-        // Instruction line (or top-level binding) handling.
 
+        // Instruction line (or top-level binding) handling.
         let gather = gather_instruction(lines, index);
         let gathered_line = gather.text;
         // Always advance by at least one line; `gather.lines_consumed` counts
@@ -419,15 +377,11 @@ fn parse_native_artifact_impl(text: string, include_instructions: boolean, inclu
         index += gather.lines_consumed + 1;
         let instruction_result = parse_instruction(gathered_line, pending_span, pending_value_span);
         let instructions = instruction_result.instructions;
-        if instruction_result.span_consumed {
-            pending_span = null;
-        } else if pending_span != null {
+        if instruction_result.span_consumed { pending_span = null; } else if pending_span != null {
             diagnostics.push("unused span metadata before: " + gathered_line);
             pending_span = null;
         }
-        if instruction_result.value_span_consumed {
-            pending_value_span = null;
-        } else if pending_value_span != null {
+        if instruction_result.value_span_consumed { pending_value_span = null; } else if pending_value_span != null {
             diagnostics.push("unused initializer span metadata before: " + gathered_line);
             pending_value_span = null;
         }
@@ -436,9 +390,7 @@ fn parse_native_artifact_impl(text: string, include_instructions: boolean, inclu
             if include_top_level_bindings {
                 let mut _if359: boolean = false;
                 if instructions.length == 1 {
-                    if instructions[0].variant == "Let" {
-                        _if359 = true;
-                    }
+                    if instructions[0].variant == "Let" { _if359 = true; }
                 }
                 if _if359 {
                     bindings.push(binding_from_instruction(instructions[0]));
@@ -450,9 +402,7 @@ fn parse_native_artifact_impl(text: string, include_instructions: boolean, inclu
         }
         let mut instruction_index: number = 0;
         loop {
-            if instruction_index >= instructions.length {
-                break;
-            }
+            if instruction_index >= instructions.length { break; }
             current = append_instruction(current, instructions[instruction_index]);
             instruction_index += 1;
         }
@@ -468,7 +418,15 @@ fn parse_native_artifact_impl(text: string, include_instructions: boolean, inclu
         diagnostics.push("dangling decorator directives at end of artifact");
     }
 
-    return ParseNativeResult { functions: functions, imports: imports, structs: structs, interfaces: interfaces, enums: enums, bindings: bindings, diagnostics: diagnostics };
+    return ParseNativeResult {
+        functions: functions,
+        imports: imports,
+        structs: structs,
+        interfaces: interfaces,
+        enums: enums,
+        bindings: bindings,
+        diagnostics: diagnostics
+    };
 }
 
 fn binding_from_instruction(instruction: NativeInstruction) -> NativeBinding {

--- a/compiler/src/native_ir_parser_defs.sfn
+++ b/compiler/src/native_ir_parser_defs.sfn
@@ -17,16 +17,16 @@ import {
     NativeStructField,
     NativeStructLayout,
     NativeStructLayoutField,
-    StructParseResult,
+    StructParseResult
 } from "./native_ir";
-import { parse_instruction, } from "./native_ir_parser_instructions";
+import { parse_instruction } from "./native_ir_parser_instructions";
 import {
     parse_decimal_number,
     parse_enum_layout_header,
     parse_enum_payload_layout,
     parse_enum_variant_layout,
     parse_struct_layout_field,
-    parse_struct_layout_header,
+    parse_struct_layout_header
 } from "./native_ir_utils_layout";
 import {
     parse_decorator_name,
@@ -35,7 +35,7 @@ import {
     parse_function_name,
     parse_parameter_entry,
     parse_struct_field_line,
-    parse_struct_header,
+    parse_struct_header
 } from "./native_ir_utils_parse";
 import {
     index_of,
@@ -44,7 +44,7 @@ import {
     starts_with,
     strip_generics,
     strip_prefix,
-    trim_text,
+    trim_text
 } from "./native_ir_utils_text";
 import { char_code, substring } from "./string_utils";
 
@@ -65,7 +65,7 @@ fn parse_source_span(text: string) -> NativeSourceSpan? {
         start_line: start_line.value,
         start_column: start_column.value,
         end_line: end_line.value,
-        end_column: end_column.value,
+        end_column: end_column.value
     };
 }
 
@@ -80,7 +80,7 @@ fn append_parameter(function: NativeFunction, parameter: NativeParameter) -> Nat
         effects: function.effects,
         decorators: function.decorators,
         is_extern: function.is_extern,
-        instructions: function.instructions,
+        instructions: function.instructions
     };
 }
 
@@ -95,7 +95,7 @@ fn append_instruction(function: NativeFunction, instruction: NativeInstruction) 
         effects: function.effects,
         decorators: function.decorators,
         is_extern: function.is_extern,
-        instructions: instructions,
+        instructions: instructions
     };
 }
 
@@ -110,7 +110,7 @@ fn apply_meta(function: NativeFunction, entry: string) -> NativeFunction {
             effects: function.effects,
             decorators: function.decorators,
             is_extern: true,
-            instructions: function.instructions,
+            instructions: function.instructions
         };
     }
     if trimmed == "unsafe" { return function; }
@@ -135,7 +135,7 @@ fn update_function_meta(function: NativeFunction, return_type: string, effects: 
         effects: effects,
         decorators: function.decorators,
         is_extern: function.is_extern,
-        instructions: function.instructions,
+        instructions: function.instructions
     };
 }
 
@@ -167,7 +167,7 @@ fn update_enum_variant_fields(variants: NativeEnumVariantLayout[], index: number
                 offset: variant.offset,
                 size: variant.size,
                 align: variant.align,
-                fields: append_struct_layout_field(variant.fields, field),
+                fields: append_struct_layout_field(variant.fields, field)
             };
             result.push(updated);
         } else { result.push(variants[current_index]); }
@@ -230,7 +230,7 @@ fn parse_struct_definition(lines: string[], start_index: number, include_instruc
                     layout: struct_layout_value
                 },
                 next_index: index,
-                diagnostics: diagnostics,
+                diagnostics: diagnostics
             };
         }
         let raw_line = trim_text(lines[index]);
@@ -269,7 +269,8 @@ fn parse_struct_definition(lines: string[], start_index: number, include_instruc
             if starts_with(raw_line, ".param ") {
                 let parameter = parse_parameter_entry(strip_prefix(raw_line, ".param "), method_pending_span);
                 if parameter == null {
-                    diagnostics.push("unable to parse method parameter: " + raw_line);
+                    diagnostics.push("unable to parse method parameter: "
+                        + raw_line);
                 } else {
                     current_method = append_parameter(current_method, parameter);
                 }
@@ -278,14 +279,16 @@ fn parse_struct_definition(lines: string[], start_index: number, include_instruc
                 continue;
             }
             if starts_with(raw_line, ".method ") {
-                diagnostics.push("nested method declaration in struct " + struct_name);
+                diagnostics.push("nested method declaration in struct "
+                    + struct_name);
                 index += 1;
                 continue;
             }
             if starts_with(raw_line, ".span ") {
                 let parsed_method_span = parse_source_span(strip_prefix(raw_line, ".span "));
                 if parsed_method_span == null {
-                    diagnostics.push("unable to parse span metadata: " + raw_line);
+                    diagnostics.push("unable to parse span metadata: "
+                        + raw_line);
                 } else { method_pending_span = parsed_method_span; }
                 index += 1;
                 continue;
@@ -293,7 +296,8 @@ fn parse_struct_definition(lines: string[], start_index: number, include_instruc
             if starts_with(raw_line, ".init-span ") {
                 let parsed_method_init_span = parse_source_span(strip_prefix(raw_line, ".init-span "));
                 if parsed_method_init_span == null {
-                    diagnostics.push("unable to parse initializer span metadata: " + raw_line);
+                    diagnostics.push("unable to parse initializer span metadata: "
+                        + raw_line);
                 } else { method_pending_value_span = parsed_method_init_span; }
                 index += 1;
                 continue;
@@ -322,7 +326,8 @@ fn parse_struct_definition(lines: string[], start_index: number, include_instruc
             if method_instruction_result.value_span_consumed {
                 method_pending_value_span = null;
             } else if method_pending_value_span != null {
-                diagnostics.push("unused initializer span metadata before: " + raw_line);
+                diagnostics.push("unused initializer span metadata before: "
+                    + raw_line);
                 method_pending_value_span = null;
             }
             let mut instruction_index: number = 0;
@@ -348,7 +353,8 @@ fn parse_struct_definition(lines: string[], start_index: number, include_instruc
                 }
                 if header_result.success {
                     if struct_layout_header_success {
-                        diagnostics.push("duplicate struct layout header in " + struct_name);
+                        diagnostics.push("duplicate struct layout header in "
+                            + struct_name);
                     } else {
                         struct_layout_size = header_result.size;
                         struct_layout_align = header_result.align;
@@ -378,7 +384,8 @@ fn parse_struct_definition(lines: string[], start_index: number, include_instruc
                     }
                     if header_result.success {
                         if struct_layout_header_success {
-                            diagnostics.push("duplicate struct layout header in " + struct_name);
+                            diagnostics.push("duplicate struct layout header in "
+                                + struct_name);
                         } else {
                             struct_layout_size = header_result.size;
                             struct_layout_align = header_result.align;
@@ -400,7 +407,8 @@ fn parse_struct_definition(lines: string[], start_index: number, include_instruc
                     struct_layout_fields.push(field_result.field);
                     if !struct_layout_header_success {
                         if !struct_layout_reported_missing_header {
-                            diagnostics.push("struct " + struct_name + " layout field encountered before layout header");
+                            diagnostics.push("struct " + struct_name
+                                + " layout field encountered before layout header");
                             struct_layout_reported_missing_header = true;
                         }
                     }
@@ -426,11 +434,13 @@ fn parse_struct_definition(lines: string[], start_index: number, include_instruc
         }
         if starts_with(raw_line, ".decorator") {
             if current_method != null {
-                diagnostics.push("decorator directive encountered inside method body: " + raw_line);
+                diagnostics.push("decorator directive encountered inside method body: "
+                    + raw_line);
             } else {
                 let decorator_name = parse_decorator_name(raw_line);
                 if decorator_name == null {
-                    diagnostics.push("unable to parse decorator directive: " + raw_line);
+                    diagnostics.push("unable to parse decorator directive: "
+                        + raw_line);
                 } else { method_pending_decorators.push(decorator_name); }
             }
             index += 1;
@@ -438,7 +448,8 @@ fn parse_struct_definition(lines: string[], start_index: number, include_instruc
         }
         if starts_with(raw_line, ".method ") {
             if current_method != null {
-                diagnostics.push("nested method declaration in struct " + struct_name);
+                diagnostics.push("nested method declaration in struct "
+                    + struct_name);
             }
             let header = strip_prefix(raw_line, ".method ");
             let trimmed = trim_text(header);
@@ -453,7 +464,7 @@ fn parse_struct_definition(lines: string[], start_index: number, include_instruc
                 effects: [],
                 decorators: method_pending_decorators,
                 is_extern: false,
-                instructions: [],
+                instructions: []
             };
             method_pending_decorators = [];
             method_pending_span = null;
@@ -483,7 +494,7 @@ fn parse_struct_definition(lines: string[], start_index: number, include_instruc
             layout: struct_layout_value
         },
         next_index: index,
-        diagnostics: diagnostics,
+        diagnostics: diagnostics
     };
 }
 
@@ -527,7 +538,7 @@ fn parse_enum_definition(lines: string[], start_index: number) -> EnumParseResul
                     tag_type: enum_layout_tag_type,
                     tag_size: enum_layout_tag_size,
                     tag_align: enum_layout_tag_align,
-                    variants: enum_layout_variants,
+                    variants: enum_layout_variants
                 };
             }
             return EnumParseResult {
@@ -537,7 +548,7 @@ fn parse_enum_definition(lines: string[], start_index: number) -> EnumParseResul
                     layout: enum_layout_value
                 },
                 next_index: index,
-                diagnostics: diagnostics,
+                diagnostics: diagnostics
             };
         }
         let raw_line = trim_text(lines[index]);
@@ -564,7 +575,8 @@ fn parse_enum_definition(lines: string[], start_index: number) -> EnumParseResul
                 }
                 if header_result.success {
                     if enum_layout_header_success {
-                        diagnostics.push("duplicate enum layout header in " + enum_name);
+                        diagnostics.push("duplicate enum layout header in "
+                            + enum_name);
                     } else {
                         enum_layout_size = header_result.size;
                         enum_layout_align = header_result.align;
@@ -605,13 +617,17 @@ fn parse_enum_definition(lines: string[], start_index: number) -> EnumParseResul
                 if variant_result.success {
                     let existing_index = find_enum_variant_layout(enum_layout_variants, variant_result.variant.name);
                     if existing_index >= 0 {
-                        diagnostics.push("duplicate enum layout variant `" + variant_result.variant.name + "` in " + enum_name);
+                        diagnostics.push("duplicate enum layout variant `"
+                            + variant_result.variant.name
+                            + "` in "
+                            + enum_name);
                     } else {
                         enum_layout_variants.push(variant_result.variant);
                     }
                     if !enum_layout_header_success {
                         if !enum_layout_reported_missing_header {
-                            diagnostics.push("enum " + enum_name + " layout variant encountered before layout header");
+                            diagnostics.push("enum " + enum_name
+                                + " layout variant encountered before layout header");
                             enum_layout_reported_missing_header = true;
                         }
                     }
@@ -630,13 +646,17 @@ fn parse_enum_definition(lines: string[], start_index: number) -> EnumParseResul
                 if payload_result.success {
                     let target_index = find_enum_variant_layout(enum_layout_variants, payload_result.variant_name);
                     if target_index < 0 {
-                        diagnostics.push("enum " + enum_name + " layout payload references unknown variant `" + payload_result.variant_name + "`");
+                        diagnostics.push("enum " + enum_name
+                            + " layout payload references unknown variant `"
+                            + payload_result.variant_name
+                            + "`");
                     } else {
                         enum_layout_variants = update_enum_variant_fields(enum_layout_variants, target_index, payload_result.field);
                     }
                     if !enum_layout_header_success {
                         if !enum_layout_reported_missing_header {
-                            diagnostics.push("enum " + enum_name + " layout payload encountered before layout header");
+                            diagnostics.push("enum " + enum_name
+                                + " layout payload encountered before layout header");
                             enum_layout_reported_missing_header = true;
                         }
                     }
@@ -672,7 +692,7 @@ fn parse_enum_definition(lines: string[], start_index: number) -> EnumParseResul
             tag_type: enum_layout_tag_type,
             tag_size: enum_layout_tag_size,
             tag_align: enum_layout_tag_align,
-            variants: enum_layout_variants,
+            variants: enum_layout_variants
         };
     }
 
@@ -683,7 +703,7 @@ fn parse_enum_definition(lines: string[], start_index: number) -> EnumParseResul
             layout: enum_layout_value
         },
         next_index: index,
-        diagnostics: diagnostics,
+        diagnostics: diagnostics
     };
 }
 

--- a/compiler/src/native_ir_parser_defs.sfn
+++ b/compiler/src/native_ir_parser_defs.sfn
@@ -2,37 +2,24 @@
 //
 // Struct and enum definition parsing, extracted from native_ir_parser.sfn
 // to keep the module under the seed compiler's OOM threshold.
-
-import { substring, char_code } from "./string_utils";
-
 import {
-    NativeInstruction,
-    NativeSourceSpan,
-    NativeParameter,
-    NativeFunction,
-    NativeStructField,
-    NativeStructLayoutField,
-    NativeStructLayout,
-    NativeStruct,
-    NativeEnumVariant,
-    NativeEnumVariantLayout,
-    NativeEnumLayout,
-    NativeEnum,
     EnumParseResult,
     InstructionParseResult,
+    NativeEnum,
+    NativeEnumLayout,
+    NativeEnumVariant,
+    NativeEnumVariantLayout,
+    NativeFunction,
+    NativeInstruction,
+    NativeParameter,
+    NativeSourceSpan,
+    NativeStruct,
+    NativeStructField,
+    NativeStructLayout,
+    NativeStructLayoutField,
     StructParseResult,
 } from "./native_ir";
-
-import {
-    index_of,
-    is_trim_char,
-    starts_with,
-    strip_generics,
-    strip_prefix,
-    trim_text,
-    split_whitespace,
-} from "./native_ir_utils_text";
-
+import { parse_instruction, } from "./native_ir_parser_instructions";
 import {
     parse_decimal_number,
     parse_enum_layout_header,
@@ -41,7 +28,6 @@ import {
     parse_struct_layout_field,
     parse_struct_layout_header,
 } from "./native_ir_utils_layout";
-
 import {
     parse_decorator_name,
     parse_effect_list,
@@ -51,36 +37,30 @@ import {
     parse_struct_field_line,
     parse_struct_header,
 } from "./native_ir_utils_parse";
-
 import {
-    parse_instruction,
-} from "./native_ir_parser_instructions";
+    index_of,
+    is_trim_char,
+    split_whitespace,
+    starts_with,
+    strip_generics,
+    strip_prefix,
+    trim_text,
+} from "./native_ir_utils_text";
+import { char_code, substring } from "./string_utils";
 
 fn parse_source_span(text: string) -> NativeSourceSpan? {
     let trimmed = trim_text(text);
-    if trimmed.length == 0 {
-        return null;
-    }
+    if trimmed.length == 0 { return null; }
     let parts = split_whitespace(trimmed);
-    if parts.length != 4 {
-        return null;
-    }
+    if parts.length != 4 { return null; }
     let start_line = parse_decimal_number(parts[0]);
-    if !start_line.success {
-        return null;
-    }
+    if !start_line.success { return null; }
     let start_column = parse_decimal_number(parts[1]);
-    if !start_column.success {
-        return null;
-    }
+    if !start_column.success { return null; }
     let end_line = parse_decimal_number(parts[2]);
-    if !end_line.success {
-        return null;
-    }
+    if !end_line.success { return null; }
     let end_column = parse_decimal_number(parts[3]);
-    if !end_column.success {
-        return null;
-    }
+    if !end_column.success { return null; }
     return NativeSourceSpan {
         start_line: start_line.value,
         start_column: start_column.value,
@@ -133,9 +113,7 @@ fn apply_meta(function: NativeFunction, entry: string) -> NativeFunction {
             instructions: function.instructions,
         };
     }
-    if trimmed == "unsafe" {
-        return function;
-    }
+    if trimmed == "unsafe" { return function; }
     if starts_with(trimmed, "return ") {
         let return_type = trim_text(strip_prefix(trimmed, "return "));
         return update_function_meta(function, return_type, function.effects);
@@ -169,12 +147,8 @@ fn append_struct_layout_field(fields: NativeStructLayoutField[], field: NativeSt
 fn find_enum_variant_layout(variants: NativeEnumVariantLayout[], name: string) -> number {
     let mut index: number = 0;
     loop {
-        if index >= variants.length {
-            break;
-        }
-        if variants[index].name == name {
-            return index;
-        }
+        if index >= variants.length { break; }
+        if variants[index].name == name { return index; }
         index += 1;
     }
     return -1;
@@ -184,9 +158,7 @@ fn update_enum_variant_fields(variants: NativeEnumVariantLayout[], index: number
     let mut result: NativeEnumVariantLayout[] = [];
     let mut current_index: number = 0;
     loop {
-        if current_index >= variants.length {
-            break;
-        }
+        if current_index >= variants.length { break; }
         if current_index == index {
             let variant = variants[current_index];
             let updated = NativeEnumVariantLayout {
@@ -198,9 +170,7 @@ fn update_enum_variant_fields(variants: NativeEnumVariantLayout[], index: number
                 fields: append_struct_layout_field(variant.fields, field),
             };
             result.push(updated);
-        } else {
-            result.push(variants[current_index]);
-        }
+        } else { result.push(variants[current_index]); }
         current_index += 1;
     }
     return result;
@@ -221,7 +191,11 @@ fn parse_struct_definition(lines: string[], start_index: number, include_instruc
     let mut implements = header_parse.implements;
     if struct_name.length == 0 {
         diagnostics.push("unable to parse struct header: " + header);
-        return StructParseResult { definition: null, next_index: start_index + 1, diagnostics: diagnostics };
+        return StructParseResult {
+            definition: null,
+            next_index: start_index + 1,
+            diagnostics: diagnostics
+        };
     }
 
     let mut fields: NativeStructField[] = [];
@@ -241,10 +215,20 @@ fn parse_struct_definition(lines: string[], start_index: number, include_instruc
             diagnostics.push("unterminated struct " + struct_name);
             let mut struct_layout_value: NativeStructLayout? = null;
             if struct_layout_header_success {
-                struct_layout_value = NativeStructLayout { size: struct_layout_size, align: struct_layout_align, fields: struct_layout_fields };
+                struct_layout_value = NativeStructLayout {
+                    size: struct_layout_size,
+                    align: struct_layout_align,
+                    fields: struct_layout_fields
+                };
             }
             return StructParseResult {
-                definition: NativeStruct { name: struct_name, fields: fields, methods: methods, implements: implements, layout: struct_layout_value },
+                definition: NativeStruct {
+                    name: struct_name,
+                    fields: fields,
+                    methods: methods,
+                    implements: implements,
+                    layout: struct_layout_value
+                },
                 next_index: index,
                 diagnostics: diagnostics,
             };
@@ -302,9 +286,7 @@ fn parse_struct_definition(lines: string[], start_index: number, include_instruc
                 let parsed_method_span = parse_source_span(strip_prefix(raw_line, ".span "));
                 if parsed_method_span == null {
                     diagnostics.push("unable to parse span metadata: " + raw_line);
-                } else {
-                    method_pending_span = parsed_method_span;
-                }
+                } else { method_pending_span = parsed_method_span; }
                 index += 1;
                 continue;
             }
@@ -312,9 +294,7 @@ fn parse_struct_definition(lines: string[], start_index: number, include_instruc
                 let parsed_method_init_span = parse_source_span(strip_prefix(raw_line, ".init-span "));
                 if parsed_method_init_span == null {
                     diagnostics.push("unable to parse initializer span metadata: " + raw_line);
-                } else {
-                    method_pending_value_span = parsed_method_init_span;
-                }
+                } else { method_pending_value_span = parsed_method_init_span; }
                 index += 1;
                 continue;
             }
@@ -323,13 +303,9 @@ fn parse_struct_definition(lines: string[], start_index: number, include_instruc
                 method_pending_value_span = null;
                 let mut scan = index;
                 loop {
-                    if scan >= lines.length {
-                        break;
-                    }
+                    if scan >= lines.length { break; }
                     let candidate = trim_text(lines[scan]);
-                    if candidate == ".endmethod" {
-                        break;
-                    }
+                    if candidate == ".endmethod" { break; }
                     scan += 1;
                 }
                 index = scan;
@@ -386,13 +362,9 @@ fn parse_struct_definition(lines: string[], start_index: number, include_instruc
                 let tail = trim_text(strip_prefix(body, "field "));
                 let mut is_struct_header: boolean = false;
                 if starts_with(tail, "struct") {
-                    if tail.length == 6 {
-                        is_struct_header = true;
-                    } else if tail.length > 6 {
+                    if tail.length == 6 { is_struct_header = true; } else if tail.length > 6 {
                         let after = tail[6];
-                        if is_trim_char(after) {
-                            is_struct_header = true;
-                        }
+                        if is_trim_char(after) { is_struct_header = true; }
                     }
                 }
                 if is_struct_header {
@@ -448,9 +420,7 @@ fn parse_struct_definition(lines: string[], start_index: number, include_instruc
             let parsed_field = parse_struct_field_line(strip_prefix(raw_line, ".field "));
             if parsed_field == null {
                 diagnostics.push("unable to parse struct field: " + raw_line);
-            } else {
-                fields.push(parsed_field);
-            }
+            } else { fields.push(parsed_field); }
             index += 1;
             continue;
         }
@@ -461,9 +431,7 @@ fn parse_struct_definition(lines: string[], start_index: number, include_instruc
                 let decorator_name = parse_decorator_name(raw_line);
                 if decorator_name == null {
                     diagnostics.push("unable to parse decorator directive: " + raw_line);
-                } else {
-                    method_pending_decorators.push(decorator_name);
-                }
+                } else { method_pending_decorators.push(decorator_name); }
             }
             index += 1;
             continue;
@@ -475,9 +443,7 @@ fn parse_struct_definition(lines: string[], start_index: number, include_instruc
             let header = strip_prefix(raw_line, ".method ");
             let trimmed = trim_text(header);
             let mut is_async: boolean = false;
-            if starts_with(trimmed, "async ") {
-                is_async = true;
-            }
+            if starts_with(trimmed, "async ") { is_async = true; }
             let method_name = parse_function_name(header);
             current_method = NativeFunction {
                 name: method_name,
@@ -501,11 +467,21 @@ fn parse_struct_definition(lines: string[], start_index: number, include_instruc
 
     let mut struct_layout_value: NativeStructLayout? = null;
     if struct_layout_header_success {
-        struct_layout_value = NativeStructLayout { size: struct_layout_size, align: struct_layout_align, fields: struct_layout_fields };
+        struct_layout_value = NativeStructLayout {
+            size: struct_layout_size,
+            align: struct_layout_align,
+            fields: struct_layout_fields
+        };
     }
 
     return StructParseResult {
-        definition: NativeStruct { name: struct_name, fields: fields, methods: methods, implements: implements, layout: struct_layout_value },
+        definition: NativeStruct {
+            name: struct_name,
+            fields: fields,
+            methods: methods,
+            implements: implements,
+            layout: struct_layout_value
+        },
         next_index: index,
         diagnostics: diagnostics,
     };
@@ -518,12 +494,16 @@ fn parse_enum_definition(lines: string[], start_index: number) -> EnumParseResul
     let mut enum_name: string = name_text;
     let space_index = index_of(enum_name, " ");
     if space_index >= 0 {
-    enum_name = trim_text(substring(enum_name, 0, space_index));
+        enum_name = trim_text(substring(enum_name, 0, space_index));
     }
     enum_name = strip_generics(enum_name);
     if enum_name.length == 0 {
         diagnostics.push("unable to parse enum header: " + header);
-        return EnumParseResult { definition: null, next_index: start_index + 1, diagnostics: diagnostics };
+        return EnumParseResult {
+            definition: null,
+            next_index: start_index + 1,
+            diagnostics: diagnostics
+        };
     }
 
     let mut variants: NativeEnumVariant[] = [];
@@ -551,7 +531,11 @@ fn parse_enum_definition(lines: string[], start_index: number) -> EnumParseResul
                 };
             }
             return EnumParseResult {
-                definition: NativeEnum { name: enum_name, variants: variants, layout: enum_layout_value },
+                definition: NativeEnum {
+                    name: enum_name,
+                    variants: variants,
+                    layout: enum_layout_value
+                },
                 next_index: index,
                 diagnostics: diagnostics,
             };
@@ -672,9 +656,7 @@ fn parse_enum_definition(lines: string[], start_index: number) -> EnumParseResul
             let parsed_variant = parse_enum_variant_line(strip_prefix(raw_line, ".variant "));
             if parsed_variant == null {
                 diagnostics.push("unable to parse enum variant: " + raw_line);
-            } else {
-                variants.push(parsed_variant);
-            }
+            } else { variants.push(parsed_variant); }
             index += 1;
             continue;
         }
@@ -695,10 +677,21 @@ fn parse_enum_definition(lines: string[], start_index: number) -> EnumParseResul
     }
 
     return EnumParseResult {
-        definition: NativeEnum { name: enum_name, variants: variants, layout: enum_layout_value },
+        definition: NativeEnum {
+            name: enum_name,
+            variants: variants,
+            layout: enum_layout_value
+        },
         next_index: index,
         diagnostics: diagnostics,
     };
 }
 
-export { parse_struct_definition, parse_enum_definition, parse_source_span, apply_meta, append_parameter, append_instruction };
+export {
+    parse_struct_definition,
+    parse_enum_definition,
+    parse_source_span,
+    apply_meta,
+    append_parameter,
+    append_instruction
+};

--- a/compiler/src/native_ir_parser_instructions.sfn
+++ b/compiler/src/native_ir_parser_instructions.sfn
@@ -2,17 +2,19 @@
 //
 // Instruction parsing helpers extracted from native_ir_parser.sfn to keep
 // the module under the seed compiler's OOM threshold.
-
-import { substring } from "./string_utils";
-
 import {
+    InstructionDepthState,
+    InstructionGatherResult,
+    InstructionParseResult,
     NativeInstruction,
     NativeSourceSpan,
-    InstructionParseResult,
-    InstructionGatherResult,
-    InstructionDepthState,
 } from "./native_ir";
-
+import {
+    parse_binding_components,
+    parse_case_instruction,
+    parse_inline_case_instruction,
+    parse_let_instruction,
+} from "./native_ir_utils_parse";
 import {
     index_of,
     maybe_trim_trailing,
@@ -21,16 +23,16 @@ import {
     trim_text,
     trim_trailing_delimiters,
 } from "./native_ir_utils_text";
-
-import {
-    parse_binding_components,
-    parse_case_instruction,
-    parse_inline_case_instruction,
-    parse_let_instruction,
-} from "./native_ir_utils_parse";
+import { substring } from "./string_utils";
 
 fn initial_instruction_depth_state() -> InstructionDepthState {
-    return InstructionDepthState { paren_depth: 0, bracket_depth: 0, brace_depth: 0, in_string: false, escaping: false };
+    return InstructionDepthState {
+        paren_depth: 0,
+        bracket_depth: 0,
+        brace_depth: 0,
+        in_string: false,
+        escaping: false
+    };
 }
 
 fn update_instruction_depth_state(state: InstructionDepthState, text: string) -> InstructionDepthState {
@@ -42,9 +44,7 @@ fn update_instruction_depth_state(state: InstructionDepthState, text: string) ->
 
     let mut index: number = 0;
     loop {
-        if index >= text.length {
-            break;
-        }
+        if index >= text.length { break; }
         let ch = text[index];
         if in_string {
             if escaping {
@@ -57,9 +57,7 @@ fn update_instruction_depth_state(state: InstructionDepthState, text: string) ->
                 index += 1;
                 continue;
             }
-            if ch == "\"" {
-                in_string = false;
-            }
+            if ch == "\"" { in_string = false; }
             index += 1;
             continue;
         }
@@ -75,9 +73,7 @@ fn update_instruction_depth_state(state: InstructionDepthState, text: string) ->
             continue;
         }
         if ch == ")" {
-            if paren_depth > 0 {
-                paren_depth -= 1;
-            }
+            if paren_depth > 0 { paren_depth -= 1; }
             index += 1;
             continue;
         }
@@ -87,9 +83,7 @@ fn update_instruction_depth_state(state: InstructionDepthState, text: string) ->
             continue;
         }
         if ch == "]" {
-            if bracket_depth > 0 {
-                bracket_depth -= 1;
-            }
+            if bracket_depth > 0 { bracket_depth -= 1; }
             index += 1;
             continue;
         }
@@ -99,9 +93,7 @@ fn update_instruction_depth_state(state: InstructionDepthState, text: string) ->
             continue;
         }
         if ch == "}" {
-            if brace_depth > 0 {
-                brace_depth -= 1;
-            }
+            if brace_depth > 0 { brace_depth -= 1; }
             index += 1;
             continue;
         }
@@ -118,44 +110,26 @@ fn update_instruction_depth_state(state: InstructionDepthState, text: string) ->
 }
 
 fn instruction_requires_continuation(state: InstructionDepthState) -> boolean {
-    if state.in_string {
-        return true;
-    }
-    if state.paren_depth > 0 {
-        return true;
-    }
-    if state.bracket_depth > 0 {
-        return true;
-    }
-    if state.brace_depth > 0 {
-        return true;
-    }
+    if state.in_string { return true; }
+    if state.paren_depth > 0 { return true; }
+    if state.bracket_depth > 0 { return true; }
+    if state.brace_depth > 0 { return true; }
     return false;
 }
 
 fn instruction_supports_multiline(line: string) -> boolean {
-    if starts_with(line, "eval ") {
-        return true;
-    }
-    if starts_with(line, "ret ") {
-        return true;
-    }
-    if starts_with(line, ".let ") {
-        return true;
-    }
+    if starts_with(line, "eval ") { return true; }
+    if starts_with(line, "ret ") { return true; }
+    if starts_with(line, ".let ") { return true; }
     return false;
 }
 
 fn instruction_line_requires_operator_continuation(line: string) -> boolean {
     let trimmed = trim_text(line);
-    if trimmed.length == 0 {
-        return false;
-    }
+    if trimmed.length == 0 { return false; }
     let mut index = trimmed.length - 1;
     loop {
-        if index < 0 {
-            return false;
-        }
+        if index < 0 { return false; }
         let ch = trimmed[index];
         let mut _if360: boolean = false;
         if ch == " " { _if360 = true; }
@@ -166,9 +140,7 @@ fn instruction_line_requires_operator_continuation(line: string) -> boolean {
             index -= 1;
             continue;
         }
-        if ch == "+" {
-            return true;
-        }
+        if ch == "+" { return true; }
         return false;
     }
 
@@ -177,9 +149,7 @@ fn instruction_line_requires_operator_continuation(line: string) -> boolean {
 
 fn is_native_directive_line(line: string) -> boolean {
     let trimmed = trim_text(line);
-    if trimmed.length == 0 {
-        return false;
-    }
+    if trimmed.length == 0 { return false; }
     return starts_with(trimmed, ".");
 }
 
@@ -189,16 +159,25 @@ fn gather_instruction(lines: string[], start_index: number) -> InstructionGather
     }
     let first_line = trim_text(lines[start_index]);
     if first_line.length == 0 {
-        return InstructionGatherResult { text: first_line, lines_consumed: 0 };
+        return InstructionGatherResult {
+            text: first_line,
+            lines_consumed: 0
+        };
     }
     if !instruction_supports_multiline(first_line) {
-        return InstructionGatherResult { text: first_line, lines_consumed: 0 };
+        return InstructionGatherResult {
+            text: first_line,
+            lines_consumed: 0
+        };
     }
 
     let mut state = update_instruction_depth_state(initial_instruction_depth_state(), first_line);
     if !instruction_requires_continuation(state) {
         if !instruction_line_requires_operator_continuation(first_line) {
-            return InstructionGatherResult { text: first_line, lines_consumed: 0 };
+            return InstructionGatherResult {
+                text: first_line,
+                lines_consumed: 0
+            };
         }
     }
 
@@ -207,16 +186,10 @@ fn gather_instruction(lines: string[], start_index: number) -> InstructionGather
     let mut index = start_index + 1;
     let mut last_nonempty = first_line;
     loop {
-        if index >= lines.length {
-            break;
-        }
+        if index >= lines.length { break; }
         let continuation = trim_text(lines[index]);
-        if is_native_directive_line(continuation) {
-            break;
-        }
-        if continuation.length == 0 {
-            combined = combined + "\n";
-        } else {
+        if is_native_directive_line(continuation) { break; }
+        if continuation.length == 0 { combined = combined + "\n"; } else {
             combined = combined + "\n" + continuation;
             state = update_instruction_depth_state(state, continuation);
             last_nonempty = continuation;
@@ -230,22 +203,41 @@ fn gather_instruction(lines: string[], start_index: number) -> InstructionGather
         }
     }
     let normalized = trim_text(combined);
-    return InstructionGatherResult { text: normalized, lines_consumed: consumed };
+    return InstructionGatherResult {
+        text: normalized,
+        lines_consumed: consumed
+    };
 }
 
 fn parse_instruction(line: string, span: NativeSourceSpan?, value_span: NativeSourceSpan?) -> InstructionParseResult {
     if line == "noop" {
-        return InstructionParseResult { instructions: [NativeInstruction.Noop()], span_consumed: false, value_span_consumed: false };
+        return InstructionParseResult {
+            instructions: [NativeInstruction.Noop()],
+            span_consumed: false,
+            value_span_consumed: false
+        };
     }
     if starts_with(line, ".if ") {
         let condition = trim_text(strip_prefix(line, ".if "));
-        return InstructionParseResult { instructions: [NativeInstruction.If { condition: condition }], span_consumed: false, value_span_consumed: false };
+        return InstructionParseResult {
+            instructions: [NativeInstruction.If { condition: condition }],
+            span_consumed: false,
+            value_span_consumed: false
+        };
     }
     if line == ".else" {
-        return InstructionParseResult { instructions: [NativeInstruction.Else()], span_consumed: false, value_span_consumed: false };
+        return InstructionParseResult {
+            instructions: [NativeInstruction.Else()],
+            span_consumed: false,
+            value_span_consumed: false
+        };
     }
     if line == ".endif" {
-        return InstructionParseResult { instructions: [NativeInstruction.EndIf()], span_consumed: false, value_span_consumed: false };
+        return InstructionParseResult {
+            instructions: [NativeInstruction.EndIf()],
+            span_consumed: false,
+            value_span_consumed: false
+        };
     }
     if starts_with(line, ".for ") {
         let body = trim_text(strip_prefix(line, ".for "));
@@ -254,50 +246,110 @@ fn parse_instruction(line: string, span: NativeSourceSpan?, value_span: NativeSo
         if index >= 0 {
             let target = trim_text(substring(body, 0, index));
             let iterable = trim_text(substring(body, index + separator.length, body.length));
-            return InstructionParseResult { instructions: [NativeInstruction.For { target: target, iterable: iterable }], span_consumed: false, value_span_consumed: false };
+            return InstructionParseResult {
+                instructions: [NativeInstruction.For {
+                    target: target, iterable: iterable
+                }],
+                span_consumed: false,
+                value_span_consumed: false
+            };
         }
     }
     if line == ".endfor" {
-        return InstructionParseResult { instructions: [NativeInstruction.EndFor()], span_consumed: false, value_span_consumed: false };
+        return InstructionParseResult {
+            instructions: [NativeInstruction.EndFor()],
+            span_consumed: false,
+            value_span_consumed: false
+        };
     }
     if line == ".loop" {
-        return InstructionParseResult { instructions: [NativeInstruction.Loop()], span_consumed: false, value_span_consumed: false };
+        return InstructionParseResult {
+            instructions: [NativeInstruction.Loop()],
+            span_consumed: false,
+            value_span_consumed: false
+        };
     }
     if line == ".endloop" {
-        return InstructionParseResult { instructions: [NativeInstruction.EndLoop()], span_consumed: false, value_span_consumed: false };
+        return InstructionParseResult {
+            instructions: [NativeInstruction.EndLoop()],
+            span_consumed: false,
+            value_span_consumed: false
+        };
     }
     if line == "break" {
-        return InstructionParseResult { instructions: [NativeInstruction.Break()], span_consumed: false, value_span_consumed: false };
+        return InstructionParseResult {
+            instructions: [NativeInstruction.Break()],
+            span_consumed: false,
+            value_span_consumed: false
+        };
     }
     if line == "continue" {
-        return InstructionParseResult { instructions: [NativeInstruction.Continue()], span_consumed: false, value_span_consumed: false };
+        return InstructionParseResult {
+            instructions: [NativeInstruction.Continue()],
+            span_consumed: false,
+            value_span_consumed: false
+        };
     }
     if starts_with(line, ".match ") {
         let expression = trim_text(strip_prefix(line, ".match "));
-        return InstructionParseResult { instructions: [NativeInstruction.Match { expression: expression }], span_consumed: false, value_span_consumed: false };
+        return InstructionParseResult {
+            instructions: [NativeInstruction.Match { expression: expression }],
+            span_consumed: false,
+            value_span_consumed: false
+        };
     }
     if starts_with(line, ".case ") {
-        return InstructionParseResult { instructions: [parse_case_instruction(line)], span_consumed: false, value_span_consumed: false };
+        return InstructionParseResult {
+            instructions: [parse_case_instruction(line)],
+            span_consumed: false,
+            value_span_consumed: false
+        };
     }
     if line == ".endmatch" {
-        return InstructionParseResult { instructions: [NativeInstruction.EndMatch()], span_consumed: false, value_span_consumed: false };
+        return InstructionParseResult {
+            instructions: [NativeInstruction.EndMatch()],
+            span_consumed: false,
+            value_span_consumed: false
+        };
     }
     if line == ".try" {
-        return InstructionParseResult { instructions: [NativeInstruction.Try()], span_consumed: false, value_span_consumed: false };
+        return InstructionParseResult {
+            instructions: [NativeInstruction.Try()],
+            span_consumed: false,
+            value_span_consumed: false
+        };
     }
     if starts_with(line, ".catch ") {
         let name = trim_text(strip_prefix(line, ".catch "));
-        return InstructionParseResult { instructions: [NativeInstruction.Catch { name: name }], span_consumed: false, value_span_consumed: false };
+        return InstructionParseResult {
+            instructions: [NativeInstruction.Catch { name: name }],
+            span_consumed: false,
+            value_span_consumed: false
+        };
     }
     if line == ".finally" {
-        return InstructionParseResult { instructions: [NativeInstruction.Finally()], span_consumed: false, value_span_consumed: false };
+        return InstructionParseResult {
+            instructions: [NativeInstruction.Finally()],
+            span_consumed: false,
+            value_span_consumed: false
+        };
     }
     if line == ".endtry" {
-        return InstructionParseResult { instructions: [NativeInstruction.EndTry()], span_consumed: false, value_span_consumed: false };
+        return InstructionParseResult {
+            instructions: [NativeInstruction.EndTry()],
+            span_consumed: false,
+            value_span_consumed: false
+        };
     }
     if starts_with(line, "throw ") {
         let expression = trim_trailing_delimiters(trim_text(strip_prefix(line, "throw ")));
-        return InstructionParseResult { instructions: [NativeInstruction.Throw { expression: expression, span: span }], span_consumed: true, value_span_consumed: false };
+        return InstructionParseResult {
+            instructions: [NativeInstruction.Throw {
+                expression: expression, span: span
+            }],
+            span_consumed: true,
+            value_span_consumed: false
+        };
     }
     if starts_with(line, ".let ") {
         return InstructionParseResult {
@@ -313,7 +365,9 @@ fn parse_instruction(line: string, span: NativeSourceSpan?, value_span: NativeSo
             expression = trim_trailing_delimiters(remainder);
         }
         return InstructionParseResult {
-            instructions: [NativeInstruction.Return { expression: expression, span: span }],
+            instructions: [NativeInstruction.Return {
+                expression: expression, span: span
+            }],
             span_consumed: true,
             value_span_consumed: false,
         };
@@ -321,7 +375,9 @@ fn parse_instruction(line: string, span: NativeSourceSpan?, value_span: NativeSo
     if starts_with(line, "ret") {
         if line.length == 3 {
             return InstructionParseResult {
-                instructions: [NativeInstruction.Return { expression: "", span: span }],
+                instructions: [NativeInstruction.Return {
+                    expression: "", span: span
+                }],
                 span_consumed: true,
                 value_span_consumed: false,
             };
@@ -334,13 +390,17 @@ fn parse_instruction(line: string, span: NativeSourceSpan?, value_span: NativeSo
             let remainder = trim_text(substring(line, 3, line.length));
             if remainder.length == 0 {
                 return InstructionParseResult {
-                    instructions: [NativeInstruction.Return { expression: "", span: span }],
+                    instructions: [NativeInstruction.Return {
+                        expression: "", span: span
+                    }],
                     span_consumed: true,
                     value_span_consumed: false,
                 };
             }
             return InstructionParseResult {
-                instructions: [NativeInstruction.Return { expression: trim_trailing_delimiters(remainder), span: span }],
+                instructions: [NativeInstruction.Return {
+                    expression: trim_trailing_delimiters(remainder), span: span
+                }],
                 span_consumed: true,
                 value_span_consumed: false,
             };
@@ -356,12 +416,7 @@ fn parse_instruction(line: string, span: NativeSourceSpan?, value_span: NativeSo
         let parsed = parse_binding_components(body);
         return InstructionParseResult {
             instructions: [NativeInstruction.Let {
-                    name: parsed.name,
-                    mutable: is_mutable,
-                    type_annotation: parsed.type_annotation,
-                    value: maybe_trim_trailing(parsed.value),
-                    span: span,
-                    value_span: value_span,
+                name: parsed.name, mutable: is_mutable, type_annotation: parsed.type_annotation, value: maybe_trim_trailing(parsed.value), span: span, value_span: value_span,
             }],
             span_consumed: true,
             value_span_consumed: true,
@@ -369,15 +424,25 @@ fn parse_instruction(line: string, span: NativeSourceSpan?, value_span: NativeSo
     }
     if starts_with(line, "eval ") {
         return InstructionParseResult {
-            instructions: [NativeInstruction.Expression { expression: trim_trailing_delimiters(trim_text(strip_prefix(line, "eval "))), span: span }],
+            instructions: [NativeInstruction.Expression {
+                expression: trim_trailing_delimiters(trim_text(strip_prefix(line, "eval "))), span: span
+            }],
             span_consumed: true,
             value_span_consumed: false,
         };
     }
     if index_of(line, "=>") >= 0 {
-        return InstructionParseResult { instructions: parse_inline_case_instruction(line), span_consumed: false, value_span_consumed: false };
+        return InstructionParseResult {
+            instructions: parse_inline_case_instruction(line),
+            span_consumed: false,
+            value_span_consumed: false
+        };
     }
-    return InstructionParseResult { instructions: [NativeInstruction.Unknown { text: line }], span_consumed: false, value_span_consumed: false };
+    return InstructionParseResult {
+        instructions: [NativeInstruction.Unknown { text: line }],
+        span_consumed: false,
+        value_span_consumed: false
+    };
 }
 
 export { parse_instruction, gather_instruction };

--- a/compiler/src/native_ir_parser_instructions.sfn
+++ b/compiler/src/native_ir_parser_instructions.sfn
@@ -7,13 +7,13 @@ import {
     InstructionGatherResult,
     InstructionParseResult,
     NativeInstruction,
-    NativeSourceSpan,
+    NativeSourceSpan
 } from "./native_ir";
 import {
     parse_binding_components,
     parse_case_instruction,
     parse_inline_case_instruction,
-    parse_let_instruction,
+    parse_let_instruction
 } from "./native_ir_utils_parse";
 import {
     index_of,
@@ -21,7 +21,7 @@ import {
     starts_with,
     strip_prefix,
     trim_text,
-    trim_trailing_delimiters,
+    trim_trailing_delimiters
 } from "./native_ir_utils_text";
 import { substring } from "./string_utils";
 
@@ -105,7 +105,7 @@ fn update_instruction_depth_state(state: InstructionDepthState, text: string) ->
         bracket_depth: bracket_depth,
         brace_depth: brace_depth,
         in_string: in_string,
-        escaping: escaping,
+        escaping: escaping
     };
 }
 
@@ -355,7 +355,7 @@ fn parse_instruction(line: string, span: NativeSourceSpan?, value_span: NativeSo
         return InstructionParseResult {
             instructions: [parse_let_instruction(line, span, value_span)],
             span_consumed: true,
-            value_span_consumed: true,
+            value_span_consumed: true
         };
     }
     if starts_with(line, ".return") {
@@ -369,7 +369,7 @@ fn parse_instruction(line: string, span: NativeSourceSpan?, value_span: NativeSo
                 expression: expression, span: span
             }],
             span_consumed: true,
-            value_span_consumed: false,
+            value_span_consumed: false
         };
     }
     if starts_with(line, "ret") {
@@ -379,7 +379,7 @@ fn parse_instruction(line: string, span: NativeSourceSpan?, value_span: NativeSo
                     expression: "", span: span
                 }],
                 span_consumed: true,
-                value_span_consumed: false,
+                value_span_consumed: false
             };
         }
         let separator = line[3];
@@ -394,7 +394,7 @@ fn parse_instruction(line: string, span: NativeSourceSpan?, value_span: NativeSo
                         expression: "", span: span
                     }],
                     span_consumed: true,
-                    value_span_consumed: false,
+                    value_span_consumed: false
                 };
             }
             return InstructionParseResult {
@@ -402,7 +402,7 @@ fn parse_instruction(line: string, span: NativeSourceSpan?, value_span: NativeSo
                     expression: trim_trailing_delimiters(remainder), span: span
                 }],
                 span_consumed: true,
-                value_span_consumed: false,
+                value_span_consumed: false
             };
         }
     }
@@ -416,10 +416,10 @@ fn parse_instruction(line: string, span: NativeSourceSpan?, value_span: NativeSo
         let parsed = parse_binding_components(body);
         return InstructionParseResult {
             instructions: [NativeInstruction.Let {
-                name: parsed.name, mutable: is_mutable, type_annotation: parsed.type_annotation, value: maybe_trim_trailing(parsed.value), span: span, value_span: value_span,
+                name: parsed.name, mutable: is_mutable, type_annotation: parsed.type_annotation, value: maybe_trim_trailing(parsed.value), span: span, value_span: value_span
             }],
             span_consumed: true,
-            value_span_consumed: true,
+            value_span_consumed: true
         };
     }
     if starts_with(line, "eval ") {
@@ -428,7 +428,7 @@ fn parse_instruction(line: string, span: NativeSourceSpan?, value_span: NativeSo
                 expression: trim_trailing_delimiters(trim_text(strip_prefix(line, "eval "))), span: span
             }],
             span_consumed: true,
-            value_span_consumed: false,
+            value_span_consumed: false
         };
     }
     if index_of(line, "=>") >= 0 {

--- a/compiler/src/native_ir_utils_layout.sfn
+++ b/compiler/src/native_ir_utils_layout.sfn
@@ -9,13 +9,13 @@ import {
     NativeStructLayoutField,
     NumberParseResult,
     StructLayoutFieldParse,
-    StructLayoutHeaderParse,
+    StructLayoutHeaderParse
 } from "./native_ir";
 import {
     index_of,
     split_whitespace,
     starts_with,
-    trim_text,
+    trim_text
 } from "./native_ir_utils_text";
 import { substring } from "./string_utils";
 
@@ -25,7 +25,7 @@ export {
     parse_struct_layout_field,
     parse_enum_layout_header,
     parse_enum_variant_layout,
-    parse_enum_payload_layout,
+    parse_enum_payload_layout
 };
 
 fn parse_decimal_number(text: string) -> NumberParseResult {
@@ -98,7 +98,9 @@ fn parse_struct_layout_header(text: string) -> StructLayoutHeaderParse {
                 size_found = true;
                 size_value = parsed.value;
             } else {
-                diagnostics.push("struct layout header has invalid size `" + value_text + "`");
+                diagnostics.push("struct layout header has invalid size `"
+                    + value_text
+                    + "`");
             }
         } else if starts_with(token, "align=") {
             let value_text = substring(token, 6, token.length);
@@ -107,10 +109,13 @@ fn parse_struct_layout_header(text: string) -> StructLayoutHeaderParse {
                 align_found = true;
                 align_value = parsed.value;
             } else {
-                diagnostics.push("struct layout header has invalid align `" + value_text + "`");
+                diagnostics.push("struct layout header has invalid align `"
+                    + value_text
+                    + "`");
             }
         } else {
-            diagnostics.push("struct layout header unrecognized token `" + token + "`");
+            diagnostics.push("struct layout header unrecognized token `" + token
+                + "`");
         }
         index += 1;
     }
@@ -147,7 +152,8 @@ fn parse_struct_layout_field(text: string, struct_name: string) -> StructLayoutF
         align: 0
     };
     if trimmed.length == 0 {
-        diagnostics.push("struct " + struct_name + " layout field missing content");
+        diagnostics.push("struct " + struct_name
+            + " layout field missing content");
         return StructLayoutFieldParse {
             success: false,
             field: default_field,
@@ -156,7 +162,8 @@ fn parse_struct_layout_field(text: string, struct_name: string) -> StructLayoutF
     }
     let tokens = split_whitespace(trimmed);
     if tokens.length == 0 {
-        diagnostics.push("struct " + struct_name + " layout field missing entries");
+        diagnostics.push("struct " + struct_name
+            + " layout field missing entries");
         return StructLayoutFieldParse {
             success: false,
             field: default_field,
@@ -192,7 +199,11 @@ fn parse_struct_layout_field(text: string, struct_name: string) -> StructLayoutF
                 offset_found = true;
                 offset_value = parsed.value;
             } else {
-                diagnostics.push("struct " + struct_name + " layout field `" + field_name + "` has invalid offset `" + value_text + "`");
+                diagnostics.push("struct " + struct_name + " layout field `"
+                    + field_name
+                    + "` has invalid offset `"
+                    + value_text
+                    + "`");
             }
         } else if starts_with(token, "size=") {
             let value_text = substring(token, 5, token.length);
@@ -201,7 +212,11 @@ fn parse_struct_layout_field(text: string, struct_name: string) -> StructLayoutF
                 size_found = true;
                 size_value = parsed.value;
             } else {
-                diagnostics.push("struct " + struct_name + " layout field `" + field_name + "` has invalid size `" + value_text + "`");
+                diagnostics.push("struct " + struct_name + " layout field `"
+                    + field_name
+                    + "` has invalid size `"
+                    + value_text
+                    + "`");
             }
         } else if starts_with(token, "align=") {
             let value_text = substring(token, 6, token.length);
@@ -210,24 +225,40 @@ fn parse_struct_layout_field(text: string, struct_name: string) -> StructLayoutF
                 align_found = true;
                 align_value = parsed.value;
             } else {
-                diagnostics.push("struct " + struct_name + " layout field `" + field_name + "` has invalid align `" + value_text + "`");
+                diagnostics.push("struct " + struct_name + " layout field `"
+                    + field_name
+                    + "` has invalid align `"
+                    + value_text
+                    + "`");
             }
         } else {
-            diagnostics.push("struct " + struct_name + " layout field `" + field_name + "` unrecognized token `" + token + "`");
+            diagnostics.push("struct " + struct_name + " layout field `"
+                + field_name
+                + "` unrecognized token `"
+                + token
+                + "`");
         }
         index += 1;
     }
     if type_text.length == 0 {
-        diagnostics.push("struct " + struct_name + " layout field `" + field_name + "` missing type entry");
+        diagnostics.push("struct " + struct_name + " layout field `"
+            + field_name
+            + "` missing type entry");
     }
     if !offset_found {
-        diagnostics.push("struct " + struct_name + " layout field `" + field_name + "` missing offset entry");
+        diagnostics.push("struct " + struct_name + " layout field `"
+            + field_name
+            + "` missing offset entry");
     }
     if !size_found {
-        diagnostics.push("struct " + struct_name + " layout field `" + field_name + "` missing size entry");
+        diagnostics.push("struct " + struct_name + " layout field `"
+            + field_name
+            + "` missing size entry");
     }
     if !align_found {
-        diagnostics.push("struct " + struct_name + " layout field `" + field_name + "` missing align entry");
+        diagnostics.push("struct " + struct_name + " layout field `"
+            + field_name
+            + "` missing align entry");
     }
     let mut _let375: boolean = false;
     if type_text.length > 0 {
@@ -295,7 +326,9 @@ fn parse_enum_layout_header(text: string) -> EnumLayoutHeaderParse {
                 size_found = true;
                 size_value = parsed.value;
             } else {
-                diagnostics.push("enum layout header has invalid size `" + value_text + "`");
+                diagnostics.push("enum layout header has invalid size `"
+                    + value_text
+                    + "`");
             }
         } else if starts_with(token, "align=") {
             let value_text = substring(token, 6, token.length);
@@ -304,7 +337,9 @@ fn parse_enum_layout_header(text: string) -> EnumLayoutHeaderParse {
                 align_found = true;
                 align_value = parsed.value;
             } else {
-                diagnostics.push("enum layout header has invalid align `" + value_text + "`");
+                diagnostics.push("enum layout header has invalid align `"
+                    + value_text
+                    + "`");
             }
         } else if starts_with(token, "tag_type=") {
             tag_type = substring(token, 9, token.length);
@@ -315,7 +350,9 @@ fn parse_enum_layout_header(text: string) -> EnumLayoutHeaderParse {
                 tag_size_found = true;
                 tag_size_value = parsed.value;
             } else {
-                diagnostics.push("enum layout header has invalid tag_size `" + value_text + "`");
+                diagnostics.push("enum layout header has invalid tag_size `"
+                    + value_text
+                    + "`");
             }
         } else if starts_with(token, "tag_align=") {
             let value_text = substring(token, 10, token.length);
@@ -324,10 +361,13 @@ fn parse_enum_layout_header(text: string) -> EnumLayoutHeaderParse {
                 tag_align_found = true;
                 tag_align_value = parsed.value;
             } else {
-                diagnostics.push("enum layout header has invalid tag_align `" + value_text + "`");
+                diagnostics.push("enum layout header has invalid tag_align `"
+                    + value_text
+                    + "`");
             }
         } else {
-            diagnostics.push("enum layout header unrecognized token `" + token + "`");
+            diagnostics.push("enum layout header unrecognized token `" + token
+                + "`");
         }
         index += 1;
     }
@@ -367,7 +407,7 @@ fn parse_enum_layout_header(text: string) -> EnumLayoutHeaderParse {
         tag_type: tag_type,
         tag_size: tag_size_value,
         tag_align: tag_align_value,
-        diagnostics: diagnostics,
+        diagnostics: diagnostics
     };
 }
 
@@ -427,7 +467,11 @@ fn parse_enum_variant_layout(text: string, enum_name: string) -> EnumLayoutVaria
                 tag_found = true;
                 tag_value = parsed.value;
             } else {
-                diagnostics.push("enum " + enum_name + " layout variant `" + variant_name + "` has invalid tag `" + value_text + "`");
+                diagnostics.push("enum " + enum_name + " layout variant `"
+                    + variant_name
+                    + "` has invalid tag `"
+                    + value_text
+                    + "`");
             }
         } else if starts_with(token, "offset=") {
             let value_text = substring(token, 7, token.length);
@@ -436,7 +480,11 @@ fn parse_enum_variant_layout(text: string, enum_name: string) -> EnumLayoutVaria
                 offset_found = true;
                 offset_value = parsed.value;
             } else {
-                diagnostics.push("enum " + enum_name + " layout variant `" + variant_name + "` has invalid offset `" + value_text + "`");
+                diagnostics.push("enum " + enum_name + " layout variant `"
+                    + variant_name
+                    + "` has invalid offset `"
+                    + value_text
+                    + "`");
             }
         } else if starts_with(token, "size=") {
             let value_text = substring(token, 5, token.length);
@@ -445,7 +493,11 @@ fn parse_enum_variant_layout(text: string, enum_name: string) -> EnumLayoutVaria
                 size_found = true;
                 size_value = parsed.value;
             } else {
-                diagnostics.push("enum " + enum_name + " layout variant `" + variant_name + "` has invalid size `" + value_text + "`");
+                diagnostics.push("enum " + enum_name + " layout variant `"
+                    + variant_name
+                    + "` has invalid size `"
+                    + value_text
+                    + "`");
             }
         } else if starts_with(token, "align=") {
             let value_text = substring(token, 6, token.length);
@@ -454,24 +506,40 @@ fn parse_enum_variant_layout(text: string, enum_name: string) -> EnumLayoutVaria
                 align_found = true;
                 align_value = parsed.value;
             } else {
-                diagnostics.push("enum " + enum_name + " layout variant `" + variant_name + "` has invalid align `" + value_text + "`");
+                diagnostics.push("enum " + enum_name + " layout variant `"
+                    + variant_name
+                    + "` has invalid align `"
+                    + value_text
+                    + "`");
             }
         } else {
-            diagnostics.push("enum " + enum_name + " layout variant `" + variant_name + "` unrecognized token `" + token + "`");
+            diagnostics.push("enum " + enum_name + " layout variant `"
+                + variant_name
+                + "` unrecognized token `"
+                + token
+                + "`");
         }
         index += 1;
     }
     if !tag_found {
-        diagnostics.push("enum " + enum_name + " layout variant `" + variant_name + "` missing tag entry");
+        diagnostics.push("enum " + enum_name + " layout variant `"
+            + variant_name
+            + "` missing tag entry");
     }
     if !offset_found {
-        diagnostics.push("enum " + enum_name + " layout variant `" + variant_name + "` missing offset entry");
+        diagnostics.push("enum " + enum_name + " layout variant `"
+            + variant_name
+            + "` missing offset entry");
     }
     if !size_found {
-        diagnostics.push("enum " + enum_name + " layout variant `" + variant_name + "` missing size entry");
+        diagnostics.push("enum " + enum_name + " layout variant `"
+            + variant_name
+            + "` missing size entry");
     }
     if !align_found {
-        diagnostics.push("enum " + enum_name + " layout variant `" + variant_name + "` missing align entry");
+        diagnostics.push("enum " + enum_name + " layout variant `"
+            + variant_name
+            + "` missing align entry");
     }
     let mut _let377: boolean = false;
     if tag_found {
@@ -535,7 +603,9 @@ fn parse_enum_payload_layout(text: string, enum_name: string) -> EnumLayoutPaylo
     if dot_index <= 0 { _if378 = true; }
     if _dot_next >= identifier.length { _if378 = true; }
     if _if378 {
-        diagnostics.push("enum " + enum_name + " layout payload identifier `" + identifier + "` invalid");
+        diagnostics.push("enum " + enum_name + " layout payload identifier `"
+            + identifier
+            + "` invalid");
         return EnumLayoutPayloadParse {
             success: false,
             variant_name: "",
@@ -565,7 +635,11 @@ fn parse_enum_payload_layout(text: string, enum_name: string) -> EnumLayoutPaylo
                 offset_found = true;
                 offset_value = parsed.value;
             } else {
-                diagnostics.push("enum " + enum_name + " layout payload `" + identifier + "` has invalid offset `" + value_text + "`");
+                diagnostics.push("enum " + enum_name + " layout payload `"
+                    + identifier
+                    + "` has invalid offset `"
+                    + value_text
+                    + "`");
             }
         } else if starts_with(token, "size=") {
             let value_text = substring(token, 5, token.length);
@@ -574,7 +648,11 @@ fn parse_enum_payload_layout(text: string, enum_name: string) -> EnumLayoutPaylo
                 size_found = true;
                 size_value = parsed.value;
             } else {
-                diagnostics.push("enum " + enum_name + " layout payload `" + identifier + "` has invalid size `" + value_text + "`");
+                diagnostics.push("enum " + enum_name + " layout payload `"
+                    + identifier
+                    + "` has invalid size `"
+                    + value_text
+                    + "`");
             }
         } else if starts_with(token, "align=") {
             let value_text = substring(token, 6, token.length);
@@ -583,24 +661,36 @@ fn parse_enum_payload_layout(text: string, enum_name: string) -> EnumLayoutPaylo
                 align_found = true;
                 align_value = parsed.value;
             } else {
-                diagnostics.push("enum " + enum_name + " layout payload `" + identifier + "` has invalid align `" + value_text + "`");
+                diagnostics.push("enum " + enum_name + " layout payload `"
+                    + identifier
+                    + "` has invalid align `"
+                    + value_text
+                    + "`");
             }
         } else {
-            diagnostics.push("enum " + enum_name + " layout payload `" + identifier + "` unrecognized token `" + token + "`");
+            diagnostics.push("enum " + enum_name + " layout payload `"
+                + identifier
+                + "` unrecognized token `"
+                + token
+                + "`");
         }
         index += 1;
     }
     if type_text.length == 0 {
-        diagnostics.push("enum " + enum_name + " layout payload `" + identifier + "` missing type entry");
+        diagnostics.push("enum " + enum_name + " layout payload `" + identifier
+            + "` missing type entry");
     }
     if !offset_found {
-        diagnostics.push("enum " + enum_name + " layout payload `" + identifier + "` missing offset entry");
+        diagnostics.push("enum " + enum_name + " layout payload `" + identifier
+            + "` missing offset entry");
     }
     if !size_found {
-        diagnostics.push("enum " + enum_name + " layout payload `" + identifier + "` missing size entry");
+        diagnostics.push("enum " + enum_name + " layout payload `" + identifier
+            + "` missing size entry");
     }
     if !align_found {
-        diagnostics.push("enum " + enum_name + " layout payload `" + identifier + "` missing align entry");
+        diagnostics.push("enum " + enum_name + " layout payload `" + identifier
+            + "` missing align entry");
     }
     let mut _let379: boolean = false;
     if type_text.length > 0 {

--- a/compiler/src/native_ir_utils_layout.sfn
+++ b/compiler/src/native_ir_utils_layout.sfn
@@ -1,9 +1,6 @@
 // compiler/src/native_ir_utils_layout.sfn
 //
 // Layout parsing utilities for struct and enum layout sections in .sfn-asm IR.
-
-import { substring } from "./string_utils";
-
 import {
     EnumLayoutHeaderParse,
     EnumLayoutPayloadParse,
@@ -14,13 +11,13 @@ import {
     StructLayoutFieldParse,
     StructLayoutHeaderParse,
 } from "./native_ir";
-
 import {
     index_of,
-    starts_with,
     split_whitespace,
+    starts_with,
     trim_text,
 } from "./native_ir_utils_text";
+import { substring } from "./string_utils";
 
 export {
     parse_decimal_number,
@@ -47,28 +44,24 @@ fn parse_decimal_number(text: string) -> NumberParseResult {
         }
     }
     loop {
-        if index >= trimmed.length {
-            break;
-        }
+        if index >= trimmed.length { break; }
         let code = trimmed[index];
-        if code == "0" { value = value * 10; }
-        else if code == "1" { value = value * 10 + 1; }
-        else if code == "2" { value = value * 10 + 2; }
-        else if code == "3" { value = value * 10 + 3; }
-        else if code == "4" { value = value * 10 + 4; }
-        else if code == "5" { value = value * 10 + 5; }
-        else if code == "6" { value = value * 10 + 6; }
-        else if code == "7" { value = value * 10 + 7; }
-        else if code == "8" { value = value * 10 + 8; }
-        else if code == "9" { value = value * 10 + 9; }
-        else {
+        if code == "0" { value = value * 10; } else if code == "1" {
+            value = value * 10 + 1;
+        } else if code == "2" { value = value * 10 + 2; } else if code == "3" {
+            value = value * 10 + 3;
+        } else if code == "4" { value = value * 10 + 4; } else if code == "5" {
+            value = value * 10 + 5;
+        } else if code == "6" { value = value * 10 + 6; } else if code == "7" {
+            value = value * 10 + 7;
+        } else if code == "8" { value = value * 10 + 8; } else if code == "9" {
+            value = value * 10 + 9;
+        } else {
             return NumberParseResult { success: false, value: 0 };
         }
         index += 1;
     }
-    if negative {
-        value = 0 - value;
-    }
+    if negative { value = 0 - value; }
     return NumberParseResult { success: true, value: value };
 }
 
@@ -77,7 +70,13 @@ fn parse_struct_layout_header(text: string) -> StructLayoutHeaderParse {
     let mut diagnostics: string[] = [];
     if tokens.length == 0 {
         diagnostics.push("struct layout header missing entries");
-        return StructLayoutHeaderParse { success: false, name: "", size: 0, align: 0, diagnostics: diagnostics };
+        return StructLayoutHeaderParse {
+            success: false,
+            name: "",
+            size: 0,
+            align: 0,
+            diagnostics: diagnostics
+        };
     }
     let mut name_found: boolean = false;
     let mut size_found: boolean = false;
@@ -87,9 +86,7 @@ fn parse_struct_layout_header(text: string) -> StructLayoutHeaderParse {
     let mut align_value: number = 0;
     let mut index: number = 0;
     loop {
-        if index >= tokens.length {
-            break;
-        }
+        if index >= tokens.length { break; }
         let token = tokens[index];
         if starts_with(token, "name=") {
             name_value = substring(token, 5, token.length);
@@ -126,32 +123,54 @@ fn parse_struct_layout_header(text: string) -> StructLayoutHeaderParse {
     let mut _let374: boolean = false;
     if size_found {
         if align_found {
-            if diagnostics.length == 0 {
-                _let374 = true;
-            }
+            if diagnostics.length == 0 { _let374 = true; }
         }
     }
     let success = _let374;
-    return StructLayoutHeaderParse { success: success, name: name_value, size: size_value, align: align_value, diagnostics: diagnostics };
+    return StructLayoutHeaderParse {
+        success: success,
+        name: name_value,
+        size: size_value,
+        align: align_value,
+        diagnostics: diagnostics
+    };
 }
 
 fn parse_struct_layout_field(text: string, struct_name: string) -> StructLayoutFieldParse {
     let trimmed = trim_text(text);
     let mut diagnostics: string[] = [];
-    let default_field = NativeStructLayoutField { name: "", type_annotation: "", offset: 0, size: 0, align: 0 };
+    let default_field = NativeStructLayoutField {
+        name: "",
+        type_annotation: "",
+        offset: 0,
+        size: 0,
+        align: 0
+    };
     if trimmed.length == 0 {
         diagnostics.push("struct " + struct_name + " layout field missing content");
-        return StructLayoutFieldParse { success: false, field: default_field, diagnostics: diagnostics };
+        return StructLayoutFieldParse {
+            success: false,
+            field: default_field,
+            diagnostics: diagnostics
+        };
     }
     let tokens = split_whitespace(trimmed);
     if tokens.length == 0 {
         diagnostics.push("struct " + struct_name + " layout field missing entries");
-        return StructLayoutFieldParse { success: false, field: default_field, diagnostics: diagnostics };
+        return StructLayoutFieldParse {
+            success: false,
+            field: default_field,
+            diagnostics: diagnostics
+        };
     }
     let field_name = tokens[0];
     if field_name.length == 0 {
         diagnostics.push("struct " + struct_name + " layout field missing name");
-        return StructLayoutFieldParse { success: false, field: default_field, diagnostics: diagnostics };
+        return StructLayoutFieldParse {
+            success: false,
+            field: default_field,
+            diagnostics: diagnostics
+        };
     }
     let mut type_text: string = "";
     let mut offset_found: boolean = false;
@@ -162,9 +181,7 @@ fn parse_struct_layout_field(text: string, struct_name: string) -> StructLayoutF
     let mut align_value: number = 0;
     let mut index: number = 1;
     loop {
-        if index >= tokens.length {
-            break;
-        }
+        if index >= tokens.length { break; }
         let token = tokens[index];
         if starts_with(token, "type=") {
             type_text = substring(token, 5, token.length);
@@ -217,16 +234,24 @@ fn parse_struct_layout_field(text: string, struct_name: string) -> StructLayoutF
         if offset_found {
             if size_found {
                 if align_found {
-                    if diagnostics.length == 0 {
-                        _let375 = true;
-                    }
+                    if diagnostics.length == 0 { _let375 = true; }
                 }
             }
         }
     }
     let success = _let375;
-    let field = NativeStructLayoutField { name: field_name, type_annotation: type_text, offset: offset_value, size: size_value, align: align_value };
-    return StructLayoutFieldParse { success: success, field: field, diagnostics: diagnostics };
+    let field = NativeStructLayoutField {
+        name: field_name,
+        type_annotation: type_text,
+        offset: offset_value,
+        size: size_value,
+        align: align_value
+    };
+    return StructLayoutFieldParse {
+        success: success,
+        field: field,
+        diagnostics: diagnostics
+    };
 }
 
 fn parse_enum_layout_header(text: string) -> EnumLayoutHeaderParse {
@@ -234,7 +259,16 @@ fn parse_enum_layout_header(text: string) -> EnumLayoutHeaderParse {
     let mut diagnostics: string[] = [];
     if tokens.length == 0 {
         diagnostics.push("enum layout header missing entries");
-        return EnumLayoutHeaderParse { success: false, name: "", size: 0, align: 0, tag_type: "", tag_size: 0, tag_align: 0, diagnostics: diagnostics };
+        return EnumLayoutHeaderParse {
+            success: false,
+            name: "",
+            size: 0,
+            align: 0,
+            tag_type: "",
+            tag_size: 0,
+            tag_align: 0,
+            diagnostics: diagnostics
+        };
     }
     let mut name_found: boolean = false;
     let mut size_found: boolean = false;
@@ -249,9 +283,7 @@ fn parse_enum_layout_header(text: string) -> EnumLayoutHeaderParse {
     let mut tag_align_value: number = 0;
     let mut index: number = 0;
     loop {
-        if index >= tokens.length {
-            break;
-        }
+        if index >= tokens.length { break; }
         let token = tokens[index];
         if starts_with(token, "name=") {
             name_value = substring(token, 5, token.length);
@@ -320,9 +352,7 @@ fn parse_enum_layout_header(text: string) -> EnumLayoutHeaderParse {
             if tag_type.length > 0 {
                 if tag_size_found {
                     if tag_align_found {
-                        if diagnostics.length == 0 {
-                            _let376 = true;
-                        }
+                        if diagnostics.length == 0 { _let376 = true; }
                     }
                 }
             }
@@ -344,20 +374,39 @@ fn parse_enum_layout_header(text: string) -> EnumLayoutHeaderParse {
 fn parse_enum_variant_layout(text: string, enum_name: string) -> EnumLayoutVariantParse {
     let trimmed = trim_text(text);
     let mut diagnostics: string[] = [];
-    let default_variant = NativeEnumVariantLayout { name: "", tag: 0, offset: 0, size: 0, align: 0, fields: [] };
+    let default_variant = NativeEnumVariantLayout {
+        name: "",
+        tag: 0,
+        offset: 0,
+        size: 0,
+        align: 0,
+        fields: []
+    };
     if trimmed.length == 0 {
         diagnostics.push("enum " + enum_name + " layout variant missing content");
-        return EnumLayoutVariantParse { success: false, variant: default_variant, diagnostics: diagnostics };
+        return EnumLayoutVariantParse {
+            success: false,
+            variant: default_variant,
+            diagnostics: diagnostics
+        };
     }
     let tokens = split_whitespace(trimmed);
     if tokens.length == 0 {
         diagnostics.push("enum " + enum_name + " layout variant missing entries");
-        return EnumLayoutVariantParse { success: false, variant: default_variant, diagnostics: diagnostics };
+        return EnumLayoutVariantParse {
+            success: false,
+            variant: default_variant,
+            diagnostics: diagnostics
+        };
     }
     let variant_name = tokens[0];
     if variant_name.length == 0 {
         diagnostics.push("enum " + enum_name + " layout variant missing name");
-        return EnumLayoutVariantParse { success: false, variant: default_variant, diagnostics: diagnostics };
+        return EnumLayoutVariantParse {
+            success: false,
+            variant: default_variant,
+            diagnostics: diagnostics
+        };
     }
     let mut tag_found: boolean = false;
     let mut offset_found: boolean = false;
@@ -369,9 +418,7 @@ fn parse_enum_variant_layout(text: string, enum_name: string) -> EnumLayoutVaria
     let mut align_value: number = 0;
     let mut index: number = 1;
     loop {
-        if index >= tokens.length {
-            break;
-        }
+        if index >= tokens.length { break; }
         let token = tokens[index];
         if starts_with(token, "tag=") {
             let value_text = substring(token, 4, token.length);
@@ -431,30 +478,55 @@ fn parse_enum_variant_layout(text: string, enum_name: string) -> EnumLayoutVaria
         if offset_found {
             if size_found {
                 if align_found {
-                    if diagnostics.length == 0 {
-                        _let377 = true;
-                    }
+                    if diagnostics.length == 0 { _let377 = true; }
                 }
             }
         }
     }
     let success = _let377;
-    let variant = NativeEnumVariantLayout { name: variant_name, tag: tag_value, offset: offset_value, size: size_value, align: align_value, fields: [] };
-    return EnumLayoutVariantParse { success: success, variant: variant, diagnostics: diagnostics };
+    let variant = NativeEnumVariantLayout {
+        name: variant_name,
+        tag: tag_value,
+        offset: offset_value,
+        size: size_value,
+        align: align_value,
+        fields: []
+    };
+    return EnumLayoutVariantParse {
+        success: success,
+        variant: variant,
+        diagnostics: diagnostics
+    };
 }
 
 fn parse_enum_payload_layout(text: string, enum_name: string) -> EnumLayoutPayloadParse {
     let trimmed = trim_text(text);
     let mut diagnostics: string[] = [];
-    let default_field = NativeStructLayoutField { name: "", type_annotation: "", offset: 0, size: 0, align: 0 };
+    let default_field = NativeStructLayoutField {
+        name: "",
+        type_annotation: "",
+        offset: 0,
+        size: 0,
+        align: 0
+    };
     if trimmed.length == 0 {
         diagnostics.push("enum " + enum_name + " layout payload missing content");
-        return EnumLayoutPayloadParse { success: false, variant_name: "", field: default_field, diagnostics: diagnostics };
+        return EnumLayoutPayloadParse {
+            success: false,
+            variant_name: "",
+            field: default_field,
+            diagnostics: diagnostics
+        };
     }
     let tokens = split_whitespace(trimmed);
     if tokens.length == 0 {
         diagnostics.push("enum " + enum_name + " layout payload missing entries");
-        return EnumLayoutPayloadParse { success: false, variant_name: "", field: default_field, diagnostics: diagnostics };
+        return EnumLayoutPayloadParse {
+            success: false,
+            variant_name: "",
+            field: default_field,
+            diagnostics: diagnostics
+        };
     }
     let identifier = tokens[0];
     let dot_index = index_of(identifier, ".");
@@ -464,7 +536,12 @@ fn parse_enum_payload_layout(text: string, enum_name: string) -> EnumLayoutPaylo
     if _dot_next >= identifier.length { _if378 = true; }
     if _if378 {
         diagnostics.push("enum " + enum_name + " layout payload identifier `" + identifier + "` invalid");
-        return EnumLayoutPayloadParse { success: false, variant_name: "", field: default_field, diagnostics: diagnostics };
+        return EnumLayoutPayloadParse {
+            success: false,
+            variant_name: "",
+            field: default_field,
+            diagnostics: diagnostics
+        };
     }
     let variant_name = substring(identifier, 0, dot_index);
     let field_name = substring(identifier, _dot_next, identifier.length);
@@ -477,9 +554,7 @@ fn parse_enum_payload_layout(text: string, enum_name: string) -> EnumLayoutPaylo
     let mut align_value: number = 0;
     let mut index: number = 1;
     loop {
-        if index >= tokens.length {
-            break;
-        }
+        if index >= tokens.length { break; }
         let token = tokens[index];
         if starts_with(token, "type=") {
             type_text = substring(token, 5, token.length);
@@ -532,14 +607,23 @@ fn parse_enum_payload_layout(text: string, enum_name: string) -> EnumLayoutPaylo
         if offset_found {
             if size_found {
                 if align_found {
-                    if diagnostics.length == 0 {
-                        _let379 = true;
-                    }
+                    if diagnostics.length == 0 { _let379 = true; }
                 }
             }
         }
     }
     let success = _let379;
-    let field = NativeStructLayoutField { name: field_name, type_annotation: type_text, offset: offset_value, size: size_value, align: align_value };
-    return EnumLayoutPayloadParse { success: success, variant_name: variant_name, field: field, diagnostics: diagnostics };
+    let field = NativeStructLayoutField {
+        name: field_name,
+        type_annotation: type_text,
+        offset: offset_value,
+        size: size_value,
+        align: align_value
+    };
+    return EnumLayoutPayloadParse {
+        success: success,
+        variant_name: variant_name,
+        field: field,
+        diagnostics: diagnostics
+    };
 }

--- a/compiler/src/native_ir_utils_parse.sfn
+++ b/compiler/src/native_ir_utils_parse.sfn
@@ -2,9 +2,6 @@
 //
 // IR definition and instruction parsing utilities: imports, cases, decorators,
 // interfaces, structs, enums, bindings, parameters, and effects.
-
-import { substring } from "./string_utils";
-
 import {
     BindingComponents,
     CaseComponents,
@@ -24,7 +21,6 @@ import {
     NativeStructField,
     StructHeaderParse,
 } from "./native_ir";
-
 import {
     find_matching_angle,
     find_matching_paren,
@@ -40,6 +36,7 @@ import {
     trim_text,
     trim_trailing_delimiters,
 } from "./native_ir_utils_text";
+import { substring } from "./string_utils";
 
 export {
     parse_case_instruction,
@@ -73,7 +70,10 @@ export {
 fn parse_case_instruction(line: string) -> NativeInstruction {
     let body = trim_text(strip_prefix(line, ".case "));
     let split = split_case_components(body);
-    return NativeInstruction.Case { pattern: split.pattern, guard: split.guard };
+    return NativeInstruction.Case {
+        pattern: split.pattern,
+        guard: split.guard
+    };
 }
 
 fn parse_inline_case_instruction(line: string) -> NativeInstruction[] {
@@ -86,7 +86,9 @@ fn parse_inline_case_instruction(line: string) -> NativeInstruction[] {
     let remainder = trim_trailing_delimiters(trim_text(substring(trimmed, arrow_index + 2, trimmed.length)));
     let split = split_case_components(head);
     let mut instructions: NativeInstruction[] = [];
-    instructions.push(NativeInstruction.Case { pattern: split.pattern, guard: split.guard });
+    instructions.push(NativeInstruction.Case {
+        pattern: split.pattern, guard: split.guard
+    });
     if remainder.length == 0 {
         instructions.push(NativeInstruction.Noop());
         return instructions;
@@ -103,7 +105,10 @@ fn parse_inline_case_body_instruction(body: string) -> NativeInstruction {
         return NativeInstruction.Return { expression: value, span: null };
     }
     if starts_with(lowered, "eval ") {
-        return NativeInstruction.Expression { expression: trim_trailing_delimiters(trim_text(strip_prefix(lowered, "eval "))), span: null };
+        return NativeInstruction.Expression {
+            expression: trim_trailing_delimiters(trim_text(strip_prefix(lowered, "eval "))),
+            span: null
+        };
     }
     return NativeInstruction.Expression { expression: lowered, span: null };
 }
@@ -128,9 +133,7 @@ fn split_case_components(text: string) -> CaseComponents {
 
 fn parse_import_entry(kind: string, entry: string) -> NativeImport? {
     let trimmed = trim_text(entry);
-    if trimmed.length == 0 {
-        return null;
-    }
+    if trimmed.length == 0 { return null; }
     let mut module_text: string = trimmed;
     let mut specifiers: NativeImportSpecifier[] = [];
     let brace_index = index_of(trimmed, "{");
@@ -139,33 +142,29 @@ fn parse_import_entry(kind: string, entry: string) -> NativeImport? {
         let mut _if362: boolean = false;
         if close_index < 0 { _if362 = true; }
         if close_index <= brace_index { _if362 = true; }
-        if _if362 {
-            return null;
-        }
+        if _if362 { return null; }
         module_text = trim_text(substring(trimmed, 0, brace_index));
         let names_segment = substring(trimmed, brace_index + 1, close_index);
         specifiers = parse_import_specifiers(names_segment);
     }
     module_text = strip_quotes(trim_text(module_text));
-    return NativeImport { kind: kind, module: module_text, specifiers: specifiers };
+    return NativeImport {
+        kind: kind,
+        module: module_text,
+        specifiers: specifiers
+    };
 }
 
 fn parse_import_specifiers(text: string) -> NativeImportSpecifier[] {
     let trimmed = trim_text(text);
-    if trimmed.length == 0 {
-        return [];
-    }
+    if trimmed.length == 0 { return []; }
     let entries = split_comma_separated(trimmed);
     let mut specifiers: NativeImportSpecifier[] = [];
     let mut index: number = 0;
     loop {
-        if index >= entries.length {
-            break;
-        }
+        if index >= entries.length { break; }
         let parsed = parse_single_specifier(entries[index]);
-        if parsed.name.length > 0 {
-            specifiers.push(parsed);
-        }
+        if parsed.name.length > 0 { specifiers.push(parsed); }
         index += 1;
     }
     return specifiers;
@@ -191,34 +190,20 @@ fn parse_single_specifier(entry: string) -> NativeImportSpecifier {
 
 fn parse_decorator_name(line: string) -> string? {
     let trimmed = trim_text(line);
-    if !starts_with(trimmed, ".decorator") {
-        return null;
-    }
+    if !starts_with(trimmed, ".decorator") { return null; }
     let tail = trim_text(strip_prefix(trimmed, ".decorator"));
-    if tail.length == 0 {
-        return null;
-    }
-    if tail[0] != "@" {
-        return null;
-    }
+    if tail.length == 0 { return null; }
+    if tail[0] != "@" { return null; }
     let mut index: number = 1;
     loop {
-        if index >= tail.length {
-            break;
-        }
+        if index >= tail.length { break; }
         let ch = tail[index];
-        if ch == "(" {
-            break;
-        }
-        if is_trim_char(ch) {
-            break;
-        }
+        if ch == "(" { break; }
+        if is_trim_char(ch) { break; }
         index += 1;
     }
     let name = trim_text(substring(tail, 1, index));
-    if name.length == 0 {
-        return null;
-    }
+    if name.length == 0 { return null; }
     return name;
 }
 
@@ -236,7 +221,11 @@ fn parse_interface_definition(lines: string[], start_index: number) -> Interface
     let interface_name = header_parse.name;
     if interface_name.length == 0 {
         diagnostics.push("unable to parse interface header: " + header);
-        return InterfaceParseResult { definition: null, next_index: start_index + 1, diagnostics: diagnostics };
+        return InterfaceParseResult {
+            definition: null,
+            next_index: start_index + 1,
+            diagnostics: diagnostics
+        };
     }
 
     let mut signatures: NativeInterfaceSignature[] = [];
@@ -245,7 +234,11 @@ fn parse_interface_definition(lines: string[], start_index: number) -> Interface
         if index >= lines.length {
             diagnostics.push("unterminated interface " + interface_name);
             return InterfaceParseResult {
-                definition: NativeInterface { name: interface_name, type_parameters: header_parse.type_parameters, signatures: signatures },
+                definition: NativeInterface {
+                    name: interface_name,
+                    type_parameters: header_parse.type_parameters,
+                    signatures: signatures
+                },
                 next_index: index,
                 diagnostics: diagnostics,
             };
@@ -285,7 +278,11 @@ fn parse_interface_definition(lines: string[], start_index: number) -> Interface
     }
 
     return InterfaceParseResult {
-        definition: NativeInterface { name: interface_name, type_parameters: header_parse.type_parameters, signatures: signatures },
+        definition: NativeInterface {
+            name: interface_name,
+            type_parameters: header_parse.type_parameters,
+            signatures: signatures
+        },
         next_index: index,
         diagnostics: diagnostics,
     };
@@ -300,14 +297,16 @@ fn parse_struct_header(text: string) -> StructHeaderParse {
             let list_text = trim_text(strip_prefix(base.remainder, "implements "));
             if list_text.length == 0 {
                 diagnostics.push("struct " + base.name + " header missing implements list");
-            } else {
-                implements = parse_implements_list(list_text);
-            }
+            } else { implements = parse_implements_list(list_text); }
         } else {
             diagnostics.push("struct " + base.name + " header has unsupported segment `" + base.remainder + "`");
         }
     }
-    return StructHeaderParse { name: base.name, implements: implements, diagnostics: diagnostics };
+    return StructHeaderParse {
+        name: base.name,
+        implements: implements,
+        diagnostics: diagnostics
+    };
 }
 
 fn parse_interface_header(text: string) -> InterfaceHeaderParse {
@@ -316,7 +315,11 @@ fn parse_interface_header(text: string) -> InterfaceHeaderParse {
     if base.remainder.length > 0 {
         diagnostics.push("interface " + base.name + " header has unsupported segment `" + base.remainder + "`");
     }
-    return InterfaceHeaderParse { name: base.name, type_parameters: base.type_parameters, diagnostics: diagnostics };
+    return InterfaceHeaderParse {
+        name: base.name,
+        type_parameters: base.type_parameters,
+        diagnostics: diagnostics
+    };
 }
 
 fn parse_interface_signature(text: string, interface_name: string) -> InterfaceSignatureParse {
@@ -333,7 +336,11 @@ fn parse_interface_signature(text: string, interface_name: string) -> InterfaceS
     let trimmed = trim_trailing_delimiters(trim_text(text));
     if trimmed.length == 0 {
         diagnostics.push("interface " + interface_name + " signature missing content");
-        return InterfaceSignatureParse { success: false, signature: default_signature, diagnostics: diagnostics };
+        return InterfaceSignatureParse {
+            success: false,
+            signature: default_signature,
+            diagnostics: diagnostics
+        };
     }
 
     let mut remainder: string = trimmed;
@@ -346,13 +353,21 @@ fn parse_interface_signature(text: string, interface_name: string) -> InterfaceS
     let paren_index = index_of(remainder, "(");
     if paren_index < 0 {
         diagnostics.push("interface " + interface_name + " signature missing parameter list: " + trimmed);
-        return InterfaceSignatureParse { success: false, signature: default_signature, diagnostics: diagnostics };
+        return InterfaceSignatureParse {
+            success: false,
+            signature: default_signature,
+            diagnostics: diagnostics
+        };
     }
 
     let close_index = find_matching_paren(remainder, paren_index);
     if close_index < 0 {
         diagnostics.push("interface " + interface_name + " signature has unterminated parameter list: " + trimmed);
-        return InterfaceSignatureParse { success: false, signature: default_signature, diagnostics: diagnostics };
+        return InterfaceSignatureParse {
+            success: false,
+            signature: default_signature,
+            diagnostics: diagnostics
+        };
     }
 
     let head = trim_text(substring(remainder, 0, paren_index));
@@ -378,15 +393,11 @@ fn parse_interface_signature(text: string, interface_name: string) -> InterfaceS
         let entries = split_parameter_entries(parameter_text);
         let mut entry_index: number = 0;
         loop {
-            if entry_index >= entries.length {
-                break;
-            }
+            if entry_index >= entries.length { break; }
             let parsed = parse_parameter_entry(entries[entry_index], null);
             if parsed == null {
                 diagnostics.push("interface " + interface_name + " signature `" + method_name + "` has invalid parameter `" + entries[entry_index] + "`");
-            } else {
-                parameters.push(parsed);
-            }
+            } else { parameters.push(parsed); }
             entry_index += 1;
         }
     }
@@ -404,9 +415,7 @@ fn parse_interface_signature(text: string, interface_name: string) -> InterfaceS
         if suffix.length > 0 {
             if starts_with(suffix, "->") {
                 let type_text = trim_text(strip_prefix(suffix, "->"));
-                if type_text.length > 0 {
-                    return_type = type_text;
-                }
+                if type_text.length > 0 { return_type = type_text; }
             } else {
                 diagnostics.push("interface " + interface_name + " signature `" + method_name + "` has unsupported suffix `" + suffix + "`");
             }
@@ -437,19 +446,26 @@ fn parse_interface_signature(text: string, interface_name: string) -> InterfaceS
     };
     let mut _let366: boolean = false;
     if method_name.length > 0 {
-        if diagnostics.length == 0 {
-            _let366 = true;
-        }
+        if diagnostics.length == 0 { _let366 = true; }
     }
     let success = _let366;
-    return InterfaceSignatureParse { success: success, signature: signature, diagnostics: diagnostics };
+    return InterfaceSignatureParse {
+        success: success,
+        signature: signature,
+        diagnostics: diagnostics
+    };
 }
 
 fn parse_header_name_and_remainder(text: string) -> HeaderNameParse {
     let mut diagnostics: string[] = [];
     let trimmed = trim_text(text);
     if trimmed.length == 0 {
-        return HeaderNameParse { name: "", type_parameters: [], remainder: "", diagnostics: diagnostics };
+        return HeaderNameParse {
+            name: "",
+            type_parameters: [],
+            remainder: "",
+            diagnostics: diagnostics
+        };
     }
     let mut name: string = trimmed;
     let mut remainder: string = "";
@@ -460,7 +476,12 @@ fn parse_header_name_and_remainder(text: string) -> HeaderNameParse {
         if close_index < 0 {
             diagnostics.push("header `" + text + "` missing closing `>`");
             name = strip_generics(trimmed);
-            return HeaderNameParse { name: name, type_parameters: type_parameters, remainder: remainder, diagnostics: diagnostics };
+            return HeaderNameParse {
+                name: name,
+                type_parameters: type_parameters,
+                remainder: remainder,
+                diagnostics: diagnostics
+            };
         }
         name = trim_text(substring(trimmed, 0, generics_index));
         let generics_text = substring(trimmed, generics_index + 1, close_index);
@@ -474,62 +495,56 @@ fn parse_header_name_and_remainder(text: string) -> HeaderNameParse {
         }
     }
     name = strip_generics(name);
-    return HeaderNameParse { name: name, type_parameters: type_parameters, remainder: remainder, diagnostics: diagnostics };
+    return HeaderNameParse {
+        name: name,
+        type_parameters: type_parameters,
+        remainder: remainder,
+        diagnostics: diagnostics
+    };
 }
 
 fn parse_type_parameter_entries(text: string) -> string[] {
     let trimmed = trim_text(text);
-    if trimmed.length == 0 {
-        return [];
-    }
+    if trimmed.length == 0 { return []; }
     return split_top_level_commas(trimmed);
 }
 
 fn parse_implements_list(text: string) -> string[] {
     let trimmed = trim_text(text);
-    if trimmed.length == 0 {
-        return [];
-    }
+    if trimmed.length == 0 { return []; }
     return split_top_level_commas(trimmed);
 }
 
 fn parse_enum_variant_line(text: string) -> NativeEnumVariant? {
     let trimmed = trim_trailing_delimiters(trim_text(text));
-    if trimmed.length == 0 {
-        return null;
-    }
+    if trimmed.length == 0 { return null; }
     let brace_index = index_of(trimmed, "{");
     if brace_index < 0 {
-        return NativeEnumVariant { name: strip_generics(trimmed), fields: [] };
+        return NativeEnumVariant {
+            name: strip_generics(trimmed),
+            fields: []
+        };
     }
     let close_index = last_index_of(trimmed, "}");
     let mut _if370: boolean = false;
     if close_index < 0 { _if370 = true; }
     if close_index <= brace_index { _if370 = true; }
-    if _if370 {
-        return null;
-    }
+    if _if370 { return null; }
     let name_text = strip_generics(trim_text(substring(trimmed, 0, brace_index)));
-    if name_text.length == 0 {
-        return null;
-    }
+    if name_text.length == 0 { return null; }
     let fields_segment = substring(trimmed, brace_index + 1, close_index);
     let entries = split_enum_field_entries(fields_segment);
     let mut fields: NativeEnumVariantField[] = [];
     let mut index: number = 0;
     loop {
-        if index >= entries.length {
-            break;
-        }
+        if index >= entries.length { break; }
         let entry = trim_trailing_delimiters(trim_text(entries[index]));
         if entry.length == 0 {
             index += 1;
             continue;
         }
         let parsed_field = parse_enum_variant_field(entry);
-        if parsed_field == null {
-            return null;
-        }
+        if parsed_field == null { return null; }
         fields.push(parsed_field);
         index += 1;
     }
@@ -542,52 +557,38 @@ fn split_enum_field_entries(text: string) -> string[] {
     let mut depth: number = 0;
     let mut index: number = 0;
     loop {
-        if index >= text.length {
-            break;
-        }
+        if index >= text.length { break; }
         let ch = text[index];
         let mut _if371: boolean = false;
         if ch == "{" { _if371 = true; }
         if ch == "[" { _if371 = true; }
         if ch == "(" { _if371 = true; }
-        if _if371 {
-            depth += 1;
-        } else {
+        if _if371 { depth += 1; } else {
             let mut _elif393: boolean = false;
             if ch == "}" { _elif393 = true; }
             if ch == "]" { _elif393 = true; }
             if ch == ")" { _elif393 = true; }
             if _elif393 {
-                if depth > 0 {
-                    depth -= 1;
-                }
+                if depth > 0 { depth -= 1; }
             }
         }
         let mut _if372: boolean = false;
         if ch == ";" {
-            if depth == 0 {
-                _if372 = true;
-            }
+            if depth == 0 { _if372 = true; }
         }
         if _if372 {
             entries.push(current);
             current = "";
-        } else {
-            current = current + ch;
-        }
+        } else { current = current + ch; }
         index += 1;
     }
-    if current.length > 0 {
-        entries.push(current);
-    }
+    if current.length > 0 { entries.push(current); }
     return entries;
 }
 
 fn parse_enum_variant_field(text: string) -> NativeEnumVariantField? {
     let mut trimmed = trim_text(text);
-    if trimmed.length == 0 {
-        return null;
-    }
+    if trimmed.length == 0 { return null; }
     let mut is_mutable: boolean = false;
     if starts_with(trimmed, "mut ") {
         is_mutable = true;
@@ -612,22 +613,20 @@ fn parse_enum_variant_field(text: string) -> NativeEnumVariantField? {
             sep_len = 4;
         }
     }
-    if arrow_index < 0 {
-        return null;
-    }
+    if arrow_index < 0 { return null; }
     let name = trim_text(substring(trimmed, 0, arrow_index));
-    if name.length == 0 {
-        return null;
-    }
+    if name.length == 0 { return null; }
     let type_text = trim_text(substring(trimmed, arrow_index + sep_len, trimmed.length));
-    return NativeEnumVariantField { name: name, type_annotation: type_text, mutable: is_mutable };
+    return NativeEnumVariantField {
+        name: name,
+        type_annotation: type_text,
+        mutable: is_mutable
+    };
 }
 
 fn parse_struct_field_line(text: string) -> NativeStructField? {
     let mut trimmed = trim_text(text);
-    if trimmed.length == 0 {
-        return null;
-    }
+    if trimmed.length == 0 { return null; }
     let mut is_mutable: boolean = false;
     if starts_with(trimmed, "mut ") {
         is_mutable = true;
@@ -652,15 +651,15 @@ fn parse_struct_field_line(text: string) -> NativeStructField? {
             sep_len = 4;
         }
     }
-    if arrow_index < 0 {
-        return null;
-    }
+    if arrow_index < 0 { return null; }
     let name = trim_text(substring(trimmed, 0, arrow_index));
-    if name.length == 0 {
-        return null;
-    }
+    if name.length == 0 { return null; }
     let type_text = trim_text(substring(trimmed, arrow_index + sep_len, trimmed.length));
-    return NativeStructField { name: name, type_annotation: type_text, mutable: is_mutable };
+    return NativeStructField {
+        name: name,
+        type_annotation: type_text,
+        mutable: is_mutable
+    };
 }
 
 fn parse_let_instruction(line: string, span: NativeSourceSpan?, value_span: NativeSourceSpan?) -> NativeInstruction {
@@ -686,17 +685,13 @@ fn parse_binding_components(text: string) -> BindingComponents {
     let mut name: string = "";
     let mut index: number = 0;
     loop {
-        if index >= text.length {
-            break;
-        }
+        if index >= text.length { break; }
         let ch = text[index];
         let mut _if380: boolean = false;
         if ch == " " { _if380 = true; }
         if ch == ":" { _if380 = true; }
         if ch == "=" { _if380 = true; }
-        if _if380 {
-            break;
-        }
+        if _if380 { break; }
         name = name + ch;
         index += 1;
     }
@@ -711,35 +706,29 @@ fn parse_binding_components(text: string) -> BindingComponents {
             if assign_index >= 0 {
                 type_annotation = trim_text(substring(remainder, 0, assign_index));
                 let value_text = trim_text(substring(remainder, assign_index + 1, remainder.length));
-                if value_text.length > 0 {
-                    value = value_text;
-                }
-            } else {
-                type_annotation = trim_text(remainder);
-            }
+                if value_text.length > 0 { value = value_text; }
+            } else { type_annotation = trim_text(remainder); }
         } else if starts_with(remainder, ":") {
             remainder = trim_text(strip_prefix(remainder, ":"));
             let assign_index = index_of(remainder, "=");
             if assign_index >= 0 {
                 type_annotation = trim_text(substring(remainder, 0, assign_index));
                 let value_text = trim_text(substring(remainder, assign_index + 1, remainder.length));
-                if value_text.length > 0 {
-                    value = value_text;
-                }
-            } else {
-                type_annotation = trim_text(remainder);
-            }
+                if value_text.length > 0 { value = value_text; }
+            } else { type_annotation = trim_text(remainder); }
         } else if starts_with(remainder, "=") {
             let value_text = trim_text(strip_prefix(remainder, "="));
-            if value_text.length > 0 {
-                value = value_text;
-            }
+            if value_text.length > 0 { value = value_text; }
         } else {
             // Fallback: treat the remainder as an initializer without prefix.
             value = remainder;
         }
     }
-    return BindingComponents { name: name, type_annotation: type_annotation, value: value };
+    return BindingComponents {
+        name: name,
+        type_annotation: type_annotation,
+        value: value
+    };
 }
 
 fn parse_function_name(header: string) -> string {
@@ -761,9 +750,7 @@ fn parse_function_name(header: string) -> string {
 
 fn parse_parameter_entry(body: string, span: NativeSourceSpan?) -> NativeParameter? {
     let mut trimmed = trim_text(body);
-    if trimmed.length == 0 {
-        return null;
-    }
+    if trimmed.length == 0 { return null; }
     let mut is_mutable: boolean = false;
     if starts_with(trimmed, "mut ") {
         is_mutable = true;
@@ -772,25 +759,19 @@ fn parse_parameter_entry(body: string, span: NativeSourceSpan?) -> NativeParamet
     let mut name: string = "";
     let mut index: number = 0;
     loop {
-        if index >= trimmed.length {
-            break;
-        }
+        if index >= trimmed.length { break; }
         let ch = trimmed[index];
         let mut _if381: boolean = false;
         if ch == " " { _if381 = true; }
         if ch == "-" { _if381 = true; }
         if ch == "=" { _if381 = true; }
         if ch == ":" { _if381 = true; }
-        if _if381 {
-            break;
-        }
+        if _if381 { break; }
         name = name + ch;
         index += 1;
     }
     name = trim_text(name);
-    if name.length == 0 {
-        return null;
-    }
+    if name.length == 0 { return null; }
     let mut type_annotation: string = "";
     let mut default_value: string? = null;
     let mut remainder = trim_text(substring(trimmed, index, trimmed.length));
@@ -801,29 +782,19 @@ fn parse_parameter_entry(body: string, span: NativeSourceSpan?) -> NativeParamet
             if assign_index >= 0 {
                 type_annotation = trim_text(substring(remainder, 0, assign_index));
                 let default_text = trim_text(substring(remainder, assign_index + 1, remainder.length));
-                if default_text.length > 0 {
-                    default_value = default_text;
-                }
-            } else {
-                type_annotation = trim_text(remainder);
-            }
+                if default_text.length > 0 { default_value = default_text; }
+            } else { type_annotation = trim_text(remainder); }
         } else if starts_with(remainder, "->") {
             remainder = trim_text(strip_prefix(remainder, "->"));
             let assign_index = index_of(remainder, "=");
             if assign_index >= 0 {
                 type_annotation = trim_text(substring(remainder, 0, assign_index));
                 let default_text = trim_text(substring(remainder, assign_index + 1, remainder.length));
-                if default_text.length > 0 {
-                    default_value = default_text;
-                }
-            } else {
-                type_annotation = trim_text(remainder);
-            }
+                if default_text.length > 0 { default_value = default_text; }
+            } else { type_annotation = trim_text(remainder); }
         } else if starts_with(remainder, "=") {
             let default_text = trim_text(strip_prefix(remainder, "="));
-            if default_text.length > 0 {
-                default_value = default_text;
-            }
+            if default_text.length > 0 { default_value = default_text; }
         }
     }
     return NativeParameter {
@@ -837,65 +808,39 @@ fn parse_parameter_entry(body: string, span: NativeSourceSpan?) -> NativeParamet
 
 fn line_looks_like_parameter_entry(text: string) -> boolean {
     let trimmed = trim_text(text);
-    if trimmed.length == 0 {
-        return false;
-    }
-    if starts_with(trimmed, ".") {
-        return false;
-    }
-    if starts_with(trimmed, ";") {
-        return false;
-    }
+    if trimmed.length == 0 { return false; }
+    if starts_with(trimmed, ".") { return false; }
+    if starts_with(trimmed, ";") { return false; }
     let arrow_index = index_of(trimmed, "->");
     let colon_index = index_of(trimmed, ":");
     let mut sep_index: number = -1;
-    if colon_index >= 0 {
-        sep_index = colon_index;
-    }
+    if colon_index >= 0 { sep_index = colon_index; }
     if arrow_index >= 0 {
-        if sep_index < 0 {
-            sep_index = arrow_index;
-        } else if arrow_index < sep_index {
+        if sep_index < 0 { sep_index = arrow_index; } else if arrow_index < sep_index {
             sep_index = arrow_index;
         }
     }
     if sep_index >= 0 {
         let mut head = trim_text(substring(trimmed, 0, sep_index));
-        if head.length == 0 {
-            return false;
-        }
+        if head.length == 0 { return false; }
         if starts_with(head, "mut ") {
             head = trim_text(strip_prefix(head, "mut "));
         }
-        if head.length == 0 {
-            return false;
-        }
-        if index_of(head, " ") >= 0 {
-            return false;
-        }
-        if index_of(head, "\t") >= 0 {
-            return false;
-        }
+        if head.length == 0 { return false; }
+        if index_of(head, " ") >= 0 { return false; }
+        if index_of(head, "\t") >= 0 { return false; }
         return true;
     }
     let assign_index = index_of(trimmed, "=");
     if assign_index >= 0 {
         let mut head = trim_text(substring(trimmed, 0, assign_index));
-        if head.length == 0 {
-            return false;
-        }
+        if head.length == 0 { return false; }
         if starts_with(head, "mut ") {
             head = trim_text(strip_prefix(head, "mut "));
         }
-        if head.length == 0 {
-            return false;
-        }
-        if index_of(head, " ") >= 0 {
-            return false;
-        }
-        if index_of(head, "\t") >= 0 {
-            return false;
-        }
+        if head.length == 0 { return false; }
+        if index_of(head, " ") >= 0 { return false; }
+        if index_of(head, "\t") >= 0 { return false; }
         return true;
     }
     return false;
@@ -909,9 +854,7 @@ fn split_parameter_entries(body: string) -> string[] {
     let mut quote: string = "";
 
     loop {
-        if index >= body.length {
-            break;
-        }
+        if index >= body.length { break; }
         let ch = body[index];
 
         if quote.length > 0 {
@@ -924,9 +867,7 @@ fn split_parameter_entries(body: string) -> string[] {
                     continue;
                 }
             }
-            if ch == quote {
-                quote = "";
-            }
+            if ch == quote { quote = ""; }
             index += 1;
             continue;
         }
@@ -957,9 +898,7 @@ fn split_parameter_entries(body: string) -> string[] {
         if ch == "]" { _if384 = true; }
         if ch == "}" { _if384 = true; }
         if _if384 {
-            if depth > 0 {
-                depth -= 1;
-            }
+            if depth > 0 { depth -= 1; }
             current = current + ch;
             index += 1;
             continue;
@@ -968,9 +907,7 @@ fn split_parameter_entries(body: string) -> string[] {
         if ch == "," {
             if depth == 0 {
                 let segment = trim_text(current);
-                if segment.length > 0 {
-                    entries.push(segment);
-                }
+                if segment.length > 0 { entries.push(segment); }
                 current = "";
                 index += 1;
                 continue;
@@ -982,17 +919,13 @@ fn split_parameter_entries(body: string) -> string[] {
     }
 
     let segment = trim_text(current);
-    if segment.length > 0 {
-        entries.push(segment);
-    }
+    if segment.length > 0 { entries.push(segment); }
 
     return entries;
 }
 
 fn parse_effect_list(text: string) -> string[] {
     let trimmed = trim_text(text);
-    if trimmed == "none" {
-        return [];
-    }
+    if trimmed == "none" { return []; }
     return split_comma_separated(trimmed);
 }

--- a/compiler/src/native_ir_utils_parse.sfn
+++ b/compiler/src/native_ir_utils_parse.sfn
@@ -19,7 +19,7 @@ import {
     NativeParameter,
     NativeSourceSpan,
     NativeStructField,
-    StructHeaderParse,
+    StructHeaderParse
 } from "./native_ir";
 import {
     find_matching_angle,
@@ -34,7 +34,7 @@ import {
     strip_prefix,
     strip_quotes,
     trim_text,
-    trim_trailing_delimiters,
+    trim_trailing_delimiters
 } from "./native_ir_utils_text";
 import { substring } from "./string_utils";
 
@@ -64,7 +64,7 @@ export {
     parse_parameter_entry,
     line_looks_like_parameter_entry,
     split_parameter_entries,
-    parse_effect_list,
+    parse_effect_list
 };
 
 fn parse_case_instruction(line: string) -> NativeInstruction {
@@ -83,7 +83,8 @@ fn parse_inline_case_instruction(line: string) -> NativeInstruction[] {
         return [NativeInstruction.Unknown { text: line }];
     }
     let head = trim_text(substring(trimmed, 0, arrow_index));
-    let remainder = trim_trailing_delimiters(trim_text(substring(trimmed, arrow_index + 2, trimmed.length)));
+    let remainder = trim_trailing_delimiters(trim_text(substring(trimmed, arrow_index
+        + 2, trimmed.length)));
     let split = split_case_components(head);
     let mut instructions: NativeInstruction[] = [];
     instructions.push(NativeInstruction.Case {
@@ -240,7 +241,7 @@ fn parse_interface_definition(lines: string[], start_index: number) -> Interface
                     signatures: signatures
                 },
                 next_index: index,
-                diagnostics: diagnostics,
+                diagnostics: diagnostics
             };
         }
         let raw_line = trim_text(lines[index]);
@@ -284,7 +285,7 @@ fn parse_interface_definition(lines: string[], start_index: number) -> Interface
             signatures: signatures
         },
         next_index: index,
-        diagnostics: diagnostics,
+        diagnostics: diagnostics
     };
 }
 
@@ -296,10 +297,14 @@ fn parse_struct_header(text: string) -> StructHeaderParse {
         if starts_with(base.remainder, "implements ") {
             let list_text = trim_text(strip_prefix(base.remainder, "implements "));
             if list_text.length == 0 {
-                diagnostics.push("struct " + base.name + " header missing implements list");
+                diagnostics.push("struct " + base.name
+                    + " header missing implements list");
             } else { implements = parse_implements_list(list_text); }
         } else {
-            diagnostics.push("struct " + base.name + " header has unsupported segment `" + base.remainder + "`");
+            diagnostics.push("struct " + base.name
+                + " header has unsupported segment `"
+                + base.remainder
+                + "`");
         }
     }
     return StructHeaderParse {
@@ -313,7 +318,10 @@ fn parse_interface_header(text: string) -> InterfaceHeaderParse {
     let base = parse_header_name_and_remainder(text);
     let mut diagnostics: string[] = base.diagnostics;
     if base.remainder.length > 0 {
-        diagnostics.push("interface " + base.name + " header has unsupported segment `" + base.remainder + "`");
+        diagnostics.push("interface " + base.name
+            + " header has unsupported segment `"
+            + base.remainder
+            + "`");
     }
     return InterfaceHeaderParse {
         name: base.name,
@@ -330,12 +338,13 @@ fn parse_interface_signature(text: string, interface_name: string) -> InterfaceS
         type_parameters: [],
         parameters: [],
         return_type: "void",
-        effects: [],
+        effects: []
     };
 
     let trimmed = trim_trailing_delimiters(trim_text(text));
     if trimmed.length == 0 {
-        diagnostics.push("interface " + interface_name + " signature missing content");
+        diagnostics.push("interface " + interface_name
+            + " signature missing content");
         return InterfaceSignatureParse {
             success: false,
             signature: default_signature,
@@ -352,7 +361,9 @@ fn parse_interface_signature(text: string, interface_name: string) -> InterfaceS
 
     let paren_index = index_of(remainder, "(");
     if paren_index < 0 {
-        diagnostics.push("interface " + interface_name + " signature missing parameter list: " + trimmed);
+        diagnostics.push("interface " + interface_name
+            + " signature missing parameter list: "
+            + trimmed);
         return InterfaceSignatureParse {
             success: false,
             signature: default_signature,
@@ -362,7 +373,9 @@ fn parse_interface_signature(text: string, interface_name: string) -> InterfaceS
 
     let close_index = find_matching_paren(remainder, paren_index);
     if close_index < 0 {
-        diagnostics.push("interface " + interface_name + " signature has unterminated parameter list: " + trimmed);
+        diagnostics.push("interface " + interface_name
+            + " signature has unterminated parameter list: "
+            + trimmed);
         return InterfaceSignatureParse {
             success: false,
             signature: default_signature,
@@ -379,11 +392,17 @@ fn parse_interface_signature(text: string, interface_name: string) -> InterfaceS
         _ci += 1;
     }
     if name_parse.remainder.length > 0 {
-        diagnostics.push("interface " + interface_name + " signature `" + trimmed + "` has unsupported segment `" + name_parse.remainder + "`");
+        diagnostics.push("interface " + interface_name + " signature `"
+            + trimmed
+            + "` has unsupported segment `"
+            + name_parse.remainder
+            + "`");
     }
     let method_name = name_parse.name;
     if method_name.length == 0 {
-        diagnostics.push("interface " + interface_name + " signature `" + trimmed + "` missing name");
+        diagnostics.push("interface " + interface_name + " signature `"
+            + trimmed
+            + "` missing name");
     }
 
     let parameters_section = substring(remainder, paren_index + 1, close_index);
@@ -396,7 +415,11 @@ fn parse_interface_signature(text: string, interface_name: string) -> InterfaceS
             if entry_index >= entries.length { break; }
             let parsed = parse_parameter_entry(entries[entry_index], null);
             if parsed == null {
-                diagnostics.push("interface " + interface_name + " signature `" + method_name + "` has invalid parameter `" + entries[entry_index] + "`");
+                diagnostics.push("interface " + interface_name + " signature `"
+                    + method_name
+                    + "` has invalid parameter `"
+                    + entries[entry_index]
+                    + "`");
             } else { parameters.push(parsed); }
             entry_index += 1;
         }
@@ -417,7 +440,11 @@ fn parse_interface_signature(text: string, interface_name: string) -> InterfaceS
                 let type_text = trim_text(strip_prefix(suffix, "->"));
                 if type_text.length > 0 { return_type = type_text; }
             } else {
-                diagnostics.push("interface " + interface_name + " signature `" + method_name + "` has unsupported suffix `" + suffix + "`");
+                diagnostics.push("interface " + interface_name + " signature `"
+                    + method_name
+                    + "` has unsupported suffix `"
+                    + suffix
+                    + "`");
             }
         }
         if effect_segment.length > 0 {
@@ -431,7 +458,11 @@ fn parse_interface_signature(text: string, interface_name: string) -> InterfaceS
                 let body = substring(effect_segment, 2, effect_segment.length - 1);
                 effects = parse_effect_list(body);
             } else {
-                diagnostics.push("interface " + interface_name + " signature `" + method_name + "` has invalid effects annotation `" + effect_segment + "`");
+                diagnostics.push("interface " + interface_name + " signature `"
+                    + method_name
+                    + "` has invalid effects annotation `"
+                    + effect_segment
+                    + "`");
             }
         }
     }
@@ -442,7 +473,7 @@ fn parse_interface_signature(text: string, interface_name: string) -> InterfaceS
         type_parameters: name_parse.type_parameters,
         parameters: parameters,
         return_type: return_type,
-        effects: effects,
+        effects: effects
     };
     let mut _let366: boolean = false;
     if method_name.length > 0 {
@@ -677,7 +708,7 @@ fn parse_let_instruction(line: string, span: NativeSourceSpan?, value_span: Nati
         type_annotation: parsed.type_annotation,
         value: parsed.value,
         span: span,
-        value_span: value_span,
+        value_span: value_span
     };
 }
 
@@ -781,7 +812,8 @@ fn parse_parameter_entry(body: string, span: NativeSourceSpan?) -> NativeParamet
             let assign_index = index_of(remainder, "=");
             if assign_index >= 0 {
                 type_annotation = trim_text(substring(remainder, 0, assign_index));
-                let default_text = trim_text(substring(remainder, assign_index + 1, remainder.length));
+                let default_text = trim_text(substring(remainder, assign_index
+                    + 1, remainder.length));
                 if default_text.length > 0 { default_value = default_text; }
             } else { type_annotation = trim_text(remainder); }
         } else if starts_with(remainder, "->") {
@@ -789,7 +821,8 @@ fn parse_parameter_entry(body: string, span: NativeSourceSpan?) -> NativeParamet
             let assign_index = index_of(remainder, "=");
             if assign_index >= 0 {
                 type_annotation = trim_text(substring(remainder, 0, assign_index));
-                let default_text = trim_text(substring(remainder, assign_index + 1, remainder.length));
+                let default_text = trim_text(substring(remainder, assign_index
+                    + 1, remainder.length));
                 if default_text.length > 0 { default_value = default_text; }
             } else { type_annotation = trim_text(remainder); }
         } else if starts_with(remainder, "=") {
@@ -802,7 +835,7 @@ fn parse_parameter_entry(body: string, span: NativeSourceSpan?) -> NativeParamet
         type_annotation: type_annotation,
         mutable: is_mutable,
         default_value: default_value,
-        span: span,
+        span: span
     };
 }
 

--- a/compiler/src/native_ir_utils_text.sfn
+++ b/compiler/src/native_ir_utils_text.sfn
@@ -22,7 +22,7 @@ export {
     split_top_level_commas,
     find_matching_angle,
     find_matching_paren,
-    split_whitespace,
+    split_whitespace
 };
 
 fn is_trim_char(ch: string) -> boolean {

--- a/compiler/src/native_ir_utils_text.sfn
+++ b/compiler/src/native_ir_utils_text.sfn
@@ -2,7 +2,6 @@
 //
 // Pure string utility functions used across the native IR parser modules.
 // No dependencies on native_ir types.
-
 import { substring } from "./string_utils";
 
 export {
@@ -39,45 +38,29 @@ fn trim_text(value: string) -> string {
     let mut start: number = 0;
     let mut end: number = value.length;
     loop {
-        if start >= end {
-            break;
-        }
+        if start >= end { break; }
         let ch = value[start];
-        if !is_trim_char(ch) {
-            break;
-        }
+        if !is_trim_char(ch) { break; }
         start += 1;
     }
     loop {
-        if end <= start {
-            break;
-        }
+        if end <= start { break; }
         let ch = value[end - 1];
-        if !is_trim_char(ch) {
-            break;
-        }
+        if !is_trim_char(ch) { break; }
         end -= 1;
     }
     if start == 0 {
-        if end == value.length {
-            return value;
-        }
+        if end == value.length { return value; }
     }
     return substring(value, start, end);
 }
 
 fn starts_with(value: string, prefix: string) -> boolean {
-    if prefix.length > value.length {
-        return false;
-    }
+    if prefix.length > value.length { return false; }
     let mut index: number = 0;
     loop {
-        if index >= prefix.length {
-            break;
-        }
-        if value[index] != prefix[index] {
-            return false;
-        }
+        if index >= prefix.length { break; }
+        if value[index] != prefix[index] { return false; }
         index += 1;
     }
     return true;
@@ -91,24 +74,16 @@ fn strip_prefix(value: string, prefix: string) -> string {
 }
 
 fn index_of(value: string, target: string) -> number {
-    if target.length == 0 {
-        return 0;
-    }
-    if target.length > value.length {
-        return -1;
-    }
+    if target.length == 0 { return 0; }
+    if target.length > value.length { return -1; }
     let limit = value.length - target.length;
     let mut index: number = 0;
     loop {
-        if index > limit {
-            break;
-        }
+        if index > limit { break; }
         let mut match_index: number = 0;
         let mut matches: boolean = true;
         loop {
-            if match_index >= target.length {
-                break;
-            }
+            if match_index >= target.length { break; }
             let _cmp_pos = index + match_index;
             if value[_cmp_pos] != target[match_index] {
                 matches = false;
@@ -116,38 +91,26 @@ fn index_of(value: string, target: string) -> number {
             }
             match_index += 1;
         }
-        if matches {
-            return index;
-        }
+        if matches { return index; }
         index += 1;
     }
     return -1;
 }
 
 fn strip_quotes(value: string) -> string {
-    if value.length < 2 {
-        return value;
-    }
+    if value.length < 2 { return value; }
     let first = value[0];
     let last = value[value.length - 1];
     let mut _if360: boolean = false;
     if first == "\"" {
-        if last == "\"" {
-            _if360 = true;
-        }
+        if last == "\"" { _if360 = true; }
     }
-    if _if360 {
-        return substring(value, 1, value.length - 1);
-    }
+    if _if360 { return substring(value, 1, value.length - 1); }
     let mut _if361: boolean = false;
     if first == "'" {
-        if last == "'" {
-            _if361 = true;
-        }
+        if last == "'" { _if361 = true; }
     }
-    if _if361 {
-        return substring(value, 1, value.length - 1);
-    }
+    if _if361 { return substring(value, 1, value.length - 1); }
     return value;
 }
 
@@ -157,9 +120,7 @@ fn split_lines(value: string) -> string[] {
     let mut start: number = 0;
     let mut index: number = 0;
     loop {
-        if index >= value_len {
-            break;
-        }
+        if index >= value_len { break; }
         let ch = value[index];
         if ch == "\n" {
             lines.push(substring(value, start, index));
@@ -176,9 +137,7 @@ fn strip_generics(name: string) -> string {
     let mut depth: number = 0;
     let mut index: number = 0;
     loop {
-        if index >= name.length {
-            break;
-        }
+        if index >= name.length { break; }
         let ch = name[index];
         if ch == "<" {
             depth += 1;
@@ -186,35 +145,25 @@ fn strip_generics(name: string) -> string {
             continue;
         }
         if ch == ">" {
-            if depth > 0 {
-                depth -= 1;
-            }
+            if depth > 0 { depth -= 1; }
             index += 1;
             continue;
         }
-        if depth == 0 {
-            result = result + ch;
-        }
+        if depth == 0 { result = result + ch; }
         index += 1;
     }
     return trim_text(result);
 }
 
 fn last_index_of(value: string, target: string) -> number {
-    if target.length == 0 {
-        return value.length;
-    }
+    if target.length == 0 { return value.length; }
     let mut index: number = value.length - target.length;
     loop {
-        if index < 0 {
-            break;
-        }
+        if index < 0 { break; }
         let mut match_index: number = 0;
         let mut matches: boolean = true;
         loop {
-            if match_index >= target.length {
-                break;
-            }
+            if match_index >= target.length { break; }
             let _cmp_pos2 = index + match_index;
             if value[_cmp_pos2] != target[match_index] {
                 matches = false;
@@ -222,30 +171,22 @@ fn last_index_of(value: string, target: string) -> number {
             }
             match_index += 1;
         }
-        if matches {
-            return index;
-        }
+        if matches { return index; }
         index -= 1;
     }
     return -1;
 }
 
 fn split_text(value: string, delimiter: string) -> string[] {
-    if delimiter.length == 0 {
-        return [value];
-    }
+    if delimiter.length == 0 { return [value]; }
     let mut parts: string[] = [];
     let mut start: number = 0;
     let mut index: number = 0;
 
     loop {
-        if index >= value.length {
-            break;
-        }
+        if index >= value.length { break; }
         let pos = index_of(substring(value, index, value.length), delimiter);
-        if pos < 0 {
-            break;
-        }
+        if pos < 0 { break; }
         let actual_pos = index + pos;
         parts.push(substring(value, start, actual_pos));
         start = actual_pos + delimiter.length;
@@ -254,9 +195,7 @@ fn split_text(value: string, delimiter: string) -> string[] {
 
     if start < value.length {
         parts.push(substring(value, start, value.length));
-    } else if start == value.length {
-        parts.push("");
-    }
+    } else if start == value.length { parts.push(""); }
 
     return parts;
 }
@@ -267,52 +206,36 @@ fn split_comma_separated(value: string) -> string[] {
     let mut current: string = "";
     let mut index: number = 0;
     loop {
-        if index >= value_len {
-            break;
-        }
+        if index >= value_len { break; }
         let ch = value[index];
         if ch == "," {
             results.push(trim_text(current));
             current = "";
-        } else {
-            current = current + ch;
-        }
+        } else { current = current + ch; }
         index += 1;
     }
-    if current.length > 0 {
-        results.push(trim_text(current));
-    }
+    if current.length > 0 { results.push(trim_text(current)); }
     let mut filtered: string[] = [];
     index = 0;
     loop {
-        if index >= results.length {
-            break;
-        }
+        if index >= results.length { break; }
         let entry = results[index];
-        if entry.length > 0 {
-            filtered.push(entry);
-        }
+        if entry.length > 0 { filtered.push(entry); }
         index += 1;
     }
     return filtered;
 }
 
 fn text_char_at(value: string, index: number) -> string {
-    if index < 0 {
-        return "";
-    }
-    if index >= value.length {
-        return "";
-    }
+    if index < 0 { return ""; }
+    if index >= value.length { return ""; }
     return value[index];
 }
 
 fn trim_trailing_delimiters(text: string) -> string {
     let mut end: number = text.length;
     loop {
-        if end <= 0 {
-            break;
-        }
+        if end <= 0 { break; }
         let ch = text_char_at(text, end - 1);
         let mut _if373: boolean = false;
         if ch == "," { _if373 = true; }
@@ -323,16 +246,12 @@ fn trim_trailing_delimiters(text: string) -> string {
         }
         break;
     }
-    if end == text.length {
-        return text;
-    }
+    if end == text.length { return text; }
     return substring(text, 0, end);
 }
 
 fn maybe_trim_trailing(value: string?) -> string? {
-    if value == null {
-        return null;
-    }
+    if value == null { return null; }
     let trimmed = trim_trailing_delimiters(value);
     return trimmed;
 }
@@ -347,9 +266,7 @@ fn split_top_level_commas(text: string) -> string[] {
     let mut bracket_depth: number = 0;
     let mut brace_depth: number = 0;
     loop {
-        if index >= text.length {
-            break;
-        }
+        if index >= text.length { break; }
         let ch = text[index];
         if quote.length > 0 {
             current = current + ch;
@@ -361,9 +278,7 @@ fn split_top_level_commas(text: string) -> string[] {
                     continue;
                 }
             }
-            if ch == quote {
-                quote = "";
-            }
+            if ch == quote { quote = ""; }
             index += 1;
             continue;
         }
@@ -383,9 +298,7 @@ fn split_top_level_commas(text: string) -> string[] {
             continue;
         }
         if ch == ">" {
-            if angle_depth > 0 {
-                angle_depth -= 1;
-            }
+            if angle_depth > 0 { angle_depth -= 1; }
             current = current + ch;
             index += 1;
             continue;
@@ -397,9 +310,7 @@ fn split_top_level_commas(text: string) -> string[] {
             continue;
         }
         if ch == ")" {
-            if paren_depth > 0 {
-                paren_depth -= 1;
-            }
+            if paren_depth > 0 { paren_depth -= 1; }
             current = current + ch;
             index += 1;
             continue;
@@ -411,9 +322,7 @@ fn split_top_level_commas(text: string) -> string[] {
             continue;
         }
         if ch == "]" {
-            if bracket_depth > 0 {
-                bracket_depth -= 1;
-            }
+            if bracket_depth > 0 { bracket_depth -= 1; }
             current = current + ch;
             index += 1;
             continue;
@@ -425,9 +334,7 @@ fn split_top_level_commas(text: string) -> string[] {
             continue;
         }
         if ch == "}" {
-            if brace_depth > 0 {
-                brace_depth -= 1;
-            }
+            if brace_depth > 0 { brace_depth -= 1; }
             current = current + ch;
             index += 1;
             continue;
@@ -453,9 +360,7 @@ fn split_top_level_commas(text: string) -> string[] {
         index += 1;
     }
     let segment = trim_text(current);
-    if segment.length > 0 {
-        entries.push(segment);
-    }
+    if segment.length > 0 { entries.push(segment); }
     return entries;
 }
 
@@ -463,21 +368,13 @@ fn find_matching_angle(text: string, start_index: number) -> number {
     let mut depth: number = 0;
     let mut index: number = start_index;
     loop {
-        if index >= text.length {
-            break;
-        }
+        if index >= text.length { break; }
         let ch = text[index];
-        if ch == "<" {
-            depth += 1;
-        } else if ch == ">" {
+        if ch == "<" { depth += 1; } else if ch == ">" {
             if depth > 0 {
                 depth -= 1;
-                if depth == 0 {
-                    return index;
-                }
-            } else {
-                return index;
-            }
+                if depth == 0 { return index; }
+            } else { return index; }
         }
         index += 1;
     }
@@ -488,9 +385,7 @@ fn find_matching_paren(text: string, start_index: number) -> number {
     let mut depth: number = 0;
     let mut index: number = start_index;
     loop {
-        if index >= text.length {
-            break;
-        }
+        if index >= text.length { break; }
         let ch = text[index];
         let mut _if368: boolean = false;
         if ch == "\"" { _if368 = true; }
@@ -498,9 +393,7 @@ fn find_matching_paren(text: string, start_index: number) -> number {
         if _if368 {
             let mut lookahead = index + 1;
             loop {
-                if lookahead >= text.length {
-                    return -1;
-                }
+                if lookahead >= text.length { return -1; }
                 let current = text[lookahead];
                 if current == "\\" {
                     lookahead += 2;
@@ -512,17 +405,11 @@ fn find_matching_paren(text: string, start_index: number) -> number {
                 }
                 lookahead += 1;
             }
-        } else if ch == "(" {
-            depth += 1;
-        } else if ch == ")" {
+        } else if ch == "(" { depth += 1; } else if ch == ")" {
             if depth > 0 {
                 depth -= 1;
-                if depth == 0 {
-                    return index;
-                }
-            } else {
-                return -1;
-            }
+                if depth == 0 { return index; }
+            } else { return -1; }
         }
         index += 1;
     }
@@ -531,15 +418,11 @@ fn find_matching_paren(text: string, start_index: number) -> number {
 
 fn split_whitespace(value: string) -> string[] {
     let mut parts: string[] = [];
-    if value.length == 0 {
-        return parts;
-    }
+    if value.length == 0 { return parts; }
     let mut start: number = -1;
     let mut index: number = 0;
     loop {
-        if index >= value.length {
-            break;
-        }
+        if index >= value.length { break; }
         let ch = text_char_at(value, index);
         let mut _let385: boolean = false;
         if ch == " " { _let385 = true; }
@@ -552,9 +435,7 @@ fn split_whitespace(value: string) -> string[] {
                 parts.push(substring(value, start, index));
                 start = -1;
             }
-        } else if start < 0 {
-            start = index;
-        }
+        } else if start < 0 { start = index; }
         index += 1;
     }
     if start >= 0 {

--- a/compiler/src/parser/declarations.sfn
+++ b/compiler/src/parser/declarations.sfn
@@ -18,7 +18,7 @@ import {
     Statement,
     TypeAnnotation,
     TypeParameter,
-    decorator_names,
+    decorator_names
 } from "../ast";
 import { infer_effects } from "../decorator_semantics";
 import {
@@ -56,7 +56,7 @@ import {
     symbol_matches,
     token_slice,
     tokens_to_text,
-    trim_token_edges,
+    trim_token_edges
 } from "./token_utils";
 import {
     BlockParseResult,
@@ -75,14 +75,14 @@ import {
     StatementParseResult,
     StructFieldParseResult,
     TypeParameterParseResult,
-    TypeSeparatorParseResult,
+    TypeSeparatorParseResult
 } from "./types";
 import {
     looks_like_number,
     normalize_test_name,
     strip_loose_quotes,
     strip_surrounding_quotes,
-    trim_text,
+    trim_text
 } from "./utils";
 
 // ============================================================================
@@ -414,7 +414,7 @@ fn parse_implements_clause(parser: Parser) -> ImplementsParseResult {
     return ImplementsParseResult {
         parser: current,
         types: implements_types,
-        found: true,
+        found: true
     };
 }
 
@@ -509,7 +509,7 @@ fn parse_single_parameter(initial_parser: Parser) -> ParameterParseResult {
         type_annotation: type_annotation,
         default_value: default_value,
         mutable: is_mutable,
-        span: span,
+        span: span
     };
     return ParameterParseResult { parser: parser, parameter: parameter };
 }
@@ -554,7 +554,7 @@ fn parse_import(initial_parser: Parser) -> StatementParseResult {
 
     let statement = Statement.ImportDeclaration {
         import_specifiers: import_specifiers,
-        source: source,
+        source: source
     };
     return StatementParseResult { parser: parser, statement: statement };
 }
@@ -596,7 +596,7 @@ fn parse_export(initial_parser: Parser) -> StatementParseResult {
 
     let statement = Statement.ExportDeclaration {
         export_specifiers: export_specifiers,
-        source: source,
+        source: source
     };
     return StatementParseResult { parser: parser, statement: statement };
 }
@@ -785,7 +785,7 @@ fn parse_variable(initial_parser: Parser) -> StatementParseResult {
         type_annotation: type_annotation,
         initializer: initializer,
         span: span,
-        initializer_span: initializer_span,
+        initializer_span: initializer_span
     };
     return StatementParseResult { parser: parser, statement: statement };
 }
@@ -876,13 +876,13 @@ fn parse_function(initial_parser: Parser, starts_with_async: boolean, decorators
         return_type: return_type,
         effects: inferred_effects,
         type_parameters: type_parameters,
-        name_span: name_span,
+        name_span: name_span
     };
 
     let statement = Statement.FunctionDeclaration {
         signature: signature,
         body: body,
-        decorators: decorators,
+        decorators: decorators
     };
     return StatementParseResult { parser: parser, statement: statement };
 }
@@ -961,13 +961,13 @@ fn parse_extern_function(initial_parser: Parser, starts_with_unsafe: boolean, de
         return_type: return_type,
         effects: inferred_effects,
         type_parameters: type_parameters,
-        name_span: name_span,
+        name_span: name_span
     };
 
     let statement = Statement.ExternFunctionDeclaration {
         signature: signature,
         unsafe: is_unsafe,
-        decorators: decorators,
+        decorators: decorators
     };
     return StatementParseResult { parser: parser, statement: statement };
 }
@@ -1047,7 +1047,7 @@ fn parse_struct(initial_parser: Parser, decorators: Decorator[]) -> StatementPar
         implements_types: implements_types,
         fields: fields,
         methods: methods,
-        decorators: decorators,
+        decorators: decorators
     };
     return StatementParseResult { parser: parser, statement: statement };
 }
@@ -1114,13 +1114,13 @@ fn parse_struct_field(parser: Parser) -> StructFieldParseResult {
         name: name,
         type_annotation: TypeAnnotation { text: type_text },
         mutable: is_mutable,
-        name_span: name_span,
+        name_span: name_span
     };
 
     return StructFieldParseResult {
         parser: current,
         field: field,
-        success: true,
+        success: true
     };
 }
 
@@ -1199,19 +1199,19 @@ fn parse_struct_method(parser: Parser, decorators: Decorator[]) -> MethodParseRe
         return_type: return_type,
         effects: inferred_effects,
         type_parameters: type_parameters,
-        name_span: name_span,
+        name_span: name_span
     };
 
     let method = MethodDeclaration {
         signature: signature,
         body: body,
-        decorators: decorators,
+        decorators: decorators
     };
 
     return MethodParseResult {
         parser: current,
         method: method,
-        success: true,
+        success: true
     };
 }
 
@@ -1269,7 +1269,7 @@ fn parse_enum(initial_parser: Parser, decorators: Decorator[]) -> StatementParse
         name_span: name_span,
         type_parameters: type_parameters,
         variants: variants,
-        decorators: decorators,
+        decorators: decorators
     };
     return StatementParseResult { parser: parser, statement: statement };
 }
@@ -1327,13 +1327,13 @@ fn parse_enum_variant(parser: Parser) -> EnumVariantParseResult {
     let variant = EnumVariant {
         name: name,
         fields: fields,
-        name_span: name_span,
+        name_span: name_span
     };
 
     return EnumVariantParseResult {
         parser: current,
         variant: variant,
-        success: true,
+        success: true
     };
 }
 
@@ -1408,13 +1408,13 @@ fn parse_enum_variant_field(parser: Parser) -> StructFieldParseResult {
         name: name,
         type_annotation: TypeAnnotation { text: type_text },
         mutable: is_mutable,
-        name_span: name_span,
+        name_span: name_span
     };
 
     return StructFieldParseResult {
         parser: current,
         field: field,
-        success: true,
+        success: true
     };
 }
 
@@ -1477,7 +1477,7 @@ fn parse_interface(initial_parser: Parser, decorators: Decorator[]) -> Statement
         name_span: name_span,
         type_parameters: type_parameters,
         members: members,
-        decorators: decorators,
+        decorators: decorators
     };
     return StatementParseResult { parser: parser, statement: statement };
 }
@@ -1562,13 +1562,13 @@ fn parse_interface_member(parser: Parser, decorators: Decorator[]) -> InterfaceM
         return_type: return_type,
         effects: inferred_effects,
         type_parameters: type_parameters,
-        name_span: name_span,
+        name_span: name_span
     };
 
     return InterfaceMemberParseResult {
         parser: current,
         signature: signature,
-        success: true,
+        success: true
     };
 }
 
@@ -1616,7 +1616,7 @@ fn parse_type_alias(initial_parser: Parser, decorators: Decorator[]) -> Statemen
         name_span: name_span,
         type_parameters: type_parameters,
         aliased_type: aliased_type,
-        decorators: decorators,
+        decorators: decorators
     };
     return StatementParseResult { parser: parser, statement: statement };
 }
@@ -1690,7 +1690,7 @@ fn parse_model(initial_parser: Parser, decorators: Decorator[]) -> StatementPars
         model_type: model_type,
         properties: properties,
         effects: effects,
-        decorators: decorators,
+        decorators: decorators
     };
     return StatementParseResult { parser: parser, statement: statement };
 }
@@ -1737,7 +1737,7 @@ fn parse_model_property(parser: Parser) -> ModelPropertyParseResult {
     let property = ModelProperty {
         name: name,
         value: value_expression,
-        span: source_span_from_tokens([name_token]),
+        span: source_span_from_tokens([name_token])
     };
 
     return ModelPropertyParseResult {
@@ -1815,13 +1815,13 @@ fn parse_pipeline(initial_parser: Parser, decorators: Decorator[]) -> StatementP
         return_type: return_type,
         effects: inferred_effects,
         type_parameters: [],
-        name_span: name_span,
+        name_span: name_span
     };
 
     let statement = Statement.PipelineDeclaration {
         signature: signature,
         body: body,
-        decorators: decorators,
+        decorators: decorators
     };
     return StatementParseResult { parser: parser, statement: statement };
 }
@@ -1890,13 +1890,13 @@ fn parse_tool(initial_parser: Parser, decorators: Decorator[]) -> StatementParse
         return_type: return_type,
         effects: inferred_effects,
         type_parameters: [],
-        name_span: name_span,
+        name_span: name_span
     };
 
     let statement = Statement.ToolDeclaration {
         signature: signature,
         body: body,
-        decorators: decorators,
+        decorators: decorators
     };
     return StatementParseResult { parser: parser, statement: statement };
 }
@@ -1931,7 +1931,7 @@ fn parse_test(initial_parser: Parser, decorators: Decorator[]) -> StatementParse
         name_span: name_span,
         body: body,
         effects: inferred_effects,
-        decorators: decorators,
+        decorators: decorators
     };
     return StatementParseResult { parser: parser, statement: statement };
 }

--- a/compiler/src/parser/declarations.sfn
+++ b/compiler/src/parser/declarations.sfn
@@ -2,93 +2,99 @@
 //
 // Top-level declaration parsing - functions, structs, enums, interfaces,
 // imports, exports, models, pipelines, tools, tests, and type aliases.
-
-import { Token } from "../token";
 import {
     Block,
     Decorator,
     DecoratorArgument,
+    EnumVariant,
+    ExportSpecifier,
     Expression,
     FieldDeclaration,
     FunctionSignature,
-    EnumVariant,
+    ImportSpecifier,
     MethodDeclaration,
     ModelProperty,
     Parameter,
     Statement,
-    ImportSpecifier,
-    ExportSpecifier,
-    TypeParameter,
     TypeAnnotation,
+    TypeParameter,
     decorator_names,
 } from "../ast";
 import { infer_effects } from "../decorator_semantics";
-import { substring, char_code, char_at, strings_equal } from "../string_utils";
 import {
-    Parser,
-    StatementParseResult,
-    ParameterParseResult,
-    ParameterListParseResult,
-    StructFieldParseResult,
-    ModelPropertyParseResult,
-    MethodParseResult,
-    InterfaceMemberParseResult,
-    EnumVariantParseResult,
-    TypeParameterParseResult,
-    ImplementsParseResult,
-    DecoratorParseResult,
-    EffectParseResult,
-    TypeSeparatorParseResult,
-    SpecifierListParseResult,
-    NamedSpecifier,
-    BlockParseResult,
-} from "./types";
-import {
-    trim_text,
-    strip_surrounding_quotes,
-    strip_loose_quotes,
-    looks_like_number,
-    normalize_test_name,
-} from "./utils";
-import {
-    parser_peek_raw,
-    parser_advance_raw,
-    skip_trivia,
-    identifier_matches,
-    symbol_matches,
-    identifier_text,
-    string_literal_value,
-    consume_keyword,
-    consume_symbol,
-    advance_to_symbol,
-    collect_until,
-    collect_parenthesized,
-    token_slice,
-    trim_token_edges,
-    filter_trivia,
-    tokens_to_text,
-    source_span_from_tokens,
-    append_token,
-    find_top_level_symbol,
-    find_top_level_colon,
-    split_tokens_by_comma,
-    split_token_slices_by_comma,
-    skip_struct_member,
-    skip_enum_variant_entry,
-    skip_trailing_comma,
-    is_end_of_file,
-} from "./token_utils";
+    char_at,
+    char_code,
+    strings_equal,
+    substring
+} from "../string_utils";
+import { Token } from "../token";
 import { expression_from_tokens, normalize_expression } from "./expressions";
 import { parse_block } from "./statements";
+import {
+    advance_to_symbol,
+    append_token,
+    collect_parenthesized,
+    collect_until,
+    consume_keyword,
+    consume_symbol,
+    filter_trivia,
+    find_top_level_colon,
+    find_top_level_symbol,
+    identifier_matches,
+    identifier_text,
+    is_end_of_file,
+    parser_advance_raw,
+    parser_peek_raw,
+    skip_enum_variant_entry,
+    skip_struct_member,
+    skip_trailing_comma,
+    skip_trivia,
+    source_span_from_tokens,
+    split_token_slices_by_comma,
+    split_tokens_by_comma,
+    string_literal_value,
+    symbol_matches,
+    token_slice,
+    tokens_to_text,
+    trim_token_edges,
+} from "./token_utils";
+import {
+    BlockParseResult,
+    DecoratorParseResult,
+    EffectParseResult,
+    EnumVariantParseResult,
+    ImplementsParseResult,
+    InterfaceMemberParseResult,
+    MethodParseResult,
+    ModelPropertyParseResult,
+    NamedSpecifier,
+    ParameterListParseResult,
+    ParameterParseResult,
+    Parser,
+    SpecifierListParseResult,
+    StatementParseResult,
+    StructFieldParseResult,
+    TypeParameterParseResult,
+    TypeSeparatorParseResult,
+} from "./types";
+import {
+    looks_like_number,
+    normalize_test_name,
+    strip_loose_quotes,
+    strip_surrounding_quotes,
+    trim_text,
+} from "./utils";
 
 // ============================================================================
 // Type Separator
 // ============================================================================
-
 fn consume_annotation_separator(parser: Parser) -> TypeSeparatorParseResult {
     let token = parser_peek_raw(parser);
     if symbol_matches(token, ":") {
-        return TypeSeparatorParseResult { parser: parser_advance_raw(parser), found: true };
+        return TypeSeparatorParseResult {
+            parser: parser_advance_raw(parser),
+            found: true
+        };
     }
     return TypeSeparatorParseResult { parser: parser, found: false };
 }
@@ -96,7 +102,10 @@ fn consume_annotation_separator(parser: Parser) -> TypeSeparatorParseResult {
 fn consume_return_type_separator(parser: Parser) -> TypeSeparatorParseResult {
     let token = parser_peek_raw(parser);
     if symbol_matches(token, "->") {
-        return TypeSeparatorParseResult { parser: parser_advance_raw(parser), found: true };
+        return TypeSeparatorParseResult {
+            parser: parser_advance_raw(parser),
+            found: true
+        };
     }
     // Tolerate a lexer/runtime bug where `->` is split into `-` and `>`.
     if symbol_matches(token, "-") {
@@ -113,7 +122,6 @@ fn consume_return_type_separator(parser: Parser) -> TypeSeparatorParseResult {
 // ============================================================================
 // Decorator Parsing
 // ============================================================================
-
 fn parse_decorators(parser: Parser) -> DecoratorParseResult {
     let mut current = parser;
     let mut decorators: Decorator[] = [];
@@ -121,9 +129,7 @@ fn parse_decorators(parser: Parser) -> DecoratorParseResult {
     loop {
         current = skip_trivia(current);
         let token = parser_peek_raw(current);
-        if !symbol_matches(token, "@") {
-            break;
-        }
+        if !symbol_matches(token, "@") { break; }
 
         let decorator_start = current;
         current = parser_advance_raw(current);
@@ -152,45 +158,25 @@ fn parse_decorators(parser: Parser) -> DecoratorParseResult {
 
                 let mut index: number = 0;
                 loop {
-                    if index >= paren_result.tokens.length {
-                        break;
-                    }
+                    if index >= paren_result.tokens.length { break; }
                     let tok = paren_result.tokens[index];
                     if tok.kind.variant == "Symbol" {
                         let sym = tok.lexeme;
-                        if strings_equal(sym, "<") {
-                            angle += 1;
-                        } else if strings_equal(sym, ">") {
-                            if angle > 0 {
-                                angle -= 1;
-                            }
-                        } else if strings_equal(sym, "(") {
-                            paren += 1;
-                        } else if strings_equal(sym, ")") {
-                            if paren > 0 {
-                                paren -= 1;
-                            }
-                        } else if strings_equal(sym, "{") {
-                            brace += 1;
-                        } else if strings_equal(sym, "}") {
-                            if brace > 0 {
-                                brace -= 1;
-                            }
-                        } else if strings_equal(sym, "[") {
-                            bracket += 1;
-                        } else if strings_equal(sym, "]") {
-                            if bracket > 0 {
-                                bracket -= 1;
-                            }
+                        if strings_equal(sym, "<") { angle += 1; } else if strings_equal(sym, ">") {
+                            if angle > 0 { angle -= 1; }
+                        } else if strings_equal(sym, "(") { paren += 1; } else if strings_equal(sym, ")") {
+                            if paren > 0 { paren -= 1; }
+                        } else if strings_equal(sym, "{") { brace += 1; } else if strings_equal(sym, "}") {
+                            if brace > 0 { brace -= 1; }
+                        } else if strings_equal(sym, "[") { bracket += 1; } else if strings_equal(sym, "]") {
+                            if bracket > 0 { bracket -= 1; }
                         }
 
                         let mut _let397: boolean = false;
                         if angle == 0 {
                             if paren == 0 {
                                 if brace == 0 {
-                                    if bracket == 0 {
-                                        _let397 = true;
-                                    }
+                                    if bracket == 0 { _let397 = true; }
                                 }
                             }
                         }
@@ -224,23 +210,21 @@ fn parse_decorators(parser: Parser) -> DecoratorParseResult {
             }
         }
 
-        decorators = append_decorator(decorators, Decorator { name: name, arguments: decorator_arguments });
+        decorators = append_decorator(decorators, Decorator {
+            name: name, arguments: decorator_arguments
+        });
     }
 
     return DecoratorParseResult { parser: current, decorators: decorators };
 }
 
 fn parse_decorator_argument(tokens: Token[]) -> DecoratorArgument? {
-    if tokens.length == 0 {
-        return null;
-    }
+    if tokens.length == 0 { return null; }
 
     let colon_index = find_top_level_colon(tokens);
     if colon_index == -1 {
         let trimmed_tokens = trim_token_edges(tokens);
-        if trimmed_tokens.length == 0 {
-            return null;
-        }
+        if trimmed_tokens.length == 0 { return null; }
         let expr = normalize_expression(trimmed_tokens, expression_from_tokens(trimmed_tokens));
         return DecoratorArgument { name: null, expression: expr };
     }
@@ -248,14 +232,10 @@ fn parse_decorator_argument(tokens: Token[]) -> DecoratorArgument? {
     let name_tokens = trim_token_edges(token_slice(tokens, 0, colon_index));
     let value_tokens = trim_token_edges(token_slice(tokens, colon_index + 1, tokens.length));
 
-    if value_tokens.length == 0 {
-        return null;
-    }
+    if value_tokens.length == 0 { return null; }
 
     let name_text = trim_text(tokens_to_text(name_tokens));
-    if name_text.length == 0 {
-        return null;
-    }
+    if name_text.length == 0 { return null; }
 
     let mut expr = normalize_expression(value_tokens, expression_from_tokens(value_tokens));
     if expr.variant == "Raw" {
@@ -285,7 +265,6 @@ fn parse_decorator_argument(tokens: Token[]) -> DecoratorArgument? {
 // ============================================================================
 // Effect List Parsing
 // ============================================================================
-
 fn parse_effect_list(initial_parser: Parser) -> EffectParseResult {
     let mut parser: Parser = initial_parser;
     parser = skip_trivia(parser);
@@ -329,7 +308,6 @@ fn parse_effect_list(initial_parser: Parser) -> EffectParseResult {
 // ============================================================================
 // Type Parameter Clause
 // ============================================================================
-
 fn parse_type_parameter_clause(parser: Parser) -> TypeParameterParseResult {
     let mut current = skip_trivia(parser);
     let token = parser_peek_raw(current);
@@ -343,14 +321,10 @@ fn parse_type_parameter_clause(parser: Parser) -> TypeParameterParseResult {
 
     loop {
         let tok = parser_peek_raw(current);
-        if tok.kind.variant == "EndOfFile" {
-            break;
-        }
+        if tok.kind.variant == "EndOfFile" { break; }
         if tok.kind.variant == "Symbol" {
             let sym = tok.lexeme;
-            if strings_equal(sym, "<") {
-                depth += 1;
-            } else if strings_equal(sym, ">") {
+            if strings_equal(sym, "<") { depth += 1; } else if strings_equal(sym, ">") {
                 depth -= 1;
                 if depth == 0 {
                     current = parser_advance_raw(current);
@@ -366,9 +340,7 @@ fn parse_type_parameter_clause(parser: Parser) -> TypeParameterParseResult {
     let mut parameters: TypeParameter[] = [];
     let mut index: number = 0;
     loop {
-        if index >= slices.length {
-            break;
-        }
+        if index >= slices.length { break; }
         let slice_tokens = trim_token_edges(slices[index]);
         if slice_tokens.length > 0 {
             let colon_index = find_top_level_symbol(slice_tokens, ":");
@@ -389,24 +361,34 @@ fn parse_type_parameter_clause(parser: Parser) -> TypeParameterParseResult {
                     }
                 }
                 let name_span = source_span_from_tokens(name_tokens);
-                let parameter = TypeParameter { name: name_text, bound: bound, span: name_span };
+                let parameter = TypeParameter {
+                    name: name_text,
+                    bound: bound,
+                    span: name_span
+                };
                 parameters.push(parameter);
             }
         }
         index += 1;
     }
 
-    return TypeParameterParseResult { parser: current, parameters: parameters };
+    return TypeParameterParseResult {
+        parser: current,
+        parameters: parameters
+    };
 }
 
 // ============================================================================
 // Implements Clause
 // ============================================================================
-
 fn parse_implements_clause(parser: Parser) -> ImplementsParseResult {
     let mut current = skip_trivia(parser);
     if !identifier_matches(parser_peek_raw(current), "implements") {
-        return ImplementsParseResult { parser: parser, types: [], found: false };
+        return ImplementsParseResult {
+            parser: parser,
+            types: [],
+            found: false
+        };
     }
 
     current = consume_keyword(current, "implements");
@@ -419,12 +401,12 @@ fn parse_implements_clause(parser: Parser) -> ImplementsParseResult {
     let entries = split_tokens_by_comma(capture.tokens);
     let mut index: number = 0;
     loop {
-        if index >= entries.length {
-            break;
-        }
+        if index >= entries.length { break; }
         let text = trim_text(entries[index]);
         if text.length > 0 {
-            implements_types = append_type_annotation(implements_types, TypeAnnotation { text: text });
+            implements_types = append_type_annotation(implements_types, TypeAnnotation {
+                text: text
+            });
         }
         index += 1;
     }
@@ -439,7 +421,6 @@ fn parse_implements_clause(parser: Parser) -> ImplementsParseResult {
 // ============================================================================
 // Parameter Parsing
 // ============================================================================
-
 fn parse_parameter_list(initial_parser: Parser) -> ParameterListParseResult {
     let mut parser: Parser = initial_parser;
     parser = skip_trivia(parser);
@@ -448,7 +429,10 @@ fn parse_parameter_list(initial_parser: Parser) -> ParameterListParseResult {
     let token = parser_peek_raw(parser);
     if symbol_matches(token, ")") {
         parser = parser_advance_raw(parser);
-        return ParameterListParseResult { parser: parser, parameters: parameters };
+        return ParameterListParseResult {
+            parser: parser,
+            parameters: parameters
+        };
     }
 
     loop {
@@ -466,12 +450,13 @@ fn parse_parameter_list(initial_parser: Parser) -> ParameterListParseResult {
             parser = parser_advance_raw(parser);
             break;
         }
-        if separator.kind.variant == "EndOfFile" {
-            break;
-        }
+        if separator.kind.variant == "EndOfFile" { break; }
     }
 
-    return ParameterListParseResult { parser: parser, parameters: parameters };
+    return ParameterListParseResult {
+        parser: parser,
+        parameters: parameters
+    };
 }
 
 fn parse_single_parameter(initial_parser: Parser) -> ParameterParseResult {
@@ -532,7 +517,6 @@ fn parse_single_parameter(initial_parser: Parser) -> ParameterParseResult {
 // ============================================================================
 // Import/Export Parsing
 // ============================================================================
-
 fn parse_import(initial_parser: Parser) -> StatementParseResult {
     let mut parser: Parser = initial_parser;
     parser = skip_trivia(parser);
@@ -550,9 +534,7 @@ fn parse_import(initial_parser: Parser) -> StatementParseResult {
     let text = token.lexeme;
     let mut _if399: boolean = false;
     if text.length > 0 {
-        if strings_equal(char_at(text, 0), "\"") {
-            _if399 = true;
-        }
+        if strings_equal(char_at(text, 0), "\"") { _if399 = true; }
     }
     if _if399 {
         source = string_literal_value(token);
@@ -594,9 +576,7 @@ fn parse_export(initial_parser: Parser) -> StatementParseResult {
     let text = token.lexeme;
     let mut _if400: boolean = false;
     if text.length > 0 {
-        if strings_equal(char_at(text, 0), "\"") {
-            _if400 = true;
-        }
+        if strings_equal(char_at(text, 0), "\"") { _if400 = true; }
     }
     if _if400 {
         source = string_literal_value(token);
@@ -636,9 +616,7 @@ fn parse_specifier_list(initial_parser: Parser) -> SpecifierListParseResult {
             parser = parser_advance_raw(parser);
             break;
         }
-        if current.kind.variant != "Identifier" {
-            break;
-        }
+        if current.kind.variant != "Identifier" { break; }
 
         let name = identifier_text(current);
         parser = parser_advance_raw(parser);
@@ -658,9 +636,7 @@ fn parse_specifier_list(initial_parser: Parser) -> SpecifierListParseResult {
         }
 
         spec_names.push(name);
-        if alias != null {
-            spec_aliases.push(alias);
-        } else {
+        if alias != null { spec_aliases.push(alias); } else {
             spec_aliases.push("");
         }
         spec_count += 1;
@@ -680,10 +656,10 @@ fn parse_specifier_list(initial_parser: Parser) -> SpecifierListParseResult {
     loop {
         if _si >= spec_count { break; }
         let mut _a: string? = null;
-        if spec_aliases[_si].length > 0 {
-            _a = spec_aliases[_si];
-        }
-        specifiers = specifiers.concat([NamedSpecifier { name: spec_names[_si], alias: _a }]);
+        if spec_aliases[_si].length > 0 { _a = spec_aliases[_si]; }
+        specifiers = specifiers.concat([NamedSpecifier {
+            name: spec_names[_si], alias: _a
+        }]);
         _si += 1;
     }
 
@@ -692,18 +668,21 @@ fn parse_specifier_list(initial_parser: Parser) -> SpecifierListParseResult {
         parser = parser_advance_raw(parser);
     }
 
-    return SpecifierListParseResult { parser: parser, specifiers: specifiers };
+    return SpecifierListParseResult {
+        parser: parser,
+        specifiers: specifiers
+    };
 }
 
 fn build_import_specifiers(values: NamedSpecifier[]) -> ImportSpecifier[] {
     let mut result: ImportSpecifier[] = [];
     let mut index: number = 0;
     loop {
-        if index >= values.length {
-            break;
-        }
+        if index >= values.length { break; }
         let entry = values[index];
-        result.push(ImportSpecifier { name: entry.name, alias: entry.alias });
+        result.push(ImportSpecifier {
+            name: entry.name, alias: entry.alias
+        });
         index += 1;
     }
     return result;
@@ -713,11 +692,11 @@ fn build_export_specifiers(values: NamedSpecifier[]) -> ExportSpecifier[] {
     let mut result: ExportSpecifier[] = [];
     let mut index: number = 0;
     loop {
-        if index >= values.length {
-            break;
-        }
+        if index >= values.length { break; }
         let entry = values[index];
-        result.push(ExportSpecifier { name: entry.name, alias: entry.alias });
+        result.push(ExportSpecifier {
+            name: entry.name, alias: entry.alias
+        });
         index += 1;
     }
     return result;
@@ -726,7 +705,6 @@ fn build_export_specifiers(values: NamedSpecifier[]) -> ExportSpecifier[] {
 // ============================================================================
 // Variable Declaration
 // ============================================================================
-
 fn parse_variable(initial_parser: Parser) -> StatementParseResult {
     let mut parser: Parser = initial_parser;
     parser = skip_trivia(parser);
@@ -760,9 +738,7 @@ fn parse_variable(initial_parser: Parser) -> StatementParseResult {
         let capture = collect_until(skip_trivia(parser), ["=", ";"]);
         let mut index: number = 0;
         loop {
-            if index >= capture.tokens.length {
-                break;
-            }
+            if index >= capture.tokens.length { break; }
             statement_tokens = append_token(statement_tokens, capture.tokens[index]);
             index += 1;
         }
@@ -783,9 +759,7 @@ fn parse_variable(initial_parser: Parser) -> StatementParseResult {
         let capture = collect_until(skip_trivia(parser), [";"]);
         let mut index: number = 0;
         loop {
-            if index >= capture.tokens.length {
-                break;
-            }
+            if index >= capture.tokens.length { break; }
             statement_tokens = append_token(statement_tokens, capture.tokens[index]);
             index += 1;
         }
@@ -819,7 +793,6 @@ fn parse_variable(initial_parser: Parser) -> StatementParseResult {
 // ============================================================================
 // Function Declaration
 // ============================================================================
-
 fn parse_function(initial_parser: Parser, starts_with_async: boolean, decorators: Decorator[]) -> StatementParseResult {
     let mut parser: Parser = initial_parser;
     parser = skip_trivia(parser);
@@ -1002,7 +975,6 @@ fn parse_extern_function(initial_parser: Parser, starts_with_unsafe: boolean, de
 // ============================================================================
 // Struct Declaration
 // ============================================================================
-
 fn parse_struct(initial_parser: Parser, decorators: Decorator[]) -> StatementParseResult {
     let mut parser: Parser = initial_parser;
     parser = skip_trivia(parser);
@@ -1043,9 +1015,7 @@ fn parse_struct(initial_parser: Parser, decorators: Decorator[]) -> StatementPar
             parser = parser_advance_raw(parser);
             break;
         }
-        if token.kind.variant == "EndOfFile" {
-            break;
-        }
+        if token.kind.variant == "EndOfFile" { break; }
 
         let field_result = parse_struct_field(parser);
         if field_result.success {
@@ -1096,7 +1066,11 @@ fn parse_struct_field(parser: Parser) -> StructFieldParseResult {
     }
 
     if token_to_use.kind.variant != "Identifier" {
-        return StructFieldParseResult { parser: parser, field: null, success: false };
+        return StructFieldParseResult {
+            parser: parser,
+            field: null,
+            success: false
+        };
     }
 
     let name = identifier_text(token_to_use);
@@ -1107,20 +1081,32 @@ fn parse_struct_field(parser: Parser) -> StructFieldParseResult {
     let separator_result = consume_annotation_separator(current);
     current = separator_result.parser;
     if !separator_result.found {
-        return StructFieldParseResult { parser: parser, field: null, success: false };
+        return StructFieldParseResult {
+            parser: parser,
+            field: null,
+            success: false
+        };
     }
 
     let capture = collect_until(skip_trivia(current), [";", ",", "}"]);
     current = capture.parser;
     let type_text = trim_text(tokens_to_text(capture.tokens));
     if type_text.length == 0 {
-        return StructFieldParseResult { parser: parser, field: null, success: false };
+        return StructFieldParseResult {
+            parser: parser,
+            field: null,
+            success: false
+        };
     }
 
     current = skip_trivia(current);
     let terminator = parser_peek_raw(current);
     if !symbol_matches(terminator, ";") {
-        return StructFieldParseResult { parser: parser, field: null, success: false };
+        return StructFieldParseResult {
+            parser: parser,
+            field: null,
+            success: false
+        };
     }
     current = parser_advance_raw(current);
 
@@ -1153,14 +1139,22 @@ fn parse_struct_method(parser: Parser, decorators: Decorator[]) -> MethodParseRe
 
     current = skip_trivia(current);
     if !identifier_matches(parser_peek_raw(current), "fn") {
-        return MethodParseResult { parser: parser, method: null, success: false };
+        return MethodParseResult {
+            parser: parser,
+            method: null,
+            success: false
+        };
     }
     current = consume_keyword(current, "fn");
 
     current = skip_trivia(current);
     let name_token = parser_peek_raw(current);
     if name_token.kind.variant != "Identifier" {
-        return MethodParseResult { parser: parser, method: null, success: false };
+        return MethodParseResult {
+            parser: parser,
+            method: null,
+            success: false
+        };
     }
     let name = identifier_text(name_token);
     let name_span = source_span_from_tokens([name_token]);
@@ -1224,7 +1218,6 @@ fn parse_struct_method(parser: Parser, decorators: Decorator[]) -> MethodParseRe
 // ============================================================================
 // Enum Declaration
 // ============================================================================
-
 fn parse_enum(initial_parser: Parser, decorators: Decorator[]) -> StatementParseResult {
     let mut parser: Parser = initial_parser;
     let original = parser;
@@ -1256,9 +1249,7 @@ fn parse_enum(initial_parser: Parser, decorators: Decorator[]) -> StatementParse
             parser = parser_advance_raw(parser);
             break;
         }
-        if token.kind.variant == "EndOfFile" {
-            break;
-        }
+        if token.kind.variant == "EndOfFile" { break; }
 
         let variant_result = parse_enum_variant(parser);
         if variant_result.success {
@@ -1288,7 +1279,11 @@ fn parse_enum_variant(parser: Parser) -> EnumVariantParseResult {
     let mut current = skip_trivia(parser);
     let name_token = parser_peek_raw(current);
     if name_token.kind.variant != "Identifier" {
-        return EnumVariantParseResult { parser: original, variant: null, success: false };
+        return EnumVariantParseResult {
+            parser: original,
+            variant: null,
+            success: false
+        };
     }
     let name = identifier_text(name_token);
     let name_span = source_span_from_tokens([name_token]);
@@ -1306,9 +1301,7 @@ fn parse_enum_variant(parser: Parser) -> EnumVariantParseResult {
                 current = parser_advance_raw(current);
                 break;
             }
-            if token.kind.variant == "EndOfFile" {
-                break;
-            }
+            if token.kind.variant == "EndOfFile" { break; }
 
             let field_result = parse_enum_variant_field(current);
             if field_result.success {
@@ -1358,7 +1351,11 @@ fn parse_enum_variant_field(parser: Parser) -> StructFieldParseResult {
     }
 
     if token_to_use.kind.variant != "Identifier" {
-        return StructFieldParseResult { parser: parser, field: null, success: false };
+        return StructFieldParseResult {
+            parser: parser,
+            field: null,
+            success: false
+        };
     }
 
     let name = identifier_text(token_to_use);
@@ -1368,7 +1365,11 @@ fn parse_enum_variant_field(parser: Parser) -> StructFieldParseResult {
     current = skip_trivia(current);
     let sep_result = consume_annotation_separator(current);
     if !sep_result.found {
-        return StructFieldParseResult { parser: parser, field: null, success: false };
+        return StructFieldParseResult {
+            parser: parser,
+            field: null,
+            success: false
+        };
     }
     current = sep_result.parser;
 
@@ -1376,18 +1377,18 @@ fn parse_enum_variant_field(parser: Parser) -> StructFieldParseResult {
     current = capture.parser;
     let mut type_text = trim_text(tokens_to_text(capture.tokens));
     loop {
-        if type_text.length == 0 {
-            break;
-        }
+        if type_text.length == 0 { break; }
         let last = char_at(type_text, type_text.length - 1);
-        if last != ";" {
-            break;
-        }
+        if last != ";" { break; }
         let trimmed = substring(type_text, 0, type_text.length - 1);
         type_text = trim_text(trimmed);
     }
     if type_text.length == 0 {
-        return StructFieldParseResult { parser: parser, field: null, success: false };
+        return StructFieldParseResult {
+            parser: parser,
+            field: null,
+            success: false
+        };
     }
 
     current = skip_trivia(current);
@@ -1420,7 +1421,6 @@ fn parse_enum_variant_field(parser: Parser) -> StructFieldParseResult {
 // ============================================================================
 // Interface Declaration
 // ============================================================================
-
 fn parse_interface(initial_parser: Parser, decorators: Decorator[]) -> StatementParseResult {
     let mut parser: Parser = initial_parser;
     let original = parser;
@@ -1452,9 +1452,7 @@ fn parse_interface(initial_parser: Parser, decorators: Decorator[]) -> Statement
             parser = parser_advance_raw(parser);
             break;
         }
-        if token.kind.variant == "EndOfFile" {
-            break;
-        }
+        if token.kind.variant == "EndOfFile" { break; }
 
         let member_start = parser;
         let decorator_result = parse_decorators(parser);
@@ -1500,14 +1498,22 @@ fn parse_interface_member(parser: Parser, decorators: Decorator[]) -> InterfaceM
 
     current = skip_trivia(current);
     if !identifier_matches(parser_peek_raw(current), "fn") {
-        return InterfaceMemberParseResult { parser: original, signature: null, success: false };
+        return InterfaceMemberParseResult {
+            parser: original,
+            signature: null,
+            success: false
+        };
     }
     current = consume_keyword(current, "fn");
 
     current = skip_trivia(current);
     let name_token = parser_peek_raw(current);
     if name_token.kind.variant != "Identifier" {
-        return InterfaceMemberParseResult { parser: original, signature: null, success: false };
+        return InterfaceMemberParseResult {
+            parser: original,
+            signature: null,
+            success: false
+        };
     }
     let name = identifier_text(name_token);
     let name_span = source_span_from_tokens([name_token]);
@@ -1528,7 +1534,7 @@ fn parse_interface_member(parser: Parser, decorators: Decorator[]) -> InterfaceM
     let separator_result = consume_return_type_separator(current);
     if separator_result.found {
         current = separator_result.parser;
-        let capture = collect_until(skip_trivia(current), ["!", ";", "{" ]);
+        let capture = collect_until(skip_trivia(current), ["!", ";", "{"]);
         current = capture.parser;
         let text = trim_text(tokens_to_text(capture.tokens));
         if text.length > 0 {
@@ -1569,7 +1575,6 @@ fn parse_interface_member(parser: Parser, decorators: Decorator[]) -> InterfaceM
 // ============================================================================
 // Type Alias Declaration
 // ============================================================================
-
 fn parse_type_alias(initial_parser: Parser, decorators: Decorator[]) -> StatementParseResult {
     let mut parser: Parser = initial_parser;
     let original = parser;
@@ -1591,17 +1596,13 @@ fn parse_type_alias(initial_parser: Parser, decorators: Decorator[]) -> Statemen
 
     parser = skip_trivia(parser);
     let equals = parser_peek_raw(parser);
-    if !symbol_matches(equals, "=") {
-        return parse_unknown(original);
-    }
+    if !symbol_matches(equals, "=") { return parse_unknown(original); }
     parser = parser_advance_raw(parser);
 
     let capture = collect_until(skip_trivia(parser), [";"]);
     parser = capture.parser;
     let aliased_text = trim_text(tokens_to_text(capture.tokens));
-    if aliased_text.length == 0 {
-        return parse_unknown(original);
-    }
+    if aliased_text.length == 0 { return parse_unknown(original); }
     let aliased_type = TypeAnnotation { text: aliased_text };
 
     parser = skip_trivia(parser);
@@ -1623,7 +1624,6 @@ fn parse_type_alias(initial_parser: Parser, decorators: Decorator[]) -> Statemen
 // ============================================================================
 // Model Declaration
 // ============================================================================
-
 fn parse_model(initial_parser: Parser, decorators: Decorator[]) -> StatementParseResult {
     let mut parser: Parser = initial_parser;
     let original = parser;
@@ -1643,9 +1643,7 @@ fn parse_model(initial_parser: Parser, decorators: Decorator[]) -> StatementPars
     let type_capture = collect_until(skip_trivia(parser), ["!", "{"]);
     parser = type_capture.parser;
     let type_text = trim_text(tokens_to_text(type_capture.tokens));
-    if type_text.length == 0 {
-        return parse_unknown(original);
-    }
+    if type_text.length == 0 { return parse_unknown(original); }
     let model_type = TypeAnnotation { text: type_text };
 
     let effect_result = parse_effect_list(parser);
@@ -1664,9 +1662,7 @@ fn parse_model(initial_parser: Parser, decorators: Decorator[]) -> StatementPars
             parser = parser_advance_raw(parser);
             break;
         }
-        if token.kind.variant == "EndOfFile" {
-            break;
-        }
+        if token.kind.variant == "EndOfFile" { break; }
 
         let entry_start = parser;
         let property_result = parse_model_property(parser);
@@ -1685,9 +1681,7 @@ fn parse_model(initial_parser: Parser, decorators: Decorator[]) -> StatementPars
             parser = parser_advance_raw(parser);
             break;
         }
-        if maybe_close.kind.variant == "EndOfFile" {
-            break;
-        }
+        if maybe_close.kind.variant == "EndOfFile" { break; }
     }
 
     let statement = Statement.ModelDeclaration {
@@ -1705,7 +1699,11 @@ fn parse_model_property(parser: Parser) -> ModelPropertyParseResult {
     let mut current = skip_trivia(parser);
     let name_token = parser_peek_raw(current);
     if name_token.kind.variant != "Identifier" {
-        return ModelPropertyParseResult { parser: parser, property: null, success: false };
+        return ModelPropertyParseResult {
+            parser: parser,
+            property: null,
+            success: false
+        };
     }
     let name = identifier_text(name_token);
     current = parser_advance_raw(current);
@@ -1713,7 +1711,11 @@ fn parse_model_property(parser: Parser) -> ModelPropertyParseResult {
     current = skip_trivia(current);
     let equals = parser_peek_raw(current);
     if !symbol_matches(equals, "=") {
-        return ModelPropertyParseResult { parser: parser, property: null, success: false };
+        return ModelPropertyParseResult {
+            parser: parser,
+            property: null,
+            success: false
+        };
     }
     current = parser_advance_raw(current);
 
@@ -1724,7 +1726,11 @@ fn parse_model_property(parser: Parser) -> ModelPropertyParseResult {
     current = skip_trivia(current);
     let terminator = parser_peek_raw(current);
     if !symbol_matches(terminator, ";") {
-        return ModelPropertyParseResult { parser: parser, property: null, success: false };
+        return ModelPropertyParseResult {
+            parser: parser,
+            property: null,
+            success: false
+        };
     }
     current = parser_advance_raw(current);
 
@@ -1734,13 +1740,16 @@ fn parse_model_property(parser: Parser) -> ModelPropertyParseResult {
         span: source_span_from_tokens([name_token]),
     };
 
-    return ModelPropertyParseResult { parser: current, property: property, success: true };
+    return ModelPropertyParseResult {
+        parser: current,
+        property: property,
+        success: true
+    };
 }
 
 // ============================================================================
 // Pipeline Declaration
 // ============================================================================
-
 fn parse_pipeline(initial_parser: Parser, decorators: Decorator[]) -> StatementParseResult {
     let mut parser: Parser = initial_parser;
     parser = skip_trivia(parser);
@@ -1820,7 +1829,6 @@ fn parse_pipeline(initial_parser: Parser, decorators: Decorator[]) -> StatementP
 // ============================================================================
 // Tool Declaration
 // ============================================================================
-
 fn parse_tool(initial_parser: Parser, decorators: Decorator[]) -> StatementParseResult {
     let mut parser: Parser = initial_parser;
     parser = skip_trivia(parser);
@@ -1896,7 +1904,6 @@ fn parse_tool(initial_parser: Parser, decorators: Decorator[]) -> StatementParse
 // ============================================================================
 // Test Declaration
 // ============================================================================
-
 fn parse_test(initial_parser: Parser, decorators: Decorator[]) -> StatementParseResult {
     let mut parser: Parser = initial_parser;
     let original = parser;
@@ -1906,9 +1913,7 @@ fn parse_test(initial_parser: Parser, decorators: Decorator[]) -> StatementParse
     let name_capture = collect_until(skip_trivia(parser), ["!", "{"]);
     parser = name_capture.parser;
     let name_text = trim_text(tokens_to_text(name_capture.tokens));
-    if name_text.length == 0 {
-        return parse_unknown(original);
-    }
+    if name_text.length == 0 { return parse_unknown(original); }
     let name_span = source_span_from_tokens(name_capture.tokens);
     let name = normalize_test_name(name_text);
 
@@ -1934,7 +1939,6 @@ fn parse_test(initial_parser: Parser, decorators: Decorator[]) -> StatementParse
 // ============================================================================
 // Unknown Statement (fallback)
 // ============================================================================
-
 fn parse_unknown(initial_parser: Parser) -> StatementParseResult {
     let mut parser: Parser = initial_parser;
     parser = skip_trivia(parser);
@@ -1955,12 +1959,8 @@ fn parse_unknown(initial_parser: Parser) -> StatementParseResult {
         let tok = parser_peek_raw(current);
         tokens = append_token(tokens, tok);
 
-        if symbol_matches(tok, "{") {
-            depth += 1;
-        } else if symbol_matches(tok, "}") {
-            if depth > 0 {
-                depth -= 1;
-            }
+        if symbol_matches(tok, "{") { depth += 1; } else if symbol_matches(tok, "}") {
+            if depth > 0 { depth -= 1; }
             if depth == 0 {
                 current = parser_advance_raw(current);
                 break;
@@ -1968,9 +1968,7 @@ fn parse_unknown(initial_parser: Parser) -> StatementParseResult {
         } else {
             let mut _elif401: boolean = false;
             if depth == 0 {
-                if symbol_matches(tok, ";") {
-                    _elif401 = true;
-                }
+                if symbol_matches(tok, ";") { _elif401 = true; }
             }
             if _elif401 {
                 current = parser_advance_raw(current);
@@ -1987,9 +1985,7 @@ fn parse_unknown(initial_parser: Parser) -> StatementParseResult {
     }
 
     let mut text: string = tokens_to_text(tokens);
-    if truncated {
-        text = text + " /* parse_unknown truncated */";
-    }
+    if truncated { text = text + " /* parse_unknown truncated */"; }
     let block = Statement.Unknown { tokens: tokens, text: text };
     parser = skip_trivia(current);
     return StatementParseResult { parser: parser, statement: block };
@@ -1998,7 +1994,6 @@ fn parse_unknown(initial_parser: Parser) -> StatementParseResult {
 // ============================================================================
 // Append Helpers
 // ============================================================================
-
 fn append_string(values: string[], value: string) -> string[] {
     values.push(value);
     return values;

--- a/compiler/src/parser/expressions.sfn
+++ b/compiler/src/parser/expressions.sfn
@@ -7,7 +7,7 @@ import {
     Expression,
     ObjectField,
     Parameter,
-    TypeAnnotation,
+    TypeAnnotation
 } from "../ast";
 import {
     char_at,
@@ -29,7 +29,7 @@ import {
     symbol_matches,
     token_slice,
     tokens_to_text,
-    trim_token_edges,
+    trim_token_edges
 } from "./token_utils";
 import {
     ArrayLiteralParseResult,
@@ -44,7 +44,7 @@ import {
     LambdaParameterParseResult,
     ObjectLiteralParseResult,
     Parser,
-    StructTypeNameResult,
+    StructTypeNameResult
 } from "./types";
 import { string_array_contains, trim_text } from "./utils";
 
@@ -71,7 +71,7 @@ fn expression_parse_failure(state: ExpressionTokens) -> ExpressionParseResult {
     return ExpressionParseResult {
         state: state,
         expression: Expression.Raw { text: "" },
-        success: false,
+        success: false
     };
 }
 
@@ -100,7 +100,7 @@ fn expression_tokens_consume_type_separator(state: ExpressionTokens, accept_colo
             return ExpressionTypeSeparatorParseResult {
                 state: expression_tokens_advance(state),
                 used_separator: ":",
-                found: true,
+                found: true
             };
         }
     }
@@ -110,7 +110,7 @@ fn expression_tokens_consume_type_separator(state: ExpressionTokens, accept_colo
             return ExpressionTypeSeparatorParseResult {
                 state: expression_tokens_advance(state),
                 used_separator: "->",
-                found: true,
+                found: true
             };
         }
         if symbol_matches(token, "-") {
@@ -126,7 +126,7 @@ fn expression_tokens_consume_type_separator(state: ExpressionTokens, accept_colo
             return ExpressionTypeSeparatorParseResult {
                 state: next_state,
                 used_separator: "->",
-                found: true,
+                found: true
             };
         }
     }
@@ -326,13 +326,13 @@ fn parse_expression_bp(state: ExpressionTokens, min_precedence: number) -> Expre
         if op == ".." {
             left_expression = Expression.Range {
                 start: left_expression,
-                end: rhs_result.expression,
+                end: rhs_result.expression
             };
         } else {
             left_expression = Expression.Binary {
                 operator: op,
                 left: left_expression,
-                right: rhs_result.expression,
+                right: rhs_result.expression
             };
         }
     }
@@ -340,7 +340,7 @@ fn parse_expression_bp(state: ExpressionTokens, min_precedence: number) -> Expre
     return ExpressionParseResult {
         state: current_state,
         expression: left_expression,
-        success: true,
+        success: true
     };
 }
 
@@ -363,9 +363,9 @@ fn parse_prefix_expression(state: ExpressionTokens) -> ExpressionParseResult {
                 state: operand_result.state,
                 expression: Expression.Unary {
                     operator: sym,
-                    operand: operand_result.expression,
+                    operand: operand_result.expression
                 },
-                success: true,
+                success: true
             };
         }
     }
@@ -392,14 +392,14 @@ fn parse_primary_expression(state: ExpressionTokens) -> ExpressionParseResult {
         return ExpressionParseResult {
             state: expression_tokens_advance(state),
             expression: Expression.NumberLiteral { value: token.lexeme },
-            success: true,
+            success: true
         };
     }
     if token.kind.variant == "BooleanLiteral" {
         return ExpressionParseResult {
             state: expression_tokens_advance(state),
             expression: Expression.BooleanLiteral { value: token.lexeme },
-            success: true,
+            success: true
         };
     }
     if token.kind.variant == "StringLiteral" {
@@ -408,7 +408,7 @@ fn parse_primary_expression(state: ExpressionTokens) -> ExpressionParseResult {
             expression: Expression.StringLiteral {
                 value: string_literal_value(token)
             },
-            success: true,
+            success: true
         };
     }
     if token.kind.variant == "Identifier" {
@@ -417,27 +417,27 @@ fn parse_primary_expression(state: ExpressionTokens) -> ExpressionParseResult {
             return ExpressionParseResult {
                 state: expression_tokens_advance(state),
                 expression: Expression.BooleanLiteral { value: "true" },
-                success: true,
+                success: true
             };
         }
         if strings_equal(name, "false") {
             return ExpressionParseResult {
                 state: expression_tokens_advance(state),
                 expression: Expression.BooleanLiteral { value: "false" },
-                success: true,
+                success: true
             };
         }
         if strings_equal(name, "null") {
             return ExpressionParseResult {
                 state: expression_tokens_advance(state),
                 expression: Expression.NullLiteral(),
-                success: true,
+                success: true
             };
         }
         return ExpressionParseResult {
             state: expression_tokens_advance(state),
             expression: Expression.Identifier { name: name },
-            success: true,
+            success: true
         };
     }
     if symbol_matches(token, "(") {
@@ -455,7 +455,7 @@ fn parse_primary_expression(state: ExpressionTokens) -> ExpressionParseResult {
         return ExpressionParseResult {
             state: expression_tokens_advance(after_inner),
             expression: inner_result.expression,
-            success: true,
+            success: true
         };
     }
 
@@ -465,7 +465,7 @@ fn parse_primary_expression(state: ExpressionTokens) -> ExpressionParseResult {
         return ExpressionParseResult {
             state: array_result.state,
             expression: Expression.Array { elements: array_result.elements },
-            success: true,
+            success: true
         };
     }
 
@@ -475,7 +475,7 @@ fn parse_primary_expression(state: ExpressionTokens) -> ExpressionParseResult {
         return ExpressionParseResult {
             state: object_result.state,
             expression: Expression.Object { fields: object_result.fields },
-            success: true,
+            success: true
         };
     }
 
@@ -507,7 +507,7 @@ fn parse_postfix_chain(state: ExpressionTokens, expression: Expression) -> Expre
             current_state = expression_tokens_advance(after_dot);
             current_expression = Expression.Member {
                 object: current_expression,
-                member: identifier_text(member_token),
+                member: identifier_text(member_token)
             };
             continue;
         }
@@ -519,7 +519,7 @@ fn parse_postfix_chain(state: ExpressionTokens, expression: Expression) -> Expre
             current_state = call_result.state;
             current_expression = Expression.Call {
                 callee: current_expression,
-                arguments: call_result.arguments,
+                arguments: call_result.arguments
             };
             continue;
         }
@@ -540,7 +540,7 @@ fn parse_postfix_chain(state: ExpressionTokens, expression: Expression) -> Expre
             current_state = expression_tokens_advance(after_index);
             current_expression = Expression.Index {
                 sequence: current_expression,
-                index: index_result.expression,
+                index: index_result.expression
             };
             continue;
         }
@@ -560,7 +560,7 @@ fn parse_postfix_chain(state: ExpressionTokens, expression: Expression) -> Expre
     return ExpressionParseResult {
         state: current_state,
         expression: current_expression,
-        success: true,
+        success: true
     };
 }
 
@@ -846,9 +846,9 @@ fn parse_struct_literal(state: ExpressionTokens, target: Expression) -> Expressi
         state: fields_result.state,
         expression: Expression.Struct {
             type_name: type_result.parts,
-            fields: fields_result.fields,
+            fields: fields_result.fields
         },
-        success: true,
+        success: true
     };
 }
 
@@ -874,7 +874,7 @@ fn collect_struct_type_name(expression: Expression) -> StructTypeNameResult {
         }
         return StructTypeNameResult {
             parts: append_string_local(inner.parts, expression.member),
-            success: true,
+            success: true
         };
     }
     return StructTypeNameResult { parts: [], success: false };
@@ -934,7 +934,7 @@ fn parse_lambda_expression(state: ExpressionTokens) -> ExpressionParseResult {
 
     let mut block_tokens = block_result.tokens;
     block_tokens = append_token(block_tokens, Token {
-        kind: TokenKind.EndOfFile(), lexeme: "", line: 0, column: 0,
+        kind: TokenKind.EndOfFile(), lexeme: "", line: 0, column: 0
     });
     let block_parser = Parser { tokens: block_tokens, index: 0 };
     let parsed_block = parse_block_for_lambda(block_parser);
@@ -945,9 +945,9 @@ fn parse_lambda_expression(state: ExpressionTokens) -> ExpressionParseResult {
         expression: Expression.Lambda {
             parameters: parameters,
             body: body,
-            return_type: return_type,
+            return_type: return_type
         },
-        success: true,
+        success: true
     };
 }
 
@@ -1066,7 +1066,7 @@ fn parse_lambda_parameter(state: ExpressionTokens) -> LambdaParameterParseResult
         type_annotation: type_annotation,
         default_value: default_value,
         mutable: is_mutable,
-        span: span,
+        span: span
     };
 
     return LambdaParameterParseResult {
@@ -1298,7 +1298,7 @@ fn parse_block_for_lambda(parser: Parser) -> BlockParseResult {
     if !symbol_matches(token, "{") {
         return BlockParseResult {
             parser: current,
-            block: Block { tokens: [], text: "", statements: [] },
+            block: Block { tokens: [], text: "", statements: [] }
         };
     }
 

--- a/compiler/src/parser/expressions.sfn
+++ b/compiler/src/parser/expressions.sfn
@@ -2,8 +2,6 @@
 //
 // Expression parsing - Pratt parser implementation for expressions including
 // literals, binary/unary operators, member access, calls, lambdas, and more.
-
-import { Token, TokenKind } from "../token";
 import {
     Block,
     Expression,
@@ -11,43 +9,48 @@ import {
     Parameter,
     TypeAnnotation,
 } from "../ast";
-import { substring, char_code, char_at, strings_equal } from "../string_utils";
 import {
-    Parser,
-    ExpressionTokens,
-    ExpressionParseResult,
-    ExpressionTypeSeparatorParseResult,
-    ExpressionCollectResult,
-    ExpressionBlockParseResult,
-    LambdaParameterParseResult,
-    LambdaParameterListParseResult,
-    CallArgumentsParseResult,
-    ArrayLiteralParseResult,
-    ObjectLiteralParseResult,
-    StructTypeNameResult,
-    BlockParseResult,
-} from "./types";
-import { trim_text, string_array_contains } from "./utils";
+    char_at,
+    char_code,
+    strings_equal,
+    substring
+} from "../string_utils";
+import { Token, TokenKind } from "../token";
 import {
-    identifier_matches,
-    symbol_matches,
-    identifier_text,
-    string_literal_value,
-    token_slice,
-    trim_token_edges,
-    filter_trivia,
-    tokens_to_text,
-    source_span_from_tokens,
     append_token,
-    parser_peek_raw,
+    filter_trivia,
+    identifier_matches,
+    identifier_text,
     parser_advance_raw,
+    parser_peek_raw,
     skip_trivia,
+    source_span_from_tokens,
+    string_literal_value,
+    symbol_matches,
+    token_slice,
+    tokens_to_text,
+    trim_token_edges,
 } from "./token_utils";
+import {
+    ArrayLiteralParseResult,
+    BlockParseResult,
+    CallArgumentsParseResult,
+    ExpressionBlockParseResult,
+    ExpressionCollectResult,
+    ExpressionParseResult,
+    ExpressionTokens,
+    ExpressionTypeSeparatorParseResult,
+    LambdaParameterListParseResult,
+    LambdaParameterParseResult,
+    ObjectLiteralParseResult,
+    Parser,
+    StructTypeNameResult,
+} from "./types";
+import { string_array_contains, trim_text } from "./utils";
 
 // ============================================================================
 // Expression State Operations
 // ============================================================================
-
 fn expression_tokens_is_at_end(state: ExpressionTokens) -> boolean {
     return state.index >= state.tokens.length;
 }
@@ -57,10 +60,11 @@ fn expression_tokens_peek(state: ExpressionTokens) -> Token {
 }
 
 fn expression_tokens_advance(state: ExpressionTokens) -> ExpressionTokens {
-    if state.index >= state.tokens.length {
-        return state;
-    }
-    return ExpressionTokens { tokens: state.tokens, index: state.index + 1 };
+    if state.index >= state.tokens.length { return state; }
+    return ExpressionTokens {
+        tokens: state.tokens,
+        index: state.index + 1
+    };
 }
 
 fn expression_parse_failure(state: ExpressionTokens) -> ExpressionParseResult {
@@ -74,14 +78,21 @@ fn expression_parse_failure(state: ExpressionTokens) -> ExpressionParseResult {
 // ============================================================================
 // Type Separator Parsing
 // ============================================================================
-
 fn expression_tokens_consume_type_separator(state: ExpressionTokens, accept_colon: boolean, accept_arrow: boolean) -> ExpressionTypeSeparatorParseResult {
     if expression_tokens_is_at_end(state) {
-        return ExpressionTypeSeparatorParseResult { state: state, used_separator: "", found: false };
+        return ExpressionTypeSeparatorParseResult {
+            state: state,
+            used_separator: "",
+            found: false
+        };
     }
     let token = expression_tokens_peek(state);
     if token.kind.variant != "Symbol" {
-        return ExpressionTypeSeparatorParseResult { state: state, used_separator: "", found: false };
+        return ExpressionTypeSeparatorParseResult {
+            state: state,
+            used_separator: "",
+            found: false
+        };
     }
 
     if accept_colon {
@@ -120,13 +131,16 @@ fn expression_tokens_consume_type_separator(state: ExpressionTokens, accept_colo
         }
     }
 
-    return ExpressionTypeSeparatorParseResult { state: state, used_separator: "", found: false };
+    return ExpressionTypeSeparatorParseResult {
+        state: state,
+        used_separator: "",
+        found: false
+    };
 }
 
 // ============================================================================
 // Expression Token Collection
 // ============================================================================
-
 fn expression_tokens_collect_until(state: ExpressionTokens, terminators: string[]) -> ExpressionCollectResult {
     let mut current = state;
     let mut collected: Token[] = [];
@@ -137,70 +151,66 @@ fn expression_tokens_collect_until(state: ExpressionTokens, terminators: string[
 
     loop {
         if expression_tokens_is_at_end(current) {
-            return ExpressionCollectResult { state: current, tokens: collected, success: false };
+            return ExpressionCollectResult {
+                state: current,
+                tokens: collected,
+                success: false
+            };
         }
         let token = expression_tokens_peek(current);
         let mut _let402: boolean = false;
         if angle == 0 {
             if paren == 0 {
                 if brace == 0 {
-                    if bracket == 0 {
-                        _let402 = true;
-                    }
+                    if bracket == 0 { _let402 = true; }
                 }
             }
         }
         let at_top = _let402;
         if at_top {
             if token.kind.variant == "Symbol" {
-                if string_array_contains(terminators, token.lexeme) {
-                    break;
-                }
+                if string_array_contains(terminators, token.lexeme) { break; }
             }
         }
         if token.kind.variant == "Symbol" {
             let sym = token.lexeme;
-            if strings_equal(sym, "<") {
-                angle += 1;
-            } else if strings_equal(sym, ">") {
-                if angle > 0 {
-                    angle -= 1;
-                }
-            } else if strings_equal(sym, "(") {
-                paren += 1;
-            } else if strings_equal(sym, ")") {
-                if paren > 0 {
-                    paren -= 1;
-                }
-            } else if strings_equal(sym, "{") {
-                brace += 1;
-            } else if strings_equal(sym, "}") {
-                if brace > 0 {
-                    brace -= 1;
-                }
-            } else if strings_equal(sym, "[") {
-                bracket += 1;
-            } else if strings_equal(sym, "]") {
-                if bracket > 0 {
-                    bracket -= 1;
-                }
+            if strings_equal(sym, "<") { angle += 1; } else if strings_equal(sym, ">") {
+                if angle > 0 { angle -= 1; }
+            } else if strings_equal(sym, "(") { paren += 1; } else if strings_equal(sym, ")") {
+                if paren > 0 { paren -= 1; }
+            } else if strings_equal(sym, "{") { brace += 1; } else if strings_equal(sym, "}") {
+                if brace > 0 { brace -= 1; }
+            } else if strings_equal(sym, "[") { bracket += 1; } else if strings_equal(sym, "]") {
+                if bracket > 0 { bracket -= 1; }
             }
         }
         collected = append_token(collected, token);
         current = expression_tokens_advance(current);
     }
 
-    return ExpressionCollectResult { state: current, tokens: collected, success: true };
+    return ExpressionCollectResult {
+        state: current,
+        tokens: collected,
+        success: true
+    };
 }
 
 fn collect_expression_block(state: ExpressionTokens) -> ExpressionBlockParseResult {
     let mut current = state;
     if expression_tokens_is_at_end(current) {
-        return ExpressionBlockParseResult { state: current, tokens: [], success: false };
+        return ExpressionBlockParseResult {
+            state: current,
+            tokens: [],
+            success: false
+        };
     }
     let first = expression_tokens_peek(current);
     if !symbol_matches(first, "{") {
-        return ExpressionBlockParseResult { state: current, tokens: [], success: false };
+        return ExpressionBlockParseResult {
+            state: current,
+            tokens: [],
+            success: false
+        };
     }
 
     let mut tokens: Token[] = [];
@@ -208,15 +218,17 @@ fn collect_expression_block(state: ExpressionTokens) -> ExpressionBlockParseResu
 
     loop {
         if expression_tokens_is_at_end(current) {
-            return ExpressionBlockParseResult { state: current, tokens: tokens, success: false };
+            return ExpressionBlockParseResult {
+                state: current,
+                tokens: tokens,
+                success: false
+            };
         }
         let token = expression_tokens_peek(current);
         tokens = append_token(tokens, token);
         if token.kind.variant == "Symbol" {
             let sym = token.lexeme;
-            if strings_equal(sym, "{") {
-                depth += 1;
-            } else if strings_equal(sym, "}") {
+            if strings_equal(sym, "{") { depth += 1; } else if strings_equal(sym, "}") {
                 depth -= 1;
                 if depth == 0 {
                     current = expression_tokens_advance(current);
@@ -227,13 +239,16 @@ fn collect_expression_block(state: ExpressionTokens) -> ExpressionBlockParseResu
         current = expression_tokens_advance(current);
     }
 
-    return ExpressionBlockParseResult { state: current, tokens: tokens, success: true };
+    return ExpressionBlockParseResult {
+        state: current,
+        tokens: tokens,
+        success: true
+    };
 }
 
 // ============================================================================
 // Main Expression Entry Point
 // ============================================================================
-
 fn expression_from_tokens(tokens: Token[]) -> Expression {
     let filtered = filter_trivia(tokens);
     if filtered.length == 0 {
@@ -242,9 +257,7 @@ fn expression_from_tokens(tokens: Token[]) -> Expression {
 
     if filtered.length == 1 {
         let single = expression_from_single_token(filtered[0]);
-        if single != null {
-            return single;
-        }
+        if single != null { return single; }
     }
 
     let state = ExpressionTokens { tokens: filtered, index: 0 };
@@ -268,7 +281,9 @@ fn expression_from_single_token(token: Token) -> Expression? {
         return Expression.BooleanLiteral { value: token.lexeme };
     }
     if token.kind.variant == "StringLiteral" {
-        return Expression.StringLiteral { value: string_literal_value(token) };
+        return Expression.StringLiteral {
+            value: string_literal_value(token)
+        };
     }
     if token.kind.variant == "Identifier" {
         let value = identifier_text(token);
@@ -278,9 +293,7 @@ fn expression_from_single_token(token: Token) -> Expression? {
         if strings_equal(value, "false") {
             return Expression.BooleanLiteral { value: "false" };
         }
-        if strings_equal(value, "null") {
-            return Expression.NullLiteral();
-        }
+        if strings_equal(value, "null") { return Expression.NullLiteral(); }
         return Expression.Identifier { name: value };
     }
     return null;
@@ -289,39 +302,26 @@ fn expression_from_single_token(token: Token) -> Expression? {
 // ============================================================================
 // Pratt Parser - Binary Precedence Climbing
 // ============================================================================
-
 fn parse_expression_bp(state: ExpressionTokens, min_precedence: number) -> ExpressionParseResult {
     let prefix_result = parse_prefix_expression(state);
-    if !prefix_result.success {
-        return prefix_result;
-    }
+    if !prefix_result.success { return prefix_result; }
 
     let mut current_state = prefix_result.state;
     let mut left_expression = prefix_result.expression;
 
     loop {
-        if expression_tokens_is_at_end(current_state) {
-            break;
-        }
+        if expression_tokens_is_at_end(current_state) { break; }
         let token = expression_tokens_peek(current_state);
-        if token.kind.variant != "Symbol" {
-            break;
-        }
+        if token.kind.variant != "Symbol" { break; }
 
         let op = token.lexeme;
         let precedence = binary_precedence(op);
-        if precedence == -1 {
-            break;
-        }
-        if precedence < min_precedence {
-            break;
-        }
+        if precedence == -1 { break; }
+        if precedence < min_precedence { break; }
 
         current_state = expression_tokens_advance(current_state);
         let rhs_result = parse_expression_bp(current_state, precedence + 1);
-        if !rhs_result.success {
-            return expression_parse_failure(state);
-        }
+        if !rhs_result.success { return expression_parse_failure(state); }
         current_state = rhs_result.state;
         if op == ".." {
             left_expression = Expression.Range {
@@ -358,9 +358,7 @@ fn parse_prefix_expression(state: ExpressionTokens) -> ExpressionParseResult {
         if _if403 {
             let advanced = expression_tokens_advance(state);
             let operand_result = parse_expression_bp(advanced, unary_precedence());
-            if !operand_result.success {
-                return operand_result;
-            }
+            if !operand_result.success { return operand_result; }
             return ExpressionParseResult {
                 state: operand_result.state,
                 expression: Expression.Unary {
@@ -375,16 +373,12 @@ fn parse_prefix_expression(state: ExpressionTokens) -> ExpressionParseResult {
     if token.kind.variant == "Identifier" {
         if identifier_matches(token, "fn") {
             let lambda_result = parse_lambda_expression(state);
-            if lambda_result.success {
-                return lambda_result;
-            }
+            if lambda_result.success { return lambda_result; }
         }
     }
 
     let primary_result = parse_primary_expression(state);
-    if !primary_result.success {
-        return primary_result;
-    }
+    if !primary_result.success { return primary_result; }
     return parse_postfix_chain(primary_result.state, primary_result.expression);
 }
 
@@ -411,7 +405,9 @@ fn parse_primary_expression(state: ExpressionTokens) -> ExpressionParseResult {
     if token.kind.variant == "StringLiteral" {
         return ExpressionParseResult {
             state: expression_tokens_advance(state),
-            expression: Expression.StringLiteral { value: string_literal_value(token) },
+            expression: Expression.StringLiteral {
+                value: string_literal_value(token)
+            },
             success: true,
         };
     }
@@ -447,9 +443,7 @@ fn parse_primary_expression(state: ExpressionTokens) -> ExpressionParseResult {
     if symbol_matches(token, "(") {
         let inner_state = expression_tokens_advance(state);
         let inner_result = parse_expression_bp(inner_state, 0);
-        if !inner_result.success {
-            return inner_result;
-        }
+        if !inner_result.success { return inner_result; }
         let after_inner = inner_result.state;
         if expression_tokens_is_at_end(after_inner) {
             return expression_parse_failure(state);
@@ -467,9 +461,7 @@ fn parse_primary_expression(state: ExpressionTokens) -> ExpressionParseResult {
 
     if symbol_matches(token, "[") {
         let array_result = parse_array_literal(expression_tokens_advance(state));
-        if !array_result.success {
-            return expression_parse_failure(state);
-        }
+        if !array_result.success { return expression_parse_failure(state); }
         return ExpressionParseResult {
             state: array_result.state,
             expression: Expression.Array { elements: array_result.elements },
@@ -479,9 +471,7 @@ fn parse_primary_expression(state: ExpressionTokens) -> ExpressionParseResult {
 
     if symbol_matches(token, "{") {
         let object_result = parse_object_literal(expression_tokens_advance(state));
-        if !object_result.success {
-            return expression_parse_failure(state);
-        }
+        if !object_result.success { return expression_parse_failure(state); }
         return ExpressionParseResult {
             state: object_result.state,
             expression: Expression.Object { fields: object_result.fields },
@@ -495,19 +485,14 @@ fn parse_primary_expression(state: ExpressionTokens) -> ExpressionParseResult {
 // ============================================================================
 // Postfix Operators (calls, member access, indexing, struct literals)
 // ============================================================================
-
 fn parse_postfix_chain(state: ExpressionTokens, expression: Expression) -> ExpressionParseResult {
     let mut current_state = state;
     let mut current_expression = expression;
 
     loop {
-        if expression_tokens_is_at_end(current_state) {
-            break;
-        }
+        if expression_tokens_is_at_end(current_state) { break; }
         let token = expression_tokens_peek(current_state);
-        if token.kind.variant != "Symbol" {
-            break;
-        }
+        if token.kind.variant != "Symbol" { break; }
 
         let sym = token.lexeme;
         if strings_equal(sym, ".") {
@@ -560,9 +545,7 @@ fn parse_postfix_chain(state: ExpressionTokens, expression: Expression) -> Expre
             continue;
         }
         if strings_equal(sym, "{") {
-            if !expression_is_struct_target(current_expression) {
-                break;
-            }
+            if !expression_is_struct_target(current_expression) { break; }
             let struct_result = parse_struct_literal(expression_tokens_advance(current_state), current_expression);
             if !struct_result.success {
                 return expression_parse_failure(state);
@@ -584,32 +567,47 @@ fn parse_postfix_chain(state: ExpressionTokens, expression: Expression) -> Expre
 // ============================================================================
 // Call Arguments
 // ============================================================================
-
 fn parse_call_arguments(state: ExpressionTokens) -> CallArgumentsParseResult {
     let mut current = expression_tokens_advance(state);
     let mut arguments: Expression[] = [];
 
     if expression_tokens_is_at_end(current) {
-        return CallArgumentsParseResult { state: state, arguments: [], success: false };
+        return CallArgumentsParseResult {
+            state: state,
+            arguments: [],
+            success: false
+        };
     }
 
     let closing_token = expression_tokens_peek(current);
     if closing_token.kind.variant == "Symbol" {
         if symbol_matches(closing_token, ")") {
             current = expression_tokens_advance(current);
-            return CallArgumentsParseResult { state: current, arguments: arguments, success: true };
+            return CallArgumentsParseResult {
+                state: current,
+                arguments: arguments,
+                success: true
+            };
         }
     }
 
     loop {
         let argument_result = parse_expression_bp(current, 0);
         if !argument_result.success {
-            return CallArgumentsParseResult { state: state, arguments: [], success: false };
+            return CallArgumentsParseResult {
+                state: state,
+                arguments: [],
+                success: false
+            };
         }
         arguments = append_expression(arguments, argument_result.expression);
         current = argument_result.state;
         if expression_tokens_is_at_end(current) {
-            return CallArgumentsParseResult { state: state, arguments: [], success: false };
+            return CallArgumentsParseResult {
+                state: state,
+                arguments: [],
+                success: false
+            };
         }
         let separator = expression_tokens_peek(current);
         if symbol_matches(separator, ",") {
@@ -620,49 +618,76 @@ fn parse_call_arguments(state: ExpressionTokens) -> CallArgumentsParseResult {
             current = expression_tokens_advance(current);
             break;
         }
-        return CallArgumentsParseResult { state: state, arguments: [], success: false };
+        return CallArgumentsParseResult {
+            state: state,
+            arguments: [],
+            success: false
+        };
     }
 
-    return CallArgumentsParseResult { state: current, arguments: arguments, success: true };
+    return CallArgumentsParseResult {
+        state: current,
+        arguments: arguments,
+        success: true
+    };
 }
 
 // ============================================================================
 // Array Literals
 // ============================================================================
-
 fn parse_array_literal(state: ExpressionTokens) -> ArrayLiteralParseResult {
     let mut current = state;
     let mut elements: Expression[] = [];
 
     if expression_tokens_is_at_end(current) {
-        return ArrayLiteralParseResult { state: state, elements: [], success: false };
+        return ArrayLiteralParseResult {
+            state: state,
+            elements: [],
+            success: false
+        };
     }
 
     let closing_bracket = expression_tokens_peek(current);
     if closing_bracket.kind.variant == "Symbol" {
         if symbol_matches(closing_bracket, "]") {
             current = expression_tokens_advance(current);
-            return ArrayLiteralParseResult { state: current, elements: elements, success: true };
+            return ArrayLiteralParseResult {
+                state: current,
+                elements: elements,
+                success: true
+            };
         }
     }
 
     loop {
         let element_result = parse_expression_bp(current, 0);
         if !element_result.success {
-            return ArrayLiteralParseResult { state: state, elements: [], success: false };
+            return ArrayLiteralParseResult {
+                state: state,
+                elements: [],
+                success: false
+            };
         }
         elements = append_expression(elements, element_result.expression);
         current = element_result.state;
 
         if expression_tokens_is_at_end(current) {
-            return ArrayLiteralParseResult { state: state, elements: [], success: false };
+            return ArrayLiteralParseResult {
+                state: state,
+                elements: [],
+                success: false
+            };
         }
 
         let separator = expression_tokens_peek(current);
         if symbol_matches(separator, ",") {
             current = expression_tokens_advance(current);
             if expression_tokens_is_at_end(current) {
-                return ArrayLiteralParseResult { state: state, elements: [], success: false };
+                return ArrayLiteralParseResult {
+                    state: state,
+                    elements: [],
+                    success: false
+                };
             }
             let maybe_end = expression_tokens_peek(current);
             if symbol_matches(maybe_end, "]") {
@@ -675,67 +700,112 @@ fn parse_array_literal(state: ExpressionTokens) -> ArrayLiteralParseResult {
             current = expression_tokens_advance(current);
             break;
         }
-        return ArrayLiteralParseResult { state: state, elements: [], success: false };
+        return ArrayLiteralParseResult {
+            state: state,
+            elements: [],
+            success: false
+        };
     }
 
-    return ArrayLiteralParseResult { state: current, elements: elements, success: true };
+    return ArrayLiteralParseResult {
+        state: current,
+        elements: elements,
+        success: true
+    };
 }
 
 // ============================================================================
 // Object Literals
 // ============================================================================
-
 fn parse_object_literal(state: ExpressionTokens) -> ObjectLiteralParseResult {
     let mut current = state;
     let mut fields: ObjectField[] = [];
 
     if expression_tokens_is_at_end(current) {
-        return ObjectLiteralParseResult { state: state, fields: [], success: false };
+        return ObjectLiteralParseResult {
+            state: state,
+            fields: [],
+            success: false
+        };
     }
 
     let closing_brace = expression_tokens_peek(current);
     if closing_brace.kind.variant == "Symbol" {
         if symbol_matches(closing_brace, "}") {
             current = expression_tokens_advance(current);
-            return ObjectLiteralParseResult { state: current, fields: fields, success: true };
+            return ObjectLiteralParseResult {
+                state: current,
+                fields: fields,
+                success: true
+            };
         }
     }
 
     loop {
         if expression_tokens_is_at_end(current) {
-            return ObjectLiteralParseResult { state: state, fields: [], success: false };
+            return ObjectLiteralParseResult {
+                state: state,
+                fields: [],
+                success: false
+            };
         }
         let name_token = expression_tokens_peek(current);
         if name_token.kind.variant != "Identifier" {
-            return ObjectLiteralParseResult { state: state, fields: [], success: false };
+            return ObjectLiteralParseResult {
+                state: state,
+                fields: [],
+                success: false
+            };
         }
         let field_name = identifier_text(name_token);
         current = expression_tokens_advance(current);
 
         if expression_tokens_is_at_end(current) {
-            return ObjectLiteralParseResult { state: state, fields: [], success: false };
+            return ObjectLiteralParseResult {
+                state: state,
+                fields: [],
+                success: false
+            };
         }
         let colon = expression_tokens_peek(current);
         if !symbol_matches(colon, ":") {
-            return ObjectLiteralParseResult { state: state, fields: [], success: false };
+            return ObjectLiteralParseResult {
+                state: state,
+                fields: [],
+                success: false
+            };
         }
         current = expression_tokens_advance(current);
 
         let value_result = parse_expression_bp(current, 0);
         if !value_result.success {
-            return ObjectLiteralParseResult { state: state, fields: [], success: false };
+            return ObjectLiteralParseResult {
+                state: state,
+                fields: [],
+                success: false
+            };
         }
         current = value_result.state;
-        fields = append_object_field(fields, ObjectField { name: field_name, value: value_result.expression });
+        fields = append_object_field(fields, ObjectField {
+            name: field_name, value: value_result.expression
+        });
 
         if expression_tokens_is_at_end(current) {
-            return ObjectLiteralParseResult { state: state, fields: [], success: false };
+            return ObjectLiteralParseResult {
+                state: state,
+                fields: [],
+                success: false
+            };
         }
         let separator = expression_tokens_peek(current);
         if symbol_matches(separator, ",") {
             current = expression_tokens_advance(current);
             if expression_tokens_is_at_end(current) {
-                return ObjectLiteralParseResult { state: state, fields: [], success: false };
+                return ObjectLiteralParseResult {
+                    state: state,
+                    fields: [],
+                    success: false
+                };
             }
             let maybe_end = expression_tokens_peek(current);
             if symbol_matches(maybe_end, "}") {
@@ -748,26 +818,29 @@ fn parse_object_literal(state: ExpressionTokens) -> ObjectLiteralParseResult {
             current = expression_tokens_advance(current);
             break;
         }
-        return ObjectLiteralParseResult { state: state, fields: [], success: false };
+        return ObjectLiteralParseResult {
+            state: state,
+            fields: [],
+            success: false
+        };
     }
 
-    return ObjectLiteralParseResult { state: current, fields: fields, success: true };
+    return ObjectLiteralParseResult {
+        state: current,
+        fields: fields,
+        success: true
+    };
 }
 
 // ============================================================================
 // Struct Literals
 // ============================================================================
-
 fn parse_struct_literal(state: ExpressionTokens, target: Expression) -> ExpressionParseResult {
     let type_result = collect_struct_type_name(target);
-    if !type_result.success {
-        return expression_parse_failure(state);
-    }
+    if !type_result.success { return expression_parse_failure(state); }
 
     let fields_result = parse_object_literal(state);
-    if !fields_result.success {
-        return expression_parse_failure(state);
-    }
+    if !fields_result.success { return expression_parse_failure(state); }
 
     return ExpressionParseResult {
         state: fields_result.state,
@@ -780,9 +853,7 @@ fn parse_struct_literal(state: ExpressionTokens, target: Expression) -> Expressi
 }
 
 fn expression_is_struct_target(expression: Expression) -> boolean {
-    if expression.variant == "Identifier" {
-        return true;
-    }
+    if expression.variant == "Identifier" { return true; }
     if expression.variant == "Member" {
         return expression_is_struct_target(expression.object);
     }
@@ -791,7 +862,10 @@ fn expression_is_struct_target(expression: Expression) -> boolean {
 
 fn collect_struct_type_name(expression: Expression) -> StructTypeNameResult {
     if expression.variant == "Identifier" {
-        return StructTypeNameResult { parts: [expression.name], success: true };
+        return StructTypeNameResult {
+            parts: [expression.name],
+            success: true
+        };
     }
     if expression.variant == "Member" {
         let inner = collect_struct_type_name(expression.object);
@@ -809,7 +883,6 @@ fn collect_struct_type_name(expression: Expression) -> StructTypeNameResult {
 // ============================================================================
 // Lambda Expressions
 // ============================================================================
-
 fn parse_lambda_expression(state: ExpressionTokens) -> ExpressionParseResult {
     let mut current = state;
     if expression_tokens_is_at_end(current) {
@@ -819,9 +892,7 @@ fn parse_lambda_expression(state: ExpressionTokens) -> ExpressionParseResult {
     let mut _if404: boolean = false;
     if token.kind.variant != "Identifier" { _if404 = true; }
     if !identifier_matches(token, "fn") { _if404 = true; }
-    if _if404 {
-        return expression_parse_failure(state);
-    }
+    if _if404 { return expression_parse_failure(state); }
 
     current = expression_tokens_advance(current);
     if expression_tokens_is_at_end(current) {
@@ -834,9 +905,7 @@ fn parse_lambda_expression(state: ExpressionTokens) -> ExpressionParseResult {
 
     current = expression_tokens_advance(current);
     let params_result = parse_lambda_parameter_list(current);
-    if !params_result.success {
-        return expression_parse_failure(state);
-    }
+    if !params_result.success { return expression_parse_failure(state); }
     current = params_result.state;
     let parameters = params_result.parameters;
 
@@ -846,9 +915,7 @@ fn parse_lambda_expression(state: ExpressionTokens) -> ExpressionParseResult {
         if sep_result.found {
             current = sep_result.state;
             let capture = expression_tokens_collect_until(current, ["{"]);
-            if !capture.success {
-                return expression_parse_failure(state);
-            }
+            if !capture.success { return expression_parse_failure(state); }
             let type_text = trim_text(tokens_to_text(capture.tokens));
             if type_text.length > 0 {
                 return_type = TypeAnnotation { text: type_text };
@@ -862,17 +929,12 @@ fn parse_lambda_expression(state: ExpressionTokens) -> ExpressionParseResult {
     }
 
     let block_result = collect_expression_block(current);
-    if !block_result.success {
-        return expression_parse_failure(state);
-    }
+    if !block_result.success { return expression_parse_failure(state); }
     current = block_result.state;
 
     let mut block_tokens = block_result.tokens;
     block_tokens = append_token(block_tokens, Token {
-            kind: TokenKind.EndOfFile(),
-            lexeme: "",
-            line: 0,
-            column: 0,
+        kind: TokenKind.EndOfFile(), lexeme: "", line: 0, column: 0,
     });
     let block_parser = Parser { tokens: block_tokens, index: 0 };
     let parsed_block = parse_block_for_lambda(block_parser);
@@ -892,7 +954,17 @@ fn parse_lambda_expression(state: ExpressionTokens) -> ExpressionParseResult {
 fn parse_lambda_parameter(state: ExpressionTokens) -> LambdaParameterParseResult {
     let mut current = state;
     if expression_tokens_is_at_end(current) {
-        return LambdaParameterParseResult { state: current, parameter: Parameter { name: "", type_annotation: null, default_value: null, mutable: false, span: null }, success: false };
+        return LambdaParameterParseResult {
+            state: current,
+            parameter: Parameter {
+                name: "",
+                type_annotation: null,
+                default_value: null,
+                mutable: false,
+                span: null
+            },
+            success: false
+        };
     }
 
     let start_index = current.index;
@@ -903,14 +975,34 @@ fn parse_lambda_parameter(state: ExpressionTokens) -> LambdaParameterParseResult
             is_mutable = true;
             current = expression_tokens_advance(current);
             if expression_tokens_is_at_end(current) {
-                return LambdaParameterParseResult { state: current, parameter: Parameter { name: "", type_annotation: null, default_value: null, mutable: false, span: null }, success: false };
+                return LambdaParameterParseResult {
+                    state: current,
+                    parameter: Parameter {
+                        name: "",
+                        type_annotation: null,
+                        default_value: null,
+                        mutable: false,
+                        span: null
+                    },
+                    success: false
+                };
             }
         }
     }
 
     let name_token = expression_tokens_peek(current);
     if name_token.kind.variant != "Identifier" {
-        return LambdaParameterParseResult { state: current, parameter: Parameter { name: "", type_annotation: null, default_value: null, mutable: false, span: null }, success: false };
+        return LambdaParameterParseResult {
+            state: current,
+            parameter: Parameter {
+                name: "",
+                type_annotation: null,
+                default_value: null,
+                mutable: false,
+                span: null
+            },
+            success: false
+        };
     }
     let name = identifier_text(name_token);
     current = expression_tokens_advance(current);
@@ -922,7 +1014,17 @@ fn parse_lambda_parameter(state: ExpressionTokens) -> LambdaParameterParseResult
             current = sep_result.state;
             let capture = expression_tokens_collect_until(current, ["=", ",", ")"]);
             if !capture.success {
-                return LambdaParameterParseResult { state: current, parameter: Parameter { name: name, type_annotation: null, default_value: null, mutable: is_mutable, span: null }, success: false };
+                return LambdaParameterParseResult {
+                    state: current,
+                    parameter: Parameter {
+                        name: name,
+                        type_annotation: null,
+                        default_value: null,
+                        mutable: is_mutable,
+                        span: null
+                    },
+                    success: false
+                };
             }
             let type_text = trim_text(tokens_to_text(capture.tokens));
             if type_text.length > 0 {
@@ -939,7 +1041,17 @@ fn parse_lambda_parameter(state: ExpressionTokens) -> LambdaParameterParseResult
             current = expression_tokens_advance(current);
             let capture = expression_tokens_collect_until(current, [",", ")"]);
             if !capture.success {
-                return LambdaParameterParseResult { state: current, parameter: Parameter { name: name, type_annotation: type_annotation, default_value: null, mutable: is_mutable, span: null }, success: false };
+                return LambdaParameterParseResult {
+                    state: current,
+                    parameter: Parameter {
+                        name: name,
+                        type_annotation: type_annotation,
+                        default_value: null,
+                        mutable: is_mutable,
+                        span: null
+                    },
+                    success: false
+                };
             }
             default_value = expression_from_tokens(capture.tokens);
             current = capture.state;
@@ -957,7 +1069,11 @@ fn parse_lambda_parameter(state: ExpressionTokens) -> LambdaParameterParseResult
         span: span,
     };
 
-    return LambdaParameterParseResult { state: current, parameter: parameter, success: true };
+    return LambdaParameterParseResult {
+        state: current,
+        parameter: parameter,
+        success: true
+    };
 }
 
 fn parse_lambda_parameter_list(state: ExpressionTokens) -> LambdaParameterListParseResult {
@@ -965,24 +1081,40 @@ fn parse_lambda_parameter_list(state: ExpressionTokens) -> LambdaParameterListPa
     let mut parameters: Parameter[] = [];
 
     if expression_tokens_is_at_end(current) {
-        return LambdaParameterListParseResult { state: current, parameters: parameters, success: false };
+        return LambdaParameterListParseResult {
+            state: current,
+            parameters: parameters,
+            success: false
+        };
     }
 
     let closing = expression_tokens_peek(current);
     if symbol_matches(closing, ")") {
         current = expression_tokens_advance(current);
-        return LambdaParameterListParseResult { state: current, parameters: parameters, success: true };
+        return LambdaParameterListParseResult {
+            state: current,
+            parameters: parameters,
+            success: true
+        };
     }
 
     loop {
         let param_result = parse_lambda_parameter(current);
         if !param_result.success {
-            return LambdaParameterListParseResult { state: current, parameters: parameters, success: false };
+            return LambdaParameterListParseResult {
+                state: current,
+                parameters: parameters,
+                success: false
+            };
         }
         parameters = append_parameter(parameters, param_result.parameter);
         current = param_result.state;
         if expression_tokens_is_at_end(current) {
-            return LambdaParameterListParseResult { state: current, parameters: parameters, success: false };
+            return LambdaParameterListParseResult {
+                state: current,
+                parameters: parameters,
+                success: false
+            };
         }
         let separator = expression_tokens_peek(current);
         if separator.kind.variant == "Symbol" {
@@ -995,71 +1127,63 @@ fn parse_lambda_parameter_list(state: ExpressionTokens) -> LambdaParameterListPa
                 break;
             }
         }
-        return LambdaParameterListParseResult { state: current, parameters: parameters, success: false };
+        return LambdaParameterListParseResult {
+            state: current,
+            parameters: parameters,
+            success: false
+        };
     }
 
-    return LambdaParameterListParseResult { state: current, parameters: parameters, success: true };
+    return LambdaParameterListParseResult {
+        state: current,
+        parameters: parameters,
+        success: true
+    };
 }
 
 // ============================================================================
 // Operator Precedence
 // ============================================================================
-
 fn binary_precedence(op: string) -> number {
-    if op == ".." {
-        return 0;
-    }
-    if op == "||" {
-        return 1;
-    }
-    if op == "&&" {
-        return 2;
-    }
+    if op == ".." { return 0; }
+    if op == "||" { return 1; }
+    if op == "&&" { return 2; }
     let mut _if405: boolean = false;
     if op == "==" { _if405 = true; }
     if op == "!=" { _if405 = true; }
-    if _if405 {
-        return 3;
-    }
+    if _if405 { return 3; }
     let mut _if406: boolean = false;
     if op == "<" { _if406 = true; }
     if op == "<=" { _if406 = true; }
     if op == ">" { _if406 = true; }
     if op == ">=" { _if406 = true; }
-    if _if406 {
-        return 4;
-    }
+    if _if406 { return 4; }
     let mut _if407: boolean = false;
     if op == "+" { _if407 = true; }
     if op == "-" { _if407 = true; }
-    if _if407 {
-        return 5;
-    }
+    if _if407 { return 5; }
     let mut _if408: boolean = false;
     if op == "*" { _if408 = true; }
     if op == "/" { _if408 = true; }
     if op == "%" { _if408 = true; }
-    if _if408 {
-        return 6;
-    }
+    if _if408 { return 6; }
     return -1;
 }
 
-fn unary_precedence() -> number {
-    return 7;
-}
+fn unary_precedence() -> number { return 7; }
 
 // ============================================================================
 // Expression Normalization
 // ============================================================================
-
 fn normalize_expression(tokens: Token[], expr: Expression) -> Expression {
     if expr.variant == "Raw" {
         let filtered = filter_trivia(tokens);
         if filtered.length == 1 {
             let token = filtered[0];
             if token.kind.variant == "StringLiteral" {
-                return Expression.StringLiteral { value: string_literal_value(token) };
+                return Expression.StringLiteral {
+                    value: string_literal_value(token)
+                };
             }
             if token.kind.variant == "BooleanLiteral" {
                 return Expression.BooleanLiteral { value: token.lexeme };
@@ -1091,47 +1215,33 @@ fn normalize_expression(tokens: Token[], expr: Expression) -> Expression {
 }
 
 fn strip_surrounding_quotes_expr(text: string) -> string {
-    if text.length < 2 {
-        return text;
-    }
+    if text.length < 2 { return text; }
     let first = char_code(char_at(text, 0));
     let last = char_code(char_at(text, text.length - 1));
     if first == 34 {
-        if last == 34 {
-            return substring(text, 1, text.length - 1);
-        }
+        if last == 34 { return substring(text, 1, text.length - 1); }
     }
     return text;
 }
 
 fn looks_like_number_expr(text: string) -> boolean {
-    if text.length == 0 {
-        return false;
-    }
+    if text.length == 0 { return false; }
     let mut has_decimal: boolean = false;
     let mut index: number = 0;
     if char_at(text, 0) == "-" {
-        if text.length == 1 {
-            return false;
-        }
+        if text.length == 1 { return false; }
         index = 1;
     }
     loop {
-        if index >= text.length {
-            break;
-        }
+        if index >= text.length { break; }
         let ch = char_at(text, index);
         if ch == "." {
-            if has_decimal {
-                return false;
-            }
+            if has_decimal { return false; }
             has_decimal = true;
             index += 1;
             continue;
         }
-        if !is_decimal_digit_expr(ch) {
-            return false;
-        }
+        if !is_decimal_digit_expr(ch) { return false; }
         index += 1;
     }
     return true;
@@ -1155,7 +1265,6 @@ fn is_decimal_digit_expr(ch: string) -> boolean {
 // ============================================================================
 // Append Helpers
 // ============================================================================
-
 fn append_expression(expressions: Expression[], expression: Expression) -> Expression[] {
     expressions.push(expression);
     return expressions;
@@ -1182,7 +1291,6 @@ fn append_string_local(values: string[], value: string) -> string[] {
 // We'll use a simple implementation that creates an empty block for now,
 // and the actual implementation will be in statements.sfn
 // ============================================================================
-
 fn parse_block_for_lambda(parser: Parser) -> BlockParseResult {
     let mut current = parser;
     current = skip_trivia(current);
@@ -1211,19 +1319,13 @@ fn parse_block_for_lambda(parser: Parser) -> BlockParseResult {
                 break;
             }
         }
-        if symbol_matches(tok, "{") {
-            depth += 1;
-        }
-        if tok.kind.variant == "EndOfFile" {
-            break;
-        }
+        if symbol_matches(tok, "{") { depth += 1; }
+        if tok.kind.variant == "EndOfFile" { break; }
         current = parser_advance_raw(current);
     }
 
     let mut end_index = current.index;
-    if block_end_index > start_index {
-        end_index = block_end_index;
-    }
+    if block_end_index > start_index { end_index = block_end_index; }
     let block_tokens = token_slice(parser.tokens, start_index, end_index);
     let text = tokens_to_text(block_tokens);
     let block = Block { tokens: block_tokens, text: text, statements: [] };

--- a/compiler/src/parser/mod.sfn
+++ b/compiler/src/parser/mod.sfn
@@ -27,7 +27,7 @@ import {
     parse_tool,
     parse_type_alias,
     parse_unknown,
-    parse_variable,
+    parse_variable
 } from "./declarations";
 import {
     identifier_matches,
@@ -211,7 +211,7 @@ export {
     CallArgumentsParseResult,
     ArrayLiteralParseResult,
     ObjectLiteralParseResult,
-    StructTypeNameResult,
+    StructTypeNameResult
 } from "./types";
 
 // Re-export string utilities
@@ -225,7 +225,7 @@ export {
     looks_like_number,
     is_decimal_digit,
     string_array_contains,
-    append_string,
+    append_string
 } from "./utils";
 
 // Re-export token utilities
@@ -284,7 +284,7 @@ export {
 
     // Append helpers
     append_token,
-    append_token_array,
+    append_token_array
 } from "./token_utils";
 
 // Re-export expression parsing functions
@@ -334,7 +334,7 @@ export {
     unary_precedence,
 
     // Expression normalization
-    normalize_expression,
+    normalize_expression
 } from "./expressions";
 
 // Re-export statement parsing functions
@@ -372,7 +372,7 @@ export {
     parse_expression_statement,
 
     // Unknown statement (fallback)
-    parse_unknown_statement,
+    parse_unknown_statement
 } from "./statements";
 
 // Re-export declaration parsing functions
@@ -443,5 +443,5 @@ export {
     parse_test,
 
     // Unknown statement (fallback)
-    parse_unknown,
+    parse_unknown
 } from "./declarations";

--- a/compiler/src/parser/mod.sfn
+++ b/compiler/src/parser/mod.sfn
@@ -9,36 +9,39 @@
 //   - expressions.sfn:  Expression parsing (Pratt parser, literals, lambdas)
 //   - statements.sfn:   Block statement parsing (control flow, return, match)
 //   - declarations.sfn: Top-level declarations (fn, struct, enum, import, etc.)
-
+import { Program, Statement } from "../ast";
 import { lex } from "../lexer";
 import { Token, TokenKind } from "../token";
-import { Program, Statement } from "../ast";
-
-// Import types from submodules
-import { Parser, StatementParseResult } from "./types";
-import { parser_peek_raw, parser_advance_raw, skip_trivia, is_end_of_file, identifier_matches } from "./token_utils";
 import {
     parse_decorators,
-    parse_import,
+    parse_enum,
     parse_export,
-    parse_variable,
+    parse_extern_function,
+    parse_function,
+    parse_import,
+    parse_interface,
     parse_model,
     parse_pipeline,
-    parse_tool,
-    parse_test,
-    parse_function,
-    parse_extern_function,
     parse_struct,
+    parse_test,
+    parse_tool,
     parse_type_alias,
-    parse_interface,
-    parse_enum,
     parse_unknown,
+    parse_variable,
 } from "./declarations";
+import {
+    identifier_matches,
+    is_end_of_file,
+    parser_advance_raw,
+    parser_peek_raw,
+    skip_trivia
+} from "./token_utils";
+// Import types from submodules
+import { Parser, StatementParseResult } from "./types";
 
 // ============================================================================
 // Main Entry Points
 // ============================================================================
-
 fn parse_program(source: string) -> Program {
     let tokens = lex(source);
     return parse_tokens(tokens);
@@ -51,9 +54,7 @@ fn parse_tokens(tokens: Token[]) -> Program {
 
     loop {
         let token = parser_peek_raw(parser);
-        if is_end_of_file(parser, token) {
-            break;
-        }
+        if is_end_of_file(parser, token) { break; }
 
         let prev_index = parser.index;
         let result = parse_statement(parser);
@@ -72,7 +73,6 @@ fn parse_tokens(tokens: Token[]) -> Program {
 // ============================================================================
 // Top-Level Statement Dispatch
 // ============================================================================
-
 fn parse_statement(initial_parser: Parser) -> StatementParseResult {
     let mut parser: Parser = initial_parser;
     let original = parser;
@@ -86,45 +86,31 @@ fn parse_statement(initial_parser: Parser) -> StatementParseResult {
     let token = parser_peek_raw(parser);
 
     if identifier_matches(token, "import") {
-        if decorators.length > 0 {
-            return parse_unknown(original);
-        }
+        if decorators.length > 0 { return parse_unknown(original); }
         return parse_import(parser);
     }
     if identifier_matches(token, "export") {
-        if decorators.length > 0 {
-            return parse_unknown(original);
-        }
+        if decorators.length > 0 { return parse_unknown(original); }
         return parse_export(parser);
     }
     if identifier_matches(token, "let") {
-        if decorators.length > 0 {
-            return parse_unknown(original);
-        }
+        if decorators.length > 0 { return parse_unknown(original); }
         return parse_variable(parser);
     }
     if identifier_matches(token, "model") {
-        if decorators.length > 0 {
-            return parse_unknown(original);
-        }
+        if decorators.length > 0 { return parse_unknown(original); }
         return parse_model(parser, decorators);
     }
     if identifier_matches(token, "pipeline") {
-        if decorators.length > 0 {
-            return parse_unknown(original);
-        }
+        if decorators.length > 0 { return parse_unknown(original); }
         return parse_pipeline(parser, decorators);
     }
     if identifier_matches(token, "tool") {
-        if decorators.length > 0 {
-            return parse_unknown(original);
-        }
+        if decorators.length > 0 { return parse_unknown(original); }
         return parse_tool(parser, decorators);
     }
     if identifier_matches(token, "test") {
-        if decorators.length > 0 {
-            return parse_unknown(original);
-        }
+        if decorators.length > 0 { return parse_unknown(original); }
         return parse_test(parser, decorators);
     }
     if identifier_matches(token, "fn") {
@@ -158,9 +144,7 @@ fn parse_statement(initial_parser: Parser) -> StatementParseResult {
         return parse_enum(parser, decorators);
     }
 
-    if decorators.length > 0 {
-        return parse_unknown(original);
-    }
+    if decorators.length > 0 { return parse_unknown(original); }
 
     return parse_unknown(parser);
 }
@@ -168,7 +152,6 @@ fn parse_statement(initial_parser: Parser) -> StatementParseResult {
 // ============================================================================
 // Append Helper
 // ============================================================================
-
 fn append_statement(statements: Statement[], statement: Statement) -> Statement[] {
     statements.push(statement);
     return statements;
@@ -177,7 +160,6 @@ fn append_statement(statements: Statement[], statement: Statement) -> Statement[
 // ============================================================================
 // Re-exports
 // ============================================================================
-
 // Re-export all types
 export {
     // Core parser state

--- a/compiler/src/parser/statements.sfn
+++ b/compiler/src/parser/statements.sfn
@@ -2,52 +2,56 @@
 //
 // Block-level statement parsing - control flow, loops, return, throw,
 // try/catch, match statements, and expression statements.
-
-import { Token } from "../token";
 import {
     Block,
     Decorator,
-    Expression,
-    Statement,
-    MatchCase,
     ElseBranch,
+    Expression,
     ForClause,
-    WithClause,
+    MatchCase,
     SourceSpan,
+    Statement,
+    WithClause,
 } from "../ast";
-import { substring, char_code, char_at, strings_equal } from "../string_utils";
 import {
-    Parser,
-    StatementParseResult,
-    BlockStatementParseResult,
-    BlockParseResult,
-    DecoratorParseResult,
-    MatchCasesParseResult,
-    MatchCaseParseResult,
-    MatchCaseTokenSplit,
-} from "./types";
-import { trim_text } from "./utils";
+    char_at,
+    char_code,
+    strings_equal,
+    substring
+} from "../string_utils";
+import { Token } from "../token";
+import { expression_from_tokens } from "./expressions";
 import {
-    parser_peek_raw,
-    parser_advance_raw,
-    skip_trivia,
-    identifier_matches,
-    symbol_matches,
-    identifier_text,
-    string_literal_value,
+    append_token,
+    collect_pattern_until_arrow,
+    collect_until,
     consume_keyword,
     consume_symbol,
-    collect_until,
-    collect_pattern_until_arrow,
-    token_slice,
-    trim_token_edges,
-    tokens_to_text,
-    source_span_from_tokens,
-    append_token,
     find_top_level_identifier,
+    identifier_matches,
+    identifier_text,
+    parser_advance_raw,
+    parser_peek_raw,
+    skip_trivia,
+    source_span_from_tokens,
     split_token_slices_by_comma,
+    string_literal_value,
+    symbol_matches,
+    token_slice,
+    tokens_to_text,
+    trim_token_edges,
 } from "./token_utils";
-import { expression_from_tokens } from "./expressions";
+import {
+    BlockParseResult,
+    BlockStatementParseResult,
+    DecoratorParseResult,
+    MatchCaseParseResult,
+    MatchCaseTokenSplit,
+    MatchCasesParseResult,
+    Parser,
+    StatementParseResult,
+} from "./types";
+import { trim_text } from "./utils";
 
 // Forward declaration for decorators - will be imported from declarations
 // For now we provide a stub that returns empty decorators
@@ -58,9 +62,7 @@ fn parse_decorators_stub(parser: Parser) -> DecoratorParseResult {
     loop {
         current = skip_trivia(current);
         let token = parser_peek_raw(current);
-        if !symbol_matches(token, "@") {
-            break;
-        }
+        if !symbol_matches(token, "@") { break; }
 
         let decorator_start = current;
         current = parser_advance_raw(current);
@@ -83,13 +85,9 @@ fn parse_decorators_stub(parser: Parser) -> DecoratorParseResult {
             current = parser_advance_raw(current);
             loop {
                 let tok = parser_peek_raw(current);
-                if tok.kind.variant == "EndOfFile" {
-                    break;
-                }
+                if tok.kind.variant == "EndOfFile" { break; }
                 if tok.kind.variant == "Symbol" {
-                    if strings_equal(tok.lexeme, "(") {
-                        depth += 1;
-                    } else if strings_equal(tok.lexeme, ")") {
+                    if strings_equal(tok.lexeme, "(") { depth += 1; } else if strings_equal(tok.lexeme, ")") {
                         depth -= 1;
                         if depth == 0 {
                             current = parser_advance_raw(current);
@@ -101,7 +99,9 @@ fn parse_decorators_stub(parser: Parser) -> DecoratorParseResult {
             }
         }
 
-        decorators = append_decorator(decorators, Decorator { name: name, arguments: [] });
+        decorators = append_decorator(decorators, Decorator {
+            name: name, arguments: []
+        });
     }
 
     return DecoratorParseResult { parser: current, decorators: decorators };
@@ -110,7 +110,6 @@ fn parse_decorators_stub(parser: Parser) -> DecoratorParseResult {
 // ============================================================================
 // Block Parsing
 // ============================================================================
-
 fn parse_block(initial_parser: Parser) -> BlockParseResult {
     let mut parser: Parser = initial_parser;
     parser = skip_trivia(parser);
@@ -135,9 +134,7 @@ fn parse_block(initial_parser: Parser) -> BlockParseResult {
             current = parser_advance_raw(current);
             break;
         }
-        if tok.kind.variant == "EndOfFile" {
-            break;
-        }
+        if tok.kind.variant == "EndOfFile" { break; }
 
         let block_result = parse_block_statement(current);
         if block_result.success {
@@ -161,13 +158,15 @@ fn parse_block(initial_parser: Parser) -> BlockParseResult {
     }
 
     let mut end_index = current.index;
-    if block_end_index > start_index {
-        end_index = block_end_index;
-    }
+    if block_end_index > start_index { end_index = block_end_index; }
     let mut block_tokens = token_slice(parser.tokens, start_index, end_index);
     block_tokens = trim_block_tokens_local(block_tokens);
     let text = tokens_to_text(block_tokens);
-    let block = Block { tokens: block_tokens, text: text, statements: statements };
+    let block = Block {
+        tokens: block_tokens,
+        text: text,
+        statements: statements
+    };
     return BlockParseResult { parser: skip_trivia(current), block: block };
 }
 
@@ -176,18 +175,12 @@ fn trim_block_tokens_local(tokens: Token[]) -> Token[] {
     let mut index: number = 0;
     let mut end: number = tokens.length;
     loop {
-        if index >= tokens.length {
-            break;
-        }
+        if index >= tokens.length { break; }
         let token = tokens[index];
         if token.kind.variant == "Symbol" {
             let sym = token.lexeme;
-            if strings_equal(sym, "{") {
-                depth += 1;
-            } else if strings_equal(sym, "}") {
-                if depth > 0 {
-                    depth -= 1;
-                }
+            if strings_equal(sym, "{") { depth += 1; } else if strings_equal(sym, "}") {
+                if depth > 0 { depth -= 1; }
                 if depth == 0 {
                     end = index + 1;
                     break;
@@ -202,7 +195,6 @@ fn trim_block_tokens_local(tokens: Token[]) -> Token[] {
 // ============================================================================
 // Block Statement Dispatch
 // ============================================================================
-
 fn parse_block_statement(parser: Parser) -> BlockStatementParseResult {
     let original = parser;
     let decorator_result = parse_decorators_stub(parser);
@@ -213,7 +205,11 @@ fn parse_block_statement(parser: Parser) -> BlockStatementParseResult {
     let token = parser_peek_raw(after_decorators);
     if symbol_matches(token, "{") {
         if decorators.length > 0 {
-            return BlockStatementParseResult { parser: original, statement: null, success: false };
+            return BlockStatementParseResult {
+                parser: original,
+                statement: null,
+                success: false
+            };
         }
         let body_result = parse_block(after_decorators);
         return BlockStatementParseResult {
@@ -230,13 +226,21 @@ fn parse_block_statement(parser: Parser) -> BlockStatementParseResult {
     }
     if identifier_matches(token, "break") {
         if decorators.length > 0 {
-            return BlockStatementParseResult { parser: original, statement: null, success: false };
+            return BlockStatementParseResult {
+                parser: original,
+                statement: null,
+                success: false
+            };
         }
         return parse_break_statement(after_decorators);
     }
     if identifier_matches(token, "continue") {
         if decorators.length > 0 {
-            return BlockStatementParseResult { parser: original, statement: null, success: false };
+            return BlockStatementParseResult {
+                parser: original,
+                statement: null,
+                success: false
+            };
         }
         return parse_continue_statement(after_decorators);
     }
@@ -254,7 +258,11 @@ fn parse_block_statement(parser: Parser) -> BlockStatementParseResult {
     }
     if identifier_matches(token, "unsafe") {
         if decorators.length > 0 {
-            return BlockStatementParseResult { parser: original, statement: null, success: false };
+            return BlockStatementParseResult {
+                parser: original,
+                statement: null,
+                success: false
+            };
         }
         let mut unsafe_current = consume_keyword(after_decorators, "unsafe");
         unsafe_current = skip_trivia(unsafe_current);
@@ -267,46 +275,67 @@ fn parse_block_statement(parser: Parser) -> BlockStatementParseResult {
     }
     if identifier_matches(token, "return") {
         if decorators.length > 0 {
-            return BlockStatementParseResult { parser: original, statement: null, success: false };
+            return BlockStatementParseResult {
+                parser: original,
+                statement: null,
+                success: false
+            };
         }
         return parse_return_statement(after_decorators);
     }
     if identifier_matches(token, "throw") {
         if decorators.length > 0 {
-            return BlockStatementParseResult { parser: original, statement: null, success: false };
+            return BlockStatementParseResult {
+                parser: original,
+                statement: null,
+                success: false
+            };
         }
         return parse_throw_statement(after_decorators);
     }
     if identifier_matches(token, "try") {
         if decorators.length > 0 {
-            return BlockStatementParseResult { parser: original, statement: null, success: false };
+            return BlockStatementParseResult {
+                parser: original,
+                statement: null,
+                success: false
+            };
         }
         return parse_try_statement(after_decorators);
     }
     if identifier_matches(token, "assert") {
         if decorators.length > 0 {
-            return BlockStatementParseResult { parser: original, statement: null, success: false };
+            return BlockStatementParseResult {
+                parser: original,
+                statement: null,
+                success: false
+            };
         }
         return parse_assert_statement(after_decorators);
     }
 
     let expression_result = parse_expression_statement(after_decorators, decorators);
-    if expression_result.success {
-        return expression_result;
-    }
+    if expression_result.success { return expression_result; }
 
-    return BlockStatementParseResult { parser: original, statement: null, success: false };
+    return BlockStatementParseResult {
+        parser: original,
+        statement: null,
+        success: false
+    };
 }
 
 // ============================================================================
 // Control Flow Statements
 // ============================================================================
-
 fn parse_for_statement(parser: Parser, decorators: Decorator[]) -> BlockStatementParseResult {
     let original = parser;
     let mut current = skip_trivia(parser);
     if !identifier_matches(parser_peek_raw(current), "for") {
-        return BlockStatementParseResult { parser: original, statement: null, success: false };
+        return BlockStatementParseResult {
+            parser: original,
+            statement: null,
+            success: false
+        };
     }
     current = consume_keyword(current, "for");
 
@@ -314,12 +343,20 @@ fn parse_for_statement(parser: Parser, decorators: Decorator[]) -> BlockStatemen
     current = clause_capture.parser;
     let clause_tokens = trim_token_edges(clause_capture.tokens);
     if clause_tokens.length == 0 {
-        return BlockStatementParseResult { parser: original, statement: null, success: false };
+        return BlockStatementParseResult {
+            parser: original,
+            statement: null,
+            success: false
+        };
     }
 
     let in_index = find_top_level_identifier(clause_tokens, "in");
     if in_index == -1 {
-        return BlockStatementParseResult { parser: original, statement: null, success: false };
+        return BlockStatementParseResult {
+            parser: original,
+            statement: null,
+            success: false
+        };
     }
 
     let target_tokens = trim_token_edges(token_slice(clause_tokens, 0, in_index));
@@ -328,7 +365,11 @@ fn parse_for_statement(parser: Parser, decorators: Decorator[]) -> BlockStatemen
     if target_tokens.length == 0 { _if410 = true; }
     if iterable_tokens.length == 0 { _if410 = true; }
     if _if410 {
-        return BlockStatementParseResult { parser: original, statement: null, success: false };
+        return BlockStatementParseResult {
+            parser: original,
+            statement: null,
+            success: false
+        };
     }
 
     let target_expression = expression_from_tokens(target_tokens);
@@ -341,7 +382,11 @@ fn parse_for_statement(parser: Parser, decorators: Decorator[]) -> BlockStatemen
 
     let body_result = parse_block(current);
     if body_result.block.tokens.length == 0 {
-        return BlockStatementParseResult { parser: original, statement: null, success: false };
+        return BlockStatementParseResult {
+            parser: original,
+            statement: null,
+            success: false
+        };
     }
     current = body_result.parser;
     let body = body_result.block;
@@ -369,13 +414,21 @@ fn parse_loop_statement(parser: Parser, decorators: Decorator[]) -> BlockStateme
     let original = parser;
     let mut current = skip_trivia(parser);
     if !identifier_matches(parser_peek_raw(current), "loop") {
-        return BlockStatementParseResult { parser: original, statement: null, success: false };
+        return BlockStatementParseResult {
+            parser: original,
+            statement: null,
+            success: false
+        };
     }
     current = consume_keyword(current, "loop");
 
     let body_result = parse_block(current);
     if body_result.block.tokens.length == 0 {
-        return BlockStatementParseResult { parser: original, statement: null, success: false };
+        return BlockStatementParseResult {
+            parser: original,
+            statement: null,
+            success: false
+        };
     }
     current = body_result.parser;
 
@@ -401,7 +454,11 @@ fn parse_break_statement(parser: Parser) -> BlockStatementParseResult {
     let original = parser;
     let mut current = skip_trivia(parser);
     if !identifier_matches(parser_peek_raw(current), "break") {
-        return BlockStatementParseResult { parser: original, statement: null, success: false };
+        return BlockStatementParseResult {
+            parser: original,
+            statement: null,
+            success: false
+        };
     }
     current = consume_keyword(current, "break");
 
@@ -422,7 +479,11 @@ fn parse_continue_statement(parser: Parser) -> BlockStatementParseResult {
     let original = parser;
     let mut current = skip_trivia(parser);
     if !identifier_matches(parser_peek_raw(current), "continue") {
-        return BlockStatementParseResult { parser: original, statement: null, success: false };
+        return BlockStatementParseResult {
+            parser: original,
+            statement: null,
+            success: false
+        };
     }
     current = consume_keyword(current, "continue");
 
@@ -443,7 +504,11 @@ fn parse_if_statement(parser: Parser, decorators: Decorator[]) -> BlockStatement
     let original = parser;
     let mut current = skip_trivia(parser);
     if !identifier_matches(parser_peek_raw(current), "if") {
-        return BlockStatementParseResult { parser: original, statement: null, success: false };
+        return BlockStatementParseResult {
+            parser: original,
+            statement: null,
+            success: false
+        };
     }
     current = consume_keyword(current, "if");
 
@@ -451,13 +516,21 @@ fn parse_if_statement(parser: Parser, decorators: Decorator[]) -> BlockStatement
     current = condition_capture.parser;
     let condition_tokens = trim_token_edges(condition_capture.tokens);
     if condition_tokens.length == 0 {
-        return BlockStatementParseResult { parser: original, statement: null, success: false };
+        return BlockStatementParseResult {
+            parser: original,
+            statement: null,
+            success: false
+        };
     }
     let condition_expression = expression_from_tokens(condition_tokens);
 
     let then_result = parse_block(current);
     if then_result.block.tokens.length == 0 {
-        return BlockStatementParseResult { parser: original, statement: null, success: false };
+        return BlockStatementParseResult {
+            parser: original,
+            statement: null,
+            success: false
+        };
     }
     current = then_result.parser;
     let then_block = then_result.block;
@@ -471,25 +544,43 @@ fn parse_if_statement(parser: Parser, decorators: Decorator[]) -> BlockStatement
         if identifier_matches(next_token, "if") {
             let nested_result = parse_if_statement(current, []);
             if !nested_result.success {
-                return BlockStatementParseResult { parser: original, statement: null, success: false };
+                return BlockStatementParseResult {
+                    parser: original,
+                    statement: null,
+                    success: false
+                };
             }
             if nested_result.statement == null {
-                return BlockStatementParseResult { parser: original, statement: null, success: false };
+                return BlockStatementParseResult {
+                    parser: original,
+                    statement: null,
+                    success: false
+                };
             }
             current = nested_result.parser;
-            else_branch = ElseBranch { statement: nested_result.statement, body: null };
+            else_branch = ElseBranch {
+                statement: nested_result.statement,
+                body: null
+            };
         } else {
             let else_result = parse_block(current);
             if else_result.block.tokens.length == 0 {
-                return BlockStatementParseResult { parser: original, statement: null, success: false };
+                return BlockStatementParseResult {
+                    parser: original,
+                    statement: null,
+                    success: false
+                };
             }
             current = else_result.parser;
-            else_branch = ElseBranch { statement: null, body: else_result.block };
+            else_branch = ElseBranch {
+                statement: null,
+                body: else_result.block
+            };
         }
 
         current = skip_trivia(current);
         let terminator = parser_peek_raw(current);
-    if symbol_matches(terminator, ";") {
+        if symbol_matches(terminator, ";") {
             current = parser_advance_raw(current);
         }
     }
@@ -511,12 +602,15 @@ fn parse_if_statement(parser: Parser, decorators: Decorator[]) -> BlockStatement
 // ============================================================================
 // Match Statement
 // ============================================================================
-
 fn parse_match_statement(parser: Parser, decorators: Decorator[]) -> BlockStatementParseResult {
     let original = parser;
     let mut current = skip_trivia(parser);
     if !identifier_matches(parser_peek_raw(current), "match") {
-        return BlockStatementParseResult { parser: original, statement: null, success: false };
+        return BlockStatementParseResult {
+            parser: original,
+            statement: null,
+            success: false
+        };
     }
     current = consume_keyword(current, "match");
 
@@ -524,13 +618,21 @@ fn parse_match_statement(parser: Parser, decorators: Decorator[]) -> BlockStatem
     current = value_capture.parser;
     let value_tokens = trim_token_edges(value_capture.tokens);
     if value_tokens.length == 0 {
-        return BlockStatementParseResult { parser: original, statement: null, success: false };
+        return BlockStatementParseResult {
+            parser: original,
+            statement: null,
+            success: false
+        };
     }
     let match_expression = expression_from_tokens(value_tokens);
 
     let body_result = parse_match_cases(current);
     if !body_result.success {
-        return BlockStatementParseResult { parser: original, statement: null, success: false };
+        return BlockStatementParseResult {
+            parser: original,
+            statement: null,
+            success: false
+        };
     }
     current = body_result.parser;
 
@@ -560,7 +662,11 @@ fn parse_match_cases(parser: Parser) -> MatchCasesParseResult {
     current = advance_to_symbol_local(current, "{");
     let peek = parser_peek_raw(current);
     if !symbol_matches(peek, "{") {
-        return MatchCasesParseResult { parser: parser, cases: [], success: false };
+        return MatchCasesParseResult {
+            parser: parser,
+            cases: [],
+            success: false
+        };
     }
     current = parser_advance_raw(current);
 
@@ -574,7 +680,11 @@ fn parse_match_cases(parser: Parser) -> MatchCasesParseResult {
             break;
         }
         if token.kind.variant == "EndOfFile" {
-            return MatchCasesParseResult { parser: parser, cases: [], success: false };
+            return MatchCasesParseResult {
+                parser: parser,
+                cases: [],
+                success: false
+            };
         }
 
         let case_result = parse_match_case(current);
@@ -582,7 +692,11 @@ fn parse_match_cases(parser: Parser) -> MatchCasesParseResult {
         if !case_result.success { _if411 = true; }
         if case_result.case == null { _if411 = true; }
         if _if411 {
-            return MatchCasesParseResult { parser: parser, cases: [], success: false };
+            return MatchCasesParseResult {
+                parser: parser,
+                cases: [],
+                success: false
+            };
         }
         current = case_result.parser;
         cases = append_match_case(cases, case_result.case);
@@ -594,7 +708,11 @@ fn parse_match_cases(parser: Parser) -> MatchCasesParseResult {
         }
     }
 
-    return MatchCasesParseResult { parser: current, cases: cases, success: true };
+    return MatchCasesParseResult {
+        parser: current,
+        cases: cases,
+        success: true
+    };
 }
 
 fn parse_match_case(parser: Parser) -> MatchCaseParseResult {
@@ -608,12 +726,20 @@ fn parse_match_case(parser: Parser) -> MatchCaseParseResult {
 
     let pattern_capture = collect_pattern_until_arrow(current);
     if !pattern_capture.success {
-        return MatchCaseParseResult { parser: original, case: null, success: false };
+        return MatchCaseParseResult {
+            parser: original,
+            case: null,
+            success: false
+        };
     }
     current = pattern_capture.parser;
     let split_tokens = split_match_case_tokens(pattern_capture.tokens);
     if split_tokens.pattern_tokens.length == 0 {
-        return MatchCaseParseResult { parser: original, case: null, success: false };
+        return MatchCaseParseResult {
+            parser: original,
+            case: null,
+            success: false
+        };
     }
 
     let pattern_expression = expression_from_tokens(split_tokens.pattern_tokens);
@@ -621,7 +747,11 @@ fn parse_match_case(parser: Parser) -> MatchCaseParseResult {
     let mut guard_expression: Expression? = null;
     if split_tokens.has_guard {
         if split_tokens.guard_tokens.length == 0 {
-            return MatchCaseParseResult { parser: original, case: null, success: false };
+            return MatchCaseParseResult {
+                parser: original,
+                case: null,
+                success: false
+            };
         }
         guard_expression = expression_from_tokens(split_tokens.guard_tokens);
     }
@@ -634,7 +764,11 @@ fn parse_match_case(parser: Parser) -> MatchCaseParseResult {
     if symbol_matches(next, "{") {
         let body_result = parse_block(current);
         if body_result.block.tokens.length == 0 {
-            return MatchCaseParseResult { parser: original, case: null, success: false };
+            return MatchCaseParseResult {
+                parser: original,
+                case: null,
+                success: false
+            };
         }
         current = body_result.parser;
         body = body_result.block;
@@ -647,9 +781,7 @@ fn parse_match_case(parser: Parser) -> MatchCaseParseResult {
         let capture = collect_until(current, [";", ",", "}"]);
         let mut index: number = 0;
         loop {
-            if index >= capture.tokens.length {
-                break;
-            }
+            if index >= capture.tokens.length { break; }
             block_tokens = append_token(block_tokens, capture.tokens[index]);
             index += 1;
         }
@@ -664,24 +796,34 @@ fn parse_match_case(parser: Parser) -> MatchCaseParseResult {
 
         current = skip_trivia(capture.parser);
         let terminator = parser_peek_raw(current);
-    if symbol_matches(terminator, ";") {
+        if symbol_matches(terminator, ";") {
             block_tokens = append_token(block_tokens, terminator);
             current = parser_advance_raw(current);
         }
 
-    block_tokens = trim_token_edges(block_tokens);
+        block_tokens = trim_token_edges(block_tokens);
 
-    let statement_span = source_span_from_tokens(block_tokens);
+        let statement_span = source_span_from_tokens(block_tokens);
 
-    let mut statements: Statement[] = [];
-    statements = append_statement(statements, Statement.ReturnStatement { expression: return_expression, span: statement_span });
+        let mut statements: Statement[] = [];
+        statements = append_statement(statements, Statement.ReturnStatement {
+            expression: return_expression, span: statement_span
+        });
         let text = trim_text(tokens_to_text(block_tokens));
-        body = Block { tokens: block_tokens, text: text, statements: statements };
+        body = Block {
+            tokens: block_tokens,
+            text: text,
+            statements: statements
+        };
     } else {
         let capture = collect_until(current, [";", ",", "}"]);
         let trimmed_expression_tokens = trim_token_edges(capture.tokens);
         if trimmed_expression_tokens.length == 0 {
-            return MatchCaseParseResult { parser: original, case: null, success: false };
+            return MatchCaseParseResult {
+                parser: original,
+                case: null,
+                success: false
+            };
         }
 
         let expression = expression_from_tokens(trimmed_expression_tokens);
@@ -689,32 +831,40 @@ fn parse_match_case(parser: Parser) -> MatchCaseParseResult {
         let mut block_tokens: Token[] = [];
         let mut index: number = 0;
         loop {
-            if index >= capture.tokens.length {
-                break;
-            }
+            if index >= capture.tokens.length { break; }
             block_tokens = append_token(block_tokens, capture.tokens[index]);
             index += 1;
         }
 
         current = skip_trivia(capture.parser);
         let terminator = parser_peek_raw(current);
-    if symbol_matches(terminator, ";") {
+        if symbol_matches(terminator, ";") {
             block_tokens = append_token(block_tokens, terminator);
             current = parser_advance_raw(current);
         }
 
-    block_tokens = trim_token_edges(block_tokens);
+        block_tokens = trim_token_edges(block_tokens);
 
-    let statement_span = source_span_from_tokens(block_tokens);
+        let statement_span = source_span_from_tokens(block_tokens);
 
-    let mut statements: Statement[] = [];
-    statements = append_statement(statements, Statement.ExpressionStatement { expression: expression, span: statement_span });
+        let mut statements: Statement[] = [];
+        statements = append_statement(statements, Statement.ExpressionStatement {
+            expression: expression, span: statement_span
+        });
         let text = trim_text(tokens_to_text(block_tokens));
-        body = Block { tokens: block_tokens, text: text, statements: statements };
+        body = Block {
+            tokens: block_tokens,
+            text: text,
+            statements: statements
+        };
     }
 
     if body == null {
-        return MatchCaseParseResult { parser: original, case: null, success: false };
+        return MatchCaseParseResult {
+            parser: original,
+            case: null,
+            success: false
+        };
     }
 
     let case = MatchCase {
@@ -723,7 +873,11 @@ fn parse_match_case(parser: Parser) -> MatchCaseParseResult {
         body: body,
     };
 
-    return MatchCaseParseResult { parser: current, case: case, success: true };
+    return MatchCaseParseResult {
+        parser: current,
+        case: case,
+        success: true
+    };
 }
 
 fn split_match_case_tokens(tokens: Token[]) -> MatchCaseTokenSplit {
@@ -758,13 +912,16 @@ fn split_match_case_tokens(tokens: Token[]) -> MatchCaseTokenSplit {
 // ============================================================================
 // Special Statements (prompt, with)
 // ============================================================================
-
 fn parse_prompt_statement(parser: Parser, decorators: Decorator[]) -> BlockStatementParseResult {
     let original = parser;
     let mut current = skip_trivia(parser);
     let prompt_token = parser_peek_raw(current);
     if !identifier_matches(prompt_token, "prompt") {
-        return BlockStatementParseResult { parser: original, statement: null, success: false };
+        return BlockStatementParseResult {
+            parser: original,
+            statement: null,
+            success: false
+        };
     }
     current = consume_keyword(current, "prompt");
 
@@ -778,12 +935,20 @@ fn parse_prompt_statement(parser: Parser, decorators: Decorator[]) -> BlockState
         channel = string_literal_value(channel_token);
         current = parser_advance_raw(current);
     } else {
-        return BlockStatementParseResult { parser: original, statement: null, success: false };
+        return BlockStatementParseResult {
+            parser: original,
+            statement: null,
+            success: false
+        };
     }
 
     let block_result = parse_block(current);
     if block_result.block.tokens.length == 0 {
-        return BlockStatementParseResult { parser: original, statement: null, success: false };
+        return BlockStatementParseResult {
+            parser: original,
+            statement: null,
+            success: false
+        };
     }
     current = block_result.parser;
     let body = block_result.block;
@@ -811,7 +976,11 @@ fn parse_with_statement(parser: Parser, decorators: Decorator[]) -> BlockStateme
     let original = parser;
     let mut current = skip_trivia(parser);
     if !identifier_matches(parser_peek_raw(current), "with") {
-        return BlockStatementParseResult { parser: original, statement: null, success: false };
+        return BlockStatementParseResult {
+            parser: original,
+            statement: null,
+            success: false
+        };
     }
     current = consume_keyword(current, "with");
 
@@ -821,20 +990,24 @@ fn parse_with_statement(parser: Parser, decorators: Decorator[]) -> BlockStateme
     let mut clauses: WithClause[] = [];
     let mut index: number = 0;
     loop {
-        if index >= clause_slices.length {
-            break;
-        }
+        if index >= clause_slices.length { break; }
         let slice_tokens = trim_token_edges(clause_slices[index]);
         if slice_tokens.length > 0 {
             let expression = expression_from_tokens(slice_tokens);
-            clauses = append_with_clause(clauses, WithClause { expression: expression });
+            clauses = append_with_clause(clauses, WithClause {
+                expression: expression
+            });
         }
         index += 1;
     }
 
     let block_result = parse_block(current);
     if block_result.block.tokens.length == 0 {
-        return BlockStatementParseResult { parser: original, statement: null, success: false };
+        return BlockStatementParseResult {
+            parser: original,
+            statement: null,
+            success: false
+        };
     }
     current = block_result.parser;
     let body = block_result.block;
@@ -860,12 +1033,15 @@ fn parse_with_statement(parser: Parser, decorators: Decorator[]) -> BlockStateme
 // ============================================================================
 // Return, Throw, Try/Catch, Assert
 // ============================================================================
-
 fn parse_return_statement(parser: Parser) -> BlockStatementParseResult {
     let original = parser;
     let mut current = skip_trivia(parser);
     if !identifier_matches(parser_peek_raw(current), "return") {
-        return BlockStatementParseResult { parser: original, statement: null, success: false };
+        return BlockStatementParseResult {
+            parser: original,
+            statement: null,
+            success: false
+        };
     }
     let mut statement_tokens: Token[] = [];
     statement_tokens = append_token(statement_tokens, parser_peek_raw(current));
@@ -876,17 +1052,13 @@ fn parse_return_statement(parser: Parser) -> BlockStatementParseResult {
     let trimmed = trim_token_edges(capture.tokens);
 
     let mut expression: Expression? = null;
-    if trimmed.length > 0 {
-        expression = expression_from_tokens(trimmed);
-    } else if capture.tokens.length > 0 {
+    if trimmed.length > 0 { expression = expression_from_tokens(trimmed); } else if capture.tokens.length > 0 {
         expression = expression_from_tokens(capture.tokens);
     }
 
     let mut index: number = 0;
     loop {
-        if index >= capture.tokens.length {
-            break;
-        }
+        if index >= capture.tokens.length { break; }
         statement_tokens = append_token(statement_tokens, capture.tokens[index]);
         index += 1;
     }
@@ -900,7 +1072,10 @@ fn parse_return_statement(parser: Parser) -> BlockStatementParseResult {
 
     let span = source_span_from_tokens(statement_tokens);
 
-    let statement = Statement.ReturnStatement { expression: expression, span: span };
+    let statement = Statement.ReturnStatement {
+        expression: expression,
+        span: span
+    };
     return BlockStatementParseResult {
         parser: current,
         statement: statement,
@@ -912,7 +1087,11 @@ fn parse_throw_statement(parser: Parser) -> BlockStatementParseResult {
     let original = parser;
     let mut current = skip_trivia(parser);
     if !identifier_matches(parser_peek_raw(current), "throw") {
-        return BlockStatementParseResult { parser: original, statement: null, success: false };
+        return BlockStatementParseResult {
+            parser: original,
+            statement: null,
+            success: false
+        };
     }
 
     let mut statement_tokens: Token[] = [];
@@ -923,14 +1102,16 @@ fn parse_throw_statement(parser: Parser) -> BlockStatementParseResult {
     current = capture.parser;
     let trimmed = trim_token_edges(capture.tokens);
     if trimmed.length == 0 {
-        return BlockStatementParseResult { parser: original, statement: null, success: false };
+        return BlockStatementParseResult {
+            parser: original,
+            statement: null,
+            success: false
+        };
     }
 
     let mut index: number = 0;
     loop {
-        if index >= capture.tokens.length {
-            break;
-        }
+        if index >= capture.tokens.length { break; }
         statement_tokens = append_token(statement_tokens, capture.tokens[index]);
         index += 1;
     }
@@ -944,23 +1125,38 @@ fn parse_throw_statement(parser: Parser) -> BlockStatementParseResult {
 
     let span = source_span_from_tokens(statement_tokens);
     let expression = expression_from_tokens(trimmed);
-    let statement = Statement.ThrowStatement { expression: expression, span: span };
+    let statement = Statement.ThrowStatement {
+        expression: expression,
+        span: span
+    };
 
-    return BlockStatementParseResult { parser: current, statement: statement, success: true };
+    return BlockStatementParseResult {
+        parser: current,
+        statement: statement,
+        success: true
+    };
 }
 
 fn parse_try_statement(parser: Parser) -> BlockStatementParseResult {
     let original = parser;
     let mut current = skip_trivia(parser);
     if !identifier_matches(parser_peek_raw(current), "try") {
-        return BlockStatementParseResult { parser: original, statement: null, success: false };
+        return BlockStatementParseResult {
+            parser: original,
+            statement: null,
+            success: false
+        };
     }
 
     current = consume_keyword(current, "try");
 
     let try_result = parse_block(current);
     if try_result.block.tokens.length == 0 {
-        return BlockStatementParseResult { parser: original, statement: null, success: false };
+        return BlockStatementParseResult {
+            parser: original,
+            statement: null,
+            success: false
+        };
     }
     current = try_result.parser;
 
@@ -979,7 +1175,11 @@ fn parse_try_statement(parser: Parser) -> BlockStatementParseResult {
             current = skip_trivia(current);
             let name_token = parser_peek_raw(current);
             if name_token.kind.variant != "Identifier" {
-                return BlockStatementParseResult { parser: original, statement: null, success: false };
+                return BlockStatementParseResult {
+                    parser: original,
+                    statement: null,
+                    success: false
+                };
             }
             catch_name = name_token.lexeme;
             catch_name_token = name_token;
@@ -987,14 +1187,22 @@ fn parse_try_statement(parser: Parser) -> BlockStatementParseResult {
 
             current = skip_trivia(current);
             if !symbol_matches(parser_peek_raw(current), ")") {
-                return BlockStatementParseResult { parser: original, statement: null, success: false };
+                return BlockStatementParseResult {
+                    parser: original,
+                    statement: null,
+                    success: false
+                };
             }
             current = parser_advance_raw(current);
         }
 
         let catch_result = parse_block(current);
         if catch_result.block.tokens.length == 0 {
-            return BlockStatementParseResult { parser: original, statement: null, success: false };
+            return BlockStatementParseResult {
+                parser: original,
+                statement: null,
+                success: false
+            };
         }
         catch_block = catch_result.block;
         current = catch_result.parser;
@@ -1006,7 +1214,11 @@ fn parse_try_statement(parser: Parser) -> BlockStatementParseResult {
         current = consume_keyword(current, "finally");
         let finally_result = parse_block(current);
         if finally_result.block.tokens.length == 0 {
-            return BlockStatementParseResult { parser: original, statement: null, success: false };
+            return BlockStatementParseResult {
+                parser: original,
+                statement: null,
+                success: false
+            };
         }
         finally_block = finally_result.block;
         current = finally_result.parser;
@@ -1026,14 +1238,22 @@ fn parse_try_statement(parser: Parser) -> BlockStatementParseResult {
         finally_block: finally_block,
     };
 
-    return BlockStatementParseResult { parser: current, statement: statement, success: true };
+    return BlockStatementParseResult {
+        parser: current,
+        statement: statement,
+        success: true
+    };
 }
 
 fn parse_assert_statement(parser: Parser) -> BlockStatementParseResult {
     let original = parser;
     let mut current = skip_trivia(parser);
     if !identifier_matches(parser_peek_raw(current), "assert") {
-        return BlockStatementParseResult { parser: original, statement: null, success: false };
+        return BlockStatementParseResult {
+            parser: original,
+            statement: null,
+            success: false
+        };
     }
 
     let mut statement_tokens: Token[] = [];
@@ -1044,14 +1264,16 @@ fn parse_assert_statement(parser: Parser) -> BlockStatementParseResult {
     current = capture.parser;
     let trimmed = trim_token_edges(capture.tokens);
     if trimmed.length == 0 {
-        return BlockStatementParseResult { parser: original, statement: null, success: false };
+        return BlockStatementParseResult {
+            parser: original,
+            statement: null,
+            success: false
+        };
     }
 
     let mut index: number = 0;
     loop {
-        if index >= capture.tokens.length {
-            break;
-        }
+        if index >= capture.tokens.length { break; }
         statement_tokens = append_token(statement_tokens, capture.tokens[index]);
         index += 1;
     }
@@ -1059,7 +1281,11 @@ fn parse_assert_statement(parser: Parser) -> BlockStatementParseResult {
     current = skip_trivia(current);
     let terminator = parser_peek_raw(current);
     if !symbol_matches(terminator, ";") {
-        return BlockStatementParseResult { parser: original, statement: null, success: false };
+        return BlockStatementParseResult {
+            parser: original,
+            statement: null,
+            success: false
+        };
     }
     statement_tokens = append_token(statement_tokens, terminator);
     current = parser_advance_raw(current);
@@ -1070,10 +1296,17 @@ fn parse_assert_statement(parser: Parser) -> BlockStatementParseResult {
         callee: Expression.Identifier { name: "runtime_raise_value_error_fn" },
         arguments: [Expression.StringLiteral { value: "assertion failed" }],
     };
-    let fail_statement = Statement.ExpressionStatement { expression: fail_call, span: null };
+    let fail_statement = Statement.ExpressionStatement {
+        expression: fail_call,
+        span: null
+    };
 
     let then_block = Block { tokens: [], text: "", statements: [] };
-    let else_block = Block { tokens: [], text: "", statements: [fail_statement] };
+    let else_block = Block {
+        tokens: [],
+        text: "",
+        statements: [fail_statement]
+    };
     let else_branch = ElseBranch { statement: null, body: else_block };
 
     let statement = Statement.IfStatement {
@@ -1092,16 +1325,23 @@ fn parse_assert_statement(parser: Parser) -> BlockStatementParseResult {
 // ============================================================================
 // Expression Statement
 // ============================================================================
-
 fn parse_expression_statement(parser: Parser, decorators: Decorator[]) -> BlockStatementParseResult {
     if decorators.length > 0 {
-        return BlockStatementParseResult { parser: parser, statement: null, success: false };
+        return BlockStatementParseResult {
+            parser: parser,
+            statement: null,
+            success: false
+        };
     }
 
     let mut current = skip_trivia(parser);
     let start = parser_peek_raw(current);
     if start.kind.variant == "EndOfFile" {
-        return BlockStatementParseResult { parser: parser, statement: null, success: false };
+        return BlockStatementParseResult {
+            parser: parser,
+            statement: null,
+            success: false
+        };
     }
     if start.kind.variant == "Symbol" {
         let sym = start.lexeme;
@@ -1109,7 +1349,11 @@ fn parse_expression_statement(parser: Parser, decorators: Decorator[]) -> BlockS
         if strings_equal(sym, "}") { _if412 = true; }
         if strings_equal(sym, "{") { _if412 = true; }
         if _if412 {
-            return BlockStatementParseResult { parser: parser, statement: null, success: false };
+            return BlockStatementParseResult {
+                parser: parser,
+                statement: null,
+                success: false
+            };
         }
     }
 
@@ -1118,22 +1362,28 @@ fn parse_expression_statement(parser: Parser, decorators: Decorator[]) -> BlockS
     // block close '}' to omit the semicolon.
     let capture = collect_until(current, [";", "}"]);
     if capture.tokens.length == 0 {
-        return BlockStatementParseResult { parser: parser, statement: null, success: false };
+        return BlockStatementParseResult {
+            parser: parser,
+            statement: null,
+            success: false
+        };
     }
 
     let mut statement_tokens: Token[] = [];
     let mut token_index: number = 0;
     loop {
-        if token_index >= capture.tokens.length {
-            break;
-        }
+        if token_index >= capture.tokens.length { break; }
         statement_tokens = append_token(statement_tokens, capture.tokens[token_index]);
         token_index += 1;
     }
 
     let trimmed = trim_token_edges(capture.tokens);
     if trimmed.length == 0 {
-        return BlockStatementParseResult { parser: parser, statement: null, success: false };
+        return BlockStatementParseResult {
+            parser: parser,
+            statement: null,
+            success: false
+        };
     }
 
     current = capture.parser;
@@ -1145,12 +1395,19 @@ fn parse_expression_statement(parser: Parser, decorators: Decorator[]) -> BlockS
         statement_tokens = append_token(statement_tokens, terminator);
         current = parser_advance_raw(current);
     } else if !symbol_matches(terminator, "}") {
-        return BlockStatementParseResult { parser: parser, statement: null, success: false };
+        return BlockStatementParseResult {
+            parser: parser,
+            statement: null,
+            success: false
+        };
     }
 
     let expression = expression_from_tokens(trimmed);
     let span = source_span_from_tokens(statement_tokens);
-    let statement = Statement.ExpressionStatement { expression: expression, span: span };
+    let statement = Statement.ExpressionStatement {
+        expression: expression,
+        span: span
+    };
     return BlockStatementParseResult {
         parser: current,
         statement: statement,
@@ -1161,7 +1418,6 @@ fn parse_expression_statement(parser: Parser, decorators: Decorator[]) -> BlockS
 // ============================================================================
 // Unknown Statement (fallback)
 // ============================================================================
-
 fn parse_unknown_statement(initial_parser: Parser) -> StatementParseResult {
     let mut parser: Parser = initial_parser;
     parser = skip_trivia(parser);
@@ -1182,12 +1438,8 @@ fn parse_unknown_statement(initial_parser: Parser) -> StatementParseResult {
         let tok = parser_peek_raw(current);
         tokens = append_token(tokens, tok);
 
-        if symbol_matches(tok, "{") {
-            depth += 1;
-        } else if symbol_matches(tok, "}") {
-            if depth > 0 {
-                depth -= 1;
-            }
+        if symbol_matches(tok, "{") { depth += 1; } else if symbol_matches(tok, "}") {
+            if depth > 0 { depth -= 1; }
             if depth == 0 {
                 current = parser_advance_raw(current);
                 break;
@@ -1195,9 +1447,7 @@ fn parse_unknown_statement(initial_parser: Parser) -> StatementParseResult {
         } else {
             let mut _elif413: boolean = false;
             if depth == 0 {
-                if symbol_matches(tok, ";") {
-                    _elif413 = true;
-                }
+                if symbol_matches(tok, ";") { _elif413 = true; }
             }
             if _elif413 {
                 current = parser_advance_raw(current);
@@ -1214,9 +1464,7 @@ fn parse_unknown_statement(initial_parser: Parser) -> StatementParseResult {
     }
 
     let mut text: string = tokens_to_text(tokens);
-    if truncated {
-        text = text + " /* parse_unknown truncated */";
-    }
+    if truncated { text = text + " /* parse_unknown truncated */"; }
     let block = Statement.Unknown { tokens: tokens, text: text };
     parser = skip_trivia(current);
     return StatementParseResult { parser: parser, statement: block };
@@ -1234,16 +1482,10 @@ fn advance_to_symbol_local(parser: Parser, symbol: string) -> Parser {
     loop {
         current = skip_trivia(current);
         let token = parser_peek_raw(current);
-        if symbol_matches(token, symbol) {
-            return current;
-        }
-        if token.kind.variant == "EndOfFile" {
-            return current;
-        }
+        if symbol_matches(token, symbol) { return current; }
+        if token.kind.variant == "EndOfFile" { return current; }
         let next = parser_advance_raw(current);
-        if next.index == current.index {
-            return current;
-        }
+        if next.index == current.index { return current; }
         current = next;
     }
     return current;
@@ -1252,7 +1494,6 @@ fn advance_to_symbol_local(parser: Parser, symbol: string) -> Parser {
 // ============================================================================
 // Append Helpers
 // ============================================================================
-
 fn append_statement(statements: Statement[], statement: Statement) -> Statement[] {
     statements.push(statement);
     return statements;

--- a/compiler/src/parser/statements.sfn
+++ b/compiler/src/parser/statements.sfn
@@ -11,7 +11,7 @@ import {
     MatchCase,
     SourceSpan,
     Statement,
-    WithClause,
+    WithClause
 } from "../ast";
 import {
     char_at,
@@ -39,7 +39,7 @@ import {
     symbol_matches,
     token_slice,
     tokens_to_text,
-    trim_token_edges,
+    trim_token_edges
 } from "./token_utils";
 import {
     BlockParseResult,
@@ -49,7 +49,7 @@ import {
     MatchCaseTokenSplit,
     MatchCasesParseResult,
     Parser,
-    StatementParseResult,
+    StatementParseResult
 } from "./types";
 import { trim_text } from "./utils";
 
@@ -117,7 +117,7 @@ fn parse_block(initial_parser: Parser) -> BlockParseResult {
     if !symbol_matches(token, "{") {
         return BlockParseResult {
             parser: parser,
-            block: Block { tokens: [], text: "", statements: [] },
+            block: Block { tokens: [], text: "", statements: [] }
         };
     }
 
@@ -215,7 +215,7 @@ fn parse_block_statement(parser: Parser) -> BlockStatementParseResult {
         return BlockStatementParseResult {
             parser: body_result.parser,
             statement: Statement.BlockStatement { body: body_result.block },
-            success: true,
+            success: true
         };
     }
     if identifier_matches(token, "for") {
@@ -270,7 +270,7 @@ fn parse_block_statement(parser: Parser) -> BlockStatementParseResult {
         return BlockStatementParseResult {
             parser: body_result.parser,
             statement: Statement.BlockStatement { body: body_result.block },
-            success: true,
+            success: true
         };
     }
     if identifier_matches(token, "return") {
@@ -360,7 +360,8 @@ fn parse_for_statement(parser: Parser, decorators: Decorator[]) -> BlockStatemen
     }
 
     let target_tokens = trim_token_edges(token_slice(clause_tokens, 0, in_index));
-    let iterable_tokens = trim_token_edges(token_slice(clause_tokens, in_index + 1, clause_tokens.length));
+    let iterable_tokens = trim_token_edges(token_slice(clause_tokens, in_index
+        + 1, clause_tokens.length));
     let mut _if410: boolean = false;
     if target_tokens.length == 0 { _if410 = true; }
     if iterable_tokens.length == 0 { _if410 = true; }
@@ -377,7 +378,7 @@ fn parse_for_statement(parser: Parser, decorators: Decorator[]) -> BlockStatemen
     let clause = ForClause {
         target: target_expression,
         iterable: iterable_expression,
-        tokens: clause_tokens,
+        tokens: clause_tokens
     };
 
     let body_result = parse_block(current);
@@ -400,13 +401,13 @@ fn parse_for_statement(parser: Parser, decorators: Decorator[]) -> BlockStatemen
     let statement = Statement.ForStatement {
         clause: clause,
         body: body,
-        decorators: decorators,
+        decorators: decorators
     };
 
     return BlockStatementParseResult {
         parser: current,
         statement: statement,
-        success: true,
+        success: true
     };
 }
 
@@ -440,13 +441,13 @@ fn parse_loop_statement(parser: Parser, decorators: Decorator[]) -> BlockStateme
 
     let statement = Statement.LoopStatement {
         body: body_result.block,
-        decorators: decorators,
+        decorators: decorators
     };
 
     return BlockStatementParseResult {
         parser: current,
         statement: statement,
-        success: true,
+        success: true
     };
 }
 
@@ -471,7 +472,7 @@ fn parse_break_statement(parser: Parser) -> BlockStatementParseResult {
     return BlockStatementParseResult {
         parser: current,
         statement: Statement.BreakStatement(),
-        success: true,
+        success: true
     };
 }
 
@@ -496,7 +497,7 @@ fn parse_continue_statement(parser: Parser) -> BlockStatementParseResult {
     return BlockStatementParseResult {
         parser: current,
         statement: Statement.ContinueStatement(),
-        success: true,
+        success: true
     };
 }
 
@@ -589,13 +590,13 @@ fn parse_if_statement(parser: Parser, decorators: Decorator[]) -> BlockStatement
         condition: condition_expression,
         then_block: then_block,
         else_branch: else_branch,
-        decorators: decorators,
+        decorators: decorators
     };
 
     return BlockStatementParseResult {
         parser: current,
         statement: statement,
-        success: true,
+        success: true
     };
 }
 
@@ -647,13 +648,13 @@ fn parse_match_statement(parser: Parser, decorators: Decorator[]) -> BlockStatem
     let statement = Statement.MatchStatement {
         expression: match_expression,
         cases: body_result.cases,
-        decorators: decorators,
+        decorators: decorators
     };
 
     return BlockStatementParseResult {
         parser: current,
         statement: statement,
-        success: true,
+        success: true
     };
 }
 
@@ -870,7 +871,7 @@ fn parse_match_case(parser: Parser) -> MatchCaseParseResult {
     let case = MatchCase {
         pattern: pattern_expression,
         guard: guard_expression,
-        body: body,
+        body: body
     };
 
     return MatchCaseParseResult {
@@ -886,7 +887,7 @@ fn split_match_case_tokens(tokens: Token[]) -> MatchCaseTokenSplit {
         return MatchCaseTokenSplit {
             pattern_tokens: [],
             guard_tokens: [],
-            has_guard: false,
+            has_guard: false
         };
     }
 
@@ -895,7 +896,7 @@ fn split_match_case_tokens(tokens: Token[]) -> MatchCaseTokenSplit {
         return MatchCaseTokenSplit {
             pattern_tokens: trimmed,
             guard_tokens: [],
-            has_guard: false,
+            has_guard: false
         };
     }
 
@@ -905,7 +906,7 @@ fn split_match_case_tokens(tokens: Token[]) -> MatchCaseTokenSplit {
     return MatchCaseTokenSplit {
         pattern_tokens: pattern_tokens,
         guard_tokens: guard_tokens,
-        has_guard: true,
+        has_guard: true
     };
 }
 
@@ -963,12 +964,12 @@ fn parse_prompt_statement(parser: Parser, decorators: Decorator[]) -> BlockState
         keyword_token: prompt_token,
         channel_token: channel_token,
         body: body,
-        decorators: decorators,
+        decorators: decorators
     };
     return BlockStatementParseResult {
         parser: current,
         statement: statement,
-        success: true,
+        success: true
     };
 }
 
@@ -1020,13 +1021,13 @@ fn parse_with_statement(parser: Parser, decorators: Decorator[]) -> BlockStateme
     let statement = Statement.WithStatement {
         clauses: clauses,
         body: body,
-        decorators: decorators,
+        decorators: decorators
     };
 
     return BlockStatementParseResult {
         parser: current,
         statement: statement,
-        success: true,
+        success: true
     };
 }
 
@@ -1079,7 +1080,7 @@ fn parse_return_statement(parser: Parser) -> BlockStatementParseResult {
     return BlockStatementParseResult {
         parser: current,
         statement: statement,
-        success: true,
+        success: true
     };
 }
 
@@ -1235,7 +1236,7 @@ fn parse_try_statement(parser: Parser) -> BlockStatementParseResult {
         catch_name: catch_name,
         catch_name_token: catch_name_token,
         catch_block: catch_block,
-        finally_block: finally_block,
+        finally_block: finally_block
     };
 
     return BlockStatementParseResult {
@@ -1294,7 +1295,7 @@ fn parse_assert_statement(parser: Parser) -> BlockStatementParseResult {
 
     let fail_call = Expression.Call {
         callee: Expression.Identifier { name: "runtime_raise_value_error_fn" },
-        arguments: [Expression.StringLiteral { value: "assertion failed" }],
+        arguments: [Expression.StringLiteral { value: "assertion failed" }]
     };
     let fail_statement = Statement.ExpressionStatement {
         expression: fail_call,
@@ -1313,12 +1314,12 @@ fn parse_assert_statement(parser: Parser) -> BlockStatementParseResult {
         condition: condition,
         then_block: then_block,
         else_branch: else_branch,
-        decorators: [],
+        decorators: []
     };
     return BlockStatementParseResult {
         parser: current,
         statement: statement,
-        success: true,
+        success: true
     };
 }
 
@@ -1411,7 +1412,7 @@ fn parse_expression_statement(parser: Parser, decorators: Decorator[]) -> BlockS
     return BlockStatementParseResult {
         parser: current,
         statement: statement,
-        success: true,
+        success: true
     };
 }
 

--- a/compiler/src/parser/token_utils.sfn
+++ b/compiler/src/parser/token_utils.sfn
@@ -33,7 +33,7 @@ fn parser_peek_raw(parser: Parser) -> Token {
 fn parser_advance_raw(parser: Parser) -> Parser {
     if parser.tokens == null { return parser; }
     if parser.index + 1 > parser.tokens.length { return parser; }
-    return Parser { tokens: parser.tokens, index: parser.index + 1, };
+    return Parser { tokens: parser.tokens, index: parser.index + 1 };
 }
 
 fn skip_trivia(parser: Parser) -> Parser {
@@ -350,7 +350,7 @@ fn source_span_from_tokens(tokens: Token[]) -> SourceSpan? {
         start_line: start.line,
         start_column: start.column,
         end_line: end_line,
-        end_column: end_column,
+        end_column: end_column
     };
 }
 

--- a/compiler/src/parser/token_utils.sfn
+++ b/compiler/src/parser/token_utils.sfn
@@ -2,24 +2,28 @@
 //
 // Token manipulation utilities - functions for working with token arrays,
 // parser state management, trivia handling, and token-to-text conversion.
-
-import { Token, eof_token } from "../token";
 import { SourceSpan } from "../ast";
-import { substring, char_code, char_at, strings_equal } from "../string_utils";
-import { Parser, CaptureResult, ParenthesizedParseResult, PatternCaptureResult } from "./types";
+import {
+    char_at,
+    char_code,
+    strings_equal,
+    substring
+} from "../string_utils";
+import { Token, eof_token } from "../token";
+import {
+    CaptureResult,
+    ParenthesizedParseResult,
+    Parser,
+    PatternCaptureResult
+} from "./types";
 import { string_array_contains, trim_text } from "./utils";
 
 // ============================================================================
 // Parser State Operations
 // ============================================================================
-
 fn parser_peek_raw(parser: Parser) -> Token {
-    if parser.tokens == null {
-        return eof_token(0, 0);
-    }
-    if parser.tokens.length == 0 {
-        return eof_token(0, 0);
-    }
+    if parser.tokens == null { return eof_token(0, 0); }
+    if parser.tokens.length == 0 { return eof_token(0, 0); }
     if parser.index >= parser.tokens.length {
         return parser.tokens[parser.tokens.length - 1];
     }
@@ -27,27 +31,16 @@ fn parser_peek_raw(parser: Parser) -> Token {
 }
 
 fn parser_advance_raw(parser: Parser) -> Parser {
-    if parser.tokens == null {
-        return parser;
-    }
-    if parser.index + 1 > parser.tokens.length {
-        return parser;
-    }
-    return Parser {
-        tokens: parser.tokens,
-        index: parser.index + 1,
-    };
+    if parser.tokens == null { return parser; }
+    if parser.index + 1 > parser.tokens.length { return parser; }
+    return Parser { tokens: parser.tokens, index: parser.index + 1, };
 }
 
 fn skip_trivia(parser: Parser) -> Parser {
     let mut current = parser;
     loop {
-        if current.tokens == null {
-            break;
-        }
-        if current.index >= current.tokens.length {
-            break;
-        }
+        if current.tokens == null { break; }
+        if current.index >= current.tokens.length { break; }
         let token = current.tokens[current.index];
         if is_trivia_token(token) {
             current = parser_advance_raw(current);
@@ -62,9 +55,7 @@ fn is_end_of_file(parser: Parser, token: Token) -> boolean {
     // Avoid relying on `token.kind.variant` in native mode.
     // The lexer appends a final EOF token; treat the last token with an empty
     // lexeme as end-of-file.
-    if parser.tokens == null {
-        return true;
-    }
+    if parser.tokens == null { return true; }
     if parser.index + 1 >= parser.tokens.length {
         return token.lexeme.length == 0;
     }
@@ -74,14 +65,11 @@ fn is_end_of_file(parser: Parser, token: Token) -> boolean {
 // ============================================================================
 // Token Matching
 // ============================================================================
-
 fn identifier_matches(token: Token, expected: string) -> boolean {
     let lexeme = token.lexeme;
     let mut _ret414: boolean = false;
     if lexeme.length > 0 {
-        if strings_equal(lexeme, expected) {
-            _ret414 = true;
-        }
+        if strings_equal(lexeme, expected) { _ret414 = true; }
     }
     return _ret414;
 }
@@ -90,16 +78,12 @@ fn symbol_matches(token: Token, expected: string) -> boolean {
     let lexeme = token.lexeme;
     let mut _ret415: boolean = false;
     if lexeme.length > 0 {
-        if strings_equal(lexeme, expected) {
-            _ret415 = true;
-        }
+        if strings_equal(lexeme, expected) { _ret415 = true; }
     }
     return _ret415;
 }
 
-fn identifier_text(token: Token) -> string {
-    return token.lexeme;
-}
+fn identifier_text(token: Token) -> string { return token.lexeme; }
 
 fn string_literal_value(token: Token) -> string {
     let lexeme = token.lexeme;
@@ -108,29 +92,21 @@ fn string_literal_value(token: Token) -> string {
 }
 
 fn strip_surrounding_quotes_local(text: string) -> string {
-    if text.length < 2 {
-        return text;
-    }
+    if text.length < 2 { return text; }
     let first = char_code(char_at(text, 0));
     let last = char_code(char_at(text, text.length - 1));
     if first == 34 {
-        if last == 34 {
-            return substring(text, 1, text.length - 1);
-        }
+        if last == 34 { return substring(text, 1, text.length - 1); }
     }
     return text;
 }
 
 fn decode_string_literal_escapes_local(text: string) -> string {
-    if text.length == 0 {
-        return "";
-    }
+    if text.length == 0 { return ""; }
     let mut decoded: string = "";
     let mut index: number = 0;
     loop {
-        if index >= text.length {
-            break;
-        }
+        if index >= text.length { break; }
         let ch = char_at(text, index);
         if ch == "\\" {
             let next_index = index + 1;
@@ -140,17 +116,11 @@ fn decode_string_literal_escapes_local(text: string) -> string {
                 continue;
             }
             let escaped = char_at(text, next_index);
-            if escaped == "n" {
-                decoded = decoded + "\n";
-            } else if escaped == "t" {
+            if escaped == "n" { decoded = decoded + "\n"; } else if escaped == "t" {
                 decoded = decoded + "\t";
-            } else if escaped == "r" {
-                decoded = decoded + "\r";
-            } else if escaped == "\"" {
+            } else if escaped == "r" { decoded = decoded + "\r"; } else if escaped == "\"" {
                 decoded = decoded + "\"";
-            } else if escaped == "\\" {
-                decoded = decoded + "\\";
-            } else {
+            } else if escaped == "\\" { decoded = decoded + "\\"; } else {
                 decoded = decoded + escaped;
             }
             index += 2;
@@ -165,7 +135,6 @@ fn decode_string_literal_escapes_local(text: string) -> string {
 // ============================================================================
 // Keyword/Symbol Consumption
 // ============================================================================
-
 fn consume_keyword(initial_parser: Parser, keyword: string) -> Parser {
     let mut parser: Parser = initial_parser;
     parser = skip_trivia(parser);
@@ -180,9 +149,7 @@ fn consume_symbol(initial_parser: Parser, symbol: string) -> Parser {
     let mut parser: Parser = initial_parser;
     parser = skip_trivia(parser);
     let token = parser_peek_raw(parser);
-    if symbol_matches(token, symbol) {
-        return parser_advance_raw(parser);
-    }
+    if symbol_matches(token, symbol) { return parser_advance_raw(parser); }
     return parser;
 }
 
@@ -191,16 +158,10 @@ fn advance_to_symbol(parser: Parser, symbol: string) -> Parser {
     loop {
         current = skip_trivia(current);
         let token = parser_peek_raw(current);
-        if symbol_matches(token, symbol) {
-            return current;
-        }
-        if token.kind.variant == "EndOfFile" {
-            return current;
-        }
+        if symbol_matches(token, symbol) { return current; }
+        if token.kind.variant == "EndOfFile" { return current; }
         let next = parser_advance_raw(current);
-        if next.index == current.index {
-            return current;
-        }
+        if next.index == current.index { return current; }
         current = next;
     }
     return current;
@@ -209,46 +170,31 @@ fn advance_to_symbol(parser: Parser, symbol: string) -> Parser {
 // ============================================================================
 // Trivia Detection
 // ============================================================================
-
 fn is_trivia_token(token: Token) -> boolean {
     let mut _if416: boolean = false;
     if token.kind.variant == "Whitespace" { _if416 = true; }
     if token.kind.variant == "Comment" { _if416 = true; }
-    if _if416 {
-        return true;
-    }
+    if _if416 { return true; }
     let text = token.lexeme;
-    if text.length == 0 {
-        return false;
-    }
-    if is_whitespace_lexeme(text) {
-        return true;
-    }
+    if text.length == 0 { return false; }
+    if is_whitespace_lexeme(text) { return true; }
     if text.length >= 2 {
         let prefix = substring(text, 0, 2);
         let mut _if417: boolean = false;
         if strings_equal(prefix, "//") { _if417 = true; }
         if strings_equal(prefix, "/*") { _if417 = true; }
-        if _if417 {
-            return true;
-        }
+        if _if417 { return true; }
     }
     return false;
 }
 
 fn is_whitespace_lexeme(text: string) -> boolean {
-    if text.length == 0 {
-        return false;
-    }
+    if text.length == 0 { return false; }
     let mut index: number = 0;
     loop {
-        if index >= text.length {
-            break;
-        }
+        if index >= text.length { break; }
         let ch = char_at(text, index);
-        if !is_trim_whitespace_local(ch) {
-            return false;
-        }
+        if !is_trim_whitespace_local(ch) { return false; }
         index += 1;
     }
     return true;
@@ -266,14 +212,11 @@ fn is_trim_whitespace_local(ch: string) -> boolean {
 // ============================================================================
 // Token Array Operations
 // ============================================================================
-
 fn token_slice(tokens: Token[], start: number, end: number) -> Token[] {
     let mut result: Token[] = [];
     let mut index: number = start;
     loop {
-        if index >= end {
-            break;
-        }
+        if index >= end { break; }
         result = append_token(result, tokens[index]);
         index += 1;
     }
@@ -285,9 +228,7 @@ fn trim_token_edges(tokens: Token[]) -> Token[] {
     let mut end: number = tokens.length;
 
     loop {
-        if start >= end {
-            break;
-        }
+        if start >= end { break; }
         let token = tokens[start];
         if is_trivia_token(token) {
             start += 1;
@@ -297,9 +238,7 @@ fn trim_token_edges(tokens: Token[]) -> Token[] {
     }
 
     loop {
-        if end <= start {
-            break;
-        }
+        if end <= start { break; }
         let token = tokens[end - 1];
         if is_trivia_token(token) {
             end -= 1;
@@ -316,18 +255,12 @@ fn trim_block_tokens(tokens: Token[]) -> Token[] {
     let mut index: number = 0;
     let mut end: number = tokens.length;
     loop {
-        if index >= tokens.length {
-            break;
-        }
+        if index >= tokens.length { break; }
         let token = tokens[index];
         if token.kind.variant == "Symbol" {
             let sym = token.lexeme;
-            if strings_equal(sym, "{") {
-                depth += 1;
-            } else if strings_equal(sym, "}") {
-                if depth > 0 {
-                    depth -= 1;
-                }
+            if strings_equal(sym, "{") { depth += 1; } else if strings_equal(sym, "}") {
+                if depth > 0 { depth -= 1; }
                 if depth == 0 {
                     end = index + 1;
                     break;
@@ -344,9 +277,7 @@ fn filter_trivia(tokens: Token[]) -> Token[] {
     let mut filtered: Token[] = [];
 
     loop {
-        if index >= tokens.length {
-            break;
-        }
+        if index >= tokens.length { break; }
         let token = tokens[index];
         if token.kind.variant != "Whitespace" {
             if token.kind.variant != "Comment" {
@@ -364,7 +295,6 @@ fn filter_trivia(tokens: Token[]) -> Token[] {
 // ============================================================================
 // Token-to-Text Conversion
 // ============================================================================
-
 fn tokens_to_text(tokens: Token[]) -> string {
     let mut text: string = "";
     let mut index: number = 0;
@@ -372,9 +302,7 @@ fn tokens_to_text(tokens: Token[]) -> string {
     let max_tokens: number = 512;
     let mut truncated: boolean = false;
     loop {
-        if index >= tokens.length {
-            break;
-        }
+        if index >= tokens.length { break; }
         if index >= max_tokens {
             truncated = true;
             break;
@@ -388,25 +316,18 @@ fn tokens_to_text(tokens: Token[]) -> string {
         }
     }
     if truncated {
-        if text.length > limit {
-            text = substring(text, 0, limit);
-        }
+        if text.length > limit { text = substring(text, 0, limit); }
     }
-    if truncated {
-        text = text + "... (truncated)";
-    }
+    if truncated { text = text + "... (truncated)"; }
     return text;
 }
 
 // ============================================================================
 // Source Span Construction
 // ============================================================================
-
 fn source_span_from_tokens(tokens: Token[]) -> SourceSpan? {
     let trimmed = trim_token_edges(tokens);
-    if trimmed.length == 0 {
-        return null;
-    }
+    if trimmed.length == 0 { return null; }
 
     let start = trimmed[0];
     let last = trimmed[trimmed.length - 1];
@@ -416,16 +337,12 @@ fn source_span_from_tokens(tokens: Token[]) -> SourceSpan? {
     let lexeme = last.lexeme;
     let mut index: number = 0;
     loop {
-        if index >= lexeme.length {
-            break;
-        }
+        if index >= lexeme.length { break; }
         let ch = char_at(lexeme, index);
         if ch == "\n" {
             end_line += 1;
             end_column = 1;
-        } else {
-            end_column += 1;
-        }
+        } else { end_column += 1; }
         index += 1;
     }
 
@@ -440,7 +357,6 @@ fn source_span_from_tokens(tokens: Token[]) -> SourceSpan? {
 // ============================================================================
 // Token Collection Functions
 // ============================================================================
-
 fn collect_until(parser: Parser, terminators: string[]) -> CaptureResult {
     let mut current = parser;
     let mut captured: Token[] = [];
@@ -450,16 +366,12 @@ fn collect_until(parser: Parser, terminators: string[]) -> CaptureResult {
 
     loop {
         let token = parser_peek_raw(current);
-        if token.kind.variant == "EndOfFile" {
-            break;
-        }
+        if token.kind.variant == "EndOfFile" { break; }
 
         let mut _let418: boolean = false;
         if paren_depth == 0 {
             if brace_depth == 0 {
-                if bracket_depth == 0 {
-                    _let418 = true;
-                }
+                if bracket_depth == 0 { _let418 = true; }
             }
         }
         let is_balanced = _let418;
@@ -470,39 +382,23 @@ fn collect_until(parser: Parser, terminators: string[]) -> CaptureResult {
                 should_stop = string_array_contains(terminators, token.lexeme);
             }
         }
-        if should_stop {
-            break;
-        }
+        if should_stop { break; }
 
         captured = append_token(captured, token);
 
         if token.kind.variant == "Symbol" {
             let sym = token.lexeme;
-            if strings_equal(sym, "(") {
-                paren_depth += 1;
-            } else if strings_equal(sym, ")") {
-                if paren_depth > 0 {
-                    paren_depth -= 1;
-                }
-            } else if strings_equal(sym, "{") {
-                brace_depth += 1;
-            } else if strings_equal(sym, "}") {
-                if brace_depth > 0 {
-                    brace_depth -= 1;
-                }
-            } else if strings_equal(sym, "[") {
-                bracket_depth += 1;
-            } else if strings_equal(sym, "]") {
-                if bracket_depth > 0 {
-                    bracket_depth -= 1;
-                }
+            if strings_equal(sym, "(") { paren_depth += 1; } else if strings_equal(sym, ")") {
+                if paren_depth > 0 { paren_depth -= 1; }
+            } else if strings_equal(sym, "{") { brace_depth += 1; } else if strings_equal(sym, "}") {
+                if brace_depth > 0 { brace_depth -= 1; }
+            } else if strings_equal(sym, "[") { bracket_depth += 1; } else if strings_equal(sym, "]") {
+                if bracket_depth > 0 { bracket_depth -= 1; }
             }
         }
 
         let advanced = parser_advance_raw(current);
-        if advanced.index == current.index {
-            break;
-        }
+        if advanced.index == current.index { break; }
         current = advanced;
     }
 
@@ -513,7 +409,11 @@ fn collect_parenthesized(parser: Parser) -> ParenthesizedParseResult {
     let mut current = skip_trivia(parser);
     let start = parser_peek_raw(current);
     if !symbol_matches(start, "(") {
-        return ParenthesizedParseResult { parser: parser, tokens: [], success: false };
+        return ParenthesizedParseResult {
+            parser: parser,
+            tokens: [],
+            success: false
+        };
     }
 
     current = parser_advance_raw(current);
@@ -523,14 +423,16 @@ fn collect_parenthesized(parser: Parser) -> ParenthesizedParseResult {
     loop {
         let token = parser_peek_raw(current);
         if token.kind.variant == "EndOfFile" {
-            return ParenthesizedParseResult { parser: parser, tokens: [], success: false };
+            return ParenthesizedParseResult {
+                parser: parser,
+                tokens: [],
+                success: false
+            };
         }
 
         if token.kind.variant == "Symbol" {
             let sym = token.lexeme;
-            if strings_equal(sym, "(") {
-                depth += 1;
-            } else if strings_equal(sym, ")") {
+            if strings_equal(sym, "(") { depth += 1; } else if strings_equal(sym, ")") {
                 depth -= 1;
                 if depth == 0 {
                     current = parser_advance_raw(current);
@@ -543,7 +445,11 @@ fn collect_parenthesized(parser: Parser) -> ParenthesizedParseResult {
         current = parser_advance_raw(current);
     }
 
-    return ParenthesizedParseResult { parser: current, tokens: tokens, success: true };
+    return ParenthesizedParseResult {
+        parser: current,
+        tokens: tokens,
+        success: true
+    };
 }
 
 fn collect_pattern_until_arrow(parser: Parser) -> PatternCaptureResult {
@@ -553,7 +459,11 @@ fn collect_pattern_until_arrow(parser: Parser) -> PatternCaptureResult {
     loop {
         let token = parser_peek_raw(current);
         if token.kind.variant == "EndOfFile" {
-            return PatternCaptureResult { parser: parser, tokens: [], success: false };
+            return PatternCaptureResult {
+                parser: parser,
+                tokens: [],
+                success: false
+            };
         }
         if token.kind.variant == "Symbol" {
             let sym = token.lexeme;
@@ -568,18 +478,25 @@ fn collect_pattern_until_arrow(parser: Parser) -> PatternCaptureResult {
         tokens = append_token(tokens, token);
         let advanced = parser_advance_raw(current);
         if advanced.index == current.index {
-            return PatternCaptureResult { parser: parser, tokens: [], success: false };
+            return PatternCaptureResult {
+                parser: parser,
+                tokens: [],
+                success: false
+            };
         }
         current = advanced;
     }
 
-    return PatternCaptureResult { parser: current, tokens: tokens, success: true };
+    return PatternCaptureResult {
+        parser: current,
+        tokens: tokens,
+        success: true
+    };
 }
 
 // ============================================================================
 // Token Splitting Functions
 // ============================================================================
-
 fn split_tokens_by_comma(tokens: Token[]) -> string[] {
     let mut parts: string[] = [];
     let mut segment: string = "";
@@ -590,36 +507,18 @@ fn split_tokens_by_comma(tokens: Token[]) -> string[] {
 
     let mut index: number = 0;
     loop {
-        if index >= tokens.length {
-            break;
-        }
+        if index >= tokens.length { break; }
         let token = tokens[index];
         if token.kind.variant == "Symbol" {
             let sym = token.lexeme;
-            if strings_equal(sym, "<") {
-                angle += 1;
-            } else if strings_equal(sym, ">") {
-                if angle > 0 {
-                    angle -= 1;
-                }
-            } else if strings_equal(sym, "(") {
-                paren += 1;
-            } else if strings_equal(sym, ")") {
-                if paren > 0 {
-                    paren -= 1;
-                }
-            } else if strings_equal(sym, "{") {
-                brace += 1;
-            } else if strings_equal(sym, "}") {
-                if brace > 0 {
-                    brace -= 1;
-                }
-            } else if strings_equal(sym, "[") {
-                bracket += 1;
-            } else if strings_equal(sym, "]") {
-                if bracket > 0 {
-                    bracket -= 1;
-                }
+            if strings_equal(sym, "<") { angle += 1; } else if strings_equal(sym, ">") {
+                if angle > 0 { angle -= 1; }
+            } else if strings_equal(sym, "(") { paren += 1; } else if strings_equal(sym, ")") {
+                if paren > 0 { paren -= 1; }
+            } else if strings_equal(sym, "{") { brace += 1; } else if strings_equal(sym, "}") {
+                if brace > 0 { brace -= 1; }
+            } else if strings_equal(sym, "[") { bracket += 1; } else if strings_equal(sym, "]") {
+                if bracket > 0 { bracket -= 1; }
             }
 
             if strings_equal(sym, ",") {
@@ -645,9 +544,7 @@ fn split_tokens_by_comma(tokens: Token[]) -> string[] {
     }
 
     let tail = trim_text(segment);
-    if tail.length > 0 {
-        parts = append_string_local(parts, tail);
-    }
+    if tail.length > 0 { parts = append_string_local(parts, tail); }
     return parts;
 }
 
@@ -661,36 +558,18 @@ fn split_token_slices_by_comma(tokens: Token[]) -> Token[][] {
 
     let mut index: number = 0;
     loop {
-        if index >= tokens.length {
-            break;
-        }
+        if index >= tokens.length { break; }
         let token = tokens[index];
         if token.kind.variant == "Symbol" {
             let sym = token.lexeme;
-            if strings_equal(sym, "<") {
-                angle += 1;
-            } else if strings_equal(sym, ">") {
-                if angle > 0 {
-                    angle -= 1;
-                }
-            } else if strings_equal(sym, "(") {
-                paren += 1;
-            } else if strings_equal(sym, ")") {
-                if paren > 0 {
-                    paren -= 1;
-                }
-            } else if strings_equal(sym, "{") {
-                brace += 1;
-            } else if strings_equal(sym, "}") {
-                if brace > 0 {
-                    brace -= 1;
-                }
-            } else if strings_equal(sym, "[") {
-                bracket += 1;
-            } else if strings_equal(sym, "]") {
-                if bracket > 0 {
-                    bracket -= 1;
-                }
+            if strings_equal(sym, "<") { angle += 1; } else if strings_equal(sym, ">") {
+                if angle > 0 { angle -= 1; }
+            } else if strings_equal(sym, "(") { paren += 1; } else if strings_equal(sym, ")") {
+                if paren > 0 { paren -= 1; }
+            } else if strings_equal(sym, "{") { brace += 1; } else if strings_equal(sym, "}") {
+                if brace > 0 { brace -= 1; }
+            } else if strings_equal(sym, "[") { bracket += 1; } else if strings_equal(sym, "]") {
+                if bracket > 0 { bracket -= 1; }
             }
 
             if strings_equal(sym, ",") {
@@ -712,16 +591,13 @@ fn split_token_slices_by_comma(tokens: Token[]) -> Token[][] {
         index += 1;
     }
 
-    if segment.length > 0 {
-        parts = append_token_array(parts, segment);
-    }
+    if segment.length > 0 { parts = append_token_array(parts, segment); }
     return parts;
 }
 
 // ============================================================================
 // Top-Level Search Functions
 // ============================================================================
-
 fn find_top_level_symbol(tokens: Token[], symbol: string) -> number {
     let mut angle: number = 0;
     let mut paren: number = 0;
@@ -730,45 +606,25 @@ fn find_top_level_symbol(tokens: Token[], symbol: string) -> number {
 
     let mut index: number = 0;
     loop {
-        if index >= tokens.length {
-            break;
-        }
+        if index >= tokens.length { break; }
         let token = tokens[index];
         if token.kind.variant == "Symbol" {
             let sym = token.lexeme;
-            if strings_equal(sym, "<") {
-                angle += 1;
-            } else if strings_equal(sym, ">") {
-                if angle > 0 {
-                    angle -= 1;
-                }
-            } else if strings_equal(sym, "(") {
-                paren += 1;
-            } else if strings_equal(sym, ")") {
-                if paren > 0 {
-                    paren -= 1;
-                }
-            } else if strings_equal(sym, "{") {
-                brace += 1;
-            } else if strings_equal(sym, "}") {
-                if brace > 0 {
-                    brace -= 1;
-                }
-            } else if strings_equal(sym, "[") {
-                bracket += 1;
-            } else if strings_equal(sym, "]") {
-                if bracket > 0 {
-                    bracket -= 1;
-                }
+            if strings_equal(sym, "<") { angle += 1; } else if strings_equal(sym, ">") {
+                if angle > 0 { angle -= 1; }
+            } else if strings_equal(sym, "(") { paren += 1; } else if strings_equal(sym, ")") {
+                if paren > 0 { paren -= 1; }
+            } else if strings_equal(sym, "{") { brace += 1; } else if strings_equal(sym, "}") {
+                if brace > 0 { brace -= 1; }
+            } else if strings_equal(sym, "[") { bracket += 1; } else if strings_equal(sym, "]") {
+                if bracket > 0 { bracket -= 1; }
             }
 
             if strings_equal(sym, symbol) {
                 if angle == 0 {
                     if paren == 0 {
                         if brace == 0 {
-                            if bracket == 0 {
-                                return index;
-                            }
+                            if bracket == 0 { return index; }
                         }
                     }
                 }
@@ -787,36 +643,18 @@ fn find_top_level_identifier(tokens: Token[], keyword: string) -> number {
 
     let mut index: number = 0;
     loop {
-        if index >= tokens.length {
-            break;
-        }
+        if index >= tokens.length { break; }
         let token = tokens[index];
         if token.kind.variant == "Symbol" {
             let sym = token.lexeme;
-            if strings_equal(sym, "<") {
-                angle += 1;
-            } else if strings_equal(sym, ">") {
-                if angle > 0 {
-                    angle -= 1;
-                }
-            } else if strings_equal(sym, "(") {
-                paren += 1;
-            } else if strings_equal(sym, ")") {
-                if paren > 0 {
-                    paren -= 1;
-                }
-            } else if strings_equal(sym, "{") {
-                brace += 1;
-            } else if strings_equal(sym, "}") {
-                if brace > 0 {
-                    brace -= 1;
-                }
-            } else if strings_equal(sym, "[") {
-                bracket += 1;
-            } else if strings_equal(sym, "]") {
-                if bracket > 0 {
-                    bracket -= 1;
-                }
+            if strings_equal(sym, "<") { angle += 1; } else if strings_equal(sym, ">") {
+                if angle > 0 { angle -= 1; }
+            } else if strings_equal(sym, "(") { paren += 1; } else if strings_equal(sym, ")") {
+                if paren > 0 { paren -= 1; }
+            } else if strings_equal(sym, "{") { brace += 1; } else if strings_equal(sym, "}") {
+                if brace > 0 { brace -= 1; }
+            } else if strings_equal(sym, "[") { bracket += 1; } else if strings_equal(sym, "]") {
+                if bracket > 0 { bracket -= 1; }
             }
         }
 
@@ -825,9 +663,7 @@ fn find_top_level_identifier(tokens: Token[], keyword: string) -> number {
                 if angle == 0 {
                     if paren == 0 {
                         if brace == 0 {
-                            if bracket == 0 {
-                                return index;
-                            }
+                            if bracket == 0 { return index; }
                         }
                     }
                 }
@@ -846,51 +682,29 @@ fn find_top_level_colon(tokens: Token[]) -> number {
 
     let mut index: number = 0;
     loop {
-        if index >= tokens.length {
-            break;
-        }
+        if index >= tokens.length { break; }
         let token = tokens[index];
         if token.kind.variant == "Symbol" {
             let sym = token.lexeme;
-            if strings_equal(sym, "<") {
-                angle += 1;
-            } else if strings_equal(sym, ">") {
-                if angle > 0 {
-                    angle -= 1;
-                }
-            } else if strings_equal(sym, "(") {
-                paren += 1;
-            } else if strings_equal(sym, ")") {
-                if paren > 0 {
-                    paren -= 1;
-                }
-            } else if strings_equal(sym, "{") {
-                brace += 1;
-            } else if strings_equal(sym, "}") {
-                if brace > 0 {
-                    brace -= 1;
-                }
-            } else if strings_equal(sym, "[") {
-                bracket += 1;
-            } else if strings_equal(sym, "]") {
-                if bracket > 0 {
-                    bracket -= 1;
-                }
+            if strings_equal(sym, "<") { angle += 1; } else if strings_equal(sym, ">") {
+                if angle > 0 { angle -= 1; }
+            } else if strings_equal(sym, "(") { paren += 1; } else if strings_equal(sym, ")") {
+                if paren > 0 { paren -= 1; }
+            } else if strings_equal(sym, "{") { brace += 1; } else if strings_equal(sym, "}") {
+                if brace > 0 { brace -= 1; }
+            } else if strings_equal(sym, "[") { bracket += 1; } else if strings_equal(sym, "]") {
+                if bracket > 0 { bracket -= 1; }
             } else if strings_equal(sym, ":") {
                 let mut _let432: boolean = false;
                 if angle == 0 {
                     if paren == 0 {
                         if brace == 0 {
-                            if bracket == 0 {
-                                _let432 = true;
-                            }
+                            if bracket == 0 { _let432 = true; }
                         }
                     }
                 }
                 let at_top = _let432;
-                if at_top {
-                    return index;
-                }
+                if at_top { return index; }
             }
         }
         index += 1;
@@ -901,28 +715,21 @@ fn find_top_level_colon(tokens: Token[]) -> number {
 // ============================================================================
 // Skip Functions
 // ============================================================================
-
 fn skip_struct_member(parser: Parser) -> Parser {
     let mut current = parser;
     loop {
         let next = parser_advance_raw(current);
-        if next.index == current.index {
-            return current;
-        }
+        if next.index == current.index { return current; }
         current = next;
         let token = parser_peek_raw(current);
-        if token.kind.variant == "EndOfFile" {
-            return current;
-        }
+        if token.kind.variant == "EndOfFile" { return current; }
         if token.kind.variant == "Symbol" {
             let sym = token.lexeme;
             if strings_equal(sym, ";") {
                 current = parser_advance_raw(current);
                 return current;
             }
-            if strings_equal(sym, "}") {
-                return current;
-            }
+            if strings_equal(sym, "}") { return current; }
         }
     }
     return current;
@@ -932,23 +739,17 @@ fn skip_enum_variant_entry(parser: Parser) -> Parser {
     let mut current = parser;
     loop {
         let next = parser_advance_raw(current);
-        if next.index == current.index {
-            return current;
-        }
+        if next.index == current.index { return current; }
         current = next;
         let token = parser_peek_raw(current);
-        if token.kind.variant == "EndOfFile" {
-            return current;
-        }
+        if token.kind.variant == "EndOfFile" { return current; }
         if token.kind.variant == "Symbol" {
             let sym = token.lexeme;
             if strings_equal(sym, ",") {
                 current = parser_advance_raw(current);
                 return current;
             }
-            if strings_equal(sym, "}") {
-                return current;
-            }
+            if strings_equal(sym, "}") { return current; }
         }
     }
     return current;
@@ -957,16 +758,13 @@ fn skip_enum_variant_entry(parser: Parser) -> Parser {
 fn skip_trailing_comma(parser: Parser) -> Parser {
     let mut current = skip_trivia(parser);
     let token = parser_peek_raw(current);
-    if symbol_matches(token, ",") {
-        current = parser_advance_raw(current);
-    }
+    if symbol_matches(token, ",") { current = parser_advance_raw(current); }
     return current;
 }
 
 // ============================================================================
 // Append Helpers
 // ============================================================================
-
 fn append_token(tokens: Token[], token: Token) -> Token[] {
     tokens.push(token);
     return tokens;

--- a/compiler/src/parser/types.sfn
+++ b/compiler/src/parser/types.sfn
@@ -23,7 +23,7 @@ import {
     Statement,
     TypeAnnotation,
     TypeParameter,
-    WithClause,
+    WithClause
 } from "../ast";
 import { Token } from "../token";
 

--- a/compiler/src/parser/types.sfn
+++ b/compiler/src/parser/types.sfn
@@ -3,36 +3,33 @@
 // Parser type definitions - result structs for various parsing operations.
 // These types are used throughout the parser to return parse results along
 // with updated parser state.
-
-import { Token } from "../token";
 import {
     Block,
     Decorator,
     DecoratorArgument,
+    ElseBranch,
+    EnumVariant,
+    ExportSpecifier,
     Expression,
     FieldDeclaration,
     FunctionSignature,
-    EnumVariant,
+    ImportSpecifier,
+    MatchCase,
     MethodDeclaration,
     ModelProperty,
     ObjectField,
     Parameter,
-    Statement,
-    ImportSpecifier,
-    ExportSpecifier,
-    TypeParameter,
-    TypeAnnotation,
-    MatchCase,
-    ElseBranch,
-    WithClause,
     SourceSpan,
+    Statement,
+    TypeAnnotation,
+    TypeParameter,
+    WithClause,
 } from "../ast";
-
+import { Token } from "../token";
 
 // ============================================================================
 // Core Parser State
 // ============================================================================
-
 struct Parser {
     tokens: Token[];
     index: number;
@@ -41,7 +38,6 @@ struct Parser {
 // ============================================================================
 // Statement Parsing Results
 // ============================================================================
-
 struct StatementParseResult {
     parser: Parser;
     statement: Statement;
@@ -61,7 +57,6 @@ struct BlockParseResult {
 // ============================================================================
 // Declaration Parsing Results
 // ============================================================================
-
 struct ParameterParseResult {
     parser: Parser;
     parameter: Parameter;
@@ -131,7 +126,6 @@ struct TypeSeparatorParseResult {
 // ============================================================================
 // Import/Export Parsing Results
 // ============================================================================
-
 struct SpecifierListParseResult {
     parser: Parser;
     specifiers: NamedSpecifier[];
@@ -145,7 +139,6 @@ struct NamedSpecifier {
 // ============================================================================
 // Token Collection Results
 // ============================================================================
-
 struct CaptureResult {
     parser: Parser;
     tokens: Token[];
@@ -166,7 +159,6 @@ struct PatternCaptureResult {
 // ============================================================================
 // Match Statement Results
 // ============================================================================
-
 struct MatchCasesParseResult {
     parser: Parser;
     cases: MatchCase[];
@@ -188,7 +180,6 @@ struct MatchCaseTokenSplit {
 // ============================================================================
 // Expression Parsing State and Results
 // ============================================================================
-
 struct ExpressionTokens {
     tokens: Token[];
     index: number;
@@ -221,7 +212,6 @@ struct ExpressionBlockParseResult {
 // ============================================================================
 // Lambda Parsing Results
 // ============================================================================
-
 struct LambdaParameterParseResult {
     state: ExpressionTokens;
     parameter: Parameter;
@@ -237,7 +227,6 @@ struct LambdaParameterListParseResult {
 // ============================================================================
 // Literal Parsing Results
 // ============================================================================
-
 struct CallArgumentsParseResult {
     state: ExpressionTokens;
     arguments: Expression[];

--- a/compiler/src/parser/utils.sfn
+++ b/compiler/src/parser/utils.sfn
@@ -2,21 +2,22 @@
 //
 // Parser utility functions for string manipulation, text processing,
 // and general helpers used throughout the parser.
-
-import { substring, char_code, char_at, strings_equal } from "../string_utils";
+import {
+    substring,
+    char_code,
+    char_at,
+    strings_equal
+} from "../string_utils";
 
 // ============================================================================
 // String Utilities
 // ============================================================================
-
 fn trim_text(value: string) -> string {
     let mut start: number = 0;
     let mut end: number = value.length;
 
     loop {
-        if start >= end {
-            break;
-        }
+        if start >= end { break; }
         let ch = char_at(value, start);
         if is_trim_whitespace(ch) {
             start += 1;
@@ -26,9 +27,7 @@ fn trim_text(value: string) -> string {
     }
 
     loop {
-        if end <= start {
-            break;
-        }
+        if end <= start { break; }
         let ch = char_at(value, end - 1);
         if is_trim_whitespace(ch) {
             end -= 1;
@@ -50,29 +49,21 @@ fn is_trim_whitespace(ch: string) -> boolean {
 }
 
 fn strip_surrounding_quotes(text: string) -> string {
-    if text.length < 2 {
-        return text;
-    }
+    if text.length < 2 { return text; }
     let first = char_code(char_at(text, 0));
     let last = char_code(char_at(text, text.length - 1));
     if first == 34 {
-        if last == 34 {
-            return substring(text, 1, text.length - 1);
-        }
+        if last == 34 { return substring(text, 1, text.length - 1); }
     }
     return text;
 }
 
 fn strip_loose_quotes(text: string) -> string {
-    if text.length == 0 {
-        return text;
-    }
+    if text.length == 0 { return text; }
     let mut start: number = 0;
     let mut end: number = text.length;
     loop {
-        if start >= end {
-            break;
-        }
+        if start >= end { break; }
         let first = char_code(char_at(text, start));
         if first == 34 {
             start += 1;
@@ -81,9 +72,7 @@ fn strip_loose_quotes(text: string) -> string {
         break;
     }
     loop {
-        if end <= start {
-            break;
-        }
+        if end <= start { break; }
         let last = char_code(char_at(text, end - 1));
         if last == 34 {
             end -= 1;
@@ -92,23 +81,17 @@ fn strip_loose_quotes(text: string) -> string {
         break;
     }
     if start == 0 {
-        if end == text.length {
-            return text;
-        }
+        if end == text.length { return text; }
     }
     return substring(text, start, end);
 }
 
 fn decode_string_literal_escapes(text: string) -> string {
-    if text.length == 0 {
-        return "";
-    }
+    if text.length == 0 { return ""; }
     let mut decoded: string = "";
     let mut index: number = 0;
     loop {
-        if index >= text.length {
-            break;
-        }
+        if index >= text.length { break; }
         let ch = char_at(text, index);
         if ch == "\\" {
             let next_index = index + 1;
@@ -118,17 +101,11 @@ fn decode_string_literal_escapes(text: string) -> string {
                 continue;
             }
             let escaped = char_at(text, next_index);
-            if escaped == "n" {
-                decoded = decoded + "\n";
-            } else if escaped == "t" {
+            if escaped == "n" { decoded = decoded + "\n"; } else if escaped == "t" {
                 decoded = decoded + "\t";
-            } else if escaped == "r" {
-                decoded = decoded + "\r";
-            } else if escaped == "\"" {
+            } else if escaped == "r" { decoded = decoded + "\r"; } else if escaped == "\"" {
                 decoded = decoded + "\"";
-            } else if escaped == "\\" {
-                decoded = decoded + "\\";
-            } else {
+            } else if escaped == "\\" { decoded = decoded + "\\"; } else {
                 decoded = decoded + escaped;
             }
             index += 2;
@@ -146,9 +123,7 @@ fn normalize_test_name(text: string) -> string {
         let first = char_code(char_at(trimmed, 0));
         let last = char_code(char_at(trimmed, trimmed.length - 1));
         if first == 34 {
-            if last == 34 {
-                return strip_surrounding_quotes(trimmed);
-            }
+            if last == 34 { return strip_surrounding_quotes(trimmed); }
         }
     }
     return trimmed;
@@ -157,35 +132,24 @@ fn normalize_test_name(text: string) -> string {
 // ============================================================================
 // Number Detection
 // ============================================================================
-
 fn looks_like_number(text: string) -> boolean {
-    if text.length == 0 {
-        return false;
-    }
+    if text.length == 0 { return false; }
     let mut has_decimal: boolean = false;
     let mut index: number = 0;
     if char_at(text, 0) == "-" {
-        if text.length == 1 {
-            return false;
-        }
+        if text.length == 1 { return false; }
         index = 1;
     }
     loop {
-        if index >= text.length {
-            break;
-        }
+        if index >= text.length { break; }
         let ch = char_at(text, index);
         if ch == "." {
-            if has_decimal {
-                return false;
-            }
+            if has_decimal { return false; }
             has_decimal = true;
             index += 1;
             continue;
         }
-        if !is_decimal_digit(ch) {
-            return false;
-        }
+        if !is_decimal_digit(ch) { return false; }
         index += 1;
     }
     return true;
@@ -209,16 +173,11 @@ fn is_decimal_digit(ch: string) -> boolean {
 // ============================================================================
 // Array Utilities
 // ============================================================================
-
 fn string_array_contains(values: string[], target: string) -> boolean {
     let mut index: number = 0;
     loop {
-        if index >= values.length {
-            break;
-        }
-        if strings_equal(values[index], target) {
-            return true;
-        }
+        if index >= values.length { break; }
+        if strings_equal(values[index], target) { return true; }
         index += 1;
     }
     return false;

--- a/compiler/src/string_utils.sfn
+++ b/compiler/src/string_utils.sfn
@@ -2,152 +2,119 @@
 //
 // Shared string helpers surfaced via the runtime prelude. The compiler and
 // downstream projects import from here to keep a single implementation.
-
-import { clamp, substring, find_char, grapheme_count, grapheme_at, char_code, strings_equal } from "runtime/prelude";
+import {
+    clamp,
+    substring,
+    find_char,
+    grapheme_count,
+    grapheme_at,
+    char_code,
+    strings_equal
+} from "runtime/prelude";
 
 fn char_at(value: string, index: number) -> string {
-	let value_len = value.length;
-	if value_len == 0 {
-		return "";
-	}
-	if index < 0 {
-		return "";
-	}
-	if index >= value_len {
-		return "";
-	}
-	// Prefer grapheme_at so ASCII access avoids substring allocations.
-	return grapheme_at(value, index);
+    let value_len = value.length;
+    if value_len == 0 { return ""; }
+    if index < 0 { return ""; }
+    if index >= value_len { return ""; }
+    // Prefer grapheme_at so ASCII access avoids substring allocations.
+    return grapheme_at(value, index);
 }
 
 fn is_symbol_char(ch: string) -> boolean {
-	if ch.length == 0 {
-		return false;
-	}
-	if ch == "_" {
-		return true;
-	}
-	let code = char_code(ch);
-	let lower_a = char_code("a");
-	let lower_z = char_code("z");
-	if code >= lower_a {
-	    if code <= lower_z {
-    		return true;
-	    }
-	}
-	let upper_a = char_code("A");
-	let upper_z = char_code("Z");
-	if code >= upper_a {
-	    if code <= upper_z {
-    		return true;
-	    }
-	}
-	let zero = char_code("0");
-	let nine = char_code("9");
-	if code >= zero {
-	    if code <= nine {
-    		return true;
-	    }
-	}
-	return false;
+    if ch.length == 0 { return false; }
+    if ch == "_" { return true; }
+    let code = char_code(ch);
+    let lower_a = char_code("a");
+    let lower_z = char_code("z");
+    if code >= lower_a {
+        if code <= lower_z { return true; }
+    }
+    let upper_a = char_code("A");
+    let upper_z = char_code("Z");
+    if code >= upper_a {
+        if code <= upper_z { return true; }
+    }
+    let zero = char_code("0");
+    let nine = char_code("9");
+    if code >= zero {
+        if code <= nine { return true; }
+    }
+    return false;
 }
 
 fn sanitize_symbol(name: string) -> string {
-	let name_len = name.length;
-	if name_len == 0 {
-		return "_";
-	}
-	let mut result: string = "";
-	let mut index: number = 0;
-	loop {
-		if index >= name_len {
-			break;
-		}
-		// index is already bounds-checked against name_len.
-		let ch = grapheme_at(name, index);
-		if is_symbol_char(ch) {
-			result = result + ch;
-		}
-		index += 1;
-	}
-	if result.length == 0 {
-		return "_";
-	}
-	let first = char_at(result, 0);
-	let first_code = char_code(first);
-	let zero = char_code("0");
-	let nine = char_code("9");
-	if first_code >= zero {
-	    if first_code <= nine {
-    		result = "_" + result;
-	    }
-	}
-	return result;
+    let name_len = name.length;
+    if name_len == 0 { return "_"; }
+    let mut result: string = "";
+    let mut index: number = 0;
+    loop {
+        if index >= name_len { break; }
+        // index is already bounds-checked against name_len.
+        let ch = grapheme_at(name, index);
+        if is_symbol_char(ch) { result = result + ch; }
+        index += 1;
+    }
+    if result.length == 0 { return "_"; }
+    let first = char_at(result, 0);
+    let first_code = char_code(first);
+    let zero = char_code("0");
+    let nine = char_code("9");
+    if first_code >= zero {
+        if first_code <= nine { result = "_" + result; }
+    }
+    return result;
 }
 
 fn char_code_at_text(text: string, index: number) -> number {
-	return char_code(char_at(text, index));
+    return char_code(char_at(text, index));
 }
 
 fn index_of(value: string, target: string) -> number {
-	if target.length == 0 {
-		return 0;
-	}
-	let _search_limit = value.length - target.length;
-	let mut index: number = 0;
-	loop {
-		if index > _search_limit {
-			break;
-		}
-		let mut match_index: number = 0;
-		let mut matches: boolean = true;
-		loop {
-			if match_index >= target.length {
-				break;
-			}
-			let _cmp_pos = index + match_index;
-			if char_code_at_text(value, _cmp_pos) != char_code_at_text(target, match_index) {
-				matches = false;
-				break;
-			}
-			match_index += 1;
-		}
-		if matches {
-			return index;
-		}
-		index += 1;
-	}
-	return -1;
+    if target.length == 0 { return 0; }
+    let _search_limit = value.length - target.length;
+    let mut index: number = 0;
+    loop {
+        if index > _search_limit { break; }
+        let mut match_index: number = 0;
+        let mut matches: boolean = true;
+        loop {
+            if match_index >= target.length { break; }
+            let _cmp_pos = index + match_index;
+            if char_code_at_text(value, _cmp_pos) != char_code_at_text(target, match_index) {
+                matches = false;
+                break;
+            }
+            match_index += 1;
+        }
+        if matches { return index; }
+        index += 1;
+    }
+    return -1;
 }
 
 fn find_last_index_of_char(value: string, target: string) -> number {
-	if target.length != 1 {
-		return -1;
-	}
-	let target_code = char_code_at_text(target, 0);
-	let mut index: number = value.length;
-	loop {
-		if index <= 0 {
-			break;
-		}
-		index -= 1;
-		if char_code_at_text(value, index) == target_code {
-			return index;
-		}
-	}
-	return -1;
+    if target.length != 1 { return -1; }
+    let target_code = char_code_at_text(target, 0);
+    let mut index: number = value.length;
+    loop {
+        if index <= 0 { break; }
+        index -= 1;
+        if char_code_at_text(value, index) == target_code { return index; }
+    }
+    return -1;
 }
 
 export {
-	clamp,
-	substring,
-	find_char,
-	grapheme_count,
-	grapheme_at,
-	char_code,
-	char_at,
-	sanitize_symbol,
-	strings_equal,
-	index_of,
-	find_last_index_of_char,
+    clamp,
+    substring,
+    find_char,
+    grapheme_count,
+    grapheme_at,
+    char_code,
+    char_at,
+    sanitize_symbol,
+    strings_equal,
+    index_of,
+    find_last_index_of_char,
 };

--- a/compiler/src/string_utils.sfn
+++ b/compiler/src/string_utils.sfn
@@ -116,5 +116,5 @@ export {
     sanitize_symbol,
     strings_equal,
     index_of,
-    find_last_index_of_char,
+    find_last_index_of_char
 };

--- a/compiler/src/token.sfn
+++ b/compiler/src/token.sfn
@@ -3,7 +3,6 @@
 // Token types shared by the self-hosting compiler front-end. The focus for the
 // first milestone is a pragmatic subset that unlocks bootstrapping the parser
 // without committing to every token the language might eventually surface.
-
 enum TokenKind {
     Identifier,
     NumberLiteral,

--- a/compiler/src/token.sfn
+++ b/compiler/src/token.sfn
@@ -11,7 +11,7 @@ enum TokenKind {
     Symbol,
     Whitespace,
     Comment,
-    EndOfFile,
+    EndOfFile
 }
 
 struct Token {
@@ -26,6 +26,6 @@ fn eof_token(line: number, column: number) -> Token {
         kind: TokenKind.EndOfFile(),
         lexeme: "",
         line: line,
-        column: column,
+        column: column
     };
 }

--- a/compiler/src/toml_parser.sfn
+++ b/compiler/src/toml_parser.sfn
@@ -2,7 +2,6 @@
 //
 // Minimal TOML parser for capsule.toml manifests. Provides a string-based API
 // so callers never need to allocate the SailToml struct across modules.
-
 struct SailToml {
     name: string;
     version: string;
@@ -28,9 +27,7 @@ fn _toml_trim(text: string) -> string {
         if ch == " " { _if434 = true; }
         if ch == "\t" { _if434 = true; }
         if ch == "\r" { _if434 = true; }
-        if _if434 {
-            start += 1;
-        } else { break; }
+        if _if434 { start += 1; } else { break; }
     }
     loop {
         if end <= start { break; }
@@ -39,9 +36,7 @@ fn _toml_trim(text: string) -> string {
         if ch == " " { _if435 = true; }
         if ch == "\t" { _if435 = true; }
         if ch == "\r" { _if435 = true; }
-        if _if435 {
-            end -= 1;
-        } else { break; }
+        if _if435 { end -= 1; } else { break; }
     }
     return substring(text, start, end);
 }
@@ -52,18 +47,12 @@ fn _toml_strip_quotes(text: string) -> string {
         let last = text[text.length - 1];
         let mut _if436: boolean = false;
         if first == "\"" {
-            if last == "\"" {
-                _if436 = true;
-            }
+            if last == "\"" { _if436 = true; }
         }
         if first == "'" {
-            if last == "'" {
-                _if436 = true;
-            }
+            if last == "'" { _if436 = true; }
         }
-        if _if436 {
-            return substring(text, 1, text.length - 1);
-        }
+        if _if436 { return substring(text, 1, text.length - 1); }
     }
     return text;
 }
@@ -81,9 +70,7 @@ fn _toml_split_lines(text: string) -> string[] {
         }
         i += 1;
     }
-    if start <= len {
-        lines.push(substring(text, start, len));
-    }
+    if start <= len { lines.push(substring(text, start, len)); }
     return lines;
 }
 
@@ -110,14 +97,15 @@ fn _toml_parse_string_array(value: string) -> string[] {
         i += 1;
     }
     let last_item = _toml_trim(substring(inner, start, len));
-    if last_item.length > 0 { items.push(_toml_strip_quotes(last_item)); }
+    if last_item.length > 0 {
+        items.push(_toml_strip_quotes(last_item));
+    }
     return items;
 }
 
 // ---- Stdlib resolution ----
 // Standard capsules can be referenced by bare name ("http") or full
 // registry name ("sfn/http"). These functions handle the mapping.
-
 fn _is_stdlib(name: string) -> boolean {
     if strings_equal(name, "http") { return true; }
     if strings_equal(name, "fs") { return true; }
@@ -149,9 +137,7 @@ fn resolve_capsule_name(name: string) -> string {
         i += 1;
     }
     // Bare name — check if it's a stdlib capsule
-    if _is_stdlib(name) {
-        return "sfn/" + name;
-    }
+    if _is_stdlib(name) { return "sfn/" + name; }
     // Unknown bare name — return as-is (will fail at download if not found)
     return name;
 }
@@ -160,15 +146,12 @@ fn display_capsule_name(name: string) -> string {
     // "sfn/http" → "http" for stdlib, "acme/router" → "acme/router" for third-party
     if string_starts_with(name, "sfn/") {
         let short = substring(name, 4, name.length);
-        if _is_stdlib(short) {
-            return short;
-        }
+        if _is_stdlib(short) { return short; }
     }
     return name;
 }
 
 // ---- Internal parse ----
-
 fn _parse_toml_internal(text: string) -> SailToml {
     let mut toml = SailToml {
         name: "",
@@ -191,7 +174,9 @@ fn _parse_toml_internal(text: string) -> SailToml {
         if line[0] == "#" { continue; }
         if line[0] == "[" {
             let close = find_char(line, "]", 0);
-            if close > 0 { section = _toml_trim(substring(line, 1, close)); }
+            if close > 0 {
+                section = _toml_trim(substring(line, 1, close));
+            }
             continue;
         }
         let eq_pos = find_char(line, "=", 0);
@@ -201,18 +186,30 @@ fn _parse_toml_internal(text: string) -> SailToml {
         let stripped_key = _toml_strip_quotes(key);
         let stripped_value = _toml_strip_quotes(value);
         if strings_equal(section, "capsule") {
-            if strings_equal(stripped_key, "name") { toml.name = stripped_value; }
-            if strings_equal(stripped_key, "version") { toml.version = stripped_value; }
-            if strings_equal(stripped_key, "description") { toml.description = stripped_value; }
+            if strings_equal(stripped_key, "name") {
+                toml.name = stripped_value;
+            }
+            if strings_equal(stripped_key, "version") {
+                toml.version = stripped_value;
+            }
+            if strings_equal(stripped_key, "description") {
+                toml.description = stripped_value;
+            }
         }
         if strings_equal(section, "build") {
-            if strings_equal(stripped_key, "entry") { toml.entry = stripped_value; }
+            if strings_equal(stripped_key, "entry") {
+                toml.entry = stripped_value;
+            }
         }
         if strings_equal(section, "dependencies") {
-            toml.dependencies.push(TomlDependency { capsule: stripped_key, version: stripped_value });
+            toml.dependencies.push(TomlDependency {
+                capsule: stripped_key, version: stripped_value
+            });
         }
         if strings_equal(section, "dev-dependencies") {
-            toml.dev_dependencies.push(TomlDependency { capsule: stripped_key, version: stripped_value });
+            toml.dev_dependencies.push(TomlDependency {
+                capsule: stripped_key, version: stripped_value
+            });
         }
         if strings_equal(section, "capabilities") {
             if strings_equal(stripped_key, "required") {
@@ -224,7 +221,6 @@ fn _parse_toml_internal(text: string) -> SailToml {
 }
 
 // ---- String-based public API (safe for cross-module use) ----
-
 fn toml_get_name(text: string) -> string {
     let t = _parse_toml_internal(text);
     return t.name;
@@ -292,7 +288,9 @@ fn toml_add_dependency(toml_text: string, capsule: string, version: string) -> s
         di += 1;
     }
     if !found {
-        t.dependencies.push(TomlDependency { capsule: capsule, version: version });
+        t.dependencies.push(TomlDependency {
+            capsule: capsule, version: version
+        });
     }
     return _write_toml(t);
 }
@@ -311,7 +309,9 @@ fn toml_add_dev_dependency(toml_text: string, capsule: string, version: string) 
         di += 1;
     }
     if !found {
-        t.dev_dependencies.push(TomlDependency { capsule: capsule, version: version });
+        t.dev_dependencies.push(TomlDependency {
+            capsule: capsule, version: version
+        });
     }
     return _write_toml(t);
 }

--- a/compiler/src/toml_parser.sfn
+++ b/compiler/src/toml_parser.sfn
@@ -160,7 +160,7 @@ fn _parse_toml_internal(text: string) -> SailToml {
         entry: "src/main.sfn",
         dependencies: [],
         dev_dependencies: [],
-        capabilities: [],
+        capabilities: []
     };
     let lines = _toml_split_lines(text);
     let mut section: string = "";

--- a/compiler/src/tools/fmt.sfn
+++ b/compiler/src/tools/fmt.sfn
@@ -2,16 +2,14 @@
 //
 // Canonical formatter for .sfn files. Operates on the token stream
 // (not the AST) to preserve comments. One style, no configuration.
-
-import { Token } from "../token";
 import { lex } from "../lexer";
-import { char_at, substring, strings_equal } from "../string_utils";
-import { wraps_at_threshold, import_group } from "./fmt_rules";
+import { char_at, strings_equal, substring } from "../string_utils";
+import { Token } from "../token";
+import { import_group, wraps_at_threshold } from "./fmt_rules";
 
 // ═══════════════════════════════════════════════════════════════════
 // Enriched token for formatting
 // ═══════════════════════════════════════════════════════════════════
-
 struct FmtToken {
     token: Token;
     leading_comments: Token[];
@@ -23,7 +21,6 @@ struct FmtToken {
 // ═══════════════════════════════════════════════════════════════════
 // Formatting context (state carried through the emit phase)
 // ═══════════════════════════════════════════════════════════════════
-
 struct FmtContext {
     indent: number;
     line_pos: number;
@@ -35,15 +32,12 @@ struct FmtContext {
 // ═══════════════════════════════════════════════════════════════════
 // Helpers
 // ═══════════════════════════════════════════════════════════════════
-
 fn _count_newlines(text: string) -> number {
     let mut count = 0;
     let mut i = 0;
     loop {
         if i >= text.length { break; }
-        if char_at(text, i) == "\n" {
-            count += 1;
-        }
+        if char_at(text, i) == "\n" { count += 1; }
         i += 1;
     }
     return count;
@@ -145,7 +139,6 @@ fn _is_top_level_decl(lexeme: string) -> boolean {
 // ═══════════════════════════════════════════════════════════════════
 // Phase 2: Strip whitespace, classify tokens, attach comments
 // ═══════════════════════════════════════════════════════════════════
-
 fn _classify_role(token: Token, prev_lexeme: string, next_lexeme: string) -> string {
     let kind = token.kind.variant;
     let lex = token.lexeme;
@@ -170,6 +163,7 @@ fn _classify_role(token: Token, prev_lexeme: string, next_lexeme: string) -> str
             return "operator";
         }
         if strings_equal(lex, "@") { return "decorator"; }
+        if strings_equal(lex, "?") { return "optional_suffix"; }
         if _is_assign_op(lex) { return "assign"; }
         if _is_binary_op(lex) { return "operator"; }
         return "symbol";
@@ -199,9 +193,7 @@ fn strip_and_classify(tokens: Token[]) -> FmtToken[] {
         // Skip whitespace, but track blank lines
         if strings_equal(kind, "Whitespace") {
             let nl = _count_newlines(token.lexeme);
-            if nl >= 2 {
-                blank_lines = 1;
-            }
+            if nl >= 2 { blank_lines = 1; }
             i += 1;
             continue;
         }
@@ -249,8 +241,14 @@ fn strip_and_classify(tokens: Token[]) -> FmtToken[] {
         loop {
             if ni >= tokens.length { break; }
             let nk = tokens[ni].kind.variant;
-            if strings_equal(nk, "Whitespace") { ni += 1; continue; }
-            if strings_equal(nk, "Comment") { ni += 1; continue; }
+            if strings_equal(nk, "Whitespace") {
+                ni += 1;
+                continue;
+            }
+            if strings_equal(nk, "Comment") {
+                ni += 1;
+                continue;
+            }
             next_lex = tokens[ni].lexeme;
             break;
         }
@@ -258,11 +256,7 @@ fn strip_and_classify(tokens: Token[]) -> FmtToken[] {
         let role = _classify_role(token, prev_lex, next_lex);
 
         result.push(FmtToken {
-                token: token,
-                leading_comments: pending_comments,
-                trailing_comment: [],
-                blank_lines_before: blank_lines,
-                role: role,
+            token: token, leading_comments: pending_comments, trailing_comment: [], blank_lines_before: blank_lines, role: role,
         });
 
         last_structural_line = token.line;
@@ -297,10 +291,232 @@ fn strip_and_classify(tokens: Token[]) -> FmtToken[] {
     return result;
 }
 
+// Reclassify unary ! and - operators: when preceded by an operator, assignment,
+// open delimiter, keyword, separator, colon, arrow, or semicolon, the token is
+// a unary prefix operator, not binary.  This changes the role from "operator"
+// to "unary_op" so the emit phase omits the space after it.
+fn _reclassify_unary_ops(fmt_tokens: FmtToken[]) -> FmtToken[] {
+    let mut i = 0;
+    loop {
+        if i >= fmt_tokens.length { break; }
+        let ft = fmt_tokens[i];
+        if strings_equal(ft.role, "operator") {
+            let lex = ft.token.lexeme;
+            if strings_equal(lex, "!") {
+                let prev_role = "";
+                if i > 0 { prev_role = fmt_tokens[i - 1].role; }
+                if strings_equal(prev_role, "") {
+                    fmt_tokens[i] = FmtToken {
+                        token: ft.token,
+                        leading_comments: ft.leading_comments,
+                        trailing_comment: ft.trailing_comment,
+                        blank_lines_before: ft.blank_lines_before,
+                        role: "unary_op"
+                    };
+                }
+                if strings_equal(prev_role, "assign") {
+                    fmt_tokens[i] = FmtToken {
+                        token: ft.token,
+                        leading_comments: ft.leading_comments,
+                        trailing_comment: ft.trailing_comment,
+                        blank_lines_before: ft.blank_lines_before,
+                        role: "unary_op"
+                    };
+                }
+                if strings_equal(prev_role, "operator") {
+                    fmt_tokens[i] = FmtToken {
+                        token: ft.token,
+                        leading_comments: ft.leading_comments,
+                        trailing_comment: ft.trailing_comment,
+                        blank_lines_before: ft.blank_lines_before,
+                        role: "unary_op"
+                    };
+                }
+                if strings_equal(prev_role, "paren_open") {
+                    fmt_tokens[i] = FmtToken {
+                        token: ft.token,
+                        leading_comments: ft.leading_comments,
+                        trailing_comment: ft.trailing_comment,
+                        blank_lines_before: ft.blank_lines_before,
+                        role: "unary_op"
+                    };
+                }
+                if strings_equal(prev_role, "bracket_open") {
+                    fmt_tokens[i] = FmtToken {
+                        token: ft.token,
+                        leading_comments: ft.leading_comments,
+                        trailing_comment: ft.trailing_comment,
+                        blank_lines_before: ft.blank_lines_before,
+                        role: "unary_op"
+                    };
+                }
+                if strings_equal(prev_role, "separator") {
+                    fmt_tokens[i] = FmtToken {
+                        token: ft.token,
+                        leading_comments: ft.leading_comments,
+                        trailing_comment: ft.trailing_comment,
+                        blank_lines_before: ft.blank_lines_before,
+                        role: "unary_op"
+                    };
+                }
+                if strings_equal(prev_role, "keyword") {
+                    fmt_tokens[i] = FmtToken {
+                        token: ft.token,
+                        leading_comments: ft.leading_comments,
+                        trailing_comment: ft.trailing_comment,
+                        blank_lines_before: ft.blank_lines_before,
+                        role: "unary_op"
+                    };
+                }
+                if strings_equal(prev_role, "colon") {
+                    fmt_tokens[i] = FmtToken {
+                        token: ft.token,
+                        leading_comments: ft.leading_comments,
+                        trailing_comment: ft.trailing_comment,
+                        blank_lines_before: ft.blank_lines_before,
+                        role: "unary_op"
+                    };
+                }
+                if strings_equal(prev_role, "arrow") {
+                    fmt_tokens[i] = FmtToken {
+                        token: ft.token,
+                        leading_comments: ft.leading_comments,
+                        trailing_comment: ft.trailing_comment,
+                        blank_lines_before: ft.blank_lines_before,
+                        role: "unary_op"
+                    };
+                }
+                if strings_equal(prev_role, "semicolon") {
+                    fmt_tokens[i] = FmtToken {
+                        token: ft.token,
+                        leading_comments: ft.leading_comments,
+                        trailing_comment: ft.trailing_comment,
+                        blank_lines_before: ft.blank_lines_before,
+                        role: "unary_op"
+                    };
+                }
+                if strings_equal(prev_role, "unary_op") {
+                    fmt_tokens[i] = FmtToken {
+                        token: ft.token,
+                        leading_comments: ft.leading_comments,
+                        trailing_comment: ft.trailing_comment,
+                        blank_lines_before: ft.blank_lines_before,
+                        role: "unary_op"
+                    };
+                }
+            }
+            if strings_equal(lex, "-") {
+                let prev_role = "";
+                if i > 0 { prev_role = fmt_tokens[i - 1].role; }
+                if strings_equal(prev_role, "") {
+                    fmt_tokens[i] = FmtToken {
+                        token: ft.token,
+                        leading_comments: ft.leading_comments,
+                        trailing_comment: ft.trailing_comment,
+                        blank_lines_before: ft.blank_lines_before,
+                        role: "unary_op"
+                    };
+                }
+                if strings_equal(prev_role, "assign") {
+                    fmt_tokens[i] = FmtToken {
+                        token: ft.token,
+                        leading_comments: ft.leading_comments,
+                        trailing_comment: ft.trailing_comment,
+                        blank_lines_before: ft.blank_lines_before,
+                        role: "unary_op"
+                    };
+                }
+                if strings_equal(prev_role, "operator") {
+                    fmt_tokens[i] = FmtToken {
+                        token: ft.token,
+                        leading_comments: ft.leading_comments,
+                        trailing_comment: ft.trailing_comment,
+                        blank_lines_before: ft.blank_lines_before,
+                        role: "unary_op"
+                    };
+                }
+                if strings_equal(prev_role, "paren_open") {
+                    fmt_tokens[i] = FmtToken {
+                        token: ft.token,
+                        leading_comments: ft.leading_comments,
+                        trailing_comment: ft.trailing_comment,
+                        blank_lines_before: ft.blank_lines_before,
+                        role: "unary_op"
+                    };
+                }
+                if strings_equal(prev_role, "bracket_open") {
+                    fmt_tokens[i] = FmtToken {
+                        token: ft.token,
+                        leading_comments: ft.leading_comments,
+                        trailing_comment: ft.trailing_comment,
+                        blank_lines_before: ft.blank_lines_before,
+                        role: "unary_op"
+                    };
+                }
+                if strings_equal(prev_role, "separator") {
+                    fmt_tokens[i] = FmtToken {
+                        token: ft.token,
+                        leading_comments: ft.leading_comments,
+                        trailing_comment: ft.trailing_comment,
+                        blank_lines_before: ft.blank_lines_before,
+                        role: "unary_op"
+                    };
+                }
+                if strings_equal(prev_role, "keyword") {
+                    fmt_tokens[i] = FmtToken {
+                        token: ft.token,
+                        leading_comments: ft.leading_comments,
+                        trailing_comment: ft.trailing_comment,
+                        blank_lines_before: ft.blank_lines_before,
+                        role: "unary_op"
+                    };
+                }
+                if strings_equal(prev_role, "colon") {
+                    fmt_tokens[i] = FmtToken {
+                        token: ft.token,
+                        leading_comments: ft.leading_comments,
+                        trailing_comment: ft.trailing_comment,
+                        blank_lines_before: ft.blank_lines_before,
+                        role: "unary_op"
+                    };
+                }
+                if strings_equal(prev_role, "arrow") {
+                    fmt_tokens[i] = FmtToken {
+                        token: ft.token,
+                        leading_comments: ft.leading_comments,
+                        trailing_comment: ft.trailing_comment,
+                        blank_lines_before: ft.blank_lines_before,
+                        role: "unary_op"
+                    };
+                }
+                if strings_equal(prev_role, "semicolon") {
+                    fmt_tokens[i] = FmtToken {
+                        token: ft.token,
+                        leading_comments: ft.leading_comments,
+                        trailing_comment: ft.trailing_comment,
+                        blank_lines_before: ft.blank_lines_before,
+                        role: "unary_op"
+                    };
+                }
+                if strings_equal(prev_role, "unary_op") {
+                    fmt_tokens[i] = FmtToken {
+                        token: ft.token,
+                        leading_comments: ft.leading_comments,
+                        trailing_comment: ft.trailing_comment,
+                        blank_lines_before: ft.blank_lines_before,
+                        role: "unary_op"
+                    };
+                }
+            }
+        }
+        i += 1;
+    }
+    return fmt_tokens;
+}
+
 // ═══════════════════════════════════════════════════════════════════
 // Phase 3: Emit formatted output
 // ═══════════════════════════════════════════════════════════════════
-
 // Measure the single-line length of tokens from start (inclusive, should be
 // block_open) to its matching block_close.  Returns -1 if the span contains
 // nested blocks (not a simple inline candidate) or if no matching close is
@@ -312,6 +528,8 @@ fn _measure_inline_block(fmt_tokens: FmtToken[], start: number) -> number {
     let mut length = 0;
     let mut items = 1;
     let mut has_content = false;
+    let mut semicolons = 0;
+    let mut has_colon = false;
     let mut j = start;
     loop {
         if j >= fmt_tokens.length { return -1; }
@@ -335,6 +553,13 @@ fn _measure_inline_block(fmt_tokens: FmtToken[], start: number) -> number {
         if strings_equal(role, "block_close") {
             if depth == 1 {
                 if !has_content { items = 0; }
+                // Multi-statement code blocks (2+ semicolons) should not inline
+                if semicolons > 1 { return -1; }
+                // Blocks with both colons and semicolons are field declarations
+                // (struct/enum), not code blocks — do not inline
+                if has_colon {
+                    if semicolons > 0 { return -1; }
+                }
                 length = length + 1 + lex.length;
                 let encoded = length * 1000 + items;
                 return encoded;
@@ -347,13 +572,13 @@ fn _measure_inline_block(fmt_tokens: FmtToken[], start: number) -> number {
             items += 1;
             length = length + lex.length + 1;
         } else if strings_equal(role, "colon") {
+            has_colon = true;
             length = length + lex.length + 1;
         } else if strings_equal(role, "semicolon") {
+            semicolons += 1;
             length = length + lex.length;
         } else {
-            if j > start + 1 {
-                length = length + 1;
-            }
+            if j > start + 1 { length = length + 1; }
             length = length + lex.length;
         }
         j += 1;
@@ -362,17 +587,40 @@ fn _measure_inline_block(fmt_tokens: FmtToken[], start: number) -> number {
 }
 
 fn _is_inline_block_context(fmt_tokens: FmtToken[], block_open_idx: number) -> boolean {
-    // A block is inlineable if it's a struct literal or import specifier list.
-    // Check what precedes the {: if it's a value (struct name) or keyword
-    // "import", it's a candidate.
+    // A block is inlineable if it fits on one line. The measure function
+    // rejects nested blocks, comments, blank lines, and multi-statement
+    // blocks. Here we just check that the context is reasonable.
     if block_open_idx == 0 { return false; }
     let prev = fmt_tokens[block_open_idx - 1];
     // import { ... }
     if strings_equal(prev.token.lexeme, "import") { return true; }
+    // export { ... }
+    if strings_equal(prev.token.lexeme, "export") { return true; }
     // StructName { ... }  — value followed by {
-    if strings_equal(prev.role, "value") { return true; }
+    // BUT exclude struct/enum declarations: struct Foo { ... }
+    if strings_equal(prev.role, "value") {
+        if block_open_idx >= 2 {
+            let prev2 = fmt_tokens[block_open_idx - 2];
+            if strings_equal(prev2.token.lexeme, "struct") { return false; }
+            if strings_equal(prev2.token.lexeme, "enum") { return false; }
+            if strings_equal(prev2.token.lexeme, "interface") { return false; }
+        }
+        return true;
+    }
     // Type parameter close: GenericStruct<T> { ... }
     if strings_equal(prev.role, "bracket_close") { return true; }
+    // After closing paren: if cond() { ... }, fn foo() { ... }
+    if strings_equal(prev.role, "paren_close") { return true; }
+    // After keywords: else { ... }, loop { ... }, try { ... }, catch { ... }
+    // BUT exclude struct/enum/interface keyword followed by name followed by {
+    if strings_equal(prev.role, "keyword") {
+        if strings_equal(prev.token.lexeme, "struct") { return false; }
+        if strings_equal(prev.token.lexeme, "enum") { return false; }
+        if strings_equal(prev.token.lexeme, "interface") { return false; }
+        return true;
+    }
+    // Match arms: Pattern => { body; }
+    if strings_equal(prev.role, "arrow") { return true; }
     return false;
 }
 
@@ -409,6 +657,12 @@ fn _needs_newline_before(role: string, prev_role: string, lexeme: string, prev_l
 fn _needs_space_before(role: string, prev_role: string, lexeme: string, prev_lexeme: string) -> boolean {
     // No space at start of output
     if strings_equal(prev_role, "") { return false; }
+
+    // No space after unary operator (!, -)
+    if strings_equal(prev_role, "unary_op") { return false; }
+
+    // Optional suffix ?: no space before
+    if strings_equal(role, "optional_suffix") { return false; }
 
     // Compound assignment: operator followed by = (lexer splits += into + and =)
     if strings_equal(role, "assign") {
@@ -504,9 +758,7 @@ fn emit_formatted(fmt_tokens: FmtToken[]) -> string {
                         }
                     }
                 }
-            } else {
-                inline_block_depth += 1;
-            }
+            } else { inline_block_depth += 1; }
         }
 
         // ── Emit blank line ──
@@ -518,15 +770,11 @@ fn emit_formatted(fmt_tokens: FmtToken[]) -> string {
                     suppress_blank = true;
                 }
                 // Suppress blank lines at block end (before })
-                if strings_equal(role, "block_close") {
-                    suppress_blank = true;
-                }
+                if strings_equal(role, "block_close") { suppress_blank = true; }
 
                 if ft.blank_lines_before > 0 {
                     if !suppress_blank {
-                        if !at_line_start {
-                            out = out + "\n";
-                        }
+                        if !at_line_start { out = out + "\n"; }
                         out = out + "\n";
                         at_line_start = true;
                     }
@@ -545,9 +793,7 @@ fn emit_formatted(fmt_tokens: FmtToken[]) -> string {
                                     need_blank = true;
                                 }
                                 if need_blank {
-                                    if !at_line_start {
-                                        out = out + "\n";
-                                    }
+                                    if !at_line_start { out = out + "\n"; }
                                     out = out + "\n";
                                     at_line_start = true;
                                 }
@@ -557,16 +803,12 @@ fn emit_formatted(fmt_tokens: FmtToken[]) -> string {
                         if strings_equal(role, "decorator") {
                             if !strings_equal(prev_role, "") {
                                 if strings_equal(prev_role, "semicolon") {
-                                    if !at_line_start {
-                                        out = out + "\n";
-                                    }
+                                    if !at_line_start { out = out + "\n"; }
                                     out = out + "\n";
                                     at_line_start = true;
                                 }
                                 if strings_equal(prev_role, "block_close") {
-                                    if !at_line_start {
-                                        out = out + "\n";
-                                    }
+                                    if !at_line_start { out = out + "\n"; }
                                     out = out + "\n";
                                     at_line_start = true;
                                 }
@@ -583,9 +825,7 @@ fn emit_formatted(fmt_tokens: FmtToken[]) -> string {
             loop {
                 if ci >= ft.leading_comments.length { break; }
                 let comment = ft.leading_comments[ci];
-                if !at_line_start {
-                    out = out + "\n";
-                }
+                if !at_line_start { out = out + "\n"; }
                 out = out + _emit_indent(indent) + comment.lexeme + "\n";
                 at_line_start = true;
                 ci += 1;
@@ -615,13 +855,9 @@ fn emit_formatted(fmt_tokens: FmtToken[]) -> string {
                 // Space before { in inline mode (e.g., "StructName {")
                 if !at_line_start {
                     let needs_sp = _needs_space_before(role, prev_role, lexeme, prev_lexeme);
-                    if needs_sp {
-                        out = out + " ";
-                    }
+                    if needs_sp { out = out + " "; }
                 }
-            } else if strings_equal(role, "block_close") {
-                out = out + " ";
-            } else if strings_equal(role, "separator") {
+            } else if strings_equal(role, "block_close") { out = out + " "; } else if strings_equal(role, "separator") {
                 // No space before comma
             } else if strings_equal(role, "semicolon") {
                 // No space before semicolon
@@ -633,36 +869,28 @@ fn emit_formatted(fmt_tokens: FmtToken[]) -> string {
                 // No space after dot
             } else if strings_equal(prev_role, "block_open") {
                 out = out + " ";
-            } else if strings_equal(prev_role, "separator") {
+            } else if strings_equal(prev_role, "separator") { out = out + " "; } else if strings_equal(prev_role, "colon") {
                 out = out + " ";
-            } else if strings_equal(prev_role, "colon") {
-                out = out + " ";
+            } else if strings_equal(prev_role, "unary_op") {
+                // No space after unary operator
             } else {
                 let needs_sp = _needs_space_before(role, prev_role, lexeme, prev_lexeme);
-                if needs_sp {
-                    out = out + " ";
-                }
+                if needs_sp { out = out + " "; }
             }
             at_line_start = false;
         } else {
             let needs_nl = _needs_newline_before(role, prev_role, lexeme, prev_lexeme);
             if needs_nl {
-                if !at_line_start {
-                    out = out + "\n";
-                }
+                if !at_line_start { out = out + "\n"; }
                 out = out + _emit_indent(indent);
                 at_line_start = false;
             } else {
                 if at_line_start {
-                    if i > 0 {
-                        out = out + _emit_indent(indent);
-                    }
+                    if i > 0 { out = out + _emit_indent(indent); }
                     at_line_start = false;
                 } else {
                     let needs_sp = _needs_space_before(role, prev_role, lexeme, prev_lexeme);
-                    if needs_sp {
-                        out = out + " ";
-                    }
+                    if needs_sp { out = out + " "; }
                 }
             }
         }
@@ -672,22 +900,14 @@ fn emit_formatted(fmt_tokens: FmtToken[]) -> string {
 
         // ── Adjust indent after opening tokens (skip in inline mode) ──
         if inline_block_depth == 0 {
-            if strings_equal(role, "block_open") {
-                indent += 1;
-            }
+            if strings_equal(role, "block_open") { indent += 1; }
         }
-        if strings_equal(role, "paren_open") {
-            paren_depth += 1;
-        }
-        if strings_equal(role, "bracket_open") {
-            paren_depth += 1;
-        }
+        if strings_equal(role, "paren_open") { paren_depth += 1; }
+        if strings_equal(role, "bracket_open") { paren_depth += 1; }
 
         // ── Track inline block exit ──
         if strings_equal(role, "block_close") {
-            if inline_block_depth > 0 {
-                inline_block_depth -= 1;
-            }
+            if inline_block_depth > 0 { inline_block_depth -= 1; }
         }
 
         // ── Emit trailing comments ──
@@ -722,9 +942,7 @@ fn emit_formatted(fmt_tokens: FmtToken[]) -> string {
 
     // Ensure file ends with exactly one newline
     if out.length > 0 {
-        if !at_line_start {
-            out = out + "\n";
-        }
+        if !at_line_start { out = out + "\n"; }
     }
 
     return out;
@@ -733,11 +951,9 @@ fn emit_formatted(fmt_tokens: FmtToken[]) -> string {
 // ═══════════════════════════════════════════════════════════════════
 // Import sorting
 // ═══════════════════════════════════════════════════════════════════
-
 // An import statement is a contiguous range of FmtTokens from
 // "import" to ";".  We collect these, extract the path, sort, and
 // rebuild the token list.
-
 struct ImportSpan {
     start: number;
     end: number;
@@ -751,9 +967,7 @@ fn _extract_import_path(fmt_tokens: FmtToken[], start: number, end: number) -> s
     loop {
         if j > end { break; }
         if strings_equal(fmt_tokens[j].token.lexeme, "from") {
-            if j + 1 <= end {
-                return fmt_tokens[j + 1].token.lexeme;
-            }
+            if j + 1 <= end { return fmt_tokens[j + 1].token.lexeme; }
         }
         j += 1;
     }
@@ -774,7 +988,9 @@ fn _find_import_spans(fmt_tokens: FmtToken[]) -> ImportSpan[] {
                 if strings_equal(fmt_tokens[j].role, "semicolon") {
                     let path = _extract_import_path(fmt_tokens, start, j);
                     let grp = import_group(path);
-                    spans.push(ImportSpan { start: start, end: j, path: path, group: grp });
+                    spans.push(ImportSpan {
+                        start: start, end: j, path: path, group: grp
+                    });
                     i = j + 1;
                     break;
                 }
@@ -802,9 +1018,7 @@ fn _are_consecutive_imports(fmt_tokens: FmtToken[], spans: ImportSpan[]) -> bool
             if j >= next_start { break; }
             let ft = fmt_tokens[j];
             // If we hit a non-import structural token, imports are not consecutive
-            if !strings_equal(ft.role, "comment") {
-                return false;
-            }
+            if !strings_equal(ft.role, "comment") { return false; }
             j += 1;
         }
         k += 1;
@@ -830,9 +1044,7 @@ fn _sort_import_spans(spans: ImportSpan[]) -> ImportSpan[] {
             if j <= 0 { break; }
             let prev = sorted[j - 1];
             let mut should_swap = false;
-            if prev.group > key.group {
-                should_swap = true;
-            } else if prev.group == key.group {
+            if prev.group > key.group { should_swap = true; } else if prev.group == key.group {
                 // Compare paths lexicographically
                 let mut ci = 0;
                 let a = prev.path;
@@ -844,8 +1056,14 @@ fn _sort_import_spans(spans: ImportSpan[]) -> ImportSpan[] {
                     if ci >= min_len { break; }
                     let ca = char_at(a, ci);
                     let cb = char_at(b, ci);
-                    if ca < cb { cmp = -1; break; }
-                    if ca > cb { cmp = 1; break; }
+                    if ca < cb {
+                        cmp = -1;
+                        break;
+                    }
+                    if ca > cb {
+                        cmp = 1;
+                        break;
+                    }
                     ci += 1;
                 }
                 if cmp == 0 {
@@ -872,9 +1090,7 @@ fn _sort_import_specifiers(fmt_tokens: FmtToken[], start: number, end: number) -
     let mut j = start;
     loop {
         if j > end { break; }
-        if strings_equal(fmt_tokens[j].role, "block_open") {
-            brace_open = j;
-        }
+        if strings_equal(fmt_tokens[j].role, "block_open") { brace_open = j; }
         if strings_equal(fmt_tokens[j].role, "block_close") {
             brace_close = j;
             break;
@@ -914,8 +1130,14 @@ fn _sort_import_specifiers(fmt_tokens: FmtToken[], start: number, end: number) -
                 if ci >= min_len { break; }
                 let ca = char_at(prev_name, ci);
                 let cb = char_at(key_name, ci);
-                if ca < cb { cmp = -1; break; }
-                if ca > cb { cmp = 1; break; }
+                if ca < cb {
+                    cmp = -1;
+                    break;
+                }
+                if ca > cb {
+                    cmp = 1;
+                    break;
+                }
                 ci += 1;
             }
             if cmp == 0 {
@@ -931,6 +1153,80 @@ fn _sort_import_specifiers(fmt_tokens: FmtToken[], start: number, end: number) -
     }
 
     return names;
+}
+
+// Push tokens from span.start+1 to span.end into result, sorting specifier
+// names inside { ... } alphabetically.
+fn _push_span_sorted(result: FmtToken[], fmt_tokens: FmtToken[], span_start: number, span_end: number) -> FmtToken[] {
+    let sorted_names = _sort_import_specifiers(fmt_tokens, span_start, span_end);
+    if sorted_names.length == 0 {
+        // No braces or no specifiers — copy as-is
+        let mut j = span_start + 1;
+        loop {
+            if j > span_end { break; }
+            result.push(fmt_tokens[j]);
+            j += 1;
+        }
+        return result;
+    }
+
+    // Find the brace region
+    let mut brace_open = -1;
+    let mut brace_close = -1;
+    let mut j = span_start;
+    loop {
+        if j > span_end { break; }
+        if strings_equal(fmt_tokens[j].role, "block_open") { brace_open = j; }
+        if strings_equal(fmt_tokens[j].role, "block_close") {
+            brace_close = j;
+            break;
+        }
+        j += 1;
+    }
+
+    // Collect positions of value tokens inside braces
+    let mut value_positions: number[] = [];
+    let mut k = brace_open + 1;
+    loop {
+        if k >= brace_close { break; }
+        if strings_equal(fmt_tokens[k].role, "value") {
+            value_positions.push(k);
+        }
+        k += 1;
+    }
+
+    // Copy tokens, replacing value tokens with sorted names
+    let mut name_idx = 0;
+    let mut ti = span_start + 1;
+    loop {
+        if ti > span_end { break; }
+        // Check if this is a value token inside the braces that needs reordering
+        let mut is_specifier = false;
+        if ti > brace_open {
+            if ti < brace_close {
+                if strings_equal(fmt_tokens[ti].role, "value") {
+                    is_specifier = true;
+                }
+            }
+        }
+        if is_specifier {
+            if name_idx < sorted_names.length {
+                let orig = fmt_tokens[ti];
+                let new_token = Token {
+                    kind: orig.token.kind,
+                    lexeme: sorted_names[name_idx],
+                    line: orig.token.line,
+                    column: orig.token.column,
+                };
+                result.push(FmtToken {
+                    token: new_token, leading_comments: orig.leading_comments, trailing_comment: orig.trailing_comment, blank_lines_before: orig.blank_lines_before, role: orig.role,
+                });
+                name_idx += 1;
+            }
+        } else { result.push(fmt_tokens[ti]); }
+        ti += 1;
+    }
+    return result;
 }
 
 fn sort_imports(fmt_tokens: FmtToken[]) -> FmtToken[] {
@@ -984,58 +1280,29 @@ fn sort_imports(fmt_tokens: FmtToken[]) -> FmtToken[] {
         if si == 0 {
             use_comments = header_comments;
             use_blanks = header_blanks;
-        } else if span.start == orig_first_start {
-            use_comments = [];
-        }
+        } else if span.start == orig_first_start { use_comments = []; }
 
         // Insert blank line between import groups
         if prev_group >= 0 {
             if span.group != prev_group {
                 // Add blank_lines_before to the first token of this import
                 result.push(FmtToken {
-                        token: first_ft.token,
-                        leading_comments: use_comments,
-                        trailing_comment: first_ft.trailing_comment,
-                        blank_lines_before: 1,
-                        role: first_ft.role,
+                    token: first_ft.token, leading_comments: use_comments, trailing_comment: first_ft.trailing_comment, blank_lines_before: 1, role: first_ft.role,
                 });
-                let mut j = span.start + 1;
-                loop {
-                    if j > span.end { break; }
-                    result.push(fmt_tokens[j]);
-                    j += 1;
-                }
+                result = _push_span_sorted(result, fmt_tokens, span.start, span.end);
             } else {
                 // Same group: clear any blank lines between
                 result.push(FmtToken {
-                        token: first_ft.token,
-                        leading_comments: use_comments,
-                        trailing_comment: first_ft.trailing_comment,
-                        blank_lines_before: 0,
-                        role: first_ft.role,
+                    token: first_ft.token, leading_comments: use_comments, trailing_comment: first_ft.trailing_comment, blank_lines_before: 0, role: first_ft.role,
                 });
-                let mut j = span.start + 1;
-                loop {
-                    if j > span.end { break; }
-                    result.push(fmt_tokens[j]);
-                    j += 1;
-                }
+                result = _push_span_sorted(result, fmt_tokens, span.start, span.end);
             }
         } else {
             // First emitted import: use header comments/blanks
             result.push(FmtToken {
-                    token: first_ft.token,
-                    leading_comments: use_comments,
-                    trailing_comment: first_ft.trailing_comment,
-                    blank_lines_before: use_blanks,
-                    role: first_ft.role,
+                token: first_ft.token, leading_comments: use_comments, trailing_comment: first_ft.trailing_comment, blank_lines_before: use_blanks, role: first_ft.role,
             });
-            let mut j = span.start + 1;
-            loop {
-                if j > span.end { break; }
-                result.push(fmt_tokens[j]);
-                j += 1;
-            }
+            result = _push_span_sorted(result, fmt_tokens, span.start, span.end);
         }
 
         prev_group = span.group;
@@ -1056,11 +1323,8 @@ fn sort_imports(fmt_tokens: FmtToken[]) -> FmtToken[] {
 // ═══════════════════════════════════════════════════════════════════
 // Public entry point
 // ═══════════════════════════════════════════════════════════════════
-
 fn format_source(source: string) -> string {
-    if source.length == 0 {
-        return "";
-    }
+    if source.length == 0 { return ""; }
     let tokens = lex(source);
     let fmt_tokens = strip_and_classify(tokens);
     if fmt_tokens.length == 0 {
@@ -1077,7 +1341,8 @@ fn format_source(source: string) -> string {
         }
         return out;
     }
-    let sorted = sort_imports(fmt_tokens);
+    let classified = _reclassify_unary_ops(fmt_tokens);
+    let sorted = sort_imports(classified);
     return emit_formatted(sorted);
 }
 

--- a/compiler/src/tools/fmt.sfn
+++ b/compiler/src/tools/fmt.sfn
@@ -256,7 +256,7 @@ fn strip_and_classify(tokens: Token[]) -> FmtToken[] {
         let role = _classify_role(token, prev_lex, next_lex);
 
         result.push(FmtToken {
-                token: token, leading_comments: pending_comments, trailing_comment: [], blank_lines_before: blank_lines, role: role
+            token: token, leading_comments: pending_comments, trailing_comment: [], blank_lines_before: blank_lines, role: role
         });
 
         last_structural_line = token.line;
@@ -922,7 +922,7 @@ fn emit_formatted(fmt_tokens: FmtToken[]) -> string {
                                         next_len = fmt_tokens[i + 1].token.lexeme.length;
                                     }
                                     if cur_pos + 1 + lexeme.length + 1
-                                    + next_len > 80 { should_wrap = true; }
+                                        + next_len > 80 { should_wrap = true; }
                                 }
                             }
                         }
@@ -1049,7 +1049,7 @@ fn _find_import_spans(fmt_tokens: FmtToken[]) -> ImportSpan[] {
                     let path = _extract_import_path(fmt_tokens, start, j);
                     let grp = import_group(path);
                     spans.push(ImportSpan {
-                            start: start, end: j, path: path, group: grp
+                        start: start, end: j, path: path, group: grp
                     });
                     i = j + 1;
                     break;
@@ -1279,7 +1279,7 @@ fn _push_span_sorted(result: FmtToken[], fmt_tokens: FmtToken[], span_start: num
                     column: orig.token.column
                 };
                 result.push(FmtToken {
-                        token: new_token, leading_comments: orig.leading_comments, trailing_comment: orig.trailing_comment, blank_lines_before: orig.blank_lines_before, role: orig.role
+                    token: new_token, leading_comments: orig.leading_comments, trailing_comment: orig.trailing_comment, blank_lines_before: orig.blank_lines_before, role: orig.role
                 });
                 name_idx += 1;
             }
@@ -1347,20 +1347,20 @@ fn sort_imports(fmt_tokens: FmtToken[]) -> FmtToken[] {
             if span.group != prev_group {
                 // Add blank_lines_before to the first token of this import
                 result.push(FmtToken {
-                        token: first_ft.token, leading_comments: use_comments, trailing_comment: first_ft.trailing_comment, blank_lines_before: 1, role: first_ft.role
+                    token: first_ft.token, leading_comments: use_comments, trailing_comment: first_ft.trailing_comment, blank_lines_before: 1, role: first_ft.role
                 });
                 result = _push_span_sorted(result, fmt_tokens, span.start, span.end);
             } else {
                 // Same group: clear any blank lines between
                 result.push(FmtToken {
-                        token: first_ft.token, leading_comments: use_comments, trailing_comment: first_ft.trailing_comment, blank_lines_before: 0, role: first_ft.role
+                    token: first_ft.token, leading_comments: use_comments, trailing_comment: first_ft.trailing_comment, blank_lines_before: 0, role: first_ft.role
                 });
                 result = _push_span_sorted(result, fmt_tokens, span.start, span.end);
             }
         } else {
             // First emitted import: use header comments/blanks
             result.push(FmtToken {
-                    token: first_ft.token, leading_comments: use_comments, trailing_comment: first_ft.trailing_comment, blank_lines_before: use_blanks, role: first_ft.role
+                token: first_ft.token, leading_comments: use_comments, trailing_comment: first_ft.trailing_comment, blank_lines_before: use_blanks, role: first_ft.role
             });
             result = _push_span_sorted(result, fmt_tokens, span.start, span.end);
         }

--- a/compiler/src/tools/fmt.sfn
+++ b/compiler/src/tools/fmt.sfn
@@ -219,7 +219,7 @@ fn strip_and_classify(tokens: Token[]) -> FmtToken[] {
                         leading_comments: prev_ft.leading_comments,
                         trailing_comment: updated_trailing,
                         blank_lines_before: prev_ft.blank_lines_before,
-                        role: prev_ft.role,
+                        role: prev_ft.role
                     };
                     i += 1;
                     continue;
@@ -256,7 +256,7 @@ fn strip_and_classify(tokens: Token[]) -> FmtToken[] {
         let role = _classify_role(token, prev_lex, next_lex);
 
         result.push(FmtToken {
-            token: token, leading_comments: pending_comments, trailing_comment: [], blank_lines_before: blank_lines, role: role,
+                token: token, leading_comments: pending_comments, trailing_comment: [], blank_lines_before: blank_lines, role: role
         });
 
         last_structural_line = token.line;
@@ -283,7 +283,7 @@ fn strip_and_classify(tokens: Token[]) -> FmtToken[] {
                 leading_comments: last_ft.leading_comments,
                 trailing_comment: merged,
                 blank_lines_before: last_ft.blank_lines_before,
-                role: last_ft.role,
+                role: last_ft.role
             };
         }
     }
@@ -569,8 +569,17 @@ fn _measure_inline_block(fmt_tokens: FmtToken[], start: number) -> number {
 
         has_content = true;
         if strings_equal(role, "separator") {
-            items += 1;
-            length = length + lex.length + 1;
+            // Don't count trailing comma (separator before block_close) as an item or length
+            let is_trailing = false;
+            if j + 1 < fmt_tokens.length {
+                if strings_equal(fmt_tokens[j + 1].role, "block_close") {
+                    is_trailing = true;
+                }
+            }
+            if !is_trailing {
+                items += 1;
+                length = length + lex.length + 1;
+            }
         } else if strings_equal(role, "colon") {
             has_colon = true;
             length = length + lex.length + 1;
@@ -734,6 +743,7 @@ fn emit_formatted(fmt_tokens: FmtToken[]) -> string {
     let mut paren_depth = 0;
     let mut inline_block_depth = 0;
     let mut inline_block_end = -1;
+    let mut wrap_operators = false;
 
     let mut i = 0;
     loop {
@@ -753,9 +763,8 @@ fn emit_formatted(fmt_tokens: FmtToken[]) -> string {
                         let item_count = measure % 1000;
                         // Current line position (bounded scan, O(1))
                         let cur_line_pos = _line_pos_from_end(out);
-                        if !wraps_at_threshold(item_count, cur_line_pos + line_len) {
-                            inline_block_depth = 1;
-                        }
+                        if !wraps_at_threshold(item_count, cur_line_pos
+                            + line_len) { inline_block_depth = 1; }
                     }
                 }
             } else { inline_block_depth += 1; }
@@ -890,7 +899,53 @@ fn emit_formatted(fmt_tokens: FmtToken[]) -> string {
                     at_line_start = false;
                 } else {
                     let needs_sp = _needs_space_before(role, prev_role, lexeme, prev_lexeme);
-                    if needs_sp { out = out + " "; }
+                    if needs_sp {
+                        // Expression wrapping: break before binary operator when line gets long
+                        let mut should_wrap = false;
+                        if strings_equal(role, "operator") {
+                            // Only wrap at chain-style operators, not arithmetic
+                            let is_wrappable = false;
+                            if strings_equal(lexeme, "+") {
+                                is_wrappable = true;
+                            }
+                            if strings_equal(lexeme, "&&") {
+                                is_wrappable = true;
+                            }
+                            if strings_equal(lexeme, "||") {
+                                is_wrappable = true;
+                            }
+                            if is_wrappable {
+                                if wrap_operators { should_wrap = true; } else {
+                                    let cur_pos = _line_pos_from_end(out);
+                                    let mut next_len = 0;
+                                    if i + 1 < fmt_tokens.length {
+                                        next_len = fmt_tokens[i + 1].token.lexeme.length;
+                                    }
+                                    if cur_pos + 1 + lexeme.length + 1
+                                    + next_len > 80 { should_wrap = true; }
+                                }
+                            }
+                        }
+                        if should_wrap {
+                            out = out + "\n" + _emit_indent(indent + 1);
+                            wrap_operators = true;
+                        } else { out = out + " "; }
+                    }
+                }
+            }
+        }
+
+        // ── Skip trailing comma before closing delimiter ──
+        // Strips trailing commas in single-line imports: { a, b, } → { a, b }
+        if strings_equal(role, "separator") {
+            if i + 1 < fmt_tokens.length {
+                let next_role = fmt_tokens[i + 1].role;
+                if strings_equal(next_role, "block_close") {
+                    // Skip this comma — don't emit it
+                    prev_role = role;
+                    prev_lexeme = lexeme;
+                    i += 1;
+                    continue;
                 }
             }
         }
@@ -924,6 +979,7 @@ fn emit_formatted(fmt_tokens: FmtToken[]) -> string {
             if strings_equal(role, "semicolon") {
                 out = out + "\n";
                 at_line_start = true;
+                wrap_operators = false;
             }
 
             // ── Newline after comma at statement level ──
@@ -934,6 +990,10 @@ fn emit_formatted(fmt_tokens: FmtToken[]) -> string {
                 }
             }
         }
+
+        // Reset expression wrapping at block boundaries
+        if strings_equal(role, "block_open") { wrap_operators = false; }
+        if strings_equal(role, "block_close") { wrap_operators = false; }
 
         prev_role = role;
         prev_lexeme = lexeme;
@@ -989,7 +1049,7 @@ fn _find_import_spans(fmt_tokens: FmtToken[]) -> ImportSpan[] {
                     let path = _extract_import_path(fmt_tokens, start, j);
                     let grp = import_group(path);
                     spans.push(ImportSpan {
-                        start: start, end: j, path: path, group: grp
+                            start: start, end: j, path: path, group: grp
                     });
                     i = j + 1;
                     break;
@@ -1216,10 +1276,10 @@ fn _push_span_sorted(result: FmtToken[], fmt_tokens: FmtToken[], span_start: num
                     kind: orig.token.kind,
                     lexeme: sorted_names[name_idx],
                     line: orig.token.line,
-                    column: orig.token.column,
+                    column: orig.token.column
                 };
                 result.push(FmtToken {
-                    token: new_token, leading_comments: orig.leading_comments, trailing_comment: orig.trailing_comment, blank_lines_before: orig.blank_lines_before, role: orig.role,
+                        token: new_token, leading_comments: orig.leading_comments, trailing_comment: orig.trailing_comment, blank_lines_before: orig.blank_lines_before, role: orig.role
                 });
                 name_idx += 1;
             }
@@ -1287,20 +1347,20 @@ fn sort_imports(fmt_tokens: FmtToken[]) -> FmtToken[] {
             if span.group != prev_group {
                 // Add blank_lines_before to the first token of this import
                 result.push(FmtToken {
-                    token: first_ft.token, leading_comments: use_comments, trailing_comment: first_ft.trailing_comment, blank_lines_before: 1, role: first_ft.role,
+                        token: first_ft.token, leading_comments: use_comments, trailing_comment: first_ft.trailing_comment, blank_lines_before: 1, role: first_ft.role
                 });
                 result = _push_span_sorted(result, fmt_tokens, span.start, span.end);
             } else {
                 // Same group: clear any blank lines between
                 result.push(FmtToken {
-                    token: first_ft.token, leading_comments: use_comments, trailing_comment: first_ft.trailing_comment, blank_lines_before: 0, role: first_ft.role,
+                        token: first_ft.token, leading_comments: use_comments, trailing_comment: first_ft.trailing_comment, blank_lines_before: 0, role: first_ft.role
                 });
                 result = _push_span_sorted(result, fmt_tokens, span.start, span.end);
             }
         } else {
             // First emitted import: use header comments/blanks
             result.push(FmtToken {
-                token: first_ft.token, leading_comments: use_comments, trailing_comment: first_ft.trailing_comment, blank_lines_before: use_blanks, role: first_ft.role,
+                    token: first_ft.token, leading_comments: use_comments, trailing_comment: first_ft.trailing_comment, blank_lines_before: use_blanks, role: first_ft.role
             });
             result = _push_span_sorted(result, fmt_tokens, span.start, span.end);
         }

--- a/compiler/src/tools/fmt_rules.sfn
+++ b/compiler/src/tools/fmt_rules.sfn
@@ -2,13 +2,11 @@
 //
 // Formatting rule tables for sfn fmt. Spacing, blank-line, and
 // classification lookups used by the emit phase in fmt.sfn.
-
 import { strings_equal, substring } from "../string_utils";
 
 // ═══════════════════════════════════════════════════════════════════
 // Spacing rules
 // ═══════════════════════════════════════════════════════════════════
-
 // Returns "space", "none", or "newline" for the gap between two tokens
 // based on their roles.
 fn get_spacing_rule(left_role: string, right_role: string) -> string {
@@ -76,7 +74,6 @@ fn get_spacing_rule(left_role: string, right_role: string) -> string {
 // ═══════════════════════════════════════════════════════════════════
 // Blank-line rules
 // ═══════════════════════════════════════════════════════════════════
-
 // Returns the number of blank lines required for a context transition.
 // context values: "top_level", "after_imports", "in_block"
 fn get_blank_line_rule(context: string) -> number {
@@ -88,7 +85,6 @@ fn get_blank_line_rule(context: string) -> number {
 // ═══════════════════════════════════════════════════════════════════
 // Classification helpers
 // ═══════════════════════════════════════════════════════════════════
-
 fn opens_block(lexeme: string) -> boolean {
     if strings_equal(lexeme, "fn") { return true; }
     if strings_equal(lexeme, "struct") { return true; }
@@ -147,9 +143,7 @@ fn is_binary_operator(lexeme: string) -> boolean {
 // assignment, keyword, or at expression start.
 fn is_unary_prefix(lexeme: string, prev_role: string) -> boolean {
     if !strings_equal(lexeme, "-") {
-        if !strings_equal(lexeme, "!") {
-            return false;
-        }
+        if !strings_equal(lexeme, "!") { return false; }
     }
     // After these roles, - and ! are unary prefix
     if strings_equal(prev_role, "") { return true; }
@@ -174,4 +168,13 @@ fn import_group(path: string) -> number {
     return 1;
 }
 
-export { get_spacing_rule, get_blank_line_rule, opens_block, closes_statement, wraps_at_threshold, is_binary_operator, is_unary_prefix, import_group };
+export {
+    get_spacing_rule,
+    get_blank_line_rule,
+    opens_block,
+    closes_statement,
+    wraps_at_threshold,
+    is_binary_operator,
+    is_unary_prefix,
+    import_group
+};

--- a/compiler/src/typecheck.sfn
+++ b/compiler/src/typecheck.sfn
@@ -84,7 +84,7 @@ fn collect_top_level_symbols(program: Program) -> SymbolCollectionResult {
 
     return SymbolCollectionResult {
         symbols: symbols,
-        diagnostics: diagnostics,
+        diagnostics: diagnostics
     };
 }
 
@@ -119,7 +119,7 @@ fn register_top_level_symbol(statement: Statement, existing: SymbolEntry[]) -> S
     if statement.variant == "VariableDeclaration" {
         return register_symbol(statement.name, "variable", statement.span, existing);
     }
-    return SymbolCollectionResult { symbols: existing, diagnostics: [], };
+    return SymbolCollectionResult { symbols: existing, diagnostics: [] };
 }
 
 fn check_program_scopes(program: Program, interfaces: Statement[]) -> Diagnostic[] {
@@ -163,7 +163,7 @@ fn check_statement(statement: Statement, bindings: SymbolEntry[], interfaces: St
         }
         return ScopeResult {
             bindings: registration.bindings,
-            diagnostics: diagnostics,
+            diagnostics: diagnostics
         };
     }
     if statement.variant == "StructDeclaration" {
@@ -212,7 +212,7 @@ fn check_statement(statement: Statement, bindings: SymbolEntry[], interfaces: St
         }
         return ScopeResult {
             bindings: registration.bindings,
-            diagnostics: diagnostics,
+            diagnostics: diagnostics
         };
     }
     if statement.variant == "EnumDeclaration" {
@@ -234,7 +234,7 @@ fn check_statement(statement: Statement, bindings: SymbolEntry[], interfaces: St
         }
         return ScopeResult {
             bindings: registration.bindings,
-            diagnostics: diagnostics,
+            diagnostics: diagnostics
         };
     }
     if statement.variant == "InterfaceDeclaration" {
@@ -256,7 +256,7 @@ fn check_statement(statement: Statement, bindings: SymbolEntry[], interfaces: St
         }
         return ScopeResult {
             bindings: registration.bindings,
-            diagnostics: diagnostics,
+            diagnostics: diagnostics
         };
     }
     if statement.variant == "ModelDeclaration" {
@@ -271,7 +271,7 @@ fn check_statement(statement: Statement, bindings: SymbolEntry[], interfaces: St
         }
         return ScopeResult {
             bindings: registration.bindings,
-            diagnostics: diagnostics,
+            diagnostics: diagnostics
         };
     }
     if statement.variant == "PipelineDeclaration" {
@@ -293,7 +293,7 @@ fn check_statement(statement: Statement, bindings: SymbolEntry[], interfaces: St
         }
         return ScopeResult {
             bindings: registration.bindings,
-            diagnostics: diagnostics,
+            diagnostics: diagnostics
         };
     }
     if statement.variant == "ToolDeclaration" {
@@ -315,7 +315,7 @@ fn check_statement(statement: Statement, bindings: SymbolEntry[], interfaces: St
         }
         return ScopeResult {
             bindings: registration.bindings,
-            diagnostics: diagnostics,
+            diagnostics: diagnostics
         };
     }
     if statement.variant == "TestDeclaration" {
@@ -330,19 +330,19 @@ fn check_statement(statement: Statement, bindings: SymbolEntry[], interfaces: St
         }
         return ScopeResult {
             bindings: registration.bindings,
-            diagnostics: diagnostics,
+            diagnostics: diagnostics
         };
     }
     if statement.variant == "WithStatement" {
         return ScopeResult {
             bindings: bindings,
-            diagnostics: check_block(statement.body, bindings, interfaces),
+            diagnostics: check_block(statement.body, bindings, interfaces)
         };
     }
     if statement.variant == "ForStatement" {
         return ScopeResult {
             bindings: bindings,
-            diagnostics: check_block(statement.body, bindings, interfaces),
+            diagnostics: check_block(statement.body, bindings, interfaces)
         };
     }
     if statement.variant == "MatchStatement" {
@@ -360,7 +360,7 @@ fn check_statement(statement: Statement, bindings: SymbolEntry[], interfaces: St
             }
             index += 1;
         }
-        return ScopeResult { bindings: bindings, diagnostics: diagnostics, };
+        return ScopeResult { bindings: bindings, diagnostics: diagnostics };
     }
     if statement.variant == "IfStatement" {
         let mut diagnostics = check_block(statement.then_block, bindings, interfaces);
@@ -385,18 +385,18 @@ fn check_statement(statement: Statement, bindings: SymbolEntry[], interfaces: St
                 }
             }
         }
-        return ScopeResult { bindings: bindings, diagnostics: diagnostics, };
+        return ScopeResult { bindings: bindings, diagnostics: diagnostics };
     }
     if statement.variant == "BlockStatement" {
         return ScopeResult {
             bindings: bindings,
-            diagnostics: check_block(statement.body, bindings, interfaces),
+            diagnostics: check_block(statement.body, bindings, interfaces)
         };
     }
     if statement.variant == "PromptStatement" {
         return ScopeResult {
             bindings: bindings,
-            diagnostics: check_block(statement.body, bindings, interfaces),
+            diagnostics: check_block(statement.body, bindings, interfaces)
         };
     }
     if statement.variant == "TypeAliasDeclaration" {
@@ -411,10 +411,10 @@ fn check_statement(statement: Statement, bindings: SymbolEntry[], interfaces: St
         }
         return ScopeResult {
             bindings: registration.bindings,
-            diagnostics: diagnostics,
+            diagnostics: diagnostics
         };
     }
-    return ScopeResult { bindings: bindings, diagnostics: [], };
+    return ScopeResult { bindings: bindings, diagnostics: [] };
 }
 
 fn check_function_body(signature: FunctionSignature, body: Block, interfaces: Statement[]) -> Diagnostic[] {
@@ -445,7 +445,7 @@ fn seed_parameter_scope(signature: FunctionSignature) -> ScopeResult {
         }
     }
 
-    return ScopeResult { bindings: bindings, diagnostics: diagnostics, };
+    return ScopeResult { bindings: bindings, diagnostics: diagnostics };
 }
 
 fn check_block(block: Block, parent_bindings: SymbolEntry[], interfaces: Statement[]) -> Diagnostic[] {

--- a/compiler/src/typecheck.sfn
+++ b/compiler/src/typecheck.sfn
@@ -3,10 +3,37 @@
 // Typechecking and semantic analysis for Sailfin programs. This phase 
 // validates symbol usage, scopes, and effect requirements, producing
 // diagnostics for any issues found.
-
-import { Program, Statement, FunctionSignature, Block, FieldDeclaration, MethodDeclaration, EnumVariant, ModelProperty, TypeParameter, TypeAnnotation, SourceSpan } from "./ast";
+import {
+    Block,
+    EnumVariant,
+    FieldDeclaration,
+    FunctionSignature,
+    MethodDeclaration,
+    ModelProperty,
+    Program,
+    SourceSpan,
+    Statement,
+    TypeAnnotation,
+    TypeParameter
+} from "./ast";
 import { Token, TokenKind } from "./token";
-import { Diagnostic, SymbolEntry, SymbolCollectionResult, ScopeResult, check_function_signature, check_type_parameters, check_struct_fields, check_struct_methods, check_struct_implements_interfaces, check_enum_variants, check_interface_members, check_model_properties, register_local_symbol, register_symbol, clone_bindings } from "./typecheck_types";
+import {
+    Diagnostic,
+    ScopeResult,
+    SymbolCollectionResult,
+    SymbolEntry,
+    check_enum_variants,
+    check_function_signature,
+    check_interface_members,
+    check_model_properties,
+    check_struct_fields,
+    check_struct_implements_interfaces,
+    check_struct_methods,
+    check_type_parameters,
+    clone_bindings,
+    register_local_symbol,
+    register_symbol
+} from "./typecheck_types";
 
 fn typecheck_diagnostics(program: Program) -> Diagnostic[] {
     let top_level = collect_top_level_symbols(program);
@@ -49,9 +76,7 @@ fn collect_top_level_symbols(program: Program) -> SymbolCollectionResult {
         symbols = result.symbols;
         let mut _ci: number = 0;
         loop {
-            if _ci >= result.diagnostics.length {
-                break;
-            }
+            if _ci >= result.diagnostics.length { break; }
             diagnostics.push(result.diagnostics[_ci]);
             _ci += 1;
         }
@@ -94,10 +119,7 @@ fn register_top_level_symbol(statement: Statement, existing: SymbolEntry[]) -> S
     if statement.variant == "VariableDeclaration" {
         return register_symbol(statement.name, "variable", statement.span, existing);
     }
-    return SymbolCollectionResult {
-        symbols: existing,
-        diagnostics: [],
-    };
+    return SymbolCollectionResult { symbols: existing, diagnostics: [], };
 }
 
 fn check_program_scopes(program: Program, interfaces: Statement[]) -> Diagnostic[] {
@@ -109,9 +131,7 @@ fn check_program_scopes(program: Program, interfaces: Statement[]) -> Diagnostic
         bindings = result.bindings;
         let mut _ci: number = 0;
         loop {
-            if _ci >= result.diagnostics.length {
-                break;
-            }
+            if _ci >= result.diagnostics.length { break; }
             diagnostics.push(result.diagnostics[_ci]);
             _ci += 1;
         }
@@ -130,18 +150,14 @@ fn check_statement(statement: Statement, bindings: SymbolEntry[], interfaces: St
         let _sig_diags = check_function_signature(statement.signature);
         let mut _ci: number = 0;
         loop {
-            if _ci >= _sig_diags.length {
-                break;
-            }
+            if _ci >= _sig_diags.length { break; }
             diagnostics.push(_sig_diags[_ci]);
             _ci += 1;
         }
         let function_diagnostics = check_function_body(statement.signature, statement.body, interfaces);
         let mut _ci2: number = 0;
         loop {
-            if _ci2 >= function_diagnostics.length {
-                break;
-            }
+            if _ci2 >= function_diagnostics.length { break; }
             diagnostics.push(function_diagnostics[_ci2]);
             _ci2 += 1;
         }
@@ -156,51 +172,39 @@ fn check_statement(statement: Statement, bindings: SymbolEntry[], interfaces: St
         let _tp_diags = check_type_parameters(statement.type_parameters);
         let mut _ci: number = 0;
         loop {
-            if _ci >= _tp_diags.length {
-                break;
-            }
+            if _ci >= _tp_diags.length { break; }
             diagnostics.push(_tp_diags[_ci]);
             _ci += 1;
         }
         let _sf_diags = check_struct_fields(statement.fields);
         let mut _ci2: number = 0;
         loop {
-            if _ci2 >= _sf_diags.length {
-                break;
-            }
+            if _ci2 >= _sf_diags.length { break; }
             diagnostics.push(_sf_diags[_ci2]);
             _ci2 += 1;
         }
         let _sm_diags = check_struct_methods(statement.methods);
         let mut _ci3: number = 0;
         loop {
-            if _ci3 >= _sm_diags.length {
-                break;
-            }
+            if _ci3 >= _sm_diags.length { break; }
             diagnostics.push(_sm_diags[_ci3]);
             _ci3 += 1;
         }
         let _si_diags = check_struct_implements_interfaces(statement, interfaces);
         let mut _ci4: number = 0;
         loop {
-            if _ci4 >= _si_diags.length {
-                break;
-            }
+            if _ci4 >= _si_diags.length { break; }
             diagnostics.push(_si_diags[_ci4]);
             _ci4 += 1;
         }
         let mut index: number = 0;
         loop {
-            if index >= statement.methods.length {
-                break;
-            }
+            if index >= statement.methods.length { break; }
             let method = statement.methods[index];
             let _mb_diags = check_function_body(method.signature, method.body, interfaces);
             let mut _ci5: number = 0;
             loop {
-                if _ci5 >= _mb_diags.length {
-                    break;
-                }
+                if _ci5 >= _mb_diags.length { break; }
                 diagnostics.push(_mb_diags[_ci5]);
                 _ci5 += 1;
             }
@@ -217,18 +221,14 @@ fn check_statement(statement: Statement, bindings: SymbolEntry[], interfaces: St
         let _tp_diags = check_type_parameters(statement.type_parameters);
         let mut _ci: number = 0;
         loop {
-            if _ci >= _tp_diags.length {
-                break;
-            }
+            if _ci >= _tp_diags.length { break; }
             diagnostics.push(_tp_diags[_ci]);
             _ci += 1;
         }
         let _ev_diags = check_enum_variants(statement.variants);
         let mut _ci2: number = 0;
         loop {
-            if _ci2 >= _ev_diags.length {
-                break;
-            }
+            if _ci2 >= _ev_diags.length { break; }
             diagnostics.push(_ev_diags[_ci2]);
             _ci2 += 1;
         }
@@ -243,18 +243,14 @@ fn check_statement(statement: Statement, bindings: SymbolEntry[], interfaces: St
         let _tp_diags = check_type_parameters(statement.type_parameters);
         let mut _ci: number = 0;
         loop {
-            if _ci >= _tp_diags.length {
-                break;
-            }
+            if _ci >= _tp_diags.length { break; }
             diagnostics.push(_tp_diags[_ci]);
             _ci += 1;
         }
         let _im_diags = check_interface_members(statement.members);
         let mut _ci2: number = 0;
         loop {
-            if _ci2 >= _im_diags.length {
-                break;
-            }
+            if _ci2 >= _im_diags.length { break; }
             diagnostics.push(_im_diags[_ci2]);
             _ci2 += 1;
         }
@@ -269,9 +265,7 @@ fn check_statement(statement: Statement, bindings: SymbolEntry[], interfaces: St
         let _mp_diags = check_model_properties(statement.properties);
         let mut _ci: number = 0;
         loop {
-            if _ci >= _mp_diags.length {
-                break;
-            }
+            if _ci >= _mp_diags.length { break; }
             diagnostics.push(_mp_diags[_ci]);
             _ci += 1;
         }
@@ -286,18 +280,14 @@ fn check_statement(statement: Statement, bindings: SymbolEntry[], interfaces: St
         let _sig_diags = check_function_signature(statement.signature);
         let mut _ci: number = 0;
         loop {
-            if _ci >= _sig_diags.length {
-                break;
-            }
+            if _ci >= _sig_diags.length { break; }
             diagnostics.push(_sig_diags[_ci]);
             _ci += 1;
         }
         let _fb_diags = check_function_body(statement.signature, statement.body, interfaces);
         let mut _ci2: number = 0;
         loop {
-            if _ci2 >= _fb_diags.length {
-                break;
-            }
+            if _ci2 >= _fb_diags.length { break; }
             diagnostics.push(_fb_diags[_ci2]);
             _ci2 += 1;
         }
@@ -312,18 +302,14 @@ fn check_statement(statement: Statement, bindings: SymbolEntry[], interfaces: St
         let _sig_diags = check_function_signature(statement.signature);
         let mut _ci: number = 0;
         loop {
-            if _ci >= _sig_diags.length {
-                break;
-            }
+            if _ci >= _sig_diags.length { break; }
             diagnostics.push(_sig_diags[_ci]);
             _ci += 1;
         }
         let _fb_diags = check_function_body(statement.signature, statement.body, interfaces);
         let mut _ci2: number = 0;
         loop {
-            if _ci2 >= _fb_diags.length {
-                break;
-            }
+            if _ci2 >= _fb_diags.length { break; }
             diagnostics.push(_fb_diags[_ci2]);
             _ci2 += 1;
         }
@@ -338,9 +324,7 @@ fn check_statement(statement: Statement, bindings: SymbolEntry[], interfaces: St
         let _blk_diags = check_block(statement.body, [], interfaces);
         let mut _ci: number = 0;
         loop {
-            if _ci >= _blk_diags.length {
-                break;
-            }
+            if _ci >= _blk_diags.length { break; }
             diagnostics.push(_blk_diags[_ci]);
             _ci += 1;
         }
@@ -365,25 +349,18 @@ fn check_statement(statement: Statement, bindings: SymbolEntry[], interfaces: St
         let mut diagnostics: Diagnostic[] = [];
         let mut index: number = 0;
         loop {
-            if index >= statement.cases.length {
-                break;
-            }
+            if index >= statement.cases.length { break; }
             let case = statement.cases[index];
             let _blk_diags = check_block(case.body, bindings, interfaces);
             let mut _ci: number = 0;
             loop {
-                if _ci >= _blk_diags.length {
-                    break;
-                }
+                if _ci >= _blk_diags.length { break; }
                 diagnostics.push(_blk_diags[_ci]);
                 _ci += 1;
             }
             index += 1;
         }
-        return ScopeResult {
-            bindings: bindings,
-            diagnostics: diagnostics,
-        };
+        return ScopeResult { bindings: bindings, diagnostics: diagnostics, };
     }
     if statement.variant == "IfStatement" {
         let mut diagnostics = check_block(statement.then_block, bindings, interfaces);
@@ -393,9 +370,7 @@ fn check_statement(statement: Statement, bindings: SymbolEntry[], interfaces: St
                 let _blk_diags = check_block(branch.body, bindings, interfaces);
                 let mut _ci: number = 0;
                 loop {
-                    if _ci >= _blk_diags.length {
-                        break;
-                    }
+                    if _ci >= _blk_diags.length { break; }
                     diagnostics.push(_blk_diags[_ci]);
                     _ci += 1;
                 }
@@ -404,18 +379,13 @@ fn check_statement(statement: Statement, bindings: SymbolEntry[], interfaces: St
                 let result = check_statement(branch.statement, bindings, interfaces);
                 let mut _ci2: number = 0;
                 loop {
-                    if _ci2 >= result.diagnostics.length {
-                        break;
-                    }
+                    if _ci2 >= result.diagnostics.length { break; }
                     diagnostics.push(result.diagnostics[_ci2]);
                     _ci2 += 1;
                 }
             }
         }
-        return ScopeResult {
-            bindings: bindings,
-            diagnostics: diagnostics,
-        };
+        return ScopeResult { bindings: bindings, diagnostics: diagnostics, };
     }
     if statement.variant == "BlockStatement" {
         return ScopeResult {
@@ -435,9 +405,7 @@ fn check_statement(statement: Statement, bindings: SymbolEntry[], interfaces: St
         let _tp_diags = check_type_parameters(statement.type_parameters);
         let mut _ci: number = 0;
         loop {
-            if _ci >= _tp_diags.length {
-                break;
-            }
+            if _ci >= _tp_diags.length { break; }
             diagnostics.push(_tp_diags[_ci]);
             _ci += 1;
         }
@@ -446,10 +414,7 @@ fn check_statement(statement: Statement, bindings: SymbolEntry[], interfaces: St
             diagnostics: diagnostics,
         };
     }
-    return ScopeResult {
-        bindings: bindings,
-        diagnostics: [],
-    };
+    return ScopeResult { bindings: bindings, diagnostics: [], };
 }
 
 fn check_function_body(signature: FunctionSignature, body: Block, interfaces: Statement[]) -> Diagnostic[] {
@@ -458,9 +423,7 @@ fn check_function_body(signature: FunctionSignature, body: Block, interfaces: St
     let mut _result = parameter_scope.diagnostics;
     let mut _ci: number = 0;
     loop {
-        if _ci >= body_diagnostics.length {
-            break;
-        }
+        if _ci >= body_diagnostics.length { break; }
         _result.push(body_diagnostics[_ci]);
         _ci += 1;
     }
@@ -476,18 +439,13 @@ fn seed_parameter_scope(signature: FunctionSignature) -> ScopeResult {
         bindings = registration.bindings;
         let mut _ci: number = 0;
         loop {
-            if _ci >= registration.diagnostics.length {
-                break;
-            }
+            if _ci >= registration.diagnostics.length { break; }
             diagnostics.push(registration.diagnostics[_ci]);
             _ci += 1;
         }
     }
 
-    return ScopeResult {
-        bindings: bindings,
-        diagnostics: diagnostics,
-    };
+    return ScopeResult { bindings: bindings, diagnostics: diagnostics, };
 }
 
 fn check_block(block: Block, parent_bindings: SymbolEntry[], interfaces: Statement[]) -> Diagnostic[] {
@@ -499,9 +457,7 @@ fn check_block(block: Block, parent_bindings: SymbolEntry[], interfaces: Stateme
         bindings = result.bindings;
         let mut _ci: number = 0;
         loop {
-            if _ci >= result.diagnostics.length {
-                break;
-            }
+            if _ci >= result.diagnostics.length { break; }
             diagnostics.push(result.diagnostics[_ci]);
             _ci += 1;
         }
@@ -509,4 +465,3 @@ fn check_block(block: Block, parent_bindings: SymbolEntry[], interfaces: Stateme
 
     return diagnostics;
 }
-

--- a/compiler/src/typecheck_types.sfn
+++ b/compiler/src/typecheck_types.sfn
@@ -141,7 +141,8 @@ fn format_interface_signature(interface_definition: Statement) -> string {
         _pi += 1;
     }
     if names.length == 0 { return interface_definition.name; }
-    return interface_definition.name + "<" + join_with_separator(names, ", ") + ">";
+    return interface_definition.name + "<" + join_with_separator(names, ", ")
+        + ">";
 }
 
 fn join_with_separator(items: string[], separator: string) -> string {
@@ -386,25 +387,25 @@ fn register_local_symbol(bindings: SymbolEntry[], name: string, kind: string, sp
     if has_symbol(bindings, name) {
         return ScopeResult {
             bindings: bindings,
-            diagnostics: [make_duplicate_symbol_diagnostic(name, kind, token_from_name(name, span))],
+            diagnostics: [make_duplicate_symbol_diagnostic(name, kind, token_from_name(name, span))]
         };
     }
 
     let updated = append_symbol(bindings, name, kind, span);
-    return ScopeResult { bindings: updated, diagnostics: [], };
+    return ScopeResult { bindings: updated, diagnostics: [] };
 }
 
 fn register_symbol(name: string, kind: string, span: SourceSpan?, existing: SymbolEntry[]) -> SymbolCollectionResult {
     if has_symbol(existing, name) {
         return SymbolCollectionResult {
             symbols: existing,
-            diagnostics: [make_duplicate_symbol_diagnostic(name, kind, token_from_name(name, span))],
+            diagnostics: [make_duplicate_symbol_diagnostic(name, kind, token_from_name(name, span))]
         };
     }
 
     return SymbolCollectionResult {
         symbols: append_symbol(existing, name, kind, span),
-        diagnostics: [],
+        diagnostics: []
     };
 }
 
@@ -438,24 +439,33 @@ fn has_symbol(symbols: SymbolEntry[], name: string) -> boolean {
 fn make_interface_missing_type_arguments_diagnostic(struct_name: string, interface_name: string, interface_signature: string) -> Diagnostic {
     return Diagnostic {
         code: "E0302",
-        message: "struct " + struct_name + " implements " + interface_name + " but must specify " + interface_signature + " type arguments",
-        primary: null,
+        message: "struct " + struct_name + " implements " + interface_name
+            + " but must specify "
+            + interface_signature
+            + " type arguments",
+        primary: null
     };
 }
 
 fn make_interface_type_argument_mismatch_diagnostic(struct_name: string, annotation_text: string, interface_signature: string) -> Diagnostic {
     return Diagnostic {
         code: "E0302",
-        message: "struct " + struct_name + " implements " + annotation_text + " but must match " + interface_signature + " type arguments",
-        primary: null,
+        message: "struct " + struct_name + " implements " + annotation_text
+            + " but must match "
+            + interface_signature
+            + " type arguments",
+        primary: null
     };
 }
 
 fn make_interface_no_type_arguments_diagnostic(struct_name: string, annotation_text: string, interface_name: string) -> Diagnostic {
     return Diagnostic {
         code: "E0302",
-        message: "struct " + struct_name + " implements " + annotation_text + " but " + interface_name + " does not take type arguments",
-        primary: null,
+        message: "struct " + struct_name + " implements " + annotation_text
+            + " but "
+            + interface_name
+            + " does not take type arguments",
+        primary: null
     };
 }
 
@@ -465,7 +475,7 @@ fn token_from_name(name: string, span: SourceSpan?) -> Token? {
         kind: TokenKind.Identifier(),
         lexeme: name,
         line: span.start_line,
-        column: span.start_column,
+        column: span.start_column
     };
 }
 
@@ -473,15 +483,18 @@ fn make_duplicate_symbol_diagnostic(name: string, kind: string, token: Token?) -
     return Diagnostic {
         code: "E0001",
         message: "duplicate " + kind + " `" + name + "` declared",
-        primary: token,
+        primary: token
     };
 }
 
 fn make_missing_interface_member_diagnostic(struct_name: string, interface_name: string, member_name: string) -> Diagnostic {
     return Diagnostic {
         code: "E0301",
-        message: "struct " + struct_name + " implements " + interface_name + " but is missing member `" + member_name + "`",
-        primary: null,
+        message: "struct " + struct_name + " implements " + interface_name
+            + " but is missing member `"
+            + member_name
+            + "`",
+        primary: null
     };
 }
 

--- a/compiler/src/typecheck_types.sfn
+++ b/compiler/src/typecheck_types.sfn
@@ -2,8 +2,17 @@
 //
 // Struct, enum, interface, and model validation helpers for typechecking.
 // Extracted from typecheck.sfn to keep file sizes manageable.
-
-import { Statement, FunctionSignature, FieldDeclaration, MethodDeclaration, EnumVariant, ModelProperty, TypeParameter, TypeAnnotation, SourceSpan } from "./ast";
+import {
+    EnumVariant,
+    FieldDeclaration,
+    FunctionSignature,
+    MethodDeclaration,
+    ModelProperty,
+    SourceSpan,
+    Statement,
+    TypeAnnotation,
+    TypeParameter
+} from "./ast";
 import { Token, TokenKind } from "./token";
 
 struct Diagnostic {
@@ -29,9 +38,7 @@ struct ScopeResult {
 }
 
 fn check_struct_implements_interfaces(statement: Statement, interfaces: Statement[]) -> Diagnostic[] {
-    if statement.implements_types.length == 0 {
-        return [];
-    }
+    if statement.implements_types.length == 0 { return []; }
 
     let mut method_names: string[] = [];
     let mut _mi: number = 0;
@@ -47,16 +54,12 @@ fn check_struct_implements_interfaces(statement: Statement, interfaces: Statemen
         if _ai >= statement.implements_types.length { break; }
         let annotation = statement.implements_types[_ai];
         let interface_definition = resolve_interface_annotation(annotation, interfaces);
-        if interface_definition == null {
-            continue;
-        }
+        if interface_definition == null { continue; }
         let interface_name = interface_definition.name;
         let _via_diags = validate_interface_annotation(statement.name, interface_definition, annotation);
         let mut _ci: number = 0;
         loop {
-            if _ci >= _via_diags.length {
-                break;
-            }
+            if _ci >= _via_diags.length { break; }
             diagnostics.push(_via_diags[_ci]);
             _ci += 1;
         }
@@ -82,13 +85,9 @@ fn resolve_interface_annotation(annotation: TypeAnnotation, interfaces: Statemen
         if _ii >= interfaces.length { break; }
         let iface = interfaces[_ii];
         let name = iface.name;
-        if text == name {
-            return iface;
-        }
+        if text == name { return iface; }
         let generic_prefix = name + "<";
-        if starts_with(text, generic_prefix) {
-            return iface;
-        }
+        if starts_with(text, generic_prefix) { return iface; }
         _ii += 1;
     }
     return null;
@@ -105,9 +104,7 @@ fn check_struct_fields(fields: FieldDeclaration[]) -> Diagnostic[] {
         let name = field.name;
         if contains_string(seen, name) {
             diagnostics.push(make_duplicate_symbol_diagnostic(name, "struct field", token_from_name(name, field.name_span)));
-        } else {
-            seen.push(name);
-        }
+        } else { seen.push(name); }
         _fi += 1;
     }
 
@@ -119,35 +116,17 @@ fn validate_interface_annotation(struct_name: string, interface_definition: Stat
     let provided_arguments = parse_type_arguments(annotation.text);
     if expected_count == 0 {
         if provided_arguments.length > 0 {
-            return [
-                make_interface_no_type_arguments_diagnostic(
-                    struct_name,
-                    trim_text(annotation.text),
-                    interface_definition.name
-                )
-            ];
+            return [make_interface_no_type_arguments_diagnostic(struct_name, trim_text(annotation.text), interface_definition.name)];
         }
         return [];
     }
 
     if provided_arguments.length == 0 {
-        return [
-            make_interface_missing_type_arguments_diagnostic(
-                struct_name,
-                interface_definition.name,
-                format_interface_signature(interface_definition)
-            )
-        ];
+        return [make_interface_missing_type_arguments_diagnostic(struct_name, interface_definition.name, format_interface_signature(interface_definition))];
     }
 
     if provided_arguments.length != expected_count {
-        return [
-            make_interface_type_argument_mismatch_diagnostic(
-                struct_name,
-                trim_text(annotation.text),
-                format_interface_signature(interface_definition)
-            )
-        ];
+        return [make_interface_type_argument_mismatch_diagnostic(struct_name, trim_text(annotation.text), format_interface_signature(interface_definition))];
     }
 
     return [];
@@ -161,22 +140,16 @@ fn format_interface_signature(interface_definition: Statement) -> string {
         names.push(interface_definition.type_parameters[_pi].name);
         _pi += 1;
     }
-    if names.length == 0 {
-        return interface_definition.name;
-    }
+    if names.length == 0 { return interface_definition.name; }
     return interface_definition.name + "<" + join_with_separator(names, ", ") + ">";
 }
 
 fn join_with_separator(items: string[], separator: string) -> string {
-    if items.length == 0 {
-        return "";
-    }
+    if items.length == 0 { return ""; }
     let mut result = items[0];
     let mut index: number = 1;
     loop {
-        if index >= items.length {
-            break;
-        }
+        if index >= items.length { break; }
         result = result + separator + items[index];
         index += 1;
     }
@@ -185,9 +158,7 @@ fn join_with_separator(items: string[], separator: string) -> string {
 
 fn parse_type_arguments(annotation_text: string) -> string[] {
     let block = extract_generic_argument_block(annotation_text);
-    if block == null {
-        return [];
-    }
+    if block == null { return []; }
     return split_generic_argument_list(block);
 }
 
@@ -197,19 +168,13 @@ fn extract_generic_argument_block(annotation_text: string) -> string? {
     let mut depth: number = 0;
     let mut start_index: number = -1;
     loop {
-        if index >= trimmed.length {
-            break;
-        }
+        if index >= trimmed.length { break; }
         let ch = trimmed[index];
         if ch == "<" {
-            if depth == 0 {
-                start_index = index + 1;
-            }
+            if depth == 0 { start_index = index + 1; }
             depth += 1;
         } else if ch == ">" {
-            if depth == 0 {
-                return null;
-            }
+            if depth == 0 { return null; }
             depth -= 1;
             if depth == 0 {
                 return slice_text(trimmed, start_index, index);
@@ -226,38 +191,28 @@ fn split_generic_argument_list(block: string) -> string[] {
     let mut depth: number = 0;
     let mut index: number = 0;
     loop {
-        if index >= block.length {
-            break;
-        }
+        if index >= block.length { break; }
         let ch = block[index];
         if ch == "<" {
             depth += 1;
             current = current + ch;
         } else if ch == ">" {
-            if depth > 0 {
-                depth -= 1;
-            }
+            if depth > 0 { depth -= 1; }
             current = current + ch;
         } else if ch == "," {
             if depth == 0 {
                 let trimmed = trim_text(current);
-                if trimmed.length > 0 {
-                    arguments.push(trimmed);
-                }
+                if trimmed.length > 0 { arguments.push(trimmed); }
                 current = "";
                 index += 1;
                 continue;
             }
             current = current + ch;
-        } else {
-            current = current + ch;
-        }
+        } else { current = current + ch; }
         index += 1;
     }
     let tail = trim_text(current);
-    if tail.length > 0 {
-        arguments.push(tail);
-    }
+    if tail.length > 0 { arguments.push(tail); }
     return arguments;
 }
 
@@ -265,9 +220,7 @@ fn trim_text(value: string) -> string {
     let mut start: number = 0;
     let mut end: number = value.length;
     loop {
-        if start >= end {
-            break;
-        }
+        if start >= end { break; }
         if is_whitespace(value[start]) {
             start += 1;
             continue;
@@ -275,9 +228,7 @@ fn trim_text(value: string) -> string {
         break;
     }
     loop {
-        if end <= start {
-            break;
-        }
+        if end <= start { break; }
         if is_whitespace(value[end - 1]) {
             end -= 1;
             continue;
@@ -291,21 +242,13 @@ fn slice_text(value: string, start: number, end: number) -> string {
     let mut normalized_start: number = start;
     let mut normalized_end: number = end;
 
-    if normalized_start < 0 {
-        normalized_start = 0;
-    }
-    if normalized_end > value.length {
-        normalized_end = value.length;
-    }
-    if normalized_end <= normalized_start {
-        return "";
-    }
+    if normalized_start < 0 { normalized_start = 0; }
+    if normalized_end > value.length { normalized_end = value.length; }
+    if normalized_end <= normalized_start { return ""; }
     let mut result: string = "";
     let mut index = normalized_start;
     loop {
-        if index >= normalized_end {
-            break;
-        }
+        if index >= normalized_end { break; }
         result = result + value[index];
         index += 1;
     }
@@ -332,18 +275,14 @@ fn check_struct_methods(methods: MethodDeclaration[]) -> Diagnostic[] {
         let _sig_diags = check_function_signature(method.signature);
         let mut _ci: number = 0;
         loop {
-            if _ci >= _sig_diags.length {
-                break;
-            }
+            if _ci >= _sig_diags.length { break; }
             diagnostics.push(_sig_diags[_ci]);
             _ci += 1;
         }
         let name = method.signature.name;
         if contains_string(seen, name) {
             diagnostics.push(make_duplicate_symbol_diagnostic(name, "method", token_from_name(name, method.signature.name_span)));
-        } else {
-            seen.push(name);
-        }
+        } else { seen.push(name); }
         _mi += 1;
     }
 
@@ -361,9 +300,7 @@ fn check_enum_variants(variants: EnumVariant[]) -> Diagnostic[] {
         let name = variant.name;
         if contains_string(seen, name) {
             diagnostics.push(make_duplicate_symbol_diagnostic(name, "enum variant", token_from_name(name, variant.name_span)));
-        } else {
-            seen.push(name);
-        }
+        } else { seen.push(name); }
         _vi += 1;
     }
 
@@ -381,18 +318,14 @@ fn check_interface_members(members: FunctionSignature[]) -> Diagnostic[] {
         let _sig_diags = check_function_signature(member);
         let mut _ci: number = 0;
         loop {
-            if _ci >= _sig_diags.length {
-                break;
-            }
+            if _ci >= _sig_diags.length { break; }
             diagnostics.push(_sig_diags[_ci]);
             _ci += 1;
         }
         let name = member.name;
         if contains_string(seen, name) {
             diagnostics.push(make_duplicate_symbol_diagnostic(name, "interface member", token_from_name(name, member.name_span)));
-        } else {
-            seen.push(name);
-        }
+        } else { seen.push(name); }
         _mbi += 1;
     }
 
@@ -410,9 +343,7 @@ fn check_model_properties(properties: ModelProperty[]) -> Diagnostic[] {
         let name = property.name;
         if contains_string(seen, name) {
             diagnostics.push(make_duplicate_symbol_diagnostic(name, "model property", token_from_name(name, property.span)));
-        } else {
-            seen.push(name);
-        }
+        } else { seen.push(name); }
         _pi += 1;
     }
 
@@ -434,9 +365,7 @@ fn check_type_parameters(type_parameters: TypeParameter[]) -> Diagnostic[] {
         let name = type_parameter.name;
         if contains_string(seen, name) {
             diagnostics.push(make_duplicate_symbol_diagnostic(name, "type parameter", token_from_name(name, type_parameter.span)));
-        } else {
-            seen.push(name);
-        }
+        } else { seen.push(name); }
         _tpi += 1;
     }
 
@@ -447,9 +376,7 @@ fn contains_string(items: string[], candidate: string) -> boolean {
     let mut _ci: number = 0;
     loop {
         if _ci >= items.length { break; }
-        if items[_ci] == candidate {
-            return true;
-        }
+        if items[_ci] == candidate { return true; }
         _ci += 1;
     }
     return false;
@@ -464,10 +391,7 @@ fn register_local_symbol(bindings: SymbolEntry[], name: string, kind: string, sp
     }
 
     let updated = append_symbol(bindings, name, kind, span);
-    return ScopeResult {
-        bindings: updated,
-        diagnostics: [],
-    };
+    return ScopeResult { bindings: updated, diagnostics: [], };
 }
 
 fn register_symbol(name: string, kind: string, span: SourceSpan?, existing: SymbolEntry[]) -> SymbolCollectionResult {
@@ -505,9 +429,7 @@ fn has_symbol(symbols: SymbolEntry[], name: string) -> boolean {
     let mut _si: number = 0;
     loop {
         if _si >= symbols.length { break; }
-        if symbols[_si].name == name {
-            return true;
-        }
+        if symbols[_si].name == name { return true; }
         _si += 1;
     }
     return false;
@@ -538,9 +460,7 @@ fn make_interface_no_type_arguments_diagnostic(struct_name: string, annotation_t
 }
 
 fn token_from_name(name: string, span: SourceSpan?) -> Token? {
-    if span == null {
-        return null;
-    }
+    if span == null { return null; }
     return Token {
         kind: TokenKind.Identifier(),
         lexeme: name,
@@ -566,17 +486,11 @@ fn make_missing_interface_member_diagnostic(struct_name: string, interface_name:
 }
 
 fn starts_with(value: string, prefix: string) -> boolean {
-    if prefix.length > value.length {
-        return false;
-    }
+    if prefix.length > value.length { return false; }
     let mut index: number = 0;
     loop {
-        if index >= prefix.length {
-            break;
-        }
-        if value[index] != prefix[index] {
-            return false;
-        }
+        if index >= prefix.length { break; }
+        if value[index] != prefix[index] { return false; }
         index += 1;
     }
     return true;

--- a/compiler/src/version.sfn
+++ b/compiler/src/version.sfn
@@ -8,7 +8,6 @@
 //
 // For installed binaries where capsule.toml isn't on disk, the hardcoded
 // __version_fallback__ is returned instead.  Release CI keeps it in sync.
-
 import { toml_get_version } from "./toml_parser";
 
 // Hardcoded fallback for installed binaries where capsule.toml is not
@@ -17,9 +16,7 @@ let __version_fallback__ = "0.5.3-alpha.1";
 
 // Pure version accessor — returns the baked-in fallback.  Use this when
 // IO is unavailable or when you just need "some version string".
-fn sailfin_version() -> string {
-    return __version_fallback__;
-}
+fn sailfin_version() -> string { return __version_fallback__; }
 
 // Read a version string from a raw capsule.toml text blob.
 // Returns the fallback if the TOML text doesn't contain an explicit
@@ -27,9 +24,7 @@ fn sailfin_version() -> string {
 // for missing keys, which we must not treat as a real version).
 fn version_from_capsule_toml(toml_text: string) -> string {
     let ver = _strict_capsule_version(toml_text);
-    if ver.length > 0 {
-        return ver;
-    }
+    if ver.length > 0 { return ver; }
     return __version_fallback__;
 }
 
@@ -37,9 +32,7 @@ fn version_from_capsule_toml(toml_text: string) -> string {
 // [capsule] section.  Returns "" if the key is missing or the
 // TOML text is empty/malformed.
 fn _strict_capsule_version(toml_text: string) -> string {
-    if toml_text.length == 0 {
-        return "";
-    }
+    if toml_text.length == 0 { return ""; }
     // Quick check: the text must contain a 'version' key line.
     // This avoids returning the parser's "0.1.0" default.
     let mut has_version_key: boolean = false;
@@ -58,9 +51,7 @@ fn _strict_capsule_version(toml_text: string) -> string {
         }
         i += 1;
     }
-    if !has_version_key {
-        return "";
-    }
+    if !has_version_key { return ""; }
     let ver = toml_get_version(toml_text);
     // Reject the parser's default "0.1.0" if that's not what the file says.
     if strings_equal(ver, "0.1.0") {
@@ -80,9 +71,7 @@ fn _strict_capsule_version(toml_text: string) -> string {
             }
             j += 1;
         }
-        if !found_literal {
-            return "";
-        }
+        if !found_literal { return ""; }
     }
     return ver;
 }
@@ -100,9 +89,7 @@ fn _read_stamp(path: string) -> string ![io] {
                 if content[end] == "\r" { break; }
                 end += 1;
             }
-            if end > 0 {
-                return substring(content, 0, end);
-            }
+            if end > 0 { return substring(content, 0, end); }
         }
     }
     return "";
@@ -118,9 +105,7 @@ fn _read_capsule_version(paths: string[]) -> string ![io] {
         if fs.exists(paths[i]) {
             let text = fs.readFile(paths[i]);
             let ver = _strict_capsule_version(text);
-            if ver.length > 0 {
-                return ver;
-            }
+            if ver.length > 0 { return ver; }
         }
         i += 1;
     }
@@ -137,16 +122,12 @@ fn _read_capsule_version(paths: string[]) -> string ![io] {
 fn resolve_compiler_version() -> string ![io] {
     // 1. Build stamp takes priority (includes git hash for dev builds).
     let stamp = _read_stamp("build/native/.build-stamp");
-    if stamp.length > 0 {
-        return stamp;
-    }
+    if stamp.length > 0 { return stamp; }
 
     // 2. Try capsule.toml at known relative paths.
     let capsule_paths: string[] = ["compiler/capsule.toml", "capsule.toml"];
     let capsule_ver = _read_capsule_version(capsule_paths);
-    if capsule_ver.length > 0 {
-        return capsule_ver;
-    }
+    if capsule_ver.length > 0 { return capsule_ver; }
 
     // 3. Fallback to the baked-in version.
     return __version_fallback__;

--- a/compiler/tests/e2e/test_fmt.sh
+++ b/compiler/tests/e2e/test_fmt.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+# End-to-end tests for `sfn fmt`.
+#
+# Usage:
+#   compiler/tests/e2e/test_fmt.sh <compiler-binary>
+
+set -euo pipefail
+
+BINARY="${1:?usage: test_fmt.sh <compiler-binary>}"
+PASS=0
+FAIL=0
+TMPDIR_BASE="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_BASE"' EXIT
+
+run_test() {
+    local name="$1"
+    shift
+    if "$@"; then
+        echo "[test] PASS: $name"
+        PASS=$((PASS + 1))
+    else
+        echo "[test] FAIL: $name"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# Helper: write input to a temp file, run fmt, compare to expected.
+# Note: expected should NOT include a trailing newline — the comparison
+# strips trailing newlines from both sides (bash $() strips them).
+assert_fmt() {
+    local name="$1"
+    local input="$2"
+    local expected="$3"
+    local tmpfile="$TMPDIR_BASE/${name// /_}.sfn"
+    printf '%s' "$input" > "$tmpfile"
+    local actual
+    actual="$("$BINARY" fmt "$tmpfile" 2>&1)" || true
+    if [ "$actual" = "$expected" ]; then
+        return 0
+    else
+        echo "  expected:"
+        echo "$expected" | head -5 | sed 's/^/    /'
+        echo "  actual:"
+        echo "$actual" | head -5 | sed 's/^/    /'
+        return 1
+    fi
+}
+
+# Helper: verify formatting is idempotent (format twice = same result)
+assert_idempotent() {
+    local name="$1"
+    local input="$2"
+    local tmpfile="$TMPDIR_BASE/${name// /_}.sfn"
+    printf '%s' "$input" > "$tmpfile"
+    local first second
+    first="$("$BINARY" fmt "$tmpfile" 2>&1)" || true
+    local tmpfile2="$TMPDIR_BASE/${name// /_}_pass2.sfn"
+    printf '%s' "$first" > "$tmpfile2"
+    second="$("$BINARY" fmt "$tmpfile2" 2>&1)" || true
+    if [ "$first" = "$second" ]; then
+        return 0
+    else
+        echo "  pass1 and pass2 differ (not idempotent)"
+        diff <(echo "$first") <(echo "$second") | head -10 || true
+        return 1
+    fi
+}
+
+# ---- Test: empty file ----
+run_test "fmt: empty file" assert_fmt "empty" "" ""
+
+# ---- Test: comment-only file ----
+run_test "fmt: comment-only file" assert_fmt "comment_only" \
+    '// This is a comment
+// Another comment' \
+    '// This is a comment
+// Another comment'
+
+# ---- Test: simple function ----
+run_test "fmt: simple function spacing" assert_fmt "simple_fn" \
+    'fn hello() -> string { return "world"; }' \
+    'fn hello() -> string { return "world"; }'
+
+# ---- Test: unary negation (no space after -) ----
+run_test "fmt: unary negation" assert_fmt "unary_neg" \
+    "fn neg(x: number) -> number { return -x; }" \
+    "fn neg(x: number) -> number { return -x; }"
+
+# ---- Test: unary not (no space after !) ----
+run_test "fmt: unary not" assert_fmt "unary_not" \
+    'fn check(a: string, b: string) -> boolean { return !strings_equal(a, b); }' \
+    'fn check(a: string, b: string) -> boolean { return !strings_equal(a, b); }'
+
+# ---- Test: optional type suffix (no space before ?) ----
+# Note: the function body expands because ? isn't yet an inline-context token
+run_test "fmt: optional type suffix" assert_fmt "optional_type" \
+    "fn find(x: string) -> string? { return x; }" \
+    'fn find(x: string) -> string? {
+    return x;
+}'
+
+# ---- Test: effect annotations ----
+run_test "fmt: effect annotations" assert_fmt "effects" \
+    'fn fetch(url: string) -> string ![io, net] { return ""; }' \
+    'fn fetch(url: string) -> string ![io, net] { return ""; }'
+
+# ---- Test: struct declaration stays multi-line ----
+run_test "fmt: struct decl not inlined" assert_fmt "struct_decl" \
+    'struct Point {
+    x: number;
+    y: number;
+}' \
+    'struct Point {
+    x: number;
+    y: number;
+}'
+
+# ---- Test: import stays inline ----
+run_test "fmt: import inline" assert_fmt "import_inline" \
+    'import { foo, bar } from "./mod";' \
+    'import { foo, bar } from "./mod";'
+
+# ---- Test: let binding ----
+run_test "fmt: let binding spacing" assert_fmt "let_binding" \
+    'let x: number = 42;' \
+    'let x: number = 42;'
+
+# ---- Test: if/else stays inline inside expanded fn ----
+# The outer fn body expands (contains nested blocks), but inner if/else
+# blocks stay inline on their own line.
+run_test "fmt: if/else inline" assert_fmt "if_else_inline" \
+    'fn f(x: boolean) -> number { if x { return 1; } else { return 0; } }' \
+    'fn f(x: boolean) -> number {
+    if x { return 1; } else { return 0; }
+}'
+
+# ---- Test: idempotency on real compiler file ----
+run_test "fmt: idempotency on string_utils.sfn" assert_idempotent "idem_string_utils" \
+    "$(cat compiler/src/string_utils.sfn)"
+
+# ---- Test: idempotency on ast.sfn ----
+run_test "fmt: idempotency on ast.sfn" assert_idempotent "idem_ast" \
+    "$(cat compiler/src/ast.sfn)"
+
+# ---- Test: idempotency on effect_checker.sfn ----
+run_test "fmt: idempotency on effect_checker.sfn" assert_idempotent "idem_effect_checker" \
+    "$(cat compiler/src/effect_checker.sfn)"
+
+# ---- Test: --check mode detects unformatted file ----
+test_check_mode_detects_diff() {
+    local tmpfile="$TMPDIR_BASE/check_diff.sfn"
+    printf 'fn   foo( )  ->   string  {  return "bar" ;  }' > "$tmpfile"
+    # --check should exit non-zero when file differs from formatted output
+    if "$BINARY" fmt --check "$tmpfile" > /dev/null 2>&1; then
+        echo "  --check should have exited non-zero for unformatted file"
+        return 1
+    fi
+    return 0
+}
+run_test "fmt: --check detects unformatted" test_check_mode_detects_diff
+
+# ---- Test: --check mode passes on formatted file ----
+test_check_mode_passes() {
+    local tmpfile="$TMPDIR_BASE/check_pass.sfn"
+    printf 'fn foo() -> string { return "bar"; }' > "$tmpfile"
+    # Use --write first, then --check should pass
+    "$BINARY" fmt --write "$tmpfile" > /dev/null 2>&1
+    if "$BINARY" fmt --check "$tmpfile" > /dev/null 2>&1; then
+        return 0
+    else
+        echo "  --check should have exited 0 for already-formatted file"
+        return 1
+    fi
+}
+run_test "fmt: --check passes on formatted" test_check_mode_passes
+
+# ---- Test: --write mode modifies file in place ----
+test_write_mode() {
+    local tmpfile="$TMPDIR_BASE/write_mode.sfn"
+    printf 'fn   foo( )  ->   string  {  return "bar" ;  }' > "$tmpfile"
+    "$BINARY" fmt --write "$tmpfile" > /dev/null 2>&1
+    # After --write, --check should pass
+    if "$BINARY" fmt --check "$tmpfile" > /dev/null 2>&1; then
+        return 0
+    else
+        echo "  --write did not produce formatted output"
+        return 1
+    fi
+}
+run_test "fmt: --write modifies file" test_write_mode
+
+# ---- Summary ----
+echo ""
+echo "[test] $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/docs/proposals/fmt-architecture.md
+++ b/docs/proposals/fmt-architecture.md
@@ -533,18 +533,18 @@ enforce exactly 1 between top-level declarations and before decorators at
 indent 0. Fixed inline block indent tracking (opening `{` no longer
 increments indent when inlined).
 
-### Step 5: Edge Cases, Self-Hosting Validation & CI
+### Step 5: Edge Cases, Self-Hosting Validation & CI ✅
 
 **Goal:** Handle all edge cases in the compiler source and wire into CI.
 
-- Format all 120 compiler source files; fix any formatter bugs discovered
-- Verify `sfn fmt --write compiler/src/ && make compile` succeeds
+- ✅ Format all 123 compiler source files + `runtime/prelude.sfn`; fixed formatter bugs discovered during the pass
+- ✅ Verify `sfn fmt --write compiler/src/ && make rebuild` succeeds
   (formatted code self-hosts)
-- Add idempotency test: `sfn fmt | sfn fmt` produces same output
-- Add `--check` validation to CI (GitHub Actions)
-- Handle edge cases:
-  - Empty files
-  - Files with only comments
+- ✅ Idempotency verified: second `sfn fmt` pass produces identical output across all files
+- ✅ `--check` validation added to CI (GitHub Actions `ci.yml`)
+- ✅ Handle edge cases:
+  - Empty files (returns empty string)
+  - Files with only comments (emits comments directly)
   - Deeply nested constructs (6+ levels)
   - Very long string literals
   - Adjacent comments with no code between them
@@ -552,11 +552,22 @@ increments indent when inlined).
   - Enum variants with payloads
   - Match expressions with `=>`
   - Decorator syntax (`@logExecution`)
+  - Unary operators `!` and `-` (no space after via `_reclassify_unary_ops` post-pass)
+  - Optional type suffix `?` (no space before via `optional_suffix` role)
+  - Struct/enum declaration inlining guard (blocks with both colons and semicolons rejected)
+- ✅ E2E test suite: `compiler/tests/e2e/test_fmt.sh` (17 tests)
 
 **Test:** `sfn fmt --check compiler/src/` exits 0 after running
 `sfn fmt --write compiler/src/`.
 
 **Deliverable:** CI-enforced canonical formatting for the entire project.
+
+**Known limitations (v1):**
+- Bulk `sfn fmt --write <directory>` with many files may OOM due to `string_concat` accumulation; CI uses a per-file loop as workaround
+- No expression wrapping — long expressions stay on one line regardless of length
+- Blank lines between section-divider comments and declarations may be collapsed
+- No semantic formatting (cannot reorder match arms, inline function bodies, etc.)
+- No `--diff` mode (compare formatted vs original inline)
 
 ## Key Design Decisions & Rationale
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -78,7 +78,7 @@ feature availability.
 | `scope.with_timeout(...)` | **Not implemented** | |
 | `unsafe` / `extern` | Parsed only | Syntax accepted; enforcement not active |
 | Policy decorators (`@policy(...)`) | Parsed only | No compiler or runtime effect |
-| `sfn fmt` (formatter) | Partial (Steps 1-4 of 5) | CLI wiring, token-stream formatting with indentation/spacing/inline blocks, import sorting, blank line normalization; see `docs/proposals/fmt-architecture.md` |
+| `sfn fmt` (formatter) | **Shipped** | Token-stream formatter: indentation, spacing, inline blocks, unary operator handling, import sorting & specifier reordering, blank line normalization, `--check`/`--write` modes, CI enforcement; see `docs/proposals/fmt-architecture.md` for architecture and known limitations |
 | `sfn check` (fast analysis) | Planned | Pre-1.0; see `docs/proposals/tooling.md` |
 | `sfn vet` (static analyzer) | Planned | Pre-1.0; see `docs/proposals/tooling.md` |
 | `sfn lsp` (language server) | Planned | Phase 1 pre-1.0; see `docs/proposals/tooling.md` |

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -4,6 +4,20 @@ This guide captures the current Sailfin repository layout and the conventions
 the compiler, runtime, and examples follow. Treat it as the source of truth
 for naming, organization, and where new work should land.
 
+## Code Formatting
+
+All `.sfn` files in the repository are formatted with `sfn fmt` and CI enforces
+this on every pull request. There is one canonical style with no configuration.
+
+```bash
+sfn fmt --write compiler/src/   # format files in place
+sfn fmt --check compiler/src/   # verify formatting (CI mode)
+```
+
+Do not manually adjust indentation, spacing, or brace placement — `sfn fmt`
+handles all of it. If you disagree with a formatting decision, file an issue
+against the formatter rather than overriding the output.
+
 ## Goals
 
 - Keep one major concern per file (lexer, parser, lowering, etc.).

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # Sailfin Language Reference for LLMs
 
-> Version: 0.5.2-alpha.1 | Updated: 2026-04-16
+> Version: 0.5.3-alpha.1 | Updated: 2026-04-16
 > Source: https://github.com/SailfinIO/sailfin | Site: https://sailfin.dev
 
 Sailfin is a compiled systems language with compile-time capability enforcement
@@ -273,6 +273,7 @@ These features parse, type-check, emit to .sfn-asm IR, and lower to LLVM:
 - Effect annotations (parsed and carried through to IR)
 - Colon type annotations (x: Type) for params, variables, fields
 - Arrow return types (-> Type) for functions
+- Code formatting via sfn fmt (token-stream, idempotent, CI-enforced)
 
 ## What Is Parsed but Not Fully Implemented
 
@@ -313,6 +314,31 @@ Build commands:
     make test       -- run unit + integration + e2e test suites
     make check      -- full validation including seedcheck
     make install    -- install to ~/.local/bin
+
+## Tooling
+
+### sfn fmt — Code Formatter
+
+Built-in formatter with one canonical style, no configuration. Like gofmt.
+
+    sfn fmt file.sfn              # print formatted output to stdout
+    sfn fmt --write src/          # format files in place
+    sfn fmt --check src/          # CI mode: exit 1 if any file would change
+
+Formatting rules:
+- 4-space indentation, K&R braces (opening brace on same line)
+- Spaces around operators and after keywords
+- No space before : ; ? (optional suffix) or after unary ! -
+- Imports sorted by path, specifiers sorted alphabetically
+- Blank lines: exactly 1 between top-level declarations
+- Inline blocks: single-statement blocks stay on one line if they fit
+- Comments preserved exactly as written
+
+Known limitations:
+- No expression wrapping (long lines stay as-is)
+- No --diff mode
+- Bulk directory formatting may OOM on very large codebases (use per-file loop)
+- No semantic restructuring (match arm reordering, function inlining)
 
 ## Package Manifest (capsule.toml)
 

--- a/runtime/prelude.sfn
+++ b/runtime/prelude.sfn
@@ -463,7 +463,8 @@ fn parse_type_descriptor(text: string) -> TypeDescriptor {
     if string_starts_with(normalized, "runtime.") {
         normalized = descriptor_trim(substring(normalized, 8, normalized.length));
     }
-    if normalized == "string" || normalized == "number" || normalized == "boolean" || normalized == "void" {
+    if normalized == "string" || normalized == "number" || normalized == "boolean"
+        || normalized == "void" {
         return type_descriptor_primitive(normalized);
     }
     return type_descriptor_named(normalized);

--- a/runtime/prelude.sfn
+++ b/runtime/prelude.sfn
@@ -3,7 +3,6 @@
 // Runtime facade for Sailfin programs emitted by the self-hosted compiler.
 // These helpers delegate to the bootstrap runtime so Sailfin sources can run
 // without bespoke Python shims once the compiler self-hosts.
-
 let console = runtime.console;
 let fs = runtime.fs;
 let http = runtime.http;
@@ -85,15 +84,13 @@ struct TypeDescriptor {
     items: TypeDescriptor[];
 }
 
-fn sleep(milliseconds: number) ![clock] {
-    runtime_sleep_fn(milliseconds);
-}
+fn sleep(milliseconds: number) ![clock] { runtime_sleep_fn(milliseconds); }
 
 fn monotonic_millis() -> number ![clock] {
     return runtime_monotonic_millis_fn();
 }
 
-fn channel<T>(capacity: number = 0) -> any ![io] {
+fn channel < T > (capacity: number = 0) -> any ![io] {
     return runtime_channel_fn(capacity);
 }
 
@@ -122,15 +119,9 @@ fn array_reduce(items: any[], initial: any, reducer: any) -> any {
 }
 
 fn char_at(value: string, index: number) -> string {
-    if value.length == 0 {
-        return "";
-    }
-    if index < 0 {
-        return "";
-    }
-    if index >= value.length {
-        return "";
-    }
+    if value.length == 0 { return ""; }
+    if index < 0 { return ""; }
+    if index >= value.length { return ""; }
     return runtime_grapheme_at_fn(value, index);
 }
 
@@ -143,7 +134,10 @@ fn enum_field(name: string, value: any) -> EnumField {
 }
 
 fn enum_define_variant(enum_type: EnumType, variant_name: string, field_names: string[]) -> EnumType {
-    let variant = EnumVariantDefinition { name: variant_name, field_names: field_names };
+    let variant = EnumVariantDefinition {
+        name: variant_name,
+        field_names: field_names
+    };
     let updated = enum_type.variants.concat([variant]);
     return EnumType { name: enum_type.name, variants: updated };
 }
@@ -151,13 +145,9 @@ fn enum_define_variant(enum_type: EnumType, variant_name: string, field_names: s
 fn enum_lookup_field(fields: EnumField[], name: string) -> EnumField? {
     let mut index = 0;
     loop {
-        if index >= fields.length {
-            break;
-        }
+        if index >= fields.length { break; }
         let field = fields[index];
-        if field.name == name {
-            return field;
-        }
+        if field.name == name { return field; }
         index = index + 1;
     }
     return null;
@@ -166,39 +156,29 @@ fn enum_lookup_field(fields: EnumField[], name: string) -> EnumField? {
 fn enum_find_variant(enum_type: EnumType, variant_name: string) -> EnumVariantDefinition? {
     let mut index = 0;
     loop {
-        if index >= enum_type.variants.length {
-            break;
-        }
+        if index >= enum_type.variants.length { break; }
         let variant = enum_type.variants[index];
-        if variant.name == variant_name {
-            return variant;
-        }
+        if variant.name == variant_name { return variant; }
         index = index + 1;
     }
     return null;
 }
 
 fn enum_normalize_fields(definition: EnumVariantDefinition?, provided: EnumField[]) -> EnumField[] {
-    if definition == null {
-        return provided;
-    }
+    if definition == null { return provided; }
     let expected = definition.field_names;
-    if expected.length == 0 {
-        return [];
-    }
+    if expected.length == 0 { return []; }
     let mut normalized: EnumField[] = [];
     let mut index = 0;
     loop {
-        if index >= expected.length {
-            break;
-        }
+        if index >= expected.length { break; }
         let field_name = expected[index];
         let candidate = enum_lookup_field(provided, field_name);
         let value = null;
-        if candidate != null {
-            value = candidate.value;
-        }
-        normalized = normalized.concat([EnumField { name: field_name, value: value }]);
+        if candidate != null { value = candidate.value; }
+        normalized = normalized.concat([EnumField {
+            name: field_name, value: value
+        }]);
         index = index + 1;
     }
     return normalized;
@@ -207,19 +187,19 @@ fn enum_normalize_fields(definition: EnumVariantDefinition?, provided: EnumField
 fn enum_instantiate(enum_type: EnumType, variant_name: string, provided: EnumField[]) -> EnumInstance {
     let definition = enum_find_variant(enum_type, variant_name);
     let fields = enum_normalize_fields(definition, provided);
-    return EnumInstance { type: enum_type, variant: variant_name, fields: fields };
+    return EnumInstance {
+        type: enum_type,
+        variant: variant_name,
+        fields: fields
+    };
 }
 
 fn enum_get_field(instance: EnumInstance, name: string) -> any {
     let mut index = 0;
     loop {
-        if index >= instance.fields.length {
-            break;
-        }
+        if index >= instance.fields.length { break; }
         let field = instance.fields[index];
-        if field.name == name {
-            return field.value;
-        }
+        if field.name == name { return field.value; }
         index = index + 1;
     }
     return null;
@@ -233,12 +213,8 @@ fn struct_repr(name: string, fields: StructField[]) -> string {
     let mut result = name + "(";
     let mut index = 0;
     loop {
-        if index >= fields.length {
-            break;
-        }
-        if index > 0 {
-            result = result + ", ";
-        }
+        if index >= fields.length { break; }
+        if index > 0 { result = result + ", "; }
         let field = fields[index];
         let value_text = to_debug_string(field.value);
         result = result + field.name + "=" + value_text;
@@ -256,9 +232,7 @@ fn format_interpolated(parts: string[], values: any[]) -> string {
     let mut result = "";
     let mut index = 0;
     loop {
-        if index >= parts.length {
-            break;
-        }
+        if index >= parts.length { break; }
         result = result + parts[index];
         if index < values.length {
             result = result + to_debug_string(values[index]);
@@ -304,9 +278,7 @@ fn descriptor_trim(value: string) -> string {
     let mut start = 0;
     let mut end = value.length;
     loop {
-        if start >= end {
-            break;
-        }
+        if start >= end { break; }
         let ch = grapheme_at(value, start);
         if ch == " " || ch == "\n" || ch == "\t" || ch == "\r" {
             start = start + 1;
@@ -315,9 +287,7 @@ fn descriptor_trim(value: string) -> string {
         break;
     }
     loop {
-        if end <= start {
-            break;
-        }
+        if end <= start { break; }
         let ch = grapheme_at(value, end - 1);
         if ch == " " || ch == "\n" || ch == "\t" || ch == "\r" {
             end = end - 1;
@@ -329,39 +299,27 @@ fn descriptor_trim(value: string) -> string {
 }
 
 fn string_starts_with(value: string, prefix: string) -> boolean {
-    if prefix.length > value.length {
-        return false;
-    }
+    if prefix.length > value.length { return false; }
     let mut index = 0;
     loop {
-        if index >= prefix.length {
-            break;
-        }
+        if index >= prefix.length { break; }
         let value_ch = grapheme_at(value, index);
         let prefix_ch = grapheme_at(prefix, index);
-        if value_ch != prefix_ch {
-            return false;
-        }
+        if value_ch != prefix_ch { return false; }
         index = index + 1;
     }
     return true;
 }
 
 fn string_ends_with(value: string, suffix: string) -> boolean {
-    if suffix.length > value.length {
-        return false;
-    }
+    if suffix.length > value.length { return false; }
     let mut offset = value.length - suffix.length;
     let mut index = 0;
     loop {
-        if index >= suffix.length {
-            break;
-        }
+        if index >= suffix.length { break; }
         let value_ch = grapheme_at(value, offset + index);
         let suffix_ch = grapheme_at(suffix, index);
-        if value_ch != suffix_ch {
-            return false;
-        }
+        if value_ch != suffix_ch { return false; }
         index = index + 1;
     }
     return true;
@@ -369,37 +327,21 @@ fn string_ends_with(value: string, suffix: string) -> boolean {
 
 fn descriptor_find_top_level(value: string, needle: string) -> number {
     let trimmed = descriptor_trim(value);
-    if needle.length != 1 {
-        return -1;
-    }
+    if needle.length != 1 { return -1; }
     let target = grapheme_at(needle, 0);
     let mut index = 0;
     let mut paren_depth = 0;
     let mut angle_depth = 0;
     let mut bracket_depth = 0;
     loop {
-        if index >= trimmed.length {
-            break;
-        }
+        if index >= trimmed.length { break; }
         let ch = grapheme_at(trimmed, index);
-        if ch == "(" {
-            paren_depth = paren_depth + 1;
-        } else if ch == ")" {
-            if paren_depth > 0 {
-                paren_depth = paren_depth - 1;
-            }
-        } else if ch == "<" {
-            angle_depth = angle_depth + 1;
-        } else if ch == ">" {
-            if angle_depth > 0 {
-                angle_depth = angle_depth - 1;
-            }
-        } else if ch == "[" {
-            bracket_depth = bracket_depth + 1;
-        } else if ch == "]" {
-            if bracket_depth > 0 {
-                bracket_depth = bracket_depth - 1;
-            }
+        if ch == "(" { paren_depth = paren_depth + 1; } else if ch == ")" {
+            if paren_depth > 0 { paren_depth = paren_depth - 1; }
+        } else if ch == "<" { angle_depth = angle_depth + 1; } else if ch == ">" {
+            if angle_depth > 0 { angle_depth = angle_depth - 1; }
+        } else if ch == "[" { bracket_depth = bracket_depth + 1; } else if ch == "]" {
+            if bracket_depth > 0 { bracket_depth = bracket_depth - 1; }
         }
         if ch == target && paren_depth == 0 && angle_depth == 0 && bracket_depth == 0 {
             return index;
@@ -412,26 +354,16 @@ fn descriptor_find_top_level(value: string, needle: string) -> number {
 fn descriptor_strip_outer_parens(value: string) -> string {
     let mut current = descriptor_trim(value);
     loop {
-        if current.length < 2 {
-            return current;
-        }
-        if grapheme_at(current, 0) != "(" {
-            return current;
-        }
-        if grapheme_at(current, current.length - 1) != ")" {
-            return current;
-        }
+        if current.length < 2 { return current; }
+        if grapheme_at(current, 0) != "(" { return current; }
+        if grapheme_at(current, current.length - 1) != ")" { return current; }
         let mut depth = 0;
         let mut index = 0;
         let mut valid = true;
         loop {
-            if index >= current.length {
-                break;
-            }
+            if index >= current.length { break; }
             let ch = grapheme_at(current, index);
-            if ch == "(" {
-                depth = depth + 1;
-            } else if ch == ")" {
+            if ch == "(" { depth = depth + 1; } else if ch == ")" {
                 depth = depth - 1;
                 if depth < 0 {
                     valid = false;
@@ -444,9 +376,7 @@ fn descriptor_strip_outer_parens(value: string) -> string {
             }
             index = index + 1;
         }
-        if !valid || depth != 0 {
-            return current;
-        }
+        if !valid || depth != 0 { return current; }
         current = descriptor_trim(substring(current, 1, current.length - 1));
     }
     return current;
@@ -454,9 +384,7 @@ fn descriptor_strip_outer_parens(value: string) -> string {
 
 fn split_descriptor(value: string, separator: string) -> string[] {
     let trimmed = descriptor_trim(value);
-    if separator.length != 1 {
-        return [trimmed];
-    }
+    if separator.length != 1 { return [trimmed]; }
     let mut parts: string[] = [];
     let mut start = 0;
     let mut index = 0;
@@ -465,28 +393,14 @@ fn split_descriptor(value: string, separator: string) -> string[] {
     let mut bracket_depth = 0;
     let target = grapheme_at(separator, 0);
     loop {
-        if index >= trimmed.length {
-            break;
-        }
+        if index >= trimmed.length { break; }
         let ch = grapheme_at(trimmed, index);
-        if ch == "(" {
-            paren_depth = paren_depth + 1;
-        } else if ch == ")" {
-            if paren_depth > 0 {
-                paren_depth = paren_depth - 1;
-            }
-        } else if ch == "<" {
-            angle_depth = angle_depth + 1;
-        } else if ch == ">" {
-            if angle_depth > 0 {
-                angle_depth = angle_depth - 1;
-            }
-        } else if ch == "[" {
-            bracket_depth = bracket_depth + 1;
-        } else if ch == "]" {
-            if bracket_depth > 0 {
-                bracket_depth = bracket_depth - 1;
-            }
+        if ch == "(" { paren_depth = paren_depth + 1; } else if ch == ")" {
+            if paren_depth > 0 { paren_depth = paren_depth - 1; }
+        } else if ch == "<" { angle_depth = angle_depth + 1; } else if ch == ">" {
+            if angle_depth > 0 { angle_depth = angle_depth - 1; }
+        } else if ch == "[" { bracket_depth = bracket_depth + 1; } else if ch == "]" {
+            if bracket_depth > 0 { bracket_depth = bracket_depth - 1; }
         }
         if ch == target && paren_depth == 0 && angle_depth == 0 && bracket_depth == 0 {
             let segment = substring(trimmed, start, index);
@@ -507,9 +421,7 @@ fn parse_descriptor_list(parts: string[]) -> TypeDescriptor[] {
     let mut descriptors: TypeDescriptor[] = [];
     let mut index = 0;
     loop {
-        if index >= parts.length {
-            break;
-        }
+        if index >= parts.length { break; }
         let entry = parts[index];
         if entry.length > 0 {
             descriptors = descriptors.concat([parse_type_descriptor(entry)]);
@@ -521,9 +433,7 @@ fn parse_descriptor_list(parts: string[]) -> TypeDescriptor[] {
 
 fn parse_type_descriptor(text: string) -> TypeDescriptor {
     let trimmed = descriptor_strip_outer_parens(text);
-    if trimmed.length == 0 {
-        return type_descriptor_unknown();
-    }
+    if trimmed.length == 0 { return type_descriptor_unknown(); }
     let union_parts = split_descriptor(trimmed, "|");
     if union_parts.length > 1 {
         return type_descriptor_union(parse_descriptor_list(union_parts));
@@ -560,34 +470,22 @@ fn parse_type_descriptor(text: string) -> TypeDescriptor {
 }
 
 fn check_type_primitive(value: any, name: string) -> boolean {
-    if name == "string" {
-        return runtime_is_string_fn(value);
-    }
-    if name == "number" {
-        return runtime_is_number_fn(value);
-    }
-    if name == "boolean" {
-        return runtime_is_boolean_fn(value);
-    }
-    if name == "void" {
-        return runtime_is_void_fn(value);
-    }
+    if name == "string" { return runtime_is_string_fn(value); }
+    if name == "number" { return runtime_is_number_fn(value); }
+    if name == "boolean" { return runtime_is_boolean_fn(value); }
+    if name == "void" { return runtime_is_void_fn(value); }
     return false;
 }
 
 fn check_type_descriptor(value: any, descriptor: TypeDescriptor) -> boolean {
     if descriptor.kind == "primitive" {
-        if descriptor.name == null {
-            return false;
-        }
+        if descriptor.name == null { return false; }
         return check_type_primitive(value, descriptor.name);
     }
     if descriptor.kind == "union" {
         let mut index = 0;
         loop {
-            if index >= descriptor.items.length {
-                break;
-            }
+            if index >= descriptor.items.length { break; }
             if check_type_descriptor(value, descriptor.items[index]) {
                 return true;
             }
@@ -598,9 +496,7 @@ fn check_type_descriptor(value: any, descriptor: TypeDescriptor) -> boolean {
     if descriptor.kind == "intersection" {
         let mut index = 0;
         loop {
-            if index >= descriptor.items.length {
-                break;
-            }
+            if index >= descriptor.items.length { break; }
             if !check_type_descriptor(value, descriptor.items[index]) {
                 return false;
             }
@@ -612,15 +508,11 @@ fn check_type_descriptor(value: any, descriptor: TypeDescriptor) -> boolean {
         if descriptor.items.length == 0 {
             return runtime_is_array_fn(value);
         }
-        if !runtime_is_array_fn(value) {
-            return false;
-        }
+        if !runtime_is_array_fn(value) { return false; }
         let element_descriptor = descriptor.items[0];
         let mut index = 0;
         loop {
-            if index >= value.length {
-                break;
-            }
+            if index >= value.length { break; }
             if !check_type_descriptor(value[index], element_descriptor) {
                 return false;
             }
@@ -632,15 +524,11 @@ fn check_type_descriptor(value: any, descriptor: TypeDescriptor) -> boolean {
         return runtime_is_callable_fn(value);
     }
     if descriptor.kind == "named" {
-        if descriptor.name == null {
-            return false;
-        }
+        if descriptor.name == null { return false; }
         let resolved = runtime_resolve_runtime_type_fn(descriptor.name);
         return runtime_instance_of_fn(value, resolved);
     }
-    if descriptor.kind == "unknown" {
-        return false;
-    }
+    if descriptor.kind == "unknown" { return false; }
     return false;
 }
 
@@ -654,25 +542,17 @@ fn serve(handler: any, config: any? = null) -> void ![io, net] {
 }
 
 fn clamp(value: number, minimum: number, maximum: number) -> number {
-    if value < minimum {
-        return minimum;
-    }
-    if value > maximum {
-        return maximum;
-    }
+    if value < minimum { return minimum; }
+    if value > maximum { return maximum; }
     return value;
 }
 
 fn substring(text: string, start: number, end: number) -> string {
     let length = text.length;
-    if length == 0 {
-        return "";
-    }
+    if length == 0 { return ""; }
     let mut normalized_start = clamp(start, 0, length);
     let mut normalized_end = clamp(end, 0, length);
-    if normalized_start >= normalized_end {
-        return "";
-    }
+    if normalized_start >= normalized_end { return ""; }
     // Use the O(N) runtime intrinsic. The prior Sailfin-level loop did
     // `result = result + grapheme_at(text, i)` per index, which is O(N^2)
     // memory under the zero-GC runtime. grapheme_at is byte-indexed in the
@@ -683,14 +563,10 @@ fn substring(text: string, start: number, end: number) -> string {
 }
 
 fn strings_equal(left: string, right: string) -> boolean {
-    if left.length != right.length {
-        return false;
-    }
+    if left.length != right.length { return false; }
     let mut index = 0;
     loop {
-        if index >= left.length {
-            break;
-        }
+        if index >= left.length { break; }
         let left_char = grapheme_at(left, index);
         let right_char = grapheme_at(right, index);
         if runtime_char_code_fn(left_char) != runtime_char_code_fn(right_char) {
@@ -703,38 +579,24 @@ fn strings_equal(left: string, right: string) -> boolean {
 
 fn find_char(text: string, character: string, start: number = 0) -> number {
     let length = text.length;
-    if length == 0 {
-        return -1;
-    }
+    if length == 0 { return -1; }
 
     let mut normalized_start = start;
-    if normalized_start < 0 {
-        normalized_start = 0;
-    }
-    if normalized_start >= length {
-        return -1;
-    }
+    if normalized_start < 0 { normalized_start = 0; }
+    if normalized_start >= length { return -1; }
 
     let mut target = character;
     if target.length == 2 && grapheme_at(target, 0) == "\\" {
         let escape = grapheme_at(target, 1);
-        if escape == "n" {
-            target = "\n";
-        } else if escape == "r" {
+        if escape == "n" { target = "\n"; } else if escape == "r" {
             target = "\r";
-        } else if escape == "t" {
-            target = "\t";
-        }
+        } else if escape == "t" { target = "\t"; }
     }
 
     let mut index = normalized_start;
     loop {
-        if index >= length {
-            break;
-        }
-        if strings_equal(grapheme_at(text, index), target) {
-            return index;
-        }
+        if index >= length { break; }
+        if strings_equal(grapheme_at(text, index), target) { return index; }
         index = index + 1;
     }
 
@@ -747,9 +609,7 @@ fn match_exhaustive_failed(value: any) -> void {
 }
 
 fn char_code(character: string) -> number {
-    if character.length == 0 {
-        return -1;
-    }
+    if character.length == 0 { return -1; }
 
     // Performance note: this function sits on hot paths in the compiler.
     // Prefer the runtime intrinsic instead of scanning through ASCII tables.
@@ -757,7 +617,6 @@ fn char_code(character: string) -> number {
     // corresponding Unicode code point.
     return runtime_char_code_fn(grapheme_at(character, 0));
 }
-
 
 fn grapheme_count(text: string) -> number {
     return runtime_grapheme_count_fn(text);
@@ -767,4 +626,26 @@ fn grapheme_at(text: string, index: number) -> string {
     return runtime_grapheme_at_fn(text, index);
 }
 
-export { capability_grant, fs_bridge, http_bridge, model_bridge, clamp, substring, find_char, grapheme_count, grapheme_at, char_code, match_exhaustive_failed, enum_type, enum_define_variant, enum_field, enum_instantiate, enum_get_field, struct_field, struct_repr, check_type, parse_type_descriptor, format_interpolated };
+export {
+    capability_grant,
+    fs_bridge,
+    http_bridge,
+    model_bridge,
+    clamp,
+    substring,
+    find_char,
+    grapheme_count,
+    grapheme_at,
+    char_code,
+    match_exhaustive_failed,
+    enum_type,
+    enum_define_variant,
+    enum_field,
+    enum_instantiate,
+    enum_get_field,
+    struct_field,
+    struct_repr,
+    check_type,
+    parse_type_descriptor,
+    format_interpolated
+};

--- a/site/src/content/docs/getting-started/editor-setup.md
+++ b/site/src/content/docs/getting-started/editor-setup.md
@@ -157,6 +157,16 @@ root:
         "reveal": "always",
         "panel": "shared"
       }
+    },
+    {
+      "label": "Sailfin: Format current file",
+      "type": "shell",
+      "command": "sfn fmt --write ${file}",
+      "group": "none",
+      "presentation": {
+        "reveal": "silent",
+        "panel": "shared"
+      }
     }
   ]
 }
@@ -173,6 +183,66 @@ With this configuration:
 
 Compiler output appears in the **Terminal** panel. Errors include file paths and
 line numbers, so you can click through to the relevant location.
+
+---
+
+## Formatting with `sfn fmt`
+
+Sailfin ships a built-in code formatter. One canonical style, no configuration —
+like `gofmt` for Go. All Sailfin compiler sources and the runtime are formatted
+with `sfn fmt` and CI enforces it on every pull request.
+
+### Quick start
+
+```bash
+# Format a file and see the result in stdout
+sfn fmt src/main.sfn
+
+# Format a file in place
+sfn fmt --write src/main.sfn
+
+# Format all .sfn files in a directory
+sfn fmt --write src/
+
+# Check formatting without modifying (CI mode)
+sfn fmt --check src/
+```
+
+### Format-on-save in VS Code
+
+Until the Sailfin language server is available, you can approximate format-on-save
+by binding a keyboard shortcut to the format task above. Open **Keyboard Shortcuts**
+(`Ctrl+K Ctrl+S`) and bind the **Sailfin: Format current file** task to your
+preferred key.
+
+Alternatively, add a `runOnSave` extension (e.g.,
+[emeraldwalk.RunOnSave](https://marketplace.visualstudio.com/items?itemName=emeraldwalk.RunOnSave))
+with this configuration in `.vscode/settings.json`:
+
+```json
+{
+  "emeraldwalk.runonsave": {
+    "commands": [
+      {
+        "match": "\\.sfn$",
+        "cmd": "sfn fmt --write ${file}"
+      }
+    ]
+  }
+}
+```
+
+### What the formatter does
+
+- 4-space indentation, K&R braces
+- Spaces around operators and after keywords; no space before `:`, `;`, `?`
+- No space after unary `!` and `-`
+- Imports sorted by path, specifiers sorted alphabetically
+- One blank line between top-level declarations
+- Single-statement blocks stay inline when they fit
+
+See the [CLI Reference](/docs/reference/cli) for the full list of formatting rules
+and known limitations.
 
 ---
 

--- a/site/src/content/docs/reference/cli.md
+++ b/site/src/content/docs/reference/cli.md
@@ -82,6 +82,76 @@ test "addition is commutative" {
 
 ---
 
+### `sfn fmt [options] <path...>`
+
+Format Sailfin source files. One style, no configuration — like `gofmt` for Sailfin.
+
+The formatter operates on the token stream (not the AST), so it works on any syntactically valid file including partial or experimental code. It preserves all comments and produces deterministic, idempotent output.
+
+**Usage:**
+
+```bash
+sfn fmt <file.sfn>             # print formatted output to stdout
+sfn fmt --write <path...>      # format files in place
+sfn fmt --check <path...>      # exit 1 if any file would change (CI mode)
+```
+
+**Options:**
+
+| Flag | Description |
+|---|---|
+| `--write` | Overwrite files in place with formatted output |
+| `--check` | Check if files are formatted; exit 1 if any differ (no modifications) |
+
+`--check` and `--write` are mutually exclusive. Without either flag, formatted output is printed to stdout.
+
+Paths can be individual `.sfn` files or directories. When given a directory, `sfn fmt` recursively discovers all `.sfn` files (up to 10 levels deep).
+
+**Examples:**
+
+```bash
+# Format a single file and see the result
+sfn fmt src/main.sfn
+
+# Format all compiler sources in place
+sfn fmt --write compiler/src/
+
+# CI check — fails if any file is unformatted
+sfn fmt --check compiler/src/ runtime/
+```
+
+**Formatting rules:**
+
+- **Indentation:** 4 spaces per level (no tabs)
+- **Spacing:** Spaces around operators and after keywords; no space before `:`, `;`, or `?` (optional suffix); no space after unary `!` and `-`
+- **Braces:** K&R style — opening brace on the same line as the declaration
+- **Blank lines:** Exactly one between top-level declarations; suppress at block boundaries
+- **Imports:** Sorted by path (standard library first, then relative), specifiers sorted alphabetically within each import
+- **Inline blocks:** Single-statement blocks stay on one line when they fit (e.g., `if x { return true; }`); multi-statement blocks and struct/enum declarations always expand
+- **Comments:** Preserved exactly as written; leading and trailing comments kept attached to their tokens
+- **Wrapping:** Import specifier lists and struct literals wrap at 80 characters
+
+**Known limitations:**
+
+| Limitation | Description |
+|---|---|
+| No expression wrapping | Long expressions stay on one line; the formatter does not break at operator boundaries |
+| No `--diff` mode | Cannot show inline diff between original and formatted; use `diff` externally |
+| Bulk OOM on many files | `sfn fmt --write <large-directory>` may OOM when processing hundreds of files in a single invocation; use a per-file loop as workaround (see below) |
+| No semantic formatting | Cannot reorder match arms, inline function bodies, or restructure code |
+| Comment-blank-line collapse | Blank lines between section-divider comments and declarations may be normalized away |
+
+**Workaround for bulk formatting:**
+
+```bash
+# Per-file loop avoids OOM on large codebases
+find compiler/src runtime -name '*.sfn' | while read f; do
+    sfn fmt --write "$f"
+done
+```
+
+---
+
 ### `sfn build <file>`
 
 Compile a Sailfin source file without running it. Writes an executable to the output path (default: the source filename without `.sfn` in the current directory).
@@ -148,7 +218,6 @@ The following commands are planned for a future release. They are not available 
 | `sfn init [name]` | Scaffold a new Sailfin capsule with a `capsule.toml` manifest |
 | `sfn add <capsule>` | Add a dependency to the current capsule |
 | `sfn publish` | Publish the current capsule to the package registry |
-| `sfn fmt [path]` | Format Sailfin source files in place |
 | `sfn check [path]` | Type-check and effect-check without compiling to a binary |
 
 ---

--- a/site/src/pages/roadmap.astro
+++ b/site/src/pages/roadmap.astro
@@ -94,7 +94,7 @@ const v1Categories: RoadmapCategory[] = [
     title: "Tooling & Developer Workflow",
     description: "CLI tools and build toolchain modernization.",
     items: [
-      { label: "sfn fmt — code formatter", status: "planned" },
+      { label: "sfn fmt — code formatter (token-stream, one style, CI-enforced)", status: "done" },
       { label: "sfn check — fast type and effect analysis", status: "planned" },
       { label: "sfn vet — static analyzer", status: "planned" },
       { label: "sfn audit — dependency capability surface analysis", status: "planned" },


### PR DESCRIPTION
## Summary

Completes Step 5 of the `sfn fmt` formatter implementation ([architecture](docs/proposals/fmt-architecture.md)). All compiler sources and the runtime are now canonically formatted and CI enforces it.

### Formatter improvements

- Prevent multi-statement block inlining (semicolons > 1)
- Guard against struct/enum declaration inlining (colon + semicolon heuristic avoids triggering codegen bug)
- Extend inline block context for `paren_close`, `keyword`, `arrow`
- Add `_reclassify_unary_ops` post-pass: `!` and `-` get no trailing space in unary context
- Add `optional_suffix` role for `?` (no space before)
- Wire `_sort_import_specifiers` into the pipeline via `_push_span_sorted`

### Applied formatting

- **124 files** formatted: 123 compiler source files + `runtime/prelude.sfn`
- **Idempotency verified**: second `sfn fmt` pass produces identical output across all files
- **Self-hosting verified**: `make rebuild` succeeds with formatted source

### Testing

- **17 e2e tests** in `compiler/tests/e2e/test_fmt.sh`: edge cases (empty files, comment-only, unary ops, optional types, effect annotations, struct declarations, imports, if/else), idempotency on real compiler files, `--check`/`--write` mode validation
- **CI enforcement**: `sfn fmt --check` step added to `.github/workflows/ci.yml` (per-file loop to avoid OOM)

### Documentation

- `docs/status.md`: `sfn fmt` marked as **Shipped**
- `docs/proposals/fmt-architecture.md`: Step 5 marked complete with implementation details and known limitations
- `docs/style-guide.md`: Added Code Formatting section
- `site/src/content/docs/reference/cli.md`: Full `sfn fmt` command reference with usage, options, formatting rules, known limitations, and OOM workaround
- `site/src/pages/roadmap.astro`: `sfn fmt` marked as done
- `site/src/content/docs/getting-started/editor-setup.md`: Formatting section with format-on-save instructions
- `llms.txt` + `site/public/llms.txt`: New Tooling section with `sfn fmt` reference

### Known limitations (called out in docs)

| Limitation | Detail |
|---|---|
| No expression wrapping | Long expressions stay on one line |
| Bulk OOM | `sfn fmt --write <large-dir>` may OOM on hundreds of files; use per-file loop |
| No `--diff` mode | Use external `diff` to compare |
| No semantic formatting | Cannot reorder match arms or inline function bodies |
| Comment-blank-line collapse | Blank lines between section-divider comments may be normalized |

### Verification

```bash
make rebuild              # self-hosting with formatted source
make test                 # full test suite
bash compiler/tests/e2e/test_fmt.sh build/native/sailfin  # fmt tests
```

### CI seed version

Bumped `SEED_VERSION` in `ci.yml` from `0.5.2-alpha.1` to `0.5.3-alpha.1`.
