### PR TITLE
Stage C2b2: route dep .ll outputs into per-capsule ir/ tree

### DIFF
--- a/compiler/src/build_report.sfn
+++ b/compiler/src/build_report.sfn
@@ -47,10 +47,21 @@ import { substring } from "./string_utils";
 //   },
 //   "deps": {
 //     "count": 1,
-//     "ll_paths": ["build/sailfin/capsules/sfn__math__mod.ll"]
+//     "ll_paths": ["build/capsules/sfn/math/ir/mod.ll"]
 //   },
 //   "diagnostics": []
 // }
+//
+// schema_version stays at "1" after the C2b2 dep `.ll` path
+// migration. `dep_ll_paths` describes a list of `.ll` file paths;
+// the strings drifted from `build/sailfin/capsules/<mangled>.ll`
+// to `build/capsules/<scope>/<name>/ir/<rel>.ll` for manifest-
+// declared deps and intra-capsule sources of `-p` builds with
+// safe scope/name. Positional builds (and the compiler self-host,
+// whose `[capsule].name = "sailfin"` is single-segment) still
+// produce legacy paths in this field. Field shape is unchanged
+// (string array of file paths); a *shape* change (entries become
+// objects, etc.) would require a v2.
 //
 // `diagnostics` is reserved for future structured link errors
 // (proposal §4.11). Empty array today; consumers should treat

--- a/compiler/src/build_report.sfn
+++ b/compiler/src/build_report.sfn
@@ -53,9 +53,11 @@ import { substring } from "./string_utils";
 // }
 //
 // schema_version stays at "1" after the C2b2 dep `.ll` path
-// migration. `dep_ll_paths` describes a list of `.ll` file paths;
-// the strings drifted from `build/sailfin/capsules/<mangled>.ll`
-// to `build/capsules/<scope>/<name>/ir/<rel>.ll` for manifest-
+// migration. The `deps.ll_paths` JSON field (serialized from
+// the internal `BuildReport.dep_ll_paths` struct field)
+// describes a list of `.ll` file paths; the strings drifted
+// from `build/sailfin/capsules/<mangled>.ll` to
+// `build/capsules/<scope>/<name>/ir/<rel>.ll` for manifest-
 // declared deps and intra-capsule sources of `-p` builds with
 // safe scope/name. Positional builds (and the compiler self-host,
 // whose `[capsule].name = "sailfin"` is single-segment) still

--- a/compiler/src/capsule_artifact.sfn
+++ b/compiler/src/capsule_artifact.sfn
@@ -50,14 +50,16 @@ import { substring } from "./string_utils";
 // }
 //
 // schema_version is intentionally still "1" after the C2b2 dep `.ll`
-// path migration. `dep_ll_paths` describes a list of paths to dep
-// `.ll` files; the path strings drifted from the legacy
-// `build/sailfin/capsules/<mangled>.ll` form to the per-capsule
-// `build/capsules/<scope>/<name>/ir/<rel>.ll` tree, but the field
-// shape (string array of file paths) is unchanged. Same precedent as
-// C2b1, where `out_path` migrated from `build/sailfin/program{,.o}`
-// to `build/capsules/<scope>/<name>/{obj/mod.o, bin/<name>}` without
-// a schema bump. A *shape* change (entries become objects, etc.)
+// path migration. The `deps.ll_paths` JSON field (serialized from
+// the internal `CapsuleArtifactManifest.dep_ll_paths` struct field)
+// describes a list of paths to dep `.ll` files; the path strings
+// drifted from the legacy `build/sailfin/capsules/<mangled>.ll`
+// form to the per-capsule `build/capsules/<scope>/<name>/ir/<rel>.ll`
+// tree, but the field shape (string array of file paths) is
+// unchanged. Same precedent as C2b1, where `out_path` migrated from
+// `build/sailfin/program{,.o}` to
+// `build/capsules/<scope>/<name>/{obj/mod.o, bin/<name>}` without a
+// schema bump. A *shape* change (entries become objects, etc.)
 // would be a v2.
 struct ScopeName {
     scope: string;
@@ -271,14 +273,13 @@ struct CapsuleArtifactLayout {
 }
 
 fn empty_capsule_artifact_layout() -> CapsuleArtifactLayout {
-    let empty: string[] = [];
-    let empty2: string[] = [];
-    let empty3: string[] = [];
+    let empty_scopes: string[] = [];
+    let empty_names: string[] = [];
     return CapsuleArtifactLayout {
         consumer_scope: "",
         consumer_name: "",
-        dep_scopes: empty,
-        dep_names: empty2
+        dep_scopes: empty_scopes,
+        dep_names: empty_names
     };
 }
 

--- a/compiler/src/capsule_artifact.sfn
+++ b/compiler/src/capsule_artifact.sfn
@@ -45,9 +45,20 @@ import { substring } from "./string_utils";
 //                                        //   or <scope>/<name>/obj in C2b
 //   "deps": {
 //     "count": 1,
-//     "ll_paths": ["build/sailfin/capsules/sfn__runtime__mod.ll"]
+//     "ll_paths": ["build/capsules/sfn/runtime/ir/mod.ll"]
 //   }
 // }
+//
+// schema_version is intentionally still "1" after the C2b2 dep `.ll`
+// path migration. `dep_ll_paths` describes a list of paths to dep
+// `.ll` files; the path strings drifted from the legacy
+// `build/sailfin/capsules/<mangled>.ll` form to the per-capsule
+// `build/capsules/<scope>/<name>/ir/<rel>.ll` tree, but the field
+// shape (string array of file paths) is unchanged. Same precedent as
+// C2b1, where `out_path` migrated from `build/sailfin/program{,.o}`
+// to `build/capsules/<scope>/<name>/{obj/mod.o, bin/<name>}` without
+// a schema bump. A *shape* change (entries become objects, etc.)
+// would be a v2.
 struct ScopeName {
     scope: string;
     name: string;
@@ -170,6 +181,16 @@ fn capsule_artifact_manifest_path(scope: string, name: string) -> string {
     return capsule_artifact_dir(scope, name) + "/manifest.json";
 }
 
+// `<artifact_dir>/ir` — canonical per-capsule LLVM IR tree (Stage
+// C2b2). Each module's `.ll` lands at `<ir_dir>/<rel-slug>.ll`,
+// preserving the slug's `/`-separated subdirectories so a
+// `sfn/http/internal/buffer` slug becomes
+// `build/capsules/sfn/http/ir/internal/buffer.ll`. Pure; does not
+// create the directory.
+fn capsule_artifact_ir_dir(scope: string, name: string) -> string {
+    return capsule_artifact_dir(scope, name) + "/ir";
+}
+
 // `<artifact_dir>/obj/mod.o` — canonical library object location
 // (Stage C2b). Pure; does not create the directory.
 fn capsule_artifact_obj_path(scope: string, name: string) -> string {
@@ -202,6 +223,207 @@ fn capsule_default_bin_name(name: string) -> string {
     if last_slash < 0 { return name; }
     if last_slash == name.length - 1 { return ""; }
     return substring(name, last_slash + 1, name.length);
+}
+
+// -------------------------------------------------------------------
+// Stage C2b2 — per-capsule `.ll` layout
+// -------------------------------------------------------------------
+//
+// The resolver constructs `CapsuleSource.ll_path` strings that point
+// at where each module's lowered `.ll` will live on disk. Pre-C2b2
+// every dep `.ll` was written to a single flat directory
+// (`build/sailfin/capsules/<mangled-slug>.ll`); C2b2 routes them
+// into the per-capsule tree from §4.4 of the build-architecture
+// proposal.
+//
+// Routing rules, applied by `ir_path_for_slug`:
+//   1. If the slug starts with a known dep prefix `<scope>/<name>/`,
+//      the `.ll` lands under the **dep's** tree:
+//        `build/capsules/<scope>/<name>/ir/<rest>.ll`
+//   2. Otherwise, if the **consumer** capsule (the project being
+//      built via `-p`) has a safe scope/name, the `.ll` lands under
+//      the consumer's tree:
+//        `build/capsules/<consumer-scope>/<consumer-name>/ir/<slug>.ll`
+//   3. Otherwise — positional builds, single-segment names like
+//      `"sailfin"`, etc. — the function returns `""` and the
+//      resolver falls back to the legacy flat layout. The compiler
+//      self-host falls into this case by construction (its
+//      `capsule.toml` declares `name = "sailfin"`, single-segment).
+//
+// The struct + helpers below are pure: they take strings, return
+// strings, and never touch the filesystem. The resolver builds
+// `CapsuleArtifactLayout` from its dep source list once per build
+// (in `_cr_resolve_and_dedupe`) and consults it as it fills in
+// each `CapsuleSource.ll_path`.
+struct CapsuleArtifactLayout {
+    // Consumer's manifest scope/name, when `sfn build -p` was used
+    // and `[capsule].name` is in safe scope/name form. Empty means
+    // intra-capsule slugs fall through to the legacy flat layout.
+    consumer_scope: string;
+    consumer_name: string;
+    // Parallel arrays: `dep_scopes[i] / dep_names[i]` is one
+    // declared dep capsule. A slug starting with `<scope>/<name>/`
+    // is routed under that dep's tree. Built from
+    // `CapsuleSource.spec` values (filtered through
+    // `is_safe_scope_name`), deduped.
+    dep_scopes: string[];
+    dep_names: string[];
+}
+
+fn empty_capsule_artifact_layout() -> CapsuleArtifactLayout {
+    let empty: string[] = [];
+    let empty2: string[] = [];
+    let empty3: string[] = [];
+    return CapsuleArtifactLayout {
+        consumer_scope: "",
+        consumer_name: "",
+        dep_scopes: empty,
+        dep_names: empty2
+    };
+}
+
+// True iff `s` is a single safe path segment (no `/`, no `\`, not
+// `.`, not `..`, non-empty). Local copy of `_ca_is_safe_segment`'s
+// shape; kept private to this layout block so the validator can
+// evolve independently of the sidecar emit guard if needed.
+fn _ca_is_safe_relpath_segment(s: string) -> boolean {
+    if s.length == 0 { return false; }
+    if s == "." { return false; }
+    if s == ".." { return false; }
+    let mut i: number = 0;
+    loop {
+        if i >= s.length { break; }
+        let ch = substring(s, i, i + 1);
+        if ch == "/" { return false; }
+        if ch == "\\" { return false; }
+        i += 1;
+    }
+    return true;
+}
+
+// True iff `s` is a safe slash-separated relative path: no leading
+// `/`, no `\` anywhere, every `/`-segment is safe per
+// `_ca_is_safe_relpath_segment`. Used to validate slug tails before
+// interpolating them into a filesystem path. The slug itself is
+// produced by `module_name_from_path` and is already structurally
+// safe in practice; this is a defense-in-depth guard.
+fn _ca_is_safe_relpath(s: string) -> boolean {
+    if s.length == 0 { return false; }
+    if substring(s, 0, 1) == "/" { return false; }
+    let mut start: number = 0;
+    let mut i: number = 0;
+    loop {
+        if i >= s.length { break; }
+        let ch = substring(s, i, i + 1);
+        if ch == "\\" { return false; }
+        if ch == "/" {
+            let segment = substring(s, start, i);
+            if !_ca_is_safe_relpath_segment(segment) { return false; }
+            start = i + 1;
+        }
+        i += 1;
+    }
+    let last = substring(s, start, s.length);
+    return _ca_is_safe_relpath_segment(last);
+}
+
+// Returns the canonical per-capsule `.ll` path for `slug` under
+// `layout`, or `""` to signal "use the legacy fallback." See the
+// routing rules at the top of this section.
+//
+// The caller (`capsule_resolver.sfn`) treats `""` as "fall back to
+// `build/sailfin/capsules/<mangled>.ll`" — that's the pre-migration
+// layout, preserved for positional builds and the compiler
+// self-host. Callers do NOT need to interpret the returned path
+// further; it's already absolute-relative-to-cwd and uses `/`
+// separators throughout.
+fn ir_path_for_slug(layout: CapsuleArtifactLayout, slug: string) -> string {
+    if slug.length == 0 { return ""; }
+    // Defense-in-depth: a slug containing path-traversal segments
+    // would let a malformed source file land its `.ll` outside the
+    // build tree. `module_name_from_path` doesn't produce these in
+    // practice, but the validator is cheap.
+    if !_ca_is_safe_relpath(slug) { return ""; }
+
+    // Rule 1: dep-prefix match. Iterate in the order layout was
+    // built; specs are deduped at construction so each (scope,
+    // name) pair is checked at most once.
+    let mut i: number = 0;
+    loop {
+        if i >= layout.dep_scopes.length { break; }
+        let dep_scope = layout.dep_scopes[i];
+        let dep_name = layout.dep_names[i];
+        let prefix = dep_scope + "/" + dep_name + "/";
+        if slug.length > prefix.length {
+            if substring(slug, 0, prefix.length) == prefix {
+                let tail = substring(slug, prefix.length, slug.length);
+                if _ca_is_safe_relpath(tail) {
+                    return capsule_artifact_ir_dir(dep_scope, dep_name) + "/"
+                        + tail
+                        + ".ll";
+                }
+                return "";
+            }
+        }
+        i += 1;
+    }
+
+    // Rule 2: consumer fallback.
+    if layout.consumer_scope.length > 0 {
+        if layout.consumer_name.length > 0 {
+            if is_safe_scope_name(layout.consumer_scope, layout.consumer_name) {
+                return capsule_artifact_ir_dir(layout.consumer_scope, layout.consumer_name)
+                    + "/"
+                    + slug
+                    + ".ll";
+            }
+        }
+    }
+
+    // Rule 3: legacy fallback — caller composes the legacy path.
+    return "";
+}
+
+// Build a `CapsuleArtifactLayout` from a list of dep specs
+// (`CapsuleSource.spec` values from the resolver) plus the
+// consumer's scope/name. Dedupes (scope, name) pairs and filters
+// out any spec that fails `is_safe_scope_name`. Pure — testable
+// without filesystem setup.
+fn capsule_artifact_layout_from_specs(specs: string[], consumer_scope: string, consumer_name: string) -> CapsuleArtifactLayout {
+    let mut dep_scopes: string[] = [];
+    let mut dep_names: string[] = [];
+    let mut i: number = 0;
+    loop {
+        if i >= specs.length { break; }
+        let spec = specs[i];
+        i += 1;
+        if spec.length == 0 { continue; }
+        let p = parse_scope_name(spec);
+        if p.scope.length == 0 { continue; }
+        if !is_safe_scope_name(p.scope, p.name) { continue; }
+        let mut already: boolean = false;
+        let mut j: number = 0;
+        loop {
+            if j >= dep_scopes.length { break; }
+            if dep_scopes[j] == p.scope {
+                if dep_names[j] == p.name {
+                    already = true;
+                    break;
+                }
+            }
+            j += 1;
+        }
+        if !already {
+            dep_scopes.push(p.scope);
+            dep_names.push(p.name);
+        }
+    }
+    return CapsuleArtifactLayout {
+        consumer_scope: consumer_scope,
+        consumer_name: consumer_name,
+        dep_scopes: dep_scopes,
+        dep_names: dep_names
+    };
 }
 
 // -------------------------------------------------------------------
@@ -310,15 +532,20 @@ fn capsule_artifact_manifest_to_json(m: CapsuleArtifactManifest) -> string {
 }
 
 export {
+    CapsuleArtifactLayout,
     CapsuleArtifactManifest,
     ScopeName,
-    empty_capsule_artifact_manifest,
-    parse_scope_name,
-    is_safe_scope_name,
-    capsule_artifact_dir,
-    capsule_artifact_manifest_path,
-    capsule_artifact_obj_path,
     capsule_artifact_bin_path,
+    capsule_artifact_dir,
+    capsule_artifact_ir_dir,
+    capsule_artifact_layout_from_specs,
+    capsule_artifact_manifest_path,
+    capsule_artifact_manifest_to_json,
+    capsule_artifact_obj_path,
     capsule_default_bin_name,
-    capsule_artifact_manifest_to_json
+    empty_capsule_artifact_layout,
+    empty_capsule_artifact_manifest,
+    ir_path_for_slug,
+    is_safe_scope_name,
+    parse_scope_name
 };

--- a/compiler/src/capsule_resolver.sfn
+++ b/compiler/src/capsule_resolver.sfn
@@ -50,6 +50,11 @@ import {
     is_valid_digest
 } from "./build_cache";
 import {
+    CapsuleArtifactLayout,
+    capsule_artifact_layout_from_specs,
+    ir_path_for_slug
+} from "./capsule_artifact";
+import {
     compile_to_llvm_file_with_module,
     module_name_from_path,
     number_to_string,
@@ -67,26 +72,28 @@ import { resolve_compiler_version_for_cache } from "./version";
 export {
     CapsuleSource,
     CheckCapsuleResolution,
+    CompileCapsuleResult,
+    ProjectCapsuleResult,
+    ResolverConsumer,
     TestCapsuleResolution,
     WorkspaceMember,
     collect_relative_import_specs,
     collect_scoped_import_specs,
+    compile_capsule_modules,
     discover_project_root,
     discover_workspace_root,
+    empty_resolver_consumer,
     enumerate_capsule_sources,
     enumerate_relative_sources,
     enumerate_workspace_implicit_sources,
     load_workspace_members,
+    mangle_slug,
     parse_workspace_member_paths,
     prepare_project_capsules,
     prepare_project_capsules_for_check,
     prepare_project_capsules_for_test,
-    ProjectCapsuleResult,
-    CompileCapsuleResult,
     resolve_relative_import,
     stage_capsule_imports,
-    compile_capsule_modules,
-    mangle_slug,
     workspace_member_for_spec
 };
 
@@ -94,7 +101,39 @@ struct CapsuleSource {
     spec: string;  // e.g. "sfn/cli" — the dep key from capsule.toml
     source_path: string;  // absolute path to the .sfn file
     slug: string;  // e.g. "sfn/cli/mod" — used for staging + symbol mangling
-    ll_path: string;  // e.g. "build/sailfin/capsules/sfn__cli__mod.ll"
+    // Where the per-module `.ll` lands on disk. Stage C2b2 routes
+    // it via `ir_path_for_slug` into the per-capsule tree:
+    //   `build/capsules/<scope>/<name>/ir/<rel>.ll` for manifest-
+    //   declared deps and intra-capsule sources of a `-p` build
+    //   whose `[capsule].name` is in safe scope/name form;
+    //   otherwise falls back to legacy
+    //   `build/sailfin/capsules/<mangled>.ll`.
+    // Construction sites emit `ll_path = ""` and the post-dedupe
+    // pass in `_cr_resolve_and_dedupe` fills it in once the
+    // consumer + dep layout is known. Never observed empty by
+    // downstream callers.
+    ll_path: string;
+}
+
+// Identifies the "consumer" capsule of a resolver pass — the
+// capsule whose entry source we're building. Threaded into
+// `prepare_project_capsules{,_for_check,_for_test}` so the resolver
+// can route intra-capsule (relative-import) `.ll` outputs into the
+// consumer's own `build/capsules/<scope>/<name>/ir/` tree (Stage
+// C2b2). Both fields empty (`empty_resolver_consumer()`) means
+// "positional / no `-p`" — the legacy flat layout is used for any
+// source that doesn't fall under a manifest-declared dep prefix.
+//
+// `cli_main.sfn::is_build` populates this from the resolved
+// `[capsule].name`; `sfn run`, `sfn check`, and `sfn test` pass the
+// empty consumer until they grow `-p` plumbing of their own.
+struct ResolverConsumer {
+    scope: string;
+    name: string;
+}
+
+fn empty_resolver_consumer() -> ResolverConsumer {
+    return ResolverConsumer { scope: "", name: "" };
 }
 
 // Result of `compile_capsule_modules`: per-build .ll paths plus the
@@ -155,7 +194,10 @@ struct CheckCapsuleResolution {
 // been masking the resolver's correctness — was fixed.)
 struct TestCapsuleResolution {
     asm_paths: string[];  // build/native/import-context/<slug>.sfn-asm
-    ll_paths: string[];  // build/sailfin/capsules/<mangled-slug>.ll
+    // build/capsules/<scope>/<name>/ir/<rel>.ll (or legacy
+    // build/sailfin/capsules/<mangled>.ll fallback). See
+    // `CapsuleSource.ll_path` for the routing rules.
+    ll_paths: string[];
     capsule_count: number;  // post-dedupe count, for diagnostic output
     staging_failed: boolean;  // true on slug collision, stage-write, or compile failure
     // Phase F: same `[capabilities] required` surfacing as
@@ -268,6 +310,65 @@ fn mangle_slug(slug: string) -> string {
         i += 1;
     }
     return out;
+}
+
+// ---- LL path resolution (Stage C2b2) ----
+// Legacy flat layout for the `.ll` of a slug. Used by the C2b2
+// fallback path: positional builds, single-segment `[capsule].name`
+// (the compiler self-host falls in this bucket — its name is
+// `"sailfin"`), and any source whose slug doesn't match a known
+// dep prefix. One source of truth so the fallback never drifts
+// across the two CapsuleSource construction sites.
+fn _cr_legacy_ll_path(slug: string) -> string {
+    return "build/sailfin/capsules/" + mangle_slug(slug) + ".ll";
+}
+
+// Resolve the per-module `.ll` path under the given layout, falling
+// back to the legacy flat layout when the layout doesn't classify
+// the slug. Pure delegate to `ir_path_for_slug` from
+// `capsule_artifact.sfn`; kept here so the resolver has a single
+// site that owns the fallback policy.
+fn _cr_resolve_ll_path(slug: string, layout: CapsuleArtifactLayout) -> string {
+    let candidate = ir_path_for_slug(layout, slug);
+    if candidate.length > 0 { return candidate; }
+    return _cr_legacy_ll_path(slug);
+}
+
+// Compute the prefix that should be stripped from a relative-
+// import slug before routing it under the consumer's per-capsule
+// `ir/` tree. Returns `""` when the consumer isn't in safe
+// scope-form (in which case the consumer-tree branch is dead and
+// the prefix never matters) or when the `project_root` is empty
+// (positional builds without a discoverable manifest).
+//
+// The trailing `/` on the prefix is intentional: stripping
+// `project_root + "/"` (rather than `project_root`) keeps a
+// sibling path like `<project_root>extra/util.sfn` from being
+// mistakenly treated as intra-capsule.
+fn _cr_consumer_root_prefix(project_root: string, consumer: ResolverConsumer) -> string {
+    if consumer.scope.length == 0 { return ""; }
+    if consumer.name.length == 0 { return ""; }
+    if project_root.length == 0 { return ""; }
+    return project_root + "/";
+}
+
+// Compute the slug used purely for `ll_path` routing. For
+// intra-capsule (relative-import) sources whose path-shaped slug
+// starts with the consumer-root prefix, strip the prefix so the
+// routed path mirrors the source layout under the consumer's
+// `ir/` tree. For everything else (manifest deps with `<scope>/
+// <name>/<rest>` slugs, or any source where the prefix doesn't
+// match), return the slug unchanged. The original slug is
+// preserved on `CapsuleSource.slug` for cache keying, symbol
+// mangling, and `.sfn-asm` staging.
+fn _cr_routing_slug(cur: CapsuleSource, consumer_root_prefix: string) -> string {
+    if cur.spec.length > 0 { return cur.slug; }
+    if consumer_root_prefix.length == 0 { return cur.slug; }
+    if cur.slug.length <= consumer_root_prefix.length { return cur.slug; }
+    if substring(cur.slug, 0, consumer_root_prefix.length) != consumer_root_prefix {
+        return cur.slug;
+    }
+    return substring(cur.slug, consumer_root_prefix.length, cur.slug.length);
 }
 
 // ---- Project discovery ----
@@ -400,9 +501,14 @@ fn _cr_collect_capsule_sources(src_dir: string, spec: string) -> CapsuleSource[]
             if _cr_ends_with(entry, ".sfn") {
                 let stem = substring(entry, 0, entry.length - 4);
                 let slug = slug_prefix + "/" + stem;
-                let ll = "build/sailfin/capsules/" + mangle_slug(slug) + ".ll";
+                // ll_path is filled in by `_cr_resolve_and_dedupe`
+                // once the consumer + dep layout is known (Stage
+                // C2b2). Constructing it here would require
+                // threading the layout into every collector site;
+                // doing it post-dedupe keeps the layout decision
+                // in one place.
                 out.push(CapsuleSource {
-                    spec: spec, source_path: full, slug: slug, ll_path: ll
+                    spec: spec, source_path: full, slug: slug, ll_path: ""
                 });
             } else {
                 // Treat anything without a .sfn suffix as a potential
@@ -1481,10 +1587,13 @@ fn enumerate_relative_sources(entry_path: string) -> CapsuleSource[] ![io] {
                     visited.push(dep_path);
                     queue.push(dep_path);
                     let slug = _cr_relative_slug(entry_dir, dep_path);
-                    let ll = "build/sailfin/capsules/" + mangle_slug(slug)
-                        + ".ll";
+                    // ll_path is filled in by `_cr_resolve_and_dedupe`
+                    // once the consumer is known (Stage C2b2) — for
+                    // a `-p <consumer>` build with safe scope/name,
+                    // this lands under the consumer's per-capsule
+                    // tree; otherwise the legacy flat layout.
                     out.push(CapsuleSource {
-                        spec: "", source_path: dep_path, slug: slug, ll_path: ll
+                        spec: "", source_path: dep_path, slug: slug, ll_path: ""
                     });
                 }
             }
@@ -1905,7 +2014,13 @@ struct ResolverDedupeResult {
 // slug), prints a structured error to stderr and returns
 // `has_collision = true`. Same-slug-same-path entries are silently
 // deduped — that's an exact duplicate, not a conflict.
-fn _cr_resolve_and_dedupe(entry_paths: string[]) -> ResolverDedupeResult ![io] {
+//
+// Stage C2b2: after dedupe, this pass also fills in each
+// `CapsuleSource.ll_path` per the per-capsule layout (proposal
+// §4.4). Construction sites emit `ll_path = ""`; the layout
+// decision is centralized here so both manifest deps and
+// relative-imports route through the same policy.
+fn _cr_resolve_and_dedupe(entry_paths: string[], consumer: ResolverConsumer) -> ResolverDedupeResult ![io] {
     let mut sources: CapsuleSource[] = [];
     let empty_sources: CapsuleSource[] = [];
 
@@ -2041,8 +2156,52 @@ fn _cr_resolve_and_dedupe(entry_paths: string[]) -> ResolverDedupeResult ![io] {
         si += 1;
     }
 
+    // Stage C2b2: fill in `ll_path` for each deduped source via
+    // the per-capsule layout. Build the layout once from the
+    // post-dedupe spec set so each (scope, name) pair is checked
+    // at most once during routing. `ll_path` was emitted as `""`
+    // at the construction sites; downstream callers (
+    // `compile_capsule_modules`, `_clang_link_multi`) only ever
+    // see the resolved value.
+    let mut dep_specs: string[] = [];
+    let mut ds: number = 0;
+    loop {
+        if ds >= deduped.length { break; }
+        if deduped[ds].spec.length > 0 {
+            dep_specs.push(deduped[ds].spec);
+        }
+        ds += 1;
+    }
+    let layout = capsule_artifact_layout_from_specs(dep_specs, consumer.scope, consumer.name);
+
+    // For intra-capsule (relative-import) sources, the slug
+    // produced by `module_name_from_path` is a path-shaped
+    // identifier — for files outside `compiler/src/` and
+    // `runtime/` it's the full source path minus extension (e.g.
+    // `/tmp/widget/src/util` for an absolute entry). That's
+    // unsuitable as a tail under `<consumer>/ir/` (it'd start
+    // with `/`). Strip the discovered `project_root` prefix so
+    // the routed tail mirrors the source layout (e.g. `src/util`
+    // → `build/capsules/<consumer>/ir/src/util.ll`). The
+    // original slug stays in `cur.slug` for cache keying, symbol
+    // mangling, and `.sfn-asm` staging — only the ll_path
+    // computation sees the relativized form.
+    let consumer_root_prefix = _cr_consumer_root_prefix(project_root, consumer);
+    let mut resolved: CapsuleSource[] = [];
+    let mut ri: number = 0;
+    loop {
+        if ri >= deduped.length { break; }
+        let cur = deduped[ri];
+        let routing_slug = _cr_routing_slug(cur, consumer_root_prefix);
+        let ll = _cr_resolve_ll_path(routing_slug, layout);
+        resolved.push(CapsuleSource {
+            spec: cur.spec, source_path: cur.source_path, slug: cur.slug, ll_path: ll
+        });
+        ri += 1;
+    }
+
     return ResolverDedupeResult {
-        sources: deduped,
+        sources: resolved,
         has_collision: false,
         capabilities_required: capabilities_required
     };
@@ -2057,10 +2216,10 @@ fn _cr_resolve_and_dedupe(entry_paths: string[]) -> ResolverDedupeResult ![io] {
 // missing-symbol follow-up downstream. Inspect `stats` (and any
 // `print.err` output the helpers emitted) for setup failures vs.
 // genuinely-empty dep graphs.
-fn prepare_project_capsules(input_path: string, config: BuildCacheConfig) -> ProjectCapsuleResult ![io] {
+fn prepare_project_capsules(input_path: string, config: BuildCacheConfig, consumer: ResolverConsumer) -> ProjectCapsuleResult ![io] {
     let empty_paths: string[] = [];
     let entry_paths: string[] = [input_path];
-    let resolved = _cr_resolve_and_dedupe(entry_paths);
+    let resolved = _cr_resolve_and_dedupe(entry_paths, consumer);
     if resolved.has_collision {
         return ProjectCapsuleResult {
             ll_paths: empty_paths,
@@ -2118,9 +2277,9 @@ fn prepare_project_capsules(input_path: string, config: BuildCacheConfig) -> Pro
 //   - Standalone files outside any capsule.toml are valid input and
 //     return an empty resolution (no error) — relative-import walking
 //     still happens via `enumerate_relative_sources`.
-fn prepare_project_capsules_for_check(entry_paths: string[]) -> CheckCapsuleResolution ![io] {
+fn prepare_project_capsules_for_check(entry_paths: string[], consumer: ResolverConsumer) -> CheckCapsuleResolution ![io] {
     let empty_paths: string[] = [];
-    let resolved = _cr_resolve_and_dedupe(entry_paths);
+    let resolved = _cr_resolve_and_dedupe(entry_paths, consumer);
     // Phase F: surface the manifest's capability surface even on
     // the early-exit paths. A collision/stage failure shouldn't
     // silently disable E0403 for a clean re-run; the failure modes
@@ -2197,9 +2356,9 @@ fn prepare_project_capsules_for_check(entry_paths: string[]) -> CheckCapsuleReso
 //     own compile path still runs, and any relative-import walking
 //     happens inside the per-entry `enumerate_relative_sources`
 //     branch of `_cr_resolve_and_dedupe`.
-fn prepare_project_capsules_for_test(entry_paths: string[]) -> TestCapsuleResolution ![io] {
+fn prepare_project_capsules_for_test(entry_paths: string[], consumer: ResolverConsumer) -> TestCapsuleResolution ![io] {
     let empty_paths: string[] = [];
-    let resolved = _cr_resolve_and_dedupe(entry_paths);
+    let resolved = _cr_resolve_and_dedupe(entry_paths, consumer);
     // Phase F: thread `capabilities_required` through every exit
     // path. Same rationale as `prepare_project_capsules_for_check`:
     // staging failures are setup-time concerns, not manifest

--- a/compiler/src/cli_check.sfn
+++ b/compiler/src/cli_check.sfn
@@ -21,6 +21,7 @@ import {
     CheckCapsuleResolution,
     discover_project_root,
     discover_workspace_root,
+    empty_resolver_consumer,
     prepare_project_capsules_for_check
 } from "./capsule_resolver";
 import { _collect_sfn_files_cmd, _dirname_cmd } from "./cli_commands_utils";
@@ -247,7 +248,12 @@ fn handle_check_command(args: string[]) -> number ![io] {
     let mut gi: number = 0;
     loop {
         if gi >= groups.length { break; }
-        let resolution = prepare_project_capsules_for_check(groups[gi].entry_paths);
+        // `sfn check` does not write `.ll` (it stops after staging),
+        // so the per-capsule layout has no observable effect on
+        // this path. Pass an empty consumer; when `sfn check -p`
+        // lands the consumer is computed from the project's manifest
+        // the same way `sfn build` does it.
+        let resolution = prepare_project_capsules_for_check(groups[gi].entry_paths, empty_resolver_consumer());
         if resolution.staging_failed {
             // The resolver already wrote a structured error to
             // stderr (slug collision or stage-write failure).

--- a/compiler/src/cli_commands.sfn
+++ b/compiler/src/cli_commands.sfn
@@ -7,6 +7,7 @@ import {
     TestCapsuleResolution,
     discover_project_root,
     discover_workspace_root,
+    empty_resolver_consumer,
     prepare_project_capsules_for_test
 } from "./capsule_resolver";
 import {
@@ -349,7 +350,12 @@ fn handle_test_command(args: string[], runtime_root: string) -> number ![io] {
                 + number_to_string(groups[gi].entry_paths.length)
                 + ")");
         }
-        let resolution = prepare_project_capsules_for_test(groups[gi].entry_paths);
+        // `sfn test` does not yet take `-p`, so the consumer is
+        // empty and per-capsule `.ll` routing falls back to the
+        // legacy flat layout (Stage C2b2). Test-time link continues
+        // to consume `build/sailfin/capsules/<mangled>.ll` until
+        // `sfn test -p` ships.
+        let resolution = prepare_project_capsules_for_test(groups[gi].entry_paths, empty_resolver_consumer());
         if resolution.staging_failed {
             // Resolver already emitted a structured error to stderr
             // (slug collision, stage-write, or compile failure).

--- a/compiler/src/cli_main.sfn
+++ b/compiler/src/cli_main.sfn
@@ -22,7 +22,12 @@ import {
     is_safe_scope_name,
     parse_scope_name
 } from "./capsule_artifact";
-import { ProjectCapsuleResult, prepare_project_capsules } from "./capsule_resolver";
+import {
+    ProjectCapsuleResult,
+    ResolverConsumer,
+    empty_resolver_consumer,
+    prepare_project_capsules
+} from "./capsule_resolver";
 import { handle_check_command } from "./cli_check";
 import {
     handle_add_command,
@@ -746,6 +751,26 @@ fn sailfin_cli_main(argv: string[]) -> number ![io, clock] {
             return 2;
         }
 
+        // Resolve the consumer's safe scope/name once. Used by:
+        //   (a) the canonical-`out_path` defaulting block below
+        //       (Stage C2b1), and
+        //   (b) the resolver's `ResolverConsumer` so intra-capsule
+        //       relative-import `.ll`s land under the consumer's
+        //       per-capsule tree (Stage C2b2).
+        // Both `out_path` and dep `.ll` routing fall back to the
+        // legacy flat layout when the name isn't scope-form (e.g.
+        // the compiler's own `[capsule].name = "sailfin"`).
+        let mut consumer = empty_resolver_consumer();
+        if cap_capsule_name.length > 0 {
+            let parts0 = parse_scope_name(cap_capsule_name);
+            if is_safe_scope_name(parts0.scope, parts0.name) {
+                consumer = ResolverConsumer {
+                    scope: parts0.scope,
+                    name: parts0.name
+                };
+            }
+        }
+
         if out_path.length == 0 {
             // Stage C2b: when `-p` is used and `-o` was NOT given,
             // default to the canonical per-capsule layout
@@ -757,21 +782,18 @@ fn sailfin_cli_main(argv: string[]) -> number ![io, clock] {
             // malformed `[capsule].name` can never escape the
             // build root.
             let mut canonical_set: boolean = false;
-            if cap_capsule_name.length > 0 {
-                let parts = parse_scope_name(cap_capsule_name);
-                if is_safe_scope_name(parts.scope, parts.name) {
-                    let cap_dir = capsule_artifact_dir(parts.scope, parts.name);
-                    if no_link {
-                        _ensure_dir(cap_dir + "/obj");
-                        out_path = capsule_artifact_obj_path(parts.scope, parts.name);
+            if consumer.scope.length > 0 {
+                let cap_dir = capsule_artifact_dir(consumer.scope, consumer.name);
+                if no_link {
+                    _ensure_dir(cap_dir + "/obj");
+                    out_path = capsule_artifact_obj_path(consumer.scope, consumer.name);
+                    canonical_set = true;
+                } else {
+                    let bin_name = capsule_default_bin_name(consumer.name);
+                    if bin_name.length > 0 {
+                        _ensure_dir(cap_dir + "/bin");
+                        out_path = capsule_artifact_bin_path(consumer.scope, consumer.name, bin_name);
                         canonical_set = true;
-                    } else {
-                        let bin_name = capsule_default_bin_name(parts.name);
-                        if bin_name.length > 0 {
-                            _ensure_dir(cap_dir + "/bin");
-                            out_path = capsule_artifact_bin_path(parts.scope, parts.name, bin_name);
-                            canonical_set = true;
-                        }
                     }
                 }
             }
@@ -795,7 +817,7 @@ fn sailfin_cli_main(argv: string[]) -> number ![io, clock] {
         // capsule.toml before compiling the main source. stage_capsule_imports
         // writes .sfn-asm + .layout-manifest into build/native/import-context/
         // where the main module's lowering will find them.
-        let capsule_result = prepare_project_capsules(input_path, cache_config);
+        let capsule_result = prepare_project_capsules(input_path, cache_config, consumer);
         let capsule_lls = capsule_result.ll_paths;
 
         let ll_path = "build/sailfin/program.ll";
@@ -926,7 +948,11 @@ fn sailfin_cli_main(argv: string[]) -> number ![io, clock] {
         // (`--no-cache` / `--clean` / `--cache-trace`) layer on top of
         // env-var defaults (`SAILFIN_NO_CACHE` / `SAILFIN_CACHE_TRACE`).
         let run_cache_config = resolve_build_cache_config(no_cache_flag, cache_trace_flag, clean_flag);
-        let run_capsule_result = prepare_project_capsules(input_path, run_cache_config);
+        // `sfn run` has no `-p` plumbing yet, so the consumer is
+        // always empty: relative-import `.ll`s take the legacy
+        // flat layout (Stage C2b2). When `sfn run -p` lands, this
+        // becomes a one-line update mirroring `sfn build`.
+        let run_capsule_result = prepare_project_capsules(input_path, run_cache_config, empty_resolver_consumer());
         let capsule_lls = run_capsule_result.ll_paths;
 
         let source = fs.readFile(input_path);

--- a/compiler/tests/e2e/test_build_json_schema.sh
+++ b/compiler/tests/e2e/test_build_json_schema.sh
@@ -125,6 +125,31 @@ test_deps_consistency() {
 }
 run_test "deps.count matches deps.ll_paths.length (>= 1)" test_deps_consistency
 
+# ---- Test 5b: every deps.ll_paths entry exists on disk ----
+# Hardens the schema test against future path-shape drift without
+# locking the prefix: any path the report names must be a real
+# `.ll` file the linker actually saw. Catches both stale path
+# strings and dropped-but-listed dep regressions. Stage C2b2.
+test_deps_ll_paths_exist() {
+    local missing=0
+    while IFS= read -r path; do
+        [ -z "$path" ] && continue
+        if [ ! -f "$SCRATCH/$path" ]; then
+            echo "[test]   missing dep .ll: $path" >&2
+            missing=1
+        fi
+        case "$path" in
+            *.ll) ;;
+            *)
+                echo "[test]   dep_ll_paths entry doesn't end in .ll: $path" >&2
+                missing=1
+                ;;
+        esac
+    done < <(jq -r '.deps.ll_paths[]' "$SCRATCH/cold.json")
+    [ "$missing" -eq 0 ]
+}
+run_test "every deps.ll_paths entry is a real .ll file" test_deps_ll_paths_exist
+
 # ---- Test 6: diagnostics is empty array (reserved for §4.11) ----
 test_diagnostics_reserved() {
     [ "$(jq -r '.diagnostics | length' "$SCRATCH/cold.json")" = "0" ]

--- a/compiler/tests/e2e/test_capsule_artifact_sidecar.sh
+++ b/compiler/tests/e2e/test_capsule_artifact_sidecar.sh
@@ -143,6 +143,47 @@ test_deps_consistency() {
 }
 run_test "deps.count matches deps.ll_paths.length (>= 1)" test_deps_consistency
 
+# ---- Test 8b: every deps.ll_paths entry exists on disk ----
+# Stage C2b2 — `dep_ll_paths` strings must point at real `.ll`
+# files. Hardens the schema contract without locking the prefix:
+# the path shape can drift across stages, but every named entry
+# must be a real, on-disk artifact with the `.ll` extension.
+test_deps_ll_paths_exist() {
+    local missing=0
+    while IFS= read -r path; do
+        [ -z "$path" ] && continue
+        if [ ! -f "$SCRATCH/$path" ]; then
+            echo "[test]   missing dep .ll: $path" >&2
+            missing=1
+        fi
+        case "$path" in
+            *.ll) ;;
+            *)
+                echo "[test]   dep_ll_paths entry doesn't end in .ll: $path" >&2
+                missing=1
+                ;;
+        esac
+    done < <(jq -r '.deps.ll_paths[]' "$SIDECAR")
+    [ "$missing" -eq 0 ]
+}
+run_test "every deps.ll_paths entry is a real .ll file" test_deps_ll_paths_exist
+
+# ---- Test 8c: dep .ll lives under the per-capsule tree ----
+# Stage C2b2: `sfn/math` is a manifest-declared dep, so its `.ll`
+# must land at `build/capsules/sfn/math/ir/mod.ll` rather than the
+# legacy `build/sailfin/capsules/sfn__math__mod.ll`. Locks the
+# per-capsule routing in the sidecar's view of the world.
+test_dep_ll_under_per_capsule_tree() {
+    local found=0
+    while IFS= read -r path; do
+        case "$path" in
+            build/capsules/sfn/math/ir/*.ll) found=1 ;;
+        esac
+    done < <(jq -r '.deps.ll_paths[]' "$SIDECAR")
+    [ "$found" -eq 1 ]
+}
+run_test "dep .ll routes under build/capsules/sfn/math/ir/ (Stage C2b2)" test_dep_ll_under_per_capsule_tree
+
 # ---- Test 9b: -o EXPLICIT overrides the canonical default ----
 test_explicit_o_wins() {
     cd "$SCRATCH" || return 1

--- a/compiler/tests/e2e/test_capsule_build.sh
+++ b/compiler/tests/e2e/test_capsule_build.sh
@@ -114,11 +114,21 @@ test_import_context_staged() {
 }
 run_test "capsule import-context was staged" test_import_context_staged
 
-# ---- Test 4: capsule .ll was produced ----
+# ---- Test 4: capsule .ll was produced under the per-capsule tree ----
+# Stage C2b2 routes manifest-declared dep `.ll` outputs under
+# `build/capsules/<scope>/<name>/ir/<rel>.ll` regardless of whether
+# the build was invoked with `-p` or positionally — the dep's own
+# `(scope, name)` is what determines the routing.
 test_capsule_ll_produced() {
-    [ -f "$SCRATCH/build/sailfin/capsules/sfn__math__mod.ll" ]
+    [ -f "$SCRATCH/build/capsules/sfn/math/ir/mod.ll" ]
 }
-run_test "capsule .ll was produced" test_capsule_ll_produced
+run_test "capsule .ll was produced under per-capsule tree" test_capsule_ll_produced
+
+# ---- Test 5: legacy flat .ll path is no longer written for manifest deps ----
+test_legacy_path_absent() {
+    ! [ -f "$SCRATCH/build/sailfin/capsules/sfn__math__mod.ll" ]
+}
+run_test "legacy flat .ll path is no longer used for manifest deps" test_legacy_path_absent
 
 # ---- Summary ----
 echo ""

--- a/compiler/tests/e2e/test_capsule_ir_layout.sh
+++ b/compiler/tests/e2e/test_capsule_ir_layout.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+# End-to-end test for the per-capsule `.ll` layout (Stage C2b2).
+#
+# Verifies that `sfn build -p <capsule>` routes module `.ll`
+# outputs into the canonical per-capsule tree from proposal §4.4:
+#
+#   build/capsules/<dep-scope>/<dep-name>/ir/<rel>.ll
+#       — for sources of manifest-declared deps
+#   build/capsules/<consumer-scope>/<consumer-name>/ir/<rel>.ll
+#       — for intra-capsule (relative-import) sources of a `-p`
+#         consumer with a safe scope/name
+#   build/sailfin/capsules/<mangled>.ll
+#       — legacy fallback (positional builds, single-segment names)
+#
+# Also re-confirms that the build_report.sfn `dep_ll_paths` and
+# capsule_artifact.sfn sidecar reflect the new paths.
+#
+# Schema bumps are explicitly NOT happening for path drift inside
+# `dep_ll_paths` — see capsule_artifact.sfn / build_report.sfn for
+# the rationale. This test locks the new path shape; if it ever
+# regresses to the legacy flat form for manifest deps, downstream
+# tooling that walks the per-capsule tree breaks.
+#
+# Usage:
+#   compiler/tests/e2e/test_capsule_ir_layout.sh <compiler-binary>
+
+set -euo pipefail
+
+BINARY="${1:?usage: test_capsule_ir_layout.sh <compiler-binary>}"
+BINARY="$(realpath "$BINARY")"
+PASS=0
+FAIL=0
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "[test] SKIP: jq not installed (required for sidecar/report parsing)" >&2
+    exit 0
+fi
+
+SCRATCH="$(mktemp -d -t sfn-capsule-ir-layout-XXXXXX)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+
+run_test() {
+    local name="$1"
+    shift
+    if "$@"; then
+        echo "[test] PASS: $name"
+        PASS=$((PASS + 1))
+    else
+        echo "[test] FAIL: $name"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# ---- Setup: a `demo/widget` library with a relative import + dep ----
+# - `src/mod.sfn` imports from a manifest dep (sfn/math) AND a
+#   relative sibling (./util) so we exercise BOTH routing rules.
+# - `src/util.sfn` is the relative-import target; under C2b2 its
+#   `.ll` lands under the consumer's tree, NOT the dep tree.
+mkdir -p "$SCRATCH/src"
+ln -s "$REPO_ROOT/capsules" "$SCRATCH/capsules"
+
+cat > "$SCRATCH/capsule.toml" <<'EOF'
+[capsule]
+name = "demo/widget"
+version = "0.1.0"
+description = "E2E fixture for the Stage C2b2 per-capsule .ll layout"
+
+[dependencies]
+"sfn/math" = "0.1.0"
+
+[capabilities]
+required = ["io"]
+
+[build]
+kind = "library"
+entry = "src/mod.sfn"
+EOF
+
+cat > "$SCRATCH/src/mod.sfn" <<'EOF'
+import { abs } from "sfn/math";
+import { double } from "./util";
+
+fn widget_compute(n: number) -> number {
+    return double(abs(n));
+}
+EOF
+
+cat > "$SCRATCH/src/util.sfn" <<'EOF'
+fn double(n: number) -> number {
+    return n * 2;
+}
+EOF
+
+# ---- Test 1: build succeeds ----
+test_build_succeeds() {
+    cd "$SCRATCH" || return 1
+    "$BINARY" build -p . --json > "$SCRATCH/build.json" 2> "$SCRATCH/build.err"
+    local rc=$?
+    if [ "$rc" -ne 0 ]; then
+        echo "[test]   sfn build -p exited with code $rc; stderr:" >&2
+        cat "$SCRATCH/build.err" >&2
+        return $rc
+    fi
+    jq . "$SCRATCH/build.json" > /dev/null 2>&1
+}
+run_test "sfn build -p succeeds with --json" test_build_succeeds
+
+SIDECAR="$SCRATCH/build/capsules/demo/widget/manifest.json"
+
+# ---- Test 2: manifest dep .ll lives under the dep's tree ----
+test_dep_ll_under_dep_tree() {
+    [ -f "$SCRATCH/build/capsules/sfn/math/ir/mod.ll" ]
+}
+run_test "manifest dep .ll lands at build/capsules/sfn/math/ir/mod.ll" test_dep_ll_under_dep_tree
+
+# ---- Test 3: relative-import .ll lives under the consumer's tree ----
+# The slug for `./util` from `src/mod.sfn` is computed by
+# `module_name_from_path` and lands at `<project_root>/src/util`
+# (path-shaped). Stage C2b2 strips the discovered project_root
+# prefix before routing, so the .ll lands at
+# `build/capsules/<consumer>/ir/src/util.ll` — mirroring the
+# source layout under the capsule's own ir/ tree.
+test_relative_ll_under_consumer_tree() {
+    [ -f "$SCRATCH/build/capsules/demo/widget/ir/src/util.ll" ]
+}
+run_test "relative-import .ll lands at build/capsules/demo/widget/ir/src/util.ll" test_relative_ll_under_consumer_tree
+
+# ---- Test 4: legacy mangled paths are NOT written for manifest deps ----
+# Defends against double-emission regressions: if both paths exist,
+# the linker could end up consuming stale or duplicate copies.
+test_no_legacy_dep_path() {
+    ! [ -f "$SCRATCH/build/sailfin/capsules/sfn__math__mod.ll" ]
+}
+run_test "legacy build/sailfin/capsules/sfn__math__mod.ll is not written" test_no_legacy_dep_path
+
+# ---- Test 5: legacy mangled paths are NOT written for relative imports ----
+# The pre-C2b2 mangling of the project_root-rooted slug
+# (`<project_root>/src/util` → `<...>__src__util`) must no longer
+# appear under `build/sailfin/capsules/`.
+test_no_legacy_relative_path() {
+    # No file at any well-known mangled name for `./util`.
+    ! [ -f "$SCRATCH/build/sailfin/capsules/src__util.ll" ] || return 1
+    ! [ -f "$SCRATCH/build/sailfin/capsules/util.ll" ]
+}
+run_test "no legacy build/sailfin/capsules/...util.ll is written" test_no_legacy_relative_path
+
+# ---- Test 6: build_report dep_ll_paths reflects per-capsule tree ----
+test_report_paths_canonical() {
+    local report="$SCRATCH/build.json"
+    local found_dep=0 found_rel=0 missing=0
+    while IFS= read -r path; do
+        [ -z "$path" ] && continue
+        if [ ! -f "$SCRATCH/$path" ]; then
+            echo "[test]   missing report dep .ll: $path" >&2
+            missing=1
+        fi
+        case "$path" in
+            build/capsules/sfn/math/ir/*.ll) found_dep=1 ;;
+            build/capsules/demo/widget/ir/*.ll) found_rel=1 ;;
+        esac
+    done < <(jq -r '.deps.ll_paths[]' "$report")
+    [ "$missing" -eq 0 ] && [ "$found_dep" -eq 1 ] && [ "$found_rel" -eq 1 ]
+}
+run_test "build report dep_ll_paths covers both dep + relative tree" test_report_paths_canonical
+
+# ---- Test 7: sidecar dep_ll_paths reflects per-capsule tree ----
+test_sidecar_paths_canonical() {
+    [ -f "$SIDECAR" ] || return 1
+    local found_dep=0 found_rel=0 missing=0
+    while IFS= read -r path; do
+        [ -z "$path" ] && continue
+        if [ ! -f "$SCRATCH/$path" ]; then
+            echo "[test]   missing sidecar dep .ll: $path" >&2
+            missing=1
+        fi
+        case "$path" in
+            build/capsules/sfn/math/ir/*.ll) found_dep=1 ;;
+            build/capsules/demo/widget/ir/*.ll) found_rel=1 ;;
+        esac
+    done < <(jq -r '.deps.ll_paths[]' "$SIDECAR")
+    [ "$missing" -eq 0 ] && [ "$found_dep" -eq 1 ] && [ "$found_rel" -eq 1 ]
+}
+run_test "sidecar dep_ll_paths covers both dep + relative tree" test_sidecar_paths_canonical
+
+# ---- Summary ----
+echo ""
+echo "[test] $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/compiler/tests/unit/capsule_artifact_test.sfn
+++ b/compiler/tests/unit/capsule_artifact_test.sfn
@@ -8,14 +8,19 @@
 // unit tests lock the per-field invariants — the e2e exercises
 // the full pipeline.
 import {
+    CapsuleArtifactLayout,
     CapsuleArtifactManifest,
     capsule_artifact_bin_path,
     capsule_artifact_dir,
+    capsule_artifact_ir_dir,
+    capsule_artifact_layout_from_specs,
     capsule_artifact_manifest_path,
     capsule_artifact_manifest_to_json,
     capsule_artifact_obj_path,
     capsule_default_bin_name,
+    empty_capsule_artifact_layout,
     empty_capsule_artifact_manifest,
+    ir_path_for_slug,
     is_safe_scope_name,
     parse_scope_name,
     ScopeName
@@ -156,6 +161,143 @@ test "capsule_default_bin_name: trailing slash returns empty" {
 
 test "capsule_artifact_manifest_path: composes <dir>/manifest.json" {
     assert capsule_artifact_manifest_path("sfn", "math") == "build/capsules/sfn/math/manifest.json";
+}
+
+test "capsule_artifact_ir_dir: composes <dir>/ir" {
+    assert capsule_artifact_ir_dir("sfn", "math") == "build/capsules/sfn/math/ir";
+}
+
+// --------------------------------------------------------------
+// Stage C2b2 layout: capsule_artifact_layout_from_specs
+// --------------------------------------------------------------
+test "layout_from_specs: empty inputs produce empty layout" {
+    let empty: string[] = [];
+    let layout = capsule_artifact_layout_from_specs(empty, "", "");
+    assert layout.consumer_scope == "";
+    assert layout.consumer_name == "";
+    assert layout.dep_scopes.length == 0;
+    assert layout.dep_names.length == 0;
+}
+
+test "layout_from_specs: scoped specs split into parallel arrays" {
+    let specs = ["sfn/math", "sfn/http"];
+    let layout = capsule_artifact_layout_from_specs(specs, "demo", "widget");
+    assert layout.consumer_scope == "demo";
+    assert layout.consumer_name == "widget";
+    assert layout.dep_scopes.length == 2;
+    assert layout.dep_names.length == 2;
+    assert layout.dep_scopes[0] == "sfn";
+    assert layout.dep_names[0] == "math";
+    assert layout.dep_scopes[1] == "sfn";
+    assert layout.dep_names[1] == "http";
+}
+
+test "layout_from_specs: dedupes identical (scope, name) pairs" {
+    // The same dep can appear twice in the source list (e.g. once
+    // from the manifest, once from a workspace-implicit walk).
+    // The layout collapses them so the routing loop checks each
+    // prefix at most once.
+    let specs = ["sfn/math", "sfn/math", "sfn/http"];
+    let layout = capsule_artifact_layout_from_specs(specs, "", "");
+    assert layout.dep_scopes.length == 2;
+    assert layout.dep_names.length == 2;
+}
+
+test "layout_from_specs: empty/non-scoped specs are skipped" {
+    // Relative-import sources have empty `spec`; bare specs without
+    // a slash (rare, but possible if a manifest is malformed) get
+    // dropped because they aren't routable.
+    let specs = ["", "sfn/math", "noslash"];
+    let layout = capsule_artifact_layout_from_specs(specs, "", "");
+    assert layout.dep_scopes.length == 1;
+    assert layout.dep_scopes[0] == "sfn";
+    assert layout.dep_names[0] == "math";
+}
+
+test "layout_from_specs: unsafe scope/name filtered out" {
+    // A spec like `../etc/oops` would parse_scope_name to
+    // ("..", "etc/oops"); is_safe_scope_name rejects it. The
+    // routing layer must never see an unsafe pair.
+    let specs = ["../etc/oops", "sfn/math"];
+    let layout = capsule_artifact_layout_from_specs(specs, "", "");
+    assert layout.dep_scopes.length == 1;
+    assert layout.dep_scopes[0] == "sfn";
+    assert layout.dep_names[0] == "math";
+}
+
+// --------------------------------------------------------------
+// Stage C2b2 layout: ir_path_for_slug
+// --------------------------------------------------------------
+test "ir_path_for_slug: dep-prefix routes under the dep tree" {
+    let layout = capsule_artifact_layout_from_specs(["sfn/math"], "demo", "widget");
+    assert ir_path_for_slug(layout, "sfn/math/mod") == "build/capsules/sfn/math/ir/mod.ll";
+}
+
+test "ir_path_for_slug: dep submodule keeps slug subdirs" {
+    let layout = capsule_artifact_layout_from_specs(["sfn/http"], "demo", "widget");
+    assert ir_path_for_slug(layout, "sfn/http/internal/buffer") == "build/capsules/sfn/http/ir/internal/buffer.ll";
+}
+
+test "ir_path_for_slug: relative slug routes under consumer tree" {
+    let layout = capsule_artifact_layout_from_specs([], "demo", "widget");
+    assert ir_path_for_slug(layout, "util/helpers") == "build/capsules/demo/widget/ir/util/helpers.ll";
+}
+
+test "ir_path_for_slug: empty consumer + no dep match returns empty (legacy)" {
+    let layout = empty_capsule_artifact_layout();
+    assert ir_path_for_slug(layout, "anything") == "";
+}
+
+test "ir_path_for_slug: unsafe consumer scope falls through to legacy" {
+    let mut layout = empty_capsule_artifact_layout();
+    layout.consumer_scope = "..";
+    layout.consumer_name = "widget";
+    assert ir_path_for_slug(layout, "util") == "";
+}
+
+test "ir_path_for_slug: slug with .. segment rejected" {
+    let layout = capsule_artifact_layout_from_specs([], "demo", "widget");
+    assert ir_path_for_slug(layout, "../escape") == "";
+    assert ir_path_for_slug(layout, "good/../bad") == "";
+}
+
+test "ir_path_for_slug: slug with backslash rejected" {
+    let layout = capsule_artifact_layout_from_specs([], "demo", "widget");
+    assert ir_path_for_slug(layout, "win\\path") == "";
+}
+
+test "ir_path_for_slug: slug with leading slash rejected" {
+    let layout = capsule_artifact_layout_from_specs([], "demo", "widget");
+    assert ir_path_for_slug(layout, "/abs/path") == "";
+}
+
+test "ir_path_for_slug: empty slug returns empty" {
+    let layout = capsule_artifact_layout_from_specs([], "demo", "widget");
+    assert ir_path_for_slug(layout, "") == "";
+}
+
+test "ir_path_for_slug: slug equal to dep prefix without tail falls through to consumer" {
+    // A slug of exactly "sfn/math" (no trailing /<something>) does
+    // NOT match the `<scope>/<name>/<rest>` rule (it's missing the
+    // tail), so it falls through to the consumer rule. In practice
+    // capsule slugs always include a module name, so this case is
+    // theoretical — but the validator's behavior is locked here.
+    let layout = capsule_artifact_layout_from_specs(["sfn/math"], "demo", "widget");
+    assert ir_path_for_slug(layout, "sfn/math") == "build/capsules/demo/widget/ir/sfn/math.ll";
+}
+
+test "ir_path_for_slug: dep-prefix wins over consumer fallback" {
+    let layout = capsule_artifact_layout_from_specs(["sfn/math"], "demo", "widget");
+    // A slug that could be either a dep submodule OR something
+    // under the consumer tree must pick the dep route.
+    assert ir_path_for_slug(layout, "sfn/math/util") == "build/capsules/sfn/math/ir/util.ll";
+}
+
+test "ir_path_for_slug: single-segment consumer name accepted" {
+    // `is_safe_scope_name` accepts ("demo", "widget"). The
+    // sub-segment-only check applies to the name parts.
+    let layout = capsule_artifact_layout_from_specs([], "demo", "widget");
+    assert ir_path_for_slug(layout, "main") == "build/capsules/demo/widget/ir/main.ll";
 }
 
 // --------------------------------------------------------------

--- a/docs/proposals/build-architecture.md
+++ b/docs/proposals/build-architecture.md
@@ -4,7 +4,7 @@ Status: Stages A and B fully shipped. **Stage C cache milestone shipped (PR1–1
 Date: 2026-04-17 (drafted) · 2026-04-25 (status refreshed) · 2026-04-25 (Stage B PR1 landed) · 2026-04-25 (PR2/A1 typecheck hookup landed) · 2026-04-25 (PR2/A2 resolver wiring landed) · 2026-04-26 (PR2 `sfn test` migration + A4 deletion landed) · 2026-04-28 (PR3 `llvm-objcopy --weaken` retired via path-norm fix; libextract decoupled) · 2026-04-28 (Stage C cache milestone PR1–1f shipped)
 Authors: Core Team
 
-## Implementation Status (as of 2026-04-28, Stage C cache + per-capsule artifact layout milestones shipped through C2b2)
+## Implementation Status (as of 2026-04-28, Stage C cache milestone shipped + per-capsule artifact layout shipped through C2b1; C2b2 in flight)
 
 **Stage A — shipped.** Manifest schema, `workspace.toml`,
 `capsules/sfn/prelude/capsule.toml`, and `[build].kind = "binary"` on the

--- a/docs/proposals/build-architecture.md
+++ b/docs/proposals/build-architecture.md
@@ -4,7 +4,7 @@ Status: Stages A and B fully shipped. **Stage C cache milestone shipped (PR1–1
 Date: 2026-04-17 (drafted) · 2026-04-25 (status refreshed) · 2026-04-25 (Stage B PR1 landed) · 2026-04-25 (PR2/A1 typecheck hookup landed) · 2026-04-25 (PR2/A2 resolver wiring landed) · 2026-04-26 (PR2 `sfn test` migration + A4 deletion landed) · 2026-04-28 (PR3 `llvm-objcopy --weaken` retired via path-norm fix; libextract decoupled) · 2026-04-28 (Stage C cache milestone PR1–1f shipped)
 Authors: Core Team
 
-## Implementation Status (as of 2026-04-28, Stage C cache milestone shipped)
+## Implementation Status (as of 2026-04-28, Stage C cache + per-capsule artifact layout milestones shipped through C2b2)
 
 **Stage A — shipped.** Manifest schema, `workspace.toml`,
 `capsules/sfn/prelude/capsule.toml`, and `[build].kind = "binary"` on the
@@ -1321,15 +1321,42 @@ The cache-aside Stage C exit criteria from the original plan (every
 stdlib capsule builds with `sfn build -p`, byte-for-byte parity
 with `build.sh`, CI cache-hit floor) still stand and break down as:
 
-- **C2 — Standard artifact layout** (next). Move `sfn build`'s
+- **C2 — Standard artifact layout** (in flight). Move `sfn build`'s
   outputs into the per-capsule tree from §4.4
   (`build/capsules/<scope>/<name>/{manifest.json, ir/, obj/, bin/}`).
-  The shipped cache already materializes much of the same artifact
-  set (IR / obj / etc.), but it is content-addressed under
-  `build/cache/v1/<shard>/<key>/...` rather than per-capsule; the
-  in-tree build tree does not yet follow the standardized
-  per-capsule layout. Unblocks C4 (`sfn package` knows what's in
-  a capsule).
+  Broken into four sub-PRs by risk:
+    - **C2a — sidecar schema** (shipped, #261). Per-capsule
+      `manifest.json` written after `sfn build -p`. Locks the
+      schema downstream consumers (`sfn package`, `sfn lsp`,
+      MCP) consume. Path-traversal hardening via
+      `is_safe_scope_name`.
+    - **C2b1 — binary / library out_path** (shipped, #262).
+      `sfn build -p` (no `-o`) defaults library outputs to
+      `<dir>/obj/mod.o` and binary outputs to
+      `<dir>/bin/<bin-name>`. User-provided `-o` still wins.
+      Unsafe-scope `[capsule].name` falls back to legacy
+      `build/sailfin/program{,.o}`.
+    - **C2b2 — dep `.ll` migration** (in flight). Manifest-
+      declared dep sources land at
+      `build/capsules/<dep-scope>/<dep-name>/ir/<rel>.ll`;
+      intra-capsule (relative-import) sources of a `-p`
+      consumer land under the consumer's own `ir/` tree.
+      Centralised in `capsule_artifact.sfn::ir_path_for_slug`
+      + `capsule_resolver.sfn::ResolverConsumer`. Two-pass
+      resolution: source collectors emit `ll_path = ""` and
+      `_cr_resolve_and_dedupe` fills in the resolved path
+      from the per-build layout. `BuildReport.dep_ll_paths`
+      and the sidecar's `deps.ll_paths` reflect the new
+      paths; `schema_version` stays at `"1"` (string-array-
+      of-paths shape unchanged — same precedent C2b1 set
+      for `out_path`).
+    - **C2c — per-module sidecar entries** (next). Add a
+      `modules: [{slug, ir_path, obj_path, cache_key}]`
+      array to the sidecar so `sfn package` can enumerate
+      per-source artifacts without re-walking the build
+      tree. Builds on C2b2 — slug → `ir_path` mapping is
+      already centralised.
+  Unblocks C4 (`sfn package` knows what's in a capsule).
 - **C3 — CI gate on stdlib.** Build every `capsules/sfn/*` with
   `sfn build -p` in CI and assert byte-for-byte parity vs `build.sh`
   + a cache-hit-rate floor on no-source-change reruns. Likely a

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,6 +1,6 @@
 # Status
 
-Updated: April 28, 2026 (Stage C cache milestone shipped — PR1–1f / #254–#259)
+Updated: April 28, 2026 (Stage C cache milestone + per-capsule layout milestones shipped — PR1–1f / #254–#259, C2a / #261, C2b1 / #262, C2b2 in flight)
 
 This document tracks what works today and what is in progress. It is the source
 of truth — consult it before editing docs, examples, or making claims about
@@ -113,6 +113,41 @@ feature availability.
     MCP server's structured compile feedback, CI cache-hit-rate
     gates, and future structured link errors (proposal §4.11 —
     the `diagnostics: []` slot is the forward-compat hook).
+- **Stage C2 per-capsule artifact layout (in flight, 2026-04-28).**
+  Three PRs land the §4.4 layout (`build/capsules/<scope>/<name>/`)
+  for everything `sfn build -p` produces:
+  - **C2a (#261)** — per-capsule manifest sidecar.
+    `compiler/src/capsule_artifact.sfn` defines
+    `CapsuleArtifactManifest` and the `schema_version: "1"`
+    JSON shape; after a successful `sfn build -p` the resolver
+    writes `build/capsules/<scope>/<name>/manifest.json`.
+    Path-traversal hardening via `is_safe_scope_name` rejects
+    malicious `[capsule].name = "../../etc"`. Locked by
+    `compiler/tests/e2e/test_capsule_artifact_sidecar.sh`.
+  - **C2b1 (#262)** — `-p` build outputs default to the
+    canonical per-capsule paths: library obj at
+    `build/capsules/<scope>/<name>/obj/mod.o`, binary at
+    `build/capsules/<scope>/<name>/bin/<bin-name>`. Positional
+    builds and explicit `-o` keep their existing locations.
+  - **C2b2 (this PR)** — dep `.ll` files migrate from the flat
+    `build/sailfin/capsules/<mangled>.ll` layout into the
+    per-capsule tree. Manifest-declared dep sources land at
+    `build/capsules/<dep-scope>/<dep-name>/ir/<rel>.ll`;
+    intra-capsule (relative-import) sources of a `-p`
+    consumer with safe scope/name land under the consumer's
+    own `ir/` tree. Positional builds and the compiler
+    self-host (`[capsule].name = "sailfin"` is single-segment)
+    keep the legacy fallback automatically. Centralised in
+    `capsule_artifact.sfn::ir_path_for_slug` + the resolver's
+    new `ResolverConsumer`. `BuildReport.dep_ll_paths` and the
+    sidecar's `deps.ll_paths` reflect the new path strings;
+    `schema_version` stays at "1" (string-array-of-paths shape
+    is unchanged — only path content drifted, same precedent
+    C2b1 set for `out_path`). Locked by new
+    `test_capsule_ir_layout.sh` and hardened
+    `test_build_json_schema.sh` /
+    `test_capsule_artifact_sidecar.sh` `dep_ll_paths`
+    file-exists assertions.
 - `make compile` builds the compiler from a released seed. `make check`
   validates the seedcheck binary can run `hello-world.sfn` and pass the test suite.
 - **Deterministic self-hosting**: the compiler is a verified fixed point —


### PR DESCRIPTION
## Summary

Stage C2b2 of the unified build architecture — migrates per-module `.ll` outputs from the flat `build/sailfin/capsules/<mangled>.ll` layout into the per-capsule tree from §4.4 of `docs/proposals/build-architecture.md`.

| Source kind | New location | When |
|---|---|---|
| Manifest dep / workspace-implicit | `build/capsules/<dep-scope>/<dep-name>/ir/<rel>.ll` | always |
| Intra-capsule (relative import) | `build/capsules/<consumer-scope>/<consumer-name>/ir/<rel>.ll` | `sfn build -p <consumer>` with safe-scope `[capsule].name` |
| Anything else (positional / single-segment name / unsafe scope) | `build/sailfin/capsules/<mangled>.ll` (legacy) | fallback |

The compiler self-host (`[capsule].name = "sailfin"`, single-segment) keeps the legacy fallback automatically — `make compile` is unaffected.

### Design

- New `capsule_artifact.sfn::CapsuleArtifactLayout` + pure helpers `capsule_artifact_layout_from_specs`, `ir_path_for_slug`, `capsule_artifact_ir_dir`.
- New `capsule_resolver.sfn::ResolverConsumer { scope, name }` threaded through `prepare_project_capsules{,_for_check,_for_test}` (3rd parameter).
- Two `CapsuleSource.ll_path` construction sites in the resolver now emit `""`; `_cr_resolve_and_dedupe` performs a single post-dedupe layout pass that fills in the resolved path.
- For intra-capsule slugs (path-shaped from `module_name_from_path` for files outside `compiler/src/`/`runtime/`), the dedupe pass strips the discovered `project_root` prefix before routing so the tail mirrors source layout (`src/util` → `<consumer>/ir/src/util.ll`). The original slug stays on `CapsuleSource.slug` for cache keying, symbol mangling, and `.sfn-asm` staging.
- `BuildReport.dep_ll_paths` and the sidecar's `deps.ll_paths` reflect the new strings; **`schema_version` stays at `"1"`** — field shape unchanged, only path content drifted (same precedent C2b1 set for `out_path`).

### Tests

| Suite | Result |
|---|---|
| `make test-unit` | **78/78 passed** (18 new for layout helpers + traversal guards) |
| `make test-integration` | **17/17 passed** |
| `make test-e2e` | **19/19 passed** (incl. new `test_capsule_ir_layout.sh`) |
| `make compile` (self-host) | **green @ 158s** |
| `sfn fmt --check` | **clean** on all 7 touched files |

New `compiler/tests/e2e/test_capsule_ir_layout.sh` covers a `demo/widget` library that imports `sfn/math` (manifest dep) AND a relative `./util` (intra-capsule), locking both routing rules + the absence of double-emission to legacy paths + the sidecar/build-report `dep_ll_paths` shape.

Existing e2e hardened with file-exists assertions on every `dep_ll_paths` entry (`test_build_json_schema.sh`, `test_capsule_artifact_sidecar.sh`) and an explicit dep-tree-prefix check in the sidecar test.

## Test plan

- [x] `make compile` — self-host passes
- [x] `make test-unit` — 78/78 (incl. new layout helpers)
- [x] `make test-integration` — 17/17
- [x] `make test-e2e` — 19/19 (incl. new `test_capsule_ir_layout.sh`)
- [x] `sfn fmt --check` clean on all touched `.sfn` files
- [ ] Cloudflare Pages preview renders updated `docs/status.md` and `docs/proposals/build-architecture.md`

Closes part of Stage C2; follow-ups: **C2c** (per-module sidecar entries — slug → ir_path mapping is already centralised) and **C4** (`sfn package` — sidecar + per-capsule tree are now both stable enough to consume).

https://claude.ai/code/session_01Wtm6pciPANUjuJ4qS2LB2a

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wtm6pciPANUjuJ4qS2LB2a)_