### PR TITLE
fix(parser): reject `while` at statement position; replace 15 silent-dead loops

### DIFF
--- a/compiler/src/llvm/expression_lowering/native/core_literals_lowering.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_literals_lowering.sfn
@@ -113,8 +113,9 @@ fn lower_array_literal(text: string, bindings: ParameterBinding[], locals: Local
                     };
                 }
                 let with_sep = emit_string_concat(current_operand, sep.operand, current_temp, current_lines);
-                let _ci0 = 0;
-                while _ci0 < with_sep.diagnostics.length {
+                let mut _ci0: number = 0;
+                loop {
+                    if _ci0 >= with_sep.diagnostics.length { break; }
                     diagnostics.push(with_sep.diagnostics[_ci0]);
                     _ci0 += 1;
                 }
@@ -133,8 +134,9 @@ fn lower_array_literal(text: string, bindings: ParameterBinding[], locals: Local
             }
 
             let lowered = lower_expression(element_text, bindings, locals, current_temp, current_lines, functions, context, "");
-            let _ci1 = 0;
-            while _ci1 < lowered.diagnostics.length {
+            let mut _ci1: number = 0;
+            loop {
+                if _ci1 >= lowered.diagnostics.length { break; }
                 diagnostics.push(lowered.diagnostics[_ci1]);
                 _ci1 += 1;
             }
@@ -153,8 +155,9 @@ fn lower_array_literal(text: string, bindings: ParameterBinding[], locals: Local
             }
 
             let as_string = coerce_operand_to_string(lowered.operand, current_temp, current_lines);
-            let _ci2 = 0;
-            while _ci2 < as_string.diagnostics.length {
+            let mut _ci2: number = 0;
+            loop {
+                if _ci2 >= as_string.diagnostics.length { break; }
                 diagnostics.push(as_string.diagnostics[_ci2]);
                 _ci2 += 1;
             }
@@ -173,8 +176,9 @@ fn lower_array_literal(text: string, bindings: ParameterBinding[], locals: Local
             }
 
             let appended = emit_string_concat(current_operand, as_string.operand, current_temp, current_lines);
-            let _ci3 = 0;
-            while _ci3 < appended.diagnostics.length {
+            let mut _ci3: number = 0;
+            loop {
+                if _ci3 >= appended.diagnostics.length { break; }
                 diagnostics.push(appended.diagnostics[_ci3]);
                 _ci3 += 1;
             }
@@ -207,8 +211,9 @@ fn lower_array_literal(text: string, bindings: ParameterBinding[], locals: Local
             };
         }
         let finished = emit_string_concat(current_operand, close.operand, current_temp, current_lines);
-        let _ci4 = 0;
-        while _ci4 < finished.diagnostics.length {
+        let mut _ci4: number = 0;
+        loop {
+            if _ci4 >= finished.diagnostics.length { break; }
             diagnostics.push(finished.diagnostics[_ci4]);
             _ci4 += 1;
         }
@@ -658,8 +663,9 @@ fn lower_struct_literal(parse: StructLiteralParse, bindings: ParameterBinding[],
                 field_value_text = literal_field.name;
             }
             let lowered = lower_expression(field_value_text, bindings, locals, current_temp, current_lines, functions, context, expected.llvm_type);
-            let _ci5 = 0;
-            while _ci5 < lowered.diagnostics.length {
+            let mut _ci5: number = 0;
+            loop {
+                if _ci5 >= lowered.diagnostics.length { break; }
                 diagnostics.push(lowered.diagnostics[_ci5]);
                 _ci5 += 1;
             }
@@ -668,8 +674,9 @@ fn lower_struct_literal(parse: StructLiteralParse, bindings: ParameterBinding[],
             collected_string_constants = merge_string_constants(collected_string_constants, lowered.string_constants);
             if lowered.operand != null {
                 let coerced = coerce_operand_to_type(lowered.operand, expected.llvm_type, current_temp, current_lines);
-                let _ci6 = 0;
-                while _ci6 < coerced.diagnostics.length {
+                let mut _ci6: number = 0;
+                loop {
+                    if _ci6 >= coerced.diagnostics.length { break; }
                     diagnostics.push(coerced.diagnostics[_ci6]);
                     _ci6 += 1;
                 }
@@ -955,8 +962,9 @@ fn lower_enum_literal(parse: EnumLiteralParse, bindings: ParameterBinding[], loc
             if literal_index >= 0 {
                 let literal_field = parse.fields[literal_index];
                 let lowered = lower_expression(literal_field.value, bindings, locals, current_temp, current_lines, functions, context, expected.llvm_type);
-                let _ci7 = 0;
-                while _ci7 < lowered.diagnostics.length {
+                let mut _ci7: number = 0;
+                loop {
+                    if _ci7 >= lowered.diagnostics.length { break; }
                     diagnostics.push(lowered.diagnostics[_ci7]);
                     _ci7 += 1;
                 }
@@ -973,8 +981,9 @@ fn lower_enum_literal(parse: EnumLiteralParse, bindings: ParameterBinding[], loc
                         if !ends_with_pointer_suffix(field_operand.llvm_type) {
                             if field_is_aggregate {
                                 let boxed = box_aggregate_operand(field_operand, expected.llvm_type, current_temp, current_lines, context);
-                                let _ci8 = 0;
-                                while _ci8 < boxed.diagnostics.length {
+                                let mut _ci8: number = 0;
+                                loop {
+                                    if _ci8 >= boxed.diagnostics.length { break; }
                                     diagnostics.push(boxed.diagnostics[_ci8]);
                                     _ci8 += 1;
                                 }
@@ -987,8 +996,9 @@ fn lower_enum_literal(parse: EnumLiteralParse, bindings: ParameterBinding[], loc
                         }
                     }
                     let coerced = coerce_operand_to_type(field_operand, expected.llvm_type, current_temp, current_lines);
-                    let _ci9 = 0;
-                    while _ci9 < coerced.diagnostics.length {
+                    let mut _ci9: number = 0;
+                    loop {
+                        if _ci9 >= coerced.diagnostics.length { break; }
                         diagnostics.push(coerced.diagnostics[_ci9]);
                         _ci9 += 1;
                     }
@@ -1145,8 +1155,9 @@ fn lower_cast_expression(parse: CastParseResult, bindings: ParameterBinding[], l
     }
 
     let lowered = lower_expression(parse.value, bindings, locals, temp_index, lines, functions, context, "");
-    let _ci10 = 0;
-    while _ci10 < lowered.diagnostics.length {
+    let mut _ci10: number = 0;
+    loop {
+        if _ci10 >= lowered.diagnostics.length { break; }
         diagnostics.push(lowered.diagnostics[_ci10]);
         _ci10 += 1;
     }
@@ -1159,18 +1170,6 @@ fn lower_cast_expression(parse: CastParseResult, bindings: ParameterBinding[], l
             string_constants: lowered.string_constants
         };
     }
-    // Seed-DCE workaround — tracked in issue #295. Bind `operand`
-    // via `coerce_operand_to_type` (a no-op when source and target
-    // types match) before any field access. The function call
-    // materialises the struct in the seed's SSA form and prevents
-    // the alpha.8 dead-code pass from eliding a direct
-    // `let operand = lowered.operand` binding —
-    // `lower_return_instruction` works around the same DCE quirk
-    // by passing `operand` to `coerce_operand_to_type` immediately
-    // after the binding. Once the seed bug is fixed and a fixed
-    // seed is pinned, delete this `_operand_keepalive` line and
-    // both surrounding comments.
-    let _operand_keepalive = coerce_operand_to_type(lowered.operand, lowered.operand.llvm_type, lowered.temp_index, lowered.lines);
     let operand = lowered.operand;
     if operand.llvm_type == target_type {
         return ExpressionResult {
@@ -1315,10 +1314,9 @@ fn lower_cast_expression(parse: CastParseResult, bindings: ParameterBinding[], l
     // sources. `255_u8 as u64` therefore lowers as `sext` and
     // becomes `-1` (sign-extended) rather than `255` (zero-
     // extended). Distinguishing requires source-level type tracking
-    // through the cast lowering — deferred to a Slice D follow-up
-    // alongside the `as bool` audit; see issue #295/#296. The
-    // architect's brief explicitly accepted "all integer casts emit
-    // signed forms" for this slice.
+    // through the cast lowering — deferred to a Slice D follow-up.
+    // The architect's brief explicitly accepted "all integer casts
+    // emit signed forms" for this slice.
     let operand_is_int = is_integer_llvm_type(operand.llvm_type);
     let operand_is_float = is_float_llvm_type(operand.llvm_type);
     let target_is_int = is_integer_llvm_type(target_type);
@@ -1427,8 +1425,9 @@ fn try_lower_interpolated_string_literal(literal: string, bindings: ParameterBin
 
         let expr_text = parsed.expressions[index];
         let lowered_expr = lower_expression(expr_text, bindings, locals, current_temp, current_lines, functions, context, "i8*");
-        let _ci11 = 0;
-        while _ci11 < lowered_expr.diagnostics.length {
+        let mut _ci11: number = 0;
+        loop {
+            if _ci11 >= lowered_expr.diagnostics.length { break; }
             diagnostics.push(lowered_expr.diagnostics[_ci11]);
             _ci11 += 1;
         }
@@ -1450,8 +1449,9 @@ fn try_lower_interpolated_string_literal(literal: string, bindings: ParameterBin
         }
 
         let coerced = coerce_operand_to_string(lowered_expr.operand, current_temp, current_lines);
-        let _ci12 = 0;
-        while _ci12 < coerced.diagnostics.length {
+        let mut _ci12: number = 0;
+        loop {
+            if _ci12 >= coerced.diagnostics.length { break; }
             diagnostics.push(coerced.diagnostics[_ci12]);
             _ci12 += 1;
         }
@@ -1472,8 +1472,9 @@ fn try_lower_interpolated_string_literal(literal: string, bindings: ParameterBin
         }
 
         let concat1 = emit_string_concat(current_operand, coerced.operand, current_temp, current_lines);
-        let _ci13 = 0;
-        while _ci13 < concat1.diagnostics.length {
+        let mut _ci13: number = 0;
+        loop {
+            if _ci13 >= concat1.diagnostics.length { break; }
             diagnostics.push(concat1.diagnostics[_ci13]);
             _ci13 += 1;
         }
@@ -1506,8 +1507,9 @@ fn try_lower_interpolated_string_literal(literal: string, bindings: ParameterBin
         }
 
         let concat2 = emit_string_concat(current_operand, part_value.operand, current_temp, current_lines);
-        let _ci14 = 0;
-        while _ci14 < concat2.diagnostics.length {
+        let mut _ci14: number = 0;
+        loop {
+            if _ci14 >= concat2.diagnostics.length { break; }
             diagnostics.push(concat2.diagnostics[_ci14]);
             _ci14 += 1;
         }

--- a/compiler/src/llvm/expression_lowering/native/core_literals_lowering.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_literals_lowering.sfn
@@ -983,7 +983,9 @@ fn lower_enum_literal(parse: EnumLiteralParse, bindings: ParameterBinding[], loc
                                 let boxed = box_aggregate_operand(field_operand, expected.llvm_type, current_temp, current_lines, context);
                                 let mut _ci8: number = 0;
                                 loop {
-                                    if _ci8 >= boxed.diagnostics.length { break; }
+                                    if _ci8 >= boxed.diagnostics.length {
+                                        break;
+                                    }
                                     diagnostics.push(boxed.diagnostics[_ci8]);
                                     _ci8 += 1;
                                 }

--- a/compiler/src/parser/statements.sfn
+++ b/compiler/src/parser/statements.sfn
@@ -310,6 +310,20 @@ fn parse_block_statement(parser: Parser) -> BlockStatementParseResult {
         return parse_assert_statement(after_decorators);
     }
 
+    // Reserved but not implemented at statement position.
+    // Without this guard, `while X { ... }` would fall through to
+    // `parse_expression_statement` and be silently absorbed into a
+    // brace-balanced `eval` instruction, eating surrounding statements
+    // along with it. Routing through `parse_unknown_statement` instead
+    // lets `typecheck.sfn` emit `E0411` with a `loop`/`break` fix-it.
+    if identifier_matches(token, "while") {
+        return BlockStatementParseResult {
+            parser: original,
+            statement: null,
+            success: false
+        };
+    }
+
     let expression_result = parse_expression_statement(after_decorators, decorators);
     if expression_result.success { return expression_result; }
 

--- a/compiler/src/typecheck.sfn
+++ b/compiler/src/typecheck.sfn
@@ -31,7 +31,9 @@ import {
     check_type_parameters,
     clone_bindings,
     detect_removed_ai_keyword,
+    detect_unsupported_statement_keyword,
     make_removed_keyword_diagnostic,
+    make_unsupported_statement_keyword_diagnostic,
     register_local_symbol,
     register_symbol
 } from "./typecheck_types";
@@ -401,6 +403,13 @@ fn check_statement(statement: Statement, bindings: SymbolEntry[], interfaces: St
             return ScopeResult {
                 bindings: bindings,
                 diagnostics: [make_removed_keyword_diagnostic(keyword)]
+            };
+        }
+        let unsupported = detect_unsupported_statement_keyword(statement.text);
+        if unsupported.length > 0 {
+            return ScopeResult {
+                bindings: bindings,
+                diagnostics: [make_unsupported_statement_keyword_diagnostic(unsupported)]
             };
         }
         return ScopeResult { bindings: bindings, diagnostics: [] };

--- a/compiler/src/typecheck_types.sfn
+++ b/compiler/src/typecheck_types.sfn
@@ -1108,6 +1108,35 @@ fn make_removed_keyword_diagnostic(keyword: string) -> Diagnostic {
     };
 }
 
+// Match a reserved keyword that has no statement-level implementation.
+// `parse_block_statement` routes these to `parse_unknown_statement` so the
+// diagnostic surfaces here instead of being silently absorbed by the
+// expression-statement fallthrough. Currently only `while` (Sailfin's
+// canonical loop is `loop` per `grammar.md` / `spec/04-statements.md`).
+fn detect_unsupported_statement_keyword(text: string) -> string {
+    if starts_with(text, "while ") { return "while"; }
+    if starts_with(text, "while(") { return "while"; }
+    if starts_with(text, "while{") { return "while"; }
+    return "";
+}
+
+fn make_unsupported_statement_keyword_diagnostic(keyword: string) -> Diagnostic {
+    let mut message: string = "`" + keyword + "` is reserved but not implemented;";
+    if strings_equal(keyword, "while") {
+        message = message + " Sailfin's only loop construct is `loop`."
+            + " Rewrite `while cond { body }` as"
+            + " `loop { if !cond { break; } body }`.";
+    }
+    return Diagnostic {
+        code: "E0411",
+        severity: "error",
+        message: message,
+        file_path: "",
+        primary: null,
+        suggestion: null
+    };
+}
+
 fn make_missing_interface_member_diagnostic(struct_name: string, interface_name: string, member_name: string) -> Diagnostic {
     return Diagnostic {
         code: "E0301",

--- a/compiler/src/typecheck_types.sfn
+++ b/compiler/src/typecheck_types.sfn
@@ -1113,15 +1113,23 @@ fn make_removed_keyword_diagnostic(keyword: string) -> Diagnostic {
 // diagnostic surfaces here instead of being silently absorbed by the
 // expression-statement fallthrough. Currently only `while` (Sailfin's
 // canonical loop is `loop` per `grammar.md` / `spec/04-statements.md`).
+//
+// Boundary check: the keyword must NOT be followed by an identifier-
+// continuation char, otherwise prefixes like `whilepass` / `while_count`
+// would false-positive. `is_identifier_char` covers `[A-Za-z0-9_]`, so
+// any other byte (space, tab, newline, `(`, `{`, comment-start `/`, …)
+// counts as a true keyword boundary.
 fn detect_unsupported_statement_keyword(text: string) -> string {
-    if starts_with(text, "while ") { return "while"; }
-    if starts_with(text, "while(") { return "while"; }
-    if starts_with(text, "while{") { return "while"; }
-    return "";
+    if !starts_with(text, "while") { return ""; }
+    if text.length == 5 { return "while"; }
+    let next = text[5];
+    if is_identifier_char(next) { return ""; }
+    return "while";
 }
 
 fn make_unsupported_statement_keyword_diagnostic(keyword: string) -> Diagnostic {
-    let mut message: string = "`" + keyword + "` is reserved but not implemented;";
+    let mut message: string = "`" + keyword
+        + "` is reserved but not implemented;";
     if strings_equal(keyword, "while") {
         message = message + " Sailfin's only loop construct is `loop`."
             + " Rewrite `while cond { body }` as"

--- a/compiler/tests/unit/unsupported_statement_keywords_test.sfn
+++ b/compiler/tests/unit/unsupported_statement_keywords_test.sfn
@@ -35,11 +35,25 @@ fn _starts_with(value: string, prefix: string) -> boolean {
     return true;
 }
 
+fn _is_identifier_char(ch: string) -> boolean {
+    if ch.length != 1 { return false; }
+    if ch == "_" { return true; }
+    let alphanum = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+    let mut i: number = 0;
+    loop {
+        if i >= alphanum.length { break; }
+        if alphanum[i] == ch { return true; }
+        i += 1;
+    }
+    return false;
+}
+
 fn _detect_unsupported_statement_keyword(text: string) -> string {
-    if _starts_with(text, "while ") { return "while"; }
-    if _starts_with(text, "while(") { return "while"; }
-    if _starts_with(text, "while{") { return "while"; }
-    return "";
+    if !_starts_with(text, "while") { return ""; }
+    if text.length == 5 { return "while"; }
+    let next = text[5];
+    if _is_identifier_char(next) { return ""; }
+    return "while";
 }
 
 fn _strings_equal(a: string, b: string) -> boolean {
@@ -101,12 +115,38 @@ test "unsupported keywords: detects `while` with brace" {
     assert _detect_unsupported_statement_keyword("while{ true } { break; }") == "while";
 }
 
+test "unsupported keywords: detects `while` followed by newline" {
+    // `parse_unknown_statement` collects raw whitespace tokens, so source
+    // formatted as `while\n    cond { … }` reaches the detector with
+    // `\n` directly after `while`. Must still trigger E0411.
+    assert _detect_unsupported_statement_keyword("while\n    i < 3 { i += 1; }") == "while";
+}
+
+test "unsupported keywords: detects `while` followed by tab" {
+    assert _detect_unsupported_statement_keyword("while\ti < 3 { i += 1; }") == "while";
+}
+
+test "unsupported keywords: detects `while` followed by carriage return" {
+    assert _detect_unsupported_statement_keyword("while\r\ni < 3 { }") == "while";
+}
+
+test "unsupported keywords: detects `while` followed by comment-start" {
+    // Conservative: `while/*comment*/cond` is still a `while` keyword
+    // — the boundary check rejects identifier-continuation chars only.
+    assert _detect_unsupported_statement_keyword("while/*c*/i < 3 { }") == "while";
+}
+
+test "unsupported keywords: detects bare `while` token" {
+    assert _detect_unsupported_statement_keyword("while") == "while";
+}
+
 test "unsupported keywords: ignores identifiers that share a prefix" {
-    // `whilepass`, `while_count`, etc. must not fire — the match is anchored
-    // on the trailing space/paren/brace after the keyword.
+    // `whilepass`, `while_count`, etc. must not fire — the boundary check
+    // rejects when the byte after `while` is `[A-Za-z0-9_]`.
     assert _detect_unsupported_statement_keyword("whilepass = init();") == "";
     assert _detect_unsupported_statement_keyword("while_count += 1;") == "";
     assert _detect_unsupported_statement_keyword("whileness.flag = true;") == "";
+    assert _detect_unsupported_statement_keyword("while1") == "";
 }
 
 test "unsupported keywords: returns empty for unrelated unknown text" {

--- a/compiler/tests/unit/unsupported_statement_keywords_test.sfn
+++ b/compiler/tests/unit/unsupported_statement_keywords_test.sfn
@@ -1,0 +1,126 @@
+// Regression tests covering the typecheck diagnostic for reserved keywords
+// that have no statement-level implementation. Currently scoped to `while`
+// (Sailfin's only loop construct is `loop` per
+// `site/src/content/docs/docs/reference/grammar.md` and
+// `spec/04-statements.md`). When source uses `while`, `parse_block_statement`
+// in `compiler/src/parser/statements.sfn` returns `success: false` so the
+// block parser falls through to `parse_unknown_statement`, and the typechecker
+// then emits E0411 with a fix-it pointing at `loop` / `break`.
+//
+// Why this test exists: prior to the fix, `while` was silently absorbed into
+// an opaque `eval` instruction by the expression-statement fallthrough, eating
+// surrounding statements with it. The 15 `while` loops in
+// `core_literals_lowering.sfn` were silently dead code (issue #295). The fix
+// must keep the rejection in place so the regression cannot reappear.
+//
+// Kept self-contained (no imports, no struct literals) to match the pattern
+// used by `removed_ai_keywords_test.sfn` and `fmt_test.sfn` — the standalone
+// test runner cannot link the string_utils → runtime chain.
+//
+// The helpers below mirror the logic in
+// `compiler/src/typecheck_types.sfn::detect_unsupported_statement_keyword` and
+// `compiler/src/typecheck_types.sfn::make_unsupported_statement_keyword_diagnostic`
+// — keep them in sync when that file changes.
+// -------------------------------------------------------------------
+// Local helpers
+// -------------------------------------------------------------------
+fn _starts_with(value: string, prefix: string) -> boolean {
+    if prefix.length > value.length { return false; }
+    let mut index: number = 0;
+    loop {
+        if index >= prefix.length { break; }
+        if value[index] != prefix[index] { return false; }
+        index += 1;
+    }
+    return true;
+}
+
+fn _detect_unsupported_statement_keyword(text: string) -> string {
+    if _starts_with(text, "while ") { return "while"; }
+    if _starts_with(text, "while(") { return "while"; }
+    if _starts_with(text, "while{") { return "while"; }
+    return "";
+}
+
+fn _strings_equal(a: string, b: string) -> boolean {
+    if a.length != b.length { return false; }
+    let mut i: number = 0;
+    loop {
+        if i >= a.length { break; }
+        if a[i] != b[i] { return false; }
+        i += 1;
+    }
+    return true;
+}
+
+fn _diagnostic_message(keyword: string) -> string {
+    let mut message: string = "`" + keyword + "` is reserved but not implemented;";
+    if _strings_equal(keyword, "while") {
+        message = message + " Sailfin's only loop construct is `loop`."
+            + " Rewrite `while cond { body }` as"
+            + " `loop { if !cond { break; } body }`.";
+    }
+    return message;
+}
+
+fn _contains(haystack: string, needle: string) -> boolean {
+    if needle.length == 0 { return true; }
+    if needle.length > haystack.length { return false; }
+    let limit = haystack.length - needle.length;
+    let mut i: number = 0;
+    loop {
+        if i > limit { break; }
+        let mut matched: boolean = true;
+        let mut j: number = 0;
+        loop {
+            if j >= needle.length { break; }
+            if haystack[i + j] != needle[j] {
+                matched = false;
+                break;
+            }
+            j += 1;
+        }
+        if matched { return true; }
+        i += 1;
+    }
+    return false;
+}
+
+// -------------------------------------------------------------------
+// Tests
+// -------------------------------------------------------------------
+test "unsupported keywords: detects `while` with space" {
+    assert _detect_unsupported_statement_keyword("while i < 3 { i += 1; }") == "while";
+}
+
+test "unsupported keywords: detects `while` with paren" {
+    assert _detect_unsupported_statement_keyword("while(true) { break; }") == "while";
+}
+
+test "unsupported keywords: detects `while` with brace" {
+    assert _detect_unsupported_statement_keyword("while{ true } { break; }") == "while";
+}
+
+test "unsupported keywords: ignores identifiers that share a prefix" {
+    // `whilepass`, `while_count`, etc. must not fire — the match is anchored
+    // on the trailing space/paren/brace after the keyword.
+    assert _detect_unsupported_statement_keyword("whilepass = init();") == "";
+    assert _detect_unsupported_statement_keyword("while_count += 1;") == "";
+    assert _detect_unsupported_statement_keyword("whileness.flag = true;") == "";
+}
+
+test "unsupported keywords: returns empty for unrelated unknown text" {
+    assert _detect_unsupported_statement_keyword("???") == "";
+    assert _detect_unsupported_statement_keyword("let x = 1;") == "";
+    assert _detect_unsupported_statement_keyword("") == "";
+    assert _detect_unsupported_statement_keyword("loop { if x { break; } }") == "";
+}
+
+test "unsupported keywords: diagnostic message names the keyword and points at loop/break" {
+    let msg = _diagnostic_message("while");
+    assert _starts_with(msg, "`while` is reserved but not implemented");
+    // The fix-it must steer the user at `loop` and `break`, not at adding
+    // a `while` keyword.
+    assert _contains(msg, "loop");
+    assert _contains(msg, "break");
+}

--- a/docs/runtime_architecture.md
+++ b/docs/runtime_architecture.md
@@ -65,15 +65,7 @@
 >   fix-it suggesting `x != 0`. Pinned by
 >   `compiler/tests/unit/numeric_cast_test.sfn` (extended) and
 >   `compiler/tests/e2e/test_numeric_cast.sh` (8 LLVM-shape
->   pinning cases). The matrix opens with a no-op
->   `coerce_operand_to_type(lowered.operand, lowered.operand.llvm_type, …)`
->   keepalive call — without it, the alpha.8 seed's dead-code pass
->   elides the `let operand = lowered.operand` binding and the
->   matrix never matches; passing `lowered.operand` to a function
->   first materialises the struct in the seed's SSA form
->   (`lower_return_instruction` works around the same DCE quirk by
->   passing `operand` to `coerce_operand_to_type` immediately after
->   binding). Self-host stays green.
+>   pinning cases). Self-host stays green.
 >   **L2/L3 silent-widening rejection deferred to Slice E.**
 >   The architect's plan called for `dominant_type` to refuse
 >   silent int↔float coercion at the same time, but the lowered
@@ -85,9 +77,24 @@
 >   default integer literals to `int`) so the language
 >   semantics line up with the tightened lowering rule. Slice D
 >   ships the `as` cast escape valve so authors can spell the
->   conversion explicitly today.
->   Tracked: seed-DCE workaround in issue #295, L2/L3 closure
->   follow-up in issue #296.
+>   conversion explicitly today. L2/L3 closure follow-up is
+>   tracked in issue #296.
+> - **Issue #295 closed 2026-05-04.** The "alpha.8 seed DCE"
+>   reported alongside Slice D was misdiagnosed. Root cause: the
+>   parser has no `while` keyword (Sailfin's only loop construct
+>   is `loop` per `grammar.md` and `spec/04-statements.md`), but
+>   `parse_block_statement` silently fell through to
+>   `parse_expression_statement` for unrecognized statement-leading
+>   identifiers — so `while X { … }` was absorbed into an opaque
+>   `eval` instruction that the LLVM lowerer dropped, taking
+>   surrounding statements with it. 15 `while` loops in
+>   `core_literals_lowering.sfn` (introduced when the file was
+>   split out of `core.sfn`) were silently dead. Fix: rewrote the
+>   15 sites to canonical `loop { if X { break; } … }`, deleted
+>   the `_operand_keepalive` workaround, and added a hard parser
+>   diagnostic in `parse_block_statement` rejecting reserved-but-
+>   unimplemented keywords at statement position with a fix-it
+>   pointing at `loop`.
 > - **Diagnosed and fixed 2026-05-02 (PR #289 follow-up).** The
 >   reported "string-aliasing seed bug" was a parser silent-skip in
 >   `parse_struct_field` (`compiler/src/parser/declarations.sfn`).

--- a/docs/runtime_architecture.md
+++ b/docs/runtime_architecture.md
@@ -90,11 +90,13 @@
 >   surrounding statements with it. 15 `while` loops in
 >   `core_literals_lowering.sfn` (introduced when the file was
 >   split out of `core.sfn`) were silently dead. Fix: rewrote the
->   15 sites to canonical `loop { if X { break; } … }`, deleted
->   the `_operand_keepalive` workaround, and added a hard parser
->   diagnostic in `parse_block_statement` rejecting reserved-but-
->   unimplemented keywords at statement position with a fix-it
->   pointing at `loop`.
+>   15 sites to canonical `loop { if !cond { break; } body }`
+>   form (the on-disk rewrites use the de-Morgan'd form
+>   `if i >= L { break; }` since each site's condition was
+>   `i < L`), deleted the `_operand_keepalive` workaround, and
+>   added a hard parser diagnostic in `parse_block_statement`
+>   rejecting reserved-but-unimplemented keywords at statement
+>   position with a fix-it pointing at `loop`.
 > - **Diagnosed and fixed 2026-05-02 (PR #289 follow-up).** The
 >   reported "string-aliasing seed bug" was a parser silent-skip in
 >   `parse_struct_field` (`compiler/src/parser/declarations.sfn`).


### PR DESCRIPTION
## Summary

- Closes #295. The "alpha.8 seed DCE" reported alongside Slice D was misdiagnosed. Root cause: Sailfin has no `while` keyword (the only loop construct is `loop`, per `grammar.md` and `spec/04-statements.md`), but `parse_block_statement` had no guard for it, so `while X { … }` silently fell through to `parse_expression_statement`, which greedy-consumed brace-balanced text into an opaque `eval`. The LLVM lowerer dropped the `eval`, taking the `while` body, the trailing `if … return` block, and the `let operand = lowered.operand` binding with it. The bug was present in both alpha.8 and alpha.9 — never seed-specific.

- All 15 `while` loops in `core_literals_lowering.sfn` (introduced when the file was split out of `core.sfn`) were silently dead code. The `_operand_keepalive` workaround masked the symptom in `lower_cast_expression` by anchoring the parser back to a fresh statement boundary — not by influencing the seed's SSA form. The "materialises the struct" inline comment was folklore.

- Issue #296 (`dominant_type` int↔float tightening) remains correctly blocked on Slice E retiring `number`. No change there.

## Changes

1. **Rewrite all 15 `while` loops in `compiler/src/llvm/expression_lowering/native/core_literals_lowering.sfn`** to canonical `loop { if X >= L { break; } …; X += 1 }`, matching the 1,282 existing `loop` sites elsewhere in the compiler.
2. **Remove the `_operand_keepalive` workaround** in `lower_cast_expression` along with its inline-comment block. The `as` cast lowering matrix now executes correctly because the diagnostics-propagation loop above it actually runs.
3. **Add E0411 for reserved-keyword-as-statement.** `parse_block_statement` now routes `while` through `parse_unknown_statement`; `typecheck.sfn` detects it via the same mechanism as the existing E0410 removed-AI-keyword diagnostic and emits a fix-it pointing at `loop { if !cond { break; } body }`. Future occurrences of `while` fail compilation immediately instead of silently corrupting the AST.
4. **Update `docs/runtime_architecture.md` §3.7** Slice D bullet: remove the SSA-form folklore, document the actual root cause, mark #295 closed.
5. **New regression test** `compiler/tests/unit/unsupported_statement_keywords_test.sfn` pins the detection helper and diagnostic message, mirroring `removed_ai_keywords_test.sfn`.

## Why no `while` keyword

Per `grammar.md:189` and `spec/04-statements.md`, Sailfin's only loop construct is `loop`. `while X { Y }` is exactly `loop { if !X { break; } Y }` — adding `while` would be redundant syntax sugar that violates the "boring syntax wins / only add keywords for constructs that can't be expressed otherwise" principle in `CLAUDE.md`. The fix is to enforce the existing spec, not to extend it.

## Validation

- [x] `make test-unit` — 87/87 passed (including the new test).
- [x] `make check` — full clean build + tests + stage3 self-host with fixed-point comparison. **stage2 == stage3 ✓.**
- [x] `make test-integration` — covered as part of `make check`.
- [x] e2e — 29/29 passed.
- [x] Cast lowering smoke: `fn convert(x: int) -> float { return x as float; }` → `%t0 = sitofp i64 %x to double; ret double %t0` (no keepalive).
- [x] E0411 smoke: `build/native/sailfin check while_diag.sfn` → exit 1 with the fix-it message.

## Test plan

- [ ] CI green (pending push).
- [ ] Verify the build driver fails non-zero when source contains `while` (covered structurally — E0411 has `severity: "error"` and flows through the same diagnostic pipeline as E0410).
- [ ] Spot-check that no other reserved-but-unimplemented keywords (e.g. `routine`, `scope`) leak through similarly. Out of scope here; can extend the detector list incrementally.

https://claude.ai/code/session_01VLW1MFCcXBWcF6FRTVvSzZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01VLW1MFCcXBWcF6FRTVvSzZ)_