### PR TITLE
feat(typecheck): add native-IR → AST converter for imported interfaces

### DIFF
--- a/compiler/src/typecheck.sfn
+++ b/compiler/src/typecheck.sfn
@@ -46,16 +46,40 @@ fn typecheck_diagnostics(program: Program) -> Diagnostic[] {
 // interface list so cross-module `implements` clauses are conformance-
 // checked against the actual member signatures rather than silently
 // no-oping when the lookup misses.
+//
+// Defensive variant filter: `resolve_interface_annotation` looks up
+// interfaces by `.name` without checking the discriminator, and
+// `check_struct_implements_interfaces` then reads `.members`, so any
+// non-InterfaceDeclaration statement passing through here would either
+// crash or misbehave on the `.members` access. Today the only producer
+// is `interface_statement_from_native` which only emits
+// `Statement.InterfaceDeclaration`, but filtering at the API boundary
+// keeps the contract enforceable for future callers (e.g. `sfn lsp`).
 fn typecheck_diagnostics_with_imports(program: Program, imported_interfaces: Statement[]) -> Diagnostic[] {
     let top_level = collect_top_level_symbols(program);
     let local_interfaces = collect_interface_definitions(program);
-    let combined_interfaces = local_interfaces.concat(imported_interfaces);
+    let filtered_imports = _filter_interface_declarations(imported_interfaces);
+    let combined_interfaces = local_interfaces.concat(filtered_imports);
     let scoped_diagnostics = check_program_scopes(program, combined_interfaces);
 
     // Merge diagnostics using concat (avoids loop-with-if-break pattern that
     // the compiler lowers incorrectly — loops emit without exit conditions).
     let diagnostics_with_scopes = top_level.diagnostics.concat(scoped_diagnostics);
     return diagnostics_with_scopes;
+}
+
+fn _filter_interface_declarations(statements: Statement[]) -> Statement[] {
+    let mut out: Statement[] = [];
+    let mut i: number = 0;
+    loop {
+        if i >= statements.length { break; }
+        let s = statements[i];
+        if strings_equal(s.variant, "InterfaceDeclaration") {
+            out.push(s);
+        }
+        i += 1;
+    }
+    return out;
 }
 
 fn typecheck_error_count(program: Program) -> number {

--- a/compiler/src/typecheck.sfn
+++ b/compiler/src/typecheck.sfn
@@ -36,9 +36,21 @@ import {
 } from "./typecheck_types";
 
 fn typecheck_diagnostics(program: Program) -> Diagnostic[] {
+    let empty_imports: Statement[] = [];
+    return typecheck_diagnostics_with_imports(program, empty_imports);
+}
+
+// Cross-module-aware variant. `imported_interfaces` carries interface
+// declarations sourced from the import-context layer (see
+// typecheck_imports.sfn). They are concatenated onto the program's local
+// interface list so cross-module `implements` clauses are conformance-
+// checked against the actual member signatures rather than silently
+// no-oping when the lookup misses.
+fn typecheck_diagnostics_with_imports(program: Program, imported_interfaces: Statement[]) -> Diagnostic[] {
     let top_level = collect_top_level_symbols(program);
-    let interfaces = collect_interface_definitions(program);
-    let scoped_diagnostics = check_program_scopes(program, interfaces);
+    let local_interfaces = collect_interface_definitions(program);
+    let combined_interfaces = local_interfaces.concat(imported_interfaces);
+    let scoped_diagnostics = check_program_scopes(program, combined_interfaces);
 
     // Merge diagnostics using concat (avoids loop-with-if-break pattern that
     // the compiler lowers incorrectly — loops emit without exit conditions).

--- a/compiler/src/typecheck_imports.sfn
+++ b/compiler/src/typecheck_imports.sfn
@@ -1,0 +1,160 @@
+// compiler/src/typecheck_imports.sfn
+//
+// Bridge between the native-IR import-context layer and the typechecker's
+// AST-level symbol model. Lets the typechecker see interface declarations
+// from imported modules so cross-module `implements` clauses are
+// conformance-checked against their actual interface definitions.
+//
+// Today the textual import inliner used by `sfn check` brings imported
+// interfaces into the typechecker's `interfaces` list as a side effect of
+// concatenating sources. As that inliner retires (Stage B PR2 of the
+// unified-build architecture), the typechecker needs an explicit channel
+// for cross-module interface info. This module is that channel.
+//
+// Scope of this module:
+// - Pure converters from native-IR shapes (`NativeInterface`,
+//   `NativeInterfaceSignature`, `NativeParameter`) to AST shapes
+//   (`Statement.InterfaceDeclaration`, `FunctionSignature`, `Parameter`).
+// - No I/O. The companion I/O wrapper (added alongside the new typecheck
+//   entry point) lives in the same file once it lands; for now this
+//   module is converter-only so it can be exercised by unit tests
+//   without touching the filesystem.
+//
+// See docs/proposals/check-architecture.md and
+// docs/proposals/build-architecture.md (Stage B PR2) for the design
+// rationale.
+import {
+    Decorator,
+    FunctionSignature,
+    Parameter,
+    Statement,
+    TypeAnnotation,
+    TypeParameter
+} from "./ast";
+import {
+    NativeInterface,
+    NativeInterfaceSignature,
+    NativeParameter
+} from "./native_ir";
+
+// -------------------------------------------------------------------
+// Field-level converters
+// -------------------------------------------------------------------
+
+fn _type_annotation_or_null_from_text(text: string) -> TypeAnnotation? {
+    if text.length == 0 { return null; }
+    return TypeAnnotation { text: text };
+}
+
+fn parameter_from_native(native: NativeParameter) -> Parameter {
+    let annotation: TypeAnnotation? = _type_annotation_or_null_from_text(native.type_annotation);
+    return Parameter {
+        name: native.name,
+        type_annotation: annotation,
+        default_value: null,
+        mutable: native.mutable,
+        span: null
+    };
+}
+
+fn parameters_from_native(natives: NativeParameter[]) -> Parameter[] {
+    let mut out: Parameter[] = [];
+    let mut i: number = 0;
+    loop {
+        if i >= natives.length { break; }
+        out.push(parameter_from_native(natives[i]));
+        i += 1;
+    }
+    return out;
+}
+
+fn type_parameter_from_name(name: string) -> TypeParameter {
+    return TypeParameter {
+        name: name,
+        bound: null,
+        span: null
+    };
+}
+
+fn type_parameters_from_names(names: string[]) -> TypeParameter[] {
+    let mut out: TypeParameter[] = [];
+    let mut i: number = 0;
+    loop {
+        if i >= names.length { break; }
+        out.push(type_parameter_from_name(names[i]));
+        i += 1;
+    }
+    return out;
+}
+
+fn _copy_string_array(items: string[]) -> string[] {
+    let mut out: string[] = [];
+    let mut i: number = 0;
+    loop {
+        if i >= items.length { break; }
+        out.push(items[i]);
+        i += 1;
+    }
+    return out;
+}
+
+fn function_signature_from_native_interface_signature(native: NativeInterfaceSignature) -> FunctionSignature {
+    let return_type: TypeAnnotation? = _type_annotation_or_null_from_text(native.return_type);
+    return FunctionSignature {
+        name: native.name,
+        is_async: native.is_async,
+        parameters: parameters_from_native(native.parameters),
+        return_type: return_type,
+        effects: _copy_string_array(native.effects),
+        type_parameters: type_parameters_from_names(native.type_parameters),
+        name_span: null
+    };
+}
+
+fn function_signatures_from_native(signatures: NativeInterfaceSignature[]) -> FunctionSignature[] {
+    let mut out: FunctionSignature[] = [];
+    let mut i: number = 0;
+    loop {
+        if i >= signatures.length { break; }
+        out.push(function_signature_from_native_interface_signature(signatures[i]));
+        i += 1;
+    }
+    return out;
+}
+
+// -------------------------------------------------------------------
+// Top-level converter
+// -------------------------------------------------------------------
+
+fn interface_statement_from_native(native: NativeInterface) -> Statement {
+    let empty_decorators: Decorator[] = [];
+    return Statement.InterfaceDeclaration {
+        name: native.name,
+        name_span: null,
+        type_parameters: type_parameters_from_names(native.type_parameters),
+        members: function_signatures_from_native(native.signatures),
+        decorators: empty_decorators
+    };
+}
+
+fn interfaces_from_native(natives: NativeInterface[]) -> Statement[] {
+    let mut out: Statement[] = [];
+    let mut i: number = 0;
+    loop {
+        if i >= natives.length { break; }
+        out.push(interface_statement_from_native(natives[i]));
+        i += 1;
+    }
+    return out;
+}
+
+export {
+    function_signature_from_native_interface_signature,
+    function_signatures_from_native,
+    interface_statement_from_native,
+    interfaces_from_native,
+    parameter_from_native,
+    parameters_from_native,
+    type_parameter_from_name,
+    type_parameters_from_names
+};

--- a/compiler/src/typecheck_imports.sfn
+++ b/compiler/src/typecheck_imports.sfn
@@ -33,18 +33,26 @@ import {
     TypeAnnotation,
     TypeParameter
 } from "./ast";
-import {
-    NativeInterface,
-    NativeInterfaceSignature,
-    NativeParameter
-} from "./native_ir";
+import { NativeInterface, NativeInterfaceSignature, NativeParameter } from "./native_ir";
 
 // -------------------------------------------------------------------
 // Field-level converters
 // -------------------------------------------------------------------
-
+// The .sfn-asm round-trip is intentionally lossy on the absence of an
+// explicit return type: the emitter writes nothing after `()` when the
+// source-level FunctionSignature has `return_type: null`, and the
+// parser (`native_ir_utils_parse.sfn`) defaults the parsed return type
+// to the literal string "void" when no `-> T` clause is present. So
+// when we convert back to AST, "void" is the canonical signal for "no
+// return type" and must map to `null` to match the parser's typical
+// output for `fn bar();`-style signatures. Source-level
+// `fn bar() -> void;` collapses to the same shape — the language
+// treats both as "returns no useful value" so the conformance and
+// signature-fidelity checks downstream already need to consider them
+// equivalent.
 fn _type_annotation_or_null_from_text(text: string) -> TypeAnnotation? {
     if text.length == 0 { return null; }
+    if strings_equal(text, "void") { return null; }
     return TypeAnnotation { text: text };
 }
 
@@ -71,11 +79,7 @@ fn parameters_from_native(natives: NativeParameter[]) -> Parameter[] {
 }
 
 fn type_parameter_from_name(name: string) -> TypeParameter {
-    return TypeParameter {
-        name: name,
-        bound: null,
-        span: null
-    };
+    return TypeParameter { name: name, bound: null, span: null };
 }
 
 fn type_parameters_from_names(names: string[]) -> TypeParameter[] {
@@ -127,7 +131,6 @@ fn function_signatures_from_native(signatures: NativeInterfaceSignature[]) -> Fu
 // -------------------------------------------------------------------
 // Top-level converter
 // -------------------------------------------------------------------
-
 fn interface_statement_from_native(native: NativeInterface) -> Statement {
     let empty_decorators: Decorator[] = [];
     return Statement.InterfaceDeclaration {

--- a/compiler/src/typecheck_imports.sfn
+++ b/compiler/src/typecheck_imports.sfn
@@ -15,10 +15,12 @@
 // - Pure converters from native-IR shapes (`NativeInterface`,
 //   `NativeInterfaceSignature`, `NativeParameter`) to AST shapes
 //   (`Statement.InterfaceDeclaration`, `FunctionSignature`, `Parameter`).
-// - No I/O. The companion I/O wrapper (added alongside the new typecheck
-//   entry point) lives in the same file once it lands; for now this
-//   module is converter-only so it can be exercised by unit tests
-//   without touching the filesystem.
+// - No I/O, no native-IR parser dependency. This module is a leaf
+//   (depends only on `ast` and `native_ir`, both of which are themselves
+//   type-only) so any test or future consumer can pull it in without
+//   incurring the heavier native-IR parser graph. The `.sfn-asm`-text
+//   helper and the on-disk loader live alongside the eventual
+//   `cli_check`/resolver integration in A2.
 //
 // See docs/proposals/check-architecture.md and
 // docs/proposals/build-architecture.md (Stage B PR2) for the design

--- a/compiler/tests/unit/typecheck_imports_test.sfn
+++ b/compiler/tests/unit/typecheck_imports_test.sfn
@@ -8,12 +8,7 @@
 // test bodies — see check_tool_test.sfn preamble).
 //
 // See docs/proposals/check-architecture.md.
-
-import {
-    NativeInterface,
-    NativeInterfaceSignature,
-    NativeParameter
-} from "../../src/native_ir";
+import { NativeInterface, NativeInterfaceSignature, NativeParameter } from "../../src/native_ir";
 import {
     interface_statement_from_native,
     interfaces_from_native,
@@ -24,7 +19,6 @@ import {
 // -------------------------------------------------------------------
 // Builder helpers (avoid nested struct literals in test bodies)
 // -------------------------------------------------------------------
-
 fn _make_native_parameter(name: string, type_annotation: string, mutable: boolean) -> NativeParameter {
     return NativeParameter {
         name: name,
@@ -72,7 +66,6 @@ fn _make_native_interface(name: string, type_parameters: string[], signatures: N
 // -------------------------------------------------------------------
 // Tests — parameter_from_native
 // -------------------------------------------------------------------
-
 test "typecheck_imports: parameter copies name and mutable" {
     let native = _make_native_parameter("count", "number", true);
     let converted = parameter_from_native(native);
@@ -103,7 +96,6 @@ test "typecheck_imports: parameter clears default and span" {
 // -------------------------------------------------------------------
 // Tests — type_parameter_from_name
 // -------------------------------------------------------------------
-
 test "typecheck_imports: type parameter preserves name" {
     let tp = type_parameter_from_name("T");
     assert strings_equal(tp.name, "T");
@@ -114,7 +106,6 @@ test "typecheck_imports: type parameter preserves name" {
 // -------------------------------------------------------------------
 // Tests — interface_statement_from_native (single interface)
 // -------------------------------------------------------------------
-
 test "typecheck_imports: interface preserves name and variant" {
     let no_type_params: string[] = [];
     let no_sigs: NativeInterfaceSignature[] = [];
@@ -168,7 +159,6 @@ test "typecheck_imports: interface decorators default to empty" {
 // -------------------------------------------------------------------
 // Tests — member signature fidelity
 // -------------------------------------------------------------------
-
 test "typecheck_imports: member signature roundtrips parameters" {
     let p_a = _make_native_parameter("buf", "Bytes", false);
     let p_b = _make_native_parameter("len", "number", false);
@@ -230,10 +220,30 @@ test "typecheck_imports: member signature leaves empty return type null" {
     assert member.return_type == null;
 }
 
+test "typecheck_imports: native \"void\" return type maps to null" {
+    // The .sfn-asm parser (`native_ir_utils_parse.sfn`) defaults
+    // `return_type` to the literal "void" when no `-> T` clause is
+    // present. The converter must collapse that back to null so
+    // imported interface signatures match the source-level AST shape
+    // produced by the parser for `fn bar();`-style declarations.
+    // Without this mapping, future cross-module signature-fidelity
+    // checks would see false mismatches against locally-parsed
+    // signatures whose return type is null.
+    let no_params: NativeParameter[] = [];
+    let no_effects: string[] = [];
+    let sig = _make_native_interface_signature_with("close", no_params, "void", no_effects);
+    let sigs: NativeInterfaceSignature[] = [sig];
+    let no_type_params: string[] = [];
+    let native = _make_native_interface("Closeable", no_type_params, sigs);
+
+    let stmt = interface_statement_from_native(native);
+    let member = stmt.members[0];
+    assert member.return_type == null;
+}
+
 // -------------------------------------------------------------------
 // Tests — interfaces_from_native (batch)
 // -------------------------------------------------------------------
-
 test "typecheck_imports: empty native list yields empty statements" {
     let empty: NativeInterface[] = [];
     let result = interfaces_from_native(empty);

--- a/compiler/tests/unit/typecheck_imports_test.sfn
+++ b/compiler/tests/unit/typecheck_imports_test.sfn
@@ -1,0 +1,256 @@
+// Unit tests for compiler/src/typecheck_imports.sfn — pure converters
+// from native-IR interface descriptors to AST statements.
+//
+// Tests construct NativeInterface / NativeInterfaceSignature /
+// NativeParameter values via small helper functions. The helpers wrap
+// the struct literals so test bodies stay flat (some seed compilers
+// previously segfaulted on deeply nested struct-literal initialisers in
+// test bodies — see check_tool_test.sfn preamble).
+//
+// See docs/proposals/check-architecture.md.
+
+import {
+    NativeInterface,
+    NativeInterfaceSignature,
+    NativeParameter
+} from "../../src/native_ir";
+import {
+    interface_statement_from_native,
+    interfaces_from_native,
+    parameter_from_native,
+    type_parameter_from_name
+} from "../../src/typecheck_imports";
+
+// -------------------------------------------------------------------
+// Builder helpers (avoid nested struct literals in test bodies)
+// -------------------------------------------------------------------
+
+fn _make_native_parameter(name: string, type_annotation: string, mutable: boolean) -> NativeParameter {
+    return NativeParameter {
+        name: name,
+        type_annotation: type_annotation,
+        mutable: mutable,
+        default_value: null,
+        span: null
+    };
+}
+
+fn _make_native_interface_signature_no_params(name: string, return_type: string) -> NativeInterfaceSignature {
+    let no_params: NativeParameter[] = [];
+    let no_type_params: string[] = [];
+    let no_effects: string[] = [];
+    return NativeInterfaceSignature {
+        name: name,
+        is_async: false,
+        type_parameters: no_type_params,
+        parameters: no_params,
+        return_type: return_type,
+        effects: no_effects
+    };
+}
+
+fn _make_native_interface_signature_with(name: string, params: NativeParameter[], return_type: string, effects: string[]) -> NativeInterfaceSignature {
+    let no_type_params: string[] = [];
+    return NativeInterfaceSignature {
+        name: name,
+        is_async: false,
+        type_parameters: no_type_params,
+        parameters: params,
+        return_type: return_type,
+        effects: effects
+    };
+}
+
+fn _make_native_interface(name: string, type_parameters: string[], signatures: NativeInterfaceSignature[]) -> NativeInterface {
+    return NativeInterface {
+        name: name,
+        type_parameters: type_parameters,
+        signatures: signatures
+    };
+}
+
+// -------------------------------------------------------------------
+// Tests — parameter_from_native
+// -------------------------------------------------------------------
+
+test "typecheck_imports: parameter copies name and mutable" {
+    let native = _make_native_parameter("count", "number", true);
+    let converted = parameter_from_native(native);
+    assert strings_equal(converted.name, "count");
+    assert converted.mutable == true;
+}
+
+test "typecheck_imports: parameter wraps non-empty type annotation" {
+    let native = _make_native_parameter("payload", "Order", false);
+    let converted = parameter_from_native(native);
+    assert converted.type_annotation != null;
+    assert strings_equal(converted.type_annotation.text, "Order");
+}
+
+test "typecheck_imports: parameter leaves blank type annotation null" {
+    let native = _make_native_parameter("anon", "", false);
+    let converted = parameter_from_native(native);
+    assert converted.type_annotation == null;
+}
+
+test "typecheck_imports: parameter clears default and span" {
+    let native = _make_native_parameter("x", "number", false);
+    let converted = parameter_from_native(native);
+    assert converted.default_value == null;
+    assert converted.span == null;
+}
+
+// -------------------------------------------------------------------
+// Tests — type_parameter_from_name
+// -------------------------------------------------------------------
+
+test "typecheck_imports: type parameter preserves name" {
+    let tp = type_parameter_from_name("T");
+    assert strings_equal(tp.name, "T");
+    assert tp.bound == null;
+    assert tp.span == null;
+}
+
+// -------------------------------------------------------------------
+// Tests — interface_statement_from_native (single interface)
+// -------------------------------------------------------------------
+
+test "typecheck_imports: interface preserves name and variant" {
+    let no_type_params: string[] = [];
+    let no_sigs: NativeInterfaceSignature[] = [];
+    let native = _make_native_interface("Closeable", no_type_params, no_sigs);
+    let stmt = interface_statement_from_native(native);
+    assert strings_equal(stmt.variant, "InterfaceDeclaration");
+    assert strings_equal(stmt.name, "Closeable");
+}
+
+test "typecheck_imports: interface with no members yields empty members" {
+    let no_type_params: string[] = [];
+    let no_sigs: NativeInterfaceSignature[] = [];
+    let native = _make_native_interface("Empty", no_type_params, no_sigs);
+    let stmt = interface_statement_from_native(native);
+    assert stmt.members.length == 0;
+    assert stmt.type_parameters.length == 0;
+}
+
+test "typecheck_imports: interface with members preserves member names" {
+    let sig_a = _make_native_interface_signature_no_params("close", "void");
+    let sig_b = _make_native_interface_signature_no_params("flush", "void");
+    let sigs: NativeInterfaceSignature[] = [sig_a, sig_b];
+    let no_type_params: string[] = [];
+    let native = _make_native_interface("Closeable", no_type_params, sigs);
+
+    let stmt = interface_statement_from_native(native);
+    assert stmt.members.length == 2;
+    assert strings_equal(stmt.members[0].name, "close");
+    assert strings_equal(stmt.members[1].name, "flush");
+}
+
+test "typecheck_imports: interface preserves type parameter arity" {
+    let no_sigs: NativeInterfaceSignature[] = [];
+    let type_params: string[] = ["T", "E"];
+    let native = _make_native_interface("Result", type_params, no_sigs);
+
+    let stmt = interface_statement_from_native(native);
+    assert stmt.type_parameters.length == 2;
+    assert strings_equal(stmt.type_parameters[0].name, "T");
+    assert strings_equal(stmt.type_parameters[1].name, "E");
+}
+
+test "typecheck_imports: interface decorators default to empty" {
+    let no_type_params: string[] = [];
+    let no_sigs: NativeInterfaceSignature[] = [];
+    let native = _make_native_interface("Closeable", no_type_params, no_sigs);
+    let stmt = interface_statement_from_native(native);
+    assert stmt.decorators.length == 0;
+}
+
+// -------------------------------------------------------------------
+// Tests — member signature fidelity
+// -------------------------------------------------------------------
+
+test "typecheck_imports: member signature roundtrips parameters" {
+    let p_a = _make_native_parameter("buf", "Bytes", false);
+    let p_b = _make_native_parameter("len", "number", false);
+    let params: NativeParameter[] = [p_a, p_b];
+    let no_effects: string[] = [];
+    let sig = _make_native_interface_signature_with("write", params, "number", no_effects);
+    let sigs: NativeInterfaceSignature[] = [sig];
+    let no_type_params: string[] = [];
+    let native = _make_native_interface("Writer", no_type_params, sigs);
+
+    let stmt = interface_statement_from_native(native);
+    assert stmt.members.length == 1;
+    let member = stmt.members[0];
+    assert member.parameters.length == 2;
+    assert strings_equal(member.parameters[0].name, "buf");
+    assert strings_equal(member.parameters[1].name, "len");
+    assert strings_equal(member.parameters[0].type_annotation.text, "Bytes");
+}
+
+test "typecheck_imports: member signature preserves effects" {
+    let no_params: NativeParameter[] = [];
+    let effects: string[] = ["io", "net"];
+    let sig = _make_native_interface_signature_with("send", no_params, "void", effects);
+    let sigs: NativeInterfaceSignature[] = [sig];
+    let no_type_params: string[] = [];
+    let native = _make_native_interface("Channel", no_type_params, sigs);
+
+    let stmt = interface_statement_from_native(native);
+    let member = stmt.members[0];
+    assert member.effects.length == 2;
+    assert strings_equal(member.effects[0], "io");
+    assert strings_equal(member.effects[1], "net");
+}
+
+test "typecheck_imports: member signature wraps return type when present" {
+    let no_params: NativeParameter[] = [];
+    let no_effects: string[] = [];
+    let sig = _make_native_interface_signature_with("name", no_params, "string", no_effects);
+    let sigs: NativeInterfaceSignature[] = [sig];
+    let no_type_params: string[] = [];
+    let native = _make_native_interface("Named", no_type_params, sigs);
+
+    let stmt = interface_statement_from_native(native);
+    let member = stmt.members[0];
+    assert member.return_type != null;
+    assert strings_equal(member.return_type.text, "string");
+}
+
+test "typecheck_imports: member signature leaves empty return type null" {
+    let no_params: NativeParameter[] = [];
+    let no_effects: string[] = [];
+    let sig = _make_native_interface_signature_with("init", no_params, "", no_effects);
+    let sigs: NativeInterfaceSignature[] = [sig];
+    let no_type_params: string[] = [];
+    let native = _make_native_interface("Bootstrappable", no_type_params, sigs);
+
+    let stmt = interface_statement_from_native(native);
+    let member = stmt.members[0];
+    assert member.return_type == null;
+}
+
+// -------------------------------------------------------------------
+// Tests — interfaces_from_native (batch)
+// -------------------------------------------------------------------
+
+test "typecheck_imports: empty native list yields empty statements" {
+    let empty: NativeInterface[] = [];
+    let result = interfaces_from_native(empty);
+    assert result.length == 0;
+}
+
+test "typecheck_imports: multiple natives are converted in order" {
+    let no_type_params: string[] = [];
+    let no_sigs: NativeInterfaceSignature[] = [];
+    let a = _make_native_interface("A", no_type_params, no_sigs);
+    let b = _make_native_interface("B", no_type_params, no_sigs);
+    let c = _make_native_interface("C", no_type_params, no_sigs);
+    let natives: NativeInterface[] = [a, b, c];
+
+    let result = interfaces_from_native(natives);
+    assert result.length == 3;
+    assert strings_equal(result[0].name, "A");
+    assert strings_equal(result[1].name, "B");
+    assert strings_equal(result[2].name, "C");
+}

--- a/docs/proposals/build-architecture.md
+++ b/docs/proposals/build-architecture.md
@@ -1,7 +1,7 @@
 # Proposal: Unified Build Architecture for Sailfin
 
-Status: Stage A shipped; Stage B split into two PRs, PR1 shipped, PR2 next
-Date: 2026-04-17 (drafted) · 2026-04-25 (status refreshed) · 2026-04-25 (Stage B PR1 landed)
+Status: Stage A shipped; Stage B split into two PRs, PR1 shipped, PR2 in progress (A1 hookup landed)
+Date: 2026-04-17 (drafted) · 2026-04-25 (status refreshed) · 2026-04-25 (Stage B PR1 landed) · 2026-04-25 (PR2/A1 typecheck hookup landed)
 Authors: Core Team
 
 ## Implementation Status (as of 2026-04-25, end of Stage B PR1)
@@ -69,10 +69,21 @@ that turned out to be architecturally coupled to libextract:
 
 2. **`sfn check` migration.** `tools/check.check_source` operates on a
    single source string and has no notion of cross-module symbols.
-   Today the textual inliner is the only reason imported names resolve.
-   Migrating means extending typecheck to load layout-manifests so
-   imported symbol references don't trip "undefined" diagnostics — a
-   non-trivial typechecker change.
+   Today the textual inliner is the only reason imported interface
+   declarations are visible to `check_struct_implements_interfaces`
+   in `typecheck_types.sfn`. (The typechecker does not currently emit
+   any "undefined symbol" diagnostic — earlier framing of this point
+   was wrong on that detail. The single load-bearing case the inliner
+   covers is cross-module interface conformance.)
+
+   A1 of Track A ships the typechecker-side hookup
+   (`compiler/src/typecheck_imports.sfn` plus
+   `typecheck_diagnostics_with_imports`). The remaining work for PR2
+   is the resolver-side hookup: extract `.sfn-asm` paths from the
+   project's resolved capsule graph, feed them into
+   `load_imported_interfaces_from_paths` (lands in A2 alongside
+   `cli_check.sfn` integration), and pass the resulting interface
+   list into the new typecheck entry point.
 
 3. **Delete the legacy helpers.** Once `sfn test` and `sfn check` are
    migrated, delete `_inline_relative_imports_cmd`,
@@ -1116,18 +1127,35 @@ coupled to the libextract work originally scoped here:
   for tests. PR1 reverted its test-runner wiring after confirming the
   link error empirically.
 - **`sfn check`**: `tools/check.check_source` operates on a single
-  source string with no notion of cross-module symbols. Without
-  textual inlining, every imported name becomes "undefined". Migrating
-  needs typecheck to load layout-manifests.
+  source string with no notion of cross-module symbols. The
+  load-bearing case the textual inliner covers is cross-module
+  interface conformance — without it, `check_struct_implements_interfaces`
+  silently no-ops on `implements` clauses that point at an interface
+  declared in another module. (Earlier framing assumed the inliner was
+  also preventing "undefined symbol" diagnostics; investigation showed
+  the typechecker emits no such diagnostic today.) Migrating means
+  feeding the typechecker the imported interface set explicitly.
 
-PR2's full scope:
+PR2's full scope, organized as Track A:
 
+- **A1 (shipped):** Add `compiler/src/typecheck_imports.sfn` (pure
+  `NativeInterface → Statement.InterfaceDeclaration` converter, leaf
+  module) and `typecheck_diagnostics_with_imports(program,
+  imported_interfaces)`. Original `typecheck_diagnostics` becomes a
+  one-line wrapper. Self-hosts; stage2/stage3 fixed point holds. See
+  `docs/proposals/check-architecture.md` for details.
+- **A2 (next):** Add the `.sfn-asm`-text helper plus on-disk loader
+  (`load_imported_interfaces_from_paths`) — likely in a new module
+  that depends on `native_ir_api`. Wire `cli_check.sfn` through the
+  unified resolver (`prepare_project_capsules`) and pass loaded
+  interfaces into the new typecheck entry point. Delete
+  `inline_imports_for_source`'s `sfn check` call site.
+- **A3:** Diagnostic struct enhancement (`severity`, `file_path`).
+- **A4:** Delete legacy helpers once the test path also migrates.
 - Pick a fix path for `sfn test` mangling (see PR1's
   `entrypoints_tests_writer.sfn` change for one starting attempt — it
   loaded import-context but the mangle-symbols mismatch defeated it)
   and migrate `handle_test_command` to consume the resolver.
-- Extend `check_source` to load layout-manifests so `sfn check`
-  resolves cross-module imports without textual inlining.
 - Extract `sfn/compiler-lib` from `compiler/src/` (everything except
   `cli_main.sfn`, `cli_commands.sfn`, `cli_commands_utils.sfn`) so
   tests that need compiler internals depend on it as a dev-dep.

--- a/docs/proposals/check-architecture.md
+++ b/docs/proposals/check-architecture.md
@@ -1,7 +1,7 @@
 # Architecture: `sfn check` — Fast Analysis Without Codegen
 
 Status: Shipped (initial v1 — parse + typecheck + effect-check, default stderr rendering, `--quiet`)
-Date: April 15, 2026 (design); shipped April 18, 2026
+Date: April 15, 2026 (design); shipped April 18, 2026; A1 (cross-module conformance hookup) shipped April 25, 2026
 Parent: [docs/proposals/tooling.md](../proposals/tooling.md)
 
 ## Implementation Status
@@ -9,13 +9,49 @@ Parent: [docs/proposals/tooling.md](../proposals/tooling.md)
 The initial implementation ships in `compiler/src/tools/check.sfn` and is wired
 into the CLI as `sfn check`. Covered by `compiler/tests/unit/check_tool_test.sfn`.
 
-Still deferred to a follow-up:
+### Continuation: Track A — retire textual import inlining
+
+Track A migrates `sfn check` off the legacy textual inliner so it can share
+the unified resolver introduced in Stage B PR1 of the build architecture
+(`docs/proposals/build-architecture.md`). The track splits into four
+sub-PRs:
+
+- **A1 — typechecker hookup (shipped April 25, 2026).**
+  New leaf module `compiler/src/typecheck_imports.sfn` converts
+  `NativeInterface` descriptors (extracted from `.sfn-asm` import-context
+  artifacts) into `Statement.InterfaceDeclaration` values the typechecker
+  understands. New entry point `typecheck_diagnostics_with_imports(program,
+  imported_interfaces)` accepts that converted list and concatenates it
+  onto the program's local interface set before running
+  `check_program_scopes`. The original `typecheck_diagnostics(program)`
+  becomes a one-line wrapper that calls the new entry with `[]`. Coverage:
+  16 unit tests in `compiler/tests/unit/typecheck_imports_test.sfn`. The
+  empty-imports path is exercised on every module during selfhost; the
+  stage2/stage3 fixed-point holds.
+- **A2 — resolver wiring (next).** Add the artifact-text helper and the
+  on-disk loader (`load_imported_interfaces_from_paths`) to a separate
+  module that depends on `native_ir_api`, then wire `cli_check.sfn`
+  through `prepare_project_capsules` and pass the resulting interface
+  list into `typecheck_diagnostics_with_imports`. Delete the
+  `inline_imports_for_source` call in `cli_check.sfn`. Cross-module
+  interface conformance becomes live for end users.
+- **A3 — diagnostic enhancement.** Add `severity` and `file_path`
+  fields to `Diagnostic` (the deferred Phase 1 item below). With A2
+  in place every diagnostic naturally carries the originating module
+  path, so the renderer can drop its single-file assumption.
+- **A4 — delete legacy helpers.** Remove `inline_imports_for_source`,
+  `_inline_relative_imports_cmd`, and `_is_stdlib_capsule_cmd` once
+  the test path (Stage B PR2's `sfn test` migration) lands too.
+
+### Still deferred to a follow-up
 
 - Diagnostic struct enhancement (Phase 1 — `severity` and `file_path` fields).
-  The v1 renderer synthesises severity from the error code instead.
+  The v1 renderer synthesises severity from the error code instead. Slated
+  for A3 above.
 - Fix-it suggestion edits (Phase 2 — `FixSuggestion`/`TextEdit` structs).
 - `make check-fast` target and CI pre-build wiring.
 - Parallel / cached multi-file checking.
+- `--json` output (LLM Adoption Strategy lever #3 — see CLAUDE.md).
 
 
 ## Overview

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,6 +1,6 @@
 # Status
 
-Updated: April 25, 2026
+Updated: April 25, 2026 (typecheck cross-module conformance hookup — A1)
 
 This document tracks what works today and what is in progress. It is the source
 of truth — consult it before editing docs, examples, or making claims about
@@ -27,7 +27,10 @@ feature availability.
 - **`sfn test` and `sfn check` still use textual inlining** via the legacy
   `_inline_relative_imports_cmd` and `inline_imports_for_source` helpers.
   Migrating them is Stage B PR2 (coupled to the `sfn/compiler-lib`
-  extraction — see `docs/proposals/build-architecture.md`).
+  extraction — see `docs/proposals/build-architecture.md`). The
+  typechecker-side hookup for `sfn check`'s migration shipped in A1
+  (`compiler/src/typecheck_imports.sfn` + `typecheck_diagnostics_with_imports`)
+  — the in-process resolver wiring lands in A2.
 - `make compile` builds the compiler from a released seed. `make check`
   validates the seedcheck binary can run `hello-world.sfn` and pass the test suite.
 - **Deterministic self-hosting**: the compiler is a verified fixed point —
@@ -95,7 +98,7 @@ feature availability.
 | `unsafe` / `extern` | Parsed only | Syntax accepted; enforcement not active |
 | Policy decorators (`@policy(...)`) | Parsed only | No compiler or runtime effect |
 | `sfn fmt` (formatter) | **Shipped** | Token-stream formatter: indentation, spacing, inline blocks, unary operator handling, import sorting & specifier reordering, blank line normalization, `--check`/`--write` modes, CI enforcement; see `docs/proposals/fmt-architecture.md` for architecture and known limitations |
-| `sfn check` (fast analysis) | **Shipped** | Runs parse + typecheck + effect-check on `.sfn` sources without emitting IR or invoking `clang`. Reports diagnostics to stderr with a summary on stdout. Exits non-zero on findings. See `docs/proposals/check-architecture.md`. |
+| `sfn check` (fast analysis) | **Shipped (v1)** | Runs parse + typecheck + effect-check on `.sfn` sources without emitting IR or invoking `clang`. Reports diagnostics to stderr with a summary on stdout. Exits non-zero on findings. Currently runs on a single textually-inlined buffer per file; cross-module interface conformance will become live once A2 wires the unified resolver in. See `docs/proposals/check-architecture.md`. |
 | `sfn vet` (static analyzer) | Planned | Pre-1.0; see `docs/proposals/tooling.md` |
 | `sfn lsp` (language server) | Planned | Phase 1 pre-1.0; see `docs/proposals/tooling.md` |
 | `sfn doc` (doc generator) | Planned | 1.0; see `docs/proposals/tooling.md` |


### PR DESCRIPTION
Bridge module that converts NativeInterface descriptors (from .sfn-asm
import-context artifacts) into Statement.InterfaceDeclaration values the
typechecker can consume. Pure functions only — no I/O.

Prerequisite for retiring `sfn check`'s textual import inliner. Today the
inliner is the only thing that brings cross-module interface declarations
into typecheck's `interfaces` list, which the conformance check
(check_struct_implements_interfaces in typecheck_types.sfn) walks when a
struct says `implements Foo`. Once the inliner retires, this converter
plus a forthcoming `typecheck_diagnostics_with_imports` entry point keep
that conformance check working.

The converter preserves member names, parameters (name/type/mutable),
return types, effects, and type-parameter arity — fields the conformance
check ignores today but that future cross-module signature/effect checks
will need.

Coverage: 16 new unit tests in typecheck_imports_test.sfn covering
parameter conversion, type-parameter conversion, single/multi interface
batches, member-signature fidelity (parameters, effects, return types),
and ordering. All 68 unit tests still pass; make compile clean.

See docs/proposals/check-architecture.md and
docs/proposals/build-architecture.md (Stage B PR2) for the design.