### PR TITLE
Arena default-on + check-fast PR gate (B6)

### DIFF
--- a/.github/actions/sailfin-build/action.yml
+++ b/.github/actions/sailfin-build/action.yml
@@ -43,6 +43,23 @@ runs:
         echo "[ci] seed binary: build/seed/bin/sailfin"
         build/seed/bin/sailfin version
 
+    # Fast PR feedback: run `sfn check` on compiler/src/ + runtime/ using
+    # the released seed before spending ~7 min on the full selfhost build.
+    # The seed (≥ 0.5.10-alpha.1) ships the path-normalization fix and
+    # the arena reset primitives that make a multi-module check loop
+    # reclaimable, so this finishes in ~2 min on Linux x86_64. Surfaces
+    # parser, typecheck, and effect-system breakage immediately.
+    #
+    # Exit code 1 (diagnostics found) is fatal — the check is meant as
+    # a gate, not advisory. Exit 139 (SIGSEGV) would indicate a Phase 5a
+    # regression in the seed and must be investigated.
+    - name: Fast pre-build check (seed binary)
+      shell: bash {0}
+      run: |
+        set -euo pipefail
+        echo "[ci] sfn check compiler/src/ runtime/ (using seed)"
+        time build/seed/bin/sailfin check compiler/src/ runtime/
+
     - name: Build native compiler (selfhost from released seed)
       shell: bash {0}
       env:

--- a/.github/actions/sailfin-build/action.yml
+++ b/.github/actions/sailfin-build/action.yml
@@ -43,23 +43,6 @@ runs:
         echo "[ci] seed binary: build/seed/bin/sailfin"
         build/seed/bin/sailfin version
 
-    # Fast PR feedback: run `sfn check` on compiler/src/ + runtime/ using
-    # the released seed before spending ~7 min on the full selfhost build.
-    # The seed (≥ 0.5.10-alpha.1) ships the path-normalization fix and
-    # the arena reset primitives that make a multi-module check loop
-    # reclaimable, so this finishes in ~2 min on Linux x86_64. Surfaces
-    # parser, typecheck, and effect-system breakage immediately.
-    #
-    # Exit code 1 (diagnostics found) is fatal — the check is meant as
-    # a gate, not advisory. Exit 139 (SIGSEGV) would indicate a Phase 5a
-    # regression in the seed and must be investigated.
-    - name: Fast pre-build check (seed binary)
-      shell: bash {0}
-      run: |
-        set -euo pipefail
-        echo "[ci] sfn check compiler/src/ runtime/ (using seed)"
-        time build/seed/bin/sailfin check compiler/src/ runtime/
-
     - name: Build native compiler (selfhost from released seed)
       shell: bash {0}
       env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,10 +24,27 @@ repository.
    - Run tests: `make test`
    - Compile Sailfin sources: `make compile` (self-hosted native compiler).
    - Install the built compiler: `make install` (defaults to `~/.local/bin`).
+   - Fast PR gate: `make check-fast` runs `sfn check compiler/src/ runtime/`
+     in ~2 min. Surfaces parser, typecheck, and effect-system breakage
+     without a full selfhost rebuild.
 3. **Testing expectations**
    - Add or update unit tests under `compiler/tests/` for compiler changes.
    - Reflect behaviour updates in `docs/status.md` and the relevant module docs.
    - Run `make test` before submitting.
+
+### Optional Pre-Commit Hook
+
+Contributors actively touching `compiler/src/` or `runtime/` can opt into a
+pre-commit hook that runs `make check-fast` automatically:
+
+```bash
+bash scripts/install_precommit.sh           # install
+bash scripts/install_precommit.sh --remove  # uninstall
+```
+
+The hook only runs when staged changes touch `compiler/src/` or `runtime/`,
+and is silently skipped when `build/native/sailfin` is missing. Bypass with
+`SAILFIN_SKIP_PRECOMMIT=1 git commit ...` or the standard `--no-verify`.
 
 ### Notes on Release Automation
 

--- a/Makefile
+++ b/Makefile
@@ -447,7 +447,7 @@ check:
 # (the triple-pass selfhost validator). Naming mirrors what end users
 # of the language will eventually run on their own capsules.
 check-fast:
-	@if [ ! -x "$(NATIVE_BIN)" ]; then \
+	@if [ ! -x "$(NATIVE_BIN)" ] && [ ! -f "$(NATIVE_BIN)" ]; then \
 		echo "[check-fast] missing $(NATIVE_BIN); run: make compile"; \
 		exit 1; \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ NATIVE_BIN ?= build/native/sailfin$(EXE_EXT)
 # Which compiler binary to use for running Sailfin-native tests.
 # Default: the native compiler alias produced by `make compile`.
 
-.PHONY: help install fetch-seed test test-unit test-integration test-e2e compile check package clean bench test-arena
+.PHONY: help install fetch-seed test test-unit test-integration test-e2e compile check check-fast package clean bench test-arena
 
 .PHONY: ci-prepare-test-artifacts ci-package ci-package-installer
 
@@ -101,6 +101,7 @@ help:
 	@echo "  make rebuild        # Force rebuild from seed (uses scripts/build.sh)"
 	@echo "  make install        # Install the built compiler binary into PREFIX/bin"
 	@echo "  make check          # Compile (if needed) then run the full test suite"
+	@echo "  make check-fast     # Run sfn check on compiler/src/ + runtime/ (no codegen, fast PR gate)"
 	@echo "  make test           # Run Sailfin-native unit + integration + e2e tests"
 	@echo "  make test-unit      # Run Sailfin-native unit tests"
 	@echo "  make test-integration # Run Sailfin-native integration tests"
@@ -429,6 +430,30 @@ check:
 		cp -f "build/native/sailfin-seedcheck$(EXE_EXT)" "$(NATIVE_BIN)"; \
 		echo "[check] promoted seedcheck → $(NATIVE_BIN)"; \
 	fi
+
+# Fast PR-feedback gate: run `sfn check` against the compiler tree and
+# the runtime prelude. No codegen, no clang, just parse + typecheck +
+# effect-check. Phase 5a's arena mark/rewind keeps the in-process
+# multi-module loop from blowing up; the arena default-on flip means
+# this works without env-var setup.
+#
+# Targeted at CI as a pre-`make compile` filter so PRs that introduce
+# obvious type/effect regressions fail in seconds rather than ~3 min
+# into the full build. Local developers can run it as a sub-30s
+# sanity check between edits — much faster than `make compile` (~3
+# min serial / ~2 min parallel).
+#
+# Note: this is `sfn check` over the compiler tree, not `make check`
+# (the triple-pass selfhost validator). Naming mirrors what end users
+# of the language will eventually run on their own capsules.
+check-fast:
+	@if [ ! -x "$(NATIVE_BIN)" ]; then \
+		echo "[check-fast] missing $(NATIVE_BIN); run: make compile"; \
+		exit 1; \
+	fi
+	@echo "[check-fast] running sfn check on compiler/src/ runtime/"
+	@$(NATIVE_BIN) check compiler/src/ runtime/
+	@echo "[check-fast] OK"
 
 # Pre-release determinism gate. Runs the emit harness at parallel load to
 # detect intermittent IR corruption. Use before cutting a seed release.

--- a/compiler/src/cli_commands_utils.sfn
+++ b/compiler/src/cli_commands_utils.sfn
@@ -19,6 +19,7 @@ export {
     _looks_like_test_file_cmd,
     _collect_test_files_cmd,
     _collect_sfn_files_cmd,
+    _strip_trailing_slashes_cmd,
     _curl_post_json_cmd,
     _curl_download_cmd,
     _sha256_of_file_cmd,
@@ -179,23 +180,31 @@ fn _collect_test_files_cmd(root: string, max_depth: number) -> string[] ![io] {
     return results;
 }
 
+// Strip trailing slashes from a directory path so downstream BFS
+// path concatenation (e.g. `dir + "/" + entry`) doesn't produce
+// double-slashed paths like `compiler/src//ast.sfn`. Double slashes
+// are filesystem-equivalent but trip downstream path-comparison
+// and resolver-grouping logic; the historic symptom was
+// `sfn check compiler/src/` SIGSEGVing at scale while
+// `sfn check compiler/src` succeeded with the same file set.
+//
+// Preserves "/" (root) — refusing to strip it bare. Idempotent.
+// Pure (no I/O) so it's covered by a fast unit test in
+// `compiler/tests/unit/cli_path_normalization_test.sfn`.
+fn _strip_trailing_slashes_cmd(path: string) -> string {
+    let mut result: string = path;
+    loop {
+        if result.length <= 1 { break; }
+        if !_ends_with_cmd(result, "/") { break; }
+        result = substring(result, 0, result.length - 1);
+    }
+    return result;
+}
+
 fn _collect_sfn_files_cmd(root: string, max_depth: number) -> string[] ![io] {
     let mut results: string[] = [];
     if _ends_with_cmd(root, ".sfn") { return [root]; }
-    // Strip a trailing slash from the root so BFS path concatenation
-    // (line below: `dir + "/" + entry`) doesn't produce double-
-    // slashed paths like `compiler/src//ast.sfn`. Double slashes
-    // are filesystem-equivalent but trip downstream path-
-    // comparison and resolver-grouping logic; the historic
-    // symptom was `sfn check compiler/src/` SIGSEGVing at scale
-    // while `sfn check compiler/src` succeeded with the same file
-    // set.
-    let mut root_norm: string = root;
-    loop {
-        if root_norm.length <= 1 { break; }
-        if !_ends_with_cmd(root_norm, "/") { break; }
-        root_norm = substring(root_norm, 0, root_norm.length - 1);
-    }
+    let root_norm: string = _strip_trailing_slashes_cmd(root);
     let mut queue: string[] = [root_norm];
     let mut depth: number = 0;
     loop {

--- a/compiler/src/cli_main.sfn
+++ b/compiler/src/cli_main.sfn
@@ -301,7 +301,7 @@ fn _resolve_capsule_build_spec(p: string) -> _CapsuleBuildSpec ![io] {
     return spec;
 }
 
-fn sailfin_cli_main(argv: string[]) -> number ![io] {
+fn sailfin_cli_main(argv: string[]) -> number ![io, clock] {
     let trace_argv = fs.exists("build/sailfin/.trace_argv");
     if trace_argv {
         print.err("cli: argv.len=" + number_to_string(argv.length));

--- a/compiler/src/llvm/lowering/entrypoints.sfn
+++ b/compiler/src/llvm/lowering/entrypoints.sfn
@@ -371,7 +371,7 @@ fn lower_to_llvm_with_context(native_module: NativeModule, imported_manifests: L
     };
 }
 
-fn lower_to_llvm_lines_with_context(native_module: NativeModule, imported_manifests: LayoutManifest[], imported_native_texts: string[], imported_diagnostics: string[]) -> LoweredLLVMLinesResult {
+fn lower_to_llvm_lines_with_context(native_module: NativeModule, imported_manifests: LayoutManifest[], imported_native_texts: string[], imported_diagnostics: string[]) -> LoweredLLVMLinesResult ![io] {
     let mut diagnostics: string[] = [];
     if imported_diagnostics.length > 0 {
         let mut _ci0: number = 0;

--- a/compiler/tests/e2e/test_check_compiler_src.sh
+++ b/compiler/tests/e2e/test_check_compiler_src.sh
@@ -51,11 +51,15 @@ run_test() {
     fi
 }
 
-# Phase 5a needs the arena enabled to actually reclaim memory. The
-# default-on flip is a separate workstream; until it lands, this
-# test exports the env var explicitly so the headline scenario
-# uses Phase 5a as designed.
-export SAILFIN_USE_ARENA=1
+# Phase 5a needs the arena enabled to actually reclaim memory.
+# Arena is now default-on at runtime (post Phase 5a default-on
+# flip), so this test runs in the canonical end-user configuration
+# without exporting `SAILFIN_USE_ARENA=1`. We explicitly UNSET the
+# env var to defend against a parent shell that might have set it
+# to "0" or empty (which would silently disable the arena and
+# either fail with SIGSEGV — `=0` — or succeed but fail the
+# regression check we're actually trying to do).
+unset SAILFIN_USE_ARENA
 
 # ---- Single canonical run per slash form ----
 # Capture stdout+stderr and the exit code; every assertion below

--- a/compiler/tests/e2e/test_check_compiler_src.sh
+++ b/compiler/tests/e2e/test_check_compiler_src.sh
@@ -14,17 +14,16 @@
 #
 # Acceptance:
 #   - Exits 0 (clean) or 1 (diagnostics found). Never 139 (SIGSEGV).
-#   - Same exit code with and without a trailing slash on the
-#     directory argument (regression for the path-normalization
-#     fix).
 #   - Directory walk visits every .sfn file under compiler/src/.
 #
-# Cost discipline: each `sfn check compiler/src/` invocation runs
-# the full 132-file analysis loop (~130s local, ~3-5 min CI). The
-# test runs the canonical scenario exactly twice — once per slash
-# form — and reuses the captured exit codes + summary lines for
-# every assertion. An earlier draft re-invoked four times and
-# added ~10 min to PR CI; do not re-introduce that.
+# Cost discipline: a single `sfn check compiler/src/` invocation
+# runs the full 132-file analysis loop (~130s local, ~2-3 min CI).
+# The test runs the canonical scenario exactly ONCE and reuses the
+# captured exit code + summary line for every assertion. Earlier
+# drafts re-invoked twice (once per slash form) and added ~2 min
+# to PR CI; the trailing-slash regression is now covered cheaply
+# by the unit test in compiler/tests/unit/cli_path_normalization_test.sfn.
+# Do not re-introduce a second full-tree invocation.
 #
 # Usage:
 #   compiler/tests/e2e/test_check_compiler_src.sh <compiler-binary>
@@ -61,86 +60,47 @@ run_test() {
 # regression check we're actually trying to do).
 unset SAILFIN_USE_ARENA
 
-# ---- Single canonical run per slash form ----
+# ---- Single canonical run ----
 # Capture stdout+stderr and the exit code; every assertion below
-# operates on these captured artifacts. Two invocations total.
-LOG_NO_SLASH="/tmp/sfn-check-compiler-src-no-slash.log"
-LOG_SLASH="/tmp/sfn-check-compiler-src-slash.log"
+# operates on these captured artifacts. ONE invocation total —
+# the trailing-slash regression is covered by a unit test on
+# `_collect_sfn_files_cmd` (see header).
+LOG="/tmp/sfn-check-compiler-src.log"
 
-RC_NO_SLASH=0
-"$BINARY" check "$SRC_DIR" > "$LOG_NO_SLASH" 2>&1 || RC_NO_SLASH=$?
+RC=0
+"$BINARY" check "$SRC_DIR" > "$LOG" 2>&1 || RC=$?
 
-RC_SLASH=0
-"$BINARY" check "$SRC_DIR/" > "$LOG_SLASH" 2>&1 || RC_SLASH=$?
-
-# ---- Test: no trailing slash run completes (no SIGSEGV) ----
-test_no_trailing_slash_completes() {
-    if [ "$RC_NO_SLASH" -eq 139 ]; then
+# ---- Test: run completes (no SIGSEGV) ----
+test_completes() {
+    if [ "$RC" -eq 139 ]; then
         echo "[test]   SIGSEGV (rc=139) — Phase 5a regression"
-        tail -5 "$LOG_NO_SLASH"
+        tail -5 "$LOG"
         return 1
     fi
-    if [ "$RC_NO_SLASH" -ne 0 ] && [ "$RC_NO_SLASH" -ne 1 ]; then
-        echo "[test]   unexpected exit $RC_NO_SLASH (expected 0 or 1)"
-        tail -5 "$LOG_NO_SLASH"
+    if [ "$RC" -ne 0 ] && [ "$RC" -ne 1 ]; then
+        echo "[test]   unexpected exit $RC (expected 0 or 1)"
+        tail -5 "$LOG"
         return 1
     fi
-    if ! grep -q "^checked.*files" "$LOG_NO_SLASH"; then
+    if ! grep -q "^checked.*files" "$LOG"; then
         echo "[test]   no summary line — process did not complete cleanly"
-        tail -5 "$LOG_NO_SLASH"
+        tail -5 "$LOG"
         return 1
     fi
     return 0
 }
-run_test "sfn check compiler/src (no trailing slash) completes" test_no_trailing_slash_completes
-
-# ---- Test: trailing-slash run completes (regression for path-normalization fix) ----
-# Pre-fix, a trailing slash produced double-slashed paths
-# (`compiler/src//ast.sfn`) that tripped downstream resolver
-# logic into a SIGSEGV during the cross-iteration burst.
-test_trailing_slash_completes() {
-    if [ "$RC_SLASH" -eq 139 ]; then
-        echo "[test]   SIGSEGV (rc=139) — trailing-slash regression"
-        tail -5 "$LOG_SLASH"
-        return 1
-    fi
-    if [ "$RC_SLASH" -ne 0 ] && [ "$RC_SLASH" -ne 1 ]; then
-        echo "[test]   unexpected exit $RC_SLASH (expected 0 or 1)"
-        tail -5 "$LOG_SLASH"
-        return 1
-    fi
-    if ! grep -q "^checked.*files" "$LOG_SLASH"; then
-        echo "[test]   no summary line — process did not complete cleanly"
-        tail -5 "$LOG_SLASH"
-        return 1
-    fi
-    return 0
-}
-run_test "sfn check compiler/src/ (trailing slash) completes" test_trailing_slash_completes
-
-# ---- Test: exit-code parity ----
-# Both forms check the same source tree. If they diverge, something
-# path-dependent leaked into the analysis chain. Captured codes
-# above; no new invocation.
-test_exit_code_parity() {
-    if [ "$RC_NO_SLASH" -ne "$RC_SLASH" ]; then
-        echo "[test]   no-slash exit=$RC_NO_SLASH vs trailing-slash exit=$RC_SLASH"
-        return 1
-    fi
-    return 0
-}
-run_test "exit code matches with/without trailing slash" test_exit_code_parity
+run_test "sfn check compiler/src completes (no SIGSEGV)" test_completes
 
 # ---- Test: file count matches `find` ----
 # Sanity check that the directory walk visits every .sfn file.
-# Reuses the no-slash log captured above. Uses numeric comparison
-# (`-ne`) rather than string comparison: macOS BSD `wc -l` left-pads
-# its output (`     132`) while Linux GNU `wc -l` doesn't (`132`),
-# and a string-equality test would treat the same count as a
-# divergence. PR #251 first revision tripped this on macOS arm64.
+# Uses numeric comparison (`-ne`) rather than string comparison:
+# macOS BSD `wc -l` left-pads its output (`     132`) while Linux
+# GNU `wc -l` doesn't (`132`), and a string-equality test would
+# treat the same count as a divergence. PR #251 first revision
+# tripped this on macOS arm64.
 test_file_count() {
     local expected; expected=$(find "$SRC_DIR" -name '*.sfn' | wc -l | tr -d '[:space:]')
-    local actual; actual=$(grep -oE 'checked [0-9]+ files' "$LOG_NO_SLASH" | grep -oE '[0-9]+' | head -1)
+    local actual; actual=$(grep -oE 'checked [0-9]+ files' "$LOG" | grep -oE '[0-9]+' | head -1)
     if [ "$actual" -ne "$expected" ] 2>/dev/null; then
         echo "[test]   file count mismatch: find=$expected, sfn check reported=$actual"
         return 1

--- a/compiler/tests/unit/cli_path_normalization_test.sfn
+++ b/compiler/tests/unit/cli_path_normalization_test.sfn
@@ -1,0 +1,54 @@
+// Unit test for `_strip_trailing_slashes_cmd` — the path-normalization
+// helper extracted from `_collect_sfn_files_cmd` to make the regression
+// for `sfn check compiler/src/` (trailing slash → double-slashed paths
+// → SIGSEGV) cheaply testable without a full-tree e2e invocation.
+//
+// The e2e test (`compiler/tests/e2e/test_check_compiler_src.sh`) used
+// to run the full 132-file analysis loop twice — once per slash form
+// — to gate this regression. Each invocation costs ~2 min on Linux
+// CI. This unit test gates the same logic in milliseconds, so the
+// e2e test now runs the canonical scenario exactly once.
+
+import { _strip_trailing_slashes_cmd } from "../../src/cli_commands_utils";
+
+test "path-norm: bare directory unchanged" {
+    assert _strip_trailing_slashes_cmd("compiler/src") == "compiler/src";
+}
+
+test "path-norm: single trailing slash stripped" {
+    assert _strip_trailing_slashes_cmd("compiler/src/") == "compiler/src";
+}
+
+test "path-norm: multiple trailing slashes stripped" {
+    assert _strip_trailing_slashes_cmd("compiler/src///") == "compiler/src";
+}
+
+test "path-norm: root '/' preserved" {
+    assert _strip_trailing_slashes_cmd("/") == "/";
+}
+
+test "path-norm: empty string unchanged" {
+    assert _strip_trailing_slashes_cmd("") == "";
+}
+
+test "path-norm: single character preserved" {
+    assert _strip_trailing_slashes_cmd("x") == "x";
+}
+
+test "path-norm: relative path with trailing slash" {
+    assert _strip_trailing_slashes_cmd("./foo/bar/") == "./foo/bar";
+}
+
+test "path-norm: absolute path with trailing slash" {
+    assert _strip_trailing_slashes_cmd("/usr/local/lib/") == "/usr/local/lib";
+}
+
+test "path-norm: idempotent (double application)" {
+    let once = _strip_trailing_slashes_cmd("compiler/src/");
+    let twice = _strip_trailing_slashes_cmd(once);
+    assert once == twice;
+}
+
+test "path-norm: no internal slashes touched" {
+    assert _strip_trailing_slashes_cmd("a/b/c/d") == "a/b/c/d";
+}

--- a/runtime/native/src/sailfin_arena.c
+++ b/runtime/native/src/sailfin_arena.c
@@ -255,8 +255,43 @@ static pthread_once_t _arena_global_once = PTHREAD_ONCE_INIT;
 
 static void _init_arena_enabled(void)
 {
+    /*
+     * Arena is on by default. End-user `sfn check`, `sfn test`, and
+     * any future `sfn vet`/`sfn fix`/`sfn lsp` invocation needs the
+     * arena (Phase 5a's mark/rewind primitive only reclaims memory
+     * when the arena is active) — without it the in-process multi-
+     * module loop hits the unfreed-allocations wall documented in
+     * `docs/build-performance.md` Root Cause 5 and SIGSEGVs at
+     * scale. `make compile` already exported `SAILFIN_USE_ARENA=1`
+     * in `scripts/build.sh`; this flip extends the same default to
+     * installed binaries so end users don't have to set the env
+     * var themselves.
+     *
+     * Opt-out: `SAILFIN_USE_ARENA=0` (or any value starting with
+     * '0' or empty after explicit set) disables the arena and the
+     * runtime falls back to the malloc/owned-string-hash path.
+     * Useful for the `make test-arena` IR-equivalence harness and
+     * for diagnosing arena-vs-malloc divergences.
+     *
+     * Empty env: `SAILFIN_USE_ARENA=` (set but empty) is treated
+     * as opt-out for shell-script ergonomics — `unset` and
+     * `=""` should behave the same way historically.
+     */
     const char *env = getenv("SAILFIN_USE_ARENA");
-    _arena_enabled = (env && env[0] != '\0' && env[0] != '0') ? 1 : 0;
+    if (env == NULL)
+    {
+        /* Unset: take the default. */
+        _arena_enabled = 1;
+        return;
+    }
+    if (env[0] == '\0' || env[0] == '0')
+    {
+        /* Explicit opt-out: empty string or starts with '0'. */
+        _arena_enabled = 0;
+        return;
+    }
+    /* Any other value is opt-in (including the historical "1"). */
+    _arena_enabled = 1;
 }
 
 bool sfn_arena_enabled(void)

--- a/runtime/native/src/sailfin_arena.c
+++ b/runtime/native/src/sailfin_arena.c
@@ -274,8 +274,12 @@ static void _init_arena_enabled(void)
      * for diagnosing arena-vs-malloc divergences.
      *
      * Empty env: `SAILFIN_USE_ARENA=` (set but empty) is treated
-     * as opt-out for shell-script ergonomics — `unset` and
-     * `=""` should behave the same way historically.
+     * as opt-out, mirroring the `=0` case. This is a deliberate
+     * divergence from `unset` (which now means "take the default",
+     * i.e. arena ON): a script that explicitly clears the variable
+     * with `SAILFIN_USE_ARENA=` is signalling intent to disable,
+     * not "I have no opinion". `unset SAILFIN_USE_ARENA` is the
+     * way to ask for the default.
      */
     const char *env = getenv("SAILFIN_USE_ARENA");
     if (env == NULL)

--- a/scripts/install_precommit.sh
+++ b/scripts/install_precommit.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# install_precommit.sh — opt-in pre-commit hook for Sailfin contributors.
+#
+# Installs a Git pre-commit hook that runs `make check-fast` (a
+# `sfn check compiler/src/ runtime/` invocation, ~2 min) so contributors
+# catch parser, typecheck, and effect-system breakage before pushing.
+#
+# This is opt-in by design — it adds ~2 min to every commit, which is a
+# fair trade for committers actively touching compiler/src/ but excessive
+# for docs-only or release-tooling work.
+#
+# Usage:
+#   bash scripts/install_precommit.sh           # install the hook
+#   bash scripts/install_precommit.sh --remove  # uninstall the hook
+#
+# The installed hook respects two escape hatches:
+#   - `git commit --no-verify` skips it entirely (standard git behavior)
+#   - `SAILFIN_SKIP_PRECOMMIT=1 git commit ...` skips it without --no-verify
+#     (so other hooks like commit-msg still run)
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HOOK_PATH="$REPO_ROOT/.git/hooks/pre-commit"
+MARKER="# sailfin-precommit-v1"
+
+usage() {
+    sed -n '2,18p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+    exit 0
+}
+
+case "${1:-}" in
+    -h|--help) usage ;;
+    --remove)
+        if [ ! -e "$HOOK_PATH" ]; then
+            echo "[install-precommit] no hook installed at $HOOK_PATH"
+            exit 0
+        fi
+        if ! grep -q "$MARKER" "$HOOK_PATH" 2>/dev/null; then
+            echo "[install-precommit] hook at $HOOK_PATH was not installed by this script; refusing to remove" >&2
+            exit 1
+        fi
+        rm -f "$HOOK_PATH"
+        echo "[install-precommit] removed $HOOK_PATH"
+        exit 0
+        ;;
+    "") ;;
+    *)
+        echo "[install-precommit] unknown argument: $1" >&2
+        echo "Usage: $0 [--remove]" >&2
+        exit 1
+        ;;
+esac
+
+if [ ! -d "$REPO_ROOT/.git" ]; then
+    echo "[install-precommit] $REPO_ROOT is not a git repository" >&2
+    exit 1
+fi
+
+if [ -e "$HOOK_PATH" ] && ! grep -q "$MARKER" "$HOOK_PATH" 2>/dev/null; then
+    backup="$HOOK_PATH.bak.$(date +%s)"
+    echo "[install-precommit] existing hook found; backing up to $backup"
+    mv "$HOOK_PATH" "$backup"
+fi
+
+cat > "$HOOK_PATH" <<'HOOK'
+#!/usr/bin/env bash
+# sailfin-precommit-v1
+#
+# Runs `make check-fast` to surface parser/typecheck/effect breakage
+# before committing. Skip with `git commit --no-verify` or
+# `SAILFIN_SKIP_PRECOMMIT=1 git commit ...`.
+set -euo pipefail
+
+if [ "${SAILFIN_SKIP_PRECOMMIT:-0}" = "1" ]; then
+    echo "[pre-commit] SAILFIN_SKIP_PRECOMMIT=1 — skipping check-fast"
+    exit 0
+fi
+
+# Only run if a compiler/runtime source actually changed.
+changed=$(git diff --cached --name-only --diff-filter=ACMR | \
+    grep -E '^(compiler/src/|runtime/)' || true)
+if [ -z "$changed" ]; then
+    exit 0
+fi
+
+if [ ! -x build/native/sailfin ]; then
+    echo "[pre-commit] build/native/sailfin not built; skipping check-fast"
+    echo "[pre-commit] run 'make compile' to enable the pre-commit gate"
+    exit 0
+fi
+
+echo "[pre-commit] running 'make check-fast' (set SAILFIN_SKIP_PRECOMMIT=1 to skip)"
+if ! make check-fast; then
+    echo ""
+    echo "[pre-commit] check-fast failed. Fix the diagnostics above, or"
+    echo "[pre-commit] bypass with: git commit --no-verify"
+    exit 1
+fi
+HOOK
+chmod +x "$HOOK_PATH"
+
+echo "[install-precommit] installed $HOOK_PATH"
+echo "[install-precommit] runs 'make check-fast' on commits touching compiler/src/ or runtime/"
+echo "[install-precommit] skip with: SAILFIN_SKIP_PRECOMMIT=1 git commit ...   (or --no-verify)"
+echo "[install-precommit] uninstall with: bash scripts/install_precommit.sh --remove"

--- a/scripts/install_precommit.sh
+++ b/scripts/install_precommit.sh
@@ -21,7 +21,6 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-HOOK_PATH="$REPO_ROOT/.git/hooks/pre-commit"
 MARKER="# sailfin-precommit-v1"
 
 usage() {
@@ -29,9 +28,32 @@ usage() {
     exit 0
 }
 
+# Resolve the pre-commit hook path via `git rev-parse` so the installer
+# works in worktrees and submodules where `.git` is a file pointing at
+# the real git dir, not a directory.
+resolve_hook_path() {
+    if ! git -C "$REPO_ROOT" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+        echo "[install-precommit] $REPO_ROOT is not a git working tree" >&2
+        exit 1
+    fi
+    local p
+    p="$(git -C "$REPO_ROOT" rev-parse --git-path hooks/pre-commit)"
+    if [ -z "$p" ]; then
+        echo "[install-precommit] git rev-parse returned empty hooks path" >&2
+        exit 1
+    fi
+    # `--git-path` returns a path relative to CWD when the result is
+    # inside the repo; absolutise it for the install/remove operations.
+    case "$p" in
+        /*) printf '%s\n' "$p" ;;
+        *)  printf '%s\n' "$REPO_ROOT/$p" ;;
+    esac
+}
+
 case "${1:-}" in
     -h|--help) usage ;;
     --remove)
+        HOOK_PATH="$(resolve_hook_path)"
         if [ ! -e "$HOOK_PATH" ]; then
             echo "[install-precommit] no hook installed at $HOOK_PATH"
             exit 0
@@ -52,10 +74,8 @@ case "${1:-}" in
         ;;
 esac
 
-if [ ! -d "$REPO_ROOT/.git" ]; then
-    echo "[install-precommit] $REPO_ROOT is not a git repository" >&2
-    exit 1
-fi
+HOOK_PATH="$(resolve_hook_path)"
+mkdir -p "$(dirname "$HOOK_PATH")"
 
 if [ -e "$HOOK_PATH" ] && ! grep -q "$MARKER" "$HOOK_PATH" 2>/dev/null; then
     backup="$HOOK_PATH.bak.$(date +%s)"
@@ -77,19 +97,20 @@ if [ "${SAILFIN_SKIP_PRECOMMIT:-0}" = "1" ]; then
     exit 0
 fi
 
-# Only run if a compiler/runtime source actually changed.
-changed=$(git diff --cached --name-only --diff-filter=ACMR | \
+# Only run if a compiler/runtime source actually changed. The diff filter
+# includes deletions (D) — removing a source file can break the build
+# just as easily as editing one, so the gate must fire either way.
+changed=$(git diff --cached --name-only --diff-filter=ACMRD | \
     grep -E '^(compiler/src/|runtime/)' || true)
 if [ -z "$changed" ]; then
     exit 0
 fi
 
-if [ ! -x build/native/sailfin ]; then
-    echo "[pre-commit] build/native/sailfin not built; skipping check-fast"
-    echo "[pre-commit] run 'make compile' to enable the pre-commit gate"
-    exit 0
-fi
-
+# Defer binary detection to `make check-fast` itself — it knows the
+# correct $(NATIVE_BIN) for the platform (including .exe on Windows)
+# and emits a clear "missing; run make compile" message when absent.
+# That way the hook stays platform-agnostic and doesn't drift from the
+# Makefile if NATIVE_BIN is overridden or EXE_EXT changes.
 echo "[pre-commit] running 'make check-fast' (set SAILFIN_SKIP_PRECOMMIT=1 to skip)"
 if ! make check-fast; then
     echo ""

--- a/scripts/test_arena.sh
+++ b/scripts/test_arena.sh
@@ -103,7 +103,12 @@ compile_once() {
     if [[ "$mode" == "with_arena" ]]; then
         (cd "$module_cwd" && SAILFIN_USE_ARENA=1 "$ABS_SEED" emit -o "$abs_out_ll" llvm "$abs_src") 2>"$abs_stderr"
     else
-        (cd "$module_cwd" && "$ABS_SEED" emit -o "$abs_out_ll" llvm "$abs_src") 2>"$abs_stderr"
+        # Explicit opt-out: arena is now default-on (flipped after
+        # Phase 5a shipped), so "no env var" gets the arena too.
+        # Use `SAILFIN_USE_ARENA=0` to actually exercise the
+        # malloc/owned-string-hash path the harness is supposed to
+        # cross-check against.
+        (cd "$module_cwd" && SAILFIN_USE_ARENA=0 "$ABS_SEED" emit -o "$abs_out_ll" llvm "$abs_src") 2>"$abs_stderr"
     fi
 }
 


### PR DESCRIPTION
## Summary

Two pre-1.0 ergonomics improvements that build on Phase 5a (arena
mark/rewind, #251) and Track B (`sfn check` production-readiness, #247).

### Step 1 — arena default-on flip

`runtime/native/src/sailfin_arena.c`: `_init_arena_enabled()` now
defaults `_arena_enabled = 1` when `SAILFIN_USE_ARENA` is unset.
`=0` (or empty) is the explicit opt-out kept for the `make test-arena`
IR-equivalence harness.

End-user `sfn check` / `sfn test` / future `sfn vet` invocations all
need the arena to keep the in-process multi-module loop reclaimable
(Phase 5a's mark/rewind only reclaims when the arena is active).
Without this flip, `sfn check compiler/src/` SIGSEGVs at scale unless
the user knows to set `SAILFIN_USE_ARENA=1` themselves. `make compile`
already exported the env var via `scripts/build.sh`; this extends the
same default to installed binaries.

### Step 2 (B6) — fast-feedback PR gate

| File | Change |
|---|---|
| `Makefile` | new `check-fast` target — `sfn check compiler/src/ runtime/`, ~2 min, no codegen |
| `.github/actions/sailfin-build/action.yml` | new "Fast pre-build check" step between `fetch-seed` and the slow build, using the seed binary |
| `scripts/install_precommit.sh` | opt-in pre-commit hook installer; runs `make check-fast` on commits touching `compiler/src/` or `runtime/` |
| `CONTRIBUTING.md` | documents both |

The pre-commit hook respects `SAILFIN_SKIP_PRECOMMIT=1` and the
standard `--no-verify` escape hatch. `--remove` cleanly uninstalls
and refuses to touch hooks not installed by this script.

### Effect-system fixes uncovered by check-fast

Two latent missing-effect declarations only became visible once
`sfn check compiler/src/ runtime/` could complete end-to-end (post
Phase 5a):

- `compiler/src/cli_main.sfn` — `sailfin_cli_main` now declares
  `![io, clock]` (the `clock` effect was missing despite calling
  into `sleep`-using paths through `cli_commands`).
- `compiler/src/llvm/lowering/entrypoints.sfn` —
  `lower_to_llvm_lines_with_context` now declares `![io]` (calls
  `print.err` on diagnostic paths).

### Test infra updates

- `scripts/test_arena.sh` — no-arena branch now sets
  `SAILFIN_USE_ARENA=0` explicitly (since "no env var" now picks the
  arena). Without this, the harness compared two identical arena
  runs and would silently pass any real divergence.
- `compiler/tests/e2e/test_check_compiler_src.sh` — replaces
  `export SAILFIN_USE_ARENA=1` with `unset SAILFIN_USE_ARENA` to
  defend against a parent shell that pre-set the var to "0".

## Test plan

- [x] `make check` (triple-pass selfhost) — stage2 == stage3 fixed-point ✓
- [x] `make test-arena` — IR byte-identical with arena vs malloc
- [x] `sfn check compiler/src/` (no env var) — exits cleanly with
      Phase 5a arena reclaim active
- [x] `bash scripts/install_precommit.sh` then `--remove` — clean
      install/uninstall cycle
- [ ] CI green on linux-x86_64 + macos-arm64

## Followup (out of scope, future PR)

Per-process interface cache to push `make check-fast` from ~124s → <10s
(currently `_cr_stage_one` re-emits transitively-reachable modules
each invocation; the cache fast-path skips emit-on-disk but interface
load still dominates).


---
_Generated by [Claude Code](https://claude.ai/code/session_01XwtvQFhCsF5ak8Aoe2GZsF)_