### PR TITLE
docs(perf): refresh build-performance.md to post-0.5.9 state

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,10 +17,6 @@ NATIVE_OPT ?= -O2
 #   CLANG_LL_FLAGS=-mllvm -opaque-pointers
 CLANG_LL_FLAGS ?=
 
-# Parallelism for the compiler build orchestrator's per-module emit + clang compile.
-# Keep conservative by default: this can increase peak memory.
-BUILD_JOBS ?= 1
-
 # Extra args passed through to the build orchestrator script.
 BUILD_ARGS ?=
 
@@ -40,6 +36,22 @@ else ifeq ($(IS_WINDOWS),1)
 TIMEOUT_CMD ?=
 else
 TIMEOUT_CMD ?= timeout
+endif
+
+# Parallelism for the compiler build orchestrator's per-module emit + clang
+# compile (passed through to scripts/build.sh as JOBS).
+#
+# Default: auto-detected from CPU count and total RAM via
+# scripts/detect_build_jobs.sh, with a per-job budget of 5 GB (heaviest module
+# ~4.7 GB peak RSS under the arena allocator, plus headroom). macOS additionally
+# caps at 2 because the M1 GitHub runner has only 7 GB total RAM. Windows / hosts
+# we cannot probe fall back to 1.
+#
+# Override explicitly with `BUILD_JOBS=N` (or the legacy `make rebuild
+# BUILD_JOBS=4`); empty / unset uses auto-detect. See docs/build-performance.md
+# → Phase 6 for the rollout plan and the per-job budget rationale.
+ifeq ($(strip $(BUILD_JOBS)),)
+BUILD_JOBS := $(shell bash scripts/detect_build_jobs.sh 2>/dev/null || echo 1)
 endif
 
 # Portable SHA-256 hasher. `shasum -a 256` ships with Perl on both macOS and

--- a/docs/build-performance.md
+++ b/docs/build-performance.md
@@ -1,24 +1,25 @@
 # Build Performance: Root Cause Analysis & Fix Plan
 
-**Date:** 2026-04-24 (revised, post 0.5.9 release — first IPC-free seed)
-**Previous revisions:** 2026-04-19 (post `.fn_*` channel removal), 2026-04-15 (post-d2d0bf1/220c8b7), 2026-04-15 (morning), 2026-04-11
-**Context:** 0.5.9 has shipped and is pinned as the seed (`.seed-version`). It is **the first release with no file-based data-flow IPC** — every cross-phase channel that used `build/sailfin/.xxx` files has been removed. The 48 remaining `build/sailfin/.xxx` references are debug/diag gates (`.trace_*`, `.phase_*_diagnostics`, `.skip_*`, `.test_runner_active`, `.dump_test_sources`), not data IPC. The structural cleanup arc opened in April 11's RCA is closed. The remaining wall-time win is **flipping on parallel builds** — the `xargs -P` machinery in `scripts/build.sh:766` has been mature for weeks, but the Makefile defaults to `BUILD_JOBS=1` and CI never overrides it, so every build today is single-threaded.
+**Date:** 2026-04-25 (revised, post Phase 6 Stage 1+2 flip)
+**Previous revisions:** 2026-04-24 (post 0.5.9 release — first IPC-free seed), 2026-04-19 (post `.fn_*` channel removal), 2026-04-15 (post-d2d0bf1/220c8b7), 2026-04-15 (morning), 2026-04-11
+**Context:** 0.5.9 has shipped and is pinned as the seed (`.seed-version`). It is **the first release with no file-based data-flow IPC** — every cross-phase channel that used `build/sailfin/.xxx` files has been removed. The 48 remaining `build/sailfin/.xxx` references are debug/diag gates (`.trace_*`, `.phase_*_diagnostics`, `.skip_*`, `.test_runner_active`, `.dump_test_sources`), not data IPC. The structural cleanup arc opened in April 11's RCA is closed. **Phase 6 Stages 1 and 2 flipped on April 24/25**: `stage_import_context` now runs in parallel under the same `JOBS` knob as the per-module emit loop (`build_module` parallel path was already in place), and the Makefile auto-detects `BUILD_JOBS` from CPU count and total RAM. First post-flip CI wall-times: **Linux x86_64 5:28 (was ~13 min single-threaded; 2.4× speedup)**, macOS arm64 10:37 (unchanged — heuristic picks `BUILD_JOBS=1` due to 7 GB total RAM cap). Stages 3 (CI flag wiring) and 4 (drop `EMIT_RETRIES` 3→1) remain queued.
 
 ---
 
 ## Symptom Summary
 
-| Metric                          | April 11            | April 19              | Current (April 24, 0.5.9) | Target           |
-| ------------------------------- | ------------------- | --------------------- | ------------------------- | ---------------- |
-| Full build (121 modules, 1 job) | 60-90 min           | 13-16 min             | ~13 min (CI Linux)        | < 5 min          |
-| Per-module compile time (heavy) | 4-7 min             | 1-3 min               | 1-3 min                   | < 30s            |
-| Per-module compile time (light) | 30s-2 min           | 10-30s                | 10-30s                    | < 5s             |
-| Per-module peak RAM             | 1-2 GB              | 0.5-1.5 GB            | 0.5-1.5 GB (4.7 GB worst) | < 256 MB         |
-| Parallel builds (`BUILD_JOBS`)  | Broken              | Functional but risky  | Mature, never enabled     | Default-on, ≥4 jobs Linux |
-| `fs.*` calls (total)            | 667 across 42 files | 489 across 37 files   | **212 across 24 files**   | bounded by CLI / capsule manifest reads |
-| `build/sailfin/` dotfile refs   | 487                 | 228 (dotfiles)        | **48 (diag/trace only)**  | 0 (post-Phase 5)        |
-| Active data-flow IPC channels   | 12+                 | 6                     | **0**                     | 0                |
-| Seed memory limit               | 8 GB                | 12 GB                 | 12 GB                     | < 4 GB           |
+| Metric                          | April 11            | April 19              | April 24 (0.5.9)          | Current (April 25, post-Phase 6 Stage 1+2) | Target           |
+| ------------------------------- | ------------------- | --------------------- | ------------------------- | ------------------------------------------ | ---------------- |
+| Full build (1 job, single-threaded) | 60-90 min       | 13-16 min             | ~13 min (CI Linux)        | ~13 min serial / **5:28 parallel** (CI Linux) | < 5 min          |
+| Full build (CI macOS arm64)     | n/a                 | n/a                   | ~13 min                   | **10:37** (BUILD_JOBS=1, mem-bound)       | < 5 min          |
+| Per-module compile time (heavy) | 4-7 min             | 1-3 min               | 1-3 min                   | 1-3 min                                    | < 30s            |
+| Per-module compile time (light) | 30s-2 min           | 10-30s                | 10-30s                    | 10-30s                                     | < 5s             |
+| Per-module peak RAM             | 1-2 GB              | 0.5-1.5 GB            | 0.5-1.5 GB (4.7 GB worst) | 0.5-1.5 GB (4.7 GB worst)                  | < 256 MB         |
+| Parallel builds (`BUILD_JOBS`)  | Broken              | Functional but risky  | Mature, never enabled     | **Auto-detected default; Linux ≈3 jobs, macOS 1 job** | Default-on, ≥4 jobs Linux |
+| `fs.*` calls (total)            | 667 across 42 files | 489 across 37 files   | 212 across 24 files       | 212 across 24 files                        | bounded by CLI / capsule manifest reads |
+| `build/sailfin/` dotfile refs   | 487                 | 228 (dotfiles)        | 48 (diag/trace only)      | 48 (diag/trace only)                       | 0 (post-Phase 5) |
+| Active data-flow IPC channels   | 12+                 | 6                     | 0                         | **0**                                       | 0                |
+| Seed memory limit               | 8 GB                | 12 GB                 | 12 GB                     | 12 GB                                      | < 4 GB           |
 
 ---
 
@@ -36,10 +37,10 @@ Status of every track named in the original RCA. "Shipped" means the work landed
 | Phase 4 PR 1 — Light recovery off non-test primary path         | **Shipped**                                                                   | counted                                   |
 | Phase 4 PR 2 — `parse_native_artifact` primary swap             | **Unblocked by PR #229** (in-memory `compile_to_llvm_file_with_module`)       | 5–8%                                      |
 | Phase 4b — Defensive light-recovery arm deletion                | Not started; needs counters bake then delete ~600 LOC                         | trivial wall-time                         |
-| **Phase 6 — Parallel builds (NEW, primary remaining win)**      | Machinery in place; `BUILD_JOBS=1` default; never enabled in CI               | **40–60%** wall-time on Linux             |
+| **Phase 6 — Parallel builds**                                   | **Stage 1+2 shipped April 24/25** (parallel `stage_import_context`, adaptive `BUILD_JOBS` default); Stages 3–4 (CI input + retry budget) pending | Linux measured: **2.4× speedup** (13 min → 5:28). Stage 3 wires CI; Stage 4 worth maybe 5%. |
 | Phase 5 — Long-lived compiler process                           | Post-1.0; needs `compile module` entry point and arena reset between modules  | 50–70% on top of Phase 6                  |
 
-Two follow-up tracks worth catalogueing:
+Two follow-up tracks worth cataloguing:
 
 - **Per-module memory reduction** — heaviest module (`lowering_core`) still peaks at ~4.7 GB RSS with arena. Every GB shaved raises the safe `BUILD_JOBS` ceiling on memory-constrained hosts (macOS runners cap at 7 GB total). Profiling target: arena page count + per-pass pressure.
 - **Selfhost1 clang opt level** — `make check`'s first-pass binary doesn't need `-O2`; second-pass (the binary we ship as a seed) does. Easy 20–30% off the clang-compile stage in `make check`.
@@ -335,27 +336,36 @@ Replace the 121 separate compiler processes with a single long-lived process tha
 
 This requires the compiler to support a "compile module" entry point that takes import context as an argument rather than reading it from the filesystem.
 
-### Phase 6: Parallel Builds (NEW — primary remaining pre-1.0 win)
+### Phase 6: Parallel Builds
 
-**Priority:** Highest — **Expected:** 40–60% wall-time on Linux (CI Linux build at `BUILD_JOBS=4` should drop ~13 min → ~5–7 min)
+**Priority:** Highest. **Stages 1+2 shipped April 24/25; measured 2.4× speedup on Linux CI.** Stages 3–4 remain queued.
 **Depends on:** Phase 0 (arena default-on, shipped) and Phase 2 (IPC removal, shipped). Both prerequisites are met.
 
-The xargs-based parallel emit path (`scripts/build.sh:766-797`) has been mature for weeks. Each parallel worker runs `bash scripts/build.sh --_build_module_worker` in an isolated `seed_cwd`, copies the import-context, runs the seed, and appends one line to a shared `MODULES_LIST` (atomic for sub-PIPE_BUF lines). The list is `LC_ALL=C sort`ed before `llvm-link` consumption so link order is deterministic regardless of completion order.
+The xargs-based parallel emit path in `build_module` (`scripts/build.sh`) has been mature for weeks. Each parallel worker runs `bash scripts/build.sh --_build_module_worker` in an isolated `seed_cwd`, copies the import-context, runs the seed, and appends one line to a shared `MODULES_LIST` (atomic for sub-PIPE_BUF lines). The list is `LC_ALL=C sort`ed before `llvm-link` consumption so link order is deterministic regardless of completion order. The same pattern now applies to `stage_import_context` via the new `--_stage_import_worker` entry.
 
-The reason it never went default is per-job memory: with the arena default-on, `lowering_core` (the heaviest module) peaks at ~4.7 GB RSS. With `BUILD_JOBS=4`, worst-case concurrent peak is ~18.8 GB. That fits ubuntu-24.04 GitHub runners (22 GB) but overcommits `macos-latest` (M1, 7 GB).
+The reason it never went default before April 25 was per-job memory: with the arena default-on, `lowering_core` (the heaviest module) peaks at ~4.7 GB RSS. With `BUILD_JOBS=4`, worst-case concurrent peak is ~18.8 GB. That fits ubuntu-24.04 GitHub runners (22 GB) but overcommits `macos-latest` (M1, 7 GB) — which is exactly why the Stage 2 heuristic caps macOS at `BUILD_JOBS=1`.
 
-#### Enablement plan (staged for safe rollout)
+#### Measured CI wall-time (post-flip)
 
-1. **Stage 1 — parallelize `stage_import_context`.** The loop at `build.sh:747-751` is currently sequential ("for safety with older seeds"). 0.5.9 is the safe seed; this is the lowest-risk free win. Each `seed emit native <src> >dest` call writes to a distinct destination path with no shared state — the same `xargs -P` pattern from the build loop applies directly. ✅ **Shipped** April 24 — same commit as Stage 2.
-2. **Stage 2 — adaptive `BUILD_JOBS` default in the Makefile.** Compute `BUILD_JOBS` from `nproc` capped by a memory budget (5 GB per job ≈ heaviest-module peak under arena, plus headroom). On macOS, cap at 2 jobs because of the 7 GB total RAM ceiling on M1 runners. Per-host hardware determines the cap; nobody has to think about it. Existing `BUILD_JOBS=N` env override still wins. ✅ **Shipped** April 24.
-3. **Stage 3 — wire `BUILD_JOBS` through the CI composite action.** Add a `build_jobs` input to `.github/actions/sailfin-build/action.yml` (default `auto`); pass it to `make rebuild`. Run one `nightly-selfhost` cycle with the new default, compare wall-time against the 13-min baseline, then promote to PR CI. **Pending** — wait for Stage 1+2 to bake locally.
-4. **Stage 4 — drop `EMIT_RETRIES` default 3 → 1.** With 0.5.9 stable, the corruption corpus is dry; retries only hide regressions now. Keep the env knob for diagnostic builds. **Pending** — needs one full build with retries.log inspection to confirm zero retry hits in CI.
+| Runner          | Before (single-thread) | After (auto BUILD_JOBS) | Speedup |
+| --------------- | ---------------------- | ----------------------- | ------- |
+| linux-x86_64    | ~13 min                | **5:28**                | 2.4×    |
+| macos-arm64     | ~13 min                | **10:37** (BUILD_JOBS=1) | 1.2×   |
+
+macOS gets a smaller win because the heuristic picks `BUILD_JOBS=1` to fit the 7 GB total RAM ceiling. The improvement there comes entirely from the parallel `stage_import_context` step still being able to overlap I/O even when `JOBS=1` (which… it can't — at JOBS=1 staging is serial). The macOS speedup likely comes from the per-worker preamble silencing fix and modest CI runner variance, not parallelism.
+
+#### Enablement plan (staged rollout)
+
+1. **Stage 1 — parallelize `stage_import_context`.** ✅ **Shipped April 24** (commit `d5a2d93`, plus log-noise fix `0eda32b`). The loop was previously sequential ("for safety with older seeds"). 0.5.9 is the safe seed; the same `xargs -P` pattern from `build_module` applies directly. Each `seed emit native <src> >dest` call writes to a distinct destination, no shared state.
+2. **Stage 2 — adaptive `BUILD_JOBS` default in the Makefile.** ✅ **Shipped April 24** (commit `7f0ef9a`). `scripts/detect_build_jobs.sh` computes `BUILD_JOBS` from `nproc` capped by a memory budget (5 GB per job ≈ heaviest-module peak under arena, plus headroom). On macOS, cap at 2 jobs because of the 7 GB total RAM ceiling on M1 runners. Global cap of 8 jobs prevents I/O / link-time contention from dominating on workstations. Existing `BUILD_JOBS=N` env override still wins.
+3. **Stage 3 — wire `BUILD_JOBS` through the CI composite action.** Currently CI inherits the Makefile's auto-detected default (Stage 2 carried this for free since `.github/actions/sailfin-build` calls `make rebuild` without overriding `BUILD_JOBS`). The remaining work is to surface `build_jobs` as an explicit composite-action input so individual workflows can override (e.g. pin to 1 for a regression bisect, or to 8 on a self-hosted runner). **Pending** — low-priority polish; the auto default is already producing the desired effect in PR CI.
+4. **Stage 4 — drop `EMIT_RETRIES` default 3 → 1.** With 0.5.9 stable, the corruption corpus is dry; retries only hide regressions now. Keep the env knob for diagnostic builds. **Pending** — needs one full build with `retries.log` inspection to confirm zero retry hits in CI.
 
 #### Why each stage is safe
 
-- **Stage 1 (parallel staging):** Each `stage_import_context` call writes to `$IMPORT_CACHE/${slug}.sfn-asm` and `$IMPORT_CACHE/${slug}.layout-manifest`. Slugs are derived from source paths (`slug_from_path`), which are unique by construction. The seed runs from `REPO_ROOT` and writes only to the redirected destination — no shared scratch directory.
-- **Stage 2 (adaptive default):** Picks `min(nproc, total_ram_gb / 5)` clamped to `[1, 8]`. Falls back to 1 on any platform we can't probe (Windows, BSD without `/proc/meminfo` and without `sysctl hw.memsize`). The `BUILD_JOBS` env var still overrides — local users who know their hardware can pin a specific value.
-- **Stage 3 (CI wiring):** Adding the input is purely additive. Existing callers that don't set it inherit the auto-detected default.
+- **Stage 1 (parallel staging):** Each `stage_import_context` call writes to `$IMPORT_CACHE/${slug}.sfn-asm` and `$IMPORT_CACHE/${slug}.layout-manifest`. Slugs are derived from source paths via `slug_from_path`, which is unique by construction. The seed writes only to the redirected destination — no shared scratch directory. The April 25 follow-up (`fix(build): silence per-worker preamble`) gates the directory-prep / cleanup blocks behind `IS_WORKER=0`, eliminating a latent race where peer workers could have stomped each other's `.ll` files when `build_module` parallelism is increased further.
+- **Stage 2 (adaptive default):** `detect_build_jobs.sh` picks `min(nproc, total_ram_gb / 5)` clamped to `[1, 8]`, with a macOS additional cap of 2. Falls back to 1 on any platform we can't probe (Windows, BSD without `/proc/meminfo` and without `sysctl hw.memsize`). `BUILD_JOBS` env var still overrides for users who want a specific number.
+- **Stage 3 (CI wiring):** Adding the input is purely additive. Existing callers that don't set it continue to inherit the Makefile's auto-detected default.
 - **Stage 4 (retry budget):** The retry corpus (`build/selfhost/native/corrupted/`) is the canonical signal. If `find $WORK_DIR/corrupted -type f -newer build/native/sailfin | wc -l` is 0 across one full nightly, retries are dead weight.
 
 #### What this does NOT change

--- a/docs/build-performance.md
+++ b/docs/build-performance.md
@@ -1,23 +1,48 @@
 # Build Performance: Root Cause Analysis & Fix Plan
 
-**Date:** 2026-04-19 (revised, post `.fn_*` channel removal)
-**Previous revision:** 2026-04-15 (revised, post-d2d0bf1/220c8b7), 2026-04-15 (morning), 2026-04-11
-**Context:** Self-hosting the compiler from the 0.5.2-alpha.1 seed via `build.sh` takes ~13-16 minutes for 121 modules single-threaded. Down from 60-90 minutes at the April 11 baseline thanks to partial IPC removal, string concat optimization, module splitting, and the Phase 1 accumulator sweep (`d2d0bf1`). Still far from the <5 minute target. The IPC-as-GC memory management blocker (formerly blocking ~146 Phase 2 channel refs) is now cleared: the arena allocator is default-on for selfhost as of the April 19 flip (see [Completed Work: Arena Allocator Default-On](#arena-allocator-default-on-april-19)). The two residual O(n²) copy sites (`concat_native_functions`, `append_local_binding`) that were reverted in `220c8b7` because callers rely on input-array immutability are now safe to convert to in-place push under arena — tracked as immediate follow-up work.
+**Date:** 2026-04-24 (revised, post 0.5.9 release — first IPC-free seed)
+**Previous revisions:** 2026-04-19 (post `.fn_*` channel removal), 2026-04-15 (post-d2d0bf1/220c8b7), 2026-04-15 (morning), 2026-04-11
+**Context:** 0.5.9 has shipped and is pinned as the seed (`.seed-version`). It is **the first release with no file-based data-flow IPC** — every cross-phase channel that used `build/sailfin/.xxx` files has been removed. The 48 remaining `build/sailfin/.xxx` references are debug/diag gates (`.trace_*`, `.phase_*_diagnostics`, `.skip_*`, `.test_runner_active`, `.dump_test_sources`), not data IPC. The structural cleanup arc opened in April 11's RCA is closed. The remaining wall-time win is **flipping on parallel builds** — the `xargs -P` machinery in `scripts/build.sh:766` has been mature for weeks, but the Makefile defaults to `BUILD_JOBS=1` and CI never overrides it, so every build today is single-threaded.
 
 ---
 
 ## Symptom Summary
 
-| Metric                          | April 11            | Current (April 19)   | Target           |
-| ------------------------------- | ------------------- | -------------------- | ---------------- |
-| Full build (121 modules, 1 job) | 60-90 min           | 13-16 min            | < 5 min          |
-| Per-module compile time (heavy) | 4-7 min             | 1-3 min              | < 30s            |
-| Per-module compile time (light) | 30s-2 min           | 10-30s               | < 5s             |
-| Per-module peak RAM             | 1-2 GB              | 0.5-1.5 GB           | < 256 MB         |
-| Parallel builds (`--jobs N`)    | Broken              | Functional but risky | Stable at 4 jobs |
-| `fs.*` calls (total)            | 667 across 42 files | 489 across 37 files  | < 50 per module  |
-| `build/sailfin/` IPC refs       | 487                 | 228 (dotfiles)       | 0                |
-| Seed memory limit               | 8 GB                | 12 GB                | < 4 GB           |
+| Metric                          | April 11            | April 19              | Current (April 24, 0.5.9) | Target           |
+| ------------------------------- | ------------------- | --------------------- | ------------------------- | ---------------- |
+| Full build (121 modules, 1 job) | 60-90 min           | 13-16 min             | ~13 min (CI Linux)        | < 5 min          |
+| Per-module compile time (heavy) | 4-7 min             | 1-3 min               | 1-3 min                   | < 30s            |
+| Per-module compile time (light) | 30s-2 min           | 10-30s                | 10-30s                    | < 5s             |
+| Per-module peak RAM             | 1-2 GB              | 0.5-1.5 GB            | 0.5-1.5 GB (4.7 GB worst) | < 256 MB         |
+| Parallel builds (`BUILD_JOBS`)  | Broken              | Functional but risky  | Mature, never enabled     | Default-on, ≥4 jobs Linux |
+| `fs.*` calls (total)            | 667 across 42 files | 489 across 37 files   | **212 across 24 files**   | bounded by CLI / capsule manifest reads |
+| `build/sailfin/` dotfile refs   | 487                 | 228 (dotfiles)        | **48 (diag/trace only)**  | 0 (post-Phase 5)        |
+| Active data-flow IPC channels   | 12+                 | 6                     | **0**                     | 0                |
+| Seed memory limit               | 8 GB                | 12 GB                 | 12 GB                     | < 4 GB           |
+
+---
+
+## Reassessed Roadmap (April 24)
+
+Status of every track named in the original RCA. "Shipped" means the work landed and the doc's **Completed Work** section has the entry.
+
+| Track                                                           | Status                                                                        | Expected wall-time delta (remaining work) |
+| --------------------------------------------------------------- | ----------------------------------------------------------------------------- | ----------------------------------------- |
+| Phase 0 — M0.5 arena allocator                                  | **Shipped** (default-on April 19)                                             | counted                                   |
+| Phase 1 — O(n²) array accumulation sweep                        | **Shipped** (1 residual aliasing site under arena, low-frequency)             | <2%                                       |
+| Phase 2 — File-based IPC channel removal                        | **Shipped** (0.5.9 — first IPC-free seed)                                     | counted                                   |
+| Phase 3a — Import-discovery fast-path scanner                   | **Shipped**                                                                   | counted                                   |
+| Phase 3b — Pre-parsed `.imports` sidecar                        | Not started; may be subsumed by Phase 5                                       | 5–10%                                     |
+| Phase 4 PR 1 — Light recovery off non-test primary path         | **Shipped**                                                                   | counted                                   |
+| Phase 4 PR 2 — `parse_native_artifact` primary swap             | **Unblocked by PR #229** (in-memory `compile_to_llvm_file_with_module`)       | 5–8%                                      |
+| Phase 4b — Defensive light-recovery arm deletion                | Not started; needs counters bake then delete ~600 LOC                         | trivial wall-time                         |
+| **Phase 6 — Parallel builds (NEW, primary remaining win)**      | Machinery in place; `BUILD_JOBS=1` default; never enabled in CI               | **40–60%** wall-time on Linux             |
+| Phase 5 — Long-lived compiler process                           | Post-1.0; needs `compile module` entry point and arena reset between modules  | 50–70% on top of Phase 6                  |
+
+Two follow-up tracks worth catalogueing:
+
+- **Per-module memory reduction** — heaviest module (`lowering_core`) still peaks at ~4.7 GB RSS with arena. Every GB shaved raises the safe `BUILD_JOBS` ceiling on memory-constrained hosts (macOS runners cap at 7 GB total). Profiling target: arena page count + per-pass pressure.
+- **Selfhost1 clang opt level** — `make check`'s first-pass binary doesn't need `-O2`; second-pass (the binary we ship as a seed) does. Easy 20–30% off the clang-compile stage in `make check`.
 
 ---
 
@@ -245,14 +270,11 @@ Per-site aliasing audit (see [runtime_architecture.md §4.4](runtime_architectur
 
 The win is concentrated on the target module; aggregate is within bench variance. `append_local_binding` conversions become cheap automatically under the M0.5 arena, so Phase 1b is complete as a pre-arena intervention.
 
-### Phase 2: Eliminate IPC Files (Resumed)
+### Phase 2: Eliminate IPC Files (✅ Shipped in 0.5.9)
 
-**Priority:** Highest — **Expected:** 40-60% time reduction, enables parallel builds
-**Depends on:** ~~Enabling the arena allocator by default~~ — cleared April 19 with the arena default-on flip. All Phase 2 channels are now pickable.
+**Status:** Complete. 0.5.9 is the first release with no file-based data-flow IPC. Every cross-phase channel has been removed; the 48 remaining `build/sailfin/.xxx` references are debug/diag gates (`.trace_*`, `.phase_*_diagnostics`, `.skip_*`, `.test_runner_active`, `.dump_test_sources`) — none of them carry pipeline data. The full removal arc is documented in **Completed Work** below; the per-channel entries (block_result, fn_*, expr_stmt, coerce_result, call_result, dispatch/let_result, instr_fn_name, enum_info, struct_info, async_inner_return_type, condition_locals, self_field, expr_stmt_temp, module_globals, function_metadata, emit-native.tmp / emit-llvm.tmp) cover every channel that ever existed.
 
-Most IPC channels were introduced as workarounds for v0.1.1-seed ABI corruption of array-of-struct parameters across module boundaries. The 0.5.x seed lineage no longer corrupts those parameters, so many channels are now dead-code fallbacks whose readers already have the data in-memory via an existing `bindings` or `locals` parameter.
-
-Channels that serialize per-instruction/per-binding control-flow state (dispatch, let result, block result, statement mutations) were previously blocked by the IPC-as-GC problem — removing them without arena caused OOM because the file write/read cycle was implicitly freeing the source values. Under the default-on arena, those values stay alive in the arena until process exit, but the arena is bulk-freed at exit; per-module peak RAM rises but never OOMs because the arena replaces ad-hoc malloc churn with bump allocation.
+**Original framing (kept for the historical record):** Most IPC channels were introduced as workarounds for v0.1.1-seed ABI corruption of array-of-struct parameters across module boundaries. The 0.5.x seed lineage no longer corrupts those parameters, so the channels were dead-code fallbacks whose readers already had the data in-memory via an existing `bindings` or `locals` parameter. Channels that serialized per-instruction/per-binding control-flow state (dispatch, let_result, block_result, statement mutations) were previously blocked by the IPC-as-GC problem — removing them without arena caused OOM because the file write/read cycle was implicitly freeing the source values. The April 19 arena default-on flip cleared that blocker and the rest of the channels came out in the following four weeks.
 
 #### Procedure: Removing an IPC Channel
 
@@ -302,7 +324,7 @@ Replace `recover_native_functions_light` (line-by-line scanning with 20+ `starts
 
 ### Phase 5: Long-Lived Compiler Process (Future)
 
-**Priority:** Future (post-1.0 or late pre-1.0) — **Expected:** 50-70% time reduction
+**Priority:** Future (post-1.0 or late pre-1.0) — **Expected:** 50-70% time reduction on top of Phase 6
 
 Replace the 121 separate compiler processes with a single long-lived process that compiles all modules in sequence (or in parallel with shared state):
 
@@ -312,6 +334,35 @@ Replace the 121 separate compiler processes with a single long-lived process tha
 - Arena allocator resets between modules instead of process exit
 
 This requires the compiler to support a "compile module" entry point that takes import context as an argument rather than reading it from the filesystem.
+
+### Phase 6: Parallel Builds (NEW — primary remaining pre-1.0 win)
+
+**Priority:** Highest — **Expected:** 40–60% wall-time on Linux (CI Linux build at `BUILD_JOBS=4` should drop ~13 min → ~5–7 min)
+**Depends on:** Phase 0 (arena default-on, shipped) and Phase 2 (IPC removal, shipped). Both prerequisites are met.
+
+The xargs-based parallel emit path (`scripts/build.sh:766-797`) has been mature for weeks. Each parallel worker runs `bash scripts/build.sh --_build_module_worker` in an isolated `seed_cwd`, copies the import-context, runs the seed, and appends one line to a shared `MODULES_LIST` (atomic for sub-PIPE_BUF lines). The list is `LC_ALL=C sort`ed before `llvm-link` consumption so link order is deterministic regardless of completion order.
+
+The reason it never went default is per-job memory: with the arena default-on, `lowering_core` (the heaviest module) peaks at ~4.7 GB RSS. With `BUILD_JOBS=4`, worst-case concurrent peak is ~18.8 GB. That fits ubuntu-24.04 GitHub runners (22 GB) but overcommits `macos-latest` (M1, 7 GB).
+
+#### Enablement plan (staged for safe rollout)
+
+1. **Stage 1 — parallelize `stage_import_context`.** The loop at `build.sh:747-751` is currently sequential ("for safety with older seeds"). 0.5.9 is the safe seed; this is the lowest-risk free win. Each `seed emit native <src> >dest` call writes to a distinct destination path with no shared state — the same `xargs -P` pattern from the build loop applies directly. ✅ **Shipped** April 24 — same commit as Stage 2.
+2. **Stage 2 — adaptive `BUILD_JOBS` default in the Makefile.** Compute `BUILD_JOBS` from `nproc` capped by a memory budget (5 GB per job ≈ heaviest-module peak under arena, plus headroom). On macOS, cap at 2 jobs because of the 7 GB total RAM ceiling on M1 runners. Per-host hardware determines the cap; nobody has to think about it. Existing `BUILD_JOBS=N` env override still wins. ✅ **Shipped** April 24.
+3. **Stage 3 — wire `BUILD_JOBS` through the CI composite action.** Add a `build_jobs` input to `.github/actions/sailfin-build/action.yml` (default `auto`); pass it to `make rebuild`. Run one `nightly-selfhost` cycle with the new default, compare wall-time against the 13-min baseline, then promote to PR CI. **Pending** — wait for Stage 1+2 to bake locally.
+4. **Stage 4 — drop `EMIT_RETRIES` default 3 → 1.** With 0.5.9 stable, the corruption corpus is dry; retries only hide regressions now. Keep the env knob for diagnostic builds. **Pending** — needs one full build with retries.log inspection to confirm zero retry hits in CI.
+
+#### Why each stage is safe
+
+- **Stage 1 (parallel staging):** Each `stage_import_context` call writes to `$IMPORT_CACHE/${slug}.sfn-asm` and `$IMPORT_CACHE/${slug}.layout-manifest`. Slugs are derived from source paths (`slug_from_path`), which are unique by construction. The seed runs from `REPO_ROOT` and writes only to the redirected destination — no shared scratch directory.
+- **Stage 2 (adaptive default):** Picks `min(nproc, total_ram_gb / 5)` clamped to `[1, 8]`. Falls back to 1 on any platform we can't probe (Windows, BSD without `/proc/meminfo` and without `sysctl hw.memsize`). The `BUILD_JOBS` env var still overrides — local users who know their hardware can pin a specific value.
+- **Stage 3 (CI wiring):** Adding the input is purely additive. Existing callers that don't set it inherit the auto-detected default.
+- **Stage 4 (retry budget):** The retry corpus (`build/selfhost/native/corrupted/`) is the canonical signal. If `find $WORK_DIR/corrupted -type f -newer build/native/sailfin | wc -l` is 0 across one full nightly, retries are dead weight.
+
+#### What this does NOT change
+
+- Determinism: link order is sorted post-emit; LLVM IR output is byte-identical to the serial path (the existing `make check` fixed-point comparison continues to gate this).
+- Memory ceiling: `SEED_MEM_LIMIT=12 GB` per process is unchanged. A future PR can lower this to 6 GB once we have telemetry showing no module needs more.
+- `make check` triple-pass logic: the seedcheck and stage3 builds use the same `BUILD_JOBS` knob, so the fixed-point comparison runs at parallel load too.
 
 ---
 
@@ -996,23 +1047,41 @@ The fix is not to guess at the ABI corner; the fix is to not rely on the cross-m
 
 ## Appendix: IPC Channel Census
 
-Total: **489 `fs.*` calls across 37 files.** 228 dotfile references to `build/sailfin/.xxx` temp paths across 27 files.
+**Current (April 24, post-0.5.9):** 212 `fs.*` calls across 24 files. 48 `build/sailfin/.xxx` references across 18 files. **Zero data-flow IPC channels.**
 
-### Top IPC files by build/sailfin/ reference count
+The remaining `fs.*` surface is concentrated in CLI / orchestration paths that legitimately read filesystem state (capsule manifest resolution, lock-file management, target-directory bookkeeping) — not pipeline IPC:
 
-| File                           | Dotfile refs |
-| ------------------------------ | ------------ |
-| `instructions_dispatch.sfn`    | 45           |
-| `instructions_let.sfn`         | 32           |
-| `instructions_helpers.sfn`     | 30           |
-| `statement.sfn`                | 16           |
-| `core_call_emission.sfn`       | 13           |
-| `core_literals_lowering.sfn`   | 12           |
-| `main.sfn`                     | 12           |
-| `statement_assignment.sfn`     | 9            |
-| `lowering_core.sfn`            | 9            |
-| `lowering_phase_types.sfn`     | 7            |
-| `cli_commands.sfn`             | 4            |
-| `emission.sfn`                 | 3            |
-| `lowering_phase_functions.sfn` | 2            |
-| `core_call_resolution.sfn`     | 1            |
+| File                                        | `fs.*` calls | Role                            |
+| ------------------------------------------- | -----------: | ------------------------------- |
+| `cli_commands.sfn`                          |           60 | CLI subcommand dispatch          |
+| `main.sfn`                                  |           36 | binary entry point + flag parsing |
+| `cli_main.sfn`                              |           22 | CLI argv routing                  |
+| `capsule_resolver.sfn`                      |           19 | capsule manifest + dep resolution |
+| `llvm/lowering/lowering_core.sfn`           |           14 | trace gates + diagnostic dumps    |
+| `llvm/imports.sfn`                          |           13 | import-context reads              |
+| `cli_commands_utils.sfn`                    |           13 | CLI helpers                       |
+| `llvm/lowering/lowering_io.sfn`             |            9 | LLVM IR output                    |
+| `version.sfn`                               |            6 | resolve compiler version          |
+| `llvm/runtime_helpers.sfn`                  |            5 | runtime IR file reads             |
+
+The 48 remaining `build/sailfin/.xxx` references are **all flag/diagnostic gates**:
+
+```
+build/sailfin/.dump_test_sources         build/sailfin/.skip_typecheck
+build/sailfin/.phase_functions_diagnostics build/sailfin/.test_runner_active
+build/sailfin/.phase_types_diagnostics   build/sailfin/.trace_argv
+build/sailfin/.skip_module_globals       build/sailfin/.trace_call_lowering
+build/sailfin/.skip_test_inlining        build/sailfin/.trace_emit
+                                         build/sailfin/.trace_lowering
+                                         build/sailfin/.trace_test_runner
+```
+
+These are checked via `fs.exists`/`fs.readFile` as a workaround for the lack of `--feature-flag X=Y` plumbing in the CLI. They carry no pipeline data and add no per-module I/O overhead in the common case (the seed checks once at startup). Migrating these to env vars or proper CLI flags is a hygiene cleanup, not a performance task.
+
+### Pre-0.5.9 census (kept for the historical record)
+
+| Date       | `fs.*` calls          | Dotfile refs | Active data-flow channels |
+| ---------- | --------------------- | -----------: | ------------------------: |
+| April 11   | 667 across 42 files   | 487          | 12+                       |
+| April 19   | 489 across 37 files   | 228          | 6                         |
+| **April 24 (0.5.9)** | **212 across 24 files** | **48**     | **0**                     |

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -55,6 +55,14 @@ WORKER_SRC=""
 STAGE_IMPORT_WORKER=0
 STAGE_IMPORT_SRC=""
 
+# Worker invocations re-enter build.sh to dispatch a single
+# stage_import_context or build_module call. They only need a small subset of
+# the parent's setup (helpers, SEED, dirname helpers); the SOURCES collection,
+# directory cleanup, and most preamble logging are wasted work that — at
+# JOBS=N parallelism — also produces N copies of every banner line in the
+# build log. IS_WORKER gates that preamble out.
+IS_WORKER=0
+
 # Build directories (overridable via --work-dir)
 WORK_DIR="${WORK_DIR:-build/selfhost/native}"
 
@@ -100,6 +108,12 @@ while [[ $# -gt 0 ]]; do
         *)          echo "[build] unknown option: $1" >&2; exit 1 ;;
     esac
 done
+
+# Worker mode if either dispatch flag is set. Computed after argv parsing so
+# downstream blocks (preamble logs, SOURCES collection) can short-circuit.
+if [[ "$BUILD_MODULE_WORKER" -eq 1 || "$STAGE_IMPORT_WORKER" -eq 1 ]]; then
+    IS_WORKER=1
+fi
 
 # ---------------------------------------------------------------------------
 # Arena allocator default (Phase 0 / M0.5 — see docs/build-performance.md)
@@ -374,7 +388,9 @@ SEED="$(command -v "$SEED" 2>/dev/null || echo "$SEED")"
 SEED="$(cd "$REPO_ROOT" && realpath "$SEED")"
 [[ -x "$SEED" ]] || die "seed compiler not executable: $SEED"
 
-log "seed: $SEED ($("$SEED" version 2>/dev/null || "$SEED" --version 2>/dev/null || echo 'unknown'))"
+if [[ "$IS_WORKER" -eq 0 ]]; then
+    log "seed: $SEED ($("$SEED" version 2>/dev/null || "$SEED" --version 2>/dev/null || echo 'unknown'))"
+fi
 
 # ---------------------------------------------------------------------------
 # Collect sources
@@ -419,46 +435,51 @@ collect_compiler_capsule_deps() {
     ' "$manifest"
 }
 
-# Collect all .sfn files in deterministic order
+# Collect all .sfn files in deterministic order. Workers receive their target
+# source path as an argument and don't enumerate the tree, so skip this work
+# (and the per-worker log line) in worker mode — it's redundant and produces
+# JOBS copies of every banner line in the build log when fan-out is high.
 SOURCES=()
-while IFS= read -r -d '' f; do
-    SOURCES+=("$f")
-done < <(find "$COMPILER_SRC" -name '*.sfn' -print0 | LC_ALL=C sort -z)
-while IFS= read -r -d '' f; do
-    SOURCES+=("$f")
-done < <(find "$RUNTIME_SRC" -name '*.sfn' -print0 | LC_ALL=C sort -z)
-
-# Pull in declared capsule dependencies. For now we resolve them against
-# the in-tree `capsules/<scope>/<name>/src/` layout.
-#
-# Resolution policy:
-#   - sfn/* deps MUST have an in-tree source — fail fast if missing, since
-#     that indicates a stale allowlist or a typo in compiler/capsule.toml.
-#   - Third-party (non-sfn/) deps that only live in the user cache
-#     (~/.sfn/cache/capsules/...) are warned-and-skipped for now. Wire
-#     them up here once the compiler actually takes a third-party dep.
 CAPSULE_DEP_COUNT=0
-while IFS= read -r dep; do
-    [[ -n "$dep" ]] || continue
-    cap_dir="$CAPSULES_DIR/$dep/src"
-    if [[ ! -d "$cap_dir" ]]; then
-        if [[ "$dep" == sfn/* ]]; then
-            die "capsule dep '$dep' declared in compiler/capsule.toml but no in-tree source at $cap_dir"
-        fi
-        warn "capsule dep '$dep' has no in-tree source at $cap_dir; skipping (user-cache resolution not yet wired)"
-        continue
-    fi
+if [[ "$IS_WORKER" -eq 0 ]]; then
     while IFS= read -r -d '' f; do
         SOURCES+=("$f")
-        CAPSULE_DEP_COUNT=$((CAPSULE_DEP_COUNT + 1))
-    done < <(find "$cap_dir" -name '*.sfn' -print0 | LC_ALL=C sort -z)
-done < <(collect_compiler_capsule_deps "$COMPILER_MANIFEST")
+    done < <(find "$COMPILER_SRC" -name '*.sfn' -print0 | LC_ALL=C sort -z)
+    while IFS= read -r -d '' f; do
+        SOURCES+=("$f")
+    done < <(find "$RUNTIME_SRC" -name '*.sfn' -print0 | LC_ALL=C sort -z)
 
-[[ ${#SOURCES[@]} -gt 0 ]] || die "no .sfn sources found"
-if [[ $CAPSULE_DEP_COUNT -gt 0 ]]; then
-    log "found ${#SOURCES[@]} source modules (includes $CAPSULE_DEP_COUNT from capsule deps)"
-else
-    log "found ${#SOURCES[@]} source modules"
+    # Pull in declared capsule dependencies. For now we resolve them against
+    # the in-tree `capsules/<scope>/<name>/src/` layout.
+    #
+    # Resolution policy:
+    #   - sfn/* deps MUST have an in-tree source — fail fast if missing, since
+    #     that indicates a stale allowlist or a typo in compiler/capsule.toml.
+    #   - Third-party (non-sfn/) deps that only live in the user cache
+    #     (~/.sfn/cache/capsules/...) are warned-and-skipped for now. Wire
+    #     them up here once the compiler actually takes a third-party dep.
+    while IFS= read -r dep; do
+        [[ -n "$dep" ]] || continue
+        cap_dir="$CAPSULES_DIR/$dep/src"
+        if [[ ! -d "$cap_dir" ]]; then
+            if [[ "$dep" == sfn/* ]]; then
+                die "capsule dep '$dep' declared in compiler/capsule.toml but no in-tree source at $cap_dir"
+            fi
+            warn "capsule dep '$dep' has no in-tree source at $cap_dir; skipping (user-cache resolution not yet wired)"
+            continue
+        fi
+        while IFS= read -r -d '' f; do
+            SOURCES+=("$f")
+            CAPSULE_DEP_COUNT=$((CAPSULE_DEP_COUNT + 1))
+        done < <(find "$cap_dir" -name '*.sfn' -print0 | LC_ALL=C sort -z)
+    done < <(collect_compiler_capsule_deps "$COMPILER_MANIFEST")
+
+    [[ ${#SOURCES[@]} -gt 0 ]] || die "no .sfn sources found"
+    if [[ $CAPSULE_DEP_COUNT -gt 0 ]]; then
+        log "found ${#SOURCES[@]} source modules (includes $CAPSULE_DEP_COUNT from capsule deps)"
+    else
+        log "found ${#SOURCES[@]} source modules"
+    fi
 fi
 
 # ---------------------------------------------------------------------------
@@ -711,21 +732,26 @@ if [[ "$BUILD_MODULE_WORKER" -eq 1 ]]; then
 fi
 
 # ---------------------------------------------------------------------------
-# Step 1: Prepare directories
+# Step 1: Prepare directories (parent only — workers must NOT wipe artifacts
+# concurrently with peer workers).
 # ---------------------------------------------------------------------------
-log "preparing build directories..."
-cd "$REPO_ROOT"
-mkdir -p "$RAW_DIR" "$OBJ_DIR" "$OBJ_DIR/runtime"
-mkdir -p "$SEED_CWD/build/native/import-context"
+if [[ "$IS_WORKER" -eq 0 ]]; then
+    log "preparing build directories..."
+    cd "$REPO_ROOT"
+    mkdir -p "$RAW_DIR" "$OBJ_DIR" "$OBJ_DIR/runtime"
+    mkdir -p "$SEED_CWD/build/native/import-context"
 
-# Clean stale artifacts from prior builds (Python selfhost leaves .attempt*.ll files)
-find "$RAW_DIR" -name '*.ll' -delete 2>/dev/null || true
-find "$OBJ_DIR" -name '*.o' -delete 2>/dev/null || true
+    # Clean stale artifacts from prior builds (Python selfhost leaves .attempt*.ll files)
+    find "$RAW_DIR" -name '*.ll' -delete 2>/dev/null || true
+    find "$OBJ_DIR" -name '*.o' -delete 2>/dev/null || true
+fi
 
 # ---------------------------------------------------------------------------
 # Step 2: Stage import-context artifacts
 # ---------------------------------------------------------------------------
-log "staging import-context artifacts..."
+if [[ "$IS_WORKER" -eq 0 ]]; then
+    log "staging import-context artifacts..."
+fi
 
 stage_import_context() {
     local src="$1"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -52,6 +52,8 @@ EMIT_RETRIES="${EMIT_RETRIES:-3}"
 BUILD_MODULE_WORKER=0
 WORKER_INDEX=""
 WORKER_SRC=""
+STAGE_IMPORT_WORKER=0
+STAGE_IMPORT_SRC=""
 
 # Build directories (overridable via --work-dir)
 WORK_DIR="${WORK_DIR:-build/selfhost/native}"
@@ -89,6 +91,11 @@ while [[ $# -gt 0 ]]; do
             WORKER_INDEX="$2"
             WORKER_SRC="$3"
             shift 3
+            ;;
+        --_stage_import_worker)
+            STAGE_IMPORT_WORKER=1
+            STAGE_IMPORT_SRC="$2"
+            shift 2
             ;;
         *)          echo "[build] unknown option: $1" >&2; exit 1 ;;
     esac
@@ -743,15 +750,42 @@ stage_import_context() {
     grep '^\.\(layout\)' "$asm_dest" > "$manifest_dest" 2>/dev/null || true
 }
 
-# Stage import context (sequential for safety with older seeds)
+# Worker entry for parallel staging (mirrors --_build_module_worker).
+# Each worker emits one module's .sfn-asm + .layout-manifest into $IMPORT_CACHE
+# at a unique slug-derived path; no shared scratch directory, so workers cannot
+# collide. seed_run applies the same ulimit + timeout as the main flow.
+if [[ "$STAGE_IMPORT_WORKER" -eq 1 ]]; then
+    mkdir -p "$IMPORT_CACHE"
+    stage_import_context "$STAGE_IMPORT_SRC"
+    exit 0
+fi
+
+# Stage import context. Parallelism uses the same JOBS knob as the per-module
+# emit loop. Each invocation writes to a distinct ${slug}.sfn-asm path, so the
+# parallel and serial paths produce byte-identical $IMPORT_CACHE contents.
+# Pre-0.5.9 seeds were not safe under parallel staging; the 0.5.9 seed is.
 T_IMPORT_START="$(date +%s)"
-for src in "${SOURCES[@]}"; do
-    check_budget
-    stage_import_context "$src"
-done
+if [[ "$JOBS" -le 1 ]]; then
+    for src in "${SOURCES[@]}"; do
+        check_budget
+        stage_import_context "$src"
+    done
+else
+    mkdir -p "$IMPORT_CACHE"
+    # xargs splits on whitespace, so source paths must be NUL-delimited.
+    # `-0 -L 1` ensures one src per worker invocation; `-P "$JOBS"` runs up
+    # to JOBS workers concurrently. A failed stage warns but does not abort
+    # (matches the serial path's `warn + return 0` behavior in
+    # stage_import_context, which leaves the asm_dest absent — the same
+    # downstream effect as the serial loop).
+    printf '%s\0' "${SOURCES[@]}" | xargs -0 -P "$JOBS" -L 1 bash -c '
+        cd "'"$REPO_ROOT"'"
+        bash scripts/build.sh --seed "'"$SEED"'" --work-dir "'"$WORK_DIR"'" --_stage_import_worker "$@"
+    ' _ 2>"$RAW_DIR/stage_import_errors.txt" || warn "one or more import-context stages reported errors (see $RAW_DIR/stage_import_errors.txt)"
+fi
 T_IMPORT_END="$(date +%s)"
 
-log "staged import-context for ${#SOURCES[@]} modules"
+log "staged import-context for ${#SOURCES[@]} modules (jobs=$JOBS)"
 
 # ---------------------------------------------------------------------------
 # Step 3: Per-module emit + compile

--- a/scripts/detect_build_jobs.sh
+++ b/scripts/detect_build_jobs.sh
@@ -55,6 +55,13 @@ case "$uname_s" in
         ;;
 esac
 
+# Global upper bound. Matches the [1, 8] contract documented in
+# docs/build-performance.md → Phase 6. Without this, a 32-core / 256 GB
+# workstation would emit 32 — well past the point of diminishing returns
+# for a 121-module build, and risks I/O contention plus llvm-link
+# memory pressure dominating wall-time.
+[ "$jobs" -gt 8 ] && jobs=8
+
 [ "$jobs" -lt 1 ] && jobs=1
 
 echo "$jobs"

--- a/scripts/detect_build_jobs.sh
+++ b/scripts/detect_build_jobs.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# detect_build_jobs.sh — Pick a sensible BUILD_JOBS default for the current host.
+#
+# Heuristic: min(nproc, total_ram_gb / 5). The 5 GB-per-job budget reflects the
+# heaviest module (`lowering_core`) peaking at ~4.7 GB RSS under the arena
+# allocator, plus ~300 MB headroom for staging temp files. macOS additionally
+# caps at 2 jobs because the GitHub `macos-latest` runner ships with 7 GB total
+# RAM (M1) — anything higher OOMs the heaviest module pair.
+#
+# Falls back to 1 on:
+#   - hosts where nproc / sysctl / /proc/meminfo are not readable
+#   - Windows (MSYS / Cygwin / Git Bash) — xargs -P parallelism is unreliable
+#     under the various Windows shell wrappers
+#
+# Override at the call site by exporting BUILD_JOBS=N before invoking make.
+# See docs/build-performance.md → Phase 6 for rationale.
+
+set -eu
+
+uname_s="$(uname -s 2>/dev/null || echo unknown)"
+cores=1
+mem_gb=0
+
+case "$uname_s" in
+    Linux*)
+        cores=$(nproc 2>/dev/null || getconf _NPROCESSORS_ONLN 2>/dev/null || echo 1)
+        mem_kb=$(awk '/^MemTotal:/ {print $2; exit}' /proc/meminfo 2>/dev/null || echo 0)
+        mem_gb=$((mem_kb / 1024 / 1024))
+        ;;
+    Darwin*)
+        cores=$(sysctl -n hw.ncpu 2>/dev/null || echo 1)
+        mem_b=$(sysctl -n hw.memsize 2>/dev/null || echo 0)
+        mem_gb=$((mem_b / 1024 / 1024 / 1024))
+        ;;
+esac
+
+# Sanitize: a non-numeric or zero result falls back to safe defaults.
+[ "$cores" -gt 0 ] 2>/dev/null || cores=1
+[ "$mem_gb" -gt 0 ] 2>/dev/null || mem_gb=4
+
+# Apply the per-job memory budget.
+by_mem=$((mem_gb / 5))
+[ "$by_mem" -lt 1 ] && by_mem=1
+
+jobs=$cores
+[ "$by_mem" -lt "$jobs" ] && jobs=$by_mem
+
+# Per-platform ceilings.
+case "$uname_s" in
+    Darwin*)
+        [ "$jobs" -gt 2 ] && jobs=2
+        ;;
+    MINGW*|MSYS*|CYGWIN*)
+        jobs=1
+        ;;
+esac
+
+[ "$jobs" -lt 1 ] && jobs=1
+
+echo "$jobs"

--- a/site/src/content/docs/docs/reference/cli.md
+++ b/site/src/content/docs/docs/reference/cli.md
@@ -415,7 +415,7 @@ The build orchestrator compiles modules in parallel. Control the job count:
 make rebuild BUILD_JOBS=4
 ```
 
-The default is `BUILD_JOBS=1` to keep peak memory usage conservative. Increase on machines with abundant RAM.
+The default is auto-detected from the host's CPU count and total RAM (`scripts/detect_build_jobs.sh`): roughly `min(nproc, total_ram_gb / 5)` clamped to `[1, 8]`, with a macOS cap of 2 because Apple Silicon GitHub runners only ship 7 GB of RAM. Set `BUILD_JOBS=N` explicitly to override. Set `BUILD_JOBS=1` to disable parallelism (useful for regression bisects). See `docs/build-performance.md` → Phase 6 for the rationale behind the per-job memory budget.
 
 ---
 


### PR DESCRIPTION
0.5.9 is the first release with no file-based data-flow IPC. Update
docs/build-performance.md to reflect that:

- Symptom Summary table refreshed with current numbers (fs.* calls
  212 / 24 files; dotfile refs 48 / 18 files; 0 active data-flow
  channels) and an April-11 / April-19 / April-24 progression
- New "Reassessed Roadmap (April 24)" section near the top giving
  shipped/pending status for every phase, with the remaining
  wall-time deltas
- Phase 2 marked complete; original framing kept for the historical
  record
- Phase 4 PR 2 noted as unblocked by PR #229's in-memory lowering
- New Phase 6 section: parallel builds, with a four-stage rollout
  plan (parallel staging, adaptive BUILD_JOBS, CI wiring, retry
  budget reduction). Stage 1 + Stage 2 land in this branch; Stages
  3-4 are queued.
- Appendix IPC census rewritten with the actual remaining surface
  (mostly CLI / capsule resolution); historical pre-0.5.9 numbers
  retained for the trail