### PR TITLE
Stage C2a: per-capsule artifact manifest sidecar

### DIFF
--- a/compiler/src/capsule_artifact.sfn
+++ b/compiler/src/capsule_artifact.sfn
@@ -1,0 +1,239 @@
+// compiler/src/capsule_artifact.sfn
+//
+// Stage C C2a — per-capsule build artifact manifest.
+//
+// After a successful `sfn build -p <capsule-path>`, we emit a
+// `build/capsules/<scope>/<name>/manifest.json` sidecar that
+// captures the resolved build state for that capsule. The sidecar
+// is purely additive — actual `.ll` / `.o` artifacts still live
+// at their pre-existing flat paths until C2b migrates them into
+// the canonical per-capsule tree.
+//
+// Why a per-capsule sidecar before the path migration:
+//   - Locks in the schema future stages (C4 `sfn package`,
+//     `sfn lsp` capsule discovery, MCP tooling) will consume.
+//   - Gives downstream consumers a stable file to read TODAY
+//     without waiting on C2b's larger refactor.
+//   - The C2b path migration is then "fill in `<scope>/<name>/{ir, obj, bin}/`"
+//     under directories the sidecar already names, rather than a
+//     simultaneous schema + path refactor.
+//
+// Schema is `schema_version: "1"`. Bumping the version is the
+// contract for breaking changes — downstream consumers hard-fail
+// on unknown values rather than silently misinterpret. Same
+// pattern as `build_report.sfn` and `diagnostics_json.sfn`.
+//
+// Self-contained module: duplicates JSON primitive encoders from
+// `build_report.sfn` rather than importing them — same precedent
+// (seed compiler doesn't handle the import cycle cleanly), and
+// the duplication keeps each emitter independently unit-testable.
+import { substring } from "./string_utils";
+
+// -------------------------------------------------------------------
+// Schema
+// -------------------------------------------------------------------
+//
+// {
+//   "schema_version": "1",
+//   "capsule": "sfn/math",
+//   "version": "0.1.0",
+//   "kind": "library",                  // "binary" | "library"
+//   "compiler_version": "0.5.10-alpha.2+dev.<hash>",
+//   "entry": "src/mod.sfn",              // relative to capsule.toml's dir
+//   "out": "build/sailfin/program.o",    // current ad-hoc location;
+//                                        //   migrates to <scope>/<name>/bin
+//                                        //   or <scope>/<name>/obj in C2b
+//   "deps": {
+//     "count": 1,
+//     "ll_paths": ["build/sailfin/capsules/sfn__runtime__mod.ll"]
+//   }
+// }
+struct ScopeName {
+    scope: string;
+    name: string;
+}
+
+struct CapsuleArtifactManifest {
+    capsule_name: string;
+    version: string;
+    kind: string;
+    compiler_version: string;
+    entry_relative: string;
+    out_path: string;
+    dep_ll_paths: string[];
+}
+
+fn empty_capsule_artifact_manifest() -> CapsuleArtifactManifest {
+    let empty: string[] = [];
+    return CapsuleArtifactManifest {
+        capsule_name: "",
+        version: "",
+        kind: "library",
+        compiler_version: "",
+        entry_relative: "",
+        out_path: "",
+        dep_ll_paths: empty
+    };
+}
+
+// -------------------------------------------------------------------
+// Path helpers
+// -------------------------------------------------------------------
+// Split `"scope/name"` into its two parts. Returns `("", "")` if
+// the input has no slash or is empty — invalid inputs are the
+// caller's responsibility to detect (the manifest must have a
+// scoped capsule name to be writable).
+fn parse_scope_name(capsule_name: string) -> ScopeName {
+    if capsule_name.length == 0 {
+        return ScopeName { scope: "", name: "" };
+    }
+    let mut i: number = 0;
+    let mut slash_at: number = -1;
+    loop {
+        if i >= capsule_name.length { break; }
+        if substring(capsule_name, i, i + 1) == "/" {
+            slash_at = i;
+            break;
+        }
+        i += 1;
+    }
+    if slash_at < 0 {
+        return ScopeName { scope: "", name: "" };
+    }
+    let scope = substring(capsule_name, 0, slash_at);
+    let name = substring(capsule_name, slash_at + 1, capsule_name.length);
+    if scope.length == 0 {
+        return ScopeName { scope: "", name: "" };
+    }
+    if name.length == 0 {
+        return ScopeName { scope: "", name: "" };
+    }
+    return ScopeName { scope: scope, name: name };
+}
+
+// `build/capsules/<scope>/<name>` — the canonical per-capsule
+// artifact tree from proposal §4.4. Pure; tests pass arbitrary
+// scope/name without requiring fs setup.
+fn capsule_artifact_dir(scope: string, name: string) -> string {
+    return "build/capsules/" + scope + "/" + name;
+}
+
+// `<artifact_dir>/manifest.json` — the sidecar this module writes.
+fn capsule_artifact_manifest_path(scope: string, name: string) -> string {
+    return capsule_artifact_dir(scope, name) + "/manifest.json";
+}
+
+// -------------------------------------------------------------------
+// JSON primitive encoders (duplicated; see top-of-file rationale)
+// -------------------------------------------------------------------
+fn _ca_json_escape(s: string) -> string {
+    let mut out: string = "";
+    let mut i: number = 0;
+    loop {
+        if i >= s.length { break; }
+        let ch = substring(s, i, i + 1);
+        if ch == "\"" { out = out + "\\\""; } else if ch == "\\" {
+            out = out + "\\\\";
+        } else if ch == "\n" { out = out + "\\n"; } else if ch == "\r" {
+            out = out + "\\r";
+        } else if ch == "\t" { out = out + "\\t"; } else { out = out + ch; }
+        i += 1;
+    }
+    return out;
+}
+
+fn _ca_json_quote(s: string) -> string {
+    return "\"" + _ca_json_escape(s) + "\"";
+}
+
+fn _ca_json_field(name: string, value: string) -> string {
+    return _ca_json_quote(name) + ":" + value;
+}
+
+fn _ca_json_string_field(name: string, value: string) -> string {
+    return _ca_json_field(name, _ca_json_quote(value));
+}
+
+fn _ca_json_number_field(name: string, value: number) -> string {
+    return _ca_json_field(name, _ca_number_to_string(value));
+}
+
+// Same repeated-subtraction algorithm as `build_report.sfn` and
+// `compiler/src/main.sfn::number_to_string` — Sailfin's `number`
+// is a float, so `working / 10` doesn't truncate.
+fn _ca_number_to_string(value: number) -> string {
+    if value == 0 { return "0"; }
+    let mut working: number = value;
+    let mut negative: boolean = false;
+    if working < 0 {
+        negative = true;
+        working = 0 - working;
+    }
+    let digits = "0123456789";
+    let mut remaining: number = working;
+    let mut output: string = "";
+    loop {
+        if remaining <= 0 { break; }
+        let mut temp: number = remaining;
+        let mut quotient: number = 0;
+        loop {
+            if temp < 10 { break; }
+            temp -= 10;
+            quotient += 1;
+        }
+        let ch = substring(digits, temp, temp + 1);
+        output = ch + output;
+        remaining = quotient;
+    }
+    if negative { output = "-" + output; }
+    return output;
+}
+
+fn _ca_json_string_array(values: string[]) -> string {
+    let mut out: string = "[";
+    let mut i: number = 0;
+    loop {
+        if i >= values.length { break; }
+        if i > 0 { out = out + ","; }
+        out = out + _ca_json_quote(values[i]);
+        i += 1;
+    }
+    return out + "]";
+}
+
+fn _ca_json_deps_object(ll_paths: string[]) -> string {
+    return "{" + _ca_json_number_field("count", ll_paths.length) + ","
+        + _ca_json_field("ll_paths", _ca_json_string_array(ll_paths))
+        + "}";
+}
+
+// -------------------------------------------------------------------
+// Public encoder
+// -------------------------------------------------------------------
+fn capsule_artifact_manifest_to_json(m: CapsuleArtifactManifest) -> string {
+    return "{" + _ca_json_string_field("schema_version", "1") + ","
+        + _ca_json_string_field("capsule", m.capsule_name)
+        + ","
+        + _ca_json_string_field("version", m.version)
+        + ","
+        + _ca_json_string_field("kind", m.kind)
+        + ","
+        + _ca_json_string_field("compiler_version", m.compiler_version)
+        + ","
+        + _ca_json_string_field("entry", m.entry_relative)
+        + ","
+        + _ca_json_string_field("out", m.out_path)
+        + ","
+        + _ca_json_field("deps", _ca_json_deps_object(m.dep_ll_paths))
+        + "}";
+}
+
+export {
+    CapsuleArtifactManifest,
+    ScopeName,
+    empty_capsule_artifact_manifest,
+    parse_scope_name,
+    capsule_artifact_dir,
+    capsule_artifact_manifest_path,
+    capsule_artifact_manifest_to_json
+};

--- a/compiler/src/capsule_artifact.sfn
+++ b/compiler/src/capsule_artifact.sfn
@@ -118,6 +118,53 @@ fn capsule_artifact_dir(scope: string, name: string) -> string {
     return "build/capsules/" + scope + "/" + name;
 }
 
+// Path-segment validator: rejects empty / `.` / `..` / segments
+// containing `/` or `\` / segments starting with `/`.
+// `[capsule].name` is end-user-controlled (a malicious manifest
+// could set `name = "../../etc"`); the emitter MUST validate
+// before interpolating into a filesystem path.
+fn _ca_is_safe_segment(s: string) -> boolean {
+    if s.length == 0 { return false; }
+    if s == "." { return false; }
+    if s == ".." { return false; }
+    let mut i: number = 0;
+    loop {
+        if i >= s.length { break; }
+        let ch = substring(s, i, i + 1);
+        if ch == "/" { return false; }
+        if ch == "\\" { return false; }
+        i += 1;
+    }
+    return true;
+}
+
+// True iff `(scope, name)` produces a safe `build/capsules/...`
+// path: `scope` is a single safe segment; `name` may contain
+// `/`-separated segments (e.g. `http/client` for a submodule
+// capsule), and every segment must independently be safe.
+fn is_safe_scope_name(scope: string, name: string) -> boolean {
+    if !_ca_is_safe_segment(scope) { return false; }
+    if name.length == 0 { return false; }
+    // Reject leading slash so the emitter never lands at an
+    // absolute path. (parse_scope_name already drops the leading
+    // slash case, but defending here keeps the validator usable
+    // by other callers.)
+    if substring(name, 0, 1) == "/" { return false; }
+    let mut start: number = 0;
+    let mut i: number = 0;
+    loop {
+        if i >= name.length { break; }
+        if substring(name, i, i + 1) == "/" {
+            let segment = substring(name, start, i);
+            if !_ca_is_safe_segment(segment) { return false; }
+            start = i + 1;
+        }
+        i += 1;
+    }
+    let last = substring(name, start, name.length);
+    return _ca_is_safe_segment(last);
+}
+
 // `<artifact_dir>/manifest.json` — the sidecar this module writes.
 fn capsule_artifact_manifest_path(scope: string, name: string) -> string {
     return capsule_artifact_dir(scope, name) + "/manifest.json";
@@ -233,6 +280,7 @@ export {
     ScopeName,
     empty_capsule_artifact_manifest,
     parse_scope_name,
+    is_safe_scope_name,
     capsule_artifact_dir,
     capsule_artifact_manifest_path,
     capsule_artifact_manifest_to_json

--- a/compiler/src/cli_main.sfn
+++ b/compiler/src/cli_main.sfn
@@ -16,6 +16,7 @@ import {
     capsule_artifact_manifest_path,
     capsule_artifact_manifest_to_json,
     empty_capsule_artifact_manifest,
+    is_safe_scope_name,
     parse_scope_name
 } from "./capsule_artifact";
 import { ProjectCapsuleResult, prepare_project_capsules } from "./capsule_resolver";
@@ -159,6 +160,17 @@ fn _emit_capsule_artifact_sidecar(spec_capsule_name: string, spec_version: strin
     if parts.scope.length == 0 {
         print.err("[capsule-artifact] capsule name \"" + spec_capsule_name
             + "\" is not in scope/name form; skipping sidecar");
+        return;
+    }
+    // Path-traversal guard: `[capsule].name` is end-user-controlled,
+    // and the scope/name is interpolated into a filesystem path. A
+    // malicious manifest could set `name = "../../etc"` and escape
+    // `build/capsules/`. Reject any segment that is empty, `.`, `..`,
+    // or contains `/` (in scope) or `\` (in either). See
+    // `capsule_artifact.sfn::is_safe_scope_name`.
+    if !is_safe_scope_name(parts.scope, parts.name) {
+        print.err("[capsule-artifact] capsule name \"" + spec_capsule_name
+            + "\" contains unsafe path segments; skipping sidecar");
         return;
     }
     let mut manifest = empty_capsule_artifact_manifest();
@@ -352,7 +364,6 @@ struct _CapsuleBuildSpec {
     kind: string;
     capsule_name: string;
     version: string;
-    manifest_dir: string;
     entry_relative: string;
 }
 
@@ -374,7 +385,6 @@ fn _resolve_capsule_build_spec(p: string) -> _CapsuleBuildSpec ![io] {
         kind: "binary",
         capsule_name: "",
         version: "",
-        manifest_dir: "",
         entry_relative: ""
     };
     if p.length == 0 { return spec; }
@@ -398,7 +408,6 @@ fn _resolve_capsule_build_spec(p: string) -> _CapsuleBuildSpec ![io] {
     }
     let manifest_dir = _dirname(manifest_path);
     spec.entry_path = _path_join(manifest_dir, entry_rel);
-    spec.manifest_dir = manifest_dir;
     spec.entry_relative = entry_rel;
     spec.capsule_name = toml_get_name(manifest_text);
     spec.version = toml_get_version(manifest_text);

--- a/compiler/src/cli_main.sfn
+++ b/compiler/src/cli_main.sfn
@@ -9,6 +9,15 @@ import {
     resolve_build_cache_config
 } from "./build_cache";
 import { BuildReport, build_report_to_json, empty_build_report } from "./build_report";
+import {
+    CapsuleArtifactManifest,
+    ScopeName,
+    capsule_artifact_dir,
+    capsule_artifact_manifest_path,
+    capsule_artifact_manifest_to_json,
+    empty_capsule_artifact_manifest,
+    parse_scope_name
+} from "./capsule_artifact";
 import { ProjectCapsuleResult, prepare_project_capsules } from "./capsule_resolver";
 import { handle_check_command } from "./cli_check";
 import {
@@ -32,7 +41,12 @@ import {
     print_llvm_with_module,
     write_native_text_file_with_module
 } from "./main";
-import { toml_get_build_kind, toml_get_entry } from "./toml_parser";
+import {
+    toml_get_build_kind,
+    toml_get_entry,
+    toml_get_name,
+    toml_get_version
+} from "./toml_parser";
 import { resolve_compiler_version } from "./version";
 
 fn _usage() -> string {
@@ -120,6 +134,46 @@ fn _print_cache_summary(stats: CacheStats) ![io] {
         + number_to_string(stats.invalid_keys)
         + " copy_failures="
         + number_to_string(stats.copy_failures));
+}
+
+// Stage C2a — write `build/capsules/<scope>/<name>/manifest.json`
+// after a successful `sfn build -p`. Schema-versioned sidecar that
+// captures the resolved per-capsule build state for downstream
+// consumers (`sfn package` C4, `sfn lsp` capsule discovery, MCP
+// tooling) to read without re-running the build.
+//
+// Quiet on `--json` mode the same way `_print_cache_summary` is —
+// the sidecar lives on disk regardless, but no stdout chatter is
+// emitted.
+//
+// Best-effort: failure to write the sidecar is logged to stderr
+// but does NOT fail the build, since the binary/library was
+// already produced and the sidecar is metadata only.
+fn _emit_capsule_artifact_sidecar(spec_capsule_name: string, spec_version: string, spec_kind: string, spec_entry_relative: string, out_path: string, capsule_result: ProjectCapsuleResult) ![io] {
+    if spec_capsule_name.length == 0 {
+        // Manifest had no `[capsule].name` — can't compose a path.
+        // The build itself succeeded; just skip the sidecar.
+        return;
+    }
+    let parts = parse_scope_name(spec_capsule_name);
+    if parts.scope.length == 0 {
+        print.err("[capsule-artifact] capsule name \"" + spec_capsule_name
+            + "\" is not in scope/name form; skipping sidecar");
+        return;
+    }
+    let mut manifest = empty_capsule_artifact_manifest();
+    manifest.capsule_name = spec_capsule_name;
+    manifest.version = spec_version;
+    manifest.kind = spec_kind;
+    manifest.compiler_version = resolve_compiler_version("");
+    manifest.entry_relative = spec_entry_relative;
+    manifest.out_path = out_path;
+    manifest.dep_ll_paths = capsule_result.ll_paths;
+
+    let dir = capsule_artifact_dir(parts.scope, parts.name);
+    fs.createDirectory(dir, true);
+    let path = capsule_artifact_manifest_path(parts.scope, parts.name);
+    fs.writeFile(path, capsule_artifact_manifest_to_json(manifest));
 }
 
 // Compose a `BuildReport` for a successful build and print its
@@ -296,6 +350,10 @@ fn _clang_link_multi(ll_paths: string[], out_path: string, runtime_root: string)
 struct _CapsuleBuildSpec {
     entry_path: string;
     kind: string;
+    capsule_name: string;
+    version: string;
+    manifest_dir: string;
+    entry_relative: string;
 }
 
 // Resolve `-p <path>` for `sfn build`. The path is either a directory
@@ -304,8 +362,21 @@ struct _CapsuleBuildSpec {
 // manifest's directory) plus the build kind from `[build].kind` (defaults
 // to "binary" when unset, matching historical sfn build behaviour).
 // `entry_path` is "" with an error printed on failure.
+//
+// Also surfaces the manifest's `[capsule].name` + `[capsule].version`
+// + the manifest directory + the relative entry path so the
+// post-build sidecar emitter (Stage C2a) can compose
+// `build/capsules/<scope>/<name>/manifest.json` without re-reading
+// the capsule.toml.
 fn _resolve_capsule_build_spec(p: string) -> _CapsuleBuildSpec ![io] {
-    let mut spec = _CapsuleBuildSpec { entry_path: "", kind: "binary" };
+    let mut spec = _CapsuleBuildSpec {
+        entry_path: "",
+        kind: "binary",
+        capsule_name: "",
+        version: "",
+        manifest_dir: "",
+        entry_relative: ""
+    };
     if p.length == 0 { return spec; }
     // Treat `p` as a manifest path only when its final segment is exactly
     // `capsule.toml`. Substring-only checks would also accept paths like
@@ -327,6 +398,10 @@ fn _resolve_capsule_build_spec(p: string) -> _CapsuleBuildSpec ![io] {
     }
     let manifest_dir = _dirname(manifest_path);
     spec.entry_path = _path_join(manifest_dir, entry_rel);
+    spec.manifest_dir = manifest_dir;
+    spec.entry_relative = entry_rel;
+    spec.capsule_name = toml_get_name(manifest_text);
+    spec.version = toml_get_version(manifest_text);
     let declared_kind = toml_get_build_kind(manifest_text);
     if declared_kind.length > 0 {
         // Validate against the supported set so a typo in capsule.toml
@@ -626,6 +701,13 @@ fn sailfin_cli_main(argv: string[]) -> number ![io, clock] {
         // file, with the kind controlling whether we link an executable
         // (binary) or just emit an object (library/runtime).
         let mut build_kind: string = "binary";
+        // Captured from `-p` resolution so the post-build sidecar
+        // emitter (Stage C2a) has the manifest's name + version
+        // + entry-relative path without re-reading capsule.toml.
+        // Empty when `-p` was not used (positional source only).
+        let mut cap_capsule_name: string = "";
+        let mut cap_version: string = "";
+        let mut cap_entry_relative: string = "";
         if capsule_path.length > 0 {
             if input_path.length > 0 {
                 print("sfn build: -p and positional source are mutually exclusive");
@@ -635,6 +717,9 @@ fn sailfin_cli_main(argv: string[]) -> number ![io, clock] {
             if cap_spec.entry_path.length == 0 { return 1; }
             input_path = cap_spec.entry_path;
             build_kind = cap_spec.kind;
+            cap_capsule_name = cap_spec.capsule_name;
+            cap_version = cap_spec.version;
+            cap_entry_relative = cap_spec.entry_relative;
         }
         if input_path.length == 0 {
             print(_usage());
@@ -702,6 +787,9 @@ fn sailfin_cli_main(argv: string[]) -> number ![io, clock] {
                 print("built: " + out_path);
                 _print_cache_summary(capsule_result.stats);
             }
+            // Stage C2a: per-capsule artifact sidecar for `-p` builds.
+            // No-op for positional builds (cap_capsule_name == "").
+            _emit_capsule_artifact_sidecar(cap_capsule_name, cap_version, "library", cap_entry_relative, out_path, capsule_result);
             return 0;
         }
 
@@ -726,6 +814,9 @@ fn sailfin_cli_main(argv: string[]) -> number ![io, clock] {
             print("built: " + exe_path);
             _print_cache_summary(capsule_result.stats);
         }
+        // Stage C2a: per-capsule artifact sidecar for `-p` builds.
+        // No-op for positional builds (cap_capsule_name == "").
+        _emit_capsule_artifact_sidecar(cap_capsule_name, cap_version, "binary", cap_entry_relative, exe_path, capsule_result);
         return 0;
     }
 

--- a/compiler/tests/e2e/test_capsule_artifact_sidecar.sh
+++ b/compiler/tests/e2e/test_capsule_artifact_sidecar.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# End-to-end test for the per-capsule artifact sidecar (Stage C2a).
+#
+# Verifies that `sfn build -p <capsule-path>` writes
+# `build/capsules/<scope>/<name>/manifest.json` after a successful
+# build, with a schema-versioned, jq-parseable shape that downstream
+# consumers (sfn package, sfn lsp, MCP tooling) can read.
+#
+# Schema is locked here. If `capsule_artifact.sfn`'s serializer
+# drifts, this test catches it before downstream consumers do.
+#
+# Usage:
+#   compiler/tests/e2e/test_capsule_artifact_sidecar.sh <compiler-binary>
+
+set -euo pipefail
+
+BINARY="${1:?usage: test_capsule_artifact_sidecar.sh <compiler-binary>}"
+BINARY="$(realpath "$BINARY")"
+PASS=0
+FAIL=0
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "[test] SKIP: jq not installed (required for sidecar schema validation)" >&2
+    exit 0
+fi
+
+SCRATCH="$(mktemp -d -t sfn-capsule-artifact-XXXXXX)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+
+run_test() {
+    local name="$1"
+    shift
+    if "$@"; then
+        echo "[test] PASS: $name"
+        PASS=$((PASS + 1))
+    else
+        echo "[test] FAIL: $name"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# ---- Setup: a tiny library capsule with a single export ----
+# Uses the in-tree `sfn/math` as a synthetic dependency so the
+# resolver has at least one dep `.ll` to record in the sidecar's
+# `deps.ll_paths`. Symlink placement matches `test_capsule_build.sh`:
+# the in-tree `capsules/` lives next to the consuming `capsule.toml`
+# so `enumerate_capsule_sources` finds `sfn/math` at
+# `<project>/capsules/sfn/math/src/`.
+mkdir -p "$SCRATCH/src"
+ln -s "$REPO_ROOT/capsules" "$SCRATCH/capsules"
+
+cat > "$SCRATCH/capsule.toml" <<'EOF'
+[capsule]
+name = "demo/widget"
+version = "0.4.2"
+description = "E2E fixture for the per-capsule artifact sidecar"
+
+[dependencies]
+"sfn/math" = "0.1.0"
+
+[capabilities]
+required = ["io"]
+
+[build]
+kind = "library"
+entry = "src/mod.sfn"
+EOF
+
+cat > "$SCRATCH/src/mod.sfn" <<'EOF'
+import { abs } from "sfn/math";
+fn widget_abs(n: number) -> number { return abs(n); }
+EOF
+
+# ---- Test 1: sfn build -p succeeds and writes the sidecar ----
+test_sidecar_written() {
+    cd "$SCRATCH" || return 1
+    "$BINARY" build -p . > "$SCRATCH/build.stdout" 2>&1
+    local rc=$?
+    if [ "$rc" -ne 0 ]; then
+        echo "[test]   sfn build -p exited with code $rc; output:" >&2
+        cat "$SCRATCH/build.stdout" >&2
+        return $rc
+    fi
+    [ -f "$SCRATCH/build/capsules/demo/widget/manifest.json" ]
+}
+run_test "sfn build -p writes build/capsules/<scope>/<name>/manifest.json" test_sidecar_written
+
+SIDECAR="$SCRATCH/build/capsules/demo/widget/manifest.json"
+
+# ---- Test 2: sidecar is valid JSON ----
+test_sidecar_valid_json() {
+    jq . "$SIDECAR" > /dev/null 2>&1
+}
+run_test "sidecar is valid JSON" test_sidecar_valid_json
+
+# ---- Test 3: schema_version locked to "1" ----
+test_schema_version_locked() {
+    [ "$(jq -r .schema_version "$SIDECAR")" = "1" ]
+}
+run_test "schema_version is '1'" test_schema_version_locked
+
+# ---- Test 4: capsule + version + kind round-trip from capsule.toml ----
+test_capsule_metadata_present() {
+    [ "$(jq -r .capsule "$SIDECAR")" = "demo/widget" ] || return 1
+    [ "$(jq -r .version "$SIDECAR")" = "0.4.2" ] || return 1
+    [ "$(jq -r .kind "$SIDECAR")" = "library" ] || return 1
+}
+run_test "capsule / version / kind round-trip from capsule.toml" test_capsule_metadata_present
+
+# ---- Test 5: entry path is relative ----
+test_entry_relative() {
+    [ "$(jq -r .entry "$SIDECAR")" = "src/mod.sfn" ]
+}
+run_test "entry is relative to capsule.toml's dir" test_entry_relative
+
+# ---- Test 6: out points at the produced object ----
+test_out_present() {
+    local out
+    out=$(jq -r .out "$SIDECAR")
+    [ -n "$out" ] || return 1
+    # The library build produces a `.o` at the default path today.
+    case "$out" in
+        *.o) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+run_test "out names a file ending in .o (library build)" test_out_present
+
+# ---- Test 7: compiler_version is non-empty ----
+test_compiler_version_present() {
+    [ -n "$(jq -r .compiler_version "$SIDECAR")" ]
+}
+run_test "compiler_version is non-empty" test_compiler_version_present
+
+# ---- Test 8: deps.count matches deps.ll_paths length ----
+test_deps_consistency() {
+    local count len
+    count=$(jq -r .deps.count "$SIDECAR")
+    len=$(jq -r '.deps.ll_paths | length' "$SIDECAR")
+    [ "$count" = "$len" ] && [ "$count" -ge 1 ]
+}
+run_test "deps.count matches deps.ll_paths.length (>= 1)" test_deps_consistency
+
+# ---- Test 9: positional `sfn build` does NOT write a sidecar ----
+# The sidecar is a `-p` opt-in (we don't know the capsule name for
+# positional builds). This guards against accidental drive-by sidecars.
+test_positional_no_sidecar() {
+    rm -rf "$SCRATCH/build/capsules"
+    cd "$SCRATCH" || return 1
+    "$BINARY" build src/mod.sfn -o "$SCRATCH/build/program.o" \
+        > "$SCRATCH/positional.stdout" 2>&1 || true
+    # Whether the build itself succeeds depends on having sfn/math
+    # workspace-resolvable from this CWD; what we really need to
+    # check is "no sidecar was written" regardless.
+    [ ! -f "$SCRATCH/build/capsules/demo/widget/manifest.json" ]
+}
+run_test "positional sfn build writes no sidecar" test_positional_no_sidecar
+
+echo ""
+echo "[test] $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/compiler/tests/unit/capsule_artifact_test.sfn
+++ b/compiler/tests/unit/capsule_artifact_test.sfn
@@ -13,6 +13,7 @@ import {
     capsule_artifact_manifest_path,
     capsule_artifact_manifest_to_json,
     empty_capsule_artifact_manifest,
+    is_safe_scope_name,
     parse_scope_name,
     ScopeName
 } from "../../src/capsule_artifact";
@@ -58,6 +59,60 @@ test "parse_scope_name: trailing slash rejects (empty name)" {
     let p = parse_scope_name("sfn/");
     assert p.scope == "";
     assert p.name == "";
+}
+
+// --------------------------------------------------------------
+// is_safe_scope_name (path-traversal guard for sidecar emit)
+// --------------------------------------------------------------
+// `[capsule].name` is end-user-controlled. The validator MUST
+// reject anything that, after splitting on `/`, would let a
+// malicious manifest escape `build/capsules/`.
+test "is_safe_scope_name: simple scope+name accepted" {
+    assert is_safe_scope_name("sfn", "math");
+}
+
+test "is_safe_scope_name: submodule name with slashes accepted" {
+    assert is_safe_scope_name("sfn", "http/client");
+}
+
+test "is_safe_scope_name: empty scope rejected" {
+    assert ! is_safe_scope_name("", "math");
+}
+
+test "is_safe_scope_name: empty name rejected" {
+    assert ! is_safe_scope_name("sfn", "");
+}
+
+test "is_safe_scope_name: dot scope rejected" {
+    assert ! is_safe_scope_name(".", "math");
+}
+
+test "is_safe_scope_name: dotdot in name rejected" {
+    assert ! is_safe_scope_name("sfn", "..");
+    assert ! is_safe_scope_name("sfn", "../etc");
+    assert ! is_safe_scope_name("sfn", "good/../bad");
+}
+
+test "is_safe_scope_name: backslash in scope rejected" {
+    assert ! is_safe_scope_name("sfn\\evil", "math");
+}
+
+test "is_safe_scope_name: backslash in name segment rejected" {
+    assert ! is_safe_scope_name("sfn", "math\\evil");
+}
+
+test "is_safe_scope_name: leading slash in name rejected (absolute)" {
+    assert ! is_safe_scope_name("sfn", "/abs/path");
+}
+
+test "is_safe_scope_name: trailing slash in name rejected (empty last segment)" {
+    assert ! is_safe_scope_name("sfn", "math/");
+}
+
+test "is_safe_scope_name: scope with slash rejected" {
+    // Scope must be a single segment; any internal slash is a
+    // sign the parser should have run first.
+    assert ! is_safe_scope_name("sfn/extra", "math");
 }
 
 // --------------------------------------------------------------

--- a/compiler/tests/unit/capsule_artifact_test.sfn
+++ b/compiler/tests/unit/capsule_artifact_test.sfn
@@ -1,0 +1,166 @@
+// Stage C C2a regression tests for `compiler/src/capsule_artifact.sfn`.
+//
+// `capsule_artifact_manifest_to_json` is the per-capsule sidecar
+// serializer that future `sfn package` (C4), `sfn lsp` capsule
+// discovery, and MCP tooling will consume. Schema is documented
+// inline in `capsule_artifact.sfn` and gated by
+// `compiler/tests/e2e/test_capsule_artifact_sidecar.sh`. These
+// unit tests lock the per-field invariants — the e2e exercises
+// the full pipeline.
+import {
+    CapsuleArtifactManifest,
+    capsule_artifact_dir,
+    capsule_artifact_manifest_path,
+    capsule_artifact_manifest_to_json,
+    empty_capsule_artifact_manifest,
+    parse_scope_name,
+    ScopeName
+} from "../../src/capsule_artifact";
+
+// --------------------------------------------------------------
+// parse_scope_name
+// --------------------------------------------------------------
+test "parse_scope_name: scope/name splits at the first slash" {
+    let p = parse_scope_name("sfn/math");
+    assert p.scope == "sfn";
+    assert p.name == "math";
+}
+
+test "parse_scope_name: submodule keeps everything after first slash" {
+    // For a sidecar we only care about the capsule (`scope/name`);
+    // submodule-level packaging is a future concern. The contract
+    // here is "split on the first slash"; what comes after stays
+    // intact.
+    let p = parse_scope_name("sfn/http/client");
+    assert p.scope == "sfn";
+    assert p.name == "http/client";
+}
+
+test "parse_scope_name: no slash returns empty parts" {
+    let p = parse_scope_name("noslash");
+    assert p.scope == "";
+    assert p.name == "";
+}
+
+test "parse_scope_name: empty input returns empty parts" {
+    let p = parse_scope_name("");
+    assert p.scope == "";
+    assert p.name == "";
+}
+
+test "parse_scope_name: leading slash rejects (empty scope)" {
+    let p = parse_scope_name("/math");
+    assert p.scope == "";
+    assert p.name == "";
+}
+
+test "parse_scope_name: trailing slash rejects (empty name)" {
+    let p = parse_scope_name("sfn/");
+    assert p.scope == "";
+    assert p.name == "";
+}
+
+// --------------------------------------------------------------
+// path helpers
+// --------------------------------------------------------------
+test "capsule_artifact_dir: composes build/capsules/<scope>/<name>" {
+    assert capsule_artifact_dir("sfn", "math") == "build/capsules/sfn/math";
+}
+
+test "capsule_artifact_manifest_path: composes <dir>/manifest.json" {
+    assert capsule_artifact_manifest_path("sfn", "math") == "build/capsules/sfn/math/manifest.json";
+}
+
+// --------------------------------------------------------------
+// empty_capsule_artifact_manifest defaults
+// --------------------------------------------------------------
+test "empty_capsule_artifact_manifest: kind defaults to 'library'" {
+    assert empty_capsule_artifact_manifest().kind == "library";
+}
+
+test "empty_capsule_artifact_manifest: dep_ll_paths is empty" {
+    assert empty_capsule_artifact_manifest().dep_ll_paths.length == 0;
+}
+
+// --------------------------------------------------------------
+// capsule_artifact_manifest_to_json — schema invariants
+// --------------------------------------------------------------
+test "manifest_to_json: includes schema_version 1" {
+    let json = capsule_artifact_manifest_to_json(empty_capsule_artifact_manifest());
+    // Schema version is the contract for breaking changes.
+    assert _contains(json, "\"schema_version\":\"1\"");
+}
+
+test "manifest_to_json: round-trips capsule + version + kind" {
+    let mut m = empty_capsule_artifact_manifest();
+    m.capsule_name = "sfn/math";
+    m.version = "0.1.0";
+    m.kind = "library";
+    let json = capsule_artifact_manifest_to_json(m);
+    assert _contains(json, "\"capsule\":\"sfn/math\"");
+    assert _contains(json, "\"version\":\"0.1.0\"");
+    assert _contains(json, "\"kind\":\"library\"");
+}
+
+test "manifest_to_json: round-trips entry + out paths" {
+    let mut m = empty_capsule_artifact_manifest();
+    m.entry_relative = "src/mod.sfn";
+    m.out_path = "build/sailfin/program.o";
+    let json = capsule_artifact_manifest_to_json(m);
+    assert _contains(json, "\"entry\":\"src/mod.sfn\"");
+    assert _contains(json, "\"out\":\"build/sailfin/program.o\"");
+}
+
+test "manifest_to_json: round-trips compiler_version" {
+    let mut m = empty_capsule_artifact_manifest();
+    m.compiler_version = "0.5.10-alpha.2+dev.abc123";
+    let json = capsule_artifact_manifest_to_json(m);
+    assert _contains(json, "\"compiler_version\":\"0.5.10-alpha.2+dev.abc123\"");
+}
+
+test "manifest_to_json: deps.count matches array length" {
+    let mut m = empty_capsule_artifact_manifest();
+    m.dep_ll_paths = ["a.ll", "b.ll"];
+    let json = capsule_artifact_manifest_to_json(m);
+    assert _contains(json, "\"count\":2");
+    assert _contains(json, "\"a.ll\"");
+    assert _contains(json, "\"b.ll\"");
+}
+
+test "manifest_to_json: empty deps produce count=0 and []" {
+    let json = capsule_artifact_manifest_to_json(empty_capsule_artifact_manifest());
+    assert _contains(json, "\"count\":0");
+    assert _contains(json, "\"ll_paths\":[]");
+}
+
+test "manifest_to_json: backslash + quote in paths escaped per RFC 8259" {
+    let mut m = empty_capsule_artifact_manifest();
+    m.entry_relative = "src\\with\"quote.sfn";
+    let json = capsule_artifact_manifest_to_json(m);
+    assert _contains(json, "\"entry\":\"src\\\\with\\\"quote.sfn\"");
+}
+
+// --------------------------------------------------------------
+// Helpers
+// --------------------------------------------------------------
+fn _contains(haystack: string, needle: string) -> boolean {
+    if needle.length == 0 { return true; }
+    if haystack.length < needle.length { return false; }
+    let mut i: number = 0;
+    loop {
+        if i + needle.length > haystack.length { break; }
+        let mut j: number = 0;
+        let mut matches: boolean = true;
+        loop {
+            if j >= needle.length { break; }
+            if haystack[i + j] != needle[j] {
+                matches = false;
+                break;
+            }
+            j += 1;
+        }
+        if matches { return true; }
+        i += 1;
+    }
+    return false;
+}


### PR DESCRIPTION
## Summary

First step of Stage C2 (standard artifact layout). After a successful `sfn build -p`, emit `build/capsules/<scope>/<name>/manifest.json` capturing the resolved per-capsule build state. Schema-versioned, jq-parseable; downstream consumers (`sfn package` C4, `sfn lsp` capsule discovery, MCP tooling) can read it without re-running the build.

**Purely additive** — actual `.ll`/`.o` artifacts still live at their existing flat paths. C2b will migrate them into the canonical per-capsule tree under directories the sidecar already names.

```sh
$ sfn build -p capsules/sfn/math
$ jq . build/capsules/sfn/math/manifest.json
{
  "schema_version": "1",
  "capsule": "sfn/math",
  "version": "0.1.0",
  "kind": "library",
  "compiler_version": "0.5.10-alpha.2+dev.<hash>",
  "entry": "src/mod.sfn",
  "out": "build/sailfin/program.o",
  "deps": {
    "count": 0,
    "ll_paths": []
  }
}
```

## What ships

### `compiler/src/capsule_artifact.sfn` (new, 235 LOC)

- `CapsuleArtifactManifest` struct + `empty_capsule_artifact_manifest()`.
- `parse_scope_name(capsule_name)` — splits `"sfn/math"` into `("sfn", "math")`.
- `capsule_artifact_dir(scope, name)` → `build/capsules/<scope>/<name>` (proposal §4.4).
- `capsule_artifact_manifest_path(scope, name)` → `<dir>/manifest.json`.
- `capsule_artifact_manifest_to_json(m)` serializer.
- Self-contained JSON primitive encoders (mirrors `build_report.sfn`'s precedent).

### `compiler/src/cli_main.sfn`

- `_CapsuleBuildSpec` extended to carry `capsule_name`, `version`, `manifest_dir`, `entry_relative` so the post-build sidecar emitter doesn't re-read `capsule.toml`.
- `_emit_capsule_artifact_sidecar(...)` helper next to `_emit_build_report` / `_print_cache_summary`.
- Both success paths (library + binary) call the helper after existing output. `cap_capsule_name == ""` (positional build) short-circuits to a no-op.
- **Sidecar emission is independent of `--json`** — the file lives on disk regardless; stdout chatter still gates on `json_flag`.

## Why a sidecar before the path migration

1. **Locks in the schema** future stages (C4 `sfn package`, `sfn lsp` discovery, MCP) will consume.
2. **Gives downstream consumers a stable file to read TODAY** without waiting on C2b's larger refactor.
3. **C2b becomes "fill in `<scope>/<name>/{ir, obj, bin}/`"** under directories the sidecar already names — incremental rather than a simultaneous schema + path refactor.

## Test plan

- [x] `make compile` clean (135 modules, ~150s).
- [x] **`capsule_artifact_test.sfn`:** 17/17 PASS — `parse_scope_name` (6), path helpers (2), defaults (2), schema invariants (7).
- [x] **`test_capsule_artifact_sidecar.sh`:** 9/9 PASS — full pipeline via `jq`; gracefully skips if `jq` not installed.
- [x] **Regression:** `test_run_cache_flags.sh` 6/6, `test_capsule_build.sh` 4/4, `test_build_json_schema.sh` 9/9.
- [ ] **CI:** full unit + integration + e2e + cross-compile matrix.

## What's next (C2b)

- Migrate actual `.ll` / `.o` outputs into the canonical `build/capsules/<scope>/<name>/{ir, obj, bin}/` tree.
- Update `out_path` semantics to point at the canonical location.
- Add `modules` array enumerating per-source artifacts with cache keys threaded from `CacheStats`.

After C2b, C4 (`sfn package`) consumes the sidecar to know what to bundle.

https://claude.ai/code/session_01EyxoafGBhk1G9qjKvHiqby

---
_Generated by [Claude Code](https://claude.ai/code/session_01EyxoafGBhk1G9qjKvHiqby)_