### PR TITLE
perf(compiler): remove .expr_stmt_* and .coerce_result_* IPC channels

### DIFF
--- a/compiler/src/cli_commands.sfn
+++ b/compiler/src/cli_commands.sfn
@@ -697,10 +697,15 @@ fn _clean_lowering_state(dir: string) -> number ![io] {
         // older build dirs / older seed binaries should still be swept.
         if _has_prefix_cmd(entry, ".block_result_") { is_scratch = true; }
         if _has_prefix_cmd(entry, ".call_result_") { is_scratch = true; }
+        // Legacy: .coerce_result_* file IPC fallback was removed (no writer
+        // was ever shipped); sweep stale files from older build dirs.
+        if _has_prefix_cmd(entry, ".coerce_result_") { is_scratch = true; }
         // Legacy: .ctx_func_* IPC channel was removed but stale files from
         // older build dirs / older seed binaries should still be swept.
         if _has_prefix_cmd(entry, ".ctx_func_") { is_scratch = true; }
         if _has_prefix_cmd(entry, ".dispatch_") { is_scratch = true; }
+        // Legacy: .expr_stmt_* IPC channel was removed but stale files from
+        // older build dirs / older seed binaries should still be swept.
         if _has_prefix_cmd(entry, ".expr_stmt_") { is_scratch = true; }
         // Legacy: .fn_* IPC channel was removed but stale files from
         // older build dirs / older seed binaries should still be swept.

--- a/compiler/src/llvm/expression_lowering/native/statement.sfn
+++ b/compiler/src/llvm/expression_lowering/native/statement.sfn
@@ -212,7 +212,7 @@ fn lower_expression_statement(function_name: string, instruction: NativeInstruct
             if index_check.success { is_lvalue = true; }
         }
         if is_lvalue {
-            return lower_lvalue_assignment_stmt(parsed_assignment.target, parsed_assignment.value, parsed_assignment.operator, current_bindings, current_locals, current_temp, current_lines, lines.length, current_next_region, scope_id, scope_depth, functions, context, current_label);
+            return lower_lvalue_assignment_stmt(parsed_assignment.target, parsed_assignment.value, parsed_assignment.operator, current_bindings, current_locals, current_temp, current_lines, current_next_region, scope_id, scope_depth, functions, context, current_label);
         }
 
         // Simple local assignment

--- a/compiler/src/llvm/expression_lowering/native/statement.sfn
+++ b/compiler/src/llvm/expression_lowering/native/statement.sfn
@@ -118,48 +118,6 @@ fn _recover_temp_from_lines(lines: string[], floor: number) -> number {
     return result;
 }
 
-// ---------------------------------------------------------------------------
-// IPC file helpers
-// ---------------------------------------------------------------------------
-// Helper: write expression statement result to files so cross-module
-// callers can read them even when struct return ABI is broken (v0.1.1 seed
-// compiles ExpressionStatementResult as i8* null for cross-module returns).
-fn _write_expr_stmt_result_files(input_lines_len: number, current_lines: string[], current_temp: number, mutations: LocalMutation[], current_next_region: number) ![io] {
-    fs.writeFile("build/sailfin/.expr_stmt_temp_index", number_to_string(current_temp));
-    fs.writeFile("build/sailfin/.expr_stmt_next_region_id", number_to_string(current_next_region));
-    let mut_count = mutations.length;
-    fs.writeFile("build/sailfin/.expr_stmt_mut_count", number_to_string(mut_count));
-    let mut mut_i = 0;
-    loop {
-        if mut_i >= mut_count { break; }
-        let m = mutations[mut_i];
-        let prefix = "build/sailfin/.expr_stmt_mut_" + number_to_string(mut_i);
-        fs.writeFile(prefix + "_name", m.name);
-        fs.writeFile(prefix + "_type", m.llvm_type);
-        fs.writeFile(prefix + "_value", m.value_name);
-        let mut label_val: string = "";
-        if m.originating_label != null { label_val = m.originating_label; }
-        fs.writeFile(prefix + "_label", label_val);
-        mut_i += 1;
-    }
-}
-
-// Variant that also serializes string constants to a file.
-fn _write_expr_stmt_result_files_with_constants(input_lines_len: number, current_lines: string[], current_temp: number, mutations: LocalMutation[], current_next_region: number, string_constants: StringConstant[]) ![io] {
-    _write_expr_stmt_result_files(input_lines_len, current_lines, current_temp, mutations, current_next_region);
-    // Write string constants as tab-separated lines: name\tcontent\tbyte_count
-    let mut sc_lines: string[] = [];
-    let mut si: number = 0;
-    loop {
-        if si >= string_constants.length { break; }
-        sc_lines.push(string_constants[si].name + "\t" + string_constants[si].content
-            + "\t"
-            + number_to_string(string_constants[si].byte_count));
-        si = si + 1;
-    }
-    fs.writeLines("build/sailfin/.expr_stmt_string_constants", sc_lines);
-}
-
 fn _parse_int_local(text: string) -> number {
     let len = text.length;
     if len == 0 { return 0; }
@@ -406,7 +364,6 @@ fn lower_expression_statement(function_name: string, instruction: NativeInstruct
             };
             mutations.push(mutation);
         }
-        _write_expr_stmt_result_files_with_constants(lines.length, current_lines, current_temp, mutations, current_next_region, string_constants);
         return ExpressionStatementResult {
             lines: current_lines,
             temp_index: current_temp,
@@ -498,7 +455,6 @@ fn lower_expression_statement(function_name: string, instruction: NativeInstruct
             + " delta="
             + number_to_string(current_lines.length - _pre_call_lines_len));
     }
-    _write_expr_stmt_result_files_with_constants(_pre_call_lines_len, current_lines, current_temp, mutations, current_next_region, string_constants);
     return ExpressionStatementResult {
         lines: current_lines,
         temp_index: current_temp,
@@ -565,7 +521,6 @@ fn lower_return_instruction(function: NativeFunction, instruction: NativeInstruc
                 + number_to_string(current_lines.length));
         }
         let empty_constants = empty_string_constant_set();
-        _write_expr_stmt_result_files_with_constants(lines.length, current_lines, current_temp, [], current_next_region, empty_constants);
         return ExpressionStatementResult {
             lines: current_lines,
             temp_index: current_temp,
@@ -671,7 +626,6 @@ fn lower_return_instruction(function: NativeFunction, instruction: NativeInstruc
             print.err("test llvm: lower_return no_operand lines_after="
                 + number_to_string(current_lines.length));
         }
-        _write_expr_stmt_result_files_with_constants(lines.length, current_lines, current_temp, [], current_next_region, string_constants);
         return ExpressionStatementResult {
             lines: current_lines,
             temp_index: current_temp,
@@ -697,7 +651,6 @@ fn lower_return_instruction(function: NativeFunction, instruction: NativeInstruc
         diagnostics.push("llvm lowering: void function `" + fn_name
             + "` returned a value");
         current_lines.push("  ret void");
-        _write_expr_stmt_result_files_with_constants(lines.length, current_lines, current_temp, [], current_next_region, string_constants);
         return ExpressionStatementResult {
             lines: current_lines,
             temp_index: current_temp,
@@ -742,7 +695,6 @@ fn lower_return_instruction(function: NativeFunction, instruction: NativeInstruc
             print.err("test llvm: lower_return no_coerce lines_after="
                 + number_to_string(current_lines.length));
         }
-        _write_expr_stmt_result_files_with_constants(lines.length, current_lines, current_temp, [], current_next_region, string_constants);
         return ExpressionStatementResult {
             lines: current_lines,
             temp_index: current_temp,
@@ -776,7 +728,6 @@ fn lower_return_instruction(function: NativeFunction, instruction: NativeInstruc
             current_bindings = mark_parameter_consumed(current_bindings, consumption.name);
         }
     }
-    _write_expr_stmt_result_files_with_constants(lines.length, current_lines, current_temp, [], current_next_region, string_constants);
     return ExpressionStatementResult {
         lines: current_lines,
         temp_index: current_temp,

--- a/compiler/src/llvm/expression_lowering/native/statement_assignment.sfn
+++ b/compiler/src/llvm/expression_lowering/native/statement_assignment.sfn
@@ -102,17 +102,10 @@ fn _assign_parse_int(text: string) -> number {
 }
 
 fn _write_assign_result_files(pre_lines_count: number, lines: string[], temp_index: number, mutations: LocalMutation[], next_region_id: number, string_constants: StringConstant[]) ![io] {
-    let new_count = lines.length - pre_lines_count;
     fs.writeFile("build/sailfin/.call_result_lines_count", number_to_string(lines.length));
     // Write all lines as bulk array
     fs.writeLines("build/sailfin/.call_result_lines", lines);
     fs.writeFile("build/sailfin/.call_result_temp", number_to_string(temp_index));
-    // Also write to .expr_stmt_temp_index — the caller in instructions.sfn reads
-    // this file for temp counter recovery.  Without this, lvalue assignments
-    // (struct field mutations like state.index += 1) leave a stale counter and
-    // the next statement reuses the same %tN temporaries.
-    fs.writeFile("build/sailfin/.expr_stmt_temp_index", number_to_string(temp_index));
-    fs.writeFile("build/sailfin/.expr_stmt_next_region_id", number_to_string(next_region_id));
 }
 
 // Handles deref (*ptr = value), member access (obj.field = value), and

--- a/compiler/src/llvm/expression_lowering/native/statement_assignment.sfn
+++ b/compiler/src/llvm/expression_lowering/native/statement_assignment.sfn
@@ -101,7 +101,7 @@ fn _assign_parse_int(text: string) -> number {
     return result;
 }
 
-fn _write_assign_result_files(pre_lines_count: number, lines: string[], temp_index: number, mutations: LocalMutation[], next_region_id: number, string_constants: StringConstant[]) ![io] {
+fn _write_assign_result_files(lines: string[], temp_index: number) ![io] {
     fs.writeFile("build/sailfin/.call_result_lines_count", number_to_string(lines.length));
     // Write all lines as bulk array
     fs.writeLines("build/sailfin/.call_result_lines", lines);
@@ -110,7 +110,7 @@ fn _write_assign_result_files(pre_lines_count: number, lines: string[], temp_ind
 
 // Handles deref (*ptr = value), member access (obj.field = value), and
 // array index (arr[i] = value) assignments. Returns ExpressionStatementResult.
-fn lower_lvalue_assignment_stmt(assign_target: string, assign_value: string, assign_operator: string, current_bindings: ParameterBinding[], current_locals: LocalBinding[], temp_index: number, lines: string[], pre_lines_count: number, next_region_id: number, scope_id: string, scope_depth: number, functions: NativeFunction[], context: TypeContext, current_label: string) -> ExpressionStatementResult ![io] {
+fn lower_lvalue_assignment_stmt(assign_target: string, assign_value: string, assign_operator: string, current_bindings: ParameterBinding[], current_locals: LocalBinding[], temp_index: number, lines: string[], next_region_id: number, scope_id: string, scope_depth: number, functions: NativeFunction[], context: TypeContext, current_label: string) -> ExpressionStatementResult ![io] {
     let mut diagnostics: string[] = [];
     let mut current_lines: string[] = lines;
     let mut current_temp: number = temp_index;
@@ -144,7 +144,7 @@ fn lower_lvalue_assignment_stmt(assign_target: string, assign_value: string, ass
             diagnostics.push("llvm lowering: failed to lower assignment value for deref target `"
                 + assign_target
                 + "`");
-            _write_assign_result_files(pre_lines_count, current_lines, current_temp, mutations, current_next_region, string_constants);
+            _write_assign_result_files(current_lines, current_temp);
             return ExpressionStatementResult {
                 lines: current_lines,
                 temp_index: current_temp,
@@ -161,7 +161,7 @@ fn lower_lvalue_assignment_stmt(assign_target: string, assign_value: string, ass
         let pointer_text = trim_text(substring(trimmed_target, 1, trimmed_target.length));
         if pointer_text.length == 0 {
             diagnostics.push("llvm lowering: deref assignment missing pointer operand");
-            _write_assign_result_files(pre_lines_count, current_lines, current_temp, mutations, current_next_region, string_constants);
+            _write_assign_result_files(current_lines, current_temp);
             return ExpressionStatementResult {
                 lines: current_lines,
                 temp_index: current_temp,
@@ -189,7 +189,7 @@ fn lower_lvalue_assignment_stmt(assign_target: string, assign_value: string, ass
             diagnostics.push("llvm lowering: deref assignment pointer `"
                 + pointer_text
                 + "` produced no value");
-            _write_assign_result_files(pre_lines_count, current_lines, current_temp, mutations, current_next_region, string_constants);
+            _write_assign_result_files(current_lines, current_temp);
             return ExpressionStatementResult {
                 lines: current_lines,
                 temp_index: current_temp,
@@ -207,7 +207,7 @@ fn lower_lvalue_assignment_stmt(assign_target: string, assign_value: string, ass
             diagnostics.push("llvm lowering: deref assignment target is not a pointer (got `"
                 + lowered_ptr.operand.llvm_type
                 + "`)");
-            _write_assign_result_files(pre_lines_count, current_lines, current_temp, mutations, current_next_region, string_constants);
+            _write_assign_result_files(current_lines, current_temp);
             return ExpressionStatementResult {
                 lines: current_lines,
                 temp_index: current_temp,
@@ -236,7 +236,7 @@ fn lower_lvalue_assignment_stmt(assign_target: string, assign_value: string, ass
             diagnostics.push("llvm lowering: unable to coerce deref assignment value to `"
                 + element_type
                 + "`");
-            _write_assign_result_files(pre_lines_count, current_lines, current_temp, mutations, current_next_region, string_constants);
+            _write_assign_result_files(current_lines, current_temp);
             return ExpressionStatementResult {
                 lines: current_lines,
                 temp_index: current_temp,
@@ -255,7 +255,7 @@ fn lower_lvalue_assignment_stmt(assign_target: string, assign_value: string, ass
             + element_type
             + "* "
             + lowered_ptr.operand.value);
-        _write_assign_result_files(pre_lines_count, current_lines, current_temp, mutations, current_next_region, string_constants);
+        _write_assign_result_files(current_lines, current_temp);
         return ExpressionStatementResult {
             lines: current_lines,
             temp_index: current_temp,
@@ -334,7 +334,7 @@ fn lower_lvalue_assignment_stmt(assign_target: string, assign_value: string, ass
                     diagnostics.push("llvm lowering: member access assignment base `"
                         + member_parse.base
                         + "` is not addressable");
-                    _write_assign_result_files(pre_lines_count, current_lines, current_temp, mutations, current_next_region, string_constants);
+                    _write_assign_result_files(current_lines, current_temp);
                     return ExpressionStatementResult {
                         lines: current_lines,
                         temp_index: current_temp,
@@ -397,7 +397,7 @@ fn lower_lvalue_assignment_stmt(assign_target: string, assign_value: string, ass
                 }
             }
         }
-        _write_assign_result_files(pre_lines_count, current_lines, current_temp, mutations, current_next_region, string_constants);
+        _write_assign_result_files(current_lines, current_temp);
         return ExpressionStatementResult {
             lines: current_lines,
             temp_index: current_temp,
@@ -499,7 +499,7 @@ fn lower_lvalue_assignment_stmt(assign_target: string, assign_value: string, ass
                                 diagnostics.push("llvm lowering: unable to coerce array index to i64 for `"
                                     + assign_target
                                     + "`");
-                                _write_assign_result_files(pre_lines_count, current_lines, current_temp, mutations, current_next_region, string_constants);
+                                _write_assign_result_files(current_lines, current_temp);
                                 return ExpressionStatementResult {
                                     lines: current_lines,
                                     temp_index: current_temp,
@@ -555,7 +555,7 @@ fn lower_lvalue_assignment_stmt(assign_target: string, assign_value: string, ass
                 }
             }
         }
-        _write_assign_result_files(pre_lines_count, current_lines, current_temp, mutations, current_next_region, string_constants);
+        _write_assign_result_files(current_lines, current_temp);
         return ExpressionStatementResult {
             lines: current_lines,
             temp_index: current_temp,
@@ -571,7 +571,7 @@ fn lower_lvalue_assignment_stmt(assign_target: string, assign_value: string, ass
     }
 
     // Not a complex lvalue — should not reach here; caller dispatches simple local separately.
-    _write_assign_result_files(pre_lines_count, current_lines, current_temp, mutations, current_next_region, string_constants);
+    _write_assign_result_files(current_lines, current_temp);
     return ExpressionStatementResult {
         lines: current_lines,
         temp_index: current_temp,

--- a/compiler/src/llvm/lowering/instructions_dispatch.sfn
+++ b/compiler/src/llvm/lowering/instructions_dispatch.sfn
@@ -31,12 +31,11 @@ import {
 import {
     append_string,
     extend_string_array,
-    index_of,
     number_to_string,
     starts_with,
     trim_text
 } from "../utils";
-import { _parse_int_from_string, _read_ipc_int_min, extend_mutations } from "./instructions_helpers";
+import { extend_mutations } from "./instructions_helpers";
 import { extend_lifetime_regions } from "./instructions_helpers";
 import { lower_let_instruction } from "./instructions_let";
 import {
@@ -98,45 +97,6 @@ fn _write_locals_to_files(locals: LocalBinding[]) ![io] {
         fs.writeFile(lw_prefix + "_scope_depth", number_to_string(locals[lw_i].scope_depth));
         lw_i += 1;
     }
-}
-
-// Read string constants from the expr_stmt_string_constants file.
-// Returns the merged string constants.
-fn _read_expr_string_constants(existing: StringConstant[]) -> StringConstant[] ![io] {
-    let mut result = existing;
-    if fs.exists("build/sailfin/.expr_stmt_string_constants") {
-        let _raw = fs.readFile("build/sailfin/.expr_stmt_string_constants");
-        if _raw.length > 0 {
-            let mut _pos: number = 0;
-            loop {
-                if _pos >= _raw.length { break; }
-                let _nl = index_of(substring(_raw, _pos, _raw.length), "\n");
-                let mut _line: string = "";
-                if _nl < 0 {
-                    _line = substring(_raw, _pos, _raw.length);
-                    _pos = _raw.length;
-                } else {
-                    _line = substring(_raw, _pos, _pos + _nl);
-                    _pos = _pos + _nl + 1;
-                }
-                if _line.length == 0 { continue; }
-                let _t1 = index_of(_line, "\t");
-                if _t1 < 0 { continue; }
-                let _nm = substring(_line, 0, _t1);
-                let _r2 = substring(_line, _t1 + 1, _line.length);
-                let _t2 = index_of(_r2, "\t");
-                if _t2 < 0 { continue; }
-                let _ct = substring(_r2, 0, _t2);
-                let _bct = substring(_r2, _t2 + 1, _r2.length);
-                let _bc = _parse_int_from_string(_bct);
-                result = merge_string_constants(result, [StringConstant {
-                    name: _nm, content: _ct, byte_count: _bc
-                }]);
-            }
-        }
-        fs.writeFile("build/sailfin/.expr_stmt_string_constants", "");
-    }
-    return result;
 }
 
 // Read Let result from files and apply to caller's state.
@@ -235,31 +195,16 @@ fn dispatch_expression_instruction(function: NativeFunction, index: number, inst
         _write_bindings_to_files(bindings);
         _write_locals_to_files(result_locals);
         let lowered = lower_expression_statement(function.name, instruction, trimmed_expression, bindings, result_locals, temp_index, lines, next_region_id, scope_id, scope_depth, functions, context, active_label);
-        // Read scalar results from files. Use floor-protected reader so that
-        // a missing/empty/stale temp-index file cannot cause the SSA counter
-        // to reset below `temp_index`, which would produce duplicate %tN
-        // definitions in the same function (see _read_ipc_int_min doc).
-        let _expr_temp = _read_ipc_int_min("build/sailfin/.expr_stmt_temp_index", temp_index);
-        let _expr_region = _parse_int_from_string(fs.readFile("build/sailfin/.expr_stmt_next_region_id"));
+        // Floor-protect the temp counter: a stale or zero value would
+        // produce duplicate %tN in the next emission (see _read_ipc_int_min doc).
+        let mut _expr_temp = lowered.temp_index;
+        if _expr_temp < temp_index { _expr_temp = temp_index; }
+        let _expr_region = lowered.next_region_id;
         fs.writeFile("build/sailfin/.dispatch_temp", number_to_string(_expr_temp));
         fs.writeFile("build/sailfin/.dispatch_next_region", number_to_string(_expr_region));
         fs.writeFile("build/sailfin/.dispatch_used_file_ipc", "1");
-        // Read mutations
-        let _mut_count = _parse_int_from_string(fs.readFile("build/sailfin/.expr_stmt_mut_count"));
-        let mut _mi: number = 0;
-        loop {
-            if _mi >= _mut_count { break; }
-            let _mp = "build/sailfin/.expr_stmt_mut_" + number_to_string(_mi);
-            let _mn = fs.readFile(_mp + "_name");
-            let _mt = fs.readFile(_mp + "_type");
-            let _mv = fs.readFile(_mp + "_value");
-            let _ml = fs.readFile(_mp + "_label");
-            current_mutations = extend_mutations(current_mutations, [LocalMutation {
-                name: _mn, llvm_type: _mt, value_name: _mv, span: null, originating_label: _ml
-            }]);
-            _mi += 1;
-        }
-        current_string_constants = _read_expr_string_constants(current_string_constants);
+        current_mutations = extend_mutations(current_mutations, lowered.mutations);
+        current_string_constants = merge_string_constants(current_string_constants, lowered.string_constants);
     }
     // Write mutation count for caller
     fs.writeFile("build/sailfin/.dispatch_mutation_count", number_to_string(current_mutations.length));
@@ -288,13 +233,14 @@ fn dispatch_return_instruction(function: NativeFunction, index: number, instruct
     _write_bindings_to_files(bindings);
     _write_locals_to_files(locals);
     let lowered = lower_return_instruction(function, instruction, llvm_return, bindings, locals, temp_index, lines, next_region_id, scope_id, scope_depth, functions, context);
-    // Read scalar results. Floor-protected: see _read_ipc_int_min.
-    let _ret_temp = _read_ipc_int_min("build/sailfin/.expr_stmt_temp_index", temp_index);
-    let _ret_region = _parse_int_from_string(fs.readFile("build/sailfin/.expr_stmt_next_region_id"));
+    // Floor-protect the temp counter: a stale or zero value would
+    // produce duplicate %tN in the next emission (see _read_ipc_int_min doc).
+    let mut _ret_temp: number = lowered.temp_index;
+    if _ret_temp < temp_index { _ret_temp = temp_index; }
+    let _ret_region = lowered.next_region_id;
     fs.writeFile("build/sailfin/.dispatch_temp", number_to_string(_ret_temp));
     fs.writeFile("build/sailfin/.dispatch_next_region", number_to_string(_ret_region));
-    // Read string constants
-    let result_sc = _read_expr_string_constants(string_constants);
+    let result_sc = merge_string_constants(string_constants, lowered.string_constants);
     // Write string constants count for caller
     let mut _joined_sc: string = "";
     let mut _si: number = 0;

--- a/compiler/src/llvm/lowering/instructions_helpers.sfn
+++ b/compiler/src/llvm/lowering/instructions_helpers.sfn
@@ -177,45 +177,6 @@ fn write_locals_to_files(locals: LocalBinding[]) ![io] {
     }
 }
 
-// Read string constants from the expr_stmt_string_constants file,
-// merging into existing. Clears the file after reading.
-fn read_expr_string_constants(existing: StringConstant[]) -> StringConstant[] ![io] {
-    let mut result = existing;
-    if fs.exists("build/sailfin/.expr_stmt_string_constants") {
-        let _raw = fs.readFile("build/sailfin/.expr_stmt_string_constants");
-        if _raw.length > 0 {
-            let mut _pos: number = 0;
-            loop {
-                if _pos >= _raw.length { break; }
-                let _nl = index_of(substring(_raw, _pos, _raw.length), "\n");
-                let mut _line: string = "";
-                if _nl < 0 {
-                    _line = substring(_raw, _pos, _raw.length);
-                    _pos = _raw.length;
-                } else {
-                    _line = substring(_raw, _pos, _pos + _nl);
-                    _pos = _pos + _nl + 1;
-                }
-                if _line.length == 0 { continue; }
-                let _t1 = index_of(_line, "\t");
-                if _t1 < 0 { continue; }
-                let _nm = substring(_line, 0, _t1);
-                let _r2 = substring(_line, _t1 + 1, _line.length);
-                let _t2 = index_of(_r2, "\t");
-                if _t2 < 0 { continue; }
-                let _ct = substring(_r2, 0, _t2);
-                let _bct = substring(_r2, _t2 + 1, _r2.length);
-                let _bc = _parse_int_from_string(_bct);
-                result = merge_string_constants(result, [StringConstant {
-                    name: _nm, content: _ct, byte_count: _bc
-                }]);
-            }
-        }
-        fs.writeFile("build/sailfin/.expr_stmt_string_constants", "");
-    }
-    return result;
-}
-
 // Read string constants from the let_result_string_constants file,
 // merging into existing. Used by let instruction handler.
 fn read_let_result_string_constants(existing: StringConstant[]) -> StringConstant[] ![io] {
@@ -305,26 +266,6 @@ fn read_let_result_from_files(diagnostics: string[], current_locals: LocalBindin
         }
     } else { fs.writeFile("build/sailfin/.let_ipc_used", "0"); }
     return result_locals;
-}
-
-// Read mutations from expr_stmt file IPC.
-fn read_expr_mutations(existing: LocalMutation[]) -> LocalMutation[] ![io] {
-    let mut result = existing;
-    let _mut_count = _parse_int_from_string(fs.readFile("build/sailfin/.expr_stmt_mut_count"));
-    let mut _mi: number = 0;
-    loop {
-        if _mi >= _mut_count { break; }
-        let _mp = "build/sailfin/.expr_stmt_mut_" + number_to_string(_mi);
-        let _mn = fs.readFile(_mp + "_name");
-        let _mt = fs.readFile(_mp + "_type");
-        let _mv = fs.readFile(_mp + "_value");
-        let _ml = fs.readFile(_mp + "_label");
-        result = extend_mutations(result, [LocalMutation {
-            name: _mn, llvm_type: _mt, value_name: _mv, span: null, originating_label: _ml
-        }]);
-        _mi += 1;
-    }
-    return result;
 }
 
 // Scan accumulated IR lines for the highest %tN temp index and return

--- a/compiler/src/llvm/lowering/instructions_let.sfn
+++ b/compiler/src/llvm/lowering/instructions_let.sfn
@@ -368,66 +368,36 @@ fn lower_let_instruction(function: NativeFunction, instruction: NativeInstructio
                     + operand.value);
             }
         } else {
-            // Types differ — need coercion. Since coerce_operand_to_type returns
-            // a struct across module boundaries (ABI corruption risk), we write
-            // the result to files from inside coerce_operand_to_type and read back.
+            // Types differ — coerce and use the returned struct.
             let coerced = coerce_operand_to_type(operand, llvm_type, current_temp, current_lines);
-            // Try file-based result first
-            if fs.exists("build/sailfin/.coerce_result_type") {
-                let _cr_type = fs.readFile("build/sailfin/.coerce_result_type");
-                let _cr_value = fs.readFile("build/sailfin/.coerce_result_value");
-                if _cr_type.length > 0 {
-                    stored_value = _cr_value;
-                    current_lines.push("  store " + llvm_type + " " + _cr_value
-                        + ", "
-                        + llvm_type
-                        + "* "
-                        + pointer);
-                } else {
-                    diagnostics.push("llvm lowering: unable to coerce initializer for `"
-                        + instruction.name
-                        + "` to `"
-                        + llvm_type
-                        + "`");
-                    current_lines.push("  store " + llvm_type + " "
-                        + default_return_literal(llvm_type)
-                        + ", "
-                        + llvm_type
-                        + "* "
-                        + pointer);
-                }
-                fs.deleteFile("build/sailfin/.coerce_result_type");
+            let mut _ci20: number = 0;
+            loop {
+                if _ci20 >= coerced.diagnostics.length { break; }
+                diagnostics.push(coerced.diagnostics[_ci20]);
+                _ci20 += 1;
+            }
+            current_lines = coerced.lines;
+            current_temp = coerced.temp_index;
+            if coerced.operand == null {
+                diagnostics.push("llvm lowering: unable to coerce initializer for `"
+                    + instruction.name
+                    + "` to `"
+                    + llvm_type
+                    + "`");
+                current_lines.push("  store " + llvm_type + " "
+                    + default_return_literal(llvm_type)
+                    + ", "
+                    + llvm_type
+                    + "* "
+                    + pointer);
             } else {
-                // Fallback: try struct fields (may crash if corrupted)
-                let mut _ci20: number = 0;
-                loop {
-                    if _ci20 >= coerced.diagnostics.length { break; }
-                    diagnostics.push(coerced.diagnostics[_ci20]);
-                    _ci20 += 1;
-                }
-                current_lines = coerced.lines;
-                current_temp = coerced.temp_index;
-                if coerced.operand == null {
-                    diagnostics.push("llvm lowering: unable to coerce initializer for `"
-                        + instruction.name
-                        + "` to `"
-                        + llvm_type
-                        + "`");
-                    current_lines.push("  store " + llvm_type + " "
-                        + default_return_literal(llvm_type)
-                        + ", "
-                        + llvm_type
-                        + "* "
-                        + pointer);
-                } else {
-                    let stored = coerced.operand;
-                    stored_value = stored.value;
-                    current_lines.push("  store " + llvm_type + " " + stored.value
-                        + ", "
-                        + llvm_type
-                        + "* "
-                        + pointer);
-                }
+                let stored = coerced.operand;
+                stored_value = stored.value;
+                current_lines.push("  store " + llvm_type + " " + stored.value
+                    + ", "
+                    + llvm_type
+                    + "* "
+                    + pointer);
             }
         }
     } else {

--- a/docs/build-performance.md
+++ b/docs/build-performance.md
@@ -433,7 +433,7 @@ Criterion (2) is the only unmet gate, and its failure is **not arena-induced** �
    - `concat_native_functions` site 2 in `lowering_core.sfn:573` (the one the d2d0bf1 sweep left copying because `collect_runtime_helper_targets`/`render_llvm_preamble`/`lower_all_functions` needed a pristine `local_functions`).
    - All 6 `append_local_binding` sites in `expression_lowering/native/core_scopes.sfn:174-186`.
    Both were deferred because in-place mutation leaked across scope restoration. Under arena, the copy is a cheap bump alloc and both views are preserved — in-place conversions are safe.
-2. **Phase 2 IPC channels previously blocked by IPC-as-GC (~146 refs) become pickable:** `.call_result_*` (51), `.let_result_*` / `.let_ipc_*` (39), `.expr_stmt_*` (21), `.instr_*` (18), `.dispatch_*` (12), `.block_result_*` (5).
+2. **Phase 2 IPC channels previously blocked by IPC-as-GC (~146 refs) become pickable:** `.call_result_*` (51), `.let_result_*` / `.let_ipc_*` (39), ~~`.expr_stmt_*` (21)~~ removed in PR #191, `.instr_*` (18), `.dispatch_*` (12), ~~`.block_result_*` (5)~~ removed in PR #188.
 
 **macOS-arm64 determinism:** The 0.5.7 seed's residual non-determinism on macOS-arm64 (PRs #178 / #183 / #184 / #185 each measured 20-run hash sweeps against this) is driven by Phase 2 channels still active, not by memory allocation patterns. The arena flip itself should not change the non-determinism surface area — measurement will land in the PR body once CI completes on macOS-arm64.
 
@@ -519,7 +519,35 @@ The channel existed as a workaround for the v0.1.1-seed compiling `emission.sfn`
 
 For a typical compiler module (50-200 functions, ~3 params + 0-1 decorators per fn), this eliminates roughly 500-2000 filesystem operations per module compile.
 
-**Determinism delta:** Full build + test suite passed on CI across platforms after removal. Linux x86_64 on seed 0.5.7 was already 20/20 identical on the hot modules per the arena-flip entry; this change removes per-function file-I/O overhead without introducing new non-determinism. macOS-arm64 determinism surface continues to be driven by the remaining Phase 2 channels (call-result, dispatch, let-result, expr-stmt) and is unchanged by this removal.
+**Determinism delta:** Full build + test suite passed on CI across platforms after removal. Linux x86_64 on seed 0.5.7 was already 20/20 identical on the hot modules per the arena-flip entry; this change removes per-function file-I/O overhead without introducing new non-determinism. macOS-arm64 determinism surface continues to be driven by the remaining Phase 2 channels (call-result, dispatch, let-result) and is unchanged by this removal.
+
+### Expression Statement & Coerce Result IPC Channel Removal (April 19, PR #191)
+
+**Status: Implemented.** Removed two channels in one sweep:
+
+* **`.expr_stmt_*`** (21 dotfile refs, 2 writers, 2 readers): the v0.1.1-seed-era workaround used by `lower_expression_statement` / `lower_return_instruction` to ship per-statement temp counter, region id, mutations, and string constants back to `dispatch_expression_instruction` / `dispatch_return_instruction`. Both writers already returned a fully-populated `ExpressionStatementResult` struct; the file IPC was a parallel copy of the same data. Under the default-on arena (PR #186) the 0.5.7 seed handles cross-module struct returns correctly — same pattern validated by PRs #183 / #184 / #185 / #188 / #189. The dispatch readers now consume `lowered.{temp_index, next_region_id, mutations, string_constants}` directly, with the same temp-counter floor protection inlined.
+
+* **`.coerce_result_*`** (4 dotfile refs, 0 writers): pure dead code. The fallback reader in `instructions_let.sfn` checked for files no caller ever wrote — `coerce_operand_to_type` returns its result via `CoercionResult` struct and never touched the filesystem. Collapsed to the existing struct-field path.
+
+**Shape of change:**
+- `_write_expr_stmt_result_files{,_with_constants}` deleted from `statement.sfn` (2 helpers + 8 call sites at all return points of `lower_expression_statement` and `lower_return_instruction`).
+- `_read_expr_string_constants` deleted from `instructions_dispatch.sfn`; both dispatch readers now use struct fields directly.
+- `read_expr_string_constants` and `read_expr_mutations` deleted from `instructions_helpers.sfn` — both were unused/dead code.
+- `_write_assign_result_files` in `statement_assignment.sfn` had its two `.expr_stmt_*` writes dropped (the surrounding `.call_result_*` writes stay — separate channel, not in scope). Signature simplified from `(pre_lines_count, lines, temp_index, mutations, next_region_id, string_constants)` to `(lines, temp_index)` after the unused params became dead, with `lower_lvalue_assignment_stmt` losing its `pre_lines_count` parameter as well (per PR #191 review).
+- `instructions_let.sfn`'s `.coerce_result_type` file-existence branch (62 lines including the dead "fallback") collapsed to the `CoercionResult` struct path.
+- `cli_commands._clean_lowering_state` adds `.expr_stmt_` and `.coerce_result_` "Legacy" sweeps for stale files from older build dirs / older seed binaries (precedent: PRs #183 / #184 / #185 / #188 / #189).
+
+**Per-statement overhead removed:**
+- 5 + 4N `fs.writeFile` per emitted statement (temp/region/mut_count scalars + 4 per mutation: name/type/value/label)
+- 1 `fs.writeLines` per statement (string_constants array)
+- 5 `fs.readFile` + bulk parsing on the reader side
+- 4 `fs.readFile` per mutation on the reader side
+
+For typical compiler modules (hundreds of statements per function, dozens of functions per module) this eliminates thousands of filesystem operations per module compile.
+
+**Scope:**
+- 6 source files modified, ~−241 / +47 lines net.
+- No new tests added — the existing integration suite (`selfhost_pipeline_test.sfn`, `async_struct_return_stress_test.sfn`, `compiler_ir_patterns_test.sfn`) and the self-hosting build itself exercise every path that was changed.
 
 ---
 


### PR DESCRIPTION
Continues the Phase 2 IPC removal sweep tracked in
docs/build-performance.md. Two channels are eliminated:

* `.expr_stmt_*` (21 dotfile refs, 2 writers, 2 readers): a v0.1.1-seed-era
  workaround used by `lower_expression_statement` /
  `lower_return_instruction` to ship per-statement temp counter, region id,
  mutations, and string constants back to `dispatch_expression_instruction`
  / `dispatch_return_instruction`. Both writers already returned a fully
  populated `ExpressionStatementResult` struct; the file IPC was a parallel
  copy of the same data. Under the default-on arena (PR #186) the 0.5.7
  seed handles cross-module struct returns correctly — same pattern
  validated by PRs #183/#184/#185/#188/#189. The dispatch readers now use
  `lowered.{temp_index, next_region_id, mutations, string_constants}`
  directly, with the same temp-counter floor protection inlined. Helpers
  `_write_expr_stmt_result_files{,_with_constants}` (statement.sfn),
  `read_expr_string_constants` / `read_expr_mutations` (instructions_helpers.sfn,
  unused), and `_read_expr_string_constants` (instructions_dispatch.sfn) are
  deleted. The two `.expr_stmt_*` writes inside `_write_assign_result_files`
  are dropped (the surrounding `.call_result_*` writes stay — separate
  channel, not in scope).

* `.coerce_result_*` (4 dotfile refs, 0 writers): pure dead code. The
  fallback reader in `instructions_let.sfn` checked for a file that no
  caller ever wrote — `coerce_operand_to_type` returns its result via
  `CoercionResult` struct and never touched the filesystem. Collapsed to
  the existing struct-field path.

Per-statement overhead removed:
- 5 + 4N `fs.writeFile` per emitted statement (temp/region/mut_count
  scalars + 4 per mutation: name/type/value/label)
- 1 `fs.writeLines` per statement (string_constants array)
- 5 `fs.readFile` + bulk parsing on the reader side
- 4 `fs.readFile` per mutation on the reader side

For typical compiler modules (hundreds of statements per function, dozens
of functions per module) this eliminates thousands of filesystem
operations per module compile.

Both `.expr_stmt_` and `.coerce_result_` prefixes are kept in the
`_clean_lowering_state` legacy sweep to clean stale files from older
build dirs, following the PR #183 / #184 / #185 / #188 / #189 precedent.

https://claude.ai/code/session_01N8pS8D81CRJzwKnB9ei8yZ