### PR TITLE
perf(compiler): remove .block_result_* IPC channel

### DIFF
--- a/compiler/src/cli_commands.sfn
+++ b/compiler/src/cli_commands.sfn
@@ -692,6 +692,8 @@ fn _clean_lowering_state(dir: string) -> number ![io] {
         // Only delete known lowering scratch prefixes.
         let mut is_scratch: boolean = false;
         if _has_prefix_cmd(entry, ".async_inner_") { is_scratch = true; }
+        // Legacy: .block_result_* IPC channel was removed but stale files from
+        // older build dirs / older seed binaries should still be swept.
         if _has_prefix_cmd(entry, ".block_result_") { is_scratch = true; }
         if _has_prefix_cmd(entry, ".call_result_") { is_scratch = true; }
         // Legacy: .ctx_func_* IPC channel was removed but stale files from

--- a/compiler/src/llvm/lowering/emission.sfn
+++ b/compiler/src/llvm/lowering/emission.sfn
@@ -11,7 +11,7 @@
 // needs the main emit_llvm_function for the inner body, while the main
 // emitter delegates async wrapper generation to the async module.
 import { NativeFunction } from "../../native_ir";
-import { find_char, substring } from "../../string_utils";
+import { substring } from "../../string_utils";
 import { lower_expression } from "../expression_lowering/native/core";
 import { append_llvm_operand } from "../expression_lowering/native/core_scopes";
 import { make_string_constant_name_for_module } from "../expression_lowering/native/core_text";
@@ -52,23 +52,6 @@ import { emit_async_function } from "./emission_async";
 import { build_define_header_line } from "./emission_header";
 import { lower_instruction_range } from "./instructions";
 import { module_user_main_symbol } from "./module_globals";
-
-fn _split_by_newline(content: string) -> string[] {
-    let mut result: string[] = [];
-    if content.length == 0 { return result; }
-    let mut start: number = 0;
-    loop {
-        if start >= content.length { break; }
-        let next = find_char(content, "\n", start);
-        if next < 0 {
-            result.push(substring(content, start, content.length));
-            break;
-        }
-        result.push(substring(content, start, next));
-        start = next + 1;
-    }
-    return result;
-}
 
 fn is_safe_llvm_type_text(value: string) -> boolean {
     if value == null { return false; }
@@ -713,40 +696,4 @@ fn emit_body(function_unused: string, fn_name: string, fn_instr_count: number, l
         lifetime_regions: _empty_lifetime_regions,
         string_constants: lowered.string_constants
     };
-}
-
-// Parse serialized string constants from the file written by _write_block_result_files.
-// Format: one constant per line as "name\tcontent\tbyte_count".
-fn _parse_string_constants_from_file(raw: string) -> StringConstant[] {
-    let mut result: StringConstant[] = [];
-    let lines = _split_by_newline(raw);
-    let mut i: number = 0;
-    loop {
-        if i >= lines.length { break; }
-        let line = lines[i];
-        if line.length == 0 {
-            i += 1;
-            continue;
-        }
-        let tab1 = index_of(line, "\t");
-        if tab1 < 0 {
-            i += 1;
-            continue;
-        }
-        let name = substring(line, 0, tab1);
-        let rest = substring(line, tab1 + 1, line.length);
-        let tab2 = index_of(rest, "\t");
-        if tab2 < 0 {
-            i += 1;
-            continue;
-        }
-        let content = substring(rest, 0, tab2);
-        let byte_count_text = substring(rest, tab2 + 1, rest.length);
-        let byte_count = parse_simple_integer(byte_count_text);
-        result = append_string_constant(result, StringConstant {
-            name: name, content: content, byte_count: byte_count
-        });
-        i += 1;
-    }
-    return result;
 }

--- a/compiler/src/llvm/lowering/instructions.sfn
+++ b/compiler/src/llvm/lowering/instructions.sfn
@@ -3,8 +3,8 @@
 // Instruction lowering: main dispatch loop.
 //
 // Helper functions (clone_local_bindings, extend_lifetime_regions,
-// extend_mutations, insert_lines_before_index, _write_block_result_files,
-// _parse_int_from_string) live in instructions_helpers.sfn so that
+// extend_mutations, insert_lines_before_index, _parse_int_from_string)
+// live in instructions_helpers.sfn so that
 // lower_instruction_range is at source position 1 — within the v0.1.1
 // seed's per-module streaming emission limit.
 import { NativeFunction, NativeInstruction } from "../../native_ir";

--- a/compiler/src/llvm/lowering/instructions_helpers.sfn
+++ b/compiler/src/llvm/lowering/instructions_helpers.sfn
@@ -91,38 +91,6 @@ fn insert_lines_before_index(lines: string[], index: number, insert_lines: strin
     return result;
 }
 
-fn _write_block_result_files(lines: string[], allocas: string[], terminated: boolean, diagnostics: string[], string_constants: StringConstant[], temp_index: number, block_counter: number, next_local_id: number, next_lifetime_region_id: number, next_index: number) ![io] {
-    // Only write the two IPC files that still have live readers.
-    let mut term_val: string = "0";
-    if terminated { term_val = "1"; }
-    fs.writeFile("build/sailfin/.block_result_terminated", term_val);
-
-    let mut sc_lines: string[] = [];
-    let mut si: number = 0;
-    loop {
-        if si >= string_constants.length { break; }
-        sc_lines.push(string_constants[si].name + "\t" + string_constants[si].content
-            + "\t"
-            + number_to_string(string_constants[si].byte_count));
-        si = si + 1;
-    }
-    fs.writeLines("build/sailfin/.block_result_string_constants", sc_lines);
-}
-
-// Read the block_result_terminated IPC file and return true only if the file
-// contains the string "1".  The seedcheck's compiled `== "1"` comparison
-// gets mis-compiled into a pointer-to-bool bitcast (double-encoding bug),
-// which reads byte 0x30 from the string "0" as non-zero (true).  Using
-// grapheme_at to extract the first character avoids the cross-module ABI
-// corruption entirely.
-fn _read_ipc_terminated() -> boolean ![io] {
-    let content = fs.readFile("build/sailfin/.block_result_terminated");
-    if content.length == 0 { return false; }
-    let first_char = grapheme_at(content, 0);
-    if first_char == "1" { return true; }
-    return false;
-}
-
 fn _parse_int_from_string(text: string) -> number {
     let len = text.length;
     if len == 0 { return 0; }
@@ -207,44 +175,6 @@ fn write_locals_to_files(locals: LocalBinding[]) ![io] {
         fs.writeFile(lw_prefix + "_scope_depth", number_to_string(locals[lw_i].scope_depth));
         lw_i += 1;
     }
-}
-
-// Read string constants from the block_result_string_constants file,
-// merging into existing. Used by if/loop/match/for/try handlers.
-fn read_block_result_string_constants(existing: StringConstant[]) -> StringConstant[] ![io] {
-    let mut result = existing;
-    if fs.exists("build/sailfin/.block_result_string_constants") {
-        let _raw = fs.readFile("build/sailfin/.block_result_string_constants");
-        if _raw.length > 0 {
-            let mut _pos: number = 0;
-            loop {
-                if _pos >= _raw.length { break; }
-                let _nl = index_of(substring(_raw, _pos, _raw.length), "\n");
-                let mut _line: string = "";
-                if _nl < 0 {
-                    _line = substring(_raw, _pos, _raw.length);
-                    _pos = _raw.length;
-                } else {
-                    _line = substring(_raw, _pos, _pos + _nl);
-                    _pos = _pos + _nl + 1;
-                }
-                if _line.length == 0 { continue; }
-                let _t1 = index_of(_line, "\t");
-                if _t1 < 0 { continue; }
-                let _nm = substring(_line, 0, _t1);
-                let _r2 = substring(_line, _t1 + 1, _line.length);
-                let _t2 = index_of(_r2, "\t");
-                if _t2 < 0 { continue; }
-                let _ct = substring(_r2, 0, _t2);
-                let _bct = substring(_r2, _t2 + 1, _r2.length);
-                let _bc = _parse_int_from_string(_bct);
-                result = merge_string_constants(result, [StringConstant {
-                    name: _nm, content: _ct, byte_count: _bc
-                }]);
-            }
-        }
-    }
-    return result;
 }
 
 // Read string constants from the expr_stmt_string_constants file,

--- a/compiler/src/llvm/lowering/instructions_try.sfn
+++ b/compiler/src/llvm/lowering/instructions_try.sfn
@@ -187,8 +187,6 @@ fn lower_throw_instruction(function_name: string, instruction: NativeInstruction
     };
 }
 
-// Read all BlockLoweringResult fields from the file IPC written by _write_block_result_files.
-// Same-module struct return avoids the v0.1.1 seed ABI corruption for cross-module returns.
 fn lower_try_instruction(function: NativeFunction, start_index: number, llvm_return: string, bindings: ParameterBinding[], locals: LocalBinding[], allocas: string[], lines: string[], temp_index: number, block_counter: number, next_local_id: number, next_region_id: number, functions: NativeFunction[], loop_stack: LoopContext[], end: number, context: TypeContext, scope_id: string, scope_depth: number, current_label: string) -> BlockLoweringResult {
     let mut diagnostics: string[] = [];
     let structure = collect_try_structure(function.instructions, start_index, end, function.name);


### PR DESCRIPTION
Deletes the dead writer _write_block_result_files (instructions_helpers.sfn)
and its two readers (_read_ipc_terminated, read_block_result_string_constants),
plus the dead parser _parse_string_constants_from_file and its _split_by_newline
helper in emission.sfn. All four functions were already unreferenced from any
call site in compiler/src — only comment breadcrumbs remained.

First channel removal under the default-on arena (PR #186). The .block_result_
channel was on the Phase 2 previously-blocked list (5 refs per the April 19
docs entry); now serves as a sanity-check that the arena flip didn't change
the IPC-removal workflow shape.

Scope:
- Writer deletion: _write_block_result_files (17 lines, 2 fs.writeFile/Lines)
- Reader deletions: _read_ipc_terminated (7 lines, 1 fs.readFile),
  read_block_result_string_constants (36 lines, 1 fs.exists + 1 fs.readFile)
- Dead parser cleanup: _parse_string_constants_from_file (34 lines) and
  _split_by_newline (17 lines) in emission.sfn — only used by the deleted
  parser
- Dead import cleanup: find_char no longer needed in emission.sfn
- Stale comment cleanup: instructions.sfn header comment listing
  _write_block_result_files as a helper; instructions_try.sfn lower_try_instruction
  comment referencing the removed writer
- cli_commands._clean_lowering_state keeps the ".block_result_" prefix with a
  "Legacy" comment (precedent: PR #183 / #184 / #185 — never drop a prefix)

No behavioral change: all four functions were dead code. No writer callers
existed to delete. 128 lines removed, 5 added (net -123).

Determinism measurement deferred to CI — this sandbox lacks the resources
to run the full 20x emit sweep. Linux x86_64 on seed 0.5.7 is already
20/20 identical on the hot modules per the docs §4.4 arena-flip entry;
macOS-arm64 will be measured in CI.