### PR TITLE
Stage C PR1d: mirror cache flag parser onto sfn run

### DIFF
--- a/compiler/src/cli_main.sfn
+++ b/compiler/src/cli_main.sfn
@@ -40,7 +40,7 @@ fn _usage() -> string {
     out = out
         + "  sfn build [-o OUTPUT] [--no-cache] [--clean] [--cache-trace] (<file.sfn> | -p <capsule-path>)\n";
     out = out
-        + "  sfn run   [--no-cache] [--clean] [--cache-trace] <file.sfn | exe>\n";
+        + "  sfn run   [--no-cache] [--clean] [--cache-trace] (<file.sfn> | <exe>)\n";
     out = out
         + "  sfn emit  [--timing] [-o OUTPUT] llvm|sailfin|native <file.sfn>\n";
     out = out + "\n";

--- a/compiler/src/cli_main.sfn
+++ b/compiler/src/cli_main.sfn
@@ -39,7 +39,8 @@ fn _usage() -> string {
     out = out + "build & run:\n";
     out = out
         + "  sfn build [-o OUTPUT] [--no-cache] [--clean] [--cache-trace] (<file.sfn> | -p <capsule-path>)\n";
-    out = out + "  sfn run   <file.sfn | exe>\n";
+    out = out
+        + "  sfn run   [--no-cache] [--clean] [--cache-trace] <file.sfn | exe>\n";
     out = out
         + "  sfn emit  [--timing] [-o OUTPUT] llvm|sailfin|native <file.sfn>\n";
     out = out + "\n";
@@ -691,12 +692,44 @@ fn sailfin_cli_main(argv: string[]) -> number ![io, clock] {
     }
 
     if is_run {
-        if args.length != 2 {
+        // run [--no-cache] [--clean] [--cache-trace] <file.sfn | exe>
+        let mut input_path: string = "";
+        let mut no_cache_flag: boolean = false;
+        let mut clean_flag: boolean = false;
+        let mut cache_trace_flag: boolean = false;
+
+        let mut ri: number = 1;
+        loop {
+            if ri >= args.length { break; }
+            let a = args[ri];
+            if strings_equal(a, "--no-cache") {
+                no_cache_flag = true;
+                ri += 1;
+                continue;
+            }
+            if strings_equal(a, "--clean") {
+                clean_flag = true;
+                ri += 1;
+                continue;
+            }
+            if strings_equal(a, "--cache-trace") {
+                cache_trace_flag = true;
+                ri += 1;
+                continue;
+            }
+            // Positional argument: the source file (or executable).
+            if input_path.length > 0 {
+                print(_usage());
+                return 2;
+            }
+            input_path = a;
+            ri += 1;
+        }
+        if input_path.length == 0 {
             print(_usage());
 
             return 2;
         }
-        let input_path = args[1];
 
         // If the argument doesn't look like Sailfin source, treat it as an executable.
         if !_ends_with(input_path, ".sfn") {
@@ -718,11 +751,10 @@ fn sailfin_cli_main(argv: string[]) -> number ![io, clock] {
         // Resolve and compile capsule deps before lowering the main file.
         // The unified resolver covers relative imports, manifest-declared
         // capsule deps, and workspace-implicit imports in one pass —
-        // text-level fallback retired with Stage B. `sfn run` does not
-        // yet take CLI cache flags, so all overrides come from env
-        // (`SAILFIN_NO_CACHE` / `SAILFIN_CACHE_TRACE`); CLI flag plumbing
-        // is a follow-up that mirrors the build path's parser block.
-        let run_cache_config = resolve_build_cache_config(false, false, false);
+        // text-level fallback retired with Stage B. CLI overrides
+        // (`--no-cache` / `--clean` / `--cache-trace`) layer on top of
+        // env-var defaults (`SAILFIN_NO_CACHE` / `SAILFIN_CACHE_TRACE`).
+        let run_cache_config = resolve_build_cache_config(no_cache_flag, cache_trace_flag, clean_flag);
         let run_capsule_result = prepare_project_capsules(input_path, run_cache_config);
         let capsule_lls = run_capsule_result.ll_paths;
 
@@ -752,6 +784,11 @@ fn sailfin_cli_main(argv: string[]) -> number ![io, clock] {
             return link_rc;
         }
 
+        // Cache summary mirrors `sfn build`: quiet for builds with no
+        // cache activity (no manifest deps, or `--no-cache`), and the
+        // human-readable counterpart of the eventual `--json` build
+        // report's `cache` field.
+        _print_cache_summary(run_capsule_result.stats);
         let run_rc = process.run([exe_path]);
         return run_rc;
     }

--- a/compiler/tests/e2e/test_run_cache_flags.sh
+++ b/compiler/tests/e2e/test_run_cache_flags.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# End-to-end test for `sfn run` cache flag plumbing (Stage C PR1d).
+#
+# Verifies that `sfn run` honours the same cache contract as
+# `sfn build`:
+#   - backwards-compat `sfn run <file>` (no flags) still works
+#   - `--no-cache` suppresses the cache summary line
+#   - `--clean` wipes `<cache_root>/v1/...` before building
+#   - `--cache-trace` emits per-module `[cache hit/miss/store]` lines
+#   - the cache stats summary fires after a successful run when the
+#     cache was consulted
+#
+# Mirrors the `sfn build` flag surface from PR #256, so the two
+# commands stay in lockstep. If either drifts, this test catches it.
+#
+# Usage:
+#   compiler/tests/e2e/test_run_cache_flags.sh <compiler-binary>
+
+set -euo pipefail
+
+BINARY="${1:?usage: test_run_cache_flags.sh <compiler-binary>}"
+BINARY="$(realpath "$BINARY")"
+PASS=0
+FAIL=0
+
+SCRATCH="$(mktemp -d -t sfn-run-cache-flags-XXXXXX)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+
+run_test() {
+    local name="$1"
+    shift
+    if "$@"; then
+        echo "[test] PASS: $name"
+        PASS=$((PASS + 1))
+    else
+        echo "[test] FAIL: $name"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# ---- Setup: a project depending on sfn/math so cache work happens ----
+mkdir -p "$SCRATCH/src"
+ln -s "$REPO_ROOT/capsules" "$SCRATCH/capsules"
+
+cat > "$SCRATCH/capsule.toml" <<'EOF'
+[capsule]
+name = "run-cache-flags-test"
+version = "0.1.0"
+description = "E2E test for sfn run cache flag plumbing"
+
+[dependencies]
+"sfn/math" = "0.1.0"
+
+[capabilities]
+required = ["io"]
+
+[build]
+entry = "src/main.sfn"
+EOF
+
+cat > "$SCRATCH/src/main.sfn" <<'EOF'
+import { abs } from "sfn/math";
+fn main() ![io] {
+    if abs(-7) != 7 { print("FAIL"); } else { print("OK"); }
+}
+EOF
+
+CACHE_DIR="$SCRATCH/cache"
+
+# ---- Test 1: backwards compat — `sfn run <file>` with no flags ----
+test_run_backwards_compat() {
+    cd "$SCRATCH" || return 1
+    SAILFIN_BUILD_CACHE_DIR="$CACHE_DIR" "$BINARY" run src/main.sfn \
+        > "$SCRATCH/run1.stdout" 2>&1
+    local rc=$?
+    if [ "$rc" -ne 0 ]; then
+        echo "[test]   sfn run exited with code $rc; output:" >&2
+        cat "$SCRATCH/run1.stdout" >&2
+        return $rc
+    fi
+    grep -q "^OK$" "$SCRATCH/run1.stdout"
+}
+run_test "sfn run <file> still works (no flags)" test_run_backwards_compat
+
+# ---- Test 2: cold run prints summary with miss + store ----
+test_first_run_summary() {
+    grep -qE '^\[cache\] hits=0 misses=1 stores=1' "$SCRATCH/run1.stdout"
+}
+run_test "first run prints '[cache] hits=0 misses=1 stores=1'" test_first_run_summary
+
+# ---- Test 3: warm run prints summary with a hit ----
+test_warm_run_hit() {
+    cd "$SCRATCH" || return 1
+    SAILFIN_BUILD_CACHE_DIR="$CACHE_DIR" "$BINARY" run src/main.sfn \
+        > "$SCRATCH/run2.stdout" 2>&1
+    local rc=$?
+    if [ "$rc" -ne 0 ]; then
+        echo "[test]   warm run exited with code $rc; output:" >&2
+        cat "$SCRATCH/run2.stdout" >&2
+        return $rc
+    fi
+    grep -qE '^\[cache\] hits=1 misses=0' "$SCRATCH/run2.stdout"
+}
+run_test "warm run prints '[cache] hits=1 misses=0'" test_warm_run_hit
+
+# ---- Test 4: --no-cache suppresses the summary line entirely ----
+test_no_cache_suppresses_summary() {
+    cd "$SCRATCH" || return 1
+    SAILFIN_BUILD_CACHE_DIR="$CACHE_DIR" "$BINARY" run --no-cache src/main.sfn \
+        > "$SCRATCH/run_no_cache.stdout" 2>&1
+    local rc=$?
+    if [ "$rc" -ne 0 ]; then
+        echo "[test]   --no-cache run exited with code $rc; output:" >&2
+        cat "$SCRATCH/run_no_cache.stdout" >&2
+        return $rc
+    fi
+    grep -q "^OK$" "$SCRATCH/run_no_cache.stdout" || return 1
+    # The summary line must NOT appear; lookup_attempted is false on
+    # every module so cache_stats_is_empty short-circuits the print.
+    if grep -qE '^\[cache\]' "$SCRATCH/run_no_cache.stdout"; then
+        echo "[test]   --no-cache run produced a cache summary; output:" >&2
+        cat "$SCRATCH/run_no_cache.stdout" >&2
+        return 1
+    fi
+    return 0
+}
+run_test "sfn run --no-cache prints no '[cache]' summary" test_no_cache_suppresses_summary
+
+# ---- Test 5: --cache-trace emits per-module trace lines ----
+test_cache_trace_lines() {
+    cd "$SCRATCH" || return 1
+    SAILFIN_BUILD_CACHE_DIR="$CACHE_DIR" "$BINARY" run --cache-trace src/main.sfn \
+        > "$SCRATCH/run_trace.stdout" 2>&1
+    local rc=$?
+    if [ "$rc" -ne 0 ]; then
+        echo "[test]   --cache-trace run exited with code $rc; output:" >&2
+        cat "$SCRATCH/run_trace.stdout" >&2
+        return $rc
+    fi
+    grep -qE '^\[cache hit\] sfn/math/mod' "$SCRATCH/run_trace.stdout"
+}
+run_test "sfn run --cache-trace prints '[cache hit] sfn/math/mod'" test_cache_trace_lines
+
+# ---- Test 6: --clean wipes cache and forces a fresh miss ----
+test_clean_wipes_cache() {
+    cd "$SCRATCH" || return 1
+    # Sanity: cache_root must exist before --clean (populated by tests 1-2)
+    [ -d "$CACHE_DIR/v1" ] || return 1
+    SAILFIN_BUILD_CACHE_DIR="$CACHE_DIR" "$BINARY" run --clean src/main.sfn \
+        > "$SCRATCH/run_clean.stdout" 2>&1
+    local rc=$?
+    if [ "$rc" -ne 0 ]; then
+        echo "[test]   --clean run exited with code $rc; output:" >&2
+        cat "$SCRATCH/run_clean.stdout" >&2
+        return $rc
+    fi
+    # After --clean the build path repopulates the cache: miss + store,
+    # NOT a hit.
+    grep -qE '^\[cache\] hits=0 misses=1 stores=1' "$SCRATCH/run_clean.stdout"
+}
+run_test "sfn run --clean wipes the cache and rebuilds" test_clean_wipes_cache
+
+# ---- Summary ----
+echo ""
+echo "[test] $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

Closes the user-facing gap from PR #256: every Sailfin command that touches deps now respects the same cache contract. `sfn run` previously honoured only env vars; this PR mirrors the `sfn build` flag parser verbatim so:

```sh
sfn run [--no-cache] [--clean] [--cache-trace] <file.sfn | exe>
```

End-user behaviour:

```
$ sfn run src/main.sfn               # first run
[cache] hits=0 misses=1 stores=1 invalid_keys=0 copy_failures=0
abs=3

$ sfn run src/main.sfn               # second run
[cache] hits=1 misses=0 stores=0 invalid_keys=0 copy_failures=0
abs=3

$ sfn run --no-cache src/main.sfn
abs=3

$ sfn run --clean --cache-trace src/main.sfn
[cache miss] sfn/math/mod
[cache store] sfn/math/mod
[cache] hits=0 misses=1 stores=1 invalid_keys=0 copy_failures=0
abs=3
```

## What ships

`compiler/src/cli_main.sfn` (single file, 45 insertions / 8 deletions):

- `is_run` block now parses the three cache flags + the positional source path. Old form `sfn run <file>` still works (strict superset).
- `resolve_build_cache_config(no_cache_flag, trace_flag, clean_flag)` folds CLI flags with `SAILFIN_NO_CACHE` / `SAILFIN_CACHE_TRACE` env-var defaults — identical semantics to `sfn build`.
- `_print_cache_summary(run_capsule_result.stats)` fires after successful run.
- `_usage` updated.

**Deliberately mechanical:** no new structs, no new helpers, no new shared abstraction. The parser is a verbatim mirror of the build path's pattern. Once both commands grow more flags, the shared extraction becomes obvious follow-up work.

## Test plan

- [x] `make compile` clean (134 modules, ~152s).
- [x] **E2E (output above):** clean → warm → `--no-cache` → `--clean --cache-trace` all match the `sfn build` behaviour from PR1c.
- [x] **Backwards compat:** `sfn run src/main.sfn` (no flags) works identically to before.
- [ ] **CI:** full unit + integration + e2e + cross-compile matrix.

## What's next

- **PR1e:** per-source `dep_manifests` — replace conservative "all staged" with actual transitive imports per source (cache hit rate win).
- **PR1f:** `sfn build --json` — first machine-readable surface; `cache` field consumes `CacheStats`.

After PR1e+PR1f, the cache milestone is functionally complete; Stage C moves to C2 (artifact layout) / C3 (CI gate on stdlib capsules).

https://claude.ai/code/session_01EyxoafGBhk1G9qjKvHiqby

---
_Generated by [Claude Code](https://claude.ai/code/session_01EyxoafGBhk1G9qjKvHiqby)_