### PR TITLE
fix(test-runner): isolate sfn test scratch dir + replace racey _shell_read_cmd

### DIFF
--- a/compiler/src/capsule_resolver.sfn
+++ b/compiler/src/capsule_resolver.sfn
@@ -620,14 +620,31 @@ fn mangle_slug(slug: string) -> string {
 }
 
 // ---- LL path resolution (Stage C2b2) ----
+// Resolve the scratch root used for `_cr_legacy_ll_path` and the
+// `compile_capsule_modules` ensure-dir calls. Defaults to
+// `"build/sailfin"`; honours `SAILFIN_TEST_SCRATCH` when set so that
+// callers wanting per-invocation isolation (e.g.
+// `scripts/run_native_test.sh` running tests under a fresh
+// `mktemp -d`) can keep concurrent `sfn test` runs from racing on
+// `build/sailfin/capsules/<slug>.ll`. The env var is read once via
+// the shell printf trick the resolver already uses for
+// `SAILFIN_BUILD_JOBS`; an empty value falls through to the default
+// so that `unset SAILFIN_TEST_SCRATCH` and `SAILFIN_TEST_SCRATCH=`
+// behave identically (no surprise paths on a stripped env).
+fn _cr_scratch_root() -> string ![io] {
+    let env = _cr_shell_read("printf '%s' \"$SAILFIN_TEST_SCRATCH\"");
+    if env.length > 0 { return env; }
+    return "build/sailfin";
+}
+
 // Legacy flat layout for the `.ll` of a slug. Used by the C2b2
 // fallback path: positional builds, single-segment `[capsule].name`
 // (the compiler self-host falls in this bucket — its name is
 // `"sailfin"`), and any source whose slug doesn't match a known
 // dep prefix. One source of truth so the fallback never drifts
 // across the two CapsuleSource construction sites.
-fn _cr_legacy_ll_path(slug: string) -> string {
-    return "build/sailfin/capsules/" + mangle_slug(slug) + ".ll";
+fn _cr_legacy_ll_path(slug: string) -> string ![io] {
+    return _cr_scratch_root() + "/capsules/" + mangle_slug(slug) + ".ll";
 }
 
 // Resolve the per-module `.ll` path under the given layout, falling
@@ -635,7 +652,7 @@ fn _cr_legacy_ll_path(slug: string) -> string {
 // the slug. Pure delegate to `ir_path_for_slug` from
 // `capsule_artifact.sfn`; kept here so the resolver has a single
 // site that owns the fallback policy.
-fn _cr_resolve_ll_path(slug: string, layout: CapsuleArtifactLayout) -> string {
+fn _cr_resolve_ll_path(slug: string, layout: CapsuleArtifactLayout) -> string ![io] {
     let candidate = ir_path_for_slug(layout, slug);
     if candidate.length > 0 { return candidate; }
     return _cr_legacy_ll_path(slug);
@@ -1526,8 +1543,9 @@ fn _cr_compile_one(src: CapsuleSource, dep_manifests: string[], cache_root_path:
 // root before any per-module work — done once per build, not per
 // module, so a single `--clean` run can't double-wipe.
 fn compile_capsule_modules(sources: CapsuleSource[], config: BuildCacheConfig, sailfin_exe: string) -> CompileCapsuleResult ![io] {
-    _cr_ensure_dir("build/sailfin");
-    _cr_ensure_dir("build/sailfin/capsules");
+    let scratch_root = _cr_scratch_root();
+    _cr_ensure_dir(scratch_root);
+    _cr_ensure_dir(scratch_root + "/capsules");
     // Per-source dep manifests (PR1e): each `_cr_compile_one` call
     // sees only the manifests of modules it directly imports, so an
     // unrelated capsule changing busts only the modules that

--- a/compiler/src/capsule_resolver.sfn
+++ b/compiler/src/capsule_resolver.sfn
@@ -299,20 +299,49 @@ fn _cr_ends_with(text: string, suffix: string) -> boolean {
     return strings_equal(substring(text, start, text.length), suffix);
 }
 
+// Forward-declare the arena-aware popen-based capture helper so the
+// resolver's env reads (`_cr_scratch_root`, `_cr_get_home`,
+// `SAILFIN_BUILD_JOBS` lookup, `mktemp` calls) don't go through the
+// fixed `/tmp/.sfn_capsule_resolver_tmp` path that previously raced
+// across xargs-spawned emit workers and parallel `sfn test`
+// invocations. The helper is the same one
+// `cli_commands_utils.sfn:_shell_read_cmd` calls; declaring it here
+// keeps the resolver self-contained (no new cross-module import).
+extern fn sailfin_runtime_shell_capture(cmd: * u8) -> * u8;
+
 fn _cr_shell_read(cmd: string) -> string ![io] {
-    let tmp = "/tmp/.sfn_capsule_resolver_tmp";
-    let rc = process.run(["sh", "-c", cmd + " > " + tmp + " 2>/dev/null"]);
-    if rc != 0 { return ""; }
-    if !fs.exists(tmp) { return ""; }
-    let raw = fs.readFile(tmp);
-    process.run(["rm", "-f", tmp]);
-    // Trim trailing newline
-    if raw.length > 0 {
-        if substring(raw, raw.length - 1, raw.length) == "\n" {
-            return substring(raw, 0, raw.length - 1);
-        }
+    let captured = sailfin_runtime_shell_capture(cmd);
+    // Match the trimming semantics of `cli_commands_utils.sfn:_shell_read_cmd`
+    // (which routes through `_toml_trim_cmd` for symmetric whitespace
+    // stripping). Without this, an env value with trailing whitespace
+    // could make `_cr_scratch_root` and `_test_scratch_root` disagree
+    // on the path and route artifacts to different directories.
+    if captured.length == 0 { return ""; }
+    let mut start: number = 0;
+    let mut end: number = captured.length;
+    loop {
+        if start >= end { break; }
+        let c = substring(captured, start, start + 1);
+        let mut ws: boolean = false;
+        if c == " " { ws = true; }
+        if c == "\n" { ws = true; }
+        if c == "\r" { ws = true; }
+        if c == "\t" { ws = true; }
+        if !ws { break; }
+        start += 1;
     }
-    return raw;
+    loop {
+        if end <= start { break; }
+        let c = substring(captured, end - 1, end);
+        let mut ws: boolean = false;
+        if c == " " { ws = true; }
+        if c == "\n" { ws = true; }
+        if c == "\r" { ws = true; }
+        if c == "\t" { ws = true; }
+        if !ws { break; }
+        end -= 1;
+    }
+    return substring(captured, start, end);
 }
 
 fn _cr_get_home() -> string ![io] {

--- a/compiler/src/cli_commands.sfn
+++ b/compiler/src/cli_commands.sfn
@@ -152,6 +152,31 @@ fn _clang_link_test_cmd_with_deps(ll_path: string, out_path: string, runtime_roo
     return process.run(args);
 }
 
+// Resolve the per-test scratch root used for the test runner's
+// ephemeral artifacts (`test.ll`, the linked test executable,
+// `test-o0/`, dump-sources output, and the resolver's per-module
+// `.ll` cache via `_cr_scratch_root`). Defaults to
+// `"build/sailfin"`; honours `SAILFIN_TEST_SCRATCH` when set so
+// that callers wanting per-invocation isolation (e.g.
+// `scripts/run_native_test.sh` running tests under a fresh
+// `mktemp -d`) can keep concurrent `sfn test` runs from racing on
+// the same `test.ll` / `capsules/<slug>.ll` paths. The capsule
+// resolver reads the same env var (`_cr_scratch_root`), so both
+// halves of a `sfn test` run agree on the scratch root without
+// any in-process plumbing.
+//
+// Persistent control flags (`.trace_test_runner`,
+// `.dump_test_sources`) and the run-marker (`.test_runner_active`)
+// stay rooted at `build/sailfin/` so an `unset SAILFIN_TEST_SCRATCH`
+// run still observes user-toggled debug switches and so the
+// marker file remains discoverable across processes for the
+// existing diagnostic tooling that grep's for it.
+fn _test_scratch_root() -> string ![io] {
+    let env = _get_env_cmd("SAILFIN_TEST_SCRATCH");
+    if env.length > 0 { return env; }
+    return "build/sailfin";
+}
+
 // ---- Exported command handlers ----
 // Remove stale LLVM lowering scratchpad files from build/sailfin/ so that
 // inter-phase data from a previous compilation doesn't corrupt the next one.
@@ -288,8 +313,15 @@ fn handle_test_command(args: string[], runtime_root: string) -> number ![io] {
 
     _ensure_dir_cmd("build");
     _ensure_dir_cmd("build/sailfin");
-    _ensure_dir_cmd("build/sailfin/test-o0");
+    let scratch_root = _test_scratch_root();
+    _ensure_dir_cmd(scratch_root);
+    _ensure_dir_cmd(scratch_root + "/test-o0");
 
+    // Persistent control flags + run-marker stay at the fixed
+    // `build/sailfin/` root; see `_test_scratch_root` for the
+    // rationale. Per-test ephemera (`test.ll`, the linked test
+    // exe, `test-source-*` dumps) live under `scratch_root` so
+    // concurrent invocations don't clobber each other.
     let test_runner_active_path = "build/sailfin/.test_runner_active";
     _write_text_cmd(test_runner_active_path, "");
 
@@ -300,8 +332,8 @@ fn handle_test_command(args: string[], runtime_root: string) -> number ![io] {
         return 1;
     }
 
-    let ll_path = "build/sailfin/test.ll";
-    let exe_path = "build/sailfin/test";
+    let ll_path = scratch_root + "/test.ll";
+    let exe_path = scratch_root + "/test";
     let dump_sources = fs.exists("build/sailfin/.dump_test_sources");
     let trace_runner = fs.exists("build/sailfin/.trace_test_runner");
 
@@ -427,11 +459,11 @@ fn handle_test_command(args: string[], runtime_root: string) -> number ![io] {
 
         if dump_sources {
             let safe = _sanitize_filename_cmd(path);
-            _write_text_cmd("build/sailfin/test-source-" + safe + ".sfn", source);
+            _write_text_cmd(scratch_root + "/test-source-" + safe + ".sfn", source);
         }
 
         if trace_runner { print.err("test runner: compile start"); }
-        _clean_lowering_state("build/sailfin");
+        _clean_lowering_state(scratch_root);
         let empty_manifests: LayoutManifest[] = [];
         let _compiled = compile_tests_to_llvm_file_with_module_imports(source, module_name, ll_path, groups[group_idx].interfaces, empty_manifests, groups[group_idx].native_texts, groups[group_idx].function_effects, groups[group_idx].capabilities_required);
         if !_compiled {

--- a/compiler/src/cli_commands_utils.sfn
+++ b/compiler/src/cli_commands_utils.sfn
@@ -96,14 +96,24 @@ fn _toml_trim_cmd(text: string) -> string {
     return substring(text, s, e);
 }
 
+// Forward declare the arena-aware popen-based capture helper added
+// in `runtime/native/src/sailfin_runtime.c`. The pre-existing
+// implementation of `_shell_read_cmd` redirected the shell's stdout
+// through `/tmp/.sfn_shell_read_cmd_tmp` — a single fixed path that
+// raced under any cross-process concurrency (xargs-spawned emit
+// workers, parallel `sfn test` invocations, `make compile`'s
+// subprocess-stage import-context). One process truncating the file
+// while another was mid-write produced silently-corrupt env reads,
+// broken build-cache key hashes, and the
+// `clang: error: no such file or directory: build/sailfin/capsules/<slug>.ll`
+// flake that surfaced as "transient I/O-pressure" in
+// `scripts/run_native_test.sh`'s retry table. Reading via popen
+// avoids the tmp file entirely.
+extern fn sailfin_runtime_shell_capture(cmd: * u8) -> * u8;
+
 fn _shell_read_cmd(cmd: string) -> string ![io] {
-    let tmp = "/tmp/.sfn_shell_read_cmd_tmp";
-    let rc = process.run(["sh", "-c", cmd + " > " + tmp + " 2>/dev/null"]);
-    if rc != 0 { return ""; }
-    if !fs.exists(tmp) { return ""; }
-    let raw = fs.readFile(tmp);
-    process.run(["rm", "-f", tmp]);
-    return _toml_trim_cmd(raw);
+    let captured = sailfin_runtime_shell_capture(cmd);
+    return _toml_trim_cmd(captured);
 }
 
 fn _get_env_cmd(name: string) -> string ![io] {

--- a/runtime/native/include/sailfin_runtime.h
+++ b/runtime/native/include/sailfin_runtime.h
@@ -102,6 +102,16 @@ extern "C"
     // Terminate the process with the given exit code. Never returns.
     void sailfin_runtime_process_exit(double code);
 
+    // Execute `cmd` via popen("r") and return its stdout as a
+    // freshly-allocated runtime string. Used by `_shell_read_cmd`
+    // and friends to capture command output without the shared-tmp-
+    // file dance that previously raced across concurrent processes
+    // (every caller writing to `/tmp/.sfn_shell_read_cmd_tmp`).
+    // Returns "" on popen failure or non-zero exit; callers cannot
+    // distinguish those from a legitimately empty output, matching
+    // the pre-existing `_shell_read_cmd` contract.
+    char *sailfin_runtime_shell_capture(char *cmd);
+
     // Additional prelude/runtime helpers (currently minimal implementations).
     void sailfin_runtime_copy_bytes(char *dest, char *src, int64_t length);
     char *sailfin_runtime_log_execution(char *value);

--- a/runtime/native/src/sailfin_runtime.c
+++ b/runtime/native/src/sailfin_runtime.c
@@ -5160,19 +5160,32 @@ void sailfin_runtime_process_exit(double code)
  */
 static char *_popen_read_all(const char *cmd);
 
+/*
+ * Static empty-string fallback for `sailfin_runtime_shell_capture`'s
+ * OOM paths. The Sailfin caller treats the return value as a
+ * `string` (i8*) and immediately reads `.length` / iterates over it;
+ * returning NULL would crash the trim loop in
+ * `_shell_read_cmd` / `_cr_shell_read`. A static `""` is safe under
+ * either allocator mode — the caller never frees it (string_drop is
+ * a no-op for `mark_persistent`-style pointers, and arena mode skips
+ * free entirely), and even if a future caller did free it, the C
+ * heap-validator catches that as a clear "tried to free a static"
+ * abort, not a silent corruption. The address is unique and stable,
+ * so equality checks against this sentinel keep working.
+ */
+static char _sailfin_runtime_shell_capture_empty[1] = { '\0' };
+
 char *sailfin_runtime_shell_capture(char *cmd)
 {
     _runtime_enter();
     if (!cmd)
     {
-        char *empty = (char *)_rt_calloc(1, 1);
-        return empty;
+        return _sailfin_runtime_shell_capture_empty;
     }
     char *captured = _popen_read_all(cmd);
     if (!captured)
     {
-        char *empty = (char *)_rt_calloc(1, 1);
-        return empty;
+        return _sailfin_runtime_shell_capture_empty;
     }
     /* `_popen_read_all` returns malloc-allocated memory for legacy
      * compatibility with `sailfin_runtime_http_*`. Copy into the
@@ -5183,8 +5196,10 @@ char *sailfin_runtime_shell_capture(char *cmd)
     char *out = (char *)_rt_calloc(1, len + 1);
     if (!out)
     {
+        /* OOM during the rt-side copy — fall through to the static
+         * empty string so the Sailfin caller never sees NULL. */
         free(captured);
-        return NULL;
+        return _sailfin_runtime_shell_capture_empty;
     }
     memcpy(out, captured, len);
     free(captured);

--- a/runtime/native/src/sailfin_runtime.c
+++ b/runtime/native/src/sailfin_runtime.c
@@ -5129,6 +5129,68 @@ void sailfin_runtime_process_exit(double code)
     exit(exit_code);
 }
 
+/*
+ * sailfin_runtime_shell_capture
+ *
+ * Run `cmd` through popen and return its stdout as a freshly-
+ * allocated runtime string. Replaces the cross-process-racey pattern
+ * `_shell_read_cmd` previously implemented in Sailfin source —
+ *
+ *   process.run(["sh","-c", cmd + " > /tmp/.sfn_shell_read_cmd_tmp"])
+ *   fs.readFile("/tmp/.sfn_shell_read_cmd_tmp")
+ *
+ * — where every concurrent invocation across a process boundary
+ * (xargs-spawned compile workers, parallel `sfn test` invocations,
+ * `make compile`'s subprocess-stage import-context) collided on the
+ * single fixed tmp path. One process's redirect-truncate would
+ * empty another's just-written output mid-flight, producing
+ * silently-corrupt env reads, broken cache hashes, and ultimately
+ * `clang: error: no such file or directory: build/sailfin/capsules/<slug>.ll`
+ * at link time when the cache key drifted away from the real input.
+ *
+ * Allocation lifetime matches the existing `_popen_read_all`-using
+ * helpers (`sailfin_runtime_http_get`, etc.): the buffer is
+ * `_rt_calloc`-routed via `_runtime_enter` so arena mode reclaims it
+ * in bulk, and malloc mode owns it through the runtime's standard
+ * lifecycle. Callers must not free.
+ *
+ * Empty output is returned as a freshly-allocated empty string (not
+ * NULL) so Sailfin-side `.length == 0` checks behave identically
+ * to the pre-existing `_shell_read_cmd` contract.
+ */
+static char *_popen_read_all(const char *cmd);
+
+char *sailfin_runtime_shell_capture(char *cmd)
+{
+    _runtime_enter();
+    if (!cmd)
+    {
+        char *empty = (char *)_rt_calloc(1, 1);
+        return empty;
+    }
+    char *captured = _popen_read_all(cmd);
+    if (!captured)
+    {
+        char *empty = (char *)_rt_calloc(1, 1);
+        return empty;
+    }
+    /* `_popen_read_all` returns malloc-allocated memory for legacy
+     * compatibility with `sailfin_runtime_http_*`. Copy into the
+     * runtime allocator so arena mode can reclaim it; malloc mode's
+     * `_rt_calloc` is just a `calloc`, so the copy is the only
+     * change in cost. */
+    size_t len = strlen(captured);
+    char *out = (char *)_rt_calloc(1, len + 1);
+    if (!out)
+    {
+        free(captured);
+        return NULL;
+    }
+    memcpy(out, captured, len);
+    free(captured);
+    return out;
+}
+
 bool sailfin_runtime_is_callable(char *value)
 {
     (void)value;

--- a/scripts/run_native_test.sh
+++ b/scripts/run_native_test.sh
@@ -13,11 +13,33 @@ COMPILER="$1"
 TEST_FILE="$2"
 BASENAME="$(basename "$TEST_FILE")"
 
-# Clean build/sailfin/ scratch directory to prevent cross-test contamination.
-# The compiler writes intermediate files (test.ll, IPC dot-files) into this
-# directory; leftovers from a prior test can alter subsequent runs.
-rm -rf build/sailfin 2>/dev/null || true
+# Per-invocation scratch dir, exported via `SAILFIN_TEST_SCRATCH` so
+# the test command + capsule resolver write `test.ll`, the linked
+# test exe, and per-module `capsules/<slug>.ll` under a path nobody
+# else can touch. Two motivations:
+#   1. Concurrent invocations no longer race on
+#      `build/sailfin/capsules/<slug>.ll`. Pre-fix, two parallel
+#      `sfn test` runs of the same test produced
+#      `clang: error: no such file or directory: build/sailfin/capsules/parser__mod.ll`
+#      ~50% of the time because each invocation's `rm -rf
+#      build/sailfin` at the head of this script clobbered the
+#      other's resolver output mid-flight.
+#   2. Sequential test runs no longer need a destructive `rm -rf`
+#      to guarantee isolation — each test owns its own tree, and
+#      the cleanup trap below removes it on exit. That keeps the
+#      previous test's artifacts available for post-mortem if the
+#      *current* test fails (the compiler still writes its
+#      diagnostics into the now-isolated scratch).
+#
+# We still ensure `build/sailfin/` exists for persistent control
+# flags (`.trace_test_runner`, `.dump_test_sources`,
+# `.test_runner_active`) that callers create against the canonical
+# path; `sfn test` reads those from `build/sailfin/` regardless of
+# `SAILFIN_TEST_SCRATCH`.
 mkdir -p build/sailfin
+SAILFIN_TEST_SCRATCH="$(mktemp -d "${TMPDIR:-/tmp}/sfn-test-XXXXXX")"
+export SAILFIN_TEST_SCRATCH
+trap 'rm -rf "$SAILFIN_TEST_SCRATCH"' EXIT
 
 # Per-test wall-clock budget. Tight enough that hung binaries fail fast,
 # loose enough that legitimate compiles don't get clipped on CI under

--- a/scripts/run_native_test.sh
+++ b/scripts/run_native_test.sh
@@ -26,10 +26,15 @@ BASENAME="$(basename "$TEST_FILE")"
 #      other's resolver output mid-flight.
 #   2. Sequential test runs no longer need a destructive `rm -rf`
 #      to guarantee isolation — each test owns its own tree, and
-#      the cleanup trap below removes it on exit. That keeps the
-#      previous test's artifacts available for post-mortem if the
-#      *current* test fails (the compiler still writes its
-#      diagnostics into the now-isolated scratch).
+#      the cleanup trap below removes it on success. The trap
+#      preserves the scratch tree on FAILURE so post-mortem tooling
+#      can inspect the partial `.ll` outputs, the `test.ll` source,
+#      and any resolver dot-files that recorded what went wrong;
+#      without that, the only debugging signal would be the
+#      truncated `tail -10` of the test runner's combined output.
+#      Set `SAILFIN_TEST_KEEP_SCRATCH=1` to preserve the tree even
+#      on success (useful when bisecting a green-but-suspicious
+#      test that's masking a partial flake).
 #
 # We still ensure `build/sailfin/` exists for persistent control
 # flags (`.trace_test_runner`, `.dump_test_sources`,
@@ -39,7 +44,19 @@ BASENAME="$(basename "$TEST_FILE")"
 mkdir -p build/sailfin
 SAILFIN_TEST_SCRATCH="$(mktemp -d "${TMPDIR:-/tmp}/sfn-test-XXXXXX")"
 export SAILFIN_TEST_SCRATCH
-trap 'rm -rf "$SAILFIN_TEST_SCRATCH"' EXIT
+_sfn_test_cleanup() {
+    rc=$?
+    if [ "${SAILFIN_TEST_KEEP_SCRATCH:-0}" = "1" ]; then
+        echo "[run_native_test] preserving scratch: $SAILFIN_TEST_SCRATCH (SAILFIN_TEST_KEEP_SCRATCH=1)" >&2
+        return
+    fi
+    if [ "$rc" -ne 0 ]; then
+        echo "[run_native_test] preserving scratch on failure: $SAILFIN_TEST_SCRATCH" >&2
+        return
+    fi
+    rm -rf "$SAILFIN_TEST_SCRATCH"
+}
+trap _sfn_test_cleanup EXIT
 
 # Per-test wall-clock budget. Tight enough that hung binaries fail fast,
 # loose enough that legitimate compiles don't get clipped on CI under


### PR DESCRIPTION
## Summary

Two foundational cross-process fixes for the flake the test runner currently retries-and-papers-over as "transient I/O-pressure". Both manifest as `clang: error: no such file or directory: build/sailfin/capsules/<slug>.ll` at link time — the underlying causes are file-system races, not memory pressure.

### 1. Per-invocation scratch root for `sfn test`

`cli_commands.sfn` and `capsule_resolver.sfn` now honour `SAILFIN_TEST_SCRATCH` for every per-test artifact: `test.ll`, the linked test executable, `test-source-*` dumps, `_clean_lowering_state`, and the resolver's per-module `capsules/<slug>.ll` cache (both `_cr_legacy_ll_path` and `compile_capsule_modules`'s ensure-dir calls). `run_native_test.sh` now creates a fresh `mktemp -d` per invocation, exports `SAILFIN_TEST_SCRATCH` to point at it, and cleans up via `trap … EXIT`. Persistent control flags (`.trace_test_runner`, `.dump_test_sources`, `.test_runner_active`) stay rooted at `build/sailfin/` so existing diagnostic tooling that grep's for them is unchanged.

**Demonstrated bug** (origin/main): 6 concurrent `sfn test` invocations of the same test failed 3/6 of the time with `clang: error: no such file or directory: build/sailfin/capsules/parser__mod.ll`. Each `run_native_test.sh` does `rm -rf build/sailfin` at the head — concurrent invocations clobber each other's resolver output mid-flight. Post-fix: 6/6 parallel runs pass cleanly.

### 2. `sailfin_runtime_shell_capture` replaces `_shell_read_cmd`'s tmp-file dance

The previous `_shell_read_cmd` redirected the shell's stdout through a single fixed path (`/tmp/.sfn_shell_read_cmd_tmp`) that raced under any cross-process concurrency — most painfully the `xargs -P`-spawned emit workers in `_cr_run_parallel_emit`, every one of which calls `_shell_read_cmd` for env reads (`SAILFIN_BUILD_JOBS`, etc.) and would clobber its siblings' just-written output. One process's redirect-truncate would empty another's just-written value mid-flight, producing silently-corrupt env reads, broken build-cache key hashes, and the `clang: error: no such file or directory` flake at link time when the cache key drifted away from the real input.

The new runtime helper uses `popen("r")` + `_rt_calloc` and is forward-declared from Sailfin via `extern fn` (verified working end-to-end against the alpha.7 seed — no seed bump required).

## Files

- `runtime/native/include/sailfin_runtime.h` — declare `sailfin_runtime_shell_capture`.
- `runtime/native/src/sailfin_runtime.c` — implement via `_popen_read_all` + arena-aware copy; forward-decl `_popen_read_all` so the new function lands ahead of its existing definition.
- `compiler/src/cli_commands_utils.sfn` — `_shell_read_cmd` calls the new helper through `extern fn`; the tmp-file path is gone.
- `compiler/src/cli_commands.sfn` — `_test_scratch_root()` helper + thread it through `handle_test_command` for `test.ll`/`test`/`test-o0`/`test-source-*`/`_clean_lowering_state`.
- `compiler/src/capsule_resolver.sfn` — `_cr_scratch_root()` helper + thread it through `_cr_legacy_ll_path` + `compile_capsule_modules`'s ensure-dir calls.
- `scripts/run_native_test.sh` — replace destructive `rm -rf build/sailfin` with `mktemp -d` + `SAILFIN_TEST_SCRATCH` export + `trap` cleanup.

## Test plan

- [x] `make compile` from seed (alpha.7).
- [x] Build seedcheck via `scripts/build.sh`.
- [x] **6/6 parallel `run_native_test.sh` invocations** of `emit_native_extern_test.sfn` against seedcheck — race-failure-free (origin/main was 3/6 fail).
- [x] `make test-unit NATIVE_BIN=build/native/sailfin-seedcheck` → 82/82 PASS.
- [x] `make test-integration NATIVE_BIN=build/native/sailfin-seedcheck` → 17/17 PASS.
- [x] `make test-e2e NATIVE_BIN=build/native/sailfin-seedcheck` → 22/22 PASS (including `test_check_compiler_src.sh`).

## Pre-existing limitation noted, not addressed here

`make test` against the **one-pass** `build/native/sailfin` binary still hits the pre-existing alpha.7 seed's `@calloc` leak in `sfn check compiler/src/` (peak RSS 8 GB, SIGSEGV under the local 8 GB ulimit). PR #282 fixed that leak in source, but `.seed-version` is still pinned at `0.5.10-alpha.7` (pre-#282); the seedcheck binary picks up the new lowering and runs `sfn check` at peak ~2.3 GB. A seed bump to alpha.8+ would close that out for one-pass builds; out of scope for this PR.

https://claude.ai/code/session_01BPr16CrzUeYHjX53gsUBbJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01BPr16CrzUeYHjX53gsUBbJ)_