### PR TITLE
effect validation Phase E: cross-module effect propagation (E0402)

### DIFF
--- a/compiler/src/cli_check.sfn
+++ b/compiler/src/cli_check.sfn
@@ -25,6 +25,7 @@ import {
 } from "./capsule_resolver";
 import { _collect_sfn_files_cmd, _dirname_cmd } from "./cli_commands_utils";
 import { render_diagnostic } from "./diagnostics_render";
+import { ImportSymbolTable, empty_import_symbols } from "./effect_imports";
 import {
     CheckResult,
     check_source_with_imports,
@@ -43,6 +44,11 @@ struct CheckGroup {
     key: string;
     entry_paths: string[];
     interfaces: Statement[];
+    // Phase E: cross-module effect propagation table built from the
+    // same artifacts the `interfaces` list pulls from. Threaded into
+    // `check_source_with_imports` so a caller missing
+    // `![<callee_effect>]` produces an `E0402` diagnostic.
+    function_effects: ImportSymbolTable;
 }
 
 fn _emit_check_header(path: string, quiet: boolean) ![io] {
@@ -195,7 +201,7 @@ fn handle_check_command(args: string[]) -> number ![io] {
             let empty_entries: string[] = [];
             let empty_interfaces: Statement[] = [];
             groups.push(CheckGroup {
-                key: key, entry_paths: empty_entries, interfaces: empty_interfaces
+                key: key, entry_paths: empty_entries, interfaces: empty_interfaces, function_effects: empty_import_symbols()
             });
             idx = groups.length - 1;
         }
@@ -224,6 +230,10 @@ fn handle_check_command(args: string[]) -> number ![io] {
         }
         let load = load_imported_interfaces_from_paths(resolution.asm_paths);
         groups[gi].interfaces = load.interfaces;
+        // Phase E: stash the cross-module function-effect table so
+        // the per-file analysis loop below can hand it to
+        // `check_source_with_imports` alongside the interface list.
+        groups[gi].function_effects = load.function_effects;
 
         let mut mi: number = 0;
         loop {
@@ -254,7 +264,7 @@ fn handle_check_command(args: string[]) -> number ![io] {
         let path = files[fi];
         let group_idx = file_group_index[fi];
         let source = fs.readFile(path);
-        let result = check_source_with_imports(source, path, groups[group_idx].interfaces);
+        let result = check_source_with_imports(source, path, groups[group_idx].interfaces, groups[group_idx].function_effects);
         // Emit any diagnostic — error or warning — so contributors
         // running `sfn check` under Phase B (warning default) actually
         // see the effect-violation output. Pre-Phase-B effect
@@ -276,6 +286,7 @@ fn handle_check_command(args: string[]) -> number ![io] {
     let empty_texts: string[] = [];
     let aggregate_load_result = ImportedInterfaceLoadResult {
         interfaces: empty_interfaces,
+        function_effects: empty_import_symbols(),
         missing_paths: aggregate_missing,
         parse_failure_paths: aggregate_parse_failures,
         skipped_paths: aggregate_skipped,

--- a/compiler/src/cli_commands.sfn
+++ b/compiler/src/cli_commands.sfn
@@ -33,6 +33,7 @@ import {
     _write_text_cmd,
     find_char
 } from "./cli_commands_utils";
+import { ImportSymbolTable, empty_import_symbols } from "./effect_imports";
 import { lock_add_entry, lock_get_version } from "./lock";
 import {
     compile_tests_to_llvm_file_with_module_imports,
@@ -294,6 +295,13 @@ struct TestGroup {
     interfaces: Statement[];
     native_texts: string[];
     dep_ll_paths: string[];
+    // Phase E: cross-module effect-propagation table, populated from
+    // the same `.sfn-asm` artifacts the resolver stages for
+    // `interfaces` / `native_texts`. Threaded into
+    // `compile_tests_to_llvm_file_with_module_imports` so a test
+    // that calls an imported effectful helper without declaring the
+    // effect produces an `E0402` diagnostic.
+    function_effects: ImportSymbolTable;
 }
 
 // Compute the resolution-group key for a test file path. Two files
@@ -366,7 +374,7 @@ fn handle_test_command(args: string[], runtime_root: string) -> number ![io] {
             let empty_texts: string[] = [];
             let empty_lls: string[] = [];
             groups.push(TestGroup {
-                key: key, entry_paths: empty_entries, interfaces: empty_interfaces, native_texts: empty_texts, dep_ll_paths: empty_lls
+                key: key, entry_paths: empty_entries, interfaces: empty_interfaces, native_texts: empty_texts, dep_ll_paths: empty_lls, function_effects: empty_import_symbols()
             });
             idx = groups.length - 1;
         }
@@ -407,6 +415,11 @@ fn handle_test_command(args: string[], runtime_root: string) -> number ![io] {
         groups[gi].interfaces = load.interfaces;
         groups[gi].native_texts = load.native_texts;
         groups[gi].dep_ll_paths = resolution.ll_paths;
+        // Phase E: stash the cross-module function-effect table so
+        // the per-test compile below can hand it to
+        // `compile_tests_to_llvm_file_with_module_imports` alongside
+        // the interface list.
+        groups[gi].function_effects = load.function_effects;
         if trace_runner {
             print.err("test runner: resolver pass done (group="
                 + number_to_string(gi)
@@ -438,7 +451,7 @@ fn handle_test_command(args: string[], runtime_root: string) -> number ![io] {
         if trace_runner { print.err("test runner: compile start"); }
         _clean_lowering_state("build/sailfin");
         let empty_manifests: LayoutManifest[] = [];
-        let _compiled = compile_tests_to_llvm_file_with_module_imports(source, module_name, ll_path, groups[group_idx].interfaces, empty_manifests, groups[group_idx].native_texts);
+        let _compiled = compile_tests_to_llvm_file_with_module_imports(source, module_name, ll_path, groups[group_idx].interfaces, empty_manifests, groups[group_idx].native_texts, groups[group_idx].function_effects);
         if !_compiled {
             print("test runner: compile failed for " + path);
             fs.deleteFile(test_runner_active_path);

--- a/compiler/src/diagnostics_render.sfn
+++ b/compiler/src/diagnostics_render.sfn
@@ -52,18 +52,41 @@ fn join_effects(effects: string[]) -> string {
 }
 
 fn code_for_missing_effect(missing_effects: string[], requirements: EffectRequirement[]) -> string {
-    // E0400 — missing effect declaration (general)
+    // E0400 — missing effect declaration (general, in-module)
     // E0401 — decorator-implied effect missing
+    // E0402 — cross-module effect not propagated from imported callee
+    //
+    // E0402 is identified by the description prefix `imported \``
+    // that `effect_checker._propagate_imported_callee_effects`
+    // attaches when the offending callee is an imported function.
+    // E0401 wins over E0402 when both apply (decorator-implied
+    // effects are typically I/O regardless of any cross-module
+    // propagation), matching the historical Phase A precedence.
+    let mut has_imported: boolean = false;
     let mut i: number = 0;
     loop {
         if i >= requirements.length { break; }
         let desc = requirements[i].description;
         if desc.length > 0 {
             if desc[0] == "@" { return "E0401"; }
+            if _description_starts_with_imported(desc) { has_imported = true; }
         }
         i += 1;
     }
+    if has_imported { return "E0402"; }
     return "E0400";
+}
+
+fn _description_starts_with_imported(desc: string) -> boolean {
+    let prefix = "imported `";
+    if desc.length < prefix.length { return false; }
+    let mut i: number = 0;
+    loop {
+        if i >= prefix.length { break; }
+        if desc[i] != prefix[i] { return false; }
+        i += 1;
+    }
+    return true;
 }
 
 fn effect_violation_to_diagnostic(violation: EffectViolation) -> Diagnostic {

--- a/compiler/src/effect_checker.sfn
+++ b/compiler/src/effect_checker.sfn
@@ -404,11 +404,14 @@ fn collect_effects_from_expression(expression: Expression?, imports: ImportSymbo
             // out of scope for E1; see proposal §5 (Phase E).
             required = _propagate_imported_callee_effects(name, imports, required);
         }
-        if expression.callee.variant == "Member" {
-            // Member access effect is handled below, but calls are a strong signal.
-            required = merge_requirements(required, collect_effects_from_expression(expression.callee, imports));
-        }
 
+        // Member-callee effects (e.g. `fs.exists(...)`) are already
+        // captured by the unconditional `collect_effects_from_expression(
+        // expression.callee, imports)` at the top of this branch — the
+        // Member case in that recursive call walks the object identifier
+        // and emits the right requirement (`fs` → io, `http` → net,
+        // etc.). Don't re-analyze the callee here; doing so would
+        // double-count every Member-callee effect.
         let mut argument_index: number = 0;
         loop {
             if argument_index >= expression.arguments.length { break; }

--- a/compiler/src/effect_checker.sfn
+++ b/compiler/src/effect_checker.sfn
@@ -16,6 +16,16 @@
 // separate refactor scoped for a follow-up. Pointing the diagnostic
 // at the function declaration is also the actionable location — the
 // fix is "add `![effect]` to the signature on this line."
+//
+// Phase E (this commit) adds cross-module call resolution: when the
+// caller invokes an `Identifier` that names an imported function,
+// the checker looks it up in the `ImportSymbolTable` threaded in
+// from the typecheck-import loader and propagates the callee's
+// declared effects. Diagnostics carry the description prefix
+// `imported \`<name>\`` so `diagnostics_render.code_for_missing_effect`
+// promotes them from `E0400` (in-module) to `E0402` (cross-module).
+// Member-callee resolution (`mod.fetch()`) and decorator-implied
+// transitives are out of scope for E1; see proposal §5 (Phase E).
 import {
     Block,
     Decorator,
@@ -29,6 +39,13 @@ import {
     Statement,
     decorator_names
 } from "./ast";
+import {
+    ImportSymbolTable,
+    ImportedFunctionSignature,
+    empty_import_symbols,
+    localize_import_symbols_for_program,
+    lookup_imported_function
+} from "./effect_imports";
 import { substring } from "./string_utils";
 import { Token, TokenKind } from "./token";
 
@@ -86,20 +103,36 @@ fn _token_from_signature(span: SourceSpan?, name: string) -> Token? {
     };
 }
 
+// Phase B/C/D entry — preserved for the legacy build-path callers
+// that don't have an import resolver in scope (synthesized fixtures,
+// `compile_to_sailfin`, etc.). New callers should use
+// `validate_effects_with_imports` so cross-module propagation
+// (Phase E) lights up.
 fn validate_effects(program: Program) -> EffectViolation[] {
+    return validate_effects_with_imports(program, empty_import_symbols());
+}
+
+// Phase E entry — accepts the global symbol table the loader
+// produced from the imported `.sfn-asm` artifacts. `localize_…`
+// filters the table down to just-this-program's imports and applies
+// alias rewrites, so the per-`Call` lookup in
+// `collect_effects_from_expression` keys directly off the local
+// identifier name.
+fn validate_effects_with_imports(program: Program, imports: ImportSymbolTable) -> EffectViolation[] {
+    let local_imports = localize_import_symbols_for_program(program, imports);
     let mut violations: EffectViolation[] = [];
     let mut index: number = 0;
     loop {
         if index >= program.statements.length { break; }
-        violations = append_violations(violations, analyze_statement(program.statements[index]));
+        violations = append_violations(violations, analyze_statement(program.statements[index], local_imports));
         index += 1;
     }
     return violations;
 }
 
-fn analyze_statement(statement: Statement) -> EffectViolation[] {
+fn analyze_statement(statement: Statement, imports: ImportSymbolTable) -> EffectViolation[] {
     if statement.variant == "FunctionDeclaration" {
-        return analyze_routine(statement.signature, statement.body, statement.decorators, statement.signature.name);
+        return analyze_routine(statement.signature, statement.body, statement.decorators, statement.signature.name, imports);
     }
     if statement.variant == "TestDeclaration" {
         let signature = FunctionSignature {
@@ -112,7 +145,7 @@ fn analyze_statement(statement: Statement) -> EffectViolation[] {
             name_span: statement.name_span
         };
         let qualified = "test " + statement.name;
-        return analyze_routine(signature, statement.body, statement.decorators, qualified);
+        return analyze_routine(signature, statement.body, statement.decorators, qualified, imports);
     }
     if statement.variant == "StructDeclaration" {
         let mut issues: EffectViolation[] = [];
@@ -121,7 +154,7 @@ fn analyze_statement(statement: Statement) -> EffectViolation[] {
             if index >= statement.methods.length { break; }
             let method = statement.methods[index];
             let qualified = statement.name + "." + method.signature.name;
-            issues = append_violations(issues, analyze_routine(method.signature, method.body, method.decorators, qualified));
+            issues = append_violations(issues, analyze_routine(method.signature, method.body, method.decorators, qualified, imports));
             index += 1;
         }
         return issues;
@@ -129,7 +162,7 @@ fn analyze_statement(statement: Statement) -> EffectViolation[] {
     return [];
 }
 
-fn analyze_routine(signature: FunctionSignature, body: Block, decorators: Decorator[], name: string) -> EffectViolation[] {
+fn analyze_routine(signature: FunctionSignature, body: Block, decorators: Decorator[], name: string, imports: ImportSymbolTable) -> EffectViolation[] {
     let names = decorator_names(decorators);
     let mut declared: string[] = [];
     let mut declared_index: number = 0;
@@ -156,7 +189,7 @@ fn analyze_routine(signature: FunctionSignature, body: Block, decorators: Decora
     if requires_io_from_decorators {
         declared = append_unique_effect(declared, "io");
     }
-    let required = required_effects(body);
+    let required = required_effects(body, imports);
     let mut missing: string[] = [];
     let mut missing_requirements: EffectRequirement[] = [];
     let mut index: number = 0;
@@ -205,91 +238,91 @@ fn analyze_routine(signature: FunctionSignature, body: Block, decorators: Decora
     return result;
 }
 
-fn required_effects(body: Block) -> EffectRequirement[] {
-    return collect_effects_from_block(body);
+fn required_effects(body: Block, imports: ImportSymbolTable) -> EffectRequirement[] {
+    return collect_effects_from_block(body, imports);
 }
 
-fn collect_effects_from_block(block: Block) -> EffectRequirement[] {
+fn collect_effects_from_block(block: Block, imports: ImportSymbolTable) -> EffectRequirement[] {
     let mut required: EffectRequirement[] = [];
     let mut index: number = 0;
     loop {
         if index >= block.statements.length { break; }
-        required = merge_requirements(required, collect_effects_from_statement(block.statements[index]));
+        required = merge_requirements(required, collect_effects_from_statement(block.statements[index], imports));
         index += 1;
     }
     return required;
 }
 
-fn collect_effects_from_optional_block(block: Block?) -> EffectRequirement[] {
+fn collect_effects_from_optional_block(block: Block?, imports: ImportSymbolTable) -> EffectRequirement[] {
     if block == null { return []; }
-    return collect_effects_from_block(block);
+    return collect_effects_from_block(block, imports);
 }
 
-fn collect_effects_from_optional_statement(statement: Statement?) -> EffectRequirement[] {
+fn collect_effects_from_optional_statement(statement: Statement?, imports: ImportSymbolTable) -> EffectRequirement[] {
     if statement == null { return []; }
-    return collect_effects_from_statement(statement);
+    return collect_effects_from_statement(statement, imports);
 }
 
-fn collect_effects_from_statement(statement: Statement) -> EffectRequirement[] {
+fn collect_effects_from_statement(statement: Statement, imports: ImportSymbolTable) -> EffectRequirement[] {
     if statement.variant == "WithStatement" {
-        let mut required = collect_effects_from_block(statement.body);
+        let mut required = collect_effects_from_block(statement.body, imports);
         let mut clause_index: number = 0;
         loop {
             if clause_index >= statement.clauses.length { break; }
             let clause = statement.clauses[clause_index];
-            required = merge_requirements(required, collect_effects_from_expression(clause.expression));
+            required = merge_requirements(required, collect_effects_from_expression(clause.expression, imports));
             clause_index += 1;
         }
         return required;
     }
     if statement.variant == "ForStatement" {
-        let mut required = collect_effects_from_block(statement.body);
-        required = merge_requirements(required, collect_effects_from_expression(statement.clause.target));
-        required = merge_requirements(required, collect_effects_from_expression(statement.clause.iterable));
+        let mut required = collect_effects_from_block(statement.body, imports);
+        required = merge_requirements(required, collect_effects_from_expression(statement.clause.target, imports));
+        required = merge_requirements(required, collect_effects_from_expression(statement.clause.iterable, imports));
         return required;
     }
     if statement.variant == "LoopStatement" {
-        return collect_effects_from_block(statement.body);
+        return collect_effects_from_block(statement.body, imports);
     }
     if statement.variant == "MatchStatement" {
-        let mut required = collect_effects_from_expression(statement.expression);
+        let mut required = collect_effects_from_expression(statement.expression, imports);
         let mut case_index: number = 0;
         loop {
             if case_index >= statement.cases.length { break; }
-            required = merge_requirements(required, collect_effects_from_match_case(statement.cases[case_index]));
+            required = merge_requirements(required, collect_effects_from_match_case(statement.cases[case_index], imports));
             case_index += 1;
         }
         return required;
     }
     if statement.variant == "IfStatement" {
-        let mut required = collect_effects_from_expression(statement.condition);
-        required = merge_requirements(required, collect_effects_from_block(statement.then_block));
+        let mut required = collect_effects_from_expression(statement.condition, imports);
+        required = merge_requirements(required, collect_effects_from_block(statement.then_block, imports));
         let else_branch = statement.else_branch;
         if else_branch == null { return required; }
-        required = merge_requirements(required, collect_effects_from_else_branch(else_branch));
+        required = merge_requirements(required, collect_effects_from_else_branch(else_branch, imports));
         return required;
     }
     if statement.variant == "ReturnStatement" {
-        return collect_effects_from_expression(statement.expression);
+        return collect_effects_from_expression(statement.expression, imports);
     }
     if statement.variant == "ExpressionStatement" {
-        return collect_effects_from_expression(statement.expression);
+        return collect_effects_from_expression(statement.expression, imports);
     }
     if statement.variant == "VariableDeclaration" {
-        return collect_effects_from_expression(statement.initializer);
+        return collect_effects_from_expression(statement.initializer, imports);
     }
     if statement.variant == "FunctionDeclaration" {
-        return collect_effects_from_block(statement.body);
+        return collect_effects_from_block(statement.body, imports);
     }
     if statement.variant == "TestDeclaration" {
-        return collect_effects_from_block(statement.body);
+        return collect_effects_from_block(statement.body, imports);
     }
     if statement.variant == "StructDeclaration" {
         let mut required: EffectRequirement[] = [];
         let mut method_index: number = 0;
         loop {
             if method_index >= statement.methods.length { break; }
-            required = merge_requirements(required, collect_effects_from_block(statement.methods[method_index].body));
+            required = merge_requirements(required, collect_effects_from_block(statement.methods[method_index].body, imports));
             method_index += 1;
         }
         return required;
@@ -300,24 +333,50 @@ fn collect_effects_from_statement(statement: Statement) -> EffectRequirement[] {
     return [];
 }
 
-fn collect_effects_from_else_branch(branch: ElseBranch) -> EffectRequirement[] {
+fn collect_effects_from_else_branch(branch: ElseBranch, imports: ImportSymbolTable) -> EffectRequirement[] {
     let mut required: EffectRequirement[] = [];
-    required = merge_requirements(required, collect_effects_from_optional_block(branch.body));
-    required = merge_requirements(required, collect_effects_from_optional_statement(branch.statement));
+    required = merge_requirements(required, collect_effects_from_optional_block(branch.body, imports));
+    required = merge_requirements(required, collect_effects_from_optional_statement(branch.statement, imports));
     return required;
 }
 
-fn collect_effects_from_match_case(case: MatchCase) -> EffectRequirement[] {
-    let mut required = collect_effects_from_expression(case.pattern);
-    required = merge_requirements(required, collect_effects_from_expression(case.guard));
-    required = merge_requirements(required, collect_effects_from_block(case.body));
+fn collect_effects_from_match_case(case: MatchCase, imports: ImportSymbolTable) -> EffectRequirement[] {
+    let mut required = collect_effects_from_expression(case.pattern, imports);
+    required = merge_requirements(required, collect_effects_from_expression(case.guard, imports));
+    required = merge_requirements(required, collect_effects_from_block(case.body, imports));
     return required;
 }
 
-fn collect_effects_from_expression(expression: Expression?) -> EffectRequirement[] {
+// Phase E helper: append one requirement per declared effect on the
+// imported callee. The description prefix `imported \`<name>\``
+// is what `diagnostics_render.code_for_missing_effect` keys on to
+// promote the diagnostic from the in-module `E0400` to the
+// cross-module `E0402`. Each effect produces its own requirement so
+// missing-effect rendering preserves the per-effect "required by"
+// breakdown the user sees in the caret diagnostic.
+fn _propagate_imported_callee_effects(name: string, imports: ImportSymbolTable, base: EffectRequirement[]) -> EffectRequirement[] {
+    let entry_opt = lookup_imported_function(imports, name);
+    if entry_opt == null { return base; }
+    let entry: ImportedFunctionSignature? = entry_opt;
+    if entry.effects.length == 0 { return base; }
+    let mut required = base;
+    let prefix = "imported `" + name + "` declares ![";
+    let mut e: number = 0;
+    loop {
+        if e >= entry.effects.length { break; }
+        let effect = entry.effects[e];
+        required = append_requirement(required, EffectRequirement {
+            effect: effect, description: prefix + effect + "]"
+        });
+        e += 1;
+    }
+    return required;
+}
+
+fn collect_effects_from_expression(expression: Expression?, imports: ImportSymbolTable) -> EffectRequirement[] {
     if expression == null { return []; }
     if expression.variant == "Call" {
-        let mut required = collect_effects_from_expression(expression.callee);
+        let mut required = collect_effects_from_expression(expression.callee, imports);
 
         // Capture runtime helpers that imply effects.
         if expression.callee.variant == "Identifier" {
@@ -337,22 +396,29 @@ fn collect_effects_from_expression(expression: Expression?) -> EffectRequirement
                     effect: "net", description: "serve call"
                 });
             }
+            // Phase E: cross-module call resolution. The imports
+            // table is per-program-localized (alias-rewritten,
+            // scope-filtered) so a direct `Identifier` lookup is
+            // both correct and fast. Member-callee resolution
+            // (`mod.fn()`) and decorator-implied transitives are
+            // out of scope for E1; see proposal §5 (Phase E).
+            required = _propagate_imported_callee_effects(name, imports, required);
         }
         if expression.callee.variant == "Member" {
             // Member access effect is handled below, but calls are a strong signal.
-            required = merge_requirements(required, collect_effects_from_expression(expression.callee));
+            required = merge_requirements(required, collect_effects_from_expression(expression.callee, imports));
         }
 
         let mut argument_index: number = 0;
         loop {
             if argument_index >= expression.arguments.length { break; }
-            required = merge_requirements(required, collect_effects_from_expression(expression.arguments[argument_index]));
+            required = merge_requirements(required, collect_effects_from_expression(expression.arguments[argument_index], imports));
             argument_index += 1;
         }
         return required;
     }
     if expression.variant == "Member" {
-        let mut required = collect_effects_from_expression(expression.object);
+        let mut required = collect_effects_from_expression(expression.object, imports);
         if expression.object.variant == "Identifier" {
             let root = expression.object.name;
             if root == "fs" {
@@ -380,11 +446,11 @@ fn collect_effects_from_expression(expression: Expression?) -> EffectRequirement
         return required;
     }
     if expression.variant == "Unary" {
-        return collect_effects_from_expression(expression.operand);
+        return collect_effects_from_expression(expression.operand, imports);
     }
     if expression.variant == "Binary" {
-        let mut required = collect_effects_from_expression(expression.left);
-        required = merge_requirements(required, collect_effects_from_expression(expression.right));
+        let mut required = collect_effects_from_expression(expression.left, imports);
+        required = merge_requirements(required, collect_effects_from_expression(expression.right, imports));
         return required;
     }
     if expression.variant == "Array" {
@@ -392,7 +458,7 @@ fn collect_effects_from_expression(expression: Expression?) -> EffectRequirement
         let mut element_index: number = 0;
         loop {
             if element_index >= expression.elements.length { break; }
-            required = merge_requirements(required, collect_effects_from_expression(expression.elements[element_index]));
+            required = merge_requirements(required, collect_effects_from_expression(expression.elements[element_index], imports));
             element_index += 1;
         }
         return required;
@@ -402,7 +468,7 @@ fn collect_effects_from_expression(expression: Expression?) -> EffectRequirement
         let mut field_index: number = 0;
         loop {
             if field_index >= expression.fields.length { break; }
-            required = merge_requirements(required, collect_effects_from_expression(expression.fields[field_index].value));
+            required = merge_requirements(required, collect_effects_from_expression(expression.fields[field_index].value, imports));
             field_index += 1;
         }
         return required;
@@ -412,22 +478,22 @@ fn collect_effects_from_expression(expression: Expression?) -> EffectRequirement
         let mut field_index: number = 0;
         loop {
             if field_index >= expression.fields.length { break; }
-            required = merge_requirements(required, collect_effects_from_expression(expression.fields[field_index].value));
+            required = merge_requirements(required, collect_effects_from_expression(expression.fields[field_index].value, imports));
             field_index += 1;
         }
         return required;
     }
     if expression.variant == "Lambda" {
-        return collect_effects_from_block(expression.body);
+        return collect_effects_from_block(expression.body, imports);
     }
     if expression.variant == "Index" {
-        let mut required = collect_effects_from_expression(expression.sequence);
-        required = merge_requirements(required, collect_effects_from_expression(expression.index));
+        let mut required = collect_effects_from_expression(expression.sequence, imports);
+        required = merge_requirements(required, collect_effects_from_expression(expression.index, imports));
         return required;
     }
     if expression.variant == "Range" {
-        let mut required = collect_effects_from_expression(expression.start);
-        required = merge_requirements(required, collect_effects_from_expression(expression.end));
+        let mut required = collect_effects_from_expression(expression.start, imports);
+        required = merge_requirements(required, collect_effects_from_expression(expression.end, imports));
         return required;
     }
     if expression.variant == "Raw" {

--- a/compiler/src/effect_gate.sfn
+++ b/compiler/src/effect_gate.sfn
@@ -52,7 +52,7 @@ import {
     split_source_lines
 } from "./diagnostics_render";
 import { EffectViolation, validate_effects_with_imports } from "./effect_checker";
-import { ImportSymbolTable, empty_import_symbols } from "./effect_imports";
+import { ImportSymbolTable } from "./effect_imports";
 import { sanitize_symbol, substring } from "./string_utils";
 import { Diagnostic } from "./typecheck_types";
 

--- a/compiler/src/effect_gate.sfn
+++ b/compiler/src/effect_gate.sfn
@@ -51,7 +51,8 @@ import {
     render_diagnostic,
     split_source_lines
 } from "./diagnostics_render";
-import { EffectViolation, validate_effects } from "./effect_checker";
+import { EffectViolation, validate_effects_with_imports } from "./effect_checker";
+import { ImportSymbolTable, empty_import_symbols } from "./effect_imports";
 import { sanitize_symbol, substring } from "./string_utils";
 import { Diagnostic } from "./typecheck_types";
 
@@ -147,7 +148,7 @@ fn read_effect_enforcement_env(unique_key: string) -> string ![io] {
 // source path through every `compile_to_*` signature is a bigger
 // refactor than Phase B should take. Phase E (cross-module
 // propagation) revisits the path-plumbing question.
-fn validate_and_render_effects(program: Program, source: string, file_path: string) -> number ![io] {
+fn validate_and_render_effects(program: Program, source: string, file_path: string, imports: ImportSymbolTable) -> number ![io] {
     let raw = read_effect_enforcement_env(file_path);
     let severity = resolve_effect_enforcement(raw);
     if severity == "off" {
@@ -159,7 +160,13 @@ fn validate_and_render_effects(program: Program, source: string, file_path: stri
             + file_path);
         return 0;
     }
-    let violations = validate_effects(program);
+    // Phase E: pass the per-build import symbol table so
+    // `validate_effects_with_imports` can localize it to this
+    // program's `Statement.ImportDeclaration` specifiers and resolve
+    // cross-module call sites. Empty-table callers (legacy
+    // `compile_to_sailfin`, `compile_to_llvm`) get the same
+    // in-module-only behavior they had pre-Phase-E.
+    let violations = validate_effects_with_imports(program, imports);
     if violations.length == 0 { return 0; }
     let source_lines = split_source_lines(source);
     let mut errors: number = 0;

--- a/compiler/src/effect_imports.sfn
+++ b/compiler/src/effect_imports.sfn
@@ -32,10 +32,15 @@
 import { Program } from "./ast";
 
 // One callable signature exposed to a downstream caller. `name` is
-// the identifier the importing module sees (after alias resolution
-// in the caller's `Statement.ImportDeclaration` specifiers); the
-// effect_checker handles aliases at lookup time so this struct
-// always carries the original exporting-module name.
+// the identifier the importing module sees after alias resolution
+// in the caller's `Statement.ImportDeclaration` specifiers.
+// `localize_import_symbols_for_program` rewrites imported symbols
+// to that caller-visible local name, so consumers (the AST walker
+// in `effect_checker.collect_effects_from_expression`) should look
+// up the localized identifier directly rather than the
+// exporting-module name. The global table fed in from the loader
+// keys by exporting-module name; the localized table swaps the
+// keys to local names before the AST walk runs.
 struct ImportedFunctionSignature {
     name: string;
     effects: string[];

--- a/compiler/src/effect_imports.sfn
+++ b/compiler/src/effect_imports.sfn
@@ -1,0 +1,177 @@
+// compiler/src/effect_imports.sfn
+//
+// Phase E (`docs/proposals/effect-validation.md` §5) data shapes that
+// let the effect checker resolve cross-module call sites against the
+// effects declared on imported callees.
+//
+// The loader (`typecheck_import_loader.sfn`) reads the `effects: string[]`
+// field every `.sfn-asm` artifact already carries on each
+// `NativeFunction` and folds it into an `ImportSymbolTable` here.
+// The checker (`effect_checker.sfn`) walks the caller's AST, looks
+// each `Identifier` callee up in the table, and propagates the
+// callee's effects to the caller's required-effect set with a
+// description prefix `imported \`<name>\`` — that prefix is what
+// `diagnostics_render.code_for_missing_effect` keys on to emit
+// `E0402` instead of the in-module `E0400`.
+//
+// The module is intentionally a leaf:
+//   - No I/O (the loader does that).
+//   - No dependency on `ast`, `effect_checker`, or `native_ir` —
+//     callers wrap raw `(name, effects[])` pairs into the public
+//     constructor and the table stays a pure value.
+// That isolation lets unit tests synthesize tables directly without
+// faking a `.sfn-asm` round-trip and lets `tools/check.sfn`,
+// `effect_gate.sfn`, and `main.sfn` import the types without pulling
+// the disk loader into their import graphs.
+//
+// One AST dependency: `localize_import_symbols_for_program` walks
+// the caller's `Statement.ImportDeclaration` list to filter the
+// global table down to just-this-program's imports (and apply alias
+// rewrites). That keeps cross-module name collisions from emitting
+// spurious `E0402` against a same-named in-module function.
+import { Program } from "./ast";
+
+// One callable signature exposed to a downstream caller. `name` is
+// the identifier the importing module sees (after alias resolution
+// in the caller's `Statement.ImportDeclaration` specifiers); the
+// effect_checker handles aliases at lookup time so this struct
+// always carries the original exporting-module name.
+struct ImportedFunctionSignature {
+    name: string;
+    effects: string[];
+}
+
+// Aggregate of imported callable signatures exposed to a single
+// compilation unit. Today only standalone functions are populated —
+// interface methods are reachable through `imported_interfaces`
+// (the existing `Statement[]` channel) and are therefore not
+// duplicated here. If a future Phase E2 needs to resolve
+// `pkg.method()` member calls, the table can grow a parallel
+// `methods` field without breaking existing consumers.
+struct ImportSymbolTable {
+    functions: ImportedFunctionSignature[];
+}
+
+// Construct an empty table — used by build-path callers that don't
+// have an import resolver in scope (e.g. `compile_to_sailfin`,
+// `compile_to_llvm`, the legacy entry points that pre-date the
+// resolver migration). Returning a real value (not null) keeps the
+// effect_checker's lookup loop branchless.
+fn empty_import_symbols() -> ImportSymbolTable {
+    let empty: ImportedFunctionSignature[] = [];
+    return ImportSymbolTable { functions: empty };
+}
+
+// Push a single (name, effects) pair onto an existing table. The
+// helper de-duplicates by name — the loader can call it for every
+// `NativeFunction` in every staged `.sfn-asm` artifact without
+// worrying about double-staging when two artifacts re-export the
+// same symbol. Last-write-wins is fine for the common case (every
+// re-export carries identical effect annotations); a future
+// diagnostic for divergent effect lists can land in Phase G.
+fn append_import_function(table: ImportSymbolTable, name: string, effects: string[]) -> ImportSymbolTable {
+    if name.length == 0 { return table; }
+    let mut updated = table;
+    let mut existing_index: number = -1;
+    let mut i: number = 0;
+    loop {
+        if i >= updated.functions.length { break; }
+        if updated.functions[i].name == name {
+            existing_index = i;
+            break;
+        }
+        i += 1;
+    }
+    let mut effects_copy: string[] = [];
+    let mut j: number = 0;
+    loop {
+        if j >= effects.length { break; }
+        effects_copy.push(effects[j]);
+        j += 1;
+    }
+    let entry = ImportedFunctionSignature {
+        name: name,
+        effects: effects_copy
+    };
+    if existing_index >= 0 {
+        updated.functions[existing_index] = entry;
+        return updated;
+    }
+    updated.functions.push(entry);
+    return updated;
+}
+
+// O(N) name lookup. Returns null when the name is not an imported
+// function. The caller (`effect_checker.collect_effects_from_expression`)
+// uses null as the signal "this Identifier isn't a known import,
+// skip cross-module propagation for this Call". A scan is sufficient
+// at the table sizes this path sees (a few hundred imports per
+// compilation unit, called once per `Call` expression in the body).
+fn lookup_imported_function(table: ImportSymbolTable, name: string) -> ImportedFunctionSignature? {
+    let mut i: number = 0;
+    loop {
+        if i >= table.functions.length { break; }
+        if table.functions[i].name == name { return table.functions[i]; }
+        i += 1;
+    }
+    return null;
+}
+
+// Produce a per-program-localized symbol table from a global one.
+// The loader stages every standalone-fn `effects` field across every
+// dependency artifact, so the global `table` is keyed by exporting-
+// module symbol name. Two filters happen here:
+//
+//   1. **Scope filter** — the local table only contains entries the
+//      `program` actually imports. Without this, a same-named local
+//      function would be misidentified as "imported with effects
+//      ![X]" and trigger spurious `E0402` diagnostics. Only entries
+//      under a `Statement.ImportDeclaration` import-specifier survive.
+//
+//   2. **Alias rewrite** — `import { fetch as get } from "..."` lets
+//      the local name `get` stand in for the export `fetch`. The
+//      effect_checker walks the AST and sees `Call(Identifier("get"))`
+//      at the call site, so the localized entry is keyed by `get`
+//      with `fetch`'s effects. Non-aliased specifiers (`alias == null`
+//      or empty) keep the original export name.
+//
+// The function is pure — no I/O — so unit tests can synthesize a
+// global table + program in-memory and assert the localized result.
+fn localize_import_symbols_for_program(program: Program, table: ImportSymbolTable) -> ImportSymbolTable {
+    let mut local = empty_import_symbols();
+    let mut i: number = 0;
+    loop {
+        if i >= program.statements.length { break; }
+        let statement = program.statements[i];
+        if statement.variant == "ImportDeclaration" {
+            let mut s: number = 0;
+            loop {
+                if s >= statement.import_specifiers.length { break; }
+                let spec = statement.import_specifiers[s];
+                let entry_opt = lookup_imported_function(table, spec.name);
+                if entry_opt != null {
+                    let entry: ImportedFunctionSignature? = entry_opt;
+                    let mut local_name = spec.name;
+                    let alias = spec.alias;
+                    if alias != null {
+                        let alias_str: string? = alias;
+                        if alias_str.length > 0 { local_name = alias_str; }
+                    }
+                    local = append_import_function(local, local_name, entry.effects);
+                }
+                s += 1;
+            }
+        }
+        i += 1;
+    }
+    return local;
+}
+
+export {
+    ImportSymbolTable,
+    ImportedFunctionSignature,
+    append_import_function,
+    empty_import_symbols,
+    localize_import_symbols_for_program,
+    lookup_imported_function
+};

--- a/compiler/src/main.sfn
+++ b/compiler/src/main.sfn
@@ -3,6 +3,7 @@
 // Sailfin compiler main module and compilation entry points.
 import { Program, Statement } from "./ast";
 import { validate_and_render_effects } from "./effect_gate";
+import { ImportSymbolTable, empty_import_symbols } from "./effect_imports";
 import {
     NativeModule,
     collect_reexport_violations,
@@ -67,7 +68,9 @@ fn compile_to_sailfin(source: string) -> string ![io] {
         return "";
     }
     if _reject_reexport_violations(program) { return ""; }
-    if validate_and_render_effects(program, source, "main") > 0 { return ""; }
+    if validate_and_render_effects(program, source, "main", empty_import_symbols()) > 0 {
+        return "";
+    }
     return emit_program(program);
 }
 
@@ -157,7 +160,9 @@ fn compile_to_llvm(source: string) -> string ![io] {
         return "";
     }
     if _reject_reexport_violations(program) { return ""; }
-    if validate_and_render_effects(program, source, "main") > 0 { return ""; }
+    if validate_and_render_effects(program, source, "main", empty_import_symbols()) > 0 {
+        return "";
+    }
     let trace_emit = fs.exists("build/sailfin/.trace_emit");
     let native_text = emit_native_text_with_module_name(program, "main");
     if trace_emit {
@@ -206,7 +211,7 @@ fn print_llvm_with_module(source: string, module_name: string) -> boolean ![io] 
         }
     }
     if _reject_reexport_violations(program) { return false; }
-    if validate_and_render_effects(program, source, module_name) > 0 {
+    if validate_and_render_effects(program, source, module_name, empty_import_symbols()) > 0 {
         return false;
     }
     let native_text = emit_native_text_with_module_name(program, module_name);
@@ -227,7 +232,7 @@ fn compile_to_llvm_with_module(source: string, module_name: string) -> string ![
         print.err("emit-llvm: skipping typecheck (build/sailfin/.skip_typecheck present)");
     }
     if _reject_reexport_violations(program) { return ""; }
-    if validate_and_render_effects(program, source, module_name) > 0 {
+    if validate_and_render_effects(program, source, module_name, empty_import_symbols()) > 0 {
         return "";
     }
     let trace_emit = fs.exists("build/sailfin/.trace_emit");
@@ -286,7 +291,7 @@ fn compile_to_llvm_with_module_timed(source: string, module_name: string) -> str
         print.err(_timing_line(module_name, "typecheck", t_typecheck));
         return "";
     }
-    if validate_and_render_effects(program, source, module_name) > 0 {
+    if validate_and_render_effects(program, source, module_name, empty_import_symbols()) > 0 {
         print.err(_timing_line(module_name, "parse", t_parse));
         print.err(_timing_line(module_name, "typecheck", t_typecheck));
         return "";
@@ -353,7 +358,7 @@ fn compile_to_llvm_with_module_timed(source: string, module_name: string) -> str
 // on the `Diagnostic` struct, so we filter for `severity == "error"`
 // before reporting and bailing. Warnings (e.g. future W01xx load
 // warnings) flow through without aborting the test compile.
-fn compile_tests_to_llvm_file_with_module_imports(source: string, module_name: string, out_path: string, imported_interfaces: Statement[], imported_manifests: LayoutManifest[], imported_native_texts: string[]) -> boolean ![io] {
+fn compile_tests_to_llvm_file_with_module_imports(source: string, module_name: string, out_path: string, imported_interfaces: Statement[], imported_manifests: LayoutManifest[], imported_native_texts: string[], imported_function_effects: ImportSymbolTable) -> boolean ![io] {
     let trace_file = fs.exists("build/sailfin/.trace_test_runner");
     let active_file = fs.exists("build/sailfin/.test_runner_active");
     let mut _let_trace: boolean = false;
@@ -379,7 +384,12 @@ fn compile_tests_to_llvm_file_with_module_imports(source: string, module_name: s
         return false;
     }
     if _reject_reexport_violations(program) { return false; }
-    if validate_and_render_effects(program, source, module_name) > 0 {
+    // Phase E: thread the resolver-built function-effect table so
+    // a test source that calls an imported `![net]` helper without
+    // declaring `![net]` produces an `E0402` diagnostic. Pre-Phase-E
+    // tests that only use in-module fns get an empty table from the
+    // caller and behave identically to before.
+    if validate_and_render_effects(program, source, module_name, imported_function_effects) > 0 {
         return false;
     }
     if trace {
@@ -430,7 +440,7 @@ fn compile_to_native_text_with_module(source: string, module_name: string) -> st
         return "";
     }
     if _reject_reexport_violations(program) { return ""; }
-    if validate_and_render_effects(program, source, module_name) > 0 {
+    if validate_and_render_effects(program, source, module_name, empty_import_symbols()) > 0 {
         return "";
     }
     let trace_emit = fs.exists("build/sailfin/.trace_emit");
@@ -454,7 +464,7 @@ fn write_native_text_file_with_module(source: string, module_name: string, out_p
         return false;
     }
     if _reject_reexport_violations(program) { return false; }
-    if validate_and_render_effects(program, source, module_name) > 0 {
+    if validate_and_render_effects(program, source, module_name, empty_import_symbols()) > 0 {
         return false;
     }
     return emit_native_text_to_file_with_module_name(program, module_name, out_path);
@@ -539,7 +549,7 @@ fn compile_to_llvm_file_with_module(source: string, module_name: string, out_pat
         print.err("emit-llvm-file: skipping typecheck (build/sailfin/.skip_typecheck present)");
     }
     if _reject_reexport_violations(program) { return false; }
-    if validate_and_render_effects(program, source, module_name) > 0 {
+    if validate_and_render_effects(program, source, module_name, empty_import_symbols()) > 0 {
         return false;
     }
 

--- a/compiler/src/tools/check.sfn
+++ b/compiler/src/tools/check.sfn
@@ -26,8 +26,9 @@ import {
     render_diagnostic,
     split_source_lines
 } from "../diagnostics_render";
-import { validate_effects } from "../effect_checker";
+import { validate_effects_with_imports } from "../effect_checker";
 import { read_effect_enforcement_env, resolve_effect_enforcement } from "../effect_gate";
+import { ImportSymbolTable, empty_import_symbols } from "../effect_imports";
 import { number_to_string } from "../main";
 import { parse_program } from "../parser/mod";
 import { substring } from "../string_utils";
@@ -59,8 +60,8 @@ fn _is_sfn_file(path: string) -> boolean {
 }
 
 fn check_source(source: string, file_path: string) -> CheckResult ![io] {
-    let no_imports: Statement[] = [];
-    return check_source_with_imports(source, file_path, no_imports);
+    let no_interfaces: Statement[] = [];
+    return check_source_with_imports(source, file_path, no_interfaces, empty_import_symbols());
 }
 
 // Cross-module-aware variant: `imported_interfaces` carries
@@ -69,10 +70,16 @@ fn check_source(source: string, file_path: string) -> CheckResult ![io] {
 // passed through to `typecheck_diagnostics_with_imports` so cross-
 // module `implements` clauses are conformance-checked against the
 // real interface definitions instead of silently no-oping.
-fn check_source_with_imports(source: string, file_path: string, imported_interfaces: Statement[]) -> CheckResult ![io] {
+//
+// Phase E: `function_effects` carries the per-build cross-module
+// effect symbol table built from the same `.sfn-asm` artifacts.
+// It is threaded into `validate_effects_with_imports` so a caller
+// missing `![<imported_callee_effect>]` produces an `E0402`
+// diagnostic alongside any in-module `E0400` / `E0401` findings.
+fn check_source_with_imports(source: string, file_path: string, imported_interfaces: Statement[], function_effects: ImportSymbolTable) -> CheckResult ![io] {
     let program = parse_program(source);
     let type_diags = typecheck_diagnostics_with_imports(program, imported_interfaces);
-    let effect_violations = validate_effects(program);
+    let effect_violations = validate_effects_with_imports(program, function_effects);
 
     let source_lines = split_source_lines(source);
     let mut combined: Diagnostic[] = [];

--- a/compiler/src/typecheck_import_loader.sfn
+++ b/compiler/src/typecheck_import_loader.sfn
@@ -28,6 +28,7 @@
 // artifact from looking like a benign module that just happened to
 // export only structs/functions.
 import { Statement } from "./ast";
+import { ImportSymbolTable, append_import_function, empty_import_symbols } from "./effect_imports";
 import { parse_native_artifact_for_import_context } from "./native_ir_api";
 import { interfaces_from_native } from "./typecheck_imports";
 
@@ -37,6 +38,7 @@ import { interfaces_from_native } from "./typecheck_imports";
 // as an empty-but-valid module.
 struct ArtifactInterfaceParse {
     interfaces: Statement[];
+    function_effects: ImportSymbolTable;
     diagnostics: string[];
 }
 
@@ -47,6 +49,12 @@ struct ArtifactInterfaceParse {
 //      produced diagnostics — treat as corrupt/stale.
 //   - `skipped_paths`: parsed fine and contained zero interfaces
 //      (benign — common for modules that export only structs/fns).
+//
+// `function_effects` is the Phase E channel: an `ImportSymbolTable`
+// aggregating the `effects` field on every `NativeFunction` declared
+// across the loaded artifacts. The effect checker resolves caller
+// `Call` expressions against this table so cross-module effect
+// propagation lights up without re-parsing artifacts.
 //
 // `native_texts` is the raw `.sfn-asm` text for every artifact that
 // existed on disk (i.e. NOT in `missing_paths`), in input-order. The
@@ -59,19 +67,40 @@ struct ArtifactInterfaceParse {
 // today; future consumers would benefit too).
 struct ImportedInterfaceLoadResult {
     interfaces: Statement[];
+    function_effects: ImportSymbolTable;
     missing_paths: string[];
     parse_failure_paths: string[];
     skipped_paths: string[];
     native_texts: string[];
 }
 
-// Pure: parse a `.sfn-asm` text buffer and return both its interface
-// declarations and any diagnostics the native-IR parser produced.
+// Pure: parse a `.sfn-asm` text buffer and return its interface
+// declarations, the cross-module function-effect table contributed
+// by its top-level `NativeFunction` decls, and any diagnostics the
+// native-IR parser produced.
 fn interfaces_from_native_artifact(text: string) -> ArtifactInterfaceParse {
     let parsed = parse_native_artifact_for_import_context(text);
     let interfaces = interfaces_from_native(parsed.interfaces);
+    let mut function_effects = empty_import_symbols();
+    let mut i: number = 0;
+    loop {
+        if i >= parsed.functions.length { break; }
+        let function = parsed.functions[i];
+        // Skip extern declarations — the effect-checker's `E0402`
+        // contract is "imported Sailfin function carries effects
+        // the caller must propagate". `extern fn` has no
+        // declared-effects metadata in the round-tripped artifact
+        // today; the C-runtime FFI surface is gated by the
+        // hardcoded helper roots (`fs.`, `print.`, etc.) that the
+        // in-module checker already handles.
+        if !function.is_extern {
+            function_effects = append_import_function(function_effects, function.name, function.effects);
+        }
+        i += 1;
+    }
     return ArtifactInterfaceParse {
         interfaces: interfaces,
+        function_effects: function_effects,
         diagnostics: parsed.diagnostics
     };
 }
@@ -86,6 +115,7 @@ fn interfaces_from_native_artifact(text: string) -> ArtifactInterfaceParse {
 // a warning.
 fn load_imported_interfaces_from_paths(paths: string[]) -> ImportedInterfaceLoadResult ![io] {
     let mut interfaces: Statement[] = [];
+    let mut function_effects = empty_import_symbols();
     let mut missing: string[] = [];
     let mut parse_failures: string[] = [];
     let mut skipped: string[] = [];
@@ -113,6 +143,19 @@ fn load_imported_interfaces_from_paths(paths: string[]) -> ImportedInterfaceLoad
             i += 1;
             continue;
         }
+        // Phase E: merge this artifact's exported function-effects
+        // into the per-batch table, regardless of whether the
+        // artifact also declared interfaces. A module that exports
+        // only standalone fns is `skipped` for interface purposes
+        // but still contributes effect entries for cross-module
+        // propagation.
+        let mut k: number = 0;
+        loop {
+            if k >= parsed.function_effects.functions.length { break; }
+            let entry = parsed.function_effects.functions[k];
+            function_effects = append_import_function(function_effects, entry.name, entry.effects);
+            k += 1;
+        }
         if parsed.interfaces.length == 0 { skipped.push(path); } else {
             let mut j: number = 0;
             loop {
@@ -126,6 +169,7 @@ fn load_imported_interfaces_from_paths(paths: string[]) -> ImportedInterfaceLoad
 
     return ImportedInterfaceLoadResult {
         interfaces: interfaces,
+        function_effects: function_effects,
         missing_paths: missing,
         parse_failure_paths: parse_failures,
         skipped_paths: skipped,

--- a/compiler/tests/unit/check_tool_test.sfn
+++ b/compiler/tests/unit/check_tool_test.sfn
@@ -69,6 +69,15 @@ fn _local_build_effect_message(routine_name: string, missing_effects: string[]) 
 fn _local_code_for_first_description(first_desc: string) -> string {
     if first_desc.length == 0 { return "E0400"; }
     if substring(first_desc, 0, 1) == "@" { return "E0401"; }
+    // Phase E: cross-module call resolution attaches descriptions
+    // of the form `imported \`<name>\` declares !\[…\]` so the
+    // diagnostic code promotes from in-module E0400 to E0402.
+    let imported_prefix = "imported `";
+    if first_desc.length >= imported_prefix.length {
+        if substring(first_desc, 0, imported_prefix.length) == imported_prefix {
+            return "E0402";
+        }
+    }
     return "E0400";
 }
 
@@ -168,6 +177,25 @@ test "check: decorator-implied effect is E0401" {
 
 test "check: empty description defaults to E0400" {
     assert strings_equal(_local_code_for_first_description(""), "E0400");
+}
+
+test "check: cross-module imported description is E0402" {
+    // Phase E: descriptions emitted by
+    // `effect_checker._propagate_imported_callee_effects` carry the
+    // prefix `imported \`<name>\` declares !\[…\]`. Pin the prefix
+    // → E0402 mapping so a refactor that "tidies" the description
+    // string (e.g. drops the backtick or capitalises) doesn't
+    // silently regress the cross-module diagnostic to E0400.
+    assert strings_equal(_local_code_for_first_description("imported `fetch` declares ![net]"), "E0402");
+    assert strings_equal(_local_code_for_first_description("imported `read_file` declares ![io]"), "E0402");
+}
+
+test "check: imported substring without prefix stays E0400" {
+    // Defensive — make sure the prefix check doesn't false-match
+    // descriptions that merely contain the word "imported" later
+    // in the string (e.g. an in-module helper named "use_imported").
+    assert strings_equal(_local_code_for_first_description("use_imported_helper requires ![io]"), "E0400");
+    assert strings_equal(_local_code_for_first_description("filesystem helper usage"), "E0400");
 }
 
 // -------------------------------------------------------------------

--- a/compiler/tests/unit/effect_imports_test.sfn
+++ b/compiler/tests/unit/effect_imports_test.sfn
@@ -1,0 +1,324 @@
+// Unit tests for compiler/src/effect_imports.sfn and the Phase E
+// (`docs/proposals/effect-validation.md` §5) cross-module
+// propagation path through compiler/src/effect_checker.sfn.
+//
+// Phase E lets the effect checker resolve `Identifier` callees at
+// every `Call` expression against a per-program-localized
+// `ImportSymbolTable`. A caller that imports a function with
+// declared effects but doesn't propagate them to its own signature
+// fails with the new `E0402` diagnostic code (distinct from
+// `E0400` in-module and `E0401` decorator-implied).
+//
+// Tests construct AST values via small helper functions to stay
+// flat — some seed compilers previously segfaulted on deeply nested
+// struct-literal initialisers in test bodies (see
+// `effect_checker_test.sfn` preamble for the same workaround).
+import {
+    Block,
+    Decorator,
+    Expression,
+    FunctionSignature,
+    ImportSpecifier,
+    Program,
+    SourceSpan,
+    Statement
+} from "../../src/ast";
+import { EffectViolation, validate_effects_with_imports } from "../../src/effect_checker";
+import {
+    ImportSymbolTable,
+    ImportedFunctionSignature,
+    append_import_function,
+    empty_import_symbols,
+    localize_import_symbols_for_program,
+    lookup_imported_function
+} from "../../src/effect_imports";
+
+// -------------------------------------------------------------------
+// Builder helpers
+// -------------------------------------------------------------------
+fn _empty_block() -> Block {
+    return Block { tokens: [], text: "", statements: [] };
+}
+
+fn _span(line: number, column: number) -> SourceSpan {
+    return SourceSpan {
+        start_line: line,
+        start_column: column,
+        end_line: line,
+        end_column: column + 1
+    };
+}
+
+fn _signature(name: string, effects: string[], span: SourceSpan?) -> FunctionSignature {
+    return FunctionSignature {
+        name: name,
+        is_async: false,
+        parameters: [],
+        return_type: null,
+        effects: effects,
+        type_parameters: [],
+        name_span: span
+    };
+}
+
+fn _import_decl(name: string, alias: string?, source: string) -> Statement {
+    let spec = ImportSpecifier { name: name, alias: alias };
+    return Statement.ImportDeclaration {
+        import_specifiers: [spec],
+        source: source
+    };
+}
+
+// Build a routine whose body calls `callee_name(...)` once, with no
+// declared effects on the signature. The body is encoded as an
+// `ExpressionStatement` wrapping a `Call(Identifier(callee_name))`
+// so `collect_effects_from_expression` walks it through the
+// Phase E `_propagate_imported_callee_effects` path.
+fn _routine_calling(routine_name: string, callee_name: string, span_line: number) -> Statement {
+    let span = _span(span_line, 4);
+    let callee = Expression.Identifier { name: callee_name };
+    let no_args: Expression[] = [];
+    let call_expr = Expression.Call { callee: callee, arguments: no_args };
+    let body_stmt = Statement.ExpressionStatement {
+        expression: call_expr,
+        span: null
+    };
+    let body_block = Block {
+        tokens: [],
+        text: callee_name + "();",
+        statements: [body_stmt]
+    };
+    let mut empty_decorators: Decorator[] = [];
+    let mut empty_effects: string[] = [];
+    return Statement.FunctionDeclaration {
+        signature: _signature(routine_name, empty_effects, span),
+        body: body_block,
+        decorators: empty_decorators
+    };
+}
+
+// -------------------------------------------------------------------
+// ImportSymbolTable primitives
+// -------------------------------------------------------------------
+test "empty_import_symbols: produces an empty table" {
+    let table = empty_import_symbols();
+    assert table.functions.length == 0;
+}
+
+test "append_import_function: pushes a new entry" {
+    let mut table = empty_import_symbols();
+    table = append_import_function(table, "fetch", ["net"]);
+    assert table.functions.length == 1;
+    assert table.functions[0].name == "fetch";
+    assert table.functions[0].effects.length == 1;
+    assert table.functions[0].effects[0] == "net";
+}
+
+test "append_import_function: ignores empty names" {
+    // Empty name should be a no-op so the loader can call this
+    // unconditionally on every NativeFunction without filtering
+    // out anonymous/synthesized helpers itself.
+    let mut table = empty_import_symbols();
+    table = append_import_function(table, "", ["net"]);
+    assert table.functions.length == 0;
+}
+
+test "append_import_function: deduplicates by name (last write wins)" {
+    // The loader merges every staged artifact — re-exports show up
+    // multiple times. Last-write-wins keeps the table size bounded
+    // and is fine because every re-export carries identical effect
+    // metadata; divergent-effect detection is a Phase G concern.
+    let mut table = empty_import_symbols();
+    table = append_import_function(table, "fetch", ["net"]);
+    table = append_import_function(table, "fetch", ["net", "io"]);
+    assert table.functions.length == 1;
+    assert table.functions[0].effects.length == 2;
+}
+
+test "lookup_imported_function: returns null for missing name" {
+    let table = empty_import_symbols();
+    assert lookup_imported_function(table, "anything") == null;
+}
+
+test "lookup_imported_function: returns the entry by exact name" {
+    let mut table = empty_import_symbols();
+    table = append_import_function(table, "fetch", ["net"]);
+    let entry_opt = lookup_imported_function(table, "fetch");
+    assert entry_opt != null;
+    let entry: ImportedFunctionSignature? = entry_opt;
+    assert entry.name == "fetch";
+}
+
+// -------------------------------------------------------------------
+// Localization (alias resolution + scope filter)
+// -------------------------------------------------------------------
+test "localize: filters out names the program does not import" {
+    // The global table has `fetch` from a staged artifact, but the
+    // program declares no imports. Localized result must be empty,
+    // otherwise an in-module same-named function would erroneously
+    // pull cross-module effects (false-positive E0402).
+    let mut global = empty_import_symbols();
+    global = append_import_function(global, "fetch", ["net"]);
+    let no_stmts: Statement[] = [];
+    let program = Program { statements: no_stmts };
+    let local = localize_import_symbols_for_program(program, global);
+    assert local.functions.length == 0;
+}
+
+test "localize: preserves direct (non-aliased) imports keyed by export name" {
+    let mut global = empty_import_symbols();
+    global = append_import_function(global, "fetch", ["net"]);
+    let import_stmt = _import_decl("fetch", null, "modA");
+    let program = Program { statements: [import_stmt] };
+    let local = localize_import_symbols_for_program(program, global);
+    assert local.functions.length == 1;
+    assert local.functions[0].name == "fetch";
+    assert local.functions[0].effects[0] == "net";
+}
+
+test "localize: rewrites aliases so call sites use the local name" {
+    // `import { fetch as get } from "modA"` makes `get` the name
+    // visible in the importing module. Localized table must key on
+    // `get`, not `fetch`, so the AST walker's
+    // `Call(Identifier("get"))` lookup hits.
+    let mut global = empty_import_symbols();
+    global = append_import_function(global, "fetch", ["net"]);
+    let import_stmt = _import_decl("fetch", "get", "modA");
+    let program = Program { statements: [import_stmt] };
+    let local = localize_import_symbols_for_program(program, global);
+    assert local.functions.length == 1;
+    assert local.functions[0].name == "get";
+    assert local.functions[0].effects[0] == "net";
+}
+
+// -------------------------------------------------------------------
+// End-to-end: Phase E propagation through the effect checker
+// -------------------------------------------------------------------
+test "validate_effects_with_imports: imported callee surfaces E0402-shaped violation" {
+    // The fixture: a routine `run()` that calls `fetch()` with no
+    // declared effects on `run`. With `fetch -> [net]` in the
+    // imports table, validate_effects_with_imports must emit one
+    // violation, missing_effects = ["net"], and the requirement's
+    // description must start with `imported \`fetch\`` (which is
+    // what `diagnostics_render.code_for_missing_effect` keys on to
+    // promote the diagnostic to E0402).
+    let mut global = empty_import_symbols();
+    global = append_import_function(global, "fetch", ["net"]);
+    let import_stmt = _import_decl("fetch", null, "modA");
+    let routine_stmt = _routine_calling("run", "fetch", 5);
+    let program = Program { statements: [import_stmt, routine_stmt] };
+    let violations = validate_effects_with_imports(program, global);
+    assert violations.length == 1;
+    let v = violations[0];
+    assert v.routine_name == "run";
+    assert v.missing_effects.length == 1;
+    assert v.missing_effects[0] == "net";
+    assert v.requirements.length == 1;
+    let req = v.requirements[0];
+    assert req.effect == "net";
+    // Prefix check — same shape diagnostics_render keys on. Spelled
+    // out by hand because the prefix is the cross-module contract.
+    let prefix = "imported `";
+    assert req.description.length >= prefix.length;
+    let mut i: number = 0;
+    let mut prefix_match: boolean = true;
+    loop {
+        if i >= prefix.length { break; }
+        if req.description[i] != prefix[i] { prefix_match = false; }
+        i += 1;
+    }
+    assert prefix_match;
+}
+
+test "validate_effects_with_imports: aliased import resolves under the local name" {
+    // Same setup as the previous test but with `import { fetch as
+    // get }` — the call site reads `get()`. Localization must
+    // rewrite the table so `get` carries `fetch`'s effects.
+    let mut global = empty_import_symbols();
+    global = append_import_function(global, "fetch", ["net"]);
+    let import_stmt = _import_decl("fetch", "get", "modA");
+    let routine_stmt = _routine_calling("run", "get", 5);
+    let program = Program { statements: [import_stmt, routine_stmt] };
+    let violations = validate_effects_with_imports(program, global);
+    assert violations.length == 1;
+    assert violations[0].missing_effects[0] == "net";
+}
+
+test "validate_effects_with_imports: declared effect on caller suppresses violation" {
+    // The happy path: caller declares `![net]`, imported `fetch`
+    // declares `![net]`, no violation.
+    let mut global = empty_import_symbols();
+    global = append_import_function(global, "fetch", ["net"]);
+    let import_stmt = _import_decl("fetch", null, "modA");
+
+    let span = _span(5, 4);
+    let callee = Expression.Identifier { name: "fetch" };
+    let no_args: Expression[] = [];
+    let call_expr = Expression.Call { callee: callee, arguments: no_args };
+    let body_stmt = Statement.ExpressionStatement {
+        expression: call_expr,
+        span: null
+    };
+    let body_block = Block {
+        tokens: [],
+        text: "fetch();",
+        statements: [body_stmt]
+    };
+    let mut empty_decorators: Decorator[] = [];
+    let routine_stmt = Statement.FunctionDeclaration {
+        signature: _signature("run", ["net"], span),
+        body: body_block,
+        decorators: empty_decorators
+    };
+
+    let program = Program { statements: [import_stmt, routine_stmt] };
+    let violations = validate_effects_with_imports(program, global);
+    assert violations.length == 0;
+}
+
+test "validate_effects_with_imports: same-named in-module fn does not trigger E0402" {
+    // Critical scope-filter test. The global table has `fetch ->
+    // [net]` because some staged artifact exports it, but the
+    // program does NOT import that fetch — the program defines its
+    // own local `fetch`. Localization must filter the global
+    // entry out so the `Call(Identifier("fetch"))` lookup misses
+    // and no spurious violation fires. Only an in-module local
+    // function is at play, and the body does no effectful ops, so
+    // the result must be zero violations.
+    let mut global = empty_import_symbols();
+    global = append_import_function(global, "fetch", ["net"]);
+
+    // Build a routine whose body is just an empty block — no Call,
+    // no effectful call, just a return-style empty body. The point
+    // is that even if a *call* to `fetch` showed up, the program
+    // hasn't imported it so localization filters out the entry.
+    let span = _span(5, 4);
+    let body_block = _empty_block();
+    let mut empty_decorators: Decorator[] = [];
+    let mut empty_effects: string[] = [];
+    let routine_stmt = Statement.FunctionDeclaration {
+        signature: _signature("run", empty_effects, span),
+        body: body_block,
+        decorators: empty_decorators
+    };
+
+    // No import declaration in the program, so localize produces
+    // an empty table and `fetch` lookups don't hit.
+    let program = Program { statements: [routine_stmt] };
+    let violations = validate_effects_with_imports(program, global);
+    assert violations.length == 0;
+}
+
+test "validate_effects: legacy entry stays compatible (empty imports)" {
+    // The Phase B `validate_effects(program)` wrapper is preserved
+    // for legacy callers. It must behave identically to
+    // `validate_effects_with_imports(program, empty)`. Pin the
+    // contract so a refactor that makes the legacy entry drift
+    // (e.g. drops the wrapper) breaks loudly.
+    let import_stmt = _import_decl("fetch", null, "modA");
+    let routine_stmt = _routine_calling("run", "fetch", 5);
+    let program = Program { statements: [import_stmt, routine_stmt] };
+    // No import table → no cross-module propagation → no violation.
+    let violations = validate_effects_with_imports(program, empty_import_symbols());
+    assert violations.length == 0;
+}

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,6 +1,6 @@
 # Status
 
-Updated: April 26, 2026 (effect validation Phases C/D — audit + default flipped to error)
+Updated: April 26, 2026 (effect validation Phase E — cross-module propagation)
 
 This document tracks what works today and what is in progress. It is the source
 of truth — consult it before editing docs, examples, or making claims about
@@ -129,6 +129,28 @@ feature availability.
   All `examples/*.sfn` build cleanly under the new default. Capsule
   authors who need to migrate gradually can opt into
   `SAILFIN_EFFECT_ENFORCE=warning` for telemetry-only mode.
+- **Cross-module effect propagation (Phase E — shipped 2026-04-26).**
+  When a caller invokes an `Identifier` that resolves to an imported
+  function with declared effects, `validate_effects_with_imports`
+  promotes the call into a per-call effect requirement and emits
+  `E0402` (cross-module) instead of the in-module `E0400` if the
+  caller's signature doesn't propagate the effect. The new
+  `compiler/src/effect_imports.sfn` module owns the
+  `ImportSymbolTable` data shape; the loader
+  (`typecheck_import_loader.sfn`) populates it as a side-channel of
+  the same `.sfn-asm` artifact read that already produces the
+  `Statement.InterfaceDeclaration` list. `tools/check.sfn`,
+  `effect_gate.sfn`, `cli_check.sfn`, and `cli_commands.sfn` thread
+  the table through to every analysis surface.
+
+  Alias resolution: `import { foo as bar } from "..."` registers
+  `bar` in the localized table with `foo`'s effect set, so the AST
+  walker sees `Call(Identifier("bar"))` and resolves correctly. The
+  scope filter in `localize_import_symbols_for_program` ensures a
+  same-named in-module function never picks up a global table
+  entry's effects. E1 covers direct `Identifier` callees;
+  `Member`-callee resolution (`mod.fn()`) and decorator-implied
+  transitives are deferred to a follow-up Phase E2.
 - Experimental LLVM JIT execution is available for targeted backend coverage.
 - CI uses the native build workflow (`.github/workflows/ci.yml`) to build, test,
   and attach release assets.
@@ -158,7 +180,8 @@ feature availability.
 | Effect enforcement — `model` | Reserved | Declarable; effect-checker has no detector yet. The `sfn/ai` capsule (post-1.0) supplies the call sites Phase G's name-resolution detector will key on |
 | Effect enforcement — `clock` | **Enforced** | Checker detects `sleep` / `runtime.sleep`; build fails on undeclared usage by default |
 | Effect enforcement — `gpu`, `rand` | Parsed only | Reserved at 1.0 in the canonical taxonomy; no detector logic yet |
-| Effect enforcement as compilation gate | **Shipped (Phase D, 2026-04-26)** | `validate_and_render_effects` runs after typecheck in every `compile_to_*` entry; default severity is `error` so undeclared effects fail the build. `SAILFIN_EFFECT_ENFORCE=warning` opt-in for capsule authors mid-migration; `=off` build-path escape hatch (proposal §4.7). Phase E (cross-module propagation) and Phase F (capsule.toml capability cross-check) are next on the roadmap |
+| Effect enforcement as compilation gate | **Shipped (Phase D, 2026-04-26)** | `validate_and_render_effects` runs after typecheck in every `compile_to_*` entry; default severity is `error` so undeclared effects fail the build. `SAILFIN_EFFECT_ENFORCE=warning` opt-in for capsule authors mid-migration; `=off` build-path escape hatch (proposal §4.7) |
+| Cross-module effect propagation | **Shipped (Phase E, 2026-04-26)** | A caller of an imported function inherits the callee's declared effects; missing propagation fails the build with `E0402`. Aliased imports (`import { foo as bar }`) resolve under the local name. E1 covers direct `Identifier` calls; `Member`-callee resolution and decorator-implied transitives deferred to Phase E2. Phase F (capsule.toml capability cross-check) is next |
 | Generic type inference | Partial | Type params captured; inference coverage is limited |
 | Interface conformance validation | Partial | Basic checks; variance not yet enforced |
 | `Affine<T>` / `Linear<T>` | Parsed only | Ownership wrappers accepted; move/consume rules not enforced |

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # Sailfin Language Reference for LLMs
 
-> Version: 0.5.9 | Updated: 2026-04-26
+> Version: 0.5.9 | Updated: 2026-04-26 (Phase E)
 > Source: https://github.com/SailfinIO/sailfin | Site: https://sailfin.dev
 
 Sailfin is a compiled systems language with compile-time capability enforcement
@@ -17,9 +17,11 @@ enforced at compile time: undeclared effect usage fails `make compile`,
 `=warning` (telemetry-only mode) while migrating, or `=off` (build-path
 bypass; `sfn check` still validates per proposal §4.7).
 
-Cross-module call-graph propagation (A must declare B's effects when
-A calls B from another module) is the next milestone on the roadmap
-(Phase E in `docs/proposals/effect-validation.md`).
+Cross-module call-graph propagation is enforced: if A imports B and
+calls it, A must declare every effect B declares (diagnostic code
+`E0402`). Aliased imports (`import { foo as bar }`) resolve under the
+local name. `Member`-callee resolution (`mod.fn()`) is a follow-up
+(Phase E2 in `docs/proposals/effect-validation.md`).
 
     fn read_config(path: string) -> string ![io] {
         return fs.readFile(path);
@@ -283,7 +285,7 @@ These features parse, type-check, emit to .sfn-asm IR, and lower to LLVM:
 
 ## What Is Parsed but Not Fully Implemented
 
-- Cross-module effect propagation -- direct effect calls inside a function are enforced; transitive effects from imported callees are not yet (Phase E of effect-validation)
+- Member-callee cross-module effect propagation (`mod.fetch()`) -- direct `Identifier` callee resolution ships in Phase E1; member callees and decorator-implied transitives are deferred to Phase E2
 - Closures with capture -- lambdas parse but don't capture enclosing scope
 - Generic constraints (<T: Bound>) -- parsed as text, not enforced
 - Affine<T> / Linear<T> ownership -- parsed, transparent (no enforcement)

--- a/site/src/content/docs/docs/reference/spec/07-effects.md
+++ b/site/src/content/docs/docs/reference/spec/07-effects.md
@@ -30,6 +30,6 @@ fn analyze(text: string) ![io, model] { }      // multiple effects
 1. Any function calling an effectful operation directly must declare that effect — violations produce diagnostics with fix-it hints and are errors by default
 2. Enforcement runs on every build path (`make compile`, `sfn build`, `sfn run`, `sfn test`, `sfn check`); the `SAILFIN_EFFECT_ENFORCE` env var lets capsule authors opt into `=warning` (telemetry-only) or `=off` (build-path bypass; `sfn check` still validates)
 3. Tests follow the same rules as functions
-4. Call-graph–transitive enforcement (A must declare B's effects when A calls B) is planned for Phase E and not yet implemented
+4. **Cross-module call-graph propagation** (Phase E, shipped): if A imports B and calls it, A must declare every effect B declares. Diagnostic code `E0402`. Aliased imports (`import { foo as bar }`) resolve under the local name. `Member`-callee resolution (`mod.fn()`) is a Phase E2 follow-up
 
 See [Effect System Reference](/docs/reference/effects) for the complete API surface per effect.


### PR DESCRIPTION
A caller that imports and calls a function from another module must
now declare the imported callee's effects, or the build fails with
E0402. Closes Phase E1 of `docs/proposals/effect-validation.md` §5.

The wire format already serialized `NativeFunction.effects: string[]`
for every standalone-fn declaration in every `.sfn-asm` artifact;
Phase E plumbs that data through to the analysis layer.

Architecture
============

New `compiler/src/effect_imports.sfn` (leaf, no I/O) owns:
- `ImportedFunctionSignature` / `ImportSymbolTable` value types.
- `empty_import_symbols()` — null-equivalent for legacy callers.
- `append_import_function(table, name, effects)` — last-write-wins.
- `lookup_imported_function(table, name) -> ImportedFunctionSignature?`.
- `localize_import_symbols_for_program(program, global_table)` —
  pure helper that walks `Statement.ImportDeclaration` to apply two
  filters:
    1. Scope filter: only entries the program actually imports
       survive. Without this, a same-named in-module function
       would erroneously inherit a global-table entry's effects
       and trigger spurious E0402.
    2. Alias rewrite: `import { foo as bar } from "..."` registers
       `bar` in the localized table with `foo`'s effects so the
       AST walker's `Call(Identifier("bar"))` lookup hits.

Loader (`typecheck_import_loader.sfn`):
- `ArtifactInterfaceParse` and `ImportedInterfaceLoadResult` gain a
  `function_effects: ImportSymbolTable` field. Built in the same
  artifact-read pass that already produces `interfaces`, so no
  extra disk I/O. `extern fn` declarations are skipped — Sailfin's
  C-runtime FFI surface is gated by hardcoded helper roots
  (`fs.`, `print.`, etc.) that the in-module checker already
  handles.

Effect checker (`effect_checker.sfn`):
- New `validate_effects_with_imports(program, imports)` entry; the
  legacy `validate_effects(program)` becomes a one-line wrapper
  that passes `empty_import_symbols()`.
- The full `analyze_routine → required_effects →
  collect_effects_from_block → … → collect_effects_from_expression`
  chain threads the (already-localized) `ImportSymbolTable` through
  unchanged in shape.
- New `_propagate_imported_callee_effects(name, imports, base)`
  appends one `EffectRequirement` per declared effect on the
  imported callee with the description prefix
  `imported \`<name>\` declares ![<effect>]`. The prefix is the
  cross-module contract `diagnostics_render` keys on.

Diagnostic codes (`diagnostics_render.sfn`):
- `code_for_missing_effect` now returns `E0402` when any
  requirement description starts with the `imported \`` prefix.
  E0401 (decorator-implied) wins over E0402 when both apply,
  matching the Phase A precedence. New
  `_description_starts_with_imported` helper does the strict
  prefix match (no false positives for descriptions that merely
  contain the word "imported" later in the string).

Build path (`main.sfn`, `effect_gate.sfn`):
- `validate_and_render_effects` accepts an `imports` parameter.
- Every `compile_to_*` entrypoint that lacks a resolver context
  (`compile_to_sailfin`, `compile_to_llvm`, `compile_to_llvm_with_module`,
  `compile_to_llvm_with_module_timed`, `compile_to_llvm_file_with_module`,
  `compile_to_native_text_with_module`, `write_native_text_file_with_module`,
  `print_llvm_with_module`) passes `empty_import_symbols()`.
- `compile_tests_to_llvm_file_with_module_imports` gains an
  `imported_function_effects: ImportSymbolTable` parameter that
  flows from `cli_commands`'s `TestGroup`.

`sfn check` (`tools/check.sfn`, `cli_check.sfn`):
- `check_source_with_imports` takes `function_effects: ImportSymbolTable`.
- `CheckGroup` carries the per-group function-effect table; the
  resolver's `load_imported_interfaces_from_paths` populates it
  alongside `interfaces`.

`sfn test` (`cli_commands.sfn`):
- `TestGroup.function_effects` plumbed identically.

Tests
=====

New `compiler/tests/unit/effect_imports_test.sfn` (14 tests):
- `empty_import_symbols`, `append_import_function`,
  `lookup_imported_function` primitives.
- `localize_import_symbols_for_program`: scope filter, direct
  imports, alias rewrites.
- `validate_effects_with_imports`:
    - imported callee surfaces E0402-shaped violation
    - aliased import resolves under the local name
    - declared effect on caller suppresses violation
    - same-named in-module fn does NOT trigger E0402 (scope filter)
- `validate_effects` legacy wrapper still produces zero violations
  when imports are empty.

`compiler/tests/unit/check_tool_test.sfn` extended with two new
tests pinning the `imported \`` prefix → E0402 mapping (and a
defensive negative test that "use_imported_helper" stays E0400).

Verified
========

- `make rebuild` succeeds in 143s under strict default with no env
  override; the 132-module compiler self-hosts cleanly.
- 71 unit + 17 integration + 11 e2e tests pass against the
  rebuilt binary (the new effect_imports_test contributes 14 of
  those 71).
- `sfn check` over the compiler tree (cli_check, cli_main,
  cli_commands, main) emits zero E0402 — Phase D's audit + the
  existing `![io]` declarations form a closed set, so no
  in-tree caller is missing a transitive effect.
- Single-file `sfn emit` sweep across 132 modules also shows zero
  in-module E0400/E0401 regressions from Phase E plumbing.

Out of scope (deferred)
=======================

- E2: `Member`-callee resolution (`mod.fetch()`), decorator-implied
  transitive effects, lambda escapes. Sailfin's typical `import {
  foo } from "..."; foo()` pattern is the dominant call-site shape;
  member-callee resolution is post-1.0 polish.
- Phase F: capsule.toml capability cross-check (`E0403`). Next on
  the roadmap.

https://claude.ai/code/session_0157FJzrK3YtAjEKcoJ8xBhs