### PR TITLE
Stage C2b1: canonical out-path for sfn build -p

### DIFF
--- a/compiler/src/capsule_artifact.sfn
+++ b/compiler/src/capsule_artifact.sfn
@@ -170,6 +170,40 @@ fn capsule_artifact_manifest_path(scope: string, name: string) -> string {
     return capsule_artifact_dir(scope, name) + "/manifest.json";
 }
 
+// `<artifact_dir>/obj/mod.o` — canonical library object location
+// (Stage C2b). Pure; does not create the directory.
+fn capsule_artifact_obj_path(scope: string, name: string) -> string {
+    return capsule_artifact_dir(scope, name) + "/obj/mod.o";
+}
+
+// `<artifact_dir>/bin/<bin>` — canonical binary executable
+// location (Stage C2b). `bin` defaults to the last `/`-separated
+// segment of the capsule name when the manifest doesn't override
+// it via `[build].bin-name` (post-C2b refinement).
+fn capsule_artifact_bin_path(scope: string, name: string, bin: string) -> string {
+    return capsule_artifact_dir(scope, name) + "/bin/" + bin;
+}
+
+// Last `/`-separated segment of a capsule name. For `"sfn/cli"`
+// returns `"cli"`; for a submodule capsule like
+// `"acme/router/middleware/auth"` returns `"auth"`. Used as the
+// default binary filename when `[build].bin-name` is unset.
+// Returns `""` for empty input or trailing-slash input — the
+// emitter must check the result before using it as a filename.
+fn capsule_default_bin_name(name: string) -> string {
+    if name.length == 0 { return ""; }
+    let mut last_slash: number = -1;
+    let mut i: number = 0;
+    loop {
+        if i >= name.length { break; }
+        if substring(name, i, i + 1) == "/" { last_slash = i; }
+        i += 1;
+    }
+    if last_slash < 0 { return name; }
+    if last_slash == name.length - 1 { return ""; }
+    return substring(name, last_slash + 1, name.length);
+}
+
 // -------------------------------------------------------------------
 // JSON primitive encoders (duplicated; see top-of-file rationale)
 // -------------------------------------------------------------------
@@ -283,5 +317,8 @@ export {
     is_safe_scope_name,
     capsule_artifact_dir,
     capsule_artifact_manifest_path,
+    capsule_artifact_obj_path,
+    capsule_artifact_bin_path,
+    capsule_default_bin_name,
     capsule_artifact_manifest_to_json
 };

--- a/compiler/src/cli_main.sfn
+++ b/compiler/src/cli_main.sfn
@@ -12,9 +12,12 @@ import { BuildReport, build_report_to_json, empty_build_report } from "./build_r
 import {
     CapsuleArtifactManifest,
     ScopeName,
+    capsule_artifact_bin_path,
     capsule_artifact_dir,
     capsule_artifact_manifest_path,
     capsule_artifact_manifest_to_json,
+    capsule_artifact_obj_path,
+    capsule_default_bin_name,
     empty_capsule_artifact_manifest,
     is_safe_scope_name,
     parse_scope_name
@@ -744,8 +747,38 @@ fn sailfin_cli_main(argv: string[]) -> number ![io, clock] {
         }
 
         if out_path.length == 0 {
-            if no_link { out_path = "build/sailfin/program.o"; } else {
-                out_path = "build/sailfin/program";
+            // Stage C2b: when `-p` is used and `-o` was NOT given,
+            // default to the canonical per-capsule layout
+            // (`build/capsules/<scope>/<name>/{obj/mod.o, bin/<name>}`)
+            // from proposal §4.4. Positional builds and explicit
+            // `-o` paths still use their pre-existing locations —
+            // user override is sacred. Unsafe / non-scope-form
+            // capsule names fall back to the legacy paths so a
+            // malformed `[capsule].name` can never escape the
+            // build root.
+            let mut canonical_set: boolean = false;
+            if cap_capsule_name.length > 0 {
+                let parts = parse_scope_name(cap_capsule_name);
+                if is_safe_scope_name(parts.scope, parts.name) {
+                    let cap_dir = capsule_artifact_dir(parts.scope, parts.name);
+                    if no_link {
+                        _ensure_dir(cap_dir + "/obj");
+                        out_path = capsule_artifact_obj_path(parts.scope, parts.name);
+                        canonical_set = true;
+                    } else {
+                        let bin_name = capsule_default_bin_name(parts.name);
+                        if bin_name.length > 0 {
+                            _ensure_dir(cap_dir + "/bin");
+                            out_path = capsule_artifact_bin_path(parts.scope, parts.name, bin_name);
+                            canonical_set = true;
+                        }
+                    }
+                }
+            }
+            if !canonical_set {
+                if no_link { out_path = "build/sailfin/program.o"; } else {
+                    out_path = "build/sailfin/program";
+                }
             }
         }
 

--- a/compiler/tests/e2e/test_capsule_artifact_sidecar.sh
+++ b/compiler/tests/e2e/test_capsule_artifact_sidecar.sh
@@ -115,18 +115,18 @@ test_entry_relative() {
 }
 run_test "entry is relative to capsule.toml's dir" test_entry_relative
 
-# ---- Test 6: out points at the produced object ----
-test_out_present() {
+# ---- Test 6: out points at the canonical per-capsule location ----
+test_out_canonical() {
+    # Stage C2b: `sfn build -p` (no explicit -o) writes to
+    # `build/capsules/<scope>/<name>/obj/mod.o` for libraries.
+    local expected="build/capsules/demo/widget/obj/mod.o"
     local out
     out=$(jq -r .out "$SIDECAR")
-    [ -n "$out" ] || return 1
-    # The library build produces a `.o` at the default path today.
-    case "$out" in
-        *.o) return 0 ;;
-        *) return 1 ;;
-    esac
+    [ "$out" = "$expected" ] || return 1
+    # And the file actually exists on disk.
+    [ -f "$SCRATCH/$expected" ]
 }
-run_test "out names a file ending in .o (library build)" test_out_present
+run_test "out points at build/capsules/<scope>/<name>/obj/mod.o (library)" test_out_canonical
 
 # ---- Test 7: compiler_version is non-empty ----
 test_compiler_version_present() {
@@ -143,7 +143,28 @@ test_deps_consistency() {
 }
 run_test "deps.count matches deps.ll_paths.length (>= 1)" test_deps_consistency
 
-# ---- Test 9: positional `sfn build` does NOT write a sidecar ----
+# ---- Test 9b: -o EXPLICIT overrides the canonical default ----
+test_explicit_o_wins() {
+    cd "$SCRATCH" || return 1
+    local explicit="$SCRATCH/build/explicit.o"
+    rm -f "$explicit"
+    "$BINARY" build -p . -o "$explicit" \
+        > "$SCRATCH/explicit.stdout" 2>&1
+    local rc=$?
+    if [ "$rc" -ne 0 ]; then
+        cat "$SCRATCH/explicit.stdout" >&2
+        return $rc
+    fi
+    # The user's explicit path wins for the actual artifact AND
+    # for the sidecar's `out` field.
+    [ -f "$explicit" ] || return 1
+    local sidecar_out
+    sidecar_out=$(jq -r .out "$SIDECAR")
+    [ "$sidecar_out" = "$explicit" ]
+}
+run_test "-o EXPLICIT overrides the canonical default" test_explicit_o_wins
+
+# ---- Test 10: positional `sfn build` does NOT write a sidecar ----
 # The sidecar is a `-p` opt-in (we don't know the capsule name for
 # positional builds). This guards against accidental drive-by sidecars.
 test_positional_no_sidecar() {

--- a/compiler/tests/e2e/test_capsule_artifact_sidecar.sh
+++ b/compiler/tests/e2e/test_capsule_artifact_sidecar.sh
@@ -179,6 +179,72 @@ test_positional_no_sidecar() {
 }
 run_test "positional sfn build writes no sidecar" test_positional_no_sidecar
 
+# ---- Test 11: kind = "binary" lands at <dir>/bin/<bin-name> ----
+# Stage C2b1 covers BOTH library and binary canonical paths; the
+# library coverage is in tests 6 + 9b above. This block exercises
+# the binary path: a `[build].kind = "binary"` capsule built via
+# `sfn build -p .` (no `-o`) must produce `<dir>/bin/<bin-name>`
+# AND the sidecar's `out` field must point at that same path.
+BIN_SCRATCH="$(mktemp -d -t sfn-capsule-artifact-bin-XXXXXX)"
+# Same-shell trap: unconditionally remove BIN_SCRATCH when this
+# script exits, in addition to the SCRATCH cleanup at the top.
+trap 'rm -rf "$SCRATCH" "$BIN_SCRATCH"' EXIT
+
+mkdir -p "$BIN_SCRATCH/src"
+ln -s "$REPO_ROOT/capsules" "$BIN_SCRATCH/capsules"
+
+cat > "$BIN_SCRATCH/capsule.toml" <<'EOF'
+[capsule]
+name = "demo/widgetcli"
+version = "0.5.1"
+description = "E2E fixture for the binary canonical path"
+
+[capabilities]
+required = ["io"]
+
+[build]
+kind = "binary"
+entry = "src/main.sfn"
+EOF
+
+cat > "$BIN_SCRATCH/src/main.sfn" <<'EOF'
+fn main() ![io] {
+    print("widgetcli ok");
+}
+EOF
+
+BIN_SIDECAR="$BIN_SCRATCH/build/capsules/demo/widgetcli/manifest.json"
+BIN_EXPECTED_OUT="build/capsules/demo/widgetcli/bin/widgetcli"
+
+test_binary_canonical_out() {
+    cd "$BIN_SCRATCH" || return 1
+    "$BINARY" build -p . > "$BIN_SCRATCH/build.stdout" 2>&1
+    local rc=$?
+    if [ "$rc" -ne 0 ]; then
+        echo "[test]   sfn build -p (binary) exited with code $rc; output:" >&2
+        cat "$BIN_SCRATCH/build.stdout" >&2
+        return $rc
+    fi
+    [ -f "$BIN_SIDECAR" ] || return 1
+    [ -x "$BIN_SCRATCH/$BIN_EXPECTED_OUT" ] || return 1
+    [ "$(jq -r .out "$BIN_SIDECAR")" = "$BIN_EXPECTED_OUT" ] || return 1
+    [ "$(jq -r .kind "$BIN_SIDECAR")" = "binary" ]
+}
+run_test "kind=binary lands at build/capsules/<scope>/<name>/bin/<bin-name>" test_binary_canonical_out
+
+# ---- Test 12: produced binary actually runs ----
+# Confirms the binary path isn't just metadata — clang link
+# produced an executable that starts and prints the expected
+# marker. Catches a future regression where the canonical path
+# is reported but no real binary lands there.
+test_binary_runs() {
+    cd "$BIN_SCRATCH" || return 1
+    [ -x "$BIN_EXPECTED_OUT" ] || return 1
+    "$BIN_SCRATCH/$BIN_EXPECTED_OUT" > "$BIN_SCRATCH/run.stdout" 2>&1 || return 1
+    grep -q "^widgetcli ok$" "$BIN_SCRATCH/run.stdout"
+}
+run_test "binary at canonical path runs and prints expected marker" test_binary_runs
+
 echo ""
 echo "[test] $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]

--- a/compiler/tests/unit/capsule_artifact_test.sfn
+++ b/compiler/tests/unit/capsule_artifact_test.sfn
@@ -9,9 +9,12 @@
 // the full pipeline.
 import {
     CapsuleArtifactManifest,
+    capsule_artifact_bin_path,
     capsule_artifact_dir,
     capsule_artifact_manifest_path,
     capsule_artifact_manifest_to_json,
+    capsule_artifact_obj_path,
+    capsule_default_bin_name,
     empty_capsule_artifact_manifest,
     is_safe_scope_name,
     parse_scope_name,
@@ -120,6 +123,35 @@ test "is_safe_scope_name: scope with slash rejected" {
 // --------------------------------------------------------------
 test "capsule_artifact_dir: composes build/capsules/<scope>/<name>" {
     assert capsule_artifact_dir("sfn", "math") == "build/capsules/sfn/math";
+}
+
+test "capsule_artifact_obj_path: composes <dir>/obj/mod.o" {
+    assert capsule_artifact_obj_path("sfn", "math") == "build/capsules/sfn/math/obj/mod.o";
+}
+
+test "capsule_artifact_bin_path: composes <dir>/bin/<bin>" {
+    assert capsule_artifact_bin_path("sfn", "cli", "cli") == "build/capsules/sfn/cli/bin/cli";
+    // Bin name can differ from the capsule's `name` segment if
+    // `[build].bin-name` is set in capsule.toml (post-C2b refinement).
+    assert capsule_artifact_bin_path("acme", "server", "httpd") == "build/capsules/acme/server/bin/httpd";
+}
+
+test "capsule_default_bin_name: simple name returns it verbatim" {
+    assert capsule_default_bin_name("cli") == "cli";
+}
+
+test "capsule_default_bin_name: submodule keeps last segment" {
+    assert capsule_default_bin_name("router/middleware/auth") == "auth";
+}
+
+test "capsule_default_bin_name: empty input returns empty" {
+    assert capsule_default_bin_name("") == "";
+}
+
+test "capsule_default_bin_name: trailing slash returns empty" {
+    // Trailing slash means the last segment is empty; emitter must
+    // detect this before using the result as a filename.
+    assert capsule_default_bin_name("foo/") == "";
 }
 
 test "capsule_artifact_manifest_path: composes <dir>/manifest.json" {


### PR DESCRIPTION
## Summary

Second step of Stage C2 (standard artifact layout). When `sfn build -p` is used and `-o` was NOT explicitly set, the build output now lands at the canonical per-capsule location from proposal §4.4:

| Build kind | Canonical location |
|---|---|
| library | `build/capsules/<scope>/<name>/obj/mod.o` |
| binary  | `build/capsules/<scope>/<name>/bin/<bin-name>` |

`<bin-name>` defaults to the last `/`-separated segment of the capsule name (`sfn/cli` → `cli`). Future C2c lets `[build].bin-name` in capsule.toml override this default.

```sh
$ sfn build -p capsules/sfn/math
$ ls build/capsules/sfn/math/
manifest.json  obj/
$ ls build/capsules/sfn/math/obj/
mod.o
```

The sidecar's `out` field naturally reflects the new path.

## Preserved behaviours

- `sfn build -p . -o build/program` → explicit `-o` wins. **User override is sacred.**
- `sfn build src/main.sfn` (positional, no `-p`) → legacy `build/sailfin/program{,.o}`. No change.
- Malformed `[capsule].name` (fails `is_safe_scope_name`) → falls back to legacy default. The sidecar emitter already short-circuits on the same check, so the build never lands outside `build/capsules/`.

## What ships

### `compiler/src/capsule_artifact.sfn`

- `capsule_artifact_obj_path(scope, name)` → `<dir>/obj/mod.o`
- `capsule_artifact_bin_path(scope, name, bin)` → `<dir>/bin/<bin>`
- `capsule_default_bin_name(name)` — last `/`-separated segment; `""` for empty / trailing-slash input

### `compiler/src/cli_main.sfn`

- `is_build`'s `out_path` defaulting now branches on `cap_capsule_name.length > 0`. For safe scope/name pairs, `_ensure_dir` creates `<dir>/{obj,bin}/` and `out_path` lands in the canonical location; otherwise the legacy default applies.

## Test plan

- [x] `make compile` clean (135 modules, ~150s).
- [x] **`capsule_artifact_test.sfn`:** 34/34 PASS (+6 from new path / bin-name helpers).
- [x] **`test_capsule_artifact_sidecar.sh`:** 10/10 PASS (+2: out points at canonical location; `-o EXPLICIT` overrides).
- [x] **Regression:** `test_capsule_build.sh` 4/4, `test_build_json_schema.sh` 9/9 — both use explicit `-o`, unaffected.
- [ ] **CI:** full unit + integration + e2e + cross-compile matrix.

## What's next

- **C2b2:** migrate dep `.ll` paths from flat `build/sailfin/capsules/<mangled-slug>.ll` → per-capsule `build/capsules/<scope>/<name>/ir/mod.ll`. Touches the resolver, `_clang_link_multi`, and the build report.
- **C2c:** per-module entries in the sidecar (slug, ir_path, obj_path, cache_key threaded from `CacheStats`).
- **C4:** `sfn package` consumes the canonical layout.

https://claude.ai/code/session_01EyxoafGBhk1G9qjKvHiqby

---
_Generated by [Claude Code](https://claude.ai/code/session_01EyxoafGBhk1G9qjKvHiqby)_