### PR TITLE
fix(compiler): refuse implicit re-exports of imported symbols

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,6 +148,18 @@ jobs:
           fi
           echo "[canary] all canary files emit cleanly"
 
+      # Static lint: catch any new `export { X };` (no `from`) that
+      # re-exports a symbol imported from a local module path before
+      # the slow self-host build can detect it.  The Sailfin emitter
+      # also rejects this pattern (Option B in the RCA), so this lint
+      # exists as an early-feedback signal duplicated cheaply in CI.
+      # See docs/rca/2026-04-18-reexport-diagnostic-gep.md.
+      - name: Re-export lint (catches `export { X };` of imports)
+        shell: bash {0}
+        run: |
+          set -euo pipefail
+          python3 scripts/lint_no_implicit_reexports.py compiler/src runtime
+
       - name: Enable test runner trace (macOS)
         if: runner.os == 'macOS'
         shell: bash {0}

--- a/compiler/src/emit_native.sfn
+++ b/compiler/src/emit_native.sfn
@@ -53,6 +53,7 @@ import {
     LayoutContext,
     NativeState,
     StatementDispatchResult,
+    append_string,
     append_unique,
     builder_to_string,
     join_type_annotations,
@@ -65,7 +66,7 @@ import {
     state_pop_indent,
     state_push_indent
 } from "./emit_native_state";
-import { char_code } from "./string_utils";
+import { char_code, contains_string, substring } from "./string_utils";
 
 // ── Public data structures ───────────────────────────────────────────
 struct NativeModule {
@@ -851,4 +852,162 @@ fn count_exported_symbols(program: Program) -> number {
         index += 1;
     }
     return count;
+}
+
+// ── Re-export validation ─────────────────────────────────────────────
+// Refuse `export { X };` where X is only imported (no local definition)
+// and the import source is a local module path.  The emitter produces no
+// `.fn X` entry in the re-exporter's .sfn-asm for such symbols, so any
+// consumer that imports X through this module loses the real signature
+// and silently miscompiles (boolean returns drop `if` guards).
+//
+// Imports from non-local paths (e.g. "runtime/prelude") are resolved via
+// the runtime helper descriptor table in compiler/src/llvm/runtime_helpers.sfn
+// rather than the re-exporter's .sfn-asm, so they are exempt.
+//
+// See docs/rca/2026-04-18-reexport-diagnostic-gep.md.
+fn collect_reexport_violations(program: Program) -> string[] {
+    let local_defs = collect_local_definition_names(program);
+    let mut violations: string[] = [];
+    let mut index: number = 0;
+    loop {
+        if index >= program.statements.length { break; }
+        let statement = program.statements[index];
+        if statement.variant == "ExportDeclaration" {
+            if statement.source.length == 0 {
+                let mut spec_index: number = 0;
+                loop {
+                    if spec_index >= statement.export_specifiers.length { break; }
+                    let spec = statement.export_specifiers[spec_index];
+                    if !contains_string(local_defs, spec.name) {
+                        let origin = find_local_import_source(program, spec.name);
+                        if origin.length > 0 {
+                            if is_local_module_path(origin) {
+                                violations = append_string(
+                                    violations,
+                                    format_reexport_violation(spec.name, origin)
+                                );
+                            }
+                        }
+                    }
+                    spec_index += 1;
+                }
+            }
+        }
+        index += 1;
+    }
+    return violations;
+}
+
+fn collect_local_definition_names(program: Program) -> string[] {
+    let mut names: string[] = [];
+    let mut index: number = 0;
+    loop {
+        if index >= program.statements.length { break; }
+        let stmt = program.statements[index];
+        if stmt.variant == "FunctionDeclaration" {
+            names = append_unique(names, stmt.signature.name);
+        }
+        if stmt.variant == "ExternFunctionDeclaration" {
+            names = append_unique(names, stmt.signature.name);
+        }
+        if stmt.variant == "PipelineDeclaration" {
+            names = append_unique(names, stmt.signature.name);
+        }
+        if stmt.variant == "ToolDeclaration" {
+            names = append_unique(names, stmt.signature.name);
+        }
+        if stmt.variant == "StructDeclaration" {
+            names = append_unique(names, stmt.name);
+        }
+        if stmt.variant == "EnumDeclaration" {
+            names = append_unique(names, stmt.name);
+        }
+        if stmt.variant == "InterfaceDeclaration" {
+            names = append_unique(names, stmt.name);
+        }
+        if stmt.variant == "TypeAliasDeclaration" {
+            names = append_unique(names, stmt.name);
+        }
+        if stmt.variant == "ModelDeclaration" {
+            names = append_unique(names, stmt.name);
+        }
+        if stmt.variant == "VariableDeclaration" {
+            names = append_unique(names, stmt.name);
+        }
+        if stmt.variant == "TestDeclaration" {
+            names = append_unique(names, stmt.name);
+        }
+        index += 1;
+    }
+    return names;
+}
+
+// Return the import source path for a symbol name, matching against the
+// locally-visible name (the alias when one is present and non-empty,
+// otherwise the original name).  Returns "" if no matching import is
+// found.
+fn find_local_import_source(program: Program, name: string) -> string {
+    let mut index: number = 0;
+    loop {
+        if index >= program.statements.length { break; }
+        let stmt = program.statements[index];
+        if stmt.variant == "ImportDeclaration" {
+            let mut spec_index: number = 0;
+            loop {
+                if spec_index >= stmt.import_specifiers.length { break; }
+                let spec = stmt.import_specifiers[spec_index];
+                if specifier_local_name(spec.name, spec.alias) == name {
+                    return stmt.source;
+                }
+                spec_index += 1;
+            }
+        }
+        index += 1;
+    }
+    return "";
+}
+
+fn specifier_local_name(name: string, alias: string?) -> string {
+    let mut _no_alias: boolean = false;
+    if alias == null { _no_alias = true; }
+    if alias.length == 0 { _no_alias = true; }
+    if _no_alias { return name; }
+    return "" + alias;
+}
+
+fn is_local_module_path(path: string) -> boolean {
+    if path.length >= 2 {
+        if substring(path, 0, 2) == "./" { return true; }
+    }
+    if path.length >= 3 {
+        if substring(path, 0, 3) == "../" { return true; }
+    }
+    return false;
+}
+
+fn format_reexport_violation(symbol: string, origin: string) -> string {
+    return "`export { " + symbol + " };` re-exports a symbol imported from \""
+        + origin
+        + "\" but there is no local `fn "
+        + symbol
+        + "` definition.  Sailfin does not support re-exporting imported symbols: "
+        + "the emitter produces no `.fn` signature for them, so consumers silently "
+        + "fall back to `i8*` and miscompile boolean `if` guards.  Fix: remove `"
+        + symbol
+        + "` from this module's export block and have consumers import it "
+        + "directly from \""
+        + origin
+        + "\", or add a local `fn "
+        + symbol
+        + "(...)` forwarder.  See docs/rca/2026-04-18-reexport-diagnostic-gep.md.";
+}
+
+fn report_reexport_violations(violations: string[]) ![io] {
+    let mut index: number = 0;
+    loop {
+        if index >= violations.length { break; }
+        print.err("[emit-native] " + violations[index]);
+        index += 1;
+    }
 }

--- a/compiler/src/emit_native.sfn
+++ b/compiler/src/emit_native.sfn
@@ -877,16 +877,15 @@ fn collect_reexport_violations(program: Program) -> string[] {
             if statement.source.length == 0 {
                 let mut spec_index: number = 0;
                 loop {
-                    if spec_index >= statement.export_specifiers.length { break; }
+                    if spec_index >= statement.export_specifiers.length {
+                        break;
+                    }
                     let spec = statement.export_specifiers[spec_index];
                     if !contains_string(local_defs, spec.name) {
                         let origin = find_local_import_source(program, spec.name);
                         if origin.length > 0 {
                             if is_local_module_path(origin) {
-                                violations = append_string(
-                                    violations,
-                                    format_reexport_violation(spec.name, origin)
-                                );
+                                violations = append_string(violations, format_reexport_violation(spec.name, origin));
                             }
                         }
                     }
@@ -989,18 +988,18 @@ fn is_local_module_path(path: string) -> boolean {
 fn format_reexport_violation(symbol: string, origin: string) -> string {
     return "`export { " + symbol + " };` re-exports a symbol imported from \""
         + origin
-        + "\" but there is no local `fn "
+        + "\" but there is no local definition of `"
         + symbol
-        + "` definition.  Sailfin does not support re-exporting imported symbols: "
+        + "` in this module.  Sailfin does not support implicit re-exports of imported symbols: "
         + "the emitter produces no `.fn` signature for them, so consumers silently "
         + "fall back to `i8*` and miscompile boolean `if` guards.  Fix: remove `"
         + symbol
         + "` from this module's export block and have consumers import it "
         + "directly from \""
         + origin
-        + "\", or add a local `fn "
+        + "\", or add a local definition or forwarder for `"
         + symbol
-        + "(...)` forwarder.  See docs/rca/2026-04-18-reexport-diagnostic-gep.md.";
+        + "` in this module.  See docs/rca/2026-04-18-reexport-diagnostic-gep.md.";
 }
 
 fn report_reexport_violations(violations: string[]) ![io] {

--- a/compiler/src/main.sfn
+++ b/compiler/src/main.sfn
@@ -4,10 +4,12 @@
 import { Program } from "./ast";
 import {
     NativeModule,
+    collect_reexport_violations,
     emit_native,
     emit_native_text_to_file_with_module_name,
     emit_native_text_with_module_name,
-    emit_native_with_module_name
+    emit_native_with_module_name,
+    report_reexport_violations
 } from "./emit_native";
 import { emit_program } from "./emitter_sailfin";
 import {
@@ -39,6 +41,17 @@ fn _timing_line(module_name: string, phase: string, elapsed_ms: number) -> strin
         + number_to_string(elapsed_ms);
 }
 
+// Refuse compilation when any `export { X };` in this module re-exports
+// an imported symbol without a local definition.  Reports each violation
+// via print.err and returns true if the caller should bail.  See
+// docs/rca/2026-04-18-reexport-diagnostic-gep.md.
+fn _reject_reexport_violations(program: Program) -> boolean ![io] {
+    let violations = collect_reexport_violations(program);
+    if violations.length == 0 { return false; }
+    report_reexport_violations(violations);
+    return true;
+}
+
 fn compile_to_sailfin(source: string) -> string ![io] {
     let program: Program = parse_program(source);
     if typecheck_has_errors(program) {
@@ -46,6 +59,7 @@ fn compile_to_sailfin(source: string) -> string ![io] {
         report_typecheck_errors(diagnostics, source);
         return "";
     }
+    if _reject_reexport_violations(program) { return ""; }
     return emit_program(program);
 }
 
@@ -134,6 +148,7 @@ fn compile_to_llvm(source: string) -> string ![io] {
         report_typecheck_errors(diagnostics, source);
         return "";
     }
+    if _reject_reexport_violations(program) { return ""; }
     let trace_emit = fs.exists("build/sailfin/.trace_emit");
     let native_text = emit_native_text_with_module_name(program, "main");
     if trace_emit {
@@ -178,6 +193,7 @@ fn compile_to_llvm_with_module(source: string, module_name: string) -> string ![
     } else {
         print.err("emit-llvm: skipping typecheck (build/sailfin/.skip_typecheck present)");
     }
+    if _reject_reexport_violations(program) { return ""; }
     let trace_emit = fs.exists("build/sailfin/.trace_emit");
     let native_text = emit_native_text_with_module_name(program, module_name);
     if trace_emit {
@@ -228,6 +244,11 @@ fn compile_to_llvm_with_module_timed(source: string, module_name: string) -> str
     } else {
         t_typecheck = _ms_since(t1);
         print.err("emit-llvm: skipping typecheck (build/sailfin/.skip_typecheck present)");
+    }
+    if _reject_reexport_violations(program) {
+        print.err(_timing_line(module_name, "parse", t_parse));
+        print.err(_timing_line(module_name, "typecheck", t_typecheck));
+        return "";
     }
 
     let t2 = monotonic_millis();
@@ -299,6 +320,7 @@ fn compile_tests_to_llvm_file_with_module(source: string, module_name: string, o
         report_typecheck_errors(diagnostics, source);
         return false;
     }
+    if _reject_reexport_violations(program) { return false; }
     if trace {
         print.err("test compiler: emit_native_with_module_name start (module="
             + module_name
@@ -342,6 +364,7 @@ fn compile_to_native_text_with_module(source: string, module_name: string) -> st
         report_typecheck_errors(diagnostics, source);
         return "";
     }
+    if _reject_reexport_violations(program) { return ""; }
     let trace_emit = fs.exists("build/sailfin/.trace_emit");
     let text = emit_native_text_with_module_name(program, module_name);
     if trace_emit {
@@ -362,6 +385,7 @@ fn write_native_text_file_with_module(source: string, module_name: string, out_p
         report_typecheck_errors(diagnostics, source);
         return false;
     }
+    if _reject_reexport_violations(program) { return false; }
     return emit_native_text_to_file_with_module_name(program, module_name, out_path);
 }
 
@@ -440,6 +464,7 @@ fn compile_to_llvm_file_with_module(source: string, module_name: string, out_pat
     } else {
         print.err("emit-llvm-file: skipping typecheck (build/sailfin/.skip_typecheck present)");
     }
+    if _reject_reexport_violations(program) { return false; }
 
     let native_text_path = "build/sailfin/emit-native.tmp";
     if fs.exists(native_text_path) { fs.deleteFile(native_text_path); }

--- a/compiler/tests/e2e/test_reexport.sh
+++ b/compiler/tests/e2e/test_reexport.sh
@@ -10,11 +10,27 @@
 # "undefined reference" at link time.
 #
 # See docs/rca/2026-04-18-reexport-diagnostic-gep.md for the full
-# story.  This test is currently an **xfail marker** — it documents
-# the expected failure shape and reports it clearly without blocking
-# CI.  When the compiler-side fix lands (either emitter-side forwarder
-# or compile-time refusal with diagnostic), the expected-failure path
-# goes away and the test will flip to a real regression gate.
+# story.  Two outcomes count as "fixed":
+#
+#   BUG_FIXED_REFUSE   — Option B: the emitter refuses to compile the
+#                        re-exporter and prints a clear diagnostic.
+#                        We confirm by trying to emit middle.sfn alone
+#                        (no inlining) and checking the error message.
+#   BUG_FIXED_FORWARDER — Option A: the emitter synthesises a local
+#                        forwarder so consumers can resolve the symbol.
+#                        We confirm by building+running main.sfn and
+#                        verifying every `-ok` line.
+#
+# Two outcomes count as "still broken":
+#
+#   EXPECTED_BUG_LINK   — linker can't find `sym__middle` (the most
+#                         common manifestation under the original
+#                         compiler).
+#   EXPECTED_BUG_GUARDS — binary builds and runs but prints `FAIL`
+#                         lines (dropped `if` guards from the i8*
+#                         fallback).
+#
+# Anything else is UNEXPECTED and fails the test loud.
 #
 # Fixture:
 #   fixtures/reexport/origin.sfn  — defines the helpers
@@ -39,39 +55,51 @@ else
     exit 1
 fi
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FIXTURE="$SCRIPT_DIR/fixtures/reexport"
 
-# Classify the build+run outcome into one of:
-#   EXPECTED_BUG_LINK    — linker can't find `sym__middle` (most
-#                          common manifestation under current compiler)
-#   EXPECTED_BUG_GUARDS  — binary builds and runs but prints FAIL
-#                          lines (dropped `if` guards)
-#   BUG_FIXED            — binary prints all six `-ok` lines cleanly
-#   UNEXPECTED           — something else went wrong
-outcome() {
-    local out_dir exe build_log output
-    out_dir="$(mktemp -d)"
-    exe="$out_dir/reexport_main"
-    build_log="$out_dir/build.log"
+# Marker phrase the Option B emitter prints when it refuses an illegal
+# implicit re-export.  Must match the diagnostic in
+# emit_native.sfn:format_reexport_violation.
+REEXPORT_REFUSE_MARKER="re-exports a symbol imported from"
 
-    # Build from a tempdir so `build/sailfin/` scratch files don't
-    # pollute the fixture directory.  `sfn build` resolves relative
-    # imports from the source file's own location, so absolute paths
-    # work from any cwd.
-    local fixture="$SCRIPT_DIR/fixtures/reexport"
-    if (cd "$out_dir" && "$BINARY" build -o "$exe" "$fixture/main.sfn") \
+# Try compiling middle.sfn alone via `sfn emit native`.  This goes
+# straight through parse → typecheck → emit without the link step
+# (middle.sfn has no `fn main`) and without the inline-imports text
+# rewrite (only `sfn run` does that).  The parsed AST therefore
+# carries the bare re-export shape and the Option B validator can
+# fire.  Returns 0 (compile succeeded — Option B not active) or
+# non-zero (compile rejected — likely the refusal we want).
+try_compile_middle() {
+    local out_dir="$1"
+    local log="$2"
+    local middle_asm="$out_dir/middle.sfn-asm"
+    (cd "$out_dir" && "$BINARY" emit -o "$middle_asm" native "$FIXTURE/middle.sfn") \
+        > "$log" 2>&1
+}
+
+# Classify the outcome of building + running main.sfn end-to-end.
+# Returns:
+#   0 → BUG_FIXED_FORWARDER   (Option A — every `-ok` line printed)
+#   1 → EXPECTED_BUG_LINK     (linker can't find `__middle` symbol)
+#   2 → EXPECTED_BUG_GUARDS   (binary built, but `FAIL` lines printed)
+#   3 → UNEXPECTED            (anything else)
+classify_full_build() {
+    local out_dir="$1"
+    local exe="$out_dir/reexport_main"
+    local build_log="$out_dir/build.log"
+    local output
+
+    if (cd "$out_dir" && "$BINARY" build -o "$exe" "$FIXTURE/main.sfn") \
             > "$build_log" 2>&1; then
-        # Build succeeded.  Run and look at output.
         if ! output="$("$exe" 2>&1)"; then
             echo "[outcome] UNEXPECTED: binary built but exited non-zero"
             echo "$output"
-            rm -rf "$out_dir"
-            return 2
+            return 3
         fi
-        rm -rf "$out_dir"
         if echo "$output" | grep -q FAIL; then
             echo "[outcome] EXPECTED_BUG_GUARDS"
             echo "$output"
-            return 1
+            return 2
         fi
         local expected all_ok=1
         for expected in \
@@ -87,12 +115,12 @@ outcome() {
             fi
         done
         if [ "$all_ok" -eq 1 ]; then
-            echo "[outcome] BUG_FIXED"
+            echo "[outcome] BUG_FIXED_FORWARDER (Option A)"
             return 0
         fi
         echo "[outcome] UNEXPECTED: built, ran, no FAIL lines, but some \`-ok\` lines missing"
         echo "$output"
-        return 2
+        return 3
     fi
 
     # Build failed.  Classify based on stderr.  The "symbol not found
@@ -108,34 +136,59 @@ outcome() {
             && grep -q '__middle' "$build_log"; then
         echo "[outcome] EXPECTED_BUG_LINK"
         tail -15 "$build_log"
-        rm -rf "$out_dir"
         return 1
     fi
 
     echo "[outcome] UNEXPECTED: build failed with an error other than the known linker miss"
     tail -20 "$build_log"
-    rm -rf "$out_dir"
-    return 2
+    return 3
 }
 
+out_dir="$(mktemp -d)"
+trap 'rm -rf "$out_dir"' EXIT
+
+middle_log="$out_dir/middle-build.log"
 out_rc=0
-outcome || out_rc=$?
+
+# Step 1: Direct test of Option B — compile middle.sfn alone.
+# `sfn build` does NOT inline relative imports, so the parsed AST
+# contains the bare re-export pattern that the validator must reject.
+if try_compile_middle "$out_dir" "$middle_log"; then
+    # middle.sfn compiled.  Option B not active.  Fall through to the
+    # full build/run path to detect Option A or remaining bug shapes.
+    echo "[outcome] middle.sfn compile succeeded — Option B not active"
+    echo "[outcome] checking full build+run for Option A or stale bug"
+    classify_full_build "$out_dir" || out_rc=$?
+else
+    if grep -q "$REEXPORT_REFUSE_MARKER" "$middle_log"; then
+        echo "[outcome] BUG_FIXED_REFUSE (Option B)"
+        grep "$REEXPORT_REFUSE_MARKER" "$middle_log" | head -2
+        out_rc=0
+    else
+        echo "[outcome] UNEXPECTED: middle.sfn compile failed with an error other than the re-export diagnostic"
+        tail -20 "$middle_log"
+        out_rc=3
+    fi
+fi
 
 case "$out_rc" in
     0)
         echo ""
-        echo "[test] PASS: reexport bug appears FIXED — this test should be"
-        echo "[test]       promoted to a hard regression gate in CI."
+        echo "[test] PASS: re-export bug FIXED — the compiler now handles"
+        echo "[test]       \`export { X };\` of an imported symbol correctly."
         echo "[test]       See docs/rca/2026-04-18-reexport-diagnostic-gep.md."
         ;;
-    1)
+    1 | 2)
         echo ""
-        echo "[test] PASS (xfail): reexport bug reproduced in the expected shape."
-        echo "[test]                Compiler-side fix still pending; see RCA."
+        echo "[test] FAIL (xfail flipped to hard fail): re-export bug reproduced."
+        echo "[test]        The compiler-side fix landed in this branch but the"
+        echo "[test]        regression came back.  See"
+        echo "[test]        docs/rca/2026-04-18-reexport-diagnostic-gep.md."
+        exit 1
         ;;
     *)
         echo ""
-        echo "[test] FAIL: reexport fixture failed in an unexpected way."
+        echo "[test] FAIL: re-export fixture failed in an unexpected way."
         echo "[test]       Either the fixture broke or a new miscompile"
         echo "[test]       shape appeared.  Investigate before merging."
         exit 1

--- a/docs/rca/2026-04-18-reexport-diagnostic-gep.md
+++ b/docs/rca/2026-04-18-reexport-diagnostic-gep.md
@@ -5,7 +5,7 @@
 - **Severity:** High — blocked triple-pass `make check`, blocked seed advancement past 0.5.3-alpha.1
 - **Affected releases:** 0.5.4, 0.5.5, 0.5.6 (the binary artifacts, not the source history)
 - **Resolved by:** [`v0.5.7`](https://github.com/SailfinIO/sailfin/releases/tag/v0.5.7) — first release built from a source tree where `native_ir_utils_text.sfn` defines `starts_with`/`strip_prefix` locally (`dc3c40e`), so the re-exporter's `.sfn-asm` emits real `.fn` entries consumers can resolve against.
-- **Status:** Immediate blocker cleared; `0.5.7` is now the canonical seed across CI, release-tag, and nightly. Underlying compiler bug (the emitter does not produce `.fn` signatures for re-exported imports) is still present in the binary and is tracked as a 1.0-blocker follow-up.
+- **Status:** Closed.  The 0.5.7 release worked around the bug at the source level (commit `dc3c40e` defines `starts_with`/`strip_prefix` locally in `native_ir_utils_text.sfn`) and is the canonical seed across CI, release-tag, and nightly.  The underlying compiler bug is now fixed at the emitter: implicit re-exports of imported symbols are refused with a clear diagnostic.  See [Compiler fix](#compiler-fix) below.
 
 ## TL;DR
 
@@ -527,6 +527,31 @@ This runs in under 30 seconds and does not require a full build. Any
 CI-equivalent health check that runs this single emit on every module
 after a build would have caught the bug immediately. Add this to CI as a
 cheap pre-check.
+
+## Compiler fix
+
+The compiler now implements **Option B** from the [Recommended audit and design work](#recommended-audit-and-design-work) section: the emitter refuses to compile any module containing `export { X };` (no `from` clause) where `X` is imported from a local module path (`./X` or `../X`) and has no local `fn`/`struct`/`enum`/`interface`/`type` definition.  Rejected compiles fail with a diagnostic that names the symbol, the import path, and a fix-it suggestion (import directly from the origin or add a local forwarder).
+
+### Why Option B
+
+1. **No ABI cost.**  The forwarder (Option A) would require the emitter to know the return type of the re-exported symbol at emit time, which the per-file emitter currently does not — origin signatures live in another file's `.sfn-asm`.  Threading that information through would be invasive.
+2. **The RCA already recommended it.**  The "Recommended audit and design work" section called Option B "the least surprising of the three, has no ABI cost, and the `7f47f70` commit already set the precedent by importing from the origin."
+3. **Zero in-tree fallout.**  An audit of every implicit `export { X };` block in `compiler/src/` and `runtime/` (see `scripts/lint_no_implicit_reexports.py`) found no remaining violations after the 0.5.7 source-level workaround landed.  The seven re-exports in `compiler/src/string_utils.sfn` (`clamp`, `substring`, `find_char`, `grapheme_count`, `grapheme_at`, `char_code`, `strings_equal`) are all re-exports of `runtime/prelude` symbols and are exempt: they resolve via the runtime helper descriptor table in `compiler/src/llvm/runtime_helpers.sfn`, not via the re-exporter's `.sfn-asm`, so they were never broken.
+
+### Carve-out: `runtime/prelude` and capsule paths
+
+The validator only fires for imports whose source path starts with `./` or `../` (i.e. relative module references).  Imports from `runtime/prelude`, capsule scopes (`sfn/cli`, `acme/foo`), and any other non-relative path are exempt because the consumer-side LLVM lowering resolves their signatures from the runtime helper descriptor table (`compiler/src/llvm/runtime_helpers.sfn`), not from the imported module's `.sfn-asm`.  This preserves the existing behaviour of `string_utils.sfn` and similar prelude-bridging modules while still catching the dangerous local-module-re-export pattern.
+
+### Where it lives
+
+- `compiler/src/emit_native.sfn:collect_reexport_violations` — the validator.
+- `compiler/src/main.sfn:_reject_reexport_violations` — the IO-effect reporter, called from every `compile_to_llvm*` and `compile_to_native_text*` path right after typecheck.
+- `scripts/lint_no_implicit_reexports.py` — the equivalent textual lint, wired into `.github/workflows/ci.yml` so PR authors see the failure in seconds rather than waiting for the ~13-minute self-host build.
+- `compiler/tests/e2e/test_reexport.sh` — the regression gate.  It tries to compile `fixtures/reexport/middle.sfn` (which has the bare bug shape) directly; the test passes when the emitter refuses with the expected diagnostic.
+
+### Inline `export { X } from "./path"` is out of scope
+
+The inline form (used by vestigial barrel modules like `compiler/src/llvm/expressions.sfn`) is a separate statement shape and is **not** rejected by this fix.  Those barrels currently have no consumers and would suffer the same bug if any consumer arrived.  Tightening the validator to cover the inline form is tracked as a 1.0 follow-up; see `docs/proposals/module-system-1.0.md` (TBD).
 
 ## Links
 

--- a/docs/rca/2026-04-18-reexport-diagnostic-gep.md
+++ b/docs/rca/2026-04-18-reexport-diagnostic-gep.md
@@ -551,7 +551,7 @@ The validator only fires for imports whose source path starts with `./` or `../`
 
 ### Inline `export { X } from "./path"` is out of scope
 
-The inline form (used by vestigial barrel modules like `compiler/src/llvm/expressions.sfn`) is a separate statement shape and is **not** rejected by this fix.  Those barrels currently have no consumers and would suffer the same bug if any consumer arrived.  Tightening the validator to cover the inline form is tracked as a 1.0 follow-up; see `docs/proposals/module-system-1.0.md` (TBD).
+The inline form (used by vestigial barrel modules like `compiler/src/llvm/expressions.sfn`) is a separate statement shape and is **not** rejected by this fix.  Those barrels currently have no consumers and would suffer the same bug if any consumer arrived.  Tightening the validator to cover the inline form is tracked as an unscheduled 1.0 follow-up (the module-system proposal called out in the "Recommended audit and design work" section above has not yet been written).
 
 ## Links
 

--- a/scripts/lint_no_implicit_reexports.py
+++ b/scripts/lint_no_implicit_reexports.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Lint: refuse `export { X };` (no `from` clause) where X is imported
+from a local module path (./X or ../X) and has no local definition.
+
+This is the textual equivalent of the Sailfin emitter's Option-B check
+in compiler/src/emit_native.sfn:collect_reexport_violations.  Running
+it here gives PR authors immediate feedback without waiting for the
+~13-minute self-host build to surface the same diagnostic.
+
+Usage: scripts/lint_no_implicit_reexports.py <root> [<root> ...]
+
+Exits 0 if no violations.  Exits 1 with one line per violation otherwise.
+
+Symbols imported from non-local paths (e.g. "runtime/prelude" or
+"sfn/cli") are exempt — runtime helpers are resolved via the runtime
+helper descriptor table in compiler/src/llvm/runtime_helpers.sfn rather
+than the re-exporter's .sfn-asm, so they do not trigger the bug.
+
+See docs/rca/2026-04-18-reexport-diagnostic-gep.md for the underlying
+miscompile.
+"""
+from __future__ import annotations
+
+import os
+import re
+import sys
+
+IMPORT_RE = re.compile(
+    r"^\s*import\s*\{([^}]*)\}\s*from\s*\"([^\"]+)\"",
+    re.MULTILINE,
+)
+EXPORT_RE = re.compile(
+    r"^\s*export\s*\{([^}]*)\}\s*;",
+    re.MULTILINE | re.DOTALL,
+)
+LOCAL_DECL_RE = re.compile(
+    r"^\s*(?:async\s+)?(?:unsafe\s+)?(?:extern\s+)?"
+    r"(?:fn|struct|enum|interface|type|model|pipeline|tool)\s+"
+    r"([A-Za-z_][A-Za-z0-9_]*)",
+    re.MULTILINE,
+)
+
+
+def parse_specifier_list(text: str) -> list[tuple[str, str | None]]:
+    """Return list of (name, alias-or-None) tuples from `{a, b as c, d}`."""
+    out: list[tuple[str, str | None]] = []
+    for raw in text.split(","):
+        item = raw.strip()
+        if not item:
+            continue
+        if " as " in item:
+            name, _, alias = item.partition(" as ")
+            out.append((name.strip(), alias.strip()))
+        else:
+            out.append((item, None))
+    return out
+
+
+def is_local_module_path(path: str) -> bool:
+    return path.startswith("./") or path.startswith("../")
+
+
+def lint_file(path: str) -> list[str]:
+    """Return human-readable violation messages for `path` (empty if clean)."""
+    try:
+        with open(path, encoding="utf-8") as fh:
+            text = fh.read()
+    except (OSError, UnicodeDecodeError):
+        return []
+
+    # Build the table of imported names → source path (using the
+    # locally-visible name, i.e. alias when present).
+    imports: dict[str, str] = {}
+    for match in IMPORT_RE.finditer(text):
+        source = match.group(2)
+        for name, alias in parse_specifier_list(match.group(1)):
+            local = alias if alias else name
+            imports[local] = source
+
+    # Collect locally defined names.
+    locals_set: set[str] = {m.group(1) for m in LOCAL_DECL_RE.finditer(text)}
+
+    # Scan implicit `export { ... };` (no `from`) blocks.  EXPORT_RE
+    # requires a trailing `;` immediately after `}`, so the inline form
+    # `export { ... } from "..."` is automatically excluded.
+    violations: list[str] = []
+    for match in EXPORT_RE.finditer(text):
+        for name, _alias in parse_specifier_list(match.group(1)):
+            if name in locals_set:
+                continue
+            origin = imports.get(name)
+            if origin is None:
+                continue
+            if not is_local_module_path(origin):
+                continue
+            violations.append(
+                f'{path}: `export {{ {name} }};` re-exports a symbol '
+                f'imported from "{origin}" but there is no local '
+                f'`fn {name}` definition. Sailfin does not support '
+                f'implicit re-exports of imported symbols. '
+                f'Fix: remove `{name}` from this module\'s export '
+                f'block and import it directly from "{origin}", or '
+                f'add a local `fn {name}(...)` forwarder.'
+            )
+    return violations
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 2:
+        print(f"usage: {argv[0]} <root> [<root> ...]", file=sys.stderr)
+        return 2
+
+    paths: list[str] = []
+    for root in argv[1:]:
+        if os.path.isfile(root) and root.endswith(".sfn"):
+            paths.append(root)
+            continue
+        for dirpath, _dirs, files in os.walk(root):
+            for name in files:
+                if name.endswith(".sfn"):
+                    paths.append(os.path.join(dirpath, name))
+
+    paths.sort()
+
+    all_violations: list[str] = []
+    for path in paths:
+        all_violations.extend(lint_file(path))
+
+    if all_violations:
+        for line in all_violations:
+            print(line)
+        print(
+            f"\n[lint] {len(all_violations)} implicit re-export violation(s) "
+            f"across {len(paths)} file(s).",
+            file=sys.stderr,
+        )
+        print(
+            "[lint] See docs/rca/2026-04-18-reexport-diagnostic-gep.md.",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"[lint] {len(paths)} file(s) scanned; no implicit re-export violations.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/lint_no_implicit_reexports.py
+++ b/scripts/lint_no_implicit_reexports.py
@@ -39,6 +39,22 @@ LOCAL_DECL_RE = re.compile(
     r"([A-Za-z_][A-Za-z0-9_]*)",
     re.MULTILINE,
 )
+# Match top-level `let [mut] name` variable declarations.  Keep the
+# definition set aligned with the emitter's collect_local_definition_names
+# in compiler/src/emit_native.sfn so this lint does not produce false
+# positives that the compiler would accept.
+LOCAL_LET_RE = re.compile(
+    r"^\s*let\s+(?:mut\s+)?([A-Za-z_][A-Za-z0-9_]*)",
+    re.MULTILINE,
+)
+# Match top-level `test "name" { ... }` declarations.  Test names are
+# string literals, but the emitter treats the literal content as the
+# local name for re-export resolution.  Keep in sync with
+# Statement.TestDeclaration handling in emit_native.sfn.
+LOCAL_TEST_RE = re.compile(
+    r'^\s*test\s+"([^"\n]+)"',
+    re.MULTILINE,
+)
 
 
 def parse_specifier_list(text: str) -> list[tuple[str, str | None]]:
@@ -77,8 +93,13 @@ def lint_file(path: str) -> list[str]:
             local = alias if alias else name
             imports[local] = source
 
-    # Collect locally defined names.
+    # Collect locally defined names.  The set must mirror
+    # collect_local_definition_names in compiler/src/emit_native.sfn:
+    # fn / struct / enum / interface / type / model / pipeline / tool /
+    # let (variable) / test.
     locals_set: set[str] = {m.group(1) for m in LOCAL_DECL_RE.finditer(text)}
+    locals_set.update(m.group(1) for m in LOCAL_LET_RE.finditer(text))
+    locals_set.update(m.group(1) for m in LOCAL_TEST_RE.finditer(text))
 
     # Scan implicit `export { ... };` (no `from`) blocks.  EXPORT_RE
     # requires a trailing `;` immediately after `}`, so the inline form
@@ -96,11 +117,11 @@ def lint_file(path: str) -> list[str]:
             violations.append(
                 f'{path}: `export {{ {name} }};` re-exports a symbol '
                 f'imported from "{origin}" but there is no local '
-                f'`fn {name}` definition. Sailfin does not support '
+                f'definition of `{name}`. Sailfin does not support '
                 f'implicit re-exports of imported symbols. '
                 f'Fix: remove `{name}` from this module\'s export '
                 f'block and import it directly from "{origin}", or '
-                f'add a local `fn {name}(...)` forwarder.'
+                f'add a local definition of `{name}` in this module.'
             )
     return violations
 


### PR DESCRIPTION
Closes the underlying compiler bug documented in
docs/rca/2026-04-18-reexport-diagnostic-gep.md.  The 0.5.7 release
worked around the bug at the source level (dc3c40e); this change
removes the bug from the binary so it cannot recur.

Implements Option B from the RCA's "Recommended audit and design work"
section: when `export { X };` (no `from` clause) re-exports a symbol
that is imported from a local module path (./X or ../X) and has no
local `fn`/`struct`/`enum`/`interface`/`type` definition, the emitter
refuses compilation with a clear fix-it diagnostic naming the symbol,
the import path, and two ways to fix it (import directly from the
origin, or add a local forwarder).

Why Option B over Option A (forwarder synthesis):

- The forwarder requires the emitter to know the return type of the
  re-exported symbol at emit time, which the per-file emitter does
  not — origin signatures live in another file's `.sfn-asm`.
- The RCA explicitly recommended Option B as "the least surprising of
  the three, has no ABI cost, and the 7f47f70 commit already set the
  precedent by importing from the origin."
- Zero in-tree fallout: `scripts/lint_no_implicit_reexports.py`
  scans compiler/src + runtime and finds no remaining violations.

Carve-out: re-exports of symbols imported from non-local paths
(e.g. "runtime/prelude") are exempt because the consumer-side
lowering resolves those signatures via the runtime helper descriptor
table in compiler/src/llvm/runtime_helpers.sfn rather than the
re-exporter's `.sfn-asm`, so they were never affected by the bug.
This preserves the seven prelude bridges in `string_utils.sfn`
(clamp, substring, find_char, grapheme_count, grapheme_at, char_code,
strings_equal) without forcing a 39-file consumer migration.

Where the fix lives:

- compiler/src/emit_native.sfn:collect_reexport_violations and
  helpers — the validator (pure AST walk, no IO).
- compiler/src/main.sfn:_reject_reexport_violations — the IO-effect
  reporter, called right after typecheck in every compile_to_*
  entrypoint so violations surface as `[emit-native] ...` stderr
  diagnostics and a non-zero exit before any LLVM lowering runs.
- scripts/lint_no_implicit_reexports.py — textual mirror of the
  emitter check, wired into .github/workflows/ci.yml so PR authors
  get the failure within seconds rather than waiting for the full
  ~13-minute self-host build.
- compiler/tests/e2e/test_reexport.sh — flipped from xfail marker to
  a hard regression gate that compiles middle.sfn alone via
  `sfn emit native` and accepts either Option B refusal or Option A
  forwarder as "fixed".

Inline `export { X } from "./path"` (used by vestigial barrel modules
like compiler/src/llvm/expressions.sfn that have no consumers) is
out of scope for this change and tracked as a 1.0 follow-up.

https://claude.ai/code/session_013oRJkwL2YYt8H5Pg5MrGqE