### PR TITLE
Stage C4b: sfn package --installer mode

### DIFF
--- a/compiler/src/cli_commands.sfn
+++ b/compiler/src/cli_commands.sfn
@@ -851,6 +851,7 @@ fn handle_package_command(args: string[]) -> number ![io] {
     let mut out_dir: string = "dist";
     let mut compiler_bin: string = "build/native/sailfin";
     let mut capsule_path: string = "";
+    let mut installer_mode: boolean = false;
     let mut argi: number = 1;
     loop {
         if argi >= args.length { break; }
@@ -882,6 +883,11 @@ fn handle_package_command(args: string[]) -> number ![io] {
             argi += 2;
             continue;
         }
+        if strings_equal(a, "--installer") {
+            installer_mode = true;
+            argi += 1;
+            continue;
+        }
         if strings_equal(a, "-p") {
             if argi + 1 >= args.length {
                 print("sfn package: -p requires a capsule path");
@@ -892,8 +898,18 @@ fn handle_package_command(args: string[]) -> number ![io] {
             continue;
         }
         print("sfn package: unknown argument \"" + a + "\"");
-        print("usage: sfn package [--target T] [--out DIR] [--compiler-bin PATH] [-p <capsule-path>]");
+        print("usage: sfn package [--target T] [--out DIR] [--compiler-bin PATH] [--installer] [-p <capsule-path>]");
         return 2;
+    }
+
+    // `--installer` and `-p` are mutually exclusive: the installer
+    // tarball bundles compiler + runtime + import-context, which
+    // are all compiler-specific. A user capsule has no analogue.
+    if installer_mode {
+        if capsule_path.length > 0 {
+            print("sfn package: --installer is incompatible with -p");
+            return 2;
+        }
     }
 
     // Detect platform target if not overridden.
@@ -904,7 +920,10 @@ fn handle_package_command(args: string[]) -> number ![io] {
         return 1;
     }
 
-    // Routing: compiler vs user capsule.
+    // Routing: installer vs compiler vs user capsule.
+    if installer_mode {
+        return _package_installer(target, out_dir, compiler_bin);
+    }
     if capsule_path.length == 0 {
         return _package_compiler(target, out_dir, compiler_bin);
     }
@@ -1017,6 +1036,163 @@ fn _package_compiler(target: string, out_dir: string, compiler_bin: string) -> n
 
     let manifest_out = out_dir + "/" + stem + ".manifest.json";
     fs.writeFile(manifest_out, dist_manifest_to_json(manifest));
+
+    process.run(["rm", "-rf", staging]);
+
+    print("[package] created " + tarball);
+    print("[package] created " + tarball + ".sha256");
+    print("[package] created " + manifest_out);
+    return 0;
+}
+
+// Package the installer (Stage C4b) — replaces the second half of
+// `tools/package.sh`. Bundles the compiler binary together with
+// the C runtime sources, the prelude object, and the staged
+// import-context so a fresh-clone consumer can invoke
+// `install.sh` (or eventually `sfn bootstrap`) and get a
+// working compiler without rebuilding from a seed.
+//
+// Tarball name: `installer-<target>.tar.gz` (no version, matching
+// the historical `tools/package.sh` shape — the version is on
+// the bundled binary, not the dist artifact). Manifest is named
+// `installer-<target>.manifest.json` and reuses
+// `DistManifest.kind = "installer"` for downstream tooling that
+// needs to disambiguate tarball flavours.
+//
+// Tarball contents (under top-level `<root>/`, no wrapping dir
+// — `tar -czf <out> -C <staging> .` mirrors the original):
+//   - bin/sailfin, bin/sfn               — the compiler
+//   - runtime/native/                    — the full C runtime tree
+//   - runtime/native/obj/prelude.o       — pre-built prelude (if available)
+//   - import-context/                    — staged .sfn-asm tree (if available)
+//
+// Prelude + import-context are conditionally included: the
+// installer is producible from a freshly built compiler that
+// hasn't run a self-host pass yet, and downstream consumers can
+// regenerate both. `tools/package.sh` had the same conditional
+// inclusion.
+fn _package_installer(target: string, out_dir: string, compiler_bin: string) -> number ![io] {
+    if !fs.exists(compiler_bin) {
+        print("sfn package: compiler binary not found: " + compiler_bin);
+        print("hint: run `make compile` first");
+        return 1;
+    }
+    let manifest_path = "compiler/capsule.toml";
+    if !fs.exists(manifest_path) {
+        print("sfn package: missing " + manifest_path);
+        return 1;
+    }
+    let manifest_text = fs.readFile(manifest_path);
+    let version = toml_get_version(manifest_text);
+    let capsule_name = toml_get_name(manifest_text);
+    if version.length == 0 {
+        print("sfn package: missing version in compiler/capsule.toml");
+        return 1;
+    }
+    if !_is_safe_capsule_version_cmd(version) {
+        print("sfn package: rejecting unsafe version string \"" + version + "\"");
+        return 1;
+    }
+
+    let stem = "installer-" + target;
+    let staging = "build/sailfin/.installer-staging";
+    let staging_bin = staging + "/bin";
+    let staging_runtime = staging + "/runtime";
+    let staging_runtime_obj = staging + "/runtime/native/obj";
+    process.run(["rm", "-rf", staging]);
+    process.run(["mkdir", "-p", staging_bin]);
+    process.run(["mkdir", "-p", staging_runtime]);
+    let cp1 = process.run(["cp", "-f", compiler_bin, staging_bin + "/sailfin"]);
+    let cp2 = process.run(["cp", "-f", compiler_bin, staging_bin + "/sfn"]);
+    if cp1 != 0 {
+        print("sfn package: failed to stage sailfin binary");
+        process.run(["rm", "-rf", staging]);
+        return 1;
+    }
+    if cp2 != 0 {
+        print("sfn package: failed to stage sfn binary");
+        process.run(["rm", "-rf", staging]);
+        return 1;
+    }
+
+    // Full runtime tree. `cp -R src dest` copies the directory
+    // ITSELF into dest — so this lands at staging/runtime/native/.
+    if !fs.exists("runtime/native") {
+        print("sfn package: missing runtime/native (was the build run from the repo root?)");
+        process.run(["rm", "-rf", staging]);
+        return 1;
+    }
+    let cp_runtime = process.run(["cp", "-R", "runtime/native", staging_runtime]);
+    if cp_runtime != 0 {
+        print("sfn package: failed to copy runtime/native");
+        process.run(["rm", "-rf", staging]);
+        return 1;
+    }
+
+    // Pre-built prelude object — preferred from the selfhost
+    // tree (which the active build wrote), falling back to a
+    // legacy build/native/obj path. Optional: a clean checkout
+    // without a prior `make compile` won't have either.
+    let prelude_a = "build/selfhost/native/obj/runtime/prelude.o";
+    let prelude_b = "build/native/obj/runtime/prelude.o";
+    let mut prelude_src: string = "";
+    if fs.exists(prelude_a) { prelude_src = prelude_a; } else {
+        if fs.exists(prelude_b) { prelude_src = prelude_b; }
+    }
+    if prelude_src.length > 0 {
+        process.run(["mkdir", "-p", staging_runtime_obj]);
+        process.run(["cp", "-f", prelude_src, staging_runtime_obj + "/prelude.o"]);
+    }
+
+    // Staged import-context — only present after a self-host
+    // build has run. Tools consuming the installer can survive
+    // without it (they regenerate from the seed) but bundling
+    // saves a rebuild on first use.
+    if fs.exists("build/native/import-context") {
+        process.run(["cp", "-R", "build/native/import-context", staging
+            + "/import-context"]);
+    }
+
+    process.run(["mkdir", "-p", out_dir]);
+    let tarball = out_dir + "/" + stem + ".tar.gz";
+    let tar_rc = process.run(["tar", "-czf", tarball, "-C", staging, ".",]);
+    if tar_rc != 0 {
+        print("sfn package: tar failed (exit=" + number_to_string(tar_rc) + ")");
+        process.run(["rm", "-rf", staging]);
+        return 1;
+    }
+
+    let digest = _sha256_of_file_cmd(tarball);
+    if digest.length == 0 {
+        print("sfn package: failed to compute sha256 for " + tarball);
+        process.run(["rm", "-rf", staging]);
+        return 1;
+    }
+    fs.writeFile(tarball + ".sha256", digest + "\n");
+
+    // `binary_size` reports the bundled compiler binary's size.
+    // For an installer tarball this is the most useful "primary
+    // payload" measurement; the rest of the tarball (runtime
+    // sources, optional prelude/import-context) is supporting
+    // material with size already encoded in `tarball_size`.
+    let binary_size = _package_size_of_file(compiler_bin);
+    let tarball_size = _package_size_of_file(tarball);
+    let build_date = _shell_read_cmd("date -u +%Y-%m-%dT%H:%M:%SZ");
+
+    let mut dm = empty_dist_manifest();
+    dm.name = stem;
+    dm.kind = "installer";
+    dm.capsule_name = capsule_name;
+    dm.version = version;
+    dm.target = target;
+    dm.tarball = stem + ".tar.gz";
+    dm.sha256 = digest;
+    dm.binary_size = binary_size;
+    dm.tarball_size = tarball_size;
+    dm.build_date = build_date;
+
+    let manifest_out = out_dir + "/" + stem + ".manifest.json";
+    fs.writeFile(manifest_out, dist_manifest_to_json(dm));
 
     process.run(["rm", "-rf", staging]);
 

--- a/compiler/src/cli_commands.sfn
+++ b/compiler/src/cli_commands.sfn
@@ -1140,17 +1140,43 @@ fn _package_installer(target: string, out_dir: string, compiler_bin: string) -> 
         if fs.exists(prelude_b) { prelude_src = prelude_b; }
     }
     if prelude_src.length > 0 {
-        process.run(["mkdir", "-p", staging_runtime_obj]);
-        process.run(["cp", "-f", prelude_src, staging_runtime_obj + "/prelude.o"]);
+        // The prelude object's INCLUSION is conditional (it
+        // doesn't exist on a fresh checkout), but once we've
+        // committed to including it, a `mkdir`/`cp` failure is
+        // a bug — fail loudly rather than silently shipping
+        // an installer missing the expected `prelude.o`.
+        let mk_obj_dir = process.run(["mkdir", "-p", staging_runtime_obj]);
+        if mk_obj_dir != 0 {
+            print("sfn package: failed to create runtime obj staging dir");
+            process.run(["rm", "-rf", staging]);
+            return 1;
+        }
+        let cp_prelude = process.run(["cp", "-f", prelude_src, staging_runtime_obj
+            + "/prelude.o"]);
+        if cp_prelude != 0 {
+            print("sfn package: failed to stage prelude object from "
+                + prelude_src);
+            process.run(["rm", "-rf", staging]);
+            return 1;
+        }
     }
 
     // Staged import-context — only present after a self-host
     // build has run. Tools consuming the installer can survive
     // without it (they regenerate from the seed) but bundling
-    // saves a rebuild on first use.
+    // saves a rebuild on first use. Same logic as the prelude
+    // copy: presence is conditional, but once present a
+    // failed `cp -R` is a bug, not a soft skip.
     if fs.exists("build/native/import-context") {
-        process.run(["cp", "-R", "build/native/import-context", staging
+        let cp_import_ctx = process.run(["cp", "-R", "build/native/import-context", staging
             + "/import-context"]);
+        if cp_import_ctx != 0 {
+            print("sfn package: failed to stage import-context (cp exit="
+                + number_to_string(cp_import_ctx)
+                + ")");
+            process.run(["rm", "-rf", staging]);
+            return 1;
+        }
     }
 
     process.run(["mkdir", "-p", out_dir]);

--- a/compiler/src/cli_main.sfn
+++ b/compiler/src/cli_main.sfn
@@ -83,7 +83,7 @@ fn _usage() -> string {
     out = out + "  sfn add     [--dev] [--update] <capsule>\n";
     out = out + "  sfn publish [path]\n";
     out = out
-        + "  sfn package [--target T] [--out DIR] [--compiler-bin PATH] [-p <capsule-path>]\n";
+        + "  sfn package [--target T] [--out DIR] [--compiler-bin PATH] [--installer] [-p <capsule-path>]\n";
     out = out + "  sfn login   [token]\n";
     out = out + "  sfn config  <get|set|unset|list> [key] [value]\n";
     out = out + "\n";

--- a/compiler/tests/e2e/test_sfn_package.sh
+++ b/compiler/tests/e2e/test_sfn_package.sh
@@ -300,12 +300,15 @@ test_installer_tarball_contents() {
     # Installer contents must include bin/{sailfin,sfn} and
     # runtime/native/. Tar layout uses `-C <staging> .` so contents
     # appear at the tarball top level (no wrapping root dir).
+    # Some tar implementations (notably BSD `tar` on macOS) omit
+    # the leading `./` from `tar -tzf` output even when the
+    # archive was created with `-C <dir> .`; accept both forms.
     local listing
     listing="$(tar -tzf "$INSTALLER_TARBALL")"
-    echo "$listing" | grep -qE "^\\./bin/sailfin\$" || return 1
-    echo "$listing" | grep -qE "^\\./bin/sfn\$" || return 1
+    echo "$listing" | grep -qE "^(\\./)?bin/sailfin\$" || return 1
+    echo "$listing" | grep -qE "^(\\./)?bin/sfn\$" || return 1
     # Runtime tree present (any file under runtime/native/).
-    echo "$listing" | grep -qE "^\\./runtime/native/" || return 1
+    echo "$listing" | grep -qE "^(\\./)?runtime/native/" || return 1
 }
 run_test "installer tarball contains bin/sailfin + bin/sfn + runtime/native/" test_installer_tarball_contents
 

--- a/compiler/tests/e2e/test_sfn_package.sh
+++ b/compiler/tests/e2e/test_sfn_package.sh
@@ -247,6 +247,112 @@ test_user_capsule_manifest_kind() {
 }
 run_test "user-capsule manifest kind=library, capsule=demo/widget, name=demo-widget" test_user_capsule_manifest_kind
 
+# ---- Installer mode (Stage C4b) ----
+# Bundles the compiler with runtime sources, prelude (if available),
+# and import-context (if available). Replaces the second half of
+# `tools/package.sh` which produced `dist/installer-<target>.tar.gz`.
+INSTALLER_DIR="$SCRATCH/dist-installer"
+
+test_installer_package_succeeds() {
+    cd "$REPO_ROOT" || return 1
+    "$BINARY" package --installer --out "$INSTALLER_DIR" --compiler-bin "$BINARY" \
+        > "$SCRATCH/installer.stdout" 2> "$SCRATCH/installer.err"
+    local rc=$?
+    if [ "$rc" -ne 0 ]; then
+        echo "[test]   sfn package --installer exited with code $rc; stderr:" >&2
+        cat "$SCRATCH/installer.err" >&2
+        return $rc
+    fi
+}
+run_test "sfn package --installer succeeds" test_installer_package_succeeds
+
+# Discover installer artifacts. Use `|| true` so an empty glob can't
+# trip `set -e` and skip subsequent assertions.
+INSTALLER_TARBALL="$(ls "$INSTALLER_DIR"/installer-*.tar.gz 2>/dev/null | head -n 1 || true)"
+INSTALLER_TARBALL_STEM="$(basename "${INSTALLER_TARBALL%.tar.gz}" 2>/dev/null || echo "")"
+INSTALLER_MANIFEST="$INSTALLER_DIR/${INSTALLER_TARBALL_STEM}.manifest.json"
+
+test_installer_artifacts_exist() {
+    [ -f "$INSTALLER_TARBALL" ] || return 1
+    [ -f "${INSTALLER_TARBALL}.sha256" ] || return 1
+    [ -f "$INSTALLER_MANIFEST" ] || return 1
+}
+run_test "installer tarball + sha256 + manifest exist" test_installer_artifacts_exist
+
+test_installer_tarball_no_version_in_name() {
+    # `tools/package.sh` historically named the installer tarball
+    # `installer-<target>.tar.gz` with NO version. Locks that
+    # convention so the release workflow's path expectations
+    # (.github/workflows/ci.yml + release-tag.yml) keep working.
+    case "$INSTALLER_TARBALL_STEM" in
+        installer-*) ;;
+        *) return 1 ;;
+    esac
+    # The version should not appear in the stem.
+    if echo "$INSTALLER_TARBALL_STEM" | grep -q "$COMPILER_VERSION"; then
+        echo "[test]   installer stem unexpectedly contains version: $INSTALLER_TARBALL_STEM" >&2
+        return 1
+    fi
+}
+run_test "installer tarball name omits version (matches tools/package.sh)" test_installer_tarball_no_version_in_name
+
+test_installer_tarball_contents() {
+    # Installer contents must include bin/{sailfin,sfn} and
+    # runtime/native/. Tar layout uses `-C <staging> .` so contents
+    # appear at the tarball top level (no wrapping root dir).
+    local listing
+    listing="$(tar -tzf "$INSTALLER_TARBALL")"
+    echo "$listing" | grep -qE "^\\./bin/sailfin\$" || return 1
+    echo "$listing" | grep -qE "^\\./bin/sfn\$" || return 1
+    # Runtime tree present (any file under runtime/native/).
+    echo "$listing" | grep -qE "^\\./runtime/native/" || return 1
+}
+run_test "installer tarball contains bin/sailfin + bin/sfn + runtime/native/" test_installer_tarball_contents
+
+test_installer_manifest_kind() {
+    [ "$(jq -r .kind "$INSTALLER_MANIFEST")" = "installer" ] || return 1
+    [ "$(jq -r .capsule "$INSTALLER_MANIFEST")" = "sailfin" ] || return 1
+    [ "$(jq -r .version "$INSTALLER_MANIFEST")" = "$COMPILER_VERSION" ] || return 1
+    # `name` follows the tarball stem (no version), differentiating
+    # from the standalone-compiler manifest which has the version.
+    case "$(jq -r .name "$INSTALLER_MANIFEST")" in
+        installer-*) ;;
+        *) return 1 ;;
+    esac
+}
+run_test "installer manifest kind=installer, capsule=sailfin, name=installer-<target>" test_installer_manifest_kind
+
+test_installer_manifest_schema_v1() {
+    [ "$(jq -r .schema_version "$INSTALLER_MANIFEST")" = "1" ]
+}
+run_test "installer manifest schema_version is '1'" test_installer_manifest_schema_v1
+
+test_installer_sha256_matches() {
+    local manifest_hex sidecar_hex actual_hex
+    manifest_hex="$(jq -r .sha256 "$INSTALLER_MANIFEST")"
+    sidecar_hex="$(head -c 64 "${INSTALLER_TARBALL}.sha256")"
+    if command -v sha256sum >/dev/null 2>&1; then
+        actual_hex="$(sha256sum "$INSTALLER_TARBALL" | awk '{print $1}')"
+    else
+        actual_hex="$(shasum -a 256 "$INSTALLER_TARBALL" | awk '{print $1}')"
+    fi
+    [ "$manifest_hex" = "$sidecar_hex" ] && [ "$manifest_hex" = "$actual_hex" ]
+}
+run_test "installer sha256 matches across manifest, sidecar, and actual digest" test_installer_sha256_matches
+
+test_installer_with_p_errors() {
+    # `--installer` and `-p` are mutually exclusive. Lock that.
+    cd "$REPO_ROOT" || return 1
+    set +e
+    "$BINARY" package --installer -p . --out "$SCRATCH/dist-bad" \
+        > "$SCRATCH/bad.stdout" 2>&1
+    local rc=$?
+    set -e
+    [ "$rc" -ne 0 ] || return 1
+    grep -q "incompatible" "$SCRATCH/bad.stdout"
+}
+run_test "sfn package --installer -p errors out (mutual exclusion)" test_installer_with_p_errors
+
 # ---- Error cases ----
 
 test_missing_compiler_bin_errors() {

--- a/docs/proposals/build-architecture.md
+++ b/docs/proposals/build-architecture.md
@@ -1372,20 +1372,30 @@ with `build.sh`, CI cache-hit floor) still stand and break down as:
   `sfn build -p` in CI and assert byte-for-byte parity vs `build.sh`
   + a cache-hit-rate floor on no-source-change reruns. Likely a
   nightly cron rather than per-PR to keep CI fast.
-- **C4 — `sfn package`** (v1 in flight). New Sailfin-native
-  `handle_package_command` in `cli_commands.sfn` produces the
-  same standalone-compiler tarball + sha256 + manifest shape
-  `tools/package.sh` does, plus a parallel codepath for user
-  capsules (`-p <capsule-path>`) driven off the C2c sidecar.
-  Manifest is now schema-versioned via `dist_manifest.sfn`
-  (`DistManifest.schema_version = "1"`) — adds `kind` (compiler /
-  binary / library), `capsule`, and `tarball` fields beyond
-  what `tools/package.sh` emitted. Installer-tarball mode
-  (compiler + runtime + import-context) is deferred to **C4b**.
-  Migration is staged: this PR ships the command alongside the
-  shell script; subsequent PRs flip `Makefile`'s `package` /
-  `ci-package` targets and `release.yml` over to `sfn package`,
-  then delete `tools/package.sh` after one release cycle.
+- **C4 — `sfn package`.** Sailfin-native `handle_package_command`
+  in `cli_commands.sfn` produces tarballs + sha256 sidecars +
+  schema-versioned JSON manifests for three artifact shapes:
+    - **C4 v1 (#265, shipped).** Standalone compiler tarball
+      (`sailfin-native-<target>-<version>.tar.gz`) replacing
+      `tools/package.sh`'s first output, plus user-capsule
+      packaging (`-p <capsule-path>`) driven off the C2c
+      sidecar.
+    - **C4b (in flight).** `--installer` mode bundles the
+      compiler + `runtime/native/` + (if available) the prelude
+      `.o` + (if available) the staged `import-context/` into
+      `installer-<target>.tar.gz`, replacing the second half of
+      `tools/package.sh`. Tarball name omits the version
+      (matching the historical convention release-tag.yml +
+      ci.yml expect); manifest reuses
+      `DistManifest.kind = "installer"`. After C4b lands,
+      every output of `tools/package.sh` has a Sailfin-native
+      replacement, and the migration PR (Makefile + release.yml
+      → `sfn package` / `sfn package --installer`) becomes a
+      tight mechanical change followed by deleting the shell
+      script after one release cycle.
+  Manifest schema is `DistManifest.schema_version = "1"` — adds
+  `kind` (compiler / installer / binary / library), `capsule`,
+  and `tarball` fields beyond what `tools/package.sh` emitted.
 - **C5 — `sfn bench` + `sfn bootstrap`.** Replace
   `scripts/bench_compile.sh` and (for upgrade users) `install.sh`.
   After this, `scripts/build.sh` is the only build-related shell

--- a/docs/proposals/build-architecture.md
+++ b/docs/proposals/build-architecture.md
@@ -1389,10 +1389,12 @@ with `build.sh`, CI cache-hit floor) still stand and break down as:
       ci.yml expect); manifest reuses
       `DistManifest.kind = "installer"`. After C4b lands,
       every output of `tools/package.sh` has a Sailfin-native
-      replacement, and the migration PR (Makefile + release.yml
-      → `sfn package` / `sfn package --installer`) becomes a
-      tight mechanical change followed by deleting the shell
-      script after one release cycle.
+      replacement, and the migration PR (Makefile +
+      `.github/workflows/release-tag.yml` +
+      `.github/workflows/ci.yml` → `sfn package` /
+      `sfn package --installer`) becomes a tight mechanical
+      change followed by deleting the shell script after one
+      release cycle.
   Manifest schema is `DistManifest.schema_version = "1"` — adds
   `kind` (compiler / installer / binary / library), `capsule`,
   and `tarball` fields beyond what `tools/package.sh` emitted.

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,6 +1,6 @@
 # Status
 
-Updated: April 29, 2026 (Stage C cache milestone + per-capsule layout shipped through C2c — PR1–1f / #254–#259, C2a / #261, C2b1 / #262, C2b2 / #263, C2c / #264; C4 `sfn package` v1 in flight)
+Updated: April 29, 2026 (Stage C cache milestone + per-capsule layout + sfn package shipped — PR1–1f / #254–#259, C2a / #261, C2b1 / #262, C2b2 / #263, C2c / #264, C4 v1 / #265; C4b installer mode in flight)
 
 This document tracks what works today and what is in progress. It is the source
 of truth — consult it before editing docs, examples, or making claims about
@@ -162,15 +162,16 @@ feature availability.
     working). `obj_path` deferred — per-module `.o`s
     aren't materialised in the per-capsule tree today
     (only the cache has them, content-addressed).
-- **Stage C4 `sfn package` v1 (in flight, this PR).**
+- **Stage C4 `sfn package` (#265 + this PR).**
   Sailfin-native command that produces a distributable tarball
-  + sha256 sidecar + JSON manifest. Two modes:
-  - **Compiler mode (no `-p`):** reads `compiler/capsule.toml`
-    for version, stages `bin/sailfin` + `bin/sfn` from
-    `--compiler-bin` (default `build/native/sailfin`), tars
-    them to `<out>/sailfin-native-<target>-<version>.tar.gz`.
-    Replaces the standalone-compiler half of
-    `tools/package.sh`.
+  + sha256 sidecar + JSON manifest. Three modes:
+  - **Compiler mode (no `-p`, no `--installer`):** reads
+    `compiler/capsule.toml` for version, stages `bin/sailfin` +
+    `bin/sfn` from `--compiler-bin` (default
+    `build/native/sailfin`), tars them to
+    `<out>/sailfin-native-<target>-<version>.tar.gz`. Replaces
+    the standalone-compiler half of `tools/package.sh`. **C4 v1
+    (#265).**
   - **User-capsule mode (`-p <path>`):** reads the C2c sidecar
     at `<path>/build/capsules/<scope>/<name>/manifest.json`,
     extracts `kind` + `out` to locate the artifact, stages
@@ -178,19 +179,27 @@ feature availability.
     `capsule.toml` into a self-describing tarball at
     `<out>/<sanitised-name>-<target>-<version>.tar.gz`. Falls
     over with a clear error when the sidecar is missing
-    (hint: `sfn build -p <path>` first).
-  - **Manifest** is now schema-versioned via
+    (hint: `sfn build -p <path>` first). **C4 v1 (#265).**
+  - **Installer mode (`--installer`, this PR):** bundles the
+    compiler + `runtime/native/` + (when available) the
+    pre-built prelude `.o` + (when available) the staged
+    `import-context/` into `<out>/installer-<target>.tar.gz`.
+    No version in the tarball name (matches the historical
+    `tools/package.sh` shape consumed by `release-tag.yml` +
+    `ci.yml`); manifest carries `kind = "installer"`. Mutually
+    exclusive with `-p`. Replaces the second half of
+    `tools/package.sh` — after this lands, every output of the
+    shell script has a Sailfin-native equivalent.
+  - **Manifest** is schema-versioned via
     `dist_manifest.sfn::DistManifest` (`schema_version: "1"`)
-    — adds `kind` (compiler / binary / library), `capsule`,
-    and `tarball` fields beyond `tools/package.sh`'s output.
-  - **Defers** to C4b: installer tarball (compiler + runtime
-    + import-context), cross-compile validation, auto-rebuild
-    on stale `--compiler-bin`. Run `make compile` (or `sfn
-    build -p <path>`) before `sfn package`.
-  - `tools/package.sh` and the Makefile's `package` /
-    `ci-package` targets are untouched in this PR; subsequent
-    PRs will flip them to call `sfn package`, then delete the
-    shell script after one release cycle.
+    — adds `kind` (compiler / installer / binary / library),
+    `capsule`, and `tarball` fields beyond
+    `tools/package.sh`'s output.
+  - **Migration**: `tools/package.sh` and the Makefile's
+    `package` / `ci-package` targets stay untouched until C4b
+    lands; the next PR flips them to call `sfn package` /
+    `sfn package --installer`, then deletes the shell script
+    after one release cycle confirms output shape parity.
 - `make compile` builds the compiler from a released seed. `make check`
   validates the seedcheck binary can run `hello-world.sfn` and pass the test suite.
 - **Deterministic self-hosting**: the compiler is a verified fixed point —


### PR DESCRIPTION
## Summary

Stage C4b — finishes the `sfn package` story by adding installer-tarball mode. After this lands, every output of `tools/package.sh` has a Sailfin-native equivalent.

```bash
sfn package --installer --out dist
# → dist/installer-<target>.tar.gz
#       (top-level: bin/sailfin, bin/sfn, runtime/native/, runtime/native/obj/prelude.o, import-context/)
# → dist/installer-<target>.tar.gz.sha256
# → dist/installer-<target>.manifest.json    (kind="installer", schema_version="1")
```

### Layout & convention

| Aspect | Choice | Why |
|---|---|---|
| **Tarball name** | `installer-<target>.tar.gz` (no version) | Matches `tools/package.sh`'s convention; `release-tag.yml` (lines 148, 182-183, 190-191, 217, 224) and `ci.yml` (lines 272-273, 280-281) consume this exact path |
| **Tarball layout** | `tar -czf <out> -C <staging> .` (no wrapping root dir) | Mirrors the original; consumers untar and find `bin/`, `runtime/`, `import-context/` at the top |
| **Manifest `kind`** | `"installer"` (new value of existing `DistManifest.kind`) | C4 v1 already defined the field as open; downstream tooling routes by it |
| **Mutual exclusion** | `--installer` + `-p` errors out with "incompatible" | Installer is compiler-specific; user capsules have no analogue |
| **Conditional inclusion** | Prelude `.o` + `import-context/` only if present on disk | Both regenerable; bundling saves a rebuild on first use |
| **Schema** | Stays at `"1"` | `kind`'s value space was open; this is a new value, not a shape change |

### Reused C4 v1 infrastructure

- `_shell_single_quote_arg` for safe path interpolation in shell commands.
- `_sha256_of_file_cmd` (sha256sum → shasum -a 256 fallback) so this works on macOS without coreutils.
- `_is_safe_capsule_version_cmd` validation gate before composing the version into shell-bound paths.
- `DistManifest` + `dist_manifest_to_json` from `dist_manifest.sfn`.
- Deterministic staging dir (`build/sailfin/.installer-staging`) wiped at start AND end.

## Test plan

- [x] `make compile` — self-host green
- [x] `make test-unit` — **79/79**
- [x] `bash test_sfn_package.sh` — **26/26** (8 new installer assertions: succeeds, artifacts exist, name omits version, contents include bin/{sailfin,sfn} + runtime/native/, manifest fields/schema, sha256 matches across manifest/sidecar/disk, mutual-exclusion error)
- [x] `sfn fmt --check` clean on touched .sfn files
- [ ] Cloudflare Pages preview renders updated `docs/status.md` and `docs/proposals/build-architecture.md`

## Migration unblocked (next PR)

After this lands:
- `Makefile`'s `package` (line 475) and `ci-package` (line 510) targets flip from `tools/package.sh` to `build/native/sailfin package` + `build/native/sailfin package --installer`.
- `release-tag.yml` + `ci.yml` keep consuming `dist/installer-<target>.tar.gz` unchanged.
- `tools/package.sh` stays around as fallback for one release cycle, then retires.

After the migration PR + one release cycle, the only build-related shell scripts left are `scripts/build.sh` (Stage D cutover) and `scripts/bench_compile.sh` + `install.sh` (Stage C5).

https://claude.ai/code/session_01Wtm6pciPANUjuJ4qS2LB2a

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wtm6pciPANUjuJ4qS2LB2a)_