### PR TITLE
fix(lowering): route boxed allocations through arena-aware runtime helper

### DIFF
--- a/compiler/src/llvm/expression_lowering/arrays.sfn
+++ b/compiler/src/llvm/expression_lowering/arrays.sfn
@@ -130,7 +130,7 @@ fn lower_struct_array_concat(lhs: LLVMOperand, rhs: LLVMOperand, element_type: s
     let new_raw_buffer = format_temp_name(current_temp);
     current_temp += 1;
     current_lines.push("  " + new_raw_buffer
-        + " = call noalias i8* @calloc(i64 1, i64 "
+        + " = call noalias i8* @sailfin_runtime_alloc_struct(i64 "
         + total_bytes
         + ")");
     let new_data_ptr = format_temp_name(current_temp);
@@ -215,7 +215,7 @@ fn lower_struct_array_concat(lhs: LLVMOperand, rhs: LLVMOperand, element_type: s
 
     let new_struct_raw = format_temp_name(current_temp);
     current_temp += 1;
-    current_lines.push("  " + new_struct_raw + " = call i8* @calloc(i64 1, i64 "
+    current_lines.push("  " + new_struct_raw + " = call i8* @sailfin_runtime_alloc_struct(i64 "
         + struct_size_value
         + ")");
     let new_struct_ptr = format_temp_name(current_temp);

--- a/compiler/src/llvm/expression_lowering/arrays.sfn
+++ b/compiler/src/llvm/expression_lowering/arrays.sfn
@@ -215,7 +215,8 @@ fn lower_struct_array_concat(lhs: LLVMOperand, rhs: LLVMOperand, element_type: s
 
     let new_struct_raw = format_temp_name(current_temp);
     current_temp += 1;
-    current_lines.push("  " + new_struct_raw + " = call i8* @sailfin_runtime_alloc_struct(i64 "
+    current_lines.push("  " + new_struct_raw
+        + " = call i8* @sailfin_runtime_alloc_struct(i64 "
         + struct_size_value
         + ")");
     let new_struct_ptr = format_temp_name(current_temp);

--- a/compiler/src/llvm/expression_lowering/native/core.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core.sfn
@@ -675,7 +675,12 @@ fn lower_expression(expression: string, bindings: ParameterBinding[], locals: Lo
                                 + trimmed_expected
                                 + "* "
                                 + typed_ptr_temp);
-                            awaited_lines2.push("  call void @free(i8* "
+                            // Arena-aware free: the impl function's return
+                            // box is allocated via `@sailfin_runtime_alloc_struct`
+                            // (Phase 5a follow-up), so this must route through
+                            // the matching arena-aware free. Plain `@free` on
+                            // an arena pointer corrupts glibc chunk metadata.
+                            awaited_lines2.push("  call void @sailfin_runtime_free(i8* "
                                 + result_temp
                                 + ")");
                             let out_operand_unboxed = LLVMOperand {

--- a/compiler/src/llvm/expression_lowering/native/core_literals_lowering.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_literals_lowering.sfn
@@ -467,7 +467,8 @@ fn lower_array_literal(text: string, bindings: ParameterBinding[], locals: Local
     current_temp += 1;
 
     let raw_array_ptr = format_temp_name(current_temp);
-    current_lines.push("  " + raw_array_ptr + " = call i8* @sailfin_runtime_alloc_struct(i64 "
+    current_lines.push("  " + raw_array_ptr
+        + " = call i8* @sailfin_runtime_alloc_struct(i64 "
         + adjusted_array_bytes
         + ")");
     current_temp += 1;
@@ -521,7 +522,8 @@ fn lower_array_literal(text: string, bindings: ParameterBinding[], locals: Local
     current_temp += 1;
 
     let raw_struct_ptr = format_temp_name(current_temp);
-    current_lines.push("  " + raw_struct_ptr + " = call i8* @sailfin_runtime_alloc_struct(i64 "
+    current_lines.push("  " + raw_struct_ptr
+        + " = call i8* @sailfin_runtime_alloc_struct(i64 "
         + struct_bytes
         + ")");
     current_temp += 1;

--- a/compiler/src/llvm/expression_lowering/native/core_literals_lowering.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_literals_lowering.sfn
@@ -467,7 +467,7 @@ fn lower_array_literal(text: string, bindings: ParameterBinding[], locals: Local
     current_temp += 1;
 
     let raw_array_ptr = format_temp_name(current_temp);
-    current_lines.push("  " + raw_array_ptr + " = call i8* @calloc(i64 1, i64 "
+    current_lines.push("  " + raw_array_ptr + " = call i8* @sailfin_runtime_alloc_struct(i64 "
         + adjusted_array_bytes
         + ")");
     current_temp += 1;
@@ -521,7 +521,7 @@ fn lower_array_literal(text: string, bindings: ParameterBinding[], locals: Local
     current_temp += 1;
 
     let raw_struct_ptr = format_temp_name(current_temp);
-    current_lines.push("  " + raw_struct_ptr + " = call i8* @calloc(i64 1, i64 "
+    current_lines.push("  " + raw_struct_ptr + " = call i8* @sailfin_runtime_alloc_struct(i64 "
         + struct_bytes
         + ")");
     current_temp += 1;
@@ -799,7 +799,7 @@ fn box_aggregate_operand(operand: LLVMOperand, expected_pointer_type: string, te
     let malloc_temp = format_temp_name(current_temp);
     current_temp += 1;
     current_lines.push("  " + malloc_temp
-        + " = call noalias i8* @calloc(i64 1, i64 "
+        + " = call noalias i8* @sailfin_runtime_alloc_struct(i64 "
         + size_temp
         + ")");
 

--- a/compiler/src/llvm/expression_lowering/native/core_operands.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_operands.sfn
@@ -627,7 +627,7 @@ fn coerce_numeric_primitive(operand: LLVMOperand, operand_type: string, target: 
         if operand_type == "i8" {
             let malloc_temp = format_temp_name(temp_index);
             current_lines.push("  " + malloc_temp
-                + " = call noalias i8* @calloc(i64 1, i64 2)");
+                + " = call noalias i8* @sailfin_runtime_alloc_struct(i64 2)");
             let char_ptr = format_temp_name(temp_index + 1);
             current_lines.push("  " + char_ptr + " = getelementptr i8, i8* "
                 + malloc_temp
@@ -751,7 +751,7 @@ fn coerce_pointer_or_struct(operand: LLVMOperand, operand_type: string, target: 
                         + size_ptr_temp
                         + " to i64");
                     current_lines.push("  " + malloc_temp
-                        + " = call noalias i8* @calloc(i64 1, i64 "
+                        + " = call noalias i8* @sailfin_runtime_alloc_struct(i64 "
                         + size_temp
                         + ")");
                     current_lines.push("  " + typed_ptr_temp + " = bitcast i8* "
@@ -832,7 +832,7 @@ fn coerce_pointer_or_struct(operand: LLVMOperand, operand_type: string, target: 
             + size_ptr_temp
             + " to i64");
         current_lines.push("  " + malloc_temp
-            + " = call noalias i8* @calloc(i64 1, i64 "
+            + " = call noalias i8* @sailfin_runtime_alloc_struct(i64 "
             + size_temp
             + ")");
         current_lines.push("  " + typed_ptr_temp + " = bitcast i8* "
@@ -914,7 +914,7 @@ fn coerce_general_fallback(operand: LLVMOperand, operand_type: string, target: s
                         + size_ptr_temp
                         + " to i64");
                     current_lines.push("  " + malloc_temp
-                        + " = call noalias i8* @calloc(i64 1, i64 "
+                        + " = call noalias i8* @sailfin_runtime_alloc_struct(i64 "
                         + size_temp
                         + ")");
                     current_lines.push("  " + typed_ptr_temp + " = bitcast i8* "
@@ -983,7 +983,7 @@ fn coerce_general_fallback(operand: LLVMOperand, operand_type: string, target: s
                             + size_ptr_temp
                             + " to i64");
                         local_lines.push("  " + malloc_temp
-                            + " = call noalias i8* @calloc(i64 1, i64 "
+                            + " = call noalias i8* @sailfin_runtime_alloc_struct(i64 "
                             + size_temp
                             + ")");
                         local_lines.push("  " + typed_ptr_temp
@@ -1033,7 +1033,7 @@ fn coerce_general_fallback(operand: LLVMOperand, operand_type: string, target: s
                                 + size_ptr_temp
                                 + " to i64");
                             local_lines.push("  " + malloc_temp
-                                + " = call noalias i8* @calloc(i64 1, i64 "
+                                + " = call noalias i8* @sailfin_runtime_alloc_struct(i64 "
                                 + size_temp
                                 + ")");
                             local_lines.push("  " + typed_ptr_temp
@@ -1191,7 +1191,7 @@ fn coerce_general_fallback(operand: LLVMOperand, operand_type: string, target: s
                     + size_ptr_temp
                     + " to i64");
                 current_lines.push("  " + malloc_temp
-                    + " = call noalias i8* @calloc(i64 1, i64 "
+                    + " = call noalias i8* @sailfin_runtime_alloc_struct(i64 "
                     + size_temp
                     + ")");
                 current_lines.push("  " + typed_ptr_temp + " = bitcast i8* "
@@ -1254,7 +1254,7 @@ fn coerce_general_fallback(operand: LLVMOperand, operand_type: string, target: s
                     + size_ptr_temp
                     + " to i64");
                 current_lines.push("  " + malloc_temp
-                    + " = call noalias i8* @calloc(i64 1, i64 "
+                    + " = call noalias i8* @sailfin_runtime_alloc_struct(i64 "
                     + size_temp
                     + ")");
                 current_lines.push("  " + typed_ptr_temp + " = bitcast i8* "

--- a/compiler/src/llvm/expression_lowering/native/core_strings.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_strings.sfn
@@ -13,16 +13,19 @@ fn lower_string_literal(literal: string, temp_index: number, lines: string[]) ->
     // The original lowering model used global string constants (@.str.len...).
     // Stage2's struct-return plumbing can drop the collected constant table,
     // yielding link-time failures (undefined @.str.*). To keep emitted LLVM
-    // self-contained and clang-linkable, we materialize literals directly
-    // into heap memory via store of an inline constant array. The buffer
-    // is allocated through the arena-aware runtime helper so that
-    // multi-module in-process drivers (`sfn check <dir>`, `sfn test`,
-    // future `sfn lsp`) can reclaim per-iteration literal storage via
-    // `runtime.arena_rewind`. Falling back to libc `calloc` here was
-    // the original Phase 5a leak: every `is_trivia_token` /
-    // `strings_equal` call re-allocated its comparison strings and the
-    // mark/rewind primitive could not reach them, blowing peak RSS
-    // past the 2 GB Phase 5a target on `sfn check compiler/src/`.
+    // self-contained and clang-linkable, we materialize literals into a
+    // runtime-allocated buffer via store of an inline constant array. The
+    // buffer is allocated through `sailfin_runtime_alloc_struct`, which
+    // routes through the bump-allocator arena when enabled (default-on
+    // for selfhost / installed binaries) and falls through to libc calloc
+    // otherwise. Arena routing lets multi-module in-process drivers
+    // (`sfn check <dir>`, `sfn test`, future `sfn lsp`) reclaim per-
+    // iteration literal storage via `runtime.arena_rewind`. The previous
+    // raw `@calloc` was the original Phase 5a leak: every
+    // `is_trivia_token` / `strings_equal` call re-allocated its
+    // comparison strings and the mark/rewind primitive could not reach
+    // them, blowing peak RSS past the 2 GB Phase 5a target on
+    // `sfn check compiler/src/`.
     let content = unescape_string_literal(literal);
     let escaped = escape_string_for_llvm(content);
     let array_length = content.length + 1;

--- a/compiler/src/llvm/expression_lowering/native/core_strings.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_strings.sfn
@@ -14,7 +14,15 @@ fn lower_string_literal(literal: string, temp_index: number, lines: string[]) ->
     // Stage2's struct-return plumbing can drop the collected constant table,
     // yielding link-time failures (undefined @.str.*). To keep emitted LLVM
     // self-contained and clang-linkable, we materialize literals directly
-    // into heap memory via malloc + store of an inline constant array.
+    // into heap memory via store of an inline constant array. The buffer
+    // is allocated through the arena-aware runtime helper so that
+    // multi-module in-process drivers (`sfn check <dir>`, `sfn test`,
+    // future `sfn lsp`) can reclaim per-iteration literal storage via
+    // `runtime.arena_rewind`. Falling back to libc `calloc` here was
+    // the original Phase 5a leak: every `is_trivia_token` /
+    // `strings_equal` call re-allocated its comparison strings and the
+    // mark/rewind primitive could not reach them, blowing peak RSS
+    // past the 2 GB Phase 5a target on `sfn check compiler/src/`.
     let content = unescape_string_literal(literal);
     let escaped = escape_string_for_llvm(content);
     let array_length = content.length + 1;
@@ -22,7 +30,7 @@ fn lower_string_literal(literal: string, temp_index: number, lines: string[]) ->
 
     let mut current_lines: string[] = lines;
     let malloc_temp = format_temp_name(temp_index);
-    current_lines.push("  " + malloc_temp + " = call i8* @calloc(i64 1, i64 "
+    current_lines.push("  " + malloc_temp + " = call i8* @sailfin_runtime_alloc_struct(i64 "
         + number_to_string(array_length)
         + ")");
     let cast_temp = format_temp_name(temp_index + 1);

--- a/compiler/src/llvm/expression_lowering/native/core_strings.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_strings.sfn
@@ -33,7 +33,8 @@ fn lower_string_literal(literal: string, temp_index: number, lines: string[]) ->
 
     let mut current_lines: string[] = lines;
     let malloc_temp = format_temp_name(temp_index);
-    current_lines.push("  " + malloc_temp + " = call i8* @sailfin_runtime_alloc_struct(i64 "
+    current_lines.push("  " + malloc_temp
+        + " = call i8* @sailfin_runtime_alloc_struct(i64 "
         + number_to_string(array_length)
         + ")");
     let cast_temp = format_temp_name(temp_index + 1);

--- a/compiler/src/llvm/lowering/lowering_phase_render.sfn
+++ b/compiler/src/llvm/lowering/lowering_phase_render.sfn
@@ -148,6 +148,23 @@ fn render_llvm_preamble(module_name: string, type_context: TypeContext, trait_me
     if find_function_by_name(context_functions, "free") == null {
         lines.push("declare void @free(i8*)");
     }
+    // Arena-aware allocation primitive. The expression-lowering pass
+    // emits `@sailfin_runtime_alloc_struct` instead of raw `@calloc`
+    // for string-literal materialization, struct/array literal boxes,
+    // and scalar→i8* coercions so that in-process multi-module drivers
+    // (`sfn check <dir>`, `sfn test`, future `sfn lsp`) can reclaim
+    // per-iteration scratch via Phase 5a's `runtime.arena_rewind`.
+    // Without this routing the rewind primitive cannot reach libc-
+    // owned literal storage and peak RSS climbs unbounded across the
+    // per-file loop. The runtime helper falls back to libc calloc when
+    // the arena is disabled, so behaviour for `SAILFIN_USE_ARENA=0`
+    // is unchanged.
+    if find_function_by_name(context_functions, "sailfin_runtime_alloc_struct") == null {
+        lines.push("declare noalias i8* @sailfin_runtime_alloc_struct(i64)");
+    }
+    if find_function_by_name(context_functions, "sailfin_runtime_free") == null {
+        lines.push("declare void @sailfin_runtime_free(i8*)");
+    }
     lines.push("");
 
     // Runtime global

--- a/runtime/native/include/sailfin_runtime.h
+++ b/runtime/native/include/sailfin_runtime.h
@@ -65,6 +65,17 @@ extern "C"
     // non-deterministic truncation under seed 0.5.7 on Apple Silicon.
     void *sailfin_runtime_alloc_struct(int64_t size_bytes);
 
+    // Arena-aware free counterpart for `sailfin_runtime_alloc_struct`. When the
+    // arena is enabled (default-on for selfhost / installed binaries) this is a
+    // no-op; the arena reclaims the allocation on `runtime.arena_rewind` or
+    // process exit. When the arena is disabled it falls through to libc free,
+    // matching the lifetime contract that the boxed-struct ABI inherited from
+    // the previous raw `@calloc` / `@free` pairing in the await unboxing path.
+    // Callers must pair this with `sailfin_runtime_alloc_struct` (or any other
+    // `_rt_calloc`-routed allocation) — calling it on a libc-allocated pointer
+    // while the arena is on would leak that pointer.
+    void sailfin_runtime_free(void *ptr);
+
     // ---- Array helpers ----
 
     // For `{ i8**, i64 }*` concatenation, native IR uses `@sailfin_runtime_concat({i8**,i64}*,{i8**,i64}*)`.

--- a/runtime/native/src/sailfin_runtime.c
+++ b/runtime/native/src/sailfin_runtime.c
@@ -3202,6 +3202,22 @@ void *sailfin_runtime_alloc_struct(int64_t size_bytes)
     return _rt_calloc(1, (size_t)size_bytes);
 }
 
+/* Arena-aware free for `sailfin_runtime_alloc_struct` allocations. The async
+ * await unboxing path in `compiler/src/llvm/expression_lowering/native/core.sfn`
+ * frees the boxed struct returned by an `async fn -> %T` after copying the
+ * value onto the awaiter's stack. Pre-Phase-5a-followup that path used raw
+ * `@free`, which assumed the box lived in libc heap. With the boxed-struct
+ * literal lowering routed through the arena, libc `free` on an arena pointer
+ * corrupts glibc's chunk metadata (`munmap_chunk(): invalid pointer`). This
+ * wrapper preserves the no-leak contract under the malloc fallback while
+ * letting the arena reclaim the allocation in bulk. */
+void sailfin_runtime_free(void *ptr)
+{
+    if (!ptr)
+        return;
+    _rt_free(ptr);
+}
+
 SailfinPtrArray *sailfin_runtime_concat(SailfinPtrArray *a, SailfinPtrArray *b)
 {
     _invalidate_concat_reuse();

--- a/scripts/run_native_test.sh
+++ b/scripts/run_native_test.sh
@@ -112,6 +112,20 @@ fi
 
 if [ $RC_INNER -ne 0 ]; then
     echo "[test] FAIL: $BASENAME (exit code $RC_INNER, timeout=$TIMEOUT)"
+    # When a test fails, the error of interest is rarely in the last 10 lines
+    # — link errors land 100+ lines back, behind a wall of clang's
+    # `-Woverride-module` warnings. Surface every line that smells like an
+    # error or signal-shaped cause (clang/ld diagnostics, resolver retries,
+    # missing files, OOM/abort), bounded to keep the CI log readable. The
+    # tail of the output still prints last so failure summaries that rely
+    # on the final lines (e.g. assertion messages) are not lost.
+    diag="$(grep -nE '^(clang(-[0-9]+)?|sh|/usr/bin/ld|ld)\.?: |error:|undefined reference| no such file|Killed|Aborted|abort\(\)|munmap_chunk|capsule-resolver:|\[emit retry\]|\[cache (copy-failed|store-failed|invalid-key)\]|test runner: compile failed|link failed|test failed:' <<< "$output" | head -40)"
+    if [ -n "$diag" ]; then
+        echo "[test] -- diagnostic excerpt --"
+        echo "$diag"
+        echo "[test] -- /diagnostic excerpt --"
+    fi
+    echo "[test] -- last 10 lines of output --"
     echo "$output" | tail -10
     exit 1
 fi

--- a/site/src/content/docs/docs/reference/runtime-abi.md
+++ b/site/src/content/docs/docs/reference/runtime-abi.md
@@ -47,6 +47,30 @@ Hybrid approach: reference counting + arenas.
 - **Reference counting** for values that escape their scope
 - **Explicit retain/release** for RC-managed values
 
+## Allocation Helpers
+
+The compiler emits calls to two arena-aware helpers for boxed allocations
+that the bump-allocator arena (`runtime/native/src/sailfin_arena.c`) can
+reclaim in bulk via `runtime.arena_mark` / `runtime.arena_rewind`.
+Both fall through to libc `calloc` / `free` when the arena is disabled
+(`SAILFIN_USE_ARENA=0`), so off-arena callers retain the original
+malloc-based lifetime contract.
+
+| Symbol | Signature | When emitted | Pairs with | Arena | Off-arena |
+| --- | --- | --- | --- | --- | --- |
+| `sailfin_runtime_alloc_struct` | `i8* (i64 size_bytes)` | string-literal materialization, struct/array literal boxing, scalar→`i8*` coercion | `sailfin_runtime_free` (or arena bulk reclaim) | `_rt_calloc` → arena | `calloc(1, size)` |
+| `sailfin_runtime_free` | `void (i8*)` | await-unboxing of a boxed-struct future return | `sailfin_runtime_alloc_struct` | no-op (arena reclaims at rewind / exit) | `free(ptr)` |
+
+Important: `sailfin_runtime_free` must only be paired with pointers from
+`sailfin_runtime_alloc_struct` (or other `_rt_calloc`-routed allocations).
+Calling it on a libc-`malloc`/`calloc` pointer while the arena is
+enabled would leak that pointer; calling libc `free` on an arena-allocated
+pointer corrupts glibc chunk metadata.
+
+The async-context calloc/free pair in `compiler/src/llvm/lowering/emission_async.sfn`
+intentionally stays on raw `@calloc` / `@free` because both ends of the
+allocation are libc-resident regardless of arena state.
+
 ## Exception / Unwind ABI
 
 Structured frames with deterministic unwind. Currently implemented via C runtime's `setjmp`/`longjmp`, planned to move to native structured exceptions.


### PR DESCRIPTION
## Summary

The `test_check_compiler_src.sh` "flake" recent claude sessions have been dismissing in PR descriptions is a real, reproducible regression — not flaky. Under the project's 8 GB local ulimit, `sfn check compiler/src/` exits 139 (SIGSEGV) on a clean build of `main`. Stack-trace + core-dump analysis pinned the crash to `calloc()` returning NULL inside `is_trivia_token` after peak RSS climbed to **~8.5 GB** — 4× over Phase 5a's stated <2 GB target.

### Root cause

The LLVM lowering pass emits raw `@calloc(i64 1, i64 N)` for **every** string-literal materialization, struct/array-literal box, and scalar→i8\* coercion (14 sites across 5 files). Phase 5a's `runtime.arena_mark` / `runtime.arena_rewind` primitive (in `cli_check.handle_check_command`) cannot reach libc heap, so the per-file rewind reclaimed nothing and `is_trivia_token`'s "Whitespace" / "Comment" comparison literals leaked across all 137 modules until calloc walked off the address-space cap.

The runtime already exposes the right primitive — `sailfin_runtime_alloc_struct(int64)` wraps `_rt_calloc`, which routes through `sfn_arena_global()` when the arena is enabled and falls through to libc calloc otherwise. It just was never wired into the IR emitter.

CI tends to mask this because runners ship more than 16 GB; locally under the 8 GB rule the test is 100 % deterministic.

### Fix

- Replace `@calloc(i64 1, i64 N)` → `@sailfin_runtime_alloc_struct(i64 N)` for the *unfreed* lowering sites: string literals (`core_strings.sfn`), struct/array literal boxes (`core_literals_lowering.sfn`, `arrays.sfn`), and scalar→i8\* coercions (`core_operands.sfn`).
- Add `sailfin_runtime_free` (no-op when arena enabled, libc free otherwise) and route the await-unbox free in `core.sfn` through it. Without this the libc `@free` would corrupt glibc chunk metadata (`munmap_chunk(): invalid pointer`) on arena-allocated boxed structs returned by `async fn -> %T`.
- Async-context `@calloc`/`@free` in `emission_async.sfn` stays libc — those are paired allocations that don't leak, and arena memory must not flow into libc free.
- Add the corresponding `declare`s to `lowering_phase_render.sfn`.

Self-host invariant holds: the seed lowers using its own (old) lowering; the new IR pattern only takes effect on the next build.

### Numbers

`sfn check compiler/src/` under `ulimit -v 8388608`:

| | exit | peak RSS |
|---|---|---|
| pre-fix | 139 (SIGSEGV) | 8.5 GB |
| post-fix | 0 | 2.3 GB |

3 consecutive runs: 2316 / 2317 / 2317 MB (deterministic, < 1 MB variance).

## Test plan

- [x] `make compile` from seed
- [x] Build `sailfin-seedcheck` from the modified binary (this is what exercises the new IR)
- [x] `bash compiler/tests/e2e/test_check_compiler_src.sh build/native/sailfin-seedcheck` → 2/2 PASS
- [x] `make test-unit NATIVE_BIN=build/native/sailfin-seedcheck` → 82/82 PASS
- [x] `make test-integration NATIVE_BIN=build/native/sailfin-seedcheck` → 17/17 PASS (including `async_struct_return_test`, which hit `munmap_chunk` until I added `sailfin_runtime_free`)
- [x] `make test-e2e NATIVE_BIN=build/native/sailfin-seedcheck` → 21/21 PASS
- [x] 3× stability run of the headline scenario — peak RSS 2316 / 2317 / 2317 MB

https://claude.ai/code/session_01BPr16CrzUeYHjX53gsUBbJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01BPr16CrzUeYHjX53gsUBbJ)_