### PR TITLE
Stage C PR1f: sfn build --json structured build report

### DIFF
--- a/compiler/src/build_report.sfn
+++ b/compiler/src/build_report.sfn
@@ -1,0 +1,240 @@
+// compiler/src/build_report.sfn
+//
+// Stage C PR1f — structured build report for `sfn build --json`.
+//
+// First machine-readable surface for build outcomes. Consumed by:
+//   - The MCP server (`tools/mcp-server/`) for structured compile feedback.
+//   - `sfn lsp` (future) for editor integrations.
+//   - CI cache-hit-rate gates ("fail PR if hits drop below 80%").
+//   - Future structured link-error parsing
+//     (`docs/proposals/build-architecture.md` §4.11).
+//
+// Schema is documented inline below and gated by
+// `compiler/tests/e2e/test_build_json_schema.sh`. Bumping
+// `schema_version` is the contract for breaking changes —
+// downstream consumers hard-fail on unknown versions rather than
+// silently misinterpret unknown fields.
+//
+// This module is intentionally self-contained: it duplicates the
+// JSON primitive encoders from `diagnostics_json.sfn` rather than
+// importing them. Same precedent the diagnostics envelope already
+// follows — the seed compiler doesn't handle the resulting import
+// cycle cleanly, and the duplication (six small functions) is
+// well worth the unit-test isolation.
+import { CacheStats } from "./build_cache";
+import { substring } from "./string_utils";
+
+// -------------------------------------------------------------------
+// Schema
+// -------------------------------------------------------------------
+//
+// {
+//   "schema_version": "1",
+//   "command": "build",
+//   "input": "src/main.sfn",
+//   "out": "build/program",
+//   "kind": "binary",          // "binary" | "library"
+//   "exit_code": 0,
+//   "compiler_version": "0.5.10-alpha.2+dev.<hash>",
+//   "cache": {
+//     "hits": 3,
+//     "misses": 1,
+//     "stores": 1,
+//     "invalid_keys": 0,
+//     "copy_failures": 0,
+//     "root": "build/cache/v1",
+//     "enabled": true
+//   },
+//   "deps": {
+//     "count": 1,
+//     "ll_paths": ["build/sailfin/capsules/sfn__math__mod.ll"]
+//   },
+//   "diagnostics": []
+// }
+//
+// `diagnostics` is reserved for future structured link errors
+// (proposal §4.11). Empty array today; consumers should treat
+// missing entries as absent rather than as errors.
+struct BuildReport {
+    command: string;
+    input: string;
+    out: string;
+    kind: string;
+    exit_code: number;
+    compiler_version: string;
+    cache: CacheStats;
+    cache_root: string;
+    cache_enabled: boolean;
+    dep_ll_paths: string[];
+}
+
+fn empty_build_report() -> BuildReport {
+    return BuildReport {
+        command: "build",
+        input: "",
+        out: "",
+        kind: "binary",
+        exit_code: 0,
+        compiler_version: "",
+        cache: CacheStats {
+            hits: 0,
+            misses: 0,
+            stores: 0,
+            invalid_keys: 0,
+            copy_failures: 0
+        },
+        cache_root: "",
+        cache_enabled: true,
+        dep_ll_paths: []
+    };
+}
+
+// -------------------------------------------------------------------
+// Primitive encoders
+// -------------------------------------------------------------------
+// JSON string escaping per RFC 8259. Mirrors
+// `diagnostics_json.sfn::_json_escape_string` and `sfn/json`'s
+// `_escape_json_string`. Six escapes plus literal passthrough for
+// everything else. Control characters below 0x20 are not escaped
+// today; the strings that flow through here (paths, version
+// strings, slugs) are ASCII-clean.
+fn _br_json_escape(s: string) -> string {
+    let mut out: string = "";
+    let mut i: number = 0;
+    loop {
+        if i >= s.length { break; }
+        let ch = substring(s, i, i + 1);
+        if ch == "\"" { out = out + "\\\""; } else if ch == "\\" {
+            out = out + "\\\\";
+        } else if ch == "\n" { out = out + "\\n"; } else if ch == "\r" {
+            out = out + "\\r";
+        } else if ch == "\t" { out = out + "\\t"; } else { out = out + ch; }
+        i += 1;
+    }
+    return out;
+}
+
+fn _br_json_quote(s: string) -> string {
+    return "\"" + _br_json_escape(s) + "\"";
+}
+
+fn _br_json_field(name: string, value: string) -> string {
+    return _br_json_quote(name) + ":" + value;
+}
+
+fn _br_json_string_field(name: string, value: string) -> string {
+    return _br_json_field(name, _br_json_quote(value));
+}
+
+fn _br_json_number_field(name: string, value: number) -> string {
+    return _br_json_field(name, _br_number_to_string(value));
+}
+
+fn _br_json_bool_field(name: string, value: boolean) -> string {
+    if value { return _br_json_field(name, "true"); }
+    return _br_json_field(name, "false");
+}
+
+// Local copy of `number_to_string` — same precedent as
+// `diagnostics_json.sfn::_dj_number_to_string`. Importing from
+// `main.sfn` would create a cycle the seed compiler doesn't
+// resolve cleanly.
+//
+// Uses the canonical repeated-subtraction algorithm (NOT integer
+// division by 10 + modulo) because Sailfin's `number` is a float —
+// `7 / 10` evaluates to 0.7, not 0, so a naïve `working / 10` loop
+// runs forever or emits a stream of zeros. The repeated-subtraction
+// path keeps everything integer-valued. See
+// `compiler/src/main.sfn::number_to_string` for the same shape.
+fn _br_number_to_string(value: number) -> string {
+    if value == 0 { return "0"; }
+    let mut working: number = value;
+    let mut negative: boolean = false;
+    if working < 0 {
+        negative = true;
+        working = 0 - working;
+    }
+    let digits = "0123456789";
+    let mut remaining: number = working;
+    let mut output: string = "";
+    loop {
+        if remaining <= 0 { break; }
+        let mut temp: number = remaining;
+        let mut quotient: number = 0;
+        loop {
+            if temp < 10 { break; }
+            temp -= 10;
+            quotient += 1;
+        }
+        let ch = substring(digits, temp, temp + 1);
+        output = ch + output;
+        remaining = quotient;
+    }
+    if negative { output = "-" + output; }
+    return output;
+}
+
+// -------------------------------------------------------------------
+// Composite encoders
+// -------------------------------------------------------------------
+fn _br_json_string_array(values: string[]) -> string {
+    let mut out: string = "[";
+    let mut i: number = 0;
+    loop {
+        if i >= values.length { break; }
+        if i > 0 { out = out + ","; }
+        out = out + _br_json_quote(values[i]);
+        i += 1;
+    }
+    return out + "]";
+}
+
+fn _br_json_cache_object(stats: CacheStats, root: string, enabled: boolean) -> string {
+    return "{" + _br_json_number_field("hits", stats.hits) + ","
+        + _br_json_number_field("misses", stats.misses)
+        + ","
+        + _br_json_number_field("stores", stats.stores)
+        + ","
+        + _br_json_number_field("invalid_keys", stats.invalid_keys)
+        + ","
+        + _br_json_number_field("copy_failures", stats.copy_failures)
+        + ","
+        + _br_json_string_field("root", root)
+        + ","
+        + _br_json_bool_field("enabled", enabled)
+        + "}";
+}
+
+fn _br_json_deps_object(ll_paths: string[]) -> string {
+    return "{" + _br_json_number_field("count", ll_paths.length) + ","
+        + _br_json_field("ll_paths", _br_json_string_array(ll_paths))
+        + "}";
+}
+
+// -------------------------------------------------------------------
+// Public encoder
+// -------------------------------------------------------------------
+fn build_report_to_json(report: BuildReport) -> string {
+    let empty_diagnostics: string[] = [];
+    return "{" + _br_json_string_field("schema_version", "1") + ","
+        + _br_json_string_field("command", report.command)
+        + ","
+        + _br_json_string_field("input", report.input)
+        + ","
+        + _br_json_string_field("out", report.out)
+        + ","
+        + _br_json_string_field("kind", report.kind)
+        + ","
+        + _br_json_number_field("exit_code", report.exit_code)
+        + ","
+        + _br_json_string_field("compiler_version", report.compiler_version)
+        + ","
+        + _br_json_field("cache", _br_json_cache_object(report.cache, report.cache_root, report.cache_enabled))
+        + ","
+        + _br_json_field("deps", _br_json_deps_object(report.dep_ll_paths))
+        + ","
+        + _br_json_field("diagnostics", _br_json_string_array(empty_diagnostics))
+        + "}";
+}
+
+export { BuildReport, empty_build_report, build_report_to_json };

--- a/compiler/src/cli_main.sfn
+++ b/compiler/src/cli_main.sfn
@@ -4,9 +4,11 @@
 import {
     BuildCacheConfig,
     CacheStats,
+    cache_root,
     cache_stats_is_empty,
     resolve_build_cache_config
 } from "./build_cache";
+import { BuildReport, build_report_to_json, empty_build_report } from "./build_report";
 import { ProjectCapsuleResult, prepare_project_capsules } from "./capsule_resolver";
 import { handle_check_command } from "./cli_check";
 import {
@@ -38,7 +40,7 @@ fn _usage() -> string {
     out = out + "\n";
     out = out + "build & run:\n";
     out = out
-        + "  sfn build [-o OUTPUT] [--no-cache] [--clean] [--cache-trace] (<file.sfn> | -p <capsule-path>)\n";
+        + "  sfn build [-o OUTPUT] [--no-cache] [--clean] [--cache-trace] [--json] (<file.sfn> | -p <capsule-path>)\n";
     out = out
         + "  sfn run   [--no-cache] [--clean] [--cache-trace] (<file.sfn> | <exe>)\n";
     out = out
@@ -118,6 +120,25 @@ fn _print_cache_summary(stats: CacheStats) ![io] {
         + number_to_string(stats.invalid_keys)
         + " copy_failures="
         + number_to_string(stats.copy_failures));
+}
+
+// Compose a `BuildReport` for a successful build and print its
+// JSON encoding to stdout. Mirrors `_print_cache_summary`'s
+// placement (end of the success path); machine-readable consumers
+// (`sfn lsp`, MCP, CI gates) read this single line and parse it
+// rather than scraping `built: ...` + `[cache] ...` from stderr.
+fn _emit_build_report(input_path: string, out_path: string, kind: string, exit_code: number, capsule_result: ProjectCapsuleResult, cache_config: BuildCacheConfig) ![io] {
+    let mut report = empty_build_report();
+    report.input = input_path;
+    report.out = out_path;
+    report.kind = kind;
+    report.exit_code = exit_code;
+    report.compiler_version = resolve_compiler_version("");
+    report.cache = capsule_result.stats;
+    report.cache_root = cache_root();
+    report.cache_enabled = cache_config.enabled;
+    report.dep_ll_paths = capsule_result.ll_paths;
+    print(build_report_to_json(report));
 }
 
 fn _ensure_dir(path: string) ![io] {
@@ -537,7 +558,7 @@ fn sailfin_cli_main(argv: string[]) -> number ![io, clock] {
     }
 
     if is_build {
-        // build [-o OUTPUT] [--no-cache] [--clean] [--cache-trace]
+        // build [-o OUTPUT] [--no-cache] [--clean] [--cache-trace] [--json]
         //       (file | -p <capsule-path>)
         let mut out_path: string = "";
         let mut input_path: string = "";
@@ -545,6 +566,7 @@ fn sailfin_cli_main(argv: string[]) -> number ![io, clock] {
         let mut no_cache_flag: boolean = false;
         let mut clean_flag: boolean = false;
         let mut cache_trace_flag: boolean = false;
+        let mut json_flag: boolean = false;
 
         // Parse args: support -o OUTPUT and -p PATH in any combination.
         let mut bi: number = 1;
@@ -581,6 +603,11 @@ fn sailfin_cli_main(argv: string[]) -> number ![io, clock] {
             }
             if strings_equal(a, "--cache-trace") {
                 cache_trace_flag = true;
+                bi += 1;
+                continue;
+            }
+            if strings_equal(a, "--json") {
+                json_flag = true;
                 bi += 1;
                 continue;
             }
@@ -663,12 +690,18 @@ fn sailfin_cli_main(argv: string[]) -> number ![io, clock] {
         if no_link {
             let rc_obj = process.run(["clang", "-O2", "-Wno-override-module", "-c", ll_path, "-o", out_path,]);
             if rc_obj != 0 {
-                print("library build failed (clang exit=" + number_to_string(rc_obj)
-                    + ")");
+                if !json_flag {
+                    print("library build failed (clang exit=" + number_to_string(rc_obj)
+                        + ")");
+                }
                 return rc_obj;
             }
-            print("built: " + out_path);
-            _print_cache_summary(capsule_result.stats);
+            if json_flag {
+                _emit_build_report(input_path, out_path, "library", 0, capsule_result, cache_config);
+            } else {
+                print("built: " + out_path);
+                _print_cache_summary(capsule_result.stats);
+            }
             return 0;
         }
 
@@ -682,12 +715,17 @@ fn sailfin_cli_main(argv: string[]) -> number ![io, clock] {
         }
         let rc = _clang_link_multi(all_lls, exe_path, runtime_root);
         if rc != 0 {
-            print("link failed (clang exit=" + number_to_string(rc) + ")");
-
+            if !json_flag {
+                print("link failed (clang exit=" + number_to_string(rc) + ")");
+            }
             return rc;
         }
-        print("built: " + exe_path);
-        _print_cache_summary(capsule_result.stats);
+        if json_flag {
+            _emit_build_report(input_path, exe_path, "binary", 0, capsule_result, cache_config);
+        } else {
+            print("built: " + exe_path);
+            _print_cache_summary(capsule_result.stats);
+        }
         return 0;
     }
 

--- a/compiler/tests/e2e/test_build_json_schema.sh
+++ b/compiler/tests/e2e/test_build_json_schema.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+# End-to-end test for `sfn build --json` schema (Stage C PR1f).
+#
+# Verifies that:
+#   - `--json` emits a single line of valid JSON to stdout
+#   - the schema version is locked to "1"
+#   - the cache stats reflect actual build behaviour (cold → warm)
+#   - top-level fields the MCP / LSP / CI consumers depend on
+#     (`exit_code`, `kind`, `input`, `out`, `compiler_version`,
+#     `deps.count`, `cache.enabled`) are present
+#   - no human "built: ..." or "[cache] ..." lines leak through
+#     (would break consumers that line-parse stdout)
+#   - `--json` and `--no-cache` compose: cache fields are still
+#     emitted, with hits/misses/stores all zero
+#
+# If any of these schema fields drift, downstream consumers
+# silently misinterpret the output — this test catches it.
+#
+# Usage:
+#   compiler/tests/e2e/test_build_json_schema.sh <compiler-binary>
+
+set -euo pipefail
+
+BINARY="${1:?usage: test_build_json_schema.sh <compiler-binary>}"
+BINARY="$(realpath "$BINARY")"
+PASS=0
+FAIL=0
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "[test] SKIP: jq not installed (required for --json schema validation)" >&2
+    exit 0
+fi
+
+SCRATCH="$(mktemp -d -t sfn-build-json-XXXXXX)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+
+run_test() {
+    local name="$1"
+    shift
+    if "$@"; then
+        echo "[test] PASS: $name"
+        PASS=$((PASS + 1))
+    else
+        echo "[test] FAIL: $name"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+mkdir -p "$SCRATCH/src"
+ln -s "$REPO_ROOT/capsules" "$SCRATCH/capsules"
+
+cat > "$SCRATCH/capsule.toml" <<'EOF'
+[capsule]
+name = "build-json-test"
+version = "0.1.0"
+description = "E2E test for sfn build --json"
+
+[dependencies]
+"sfn/math" = "0.1.0"
+
+[capabilities]
+required = ["io"]
+
+[build]
+entry = "src/main.sfn"
+EOF
+
+cat > "$SCRATCH/src/main.sfn" <<'EOF'
+import { abs } from "sfn/math";
+fn main() ![io] { print("abs=" + number_to_string(abs(-7))); }
+EOF
+
+CACHE_DIR="$SCRATCH/cache"
+
+# ---- Test 1: cold build emits valid JSON ----
+test_cold_build_emits_json() {
+    cd "$SCRATCH" || return 1
+    SAILFIN_BUILD_CACHE_DIR="$CACHE_DIR" "$BINARY" build --json -o build/program src/main.sfn \
+        > "$SCRATCH/cold.json" 2> "$SCRATCH/cold.err"
+    local rc=$?
+    if [ "$rc" -ne 0 ]; then
+        echo "[test]   sfn build --json exited with code $rc; stderr:" >&2
+        cat "$SCRATCH/cold.err" >&2
+        return $rc
+    fi
+    jq . "$SCRATCH/cold.json" > /dev/null 2>&1
+}
+run_test "sfn build --json emits valid JSON" test_cold_build_emits_json
+
+# ---- Test 2: schema_version is "1" ----
+test_schema_version_locked() {
+    [ "$(jq -r .schema_version "$SCRATCH/cold.json")" = "1" ]
+}
+run_test "schema_version is '1'" test_schema_version_locked
+
+# ---- Test 3: top-level fields present ----
+test_top_level_fields() {
+    [ "$(jq -r .command "$SCRATCH/cold.json")" = "build" ] || return 1
+    [ "$(jq -r .kind "$SCRATCH/cold.json")" = "binary" ] || return 1
+    [ "$(jq -r .exit_code "$SCRATCH/cold.json")" = "0" ] || return 1
+    [ "$(jq -r .input "$SCRATCH/cold.json")" = "src/main.sfn" ] || return 1
+    [ -n "$(jq -r .compiler_version "$SCRATCH/cold.json")" ] || return 1
+}
+run_test "top-level fields present (command/kind/exit_code/input/version)" test_top_level_fields
+
+# ---- Test 4: cold build cache stats are miss + store ----
+test_cold_cache_stats() {
+    [ "$(jq -r .cache.hits "$SCRATCH/cold.json")" = "0" ] || return 1
+    [ "$(jq -r .cache.misses "$SCRATCH/cold.json")" = "1" ] || return 1
+    [ "$(jq -r .cache.stores "$SCRATCH/cold.json")" = "1" ] || return 1
+    [ "$(jq -r .cache.enabled "$SCRATCH/cold.json")" = "true" ] || return 1
+    [ -n "$(jq -r .cache.root "$SCRATCH/cold.json")" ] || return 1
+}
+run_test "cold build cache stats: hits=0 misses=1 stores=1 enabled=true" test_cold_cache_stats
+
+# ---- Test 5: deps.count matches deps.ll_paths.length ----
+test_deps_consistency() {
+    local count
+    count=$(jq -r .deps.count "$SCRATCH/cold.json")
+    local len
+    len=$(jq -r '.deps.ll_paths | length' "$SCRATCH/cold.json")
+    [ "$count" = "$len" ] && [ "$count" -ge 1 ]
+}
+run_test "deps.count matches deps.ll_paths.length (>= 1)" test_deps_consistency
+
+# ---- Test 6: diagnostics is empty array (reserved for §4.11) ----
+test_diagnostics_reserved() {
+    [ "$(jq -r '.diagnostics | length' "$SCRATCH/cold.json")" = "0" ]
+}
+run_test "diagnostics array is empty (reserved slot)" test_diagnostics_reserved
+
+# ---- Test 7: no human output leaks through stdout ----
+test_no_human_output() {
+    # `[cache] ...` and `built: ...` are the human-mode lines —
+    # neither must appear in the JSON-mode stdout.
+    if grep -qE '^\[cache\]' "$SCRATCH/cold.json"; then return 1; fi
+    if grep -qE '^built:' "$SCRATCH/cold.json"; then return 1; fi
+    return 0
+}
+run_test "no '[cache]' or 'built:' lines leak into JSON stdout" test_no_human_output
+
+# ---- Test 8: warm build reflects cache hit ----
+test_warm_cache_hit() {
+    cd "$SCRATCH" || return 1
+    SAILFIN_BUILD_CACHE_DIR="$CACHE_DIR" "$BINARY" build --json -o build/program src/main.sfn \
+        > "$SCRATCH/warm.json" 2> "$SCRATCH/warm.err"
+    local rc=$?
+    if [ "$rc" -ne 0 ]; then
+        cat "$SCRATCH/warm.err" >&2
+        return $rc
+    fi
+    jq . "$SCRATCH/warm.json" > /dev/null 2>&1 || return 1
+    [ "$(jq -r .cache.hits "$SCRATCH/warm.json")" = "1" ] || return 1
+    [ "$(jq -r .cache.misses "$SCRATCH/warm.json")" = "0" ] || return 1
+}
+run_test "warm build cache.hits=1 misses=0" test_warm_cache_hit
+
+# ---- Test 9: --no-cache + --json composes ----
+test_json_with_no_cache() {
+    cd "$SCRATCH" || return 1
+    SAILFIN_BUILD_CACHE_DIR="$CACHE_DIR" "$BINARY" build --json --no-cache -o build/program src/main.sfn \
+        > "$SCRATCH/no_cache.json" 2> "$SCRATCH/no_cache.err"
+    local rc=$?
+    if [ "$rc" -ne 0 ]; then
+        cat "$SCRATCH/no_cache.err" >&2
+        return $rc
+    fi
+    jq . "$SCRATCH/no_cache.json" > /dev/null 2>&1 || return 1
+    # All cache counters should be zero — `--no-cache` skips both
+    # lookup and store. `enabled` reports the runtime state.
+    [ "$(jq -r .cache.hits "$SCRATCH/no_cache.json")" = "0" ] || return 1
+    [ "$(jq -r .cache.misses "$SCRATCH/no_cache.json")" = "0" ] || return 1
+    [ "$(jq -r .cache.stores "$SCRATCH/no_cache.json")" = "0" ] || return 1
+    [ "$(jq -r .cache.enabled "$SCRATCH/no_cache.json")" = "false" ] || return 1
+}
+run_test "sfn build --json --no-cache: counters all zero, enabled=false" test_json_with_no_cache
+
+# ---- Summary ----
+echo ""
+echo "[test] $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/compiler/tests/unit/build_report_test.sfn
+++ b/compiler/tests/unit/build_report_test.sfn
@@ -1,0 +1,191 @@
+// Stage C PR1f regression tests for `compiler/src/build_report.sfn`.
+//
+// `build_report_to_json` is the foundation surface for `sfn lsp`,
+// the MCP server's structured compile feedback, and CI cache-health
+// gates. The schema is documented inline in `build_report.sfn` and
+// gated by `compiler/tests/e2e/test_build_json_schema.sh`. These
+// unit tests lock the per-field serialization invariants — the e2e
+// test exercises the full pipeline.
+//
+// `BuildReport` wraps `CacheStats`, so importing from
+// `./build_report` pulls in `./build_cache` too. That's a small
+// surface; no inline-duplication needed (mirrors the
+// `cli_path_normalization_test.sfn` precedent).
+import { CacheStats } from "../../src/build_cache";
+import { BuildReport, build_report_to_json, empty_build_report } from "../../src/build_report";
+
+// --------------------------------------------------------------
+// empty_build_report defaults
+// --------------------------------------------------------------
+test "empty_build_report: command defaults to 'build'" {
+    assert empty_build_report().command == "build";
+}
+
+test "empty_build_report: kind defaults to 'binary'" {
+    assert empty_build_report().kind == "binary";
+}
+
+test "empty_build_report: exit_code defaults to 0" {
+    assert empty_build_report().exit_code == 0;
+}
+
+test "empty_build_report: cache stats are zero" {
+    let r = empty_build_report();
+    assert r.cache.hits == 0;
+    assert r.cache.misses == 0;
+    assert r.cache.stores == 0;
+    assert r.cache.invalid_keys == 0;
+    assert r.cache.copy_failures == 0;
+}
+
+test "empty_build_report: cache_enabled defaults to true" {
+    assert empty_build_report().cache_enabled;
+}
+
+test "empty_build_report: dep_ll_paths is empty" {
+    assert empty_build_report().dep_ll_paths.length == 0;
+}
+
+// --------------------------------------------------------------
+// build_report_to_json — schema invariants
+// --------------------------------------------------------------
+test "build_report_to_json: includes schema_version 1" {
+    let json = build_report_to_json(empty_build_report());
+    // Schema version is the contract for breaking changes;
+    // downstream consumers hard-fail on unknown values.
+    assert _contains(json, "\"schema_version\":\"1\"");
+}
+
+test "build_report_to_json: includes command default" {
+    let json = build_report_to_json(empty_build_report());
+    assert _contains(json, "\"command\":\"build\"");
+}
+
+test "build_report_to_json: includes kind override 'library'" {
+    let mut r = empty_build_report();
+    r.kind = "library";
+    let json = build_report_to_json(r);
+    assert _contains(json, "\"kind\":\"library\"");
+}
+
+test "build_report_to_json: includes exit_code override" {
+    let mut r = empty_build_report();
+    r.exit_code = 7;
+    let json = build_report_to_json(r);
+    assert _contains(json, "\"exit_code\":7");
+}
+
+test "build_report_to_json: includes input + out paths" {
+    let mut r = empty_build_report();
+    r.input = "src/main.sfn";
+    r.out = "build/program";
+    let json = build_report_to_json(r);
+    assert _contains(json, "\"input\":\"src/main.sfn\"");
+    assert _contains(json, "\"out\":\"build/program\"");
+}
+
+test "build_report_to_json: cache fields present and counted" {
+    let mut r = empty_build_report();
+    r.cache = CacheStats {
+        hits: 3,
+        misses: 1,
+        stores: 1,
+        invalid_keys: 0,
+        copy_failures: 0
+    };
+    r.cache_root = "/tmp/sfn-cache/v1";
+    r.cache_enabled = true;
+    let json = build_report_to_json(r);
+    assert _contains(json, "\"hits\":3");
+    assert _contains(json, "\"misses\":1");
+    assert _contains(json, "\"stores\":1");
+    assert _contains(json, "\"invalid_keys\":0");
+    assert _contains(json, "\"copy_failures\":0");
+    assert _contains(json, "\"root\":\"/tmp/sfn-cache/v1\"");
+    assert _contains(json, "\"enabled\":true");
+}
+
+test "build_report_to_json: cache_enabled false serializes literally" {
+    let mut r = empty_build_report();
+    r.cache_enabled = false;
+    let json = build_report_to_json(r);
+    assert _contains(json, "\"enabled\":false");
+}
+
+test "build_report_to_json: deps.count matches array length" {
+    let mut r = empty_build_report();
+    r.dep_ll_paths = ["a.ll", "b.ll", "c.ll"];
+    let json = build_report_to_json(r);
+    assert _contains(json, "\"count\":3");
+    assert _contains(json, "\"a.ll\"");
+    assert _contains(json, "\"b.ll\"");
+    assert _contains(json, "\"c.ll\"");
+}
+
+test "build_report_to_json: empty deps produce count=0 and []" {
+    let json = build_report_to_json(empty_build_report());
+    assert _contains(json, "\"count\":0");
+    assert _contains(json, "\"ll_paths\":[]");
+}
+
+test "build_report_to_json: diagnostics is empty array (reserved for §4.11)" {
+    let json = build_report_to_json(empty_build_report());
+    assert _contains(json, "\"diagnostics\":[]");
+}
+
+// --------------------------------------------------------------
+// build_report_to_json — escape correctness
+// --------------------------------------------------------------
+test "build_report_to_json: input path with backslash escapes correctly" {
+    let mut r = empty_build_report();
+    r.input = "src\\main.sfn";
+    let json = build_report_to_json(r);
+    // `\` → `\\` per RFC 8259.
+    assert _contains(json, "\"input\":\"src\\\\main.sfn\"");
+}
+
+test "build_report_to_json: input path with embedded quote escapes correctly" {
+    let mut r = empty_build_report();
+    r.input = "src/\"quoted\".sfn";
+    let json = build_report_to_json(r);
+    assert _contains(json, "\"input\":\"src/\\\"quoted\\\".sfn\"");
+}
+
+test "build_report_to_json: input path with newline escapes correctly" {
+    let mut r = empty_build_report();
+    r.input = "src/with\nnewline";
+    let json = build_report_to_json(r);
+    assert _contains(json, "\"input\":\"src/with\\nnewline\"");
+}
+
+test "build_report_to_json: negative exit_code serializes with sign" {
+    let mut r = empty_build_report();
+    r.exit_code = -1;
+    let json = build_report_to_json(r);
+    assert _contains(json, "\"exit_code\":-1");
+}
+
+// --------------------------------------------------------------
+// Helpers
+// --------------------------------------------------------------
+fn _contains(haystack: string, needle: string) -> boolean {
+    if needle.length == 0 { return true; }
+    if haystack.length < needle.length { return false; }
+    let mut i: number = 0;
+    loop {
+        if i + needle.length > haystack.length { break; }
+        let mut j: number = 0;
+        let mut matches: boolean = true;
+        loop {
+            if j >= needle.length { break; }
+            if haystack[i + j] != needle[j] {
+                matches = false;
+                break;
+            }
+            j += 1;
+        }
+        if matches { return true; }
+        i += 1;
+    }
+    return false;
+}


### PR DESCRIPTION
## Summary

`sfn build --json` ships the first machine-readable surface for build outcomes — foundation for `sfn lsp`, the MCP server's structured compile feedback, CI cache-health gates, and future structured link errors (proposal §4.11). Closes the cache milestone.

```sh
$ sfn build --json src/main.sfn | jq .
{
  "schema_version": "1",
  "command": "build",
  "input": "src/main.sfn",
  "out": "build/program",
  "kind": "binary",
  "exit_code": 0,
  "compiler_version": "0.5.10-alpha.2+dev.<hash>",
  "cache": {
    "hits": 0, "misses": 1, "stores": 1,
    "invalid_keys": 0, "copy_failures": 0,
    "root": "build/cache/v1", "enabled": true
  },
  "deps": {
    "count": 1,
    "ll_paths": ["build/sailfin/capsules/sfn__math__mod.ll"]
  },
  "diagnostics": []
}
```

## What ships

### `compiler/src/build_report.sfn` (new)

- `BuildReport` struct + `empty_build_report()` defaults.
- `build_report_to_json(report)` serializer.
- Self-contained JSON primitive encoders (mirrors the same precedent `diagnostics_json.sfn` already follows for the seed-cycle reason).
- Local `_br_number_to_string` using the **canonical repeated-subtraction algorithm** — Sailfin's `number` is a float, so naïve `working / 10` doesn't truncate (it emits an infinite zero stream).

### `compiler/src/cli_main.sfn`

- `--json` flag on `sfn build`. Mutually composable with `--no-cache` / `--clean` / `--cache-trace`.
- `_emit_build_report` helper next to `_print_cache_summary`.
- Success path gates: emit JSON envelope OR human output, never both — preserves line-parseability for consumers.
- Failure path unchanged for now (the `diagnostics: []` slot is the forward-compat hook for §4.11).

### Schema-version contract

Bumping `schema_version` is the contract for breaking changes — downstream consumers hard-fail on unknown values rather than silently misinterpret. Pattern matches `diagnostics_json.sfn`'s envelope.

## Test plan

- [x] `make compile` clean (134 modules, ~146s).
- [x] **`build_report_test.sfn`:** 20/20 PASS — defaults, schema_version, all top-level fields, cache subfields, deps consistency, `diagnostics: []` slot, escape correctness (backslash, quote, newline), negative exit_code.
- [x] **`test_build_json_schema.sh`:** 9/9 PASS — uses `jq` to validate the schema end-to-end (skips gracefully when `jq` not present); covers cold/warm cache, `--no-cache` composition, "no human leak" assertions.
- [x] **Regression:** `test_run_cache_flags.sh` 6/6 PASS, `test_capsule_build.sh` 4/4 PASS.
- [ ] **CI:** full unit + integration + e2e + cross-compile matrix.

## Cache milestone status

After PR1f the cache milestone is **functionally complete**:

| PR | What it added |
|---|---|
| #254 PR1 | Cache module foundation |
| #255 PR1b | Wired into `_cr_compile_one` |
| #256 PR1c | Stats + CLI flags on `sfn build` |
| #257 PR1d | Same flags on `sfn run` |
| #258 PR1e | Per-source dep manifests |
| this PR1f | `sfn build --json` |

## What's next

Stage C moves on:
- **C2:** standard artifact layout (`build/capsules/<scope>/<name>/{ir, obj, bin}/`)
- **C3:** CI builds every stdlib capsule with `sfn build -p` + cache-hit floor
- **C4:** `sfn package` (replaces `tools/package.sh`)
- **C5:** `sfn bench` + `sfn bootstrap`

https://claude.ai/code/session_01EyxoafGBhk1G9qjKvHiqby

---
_Generated by [Claude Code](https://claude.ai/code/session_01EyxoafGBhk1G9qjKvHiqby)_