### PR TITLE
Remove unused code and optimize debug flag checks

### DIFF
--- a/compiler/src/llvm/expression_lowering/native/statement.sfn
+++ b/compiler/src/llvm/expression_lowering/native/statement.sfn
@@ -56,7 +56,7 @@ import {
     infer_borrow_base_scope,
     make_lifetime_region_metadata
 } from "./core_scopes";
-import { lower_lvalue_assignment_stmt, preprocess_self_field_access } from "./statement_assignment";
+import { lower_lvalue_assignment_stmt } from "./statement_assignment";
 // Submodules extracted from this file
 import { parse_assignment_expression, parse_inline_let_expression } from "./statement_parsing";
 import { detect_suspension_conflicts } from "./statement_suspension";
@@ -509,15 +509,8 @@ fn lower_return_instruction(function: NativeFunction, instruction: NativeInstruc
             bind_i += 1;
         }
     }
-    // Pre-process self.field patterns via helper (extracted to stay under 500 instr)
-    let _sf_result = preprocess_self_field_access(instr_expression, current_temp, current_lines);
-    let _ret_expr: string = _sf_result.expression;
-    current_temp = _sf_result.temp_index;
     current_temp = _recover_temp_from_lines(current_lines, current_temp);
-    if _sf_result.lines.length > current_lines.length {
-        current_lines = _sf_result.lines;
-    }
-    let lowered = lower_expression(_ret_expr, current_bindings, current_locals, current_temp, current_lines, functions, context, safe_llvm_return);
+    let lowered = lower_expression(instr_expression, current_bindings, current_locals, current_temp, current_lines, functions, context, safe_llvm_return);
     if debug_lowering {
         print.err("emit-llvm: lower_return post_lower_expr fn=" + fn_name);
     }

--- a/compiler/src/llvm/expression_lowering/native/statement_assignment.sfn
+++ b/compiler/src/llvm/expression_lowering/native/statement_assignment.sfn
@@ -23,7 +23,6 @@ import {
     LocalMutation,
     OwnershipInfo,
     ParameterBinding,
-    SelfFieldResult,
     StringConstant,
     TypeContext
 } from "../../types";
@@ -568,27 +567,4 @@ fn lower_lvalue_assignment_stmt(assign_target: string, assign_value: string, ass
     };
 }
 
-// Pre-process self.field patterns in return expressions. This is extracted from
-// lower_return_instruction to keep it under ~500 instructions.
-// Returns the rewritten expression, the next temp index, and the updated
-// lines array including any emitted GEP/bitcast/load instructions.
-fn preprocess_self_field_access(expression: string, current_temp: number, current_lines: string[]) -> SelfFieldResult {
-    let mut result_expr: string = expression;
-    let mut result_temp: number = current_temp;
-    let mut result_lines: string[] = current_lines;
-
-    if index_of(result_expr, "self.") < 0 {
-        return SelfFieldResult {
-            expression: result_expr,
-            temp_index: result_temp,
-            lines: result_lines
-        };
-    }
-    return SelfFieldResult {
-        expression: result_expr,
-        temp_index: result_temp,
-        lines: result_lines
-    };
-}
-
-export { lower_lvalue_assignment_stmt, preprocess_self_field_access };
+export { lower_lvalue_assignment_stmt };

--- a/compiler/src/llvm/lowering/instructions_helpers.sfn
+++ b/compiler/src/llvm/lowering/instructions_helpers.sfn
@@ -3,28 +3,9 @@
 // Shared helper utilities extracted from instructions.sfn so that
 // lower_instruction_range occupies position 1 in its module -- within
 // the v0.1.1 seed's per-module streaming emission limit.
-import { NativeFunction, NativeInstruction, NativeSourceSpan } from "../../native_ir";
 import { char_code, grapheme_at } from "../../string_utils";
-import {
-    BlockLoweringResult,
-    LLVMOperand,
-    LetLoweringResult,
-    LifetimeRegionMetadata,
-    LifetimeReleaseEvent,
-    LocalBinding,
-    LocalMutation,
-    LoopContext,
-    OwnershipConsumption,
-    OwnershipInfo,
-    ScopeMetadata,
-    TypeContext
-} from "../types";
-import {
-    append_string,
-    extend_string_array,
-    starts_with,
-    trim_text
-} from "../utils";
+import { LifetimeRegionMetadata, LocalBinding, LocalMutation } from "../types";
+import { extend_string_array } from "../utils";
 
 fn clone_local_bindings(values: LocalBinding[]) -> LocalBinding[] {
     let mut result: LocalBinding[] = [];
@@ -102,62 +83,5 @@ fn _parse_int_from_string(text: string) -> number {
         i = i + 1;
     }
     if first_ch == "-" { return 0 - result; }
-    return result;
-}
-
-// Read an IPC integer from a file, returning at least `floor_value`.
-// This prevents temp_index resets to 0 when files are missing/empty/stale,
-// which otherwise causes duplicate SSA names (%tN) in LLVM IR.
-fn _read_ipc_int_min(path: string, floor_value: number) -> number ![io] {
-    if !fs.exists(path) { return floor_value; }
-    let text = fs.readFile(path);
-    if text.length == 0 { return floor_value; }
-    let parsed = _parse_int_from_string(text);
-    if parsed > floor_value { return parsed; }
-    return floor_value;
-}
-
-// Scan accumulated IR lines for the highest %tN temp index and return
-// max(highest + 1, floor).  This provides a robust fallback when IPC
-// files carry stale temp counters (e.g. after cross-module expression
-// lowering where struct-return scalars are ABI-corrupted).
-fn recover_temp_from_lines(lines: string[], floor: number) -> number {
-    let mut result: number = floor;
-    let mut ri: number = 0;
-    loop {
-        if ri >= lines.length { break; }
-        let rl = lines[ri];
-        if rl.length >= 5 {
-            let c0 = char_code(grapheme_at(rl, 0));
-            let c1 = char_code(grapheme_at(rl, 1));
-            let c2 = char_code(grapheme_at(rl, 2));
-            let c3 = char_code(grapheme_at(rl, 3));
-            // Match "  %t" (two spaces, percent, lowercase t)
-            if c0 == 32 {
-                if c1 == 32 {
-                    if c2 == 37 {
-                        if c3 == 116 {
-                            let mut rn: number = 0;
-                            let mut rj: number = 4;
-                            let mut rvalid: boolean = false;
-                            loop {
-                                if rj >= rl.length { break; }
-                                let rc = char_code(grapheme_at(rl, rj));
-                                if rc < 48 { break; }
-                                if rc > 57 { break; }
-                                rn = rn * 10 + (rc - 48);
-                                rvalid = true;
-                                rj += 1;
-                            }
-                            if rvalid {
-                                if rn >= result { result = rn + 1; }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        ri += 1;
-    }
     return result;
 }

--- a/compiler/src/llvm/lowering/instructions_let.sfn
+++ b/compiler/src/llvm/lowering/instructions_let.sfn
@@ -78,6 +78,7 @@ fn lower_let_instruction(function: NativeFunction, instruction: NativeInstructio
     let mut lifetime_releases: LifetimeReleaseEvent[] = [];
     let mut current_next_region: number = next_region_id;
     let mut mutations: LocalMutation[] = [];
+    let debug_lowering = fs.exists("build/sailfin/.trace_lowering");
     if initializer_span == null { initializer_span = instruction.span; }
 
     let suspension_diagnostics = detect_suspension_conflicts(instruction.value, current_locals, current_bindings, function.name, initializer_span);
@@ -179,17 +180,17 @@ fn lower_let_instruction(function: NativeFunction, instruction: NativeInstructio
             + function.name
             + "`");
     } else {
-        if fs.exists("build/sailfin/.trace_lowering") {
+        if debug_lowering {
             print.err("let-lowering: pre-lower_expression name=" + instruction.name
                 + " value="
                 + instruction.value);
         }
         let _pre_expr_line_count = current_lines.length;
         let lowered = lower_expression(instruction.value, current_bindings, current_locals, current_temp, current_lines, functions, context, llvm_type);
-        if fs.exists("build/sailfin/.trace_lowering") {
+        if debug_lowering {
             print.err("let-lowering: post-lower_expression name=" + instruction.name);
         }
-        if fs.exists("build/sailfin/.trace_lowering") {
+        if debug_lowering {
             print.err("let-lowering: accessing lowered.diagnostics");
         }
         let mut _ci19: number = 0;
@@ -198,20 +199,20 @@ fn lower_let_instruction(function: NativeFunction, instruction: NativeInstructio
             diagnostics.push(lowered.diagnostics[_ci19]);
             _ci19 += 1;
         }
-        if fs.exists("build/sailfin/.trace_lowering") {
+        if debug_lowering {
             print.err("let-lowering: accessing lowered.lines");
         }
         current_lines = lowered.lines;
-        if fs.exists("build/sailfin/.trace_lowering") {
+        if debug_lowering {
             print.err("let-lowering: got lines, accessing temp_index");
         }
         current_temp = lowered.temp_index;
-        if fs.exists("build/sailfin/.trace_lowering") {
+        if debug_lowering {
             print.err("let-lowering: got temp_index=" + number_to_string(current_temp)
                 + ", accessing operand");
         }
         operand = lowered.operand;
-        if fs.exists("build/sailfin/.trace_lowering") {
+        if debug_lowering {
             print.err("let-lowering: got operand, accessing string_constants");
         }
         // Use lowered.string_constants directly (covers enum variant
@@ -223,12 +224,12 @@ fn lower_let_instruction(function: NativeFunction, instruction: NativeInstructio
         string_constants = merge_string_constants(string_constants, inferred);
     }
 
-    if fs.exists("build/sailfin/.trace_lowering") {
+    if debug_lowering {
         print.err("let-lowering: checking llvm_type len=" + number_to_string(llvm_type.length));
     }
     if llvm_type.length == 0 {
         if operand != null {
-            if fs.exists("build/sailfin/.trace_lowering") {
+            if debug_lowering {
                 print.err("let-lowering: operand not null, trimming type");
             }
             let operand_type = trim_text(operand.llvm_type);
@@ -329,7 +330,7 @@ fn lower_let_instruction(function: NativeFunction, instruction: NativeInstructio
                 + llvm_type
                 + "* "
                 + pointer);
-            if fs.exists("build/sailfin/.trace_lowering") {
+            if debug_lowering {
                 print.err("let-lowering: identity coerce type=" + llvm_type
                     + " value="
                     + operand.value);
@@ -410,7 +411,7 @@ fn lower_let_instruction(function: NativeFunction, instruction: NativeInstructio
     };
     mutations.push(mutation);
 
-    if fs.exists("build/sailfin/.trace_lowering") {
+    if debug_lowering {
         print.err("let-lowering: returning LetLoweringResult for name="
             + instruction.name);
     }

--- a/compiler/src/llvm/lowering/instructions_loops.sfn
+++ b/compiler/src/llvm/lowering/instructions_loops.sfn
@@ -346,8 +346,6 @@ fn lower_loop_instruction(function: NativeFunction, start_index: number, llvm_re
         mutations: _body_mutations,
         string_constants: _body_string_constants
     };
-    // Cross-module ABI: scalar fields corrupted; read from file IPC instead.
-    // Use _read_ipc_int_min to prevent the counter from going backwards.
     let _br_lp_temp = _body_temp;
     let _br_lp_blkctr = _body_blkctr;
     let _br_lp_nextloc = _body_nextloc;

--- a/compiler/src/llvm/types.sfn
+++ b/compiler/src/llvm/types.sfn
@@ -449,12 +449,6 @@ struct TernaryParseResult {
 // =============================================================================
 // Statement/Instruction Lowering Results
 // =============================================================================
-struct SelfFieldResult {
-    expression: string;
-    temp_index: number;
-    lines: string[];
-}
-
 struct ExpressionStatementResult {
     lines: string[];
     temp_index: number;


### PR DESCRIPTION
## Summary
This PR removes unused functions and type definitions, and optimizes repeated file system checks by caching the debug flag value.

## Key Changes

- **Removed unused imports and functions** from `instructions_helpers.sfn`:
  - Removed imports of `NativeFunction`, `NativeInstruction`, `NativeSourceSpan` from native_ir
  - Removed unused type imports (`BlockLoweringResult`, `LLVMOperand`, `LetLoweringResult`, `LifetimeReleaseEvent`, `OwnershipConsumption`, `OwnershipInfo`, `ScopeMetadata`, `TypeContext`)
  - Removed unused utility function imports (`append_string`, `starts_with`, `trim_text`)
  - Deleted `_read_ipc_int_min()` and `recover_temp_from_lines()` functions that were not being called

- **Removed unused code** from `statement_assignment.sfn`:
  - Deleted `preprocess_self_field_access()` function which was a no-op stub
  - Removed `SelfFieldResult` type import
  - Updated exports to remove the unused function

- **Optimized debug logging** in `instructions_let.sfn`:
  - Cached the debug flag check result in `debug_lowering` variable at function start
  - Replaced 11 repeated `fs.exists("build/sailfin/.trace_lowering")` calls with the cached variable
  - This eliminates redundant file system checks during expression lowering

- **Cleaned up statement.sfn**:
  - Removed call to `preprocess_self_field_access()` in `lower_return_instruction()`
  - Simplified return expression handling by directly using `instr_expression`
  - Removed import of the deleted function

- **Removed unused type** from `types.sfn`:
  - Deleted `SelfFieldResult` struct definition

- **Removed stale comment** from `instructions_loops.sfn`:
  - Deleted outdated comment about cross-module ABI and IPC file handling

## Implementation Details
The debug flag optimization reduces file system I/O during the lowering process by checking once at the start of `lower_let_instruction()` rather than repeatedly throughout the function execution.

https://claude.ai/code/session_01KFqeRv4GuocyxJJ8yJTRJB