### PR TITLE
fix(engineer): comment on issue before focus-gate noop

### DIFF
--- a/.github/workflows/engineer.md
+++ b/.github/workflows/engineer.md
@@ -80,10 +80,10 @@ will be updated in the same PR.
 `type:refactor`, verify the issue body contains a `## Focus Workstream`
 section citing an open `focus:approved` issue. If missing:
 
-  1. Post a comment on the issue (via `add-comment`) with this text — verbatim so humans and downstream agents can pattern-match on it. The leading `[focus-gate-standdown]` is a stable marker for grep/automation; the `@…` expression expands to the real issue author at render time:
+  1. Post a comment on the issue (via `add-comment`). Before calling `add-comment`, look up the issue author's GitHub login (via the GitHub tool you use to read the issue, e.g. `issue_read` / `get_issue`) and substitute it into `<login>` in the template below. The leading `[focus-gate-standdown]` token is a stable marker for downstream automation and human grep — keep it verbatim at the start of the comment.
 
      ```
-     [focus-gate-standdown] @${{ github.event.issue.user.login }} the engineer agent stood down without implementing this issue because it does not cite a current focus workstream. This is a feature/perf/refactor issue, so per `.github/AGENTS.md` it must include a `## Focus Workstream` section linking to an open `focus:approved` issue. Either (a) the architect should amend the issue to add the citation, or (b) a maintainer should re-label this as `type:bug` if it's a correctness fix that shouldn't wait for the weekly focus.
+     [focus-gate-standdown] @<login> the engineer agent stood down without implementing this issue because it does not cite a current focus workstream. This is a feature/perf/refactor issue, so per `.github/AGENTS.md` it must include a `## Focus Workstream` section linking to an open `focus:approved` issue. Either (a) the architect should amend the issue to add the citation, or (b) a maintainer should re-label this as `type:bug` if it's a correctness fix that shouldn't wait for the weekly focus.
      ```
 
   2. Then call `noop`:

--- a/.github/workflows/engineer.md
+++ b/.github/workflows/engineer.md
@@ -80,10 +80,10 @@ will be updated in the same PR.
 `type:refactor`, verify the issue body contains a `## Focus Workstream`
 section citing an open `focus:approved` issue. If missing:
 
-  1. Post a comment on the issue (via `add-comment`) with this text — verbatim so humans and downstream agents can pattern-match on it:
+  1. Post a comment on the issue (via `add-comment`) with this text — verbatim so humans and downstream agents can pattern-match on it. The leading `[focus-gate-standdown]` is a stable marker for grep/automation; the `@…` expression expands to the real issue author at render time:
 
      ```
-     @<issue_author> The engineer agent stood down without implementing this issue because it does not cite a current focus workstream. This is a feature/perf/refactor issue, so per `.github/AGENTS.md` it must include a `## Focus Workstream` section linking to an open `focus:approved` issue. Either (a) the architect should amend the issue to add the citation, or (b) a maintainer should re-label this as `type:bug` if it's a correctness fix that shouldn't wait for the weekly focus.
+     [focus-gate-standdown] @${{ github.event.issue.user.login }} the engineer agent stood down without implementing this issue because it does not cite a current focus workstream. This is a feature/perf/refactor issue, so per `.github/AGENTS.md` it must include a `## Focus Workstream` section linking to an open `focus:approved` issue. Either (a) the architect should amend the issue to add the citation, or (b) a maintainer should re-label this as `type:bug` if it's a correctness fix that shouldn't wait for the weekly focus.
      ```
 
   2. Then call `noop`:

--- a/.github/workflows/engineer.md
+++ b/.github/workflows/engineer.md
@@ -78,9 +78,18 @@ will be updated in the same PR.
 
 **3. Focus gate (soft).** For issues tagged `type:feature`, `type:perf`, or
 `type:refactor`, verify the issue body contains a `## Focus Workstream`
-section citing an open `focus:approved` issue. If missing, call `noop`:
-`{"noop": {"message": "focus gate: issue lacks Focus Workstream citation; escalating to architect"}}`
-(Bug fixes labeled `type:bug` are exempt — urgent fixes don't wait for the weekly focus.)
+section citing an open `focus:approved` issue. If missing:
+
+  1. Post a comment on the issue (via `add-comment`) with this text — verbatim so humans and downstream agents can pattern-match on it:
+
+     ```
+     @<issue_author> The engineer agent stood down without implementing this issue because it does not cite a current focus workstream. This is a feature/perf/refactor issue, so per `.github/AGENTS.md` it must include a `## Focus Workstream` section linking to an open `focus:approved` issue. Either (a) the architect should amend the issue to add the citation, or (b) a maintainer should re-label this as `type:bug` if it's a correctness fix that shouldn't wait for the weekly focus.
+     ```
+
+  2. Then call `noop`:
+     `{"noop": {"message": "focus gate: issue lacks Focus Workstream citation; commented on issue and standing down"}}`
+
+  (Bug fixes labeled `type:bug` are exempt — urgent fixes don't wait for the weekly focus.)
 
 All three must pass before any file is read for implementation.
 


### PR DESCRIPTION
## Summary

Follow-up to the non-blocking security observation on #205: the engineer's focus gate previously noop'd silently when a `type:feature`/`perf`/`refactor` issue reached it without a `## Focus Workstream` citation, leaving the issue author with no signal about why nothing happened.

Now the engineer posts a templated comment on the issue before standing down, telling the author (or an architect) exactly what to do:
- **(a)** have the architect add the focus-workstream citation, or
- **(b)** relabel as `type:bug` if it's a correctness fix that shouldn't wait for the weekly focus.

## Why this matters

Silent noops are a bad DX pattern — they look identical to "nothing happened yet" and make the pipeline feel broken to humans interacting with it. The fix adds one observable signal (the comment) without loosening the gate itself.

## Implementation

One source edit in `.github/workflows/engineer.md`:
- Replaces the bare `noop` call in precondition #3 with a two-step sequence: `add-comment` (templated message with the three options) → `noop`
- Noop message updated to `"focus gate: issue lacks Focus Workstream citation; commented on issue and standing down"` so it's visibly distinct from other noops
- No schema change — `add-comment` is already in `safe-outputs`

Bug fixes (`type:bug`) remain exempt, as before.

## Pre-merge checklist

- [ ] Run `gh aw compile --approve-updates` to regenerate `.github/workflows/engineer.lock.yml`
- [ ] Commit and push the regenerated lock file (activation check will fail until this lands)

## Test plan

- [ ] After merging + the lock-file recompile, open a throwaway issue labeled `type:feature` + `design-approved` without a `## Focus Workstream` section and verify the engineer posts the templated comment before standing down.
- [ ] Open an issue labeled `type:bug` + `design-approved` and verify the engineer proceeds normally (bug exemption unchanged).

https://claude.ai/code/session_016tW8uf8UHneKBZijugdtsp