### PR TITLE
Stage C2c: per-module entries in the per-capsule sidecar

### DIFF
--- a/compiler/src/capsule_artifact.sfn
+++ b/compiler/src/capsule_artifact.sfn
@@ -40,26 +40,37 @@ import { substring } from "./string_utils";
 //   "kind": "library",                  // "binary" | "library"
 //   "compiler_version": "0.5.10-alpha.2+dev.<hash>",
 //   "entry": "src/mod.sfn",              // relative to capsule.toml's dir
-//   "out": "build/sailfin/program.o",    // current ad-hoc location;
-//                                        //   migrates to <scope>/<name>/bin
-//                                        //   or <scope>/<name>/obj in C2b
+//   "out": "build/capsules/sfn/math/obj/mod.o",
 //   "deps": {
 //     "count": 1,
 //     "ll_paths": ["build/capsules/sfn/runtime/ir/mod.ll"]
-//   }
+//   },
+//   "modules": [
+//     {
+//       "slug": "sfn/runtime/mod",
+//       "ir_path": "build/capsules/sfn/runtime/ir/mod.ll",
+//       "cache_key": "ab12...e7"   // sha256 hex, "" if caching disabled
+//     }
+//   ]
 // }
 //
 // schema_version is intentionally still "1" after the C2b2 dep `.ll`
-// path migration. The `deps.ll_paths` JSON field (serialized from
-// the internal `CapsuleArtifactManifest.dep_ll_paths` struct field)
-// describes a list of paths to dep `.ll` files; the path strings
-// drifted from the legacy `build/sailfin/capsules/<mangled>.ll`
-// form to the per-capsule `build/capsules/<scope>/<name>/ir/<rel>.ll`
-// tree, but the field shape (string array of file paths) is
-// unchanged. Same precedent as C2b1, where `out_path` migrated from
-// `build/sailfin/program{,.o}` to
-// `build/capsules/<scope>/<name>/{obj/mod.o, bin/<name>}` without a
-// schema bump. A *shape* change (entries become objects, etc.)
+// path migration AND the C2c per-module entries addition. The
+// `deps.ll_paths` JSON field (serialized from the internal
+// `CapsuleArtifactManifest.dep_ll_paths` struct field) describes a
+// list of paths to dep `.ll` files; the path strings drifted from
+// the legacy `build/sailfin/capsules/<mangled>.ll` form to the
+// per-capsule `build/capsules/<scope>/<name>/ir/<rel>.ll` tree, but
+// the field shape (string array of file paths) is unchanged.
+//
+// `modules` is an additive C2c array. Existing v1 consumers that
+// only read previously-defined fields (`capsule`, `version`,
+// `kind`, `compiler_version`, `entry`, `out`, `deps`) ignore it
+// and keep working. New consumers (`sfn package` C4, `sfn lsp`
+// capsule discovery, MCP) can enumerate per-module artifacts
+// without re-walking the build tree. Same precedent as C2b1,
+// where `out_path` migrated without a schema bump. A *shape*
+// change to an existing field (entries become objects, etc.)
 // would be a v2.
 struct ScopeName {
     scope: string;
@@ -74,10 +85,54 @@ struct CapsuleArtifactManifest {
     entry_relative: string;
     out_path: string;
     dep_ll_paths: string[];
+    // Stage C2c: per-module artifact entries. Each module the
+    // resolver compiled (manifest deps + workspace-implicit deps
+    // + relative imports) appears here with its slug, lowered
+    // `.ll` path, and the cache key used to look it up. Empty
+    // when no deps were compiled. Additive at schema_version
+    // "1" — consumers that only read `dep_ll_paths` keep
+    // working unchanged.
+    modules: CapsuleArtifactModule[];
+}
+
+// One per-source artifact entry (Stage C2c). Mirrors the JSON
+// shape `{ "slug": "<scope>/<name>/<rel>", "ir_path": "<...>.ll",
+// "cache_key": "<sha256-hex>" | "" }`.
+//
+// `slug` is the resolver's stable identifier for the module
+// (matches `CapsuleSource.slug`); used for symbol mangling and
+// identifies the module independently of file-system path.
+//
+// `ir_path` is where the module's `.ll` lives on disk. Same
+// content as the corresponding entry in `dep_ll_paths`; locked
+// here per-module so consumers (`sfn package`, `sfn lsp`, MCP)
+// can iterate `modules` and find each module's IR without a
+// parallel-array lookup against `dep_ll_paths`.
+//
+// `cache_key` is the `CacheKey.digest` (sha256 hex) used for
+// the module's cache lookup. Empty when caching is disabled
+// (`--no-cache`) or the digest was rejected by `is_valid_digest`.
+// Empty does NOT mean "no cache activity" — `--no-cache` builds
+// produce empty digests on every entry, while a build with one
+// invalid-key module produces an empty digest only on that
+// module. Consumers that need to distinguish should consult the
+// `cache` field on the build report (`CacheStats`) or their
+// own per-module accounting.
+//
+// Future fields (post-C2c, when per-module compile-then-link
+// lands): `obj_path` (per-module `.o` location). Skipped today
+// because the build only produces a single `mod.o` per capsule
+// (libraries) or no per-capsule object (binaries link the .ll
+// set directly).
+struct CapsuleArtifactModule {
+    slug: string;
+    ir_path: string;
+    cache_key: string;
 }
 
 fn empty_capsule_artifact_manifest() -> CapsuleArtifactManifest {
     let empty: string[] = [];
+    let empty_modules: CapsuleArtifactModule[] = [];
     return CapsuleArtifactManifest {
         capsule_name: "",
         version: "",
@@ -85,7 +140,16 @@ fn empty_capsule_artifact_manifest() -> CapsuleArtifactManifest {
         compiler_version: "",
         entry_relative: "",
         out_path: "",
-        dep_ll_paths: empty
+        dep_ll_paths: empty,
+        modules: empty_modules
+    };
+}
+
+fn make_capsule_artifact_module(slug: string, ir_path: string, cache_key: string) -> CapsuleArtifactModule {
+    return CapsuleArtifactModule {
+        slug: slug,
+        ir_path: ir_path,
+        cache_key: cache_key
     };
 }
 
@@ -511,6 +575,30 @@ fn _ca_json_deps_object(ll_paths: string[]) -> string {
         + "}";
 }
 
+// One per-module entry under `modules: [...]`. Fields locked to
+// `slug`, `ir_path`, `cache_key` (Stage C2c). Field order is
+// stable so the encoded form is byte-deterministic across runs
+// for any given input.
+fn _ca_json_module_entry(m: CapsuleArtifactModule) -> string {
+    return "{" + _ca_json_string_field("slug", m.slug) + ","
+        + _ca_json_string_field("ir_path", m.ir_path)
+        + ","
+        + _ca_json_string_field("cache_key", m.cache_key)
+        + "}";
+}
+
+fn _ca_json_modules_array(modules: CapsuleArtifactModule[]) -> string {
+    let mut out: string = "[";
+    let mut i: number = 0;
+    loop {
+        if i >= modules.length { break; }
+        if i > 0 { out = out + ","; }
+        out = out + _ca_json_module_entry(modules[i]);
+        i += 1;
+    }
+    return out + "]";
+}
+
 // -------------------------------------------------------------------
 // Public encoder
 // -------------------------------------------------------------------
@@ -529,12 +617,15 @@ fn capsule_artifact_manifest_to_json(m: CapsuleArtifactManifest) -> string {
         + _ca_json_string_field("out", m.out_path)
         + ","
         + _ca_json_field("deps", _ca_json_deps_object(m.dep_ll_paths))
+        + ","
+        + _ca_json_field("modules", _ca_json_modules_array(m.modules))
         + "}";
 }
 
 export {
     CapsuleArtifactLayout,
     CapsuleArtifactManifest,
+    CapsuleArtifactModule,
     ScopeName,
     capsule_artifact_bin_path,
     capsule_artifact_dir,
@@ -548,5 +639,6 @@ export {
     empty_capsule_artifact_manifest,
     ir_path_for_slug,
     is_safe_scope_name,
+    make_capsule_artifact_module,
     parse_scope_name
 };

--- a/compiler/src/capsule_resolver.sfn
+++ b/compiler/src/capsule_resolver.sfn
@@ -73,6 +73,7 @@ export {
     CapsuleSource,
     CheckCapsuleResolution,
     CompileCapsuleResult,
+    ModuleCacheEvent,
     ProjectCapsuleResult,
     ResolverConsumer,
     TestCapsuleResolution,
@@ -140,19 +141,33 @@ fn empty_resolver_consumer() -> ResolverConsumer {
 // cache stats accumulated across all per-module compiles. `success`
 // distinguishes "no deps" (empty `ll_paths`, success=true) from a
 // compile failure (empty `ll_paths`, success=false).
+//
+// Stage C2c: `module_events` is a parallel array (length matches
+// `ll_paths`) holding the per-module `ModuleCacheEvent` returned
+// by `_cr_compile_one`. The sidecar emitter consumes `slug` +
+// `cache_key_digest` from each event to enumerate per-source
+// artifacts in `manifest.json`. `stats` remains the totals
+// summary; `module_events` is the per-source detail.
 struct CompileCapsuleResult {
     ll_paths: string[];
     stats: CacheStats;
     success: boolean;
+    module_events: ModuleCacheEvent[];
 }
 
 // Result of `prepare_project_capsules` (the build / run path).
 // `ll_paths` is the dep `.ll` list for the linker; `stats` is the
 // per-build cache summary the CLI prints at the end (and that
 // `--json` will eventually emit as a structured field).
+//
+// Stage C2c: `module_events` is forwarded from
+// `CompileCapsuleResult` so the CLI's sidecar emitter has the
+// per-module slug + cache_key_digest without re-running the
+// compile loop.
 struct ProjectCapsuleResult {
     ll_paths: string[];
     stats: CacheStats;
+    module_events: ModuleCacheEvent[];
 }
 
 // One entry from the workspace's [workspace].members list, with the
@@ -811,16 +826,27 @@ struct ModuleCacheEvent {
     stored: boolean;  // miss path stored a fresh artifact
     invalid_key: boolean;  // is_valid_digest rejected the digest
     copy_failed: boolean;  // cache had it; cp to dst failed
+    // Stage C2c: per-module identity threaded back to the
+    // sidecar emitter so `manifest.json` can list every module
+    // the build produced. `slug` matches `CapsuleSource.slug`
+    // (stable, used for symbol mangling). `cache_key_digest` is
+    // the sha256 hex string from `CacheKey.digest`, or `""`
+    // when caching was disabled (`config.enabled = false`) or
+    // the digest was rejected by `is_valid_digest`.
+    slug: string;
+    cache_key_digest: string;
 }
 
-fn _cr_module_cache_event_failure() -> ModuleCacheEvent {
+fn _cr_module_cache_event_failure(slug: string) -> ModuleCacheEvent {
     return ModuleCacheEvent {
         success: false,
         lookup_attempted: false,
         hit: false,
         stored: false,
         invalid_key: false,
-        copy_failed: false
+        copy_failed: false,
+        slug: slug,
+        cache_key_digest: ""
     };
 }
 
@@ -835,7 +861,7 @@ fn _cr_module_cache_event_failure() -> ModuleCacheEvent {
 fn _cr_compile_one(src: CapsuleSource, dep_manifests: string[], cache_root_path: string, config: BuildCacheConfig, compiler_version: string, flags_canonical: string) -> ModuleCacheEvent ![io] {
     if !fs.exists(src.source_path) {
         print.err("capsule-resolver: missing source file: " + src.source_path);
-        return _cr_module_cache_event_failure();
+        return _cr_module_cache_event_failure(src.slug);
     }
     let ll_dir = _cr_dirname(src.ll_path);
     _cr_ensure_dir(ll_dir);
@@ -858,7 +884,9 @@ fn _cr_compile_one(src: CapsuleSource, dep_manifests: string[], cache_root_path:
                     hit: true,
                     stored: false,
                     invalid_key: false,
-                    copy_failed: false
+                    copy_failed: false,
+                    slug: src.slug,
+                    cache_key_digest: cache_key.digest
                 };
             }
             // Cache had the entry but materialisation failed (e.g.
@@ -879,7 +907,7 @@ fn _cr_compile_one(src: CapsuleSource, dep_manifests: string[], cache_root_path:
     if !ok {
         print.err("capsule-resolver: failed to lower " + src.slug
             + " to LLVM IR");
-        return _cr_module_cache_event_failure();
+        return _cr_module_cache_event_failure(src.slug);
     }
 
     let mut stored: boolean = false;
@@ -911,7 +939,9 @@ fn _cr_compile_one(src: CapsuleSource, dep_manifests: string[], cache_root_path:
         hit: false,
         stored: stored,
         invalid_key: invalid_key,
-        copy_failed: copy_failed
+        copy_failed: copy_failed,
+        slug: src.slug,
+        cache_key_digest: cache_key.digest
     };
 }
 
@@ -973,15 +1003,23 @@ fn compile_capsule_modules(sources: CapsuleSource[], config: BuildCacheConfig) -
     let flags_canonical = canonicalize_flags(empty_flags);
     let mut out: string[] = [];
     let mut stats = empty_cache_stats();
+    let mut events: ModuleCacheEvent[] = [];
     let mut i: number = 0;
     loop {
         if i >= sources.length { break; }
         let evt = _cr_compile_one(sources[i], per_source_dep_manifests[i], cache_root_path, config, compiler_version, flags_canonical);
         if !evt.success {
+            // Stage C2c: even on the bail path we surface the
+            // events accumulated so far. Sidecar emission is
+            // gated upstream by `success = true`, so this is
+            // primarily for diagnostic introspection — but the
+            // shape stays consistent across exit paths.
+            events.push(evt);
             return CompileCapsuleResult {
                 ll_paths: out,
                 stats: stats,
-                success: false
+                success: false,
+                module_events: events
             };
         }
         // Only count hits/misses when the cache was actually
@@ -1000,12 +1038,14 @@ fn compile_capsule_modules(sources: CapsuleSource[], config: BuildCacheConfig) -
             stats.copy_failures = stats.copy_failures + 1;
         }
         out.push(sources[i].ll_path);
+        events.push(evt);
         i += 1;
     }
     return CompileCapsuleResult {
         ll_paths: out,
         stats: stats,
-        success: true
+        success: true,
+        module_events: events
     };
 }
 
@@ -2218,18 +2258,21 @@ fn _cr_resolve_and_dedupe(entry_paths: string[], consumer: ResolverConsumer) -> 
 // genuinely-empty dep graphs.
 fn prepare_project_capsules(input_path: string, config: BuildCacheConfig, consumer: ResolverConsumer) -> ProjectCapsuleResult ![io] {
     let empty_paths: string[] = [];
+    let empty_events: ModuleCacheEvent[] = [];
     let entry_paths: string[] = [input_path];
     let resolved = _cr_resolve_and_dedupe(entry_paths, consumer);
     if resolved.has_collision {
         return ProjectCapsuleResult {
             ll_paths: empty_paths,
-            stats: empty_cache_stats()
+            stats: empty_cache_stats(),
+            module_events: empty_events
         };
     }
     if resolved.sources.length == 0 {
         return ProjectCapsuleResult {
             ll_paths: empty_paths,
-            stats: empty_cache_stats()
+            stats: empty_cache_stats(),
+            module_events: empty_events
         };
     }
 
@@ -2238,19 +2281,22 @@ fn prepare_project_capsules(input_path: string, config: BuildCacheConfig, consum
         print.err("capsule-resolver: failed to stage import-context for project capsules");
         return ProjectCapsuleResult {
             ll_paths: empty_paths,
-            stats: empty_cache_stats()
+            stats: empty_cache_stats(),
+            module_events: empty_events
         };
     }
     let result = compile_capsule_modules(resolved.sources, config);
     if !result.success {
         return ProjectCapsuleResult {
             ll_paths: empty_paths,
-            stats: result.stats
+            stats: result.stats,
+            module_events: result.module_events
         };
     }
     return ProjectCapsuleResult {
         ll_paths: result.ll_paths,
-        stats: result.stats
+        stats: result.stats,
+        module_events: result.module_events
     };
 }
 

--- a/compiler/src/capsule_resolver.sfn
+++ b/compiler/src/capsule_resolver.sfn
@@ -142,12 +142,20 @@ fn empty_resolver_consumer() -> ResolverConsumer {
 // distinguishes "no deps" (empty `ll_paths`, success=true) from a
 // compile failure (empty `ll_paths`, success=false).
 //
-// Stage C2c: `module_events` is a parallel array (length matches
-// `ll_paths`) holding the per-module `ModuleCacheEvent` returned
-// by `_cr_compile_one`. The sidecar emitter consumes `slug` +
-// `cache_key_digest` from each event to enumerate per-source
-// artifacts in `manifest.json`. `stats` remains the totals
-// summary; `module_events` is the per-source detail.
+// Stage C2c: when `success=true`, `module_events` is a parallel
+// array to `ll_paths` (same length, matching indices) holding
+// the per-module `ModuleCacheEvent` returned by
+// `_cr_compile_one`. When `success=false`, the bail path
+// preserves whichever events were already accumulated AND
+// pushes the failing event, so `module_events.length` may be
+// `ll_paths.length + 1` while `ll_paths` reflects only the
+// modules that finished cleanly. Sidecar emission is gated on
+// `success=true` upstream, so the sidecar never sees the
+// extra entry; the divergence is purely diagnostic. The
+// sidecar emitter consumes `slug` + `cache_key_digest` from
+// each event to enumerate per-source artifacts in
+// `manifest.json`. `stats` remains the totals summary;
+// `module_events` is the per-source detail.
 struct CompileCapsuleResult {
     ll_paths: string[];
     stats: CacheStats;

--- a/compiler/src/cli_main.sfn
+++ b/compiler/src/cli_main.sfn
@@ -11,6 +11,7 @@ import {
 import { BuildReport, build_report_to_json, empty_build_report } from "./build_report";
 import {
     CapsuleArtifactManifest,
+    CapsuleArtifactModule,
     ScopeName,
     capsule_artifact_bin_path,
     capsule_artifact_dir,
@@ -20,9 +21,11 @@ import {
     capsule_default_bin_name,
     empty_capsule_artifact_manifest,
     is_safe_scope_name,
+    make_capsule_artifact_module,
     parse_scope_name
 } from "./capsule_artifact";
 import {
+    ModuleCacheEvent,
     ProjectCapsuleResult,
     ResolverConsumer,
     empty_resolver_consumer,
@@ -189,6 +192,27 @@ fn _emit_capsule_artifact_sidecar(spec_capsule_name: string, spec_version: strin
     manifest.entry_relative = spec_entry_relative;
     manifest.out_path = out_path;
     manifest.dep_ll_paths = capsule_result.ll_paths;
+
+    // Stage C2c: per-module entries. `module_events` is a
+    // parallel array to `ll_paths` (lockstep emission in
+    // `compile_capsule_modules`), so index alignment is safe;
+    // we still defend against mismatch by using the shorter
+    // length. `cache_key_digest` is `""` when caching was
+    // disabled or the digest was rejected — surfaced verbatim
+    // as the JSON `cache_key` field.
+    let mut modules: CapsuleArtifactModule[] = [];
+    let event_count = capsule_result.module_events.length;
+    let path_count = capsule_result.ll_paths.length;
+    let mut limit = event_count;
+    if path_count < limit { limit = path_count; }
+    let mut mi: number = 0;
+    loop {
+        if mi >= limit { break; }
+        let evt = capsule_result.module_events[mi];
+        modules.push(make_capsule_artifact_module(evt.slug, capsule_result.ll_paths[mi], evt.cache_key_digest));
+        mi += 1;
+    }
+    manifest.modules = modules;
 
     let dir = capsule_artifact_dir(parts.scope, parts.name);
     fs.createDirectory(dir, true);

--- a/compiler/tests/e2e/test_capsule_artifact_sidecar.sh
+++ b/compiler/tests/e2e/test_capsule_artifact_sidecar.sh
@@ -184,6 +184,69 @@ test_dep_ll_under_per_capsule_tree() {
 }
 run_test "dep .ll routes under build/capsules/sfn/math/ir/ (Stage C2b2)" test_dep_ll_under_per_capsule_tree
 
+# ---- Test 8d: modules array present + matches deps.count ----
+# Stage C2c: every dep `.ll` the build produced should appear as a
+# `{slug, ir_path, cache_key}` entry under `modules`. The array is
+# the per-source detail companion to the aggregate `deps.ll_paths`.
+test_modules_array_present() {
+    local mods_count
+    mods_count=$(jq -r '.modules | length' "$SIDECAR")
+    [ "$mods_count" -ge 1 ] || return 1
+    # Every entry must have the three locked fields as strings.
+    local malformed
+    malformed=$(jq -r '[.modules[] | select((.slug|type) != "string" or (.ir_path|type) != "string" or (.cache_key|type) != "string")] | length' "$SIDECAR")
+    [ "$malformed" = "0" ]
+}
+run_test "modules array present with locked {slug, ir_path, cache_key} fields" test_modules_array_present
+
+# ---- Test 8e: modules ir_path values exist on disk ----
+# Same hardening as `dep_ll_paths` but on the per-module list:
+# every `ir_path` must point at a real `.ll` file. Catches stale
+# entries that name a path the build never produced.
+test_modules_ir_paths_exist() {
+    local missing=0
+    while IFS= read -r path; do
+        [ -z "$path" ] && continue
+        if [ ! -f "$SCRATCH/$path" ]; then
+            echo "[test]   missing module ir_path: $path" >&2
+            missing=1
+        fi
+        case "$path" in
+            *.ll) ;;
+            *)
+                echo "[test]   module ir_path doesn't end in .ll: $path" >&2
+                missing=1
+                ;;
+        esac
+    done < <(jq -r '.modules[].ir_path' "$SIDECAR")
+    [ "$missing" -eq 0 ]
+}
+run_test "every modules[].ir_path is a real .ll file" test_modules_ir_paths_exist
+
+# ---- Test 8f: modules slug uniqueness ----
+# Slug collisions are detected at resolve time but a regression in
+# event accumulation could produce duplicate entries here. Lock
+# uniqueness so a future change can't silently double-emit.
+test_modules_slugs_unique() {
+    local total uniq
+    total=$(jq -r '.modules | length' "$SIDECAR")
+    uniq=$(jq -r '[.modules[].slug] | unique | length' "$SIDECAR")
+    [ "$total" = "$uniq" ]
+}
+run_test "modules[].slug values are unique" test_modules_slugs_unique
+
+# ---- Test 8g: cache_key is non-empty after a fresh cache build ----
+# The default fixture build runs without `--no-cache`, so each
+# module either hit or stored in the cache. Either way the digest
+# is a valid sha256 hex string (non-empty). `--no-cache` is
+# tested separately below.
+test_modules_cache_keys_populated() {
+    local empties
+    empties=$(jq -r '[.modules[].cache_key | select(. == "")] | length' "$SIDECAR")
+    [ "$empties" = "0" ]
+}
+run_test "modules[].cache_key is non-empty after a default (cached) build" test_modules_cache_keys_populated
+
 # ---- Test 9b: -o EXPLICIT overrides the canonical default ----
 test_explicit_o_wins() {
     cd "$SCRATCH" || return 1

--- a/compiler/tests/e2e/test_capsule_artifact_sidecar.sh
+++ b/compiler/tests/e2e/test_capsule_artifact_sidecar.sh
@@ -187,17 +187,24 @@ run_test "dep .ll routes under build/capsules/sfn/math/ir/ (Stage C2b2)" test_de
 # ---- Test 8d: modules array present + matches deps.count ----
 # Stage C2c: every dep `.ll` the build produced should appear as a
 # `{slug, ir_path, cache_key}` entry under `modules`. The array is
-# the per-source detail companion to the aggregate `deps.ll_paths`.
+# the per-source detail companion to the aggregate `deps.ll_paths`,
+# so `modules.length` must equal `deps.count` (`compile_capsule_modules`
+# accumulates events in lockstep with `ll_paths`).
 test_modules_array_present() {
-    local mods_count
+    local mods_count deps_count
     mods_count=$(jq -r '.modules | length' "$SIDECAR")
+    deps_count=$(jq -r '.deps.count' "$SIDECAR")
     [ "$mods_count" -ge 1 ] || return 1
+    [ "$mods_count" = "$deps_count" ] || {
+        echo "[test]   modules.length ($mods_count) != deps.count ($deps_count)" >&2
+        return 1
+    }
     # Every entry must have the three locked fields as strings.
     local malformed
     malformed=$(jq -r '[.modules[] | select((.slug|type) != "string" or (.ir_path|type) != "string" or (.cache_key|type) != "string")] | length' "$SIDECAR")
     [ "$malformed" = "0" ]
 }
-run_test "modules array present with locked {slug, ir_path, cache_key} fields" test_modules_array_present
+run_test "modules array length equals deps.count + locked {slug, ir_path, cache_key} fields" test_modules_array_present
 
 # ---- Test 8e: modules ir_path values exist on disk ----
 # Same hardening as `dep_ll_paths` but on the per-module list:

--- a/compiler/tests/e2e/test_capsule_ir_layout.sh
+++ b/compiler/tests/e2e/test_capsule_ir_layout.sh
@@ -186,34 +186,85 @@ run_test "sidecar dep_ll_paths covers both dep + relative tree" test_sidecar_pat
 
 # ---- Test 8: modules[] entries cover both routing categories ----
 # Stage C2c: every routed `.ll` should also appear as a per-module
-# entry with matching `slug` and `ir_path`. Locks the
-# `modules` array against the same {dep, relative} routing rules
+# entry with matching `slug` and `ir_path`. Locks the `modules`
+# array against the same {dep, relative} routing rules
 # `deps.ll_paths` already exercises, so future changes to one
-# array can't desync the other.
+# array can't desync the other. Iterates `deps.ll_paths` and
+# asserts each path has exactly one matching modules[] entry
+# whose slug aligns with the routing category.
 test_modules_routing_coverage() {
     [ -f "$SIDECAR" ] || return 1
-    local found_dep=0 found_rel=0
+    local found_dep=0 found_rel=0 missing=0
+    local ir_path match_count slug
     while IFS= read -r ir_path; do
+        [ -z "$ir_path" ] && continue
+        match_count=$(jq -r --arg ir_path "$ir_path" '[.modules[] | select(.ir_path == $ir_path)] | length' "$SIDECAR")
+        if [ "$match_count" -ne 1 ]; then
+            echo "[test]   expected exactly one modules[] entry for ll path: $ir_path (found $match_count)" >&2
+            missing=1
+            continue
+        fi
+        slug=$(jq -r --arg ir_path "$ir_path" '.modules[] | select(.ir_path == $ir_path) | .slug' "$SIDECAR")
         case "$ir_path" in
-            build/capsules/sfn/math/ir/*.ll) found_dep=1 ;;
-            build/capsules/demo/widget/ir/*.ll) found_rel=1 ;;
+            build/capsules/sfn/math/ir/*.ll)
+                found_dep=1
+                case "$slug" in
+                    sfn/math|sfn/math/*) ;;
+                    *)
+                        echo "[test]   dep module slug does not align with ir_path: slug=$slug ir_path=$ir_path" >&2
+                        missing=1
+                        ;;
+                esac
+                ;;
+            build/capsules/demo/widget/ir/*.ll)
+                found_rel=1
+                # Relative-import slugs from `module_name_from_path`
+                # don't carry the `<consumer>/` prefix — they're
+                # the project-relative path-shaped slug (e.g.
+                # `src/util` for `./src/util.sfn`). The C2b2
+                # routing pass strips the project_root from the
+                # slug only at ll_path-derivation time; the
+                # `slug` field preserves the original.
+                #
+                # Locking: slug must be non-empty AND must
+                # equal the suffix of `ir_path` after
+                # `build/capsules/demo/widget/ir/` minus the
+                # `.ll` extension, since that's how the C2b2
+                # routing builds the path.
+                local expected
+                expected="${ir_path#build/capsules/demo/widget/ir/}"
+                expected="${expected%.ll}"
+                if [ "$slug" != "$expected" ]; then
+                    echo "[test]   relative module slug != ir_path tail: slug=$slug expected=$expected ir_path=$ir_path" >&2
+                    missing=1
+                fi
+                ;;
         esac
-    done < <(jq -r '.modules[].ir_path' "$SIDECAR")
-    [ "$found_dep" -eq 1 ] && [ "$found_rel" -eq 1 ]
+    done < <(jq -r '.deps.ll_paths[]' "$SIDECAR")
+    [ "$missing" -eq 0 ] && [ "$found_dep" -eq 1 ] && [ "$found_rel" -eq 1 ]
 }
-run_test "modules[] entries cover dep + relative routing" test_modules_routing_coverage
+run_test "modules[] entries align slug + ir_path for dep + relative routing" test_modules_routing_coverage
 
-# ---- Test 9: modules[] slug for the relative-import points at the consumer ----
-# The relative `./util` source must produce a slug that resolves
-# under the consumer's tree (not the dep's), confirming the C2b2
-# routing decision propagates into the C2c per-module record.
+# ---- Test 9: relative-import modules[] entry has slug + ir_path locked ----
+# The relative `./util` source must produce a `{slug, ir_path}`
+# pair where:
+#   - `ir_path` lives under the consumer's tree (C2b2 routing).
+#   - `slug` matches the project-relative form
+#     `src/util` (the resolver passes the original
+#     pre-prefix-strip slug to the cache and the sidecar; the
+#     consumer prefix is applied only at ll_path-derivation
+#     time). Locks both halves of the C2b2 ↔ C2c split into
+#     the per-module record.
 test_relative_module_slug_under_consumer() {
     [ -f "$SIDECAR" ] || return 1
-    local rel_ir
-    rel_ir=$(jq -r '.modules[] | select(.ir_path | startswith("build/capsules/demo/widget/ir/")) | .ir_path' "$SIDECAR")
-    [ -n "$rel_ir" ]
+    local pair rel_ir rel_slug
+    pair=$(jq -r '.modules[] | select(.ir_path | startswith("build/capsules/demo/widget/ir/")) | [.ir_path, .slug] | @tsv' "$SIDECAR" | head -n 1)
+    [ -n "$pair" ] || return 1
+    IFS=$'\t' read -r rel_ir rel_slug <<< "$pair"
+    [ -n "$rel_ir" ] || return 1
+    [ "$rel_slug" = "src/util" ]
 }
-run_test "modules[] surfaces the consumer-tree relative-import entry" test_relative_module_slug_under_consumer
+run_test "modules[] surfaces relative-import entry with slug=src/util + consumer-tree ir_path" test_relative_module_slug_under_consumer
 
 # ---- Summary ----
 echo ""

--- a/compiler/tests/e2e/test_capsule_ir_layout.sh
+++ b/compiler/tests/e2e/test_capsule_ir_layout.sh
@@ -184,6 +184,37 @@ test_sidecar_paths_canonical() {
 }
 run_test "sidecar dep_ll_paths covers both dep + relative tree" test_sidecar_paths_canonical
 
+# ---- Test 8: modules[] entries cover both routing categories ----
+# Stage C2c: every routed `.ll` should also appear as a per-module
+# entry with matching `slug` and `ir_path`. Locks the
+# `modules` array against the same {dep, relative} routing rules
+# `deps.ll_paths` already exercises, so future changes to one
+# array can't desync the other.
+test_modules_routing_coverage() {
+    [ -f "$SIDECAR" ] || return 1
+    local found_dep=0 found_rel=0
+    while IFS= read -r ir_path; do
+        case "$ir_path" in
+            build/capsules/sfn/math/ir/*.ll) found_dep=1 ;;
+            build/capsules/demo/widget/ir/*.ll) found_rel=1 ;;
+        esac
+    done < <(jq -r '.modules[].ir_path' "$SIDECAR")
+    [ "$found_dep" -eq 1 ] && [ "$found_rel" -eq 1 ]
+}
+run_test "modules[] entries cover dep + relative routing" test_modules_routing_coverage
+
+# ---- Test 9: modules[] slug for the relative-import points at the consumer ----
+# The relative `./util` source must produce a slug that resolves
+# under the consumer's tree (not the dep's), confirming the C2b2
+# routing decision propagates into the C2c per-module record.
+test_relative_module_slug_under_consumer() {
+    [ -f "$SIDECAR" ] || return 1
+    local rel_ir
+    rel_ir=$(jq -r '.modules[] | select(.ir_path | startswith("build/capsules/demo/widget/ir/")) | .ir_path' "$SIDECAR")
+    [ -n "$rel_ir" ]
+}
+run_test "modules[] surfaces the consumer-tree relative-import entry" test_relative_module_slug_under_consumer
+
 # ---- Summary ----
 echo ""
 echo "[test] $PASS passed, $FAIL failed"

--- a/compiler/tests/unit/capsule_artifact_test.sfn
+++ b/compiler/tests/unit/capsule_artifact_test.sfn
@@ -10,6 +10,7 @@
 import {
     CapsuleArtifactLayout,
     CapsuleArtifactManifest,
+    CapsuleArtifactModule,
     capsule_artifact_bin_path,
     capsule_artifact_dir,
     capsule_artifact_ir_dir,
@@ -22,6 +23,7 @@ import {
     empty_capsule_artifact_manifest,
     ir_path_for_slug,
     is_safe_scope_name,
+    make_capsule_artifact_module,
     parse_scope_name,
     ScopeName
 } from "../../src/capsule_artifact";
@@ -367,6 +369,58 @@ test "manifest_to_json: backslash + quote in paths escaped per RFC 8259" {
     m.entry_relative = "src\\with\"quote.sfn";
     let json = capsule_artifact_manifest_to_json(m);
     assert _contains(json, "\"entry\":\"src\\\\with\\\"quote.sfn\"");
+}
+
+// --------------------------------------------------------------
+// Stage C2c: per-module entries
+// --------------------------------------------------------------
+test "empty_capsule_artifact_manifest: modules is empty" {
+    assert empty_capsule_artifact_manifest().modules.length == 0;
+}
+
+test "make_capsule_artifact_module: round-trips slug + ir_path + cache_key" {
+    let m = make_capsule_artifact_module("sfn/math/mod", "build/capsules/sfn/math/ir/mod.ll", "abc123");
+    assert m.slug == "sfn/math/mod";
+    assert m.ir_path == "build/capsules/sfn/math/ir/mod.ll";
+    assert m.cache_key == "abc123";
+}
+
+test "manifest_to_json: empty modules produce []" {
+    // Sidecars from builds with no manifest deps still emit the
+    // `modules` key — locks the field's presence so consumers
+    // can rely on it without conditional checks.
+    let json = capsule_artifact_manifest_to_json(empty_capsule_artifact_manifest());
+    assert _contains(json, "\"modules\":[]");
+}
+
+test "manifest_to_json: single module entry serialises slug + ir_path + cache_key" {
+    let mut m = empty_capsule_artifact_manifest();
+    m.modules = [make_capsule_artifact_module("sfn/math/mod", "build/capsules/sfn/math/ir/mod.ll", "deadbeef")];
+    let json = capsule_artifact_manifest_to_json(m);
+    assert _contains(json, "\"slug\":\"sfn/math/mod\"");
+    assert _contains(json, "\"ir_path\":\"build/capsules/sfn/math/ir/mod.ll\"");
+    assert _contains(json, "\"cache_key\":\"deadbeef\"");
+}
+
+test "manifest_to_json: multiple modules emit each entry" {
+    let mut m = empty_capsule_artifact_manifest();
+    m.modules = [make_capsule_artifact_module("sfn/math/mod", "build/capsules/sfn/math/ir/mod.ll", "k1"), make_capsule_artifact_module("demo/widget/util", "build/capsules/demo/widget/ir/util.ll", "k2")];
+    let json = capsule_artifact_manifest_to_json(m);
+    assert _contains(json, "\"slug\":\"sfn/math/mod\"");
+    assert _contains(json, "\"slug\":\"demo/widget/util\"");
+    assert _contains(json, "\"cache_key\":\"k1\"");
+    assert _contains(json, "\"cache_key\":\"k2\"");
+}
+
+test "manifest_to_json: empty cache_key (no-cache build) round-trips as empty string" {
+    // `--no-cache` builds emit `cache_key: ""` rather than
+    // omitting the field — consumers can rely on the field
+    // always being present and distinguish "cache was off"
+    // from "cache hit" via the value.
+    let mut m = empty_capsule_artifact_manifest();
+    m.modules = [make_capsule_artifact_module("sfn/math/mod", "build/capsules/sfn/math/ir/mod.ll", "")];
+    let json = capsule_artifact_manifest_to_json(m);
+    assert _contains(json, "\"cache_key\":\"\"");
 }
 
 // --------------------------------------------------------------

--- a/docs/proposals/build-architecture.md
+++ b/docs/proposals/build-architecture.md
@@ -1350,12 +1350,23 @@ with `build.sh`, CI cache-hit floor) still stand and break down as:
       paths; `schema_version` stays at `"1"` (string-array-
       of-paths shape unchanged — same precedent C2b1 set
       for `out_path`).
-    - **C2c — per-module sidecar entries** (next). Add a
-      `modules: [{slug, ir_path, obj_path, cache_key}]`
-      array to the sidecar so `sfn package` can enumerate
-      per-source artifacts without re-walking the build
-      tree. Builds on C2b2 — slug → `ir_path` mapping is
-      already centralised.
+    - **C2c — per-module sidecar entries** (in flight). Adds
+      `modules: [{slug, ir_path, cache_key}]` to the sidecar.
+      `slug` matches `CapsuleSource.slug`; `ir_path` is the
+      same string as the corresponding `deps.ll_paths` entry
+      (locked per-module so consumers can iterate `modules`
+      without a parallel-array lookup); `cache_key` is the
+      sha256 hex (`""` when caching is disabled or the digest
+      was rejected). `obj_path` is deferred until per-module
+      compile-then-link lands — today the build only
+      produces a single `mod.o` per library capsule (already
+      surfaced via `out`) or no per-capsule object (binaries
+      link the .ll set directly). Threaded through
+      `ModuleCacheEvent` + `CompileCapsuleResult.module_events`
+      → `ProjectCapsuleResult.module_events` →
+      `_emit_capsule_artifact_sidecar`. Schema stays at
+      "1" — the field is additive, existing v1 consumers
+      that only read previously-defined fields keep working.
   Unblocks C4 (`sfn package` knows what's in a capsule).
 - **C3 — CI gate on stdlib.** Build every `capsules/sfn/*` with
   `sfn build -p` in CI and assert byte-for-byte parity vs `build.sh`

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,6 +1,6 @@
 # Status
 
-Updated: April 28, 2026 (Stage C cache milestone + per-capsule layout milestones shipped — PR1–1f / #254–#259, C2a / #261, C2b1 / #262, C2b2 in flight)
+Updated: April 29, 2026 (Stage C cache milestone + per-capsule layout shipped through C2b2 — PR1–1f / #254–#259, C2a / #261, C2b1 / #262, C2b2 / #263; C2c per-module sidecar entries in flight)
 
 This document tracks what works today and what is in progress. It is the source
 of truth — consult it before editing docs, examples, or making claims about
@@ -129,7 +129,7 @@ feature availability.
     `build/capsules/<scope>/<name>/obj/mod.o`, binary at
     `build/capsules/<scope>/<name>/bin/<bin-name>`. Positional
     builds and explicit `-o` keep their existing locations.
-  - **C2b2 (this PR)** — dep `.ll` files migrate from the flat
+  - **C2b2 (#263)** — dep `.ll` files migrated from the flat
     `build/sailfin/capsules/<mangled>.ll` layout into the
     per-capsule tree. Manifest-declared dep sources land at
     `build/capsules/<dep-scope>/<dep-name>/ir/<rel>.ll`;
@@ -148,6 +148,20 @@ feature availability.
     `test_build_json_schema.sh` /
     `test_capsule_artifact_sidecar.sh` `dep_ll_paths`
     file-exists assertions.
+  - **C2c (this PR)** — per-module sidecar entries.
+    `CapsuleArtifactManifest.modules: [{slug, ir_path,
+    cache_key}]` enumerates every dep `.ll` the build
+    produced, so consumers (`sfn package` C4, `sfn lsp`,
+    MCP) can iterate per-source artifacts without
+    re-walking the build tree. Threaded through
+    `ModuleCacheEvent.{slug, cache_key_digest}` →
+    `CompileCapsuleResult.module_events` →
+    `ProjectCapsuleResult.module_events` → the sidecar
+    emitter. Schema stays at "1" (additive field;
+    pre-C2c v1 consumers ignore it and continue
+    working). `obj_path` deferred — per-module `.o`s
+    aren't materialised in the per-capsule tree today
+    (only the cache has them, content-addressed).
 - `make compile` builds the compiler from a released seed. `make check`
   validates the seedcheck binary can run `hello-world.sfn` and pass the test suite.
 - **Deterministic self-hosting**: the compiler is a verified fixed point —


### PR DESCRIPTION
## Summary

Stage C2c of the unified build architecture — adds a `modules: [{slug, ir_path, cache_key}]` array to the per-capsule sidecar so `sfn package`, `sfn lsp`, MCP, and other downstream tools can enumerate per-source artifacts without re-walking the build tree.

```jsonc
// build/capsules/<scope>/<name>/manifest.json after `sfn build -p`
{
  "schema_version": "1",
  "capsule": "demo/widget",
  // ... existing fields ...
  "deps":    { "count": 1, "ll_paths": ["build/capsules/sfn/math/ir/mod.ll"] },
  "modules": [
    {
      "slug": "sfn/math/mod",
      "ir_path": "build/capsules/sfn/math/ir/mod.ll",
      "cache_key": "ab12...e7"   // sha256 hex; "" when --no-cache
    }
    // ...
  ]
}
```

### Plumbing

| Layer | Change |
|---|---|
| `capsule_resolver.sfn::ModuleCacheEvent` | `+slug`, `+cache_key_digest` (populated on every return path from `_cr_compile_one`; failure helper takes the slug as a param) |
| `CompileCapsuleResult` / `ProjectCapsuleResult` | `+module_events: ModuleCacheEvent[]` (parallel array to `ll_paths`) |
| `capsule_artifact.sfn` | new `CapsuleArtifactModule` struct + `make_capsule_artifact_module` ctor, `+modules: CapsuleArtifactModule[]` on the manifest, JSON encoder extended |
| `cli_main.sfn::_emit_capsule_artifact_sidecar` | zips `module_events` with `ll_paths` (defended with `min(event_count, path_count)`) into `manifest.modules` |

### Schema policy

Schema stays at `"1"` — `modules` is **additive**, existing v1 consumers ignoring it keep working. Same precedent as C2b1 (`out_path` content drift) and C2b2 (`dep_ll_paths` content drift). A *shape* change to an existing field would still be a v2.

`obj_path` deferred — per-module `.o`s aren't materialised in the per-capsule tree today (cache holds them content-addressed; libraries surface a single `mod.o` via `out`; binaries link the `.ll` set directly). Easy follow-up when per-module compile-then-link lands.

## Test plan

- [x] `make compile` — self-host green (~2 min)
- [x] `make test-unit` — 78/78 (6 new C2c tests)
- [x] `make test-integration` — 17/17
- [x] `make test-e2e` — 19/19 (4 new sidecar assertions + 2 new layout assertions)
- [x] `sfn fmt --check` clean on all touched .sfn files
- [ ] Cloudflare Pages preview renders updated `docs/status.md` and `docs/proposals/build-architecture.md`

## Followups unblocked

- **C4** (`sfn package`) — sidecar's `modules[]` is now a stable enumeration source for tarball contents.
- **`obj_path`** — drop-in extension to `CapsuleArtifactModule` once per-module compile-then-link lands.

https://claude.ai/code/session_01Wtm6pciPANUjuJ4qS2LB2a

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wtm6pciPANUjuJ4qS2LB2a)_