### PR TITLE
Stage C PR1c: cache stats + --no-cache / --clean / --cache-trace CLI flags

### DIFF
--- a/compiler/src/build_cache.sfn
+++ b/compiler/src/build_cache.sfn
@@ -89,6 +89,118 @@ struct CacheEntryPaths {
 }
 
 // ----------------------------------------------------------------
+// Cache stats
+// ----------------------------------------------------------------
+// Per-build counters surfaced to the CLI's end-of-build summary
+// (and, in a future PR, to `sfn build --json`'s build report).
+// All fields are simple counters with no allocation, so an empty
+// build that never touches the cache produces a single
+// zero-valued struct.
+//
+// Field semantics:
+//   - `hits` — the cache served the artifact; the producer pass
+//     was skipped entirely.
+//   - `misses` — no cached artifact for the key; the producer ran.
+//   - `stores` — a fresh artifact was successfully written into
+//     the cache after a miss. Counted independently of `misses`
+//     because a `cp` failure (e.g. read-only cache root) flips a
+//     successful build into "miss-but-not-stored", which CI may
+//     want to alarm on.
+//   - `invalid_keys` — `_is_valid_digest` rejected a digest before
+//     any filesystem access. Non-zero in production indicates a
+//     hash failure (sha256sum missing, source unreadable) — the
+//     build still succeeds, but cache hit rate goes to zero. CI
+//     gates can alarm on `invalid_keys > 0`.
+//   - `copy_failures` — the cache contained the artifact but
+//     `cache_copy_artifact_to` failed to materialise it (e.g.
+//     destination filesystem full). Treated as a miss for the
+//     producer, but tracked separately so the operator can
+//     distinguish "cache was empty" from "cache was poisoned".
+struct CacheStats {
+    hits: number;
+    misses: number;
+    stores: number;
+    invalid_keys: number;
+    copy_failures: number;
+}
+
+fn empty_cache_stats() -> CacheStats {
+    return CacheStats {
+        hits: 0,
+        misses: 0,
+        stores: 0,
+        invalid_keys: 0,
+        copy_failures: 0
+    };
+}
+
+// True iff the build produced no cache activity at all (zero
+// hits and zero misses). Useful for deciding whether to print
+// the cache summary line — empty stats from a manifest-less
+// project shouldn't show a `[cache] hits=0 misses=0 ...` line.
+fn cache_stats_is_empty(stats: CacheStats) -> boolean {
+    if stats.hits != 0 { return false; }
+    if stats.misses != 0 { return false; }
+    if stats.stores != 0 { return false; }
+    if stats.invalid_keys != 0 { return false; }
+    if stats.copy_failures != 0 { return false; }
+    return true;
+}
+
+// ----------------------------------------------------------------
+// Build-cache config (CLI flags + env-var overrides)
+// ----------------------------------------------------------------
+// Resolved once at the top of a build and threaded through the
+// resolver. Lets `sfn build --no-cache` and `sfn build --clean`
+// override the env-var defaults without setenv (Sailfin's runtime
+// env-var contract is read-only).
+//
+// Resolution rules:
+//   - `enabled` is true unless `SAILFIN_NO_CACHE=1` OR `--no-cache`.
+//   - `trace` is true if `SAILFIN_CACHE_TRACE=1` OR `--cache-trace`.
+//   - `clean` flips on only via `--clean`; no env-var equivalent
+//     because wiping the cache is a destructive op the user must
+//     opt into explicitly per invocation.
+struct BuildCacheConfig {
+    enabled: boolean;
+    trace: boolean;
+    clean: boolean;
+}
+
+fn empty_build_cache_config() -> BuildCacheConfig {
+    return BuildCacheConfig { enabled: true, trace: false, clean: false };
+}
+
+// `no_cache_flag` / `trace_flag` / `clean_flag` are the CLI
+// switches; this helper folds them with the env-var defaults.
+fn resolve_build_cache_config(no_cache_flag: boolean, trace_flag: boolean, clean_flag: boolean) -> BuildCacheConfig ![io] {
+    let env_disabled = strings_equal(_get_env_cmd("SAILFIN_NO_CACHE"), "1");
+    let env_trace = strings_equal(_get_env_cmd("SAILFIN_CACHE_TRACE"), "1");
+    return BuildCacheConfig {
+        enabled: !env_disabled && !no_cache_flag,
+        trace: env_trace || trace_flag,
+        clean: clean_flag
+    };
+}
+
+// Wipe the schema-versioned subtree under `root`. Returns true on
+// success (or no-op when the directory didn't exist), false if
+// `rm` failed. Defensive: refuses to operate on an empty path.
+//
+// Note: deletes the FULL `<override>/v<N>/...` tree the cache
+// stores under. Callers should resolve `cache_root()` first and
+// pass that — wiping `$SAILFIN_BUILD_CACHE_DIR` itself would
+// nuke any sibling schema versions that future compilers might
+// be relying on.
+fn cache_clean(root: string) -> boolean ![io] {
+    if root.length == 0 { return false; }
+    if strings_equal(root, "/") { return false; }
+    if !fs.exists(root) { return true; }
+    let rc = process.run(["rm", "-rf", root]);
+    return rc == 0;
+}
+
+// ----------------------------------------------------------------
 // Cache root resolution
 // ----------------------------------------------------------------
 // Pure variant — used by tests and by the production reader below.
@@ -444,6 +556,8 @@ fn cache_key_for(source_path: string, dep_layout_manifest_paths: string[], compi
 export {
     CacheKey,
     CacheEntryPaths,
+    CacheStats,
+    BuildCacheConfig,
     build_cache_schema_version,
     cache_root_with_override,
     cache_root,
@@ -455,5 +569,10 @@ export {
     cache_copy_artifact_to,
     cache_store_artifact,
     canonicalize_flags,
-    cache_key_for
+    cache_key_for,
+    empty_cache_stats,
+    cache_stats_is_empty,
+    empty_build_cache_config,
+    resolve_build_cache_config,
+    cache_clean
 };

--- a/compiler/src/build_cache.sfn
+++ b/compiler/src/build_cache.sfn
@@ -265,6 +265,17 @@ fn _cache_entry_dir(root: string, key: CacheKey) -> string {
 // nonsense paths like `<root>///ir.sfn-asm` and pollute the
 // cache root with cross-module collisions; treating them as a
 // hard miss is the safe default.
+// Public alias of `_is_valid_digest` so the resolver can use the
+// same predicate when classifying a freshly-derived `cache_key`.
+// Without sharing the validator, callers might check `digest.length
+// == 64` (which `sha256sum` always satisfies on success) but miss
+// the non-hex case (where a future hash function or an injected
+// digest could leak in). One source of truth keeps
+// `ModuleCacheEvent.invalid_key` honest.
+fn is_valid_digest(digest: string) -> boolean {
+    return _is_valid_digest(digest);
+}
+
 fn _is_valid_digest(digest: string) -> boolean {
     if digest.length != 64 { return false; }
     let mut i: number = 0;
@@ -574,5 +585,6 @@ export {
     cache_stats_is_empty,
     empty_build_cache_config,
     resolve_build_cache_config,
-    cache_clean
+    cache_clean,
+    is_valid_digest
 };

--- a/compiler/src/capsule_resolver.sfn
+++ b/compiler/src/capsule_resolver.sfn
@@ -46,7 +46,8 @@ import {
     cache_store_artifact,
     canonicalize_flags,
     empty_build_cache_config,
-    empty_cache_stats
+    empty_cache_stats,
+    is_valid_digest
 } from "./build_cache";
 import {
     compile_to_llvm_file_with_module,
@@ -564,17 +565,25 @@ fn _cr_collect_dep_manifest_paths(sources: CapsuleSource[]) -> string[] {
 // the caller (`compile_capsule_modules`) can fold per-module
 // outcomes into the per-build `CacheStats` struct without needing
 // mutable in/out parameters.
+//
+// `lookup_attempted` distinguishes "we tried the cache and missed"
+// from "we never asked the cache" — without it, every module
+// in a `--no-cache` build would count as a miss and trigger the
+// stats summary line, which is misleading for the user-facing
+// surface.
 struct ModuleCacheEvent {
     success: boolean;  // false → caller bails this build
+    lookup_attempted: boolean;  // true iff we consulted the cache
     hit: boolean;  // cache served the .ll; producer skipped
     stored: boolean;  // miss path stored a fresh artifact
-    invalid_key: boolean;  // _is_valid_digest rejected the digest
+    invalid_key: boolean;  // is_valid_digest rejected the digest
     copy_failed: boolean;  // cache had it; cp to dst failed
 }
 
 fn _cr_module_cache_event_failure() -> ModuleCacheEvent {
     return ModuleCacheEvent {
         success: false,
+        lookup_attempted: false,
         hit: false,
         stored: false,
         invalid_key: false,
@@ -603,13 +612,16 @@ fn _cr_compile_one(src: CapsuleSource, dep_manifests: string[], cache_root_path:
     // and final-input hashes.
     let mut cache_key: CacheKey = CacheKey { digest: "" };
     let mut copy_failed: boolean = false;
+    let mut lookup_attempted: boolean = false;
     if config.enabled {
+        lookup_attempted = true;
         cache_key = cache_key_for(src.source_path, dep_manifests, compiler_version, flags_canonical, src.slug);
         if cache_lookup_artifact(cache_root_path, cache_key, "ll") {
             if cache_copy_artifact_to(cache_root_path, cache_key, "ll", src.ll_path) {
                 if config.trace { print.err("[cache hit] " + src.slug); }
                 return ModuleCacheEvent {
                     success: true,
+                    lookup_attempted: true,
                     hit: true,
                     stored: false,
                     invalid_key: false,
@@ -642,8 +654,11 @@ fn _cr_compile_one(src: CapsuleSource, dep_manifests: string[], cache_root_path:
     if config.enabled {
         // `cache_store_artifact` returns false on invalid digest
         // OR cp failure — we surface the former separately so CI
-        // can distinguish "hash failed" from "fs failed."
-        if cache_key.digest.length == 64 {
+        // can distinguish "hash failed" from "fs failed." Use the
+        // same predicate (`is_valid_digest`) the cache layer uses
+        // internally so a non-hex digest is classified the same
+        // way at both the lookup and store sites.
+        if is_valid_digest(cache_key.digest) {
             stored = cache_store_artifact(cache_root_path, cache_key, "ll", src.ll_path);
             if config.trace {
                 if stored { print.err("[cache store] " + src.slug); } else {
@@ -659,6 +674,7 @@ fn _cr_compile_one(src: CapsuleSource, dep_manifests: string[], cache_root_path:
     }
     return ModuleCacheEvent {
         success: true,
+        lookup_attempted: lookup_attempted,
         hit: false,
         stored: stored,
         invalid_key: invalid_key,
@@ -678,7 +694,21 @@ fn compile_capsule_modules(sources: CapsuleSource[], config: BuildCacheConfig) -
     _cr_ensure_dir("build/sailfin/capsules");
     let dep_manifests = _cr_collect_dep_manifest_paths(sources);
     let cache_root_path = cache_root();
-    if config.clean { cache_clean(cache_root_path); }
+    if config.clean {
+        // `--clean` is a destructive opt-in. If the wipe fails
+        // (read-only fs, perms, etc.), surface a warning so the
+        // user knows the cache may still be partially populated
+        // — falling through silently would be surprising and
+        // hard to diagnose. The build itself proceeds: a stale
+        // cache with the same content keys still produces correct
+        // artifacts; only `--clean`'s "start fresh" guarantee is
+        // violated.
+        let cleaned = cache_clean(cache_root_path);
+        if !cleaned {
+            print.err("[cache] --clean: failed to wipe " + cache_root_path
+                + " (cache may be partially populated)");
+        }
+    }
     // Strict compiler-version lookup: NEVER falls through to a CWD
     // `capsule.toml` (the project's manifest), because the build
     // cache keys IR against the compiler binary's identity — letting
@@ -713,8 +743,15 @@ fn compile_capsule_modules(sources: CapsuleSource[], config: BuildCacheConfig) -
                 success: false
             };
         }
-        if evt.hit { stats.hits = stats.hits + 1; } else {
-            stats.misses = stats.misses + 1;
+        // Only count hits/misses when the cache was actually
+        // consulted. With `--no-cache` (or `SAILFIN_NO_CACHE=1`),
+        // every module is a fresh compile but the cache layer was
+        // never asked anything — counting them as misses would
+        // make the end-of-build summary misleading.
+        if evt.lookup_attempted {
+            if evt.hit { stats.hits = stats.hits + 1; } else {
+                stats.misses = stats.misses + 1;
+            }
         }
         if evt.stored { stats.stores = stats.stores + 1; }
         if evt.invalid_key { stats.invalid_keys = stats.invalid_keys + 1; }
@@ -1877,12 +1914,14 @@ fn _cr_resolve_and_dedupe(entry_paths: string[]) -> ResolverDedupeResult ![io] {
 }
 
 // Resolve, stage, and compile every dependency reachable from
-// `input_path`. Returns the list of dependency .ll paths to feed the
-// linker (empty when no dependencies are needed). On slug collision
-// or stage failure, prints a structured error and returns `[]` —
-// `sfn build`'s call sites do not currently distinguish those cases
-// from "no deps", since clang link will surface any missing-symbol
-// follow-up downstream.
+// `input_path`. Returns a `ProjectCapsuleResult` carrying the dep
+// `.ll` paths and the per-build cache stats. `ll_paths` is empty
+// when no dependencies are needed AND on slug collision or stage
+// failure — `sfn build`'s call sites do not currently distinguish
+// those cases from "no deps", since clang link will surface any
+// missing-symbol follow-up downstream. Inspect `stats` (and any
+// `print.err` output the helpers emitted) for setup failures vs.
+// genuinely-empty dep graphs.
 fn prepare_project_capsules(input_path: string, config: BuildCacheConfig) -> ProjectCapsuleResult ![io] {
     let empty_paths: string[] = [];
     let entry_paths: string[] = [input_path];

--- a/compiler/src/capsule_resolver.sfn
+++ b/compiler/src/capsule_resolver.sfn
@@ -35,15 +35,19 @@
 // capsule .ll paths, and clang produces a linked binary with all
 // capsule symbols resolved.
 import {
+    BuildCacheConfig,
     CacheKey,
+    CacheStats,
+    cache_clean,
     cache_copy_artifact_to,
     cache_key_for,
     cache_lookup_artifact,
     cache_root,
     cache_store_artifact,
-    canonicalize_flags
+    canonicalize_flags,
+    empty_build_cache_config,
+    empty_cache_stats
 } from "./build_cache";
-import { _get_env_cmd } from "./cli_commands_utils";
 import {
     compile_to_llvm_file_with_module,
     module_name_from_path,
@@ -76,6 +80,8 @@ export {
     prepare_project_capsules,
     prepare_project_capsules_for_check,
     prepare_project_capsules_for_test,
+    ProjectCapsuleResult,
+    CompileCapsuleResult,
     resolve_relative_import,
     stage_capsule_imports,
     compile_capsule_modules,
@@ -88,6 +94,25 @@ struct CapsuleSource {
     source_path: string;  // absolute path to the .sfn file
     slug: string;  // e.g. "sfn/cli/mod" — used for staging + symbol mangling
     ll_path: string;  // e.g. "build/sailfin/capsules/sfn__cli__mod.ll"
+}
+
+// Result of `compile_capsule_modules`: per-build .ll paths plus the
+// cache stats accumulated across all per-module compiles. `success`
+// distinguishes "no deps" (empty `ll_paths`, success=true) from a
+// compile failure (empty `ll_paths`, success=false).
+struct CompileCapsuleResult {
+    ll_paths: string[];
+    stats: CacheStats;
+    success: boolean;
+}
+
+// Result of `prepare_project_capsules` (the build / run path).
+// `ll_paths` is the dep `.ll` list for the linker; `stats` is the
+// per-build cache summary the CLI prints at the end (and that
+// `--json` will eventually emit as a structured field).
+struct ProjectCapsuleResult {
+    ll_paths: string[];
+    stats: CacheStats;
 }
 
 // One entry from the workspace's [workspace].members list, with the
@@ -535,33 +560,40 @@ fn _cr_collect_dep_manifest_paths(sources: CapsuleSource[]) -> string[] {
     return out;
 }
 
-// `SAILFIN_NO_CACHE=1` disables both cache lookups and stores —
-// emergency rollback knob if a cache bug ever surfaces. Returns
-// true when caching is enabled (the default).
-fn _cr_cache_enabled() -> boolean ![io] {
-    let raw = _get_env_cmd("SAILFIN_NO_CACHE");
-    return !strings_equal(raw, "1");
+// One module's cache outcome. Returned from `_cr_compile_one` so
+// the caller (`compile_capsule_modules`) can fold per-module
+// outcomes into the per-build `CacheStats` struct without needing
+// mutable in/out parameters.
+struct ModuleCacheEvent {
+    success: boolean;  // false → caller bails this build
+    hit: boolean;  // cache served the .ll; producer skipped
+    stored: boolean;  // miss path stored a fresh artifact
+    invalid_key: boolean;  // _is_valid_digest rejected the digest
+    copy_failed: boolean;  // cache had it; cp to dst failed
 }
 
-// `SAILFIN_CACHE_TRACE=1` prints `[cache hit/miss/store] <slug>`
-// to stderr so a user (or an e2e test) can observe cache
-// behaviour without parsing an opaque build report. Quiet by
-// default.
-fn _cr_cache_trace_enabled() -> boolean ![io] {
-    let raw = _get_env_cmd("SAILFIN_CACHE_TRACE");
-    return strings_equal(raw, "1");
+fn _cr_module_cache_event_failure() -> ModuleCacheEvent {
+    return ModuleCacheEvent {
+        success: false,
+        hit: false,
+        stored: false,
+        invalid_key: false,
+        copy_failed: false
+    };
 }
 
 // ---- Capsule module compilation ----
-// Lower a single capsule source to its own .ll so the final link can
-// resolve the main module's external declarations to the capsule's
-// definitions. With `cache_enabled = true`, looks up an existing
-// `.ll` artifact under the content-addressed cache before
-// compiling, and stores the result on a clean compile.
-fn _cr_compile_one(src: CapsuleSource, dep_manifests: string[], cache_root_path: string, cache_enabled: boolean, compiler_version: string, flags_canonical: string, trace: boolean) -> boolean ![io] {
+// Lower a single capsule source to its own .ll so the final link
+// can resolve the main module's external declarations to the
+// capsule's definitions. With `config.enabled = true`, looks up an
+// existing `.ll` artifact under the content-addressed cache before
+// compiling, and stores the result on a clean compile. Returns a
+// `ModuleCacheEvent` describing the outcome so the caller can
+// accumulate stats across the build.
+fn _cr_compile_one(src: CapsuleSource, dep_manifests: string[], cache_root_path: string, config: BuildCacheConfig, compiler_version: string, flags_canonical: string) -> ModuleCacheEvent ![io] {
     if !fs.exists(src.source_path) {
         print.err("capsule-resolver: missing source file: " + src.source_path);
-        return false;
+        return _cr_module_cache_event_failure();
     }
     let ll_dir = _cr_dirname(src.ll_path);
     _cr_ensure_dir(ll_dir);
@@ -570,16 +602,30 @@ fn _cr_compile_one(src: CapsuleSource, dep_manifests: string[], cache_root_path:
     // `_sha256_of_string`'s tmp paths unique across the dep-list
     // and final-input hashes.
     let mut cache_key: CacheKey = CacheKey { digest: "" };
-    if cache_enabled {
+    let mut copy_failed: boolean = false;
+    if config.enabled {
         cache_key = cache_key_for(src.source_path, dep_manifests, compiler_version, flags_canonical, src.slug);
         if cache_lookup_artifact(cache_root_path, cache_key, "ll") {
             if cache_copy_artifact_to(cache_root_path, cache_key, "ll", src.ll_path) {
-                if trace { print.err("[cache hit] " + src.slug); }
-                return true;
+                if config.trace { print.err("[cache hit] " + src.slug); }
+                return ModuleCacheEvent {
+                    success: true,
+                    hit: true,
+                    stored: false,
+                    invalid_key: false,
+                    copy_failed: false
+                };
             }
-            if trace { print.err("[cache copy-failed] " + src.slug); }
+            // Cache had the entry but materialisation failed (e.g.
+            // dst dir uncreatable on a read-only mount). Fall
+            // through to a fresh compile and record the outcome
+            // so CI can alarm on cache poisoning.
+            copy_failed = true;
+            if config.trace {
+                print.err("[cache copy-failed] " + src.slug);
+            }
         } else {
-            if trace { print.err("[cache miss] " + src.slug); }
+            if config.trace { print.err("[cache miss] " + src.slug); }
         }
     }
 
@@ -588,31 +634,51 @@ fn _cr_compile_one(src: CapsuleSource, dep_manifests: string[], cache_root_path:
     if !ok {
         print.err("capsule-resolver: failed to lower " + src.slug
             + " to LLVM IR");
-        return false;
+        return _cr_module_cache_event_failure();
     }
 
-    if cache_enabled {
-        let stored = cache_store_artifact(cache_root_path, cache_key, "ll", src.ll_path);
-        if trace {
-            if stored { print.err("[cache store] " + src.slug); } else {
-                print.err("[cache store-failed] " + src.slug);
+    let mut stored: boolean = false;
+    let mut invalid_key: boolean = false;
+    if config.enabled {
+        // `cache_store_artifact` returns false on invalid digest
+        // OR cp failure — we surface the former separately so CI
+        // can distinguish "hash failed" from "fs failed."
+        if cache_key.digest.length == 64 {
+            stored = cache_store_artifact(cache_root_path, cache_key, "ll", src.ll_path);
+            if config.trace {
+                if stored { print.err("[cache store] " + src.slug); } else {
+                    print.err("[cache store-failed] " + src.slug);
+                }
+            }
+        } else {
+            invalid_key = true;
+            if config.trace {
+                print.err("[cache invalid-key] " + src.slug);
             }
         }
     }
-    return true;
+    return ModuleCacheEvent {
+        success: true,
+        hit: false,
+        stored: stored,
+        invalid_key: invalid_key,
+        copy_failed: copy_failed
+    };
 }
 
-// Compile every capsule module to its own .ll and return the list of
-// .ll paths to feed the linker. Resolves cache context once at the
-// top — dep-manifest paths, cache root, env-driven enable/trace —
-// and threads it into each per-module call.
-fn compile_capsule_modules(sources: CapsuleSource[]) -> string[] ![io] {
+// Compile every capsule module to its own .ll and return the
+// `CompileCapsuleResult` for the build (paths + stats + success).
+// `config` carries the CLI flag overrides; pass
+// `empty_build_cache_config()` for callers that want the default
+// env-driven behaviour. Honours `config.clean` by wiping the cache
+// root before any per-module work — done once per build, not per
+// module, so a single `--clean` run can't double-wipe.
+fn compile_capsule_modules(sources: CapsuleSource[], config: BuildCacheConfig) -> CompileCapsuleResult ![io] {
     _cr_ensure_dir("build/sailfin");
     _cr_ensure_dir("build/sailfin/capsules");
     let dep_manifests = _cr_collect_dep_manifest_paths(sources);
     let cache_root_path = cache_root();
-    let cache_enabled = _cr_cache_enabled();
-    let trace = _cr_cache_trace_enabled();
+    if config.clean { cache_clean(cache_root_path); }
     // Strict compiler-version lookup: NEVER falls through to a CWD
     // `capsule.toml` (the project's manifest), because the build
     // cache keys IR against the compiler binary's identity — letting
@@ -635,15 +701,34 @@ fn compile_capsule_modules(sources: CapsuleSource[]) -> string[] ![io] {
     let empty_flags: string[] = [];
     let flags_canonical = canonicalize_flags(empty_flags);
     let mut out: string[] = [];
+    let mut stats = empty_cache_stats();
     let mut i: number = 0;
     loop {
         if i >= sources.length { break; }
-        let ok = _cr_compile_one(sources[i], dep_manifests, cache_root_path, cache_enabled, compiler_version, flags_canonical, trace);
-        if !ok { return []; }
+        let evt = _cr_compile_one(sources[i], dep_manifests, cache_root_path, config, compiler_version, flags_canonical);
+        if !evt.success {
+            return CompileCapsuleResult {
+                ll_paths: out,
+                stats: stats,
+                success: false
+            };
+        }
+        if evt.hit { stats.hits = stats.hits + 1; } else {
+            stats.misses = stats.misses + 1;
+        }
+        if evt.stored { stats.stores = stats.stores + 1; }
+        if evt.invalid_key { stats.invalid_keys = stats.invalid_keys + 1; }
+        if evt.copy_failed {
+            stats.copy_failures = stats.copy_failures + 1;
+        }
         out.push(sources[i].ll_path);
         i += 1;
     }
-    return out;
+    return CompileCapsuleResult {
+        ll_paths: out,
+        stats: stats,
+        success: true
+    };
 }
 
 // ---- Workspace discovery ----
@@ -1798,18 +1883,42 @@ fn _cr_resolve_and_dedupe(entry_paths: string[]) -> ResolverDedupeResult ![io] {
 // `sfn build`'s call sites do not currently distinguish those cases
 // from "no deps", since clang link will surface any missing-symbol
 // follow-up downstream.
-fn prepare_project_capsules(input_path: string) -> string[] ![io] {
+fn prepare_project_capsules(input_path: string, config: BuildCacheConfig) -> ProjectCapsuleResult ![io] {
+    let empty_paths: string[] = [];
     let entry_paths: string[] = [input_path];
     let resolved = _cr_resolve_and_dedupe(entry_paths);
-    if resolved.has_collision { return []; }
-    if resolved.sources.length == 0 { return []; }
+    if resolved.has_collision {
+        return ProjectCapsuleResult {
+            ll_paths: empty_paths,
+            stats: empty_cache_stats()
+        };
+    }
+    if resolved.sources.length == 0 {
+        return ProjectCapsuleResult {
+            ll_paths: empty_paths,
+            stats: empty_cache_stats()
+        };
+    }
 
     let staged = stage_capsule_imports(resolved.sources);
     if !staged {
         print.err("capsule-resolver: failed to stage import-context for project capsules");
-        return [];
+        return ProjectCapsuleResult {
+            ll_paths: empty_paths,
+            stats: empty_cache_stats()
+        };
     }
-    return compile_capsule_modules(resolved.sources);
+    let result = compile_capsule_modules(resolved.sources, config);
+    if !result.success {
+        return ProjectCapsuleResult {
+            ll_paths: empty_paths,
+            stats: result.stats
+        };
+    }
+    return ProjectCapsuleResult {
+        ll_paths: result.ll_paths,
+        stats: result.stats
+    };
 }
 
 // Resolver pass tuned for `sfn check`: enumerate, dedupe, and stage
@@ -1962,13 +2071,17 @@ fn prepare_project_capsules_for_test(entry_paths: string[]) -> TestCapsuleResolu
         ai += 1;
     }
 
-    let ll_paths = compile_capsule_modules(resolved.sources);
-    // `compile_capsule_modules` returns `[]` on compile failure for any
-    // source; with `resolved.sources.length > 0` (guarded above) an
-    // empty list unambiguously means failure. Surface it as a setup
-    // error so the test runner exits 2 instead of trying to link
-    // against missing helper objects.
-    if ll_paths.length == 0 {
+    // `sfn test` doesn't yet take a CLI cache config; pass the
+    // env-driven default. When the test runner grows `--no-cache`
+    // / `--clean`, thread the resolved config in here.
+    let test_config = empty_build_cache_config();
+    let result = compile_capsule_modules(resolved.sources, test_config);
+    // Surface a compile failure as `staging_failed = true` so the
+    // test runner exits 2 instead of trying to link against
+    // missing helper objects. (The PR1c stats are dropped on this
+    // path — once the test runner needs them, the
+    // `TestCapsuleResolution` struct gets a `cache_stats` field.)
+    if !result.success {
         return TestCapsuleResolution {
             asm_paths: asm_paths,
             ll_paths: empty_paths,
@@ -1980,7 +2093,7 @@ fn prepare_project_capsules_for_test(entry_paths: string[]) -> TestCapsuleResolu
 
     return TestCapsuleResolution {
         asm_paths: asm_paths,
-        ll_paths: ll_paths,
+        ll_paths: result.ll_paths,
         capsule_count: resolved.sources.length,
         staging_failed: false,
         capabilities_required: resolved.capabilities_required

--- a/compiler/src/cli_main.sfn
+++ b/compiler/src/cli_main.sfn
@@ -5,7 +5,6 @@ import {
     BuildCacheConfig,
     CacheStats,
     cache_stats_is_empty,
-    empty_build_cache_config,
     resolve_build_cache_config
 } from "./build_cache";
 import { ProjectCapsuleResult, prepare_project_capsules } from "./capsule_resolver";
@@ -719,11 +718,11 @@ fn sailfin_cli_main(argv: string[]) -> number ![io, clock] {
         // Resolve and compile capsule deps before lowering the main file.
         // The unified resolver covers relative imports, manifest-declared
         // capsule deps, and workspace-implicit imports in one pass —
-        // text-level fallback retired with Stage B. `sfn run` uses the
-        // env-driven default cache config (no CLI flags wired yet);
-        // a follow-up PR can add `--no-cache` / `--clean` to `sfn run`
-        // by mirroring the build path's flag-parser block.
-        let run_cache_config = empty_build_cache_config();
+        // text-level fallback retired with Stage B. `sfn run` does not
+        // yet take CLI cache flags, so all overrides come from env
+        // (`SAILFIN_NO_CACHE` / `SAILFIN_CACHE_TRACE`); CLI flag plumbing
+        // is a follow-up that mirrors the build path's parser block.
+        let run_cache_config = resolve_build_cache_config(false, false, false);
         let run_capsule_result = prepare_project_capsules(input_path, run_cache_config);
         let capsule_lls = run_capsule_result.ll_paths;
 

--- a/compiler/src/cli_main.sfn
+++ b/compiler/src/cli_main.sfn
@@ -1,7 +1,14 @@
 // compiler/src/cli_main.sfn
 //
 // Sailfin-native CLI entrypoint invoked by the native C shim.
-import { prepare_project_capsules } from "./capsule_resolver";
+import {
+    BuildCacheConfig,
+    CacheStats,
+    cache_stats_is_empty,
+    empty_build_cache_config,
+    resolve_build_cache_config
+} from "./build_cache";
+import { ProjectCapsuleResult, prepare_project_capsules } from "./capsule_resolver";
 import { handle_check_command } from "./cli_check";
 import {
     handle_add_command,
@@ -31,7 +38,8 @@ fn _usage() -> string {
     let mut out: string = "usage: sfn <command> [options]\n";
     out = out + "\n";
     out = out + "build & run:\n";
-    out = out + "  sfn build [-o OUTPUT] (<file.sfn> | -p <capsule-path>)\n";
+    out = out
+        + "  sfn build [-o OUTPUT] [--no-cache] [--clean] [--cache-trace] (<file.sfn> | -p <capsule-path>)\n";
     out = out + "  sfn run   <file.sfn | exe>\n";
     out = out
         + "  sfn emit  [--timing] [-o OUTPUT] llvm|sailfin|native <file.sfn>\n";
@@ -92,6 +100,24 @@ fn _write_llvm_text(path: string, llvm: string) ![io] {
     // native runtime boundary via fs.writeLines, which can hang if array ABI
     // metadata is corrupted.
     fs.writeFile(path, llvm);
+}
+
+// Print the per-build cache stats summary in the
+// `[cache] hits=N misses=M stores=K invalid_keys=I copy_failures=F`
+// shape — quiet for builds with no cache activity (no manifest deps,
+// or `--no-cache`). The shape is the human-readable counterpart of
+// the eventual `--json` build report's `cache` field; keep them in
+// sync if either changes.
+fn _print_cache_summary(stats: CacheStats) ![io] {
+    if cache_stats_is_empty(stats) { return; }
+    print("[cache] hits=" + number_to_string(stats.hits) + " misses="
+        + number_to_string(stats.misses)
+        + " stores="
+        + number_to_string(stats.stores)
+        + " invalid_keys="
+        + number_to_string(stats.invalid_keys)
+        + " copy_failures="
+        + number_to_string(stats.copy_failures));
 }
 
 fn _ensure_dir(path: string) ![io] {
@@ -511,10 +537,14 @@ fn sailfin_cli_main(argv: string[]) -> number ![io, clock] {
     }
 
     if is_build {
-        // build [-o OUTPUT] (file | -p <capsule-path>)
+        // build [-o OUTPUT] [--no-cache] [--clean] [--cache-trace]
+        //       (file | -p <capsule-path>)
         let mut out_path: string = "";
         let mut input_path: string = "";
         let mut capsule_path: string = "";
+        let mut no_cache_flag: boolean = false;
+        let mut clean_flag: boolean = false;
+        let mut cache_trace_flag: boolean = false;
 
         // Parse args: support -o OUTPUT and -p PATH in any combination.
         let mut bi: number = 1;
@@ -539,6 +569,21 @@ fn sailfin_cli_main(argv: string[]) -> number ![io, clock] {
                 bi += 2;
                 continue;
             }
+            if strings_equal(a, "--no-cache") {
+                no_cache_flag = true;
+                bi += 1;
+                continue;
+            }
+            if strings_equal(a, "--clean") {
+                clean_flag = true;
+                bi += 1;
+                continue;
+            }
+            if strings_equal(a, "--cache-trace") {
+                cache_trace_flag = true;
+                bi += 1;
+                continue;
+            }
             // Positional argument: the source file.
             if input_path.length > 0 {
                 print(_usage());
@@ -547,6 +592,7 @@ fn sailfin_cli_main(argv: string[]) -> number ![io, clock] {
             input_path = a;
             bi += 1;
         }
+        let cache_config = resolve_build_cache_config(no_cache_flag, cache_trace_flag, clean_flag);
 
         // -p resolves the entry path + build kind from the capsule's
         // manifest. The build then proceeds as for a positional source
@@ -595,7 +641,8 @@ fn sailfin_cli_main(argv: string[]) -> number ![io, clock] {
         // capsule.toml before compiling the main source. stage_capsule_imports
         // writes .sfn-asm + .layout-manifest into build/native/import-context/
         // where the main module's lowering will find them.
-        let capsule_lls = prepare_project_capsules(input_path);
+        let capsule_result = prepare_project_capsules(input_path, cache_config);
+        let capsule_lls = capsule_result.ll_paths;
 
         let ll_path = "build/sailfin/program.ll";
         let source = fs.readFile(input_path);
@@ -621,6 +668,7 @@ fn sailfin_cli_main(argv: string[]) -> number ![io, clock] {
                 return rc_obj;
             }
             print("built: " + out_path);
+            _print_cache_summary(capsule_result.stats);
             return 0;
         }
 
@@ -639,6 +687,7 @@ fn sailfin_cli_main(argv: string[]) -> number ![io, clock] {
             return rc;
         }
         print("built: " + exe_path);
+        _print_cache_summary(capsule_result.stats);
         return 0;
     }
 
@@ -670,8 +719,13 @@ fn sailfin_cli_main(argv: string[]) -> number ![io, clock] {
         // Resolve and compile capsule deps before lowering the main file.
         // The unified resolver covers relative imports, manifest-declared
         // capsule deps, and workspace-implicit imports in one pass —
-        // text-level fallback retired with Stage B.
-        let capsule_lls = prepare_project_capsules(input_path);
+        // text-level fallback retired with Stage B. `sfn run` uses the
+        // env-driven default cache config (no CLI flags wired yet);
+        // a follow-up PR can add `--no-cache` / `--clean` to `sfn run`
+        // by mirroring the build path's flag-parser block.
+        let run_cache_config = empty_build_cache_config();
+        let run_capsule_result = prepare_project_capsules(input_path, run_cache_config);
+        let capsule_lls = run_capsule_result.ll_paths;
 
         let source = fs.readFile(input_path);
         let module_name = module_name_from_path(input_path);

--- a/compiler/tests/unit/build_cache_test.sfn
+++ b/compiler/tests/unit/build_cache_test.sfn
@@ -41,7 +41,8 @@ import {
     canonicalize_flags,
     cache_key_for,
     empty_build_cache_config,
-    empty_cache_stats
+    empty_cache_stats,
+    is_valid_digest
 } from "../../src/build_cache";
 
 // --------------------------------------------------------------
@@ -533,4 +534,31 @@ test "build_cache: cache_clean refuses to operate on root '/'" ![io] {
 
 test "build_cache: cache_clean refuses empty path" ![io] {
     assert ! cache_clean("");
+}
+
+// --------------------------------------------------------------
+// is_valid_digest predicate (Copilot review on PR #256 — line 647)
+// --------------------------------------------------------------
+// The resolver previously checked `digest.length == 64` to decide
+// whether to attempt a cache store. That treats a 64-char non-hex
+// digest as valid, which contradicts `_is_valid_digest`'s
+// contract. Exporting `is_valid_digest` as the single source of
+// truth closes the gap. These tests lock the contract.
+test "is_valid_digest: 64 lowercase hex chars accepted" {
+    assert is_valid_digest("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef");
+}
+
+test "is_valid_digest: empty rejected" { assert ! is_valid_digest(""); }
+
+test "is_valid_digest: too short rejected" {
+    assert ! is_valid_digest("abcdef");
+}
+
+test "is_valid_digest: 64 uppercase chars rejected" {
+    assert ! is_valid_digest("ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789");
+}
+
+test "is_valid_digest: 64 chars with non-hex letter rejected" {
+    // 'g' is outside [0-9a-f].
+    assert ! is_valid_digest("g123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef");
 }

--- a/compiler/tests/unit/build_cache_test.sfn
+++ b/compiler/tests/unit/build_cache_test.sfn
@@ -24,9 +24,12 @@
 // var contract is intentionally read-only. Each test cleans up
 // its tmp tree on exit.
 import {
+    BuildCacheConfig,
     CacheKey,
+    CacheStats,
     build_cache_schema_version,
     cache_artifact_path,
+    cache_clean,
     cache_copy_artifact_to,
     cache_lookup_artifact,
     cache_lookup_complete,
@@ -34,8 +37,11 @@ import {
     cache_root_with_override,
     cache_store,
     cache_store_artifact,
+    cache_stats_is_empty,
     canonicalize_flags,
-    cache_key_for
+    cache_key_for,
+    empty_build_cache_config,
+    empty_cache_stats
 } from "../../src/build_cache";
 
 // --------------------------------------------------------------
@@ -459,4 +465,72 @@ test "build_cache: cache_lookup_artifact rejects invalid digest" ![io] {
     let key = CacheKey { digest: "" };
     assert ! cache_lookup_artifact(cache_root, key, "ll");
     _cleanup(scratch);
+}
+
+// --------------------------------------------------------------
+// Stats + config (Stage C PR1c)
+// --------------------------------------------------------------
+test "build_cache: empty_cache_stats has all zero counters" {
+    let s = empty_cache_stats();
+    assert s.hits == 0;
+    assert s.misses == 0;
+    assert s.stores == 0;
+    assert s.invalid_keys == 0;
+    assert s.copy_failures == 0;
+}
+
+test "build_cache: cache_stats_is_empty true on zero stats" {
+    assert cache_stats_is_empty(empty_cache_stats());
+}
+
+test "build_cache: cache_stats_is_empty false when any counter is non-zero" {
+    let mut s = empty_cache_stats();
+    s.hits = 1;
+    assert ! cache_stats_is_empty(s);
+    let mut t = empty_cache_stats();
+    t.copy_failures = 1;
+    assert ! cache_stats_is_empty(t);
+}
+
+test "build_cache: empty_build_cache_config defaults are enabled+quiet" {
+    let c = empty_build_cache_config();
+    assert c.enabled;
+    assert ! c.trace;
+    assert ! c.clean;
+}
+
+test "build_cache: cache_clean wipes the schema-versioned tree" ![io] {
+    let scratch = _test_tmp_root("clean_wipe");
+    let cache_root = scratch + "/cache/v1";
+    process.run(["mkdir", "-p", cache_root + "/ab/abcdef"]);
+    let f = cache_root + "/ab/abcdef/mod.ll";
+    _write_file(f, "; bytes");
+    assert fs.exists(f);
+
+    let cleaned = cache_clean(cache_root);
+    assert cleaned;
+    assert ! fs.exists(cache_root);
+    _cleanup(scratch);
+}
+
+test "build_cache: cache_clean is no-op when root does not exist" ![io] {
+    let scratch = _test_tmp_root("clean_noop");
+    let nonexistent_root = scratch + "/never-created";
+    assert ! fs.exists(nonexistent_root);
+    let cleaned = cache_clean(nonexistent_root);
+    assert cleaned;
+    _cleanup(scratch);
+}
+
+test "build_cache: cache_clean refuses to operate on root '/'" ![io] {
+    // Defensive check — without this guard, a misconfigured
+    // SAILFIN_BUILD_CACHE_DIR could end up nuking the entire fs
+    // when --clean is passed. The function must hard-reject "/"
+    // even though every legitimate cache root is at least
+    // `/tmp/.../v1` deep.
+    assert ! cache_clean("/");
+}
+
+test "build_cache: cache_clean refuses empty path" ![io] {
+    assert ! cache_clean("");
 }


### PR DESCRIPTION
## Summary

Closes the cache surface for Stage C: per-build cache statistics + first-class CLI flags. Builds on PR #254 (cache module foundation) and PR #255 (cache wired into the per-capsule compile hot path).

End-user behavior:

```
$ sfn build src/main.sfn               # first run
built: build/program
[cache] hits=0 misses=1 stores=1 invalid_keys=0 copy_failures=0

$ sfn build src/main.sfn               # second run
built: build/program
[cache] hits=1 misses=0 stores=0 invalid_keys=0 copy_failures=0

$ sfn build --clean --cache-trace src/main.sfn
[cache miss] sfn/math/mod
[cache store] sfn/math/mod
built: build/program
[cache] hits=0 misses=1 stores=1 invalid_keys=0 copy_failures=0
```

## What ships

### `CacheStats` struct (`build_cache.sfn`)

```sfn
struct CacheStats {
    hits: number;
    misses: number;
    stores: number;
    invalid_keys: number;
    copy_failures: number;
}
```

`invalid_keys` and `copy_failures` make it easy for CI to alarm on cache health regressions ("yesterday 0 invalid_keys; today 47") without grepping stderr. The struct's shape is the eventual `--json` build report's `cache` field — locked in here.

### `BuildCacheConfig` struct + `resolve_build_cache_config`

```sfn
struct BuildCacheConfig { enabled: boolean; trace: boolean; clean: boolean; }
```

Folds CLI flag overrides with env-var defaults. `--clean` has no env-var equivalent — wiping the cache must be opt-in per invocation.

### `cache_clean(root)`

Wipes the schema-versioned subtree. Defensive: refuses empty path, refuses `/`, no-ops on non-existent root.

### CLI flags on `sfn build` (`cli_main.sfn`)

| Flag | Effect | Env equivalent |
|---|---|---|
| `--no-cache` | disable cache lookups + stores | `SAILFIN_NO_CACHE=1` |
| `--clean` | wipe `<cache_root>/v1/...` before building | (none — opt-in only) |
| `--cache-trace` | print `[cache hit/miss/store] <slug>` per module | `SAILFIN_CACHE_TRACE=1` |

Mutually composable. Usage line updated.

### API change: `compile_capsule_modules` returns a struct

```sfn
struct CompileCapsuleResult {
    ll_paths: string[];
    stats: CacheStats;
    success: boolean;
}
```

Per-module outcomes are folded via a new `ModuleCacheEvent` struct so the caller accumulates stats without mutable in/out parameters. `prepare_project_capsules` returns a similar `ProjectCapsuleResult { ll_paths, stats }`. Two CLI consumers (`sfn build`, `sfn run`) and one resolver helper (`prepare_project_capsules_for_test`) updated.

## Test plan

- [x] `make compile` clean (134 modules).
- [x] **Cache unit tests:** 37/37 PASS (+8 from PR1b: 4 stats helpers, 1 config defaults, 4 cache_clean variants).
- [x] **E2E (output above):** clean → warm → `--no-cache` → `--clean --cache-trace` all behave as designed.
- [x] **Regression sample:**
  - `effect_checker_test.sfn` 18/18 PASS
  - `cli_path_normalization_test.sfn` 12/12 PASS
  - `version_resolution_test.sfn` 8/8 PASS
  - `capsule_dep_resolution_test.sfn` 21/21 PASS
- [ ] **CI:** full unit + integration + e2e + cross-compile matrix.

## What's next (PR1d, follow-up)

- Per-source `dep_manifests` (today: all staged manifests — conservative; refines to per-source imports so an unrelated capsule change doesn't bust every module's cache).
- `sfn run` flag plumbing (mirror the build path's parser block).
- `sfn build --json` build report — `cache` field consumes the `CacheStats` struct shipped here.

https://claude.ai/code/session_01EyxoafGBhk1G9qjKvHiqby

---
_Generated by [Claude Code](https://claude.ai/code/session_01EyxoafGBhk1G9qjKvHiqby)_