### PR TITLE
Stage C PR1b: wire content-addressed cache into _cr_compile_one

### DIFF
--- a/compiler/src/build_cache.sfn
+++ b/compiler/src/build_cache.sfn
@@ -210,6 +210,63 @@ fn cache_store(root: string, key: CacheKey, sfn_asm_src: string, layout_manifest
 }
 
 // ----------------------------------------------------------------
+// Single-artifact lookup / store / restore
+// ----------------------------------------------------------------
+// Build stages typically produce only a subset of the four
+// artifact kinds. `_cr_compile_one` in `capsule_resolver.sfn`,
+// for instance, produces only `.ll` — the `.sfn-asm` and
+// `.layout-manifest` are produced earlier by
+// `stage_capsule_imports`, and the `.o` is produced downstream by
+// clang. The single-artifact API lets a stage cache exactly what
+// it produced without needing to invent placeholders for the
+// other slots.
+//
+// `kind` must be one of the four recognised values
+// (`"sfn-asm"`, `"layout-manifest"`, `"ll"`, `"obj"`); unknown
+// kinds short-circuit to false the same way invalid digests do.
+fn _is_known_kind(kind: string) -> boolean {
+    return _filename_for_kind(kind).length > 0;
+}
+
+// True iff the artifact of `kind` for `key` is on disk under
+// `root`. Returns false on invalid digest or unknown kind so the
+// caller can treat both as a hard miss.
+fn cache_lookup_artifact(root: string, key: CacheKey, kind: string) -> boolean ![io] {
+    if !_is_valid_digest(key.digest) { return false; }
+    if !_is_known_kind(kind) { return false; }
+    return fs.exists(cache_artifact_path(root, key, kind));
+}
+
+// Copy a cached artifact out to `dst_path`. Returns true on
+// success, false on missing entry, invalid key, unknown kind, or
+// `cp` failure. Used on cache hits to materialise the cached
+// artifact into the location the build expects (e.g. copying a
+// cached `.ll` to the `CapsuleSource.ll_path` the linker reads).
+fn cache_copy_artifact_to(root: string, key: CacheKey, kind: string, dst_path: string) -> boolean ![io] {
+    if !_is_valid_digest(key.digest) { return false; }
+    if !_is_known_kind(kind) { return false; }
+    let src = cache_artifact_path(root, key, kind);
+    if !fs.exists(src) { return false; }
+    let cp = process.run(["cp", src, dst_path]);
+    return cp == 0;
+}
+
+// Copy `src_path` into the cache as the artifact of `kind` for
+// `key`. Creates the entry directory on demand. Returns true on
+// success, false on invalid key, unknown kind, or `cp` failure
+// (caller treats as a non-fatal cache write miss — the build
+// itself still produced the artifact at `src_path`).
+fn cache_store_artifact(root: string, key: CacheKey, kind: string, src_path: string) -> boolean ![io] {
+    if !_is_valid_digest(key.digest) { return false; }
+    if !_is_known_kind(kind) { return false; }
+    let entry_dir = _cache_entry_dir(root, key);
+    _ensure_dir_recursive_cmd(entry_dir);
+    let dst = cache_artifact_path(root, key, kind);
+    let cp = process.run(["cp", src_path, dst]);
+    return cp == 0;
+}
+
+// ----------------------------------------------------------------
 // Hashing helpers
 // ----------------------------------------------------------------
 // Hash a string by writing it to a tmp file and sha256ing.
@@ -386,6 +443,9 @@ export {
     cache_paths_for,
     cache_lookup_complete,
     cache_store,
+    cache_lookup_artifact,
+    cache_copy_artifact_to,
+    cache_store_artifact,
     canonicalize_flags,
     cache_key_for
 };

--- a/compiler/src/build_cache.sfn
+++ b/compiler/src/build_cache.sfn
@@ -54,6 +54,7 @@
 // variables. The convenience reader `cache_root()` is the
 // production-side wrapper that resolves `$SAILFIN_BUILD_CACHE_DIR`.
 import {
+    _dirname_cmd,
     _ensure_dir_recursive_cmd,
     _get_env_cmd,
     _sanitize_filename_cmd,
@@ -242,11 +243,18 @@ fn cache_lookup_artifact(root: string, key: CacheKey, kind: string) -> boolean !
 // `cp` failure. Used on cache hits to materialise the cached
 // artifact into the location the build expects (e.g. copying a
 // cached `.ll` to the `CapsuleSource.ll_path` the linker reads).
+//
+// The destination's parent directory is created on demand —
+// without that, `cp` would fail with "No such file or directory"
+// on the first build into a fresh tree, silently flipping every
+// cache hit into a recompile.
 fn cache_copy_artifact_to(root: string, key: CacheKey, kind: string, dst_path: string) -> boolean ![io] {
     if !_is_valid_digest(key.digest) { return false; }
     if !_is_known_kind(kind) { return false; }
     let src = cache_artifact_path(root, key, kind);
     if !fs.exists(src) { return false; }
+    let dst_dir = _dirname_cmd(dst_path);
+    if dst_dir.length > 0 { _ensure_dir_recursive_cmd(dst_dir); }
     let cp = process.run(["cp", src, dst_path]);
     return cp == 0;
 }

--- a/compiler/src/capsule_resolver.sfn
+++ b/compiler/src/capsule_resolver.sfn
@@ -35,6 +35,15 @@
 // capsule .ll paths, and clang produces a linked binary with all
 // capsule symbols resolved.
 import {
+    CacheKey,
+    cache_copy_artifact_to,
+    cache_key_for,
+    cache_lookup_artifact,
+    cache_root,
+    cache_store_artifact
+} from "./build_cache";
+import { _get_env_cmd } from "./cli_commands_utils";
+import {
     compile_to_llvm_file_with_module,
     module_name_from_path,
     number_to_string,
@@ -47,6 +56,7 @@ import {
     toml_get_name,
     toml_get_workspace_members
 } from "./toml_parser";
+import { resolve_compiler_version } from "./version";
 
 export {
     CapsuleSource,
@@ -504,37 +514,119 @@ fn stage_capsule_imports(sources: CapsuleSource[]) -> boolean ![io] {
     return true;
 }
 
+// ---- Cache wiring helpers (Stage C PR1b) ----
+// Build the dep-manifest list once per `compile_capsule_modules`
+// invocation. Conservative: include every staged manifest in the
+// resolved set, not just the ones THIS source actually imports.
+// Key cost is one extra hash-input per build, not per module —
+// stable, deterministic, and a future PR can refine this to
+// "manifests of imported modules only" once the resolver hands
+// us per-source import-edges.
+fn _cr_collect_dep_manifest_paths(sources: CapsuleSource[]) -> string[] {
+    let mut out: string[] = [];
+    let mut i: number = 0;
+    loop {
+        if i >= sources.length { break; }
+        out.push("build/native/import-context/" + sources[i].slug
+            + ".layout-manifest");
+        i += 1;
+    }
+    return out;
+}
+
+// `SAILFIN_NO_CACHE=1` disables both cache lookups and stores —
+// emergency rollback knob if a cache bug ever surfaces. Returns
+// true when caching is enabled (the default).
+fn _cr_cache_enabled() -> boolean ![io] {
+    let raw = _get_env_cmd("SAILFIN_NO_CACHE");
+    return !strings_equal(raw, "1");
+}
+
+// `SAILFIN_CACHE_TRACE=1` prints `[cache hit/miss/store] <slug>`
+// to stderr so a user (or an e2e test) can observe cache
+// behaviour without parsing an opaque build report. Quiet by
+// default.
+fn _cr_cache_trace_enabled() -> boolean ![io] {
+    let raw = _get_env_cmd("SAILFIN_CACHE_TRACE");
+    return strings_equal(raw, "1");
+}
+
 // ---- Capsule module compilation ----
 // Lower a single capsule source to its own .ll so the final link can
 // resolve the main module's external declarations to the capsule's
-// definitions.
-fn _cr_compile_one(src: CapsuleSource) -> boolean ![io] {
+// definitions. With `cache_enabled = true`, looks up an existing
+// `.ll` artifact under the content-addressed cache before
+// compiling, and stores the result on a clean compile.
+fn _cr_compile_one(src: CapsuleSource, dep_manifests: string[], cache_root_path: string, cache_enabled: boolean, compiler_version: string, flags_canonical: string, trace: boolean) -> boolean ![io] {
     if !fs.exists(src.source_path) {
         print.err("capsule-resolver: missing source file: " + src.source_path);
         return false;
     }
-    let source = fs.readFile(src.source_path);
     let ll_dir = _cr_dirname(src.ll_path);
     _cr_ensure_dir(ll_dir);
+
+    // Cache lookup. Suffix the slug-derived name to keep
+    // `_sha256_of_string`'s tmp paths unique across the dep-list
+    // and final-input hashes.
+    let mut cache_key: CacheKey = CacheKey { digest: "" };
+    if cache_enabled {
+        cache_key = cache_key_for(src.source_path, dep_manifests, compiler_version, flags_canonical, src.slug);
+        if cache_lookup_artifact(cache_root_path, cache_key, "ll") {
+            if cache_copy_artifact_to(cache_root_path, cache_key, "ll", src.ll_path) {
+                if trace { print.err("[cache hit] " + src.slug); }
+                return true;
+            }
+            if trace { print.err("[cache copy-failed] " + src.slug); }
+        } else {
+            if trace { print.err("[cache miss] " + src.slug); }
+        }
+    }
+
+    let source = fs.readFile(src.source_path);
     let ok = compile_to_llvm_file_with_module(source, src.slug, src.ll_path);
     if !ok {
         print.err("capsule-resolver: failed to lower " + src.slug
             + " to LLVM IR");
         return false;
     }
+
+    if cache_enabled {
+        let stored = cache_store_artifact(cache_root_path, cache_key, "ll", src.ll_path);
+        if trace {
+            if stored { print.err("[cache store] " + src.slug); } else {
+                print.err("[cache store-failed] " + src.slug);
+            }
+        }
+    }
     return true;
 }
 
 // Compile every capsule module to its own .ll and return the list of
-// .ll paths to feed the linker.
+// .ll paths to feed the linker. Resolves cache context once at the
+// top — dep-manifest paths, cache root, env-driven enable/trace —
+// and threads it into each per-module call.
 fn compile_capsule_modules(sources: CapsuleSource[]) -> string[] ![io] {
     _cr_ensure_dir("build/sailfin");
     _cr_ensure_dir("build/sailfin/capsules");
+    let dep_manifests = _cr_collect_dep_manifest_paths(sources);
+    let cache_root_path = cache_root();
+    let cache_enabled = _cr_cache_enabled();
+    let trace = _cr_cache_trace_enabled();
+    // The version is the same for every module in this build; pass
+    // empty `binary_dir` so the resolver consults
+    // `build/native/.build-stamp` and the in-tree `capsule.toml`
+    // instead of binary-relative paths (which only matter for
+    // installed binaries running outside the workspace).
+    let compiler_version = resolve_compiler_version("");
+    // Flag canonicalization is empty for now — `sfn build -p` does
+    // not yet take build flags. Once it does, thread the flag list
+    // through `canonicalize_flags(flags)` and pass the result here.
+    let flags_canonical = "[]";
     let mut out: string[] = [];
     let mut i: number = 0;
     loop {
         if i >= sources.length { break; }
-        let ok = _cr_compile_one(sources[i]);
+        let ok = _cr_compile_one(sources[i], dep_manifests, cache_root_path, cache_enabled, compiler_version, flags_canonical, trace);
         if !ok { return []; }
         out.push(sources[i].ll_path);
         i += 1;

--- a/compiler/src/capsule_resolver.sfn
+++ b/compiler/src/capsule_resolver.sfn
@@ -40,7 +40,8 @@ import {
     cache_key_for,
     cache_lookup_artifact,
     cache_root,
-    cache_store_artifact
+    cache_store_artifact,
+    canonicalize_flags
 } from "./build_cache";
 import { _get_env_cmd } from "./cli_commands_utils";
 import {
@@ -56,7 +57,7 @@ import {
     toml_get_name,
     toml_get_workspace_members
 } from "./toml_parser";
-import { resolve_compiler_version } from "./version";
+import { resolve_compiler_version_for_cache } from "./version";
 
 export {
     CapsuleSource,
@@ -612,16 +613,27 @@ fn compile_capsule_modules(sources: CapsuleSource[]) -> string[] ![io] {
     let cache_root_path = cache_root();
     let cache_enabled = _cr_cache_enabled();
     let trace = _cr_cache_trace_enabled();
-    // The version is the same for every module in this build; pass
-    // empty `binary_dir` so the resolver consults
-    // `build/native/.build-stamp` and the in-tree `capsule.toml`
-    // instead of binary-relative paths (which only matter for
-    // installed binaries running outside the workspace).
-    let compiler_version = resolve_compiler_version("");
+    // Strict compiler-version lookup: NEVER falls through to a CWD
+    // `capsule.toml` (the project's manifest), because the build
+    // cache keys IR against the compiler binary's identity — letting
+    // the project version creep into the key would silently reuse
+    // cached `.ll` across compiler upgrades. Threading `binary_dir`
+    // from the CLI entry into this call is the next refinement;
+    // until then, `resolve_compiler_version_for_cache("")` falls
+    // through to `build/native/.build-stamp` (in-tree dev) or
+    // `compiler/capsule.toml` (in-tree dev), and finally the
+    // compile-time `__version_fallback__` — which is stable per
+    // binary, so cache keys stay coherent for any single binary
+    // even when running outside the workspace.
+    let compiler_version = resolve_compiler_version_for_cache("");
     // Flag canonicalization is empty for now — `sfn build -p` does
-    // not yet take build flags. Once it does, thread the flag list
-    // through `canonicalize_flags(flags)` and pass the result here.
-    let flags_canonical = "[]";
+    // not yet take build flags. Constructing via `canonicalize_flags`
+    // keeps the empty form a single source of truth: if the encoder
+    // changes how it spells "no flags", this site picks up the new
+    // form automatically rather than drifting against a hardcoded
+    // string literal.
+    let empty_flags: string[] = [];
+    let flags_canonical = canonicalize_flags(empty_flags);
     let mut out: string[] = [];
     let mut i: number = 0;
     loop {

--- a/compiler/src/version.sfn
+++ b/compiler/src/version.sfn
@@ -153,3 +153,52 @@ fn resolve_compiler_version(binary_dir: string) -> string ![io] {
 
     return __version_fallback__;
 }
+
+// Variant for cache-key derivation. Same lookup chain as
+// `resolve_compiler_version` EXCEPT it never falls through to a
+// project's CWD-relative `capsule.toml`. The build cache keys IR
+// against the compiler binary's identity; mixing in the project
+// version would let a `sfn` upgrade silently reuse cached `.ll`
+// produced by an older binary, which could surface as
+// hard-to-diagnose miscompiles when the IR contract has shifted.
+//
+// Strict resolution order:
+//   1. `binary_dir/.build-stamp` (when `binary_dir` is non-empty)
+//   2. `binary_dir/../../compiler/capsule.toml` (in-tree dev tree)
+//   3. `build/native/.build-stamp` (CWD-relative dev fallback)
+//   4. `compiler/capsule.toml` (CWD-relative dev fallback)
+//   5. `__version_fallback__` (compile-time constant — stable per
+//      binary, so cache keys stay coherent for any single binary)
+//
+// Step 4's CWD lookup can still match a foreign `compiler/capsule.toml`
+// in a contrived directory, but the moment a real compiler ships
+// `binary_dir` from its CLI entry the call short-circuits at step 1
+// or 2. Threading `binary_dir` through `compile_capsule_modules` is
+// the next refinement; documented in the proposal's open questions.
+fn resolve_compiler_version_for_cache(binary_dir: string) -> string ![io] {
+    if binary_dir.length > 0 {
+        let stamp = _read_stamp(binary_dir + "/.build-stamp");
+        if stamp.length > 0 { return stamp; }
+
+        let capsule_path = binary_dir + "/../../compiler/capsule.toml";
+        if fs.exists(capsule_path) {
+            let text = fs.readFile(capsule_path);
+            let ver = _strict_capsule_version(text);
+            if ver.length > 0 { return ver; }
+        }
+
+        return __version_fallback__;
+    }
+
+    let stamp = _read_stamp("build/native/.build-stamp");
+    if stamp.length > 0 { return stamp; }
+
+    // Note: only the in-tree compiler manifest, NOT the CWD-relative
+    // `capsule.toml` the non-strict variant accepts. End-user
+    // projects' manifests have nothing to do with the IR contract.
+    let capsule_paths: string[] = ["compiler/capsule.toml"];
+    let capsule_ver = _read_capsule_version(capsule_paths);
+    if capsule_ver.length > 0 { return capsule_ver; }
+
+    return __version_fallback__;
+}

--- a/compiler/tests/unit/build_cache_test.sfn
+++ b/compiler/tests/unit/build_cache_test.sfn
@@ -27,10 +27,13 @@ import {
     CacheKey,
     build_cache_schema_version,
     cache_artifact_path,
+    cache_copy_artifact_to,
+    cache_lookup_artifact,
     cache_lookup_complete,
     cache_paths_for,
     cache_root_with_override,
     cache_store,
+    cache_store_artifact,
     canonicalize_flags,
     cache_key_for
 } from "../../src/build_cache";
@@ -337,5 +340,96 @@ test "build_cache: cache_lookup_complete returns false on partial entry" ![io] {
 
     // Intentionally miss `paths.obj`.
     assert ! cache_lookup_complete(cache_root, key);
+    _cleanup(scratch);
+}
+
+// --------------------------------------------------------------
+// Single-artifact API (Stage C PR1b — cache wiring)
+// --------------------------------------------------------------
+// `cache_lookup_artifact` / `cache_store_artifact` /
+// `cache_copy_artifact_to` are the per-kind helpers used by the
+// resolver's `_cr_compile_one` hot path, which produces only the
+// `.ll` artifact. Verifying the round-trip locks the contract the
+// wiring relies on.
+test "build_cache: cache_store_artifact + cache_lookup_artifact round-trip ll" ![io] {
+    let scratch = _test_tmp_root("artifact_ll");
+    let cache_root = scratch + "/cache/v1";
+    let src_dir = scratch + "/build";
+    process.run(["mkdir", "-p", src_dir]);
+    let ll = src_dir + "/mod.ll";
+    _write_file(ll, "; ModuleID = 'foo'");
+
+    let key = CacheKey {
+        digest: "1111111111111111111111111111111111111111111111111111111111111111"
+    };
+
+    assert ! cache_lookup_artifact(cache_root, key, "ll");
+    let stored = cache_store_artifact(cache_root, key, "ll", ll);
+    assert stored;
+    assert cache_lookup_artifact(cache_root, key, "ll");
+
+    // Other artifact slots are untouched — store-of-ll does not
+    // imply a complete entry.
+    assert ! cache_lookup_artifact(cache_root, key, "sfn-asm");
+    assert ! cache_lookup_artifact(cache_root, key, "obj");
+
+    _cleanup(scratch);
+}
+
+test "build_cache: cache_copy_artifact_to materialises cached ll" ![io] {
+    let scratch = _test_tmp_root("artifact_copy");
+    let cache_root = scratch + "/cache/v1";
+    let src_dir = scratch + "/build";
+    process.run(["mkdir", "-p", src_dir]);
+    let original = src_dir + "/mod.ll";
+    _write_file(original, "; ModuleID = 'cached'");
+
+    let key = CacheKey {
+        digest: "2222222222222222222222222222222222222222222222222222222222222222"
+    };
+    cache_store_artifact(cache_root, key, "ll", original);
+
+    let dst = src_dir + "/restored.ll";
+    let copied = cache_copy_artifact_to(cache_root, key, "ll", dst);
+    assert copied;
+    assert fs.exists(dst);
+    assert fs.readFile(dst) == "; ModuleID = 'cached'";
+
+    _cleanup(scratch);
+}
+
+test "build_cache: cache_copy_artifact_to returns false on cache miss" ![io] {
+    let scratch = _test_tmp_root("artifact_miss");
+    let cache_root = scratch + "/cache/v1";
+    let key = CacheKey {
+        digest: "3333333333333333333333333333333333333333333333333333333333333333"
+    };
+    let dst = scratch + "/out.ll";
+    assert ! cache_copy_artifact_to(cache_root, key, "ll", dst);
+    assert ! fs.exists(dst);
+    _cleanup(scratch);
+}
+
+test "build_cache: cache_store_artifact rejects unknown kind" ![io] {
+    let scratch = _test_tmp_root("artifact_unknown_kind");
+    let cache_root = scratch + "/cache/v1";
+    let src_dir = scratch + "/build";
+    process.run(["mkdir", "-p", src_dir]);
+    let f = src_dir + "/anything";
+    _write_file(f, "anything");
+    let key = CacheKey {
+        digest: "4444444444444444444444444444444444444444444444444444444444444444"
+    };
+    assert ! cache_store_artifact(cache_root, key, "this-kind-does-not-exist", f);
+    // Cache root must not have been created — invalid kind is a hard reject.
+    assert ! fs.exists(cache_root);
+    _cleanup(scratch);
+}
+
+test "build_cache: cache_lookup_artifact rejects invalid digest" ![io] {
+    let scratch = _test_tmp_root("artifact_invalid_digest");
+    let cache_root = scratch + "/cache/v1";
+    let key = CacheKey { digest: "" };
+    assert ! cache_lookup_artifact(cache_root, key, "ll");
     _cleanup(scratch);
 }

--- a/compiler/tests/unit/build_cache_test.sfn
+++ b/compiler/tests/unit/build_cache_test.sfn
@@ -398,6 +398,33 @@ test "build_cache: cache_copy_artifact_to materialises cached ll" ![io] {
     _cleanup(scratch);
 }
 
+// Regression for Copilot review on PR #255 (build_cache.sfn:251):
+// `cp` fails if the destination's parent directory doesn't exist.
+// Without auto-mkdir inside `cache_copy_artifact_to`, every cache
+// hit on a fresh build tree would silently flip to recompile. The
+// helper now creates the dst dir on demand.
+test "build_cache: cache_copy_artifact_to creates dst dir on demand" ![io] {
+    let scratch = _test_tmp_root("artifact_copy_mkdir");
+    let cache_root = scratch + "/cache/v1";
+    let src_dir = scratch + "/build";
+    process.run(["mkdir", "-p", src_dir]);
+    let original = src_dir + "/mod.ll";
+    _write_file(original, "; ModuleID = 'cached'");
+
+    let key = CacheKey {
+        digest: "5555555555555555555555555555555555555555555555555555555555555555"
+    };
+    cache_store_artifact(cache_root, key, "ll", original);
+
+    // Destination's parent dir does NOT exist yet.
+    let nested_dst = scratch + "/freshly/nested/dir/restored.ll";
+    let copied = cache_copy_artifact_to(cache_root, key, "ll", nested_dst);
+    assert copied;
+    assert fs.exists(nested_dst);
+
+    _cleanup(scratch);
+}
+
 test "build_cache: cache_copy_artifact_to returns false on cache miss" ![io] {
     let scratch = _test_tmp_root("artifact_miss");
     let cache_root = scratch + "/cache/v1";


### PR DESCRIPTION
## Summary

Wires the content-addressed cache from PR #254 into the per-capsule compile hot path (`_cr_compile_one`), giving `sfn build`, `sfn run`, `sfn test`, and `sfn check` incremental rebuilds for capsule dependency modules.

End-to-end demo on a project depending on `sfn/math`:

```
=== FIRST BUILD ===
[cache miss] sfn/math/mod
[cache store] sfn/math/mod

=== SECOND BUILD ===
[cache hit] sfn/math/mod

=== CACHE FS ===
build/cache/v1/be/be9b63d6.../mod.ll
```

The second build skips `compile_to_llvm_file_with_module` entirely — copies the cached `.ll` straight to `src.ll_path`. Sharded layout per proposal §4.4.

## What ships

### Single-artifact cache API (`compiler/src/build_cache.sfn`)

PR1's API was four-artifact (`sfn-asm`/`layout-manifest`/`ll`/`obj`), but `_cr_compile_one` only produces the `.ll` (`.sfn-asm`/`.layout-manifest` come from `stage_capsule_imports`, `.o` is downstream of clang). New per-kind helpers:

- `cache_lookup_artifact(root, key, kind) -> boolean`
- `cache_copy_artifact_to(root, key, kind, dst) -> boolean`
- `cache_store_artifact(root, key, kind, src) -> boolean`

Both invalid digests AND unknown `kind` short-circuit to false before any filesystem access — same defensive shape as the four-artifact API.

### Wiring (`compiler/src/capsule_resolver.sfn`)

`compile_capsule_modules` resolves cache context **once per build** and threads it into each per-module call:

- `dep_manifests` = every staged manifest in the resolved set (conservative — refinement is a follow-up).
- `cache_root_path = cache_root()` — honors `$SAILFIN_BUILD_CACHE_DIR`.
- `cache_enabled = !($SAILFIN_NO_CACHE == "1")` — emergency rollback knob.
- `compiler_version = resolve_compiler_version("")` — same value for every module.
- `flags_canonical = "[]"` — placeholder until `sfn build -p` learns flags.

`_cr_compile_one` now:

1. Computes the cache key from (source, deps, version, flags).
2. Looks up `.ll` under the content-addressed root.
3. **Hit:** copies cached `.ll` to `src.ll_path`, skips compile.
4. **Miss:** compiles fresh, stores `.ll` for next time.

### Diagnostic trace

`SAILFIN_CACHE_TRACE=1` prints `[cache hit/miss/store] <slug>` to stderr — supports the manual e2e above and is the foundation for the eventual `sfn build --json` cache-stats report.

## Test plan

- [x] **Local rebuild** clean: `make compile` (134 modules, ~2.5 min).
- [x] **Cache unit tests:** 28/28 PASS (+5 from PR1 covering single-artifact API, unknown-kind rejection, invalid-digest rejection).
- [x] **Manual e2e** (output above): synthetic project depending on `sfn/math`, two-build hit/miss observation, sharded cache fs verified.
- [x] **Regression sample:**
  - `effect_checker_test.sfn` 18/18 PASS
  - `cli_path_normalization_test.sfn` 12/12 PASS
  - `capsule_dep_resolution_test.sfn` 21/21 PASS
- [ ] **CI:** full unit + integration + e2e + cross-compile matrix.

## What's next (PR1c, follow-up)

- Cache-stats struct threaded into the build report; first dataset for `sfn build --json`.
- `sfn build --no-cache` and `sfn build --clean` CLI flags (today the env var is the only knob).
- Refine `dep_manifests` from "all staged" to per-source imports so an unrelated capsule change doesn't bust every module's cache.

https://claude.ai/code/session_01EyxoafGBhk1G9qjKvHiqby

---
_Generated by [Claude Code](https://claude.ai/code/session_01EyxoafGBhk1G9qjKvHiqby)_