### PR TITLE
docs: use lizard mark for README banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://sailfin.dev">
-    <img src="https://raw.githubusercontent.com/SailfinIO/sailfin/main/site/public/images/sfn_wordmark_simple.svg" alt="Sailfin" width="220">
+    <img src="https://raw.githubusercontent.com/SailfinIO/sailfin/main/site/public/images/sfn_lang_logo_256.svg" alt="Sailfin" width="128">
   </a>
 </p>
 


### PR DESCRIPTION
## Summary

Replaces the README banner image with the lizard mark (`sfn_lang_logo_256.svg`) instead of the `sfn` wordmark (`sfn_wordmark_simple.svg`).

The previous banner sat the gradient `sfn` wordmark directly above the `Sailfin` H1 — visually the same "two competing brand forms" problem the earlier fix was supposed to solve, just with a gradient. The lizard mark has no text, so the icon (visual mark) and the H1 (textual brand name) don't compete.

| Before | After |
| --- | --- |
| `sfn` (gradient text) over `Sailfin` H1 | Lizard icon over `Sailfin` H1 |

## Files changed

- `README.md` — banner `<img src>` switched, `width` reduced from 220 → 128 (icon is square, narrower than the wordmark).

## Verification

This PR only touches the README; no site code/build changes. GitHub renders the new image directly from the existing asset at `site/public/images/sfn_lang_logo_256.svg` via raw.githubusercontent.com (no website dependency, per the prior Copilot guidance).

## Branch hygiene note

Cut from latest `main` (`a17be4d`) on a fresh branch (`claude/readme-lizard-logo`) rather than reusing the prior `claude/review-sailfin-docs-uk74c` branch — avoids the post-squash divergence problem that required Copilot to resolve a fake "merge conflict" on #292.

---
_Generated by [Claude Code](https://claude.ai/code/session_019wuDZweqwCPssdazaKHWUG)_