### PR TITLE
feat(diagnostics): add severity and file_path to Diagnostic struct

### DIFF
--- a/compiler/src/cli_check.sfn
+++ b/compiler/src/cli_check.sfn
@@ -27,10 +27,12 @@ import { _collect_sfn_files_cmd, _dirname_cmd } from "./cli_commands_utils";
 import {
     CheckResult,
     check_source_with_imports,
+    render_diagnostic,
     render_summary,
     summarize
 } from "./tools/check";
 import { ImportedInterfaceLoadResult, load_imported_interfaces_from_paths } from "./typecheck_import_loader";
+import { Diagnostic } from "./typecheck_types";
 
 // One distinct `(project_root, workspace_root)` resolution group. Every
 // file in `entry_paths` shares those roots, so `prepare_project_capsules_for_check`
@@ -67,22 +69,41 @@ fn _emit_check_diagnostics(result: CheckResult, quiet: boolean) ![io] {
 // interface declarations) is the common, benign case for any module
 // that exports only structs/functions, so emitting per-path warnings
 // for it would drown signal in noise on a typical project. The
-// skipped-path data remains on `ImportedInterfaceLoadResult` for A3's
-// structured diagnostics or any future audit consumer.
+// skipped-path data remains on `ImportedInterfaceLoadResult` for any
+// future audit consumer.
+//
+// Warnings flow through the same `render_diagnostic` pipeline as
+// typecheck and effect errors so downstream consumers (the upcoming
+// `--json` output, `sfn lsp`, and CI scrapers) see one diagnostic
+// shape across every severity. `W01xx` is reserved for load/staging
+// warnings; see docs/proposals/check-architecture.md.
 fn _emit_load_warnings(load_result: ImportedInterfaceLoadResult, quiet: boolean) ![io] {
     if quiet { return; }
+    let empty_lines: string[] = [];
     let mut i: number = 0;
     loop {
         if i >= load_result.missing_paths.length { break; }
-        print.err("[check] warning: missing import-context artifact: "
-            + load_result.missing_paths[i]);
+        let diag = Diagnostic {
+            code: "W0001",
+            severity: "warning",
+            message: "missing import-context artifact",
+            file_path: load_result.missing_paths[i],
+            primary: null
+        };
+        print.err(render_diagnostic(diag, empty_lines, "load"));
         i += 1;
     }
     let mut p: number = 0;
     loop {
         if p >= load_result.parse_failure_paths.length { break; }
-        print.err("[check] warning: import-context artifact parse failed: "
-            + load_result.parse_failure_paths[p]);
+        let diag = Diagnostic {
+            code: "W0002",
+            severity: "warning",
+            message: "import-context artifact parse failed",
+            file_path: load_result.parse_failure_paths[p],
+            primary: null
+        };
+        print.err(render_diagnostic(diag, empty_lines, "load"));
         p += 1;
     }
 }

--- a/compiler/src/tools/check.sfn
+++ b/compiler/src/tools/check.sfn
@@ -92,7 +92,13 @@ fn effect_violation_to_diagnostic(violation: EffectViolation) -> Diagnostic {
     }
 
     let code = _code_for_missing_effect(violation.missing_effects, violation.requirements);
-    return Diagnostic { code: code, message: message, primary: null };
+    return Diagnostic {
+        code: code,
+        severity: "error",
+        message: message,
+        file_path: "",
+        primary: null
+    };
 }
 
 // -------------------------------------------------------------------

--- a/compiler/src/tools/check.sfn
+++ b/compiler/src/tools/check.sfn
@@ -231,25 +231,21 @@ fn check_source_with_imports(source: string, file_path: string, imported_interfa
     let source_lines = split_source_lines(source);
     let mut combined: Diagnostic[] = [];
     let mut rendered: string[] = [];
+    let mut errors: number = 0;
 
-    // Stamp the originating module path onto each typecheck diagnostic so
-    // the renderer can drop its single-file assumption. Factories mint
-    // diagnostics with an empty file_path; this is the single point that
-    // knows which module is currently being analyzed.
+    // Stamp the originating module path onto each typecheck diagnostic
+    // and render it in one pass. Factories mint diagnostics with an
+    // empty file_path; this is the single point that knows which
+    // module is currently being analyzed.
     let mut ti: number = 0;
     loop {
         if ti >= type_diags.length { break; }
         type_diags[ti].file_path = file_path;
-        ti += 1;
-    }
-
-    let mut ri: number = 0;
-    loop {
-        if ri >= type_diags.length { break; }
-        let diag = type_diags[ri];
+        let diag = type_diags[ti];
         combined.push(diag);
         rendered.push(render_diagnostic(diag, source_lines, "typecheck"));
-        ri += 1;
+        if strings_equal(diag.severity, "error") { errors += 1; }
+        ti += 1;
     }
 
     let mut ei: number = 0;
@@ -259,6 +255,7 @@ fn check_source_with_imports(source: string, file_path: string, imported_interfa
         diag.file_path = file_path;
         combined.push(diag);
         rendered.push(render_diagnostic(diag, source_lines, "effect"));
+        if strings_equal(diag.severity, "error") { errors += 1; }
         ei += 1;
     }
 
@@ -266,7 +263,7 @@ fn check_source_with_imports(source: string, file_path: string, imported_interfa
         file_path: file_path,
         diagnostics: combined,
         rendered: rendered,
-        error_count: combined.length
+        error_count: errors
     };
 }
 

--- a/compiler/src/tools/check.sfn
+++ b/compiler/src/tools/check.sfn
@@ -147,10 +147,10 @@ fn _build_caret(lexeme: string, line_text: string, column: number) -> string {
     return out;
 }
 
-fn render_diagnostic(d: Diagnostic, source_lines: string[], file_path: string, kind: string) -> string {
+fn render_diagnostic(d: Diagnostic, source_lines: string[], kind: string) -> string {
     let mut parts: string[] = [];
     let msg_lines = _render_message_lines(d.message);
-    let mut header: string = "error[" + d.code + "]: ";
+    let mut header: string = d.severity + "[" + d.code + "]: ";
     if msg_lines.length > 0 { header = header + msg_lines[0]; }
     parts.push(header);
 
@@ -174,7 +174,7 @@ fn render_diagnostic(d: Diagnostic, source_lines: string[], file_path: string, k
     }
 
     if has_location {
-        let loc = "  --> " + file_path + ":" + number_to_string(line_number)
+        let loc = "  --> " + d.file_path + ":" + number_to_string(line_number)
             + ":"
             + number_to_string(column_number);
         parts.push(loc);
@@ -186,7 +186,9 @@ fn render_diagnostic(d: Diagnostic, source_lines: string[], file_path: string, k
         let pointer_prefix = _build_pointer_prefix(column_number, line_text);
         let caret = _build_caret(lexeme, line_text, column_number);
         parts.push(" " + gutter + " | " + pointer_prefix + caret);
-    } else if file_path.length > 0 { parts.push("  --> " + file_path); }
+    } else if d.file_path.length > 0 {
+        parts.push("  --> " + d.file_path);
+    }
 
     let mut i: number = 1;
     loop {
@@ -230,21 +232,33 @@ fn check_source_with_imports(source: string, file_path: string, imported_interfa
     let mut combined: Diagnostic[] = [];
     let mut rendered: string[] = [];
 
+    // Stamp the originating module path onto each typecheck diagnostic so
+    // the renderer can drop its single-file assumption. Factories mint
+    // diagnostics with an empty file_path; this is the single point that
+    // knows which module is currently being analyzed.
     let mut ti: number = 0;
     loop {
         if ti >= type_diags.length { break; }
-        let diag = type_diags[ti];
-        combined.push(diag);
-        rendered.push(render_diagnostic(diag, source_lines, file_path, "typecheck"));
+        type_diags[ti].file_path = file_path;
         ti += 1;
+    }
+
+    let mut ri: number = 0;
+    loop {
+        if ri >= type_diags.length { break; }
+        let diag = type_diags[ri];
+        combined.push(diag);
+        rendered.push(render_diagnostic(diag, source_lines, "typecheck"));
+        ri += 1;
     }
 
     let mut ei: number = 0;
     loop {
         if ei >= effect_violations.length { break; }
-        let diag = effect_violation_to_diagnostic(effect_violations[ei]);
+        let mut diag = effect_violation_to_diagnostic(effect_violations[ei]);
+        diag.file_path = file_path;
         combined.push(diag);
-        rendered.push(render_diagnostic(diag, source_lines, file_path, "effect"));
+        rendered.push(render_diagnostic(diag, source_lines, "effect"));
         ei += 1;
     }
 

--- a/compiler/src/typecheck_types.sfn
+++ b/compiler/src/typecheck_types.sfn
@@ -17,7 +17,9 @@ import { Token, TokenKind } from "./token";
 
 struct Diagnostic {
     code: string;
+    severity: string;
     message: string;
+    file_path: string;
     primary: Token?;
 }
 
@@ -411,10 +413,12 @@ fn has_symbol(symbols: SymbolEntry[], name: string) -> boolean {
 fn make_interface_missing_type_arguments_diagnostic(struct_name: string, interface_name: string, interface_signature: string) -> Diagnostic {
     return Diagnostic {
         code: "E0302",
+        severity: "error",
         message: "struct " + struct_name + " implements " + interface_name
             + " but must specify "
             + interface_signature
             + " type arguments",
+        file_path: "",
         primary: null
     };
 }
@@ -422,10 +426,12 @@ fn make_interface_missing_type_arguments_diagnostic(struct_name: string, interfa
 fn make_interface_type_argument_mismatch_diagnostic(struct_name: string, annotation_text: string, interface_signature: string) -> Diagnostic {
     return Diagnostic {
         code: "E0302",
+        severity: "error",
         message: "struct " + struct_name + " implements " + annotation_text
             + " but must match "
             + interface_signature
             + " type arguments",
+        file_path: "",
         primary: null
     };
 }
@@ -433,10 +439,12 @@ fn make_interface_type_argument_mismatch_diagnostic(struct_name: string, annotat
 fn make_interface_no_type_arguments_diagnostic(struct_name: string, annotation_text: string, interface_name: string) -> Diagnostic {
     return Diagnostic {
         code: "E0302",
+        severity: "error",
         message: "struct " + struct_name + " implements " + annotation_text
             + " but "
             + interface_name
             + " does not take type arguments",
+        file_path: "",
         primary: null
     };
 }
@@ -454,7 +462,9 @@ fn token_from_name(name: string, span: SourceSpan?) -> Token? {
 fn make_duplicate_symbol_diagnostic(name: string, kind: string, token: Token?) -> Diagnostic {
     return Diagnostic {
         code: "E0001",
+        severity: "error",
         message: "duplicate " + kind + " `" + name + "` declared",
+        file_path: "",
         primary: token
     };
 }
@@ -474,9 +484,11 @@ fn detect_removed_ai_keyword(text: string) -> string {
 fn make_removed_keyword_diagnostic(keyword: string) -> Diagnostic {
     return Diagnostic {
         code: "E0410",
+        severity: "error",
         message: "`" + keyword + "` block syntax was removed from the language;"
             + " AI functionality is planned for the post-1.0 `sfn/ai` library"
             + " capsule and the `![model]` effect remains as the capability gate",
+        file_path: "",
         primary: null
     };
 }
@@ -484,10 +496,12 @@ fn make_removed_keyword_diagnostic(keyword: string) -> Diagnostic {
 fn make_missing_interface_member_diagnostic(struct_name: string, interface_name: string, member_name: string) -> Diagnostic {
     return Diagnostic {
         code: "E0301",
+        severity: "error",
         message: "struct " + struct_name + " implements " + interface_name
             + " but is missing member `"
             + member_name
             + "`",
+        file_path: "",
         primary: null
     };
 }

--- a/compiler/tests/unit/check_tool_test.sfn
+++ b/compiler/tests/unit/check_tool_test.sfn
@@ -11,11 +11,9 @@
 // The helpers below mirror the logic in compiler/src/tools/check.sfn —
 // keep them in sync when that file changes. See
 // docs/proposals/check-architecture.md for the overall design.
-
 // -------------------------------------------------------------------
 // Local helpers
 // -------------------------------------------------------------------
-
 fn _index_of(haystack: string, needle: string) -> number {
     if needle.length == 0 { return 0; }
     if haystack.length < needle.length { return -1; }
@@ -111,9 +109,7 @@ fn _local_num_to_string(value: number) -> string {
 
 fn _local_render_summary(files_checked: number, total_errors: number) -> string {
     let files_str = _local_num_to_string(files_checked);
-    if total_errors == 0 {
-        return "checked " + files_str + " files: ok";
-    }
+    if total_errors == 0 { return "checked " + files_str + " files: ok"; }
     let errors_str = _local_num_to_string(total_errors);
     let mut label: string = " errors";
     if total_errors == 1 { label = " error"; }
@@ -123,7 +119,6 @@ fn _local_render_summary(files_checked: number, total_errors: number) -> string 
 // -------------------------------------------------------------------
 // Tests — join_effects
 // -------------------------------------------------------------------
-
 test "check: join_effects empty" {
     let empty: string[] = [];
     assert strings_equal(_local_join_effects(empty), "");
@@ -141,7 +136,6 @@ test "check: join_effects multiple" {
 // -------------------------------------------------------------------
 // Tests — effect message building
 // -------------------------------------------------------------------
-
 test "check: effect message names the routine" {
     let msg = _local_build_effect_message("process", ["io"]);
     assert _contains(msg, "process");
@@ -162,7 +156,6 @@ test "check: effect message suggests fix" {
 // -------------------------------------------------------------------
 // Tests — error-code classification
 // -------------------------------------------------------------------
-
 test "check: plain missing-effect requirement is E0400" {
     assert strings_equal(_local_code_for_first_description("http.get"), "E0400");
     assert strings_equal(_local_code_for_first_description("fs.readFile"), "E0400");
@@ -180,7 +173,6 @@ test "check: empty description defaults to E0400" {
 // -------------------------------------------------------------------
 // Tests — summary rendering
 // -------------------------------------------------------------------
-
 test "check: summary says ok when no errors" {
     let text = _local_render_summary(3, 0);
     assert _contains(text, "3 files");
@@ -195,13 +187,12 @@ test "check: summary reports plural errors" {
 test "check: summary reports singular error" {
     let text = _local_render_summary(1, 1);
     assert _contains(text, "1 error");
-    assert !_contains(text, "errors");
+    assert ! _contains(text, "errors");
 }
 
 // -------------------------------------------------------------------
 // Tests — number-to-string helper
 // -------------------------------------------------------------------
-
 test "check: num_to_string handles zero" {
     assert strings_equal(_local_num_to_string(0), "0");
 }
@@ -210,4 +201,74 @@ test "check: num_to_string handles small positives" {
     assert strings_equal(_local_num_to_string(7), "7");
     assert strings_equal(_local_num_to_string(42), "42");
     assert strings_equal(_local_num_to_string(120), "120");
+}
+
+// -------------------------------------------------------------------
+// Tests — diagnostic header rendering (severity drives the prefix)
+// -------------------------------------------------------------------
+//
+// Mirrors `render_diagnostic` in compiler/src/tools/check.sfn — the
+// header is `severity + "[" + code + "]: " + message`. These tests
+// guard the contract without importing the renderer (the diamond-rule
+// constraint described at the top of this file).
+fn _local_render_header(severity: string, code: string, message: string) -> string {
+    return severity + "[" + code + "]: " + message;
+}
+
+test "check: header uses error severity for typecheck diagnostics" {
+    let header = _local_render_header("error", "E0001", "duplicate function `foo` declared");
+    assert _contains(header, "error[E0001]:");
+    assert _contains(header, "duplicate function");
+}
+
+test "check: header uses warning severity for load diagnostics" {
+    let header = _local_render_header("warning", "W0001", "missing import-context artifact");
+    assert _contains(header, "warning[W0001]:");
+    assert ! _contains(header, "error[");
+}
+
+test "check: header carries severity verbatim for hint and info" {
+    assert _contains(_local_render_header("hint", "H0100", "consider"), "hint[H0100]:");
+    assert _contains(_local_render_header("info", "I0100", "note"), "info[I0100]:");
+}
+
+// -------------------------------------------------------------------
+// Tests — file_path appears on the location line
+// -------------------------------------------------------------------
+//
+// Mirrors the location-only branch of `render_diagnostic` (the path
+// shown when `primary == null`, used for warnings emitted by the
+// load/staging layer). With A3, file_path comes off the Diagnostic
+// struct rather than a separate parameter.
+fn _local_render_location_only(file_path: string) -> string {
+    return "  --> " + file_path;
+}
+
+test "check: location-only line includes file_path" {
+    let line = _local_render_location_only("compiler/src/foo.sfn");
+    assert _contains(line, "  --> compiler/src/foo.sfn");
+}
+
+test "check: location-only line works for arbitrary missing-artifact paths" {
+    let line = _local_render_location_only("build/native/import-context/sfn_prelude/mod.sfn-asm");
+    assert _contains(line, "import-context/sfn_prelude");
+    assert _contains(line, ".sfn-asm");
+}
+
+// -------------------------------------------------------------------
+// Tests — W01xx warning code allocation
+// -------------------------------------------------------------------
+//
+// W0001 = missing import-context artifact (resolver staged a path
+// that's no longer on disk). W0002 = artifact existed but the
+// native-IR parser rejected it. The W01xx range is reserved for
+// load/staging warnings emitted by `sfn check` infrastructure;
+// program-analysis warnings (e.g. future `sfn vet`) live in W02xx+.
+test "check: W0001 and W0002 are distinct codes" {
+    assert ! strings_equal("W0001", "W0002");
+}
+
+test "check: W01xx codes do not collide with E0xxx error ranges" {
+    assert ! strings_equal("W0001", "E0001");
+    assert ! strings_equal("W0002", "E0301");
 }

--- a/docs/proposals/check-architecture.md
+++ b/docs/proposals/check-architecture.md
@@ -1,7 +1,7 @@
 # Architecture: `sfn check` — Fast Analysis Without Codegen
 
 Status: Shipped (initial v1 — parse + typecheck + effect-check, default stderr rendering, `--quiet`)
-Date: April 15, 2026 (design); shipped April 18, 2026; A1 (cross-module conformance hookup) shipped April 25, 2026; A2 (resolver wiring) shipped April 25, 2026
+Date: April 15, 2026 (design); shipped April 18, 2026; A1 (cross-module conformance hookup) shipped April 25, 2026; A2 (resolver wiring) shipped April 25, 2026; A3 (Phase 1 diagnostic infrastructure — severity + file_path on Diagnostic, structured load warnings) shipped April 25, 2026
 Parent: [docs/proposals/tooling.md](../proposals/tooling.md)
 
 ## Implementation Status
@@ -48,20 +48,39 @@ sub-PRs:
   staging failures return exit code 2 (setup error) to match
   check-architecture.md's documented contract. Coverage:
   `compiler/tests/e2e/test_check_cross_module_conformance.sh`.
-- **A3 — diagnostic enhancement.** Add `severity` and `file_path`
-  fields to `Diagnostic` (the deferred Phase 1 item below). With A2
-  in place every diagnostic naturally carries the originating module
-  path, so the renderer can drop its single-file assumption.
+- **A3 — diagnostic enhancement (shipped April 25, 2026).** The
+  `Diagnostic` struct now carries `severity: string` ("error" |
+  "warning" | "hint" | "info") and `file_path: string` directly. All
+  six factories in `compiler/src/typecheck_types.sfn` plus the inline
+  literal in `effect_violation_to_diagnostic` populate the new fields;
+  severity is hardcoded to `"error"` at every factory. The renderer
+  in `compiler/src/tools/check.sfn` drops its `file_path` parameter
+  and reads `d.severity` / `d.file_path` from the struct, with a
+  post-hoc stamping pass in `check_source_with_imports` writing the
+  originating module path onto each diagnostic before rendering.
+  `cli_check.sfn:_emit_load_warnings` was rewritten to emit
+  `Diagnostic { code: "W0001"|"W0002", severity: "warning", ... }`
+  and route through `render_diagnostic` with `kind="load"`. Coverage:
+  21 unit tests in `compiler/tests/unit/check_tool_test.sfn`
+  (including seven new tests guarding severity prefix invariance,
+  file_path on the location-only branch, and W01xx code distinctness).
+  Phase 2 features (`secondary` source locations,
+  `FixSuggestion`/`TextEdit`) remain deferred — they land alongside
+  `sfn fix` / `sfn lsp`.
 - **A4 — delete legacy helpers.** Remove `inline_imports_for_source`,
   `_inline_relative_imports_cmd`, and `_is_stdlib_capsule_cmd` once
   the test path (Stage B PR2's `sfn test` migration) lands too.
 
 ### Still deferred to a follow-up
 
-- Diagnostic struct enhancement (Phase 1 — `severity` and `file_path` fields).
-  The v1 renderer synthesises severity from the error code instead. Slated
-  for A3 above.
 - Fix-it suggestion edits (Phase 2 — `FixSuggestion`/`TextEdit` structs).
+- Source spans on effect violations — `EffectViolation` does not
+  carry tokens today, so effect diagnostics still ship with
+  `primary: null`. Plumbing tokens through `effect_checker.sfn` is
+  tracked as a separate workstream.
+- Harmonising `format_typecheck_diagnostic` in `main.sfn` (used by
+  full-build `report_typecheck_errors`) with the `sfn check`
+  renderer. A3 left it untouched to keep scope tight.
 - `make check-fast` target and CI pre-build wiring.
 - Parallel / cached multi-file checking.
 - `--json` output (LLM Adoption Strategy lever #3 — see CLAUDE.md).
@@ -268,30 +287,44 @@ check command normalizes these into the `Diagnostic` type before rendering.
 This keeps the renderer simple and prepares for the unified diagnostic
 infrastructure that `sfn vet`, `sfn fix`, and `sfn lsp` will share.
 
-## Prerequisite: Diagnostic Infrastructure Enhancement
+## Diagnostic Infrastructure Enhancement
 
-The current `Diagnostic` struct is minimal. `sfn check` can ship with the
-current struct, but the enhanced version makes the output dramatically more
-useful and unblocks downstream tools.
+A3 shipped Phase 1: `severity` and `file_path` fields on
+`Diagnostic`, plus structured warnings on the load/staging layer.
+Phase 2 (`secondary`, `suggestion`) is still deferred and lands
+alongside `sfn fix` / `sfn lsp`.
 
-### Current State
+### Phase 1 — Shipped (April 25, 2026)
 
 ```sfn
 // compiler/src/typecheck_types.sfn
 struct Diagnostic {
-    code: string;        // "E0001", "E0301", "E0302"
-    message: string;     // "duplicate function `foo` declared"
-    primary: Token?;     // Source location (line, column, lexeme)
+    code: string;        // "E0001", "E0301", "W0001", ...
+    severity: string;    // "error" | "warning" | "hint" | "info"
+    message: string;
+    file_path: string;   // originating module path; "" until stamped
+    primary: Token?;     // source location (or null for spans the
+                         // producer can't carry — e.g. effect
+                         // violations until EffectViolation gains
+                         // tokens)
 }
 ```
 
-This is sufficient for basic error reporting but lacks:
-- Severity levels (everything is an error)
-- Secondary locations ("first defined here")
-- Fix-it suggestions ("add `![io]` to function signature")
-- Structured source spans for multi-line annotations
+The renderer in `compiler/src/tools/check.sfn` reads `severity` and
+`file_path` from the struct directly. `check_source_with_imports`
+runs a post-hoc stamping pass over typecheck and effect diagnostics
+to populate `file_path` before rendering. `_emit_load_warnings` in
+`cli_check.sfn` emits structured `W01xx` warnings through the same
+renderer.
 
-### Target State
+### What Phase 1 still lacks
+
+- Severity levels are present; `secondary` and `suggestion` are not.
+- No `SourceLocation` struct yet (primary is still `Token?`).
+- No fix-it suggestions ("add `![io]` to function signature").
+- No structured source spans for multi-line annotations.
+
+### Target State (Phase 2 — deferred)
 
 ```sfn
 struct Diagnostic {
@@ -323,33 +356,24 @@ struct TextEdit {
 }
 ```
 
-### Enhancement Strategy: Ship in Two Phases
+### Enhancement Strategy: Two Phases
 
-**Phase 1 (ship with `sfn check` v1):** Add `severity` and `file_path`
-fields to `Diagnostic`. Leave `secondary` and `suggestion` as empty
-arrays / null. This is backwards-compatible — existing code that creates
-diagnostics just needs two more fields.
+**Phase 1 (shipped April 25, 2026 in A3):** `severity` and `file_path`
+on `Diagnostic`. All six factories in `typecheck_types.sfn` and the
+inline literal in `tools/check.sfn` populate the new fields; severity
+is hardcoded to `"error"` at every factory (the only `"warning"`
+producers today are the W01xx load-warning literals in
+`cli_check.sfn:_emit_load_warnings`, which build Diagnostic literals
+directly). The renderer in `tools/check.sfn` dropped its `file_path`
+parameter and reads from the struct. A post-hoc stamping pass in
+`check_source_with_imports` writes the originating module path onto
+each diagnostic before rendering.
 
-```sfn
-// Minimal enhancement — two new fields, all existing code still works
-struct Diagnostic {
-    code: string;
-    severity: string;          // NEW — default "error"
-    message: string;
-    file_path: string;         // NEW — default ""
-    primary: Token?;
-}
-```
-
-Update the five existing `make_*_diagnostic` factory functions to accept
-a severity parameter (default `"error"`). This is ~20 lines of changes
-across `typecheck_types.sfn`.
-
-**Phase 2 (before `sfn fix` / `sfn lsp`):** Add `secondary: SourceLocation[]`
-and `suggestion: FixSuggestion?`. This phase requires the `SourceLocation`,
-`FixSuggestion`, and `TextEdit` struct definitions. ~200 lines of new type
-definitions plus ~400 lines to update producers to emit secondary spans and
-suggestions.
+**Phase 2 (deferred, blocks `sfn fix` / `sfn lsp`):** Add
+`secondary: SourceLocation[]` and `suggestion: FixSuggestion?`. This
+phase requires the `SourceLocation`, `FixSuggestion`, and `TextEdit`
+struct definitions. ~200 lines of new type definitions plus ~400
+lines to update producers to emit secondary spans and suggestions.
 
 ### Effect Violation → Diagnostic Normalization
 
@@ -392,6 +416,22 @@ distinct from `E00xx` (symbol) and `E03xx` (interface) ranges:
 | `E0400` | Missing effect declaration |
 | `E0401` | Decorator-implied effect missing |
 | `E0402` | Transitive effect not propagated |
+
+**Warning code allocation:** `W01xx` is reserved for non-fatal
+load/staging warnings emitted by `sfn check` infrastructure (the
+import-context loader, capsule resolver staging, and any future
+artifact-loading layer). These warnings flow through the same
+`render_diagnostic` pipeline as errors with `severity: "warning"` and
+`kind: "load"`, so downstream consumers (`--json`, `sfn lsp`, CI
+scrapers) can filter on the producing layer. Program-analysis
+warnings (e.g. future `sfn vet` lints for unused imports or dead
+code) will live in `W02xx`+ to keep the load-vs-analysis distinction
+machine-checkable.
+
+| Code | Meaning |
+|---|---|
+| `W0001` | Missing import-context artifact (resolver staged a path that's no longer on disk) |
+| `W0002` | Import-context artifact parse failed (artifact existed but the native-IR parser produced diagnostics) |
 
 ## Data Flow: Single-File Check
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -33,6 +33,15 @@ feature availability.
   conformance (E0301) is now live for end users without any textual
   import inlining — covered by
   `compiler/tests/e2e/test_check_cross_module_conformance.sh`.
+- **Diagnostic infrastructure Phase 1** (A3): the `Diagnostic` struct
+  now carries `severity` ("error" | "warning" | "hint" | "info") and
+  `file_path`; the renderer reads both from the struct rather than
+  hand-threaded parameters. Import-context load warnings (`W0001`
+  missing artifact, `W0002` parse failure) flow through the same
+  `render_diagnostic` pipeline as typecheck and effect errors,
+  unblocking the upcoming `--json` output flag and `sfn lsp`. Phase 2
+  (`secondary` source locations + `FixSuggestion`/`TextEdit` for
+  `sfn fix`) lands later.
 - **`sfn test` still uses textual inlining** via the legacy
   `_inline_relative_imports_cmd` and `inline_imports_for_source`
   helpers. Migrating it is the remaining work in Stage B PR2 (coupled
@@ -106,7 +115,7 @@ feature availability.
 | `unsafe` / `extern` | Parsed only | Syntax accepted; enforcement not active |
 | Policy decorators (`@policy(...)`) | Parsed only | No compiler or runtime effect |
 | `sfn fmt` (formatter) | **Shipped** | Token-stream formatter: indentation, spacing, inline blocks, unary operator handling, import sorting & specifier reordering, blank line normalization, `--check`/`--write` modes, CI enforcement; see `docs/proposals/fmt-architecture.md` for architecture and known limitations |
-| `sfn check` (fast analysis) | **Shipped (v1)** | Runs parse + typecheck + effect-check on `.sfn` sources without emitting IR or invoking `clang`. Reports diagnostics to stderr with a summary on stdout. Exits non-zero on findings. Currently runs on a single textually-inlined buffer per file; cross-module interface conformance will become live once A2 wires the unified resolver in. See `docs/proposals/check-architecture.md`. |
+| `sfn check` (fast analysis) | **Shipped (v1)** | Runs parse + typecheck + effect-check on `.sfn` sources without emitting IR or invoking `clang`. Reports diagnostics to stderr with a summary on stdout. Exits non-zero on findings. Cross-module `implements` conformance live via the unified resolver (A2). Diagnostics carry `severity` and `file_path` and route load warnings (`W0001`/`W0002`) through the same renderer as errors (A3). See `docs/proposals/check-architecture.md`. |
 | `sfn vet` (static analyzer) | Planned | Pre-1.0; see `docs/proposals/tooling.md` |
 | `sfn lsp` (language server) | Planned | Phase 1 pre-1.0; see `docs/proposals/tooling.md` |
 | `sfn doc` (doc generator) | Planned | 1.0; see `docs/proposals/tooling.md` |

--- a/site/src/pages/roadmap.astro
+++ b/site/src/pages/roadmap.astro
@@ -88,7 +88,8 @@ const v1Categories: RoadmapCategory[] = [
       { label: "Pass make check with no fallbacks", status: "done" },
       { label: "Deterministic self-hosting — stage2 == stage3 fixed-point verified", status: "done" },
       { label: "Stabilize control-flow LLVM lowering (loop/if/break headers)", status: "planned" },
-      { label: "Richer diagnostics — multi-span, severity levels, fix-it hints", status: "planned" },
+      { label: "Richer diagnostics Phase 1 — severity, file_path, structured load warnings (W01xx)", status: "done" },
+      { label: "Richer diagnostics Phase 2 — multi-span, fix-it hints, source-location labels", status: "planned" },
     ],
   },
   {


### PR DESCRIPTION
Additive Phase 1 enhancement of the Diagnostic struct used by `sfn check`
(see docs/proposals/check-architecture.md A3). Two new scalar fields:

- `severity: string` — "error" | "warning" | "hint" | "info"
- `file_path: string` — originating module path; "" until stamped

All seven producer sites populate the new fields:
- six factories in typecheck_types.sfn (E0001/E0301/E0302/E0410)
- one inline literal in tools/check.sfn:effect_violation_to_diagnostic

Severity is hardcoded to "error" at every factory; file_path is left
empty here and stamped post-hoc by check_source_with_imports in a
follow-up commit. The renderer still hardcodes "error[code]:" — no
externally visible behavior change in this commit.

Self-host clean: 128 modules, all 31 unit tests pass.