### PR TITLE
Remove file-based function resolution from call lowering

### DIFF
--- a/compiler/src/cli_commands.sfn
+++ b/compiler/src/cli_commands.sfn
@@ -694,7 +694,6 @@ fn _clean_lowering_state(dir: string) -> number ![io] {
         if _has_prefix_cmd(entry, ".async_inner_") { is_scratch = true; }
         if _has_prefix_cmd(entry, ".block_result_") { is_scratch = true; }
         if _has_prefix_cmd(entry, ".call_result_") { is_scratch = true; }
-        if _has_prefix_cmd(entry, ".ctx_func_") { is_scratch = true; }
         if _has_prefix_cmd(entry, ".dispatch_") { is_scratch = true; }
         if _has_prefix_cmd(entry, ".expr_stmt_") { is_scratch = true; }
         if _has_prefix_cmd(entry, ".fn_") { is_scratch = true; }

--- a/compiler/src/cli_commands.sfn
+++ b/compiler/src/cli_commands.sfn
@@ -694,6 +694,9 @@ fn _clean_lowering_state(dir: string) -> number ![io] {
         if _has_prefix_cmd(entry, ".async_inner_") { is_scratch = true; }
         if _has_prefix_cmd(entry, ".block_result_") { is_scratch = true; }
         if _has_prefix_cmd(entry, ".call_result_") { is_scratch = true; }
+        // Legacy: .ctx_func_* IPC channel was removed but stale files from
+        // older build dirs / older seed binaries should still be swept.
+        if _has_prefix_cmd(entry, ".ctx_func_") { is_scratch = true; }
         if _has_prefix_cmd(entry, ".dispatch_") { is_scratch = true; }
         if _has_prefix_cmd(entry, ".expr_stmt_") { is_scratch = true; }
         if _has_prefix_cmd(entry, ".fn_") { is_scratch = true; }

--- a/compiler/src/llvm/expression_lowering/native/core_call_resolution.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_call_resolution.sfn
@@ -177,8 +177,9 @@ fn resolve_call_method_target(trimmed_target: string, arguments: string[], bindi
         }
     }
 
-    // File-based fallback: parse_member_access is cross-module and returns
-    // corrupted data with the v0.1.1 seed.
+    // Inline member-access fallback: parse_member_access is cross-module
+    // and historically returned corrupted data with the v0.1.1 seed, so
+    // we re-derive the struct method target from `locals` directly.
     let _pre_dot = index_of(result_target, ".");
     if _pre_dot > 0 {
         if method_operand == null {

--- a/compiler/src/llvm/expression_lowering/native/core_call_resolution.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_call_resolution.sfn
@@ -2,14 +2,8 @@
 //
 // Call target resolution extracted from core_call_lowering.sfn to keep
 // each function under ~500 .sfn-asm instructions (avoids seed OOM).
-import { NativeFunction, NativeParameter } from "../../../native_ir";
-import {
-    char_at,
-    char_code,
-    find_last_index_of_char,
-    index_of,
-    substring
-} from "../../../string_utils";
+import { NativeFunction } from "../../../native_ir";
+import { find_last_index_of_char, index_of, substring } from "../../../string_utils";
 import { is_simple_identifier } from "../../expressions_helpers";
 import { find_function_by_name } from "../../rendering_helpers";
 import { find_runtime_helper } from "../../runtime_helpers";
@@ -47,14 +41,10 @@ import { load_local_operand } from "./core_operands";
 import { parse_member_access } from "./core_parse";
 import { find_local_binding, find_parameter_binding } from "./core_scopes";
 import { sanitize_symbol } from "./core_text";
-import {
-    future_pointer_type_for_return_type,
-    map_parameter_type,
-    map_return_type
-} from "./core_type_mapping";
+import { future_pointer_type_for_return_type, map_return_type } from "./core_type_mapping";
 
 // Resolve fused concat/push targets (e.g. `valuesconcat(xs)` → `concat`).
-// Also handles file-based method resolution and parse_member_access dispatch.
+// Also handles parse_member_access dispatch and struct-method fallback.
 // Returns a CallTargetResolution with the resolved target, method operand, etc.
 fn resolve_call_method_target(trimmed_target: string, arguments: string[], bindings: ParameterBinding[], locals: LocalBinding[], current_temp: number, current_lines: string[], functions: NativeFunction[], context: TypeContext, diagnostics: string[], collected_string_constants: StringConstant[]) -> CallTargetResolution ![io] {
     let mut result_target = trimmed_target;
@@ -616,106 +606,7 @@ fn resolve_parsed_method_dispatch(result_target: string, arguments: string[], bi
     };
 }
 
-fn _parse_int_res(text: string) -> number {
-    let len = text.length;
-    if len == 0 { return 0; }
-    let mut result: number = 0;
-    let mut i: number = 0;
-    loop {
-        if i >= len { break; }
-        let ch = char_at(text, i);
-        let code = char_code(ch);
-        if code >= 48 {
-            if code <= 57 { result = result * 10 + (code - 48); }
-        }
-        i = i + 1;
-    }
-    return result;
-}
-
-fn _find_function_from_files_res(target: string) -> NativeFunction? ![io] {
-    if !fs.exists("build/sailfin/.ctx_func_count") { return null; }
-    let count_str = fs.readFile("build/sailfin/.ctx_func_count");
-    let count = _parse_int_res(count_str);
-    let mut suffix_match: NativeFunction? = null;
-    let mut suffix_match_count: number = 0;
-    let suffix_prefix = target + "__";
-    let mut idx: number = 0;
-    loop {
-        if idx >= count { break; }
-        let prefix = "build/sailfin/.ctx_func_" + number_to_string(idx);
-        if !fs.exists(prefix + "_name") { break; }
-        let fname = fs.readFile(prefix + "_name");
-        if fname == target {
-            let ret_type = fs.readFile(prefix + "_return_type");
-            let is_async_str = fs.readFile(prefix + "_is_async");
-            let is_async = is_async_str == "1";
-            let pc_str = fs.readFile(prefix + "_param_count");
-            let pc = _parse_int_res(pc_str);
-            let mut params: NativeParameter[] = [];
-            let mut j: number = 0;
-            loop {
-                if j >= pc { break; }
-                let pp = prefix + "_param_" + number_to_string(j);
-                let pname = fs.readFile(pp + "_name");
-                let ptype = fs.readFile(pp + "_type");
-                params.push(NativeParameter {
-                    name: pname, type_annotation: ptype, mutable: false, default_value: null, span: null
-                });
-                j += 1;
-            }
-            return NativeFunction {
-                name: fname,
-                return_type: ret_type,
-                is_async: is_async,
-                parameters: params,
-                effects: [],
-                decorators: [],
-                is_extern: false,
-                instructions: []
-            };
-        }
-        if starts_with(fname, suffix_prefix) {
-            suffix_match_count += 1;
-            if suffix_match_count == 1 {
-                let ret_type = fs.readFile(prefix + "_return_type");
-                let is_async_str = fs.readFile(prefix + "_is_async");
-                let is_async = is_async_str == "1";
-                let pc_str = fs.readFile(prefix + "_param_count");
-                let pc = _parse_int_res(pc_str);
-                let mut params: NativeParameter[] = [];
-                let mut j: number = 0;
-                loop {
-                    if j >= pc { break; }
-                    let pp = prefix + "_param_" + number_to_string(j);
-                    let pname = fs.readFile(pp + "_name");
-                    let ptype = fs.readFile(pp + "_type");
-                    params.push(NativeParameter {
-                        name: pname, type_annotation: ptype, mutable: false, default_value: null, span: null
-                    });
-                    j += 1;
-                }
-                suffix_match = NativeFunction {
-                    name: fname,
-                    return_type: ret_type,
-                    is_async: is_async,
-                    parameters: params,
-                    effects: [],
-                    decorators: [],
-                    is_extern: false,
-                    instructions: []
-                };
-            }
-        }
-        idx += 1;
-    }
-    if suffix_match_count == 1 { return suffix_match; }
-    return null;
-}
-
-fn _find_function_by_name_or_import(functions: NativeFunction[], target: string) -> NativeFunction? ![io] {
-    let file_result = _find_function_from_files_res(target);
-    if file_result != null { return file_result; }
+fn _find_function_by_name_or_import(functions: NativeFunction[], target: string) -> NativeFunction? {
     let exact = find_function_by_name(functions, target);
     if exact != null { return exact; }
     let suffix_prefix = target + "__";
@@ -788,115 +679,12 @@ fn resolve_call_signature(trimmed_target: string, helper_descriptor: RuntimeHelp
         result_helper = find_runtime_helper(result_target);
     }
 
-    // File-based function resolution with mapped parameter types
-    let mut _file_fn_name: string = "";
-    let mut _file_fn_return_type: string = "";
-    let mut _file_fn_is_async: boolean = false;
-    let mut _file_fn_param_types: string[] = [];
-    let mut _file_fn_found: boolean = false;
-    let _trace_ccl = fs.exists("build/sailfin/.trace_lowering");
-    if !is_trait_dispatch {
-        if result_helper == null {
-            if fs.exists("build/sailfin/.ctx_func_count") {
-                let _fl_count_str = fs.readFile("build/sailfin/.ctx_func_count");
-                let _fl_count = _parse_int_res(_fl_count_str);
-                let _fl_suffix_prefix = result_target + "__";
-                let mut _fl_suffix_idx: number = -1;
-                let mut _fl_suffix_count: number = 0;
-                let mut _fl_i: number = 0;
-                loop {
-                    if _fl_i >= _fl_count { break; }
-                    let _fl_prefix = "build/sailfin/.ctx_func_"
-                        + number_to_string(_fl_i);
-                    if !fs.exists(_fl_prefix + "_name") { break; }
-                    let _fl_name = fs.readFile(_fl_prefix + "_name");
-                    if _fl_name == result_target {
-                        _file_fn_name = _fl_name;
-                        _file_fn_return_type = fs.readFile(_fl_prefix
-                            + "_return_type");
-                        let _fl_async_str = fs.readFile(_fl_prefix + "_is_async");
-                        _file_fn_is_async = _fl_async_str == "1";
-                        let _fl_pc_str = fs.readFile(_fl_prefix + "_param_count");
-                        let _fl_pc = _parse_int_res(_fl_pc_str);
-                        let mut _fl_j: number = 0;
-                        loop {
-                            if _fl_j >= _fl_pc { break; }
-                            let _fl_ptype = fs.readFile(_fl_prefix + "_param_"
-                                + number_to_string(_fl_j)
-                                + "_type");
-                            let _fl_mapped = map_parameter_type(context, _fl_ptype);
-                            _file_fn_param_types.push(_fl_mapped);
-                            _fl_j += 1;
-                        }
-                        _file_fn_found = true;
-                        break;
-                    }
-                    if starts_with(_fl_name, _fl_suffix_prefix) {
-                        _fl_suffix_idx = _fl_i;
-                        _fl_suffix_count += 1;
-                    }
-                    _fl_i += 1;
-                }
-                if !_file_fn_found {
-                    if _fl_suffix_count == 1 {
-                        let _fl_prefix = "build/sailfin/.ctx_func_"
-                            + number_to_string(_fl_suffix_idx);
-                        _file_fn_name = fs.readFile(_fl_prefix + "_name");
-                        _file_fn_return_type = fs.readFile(_fl_prefix
-                            + "_return_type");
-                        let _fl_async_str = fs.readFile(_fl_prefix + "_is_async");
-                        _file_fn_is_async = _fl_async_str == "1";
-                        let _fl_pc_str = fs.readFile(_fl_prefix + "_param_count");
-                        let _fl_pc = _parse_int_res(_fl_pc_str);
-                        let mut _fl_j: number = 0;
-                        loop {
-                            if _fl_j >= _fl_pc { break; }
-                            let _fl_ptype = fs.readFile(_fl_prefix + "_param_"
-                                + number_to_string(_fl_j)
-                                + "_type");
-                            let _fl_mapped = map_parameter_type(context, _fl_ptype);
-                            _file_fn_param_types.push(_fl_mapped);
-                            _fl_j += 1;
-                        }
-                        _file_fn_found = true;
-                    }
-                }
-            }
-        }
-    }
-
     if !is_trait_dispatch {
         if result_helper != null {
             let descriptor = result_helper;
             llvm_return = descriptor.return_type;
             expected_params = descriptor.parameter_types;
             function_entry = null;
-        } else if _file_fn_found {
-            result_target = _file_fn_name;
-            function_entry = null;
-            if _file_fn_is_async {
-                let future_return = future_pointer_type_for_return_type(_file_fn_return_type);
-                if future_return.length == 0 {
-                    result_diagnostics.push("llvm lowering: async function `"
-                        + result_target
-                        + "` has unsupported return type `"
-                        + _file_fn_return_type
-                        + "`");
-                    llvm_return = "i8*";
-                } else { llvm_return = future_return; }
-                // Store the underlying return type so await can unbox structs
-                fs.writeFile("build/sailfin/.async_inner_return_type", _file_fn_return_type);
-                expected_params = _file_fn_param_types;
-            } else {
-                llvm_return = map_return_type(context, _file_fn_return_type);
-                if llvm_return.length == 0 {
-                    result_diagnostics.push("llvm lowering: unsupported return type in call to `"
-                        + result_target
-                        + "`");
-                    llvm_return = "i8*";
-                }
-                expected_params = _file_fn_param_types;
-            }
         } else if function_entry != null {
             result_target = function_entry.name;
             if function_entry.is_async {

--- a/compiler/src/llvm/lowering/lowering_core.sfn
+++ b/compiler/src/llvm/lowering/lowering_core.sfn
@@ -109,7 +109,7 @@ import {
     sanitize_lowering_inputs,
     sanitize_structs
 } from "./lowering_phase_sanitize";
-import { build_type_context_with_recovery, serialize_context_functions } from "./lowering_phase_types";
+import { build_type_context_with_recovery } from "./lowering_phase_types";
 import {
     recover_functions_for_lowering,
     recover_native_enums_light,
@@ -506,8 +506,6 @@ fn lower_to_llvm_lines_with_parsed_context(native_module: NativeModule, parse_in
     // site 2, no prior snapshot is aliased.
     context_functions = extend_native_functions_inplace(context_functions, imported_struct_methods);
     if debug_lowering { print.err("emit-llvm: phase=context_functions"); }
-
-    serialize_context_functions(context_functions, debug_lowering);
 
     // ── Effect analysis ─────────────────────────────────────────────
     let skip_effects = true;

--- a/compiler/src/llvm/lowering/lowering_phase_types.sfn
+++ b/compiler/src/llvm/lowering/lowering_phase_types.sfn
@@ -9,12 +9,7 @@
 // returned TypeContext has missing or empty enum names.
 //
 // Extracted from lowering_core.sfn to reduce per-file memory footprint.
-import {
-    NativeEnum,
-    NativeFunction,
-    NativeInterface,
-    NativeStruct
-} from "../../native_ir";
+import { NativeEnum, NativeInterface, NativeStruct } from "../../native_ir";
 import { substring } from "../../string_utils";
 import { build_type_context, fixup_enum_layouts } from "../type_context";
 import { EnumTypeInfo, EnumVariantInfo, TypeContext } from "../types";
@@ -304,58 +299,4 @@ fn parse_enum_variants(variants_str: string) -> EnumVariantInfo[] {
         vpos = vend + 1;
     }
     return result;
-}
-
-// Serialize context_functions metadata to individual files so downstream
-// call resolution can read clean data instead of ABI-corrupted params.
-fn serialize_context_functions(context_functions: NativeFunction[], debug_lowering: boolean) -> number ![io] {
-    // Clean up stale files first.
-    let mut cfc_i: number = 0;
-    loop {
-        let cfc_prefix = "build/sailfin/.ctx_func_" + number_to_string(cfc_i);
-        if !fs.exists(cfc_prefix + "_name") { break; }
-        fs.deleteFile(cfc_prefix + "_name");
-        fs.deleteFile(cfc_prefix + "_return_type");
-        fs.deleteFile(cfc_prefix + "_is_async");
-        fs.deleteFile(cfc_prefix + "_param_count");
-        let mut cfc_j: number = 0;
-        loop {
-            let cfc_pp = cfc_prefix + "_param_" + number_to_string(cfc_j);
-            if !fs.exists(cfc_pp + "_name") { break; }
-            fs.deleteFile(cfc_pp + "_name");
-            fs.deleteFile(cfc_pp + "_type");
-            cfc_j += 1;
-        }
-        cfc_i += 1;
-    }
-    // Write fresh function metadata
-    fs.writeFile("build/sailfin/.ctx_func_count", number_to_string(context_functions.length));
-    let mut cfw_i: number = 0;
-    loop {
-        if cfw_i >= context_functions.length { break; }
-        let cfw_fn = context_functions[cfw_i];
-        let cfw_prefix = "build/sailfin/.ctx_func_" + number_to_string(cfw_i);
-        fs.writeFile(cfw_prefix + "_name", cfw_fn.name);
-        fs.writeFile(cfw_prefix + "_return_type", cfw_fn.return_type);
-        let mut cfw_async_flag: string = "0";
-        if cfw_fn.is_async { cfw_async_flag = "1"; }
-        fs.writeFile(cfw_prefix + "_is_async", cfw_async_flag);
-        let mut cfw_params = cfw_fn.parameters;
-        if cfw_params == null { cfw_params = []; }
-        fs.writeFile(cfw_prefix + "_param_count", number_to_string(cfw_params.length));
-        let mut cfw_j: number = 0;
-        loop {
-            if cfw_j >= cfw_params.length { break; }
-            let cfw_pp = cfw_prefix + "_param_" + number_to_string(cfw_j);
-            fs.writeFile(cfw_pp + "_name", cfw_params[cfw_j].name);
-            fs.writeFile(cfw_pp + "_type", cfw_params[cfw_j].type_annotation);
-            cfw_j += 1;
-        }
-        cfw_i += 1;
-    }
-    if debug_lowering {
-        print.err("emit-llvm: serialized context_functions count="
-            + number_to_string(context_functions.length));
-    }
-    return context_functions.length;
 }


### PR DESCRIPTION
This PR removes the file-based function resolution mechanism that was previously used during LLVM call lowering. The system relied on serializing context function metadata to individual files in `build/sailfin/` and reading them back during call resolution, which added unnecessary I/O overhead and complexity.

## Key Changes

- **Removed file-based function lookup**: Deleted `_parse_int_res()`, `_find_function_from_files_res()`, and the entire file-based resolution block from `resolve_call_signature()` in `core_call_resolution.sfn`
- **Simplified function resolution**: Updated `_find_function_by_name_or_import()` to remove file I/O dependency and rely solely on in-memory function lookups
- **Removed serialization infrastructure**: Deleted `serialize_context_functions()` from `lowering_phase_types.sfn` that was writing function metadata to disk
- **Cleaned up imports**: Removed unused imports (`NativeParameter`, `char_at`, `char_code`, `map_parameter_type`) that were only needed for file-based resolution
- **Updated call sites**: Removed the call to `serialize_context_functions()` from `lowering_core.sfn`
- **Cleanup utilities**: Updated `_clean_lowering_state()` in `cli_commands.sfn` to remove references to `.ctx_func_*` scratch files

## Implementation Details

The file-based resolution was attempting to handle cases where function metadata might be corrupted during ABI processing. By removing this mechanism, the compiler now relies entirely on in-memory function lookups, which is simpler and more efficient. The `_find_function_by_name_or_import()` function still supports suffix-based matching for method resolution but does so without file I/O.

https://claude.ai/code/session_016pDR1mxB5DPs8cNiMDzJeb