### PR TITLE
Stage D PR3: binary-capsule src/ walker + subprocess-per-module compile

### DIFF
--- a/compiler/src/capsule_resolver.sfn
+++ b/compiler/src/capsule_resolver.sfn
@@ -147,7 +147,11 @@ struct ResolverConsumer {
 }
 
 fn empty_resolver_consumer() -> ResolverConsumer {
-    return ResolverConsumer { scope: "", name: "", walk_project_src: false };
+    return ResolverConsumer {
+        scope: "",
+        name: "",
+        walk_project_src: false
+    };
 }
 
 // Result of `compile_capsule_modules`: per-build .ll paths plus the
@@ -1784,10 +1788,30 @@ fn enumerate_binary_capsule_sources(project_root: string, entry_path: string) ->
     // pattern uniform across the file.
     let mut dir_queue: string[] = [src_dir];
     let mut head: number = 0;
-    let max_depth: number = 32;
+    // Belt-and-suspenders cap on the BFS — guards against a
+    // pathological symlink loop or a runaway listDirectory binding.
+    // Sized for `compiler/src/` (137 files, 7 directories at the
+    // time of writing) plus generous headroom; mirrors
+    // `enumerate_relative_sources`'s diagnostic shape so a hit
+    // surfaces a clear bug-report hook instead of silently
+    // dropping reachable modules. The previous implementation used
+    // `head >= max_depth` with `max_depth = 32`, which capped on
+    // QUEUE INDEX (not tree depth) and would silently truncate any
+    // project with more than 32 directories under `src/`.
+    let max_iterations: number = 4096;
+    let mut iterations: number = 0;
     loop {
         if head >= dir_queue.length { break; }
-        if head >= max_depth { break; }
+        if iterations >= max_iterations {
+            print.err("capsule-resolver: enumerate_binary_capsule_sources hit "
+                + "iteration cap ("
+                + number_to_string(max_iterations)
+                + ") under "
+                + src_dir
+                + " — some sources may be missing; please file a bug");
+            break;
+        }
+        iterations += 1;
         let dir = dir_queue[head];
         head += 1;
         if !fs.exists(dir) { continue; }
@@ -1814,9 +1838,7 @@ fn enumerate_binary_capsule_sources(project_root: string, entry_path: string) ->
                 // non-directory returns an empty list, which we
                 // skip naturally.
                 let child_entries = fs.listDirectory(full);
-                if child_entries.length > 0 {
-                    dir_queue.push(full);
-                }
+                if child_entries.length > 0 { dir_queue.push(full); }
             }
             i += 1;
         }

--- a/compiler/src/capsule_resolver.sfn
+++ b/compiler/src/capsule_resolver.sfn
@@ -984,25 +984,90 @@ fn _cr_compile_one(src: CapsuleSource, dep_manifests: string[], cache_root_path:
 
     let mut ok: boolean = false;
     if sailfin_exe.length > 0 {
-        // Stage D PR3: subprocess-per-module compile. The fresh
-        // arena per child process is what makes a 138-module
-        // self-build viable in 8 GB — see the function-level
-        // comment for the OOM rationale. `--module-name` carries
-        // `src.slug` through so cross-capsule deps (whose slug is
-        // `<scope>/<name>/<sub>`, NOT `module_name_from_path`)
-        // mangle their symbols identically to the in-process path.
-        let rc = process.run([sailfin_exe, "emit", "--module-name", src.slug, "-o", src.ll_path, "llvm", src.source_path]);
-        if rc == 0 {
-            // Subprocess success ≠ valid output: an empty file
-            // means the lowering bailed without exit code (matches
-            // build.sh's stricter post-emit check). Treat empty as
-            // a compile failure so the caller sees a coherent
-            // bail event rather than letting clang surface the
-            // problem 30 modules later as a missing-symbol error.
-            if fs.exists(src.ll_path) {
-                let probe = fs.readFile(src.ll_path);
-                if probe.length > 0 { ok = true; }
+        // Stage D PR3: subprocess-per-module compile with retry.
+        // The fresh arena per child process is what makes a
+        // 138-module self-build viable in 8 GB — see the
+        // function-level comment for the OOM rationale.
+        // `--module-name` carries `src.slug` through so cross-
+        // capsule deps (whose slug is `<scope>/<name>/<sub>`, NOT
+        // `module_name_from_path`) mangle their symbols
+        // identically to the in-process path.
+        //
+        // Retry covers a known seed flake: the seed compiler
+        // intermittently emits IR with stray non-ASCII bytes
+        // mid-body (e.g. `define void 嘆name()`), which clang
+        // rejects at link time as "expected function name". The
+        // failure is non-deterministic and a simple re-emit
+        // typically produces clean output. `scripts/build.sh`
+        // applies the same retry shape (`EMIT_RETRIES=3`) for
+        // exactly this reason. Validation runs `llvm-as` on the
+        // emitted file as a cheap mid-file IR check; the empty-
+        // file probe survives as a fast pre-`llvm-as` filter so
+        // we don't pay parser cost on an obviously-broken output.
+        let max_attempts: number = 3;
+        let mut attempt: number = 0;
+        loop {
+            if ok { break; }
+            if attempt >= max_attempts { break; }
+            attempt += 1;
+            let rc = process.run([sailfin_exe, "emit", "--module-name", src.slug, "-o", src.ll_path, "llvm", src.source_path]);
+            if rc != 0 {
+                if config.trace {
+                    print.err("[emit retry] " + src.slug + " attempt "
+                        + number_to_string(attempt)
+                        + "/"
+                        + number_to_string(max_attempts)
+                        + " — exit="
+                        + number_to_string(rc));
+                }
+                continue;
             }
+            if !fs.exists(src.ll_path) {
+                if config.trace {
+                    print.err("[emit retry] " + src.slug + " attempt "
+                        + number_to_string(attempt)
+                        + "/"
+                        + number_to_string(max_attempts)
+                        + " — missing output");
+                }
+                continue;
+            }
+            let probe = fs.readFile(src.ll_path);
+            if probe.length == 0 {
+                if config.trace {
+                    print.err("[emit retry] " + src.slug + " attempt "
+                        + number_to_string(attempt)
+                        + "/"
+                        + number_to_string(max_attempts)
+                        + " — empty output");
+                }
+                continue;
+            }
+            // Mid-file validation via llvm-as (cheap parse, no
+            // codegen). Non-zero exit means clang would reject
+            // this IR at link time — a re-emit typically lands
+            // clean. Best-effort: if `llvm-as` isn't available
+            // (return code 127 from the shell), skip validation
+            // and trust the empty-file probe above.
+            let validate_rc = process.run(["sh", "-c", "llvm-as < " + src.ll_path
+                + " > /dev/null 2>&1"]);
+            if validate_rc != 0 {
+                if validate_rc == 127 {
+                    // llvm-as not on PATH — accept the output and
+                    // let downstream clang surface any IR issues.
+                    ok = true;
+                    break;
+                }
+                if config.trace {
+                    print.err("[emit retry] " + src.slug + " attempt "
+                        + number_to_string(attempt)
+                        + "/"
+                        + number_to_string(max_attempts)
+                        + " — llvm-as rejected output");
+                }
+                continue;
+            }
+            ok = true;
         }
     } else {
         let source = fs.readFile(src.source_path);

--- a/compiler/src/capsule_resolver.sfn
+++ b/compiler/src/capsule_resolver.sfn
@@ -85,6 +85,7 @@ export {
     discover_project_root,
     discover_workspace_root,
     empty_resolver_consumer,
+    enumerate_binary_capsule_sources,
     enumerate_capsule_sources,
     enumerate_relative_sources,
     enumerate_workspace_implicit_sources,
@@ -129,13 +130,24 @@ struct CapsuleSource {
 // `cli_main.sfn::is_build` populates this from the resolved
 // `[capsule].name`; `sfn run`, `sfn check`, and `sfn test` pass the
 // empty consumer until they grow `-p` plumbing of their own.
+//
+// Stage D PR3: `walk_project_src` opts the resolver into a
+// recursive walk of `<project_root>/src/**/*.sfn` for `kind =
+// "binary"` `-p` builds where the entry module doesn't transitively
+// import every source in the capsule (the compiler's `main.sfn` is
+// the canonical example — it imports `cli_main`, which is the real
+// entry, but the relative-import walker can't reach the `~138 .sfn`
+// files the link needs). Empty consumer / `walk_project_src=false`
+// preserves the legacy entry-driven enumeration, so end-user
+// builds and the existing self-host paths are unaffected.
 struct ResolverConsumer {
     scope: string;
     name: string;
+    walk_project_src: boolean;
 }
 
 fn empty_resolver_consumer() -> ResolverConsumer {
-    return ResolverConsumer { scope: "", name: "" };
+    return ResolverConsumer { scope: "", name: "", walk_project_src: false };
 }
 
 // Result of `compile_capsule_modules`: per-build .ll paths plus the
@@ -909,7 +921,20 @@ fn _cr_module_cache_event_failure(slug: string) -> ModuleCacheEvent {
 // compiling, and stores the result on a clean compile. Returns a
 // `ModuleCacheEvent` describing the outcome so the caller can
 // accumulate stats across the build.
-fn _cr_compile_one(src: CapsuleSource, dep_manifests: string[], cache_root_path: string, config: BuildCacheConfig, compiler_version: string, flags_canonical: string) -> ModuleCacheEvent ![io] {
+//
+// Stage D PR3: when `sailfin_exe.length > 0`, every fresh compile
+// shells out to `<sailfin_exe> emit --module-name <slug> -o <ll>
+// llvm <src>` instead of calling `compile_to_llvm_file_with_module`
+// in-process. That mirrors `scripts/build.sh`'s subprocess-per-
+// module pattern (line 650) and gives each compile a fresh arena —
+// without it, a 138-module self-build accumulates ~7+ GB of
+// arena state in a single process and OOMs around the 135th
+// module. Empty `sailfin_exe` falls back to in-process compile so
+// `handle_check_command` / `handle_test_command` callers (which
+// don't yet have `binary_dir` plumbed) keep their existing path;
+// their typical capsule dep counts are well under the in-process
+// budget.
+fn _cr_compile_one(src: CapsuleSource, dep_manifests: string[], cache_root_path: string, config: BuildCacheConfig, compiler_version: string, flags_canonical: string, sailfin_exe: string) -> ModuleCacheEvent ![io] {
     if !fs.exists(src.source_path) {
         print.err("capsule-resolver: missing source file: " + src.source_path);
         return _cr_module_cache_event_failure(src.slug);
@@ -953,8 +978,32 @@ fn _cr_compile_one(src: CapsuleSource, dep_manifests: string[], cache_root_path:
         }
     }
 
-    let source = fs.readFile(src.source_path);
-    let ok = compile_to_llvm_file_with_module(source, src.slug, src.ll_path);
+    let mut ok: boolean = false;
+    if sailfin_exe.length > 0 {
+        // Stage D PR3: subprocess-per-module compile. The fresh
+        // arena per child process is what makes a 138-module
+        // self-build viable in 8 GB — see the function-level
+        // comment for the OOM rationale. `--module-name` carries
+        // `src.slug` through so cross-capsule deps (whose slug is
+        // `<scope>/<name>/<sub>`, NOT `module_name_from_path`)
+        // mangle their symbols identically to the in-process path.
+        let rc = process.run([sailfin_exe, "emit", "--module-name", src.slug, "-o", src.ll_path, "llvm", src.source_path]);
+        if rc == 0 {
+            // Subprocess success ≠ valid output: an empty file
+            // means the lowering bailed without exit code (matches
+            // build.sh's stricter post-emit check). Treat empty as
+            // a compile failure so the caller sees a coherent
+            // bail event rather than letting clang surface the
+            // problem 30 modules later as a missing-symbol error.
+            if fs.exists(src.ll_path) {
+                let probe = fs.readFile(src.ll_path);
+                if probe.length > 0 { ok = true; }
+            }
+        }
+    } else {
+        let source = fs.readFile(src.source_path);
+        ok = compile_to_llvm_file_with_module(source, src.slug, src.ll_path);
+    }
     if !ok {
         print.err("capsule-resolver: failed to lower " + src.slug
             + " to LLVM IR");
@@ -1003,7 +1052,7 @@ fn _cr_compile_one(src: CapsuleSource, dep_manifests: string[], cache_root_path:
 // env-driven behaviour. Honours `config.clean` by wiping the cache
 // root before any per-module work — done once per build, not per
 // module, so a single `--clean` run can't double-wipe.
-fn compile_capsule_modules(sources: CapsuleSource[], config: BuildCacheConfig) -> CompileCapsuleResult ![io] {
+fn compile_capsule_modules(sources: CapsuleSource[], config: BuildCacheConfig, sailfin_exe: string) -> CompileCapsuleResult ![io] {
     _cr_ensure_dir("build/sailfin");
     _cr_ensure_dir("build/sailfin/capsules");
     // Per-source dep manifests (PR1e): each `_cr_compile_one` call
@@ -1058,7 +1107,7 @@ fn compile_capsule_modules(sources: CapsuleSource[], config: BuildCacheConfig) -
     let mut i: number = 0;
     loop {
         if i >= sources.length { break; }
-        let evt = _cr_compile_one(sources[i], per_source_dep_manifests[i], cache_root_path, config, compiler_version, flags_canonical);
+        let evt = _cr_compile_one(sources[i], per_source_dep_manifests[i], cache_root_path, config, compiler_version, flags_canonical, sailfin_exe);
         if !evt.success {
             // Stage C2c: even on the bail path we surface the
             // events accumulated so far. Sidecar emission is
@@ -1694,6 +1743,87 @@ fn enumerate_relative_sources(entry_path: string) -> CapsuleSource[] ![io] {
     return out;
 }
 
+// Stage D PR3: walk every `.sfn` under `<project_root>/src/` for
+// `kind = "binary"` `-p` builds (opt-in via
+// `ResolverConsumer.walk_project_src`). The relative-import walker
+// above can only see modules transitively reachable from the
+// `[build] entry`; the compiler's `compiler/src/main.sfn` reaches
+// `compile_to_llvm_*` but never imports `cli_main` (the actual
+// driver) or any of the CLI subcommand modules, so an entry-driven
+// build leaves ~100 source files out of the link and clang
+// surfaces the gap as a wall of undefined references. Directory-
+// level enumeration mirrors what `scripts/build.sh` already does
+// — every `.sfn` under `compiler/src/` is fed into the build,
+// regardless of whether anything imports it.
+//
+// Slugs come from the same `_cr_relative_slug` helper the
+// relative-import walker uses, which delegates to
+// `module_name_from_path`. That gives a slug rooted at
+// `compiler/src/` (e.g. `cli_main`, `llvm/lowering/entrypoints`)
+// — so when a file IS reachable from the entry, the
+// relative-import walk and this walker emit the same slug for it
+// and `_cr_resolve_and_dedupe`'s slug-collision check sees them
+// as exact duplicates (same path + same slug → silent dedupe).
+//
+// `entry_path` is forwarded to `_cr_relative_slug` for parameter
+// stability with the existing call shape; the helper ignores its
+// `entry_dir` argument and slugs purely off `module_name_from_path`,
+// so this walker stays in lockstep regardless of which entry the
+// `-p` resolution picked.
+fn enumerate_binary_capsule_sources(project_root: string, entry_path: string) -> CapsuleSource[] ![io] {
+    let mut out: CapsuleSource[] = [];
+    if project_root.length == 0 { return out; }
+    let src_dir = _cr_path_join(project_root, "src");
+    if !fs.exists(src_dir) { return out; }
+    let entry_dir = _cr_dirname(entry_path);
+
+    // Iterative BFS, mirroring `_cr_collect_capsule_sources`. The
+    // seed compiler has historically been brittle around recursive
+    // accumulators, and the parallel queue layout (dir + nothing
+    // else here, since slugs come from the file path) keeps the
+    // pattern uniform across the file.
+    let mut dir_queue: string[] = [src_dir];
+    let mut head: number = 0;
+    let max_depth: number = 32;
+    loop {
+        if head >= dir_queue.length { break; }
+        if head >= max_depth { break; }
+        let dir = dir_queue[head];
+        head += 1;
+        if !fs.exists(dir) { continue; }
+        let entries = fs.listDirectory(dir);
+        let mut i: number = 0;
+        loop {
+            if i >= entries.length { break; }
+            let entry = entries[i];
+            let full = _cr_path_join(dir, entry);
+            if _cr_ends_with(entry, ".sfn") {
+                // Skip the entry path itself — the caller compiles
+                // it via the standard single-file path. Matches the
+                // contract in `enumerate_relative_sources` so the
+                // dedupe loop never sees the entry twice.
+                if !strings_equal(full, entry_path) {
+                    let slug = _cr_relative_slug(entry_dir, full);
+                    out.push(CapsuleSource {
+                        spec: "", source_path: full, slug: slug, ll_path: ""
+                    });
+                }
+            } else {
+                // Treat anything without a .sfn suffix as a
+                // potential subdirectory. listDirectory on a
+                // non-directory returns an empty list, which we
+                // skip naturally.
+                let child_entries = fs.listDirectory(full);
+                if child_entries.length > 0 {
+                    dir_queue.push(full);
+                }
+            }
+            i += 1;
+        }
+    }
+    return out;
+}
+
 // ---- Scoped (capsule) import scanning ----
 // Sibling of `collect_relative_import_specs` that returns specs containing
 // `/` and not starting with `./`, `../`, or `runtime/`. These are the
@@ -2165,6 +2295,33 @@ fn _cr_resolve_and_dedupe(entry_paths: string[], consumer: ResolverConsumer) -> 
     let anchor_dir = _cr_dirname(entry_paths[0]);
 
     let project_root = discover_project_root(anchor_dir);
+
+    // (1b) Stage D PR3: opt-in `<project_root>/src/**/*.sfn` walk
+    // for `kind = "binary"` `-p` builds. The relative-import
+    // walker only follows modules transitively imported from the
+    // entry, but the compiler's `main.sfn` doesn't import every
+    // CLI / lowering module the link needs. Walking `src/`
+    // directly closes that gap — and emits the same slugs the
+    // relative-import walker would, so any module the entry DOES
+    // reach gets dedupe-collapsed cleanly below. Off by default;
+    // `cli_main.sfn` sets `walk_project_src` only when `-p` is
+    // used and the resolved kind is binary.
+    if consumer.walk_project_src {
+        if project_root.length > 0 {
+            let mut bei: number = 0;
+            loop {
+                if bei >= entry_paths.length { break; }
+                let bin_sources = enumerate_binary_capsule_sources(project_root, entry_paths[bei]);
+                let mut bsi: number = 0;
+                loop {
+                    if bsi >= bin_sources.length { break; }
+                    sources.push(bin_sources[bsi]);
+                    bsi += 1;
+                }
+                bei += 1;
+            }
+        }
+    }
     let mut covered_specs: string[] = [];
     let mut capabilities_required: string[] = [];
     if project_root.length > 0 {
@@ -2329,7 +2486,7 @@ fn _cr_resolve_and_dedupe(entry_paths: string[], consumer: ResolverConsumer) -> 
 // missing-symbol follow-up downstream. Inspect `stats` (and any
 // `print.err` output the helpers emitted) for setup failures vs.
 // genuinely-empty dep graphs.
-fn prepare_project_capsules(input_path: string, config: BuildCacheConfig, consumer: ResolverConsumer) -> ProjectCapsuleResult ![io] {
+fn prepare_project_capsules(input_path: string, config: BuildCacheConfig, consumer: ResolverConsumer, sailfin_exe: string) -> ProjectCapsuleResult ![io] {
     let empty_paths: string[] = [];
     let empty_events: ModuleCacheEvent[] = [];
     let empty_runtime_capsules: RuntimeCapsuleArtifacts[] = [];
@@ -2376,7 +2533,7 @@ fn prepare_project_capsules(input_path: string, config: BuildCacheConfig, consum
             runtime_capsules: runtime_capsules
         };
     }
-    let result = compile_capsule_modules(resolved.sources, config);
+    let result = compile_capsule_modules(resolved.sources, config, sailfin_exe);
     if !result.success {
         return ProjectCapsuleResult {
             ll_paths: empty_paths,
@@ -2495,7 +2652,7 @@ fn prepare_project_capsules_for_check(entry_paths: string[], consumer: ResolverC
 //     own compile path still runs, and any relative-import walking
 //     happens inside the per-entry `enumerate_relative_sources`
 //     branch of `_cr_resolve_and_dedupe`.
-fn prepare_project_capsules_for_test(entry_paths: string[], consumer: ResolverConsumer) -> TestCapsuleResolution ![io] {
+fn prepare_project_capsules_for_test(entry_paths: string[], consumer: ResolverConsumer, sailfin_exe: string) -> TestCapsuleResolution ![io] {
     let empty_paths: string[] = [];
     let resolved = _cr_resolve_and_dedupe(entry_paths, consumer);
     // Phase F: thread `capabilities_required` through every exit
@@ -2547,7 +2704,7 @@ fn prepare_project_capsules_for_test(entry_paths: string[], consumer: ResolverCo
     // env-driven default. When the test runner grows `--no-cache`
     // / `--clean`, thread the resolved config in here.
     let test_config = empty_build_cache_config();
-    let result = compile_capsule_modules(resolved.sources, test_config);
+    let result = compile_capsule_modules(resolved.sources, test_config, sailfin_exe);
     // Surface a compile failure as `staging_failed = true` so the
     // test runner exits 2 instead of trying to link against
     // missing helper objects. (The PR1c stats are dropped on this

--- a/compiler/src/cli_commands.sfn
+++ b/compiler/src/cli_commands.sfn
@@ -358,7 +358,13 @@ fn handle_test_command(args: string[], runtime_root: string) -> number ![io] {
         // legacy flat layout (Stage C2b2). Test-time link continues
         // to consume `build/sailfin/capsules/<mangled>.ll` until
         // `sfn test -p` ships.
-        let resolution = prepare_project_capsules_for_test(groups[gi].entry_paths, empty_resolver_consumer());
+        // Stage D PR3: `sfn test` runs from the legacy `make test`
+        // path that does not thread `binary_dir` through, so pass
+        // an empty `sailfin_exe`. The resolver falls back to the
+        // in-process compile path that has worked for tests since
+        // Stage C2c — test fixtures stay well below the per-module
+        // count where arena pressure becomes an issue.
+        let resolution = prepare_project_capsules_for_test(groups[gi].entry_paths, empty_resolver_consumer(), "");
         if resolution.staging_failed {
             // Resolver already emitted a structured error to stderr
             // (slug collision, stage-write, or compile failure).

--- a/compiler/src/cli_main.sfn
+++ b/compiler/src/cli_main.sfn
@@ -72,7 +72,7 @@ fn _usage() -> string {
     out = out
         + "  sfn run   [--no-cache] [--clean] [--cache-trace] (<file.sfn> | <exe>)\n";
     out = out
-        + "  sfn emit  [--timing] [-o OUTPUT] llvm|sailfin|native <file.sfn>\n";
+        + "  sfn emit  [--timing] [-o OUTPUT] [--module-name SLUG] llvm|sailfin|native <file.sfn>\n";
     out = out + "\n";
     out = out + "project:\n";
     out = out + "  sfn init\n";
@@ -831,15 +831,30 @@ fn sailfin_cli_main(argv: string[]) -> number ![io, clock] {
     if is_emit {
         let mut timing = false;
         let mut out_path = "";
+        // Stage D PR3: explicit module name override. Lets the
+        // resolver's per-module compile (`_cr_compile_one`) shell
+        // out to a fresh subprocess for arena isolation while
+        // preserving the slug-based module name needed for symbol
+        // mangling of cross-capsule deps (where the slug is
+        // `<scope>/<name>/<rest>`, not what `module_name_from_path`
+        // would derive). Empty / not provided → fall back to
+        // `module_name_from_path(path)` so all existing call sites
+        // (humans + tests + build.sh) keep their current shape.
+        let mut module_name_override: string = "";
         let mut base_index = 1;
-        // Parse optional flags: --timing and -o <path> (either order)
-        if base_index < args.length {
+        // Parse optional flags: --timing, --module-name <slug>, and
+        // -o <path> in any order.
+        let mut consumed_flag: boolean = true;
+        loop {
+            if !consumed_flag { break; }
+            if base_index >= args.length { break; }
+            consumed_flag = false;
             if strings_equal(args[base_index], "--timing") {
                 timing = true;
                 base_index += 1;
+                consumed_flag = true;
+                continue;
             }
-        }
-        if base_index < args.length {
             if strings_equal(args[base_index], "-o") {
                 base_index += 1;
                 if base_index >= args.length {
@@ -848,13 +863,19 @@ fn sailfin_cli_main(argv: string[]) -> number ![io, clock] {
                 }
                 out_path = args[base_index];
                 base_index += 1;
+                consumed_flag = true;
+                continue;
             }
-        }
-        // Allow --timing after -o as well
-        if base_index < args.length {
-            if strings_equal(args[base_index], "--timing") {
-                timing = true;
+            if strings_equal(args[base_index], "--module-name") {
                 base_index += 1;
+                if base_index >= args.length {
+                    print(_usage());
+                    return 2;
+                }
+                module_name_override = args[base_index];
+                base_index += 1;
+                consumed_flag = true;
+                continue;
             }
         }
         let _expected_args = base_index + 2;
@@ -872,7 +893,10 @@ fn sailfin_cli_main(argv: string[]) -> number ![io, clock] {
             return 1;
         }
         let source = fs.readFile(path);
-        let module_name = module_name_from_path(path);
+        let mut module_name = module_name_from_path(path);
+        if module_name_override.length > 0 {
+            module_name = module_name_override;
+        }
         let has_out = out_path.length > 0;
         if strings_equal(mode, "llvm") {
             if has_out {
@@ -1036,13 +1060,26 @@ fn sailfin_cli_main(argv: string[]) -> number ![io, clock] {
         // Both `out_path` and dep `.ll` routing fall back to the
         // legacy flat layout when the name isn't scope-form (e.g.
         // the compiler's own `[capsule].name = "sailfin"`).
-        let mut consumer = empty_resolver_consumer();
+        // Stage D PR3: opt the resolver into walking
+        // `<project_root>/src/**/*.sfn` for any `-p` build of a
+        // `kind = "binary"` capsule. The compiler is the canonical
+        // case — `compiler/src/main.sfn` doesn't transitively
+        // import every `.sfn` under `compiler/src/` (notably
+        // `cli_main.sfn` and the CLI subcommand modules), so the
+        // entry-driven relative-import walker would miss them and
+        // the link would surface 100+ undefined references. Library
+        // builds keep the entry-driven enumeration for now — they
+        // produce a single unlinked `.o` whose multi-file story
+        // shakes out the same way intra-project imports do today.
+        let walk_src = capsule_path.length > 0 && !is_runtime_build && !is_library_build;
+        let mut consumer = ResolverConsumer { scope: "", name: "", walk_project_src: walk_src };
         if cap_capsule_name.length > 0 {
             let parts0 = parse_scope_name(cap_capsule_name);
             if is_safe_scope_name(parts0.scope, parts0.name) {
                 consumer = ResolverConsumer {
                     scope: parts0.scope,
-                    name: parts0.name
+                    name: parts0.name,
+                    walk_project_src: walk_src
                 };
             }
         }
@@ -1093,7 +1130,16 @@ fn sailfin_cli_main(argv: string[]) -> number ![io, clock] {
         // capsule.toml before compiling the main source. stage_capsule_imports
         // writes .sfn-asm + .layout-manifest into build/native/import-context/
         // where the main module's lowering will find them.
-        let capsule_result = prepare_project_capsules(input_path, cache_config, consumer);
+        //
+        // Stage D PR3: when `binary_dir` is set (i.e. invoked via the
+        // C driver, which always passes `--binary-dir`), pass the
+        // sailfin executable path through so the resolver can shell
+        // out per-module instead of compiling them in-process. That
+        // is what makes `sfn build -p compiler` viable in 8 GB —
+        // see `_cr_compile_one`'s function-level comment.
+        let mut sailfin_exe: string = "";
+        if binary_dir.length > 0 { sailfin_exe = binary_dir + "/sailfin"; }
+        let capsule_result = prepare_project_capsules(input_path, cache_config, consumer, sailfin_exe);
         let capsule_lls = capsule_result.ll_paths;
 
         let ll_path = "build/sailfin/program.ll";
@@ -1228,7 +1274,13 @@ fn sailfin_cli_main(argv: string[]) -> number ![io, clock] {
         // always empty: relative-import `.ll`s take the legacy
         // flat layout (Stage C2b2). When `sfn run -p` lands, this
         // becomes a one-line update mirroring `sfn build`.
-        let run_capsule_result = prepare_project_capsules(input_path, run_cache_config, empty_resolver_consumer());
+        // Stage D PR3: thread the sailfin executable path so per-
+        // module compiles get fresh arenas. `sfn run` calls
+        // through the same resolver and benefits from the same
+        // isolation when a project has many capsule deps.
+        let mut run_sailfin_exe: string = "";
+        if binary_dir.length > 0 { run_sailfin_exe = binary_dir + "/sailfin"; }
+        let run_capsule_result = prepare_project_capsules(input_path, run_cache_config, empty_resolver_consumer(), run_sailfin_exe);
         let capsule_lls = run_capsule_result.ll_paths;
 
         let source = fs.readFile(input_path);

--- a/compiler/src/cli_main.sfn
+++ b/compiler/src/cli_main.sfn
@@ -1135,14 +1135,20 @@ fn sailfin_cli_main(argv: string[]) -> number ![io, clock] {
         // writes .sfn-asm + .layout-manifest into build/native/import-context/
         // where the main module's lowering will find them.
         //
-        // Stage D PR3: when `binary_dir` is set (i.e. invoked via the
-        // C driver, which always passes `--binary-dir`), pass the
-        // sailfin executable path through so the resolver can shell
-        // out per-module instead of compiling them in-process. That
-        // is what makes `sfn build -p compiler` viable in 8 GB —
-        // see `_cr_compile_one`'s function-level comment.
+        // Stage D PR3: subprocess-per-module compile is gated on
+        // `walk_src` (true only for `-p` builds of `kind = "binary"`
+        // capsules), not just `binary_dir`. The 138-module
+        // self-host needs each compile in a fresh arena to fit in
+        // 8 GB, but a typical end-user positional build (a handful
+        // of capsule deps) fits in-process and shouldn't pay the
+        // subprocess spawn cost — and shouldn't have its arena
+        // state perturbed by `process.run`'s argv allocations
+        // either, which has been observed to surface seed-corruption
+        // flakes in the entry's in-process compile downstream.
         let mut sailfin_exe: string = "";
-        if binary_dir.length > 0 { sailfin_exe = binary_dir + "/sailfin"; }
+        if walk_src {
+            if binary_dir.length > 0 { sailfin_exe = binary_dir + "/sailfin"; }
+        }
         let capsule_result = prepare_project_capsules(input_path, cache_config, consumer, sailfin_exe);
         let capsule_lls = capsule_result.ll_paths;
 
@@ -1278,13 +1284,12 @@ fn sailfin_cli_main(argv: string[]) -> number ![io, clock] {
         // always empty: relative-import `.ll`s take the legacy
         // flat layout (Stage C2b2). When `sfn run -p` lands, this
         // becomes a one-line update mirroring `sfn build`.
-        // Stage D PR3: thread the sailfin executable path so per-
-        // module compiles get fresh arenas. `sfn run` calls
-        // through the same resolver and benefits from the same
-        // isolation when a project has many capsule deps.
-        let mut run_sailfin_exe: string = "";
-        if binary_dir.length > 0 { run_sailfin_exe = binary_dir + "/sailfin"; }
-        let run_capsule_result = prepare_project_capsules(input_path, run_cache_config, empty_resolver_consumer(), run_sailfin_exe);
+        // Stage D PR3: `sfn run` keeps the in-process compile
+        // path. Subprocess-per-module is gated to `-p` binary
+        // builds only (see the `walk_src` branch above for the
+        // rationale) — `sfn run` doesn't take `-p` yet, and its
+        // typical use case is small fixtures that fit in-process.
+        let run_capsule_result = prepare_project_capsules(input_path, run_cache_config, empty_resolver_consumer(), "");
         let capsule_lls = run_capsule_result.ll_paths;
 
         let source = fs.readFile(input_path);

--- a/compiler/src/cli_main.sfn
+++ b/compiler/src/cli_main.sfn
@@ -1072,7 +1072,11 @@ fn sailfin_cli_main(argv: string[]) -> number ![io, clock] {
         // produce a single unlinked `.o` whose multi-file story
         // shakes out the same way intra-project imports do today.
         let walk_src = capsule_path.length > 0 && !is_runtime_build && !is_library_build;
-        let mut consumer = ResolverConsumer { scope: "", name: "", walk_project_src: walk_src };
+        let mut consumer = ResolverConsumer {
+            scope: "",
+            name: "",
+            walk_project_src: walk_src
+        };
         if cap_capsule_name.length > 0 {
             let parts0 = parse_scope_name(cap_capsule_name);
             if is_safe_scope_name(parts0.scope, parts0.name) {

--- a/compiler/tests/e2e/test_binary_capsule_walker.sh
+++ b/compiler/tests/e2e/test_binary_capsule_walker.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# End-to-end test for the Stage D PR3 binary-capsule src/ walker.
+#
+# When `sfn build -p <project>` resolves a `kind = "binary"` capsule,
+# the resolver opts into `enumerate_binary_capsule_sources` (see
+# `compiler/src/capsule_resolver.sfn`) which walks
+# `<project_root>/src/**/*.sfn` directly instead of relying on
+# transitive relative-import discovery from `[build] entry`. That
+# closes the gap that previously left source files unreachable from
+# the entry out of the link — most prominently the compiler's own
+# `cli_main.sfn` is not imported from `main.sfn` and would otherwise
+# never be compiled by `sfn build -p compiler`.
+#
+# This test verifies the property in miniature on a synthetic
+# fixture, then runs the real `sfn build -p compiler` self-host as
+# the integration smoke check.
+#
+# Usage:
+#   compiler/tests/e2e/test_binary_capsule_walker.sh <compiler-binary>
+
+set -euo pipefail
+
+BINARY="${1:?usage: test_binary_capsule_walker.sh <compiler-binary>}"
+BINARY="$(realpath "$BINARY")"
+PASS=0
+FAIL=0
+
+# Scratch dir for the test project. Cleaned on exit.
+SCRATCH="$(mktemp -d -t sfn-binary-walker-XXXXXX)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+
+run_test() {
+    local name="$1"
+    shift
+    if "$@"; then
+        echo "[test] PASS: $name"
+        PASS=$((PASS + 1))
+    else
+        echo "[test] FAIL: $name"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# ---- Setup: a binary capsule with a sibling module the entry never imports ----
+# Uses two source files where `main.sfn` does NOT import
+# `util/orphan.sfn`. The relative-import walker on its own would
+# leave `orphan.sfn` out of the resolver's source list. The binary-
+# capsule walker is what surfaces it, so the artifact-dir check below
+# is the unambiguous regression for this PR.
+#
+# `main.sfn` is intentionally self-contained so the link succeeds
+# without exercising the cross-module symbol mangling that has its
+# own slug-shape concerns for fixtures outside `compiler/src/`. PR3
+# is a resolver/enumeration change; symbol mangling in non-compiler
+# project trees is a separate concern.
+mkdir -p "$SCRATCH/src/util"
+
+cat > "$SCRATCH/capsule.toml" <<'EOF'
+[capsule]
+name = "binary-walker-test"
+version = "0.1.0"
+description = "E2E test for the Stage D PR3 binary-capsule src/ walker"
+
+[capabilities]
+required = ["io"]
+
+[build]
+kind = "binary"
+entry = "src/main.sfn"
+EOF
+
+cat > "$SCRATCH/src/main.sfn" <<'EOF'
+fn main() ![io] {
+    print("walker-fixture-ok");
+}
+EOF
+
+# Sibling module the entry never reaches. The walker MUST discover
+# it; the relative-import walker (driven from `main.sfn`) will not,
+# because `main.sfn` doesn't import anything.
+cat > "$SCRATCH/src/util/orphan.sfn" <<'EOF'
+export { orphan_helper };
+
+fn orphan_helper() -> string {
+    return "orphan-from-walker";
+}
+EOF
+
+# ---- Test 1: sfn build -p succeeds on the binary fixture ----
+test_build_succeeds() {
+    cd "$SCRATCH" || return 1
+    local rc
+    "$BINARY" build -p . > "$SCRATCH/build.stdout" 2>&1
+    rc=$?
+    if [ "$rc" -ne 0 ]; then
+        echo "[test]   sfn build -p . exited with code $rc; output:" >&2
+        cat "$SCRATCH/build.stdout" >&2
+    fi
+    return $rc
+}
+run_test "sfn build -p . completes for a binary capsule" test_build_succeeds
+
+# ---- Test 2: the produced binary runs and emits the expected greeting ----
+test_binary_runs() {
+    cd "$SCRATCH" || return 1
+    local exe="$SCRATCH/build/sailfin/program"
+    [ -x "$exe" ] || return 1
+    local rc
+    "$exe" > "$SCRATCH/program.stdout" 2>&1
+    rc=$?
+    if [ "$rc" -ne 0 ]; then
+        echo "[test]   binary exited with code $rc; output:" >&2
+        cat "$SCRATCH/program.stdout" >&2
+        return 1
+    fi
+    grep -q "^walker-fixture-ok$" "$SCRATCH/program.stdout"
+}
+run_test "binary links and runs" test_binary_runs
+
+# ---- Test 3: walker picked up the orphaned sibling not reachable from the entry ----
+# The fixture's `[capsule].name` ("binary-walker-test") is not in
+# scope/name form, so dep `.ll`s land under the legacy flat layout
+# (`build/sailfin/capsules/<mangled>.ll`) — see `_cr_legacy_ll_path`.
+# The slug for `<scratch>/src/util/orphan.sfn` is path-shaped
+# (`module_name_from_path` only strips `compiler/src/` and `runtime/`
+# prefixes), so the mangled filename ends in `__src__util__orphan.ll`.
+# Anchor on the suffix to keep the assertion stable across mktemp
+# directory names.
+test_orphan_compiled() {
+    cd "$SCRATCH" || return 1
+    local count
+    count=$(find "$SCRATCH/build/sailfin/capsules" -maxdepth 1 -name "*src__util__orphan.ll" 2>/dev/null | wc -l | tr -d ' ')
+    if [ "$count" != "1" ]; then
+        echo "[test]   expected exactly 1 orphan .ll under build/sailfin/capsules; found $count" >&2
+        ls "$SCRATCH/build/sailfin/capsules" 2>&1 >&2 || true
+        return 1
+    fi
+    return 0
+}
+run_test "walker enumerated the unimported sibling module" test_orphan_compiled
+
+# ---- Test 4: positional build (no -p) does NOT walk src/ ----
+# The walker is opt-in through `ResolverConsumer.walk_project_src`,
+# which only flips on for `-p` builds of `kind = "binary"` capsules.
+# A positional `sfn build src/main.sfn` should NOT enumerate the
+# orphan, because the relative-import walker driven from `main.sfn`
+# can't reach it. This guards against the walker silently flipping
+# on for end-user positional builds (where the legacy entry-driven
+# enumeration is the contract).
+test_positional_skips_walker() {
+    cd "$SCRATCH" || return 1
+    rm -rf "$SCRATCH/build"
+    "$BINARY" build src/main.sfn > "$SCRATCH/positional.stdout" 2>&1 || true
+    # If the walker fired, orphan.ll would be under capsules/. With
+    # the walker correctly gated, the capsules/ dir is empty (or
+    # absent — main.sfn imports nothing).
+    local count=0
+    if [ -d "$SCRATCH/build/sailfin/capsules" ]; then
+        count=$(find "$SCRATCH/build/sailfin/capsules" -maxdepth 1 -name "*orphan.ll" 2>/dev/null | wc -l | tr -d ' ')
+    fi
+    if [ "$count" != "0" ]; then
+        echo "[test]   positional build unexpectedly enumerated orphan; walker should be -p-only" >&2
+        return 1
+    fi
+    return 0
+}
+run_test "positional build does not trigger the binary-capsule walker" test_positional_skips_walker
+
+# ---- Summary ----
+echo ""
+echo "[test] $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/compiler/tests/e2e/test_binary_capsule_walker.sh
+++ b/compiler/tests/e2e/test_binary_capsule_walker.sh
@@ -12,8 +12,13 @@
 # never be compiled by `sfn build -p compiler`.
 #
 # This test verifies the property in miniature on a synthetic
-# fixture, then runs the real `sfn build -p compiler` self-host as
-# the integration smoke check.
+# `kind = "binary"` fixture: a `main.sfn` plus an unimported
+# sibling under `src/util/`. The full `sfn build -p compiler`
+# self-host is NOT exercised here — it costs ~6 minutes cold and
+# is verified manually before each Stage D PR; running it from a
+# unit-suite-tier e2e test would dominate CI wall time. The
+# fixture-level coverage is the bug-shape the walker has to
+# close; the compiler self-build is just a larger instance of it.
 #
 # Usage:
 #   compiler/tests/e2e/test_binary_capsule_walker.sh <compiler-binary>
@@ -28,8 +33,6 @@ FAIL=0
 # Scratch dir for the test project. Cleaned on exit.
 SCRATCH="$(mktemp -d -t sfn-binary-walker-XXXXXX)"
 trap 'rm -rf "$SCRATCH"' EXIT
-
-REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 
 run_test() {
     local name="$1"
@@ -134,7 +137,7 @@ test_orphan_compiled() {
     count=$(find "$SCRATCH/build/sailfin/capsules" -maxdepth 1 -name "*src__util__orphan.ll" 2>/dev/null | wc -l | tr -d ' ')
     if [ "$count" != "1" ]; then
         echo "[test]   expected exactly 1 orphan .ll under build/sailfin/capsules; found $count" >&2
-        ls "$SCRATCH/build/sailfin/capsules" 2>&1 >&2 || true
+        ls "$SCRATCH/build/sailfin/capsules" >&2 2>/dev/null || true
         return 1
     fi
     return 0

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,6 +1,6 @@
 # Status
 
-Updated: April 29, 2026 (Stage C complete through C4 migration; Stage D PR1 `kind = "runtime"` schema landed; Stage D PR2 driver-side runtime-capsule plumbing in flight — PR1–1f / #254–#259, C2a / #261, C2b1 / #262, C2b2 / #263, C2c / #264, C4 v1 / #265, C4b / #266, C4 migration / #267, D PR1 / #268)
+Updated: April 30, 2026 (Stage C complete through C4 migration; Stage D PR1 `kind = "runtime"` schema landed; Stage D PR2 driver-side runtime-capsule plumbing landed; Stage D PR3 binary-capsule `src/` walker + subprocess-per-module compile in flight — PR1–1f / #254–#259, C2a / #261, C2b1 / #262, C2b2 / #263, C2c / #264, C4 v1 / #265, C4b / #266, C4 migration / #267, D PR1 / #268, D PR2 / #269)
 
 This document tracks what works today and what is in progress. It is the source
 of truth — consult it before editing docs, examples, or making claims about
@@ -217,7 +217,7 @@ feature availability.
   dep_specs)` returning `RuntimeCapsuleArtifacts[]` with
   workspace-rooted paths. Pure foundation — no production call
   site invoked it yet.
-- **Stage D PR2 (in flight, this PR).** Driver-side wiring for
+- **Stage D PR2 (#269, shipped).** Driver-side wiring for
   `kind = "runtime"` capsule deps:
   - `compiler/capsule.toml` declares `[dependencies]
     "sfn/runtime-native" = "*"` so the resolver picks the
@@ -259,6 +259,45 @@ feature availability.
     `src/` walker for `kind = "binary"` projects) is the
     Stage D PR3 scope. `make compile` (build.sh path) is
     unchanged and remains the active bootstrap.
+- **Stage D PR3 (in flight, this PR).** `sfn build -p compiler`
+  produces a working compiler binary. Two changes work together:
+  - **Binary-capsule `src/` walker.** `ResolverConsumer` gains
+    a `walk_project_src` field (false by default). When
+    `cli_main.sfn` resolves `-p` to a `kind = "binary"`
+    capsule, it sets the field true and the resolver runs
+    `enumerate_binary_capsule_sources(project_root, entry)` —
+    a BFS over `<project_root>/src/**/*.sfn` mirroring
+    `_cr_collect_capsule_sources` — to surface every module the
+    `[build] entry` doesn't transitively import. Slugs come
+    from `_cr_relative_slug` so any module the entry DOES reach
+    dedupe-collapses cleanly with the relative-import walker.
+  - **Subprocess-per-module compile (mirrors `scripts/build.sh`).**
+    Without isolation the resolver's in-process compile loop
+    (138 modules in one arena) OOMed around the 135th module on
+    8 GB. `_cr_compile_one` now shells out to `<sailfin_exe>
+    emit --module-name <slug> -o <ll> llvm <src>` when
+    `cli_main.sfn` threads `binary_dir + "/sailfin"` through.
+    A new `--module-name` flag on `sfn emit` carries the slug
+    so cross-capsule deps (slug `<scope>/<name>/<sub>`, NOT
+    what `module_name_from_path` derives) mangle their symbols
+    identically to the in-process path. Empty `sailfin_exe`
+    falls back to in-process compile so `sfn check` and
+    `sfn test` (which don't yet plumb `binary_dir`) keep their
+    existing behavior.
+  - **Result.** Cold-start `sfn build --clean -p compiler`
+    succeeds in ~6.5 minutes (sequential subprocess; build.sh
+    parallelizes with `--jobs 4` so the ~2-minute target lands
+    once Stage D PR4 flips `make compile` over and the resolver
+    grows job parallelism). The produced binary runs
+    `examples/basics/hello-world.sfn` and self-builds again
+    (cache hits = 135/136 on the second pass).
+  - **Test coverage.** New `test_binary_capsule_walker.sh`
+    builds a `kind = "binary"` fixture with an unimported
+    sibling module and asserts the walker enumerates it,
+    while a positional `sfn build src/main.sfn` does NOT.
+    Full suite stays at 80 unit / 17 integration passing;
+    the pre-existing `test_check_compiler_src.sh` flake is
+    independent (reproduces on the PR2 baseline too).
 - `make compile` builds the compiler from a released seed. `make check`
   validates the seedcheck binary can run `hello-world.sfn` and pass the test suite.
 - **Deterministic self-hosting**: the compiler is a verified fixed point —


### PR DESCRIPTION
Closes the gap that prevented `sfn build -p compiler` from producing a working compiler binary, completing the Stage D self-host path.

## Walker

`compiler/src/main.sfn` does not transitively import every `.sfn` under `compiler/src/` — `cli_main.sfn` and the CLI subcommand modules are unreachable from the entry — so the resolver's relative-import walker missed ~70 files. `scripts/build.sh` worked around this by walking `compiler/src/**/*.sfn` directly; the resolver now does the same when `cli_main.sfn` opts in.

`ResolverConsumer` gains a `walk_project_src` boolean. When `-p` resolves a `kind = "binary"` capsule, the CLI flips it true and the resolver runs `enumerate_binary_capsule_sources(project_root, entry)` — a BFS over `<project_root>/src/**/*.sfn` mirroring the existing `_cr_collect_capsule_sources` pattern. Slugs come from `_cr_relative_slug` so any module the entry DOES reach dedupe-collapses cleanly with the relative-import walker (same slug + same path = silent duplicate).

## Subprocess-per-module compile

With 138 modules in the resolver's source list, the in-process compile loop accumulated ~7+ GB of arena state in a single process and OOMed around the 135th module on 8 GB. `build.sh` spawns a fresh subprocess per module precisely to bound this.

`_cr_compile_one` now shells out to `<sailfin_exe> emit --module-name <slug> -o <ll> llvm <src>` when `cli_main.sfn` threads `binary_dir + "/sailfin"` through. The new `--module-name` flag on `sfn emit llvm` carries the slug so cross-capsule deps (slug `<scope>/<name>/<sub>`, NOT what `module_name_from_path` derives) mangle their symbols identically to the in-process path.

Empty `sailfin_exe` falls back to in-process compile so `handle_test_command` (which doesn't yet thread `binary_dir`) keeps its existing behavior — test fixtures stay well below the per-module count where arena pressure becomes an issue.

## Result

Cold-start `sfn build --clean -p compiler` succeeds in ~6.5 minutes (sequential subprocess; `build.sh` hits ~2 minutes via `--jobs 4` parallelism, which lands in Stage D PR4). The produced binary runs `examples/basics/hello-world.sfn` and self-builds again (cache hits = 135/136 on the second pass).

## Tests

New `compiler/tests/e2e/test_binary_capsule_walker.sh`: builds a `kind = "binary"` fixture with an unimported sibling module and asserts (a) the build succeeds and runs, (b) the walker enumerates the orphan, (c) a positional `sfn build` does NOT trigger the walker. **4/4 pass.**

Full suite: **80 unit / 17 integration / 20-of-21 e2e.** The 1 e2e failure (`test_check_compiler_src.sh`) reproduces on the PR2 baseline too — pre-existing flake unrelated to this PR.

## Test plan

- [x] `make compile` self-builds with the walker + subprocess changes
- [x] `sfn build -p compiler` (cache populated) succeeds and produces a working binary
- [x] `sfn build --clean -p compiler` (cold start) succeeds end-to-end
- [x] Produced binary runs `examples/basics/hello-world.sfn`
- [x] Produced binary self-builds again
- [x] New e2e regression test passes (4/4)
- [x] Full unit + integration suite passes
- [x] Positional `sfn build src/main.sfn` does NOT trigger the walker (gated)

https://claude.ai/code/session_01Wtm6pciPANUjuJ4qS2LB2a

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wtm6pciPANUjuJ4qS2LB2a)_