### PR TITLE
Stage C4: sfn package v1 — Sailfin-native distribution packager

### DIFF
--- a/compiler/src/cli_commands.sfn
+++ b/compiler/src/cli_commands.sfn
@@ -3,6 +3,7 @@
 // CLI command handlers extracted from cli_main.sfn to keep
 // sailfin_cli_main under ~500 .sfn-asm instructions (avoids seed OOM).
 import { Statement } from "./ast";
+import { is_safe_scope_name, parse_scope_name } from "./capsule_artifact";
 import {
     TestCapsuleResolution,
     discover_project_root,
@@ -34,6 +35,7 @@ import {
     _write_text_cmd,
     find_char
 } from "./cli_commands_utils";
+import { DistManifest, dist_manifest_to_json, empty_dist_manifest } from "./dist_manifest";
 import { ImportSymbolTable, empty_import_symbols } from "./effect_imports";
 import { lock_add_entry, lock_get_version } from "./lock";
 import {
@@ -811,6 +813,475 @@ fn handle_publish_command(args: string[]) -> number ![io] {
     return 0;
 }
 
+// ---- sfn package (Stage C4) ----
+//
+// Produce a distributable tarball + sha256 sidecar + JSON manifest
+// describing a built artifact.  Replaces `tools/package.sh`.
+//
+// Usage:
+//   sfn package [--target T] [--out DIR] [--compiler-bin PATH] [-p <capsule-path>]
+//
+// Without `-p`: packages the compiler. Reads `compiler/capsule.toml`
+// for version (the compiler's `[capsule].name` is single-segment so
+// no per-capsule sidecar exists for it). Default `--compiler-bin =
+// build/native/sailfin`. Tarball stem `sailfin-native-<target>-<version>`.
+//
+// With `-p <path>`: packages a user capsule. Reads the C2c sidecar at
+// `<path>/build/capsules/<scope>/<name>/manifest.json` (must exist —
+// run `sfn build -p <path>` first). Tarball stem
+// `<sanitized-name>-<target>-<version>`.
+//
+// Output: `<out>/<stem>.tar.gz`, `<stem>.tar.gz.sha256`,
+// `<stem>.manifest.json`. Outputs match `tools/package.sh`'s shape
+// except the manifest is now schema-versioned (see `dist_manifest.sfn`).
+//
+// Staging path is deterministic (`build/sailfin/.package-staging`)
+// rather than mktemp — easier to inspect failed runs and to clean
+// idempotently. Concurrent invocations would clobber each other;
+// acceptable for a release-time tool.
+//
+// Does NOT auto-rebuild — run `make compile` (or `sfn build -p
+// <path>`) first. Auto-rebuilding from inside a Sailfin-native
+// command shelling out to `make` is a bootstrapping smell (the
+// compiler would be rebuilding itself before packaging itself).
+fn handle_package_command(args: string[]) -> number ![io] {
+    // Parse args.
+    let mut target_arg: string = "";
+    let mut out_dir: string = "dist";
+    let mut compiler_bin: string = "build/native/sailfin";
+    let mut capsule_path: string = "";
+    let mut argi: number = 1;
+    loop {
+        if argi >= args.length { break; }
+        let a = args[argi];
+        if strings_equal(a, "--target") {
+            if argi + 1 >= args.length {
+                print("sfn package: --target requires a value");
+                return 2;
+            }
+            target_arg = args[argi + 1];
+            argi += 2;
+            continue;
+        }
+        if strings_equal(a, "--out") {
+            if argi + 1 >= args.length {
+                print("sfn package: --out requires a directory");
+                return 2;
+            }
+            out_dir = args[argi + 1];
+            argi += 2;
+            continue;
+        }
+        if strings_equal(a, "--compiler-bin") {
+            if argi + 1 >= args.length {
+                print("sfn package: --compiler-bin requires a path");
+                return 2;
+            }
+            compiler_bin = args[argi + 1];
+            argi += 2;
+            continue;
+        }
+        if strings_equal(a, "-p") {
+            if argi + 1 >= args.length {
+                print("sfn package: -p requires a capsule path");
+                return 2;
+            }
+            capsule_path = args[argi + 1];
+            argi += 2;
+            continue;
+        }
+        print("sfn package: unknown argument \"" + a + "\"");
+        print("usage: sfn package [--target T] [--out DIR] [--compiler-bin PATH] [-p <capsule-path>]");
+        return 2;
+    }
+
+    // Detect platform target if not overridden.
+    let mut target: string = target_arg;
+    if target.length == 0 { target = _package_detect_target(); }
+    if target.length == 0 {
+        print("sfn package: failed to detect platform target");
+        return 1;
+    }
+
+    // Routing: compiler vs user capsule.
+    if capsule_path.length == 0 {
+        return _package_compiler(target, out_dir, compiler_bin);
+    }
+    return _package_user_capsule(target, out_dir, capsule_path);
+}
+
+// Map `uname -s` + `uname -m` → canonical target string.
+// Falls back to `unknown-<s>-<m>` for unrecognised pairs.
+fn _package_detect_target() -> string ![io] {
+    let os = _shell_read_cmd("uname -s");
+    let arch = _shell_read_cmd("uname -m");
+    if os.length == 0 { return ""; }
+    if arch.length == 0 { return ""; }
+    if strings_equal(os, "Linux") {
+        if strings_equal(arch, "x86_64") { return "linux-x86_64"; }
+        if strings_equal(arch, "aarch64") { return "linux-arm64"; }
+    }
+    if strings_equal(os, "Darwin") {
+        if strings_equal(arch, "arm64") { return "macos-arm64"; }
+        if strings_equal(arch, "x86_64") { return "macos-x86_64"; }
+    }
+    return "unknown-" + os + "-" + arch;
+}
+
+// Package the compiler. Reads `compiler/capsule.toml` for version,
+// stages `<bin>/sailfin` + `<bin>/sfn`, tars + sha256s + manifest.
+fn _package_compiler(target: string, out_dir: string, compiler_bin: string) -> number ![io] {
+    if !fs.exists(compiler_bin) {
+        print("sfn package: compiler binary not found: " + compiler_bin);
+        print("hint: run `make compile` first");
+        return 1;
+    }
+    let manifest_path = "compiler/capsule.toml";
+    if !fs.exists(manifest_path) {
+        print("sfn package: missing " + manifest_path);
+        return 1;
+    }
+    let manifest_text = fs.readFile(manifest_path);
+    let version = toml_get_version(manifest_text);
+    let capsule_name = toml_get_name(manifest_text);
+    if version.length == 0 {
+        print("sfn package: missing version in compiler/capsule.toml");
+        return 1;
+    }
+
+    let stem = "sailfin-native-" + target + "-" + version;
+    let staging = "build/sailfin/.package-staging";
+    let staging_root = staging + "/sailfin-native-" + target;
+    let staging_bin = staging_root + "/bin";
+
+    // Staging is wiped on entry AND exit so a prior failed run
+    // can't bleed contents into this run.
+    process.run(["rm", "-rf", staging]);
+    process.run(["mkdir", "-p", staging_bin]);
+    let cp1 = process.run(["cp", "-f", compiler_bin, staging_bin + "/sailfin"]);
+    let cp2 = process.run(["cp", "-f", compiler_bin, staging_bin + "/sfn"]);
+    if cp1 != 0 {
+        print("sfn package: failed to stage sailfin binary");
+        process.run(["rm", "-rf", staging]);
+        return 1;
+    }
+    if cp2 != 0 {
+        print("sfn package: failed to stage sfn binary");
+        process.run(["rm", "-rf", staging]);
+        return 1;
+    }
+
+    process.run(["mkdir", "-p", out_dir]);
+    let tarball = out_dir + "/" + stem + ".tar.gz";
+    let tar_rc = process.run(["tar", "-czf", tarball, "-C", staging, "sailfin-native-"
+        + target,]);
+    if tar_rc != 0 {
+        print("sfn package: tar failed (exit=" + number_to_string(tar_rc) + ")");
+        process.run(["rm", "-rf", staging]);
+        return 1;
+    }
+
+    let digest = _sha256_of_file_cmd(tarball);
+    if digest.length == 0 {
+        print("sfn package: failed to compute sha256 for " + tarball);
+        process.run(["rm", "-rf", staging]);
+        return 1;
+    }
+    fs.writeFile(tarball + ".sha256", digest + "\n");
+
+    let binary_size = _package_size_of_file(compiler_bin);
+    let tarball_size = _package_size_of_file(tarball);
+    let build_date = _shell_read_cmd("date -u +%Y-%m-%dT%H:%M:%SZ");
+
+    let mut manifest = empty_dist_manifest();
+    manifest.name = "sailfin-native";
+    manifest.kind = "compiler";
+    manifest.capsule_name = capsule_name;
+    manifest.version = version;
+    manifest.target = target;
+    manifest.tarball = stem + ".tar.gz";
+    manifest.sha256 = digest;
+    manifest.binary_size = binary_size;
+    manifest.tarball_size = tarball_size;
+    manifest.build_date = build_date;
+
+    let manifest_out = out_dir + "/" + stem + ".manifest.json";
+    fs.writeFile(manifest_out, dist_manifest_to_json(manifest));
+
+    process.run(["rm", "-rf", staging]);
+
+    print("[package] created " + tarball);
+    print("[package] created " + tarball + ".sha256");
+    print("[package] created " + manifest_out);
+    return 0;
+}
+
+// Package a user capsule. Reads the C2c sidecar to determine the
+// artifact path and kind. Stages binary/object + sidecar +
+// capsule.toml into the tarball — minimal contents until a
+// post-1.0 `--include-ir` flag adds the per-module IR.
+fn _package_user_capsule(target: string, out_dir: string, capsule_path: string) -> number ![io] {
+    // Normalise trailing slash on the path.
+    let mut path = capsule_path;
+    if path.length > 0 {
+        if substring(path, path.length - 1, path.length) == "/" {
+            path = substring(path, 0, path.length - 1);
+        }
+    }
+    let manifest_path = path + "/capsule.toml";
+    if !fs.exists(manifest_path) {
+        print("sfn package: " + manifest_path + " not found");
+        return 1;
+    }
+    let manifest_text = fs.readFile(manifest_path);
+    let capsule_name = toml_get_name(manifest_text);
+    let version = toml_get_version(manifest_text);
+    if capsule_name.length == 0 {
+        print("sfn package: missing [capsule].name in " + manifest_path);
+        return 1;
+    }
+    if version.length == 0 {
+        print("sfn package: missing version in " + manifest_path);
+        return 1;
+    }
+
+    // The sidecar lives under the capsule's per-capsule tree
+    // (Stage C2a). `[capsule].name` must be in scope/name form
+    // for the sidecar to have been written.
+    let parts = parse_scope_name(capsule_name);
+    if parts.scope.length == 0 {
+        print("sfn package: capsule name \"" + capsule_name
+            + "\" is not in scope/name form; cannot locate sidecar");
+        return 1;
+    }
+    if !is_safe_scope_name(parts.scope, parts.name) {
+        print("sfn package: capsule name \"" + capsule_name + "\" is unsafe");
+        return 1;
+    }
+    let sidecar_path = path + "/build/capsules/" + parts.scope + "/" + parts.name
+        + "/manifest.json";
+    if !fs.exists(sidecar_path) {
+        print("sfn package: no sidecar at " + sidecar_path);
+        print("hint: run `sfn build -p " + capsule_path + "` first");
+        return 1;
+    }
+    let sidecar_text = fs.readFile(sidecar_path);
+    let kind = _package_extract_top_level(sidecar_text, "kind");
+    let out_field = _package_extract_top_level(sidecar_text, "out");
+    if kind.length == 0 {
+        print("sfn package: sidecar at " + sidecar_path
+            + " has no \"kind\" field");
+        return 1;
+    }
+    if out_field.length == 0 {
+        print("sfn package: sidecar at " + sidecar_path
+            + " has no \"out\" field");
+        return 1;
+    }
+    // out field is relative to the capsule path's CWD. Resolve.
+    let artifact_path = path + "/" + out_field;
+    if !fs.exists(artifact_path) {
+        print("sfn package: artifact not found: " + artifact_path);
+        print("hint: run `sfn build -p " + capsule_path + "` to (re)produce it");
+        return 1;
+    }
+
+    // Sanitised tarball stem: replace `/` in capsule names with `-`.
+    let safe_name = _package_sanitise_name(capsule_name);
+    let stem = safe_name + "-" + target + "-" + version;
+    let staging = "build/sailfin/.package-staging";
+    let staging_root = staging + "/" + safe_name + "-" + target;
+
+    process.run(["rm", "-rf", staging]);
+    process.run(["mkdir", "-p", staging_root]);
+
+    // Stage the artifact under bin/ or obj/ depending on kind.
+    let mut artifact_dest: string = "";
+    if strings_equal(kind, "binary") {
+        process.run(["mkdir", "-p", staging_root + "/bin"]);
+        // Use the artifact's basename for the tarball's bin entry.
+        let bn = _package_basename(artifact_path);
+        if bn.length == 0 {
+            print("sfn package: could not derive binary basename from "
+                + artifact_path);
+            process.run(["rm", "-rf", staging]);
+            return 1;
+        }
+        artifact_dest = staging_root + "/bin/" + bn;
+    } else if strings_equal(kind, "library") {
+        process.run(["mkdir", "-p", staging_root + "/obj"]);
+        artifact_dest = staging_root + "/obj/mod.o";
+    } else {
+        print("sfn package: unsupported kind \"" + kind
+            + "\" (expected binary | library)");
+        process.run(["rm", "-rf", staging]);
+        return 1;
+    }
+    let cp_artifact = process.run(["cp", "-f", artifact_path, artifact_dest]);
+    if cp_artifact != 0 {
+        print("sfn package: failed to stage artifact " + artifact_path);
+        process.run(["rm", "-rf", staging]);
+        return 1;
+    }
+    // Self-describing: copy the sidecar AND capsule.toml so a
+    // consumer of the tarball can see what they got without
+    // re-running the build.
+    process.run(["cp", "-f", sidecar_path, staging_root + "/manifest.json"]);
+    process.run(["cp", "-f", manifest_path, staging_root + "/capsule.toml"]);
+
+    process.run(["mkdir", "-p", out_dir]);
+    let tarball = out_dir + "/" + stem + ".tar.gz";
+    let tar_rc = process.run(["tar", "-czf", tarball, "-C", staging, safe_name
+        + "-"
+        + target,]);
+    if tar_rc != 0 {
+        print("sfn package: tar failed (exit=" + number_to_string(tar_rc) + ")");
+        process.run(["rm", "-rf", staging]);
+        return 1;
+    }
+
+    let digest = _sha256_of_file_cmd(tarball);
+    if digest.length == 0 {
+        print("sfn package: failed to compute sha256 for " + tarball);
+        process.run(["rm", "-rf", staging]);
+        return 1;
+    }
+    fs.writeFile(tarball + ".sha256", digest + "\n");
+
+    let artifact_size = _package_size_of_file(artifact_path);
+    let tarball_size = _package_size_of_file(tarball);
+    let build_date = _shell_read_cmd("date -u +%Y-%m-%dT%H:%M:%SZ");
+
+    let mut manifest = empty_dist_manifest();
+    manifest.name = safe_name;
+    manifest.kind = kind;
+    manifest.capsule_name = capsule_name;
+    manifest.version = version;
+    manifest.target = target;
+    manifest.tarball = stem + ".tar.gz";
+    manifest.sha256 = digest;
+    manifest.binary_size = artifact_size;
+    manifest.tarball_size = tarball_size;
+    manifest.build_date = build_date;
+
+    let manifest_out = out_dir + "/" + stem + ".manifest.json";
+    fs.writeFile(manifest_out, dist_manifest_to_json(manifest));
+
+    process.run(["rm", "-rf", staging]);
+
+    print("[package] created " + tarball);
+    print("[package] created " + tarball + ".sha256");
+    print("[package] created " + manifest_out);
+    return 0;
+}
+
+// `wc -c < path` returns a base-10 size. Returns 0 on read failure.
+fn _package_size_of_file(path: string) -> number ![io] {
+    let raw = _shell_read_cmd("wc -c < '" + path + "'");
+    if raw.length == 0 { return 0; }
+    let mut value: number = 0;
+    let mut i: number = 0;
+    loop {
+        if i >= raw.length { break; }
+        let ch = substring(raw, i, i + 1);
+        if ch == "0" { value = value * 10; } else if ch == "1" {
+            value = value * 10 + 1;
+        } else if ch == "2" { value = value * 10 + 2; } else if ch == "3" {
+            value = value * 10 + 3;
+        } else if ch == "4" { value = value * 10 + 4; } else if ch == "5" {
+            value = value * 10 + 5;
+        } else if ch == "6" { value = value * 10 + 6; } else if ch == "7" {
+            value = value * 10 + 7;
+        } else if ch == "8" { value = value * 10 + 8; } else if ch == "9" {
+            value = value * 10 + 9;
+        } else { break; }
+        i += 1;
+    }
+    return value;
+}
+
+// Replace `/` and `\` in a capsule name with `-` so it's safe to
+// interpolate into a filename. Other characters pass through; the
+// caller should already have validated via `is_safe_scope_name`.
+fn _package_sanitise_name(name: string) -> string {
+    let mut out: string = "";
+    let mut i: number = 0;
+    loop {
+        if i >= name.length { break; }
+        let ch = substring(name, i, i + 1);
+        if ch == "/" { out = out + "-"; } else if ch == "\\" {
+            out = out + "-";
+        } else { out = out + ch; }
+        i += 1;
+    }
+    return out;
+}
+
+// Last `/`-separated segment of `path`. Returns `""` if the path
+// has no segments or ends with `/`.
+fn _package_basename(path: string) -> string {
+    if path.length == 0 { return ""; }
+    let mut last_slash: number = -1;
+    let mut i: number = 0;
+    loop {
+        if i >= path.length { break; }
+        if substring(path, i, i + 1) == "/" { last_slash = i; }
+        i += 1;
+    }
+    if last_slash < 0 { return path; }
+    if last_slash == path.length - 1 { return ""; }
+    return substring(path, last_slash + 1, path.length);
+}
+
+// Extract the value of a top-level string field from the per-capsule
+// sidecar JSON (Stage C2a/C2c). Anchored on the prefix `"<field>":"`
+// at the **outermost** object level — e.g. for `kind = "binary"` the
+// match is `,"kind":"binary"` (or `{"kind":"binary"`).
+//
+// Hand-rolled because we don't have a JSON parser yet; only the few
+// top-level fields `sfn package` cares about (`kind`, `out`) are
+// read this way. The sidecar's `modules[]` may also contain a
+// `"slug"` field, but the loop terminates at the FIRST match
+// against the outer-prefix anchor — and the outer fields appear
+// before `"modules":[...]` in
+// `capsule_artifact_manifest_to_json`'s field order.  If that
+// ordering ever changes, the unit test on this helper catches it.
+fn _package_extract_top_level(json: string, field: string) -> string {
+    if json.length == 0 { return ""; }
+    if field.length == 0 { return ""; }
+    let needle = "\"" + field + "\":\"";
+    let start = _package_find_substring(json, needle, 0);
+    if start < 0 { return ""; }
+    let value_start = start + needle.length;
+    // Find the closing quote, honouring backslash escapes.
+    let mut end: number = value_start;
+    loop {
+        if end >= json.length { return ""; }
+        let ch = substring(json, end, end + 1);
+        if ch == "\\" {
+            // skip the next character (escape)
+            end += 2;
+            continue;
+        }
+        if ch == "\"" { break; }
+        end += 1;
+    }
+    return substring(json, value_start, end);
+}
+
+fn _package_find_substring(haystack: string, needle: string, start: number) -> number {
+    if needle.length == 0 { return start; }
+    if haystack.length < needle.length { return -1; }
+    let limit = haystack.length - needle.length;
+    let mut i: number = start;
+    loop {
+        if i > limit { break; }
+        if substring(haystack, i, i + needle.length) == needle { return i; }
+        i += 1;
+    }
+    return -1;
+}
+
 fn handle_add_command(args: string[]) -> number ![io] {
     let mut is_dev: boolean = false;
     let mut is_update: boolean = false;
@@ -1211,6 +1682,7 @@ fn handle_fmt_command(args: string[]) -> number ![io] {
 export {
     handle_test_command,
     handle_publish_command,
+    handle_package_command,
     handle_add_command,
     handle_config_command,
     handle_init_command,

--- a/compiler/src/cli_commands.sfn
+++ b/compiler/src/cli_commands.sfn
@@ -30,6 +30,7 @@ import {
     _sanitize_filename_cmd,
     _sha256_of_file_cmd,
     _shell_read_cmd,
+    _shell_single_quote_arg,
     _string_contains_cmd,
     _toml_trim_cmd,
     _write_text_cmd,
@@ -948,6 +949,15 @@ fn _package_compiler(target: string, out_dir: string, compiler_bin: string) -> n
         print("sfn package: missing version in compiler/capsule.toml");
         return 1;
     }
+    // Defence-in-depth: `version` is interpolated into the tarball
+    // stem (used as a filename and as a `wc -c < <path>` argument).
+    // A malformed manifest with `version = "x'$(rm)"` would otherwise
+    // produce a path-traversal or shell-metachar surface. The
+    // sanitiser blocks `/`, `\`, `..` traversal components.
+    if !_is_safe_capsule_version_cmd(version) {
+        print("sfn package: rejecting unsafe version string \"" + version + "\"");
+        return 1;
+    }
 
     let stem = "sailfin-native-" + target + "-" + version;
     let staging = "build/sailfin/.package-staging";
@@ -1042,6 +1052,13 @@ fn _package_user_capsule(target: string, out_dir: string, capsule_path: string) 
     }
     if version.length == 0 {
         print("sfn package: missing version in " + manifest_path);
+        return 1;
+    }
+    // See compiler-mode rationale: `version` flows into the tarball
+    // stem and into shell commands; reject anything that could
+    // escape filename or shell quoting.
+    if !_is_safe_capsule_version_cmd(version) {
+        print("sfn package: rejecting unsafe version string \"" + version + "\"");
         return 1;
     }
 
@@ -1176,8 +1193,11 @@ fn _package_user_capsule(target: string, out_dir: string, capsule_path: string) 
 }
 
 // `wc -c < path` returns a base-10 size. Returns 0 on read failure.
+// `path` is shell-quoted via `_shell_single_quote_arg` so paths
+// containing `'` (or other shell metacharacters) can't break out
+// of the `sh -c` interpolation in `_shell_read_cmd`.
 fn _package_size_of_file(path: string) -> number ![io] {
-    let raw = _shell_read_cmd("wc -c < '" + path + "'");
+    let raw = _shell_read_cmd("wc -c < " + _shell_single_quote_arg(path));
     if raw.length == 0 { return 0; }
     let mut value: number = 0;
     let mut i: number = 0;

--- a/compiler/src/cli_commands_utils.sfn
+++ b/compiler/src/cli_commands_utils.sfn
@@ -23,6 +23,7 @@ export {
     _curl_post_json_cmd,
     _curl_download_cmd,
     _sha256_of_file_cmd,
+    _shell_single_quote_arg,
     _extract_sfnpkg_cmd,
     _is_stdlib_capsule_cmd,
     _has_slash_cmd,
@@ -270,8 +271,40 @@ fn _curl_download_cmd(url: string, output_path: string) -> number ![io] {
     return process.run(["curl", "-sfSL", "-o", output_path, url]);
 }
 
+// POSIX shell single-quote escape: wrap `value` in `'...'`, replacing
+// any embedded `'` with `'\''` (close quote, escaped quote, reopen
+// quote). Safe to interpolate verbatim into a shell command. Use
+// this for any file path or other string handed to `_shell_read_cmd`
+// or `process.run(["sh", "-c", ...])` — without it a path containing
+// `'` (or other shell metacharacters) breaks quoting and creates a
+// command-injection surface.
+fn _shell_single_quote_arg(value: string) -> string {
+    let mut out: string = "'";
+    let mut i: number = 0;
+    loop {
+        if i >= value.length { break; }
+        let ch = substring(value, i, i + 1);
+        if ch == "'" { out = out + "'\\''"; } else { out = out + ch; }
+        i += 1;
+    }
+    return out + "'";
+}
+
+// Compute the sha256 hex digest of a file. Tries `sha256sum` first
+// (universally available on Linux); falls back to `shasum -a 256` on
+// systems without coreutils (notably default macOS). Mirrors the
+// fallback ladder `tools/package.sh` used historically. Returns
+// `""` if neither tool is available or the file can't be read.
+//
+// `file_path` is properly shell-quoted so paths containing `'` or
+// other shell metacharacters can't break the command.
 fn _sha256_of_file_cmd(file_path: string) -> string ![io] {
-    return _shell_read_cmd("sha256sum '" + file_path + "' | cut -d' ' -f1");
+    let q = _shell_single_quote_arg(file_path);
+    let cmd = "(command -v sha256sum >/dev/null 2>&1 && sha256sum " + q
+        + " || shasum -a 256 "
+        + q
+        + ") | cut -d' ' -f1";
+    return _shell_read_cmd(cmd);
 }
 
 fn _extract_sfnpkg_cmd(content: string, dest_dir: string) -> void ![io] {

--- a/compiler/src/cli_main.sfn
+++ b/compiler/src/cli_main.sfn
@@ -39,6 +39,7 @@ import {
     handle_guillermo_command,
     handle_init_command,
     handle_login_command,
+    handle_package_command,
     handle_publish_command,
     handle_test_command
 } from "./cli_commands";
@@ -81,6 +82,8 @@ fn _usage() -> string {
     out = out + "packages:\n";
     out = out + "  sfn add     [--dev] [--update] <capsule>\n";
     out = out + "  sfn publish [path]\n";
+    out = out
+        + "  sfn package [--target T] [--out DIR] [--compiler-bin PATH] [-p <capsule-path>]\n";
     out = out + "  sfn login   [token]\n";
     out = out + "  sfn config  <get|set|unset|list> [key] [value]\n";
     out = out + "\n";
@@ -567,6 +570,7 @@ fn sailfin_cli_main(argv: string[]) -> number ![io, clock] {
     let is_help = _let10;
     let is_init = strings_equal(cmd, "init");
     let is_publish = strings_equal(cmd, "publish");
+    let is_package = strings_equal(cmd, "package");
     let is_add = strings_equal(cmd, "add");
     let is_login = strings_equal(cmd, "login");
     let is_config = strings_equal(cmd, "config");
@@ -1025,6 +1029,8 @@ fn sailfin_cli_main(argv: string[]) -> number ![io, clock] {
     if is_init { return handle_init_command(args); }
 
     if is_publish { return handle_publish_command(args); }
+
+    if is_package { return handle_package_command(args); }
 
     if is_add { return handle_add_command(args); }
 

--- a/compiler/src/dist_manifest.sfn
+++ b/compiler/src/dist_manifest.sfn
@@ -1,0 +1,174 @@
+// compiler/src/dist_manifest.sfn
+//
+// Stage C4 — distribution manifest for `sfn package`.
+//
+// Sibling to `capsule_artifact.sfn` (the per-capsule build sidecar at
+// `build/capsules/<scope>/<name>/manifest.json`). Where the C2a/C2b/C2c
+// sidecar describes a build's *resolved state*, this manifest describes
+// a *distributable artifact*: a compiler tarball or user-capsule
+// tarball produced by `sfn package` and uploaded to a registry / GitHub
+// release.
+//
+// Produced as `<dist_dir>/<stem>.manifest.json` next to the tarball
+// itself and its `.sha256` sidecar. Replaces the manifest emitted by
+// `tools/package.sh` (which has no schema_version and no `kind` /
+// `capsule` fields).
+//
+// Schema is `schema_version: "1"`. Bumping the version is the contract
+// for breaking changes — downstream consumers (the release workflow,
+// future `sfn install` / `sfn package verify`, MCP tooling) hard-fail
+// on unknown values rather than silently misinterpret. Same pattern
+// as `capsule_artifact.sfn`, `build_report.sfn`, `diagnostics_json.sfn`.
+//
+// Self-contained module: duplicates JSON primitive encoders from
+// `capsule_artifact.sfn` rather than importing them — same precedent
+// (seed compiler doesn't handle the import cycle cleanly), and the
+// duplication keeps each emitter independently unit-testable.
+import { substring } from "./string_utils";
+
+// -------------------------------------------------------------------
+// Schema
+// -------------------------------------------------------------------
+//
+// {
+//   "schema_version": "1",
+//   "name": "sailfin-native",                        // dist artifact name (human-facing)
+//   "kind": "compiler",                              // "compiler" | "binary" | "library"
+//   "capsule": "sailfin",                            // canonical capsule name from capsule.toml
+//   "version": "0.5.10-alpha.2",
+//   "target": "linux-x86_64",                        // <os>-<arch>
+//   "tarball": "sailfin-native-linux-x86_64-0.5.10-alpha.2.tar.gz",
+//   "sha256": "ab12...e7",                           // sha256 hex of the tarball
+//   "binary_size": 1895760,                          // bytes of the bundled binary
+//   "tarball_size": 567890,                          // bytes of the .tar.gz
+//   "build_date": "2026-04-29T12:34:56Z"             // UTC ISO-8601
+// }
+//
+// `name` differs from `capsule`: `name` is the dist artifact's
+// label (matches `tools/package.sh`'s historical "sailfin-native"
+// for compiler tarballs), while `capsule` is the canonical capsule
+// the artifact was built from. `kind` distinguishes compiler builds
+// from user-capsule binary/library packages so consumers can route
+// correctly.
+struct DistManifest {
+    name: string;
+    kind: string;
+    capsule_name: string;
+    version: string;
+    target: string;
+    tarball: string;
+    sha256: string;
+    binary_size: number;
+    tarball_size: number;
+    build_date: string;
+}
+
+fn empty_dist_manifest() -> DistManifest {
+    return DistManifest {
+        name: "",
+        kind: "compiler",
+        capsule_name: "",
+        version: "",
+        target: "",
+        tarball: "",
+        sha256: "",
+        binary_size: 0,
+        tarball_size: 0,
+        build_date: ""
+    };
+}
+
+// -------------------------------------------------------------------
+// JSON primitive encoders (duplicated; see top-of-file rationale)
+// -------------------------------------------------------------------
+fn _dm_json_escape(s: string) -> string {
+    let mut out: string = "";
+    let mut i: number = 0;
+    loop {
+        if i >= s.length { break; }
+        let ch = substring(s, i, i + 1);
+        if ch == "\"" { out = out + "\\\""; } else if ch == "\\" {
+            out = out + "\\\\";
+        } else if ch == "\n" { out = out + "\\n"; } else if ch == "\r" {
+            out = out + "\\r";
+        } else if ch == "\t" { out = out + "\\t"; } else { out = out + ch; }
+        i += 1;
+    }
+    return out;
+}
+
+fn _dm_json_quote(s: string) -> string {
+    return "\"" + _dm_json_escape(s) + "\"";
+}
+
+fn _dm_json_field(name: string, value: string) -> string {
+    return _dm_json_quote(name) + ":" + value;
+}
+
+fn _dm_json_string_field(name: string, value: string) -> string {
+    return _dm_json_field(name, _dm_json_quote(value));
+}
+
+fn _dm_json_number_field(name: string, value: number) -> string {
+    return _dm_json_field(name, _dm_number_to_string(value));
+}
+
+// Same repeated-subtraction algorithm as `capsule_artifact.sfn` and
+// `compiler/src/main.sfn::number_to_string` — Sailfin's `number` is
+// a float, so `working / 10` doesn't truncate.
+fn _dm_number_to_string(value: number) -> string {
+    if value == 0 { return "0"; }
+    let mut working: number = value;
+    let mut negative: boolean = false;
+    if working < 0 {
+        negative = true;
+        working = 0 - working;
+    }
+    let digits = "0123456789";
+    let mut remaining: number = working;
+    let mut output: string = "";
+    loop {
+        if remaining <= 0 { break; }
+        let mut temp: number = remaining;
+        let mut quotient: number = 0;
+        loop {
+            if temp < 10 { break; }
+            temp -= 10;
+            quotient += 1;
+        }
+        let ch = substring(digits, temp, temp + 1);
+        output = ch + output;
+        remaining = quotient;
+    }
+    if negative { output = "-" + output; }
+    return output;
+}
+
+// -------------------------------------------------------------------
+// Public encoder
+// -------------------------------------------------------------------
+fn dist_manifest_to_json(m: DistManifest) -> string {
+    return "{" + _dm_json_string_field("schema_version", "1") + ","
+        + _dm_json_string_field("name", m.name)
+        + ","
+        + _dm_json_string_field("kind", m.kind)
+        + ","
+        + _dm_json_string_field("capsule", m.capsule_name)
+        + ","
+        + _dm_json_string_field("version", m.version)
+        + ","
+        + _dm_json_string_field("target", m.target)
+        + ","
+        + _dm_json_string_field("tarball", m.tarball)
+        + ","
+        + _dm_json_string_field("sha256", m.sha256)
+        + ","
+        + _dm_json_number_field("binary_size", m.binary_size)
+        + ","
+        + _dm_json_number_field("tarball_size", m.tarball_size)
+        + ","
+        + _dm_json_string_field("build_date", m.build_date)
+        + "}";
+}
+
+export { DistManifest, dist_manifest_to_json, empty_dist_manifest };

--- a/compiler/tests/e2e/test_sfn_package.sh
+++ b/compiler/tests/e2e/test_sfn_package.sh
@@ -69,9 +69,11 @@ test_compiler_package_succeeds() {
 run_test "sfn package (compiler mode) succeeds" test_compiler_package_succeeds
 
 # Discover the produced tarball — target is platform-dependent so
-# we glob by stem.
-TARBALL="$(ls "$DIST_DIR"/sailfin-native-*-"$COMPILER_VERSION".tar.gz 2>/dev/null | head -n 1)"
-TARBALL_STEM="$(basename "${TARBALL%.tar.gz}")"
+# we glob by stem. Use `|| true` so an empty glob doesn't trip
+# `set -e` (which would skip every later assertion + the summary);
+# `test_artifacts_exist` reports the missing-tarball case cleanly.
+TARBALL="$(ls "$DIST_DIR"/sailfin-native-*-"$COMPILER_VERSION".tar.gz 2>/dev/null | head -n 1 || true)"
+TARBALL_STEM="$(basename "${TARBALL%.tar.gz}" 2>/dev/null || echo "")"
 SHA_FILE="${TARBALL}.sha256"
 MANIFEST="$DIST_DIR/${TARBALL_STEM}.manifest.json"
 
@@ -215,8 +217,8 @@ test_user_capsule_package_succeeds() {
 }
 run_test "sfn package -p (user capsule) succeeds" test_user_capsule_package_succeeds
 
-USER_TARBALL="$(ls "$USER_DIST"/demo-widget-*.tar.gz 2>/dev/null | head -n 1)"
-USER_TARBALL_STEM="$(basename "${USER_TARBALL%.tar.gz}")"
+USER_TARBALL="$(ls "$USER_DIST"/demo-widget-*.tar.gz 2>/dev/null | head -n 1 || true)"
+USER_TARBALL_STEM="$(basename "${USER_TARBALL%.tar.gz}" 2>/dev/null || echo "")"
 USER_MANIFEST="$USER_DIST/${USER_TARBALL_STEM}.manifest.json"
 
 test_user_capsule_artifacts_exist() {

--- a/compiler/tests/e2e/test_sfn_package.sh
+++ b/compiler/tests/e2e/test_sfn_package.sh
@@ -1,0 +1,282 @@
+#!/usr/bin/env bash
+# End-to-end test for `sfn package` (Stage C4).
+#
+# Exercises both modes:
+#   1. Compiler mode (no -p): produces standalone compiler tarball
+#      + sha256 + manifest.json. Replaces tools/package.sh's first
+#      output.
+#   2. User-capsule mode (-p): packages a `demo/widget` library
+#      from its C2c sidecar; tarball contains the obj artifact +
+#      sidecar + capsule.toml.
+#
+# Locks the schema and the tarball structure. If `dist_manifest.sfn`
+# or `handle_package_command` drift, this test catches it before
+# the release workflow consumes a misshapen artifact.
+#
+# Usage:
+#   compiler/tests/e2e/test_sfn_package.sh <compiler-binary>
+
+set -euo pipefail
+
+BINARY="${1:?usage: test_sfn_package.sh <compiler-binary>}"
+BINARY="$(realpath "$BINARY")"
+PASS=0
+FAIL=0
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "[test] SKIP: jq not installed (required for manifest schema validation)" >&2
+    exit 0
+fi
+if ! command -v tar >/dev/null 2>&1; then
+    echo "[test] SKIP: tar not installed (required for tarball production)" >&2
+    exit 0
+fi
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+SCRATCH="$(mktemp -d -t sfn-package-XXXXXX)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+run_test() {
+    local name="$1"
+    shift
+    if "$@"; then
+        echo "[test] PASS: $name"
+        PASS=$((PASS + 1))
+    else
+        echo "[test] FAIL: $name"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# ---- Compiler mode: package the running compiler ----
+# Run `sfn package` from the repo root so it can find
+# `compiler/capsule.toml`. Output goes to a scratch dir to keep
+# `dist/` (the canonical release output dir) untouched.
+DIST_DIR="$SCRATCH/dist-compiler"
+COMPILER_VERSION="$(sed -n 's/^version *= *"\([^"]*\)"/\1/p' "$REPO_ROOT/compiler/capsule.toml")"
+
+test_compiler_package_succeeds() {
+    cd "$REPO_ROOT" || return 1
+    "$BINARY" package --out "$DIST_DIR" --compiler-bin "$BINARY" \
+        > "$SCRATCH/compiler.stdout" 2> "$SCRATCH/compiler.err"
+    local rc=$?
+    if [ "$rc" -ne 0 ]; then
+        echo "[test]   sfn package exited with code $rc; stderr:" >&2
+        cat "$SCRATCH/compiler.err" >&2
+        return $rc
+    fi
+}
+run_test "sfn package (compiler mode) succeeds" test_compiler_package_succeeds
+
+# Discover the produced tarball — target is platform-dependent so
+# we glob by stem.
+TARBALL="$(ls "$DIST_DIR"/sailfin-native-*-"$COMPILER_VERSION".tar.gz 2>/dev/null | head -n 1)"
+TARBALL_STEM="$(basename "${TARBALL%.tar.gz}")"
+SHA_FILE="${TARBALL}.sha256"
+MANIFEST="$DIST_DIR/${TARBALL_STEM}.manifest.json"
+
+test_artifacts_exist() {
+    [ -f "$TARBALL" ] || return 1
+    [ -f "$SHA_FILE" ] || return 1
+    [ -f "$MANIFEST" ] || return 1
+}
+run_test "tarball + sha256 + manifest.json all exist" test_artifacts_exist
+
+test_tarball_contents() {
+    # Standalone compiler tarball: only bin/sailfin and bin/sfn,
+    # nested under `<root>/bin/`. Locks the structure consumers
+    # of the release artifact rely on.
+    local listing
+    listing="$(tar -tzf "$TARBALL")"
+    echo "$listing" | grep -qE "/bin/sailfin\$" || return 1
+    echo "$listing" | grep -qE "/bin/sfn\$" || return 1
+}
+run_test "tarball contains bin/sailfin + bin/sfn" test_tarball_contents
+
+test_sha256_sidecar_format() {
+    # `.sha256` content is `<hex>\n` only — matches what
+    # `tools/package.sh` produces and what the release workflow's
+    # `sha256sum -c` expects (after re-attaching the filename).
+    local content
+    content="$(cat "$SHA_FILE")"
+    # 64 hex chars optionally followed by a newline.
+    [ "${#content}" -ge 64 ] || return 1
+    [ "$(echo "$content" | head -c 64 | tr -d '0-9a-f')" = "" ]
+}
+run_test "sha256 sidecar is hex-only" test_sha256_sidecar_format
+
+test_sha256_matches_tarball() {
+    # The hex in the sidecar must match a fresh sha256 of the tarball.
+    local sidecar_hex actual_hex
+    sidecar_hex="$(head -c 64 "$SHA_FILE")"
+    if command -v sha256sum >/dev/null 2>&1; then
+        actual_hex="$(sha256sum "$TARBALL" | awk '{print $1}')"
+    else
+        actual_hex="$(shasum -a 256 "$TARBALL" | awk '{print $1}')"
+    fi
+    [ "$sidecar_hex" = "$actual_hex" ]
+}
+run_test "sha256 sidecar matches actual digest" test_sha256_matches_tarball
+
+test_manifest_schema_v1() {
+    # Schema version is the contract for breaking changes.
+    [ "$(jq -r .schema_version "$MANIFEST")" = "1" ]
+}
+run_test "manifest schema_version is '1'" test_manifest_schema_v1
+
+test_manifest_compiler_fields() {
+    # Compiler-mode invariants.
+    [ "$(jq -r .name "$MANIFEST")" = "sailfin-native" ] || return 1
+    [ "$(jq -r .kind "$MANIFEST")" = "compiler" ] || return 1
+    [ "$(jq -r .capsule "$MANIFEST")" = "sailfin" ] || return 1
+    [ "$(jq -r .version "$MANIFEST")" = "$COMPILER_VERSION" ] || return 1
+}
+run_test "manifest carries name/kind/capsule/version" test_manifest_compiler_fields
+
+test_manifest_size_fields() {
+    # Sizes are JSON numbers > 0 for a real build.
+    local bin_size tar_size
+    bin_size="$(jq -r .binary_size "$MANIFEST")"
+    tar_size="$(jq -r .tarball_size "$MANIFEST")"
+    [ "$bin_size" -gt 0 ] || return 1
+    [ "$tar_size" -gt 0 ] || return 1
+}
+run_test "manifest binary_size + tarball_size > 0" test_manifest_size_fields
+
+test_manifest_target_present() {
+    local target
+    target="$(jq -r .target "$MANIFEST")"
+    [ -n "$target" ] && [ "$target" != "null" ]
+}
+run_test "manifest target is non-empty" test_manifest_target_present
+
+test_manifest_sha256_round_trips() {
+    # Manifest's sha256 should match the .sha256 sidecar.
+    local manifest_hex sidecar_hex
+    manifest_hex="$(jq -r .sha256 "$MANIFEST")"
+    sidecar_hex="$(head -c 64 "$SHA_FILE")"
+    [ "$manifest_hex" = "$sidecar_hex" ]
+}
+run_test "manifest sha256 matches .sha256 sidecar" test_manifest_sha256_round_trips
+
+test_manifest_build_date_iso8601() {
+    # Coarse format check: YYYY-MM-DDTHH:MM:SSZ.
+    local bd
+    bd="$(jq -r .build_date "$MANIFEST")"
+    echo "$bd" | grep -qE "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z\$"
+}
+run_test "manifest build_date matches ISO-8601 UTC" test_manifest_build_date_iso8601
+
+# ---- User-capsule mode: package a demo/widget library ----
+# Mirrors the fixture used by `test_capsule_artifact_sidecar.sh`
+# so we exercise the same C2c sidecar shape sfn package consumes.
+WIDGET_SCRATCH="$SCRATCH/widget-fixture"
+mkdir -p "$WIDGET_SCRATCH/src"
+ln -s "$REPO_ROOT/capsules" "$WIDGET_SCRATCH/capsules"
+cat > "$WIDGET_SCRATCH/capsule.toml" <<'EOF'
+[capsule]
+name = "demo/widget"
+version = "0.1.0"
+description = "E2E fixture for sfn package"
+
+[dependencies]
+"sfn/math" = "0.1.0"
+
+[capabilities]
+required = ["io"]
+
+[build]
+kind = "library"
+entry = "src/mod.sfn"
+EOF
+cat > "$WIDGET_SCRATCH/src/mod.sfn" <<'EOF'
+import { abs } from "sfn/math";
+fn widget_abs(n: number) -> number { return abs(n); }
+EOF
+
+USER_DIST="$SCRATCH/dist-widget"
+
+test_user_capsule_build_first() {
+    cd "$WIDGET_SCRATCH" || return 1
+    "$BINARY" build -p . > "$WIDGET_SCRATCH/build.stdout" 2>&1
+}
+run_test "sfn build -p (precondition for sfn package -p) succeeds" test_user_capsule_build_first
+
+test_user_capsule_package_succeeds() {
+    cd "$WIDGET_SCRATCH" || return 1
+    "$BINARY" package -p . --out "$USER_DIST" \
+        > "$WIDGET_SCRATCH/package.stdout" 2> "$WIDGET_SCRATCH/package.err"
+    local rc=$?
+    if [ "$rc" -ne 0 ]; then
+        echo "[test]   sfn package -p exited with code $rc; stderr:" >&2
+        cat "$WIDGET_SCRATCH/package.err" >&2
+        return $rc
+    fi
+}
+run_test "sfn package -p (user capsule) succeeds" test_user_capsule_package_succeeds
+
+USER_TARBALL="$(ls "$USER_DIST"/demo-widget-*.tar.gz 2>/dev/null | head -n 1)"
+USER_TARBALL_STEM="$(basename "${USER_TARBALL%.tar.gz}")"
+USER_MANIFEST="$USER_DIST/${USER_TARBALL_STEM}.manifest.json"
+
+test_user_capsule_artifacts_exist() {
+    [ -f "$USER_TARBALL" ] || return 1
+    [ -f "${USER_TARBALL}.sha256" ] || return 1
+    [ -f "$USER_MANIFEST" ] || return 1
+}
+run_test "user-capsule tarball + sha256 + manifest exist" test_user_capsule_artifacts_exist
+
+test_user_capsule_tarball_contents() {
+    # Library-kind tarball: obj/mod.o + manifest.json (the C2c
+    # sidecar) + capsule.toml. Self-describing — the consumer can
+    # introspect what they got.
+    local listing
+    listing="$(tar -tzf "$USER_TARBALL")"
+    echo "$listing" | grep -qE "/obj/mod\.o\$" || return 1
+    echo "$listing" | grep -qE "/manifest\.json\$" || return 1
+    echo "$listing" | grep -qE "/capsule\.toml\$" || return 1
+}
+run_test "user-capsule tarball contains obj/mod.o + manifest.json + capsule.toml" test_user_capsule_tarball_contents
+
+test_user_capsule_manifest_kind() {
+    [ "$(jq -r .kind "$USER_MANIFEST")" = "library" ] || return 1
+    [ "$(jq -r .capsule "$USER_MANIFEST")" = "demo/widget" ] || return 1
+    [ "$(jq -r .name "$USER_MANIFEST")" = "demo-widget" ] || return 1
+}
+run_test "user-capsule manifest kind=library, capsule=demo/widget, name=demo-widget" test_user_capsule_manifest_kind
+
+# ---- Error cases ----
+
+test_missing_compiler_bin_errors() {
+    cd "$REPO_ROOT" || return 1
+    set +e
+    "$BINARY" package --out "$SCRATCH/dist-missing" \
+        --compiler-bin "$SCRATCH/does-not-exist" \
+        > "$SCRATCH/missing.stdout" 2> "$SCRATCH/missing.err"
+    local rc=$?
+    set -e
+    [ "$rc" -ne 0 ] || return 1
+    grep -q "compiler binary not found" "$SCRATCH/missing.stdout"
+}
+run_test "missing --compiler-bin fails with clear error" test_missing_compiler_bin_errors
+
+test_user_capsule_missing_sidecar_errors() {
+    # Fresh scratch dir — `sfn build` not run, so no sidecar.
+    local fresh="$SCRATCH/widget-no-build"
+    mkdir -p "$fresh/src"
+    cp "$WIDGET_SCRATCH/capsule.toml" "$fresh/capsule.toml"
+    cp "$WIDGET_SCRATCH/src/mod.sfn" "$fresh/src/mod.sfn"
+    set +e
+    "$BINARY" package -p "$fresh" --out "$SCRATCH/dist-nobuild" \
+        > "$SCRATCH/nobuild.stdout" 2>&1
+    local rc=$?
+    set -e
+    [ "$rc" -ne 0 ] || return 1
+    grep -q "no sidecar" "$SCRATCH/nobuild.stdout"
+}
+run_test "user-capsule without sidecar fails with clear error" test_user_capsule_missing_sidecar_errors
+
+# ---- Summary ----
+echo ""
+echo "[test] $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/compiler/tests/unit/dist_manifest_test.sfn
+++ b/compiler/tests/unit/dist_manifest_test.sfn
@@ -1,0 +1,141 @@
+// Stage C4 regression tests for `compiler/src/dist_manifest.sfn`.
+//
+// `dist_manifest_to_json` is the schema-versioned serializer for
+// the `<stem>.manifest.json` artifact `sfn package` writes next to
+// the tarball it produces. Schema is documented inline in
+// `dist_manifest.sfn` and gated end-to-end by
+// `compiler/tests/e2e/test_sfn_package.sh`. These unit tests lock
+// the per-field invariants — the e2e exercises the full pipeline.
+import { DistManifest, dist_manifest_to_json, empty_dist_manifest } from "../../src/dist_manifest";
+
+// --------------------------------------------------------------
+// empty_dist_manifest defaults
+// --------------------------------------------------------------
+test "empty_dist_manifest: kind defaults to 'compiler'" {
+    // Compiler tarballs are the historical default for
+    // `tools/package.sh`; the new handler keeps that.
+    assert empty_dist_manifest().kind == "compiler";
+}
+
+test "empty_dist_manifest: numeric sizes default to 0" {
+    let m = empty_dist_manifest();
+    assert m.binary_size == 0;
+    assert m.tarball_size == 0;
+}
+
+// --------------------------------------------------------------
+// dist_manifest_to_json — schema invariants
+// --------------------------------------------------------------
+test "manifest_to_json: includes schema_version 1" {
+    let json = dist_manifest_to_json(empty_dist_manifest());
+    // schema_version is the contract for breaking changes.
+    assert _contains(json, "\"schema_version\":\"1\"");
+}
+
+test "manifest_to_json: round-trips name + kind + capsule" {
+    let mut m = empty_dist_manifest();
+    m.name = "sailfin-native";
+    m.kind = "compiler";
+    m.capsule_name = "sailfin";
+    let json = dist_manifest_to_json(m);
+    assert _contains(json, "\"name\":\"sailfin-native\"");
+    assert _contains(json, "\"kind\":\"compiler\"");
+    assert _contains(json, "\"capsule\":\"sailfin\"");
+}
+
+test "manifest_to_json: round-trips version + target + tarball" {
+    let mut m = empty_dist_manifest();
+    m.version = "0.5.10-alpha.2";
+    m.target = "linux-x86_64";
+    m.tarball = "sailfin-native-linux-x86_64-0.5.10-alpha.2.tar.gz";
+    let json = dist_manifest_to_json(m);
+    assert _contains(json, "\"version\":\"0.5.10-alpha.2\"");
+    assert _contains(json, "\"target\":\"linux-x86_64\"");
+    assert _contains(json, "\"tarball\":\"sailfin-native-linux-x86_64-0.5.10-alpha.2.tar.gz\"");
+}
+
+test "manifest_to_json: round-trips sha256 + sizes" {
+    let mut m = empty_dist_manifest();
+    m.sha256 = "abc123";
+    m.binary_size = 1895760;
+    m.tarball_size = 567890;
+    let json = dist_manifest_to_json(m);
+    assert _contains(json, "\"sha256\":\"abc123\"");
+    assert _contains(json, "\"binary_size\":1895760");
+    assert _contains(json, "\"tarball_size\":567890");
+}
+
+test "manifest_to_json: round-trips build_date" {
+    let mut m = empty_dist_manifest();
+    m.build_date = "2026-04-29T12:34:56Z";
+    let json = dist_manifest_to_json(m);
+    assert _contains(json, "\"build_date\":\"2026-04-29T12:34:56Z\"");
+}
+
+test "manifest_to_json: backslash + quote in fields escaped per RFC 8259" {
+    // Defends against a future regression that drops the JSON
+    // escape pass for these fields.
+    let mut m = empty_dist_manifest();
+    m.name = "weird\\name\"with-quotes";
+    let json = dist_manifest_to_json(m);
+    assert _contains(json, "\"name\":\"weird\\\\name\\\"with-quotes\"");
+}
+
+test "manifest_to_json: zero sizes serialise as 0 (not empty)" {
+    // Default-empty manifests round-trip with size: 0; consumers
+    // can rely on the field always being a number.
+    let json = dist_manifest_to_json(empty_dist_manifest());
+    assert _contains(json, "\"binary_size\":0");
+    assert _contains(json, "\"tarball_size\":0");
+}
+
+test "manifest_to_json: large sizes serialise as decimal integers" {
+    // Repeat-subtraction encoder handles multi-digit numbers.
+    let mut m = empty_dist_manifest();
+    m.binary_size = 12345678;
+    m.tarball_size = 987654321;
+    let json = dist_manifest_to_json(m);
+    assert _contains(json, "\"binary_size\":12345678");
+    assert _contains(json, "\"tarball_size\":987654321");
+}
+
+test "manifest_to_json: kind switches to 'binary' when set" {
+    // User-capsule binary mode uses kind="binary"; ensure the
+    // setter round-trips.
+    let mut m = empty_dist_manifest();
+    m.kind = "binary";
+    let json = dist_manifest_to_json(m);
+    assert _contains(json, "\"kind\":\"binary\"");
+}
+
+test "manifest_to_json: kind switches to 'library' when set" {
+    let mut m = empty_dist_manifest();
+    m.kind = "library";
+    let json = dist_manifest_to_json(m);
+    assert _contains(json, "\"kind\":\"library\"");
+}
+
+// --------------------------------------------------------------
+// Helpers
+// --------------------------------------------------------------
+fn _contains(haystack: string, needle: string) -> boolean {
+    if needle.length == 0 { return true; }
+    if haystack.length < needle.length { return false; }
+    let mut i: number = 0;
+    loop {
+        if i + needle.length > haystack.length { break; }
+        let mut j: number = 0;
+        let mut matches: boolean = true;
+        loop {
+            if j >= needle.length { break; }
+            if haystack[i + j] != needle[j] {
+                matches = false;
+                break;
+            }
+            j += 1;
+        }
+        if matches { return true; }
+        i += 1;
+    }
+    return false;
+}

--- a/docs/proposals/build-architecture.md
+++ b/docs/proposals/build-architecture.md
@@ -1372,9 +1372,20 @@ with `build.sh`, CI cache-hit floor) still stand and break down as:
   `sfn build -p` in CI and assert byte-for-byte parity vs `build.sh`
   + a cache-hit-rate floor on no-source-change reruns. Likely a
   nightly cron rather than per-PR to keep CI fast.
-- **C4 — `sfn package`.** Replaces `tools/package.sh` with a
-  Sailfin-native command that consumes a per-capsule manifest from
-  C2 and produces a tarball.
+- **C4 — `sfn package`** (v1 in flight). New Sailfin-native
+  `handle_package_command` in `cli_commands.sfn` produces the
+  same standalone-compiler tarball + sha256 + manifest shape
+  `tools/package.sh` does, plus a parallel codepath for user
+  capsules (`-p <capsule-path>`) driven off the C2c sidecar.
+  Manifest is now schema-versioned via `dist_manifest.sfn`
+  (`DistManifest.schema_version = "1"`) — adds `kind` (compiler /
+  binary / library), `capsule`, and `tarball` fields beyond
+  what `tools/package.sh` emitted. Installer-tarball mode
+  (compiler + runtime + import-context) is deferred to **C4b**.
+  Migration is staged: this PR ships the command alongside the
+  shell script; subsequent PRs flip `Makefile`'s `package` /
+  `ci-package` targets and `release.yml` over to `sfn package`,
+  then delete `tools/package.sh` after one release cycle.
 - **C5 — `sfn bench` + `sfn bootstrap`.** Replace
   `scripts/bench_compile.sh` and (for upgrade users) `install.sh`.
   After this, `scripts/build.sh` is the only build-related shell

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,6 +1,6 @@
 # Status
 
-Updated: April 29, 2026 (Stage C cache milestone + per-capsule layout shipped through C2b2 — PR1–1f / #254–#259, C2a / #261, C2b1 / #262, C2b2 / #263; C2c per-module sidecar entries in flight)
+Updated: April 29, 2026 (Stage C cache milestone + per-capsule layout shipped through C2c — PR1–1f / #254–#259, C2a / #261, C2b1 / #262, C2b2 / #263, C2c / #264; C4 `sfn package` v1 in flight)
 
 This document tracks what works today and what is in progress. It is the source
 of truth — consult it before editing docs, examples, or making claims about
@@ -148,7 +148,7 @@ feature availability.
     `test_build_json_schema.sh` /
     `test_capsule_artifact_sidecar.sh` `dep_ll_paths`
     file-exists assertions.
-  - **C2c (this PR)** — per-module sidecar entries.
+  - **C2c (#264)** — per-module sidecar entries.
     `CapsuleArtifactManifest.modules: [{slug, ir_path,
     cache_key}]` enumerates every dep `.ll` the build
     produced, so consumers (`sfn package` C4, `sfn lsp`,
@@ -162,6 +162,35 @@ feature availability.
     working). `obj_path` deferred — per-module `.o`s
     aren't materialised in the per-capsule tree today
     (only the cache has them, content-addressed).
+- **Stage C4 `sfn package` v1 (in flight, this PR).**
+  Sailfin-native command that produces a distributable tarball
+  + sha256 sidecar + JSON manifest. Two modes:
+  - **Compiler mode (no `-p`):** reads `compiler/capsule.toml`
+    for version, stages `bin/sailfin` + `bin/sfn` from
+    `--compiler-bin` (default `build/native/sailfin`), tars
+    them to `<out>/sailfin-native-<target>-<version>.tar.gz`.
+    Replaces the standalone-compiler half of
+    `tools/package.sh`.
+  - **User-capsule mode (`-p <path>`):** reads the C2c sidecar
+    at `<path>/build/capsules/<scope>/<name>/manifest.json`,
+    extracts `kind` + `out` to locate the artifact, stages
+    the binary or `obj/mod.o` plus the sidecar +
+    `capsule.toml` into a self-describing tarball at
+    `<out>/<sanitised-name>-<target>-<version>.tar.gz`. Falls
+    over with a clear error when the sidecar is missing
+    (hint: `sfn build -p <path>` first).
+  - **Manifest** is now schema-versioned via
+    `dist_manifest.sfn::DistManifest` (`schema_version: "1"`)
+    — adds `kind` (compiler / binary / library), `capsule`,
+    and `tarball` fields beyond `tools/package.sh`'s output.
+  - **Defers** to C4b: installer tarball (compiler + runtime
+    + import-context), cross-compile validation, auto-rebuild
+    on stale `--compiler-bin`. Run `make compile` (or `sfn
+    build -p <path>`) before `sfn package`.
+  - `tools/package.sh` and the Makefile's `package` /
+    `ci-package` targets are untouched in this PR; subsequent
+    PRs will flip them to call `sfn package`, then delete the
+    shell script after one release cycle.
 - `make compile` builds the compiler from a released seed. `make check`
   validates the seedcheck binary can run `hello-world.sfn` and pass the test suite.
 - **Deterministic self-hosting**: the compiler is a verified fixed point —

--- a/runtime/native/src/native_driver.c
+++ b/runtime/native/src/native_driver.c
@@ -481,7 +481,7 @@ int main(int argc, char **argv)
         const char *first = argv[1];
         bool is_cli = false;
 
-        if (strcmp(first, "emit") == 0 || strcmp(first, "emit-llvm-file") == 0 || strcmp(first, "build") == 0 || strcmp(first, "run") == 0 || strcmp(first, "test") == 0 || strcmp(first, "check") == 0 || strcmp(first, "version") == 0 || strcmp(first, "init") == 0 || strcmp(first, "publish") == 0 || strcmp(first, "add") == 0 || strcmp(first, "login") == 0 || strcmp(first, "config") == 0 || strcmp(first, "guillermo") == 0 || strcmp(first, "fmt") == 0)
+        if (strcmp(first, "emit") == 0 || strcmp(first, "emit-llvm-file") == 0 || strcmp(first, "build") == 0 || strcmp(first, "run") == 0 || strcmp(first, "test") == 0 || strcmp(first, "check") == 0 || strcmp(first, "version") == 0 || strcmp(first, "init") == 0 || strcmp(first, "publish") == 0 || strcmp(first, "package") == 0 || strcmp(first, "add") == 0 || strcmp(first, "login") == 0 || strcmp(first, "config") == 0 || strcmp(first, "guillermo") == 0 || strcmp(first, "fmt") == 0)
         {
             is_cli = true;
         }


### PR DESCRIPTION
## Summary

Stage C4 of the unified build architecture — `sfn package`, a Sailfin-native subcommand that produces a distributable tarball + sha256 sidecar + JSON manifest. Replaces the standalone-compiler half of `tools/package.sh`, plus a parallel codepath for user capsules driven off the C2c per-capsule sidecar.

```bash
# Compiler distribution (replaces tools/package.sh's first output):
sfn package --out dist
# → dist/sailfin-native-<target>-<version>.tar.gz + .sha256 + .manifest.json

# User capsule packaging (new — consumes the C2c sidecar):
sfn build -p ./my-widget                     # produces the sidecar
sfn package -p ./my-widget --out dist
# → dist/<sanitised-name>-<target>-<version>.tar.gz containing
#   bin/<exe> (or obj/mod.o), manifest.json (the sidecar),
#   and capsule.toml (self-describing).
```

### Layers

| Layer | Change |
|---|---|
| `compiler/src/dist_manifest.sfn` | **New** — `DistManifest` struct + `dist_manifest_to_json` encoder. `schema_version: "1"` adds `kind` (compiler/binary/library), `capsule`, `tarball` fields beyond what `tools/package.sh` emits. |
| `compiler/src/cli_commands.sfn` | New `handle_package_command` (~430 lines incl. helpers: `uname`-based target detection, sidecar JSON scanner anchored on `"<field>":"`, decimal size parser, capsule-name sanitiser). |
| `compiler/src/cli_main.sfn` | New `is_package` boolean + dispatch (mirrors `is_publish`). Usage string updated. |
| `runtime/native/src/native_driver.c` | `package` added to the C driver's CLI subcommand allowlist (without this, the driver hits the legacy `usage: sailfin [--emit ...]` fallback instead of delegating to `sailfin_cli_main__cli_main`). |

### Design choices

- **Deterministic staging** (`build/sailfin/.package-staging`) — easier to inspect failed runs, idempotent. `rm -rf` at start AND end so partial state can't bleed between runs.
- **No auto-rebuild** — packaging is downstream of `make compile` / `sfn build -p`. Auto-rebuilding from inside a Sailfin-native command shelling out to `make` is a bootstrapping smell; pre-conditions are stated in error messages instead.
- **Compiler reads `capsule.toml` directly** (not a sidecar) — the compiler's `[capsule].name = "sailfin"` is single-segment, so `is_safe_scope_name` rejects it and no sidecar exists. User capsules read the C2c sidecar (which is the authoritative resolved-build state).
- **Schema stays at "1"** — `DistManifest` is new; this PR establishes the v1 contract. `tools/package.sh`'s old manifest had no schema version, so this is a soft migration.

### Scope cuts deferred

- **C4b** — installer-tarball mode (compiler + runtime + import-context). The DistManifest's `kind` accommodates an `"installer"` value when that lands.
- **Cross-compile validation** — `--target` is parsed but not validated against the host today.
- **Makefile + release.yml migration** — this PR leaves `tools/package.sh` untouched so CI keeps working. Next PRs flip `make package` / `make ci-package` / `release.yml` over to `sfn package`, then delete the shell script after one release cycle confirms output shape parity.

## Test plan

- [x] `make compile` — self-host green
- [x] `make test-unit` — **79/79** (12 new C4 tests in `dist_manifest_test.sfn`)
- [x] `make test-integration` — **17/17**
- [x] `make test-e2e` — **20/20** (new `test_sfn_package.sh` adds 18 assertions spanning both modes + two error cases: missing `--compiler-bin`, missing sidecar)
- [x] `sfn fmt --check` clean on all touched .sfn files
- [x] Manual smoke: `sfn package --out /tmp/dist-test` produces a valid tarball + sha256 + manifest, jq parses it, sha256 round-trips
- [ ] Cloudflare Pages preview renders updated `docs/status.md` and `docs/proposals/build-architecture.md`

## Followups unblocked

- **Migrate `make package` / `make ci-package` / `release.yml`** to call `sfn package` and delete `tools/package.sh`.
- **C4b — installer mode** (`--installer` flag on the same handler).
- **C5 — `sfn bench` / `sfn bootstrap`** (parallel workstream; replaces the remaining `scripts/bench_compile.sh` + `install.sh`).

https://claude.ai/code/session_01Wtm6pciPANUjuJ4qS2LB2a
