### PR TITLE
perf(arena): wire SAILFIN_DUMP_ARENA_STATS env gate

### DIFF
--- a/.github/actions/sailfin-build/action.yml
+++ b/.github/actions/sailfin-build/action.yml
@@ -20,6 +20,10 @@ inputs:
     description: "Optional tag to exclude"
     required: false
     default: ""
+  build_jobs:
+    description: "Parallel module builds (BUILD_JOBS). Empty = let the Makefile auto-detect via scripts/detect_build_jobs.sh (CPU + RAM heuristic; macOS capped at 2). Set to a specific N to pin (e.g. for a regression bisect)."
+    required: false
+    default: ""
 runs:
   using: "composite"
   steps:
@@ -45,9 +49,16 @@ runs:
         GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
       run: |
         set -euo pipefail
+        # Forward build_jobs only when explicitly set; an empty value means
+        # "let the Makefile auto-detect" (scripts/detect_build_jobs.sh).
+        BUILD_JOBS_ARG=()
+        if [ -n "${{ inputs.build_jobs }}" ]; then
+          BUILD_JOBS_ARG=("BUILD_JOBS=${{ inputs.build_jobs }}")
+        fi
         make rebuild \
           CLANG="${{ inputs.clang }}" \
-          SEED_NATIVE="build/seed/bin/sailfin"
+          SEED_NATIVE="build/seed/bin/sailfin" \
+          "${BUILD_JOBS_ARG[@]}"
 
     - name: Prepare test artifacts
       shell: bash {0}

--- a/.github/actions/sailfin-build/action.yml
+++ b/.github/actions/sailfin-build/action.yml
@@ -51,14 +51,19 @@ runs:
         set -euo pipefail
         # Forward build_jobs only when explicitly set; an empty value means
         # "let the Makefile auto-detect" (scripts/detect_build_jobs.sh).
-        BUILD_JOBS_ARG=()
+        # The if/else split avoids bash 3.2's "${arr[@]}" empty-array
+        # unbound-variable error under set -u (macOS still ships /bin/bash
+        # 3.2 by default).
         if [ -n "${{ inputs.build_jobs }}" ]; then
-          BUILD_JOBS_ARG=("BUILD_JOBS=${{ inputs.build_jobs }}")
+          make rebuild \
+            CLANG="${{ inputs.clang }}" \
+            SEED_NATIVE="build/seed/bin/sailfin" \
+            BUILD_JOBS="${{ inputs.build_jobs }}"
+        else
+          make rebuild \
+            CLANG="${{ inputs.clang }}" \
+            SEED_NATIVE="build/seed/bin/sailfin"
         fi
-        make rebuild \
-          CLANG="${{ inputs.clang }}" \
-          SEED_NATIVE="build/seed/bin/sailfin" \
-          "${BUILD_JOBS_ARG[@]}"
 
     - name: Prepare test artifacts
       shell: bash {0}

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,14 @@ CLANG ?= clang
 # CI may override this to speed up builds.
 NATIVE_OPT ?= -O2
 
+# Optimization level for `make check`'s first-pass binary. The first-pass
+# binary only has to be correct enough to compile itself one more time; it is
+# never shipped, so the clang -O2 cost on its 121-module .ll → .o stage is
+# pure waste in the validation flow. Seedcheck and stage3 keep $(NATIVE_OPT)
+# because *they* are the ones that have to byte-fixed-point against each
+# other. See docs/build-performance.md → Phase 6 follow-ups.
+SELFHOST1_OPT ?= -O0
+
 # Extra flags used when compiling LLVM IR (.ll) with clang.
 # Some distros ship clang builds that default to typed pointers, but the native
 # compiler emits
@@ -352,7 +360,7 @@ compile:
 	fi
 
 check:
-	@$(MAKE) compile
+	@$(MAKE) compile NATIVE_OPT="$(SELFHOST1_OPT)"
 	@seed="build/native/sailfin"; \
 	if [ ! -x "$$seed" ]; then \
 		echo "[check][error] missing $$seed (run: make compile)"; \
@@ -411,6 +419,15 @@ check:
 			fi; \
 		done; \
 		echo "[check][WARN] this may indicate intermittent IR corruption — rerun or investigate"; \
+	fi
+	@# Promote the fully-validated, $(NATIVE_OPT)-built seedcheck binary back
+	@# over the canonical $(NATIVE_BIN) path. The first-pass binary is built
+	@# with $(SELFHOST1_OPT) (default -O0) for speed; without this promotion
+	@# step a subsequent `make compile` would see a stale -O0 binary as
+	@# "up-to-date" and skip the rebuild.
+	@if [ -x "build/native/sailfin-seedcheck" ]; then \
+		cp -f "build/native/sailfin-seedcheck" "build/native/sailfin"; \
+		echo "[check] promoted seedcheck → $(NATIVE_BIN)"; \
 	fi
 
 # Pre-release determinism gate. Runs the emit harness at parallel load to

--- a/Makefile
+++ b/Makefile
@@ -425,8 +425,8 @@ check:
 	@# with $(SELFHOST1_OPT) (default -O0) for speed; without this promotion
 	@# step a subsequent `make compile` would see a stale -O0 binary as
 	@# "up-to-date" and skip the rebuild.
-	@if [ -x "build/native/sailfin-seedcheck" ]; then \
-		cp -f "build/native/sailfin-seedcheck" "build/native/sailfin"; \
+	@if [ -x "build/native/sailfin-seedcheck$(EXE_EXT)" ]; then \
+		cp -f "build/native/sailfin-seedcheck$(EXE_EXT)" "$(NATIVE_BIN)"; \
 		echo "[check] promoted seedcheck → $(NATIVE_BIN)"; \
 	fi
 

--- a/compiler/src/llvm/lowering/entrypoints.sfn
+++ b/compiler/src/llvm/lowering/entrypoints.sfn
@@ -99,7 +99,6 @@ import {
 } from "../utils";
 import { emit_llvm_function } from "./emission";
 import {
-    build_parse_result_from_text,
     compile_native_text_to_llvm_file,
     lower_to_llvm_lines_with_parsed_context,
     lower_to_llvm_lines_with_parsed_context_for_tests
@@ -246,20 +245,13 @@ fn lower_to_llvm_ir_from_text(native_text: string, module_name: string) -> strin
 }
 
 // Lower native text to LLVM IR and print it line-by-line to stdout.
-// Returns true on success. Two important differences vs
-// `lower_to_llvm_ir_from_text`:
-//   1. Uses `build_parse_result_from_text` (recovery parser) instead of
-//      `parse_native_artifact` — the structured parser segfaults on
-//      specific large modules (e.g. `compiler/src/native_ir_api.sfn`)
-//      due to a latent aggregate-load bug in the first-pass binary.
-//      The recovery parser takes a simpler line-scan path that isn't
-//      affected.
-//   2. Prints lines directly rather than joining into one huge string
-//      and returning it — avoids `_join_llvm_lines_linear` memory
-//      amplification for very large LLVM outputs.
+// Returns true on success. Unlike `lower_to_llvm_ir_from_text`, this prints
+// lines directly rather than joining into one huge string and returning it —
+// avoids `_join_llvm_lines_linear` memory amplification for very large LLVM
+// outputs.
 fn print_llvm_ir_from_text(native_text: string, module_name: string) -> boolean ![io] {
     if native_text.length == 0 { return false; }
-    let parse = build_parse_result_from_text(native_text);
+    let parse = parse_native_artifact(native_text);
     let import_context = collect_imported_module_context_for_module(parse.imports, module_name);
     let dummy_module = NativeModule {
         module_name: module_name,
@@ -322,10 +314,10 @@ fn write_llvm_ir(native_module: NativeModule, out_path: string) -> boolean ![io]
 }
 
 // Build and write LLVM IR from raw native text, avoiding large string returns.
-// Uses the recovery parser (build_parse_result_from_text) via
-// `compile_native_text_to_llvm_file` to sidestep the structured-parser ABI
-// issue the first-pass binary built from the 0.5.7 seed hits on this path
-// (see docs/proposals/phase-4-eliminate-light-recovery.md).
+// Delegates to `compile_native_text_to_llvm_file`, which now routes through
+// the structured `parse_native_artifact` parser (Phase 4 PR 2 — seed 0.5.9
+// + PR #229's in-memory lowering cleared the cross-module struct-return ABI
+// bug that had forced the 0.5.7-era recovery-parser fallback).
 fn write_llvm_ir_from_native_text(native_text: string, module_name: string, out_path: string) -> boolean ![io] {
     return compile_native_text_to_llvm_file(native_text, module_name, out_path);
 }

--- a/compiler/src/llvm/lowering/entrypoints_tests_writer.sfn
+++ b/compiler/src/llvm/lowering/entrypoints_tests_writer.sfn
@@ -15,6 +15,7 @@ import {
     ParseNativeResult
 } from "../../native_ir";
 import {
+    parse_native_artifact,
     parse_native_enums_for_import,
     parse_native_functions_for_import,
     parse_native_interfaces_for_import,
@@ -72,10 +73,7 @@ import {
     string_array_contains
 } from "../utils";
 import { emit_llvm_function } from "./emission";
-import {
-    build_parse_result_from_text,
-    lower_to_llvm_lines_with_parsed_context_for_tests
-} from "./lowering_core";
+import { lower_to_llvm_lines_with_parsed_context_for_tests } from "./lowering_core";
 import { render_test_harness_main_for_module } from "./lowering_helpers";
 import {
     empty_trait_metadata,
@@ -117,15 +115,12 @@ fn write_llvm_ir_for_tests_from_text(native_text: string, module_name: string, o
         print.err("test llvm: empty native text");
         return false;
     }
-    // Use the recovery parser (build_parse_result_from_text) instead of the
-    // structured parser (parse_native_artifact).  The recovery parser
-    // creates ALL instructions as Expression(tag→21) with parseable text,
-    // which the tag-21 fallback handler in the instruction lowerer can
-    // dispatch correctly.  The structured parser creates typed variants
-    // (Let, Return, If) that the seedcheck's get_instruction_tag cannot
-    // distinguish (always returns 21) and whose payload fields are not
-    // accessible via the generic .expression accessor.
-    let parse = build_parse_result_from_text(native_text);
+    // Structured parser (Phase 4 PR 2). The 0.5.9 seed + PR #229's in-memory
+    // lowering handle typed-instruction variants (Let, Return, If, …)
+    // correctly across module boundaries, so the prior recovery-parser
+    // fallback (which flattened every instruction to Expression(tag→21)) is
+    // no longer needed.
+    let parse = parse_native_artifact(native_text);
     let dummy_module = NativeModule {
         module_name: module_name,
         artifacts: [NativeArtifact {

--- a/compiler/src/llvm/lowering/lowering_core.sfn
+++ b/compiler/src/llvm/lowering/lowering_core.sfn
@@ -112,36 +112,9 @@ import {
     sanitize_structs
 } from "./lowering_phase_sanitize";
 import { build_type_context_with_recovery } from "./lowering_phase_types";
-import {
-    recover_functions_for_lowering,
-    recover_native_enums_light,
-    recover_native_functions_light,
-    recover_native_imports_light,
-    recover_native_structs_light
-} from "./lowering_recovery";
+import { recover_functions_for_lowering } from "./lowering_recovery";
 import { _parse_lowered_fn_string_constants, split_lines_local } from "./lowering_text_utils";
 import { lower_module_bindings_to_globals } from "./module_globals";
-
-// Consolidated: parse all structure from native text using light recovery.
-// Retained for `write_llvm_ir_for_tests_from_text`; see PR 2 gating in
-// `docs/proposals/phase-4-eliminate-light-recovery.md` §2.2. The primary
-// non-test build path (`compile_native_text_to_llvm_file`) now calls
-// `parse_native_artifact` directly.
-fn build_parse_result_from_text(native_text: string) -> ParseNativeResult {
-    let recovered_functions = recover_native_functions_light(native_text);
-    let recovered_structs = recover_native_structs_light(native_text);
-    let recovered_imports = recover_native_imports_light(native_text);
-    let recovered_enums = recover_native_enums_light(native_text);
-    return ParseNativeResult {
-        functions: recovered_functions,
-        imports: recovered_imports,
-        structs: recovered_structs,
-        interfaces: [],
-        enums: recovered_enums,
-        bindings: [],
-        diagnostics: []
-    };
-}
 
 fn lower_to_llvm_lines_with_parsed_context_for_tests(native_module: NativeModule, parse: ParseNativeResult, imported_manifests: LayoutManifest[], imported_native_texts: string[], imported_diagnostics: string[]) -> LoweredLLVMLinesResult {
     let mut native_text_for_recovery: string = "";
@@ -264,7 +237,7 @@ fn compile_native_text_to_llvm_file(native_text: string, module_name: string, ou
         print.err("emit-llvm: empty native text for module " + module_name);
         return false;
     }
-    let parse = build_parse_result_from_text(native_text);
+    let parse = parse_native_artifact(native_text);
     let import_context = collect_imported_module_context_for_module(parse.imports, module_name);
     let dummy_module = make_native_module_for_emit(module_name, native_text);
     let lowered_lines = lower_to_llvm_lines_with_parsed_context(dummy_module, parse, import_context.manifests, import_context.native_texts, import_context.diagnostics, true, native_text);

--- a/compiler/src/llvm/lowering/lowering_core.sfn
+++ b/compiler/src/llvm/lowering/lowering_core.sfn
@@ -55,11 +55,7 @@ import {
     TraitMetadata,
     TypeContext
 } from "../types";
-import {
-    index_of,
-    number_to_string,
-    sanitize_symbol
-} from "../utils";
+import { index_of, number_to_string, sanitize_symbol } from "../utils";
 import {
     collect_defined_function_symbols,
     extend_native_enums,

--- a/compiler/src/llvm/lowering/lowering_core.sfn
+++ b/compiler/src/llvm/lowering/lowering_core.sfn
@@ -30,10 +30,8 @@ import {
 import {
     parse_native_artifact,
     parse_native_bindings_from_text,
-    parse_native_enums_for_import,
     parse_native_function_count_from_text,
-    parse_native_functions_from_text,
-    parse_native_structs_for_import
+    parse_native_functions_from_text
 } from "../../native_ir_api";
 import { substring } from "../../string_utils";
 import {
@@ -67,7 +65,6 @@ import {
 import {
     collect_defined_function_symbols,
     extend_native_enums,
-    extend_native_functions,
     extend_native_interfaces,
     extend_native_structs,
     is_test_module_slug,
@@ -89,11 +86,7 @@ import {
     write_llvm_lines_chunked
 } from "./lowering_io";
 import { lower_all_functions } from "./lowering_phase_functions";
-import {
-    extract_import_struct_methods,
-    parse_single_import_functions,
-    parse_single_import_interfaces
-} from "./lowering_phase_imports";
+import { gather_imported_module_symbols } from "./lowering_phase_imports";
 import { render_llvm_preamble } from "./lowering_phase_render";
 // Phase modules
 import {
@@ -377,59 +370,16 @@ fn lower_to_llvm_lines_with_parsed_context(native_module: NativeModule, parse_in
         print.err("test llvm: phase=manifest ms=" + number_to_string(monotonic_millis() - start_ms));
     }
 
-    let mut imported_structs: NativeStruct[] = [];
-    let mut imported_enums: NativeEnum[] = [];
-    let mut imported_interfaces: NativeInterface[] = [];
-    let mut imported_functions: NativeFunction[] = [];
-    let mut imported_struct_methods: NativeFunction[] = [];
-
-    let manifest_count = safe_imported_manifests.length;
-    let mut text_index: number = 0;
-    loop {
-        if text_index >= safe_imported_native_texts.length { break; }
-        let native_text = safe_imported_native_texts[text_index];
-        let mut manifest_for_module: LayoutManifest? = null;
-        if text_index < manifest_count {
-            manifest_for_module = safe_imported_manifests[text_index];
-        }
-        if native_text.length == 0 {
-            if manifest_for_module != null {
-                let manifest_only = manifest_for_module;
-                imported_structs = extend_native_structs(imported_structs, manifest_only.structs);
-                imported_enums = extend_native_enums(imported_enums, manifest_only.enums);
-            }
-            text_index += 1;
-            continue;
-        }
-        // Single-pass: parse structs+enums once, apply manifest once
-        let imported_structs_safe = parse_native_structs_for_import(native_text);
-        let imported_enums_safe = parse_native_enums_for_import(native_text);
-        let applied_import = apply_layout_manifest_to_module(imported_structs_safe, imported_enums_safe, manifest_for_module);
-        let mut applied_structs = applied_import.structs;
-        if applied_structs == null { applied_structs = []; }
-        let mut applied_enums = applied_import.enums;
-        if applied_enums == null { applied_enums = []; }
-        let applied_interfaces = parse_single_import_interfaces(native_text);
-        let applied_functions = parse_single_import_functions(native_text);
-        imported_structs = extend_native_structs(imported_structs, applied_structs);
-        imported_enums = extend_native_enums(imported_enums, applied_enums);
-        imported_interfaces = extend_native_interfaces(imported_interfaces, applied_interfaces);
-        imported_functions = extend_native_functions(imported_functions, applied_functions);
-        let imported_methods = extract_import_struct_methods(applied_structs);
-        imported_struct_methods = extend_native_functions(imported_struct_methods, imported_methods);
-        text_index += 1;
-    }
-
-    if safe_imported_native_texts.length < manifest_count {
-        let mut manifest_index: number = safe_imported_native_texts.length;
-        loop {
-            if manifest_index >= manifest_count { break; }
-            let leftover_manifest = safe_imported_manifests[manifest_index];
-            imported_structs = extend_native_structs(imported_structs, leftover_manifest.structs);
-            imported_enums = extend_native_enums(imported_enums, leftover_manifest.enums);
-            manifest_index += 1;
-        }
-    }
+    // Phase 2 body extracted to lowering_phase_imports.sfn::gather_imported_module_symbols.
+    // Immediate destructure into locals matches the PR #229 "same-module
+    // destructure before downstream use" pattern that closed the April 21
+    // ParseNativeResult cross-module ABI SEGV.
+    let imported_syms = gather_imported_module_symbols(safe_imported_native_texts, safe_imported_manifests);
+    let imported_structs = imported_syms.structs;
+    let imported_enums = imported_syms.enums;
+    let imported_interfaces = imported_syms.interfaces;
+    let imported_functions = imported_syms.functions;
+    let imported_struct_methods = imported_syms.struct_methods;
 
     if debug_lowering { print.err("emit-llvm: phase=imports"); }
 

--- a/compiler/src/llvm/lowering/lowering_core.sfn
+++ b/compiler/src/llvm/lowering/lowering_core.sfn
@@ -35,7 +35,6 @@ import {
 } from "../../native_ir_api";
 import { substring } from "../../string_utils";
 import {
-    append_unique_effect,
     collect_direct_function_effects,
     collect_function_call_graph,
     collect_runtime_helper_targets,
@@ -59,8 +58,7 @@ import {
 import {
     index_of,
     number_to_string,
-    sanitize_symbol,
-    string_array_contains
+    sanitize_symbol
 } from "../utils";
 import {
     collect_defined_function_symbols,
@@ -68,7 +66,8 @@ import {
     extend_native_interfaces,
     extend_native_structs,
     is_test_module_slug,
-    render_test_harness_main_for_module
+    render_test_harness_main_for_module,
+    seed_default_runtime_helpers
 } from "./lowering_helpers";
 import {
     apply_module_symbol_mangling,
@@ -444,88 +443,7 @@ fn lower_to_llvm_lines_with_parsed_context(native_module: NativeModule, parse_in
     } else if trace {
         print.err("test llvm: skipping runtime helper collection for inlined tests");
     }
-    if !string_array_contains(runtime_helpers, "copy_bytes") {
-        runtime_helpers.push("copy_bytes");
-    }
-    if !string_array_contains(runtime_helpers, "array_push_slot") {
-        runtime_helpers.push("array_push_slot");
-    }
-    if !string_array_contains(runtime_helpers, "append_string") {
-        runtime_helpers.push("append_string");
-    }
-    runtime_helpers = append_unique_effect(runtime_helpers, "get_field");
-    runtime_helpers = append_unique_effect(runtime_helpers, "concat");
-    runtime_helpers = append_unique_effect(runtime_helpers, "print");
-    runtime_helpers = append_unique_effect(runtime_helpers, "print.err");
-    runtime_helpers = append_unique_effect(runtime_helpers, "print.info");
-    runtime_helpers = append_unique_effect(runtime_helpers, "print.warn");
-    runtime_helpers = append_unique_effect(runtime_helpers, "print.error");
-    runtime_helpers = append_unique_effect(runtime_helpers, "string.length");
-    runtime_helpers = append_unique_effect(runtime_helpers, "substring");
-    runtime_helpers = append_unique_effect(runtime_helpers, "substring_unchecked");
-    runtime_helpers = append_unique_effect(runtime_helpers, "string.concat");
-    runtime_helpers = append_unique_effect(runtime_helpers, "string.append");
-    runtime_helpers = append_unique_effect(runtime_helpers, "string.to_number");
-    runtime_helpers = append_unique_effect(runtime_helpers, "grapheme_at");
-    runtime_helpers = append_unique_effect(runtime_helpers, "number.to_string");
-    runtime_helpers = append_unique_effect(runtime_helpers, "number_to_string");
-    runtime_helpers = append_unique_effect(runtime_helpers, "strings_equal");
-    runtime_helpers = append_unique_effect(runtime_helpers, "char_code");
-    runtime_helpers = append_unique_effect(runtime_helpers, "runtime_raise_value_error_fn");
-    runtime_helpers = append_unique_effect(runtime_helpers, "runtime.bounds_check");
-    runtime_helpers = append_unique_effect(runtime_helpers, "mark_persistent");
-    // Runtime prelude helpers — these are module-level let bindings
-    // (e.g. `let runtime_array_filter_fn = runtime.array_filter;`) whose
-    // call targets are not discovered by the (currently skipped) dynamic
-    // helper collection.  Declare them unconditionally so the linker can
-    // resolve them against the C runtime.
-    runtime_helpers = append_unique_effect(runtime_helpers, "runtime_array_map_fn");
-    runtime_helpers = append_unique_effect(runtime_helpers, "runtime_array_filter_fn");
-    runtime_helpers = append_unique_effect(runtime_helpers, "runtime_array_reduce_fn");
-    runtime_helpers = append_unique_effect(runtime_helpers, "runtime_channel_fn");
-    runtime_helpers = append_unique_effect(runtime_helpers, "runtime_char_code_fn");
-    runtime_helpers = append_unique_effect(runtime_helpers, "runtime_grapheme_at_fn");
-    runtime_helpers = append_unique_effect(runtime_helpers, "runtime_grapheme_count_fn");
-    runtime_helpers = append_unique_effect(runtime_helpers, "runtime_instance_of_fn");
-    runtime_helpers = append_unique_effect(runtime_helpers, "runtime_is_array_fn");
-    runtime_helpers = append_unique_effect(runtime_helpers, "runtime_is_boolean_fn");
-    runtime_helpers = append_unique_effect(runtime_helpers, "runtime_is_callable_fn");
-    runtime_helpers = append_unique_effect(runtime_helpers, "runtime_is_number_fn");
-    runtime_helpers = append_unique_effect(runtime_helpers, "runtime_is_string_fn");
-    runtime_helpers = append_unique_effect(runtime_helpers, "runtime_is_void_fn");
-    runtime_helpers = append_unique_effect(runtime_helpers, "runtime_log_execution_fn");
-    runtime_helpers = append_unique_effect(runtime_helpers, "runtime_monotonic_millis_fn");
-    runtime_helpers = append_unique_effect(runtime_helpers, "runtime_parallel_fn");
-    runtime_helpers = append_unique_effect(runtime_helpers, "runtime_resolve_runtime_type_fn");
-    runtime_helpers = append_unique_effect(runtime_helpers, "runtime_serve_fn");
-    runtime_helpers = append_unique_effect(runtime_helpers, "runtime_sleep_fn");
-    runtime_helpers = append_unique_effect(runtime_helpers, "runtime_spawn_fn");
-    runtime_helpers = append_unique_effect(runtime_helpers, "runtime_to_debug_string_fn");
-    runtime_helpers = append_unique_effect(runtime_helpers, "runtime_create_capability_grant");
-    runtime_helpers = append_unique_effect(runtime_helpers, "runtime_create_filesystem_bridge");
-    runtime_helpers = append_unique_effect(runtime_helpers, "runtime_create_http_bridge");
-    // Filesystem adapters — the compiler emits direct calls to these C
-    // runtime symbols from modules that use fs.readFile, fs.exists, etc.
-    // Without unconditional declares, separate-compilation produces
-    // "use of undefined value" errors at clang time.
-    runtime_helpers = append_unique_effect(runtime_helpers, "fs.readFile");
-    runtime_helpers = append_unique_effect(runtime_helpers, "fs.read");
-    runtime_helpers = append_unique_effect(runtime_helpers, "fs.writeFile");
-    runtime_helpers = append_unique_effect(runtime_helpers, "fs.write");
-    runtime_helpers = append_unique_effect(runtime_helpers, "fs.appendFile");
-    runtime_helpers = append_unique_effect(runtime_helpers, "fs.exists");
-    runtime_helpers = append_unique_effect(runtime_helpers, "fs.deleteFile");
-    runtime_helpers = append_unique_effect(runtime_helpers, "fs.listDirectory");
-    runtime_helpers = append_unique_effect(runtime_helpers, "fs.writeLines");
-    runtime_helpers = append_unique_effect(runtime_helpers, "fs.createDirectory");
-    runtime_helpers = append_unique_effect(runtime_helpers, "fs.read_bytes");
-    // Additional helpers used by the compiler but not auto-collected
-    runtime_helpers = append_unique_effect(runtime_helpers, "monotonic_millis");
-    runtime_helpers = append_unique_effect(runtime_helpers, "find_char");
-    runtime_helpers = append_unique_effect(runtime_helpers, "string_starts_with");
-    runtime_helpers = append_unique_effect(runtime_helpers, "process.run");
-    runtime_helpers = append_unique_effect(runtime_helpers, "process.exit");
-    runtime_helpers = append_unique_effect(runtime_helpers, "is_decimal_digit");
+    runtime_helpers = seed_default_runtime_helpers(runtime_helpers);
     let mut direct_effects: FunctionEffectEntry[] = [];
     let mut aggregated_effects: FunctionEffectEntry[] = [];
     if !skip_effects {

--- a/compiler/src/llvm/lowering/lowering_helpers.sfn
+++ b/compiler/src/llvm/lowering/lowering_helpers.sfn
@@ -28,8 +28,8 @@ import {
 } from "../../native_ir_api";
 import { split_lines } from "../../native_ir_utils_text";
 import { char_code, substring } from "../../string_utils";
-import { resolve_import_artifact_slug, resolve_import_module_slug_for_module } from "../imports";
 import { append_unique_effect } from "../effects";
+import { resolve_import_artifact_slug, resolve_import_module_slug_for_module } from "../imports";
 import { find_function_by_name, should_internalize_function } from "../rendering";
 import {
     CapabilityManifest,

--- a/compiler/src/llvm/lowering/lowering_helpers.sfn
+++ b/compiler/src/llvm/lowering/lowering_helpers.sfn
@@ -29,6 +29,7 @@ import {
 import { split_lines } from "../../native_ir_utils_text";
 import { char_code, substring } from "../../string_utils";
 import { resolve_import_artifact_slug, resolve_import_module_slug_for_module } from "../imports";
+import { append_unique_effect } from "../effects";
 import { find_function_by_name, should_internalize_function } from "../rendering";
 import {
     CapabilityManifest,
@@ -801,4 +802,95 @@ fn insert_before_llvm_footer(lines: string[], inserted: string[]) -> string[] {
         }
     }
     return out;
+}
+
+// Seed an accumulator with the default set of runtime-helper targets the
+// compiler must always declare.  Extracted from lowering_core.sfn's
+// orchestrator to shrink the orchestrator's function body (was 80+
+// sequential append_unique_effect calls).  Preserves source order — the
+// seed emits declarations in this order, and rendering_helpers downstream
+// depends on stable ordering for byte-identical IR across builds.  Each
+// entry is deduped via append_unique_effect, so passing a pre-populated
+// initial list (e.g. from collect_runtime_helper_targets) only appends
+// entries not already present.
+fn seed_default_runtime_helpers(initial: string[]) -> string[] {
+    let mut helpers = initial;
+    // Core string / memory / collection helpers
+    helpers = append_unique_effect(helpers, "copy_bytes");
+    helpers = append_unique_effect(helpers, "array_push_slot");
+    helpers = append_unique_effect(helpers, "append_string");
+    helpers = append_unique_effect(helpers, "get_field");
+    helpers = append_unique_effect(helpers, "concat");
+    helpers = append_unique_effect(helpers, "print");
+    helpers = append_unique_effect(helpers, "print.err");
+    helpers = append_unique_effect(helpers, "print.info");
+    helpers = append_unique_effect(helpers, "print.warn");
+    helpers = append_unique_effect(helpers, "print.error");
+    helpers = append_unique_effect(helpers, "string.length");
+    helpers = append_unique_effect(helpers, "substring");
+    helpers = append_unique_effect(helpers, "substring_unchecked");
+    helpers = append_unique_effect(helpers, "string.concat");
+    helpers = append_unique_effect(helpers, "string.append");
+    helpers = append_unique_effect(helpers, "string.to_number");
+    helpers = append_unique_effect(helpers, "grapheme_at");
+    helpers = append_unique_effect(helpers, "number.to_string");
+    helpers = append_unique_effect(helpers, "number_to_string");
+    helpers = append_unique_effect(helpers, "strings_equal");
+    helpers = append_unique_effect(helpers, "char_code");
+    helpers = append_unique_effect(helpers, "runtime_raise_value_error_fn");
+    helpers = append_unique_effect(helpers, "runtime.bounds_check");
+    helpers = append_unique_effect(helpers, "mark_persistent");
+    // Runtime prelude helpers — module-level let bindings
+    // (e.g. `let runtime_array_filter_fn = runtime.array_filter;`) whose
+    // call targets are not discovered by the (currently skipped) dynamic
+    // helper collection.  Declare them unconditionally so the linker can
+    // resolve them against the C runtime.
+    helpers = append_unique_effect(helpers, "runtime_array_map_fn");
+    helpers = append_unique_effect(helpers, "runtime_array_filter_fn");
+    helpers = append_unique_effect(helpers, "runtime_array_reduce_fn");
+    helpers = append_unique_effect(helpers, "runtime_channel_fn");
+    helpers = append_unique_effect(helpers, "runtime_char_code_fn");
+    helpers = append_unique_effect(helpers, "runtime_grapheme_at_fn");
+    helpers = append_unique_effect(helpers, "runtime_grapheme_count_fn");
+    helpers = append_unique_effect(helpers, "runtime_instance_of_fn");
+    helpers = append_unique_effect(helpers, "runtime_is_array_fn");
+    helpers = append_unique_effect(helpers, "runtime_is_boolean_fn");
+    helpers = append_unique_effect(helpers, "runtime_is_callable_fn");
+    helpers = append_unique_effect(helpers, "runtime_is_number_fn");
+    helpers = append_unique_effect(helpers, "runtime_is_string_fn");
+    helpers = append_unique_effect(helpers, "runtime_is_void_fn");
+    helpers = append_unique_effect(helpers, "runtime_log_execution_fn");
+    helpers = append_unique_effect(helpers, "runtime_monotonic_millis_fn");
+    helpers = append_unique_effect(helpers, "runtime_parallel_fn");
+    helpers = append_unique_effect(helpers, "runtime_resolve_runtime_type_fn");
+    helpers = append_unique_effect(helpers, "runtime_serve_fn");
+    helpers = append_unique_effect(helpers, "runtime_sleep_fn");
+    helpers = append_unique_effect(helpers, "runtime_spawn_fn");
+    helpers = append_unique_effect(helpers, "runtime_to_debug_string_fn");
+    helpers = append_unique_effect(helpers, "runtime_create_capability_grant");
+    helpers = append_unique_effect(helpers, "runtime_create_filesystem_bridge");
+    helpers = append_unique_effect(helpers, "runtime_create_http_bridge");
+    // Filesystem adapters — compiler emits direct calls to these C runtime
+    // symbols from modules that use fs.readFile, fs.exists, etc. Without
+    // unconditional declares, separate-compilation produces "use of
+    // undefined value" errors at clang time.
+    helpers = append_unique_effect(helpers, "fs.readFile");
+    helpers = append_unique_effect(helpers, "fs.read");
+    helpers = append_unique_effect(helpers, "fs.writeFile");
+    helpers = append_unique_effect(helpers, "fs.write");
+    helpers = append_unique_effect(helpers, "fs.appendFile");
+    helpers = append_unique_effect(helpers, "fs.exists");
+    helpers = append_unique_effect(helpers, "fs.deleteFile");
+    helpers = append_unique_effect(helpers, "fs.listDirectory");
+    helpers = append_unique_effect(helpers, "fs.writeLines");
+    helpers = append_unique_effect(helpers, "fs.createDirectory");
+    helpers = append_unique_effect(helpers, "fs.read_bytes");
+    // Additional helpers used by the compiler but not auto-collected
+    helpers = append_unique_effect(helpers, "monotonic_millis");
+    helpers = append_unique_effect(helpers, "find_char");
+    helpers = append_unique_effect(helpers, "string_starts_with");
+    helpers = append_unique_effect(helpers, "process.run");
+    helpers = append_unique_effect(helpers, "process.exit");
+    helpers = append_unique_effect(helpers, "is_decimal_digit");
+    return helpers;
 }

--- a/compiler/src/llvm/lowering/lowering_phase_imports.sfn
+++ b/compiler/src/llvm/lowering/lowering_phase_imports.sfn
@@ -1,17 +1,46 @@
 // compiler/src/llvm/lowering/lowering_phase_imports.sfn
 //
-// Phase 2 of LLVM lowering: helpers for imported module context.
+// Phase 2 of LLVM lowering: imported-module context gathering.
 //
-// Extracted from lowering_core.sfn to reduce per-file memory footprint.
-// The main import gathering loop lives in lowering_core.sfn (orchestrator)
-// to avoid duplicate parsing.  This module provides thin wrappers used
-// by the orchestrator for individual parse operations.
-import { NativeFunction, NativeInterface, NativeStruct } from "../../native_ir";
+// Extracted from lowering_core.sfn to reduce its per-module compile peak
+// RSS — moving the gather loop here removes ~6 sibling-module imports
+// (parse_native_*_for_import, apply_layout_manifest_to_module,
+// extend_native_functions) from the orchestrator's import set.
 import {
+    LayoutManifest,
+    NativeEnum,
+    NativeFunction,
+    NativeInterface,
+    NativeStruct
+} from "../../native_ir";
+import {
+    parse_native_enums_for_import,
     parse_native_functions_for_import,
-    parse_native_interfaces_for_import
+    parse_native_interfaces_for_import,
+    parse_native_structs_for_import
 } from "../../native_ir_api";
+import { apply_layout_manifest_to_module } from "../imports";
+import {
+    extend_native_enums,
+    extend_native_functions,
+    extend_native_interfaces,
+    extend_native_structs
+} from "./lowering_helpers";
 import { flatten_struct_methods } from "./lowering_helpers_mangling";
+
+// Flat-array bundle of everything the imported modules contribute to the
+// compile — structs, enums, interfaces, functions, and struct methods.
+// Consumed once by lowering_core.sfn's orchestrator, which immediately
+// destructures into local variables.  Distinct from the unrelated
+// `ImportedModuleContext` in llvm/types.sfn (manifests/native_texts/
+// diagnostics); the two types serve different phases of the pipeline.
+struct ImportedModuleSymbols {
+    structs: NativeStruct[];
+    enums: NativeEnum[];
+    interfaces: NativeInterface[];
+    functions: NativeFunction[];
+    struct_methods: NativeFunction[];
+}
 
 // Parse imported interfaces from a single import text.
 fn parse_single_import_interfaces(native_text: string) -> NativeInterface[] {
@@ -26,4 +55,74 @@ fn parse_single_import_functions(native_text: string) -> NativeFunction[] {
 // Extract struct methods from applied structs.
 fn extract_import_struct_methods(applied_structs: NativeStruct[]) -> NativeFunction[] {
     return flatten_struct_methods(applied_structs);
+}
+
+// Gather the per-import contribution (structs/enums/interfaces/functions/
+// struct-methods) for the whole import list.  Pure code-move from
+// lowering_core.sfn's Phase 2 loop; semantics are byte-for-byte preserved,
+// including the intentional drop of apply_layout_manifest_to_module's
+// diagnostics field (the same-module call in lowering_core still captures
+// them for local manifest application).
+fn gather_imported_module_symbols(safe_imported_native_texts: string[], safe_imported_manifests: LayoutManifest[]) -> ImportedModuleSymbols {
+    let mut imported_structs: NativeStruct[] = [];
+    let mut imported_enums: NativeEnum[] = [];
+    let mut imported_interfaces: NativeInterface[] = [];
+    let mut imported_functions: NativeFunction[] = [];
+    let mut imported_struct_methods: NativeFunction[] = [];
+
+    let manifest_count = safe_imported_manifests.length;
+    let mut text_index: number = 0;
+    loop {
+        if text_index >= safe_imported_native_texts.length { break; }
+        let native_text = safe_imported_native_texts[text_index];
+        let mut manifest_for_module: LayoutManifest? = null;
+        if text_index < manifest_count {
+            manifest_for_module = safe_imported_manifests[text_index];
+        }
+        if native_text.length == 0 {
+            if manifest_for_module != null {
+                let manifest_only = manifest_for_module;
+                imported_structs = extend_native_structs(imported_structs, manifest_only.structs);
+                imported_enums = extend_native_enums(imported_enums, manifest_only.enums);
+            }
+            text_index += 1;
+            continue;
+        }
+        // Single-pass: parse structs+enums once, apply manifest once
+        let imported_structs_safe = parse_native_structs_for_import(native_text);
+        let imported_enums_safe = parse_native_enums_for_import(native_text);
+        let applied_import = apply_layout_manifest_to_module(imported_structs_safe, imported_enums_safe, manifest_for_module);
+        let mut applied_structs = applied_import.structs;
+        if applied_structs == null { applied_structs = []; }
+        let mut applied_enums = applied_import.enums;
+        if applied_enums == null { applied_enums = []; }
+        let applied_interfaces = parse_single_import_interfaces(native_text);
+        let applied_functions = parse_single_import_functions(native_text);
+        imported_structs = extend_native_structs(imported_structs, applied_structs);
+        imported_enums = extend_native_enums(imported_enums, applied_enums);
+        imported_interfaces = extend_native_interfaces(imported_interfaces, applied_interfaces);
+        imported_functions = extend_native_functions(imported_functions, applied_functions);
+        let imported_methods = extract_import_struct_methods(applied_structs);
+        imported_struct_methods = extend_native_functions(imported_struct_methods, imported_methods);
+        text_index += 1;
+    }
+
+    if safe_imported_native_texts.length < manifest_count {
+        let mut manifest_index: number = safe_imported_native_texts.length;
+        loop {
+            if manifest_index >= manifest_count { break; }
+            let leftover_manifest = safe_imported_manifests[manifest_index];
+            imported_structs = extend_native_structs(imported_structs, leftover_manifest.structs);
+            imported_enums = extend_native_enums(imported_enums, leftover_manifest.enums);
+            manifest_index += 1;
+        }
+    }
+
+    return ImportedModuleSymbols {
+        structs: imported_structs,
+        enums: imported_enums,
+        interfaces: imported_interfaces,
+        functions: imported_functions,
+        struct_methods: imported_struct_methods
+    };
 }

--- a/compiler/src/llvm/lowering/lowering_phase_sanitize.sfn
+++ b/compiler/src/llvm/lowering/lowering_phase_sanitize.sfn
@@ -27,9 +27,6 @@ import {
     recover_native_structs_light
 } from "./lowering_recovery";
 
-// Note: build_parse_result_from_text lives in lowering_core.sfn.
-// We inline its logic here to avoid a circular import
-// (lowering_core imports from this file).
 // Sanitize a single collection: null-check + length guard.
 // Returns the sanitized array length (0 if dropped).
 // The caller must handle setting the variable; this function writes

--- a/compiler/src/llvm/lowering/lowering_recovery.sfn
+++ b/compiler/src/llvm/lowering/lowering_recovery.sfn
@@ -835,8 +835,6 @@ fn recover_functions_for_lowering(current_functions: NativeFunction[], native_te
     return [];
 }
 
-// build_parse_result_from_text lives in lowering_core.sfn to preserve
-// cross-module symbol mangling compatibility with the v0.1.1 seed shims.
 // ── Enum recovery ───────────────────────────────────────────────────
 // Light line-scanner for .enum/.endenum blocks, analogous to
 // recover_native_structs_light.  Avoids the cross-module ABI corruption

--- a/docs/build-performance.md
+++ b/docs/build-performance.md
@@ -1,49 +1,51 @@
 # Build Performance: Root Cause Analysis & Fix Plan
 
-**Date:** 2026-04-25 (revised, post Phase 6 Stage 1+2 flip)
-**Previous revisions:** 2026-04-24 (post 0.5.9 release — first IPC-free seed), 2026-04-19 (post `.fn_*` channel removal), 2026-04-15 (post-d2d0bf1/220c8b7), 2026-04-15 (morning), 2026-04-11
-**Context:** 0.5.9 has shipped and is pinned as the seed (`.seed-version`). It is **the first release with no file-based data-flow IPC** — every cross-phase channel that used `build/sailfin/.xxx` files has been removed. The 48 remaining `build/sailfin/.xxx` references are debug/diag gates (`.trace_*`, `.phase_*_diagnostics`, `.skip_*`, `.test_runner_active`, `.dump_test_sources`), not data IPC. The structural cleanup arc opened in April 11's RCA is closed. **Phase 6 Stages 1 and 2 flipped on April 24/25**: `stage_import_context` now runs in parallel under the same `JOBS` knob as the per-module emit loop (`build_module` parallel path was already in place), and the Makefile auto-detects `BUILD_JOBS` from CPU count and total RAM. First post-flip CI wall-times: **Linux x86_64 5:28 (was ~13 min single-threaded; 2.4× speedup)**, macOS arm64 10:37 (unchanged — heuristic picks `BUILD_JOBS=1` due to 7 GB total RAM cap). Stages 3 (CI flag wiring) and 4 (drop `EMIT_RETRIES` 3→1) remain queued.
+**Date:** 2026-04-25 (revised, post lowering_core per-module memory splits)
+**Previous revisions:** 2026-04-25 morning (post Phase 6 Stage 1+2 flip), 2026-04-24 (post 0.5.9 release — first IPC-free seed), 2026-04-19 (post `.fn_*` channel removal), 2026-04-15 (post-d2d0bf1/220c8b7), 2026-04-15 (morning), 2026-04-11
+**Context:** 0.5.9 has shipped and is pinned as the seed (`.seed-version`). It is **the first release with no file-based data-flow IPC** — every cross-phase channel that used `build/sailfin/.xxx` files has been removed. **Phase 6 Stages 1 and 2 flipped on April 24/25**: `stage_import_context` now runs in parallel under the same `JOBS` knob as the per-module emit loop, and the Makefile auto-detects `BUILD_JOBS` from CPU count and total RAM. Post-flip CI wall-times: **Linux x86_64 5:28** (was ~13 min single-threaded; 2.4× speedup), macOS arm64 10:37 (`BUILD_JOBS=1`, 7 GB RAM cap). Stage 3 (explicit CI input) shipped as a composite-action input. Stage 4 (`EMIT_RETRIES` 3→1) attempted and **reverted** — the post-0.5.9 corruption corpus is NOT dry; `llvm/lowering/instructions.sfn` surfaced one intermittent `invalid_ir` flake under `EMIT_RETRIES=1` that recovered on retry with `EMIT_RETRIES=3`. The knob is preserved; the default stays at 3 until the flake is root-caused (separate seed-stabilizer task). Two structural per-module-memory commits shipped on top: Phase 4 PR 2 (structured parser everywhere, `build_parse_result_from_text` deleted), and a `lowering_core.sfn` decomposition that shaved peak RSS from **2350 MB → 1594 MB (-756 MB, -32%)** via two extractions (`gather_imported_module_symbols`, `seed_default_runtime_helpers`). This clears the `min(nproc, mem/5)` gate in `scripts/detect_build_jobs.sh` for the first time on macOS — a follow-up can raise `BUILD_JOBS` to 2 on that runner without OOM.
 
 ---
 
 ## Symptom Summary
 
-| Metric                          | April 11            | April 19              | April 24 (0.5.9)          | Current (April 25, post-Phase 6 Stage 1+2) | Target           |
-| ------------------------------- | ------------------- | --------------------- | ------------------------- | ------------------------------------------ | ---------------- |
-| Full build (1 job, single-threaded) | 60-90 min       | 13-16 min             | ~13 min (CI Linux)        | ~13 min serial / **5:28 parallel** (CI Linux) | < 5 min          |
-| Full build (CI macOS arm64)     | n/a                 | n/a                   | ~13 min                   | **10:37** (BUILD_JOBS=1, mem-bound)       | < 5 min          |
-| Per-module compile time (heavy) | 4-7 min             | 1-3 min               | 1-3 min                   | 1-3 min                                    | < 30s            |
-| Per-module compile time (light) | 30s-2 min           | 10-30s                | 10-30s                    | 10-30s                                     | < 5s             |
-| Per-module peak RAM             | 1-2 GB              | 0.5-1.5 GB            | 0.5-1.5 GB (4.7 GB worst) | 0.5-1.5 GB (4.7 GB worst)                  | < 256 MB         |
-| Parallel builds (`BUILD_JOBS`)  | Broken              | Functional but risky  | Mature, never enabled     | **Auto-detected default; Linux ≈3 jobs, macOS 1 job** | Default-on, ≥4 jobs Linux |
-| `fs.*` calls (total)            | 667 across 42 files | 489 across 37 files   | 212 across 24 files       | 212 across 24 files                        | bounded by CLI / capsule manifest reads |
-| `build/sailfin/` dotfile refs   | 487                 | 228 (dotfiles)        | 48 (diag/trace only)      | 48 (diag/trace only)                       | 0 (post-Phase 5) |
-| Active data-flow IPC channels   | 12+                 | 6                     | 0                         | **0**                                       | 0                |
-| Seed memory limit               | 8 GB                | 12 GB                 | 12 GB                     | 12 GB                                      | < 4 GB           |
+| Metric                          | April 11            | April 19              | April 24 (0.5.9)          | April 25 AM (post Phase 6) | **Current (April 25 PM, post lowering_core split)** | Target           |
+| ------------------------------- | ------------------- | --------------------- | ------------------------- | -------------------------- | --------------------------------------------------- | ---------------- |
+| Full build (1 job, single-threaded) | 60-90 min       | 13-16 min             | ~13 min (CI Linux)        | ~13 min serial / 5:28 parallel | ~2:30 local (3 jobs, container) / 5:28 CI Linux     | < 5 min          |
+| Full build (CI macOS arm64)     | n/a                 | n/a                   | ~13 min                   | **10:37** (BUILD_JOBS=1)  | 10:37 (BUILD_JOBS=1; ≥2 now unblocked per-module)  | < 5 min          |
+| Per-module compile time (heavy) | 4-7 min             | 1-3 min               | 1-3 min                   | 13s (`lowering_core`)     | **7.65s (`lowering_core`)**                         | < 30s ✓          |
+| Per-module compile time (light) | 30s-2 min           | 10-30s                | 10-30s                    | 10-30s                    | 10-30s                                              | < 5s             |
+| Per-module peak RAM (heaviest)  | 1-2 GB              | 0.5-1.5 GB            | 4.7 GB (`lowering_core` under 0.5.7 seed) | 2350 MB (`lowering_core` under 0.5.9+dev post Phase 4 PR 2) | **1594 MB (`lowering_core`)** | < 2 GB (macOS parallelism gate) ✓ |
+| Parallel builds (`BUILD_JOBS`)  | Broken              | Functional but risky  | Mature, never enabled     | Auto-detected (Linux ≈3, macOS 1) | Auto-detected; **macOS can now safely go to 2** after detect_build_jobs.sh re-budgeted against new peak | Default-on, ≥4 jobs Linux |
+| `fs.*` calls (total)            | 667 across 42 files | 489 across 37 files   | 212 across 24 files       | 212 across 24 files        | 212 across 24 files                                 | bounded by CLI / capsule manifest reads |
+| `build/sailfin/` dotfile refs   | 487                 | 228 (dotfiles)        | 48 (diag/trace only)      | 48 (diag/trace only)       | 48 (diag/trace only)                                | 0 (post-Phase 5) |
+| Active data-flow IPC channels   | 12+                 | 6                     | 0                         | 0                          | **0**                                               | 0                |
+| Seed memory limit               | 8 GB                | 12 GB                 | 12 GB                     | 12 GB                      | 12 GB                                               | < 4 GB           |
 
 ---
 
-## Reassessed Roadmap (April 24)
+## Reassessed Roadmap (April 25)
 
 Status of every track named in the original RCA. "Shipped" means the work landed and the doc's **Completed Work** section has the entry.
 
 | Track                                                           | Status                                                                        | Expected wall-time delta (remaining work) |
 | --------------------------------------------------------------- | ----------------------------------------------------------------------------- | ----------------------------------------- |
-| Phase 0 — M0.5 arena allocator                                  | **Shipped** (default-on April 19)                                             | counted                                   |
-| Phase 1 — O(n²) array accumulation sweep                        | **Shipped** (1 residual aliasing site under arena, low-frequency)             | <2%                                       |
+| Phase 0 — M0.5 arena allocator                                  | **Shipped** (default-on April 19); arena stats env gate shipped April 25     | counted                                   |
+| Phase 1 — O(n²) array accumulation sweep                        | **Shipped** (April 25 re-audit confirms zero residual `.concat([x])` sites in `llvm/lowering` + `llvm/expression_lowering`; `extend_string_lines` is in-place push) | <2%                                       |
 | Phase 2 — File-based IPC channel removal                        | **Shipped** (0.5.9 — first IPC-free seed)                                     | counted                                   |
 | Phase 3a — Import-discovery fast-path scanner                   | **Shipped**                                                                   | counted                                   |
 | Phase 3b — Pre-parsed `.imports` sidecar                        | Not started; may be subsumed by Phase 5                                       | 5–10%                                     |
 | Phase 4 PR 1 — Light recovery off non-test primary path         | **Shipped**                                                                   | counted                                   |
-| Phase 4 PR 2 — `parse_native_artifact` primary swap             | **Unblocked by PR #229** (in-memory `compile_to_llvm_file_with_module`)       | 5–8%                                      |
+| Phase 4 PR 2 — `parse_native_artifact` primary swap             | **Shipped April 25** (commit `395a1c7`; swapped all 3 callers; `build_parse_result_from_text` + 4 `recover_*_light` imports deleted) | counted                                   |
 | Phase 4b — Defensive light-recovery arm deletion                | Not started; needs counters bake then delete ~600 LOC                         | trivial wall-time                         |
-| **Phase 6 — Parallel builds**                                   | **Stage 1+2 shipped April 24/25** (parallel `stage_import_context`, adaptive `BUILD_JOBS` default); Stages 3–4 (CI input + retry budget) pending | Linux measured: **2.4× speedup** (13 min → 5:28). Stage 3 wires CI; Stage 4 worth maybe 5%. |
+| **Per-module memory — `lowering_core.sfn` split**               | **Shipped April 25** (commits `072bea1`, `cd34d14`): peak RSS 2350 → **1594 MB** (-32%) via `gather_imported_module_symbols` + `seed_default_runtime_helpers` extractions. Clears macOS `BUILD_JOBS=2` gate. | wall delta ancillary; unblocks parallelism |
+| **Phase 6 — Parallel builds**                                   | **Stages 1+2 shipped April 24/25**; **Stage 3 shipped April 25** (`build_jobs` composite-action input); **Stage 4 reverted April 25** — `EMIT_RETRIES=1` attempted, hit a live flake on `instructions.sfn`; default stays at 3 until root-caused | Linux: **2.4× speedup** (13 min → 5:28); macOS unlock pending `detect_build_jobs.sh` rebudget against new 1594 MB peak |
 | Phase 5 — Long-lived compiler process                           | Post-1.0; needs `compile module` entry point and arena reset between modules  | 50–70% on top of Phase 6                  |
 
-Two follow-up tracks worth cataloguing:
+Follow-up tracks:
 
-- **Per-module memory reduction** — heaviest module (`lowering_core`) still peaks at ~4.7 GB RSS with arena. Every GB shaved raises the safe `BUILD_JOBS` ceiling on memory-constrained hosts (macOS runners cap at 7 GB total). Profiling target: arena page count + per-pass pressure.
-- **Selfhost1 clang opt level** — `make check`'s first-pass binary doesn't need `-O2`; second-pass (the binary we ship as a seed) does. Easy 20–30% off the clang-compile stage in `make check`.
+- **Per-module memory reduction** — done for `lowering_core.sfn`. Next worst offenders: `parser/declarations.sfn` (1759 MB), `lowering_recovery.sfn` (1570 MB — will go away with Phase 4b delete), `instructions_match.sfn` (1361 MB). Same playbook applies to declarations; flag for a follow-up branch.
+- **Selfhost1 clang opt level** — **Shipped April 25** (commit `85deb34`). `SELFHOST1_OPT ?= -O0` threaded into `make check`'s first-pass build; seedcheck + stage3 keep `$(NATIVE_OPT)`. Promotes seedcheck to canonical `build/native/sailfin` on successful fixed-point so subsequent `make compile` doesn't see a stale -O0 binary.
+- **Scripts/bench_compile.sh memory detection** — silently returns `0MB` for all modules when `/usr/bin/time` is not installed (the detection at `scripts/bench_compile.sh:55` correctly empties `GNU_TIME`, but the fallback path in `run_module` doesn't surface the warning in the per-module row). Low priority hygiene fix — standalone `/usr/bin/time -v <seed> emit -o ...` gives correct data today.
 
 ---
 
@@ -1052,6 +1054,61 @@ The fix is not to guess at the ABI corner; the fix is to not rely on the cross-m
 
 - **Phase 4 PR 2** — gating now expands to three conditions: (a) seedcheck typed-tag dispatch works, (b) seedcheck reads typed-variant payload fields correctly, (c) seed 0.5.7+ reliably marshals `ParseNativeResult` across module boundaries (or we route the structured parse through a same-module wrapper that destructures into flat arrays before crossing). Once all three clear, swap `compile_native_text_to_llvm_file:261` + `entrypoints_tests_writer.sfn:132` to `parse_native_artifact`, delete `build_parse_result_from_text` and its four light-recovery imports in `lowering_core.sfn`, and add a test-harness determinism check.
 - **Phase 4b (PR 3)** — instrument the three remaining defensive-fallback arms with `print.err` counters; after a release cycle with zero hits, delete the arms plus the `recover_*_light` function bodies from `lowering_recovery.sfn` (~600 LOC).
+
+### Phase 4 PR 2 — Structured Parser Everywhere (April 25)
+
+**Status: Implemented.** Swaps every live caller of `build_parse_result_from_text` in `lowering_core.sfn`, `entrypoints.sfn` (`print_llvm_ir_from_text`), and `entrypoints_tests_writer.sfn` (`write_llvm_ir_for_tests_from_text`) to `parse_native_artifact` (single-pass structured parser in `native_ir_api.sfn`). Deletes the wrapper + four `recover_*_light` import aliases from `lowering_core.sfn`; trims stale comments from `lowering_recovery.sfn` and `lowering_phase_sanitize.sfn`.
+
+**Unblocked by:** seed 0.5.9 (file-IPC-free; stable cross-module struct returns on the happy path) + PR #229 (routes `compile_to_llvm_file_with_module` through in-memory lowering, closing the April 21 sanitize-chain SEGV that had forced the previous revert).
+
+**Per-module overhead removed:** 4 full line-scanner walks (the `recover_*_light` helpers inside the old `build_parse_result_from_text` body) replaced with a single `parse_native_artifact_impl` pass per non-test module compile.
+
+**Scope:** 5 files, net -64 / +19. `recover_native_functions_light` / `recover_native_structs_light` remain defined in `lowering_recovery.sfn` — still have live defensive-fallback callers in `lowering_phase_sanitize.sfn` and `lowering_recovery.sfn` itself. Phase 4b will remove those arms after counter bake.
+
+**Determinism:** Fresh `make compile FORCE=1` selfhost completed in 155s on a 3-job Linux container. No new retries. No `invalid_ir` failures in the emit loop for modules that consume `parse_native_artifact` across boundaries — the Phase 4 PR 1 revert signal.
+
+**Commit:** `395a1c7`.
+
+### lowering_core.sfn Per-Module Memory Split — PR 1 + PR 2 (April 25)
+
+**Status: Implemented.** Two-commit decomposition of `lowering_core.sfn` (732 LOC after Phase 4 PR 2) driven by a new measurement: peak RSS on the heaviest module was **2350 MB** post-Phase-4-PR-2 on a Linux container with the freshly self-hosted 0.5.9+dev binary. Gate for `BUILD_JOBS=2` on the macOS GitHub runner (7 GB RAM, `min(nproc, mem/5)`) is 2 GB per module. Goal: get under 2 GB so the macOS `BUILD_JOBS` heuristic relaxes.
+
+**PR 1 — extract Phase 2 import-gather** (commit `072bea1`):
+Pulls the 52-line Phase 2 import-gather loop out of the orchestrator and into `lowering_phase_imports.gather_imported_module_symbols`. The orchestrator now calls the helper once and destructures the returned `ImportedModuleSymbols` into the 5 local arrays. Moves 6 imports (`parse_native_structs_for_import`, `parse_native_enums_for_import`, `extend_native_functions`, `parse_single_import_interfaces`, `parse_single_import_functions`, `extract_import_struct_methods`) out of `lowering_core`.
+
+**PR 2 — seed default runtime helpers** (commit `cd34d14`):
+Collapses the 82-line block of `runtime_helpers.append_unique_effect(...)` calls (67 unconditional + 3 conditional) in the orchestrator into a single call to the new `lowering_helpers.seed_default_runtime_helpers(initial)`. Normalizes the conditional `if !string_array_contains { push }` sites to the dedupe-equivalent `append_unique_effect`. Drops 2 imports from `lowering_core` (`append_unique_effect`, `string_array_contains`).
+
+**Measured peak RSS on `lowering_core.sfn`:**
+
+| Stage | Peak RSS | Wall | Delta |
+| --- | ---: | ---: | ---: |
+| Pre-branch baseline | 2350 MB | 13.42s | — |
+| After PR 1 | 2067 MB | 9.66s | **−283 MB / −28% wall** |
+| After PR 2 | **1594 MB** | 7.65s | **−473 MB further / −21% wall** |
+| **Cumulative** | — | — | **−756 MB (−32%) / −43% wall** |
+
+Result: `lowering_core.sfn` is now **406 MB under the 2 GB per-module gate**. macOS `BUILD_JOBS=2` is unblocked on the per-module memory axis.
+
+Other modules' peak RSS unchanged: `lowering_recovery` 1570 MB, `instructions_match` 1361 MB, `parser/declarations` 1759 MB. The new homes grew proportionally: `lowering_phase_imports.sfn` 92 MB (was ~30 MB), `lowering_helpers.sfn` 1292 MB (was ~800 MB) — both comfortably under the gate.
+
+**Determinism:** 3× `emit llvm` of `lowering_core.sfn` after each commit produced md5-identical IR.
+
+**Landmine discovered and documented:** the architect's original PR 1 plan named the new struct `ImportedModuleContext` — that name is already taken by an unrelated struct in `llvm/types.sfn` (manifests / native_texts / diagnostics, consumed by `collect_imported_module_context_for_module`). Defining a second `ImportedModuleContext` in `lowering_phase_imports.sfn` made the 0.5.9 seed produce a subtly miscompiled binary: it compiled cleanly and linked, but every `emit` invocation of the produced compiler segfaulted during struct-field access. Classic shadow-struct ABI symptom. Renamed to `ImportedModuleSymbols` → SEGV disappeared, IR byte-equal across runs. Any future cross-module struct extraction should grep the repo for the proposed name first.
+
+**Not shipped (deferred):** PR 3 (test-harness extraction, projected −50 to −100 MB) and PR 4a (delete dead `skip_effects=true` block) queued in the architect's plan. The 2 GB target is already hit with 406 MB of margin; PR 3+4a are pure code tidy at this point and can ship independently if a future regression pushes peak back above 2 GB.
+
+---
+
+### Additional Perf-Track Commits (April 25)
+
+**`SAILFIN_DUMP_ARENA_STATS` env gate** (commit `69b56bd`): wires `sfn_arena_print_stats` into `native_driver.c` as an `atexit` handler gated on `SAILFIN_DUMP_ARENA_STATS=1 && SAILFIN_USE_ARENA=1`. Output line includes a source-path label derived from argv. Sample on `lowering_core.sfn` solo compile: `pages=103 capacity=412.00MB used=409.18MB allocated=332.36MB utilization=99.3%`. This surfaced the critical insight that arena allocated bytes (~332 MB) are a small fraction of peak RSS (~2350 MB pre-split) — the bulk of the seed's per-module memory is non-arena (typecheck state, import-graph transitive closure, emission buffer). Splitting the file reduces *imports-side* of that budget, which is what PR 1+2 above exploit.
+
+**`SELFHOST1_OPT ?= -O0` thread-through** (commit `85deb34`): `make check`'s first-pass binary now builds at `-O0` by default (clang compile stage drops 20-30% in the validation flow). Seedcheck + stage3 keep `$(NATIVE_OPT)` (-O2) because they are the fixed-point binaries. `check` gets a seedcheck → canonical promotion step at the tail to avoid leaving a stale -O0 binary at `build/native/sailfin` after a successful run.
+
+**`build_jobs` composite-action input** (commit `3cd820d`): `.github/actions/sailfin-build/action.yml` gains an explicit `build_jobs` input that forwards into `make rebuild` as `BUILD_JOBS=N`. Empty (default) inherits the Makefile's auto-detect. Lets individual workflows pin a value (regression bisects, self-hosted runners) without editing the composite.
+
+**`EMIT_RETRIES` 3→1 attempted + reverted** (commits `e45730e` → `ff970fc`): the first `make compile` post-commit hit a one-shot `invalid_ir` flake on `llvm/lowering/instructions.sfn` (mid-struct-definition memory corruption, `%NativeBinding = type <garbage-utf8>`). Retried with `EMIT_RETRIES=3` and the same build cleanly produced valid IR on attempt 1 — i.e. a genuine flake, not deterministic. The post-0.5.9 corruption corpus is NOT dry; retries are still masking real intermittent IR corruption. Reverted the default change until a seed-stabilizer session can root-cause the flake. Env knob still works for diagnostic builds.
 
 ---
 

--- a/runtime/native/src/native_driver.c
+++ b/runtime/native/src/native_driver.c
@@ -32,11 +32,13 @@ extern char *compile_to_llvm(char *source);
 // for the underlying CLI implementation instead.
 extern double sailfin_cli_main__cli_main(SailfinPtrArray *argv);
 
-// Optional process-exit arena telemetry. Activated when both
-// SAILFIN_USE_ARENA=1 (arena allocator on) and SAILFIN_DUMP_ARENA_STATS=1
-// (this gate) are set. Prints one stderr line at exit with arena page count,
-// capacity, used bytes, and utilization plus a label so per-module compile
-// runs are easy to grep out of a build log. See docs/build-performance.md
+// Optional process-exit arena telemetry. Gated on SAILFIN_DUMP_ARENA_STATS=1
+// alone — when set, the atexit hook always runs.  At exit it checks
+// SAILFIN_USE_ARENA: if the arena is on, prints the page/capacity/utilization
+// stats line; otherwise prints a single "stats=disabled" line so the user
+// knows they probably forgot to set SAILFIN_USE_ARENA=1.  Both lines carry
+// a label derived from argv so per-module aggregation across a parallel
+// build log is just a grep + awk away.  See docs/build-performance.md
 // Phase 0 for context.
 static char _arena_stats_label[256] = "<unknown>";
 
@@ -46,11 +48,32 @@ static int _arena_stats_enabled(void)
     return flag && flag[0] != '\0' && flag[0] != '0';
 }
 
+static int _arg_starts_value_flag(const char *arg)
+{
+    // Whitelist of flags the seed CLI takes a value for.  Conservative —
+    // adding a flag that takes no value here would only cause a positional
+    // argument to be skipped during label selection (telemetry-only impact).
+    if (!arg || arg[0] != '-')
+    {
+        return 0;
+    }
+    return strcmp(arg, "-o") == 0 || strcmp(arg, "--out") == 0 ||
+           strcmp(arg, "--emit") == 0 || strcmp(arg, "--seed") == 0 ||
+           strcmp(arg, "--clang") == 0 || strcmp(arg, "--timeout") == 0 ||
+           strcmp(arg, "--max-total") == 0 || strcmp(arg, "--work-dir") == 0 ||
+           strcmp(arg, "--jobs") == 0 || strcmp(arg, "--opt") == 0 ||
+           strcmp(arg, "--runtime-root") == 0 ||
+           strcmp(arg, "--binary-dir") == 0;
+}
+
 static void _arena_stats_capture_label(int argc, char **argv)
 {
     // Best-effort: prefer the trailing positional (typically the source file
-    // path on `seed emit -o out.ll llvm <src>`). Fall back to argv[1] then
-    // argv[0]. The label is purely informational; never fatal.
+    // path on `seed emit -o out.ll llvm <src>`). Skip flags and any argument
+    // that follows a known value-taking flag (e.g. `-o <path>`); a boolean
+    // flag like `--verbose` is not in the value-taking list and so does not
+    // mask the next positional. Fall back to argv[1] then argv[0]. The label
+    // is purely informational; never fatal.
     const char *picked = NULL;
     for (int i = argc - 1; i >= 0; i--)
     {
@@ -59,8 +82,8 @@ static void _arena_stats_capture_label(int argc, char **argv)
         {
             continue;
         }
-        // Skip --emit/--out values that follow a flag.
-        if (i > 0 && argv[i - 1] && argv[i - 1][0] == '-')
+        // Skip values that follow a known value-taking flag (e.g. `-o <path>`).
+        if (i > 0 && _arg_starts_value_flag(argv[i - 1]))
         {
             continue;
         }

--- a/runtime/native/src/native_driver.c
+++ b/runtime/native/src/native_driver.c
@@ -21,6 +21,7 @@
 #endif
 #endif
 
+#include "sailfin_arena.h"
 #include "sailfin_runtime.h"
 
 // Entry point exported by the native compiler IR.
@@ -30,6 +31,68 @@ extern char *compile_to_llvm(char *source);
 // compiler versions (plain vs module-suffixed). Call the stable mangled symbol
 // for the underlying CLI implementation instead.
 extern double sailfin_cli_main__cli_main(SailfinPtrArray *argv);
+
+// Optional process-exit arena telemetry. Activated when both
+// SAILFIN_USE_ARENA=1 (arena allocator on) and SAILFIN_DUMP_ARENA_STATS=1
+// (this gate) are set. Prints one stderr line at exit with arena page count,
+// capacity, used bytes, and utilization plus a label so per-module compile
+// runs are easy to grep out of a build log. See docs/build-performance.md
+// Phase 0 for context.
+static char _arena_stats_label[256] = "<unknown>";
+
+static int _arena_stats_enabled(void)
+{
+    const char *flag = getenv("SAILFIN_DUMP_ARENA_STATS");
+    return flag && flag[0] != '\0' && flag[0] != '0';
+}
+
+static void _arena_stats_capture_label(int argc, char **argv)
+{
+    // Best-effort: prefer the trailing positional (typically the source file
+    // path on `seed emit -o out.ll llvm <src>`). Fall back to argv[1] then
+    // argv[0]. The label is purely informational; never fatal.
+    const char *picked = NULL;
+    for (int i = argc - 1; i >= 0; i--)
+    {
+        const char *a = argv[i];
+        if (!a || a[0] == '\0' || a[0] == '-')
+        {
+            continue;
+        }
+        // Skip --emit/--out values that follow a flag.
+        if (i > 0 && argv[i - 1] && argv[i - 1][0] == '-')
+        {
+            continue;
+        }
+        picked = a;
+        break;
+    }
+    if (!picked)
+    {
+        picked = (argc > 0 && argv[0]) ? argv[0] : "<unknown>";
+    }
+    strncpy(_arena_stats_label, picked, sizeof(_arena_stats_label) - 1);
+    _arena_stats_label[sizeof(_arena_stats_label) - 1] = '\0';
+}
+
+static void _arena_stats_atexit(void)
+{
+    if (!_arena_stats_enabled())
+    {
+        return;
+    }
+    if (!sfn_arena_enabled())
+    {
+        // Avoid creating the global arena just to dump empty stats.
+        fprintf(stderr,
+                "[sailfin-arena] label=%s stats=disabled "
+                "(SAILFIN_USE_ARENA not set)\n",
+                _arena_stats_label);
+        return;
+    }
+    fprintf(stderr, "[sailfin-arena] label=%s ", _arena_stats_label);
+    sfn_arena_print_stats(sfn_arena_global());
+}
 
 static int _trace_argv_enabled(void)
 {
@@ -383,6 +446,11 @@ static char *_resolve_runtime_root(const char *argv0)
 int main(int argc, char **argv)
 {
     _trace_argv("incoming", argc, argv);
+    if (_arena_stats_enabled())
+    {
+        _arena_stats_capture_label(argc, argv);
+        atexit(_arena_stats_atexit);
+    }
     // If invoked with an explicit subcommand/flag, delegate to the Sailfin-native CLI.
     // Otherwise, preserve the legacy interface: `sailfin [--emit MODE] file.sfn`.
     if (argc >= 2)

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -46,9 +46,17 @@ SEED_TIMEOUT="${SEED_TIMEOUT:-180}"
 MAX_TOTAL="${MAX_TOTAL:-1200}"
 VERBOSE="${VERBOSE:-0}"
 # EMIT_RETRIES: how many times to re-run seed emit on empty/invalid output.
-#   Production default: 3 (tolerates sporadic memory corruption).
-#   Diagnostic runs:    1 (measures raw failure rate — no re-rolling the dice).
-EMIT_RETRIES="${EMIT_RETRIES:-3}"
+#   Default: 1 (no retries; first failure surfaces immediately).
+#   Set to 3+ when triaging an intermittent regression where you want to
+#   measure how often a retry recovers vs. how often it stays broken.
+#
+# Rationale (April 25): the corruption corpus has been dry across the post-0.5.9
+# build matrix — see retries.log absence on full local + CI runs. With every
+# file-IPC channel removed in 0.5.9 and the default-on arena (PR #186) the
+# previous sources of intermittent IR corruption are gone. Retries here used
+# to mask a real source of non-determinism; now they only mask regressions.
+# Keep the env knob so a diagnostic build can re-enable when needed.
+EMIT_RETRIES="${EMIT_RETRIES:-1}"
 BUILD_MODULE_WORKER=0
 WORKER_INDEX=""
 WORKER_SRC=""
@@ -613,8 +621,9 @@ build_module() {
     # Run from module_cwd so the seed picks up staged import-context.
     # Diagnostics go to stderr (via print.err) so stdout/file output is clean LLVM IR.
     #
-    # Retry policy: controlled by EMIT_RETRIES (default 3; set to 1 for
-    # diagnostic runs to measure raw per-module failure rate).
+    # Retry policy: controlled by EMIT_RETRIES (default 1; raise to 3+ when
+    # triaging an intermittent regression to measure how often a retry
+    # recovers vs. stays broken).
     #
     # Every failed attempt:
     #   - captures the bad .ll + stderr to $CORRUPTED_DIR (corpus-building)
@@ -624,8 +633,8 @@ build_module() {
     local stderr_log="${abs_ll_path}.stderr"
     local validate_log="${abs_ll_path}.validate"
     local attempt=0
-    local max_attempts="${EMIT_RETRIES:-3}"
-    [[ "$max_attempts" =~ ^[0-9]+$ ]] || max_attempts=3
+    local max_attempts="${EMIT_RETRIES:-1}"
+    [[ "$max_attempts" =~ ^[0-9]+$ ]] || max_attempts=1
     [[ "$max_attempts" -ge 1 ]] || max_attempts=1
     local seed_exit=0
     while [[ $attempt -lt $max_attempts ]]; do

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -46,17 +46,9 @@ SEED_TIMEOUT="${SEED_TIMEOUT:-180}"
 MAX_TOTAL="${MAX_TOTAL:-1200}"
 VERBOSE="${VERBOSE:-0}"
 # EMIT_RETRIES: how many times to re-run seed emit on empty/invalid output.
-#   Default: 1 (no retries; first failure surfaces immediately).
-#   Set to 3+ when triaging an intermittent regression where you want to
-#   measure how often a retry recovers vs. how often it stays broken.
-#
-# Rationale (April 25): the corruption corpus has been dry across the post-0.5.9
-# build matrix — see retries.log absence on full local + CI runs. With every
-# file-IPC channel removed in 0.5.9 and the default-on arena (PR #186) the
-# previous sources of intermittent IR corruption are gone. Retries here used
-# to mask a real source of non-determinism; now they only mask regressions.
-# Keep the env knob so a diagnostic build can re-enable when needed.
-EMIT_RETRIES="${EMIT_RETRIES:-1}"
+#   Production default: 3 (tolerates sporadic memory corruption).
+#   Diagnostic runs:    1 (measures raw failure rate — no re-rolling the dice).
+EMIT_RETRIES="${EMIT_RETRIES:-3}"
 BUILD_MODULE_WORKER=0
 WORKER_INDEX=""
 WORKER_SRC=""
@@ -621,9 +613,8 @@ build_module() {
     # Run from module_cwd so the seed picks up staged import-context.
     # Diagnostics go to stderr (via print.err) so stdout/file output is clean LLVM IR.
     #
-    # Retry policy: controlled by EMIT_RETRIES (default 1; raise to 3+ when
-    # triaging an intermittent regression to measure how often a retry
-    # recovers vs. stays broken).
+    # Retry policy: controlled by EMIT_RETRIES (default 3; set to 1 for
+    # diagnostic runs to measure raw per-module failure rate).
     #
     # Every failed attempt:
     #   - captures the bad .ll + stderr to $CORRUPTED_DIR (corpus-building)
@@ -633,8 +624,8 @@ build_module() {
     local stderr_log="${abs_ll_path}.stderr"
     local validate_log="${abs_ll_path}.validate"
     local attempt=0
-    local max_attempts="${EMIT_RETRIES:-1}"
-    [[ "$max_attempts" =~ ^[0-9]+$ ]] || max_attempts=1
+    local max_attempts="${EMIT_RETRIES:-3}"
+    [[ "$max_attempts" =~ ^[0-9]+$ ]] || max_attempts=3
     [[ "$max_attempts" -ge 1 ]] || max_attempts=1
     local seed_exit=0
     while [[ $attempt -lt $max_attempts ]]; do

--- a/scripts/detect_build_jobs.sh
+++ b/scripts/detect_build_jobs.sh
@@ -1,11 +1,26 @@
 #!/usr/bin/env bash
 # detect_build_jobs.sh — Pick a sensible BUILD_JOBS default for the current host.
 #
-# Heuristic: min(nproc, total_ram_gb / 5). The 5 GB-per-job budget reflects the
-# heaviest module (`lowering_core`) peaking at ~4.7 GB RSS under the arena
-# allocator, plus ~300 MB headroom for staging temp files. macOS additionally
-# caps at 2 jobs because the GitHub `macos-latest` runner ships with 7 GB total
-# RAM (M1) — anything higher OOMs the heaviest module pair.
+# Heuristic: min(nproc, total_ram_gb / 2). The ~2 GB-per-job budget reflects
+# the post-split heaviest modules:
+#   * lowering_core.sfn        : 1594 MB peak RSS (was 4700 MB pre-arena,
+#                                2350 MB post-arena pre-split)
+#   * parser/declarations.sfn  : 1759 MB peak RSS (next-worst, unsplit)
+#   * lowering_helpers.sfn     : 1292 MB peak RSS (post seed-default-runtime
+#                                helpers extraction)
+# At 2 GB-per-job, two concurrent worst-case modules peak at ~3.5 GB, which
+# fits comfortably under the 7 GB total RAM ceiling on the macOS GitHub
+# runner (M1) with the OS + Actions agent overhead.
+#
+# Pre-April-25 the divisor was 5 GB-per-job, sized to fit the pre-split
+# 4.7 GB lowering_core peak. That gave macOS 7/5 → BUILD_JOBS=1 (no
+# parallelism). The April 25 lowering_core split (commits 072bea1 +
+# cd34d14) cleared the per-module gate; this script's divisor change is
+# what actually flips macOS to BUILD_JOBS=2 in CI.
+#
+# macOS additionally caps at 2 jobs because anything higher would still
+# overcommit the 7 GB total RAM ceiling once you account for compile +
+# clang + link overhead and the parent xargs process tree.
 #
 # Falls back to 1 on:
 #   - hosts where nproc / sysctl / /proc/meminfo are not readable
@@ -38,8 +53,9 @@ esac
 [ "$cores" -gt 0 ] 2>/dev/null || cores=1
 [ "$mem_gb" -gt 0 ] 2>/dev/null || mem_gb=4
 
-# Apply the per-job memory budget.
-by_mem=$((mem_gb / 5))
+# Apply the per-job memory budget. ~2 GB per job; see the header comment
+# for the per-module RSS data this divisor is sized against.
+by_mem=$((mem_gb / 2))
 [ "$by_mem" -lt 1 ] && by_mem=1
 
 jobs=$cores

--- a/site/src/content/docs/docs/reference/cli.md
+++ b/site/src/content/docs/docs/reference/cli.md
@@ -415,7 +415,9 @@ The build orchestrator compiles modules in parallel. Control the job count:
 make rebuild BUILD_JOBS=4
 ```
 
-The default is auto-detected from the host's CPU count and total RAM (`scripts/detect_build_jobs.sh`): roughly `min(nproc, total_ram_gb / 5)` clamped to `[1, 8]`, with a macOS cap of 2 because Apple Silicon GitHub runners only ship 7 GB of RAM. Set `BUILD_JOBS=N` explicitly to override. Set `BUILD_JOBS=1` to disable parallelism (useful for regression bisects). See `docs/build-performance.md` → Phase 6 for the rationale behind the per-job memory budget.
+The default is auto-detected from the host's CPU count and total RAM (`scripts/detect_build_jobs.sh`): roughly `min(nproc, total_ram_gb / 2)` clamped to `[1, 8]`, with a macOS cap of 2 because Apple Silicon GitHub runners only ship 7 GB of RAM. Set `BUILD_JOBS=N` explicitly to override. Set `BUILD_JOBS=1` to disable parallelism (useful for regression bisects). See `docs/build-performance.md` → Phase 6 for the rationale behind the per-job memory budget.
+
+The `~2 GB-per-job` divisor reflects post-April-25 per-module peak RSS (heaviest module ~1.76 GB after the `lowering_core.sfn` decomposition). With 2 jobs running the heaviest pair concurrently, peak concurrent memory is ~3.5 GB — fits the macOS 7 GB ceiling with OS + Actions agent overhead. Hosts with more RAM are still capped by `nproc` first.
 
 ---
 

--- a/site/src/content/docs/docs/reference/cli.md
+++ b/site/src/content/docs/docs/reference/cli.md
@@ -417,7 +417,7 @@ make rebuild BUILD_JOBS=4
 
 The default is auto-detected from the host's CPU count and total RAM (`scripts/detect_build_jobs.sh`): roughly `min(nproc, total_ram_gb / 2)` clamped to `[1, 8]`, with a macOS cap of 2 because Apple Silicon GitHub runners only ship 7 GB of RAM. Set `BUILD_JOBS=N` explicitly to override. Set `BUILD_JOBS=1` to disable parallelism (useful for regression bisects). See `docs/build-performance.md` → Phase 6 for the rationale behind the per-job memory budget.
 
-The `~2 GB-per-job` divisor reflects post-April-25 per-module peak RSS (heaviest module ~1.76 GB after the `lowering_core.sfn` decomposition). With 2 jobs running the heaviest pair concurrently, peak concurrent memory is ~3.5 GB — fits the macOS 7 GB ceiling with OS + Actions agent overhead. Hosts with more RAM are still capped by `nproc` first.
+The `~2 GB-per-job` divisor reflects the per-module peak RSS documented in `docs/build-performance.md` → Phase 6 (heaviest module ~1.76 GB after the `lowering_core.sfn` decomposition). With 2 jobs running the heaviest pair concurrently, peak concurrent memory is ~3.5 GB — fits the macOS 7 GB ceiling with OS + Actions agent overhead. Hosts with more RAM are still capped by `nproc` first.
 
 ---
 


### PR DESCRIPTION
Adds a process-exit telemetry hook that prints arena page count, capacity,
used, allocated, and utilization to stderr — gated on SAILFIN_DUMP_ARENA_STATS=1
(the new gate) AND SAILFIN_USE_ARENA=1 (the existing arena toggle).

The output line includes a label derived from argv (the source file path on
typical 'seed emit -o out.ll llvm <src>' invocations) so per-module
aggregation across a parallel build log is just a grep + awk away.

Foundation for the per-module-memory work that unlocks higher BUILD_JOBS on
macOS runners. sfn_arena_print_stats already existed in
runtime/native/src/sailfin_arena.c but had no callers; now it has one.

Sample output (lowering_core.sfn, fresh self-host of 0.5.9+dev):
  [sailfin-arena] label=.../lowering_core.sfn pages=103 capacity=412.00MB \
    used=409.18MB allocated=332.36MB utilization=99.3%

No effect on builds that don't set the env var.

Refs docs/build-performance.md Phase 0 follow-ups.