### PR TITLE
Stage D PR2: thread kind=runtime capsule artifacts through the driver

### DIFF
--- a/compiler/capsule.toml
+++ b/compiler/capsule.toml
@@ -4,6 +4,19 @@ version = "0.5.10-alpha.3"
 description = "The Sailfin compiler — self-hosted, targeting LLVM via .sfn-asm IR"
 
 [dependencies]
+# Stage D PR2: declare the C runtime as an explicit dependency so
+# `sfn build -p compiler` finds it through the workspace's
+# `kind = "runtime"` capsule discovery
+# (`compiler/src/runtime_capsule_resolver.sfn`). The driver
+# iterates every declared runtime capsule's `c-sources` /
+# `ll-sources` / `include-dirs` / `link-libs` and feeds them into
+# the link phase. `make compile` (which routes through
+# `scripts/build.sh`) is unaffected — that script walks
+# `runtime/native/src/*.c` directly. Stage D PR4 is when
+# `make compile` flips to `sfn build -p compiler` and this line
+# becomes the load-bearing pointer to the bootstrap's runtime
+# sources.
+"sfn/runtime-native" = "*"
 
 [capabilities]
 # `io` covers fs.*, print.*, console.*, and process.* surface used

--- a/compiler/src/capsule_resolver.sfn
+++ b/compiler/src/capsule_resolver.sfn
@@ -60,7 +60,8 @@ import {
     number_to_string,
     write_native_text_file_with_module
 } from "./main";
-import { substring } from "./string_utils";
+import { RuntimeCapsuleArtifacts, enumerate_runtime_capsule_artifacts } from "./runtime_capsule_resolver";
+import { contains_string, substring } from "./string_utils";
 import {
     toml_get_capabilities_required,
     toml_get_dependencies,
@@ -176,6 +177,16 @@ struct ProjectCapsuleResult {
     ll_paths: string[];
     stats: CacheStats;
     module_events: ModuleCacheEvent[];
+    // Stage D PR2: every `kind = "runtime"` capsule the project's
+    // `[dependencies]` declares (transitively, via the workspace
+    // member graph). Empty when the project doesn't declare any
+    // runtime dep — `cli_main.sfn::_clang_link_multi_with_opt`
+    // falls back to the legacy hardcoded `runtime_root/native/...`
+    // path that user-program builds rely on. Populated for the
+    // compiler when its `compiler/capsule.toml` declares
+    // `[dependencies] "sfn/runtime-native" = "*"`, which is what
+    // unblocks `sfn build -p compiler` as a real bootstrap path.
+    runtime_capsules: RuntimeCapsuleArtifacts[];
 }
 
 // One entry from the workspace's [workspace].members list, with the
@@ -551,6 +562,16 @@ fn _cr_collect_capsule_sources(src_dir: string, spec: string) -> CapsuleSource[]
 
 // Enumerate every .sfn source file for every dep declared in the project's
 // capsule.toml. Returns an empty list if no manifest or no deps.
+//
+// Stage D PR2: `kind = "runtime"` capsule deps (e.g.
+// `sfn/runtime-native` for the compiler) ship C / LL source — not
+// `.sfn` modules — so they contribute zero entries here. The
+// runtime capsule resolver picks them up separately via
+// `enumerate_runtime_capsule_artifacts`. We discover them
+// up-front via workspace.toml so the legacy
+// `_cr_locate_capsule_src` lookup below doesn't false-positive
+// on a runtime capsule name and emit a "could not locate source"
+// diagnostic.
 fn enumerate_capsule_sources(project_root: string) -> CapsuleSource[] ![io] {
     let mut sources: CapsuleSource[] = [];
     if project_root.length == 0 { return sources; }
@@ -559,10 +580,33 @@ fn enumerate_capsule_sources(project_root: string) -> CapsuleSource[] ![io] {
     let text = fs.readFile(manifest);
     let deps = toml_get_dependencies(text);
     let entries = _cr_parse_deps(deps);
+
+    // Discover every `kind = "runtime"` capsule the workspace
+    // exposes, so we can skip those names below. Empty when
+    // the project sits outside any workspace, which is the
+    // common case for end-user `sfn build` invocations and
+    // matches the pre-Stage-D behaviour exactly.
+    let workspace_root = discover_workspace_root(project_root);
+    let empty_specs: string[] = [];
+    let mut runtime_cap_names: string[] = [];
+    if workspace_root.length > 0 {
+        let runtime_caps = enumerate_runtime_capsule_artifacts(workspace_root, empty_specs);
+        let mut rci: number = 0;
+        loop {
+            if rci >= runtime_caps.length { break; }
+            runtime_cap_names.push(runtime_caps[rci].capsule_name);
+            rci += 1;
+        }
+    }
+
     let mut i: number = 0;
     loop {
         if i >= entries.length { break; }
         let entry = entries[i];
+        i += 1;
+        // Stage D PR2: skip runtime capsule deps — handled
+        // separately by `enumerate_runtime_capsule_artifacts`.
+        if contains_string(runtime_cap_names, entry.spec) { continue; }
         let src_dir = _cr_locate_capsule_src(project_root, entry.spec, entry.version);
         if src_dir.length > 0 {
             let found = _cr_collect_capsule_sources(src_dir, entry.spec);
@@ -578,7 +622,6 @@ fn enumerate_capsule_sources(project_root: string) -> CapsuleSource[] ![io] {
                 + entry.spec
                 + "` to populate the cache");
         }
-        i += 1;
     }
     return sources;
 }
@@ -2034,6 +2077,19 @@ struct ResolverDedupeResult {
     // "no capability surface to compare against" and skips the
     // E0403 cross-check.
     capabilities_required: string[];
+    // Stage D PR2: every declared `[dependencies]` key from the
+    // project's `capsule.toml`. `prepare_project_capsules` passes
+    // this through `enumerate_runtime_capsule_artifacts` so the
+    // returned `ProjectCapsuleResult.runtime_capsules` only
+    // contains workspace runtime capsules the project actually
+    // depends on. Empty for standalone files / projects without
+    // a manifest, which short-circuits the runtime-capsule lookup.
+    manifest_dep_specs: string[];
+    // Stage D PR2: workspace root discovered while walking the
+    // dep graph (or `""` if the project sits outside any
+    // workspace). Required for `enumerate_runtime_capsule_artifacts`,
+    // which reads `<workspace_root>/workspace.toml`.
+    workspace_root: string;
 }
 
 // Shared resolution + dedupe used by both `prepare_project_capsules`
@@ -2071,13 +2127,16 @@ struct ResolverDedupeResult {
 fn _cr_resolve_and_dedupe(entry_paths: string[], consumer: ResolverConsumer) -> ResolverDedupeResult ![io] {
     let mut sources: CapsuleSource[] = [];
     let empty_sources: CapsuleSource[] = [];
+    let empty_specs: string[] = [];
 
     let mut empty_caps: string[] = [];
     if entry_paths.length == 0 {
         return ResolverDedupeResult {
             sources: empty_sources,
             has_collision: false,
-            capabilities_required: empty_caps
+            capabilities_required: empty_caps,
+            manifest_dep_specs: empty_specs,
+            workspace_root: ""
         };
     }
 
@@ -2155,7 +2214,9 @@ fn _cr_resolve_and_dedupe(entry_paths: string[], consumer: ResolverConsumer) -> 
         return ResolverDedupeResult {
             sources: empty_sources,
             has_collision: false,
-            capabilities_required: capabilities_required
+            capabilities_required: capabilities_required,
+            manifest_dep_specs: covered_specs,
+            workspace_root: workspace_root
         };
     }
 
@@ -2187,7 +2248,9 @@ fn _cr_resolve_and_dedupe(entry_paths: string[], consumer: ResolverConsumer) -> 
                     return ResolverDedupeResult {
                         sources: empty_sources,
                         has_collision: true,
-                        capabilities_required: capabilities_required
+                        capabilities_required: capabilities_required,
+                        manifest_dep_specs: covered_specs,
+                        workspace_root: workspace_root
                     };
                 }
                 // Same slug AND same path → exact duplicate, drop silently.
@@ -2251,7 +2314,9 @@ fn _cr_resolve_and_dedupe(entry_paths: string[], consumer: ResolverConsumer) -> 
     return ResolverDedupeResult {
         sources: resolved,
         has_collision: false,
-        capabilities_required: capabilities_required
+        capabilities_required: capabilities_required,
+        manifest_dep_specs: covered_specs,
+        workspace_root: workspace_root
     };
 }
 
@@ -2267,20 +2332,37 @@ fn _cr_resolve_and_dedupe(entry_paths: string[], consumer: ResolverConsumer) -> 
 fn prepare_project_capsules(input_path: string, config: BuildCacheConfig, consumer: ResolverConsumer) -> ProjectCapsuleResult ![io] {
     let empty_paths: string[] = [];
     let empty_events: ModuleCacheEvent[] = [];
+    let empty_runtime_capsules: RuntimeCapsuleArtifacts[] = [];
     let entry_paths: string[] = [input_path];
     let resolved = _cr_resolve_and_dedupe(entry_paths, consumer);
     if resolved.has_collision {
         return ProjectCapsuleResult {
             ll_paths: empty_paths,
             stats: empty_cache_stats(),
-            module_events: empty_events
+            module_events: empty_events,
+            runtime_capsules: empty_runtime_capsules
         };
+    }
+    // Stage D PR2: surface every `kind = "runtime"` workspace
+    // member the project's `[dependencies]` declares. Filtered by
+    // `manifest_dep_specs` so end-user builds (no runtime dep
+    // declared) get an empty list and the link path falls through
+    // to the legacy `_clang_compile_runtime_objects` helper.
+    // Resolver-side discovery is the source of truth: the workspace
+    // root + the manifest's declared deps both come from
+    // `_cr_resolve_and_dedupe` already.
+    let mut runtime_capsules: RuntimeCapsuleArtifacts[] = [];
+    if resolved.workspace_root.length > 0 {
+        if resolved.manifest_dep_specs.length > 0 {
+            runtime_capsules = enumerate_runtime_capsule_artifacts(resolved.workspace_root, resolved.manifest_dep_specs);
+        }
     }
     if resolved.sources.length == 0 {
         return ProjectCapsuleResult {
             ll_paths: empty_paths,
             stats: empty_cache_stats(),
-            module_events: empty_events
+            module_events: empty_events,
+            runtime_capsules: runtime_capsules
         };
     }
 
@@ -2290,7 +2372,8 @@ fn prepare_project_capsules(input_path: string, config: BuildCacheConfig, consum
         return ProjectCapsuleResult {
             ll_paths: empty_paths,
             stats: empty_cache_stats(),
-            module_events: empty_events
+            module_events: empty_events,
+            runtime_capsules: runtime_capsules
         };
     }
     let result = compile_capsule_modules(resolved.sources, config);
@@ -2298,13 +2381,15 @@ fn prepare_project_capsules(input_path: string, config: BuildCacheConfig, consum
         return ProjectCapsuleResult {
             ll_paths: empty_paths,
             stats: result.stats,
-            module_events: result.module_events
+            module_events: result.module_events,
+            runtime_capsules: runtime_capsules
         };
     }
     return ProjectCapsuleResult {
         ll_paths: result.ll_paths,
         stats: result.stats,
-        module_events: result.module_events
+        module_events: result.module_events,
+        runtime_capsules: runtime_capsules
     };
 }
 

--- a/compiler/src/cli_main.sfn
+++ b/compiler/src/cli_main.sfn
@@ -327,7 +327,7 @@ struct RuntimeLinkInputs {
     success: boolean;
 }
 
-fn _empty_runtime_link_inputs() -> RuntimeLinkInputs {
+fn _failed_runtime_link_inputs() -> RuntimeLinkInputs {
     let empty: string[] = [];
     let empty2: string[] = [];
     return RuntimeLinkInputs {
@@ -337,14 +337,23 @@ fn _empty_runtime_link_inputs() -> RuntimeLinkInputs {
     };
 }
 
-fn _failed_runtime_link_inputs() -> RuntimeLinkInputs {
-    let empty: string[] = [];
-    let empty2: string[] = [];
-    return RuntimeLinkInputs {
-        object_paths: empty,
-        link_libs: empty2,
-        success: false
-    };
+// Compose a per-capsule cache-key prefix for the runtime-capsule
+// `.o` outputs. `"sfn/runtime-native"` → `"sfn__runtime-native__"`;
+// the trailing `__` separates the prefix from the source basename
+// in the cached object's filename. Empty input returns `""` so
+// the legacy hardcoded `_clang_compile_runtime_objects` path
+// stays bit-identical when no capsule artifacts are present.
+fn _runtime_obj_prefix(capsule_name: string) -> string {
+    if capsule_name.length == 0 { return ""; }
+    let mut out: string = "";
+    let mut i: number = 0;
+    loop {
+        if i >= capsule_name.length { break; }
+        let ch = substring(capsule_name, i, i + 1);
+        if ch == "/" { out = out + "__"; } else { out = out + ch; }
+        i += 1;
+    }
+    return out + "__";
 }
 
 // Compile every `c-sources` / `ll-sources` entry from a list of
@@ -375,13 +384,23 @@ fn _clang_compile_runtime_capsule_objects(runtime_capsules: RuntimeCapsuleArtifa
             include_flags.push("-I" + cap.include_dirs[idi]);
             idi += 1;
         }
-        // c-sources: clang -c each, cached by basename.
+        // Per-capsule prefix for cached `.o` filenames. Replaces
+        // `/` with `__` so the capsule name maps cleanly to a
+        // filesystem segment. With this prefix two capsules can
+        // declare same-basename sources without colliding (e.g.
+        // both shipping a `util.c`).
+        let cap_prefix = _runtime_obj_prefix(cap.capsule_name);
+        // c-sources: clang -c each, cached by capsule-prefix +
+        // full basename (extension included so `foo.c` and
+        // `foo.ll` from the same capsule don't collide on the
+        // same `.o` output).
         let mut ci: number = 0;
         loop {
             if ci >= cap.c_sources.length { break; }
             let src = cap.c_sources[ci];
-            let stem = _path_strip_ext(_path_basename(src));
-            let obj = _path_join(out_dir, stem + opt_flag + ".o");
+            let obj = _path_join(out_dir, cap_prefix + _path_basename(src)
+                + opt_flag
+                + ".o");
             if !fs.exists(obj) {
                 let mut args: string[] = ["clang", opt_flag, "-Wno-override-module"];
                 let mut fi: number = 0;
@@ -403,13 +422,16 @@ fn _clang_compile_runtime_capsule_objects(runtime_capsules: RuntimeCapsuleArtifa
             objects.push(obj);
             ci += 1;
         }
-        // ll-sources: assemble each via clang, also cached.
+        // ll-sources: assemble each via clang, also cached with
+        // the capsule prefix + full basename. `foo.ll` ≠
+        // `foo.c` because the basename includes the extension.
         let mut li: number = 0;
         loop {
             if li >= cap.ll_sources.length { break; }
             let src = cap.ll_sources[li];
-            let stem = _path_strip_ext(_path_basename(src));
-            let obj = _path_join(out_dir, stem + opt_flag + ".o");
+            let obj = _path_join(out_dir, cap_prefix + _path_basename(src)
+                + opt_flag
+                + ".o");
             if !fs.exists(obj) {
                 let rc = process.run(["clang", opt_flag, "-Wno-override-module", "-c", src, "-o", obj]);
                 if rc != 0 {
@@ -522,8 +544,28 @@ fn _clang_link_multi_with_opt(ll_paths: string[], out_path: string, runtime_root
         // the prelude continues to ship as a pre-built `.o`
         // located via `_runtime_prelude_path`. Stage D PR3+ or
         // Stage F retires that fallback.
+        //
+        // When the resolver returned runtime capsule artifacts
+        // (i.e. the project actually depends on a `kind =
+        // "runtime"` capsule), the prelude `.o` is REQUIRED for
+        // the link to succeed — the capsule's compiled C
+        // sources reference prelude-emitted symbols. Failing
+        // early with a targeted diagnostic is much easier to
+        // act on than letting clang complain about ~20
+        // undefined references later.
         let prelude_obj = _runtime_prelude_path(runtime_root);
-        if prelude_obj.length > 0 { runtime_objs.push(prelude_obj); }
+        if prelude_obj.length == 0 {
+            print("sfn build: prelude object not found under runtime_root=\""
+                + runtime_root
+                + "\"");
+            print("           expected one of: <root>/native/obj/prelude.o,");
+            print("                            <root>/native/obj/runtime/prelude.o,");
+            print("                            <parent>/build/native/obj/prelude.o,");
+            print("                            <parent>/build/selfhost/native/obj/prelude.o");
+            print("           hint: run `make compile` first so the selfhost build stages prelude.o");
+            return 1;
+        }
+        runtime_objs.push(prelude_obj);
     } else {
         if runtime_root.length == 0 {
             print("runtime bundle not found; set SAILFIN_RUNTIME_ROOT or install runtime alongside the binary");

--- a/compiler/src/cli_main.sfn
+++ b/compiler/src/cli_main.sfn
@@ -54,6 +54,7 @@ import {
     print_llvm_with_module,
     write_native_text_file_with_module
 } from "./main";
+import { RuntimeCapsuleArtifacts } from "./runtime_capsule_resolver";
 import {
     toml_get_build_kind,
     toml_get_entry,
@@ -281,6 +282,162 @@ fn _runtime_prelude_path(root: string) -> string ![io] {
     return "";
 }
 
+// Last `/`-separated segment of a path. Returns the input itself
+// when there's no slash. Used for naming runtime obj outputs after
+// their source basename, matching the legacy `_clang_compile_runtime_objects`
+// naming scheme so cached `.o`s coexist between the legacy and
+// artifact-driven paths during the Stage D transition.
+fn _path_basename(path: string) -> string {
+    let mut last_slash: number = -1;
+    let mut i: number = 0;
+    loop {
+        if i >= path.length { break; }
+        if path[i] == "/" { last_slash = i; }
+        i += 1;
+    }
+    if last_slash < 0 { return path; }
+    return substring(path, last_slash + 1, path.length);
+}
+
+// Strip the last `.<ext>` from a path's basename. `"foo.c"` →
+// `"foo"`; `"foo.tar.gz"` → `"foo.tar"` (last extension only).
+// Returns the input unchanged when there's no `.`.
+fn _path_strip_ext(name: string) -> string {
+    let mut last_dot: number = -1;
+    let mut i: number = 0;
+    loop {
+        if i >= name.length { break; }
+        if name[i] == "." { last_dot = i; }
+        i += 1;
+    }
+    if last_dot < 0 { return name; }
+    return substring(name, 0, last_dot);
+}
+
+// Stage D PR2: aggregated link-phase inputs from a project's
+// `kind = "runtime"` dep capsules. `object_paths` are the cached
+// `.o`s the runtime capsule's c-sources / ll-sources compiled
+// to; `link_libs` are the linker flags (e.g. `-lm`, `-lpthread`)
+// to append after the `.ll` inputs in the final clang invocation.
+// `success` is `false` when any clang sub-invocation exited
+// non-zero — the caller bails before invoking the final link.
+struct RuntimeLinkInputs {
+    object_paths: string[];
+    link_libs: string[];
+    success: boolean;
+}
+
+fn _empty_runtime_link_inputs() -> RuntimeLinkInputs {
+    let empty: string[] = [];
+    let empty2: string[] = [];
+    return RuntimeLinkInputs {
+        object_paths: empty,
+        link_libs: empty2,
+        success: false
+    };
+}
+
+fn _failed_runtime_link_inputs() -> RuntimeLinkInputs {
+    let empty: string[] = [];
+    let empty2: string[] = [];
+    return RuntimeLinkInputs {
+        object_paths: empty,
+        link_libs: empty2,
+        success: false
+    };
+}
+
+// Compile every `c-sources` / `ll-sources` entry from a list of
+// `kind = "runtime"` capsule artifacts and return the resulting
+// `.o` paths plus the accumulated `link-libs`. Caches `.o` outputs
+// under `out_dir` keyed by source basename + `opt_flag` so repeat
+// builds skip clang.
+//
+// Used only when the resolver returns at least one runtime capsule
+// artifact (i.e. the project's `[dependencies]` declared a
+// `kind = "runtime"` workspace member). For end-user `sfn build`
+// without a runtime dep, the caller falls through to the legacy
+// `_clang_compile_runtime_objects` helper that uses the
+// hardcoded `runtime_root/native/...` layout.
+fn _clang_compile_runtime_capsule_objects(runtime_capsules: RuntimeCapsuleArtifacts[], out_dir: string, opt_flag: string) -> RuntimeLinkInputs ![io] {
+    let mut objects: string[] = [];
+    let mut link_libs: string[] = [];
+    let mut i: number = 0;
+    loop {
+        if i >= runtime_capsules.length { break; }
+        let cap = runtime_capsules[i];
+        // `-I<dir>` for every include root the capsule declares.
+        // Threaded into every c-source compile in this capsule.
+        let mut include_flags: string[] = [];
+        let mut idi: number = 0;
+        loop {
+            if idi >= cap.include_dirs.length { break; }
+            include_flags.push("-I" + cap.include_dirs[idi]);
+            idi += 1;
+        }
+        // c-sources: clang -c each, cached by basename.
+        let mut ci: number = 0;
+        loop {
+            if ci >= cap.c_sources.length { break; }
+            let src = cap.c_sources[ci];
+            let stem = _path_strip_ext(_path_basename(src));
+            let obj = _path_join(out_dir, stem + opt_flag + ".o");
+            if !fs.exists(obj) {
+                let mut args: string[] = ["clang", opt_flag, "-Wno-override-module"];
+                let mut fi: number = 0;
+                loop {
+                    if fi >= include_flags.length { break; }
+                    args.push(include_flags[fi]);
+                    fi += 1;
+                }
+                args.push("-c");
+                args.push(src);
+                args.push("-o");
+                args.push(obj);
+                let rc = process.run(args);
+                if rc != 0 {
+                    print("sfn build: failed to compile runtime c-source " + src);
+                    return _failed_runtime_link_inputs();
+                }
+            }
+            objects.push(obj);
+            ci += 1;
+        }
+        // ll-sources: assemble each via clang, also cached.
+        let mut li: number = 0;
+        loop {
+            if li >= cap.ll_sources.length { break; }
+            let src = cap.ll_sources[li];
+            let stem = _path_strip_ext(_path_basename(src));
+            let obj = _path_join(out_dir, stem + opt_flag + ".o");
+            if !fs.exists(obj) {
+                let rc = process.run(["clang", opt_flag, "-Wno-override-module", "-c", src, "-o", obj]);
+                if rc != 0 {
+                    print("sfn build: failed to assemble runtime ll-source "
+                        + src);
+                    return _failed_runtime_link_inputs();
+                }
+            }
+            objects.push(obj);
+            li += 1;
+        }
+        // link-libs flow through verbatim (resolver doesn't
+        // path-resolve these — they're linker flags like `-lm`).
+        let mut bi: number = 0;
+        loop {
+            if bi >= cap.link_libs.length { break; }
+            link_libs.push(cap.link_libs[bi]);
+            bi += 1;
+        }
+        i += 1;
+    }
+    return RuntimeLinkInputs {
+        object_paths: objects,
+        link_libs: link_libs,
+        success: true
+    };
+}
+
 fn _clang_compile_runtime_objects(runtime_root: string, out_dir: string, opt_flag: string) -> string[] ![io] {
     // Build (or reuse) cached runtime object files so repeated `test` invocations
     // don't recompile the runtime C sources per test file.
@@ -327,23 +484,14 @@ fn _clang_compile_runtime_objects(runtime_root: string, out_dir: string, opt_fla
     return [runtime_obj, arena_obj, globals_obj, prelude_obj];
 }
 
-fn _clang_link_with_opt(ll_path: string, out_path: string, runtime_root: string, opt_flag: string, cache_dir: string) -> number ![io] {
+fn _clang_link_with_opt(ll_path: string, out_path: string, runtime_root: string, runtime_capsules: RuntimeCapsuleArtifacts[], opt_flag: string, cache_dir: string) -> number ![io] {
     // Thin wrapper: most callers have one .ll; capsule-aware callers use
     // _clang_link_multi_with_opt directly.
     let single: string[] = [ll_path];
-    return _clang_link_multi_with_opt(single, out_path, runtime_root, opt_flag, cache_dir);
+    return _clang_link_multi_with_opt(single, out_path, runtime_root, runtime_capsules, opt_flag, cache_dir);
 }
 
-fn _clang_link_multi_with_opt(ll_paths: string[], out_path: string, runtime_root: string, opt_flag: string, cache_dir: string) -> number ![io] {
-    if runtime_root.length == 0 {
-        print("runtime bundle not found; set SAILFIN_RUNTIME_ROOT or install runtime alongside the binary");
-        return 1;
-    }
-    if !_runtime_bundle_exists(runtime_root) {
-        print("runtime bundle missing expected files under: " + runtime_root);
-
-        return 1;
-    }
+fn _clang_link_multi_with_opt(ll_paths: string[], out_path: string, runtime_root: string, runtime_capsules: RuntimeCapsuleArtifacts[], opt_flag: string, cache_dir: string) -> number ![io] {
     if ll_paths.length == 0 {
         print("_clang_link_multi_with_opt: no input .ll files");
         return 1;
@@ -353,24 +501,66 @@ fn _clang_link_multi_with_opt(ll_paths: string[], out_path: string, runtime_root
     _ensure_dir("build");
     _ensure_dir("build/sailfin");
     _ensure_dir(cache_dir);
-    let cached = _clang_compile_runtime_objects(runtime_root, cache_dir, opt_flag);
-    let runtime_obj = cached[0];
-    let arena_obj = cached[1];
-    let globals_obj = cached[2];
-    let prelude_obj = cached[3];
 
-    let mut _if3: boolean = false;
-    if runtime_obj.length == 0 { _if3 = true; }
-    if arena_obj.length == 0 { _if3 = true; }
-    if globals_obj.length == 0 { _if3 = true; }
-    if prelude_obj.length == 0 { _if3 = true; }
-    if _if3 {
-        print("failed to build cached runtime objects");
-
-        return 1;
+    // Stage D PR2 routing: when the resolver surfaced runtime
+    // capsule artifacts (the project declared `[dependencies]
+    // "sfn/runtime-native"` etc.), use the declarative source
+    // lists. Otherwise fall through to the legacy hardcoded
+    // `runtime_root/native/...` layout that end-user `sfn build`
+    // relies on. The legacy path stays load-bearing for every
+    // build whose project doesn't declare a runtime dep — that's
+    // the steady-state until Stage F's runtime rewrite.
+    let mut runtime_objs: string[] = [];
+    let mut runtime_link_libs: string[] = [];
+    if runtime_capsules.length > 0 {
+        let inputs = _clang_compile_runtime_capsule_objects(runtime_capsules, cache_dir, opt_flag);
+        if !inputs.success { return 1; }
+        runtime_objs = inputs.object_paths;
+        runtime_link_libs = inputs.link_libs;
+        // The runtime capsule's `prelude-entry` field (Stage D
+        // PR1 transitional bridge) isn't yet consumed here —
+        // the prelude continues to ship as a pre-built `.o`
+        // located via `_runtime_prelude_path`. Stage D PR3+ or
+        // Stage F retires that fallback.
+        let prelude_obj = _runtime_prelude_path(runtime_root);
+        if prelude_obj.length > 0 { runtime_objs.push(prelude_obj); }
+    } else {
+        if runtime_root.length == 0 {
+            print("runtime bundle not found; set SAILFIN_RUNTIME_ROOT or install runtime alongside the binary");
+            return 1;
+        }
+        if !_runtime_bundle_exists(runtime_root) {
+            print("runtime bundle missing expected files under: " + runtime_root);
+            return 1;
+        }
+        let cached = _clang_compile_runtime_objects(runtime_root, cache_dir, opt_flag);
+        let runtime_obj = cached[0];
+        let arena_obj = cached[1];
+        let globals_obj = cached[2];
+        let prelude_obj = cached[3];
+        let mut _missing: boolean = false;
+        if runtime_obj.length == 0 { _missing = true; }
+        if arena_obj.length == 0 { _missing = true; }
+        if globals_obj.length == 0 { _missing = true; }
+        if prelude_obj.length == 0 { _missing = true; }
+        if _missing {
+            print("failed to build cached runtime objects");
+            return 1;
+        }
+        runtime_objs.push(runtime_obj);
+        runtime_objs.push(arena_obj);
+        runtime_objs.push(globals_obj);
+        runtime_objs.push(prelude_obj);
+        runtime_link_libs.push("-lm");
     }
 
-    let mut args: string[] = ["clang", opt_flag, "-Wno-override-module", runtime_obj, arena_obj, globals_obj, prelude_obj,];
+    let mut args: string[] = ["clang", opt_flag, "-Wno-override-module"];
+    let mut roi: number = 0;
+    loop {
+        if roi >= runtime_objs.length { break; }
+        args.push(runtime_objs[roi]);
+        roi += 1;
+    }
     let mut i: number = 0;
     loop {
         if i >= ll_paths.length { break; }
@@ -379,19 +569,24 @@ fn _clang_link_multi_with_opt(ll_paths: string[], out_path: string, runtime_root
     }
     args.push("-o");
     args.push(out_path);
-    args.push("-lm");
+    let mut lli: number = 0;
+    loop {
+        if lli >= runtime_link_libs.length { break; }
+        args.push(runtime_link_libs[lli]);
+        lli += 1;
+    }
     return process.run(args);
 }
 
-fn _clang_link(ll_path: string, out_path: string, runtime_root: string) -> number ![io] {
+fn _clang_link(ll_path: string, out_path: string, runtime_root: string, runtime_capsules: RuntimeCapsuleArtifacts[]) -> number ![io] {
     // Default link used by `build` and `run` for single-module programs.
-    return _clang_link_with_opt(ll_path, out_path, runtime_root, "-O2", "build/sailfin");
+    return _clang_link_with_opt(ll_path, out_path, runtime_root, runtime_capsules, "-O2", "build/sailfin");
 }
 
-fn _clang_link_multi(ll_paths: string[], out_path: string, runtime_root: string) -> number ![io] {
+fn _clang_link_multi(ll_paths: string[], out_path: string, runtime_root: string, runtime_capsules: RuntimeCapsuleArtifacts[]) -> number ![io] {
     // Default link used by `build` and `run` for multi-module programs
     // (main source + capsule dependency modules).
-    return _clang_link_multi_with_opt(ll_paths, out_path, runtime_root, "-O2", "build/sailfin");
+    return _clang_link_multi_with_opt(ll_paths, out_path, runtime_root, runtime_capsules, "-O2", "build/sailfin");
 }
 
 struct _CapsuleBuildSpec {
@@ -904,7 +1099,7 @@ fn sailfin_cli_main(argv: string[]) -> number ![io, clock] {
             all_lls.push(capsule_lls[cli]);
             cli += 1;
         }
-        let rc = _clang_link_multi(all_lls, exe_path, runtime_root);
+        let rc = _clang_link_multi(all_lls, exe_path, runtime_root, capsule_result.runtime_capsules);
         if rc != 0 {
             if !json_flag {
                 print("link failed (clang exit=" + number_to_string(rc) + ")");
@@ -1010,7 +1205,7 @@ fn sailfin_cli_main(argv: string[]) -> number ![io, clock] {
             all_lls.push(capsule_lls[rli]);
             rli += 1;
         }
-        let link_rc = _clang_link_multi(all_lls, exe_path, runtime_root);
+        let link_rc = _clang_link_multi(all_lls, exe_path, runtime_root, run_capsule_result.runtime_capsules);
         if link_rc != 0 {
             print("link failed (clang exit=" + number_to_string(link_rc) + ")");
             print("run: native link failed; attempting seed fallback via `sfn run`");

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,6 +1,6 @@
 # Status
 
-Updated: April 29, 2026 (Stage C complete through C4 migration — PR1–1f / #254–#259, C2a / #261, C2b1 / #262, C2b2 / #263, C2c / #264, C4 v1 / #265, C4b / #266, C4 migration / #267 retired `tools/package.sh`; Stage D PR1 `kind = "runtime"` capsule schema in flight)
+Updated: April 29, 2026 (Stage C complete through C4 migration; Stage D PR1 `kind = "runtime"` schema landed; Stage D PR2 driver-side runtime-capsule plumbing in flight — PR1–1f / #254–#259, C2a / #261, C2b1 / #262, C2b2 / #263, C2c / #264, C4 v1 / #265, C4b / #266, C4 migration / #267, D PR1 / #268)
 
 This document tracks what works today and what is in progress. It is the source
 of truth — consult it before editing docs, examples, or making claims about
@@ -206,23 +206,59 @@ feature availability.
     compile + installer logic — Windows-target support in
     `sfn package` is a follow-up (Stage D / late-C territory,
     requires `--target` validation against host).
-- **Stage D PR1 (in flight, this PR).** `kind = "runtime"`
-  capsule schema becomes a real, parsed manifest variant.
+- **Stage D PR1 (#268, shipped).** `kind = "runtime"` capsule
+  schema landed as a real, parsed manifest variant.
   `runtime/native/capsule.toml` is the first such capsule
-  (`name = "sfn/runtime-native"`); declares `c-sources`,
+  (`name = "sfn/runtime-native"`) declaring `c-sources`,
   `ll-sources`, `include-dirs`, `link-libs`, and a transitional
   `prelude-entry = "../prelude.sfn"`. New
   `compiler/src/runtime_capsule_resolver.sfn` exposes
   `enumerate_runtime_capsule_artifacts(workspace_root,
   dep_specs)` returning `RuntimeCapsuleArtifacts[]` with
-  workspace-rooted paths. **Pure foundation** — no production
-  call site invokes it yet (Stage D PR2 wires
-  `_clang_compile_runtime_objects` to consume the resolver
-  output). `cli_main.sfn`'s old "kind = runtime not yet
-  supported" rejection becomes a no-op + hint pointing the
-  user at the supported usage (declare it as a dep of a
-  `kind = "binary"` capsule). `make compile` is unchanged
-  (still uses `scripts/build.sh`).
+  workspace-rooted paths. Pure foundation — no production call
+  site invoked it yet.
+- **Stage D PR2 (in flight, this PR).** Driver-side wiring for
+  `kind = "runtime"` capsule deps:
+  - `compiler/capsule.toml` declares `[dependencies]
+    "sfn/runtime-native" = "*"` so the resolver picks the
+    runtime capsule up via the workspace's member list.
+  - `ProjectCapsuleResult` gains a `runtime_capsules:
+    RuntimeCapsuleArtifacts[]` field; `prepare_project_capsules`
+    populates it via `enumerate_runtime_capsule_artifacts`
+    filtered by the project's manifest deps.
+    `ResolverDedupeResult` carries the new `manifest_dep_specs`
+    + `workspace_root` so the lookup happens once per
+    resolution pass.
+  - New `_clang_compile_runtime_capsule_objects` helper
+    iterates declarative `c-sources` / `ll-sources` /
+    `include-dirs` / `link-libs` from each artifact, compiles
+    cached `.o` outputs, and threads `link-libs` into the
+    final clang invocation. `_clang_link_multi_with_opt` (and
+    its public wrappers) gain a `runtime_capsules` parameter:
+    when non-empty, the new path runs; when empty, the legacy
+    hardcoded `runtime_root/native/...` lookup stays
+    load-bearing for end-user `sfn build` (which doesn't
+    declare a runtime dep).
+  - `enumerate_capsule_sources` skips `kind = "runtime"`
+    workspace members so the legacy `_cr_locate_capsule_src`
+    lookup doesn't false-positive on runtime capsule names
+    and emit "could not locate source" diagnostics.
+  - `scripts/build.sh` gets a transitional one-line bridge to
+    skip the `sfn/runtime-native` dep when iterating
+    `[dependencies]` (it lives at `runtime/native/`, not
+    `capsules/sfn/runtime-native/`). The script retires in
+    Stage D PR4.
+  - **Verification gap intentional.** `sfn build -p compiler`
+    runs through every new code path and produces a partial
+    binary, but the link line is missing the compiler's CLI
+    modules (cli_main.sfn, capsule_resolver.sfn, etc.) because
+    `compiler/src/main.sfn`'s transitive import graph doesn't
+    cover them — `scripts/build.sh` walks
+    `compiler/src/**/*.sfn` directly, while the resolver only
+    walks reachable imports. Closing this gap (a binary-capsule
+    `src/` walker for `kind = "binary"` projects) is the
+    Stage D PR3 scope. `make compile` (build.sh path) is
+    unchanged and remains the active bootstrap.
 - `make compile` builds the compiler from a released seed. `make check`
   validates the seedcheck binary can run `hello-world.sfn` and pass the test suite.
 - **Deterministic self-hosting**: the compiler is a verified fixed point —

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -460,6 +460,18 @@ if [[ "$IS_WORKER" -eq 0 ]]; then
     #     them up here once the compiler actually takes a third-party dep.
     while IFS= read -r dep; do
         [[ -n "$dep" ]] || continue
+        # Stage D PR2 transitional bridge: `sfn/runtime-native`
+        # lives at `runtime/native/`, not under `capsules/`, and
+        # ships C source — not `.sfn` modules — so it's already
+        # handled later by the dedicated C-runtime compile step.
+        # The `sfn build` driver discovers it via workspace.toml +
+        # `runtime_capsule_resolver.sfn`; this script keeps using
+        # its hardcoded `runtime/native/...` paths until Stage D
+        # PR4 retires it. Skipping here matches the runtime
+        # capsule's contract: no `.sfn` sources to enumerate.
+        if [[ "$dep" == "sfn/runtime-native" ]]; then
+            continue
+        fi
         cap_dir="$CAPSULES_DIR/$dep/src"
         if [[ ! -d "$cap_dir" ]]; then
             if [[ "$dep" == sfn/* ]]; then


### PR DESCRIPTION
## Summary

Wires Stage D PR1's `runtime_capsule_resolver` into the actual build pipeline. After this lands, the driver is **architecturally** ready to compile `kind = "runtime"` capsule deps (C/LL sources, include dirs, link libs all flow declaratively from `capsule.toml`); a follow-up (PR3) closes the remaining `kind = "binary"` `src/` walk gap so `sfn build -p compiler` actually produces a working binary.

| Layer | Change |
|---|---|
| `compiler/capsule.toml` | Declares `[dependencies] "sfn/runtime-native" = "*"` |
| `ResolverDedupeResult` | New `manifest_dep_specs: string[]` + `workspace_root: string` (single resolver pass surfaces both) |
| `ProjectCapsuleResult` | New `runtime_capsules: RuntimeCapsuleArtifacts[]` (filtered by manifest deps) |
| `cli_main.sfn` | New `_clang_compile_runtime_capsule_objects` + `RuntimeLinkInputs`; `_clang_link_multi_with_opt` (and public wrappers) gain a `runtime_capsules` parameter |
| `enumerate_capsule_sources` | Skips workspace members whose `kind = "runtime"` (avoids "could not locate source" false-positive on `sfn/runtime-native`) |
| `scripts/build.sh` | One-line transitional bridge to skip `sfn/runtime-native` while iterating `[dependencies]` (retires in PR4) |

## Routing

| Build path | runtime_capsules | Behaviour |
|---|---|---|
| End-user `sfn build` (no manifest dep) | `[]` | Legacy hardcoded `_clang_compile_runtime_objects` path — **unchanged** |
| `sfn build -p compiler` | `[sfn/runtime-native]` | New declarative path: compiles all 5 C sources + assembles `runtime_globals.ll`, threads `-lm` to the linker, falls back to `_runtime_prelude_path` for the prelude (Stage F retires that fallback) |

## Test plan

- [x] `make compile` — green (104s; `build.sh` path unaffected)
- [x] `make test-unit` — **80/80** (12 PR1 resolver tests still green under the new threading)
- [x] `sfn fmt --check` clean on touched .sfn files
- [x] End-user smoke tests: `sfn run examples/basics/hello-world.sfn` and `sfn build -p capsules/sfn/math` both green
- [ ] Cloudflare Pages preview renders updated `docs/status.md`

### Intentional verification gap

`sfn build -p compiler` runs through every new code path and produces a partial binary, but the link line is missing `cli_main.sfn` / `cli_check.sfn` / `capsule_resolver.sfn` / etc. because `compiler/src/main.sfn` doesn't transitively import them. `scripts/build.sh` walks `compiler/src/**/*.sfn` directly; the resolver only walks reachable relative imports.

Closing this gap — a binary-capsule `src/` walker so `kind = "binary"` projects enumerate sources Cargo-style — is **Stage D PR3**'s scope. Until then `make compile` (build.sh path) stays the active bootstrap and PR2's wiring is exercised via unit tests only.

## What's next

- **Stage D PR3** — binary-capsule `src/` walk so `sfn build -p compiler` produces a complete link line.
- **Stage D PR4** — bump `.seed-version` after a fresh seed cut; flip `make compile` to `sfn build -p compiler`.
- **Stage D PR5** — delete `scripts/build.sh`; collapse `ci-cross-windows`.

https://claude.ai/code/session_01Wtm6pciPANUjuJ4qS2LB2a

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wtm6pciPANUjuJ4qS2LB2a)_