### PR TITLE
Stage E PR1: subprocess-stage import-context

### DIFF
--- a/compiler/src/capsule_resolver.sfn
+++ b/compiler/src/capsule_resolver.sfn
@@ -657,7 +657,16 @@ fn enumerate_capsule_sources(project_root: string) -> CapsuleSource[] ![io] {
 // staging is a no-op when `make compile` has already produced the
 // artifacts. Refresh by `rm -rf build/native/import-context/` (or
 // `make rebuild`), the same invalidation contract `make` itself uses.
-fn _cr_stage_one(src: CapsuleSource) -> boolean ![io] {
+// Stage E PR1: stage one capsule source's import-context
+// (`.sfn-asm` + `.layout-manifest`). When `sailfin_exe.length >
+// 0`, the heavy native-text emit happens in a subprocess so the
+// parent's arena doesn't accumulate ~138 modules' worth of AST +
+// IR text — the same memory-bounding rationale that drove PR3's
+// subprocess-per-module compile path. Empty `sailfin_exe` falls
+// back to the in-process path that's worked since Stage B; the
+// fallback is what `sfn check` and tests with small dep sets
+// continue to use.
+fn _cr_stage_one(src: CapsuleSource, sailfin_exe: string) -> boolean ![io] {
     let asm_path = "build/native/import-context/" + src.slug + ".sfn-asm";
     let manifest_path = "build/native/import-context/" + src.slug
         + ".layout-manifest";
@@ -675,8 +684,26 @@ fn _cr_stage_one(src: CapsuleSource) -> boolean ![io] {
         print.err("capsule-resolver: missing source file: " + src.source_path);
         return false;
     }
-    let source = fs.readFile(src.source_path);
-    let ok = write_native_text_file_with_module(source, src.slug, asm_path);
+    let mut ok: boolean = false;
+    if sailfin_exe.length > 0 {
+        // Subprocess path — fresh arena per child, parent stays
+        // bounded. Mirror PR3's `_cr_compile_one` shape: pass the
+        // slug via `--module-name` so the child's
+        // `module_name_from_path` doesn't disagree with the slug
+        // the resolver already computed (matters for cross-
+        // capsule deps whose slug is `<scope>/<name>/<sub>`,
+        // which `module_name_from_path` would NOT derive).
+        let rc = process.run([sailfin_exe, "emit", "--module-name", src.slug, "-o", asm_path, "native", src.source_path]);
+        if rc == 0 {
+            if fs.exists(asm_path) {
+                let probe = fs.readFile(asm_path);
+                if probe.length > 0 { ok = true; }
+            }
+        }
+    } else {
+        let source = fs.readFile(src.source_path);
+        ok = write_native_text_file_with_module(source, src.slug, asm_path);
+    }
     if !ok {
         print.err("capsule-resolver: failed to emit native text for " + src.slug);
         return false;
@@ -715,14 +742,19 @@ fn _cr_stage_one(src: CapsuleSource) -> boolean ![io] {
 // Stage import-context for every capsule source. Sequential by design —
 // the seed-emit path is not thread-safe for our in-process use and
 // capsule dep sets are small (tens of modules, not hundreds).
-fn stage_capsule_imports(sources: CapsuleSource[]) -> boolean ![io] {
+//
+// Stage E PR1: `sailfin_exe` threads through to `_cr_stage_one`'s
+// subprocess emit. Empty `sailfin_exe` keeps the legacy in-process
+// path for callers (sfn check, sfn test) that don't yet plumb
+// `binary_dir` through.
+fn stage_capsule_imports(sources: CapsuleSource[], sailfin_exe: string) -> boolean ![io] {
     _cr_ensure_dir("build");
     _cr_ensure_dir("build/native");
     _cr_ensure_dir("build/native/import-context");
     let mut i: number = 0;
     loop {
         if i >= sources.length { break; }
-        let ok = _cr_stage_one(sources[i]);
+        let ok = _cr_stage_one(sources[i], sailfin_exe);
         if !ok { return false; }
         i += 1;
     }
@@ -2626,7 +2658,7 @@ fn prepare_project_capsules(input_path: string, config: BuildCacheConfig, consum
         };
     }
 
-    let staged = stage_capsule_imports(resolved.sources);
+    let staged = stage_capsule_imports(resolved.sources, sailfin_exe);
     if !staged {
         print.err("capsule-resolver: failed to stage import-context for project capsules");
         return ProjectCapsuleResult {
@@ -2659,7 +2691,7 @@ fn prepare_project_capsules(input_path: string, config: BuildCacheConfig, consum
             entry_src.push(CapsuleSource {
                 spec: "", source_path: entry_path, slug: entry_slug, ll_path: ""
             });
-            let entry_staged = stage_capsule_imports(entry_src);
+            let entry_staged = stage_capsule_imports(entry_src, sailfin_exe);
             if !entry_staged {
                 print.err("capsule-resolver: failed to stage entry import-context for "
                     + entry_path);
@@ -2739,7 +2771,12 @@ fn prepare_project_capsules_for_check(entry_paths: string[], consumer: ResolverC
         };
     }
 
-    let staged = stage_capsule_imports(resolved.sources);
+    // Stage E PR1: sfn check stays on the in-process stage path
+    // (empty `sailfin_exe`). Check's typical input — single
+    // files or small dirs — fits in-process; subprocess overhead
+    // would dominate. When `sfn check -p` lands, this becomes a
+    // one-line update mirroring `sfn build`.
+    let staged = stage_capsule_imports(resolved.sources, "");
     if !staged {
         print.err("capsule-resolver: failed to stage import-context for project capsules");
         return CheckCapsuleResolution {
@@ -2819,7 +2856,11 @@ fn prepare_project_capsules_for_test(entry_paths: string[], consumer: ResolverCo
         };
     }
 
-    let staged = stage_capsule_imports(resolved.sources);
+    // Stage E PR1: thread `sailfin_exe` to subprocess-stage
+    // imports too. `handle_test_command` currently passes "",
+    // so this falls back to the in-process path — matches the
+    // PR3 baseline behavior for tests.
+    let staged = stage_capsule_imports(resolved.sources, sailfin_exe);
     if !staged {
         print.err("capsule-resolver: failed to stage import-context for project capsules");
         return TestCapsuleResolution {

--- a/compiler/src/capsule_resolver.sfn
+++ b/compiler/src/capsule_resolver.sfn
@@ -693,12 +693,18 @@ fn _cr_stage_one(src: CapsuleSource, sailfin_exe: string) -> boolean ![io] {
         // the resolver already computed (matters for cross-
         // capsule deps whose slug is `<scope>/<name>/<sub>`,
         // which `module_name_from_path` would NOT derive).
+        //
+        // Validation is `rc == 0 && file exists` only — no probe
+        // read here. The block below already reads the asm to
+        // extract `.layout` lines; doubling the read would
+        // re-allocate the same string in the parent's arena and
+        // undermine the memory bounds this whole subprocess path
+        // is for. An empty asm produces an empty manifest, which
+        // downstream callers tolerate (the import-context loader
+        // just sees no layout lines for that slug).
         let rc = process.run([sailfin_exe, "emit", "--module-name", src.slug, "-o", asm_path, "native", src.source_path]);
         if rc == 0 {
-            if fs.exists(asm_path) {
-                let probe = fs.readFile(asm_path);
-                if probe.length > 0 { ok = true; }
-            }
+            if fs.exists(asm_path) { ok = true; }
         }
     } else {
         let source = fs.readFile(src.source_path);

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,6 +1,6 @@
 # Status
 
-Updated: May 1, 2026 (Stage C complete through C4 migration; Stage D PR1–PR4 shipped; Stage D PR5 cleanup in flight — PR1–1f / #254–#259, C2a / #261, C2b1 / #262, C2b2 / #263, C2c / #264, C4 v1 / #265, C4b / #266, C4 migration / #267, D PR1 / #268, D PR2 / #269, D PR3 / #271, D PR4 / #272; seed pinned to v0.5.10-alpha.5 — first release including PR3's binary-capsule walker, PR4's IR validator cascade, and PR4's entry-staging fix)
+Updated: May 1, 2026 (Stage C complete through C4 migration; Stage D PR1–PR5 shipped; Stage E PR1 subprocess-stage import-context in flight — PR1–1f / #254–#259, C2a / #261, C2b1 / #262, C2b2 / #263, C2c / #264, C4 v1 / #265, C4b / #266, C4 migration / #267, D PR1 / #268, D PR2 / #269, D PR3 / #271, D PR4 / #272, D PR5 / #273; seed pinned to v0.5.10-alpha.5)
 
 This document tracks what works today and what is in progress. It is the source
 of truth — consult it before editing docs, examples, or making claims about
@@ -346,6 +346,22 @@ feature availability.
   memory-bounded enough for cold builds to fit in 8 GB —
   tracked alongside Stage E (long-lived process, arena reset
   between modules) in `docs/proposals/build-architecture.md`.
+- **Stage E PR1 (in flight, this PR).** Subprocess-stage import-
+  context. `_cr_stage_one` and `stage_capsule_imports` gain a
+  `sailfin_exe` parameter that, when non-empty, shells the heavy
+  `write_native_text_file_with_module` work out to a fresh
+  subprocess (`<sailfin> emit native --module-name <slug> -o
+  <asm> <src>`). Mirrors the PR3 subprocess-per-module compile
+  shape. The parent's arena no longer accumulates 138 modules'
+  worth of AST + IR text — verified by self-hosting the new
+  compiler under the 8 GB ulimit, which previously needed to
+  fall back to `bash scripts/build.sh`. Empty `sailfin_exe`
+  preserves the in-process path that `sfn check` and `sfn test`
+  callers use; `prepare_project_capsules` (the build/run path)
+  threads the resolved binary path through. The Makefile's
+  `bash scripts/build.sh` fallback survives until the next seed
+  cut (which will pin alpha.6 with this fix and remove the
+  fallback).
 - `make compile` builds the compiler from a released seed. `make check`
   validates the seedcheck binary can run `hello-world.sfn` and pass the test suite.
 - **Deterministic self-hosting**: the compiler is a verified fixed point —

--- a/docs/status.md
+++ b/docs/status.md
@@ -321,7 +321,7 @@ feature availability.
   and a `build/.shim/llvm-as → llvm-as-18` symlink so the
   alpha.4 seed's IR validator could find a parser on Ubuntu's
   versioned-only llvm-18 install.
-- **Stage D PR5 (in flight, this PR).** Cleanup. `.seed-version`
+- **Stage D PR5 (#273, shipped).** Cleanup. `.seed-version`
   bumps to `0.5.10-alpha.5` — the first release including PR4's
   source-side fixes:
   - The validator cascade in `_cr_compile_one` (`llvm-as` →
@@ -350,8 +350,9 @@ feature availability.
   context. `_cr_stage_one` and `stage_capsule_imports` gain a
   `sailfin_exe` parameter that, when non-empty, shells the heavy
   `write_native_text_file_with_module` work out to a fresh
-  subprocess (`<sailfin> emit native --module-name <slug> -o
-  <asm> <src>`). Mirrors the PR3 subprocess-per-module compile
+  subprocess (`<sailfin> emit --module-name <slug> -o <asm>
+  native <src>` — flags before mode, matching `cli_main.sfn`'s
+  emit parser). Mirrors the PR3 subprocess-per-module compile
   shape. The parent's arena no longer accumulates 138 modules'
   worth of AST + IR text — verified by self-hosting the new
   compiler under the 8 GB ulimit, which previously needed to


### PR DESCRIPTION
`_cr_stage_one` and `stage_capsule_imports` now accept a `sailfin_exe` parameter. When non-empty, the heavy `write_native_text_file_with_module` step runs in a fresh subprocess (`<sailfin> emit native --module-name <slug> -o <asm> <src>`) instead of in-process. Mirrors the subprocess-per-module compile path PR3 added for `_cr_compile_one`.

## Why

Cold builds of the 138-module compiler peaked above the 8 GB virtual-memory cap because the parent process accumulated 138 modules' worth of AST + IR text in its arena during `stage_capsule_imports`. Each iteration's `write_native_text_file_with_module(source, slug, asm_path)` allocated transient AST, native-IR, and per-line buffer state that the arena couldn't reclaim between calls. The parent then also held the per-source dep-manifest map and the per-module compile event log, pushing past 8 GB about 60 modules in.

Subprocess-stage solves it the same way subprocess-compile did: each child gets a fresh arena that releases on exit. The parent keeps only the boolean success result.

Verified: the new compiler self-hosts via `sfn build -p compiler` end-to-end at the 8 GB ulimit (`compiler-safety.md` rule). With the previous in-process stage, the same invocation either segfaulted or fell back to `bash scripts/build.sh`.

## Scope

- `_cr_stage_one(src, sailfin_exe)` — subprocess when non-empty, in-process otherwise.
- `stage_capsule_imports(sources, sailfin_exe)` — threads the parameter through.
- `prepare_project_capsules` (build/run) passes the resolved binary path. Same call site that PR3 plumbed for compile; staging now reuses it.
- `prepare_project_capsules_for_check` passes `""` — `sfn check` stays on the in-process path (small dep counts, doesn't benefit from subprocess overhead). Becomes a one-line update when `sfn check -p` lands.
- `prepare_project_capsules_for_test` passes its existing `sailfin_exe` parameter through to staging too — `handle_test_command` currently hardcodes `""` so this is no-op for now, but matches the build path's shape.

## Follow-up

The Makefile's `bash scripts/build.sh` fallback survives this PR. The fallback fires only when `<seed> build -p compiler` bails before producing `build/sailfin/program`, which the alpha.5 seed's in-process stage path still does at 8 GB. Once alpha.6 ships with this PR's source change and `.seed-version` bumps to it, the fallback can retire (PR2 of Stage E).

## Verification

- `make rebuild` succeeds end-to-end (build.sh fallback fires because the alpha.5 seed in `.seed-version` doesn't have this fix yet — that's expected until the next seed cut).
- **The just-built compiler self-hosts via `sfn build -p compiler` end-to-end at 8 GB ulimit, no fallback needed.**
- Built binary `--version` reports `0.5.10-alpha.5+dev.<hash>`.
- Built binary builds + runs `examples/basics/hello-world.sfn`.
- Full suite: **80 unit / 17 integration / 20-of-21 e2e** (same pre-existing `test_check_compiler_src.sh` flake from prior PRs).

## Test plan

- [x] Source change builds via the alpha.5 seed (build.sh fallback fires once)
- [x] Built compiler self-hosts via `sfn build -p compiler` at 8 GB ulimit, no fallback
- [x] Built binary runs `examples/basics/hello-world.sfn`
- [x] Full unit + integration suite passes
- [ ] CI: linux + macos build/test runs
- [ ] CI: fmt check passes

https://claude.ai/code/session_01Wtm6pciPANUjuJ4qS2LB2a

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wtm6pciPANUjuJ4qS2LB2a)_