### PR TITLE
perf(compiler): remove .call_result_* IPC channel

### DIFF
--- a/compiler/src/cli_commands.sfn
+++ b/compiler/src/cli_commands.sfn
@@ -696,6 +696,8 @@ fn _clean_lowering_state(dir: string) -> number ![io] {
         // Legacy: .block_result_* IPC channel was removed but stale files from
         // older build dirs / older seed binaries should still be swept.
         if _has_prefix_cmd(entry, ".block_result_") { is_scratch = true; }
+        // Legacy: .call_result_* IPC channel was removed but stale files from
+        // older build dirs / older seed binaries should still be swept.
         if _has_prefix_cmd(entry, ".call_result_") { is_scratch = true; }
         // Legacy: .coerce_result_* file IPC fallback was removed (no writer
         // was ever shipped); sweep stale files from older build dirs.

--- a/compiler/src/llvm/expression_lowering/native/core.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core.sfn
@@ -585,9 +585,6 @@ fn lower_expression(expression: string, bindings: ParameterBinding[], locals: Lo
                     llvm_type: "void",
                     value: ""
                 };
-                // Overwrite stale call-result files from the inner spawn call
-                fs.writeFile("build/sailfin/.call_result_type", "void");
-                fs.writeFile("build/sailfin/.call_result_value", "");
                 return ExpressionResult {
                     lines: awaited_lines,
                     temp_index: lowered.temp_index,
@@ -667,9 +664,6 @@ fn lower_expression(expression: string, bindings: ParameterBinding[], locals: Lo
                                 llvm_type: trimmed_expected,
                                 value: load_temp
                             };
-                            // Overwrite stale call-result files from the inner spawn call
-                            fs.writeFile("build/sailfin/.call_result_type", trimmed_expected);
-                            fs.writeFile("build/sailfin/.call_result_value", load_temp);
                             return ExpressionResult {
                                 lines: awaited_lines2,
                                 temp_index: lowered.temp_index + 3,
@@ -686,9 +680,6 @@ fn lower_expression(expression: string, bindings: ParameterBinding[], locals: Lo
                 llvm_type: result_type,
                 value: result_temp
             };
-            // Overwrite stale call-result files from the inner spawn call
-            fs.writeFile("build/sailfin/.call_result_type", result_type);
-            fs.writeFile("build/sailfin/.call_result_value", result_temp);
             return ExpressionResult {
                 lines: awaited_lines2,
                 temp_index: lowered.temp_index + 1,

--- a/compiler/src/llvm/expression_lowering/native/core_call_emission.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_call_emission.sfn
@@ -35,10 +35,6 @@ import { parse_member_access } from "./core_parse";
 import { find_local_binding } from "./core_scopes";
 import { sanitize_symbol } from "./core_text";
 
-fn _write_emission_result_lines(result_lines: string[], result_temp: number) -> void ![io] {
-    // Dead IPC files removed — .call_result_line_count and .call_result_temp_index have no reader.
-}
-
 // Coerce operands to expected types and emit the final call instruction.
 // Handles array concat/push, trait dispatch, and normal function calls.
 fn coerce_and_emit_call(trimmed_target: string, operands: LLVMOperand[], expected_params: string[], llvm_return: string, is_trait_dispatch: boolean, is_array_concat: boolean, array_concat_element_type: string, is_array_push: boolean, array_push_element_type: string, method_operand: LLVMOperand?, helper_descriptor: RuntimeHelperDescriptor?, function_entry: NativeFunction?, current_temp: number, current_lines: string[], diagnostics: string[], collected_string_constants: StringConstant[], bindings: ParameterBinding[], locals: LocalBinding[], context: TypeContext) -> ExpressionResult ![io] {
@@ -119,9 +115,6 @@ fn coerce_and_emit_call(trimmed_target: string, operands: LLVMOperand[], expecte
                     result_lines = concat_result.lines;
                     result_temp = concat_result.temp_index;
                     if concat_result.operand == null {
-                        _write_emission_result_lines(result_lines, result_temp);
-                        fs.writeFile("build/sailfin/.call_result_type", "");
-                        fs.writeFile("build/sailfin/.call_result_value", "");
                         return ExpressionResult {
                             lines: result_lines,
                             temp_index: result_temp,
@@ -130,9 +123,6 @@ fn coerce_and_emit_call(trimmed_target: string, operands: LLVMOperand[], expecte
                             string_constants: collected_string_constants
                         };
                     }
-                    _write_emission_result_lines(result_lines, result_temp);
-                    fs.writeFile("build/sailfin/.call_result_type", concat_result.operand.llvm_type);
-                    fs.writeFile("build/sailfin/.call_result_value", concat_result.operand.value);
                     return ExpressionResult {
                         lines: result_lines,
                         temp_index: result_temp,
@@ -168,9 +158,6 @@ fn coerce_and_emit_call(trimmed_target: string, operands: LLVMOperand[], expecte
                 result_lines = push_result.lines;
                 result_temp = push_result.temp_index;
                 if push_result.operand == null {
-                    _write_emission_result_lines(result_lines, result_temp);
-                    fs.writeFile("build/sailfin/.call_result_type", "");
-                    fs.writeFile("build/sailfin/.call_result_value", "");
                     return ExpressionResult {
                         lines: result_lines,
                         temp_index: result_temp,
@@ -195,9 +182,6 @@ fn coerce_and_emit_call(trimmed_target: string, operands: LLVMOperand[], expecte
                         }
                     }
                 }
-                _write_emission_result_lines(result_lines, result_temp);
-                fs.writeFile("build/sailfin/.call_result_type", push_result.operand.llvm_type);
-                fs.writeFile("build/sailfin/.call_result_value", push_result.operand.value);
                 return ExpressionResult {
                     lines: result_lines,
                     temp_index: result_temp,
@@ -438,9 +422,6 @@ fn coerce_and_emit_call(trimmed_target: string, operands: LLVMOperand[], expecte
         if _trace_ccl {
             print.err("call_lowering: checkpoint-H void return");
         }
-        _write_emission_result_lines(result_lines, result_temp);
-        fs.writeFile("build/sailfin/.call_result_type", "");
-        fs.writeFile("build/sailfin/.call_result_value", "");
         return ExpressionResult {
             lines: result_lines,
             temp_index: result_temp,
@@ -461,12 +442,6 @@ fn coerce_and_emit_call(trimmed_target: string, operands: LLVMOperand[], expecte
         + ")";
     result_lines.push(call_line);
     let operand = LLVMOperand { llvm_type: llvm_return, value: temp_name };
-    if _trace_ccl {
-        print.err("call_lowering: checkpoint-J writing result files");
-    }
-    _write_emission_result_lines(result_lines, result_temp + 1);
-    fs.writeFile("build/sailfin/.call_result_type", llvm_return);
-    fs.writeFile("build/sailfin/.call_result_value", temp_name);
     if _trace_ccl { print.err("call_lowering: checkpoint-K returning"); }
     return ExpressionResult {
         lines: result_lines,

--- a/compiler/src/llvm/expression_lowering/native/core_literals_lowering.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_literals_lowering.sfn
@@ -208,10 +208,6 @@ fn lower_array_literal(text: string, bindings: ParameterBinding[], locals: Local
         }
         current_lines = finished.lines;
         current_temp = finished.temp_index;
-        if finished.operand != null {
-            fs.writeFile("build/sailfin/.call_result_type", finished.operand.llvm_type);
-            fs.writeFile("build/sailfin/.call_result_value", finished.operand.value);
-        }
         return ExpressionResult {
             lines: current_lines,
             temp_index: current_temp,
@@ -496,8 +492,6 @@ fn lower_array_literal(text: string, bindings: ParameterBinding[], locals: Local
         llvm_type: struct_type + "*",
         value: struct_pointer
     };
-    fs.writeFile("build/sailfin/.call_result_type", struct_type + "*");
-    fs.writeFile("build/sailfin/.call_result_value", struct_pointer);
     return ExpressionResult {
         lines: current_lines,
         temp_index: current_temp,
@@ -615,8 +609,6 @@ fn lower_struct_literal(parse: StructLiteralParse, bindings: ParameterBinding[],
             llvm_type: info.llvm_name,
             value: "zeroinitializer"
         };
-        fs.writeFile("build/sailfin/.call_result_type", info.llvm_name);
-        fs.writeFile("build/sailfin/.call_result_value", "zeroinitializer");
         return ExpressionResult {
             lines: current_lines,
             temp_index: current_temp,
@@ -725,8 +717,6 @@ fn lower_struct_literal(parse: StructLiteralParse, bindings: ParameterBinding[],
             llvm_type: info.llvm_name,
             value: "zeroinitializer"
         };
-        fs.writeFile("build/sailfin/.call_result_type", info.llvm_name);
-        fs.writeFile("build/sailfin/.call_result_value", "zeroinitializer");
         return ExpressionResult {
             lines: current_lines,
             temp_index: current_temp,
@@ -740,8 +730,6 @@ fn lower_struct_literal(parse: StructLiteralParse, bindings: ParameterBinding[],
         llvm_type: info.llvm_name,
         value: previous_value
     };
-    fs.writeFile("build/sailfin/.call_result_type", info.llvm_name);
-    fs.writeFile("build/sailfin/.call_result_value", previous_value);
     return ExpressionResult {
         lines: current_lines,
         temp_index: current_temp,

--- a/compiler/src/llvm/expression_lowering/native/core_strings.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_strings.sfn
@@ -96,11 +96,6 @@ fn emit_string_concat(left: LLVMOperand, right: LLVMOperand, temp_index: number,
         + ")";
     let mut out_lines = append_string(right_aligned.lines, line);
     let operand = LLVMOperand { llvm_type: "i8*", value: temp_name };
-    // Write result to IPC files so let-lowering picks up the latest value
-    // instead of a stale call_result_value from an intermediate function call
-    // (e.g., number_to_string used within a string concat chain).
-    fs.writeFile("build/sailfin/.call_result_type", "i8*");
-    fs.writeFile("build/sailfin/.call_result_value", temp_name);
     return ExpressionResult {
         lines: out_lines,
         temp_index: right_aligned.temp_index + 1,

--- a/compiler/src/llvm/expression_lowering/native/statement.sfn
+++ b/compiler/src/llvm/expression_lowering/native/statement.sfn
@@ -13,7 +13,6 @@ import {
     substring
 } from "../../../string_utils";
 import { default_return_literal } from "../../expressions_helpers";
-import { split_lines_local } from "../../lowering/lowering_text_utils";
 // Import string constant management
 import { empty_string_constant_set } from "../../strings";
 // Import types from modular structure
@@ -114,23 +113,6 @@ fn _recover_temp_from_lines(lines: string[], floor: number) -> number {
             }
         }
         ri += 1;
-    }
-    return result;
-}
-
-fn _parse_int_local(text: string) -> number {
-    let len = text.length;
-    if len == 0 { return 0; }
-    let mut result: number = 0;
-    let mut i: number = 0;
-    loop {
-        if i >= len { break; }
-        let ch = char_at(text, i);
-        let code = char_code(ch);
-        if code >= 48 {
-            if code <= 57 { result = result * 10 + (code - 48); }
-        }
-        i = i + 1;
     }
     return result;
 }
@@ -387,73 +369,14 @@ fn lower_expression_statement(function_name: string, instruction: NativeInstruct
     }
     let consumption = ownership_analysis.consumption;
 
-    let _pre_call_lines_len = current_lines.length;
-    // Clear the call_result sentinel BEFORE the nested lower_expression call
-    // so that its presence afterwards is a guaranteed signal from THIS call,
-    // not a stale leftover from a prior lvalue assignment in another function.
-    // Without this, the post-call IPC-read branch would overwrite current_temp
-    // and current_lines with stale data, producing duplicate %tN in the IR.
-    if fs.exists("build/sailfin/.call_result_lines_count") {
-        fs.deleteFile("build/sailfin/.call_result_lines_count");
-    }
-    let lowered = lower_expression(expression, current_bindings, current_locals, current_temp, current_lines, functions, context, "");
-    // ExpressionResult struct fields may be ABI-corrupted crossing module boundaries.
-    // Read lines/temp from files written by lower_call_expression instead.
-    if debug_lowering {
-        let _cr_exists_check = fs.exists("build/sailfin/.call_result_lines_count");
-        if _cr_exists_check {
-            print.err("stmt-lowering: call_result_lines_count EXISTS");
-        } else {
-            print.err("stmt-lowering: call_result_lines_count NOT FOUND");
-        }
-    }
-    if fs.exists("build/sailfin/.call_result_lines_count") {
-        let _cr_lines_raw = fs.readFile("build/sailfin/.call_result_lines");
-        let mut _new_lines: string[] = [];
-        if _cr_lines_raw.length > 0 {
-            _new_lines = split_lines_local(_cr_lines_raw);
-        }
-        current_lines = _new_lines;
-        if debug_lowering {
-            print.err("stmt-lowering: read " + number_to_string(_new_lines.length)
-                + " lines from call_result files, current_lines.length="
-                + number_to_string(current_lines.length));
-        }
-        let _cr_temp_str = fs.readFile("build/sailfin/.call_result_temp");
-        let _cr_parsed = _parse_int_local(_cr_temp_str);
-        // Floor-protect: if the file is stale from a prior statement (e.g. a
-        // chained `arr.push(...); pi += 1;`), _cr_parsed can be much lower
-        // than the counter we already have, which would produce duplicate
-        // %tN in the next emission. Never let the counter go below its
-        // current value; _recover_temp_from_lines below also bumps past any
-        // %tN already present in `current_lines`.
-        if _cr_parsed > current_temp { current_temp = _cr_parsed; }
-        current_temp = _recover_temp_from_lines(current_lines, current_temp);
-        // Clean up sentinel
-        fs.deleteFile("build/sailfin/.call_result_lines_count");
-    } else {
-        // Fallback: struct return fields are ABI-corrupted in the v0.1.1 seed.
-        // Do NOT replace current_lines with lowered.lines — lower_expression
-        // mutated the lines array in-place, so current_lines already has the
-        // new IR.  Using the corrupted struct field would cause
-        // _recover_temp_from_lines to scan wrong data and return a stale temp
-        // counter, leading to duplicate SSA names in the next statement.
-        current_temp = _recover_temp_from_lines(current_lines, current_temp);
-    }
+    let _lowered = lower_expression(expression, current_bindings, current_locals, current_temp, current_lines, functions, context, "");
+    current_temp = _recover_temp_from_lines(current_lines, current_temp);
     if consumption != null {
         if consumption.kind == "local" {
             current_locals = mark_local_consumed(current_locals, consumption.name);
         } else if consumption.kind == "parameter" {
             current_bindings = mark_parameter_consumed(current_bindings, consumption.name);
         }
-    }
-    if debug_lowering {
-        print.err("stmt-lowering: pre-write _pre_call_lines_len="
-            + number_to_string(_pre_call_lines_len)
-            + " current_lines.length="
-            + number_to_string(current_lines.length)
-            + " delta="
-            + number_to_string(current_lines.length - _pre_call_lines_len));
     }
     return ExpressionStatementResult {
         lines: current_lines,

--- a/compiler/src/llvm/expression_lowering/native/statement_assignment.sfn
+++ b/compiler/src/llvm/expression_lowering/native/statement_assignment.sfn
@@ -101,13 +101,6 @@ fn _assign_parse_int(text: string) -> number {
     return result;
 }
 
-fn _write_assign_result_files(lines: string[], temp_index: number) ![io] {
-    fs.writeFile("build/sailfin/.call_result_lines_count", number_to_string(lines.length));
-    // Write all lines as bulk array
-    fs.writeLines("build/sailfin/.call_result_lines", lines);
-    fs.writeFile("build/sailfin/.call_result_temp", number_to_string(temp_index));
-}
-
 // Handles deref (*ptr = value), member access (obj.field = value), and
 // array index (arr[i] = value) assignments. Returns ExpressionStatementResult.
 fn lower_lvalue_assignment_stmt(assign_target: string, assign_value: string, assign_operator: string, current_bindings: ParameterBinding[], current_locals: LocalBinding[], temp_index: number, lines: string[], next_region_id: number, scope_id: string, scope_depth: number, functions: NativeFunction[], context: TypeContext, current_label: string) -> ExpressionStatementResult ![io] {
@@ -144,7 +137,6 @@ fn lower_lvalue_assignment_stmt(assign_target: string, assign_value: string, ass
             diagnostics.push("llvm lowering: failed to lower assignment value for deref target `"
                 + assign_target
                 + "`");
-            _write_assign_result_files(current_lines, current_temp);
             return ExpressionStatementResult {
                 lines: current_lines,
                 temp_index: current_temp,
@@ -161,7 +153,6 @@ fn lower_lvalue_assignment_stmt(assign_target: string, assign_value: string, ass
         let pointer_text = trim_text(substring(trimmed_target, 1, trimmed_target.length));
         if pointer_text.length == 0 {
             diagnostics.push("llvm lowering: deref assignment missing pointer operand");
-            _write_assign_result_files(current_lines, current_temp);
             return ExpressionStatementResult {
                 lines: current_lines,
                 temp_index: current_temp,
@@ -189,7 +180,6 @@ fn lower_lvalue_assignment_stmt(assign_target: string, assign_value: string, ass
             diagnostics.push("llvm lowering: deref assignment pointer `"
                 + pointer_text
                 + "` produced no value");
-            _write_assign_result_files(current_lines, current_temp);
             return ExpressionStatementResult {
                 lines: current_lines,
                 temp_index: current_temp,
@@ -207,7 +197,6 @@ fn lower_lvalue_assignment_stmt(assign_target: string, assign_value: string, ass
             diagnostics.push("llvm lowering: deref assignment target is not a pointer (got `"
                 + lowered_ptr.operand.llvm_type
                 + "`)");
-            _write_assign_result_files(current_lines, current_temp);
             return ExpressionStatementResult {
                 lines: current_lines,
                 temp_index: current_temp,
@@ -236,7 +225,6 @@ fn lower_lvalue_assignment_stmt(assign_target: string, assign_value: string, ass
             diagnostics.push("llvm lowering: unable to coerce deref assignment value to `"
                 + element_type
                 + "`");
-            _write_assign_result_files(current_lines, current_temp);
             return ExpressionStatementResult {
                 lines: current_lines,
                 temp_index: current_temp,
@@ -255,7 +243,6 @@ fn lower_lvalue_assignment_stmt(assign_target: string, assign_value: string, ass
             + element_type
             + "* "
             + lowered_ptr.operand.value);
-        _write_assign_result_files(current_lines, current_temp);
         return ExpressionStatementResult {
             lines: current_lines,
             temp_index: current_temp,
@@ -334,7 +321,6 @@ fn lower_lvalue_assignment_stmt(assign_target: string, assign_value: string, ass
                     diagnostics.push("llvm lowering: member access assignment base `"
                         + member_parse.base
                         + "` is not addressable");
-                    _write_assign_result_files(current_lines, current_temp);
                     return ExpressionStatementResult {
                         lines: current_lines,
                         temp_index: current_temp,
@@ -397,7 +383,6 @@ fn lower_lvalue_assignment_stmt(assign_target: string, assign_value: string, ass
                 }
             }
         }
-        _write_assign_result_files(current_lines, current_temp);
         return ExpressionStatementResult {
             lines: current_lines,
             temp_index: current_temp,
@@ -499,7 +484,6 @@ fn lower_lvalue_assignment_stmt(assign_target: string, assign_value: string, ass
                                 diagnostics.push("llvm lowering: unable to coerce array index to i64 for `"
                                     + assign_target
                                     + "`");
-                                _write_assign_result_files(current_lines, current_temp);
                                 return ExpressionStatementResult {
                                     lines: current_lines,
                                     temp_index: current_temp,
@@ -555,7 +539,6 @@ fn lower_lvalue_assignment_stmt(assign_target: string, assign_value: string, ass
                 }
             }
         }
-        _write_assign_result_files(current_lines, current_temp);
         return ExpressionStatementResult {
             lines: current_lines,
             temp_index: current_temp,
@@ -571,7 +554,6 @@ fn lower_lvalue_assignment_stmt(assign_target: string, assign_value: string, ass
     }
 
     // Not a complex lvalue — should not reach here; caller dispatches simple local separately.
-    _write_assign_result_files(current_lines, current_temp);
     return ExpressionStatementResult {
         lines: current_lines,
         temp_index: current_temp,

--- a/compiler/src/llvm/lowering/instructions_let.sfn
+++ b/compiler/src/llvm/lowering/instructions_let.sfn
@@ -151,14 +151,6 @@ fn lower_let_instruction(function: NativeFunction, instruction: NativeInstructio
             + function.name
             + "`");
     } else {
-        // Clear stale call-result files before expression lowering so that only
-        // a call from THIS let's initializer can populate them.
-        if fs.exists("build/sailfin/.call_result_type") {
-            fs.deleteFile("build/sailfin/.call_result_type");
-        }
-        if fs.exists("build/sailfin/.call_result_value") {
-            fs.deleteFile("build/sailfin/.call_result_value");
-        }
         if fs.exists("build/sailfin/.trace_lowering") {
             print.err("let-lowering: pre-lower_expression name=" + instruction.name
                 + " value="
@@ -168,12 +160,6 @@ fn lower_let_instruction(function: NativeFunction, instruction: NativeInstructio
         let lowered = lower_expression(instruction.value, current_bindings, current_locals, current_temp, current_lines, functions, context, llvm_type);
         if fs.exists("build/sailfin/.trace_lowering") {
             print.err("let-lowering: post-lower_expression name=" + instruction.name);
-        }
-        // Read lines/temp from files to bypass ExpressionResult struct corruption
-        if fs.exists("build/sailfin/.call_result_type") {
-            if fs.exists("build/sailfin/.trace_lowering") {
-                print.err("let-lowering: call_result_type file exists");
-            }
         }
         if fs.exists("build/sailfin/.trace_lowering") {
             print.err("let-lowering: accessing lowered.diagnostics");
@@ -213,25 +199,12 @@ fn lower_let_instruction(function: NativeFunction, instruction: NativeInstructio
         print.err("let-lowering: checking llvm_type len=" + number_to_string(llvm_type.length));
     }
     if llvm_type.length == 0 {
-        // Try file-based fallback FIRST, since operand.llvm_type may be
-        // a corrupted pointer that crashes on access.
-        if fs.exists("build/sailfin/.call_result_type") {
-            let _crt = fs.readFile("build/sailfin/.call_result_type");
-            if _crt.length > 0 {
-                llvm_type = _crt;
-                if fs.exists("build/sailfin/.trace_lowering") {
-                    print.err("let-lowering: llvm_type from file=" + llvm_type);
-                }
+        if operand != null {
+            if fs.exists("build/sailfin/.trace_lowering") {
+                print.err("let-lowering: operand not null, trimming type");
             }
-        }
-        if llvm_type.length == 0 {
-            if operand != null {
-                if fs.exists("build/sailfin/.trace_lowering") {
-                    print.err("let-lowering: operand not null, trimming type");
-                }
-                let operand_type = trim_text(operand.llvm_type);
-                if operand_type.length > 0 { llvm_type = operand_type; }
-            }
+            let operand_type = trim_text(operand.llvm_type);
+            if operand_type.length > 0 { llvm_type = operand_type; }
         }
     }
 
@@ -319,41 +292,7 @@ fn lower_let_instruction(function: NativeFunction, instruction: NativeInstructio
     current_allocas.push("  " + pointer + " = alloca " + llvm_type);
 
     let mut stored_value: string = default_return_literal(llvm_type);
-    // Fix operand if its llvm_type was corrupted crossing module boundaries.
-    // Only use file-based reconstruction when the operand's type is clearly
-    // wrong (empty or mismatch). When the operand type matches the expected
-    // llvm_type, the operand is correct and the IPC file may contain stale
-    // intermediate values (e.g., from number_to_string inside a string concat chain).
     if operand != null {
-        let mut _use_ipc_override: boolean = false;
-        let _op_type = trim_text(operand.llvm_type);
-        if _op_type.length == 0 { _use_ipc_override = true; }
-        if _op_type != llvm_type {
-            if llvm_type.length > 0 { _use_ipc_override = true; }
-        }
-        if _use_ipc_override {
-            if fs.exists("build/sailfin/.call_result_type") {
-                let _fixup_type = fs.readFile("build/sailfin/.call_result_type");
-                if _fixup_type.length > 0 {
-                    let mut _fixup_value: string = "";
-                    if fs.exists("build/sailfin/.call_result_value") {
-                        _fixup_value = fs.readFile("build/sailfin/.call_result_value");
-                    }
-                    operand = LLVMOperand {
-                        llvm_type: _fixup_type,
-                        value: _fixup_value
-                    };
-                    if fs.exists("build/sailfin/.trace_lowering") {
-                        print.err("let-lowering: operand reconstructed type="
-                            + _fixup_type
-                            + " value="
-                            + _fixup_value);
-                    }
-                }
-            }
-        }
-        // Avoid calling coerce_operand_to_type across module boundaries when
-        // types already match — the returned CoercionResult struct gets ABI-corrupted.
         if operand.llvm_type == llvm_type {
             // Identity coercion — use operand directly
             stored_value = operand.value;

--- a/docs/build-performance.md
+++ b/docs/build-performance.md
@@ -549,6 +549,46 @@ For typical compiler modules (hundreds of statements per function, dozens of fun
 - 6 source files modified, ~−241 / +47 lines net.
 - No new tests added — the existing integration suite (`selfhost_pipeline_test.sfn`, `async_struct_return_stress_test.sfn`, `compiler_ir_patterns_test.sfn`) and the self-hosting build itself exercise every path that was changed.
 
+### Call Result IPC Channel Removal (April 20)
+
+**Status: Implemented.** Removed the `.call_result_*` file-IPC channel — the heaviest-referenced remaining Phase 2 channel. Two sub-groups shared the prefix:
+
+* **Type/value pair** (`.call_result_type`, `.call_result_value`): a v0.1.1-seed-era workaround that writers in `core_call_emission.sfn`, `core_literals_lowering.sfn`, `core_strings.sfn`, and the await paths of `core.sfn` used to ship `LLVMOperand.{llvm_type, value}` back to `instructions_let.sfn`. Every writer already populated `ExpressionResult.operand` with the identical data — the file IPC was a parallel copy. The reader in `instructions_let.sfn` used the files as a `_use_ipc_override` fallback when `operand.llvm_type` appeared corrupted crossing module boundaries. Under the default-on arena (PR #186) the 0.5.7 seed handles cross-module struct returns correctly — same pattern validated by PRs #183 / #184 / #185 / #188 / #189 / #191.
+
+* **Lines/count/temp triple** (`.call_result_lines_count`, `.call_result_lines`, `.call_result_temp`): a cross-statement leak used by `_write_assign_result_files` in `statement_assignment.sfn` to ship post-lvalue-assignment IR lines + temp counter to a sentinel-gated reader in `statement.sfn`'s `lower_expression_statement`. The sentinel-gated reader fired only when a *prior* statement's lvalue path had written the files; under arena, in-place array mutation of `current_lines` plus `_recover_temp_from_lines(current_lines, current_temp)` already delivers the same data in-band. The reader block's comment ("ExpressionResult struct fields may be ABI-corrupted crossing module boundaries") describes a pre-arena failure mode.
+
+**Shape of change:**
+- `_write_emission_result_lines` deleted from `core_call_emission.sfn` (helper + all 6 call sites at trait/concat/push/array paths).
+- 14 `fs.writeFile(".call_result_{type,value}", ...)` pairs deleted across `core_call_emission.sfn` (6), `core_literals_lowering.sfn` (5), `core.sfn` (3 await paths), `core_strings.sfn` (1).
+- `_write_assign_result_files` deleted from `statement_assignment.sfn` (helper + all 11 call sites at every return point of `lower_lvalue_assignment_stmt`).
+- `statement.sfn`'s `lower_expression_statement` pre-clear block (lines 391-398), trace-gated existence check (403-409), sentinel-gated reader (410-433), and `_pre_call_lines_len` debug print (450-457) all deleted. The surrounding `_recover_temp_from_lines(current_lines, current_temp)` call (previously the `else`-branch fallback) becomes the single temp-recovery path. Return value of the `lower_expression` call renamed to `_lowered` to signal intentional discard (struct fields are unused — the call's effect is the in-place mutation of `current_lines`).
+- `_parse_int_local` in `statement.sfn` (16 lines) deleted — only used by the dead `.call_result_temp` reader.
+- `split_lines_local` import dropped from `statement.sfn` — only use was in the dead reader block. Export kept in `lowering_text_utils.sfn` (many other files import it).
+- `instructions_let.sfn` pre-clear block (lines 154-161), `.call_result_type` trace guard (173-177), `llvm_type` fallback reader (218-225), and `_use_ipc_override` branch (328-354) all deleted. Operand path simplifies to: if `operand.llvm_type == llvm_type` → direct store (identity coerce, unchanged); else → `coerce_operand_to_type` (unchanged).
+- `cli_commands._clean_lowering_state` keeps the `.call_result_` prefix sweep with a "Legacy" comment for stale files from older build dirs / older seed binaries (precedent: PRs #183 / #184 / #185 / #188 / #189 / #191).
+
+**Per-call / per-statement overhead removed:**
+- Up to 2 `fs.writeFile` per call emission (type + value scalars) — fires on every `call` IR emission across trait dispatch, concat/push inline, void/value standard calls, array-struct literals, zero-field structs, string concat, and await unboxing.
+- 3 `fs.writeFile` per lvalue assignment statement (lines count + bulk lines + temp index) — fires on every deref, member-access, and array-index assignment.
+- 2 `fs.deleteFile` per let initializer (pre-clear sentinel).
+- Up to 3 `fs.readFile` + 1 `fs.deleteFile` per expression statement (sentinel gate + bulk lines + temp + cleanup).
+- Up to 2 `fs.readFile` per let-binding fixup (`_use_ipc_override` branch).
+- Multiple `fs.exists` trace gates.
+
+For a typical compiler module with hundreds of calls per function and dozens of functions, this eliminates thousands of filesystem operations per module compile. Together with the `.expr_stmt_*` removal in PR #191, the per-statement IR accumulation path is now fully in-memory end-to-end.
+
+**Risks evaluated:**
+- **v0.1.1-seed ABI corruption**: the channel's original purpose. 0.5.x seeds under arena validated by PRs #183-#191 — `ExpressionResult` and `ExpressionStatementResult` are reliable across module boundaries today.
+- **Cross-statement `_write_assign_result_files` → `statement.sfn` reader**: the else-branch fallback at `statement.sfn:441` (`_recover_temp_from_lines`) was already the standalone code path when the sentinel file was absent, and its comment explicitly documented that `current_lines` is mutated in-place. Removing both writer and reader together makes the scanner-based recovery the single path.
+- **`_use_ipc_override` removal**: the reader exists to repair operands whose `llvm_type` is empty or mismatched versus the expected `llvm_type`. Under arena, the operand struct returned by `lower_expression` carries the correct type — the file-based reconstruction was a parallel safety net that is no longer needed. The identity-vs-coerce split at the store site (lines 357-402) is unchanged.
+
+**Scope:**
+- 8 source files modified (7 compiler + 1 CLI), 1 docs file updated.
+- Net: ~−200 lines deleted / ~+20 lines added.
+- No new tests added — the existing integration suite (`selfhost_pipeline_test.sfn`, `async_struct_return_stress_test.sfn`, `compiler_ir_patterns_test.sfn`) plus full self-hosting exercise every path.
+
+**Determinism:** Linux x86_64 on seed 0.5.7 is already 20/20 identical on the hot modules per the arena-flip entry; this change removes file-I/O overhead without introducing new non-determinism. macOS-arm64 measurement to be recorded after CI completes on that platform. With `.call_result_*` gone, the remaining Phase 2 channels driving residual macOS-arm64 non-determinism are `.dispatch_*`, `.let_result_*` / `.let_ipc_*`, and `.instr_*`.
+
 ---
 
 ## Appendix: IPC Channel Census


### PR DESCRIPTION
Removes the heaviest-referenced remaining Phase 2 file-IPC channel. Two
sub-groups shared the prefix:

- .call_result_type / .call_result_value: writers in core_call_emission,
  core_literals_lowering, core_strings, and core.sfn's await paths wrote
  LLVMOperand.{llvm_type, value} scalars that instructions_let.sfn read
  back as a _use_ipc_override fallback when operand.llvm_type appeared
  ABI-corrupted. The data was already carried on the returned
  ExpressionResult.operand; under the default-on arena (PR #186) cross-
  module struct returns are reliable (validated PRs #183-#191).

- .call_result_lines_count / .call_result_lines / .call_result_temp:
  _write_assign_result_files in statement_assignment.sfn wrote post-
  lvalue IR lines + temp counter via a cross-statement sentinel that
  statement.sfn's lower_expression_statement gated on. In-place mutation
  of current_lines plus _recover_temp_from_lines already delivers the
  same state in-band.

Deletes:
- _write_emission_result_lines helper + 6 write pairs in core_call_emission
- 5 write pairs in core_literals_lowering (array/struct literals)
- 3 write pairs in core.sfn (await void/unboxed/opaque paths)
- 1 write pair in core_strings (emit_string_concat)
- _write_assign_result_files helper + 11 call sites in statement_assignment
- pre-clear / trace gate / sentinel reader / debug print block in
  statement.sfn's lower_expression_statement; _pre_call_lines_len dead
- _parse_int_local helper (only used by dead reader) in statement.sfn
- split_lines_local import in statement.sfn (export kept in lowering_text_utils)
- pre-clear / trace gate / llvm_type fallback / _use_ipc_override branch
  in instructions_let.sfn

Keeps:
- .call_result_ prefix sweep in cli_commands._clean_lowering_state with
  a "Legacy" comment (precedent: PRs #183-#191)
- All surrounding coerce/store logic; identity-vs-coerce split unchanged

Per-call/per-statement FS ops removed: up to 2 writeFile per call
emission, 3 writeFile per lvalue assignment, 2 deleteFile per let
initializer, up to 3 readFile + 1 deleteFile per expression statement,
up to 2 readFile per let-binding fixup. For typical modules this
eliminates thousands of filesystem operations per module compile.

Net: -214 / +49 compiler source, +40 docs.

https://claude.ai/code/session_01Qj1PEpDBJFVzqj83sdzVVL