### PR TITLE
feat(compiler): add atomic_add / atomic_sub builtins (M0-Atomics.2)

### DIFF
--- a/compiler/src/llvm/atomics.sfn
+++ b/compiler/src/llvm/atomics.sfn
@@ -7,13 +7,16 @@
 // than calls to a runtime helper.
 //
 // M0-Atomics.1 (issue #331) ships `atomic_load` and `atomic_store`
-// plus this dispatch infrastructure. The remaining four builtins
-// reuse `is_atomic_builtin` + `lower_atomic_builtin`; see issue #323
-// for the parent epic.
+// plus this dispatch infrastructure. M0-Atomics.2 (issue #332) adds
+// `atomic_add` / `atomic_sub`. The remaining two builtins reuse
+// `is_atomic_builtin` + `lower_atomic_builtin`; see issue #323 for
+// the parent epic.
 //
 // Type contract (enforced here; emits E0806 on violation):
 //   atomic_load(ptr: *int) -> int
 //   atomic_store(ptr: *int, value: int) -> void
+//   atomic_add(ptr: *int, delta: int) -> int   // returns OLD value
+//   atomic_sub(ptr: *int, delta: int) -> int   // returns OLD value
 //   atomic_fence() -> void
 // `*int` lowers to `i64*`, `int` lowers to `i64`. Atomic ops on
 // non-i64 widths are out of scope for v0. `atomic_fence` is the
@@ -69,7 +72,13 @@ fn lower_atomic_builtin(name: string, arguments: string[], bindings: ParameterBi
     if trimmed == "atomic_fence" {
         return _lower_atomic_fence(arguments, temp_index, lines);
     }
-    // M0-Atomics.2/3 will fill these in. Until then, reject the
+    if trimmed == "atomic_add" {
+        return _lower_atomic_rmw("add", "atomic_add", arguments, bindings, locals, temp_index, lines, functions, context);
+    }
+    if trimmed == "atomic_sub" {
+        return _lower_atomic_rmw("sub", "atomic_sub", arguments, bindings, locals, temp_index, lines, functions, context);
+    }
+    // M0-Atomics.3 will fill in `atomic_cas`. Until then, reject the
     // call with a `[fatal]` diagnostic so the build exits non-zero
     // — matching the issue #306 contract that the emit-level
     // entrypoints (`compile_native_text_to_llvm_file`, `write_llvm_ir`)
@@ -307,6 +316,135 @@ fn _lower_atomic_fence(arguments: string[], temp_index: number, lines: string[])
         operand: null,
         diagnostics: diagnostics,
         string_constants: []
+    };
+}
+
+// `atomic_add(ptr: *int, delta: int) -> int` →
+//     %tN = atomicrmw add ptr <ptr>, i64 <delta> seq_cst, align 8
+// `atomic_sub(ptr: *int, delta: int) -> int` →
+//     %tN = atomicrmw sub ptr <ptr>, i64 <delta> seq_cst, align 8
+//
+// Returns the **previous** value at `*ptr` — this is LLVM `atomicrmw`
+// semantics and is what reference-counting needs. The canonical RC
+// release pattern is "if `atomic_sub(rc, 1) == 1` then free", which
+// only works because we observe the value before the decrement. Do
+// NOT split this into a `load` + arithmetic + `store` (or compose it
+// from `atomic_load` + `atomic_store`) — that race is the entire
+// reason we lower to a single `atomicrmw` instruction.
+//
+// Shared between `atomic_add` and `atomic_sub`: only the LLVM op
+// mnemonic (`add` vs `sub`) differs. `name` is threaded through to
+// the diagnostics so the user sees the Sailfin-level builtin name
+// (e.g. `atomic_sub`) rather than the LLVM op.
+fn _lower_atomic_rmw(op: string, name: string, arguments: string[], bindings: ParameterBinding[], locals: LocalBinding[], temp_index: number, lines: string[], functions: NativeFunction[], context: TypeContext) -> ExpressionResult ![io] {
+    let mut diagnostics: string[] = [];
+    let mut current_lines = lines;
+    let mut current_temp = temp_index;
+    let mut collected_strings: StringConstant[] = [];
+
+    if arguments.length != 2 {
+        let diag1 = "llvm lowering [fatal] [E0806]: " + name
+            + " expects exactly 2 arguments (`*int`, `int`), got "
+            + number_to_string(arguments.length);
+        print.err(diag1);
+        diagnostics.push(diag1);
+        return ExpressionResult {
+            lines: current_lines,
+            temp_index: current_temp,
+            operand: null,
+            diagnostics: diagnostics,
+            string_constants: collected_strings
+        };
+    }
+
+    let ptr_text = trim_text(arguments[0]);
+    let ptr_lowered = lower_expression(ptr_text, bindings, locals, current_temp, current_lines, functions, context, "i64*");
+    diagnostics = extend_string_array(diagnostics, ptr_lowered.diagnostics);
+    collected_strings = merge_string_constants(collected_strings, ptr_lowered.string_constants);
+    current_lines = ptr_lowered.lines;
+    current_temp = ptr_lowered.temp_index;
+
+    if ptr_lowered.operand == null {
+        diagnostics.push("llvm lowering: " + name
+            + " failed to lower pointer argument");
+        return ExpressionResult {
+            lines: current_lines,
+            temp_index: current_temp,
+            operand: null,
+            diagnostics: diagnostics,
+            string_constants: collected_strings
+        };
+    }
+
+    let ptr_operand = ptr_lowered.operand;
+    let ptr_type = trim_text(ptr_operand.llvm_type);
+    if ptr_type != "i64*" {
+        let diag2 = "llvm lowering [fatal] [E0806]: " + name
+            + " expects argument 0 of type `*int` (i64*), got `"
+            + ptr_type
+            + "`";
+        print.err(diag2);
+        diagnostics.push(diag2);
+        return ExpressionResult {
+            lines: current_lines,
+            temp_index: current_temp,
+            operand: null,
+            diagnostics: diagnostics,
+            string_constants: collected_strings
+        };
+    }
+
+    let delta_text = trim_text(arguments[1]);
+    let delta_lowered = lower_expression(delta_text, bindings, locals, current_temp, current_lines, functions, context, "i64");
+    diagnostics = extend_string_array(diagnostics, delta_lowered.diagnostics);
+    collected_strings = merge_string_constants(collected_strings, delta_lowered.string_constants);
+    current_lines = delta_lowered.lines;
+    current_temp = delta_lowered.temp_index;
+
+    if delta_lowered.operand == null {
+        diagnostics.push("llvm lowering: " + name
+            + " failed to lower delta argument");
+        return ExpressionResult {
+            lines: current_lines,
+            temp_index: current_temp,
+            operand: null,
+            diagnostics: diagnostics,
+            string_constants: collected_strings
+        };
+    }
+
+    let delta_operand = delta_lowered.operand;
+    let delta_type = trim_text(delta_operand.llvm_type);
+    if delta_type != "i64" {
+        let diag3 = "llvm lowering [fatal] [E0806]: " + name
+            + " expects argument 1 of type `int` (i64), got `"
+            + delta_type
+            + "`";
+        print.err(diag3);
+        diagnostics.push(diag3);
+        return ExpressionResult {
+            lines: current_lines,
+            temp_index: current_temp,
+            operand: null,
+            diagnostics: diagnostics,
+            string_constants: collected_strings
+        };
+    }
+
+    let result_name = format_temp_name(current_temp);
+    current_temp += 1;
+    current_lines.push("  " + result_name + " = atomicrmw " + op + " ptr "
+        + ptr_operand.value
+        + ", i64 "
+        + delta_operand.value
+        + " seq_cst, align 8");
+
+    return ExpressionResult {
+        lines: current_lines,
+        temp_index: current_temp,
+        operand: LLVMOperand { llvm_type: "i64", value: result_name },
+        diagnostics: diagnostics,
+        string_constants: collected_strings
     };
 }
 

--- a/compiler/tests/e2e/fixtures/atomic_add_sub_basic.sfn
+++ b/compiler/tests/e2e/fixtures/atomic_add_sub_basic.sfn
@@ -1,0 +1,11 @@
+// Fixture for compiler/tests/e2e/test_atomic_add_sub_compile.sh.
+// Exercises `atomic_add` and `atomic_sub` so the emitted LLVM IR
+// contains exactly one `atomicrmw add` and one `atomicrmw sub`
+// instruction — matches the verification regex in issue #332. Each
+// builtin returns the **previous** value at `*ptr`; the surrounding
+// reference-counting idiom (retain on `atomic_add`, release-then-
+// free on `atomic_sub == 1`) is the M2 RC use case this fixture
+// models.
+fn retain(rc: * int) -> int { return atomic_add(rc, 1); }
+
+fn release(rc: * int) -> int { return atomic_sub(rc, 1); }

--- a/compiler/tests/e2e/test_atomic_add_sub_compile.sh
+++ b/compiler/tests/e2e/test_atomic_add_sub_compile.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# End-to-end test for the `atomic_add` / `atomic_sub` builtins
+# (M0-Atomics.2, issue #332). Drives `sfn emit llvm` against the
+# fixture and asserts the emitted IR contains the expected
+# `atomicrmw add` / `atomicrmw sub` shapes with `seq_cst` ordering
+# and `align 8`. Also pins the E0806 rejection on a deliberately
+# broken call so the diagnostic surface stays user-visible —
+# sibling to the load/store rejection coverage in
+# `test_atomic_load_store_compile.sh`.
+#
+# Usage:
+#   compiler/tests/e2e/test_atomic_add_sub_compile.sh <compiler-binary>
+
+set -euo pipefail
+
+BINARY="${1:?usage: test_atomic_add_sub_compile.sh <compiler-binary>}"
+BINARY="$(realpath "$BINARY")"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FIXTURE="$SCRIPT_DIR/fixtures/atomic_add_sub_basic.sfn"
+
+PASS=0
+FAIL=0
+
+SCRATCH="$(mktemp -d -t sfn-atomic-add-sub-XXXXXX)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+run_test() {
+    local name="$1"
+    shift
+    if "$@"; then
+        echo "[test] PASS: $name"
+        PASS=$((PASS + 1))
+    else
+        echo "[test] FAIL: $name"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# ---- Happy path: both builtins emit the right LLVM atomicrmw ops ----
+test_add_and_sub_emit_expected_ir() {
+    local ll="$SCRATCH/atomic_add_sub_basic.ll"
+    if ! "$BINARY" emit -o "$ll" llvm "$FIXTURE" > /dev/null 2>&1; then
+        echo "[test]   sfn emit llvm failed for atomic_add_sub_basic.sfn"
+        return 1
+    fi
+
+    # Acceptance Criteria from issue #332:
+    #   atomic_add → `%temp = atomicrmw add ptr %ptr, i64 %delta seq_cst, align 8`
+    #   atomic_sub → `%temp = atomicrmw sub ptr %ptr, i64 %delta seq_cst, align 8`
+    local missing=0
+    if ! grep -qE "atomicrmw add ptr.*i64.*seq_cst" "$ll"; then
+        echo "[test]   missing 'atomicrmw add ptr ... i64 ... seq_cst' in emitted IR"
+        missing=$((missing + 1))
+    fi
+    if ! grep -qE "atomicrmw sub ptr.*i64.*seq_cst" "$ll"; then
+        echo "[test]   missing 'atomicrmw sub ptr ... i64 ... seq_cst' in emitted IR"
+        missing=$((missing + 1))
+    fi
+    if ! grep -qE "atomicrmw add ptr.*align 8" "$ll"; then
+        echo "[test]   atomicrmw add missing 'align 8'"
+        missing=$((missing + 1))
+    fi
+    if ! grep -qE "atomicrmw sub ptr.*align 8" "$ll"; then
+        echo "[test]   atomicrmw sub missing 'align 8'"
+        missing=$((missing + 1))
+    fi
+    return "$missing"
+}
+
+# ---- Verification regex from the issue counts ≥ 2 ----
+# (`atomicrmw add ... seq_cst` + `atomicrmw sub ... seq_cst`).
+test_verification_regex_counts_at_least_two() {
+    local ll="$SCRATCH/atomic_add_sub_count.ll"
+    if ! "$BINARY" emit -o "$ll" llvm "$FIXTURE" > /dev/null 2>&1; then
+        echo "[test]   sfn emit llvm failed for verification-regex case"
+        return 1
+    fi
+    local hits
+    hits="$(grep -cE 'atomicrmw (add|sub) ptr.*i64.*seq_cst' "$ll" || true)"
+    if [ "${hits:-0}" -lt 2 ]; then
+        echo "[test]   verification regex matched only $hits lines (expected ≥ 2)"
+        return 1
+    fi
+    return 0
+}
+
+# ---- E0806: type-error on non-pointer first argument is reported ----
+test_atomic_add_rejects_non_pointer_arg() {
+    local src="$SCRATCH/bad_add.sfn"
+    local ll="$SCRATCH/bad_add.ll"
+    cat > "$src" <<'EOF'
+fn bad() -> int {
+    return atomic_add(42, 1);
+}
+EOF
+    # E0806 is emitted as a `[fatal]`-tagged lowering diagnostic and
+    # printed to stderr from `_lower_atomic_rmw`. We assert two
+    # signals (mirroring `test_atomic_load_store_compile.sh`):
+    #   1. the E0806 code is present on stderr
+    #   2. the .ll file (if produced) does NOT contain an
+    #      `atomicrmw add` line — i.e. the bogus call was rejected
+    #      before lowering would have emitted malformed IR
+    #
+    # We intentionally don't gate on the exit code: the
+    # `compile_to_llvm_file_with_module` fallback path can still
+    # produce a partial-but-valid-looking .ll even on fatal
+    # lowering diagnostics. See the load/store sibling test for the
+    # full background.
+    local stderr
+    stderr="$("$BINARY" emit -o "$ll" llvm "$src" 2>&1 1>/dev/null || true)"
+    if ! echo "$stderr" | grep -q "E0806"; then
+        echo "[test]   missing E0806 for non-pointer atomic_add argument"
+        echo "         stderr was: $stderr" | head -5
+        return 1
+    fi
+    if [ -f "$ll" ] && grep -qE "atomicrmw add ptr" "$ll"; then
+        echo "[test]   regression: emitted 'atomicrmw add ptr' for non-pointer arg"
+        return 1
+    fi
+    return 0
+}
+
+# ---- E0806: type-error on non-int delta is reported ----
+test_atomic_sub_rejects_non_int_delta() {
+    local src="$SCRATCH/bad_sub.sfn"
+    local ll="$SCRATCH/bad_sub.ll"
+    cat > "$src" <<'EOF'
+fn bad(p: *int) -> int {
+    return atomic_sub(p, "hello");
+}
+EOF
+    # See test_atomic_add_rejects_non_pointer_arg above for the
+    # rationale on why we don't gate on exit code.
+    local stderr
+    stderr="$("$BINARY" emit -o "$ll" llvm "$src" 2>&1 1>/dev/null || true)"
+    if ! echo "$stderr" | grep -q "E0806"; then
+        echo "[test]   missing E0806 for non-int atomic_sub delta"
+        echo "         stderr was: $stderr" | head -5
+        return 1
+    fi
+    if [ -f "$ll" ] && grep -qE "atomicrmw sub ptr" "$ll"; then
+        echo "[test]   regression: emitted 'atomicrmw sub ptr' for non-int delta"
+        return 1
+    fi
+    return 0
+}
+
+run_test "atomic_add + atomic_sub emit atomicrmw add/sub with seq_cst, align 8" \
+    test_add_and_sub_emit_expected_ir
+run_test "issue verification regex matches ≥ 2 atomicrmw ops" \
+    test_verification_regex_counts_at_least_two
+run_test "atomic_add with non-pointer argument reports E0806" \
+    test_atomic_add_rejects_non_pointer_arg
+run_test "atomic_sub with non-int delta reports E0806" \
+    test_atomic_sub_rejects_non_int_delta
+
+echo "[summary] $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi

--- a/compiler/tests/unit/atomic_add_sub_test.sfn
+++ b/compiler/tests/unit/atomic_add_sub_test.sfn
@@ -1,0 +1,50 @@
+// Unit tests for the `atomic_add` / `atomic_sub` builtins
+// (M0-Atomics.2, issue #332). Predecessor M0-Atomics.1 documents
+// the reason these tests can't import the LLVM lowering stack to
+// pin the IR shape directly — see `atomic_load_store_test.sfn` for
+// the full background and the GitHub Actions run that timed out at
+// 180s. The same constraint applies here: importing
+// `lower_atomic_builtin` pulls in `lower_expression` and the rest
+// of `compiler/src/llvm/expression_lowering/native/core`, which
+// blows the per-test CI budget.
+//
+// The IR shape (`atomicrmw add ptr ..., i64 ... seq_cst, align 8`
+// on the happy path, `[fatal] [E0806]` on the type-error path) is
+// pinned end-to-end in
+// `compiler/tests/e2e/test_atomic_add_sub_compile.sh`. This file
+// pins the predicate surface that gates whether the LLVM lowering
+// for these builtins runs at all, plus a few near-miss negatives
+// so a regression in `is_atomic_builtin` surfaces here without
+// paying the lowering import cost.
+import { is_atomic_builtin } from "../../src/llvm/atomics";
+
+// ── Predicate recognises the implemented names ──
+test "atomics: is_atomic_builtin recognises atomic_add" {
+    assert is_atomic_builtin("atomic_add");
+}
+
+test "atomics: is_atomic_builtin recognises atomic_sub" {
+    assert is_atomic_builtin("atomic_sub");
+}
+
+// Whitespace tolerance: `lower_atomic_builtin` calls `trim_text`
+// before dispatching, so the predicate must accept the same
+// surface that the dispatch hook sees in practice.
+test "atomics: is_atomic_builtin recognises atomic_add / atomic_sub after trim" {
+    assert is_atomic_builtin(" atomic_add ");
+    assert is_atomic_builtin(" atomic_sub ");
+}
+
+// Defence against a future regression that loosens the predicate
+// to a startsWith / endsWith match — only the exact six reserved
+// names should fire the dispatch hook, even for plausible
+// near-misses around the `atomic_add` / `atomic_sub` names.
+test "atomics: is_atomic_builtin rejects partial atomic_add / atomic_sub names" {
+    assert ! is_atomic_builtin("add");
+    assert ! is_atomic_builtin("sub");
+    assert ! is_atomic_builtin("atomic_ad");
+    assert ! is_atomic_builtin("atomic_addx");
+    assert ! is_atomic_builtin("atomic_su");
+    assert ! is_atomic_builtin("atomic_subx");
+    assert ! is_atomic_builtin("atomic_add_seq_cst");
+}


### PR DESCRIPTION
## Summary

- Extends `compiler/src/llvm/atomics.sfn` with `atomic_add(*int, int) -> int` and `atomic_sub(*int, int) -> int`, lowering to `atomicrmw add` / `atomicrmw sub` with `seq_cst` ordering and `align 8`.
- Both builtins return the **previous** value at `*ptr` — LLVM `atomicrmw` semantics, which is what the M2 RC release pattern (`if atomic_sub(rc, 1) == 1 then free`) needs. Source comment explicitly warns against decomposing into `load`+arithmetic+`store` (that race is the whole point of using `atomicrmw`).
- Reuses the M0-Atomics.1 (#331) dispatch hook + `E0806` diagnostic surface; the two new cases share a single `_lower_atomic_rmw` helper that only varies the LLVM op mnemonic (`add` vs `sub`).

## Coverage

- **Unit** (`compiler/tests/unit/atomic_add_sub_test.sfn`): 4 tests pinning `is_atomic_builtin` for both names plus near-miss negatives, mirroring the M0-Atomics.1/.4 pattern that avoids the 180s CI timeout from importing the LLVM lowering stack. The IR shape itself is pinned in the e2e test below.
- **E2E** (`compiler/tests/e2e/test_atomic_add_sub_compile.sh` + `fixtures/atomic_add_sub_basic.sfn`): drives `sfn emit llvm` against an RC-shaped fixture (`retain` calls `atomic_add(rc, 1)`, `release` calls `atomic_sub(rc, 1)`) and asserts:
  1. `atomicrmw add ptr ..., i64 ... seq_cst, align 8` is emitted.
  2. `atomicrmw sub ptr ..., i64 ... seq_cst, align 8` is emitted.
  3. The issue's verification regex (`atomicrmw (add|sub) ptr.*i64.*seq_cst`) matches ≥ 2 lines.
  4. `atomic_add(42, 1)` (non-pointer arg 0) is rejected with `E0806`.
  5. `atomic_sub(p, "hello")` (non-int delta) is rejected with `E0806`.

## Test plan

- [ ] `make compile`
- [ ] `make test-unit`
- [ ] `make test-e2e`
- [ ] `make check`
- [ ] `build/native/sailfin emit llvm compiler/tests/e2e/fixtures/atomic_add_sub_basic.sfn 2>/dev/null | grep -cE 'atomicrmw (add|sub) ptr.*i64.*seq_cst'` returns `≥ 2`

Closes #332

https://claude.ai/code/session_01WxNWD9rEwuS5CRjx4dsoL2

---
_Generated by [Claude Code](https://claude.ai/code/session_01WxNWD9rEwuS5CRjx4dsoL2)_