### PR TITLE
compiler: unblock 0.5.8 release + seedcheck self-host (3 fixes)

### DIFF
--- a/compiler/src/llvm/expression_lowering/native/core_member_lowering.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_member_lowering.sfn
@@ -325,27 +325,31 @@ fn lower_enum_member_access(parse: MemberAccessParse, enum_info: EnumTypeInfo, b
     let mut selected_fields: StructFieldInfo[] = matched_fields;
 
     if expected_type.length > 0 {
-        // Compute the base type (strip trailing `*` levels) of the expected
-        // type so we can match variants whose field is either the same type
-        // or differs by one pointer level. The downstream select-chain logic
-        // (`pointer_coercion`) already handles the mismatch by loading /
-        // taking-address as needed, so filtering by EXACT type equality
-        // would silently drop compatible variants. Concretely:
+        // Filter variants to those whose field matches the caller's expected
+        // type either exactly, or differs by at most one pointer level. The
+        // downstream select-chain logic (`pointer_coercion` below, at line
+        // ~425) handles a single pointer-depth mismatch by loading /
+        // taking-address as needed, but cannot coerce across larger depth
+        // differences. Concretely:
         //
         //   statement.expression where
-        //     ReturnStatement.expression : Expression?   -> %Expression*
-        //     ThrowStatement.expression  : Expression    -> %Expression
-        //     ExpressionStatement.expression : Expression -> %Expression
+        //     ReturnStatement.expression : Expression?   -> %Expression* (depth 1)
+        //     ThrowStatement.expression  : Expression    -> %Expression  (depth 0)
+        //     ExpressionStatement.expression : Expression -> %Expression  (depth 0)
         //
         // A caller passing this to `format_expression(expression: Expression)`
         // under the 0.5.8+ boxed-struct ABI has `expected_type = %Expression*`.
         // An exact-equality filter would keep only ReturnStatement and the
         // chain would return `null` for ExpressionStatement / ThrowStatement,
-        // crashing `format_expression(null)` at runtime.
+        // crashing `format_expression(null)` at runtime. But we still want to
+        // reject fields whose base type differs OR whose pointer depth differs
+        // by more than 1 — those the coercion cannot repair.
         let mut expected_base: string = expected_type;
+        let mut expected_depth: number = 0;
         loop {
             if !ends_with_pointer_suffix(expected_base) { break; }
             expected_base = strip_pointer_suffix(expected_base);
+            expected_depth += 1;
         }
         let mut filtered_variants: EnumVariantInfo[] = [];
         let mut filtered_fields: StructFieldInfo[] = [];
@@ -354,13 +358,21 @@ fn lower_enum_member_access(parse: MemberAccessParse, enum_info: EnumTypeInfo, b
             if selection_index >= matched_fields.length { break; }
             let candidate_field = matched_fields[selection_index];
             let mut candidate_base: string = candidate_field.llvm_type;
+            let mut candidate_depth: number = 0;
             loop {
                 if !ends_with_pointer_suffix(candidate_base) { break; }
                 candidate_base = strip_pointer_suffix(candidate_base);
+                candidate_depth += 1;
             }
             let mut accept: boolean = false;
             if candidate_field.llvm_type == expected_type { accept = true; }
-            if candidate_base == expected_base { accept = true; }
+            if candidate_base == expected_base {
+                // Only accept if pointer-depth difference is within the
+                // coercion branch's supported range (|diff| <= 1).
+                let mut diff: number = candidate_depth - expected_depth;
+                if diff < 0 { diff = 0 - diff; }
+                if diff <= 1 { accept = true; }
+            }
             if accept {
                 filtered_variants.push(matched_variants[selection_index]);
                 filtered_fields.push(candidate_field);

--- a/compiler/src/llvm/expression_lowering/native/core_member_lowering.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_member_lowering.sfn
@@ -325,13 +325,43 @@ fn lower_enum_member_access(parse: MemberAccessParse, enum_info: EnumTypeInfo, b
     let mut selected_fields: StructFieldInfo[] = matched_fields;
 
     if expected_type.length > 0 {
+        // Compute the base type (strip trailing `*` levels) of the expected
+        // type so we can match variants whose field is either the same type
+        // or differs by one pointer level. The downstream select-chain logic
+        // (`pointer_coercion`) already handles the mismatch by loading /
+        // taking-address as needed, so filtering by EXACT type equality
+        // would silently drop compatible variants. Concretely:
+        //
+        //   statement.expression where
+        //     ReturnStatement.expression : Expression?   -> %Expression*
+        //     ThrowStatement.expression  : Expression    -> %Expression
+        //     ExpressionStatement.expression : Expression -> %Expression
+        //
+        // A caller passing this to `format_expression(expression: Expression)`
+        // under the 0.5.8+ boxed-struct ABI has `expected_type = %Expression*`.
+        // An exact-equality filter would keep only ReturnStatement and the
+        // chain would return `null` for ExpressionStatement / ThrowStatement,
+        // crashing `format_expression(null)` at runtime.
+        let mut expected_base: string = expected_type;
+        loop {
+            if !ends_with_pointer_suffix(expected_base) { break; }
+            expected_base = strip_pointer_suffix(expected_base);
+        }
         let mut filtered_variants: EnumVariantInfo[] = [];
         let mut filtered_fields: StructFieldInfo[] = [];
         let mut selection_index: number = 0;
         loop {
             if selection_index >= matched_fields.length { break; }
             let candidate_field = matched_fields[selection_index];
-            if candidate_field.llvm_type == expected_type {
+            let mut candidate_base: string = candidate_field.llvm_type;
+            loop {
+                if !ends_with_pointer_suffix(candidate_base) { break; }
+                candidate_base = strip_pointer_suffix(candidate_base);
+            }
+            let mut accept: boolean = false;
+            if candidate_field.llvm_type == expected_type { accept = true; }
+            if candidate_base == expected_base { accept = true; }
+            if accept {
                 filtered_variants.push(matched_variants[selection_index]);
                 filtered_fields.push(candidate_field);
             }

--- a/compiler/src/llvm/rendering_helpers.sfn
+++ b/compiler/src/llvm/rendering_helpers.sfn
@@ -490,14 +490,19 @@ fn should_internalize_function(function: NativeFunction, entry_points: string[],
     if sanitized == "string_char_at" { _if297 = true; }
     if _if297 { return false; }
 
-    // Treat leading-underscore helpers as module-local.
-    if sanitized.length > 0 {
-        if substring(sanitized, 0, 1) == "_" { return true; }
-    }
-
     // Collision-prone local helper names observed across compiler modules.
     // Keep these module-local to avoid duplicate symbol definitions at final link.
     if sanitized == "contains_effect" { return true; }
+
+    // NOTE: A previous revision also internalised any function whose sanitized
+    // name starts with `_`. That heuristic was too aggressive — several
+    // underscore-prefix helpers (e.g. `_parse_int_from_string` from
+    // instructions_helpers, `_parse_lowered_fn_string_constants` from
+    // lowering_text_utils) are imported across modules and must retain
+    // external linkage so the final IR link succeeds. The 0.5.7 seed
+    // happened to produce external linkage for them because its own
+    // baked-in rule was narrower, which hid the regression in self-host
+    // builds until the seedcheck link step exposed it.
 
     // Default: preserve existing cross-module linkage behavior.
     return false;

--- a/compiler/src/llvm/rendering_helpers.sfn
+++ b/compiler/src/llvm/rendering_helpers.sfn
@@ -503,7 +503,6 @@ fn should_internalize_function(function: NativeFunction, entry_points: string[],
     // happened to produce external linkage for them because its own
     // baked-in rule was narrower, which hid the regression in self-host
     // builds until the seedcheck link step exposed it.
-
     // Default: preserve existing cross-module linkage behavior.
     return false;
 }

--- a/compiler/src/parser/mod.sfn
+++ b/compiler/src/parser/mod.sfn
@@ -11,6 +11,7 @@
 //   - declarations.sfn: Top-level declarations (fn, struct, enum, import, etc.)
 import { Program, Statement } from "../ast";
 import { lex } from "../lexer";
+import { substring } from "../string_utils";
 import { Token, TokenKind } from "../token";
 import {
     parse_decorators,
@@ -35,7 +36,6 @@ import {
 } from "./token_utils";
 // Import types from submodules
 import { Parser, StatementParseResult } from "./types";
-import { number_to_string } from "../emit_native_state";
 
 // ============================================================================
 // Main Entry Points
@@ -47,9 +47,17 @@ import { number_to_string } from "../emit_native_state";
 // pad string at function entry shifts subsequent allocations past the corrupted
 // bucket. Remove this once the 0.5.8 seed is released and adopted.
 fn parse_program(source: string) -> Program {
-    // Force a runtime heap allocation so 0.5.7 can't fold the pad away.
-    let _pad_len: number = source.length;
-    let _pad: string = "pp-" + number_to_string(_pad_len);
+    // Force a runtime heap allocation pattern that 0.5.7 can't fold away.
+    // `substring(source, 0, 1)` is a runtime intrinsic over `source` (a
+    // function parameter, not a compile-time value), so the seed cannot
+    // constant-fold it. Concatenating with a literal then triggers a second
+    // runtime string_concat — two heap allocations of 1 and 4 bytes
+    // respectively. Empirically this pattern shifts subsequent allocations
+    // past the bad bucket; a single 1-byte substring was not sufficient.
+    // Cost is O(1) regardless of source length — no dependency on
+    // emit_native_state.
+    let _pad_src: string = substring(source, 0, 1);
+    let _pad: string = "pp-" + _pad_src;
     let tokens = lex(source);
     return parse_tokens(tokens);
 }

--- a/compiler/src/parser/mod.sfn
+++ b/compiler/src/parser/mod.sfn
@@ -35,11 +35,21 @@ import {
 } from "./token_utils";
 // Import types from submodules
 import { Parser, StatementParseResult } from "./types";
+import { number_to_string } from "../emit_native_state";
 
 // ============================================================================
 // Main Entry Points
 // ============================================================================
+// 0.5.7 seed miscompilation workaround: when compiled by the 0.5.7 seed, some
+// heap-layout pattern in parse_program corrupts memory for source inputs with
+// specific token counts (observed on linux-x86_64 with 44-char module paths
+// like `compiler/tests/unit/struct_large_return_test`). A short heap-allocated
+// pad string at function entry shifts subsequent allocations past the corrupted
+// bucket. Remove this once the 0.5.8 seed is released and adopted.
 fn parse_program(source: string) -> Program {
+    // Force a runtime heap allocation so 0.5.7 can't fold the pad away.
+    let _pad_len: number = source.length;
+    let _pad: string = "pp-" + number_to_string(_pad_len);
     let tokens = lex(source);
     return parse_tokens(tokens);
 }

--- a/compiler/tests/unit/enum_mixed_field_types_test.sfn
+++ b/compiler/tests/unit/enum_mixed_field_types_test.sfn
@@ -1,0 +1,87 @@
+// Regression test: enum-member access across variants whose shared field has
+// different but pointer-depth-compatible LLVM types.
+//
+// Background: `lower_enum_member_access` in
+// `compiler/src/llvm/expression_lowering/native/core_member_lowering.sfn`
+// filters variants against the caller's expected type before building the
+// select chain that reads the field. The filter used to require EXACT
+// `llvm_type` equality, which silently dropped variants whose field was the
+// same base type at a different pointer depth (e.g. `Expression` vs
+// `Expression?` → `%Expression` vs `%Expression*`). The downstream
+// `pointer_coercion` branch is already designed to unify such cases by
+// loading / taking-address as needed, but filtering killed the variant
+// before that code ran — so the compiled select chain returned `null` for
+// the unmatched tags. Callers that passed the result to a function taking
+// the base type (boxed-struct ABI) then crashed on the `null` pointer.
+//
+// This test locks the fix in: it defines an enum whose variants all carry a
+// `payload` field, but one variant uses the nullable form and the others
+// use the bare form. The test accesses `.payload` in typed contexts (both
+// by-pointer and by-value) and asserts that the select chain picks the
+// right value for every variant tag.
+struct Cell {
+    value: number;
+}
+
+enum Node {
+    // `payload: Cell?` — LLVM maps to `%Cell*` (depth 1).
+    Optional { payload: Cell?, tag: number },
+    // `payload: Cell`  — LLVM maps to `%Cell`  (depth 0) under the inline
+    // user-struct field layout used for enum payloads.
+    Direct { payload: Cell, tag: number },
+    // Sentinel variant without `payload` — must not interfere with the
+    // match-arm tag lookup.
+    Missing { tag: number }
+}
+
+fn _extract_value(node: Node) -> number {
+    // Accesses `node.payload` in a context where the receiver expects a
+    // boxed `Cell?` pointer. The filter used to keep only the `Optional`
+    // variant here, returning `null` on `Direct` and crashing inside
+    // `_cell_value(null)`. With the fix, both variants are kept and the
+    // downstream coercion supplies a `Cell*` for each.
+    let cell = node.payload;
+    return _cell_value(cell);
+}
+
+fn _cell_value(cell: Cell?) -> number {
+    if cell == null { return -1; }
+    return cell.value;
+}
+
+fn _tag_of(node: Node) -> number {
+    // `.tag` is present on every variant with the same `number` type, so
+    // the filter should accept all three with no depth mismatch.
+    return node.tag;
+}
+
+test "enum_mixed: Direct variant payload is extracted correctly" {
+    let n = Node.Direct {
+        payload: Cell { value: 42 },
+        tag: 1
+    };
+    assert _extract_value(n) == 42;
+    assert _tag_of(n) == 1;
+}
+
+test "enum_mixed: Optional variant payload (Some) is extracted correctly" {
+    let n = Node.Optional {
+        payload: Cell { value: 7 },
+        tag: 2
+    };
+    assert _extract_value(n) == 7;
+    assert _tag_of(n) == 2;
+}
+
+test "enum_mixed: Optional variant payload (None) falls through to sentinel" {
+    let n = Node.Optional { payload: null, tag: 3 };
+    assert _extract_value(n) == -1;
+    assert _tag_of(n) == 3;
+}
+
+test "enum_mixed: Missing variant has no payload field" {
+    let n = Node.Missing { tag: 9 };
+    // Accessing `.payload` on a variant that lacks the field should yield
+    // the default sentinel; accessing `.tag` still works normally.
+    assert _tag_of(n) == 9;
+}


### PR DESCRIPTION
## Summary

Unblocks the 0.5.8 release build on linux-x86_64 and gets seedcheck self-host
from 0/57 unit-test pass to 54/57. Three targeted fixes, each in its own
commit so they can be reverted or cherry-picked independently:

### 1. `eb53566` — `compiler(parser): workaround 0.5.7 seed miscompilation in parse_program`

The 0.5.7 seed compiles our current `parse_program` into code that corrupts
the heap under a specific layout condition: when `module_name` happens to be
exactly 44 characters (e.g. `compiler/tests/unit/struct_large_return_test`),
a subsequent allocation inside `lex(source)` overflows a bucket boundary and
SIGSEGVs on linux-x86_64 (glibc). Six other 44-char-module tests are
latently susceptible; the CI failure log shows both
`function_signatures_test` and `struct_large_return_test` tripping the
retry path before the latter failed outright.

The fix is a tiny runtime heap allocation (`substring(source, 0, 1)`) at
the top of `parse_program`. That shifts subsequent allocations past the
bad bucket. Cost: one O(1) memcpy per compilation unit. The comment and
the PR description call out that this pad should be removed once 0.5.8 is
adopted as the seed.

(Note: after a reviewer round this was retargeted from
`"pp-" + number_to_string(source.length)` to the `substring` form —
number_to_string's repeated-subtraction loop was O(N) in source length.)

### 2. `57b46e2` — `compiler(llvm): remove over-aggressive underscore-prefix internalize rule`

`should_internalize_function` in `compiler/src/llvm/rendering_helpers.sfn`
unconditionally marked any function whose sanitized name began with `_` as
LLVM `internal` linkage. That was too aggressive — several underscore-prefix
helpers are imported across modules and need external linkage so the
final IR link succeeds:

    * `_parse_int_from_string` in llvm/lowering/instructions_helpers
      (imported by instructions, instructions_condition, instructions_for,
      instructions_for_range, instructions_if, instructions_loops,
      instructions_match, instructions_try)
    * `_parse_lowered_fn_string_constants` in llvm/lowering/lowering_text_utils
      (imported by lowering_core, lowering_recovery)

The 0.5.7 seed happened to produce external linkage for them because its
own baked-in rule was narrower, which masked the regression in release CI.
The bug surfaced in `make check`'s seedcheck link step:

    undefined reference to '_parse_int_from_string__llvm__lowering__instructions_helpers'
    undefined reference to '_parse_lowered_fn_string_constants__llvm__lowering__lowering_text_utils'
    clang: error: linker command failed with exit code 1

Removing the heuristic makes underscore-prefix helpers behave the same as
any other function: external by default, explicitly internalised only via
the `contains_effect`-style whitelist when a real name collision is
observed. A scan of `compiler/src/**/*.sfn` confirms no duplicate
`fn _name` definitions across modules, so no existing collisions are
re-exposed.

### 3. `84e7fac` — `compiler(llvm): fix enum-member filter to accept pointer-depth-compatible variants`

`lower_enum_member_access` filtered `matched_variants` by EXACT `llvm_type`
equality against the caller's `expected_type`. Under the 0.5.8+ boxed-struct
ABI this drops variants that would be unified by the downstream
`pointer_coercion` logic, so the select-chain only covered one variant and
every other variant silently returned `null`.

Concretely: `Statement.expression` appears in three variants with these
types:

    ReturnStatement.expression     : Expression?  -> %Expression*
    ThrowStatement.expression      : Expression   -> %Expression
    ExpressionStatement.expression : Expression   -> %Expression

A caller passing this to `format_expression(expression: Expression)` under
the boxed-struct ABI has `expected_type = "%Expression*"`. The exact-equality
filter kept only ReturnStatement, so the generated select chain only emitted
`icmp eq i32 %tag, 18`. For tag 19 (Throw) and tag 21 (ExpressionStatement)
the chain returned `%Expression* null`, and `format_expression(null)`
segfaulted in seedcheck on the very first `let x = 1;`:

    gdb> bt
    #0  format_expression.emit_native_format ()     rdi=0x0
    #1  emit_expression_statement.emit_native ()
    #2  emit_block.emit_native ()
    #3  emit_function.emit_native ()
    #4  emit_statement_declarations.emit_native ()
    #5  emit_native_text_with_module_name.emit_native ()
    #6  compile_to_llvm_file_with_module.main ()

The fix loosens the filter to also accept variants whose field shares the
same base type after stripping pointer suffixes, **bounded to a
pointer-depth difference of at most 1** (per review feedback — the
downstream `pointer_coercion` branch can only coerce across a single
pointer level). Larger depth mismatches still fall through to the
"incompatible field types across variants" diagnostic, same as before.

A focused regression test (`compiler/tests/unit/enum_mixed_field_types_test.sfn`)
exercises an enum whose `payload` field uses `Cell?` in one variant and
`Cell` in another, accessed in a typed context. Without the fix the select
chain drops the `Direct` variant and `_extract_value(Node.Direct{...})`
crashes on `null`.

## Results

    make test  (first-pass binary, linux-x86_64):
      ═══ unit:        57/57 passed, 0 failed ═══
      ═══ integration: 17/17 passed, 0 failed ═══
      ═══ e2e:         10/10 passed, 0 failed ═══

    seedcheck (compiled by the first-pass with all three fixes):
      runs examples/basics/hello-world.sfn cleanly
      ═══ unit: 54/57 passed, 3 failed ═══
          struct_large_return_test   (method self param lowered as i8* — separate bug)
          match_advanced_test        (match parsed as Statement.Unknown — separate bug)
          toml_test                  (TomlValue struct round-trip — separate bug)

## Path forward

These three commits make the CI release path fully green
(`make fetch-seed && make rebuild && make test` succeeds on linux-x86_64)
so a new 0.5.8 seed can be cut. The three remaining seedcheck failures are
independent miscompilations — each manifests only when the new
first-pass compiles itself — and will be chased in follow-up PRs, not
by reverting the boxed-struct ABI.

## Test plan

- [x] `make test` passes on the first-pass binary (57/57 unit + 17/17 integration + 10/10 e2e)
- [x] Seedcheck binary runs `hello-world.sfn`
- [x] Seedcheck binary: 54/57 unit tests pass (was 0/57 — crashed on any `let`)
- [x] `sfn fmt --check` is green on both modified files
- [x] New regression test locks in the enum-member filter behaviour

https://claude.ai/code/session_01DhFhFo1nGjkGbCeBuX6eZ8