### PR TITLE
fix(compiler): remove .condition_locals file IPC channel

### DIFF
--- a/compiler/src/llvm/expression_lowering/native/core_call_resolution.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_call_resolution.sfn
@@ -199,62 +199,30 @@ fn resolve_call_method_target(trimmed_target: string, arguments: string[], bindi
                     if _pre_field.length > 0 {
                         if _pre_field != "concat" {
                             if _pre_field != "push" {
-                                if fs.exists("build/sailfin/.condition_locals") {
-                                    let _pre_raw = fs.readFile("build/sailfin/.condition_locals");
-                                    if _pre_raw.length > 0 {
-                                        let mut _pre_pos: number = 0;
-                                        let mut _pre_struct: string = "";
-                                        loop {
-                                            if _pre_pos >= _pre_raw.length {
-                                                break;
-                                            }
-                                            let _pre_nl = index_of(substring(_pre_raw, _pre_pos, _pre_raw.length), "\n");
-                                            let mut _pre_line: string = "";
-                                            if _pre_nl < 0 {
-                                                _pre_line = substring(_pre_raw, _pre_pos, _pre_raw.length);
-                                                _pre_pos = _pre_raw.length;
-                                            } else {
-                                                _pre_line = substring(_pre_raw, _pre_pos, _pre_pos
-                                                    + _pre_nl);
-                                                _pre_pos = _pre_pos + _pre_nl
-                                                    + 1;
-                                            }
-                                            if _pre_line.length == 0 {
-                                                continue;
-                                            }
-                                            let _pre_t1 = index_of(_pre_line, "\t");
-                                            if _pre_t1 < 0 { continue; }
-                                            let _pre_name = substring(_pre_line, 0, _pre_t1);
-                                            if _pre_name != _pre_base {
-                                                continue;
-                                            }
-                                            let _pre_rest = substring(_pre_line, _pre_t1
-                                                + 1, _pre_line.length);
-                                            let _pre_t2 = index_of(_pre_rest, "\t");
-                                            if _pre_t2 < 0 { continue; }
-                                            _pre_struct = substring(_pre_rest, 0, _pre_t2);
+                                let _pre_local = find_local_binding(locals, _pre_base);
+                                let mut _pre_struct: string = "";
+                                if _pre_local != null {
+                                    if _pre_local.type_annotation != null {
+                                        _pre_struct = _pre_local.type_annotation;
+                                    }
+                                }
+                                if _pre_struct.length > 0 {
+                                    let _pre_lowered = lower_expression(_pre_base, bindings, locals, result_temp, result_lines, functions, context, "");
+                                    let mut _ci1: number = 0;
+                                    loop {
+                                        if _ci1 >= _pre_lowered.diagnostics.length {
                                             break;
                                         }
-                                        if _pre_struct.length > 0 {
-                                            let _pre_lowered = lower_expression(_pre_base, bindings, locals, result_temp, result_lines, functions, context, "");
-                                            let mut _ci1: number = 0;
-                                            loop {
-                                                if _ci1 >= _pre_lowered.diagnostics.length {
-                                                    break;
-                                                }
-                                                result_diagnostics.push(_pre_lowered.diagnostics[_ci1]);
-                                                _ci1 += 1;
-                                            }
-                                            result_string_constants = merge_string_constants(result_string_constants, _pre_lowered.string_constants);
-                                            result_lines = _pre_lowered.lines;
-                                            result_temp = _pre_lowered.temp_index;
-                                            if _pre_lowered.operand != null {
-                                                method_operand = _pre_lowered.operand;
-                                                result_target = _pre_struct
-                                                    + _pre_field;
-                                                injected_argument_count = 1;
-                                            }
-                                        }
+                                        result_diagnostics.push(_pre_lowered.diagnostics[_ci1]);
+                                        _ci1 += 1;
+                                    }
+                                    result_string_constants = merge_string_constants(result_string_constants, _pre_lowered.string_constants);
+                                    result_lines = _pre_lowered.lines;
+                                    result_temp = _pre_lowered.temp_index;
+                                    if _pre_lowered.operand != null {
+                                        method_operand = _pre_lowered.operand;
+                                        result_target = _pre_struct + _pre_field;
+                                        injected_argument_count = 1;
                                     }
                                 }
                             }

--- a/compiler/src/llvm/expression_lowering/native/core_member_helpers.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_member_helpers.sfn
@@ -3,6 +3,7 @@
 // Inline GEP field access helper extracted from core_member_lowering.sfn
 // to keep each function under ~500 .sfn-asm instructions (avoids seed OOM).
 import { index_of, substring } from "../../../string_utils";
+import { find_local_binding } from "../../expressions_bindings";
 import { format_temp_name } from "../../expressions_helpers";
 import {
     ExpressionResult,
@@ -17,7 +18,7 @@ import { number_to_string, trim_text } from "../../utils";
 // Try to resolve a struct field access via file-based struct info when the
 // base type is i8* (opaque pointer). Returns an ExpressionResult with the
 // loaded field value, or null if resolution fails.
-fn lower_inline_gep_field_access(base_name: string, field_name: string, base_operand: LLVMOperand, bindings: ParameterBinding[], temp_index: number, lines: string[], diagnostics: string[], string_constants: StringConstant[]) -> ExpressionResult? ![io] {
+fn lower_inline_gep_field_access(base_name: string, field_name: string, base_operand: LLVMOperand, bindings: ParameterBinding[], locals: LocalBinding[], temp_index: number, lines: string[], diagnostics: string[], string_constants: StringConstant[]) -> ExpressionResult? ![io] {
     if !fs.exists("build/sailfin/.struct_info") { return null; }
 
     let _igep_base = trim_text(base_name);
@@ -72,34 +73,12 @@ fn lower_inline_gep_field_access(base_name: string, field_name: string, base_ope
         }
     }
 
-    // Check condition_locals for local variables
+    // Check locals for type annotation on the base.
     if _igep_struct.length == 0 {
-        if fs.exists("build/sailfin/.condition_locals") {
-            let _igep_cl = fs.readFile("build/sailfin/.condition_locals");
-            let mut _igep_cp: number = 0;
-            loop {
-                if _igep_cp >= _igep_cl.length { break; }
-                let _igep_cnl = index_of(substring(_igep_cl, _igep_cp, _igep_cl.length), "\n");
-                let mut _igep_cln: string = "";
-                if _igep_cnl < 0 {
-                    _igep_cln = substring(_igep_cl, _igep_cp, _igep_cl.length);
-                    _igep_cp = _igep_cl.length;
-                } else {
-                    _igep_cln = substring(_igep_cl, _igep_cp, _igep_cp
-                        + _igep_cnl);
-                    _igep_cp = _igep_cp + _igep_cnl + 1;
-                }
-                if _igep_cln.length == 0 { continue; }
-                let _igep_ct = index_of(_igep_cln, "\t");
-                if _igep_ct < 0 { continue; }
-                if substring(_igep_cln, 0, _igep_ct) == _igep_base {
-                    let _igep_cr = substring(_igep_cln, _igep_ct + 1, _igep_cln.length);
-                    let _igep_ct2 = index_of(_igep_cr, "\t");
-                    if _igep_ct2 > 0 {
-                        _igep_struct = substring(_igep_cr, 0, _igep_ct2);
-                    }
-                    break;
-                }
+        let _igep_local = find_local_binding(locals, _igep_base);
+        if _igep_local != null {
+            if _igep_local.type_annotation != null {
+                _igep_struct = _igep_local.type_annotation;
             }
         }
     }

--- a/compiler/src/llvm/expression_lowering/native/core_member_lowering.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_member_lowering.sfn
@@ -3,6 +3,7 @@
 // Member access lowering extracted from core.sfn.
 import { NativeFunction } from "../../../native_ir";
 import { index_of, substring } from "../../../string_utils";
+import { find_local_binding } from "../../expressions_bindings";
 import { default_return_literal, format_temp_name } from "../../expressions_helpers";
 import {
     append_string_constant,
@@ -665,7 +666,7 @@ fn lower_member_access(parse: MemberAccessParse, bindings: ParameterBinding[], l
                 return lower_enum_member_access(parse, enum_info_candidate, base_operand, true, current_temp, current_lines, diagnostics, collected_string_constants, expected_type);
             }
             if base_type_trimmed == "i8*" {
-                let _igep_result = lower_inline_gep_field_access(parse.base, parse.field, base_operand, bindings, current_temp, current_lines, diagnostics, collected_string_constants);
+                let _igep_result = lower_inline_gep_field_access(parse.base, parse.field, base_operand, bindings, locals, current_temp, current_lines, diagnostics, collected_string_constants);
                 if _igep_result != null { return _igep_result; }
                 return lower_dynamic_member_access(parse.field, base_operand, current_temp, current_lines, diagnostics, collected_string_constants);
             }
@@ -694,7 +695,7 @@ fn lower_member_access(parse: MemberAccessParse, bindings: ParameterBinding[], l
                 return lower_enum_member_access(parse, enum_info_candidate, base_operand, false, current_temp, current_lines, diagnostics, collected_string_constants, expected_type);
             }
             if base_type_trimmed == "i8*" {
-                let _igep2_result = lower_inline_gep_field_access(parse.base, parse.field, base_operand, bindings, current_temp, current_lines, diagnostics, collected_string_constants);
+                let _igep2_result = lower_inline_gep_field_access(parse.base, parse.field, base_operand, bindings, locals, current_temp, current_lines, diagnostics, collected_string_constants);
                 if _igep2_result != null { return _igep2_result; }
                 return lower_dynamic_member_access(parse.field, base_operand, current_temp, current_lines, diagnostics, collected_string_constants);
             }
@@ -908,32 +909,10 @@ fn try_file_based_struct_field_access(base_name: string, field_name: string, bas
         _bi += 1;
     }
     if struct_type_ann.length == 0 {
-        // Check condition_locals file for locals
-        if fs.exists("build/sailfin/.condition_locals") {
-            let _cl_raw = fs.readFile("build/sailfin/.condition_locals");
-            let mut _cl_pos: number = 0;
-            loop {
-                if _cl_pos >= _cl_raw.length { break; }
-                let _cl_nl = index_of(substring(_cl_raw, _cl_pos, _cl_raw.length), "\n");
-                let mut _cl_line: string = "";
-                if _cl_nl < 0 {
-                    _cl_line = substring(_cl_raw, _cl_pos, _cl_raw.length);
-                    _cl_pos = _cl_raw.length;
-                } else {
-                    _cl_line = substring(_cl_raw, _cl_pos, _cl_pos + _cl_nl);
-                    _cl_pos = _cl_pos + _cl_nl + 1;
-                }
-                if _cl_line.length == 0 { continue; }
-                let _cl_t1 = index_of(_cl_line, "\t");
-                if _cl_t1 < 0 { continue; }
-                let _cl_name = substring(_cl_line, 0, _cl_t1);
-                if _cl_name != trimmed_base { continue; }
-                let _cl_rest = substring(_cl_line, _cl_t1 + 1, _cl_line.length);
-                let _cl_t2 = index_of(_cl_rest, "\t");
-                if _cl_t2 > 0 {
-                    struct_type_ann = substring(_cl_rest, 0, _cl_t2);
-                }
-                break;
+        let local = find_local_binding(locals, trimmed_base);
+        if local != null {
+            if local.type_annotation != null {
+                struct_type_ann = local.type_annotation;
             }
         }
     }

--- a/compiler/src/llvm/lowering/instructions_condition.sfn
+++ b/compiler/src/llvm/lowering/instructions_condition.sfn
@@ -34,27 +34,6 @@ fn allocate_block_label(prefix: string, counter: number) -> BlockLabelResult {
 
 fn lower_condition_to_i1(function_name: string, expression: string, bindings: ParameterBinding[], locals: LocalBinding[], temp_index: number, lines: string[], functions: NativeFunction[], context: TypeContext) -> ConditionConversion {
     let mut diagnostics: string[] = detect_suspension_conflicts(expression, locals, bindings, function_name, null);
-    // Write local type annotations to a file so the cross-module expression
-    // lowering can resolve struct types for method calls.  The v0.1.1 seed
-    // corrupts the locals array when passed across module boundaries, so
-    // resolve_struct_info_for_method_target can't inspect local.type_annotation.
-    let mut _lta_lines: string[] = [];
-    let mut _lta_i: number = 0;
-    loop {
-        if _lta_i >= locals.length { break; }
-        let mut _lta_name = locals[_lta_i].name;
-        if _lta_name == null { _lta_name = ""; }
-        let mut _lta_type = locals[_lta_i].type_annotation;
-        if _lta_type == null { _lta_type = ""; }
-        let mut _lta_llvm = locals[_lta_i].llvm_type;
-        if _lta_llvm == null { _lta_llvm = ""; }
-        let mut _lta_ptr = locals[_lta_i].pointer;
-        if _lta_ptr == null { _lta_ptr = ""; }
-        _lta_lines.push(_lta_name + "\t" + _lta_type + "\t" + _lta_llvm + "\t"
-            + _lta_ptr);
-        _lta_i += 1;
-    }
-    fs.writeLines("build/sailfin/.condition_locals", _lta_lines);
     let lowered = lower_expression(expression, bindings, locals, temp_index, lines, functions, context, "");
     let mut _ci11: number = 0;
     loop {

--- a/compiler/src/llvm/type_context_queries.sfn
+++ b/compiler/src/llvm/type_context_queries.sfn
@@ -219,7 +219,7 @@ fn lookup_allocation_info(context: TypeContext, llvm_type: string) -> TypeAlloca
 // =============================================================================
 // Method Target Resolution
 // =============================================================================
-fn resolve_struct_info_for_method_target(base: string, bindings: ParameterBinding[], locals: LocalBinding[], context: TypeContext) -> StructTypeInfo? ![io] {
+fn resolve_struct_info_for_method_target(base: string, bindings: ParameterBinding[], locals: LocalBinding[], context: TypeContext) -> StructTypeInfo? {
     let trimmed = trim_text(base);
     if trimmed.length == 0 { return null; }
     if is_simple_identifier(trimmed) {

--- a/compiler/src/llvm/type_context_queries.sfn
+++ b/compiler/src/llvm/type_context_queries.sfn
@@ -252,42 +252,6 @@ fn resolve_struct_info_for_method_target(base: string, bindings: ParameterBindin
     // Allow static method calls on a struct type (e.g. `BankAccount.new(123)`).
     let by_name = find_struct_info_by_name(context, trimmed);
     if by_name != null { return by_name; }
-    // Last resort: read locals from the condition_locals file written by
-    // instructions.sfn.  Cross-module ABI corruption in the v0.1.1 seed can
-    // leave the in-memory `locals` array empty/corrupt, so this file-based
-    // fallback ensures the type_annotation is available.
-    if fs.exists("build/sailfin/.condition_locals") {
-        let _cl_raw = fs.readFile("build/sailfin/.condition_locals");
-        if _cl_raw.length > 0 {
-            let mut _cl_pos: number = 0;
-            loop {
-                if _cl_pos >= _cl_raw.length { break; }
-                let _cl_nl = index_of(substring(_cl_raw, _cl_pos, _cl_raw.length), "\n");
-                let mut _cl_line: string = "";
-                if _cl_nl < 0 {
-                    _cl_line = substring(_cl_raw, _cl_pos, _cl_raw.length);
-                    _cl_pos = _cl_raw.length;
-                } else {
-                    _cl_line = substring(_cl_raw, _cl_pos, _cl_pos + _cl_nl);
-                    _cl_pos = _cl_pos + _cl_nl + 1;
-                }
-                if _cl_line.length == 0 { continue; }
-                // Format: name\ttype_annotation\tllvm_type\tpointer
-                let _ct1 = index_of(_cl_line, "\t");
-                if _ct1 < 0 { continue; }
-                let _cl_name = substring(_cl_line, 0, _ct1);
-                if _cl_name != trimmed { continue; }
-                let _cl_rest = substring(_cl_line, _ct1 + 1, _cl_line.length);
-                let _ct2 = index_of(_cl_rest, "\t");
-                if _ct2 < 0 { continue; }
-                let _cl_type_ann = substring(_cl_rest, 0, _ct2);
-                if _cl_type_ann.length > 0 {
-                    let by_file_annotation = find_struct_info_by_name(context, _cl_type_ann);
-                    if by_file_annotation != null { return by_file_annotation; }
-                }
-            }
-        }
-    }
     return null;
 }
 

--- a/docs/build-performance.md
+++ b/docs/build-performance.md
@@ -260,9 +260,9 @@ Channels that serialize per-instruction/per-binding control-flow state (dispatch
 
 Use this pattern for every channel in the priority list. It keeps diffs surgical, preserves self-hosting after each step, and makes the determinism delta measurable.
 
-1. **Locate the writer.** `grep 'fs\.writeLines.*\.channel_name\|fs\.writeFile.*\.channel_name' compiler/src`. There is usually exactly one.
+1. **Locate the writer.** `grep -R 'fs\.writeLines.*\.channel_name\|fs\.writeFile.*\.channel_name' compiler/src`. There is usually exactly one.
 2. **Identify the data being serialized.** If it's a struct that the writer already has as a local — and the reader already accepts that struct type as a parameter — the channel is dead code.
-3. **At each reader, check whether the enclosing function already takes that parameter.** `grep 'fs\.readFile.*\.channel_name' compiler/src` to enumerate readers. For `LocalBinding[]`, `ParameterBinding[]`, and `TypeContext`, readers almost always already have the param.
+3. **At each reader, check whether the enclosing function already takes that parameter.** `grep -R 'fs\.readFile.*\.channel_name' compiler/src` to enumerate readers. For `LocalBinding[]`, `ParameterBinding[]`, and `TypeContext`, readers almost always already have the param.
 4. **Replace the file read with the in-memory lookup.** Prefer existing helpers (`find_local_binding`, `find_parameter_binding`, `find_struct_info_by_name`) over rewriting parser logic inline.
 5. **If the enclosing function does _not_ have the parameter:** add it to the signature and update every caller. Blast radius is usually one hop. Do not introduce new wrapper structs unless two or more params need to travel together.
 6. **Delete the writer.** The channel is gone.

--- a/docs/build-performance.md
+++ b/docs/build-performance.md
@@ -250,9 +250,29 @@ The win is concentrated on the target module; aggregate is within bench variance
 ### Phase 2: Eliminate IPC Files (Resumed)
 
 **Priority:** Highest — **Expected:** 40-60% time reduction, enables parallel builds
-**Depends on:** Phase 0 (arena allocator) to prevent OOM
+**Depends on:** Phase 0 (arena allocator) to prevent OOM for the per-binding/per-instruction channels
 
-With memory management solved, resume replacing filesystem IPC with direct struct returns. Remaining targets by priority:
+Most IPC channels were introduced as workarounds for v0.1.1-seed ABI corruption of array-of-struct parameters across module boundaries. The 0.5.x seed lineage no longer corrupts those parameters, so many channels are now dead-code fallbacks whose readers already have the data in-memory via an existing `bindings` or `locals` parameter. Those channels can be removed immediately — they do not depend on Phase 0.
+
+Channels that serialize per-instruction/per-binding control-flow state (dispatch, let result, block result, statement mutations) are different: they still act as implicit GC per the IPC-as-GC Problem above and must wait for Phase 0.
+
+#### Procedure: Removing an IPC Channel
+
+Use this pattern for every channel in the priority list. It keeps diffs surgical, preserves self-hosting after each step, and makes the determinism delta measurable.
+
+1. **Locate the writer.** `grep 'fs\.writeLines.*\.channel_name\|fs\.writeFile.*\.channel_name' compiler/src`. There is usually exactly one.
+2. **Identify the data being serialized.** If it's a struct that the writer already has as a local — and the reader already accepts that struct type as a parameter — the channel is dead code.
+3. **At each reader, check whether the enclosing function already takes that parameter.** `grep 'fs\.readFile.*\.channel_name' compiler/src` to enumerate readers. For `LocalBinding[]`, `ParameterBinding[]`, and `TypeContext`, readers almost always already have the param.
+4. **Replace the file read with the in-memory lookup.** Prefer existing helpers (`find_local_binding`, `find_parameter_binding`, `find_struct_info_by_name`) over rewriting parser logic inline.
+5. **If the enclosing function does _not_ have the parameter:** add it to the signature and update every caller. Blast radius is usually one hop. Do not introduce new wrapper structs unless two or more params need to travel together.
+6. **Delete the writer.** The channel is gone.
+7. **Rebuild (`make rebuild`) to confirm self-hosting still succeeds.** This is the critical gate — if the v0.1.1-seed-era fallback was actually still live, rebuild will fail with a resolution error and you need to examine why the in-memory path is incomplete.
+8. **Measure the determinism delta.** Run the emit-sweep against a heavy module (e.g. `compiler/src/parser/expressions.sfn`) 20+ times; distinct hash counts should strictly decrease. Record the before/after in the Completed Work entry.
+9. **Delete dead imports.** `index_of`/`substring` in particular often become unused once the file-parsing loop is gone.
+
+If step 7 fails, the channel is not purely a workaround — some caller is relying on the file as actual storage. That case is out of scope for a simple channel removal and needs to be addressed with an explicit in-memory struct (Phase 0 arena may also be required before it is safe).
+
+#### Remaining targets by priority:
 
 1. **Instruction dispatch channel** (45 refs in `instructions_dispatch.sfn`) — hottest path
 2. **Let result channel** (32 refs in `instructions_let.sfn`) — per-let-binding overhead
@@ -260,7 +280,7 @@ With memory management solved, resume replacing filesystem IPC with direct struc
 4. **Function metadata channel** (13 refs in `lowering_phase_functions.sfn`) — per-function overhead
 5. **Context functions serialization** (14 refs in `lowering_phase_types.sfn`) — per-module overhead
 6. **Module globals channel** (18 refs in `module_globals.sfn`)
-7. **Remaining channels** (emission, self-field, async, coerce, condition locals)
+7. **Remaining channels** (emission, self-field, async, coerce)
 
 Named IPC functions to eliminate:
 - `_write_block_result_files()` — `instructions_helpers.sfn:122`
@@ -315,6 +335,33 @@ This requires the compiler to support a "compile module" entry point that takes 
 ### Phase 1 Array Accumulator Sweep (April 15, `d2d0bf1` + `220c8b7`)
 
 **Status: Partially implemented.** Converted `extend_string_lines` to in-place `push()` and replaced ~50 `.concat([x])` loop-accumulator sites. Two functions (`concat_native_functions`, `append_local_binding`) were reverted in `220c8b7` because callers depend on the input array staying pristine; those remain copy-based and are now tracked as Phase 1b.
+
+### Condition Locals IPC Channel Removal (April 17)
+
+**Status: Implemented.** Removed the `.condition_locals` file IPC channel — a v0.1.1-seed-era workaround for array-of-struct parameter ABI corruption that is no longer needed on the 0.5.x seed lineage. The writer in `instructions_condition.sfn` built a tab-separated view of every `LocalBinding` and wrote it to `build/sailfin/.condition_locals` immediately before calling `lower_expression`; four readers (`type_context_queries.sfn`, `core_member_lowering.sfn`, `core_call_resolution.sfn`, `core_member_helpers.sfn`) re-parsed that file as a fallback to their in-memory `locals` parameter.
+
+This channel was the first concrete source proven responsible for silent LLVM IR miscompilation on macOS arm64: when two passes' file writes and reads interleaved unpredictably within a single emit, entire source-level blocks (e.g. `if tok.kind.variant == "EndOfFile" { break; }` inside `parse_block_for_lambda`) dropped out of the generated IR, which then passed `llvm-as` validation but produced binaries that segfaulted on any parse input.
+
+**Determinism delta (emit `llvm` x 20 runs on macOS arm64, same seed):**
+
+| Module | Baseline (seed 0.5.5 pre-change) | New compiler (post-change) |
+|--------|----------------------------------|-----------------------------|
+| `compiler/src/parser/expressions.sfn` | 4/30 divergent (5 distinct hashes) | 0/20 divergent (1 hash) |
+| `compiler/src/llvm/lowering/lowering_core.sfn` | intermittently dropped all user fns | 0/20 divergent (1 hash) |
+| `compiler/src/llvm/expression_lowering/native/core.sfn` | (not measured baseline) | 0/20 divergent |
+| `compiler/src/parser/statements.sfn` | (not measured baseline) | 1/20 divergent (other channels) |
+
+The three large modules that previously flaked are now fully deterministic. The residual 1/20 flake on `parser/statements.sfn` is driven by other scratch channels still active (call-result, struct-info, instr-fn-name) and will be eliminated as subsequent Phase 2 channels are removed.
+
+Concurrently, the `build.sh` retry loop went from 3 `invalid_ir` retries per full build (`core_operands`, `core_parsing`, `instructions_helpers`) down to 1 (`cli_commands`), another signal that real non-determinism volume dropped materially.
+
+**Scope of change:**
+- 1 writer deletion (`instructions_condition.sfn`)
+- 4 reader conversions to `find_local_binding(locals, name)` against the existing in-memory parameter
+- 1 signature extension (`lower_inline_gep_field_access` in `core_member_helpers.sfn` — added `locals: LocalBinding[]`, updated two call sites in `core_member_lowering.sfn`)
+- ~150 lines removed, ~15 added
+
+This is the first IPC removal under the procedure in Phase 2 above; future channel removals should follow the same 9-step pattern.
 
 ---
 


### PR DESCRIPTION
## Summary

Removes the first filesystem-IPC channel (`build/sailfin/.condition_locals`) from the LLVM lowering pipeline. This was a v0.1.1-seed-era workaround for array-of-struct ABI corruption; every reader already had the data in-memory as a `LocalBinding[]` parameter. The file channel has since been a source of silent miscompilation on macOS-arm64 — when concurrent writes and reads of the same dotfile interleaved within a single emit, entire source-level blocks (e.g. `if tok.kind.variant == "EndOfFile" { break; }` inside `parse_block_for_lambda`) dropped out of the emitted IR, passed `llvm-as` validation, and produced binaries that segfaulted on any parse input.

This is the first IPC removal under the new 9-step procedure added to `docs/build-performance.md` Phase 2. Subsequent channels should follow the same shape.

## What changed

- `compiler/src/llvm/lowering/instructions_condition.sfn` — delete writer (17 lines of `fs.writeLines` + building the tab-separated snapshot).
- `compiler/src/llvm/type_context_queries.sfn` — delete dead fallback (36 lines); the in-memory `find_local_binding(locals, ...)` path above already covered this.
- `compiler/src/llvm/expression_lowering/native/core_member_lowering.sfn` — replace file-read block with `find_local_binding`. Added `expressions_bindings` import.
- `compiler/src/llvm/expression_lowering/native/core_call_resolution.sfn` — replace file-read block with `find_local_binding` (uses the existing `./core_scopes` import).
- `compiler/src/llvm/expression_lowering/native/core_member_helpers.sfn` — add `locals: LocalBinding[]` parameter to `lower_inline_gep_field_access`, update both call sites in `core_member_lowering.sfn`.
- `docs/build-performance.md` — add *Procedure: Removing an IPC Channel* section to Phase 2; record this channel under Completed Work with the measured determinism deltas; drop `condition locals` from Phase 2's remaining-channels list.

Net diff: ~170 lines removed, ~86 added.

## Determinism delta (emit `llvm` x 20 runs, macOS arm64, new binary)

| Module | Before | After |
|---|---|---|
| `compiler/src/parser/expressions.sfn` | 4/30 divergent (5 hashes) | 0/20 divergent |
| `compiler/src/llvm/lowering/lowering_core.sfn` | intermittently dropped all user fns | 0/20 divergent |
| `compiler/src/llvm/expression_lowering/native/core.sfn` | — | 0/20 divergent |
| `compiler/src/parser/statements.sfn` | — | 1/20 (residual, from other IPC channels still active) |

`build.sh invalid_ir` retries during a full rebuild went from 3 modules (`core_operands`, `core_parsing`, `instructions_helpers`) down to 1 (`cli_commands`).

## Test impact on macOS arm64

- Before: **0/53 unit tests** passing. Every test binary segfaulted on startup because the first-pass compiler's parser had a corrupted `parse_block_for_lambda`.
- After: **52/53 unit tests** passing.

The one remaining failure (`intrinsic_declarations_test.sfn`) is **pre-existing and unrelated** — the first-pass binary miscompiles `return <expr>` statements inside top-level `fn` bodies to empty blocks (`.sfn-asm` shows `noop` where the return should be). This test was in the failing set in the original pre-change build too. It will be tracked as a separate issue.

## Test plan

- [ ] `make clean-build && make rebuild` on CI (linux-x86_64 and macos-arm64)
- [ ] `make test` on CI — expecting 52/53 pass on macOS arm64, all pass on Linux
- [ ] `sfn fmt --check` — ran locally, passing
- [ ] If macOS CI tests pass, optionally merge; if macOS CI surfaces the `intrinsic_declarations_test.sfn` failure, follow-up issue tracks that miscompilation separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)