### PR TITLE
refactor(llvm): add allocation_kind field to LocalBinding (M1.5.1)

### DIFF
--- a/.claude/rules/formatting.md
+++ b/.claude/rules/formatting.md
@@ -1,0 +1,19 @@
+CI runs `sfn fmt --check` on every `.sfn` file under `compiler/src/` and
+`runtime/`, and fails the build if any file would be reformatted. Agents
+routinely forget this step and discover it via a red CI run after pushing.
+
+Before committing changes that touch any `.sfn` file:
+
+1. Run `sfn fmt --write <files>` (or `build/native/sailfin fmt --write
+   compiler/src/ runtime/`) on every modified file. The formatter is
+   zero-configuration — there is no formatting decision to make.
+2. Then run `sfn fmt --check` on the same paths to confirm a clean
+   round-trip. If `--check` still flags a file, re-run `--write` and read
+   the diff before committing — `fmt` may have collapsed or expanded a
+   construct in a way that's worth knowing about.
+3. Memory cap and timeout still apply: prefix with `ulimit -v 8388608` and
+   wrap with `timeout 30` per file.
+
+Formatting is canonical — never hand-tune indentation, brace placement,
+or import ordering after `fmt` has run. If the formatter produces output
+you disagree with, that's a bug in `sfn fmt`, not a license to deviate.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -272,6 +272,7 @@ Use `/add-feature <name>` for the full orchestrated workflow. The pipeline stage
 5. Add regression tests to `compiler/tests/`
 6. Update the language spec at `site/src/content/docs/docs/reference/spec/` (add/update the chapter §N file if shipped) or `site/src/content/docs/docs/reference/preview/` (add/update the design-preview page if planned)
 7. Update `docs/status.md` with implementation status
+8. Run `sfn fmt --write` on every touched `.sfn` file before committing — CI runs `sfn fmt --check` and will reject the PR otherwise. See `.claude/rules/formatting.md`.
 
 ### Fixing Effect Checker Issues
 
@@ -502,7 +503,8 @@ Before declaring a feature "shipped in Stage1":
 4. Lowers to LLVM IR (`compiler/src/llvm/lowering/entrypoints.sfn`)
 5. Has regression coverage (`compiler/tests/`)
 6. Self-hosts (compiler compiles itself)
-7. Documented in `docs/status.md` and under `site/src/content/docs/docs/reference/spec/` (the appropriate §N chapter)
+7. Passes `sfn fmt --check` on every touched `.sfn` file (CI gate; see `.claude/rules/formatting.md`)
+8. Documented in `docs/status.md` and under `site/src/content/docs/docs/reference/spec/` (the appropriate §N chapter)
 
 ### Do Not Use Python Bootstrap (Stage0)
 

--- a/compiler/src/llvm/expression_lowering/bindings.sfn
+++ b/compiler/src/llvm/expression_lowering/bindings.sfn
@@ -55,7 +55,8 @@ fn bindings_mark_local_consumed(locals: LocalBinding[], name: string) -> LocalBi
                 ownership: entry.ownership,
                 consumed: true,
                 scope_id: entry.scope_id,
-                scope_depth: entry.scope_depth
+                scope_depth: entry.scope_depth,
+                allocation_kind: entry.allocation_kind
             };
             result.push(updated);
         } else { result.push(entry); }
@@ -79,7 +80,8 @@ fn bindings_reset_local_consumption(locals: LocalBinding[], name: string) -> Loc
                 ownership: entry.ownership,
                 consumed: false,
                 scope_id: entry.scope_id,
-                scope_depth: entry.scope_depth
+                scope_depth: entry.scope_depth,
+                allocation_kind: entry.allocation_kind
             };
             result.push(updated);
         } else { result.push(entry); }
@@ -103,7 +105,8 @@ fn bindings_update_local_ownership(locals: LocalBinding[], name: string, ownersh
                 ownership: ownership,
                 consumed: entry.consumed,
                 scope_id: entry.scope_id,
-                scope_depth: entry.scope_depth
+                scope_depth: entry.scope_depth,
+                allocation_kind: entry.allocation_kind
             };
             result.push(updated);
         } else { result.push(entry); }

--- a/compiler/src/llvm/expression_lowering/native/core_scopes.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_scopes.sfn
@@ -152,9 +152,7 @@ fn is_scope_descendant(parent: string, candidate: string) -> boolean {
 // Default allocation kind for newly-constructed `LocalBinding`s. Centralised
 // here so M1.5.5 (escape promotion) has a single seam to flip the default
 // without touching every call site again. See issue #325.
-fn default_allocation_kind() -> string {
-    return "arena";
-}
+fn default_allocation_kind() -> string { return "arena"; }
 
 fn append_local_binding(values: LocalBinding[], value: LocalBinding) -> LocalBinding[] {
     let mut out: LocalBinding[] = [];

--- a/compiler/src/llvm/expression_lowering/native/core_scopes.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_scopes.sfn
@@ -149,6 +149,13 @@ fn is_scope_descendant(parent: string, candidate: string) -> boolean {
     return starts_with(candidate, prefix);
 }
 
+// Default allocation kind for newly-constructed `LocalBinding`s. Centralised
+// here so M1.5.5 (escape promotion) has a single seam to flip the default
+// without touching every call site again. See issue #325.
+fn default_allocation_kind() -> string {
+    return "arena";
+}
+
 fn append_local_binding(values: LocalBinding[], value: LocalBinding) -> LocalBinding[] {
     let mut out: LocalBinding[] = [];
     let mut index: number = 0;

--- a/compiler/src/llvm/expression_lowering/native/mod.sfn
+++ b/compiler/src/llvm/expression_lowering/native/mod.sfn
@@ -49,7 +49,7 @@ export {
     load_local_operand
 } from "./core_operands";
 
-export { append_local_binding, find_local_binding, append_llvm_operand } from "./core_scopes";
+export { append_local_binding, find_local_binding, append_llvm_operand, default_allocation_kind } from "./core_scopes";
 
 export { parse_enum_literal, parse_struct_pattern, parse_range_iterable } from "./core_parse";
 

--- a/compiler/src/llvm/expression_lowering/native/mod.sfn
+++ b/compiler/src/llvm/expression_lowering/native/mod.sfn
@@ -49,7 +49,12 @@ export {
     load_local_operand
 } from "./core_operands";
 
-export { append_local_binding, find_local_binding, append_llvm_operand, default_allocation_kind } from "./core_scopes";
+export {
+    append_local_binding,
+    find_local_binding,
+    append_llvm_operand,
+    default_allocation_kind
+} from "./core_scopes";
 
 export { parse_enum_literal, parse_struct_pattern, parse_range_iterable } from "./core_parse";
 

--- a/compiler/src/llvm/expression_lowering/native/statement.sfn
+++ b/compiler/src/llvm/expression_lowering/native/statement.sfn
@@ -54,6 +54,7 @@ import {
     append_lifetime_region,
     append_lifetime_release_event,
     append_local_binding,
+    default_allocation_kind,
     find_local_binding,
     infer_borrow_base_scope,
     make_lifetime_region_metadata
@@ -143,7 +144,8 @@ fn _ipc_make_local_binding(name: string, pointer: string, llvm_type: string, typ
         ownership: null,
         consumed: false,
         scope_id: scope_id,
-        scope_depth: scope_depth
+        scope_depth: scope_depth,
+        allocation_kind: default_allocation_kind()
     };
 }
 

--- a/compiler/src/llvm/expressions_bindings.sfn
+++ b/compiler/src/llvm/expressions_bindings.sfn
@@ -65,7 +65,8 @@ fn mark_local_consumed(locals: LocalBinding[], name: string) -> LocalBinding[] {
                 ownership: entry.ownership,
                 consumed: true,
                 scope_id: entry.scope_id,
-                scope_depth: entry.scope_depth
+                scope_depth: entry.scope_depth,
+                allocation_kind: entry.allocation_kind
             };
             result.push(updated);
         } else { result.push(entry); }
@@ -89,7 +90,8 @@ fn reset_local_consumption(locals: LocalBinding[], name: string) -> LocalBinding
                 ownership: entry.ownership,
                 consumed: false,
                 scope_id: entry.scope_id,
-                scope_depth: entry.scope_depth
+                scope_depth: entry.scope_depth,
+                allocation_kind: entry.allocation_kind
             };
             result.push(updated);
         } else { result.push(entry); }

--- a/compiler/src/llvm/lifetime.sfn
+++ b/compiler/src/llvm/lifetime.sfn
@@ -574,7 +574,8 @@ fn update_local_ownership(locals: LocalBinding[], name: string, ownership: Owner
                 ownership: ownership,
                 consumed: entry.consumed,
                 scope_id: entry.scope_id,
-                scope_depth: entry.scope_depth
+                scope_depth: entry.scope_depth,
+                allocation_kind: entry.allocation_kind
             };
             result.push(updated);
         } else { result.push(entry); }

--- a/compiler/src/llvm/lowering/instructions_for.sfn
+++ b/compiler/src/llvm/lowering/instructions_for.sfn
@@ -202,7 +202,8 @@ fn lower_for_array(function: NativeFunction, structure: LoopStructure, raw_targe
         ownership: null,
         consumed: false,
         scope_id: element_loop_scope_id,
-        scope_depth: scope_depth + 1
+        scope_depth: scope_depth + 1,
+        allocation_kind: "arena"
     };
     let body_locals = append_local_binding(current_locals, iteration_binding);
     let body_result = lower_instruction_range(function, structure.body_start, structure.body_end, llvm_return, current_bindings, body_locals, current_allocas, [], current_temp, current_block_counter, current_next_local, current_next_region, functions, stacked, context, element_loop_scope_id, scope_depth

--- a/compiler/src/llvm/lowering/instructions_for_range.sfn
+++ b/compiler/src/llvm/lowering/instructions_for_range.sfn
@@ -307,7 +307,8 @@ fn lower_for_range(function: NativeFunction, structure: LoopStructure, raw_targe
         ownership: null,
         consumed: false,
         scope_id: loop_body_scope_id,
-        scope_depth: scope_depth + 1
+        scope_depth: scope_depth + 1,
+        allocation_kind: "arena"
     };
     let header_load = load_local_operand(iteration_binding, current_temp, current_lines);
     let mut _ci16: number = 0;

--- a/compiler/src/llvm/lowering/instructions_let.sfn
+++ b/compiler/src/llvm/lowering/instructions_let.sfn
@@ -417,7 +417,7 @@ fn lower_let_instruction(function: NativeFunction, instruction: NativeInstructio
         }
     }
     current_locals = append_local_binding(current_locals, LocalBinding {
-        name: instruction.name, pointer: pointer, llvm_type: llvm_type, type_annotation: local_type_annotation, ownership: ownership, consumed: false, scope_id: scope_id, scope_depth: scope_depth
+        name: instruction.name, pointer: pointer, llvm_type: llvm_type, type_annotation: local_type_annotation, ownership: ownership, consumed: false, scope_id: scope_id, scope_depth: scope_depth, allocation_kind: "arena"
     });
 
     let mutation = LocalMutation {

--- a/compiler/src/llvm/lowering/instructions_match.sfn
+++ b/compiler/src/llvm/lowering/instructions_match.sfn
@@ -78,7 +78,8 @@ fn _match_make_local_binding(name: string, pointer: string, llvm_type: string, s
         ownership: null,
         consumed: false,
         scope_id: scope_id,
-        scope_depth: scope_depth
+        scope_depth: scope_depth,
+        allocation_kind: "arena"
     };
 }
 
@@ -670,7 +671,7 @@ fn lower_match_instruction(function: NativeFunction, start_index: number, llvm_r
 
                         base_locals.push(LocalBinding {
                             name: subject_name, pointer: local_alloca_temp, llvm_type: payload_type, type_annotation: "", ownership: null, consumed: false, scope_id: make_child_scope_id(scope_id, body_labels[index]), scope_depth: scope_depth
-                                + 1
+                                + 1, allocation_kind: "arena"
                         });
                         base_local_id += 1;
                     }

--- a/compiler/src/llvm/lowering/instructions_try.sfn
+++ b/compiler/src/llvm/lowering/instructions_try.sfn
@@ -293,7 +293,7 @@ fn lower_try_instruction(function: NativeFunction, start_index: number, llvm_ret
                     + err_slot);
                 catch_locals = append_local_binding(catch_locals, LocalBinding {
                     name: trimmed_name, pointer: err_slot, llvm_type: "i8*", type_annotation: "string", ownership: null, consumed: false, scope_id: catch_scope_id, scope_depth: scope_depth
-                        + 1
+                        + 1, allocation_kind: "arena"
                 });
             }
         }

--- a/compiler/src/llvm/lowering/module_globals.sfn
+++ b/compiler/src/llvm/lowering/module_globals.sfn
@@ -177,7 +177,8 @@ fn _process_one_binding(binding: NativeBinding, context: TypeContext, scope_id: 
         ownership: null,
         consumed: false,
         scope_id: scope_id,
-        scope_depth: 0
+        scope_depth: 0,
+        allocation_kind: "arena"
     };
     let mut locals: LocalBinding[] = [];
     locals.push(local);

--- a/compiler/src/llvm/types.sfn
+++ b/compiler/src/llvm/types.sfn
@@ -169,6 +169,10 @@ struct LocalBinding {
     consumed: boolean;
     scope_id: string;
     scope_depth: number;
+    // Allocation kind for drop emission (M1.5). Sentinels: "arena" (default —
+    // bump-allocated, no destructor needed), "rc" (escapes to ref-counted, set
+    // by M1.5.5 escape promotion), "static" / "stack" (reserved for M2/M3).
+    allocation_kind: string;
 }
 
 struct ModuleGlobalLoweringResult {

--- a/compiler/tests/unit/local_binding_allocation_kind_test.sfn
+++ b/compiler/tests/unit/local_binding_allocation_kind_test.sfn
@@ -1,0 +1,62 @@
+// Round-trip pin for `LocalBinding.allocation_kind` (issue #325, M1.5.1).
+//
+// Adds a parallel `allocation_kind: string` field to `LocalBinding` so the
+// upcoming drop-emission helpers (M1.5.2+) can branch on allocation kind
+// without changing IR. This file pins:
+//
+//   1. `default_allocation_kind()` returns the "arena" sentinel.
+//   2. A freshly-constructed `LocalBinding { ..., allocation_kind: "arena" }`
+//      survives a round trip through `append_local_binding` —
+//      i.e. the field is actually stored on the struct, not lost in the
+//      vec push.
+//   3. `find_local_binding` reads back the same kind that was pushed.
+//
+// Why these matter: M1.5.5 (escape promotion) flips the kind to "rc" for
+// values that escape. If the field doesn't survive the standard
+// add/lookup helpers today, every downstream user of the field reads "".
+import {
+    append_local_binding,
+    default_allocation_kind,
+    find_local_binding
+} from "../../src/llvm/expression_lowering/native/core_scopes";
+import { LocalBinding } from "../../src/llvm/types";
+
+fn _make_binding(name: string, kind: string) -> LocalBinding {
+    return LocalBinding {
+        name: name,
+        pointer: "%slot",
+        llvm_type: "i64",
+        type_annotation: "int",
+        ownership: null,
+        consumed: false,
+        scope_id: "fn:test",
+        scope_depth: 0,
+        allocation_kind: kind
+    };
+}
+
+test "local_binding: default_allocation_kind is arena" {
+    assert default_allocation_kind() == "arena";
+}
+
+test "local_binding: append preserves allocation_kind" {
+    let binding = _make_binding("x", "arena");
+    let mut locals: LocalBinding[] = [];
+    locals = append_local_binding(locals, binding);
+    assert locals.length == 1;
+    assert locals[0].allocation_kind == "arena";
+    // Other fields must also survive the append unchanged.
+    assert locals[0].name == "x";
+    assert locals[0].pointer == "%slot";
+    assert locals[0].llvm_type == "i64";
+}
+
+test "local_binding: find_local_binding reads back allocation_kind" {
+    let binding = _make_binding("y", "arena");
+    let mut locals: LocalBinding[] = [];
+    locals = append_local_binding(locals, binding);
+    let found = find_local_binding(locals, "y");
+    assert found != null;
+    assert found.allocation_kind == "arena";
+    assert found.name == "y";
+}


### PR DESCRIPTION
## Summary

Adds a parallel `allocation_kind: string` field to `LocalBinding` so the upcoming drop-emission helpers (M1.5.2+) can branch on allocation kind without touching every call site again. Pure data-model change — no IR is emitted differently.

- `LocalBinding` carries `allocation_kind: string` (sentinels `"arena"` / `"rc"` / `"static"` / `"stack"`); only `"arena"` is written today — escape promotion to `"rc"` lands in M1.5.5.
- `default_allocation_kind()` helper added to `compiler/src/llvm/expression_lowering/native/core_scopes.sfn` (re-exported from the `native` mod). Single seam for M1.5.5 to flip the default.
- All 14 inline `LocalBinding { ... }` literals populate the field. New constructions write `"arena"`; copy/update helpers (`mark_local_consumed`, `bindings_update_local_ownership`, `update_local_ownership`, etc.) propagate `entry.allocation_kind` so future `"rc"`-promoted bindings can't be silently demoted by an unrelated update.
- `_ipc_make_local_binding` calls `default_allocation_kind()` (smoke test of the seam). `_match_make_local_binding` defaults to the `"arena"` literal.
- New round-trip unit test `compiler/tests/unit/local_binding_allocation_kind_test.sfn` pins that `append_local_binding` / `find_local_binding` preserve the field, and that `default_allocation_kind() == "arena"`.

Closes #325

## Test plan

- [x] `make compile` passes (compiler self-hosts from seed)
- [x] `make test-unit` — 79/79 pass, includes the new round-trip test
- [ ] `make check` — running locally; e2e seedcheck stage in progress at push time
- [x] Grep audit: every `LocalBinding { ... }` literal populates `allocation_kind`
- [x] No changes to `OwnershipInfo`, `LifetimeRegionMetadata`, `LifetimeReleaseEvent` shapes
- [x] No `emit_scope_drops` helper introduced (deferred to sub-issue M1.5.2)
- [x] No escape-promotion logic introduced (deferred to sub-issue M1.5.5)

https://claude.ai/code/session_01NJJfFfsBsRdEuZ3e1ffr1j

---
_Generated by [Claude Code](https://claude.ai/code/session_01NJJfFfsBsRdEuZ3e1ffr1j)_