### PR TITLE
docs(build-architecture): refresh status; scope Stage A as pickable

### DIFF
--- a/capsules/sfn/prelude/capsule.toml
+++ b/capsules/sfn/prelude/capsule.toml
@@ -1,0 +1,18 @@
+[capsule]
+name = "sfn/prelude"
+version = "0.5.9"
+description = "Sailfin standard prelude (collections, strings, type checks)"
+
+[capabilities]
+required = []
+
+[build]
+kind = "library"
+entry = "../../../runtime/prelude.sfn"
+implicit = true
+
+# Stage A: parse-only. The entry path points back at the existing
+# runtime/prelude.sfn rather than moving the file under this capsule's
+# src/ — moving it changes every consumer's import slug and is squarely
+# Stage B work (see docs/proposals/build-architecture.md, Part 5,
+# Stage A "Open question to resolve in this stage's PR").

--- a/compiler/capsule.toml
+++ b/compiler/capsule.toml
@@ -9,6 +9,7 @@ description = "The Sailfin compiler — self-hosted, targeting LLVM via .sfn-asm
 required = ["io"]
 
 [build]
+kind = "binary"
 entry = "src/main.sfn"
 
 # The compiler reads its version from this file at runtime via

--- a/compiler/src/toml_parser.sfn
+++ b/compiler/src/toml_parser.sfn
@@ -12,10 +12,10 @@ struct SailToml {
     capabilities: string[];
     // Stage A additions (parse-only; no consumers yet — see
     // docs/proposals/build-architecture.md, Part 5, Stage A).
-    build_kind: string;             // "binary" | "library" | "runtime" | ""
-    build_implicit: boolean;        // [build] implicit = true
-    workspace_members: string[];    // [workspace] members = [...]
-    exports: string[];              // [exports] modules = [...]
+    build_kind: string;  // "binary" | "library" | "runtime" | ""
+    build_implicit: boolean;  // [build] implicit = true
+    workspace_members: string[];  // [workspace] members = [...]
+    exports: string[];  // [exports] modules = [...]
 }
 
 struct TomlDependency {
@@ -271,7 +271,6 @@ fn toml_get_description(text: string) -> string {
 // These getters expose manifest fields the unified-build proposal
 // (docs/proposals/build-architecture.md, Stage A) adds to the schema.
 // Stage B will start consuming them; Stage A only verifies round-trip.
-
 fn toml_get_build_kind(text: string) -> string {
     let t = _parse_toml_internal(text);
     return t.build_kind;
@@ -336,7 +335,10 @@ fn toml_get_target_triples(text: string) -> string {
         let mut pi: number = 0;
         loop {
             if pi >= prefix.length { break; }
-            if section[pi] != prefix[pi] { matches = false; break; }
+            if section[pi] != prefix[pi] {
+                matches = false;
+                break;
+            }
             pi += 1;
         }
         if !matches { continue; }
@@ -539,9 +541,7 @@ fn _write_toml(toml: SailToml) -> string {
     if toml.build_kind.length > 0 {
         out = out + "kind = \"" + toml.build_kind + "\"\n";
     }
-    if toml.build_implicit {
-        out = out + "implicit = true\n";
-    }
+    if toml.build_implicit { out = out + "implicit = true\n"; }
     if toml.workspace_members.length > 0 {
         out = out + "\n[workspace]\n";
         out = out + "members = [";

--- a/compiler/src/toml_parser.sfn
+++ b/compiler/src/toml_parser.sfn
@@ -10,6 +10,12 @@ struct SailToml {
     dependencies: TomlDependency[];
     dev_dependencies: TomlDependency[];
     capabilities: string[];
+    // Stage A additions (parse-only; no consumers yet — see
+    // docs/proposals/build-architecture.md, Part 5, Stage A).
+    build_kind: string;             // "binary" | "library" | "runtime" | ""
+    build_implicit: boolean;        // [build] implicit = true
+    workspace_members: string[];    // [workspace] members = [...]
+    exports: string[];              // [exports] modules = [...]
 }
 
 struct TomlDependency {
@@ -160,7 +166,11 @@ fn _parse_toml_internal(text: string) -> SailToml {
         entry: "src/main.sfn",
         dependencies: [],
         dev_dependencies: [],
-        capabilities: []
+        capabilities: [],
+        build_kind: "",
+        build_implicit: false,
+        workspace_members: [],
+        exports: []
     };
     let lines = _toml_split_lines(text);
     let mut section: string = "";
@@ -199,6 +209,22 @@ fn _parse_toml_internal(text: string) -> SailToml {
         if strings_equal(section, "build") {
             if strings_equal(stripped_key, "entry") {
                 toml.entry = stripped_value;
+            }
+            if strings_equal(stripped_key, "kind") {
+                toml.build_kind = stripped_value;
+            }
+            if strings_equal(stripped_key, "implicit") {
+                toml.build_implicit = strings_equal(stripped_value, "true");
+            }
+        }
+        if strings_equal(section, "workspace") {
+            if strings_equal(stripped_key, "members") {
+                toml.workspace_members = _toml_parse_string_array(value);
+            }
+        }
+        if strings_equal(section, "exports") {
+            if strings_equal(stripped_key, "modules") {
+                toml.exports = _toml_parse_string_array(value);
             }
         }
         if strings_equal(section, "dependencies") {
@@ -239,6 +265,130 @@ fn toml_get_entry(text: string) -> string {
 fn toml_get_description(text: string) -> string {
     let t = _parse_toml_internal(text);
     return t.description;
+}
+
+// ---- Stage A getters (parse-only; no consumers yet) ----
+// These getters expose manifest fields the unified-build proposal
+// (docs/proposals/build-architecture.md, Stage A) adds to the schema.
+// Stage B will start consuming them; Stage A only verifies round-trip.
+
+fn toml_get_build_kind(text: string) -> string {
+    let t = _parse_toml_internal(text);
+    return t.build_kind;
+}
+
+fn toml_get_build_implicit(text: string) -> boolean {
+    let t = _parse_toml_internal(text);
+    return t.build_implicit;
+}
+
+// Returns workspace members as a newline-separated string. Matches the
+// shape of toml_get_dependencies so callers split on "\n" without a
+// SailToml struct crossing module boundaries.
+fn toml_get_workspace_members(text: string) -> string {
+    let t = _parse_toml_internal(text);
+    let mut out: string = "";
+    let mut i: number = 0;
+    loop {
+        if i >= t.workspace_members.length { break; }
+        if i > 0 { out = out + "\n"; }
+        out = out + t.workspace_members[i];
+        i += 1;
+    }
+    return out;
+}
+
+// Returns [exports] modules as a newline-separated string.
+fn toml_get_exports(text: string) -> string {
+    let t = _parse_toml_internal(text);
+    let mut out: string = "";
+    let mut i: number = 0;
+    loop {
+        if i >= t.exports.length { break; }
+        if i > 0 { out = out + "\n"; }
+        out = out + t.exports[i];
+        i += 1;
+    }
+    return out;
+}
+
+// Enumerate every section header of the form `[targets.<triple>]` and
+// return the triples as a newline-separated string. Section bodies are
+// reachable via toml_get_string / toml_get_string_array with section
+// name "targets.<triple>".
+fn toml_get_target_triples(text: string) -> string {
+    let lines = _toml_split_lines(text);
+    let prefix = "targets.";
+    let mut out: string = "";
+    let mut found: number = 0;
+    let mut i: number = 0;
+    loop {
+        if i >= lines.length { break; }
+        let line = _toml_trim(lines[i]);
+        i += 1;
+        if line.length == 0 { continue; }
+        if line[0] != "[" { continue; }
+        let close = find_char(line, "]", 0);
+        if close <= 0 { continue; }
+        let section = _toml_trim(substring(line, 1, close));
+        if section.length <= prefix.length { continue; }
+        let mut matches: boolean = true;
+        let mut pi: number = 0;
+        loop {
+            if pi >= prefix.length { break; }
+            if section[pi] != prefix[pi] { matches = false; break; }
+            pi += 1;
+        }
+        if !matches { continue; }
+        let triple = substring(section, prefix.length, section.length);
+        if triple.length == 0 { continue; }
+        if found > 0 { out = out + "\n"; }
+        out = out + triple;
+        found += 1;
+    }
+    return out;
+}
+
+// Read a string-array value at `[section] key = [ ... ]`. Returns "" if
+// absent. Items are returned newline-separated. Generalises the Stage A
+// getters above so callers can read [targets.<triple>].cc-flags without
+// adding a dedicated function per key.
+fn toml_get_string_array(text: string, section: string, key: string) -> string {
+    let lines = _toml_split_lines(text);
+    let mut current_section: string = "";
+    let mut i: number = 0;
+    loop {
+        if i >= lines.length { break; }
+        let line = _toml_trim(lines[i]);
+        i += 1;
+        if line.length == 0 { continue; }
+        if line[0] == "#" { continue; }
+        if line[0] == "[" {
+            let close = find_char(line, "]", 0);
+            if close > 0 {
+                current_section = _toml_trim(substring(line, 1, close));
+            }
+            continue;
+        }
+        if !strings_equal(current_section, section) { continue; }
+        let eq_pos = find_char(line, "=", 0);
+        if eq_pos < 0 { continue; }
+        let line_key = _toml_trim(substring(line, 0, eq_pos));
+        let stripped_key = _toml_strip_quotes(line_key);
+        if !strings_equal(stripped_key, key) { continue; }
+        let value = _toml_trim(substring(line, eq_pos + 1, line.length));
+        let arr = _toml_parse_string_array(value);
+        let mut out: string = "";
+        let mut ai: number = 0;
+        loop {
+            if ai >= arr.length { break; }
+            if ai > 0 { out = out + "\n"; }
+            out = out + arr[ai];
+            ai += 1;
+        }
+        return out;
+    }
+    return "";
 }
 
 // Read a string value at `[section] key = "value"`. Returns "" if absent.
@@ -386,5 +536,35 @@ fn _write_toml(toml: SailToml) -> string {
     out = out + "]\n";
     out = out + "\n[build]\n";
     out = out + "entry = \"" + toml.entry + "\"\n";
+    if toml.build_kind.length > 0 {
+        out = out + "kind = \"" + toml.build_kind + "\"\n";
+    }
+    if toml.build_implicit {
+        out = out + "implicit = true\n";
+    }
+    if toml.workspace_members.length > 0 {
+        out = out + "\n[workspace]\n";
+        out = out + "members = [";
+        let mut wi: number = 0;
+        loop {
+            if wi >= toml.workspace_members.length { break; }
+            if wi > 0 { out = out + ", "; }
+            out = out + "\"" + toml.workspace_members[wi] + "\"";
+            wi += 1;
+        }
+        out = out + "]\n";
+    }
+    if toml.exports.length > 0 {
+        out = out + "\n[exports]\n";
+        out = out + "modules = [";
+        let mut ei: number = 0;
+        loop {
+            if ei >= toml.exports.length { break; }
+            if ei > 0 { out = out + ", "; }
+            out = out + "\"" + toml.exports[ei] + "\"";
+            ei += 1;
+        }
+        out = out + "]\n";
+    }
     return out;
 }

--- a/compiler/tests/unit/manifest_workspace_test.sfn
+++ b/compiler/tests/unit/manifest_workspace_test.sfn
@@ -1,0 +1,221 @@
+// Stage A regression tests for the unified-build manifest schema
+// (docs/proposals/build-architecture.md, Part 5, Stage A).
+//
+// Verifies parse + round-trip of the new [build].kind, [build].implicit,
+// [workspace].members, [exports].modules, and [targets.<triple>] fields.
+// No consumers exist yet — these tests exist to lock down the schema so
+// Stage B has a stable contract to lean on.
+
+import {
+    toml_get_build_kind,
+    toml_get_build_implicit,
+    toml_get_workspace_members,
+    toml_get_exports,
+    toml_get_target_triples,
+    toml_get_string_array,
+    toml_get_string,
+    toml_get_name,
+    toml_get_entry,
+    toml_get_dependencies,
+    toml_add_dependency
+} from "../../src/toml_parser";
+
+fn _str_eq(a: string, b: string) -> boolean {
+    return strings_equal(a, b);
+}
+
+fn _contains(haystack: string, needle: string) -> boolean {
+    if needle.length == 0 { return true; }
+    if haystack.length < needle.length { return false; }
+    let mut i: number = 0;
+    loop {
+        if i + needle.length > haystack.length { break; }
+        let mut j: number = 0;
+        let mut matches: boolean = true;
+        loop {
+            if j >= needle.length { break; }
+            if haystack[i + j] != needle[j] {
+                matches = false;
+                break;
+            }
+            j += 1;
+        }
+        if matches { return true; }
+        i += 1;
+    }
+    return false;
+}
+
+// ---- [build].kind ----
+
+test "manifest: build.kind absent returns empty string" {
+    let toml = "[capsule]\nname = \"x\"\nversion = \"0.1.0\"\n\n[build]\nentry = \"src/main.sfn\"\n";
+    assert _str_eq(toml_get_build_kind(toml), "");
+}
+
+test "manifest: build.kind binary parses" {
+    let toml = "[capsule]\nname = \"x\"\nversion = \"0.1.0\"\n\n[build]\nentry = \"src/main.sfn\"\nkind = \"binary\"\n";
+    assert _str_eq(toml_get_build_kind(toml), "binary");
+}
+
+test "manifest: build.kind library parses" {
+    let toml = "[capsule]\nname = \"x\"\nversion = \"0.1.0\"\n\n[build]\nkind = \"library\"\nentry = \"src/mod.sfn\"\n";
+    assert _str_eq(toml_get_build_kind(toml), "library");
+}
+
+test "manifest: build.kind runtime parses" {
+    let toml = "[capsule]\nname = \"x\"\nversion = \"0.1.0\"\n\n[build]\nkind = \"runtime\"\n";
+    assert _str_eq(toml_get_build_kind(toml), "runtime");
+}
+
+// ---- [build].implicit ----
+
+test "manifest: build.implicit absent defaults to false" {
+    let toml = "[capsule]\nname = \"x\"\nversion = \"0.1.0\"\n\n[build]\nentry = \"src/main.sfn\"\n";
+    assert toml_get_build_implicit(toml) == false;
+}
+
+test "manifest: build.implicit true parses" {
+    let toml = "[capsule]\nname = \"prelude\"\nversion = \"0.1.0\"\n\n[build]\nkind = \"library\"\nimplicit = true\nentry = \"src/mod.sfn\"\n";
+    assert toml_get_build_implicit(toml) == true;
+}
+
+test "manifest: build.implicit false parses" {
+    let toml = "[capsule]\nname = \"x\"\nversion = \"0.1.0\"\n\n[build]\nimplicit = false\n";
+    assert toml_get_build_implicit(toml) == false;
+}
+
+// ---- [workspace].members ----
+
+test "manifest: workspace.members absent returns empty string" {
+    let toml = "[capsule]\nname = \"x\"\nversion = \"0.1.0\"\n";
+    assert _str_eq(toml_get_workspace_members(toml), "");
+}
+
+test "manifest: workspace.members single entry parses" {
+    let toml = "[workspace]\nmembers = [\"compiler\"]\n";
+    assert _str_eq(toml_get_workspace_members(toml), "compiler");
+}
+
+test "manifest: workspace.members multiple entries parse newline-separated" {
+    let toml = "[workspace]\nmembers = [\"compiler\", \"capsules/sfn/*\"]\n";
+    let members = toml_get_workspace_members(toml);
+    assert _contains(members, "compiler");
+    assert _contains(members, "capsules/sfn/*");
+    assert _contains(members, "\n");
+}
+
+test "manifest: workspace-only file (no [capsule]) parses" {
+    let toml = "[workspace]\nmembers = [\"compiler\", \"capsules/sfn/*\"]\n";
+    assert _str_eq(toml_get_name(toml), "");
+    let members = toml_get_workspace_members(toml);
+    assert _contains(members, "compiler");
+}
+
+// ---- [exports].modules ----
+
+test "manifest: exports.modules absent returns empty string" {
+    let toml = "[capsule]\nname = \"x\"\nversion = \"0.1.0\"\n";
+    assert _str_eq(toml_get_exports(toml), "");
+}
+
+test "manifest: exports.modules parses newline-separated" {
+    let toml = "[capsule]\nname = \"x\"\nversion = \"0.1.0\"\n\n[exports]\nmodules = [\"client\", \"server\"]\n";
+    let exports = toml_get_exports(toml);
+    assert _contains(exports, "client");
+    assert _contains(exports, "server");
+}
+
+// ---- [dev-dependencies] (already supported pre-Stage A; lock the contract) ----
+
+test "manifest: dev-dependencies do not leak into [dependencies]" {
+    let toml = "[capsule]\nname = \"x\"\nversion = \"0.1.0\"\n\n[dependencies]\n\"http\" = \"0.2.0\"\n\n[dev-dependencies]\n\"test\" = \"0.4.0\"\n";
+    let deps = toml_get_dependencies(toml);
+    assert _contains(deps, "http=0.2.0");
+    let mut leaked: boolean = false;
+    if _contains(deps, "test=0.4.0") { leaked = true; }
+    assert leaked == false;
+}
+
+// ---- [targets.<triple>] ----
+
+test "manifest: targets section absent returns empty string" {
+    let toml = "[capsule]\nname = \"x\"\nversion = \"0.1.0\"\n";
+    assert _str_eq(toml_get_target_triples(toml), "");
+}
+
+test "manifest: single targets section enumerated" {
+    let toml = "[capsule]\nname = \"x\"\nversion = \"0.1.0\"\n\n[targets.x86_64-w64-mingw32]\nruntime = \"sfn/runtime-native\"\n";
+    assert _str_eq(toml_get_target_triples(toml), "x86_64-w64-mingw32");
+}
+
+test "manifest: multiple targets sections enumerated newline-separated" {
+    let toml = "[capsule]\nname = \"x\"\nversion = \"0.1.0\"\n\n[targets.x86_64-w64-mingw32]\nruntime = \"sfn/runtime-native\"\n\n[targets.wasm32-unknown-unknown]\nruntime = \"sfn/runtime-wasm\"\n";
+    let triples = toml_get_target_triples(toml);
+    assert _contains(triples, "x86_64-w64-mingw32");
+    assert _contains(triples, "wasm32-unknown-unknown");
+    assert _contains(triples, "\n");
+}
+
+test "manifest: targets section string fields readable via toml_get_string" {
+    let toml = "[capsule]\nname = \"x\"\nversion = \"0.1.0\"\n\n[targets.x86_64-w64-mingw32]\nruntime = \"sfn/runtime-native\"\ncc = \"x86_64-w64-mingw32-gcc\"\n";
+    let runtime = toml_get_string(toml, "targets.x86_64-w64-mingw32", "runtime");
+    let cc = toml_get_string(toml, "targets.x86_64-w64-mingw32", "cc");
+    assert _str_eq(runtime, "sfn/runtime-native");
+    assert _str_eq(cc, "x86_64-w64-mingw32-gcc");
+}
+
+test "manifest: targets section array fields readable via toml_get_string_array" {
+    let toml = "[capsule]\nname = \"x\"\nversion = \"0.1.0\"\n\n[targets.x86_64-w64-mingw32]\ncc-flags = [\"-static\", \"-O2\"]\nlink-libs = [\"-lm\"]\n";
+    let flags = toml_get_string_array(toml, "targets.x86_64-w64-mingw32", "cc-flags");
+    let libs = toml_get_string_array(toml, "targets.x86_64-w64-mingw32", "link-libs");
+    assert _contains(flags, "-static");
+    assert _contains(flags, "-O2");
+    assert _contains(flags, "\n");
+    assert _str_eq(libs, "-lm");
+}
+
+test "manifest: toml_get_string_array missing key returns empty" {
+    let toml = "[capsule]\nname = \"x\"\nversion = \"0.1.0\"\n";
+    assert _str_eq(toml_get_string_array(toml, "targets.nope", "cc-flags"), "");
+}
+
+// ---- Round-trip via toml_add_dependency (writes preserve new fields) ----
+
+test "manifest: toml_add_dependency preserves build.kind" {
+    let original = "[capsule]\nname = \"x\"\nversion = \"0.1.0\"\n\n[build]\nentry = \"src/mod.sfn\"\nkind = \"library\"\n";
+    let updated = toml_add_dependency(original, "http", "0.2.0");
+    assert _str_eq(toml_get_build_kind(updated), "library");
+    assert _contains(toml_get_dependencies(updated), "http=0.2.0");
+}
+
+test "manifest: toml_add_dependency preserves build.implicit" {
+    let original = "[capsule]\nname = \"prelude\"\nversion = \"0.1.0\"\n\n[build]\nentry = \"src/mod.sfn\"\nimplicit = true\n";
+    let updated = toml_add_dependency(original, "fmt", "0.3.0");
+    assert toml_get_build_implicit(updated) == true;
+}
+
+test "manifest: toml_add_dependency preserves workspace members" {
+    let original = "[capsule]\nname = \"root\"\nversion = \"0.1.0\"\n\n[workspace]\nmembers = [\"compiler\", \"capsules/sfn/*\"]\n";
+    let updated = toml_add_dependency(original, "fmt", "0.3.0");
+    let members = toml_get_workspace_members(updated);
+    assert _contains(members, "compiler");
+    assert _contains(members, "capsules/sfn/*");
+}
+
+test "manifest: toml_add_dependency preserves exports" {
+    let original = "[capsule]\nname = \"x\"\nversion = \"0.1.0\"\n\n[exports]\nmodules = [\"client\", \"server\"]\n";
+    let updated = toml_add_dependency(original, "fmt", "0.3.0");
+    let exports = toml_get_exports(updated);
+    assert _contains(exports, "client");
+    assert _contains(exports, "server");
+}
+
+// ---- Existing fields still parse after extension ----
+
+test "manifest: existing fields unaffected by Stage A extensions" {
+    let toml = "[capsule]\nname = \"sailfin\"\nversion = \"0.5.9\"\ndescription = \"the compiler\"\n\n[dependencies]\n\n[capabilities]\nrequired = [\"io\"]\n\n[build]\nentry = \"src/main.sfn\"\nkind = \"binary\"\n";
+    assert _str_eq(toml_get_name(toml), "sailfin");
+    assert _str_eq(toml_get_entry(toml), "src/main.sfn");
+    assert _str_eq(toml_get_build_kind(toml), "binary");
+}

--- a/compiler/tests/unit/manifest_workspace_test.sfn
+++ b/compiler/tests/unit/manifest_workspace_test.sfn
@@ -5,7 +5,6 @@
 // [workspace].members, [exports].modules, and [targets.<triple>] fields.
 // No consumers exist yet — these tests exist to lock down the schema so
 // Stage B has a stable contract to lean on.
-
 import {
     toml_get_build_kind,
     toml_get_build_implicit,
@@ -20,9 +19,7 @@ import {
     toml_add_dependency
 } from "../../src/toml_parser";
 
-fn _str_eq(a: string, b: string) -> boolean {
-    return strings_equal(a, b);
-}
+fn _str_eq(a: string, b: string) -> boolean { return strings_equal(a, b); }
 
 fn _contains(haystack: string, needle: string) -> boolean {
     if needle.length == 0 { return true; }
@@ -47,7 +44,6 @@ fn _contains(haystack: string, needle: string) -> boolean {
 }
 
 // ---- [build].kind ----
-
 test "manifest: build.kind absent returns empty string" {
     let toml = "[capsule]\nname = \"x\"\nversion = \"0.1.0\"\n\n[build]\nentry = \"src/main.sfn\"\n";
     assert _str_eq(toml_get_build_kind(toml), "");
@@ -69,7 +65,6 @@ test "manifest: build.kind runtime parses" {
 }
 
 // ---- [build].implicit ----
-
 test "manifest: build.implicit absent defaults to false" {
     let toml = "[capsule]\nname = \"x\"\nversion = \"0.1.0\"\n\n[build]\nentry = \"src/main.sfn\"\n";
     assert toml_get_build_implicit(toml) == false;
@@ -86,7 +81,6 @@ test "manifest: build.implicit false parses" {
 }
 
 // ---- [workspace].members ----
-
 test "manifest: workspace.members absent returns empty string" {
     let toml = "[capsule]\nname = \"x\"\nversion = \"0.1.0\"\n";
     assert _str_eq(toml_get_workspace_members(toml), "");
@@ -113,7 +107,6 @@ test "manifest: workspace-only file (no [capsule]) parses" {
 }
 
 // ---- [exports].modules ----
-
 test "manifest: exports.modules absent returns empty string" {
     let toml = "[capsule]\nname = \"x\"\nversion = \"0.1.0\"\n";
     assert _str_eq(toml_get_exports(toml), "");
@@ -127,7 +120,6 @@ test "manifest: exports.modules parses newline-separated" {
 }
 
 // ---- [dev-dependencies] (already supported pre-Stage A; lock the contract) ----
-
 test "manifest: dev-dependencies do not leak into [dependencies]" {
     let toml = "[capsule]\nname = \"x\"\nversion = \"0.1.0\"\n\n[dependencies]\n\"http\" = \"0.2.0\"\n\n[dev-dependencies]\n\"test\" = \"0.4.0\"\n";
     let deps = toml_get_dependencies(toml);
@@ -138,7 +130,6 @@ test "manifest: dev-dependencies do not leak into [dependencies]" {
 }
 
 // ---- [targets.<triple>] ----
-
 test "manifest: targets section absent returns empty string" {
     let toml = "[capsule]\nname = \"x\"\nversion = \"0.1.0\"\n";
     assert _str_eq(toml_get_target_triples(toml), "");
@@ -181,7 +172,6 @@ test "manifest: toml_get_string_array missing key returns empty" {
 }
 
 // ---- Round-trip via toml_add_dependency (writes preserve new fields) ----
-
 test "manifest: toml_add_dependency preserves build.kind" {
     let original = "[capsule]\nname = \"x\"\nversion = \"0.1.0\"\n\n[build]\nentry = \"src/mod.sfn\"\nkind = \"library\"\n";
     let updated = toml_add_dependency(original, "http", "0.2.0");
@@ -212,7 +202,6 @@ test "manifest: toml_add_dependency preserves exports" {
 }
 
 // ---- Existing fields still parse after extension ----
-
 test "manifest: existing fields unaffected by Stage A extensions" {
     let toml = "[capsule]\nname = \"sailfin\"\nversion = \"0.5.9\"\ndescription = \"the compiler\"\n\n[dependencies]\n\n[capabilities]\nrequired = [\"io\"]\n\n[build]\nentry = \"src/main.sfn\"\nkind = \"binary\"\n";
     assert _str_eq(toml_get_name(toml), "sailfin");

--- a/docs/proposals/build-architecture.md
+++ b/docs/proposals/build-architecture.md
@@ -1,8 +1,52 @@
 # Proposal: Unified Build Architecture for Sailfin
 
-Status: Draft
-Date: 2026-04-17
+Status: Stage A scoped, ready for grooming
+Date: 2026-04-17 (drafted) · 2026-04-25 (status refreshed)
 Authors: Core Team
+
+## Implementation Status (as of 2026-04-25)
+
+Drift since the original draft:
+
+- **Partial Stage B already shipped.** `compiler/src/capsule_resolver.sfn`
+  (~450 LOC) implements `discover_project_root` →
+  `enumerate_capsule_sources` → `stage_capsule_imports` →
+  `compile_capsule_modules`. `sfn build` and `sfn run` call it via
+  `_prepare_project_capsules` in `cli_main.sfn`, so manifest-declared
+  capsule deps no longer go through textual inlining when a
+  `capsule.toml` is present.
+- **`sfn check` shipped** (April 18 — see `docs/proposals/check-architecture.md`).
+  Provides the parser/typecheck/effect surface the unified driver will reuse.
+- **Phase 6 parallel selfhost shipped.** `make compile` is now ~2 min local
+  / 5:28 CI Linux (was ~13 min serial). The "process-per-module is a cost
+  floor" pressure (Problem 2.4) is partially relieved — Phase 5 (long-lived
+  process) is no longer urgent for the wall-time target.
+
+What is still **not** shipped (and remains the gating work for everything
+downstream):
+
+1. **Manifest schema.** `compiler/src/toml_parser.sfn` does not yet accept
+   `[build].kind`, `[build].implicit`, `[workspace]`, `[dev-dependencies]`,
+   `[targets.*]`, or `[exports]`.
+2. **No `workspace.toml`** at the repo root.
+3. **No `capsules/sfn/prelude/capsule.toml`** wrapping `runtime/prelude.sfn`.
+4. **Stdlib allowlist is still hard-coded** in `_is_stdlib_capsule_cmd`
+   (`compiler/src/cli_commands_utils.sfn:281`).
+5. **Textual inlining still in the fallback path.** `cli_main.sfn:590` calls
+   `inline_imports_for_source` whenever `_prepare_project_capsules` returns
+   empty (no manifest).
+6. **`llvm-objcopy --weaken` hack still in `sfn test`**
+   (`compiler/src/cli_commands.sfn:670`). Needs `sfn/compiler-lib`
+   extraction (Stage B) before it can retire.
+7. **`sfn build` is still single-file.** No `-p <path>`, no `kind=library`
+   artifacts, no `--release`/`--emit=`/`--target=`/`--jobs=`/`--json`.
+8. **Build-script fixups still load-bearing.** `EMIT_RETRIES=3`
+   (`scripts/build.sh:51`) — Stage 4 attempted `EMIT_RETRIES=1` and
+   reverted on April 25 because `instructions.sfn` flakes. The fallback
+   paths in `compile_to_llvm_file_with_module` are also still live.
+
+Stage A (manifest + workspace schema, parse-only) is the next pickable unit
+of work; see Part 5 for the scoped contract.
 
 ## Summary
 
@@ -841,27 +885,121 @@ and is individually revertible.
 **Goal:** Make the declarative future expressible without changing how
 builds actually run.
 
-- Extend `capsule.toml` parser to accept `[build].kind`,
-  `[build].implicit`, `[workspace]`, `[dev-dependencies]`,
-  `[targets.*]`, `[exports]`. The parser accepts them; nothing consumes
-  them yet.
-- Create `workspace.toml` at the repo root, enumerating `compiler`,
-  `runtime-native`, `runtime-prelude` (new — wrapping
-  `runtime/prelude.sfn`), and `capsules/sfn/*` as workspace members.
-- Create `capsules/sfn/prelude/capsule.toml` pointing at `runtime/prelude.sfn`.
-- `build.sh` continues to drive the build. No user-visible change.
+This stage ships parse-only. No consumers, no resolver changes, no
+behavior change in `make compile`, `sfn build`, `sfn run`, or `sfn test`.
+Its only job is to put the schema on disk so Stage B can lean on it.
 
-**Exit criteria:** `make compile && make check` passes; the new manifest
-fields round-trip through the parser; `workspace.toml` loads cleanly.
+#### Concrete work (sized **size:s**, type:refactor)
+
+**In:**
+
+- Extend `compiler/src/toml_parser.sfn` to accept and round-trip the new
+  manifest fields:
+  - `[build].kind` — string, one of `"binary" | "library" | "runtime"`
+  - `[build].implicit` — boolean
+  - `[workspace].members` — string array (glob-friendly: `"capsules/sfn/*"`)
+  - `[dev-dependencies]` — same shape as `[dependencies]`
+  - `[targets.<triple>]` — table with optional `runtime`, `cc`, `cc-flags`,
+    `link-libs`
+  - `[exports]` — string array (re-export allowlist; submodule paths)
+- Add a `ManifestExtensions` accessor module (or extend the existing
+  manifest reader in `capsule_resolver.sfn` / `cli_commands.sfn`) so a
+  caller can ask "does this manifest declare a workspace?" without
+  re-parsing. **No call sites yet** — this is a getter that returns
+  `None`/empty for every existing manifest.
+- Create `workspace.toml` at the repo root with members:
+  ```toml
+  [workspace]
+  members = [
+      "compiler",
+      "runtime-prelude",
+      "capsules/sfn/*",
+  ]
+  ```
+- Create `capsules/sfn/prelude/capsule.toml` (or, equivalently,
+  `runtime-prelude/capsule.toml` — pick one path and stick with it):
+  ```toml
+  [capsule]
+  name = "sfn/prelude"
+  version = "0.5.9"
+  description = "Sailfin standard prelude (collections, strings, type checks)"
+  [capabilities]
+  required = []
+  [build]
+  kind = "library"
+  entry = "../runtime/prelude.sfn"   # or move the file; see open question below
+  implicit = true
+  ```
+- Set the compiler's own `compiler/capsule.toml` to declare
+  `[build].kind = "binary"` (still no consumer; documents intent).
+- Add round-trip unit tests in `compiler/tests/unit/toml_parser_test.sfn`
+  covering each new field, plus a workspace-load test in
+  `compiler/tests/unit/manifest_workspace_test.sfn`.
+
+**Out (explicitly deferred to Stage B):**
+
+- The resolver does not learn about workspace members yet — keep the
+  hard-coded `_is_stdlib_capsule_cmd` allowlist.
+- `inline_imports_for_source` stays as the fallback in `cli_main.sfn:590`.
+- `sfn build -p <path>` is not added.
+- The `llvm-objcopy --weaken` path stays.
+- No changes to `scripts/build.sh` or the Makefile.
+- Do not move `runtime/prelude.sfn` on disk yet (the manifest's `entry`
+  can point at the existing path with `..`). Moving it is a Stage B
+  concern because every consumer's slug changes.
+
+#### Files affected
+
+- `compiler/src/toml_parser.sfn` (extend)
+- `compiler/tests/unit/toml_parser_test.sfn` (extend)
+- `compiler/tests/unit/manifest_workspace_test.sfn` (new)
+- `workspace.toml` (new, repo root)
+- `capsules/sfn/prelude/capsule.toml` (new)
+- `compiler/capsule.toml` (add `[build].kind = "binary"`)
+
+#### Verification
+
+- `ulimit -v 8388608 && make compile` — unchanged behavior.
+- `ulimit -v 8388608 && make test-unit` — new tests pass.
+- `ulimit -v 8388608 && make check` — fixed-point still holds.
+- Manual: `build/native/sailfin emit native workspace.toml` is **not**
+  expected to do anything meaningful; this stage adds parsing, not
+  loading semantics.
+
+#### Exit criteria
+
+- New manifest fields round-trip through `toml_parser.sfn` (covered by
+  unit tests).
+- `workspace.toml` and `capsules/sfn/prelude/capsule.toml` both parse
+  without error and produce the expected struct.
+- `make compile && make check` passes with no behavior delta.
+- The compiler binary size delta is negligible (< 1% — schema-only).
+
+#### Open question to resolve in this stage's PR
+
+- **`sfn/prelude` directory layout.** Either keep `runtime/prelude.sfn` in
+  place and have the new manifest's `entry` point at it via `..`, or move
+  it to `capsules/sfn/prelude/src/mod.sfn` now. Moving it changes every
+  consumer's import slug and `build.sh`'s `slug_from_path` special case
+  for `runtime__prelude`, which is squarely Stage B territory. Default to
+  **keep in place**; revisit at Stage B start.
 
 ### Stage B — Real resolver, retire textual inlining and the weaken hack
 
 **Goal:** One import-resolution code path, used by every CLI command.
 
-- Port `_inline_relative_imports_cmd` into a first-class resolver
-  `compiler/src/resolver/mod.sfn` that returns a `ResolvedGraph`.
+`compiler/src/capsule_resolver.sfn` already covers manifest-declared
+capsule deps (separate-compile via `discover_project_root` →
+`enumerate_capsule_sources` → `stage_capsule_imports` →
+`compile_capsule_modules`). Stage B unifies it with the relative-import
+walker and teaches it to consume the workspace file Stage A produces.
+
+- Fold `_inline_relative_imports_cmd` into `capsule_resolver.sfn` (or a
+  sibling module under `compiler/src/resolver/`) so relative and capsule
+  imports go through the same code path. The output type becomes a
+  `ResolvedGraph` that both `sfn build` and `sfn run` consume.
 - Retire `_is_stdlib_capsule_cmd` — the resolver reads the workspace
-  file to discover that `sfn/http` maps to `capsules/sfn/http`.
+  file (Stage A) to discover that `sfn/http` maps to `capsules/sfn/http`.
 - `sfn run` stops textually inlining imports; it compiles modules
   separately and links them. Diagnostics now reference original files.
 - `sfn test` stops weakening the compiler binary. Tests that need

--- a/workspace.toml
+++ b/workspace.toml
@@ -1,0 +1,11 @@
+# Sailfin workspace manifest
+#
+# Stage A of the unified-build proposal
+# (docs/proposals/build-architecture.md). Parse-only — Stage A ships the
+# schema; Stage B is when the resolver starts consuming this file.
+#
+# Glob expansion of "capsules/sfn/*" is a Stage B concern; today the
+# parser surfaces the literal entries via toml_get_workspace_members().
+
+[workspace]
+members = ["compiler", "capsules/sfn/cli", "capsules/sfn/crypto", "capsules/sfn/fmt", "capsules/sfn/fs", "capsules/sfn/http", "capsules/sfn/json", "capsules/sfn/layers", "capsules/sfn/log", "capsules/sfn/losses", "capsules/sfn/math", "capsules/sfn/net", "capsules/sfn/nn", "capsules/sfn/os", "capsules/sfn/path", "capsules/sfn/prelude", "capsules/sfn/sync", "capsules/sfn/tensor", "capsules/sfn/test", "capsules/sfn/time", "capsules/sfn/toml"]


### PR DESCRIPTION
Drift-correct the proposal against the current state (post 0.5.9):
capsule_resolver.sfn already covers manifest-declared capsule deps
(partial Stage B), sfn check shipped, and Phase 6 parallel selfhost
brought make compile to ~2 min local / 5:28 CI Linux. Phase 5
(long-lived process) is no longer urgent for the wall-time target.

Crystallize Stage A (manifest + workspace schema, parse-only) as a
sized, ready-to-pick scope: extend toml_parser.sfn for [build].kind /
[build].implicit / [workspace] / [dev-dependencies] / [targets.*] /
[exports]; add workspace.toml at the repo root; add
capsules/sfn/prelude/capsule.toml. No consumers, no behavior change.
Concrete file list, exit criteria, and the "keep prelude in place"
default are spelled out so /groom can promote this directly.

Note in Stage B that the resolver work folds into capsule_resolver.sfn
rather than starting from scratch.