### PR TITLE
docs(site,readme): add JSON-LD schemas, opt-in robots.txt, README banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 <p align="center">
   <a href="https://sailfin.dev">
-    <img src="https://sailfin.dev/images/sfn_lockup.svg" alt="Sailfin" width="360">
+    <img src="https://raw.githubusercontent.com/SailfinIO/sailfin/main/site/public/images/sfn_lockup.svg" alt="Sailfin" width="360">
   </a>
 </p>
+
+<h1 align="center">Sailfin</h1>
 
 <p align="center">
   <strong>A compiled systems language with compile-time capability enforcement.</strong>

--- a/README.md
+++ b/README.md
@@ -1,7 +1,33 @@
-# Sailfin
+<p align="center">
+  <a href="https://sailfin.dev">
+    <img src="https://sailfin.dev/images/sfn_lockup.svg" alt="Sailfin" width="360">
+  </a>
+</p>
 
-Sailfin is a compiled systems language with compile-time capability enforcement.
-Every function declares what it can do — IO, network, clock, and more — and the compiler checks direct usage of effectful operations against those declarations before your code runs.
+<p align="center">
+  <strong>A compiled systems language with compile-time capability enforcement.</strong>
+</p>
+
+<p align="center">
+  Every function declares what it can do — IO, network, clock, and more — and the compiler checks direct usage of effectful operations against those declarations before your code runs.
+</p>
+
+<p align="center">
+  <a href="https://sailfin.dev"><strong>Website</strong></a> ·
+  <a href="https://sailfin.dev/docs/getting-started/install">Install</a> ·
+  <a href="https://sailfin.dev/docs/reference/spec/">Language Spec</a> ·
+  <a href="https://sailfin.dev/roadmap">Roadmap</a> ·
+  <a href="https://sailfin.dev/blog">Blog</a> ·
+  <a href="https://sailfin.dev/llms.txt"><code>llms.txt</code></a>
+</p>
+
+<p align="center">
+  <a href="https://github.com/SailfinIO/sailfin/releases"><img alt="Latest release" src="https://img.shields.io/github/v/release/SailfinIO/sailfin?include_prereleases&display_name=tag"></a>
+  <a href="https://github.com/SailfinIO/sailfin/blob/main/LICENSE"><img alt="License: GPL v2" src="https://img.shields.io/badge/license-GPL_v2-blue"></a>
+  <a href="https://github.com/SailfinIO/sailfin/stargazers"><img alt="GitHub stars" src="https://img.shields.io/github/stars/SailfinIO/sailfin?style=flat"></a>
+</p>
+
+---
 
 ## Why Sailfin
 

--- a/site/public/robots.txt
+++ b/site/public/robots.txt
@@ -7,9 +7,15 @@
 # NOTE: Cloudflare's "Managed robots.txt" / "AI Audit" feature, when enabled
 # on the zone, intercepts /robots.txt at the edge and serves its own policy
 # regardless of this file. To make this file authoritative, disable that
-# feature in the Cloudflare dashboard for sfn.dev.
+# feature in the Cloudflare dashboard for the relevant zone(s).
+#
+# This file is served from both sailfin.dev and sfn.dev (the site has no
+# canonical-domain redirect today). Both Sitemap URLs are listed so crawlers
+# discover the same canonical content from either hostname; the HTML's
+# <link rel="canonical"> points at sailfin.dev for deduplication.
 
 User-agent: *
 Allow: /
 
 Sitemap: https://sailfin.dev/sitemap-index.xml
+Sitemap: https://sfn.dev/sitemap-index.xml

--- a/site/public/robots.txt
+++ b/site/public/robots.txt
@@ -1,0 +1,15 @@
+# Sailfin allows search engines, AI crawlers, and AI training crawlers to
+# index this site. Sailfin is positioned as a verification layer for
+# AI-generated code; broad ingestion into model training corpora is part
+# of the project's adoption strategy. See CLAUDE.md ("LLM & Agent Adoption
+# Strategy") in the repo for context.
+#
+# NOTE: Cloudflare's "Managed robots.txt" / "AI Audit" feature, when enabled
+# on the zone, intercepts /robots.txt at the edge and serves its own policy
+# regardless of this file. To make this file authoritative, disable that
+# feature in the Cloudflare dashboard for sfn.dev.
+
+User-agent: *
+Allow: /
+
+Sitemap: https://sailfin.dev/sitemap-index.xml

--- a/site/src/layouts/BaseLayout.astro
+++ b/site/src/layouts/BaseLayout.astro
@@ -3,11 +3,18 @@ import SiteHeader from "../components/SiteHeader.astro";
 import Footer from "../components/Footer.astro";
 import "../styles/global.css";
 
+interface Article {
+  headline: string;
+  datePublished: string;
+  author?: string;
+}
+
 interface Props {
   title: string;
   description?: string;
   image?: string;
   type?: "website" | "article";
+  article?: Article;
 }
 
 const {
@@ -15,12 +22,79 @@ const {
   description = "A compiled systems language with compile-time capability enforcement.",
   image = "/images/og_card.png",
   type = "website",
+  article,
 } = Astro.props;
 
 const siteUrl = Astro.site ?? new URL("https://sailfin.dev");
 const canonicalURL = new URL(Astro.url.pathname, siteUrl);
 const ogImage = new URL(image, siteUrl);
 const pageTitle = title === "Home" ? "Sailfin" : `${title} - Sailfin`;
+const isHome = Astro.url.pathname === "/";
+
+const orgId = new URL("/#organization", siteUrl).toString();
+const websiteId = new URL("/#website", siteUrl).toString();
+const logoUrl = new URL("/images/sfn_lang_logo_256.png", siteUrl).toString();
+const repoUrl = "https://github.com/SailfinIO/sailfin";
+
+// Escape `<` to neutralize any accidental `</script>` sequence inside the
+// JSON-LD payload — defense in depth even though every value is author-controlled.
+const ldJson = (data: unknown) =>
+  JSON.stringify(data).replace(/</g, "\\u003c");
+
+const organizationLd = {
+  "@context": "https://schema.org",
+  "@type": "Organization",
+  "@id": orgId,
+  name: "Sailfin",
+  legalName: "Sailfin, LLC",
+  url: siteUrl.toString(),
+  logo: logoUrl,
+  sameAs: [repoUrl],
+};
+
+const websiteLd = {
+  "@context": "https://schema.org",
+  "@type": "WebSite",
+  "@id": websiteId,
+  name: "Sailfin",
+  url: siteUrl.toString(),
+  description:
+    "A compiled systems language with compile-time capability enforcement.",
+  publisher: { "@id": orgId },
+};
+
+const softwareLd = {
+  "@context": "https://schema.org",
+  "@type": "SoftwareApplication",
+  name: "Sailfin",
+  description:
+    "A compiled systems language where every function declares its capabilities — IO, network, clock, and more — with compile-time effect checking.",
+  url: siteUrl.toString(),
+  applicationCategory: "DeveloperApplication",
+  operatingSystem: "Linux, macOS",
+  offers: { "@type": "Offer", price: "0", priceCurrency: "USD" },
+  license: "https://www.gnu.org/licenses/old-licenses/gpl-2.0.html",
+  codeRepository: repoUrl,
+  author: { "@id": orgId },
+  publisher: { "@id": orgId },
+};
+
+const blogPostingLd = article
+  ? {
+      "@context": "https://schema.org",
+      "@type": "BlogPosting",
+      headline: article.headline,
+      datePublished: article.datePublished,
+      dateModified: article.datePublished,
+      description,
+      image: ogImage.toString(),
+      mainEntityOfPage: { "@type": "WebPage", "@id": canonicalURL.toString() },
+      author: article.author
+        ? { "@type": "Person", name: article.author }
+        : { "@id": orgId },
+      publisher: { "@id": orgId },
+    }
+  : null;
 ---
 
 <!doctype html>
@@ -48,6 +122,18 @@ const pageTitle = title === "Home" ? "Sailfin" : `${title} - Sailfin`;
     <meta name="twitter:description" content={description} />
     <meta name="twitter:image" content={ogImage} />
     <meta name="twitter:image:alt" content="Sailfin — systems language with compile-time capabilities" />
+
+    <!-- Structured data (JSON-LD). Organization + WebSite ship on every page;
+         SoftwareApplication is homepage-only; BlogPosting is emitted when a
+         layout passes an `article` prop. -->
+    <script type="application/ld+json" set:html={ldJson(organizationLd)} />
+    <script type="application/ld+json" set:html={ldJson(websiteLd)} />
+    {isHome && (
+      <script type="application/ld+json" set:html={ldJson(softwareLd)} />
+    )}
+    {blogPostingLd && (
+      <script type="application/ld+json" set:html={ldJson(blogPostingLd)} />
+    )}
 
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/site/src/layouts/BlogLayout.astro
+++ b/site/src/layouts/BlogLayout.astro
@@ -10,9 +10,13 @@ interface Props {
 }
 
 const { title, description, date, author, image } = Astro.props;
+
+const article = date
+  ? { headline: title, datePublished: date, author }
+  : undefined;
 ---
 
-<BaseLayout title={title} description={description} image={image} type="article">
+<BaseLayout title={title} description={description} image={image} type="article" article={article}>
   <article class="blog-post">
     <header class="blog-header">
       <h1>{title}</h1>


### PR DESCRIPTION
## Summary

Site discoverability fixes for `sfn.dev` and the GitHub README, prompted by a Reddit post warning about CSR sites being invisible to AI/Google crawlers. The CSR concern doesn't apply to us — Astro builds with `output: "static"` and `curl https://sfn.dev` returns the full prerendered homepage — but the investigation surfaced two real problems on the AI-discoverability axis.

### Problem 1: Cloudflare's Managed `robots.txt` is blocking every AI crawler

`curl https://sfn.dev/robots.txt` currently returns a Cloudflare-injected policy with `Disallow: /` for ClaudeBot, GPTBot, Google-Extended, CCBot, Applebot-Extended, Bytespider, Amazonbot, meta-externalagent, plus `Content-Signal: ai-train=no`. This directly contradicts the project's stated "LLM & Agent Adoption Strategy" in `CLAUDE.md` (training-data presence is an explicit goal).

The actual fix is dashboard-side (Cloudflare → Security → Bots → disable Managed robots.txt / AI Audit). This PR ships the in-repo `site/public/robots.txt` that becomes authoritative once that toggle is off.

### Problem 2: No structured data on any page

`https://search.google.com/test/rich-results?url=https://sfn.dev` returns "No items detected" — the page emits OpenGraph + Twitter Card metadata but zero JSON-LD. Without it, Google can't tell the site is a software project, an organization, or a blog. This PR adds JSON-LD across the layouts.

## Changes

### `site/src/layouts/BaseLayout.astro`
- `Organization` JSON-LD on every page (Sailfin, LLC, with logo + GitHub `sameAs`).
- `WebSite` JSON-LD on every page (linked to Organization as publisher).
- `SoftwareApplication` JSON-LD on the homepage only (gated on `Astro.url.pathname === "/"`), with free `Offer`, GPL-2.0 license URL, and `codeRepository`.
- New `article` prop — when present, emits `BlogPosting` JSON-LD with author, date, image, and `mainEntityOfPage`.
- All payloads run through a `<` escaper so a stray `</script>` can't terminate the embed.

### `site/src/layouts/BlogLayout.astro`
- Builds the `article` payload from frontmatter (`title`, `date`, `author`) and forwards it to `BaseLayout`. Author falls back to the Organization when frontmatter omits it.

### `site/public/robots.txt` (new)
- Permissive opt-in policy, sitemap reference, and an inline note documenting that Cloudflare's managed robots.txt shadows this file at the edge until disabled in the dashboard.

### `README.md`
- New header banner: `sfn` lockup logo linking to `sailfin.dev`, tagline, link row (Website · Install · Spec · Roadmap · Blog · `llms.txt`), and three shields.io badges (latest release, GPL-2.0 license, GitHub stars). Previously the README had no logo, no link to the site, and no badges. Body content (Why Sailfin, What Works, Install, etc.) is untouched.

## Test plan

- [x] `npm run build` — 61 pages, 8.25s, clean (Pagefind index + sitemap-index built).
- [x] `dist/index.html` contains Organization, WebSite, SoftwareApplication (with nested Offer).
- [x] `dist/blog/welcome/index.html` contains Organization, WebSite, BlogPosting (with nested Person + WebPage).
- [x] `dist/robots.txt` published.
- [ ] After deploy + Cloudflare dashboard change: re-run [Google Rich Results test](https://search.google.com/test/rich-results?url=https://sfn.dev) — should now detect Organization, WebSite, SoftwareApplication.
- [ ] After deploy + Cloudflare dashboard change: `curl https://sfn.dev/robots.txt` should match `site/public/robots.txt` (no `Disallow: GPTBot`).

## Notes

- No content changes; pure additive metadata + branding.
- Hero example syntax (`{{ }}` interpolation, `number` type) is *not* updated here — that's a separate concern flagged in the original review and worth doing on its own branch alongside the syntax-reform work.
- The `robots.txt` is a no-op on production until the Cloudflare-side change happens. That's the deliberate handoff.


---
_Generated by [Claude Code](https://claude.ai/code/session_019wuDZweqwCPssdazaKHWUG)_