### PR TITLE
feat(compiler): add atomic_fence builtin (M0-Atomics.4)

### DIFF
--- a/compiler/src/llvm/atomics.sfn
+++ b/compiler/src/llvm/atomics.sfn
@@ -14,8 +14,11 @@
 // Type contract (enforced here; emits E0806 on violation):
 //   atomic_load(ptr: *int) -> int
 //   atomic_store(ptr: *int, value: int) -> void
+//   atomic_fence() -> void
 // `*int` lowers to `i64*`, `int` lowers to `i64`. Atomic ops on
-// non-i64 widths are out of scope for v0.
+// non-i64 widths are out of scope for v0. `atomic_fence` is the
+// odd one out — no operands, no SSA temp, just a single
+// `fence seq_cst` line acting as a cross-thread memory barrier.
 import { NativeFunction } from "../native_ir";
 // Mutually recursive: lower_atomic_builtin lowers each argument via
 // lower_expression, which itself dispatches calls back through this
@@ -63,7 +66,10 @@ fn lower_atomic_builtin(name: string, arguments: string[], bindings: ParameterBi
     if trimmed == "atomic_store" {
         return _lower_atomic_store(arguments, bindings, locals, temp_index, lines, functions, context);
     }
-    // M0-Atomics.2/3/4 will fill these in. Until then, reject the
+    if trimmed == "atomic_fence" {
+        return _lower_atomic_fence(arguments, temp_index, lines);
+    }
+    // M0-Atomics.2/3 will fill these in. Until then, reject the
     // call with a `[fatal]` diagnostic so the build exits non-zero
     // — matching the issue #306 contract that the emit-level
     // entrypoints (`compile_native_text_to_llvm_file`, `write_llvm_ir`)
@@ -265,6 +271,42 @@ fn _lower_atomic_store(arguments: string[], bindings: ParameterBinding[], locals
         operand: null,
         diagnostics: diagnostics,
         string_constants: collected_strings
+    };
+}
+
+// `atomic_fence() -> void` →
+//     fence seq_cst
+// Trivial: zero arguments, no SSA temp, no aggregate result. The
+// only failure path is "called with arguments" — rejected with
+// E0806 (the same code M0-Atomics.1 reserved for atomic-arity /
+// type errors), extended with an "expected zero arguments"
+// message as the sub-issue contract specifies.
+fn _lower_atomic_fence(arguments: string[], temp_index: number, lines: string[]) -> ExpressionResult ![io] {
+    let mut diagnostics: string[] = [];
+    let mut current_lines = lines;
+
+    if arguments.length != 0 {
+        let diag = "llvm lowering [fatal] [E0806]: atomic_fence expects zero arguments, got "
+            + number_to_string(arguments.length);
+        print.err(diag);
+        diagnostics.push(diag);
+        return ExpressionResult {
+            lines: current_lines,
+            temp_index: temp_index,
+            operand: null,
+            diagnostics: diagnostics,
+            string_constants: []
+        };
+    }
+
+    current_lines.push("  fence seq_cst");
+
+    return ExpressionResult {
+        lines: current_lines,
+        temp_index: temp_index,
+        operand: null,
+        diagnostics: diagnostics,
+        string_constants: []
     };
 }
 

--- a/compiler/tests/e2e/fixtures/atomic_fence_basic.sfn
+++ b/compiler/tests/e2e/fixtures/atomic_fence_basic.sfn
@@ -1,0 +1,17 @@
+// Fixture for compiler/tests/e2e/test_atomic_fence_compile.sh.
+// Exercises `atomic_fence` between two atomic ops so the emitted
+// LLVM IR contains exactly two `fence seq_cst` instructions —
+// matches the verification regex in issue #334. The surrounding
+// `atomic_store` / `atomic_load` pair is lifted from the
+// M0-Atomics.1 fixture; together they prove the fence does not
+// disturb sibling atomic lowering and is emitted standalone (no
+// SSA temp, no operands).
+fn flush(counter: * int, value: int) {
+    atomic_store(counter, value);
+    atomic_fence();
+}
+
+fn observe(counter: * int) -> int {
+    atomic_fence();
+    return atomic_load(counter);
+}

--- a/compiler/tests/e2e/test_atomic_fence_compile.sh
+++ b/compiler/tests/e2e/test_atomic_fence_compile.sh
@@ -48,18 +48,18 @@ test_atomic_fence_emits_expected_ir() {
     #   atomic_fence() → exactly one `fence seq_cst` line per call site,
     #   no operands, no alignment clause.
     local missing=0
-    if ! grep -qE '^\s*fence seq_cst$' "$ll"; then
+    if ! grep -qE '^[[:space:]]*fence seq_cst$' "$ll"; then
         echo "[test]   missing 'fence seq_cst' line in emitted IR"
         missing=$((missing + 1))
     fi
     # Defence against a regression that adds an alignment clause or
     # an operand to the fence instruction (LLVM rejects both for
     # `fence`, but we also want a fast unit-style failure here).
-    if grep -qE '^\s*fence seq_cst.*align' "$ll"; then
+    if grep -qE '^[[:space:]]*fence seq_cst.*align' "$ll"; then
         echo "[test]   regression: 'fence seq_cst' emitted with align clause"
         missing=$((missing + 1))
     fi
-    if grep -qE '^\s*fence seq_cst[[:space:]]+i' "$ll"; then
+    if grep -qE '^[[:space:]]*fence seq_cst[[:space:]]+i' "$ll"; then
         echo "[test]   regression: 'fence seq_cst' emitted with an operand"
         missing=$((missing + 1))
     fi
@@ -69,7 +69,9 @@ test_atomic_fence_emits_expected_ir() {
 # ---- Verification regex from the issue counts == call sites in fixture ----
 # The fixture has two `atomic_fence()` call sites. The issue's verification
 # block specifies `grep -c '^\s*fence seq_cst$'` should match the call-site
-# count.
+# count; we use the POSIX-portable `[[:space:]]*` form here so the test
+# runs cleanly under BSD grep on the macos-arm64 CI matrix (BSD ERE
+# does not honour the PCRE `\s` escape).
 test_fence_count_matches_call_sites() {
     local ll="$SCRATCH/atomic_fence_count.ll"
     if ! "$BINARY" emit -o "$ll" llvm "$FIXTURE" > /dev/null 2>&1; then
@@ -77,7 +79,7 @@ test_fence_count_matches_call_sites() {
         return 1
     fi
     local hits
-    hits="$(grep -cE '^\s*fence seq_cst$' "$ll" || true)"
+    hits="$(grep -cE '^[[:space:]]*fence seq_cst$' "$ll" || true)"
     if [ "${hits:-0}" -ne 2 ]; then
         echo "[test]   expected 2 'fence seq_cst' lines, got ${hits:-0}"
         return 1
@@ -113,7 +115,7 @@ EOF
         echo "         stderr was: $stderr" | head -5
         return 1
     fi
-    if [ -f "$ll" ] && grep -qE '^\s*fence seq_cst$' "$ll"; then
+    if [ -f "$ll" ] && grep -qE '^[[:space:]]*fence seq_cst$' "$ll"; then
         echo "[test]   regression: emitted 'fence seq_cst' for bogus arity call"
         return 1
     fi

--- a/compiler/tests/e2e/test_atomic_fence_compile.sh
+++ b/compiler/tests/e2e/test_atomic_fence_compile.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# End-to-end test for the `atomic_fence` builtin (M0-Atomics.4,
+# issue #334). Drives `sfn emit llvm` against the fixture and
+# asserts the emitted IR contains exactly one `fence seq_cst`
+# line per call site, with no spurious operands or alignment
+# clauses. Also pins the E0806 rejection on a deliberately broken
+# call (`atomic_fence(0)`) so the diagnostic surface stays
+# user-visible — sibling to the load/store rejection coverage in
+# `test_atomic_load_store_compile.sh`.
+#
+# Usage:
+#   compiler/tests/e2e/test_atomic_fence_compile.sh <compiler-binary>
+
+set -euo pipefail
+
+BINARY="${1:?usage: test_atomic_fence_compile.sh <compiler-binary>}"
+BINARY="$(realpath "$BINARY")"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FIXTURE="$SCRIPT_DIR/fixtures/atomic_fence_basic.sfn"
+
+PASS=0
+FAIL=0
+
+SCRATCH="$(mktemp -d -t sfn-atomic-fence-XXXXXX)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+run_test() {
+    local name="$1"
+    shift
+    if "$@"; then
+        echo "[test] PASS: $name"
+        PASS=$((PASS + 1))
+    else
+        echo "[test] FAIL: $name"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# ---- Happy path: each atomic_fence() call site emits one `fence seq_cst` ----
+test_atomic_fence_emits_expected_ir() {
+    local ll="$SCRATCH/atomic_fence_basic.ll"
+    if ! "$BINARY" emit -o "$ll" llvm "$FIXTURE" > /dev/null 2>&1; then
+        echo "[test]   sfn emit llvm failed for atomic_fence_basic.sfn"
+        return 1
+    fi
+
+    # Acceptance Criteria from issue #334:
+    #   atomic_fence() → exactly one `fence seq_cst` line per call site,
+    #   no operands, no alignment clause.
+    local missing=0
+    if ! grep -qE '^\s*fence seq_cst$' "$ll"; then
+        echo "[test]   missing 'fence seq_cst' line in emitted IR"
+        missing=$((missing + 1))
+    fi
+    # Defence against a regression that adds an alignment clause or
+    # an operand to the fence instruction (LLVM rejects both for
+    # `fence`, but we also want a fast unit-style failure here).
+    if grep -qE '^\s*fence seq_cst.*align' "$ll"; then
+        echo "[test]   regression: 'fence seq_cst' emitted with align clause"
+        missing=$((missing + 1))
+    fi
+    if grep -qE '^\s*fence seq_cst[[:space:]]+i' "$ll"; then
+        echo "[test]   regression: 'fence seq_cst' emitted with an operand"
+        missing=$((missing + 1))
+    fi
+    return "$missing"
+}
+
+# ---- Verification regex from the issue counts == call sites in fixture ----
+# The fixture has two `atomic_fence()` call sites. The issue's verification
+# block specifies `grep -c '^\s*fence seq_cst$'` should match the call-site
+# count.
+test_fence_count_matches_call_sites() {
+    local ll="$SCRATCH/atomic_fence_count.ll"
+    if ! "$BINARY" emit -o "$ll" llvm "$FIXTURE" > /dev/null 2>&1; then
+        echo "[test]   sfn emit llvm failed for fence-count case"
+        return 1
+    fi
+    local hits
+    hits="$(grep -cE '^\s*fence seq_cst$' "$ll" || true)"
+    if [ "${hits:-0}" -ne 2 ]; then
+        echo "[test]   expected 2 'fence seq_cst' lines, got ${hits:-0}"
+        return 1
+    fi
+    return 0
+}
+
+# ---- E0806: type-error on extra-argument call is reported ----
+test_atomic_fence_rejects_extra_argument() {
+    local src="$SCRATCH/bad_fence.sfn"
+    local ll="$SCRATCH/bad_fence.ll"
+    cat > "$src" <<'EOF'
+fn bad() {
+    atomic_fence(0);
+}
+EOF
+    # E0806 is emitted as a `[fatal]`-tagged lowering diagnostic and
+    # printed to stderr from `_lower_atomic_fence`. Mirrors the
+    # rejection-test pattern in `test_atomic_load_store_compile.sh`:
+    # we don't gate on exit code (see that file's notes on the
+    # `compile_to_llvm_file_with_module` fallback path) but we do
+    # require the diagnostic on stderr and no `fence seq_cst` line
+    # in any emitted IR.
+    local stderr
+    stderr="$("$BINARY" emit -o "$ll" llvm "$src" 2>&1 1>/dev/null || true)"
+    if ! echo "$stderr" | grep -q "E0806"; then
+        echo "[test]   missing E0806 for atomic_fence with extra argument"
+        echo "         stderr was: $stderr" | head -5
+        return 1
+    fi
+    if ! echo "$stderr" | grep -q "expects zero arguments"; then
+        echo "[test]   E0806 missing the 'expects zero arguments' message"
+        echo "         stderr was: $stderr" | head -5
+        return 1
+    fi
+    if [ -f "$ll" ] && grep -qE '^\s*fence seq_cst$' "$ll"; then
+        echo "[test]   regression: emitted 'fence seq_cst' for bogus arity call"
+        return 1
+    fi
+    return 0
+}
+
+run_test "atomic_fence emits 'fence seq_cst' with no operands" \
+    test_atomic_fence_emits_expected_ir
+run_test "atomic_fence emits one fence per call site (issue #334 verification regex)" \
+    test_fence_count_matches_call_sites
+run_test "atomic_fence with extra argument reports E0806" \
+    test_atomic_fence_rejects_extra_argument
+
+echo "[summary] $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi

--- a/compiler/tests/unit/atomic_fence_test.sfn
+++ b/compiler/tests/unit/atomic_fence_test.sfn
@@ -1,0 +1,42 @@
+// Unit tests for the `atomic_fence` builtin (M0-Atomics.4, issue
+// #334). The predecessor M0-Atomics.1 unit suite documents the
+// reason these tests can't import the LLVM lowering stack to pin
+// the IR shape directly — see `atomic_load_store_test.sfn` for the
+// full background and the GitHub Actions run that timed out at
+// 180s. The same constraint applies here: importing
+// `lower_atomic_builtin` pulls in `lower_expression` and the rest
+// of `compiler/src/llvm/expression_lowering/native/core`, which
+// blows the per-test CI budget.
+//
+// The IR shape (`fence seq_cst` on the happy path, `[fatal] [E0806]`
+// on the arity-error path) is pinned end-to-end in
+// `compiler/tests/e2e/test_atomic_fence_compile.sh`. This file
+// pins the predicate surface so a regression in
+// `is_atomic_builtin` — which gates whether the LLVM lowering for
+// `atomic_fence` runs at all — surfaces here without paying the
+// lowering import cost.
+import { is_atomic_builtin } from "../../src/llvm/atomics";
+
+// ── Predicate recognises the implemented name ──
+test "atomics: is_atomic_builtin recognises atomic_fence" {
+    assert is_atomic_builtin("atomic_fence");
+}
+
+// Whitespace tolerance: `lower_atomic_builtin` calls `trim_text`
+// before dispatching, so the predicate must accept the same
+// surface that the dispatch hook sees in practice.
+test "atomics: is_atomic_builtin recognises atomic_fence after trim" {
+    assert is_atomic_builtin("atomic_fence");
+    assert is_atomic_builtin(" atomic_fence ");
+}
+
+// Defence against a future regression that loosens the predicate
+// to a startsWith / endsWith match — only the exact six reserved
+// names should fire the dispatch hook, even for plausible
+// near-misses around the `atomic_fence` name.
+test "atomics: is_atomic_builtin rejects partial atomic_fence names" {
+    assert ! is_atomic_builtin("fence");
+    assert ! is_atomic_builtin("atomic_fenc");
+    assert ! is_atomic_builtin("atomic_fencex");
+    assert ! is_atomic_builtin("atomic_fence_seq_cst");
+}


### PR DESCRIPTION
Closes #334

## Summary

- Wire `atomic_fence()` through the existing dispatch in `compiler/src/llvm/atomics.sfn` — zero arguments, void return, lowers to a single `fence seq_cst` LLVM line.
- Reject calls with arguments during lowering with `[fatal] [E0806]: atomic_fence expects zero arguments, got N`, reusing the diagnostic code M0-Atomics.1 (#331) reserved for atomic-arity / type errors per the issue's "extend with an 'expected zero arguments' message" guidance.
- Unit + E2E coverage following the pattern set by `atomic_load_store_test.sfn` / `test_atomic_load_store_compile.sh`.

## Acceptance criteria (issue #334)

- [x] `is_atomic_builtin("atomic_fence")` returns `true` (already reserved in M0-Atomics.1; predicate test added).
- [x] `atomic_fence()` lowers to exactly one line: `fence seq_cst`.
- [x] `atomic_fence(...)` with any arguments fails with `[fatal] [E0806]` + "expects zero arguments" message.
- [x] Return type is `void` (`operand: null`); using the result in an expression context fails because the lowering returns a null operand.
- [x] `make compile && make check` passes — stage2 == stage3 fixed-point, 81/81 unit + 40/40 e2e.
- [x] Unit test cases (≥2) pin the predicate surface. Per the comment in `atomic_load_store_test.sfn`, importing the lowering stack from a `.sfn` unit test blows the 180s CI budget; the IR shape is pinned in the e2e shell test instead.
- [x] E2E test compiles a fixture with two `atomic_fence()` call sites and `grep -cE '^\s*fence seq_cst$'` returns 2.

## Files

- `compiler/src/llvm/atomics.sfn` — extended dispatch + `_lower_atomic_fence` helper (~30 LOC).
- `compiler/tests/unit/atomic_fence_test.sfn` — predicate cases (recognises name, rejects near-misses).
- `compiler/tests/e2e/fixtures/atomic_fence_basic.sfn` — fixture exercising two call sites between atomic load/store ops.
- `compiler/tests/e2e/test_atomic_fence_compile.sh` — drives `sfn emit llvm`, asserts the IR shape and the E0806 diagnostic.

## Test plan

- [x] `ulimit -v 8388608 && make compile`
- [x] `bash compiler/tests/e2e/test_atomic_fence_compile.sh build/native/sailfin` → 3/3 PASS
- [x] `bash scripts/run_native_test.sh build/native/sailfin compiler/tests/unit/atomic_fence_test.sfn` → PASS (3 consecutive runs at default 180s budget)
- [x] `make test-unit` → 81/81
- [x] `make test-e2e` → 40/40
- [x] `make check` → stage2 == stage3 fixed-point ✓, exit 0
- [x] `sfn fmt --check` clean on every touched `.sfn` file

## Smoke (issue verification block)

```
$ build/native/sailfin emit llvm compiler/tests/e2e/fixtures/atomic_fence_basic.sfn 2>/dev/null \
    | grep -c '^\s*fence seq_cst$'
2
```

Matches the two `atomic_fence()` call sites in the fixture.

---
_Generated by [Claude Code](https://claude.ai/code/session_017WgkwMpSu6MfpAXXwdEfWW)_