### PR TITLE
fix(site): read fallback version from capsule.toml on downloads page

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -86,7 +86,7 @@ api() {
     auth_args=(-H "Authorization: Bearer ${GITHUB_TOKEN}")
   fi
   curl --fail -sSL \
-    "${auth_args[@]}" \
+    ${auth_args[@]+"${auth_args[@]}"} \
     -H "Accept: application/vnd.github+json" \
     "$1"
 }
@@ -153,7 +153,7 @@ if [ -n "${GITHUB_TOKEN:-}" ]; then
   DL_AUTH_ARGS=(-H "Authorization: Bearer ${GITHUB_TOKEN}")
 fi
 curl --fail -sSL \
-  "${DL_AUTH_ARGS[@]}" \
+  ${DL_AUTH_ARGS[@]+"${DL_AUTH_ARGS[@]}"} \
   -H "Accept: application/octet-stream" \
   "https://api.github.com/repos/${REPO}/releases/assets/${asset_id}" \
   -o "$ARCHIVE_PATH"

--- a/site/src/pages/dl.astro
+++ b/site/src/pages/dl.astro
@@ -68,8 +68,25 @@ function parseAsset(asset: GHAsset): ParsedAsset | null {
   };
 }
 
+// ---------------------------------------------------------------------------
+// Derive fallback version from compiler/capsule.toml (the version source of
+// truth) so the page stays current even when the GitHub API call fails.
+// ---------------------------------------------------------------------------
+import fs from "node:fs";
+import path from "node:path";
+
+function readCapsuleVersion(): string {
+  try {
+    const tomlPath = path.resolve(import.meta.dirname, "../../../compiler/capsule.toml");
+    const toml = fs.readFileSync(tomlPath, "utf-8");
+    const match = toml.match(/^\s*version\s*=\s*"([^"]+)"/m);
+    if (match) return match[1];
+  } catch {}
+  return "0.5.7"; // last-resort hardcoded fallback
+}
+
 // Fetch releases — tolerate API failures gracefully
-let stableVersion = "0.5.1";
+let stableVersion = readCapsuleVersion();
 let stableTag = `v${stableVersion}`;
 let allAssets: ParsedAsset[] = [];
 
@@ -99,7 +116,8 @@ try {
     allAssets = installerAssets.map(parseAsset).filter((a): a is ParsedAsset => a !== null);
   }
 } catch (e) {
-  console.warn(`[dl] Failed to fetch releases from GitHub, using fallback: ${e}`);
+  console.warn(`[dl] Failed to fetch releases from GitHub API, using fallback v${stableVersion}: ${e}`);
+  console.warn(`[dl] Set GITHUB_TOKEN in your Cloudflare Pages environment to avoid rate limits.`);
 }
 
 // Fallback if API returned nothing

--- a/site/src/pages/dl.astro
+++ b/site/src/pages/dl.astro
@@ -74,14 +74,21 @@ function parseAsset(asset: GHAsset): ParsedAsset | null {
 // ---------------------------------------------------------------------------
 import fs from "node:fs";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 function readCapsuleVersion(): string {
+  const currentDir = fileURLToPath(new URL(".", import.meta.url));
+  const tomlPath = path.resolve(currentDir, "../../../compiler/capsule.toml");
+
   try {
-    const tomlPath = path.resolve(import.meta.dirname, "../../../compiler/capsule.toml");
     const toml = fs.readFileSync(tomlPath, "utf-8");
     const match = toml.match(/^\s*version\s*=\s*"([^"]+)"/m);
     if (match) return match[1];
-  } catch {}
+
+    console.warn(`[dl] Failed to parse version from capsule manifest at ${tomlPath}; falling back to hardcoded version.`);
+  } catch (error) {
+    console.warn(`[dl] Failed to read capsule manifest at ${tomlPath}; falling back to hardcoded version.`, error);
+  }
   return "0.5.7"; // last-resort hardcoded fallback
 }
 


### PR DESCRIPTION
## Problem

The downloads page at [sfn.dev/dl](https://sfn.dev/dl/) was stuck showing v0.5.1 despite multiple releases since then (latest stable is v0.5.7).

## Root Cause

`dl.astro` fetches from the GitHub Releases API at build time. When the API call fails (e.g. rate-limited without `GITHUB_TOKEN`), it fell back to a **hardcoded** `stableVersion = "0.5.1"` that was never updated.

## Fix

Replace the hardcoded fallback with `readCapsuleVersion()`, which reads the version from `compiler/capsule.toml` — the project's version source of truth. This ensures:

- When the GitHub API succeeds → uses the latest stable release data (with asset sizes, SHA256 digests, etc.)
- When the GitHub API fails → falls back to whatever version is in the repo at build time
- A last-resort hardcoded `"0.5.7"` is only used if the TOML file itself can't be read

Also improved the warning message to mention `GITHUB_TOKEN` so the issue is more visible in build logs.

## Additional Step

`GITHUB_TOKEN` has been added to the Cloudflare Pages environment so the API call should succeed going forward.

## Verification

- `make test` — no compiler changes
- Editor language server reports no errors in `dl.astro`