### PR TITLE
fix(compiler): deterministic self-hosting — fix recovery parser inline case detection

### DIFF
--- a/compiler/src/llvm/lowering/lowering_recovery.sfn
+++ b/compiler/src/llvm/lowering/lowering_recovery.sfn
@@ -163,7 +163,7 @@ fn recover_native_functions_light(native_text: string) -> NativeFunction[] {
         let method_name_from_paren = trim_text_local(substring(method_header, 0, method_paren_idx));
         let method_arrow_idx = index_of(method_header, " -> ");
         let method_ret_from_arrow = trim_text_local(substring(method_header, method_arrow_idx
-                + 4, method_header.length));
+            + 4, method_header.length));
         // Check whether the method has a `self` parameter.  Static methods
         // (e.g. `fn new(w, h)`) must NOT get self injected.
         let mut method_has_self: boolean = false;
@@ -202,14 +202,14 @@ fn recover_native_functions_light(native_text: string) -> NativeFunction[] {
         }
         let param_name_raw = trim_text_local(substring(param_text_raw, 0, param_arrow_idx));
         let param_type_raw = trim_text_local(substring(param_text_raw, param_arrow_idx
-                + param_sep_len, param_text_raw.length));
+            + param_sep_len, param_text_raw.length));
 
         // Pre-compute .for target/iterable extraction.
         let for_body_raw = trim_text_local(substring(line, 5, line.length));
         let for_in_idx = index_of(for_body_raw, " in ");
         let for_target_raw = trim_text_local(substring(for_body_raw, 0, for_in_idx));
         let for_iterable_raw = trim_text_local(substring(for_body_raw, for_in_idx
-                + 4, for_body_raw.length));
+            + 4, for_body_raw.length));
 
         // Pre-compute match/case extraction.
         let match_expr_raw = trim_text_local(substring(line, 7, line.length));
@@ -217,7 +217,7 @@ fn recover_native_functions_light(native_text: string) -> NativeFunction[] {
         // Inline case: pattern => body,
         let inline_pattern_raw = trim_text_local(substring(line, 0, inline_arrow_idx));
         let inline_body_full = trim_text_local(substring(line, inline_arrow_idx
-                + 4, line.length));
+            + 4, line.length));
         // Strip trailing comma from inline body
         let mut inline_body_raw: string = inline_body_full;
         if inline_body_full.length > 0 {
@@ -287,7 +287,7 @@ fn recover_native_functions_light(native_text: string) -> NativeFunction[] {
                 if method_paren_idx >= 0 {
                     if method_arrow_idx >= 0 {
                         let full_name = current_struct_name
-                        + method_name_from_paren;
+                            + method_name_from_paren;
                         if method_has_self {
                             current = make_native_function_method(full_name, current_struct_name, method_ret_from_arrow);
                         }
@@ -595,7 +595,7 @@ fn recover_native_structs_light(native_text: string) -> NativeStruct[] {
         }
         let f_name = trim_text_local(substring(field_text, 0, field_arrow_idx));
         let f_type = trim_text_local(substring(field_text, field_arrow_idx
-                + field_sep_len, field_text.length));
+            + field_sep_len, field_text.length));
 
         let ls_text = trim_text_local(substring(line, 15, line.length));
         let ls_size_idx = index_of(ls_text, "size=");

--- a/compiler/src/llvm/lowering/lowering_recovery.sfn
+++ b/compiler/src/llvm/lowering/lowering_recovery.sfn
@@ -163,7 +163,7 @@ fn recover_native_functions_light(native_text: string) -> NativeFunction[] {
         let method_name_from_paren = trim_text_local(substring(method_header, 0, method_paren_idx));
         let method_arrow_idx = index_of(method_header, " -> ");
         let method_ret_from_arrow = trim_text_local(substring(method_header, method_arrow_idx
-            + 4, method_header.length));
+                + 4, method_header.length));
         // Check whether the method has a `self` parameter.  Static methods
         // (e.g. `fn new(w, h)`) must NOT get self injected.
         let mut method_has_self: boolean = false;
@@ -202,14 +202,14 @@ fn recover_native_functions_light(native_text: string) -> NativeFunction[] {
         }
         let param_name_raw = trim_text_local(substring(param_text_raw, 0, param_arrow_idx));
         let param_type_raw = trim_text_local(substring(param_text_raw, param_arrow_idx
-            + param_sep_len, param_text_raw.length));
+                + param_sep_len, param_text_raw.length));
 
         // Pre-compute .for target/iterable extraction.
         let for_body_raw = trim_text_local(substring(line, 5, line.length));
         let for_in_idx = index_of(for_body_raw, " in ");
         let for_target_raw = trim_text_local(substring(for_body_raw, 0, for_in_idx));
         let for_iterable_raw = trim_text_local(substring(for_body_raw, for_in_idx
-            + 4, for_body_raw.length));
+                + 4, for_body_raw.length));
 
         // Pre-compute match/case extraction.
         let match_expr_raw = trim_text_local(substring(line, 7, line.length));
@@ -217,7 +217,7 @@ fn recover_native_functions_light(native_text: string) -> NativeFunction[] {
         // Inline case: pattern => body,
         let inline_pattern_raw = trim_text_local(substring(line, 0, inline_arrow_idx));
         let inline_body_full = trim_text_local(substring(line, inline_arrow_idx
-            + 4, line.length));
+                + 4, line.length));
         // Strip trailing comma from inline body
         let mut inline_body_raw: string = inline_body_full;
         if inline_body_full.length > 0 {
@@ -287,7 +287,7 @@ fn recover_native_functions_light(native_text: string) -> NativeFunction[] {
                 if method_paren_idx >= 0 {
                     if method_arrow_idx >= 0 {
                         let full_name = current_struct_name
-                            + method_name_from_paren;
+                        + method_name_from_paren;
                         if method_has_self {
                             current = make_native_function_method(full_name, current_struct_name, method_ret_from_arrow);
                         }
@@ -478,14 +478,19 @@ fn recover_native_functions_light(native_text: string) -> NativeFunction[] {
         }
         // Inline match case: `pattern => body,` — emit Case + body instructions.
         // Must NOT fire on `.case` or `.match` lines that happen to contain ` => `.
+        // Must NOT fire on `eval` lines where ` => ` appears inside a string literal
+        // (e.g. `eval line = line + " => {"`).  Misidentifying eval lines as inline
+        // cases corrupts the instruction list and causes a 2-cycle oscillation in
+        // the self-hosting fixed-point check.
         let mut _inline_score: number = 0;
         if is_inline_case { _inline_score += 1; }
+        if !is_eval { _inline_score += 1; }
         if !is_match_kw { _inline_score += 1; }
         if !is_case_kw { _inline_score += 1; }
         if !is_endmatch_kw { _inline_score += 1; }
         if !is_fn_start { _inline_score += 1; }
         if !is_fn_end { _inline_score += 1; }
-        if _inline_score >= 6 {
+        if _inline_score >= 7 {
             let case_instr = make_instruction_text(13, inline_pattern_raw);
             current = append_instruction_to_function(current, case_instr);
             if inline_body_is_return {
@@ -590,7 +595,7 @@ fn recover_native_structs_light(native_text: string) -> NativeStruct[] {
         }
         let f_name = trim_text_local(substring(field_text, 0, field_arrow_idx));
         let f_type = trim_text_local(substring(field_text, field_arrow_idx
-            + field_sep_len, field_text.length));
+                + field_sep_len, field_text.length));
 
         let ls_text = trim_text_local(substring(line, 15, line.length));
         let ls_size_idx = index_of(ls_text, "size=");

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,6 +1,6 @@
 # Status
 
-Updated: April 16, 2026
+Updated: April 17, 2026
 
 This document tracks what works today and what is in progress. It is the source
 of truth — consult it before editing docs, examples, or making claims about
@@ -11,6 +11,9 @@ feature availability.
 - `scripts/build.sh` is the sole build driver — pure shell, no fixups.
 - `make compile` builds the compiler from a released seed. `make check`
   validates the seedcheck binary can run `hello-world.sfn` and pass the test suite.
+- **Deterministic self-hosting**: the compiler is a verified fixed point —
+  stage2 and stage3 produce byte-identical LLVM IR across all modules.
+  `make check` enforces this.
 - The legacy Python fixup script (`selfhost_native.py`) was removed after the
   compiler reached clean LLVM IR output (v0.5.0-alpha.22+).
 

--- a/site/src/pages/roadmap.astro
+++ b/site/src/pages/roadmap.astro
@@ -85,7 +85,8 @@ const v1Categories: RoadmapCategory[] = [
     items: [
       { label: "Eliminate the Python fixup script", status: "done" },
       { label: "Make build.sh the sole clean build path with no post-processing", status: "done" },
-      { label: "Pass make check with no fallbacks", status: "planned" },
+      { label: "Pass make check with no fallbacks", status: "done" },
+      { label: "Deterministic self-hosting — stage2 == stage3 fixed-point verified", status: "done" },
       { label: "Stabilize control-flow LLVM lowering (loop/if/break headers)", status: "planned" },
       { label: "Richer diagnostics — multi-span, severity levels, fix-it hints", status: "planned" },
     ],


### PR DESCRIPTION
## Summary

Fix a systematic 2-cycle oscillation in the self-hosting fixed-point check (`make check`) where stage2 ≠ stage3 across three modules. After this fix, the compiler achieves **deterministic self-hosting**: stage2 == stage3 across all modules.

## Root Cause

The recovery parser in `recover_native_functions_light` (`lowering_recovery.sfn`) detects inline match cases by searching for ` => ` on each `.sfn-asm` line. This detection was **not excluding `eval` lines**, so eval expressions containing `" => "` as a string literal were misidentified as inline match cases:

```
eval line = line + " => {"
eval let inline_arrow_idx = index_of(line, " => ")
```

This corrupted the `NativeInstruction` list for 3 functions:
| Module | Function | Symptom |
|---|---|---|
| `emit_native.sfn` | `emit_inline_match_case` | Body replaced with `zeroinitializer` |
| `emitter_sailfin.sfn` | `emit_match_case` | If/else guard branches emptied |
| `lowering_recovery.sfn` | `recover_native_functions_light` | Local allocations shifted, extra locals inserted |

### Why it oscillated (not random)

The `.sfn-asm` intermediates were **identical** between all 3 stages — the bug was purely in LLVM lowering. Because `recover_native_functions_light`'s **own** `inline_arrow_idx` computation was one of the corrupted lines, the stage2 binary accidentally lost the inline case detection code, making its recovery parser handle eval lines **correctly**. Stage3 (compiled by stage2's accidentally-correct behavior) restored the buggy code, restarting the cycle.

## Fix

Added `!is_eval` to the inline case score check in `recover_native_functions_light`, raising the threshold from 6 to 7. This prevents eval lines from being misidentified as inline match cases.

```diff
  let mut _inline_score: number = 0;
  if is_inline_case { _inline_score += 1; }
+ if !is_eval { _inline_score += 1; }
  if !is_match_kw { _inline_score += 1; }
  ...
- if _inline_score >= 6 {
+ if _inline_score >= 7 {
```

## Verification

```
[check] comparing stage2 vs stage3 LLVM IR (fixed-point check)...
[check] stage2 == stage3: compiler is a fixed point ✓
```

Full `make clean-build && make check` passes — all tests green, fixed-point verified.

## Changes

| File | Change |
|---|---|
| `compiler/src/llvm/lowering/lowering_recovery.sfn` | Add `!is_eval` guard to inline case score; raise threshold 6→7 |
| `docs/status.md` | Document deterministic self-hosting milestone |
| `site/src/pages/roadmap.astro` | Mark "Pass make check" and deterministic self-hosting as done |
