### PR TITLE
feat(cli): configurable registry with sfn config command

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The self-hosted native compiler (`build/native/sailfin`) supports:
 - Effect annotations (`![io, net, model, clock]`) — parsed and carried through to IR; effect enforcement is planned on the [roadmap](https://sailfin.dev/roadmap)
 - String interpolation (`{{ expression }}`), decorators, `async fn`
 - Standard library capsules: `fmt`, `json`, `crypto`, `math`, `path`, `toml`, `fs`, `os`, `log`, `time`, `cli`, `http` (partial)
-- Package registry at `registry.sailfin.dev` with dependency resolution (capability auditing planned)
+- Package registry at `pkg.sfn.dev` with dependency resolution (configurable via `sfn config set registry <url>` for private/enterprise registries; capability auditing planned)
 - `print(value)` / `print.err(value)` for stdout/stderr output
 - `sfn test` for running `*_test.sfn` files
 

--- a/compiler/src/cli_commands.sfn
+++ b/compiler/src/cli_commands.sfn
@@ -47,6 +47,7 @@ import {
     toml_generate,
     toml_get_dependencies,
     toml_get_name,
+    toml_get_string,
     toml_get_version
 } from "./toml_parser";
 import { format_source } from "./tools/fmt";
@@ -811,6 +812,137 @@ fn handle_test_command(args: string[], runtime_root: string) -> number ![io] {
     return 0;
 }
 
+// ═══════════════════════════════════════════════════════════════════
+// Registry configuration
+// ═══════════════════════════════════════════════════════════════════
+//
+// Registry URL resolution order (highest priority first):
+//   1. SFN_REGISTRY environment variable (one-shot override for CI)
+//   2. `[registry] url` in ~/.sfn/config.toml (persisted via `sfn config`)
+//   3. Compiled-in default: https://pkg.sfn.dev
+//
+// Per-project overrides (e.g. `[registry]` in capsule.toml) are intentionally
+// out of scope for now — can be added later without breaking this layering.
+fn _default_registry_url_cmd() -> string { return "https://pkg.sfn.dev"; }
+
+fn _strip_trailing_slash_cmd(url: string) -> string {
+    if url.length == 0 { return url; }
+    if substring(url, url.length - 1, url.length) == "/" {
+        return substring(url, 0, url.length - 1);
+    }
+    return url;
+}
+
+fn _config_file_path_cmd() -> string ![io] {
+    let home = _get_home_cmd();
+    if home.length == 0 { return ""; }
+    return home + "/.sfn/config.toml";
+}
+
+fn _config_registry_url_from_file_cmd() -> string ![io] {
+    let path = _config_file_path_cmd();
+    if path.length == 0 { return ""; }
+    if !fs.exists(path) { return ""; }
+    let text = fs.readFile(path);
+    return _toml_trim_cmd(toml_get_string(text, "registry", "url"));
+}
+
+fn _resolve_registry_url_cmd() -> string ![io] {
+    let env_url = _toml_trim_cmd(_get_env_cmd("SFN_REGISTRY"));
+    if env_url.length > 0 { return _strip_trailing_slash_cmd(env_url); }
+    let file_url = _config_registry_url_from_file_cmd();
+    if file_url.length > 0 { return _strip_trailing_slash_cmd(file_url); }
+    return _default_registry_url_cmd();
+}
+
+fn _write_config_registry_cmd(url: string) -> number ![io] {
+    let home = _get_home_cmd();
+    if home.length == 0 {
+        print("could not determine home directory");
+        return 1;
+    }
+    let sfn_dir = home + "/.sfn";
+    _ensure_dir_recursive_cmd(sfn_dir);
+    process.run(["chmod", "700", sfn_dir]);
+    let path = sfn_dir + "/config.toml";
+    let mut out: string = "";
+    if url.length > 0 {
+        out = out + "[registry]\n";
+        out = out + "url = \"" + url + "\"\n";
+    }
+    fs.writeFile(path, out);
+    process.run(["chmod", "600", path]);
+    return 0;
+}
+
+fn handle_config_command(args: string[]) -> number ![io] {
+    if args.length < 2 {
+        print("usage: sfn config <get|set|unset|list> [key] [value]");
+        return 2;
+    }
+    let sub = args[1];
+    if strings_equal(sub, "list") {
+        if args.length != 2 {
+            print("usage: sfn config list");
+            return 2;
+        }
+        print("registry = " + _resolve_registry_url_cmd());
+        return 0;
+    }
+    if strings_equal(sub, "get") {
+        if args.length != 3 {
+            print("usage: sfn config get <key>");
+            return 2;
+        }
+        let key = args[2];
+        if strings_equal(key, "registry") {
+            print(_resolve_registry_url_cmd());
+            return 0;
+        }
+        print("unknown config key: " + key);
+        return 2;
+    }
+    if strings_equal(sub, "set") {
+        if args.length != 4 {
+            print("usage: sfn config set <key> <value>");
+            return 2;
+        }
+        let key = args[2];
+        let value = _toml_trim_cmd(args[3]);
+        if !strings_equal(key, "registry") {
+            print("unknown config key: " + key);
+            return 2;
+        }
+        if value.length == 0 {
+            print("error: empty value");
+            return 1;
+        }
+        let normalized = _strip_trailing_slash_cmd(value);
+        let rc = _write_config_registry_cmd(normalized);
+        if rc != 0 { return rc; }
+        print("registry = " + normalized);
+        return 0;
+    }
+    if strings_equal(sub, "unset") {
+        if args.length != 3 {
+            print("usage: sfn config unset <key>");
+            return 2;
+        }
+        let key = args[2];
+        if !strings_equal(key, "registry") {
+            print("unknown config key: " + key);
+            return 2;
+        }
+        let rc = _write_config_registry_cmd("");
+        if rc != 0 { return rc; }
+        print("unset " + key);
+        return 0;
+    }
+    print("unknown subcommand: " + sub);
+    print("usage: sfn config <get|set|unset|list> [key] [value]");
+    return 2;
+}
+
 fn handle_publish_command(args: string[]) -> number ![io] {
     if args.length > 2 {
         print("usage: sfn publish [path]");
@@ -924,7 +1056,8 @@ fn handle_publish_command(args: string[]) -> number ![io] {
     }
 
     let auth_header = "Bearer " + token;
-    let registry_url = "https://registry.sailfin.dev/api/publish";
+    let registry_base = _resolve_registry_url_cmd();
+    let registry_url = registry_base + "/api/publish";
     print("publishing to " + registry_url + "...");
     let response_tmp = _shell_read_cmd("mktemp /tmp/.sfn_pub_XXXXXX");
     let header_tmp = _shell_read_cmd("mktemp /tmp/.sfn_pub_XXXXXX");
@@ -1024,7 +1157,9 @@ fn handle_add_command(args: string[]) -> number ![io] {
         print("using locked version: " + display_name + "@" + resolved_version);
     } else {
         print("fetching registry index...");
-        resolved_version = _shell_read_cmd("curl -sfS 'https://registry.sailfin.dev/api/index.json'"
+        let registry_base = _resolve_registry_url_cmd();
+        resolved_version = _shell_read_cmd("curl -sfS '" + registry_base
+            + "/api/index.json'"
             + " | python3 -c \"import json,sys; d=json.load(sys.stdin); c=d.get('capsules',{}).get('"
             + registry_name
             + "',{}); print(c.get('latest',''))\" 2>/dev/null");
@@ -1073,9 +1208,8 @@ fn handle_add_command(args: string[]) -> number ![io] {
     _ensure_dir_recursive_cmd(cache_base);
 
     let pkg_path = cache_base + "/" + resolved_version + ".sfnpkg";
-    let download_url = "https://registry.sailfin.dev/api/capsules/" + scope
-        + "/"
-        + name
+    let dl_registry_base = _resolve_registry_url_cmd();
+    let download_url = dl_registry_base + "/api/capsules/" + scope + "/" + name
         + "/"
         + resolved_version
         + ".sfnpkg";
@@ -1369,6 +1503,7 @@ export {
     handle_test_command,
     handle_publish_command,
     handle_add_command,
+    handle_config_command,
     handle_init_command,
     handle_login_command,
     handle_guillermo_command,

--- a/compiler/src/cli_commands.sfn
+++ b/compiler/src/cli_commands.sfn
@@ -826,11 +826,52 @@ fn handle_test_command(args: string[], runtime_root: string) -> number ![io] {
 fn _default_registry_url_cmd() -> string { return "https://pkg.sfn.dev"; }
 
 fn _strip_trailing_slash_cmd(url: string) -> string {
-    if url.length == 0 { return url; }
-    if substring(url, url.length - 1, url.length) == "/" {
-        return substring(url, 0, url.length - 1);
+    let mut end = url.length;
+    loop {
+        if end == 0 { break; }
+        if substring(url, end - 1, end) != "/" { break; }
+        end -= 1;
     }
-    return url;
+    if end == url.length { return url; }
+    return substring(url, 0, end);
+}
+
+// Validate a registry URL before persisting or interpolating into shell/TOML.
+// Must be http:// or https://, contain no whitespace/control chars, no quotes,
+// no shell metacharacters that can escape a single-quoted context.
+fn _is_valid_registry_url_cmd(url: string) -> boolean {
+    if url.length == 0 { return false; }
+    let mut has_http = false;
+    if url.length >= 7 {
+        if strings_equal(substring(url, 0, 7), "http://") { has_http = true; }
+    }
+    if url.length >= 8 {
+        if strings_equal(substring(url, 0, 8), "https://") { has_http = true; }
+    }
+    if !has_http { return false; }
+    let mut i: number = 0;
+    loop {
+        if i >= url.length { break; }
+        let ch = url[i];
+        if ch == " " { return false; }
+        if ch == "\t" { return false; }
+        if ch == "\r" { return false; }
+        if ch == "\n" { return false; }
+        if ch == "\"" { return false; }
+        if ch == "'" { return false; }
+        if ch == "`" { return false; }
+        if ch == "$" { return false; }
+        if ch == "\\" { return false; }
+        if ch == ";" { return false; }
+        if ch == "|" { return false; }
+        if ch == "&" { return false; }
+        if ch == "<" { return false; }
+        if ch == ">" { return false; }
+        if ch == "(" { return false; }
+        if ch == ")" { return false; }
+        i += 1;
+    }
+    return true;
 }
 
 fn _config_file_path_cmd() -> string ![io] {
@@ -847,11 +888,21 @@ fn _config_registry_url_from_file_cmd() -> string ![io] {
     return _toml_trim_cmd(toml_get_string(text, "registry", "url"));
 }
 
+// Returns resolved registry base URL (no trailing slash). Silently falls back
+// to the next source if a source is set but invalid — the config-set path
+// already rejects bad URLs, so this only matters for SFN_REGISTRY from the
+// environment and hand-edited config files.
 fn _resolve_registry_url_cmd() -> string ![io] {
-    let env_url = _toml_trim_cmd(_get_env_cmd("SFN_REGISTRY"));
-    if env_url.length > 0 { return _strip_trailing_slash_cmd(env_url); }
-    let file_url = _config_registry_url_from_file_cmd();
-    if file_url.length > 0 { return _strip_trailing_slash_cmd(file_url); }
+    let env_url = _strip_trailing_slash_cmd(_toml_trim_cmd(_get_env_cmd("SFN_REGISTRY")));
+    if env_url.length > 0 {
+        if _is_valid_registry_url_cmd(env_url) { return env_url; }
+        print.err("warning: SFN_REGISTRY is not a valid http(s) URL; ignoring");
+    }
+    let file_url = _strip_trailing_slash_cmd(_config_registry_url_from_file_cmd());
+    if file_url.length > 0 {
+        if _is_valid_registry_url_cmd(file_url) { return file_url; }
+        print.err("warning: ~/.sfn/config.toml registry.url is invalid; ignoring");
+    }
     return _default_registry_url_cmd();
 }
 
@@ -863,7 +914,11 @@ fn _write_config_registry_cmd(url: string) -> number ![io] {
     }
     let sfn_dir = home + "/.sfn";
     _ensure_dir_recursive_cmd(sfn_dir);
-    process.run(["chmod", "700", sfn_dir]);
+    let dir_chmod_rc = process.run(["chmod", "700", sfn_dir]);
+    if dir_chmod_rc != 0 {
+        print("error: failed to set permissions on " + sfn_dir);
+        return 1;
+    }
     let path = sfn_dir + "/config.toml";
     let mut out: string = "";
     if url.length > 0 {
@@ -871,7 +926,11 @@ fn _write_config_registry_cmd(url: string) -> number ![io] {
         out = out + "url = \"" + url + "\"\n";
     }
     fs.writeFile(path, out);
-    process.run(["chmod", "600", path]);
+    let file_chmod_rc = process.run(["chmod", "600", path]);
+    if file_chmod_rc != 0 {
+        print("error: failed to set permissions on " + path);
+        return 1;
+    }
     return 0;
 }
 
@@ -918,6 +977,10 @@ fn handle_config_command(args: string[]) -> number ![io] {
             return 1;
         }
         let normalized = _strip_trailing_slash_cmd(value);
+        if !_is_valid_registry_url_cmd(normalized) {
+            print("error: registry must be an http(s) URL with no whitespace, quotes, or shell metacharacters");
+            return 1;
+        }
         let rc = _write_config_registry_cmd(normalized);
         if rc != 0 { return rc; }
         print("registry = " + normalized);
@@ -1135,6 +1198,27 @@ fn handle_add_command(args: string[]) -> number ![io] {
     // `scope/name` format.
     let display_name = _display_capsule_name_cmd(registry_name);
 
+    // Validate scope/name up front — registry_name is interpolated into a
+    // shell pipeline below when fetching the index, and into the cache path
+    // and download URL after. Rejecting path-traversal and directory-separator
+    // characters early covers both the shell-injection and traversal risks.
+    let slash_pos = find_char(registry_name, "/", 0);
+    if slash_pos < 0 {
+        print("invalid capsule id — expected scope/name format: "
+            + registry_name);
+        return 1;
+    }
+    let scope = substring(registry_name, 0, slash_pos);
+    let name = substring(registry_name, slash_pos + 1, registry_name.length);
+    if !_is_safe_capsule_segment_cmd(scope) {
+        print("invalid capsule scope: " + scope);
+        return 1;
+    }
+    if !_is_safe_capsule_segment_cmd(name) {
+        print("invalid capsule name: " + name);
+        return 1;
+    }
+
     // If --update was not passed and a lockfile entry exists, use the locked version.
     let mut use_locked: boolean = false;
     let mut locked_version: string = "";
@@ -1169,24 +1253,6 @@ fn handle_add_command(args: string[]) -> number ![io] {
         }
     }
 
-    let slash_pos = find_char(registry_name, "/", 0);
-    if slash_pos < 0 {
-        print("invalid capsule id — expected scope/name format: "
-            + registry_name);
-        return 1;
-    }
-    let scope = substring(registry_name, 0, slash_pos);
-    let name = substring(registry_name, slash_pos + 1, registry_name.length);
-    // Validate path segments to prevent directory traversal (especially
-    // when resolved_version comes from capsule.lock).
-    if !_is_safe_capsule_segment_cmd(scope) {
-        print("invalid capsule scope: " + scope);
-        return 1;
-    }
-    if !_is_safe_capsule_segment_cmd(name) {
-        print("invalid capsule name: " + name);
-        return 1;
-    }
     if !_is_safe_capsule_version_cmd(resolved_version) {
         print("invalid version (possible path traversal): " + resolved_version);
         return 1;

--- a/compiler/src/cli_main.sfn
+++ b/compiler/src/cli_main.sfn
@@ -44,7 +44,7 @@ fn _usage() -> string {
     out = out + "project:\n";
     out = out + "  sfn init\n";
     out = out + "  sfn check [--quiet] [path...]\n";
-    out = out + "  sfn fmt   [--check | --write] <path...>\n";
+    out = out + "  sfn fmt   [--check] [--write] <path...>\n";
     out = out + "  sfn test  [path]\n";
     out = out + "\n";
     out = out + "packages:\n";

--- a/compiler/src/cli_main.sfn
+++ b/compiler/src/cli_main.sfn
@@ -11,6 +11,7 @@ import {
 import { handle_check_command } from "./cli_check";
 import {
     handle_add_command,
+    handle_config_command,
     handle_fmt_command,
     handle_guillermo_command,
     handle_init_command,
@@ -32,37 +33,36 @@ import {
 import { resolve_compiler_version } from "./version";
 
 fn _usage() -> string {
-    let mut out: string = "usage:\n";
-    out = out + "  sfn --version\n";
-    out = out + "  sfn version\n";
-    out = out
-        + "  sfn emit [--timing] [-o OUTPUT] llvm|sailfin|native <file.sfn>\n";
+    let mut out: string = "usage: sfn <command> [options]\n";
+    out = out + "\n";
+    out = out + "build & run:\n";
     out = out + "  sfn build [-o OUTPUT] <file.sfn>\n";
-    out = out + "  sfn run <file.sfn>\n";
-    out = out + "  sfn run <exe>\n";
-    out = out + "  sfn test [path]\n";
-    out = out + "  sfn check [--quiet] [path...]\n";
-    out = out + "  sfn fmt [--check] [--write] [path...]\n";
+    out = out + "  sfn run   <file.sfn | exe>\n";
+    out = out
+        + "  sfn emit  [--timing] [-o OUTPUT] llvm|sailfin|native <file.sfn>\n";
+    out = out + "\n";
+    out = out + "project:\n";
     out = out + "  sfn init\n";
+    out = out + "  sfn check [--quiet] [path...]\n";
+    out = out + "  sfn fmt   [--check | --write] <path...>\n";
+    out = out + "  sfn test  [path]\n";
+    out = out + "\n";
+    out = out + "packages:\n";
+    out = out + "  sfn add     [--dev] [--update] <capsule>\n";
     out = out + "  sfn publish [path]\n";
-    out = out + "  sfn add [--dev] <capsule>\n";
-    out = out + "  sfn login [token]\n";
+    out = out + "  sfn login   [token]\n";
+    out = out + "  sfn config  <get|set|unset|list> [key] [value]\n";
+    out = out + "\n";
+    out = out + "meta:\n";
+    out = out + "  sfn version\n";
+    out = out + "  sfn --version\n";
     out = out + "\n";
     out = out + "examples:\n";
-    out = out + "  sfn emit llvm examples/basics/hello-world.sfn\n";
-    out = out + "  sfn emit -o hello.ll llvm examples/basics/hello-world.sfn\n";
+    out = out + "  sfn run examples/basics/hello-world.sfn\n";
     out = out
         + "  sfn build -o build/native/examples/hello examples/basics/hello-world.sfn\n";
-    out = out + "  sfn run examples/basics/hello-world.sfn\n";
-    out = out + "  sfn run build/native/examples/hello\n";
-    out = out + "  sfn test .\n";
-    out = out + "  sfn check compiler/src\n";
-    out = out + "  sfn init\n";
-    out = out + "  sfn publish [path]\n";
-    out = out + "  sfn add http\n";
-    out = out + "  sfn add --dev test\n";
     out = out + "  sfn add acme/router\n";
-    out = out + "  sfn login\n";
+    out = out + "  sfn config set registry https://registry.acme.internal\n";
     return out;
 }
 
@@ -408,6 +408,7 @@ fn sailfin_cli_main(argv: string[]) -> number ![io] {
     let is_publish = strings_equal(cmd, "publish");
     let is_add = strings_equal(cmd, "add");
     let is_login = strings_equal(cmd, "login");
+    let is_config = strings_equal(cmd, "config");
     let is_fmt = strings_equal(cmd, "fmt");
     let is_check = strings_equal(cmd, "check");
     if trace_argv {
@@ -657,6 +658,8 @@ fn sailfin_cli_main(argv: string[]) -> number ![io] {
     if is_add { return handle_add_command(args); }
 
     if is_login { return handle_login_command(args); }
+
+    if is_config { return handle_config_command(args); }
 
     if is_fmt { return handle_fmt_command(args); }
 

--- a/compiler/src/toml_parser.sfn
+++ b/compiler/src/toml_parser.sfn
@@ -241,6 +241,38 @@ fn toml_get_description(text: string) -> string {
     return t.description;
 }
 
+// Read a string value at `[section] key = "value"`. Returns "" if absent.
+// Lets callers read ad-hoc config (e.g. ~/.sfn/config.toml) without the
+// manifest-shaped SailToml struct.
+fn toml_get_string(text: string, section: string, key: string) -> string {
+    let lines = _toml_split_lines(text);
+    let mut current_section: string = "";
+    let mut i: number = 0;
+    loop {
+        if i >= lines.length { break; }
+        let line = _toml_trim(lines[i]);
+        i += 1;
+        if line.length == 0 { continue; }
+        if line[0] == "#" { continue; }
+        if line[0] == "[" {
+            let close = find_char(line, "]", 0);
+            if close > 0 {
+                current_section = _toml_trim(substring(line, 1, close));
+            }
+            continue;
+        }
+        if !strings_equal(current_section, section) { continue; }
+        let eq_pos = find_char(line, "=", 0);
+        if eq_pos < 0 { continue; }
+        let line_key = _toml_trim(substring(line, 0, eq_pos));
+        let stripped_key = _toml_strip_quotes(line_key);
+        if !strings_equal(stripped_key, key) { continue; }
+        let value = _toml_trim(substring(line, eq_pos + 1, line.length));
+        return _toml_strip_quotes(value);
+    }
+    return "";
+}
+
 // Return dependencies as a newline-separated string of "capsule=version" pairs.
 // Callers can split on "\n" and "=" to recover individual entries without
 // needing the SailToml struct across module boundaries.

--- a/compiler/tests/e2e/test_config.sh
+++ b/compiler/tests/e2e/test_config.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+# End-to-end tests for `sfn config`.
+#
+# Usage:
+#   compiler/tests/e2e/test_config.sh <compiler-binary>
+#
+# Uses a temporary HOME so the real ~/.sfn/config.toml is never touched.
+
+set -euo pipefail
+
+BINARY="${1:?usage: test_config.sh <compiler-binary>}"
+PASS=0
+FAIL=0
+
+# Do not let the caller's registry env var leak into these tests — each one
+# either sets SFN_REGISTRY explicitly or asserts the unset default.
+unset SFN_REGISTRY 2>/dev/null || true
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+run_test() {
+    local name="$1"
+    shift
+    if "$@"; then
+        echo "[test] PASS: $name"
+        PASS=$((PASS + 1))
+    else
+        echo "[test] FAIL: $name"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# ---- Test 1: no args shows usage ----
+test_config_no_args() {
+    local home="$tmpdir/t1"
+    mkdir -p "$home"
+    local output
+    output="$(HOME="$home" "$BINARY" config 2>&1 || true)"
+    echo "$output" | grep -qi "usage" || { echo "expected usage, got: $output"; return 1; }
+}
+
+# ---- Test 2: set registry writes config.toml ----
+test_config_set_registry() {
+    local home="$tmpdir/t2"
+    mkdir -p "$home"
+    HOME="$home" "$BINARY" config set registry "https://example.test"
+    [ -f "$home/.sfn/config.toml" ] || { echo "config.toml not created"; return 1; }
+    grep -q '^\[registry\]' "$home/.sfn/config.toml" \
+        || { echo "missing [registry] section"; return 1; }
+    grep -q '^url = "https://example.test"' "$home/.sfn/config.toml" \
+        || { echo "missing url line"; return 1; }
+}
+
+# ---- Test 3: set strips trailing slash ----
+test_config_set_strips_trailing_slash() {
+    local home="$tmpdir/t3"
+    mkdir -p "$home"
+    HOME="$home" "$BINARY" config set registry "https://example.test/"
+    grep -q '^url = "https://example.test"$' "$home/.sfn/config.toml" \
+        || { echo "trailing slash not stripped:"; cat "$home/.sfn/config.toml"; return 1; }
+}
+
+# ---- Test 4: get registry returns default when unset ----
+test_config_get_default() {
+    local home="$tmpdir/t4"
+    mkdir -p "$home"
+    local output
+    output="$(HOME="$home" "$BINARY" config get registry 2>&1)"
+    [ "$output" = "https://pkg.sfn.dev" ] \
+        || { echo "expected default registry, got: $output"; return 1; }
+}
+
+# ---- Test 5: get registry returns set value ----
+test_config_get_set_value() {
+    local home="$tmpdir/t5"
+    mkdir -p "$home"
+    HOME="$home" "$BINARY" config set registry "https://private.corp"
+    local output
+    output="$(HOME="$home" "$BINARY" config get registry 2>&1)"
+    [ "$output" = "https://private.corp" ] \
+        || { echo "expected 'https://private.corp', got: $output"; return 1; }
+}
+
+# ---- Test 6: SFN_REGISTRY env var wins over config file ----
+test_config_env_overrides_file() {
+    local home="$tmpdir/t6"
+    mkdir -p "$home"
+    HOME="$home" "$BINARY" config set registry "https://in-file.test"
+    local output
+    output="$(HOME="$home" SFN_REGISTRY="https://from-env.test" "$BINARY" config get registry 2>&1)"
+    [ "$output" = "https://from-env.test" ] \
+        || { echo "env did not override file: $output"; return 1; }
+}
+
+# ---- Test 7: unset registry removes the value ----
+test_config_unset_registry() {
+    local home="$tmpdir/t7"
+    mkdir -p "$home"
+    HOME="$home" "$BINARY" config set registry "https://custom.test"
+    HOME="$home" "$BINARY" config unset registry
+    local output
+    output="$(HOME="$home" "$BINARY" config get registry 2>&1)"
+    [ "$output" = "https://pkg.sfn.dev" ] \
+        || { echo "unset did not revert to default: $output"; return 1; }
+}
+
+# ---- Test 8: list shows resolved registry ----
+test_config_list() {
+    local home="$tmpdir/t8"
+    mkdir -p "$home"
+    HOME="$home" "$BINARY" config set registry "https://list.test"
+    local output
+    output="$(HOME="$home" "$BINARY" config list 2>&1)"
+    echo "$output" | grep -q "registry = https://list.test" \
+        || { echo "expected 'registry = https://list.test', got: $output"; return 1; }
+}
+
+# ---- Test 9: set with unknown key rejected ----
+test_config_set_unknown_key() {
+    local home="$tmpdir/t9"
+    mkdir -p "$home"
+    if HOME="$home" "$BINARY" config set bogus-key value 2>&1; then
+        echo "expected non-zero exit for unknown key"
+        return 1
+    fi
+    return 0
+}
+
+# ---- Test 10: get with unknown key rejected ----
+test_config_get_unknown_key() {
+    local home="$tmpdir/t10"
+    mkdir -p "$home"
+    if HOME="$home" "$BINARY" config get bogus-key 2>&1; then
+        echo "expected non-zero exit for unknown key"
+        return 1
+    fi
+    return 0
+}
+
+# ---- Test 11: set with empty value rejected ----
+test_config_set_empty_value() {
+    local home="$tmpdir/t11"
+    mkdir -p "$home"
+    if HOME="$home" "$BINARY" config set registry "" 2>&1; then
+        echo "expected non-zero exit for empty value"
+        return 1
+    fi
+    return 0
+}
+
+# ---- Test 12: unknown subcommand rejected ----
+test_config_unknown_subcommand() {
+    local home="$tmpdir/t12"
+    mkdir -p "$home"
+    local output
+    output="$(HOME="$home" "$BINARY" config quantum registry 2>&1 || true)"
+    echo "$output" | grep -qi "unknown subcommand" \
+        || { echo "expected 'unknown subcommand' in output, got: $output"; return 1; }
+}
+
+# ---- Test 13: ~/.sfn and config.toml have restrictive permissions ----
+test_config_permissions() {
+    local home="$tmpdir/t13"
+    mkdir -p "$home"
+    HOME="$home" "$BINARY" config set registry "https://perm.test"
+    local dir_perms
+    dir_perms="$(stat -c '%a' "$home/.sfn" 2>/dev/null || stat -f '%Lp' "$home/.sfn" 2>/dev/null)"
+    [ "$dir_perms" = "700" ] \
+        || { echo "expected ~/.sfn perms 700, got $dir_perms"; return 1; }
+    local file_perms
+    file_perms="$(stat -c '%a' "$home/.sfn/config.toml" 2>/dev/null || stat -f '%Lp' "$home/.sfn/config.toml" 2>/dev/null)"
+    [ "$file_perms" = "600" ] \
+        || { echo "expected config.toml perms 600, got $file_perms"; return 1; }
+}
+
+run_test "config no args shows usage" test_config_no_args
+run_test "config set registry writes config.toml" test_config_set_registry
+run_test "config set strips trailing slash" test_config_set_strips_trailing_slash
+run_test "config get returns default when unset" test_config_get_default
+run_test "config get returns set value" test_config_get_set_value
+run_test "SFN_REGISTRY env overrides config file" test_config_env_overrides_file
+run_test "config unset reverts to default" test_config_unset_registry
+run_test "config list shows resolved registry" test_config_list
+run_test "config set rejects unknown key" test_config_set_unknown_key
+run_test "config get rejects unknown key" test_config_get_unknown_key
+run_test "config set rejects empty value" test_config_set_empty_value
+run_test "config rejects unknown subcommand" test_config_unknown_subcommand
+run_test "config file permissions restricted" test_config_permissions
+
+echo ""
+echo "config tests: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/compiler/tests/e2e/test_config.sh
+++ b/compiler/tests/e2e/test_config.sh
@@ -52,13 +52,13 @@ test_config_set_registry() {
         || { echo "missing url line"; return 1; }
 }
 
-# ---- Test 3: set strips trailing slash ----
+# ---- Test 3: set strips trailing slash(es) ----
 test_config_set_strips_trailing_slash() {
     local home="$tmpdir/t3"
     mkdir -p "$home"
-    HOME="$home" "$BINARY" config set registry "https://example.test/"
+    HOME="$home" "$BINARY" config set registry "https://example.test///"
     grep -q '^url = "https://example.test"$' "$home/.sfn/config.toml" \
-        || { echo "trailing slash not stripped:"; cat "$home/.sfn/config.toml"; return 1; }
+        || { echo "trailing slashes not stripped:"; cat "$home/.sfn/config.toml"; return 1; }
 }
 
 # ---- Test 4: get registry returns default when unset ----
@@ -149,6 +149,44 @@ test_config_set_empty_value() {
     return 0
 }
 
+# ---- Test 11b: set rejects non-http(s) scheme ----
+test_config_set_rejects_bad_scheme() {
+    local home="$tmpdir/t11b"
+    mkdir -p "$home"
+    if HOME="$home" "$BINARY" config set registry "ftp://nope.test" 2>&1; then
+        echo "expected non-zero exit for non-http scheme"
+        return 1
+    fi
+    [ ! -f "$home/.sfn/config.toml" ] \
+        || { echo "config.toml should not have been written"; return 1; }
+    return 0
+}
+
+# ---- Test 11c: set rejects shell metacharacters ----
+test_config_set_rejects_metachars() {
+    local home="$tmpdir/t11c"
+    mkdir -p "$home"
+    if HOME="$home" "$BINARY" config set registry 'https://bad.test"; echo pwn' 2>&1; then
+        echo "expected non-zero exit for URL with shell metacharacters"
+        return 1
+    fi
+    [ ! -f "$home/.sfn/config.toml" ] \
+        || { echo "config.toml should not have been written"; return 1; }
+    return 0
+}
+
+# ---- Test 11d: invalid env var falls back to default with warning ----
+test_config_invalid_env_falls_back() {
+    local home="$tmpdir/t11d"
+    mkdir -p "$home"
+    local output
+    output="$(HOME="$home" SFN_REGISTRY="not a url" "$BINARY" config get registry 2>&1)"
+    echo "$output" | grep -q "https://pkg.sfn.dev" \
+        || { echo "expected default URL in output, got: $output"; return 1; }
+    echo "$output" | grep -qi "warning" \
+        || { echo "expected warning about invalid SFN_REGISTRY, got: $output"; return 1; }
+}
+
 # ---- Test 12: unknown subcommand rejected ----
 test_config_unknown_subcommand() {
     local home="$tmpdir/t12"
@@ -185,6 +223,9 @@ run_test "config list shows resolved registry" test_config_list
 run_test "config set rejects unknown key" test_config_set_unknown_key
 run_test "config get rejects unknown key" test_config_get_unknown_key
 run_test "config set rejects empty value" test_config_set_empty_value
+run_test "config set rejects non-http scheme" test_config_set_rejects_bad_scheme
+run_test "config set rejects shell metacharacters" test_config_set_rejects_metachars
+run_test "invalid SFN_REGISTRY env falls back to default" test_config_invalid_env_falls_back
 run_test "config rejects unknown subcommand" test_config_unknown_subcommand
 run_test "config file permissions restricted" test_config_permissions
 

--- a/compiler/tests/e2e/test_publish.sh
+++ b/compiler/tests/e2e/test_publish.sh
@@ -14,9 +14,11 @@ BINARY="$(cd "$(dirname "${1:?usage: test_publish.sh <compiler-binary>}")" && pw
 PASS=0
 FAIL=0
 
-# Prevent the real SFN_TOKEN from leaking into tests — each test that needs
-# a token provides one explicitly via credentials file or env override.
+# Prevent the real SFN_TOKEN / SFN_REGISTRY from leaking into tests — each
+# test that needs them provides the value explicitly via credentials file,
+# config file, or per-command env override.
 unset SFN_TOKEN 2>/dev/null || true
+unset SFN_REGISTRY 2>/dev/null || true
 
 # Portable sha256 and base64 helpers (GNU vs macOS)
 _sha256() { sha256sum "$@" 2>/dev/null || shasum -a 256 "$@"; }

--- a/compiler/tests/e2e/test_publish.sh
+++ b/compiler/tests/e2e/test_publish.sh
@@ -304,6 +304,126 @@ SHIM
         || { echo "expected 'Digest mismatch' in server error, got: $output"; return 1; }
 }
 
+# ---- Test 10: publish uses default registry when none configured ----
+test_publish_uses_default_registry() {
+    local home="$tmpdir/t10"
+    local workdir="$tmpdir/t10_work"
+    mkdir -p "$home/.sfn"
+    echo "fake-token" > "$home/.sfn/credentials"
+    make_capsule "$workdir"
+
+    local shim_dir="$tmpdir/t10_shim"
+    local captured_url="$tmpdir/t10_url"
+    mkdir -p "$shim_dir"
+    cat > "$shim_dir/curl" <<'SHIM'
+#!/usr/bin/env bash
+# Last positional arg is the URL
+last=""
+for arg in "$@"; do last="$arg"; done
+echo "$last" > "${CAPTURE_URL_TO}"
+exit 1
+SHIM
+    chmod +x "$shim_dir/curl"
+    CAPTURE_URL_TO="$captured_url" PATH="$shim_dir:$PATH" \
+        HOME="$home" "$BINARY" publish "$workdir" 2>&1 || true
+    [ -f "$captured_url" ] || { echo "curl shim did not capture url"; return 1; }
+    local url
+    url="$(cat "$captured_url")"
+    [ "$url" = "https://pkg.sfn.dev/api/publish" ] \
+        || { echo "expected default registry URL, got: $url"; return 1; }
+}
+
+# ---- Test 11: publish uses registry from config file ----
+test_publish_uses_config_file_registry() {
+    local home="$tmpdir/t11"
+    local workdir="$tmpdir/t11_work"
+    mkdir -p "$home/.sfn"
+    echo "fake-token" > "$home/.sfn/credentials"
+    cat > "$home/.sfn/config.toml" <<'CFG'
+[registry]
+url = "https://registry.acme.internal"
+CFG
+    make_capsule "$workdir"
+
+    local shim_dir="$tmpdir/t11_shim"
+    local captured_url="$tmpdir/t11_url"
+    mkdir -p "$shim_dir"
+    cat > "$shim_dir/curl" <<'SHIM'
+#!/usr/bin/env bash
+last=""
+for arg in "$@"; do last="$arg"; done
+echo "$last" > "${CAPTURE_URL_TO}"
+exit 1
+SHIM
+    chmod +x "$shim_dir/curl"
+    CAPTURE_URL_TO="$captured_url" PATH="$shim_dir:$PATH" \
+        HOME="$home" "$BINARY" publish "$workdir" 2>&1 || true
+    local url
+    url="$(cat "$captured_url")"
+    [ "$url" = "https://registry.acme.internal/api/publish" ] \
+        || { echo "expected config-file registry, got: $url"; return 1; }
+}
+
+# ---- Test 12: SFN_REGISTRY env var overrides config file ----
+test_publish_env_overrides_config() {
+    local home="$tmpdir/t12"
+    local workdir="$tmpdir/t12_work"
+    mkdir -p "$home/.sfn"
+    echo "fake-token" > "$home/.sfn/credentials"
+    cat > "$home/.sfn/config.toml" <<'CFG'
+[registry]
+url = "https://in-file.test"
+CFG
+    make_capsule "$workdir"
+
+    local shim_dir="$tmpdir/t12_shim"
+    local captured_url="$tmpdir/t12_url"
+    mkdir -p "$shim_dir"
+    cat > "$shim_dir/curl" <<'SHIM'
+#!/usr/bin/env bash
+last=""
+for arg in "$@"; do last="$arg"; done
+echo "$last" > "${CAPTURE_URL_TO}"
+exit 1
+SHIM
+    chmod +x "$shim_dir/curl"
+    CAPTURE_URL_TO="$captured_url" PATH="$shim_dir:$PATH" \
+        SFN_REGISTRY="https://from-env.test" \
+        HOME="$home" "$BINARY" publish "$workdir" 2>&1 || true
+    local url
+    url="$(cat "$captured_url")"
+    [ "$url" = "https://from-env.test/api/publish" ] \
+        || { echo "expected env registry, got: $url"; return 1; }
+}
+
+# ---- Test 13: SFN_REGISTRY strips trailing slash ----
+test_publish_env_strips_trailing_slash() {
+    local home="$tmpdir/t13"
+    local workdir="$tmpdir/t13_work"
+    mkdir -p "$home/.sfn"
+    echo "fake-token" > "$home/.sfn/credentials"
+    make_capsule "$workdir"
+
+    local shim_dir="$tmpdir/t13_shim"
+    local captured_url="$tmpdir/t13_url"
+    mkdir -p "$shim_dir"
+    cat > "$shim_dir/curl" <<'SHIM'
+#!/usr/bin/env bash
+last=""
+for arg in "$@"; do last="$arg"; done
+echo "$last" > "${CAPTURE_URL_TO}"
+exit 1
+SHIM
+    chmod +x "$shim_dir/curl"
+    CAPTURE_URL_TO="$captured_url" PATH="$shim_dir:$PATH" \
+        SFN_REGISTRY="https://slashy.test/" \
+        HOME="$home" "$BINARY" publish "$workdir" 2>&1 || true
+    local url
+    url="$(cat "$captured_url")"
+    [ "$url" = "https://slashy.test/api/publish" ] \
+        || { echo "expected stripped trailing slash, got: $url"; return 1; }
+}
+
 run_test "publish too many args shows usage" test_publish_too_many_args
 run_test "publish with no capsule.toml fails" test_publish_no_capsule_toml
 run_test "publish with path arg finds capsule" test_publish_path_finds_capsule
@@ -313,6 +433,10 @@ run_test "publish with no token fails" test_publish_no_token
 run_test "publish digest has sha256: prefix" test_publish_digest_format
 run_test "publish paths are relative with path arg" test_publish_relative_paths_in_payload
 run_test "publish surfaces HTTP error details" test_publish_surfaces_http_error
+run_test "publish uses default registry when unset" test_publish_uses_default_registry
+run_test "publish uses registry from config file" test_publish_uses_config_file_registry
+run_test "SFN_REGISTRY env overrides config file" test_publish_env_overrides_config
+run_test "SFN_REGISTRY strips trailing slash" test_publish_env_strips_trailing_slash
 
 echo ""
 echo "publish tests: $PASS passed, $FAIL failed"

--- a/docs/proposals/build-architecture.md
+++ b/docs/proposals/build-architecture.md
@@ -148,8 +148,8 @@ Three import resolution rules are interleaved across
 
 The compiler binary carries a hard-coded allowlist of stdlib capsule names.
 Third-party capsules live in `~/.sfn/cache/capsules/<scope>/<name>/<version>/`
-after `sfn add` downloads a `.sfnpkg` from `registry.sailfin.dev` and writes
-an entry to `capsule.lock`.
+after `sfn add` downloads a `.sfnpkg` from the configured registry
+(`pkg.sfn.dev` by default) and writes an entry to `capsule.lock`.
 
 
 ---

--- a/docs/proposals/model-engines-and-training.md
+++ b/docs/proposals/model-engines-and-training.md
@@ -276,7 +276,7 @@ lock_engines  = true
 sign_cards    = true
 
 [registry]
-primary = "https://registry.sailfin.dev"
+primary = "https://pkg.sfn.dev"
 
 [engines.prefs]
 device = "auto"      # "cpu" | "gpu" | "auto"

--- a/docs/proposals/package-management.md
+++ b/docs/proposals/package-management.md
@@ -81,7 +81,7 @@ version     = "0.0.0"
 description = "Core language, runtime, and tooling"
 
 [registry]
-primary = "https://registry.sailfin.dev"
+primary = "https://pkg.sfn.dev"
 cache   = "~/.sfn/cache"
 
 [build]
@@ -225,11 +225,13 @@ sfn publish
 
 ## Registry & Provenance
 
-Sailfin capsules and model artefacts are hosted on the central registry at
-<https://registry.sailfin.dev>. Uploads include provenance metadata: commit
-hashes, generation cards, capability manifests, and evaluator baselines.
-Consumers can replay model calls using the bundled cards for deterministic
-evaluation.
+Sailfin capsules and model artefacts are hosted on the default central
+registry at <https://pkg.sfn.dev>. Users can point the toolchain at any
+alternate registry (e.g. a private enterprise mirror) via
+`sfn config set registry <url>` or the `SFN_REGISTRY` environment variable.
+Uploads include provenance metadata: commit hashes, generation cards,
+capability manifests, and evaluator baselines. Consumers can replay model
+calls using the bundled cards for deterministic evaluation.
 
 The registry is live today, but the current toolchain lacks native commands
 for interacting with it; the flows above remain design targets until the CLI

--- a/docs/proposals/tooling.md
+++ b/docs/proposals/tooling.md
@@ -35,9 +35,10 @@ to the 1.0 roadmap.
 | `sfn bench` | Benchmarking framework | P3 | Post-1.0 |
 
 Existing commands (`sfn test`, `sfn build`, `sfn run`) are shipped and stable.
-Package-management commands (`sfn init`, `sfn add`, `sfn publish`, `sfn login`)
-are implemented and functional against `registry.sailfin.dev`. None of these
-are covered here.
+Package-management commands (`sfn init`, `sfn add`, `sfn publish`, `sfn login`,
+`sfn config`) are implemented and functional against `pkg.sfn.dev` (the default
+registry, overridable per-user via `sfn config set registry <url>` or per-shell
+via `SFN_REGISTRY`). None of these are covered here.
 
 
 ## Architectural Decision: Where Does Tooling Live?

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1117,8 +1117,11 @@ access, enum payload extraction, and aggregate literals share the same ABI.
 
 See `docs/status.md` for the canonical feature table and implementation notes.
 
-`registry.sailfin.dev` is live, but the current toolchain does not yet expose
-publish/resolve commands; integration work tracks on the roadmap.
+The default registry lives at `pkg.sfn.dev`. `sfn init`, `sfn add`, and
+`sfn publish` target it out of the box. Point the toolchain at a different
+registry — for example, an enterprise mirror behind a firewall — with
+`sfn config set registry <url>` (persists to `~/.sfn/config.toml`) or the
+`SFN_REGISTRY` environment variable (one-shot override).
 
 ## Effect System (Current and Planned)
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -95,7 +95,7 @@ feature availability.
 | `sfn doc` (doc generator) | Planned | 1.0; see `docs/proposals/tooling.md` |
 | `sfn fix` (auto-rewriter) | Planned | 1.0; see `docs/proposals/tooling.md` |
 | Notebook support | Not started | Post-1.0 |
-| Package registry (`sfn init/add/publish`) | Shipped | CLI commands implemented; registry at `registry.sailfin.dev` |
+| Package registry (`sfn init/add/publish`) | Shipped | CLI commands implemented; default registry at `pkg.sfn.dev`; configurable via `sfn config set registry <url>` or `SFN_REGISTRY` env var |
 
 ## Print API (Current)
 

--- a/llms.txt
+++ b/llms.txt
@@ -353,7 +353,9 @@ Known limitations:
     [capabilities]
     required = ["io", "net"]
 
-Packages are called "capsules" and published to registry.sailfin.dev.
+Packages are called "capsules" and published to pkg.sfn.dev by default.
+Override the registry with `sfn config set registry <url>` (persists to
+~/.sfn/config.toml) or set SFN_REGISTRY for a one-shot override.
 
 ## Idiomatic Patterns
 

--- a/runtime/native/src/native_driver.c
+++ b/runtime/native/src/native_driver.c
@@ -390,7 +390,7 @@ int main(int argc, char **argv)
         const char *first = argv[1];
         bool is_cli = false;
 
-        if (strcmp(first, "emit") == 0 || strcmp(first, "emit-llvm-file") == 0 || strcmp(first, "build") == 0 || strcmp(first, "run") == 0 || strcmp(first, "test") == 0 || strcmp(first, "version") == 0 || strcmp(first, "init") == 0 || strcmp(first, "publish") == 0 || strcmp(first, "add") == 0 || strcmp(first, "login") == 0 || strcmp(first, "guillermo") == 0 || strcmp(first, "fmt") == 0)
+        if (strcmp(first, "emit") == 0 || strcmp(first, "emit-llvm-file") == 0 || strcmp(first, "build") == 0 || strcmp(first, "run") == 0 || strcmp(first, "test") == 0 || strcmp(first, "check") == 0 || strcmp(first, "version") == 0 || strcmp(first, "init") == 0 || strcmp(first, "publish") == 0 || strcmp(first, "add") == 0 || strcmp(first, "login") == 0 || strcmp(first, "config") == 0 || strcmp(first, "guillermo") == 0 || strcmp(first, "fmt") == 0)
         {
             is_cli = true;
         }

--- a/site/src/components/Header.astro
+++ b/site/src/components/Header.astro
@@ -13,7 +13,7 @@ const navItems = [
       { label: "CLI Reference", href: "/docs/reference/cli" },
     ],
   },
-  { label: "Packages", href: "https://registry.sailfin.dev" },
+  { label: "Packages", href: "https://pkg.sfn.dev" },
   { label: "Blog", href: "/blog" },
   { label: "Community", href: "/community" },
 ];

--- a/site/src/content/docs/advanced/capsules.md
+++ b/site/src/content/docs/advanced/capsules.md
@@ -158,7 +158,16 @@ The `[dependencies]` table lists other capsules your capsule depends on. Depende
 
 ### Adding Dependencies
 
-**Note:** The `sfn add` command is planned for a future release. For now, add dependencies by editing `capsule.toml` directly and re-running your build command. The build system will fetch and cache the dependency from the configured registry (`pkg.sfn.dev` by default; override with `sfn config set registry <url>` or `SFN_REGISTRY`).
+Use `sfn add <capsule>` to record a dependency in `capsule.toml` and pre-fetch the package into `~/.sfn/cache/`. Pass `--dev` for dev-only dependencies and `--update` to pick up a newer version instead of honoring the lockfile:
+
+```bash
+sfn add http                  # add sfn/http (stdlib)
+sfn add --dev test            # dev dependency
+sfn add acme/router           # third-party scoped capsule
+sfn add --update acme/router  # ignore lockfile, fetch latest
+```
+
+The build system fetches capsules from the configured registry (`pkg.sfn.dev` by default; override with `sfn config set registry <url>` or `SFN_REGISTRY`).
 
 ### Dependency Resolution
 
@@ -456,7 +465,15 @@ export SFN_REGISTRY=https://registry.acme.internal
 
 Resolution order, highest priority first: `SFN_REGISTRY` env var → `~/.sfn/config.toml` → compiled-in default (`https://pkg.sfn.dev`).
 
-**Note:** The `sfn publish` command is planned and not yet implemented. When available, it will authenticate with the configured registry, validate the manifest, run tests, and upload the capsule. For now, treat the registry as a design preview.
+Publishing a capsule is a two-step flow:
+
+```bash
+sfn login                       # save your auth token to ~/.sfn/credentials (600)
+sfn publish                     # package the current capsule and upload it
+sfn publish path/to/capsule     # or package a capsule from a specific path
+```
+
+`sfn publish` bundles the capsule source (`capsule.toml` + `src/**/*.sfn`) into a SFNPKG payload, computes a SHA-256 digest, and POSTs it to `<registry>/api/publish` using the bearer token from `SFN_TOKEN` or `~/.sfn/credentials`. The registry URL is resolved through the same precedence as `sfn add` (`SFN_REGISTRY` → `~/.sfn/config.toml` → default). Capability auditing and signed provenance are in progress on the [roadmap](https://sailfin.dev/roadmap).
 
 The planned publication flow:
 

--- a/site/src/content/docs/advanced/capsules.md
+++ b/site/src/content/docs/advanced/capsules.md
@@ -158,7 +158,7 @@ The `[dependencies]` table lists other capsules your capsule depends on. Depende
 
 ### Adding Dependencies
 
-**Note:** The `sfn add` command is planned for a future release. For now, add dependencies by editing `capsule.toml` directly and re-running your build command. The build system will fetch and cache the dependency from the registry at `registry.sailfin.dev`.
+**Note:** The `sfn add` command is planned for a future release. For now, add dependencies by editing `capsule.toml` directly and re-running your build command. The build system will fetch and cache the dependency from the configured registry (`pkg.sfn.dev` by default; override with `sfn config set registry <url>` or `SFN_REGISTRY`).
 
 ### Dependency Resolution
 
@@ -405,7 +405,7 @@ When `sfn run` or `sfn build` is invoked, the build system:
 4. Emits `.sfn-asm` IR and lowers to LLVM IR.
 5. Links the native binary.
 
-If a dependency is not yet in the local cache, the build system fetches it from `registry.sailfin.dev` before proceeding.
+If a dependency is not yet in the local cache, the build system fetches it from the configured registry (`pkg.sfn.dev` by default) before proceeding.
 
 ## Writing Tests
 
@@ -444,9 +444,19 @@ test "loads config from disk" ![io] {
 
 ## Publishing
 
-The Sailfin package registry is live at [registry.sailfin.dev](https://registry.sailfin.dev).
+The default Sailfin package registry is live at [pkg.sfn.dev](https://pkg.sfn.dev). Enterprise users who need to host capsules behind a firewall can stand up a private registry and point their local toolchain at it:
 
-**Note:** The `sfn publish` command is planned and not yet implemented. When available, it will authenticate with the registry, validate the manifest, run tests, and upload the capsule. For now, treat the registry as a design preview.
+```bash
+# Persist per-user (writes ~/.sfn/config.toml)
+sfn config set registry https://registry.acme.internal
+
+# Or override just for the current shell
+export SFN_REGISTRY=https://registry.acme.internal
+```
+
+Resolution order, highest priority first: `SFN_REGISTRY` env var → `~/.sfn/config.toml` → compiled-in default (`https://pkg.sfn.dev`).
+
+**Note:** The `sfn publish` command is planned and not yet implemented. When available, it will authenticate with the configured registry, validate the manifest, run tests, and upload the capsule. For now, treat the registry as a design preview.
 
 The planned publication flow:
 

--- a/site/src/content/docs/reference/cli.md
+++ b/site/src/content/docs/reference/cli.md
@@ -268,15 +268,116 @@ The version is read from `compiler/capsule.toml` at runtime. For installed binar
 
 ---
 
-## Planned CLI Commands
+## Package Management
 
-The following commands are planned for a future release. They are not available today.
+Sailfin ships with package-management commands that target a default public registry at [`pkg.sfn.dev`](https://pkg.sfn.dev). All registry-touching commands (`sfn add`, `sfn publish`) resolve the registry URL through the same three-tier precedence — see [`sfn config`](#sfn-config-getsetunsetlist-key-value) below for how to redirect the toolchain at a private registry.
 
-| Command | Description |
+### `sfn init`
+
+Scaffold a new Sailfin capsule in the current directory. Writes a `capsule.toml` manifest (with the capsule name inferred from the directory) and a starter `src/main.sfn`.
+
+**Usage:**
+
+```bash
+sfn init
+```
+
+Fails with a non-zero exit if `capsule.toml` already exists — `sfn init` never overwrites existing manifests.
+
+---
+
+### `sfn add [--dev] [--update] <capsule>`
+
+Add a capsule dependency to the current project. The manifest (`capsule.toml`) is updated, the package is pre-fetched into `~/.sfn/cache/capsules/<scope>/<name>/<version>/`, and `capsule.lock` records the resolved version and SHA-256 integrity hash.
+
+**Flags:**
+
+- `--dev` — add to `[dev-dependencies]` instead of `[dependencies]`.
+- `--update` — ignore the existing lockfile entry and resolve the latest version from the registry.
+
+**Usage:**
+
+```bash
+sfn add http                  # stdlib capsule (resolved to sfn/http)
+sfn add --dev test            # dev-only dependency
+sfn add acme/router           # third-party scoped capsule
+sfn add --update acme/router  # force a fresh lookup
+```
+
+If a `capsule.lock` entry already exists and `--update` is not passed, the locked version is used without contacting the registry.
+
+---
+
+### `sfn publish [path]`
+
+Package a capsule (current directory by default, or the provided path) into the SFNPKG format and upload it to the configured registry.
+
+**Usage:**
+
+```bash
+sfn publish                     # package and upload the capsule at cwd
+sfn publish path/to/capsule     # or publish a capsule elsewhere on disk
+```
+
+**Authentication:** the command reads your bearer token from the `SFN_TOKEN` environment variable first, then falls back to `~/.sfn/credentials` (written by `sfn login`). If neither is set, publishing fails with a clear error.
+
+**Payload:** the capsule's `capsule.toml` and every `src/**/*.sfn` file are concatenated into a SFNPKG/1 bundle, SHA-256 digested, base64-encoded, and POSTed as JSON to `<registry>/api/publish`. Non-2xx HTTP responses are surfaced with the server error message.
+
+---
+
+### `sfn login [token]`
+
+Store a registry bearer token at `~/.sfn/credentials` (mode 600, inside `~/.sfn/` which is created at mode 700). This is the token `sfn publish` uses when `SFN_TOKEN` is not set.
+
+**Usage:**
+
+```bash
+sfn login                       # prompts and reads one line from stdin
+sfn login <token>               # or pass the token as an argument
+echo "<token>" | sfn login      # or pipe it in
+```
+
+Rejects empty tokens. Overwrites any existing credentials file.
+
+---
+
+### `sfn config <get|set|unset|list> [key] [value]`
+
+Persist per-user toolchain settings to `~/.sfn/config.toml` (mode 600). The only supported key today is `registry`, which controls where `sfn add` and `sfn publish` look for capsules.
+
+**Subcommands:**
+
+| Form | Description |
 |---|---|
-| `sfn init [name]` | Scaffold a new Sailfin capsule with a `capsule.toml` manifest |
-| `sfn add <capsule>` | Add a dependency to the current capsule |
-| `sfn publish` | Publish the current capsule to the package registry |
+| `sfn config list` | Print every resolved setting. |
+| `sfn config get <key>` | Print the resolved value for a single key. |
+| `sfn config set <key> <value>` | Persist `<value>` for `<key>`. |
+| `sfn config unset <key>` | Remove the key from `~/.sfn/config.toml`, reverting to the default. |
+
+**Usage:**
+
+```bash
+sfn config set registry https://registry.acme.internal   # point at a private registry
+sfn config get registry                                   # https://registry.acme.internal
+sfn config list                                           # registry = https://registry.acme.internal
+sfn config unset registry                                 # back to the default
+```
+
+**Resolution order** for the registry URL (highest priority first):
+
+1. `SFN_REGISTRY` environment variable — a one-shot override useful for CI.
+2. `[registry] url` in `~/.sfn/config.toml` — persisted by `sfn config set`.
+3. Compiled-in default: `https://pkg.sfn.dev`.
+
+The URL must start with `http://` or `https://` and may not contain whitespace, quotes, or shell metacharacters. Invalid values are rejected at `sfn config set` and silently ignored (with a warning to stderr) when coming from the environment or a hand-edited config file.
+
+**Enterprise example:** host a mirror behind your firewall and opt everyone in by adding a single line to your shell profile:
+
+```bash
+export SFN_REGISTRY=https://registry.acme.internal
+```
+
+Or put it in `~/.sfn/config.toml` once per workstation with `sfn config set registry ...` — no shell changes required.
 
 ---
 
@@ -324,6 +425,8 @@ These environment variables influence the behavior of `sfn` and the Makefile bui
 | Variable | Scope | Description |
 |---|---|---|
 | `SAILFIN_RUNTIME_ROOT` | `sfn` binary | Override the directory where `sfn` looks for the bundled C runtime. By default, the runtime is resolved relative to the executable. |
+| `SFN_REGISTRY` | `sfn add` / `sfn publish` | Override the package registry base URL for this shell. Takes precedence over `~/.sfn/config.toml`. See [`sfn config`](#sfn-config-getsetunsetlist-key-value). |
+| `SFN_TOKEN` | `sfn publish` | Bearer token used when uploading a capsule. Takes precedence over `~/.sfn/credentials` written by `sfn login`. |
 | `PREFIX` | Makefile | Installation prefix. Defaults to `$HOME/.local`. The binary is installed to `$(PREFIX)/bin`. |
 | `GLOBAL_BIN_DIR` | Installer script | Override the installation bin directory directly (takes precedence over `PREFIX`). |
 | `GITHUB_TOKEN` | `make fetch-seed` | GitHub personal access token used to download seed releases from the `SailfinIO/sailfin` repository. Required for `make fetch-seed`. |

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -29,9 +29,9 @@ const features = [
   },
   {
     title: "Package Registry",
-    description: "Capsules — Sailfin's packages — are published to registry.sailfin.dev with full dependency resolution and capability auditing.",
+    description: "Capsules — Sailfin's packages — are published to pkg.sfn.dev with full dependency resolution and capability auditing. Point `sfn` at a private registry with `sfn config set registry <url>`.",
     icon: "package",
-    href: "https://registry.sailfin.dev",
+    href: "https://pkg.sfn.dev",
   },
   {
     title: "Structured Concurrency",


### PR DESCRIPTION
Changes the default package registry from registry.sailfin.dev to
pkg.sfn.dev and introduces a layered configuration system so enterprise
users can point the toolchain at a private registry.

Registry URL resolution order (highest priority first):
  1. SFN_REGISTRY environment variable (one-shot override for CI)
  2. [registry] url in ~/.sfn/config.toml (persisted via sfn config)
  3. Compiled-in default: https://pkg.sfn.dev

New command: sfn config get|set|unset|list [key] [value]. Supports the
registry key today; structured to accept additional keys (cache dir,
default profile, ...) without another CLI change. Stored as TOML in
~/.sfn/config.toml with 600 permissions, matching ~/.sfn/credentials.

cli_commands.sfn: adds _resolve_registry_url_cmd and swaps the three
hardcoded URLs in publish (api/publish), add (api/index.json), and
add (api/capsules/...) to read the resolved base URL.

toml_parser.sfn: adds toml_get_string(text, section, key) for reading
ad-hoc config without allocating the SailToml struct across modules.

cli_main.sfn: rewrites _usage() into grouped sections (build & run,
project, packages, meta) and drops the duplicated command-list; only
non-obvious examples remain.

Tests: new compiler/tests/e2e/test_config.sh covering CRUD, env
override, permissions, and error paths. compiler/tests/e2e/test_publish.sh
gains coverage for default URL, config-file URL, env-var precedence,
and trailing-slash normalization via curl shims. Tests are bash e2e,
matching the pattern already used for login/publish so compiler
limitations aren't hit.

Docs: README, llms.txt, docs/status.md, docs/spec.md, the package-
management / build-architecture / tooling / model-engines proposals,
and the marketing site updated to reference pkg.sfn.dev and document
the configuration layering.

https://claude.ai/code/session_01Jp9CcvMEfj2Y2JWwVT2SRk