### PR TITLE
effect validation Phase F: capsule capability cross-check (E0403)

### DIFF
--- a/compiler/capsule.toml
+++ b/compiler/capsule.toml
@@ -6,7 +6,15 @@ description = "The Sailfin compiler — self-hosted, targeting LLVM via .sfn-asm
 [dependencies]
 
 [capabilities]
-required = ["io"]
+# `io` covers fs.*, print.*, console.*, and process.* surface used
+# across emit/lower/CLI helpers and the print.err debug traces.
+# `clock` is required because compile_to_llvm_with_module_timed
+# (compiler/src/main.sfn) wraps the lower pipeline with
+# monotonic_millis() — `--timing` mode on `sfn emit llvm`.
+# Phase F (docs/proposals/effect-validation.md §5) enforces this
+# surface against every function's declared effects: any function
+# declaring an effect outside this list fails with E0403.
+required = ["io", "clock"]
 
 [build]
 kind = "binary"

--- a/compiler/src/capsule_resolver.sfn
+++ b/compiler/src/capsule_resolver.sfn
@@ -41,7 +41,12 @@ import {
     write_native_text_file_with_module
 } from "./main";
 import { substring } from "./string_utils";
-import { toml_get_dependencies, toml_get_name, toml_get_workspace_members } from "./toml_parser";
+import {
+    toml_get_capabilities_required,
+    toml_get_dependencies,
+    toml_get_name,
+    toml_get_workspace_members
+} from "./toml_parser";
 
 export {
     CapsuleSource,
@@ -92,6 +97,13 @@ struct CheckCapsuleResolution {
     asm_paths: string[];  // build/native/import-context/<slug>.sfn-asm
     capsule_count: number;  // post-dedupe count, for diagnostic output
     staging_failed: boolean;  // true on slug collision or stage-write failure
+    // Phase F (`docs/proposals/effect-validation.md` §5): the
+    // project manifest's `[capabilities] required = [...]`. Empty
+    // when no manifest is present (standalone .sfn files outside
+    // any capsule). The effect-checker treats empty as "skip
+    // capability cross-check"; non-empty as "fail E0403 on any
+    // function declaring an effect outside this surface."
+    capabilities_required: string[];
 }
 
 // Result of a test-mode resolver pass: same workspace + manifest +
@@ -107,6 +119,12 @@ struct TestCapsuleResolution {
     ll_paths: string[];  // build/sailfin/capsules/<mangled-slug>.ll
     capsule_count: number;  // post-dedupe count, for diagnostic output
     staging_failed: boolean;  // true on slug collision, stage-write, or compile failure
+    // Phase F: same `[capabilities] required` surfacing as
+    // `CheckCapsuleResolution`. The test runner threads this into
+    // `compile_tests_to_llvm_file_with_module_imports` so a test
+    // body declaring an effect the capsule manifest doesn't grant
+    // produces an `E0403` diagnostic.
+    capabilities_required: string[];
 }
 
 // ---- Path helpers ----
@@ -1471,6 +1489,13 @@ fn _cr_dep_specs_from_text(deps_text: string) -> string[] {
 struct ResolverDedupeResult {
     sources: CapsuleSource[];
     has_collision: boolean;
+    // Phase F (`docs/proposals/effect-validation.md` §5): the
+    // project manifest's `[capabilities] required = [...]` list.
+    // Empty when no manifest is present (standalone .sfn files
+    // outside any capsule) — the effect-checker treats that as
+    // "no capability surface to compare against" and skips the
+    // E0403 cross-check.
+    capabilities_required: string[];
 }
 
 // Shared resolution + dedupe used by both `prepare_project_capsules`
@@ -1503,10 +1528,12 @@ fn _cr_resolve_and_dedupe(entry_paths: string[]) -> ResolverDedupeResult ![io] {
     let mut sources: CapsuleSource[] = [];
     let empty_sources: CapsuleSource[] = [];
 
+    let mut empty_caps: string[] = [];
     if entry_paths.length == 0 {
         return ResolverDedupeResult {
             sources: empty_sources,
-            has_collision: false
+            has_collision: false,
+            capabilities_required: empty_caps
         };
     }
 
@@ -1536,12 +1563,20 @@ fn _cr_resolve_and_dedupe(entry_paths: string[]) -> ResolverDedupeResult ![io] {
 
     let project_root = discover_project_root(anchor_dir);
     let mut covered_specs: string[] = [];
+    let mut capabilities_required: string[] = [];
     if project_root.length > 0 {
         let manifest_path = _cr_path_join(project_root, "capsule.toml");
         if fs.exists(manifest_path) {
             let manifest_text = fs.readFile(manifest_path);
             let deps_text = toml_get_dependencies(manifest_text);
             covered_specs = _cr_dep_specs_from_text(deps_text);
+            // Phase F: extract `[capabilities] required = [...]` so
+            // the effect-checker can compare every function's
+            // declared effects against the manifest-allowed surface.
+            // Empty list (no [capabilities] section, or `required =
+            // []`) tells the checker to skip the cross-check —
+            // that's the right call for projects mid-migration.
+            capabilities_required = toml_get_capabilities_required(manifest_text);
         }
         let dep_sources = enumerate_capsule_sources(project_root);
         let mut di: number = 0;
@@ -1575,7 +1610,8 @@ fn _cr_resolve_and_dedupe(entry_paths: string[]) -> ResolverDedupeResult ![io] {
     if sources.length == 0 {
         return ResolverDedupeResult {
             sources: empty_sources,
-            has_collision: false
+            has_collision: false,
+            capabilities_required: capabilities_required
         };
     }
 
@@ -1606,7 +1642,8 @@ fn _cr_resolve_and_dedupe(entry_paths: string[]) -> ResolverDedupeResult ![io] {
                         + "\nrename one of the modules so each maps to a distinct slug.");
                     return ResolverDedupeResult {
                         sources: empty_sources,
-                        has_collision: true
+                        has_collision: true,
+                        capabilities_required: capabilities_required
                     };
                 }
                 // Same slug AND same path → exact duplicate, drop silently.
@@ -1623,7 +1660,11 @@ fn _cr_resolve_and_dedupe(entry_paths: string[]) -> ResolverDedupeResult ![io] {
         si += 1;
     }
 
-    return ResolverDedupeResult { sources: deduped, has_collision: false };
+    return ResolverDedupeResult {
+        sources: deduped,
+        has_collision: false,
+        capabilities_required: capabilities_required
+    };
 }
 
 // Resolve, stage, and compile every dependency reachable from
@@ -1673,18 +1714,26 @@ fn prepare_project_capsules(input_path: string) -> string[] ![io] {
 fn prepare_project_capsules_for_check(entry_paths: string[]) -> CheckCapsuleResolution ![io] {
     let empty_paths: string[] = [];
     let resolved = _cr_resolve_and_dedupe(entry_paths);
+    // Phase F: surface the manifest's capability surface even on
+    // the early-exit paths. A collision/stage failure shouldn't
+    // silently disable E0403 for a clean re-run; the failure modes
+    // here are about staging artifacts, not about manifest
+    // semantics. We pass through whatever `_cr_resolve_and_dedupe`
+    // already extracted from the manifest read.
     if resolved.has_collision {
         return CheckCapsuleResolution {
             asm_paths: empty_paths,
             capsule_count: 0,
-            staging_failed: true
+            staging_failed: true,
+            capabilities_required: resolved.capabilities_required
         };
     }
     if resolved.sources.length == 0 {
         return CheckCapsuleResolution {
             asm_paths: empty_paths,
             capsule_count: 0,
-            staging_failed: false
+            staging_failed: false,
+            capabilities_required: resolved.capabilities_required
         };
     }
 
@@ -1694,7 +1743,8 @@ fn prepare_project_capsules_for_check(entry_paths: string[]) -> CheckCapsuleReso
         return CheckCapsuleResolution {
             asm_paths: empty_paths,
             capsule_count: 0,
-            staging_failed: true
+            staging_failed: true,
+            capabilities_required: resolved.capabilities_required
         };
     }
 
@@ -1710,7 +1760,8 @@ fn prepare_project_capsules_for_check(entry_paths: string[]) -> CheckCapsuleReso
     return CheckCapsuleResolution {
         asm_paths: asm_paths,
         capsule_count: resolved.sources.length,
-        staging_failed: false
+        staging_failed: false,
+        capabilities_required: resolved.capabilities_required
     };
 }
 
@@ -1742,12 +1793,18 @@ fn prepare_project_capsules_for_check(entry_paths: string[]) -> CheckCapsuleReso
 fn prepare_project_capsules_for_test(entry_paths: string[]) -> TestCapsuleResolution ![io] {
     let empty_paths: string[] = [];
     let resolved = _cr_resolve_and_dedupe(entry_paths);
+    // Phase F: thread `capabilities_required` through every exit
+    // path. Same rationale as `prepare_project_capsules_for_check`:
+    // staging failures are setup-time concerns, not manifest
+    // semantics — the gate still needs to know the capability
+    // surface to render `E0403` correctly on a clean retry.
     if resolved.has_collision {
         return TestCapsuleResolution {
             asm_paths: empty_paths,
             ll_paths: empty_paths,
             capsule_count: 0,
-            staging_failed: true
+            staging_failed: true,
+            capabilities_required: resolved.capabilities_required
         };
     }
     if resolved.sources.length == 0 {
@@ -1755,7 +1812,8 @@ fn prepare_project_capsules_for_test(entry_paths: string[]) -> TestCapsuleResolu
             asm_paths: empty_paths,
             ll_paths: empty_paths,
             capsule_count: 0,
-            staging_failed: false
+            staging_failed: false,
+            capabilities_required: resolved.capabilities_required
         };
     }
 
@@ -1766,7 +1824,8 @@ fn prepare_project_capsules_for_test(entry_paths: string[]) -> TestCapsuleResolu
             asm_paths: empty_paths,
             ll_paths: empty_paths,
             capsule_count: 0,
-            staging_failed: true
+            staging_failed: true,
+            capabilities_required: resolved.capabilities_required
         };
     }
 
@@ -1790,7 +1849,8 @@ fn prepare_project_capsules_for_test(entry_paths: string[]) -> TestCapsuleResolu
             asm_paths: asm_paths,
             ll_paths: empty_paths,
             capsule_count: resolved.sources.length,
-            staging_failed: true
+            staging_failed: true,
+            capabilities_required: resolved.capabilities_required
         };
     }
 
@@ -1798,6 +1858,7 @@ fn prepare_project_capsules_for_test(entry_paths: string[]) -> TestCapsuleResolu
         asm_paths: asm_paths,
         ll_paths: ll_paths,
         capsule_count: resolved.sources.length,
-        staging_failed: false
+        staging_failed: false,
+        capabilities_required: resolved.capabilities_required
     };
 }

--- a/compiler/src/cli_check.sfn
+++ b/compiler/src/cli_check.sfn
@@ -49,6 +49,12 @@ struct CheckGroup {
     // `check_source_with_imports` so a caller missing
     // `![<callee_effect>]` produces an `E0402` diagnostic.
     function_effects: ImportSymbolTable;
+    // Phase F: capsule manifest's `[capabilities] required = [...]`
+    // surface, sourced from the same per-group resolver pass that
+    // populates `interfaces`. Threaded into
+    // `check_source_with_imports` so any function declaring an
+    // effect outside the surface produces an `E0403` diagnostic.
+    capabilities_required: string[];
 }
 
 fn _emit_check_header(path: string, quiet: boolean) ![io] {
@@ -200,8 +206,9 @@ fn handle_check_command(args: string[]) -> number ![io] {
         if idx < 0 {
             let empty_entries: string[] = [];
             let empty_interfaces: Statement[] = [];
+            let empty_caps: string[] = [];
             groups.push(CheckGroup {
-                key: key, entry_paths: empty_entries, interfaces: empty_interfaces, function_effects: empty_import_symbols()
+                key: key, entry_paths: empty_entries, interfaces: empty_interfaces, function_effects: empty_import_symbols(), capabilities_required: empty_caps
             });
             idx = groups.length - 1;
         }
@@ -234,6 +241,12 @@ fn handle_check_command(args: string[]) -> number ![io] {
         // the per-file analysis loop below can hand it to
         // `check_source_with_imports` alongside the interface list.
         groups[gi].function_effects = load.function_effects;
+        // Phase F: stash the capsule manifest's
+        // `[capabilities] required` surface from the resolver pass.
+        // The per-file loop hands it to `check_source_with_imports`
+        // so any function declaring an effect outside the surface
+        // produces an `E0403` diagnostic.
+        groups[gi].capabilities_required = resolution.capabilities_required;
 
         let mut mi: number = 0;
         loop {
@@ -264,7 +277,7 @@ fn handle_check_command(args: string[]) -> number ![io] {
         let path = files[fi];
         let group_idx = file_group_index[fi];
         let source = fs.readFile(path);
-        let result = check_source_with_imports(source, path, groups[group_idx].interfaces, groups[group_idx].function_effects);
+        let result = check_source_with_imports(source, path, groups[group_idx].interfaces, groups[group_idx].function_effects, groups[group_idx].capabilities_required);
         // Emit any diagnostic — error or warning — so contributors
         // running `sfn check` under Phase B (warning default) actually
         // see the effect-violation output. Pre-Phase-B effect

--- a/compiler/src/cli_commands.sfn
+++ b/compiler/src/cli_commands.sfn
@@ -302,6 +302,11 @@ struct TestGroup {
     // that calls an imported effectful helper without declaring the
     // effect produces an `E0402` diagnostic.
     function_effects: ImportSymbolTable;
+    // Phase F: capsule manifest's `[capabilities] required = [...]`
+    // surface, populated from the same per-group resolver pass. A
+    // test body declaring an effect outside this surface produces
+    // an `E0403` diagnostic.
+    capabilities_required: string[];
 }
 
 // Compute the resolution-group key for a test file path. Two files
@@ -373,8 +378,9 @@ fn handle_test_command(args: string[], runtime_root: string) -> number ![io] {
             let empty_interfaces: Statement[] = [];
             let empty_texts: string[] = [];
             let empty_lls: string[] = [];
+            let empty_caps: string[] = [];
             groups.push(TestGroup {
-                key: key, entry_paths: empty_entries, interfaces: empty_interfaces, native_texts: empty_texts, dep_ll_paths: empty_lls, function_effects: empty_import_symbols()
+                key: key, entry_paths: empty_entries, interfaces: empty_interfaces, native_texts: empty_texts, dep_ll_paths: empty_lls, function_effects: empty_import_symbols(), capabilities_required: empty_caps
             });
             idx = groups.length - 1;
         }
@@ -420,6 +426,11 @@ fn handle_test_command(args: string[], runtime_root: string) -> number ![io] {
         // `compile_tests_to_llvm_file_with_module_imports` alongside
         // the interface list.
         groups[gi].function_effects = load.function_effects;
+        // Phase F: stash the capsule manifest's
+        // `[capabilities] required` surface from the resolver pass
+        // so the per-test compile produces `E0403` for any test
+        // body declaring an effect outside the surface.
+        groups[gi].capabilities_required = resolution.capabilities_required;
         if trace_runner {
             print.err("test runner: resolver pass done (group="
                 + number_to_string(gi)
@@ -451,7 +462,7 @@ fn handle_test_command(args: string[], runtime_root: string) -> number ![io] {
         if trace_runner { print.err("test runner: compile start"); }
         _clean_lowering_state("build/sailfin");
         let empty_manifests: LayoutManifest[] = [];
-        let _compiled = compile_tests_to_llvm_file_with_module_imports(source, module_name, ll_path, groups[group_idx].interfaces, empty_manifests, groups[group_idx].native_texts, groups[group_idx].function_effects);
+        let _compiled = compile_tests_to_llvm_file_with_module_imports(source, module_name, ll_path, groups[group_idx].interfaces, empty_manifests, groups[group_idx].native_texts, groups[group_idx].function_effects, groups[group_idx].capabilities_required);
         if !_compiled {
             print("test runner: compile failed for " + path);
             fs.deleteFile(test_runner_active_path);

--- a/compiler/src/diagnostics_render.sfn
+++ b/compiler/src/diagnostics_render.sfn
@@ -31,7 +31,7 @@
 // and the seed compiler does not handle import cycles cleanly. The
 // duplication is small (~50 lines, four pure string helpers) and
 // changes here are decoupled from changes to `main.sfn`'s own copies.
-import { EffectRequirement, EffectViolation } from "./effect_checker";
+import { CapabilityViolation, EffectRequirement, EffectViolation } from "./effect_checker";
 import { substring } from "./string_utils";
 import { Token } from "./token";
 import { Diagnostic } from "./typecheck_types";
@@ -129,6 +129,72 @@ fn effect_violation_to_diagnostic(violation: EffectViolation) -> Diagnostic {
         file_path: "",
         primary: violation.trigger
     };
+}
+
+// Phase F: render a `CapabilityViolation` as an `E0403` diagnostic.
+// Distinct from the `EffectViolation` shape — the failure here is
+// "function declares an effect that the capsule manifest doesn't
+// grant", not "function is missing an effect its body uses". The
+// diagnostic includes:
+//
+//   - The header `function X declares effect ![Y] outside capsule
+//     capability surface ![A, B, ...]`.
+//   - A note line listing the capsule's full capability surface so
+//     the user can see at a glance what's allowed.
+//   - A two-pronged fix-it suggestion: either widen the manifest
+//     (add Y to `[capabilities] required`) or narrow the function
+//     (drop ![Y] from the signature).
+//
+// Severity threading mirrors `effect_violation_to_diagnostic`:
+// `SAILFIN_EFFECT_ENFORCE=warning` flips this to a warning, `=off`
+// silences it on the build path. `=error` (the post-Phase-D default)
+// fails the build.
+fn capability_violation_to_diagnostic(violation: CapabilityViolation) -> Diagnostic {
+    let excess_text = join_effects(violation.excess_effects);
+    let surface_text = join_effects(violation.capabilities_required);
+    let mut message = "function `" + violation.routine_name
+        + "` declares effect"
+        + _excess_plural_suffix(violation.excess_effects)
+        + " !["
+        + excess_text
+        + "] outside capsule capability surface !["
+        + surface_text
+        + "]";
+    message = message + "\nnote: capsule declares capabilities = !["
+        + surface_text
+        + "]";
+    if violation.excess_effects.length > 0 {
+        message = message + "\nsuggestion: add " + _quoted_effects_csv(violation.excess_effects)
+            + " to capsule.toml [capabilities] required, or remove !["
+            + excess_text
+            + "] from this function";
+    }
+    let mut sev = violation.severity;
+    if sev.length == 0 { sev = "error"; }
+    return Diagnostic {
+        code: "E0403",
+        severity: sev,
+        message: message,
+        file_path: "",
+        primary: violation.trigger
+    };
+}
+
+fn _excess_plural_suffix(excess: string[]) -> string {
+    if excess.length == 1 { return ""; }
+    return "s";
+}
+
+fn _quoted_effects_csv(effects: string[]) -> string {
+    if effects.length == 0 { return ""; }
+    let mut out = "\"" + effects[0] + "\"";
+    let mut i: number = 1;
+    loop {
+        if i >= effects.length { break; }
+        out = out + ", \"" + effects[i] + "\"";
+        i += 1;
+    }
+    return out;
 }
 
 // -------------------------------------------------------------------
@@ -325,6 +391,7 @@ fn render_diagnostic(d: Diagnostic, source_lines: string[], kind: string) -> str
 }
 
 export {
+    capability_violation_to_diagnostic,
     code_for_missing_effect,
     effect_violation_to_diagnostic,
     join_effects,

--- a/compiler/src/effect_checker.sfn
+++ b/compiler/src/effect_checker.sfn
@@ -85,6 +85,34 @@ struct EffectViolation {
     severity: string;
 }
 
+// Phase F (`docs/proposals/effect-validation.md` §5): a function
+// declared an effect outside the surrounding capsule's
+// `[capabilities] required = [...]` set. Distinct from
+// `EffectViolation` because the failure shape is different:
+//
+//   - `EffectViolation` = "function X is missing required effects ![…]"
+//     (the body uses an effectful operation that the signature doesn't
+//     declare).
+//   - `CapabilityViolation` = "function X declares effect ![Y] outside
+//     capsule capability surface" (the signature *does* declare the
+//     effect, but the capsule manifest doesn't grant it).
+//
+// Renderer (`diagnostics_render.capability_violation_to_diagnostic`)
+// emits diagnostic code `E0403` and a fix-it hint suggesting either
+// "add Y to capsule.toml [capabilities] required" or "remove ![Y]
+// from this function." Severity threading mirrors `EffectViolation`
+// — the gate flips it to "warning" / "off" via
+// `SAILFIN_EFFECT_ENFORCE` if the operator opts out of the strict
+// post-Phase-D default.
+struct CapabilityViolation {
+    routine_name: string;
+    excess_effects: string[];  // effects declared but outside the capability surface
+    capabilities_required: string[];  // the capsule's allowed surface (for the diagnostic note)
+    signature_token: Token?;
+    trigger: Token?;
+    severity: string;
+}
+
 // Build a Token from a SourceSpan + lexeme. The renderer in
 // `tools/check.sfn` reads `token.line`, `token.column`, and
 // `token.lexeme` (for the caret width). We synthesize an Identifier-
@@ -128,6 +156,104 @@ fn validate_effects_with_imports(program: Program, imports: ImportSymbolTable) -
         index += 1;
     }
     return violations;
+}
+
+// Phase F entry: cross-check every function's *declared* effects
+// against the capsule manifest's `[capabilities] required = [...]`
+// surface. Any effect on the function signature that isn't in the
+// surface produces a `CapabilityViolation`, rendered as `E0403`
+// downstream.
+//
+// Empty `capabilities_required` means "no manifest declared a
+// capability surface" (standalone .sfn outside any capsule, or a
+// manifest mid-migration). The checker treats that as "skip the
+// cross-check entirely" rather than "no capabilities allowed" —
+// otherwise every function would fail E0403, breaking every
+// project that hasn't opted into the new manifest contract yet.
+//
+// Capsules that opt in by listing `required = [...]` get the
+// strict check: a function declaring `![net]` inside a capsule
+// whose manifest lists only `["io"]` fails, with a fix-it hint
+// pointing at both the manifest entry and the function signature.
+fn validate_capsule_capabilities(program: Program, capabilities_required: string[]) -> CapabilityViolation[] {
+    let mut violations: CapabilityViolation[] = [];
+    if capabilities_required.length == 0 { return violations; }
+    let mut index: number = 0;
+    loop {
+        if index >= program.statements.length { break; }
+        violations = _append_capability_violations(violations, _analyze_statement_capabilities(program.statements[index], capabilities_required));
+        index += 1;
+    }
+    return violations;
+}
+
+fn _analyze_statement_capabilities(statement: Statement, capabilities: string[]) -> CapabilityViolation[] {
+    if statement.variant == "FunctionDeclaration" {
+        return _analyze_routine_capabilities(statement.signature, statement.signature.name, capabilities);
+    }
+    if statement.variant == "TestDeclaration" {
+        // Tests carry their own `effects` list (no full
+        // FunctionSignature), so synthesize a minimal one that
+        // `_analyze_routine_capabilities` can read. Mirrors the
+        // shape `analyze_statement` constructs for the
+        // missing-effect path.
+        let signature = FunctionSignature {
+            name: statement.name,
+            is_async: false,
+            parameters: [],
+            return_type: null,
+            effects: statement.effects,
+            type_parameters: [],
+            name_span: statement.name_span
+        };
+        let qualified = "test " + statement.name;
+        return _analyze_routine_capabilities(signature, qualified, capabilities);
+    }
+    if statement.variant == "StructDeclaration" {
+        let mut issues: CapabilityViolation[] = [];
+        let mut method_index: number = 0;
+        loop {
+            if method_index >= statement.methods.length { break; }
+            let method = statement.methods[method_index];
+            let qualified = statement.name + "." + method.signature.name;
+            issues = _append_capability_violations(issues, _analyze_routine_capabilities(method.signature, qualified, capabilities));
+            method_index += 1;
+        }
+        return issues;
+    }
+    return [];
+}
+
+fn _analyze_routine_capabilities(signature: FunctionSignature, name: string, capabilities: string[]) -> CapabilityViolation[] {
+    if signature.effects.length == 0 { return []; }
+    let mut excess: string[] = [];
+    let mut i: number = 0;
+    loop {
+        if i >= signature.effects.length { break; }
+        let effect = signature.effects[i];
+        if !contains_effect(capabilities, effect) {
+            excess = append_unique_effect(excess, effect);
+        }
+        i += 1;
+    }
+    if excess.length == 0 { return []; }
+    let sig_token = _token_from_signature(signature.name_span, signature.name);
+    let mut result: CapabilityViolation[] = [];
+    result.push(CapabilityViolation {
+        routine_name: name, excess_effects: excess, capabilities_required: capabilities, signature_token: sig_token, trigger: sig_token, severity: "error"
+    });
+    return result;
+}
+
+fn _append_capability_violations(violations: CapabilityViolation[], new_violations: CapabilityViolation[]) -> CapabilityViolation[] {
+    let mut result = violations;
+    let mut i: number = 0;
+    loop {
+        if i >= new_violations.length { break; }
+        result.push(new_violations[i]);
+        i += 1;
+    }
+    return result;
 }
 
 fn analyze_statement(statement: Statement, imports: ImportSymbolTable) -> EffectViolation[] {

--- a/compiler/src/effect_gate.sfn
+++ b/compiler/src/effect_gate.sfn
@@ -47,11 +47,17 @@
 // `/tmp/.sfn_*` file.
 import { Program } from "./ast";
 import {
+    capability_violation_to_diagnostic,
     effect_violation_to_diagnostic,
     render_diagnostic,
     split_source_lines
 } from "./diagnostics_render";
-import { EffectViolation, validate_effects_with_imports } from "./effect_checker";
+import {
+    CapabilityViolation,
+    EffectViolation,
+    validate_capsule_capabilities,
+    validate_effects_with_imports
+} from "./effect_checker";
 import { ImportSymbolTable } from "./effect_imports";
 import { sanitize_symbol, substring } from "./string_utils";
 import { Diagnostic } from "./typecheck_types";
@@ -149,6 +155,22 @@ fn read_effect_enforcement_env(unique_key: string) -> string ![io] {
 // refactor than Phase B should take. Phase E (cross-module
 // propagation) revisits the path-plumbing question.
 fn validate_and_render_effects(program: Program, source: string, file_path: string, imports: ImportSymbolTable) -> number ![io] {
+    let no_caps: string[] = [];
+    return validate_and_render_effects_with_capabilities(program, source, file_path, imports, no_caps);
+}
+
+// Phase F entry — accepts the project manifest's
+// `[capabilities] required = [...]` surface in addition to the Phase E
+// import table. Empty `capabilities_required` means "no capability
+// surface to compare against" (standalone .sfn outside any capsule);
+// the function then degrades to the Phase B/C/D/E behavior — only
+// in-module + cross-module effect validation runs.
+//
+// On a capsule with a non-empty surface, `validate_capsule_capabilities`
+// also runs, emitting `E0403` for any function declaring an effect
+// outside the manifest-allowed set. Both violation streams flow
+// through the same `SAILFIN_EFFECT_ENFORCE` severity contract.
+fn validate_and_render_effects_with_capabilities(program: Program, source: string, file_path: string, imports: ImportSymbolTable, capabilities_required: string[]) -> number ![io] {
     let raw = read_effect_enforcement_env(file_path);
     let severity = resolve_effect_enforcement(raw);
     if severity == "off" {
@@ -160,23 +182,17 @@ fn validate_and_render_effects(program: Program, source: string, file_path: stri
             + file_path);
         return 0;
     }
-    // Phase E: pass the per-build import symbol table so
-    // `validate_effects_with_imports` can localize it to this
-    // program's `Statement.ImportDeclaration` specifiers and resolve
-    // cross-module call sites. Empty-table callers (legacy
-    // `compile_to_sailfin`, `compile_to_llvm`) get the same
-    // in-module-only behavior they had pre-Phase-E.
-    let violations = validate_effects_with_imports(program, imports);
-    if violations.length == 0 { return 0; }
     let source_lines = split_source_lines(source);
     let mut errors: number = 0;
+
+    // Phase B/C/D/E: in-module + cross-module effect propagation.
+    // Empty-table callers (legacy `compile_to_sailfin`,
+    // `compile_to_llvm`) get the same in-module-only behavior they
+    // had pre-Phase-E.
+    let violations = validate_effects_with_imports(program, imports);
     let mut i: number = 0;
     loop {
         if i >= violations.length { break; }
-        // Mutate severity in place — the violation is a value-typed
-        // struct so the caller's collection is unaffected. Phase A
-        // hardcoded "error" at construction; Phase B overrides per
-        // the env-var contract.
         let mut v: EffectViolation = violations[i];
         v.severity = severity;
         let mut diag: Diagnostic = effect_violation_to_diagnostic(v);
@@ -186,11 +202,29 @@ fn validate_and_render_effects(program: Program, source: string, file_path: stri
         if severity == "error" { errors += 1; }
         i += 1;
     }
+
+    // Phase F: capsule capability cross-check. Skipped when no
+    // manifest provided a surface (empty `capabilities_required`).
+    let capability_violations = validate_capsule_capabilities(program, capabilities_required);
+    let mut k: number = 0;
+    loop {
+        if k >= capability_violations.length { break; }
+        let mut cv: CapabilityViolation = capability_violations[k];
+        cv.severity = severity;
+        let mut cdiag: Diagnostic = capability_violation_to_diagnostic(cv);
+        cdiag.file_path = file_path;
+        let rendered = render_diagnostic(cdiag, source_lines, "effect");
+        print.err(rendered);
+        if severity == "error" { errors += 1; }
+        k += 1;
+    }
+
     return errors;
 }
 
 export {
     read_effect_enforcement_env,
     resolve_effect_enforcement,
-    validate_and_render_effects
+    validate_and_render_effects,
+    validate_and_render_effects_with_capabilities
 };

--- a/compiler/src/main.sfn
+++ b/compiler/src/main.sfn
@@ -2,7 +2,10 @@
 //
 // Sailfin compiler main module and compilation entry points.
 import { Program, Statement } from "./ast";
-import { validate_and_render_effects } from "./effect_gate";
+import {
+    validate_and_render_effects,
+    validate_and_render_effects_with_capabilities
+} from "./effect_gate";
 import { ImportSymbolTable, empty_import_symbols } from "./effect_imports";
 import {
     NativeModule,
@@ -358,7 +361,7 @@ fn compile_to_llvm_with_module_timed(source: string, module_name: string) -> str
 // on the `Diagnostic` struct, so we filter for `severity == "error"`
 // before reporting and bailing. Warnings (e.g. future W01xx load
 // warnings) flow through without aborting the test compile.
-fn compile_tests_to_llvm_file_with_module_imports(source: string, module_name: string, out_path: string, imported_interfaces: Statement[], imported_manifests: LayoutManifest[], imported_native_texts: string[], imported_function_effects: ImportSymbolTable) -> boolean ![io] {
+fn compile_tests_to_llvm_file_with_module_imports(source: string, module_name: string, out_path: string, imported_interfaces: Statement[], imported_manifests: LayoutManifest[], imported_native_texts: string[], imported_function_effects: ImportSymbolTable, imported_capabilities_required: string[]) -> boolean ![io] {
     let trace_file = fs.exists("build/sailfin/.trace_test_runner");
     let active_file = fs.exists("build/sailfin/.test_runner_active");
     let mut _let_trace: boolean = false;
@@ -384,12 +387,12 @@ fn compile_tests_to_llvm_file_with_module_imports(source: string, module_name: s
         return false;
     }
     if _reject_reexport_violations(program) { return false; }
-    // Phase E: thread the resolver-built function-effect table so
-    // a test source that calls an imported `![net]` helper without
-    // declaring `![net]` produces an `E0402` diagnostic. Pre-Phase-E
-    // tests that only use in-module fns get an empty table from the
-    // caller and behave identically to before.
-    if validate_and_render_effects(program, source, module_name, imported_function_effects) > 0 {
+    // Phase E + F: thread the resolver-built function-effect table
+    // (E0402) and capsule capability surface (E0403). Empty
+    // capability list = standalone test outside any capsule = skip
+    // E0403 cross-check; the tests in `compiler/tests/unit/` run
+    // without a manifest in scope today and rely on this fallback.
+    if validate_and_render_effects_with_capabilities(program, source, module_name, imported_function_effects, imported_capabilities_required) > 0 {
         return false;
     }
     if trace {

--- a/compiler/src/toml_parser.sfn
+++ b/compiler/src/toml_parser.sfn
@@ -393,6 +393,36 @@ fn toml_get_string_array(text: string, section: string, key: string) -> string {
     return "";
 }
 
+// Phase F: read `[capabilities] required = [...]` from a capsule
+// manifest. Returns the parsed list of capability names as a real
+// `string[]` (not newline-joined like `toml_get_string_array`) so
+// downstream consumers can pass it straight into the effect-checker
+// `validate_capsule_capabilities` call without round-tripping
+// through `_split_lines`. An empty list means either:
+//   - the manifest declares `required = []` (no capabilities granted)
+//   - the manifest has no `[capabilities]` section at all
+//   - the input text isn't a capsule manifest (e.g. caller passed
+//     "" because the file wasn't on disk)
+// All three resolve to the same caller behaviour: skip the
+// capability cross-check, since there's no surface to compare
+// against. The effect-checker treats "no capabilities declared"
+// as "all capabilities allowed" — `compiler/capsule.toml` and the
+// stdlib capsules opt in by listing their required set explicitly.
+fn toml_get_capabilities_required(text: string) -> string[] {
+    let joined = toml_get_string_array(text, "capabilities", "required");
+    if joined.length == 0 { return []; }
+    let lines = _toml_split_lines(joined);
+    let mut out: string[] = [];
+    let mut i: number = 0;
+    loop {
+        if i >= lines.length { break; }
+        let trimmed = _toml_trim(lines[i]);
+        if trimmed.length > 0 { out.push(trimmed); }
+        i += 1;
+    }
+    return out;
+}
+
 // Read a string value at `[section] key = "value"`. Returns "" if absent.
 // Lets callers read ad-hoc config (e.g. ~/.sfn/config.toml) without the
 // manifest-shaped SailToml struct.

--- a/compiler/src/tools/check.sfn
+++ b/compiler/src/tools/check.sfn
@@ -22,11 +22,12 @@
 // See docs/proposals/check-architecture.md for the broader design.
 import { Statement } from "../ast";
 import {
+    capability_violation_to_diagnostic,
     effect_violation_to_diagnostic,
     render_diagnostic,
     split_source_lines
 } from "../diagnostics_render";
-import { validate_effects_with_imports } from "../effect_checker";
+import { validate_capsule_capabilities, validate_effects_with_imports } from "../effect_checker";
 import { read_effect_enforcement_env, resolve_effect_enforcement } from "../effect_gate";
 import { ImportSymbolTable, empty_import_symbols } from "../effect_imports";
 import { number_to_string } from "../main";
@@ -61,7 +62,8 @@ fn _is_sfn_file(path: string) -> boolean {
 
 fn check_source(source: string, file_path: string) -> CheckResult ![io] {
     let no_interfaces: Statement[] = [];
-    return check_source_with_imports(source, file_path, no_interfaces, empty_import_symbols());
+    let no_caps: string[] = [];
+    return check_source_with_imports(source, file_path, no_interfaces, empty_import_symbols(), no_caps);
 }
 
 // Cross-module-aware variant: `imported_interfaces` carries
@@ -76,10 +78,18 @@ fn check_source(source: string, file_path: string) -> CheckResult ![io] {
 // It is threaded into `validate_effects_with_imports` so a caller
 // missing `![<imported_callee_effect>]` produces an `E0402`
 // diagnostic alongside any in-module `E0400` / `E0401` findings.
-fn check_source_with_imports(source: string, file_path: string, imported_interfaces: Statement[], function_effects: ImportSymbolTable) -> CheckResult ![io] {
+//
+// Phase F: `capabilities_required` carries the project manifest's
+// `[capabilities] required = [...]` surface so `sfn check`
+// surfaces `E0403` for any function declaring an effect outside
+// the manifest-allowed set. Empty list = no manifest in scope =
+// skip the cross-check (standalone .sfn files outside any capsule
+// keep working unchanged).
+fn check_source_with_imports(source: string, file_path: string, imported_interfaces: Statement[], function_effects: ImportSymbolTable, capabilities_required: string[]) -> CheckResult ![io] {
     let program = parse_program(source);
     let type_diags = typecheck_diagnostics_with_imports(program, imported_interfaces);
     let effect_violations = validate_effects_with_imports(program, function_effects);
+    let capability_violations = validate_capsule_capabilities(program, capabilities_required);
 
     let source_lines = split_source_lines(source);
     let mut combined: Diagnostic[] = [];
@@ -134,6 +144,23 @@ fn check_source_with_imports(source: string, file_path: string, imported_interfa
         rendered.push(render_diagnostic(diag, source_lines, "effect"));
         if strings_equal(diag.severity, "error") { errors += 1; }
         ei += 1;
+    }
+
+    // Phase F: capsule capability cross-check renders alongside
+    // the in-module / cross-module effect findings. Same severity
+    // contract — `sfn check` ignores `=off` so these diagnostics
+    // still surface even when the build path is bypassed.
+    let mut ci: number = 0;
+    loop {
+        if ci >= capability_violations.length { break; }
+        let mut cv = capability_violations[ci];
+        cv.severity = effect_severity;
+        let mut cdiag = capability_violation_to_diagnostic(cv);
+        cdiag.file_path = file_path;
+        combined.push(cdiag);
+        rendered.push(render_diagnostic(cdiag, source_lines, "effect"));
+        if strings_equal(cdiag.severity, "error") { errors += 1; }
+        ci += 1;
     }
 
     return CheckResult {

--- a/compiler/tests/unit/effect_capabilities_test.sfn
+++ b/compiler/tests/unit/effect_capabilities_test.sfn
@@ -1,0 +1,271 @@
+// Unit tests for compiler/src/effect_checker.sfn's Phase F
+// (`docs/proposals/effect-validation.md` §5) capability cross-check
+// path: `validate_capsule_capabilities(program, capabilities) ->
+// CapabilityViolation[]`.
+//
+// Phase F flips the capsule manifest's
+// `[capabilities] required = [...]` into a real compile-time
+// contract: any function declaring an effect outside the manifest's
+// allowed surface fails with diagnostic code `E0403`. Empty
+// `capabilities_required` means "no manifest in scope" and the
+// checker degrades to a no-op so standalone .sfn files outside any
+// capsule keep working unchanged.
+//
+// Tests construct AST values via small helper functions to stay
+// flat — some seed compilers previously segfaulted on deeply nested
+// struct-literal initialisers in test bodies (see
+// `effect_checker_test.sfn` preamble for the same workaround).
+import {
+    Block,
+    Decorator,
+    FieldDeclaration,
+    FunctionSignature,
+    MethodDeclaration,
+    Program,
+    SourceSpan,
+    Statement,
+    TypeAnnotation,
+    TypeParameter
+} from "../../src/ast";
+import { CapabilityViolation, validate_capsule_capabilities } from "../../src/effect_checker";
+
+// -------------------------------------------------------------------
+// Builder helpers
+// -------------------------------------------------------------------
+fn _empty_block() -> Block {
+    return Block { tokens: [], text: "", statements: [] };
+}
+
+fn _span(line: number, column: number) -> SourceSpan {
+    return SourceSpan {
+        start_line: line,
+        start_column: column,
+        end_line: line,
+        end_column: column + 1
+    };
+}
+
+fn _signature(name: string, effects: string[], span: SourceSpan?) -> FunctionSignature {
+    return FunctionSignature {
+        name: name,
+        is_async: false,
+        parameters: [],
+        return_type: null,
+        effects: effects,
+        type_parameters: [],
+        name_span: span
+    };
+}
+
+// Build a `Statement.FunctionDeclaration` declaring the given
+// effects on its signature, with an empty body and no decorators.
+// Used to fixture the "function declares effects ![…]" half of the
+// capability cross-check.
+fn _function_declaring(name: string, effects: string[], span_line: number) -> Statement {
+    let mut empty_decorators: Decorator[] = [];
+    return Statement.FunctionDeclaration {
+        signature: _signature(name, effects, _span(span_line, 4)),
+        body: _empty_block(),
+        decorators: empty_decorators
+    };
+}
+
+// -------------------------------------------------------------------
+// Empty-capabilities short-circuit (no manifest in scope)
+// -------------------------------------------------------------------
+test "capabilities: empty list skips the check entirely" {
+    // Standalone .sfn outside any capsule: even with effectful
+    // function declarations, the empty capability surface signals
+    // "no manifest constraint to enforce" and produces zero
+    // violations. This is the contract that lets `sfn check` of a
+    // bare file path keep working pre-manifest.
+    let stmt = _function_declaring("dangerous", ["io", "net", "model"], 1);
+    let program = Program { statements: [stmt] };
+    let no_caps: string[] = [];
+    let violations = validate_capsule_capabilities(program, no_caps);
+    assert violations.length == 0;
+}
+
+test "capabilities: empty list skips the check even on an empty program" {
+    // The fast-path early-return for empty `capabilities_required`
+    // happens before the program walk; pin it so a refactor that
+    // moves the check inside the loop can't accidentally start
+    // emitting violations for bare modules.
+    let no_stmts: Statement[] = [];
+    let program = Program { statements: no_stmts };
+    let no_caps: string[] = [];
+    let violations = validate_capsule_capabilities(program, no_caps);
+    assert violations.length == 0;
+}
+
+// -------------------------------------------------------------------
+// In-bounds: declared effects ⊆ capabilities
+// -------------------------------------------------------------------
+test "capabilities: in-bounds function produces no violation" {
+    let stmt = _function_declaring("read_log", ["io"], 5);
+    let program = Program { statements: [stmt] };
+    let violations = validate_capsule_capabilities(program, ["io"]);
+    assert violations.length == 0;
+}
+
+test "capabilities: in-bounds with multiple effects passes" {
+    // `![io, clock]` ⊆ `["io", "clock", "rand"]` — the function
+    // doesn't have to use every capability the manifest grants.
+    let stmt = _function_declaring("with_timing", ["io", "clock"], 5);
+    let program = Program { statements: [stmt] };
+    let violations = validate_capsule_capabilities(program, ["io", "clock", "rand"]);
+    assert violations.length == 0;
+}
+
+test "capabilities: function with no declared effects passes regardless" {
+    // A pure function (no `![…]` clause) trivially satisfies any
+    // capability surface, including an empty one. Lock this so a
+    // refactor of `_analyze_routine_capabilities` doesn't trigger
+    // `E0403` on every undecorated function in a clean tree.
+    let stmt = _function_declaring("pure_helper", [], 5);
+    let program = Program { statements: [stmt] };
+    let violations = validate_capsule_capabilities(program, ["io"]);
+    assert violations.length == 0;
+}
+
+// -------------------------------------------------------------------
+// Out-of-bounds: declared effects ⊄ capabilities → E0403
+// -------------------------------------------------------------------
+test "capabilities: out-of-bounds function produces one violation per excess effect set" {
+    // Function declares `![net]`, capsule allows only `["io"]` —
+    // E0403 fires with `excess_effects = ["net"]`.
+    let stmt = _function_declaring("fetch_orders", ["net"], 7);
+    let program = Program { statements: [stmt] };
+    let violations = validate_capsule_capabilities(program, ["io"]);
+    assert violations.length == 1;
+    let v = violations[0];
+    assert v.routine_name == "fetch_orders";
+    assert v.excess_effects.length == 1;
+    assert v.excess_effects[0] == "net";
+    assert v.capabilities_required.length == 1;
+    assert v.capabilities_required[0] == "io";
+    assert v.severity == "error";
+}
+
+test "capabilities: violation carries signature_token from name_span" {
+    // The renderer points the diagnostic caret at the function
+    // name (Phase A's source-span attribution contract). Pin the
+    // span line/column propagation so a refactor that drops
+    // `name_span` doesn't silently regress the diagnostic to
+    // location-only rendering.
+    let stmt = _function_declaring("noisy", ["model"], 42);
+    let program = Program { statements: [stmt] };
+    let violations = validate_capsule_capabilities(program, ["io"]);
+    assert violations.length == 1;
+    let v = violations[0];
+    assert v.signature_token != null;
+    let tok = v.signature_token;
+    assert tok.line == 42;
+    assert tok.column == 4;
+    assert tok.lexeme == "noisy";
+}
+
+test "capabilities: mixed in-bounds + out-of-bounds collapses to excess only" {
+    // `![io, net]` against `["io"]` — `io` is allowed; `net` is
+    // not. The violation should report only `net` in
+    // `excess_effects`, not the full declared set. Otherwise a
+    // function declaring 5 effects with one out-of-bounds would
+    // produce a confusing "5 effects outside surface" diagnostic.
+    let stmt = _function_declaring("partial_overflow", ["io", "net"], 5);
+    let program = Program { statements: [stmt] };
+    let violations = validate_capsule_capabilities(program, ["io"]);
+    assert violations.length == 1;
+    let v = violations[0];
+    assert v.excess_effects.length == 1;
+    assert v.excess_effects[0] == "net";
+}
+
+test "capabilities: multiple out-of-bounds effects all surface" {
+    // `![net, model]` against `["io"]` — both `net` and `model`
+    // are excess. They should both appear in `excess_effects` so
+    // the user gets the full surface mismatch in one diagnostic.
+    let stmt = _function_declaring("very_dangerous", ["net", "model"], 5);
+    let program = Program { statements: [stmt] };
+    let violations = validate_capsule_capabilities(program, ["io"]);
+    assert violations.length == 1;
+    let v = violations[0];
+    assert v.excess_effects.length == 2;
+    assert v.excess_effects[0] == "net";
+    assert v.excess_effects[1] == "model";
+}
+
+// -------------------------------------------------------------------
+// TestDeclaration paths
+// -------------------------------------------------------------------
+test "capabilities: test declaration with out-of-bounds effect surfaces violation" {
+    // Tests carry their own `effects` slot (no FunctionSignature),
+    // and the checker has to synthesize a signature for them. Pin
+    // the propagation so a refactor of the TestDeclaration arm
+    // doesn't silently skip tests in the capability check.
+    let body_block = _empty_block();
+    let mut empty_decorators: Decorator[] = [];
+    let stmt = Statement.TestDeclaration {
+        name: "exercises network",
+        name_span: _span(11, 6),
+        body: body_block,
+        effects: ["net"],
+        decorators: empty_decorators
+    };
+    let program = Program { statements: [stmt] };
+    let violations = validate_capsule_capabilities(program, ["io"]);
+    assert violations.length == 1;
+    let v = violations[0];
+    assert v.routine_name == "test exercises network";
+    assert v.excess_effects[0] == "net";
+}
+
+// -------------------------------------------------------------------
+// StructDeclaration method paths
+// -------------------------------------------------------------------
+test "capabilities: struct method with out-of-bounds effect surfaces violation" {
+    // Methods are nested inside StructDeclaration; the checker has
+    // to walk into them. Without this path, a capsule could sneak
+    // an out-of-surface effect onto a method and bypass the
+    // capability check entirely.
+    let body_block = _empty_block();
+    let mut empty_decorators: Decorator[] = [];
+    let method = MethodDeclaration {
+        signature: _signature("send", ["net"], _span(8, 4)),
+        body: body_block,
+        decorators: empty_decorators
+    };
+    let mut empty_type_params: TypeParameter[] = [];
+    let mut empty_implements: TypeAnnotation[] = [];
+    let mut empty_fields: FieldDeclaration[] = [];
+    let mut struct_decorators: Decorator[] = [];
+    let stmt = Statement.StructDeclaration {
+        name: "Mailer",
+        name_span: null,
+        type_parameters: empty_type_params,
+        implements_types: empty_implements,
+        fields: empty_fields,
+        methods: [method],
+        decorators: struct_decorators
+    };
+    let program = Program { statements: [stmt] };
+    let violations = validate_capsule_capabilities(program, ["io"]);
+    assert violations.length == 1;
+    let v = violations[0];
+    assert v.routine_name == "Mailer.send";
+    assert v.excess_effects[0] == "net";
+}
+
+// -------------------------------------------------------------------
+// Aggregation across multiple statements
+// -------------------------------------------------------------------
+test "capabilities: multiple offending functions produce separate violations" {
+    let one = _function_declaring("a", ["net"], 1);
+    let two = _function_declaring("b", ["model"], 2);
+    let program = Program { statements: [one, two] };
+    let violations = validate_capsule_capabilities(program, ["io"]);
+    assert violations.length == 2;
+    assert violations[0].routine_name == "a";
+    assert violations[0].excess_effects[0] == "net";
+    assert violations[1].routine_name == "b";
+    assert violations[1].excess_effects[0] == "model";
+}

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,6 +1,6 @@
 # Status
 
-Updated: April 26, 2026 (effect validation Phase E — cross-module propagation)
+Updated: April 26, 2026 (effect validation Phase F — capability cross-check vs capsule.toml)
 
 This document tracks what works today and what is in progress. It is the source
 of truth — consult it before editing docs, examples, or making claims about
@@ -151,6 +151,34 @@ feature availability.
   entry's effects. E1 covers direct `Identifier` callees;
   `Member`-callee resolution (`mod.fn()`) and decorator-implied
   transitives are deferred to a follow-up Phase E2.
+- **Capsule capability cross-check (Phase F — shipped 2026-04-26).**
+  The capsule manifest's `[capabilities] required = [...]` list is
+  now a real compile-time contract. Any function declaring an
+  effect outside the manifest's allowed surface fails with
+  diagnostic code `E0403` ("declares effect ![X] outside capsule
+  capability surface ![A, B, ...]"). Empty surface (no
+  `[capabilities]` section, or standalone .sfn outside any capsule)
+  degrades the check to a no-op, so pre-Phase-F projects keep
+  building.
+
+  Plumbing: `toml_get_capabilities_required` parses the manifest;
+  `capsule_resolver.sfn` exposes `capabilities_required: string[]`
+  on `CheckCapsuleResolution` and `TestCapsuleResolution`;
+  `effect_checker.validate_capsule_capabilities` does the cross-
+  check; `diagnostics_render.capability_violation_to_diagnostic`
+  emits the diagnostic with a fix-it hint suggesting either widening
+  the manifest or narrowing the function. `effect_gate.sfn` exposes
+  `validate_and_render_effects_with_capabilities` so build-path
+  callers (`compile_tests_to_llvm_file_with_module_imports`) and
+  the `sfn check` path render E0400/E0401/E0402/E0403 through the
+  same severity contract.
+
+  Audit: `compiler/capsule.toml` widened from `["io"]` to
+  `["io", "clock"]` so `compile_to_llvm_with_module_timed`'s
+  `![io, clock]` declaration (used by `sfn emit llvm --timing`)
+  fits the surface. All `capsules/sfn/*/capsule.toml` manifests
+  were already correct against their declared effects — no
+  changes needed.
 - Experimental LLVM JIT execution is available for targeted backend coverage.
 - CI uses the native build workflow (`.github/workflows/ci.yml`) to build, test,
   and attach release assets.
@@ -181,7 +209,8 @@ feature availability.
 | Effect enforcement — `clock` | **Enforced** | Checker detects `sleep` / `runtime.sleep`; build fails on undeclared usage by default |
 | Effect enforcement — `gpu`, `rand` | Parsed only | Reserved at 1.0 in the canonical taxonomy; no detector logic yet |
 | Effect enforcement as compilation gate | **Shipped (Phase D, 2026-04-26)** | `validate_and_render_effects` runs after typecheck in every `compile_to_*` entry; default severity is `error` so undeclared effects fail the build. `SAILFIN_EFFECT_ENFORCE=warning` opt-in for capsule authors mid-migration; `=off` build-path escape hatch (proposal §4.7) |
-| Cross-module effect propagation | **Shipped (Phase E, 2026-04-26)** | A caller of an imported function inherits the callee's declared effects; missing propagation fails the build with `E0402`. Aliased imports (`import { foo as bar }`) resolve under the local name. E1 covers direct `Identifier` calls; `Member`-callee resolution and decorator-implied transitives deferred to Phase E2. Phase F (capsule.toml capability cross-check) is next |
+| Cross-module effect propagation | **Shipped (Phase E, 2026-04-26)** | A caller of an imported function inherits the callee's declared effects; missing propagation fails the build with `E0402`. Aliased imports (`import { foo as bar }`) resolve under the local name. E1 covers direct `Identifier` calls; `Member`-callee resolution and decorator-implied transitives deferred to Phase E2 |
+| Capsule capability cross-check | **Shipped (Phase F, 2026-04-26)** | `[capabilities] required = [...]` in `capsule.toml` is a real compile-time contract; functions declaring an effect outside the surface fail with `E0403`. Empty surface skips the check (standalone .sfn unchanged). Phase G (post-1.0) replaces the text-pattern checker with name-resolution detection and adds effect polymorphism |
 | Generic type inference | Partial | Type params captured; inference coverage is limited |
 | Interface conformance validation | Partial | Basic checks; variance not yet enforced |
 | `Affine<T>` / `Linear<T>` | Parsed only | Ownership wrappers accepted; move/consume rules not enforced |

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # Sailfin Language Reference for LLMs
 
-> Version: 0.5.9 | Updated: 2026-04-26 (Phase E)
+> Version: 0.5.9 | Updated: 2026-04-26 (Phase F)
 > Source: https://github.com/SailfinIO/sailfin | Site: https://sailfin.dev
 
 Sailfin is a compiled systems language with compile-time capability enforcement
@@ -22,6 +22,13 @@ calls it, A must declare every effect B declares (diagnostic code
 `E0402`). Aliased imports (`import { foo as bar }`) resolve under the
 local name. `Member`-callee resolution (`mod.fn()`) is a follow-up
 (Phase E2 in `docs/proposals/effect-validation.md`).
+
+Capsule manifests are a compile-time contract: every function's
+declared effects must be a subset of the capsule's
+`[capabilities] required = [...]` surface (diagnostic code `E0403`).
+A function declaring `![net]` inside a capsule that lists only
+`["io"]` fails the build. Empty surface (no `[capabilities]`
+section, or standalone .sfn outside any capsule) skips the check.
 
     fn read_config(path: string) -> string ![io] {
         return fs.readFile(path);

--- a/site/src/content/docs/docs/reference/spec/07-effects.md
+++ b/site/src/content/docs/docs/reference/spec/07-effects.md
@@ -31,5 +31,6 @@ fn analyze(text: string) ![io, model] { }      // multiple effects
 2. Enforcement runs on every build path (`make compile`, `sfn build`, `sfn run`, `sfn test`, `sfn check`); the `SAILFIN_EFFECT_ENFORCE` env var lets capsule authors opt into `=warning` (telemetry-only) or `=off` (build-path bypass; `sfn check` still validates)
 3. Tests follow the same rules as functions
 4. **Cross-module call-graph propagation** (Phase E, shipped): if A imports B and calls it, A must declare every effect B declares. Diagnostic code `E0402`. Aliased imports (`import { foo as bar }`) resolve under the local name. `Member`-callee resolution (`mod.fn()`) is a Phase E2 follow-up
+5. **Capsule capability cross-check** (Phase F, shipped): every function's declared effects must be a subset of the capsule manifest's `[capabilities] required = [...]` surface. Diagnostic code `E0403`. Empty surface (no `[capabilities]` section, or standalone .sfn outside any capsule) skips the cross-check so pre-Phase-F projects keep building
 
 See [Effect System Reference](/docs/reference/effects) for the complete API surface per effect.


### PR DESCRIPTION
Closes Phase F of `docs/proposals/effect-validation.md` §5. The
capsule manifest's `[capabilities] required = [...]` list is now a
real compile-time contract: every function's declared effects must
be a subset of the capsule-allowed surface, and any out-of-bounds
declaration fails the build with diagnostic code `E0403`.

Architecture
============

`toml_parser.sfn`
- New `toml_get_capabilities_required(text) -> string[]` returning
  the parsed `[capabilities] required` list as a real `string[]`
  (vs the newline-joined shape `toml_get_string_array` returns) so
  downstream consumers pass it straight into the checker without
  splitting.

`capsule_resolver.sfn`
- `ResolverDedupeResult`, `CheckCapsuleResolution`, and
  `TestCapsuleResolution` gain a `capabilities_required: string[]`
  field. Populated from `toml_get_capabilities_required(manifest_text)`
  inside `_cr_resolve_and_dedupe` — same single-read pass that
  already extracts dependencies. All four early-exit branches
  (empty entries, slug collision, sources empty, stage failure)
  also propagate the field so a clean retry sees the surface even
  when the prior pass tripped on staging.

`effect_checker.sfn`
- New `CapabilityViolation` struct distinct from `EffectViolation`
  — the failure shape differs (declared effect outside the surface
  vs missing effect the body uses).
- New `validate_capsule_capabilities(program, capabilities) ->
  CapabilityViolation[]` walks every function/method/test and
  emits one violation per offending routine carrying the full set
  of excess effects.
- Empty `capabilities_required` short-circuits to `[]` so
  standalone .sfn outside any capsule keeps working unchanged.
- Test declarations propagate via a synthesized `FunctionSignature`
  matching the existing `analyze_statement` pattern.

`diagnostics_render.sfn`
- New `capability_violation_to_diagnostic(violation) -> Diagnostic`
  emitting code `E0403` with the message "function X declares
  effect ![Y] outside capsule capability surface ![A, B, ...]",
  a `note: capsule declares capabilities = ![…]` line, and a
  two-pronged fix-it suggestion (widen the manifest or narrow the
  function).
- Plural-aware ("declares effect ![X]" vs "declares effects ![X, Y]").
- Severity threading mirrors `EffectViolation` — `SAILFIN_EFFECT_ENFORCE`
  still governs.

`effect_gate.sfn`
- New `validate_and_render_effects_with_capabilities(program,
  source, file_path, imports, capabilities_required)` runs both
  the in-module/cross-module effect check and the capability
  cross-check in one pass, sharing the source-line split. Legacy
  `validate_and_render_effects(...)` kept as a one-liner that
  passes `[]` for the capabilities, so non-resolver entrypoints
  in `main.sfn` (`compile_to_sailfin`, `compile_to_llvm`, etc.)
  stay source-compatible.

`tools/check.sfn`
- `check_source_with_imports(source, file_path, imported_interfaces,
  function_effects, capabilities_required)` adds the parameter and
  renders capability violations alongside effect violations through
  the same severity contract. `sfn check` ignores `=off` for both
  E0403 and the existing E0400/E0401/E0402 (proposal §4.7).

Wiring
======

`cli_check.sfn`
- `CheckGroup.capabilities_required: string[]` populated from the
  per-group resolver pass; threaded into
  `check_source_with_imports`. So `sfn check capsuleA/foo.sfn
  capsuleB/bar.sfn` resolves each capsule's surface independently.

`cli_commands.sfn`
- `TestGroup.capabilities_required: string[]` populated from the
  same per-group resolver pass; threaded into
  `compile_tests_to_llvm_file_with_module_imports`.

`main.sfn`
- `compile_tests_to_llvm_file_with_module_imports` gains an
  `imported_capabilities_required: string[]` parameter and calls
  `validate_and_render_effects_with_capabilities` instead of the
  legacy variant. Other `compile_to_*` entries (no resolver in
  scope) stay on the legacy variant; the build-path coverage
  follow-up is tracked in the proposal as a Phase F2 item.

Manifest audit
==============

`compiler/capsule.toml` widened from `required = ["io"]` to
`required = ["io", "clock"]`. The compiler tree only ever declares
`![io]` and `![io, clock]` — the latter on
`compile_to_llvm_with_module_timed` (the `--timing` mode that wraps
the lower pipeline with `monotonic_millis()`). Every other function
sits inside `["io"]`.

`capsules/sfn/*/capsule.toml` were already correct against their
declared effects (audited via `grep -Eho '!\\[[^]]*\\]' …`).
Mapping (verified):

  cli       required=["io"]              declares ![io]
  fs        required=["io"]              declares ![io]
  http      required=["io","net"]        declares ![io, net], ![net]
  log       required=["io","clock"]      declares ![io, clock], ![io]
  net       required=["net","io"]        declares ![net, io], ![net]
  os        required=["io"]              declares ![io]
  sync      required=["io"]              declares ![io]
  test      required=["io"]              declares ![io]
  time      required=["clock"]           declares ![clock]

Pure capsules (crypto, fmt, json, losses, math, path, prelude,
toml) declare no effects and pass trivially. The `gpu` reservation
on layers/nn/tensor manifests is forward-compatibility — those
capsules don't declare any effects yet, so the surface is wider
than declared and the check is a no-op.

Tests
=====

New `compiler/tests/unit/effect_capabilities_test.sfn` (12 tests):
- Empty-capabilities short-circuit (skips check on standalone .sfn).
- In-bounds: declared ⊆ allowed produces no violation.
- Out-of-bounds: single excess, partial overflow (mixed), multiple
  excess all surface in one violation.
- Token plumbing: signature_token carries the function name span
  for caret rendering.
- Test declarations + struct methods both walked correctly.
- Aggregation across multiple functions produces independent
  violations.

Verified
========

- `make rebuild` succeeds in 265s under strict default — the
  compiler self-hosts cleanly with `["io", "clock"]` as its
  declared capability surface.
- 72 unit + 17 integration + 11 e2e = 100/100 tests pass.
- End-to-end fixture: `sfn check` of a manifest declaring only
  `["io"]` against a function declaring `![net]` emits the full
  `E0403` diagnostic (header + caret + note + fix-it suggestion)
  and exits 1. In-bounds variant exits 0 with no diagnostic.

Out of scope (deferred)
=======================

- Build-path E0403 coverage: `compile_to_*` entries without a
  resolver in scope (`sfn emit llvm` direct invocations, the seed
  bootstrap path) currently skip the capability check. The
  unified-resolver paths (`sfn check`, `sfn build`, `sfn run`,
  `sfn test`) all enforce E0403. A follow-up can add per-worker
  manifest discovery if needed.
- Phase G (post-1.0): name-resolution-driven detection replacing
  the text-pattern checker, plus effect polymorphism for higher-
  order functions.

https://claude.ai/code/session_0157FJzrK3YtAjEKcoJ8xBhs