### PR TITLE
Remove module globals IPC channel, return struct directly

### DIFF
--- a/compiler/src/cli_commands.sfn
+++ b/compiler/src/cli_commands.sfn
@@ -703,6 +703,8 @@ fn _clean_lowering_state(dir: string) -> number ![io] {
         if _has_prefix_cmd(entry, ".instr_") { is_scratch = true; }
         if _has_prefix_cmd(entry, ".let_ipc_") { is_scratch = true; }
         if _has_prefix_cmd(entry, ".let_result_") { is_scratch = true; }
+        // Legacy: .module_globals_* IPC channel was removed but stale files from
+        // older build dirs / older seed binaries should still be swept.
         if _has_prefix_cmd(entry, ".module_globals_") { is_scratch = true; }
         if _has_prefix_cmd(entry, ".phase_") { is_scratch = true; }
         // Legacy: .self_field_* IPC channel was removed but stale files from

--- a/compiler/src/llvm/lowering/lowering_core.sfn
+++ b/compiler/src/llvm/lowering/lowering_core.sfn
@@ -117,11 +117,7 @@ import {
     recover_native_imports_light,
     recover_native_structs_light
 } from "./lowering_recovery";
-import {
-    _parse_lowered_fn_string_constants,
-    _parse_module_globals_locals,
-    split_lines_local
-} from "./lowering_text_utils";
+import { _parse_lowered_fn_string_constants, split_lines_local } from "./lowering_text_utils";
 import { lower_module_bindings_to_globals } from "./module_globals";
 
 // Consolidated: parse all structure from native text using light recovery.
@@ -647,27 +643,14 @@ fn lower_to_llvm_lines_with_parsed_context(native_module: NativeModule, parse_in
         }
     } else {
         let _mg = lower_module_bindings_to_globals(safe_bindings, type_context, native_module.module_name);
-        let _mg_needs_init_raw = fs.readFile("build/sailfin/.module_globals_needs_init");
-        module_globals_needs_init_call = _mg_needs_init_raw == "1";
-    }
-    if safe_bindings.length > 0 {
-        let _mg_preamble_raw = fs.readFile("build/sailfin/.module_globals_preamble");
-        if _mg_preamble_raw.length > 0 {
-            module_preamble_lines = split_lines_local(_mg_preamble_raw);
-        }
-        let _mg_init_raw = fs.readFile("build/sailfin/.module_globals_init");
-        if _mg_init_raw.length > 0 {
-            module_init_lines = split_lines_local(_mg_init_raw);
-        }
-        module_init_symbol = fs.readFile("build/sailfin/.module_globals_init_symbol");
-        let _mg_locals_raw = fs.readFile("build/sailfin/.module_globals_locals");
-        if _mg_locals_raw.length > 0 {
-            module_global_locals = _parse_module_globals_locals(_mg_locals_raw);
-        }
-        let _mg_diags_raw = fs.readFile("build/sailfin/.module_globals_diagnostics");
-        if _mg_diags_raw.length > 0 {
-            let _mg_diags = split_lines_local(_mg_diags_raw);
-            diagnostics = extend_string_lines_checked(diagnostics, _mg_diags, "module globals");
+        module_globals_needs_init_call = _mg.needs_init_call;
+        module_preamble_lines = _mg.preamble_lines;
+        module_init_lines = _mg.init_function_lines;
+        module_init_symbol = _mg.init_function_symbol;
+        module_global_locals = _mg.locals;
+        module_string_constants = _mg.string_constants;
+        if _mg.diagnostics.length > 0 {
+            diagnostics = extend_string_lines_checked(diagnostics, _mg.diagnostics, "module globals");
         }
     }
     if module_preamble_lines.length > 0 {

--- a/compiler/src/llvm/lowering/lowering_text_utils.sfn
+++ b/compiler/src/llvm/lowering/lowering_text_utils.sfn
@@ -4,7 +4,7 @@
 // LLVM lowering recovery code.  Extracted from lowering_core.sfn to
 // reduce per-file memory footprint during self-hosting compilation.
 import { char_code, substring } from "../../string_utils";
-import { LocalBinding, StringConstant } from "../types";
+import { StringConstant } from "../types";
 import { index_of } from "../utils";
 
 // ── Character / string utilities ─────────────────────────────────────
@@ -157,49 +157,6 @@ fn _parse_lowered_fn_string_constants(raw: string) -> StringConstant[] {
             name: name, content: content, byte_count: byte_count
         });
         i += 1;
-    }
-    return result;
-}
-
-// Parse the tab-separated locals file written by _write_module_globals_files.
-// Format: name\tpointer\tllvm_type\ttype_annotation\tscope_id
-fn _parse_module_globals_locals(raw: string) -> LocalBinding[] {
-    let mut result: LocalBinding[] = [];
-    if raw.length == 0 { return result; }
-    let file_lines = split_lines_local(raw);
-    let mut i: number = 0;
-    loop {
-        if i >= file_lines.length { break; }
-        let line = file_lines[i];
-        i += 1;
-        if line.length == 0 { continue; }
-        let tab1 = index_of_char_local(line, "\t");
-        if tab1 < 0 { continue; }
-        let name = substring(line, 0, tab1);
-        let rest1 = substring(line, tab1 + 1, line.length);
-        let tab2 = index_of_char_local(rest1, "\t");
-        if tab2 < 0 { continue; }
-        let pointer = substring(rest1, 0, tab2);
-        let rest2 = substring(rest1, tab2 + 1, rest1.length);
-        let tab3 = index_of_char_local(rest2, "\t");
-        if tab3 < 0 { continue; }
-        let llvm_type = substring(rest2, 0, tab3);
-        let rest3 = substring(rest2, tab3 + 1, rest2.length);
-        let tab4 = index_of_char_local(rest3, "\t");
-        if tab4 < 0 { continue; }
-        let type_annotation = substring(rest3, 0, tab4);
-        let scope_id = substring(rest3, tab4 + 1, rest3.length);
-        let binding = LocalBinding {
-            name: name,
-            pointer: pointer,
-            llvm_type: llvm_type,
-            type_annotation: type_annotation,
-            ownership: null,
-            consumed: false,
-            scope_id: scope_id,
-            scope_depth: 0
-        };
-        result = result.push(binding);
     }
     return result;
 }

--- a/compiler/src/llvm/lowering/module_globals.sfn
+++ b/compiler/src/llvm/lowering/module_globals.sfn
@@ -1,29 +1,19 @@
 // compiler/src/llvm/lowering/module_globals.sfn
 //
 // Module-global lowering: turns `let` bindings into LLVM globals plus optional init function.
-//
-// IMPORTANT: The v0.1.1 seed compiler drops ALL code after a loop body
-// AND at the end of loop bodies (places it in the afterloop block).
-// Therefore, every function with a loop MUST NOT have significant code
-// after the loop or at the end of the loop body.
-import { NativeBinding, NativeFunction } from "../../native_ir";
-import { lower_expression } from "../expression_lowering/native/core";
-import { coerce_operand_to_type } from "../expression_lowering/native/core_operands";
-import { append_local_binding, find_local_binding } from "../expression_lowering/native/core_scopes";
+import { NativeBinding } from "../../native_ir";
 import { default_return_literal } from "../expressions_helpers";
 import { is_string_literal, normalise_number_literal } from "../expressions_literals";
 import { format_root_scope_id } from "../lifetime";
-import { empty_string_constant_set, merge_string_constants } from "../strings";
+import { empty_string_constant_set } from "../strings";
 import { map_local_type } from "../type_mapping";
 import {
+    BindingLoweringResult,
     LocalBinding,
     ModuleGlobalLoweringResult,
-    ParameterBinding,
-    StringConstant,
     TypeContext
 } from "../types";
 import {
-    append_string,
     is_boolean_literal,
     is_integer_literal,
     is_number_literal,
@@ -67,15 +57,18 @@ fn _strip_string_quotes(s: string) -> string {
     return s;
 }
 
-// Process a single module binding and write results to accumulation files.
-// This function is called from the loop body to keep the body minimal.
-// It appends preamble lines and local entries to accumulation files.
-// Returns "init" if the binding needs runtime initialization, "" otherwise.
-fn _process_one_binding(binding: NativeBinding, context: TypeContext, scope_id: string) -> string ![io] {
-    if binding == null { return ""; }
+// Process a single module binding and return its lowered preamble lines,
+// a zero-or-one-element locals array, and whether it needs runtime init.
+fn _process_one_binding(binding: NativeBinding, context: TypeContext, scope_id: string) -> BindingLoweringResult {
+    let empty_result = BindingLoweringResult {
+        preamble_lines: [],
+        locals: [],
+        needs_init: false
+    };
+    if binding == null { return empty_result; }
     let mut name = binding.name;
-    if name == null { return ""; }
-    if name.length == 0 { return ""; }
+    if name == null { return empty_result; }
+    if name.length == 0 { return empty_result; }
     let mut raw_type_annotation = binding.type_annotation;
     if raw_type_annotation == null { raw_type_annotation = ""; }
     let mut type_annotation = trim_text(raw_type_annotation);
@@ -89,7 +82,7 @@ fn _process_one_binding(binding: NativeBinding, context: TypeContext, scope_id: 
             }
         }
     }
-    if type_annotation.length == 0 { return ""; }
+    if type_annotation.length == 0 { return empty_result; }
     let global_name = module_global_symbol(name);
     let mut llvm_type: string = "";
     // Fast-path common primitive types
@@ -104,8 +97,8 @@ fn _process_one_binding(binding: NativeBinding, context: TypeContext, scope_id: 
     }
     if llvm_type.length == 0 { llvm_type = "double"; }
 
-    // Build preamble line(s) and append to accumulation file
-    let mut needs_init_result: string = "";
+    let mut preamble_lines: string[] = [];
+    let mut needs_init: boolean = false;
 
     if llvm_type == "i8*" {
         let mut string_handled: boolean = false;
@@ -128,15 +121,14 @@ fn _process_one_binding(binding: NativeBinding, context: TypeContext, scope_id: 
                     + " x i8]* "
                     + str_const_name
                     + ", i32 0, i32 0)";
-                _append_to_file("build/sailfin/.module_globals_preamble", line1);
-                _append_to_file("build/sailfin/.module_globals_preamble", line2);
+                preamble_lines.push(line1);
+                preamble_lines.push(line2);
                 string_handled = true;
             }
         }
         if !string_handled {
-            _append_to_file("build/sailfin/.module_globals_preamble", global_name
-                + " = internal global i8* null");
-            if binding.value != null { needs_init_result = "init"; }
+            preamble_lines.push(global_name + " = internal global i8* null");
+            if binding.value != null { needs_init = true; }
         }
     } else {
         let mut initializer_text: string = default_return_literal(llvm_type);
@@ -170,44 +162,37 @@ fn _process_one_binding(binding: NativeBinding, context: TypeContext, scope_id: 
                     is_const = true;
                 }
             }
-            if !is_const { needs_init_result = "init"; }
+            if !is_const { needs_init = true; }
         }
-        _append_to_file("build/sailfin/.module_globals_preamble", global_name
-            + " = internal global "
-            + llvm_type
+        preamble_lines.push(global_name + " = internal global " + llvm_type
             + " "
             + initializer_text);
     }
 
-    // Append local binding entry (tab-separated)
-    let local_line = name + "\t" + global_name + "\t" + llvm_type + "\t"
-        + effective_type_annotation
-        + "\t"
-        + scope_id;
-    _append_to_file("build/sailfin/.module_globals_locals", local_line);
+    let local = LocalBinding {
+        name: name,
+        pointer: global_name,
+        llvm_type: llvm_type,
+        type_annotation: effective_type_annotation,
+        ownership: null,
+        consumed: false,
+        scope_id: scope_id,
+        scope_depth: 0
+    };
+    let mut locals: LocalBinding[] = [];
+    locals.push(local);
 
-    return needs_init_result;
+    return BindingLoweringResult {
+        preamble_lines: preamble_lines,
+        locals: locals,
+        needs_init: needs_init
+    };
 }
 
-// Append a line to a file (read existing content, append newline + new line).
-fn _append_to_file(path: string, line: string) ![io] {
-    let mut existing: string = "";
-    if fs.exists(path) { existing = fs.readFile(path); }
-    if existing.length == 0 { fs.writeFile(path, line); } else {
-        fs.writeFile(path, existing + "\n" + line);
-    }
-}
-
-fn lower_module_bindings_to_globals(bindings: NativeBinding[], context: TypeContext, module_name: string) -> ModuleGlobalLoweringResult ![io] {
+fn lower_module_bindings_to_globals(bindings: NativeBinding[], context: TypeContext, module_name: string) -> ModuleGlobalLoweringResult {
     let init_symbol = module_init_symbol(module_name);
 
     if bindings.length == 0 {
-        fs.writeFile("build/sailfin/.module_globals_needs_init", "0");
-        fs.writeFile("build/sailfin/.module_globals_preamble", "");
-        fs.writeFile("build/sailfin/.module_globals_init", "");
-        fs.writeFile("build/sailfin/.module_globals_init_symbol", init_symbol);
-        fs.writeFile("build/sailfin/.module_globals_locals", "");
-        fs.writeFile("build/sailfin/.module_globals_diagnostics", "");
         return ModuleGlobalLoweringResult {
             preamble_lines: [],
             init_function_lines: [],
@@ -220,43 +205,36 @@ fn lower_module_bindings_to_globals(bindings: NativeBinding[], context: TypeCont
     }
 
     let scope_id = format_root_scope_id("module");
+    let mut preamble_lines: string[] = [];
+    let mut locals: LocalBinding[] = [];
     let mut needs_init: boolean = false;
-
-    // Clear accumulation files before starting
-    fs.writeFile("build/sailfin/.module_globals_preamble", "");
-    fs.writeFile("build/sailfin/.module_globals_locals", "");
-    fs.writeFile("build/sailfin/.module_globals_init", "");
-    fs.writeFile("build/sailfin/.module_globals_init_symbol", init_symbol);
-    fs.writeFile("build/sailfin/.module_globals_diagnostics", "");
-
-    // Process each binding via helper function.
-    // The helper writes preamble and locals to files (append mode).
-    // Keep loop body minimal — the seed drops end-of-body code.
     let mut index: number = 0;
     loop {
-        if index >= bindings.length {
-            // Write needs_init at exit (inside loop, before break)
-            if needs_init {
-                fs.writeFile("build/sailfin/.module_globals_needs_init", "1");
-            } else {
-                fs.writeFile("build/sailfin/.module_globals_needs_init", "0");
-            }
-            break;
-        }
+        if index >= bindings.length { break; }
         let binding = bindings[index];
         index += 1;
         let result = _process_one_binding(binding, context, scope_id);
-        if result == "init" { needs_init = true; }
+        let mut li: number = 0;
+        loop {
+            if li >= result.preamble_lines.length { break; }
+            preamble_lines.push(result.preamble_lines[li]);
+            li += 1;
+        }
+        let mut lj: number = 0;
+        loop {
+            if lj >= result.locals.length { break; }
+            locals.push(result.locals[lj]);
+            lj += 1;
+        }
+        if result.needs_init { needs_init = true; }
     }
 
-    // NOTE: Code below is UNREACHABLE when compiled by the v0.1.1 seed.
-    // File IPC is written inside the loop exit and by _process_one_binding.
     return ModuleGlobalLoweringResult {
-        preamble_lines: [],
+        preamble_lines: preamble_lines,
         init_function_lines: [],
         init_function_symbol: init_symbol,
         needs_init_call: needs_init,
-        locals: [],
+        locals: locals,
         string_constants: empty_string_constant_set(),
         diagnostics: []
     };

--- a/compiler/src/llvm/types.sfn
+++ b/compiler/src/llvm/types.sfn
@@ -181,6 +181,12 @@ struct ModuleGlobalLoweringResult {
     diagnostics: string[];
 }
 
+struct BindingLoweringResult {
+    preamble_lines: string[];
+    locals: LocalBinding[];
+    needs_init: boolean;
+}
+
 // =============================================================================
 // LLVM Operands and Expression Results
 // =============================================================================

--- a/docs/build-performance.md
+++ b/docs/build-performance.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-04-15 (revised, post-d2d0bf1/220c8b7)
 **Previous revision:** 2026-04-15 (morning), 2026-04-11
-**Context:** Self-hosting the compiler from the 0.5.2-alpha.1 seed via `build.sh` takes ~13-16 minutes for 121 modules single-threaded. Down from 60-90 minutes at the April 11 baseline thanks to partial IPC removal, string concat optimization, module splitting, and the Phase 1 accumulator sweep (`d2d0bf1`). Still far from the <5 minute target. Further IPC removal is blocked by a memory management crisis: file serialization was acting as accidental garbage collection. The two residual O(n²) copy sites (`concat_native_functions`, `append_local_binding`) were reverted in `220c8b7` because callers rely on input-array immutability — they are now aliasing-blocked until either the callers explicitly clone or the arena allocator lands.
+**Context:** Self-hosting the compiler from the 0.5.2-alpha.1 seed via `build.sh` takes ~13-16 minutes for 121 modules single-threaded. Down from 60-90 minutes at the April 11 baseline thanks to partial IPC removal, string concat optimization, module splitting, and the Phase 1 accumulator sweep (`d2d0bf1`). Still far from the <5 minute target. Further IPC removal is blocked by a memory management crisis: file serialization was acting as accidental garbage collection. The two residual O(n²) copy sites (`concat_native_functions`, `append_local_binding`) were reverted in `220c8b7` because callers rely on input-array immutability — they are now aliasing-blocked until either the callers explicitly clone or the arena allocator is enabled by default (the C arena is shipped behind `SAILFIN_USE_ARENA=1`; see [Completed Work: M0.5 Arena Allocator](#m05-arena-allocator-shipped-april-17)).
 
 ---
 
@@ -51,7 +51,7 @@ The C runtime (`runtime/native/src/sailfin_runtime.c`) has fundamental memory ma
 
 3. **Arrays are never freed.** No `array_drop` or array lifecycle management exists. Every `string[]` or `NativeFunction[]` allocated during compilation leaks.
 
-4. **No GC, no RC, no arena allocator.** The runtime tracks owned strings in a hash table for safe freeing, but this is opt-in and disabled. There is no generational GC, reference counting, or arena-based allocation.
+4. **No GC, no RC; arena allocator shipped but off by default.** The runtime tracks owned strings in a hash table for safe freeing, but this is opt-in and disabled. There is no generational GC or reference counting. The M0.5 bump-allocator arena landed in PR #174 (`runtime/native/src/sailfin_arena.c`) and is wired through `_rt_malloc` / `_rt_calloc` / `_rt_realloc` / `_rt_free`, but it only activates when `SAILFIN_USE_ARENA=1`. The default selfhost build does not set the flag, and the M0.5 fast-fail criteria (per-module RAM < 512 MB, `make check` passes with arena on) have not yet been formally validated in CI.
 
 ### The consequence
 
@@ -126,9 +126,9 @@ Both of these still allocate a fresh array and copy the input before appending. 
 Options for resolving these:
 
 1. **Caller-side clone audit.** For each call site, determine whether the caller still needs the pristine input; if yes, clone explicitly at the caller; if no, switch that caller to in-place `push()`. Keeps the copies only where they're actually required.
-2. **Wait for the arena allocator (Phase 0).** Under an arena, the copy becomes cheap (bump alloc) and doesn't leak — the aliasing problem becomes a non-issue because both views remain live and freed in bulk at module exit.
+2. **Enable the arena allocator (Phase 0).** Under an arena, the copy becomes cheap (bump alloc) and doesn't leak — the aliasing problem becomes a non-issue because both views remain live and freed in bulk at module exit. The C arena is already in-tree (`sailfin_arena.c`, PR #174) but runs only when `SAILFIN_USE_ARENA=1`; flipping it on by default after the fast-fail criteria pass is the actual next step.
 
-Option 2 is simpler but requires Phase 0 to land first. Option 1 can proceed now but requires careful call-site analysis (lowering_core invariants around `local_functions` and nested-scope locals restoration are subtle).
+Option 2 is simpler but requires flipping the arena on by default (and validating the fast-fail criteria). Option 1 can proceed now but requires careful call-site analysis (lowering_core invariants around `local_functions` and nested-scope locals restoration are subtle).
 
 ### Other O(n²) patterns to audit
 
@@ -195,25 +195,26 @@ The original plan ordered IPC removal first. That is no longer viable because re
 
 ### Phase 0: Arena Allocator for Compilation (≡ M0.5 in [runtime_architecture.md §4.4](runtime_architecture.md#44-m05--arena-in-c-temporary-unblocker))
 
-**Priority:** Critical — **Prerequisite for all other phases**
+**Status:** C implementation shipped (PR #174). Runtime integration shipped. Default-on flip + fast-fail validation outstanding.
+**Priority:** Critical — **Prerequisite for removing the ~146 refs of per-instruction/per-binding IPC channels blocked by IPC-as-GC**
 **Expected:** Unblocks IPC removal; 30-50% memory reduction standalone
 
-Add a per-compilation arena allocator to the C runtime. During a single module compilation, all strings and arrays are allocated from a bump allocator that is freed in bulk at process exit (or after each module in a future long-lived compiler process).
+The C arena allocator (`runtime/native/src/sailfin_arena.c`, 254 lines) is in-tree and wired through `_rt_malloc` / `_rt_calloc` / `_rt_realloc` / `_rt_free` in `sailfin_runtime.c:618-654`. All string and array allocations route through the process-global arena when `SAILFIN_USE_ARENA=1`. The owned-string hash table and persistent-pointer set are bypassed entirely in arena mode. A correctness harness (`make test-arena`, `scripts/test_arena.sh`) diffs emitted LLVM IR with and without the flag.
+
+**What's missing (the actual Phase 0 gate):**
+1. **Default flip.** No `SAILFIN_USE_ARENA=1` in CI, `scripts/build.sh`, or the `Makefile`. The default self-host build runs in malloc mode.
+2. **Fast-fail validation** (per `runtime_architecture.md §4.4`):
+   - `make compile` succeeds with `SAILFIN_USE_ARENA=1`
+   - Per-module peak RAM drops below 512 MB (from 0.5-1.5 GB in malloc mode)
+   - `make check` passes with arena on
+3. **Stats integration.** `sfn_arena_print_stats` exists but isn't called from any test or build target, so we have no telemetry on arena pressure or page count.
 
 **Why arena, not RC or GC:**
 - The compiler is a batch process: allocate during compilation, discard everything at the end
 - No cycles to break (no need for tracing GC)
 - No per-object overhead (no RC increments on every string copy)
-- Simple to implement: replace `malloc` with `arena_alloc`, add `arena_reset` at end
 
-**Implementation sketch:**
-1. Add `sailfin_arena_t` to `sailfin_runtime.c` (simple bump allocator with page-sized backing blocks)
-2. Route string allocations through the arena when `SAILFIN_USE_ARENA=1`
-3. Route array allocations through the arena
-4. Remove the owned-string hash table overhead (not needed with arena)
-5. Call `arena_reset()` at process exit (future: per-module reset in long-lived mode)
-
-**Risk:** The `string_append` realloc optimization assumes `realloc` returns the same or a new pointer. Arena allocators typically don't support `realloc`. Either (a) fall back to concat for arena mode, or (b) implement arena-aware realloc (grow in place if at arena tip, else copy).
+**Grow-if-at-tip realloc.** `sfn_arena_realloc` in `sailfin_arena.c:147-184` already implements grow-if-at-tip — if the pointer being realloc'd is the last allocation on the current page and the page has room, the arena extends in place. This preserves the `string_append` realloc-based concat optimization (`b3b6dad`) when arena mode is enabled.
 
 ### Phase 1: Fix O(n²) Array Accumulation (Mostly Shipped)
 
@@ -250,7 +251,7 @@ The win is concentrated on the target module; aggregate is within bench variance
 ### Phase 2: Eliminate IPC Files (Resumed)
 
 **Priority:** Highest — **Expected:** 40-60% time reduction, enables parallel builds
-**Depends on:** Phase 0 (arena allocator) to prevent OOM for the per-binding/per-instruction channels
+**Depends on:** Enabling the arena allocator by default (Phase 0 is plumbed but off by default) to prevent OOM for the per-binding/per-instruction channels
 
 Most IPC channels were introduced as workarounds for v0.1.1-seed ABI corruption of array-of-struct parameters across module boundaries. The 0.5.x seed lineage no longer corrupts those parameters, so many channels are now dead-code fallbacks whose readers already have the data in-memory via an existing `bindings` or `locals` parameter. Those channels can be removed immediately — they do not depend on Phase 0.
 
@@ -394,6 +395,27 @@ On Linux x86_64 the 0.5.7 seed is already fully deterministic on these modules, 
 - ~28 net lines removed
 
 Because the writer is called inside `lower_return_instruction`, which fires for every `return <expr>` statement in every function, this removes roughly 3-6 `fs.writeFile` calls per emitted return across every module compile. The compiler itself has no `return self.*` patterns, so the channel's data-bearing path is never exercised during self-hosting; it was pure per-return overhead.
+
+### M0.5 Arena Allocator (Shipped April 17)
+
+**Status: C implementation shipped behind a feature flag; default-on flip outstanding.** PR #174 (`de5ee36`) landed the bump-allocator C arena under `runtime/native/src/sailfin_arena.c` (254 lines) and wired it into `sailfin_runtime.c:618-654` via `_rt_malloc` / `_rt_calloc` / `_rt_realloc` / `_rt_free`. Activates only when the `SAILFIN_USE_ARENA=1` env var is set — otherwise the runtime falls back to `malloc`/`realloc` with the existing owned-string hash table and persistent-pointer set.
+
+**What's in the arena code:**
+- Linked-list of `SfnArenaPage` blocks (default 1 MiB; 4 MiB for the compiler singleton).
+- Lazy global singleton via `pthread_once` — created on first `sfn_arena_global()` call.
+- `sfn_arena_alloc(size, align)` — 8-byte aligned bump, new page allocated if the current page can't fit.
+- `sfn_arena_realloc(ptr, old, new, align)` — grow-if-at-tip in place; otherwise fresh alloc + memcpy. Preserves the `string_append` realloc optimization.
+- `sfn_arena_reset()` / `sfn_arena_destroy()` — bulk reset / tear-down.
+- `sfn_arena_print_stats()` — page count, capacity, utilization telemetry (not yet wired to any test or build target).
+- Correctness harness in `scripts/test_arena.sh` + `make test-arena` — compiles a module with and without the flag and byte-diffs the emitted LLVM IR to catch arena-induced output corruption.
+
+**What's still outstanding for Phase 0 to fully land:**
+1. Flip `SAILFIN_USE_ARENA=1` as the default for the selfhost build (`scripts/build.sh` or `Makefile`).
+2. Validate the three fast-fail criteria from `runtime_architecture.md §4.4`: (a) `make compile` succeeds with arena on, (b) per-module peak RAM drops below 512 MB, (c) `make check` passes with arena on.
+3. Add an arena-enabled CI job so regressions can't re-break the flag.
+4. Once (1-3) pass, the ~146 refs of Phase 2 IPC channels blocked by IPC-as-GC (dispatch, let-result, expr-stmt, instr-*, block-result) become pickable.
+
+Until the default is flipped, "blocked by Phase 0" in this document means "blocked by enabling the arena by default and clearing the fast-fail criteria," not "blocked by implementing the arena."
 
 ### Module Globals IPC Channel Removal (April 19)
 

--- a/docs/build-performance.md
+++ b/docs/build-performance.md
@@ -278,9 +278,7 @@ If step 7 fails, the channel is not purely a workaround — some caller is relyi
 2. **Let result channel** (32 refs in `instructions_let.sfn`) — per-let-binding overhead
 3. **Statement/assignment channels** (29+22 refs) — per-expression-statement overhead
 4. **Function metadata channel** (13 refs in `lowering_phase_functions.sfn`) — per-function overhead
-5. **Context functions serialization** (14 refs in `lowering_phase_types.sfn`) — per-module overhead
-6. **Module globals channel** (18 refs in `module_globals.sfn`)
-7. **Remaining channels** (emission, async, coerce)
+5. **Remaining channels** (emission, async, coerce)
 
 Named IPC functions to eliminate:
 - `_write_block_result_files()` — `instructions_helpers.sfn:122`
@@ -396,6 +394,42 @@ On Linux x86_64 the 0.5.7 seed is already fully deterministic on these modules, 
 - ~28 net lines removed
 
 Because the writer is called inside `lower_return_instruction`, which fires for every `return <expr>` statement in every function, this removes roughly 3-6 `fs.writeFile` calls per emitted return across every module compile. The compiler itself has no `return self.*` patterns, so the channel's data-bearing path is never exercised during self-hosting; it was pure per-return overhead.
+
+### Module Globals IPC Channel Removal (April 19)
+
+**Status: Implemented.** Removed the `.module_globals_*` file IPC channel — six scratch files (`preamble`, `locals`, `init`, `init_symbol`, `needs_init`, `diagnostics`) that `lower_module_bindings_to_globals` in `module_globals.sfn` used to ship its output back to its sole caller in `lowering_core.sfn`. The writer had always declared `ModuleGlobalLoweringResult` as its return type, but returned an empty stub; a "UNREACHABLE on v0.1.1 seed" comment documented the workaround. The 0.5.x seed lineage has no such restriction — `preprocess_self_field_access` (PR #184) validated the same return-struct pattern with 6 exits including a post-loop return.
+
+**Shape of change:**
+- Added `BindingLoweringResult { preamble_lines: string[]; locals: LocalBinding[]; needs_init: boolean }` to `llvm/types.sfn` (wrapper struct is legitimate per procedure §267: three values travelling together out of the per-binding helper).
+- `_process_one_binding` now returns a `BindingLoweringResult` at all 4 exits instead of writing `.module_globals_preamble` / `.module_globals_locals` scratch files. `![io]` removed — the helper is now pure.
+- `lower_module_bindings_to_globals` accumulates per-binding results in the outer loop (preamble via `.push`, locals via `.push`, needs_init via `|=`) and fully populates `ModuleGlobalLoweringResult` at its single return point. Early-return for empty bindings kept. `![io]` removed.
+- Caller in `lowering_core.sfn:640-672` replaces six `fs.readFile` + `split_lines_local` + `_parse_module_globals_locals` calls with six direct struct field reads.
+- `_parse_module_globals_locals` in `lowering_text_utils.sfn` is deleted as dead code (40 lines). `LocalBinding` import dropped from that file.
+- `cli_commands._clean_lowering_state` keeps the `.module_globals_` prefix sweep with a "Legacy" comment explaining it's there to clean stale files from older build dirs / older seed binaries (following the PR #183 / PR #184 precedent — never drop a prefix entirely).
+
+**Determinism delta (emit `llvm` × 20 runs on Linux x86_64, seed 0.5.7 baseline):**
+
+| Module | Baseline | Post-change |
+|--------|---------:|------------:|
+| `compiler/src/llvm/lowering/lowering_core.sfn` | 1 hash (20/20 identical) | to be measured on new binary |
+| `compiler/src/parser/expressions.sfn` | 1 hash (20/20 identical) | to be measured on new binary |
+| `compiler/src/version.sfn` (module with top-level `let`) | 1 hash (20/20 identical) | to be measured on new binary |
+
+On Linux x86_64 the 0.5.7 seed is already fully deterministic on these modules, so this channel's removal is not expected to move the hash count here — it eliminates per-binding `fs.writeFile` + clear-on-entry + read-back overhead instead. The equivalent macOS-arm64 measurements (where residual non-determinism still lives) will land in the PR body once the CI rebuild completes on that platform.
+
+**Scope of change:**
+- 1 writer function (`lower_module_bindings_to_globals`) converted from file-IPC stub to populated `ModuleGlobalLoweringResult` return
+- 1 helper (`_process_one_binding`) converted from void+file-IPC to `BindingLoweringResult` return at all 5 exits (4 early + 1 final)
+- 1 append-helper (`_append_to_file`) deleted entirely
+- 1 reader (`lowering_core.sfn:640-672`) converted from six `fs.readFile` + `split_lines_local` + `_parse_module_globals_locals` calls to direct struct field reads
+- 1 wrapper struct (`BindingLoweringResult`) added to `llvm/types.sfn` (3 fields)
+- 1 dead parser (`_parse_module_globals_locals`, 40 lines) deleted from `lowering_text_utils.sfn`
+- 13 `fs.writeFile` calls removed from the writer; 6 `fs.readFile` calls removed from the reader; `_append_to_file`'s internal `fs.exists` + `fs.readFile` + `fs.writeFile` per call removed
+- 3 `![io]` effect annotations narrowed — both `_process_one_binding` and `lower_module_bindings_to_globals` become pure; the `![io]` helper `_append_to_file` is deleted
+- `.module_globals_` prefix kept in the legacy cleanup sweep with an explanatory comment
+- ~75 net lines removed (−151, +77 per `git diff --stat`)
+
+The writer is called once per module compile, but only performs work when a module has top-level `let` bindings (the compiler has very few — `version.sfn` is the main one). The per-binding overhead was `2×` `_append_to_file` calls per preamble line plus another for the locals row, each entailing an `fs.exists` + `fs.readFile` + `fs.writeFile` round-trip — so O(N × L) filesystem operations for N bindings and L preamble lines per binding. The win is concentrated on two things: the pure-function conversion (helper and writer no longer participate in the `![io]` effect graph), and the elimination of an O(N²) read-modify-write pattern where each `_append_to_file` had to re-read the accumulating file on every call.
 
 ---
 


### PR DESCRIPTION
## Summary

Eliminate the `.module_globals_*` file IPC channel by converting `lower_module_bindings_to_globals` and its helper `_process_one_binding` to return structured results instead of writing to scratch files. This removes 13 `fs.writeFile` calls and 6 `fs.readFile` calls, eliminates an O(N²) read-modify-write pattern in the append helper, and makes both functions pure.

## Key Changes

- **New struct `BindingLoweringResult`** in `llvm/types.sfn`: wraps `preamble_lines`, `locals`, and `needs_init` flag to carry per-binding lowering results out of the helper function.

- **`_process_one_binding` refactored**: now returns `BindingLoweringResult` at all 4 early-exit points and 1 final return instead of writing `.module_globals_preamble` and `.module_globals_locals` files. Removed `![io]` effect annotation — function is now pure.

- **`lower_module_bindings_to_globals` refactored**: accumulates per-binding results in the outer loop using `.push()` on arrays, fully populates `ModuleGlobalLoweringResult` at its single return point, and removes all `fs.writeFile` calls. Removed `![io]` effect annotation.

- **Caller in `lowering_core.sfn`** simplified: replaces six `fs.readFile` + `split_lines_local` + `_parse_module_globals_locals` calls with direct struct field reads from the returned `ModuleGlobalLoweringResult`.

- **Dead code removal**: `_parse_module_globals_locals` (40 lines) deleted from `lowering_text_utils.sfn` as it is no longer needed. `_append_to_file` helper deleted entirely.

- **Legacy cleanup**: `.module_globals_` prefix retained in `cli_commands._clean_lowering_state` with a comment explaining it cleans stale files from older build directories.

## Implementation Details

- The per-binding helper previously performed O(N²) filesystem operations via `_append_to_file`, which read the entire accumulating file, appended a line, and wrote it back on each call. This is now eliminated.
- Both functions transition from file-IPC stubs to proper implementations that populate their return structures.
- The early-return path for empty bindings is preserved.
- Three `![io]` effect annotations are narrowed: the helper and writer become pure, and the append helper is deleted entirely.

https://claude.ai/code/session_01ASZvPexEw6koHyc5mKGn4q