### PR TITLE
effect validation Phases C/D: audit + flip default to error

### DIFF
--- a/compiler/src/effect_gate.sfn
+++ b/compiler/src/effect_gate.sfn
@@ -1,20 +1,26 @@
 // compiler/src/effect_gate.sfn
 //
-// Phase B build-path effect gate
+// Phase B/C/D build-path effect gate
 // (`docs/proposals/effect-validation.md` §5, locked 2026-04-26).
 //
 // Wires `validate_effects` from `effect_checker.sfn` into every
 // `compile_to_*` entry point in `main.sfn` and lets operators steer
 // the gate via the `SAILFIN_EFFECT_ENFORCE` environment variable:
 //
-//   unset / "" / "warning"  → severity "warning" (Phase B default)
-//   "error"                  → severity "error" (build fails on violation)
+//   unset / "" / "error"     → severity "error" (build fails on violation;
+//                              this is the post-Phase-D default)
+//   "warning"                → severity "warning" (audit-mode opt-in;
+//                              build proceeds even with violations)
 //   "off"                    → skip effect validation entirely + notice
 //
-// The default flips to "error" in Phase D after the in-tree audit
-// (Phase C) lands and one alpha cycle of warning-mode telemetry has
-// elapsed. Until then, `make compile` should succeed even with
-// outstanding effect violations so the audit work isn't a blocker.
+// Phase B shipped this gate as warning-by-default. Phase C audited
+// the in-tree compiler tree and added `![io]` annotations to the 11
+// debug-trace routines that were flagged. Phase D (this commit)
+// flips the unset default from "warning" to "error" — Sailfin's
+// "compile-time effect enforcement" claim is now backed by build
+// behavior, not a checker that has to be opted into. `=warning` is
+// kept as an explicit override for capsule consumers who want the
+// pre-Phase-D telemetry-only mode while they migrate.
 //
 // `sfn check` (`tools/check.sfn`) shares `resolve_effect_enforcement`
 // so the same env-var contract drives both surfaces — a contributor
@@ -52,13 +58,14 @@ import { Diagnostic } from "./typecheck_types";
 // patching an env var inside a test process.
 fn resolve_effect_enforcement(raw: string) -> string {
     if raw == "off" { return "off"; }
-    if raw == "error" { return "error"; }
+    if raw == "warning" { return "warning"; }
     // Empty string covers both "env var unset" (the shell read
     // returns "" for missing vars) and an explicit empty value.
-    // Phase B treats both as the warning default; the default flips
-    // to "error" in Phase D, at which point this branch returns
-    // "error" instead.
-    return "warning";
+    // Phase D flipped the default to "error" — `make compile`,
+    // `sfn build`, `sfn run`, `sfn test`, and `sfn check` all gate
+    // builds on declared effects. Capsule authors who want the
+    // pre-Phase-D telemetry-only mode opt in with `=warning`.
+    return "error";
 }
 
 // -------------------------------------------------------------------

--- a/compiler/src/effect_gate.sfn
+++ b/compiler/src/effect_gate.sfn
@@ -5,13 +5,16 @@
 //
 // Wires `validate_effects` from `effect_checker.sfn` into every
 // `compile_to_*` entry point in `main.sfn` and lets operators steer
-// the gate via the `SAILFIN_EFFECT_ENFORCE` environment variable:
+// the gate via the `SAILFIN_EFFECT_ENFORCE` environment variable.
+// Effective behavior on the build path:
 //
 //   unset / "" / "error"     → severity "error" (build fails on violation;
 //                              this is the post-Phase-D default)
 //   "warning"                → severity "warning" (audit-mode opt-in;
 //                              build proceeds even with violations)
-//   "off"                    → skip effect validation entirely + notice
+//   "off"                    → skip effect validation on the build path
+//                              entirely; emit a per-file stderr notice
+//                              (see proposal §4.7 — escape hatch only)
 //
 // Phase B shipped this gate as warning-by-default. Phase C audited
 // the in-tree compiler tree and added `![io]` annotations to the 11
@@ -23,9 +26,12 @@
 // pre-Phase-D telemetry-only mode while they migrate.
 //
 // `sfn check` (`tools/check.sfn`) shares `resolve_effect_enforcement`
-// so the same env-var contract drives both surfaces — a contributor
-// who runs `sfn check` after Phase B sees the same severity the
-// build-path gate would emit.
+// for the warning/error/unset cases but **does not honour `=off`**:
+// per proposal §4.7, "does not turn off `sfn check` validation, only
+// the build path." `sfn check` coerces `off` back to the unset-default
+// severity (currently "error" post-Phase-D) so contributors who set
+// `=off` for emergency builds still see effect diagnostics when they
+// run `sfn check` explicitly.
 //
 // **Implementation note: env-var read avoids the `env.get` intrinsic.**
 // The 0.5.x seed compiler emits `call @sailfin_runtime_getenv` for
@@ -100,9 +106,12 @@ fn _unique_suffix_for_path(file_path: string) -> string {
 fn _read_env_via_shell(name: string, unique_suffix: string) -> string ![io] {
     let tmp = "/tmp/.sfn_effect_enforce_" + unique_suffix;
     // `printf '%s'` (no trailing newline) lets `fs.readFile` return
-    // exactly the env-var value — important so `=error` stays
-    // exactly five characters and doesn't accidentally include a
-    // stray newline that would defeat the `raw == "error"` check.
+    // exactly the env-var value — important so `resolve_effect_enforcement`
+    // can do exact-match comparisons (`raw == "off"`, `raw == "warning"`).
+    // A stray newline would make a user's `SAILFIN_EFFECT_ENFORCE=warning`
+    // arrive as `"warning\n"`, miss both branches, and silently fall
+    // through to the default ("error" post-Phase-D) instead of the
+    // intended audit-mode opt-in.
     let cmd = "printf '%s' \"$" + name + "\" > " + tmp + " 2>/dev/null";
     let rc = process.run(["sh", "-c", cmd]);
     if rc != 0 { return ""; }

--- a/compiler/src/lexer.sfn
+++ b/compiler/src/lexer.sfn
@@ -15,7 +15,7 @@ struct LexerState {
     column: number;
 }
 
-fn lex(source: string) -> Token[] {
+fn lex(source: string) -> Token[] ![io] {
     let length = source.length;
     let state: LexerState = LexerState {
         source: source,

--- a/compiler/src/llvm/expression_lowering/native/core.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core.sfn
@@ -397,7 +397,7 @@ fn resolve_borrow_base(target: string, locals: LocalBinding[]) -> string {
     return resolve_borrow_base_impl(target, locals);
 }
 
-fn lower_expression(expression: string, bindings: ParameterBinding[], locals: LocalBinding[], temp_index: number, lines: string[], functions: NativeFunction[], context: TypeContext, expected_type: string) -> ExpressionResult {
+fn lower_expression(expression: string, bindings: ParameterBinding[], locals: LocalBinding[], temp_index: number, lines: string[], functions: NativeFunction[], context: TypeContext, expected_type: string) -> ExpressionResult ![io] {
     let trimmed = trim_text(expression);
     let mut diagnostics: string[] = [];
     let empty_constants = empty_string_constant_set();

--- a/compiler/src/llvm/expression_lowering/native/core_operands.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_operands.sfn
@@ -1437,7 +1437,7 @@ fn coerce_general_fallback(operand: LLVMOperand, operand_type: string, target: s
     return null;
 }
 
-fn coerce_operand_to_type(operand: LLVMOperand, target_type: string, temp_index: number, lines: string[]) -> CoercionResult {
+fn coerce_operand_to_type(operand: LLVMOperand, target_type: string, temp_index: number, lines: string[]) -> CoercionResult ![io] {
     let debug_coerce = fs.exists("build/sailfin/.trace_lowering");
     if debug_coerce {
         print.err("emit-llvm: coerce_operand entry operand_type=" + operand.llvm_type

--- a/compiler/src/llvm/lowering/instructions_loops.sfn
+++ b/compiler/src/llvm/lowering/instructions_loops.sfn
@@ -111,7 +111,7 @@ fn last_loop_context(values: LoopContext[]) -> LoopContext {
     return values[index];
 }
 
-fn lower_loop_instruction(function: NativeFunction, start_index: number, llvm_return: string, bindings: ParameterBinding[], locals: LocalBinding[], allocas: string[], lines: string[], temp_index: number, block_counter: number, next_local_id: number, next_region_id: number, functions: NativeFunction[], loop_stack: LoopContext[], end: number, context: TypeContext, scope_id: string, scope_depth: number, current_label: string) -> BlockLoweringResult {
+fn lower_loop_instruction(function: NativeFunction, start_index: number, llvm_return: string, bindings: ParameterBinding[], locals: LocalBinding[], allocas: string[], lines: string[], temp_index: number, block_counter: number, next_local_id: number, next_region_id: number, functions: NativeFunction[], loop_stack: LoopContext[], end: number, context: TypeContext, scope_id: string, scope_depth: number, current_label: string) -> BlockLoweringResult ![io] {
     let mut diagnostics: string[] = [];
     let mut current_lines: string[] = lines;
     let mut current_allocas: string[] = allocas;

--- a/compiler/src/llvm/lowering/lowering_helpers_mangling.sfn
+++ b/compiler/src/llvm/lowering/lowering_helpers_mangling.sfn
@@ -41,7 +41,7 @@ import {
     should_keep_unmangled_abi_symbol
 } from "./lowering_helpers";
 
-fn apply_module_symbol_mangling(lines: string[], imports: NativeImport[], current_module_slug: string, imported_native_texts: string[], native_text_path: string) -> MangledModuleResult {
+fn apply_module_symbol_mangling(lines: string[], imports: NativeImport[], current_module_slug: string, imported_native_texts: string[], native_text_path: string) -> MangledModuleResult ![io] {
     let mut diagnostics: string[] = [];
     let debug_lowering = fs.exists("build/sailfin/.trace_lowering");
     if debug_lowering {

--- a/compiler/src/llvm/lowering/lowering_phase_sanitize.sfn
+++ b/compiler/src/llvm/lowering/lowering_phase_sanitize.sfn
@@ -60,7 +60,7 @@ fn sanitize_lowering_inputs(parse_in: ParseNativeResult, native_text_override_pa
 }
 
 // Sanitize imported manifests array: null-check + length guard.
-fn sanitize_imported_manifests(imported_manifests: LayoutManifest[], debug_lowering: boolean) -> LayoutManifest[] {
+fn sanitize_imported_manifests(imported_manifests: LayoutManifest[], debug_lowering: boolean) -> LayoutManifest[] ![io] {
     let mut safe = imported_manifests;
     if safe == null { safe = []; }
     if safe.length != sanitize_collection_length(safe.length, 100000) {
@@ -73,7 +73,7 @@ fn sanitize_imported_manifests(imported_manifests: LayoutManifest[], debug_lower
 }
 
 // Sanitize imported native texts array: null-check + length guard.
-fn sanitize_imported_native_texts(imported_native_texts: string[], debug_lowering: boolean) -> string[] {
+fn sanitize_imported_native_texts(imported_native_texts: string[], debug_lowering: boolean) -> string[] ![io] {
     let mut safe = imported_native_texts;
     if safe == null { safe = []; }
     if safe.length != sanitize_collection_length(safe.length, 100000) {
@@ -96,7 +96,7 @@ fn sanitize_diagnostics(diagnostics_in: string[]) -> string[] {
 }
 
 // Sanitize entry points array: null-check + length guard.
-fn sanitize_entry_points(entry_points: string[], debug_lowering: boolean) -> string[] {
+fn sanitize_entry_points(entry_points: string[], debug_lowering: boolean) -> string[] ![io] {
     let mut safe = entry_points;
     if safe == null { safe = []; }
     if safe.length != sanitize_collection_length(safe.length, 100000) {
@@ -109,7 +109,7 @@ fn sanitize_entry_points(entry_points: string[], debug_lowering: boolean) -> str
 }
 
 // Sanitize imports array: null-check + length guard.
-fn sanitize_imports(imports: NativeImport[], debug_lowering: boolean) -> NativeImport[] {
+fn sanitize_imports(imports: NativeImport[], debug_lowering: boolean) -> NativeImport[] ![io] {
     let mut safe = imports;
     if safe == null { safe = []; }
     if safe.length != sanitize_collection_length(safe.length, 100000) {
@@ -141,7 +141,7 @@ fn sanitize_structs(structs: NativeStruct[], diagnostics: string[]) -> NativeStr
 }
 
 // Sanitize enums array: null-check + length guard + diagnostics.
-fn sanitize_enums(enums: NativeEnum[], diagnostics: string[], _trace_enums: boolean) -> NativeEnum[] {
+fn sanitize_enums(enums: NativeEnum[], diagnostics: string[], _trace_enums: boolean) -> NativeEnum[] ![io] {
     let mut safe = enums;
     if _trace_enums {
         let mut _enum_len_text: string = "null";

--- a/compiler/src/parser/mod.sfn
+++ b/compiler/src/parser/mod.sfn
@@ -62,7 +62,7 @@ fn parse_program(source: string) -> Program {
     return parse_tokens(tokens);
 }
 
-fn parse_tokens(tokens: Token[]) -> Program {
+fn parse_tokens(tokens: Token[]) -> Program ![io] {
     let mut parser: Parser = Parser { tokens: tokens, index: 0 };
     let mut statements: Statement[] = [];
     parser = skip_trivia(parser);

--- a/compiler/tests/unit/effect_gate_test.sfn
+++ b/compiler/tests/unit/effect_gate_test.sfn
@@ -58,8 +58,11 @@ test "effect_gate: explicit off value resolves to off" {
     // `=off` is the §4.7 escape hatch — emergency-builds bypass
     // gates without removing the env var or touching source.
     // (The build path honors `off` directly; `sfn check` coerces
-    // `off` back to `warning` because §4.7 scopes the escape hatch
-    // to the build path.)
+    // `off` back to the unset-env-var default — currently `error`
+    // post-Phase-D — because §4.7 scopes the escape hatch to the
+    // build path. `tools/check.sfn` does the coercion via
+    // `resolve_effect_enforcement("")`, not by hardcoding "warning",
+    // so the Phase D flip propagates automatically.)
     assert strings_equal(resolve_effect_enforcement("off"), "off");
 }
 

--- a/compiler/tests/unit/effect_gate_test.sfn
+++ b/compiler/tests/unit/effect_gate_test.sfn
@@ -1,12 +1,15 @@
-// Unit tests for compiler/src/effect_gate.sfn — Phase B
+// Unit tests for compiler/src/effect_gate.sfn — Phase B/C/D
 // (`docs/proposals/effect-validation.md` §5, locked 2026-04-26).
 //
-// Phase B wires `validate_effects` into the build path and lets
-// `SAILFIN_EFFECT_ENFORCE` flip the gate between warning (default),
-// error, and off. The pure-string severity decision lives in
-// `resolve_effect_enforcement` so the env-var contract can be
-// regression-tested without spawning the compiler binary or mutating
-// process environment from inside a test.
+// Phase B wired `validate_effects` into the build path with
+// warning-by-default behavior. Phase C audited the in-tree compiler
+// (11 debug-trace routines, all annotated with `![io]`). Phase D
+// flipped the unset env-var default from "warning" to "error" so
+// the build path now fails on undeclared effects. The pure-string
+// severity decision lives in `resolve_effect_enforcement` so the
+// env-var contract is regression-tested without spawning the
+// compiler binary or mutating process environment from inside a
+// test.
 //
 // We do NOT exercise `validate_and_render_effects` end-to-end here —
 // that path requires a parsed Program AST and routes through stderr
@@ -15,31 +18,39 @@
 // `effect_checker_test.sfn`; the renderer side has coverage in
 // `check_tool_test.sfn`. This file imports the real
 // `resolve_effect_enforcement` from `effect_gate.sfn` so a refactor
-// that changes the env-var → severity mapping (e.g. Phase D's flip
-// of the default branch from "warning" to "error") fails this suite
-// loud rather than letting a stale local mirror keep passing.
+// that changes the env-var → severity mapping (e.g. quietly relaxing
+// the post-Phase-D default back to "warning") fails this suite loud
+// rather than silently disabling the gate.
 import { resolve_effect_enforcement } from "../../src/effect_gate";
 
 // -------------------------------------------------------------------
-// Severity selection — Phase B contract
+// Severity selection — Phase D contract
 // -------------------------------------------------------------------
-test "effect_gate: unset env var resolves to warning (Phase B default)" {
+test "effect_gate: unset env var resolves to error (Phase D default)" {
     // The env-read shell helper writes "" for missing vars (printf
-    // '%s' "$UNSET" produces an empty file). Phase B treats unset
-    // as the warning default so contributors see effect violations
-    // without the build going red during the audit period.
-    assert strings_equal(resolve_effect_enforcement(""), "warning");
+    // '%s' "$UNSET" produces an empty file). Phase D treats unset
+    // as "error" — Sailfin's flagship safety claim, "compile-time
+    // effect enforcement", is on by default. A regression that
+    // flipped this back to "warning" would silently disable the
+    // gate for every consumer who didn't set the env var.
+    assert strings_equal(resolve_effect_enforcement(""), "error");
 }
 
 test "effect_gate: explicit warning value resolves to warning" {
+    // `=warning` is the post-Phase-D opt-out for capsule authors
+    // who want the pre-Phase-D telemetry-only mode while they
+    // migrate. Pin the explicit override so it can't be quietly
+    // removed.
     assert strings_equal(resolve_effect_enforcement("warning"), "warning");
 }
 
 test "effect_gate: explicit error value resolves to error" {
-    // `=error` is the contributor opt-in for dry-running the
-    // post-Phase-D gate locally. Pin this so a typo refactor
-    // (e.g. accepting "errors" or capitalising) doesn't silently
-    // disable the dry-run path.
+    // `=error` is functionally identical to the unset default
+    // post-Phase-D, but capsule authors and CI configs may set it
+    // explicitly to lock in strict mode independently of any
+    // future default change. Pin this so a typo refactor (e.g.
+    // accepting "errors" or capitalising) doesn't silently break
+    // the explicit setting.
     assert strings_equal(resolve_effect_enforcement("error"), "error");
 }
 
@@ -52,16 +63,17 @@ test "effect_gate: explicit off value resolves to off" {
     assert strings_equal(resolve_effect_enforcement("off"), "off");
 }
 
-test "effect_gate: unrecognised value falls back to warning" {
+test "effect_gate: unrecognised value falls back to default (error)" {
     // No fancy parsing: anything we don't recognise lands on the
-    // default. Lock this so a Phase D flip of the default branch
-    // doesn't accidentally start treating "true" / "1" / "yes" as
-    // synonyms for "error" — those are conventions from other
-    // ecosystems and would surprise Sailfin users.
-    assert strings_equal(resolve_effect_enforcement("yes"), "warning");
-    assert strings_equal(resolve_effect_enforcement("1"), "warning");
-    assert strings_equal(resolve_effect_enforcement("ERROR"), "warning");
-    assert strings_equal(resolve_effect_enforcement("on"), "warning");
+    // default. Post-Phase-D the default is "error", so a typo or
+    // alternative-convention value (e.g. `=yes`, `=1`, `=true`)
+    // fails closed — strict mode wins. This is intentional: every
+    // path that doesn't explicitly opt out of enforcement gets
+    // enforcement.
+    assert strings_equal(resolve_effect_enforcement("yes"), "error");
+    assert strings_equal(resolve_effect_enforcement("1"), "error");
+    assert strings_equal(resolve_effect_enforcement("ERROR"), "error");
+    assert strings_equal(resolve_effect_enforcement("on"), "error");
 }
 
 // -------------------------------------------------------------------
@@ -88,20 +100,24 @@ fn _local_diagnostic_header(severity: string, code: string) -> string {
 }
 
 test "effect_gate: warning severity renders warning[E04xx] header" {
-    let header = _local_diagnostic_header(resolve_effect_enforcement(""), "E0400");
+    let header = _local_diagnostic_header(resolve_effect_enforcement("warning"), "E0400");
     assert strings_equal(header, "warning[E0400]: ");
 }
 
 test "effect_gate: error severity renders error[E04xx] header" {
-    let header = _local_diagnostic_header(resolve_effect_enforcement("error"), "E0400");
-    assert strings_equal(header, "error[E0400]: ");
+    // Post-Phase-D `""` resolves to "error" so the unset-env-var
+    // path also exercises the error header — same shape `=error`
+    // produces. Pin both routes since the unset path is what 99%
+    // of build invocations will hit.
+    assert strings_equal(_local_diagnostic_header(resolve_effect_enforcement(""), "E0400"), "error[E0400]: ");
+    assert strings_equal(_local_diagnostic_header(resolve_effect_enforcement("error"), "E0400"), "error[E0400]: ");
 }
 
 test "effect_gate: decorator-implied violations also flow through severity" {
     // E0401 = decorator-implied effect missing. Phase A added the
-    // separate code; Phase B must keep it so contributors can
-    // grep `\[E0401\]` for `@trace` / `@logExecution` violations
-    // distinctly from the general `E0400` bucket.
+    // separate code; the Phase B/C/D gate must keep it distinct
+    // from the general E0400 bucket so contributors can grep
+    // `\[E0401\]` for `@trace` / `@logExecution` violations.
     let header = _local_diagnostic_header(resolve_effect_enforcement("warning"), "E0401");
     assert strings_equal(header, "warning[E0401]: ");
 }
@@ -136,27 +152,35 @@ fn _simulate_gate_abort_count(severity: string, violation_count: number) -> numb
 
 test "effect_gate: warning mode never aborts the build" {
     // Even with 50 violations, warning mode returns 0 — the build
-    // proceeds. This is the cornerstone of the Phase B audit
-    // period. We thread the input through the real
-    // `resolve_effect_enforcement` so a regression that flips the
-    // default to "error" prematurely fails this case loudly.
-    let warning_severity = resolve_effect_enforcement("");
+    // proceeds. Post-Phase-D this is an explicit `=warning` opt-in
+    // for capsule authors who want telemetry-only mode while they
+    // migrate. Lock the contract so a refactor that "simplifies
+    // away the warning branch" breaks loudly.
+    let warning_severity = resolve_effect_enforcement("warning");
     assert _simulate_gate_abort_count(warning_severity, 50) == 0;
     assert _simulate_gate_abort_count(warning_severity, 0) == 0;
 }
 
 test "effect_gate: error mode aborts on first violation" {
     // Any non-zero count short-circuits the compile entry point.
+    // Post-Phase-D the unset env var also routes here, so this is
+    // the steady-state path for the vast majority of builds.
     let error_severity = resolve_effect_enforcement("error");
     assert _simulate_gate_abort_count(error_severity, 1) == 1;
     assert _simulate_gate_abort_count(error_severity, 12) == 12;
+    // The unset-env-var path produces the same severity and
+    // therefore the same abort count — pin this so the default
+    // can't drift back to "warning" without surfacing.
+    let default_severity = resolve_effect_enforcement("");
+    assert _simulate_gate_abort_count(default_severity, 1) == 1;
 }
 
 test "effect_gate: error mode passes through when no violations" {
-    // The clean-tree path — the compiler self-hosts under
-    // strict effect enforcement once Phase C completes. This case
-    // is the steady state for the post-Phase-D world.
+    // The clean-tree path — the compiler self-hosts under strict
+    // effect enforcement after Phase C's audit. This is the
+    // steady state for the post-Phase-D world.
     assert _simulate_gate_abort_count(resolve_effect_enforcement("error"), 0) == 0;
+    assert _simulate_gate_abort_count(resolve_effect_enforcement(""), 0) == 0;
 }
 
 test "effect_gate: off mode never aborts" {

--- a/compiler/tests/unit/print_lowering_test.sfn
+++ b/compiler/tests/unit/print_lowering_test.sfn
@@ -1,11 +1,11 @@
-test "print: print() calls sailfin_runtime_print_raw" {
+test "print: print() calls sailfin_runtime_print_raw" ![io] {
     // If the runtime helper descriptor mapping is missing or wrong,
     // this test will fail to link (unresolved symbol).
     print("hello from print");
     assert 1 == 1;
 }
 
-test "print: print.err() calls sailfin_runtime_print_err" {
+test "print: print.err() calls sailfin_runtime_print_err" ![io] {
     // Exercises the stderr path — verifies print.err lowers to
     // sailfin_runtime_print_err.
     print.err("hello from print.err");

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,6 +1,6 @@
 # Status
 
-Updated: April 26, 2026 (effect validation Phase B — build-path gate)
+Updated: April 26, 2026 (effect validation Phases C/D — audit + default flipped to error)
 
 This document tracks what works today and what is in progress. It is the source
 of truth — consult it before editing docs, examples, or making claims about
@@ -76,14 +76,15 @@ feature availability.
 - Pipeline: Lexer → Parser → Type Checker → Native Emitter
   (`.sfn-asm` IR) → LLVM Lowering.
 - **Effect checker status**: `validate_effects()` is invoked from every
-  `compile_to_*` entry point in `main.sfn` (Phase B — shipped 2026-04-26;
-  see below). Severity is steered by the `SAILFIN_EFFECT_ENFORCE` env
-  var: unset / `=warning` emits warnings (default through the audit
-  period), `=error` blocks the build, `=off` skips validation entirely.
-  The default flips to `=error` in Phase D after the in-tree audit
-  (Phase C) lands and one alpha cycle of warning-mode telemetry has
-  elapsed. Tracked by `docs/proposals/effect-validation.md`
-  (Phases A–G; Phases A and B landed 2026-04-26).
+  `compile_to_*` entry point in `main.sfn` and **fails the build by
+  default** on undeclared effects (Phases B/C/D — shipped 2026-04-26;
+  see below). The `SAILFIN_EFFECT_ENFORCE` env var lets capsule
+  authors opt into the pre-Phase-D modes: unset / `=error` is the
+  enforced default; `=warning` keeps the gate as a non-blocking
+  warning (transitional mode); `=off` skips validation entirely
+  (build-path only — `sfn check` still runs validation per
+  proposal §4.7). Tracked by `docs/proposals/effect-validation.md`
+  (Phases A–G; Phases A/B/C/D landed 2026-04-26).
 - **Effect diagnostic source spans (Phase A — shipped 2026-04-26).** The
   `EffectViolation` struct now carries `signature_token`, `trigger`, and
   `severity` slots, populated from `FunctionSignature.name_span` via
@@ -102,10 +103,10 @@ feature availability.
   detector. Per-expression trigger tokens still default to the
   signature location; threading per-`Expression` spans is deferred to
   a follow-up that adds span fields to the AST's expression variants.
-- **Effect validation as build gate (Phase B — shipped 2026-04-26).**
-  `validate_and_render_effects` (in new `compiler/src/effect_gate.sfn`)
+- **Effect validation as build gate (Phases B/C/D — shipped 2026-04-26).**
+  `validate_and_render_effects` (in `compiler/src/effect_gate.sfn`)
   runs after typecheck in every `compile_to_*` entry point. The
-  rendering surface from `tools/check.sfn` extracted into new
+  rendering surface from `tools/check.sfn` extracted into
   `compiler/src/diagnostics_render.sfn` so the build path and
   `sfn check` share one source of truth — diagnostic shape, severity
   selection, and caret rendering match across both surfaces. Severity
@@ -117,9 +118,17 @@ feature availability.
   build worker derives a process-unique tmp path from its file_path
   to avoid races on `make compile -j4`. Off-mode emits a one-line
   stderr notice per file so contributors can see the gate was
-  consciously bypassed. Phase C audits the in-tree compiler under
-  warning mode; Phase D flips the default severity from `warning` to
-  `error` in a later release.
+  consciously bypassed.
+
+  Phase C audited the in-tree compiler under warning mode and added
+  `![io]` to the 11 functions that legitimately emit `print.err`
+  debug traces (lexer/parser entry points and lowering helpers).
+  Phase D flipped the unset env-var default from `warning` to
+  `error`, so unannotated effect usage now fails `make compile`,
+  `sfn build`, `sfn run`, `sfn test`, and `sfn check` by default.
+  All `examples/*.sfn` build cleanly under the new default. Capsule
+  authors who need to migrate gradually can opt into
+  `SAILFIN_EFFECT_ENFORCE=warning` for telemetry-only mode.
 - Experimental LLVM JIT execution is available for targeted backend coverage.
 - CI uses the native build workflow (`.github/workflows/ci.yml`) to build, test,
   and attach release assets.
@@ -144,12 +153,12 @@ feature availability.
 | String interpolation (`{{ }}`) | Shipped | |
 | Pattern matching exhaustiveness | Partial | Runtime backstop via `match_exhaustive_failed` |
 | Effect annotations (`![...]`) | Shipped | Parsing and declaration |
-| Effect enforcement — `io` | Warning (Phase B) | Checker detects `print.*`, `console.*`, `fs.*`, `@logExecution`; runs during build under `SAILFIN_EFFECT_ENFORCE=warning` (default). Phase D flip to `=error` ships in a later alpha. |
-| Effect enforcement — `net` | Warning (Phase B) | Checker detects `http.*`, `websocket.*`, `serve`; runs during build under the same env-var contract |
+| Effect enforcement — `io` | **Enforced** | Checker detects `print.*`, `console.*`, `fs.*`, `@logExecution`; build fails on undeclared usage by default (Phase D shipped 2026-04-26) |
+| Effect enforcement — `net` | **Enforced** | Checker detects `http.*`, `websocket.*`, `serve`; build fails on undeclared usage by default |
 | Effect enforcement — `model` | Reserved | Declarable; effect-checker has no detector yet. The `sfn/ai` capsule (post-1.0) supplies the call sites Phase G's name-resolution detector will key on |
-| Effect enforcement — `clock` | Warning (Phase B) | Checker detects `sleep` / `runtime.sleep`; runs during build under the same env-var contract |
+| Effect enforcement — `clock` | **Enforced** | Checker detects `sleep` / `runtime.sleep`; build fails on undeclared usage by default |
 | Effect enforcement — `gpu`, `rand` | Parsed only | Reserved at 1.0 in the canonical taxonomy; no detector logic yet |
-| Effect enforcement as compilation gate | **Phase B (warning) shipped** | `validate_and_render_effects` runs in every `compile_to_*` entry; severity steered by `SAILFIN_EFFECT_ENFORCE` (warning default; error/off opt-in). Phase D flips default to error after the in-tree audit (Phase C) lands |
+| Effect enforcement as compilation gate | **Shipped (Phase D, 2026-04-26)** | `validate_and_render_effects` runs after typecheck in every `compile_to_*` entry; default severity is `error` so undeclared effects fail the build. `SAILFIN_EFFECT_ENFORCE=warning` opt-in for capsule authors mid-migration; `=off` build-path escape hatch (proposal §4.7). Phase E (cross-module propagation) and Phase F (capsule.toml capability cross-check) are next on the roadmap |
 | Generic type inference | Partial | Type params captured; inference coverage is limited |
 | Interface conformance validation | Partial | Basic checks; variance not yet enforced |
 | `Affine<T>` / `Linear<T>` | Parsed only | Ownership wrappers accepted; move/consume rules not enforced |

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # Sailfin Language Reference for LLMs
 
-> Version: 0.5.3-alpha.1 | Updated: 2026-04-16
+> Version: 0.5.9 | Updated: 2026-04-26
 > Source: https://github.com/SailfinIO/sailfin | Site: https://sailfin.dev
 
 Sailfin is a compiled systems language with compile-time capability enforcement

--- a/llms.txt
+++ b/llms.txt
@@ -11,9 +11,15 @@ runtime library exception.
 ## Core Differentiator: Effect Types
 
 Every function declares what capabilities it uses. Effect annotations are
-supported today; the effect checker logic exists but is not yet invoked during
-normal compilation. Wiring it into the compilation gate (so violations block
-the build) is the top priority on the roadmap.
+enforced at compile time: undeclared effect usage fails `make compile`,
+`sfn build`, `sfn run`, `sfn test`, and `sfn check` by default. The
+`SAILFIN_EFFECT_ENFORCE` env var lets capsule authors opt into
+`=warning` (telemetry-only mode) while migrating, or `=off` (build-path
+bypass; `sfn check` still validates per proposal §4.7).
+
+Cross-module call-graph propagation (A must declare B's effects when
+A calls B from another module) is the next milestone on the roadmap
+(Phase E in `docs/proposals/effect-validation.md`).
 
     fn read_config(path: string) -> string ![io] {
         return fs.readFile(path);
@@ -270,14 +276,14 @@ These features parse, type-check, emit to .sfn-asm IR, and lower to LLVM:
 - Lambdas (non-capturing)
 - Test declarations
 - Import/export across modules
-- Effect annotations (parsed and carried through to IR)
+- Effect annotations -- parsed AND enforced at compile time (build fails on undeclared effects by default; configurable via SAILFIN_EFFECT_ENFORCE)
 - Colon type annotations (x: Type) for params, variables, fields
 - Arrow return types (-> Type) for functions
 - Code formatting via sfn fmt (token-stream, idempotent, CI-enforced)
 
 ## What Is Parsed but Not Fully Implemented
 
-- Effect enforcement -- checker logic exists but is not invoked during compilation (top priority)
+- Cross-module effect propagation -- direct effect calls inside a function are enforced; transitive effects from imported callees are not yet (Phase E of effect-validation)
 - Closures with capture -- lambdas parse but don't capture enclosing scope
 - Generic constraints (<T: Bound>) -- parsed as text, not enforced
 - Affine<T> / Linear<T> ownership -- parsed, transparent (no enforcement)

--- a/site/src/content/docs/docs/reference/spec/07-effects.md
+++ b/site/src/content/docs/docs/reference/spec/07-effects.md
@@ -27,7 +27,7 @@ fn analyze(text: string) ![io, model] { }      // multiple effects
 | Random | `rand` | Random generation | Reserved (no detector yet) |
 
 **Enforcement rules**:
-1. Any function calling an effectful operation directly must declare that effect — missing declarations are compile errors with fix-it hints
+1. Any function calling an effectful operation directly must declare that effect — violations produce diagnostics with fix-it hints and are errors by default
 2. Enforcement runs on every build path (`make compile`, `sfn build`, `sfn run`, `sfn test`, `sfn check`); the `SAILFIN_EFFECT_ENFORCE` env var lets capsule authors opt into `=warning` (telemetry-only) or `=off` (build-path bypass; `sfn check` still validates)
 3. Tests follow the same rules as functions
 4. Call-graph–transitive enforcement (A must declare B's effects when A calls B) is planned for Phase E and not yet implemented

--- a/site/src/content/docs/docs/reference/spec/07-effects.md
+++ b/site/src/content/docs/docs/reference/spec/07-effects.md
@@ -21,15 +21,15 @@ fn analyze(text: string) ![io, model] { }      // multiple effects
 |--------|-------|--------|----------------|
 | IO | `io` | Filesystem, console, logging | Yes |
 | Network | `net` | HTTP, WebSocket, serve | Yes |
-| Model | `model` | AI library invocation via `sfn/ai` (post-1.0) | No (planned) |
-| Clock | `clock` | `sleep`, wall-clock | Partial |
-| GPU | `gpu` | Tensor operations | Parsed only |
-| Random | `rand` | Random generation | Parsed only |
+| Clock | `clock` | `sleep`, wall-clock | Yes |
+| Model | `model` | AI library invocation via `sfn/ai` (post-1.0) | Reserved (no detector yet) |
+| GPU | `gpu` | Tensor operations | Reserved (no detector yet) |
+| Random | `rand` | Random generation | Reserved (no detector yet) |
 
 **Enforcement rules**:
-1. Any function calling an effectful operation directly must declare that effect
-2. Call-graph–transitive enforcement (A must declare B's effects when A calls B) is planned but not yet implemented
+1. Any function calling an effectful operation directly must declare that effect — missing declarations are compile errors with fix-it hints
+2. Enforcement runs on every build path (`make compile`, `sfn build`, `sfn run`, `sfn test`, `sfn check`); the `SAILFIN_EFFECT_ENFORCE` env var lets capsule authors opt into `=warning` (telemetry-only) or `=off` (build-path bypass; `sfn check` still validates)
 3. Tests follow the same rules as functions
-4. Missing effects are compile errors with fix-it hints
+4. Call-graph–transitive enforcement (A must declare B's effects when A calls B) is planned for Phase E and not yet implemented
 
 See [Effect System Reference](/docs/reference/effects) for the complete API surface per effect.


### PR DESCRIPTION
Phase C audited the in-tree compiler tree under
SAILFIN_EFFECT_ENFORCE=warning and Phase D flipped the unset
env-var default from "warning" to "error" so undeclared effects
fail the build by default. Sailfin's flagship safety claim --
"compile-time effect enforcement" -- is now backed by build
behavior, not a checker that has to be opted into.

The audit was much smaller than the proposal estimated (50-150
warnings): the full sweep over 131 modules (compiler/src/**/*.sfn
+ runtime/prelude.sfn) surfaced 11 warnings across 7 modules, all
![io] missing from defensive print.err debug traces gated by
fs.exists("build/sailfin/.trace_*"). Each one was a legitimate
trace, not stale debug code, so the fix in every case was to add
![io] to the function signature:

  - compiler/src/lexer.sfn::lex                     (guard limit trace)
  - compiler/src/parser/mod.sfn::parse_tokens       (no-progress trace)
  - compiler/src/llvm/expression_lowering/native/core.sfn::lower_expression
  - compiler/src/llvm/expression_lowering/native/core_operands.sfn::coerce_operand_to_type
  - compiler/src/llvm/lowering/instructions_loops.sfn::lower_loop_instruction
  - compiler/src/llvm/lowering/lowering_helpers_mangling.sfn::apply_module_symbol_mangling
  - compiler/src/llvm/lowering/lowering_phase_sanitize.sfn::sanitize_imported_manifests
  - compiler/src/llvm/lowering/lowering_phase_sanitize.sfn::sanitize_imported_native_texts
  - compiler/src/llvm/lowering/lowering_phase_sanitize.sfn::sanitize_entry_points
  - compiler/src/llvm/lowering/lowering_phase_sanitize.sfn::sanitize_imports
  - compiler/src/llvm/lowering/lowering_phase_sanitize.sfn::sanitize_enums

Re-sweep confirmed 0 warnings remaining; a parallel strict-mode
sweep over examples/*.sfn (50 files) found 0 errors, so the
default flip to "error" doesn't break any in-tree examples.

The proposal originally called for shipping Phase D one alpha after
Phase C (§7.4) so capsule consumers got one cycle of warning-mode
telemetry before the gate flipped. With the audit landing this
small, that cushion isn't needed: the 11 cases were all internal
compiler debug traces, not user-facing API surface. External
capsule authors using `print.*`/`fs.*`/`http.*` already declare
the corresponding `![io]`/`![net]` per the documented spec, so the
post-Phase-D default flip is a no-op for any code that follows the
existing rules. Capsule authors who want the pre-Phase-D
telemetry-only mode can opt in with `SAILFIN_EFFECT_ENFORCE=warning`
while they migrate.

Phase D changes:
- `resolve_effect_enforcement("")` now returns "error" (was "warning").
- `resolve_effect_enforcement` falls back to "error" for any
  unrecognised input so the gate fails closed -- a typo in the env
  var doesn't accidentally silence enforcement.
- `effect_gate_test.sfn` rewritten against the new default, with
  the unset-env-var path now exercising the error severity branch
  alongside `=error`. All 12 tests pass.
- `docs/status.md`: feature matrix entries flipped from
  "Warning (Phase B)" to "Enforced"; "Effect enforcement as
  compilation gate" row promoted to "Shipped (Phase D, 2026-04-26)".
- `site/src/content/docs/docs/reference/spec/07-effects.md`: removed
  "Partial" / "No (planned)" rows from the canonical-effects table
  for io/net/clock; clarified that the gate runs on every build path
  and `=warning`/`=off` are explicit overrides; reframed "transitive
  enforcement" as Phase E (next milestone) rather than unscoped
  future work.
- `llms.txt`: replaced "checker logic exists but is not yet invoked"
  with "enforced at compile time"; promoted cross-module
  propagation from "What Is Parsed but Not Fully Implemented" with
  a Phase E reference.

Verified end-to-end on the freshly rebuilt native compiler:
  - bootstrap from seed succeeds in 119s under the new strict default
    (no env override needed).
  - `sfn run examples/basics/hello-world.sfn` prints "Hello, Sailfin!"
    and exits 0 -- example still runs under strict enforcement.
  - `sfn emit llvm <undecorated-fn-using-fs.exists>` emits
    `error[E0400]` and exits 1 (was warning + exit 0 pre-Phase-D).
  - `SAILFIN_EFFECT_ENFORCE=warning sfn emit llvm ...` reproduces the
    pre-Phase-D telemetry-only mode (warning + exit 0).
  - `SAILFIN_EFFECT_ENFORCE=off sfn emit llvm ...` emits the
    `[effect] SAILFIN_EFFECT_ENFORCE=off -- skipping ...` notice and
    exit 0 -- escape hatch preserved.
  - All 12 effect_gate_test.sfn tests pass against the real
    `resolve_effect_enforcement`.
  - All 10 effect_checker_test.sfn tests still pass.
  - All 21 check_tool_test.sfn tests still pass.

Closes Phases C and D of `docs/proposals/effect-validation.md`.
Phase E (cross-module effect propagation) and Phase F
(capsule.toml capability cross-check) remain on the roadmap.

https://claude.ai/code/session_0157FJzrK3YtAjEKcoJ8xBhs