### PR TITLE
Tier 1A PR 2+3: Eliminate parse_native_artifact_safe wrapper

### DIFF
--- a/compiler/src/llvm/lowering/entrypoints.sfn
+++ b/compiler/src/llvm/lowering/entrypoints.sfn
@@ -23,17 +23,12 @@ import {
     parse_native_artifact,
     parse_native_artifact_for_import_context,
     parse_native_bindings_from_text,
-    parse_native_diagnostics_from_text,
-    parse_native_enums_from_text,
     parse_native_function_count_from_text,
     parse_native_functions_for_import,
     parse_native_functions_from_text,
     parse_native_imports_for_import,
-    parse_native_imports_from_text,
     parse_native_interfaces_for_import,
-    parse_native_interfaces_from_text,
     parse_native_structs_for_import,
-    parse_native_structs_from_text,
     select_layout_manifest_artifact,
     select_text_artifact
 } from "../../native_ir_api";
@@ -145,7 +140,6 @@ import {
     write_llvm_lines_chunked
 } from "./lowering_io";
 import {
-    parse_native_artifact_safe,
     recover_functions_for_lowering,
     recover_native_functions_light,
     recover_native_imports_light,
@@ -161,7 +155,7 @@ fn lower_to_llvm(native_module: NativeModule) -> LoweredLLVMResult ![io] {
     if _if206 {
         return lower_to_llvm_with_context(native_module, [], [], []);
     }
-    let parse = parse_native_artifact_safe(artifact.contents);
+    let parse = parse_native_artifact(artifact.contents);
     let import_context = collect_imported_module_context_for_module(parse.imports, native_module.module_name);
     return lower_to_llvm_with_parsed_context(native_module, parse, import_context.manifests, import_context.native_texts, import_context.diagnostics);
 }
@@ -217,7 +211,7 @@ fn lower_to_llvm_ir(native_module: NativeModule) -> string ![io] {
         return lowered.ir;
     }
     // Parse once and reuse throughout lowering; parsing the native artifact is expensive.
-    let parse = parse_native_artifact_safe(artifact.contents);
+    let parse = parse_native_artifact(artifact.contents);
     let import_context = collect_imported_module_context_for_module(parse.imports, native_module.module_name);
     let lowered = lower_to_llvm_with_parsed_context(native_module, parse, import_context.manifests, import_context.native_texts, import_context.diagnostics);
     return lowered.ir;
@@ -226,7 +220,7 @@ fn lower_to_llvm_ir(native_module: NativeModule) -> string ![io] {
 // Build LLVM IR from raw native text (non-test path), avoiding NativeModule ABI issues.
 fn lower_to_llvm_ir_from_text(native_text: string, module_name: string) -> string ![io] {
     if native_text.length == 0 { return ""; }
-    let parse = parse_native_artifact_safe(native_text);
+    let parse = parse_native_artifact(native_text);
     let import_context = collect_imported_module_context_for_module(parse.imports, module_name);
     let dummy_module = NativeModule {
         module_name: module_name,
@@ -260,7 +254,7 @@ fn lower_to_llvm_ir_from_text(native_text: string, module_name: string) -> strin
 fn write_llvm_ir(native_module: NativeModule, out_path: string) -> boolean ![io] {
     let artifact = select_text_artifact(native_module.artifacts);
     if artifact == null { return false; }
-    let parse = parse_native_artifact_safe(artifact.contents);
+    let parse = parse_native_artifact(artifact.contents);
     let import_context = collect_imported_module_context_for_module(parse.imports, native_module.module_name);
     let lowered_lines = lower_to_llvm_lines_with_parsed_context(native_module, parse, import_context.manifests, import_context.native_texts, import_context.diagnostics, true, artifact.contents);
     let lines = lowered_lines.lines;
@@ -363,6 +357,6 @@ fn lower_to_llvm_lines_with_context(native_module: NativeModule, imported_manife
         };
     }
 
-    let parse = parse_native_artifact_safe(artifact.contents);
+    let parse = parse_native_artifact(artifact.contents);
     return lower_to_llvm_lines_with_parsed_context(native_module, parse, imported_manifests, imported_native_texts, diagnostics, true, artifact.contents);
 }

--- a/compiler/src/llvm/lowering/entrypoints_tests.sfn
+++ b/compiler/src/llvm/lowering/entrypoints_tests.sfn
@@ -15,6 +15,7 @@ import {
     ParseNativeResult
 } from "../../native_ir";
 import {
+    parse_native_artifact,
     parse_native_enums_for_import,
     parse_native_functions_for_import,
     parse_native_interfaces_for_import,
@@ -97,7 +98,6 @@ import {
     extend_string_lines_checked,
     module_source_filename
 } from "./lowering_io";
-import { parse_native_artifact_safe } from "./lowering_recovery";
 import { lower_module_bindings_to_globals } from "./module_globals";
 
 // Stub: kept for import-graph compatibility (main.sfn imports this symbol).
@@ -114,7 +114,7 @@ fn lower_to_llvm_for_tests(native_module: NativeModule) -> LoweredLLVMResult ![i
             string_constants: empty_string_constant_set()
         };
     }
-    let parse = parse_native_artifact_safe(artifact.contents);
+    let parse = parse_native_artifact(artifact.contents);
     let import_context = collect_imported_module_context_for_module(parse.imports, native_module.module_name);
     let base = lower_to_llvm_with_parsed_context(native_module, parse, import_context.manifests, import_context.native_texts, import_context.diagnostics);
     return base;

--- a/compiler/src/llvm/lowering/entrypoints_tests_writer.sfn
+++ b/compiler/src/llvm/lowering/entrypoints_tests_writer.sfn
@@ -97,7 +97,6 @@ import {
     extend_string_lines_checked,
     module_source_filename
 } from "./lowering_io";
-import { parse_native_artifact_safe } from "./lowering_recovery";
 import { lower_module_bindings_to_globals } from "./module_globals";
 
 // Stub: kept for import-graph compatibility (main.sfn imports this symbol).
@@ -123,7 +122,7 @@ fn write_llvm_ir_for_tests_from_text(native_text: string, module_name: string, o
     // rather than stale data from a previous `run` invocation.
     fs.writeFile("build/sailfin/emit-native.tmp", native_text);
     // Use the recovery parser (build_parse_result_from_text) instead of the
-    // structured parser (parse_native_artifact_safe).  The recovery parser
+    // structured parser (parse_native_artifact).  The recovery parser
     // creates ALL instructions as Expression(tag→21) with parseable text,
     // which the tag-21 fallback handler in the instruction lowerer can
     // dispatch correctly.  The structured parser creates typed variants

--- a/compiler/src/llvm/lowering/lowering_phase_sanitize.sfn
+++ b/compiler/src/llvm/lowering/lowering_phase_sanitize.sfn
@@ -22,7 +22,6 @@ import { is_test_module_slug, sanitize_collection_length } from "./lowering_help
 import { extend_string_lines_checked } from "./lowering_io";
 import { get_struct_fields_at, get_struct_name_at } from "./lowering_native_helpers";
 import {
-    parse_native_artifact_safe,
     recover_functions_for_lowering,
     recover_native_enums_light,
     recover_native_functions_light,

--- a/compiler/src/llvm/lowering/lowering_recovery.sfn
+++ b/compiler/src/llvm/lowering/lowering_recovery.sfn
@@ -6,8 +6,8 @@
 // written for the v0.1.1 seed, which couldn't compile the structured parser's
 // deeply nested if/else chains. The structured path is now reliable under
 // seed 0.5.7+ (validated by every `.struct_info`/`.enum_info`/`.fn_*` removal
-// since PR #183); `parse_native_artifact_safe` now routes through it directly.
-// Tier 1C tracks removing the light-recovery primary path in lowering_core.
+// since PR #183). Tier 1C tracks removing the light-recovery primary path in
+// lowering_core.
 //
 // Extracted from lowering_core.sfn to reduce per-file memory footprint.
 import {
@@ -22,11 +22,9 @@ import {
     NativeStruct,
     NativeStructField,
     NativeStructLayout,
-    NativeStructLayoutField,
-    ParseNativeResult
+    NativeStructLayoutField
 } from "../../native_ir";
 import {
-    parse_native_artifact,
     parse_native_function_count_from_text,
     parse_native_functions_from_text
 } from "../../native_ir_api";
@@ -70,18 +68,6 @@ import {
     starts_with_local,
     trim_text_local
 } from "./lowering_text_utils";
-
-// ── Parse wrappers ───────────────────────────────────────────────────
-// Historically built a ParseNativeResult from 7 per-field extractors to
-// sidestep the seed v0.1.1 struct-return ABI bug. Under seed 0.5.7+ the
-// struct-return path works (validated by every `.struct_info`/`.enum_info`/
-// `.fn_*` removal since PR #183), so this now delegates directly to
-// parse_native_artifact — a single artifact walk instead of 7. The wrapper
-// is kept during Tier 1A PR 1 so callsites don't churn; PR 2 swaps the 6
-// live callers to parse_native_artifact and PR 3 deletes this function.
-fn parse_native_artifact_safe(text: string) -> ParseNativeResult {
-    return parse_native_artifact(text);
-}
 
 // ── Light function recovery ──────────────────────────────────────────
 fn recover_native_functions_light(native_text: string) -> NativeFunction[] {

--- a/compiler/src/native_ir_api.sfn
+++ b/compiler/src/native_ir_api.sfn
@@ -92,40 +92,10 @@ fn parse_native_functions_from_text(text: string) -> NativeFunction[] {
     return parsed.functions;
 }
 
-fn parse_native_structs_from_text(text: string) -> NativeStruct[] {
-    let parsed = parse_native_artifact_impl(text, true, true);
-    if parsed.structs == null { return []; }
-    return parsed.structs;
-}
-
-fn parse_native_imports_from_text(text: string) -> NativeImport[] {
-    let parsed = parse_native_artifact_impl(text, true, true);
-    if parsed.imports == null { return []; }
-    return parsed.imports;
-}
-
-fn parse_native_interfaces_from_text(text: string) -> NativeInterface[] {
-    let parsed = parse_native_artifact_impl(text, true, true);
-    if parsed.interfaces == null { return []; }
-    return parsed.interfaces;
-}
-
-fn parse_native_enums_from_text(text: string) -> NativeEnum[] {
-    let parsed = parse_native_artifact_impl(text, true, true);
-    if parsed.enums == null { return []; }
-    return parsed.enums;
-}
-
 fn parse_native_bindings_from_text(text: string) -> NativeBinding[] {
     let parsed = parse_native_artifact_impl(text, true, true);
     if parsed.bindings == null { return []; }
     return parsed.bindings;
-}
-
-fn parse_native_diagnostics_from_text(text: string) -> string[] {
-    let parsed = parse_native_artifact_impl(text, true, true);
-    if parsed.diagnostics == null { return []; }
-    return parsed.diagnostics;
 }
 
 fn parse_native_structs_for_import(text: string) -> NativeStruct[] {
@@ -196,12 +166,7 @@ export {
     parse_native_artifact,
     parse_native_function_count_from_text,
     parse_native_functions_from_text,
-    parse_native_structs_from_text,
-    parse_native_imports_from_text,
-    parse_native_interfaces_from_text,
-    parse_native_enums_from_text,
     parse_native_bindings_from_text,
-    parse_native_diagnostics_from_text,
     parse_native_structs_for_import,
     parse_native_imports_for_import,
     parse_native_interfaces_for_import,

--- a/docs/build-performance.md
+++ b/docs/build-performance.md
@@ -931,7 +931,7 @@ Pre-existing dead imports of the retained symbols in `lowering_core.sfn` and `lo
 
 **Scope:**
 
-- 6 source files modified (`entrypoints.sfn`, `entrypoints_tests.sfn`, `entrypoints_tests_writer.sfn`, `lowering_phase_sanitize.sfn`, `lowering_recovery.sfn`, `native_ir_api.sfn`) + 1 docs file.
+- 6 source files modified (`entrypoints.sfn`, `entrypoints_tests.sfn`, `entrypoints_tests_writer.sfn`, `lowering_phase_sanitize.sfn`, `lowering_recovery.sfn`, `native_ir_api.sfn`) + this entry in `docs/build-performance.md` + `docs/proposals/phase-4-eliminate-light-recovery.md` (architect's Phase 4 migration plan, dropped in the same PR so the next session can pick it up).
 - Net: approximately −70 lines across the 6 source files (wrapper deletion + 5 projection deletions + dead-import pruning). No signature changes, no new wrapper structs, no new tests (the self-host itself exercises every live path on every `make check`).
 
 **Determinism:** No new cross-phase or cross-process state. The parse result flowing into every downstream lowering phase is produced by the same single-pass `parse_native_artifact_impl` invocation as before; the only change is whether it routes through a trivial wrapper or not. CI determinism sweep on macOS-arm64 should show no regression.

--- a/docs/build-performance.md
+++ b/docs/build-performance.md
@@ -888,9 +888,53 @@ For each of the 6 live callers (`entrypoints.sfn:164,220,229,263,366` + `entrypo
 
 **Follow-ups (remaining Tier 1A work — track in subsequent PRs):**
 
-- **Tier 1A PR 2 — callsite swap.** Replace `parse_native_artifact_safe(x)` with `parse_native_artifact(x)` at all 6 live sites: `compiler/src/llvm/lowering/entrypoints.sfn:164`, `:220`, `:229`, `:263`, `:366`, and `compiler/src/llvm/lowering/entrypoints_tests.sfn:117`. Remove the two confirmed dead imports: `compiler/src/llvm/lowering/entrypoints_tests_writer.sfn:100` (imported but only referenced in a comment; real path uses `build_parse_result_from_text` at `:133`) and `compiler/src/llvm/lowering/lowering_phase_sanitize.sfn:25` (imported but not used in the file body). Requires `make clean-build` because it's a structural change to the import graph. No runtime behavior change.
-- **Tier 1A PR 3 — wrapper deletion.** Delete `fn parse_native_artifact_safe` from `compiler/src/llvm/lowering/lowering_recovery.sfn:78`. After the callsite swap in PR 2, the function has zero callers. Conditionally delete now-orphaned `_from_text` wrappers from `compiler/src/native_ir_api.sfn` if they have zero remaining callers repo-wide: `parse_native_structs_from_text`, `parse_native_imports_from_text`, `parse_native_interfaces_from_text`, `parse_native_enums_from_text`, `parse_native_diagnostics_from_text`. **Keep** `parse_native_functions_from_text` (live callers at `lowering_recovery.sfn:730,836`, `lowering_phase_sanitize.sfn:19,281`, `lowering_core.sfn:33`), `parse_native_function_count_from_text` (live caller at `lowering_recovery.sfn:826`), and `parse_native_bindings_from_text` (live callers at `lowering_phase_sanitize.sfn:19,409`, `lowering_core.sfn:31`) — verify via `grep -rn` at PR 3 time.
+- ~~**Tier 1A PR 2 — callsite swap.**~~ — **Shipped** (see [Completed Work: Tier 1A PR 2+3](#tier-1a-pr-23--callsite-swap--wrapper-deletion-april-21)).
+- ~~**Tier 1A PR 3 — wrapper deletion.**~~ — **Shipped** (combined with PR 2 in the same PR).
 - **Tier 1A PR 4 (optional) — equivalence regression test.** Add `compiler/tests/unit/parse_native_artifact_equivalence_test.sfn` constructing a synthetic `.sfn-asm` fixture that exercises every top-level directive (`.import`, `.export`, `.struct`+body, `.interface`+body, `.enum`+body, `.fn`+body, `.test`+body, top-level binding, `.decorator`, `.span`, `.init-span`) and asserts field-by-field equality between `parse_native_artifact(fixture).X` and each legacy `parse_native_X_from_text(fixture)` projection. Defense-in-depth only — the self-host itself is the real equivalence gate. Must follow the `parse_native_imports_fast_test.sfn` pattern (re-implement against minimal local types to stay under the 60s per-test budget; do not import the full parser chain).
+
+### Tier 1A PR 2+3 — Callsite Swap + Wrapper Deletion (April 21)
+
+**Status: Implemented.** Combines the two planned Tier 1A follow-ups into a single PR: swap every `parse_native_artifact_safe` callsite to `parse_native_artifact`, delete the wrapper, and prune the five orphaned `_from_text` projections that fell out once the wrapper's internal machinery was gone.
+
+**Shape of change:**
+
+- `compiler/src/llvm/lowering/entrypoints.sfn`: dropped `parse_native_artifact_safe` from the `./lowering_recovery` import block (`parse_native_artifact` was already imported from `../../native_ir_api`). Dropped the five orphan `_from_text` imports (`parse_native_structs_from_text`, `parse_native_imports_from_text`, `parse_native_interfaces_from_text`, `parse_native_enums_from_text`, `parse_native_diagnostics_from_text`) — they were imported but never referenced in this file. Swapped all 5 callsites (lines 158, 214, 223, 257, 360 after prior edits) to `parse_native_artifact`.
+- `compiler/src/llvm/lowering/entrypoints_tests.sfn`: added `parse_native_artifact` to the `../../native_ir_api` import block, dropped the `parse_native_artifact_safe` import from `./lowering_recovery`, swapped the single callsite.
+- `compiler/src/llvm/lowering/entrypoints_tests_writer.sfn`: dropped the dead `parse_native_artifact_safe` import (referenced only in a comment; real path uses `build_parse_result_from_text`). Updated the comment to reference `parse_native_artifact` instead.
+- `compiler/src/llvm/lowering/lowering_phase_sanitize.sfn`: dropped `parse_native_artifact_safe` from the `./lowering_recovery` import block — the identifier never appeared in the file body.
+- `compiler/src/llvm/lowering/lowering_recovery.sfn`: deleted `fn parse_native_artifact_safe` (one-line delegator) and its header comment block. Pruned now-unused imports `parse_native_artifact` (from `../../native_ir_api`) and `ParseNativeResult` (from `../../native_ir`). Rewrote the module header comment to drop the stale `parse_native_artifact_safe` reference.
+- `compiler/src/native_ir_api.sfn`: deleted the five orphaned `_from_text` wrappers (`parse_native_structs_from_text`, `parse_native_imports_from_text`, `parse_native_interfaces_from_text`, `parse_native_enums_from_text`, `parse_native_diagnostics_from_text`) and their entries in the `export` block. **Kept:** `parse_native_artifact`, `parse_native_function_count_from_text`, `parse_native_functions_from_text`, `parse_native_bindings_from_text`, all `_for_import` variants, `parse_native_artifact_for_import_context`, `parse_layout_manifest` — all still have live callers (verified via repo-wide `grep -rn` prior to deletion).
+
+**Caller audit at PR-open time:**
+
+| Symbol                                 | Live callers (non-import) | Decision |
+| -------------------------------------- | -------------------------: | -------- |
+| `parse_native_artifact_safe`           |                          6 | delete after swap |
+| `parse_native_structs_from_text`       |                          0 | delete |
+| `parse_native_imports_from_text`       |                          0 | delete |
+| `parse_native_interfaces_from_text`    |                          0 | delete |
+| `parse_native_enums_from_text`         |                          0 | delete |
+| `parse_native_diagnostics_from_text`   |                          0 | delete |
+| `parse_native_functions_from_text`     |                          4 | keep (`lowering_recovery`, `lowering_phase_sanitize`) |
+| `parse_native_function_count_from_text`|                          1 | keep (`lowering_recovery`) |
+| `parse_native_bindings_from_text`      |                          1 | keep (`lowering_phase_sanitize`) |
+
+Pre-existing dead imports of the retained symbols in `lowering_core.sfn` and `lowering_helpers.sfn` are left alone — they're not in scope for Tier 1A and their removal is a separate cleanup.
+
+**API surface change:** all five deleted `_from_text` symbols were in the `export` block of `native_ir_api.sfn`; they are now removed from the public surface. No capsule outside the compiler imports them (caller audit is repo-wide).
+
+**Risk assessment:**
+
+- **Output equivalence:** `parse_native_artifact(text) ≡ parse_native_artifact_impl(text, true, true)` — the exact call the wrapper delegated to. The five deleted projection wrappers were pure `parsed.X` field reads off the same underlying parser; no caller depended on any projection-only semantics.
+- **Structural / import-graph change:** touches 6 source files with one symbol deletion and 5 projection deletions. Requires `make clean-build` on a fresh build directory because several modules' import lists changed. CI's matrix build on PR open exercises this on every supported platform.
+- **Self-hosting:** only `parse_native_artifact_safe`'s five live callers were real work — each reduces from a trivial delegate call to the underlying parser call. Compiler output is byte-identical by construction.
+
+**Scope:**
+
+- 6 source files modified (`entrypoints.sfn`, `entrypoints_tests.sfn`, `entrypoints_tests_writer.sfn`, `lowering_phase_sanitize.sfn`, `lowering_recovery.sfn`, `native_ir_api.sfn`) + 1 docs file.
+- Net: approximately −70 lines across the 6 source files (wrapper deletion + 5 projection deletions + dead-import pruning). No signature changes, no new wrapper structs, no new tests (the self-host itself exercises every live path on every `make check`).
+
+**Determinism:** No new cross-phase or cross-process state. The parse result flowing into every downstream lowering phase is produced by the same single-pass `parse_native_artifact_impl` invocation as before; the only change is whether it routes through a trivial wrapper or not. CI determinism sweep on macOS-arm64 should show no regression.
 
 ---
 

--- a/docs/proposals/phase-4-eliminate-light-recovery.md
+++ b/docs/proposals/phase-4-eliminate-light-recovery.md
@@ -38,7 +38,7 @@
 
 **Two fabricated contracts the pipeline relies on:**
 
-1. **Flat struct-method flattening.** `recover_native_functions_light` flattens methods at parse time; the structured parser keeps them nested. `lowering_core.sfn:488` calls `flatten_struct_methods(module_structs)`, so this is already paper-overed on the non-test primary path via `lower_to_llvm` (`entrypoints.sfn:158`). The issue only bites `compile_native_text_to_llvm_file` and the test-writer (which skip that flatten call).
+1. **Flat struct-method flattening.** `recover_native_functions_light` flattens methods at parse time; the structured parser keeps them nested. `lowering_core.sfn:488` calls `flatten_struct_methods(module_structs)`, so this is already papered over on the non-test primary path via `lower_to_llvm` (`entrypoints.sfn:158`). The issue only bites `compile_native_text_to_llvm_file` and the test-writer (which skip that flatten call).
 
 2. **Tag-21 instruction dispatch.** Per the `entrypoints_tests_writer.sfn:124-131` comment, the seedcheck's `get_instruction_tag` historically returned 21 for every typed variant. **Confirm before proceeding** — inspect `compiler/src/native_ir.sfn`'s `get_instruction_tag` and `compiler/src/llvm/lowering/instructions_*.sfn` dispatch against typed tags under seed 0.5.7. If it now dispatches typed tags correctly, Phase 4 can cover the test path (PR 2). If not, the test path stays on `build_parse_result_from_text` and Phase 4 only covers the non-test primary (PR 1 alone).
 

--- a/docs/proposals/phase-4-eliminate-light-recovery.md
+++ b/docs/proposals/phase-4-eliminate-light-recovery.md
@@ -1,0 +1,160 @@
+# Phase 4: Eliminate `recover_native_functions_light` Primary Path
+
+**Status:** Planned (April 21, 2026). Not yet implemented.
+**Parent track:** `docs/build-performance.md` — Root Cause 4 / Phase 4.
+**Predecessor PRs:** Tier 1A PR 1 (#204), Tier 1A PR 2+3 (this branch).
+**Owner:** next session.
+
+---
+
+## 1. Call graph (confirmed)
+
+**Primary paths into light recovery** (every module hits these):
+
+- `compile_native_text_to_llvm_file` at `compiler/src/llvm/lowering/lowering_core.sfn:247-282` — the path used by `main.sfn:501` via `write_llvm_ir_from_native_text_file` for *every* non-test build. Calls `build_parse_result_from_text` (`:126-140`), which unconditionally runs all four `recover_*_light` routines, then *also* calls `recover_native_imports_light` a second time at `:258`.
+- `lower_to_llvm_lines_with_parsed_context` at `lowering_core.sfn:284` — always calls `sanitize_lowering_inputs` (`lowering_phase_sanitize.sfn:50-88`), which, when `native_text_override_path.length > 0` (the normal case from `compile_native_text_to_llvm_file`), re-runs `recover_native_functions_light` + `recover_native_structs_light` + `recover_native_enums_light` and *replaces* `parse` wholesale when the reparse has ≥ the function count.
+- Per-imported-module: `recover_native_enums_light` at `lowering_core.sfn:425` runs once per import text.
+
+**Fallback paths** (only fire on empty/corrupt parse — keep for now):
+
+- `sanitize_functions` at `:300`
+- `recover_structs_if_corrupt` at `:383`
+- `recover_functions_for_lowering` light fallbacks at `lowering_recovery.sfn:773, 838, 852`
+
+**Test-only path:**
+
+- `write_llvm_ir_for_tests_from_text` at `entrypoints_tests_writer.sfn:132` — also uses `build_parse_result_from_text`. Comment at `:124-131` explicitly states it depends on all instructions being emitted as tag-21 Expression because the seedcheck's `get_instruction_tag` cannot distinguish the typed variants.
+
+## 2. Output-contract delta (structured vs. light)
+
+| Field | `parse_native_artifact` | `recover_*_light` |
+|-------|-------------------------|-------------------|
+| `functions[i].instructions[j].tag` | Typed (0 Return, 1 Expression, 3 If, 4 Else, 5 EndIf, 8 Loop, …) | **All tag 21** except Return/If/Else/EndIf/Loop/EndLoop/For/EndFor/Break/Continue/Match/Case/EndMatch |
+| Struct-method `.method` within `.struct` | Emitted nested in `NativeStruct.methods` | Flattened to top-level `NativeFunction` with name = `StructName` + methodName |
+| Enum variants | Real variant names + payload fields | Same |
+| `bindings` | Populated | Always `[]` |
+| `interfaces` | Populated | Always `[]` |
+| `diagnostics` | Populated | Always `[]` |
+
+**Two fabricated contracts the pipeline relies on:**
+
+1. **Flat struct-method flattening.** `recover_native_functions_light` flattens methods at parse time; the structured parser keeps them nested. `lowering_core.sfn:488` calls `flatten_struct_methods(module_structs)`, so this is already paper-overed on the non-test primary path via `lower_to_llvm` (`entrypoints.sfn:158`). The issue only bites `compile_native_text_to_llvm_file` and the test-writer (which skip that flatten call).
+
+2. **Tag-21 instruction dispatch.** Per the `entrypoints_tests_writer.sfn:124-131` comment, the seedcheck's `get_instruction_tag` historically returned 21 for every typed variant. **Confirm before proceeding** — inspect `compiler/src/native_ir.sfn`'s `get_instruction_tag` and `compiler/src/llvm/lowering/instructions_*.sfn` dispatch against typed tags under seed 0.5.7. If it now dispatches typed tags correctly, Phase 4 can cover the test path (PR 2). If not, the test path stays on `build_parse_result_from_text` and Phase 4 only covers the non-test primary (PR 1 alone).
+
+## 3. Scope
+
+**In (PR 1):**
+- Delete `build_parse_result_from_text` (`lowering_core.sfn:126-140`).
+- Rework `compile_native_text_to_llvm_file` to call `parse_native_artifact` directly.
+- Delete the `_rfns`/`_rsts`/`_rens` override-reparse block in `sanitize_lowering_inputs` (`lowering_phase_sanitize.sfn:58-83`).
+- Replace per-import `recover_native_enums_light` at `lowering_core.sfn:425` with `parse_native_enums_for_import`.
+- Collapse the duplicate `recover_native_imports_light` at `lowering_core.sfn:258` into reusing `parse.imports`.
+- Clean up now-orphaned imports in `entrypoints.sfn`, `lowering_core.sfn`, `lowering_phase_sanitize.sfn`.
+
+**Out (keep as defensive fallbacks):**
+- `recover_functions_for_lowering` internal light calls — fire only when structured parse returned empty/inconsistent. Keep as belt-and-suspenders; delete in Phase 4b.
+- `sanitize_functions:300` and `recover_structs_if_corrupt:383` — same argument.
+- The `recover_*_light` function bodies themselves in `lowering_recovery.sfn` — still exported for the fallbacks. Delete in Phase 4b once counters confirm zero hits for a release cycle.
+- `write_llvm_ir_for_tests_from_text` — conditional on Section 2 item 2; most likely stays on `build_parse_result_from_text` for this PR.
+
+## 4. Sequencing
+
+### PR 1 — Non-test primary path
+
+**Branch:** `claude/phase-4-eliminate-light-recovery-primary`
+
+**Step 1** — `lowering_phase_sanitize.sfn`:
+- Lines `:58-83`: delete the override-reparse block and the length-swap. The structured `parse_in` is authoritative.
+- Lines `:25-30`: drop `recover_native_functions_light`, `recover_native_imports_light`, `recover_native_structs_light`, `recover_native_enums_light`. Keep `recover_functions_for_lowering`.
+
+**Step 2** — `lowering_core.sfn`:
+- Lines `:247-282`: replace `build_parse_result_from_text(native_text)` with `parse_native_artifact(native_text)`; replace `recover_native_imports_light(native_text)` at `:258` with `parse.imports`.
+- Lines `:126-140`: delete `build_parse_result_from_text`.
+- Lines `:115-119`: drop light-recovery imports (keep `recover_functions_for_lowering`).
+- Line `:425`: replace `recover_native_enums_light(native_text)` with `parse_native_enums_for_import(native_text)`. Add `parse_native_enums_for_import` to the `native_ir_api` import block.
+
+**Step 3** — Fallback verification:
+- Add transient `print.err` counters in `recover_functions_for_lowering`'s light fallback arms and in `sanitize_functions:300` / `recover_structs_if_corrupt:383`. Run `make compile && make check`. Expectation: counts are zero on the happy path. If any non-zero, investigate per-module before merging — there's a structured-parser bug to fix first. Remove counters before commit.
+
+**Step 4** — `entrypoints.sfn` import cleanup:
+- Lines `:142-147`: drop `recover_native_functions_light`, `recover_native_imports_light`, `recover_native_structs_light` (confirm via grep).
+
+**Verification gate:**
+- `make clean-build && make check`.
+- `make bench` before/after; record delta in PR body (target: 5–10%).
+- Determinism: 10× `make compile` on Linux, hash `build/native/sailfin` each time — all 10 must match.
+
+### PR 2 — Test-writer path (conditional)
+
+Only proceed if inspection of `native_ir.sfn:get_instruction_tag` confirms typed-tag dispatch works under seed 0.5.7. Then:
+- `entrypoints_tests_writer.sfn:132`: switch from `build_parse_result_from_text` to `parse_native_artifact`. Remove the `:76` import. Update the `:120-131` comment block.
+- Add a test-harness determinism check covering a module with `if`/`loop`/`match`.
+
+Otherwise, park PR 2 with a tracking comment and revisit after the next seed cut.
+
+### PR 3 — Phase 4b (future)
+
+Once fallback counters confirm zero hits for a full release cycle: delete `recover_native_functions_light`, `recover_native_imports_light`, `recover_native_structs_light`, `recover_native_enums_light` from `lowering_recovery.sfn`. Remove the fallback arms. Drops ~600 LOC.
+
+## 5. Risks
+
+- **macOS-arm64 determinism**: the override-reparse block in `sanitize_phase_sanitize.sfn:58-83` was added when cross-module struct returns were unreliable. Seed 0.5.7 proved stable in PR #183/#186 sweeps, but arm64 has lagged on prior ABI flakes. **Mitigation**: gate PR 1 merge on a macOS-arm64 determinism run (20× `emit llvm` per-module, hash compare). If arm64 flakes, narrow PR 1 to Step 2 only (leave the override-reparse in `sanitize_lowering_inputs` intact), reclaiming ~half the win.
+
+- **Struct-method shape mismatch in `compile_native_text_to_llvm_file`**: light parser flattens methods at parse; structured parser keeps them nested. `lower_to_llvm_lines_with_parsed_context` already calls `flatten_struct_methods` at `:488`, so flattening happens regardless. Step 2 changes `parse.functions` to no longer contain flattened methods. Net effect: methods appear once (via flatten) instead of twice. **Verify** by diffing a small module's pre/post IR; if method-mangled symbols double, there's already latent dedup and this change is a net fix.
+
+- **Instruction-tag dispatch regression**: if any instruction lowerer still has a tag-21 fast path that implicitly handled cases the typed tags now route elsewhere, typed dispatch may surface a latent bug. **Mitigation**: Step 3's counter run will catch this.
+
+- **`emit-native.tmp` disk race**: `compile_native_text_to_llvm_file:259` writes `emit-native.tmp` before calling `lower_to_llvm_lines_with_parsed_context`, and multiple fallback paths read it back. No change needed for PR 1, but note for Phase 5: when the compiler becomes long-lived, this temp file becomes a cross-invocation race and needs to move in-memory.
+
+## 6. Verification commands
+
+```
+# Per-step during PR 1
+make compile
+make test-unit
+make test-integration
+
+# Pre-merge gate
+make clean-build && make check
+
+# Determinism (Linux)
+for i in $(seq 1 10); do make rebuild >/dev/null 2>&1 && sha256sum build/native/sailfin; done | sort -u
+
+# Determinism (macOS arm64, per-module — run from CI)
+for i in $(seq 1 20); do \
+  ulimit -v 8388608; \
+  timeout 60 build/native/sailfin emit llvm compiler/src/llvm/lowering/lowering_core.sfn \
+    -o /tmp/lc.$i.ll; \
+  sha256sum /tmp/lc.$i.ll; \
+done | sort -u | wc -l
+# Expected: 1
+
+# Perf delta
+make bench > /tmp/bench.after
+diff /tmp/bench.before /tmp/bench.after
+```
+
+## 7. Future interactions
+
+- **Phase 5 (long-lived process)**: removing `emit-native.tmp` as a primary channel is a prerequisite. Phase 4 reduces its reader count from 5 to 2, shrinking Phase 5's in-memory-only transition.
+- **Structured diagnostics (`--json`)**: the structured parser produces real `diagnostics` — once Phase 4 routes everything through it, those diagnostics become first-class, unblocking machine-readable diagnostic output without double-parse.
+- **Runtime Phase 2 (typed containers)**: independent of Phase 4.
+
+## 8. Files affected
+
+**PR 1:**
+- `compiler/src/llvm/lowering/lowering_core.sfn`
+- `compiler/src/llvm/lowering/lowering_phase_sanitize.sfn`
+- `compiler/src/llvm/lowering/entrypoints.sfn`
+
+**PR 2 (conditional):**
+- `compiler/src/llvm/lowering/entrypoints_tests_writer.sfn`
+
+**Reference (read-only during planning):**
+- `compiler/src/llvm/lowering/lowering_recovery.sfn`
+- `compiler/src/native_ir_parser.sfn`
+- `compiler/src/native_ir_api.sfn`
+- `compiler/src/main.sfn` (caller of `write_llvm_ir_from_native_text_file`)
+
+No changes in lexer, parser, AST, typecheck, effect checker, or `emit_native`.

--- a/docs/proposals/phase-4-eliminate-light-recovery.md
+++ b/docs/proposals/phase-4-eliminate-light-recovery.md
@@ -99,7 +99,7 @@ Once fallback counters confirm zero hits for a full release cycle: delete `recov
 
 ## 5. Risks
 
-- **macOS-arm64 determinism**: the override-reparse block in `sanitize_phase_sanitize.sfn:58-83` was added when cross-module struct returns were unreliable. Seed 0.5.7 proved stable in PR #183/#186 sweeps, but arm64 has lagged on prior ABI flakes. **Mitigation**: gate PR 1 merge on a macOS-arm64 determinism run (20× `emit llvm` per-module, hash compare). If arm64 flakes, narrow PR 1 to Step 2 only (leave the override-reparse in `sanitize_lowering_inputs` intact), reclaiming ~half the win.
+- **macOS-arm64 determinism**: the override-reparse block in `lowering_phase_sanitize.sfn:58-83` was added when cross-module struct returns were unreliable. Seed 0.5.7 proved stable in PR #183/#186 sweeps, but arm64 has lagged on prior ABI flakes. **Mitigation**: gate PR 1 merge on a macOS-arm64 determinism run (20× `emit llvm` per-module, hash compare). If arm64 flakes, narrow PR 1 to Step 2 only (leave the override-reparse in `sanitize_lowering_inputs` intact), reclaiming ~half the win.
 
 - **Struct-method shape mismatch in `compile_native_text_to_llvm_file`**: light parser flattens methods at parse; structured parser keeps them nested. `lower_to_llvm_lines_with_parsed_context` already calls `flatten_struct_methods` at `:488`, so flattening happens regardless. Step 2 changes `parse.functions` to no longer contain flattened methods. Net effect: methods appear once (via flatten) instead of twice. **Verify** by diffing a small module's pre/post IR; if method-mangled symbols double, there's already latent dedup and this change is a net fix.
 


### PR DESCRIPTION
## Summary

Completes Tier 1A of the build-performance optimization track by eliminating the `parse_native_artifact_safe` wrapper function and five orphaned projection wrappers (`parse_native_*_from_text` variants) that became dead code once the structured parser stabilized under seed 0.5.7.

This PR combines the planned Tier 1A PR 2 (callsite swap) and PR 3 (wrapper deletion) into a single change: all 6 live callers of `parse_native_artifact_safe` are swapped to call `parse_native_artifact` directly, the wrapper is deleted, and the five projection wrappers that fell out of use are removed from the public API surface.

## Key Changes

- **`compiler/src/llvm/lowering/lowering_recovery.sfn`**: Deleted `parse_native_artifact_safe` function (one-line delegator) and its header comment block. Removed now-unused imports (`parse_native_artifact`, `ParseNativeResult`). Updated module header to drop stale reference.

- **`compiler/src/llvm/lowering/entrypoints.sfn`**: Swapped 5 callsites (lines 158, 214, 223, 257, 360) from `parse_native_artifact_safe` to `parse_native_artifact`. Dropped dead imports of five `_from_text` projection wrappers that were never referenced in this file. Removed `parse_native_artifact_safe` from the `lowering_recovery` import block.

- **`compiler/src/llvm/lowering/entrypoints_tests.sfn`**: Added `parse_native_artifact` to the `native_ir_api` import block. Swapped the single callsite from `parse_native_artifact_safe` to `parse_native_artifact`. Removed the `lowering_recovery` import.

- **`compiler/src/llvm/lowering/entrypoints_tests_writer.sfn`**: Removed dead `parse_native_artifact_safe` import (was only referenced in a comment; the real code path uses `build_parse_result_from_text`). Updated comment to reference `parse_native_artifact` instead.

- **`compiler/src/llvm/lowering/lowering_phase_sanitize.sfn`**: Removed `parse_native_artifact_safe` from the `lowering_recovery` import block (identifier never appeared in file body).

- **`compiler/src/native_ir_api.sfn`**: Deleted five orphaned projection wrappers (`parse_native_structs_from_text`, `parse_native_imports_from_text`, `parse_native_interfaces_from_text`, `parse_native_enums_from_text`, `parse_native_diagnostics_from_text`) and their entries in the `export` block. Retained `parse_native_artifact`, `parse_native_function_count_from_text`, `parse_native_functions_from_text`, `parse_native_bindings_from_text`, and all `_for_import` variants (all have live callers).

- **`docs/build-performance.md`**: Updated Tier 1A section to mark PR 2+3 as shipped and added detailed implementation notes. Added new section documenting Phase 4 (eliminate light-recovery primary path) with full sequencing, risks, and verification commands.

- **`docs/proposals/phase-4-eliminate-light-recovery.md`**: New proposal document detailing Phase 4 work: eliminating the `recover_native_functions_light` primary path by routing all non-test compilation through the structured parser. Includes call graph analysis, output-contract deltas, detailed sequencing for two PRs, risk assessment, and verification procedures.

## Implementation Details

**Caller audit at PR-open time:**
- `parse_native_artifact_safe`: 6 live callers → all swapped to `parse_native_artifact`
- `parse_native_structs_from_text`: 0 live callers → deleted
- `parse_native_imports_from_text`: 0 live callers → deleted
- `parse_native_interfaces_from_

https://claude.ai/code/session_01DMWweSyWJzePMSAApMMfqk