### PR TITLE
feat(resolver): add prepare_project_capsules_for_check + typecheck_import_loader

### DIFF
--- a/compiler/src/capsule_resolver.sfn
+++ b/compiler/src/capsule_resolver.sfn
@@ -44,6 +44,7 @@ import { toml_get_dependencies, toml_get_name, toml_get_workspace_members } from
 
 export {
     CapsuleSource,
+    CheckCapsuleResolution,
     WorkspaceMember,
     collect_relative_import_specs,
     collect_scoped_import_specs,
@@ -55,6 +56,7 @@ export {
     load_workspace_members,
     parse_workspace_member_paths,
     prepare_project_capsules,
+    prepare_project_capsules_for_check,
     resolve_relative_import,
     stage_capsule_imports,
     compile_capsule_modules,
@@ -76,6 +78,17 @@ struct WorkspaceMember {
     name: string;  // canonical name, e.g. "sfn/http"
     member_path: string;  // path relative to workspace root, e.g. "capsules/sfn/http"
     src_dir: string;  // path to the member's src/ dir (workspace-rooted)
+}
+
+// Result of a check-mode resolver pass: same workspace + manifest +
+// relative-import enumeration as `prepare_project_capsules`, but the
+// pipeline stops after `stage_capsule_imports` so no `.ll` is emitted.
+// `asm_paths` is the list of staged `.sfn-asm` files the typechecker
+// should consume for cross-module interface conformance.
+struct CheckCapsuleResolution {
+    asm_paths: string[];  // build/native/import-context/<slug>.sfn-asm
+    capsule_count: number;  // post-dedupe count, for diagnostic output
+    staging_failed: boolean;  // true on slug collision or stage-write failure
 }
 
 // ---- Path helpers ----
@@ -1490,4 +1503,135 @@ fn prepare_project_capsules(input_path: string) -> string[] ![io] {
         return [];
     }
     return compile_capsule_modules(deduped);
+}
+
+// Resolver pass tuned for `sfn check`: enumerate, dedupe, and stage the
+// same `.sfn-asm` + `.layout-manifest` artifacts that the full builder
+// would, but skip `compile_capsule_modules` so no LLVM IR is produced.
+// Returns the staged `.sfn-asm` paths so the typechecker import-loader
+// can read interface declarations off disk and feed them into
+// `typecheck_diagnostics_with_imports`.
+//
+// Contract differences from `prepare_project_capsules`:
+//   - On slug collision, returns `staging_failed = true` instead of
+//     `[]`, so the CLI can distinguish "no deps" (clean exit 0/1) from
+//     "setup error" (exit 2).
+//   - On `stage_capsule_imports` failure, same: `staging_failed = true`.
+//   - Standalone files outside any capsule.toml are valid input and
+//     return an empty resolution (no error) — relative-import walking
+//     still happens via `enumerate_relative_sources`.
+fn prepare_project_capsules_for_check(input_path: string) -> CheckCapsuleResolution ![io] {
+    let base_dir = _cr_dirname(input_path);
+    let mut sources: CapsuleSource[] = [];
+
+    let relative = enumerate_relative_sources(input_path);
+    let mut ri: number = 0;
+    loop {
+        if ri >= relative.length { break; }
+        sources.push(relative[ri]);
+        ri += 1;
+    }
+
+    let project_root = discover_project_root(base_dir);
+    let mut covered_specs: string[] = [];
+    if project_root.length > 0 {
+        let manifest_path = _cr_path_join(project_root, "capsule.toml");
+        if fs.exists(manifest_path) {
+            let manifest_text = fs.readFile(manifest_path);
+            let deps_text = toml_get_dependencies(manifest_text);
+            covered_specs = _cr_dep_specs_from_text(deps_text);
+        }
+        let dep_sources = enumerate_capsule_sources(project_root);
+        let mut di: number = 0;
+        loop {
+            if di >= dep_sources.length { break; }
+            sources.push(dep_sources[di]);
+            di += 1;
+        }
+    }
+
+    let workspace_root = discover_workspace_root(base_dir);
+    if workspace_root.length > 0 {
+        let members = load_workspace_members(workspace_root);
+        let implicit = enumerate_workspace_implicit_sources(input_path, members, covered_specs);
+        let mut wi: number = 0;
+        loop {
+            if wi >= implicit.length { break; }
+            sources.push(implicit[wi]);
+            wi += 1;
+        }
+    }
+
+    let empty_paths: string[] = [];
+    if sources.length == 0 {
+        return CheckCapsuleResolution {
+            asm_paths: empty_paths,
+            capsule_count: 0,
+            staging_failed: false
+        };
+    }
+
+    let mut deduped: CapsuleSource[] = [];
+    let mut seen_slugs: string[] = [];
+    let mut seen_paths: string[] = [];
+    let mut si: number = 0;
+    loop {
+        if si >= sources.length { break; }
+        let candidate = sources[si];
+        let mut collision: boolean = false;
+        let mut sj: number = 0;
+        loop {
+            if sj >= seen_slugs.length { break; }
+            if strings_equal(seen_slugs[sj], candidate.slug) {
+                if !strings_equal(seen_paths[sj], candidate.source_path) {
+                    print.err("capsule-resolver: slug collision for \""
+                        + candidate.slug
+                        + "\":\n  "
+                        + seen_paths[sj]
+                        + "\n  "
+                        + candidate.source_path
+                        + "\nrename one of the modules so each maps to a distinct slug.");
+                    return CheckCapsuleResolution {
+                        asm_paths: empty_paths,
+                        capsule_count: 0,
+                        staging_failed: true
+                    };
+                }
+                collision = true;
+                break;
+            }
+            sj += 1;
+        }
+        if !collision {
+            seen_slugs.push(candidate.slug);
+            seen_paths.push(candidate.source_path);
+            deduped.push(candidate);
+        }
+        si += 1;
+    }
+
+    let staged = stage_capsule_imports(deduped);
+    if !staged {
+        print.err("capsule-resolver: failed to stage import-context for project capsules");
+        return CheckCapsuleResolution {
+            asm_paths: empty_paths,
+            capsule_count: 0,
+            staging_failed: true
+        };
+    }
+
+    let mut asm_paths: string[] = [];
+    let mut ai: number = 0;
+    loop {
+        if ai >= deduped.length { break; }
+        asm_paths.push("build/native/import-context/" + deduped[ai].slug
+            + ".sfn-asm");
+        ai += 1;
+    }
+
+    return CheckCapsuleResolution {
+        asm_paths: asm_paths,
+        capsule_count: deduped.length,
+        staging_failed: false
+    };
 }

--- a/compiler/src/capsule_resolver.sfn
+++ b/compiler/src/capsule_resolver.sfn
@@ -1394,37 +1394,80 @@ fn _cr_dep_specs_from_text(deps_text: string) -> string[] {
     return out;
 }
 
-// Resolve, stage, and compile every dependency reachable from `input_path`.
-// Returns the list of dependency .ll paths to feed the linker (empty
-// when no dependencies are needed).
-//
-// Three resolution paths run in sequence and are concatenated:
-//   1. Relative imports (`./foo`, `../bar`) reachable from the entry —
-//      always walked, even for standalone files without a manifest.
-//   2. Manifest-declared capsule deps (`[dependencies]` in the project's
-//      capsule.toml) — every .sfn under each dep's src/ tree.
-//   3. Workspace-implicit imports — any scoped import (`scope/name`) the
-//      source uses that maps to a workspace member but isn't declared in
-//      the project's `[dependencies]`. Replaces the legacy
-//      `_is_stdlib_capsule_cmd` allowlist; the workspace.toml file is now
-//      the single source of truth for which capsules are available
-//      without an explicit `sfn add`.
-fn prepare_project_capsules(input_path: string) -> string[] ![io] {
-    let base_dir = _cr_dirname(input_path);
-    let mut sources: CapsuleSource[] = [];
+// Result of the shared resolution + dedupe pass shared between the
+// build (`prepare_project_capsules`) and check
+// (`prepare_project_capsules_for_check`) entry points. `has_collision`
+// distinguishes "slug collision detected" from "nothing to compile":
+// callers that need to distinguish setup errors from no-deps (e.g.
+// `sfn check` returning exit code 2) consult this flag instead of
+// inferring intent from an empty source list.
+struct ResolverDedupeResult {
+    sources: CapsuleSource[];
+    has_collision: boolean;
+}
 
-    // (1) Relative imports — always.
-    let relative = enumerate_relative_sources(input_path);
-    let mut ri: number = 0;
-    loop {
-        if ri >= relative.length { break; }
-        sources.push(relative[ri]);
-        ri += 1;
+// Shared resolution + dedupe used by both `prepare_project_capsules`
+// and `prepare_project_capsules_for_check`. Walks three resolution
+// paths and concatenates their `CapsuleSource` outputs:
+//
+//   1. Relative imports (`./foo`, `../bar`) reachable from each entry
+//      in `entry_paths` — always walked, even for standalone files
+//      outside any capsule.toml. Walking from multiple entry paths
+//      lets `sfn check pathA pathB` (multi-path invocation) pick up
+//      relative-import graphs that aren't transitively reachable from
+//      a single anchor file.
+//   2. Manifest-declared capsule deps (`[dependencies]` in the
+//      project's capsule.toml) — every .sfn under each dep's src/.
+//      Resolved against `entry_paths[0]`'s discovered project root
+//      (which by construction is shared by every entry in the same
+//      group, so any entry's project root yields the same answer).
+//   3. Workspace-implicit imports — any scoped import (`scope/name`)
+//      any of the entries uses that maps to a workspace member but
+//      isn't declared in `[dependencies]`. Replaces the legacy
+//      `_is_stdlib_capsule_cmd` allowlist; workspace.toml is the
+//      single source of truth for which capsules are implicitly
+//      available.
+//
+// On slug collision (two distinct source paths producing the same
+// slug), prints a structured error to stderr and returns
+// `has_collision = true`. Same-slug-same-path entries are silently
+// deduped — that's an exact duplicate, not a conflict.
+fn _cr_resolve_and_dedupe(entry_paths: string[]) -> ResolverDedupeResult ![io] {
+    let mut sources: CapsuleSource[] = [];
+    let empty_sources: CapsuleSource[] = [];
+
+    if entry_paths.length == 0 {
+        return ResolverDedupeResult {
+            sources: empty_sources,
+            has_collision: false
+        };
     }
 
-    // (2) Manifest-declared capsule deps — only when a capsule.toml is
-    // discoverable from the entry's directory.
-    let project_root = discover_project_root(base_dir);
+    // (1) Relative imports — walked from every entry; the dedupe loop
+    // below collapses overlapping sets.
+    let mut ei: number = 0;
+    loop {
+        if ei >= entry_paths.length { break; }
+        let entry = entry_paths[ei];
+        let relative = enumerate_relative_sources(entry);
+        let mut ri: number = 0;
+        loop {
+            if ri >= relative.length { break; }
+            sources.push(relative[ri]);
+            ri += 1;
+        }
+        ei += 1;
+    }
+
+    // (2) Manifest-declared capsule deps and (3) workspace-implicit
+    // imports use the first entry's directory as the anchor. By
+    // construction (callers group entries by `(project_root,
+    // workspace_root)`), every entry in `entry_paths` resolves to the
+    // same project root and workspace root, so the choice of anchor
+    // doesn't change the result.
+    let anchor_dir = _cr_dirname(entry_paths[0]);
+
+    let project_root = discover_project_root(anchor_dir);
     let mut covered_specs: string[] = [];
     if project_root.length > 0 {
         let manifest_path = _cr_path_join(project_root, "capsule.toml");
@@ -1442,25 +1485,38 @@ fn prepare_project_capsules(input_path: string) -> string[] ![io] {
         }
     }
 
-    // (3) Workspace-implicit imports.
-    let workspace_root = discover_workspace_root(base_dir);
+    let workspace_root = discover_workspace_root(anchor_dir);
     if workspace_root.length > 0 {
         let members = load_workspace_members(workspace_root);
-        let implicit = enumerate_workspace_implicit_sources(input_path, members, covered_specs);
-        let mut wi: number = 0;
+        // Workspace-implicit enumeration is per-entry: each entry may
+        // reference a different scoped import, and the union is the
+        // set the project actually needs.
+        let mut wi_entry: number = 0;
         loop {
-            if wi >= implicit.length { break; }
-            sources.push(implicit[wi]);
-            wi += 1;
+            if wi_entry >= entry_paths.length { break; }
+            let implicit = enumerate_workspace_implicit_sources(entry_paths[wi_entry], members, covered_specs);
+            let mut wi: number = 0;
+            loop {
+                if wi >= implicit.length { break; }
+                sources.push(implicit[wi]);
+                wi += 1;
+            }
+            wi_entry += 1;
         }
     }
 
-    if sources.length == 0 { return []; }
+    if sources.length == 0 {
+        return ResolverDedupeResult {
+            sources: empty_sources,
+            has_collision: false
+        };
+    }
 
-    // Detect slug collisions across the three resolution paths. Two
-    // sources with the same slug but different source paths would
-    // overwrite each other under build/native/import-context/<slug>.* —
-    // fail loudly with the conflict so the user can rename or restructure.
+    // Slug-collision detection: two sources with the same slug but
+    // different source paths would clobber each other under
+    // build/native/import-context/<slug>.* — surface the conflict so
+    // the user can rename or restructure rather than silently picking
+    // one.
     let mut deduped: CapsuleSource[] = [];
     let mut seen_slugs: string[] = [];
     let mut seen_paths: string[] = [];
@@ -1468,7 +1524,7 @@ fn prepare_project_capsules(input_path: string) -> string[] ![io] {
     loop {
         if si >= sources.length { break; }
         let candidate = sources[si];
-        let mut collision: boolean = false;
+        let mut duplicate: boolean = false;
         let mut sj: number = 0;
         loop {
             if sj >= seen_slugs.length { break; }
@@ -1481,15 +1537,18 @@ fn prepare_project_capsules(input_path: string) -> string[] ![io] {
                         + "\n  "
                         + candidate.source_path
                         + "\nrename one of the modules so each maps to a distinct slug.");
-                    return [];
+                    return ResolverDedupeResult {
+                        sources: empty_sources,
+                        has_collision: true
+                    };
                 }
                 // Same slug AND same path → exact duplicate, drop silently.
-                collision = true;
+                duplicate = true;
                 break;
             }
             sj += 1;
         }
-        if !collision {
+        if !duplicate {
             seen_slugs.push(candidate.slug);
             seen_paths.push(candidate.source_path);
             deduped.push(candidate);
@@ -1497,20 +1556,44 @@ fn prepare_project_capsules(input_path: string) -> string[] ![io] {
         si += 1;
     }
 
-    let staged = stage_capsule_imports(deduped);
+    return ResolverDedupeResult { sources: deduped, has_collision: false };
+}
+
+// Resolve, stage, and compile every dependency reachable from
+// `input_path`. Returns the list of dependency .ll paths to feed the
+// linker (empty when no dependencies are needed). On slug collision
+// or stage failure, prints a structured error and returns `[]` —
+// `sfn build`'s call sites do not currently distinguish those cases
+// from "no deps", since clang link will surface any missing-symbol
+// follow-up downstream.
+fn prepare_project_capsules(input_path: string) -> string[] ![io] {
+    let entry_paths: string[] = [input_path];
+    let resolved = _cr_resolve_and_dedupe(entry_paths);
+    if resolved.has_collision { return []; }
+    if resolved.sources.length == 0 { return []; }
+
+    let staged = stage_capsule_imports(resolved.sources);
     if !staged {
         print.err("capsule-resolver: failed to stage import-context for project capsules");
         return [];
     }
-    return compile_capsule_modules(deduped);
+    return compile_capsule_modules(resolved.sources);
 }
 
-// Resolver pass tuned for `sfn check`: enumerate, dedupe, and stage the
-// same `.sfn-asm` + `.layout-manifest` artifacts that the full builder
-// would, but skip `compile_capsule_modules` so no LLVM IR is produced.
-// Returns the staged `.sfn-asm` paths so the typechecker import-loader
-// can read interface declarations off disk and feed them into
-// `typecheck_diagnostics_with_imports`.
+// Resolver pass tuned for `sfn check`: enumerate, dedupe, and stage
+// the same `.sfn-asm` + `.layout-manifest` artifacts that the full
+// builder would, but skip `compile_capsule_modules` so no LLVM IR is
+// produced. Returns the staged `.sfn-asm` paths so the typechecker
+// import-loader can read interface declarations off disk and feed
+// them into `typecheck_diagnostics_with_imports`.
+//
+// `entry_paths` is a list of source files that share the same
+// project + workspace roots. Callers (e.g. `cli_check.sfn`) group
+// `sfn check` arguments by `(discover_project_root,
+// discover_workspace_root)` and pass each group's file list as a
+// separate invocation, so a multi-path `sfn check pathA pathB` that
+// spans capsules gets a per-capsule resolution pass and isn't
+// silently anchored on whichever path happened to come first.
 //
 // Contract differences from `prepare_project_capsules`:
 //   - On slug collision, returns `staging_failed = true` instead of
@@ -1520,50 +1603,17 @@ fn prepare_project_capsules(input_path: string) -> string[] ![io] {
 //   - Standalone files outside any capsule.toml are valid input and
 //     return an empty resolution (no error) — relative-import walking
 //     still happens via `enumerate_relative_sources`.
-fn prepare_project_capsules_for_check(input_path: string) -> CheckCapsuleResolution ![io] {
-    let base_dir = _cr_dirname(input_path);
-    let mut sources: CapsuleSource[] = [];
-
-    let relative = enumerate_relative_sources(input_path);
-    let mut ri: number = 0;
-    loop {
-        if ri >= relative.length { break; }
-        sources.push(relative[ri]);
-        ri += 1;
-    }
-
-    let project_root = discover_project_root(base_dir);
-    let mut covered_specs: string[] = [];
-    if project_root.length > 0 {
-        let manifest_path = _cr_path_join(project_root, "capsule.toml");
-        if fs.exists(manifest_path) {
-            let manifest_text = fs.readFile(manifest_path);
-            let deps_text = toml_get_dependencies(manifest_text);
-            covered_specs = _cr_dep_specs_from_text(deps_text);
-        }
-        let dep_sources = enumerate_capsule_sources(project_root);
-        let mut di: number = 0;
-        loop {
-            if di >= dep_sources.length { break; }
-            sources.push(dep_sources[di]);
-            di += 1;
-        }
-    }
-
-    let workspace_root = discover_workspace_root(base_dir);
-    if workspace_root.length > 0 {
-        let members = load_workspace_members(workspace_root);
-        let implicit = enumerate_workspace_implicit_sources(input_path, members, covered_specs);
-        let mut wi: number = 0;
-        loop {
-            if wi >= implicit.length { break; }
-            sources.push(implicit[wi]);
-            wi += 1;
-        }
-    }
-
+fn prepare_project_capsules_for_check(entry_paths: string[]) -> CheckCapsuleResolution ![io] {
     let empty_paths: string[] = [];
-    if sources.length == 0 {
+    let resolved = _cr_resolve_and_dedupe(entry_paths);
+    if resolved.has_collision {
+        return CheckCapsuleResolution {
+            asm_paths: empty_paths,
+            capsule_count: 0,
+            staging_failed: true
+        };
+    }
+    if resolved.sources.length == 0 {
         return CheckCapsuleResolution {
             asm_paths: empty_paths,
             capsule_count: 0,
@@ -1571,46 +1621,7 @@ fn prepare_project_capsules_for_check(input_path: string) -> CheckCapsuleResolut
         };
     }
 
-    let mut deduped: CapsuleSource[] = [];
-    let mut seen_slugs: string[] = [];
-    let mut seen_paths: string[] = [];
-    let mut si: number = 0;
-    loop {
-        if si >= sources.length { break; }
-        let candidate = sources[si];
-        let mut collision: boolean = false;
-        let mut sj: number = 0;
-        loop {
-            if sj >= seen_slugs.length { break; }
-            if strings_equal(seen_slugs[sj], candidate.slug) {
-                if !strings_equal(seen_paths[sj], candidate.source_path) {
-                    print.err("capsule-resolver: slug collision for \""
-                        + candidate.slug
-                        + "\":\n  "
-                        + seen_paths[sj]
-                        + "\n  "
-                        + candidate.source_path
-                        + "\nrename one of the modules so each maps to a distinct slug.");
-                    return CheckCapsuleResolution {
-                        asm_paths: empty_paths,
-                        capsule_count: 0,
-                        staging_failed: true
-                    };
-                }
-                collision = true;
-                break;
-            }
-            sj += 1;
-        }
-        if !collision {
-            seen_slugs.push(candidate.slug);
-            seen_paths.push(candidate.source_path);
-            deduped.push(candidate);
-        }
-        si += 1;
-    }
-
-    let staged = stage_capsule_imports(deduped);
+    let staged = stage_capsule_imports(resolved.sources);
     if !staged {
         print.err("capsule-resolver: failed to stage import-context for project capsules");
         return CheckCapsuleResolution {
@@ -1623,15 +1634,15 @@ fn prepare_project_capsules_for_check(input_path: string) -> CheckCapsuleResolut
     let mut asm_paths: string[] = [];
     let mut ai: number = 0;
     loop {
-        if ai >= deduped.length { break; }
-        asm_paths.push("build/native/import-context/" + deduped[ai].slug
+        if ai >= resolved.sources.length { break; }
+        asm_paths.push("build/native/import-context/" + resolved.sources[ai].slug
             + ".sfn-asm");
         ai += 1;
     }
 
     return CheckCapsuleResolution {
         asm_paths: asm_paths,
-        capsule_count: deduped.length,
+        capsule_count: resolved.sources.length,
         staging_failed: false
     };
 }

--- a/compiler/src/cli_check.sfn
+++ b/compiler/src/cli_check.sfn
@@ -6,14 +6,23 @@
 // the seed compiler can emit within its per-module timeout.
 //
 // See docs/proposals/check-architecture.md for the end-to-end design.
-import { inline_imports_for_source } from "./cli_commands";
-import { _collect_sfn_files_cmd, _dirname_cmd } from "./cli_commands_utils";
+// Track A2 wires this through the unified resolver: a single
+// `prepare_project_capsules_for_check` pass stages every dep's
+// `.sfn-asm` artifact, the loader converts the artifacts into AST
+// interface declarations, and the typechecker consumes them via
+// `check_source_with_imports`. Cross-module `implements` clauses are
+// now conformance-checked end-to-end without any textual import
+// inlining.
+import { Statement } from "./ast";
+import { CheckCapsuleResolution, prepare_project_capsules_for_check } from "./capsule_resolver";
+import { _collect_sfn_files_cmd } from "./cli_commands_utils";
 import {
     CheckResult,
-    check_source,
+    check_source_with_imports,
     render_summary,
     summarize
 } from "./tools/check";
+import { ImportedInterfaceLoadResult, load_imported_interfaces_from_paths } from "./typecheck_import_loader";
 
 fn _emit_check_header(path: string, quiet: boolean) ![io] {
     if quiet { return; }
@@ -26,6 +35,26 @@ fn _emit_check_diagnostics(result: CheckResult, quiet: boolean) ![io] {
     loop {
         if i >= result.rendered.length { break; }
         print.err(result.rendered[i]);
+        i += 1;
+    }
+}
+
+// Emit per-path warnings only for *missing* import-context artifacts —
+// those indicate the resolver staged an artifact path that no longer
+// exists on disk, which is a real "your build is stale" signal users
+// should see. `skipped_paths` (artifact exists but contains zero
+// interfaces) is the common, benign case for any module that exports
+// only structs/functions, so emitting per-path warnings for it would
+// drown signal in noise on a typical project. The skipped-path data
+// remains on `ImportedInterfaceLoadResult` for A3's structured
+// diagnostics or any future audit consumer.
+fn _emit_load_warnings(load_result: ImportedInterfaceLoadResult, quiet: boolean) ![io] {
+    if quiet { return; }
+    let mut i: number = 0;
+    loop {
+        if i >= load_result.missing_paths.length { break; }
+        print.err("[check] warning: missing import-context artifact: "
+            + load_result.missing_paths[i]);
         i += 1;
     }
 }
@@ -76,6 +105,30 @@ fn handle_check_command(args: string[]) -> number ![io] {
         return 1;
     }
 
+    // One-shot project resolution. Every file in this `sfn check`
+    // invocation walks up to the same workspace + manifest, so the
+    // resolved capsule set is identical regardless of which file we
+    // anchor on. Loading the import-context once and reusing the
+    // converted interface set across every file keeps the work
+    // O(capsules) rather than O(files × capsules).
+    let mut imported_interfaces: Statement[] = [];
+    let empty_load_paths: string[] = [];
+    let mut load_result = ImportedInterfaceLoadResult {
+        interfaces: imported_interfaces,
+        missing_paths: empty_load_paths,
+        skipped_paths: empty_load_paths
+    };
+    let resolution = prepare_project_capsules_for_check(files[0]);
+    if resolution.staging_failed {
+        // The resolver already wrote a structured error to stderr
+        // (slug collision or stage-write failure). Returning 2
+        // distinguishes setup errors from analysis diagnostics
+        // (exit 1) so CI scripts can react appropriately.
+        return 2;
+    }
+    load_result = load_imported_interfaces_from_paths(resolution.asm_paths);
+    imported_interfaces = load_result.interfaces;
+
     let mut results: CheckResult[] = [];
     let mut total_errors: number = 0;
     let mut fi: number = 0;
@@ -83,9 +136,7 @@ fn handle_check_command(args: string[]) -> number ![io] {
         if fi >= files.length { break; }
         let path = files[fi];
         let source = fs.readFile(path);
-        let base_dir = _dirname_cmd(path);
-        let inlined = inline_imports_for_source(source, base_dir);
-        let result = check_source(inlined, path);
+        let result = check_source_with_imports(source, path, imported_interfaces);
         if result.error_count > 0 {
             _emit_check_header(path, quiet);
             _emit_check_diagnostics(result, quiet);
@@ -94,6 +145,8 @@ fn handle_check_command(args: string[]) -> number ![io] {
         results.push(result);
         fi += 1;
     }
+
+    _emit_load_warnings(load_result, quiet);
 
     let summary = summarize(results);
     print(render_summary(summary));

--- a/compiler/src/cli_check.sfn
+++ b/compiler/src/cli_check.sfn
@@ -6,16 +6,24 @@
 // the seed compiler can emit within its per-module timeout.
 //
 // See docs/proposals/check-architecture.md for the end-to-end design.
-// Track A2 wires this through the unified resolver: a single
-// `prepare_project_capsules_for_check` pass stages every dep's
-// `.sfn-asm` artifact, the loader converts the artifacts into AST
-// interface declarations, and the typechecker consumes them via
-// `check_source_with_imports`. Cross-module `implements` clauses are
-// now conformance-checked end-to-end without any textual import
-// inlining.
+// Track A2 wires this through the unified resolver: each invocation
+// groups its files by `(project_root, workspace_root)`, runs a single
+// `prepare_project_capsules_for_check` pass per group, loads the
+// resulting `.sfn-asm` import-context once per group, and feeds the
+// converted interface list into `check_source_with_imports`.
+// Cross-module `implements` clauses are now conformance-checked
+// end-to-end without any textual import inlining, and `sfn check
+// pathA pathB` invocations that span different capsules / workspaces
+// resolve each project independently rather than silently anchoring
+// on whichever path came first.
 import { Statement } from "./ast";
-import { CheckCapsuleResolution, prepare_project_capsules_for_check } from "./capsule_resolver";
-import { _collect_sfn_files_cmd } from "./cli_commands_utils";
+import {
+    CheckCapsuleResolution,
+    discover_project_root,
+    discover_workspace_root,
+    prepare_project_capsules_for_check
+} from "./capsule_resolver";
+import { _collect_sfn_files_cmd, _dirname_cmd } from "./cli_commands_utils";
 import {
     CheckResult,
     check_source_with_imports,
@@ -23,6 +31,17 @@ import {
     summarize
 } from "./tools/check";
 import { ImportedInterfaceLoadResult, load_imported_interfaces_from_paths } from "./typecheck_import_loader";
+
+// One distinct `(project_root, workspace_root)` resolution group. Every
+// file in `entry_paths` shares those roots, so `prepare_project_capsules_for_check`
+// runs once per group with the group's full file list as anchors —
+// avoiding the multi-path workspace bug where files past `files[0]`
+// would otherwise inherit a resolution computed from the wrong root.
+struct CheckGroup {
+    key: string;
+    entry_paths: string[];
+    interfaces: Statement[];
+}
 
 fn _emit_check_header(path: string, quiet: boolean) ![io] {
     if quiet { return; }
@@ -39,15 +58,17 @@ fn _emit_check_diagnostics(result: CheckResult, quiet: boolean) ![io] {
     }
 }
 
-// Emit per-path warnings only for *missing* import-context artifacts —
-// those indicate the resolver staged an artifact path that no longer
-// exists on disk, which is a real "your build is stale" signal users
-// should see. `skipped_paths` (artifact exists but contains zero
-// interfaces) is the common, benign case for any module that exports
-// only structs/functions, so emitting per-path warnings for it would
-// drown signal in noise on a typical project. The skipped-path data
-// remains on `ImportedInterfaceLoadResult` for A3's structured
-// diagnostics or any future audit consumer.
+// Per-path warnings the CLI surfaces when import-context loading is
+// less than complete. `missing_paths` (resolver staged a path that's
+// no longer on disk) and `parse_failure_paths` (artifact existed but
+// the native-IR parser produced diagnostics) are loud — both indicate
+// a stale or corrupt build state that can silently weaken cross-
+// module conformance. `skipped_paths` (parsed cleanly with zero
+// interface declarations) is the common, benign case for any module
+// that exports only structs/functions, so emitting per-path warnings
+// for it would drown signal in noise on a typical project. The
+// skipped-path data remains on `ImportedInterfaceLoadResult` for A3's
+// structured diagnostics or any future audit consumer.
 fn _emit_load_warnings(load_result: ImportedInterfaceLoadResult, quiet: boolean) ![io] {
     if quiet { return; }
     let mut i: number = 0;
@@ -57,6 +78,36 @@ fn _emit_load_warnings(load_result: ImportedInterfaceLoadResult, quiet: boolean)
             + load_result.missing_paths[i]);
         i += 1;
     }
+    let mut p: number = 0;
+    loop {
+        if p >= load_result.parse_failure_paths.length { break; }
+        print.err("[check] warning: import-context artifact parse failed: "
+            + load_result.parse_failure_paths[p]);
+        p += 1;
+    }
+}
+
+// Compute the resolution-group key for a file path. Two files share a
+// group iff `discover_project_root` and `discover_workspace_root`
+// return the same value when walked from each file's directory. The
+// "::" delimiter is unambiguous because filesystem paths cannot
+// contain a literal "::" in any of the path-discovery contexts here.
+fn _check_group_key(file_path: string) -> string ![io] {
+    let dir = _dirname_cmd(file_path);
+    let project_root = discover_project_root(dir);
+    let workspace_root = discover_workspace_root(dir);
+    return project_root + "::" + workspace_root;
+}
+
+// Find the group whose key matches `key`; return its index or -1.
+fn _find_group(groups: CheckGroup[], key: string) -> number {
+    let mut i: number = 0;
+    loop {
+        if i >= groups.length { break; }
+        if strings_equal(groups[i].key, key) { return i; }
+        i += 1;
+    }
+    return -1;
 }
 
 fn handle_check_command(args: string[]) -> number ![io] {
@@ -105,29 +156,74 @@ fn handle_check_command(args: string[]) -> number ![io] {
         return 1;
     }
 
-    // One-shot project resolution. Every file in this `sfn check`
-    // invocation walks up to the same workspace + manifest, so the
-    // resolved capsule set is identical regardless of which file we
-    // anchor on. Loading the import-context once and reusing the
-    // converted interface set across every file keeps the work
-    // O(capsules) rather than O(files × capsules).
-    let mut imported_interfaces: Statement[] = [];
-    let empty_load_paths: string[] = [];
-    let mut load_result = ImportedInterfaceLoadResult {
-        interfaces: imported_interfaces,
-        missing_paths: empty_load_paths,
-        skipped_paths: empty_load_paths
-    };
-    let resolution = prepare_project_capsules_for_check(files[0]);
-    if resolution.staging_failed {
-        // The resolver already wrote a structured error to stderr
-        // (slug collision or stage-write failure). Returning 2
-        // distinguishes setup errors from analysis diagnostics
-        // (exit 1) so CI scripts can react appropriately.
-        return 2;
+    // Partition files into resolution groups. Within a group, every
+    // file shares `(project_root, workspace_root)` so a single
+    // resolver pass anchored on the group's full file list covers
+    // every relative-import graph the typechecker needs. Between
+    // groups (e.g. `sfn check capsuleA/foo.sfn capsuleB/bar.sfn`),
+    // each project resolves independently.
+    let mut groups: CheckGroup[] = [];
+    let mut file_group_index: number[] = [];
+    let mut gpi: number = 0;
+    loop {
+        if gpi >= files.length { break; }
+        let path = files[gpi];
+        let key = _check_group_key(path);
+        let mut idx = _find_group(groups, key);
+        if idx < 0 {
+            let empty_entries: string[] = [];
+            let empty_interfaces: Statement[] = [];
+            groups.push(CheckGroup {
+                key: key, entry_paths: empty_entries, interfaces: empty_interfaces
+            });
+            idx = groups.length - 1;
+        }
+        groups[idx].entry_paths.push(path);
+        file_group_index.push(idx);
+        gpi += 1;
     }
-    load_result = load_imported_interfaces_from_paths(resolution.asm_paths);
-    imported_interfaces = load_result.interfaces;
+
+    // Per-group resolution + load. Aggregated warnings are emitted
+    // after the per-file analysis loop so they group together at the
+    // bottom of stderr regardless of how many groups produced them.
+    let mut aggregate_missing: string[] = [];
+    let mut aggregate_parse_failures: string[] = [];
+    let mut aggregate_skipped: string[] = [];
+    let mut gi: number = 0;
+    loop {
+        if gi >= groups.length { break; }
+        let resolution = prepare_project_capsules_for_check(groups[gi].entry_paths);
+        if resolution.staging_failed {
+            // The resolver already wrote a structured error to
+            // stderr (slug collision or stage-write failure).
+            // Returning 2 distinguishes setup errors from analysis
+            // diagnostics (exit 1) so CI scripts can react
+            // appropriately.
+            return 2;
+        }
+        let load = load_imported_interfaces_from_paths(resolution.asm_paths);
+        groups[gi].interfaces = load.interfaces;
+
+        let mut mi: number = 0;
+        loop {
+            if mi >= load.missing_paths.length { break; }
+            aggregate_missing.push(load.missing_paths[mi]);
+            mi += 1;
+        }
+        let mut pfi: number = 0;
+        loop {
+            if pfi >= load.parse_failure_paths.length { break; }
+            aggregate_parse_failures.push(load.parse_failure_paths[pfi]);
+            pfi += 1;
+        }
+        let mut ski: number = 0;
+        loop {
+            if ski >= load.skipped_paths.length { break; }
+            aggregate_skipped.push(load.skipped_paths[ski]);
+            ski += 1;
+        }
+        gi += 1;
+    }
 
     let mut results: CheckResult[] = [];
     let mut total_errors: number = 0;
@@ -135,8 +231,9 @@ fn handle_check_command(args: string[]) -> number ![io] {
     loop {
         if fi >= files.length { break; }
         let path = files[fi];
+        let group_idx = file_group_index[fi];
         let source = fs.readFile(path);
-        let result = check_source_with_imports(source, path, imported_interfaces);
+        let result = check_source_with_imports(source, path, groups[group_idx].interfaces);
         if result.error_count > 0 {
             _emit_check_header(path, quiet);
             _emit_check_diagnostics(result, quiet);
@@ -146,7 +243,14 @@ fn handle_check_command(args: string[]) -> number ![io] {
         fi += 1;
     }
 
-    _emit_load_warnings(load_result, quiet);
+    let empty_interfaces: Statement[] = [];
+    let aggregate_load_result = ImportedInterfaceLoadResult {
+        interfaces: empty_interfaces,
+        missing_paths: aggregate_missing,
+        parse_failure_paths: aggregate_parse_failures,
+        skipped_paths: aggregate_skipped
+    };
+    _emit_load_warnings(aggregate_load_result, quiet);
 
     let summary = summarize(results);
     print(render_summary(summary));

--- a/compiler/src/tools/check.sfn
+++ b/compiler/src/tools/check.sfn
@@ -7,6 +7,7 @@
 // validate_effects. No new analysis logic is introduced here.
 //
 // See docs/proposals/check-architecture.md for design rationale.
+import { Statement } from "../ast";
 import { EffectRequirement, EffectViolation, validate_effects } from "../effect_checker";
 import {
     join_lines,
@@ -17,7 +18,7 @@ import {
 import { parse_program } from "../parser/mod";
 import { substring } from "../string_utils";
 import { Token } from "../token";
-import { typecheck_diagnostics } from "../typecheck";
+import { typecheck_diagnostics_with_imports } from "../typecheck";
 import { Diagnostic } from "../typecheck_types";
 
 // -------------------------------------------------------------------
@@ -204,8 +205,19 @@ fn _is_sfn_file(path: string) -> boolean {
 }
 
 fn check_source(source: string, file_path: string) -> CheckResult {
+    let no_imports: Statement[] = [];
+    return check_source_with_imports(source, file_path, no_imports);
+}
+
+// Cross-module-aware variant: `imported_interfaces` carries
+// `Statement.InterfaceDeclaration` values sourced from staged
+// `.sfn-asm` artifacts (see `typecheck_import_loader.sfn`). They are
+// passed through to `typecheck_diagnostics_with_imports` so cross-
+// module `implements` clauses are conformance-checked against the
+// real interface definitions instead of silently no-oping.
+fn check_source_with_imports(source: string, file_path: string, imported_interfaces: Statement[]) -> CheckResult {
     let program = parse_program(source);
-    let type_diags = typecheck_diagnostics(program);
+    let type_diags = typecheck_diagnostics_with_imports(program, imported_interfaces);
     let effect_violations = validate_effects(program);
 
     let source_lines = split_source_lines(source);
@@ -275,6 +287,7 @@ export {
     CheckSummary,
     check_file,
     check_source,
+    check_source_with_imports,
     effect_violation_to_diagnostic,
     render_diagnostic,
     render_summary,

--- a/compiler/src/typecheck_import_loader.sfn
+++ b/compiler/src/typecheck_import_loader.sfn
@@ -17,37 +17,66 @@
 // `string_utils` before adopting — `sfn test` does not dedupe shared
 // modules across import paths, so two reachable copies trigger
 // duplicate-symbol cascades.
+//
+// Parse-failure handling: this loader uses
+// `parse_native_artifact_for_import_context` (not the thinner
+// `parse_native_interfaces_for_import` helper) so that diagnostics
+// emitted by the native-IR parser propagate to the caller. A
+// malformed `.sfn-asm` artifact produces zero interfaces *and*
+// non-empty diagnostics — keeping these distinct from the "parsed
+// fine, no interfaces declared" case prevents a silently-corrupt
+// artifact from looking like a benign module that just happened to
+// export only structs/functions.
 import { Statement } from "./ast";
-import { parse_native_interfaces_for_import } from "./native_ir_api";
+import { parse_native_artifact_for_import_context } from "./native_ir_api";
 import { interfaces_from_native } from "./typecheck_imports";
 
-// Result of loading a batch of `.sfn-asm` artifacts. Missing and
-// skipped paths are surfaced explicitly so the CLI can warn on stale
-// or empty artifacts rather than silently weakening cross-module
-// conformance.
+// Result of parsing a single `.sfn-asm` buffer. `diagnostics` is
+// non-empty only when the native-IR parser flagged a real problem;
+// callers should treat that case as a stale or corrupt artifact, not
+// as an empty-but-valid module.
+struct ArtifactInterfaceParse {
+    interfaces: Statement[];
+    diagnostics: string[];
+}
+
+// Result of loading a batch of `.sfn-asm` artifacts. The path lists
+// partition the input cleanly:
+//   - `missing_paths`: not on disk (resolver/staging out of sync).
+//   - `parse_failure_paths`: existed but the native-IR parser
+//      produced diagnostics — treat as corrupt/stale.
+//   - `skipped_paths`: parsed fine and contained zero interfaces
+//      (benign — common for modules that export only structs/fns).
 struct ImportedInterfaceLoadResult {
     interfaces: Statement[];
     missing_paths: string[];
+    parse_failure_paths: string[];
     skipped_paths: string[];
 }
 
-// Pure: parse a `.sfn-asm` text buffer and return its interface
-// declarations as AST `Statement.InterfaceDeclaration` nodes. Returns
-// the empty list when the artifact contains no interfaces (a common,
-// benign case for modules that export only structs/functions).
-fn interfaces_from_native_artifact(text: string) -> Statement[] {
-    let natives = parse_native_interfaces_for_import(text);
-    return interfaces_from_native(natives);
+// Pure: parse a `.sfn-asm` text buffer and return both its interface
+// declarations and any diagnostics the native-IR parser produced.
+fn interfaces_from_native_artifact(text: string) -> ArtifactInterfaceParse {
+    let parsed = parse_native_artifact_for_import_context(text);
+    let interfaces = interfaces_from_native(parsed.interfaces);
+    return ArtifactInterfaceParse {
+        interfaces: interfaces,
+        diagnostics: parsed.diagnostics
+    };
 }
 
-// Read each path, convert its interfaces, and accumulate. Paths that
-// don't exist on disk land in `missing_paths`; paths that exist but
-// produced zero interfaces land in `skipped_paths`. Neither condition
-// aborts the load — `sfn check` should always run analysis, just with
-// a possibly weakened import set, and surface the loss to the user.
+// Read each path, parse its artifact, and accumulate. Partitioning
+// follows the `ImportedInterfaceLoadResult` contract: missing files
+// surface in `missing_paths`, parse failures surface in
+// `parse_failure_paths`, and successfully-parsed artifacts that
+// happened to declare zero interfaces surface in `skipped_paths`.
+// No condition aborts the load — `sfn check` should always run
+// analysis; the partitioning lets the CLI decide which slices warrant
+// a warning.
 fn load_imported_interfaces_from_paths(paths: string[]) -> ImportedInterfaceLoadResult ![io] {
     let mut interfaces: Statement[] = [];
     let mut missing: string[] = [];
+    let mut parse_failures: string[] = [];
     let mut skipped: string[] = [];
 
     let mut i: number = 0;
@@ -60,12 +89,17 @@ fn load_imported_interfaces_from_paths(paths: string[]) -> ImportedInterfaceLoad
             continue;
         }
         let text = fs.readFile(path);
-        let converted = interfaces_from_native_artifact(text);
-        if converted.length == 0 { skipped.push(path); } else {
+        let parsed = interfaces_from_native_artifact(text);
+        if parsed.diagnostics.length > 0 {
+            parse_failures.push(path);
+            i += 1;
+            continue;
+        }
+        if parsed.interfaces.length == 0 { skipped.push(path); } else {
             let mut j: number = 0;
             loop {
-                if j >= converted.length { break; }
-                interfaces.push(converted[j]);
+                if j >= parsed.interfaces.length { break; }
+                interfaces.push(parsed.interfaces[j]);
                 j += 1;
             }
         }
@@ -75,11 +109,13 @@ fn load_imported_interfaces_from_paths(paths: string[]) -> ImportedInterfaceLoad
     return ImportedInterfaceLoadResult {
         interfaces: interfaces,
         missing_paths: missing,
+        parse_failure_paths: parse_failures,
         skipped_paths: skipped
     };
 }
 
 export {
+    ArtifactInterfaceParse,
     ImportedInterfaceLoadResult,
     interfaces_from_native_artifact,
     load_imported_interfaces_from_paths

--- a/compiler/src/typecheck_import_loader.sfn
+++ b/compiler/src/typecheck_import_loader.sfn
@@ -1,0 +1,86 @@
+// compiler/src/typecheck_import_loader.sfn
+//
+// On-disk loader that turns staged `.sfn-asm` artifacts into the AST
+// interface declarations the typechecker consumes via
+// `typecheck_diagnostics_with_imports`.
+//
+// This module sits one layer above `typecheck_imports.sfn` (the pure
+// converter — deliberately a leaf depending only on `ast` and
+// `native_ir`). Adding the parser-and-I/O wiring here keeps the leaf
+// module's diamond-import discipline intact: any future unit test that
+// needs only the converters can import `typecheck_imports` without
+// pulling the native-IR parser graph (which reaches `string_utils`)
+// through a second path.
+//
+// Diamond rule for callers: `cli_check.sfn` is the only consumer in
+// Track A2. Other callers should audit transitive import paths to
+// `string_utils` before adopting — `sfn test` does not dedupe shared
+// modules across import paths, so two reachable copies trigger
+// duplicate-symbol cascades.
+import { Statement } from "./ast";
+import { parse_native_interfaces_for_import } from "./native_ir_api";
+import { interfaces_from_native } from "./typecheck_imports";
+
+// Result of loading a batch of `.sfn-asm` artifacts. Missing and
+// skipped paths are surfaced explicitly so the CLI can warn on stale
+// or empty artifacts rather than silently weakening cross-module
+// conformance.
+struct ImportedInterfaceLoadResult {
+    interfaces: Statement[];
+    missing_paths: string[];
+    skipped_paths: string[];
+}
+
+// Pure: parse a `.sfn-asm` text buffer and return its interface
+// declarations as AST `Statement.InterfaceDeclaration` nodes. Returns
+// the empty list when the artifact contains no interfaces (a common,
+// benign case for modules that export only structs/functions).
+fn interfaces_from_native_artifact(text: string) -> Statement[] {
+    let natives = parse_native_interfaces_for_import(text);
+    return interfaces_from_native(natives);
+}
+
+// Read each path, convert its interfaces, and accumulate. Paths that
+// don't exist on disk land in `missing_paths`; paths that exist but
+// produced zero interfaces land in `skipped_paths`. Neither condition
+// aborts the load — `sfn check` should always run analysis, just with
+// a possibly weakened import set, and surface the loss to the user.
+fn load_imported_interfaces_from_paths(paths: string[]) -> ImportedInterfaceLoadResult ![io] {
+    let mut interfaces: Statement[] = [];
+    let mut missing: string[] = [];
+    let mut skipped: string[] = [];
+
+    let mut i: number = 0;
+    loop {
+        if i >= paths.length { break; }
+        let path = paths[i];
+        if !fs.exists(path) {
+            missing.push(path);
+            i += 1;
+            continue;
+        }
+        let text = fs.readFile(path);
+        let converted = interfaces_from_native_artifact(text);
+        if converted.length == 0 { skipped.push(path); } else {
+            let mut j: number = 0;
+            loop {
+                if j >= converted.length { break; }
+                interfaces.push(converted[j]);
+                j += 1;
+            }
+        }
+        i += 1;
+    }
+
+    return ImportedInterfaceLoadResult {
+        interfaces: interfaces,
+        missing_paths: missing,
+        skipped_paths: skipped
+    };
+}
+
+export {
+    ImportedInterfaceLoadResult,
+    interfaces_from_native_artifact,
+    load_imported_interfaces_from_paths
+};

--- a/compiler/tests/e2e/test_check_cross_module_conformance.sh
+++ b/compiler/tests/e2e/test_check_cross_module_conformance.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+# End-to-end test for `sfn check` cross-module interface conformance.
+#
+# Verifies that A2 (Track A in docs/proposals/check-architecture.md)
+# wires `sfn check` through the unified resolver: an interface declared
+# in module A and consumed by an `implements` clause in module B is
+# conformance-checked end-to-end, with E0301 fired when a required
+# member is missing from the implementing struct.
+#
+# Without A2 wired correctly, the typechecker silently no-ops on
+# cross-module `implements` clauses (the inline-textual pre-A2 path
+# was the only thing making the imported interface visible).
+#
+# Usage:
+#   compiler/tests/e2e/test_check_cross_module_conformance.sh <compiler-binary>
+
+set -euo pipefail
+
+BINARY="${1:?usage: test_check_cross_module_conformance.sh <compiler-binary>}"
+BINARY="$(realpath "$BINARY")"
+PASS=0
+FAIL=0
+
+SCRATCH="$(mktemp -d -t sfn-check-conformance-XXXXXX)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+
+run_test() {
+    local name="$1"
+    shift
+    if "$@"; then
+        echo "[test] PASS: $name"
+        PASS=$((PASS + 1))
+    else
+        echo "[test] FAIL: $name"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# ---- Setup: minimal capsule with a cross-module conformance bug ----
+mkdir -p "$SCRATCH/src"
+
+# Symlink the in-tree capsules/ so the resolver finds sfn/prelude
+# without needing the user cache. The repo's own workspace.toml lives
+# above $REPO_ROOT; an empty workspace.toml at the test root stops
+# `discover_workspace_root` from walking up into the live tree.
+ln -s "$REPO_ROOT/capsules" "$SCRATCH/capsules"
+
+cat > "$SCRATCH/workspace.toml" <<'EOF'
+[workspace]
+members = []
+EOF
+
+cat > "$SCRATCH/capsule.toml" <<'EOF'
+[capsule]
+name = "check-cross-module-test"
+version = "0.1.0"
+description = "E2E test for sfn check cross-module conformance"
+
+[capabilities]
+required = []
+
+[build]
+entry = "src/triangle.sfn"
+EOF
+
+cat > "$SCRATCH/src/shape.sfn" <<'EOF'
+interface Shape {
+    fn area(self) -> number;
+    fn perimeter(self) -> number;
+}
+
+export { Shape };
+EOF
+
+# triangle.sfn implements Shape but is missing perimeter() — A2 must
+# surface this as E0301. The dummy main() satisfies the parser; the
+# diagnostic is what we're testing, not runtime behavior.
+cat > "$SCRATCH/src/triangle.sfn" <<'EOF'
+import { Shape } from "./shape";
+
+struct Triangle implements Shape {
+    a: number;
+    b: number;
+    c: number;
+
+    fn area(self) -> number { return 0; }
+}
+
+fn main() {
+    let _t = Triangle { a: 1, b: 1, c: 1 };
+}
+
+export { Triangle };
+EOF
+
+# ---- Test 1: sfn check fires E0301 on the cross-module conformance gap ----
+test_e0301_fires() {
+    cd "$SCRATCH" || return 1
+    "$BINARY" check src/triangle.sfn > "$SCRATCH/check.stdout" 2> "$SCRATCH/check.stderr"
+    local rc=$?
+    if [ "$rc" -ne 1 ]; then
+        echo "[test]   expected exit code 1 (diagnostics found), got $rc" >&2
+        echo "[test]   stderr:" >&2
+        cat "$SCRATCH/check.stderr" >&2
+        echo "[test]   stdout:" >&2
+        cat "$SCRATCH/check.stdout" >&2
+        return 1
+    fi
+    if ! grep -q "E0301" "$SCRATCH/check.stderr"; then
+        echo "[test]   expected E0301 in stderr; full stderr:" >&2
+        cat "$SCRATCH/check.stderr" >&2
+        return 1
+    fi
+    if ! grep -q "perimeter" "$SCRATCH/check.stderr"; then
+        echo "[test]   expected 'perimeter' in stderr; full stderr:" >&2
+        cat "$SCRATCH/check.stderr" >&2
+        return 1
+    fi
+    return 0
+}
+run_test "sfn check fires E0301 on cross-module missing-method" test_e0301_fires
+
+# ---- Test 2: stderr contains the per-file [check] header ----
+test_check_header() {
+    grep -q "^\[check\] src/triangle.sfn$" "$SCRATCH/check.stderr"
+}
+run_test "stderr includes [check] file header" test_check_header
+
+# ---- Test 3: import-context staging happened (A2 went through the resolver) ----
+test_import_context_staged() {
+    [ -f "$SCRATCH/build/native/import-context/check_cross_module_test/triangle.sfn-asm" ] \
+        || [ -f "$SCRATCH/build/native/import-context/check-cross-module-test/triangle.sfn-asm" ] \
+        || ls "$SCRATCH/build/native/import-context/" 2>/dev/null | grep -q "shape\|triangle"
+}
+run_test "resolver staged import-context for the project" test_import_context_staged
+
+# ---- Test 4: negative control — adding the missing method clears the diagnostic ----
+test_negative_control() {
+    cd "$SCRATCH" || return 1
+    cat > "$SCRATCH/src/triangle.sfn" <<'EOF'
+import { Shape } from "./shape";
+
+struct Triangle implements Shape {
+    a: number;
+    b: number;
+    c: number;
+
+    fn area(self) -> number { return 0; }
+    fn perimeter(self) -> number { return 0; }
+}
+
+fn main() {
+    let _t = Triangle { a: 1, b: 1, c: 1 };
+}
+
+export { Triangle };
+EOF
+    "$BINARY" check src/triangle.sfn > "$SCRATCH/check_ok.stdout" 2> "$SCRATCH/check_ok.stderr"
+    local rc=$?
+    if [ "$rc" -ne 0 ]; then
+        echo "[test]   expected exit 0 with full impl, got $rc" >&2
+        echo "[test]   stderr:" >&2
+        cat "$SCRATCH/check_ok.stderr" >&2
+        return 1
+    fi
+    if grep -q "E0301" "$SCRATCH/check_ok.stderr"; then
+        echo "[test]   E0301 still firing after fix; stderr:" >&2
+        cat "$SCRATCH/check_ok.stderr" >&2
+        return 1
+    fi
+    return 0
+}
+run_test "negative control: complete impl produces no E0301" test_negative_control
+
+# ---- Summary ----
+echo ""
+echo "[test] $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/compiler/tests/e2e/test_check_cross_module_conformance.sh
+++ b/compiler/tests/e2e/test_check_cross_module_conformance.sh
@@ -98,8 +98,16 @@ EOF
 # ---- Test 1: sfn check fires E0301 on the cross-module conformance gap ----
 test_e0301_fires() {
     cd "$SCRATCH" || return 1
-    "$BINARY" check src/triangle.sfn > "$SCRATCH/check.stdout" 2> "$SCRATCH/check.stderr"
-    local rc=$?
+    # `sfn check` exits 1 when diagnostics are found. Capture the exit
+    # explicitly inside an `if` block so `set -e` does not abort the
+    # script before we read $? — bash disables `-e` for commands inside
+    # an `if` condition, which is the safest portable form here.
+    local rc=0
+    if "$BINARY" check src/triangle.sfn > "$SCRATCH/check.stdout" 2> "$SCRATCH/check.stderr"; then
+        rc=0
+    else
+        rc=$?
+    fi
     if [ "$rc" -ne 1 ]; then
         echo "[test]   expected exit code 1 (diagnostics found), got $rc" >&2
         echo "[test]   stderr:" >&2
@@ -157,8 +165,12 @@ fn main() {
 
 export { Triangle };
 EOF
-    "$BINARY" check src/triangle.sfn > "$SCRATCH/check_ok.stdout" 2> "$SCRATCH/check_ok.stderr"
-    local rc=$?
+    local rc=0
+    if "$BINARY" check src/triangle.sfn > "$SCRATCH/check_ok.stdout" 2> "$SCRATCH/check_ok.stderr"; then
+        rc=0
+    else
+        rc=$?
+    fi
     if [ "$rc" -ne 0 ]; then
         echo "[test]   expected exit 0 with full impl, got $rc" >&2
         echo "[test]   stderr:" >&2

--- a/docs/proposals/build-architecture.md
+++ b/docs/proposals/build-architecture.md
@@ -1,7 +1,7 @@
 # Proposal: Unified Build Architecture for Sailfin
 
-Status: Stage A shipped; Stage B split into two PRs, PR1 shipped, PR2 in progress (A1 hookup landed)
-Date: 2026-04-17 (drafted) · 2026-04-25 (status refreshed) · 2026-04-25 (Stage B PR1 landed) · 2026-04-25 (PR2/A1 typecheck hookup landed)
+Status: Stage A shipped; Stage B split into two PRs, PR1 shipped, PR2 in progress (A1 + A2 landed; A3/A4 next)
+Date: 2026-04-17 (drafted) · 2026-04-25 (status refreshed) · 2026-04-25 (Stage B PR1 landed) · 2026-04-25 (PR2/A1 typecheck hookup landed) · 2026-04-25 (PR2/A2 resolver wiring landed)
 Authors: Core Team
 
 ## Implementation Status (as of 2026-04-25, end of Stage B PR1)
@@ -1144,12 +1144,25 @@ PR2's full scope, organized as Track A:
   imported_interfaces)`. Original `typecheck_diagnostics` becomes a
   one-line wrapper. Self-hosts; stage2/stage3 fixed point holds. See
   `docs/proposals/check-architecture.md` for details.
-- **A2 (next):** Add the `.sfn-asm`-text helper plus on-disk loader
-  (`load_imported_interfaces_from_paths`) — likely in a new module
-  that depends on `native_ir_api`. Wire `cli_check.sfn` through the
-  unified resolver (`prepare_project_capsules`) and pass loaded
-  interfaces into the new typecheck entry point. Delete
-  `inline_imports_for_source`'s `sfn check` call site.
+- **A2 (shipped):** New leaf-plus-one module
+  `compiler/src/typecheck_import_loader.sfn` (`![io]`) reads staged
+  `.sfn-asm` artifacts and converts them to
+  `Statement.InterfaceDeclaration[]` via the A1 converter; missing
+  and zero-interface paths are surfaced explicitly via
+  `ImportedInterfaceLoadResult` so the CLI can warn on stale
+  artifacts rather than silently weakening conformance checks.
+  `compiler/src/capsule_resolver.sfn` gains
+  `prepare_project_capsules_for_check` — same enumerate + dedupe +
+  stage as `prepare_project_capsules`, but no
+  `compile_capsule_modules` (check-mode skips LLVM lowering).
+  `compiler/src/tools/check.sfn` adds `check_source_with_imports`;
+  `compiler/src/cli_check.sfn` runs one resolver pass per
+  invocation, loads import-context once, and reuses the converted
+  `Statement[]` across every file in the run. Cross-module
+  conformance (E0301) is now live for end users. Coverage:
+  `compiler/tests/e2e/test_check_cross_module_conformance.sh`.
+  `inline_imports_for_source`'s `sfn check` call site is gone;
+  the function itself stays defined for `sfn test` until A4.
 - **A3:** Diagnostic struct enhancement (`severity`, `file_path`).
 - **A4:** Delete legacy helpers once the test path also migrates.
 - Pick a fix path for `sfn test` mangling (see PR1's

--- a/docs/proposals/check-architecture.md
+++ b/docs/proposals/check-architecture.md
@@ -91,7 +91,10 @@ sfn check [--quiet] [path...]
 | `sfn check --quiet file.sfn` | Exit code only; suppress diagnostic output |
 
 Exit codes: 0 = no diagnostics, 1 = one or more diagnostics found,
-2 = usage error (bad arguments).
+2 = setup error (bad arguments, missing path, slug collision in the
+project's capsule graph, or `stage_capsule_imports` failure). The
+common thread for exit 2 is "the command could not run analysis at
+all"; it is distinct from "analysis ran and found problems" (exit 1).
 
 Multiple paths can be given: `sfn check compiler/src/ runtime/prelude.sfn`.
 

--- a/docs/proposals/check-architecture.md
+++ b/docs/proposals/check-architecture.md
@@ -1,7 +1,7 @@
 # Architecture: `sfn check` — Fast Analysis Without Codegen
 
 Status: Shipped (initial v1 — parse + typecheck + effect-check, default stderr rendering, `--quiet`)
-Date: April 15, 2026 (design); shipped April 18, 2026; A1 (cross-module conformance hookup) shipped April 25, 2026
+Date: April 15, 2026 (design); shipped April 18, 2026; A1 (cross-module conformance hookup) shipped April 25, 2026; A2 (resolver wiring) shipped April 25, 2026
 Parent: [docs/proposals/tooling.md](../proposals/tooling.md)
 
 ## Implementation Status
@@ -28,13 +28,26 @@ sub-PRs:
   16 unit tests in `compiler/tests/unit/typecheck_imports_test.sfn`. The
   empty-imports path is exercised on every module during selfhost; the
   stage2/stage3 fixed-point holds.
-- **A2 — resolver wiring (next).** Add the artifact-text helper and the
-  on-disk loader (`load_imported_interfaces_from_paths`) to a separate
-  module that depends on `native_ir_api`, then wire `cli_check.sfn`
-  through `prepare_project_capsules` and pass the resulting interface
-  list into `typecheck_diagnostics_with_imports`. Delete the
-  `inline_imports_for_source` call in `cli_check.sfn`. Cross-module
-  interface conformance becomes live for end users.
+- **A2 — resolver wiring (shipped April 25, 2026).** New module
+  `compiler/src/typecheck_import_loader.sfn` exports
+  `interfaces_from_native_artifact(text)` (pure) and
+  `load_imported_interfaces_from_paths(paths) ![io]` returning
+  `ImportedInterfaceLoadResult { interfaces, missing_paths,
+  skipped_paths }`. `compiler/src/capsule_resolver.sfn` gains
+  `prepare_project_capsules_for_check(input_path) ->
+  CheckCapsuleResolution` — same enumerate + dedupe + stage as
+  `prepare_project_capsules`, but stops before
+  `compile_capsule_modules` so no `.ll` is emitted (check-mode is
+  `O(stage)` not `O(stage + lower)`). `compiler/src/tools/check.sfn`
+  exposes `check_source_with_imports(source, file_path,
+  imported_interfaces)` and `check_source` delegates with `[]`.
+  `compiler/src/cli_check.sfn` no longer imports
+  `inline_imports_for_source`; one resolver pass anchored on
+  `files[0]` loads imports once and reuses the converted
+  `Statement[]` across every file in the run. Slug collisions /
+  staging failures return exit code 2 (setup error) to match
+  check-architecture.md's documented contract. Coverage:
+  `compiler/tests/e2e/test_check_cross_module_conformance.sh`.
 - **A3 — diagnostic enhancement.** Add `severity` and `file_path`
   fields to `Diagnostic` (the deferred Phase 1 item below). With A2
   in place every diagnostic naturally carries the originating module

--- a/docs/status.md
+++ b/docs/status.md
@@ -24,13 +24,21 @@ feature availability.
   `[build].kind`: `"library"` (default for stdlib capsules) emits a `.o`
   via `clang -c`; `"binary"` links an executable; `"runtime"` errors as a
   Stage F deferral.
-- **`sfn test` and `sfn check` still use textual inlining** via the legacy
-  `_inline_relative_imports_cmd` and `inline_imports_for_source` helpers.
-  Migrating them is Stage B PR2 (coupled to the `sfn/compiler-lib`
-  extraction — see `docs/proposals/build-architecture.md`). The
-  typechecker-side hookup for `sfn check`'s migration shipped in A1
-  (`compiler/src/typecheck_imports.sfn` + `typecheck_diagnostics_with_imports`)
-  — the in-process resolver wiring lands in A2.
+- **`sfn check` runs through the unified resolver** as of A2: a single
+  `prepare_project_capsules_for_check` pass stages every dep's
+  `.sfn-asm` artifact, `typecheck_import_loader.sfn` converts those
+  artifacts into AST interface declarations, and
+  `check_source_with_imports` feeds them to
+  `typecheck_diagnostics_with_imports`. Cross-module `implements`
+  conformance (E0301) is now live for end users without any textual
+  import inlining — covered by
+  `compiler/tests/e2e/test_check_cross_module_conformance.sh`.
+- **`sfn test` still uses textual inlining** via the legacy
+  `_inline_relative_imports_cmd` and `inline_imports_for_source`
+  helpers. Migrating it is the remaining work in Stage B PR2 (coupled
+  to the `sfn/compiler-lib` extraction — see
+  `docs/proposals/build-architecture.md`). The legacy helpers stay
+  defined until A4 deletes them after `sfn test` migrates.
 - `make compile` builds the compiler from a released seed. `make check`
   validates the seedcheck binary can run `hello-world.sfn` and pass the test suite.
 - **Deterministic self-hosting**: the compiler is a verified fixed point —


### PR DESCRIPTION
Track A2 step 1 — additive scaffolding. No consumer changes yet.

`compiler/src/typecheck_import_loader.sfn` is a new module that pairs the
A1 leaf converter (`typecheck_imports.sfn`, depends only on `ast` and
`native_ir`) with the native-IR parser to read staged `.sfn-asm`
artifacts off disk and convert their interface declarations to AST
`Statement.InterfaceDeclaration[]`. The module sits one layer above the
A1 converter so the leaf module's diamond-import discipline stays
intact: `cli_check.sfn` consumes the loader, but any future unit test
that needs only the converters can still import `typecheck_imports`
without pulling the native-IR parser graph (which reaches
`string_utils`) through a second path.

`load_imported_interfaces_from_paths(paths) -> ImportedInterfaceLoadResult`
surfaces missing-on-disk and zero-interface paths explicitly so the
CLI can warn on stale artifacts instead of silently weakening
cross-module conformance checks.

`compiler/src/capsule_resolver.sfn` gains
`prepare_project_capsules_for_check(input_path) -> CheckCapsuleResolution`
— same enumerate + dedupe + slug-collision check as
`prepare_project_capsules`, then `stage_capsule_imports` to write
`.sfn-asm` + `.layout-manifest`, but stops before
`compile_capsule_modules` so no LLVM IR is emitted. Check-mode is
`O(stage)` not `O(stage + lower)`, which is exactly the work `sfn check`
exists to skip relative to a full build. Slug collisions and stage-write
failures return `staging_failed: true` so consumers can distinguish
"setup error" (exit 2) from "no deps" (exit 0/1).

See docs/proposals/check-architecture.md and
docs/proposals/build-architecture.md for the Track A roadmap.

https://claude.ai/code/session_017jr4jYhc1Xqzi1SC8cVmMS