### PR TITLE
compiler: fix enum equality under boxed-struct ABI

### DIFF
--- a/compiler/src/llvm/expression_lowering/native/core.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core.sfn
@@ -613,7 +613,19 @@ fn lower_expression(expression: string, bindings: ParameterBinding[], locals: Lo
 
             // If we're awaiting an opaque pointer future in a typed context, try to unbox.
             // This avoids leaking boxed aggregates (struct/enum values) returned as `i8*`.
+            //
+            // Two shapes are legitimate for an `%SailfinFuturePtr*` await:
+            //   - bitcast-then-load: the old by-value ABI stored the full
+            //     aggregate on the heap and the awaiter loaded the value.
+            //     Kept for primitives-embedded-as-value (currently none use
+            //     this path, but the structure stays for forward compat).
+            //   - bitcast-only: the 0.5.8+ boxed-struct ABI returns struct
+            //     and enum aggregates as `%T*` pointers already. Loading
+            //     here would materialise a by-value aggregate and lose the
+            //     pointer-shaped handle every subsequent member access and
+            //     function call is written to consume.
             let mut trimmed_expected = trim_text(expected_type);
+            let mut inferred_boxed_type: string = "";
             // When expected_type is empty (no annotation on the let), try to infer
             // the concrete return type from the future's local binding.  The let
             // lowerer stores the async function's Sailfin return type in
@@ -630,6 +642,12 @@ fn lower_expression(expression: string, bindings: ParameterBinding[], locals: Lo
                                 if mapped != "i8*" {
                                     if !ends_with_pointer_suffix(mapped) {
                                         trimmed_expected = mapped;
+                                    } else {
+                                        // Boxed user aggregate return: keep
+                                        // the pointer form; record it so the
+                                        // cast-only path below emits a
+                                        // bitcast to the typed handle.
+                                        inferred_boxed_type = mapped;
                                     }
                                 }
                             }
@@ -673,6 +691,31 @@ fn lower_expression(expression: string, bindings: ParameterBinding[], locals: Lo
                             };
                         }
                     }
+                }
+                // 0.5.8+ boxed-struct ABI: if we inferred a user aggregate
+                // return as `%T*`, emit a bitcast so the awaiter sees the
+                // typed pointer. The heap allocation is owned by the awaited
+                // value — do NOT free it here (it would dangle on the first
+                // field access).
+                if inferred_boxed_type.length > 0 {
+                    let typed_ptr_temp = format_temp_name(lowered.temp_index
+                        + 1);
+                    awaited_lines2.push("  " + typed_ptr_temp
+                        + " = bitcast i8* "
+                        + result_temp
+                        + " to "
+                        + inferred_boxed_type);
+                    let out_operand_boxed = LLVMOperand {
+                        llvm_type: inferred_boxed_type,
+                        value: typed_ptr_temp
+                    };
+                    return ExpressionResult {
+                        lines: awaited_lines2,
+                        temp_index: lowered.temp_index + 2,
+                        operand: out_operand_boxed,
+                        diagnostics: diagnostics,
+                        string_constants: lowered.string_constants
+                    };
                 }
             }
 

--- a/compiler/src/llvm/expression_lowering/native/core.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core.sfn
@@ -698,8 +698,7 @@ fn lower_expression(expression: string, bindings: ParameterBinding[], locals: Lo
                 // value — do NOT free it here (it would dangle on the first
                 // field access).
                 if inferred_boxed_type.length > 0 {
-                    let typed_ptr_temp = format_temp_name(lowered.temp_index
-                        + 1);
+                    let typed_ptr_temp = format_temp_name(lowered.temp_index + 1);
                     awaited_lines2.push("  " + typed_ptr_temp
                         + " = bitcast i8* "
                         + result_temp

--- a/compiler/src/llvm/expression_lowering/native/core_literals_lowering.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_literals_lowering.sfn
@@ -6,6 +6,8 @@ import { substring } from "../../../string_utils";
 import { default_return_literal, format_temp_name } from "../../expressions_helpers";
 import { empty_string_constant_set, merge_string_constants } from "../../strings";
 import {
+    find_enum_info_by_llvm_type,
+    find_struct_info_by_llvm_type,
     lookup_allocation_info,
     resolve_enum_info_for_literal,
     resolve_enum_variant_info,
@@ -278,6 +280,14 @@ fn lower_array_literal(text: string, bindings: ParameterBinding[], locals: Local
         // `coerce_operand_to_type` below inserts a `load %T, %T* %op`
         // before the store. Non-aggregate pointer types (`i8*`, `ptr`) keep
         // their original dominant_type semantics.
+        //
+        // The symmetric case (first element with no prior inference, no
+        // annotation, operand is `%T*`) must also prefer the unboxed form.
+        // Otherwise `[FieldInput { ... }]` seeds inferred_element_type with
+        // `%FieldInput*`, producing `{ %FieldInput**, i64 }` storage that
+        // readers (which GEP with element type `%FieldInput`) interpret as
+        // an array of by-value structs. The visible symptom is fields past
+        // the first 8 bytes reading uninitialized memory.
         let _ielt_base = inferred_element_type;
         let _op_type = lowered.operand.llvm_type;
         let mut _keep_element_type: boolean = false;
@@ -290,6 +300,36 @@ fn lower_array_literal(text: string, bindings: ParameterBinding[], locals: Local
                             if _op_base == _ielt_base {
                                 _keep_element_type = true;
                             }
+                        }
+                    }
+                }
+            }
+        }
+        if !_keep_element_type {
+            // When inferred is empty (first aggregate operand with no prior
+            // annotation) and the operand is `%T*` where `%T` is a known
+            // user aggregate, seed the inference with the unboxed `%T`
+            // form. This mirrors the option-a inline layout used for struct
+            // and enum fields — aggregates live by-value inside containers
+            // and cross function boundaries by pointer. `dominant_type`
+            // would otherwise preserve the pointer-shaped operand type,
+            // forcing a later bitcast that misaligns all field reads.
+            if _ielt_base.length == 0 {
+                if starts_with(_op_type, "%") {
+                    if ends_with_pointer_suffix(_op_type) {
+                        let _first_base = trim_text(strip_pointer_suffix(_op_type));
+                        let mut _seed_unboxed: boolean = false;
+                        if _first_base.length > 0 {
+                            if find_struct_info_by_llvm_type(context, _first_base) != null {
+                                _seed_unboxed = true;
+                            }
+                            if find_enum_info_by_llvm_type(context, _first_base) != null {
+                                _seed_unboxed = true;
+                            }
+                        }
+                        if _seed_unboxed {
+                            inferred_element_type = _first_base;
+                            _keep_element_type = true;
                         }
                     }
                 }

--- a/compiler/src/llvm/expression_lowering/native/core_ops_lowering.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_ops_lowering.sfn
@@ -5,7 +5,7 @@ import { NativeFunction } from "../../../native_ir";
 import { substring } from "../../../string_utils";
 import { default_return_literal, format_temp_name } from "../../expressions_helpers";
 import { empty_string_constant_set, merge_string_constants } from "../../strings";
-import { find_enum_info_by_llvm_type } from "../../type_context_queries";
+import { resolve_enum_info_from_llvm_type } from "../../type_context_queries";
 import { ends_with_pointer_suffix, strip_pointer_suffix } from "../../type_mapping";
 import {
     ExpressionResult,
@@ -804,24 +804,56 @@ fn lower_comparison_operation(expression: string, match: OperatorMatch, bindings
     if is_equality {
         if left_operand != null {
             if right_operand != null {
-                // Enum equality compares tags.
-                if left_operand.llvm_type == right_operand.llvm_type {
-                    let enum_info = find_enum_info_by_llvm_type(context, left_operand.llvm_type);
-                    if enum_info != null {
-                        let mut tag_llvm_type: string = "i32";
-                        if enum_info.tag_type == "i8" { tag_llvm_type = "i8"; }
-                        if enum_info.tag_type == "i16" {
-                            tag_llvm_type = "i16";
+                // Enum equality compares tags — never pointer identity.
+                //
+                // Under the 0.5.8+ boxed-struct ABI both operand forms are
+                // legitimate at the same enum type:
+                //   - value form  (%EnumT):  extracted from an inline field
+                //                            (tasks[i].status), loaded from
+                //                            an array of inline enums, or
+                //                            produced by a by-value return.
+                //   - pointer form (%EnumT*): boxed parameters, heap-boxed
+                //                            enum literals, and members of
+                //                            boxed parent structs whose
+                //                            field GEP returns a %Field*.
+                //
+                // Resolve each operand's enum identity independently (the
+                // resolver strips one pointer level) so mixed comparisons
+                // like `tasks[i].status == status_param` work alongside
+                // same-shape pairs. We fall through to the non-enum path
+                // only if both sides fail to resolve OR they resolve to
+                // different enums (which is a type error the caller will
+                // report downstream).
+                let left_enum_info = resolve_enum_info_from_llvm_type(context, left_operand.llvm_type);
+                let right_enum_info = resolve_enum_info_from_llvm_type(context, right_operand.llvm_type);
+                let mut enums_match: boolean = false;
+                if left_enum_info != null {
+                    if right_enum_info != null {
+                        if left_enum_info.llvm_name == right_enum_info.llvm_name {
+                            enums_match = true;
                         }
-                        if enum_info.tag_type == "i32" {
-                            tag_llvm_type = "i32";
-                        }
-                        if enum_info.tag_type == "i64" {
-                            tag_llvm_type = "i64";
-                        }
+                    }
+                }
+                if enums_match {
+                    let enum_info = left_enum_info;
+                    let mut tag_llvm_type: string = "i32";
+                    if enum_info.tag_type == "i8" { tag_llvm_type = "i8"; }
+                    if enum_info.tag_type == "i16" {
+                        tag_llvm_type = "i16";
+                    }
+                    if enum_info.tag_type == "i32" {
+                        tag_llvm_type = "i32";
+                    }
+                    if enum_info.tag_type == "i64" {
+                        tag_llvm_type = "i64";
+                    }
 
-                        // 0.5.8+ boxed-struct ABI: enum operands are %EnumT*,
-                        // not by-value %EnumT. Read the tag via GEP+load.
+                    // Read each operand's tag. Pointer form walks GEP+load;
+                    // value form uses extractvalue on the aggregate. Mixed
+                    // forms are both fine — one side may be a boxed param
+                    // while the other is a loaded inline field.
+                    let mut left_tag_value: string = "";
+                    if ends_with_pointer_suffix(left_operand.llvm_type) {
                         let left_tag_ptr_temp = format_temp_name(alignment_temp);
                         alignment_temp += 1;
                         alignment_lines.push("  " + left_tag_ptr_temp
@@ -840,7 +872,21 @@ fn lower_comparison_operation(expression: string, match: OperatorMatch, bindings
                             + tag_llvm_type
                             + "* "
                             + left_tag_ptr_temp);
+                        left_tag_value = left_tag_temp;
+                    } else {
+                        let left_tag_temp = format_temp_name(alignment_temp);
+                        alignment_temp += 1;
+                        alignment_lines.push("  " + left_tag_temp
+                            + " = extractvalue "
+                            + enum_info.llvm_name
+                            + " "
+                            + left_operand.value
+                            + ", 0");
+                        left_tag_value = left_tag_temp;
+                    }
 
+                    let mut right_tag_value: string = "";
+                    if ends_with_pointer_suffix(right_operand.llvm_type) {
                         let right_tag_ptr_temp = format_temp_name(alignment_temp);
                         alignment_temp += 1;
                         alignment_lines.push("  " + right_tag_ptr_temp
@@ -859,31 +905,42 @@ fn lower_comparison_operation(expression: string, match: OperatorMatch, bindings
                             + tag_llvm_type
                             + "* "
                             + right_tag_ptr_temp);
-
-                        let compare_temp = format_temp_name(alignment_temp);
+                        right_tag_value = right_tag_temp;
+                    } else {
+                        let right_tag_temp = format_temp_name(alignment_temp);
                         alignment_temp += 1;
-                        let mut predicate: string = "icmp eq";
-                        if match.symbol == "!=" { predicate = "icmp ne"; }
-                        alignment_lines.push("  " + compare_temp + " = "
-                            + predicate
+                        alignment_lines.push("  " + right_tag_temp
+                            + " = extractvalue "
+                            + enum_info.llvm_name
                             + " "
-                            + tag_llvm_type
-                            + " "
-                            + left_tag_temp
-                            + ", "
-                            + right_tag_temp);
-                        let operand = LLVMOperand {
-                            llvm_type: "i1",
-                            value: compare_temp
-                        };
-                        return ExpressionResult {
-                            lines: alignment_lines,
-                            temp_index: alignment_temp,
-                            operand: operand,
-                            diagnostics: diagnostics,
-                            string_constants: string_constants
-                        };
+                            + right_operand.value
+                            + ", 0");
+                        right_tag_value = right_tag_temp;
                     }
+
+                    let compare_temp = format_temp_name(alignment_temp);
+                    alignment_temp += 1;
+                    let mut predicate: string = "icmp eq";
+                    if match.symbol == "!=" { predicate = "icmp ne"; }
+                    alignment_lines.push("  " + compare_temp + " = "
+                        + predicate
+                        + " "
+                        + tag_llvm_type
+                        + " "
+                        + left_tag_value
+                        + ", "
+                        + right_tag_value);
+                    let operand = LLVMOperand {
+                        llvm_type: "i1",
+                        value: compare_temp
+                    };
+                    return ExpressionResult {
+                        lines: alignment_lines,
+                        temp_index: alignment_temp,
+                        operand: operand,
+                        diagnostics: diagnostics,
+                        string_constants: string_constants
+                    };
                 }
 
                 let left_is_char = left_operand.llvm_type == "i8";

--- a/compiler/src/llvm/expression_lowering/native/core_ops_lowering.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_ops_lowering.sfn
@@ -838,15 +838,9 @@ fn lower_comparison_operation(expression: string, match: OperatorMatch, bindings
                     let enum_info = left_enum_info;
                     let mut tag_llvm_type: string = "i32";
                     if enum_info.tag_type == "i8" { tag_llvm_type = "i8"; }
-                    if enum_info.tag_type == "i16" {
-                        tag_llvm_type = "i16";
-                    }
-                    if enum_info.tag_type == "i32" {
-                        tag_llvm_type = "i32";
-                    }
-                    if enum_info.tag_type == "i64" {
-                        tag_llvm_type = "i64";
-                    }
+                    if enum_info.tag_type == "i16" { tag_llvm_type = "i16"; }
+                    if enum_info.tag_type == "i32" { tag_llvm_type = "i32"; }
+                    if enum_info.tag_type == "i64" { tag_llvm_type = "i64"; }
 
                     // Read each operand's tag. Pointer form walks GEP+load;
                     // value form uses extractvalue on the aggregate. Mixed
@@ -922,8 +916,7 @@ fn lower_comparison_operation(expression: string, match: OperatorMatch, bindings
                     alignment_temp += 1;
                     let mut predicate: string = "icmp eq";
                     if match.symbol == "!=" { predicate = "icmp ne"; }
-                    alignment_lines.push("  " + compare_temp + " = "
-                        + predicate
+                    alignment_lines.push("  " + compare_temp + " = " + predicate
                         + " "
                         + tag_llvm_type
                         + " "

--- a/compiler/src/llvm/expression_lowering/native/statement_assignment.sfn
+++ b/compiler/src/llvm/expression_lowering/native/statement_assignment.sfn
@@ -316,6 +316,123 @@ fn lower_lvalue_assignment_stmt(assign_target: string, assign_value: string, ass
                         }
                     }
                 }
+                // Subscripted lvalue: `arr[i].field = value`.
+                //
+                // The default `lower_expression(member_parse.base, ...)` call
+                // above yields a loaded aggregate (e.g. `%_LockEntry`) for a
+                // subscript base because `lower_index_expression` reads the
+                // element by value. Storing into a loaded copy discards the
+                // mutation, which is why `entries[i].version = v` silently
+                // dropped writes before this path existed.
+                //
+                // When the base parses as a subscript, recompute the slot
+                // pointer (`getelementptr` into the array's data buffer)
+                // and use that as the struct-field GEP base. The emission
+                // mirrors the `arr[i] = value` branch below so bounds
+                // checking and element-type determination stay consistent.
+                if !ends_with_pointer_suffix(base_pointer_type) {
+                    let subscript_parse = parse_index_expression(base_name);
+                    if subscript_parse.success {
+                        let array_result = lower_expression(subscript_parse.base, current_bindings, current_locals, current_temp, current_lines, functions, context, "");
+                        let mut _sci0: number = 0;
+                        loop {
+                            if _sci0 >= array_result.diagnostics.length {
+                                break;
+                            }
+                            diagnostics.push(array_result.diagnostics[_sci0]);
+                            _sci0 += 1;
+                        }
+                        current_lines = array_result.lines;
+                        current_temp = array_result.temp_index;
+                        current_temp = _recover_assign_temp(current_lines, current_temp);
+                        if array_result.operand != null {
+                            let array_operand = array_result.operand;
+                            let element_type = array_pointer_element_type(array_operand.llvm_type);
+                            if element_type.length > 0 {
+                                let index_result = lower_expression(subscript_parse.index, current_bindings, current_locals, current_temp, current_lines, functions, context, "");
+                                let mut _sci1: number = 0;
+                                loop {
+                                    if _sci1 >= index_result.diagnostics.length {
+                                        break;
+                                    }
+                                    diagnostics.push(index_result.diagnostics[_sci1]);
+                                    _sci1 += 1;
+                                }
+                                current_lines = index_result.lines;
+                                current_temp = index_result.temp_index;
+                                current_temp = _recover_assign_temp(current_lines, current_temp);
+                                if index_result.operand != null {
+                                    let coerced_index = coerce_operand_to_type(index_result.operand, "i64", current_temp, current_lines);
+                                    let mut _sci2: number = 0;
+                                    loop {
+                                        if _sci2 >= coerced_index.diagnostics.length {
+                                            break;
+                                        }
+                                        diagnostics.push(coerced_index.diagnostics[_sci2]);
+                                        _sci2 += 1;
+                                    }
+                                    current_lines = coerced_index.lines;
+                                    current_temp = coerced_index.temp_index;
+                                    current_temp = _recover_assign_temp(current_lines, current_temp);
+                                    if coerced_index.operand != null {
+                                        let data_field_ptr = format_temp_name(current_temp);
+                                        current_temp += 1;
+                                        current_lines.push("  " + data_field_ptr
+                                            + " = getelementptr "
+                                            + array_struct_type_for_element(element_type)
+                                            + ", "
+                                            + array_operand.llvm_type
+                                            + " "
+                                            + array_operand.value
+                                            + ", i32 0, i32 0");
+                                        let data_ptr_loaded = format_temp_name(current_temp);
+                                        current_temp += 1;
+                                        current_lines.push("  " + data_ptr_loaded
+                                            + " = load "
+                                            + element_type
+                                            + "*, "
+                                            + element_type
+                                            + "** "
+                                            + data_field_ptr);
+                                        let length_field_ptr = format_temp_name(current_temp);
+                                        current_temp += 1;
+                                        current_lines.push("  " + length_field_ptr
+                                            + " = getelementptr "
+                                            + array_struct_type_for_element(element_type)
+                                            + ", "
+                                            + array_operand.llvm_type
+                                            + " "
+                                            + array_operand.value
+                                            + ", i32 0, i32 1");
+                                        let length_loaded = format_temp_name(current_temp);
+                                        current_temp += 1;
+                                        current_lines.push("  " + length_loaded
+                                            + " = load i64, i64* "
+                                            + length_field_ptr);
+                                        current_lines.push("  call void @sailfin_runtime_bounds_check(i64 "
+                                            + coerced_index.operand.value
+                                            + ", i64 "
+                                            + length_loaded
+                                            + ")");
+                                        let slot_ptr = format_temp_name(current_temp);
+                                        current_temp += 1;
+                                        current_lines.push("  " + slot_ptr
+                                            + " = getelementptr "
+                                            + element_type
+                                            + ", "
+                                            + element_type
+                                            + "* "
+                                            + data_ptr_loaded
+                                            + ", i64 "
+                                            + coerced_index.operand.value);
+                                        base_pointer_type = element_type + "*";
+                                        base_pointer_value = slot_ptr;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
                 if !ends_with_pointer_suffix(base_pointer_type) {
                     diagnostics.push("llvm lowering: member access assignment base `"
                         + member_parse.base

--- a/compiler/src/llvm/expression_lowering/native/statement_assignment.sfn
+++ b/compiler/src/llvm/expression_lowering/native/statement_assignment.sfn
@@ -387,7 +387,8 @@ fn lower_lvalue_assignment_stmt(assign_target: string, assign_value: string, ass
                                             + ", i32 0, i32 0");
                                         let data_ptr_loaded = format_temp_name(current_temp);
                                         current_temp += 1;
-                                        current_lines.push("  " + data_ptr_loaded
+                                        current_lines.push("  "
+                                            + data_ptr_loaded
                                             + " = load "
                                             + element_type
                                             + "*, "
@@ -396,7 +397,8 @@ fn lower_lvalue_assignment_stmt(assign_target: string, assign_value: string, ass
                                             + data_field_ptr);
                                         let length_field_ptr = format_temp_name(current_temp);
                                         current_temp += 1;
-                                        current_lines.push("  " + length_field_ptr
+                                        current_lines.push("  "
+                                            + length_field_ptr
                                             + " = getelementptr "
                                             + array_struct_type_for_element(element_type)
                                             + ", "

--- a/compiler/src/llvm/mod.sfn
+++ b/compiler/src/llvm/mod.sfn
@@ -138,6 +138,7 @@ export {
     find_struct_info_by_name,
     find_struct_info_by_llvm_name,
     find_enum_info_by_llvm_type,
+    resolve_enum_info_from_llvm_type,
     find_interface_info_by_name,
     resolve_struct_info_for_literal
 } from "./type_context_queries";

--- a/compiler/src/llvm/type_context_queries.sfn
+++ b/compiler/src/llvm/type_context_queries.sfn
@@ -171,6 +171,21 @@ fn resolve_struct_info_from_llvm_type(context: TypeContext, llvm_type: string) -
     return find_struct_info_by_llvm_type(context, candidate);
 }
 
+// Resolve enum info from an operand's LLVM type that may be either the
+// value form (`%Enum`) or the boxed pointer form (`%Enum*`). Mirrors
+// resolve_struct_info_from_llvm_type — callers that need pointer-depth-
+// tolerant lookup should use this; callers that require an exact llvm_name
+// match (e.g. the aggregate-field classifier in core_member_lowering) must
+// continue to use find_enum_info_by_llvm_type directly.
+fn resolve_enum_info_from_llvm_type(context: TypeContext, llvm_type: string) -> EnumTypeInfo? {
+    let mut candidate = trim_text(llvm_type);
+    if candidate.length == 0 { return null; }
+    if ends_with_pointer_suffix(candidate) {
+        candidate = strip_pointer_suffix(candidate);
+    }
+    return find_enum_info_by_llvm_type(context, candidate);
+}
+
 fn lookup_allocation_info(context: TypeContext, llvm_type: string) -> TypeAllocationInfo? {
     let trimmed = trim_text(llvm_type);
     if trimmed.length == 0 { return null; }

--- a/compiler/tests/unit/array_literal_aggregate_seed_test.sfn
+++ b/compiler/tests/unit/array_literal_aggregate_seed_test.sfn
@@ -26,7 +26,6 @@
 // user struct or enum in the type context. Primitives (`i8*`, `ptr`,
 // `double*`) keep the existing pointer semantics; arrays and optionals
 // retain their pointer-form inference.
-
 struct Field {
     name: string;
     offset: number;
@@ -64,10 +63,7 @@ fn _layout_for(inputs: FieldInput[]) -> Record {
             align = 1;
         }
         fields.push(Field {
-            name: input.name,
-            offset: offset,
-            size: size,
-            align: align,
+            name: input.name, offset: offset, size: size, align: align
         });
         offset += size;
         if align > max_align { max_align = align; }
@@ -77,7 +73,6 @@ fn _layout_for(inputs: FieldInput[]) -> Record {
 }
 
 // -- the exact shape that broke emit_native_layout_test --
-
 test "array_literal_aggregate_seed: single struct element via literal" {
     let inputs = [FieldInput { name: "x", type_name: "number" }];
     let result = _layout_for(inputs);
@@ -94,10 +89,9 @@ test "array_literal_aggregate_seed: single struct element via literal" {
 }
 
 test "array_literal_aggregate_seed: two struct elements via literal" {
-    let inputs = [
-        FieldInput { name: "a", type_name: "i32" },
-        FieldInput { name: "b", type_name: "i32" },
-    ];
+    let inputs = [FieldInput { name: "a", type_name: "i32" }, FieldInput {
+        name: "b", type_name: "i32"
+    },];
     let result = _layout_for(inputs);
     assert result.fields.length == 2;
     assert result.fields[0].name == "a";
@@ -111,7 +105,6 @@ test "array_literal_aggregate_seed: two struct elements via literal" {
 }
 
 // -- direct reads, without the function boundary --
-
 test "array_literal_aggregate_seed: direct read from inline literal" {
     let inputs = [FieldInput { name: "y", type_name: "boolean" }];
     assert inputs.length == 1;
@@ -120,7 +113,6 @@ test "array_literal_aggregate_seed: direct read from inline literal" {
 }
 
 // -- primitive arrays still work (fix must not regress them) --
-
 test "array_literal_aggregate_seed: number array literal unchanged" {
     let xs = [1.0, 2.5, 4.0];
     assert xs.length == 3;
@@ -137,13 +129,10 @@ test "array_literal_aggregate_seed: string array literal unchanged" {
 }
 
 // -- mixed: struct element followed by more struct elements --
-
 test "array_literal_aggregate_seed: three struct elements end-to-end" {
-    let inputs = [
-        FieldInput { name: "one",   type_name: "number" },
-        FieldInput { name: "two",   type_name: "number" },
-        FieldInput { name: "three", type_name: "number" },
-    ];
+    let inputs = [FieldInput { name: "one", type_name: "number" }, FieldInput {
+        name: "two", type_name: "number"
+    }, FieldInput { name: "three", type_name: "number" },];
     let result = _layout_for(inputs);
     assert result.fields.length == 3;
     assert result.fields[0].name == "one";

--- a/compiler/tests/unit/array_literal_aggregate_seed_test.sfn
+++ b/compiler/tests/unit/array_literal_aggregate_seed_test.sfn
@@ -1,0 +1,156 @@
+// Regression test: array literals whose element type is inferred from a
+// single boxed struct operand must seed the inferred element type with the
+// unboxed `%T` form, not the boxed `%T*` form.
+//
+// Background: `lower_array_literal` in
+// `compiler/src/llvm/expression_lowering/native/core_literals_lowering.sfn`
+// threads an `inferred_element_type` across operand lowering, falling back
+// to `dominant_type(inferred, operand_type)` when the previous element
+// already picked a type. PR #221 fixed the mid-sequence case (keep `%T`
+// when the prior inference was `%T` and the operand is `%T*`), but left
+// the FIRST-element case unpatched. That case still took the default
+// `dominant_type("", "%T*")` branch, which yields `"%T*"`.
+//
+// With `inferred_element_type = "%T*"`, the array buffer allocated below
+// is `[N x %T*]` (array of pointers) and the header is cast to the
+// `{ %T*, i64 }` shape the rest of the compiler expects. Readers GEP with
+// element type `%T` into a buffer of `%T*` values — every struct field
+// past the first 8 bytes reads the junk that used to be part of the stored
+// pointer, or memory past the pointer bytes. The user-visible symptom is
+// that `result.fields[0].offset`, `result.fields[0].size`, etc. come back
+// as uninitialized values whenever the array literal had a single
+// heap-boxed struct element at construction time.
+//
+// The fix seeds `inferred_element_type` with the stripped `%T` when the
+// first operand is an aggregate pointer whose base resolves to a known
+// user struct or enum in the type context. Primitives (`i8*`, `ptr`,
+// `double*`) keep the existing pointer semantics; arrays and optionals
+// retain their pointer-form inference.
+
+struct Field {
+    name: string;
+    offset: number;
+    size: number;
+    align: number;
+}
+
+struct Record {
+    size: number;
+    align: number;
+    fields: Field[];
+}
+
+struct FieldInput {
+    name: string;
+    type_name: string;
+}
+
+fn _layout_for(inputs: FieldInput[]) -> Record {
+    let mut fields: Field[] = [];
+    let mut offset: number = 0;
+    let mut max_align: number = 1;
+    let mut i: number = 0;
+    loop {
+        if i >= inputs.length { break; }
+        let input = inputs[i];
+        let mut size: number = 8;
+        let mut align: number = 8;
+        if input.type_name == "i32" {
+            size = 4;
+            align = 4;
+        }
+        if input.type_name == "boolean" {
+            size = 1;
+            align = 1;
+        }
+        fields.push(Field {
+            name: input.name,
+            offset: offset,
+            size: size,
+            align: align,
+        });
+        offset += size;
+        if align > max_align { max_align = align; }
+        i += 1;
+    }
+    return Record { size: offset, align: max_align, fields: fields };
+}
+
+// -- the exact shape that broke emit_native_layout_test --
+
+test "array_literal_aggregate_seed: single struct element via literal" {
+    let inputs = [FieldInput { name: "x", type_name: "number" }];
+    let result = _layout_for(inputs);
+    // Before the fix, `result.fields[0].name` read the first 8 bytes of
+    // the stored `%FieldInput*` pointer — an invalid string — so both
+    // the name and every field past it came back garbled.
+    assert result.fields.length == 1;
+    assert result.fields[0].name == "x";
+    assert result.fields[0].offset == 0;
+    assert result.fields[0].size == 8;
+    assert result.fields[0].align == 8;
+    assert result.size == 8;
+    assert result.align == 8;
+}
+
+test "array_literal_aggregate_seed: two struct elements via literal" {
+    let inputs = [
+        FieldInput { name: "a", type_name: "i32" },
+        FieldInput { name: "b", type_name: "i32" },
+    ];
+    let result = _layout_for(inputs);
+    assert result.fields.length == 2;
+    assert result.fields[0].name == "a";
+    assert result.fields[0].offset == 0;
+    assert result.fields[0].size == 4;
+    assert result.fields[1].name == "b";
+    assert result.fields[1].offset == 4;
+    assert result.fields[1].size == 4;
+    assert result.size == 8;
+    assert result.align == 4;
+}
+
+// -- direct reads, without the function boundary --
+
+test "array_literal_aggregate_seed: direct read from inline literal" {
+    let inputs = [FieldInput { name: "y", type_name: "boolean" }];
+    assert inputs.length == 1;
+    assert inputs[0].name == "y";
+    assert inputs[0].type_name == "boolean";
+}
+
+// -- primitive arrays still work (fix must not regress them) --
+
+test "array_literal_aggregate_seed: number array literal unchanged" {
+    let xs = [1.0, 2.5, 4.0];
+    assert xs.length == 3;
+    assert xs[0] == 1.0;
+    assert xs[1] == 2.5;
+    assert xs[2] == 4.0;
+}
+
+test "array_literal_aggregate_seed: string array literal unchanged" {
+    let names = ["alpha", "beta", "gamma"];
+    assert names.length == 3;
+    assert names[0] == "alpha";
+    assert names[2] == "gamma";
+}
+
+// -- mixed: struct element followed by more struct elements --
+
+test "array_literal_aggregate_seed: three struct elements end-to-end" {
+    let inputs = [
+        FieldInput { name: "one",   type_name: "number" },
+        FieldInput { name: "two",   type_name: "number" },
+        FieldInput { name: "three", type_name: "number" },
+    ];
+    let result = _layout_for(inputs);
+    assert result.fields.length == 3;
+    assert result.fields[0].name == "one";
+    assert result.fields[1].name == "two";
+    assert result.fields[2].name == "three";
+    assert result.fields[0].offset == 0;
+    assert result.fields[1].offset == 8;
+    assert result.fields[2].offset == 16;
+    assert result.size == 24;
+}

--- a/compiler/tests/unit/async_struct_return_boxed_test.sfn
+++ b/compiler/tests/unit/async_struct_return_boxed_test.sfn
@@ -1,0 +1,60 @@
+// Regression test: `await f` on a `Future<AsyncStructT>` must surface a
+// typed `%AsyncStructT*` pointer, not leave the result as opaque `i8*`.
+//
+// Background: under the 0.5.8+ boxed-struct ABI an async function whose
+// return type is a user struct or enum returns the aggregate by pointer
+// (`%T*`). The future's opaque `i8*` payload IS that pointer — it just
+// needs a bitcast before the caller can project fields.
+//
+// Before the fix, `lower_expression`'s await path in
+// `compiler/src/llvm/expression_lowering/native/core.sfn` inferred the
+// callee's Sailfin return type, mapped it to LLVM, and then dropped the
+// mapping on the floor whenever `map_return_type` returned a pointer
+// (`ends_with_pointer_suffix(mapped)` skipped the assignment to
+// `trimmed_expected`). The subsequent "unbox" branch only triggers on
+// non-pointer typed returns, so the await result leaked as `i8*` — the
+// caller's `result.field` projection collapsed to dynamic
+// `sailfin_runtime_get_field` lookups that compare stringified field
+// values instead of reading the struct directly.
+//
+// The fix captures the pointer form into `inferred_boxed_type` and emits
+// a bitcast-only path (no load, no free — the heap allocation is the
+// value). Subsequent field accesses then flow through the normal boxed
+// member-access lowering.
+
+struct Point {
+    x: number;
+    y: number;
+}
+
+async fn make_origin() -> Point {
+    return Point { x: 0, y: 0 };
+}
+
+async fn make_point(x: number, y: number) -> Point {
+    return Point { x: x, y: y };
+}
+
+test "async_boxed_return: awaiting a struct return projects fields" {
+    let f = make_point(3, 4);
+    let p = await f;
+    assert p.x == 3;
+    assert p.y == 4;
+}
+
+test "async_boxed_return: awaiting origin returns zeroed struct" {
+    let f = make_origin();
+    let p = await f;
+    assert p.x == 0;
+    assert p.y == 0;
+}
+
+test "async_boxed_return: awaiting a struct-returning call with args" {
+    let f = make_point(7, 11);
+    let p = await f;
+    assert p.x == 7;
+    assert p.y == 11;
+    // The pointer stays live past the first projection — readers are not
+    // allowed to free the awaited allocation, the owning future is.
+    assert p.x + p.y == 18;
+}

--- a/compiler/tests/unit/async_struct_return_boxed_test.sfn
+++ b/compiler/tests/unit/async_struct_return_boxed_test.sfn
@@ -21,7 +21,6 @@
 // a bitcast-only path (no load, no free — the heap allocation is the
 // value). Subsequent field accesses then flow through the normal boxed
 // member-access lowering.
-
 struct Point {
     x: number;
     y: number;

--- a/compiler/tests/unit/enum_equality_boxed_abi_test.sfn
+++ b/compiler/tests/unit/enum_equality_boxed_abi_test.sfn
@@ -26,19 +26,18 @@
 // the same enum (by `llvm_name`), and reads each operand's tag in the
 // form appropriate to its shape: `extractvalue` for value form,
 // `getelementptr`+`load` for pointer form.
-
 enum Priority {
     Low,
     Medium,
     High,
-    Critical,
+    Critical
 }
 
 enum TaskStatus {
     Todo,
     InProgress,
     Done,
-    Blocked,
+    Blocked
 }
 
 struct Task {
@@ -50,9 +49,7 @@ struct Task {
 
 // Pointer-vs-pointer: both sides arrive boxed (a local variable and a
 // fresh enum literal). Before the fix this compared heap identities.
-fn _pointer_vs_pointer(p: Priority) -> boolean {
-    return p == Priority.High;
-}
+fn _pointer_vs_pointer(p: Priority) -> boolean { return p == Priority.High; }
 
 // Value-vs-value: reading two enum fields from the same struct, both
 // extracted by value from an inline field position.
@@ -86,7 +83,6 @@ fn _contains_critical(priorities: Priority[]) -> boolean {
 }
 
 // -- pointer-vs-pointer --
-
 test "enum_equality_boxed_abi: pointer vs pointer — equal tags" {
     assert _pointer_vs_pointer(Priority.High) == true;
 }
@@ -100,31 +96,49 @@ test "enum_equality_boxed_abi: pointer vs pointer — different tags" {
 test "enum_equality_boxed_abi: pointer vs pointer — != inverts" {
     let p: Priority = Priority.Low;
     assert p != Priority.High;
-    assert !(p != Priority.Low);
+    assert ! (p != Priority.Low);
 }
 
 // -- value-vs-value (two inline fields) --
-
 test "enum_equality_boxed_abi: value vs value — equal tags" {
-    let a = Task { name: "a", priority: Priority.Low, status: TaskStatus.Todo, effort: 0 };
-    let b = Task { name: "b", priority: Priority.High, status: TaskStatus.Todo, effort: 0 };
+    let a = Task {
+        name: "a",
+        priority: Priority.Low,
+        status: TaskStatus.Todo,
+        effort: 0
+    };
+    let b = Task {
+        name: "b",
+        priority: Priority.High,
+        status: TaskStatus.Todo,
+        effort: 0
+    };
     assert _value_vs_value(a, b) == true;
 }
 
 test "enum_equality_boxed_abi: value vs value — different tags" {
-    let a = Task { name: "a", priority: Priority.Low, status: TaskStatus.Todo, effort: 0 };
-    let b = Task { name: "b", priority: Priority.High, status: TaskStatus.Done, effort: 0 };
+    let a = Task {
+        name: "a",
+        priority: Priority.Low,
+        status: TaskStatus.Todo,
+        effort: 0
+    };
+    let b = Task {
+        name: "b",
+        priority: Priority.High,
+        status: TaskStatus.Done,
+        effort: 0
+    };
     assert _value_vs_value(a, b) == false;
 }
 
 // -- mixed forms --
-
 test "enum_equality_boxed_abi: value vs pointer — matches" {
     let t = Task {
         name: "deploy",
         priority: Priority.High,
         status: TaskStatus.InProgress,
-        effort: 3,
+        effort: 3
     };
     assert _value_vs_pointer(t, TaskStatus.InProgress) == true;
     assert _value_vs_pointer(t, TaskStatus.Done) == false;
@@ -135,14 +149,13 @@ test "enum_equality_boxed_abi: pointer vs value — matches" {
         name: "deploy",
         priority: Priority.High,
         status: TaskStatus.InProgress,
-        effort: 3,
+        effort: 3
     };
     assert _pointer_vs_value(TaskStatus.InProgress, t) == true;
     assert _pointer_vs_value(TaskStatus.Blocked, t) == false;
 }
 
 // -- array of enums (value vs pointer inside a loop) --
-
 test "enum_equality_boxed_abi: array contains — found" {
     let mut ps: Priority[] = [];
     ps.push(Priority.Low);

--- a/compiler/tests/unit/enum_equality_boxed_abi_test.sfn
+++ b/compiler/tests/unit/enum_equality_boxed_abi_test.sfn
@@ -1,0 +1,160 @@
+// Regression test: enum `==` / `!=` must compare tags, not pointer identity,
+// across every combination of boxed-struct-ABI operand forms.
+//
+// Background: under the 0.5.8+ boxed-struct ABI an enum value can reach a
+// comparison site in either:
+//   - value form   (`%Enum`)  — extracted from an inline parent field or
+//                                loaded from an array of inline enums, or
+//   - pointer form (`%Enum*`) — a boxed parameter, a heap-boxed literal,
+//                                or the GEP pointer returned from a member
+//                                access on a boxed parent struct.
+//
+// Before the fix, `lower_comparison_operation` in
+// `compiler/src/llvm/expression_lowering/native/core_ops_lowering.sfn`
+// only resolved enum info on an exact llvm_name match (via
+// `find_enum_info_by_llvm_type`), which missed the `%Enum*` form entirely,
+// and further required `left.llvm_type == right.llvm_type` before emitting
+// a tag compare. That meant:
+//   1. pointer-vs-pointer comparisons silently fell through to `icmp eq
+//      %Enum* a, %Enum* b` — always false, because every literal
+//      heap-allocates a fresh tag cell;
+//   2. value-vs-pointer comparisons (`tasks[i].status == status_param`)
+//      skipped the tag-compare path because the types didn't match.
+//
+// The fix resolves each operand's enum identity via a pointer-tolerant
+// `resolve_enum_info_from_llvm_type`, requires both sides to resolve to
+// the same enum (by `llvm_name`), and reads each operand's tag in the
+// form appropriate to its shape: `extractvalue` for value form,
+// `getelementptr`+`load` for pointer form.
+
+enum Priority {
+    Low,
+    Medium,
+    High,
+    Critical,
+}
+
+enum TaskStatus {
+    Todo,
+    InProgress,
+    Done,
+    Blocked,
+}
+
+struct Task {
+    name: string;
+    priority: Priority;
+    status: TaskStatus;
+    effort: number;
+}
+
+// Pointer-vs-pointer: both sides arrive boxed (a local variable and a
+// fresh enum literal). Before the fix this compared heap identities.
+fn _pointer_vs_pointer(p: Priority) -> boolean {
+    return p == Priority.High;
+}
+
+// Value-vs-value: reading two enum fields from the same struct, both
+// extracted by value from an inline field position.
+fn _value_vs_value(a: Task, b: Task) -> boolean {
+    return a.status == b.status;
+}
+
+// Mixed value-vs-pointer: the left side reads an enum field by value
+// from a struct, the right side is a boxed parameter. This is the
+// very common `tasks[i].status == status` shape.
+fn _value_vs_pointer(t: Task, s: TaskStatus) -> boolean {
+    return t.status == s;
+}
+
+// Mixed pointer-vs-value: the symmetric case, where the boxed side is
+// on the left. The comparison must still canonicalise to a tag compare.
+fn _pointer_vs_value(s: TaskStatus, t: Task) -> boolean {
+    return s == t.status;
+}
+
+// Array of enums: elements are inline (value form when loaded), so
+// `priorities[i] == Priority.High` is value vs pointer.
+fn _contains_critical(priorities: Priority[]) -> boolean {
+    let mut i: number = 0;
+    loop {
+        if i >= priorities.length { break; }
+        if priorities[i] == Priority.Critical { return true; }
+        i += 1;
+    }
+    return false;
+}
+
+// -- pointer-vs-pointer --
+
+test "enum_equality_boxed_abi: pointer vs pointer — equal tags" {
+    assert _pointer_vs_pointer(Priority.High) == true;
+}
+
+test "enum_equality_boxed_abi: pointer vs pointer — different tags" {
+    assert _pointer_vs_pointer(Priority.Low) == false;
+    assert _pointer_vs_pointer(Priority.Medium) == false;
+    assert _pointer_vs_pointer(Priority.Critical) == false;
+}
+
+test "enum_equality_boxed_abi: pointer vs pointer — != inverts" {
+    let p: Priority = Priority.Low;
+    assert p != Priority.High;
+    assert !(p != Priority.Low);
+}
+
+// -- value-vs-value (two inline fields) --
+
+test "enum_equality_boxed_abi: value vs value — equal tags" {
+    let a = Task { name: "a", priority: Priority.Low, status: TaskStatus.Todo, effort: 0 };
+    let b = Task { name: "b", priority: Priority.High, status: TaskStatus.Todo, effort: 0 };
+    assert _value_vs_value(a, b) == true;
+}
+
+test "enum_equality_boxed_abi: value vs value — different tags" {
+    let a = Task { name: "a", priority: Priority.Low, status: TaskStatus.Todo, effort: 0 };
+    let b = Task { name: "b", priority: Priority.High, status: TaskStatus.Done, effort: 0 };
+    assert _value_vs_value(a, b) == false;
+}
+
+// -- mixed forms --
+
+test "enum_equality_boxed_abi: value vs pointer — matches" {
+    let t = Task {
+        name: "deploy",
+        priority: Priority.High,
+        status: TaskStatus.InProgress,
+        effort: 3,
+    };
+    assert _value_vs_pointer(t, TaskStatus.InProgress) == true;
+    assert _value_vs_pointer(t, TaskStatus.Done) == false;
+}
+
+test "enum_equality_boxed_abi: pointer vs value — matches" {
+    let t = Task {
+        name: "deploy",
+        priority: Priority.High,
+        status: TaskStatus.InProgress,
+        effort: 3,
+    };
+    assert _pointer_vs_value(TaskStatus.InProgress, t) == true;
+    assert _pointer_vs_value(TaskStatus.Blocked, t) == false;
+}
+
+// -- array of enums (value vs pointer inside a loop) --
+
+test "enum_equality_boxed_abi: array contains — found" {
+    let mut ps: Priority[] = [];
+    ps.push(Priority.Low);
+    ps.push(Priority.Medium);
+    ps.push(Priority.Critical);
+    assert _contains_critical(ps) == true;
+}
+
+test "enum_equality_boxed_abi: array contains — not found" {
+    let mut ps: Priority[] = [];
+    ps.push(Priority.Low);
+    ps.push(Priority.Medium);
+    ps.push(Priority.High);
+    assert _contains_critical(ps) == false;
+}

--- a/compiler/tests/unit/subscript_member_assignment_test.sfn
+++ b/compiler/tests/unit/subscript_member_assignment_test.sfn
@@ -21,7 +21,6 @@
 // (compiler/src/lock.sfn:lock_add_entry and compiler/src/toml_parser.sfn)
 // — a local array built up with `push`, then mutated by
 // `arr[i].field = value`, then observed via `arr[i].field` reads.
-
 struct Entry {
     key: string;
     value: number;
@@ -31,7 +30,7 @@ struct Entry {
 fn _make_entries() -> Entry[] {
     let mut entries: Entry[] = [];
     entries.push(Entry { key: "alpha", value: 1, tag: 0 });
-    entries.push(Entry { key: "beta",  value: 2, tag: 0 });
+    entries.push(Entry { key: "beta", value: 2, tag: 0 });
     entries.push(Entry { key: "gamma", value: 3, tag: 0 });
     return entries;
 }

--- a/compiler/tests/unit/subscript_member_assignment_test.sfn
+++ b/compiler/tests/unit/subscript_member_assignment_test.sfn
@@ -1,0 +1,120 @@
+// Regression test: `arr[i].field = value` must actually mutate the slot.
+//
+// Background: `lower_lvalue_assignment_stmt` in
+// `compiler/src/llvm/expression_lowering/native/statement_assignment.sfn`
+// parses `entries[i].version` into base=`entries[i]`, field=`version`,
+// then lowers the base via `lower_expression`. Under the 0.5.8+
+// boxed-struct ABI, `lower_index_expression` LOADS the element by value,
+// so the returned operand carries `%_LockEntry` — not a pointer into
+// the array slot. The subsequent addressability check (`is_simple_identifier`
+// + `find_local_binding`) then fails because `entries[i]` isn't a bare
+// identifier, the branch emits a `not addressable` diagnostic, and the
+// store is dropped. Callers observe the slot unchanged.
+//
+// The fix teaches the member-access branch to detect a subscripted base
+// and compute the slot pointer directly (the same GEP pattern as the
+// existing `arr[i] = value` branch) so the struct-field GEP+store writes
+// through to the correct slot, bounds-checked. Both plain and compound
+// assignment paths are covered.
+//
+// Tests mirror the shape that actually appears in production code
+// (compiler/src/lock.sfn:lock_add_entry and compiler/src/toml_parser.sfn)
+// — a local array built up with `push`, then mutated by
+// `arr[i].field = value`, then observed via `arr[i].field` reads.
+
+struct Entry {
+    key: string;
+    value: number;
+    tag: number;
+}
+
+fn _make_entries() -> Entry[] {
+    let mut entries: Entry[] = [];
+    entries.push(Entry { key: "alpha", value: 1, tag: 0 });
+    entries.push(Entry { key: "beta",  value: 2, tag: 0 });
+    entries.push(Entry { key: "gamma", value: 3, tag: 0 });
+    return entries;
+}
+
+// Plain assignment to a numeric field.
+test "subscript_member_assign: plain assign updates slot 0 value" {
+    let mut entries = _make_entries();
+    entries[0].value = 999;
+    assert entries[0].value == 999;
+    assert entries[1].value == 2;
+    assert entries[2].value == 3;
+    // Unchanged fields stay unchanged.
+    assert entries[0].key == "alpha";
+    assert entries[0].tag == 0;
+}
+
+// Plain assignment to a non-boundary slot.
+test "subscript_member_assign: plain assign updates middle slot" {
+    let mut entries = _make_entries();
+    entries[1].value = 42;
+    assert entries[0].value == 1;
+    assert entries[1].value == 42;
+    assert entries[2].value == 3;
+}
+
+// Plain assignment to a non-numeric (string) field.
+test "subscript_member_assign: assigning a string field writes through" {
+    let mut entries = _make_entries();
+    entries[2].key = "zeta";
+    assert entries[2].key == "zeta";
+    // Siblings untouched.
+    assert entries[0].key == "alpha";
+    assert entries[1].key == "beta";
+    // Value field in the mutated slot untouched.
+    assert entries[2].value == 3;
+}
+
+// Compound assignment: `+=`.
+test "subscript_member_assign: += compound updates in place" {
+    let mut entries = _make_entries();
+    entries[1].value += 10;
+    assert entries[0].value == 1;
+    assert entries[1].value == 12;
+    assert entries[2].value == 3;
+}
+
+test "subscript_member_assign: repeated += accumulates" {
+    let mut entries = _make_entries();
+    entries[0].value += 5;
+    entries[0].value += 5;
+    assert entries[0].value == 11;
+}
+
+// Multiple sequential writes hitting two different slots in the same block.
+test "subscript_member_assign: multiple fields in same and neighbour slots" {
+    let mut entries = _make_entries();
+    entries[0].value = 100;
+    entries[0].tag = 1;
+    entries[2].value = 200;
+    entries[2].tag = 2;
+    assert entries[0].value == 100;
+    assert entries[0].tag == 1;
+    assert entries[1].value == 2;
+    assert entries[1].tag == 0;
+    assert entries[2].value == 200;
+    assert entries[2].tag == 2;
+}
+
+// Loop mutation through the subscript — mirrors the `lock_add_entry`
+// shape that drove the bug: iterate, test, mutate the matching slot.
+test "subscript_member_assign: loop mutation through subscript" {
+    let mut entries = _make_entries();
+    let mut i: number = 0;
+    loop {
+        if i >= entries.length { break; }
+        entries[i].tag = entries[i].tag + i + 1;
+        i += 1;
+    }
+    assert entries[0].tag == 1;
+    assert entries[1].tag == 2;
+    assert entries[2].tag == 3;
+    // Other fields untouched.
+    assert entries[0].value == 1;
+    assert entries[1].value == 2;
+    assert entries[2].value == 3;
+}


### PR DESCRIPTION
Under the 0.5.8+ boxed-struct ABI every enum literal and boxed parameter
crosses function boundaries as `%Enum*`, yet `lower_comparison_operation`
in `compiler/src/llvm/expression_lowering/native/core_ops_lowering.sfn`
only resolved enum info on an exact `%Enum` match (via
`find_enum_info_by_llvm_type`) and further required
`left.llvm_type == right.llvm_type` before taking the tag-compare path.
Both conditions failed on the common cases — `p == Priority.High` with
both sides pointer-form, or `tasks[i].status == status_param` with one
value-form and one pointer-form operand — so the comparison fell through
to `icmp eq %Enum* a, %Enum* b`, which compared fresh heap allocations
and always returned false.

The fix resolves each operand's enum identity with a new
pointer-tolerant `resolve_enum_info_from_llvm_type`
(mirror of `resolve_struct_info_from_llvm_type`), requires both sides to
resolve to the same enum by `llvm_name`, and reads each operand's tag in
the form appropriate to its shape — `getelementptr`+`load` for pointer
form, `extractvalue` for value form. Mixed value/pointer pairs now flow
through the tag compare together instead of being rejected at the type
match.

The existing `find_enum_info_by_llvm_type` keeps its strict-match
semantics so callers that classify struct-field LLVM types (e.g. the
aggregate-field inlining check in `core_member_lowering.sfn`, which must
keep `%Foo*` pointer fields distinct from `%Foo` inline fields) do not
change behavior.

Local validation:
- make compile + make test NATIVE_BIN=build/native/sailfin-seedcheck
  with the seedcheck built from a freshly compiled first-pass now
  passes the 4 enum-equality tests that previously failed
  (enums_test, enum_complex_test, enum_match_struct_test,
  enum_state_machine_test) plus the new
  enum_equality_boxed_abi_test regression.
- struct_large_return_test, match_advanced_test, toml_test, and
  enum_mixed_field_types_test still pass (no regression in the
  previously-green paths).
- sailfin-seedcheck run examples/basics/hello-world.sfn prints
  Hello, Sailfin!.

https://claude.ai/code/session_01WYp3EwKzj27F73CUnfuC95