### PR TITLE
effect validation Phase B: wire validate_effects into the build path

### DIFF
--- a/compiler/src/cli_check.sfn
+++ b/compiler/src/cli_check.sfn
@@ -24,10 +24,10 @@ import {
     prepare_project_capsules_for_check
 } from "./capsule_resolver";
 import { _collect_sfn_files_cmd, _dirname_cmd } from "./cli_commands_utils";
+import { render_diagnostic } from "./diagnostics_render";
 import {
     CheckResult,
     check_source_with_imports,
-    render_diagnostic,
     render_summary,
     summarize
 } from "./tools/check";

--- a/compiler/src/cli_check.sfn
+++ b/compiler/src/cli_check.sfn
@@ -255,7 +255,15 @@ fn handle_check_command(args: string[]) -> number ![io] {
         let group_idx = file_group_index[fi];
         let source = fs.readFile(path);
         let result = check_source_with_imports(source, path, groups[group_idx].interfaces);
-        if result.error_count > 0 {
+        // Emit any diagnostic — error or warning — so contributors
+        // running `sfn check` under Phase B (warning default) actually
+        // see the effect-violation output. Pre-Phase-B effect
+        // diagnostics were hardcoded "error" severity, so a non-zero
+        // error_count gated emission; with severity routed through
+        // `SAILFIN_EFFECT_ENFORCE` the gate has to widen to any
+        // diagnostic. The summary line still keys on error_count
+        // (warnings don't change the exit code).
+        if result.rendered.length > 0 {
             _emit_check_header(path, quiet);
             _emit_check_diagnostics(result, quiet);
         }

--- a/compiler/src/diagnostics_render.sfn
+++ b/compiler/src/diagnostics_render.sfn
@@ -1,0 +1,310 @@
+// compiler/src/diagnostics_render.sfn
+//
+// Single source of truth for diagnostic rendering shared between
+// `sfn check` (`tools/check.sfn`) and the build path
+// (`main.sfn` via `effect_gate.sfn`). Phase B
+// (`docs/proposals/effect-validation.md` §5, locked 2026-04-26)
+// extracts this code from `tools/check.sfn` so the build pipeline
+// can render effect diagnostics in the same shape — same headers,
+// same caret pointers, same `[kind: effect]` suffix — without
+// pulling in a dependency cycle through `main.sfn`.
+//
+// The rendering API is intentionally narrow:
+//
+//   - `effect_violation_to_diagnostic(violation) -> Diagnostic` —
+//     converts an `EffectViolation` (carrying signature/trigger
+//     tokens since Phase A) into the typed `Diagnostic` value the
+//     renderer consumes.
+//   - `render_diagnostic(diag, source_lines, kind) -> string` —
+//     returns the multi-line rendered text (caret diagram included
+//     when `diag.primary` is non-null and the line index is in
+//     range; location-only `--> file_path` line otherwise).
+//   - `split_source_lines(source) -> string[]` — splits source on
+//     CR/LF/CRLF the same way `main.sfn`'s
+//     `format_typecheck_diagnostic` does, kept here so the renderer
+//     is self-contained and can be unit-tested without bootstrapping
+//     a full compile pipeline.
+//
+// Every other helper in this module is private (`_dr_*` prefix) and
+// is duplicated rather than imported from `main.sfn` on purpose:
+// `main.sfn` imports diagnostic-rendering helpers from this module,
+// and the seed compiler does not handle import cycles cleanly. The
+// duplication is small (~50 lines, four pure string helpers) and
+// changes here are decoupled from changes to `main.sfn`'s own copies.
+import { EffectRequirement, EffectViolation } from "./effect_checker";
+import { substring } from "./string_utils";
+import { Token } from "./token";
+import { Diagnostic } from "./typecheck_types";
+
+// -------------------------------------------------------------------
+// Effect-violation → Diagnostic
+// -------------------------------------------------------------------
+fn join_effects(effects: string[]) -> string {
+    if effects.length == 0 { return ""; }
+    let mut out = effects[0];
+    let mut i: number = 1;
+    loop {
+        if i >= effects.length { break; }
+        out = out + ", " + effects[i];
+        i += 1;
+    }
+    return out;
+}
+
+fn code_for_missing_effect(missing_effects: string[], requirements: EffectRequirement[]) -> string {
+    // E0400 — missing effect declaration (general)
+    // E0401 — decorator-implied effect missing
+    let mut i: number = 0;
+    loop {
+        if i >= requirements.length { break; }
+        let desc = requirements[i].description;
+        if desc.length > 0 {
+            if desc[0] == "@" { return "E0401"; }
+        }
+        i += 1;
+    }
+    return "E0400";
+}
+
+fn effect_violation_to_diagnostic(violation: EffectViolation) -> Diagnostic {
+    let effects_text = join_effects(violation.missing_effects);
+    let mut message = "function `" + violation.routine_name
+        + "` is missing required effects: !["
+        + effects_text
+        + "]";
+
+    if violation.requirements.length > 0 {
+        message = message + "\nrequired by:";
+        let mut i: number = 0;
+        loop {
+            if i >= violation.requirements.length { break; }
+            let req = violation.requirements[i];
+            message = message + "\n  - " + req.description + " requires !["
+                + req.effect
+                + "]";
+            i += 1;
+        }
+    }
+
+    if violation.missing_effects.length > 0 {
+        message = message + "\nsuggestion: add ![" + effects_text
+            + "] to the function signature";
+    }
+
+    let code = code_for_missing_effect(violation.missing_effects, violation.requirements);
+    // `severity` rides on the violation since Phase A so the gate
+    // (`effect_gate.sfn`) can flip warning/error from
+    // `SAILFIN_EFFECT_ENFORCE` without reaching into the renderer.
+    // Empty-string fallback keeps callers that never set severity
+    // (e.g. seed-compiler test fixtures) on the historical default.
+    let mut sev = violation.severity;
+    if sev.length == 0 { sev = "error"; }
+    return Diagnostic {
+        code: code,
+        severity: sev,
+        message: message,
+        file_path: "",
+        primary: violation.trigger
+    };
+}
+
+// -------------------------------------------------------------------
+// Diagnostic rendering
+// -------------------------------------------------------------------
+fn _dr_split_lines(source: string) -> string[] {
+    let mut lines: string[] = [];
+    let mut current: string = "";
+    let mut index: number = 0;
+    loop {
+        if index >= source.length { break; }
+        let _ch_next = index + 1;
+        let ch = substring(source, index, _ch_next);
+        if ch == "\r" {
+            lines.push(current);
+            current = "";
+            if _ch_next < source.length {
+                let _ch_next2 = index + 2;
+                let next = substring(source, _ch_next, _ch_next2);
+                if next == "\n" {
+                    index += 2;
+                    continue;
+                }
+            }
+            index += 1;
+            continue;
+        }
+        if ch == "\n" {
+            lines.push(current);
+            current = "";
+            index += 1;
+            continue;
+        }
+        current = current + ch;
+        index += 1;
+    }
+    lines.push(current);
+    return lines;
+}
+
+fn split_source_lines(source: string) -> string[] {
+    return _dr_split_lines(source);
+}
+
+fn _dr_join_lines(lines: string[]) -> string {
+    if lines.length == 0 { return ""; }
+    let mut result: string = lines[0];
+    let mut index: number = 1;
+    loop {
+        if index >= lines.length { break; }
+        result = result + "\n" + lines[index];
+        index += 1;
+    }
+    return result;
+}
+
+fn _dr_number_to_string(value: number) -> string {
+    if value == 0 { return "0"; }
+    let mut working: number = value;
+    let mut negative: boolean = false;
+    if working < 0 {
+        negative = true;
+        working = 0 - working;
+    }
+    let digits = "0123456789";
+    let mut remaining: number = working;
+    let mut output: string = "";
+    loop {
+        if remaining <= 0 { break; }
+        let mut temp: number = remaining;
+        let mut quotient: number = 0;
+        loop {
+            if temp < 10 { break; }
+            temp -= 10;
+            quotient += 1;
+        }
+        let ch = substring(digits, temp, temp + 1);
+        output = ch + output;
+        remaining = quotient;
+    }
+    if negative { output = "-" + output; }
+    return output;
+}
+
+fn _dr_repeat(ch: string, count: number) -> string {
+    if count <= 0 { return ""; }
+    let mut index: number = 0;
+    let mut result: string = "";
+    loop {
+        if index >= count { break; }
+        result = result + ch;
+        index += 1;
+    }
+    return result;
+}
+
+fn _dr_render_message_lines(message: string) -> string[] {
+    return _dr_split_lines(message);
+}
+
+fn _dr_pad_number_string(value: string, width: number) -> string {
+    if value.length >= width { return value; }
+    let pad_count = width - value.length;
+    return _dr_repeat(" ", pad_count) + value;
+}
+
+fn _dr_build_pointer_prefix(column: number, line_text: string) -> string {
+    if column <= 1 { return ""; }
+    let mut prefix: string = "";
+    let mut index: number = 1;
+    loop {
+        if index >= column { break; }
+        if index <= line_text.length {
+            let ch = substring(line_text, index - 1, index);
+            if ch == "\t" { prefix = prefix + "\t"; } else {
+                prefix = prefix + " ";
+            }
+        } else { prefix = prefix + " "; }
+        index += 1;
+    }
+    return prefix;
+}
+
+fn _dr_build_caret(lexeme: string, line_text: string, column: number) -> string {
+    let mut highlight: number = lexeme.length;
+    if highlight <= 0 { highlight = 1; }
+    let mut remaining: number = line_text.length - (column - 1);
+    if remaining <= 0 { remaining = 1; }
+    if highlight > remaining { highlight = remaining; }
+    let mut out: string = "";
+    let mut i: number = 0;
+    loop {
+        if i >= highlight { break; }
+        out = out + "^";
+        i += 1;
+    }
+    return out;
+}
+
+fn render_diagnostic(d: Diagnostic, source_lines: string[], kind: string) -> string {
+    let mut parts: string[] = [];
+    let msg_lines = _dr_render_message_lines(d.message);
+    let mut header: string = d.severity + "[" + d.code + "]: ";
+    if msg_lines.length > 0 { header = header + msg_lines[0]; }
+    parts.push(header);
+
+    let mut padding_width: number = 1;
+    if source_lines.length > 0 {
+        padding_width = _dr_number_to_string(source_lines.length).length;
+    }
+
+    let mut has_location: boolean = false;
+    let mut line_number: number = 0;
+    let mut column_number: number = 1;
+    let mut lexeme: string = "";
+    if d.primary != null {
+        let token: Token? = d.primary;
+        line_number = token.line;
+        column_number = token.column;
+        lexeme = token.lexeme;
+        if line_number >= 1 {
+            if line_number <= source_lines.length { has_location = true; }
+        }
+    }
+
+    if has_location {
+        let loc = "  --> " + d.file_path + ":" + _dr_number_to_string(line_number)
+            + ":"
+            + _dr_number_to_string(column_number);
+        parts.push(loc);
+        let gutter = _dr_repeat(" ", padding_width);
+        parts.push(" " + gutter + " |");
+        let line_text = source_lines[line_number - 1];
+        let line_label = _dr_pad_number_string(_dr_number_to_string(line_number), padding_width);
+        parts.push(" " + line_label + " | " + line_text);
+        let pointer_prefix = _dr_build_pointer_prefix(column_number, line_text);
+        let caret = _dr_build_caret(lexeme, line_text, column_number);
+        parts.push(" " + gutter + " | " + pointer_prefix + caret);
+    } else if d.file_path.length > 0 {
+        parts.push("  --> " + d.file_path);
+    }
+
+    let mut i: number = 1;
+    loop {
+        if i >= msg_lines.length { break; }
+        parts.push("  = " + msg_lines[i]);
+        i += 1;
+    }
+
+    // Prefix tag (typecheck vs effect) helps grep/filtering.
+    if kind.length > 0 { parts.push("  [kind: " + kind + "]"); }
+
+    return _dr_join_lines(parts);
+}
+
+export {
+    code_for_missing_effect,
+    effect_violation_to_diagnostic,
+    join_effects,
+    render_diagnostic,
+    split_source_lines
+};

--- a/compiler/src/effect_gate.sfn
+++ b/compiler/src/effect_gate.sfn
@@ -1,0 +1,172 @@
+// compiler/src/effect_gate.sfn
+//
+// Phase B build-path effect gate
+// (`docs/proposals/effect-validation.md` §5, locked 2026-04-26).
+//
+// Wires `validate_effects` from `effect_checker.sfn` into every
+// `compile_to_*` entry point in `main.sfn` and lets operators steer
+// the gate via the `SAILFIN_EFFECT_ENFORCE` environment variable:
+//
+//   unset / "" / "warning"  → severity "warning" (Phase B default)
+//   "error"                  → severity "error" (build fails on violation)
+//   "off"                    → skip effect validation entirely + notice
+//
+// The default flips to "error" in Phase D after the in-tree audit
+// (Phase C) lands and one alpha cycle of warning-mode telemetry has
+// elapsed. Until then, `make compile` should succeed even with
+// outstanding effect violations so the audit work isn't a blocker.
+//
+// `sfn check` (`tools/check.sfn`) shares `resolve_effect_enforcement`
+// so the same env-var contract drives both surfaces — a contributor
+// who runs `sfn check` after Phase B sees the same severity the
+// build-path gate would emit.
+//
+// **Implementation note: env-var read avoids the `env.get` intrinsic.**
+// The 0.5.x seed compiler emits `call @sailfin_runtime_getenv` for
+// `env.get(name)` calls but does not emit a corresponding `declare`
+// in the LLVM preamble — the resulting IR fails `llvm-as` validation
+// during the bootstrap. Until the seed is rebased past that latent
+// runtime-helper-collection bug, this module reads `SAILFIN_EFFECT_ENFORCE`
+// via `process.run(["sh", "-c", "printf %s \"$VAR\" > tmp"])` plus
+// `fs.readFile` — the same shape `cli_commands_utils._shell_read_cmd`
+// uses for `SFN_REGISTRY`. The `tmp` path is process-unique
+// (suffixed by the caller's `file_path` slug) so 4-way parallel
+// `make compile` workers don't race each other on a shared
+// `/tmp/.sfn_*` file.
+import { Program } from "./ast";
+import {
+    effect_violation_to_diagnostic,
+    render_diagnostic,
+    split_source_lines
+} from "./diagnostics_render";
+import { EffectViolation, validate_effects } from "./effect_checker";
+import { sanitize_symbol, substring } from "./string_utils";
+import { Diagnostic } from "./typecheck_types";
+
+// -------------------------------------------------------------------
+// Severity selection
+// -------------------------------------------------------------------
+//
+// Pure function — exported separately from the gate so unit tests
+// can lock the env-var contract without spinning up a Program AST or
+// patching an env var inside a test process.
+fn resolve_effect_enforcement(raw: string) -> string {
+    if raw == "off" { return "off"; }
+    if raw == "error" { return "error"; }
+    // Empty string covers both "env var unset" (the shell read
+    // returns "" for missing vars) and an explicit empty value.
+    // Phase B treats both as the warning default; the default flips
+    // to "error" in Phase D, at which point this branch returns
+    // "error" instead.
+    return "warning";
+}
+
+// -------------------------------------------------------------------
+// Env-var read (process-unique tmp path)
+// -------------------------------------------------------------------
+//
+// Sailfin's tooling intrinsic for env reads is `env.get(name)` — but
+// the 0.5.x seed compiler doesn't emit a `declare` for the lowered
+// `sailfin_runtime_getenv` call, so any module the seed compiles
+// that calls `env.get` produces invalid LLVM IR. Until a newer seed
+// closes that bug, we shell out via `process.run` and write the
+// value to a process-unique tmp file the caller then reads with
+// `fs.readFile`.
+//
+// `unique_suffix` is a slug derived from the caller's `file_path` so
+// parallel build workers (`make compile -j4`) write to distinct
+// paths — no race on a shared `/tmp/.sfn_*` file. Callers in
+// `validate_and_render_effects` thread their `file_path` through
+// `_unique_suffix_for_path`.
+fn _unique_suffix_for_path(file_path: string) -> string {
+    if file_path.length == 0 { return "anon"; }
+    let slug = sanitize_symbol(file_path);
+    if slug.length == 0 { return "anon"; }
+    // sanitize_symbol can return very long strings for deeply nested
+    // module names; cap at 64 chars so we don't blow tmp-path limits.
+    if slug.length <= 64 { return slug; }
+    return substring(slug, 0, 64);
+}
+
+fn _read_env_via_shell(name: string, unique_suffix: string) -> string ![io] {
+    let tmp = "/tmp/.sfn_effect_enforce_" + unique_suffix;
+    // `printf '%s'` (no trailing newline) lets `fs.readFile` return
+    // exactly the env-var value — important so `=error` stays
+    // exactly five characters and doesn't accidentally include a
+    // stray newline that would defeat the `raw == "error"` check.
+    let cmd = "printf '%s' \"$" + name + "\" > " + tmp + " 2>/dev/null";
+    let rc = process.run(["sh", "-c", cmd]);
+    if rc != 0 { return ""; }
+    if !fs.exists(tmp) { return ""; }
+    let raw = fs.readFile(tmp);
+    process.run(["rm", "-f", tmp]);
+    return raw;
+}
+
+// Public alias used by `tools/check.sfn` (which has its own
+// `file_path`) and any future build-adjacent surface that wants to
+// honour the same env-var contract. The `unique_suffix` parameter is
+// a contract: callers must pass a value that's unique within the
+// current process tree (typically the file_path slug).
+fn read_effect_enforcement_env(unique_suffix: string) -> string ![io] {
+    return _read_env_via_shell("SAILFIN_EFFECT_ENFORCE", unique_suffix);
+}
+
+// -------------------------------------------------------------------
+// Build-path orchestrator
+// -------------------------------------------------------------------
+//
+// Returns the count of error-severity violations rendered (always 0
+// in warning mode, regardless of how many violations were emitted).
+// Callers in `main.sfn` use the return value as the gate signal:
+// non-zero means "abort this compile, the user has effect errors".
+//
+// `file_path` is what the diagnostic's `--> <file>:<line>:<col>` line
+// renders; the build-path callers thread `module_name` through
+// because they don't carry the originating source path. This is a
+// Phase-B compromise: module names like `parser/mod` are still
+// disambiguating enough for the audit work, and threading the real
+// source path through every `compile_to_*` signature is a bigger
+// refactor than Phase B should take. Phase E (cross-module
+// propagation) revisits the path-plumbing question.
+fn validate_and_render_effects(program: Program, source: string, file_path: string) -> number ![io] {
+    let unique = _unique_suffix_for_path(file_path);
+    let raw = read_effect_enforcement_env(unique);
+    let severity = resolve_effect_enforcement(raw);
+    if severity == "off" {
+        // Per proposal §4.7 — `=off` is an explicit, conscious
+        // bypass and emits a single-line stderr notice each
+        // invocation so it's visible in CI logs and dev terminals.
+        // Spec-mandated wording: do not silence this message.
+        print.err("[effect] SAILFIN_EFFECT_ENFORCE=off — skipping effect validation for "
+            + file_path);
+        return 0;
+    }
+    let violations = validate_effects(program);
+    if violations.length == 0 { return 0; }
+    let source_lines = split_source_lines(source);
+    let mut errors: number = 0;
+    let mut i: number = 0;
+    loop {
+        if i >= violations.length { break; }
+        // Mutate severity in place — the violation is a value-typed
+        // struct so the caller's collection is unaffected. Phase A
+        // hardcoded "error" at construction; Phase B overrides per
+        // the env-var contract.
+        let mut v: EffectViolation = violations[i];
+        v.severity = severity;
+        let mut diag: Diagnostic = effect_violation_to_diagnostic(v);
+        diag.file_path = file_path;
+        let rendered = render_diagnostic(diag, source_lines, "effect");
+        print.err(rendered);
+        if severity == "error" { errors += 1; }
+        i += 1;
+    }
+    return errors;
+}
+
+export {
+    read_effect_enforcement_env,
+    resolve_effect_enforcement,
+    validate_and_render_effects
+};

--- a/compiler/src/effect_gate.sfn
+++ b/compiler/src/effect_gate.sfn
@@ -73,11 +73,13 @@ fn resolve_effect_enforcement(raw: string) -> string {
 // value to a process-unique tmp file the caller then reads with
 // `fs.readFile`.
 //
-// `unique_suffix` is a slug derived from the caller's `file_path` so
-// parallel build workers (`make compile -j4`) write to distinct
-// paths — no race on a shared `/tmp/.sfn_*` file. Callers in
-// `validate_and_render_effects` thread their `file_path` through
-// `_unique_suffix_for_path`.
+// `unique_key` is any caller-chosen string. The helper sanitizes it
+// internally via `_unique_suffix_for_path` so callers can pass a raw
+// `file_path` (slashes, dots, leading hyphens — all OK) without
+// constructing an invalid `/tmp/.sfn_effect_enforce_*` path. Parallel
+// build workers (`make compile -j4`) thread their distinct module
+// names through and end up with distinct sanitized paths, avoiding
+// cross-process races on a shared `/tmp/.sfn_*` file.
 fn _unique_suffix_for_path(file_path: string) -> string {
     if file_path.length == 0 { return "anon"; }
     let slug = sanitize_symbol(file_path);
@@ -103,13 +105,13 @@ fn _read_env_via_shell(name: string, unique_suffix: string) -> string ![io] {
     return raw;
 }
 
-// Public alias used by `tools/check.sfn` (which has its own
+// Public entry — used by `tools/check.sfn` (which has its own
 // `file_path`) and any future build-adjacent surface that wants to
-// honour the same env-var contract. The `unique_suffix` parameter is
-// a contract: callers must pass a value that's unique within the
-// current process tree (typically the file_path slug).
-fn read_effect_enforcement_env(unique_suffix: string) -> string ![io] {
-    return _read_env_via_shell("SAILFIN_EFFECT_ENFORCE", unique_suffix);
+// honour the same env-var contract. The `unique_key` is sanitized
+// internally; callers can pass a raw `file_path` or `module_name`
+// without worrying about slashes or other path-unsafe characters.
+fn read_effect_enforcement_env(unique_key: string) -> string ![io] {
+    return _read_env_via_shell("SAILFIN_EFFECT_ENFORCE", _unique_suffix_for_path(unique_key));
 }
 
 // -------------------------------------------------------------------
@@ -130,8 +132,7 @@ fn read_effect_enforcement_env(unique_suffix: string) -> string ![io] {
 // refactor than Phase B should take. Phase E (cross-module
 // propagation) revisits the path-plumbing question.
 fn validate_and_render_effects(program: Program, source: string, file_path: string) -> number ![io] {
-    let unique = _unique_suffix_for_path(file_path);
-    let raw = read_effect_enforcement_env(unique);
+    let raw = read_effect_enforcement_env(file_path);
     let severity = resolve_effect_enforcement(raw);
     if severity == "off" {
         // Per proposal §4.7 — `=off` is an explicit, conscious

--- a/compiler/src/main.sfn
+++ b/compiler/src/main.sfn
@@ -2,6 +2,7 @@
 //
 // Sailfin compiler main module and compilation entry points.
 import { Program, Statement } from "./ast";
+import { validate_and_render_effects } from "./effect_gate";
 import {
     NativeModule,
     collect_reexport_violations,
@@ -66,6 +67,7 @@ fn compile_to_sailfin(source: string) -> string ![io] {
         return "";
     }
     if _reject_reexport_violations(program) { return ""; }
+    if validate_and_render_effects(program, source, "main") > 0 { return ""; }
     return emit_program(program);
 }
 
@@ -155,6 +157,7 @@ fn compile_to_llvm(source: string) -> string ![io] {
         return "";
     }
     if _reject_reexport_violations(program) { return ""; }
+    if validate_and_render_effects(program, source, "main") > 0 { return ""; }
     let trace_emit = fs.exists("build/sailfin/.trace_emit");
     let native_text = emit_native_text_with_module_name(program, "main");
     if trace_emit {
@@ -203,6 +206,9 @@ fn print_llvm_with_module(source: string, module_name: string) -> boolean ![io] 
         }
     }
     if _reject_reexport_violations(program) { return false; }
+    if validate_and_render_effects(program, source, module_name) > 0 {
+        return false;
+    }
     let native_text = emit_native_text_with_module_name(program, module_name);
     if native_text.length == 0 { return false; }
     return print_llvm_ir_from_text(native_text, module_name);
@@ -221,6 +227,9 @@ fn compile_to_llvm_with_module(source: string, module_name: string) -> string ![
         print.err("emit-llvm: skipping typecheck (build/sailfin/.skip_typecheck present)");
     }
     if _reject_reexport_violations(program) { return ""; }
+    if validate_and_render_effects(program, source, module_name) > 0 {
+        return "";
+    }
     let trace_emit = fs.exists("build/sailfin/.trace_emit");
     let native_text = emit_native_text_with_module_name(program, module_name);
     if trace_emit {
@@ -273,6 +282,11 @@ fn compile_to_llvm_with_module_timed(source: string, module_name: string) -> str
         print.err("emit-llvm: skipping typecheck (build/sailfin/.skip_typecheck present)");
     }
     if _reject_reexport_violations(program) {
+        print.err(_timing_line(module_name, "parse", t_parse));
+        print.err(_timing_line(module_name, "typecheck", t_typecheck));
+        return "";
+    }
+    if validate_and_render_effects(program, source, module_name) > 0 {
         print.err(_timing_line(module_name, "parse", t_parse));
         print.err(_timing_line(module_name, "typecheck", t_typecheck));
         return "";
@@ -365,6 +379,9 @@ fn compile_tests_to_llvm_file_with_module_imports(source: string, module_name: s
         return false;
     }
     if _reject_reexport_violations(program) { return false; }
+    if validate_and_render_effects(program, source, module_name) > 0 {
+        return false;
+    }
     if trace {
         print.err("test compiler (imports): emit_native_with_module_name start (module="
             + module_name
@@ -413,6 +430,9 @@ fn compile_to_native_text_with_module(source: string, module_name: string) -> st
         return "";
     }
     if _reject_reexport_violations(program) { return ""; }
+    if validate_and_render_effects(program, source, module_name) > 0 {
+        return "";
+    }
     let trace_emit = fs.exists("build/sailfin/.trace_emit");
     let text = emit_native_text_with_module_name(program, module_name);
     if trace_emit {
@@ -434,6 +454,9 @@ fn write_native_text_file_with_module(source: string, module_name: string, out_p
         return false;
     }
     if _reject_reexport_violations(program) { return false; }
+    if validate_and_render_effects(program, source, module_name) > 0 {
+        return false;
+    }
     return emit_native_text_to_file_with_module_name(program, module_name, out_path);
 }
 
@@ -516,6 +539,9 @@ fn compile_to_llvm_file_with_module(source: string, module_name: string, out_pat
         print.err("emit-llvm-file: skipping typecheck (build/sailfin/.skip_typecheck present)");
     }
     if _reject_reexport_violations(program) { return false; }
+    if validate_and_render_effects(program, source, module_name) > 0 {
+        return false;
+    }
 
     let native_text = emit_native_text_with_module_name(program, module_name);
     if native_text.length == 0 {

--- a/compiler/src/tools/check.sfn
+++ b/compiler/src/tools/check.sfn
@@ -3,21 +3,34 @@
 // Fast analysis pass for Sailfin source files. Runs parse, typecheck,
 // and effect-check without emitting native IR or invoking clang.
 //
-// Orchestration only — reuses parse_program, typecheck_diagnostics, and
-// validate_effects. No new analysis logic is introduced here.
+// Orchestration only — reuses parse_program, typecheck_diagnostics,
+// validate_effects, and (since Phase B) the shared rendering surface
+// in `compiler/src/diagnostics_render.sfn`. No new analysis logic is
+// introduced here.
 //
-// See docs/proposals/check-architecture.md for design rationale.
+// Phase B (`docs/proposals/effect-validation.md` §5) extracted the
+// effect-violation → Diagnostic conversion and `render_diagnostic`
+// out into `diagnostics_render.sfn` so the build path
+// (`main.sfn` via `effect_gate.sfn`) renders effect violations in
+// the same shape `sfn check` always has. Severity for effect
+// violations now flows through `resolve_effect_enforcement` so the
+// `SAILFIN_EFFECT_ENFORCE` env var steers `sfn check` and the build
+// path consistently — a `=warning` setting in Phase B keeps
+// `sfn check` green for the duration of the audit, while `=error`
+// reproduces the post-Phase-D gate locally for contributors.
+//
+// See docs/proposals/check-architecture.md for the broader design.
 import { Statement } from "../ast";
-import { EffectRequirement, EffectViolation, validate_effects } from "../effect_checker";
 import {
-    join_lines,
-    number_to_string,
-    repeat_character,
+    effect_violation_to_diagnostic,
+    render_diagnostic,
     split_source_lines
-} from "../main";
+} from "../diagnostics_render";
+import { validate_effects } from "../effect_checker";
+import { read_effect_enforcement_env, resolve_effect_enforcement } from "../effect_gate";
+import { number_to_string } from "../main";
 import { parse_program } from "../parser/mod";
 import { substring } from "../string_utils";
-import { Token } from "../token";
 import { typecheck_diagnostics_with_imports } from "../typecheck";
 import { Diagnostic } from "../typecheck_types";
 
@@ -37,184 +50,6 @@ struct CheckSummary {
 }
 
 // -------------------------------------------------------------------
-// Effect violation → Diagnostic normalization
-// -------------------------------------------------------------------
-fn _join_effects(effects: string[]) -> string {
-    if effects.length == 0 { return ""; }
-    let mut out = effects[0];
-    let mut i: number = 1;
-    loop {
-        if i >= effects.length { break; }
-        out = out + ", " + effects[i];
-        i += 1;
-    }
-    return out;
-}
-
-fn _code_for_missing_effect(missing_effects: string[], requirements: EffectRequirement[]) -> string {
-    // E0400 — missing effect declaration (general)
-    // E0401 — decorator-implied effect missing
-    let mut i: number = 0;
-    loop {
-        if i >= requirements.length { break; }
-        let desc = requirements[i].description;
-        if desc.length > 0 {
-            if desc[0] == "@" { return "E0401"; }
-        }
-        i += 1;
-    }
-    return "E0400";
-}
-
-fn effect_violation_to_diagnostic(violation: EffectViolation) -> Diagnostic {
-    let effects_text = _join_effects(violation.missing_effects);
-    let mut message = "function `" + violation.routine_name
-        + "` is missing required effects: !["
-        + effects_text
-        + "]";
-
-    if violation.requirements.length > 0 {
-        message = message + "\nrequired by:";
-        let mut i: number = 0;
-        loop {
-            if i >= violation.requirements.length { break; }
-            let req = violation.requirements[i];
-            message = message + "\n  - " + req.description + " requires !["
-                + req.effect
-                + "]";
-            i += 1;
-        }
-    }
-
-    if violation.missing_effects.length > 0 {
-        message = message + "\nsuggestion: add ![" + effects_text
-            + "] to the function signature";
-    }
-
-    let code = _code_for_missing_effect(violation.missing_effects, violation.requirements);
-    // Phase A — `EffectViolation` now carries a synthesized
-    // signature Token in `trigger` (via `_token_from_signature` in
-    // `effect_checker.sfn`) and a severity slot. The renderer reads
-    // both directly so effect diagnostics render with
-    // `--> file:line:column` + caret like typecheck diagnostics.
-    // `severity` flowing through the violation (rather than being
-    // hardcoded "error" here) keeps Phase B's `SAILFIN_EFFECT_ENFORCE`
-    // wiring contained to `effect_checker.sfn` — the renderer doesn't
-    // need to know about the env var.
-    let mut sev = violation.severity;
-    if sev.length == 0 { sev = "error"; }
-    return Diagnostic {
-        code: code,
-        severity: sev,
-        message: message,
-        file_path: "",
-        primary: violation.trigger
-    };
-}
-
-// -------------------------------------------------------------------
-// Rendering
-// -------------------------------------------------------------------
-fn _render_message_lines(message: string) -> string[] {
-    return split_source_lines(message);
-}
-
-fn _pad_number_string(value: string, width: number) -> string {
-    if value.length >= width { return value; }
-    let pad_count = width - value.length;
-    return repeat_character(" ", pad_count) + value;
-}
-
-fn _build_pointer_prefix(column: number, line_text: string) -> string {
-    if column <= 1 { return ""; }
-    let mut prefix: string = "";
-    let mut index: number = 1;
-    loop {
-        if index >= column { break; }
-        if index <= line_text.length {
-            let ch = substring(line_text, index - 1, index);
-            if ch == "\t" { prefix = prefix + "\t"; } else {
-                prefix = prefix + " ";
-            }
-        } else { prefix = prefix + " "; }
-        index += 1;
-    }
-    return prefix;
-}
-
-fn _build_caret(lexeme: string, line_text: string, column: number) -> string {
-    let mut highlight: number = lexeme.length;
-    if highlight <= 0 { highlight = 1; }
-    let mut remaining: number = line_text.length - (column - 1);
-    if remaining <= 0 { remaining = 1; }
-    if highlight > remaining { highlight = remaining; }
-    let mut out: string = "";
-    let mut i: number = 0;
-    loop {
-        if i >= highlight { break; }
-        out = out + "^";
-        i += 1;
-    }
-    return out;
-}
-
-fn render_diagnostic(d: Diagnostic, source_lines: string[], kind: string) -> string {
-    let mut parts: string[] = [];
-    let msg_lines = _render_message_lines(d.message);
-    let mut header: string = d.severity + "[" + d.code + "]: ";
-    if msg_lines.length > 0 { header = header + msg_lines[0]; }
-    parts.push(header);
-
-    let mut padding_width: number = 1;
-    if source_lines.length > 0 {
-        padding_width = number_to_string(source_lines.length).length;
-    }
-
-    let mut has_location: boolean = false;
-    let mut line_number: number = 0;
-    let mut column_number: number = 1;
-    let mut lexeme: string = "";
-    if d.primary != null {
-        let token: Token? = d.primary;
-        line_number = token.line;
-        column_number = token.column;
-        lexeme = token.lexeme;
-        if line_number >= 1 {
-            if line_number <= source_lines.length { has_location = true; }
-        }
-    }
-
-    if has_location {
-        let loc = "  --> " + d.file_path + ":" + number_to_string(line_number)
-            + ":"
-            + number_to_string(column_number);
-        parts.push(loc);
-        let gutter = repeat_character(" ", padding_width);
-        parts.push(" " + gutter + " |");
-        let line_text = source_lines[line_number - 1];
-        let line_label = _pad_number_string(number_to_string(line_number), padding_width);
-        parts.push(" " + line_label + " | " + line_text);
-        let pointer_prefix = _build_pointer_prefix(column_number, line_text);
-        let caret = _build_caret(lexeme, line_text, column_number);
-        parts.push(" " + gutter + " | " + pointer_prefix + caret);
-    } else if d.file_path.length > 0 {
-        parts.push("  --> " + d.file_path);
-    }
-
-    let mut i: number = 1;
-    loop {
-        if i >= msg_lines.length { break; }
-        parts.push("  = " + msg_lines[i]);
-        i += 1;
-    }
-
-    // Prefix tag (typecheck vs effect) helps grep/filtering.
-    if kind.length > 0 { parts.push("  [kind: " + kind + "]"); }
-
-    return join_lines(parts);
-}
-
-// -------------------------------------------------------------------
 // Orchestration
 // -------------------------------------------------------------------
 fn _is_sfn_file(path: string) -> boolean {
@@ -223,7 +58,7 @@ fn _is_sfn_file(path: string) -> boolean {
     return substring(path, start, path.length) == ".sfn";
 }
 
-fn check_source(source: string, file_path: string) -> CheckResult {
+fn check_source(source: string, file_path: string) -> CheckResult ![io] {
     let no_imports: Statement[] = [];
     return check_source_with_imports(source, file_path, no_imports);
 }
@@ -234,7 +69,7 @@ fn check_source(source: string, file_path: string) -> CheckResult {
 // passed through to `typecheck_diagnostics_with_imports` so cross-
 // module `implements` clauses are conformance-checked against the
 // real interface definitions instead of silently no-oping.
-fn check_source_with_imports(source: string, file_path: string, imported_interfaces: Statement[]) -> CheckResult {
+fn check_source_with_imports(source: string, file_path: string, imported_interfaces: Statement[]) -> CheckResult ![io] {
     let program = parse_program(source);
     let type_diags = typecheck_diagnostics_with_imports(program, imported_interfaces);
     let effect_violations = validate_effects(program);
@@ -259,10 +94,31 @@ fn check_source_with_imports(source: string, file_path: string, imported_interfa
         ti += 1;
     }
 
+    // Phase B: route effect-violation severity through the same
+    // env-var contract the build path uses. `sfn check` honors
+    // `SAILFIN_EFFECT_ENFORCE` so contributors can dry-run the
+    // post-Phase-D gate by exporting `=error` locally; the default
+    // ("warning") keeps the audit period non-disruptive.
+    //
+    // The unique suffix doubles as the env-read tmp-file slug —
+    // file_path is unique-per-source for the lifetime of this
+    // check loop, so concurrent `sfn check` invocations against
+    // the same file (rare but possible in a CI matrix) won't race
+    // on a shared `/tmp/.sfn_*` path.
+    let effect_severity = resolve_effect_enforcement(read_effect_enforcement_env(file_path));
     let mut ei: number = 0;
     loop {
         if ei >= effect_violations.length { break; }
-        let mut diag = effect_violation_to_diagnostic(effect_violations[ei]);
+        if effect_severity == "off" {
+            // §4.7 escape hatch — silence effect output entirely.
+            // The build path emits a per-file notice; `sfn check`
+            // does not, since the user invoked it explicitly and
+            // a notice on every check would be noise.
+            break;
+        }
+        let mut violation = effect_violations[ei];
+        violation.severity = effect_severity;
+        let mut diag = effect_violation_to_diagnostic(violation);
         diag.file_path = file_path;
         combined.push(diag);
         rendered.push(render_diagnostic(diag, source_lines, "effect"));
@@ -278,7 +134,7 @@ fn check_source_with_imports(source: string, file_path: string, imported_interfa
     };
 }
 
-fn check_file(path: string, inlined_source: string) -> CheckResult {
+fn check_file(path: string, inlined_source: string) -> CheckResult ![io] {
     return check_source(inlined_source, path);
 }
 
@@ -310,14 +166,20 @@ fn summarize(results: CheckResult[]) -> CheckSummary {
     };
 }
 
+// Note: `effect_violation_to_diagnostic` and `render_diagnostic` are
+// not re-exported here — Sailfin's emitter rejects re-exports of
+// imported symbols without a local definition (see
+// `docs/rca/2026-04-18-reexport-diagnostic-gep.md` and the
+// `_reject_reexport_violations` gate in `main.sfn`). Consumers
+// (`cli_check.sfn`, future tooling) import them directly from
+// `compiler/src/diagnostics_render.sfn` — same source of truth as
+// the build-path gate in `effect_gate.sfn`.
 export {
     CheckResult,
     CheckSummary,
     check_file,
     check_source,
     check_source_with_imports,
-    effect_violation_to_diagnostic,
-    render_diagnostic,
     render_summary,
     summarize
 };

--- a/compiler/src/tools/check.sfn
+++ b/compiler/src/tools/check.sfn
@@ -96,26 +96,29 @@ fn check_source_with_imports(source: string, file_path: string, imported_interfa
 
     // Phase B: route effect-violation severity through the same
     // env-var contract the build path uses. `sfn check` honors
-    // `SAILFIN_EFFECT_ENFORCE` so contributors can dry-run the
+    // `=warning` and `=error` so contributors can dry-run the
     // post-Phase-D gate by exporting `=error` locally; the default
     // ("warning") keeps the audit period non-disruptive.
     //
-    // The unique suffix doubles as the env-read tmp-file slug —
-    // file_path is unique-per-source for the lifetime of this
-    // check loop, so concurrent `sfn check` invocations against
-    // the same file (rare but possible in a CI matrix) won't race
-    // on a shared `/tmp/.sfn_*` path.
-    let effect_severity = resolve_effect_enforcement(read_effect_enforcement_env(file_path));
+    // Per proposal §4.7, `=off` is a build-path escape hatch only
+    // — "does not turn off sfn check validation, only the build
+    // path." `sfn check` therefore ignores `=off` and falls back
+    // to whatever severity would apply for an unset env var. That
+    // way Phase B's warning default and Phase D's eventual error
+    // default both flow through naturally without a second knob
+    // for `sfn check` to track.
+    //
+    // `read_effect_enforcement_env` sanitizes the unique-key
+    // internally, so passing `file_path` directly is safe even
+    // when it contains slashes (e.g. `compiler/src/main.sfn`).
+    let raw_severity = resolve_effect_enforcement(read_effect_enforcement_env(file_path));
+    let mut effect_severity: string = raw_severity;
+    if effect_severity == "off" {
+        effect_severity = resolve_effect_enforcement("");
+    }
     let mut ei: number = 0;
     loop {
         if ei >= effect_violations.length { break; }
-        if effect_severity == "off" {
-            // §4.7 escape hatch — silence effect output entirely.
-            // The build path emits a per-file notice; `sfn check`
-            // does not, since the user invoked it explicitly and
-            // a notice on every check would be noise.
-            break;
-        }
         let mut violation = effect_violations[ei];
         violation.severity = effect_severity;
         let mut diag = effect_violation_to_diagnostic(violation);

--- a/compiler/tests/unit/effect_gate_test.sfn
+++ b/compiler/tests/unit/effect_gate_test.sfn
@@ -1,0 +1,160 @@
+// Unit tests for compiler/src/effect_gate.sfn — Phase B
+// (`docs/proposals/effect-validation.md` §5, locked 2026-04-26).
+//
+// Phase B wires `validate_effects` into the build path and lets
+// `SAILFIN_EFFECT_ENFORCE` flip the gate between warning (default),
+// error, and off. The pure-string severity decision lives in
+// `resolve_effect_enforcement` so the env-var contract can be
+// regression-tested without spawning the compiler binary or mutating
+// process environment from inside a test.
+//
+// We do NOT exercise `validate_and_render_effects` end-to-end here —
+// that path requires a parsed Program AST and routes through stderr
+// I/O, which would make this a fragile golden-output test. The
+// effect-checker side already has AST-level coverage in
+// `effect_checker_test.sfn`; the renderer side has coverage in
+// `check_tool_test.sfn`. This file pins the *contract* between the
+// env var and the build gate so a future "tidy the env-var parsing"
+// refactor can't quietly regress the Phase B → D rollout.
+//
+// File-isolated: no compiler imports. The helpers below mirror
+// `resolve_effect_enforcement`; keep them in sync when Phase D flips
+// the default branch from "warning" to "error".
+fn _local_resolve_effect_enforcement(raw: string) -> string {
+    if raw == "off" { return "off"; }
+    if raw == "error" { return "error"; }
+    return "warning";
+}
+
+// -------------------------------------------------------------------
+// Severity selection — Phase B contract
+// -------------------------------------------------------------------
+test "effect_gate: unset env var resolves to warning (Phase B default)" {
+    // The env-read shell helper writes "" for missing vars (printf
+    // '%s' "$UNSET" produces an empty file). Phase B treats unset
+    // as the warning default so contributors see effect violations
+    // without the build going red during the audit period.
+    assert strings_equal(_local_resolve_effect_enforcement(""), "warning");
+}
+
+test "effect_gate: explicit warning value resolves to warning" {
+    assert strings_equal(_local_resolve_effect_enforcement("warning"), "warning");
+}
+
+test "effect_gate: explicit error value resolves to error" {
+    // `=error` is the contributor opt-in for dry-running the
+    // post-Phase-D gate locally. Pin this so a typo refactor
+    // (e.g. accepting "errors" or capitalising) doesn't silently
+    // disable the dry-run path.
+    assert strings_equal(_local_resolve_effect_enforcement("error"), "error");
+}
+
+test "effect_gate: explicit off value resolves to off" {
+    // `=off` is the §4.7 escape hatch — emergency-builds bypass
+    // gates without removing the env var or touching source.
+    assert strings_equal(_local_resolve_effect_enforcement("off"), "off");
+}
+
+test "effect_gate: unrecognised value falls back to warning" {
+    // No fancy parsing: anything we don't recognise lands on the
+    // default. Lock this so a Phase D flip of the default branch
+    // doesn't accidentally start treating "true" / "1" / "yes" as
+    // synonyms for "error" — those are conventions from other
+    // ecosystems and would surprise Sailfin users.
+    assert strings_equal(_local_resolve_effect_enforcement("yes"), "warning");
+    assert strings_equal(_local_resolve_effect_enforcement("1"), "warning");
+    assert strings_equal(_local_resolve_effect_enforcement("ERROR"), "warning");
+    assert strings_equal(_local_resolve_effect_enforcement("on"), "warning");
+}
+
+// -------------------------------------------------------------------
+// Diagnostic severity codes — Phase B → D mapping
+// -------------------------------------------------------------------
+//
+// Phase B emits effect violations under whichever severity the env
+// var resolves to. The renderer keys on `Diagnostic.severity` to
+// produce `error[E04xx]:` / `warning[E04xx]:` / `hint[E04xx]:`
+// headers. Pin the mapping so that:
+//
+//   - Phase B's warning-mode rollout actually says "warning" (a
+//     regression that emitted "error" would defeat the Phase B → D
+//     transition window).
+//   - Phase D's eventual flip of the default to "error" is a
+//     one-line change to `resolve_effect_enforcement`, not a
+//     hunt-the-callsites refactor across diagnostic factories.
+//
+// The header format is verified in `check_tool_test.sfn`; here we
+// just lock the severity-string contract.
+fn _local_diagnostic_header(severity: string, code: string) -> string {
+    return severity + "[" + code + "]: ";
+}
+
+test "effect_gate: warning severity renders warning[E04xx] header" {
+    let header = _local_diagnostic_header("warning", "E0400");
+    assert strings_equal(header, "warning[E0400]: ");
+}
+
+test "effect_gate: error severity renders error[E04xx] header" {
+    let header = _local_diagnostic_header("error", "E0400");
+    assert strings_equal(header, "error[E0400]: ");
+}
+
+test "effect_gate: decorator-implied violations also flow through severity" {
+    // E0401 = decorator-implied effect missing. Phase A added the
+    // separate code; Phase B must keep it so contributors can
+    // grep `\[E0401\]` for `@trace` / `@logExecution` violations
+    // distinctly from the general `E0400` bucket.
+    let header = _local_diagnostic_header("warning", "E0401");
+    assert strings_equal(header, "warning[E0401]: ");
+}
+
+// -------------------------------------------------------------------
+// Build-gate behavior contract
+// -------------------------------------------------------------------
+//
+// `validate_and_render_effects(program, source, file_path)` returns
+// the count of *error-severity* violations. The build-path callers
+// in `main.sfn` use the return value as the abort signal:
+//
+//   if validate_and_render_effects(program, source, mod) > 0 { return ""; }
+//
+// Pin the return-value contract for the three steady states so a
+// refactor that "simplifies" by returning a boolean (or by counting
+// warnings as well) breaks loud rather than quietly relaxing the
+// Phase D gate.
+fn _local_simulate_gate_return(severity: string, violation_count: number) -> number {
+    // Mirrors `validate_and_render_effects`: warnings/hints/off
+    // never contribute to the abort count. Only "error" does.
+    if severity == "error" { return violation_count; }
+    return 0;
+}
+
+test "effect_gate: warning mode never aborts the build" {
+    // Even with 50 violations, warning mode returns 0 — the build
+    // proceeds. This is the cornerstone of the Phase B audit
+    // period.
+    assert _local_simulate_gate_return("warning", 50) == 0;
+    assert _local_simulate_gate_return("warning", 0) == 0;
+}
+
+test "effect_gate: error mode aborts on first violation" {
+    // Any non-zero count short-circuits the compile entry point.
+    assert _local_simulate_gate_return("error", 1) == 1;
+    assert _local_simulate_gate_return("error", 12) == 12;
+}
+
+test "effect_gate: error mode passes through when no violations" {
+    // The clean-tree path — the compiler self-hosts under
+    // strict effect enforcement once Phase C completes. This case
+    // is the steady state for the post-Phase-D world.
+    assert _local_simulate_gate_return("error", 0) == 0;
+}
+
+test "effect_gate: off mode never aborts" {
+    // §4.7 escape hatch — even with violations present, off
+    // skips validation entirely and returns 0. The notice line
+    // emitted alongside is verified by manual inspection (it's
+    // a stderr side effect; not unit-testable without process
+    // isolation).
+    assert _local_simulate_gate_return("off", 99) == 0;
+}

--- a/compiler/tests/unit/effect_gate_test.sfn
+++ b/compiler/tests/unit/effect_gate_test.sfn
@@ -13,18 +13,12 @@
 // I/O, which would make this a fragile golden-output test. The
 // effect-checker side already has AST-level coverage in
 // `effect_checker_test.sfn`; the renderer side has coverage in
-// `check_tool_test.sfn`. This file pins the *contract* between the
-// env var and the build gate so a future "tidy the env-var parsing"
-// refactor can't quietly regress the Phase B → D rollout.
-//
-// File-isolated: no compiler imports. The helpers below mirror
-// `resolve_effect_enforcement`; keep them in sync when Phase D flips
-// the default branch from "warning" to "error".
-fn _local_resolve_effect_enforcement(raw: string) -> string {
-    if raw == "off" { return "off"; }
-    if raw == "error" { return "error"; }
-    return "warning";
-}
+// `check_tool_test.sfn`. This file imports the real
+// `resolve_effect_enforcement` from `effect_gate.sfn` so a refactor
+// that changes the env-var → severity mapping (e.g. Phase D's flip
+// of the default branch from "warning" to "error") fails this suite
+// loud rather than letting a stale local mirror keep passing.
+import { resolve_effect_enforcement } from "../../src/effect_gate";
 
 // -------------------------------------------------------------------
 // Severity selection — Phase B contract
@@ -34,11 +28,11 @@ test "effect_gate: unset env var resolves to warning (Phase B default)" {
     // '%s' "$UNSET" produces an empty file). Phase B treats unset
     // as the warning default so contributors see effect violations
     // without the build going red during the audit period.
-    assert strings_equal(_local_resolve_effect_enforcement(""), "warning");
+    assert strings_equal(resolve_effect_enforcement(""), "warning");
 }
 
 test "effect_gate: explicit warning value resolves to warning" {
-    assert strings_equal(_local_resolve_effect_enforcement("warning"), "warning");
+    assert strings_equal(resolve_effect_enforcement("warning"), "warning");
 }
 
 test "effect_gate: explicit error value resolves to error" {
@@ -46,13 +40,16 @@ test "effect_gate: explicit error value resolves to error" {
     // post-Phase-D gate locally. Pin this so a typo refactor
     // (e.g. accepting "errors" or capitalising) doesn't silently
     // disable the dry-run path.
-    assert strings_equal(_local_resolve_effect_enforcement("error"), "error");
+    assert strings_equal(resolve_effect_enforcement("error"), "error");
 }
 
 test "effect_gate: explicit off value resolves to off" {
     // `=off` is the §4.7 escape hatch — emergency-builds bypass
     // gates without removing the env var or touching source.
-    assert strings_equal(_local_resolve_effect_enforcement("off"), "off");
+    // (The build path honors `off` directly; `sfn check` coerces
+    // `off` back to `warning` because §4.7 scopes the escape hatch
+    // to the build path.)
+    assert strings_equal(resolve_effect_enforcement("off"), "off");
 }
 
 test "effect_gate: unrecognised value falls back to warning" {
@@ -61,10 +58,10 @@ test "effect_gate: unrecognised value falls back to warning" {
     // doesn't accidentally start treating "true" / "1" / "yes" as
     // synonyms for "error" — those are conventions from other
     // ecosystems and would surprise Sailfin users.
-    assert strings_equal(_local_resolve_effect_enforcement("yes"), "warning");
-    assert strings_equal(_local_resolve_effect_enforcement("1"), "warning");
-    assert strings_equal(_local_resolve_effect_enforcement("ERROR"), "warning");
-    assert strings_equal(_local_resolve_effect_enforcement("on"), "warning");
+    assert strings_equal(resolve_effect_enforcement("yes"), "warning");
+    assert strings_equal(resolve_effect_enforcement("1"), "warning");
+    assert strings_equal(resolve_effect_enforcement("ERROR"), "warning");
+    assert strings_equal(resolve_effect_enforcement("on"), "warning");
 }
 
 // -------------------------------------------------------------------
@@ -84,18 +81,19 @@ test "effect_gate: unrecognised value falls back to warning" {
 //     hunt-the-callsites refactor across diagnostic factories.
 //
 // The header format is verified in `check_tool_test.sfn`; here we
-// just lock the severity-string contract.
+// just lock the severity-string contract that flows out of
+// `resolve_effect_enforcement` and into the diagnostic header.
 fn _local_diagnostic_header(severity: string, code: string) -> string {
     return severity + "[" + code + "]: ";
 }
 
 test "effect_gate: warning severity renders warning[E04xx] header" {
-    let header = _local_diagnostic_header("warning", "E0400");
+    let header = _local_diagnostic_header(resolve_effect_enforcement(""), "E0400");
     assert strings_equal(header, "warning[E0400]: ");
 }
 
 test "effect_gate: error severity renders error[E04xx] header" {
-    let header = _local_diagnostic_header("error", "E0400");
+    let header = _local_diagnostic_header(resolve_effect_enforcement("error"), "E0400");
     assert strings_equal(header, "error[E0400]: ");
 }
 
@@ -104,7 +102,7 @@ test "effect_gate: decorator-implied violations also flow through severity" {
     // separate code; Phase B must keep it so contributors can
     // grep `\[E0401\]` for `@trace` / `@logExecution` violations
     // distinctly from the general `E0400` bucket.
-    let header = _local_diagnostic_header("warning", "E0401");
+    let header = _local_diagnostic_header(resolve_effect_enforcement("warning"), "E0401");
     assert strings_equal(header, "warning[E0401]: ");
 }
 
@@ -118,13 +116,20 @@ test "effect_gate: decorator-implied violations also flow through severity" {
 //
 //   if validate_and_render_effects(program, source, mod) > 0 { return ""; }
 //
-// Pin the return-value contract for the three steady states so a
-// refactor that "simplifies" by returning a boolean (or by counting
-// warnings as well) breaks loud rather than quietly relaxing the
-// Phase D gate.
-fn _local_simulate_gate_return(severity: string, violation_count: number) -> number {
-    // Mirrors `validate_and_render_effects`: warnings/hints/off
-    // never contribute to the abort count. Only "error" does.
+// Pin the contract for the three steady states so a refactor that
+// "simplifies" by returning a boolean (or by counting warnings as
+// well) breaks loud rather than quietly relaxing the Phase D gate.
+//
+// The simulation mirrors the real loop in
+// `effect_gate.validate_and_render_effects` — only "error" severity
+// contributes to the abort count; "warning"/"hint"/"off" return 0
+// regardless of how many violations were rendered. We keep the
+// simulation here (rather than calling the real function) because
+// the real function takes a parsed `Program` AST and emits to
+// stderr; building the AST + capturing stderr would make the test
+// fragile against rendering changes that the renderer-side suite
+// (`check_tool_test.sfn`) already covers.
+fn _simulate_gate_abort_count(severity: string, violation_count: number) -> number {
     if severity == "error" { return violation_count; }
     return 0;
 }
@@ -132,22 +137,26 @@ fn _local_simulate_gate_return(severity: string, violation_count: number) -> num
 test "effect_gate: warning mode never aborts the build" {
     // Even with 50 violations, warning mode returns 0 — the build
     // proceeds. This is the cornerstone of the Phase B audit
-    // period.
-    assert _local_simulate_gate_return("warning", 50) == 0;
-    assert _local_simulate_gate_return("warning", 0) == 0;
+    // period. We thread the input through the real
+    // `resolve_effect_enforcement` so a regression that flips the
+    // default to "error" prematurely fails this case loudly.
+    let warning_severity = resolve_effect_enforcement("");
+    assert _simulate_gate_abort_count(warning_severity, 50) == 0;
+    assert _simulate_gate_abort_count(warning_severity, 0) == 0;
 }
 
 test "effect_gate: error mode aborts on first violation" {
     // Any non-zero count short-circuits the compile entry point.
-    assert _local_simulate_gate_return("error", 1) == 1;
-    assert _local_simulate_gate_return("error", 12) == 12;
+    let error_severity = resolve_effect_enforcement("error");
+    assert _simulate_gate_abort_count(error_severity, 1) == 1;
+    assert _simulate_gate_abort_count(error_severity, 12) == 12;
 }
 
 test "effect_gate: error mode passes through when no violations" {
     // The clean-tree path — the compiler self-hosts under
     // strict effect enforcement once Phase C completes. This case
     // is the steady state for the post-Phase-D world.
-    assert _local_simulate_gate_return("error", 0) == 0;
+    assert _simulate_gate_abort_count(resolve_effect_enforcement("error"), 0) == 0;
 }
 
 test "effect_gate: off mode never aborts" {
@@ -156,5 +165,6 @@ test "effect_gate: off mode never aborts" {
     // emitted alongside is verified by manual inspection (it's
     // a stderr side effect; not unit-testable without process
     // isolation).
-    assert _local_simulate_gate_return("off", 99) == 0;
+    let off_severity = resolve_effect_enforcement("off");
+    assert _simulate_gate_abort_count(off_severity, 99) == 0;
 }

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,6 +1,6 @@
 # Status
 
-Updated: April 25, 2026 (typecheck cross-module conformance hookup — A1)
+Updated: April 26, 2026 (effect validation Phase B — build-path gate)
 
 This document tracks what works today and what is in progress. It is the source
 of truth — consult it before editing docs, examples, or making claims about
@@ -75,14 +75,15 @@ feature availability.
   `make compile` produces `build/native/sailfin`.
 - Pipeline: Lexer → Parser → Type Checker → Native Emitter
   (`.sfn-asm` IR) → LLVM Lowering.
-- **Effect checker status**: `validate_effects()` exists in `effect_checker.sfn`
-  and runs through `sfn check`, but is **not invoked by the compiler or CLI
-  during normal builds** — users still don't see effect diagnostics during
-  compilation, and effect violations don't block compilation. Wiring effect
-  enforcement into the build is the top priority in the Effect System
-  Hardening track on the [roadmap](https://sailfin.dev/roadmap), tracked
-  by `docs/proposals/effect-validation.md` (Phases A–G; Phase A landed
-  2026-04-26).
+- **Effect checker status**: `validate_effects()` is invoked from every
+  `compile_to_*` entry point in `main.sfn` (Phase B — shipped 2026-04-26;
+  see below). Severity is steered by the `SAILFIN_EFFECT_ENFORCE` env
+  var: unset / `=warning` emits warnings (default through the audit
+  period), `=error` blocks the build, `=off` skips validation entirely.
+  The default flips to `=error` in Phase D after the in-tree audit
+  (Phase C) lands and one alpha cycle of warning-mode telemetry has
+  elapsed. Tracked by `docs/proposals/effect-validation.md`
+  (Phases A–G; Phases A and B landed 2026-04-26).
 - **Effect diagnostic source spans (Phase A — shipped 2026-04-26).** The
   `EffectViolation` struct now carries `signature_token`, `trigger`, and
   `severity` slots, populated from `FunctionSignature.name_span` via
@@ -97,10 +98,28 @@ feature availability.
   every effect-name decision; wiring `effect_checker.sfn` and
   `tools/check.sfn` to consume it (e.g. rejecting unknown effect names
   in `analyze_routine`, sorting `missing_effects` for deterministic
-  rendering) lands in Phase B alongside the build-pipeline gate.
-  Per-expression trigger tokens still default to the signature
-  location; threading per-`Expression` spans is deferred to a follow-up
-  that adds span fields to the AST's expression variants.
+  rendering) lands later in Phase G alongside the name-resolution
+  detector. Per-expression trigger tokens still default to the
+  signature location; threading per-`Expression` spans is deferred to
+  a follow-up that adds span fields to the AST's expression variants.
+- **Effect validation as build gate (Phase B — shipped 2026-04-26).**
+  `validate_and_render_effects` (in new `compiler/src/effect_gate.sfn`)
+  runs after typecheck in every `compile_to_*` entry point. The
+  rendering surface from `tools/check.sfn` extracted into new
+  `compiler/src/diagnostics_render.sfn` so the build path and
+  `sfn check` share one source of truth — diagnostic shape, severity
+  selection, and caret rendering match across both surfaces. Severity
+  is resolved from `SAILFIN_EFFECT_ENFORCE` via
+  `resolve_effect_enforcement`; the env-var read uses a
+  `process.run`-based shell helper because the 0.5.x seed compiler
+  has a known runtime-helper-collection bug for the `env.get`
+  intrinsic (it emits the call but not the LLVM `declare`). Each
+  build worker derives a process-unique tmp path from its file_path
+  to avoid races on `make compile -j4`. Off-mode emits a one-line
+  stderr notice per file so contributors can see the gate was
+  consciously bypassed. Phase C audits the in-tree compiler under
+  warning mode; Phase D flips the default severity from `warning` to
+  `error` in a later release.
 - Experimental LLVM JIT execution is available for targeted backend coverage.
 - CI uses the native build workflow (`.github/workflows/ci.yml`) to build, test,
   and attach release assets.
@@ -125,12 +144,12 @@ feature availability.
 | String interpolation (`{{ }}`) | Shipped | |
 | Pattern matching exhaustiveness | Partial | Runtime backstop via `match_exhaustive_failed` |
 | Effect annotations (`![...]`) | Shipped | Parsing and declaration |
-| Effect enforcement — `io` | Not enforced | Checker logic exists for `print.*`, `console.*`, `fs.*`, `@logExecution` but is not run during compilation |
-| Effect enforcement — `net` | Not enforced | Checker logic exists for `http.*`, `websocket.*`, `serve` but is not run during compilation |
-| Effect enforcement — `model` | Not enforced | Effect is declarable; future enforcement for `sfn/ai` calls requires wiring `validate_effects()` into compilation and adding signature-based transitive analysis once that capsule ships |
-| Effect enforcement — `clock` | Not enforced | Checker logic exists for `sleep`/`runtime.sleep` but is not run during compilation |
-| Effect enforcement — `gpu`, `rand` | Parsed only | Accepted syntactically; no checker logic |
-| Effect enforcement as compilation gate | **Not yet** | `validate_effects()` exists but is not invoked by the compiler; top priority |
+| Effect enforcement — `io` | Warning (Phase B) | Checker detects `print.*`, `console.*`, `fs.*`, `@logExecution`; runs during build under `SAILFIN_EFFECT_ENFORCE=warning` (default). Phase D flip to `=error` ships in a later alpha. |
+| Effect enforcement — `net` | Warning (Phase B) | Checker detects `http.*`, `websocket.*`, `serve`; runs during build under the same env-var contract |
+| Effect enforcement — `model` | Reserved | Declarable; effect-checker has no detector yet. The `sfn/ai` capsule (post-1.0) supplies the call sites Phase G's name-resolution detector will key on |
+| Effect enforcement — `clock` | Warning (Phase B) | Checker detects `sleep` / `runtime.sleep`; runs during build under the same env-var contract |
+| Effect enforcement — `gpu`, `rand` | Parsed only | Reserved at 1.0 in the canonical taxonomy; no detector logic yet |
+| Effect enforcement as compilation gate | **Phase B (warning) shipped** | `validate_and_render_effects` runs in every `compile_to_*` entry; severity steered by `SAILFIN_EFFECT_ENFORCE` (warning default; error/off opt-in). Phase D flips default to error after the in-tree audit (Phase C) lands |
 | Generic type inference | Partial | Type params captured; inference coverage is limited |
 | Interface conformance validation | Partial | Basic checks; variance not yet enforced |
 | `Affine<T>` / `Linear<T>` | Parsed only | Ownership wrappers accepted; move/consume rules not enforced |


### PR DESCRIPTION
`validate_effects()` now runs after typecheck in every `compile_to_*`
entry point in `main.sfn` (`compile_to_sailfin`, `compile_to_llvm` /
`_with_module` / `_with_module_timed` / `_file_with_module`,
`compile_tests_to_llvm_file_with_module_imports`,
`compile_to_native_text_with_module`, `write_native_text_file_with_module`,
`print_llvm_with_module`). Severity is steered by the
`SAILFIN_EFFECT_ENFORCE` env var per `docs/proposals/effect-validation.md`
§5 (locked 2026-04-26):

  unset / "" / "warning"  -> severity "warning" (Phase B default;
                            build proceeds)
  "error"                  -> severity "error" (build aborts on first
                            violation)
  "off"                    -> skip validation; emit a single-line
                            stderr notice per file

The default flips to `=error` in Phase D after the in-tree audit
(Phase C) lands and one alpha cycle of warning-mode telemetry has
elapsed. Until then, the bootstrap succeeds even with outstanding
effect violations so the audit work isn't a blocker.

New `compiler/src/effect_gate.sfn` owns severity selection
(`resolve_effect_enforcement`) and the validate+render orchestrator
(`validate_and_render_effects`). New `compiler/src/diagnostics_render.sfn`
extracts the `EffectViolation` -> `Diagnostic` conversion plus
`render_diagnostic` and the caret-rendering helpers from
`tools/check.sfn` so the build path and `sfn check` share one source
of truth -- diagnostic shape, severity selection, and caret rendering
match across both surfaces. `cli_check.sfn` now imports
`render_diagnostic` directly from `diagnostics_render.sfn` (the
re-export through `tools/check.sfn` would have tripped the
`_reject_reexport_violations` guard added in #229).

`tools/check.sfn`'s `check_source_with_imports` also routes through
`resolve_effect_enforcement` so contributors who run `sfn check`
locally with `SAILFIN_EFFECT_ENFORCE=error` see the post-Phase-D
gate behavior in advance.

The env-var read avoids the `env.get` intrinsic and instead shells
out via process.run + fs.readFile. The 0.5.x seed compiler has a
latent runtime-helper-collection bug for the `env.get` target -- it
emits the lowered `call @sailfin_runtime_getenv` but does not emit
the corresponding `declare`, so any module the seed compiles that
calls `env.get` produces invalid LLVM IR that fails `llvm-as`. Each
build worker derives a process-unique `/tmp` path from its
`file_path` slug so the parallel `-j4` workers don't race each other
on a shared `/tmp/.sfn_*` file.

Phase B baseline (sweep over `compiler/src/*.sfn` top-level): 1
warning -- `lex` in `lexer.sfn` is missing `![io]` from a
print/console call. Phase C will sweep the rest of the compiler tree
(including `compiler/src/llvm/` and `compiler/src/parser/`) and
annotate every violation bottom-up so the bootstrap is clean under
`SAILFIN_EFFECT_ENFORCE=error`.

Tests:
- New `compiler/tests/unit/effect_gate_test.sfn` (12 tests) locks
  the severity-selection contract for unset / explicit / off /
  unrecognised values, the diagnostic-header severity mapping, and
  the build-gate return-value contract (warning never aborts; error
  aborts on first violation; off bypasses).
- Existing `effect_checker_test.sfn` (10 tests) and
  `check_tool_test.sfn` (21 tests) still pass -- the rendering
  extraction is a move-only refactor and Phase A's
  `EffectViolation` source-span attribution is unchanged.

Verified end-to-end on the freshly built native compiler:
  - bootstrap from seed succeeds (259s, 131 modules, no env override).
  - Hand-crafted `fs.exists` violation renders `warning[E0400]` with
    caret under default severity, exit 0.
  - Same source under `SAILFIN_EFFECT_ENFORCE=error` renders
    `error[E0400]` and exits 1.
  - Same source under `SAILFIN_EFFECT_ENFORCE=off` emits
    `[effect] SAILFIN_EFFECT_ENFORCE=off -- skipping ...` and exits 0.

Closes Phase B of `docs/proposals/effect-validation.md`.

https://claude.ai/code/session_0157FJzrK3YtAjEKcoJ8xBhs