### PR TITLE
feat(runtime): seed runtime/sfn/platform/libc.sfn skeleton

### DIFF
--- a/compiler/tests/e2e/test_runtime_libc_skeleton.sh
+++ b/compiler/tests/e2e/test_runtime_libc_skeleton.sh
@@ -36,6 +36,13 @@ FAIL=0
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 SKELETON="$REPO_ROOT/runtime/sfn/platform/libc.sfn"
 
+# Use a single per-invocation scratch dir + named files inside it.
+# `mktemp --suffix=.ll` is a GNU-only flag (BSD mktemp on macOS does
+# not implement it); the `mktemp -d -t prefix-XXXXXX` form below is
+# the portable pattern used elsewhere in `compiler/tests/e2e/`.
+SCRATCH="$(mktemp -d -t sfn-libc-skeleton-XXXXXX)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
 run_test() {
     local name="$1"
     shift
@@ -50,21 +57,17 @@ run_test() {
 
 # ---- Test: sfn check passes cleanly ----
 test_check_clean() {
-    local log
-    log="$(mktemp)"
+    local log="$SCRATCH/check.log"
     if ! "$BINARY" check "$SKELETON" > "$log" 2>&1; then
         echo "[test]   sfn check exited non-zero on libc.sfn:"
         cat "$log"
-        rm -f "$log"
         return 1
     fi
     if ! grep -q "checked .* ok" "$log"; then
         echo "[test]   sfn check did not report 'ok':"
         cat "$log"
-        rm -f "$log"
         return 1
     fi
-    rm -f "$log"
     return 0
 }
 
@@ -79,11 +82,9 @@ test_fmt_clean() {
 
 # ---- Test: every extern lowers to an LLVM declare directive ----
 test_emit_declares() {
-    local ll
-    ll="$(mktemp --suffix=.ll)"
+    local ll="$SCRATCH/libc.ll"
     if ! "$BINARY" emit -o "$ll" llvm "$SKELETON" > /dev/null 2>&1; then
         echo "[test]   sfn emit llvm failed on libc.sfn"
-        rm -f "$ll"
         return 1
     fi
     # The 12 declarations expected today. When the skeleton grows,
@@ -97,7 +98,6 @@ test_emit_declares() {
             missing=$((missing + 1))
         fi
     done
-    rm -f "$ll"
     return "$missing"
 }
 

--- a/compiler/tests/e2e/test_runtime_libc_skeleton.sh
+++ b/compiler/tests/e2e/test_runtime_libc_skeleton.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# End-to-end test for the runtime/sfn/platform/libc.sfn skeleton.
+#
+# This is the headline smoke test for the post-#281 follow-up that
+# proves the full extern-fn pipeline works on a realistic file —
+# the first file in the path toward a pure-Sailfin runtime (see
+# `docs/runtime_architecture.md` §2.9 "Platform Extern Declarations").
+#
+# Acceptance:
+#   - `sfn check runtime/sfn/platform/libc.sfn` exits 0 (zero
+#     diagnostics — every declaration must satisfy the C-ABI
+#     accept-list enforced by E0801–E0805).
+#   - `sfn fmt --check runtime/sfn/platform/libc.sfn` exits 0
+#     (the file is canonical-formatted; the CI fmt step at
+#     `.github/workflows/ci.yml:113` already covers `runtime/`,
+#     but pinning it here means a regression surfaces in
+#     `make test-e2e` before it reaches CI).
+#   - `sfn emit llvm` produces a `declare` directive for every
+#     extern in the skeleton. This is the architect's M1 fast-fail
+#     criterion (§3.6) made executable.
+#
+# When this skeleton grows into a real imported module (M2),
+# this test stays useful as a regression for the LLVM `declare`
+# emission path.
+#
+# Usage:
+#   compiler/tests/e2e/test_runtime_libc_skeleton.sh <compiler-binary>
+
+set -euo pipefail
+
+BINARY="${1:?usage: test_runtime_libc_skeleton.sh <compiler-binary>}"
+BINARY="$(realpath "$BINARY")"
+PASS=0
+FAIL=0
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+SKELETON="$REPO_ROOT/runtime/sfn/platform/libc.sfn"
+
+run_test() {
+    local name="$1"
+    shift
+    if "$@"; then
+        echo "[test] PASS: $name"
+        PASS=$((PASS + 1))
+    else
+        echo "[test] FAIL: $name"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# ---- Test: sfn check passes cleanly ----
+test_check_clean() {
+    local log
+    log="$(mktemp)"
+    if ! "$BINARY" check "$SKELETON" > "$log" 2>&1; then
+        echo "[test]   sfn check exited non-zero on libc.sfn:"
+        cat "$log"
+        rm -f "$log"
+        return 1
+    fi
+    if ! grep -q "checked .* ok" "$log"; then
+        echo "[test]   sfn check did not report 'ok':"
+        cat "$log"
+        rm -f "$log"
+        return 1
+    fi
+    rm -f "$log"
+    return 0
+}
+
+# ---- Test: sfn fmt --check is clean ----
+test_fmt_clean() {
+    if ! "$BINARY" fmt --check "$SKELETON" > /dev/null 2>&1; then
+        echo "[test]   $SKELETON needs formatting (run: sfn fmt --write $SKELETON)"
+        return 1
+    fi
+    return 0
+}
+
+# ---- Test: every extern lowers to an LLVM declare directive ----
+test_emit_declares() {
+    local ll
+    ll="$(mktemp --suffix=.ll)"
+    if ! "$BINARY" emit -o "$ll" llvm "$SKELETON" > /dev/null 2>&1; then
+        echo "[test]   sfn emit llvm failed on libc.sfn"
+        rm -f "$ll"
+        return 1
+    fi
+    # The 12 declarations expected today. When the skeleton grows,
+    # extend this list — the goal is to catch a regression where an
+    # extern silently stops emitting a `declare` directive (e.g. a
+    # signature accidentally falls into a path that emits nothing).
+    local missing=0
+    for sym in malloc free realloc memcpy memcmp write read fopen fclose fread fwrite getenv; do
+        if ! grep -qE "^declare .* @${sym}\b" "$ll"; then
+            echo "[test]   missing 'declare ... @${sym}' in emitted IR"
+            missing=$((missing + 1))
+        fi
+    done
+    rm -f "$ll"
+    return "$missing"
+}
+
+run_test "sfn check runtime/sfn/platform/libc.sfn passes" test_check_clean
+run_test "sfn fmt --check runtime/sfn/platform/libc.sfn is canonical" test_fmt_clean
+run_test "sfn emit llvm produces declare for every extern" test_emit_declares
+
+echo "[summary] $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi

--- a/compiler/tests/e2e/test_runtime_libc_skeleton.sh
+++ b/compiler/tests/e2e/test_runtime_libc_skeleton.sh
@@ -91,10 +91,19 @@ test_emit_declares() {
     # extend this list — the goal is to catch a regression where an
     # extern silently stops emitting a `declare` directive (e.g. a
     # signature accidentally falls into a path that emits nothing).
+    #
+    # We anchor each match on the literal `(` that always follows
+    # the symbol in an LLVM `declare` line (`declare i64 @write(`).
+    # `\b` word-boundaries are GNU-only in ERE — BSD/macOS `grep -E`
+    # treats `\b` as a backspace and would silently skip every
+    # match — so anchoring on `(` keeps the regex portable without
+    # giving up the false-positive guard (a partial-name match like
+    # `@write_log(` cannot collide because the symbol-followed-by-`(`
+    # form is unambiguous in LLVM IR).
     local missing=0
     for sym in malloc free realloc memcpy memcmp write read fopen fclose fread fwrite getenv; do
-        if ! grep -qE "^declare .* @${sym}\b" "$ll"; then
-            echo "[test]   missing 'declare ... @${sym}' in emitted IR"
+        if ! grep -qE "^declare .* @${sym}\(" "$ll"; then
+            echo "[test]   missing 'declare ... @${sym}(' in emitted IR"
             missing=$((missing + 1))
         fi
     done

--- a/docs/runtime_architecture.md
+++ b/docs/runtime_architecture.md
@@ -733,12 +733,18 @@ declarations — pure Sailfin source, no C. The compiler emits LLVM `declare`
 directives for each extern; the linker resolves them against libc/libpthread at
 link time.
 
-**`runtime/sfn/platform/libc.sfn`** — the first 12 declarations
-shipped 2026-05-01 use `usize` for `size_t`-shaped parameters and
-omit `setjmp`/`longjmp`/`memchr` until follow-up PRs land their
-dependencies (opaque `JmpBuf` size, exception subsystem). The
-shape below is the design target across all milestones; selected
-entries:
+**`runtime/sfn/platform/libc.sfn`** — selected entries from the
+*design target* are listed below. The actually-shipped 2026-05-01
+skeleton is a subset of this list: the 12 declarations covering
+`malloc`/`free`/`realloc`/`memcpy`/`memcmp`, `write`/`read`,
+`fopen`/`fclose`/`fread`/`fwrite`, and `getenv`. `memchr`,
+`setjmp`, and `longjmp` (commented `// (deferred)` below) are part
+of the long-term shape but wait on follow-up PRs that land their
+dependencies — `memchr` needs the LLVM mapper to learn `i32`-byte
+parameters cleanly through opaque pointers, and `setjmp`/`longjmp`
+need the exception subsystem plus opaque `JmpBuf` size constants.
+Once those land, drop the `// (deferred)` markers and the
+declarations move into the live skeleton.
 
 ```sailfin
 // Memory
@@ -747,7 +753,7 @@ extern fn free(ptr: *u8) -> void;
 extern fn realloc(ptr: *u8, new_size: usize) -> *u8;
 extern fn memcpy(dst: *u8, src: *u8, n: usize) -> *u8;
 extern fn memcmp(a: *u8, b: *u8, n: usize) -> i32;
-extern fn memchr(haystack: *u8, byte: i32, n: usize) -> *u8;
+extern fn memchr(haystack: *u8, byte: i32, n: usize) -> *u8; // (deferred)
 
 // I/O (fd-based)
 extern fn write(fd: i32, buf: *u8, count: usize) -> i64;
@@ -761,8 +767,8 @@ extern fn fclose(f: *File) -> i32;
 
 // Environment + exception support
 extern fn getenv(name: *u8) -> *u8;
-extern fn setjmp(env: *JmpBuf) -> i32;
-extern fn longjmp(env: *JmpBuf, val: i32) -> void;
+extern fn setjmp(env: *JmpBuf) -> i32;                       // (deferred)
+extern fn longjmp(env: *JmpBuf, val: i32) -> void;           // (deferred)
 
 // String conversion (variadic — see open question Q6)
 extern fn strtod(nptr: *u8, endptr: **u8) -> f64;

--- a/docs/runtime_architecture.md
+++ b/docs/runtime_architecture.md
@@ -12,6 +12,11 @@
 > - M0 hard prerequisite #7 (`extern fn` typed linker-resolved symbols):
 >   **shipped 2026-05-01** (parser + typecheck + native-IR + LLVM `declare`).
 >   Cross-module call-site resolution is the remaining sub-step; see §3.6.
+> - First `runtime/sfn/platform/libc.sfn` skeleton: **shipped 2026-05-01**
+>   (12 extern declarations, typecheck + fmt + LLVM `declare` emission
+>   verified by `compiler/tests/e2e/test_runtime_libc_skeleton.sh`). The
+>   file is not yet imported anywhere — the runtime continues to reach
+>   libc through the C runtime until M2.
 > - All other M0 items (`int`/`float`, `Result<T, E>` + `?`, closures with
 >   capture, atomic intrinsics) remain planned.
 
@@ -728,25 +733,30 @@ declarations — pure Sailfin source, no C. The compiler emits LLVM `declare`
 directives for each extern; the linker resolves them against libc/libpthread at
 link time.
 
-**`runtime/sfn/platform/libc.sfn`** (selected entries):
+**`runtime/sfn/platform/libc.sfn`** — the first 12 declarations
+shipped 2026-05-01 use `usize` for `size_t`-shaped parameters and
+omit `setjmp`/`longjmp`/`memchr` until follow-up PRs land their
+dependencies (opaque `JmpBuf` size, exception subsystem). The
+shape below is the design target across all milestones; selected
+entries:
 
 ```sailfin
 // Memory
-extern fn malloc(size: i64) -> *u8;
+extern fn malloc(size: usize) -> *u8;
 extern fn free(ptr: *u8) -> void;
-extern fn realloc(ptr: *u8, new_size: i64) -> *u8;
-extern fn memcpy(dst: *u8, src: *u8, n: i64) -> *u8;
-extern fn memcmp(a: *u8, b: *u8, n: i64) -> i32;
-extern fn memchr(haystack: *u8, byte: i32, n: i64) -> *u8;
+extern fn realloc(ptr: *u8, new_size: usize) -> *u8;
+extern fn memcpy(dst: *u8, src: *u8, n: usize) -> *u8;
+extern fn memcmp(a: *u8, b: *u8, n: usize) -> i32;
+extern fn memchr(haystack: *u8, byte: i32, n: usize) -> *u8;
 
 // I/O (fd-based)
-extern fn write(fd: i32, buf: *u8, count: i64) -> i64;
-extern fn read(fd: i32, buf: *u8, count: i64) -> i64;
+extern fn write(fd: i32, buf: *u8, count: usize) -> i64;
+extern fn read(fd: i32, buf: *u8, count: usize) -> i64;
 
 // Stdio filesystem
 extern fn fopen(path: *u8, mode: *u8) -> *File;
-extern fn fread(buf: *u8, size: i64, nmemb: i64, f: *File) -> i64;
-extern fn fwrite(buf: *u8, size: i64, nmemb: i64, f: *File) -> i64;
+extern fn fread(buf: *u8, size: usize, nmemb: usize, f: *File) -> usize;
+extern fn fwrite(buf: *u8, size: usize, nmemb: usize, f: *File) -> usize;
 extern fn fclose(f: *File) -> i32;
 
 // Environment + exception support

--- a/docs/runtime_audit.md
+++ b/docs/runtime_audit.md
@@ -17,6 +17,12 @@
 >   below is satisfied. Cross-module *call-site* resolution against the
 >   typecheck symbol table is the open follow-up; today the symbol table is
 >   duplicate-detection-only, so externs round-trip without a resolver.
+> - **First `runtime/sfn/platform/libc.sfn` skeleton — shipped 2026-05-01**
+>   (12 declarations covering libc memory, fd-based I/O, stdio filesystem,
+>   environment). Not imported anywhere yet; the C runtime continues to
+>   serve libc calls until M2. Pinned by
+>   `compiler/tests/e2e/test_runtime_libc_skeleton.sh` (typecheck + fmt +
+>   LLVM `declare` emission for every symbol).
 
 ## Purpose
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -699,6 +699,7 @@ The runtime rewrite depends on compiler features that must ship first. The
 | Compiler Feature | Status | Runtime Subsystems It Unblocks |
 |---|---|---|
 | `extern fn` (parser + type-checker + LLVM `declare` emission) | **Shipped** (parser + emitter + typecheck registration with E0801–E0805 C-ABI validation; cross-module call-site resolution deferred until typecheck grows a call resolver) | All — `runtime/sfn/platform/*.sfn` modules can now type-check end-to-end |
+| First `runtime/sfn/platform/libc.sfn` skeleton (12 declarations: malloc/free/realloc/memcpy/memcmp, write/read, fopen/fclose/fread/fwrite, getenv) | **Shipped 2026-05-01** (typecheck + fmt + LLVM `declare` emission verified by `compiler/tests/e2e/test_runtime_libc_skeleton.sh`); not yet imported by any module | Confirms the extern pipeline works on a realistic file; seed for `runtime/sfn/memory.sfn`, `runtime/sfn/io.sfn`, and `runtime/sfn/adapters/filesystem.sfn` at M2 |
 | `int` / `float` numeric types | Planned | Sizes, indices, bitwise ops; fixes f64 precision hazard |
 | Raw pointer types (`*T`) enforced | Planned | OS handles (`*FILE`, `*DIR`, `*pthread_t`), buffer pointers |
 | `Result<T, E>` + `?` operator | Planned | Every fallible operation (file I/O, allocation, network) |

--- a/runtime/sfn/platform/libc.sfn
+++ b/runtime/sfn/platform/libc.sfn
@@ -1,0 +1,74 @@
+// runtime/sfn/platform/libc.sfn
+//
+// Pure-Sailfin extern declarations for a curated subset of libc.
+// This is the **first** file in the path toward a pure-Sailfin
+// runtime — see `docs/runtime_architecture.md` §2.9 ("Platform
+// Extern Declarations").
+//
+// Status: typecheck smoke test. Not imported anywhere yet; the
+// runtime continues to reach libc through `runtime/native/src/
+// sailfin_runtime.c` until the Sailfin-native runtime lands at M2
+// (per the milestone plan in `docs/runtime_architecture.md` §4).
+// Once `int`/`float` numeric types and `Result<T, E>` ship, this
+// file becomes the seed for `runtime/sfn/memory.sfn`,
+// `runtime/sfn/io.sfn`, and `runtime/sfn/adapters/filesystem.sfn`.
+//
+// Type discipline: every declaration here uses only types from the
+// v0 C-ABI accept-list enforced by `compiler/src/typecheck_types.
+// sfn:check_extern_signature` (E0801–E0805) — i8 / i32 / i64 / u8 /
+// usize / bool, raw pointers (`*T`, `*const T`, `*OpaqueStruct`),
+// `void` (return only). Wider integer/float types (i16, u32, f64,
+// isize, …) are intentionally absent until the LLVM type mapper
+// learns to lower them. Adding declarations here that step outside
+// the accept-list would surface as E0805 the moment this file is
+// imported.
+//
+// `unsafe` keyword: omitted on every declaration. The architect's
+// design doc (§3.6) calls out `unsafe` as a documentation marker
+// today; making it required is a separate parser/effect-system
+// workstream. Adapters that wrap these externs will carry the
+// `![io]`/`![net]`/etc. effects per the wrapping-adapter rule.
+// ── Memory management ─────────────────────────────────────────
+// libc memory primitives. Sizes flow as `usize` (lowered to i64
+// today). Untyped result pointers are `*u8` per the Sailfin
+// convention — adapters cast onto typed pointers as soon as the
+// memory crosses back into Sailfin.
+extern fn malloc(size: usize) -> * u8;
+
+extern fn free(ptr: * u8) -> void;
+
+extern fn realloc(ptr: * u8, new_size: usize) -> * u8;
+
+extern fn memcpy(dst: * u8, src: * u8, n: usize) -> * u8;
+
+extern fn memcmp(a: * u8, b: * u8, n: usize) -> i32;
+
+// ── Raw I/O (file-descriptor based) ───────────────────────────
+// `write`/`read` are POSIX, returning ssize_t (i64 on every
+// platform Sailfin currently targets). Negative returns signal
+// errno; adapters translate to `Result<T, IoError>` when that
+// type ships.
+extern fn write(fd: i32, buf: * u8, count: usize) -> i64;
+
+extern fn read(fd: i32, buf: * u8, count: usize) -> i64;
+
+// ── Stdio filesystem ──────────────────────────────────────────
+// `*File` is an opaque platform handle. The opaque-pointee rule
+// in the typechecker (`is_extern_opaque_pointee`) accepts any
+// uppercase identifier as a valid pointee without requiring a
+// struct definition — `*File` lowers to `i8*` in LLVM IR. The
+// Sailfin-native filesystem adapter (M3) wraps these into
+// `runtime/sfn/adapters/filesystem.sfn` calls.
+extern fn fopen(path: * u8, mode: * u8) -> * File;
+
+extern fn fclose(f: * File) -> i32;
+
+extern fn fread(buf: * u8, size: usize, nmemb: usize, f: * File) -> usize;
+
+extern fn fwrite(buf: * u8, size: usize, nmemb: usize, f: * File) -> usize;
+
+// ── Environment ───────────────────────────────────────────────
+// Returns a NUL-terminated C string owned by the libc environ
+// table — adapters must copy before storing. Adapters are gated
+// by `![io]` per the §3.6 effect-on-wrapper rule.
+extern fn getenv(name: * u8) -> * u8;

--- a/runtime/sfn/platform/libc.sfn
+++ b/runtime/sfn/platform/libc.sfn
@@ -14,14 +14,15 @@
 // `runtime/sfn/io.sfn`, and `runtime/sfn/adapters/filesystem.sfn`.
 //
 // Type discipline: every declaration here uses only types from the
-// v0 C-ABI accept-list enforced by `compiler/src/typecheck_types.
-// sfn:check_extern_signature` (E0801–E0805) — i8 / i32 / i64 / u8 /
-// usize / bool, raw pointers (`*T`, `*const T`, `*OpaqueStruct`),
-// `void` (return only). Wider integer/float types (i16, u32, f64,
-// isize, …) are intentionally absent until the LLVM type mapper
-// learns to lower them. Adding declarations here that step outside
-// the accept-list would surface as E0805 the moment this file is
-// imported.
+// v0 C-ABI accept-list. The validator is `check_extern_signature`
+// in `compiler/src/typecheck_types.sfn` and rejects non-conforming
+// signatures with diagnostics E0801–E0805. Accepted forms are i8 /
+// i32 / i64 / u8 / usize / bool, raw pointers (`* u8`, `* const T`,
+// `* OpaqueStruct`), and `void` (return only). Wider integer/float
+// types (i16, u32, f64, isize, …) are intentionally absent until
+// the LLVM type mapper learns to lower them. Adding declarations
+// here that step outside the accept-list would surface as E0805
+// the moment this file is imported.
 //
 // `unsafe` keyword: omitted on every declaration. The architect's
 // design doc (§3.6) calls out `unsafe` as a documentation marker
@@ -30,9 +31,12 @@
 // `![io]`/`![net]`/etc. effects per the wrapping-adapter rule.
 // ── Memory management ─────────────────────────────────────────
 // libc memory primitives. Sizes flow as `usize` (lowered to i64
-// today). Untyped result pointers are `*u8` per the Sailfin
+// today). Untyped result pointers are `* u8` per the Sailfin
 // convention — adapters cast onto typed pointers as soon as the
-// memory crosses back into Sailfin.
+// memory crosses back into Sailfin. (The formatter writes raw
+// pointer types with a space after `*`; the comments throughout
+// this file match that spelling so anything copy-pasted lands in
+// canonical-formatted form.)
 extern fn malloc(size: usize) -> * u8;
 
 extern fn free(ptr: * u8) -> void;
@@ -53,10 +57,10 @@ extern fn write(fd: i32, buf: * u8, count: usize) -> i64;
 extern fn read(fd: i32, buf: * u8, count: usize) -> i64;
 
 // ── Stdio filesystem ──────────────────────────────────────────
-// `*File` is an opaque platform handle. The opaque-pointee rule
+// `* File` is an opaque platform handle. The opaque-pointee rule
 // in the typechecker (`is_extern_opaque_pointee`) accepts any
 // uppercase identifier as a valid pointee without requiring a
-// struct definition — `*File` lowers to `i8*` in LLVM IR. The
+// struct definition — `* File` lowers to `i8*` in LLVM IR. The
 // Sailfin-native filesystem adapter (M3) wraps these into
 // `runtime/sfn/adapters/filesystem.sfn` calls.
 extern fn fopen(path: * u8, mode: * u8) -> * File;


### PR DESCRIPTION
## Summary

The first file in the path toward a pure-Sailfin runtime. Drops 12
extern declarations covering the libc surface the M2 runtime rewrite
will reach for first.

Per `docs/runtime_architecture.md` §2.9, this file is the
**typecheck-only smoke test** that confirms the extern-fn pipeline
(parser → typecheck → native-IR → LLVM `declare` lowering, all
shipped in #281) works end-to-end on a realistic file. It is **not
yet imported anywhere** — the runtime continues to reach libc
through `runtime/native/src/sailfin_runtime.c` until the
Sailfin-native runtime lands at M2.

Once `int`/`float` numeric types and `Result<T, E>` ship, this
skeleton becomes the seed for `runtime/sfn/memory.sfn`,
`runtime/sfn/io.sfn`, and `runtime/sfn/adapters/filesystem.sfn`.

## What ships

`runtime/sfn/platform/libc.sfn` — 12 declarations:

| Group | Symbols |
|---|---|
| Memory | `malloc`, `free`, `realloc`, `memcpy`, `memcmp` |
| Raw I/O | `write`, `read` |
| Stdio | `fopen`, `fclose`, `fread`, `fwrite` |
| Environment | `getenv` |

Type discipline: every declaration uses only types from the
post-#281 C-ABI accept-list (`i8`/`i32`/`i64`/`u8`/`usize`/`bool`,
`void` return, raw pointers, opaque-struct pointers). Sizes flow as
`usize` for `size_t`-shaped parameters; ssize_t-shaped returns are
`i64`. `*File` is an opaque platform handle accepted under the
`is_extern_opaque_pointee` rule.

`setjmp`/`longjmp`/`memchr` are deferred until follow-up PRs land
their dependencies (opaque `JmpBuf` size constants, exception
subsystem).

## Tests

`compiler/tests/e2e/test_runtime_libc_skeleton.sh` (new) runs three
checks against the skeleton:

1. **`sfn check`** exits 0 — every declaration satisfies the C-ABI
   accept-list (E0801–E0805 from #281 don't fire).
2. **`sfn fmt --check`** is canonical — the CI fmt step at
   `.github/workflows/ci.yml:113` already covers `runtime/`, but
   pinning here surfaces regressions in `make test-e2e` before
   reaching CI.
3. **`sfn emit llvm`** produces a `declare` directive for every one
   of the 12 externs. This is the architect's M1 fast-fail criterion
   (`docs/runtime_architecture.md` §3.6) made executable.

Verified emitted LLVM contains:
```
declare i8* @malloc(i64 %size)
declare void @free(i8* %ptr)
declare i8* @realloc(i8* %ptr, i64 %new_size)
declare i8* @memcpy(i8* %dst, i8* %src, i64 %n)
declare i32 @memcmp(i8* %a, i8* %b, i64 %n)
declare i64 @write(i32 %fd, i8* %buf, i64 %count)
declare i64 @read(i32 %fd, i8* %buf, i64 %count)
declare i8* @fopen(i8* %path, i8* %mode)
declare i32 @fclose(i8* %f)
declare i64 @fread(i8* %buf, i64 %size, i64 %nmemb, i8* %f)
declare i64 @fwrite(i8* %buf, i64 %size, i64 %nmemb, i8* %f)
declare i8* @getenv(i8* %name)
```

## Self-hosting safety

The skeleton file is not imported by any module in the tree. `make
compile` and the full test suite are unaffected.

## Documentation

Followed the directive to keep docs in sync:

- `docs/runtime_architecture.md` — Status delta updated with the
  skeleton bullet; §2.9 example block reformatted to match the
  actually-shipped signatures (`usize` for `size_t`, deferred
  setjmp/memchr noted).
- `docs/runtime_audit.md` — Status delta updated.
- `docs/status.md` — Runtime Migration Prerequisites table now
  lists the libc skeleton as shipped.

## Verification

- [x] `make compile` succeeds (self-host)
- [x] `make test-unit` — 82/82 passed
- [x] `make test-integration` — 17/17 passed
- [x] `bash compiler/tests/e2e/test_runtime_libc_skeleton.sh` —
  3/3 passed
- [ ] `make test-e2e` — 21/22 passed; the one failure
  (`test_check_compiler_src.sh`) is a pre-existing local SIGSEGV
  unrelated to this PR. Test scope is `compiler/src/`, not
  `runtime/`. PR #282 reduced the peak RSS in CI; my WSL
  environment still triggers under the 8 GB ulimit. Filing as
  out-of-scope.

## Sequencing — what's next

After this lands, the next items on the runtime-rewrite critical
path:

1. **`int` (i64) / `float` (f64) numeric types** — biggest ripple,
   foundational. Once shipped, the libc skeleton's `usize`/`i64`
   choices become more meaningful (today `usize` is just a
   `map_primitive_type` alias for `i64`).
2. **`Result<T, E>` + `?` operator** — required so the runtime can
   return structured errors (e.g. `read` returning
   `Result<i64, IoError>` instead of the negative-errno
   convention).
3. **Backend support for wider integer/float types** (i16, u32,
   f64, etc.) — admits more libc surface area into the skeleton
   (currently blocked by `map_primitive_type` not having entries
   for them per the post-#281 accept-list).

## Test plan
- [x] `ulimit -v 8388608 && make compile`
- [x] `ulimit -v 8388608 && make test-unit`
- [x] `ulimit -v 8388608 && make test-integration`
- [x] `ulimit -v 8388608 && bash compiler/tests/e2e/test_runtime_libc_skeleton.sh build/native/sailfin`
- [x] `ulimit -v 8388608 && build/native/sailfin emit -o /tmp/libc.ll llvm runtime/sfn/platform/libc.sfn` (manual smoke check — emitted IR contains every expected `declare`)

https://claude.ai/code/session_01UshA2J9C8CdXNsdqec9UdN

---
_Generated by [Claude Code](https://claude.ai/code/session_01UshA2J9C8CdXNsdqec9UdN)_