### PR TITLE
feat(compiler): add atomic_cas builtin (M0-Atomics.3)

### DIFF
--- a/compiler/src/llvm/atomics.sfn
+++ b/compiler/src/llvm/atomics.sfn
@@ -17,15 +17,15 @@
 //   atomic_store(ptr: *int, value: int) -> void
 //   atomic_add(ptr: *int, delta: int) -> int           // returns OLD value
 //   atomic_sub(ptr: *int, delta: int) -> int           // returns OLD value
-//   atomic_cas(ptr: *int, expected: int, new: int) -> bool  // success bit
+//   atomic_cas(ptr: *int, expected: int, new: int) -> boolean  // success bit
 //   atomic_fence() -> void
-// `*int` lowers to `i64*`, `int` lowers to `i64`, `bool` lowers to
-// `i1`. Atomic ops on non-i64 widths are out of scope for v0.
+// `*int` lowers to `i64*`, `int` lowers to `i64`, `boolean` lowers
+// to `i1`. Atomic ops on non-i64 widths are out of scope for v0.
 // `atomic_fence` is the odd one out — no operands, no SSA temp,
 // just a single `fence seq_cst` line acting as a cross-thread
 // memory barrier. `atomic_cas` is the other odd one — `cmpxchg`
 // returns a `{i64, i1}` aggregate, so the lowering emits a follow-up
-// `extractvalue` to expose the success bit (`i1` → Sailfin `bool`)
+// `extractvalue` to expose the success bit (`i1` → Sailfin `boolean`)
 // and discards the value slot (the v0 contract is success-bit only;
 // a `Result`-shaped return is post-1.0).
 import { NativeFunction } from "../native_ir";
@@ -459,15 +459,15 @@ fn _lower_atomic_rmw(op: string, name: string, arguments: string[], bindings: Pa
     };
 }
 
-// `atomic_cas(ptr: *int, expected: int, new: int) -> bool` →
+// `atomic_cas(ptr: *int, expected: int, new: int) -> boolean` →
 //     %tA = cmpxchg ptr <ptr>, i64 <expected>, i64 <new> seq_cst seq_cst, align 8
 //     %tB = extractvalue { i64, i1 } %tA, 1
 //
-// Returns the **success bit** (i1 → Sailfin `bool`) — `true` if the
-// swap landed, `false` if the location held something other than
-// `expected`. The `i64` slot of the cmpxchg aggregate (the actual
-// value at the location, whether the swap succeeded or not) is
-// intentionally discarded; v0 is success-bit only and a
+// Returns the **success bit** (i1 → Sailfin `boolean`) — `true` if
+// the swap landed, `false` if the location held something other
+// than `expected`. The `i64` slot of the cmpxchg aggregate (the
+// actual value at the location, whether the swap succeeded or
+// not) is intentionally discarded; v0 is success-bit only and a
 // `Result`-shaped return is deferred to post-1.0 (issue #333 notes).
 //
 // Both memory orderings on `cmpxchg` are pinned to `seq_cst`

--- a/compiler/src/llvm/atomics.sfn
+++ b/compiler/src/llvm/atomics.sfn
@@ -8,20 +8,26 @@
 //
 // M0-Atomics.1 (issue #331) ships `atomic_load` and `atomic_store`
 // plus this dispatch infrastructure. M0-Atomics.2 (issue #332) adds
-// `atomic_add` / `atomic_sub`. The remaining two builtins reuse
-// `is_atomic_builtin` + `lower_atomic_builtin`; see issue #323 for
-// the parent epic.
+// `atomic_add` / `atomic_sub`. M0-Atomics.3 (issue #333) adds
+// `atomic_cas`. The last builtin reuses `is_atomic_builtin` +
+// `lower_atomic_builtin`; see issue #323 for the parent epic.
 //
 // Type contract (enforced here; emits E0806 on violation):
 //   atomic_load(ptr: *int) -> int
 //   atomic_store(ptr: *int, value: int) -> void
-//   atomic_add(ptr: *int, delta: int) -> int   // returns OLD value
-//   atomic_sub(ptr: *int, delta: int) -> int   // returns OLD value
+//   atomic_add(ptr: *int, delta: int) -> int           // returns OLD value
+//   atomic_sub(ptr: *int, delta: int) -> int           // returns OLD value
+//   atomic_cas(ptr: *int, expected: int, new: int) -> bool  // success bit
 //   atomic_fence() -> void
-// `*int` lowers to `i64*`, `int` lowers to `i64`. Atomic ops on
-// non-i64 widths are out of scope for v0. `atomic_fence` is the
-// odd one out — no operands, no SSA temp, just a single
-// `fence seq_cst` line acting as a cross-thread memory barrier.
+// `*int` lowers to `i64*`, `int` lowers to `i64`, `bool` lowers to
+// `i1`. Atomic ops on non-i64 widths are out of scope for v0.
+// `atomic_fence` is the odd one out — no operands, no SSA temp,
+// just a single `fence seq_cst` line acting as a cross-thread
+// memory barrier. `atomic_cas` is the other odd one — `cmpxchg`
+// returns a `{i64, i1}` aggregate, so the lowering emits a follow-up
+// `extractvalue` to expose the success bit (`i1` → Sailfin `bool`)
+// and discards the value slot (the v0 contract is success-bit only;
+// a `Result`-shaped return is post-1.0).
 import { NativeFunction } from "../native_ir";
 // Mutually recursive: lower_atomic_builtin lowers each argument via
 // lower_expression, which itself dispatches calls back through this
@@ -78,8 +84,13 @@ fn lower_atomic_builtin(name: string, arguments: string[], bindings: ParameterBi
     if trimmed == "atomic_sub" {
         return _lower_atomic_rmw("sub", "atomic_sub", arguments, bindings, locals, temp_index, lines, functions, context);
     }
-    // M0-Atomics.3 will fill in `atomic_cas`. Until then, reject the
-    // call with a `[fatal]` diagnostic so the build exits non-zero
+    if trimmed == "atomic_cas" {
+        return _lower_atomic_cas(arguments, bindings, locals, temp_index, lines, functions, context);
+    }
+    // No remaining unimplemented atomic builtins — every reserved
+    // name above is wired through. If a future name is added to
+    // `is_atomic_builtin` without a matching dispatch arm, fall
+    // through to a `[fatal]` diagnostic so the build exits non-zero
     // — matching the issue #306 contract that the emit-level
     // entrypoints (`compile_native_text_to_llvm_file`, `write_llvm_ir`)
     // refuse to write IR when any diagnostic carries `[fatal]`.
@@ -443,6 +454,174 @@ fn _lower_atomic_rmw(op: string, name: string, arguments: string[], bindings: Pa
         lines: current_lines,
         temp_index: current_temp,
         operand: LLVMOperand { llvm_type: "i64", value: result_name },
+        diagnostics: diagnostics,
+        string_constants: collected_strings
+    };
+}
+
+// `atomic_cas(ptr: *int, expected: int, new: int) -> bool` →
+//     %tA = cmpxchg ptr <ptr>, i64 <expected>, i64 <new> seq_cst seq_cst, align 8
+//     %tB = extractvalue { i64, i1 } %tA, 1
+//
+// Returns the **success bit** (i1 → Sailfin `bool`) — `true` if the
+// swap landed, `false` if the location held something other than
+// `expected`. The `i64` slot of the cmpxchg aggregate (the actual
+// value at the location, whether the swap succeeded or not) is
+// intentionally discarded; v0 is success-bit only and a
+// `Result`-shaped return is deferred to post-1.0 (issue #333 notes).
+//
+// Both memory orderings on `cmpxchg` are pinned to `seq_cst`
+// (success and failure). v0 also ships strong cmpxchg only — no
+// `cmpxchg weak` — matching the rest of the M0 atomics surface.
+fn _lower_atomic_cas(arguments: string[], bindings: ParameterBinding[], locals: LocalBinding[], temp_index: number, lines: string[], functions: NativeFunction[], context: TypeContext) -> ExpressionResult ![io] {
+    let mut diagnostics: string[] = [];
+    let mut current_lines = lines;
+    let mut current_temp = temp_index;
+    let mut collected_strings: StringConstant[] = [];
+
+    if arguments.length != 3 {
+        let diag1 = "llvm lowering [fatal] [E0806]: atomic_cas expects exactly 3 arguments (`*int`, `int`, `int`), got "
+            + number_to_string(arguments.length);
+        print.err(diag1);
+        diagnostics.push(diag1);
+        return ExpressionResult {
+            lines: current_lines,
+            temp_index: current_temp,
+            operand: null,
+            diagnostics: diagnostics,
+            string_constants: collected_strings
+        };
+    }
+
+    let ptr_text = trim_text(arguments[0]);
+    let ptr_lowered = lower_expression(ptr_text, bindings, locals, current_temp, current_lines, functions, context, "i64*");
+    diagnostics = extend_string_array(diagnostics, ptr_lowered.diagnostics);
+    collected_strings = merge_string_constants(collected_strings, ptr_lowered.string_constants);
+    current_lines = ptr_lowered.lines;
+    current_temp = ptr_lowered.temp_index;
+
+    if ptr_lowered.operand == null {
+        diagnostics.push("llvm lowering: atomic_cas failed to lower pointer argument");
+        return ExpressionResult {
+            lines: current_lines,
+            temp_index: current_temp,
+            operand: null,
+            diagnostics: diagnostics,
+            string_constants: collected_strings
+        };
+    }
+
+    let ptr_operand = ptr_lowered.operand;
+    let ptr_type = trim_text(ptr_operand.llvm_type);
+    if ptr_type != "i64*" {
+        let diag2 = "llvm lowering [fatal] [E0806]: atomic_cas expects argument 0 of type `*int` (i64*), got `"
+            + ptr_type
+            + "`";
+        print.err(diag2);
+        diagnostics.push(diag2);
+        return ExpressionResult {
+            lines: current_lines,
+            temp_index: current_temp,
+            operand: null,
+            diagnostics: diagnostics,
+            string_constants: collected_strings
+        };
+    }
+
+    let expected_text = trim_text(arguments[1]);
+    let expected_lowered = lower_expression(expected_text, bindings, locals, current_temp, current_lines, functions, context, "i64");
+    diagnostics = extend_string_array(diagnostics, expected_lowered.diagnostics);
+    collected_strings = merge_string_constants(collected_strings, expected_lowered.string_constants);
+    current_lines = expected_lowered.lines;
+    current_temp = expected_lowered.temp_index;
+
+    if expected_lowered.operand == null {
+        diagnostics.push("llvm lowering: atomic_cas failed to lower expected argument");
+        return ExpressionResult {
+            lines: current_lines,
+            temp_index: current_temp,
+            operand: null,
+            diagnostics: diagnostics,
+            string_constants: collected_strings
+        };
+    }
+
+    let expected_operand = expected_lowered.operand;
+    let expected_type = trim_text(expected_operand.llvm_type);
+    if expected_type != "i64" {
+        let diag3 = "llvm lowering [fatal] [E0806]: atomic_cas expects argument 1 of type `int` (i64), got `"
+            + expected_type
+            + "`";
+        print.err(diag3);
+        diagnostics.push(diag3);
+        return ExpressionResult {
+            lines: current_lines,
+            temp_index: current_temp,
+            operand: null,
+            diagnostics: diagnostics,
+            string_constants: collected_strings
+        };
+    }
+
+    let new_text = trim_text(arguments[2]);
+    let new_lowered = lower_expression(new_text, bindings, locals, current_temp, current_lines, functions, context, "i64");
+    diagnostics = extend_string_array(diagnostics, new_lowered.diagnostics);
+    collected_strings = merge_string_constants(collected_strings, new_lowered.string_constants);
+    current_lines = new_lowered.lines;
+    current_temp = new_lowered.temp_index;
+
+    if new_lowered.operand == null {
+        diagnostics.push("llvm lowering: atomic_cas failed to lower new argument");
+        return ExpressionResult {
+            lines: current_lines,
+            temp_index: current_temp,
+            operand: null,
+            diagnostics: diagnostics,
+            string_constants: collected_strings
+        };
+    }
+
+    let new_operand = new_lowered.operand;
+    let new_type = trim_text(new_operand.llvm_type);
+    if new_type != "i64" {
+        let diag4 = "llvm lowering [fatal] [E0806]: atomic_cas expects argument 2 of type `int` (i64), got `"
+            + new_type
+            + "`";
+        print.err(diag4);
+        diagnostics.push(diag4);
+        return ExpressionResult {
+            lines: current_lines,
+            temp_index: current_temp,
+            operand: null,
+            diagnostics: diagnostics,
+            string_constants: collected_strings
+        };
+    }
+
+    // Two SSA temps come out of this lowering: the cmpxchg aggregate
+    // and the extracted i1 success bit. Allocating them via the
+    // existing `format_temp_name` + counter keeps the SSA names
+    // deterministic across runs (the issue calls out determinism in
+    // the "Notes for Claude" section).
+    let cmpxchg_name = format_temp_name(current_temp);
+    current_temp += 1;
+    let success_name = format_temp_name(current_temp);
+    current_temp += 1;
+
+    current_lines.push("  " + cmpxchg_name + " = cmpxchg ptr " + ptr_operand.value
+        + ", i64 "
+        + expected_operand.value
+        + ", i64 "
+        + new_operand.value
+        + " seq_cst seq_cst, align 8");
+    current_lines.push("  " + success_name + " = extractvalue { i64, i1 } "
+        + cmpxchg_name
+        + ", 1");
+
+    return ExpressionResult {
+        lines: current_lines,
+        temp_index: current_temp,
+        operand: LLVMOperand { llvm_type: "i1", value: success_name },
         diagnostics: diagnostics,
         string_constants: collected_strings
     };

--- a/compiler/tests/e2e/fixtures/atomic_cas_basic.sfn
+++ b/compiler/tests/e2e/fixtures/atomic_cas_basic.sfn
@@ -1,0 +1,16 @@
+// Fixture for compiler/tests/e2e/test_atomic_cas_compile.sh.
+// Exercises `atomic_cas` so the emitted LLVM IR contains both a
+// `cmpxchg ptr ..., i64 ..., i64 ... seq_cst seq_cst, align 8` line
+// and the `extractvalue { i64, i1 } %cmpxchg_result, 1` follow-up
+// that unwraps the success bit. Two call sites — one in a return
+// expression, one in an `if` condition — match the verification
+// pattern from issue #333 ("compiles a fixture using atomic_cas in
+// a comparison expression: `if atomic_cas(p, 0, 1) { ... }`").
+fn try_set(flag: * int, expected: int, new: int) -> boolean {
+    return atomic_cas(flag, expected, new);
+}
+
+fn try_acquire(flag: * int) -> int {
+    if atomic_cas(flag, 0, 1) { return 1; }
+    return 0;
+}

--- a/compiler/tests/e2e/test_atomic_cas_compile.sh
+++ b/compiler/tests/e2e/test_atomic_cas_compile.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# End-to-end test for the `atomic_cas` builtin (M0-Atomics.3,
+# issue #333). Drives `sfn emit llvm` against the fixture and
+# asserts the emitted IR contains both the `cmpxchg` aggregate
+# instruction and the `extractvalue { i64, i1 } ..., 1` follow-up
+# that unwraps the success bit. Also pins the E0806 rejection on
+# deliberately broken calls (non-`*int` first arg, non-`int`
+# second/third args) so the diagnostic surface stays user-visible
+# — sibling to the load/store + add/sub rejection coverage in
+# `test_atomic_load_store_compile.sh` /
+# `test_atomic_add_sub_compile.sh`.
+#
+# Usage:
+#   compiler/tests/e2e/test_atomic_cas_compile.sh <compiler-binary>
+
+set -euo pipefail
+
+BINARY="${1:?usage: test_atomic_cas_compile.sh <compiler-binary>}"
+BINARY="$(realpath "$BINARY")"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FIXTURE="$SCRIPT_DIR/fixtures/atomic_cas_basic.sfn"
+
+PASS=0
+FAIL=0
+
+SCRATCH="$(mktemp -d -t sfn-atomic-cas-XXXXXX)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+run_test() {
+    local name="$1"
+    shift
+    if "$@"; then
+        echo "[test] PASS: $name"
+        PASS=$((PASS + 1))
+    else
+        echo "[test] FAIL: $name"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# ---- Happy path: atomic_cas emits the cmpxchg + extractvalue pair ----
+test_cas_emits_expected_ir() {
+    local ll="$SCRATCH/atomic_cas_basic.ll"
+    if ! "$BINARY" emit -o "$ll" llvm "$FIXTURE" > /dev/null 2>&1; then
+        echo "[test]   sfn emit llvm failed for atomic_cas_basic.sfn"
+        return 1
+    fi
+
+    # Acceptance Criteria from issue #333:
+    #   atomic_cas(ptr, expected, new) →
+    #     %tA = cmpxchg ptr <ptr>, i64 <exp>, i64 <new> seq_cst seq_cst, align 8
+    #     %tB = extractvalue { i64, i1 } %tA, 1
+    local missing=0
+    if ! grep -qE "cmpxchg ptr.*i64.*i64.*seq_cst seq_cst" "$ll"; then
+        echo "[test]   missing 'cmpxchg ptr ... i64 ... i64 ... seq_cst seq_cst' in emitted IR"
+        missing=$((missing + 1))
+    fi
+    if ! grep -qE "cmpxchg ptr.*align 8" "$ll"; then
+        echo "[test]   cmpxchg missing 'align 8'"
+        missing=$((missing + 1))
+    fi
+    if ! grep -qE "extractvalue \{ i64, i1 \}.*, 1" "$ll"; then
+        echo "[test]   missing 'extractvalue { i64, i1 } ..., 1' (success-bit unwrap)"
+        missing=$((missing + 1))
+    fi
+    return "$missing"
+}
+
+# ---- Verification regex from the issue counts ≥ 2 ----
+# (one `cmpxchg ... seq_cst seq_cst` + one `extractvalue { i64, i1 }`
+#  for the simple `try_set` callsite; the `try_acquire` callsite
+#  inside the `if` condition pushes the count higher).
+test_verification_regex_counts_at_least_two() {
+    local ll="$SCRATCH/atomic_cas_count.ll"
+    if ! "$BINARY" emit -o "$ll" llvm "$FIXTURE" > /dev/null 2>&1; then
+        echo "[test]   sfn emit llvm failed for verification-regex case"
+        return 1
+    fi
+    local hits
+    hits="$(grep -cE 'cmpxchg ptr.*i64.*seq_cst seq_cst|extractvalue \{ i64, i1 \}' "$ll" || true)"
+    if [ "${hits:-0}" -lt 2 ]; then
+        echo "[test]   verification regex matched only $hits lines (expected ≥ 2)"
+        return 1
+    fi
+    return 0
+}
+
+# ---- E0806: type-error on non-pointer first argument is reported ----
+test_atomic_cas_rejects_non_pointer_arg() {
+    local src="$SCRATCH/bad_cas_ptr.sfn"
+    local ll="$SCRATCH/bad_cas_ptr.ll"
+    cat > "$src" <<'EOF'
+fn bad() -> boolean {
+    return atomic_cas(42, 0, 1);
+}
+EOF
+    # E0806 is emitted as a `[fatal]`-tagged lowering diagnostic and
+    # printed to stderr from `_lower_atomic_cas`. We assert two
+    # signals (mirroring `test_atomic_load_store_compile.sh`):
+    #   1. the E0806 code is present on stderr
+    #   2. the .ll file (if produced) does NOT contain a `cmpxchg`
+    #      line — i.e. the bogus call was rejected before lowering
+    #      would have emitted malformed IR
+    #
+    # We intentionally don't gate on the exit code — see the load/
+    # store + add/sub sibling tests for the full background.
+    local stderr
+    stderr="$("$BINARY" emit -o "$ll" llvm "$src" 2>&1 1>/dev/null || true)"
+    if ! echo "$stderr" | grep -q "E0806"; then
+        echo "[test]   missing E0806 for non-pointer atomic_cas argument"
+        echo "         stderr was: $stderr" | head -5
+        return 1
+    fi
+    if [ -f "$ll" ] && grep -qE "cmpxchg ptr" "$ll"; then
+        echo "[test]   regression: emitted 'cmpxchg ptr' for non-pointer arg"
+        return 1
+    fi
+    return 0
+}
+
+# ---- E0806: type-error on non-int second arg (`expected`) ----
+test_atomic_cas_rejects_non_int_expected() {
+    local src="$SCRATCH/bad_cas_expected.sfn"
+    local ll="$SCRATCH/bad_cas_expected.ll"
+    cat > "$src" <<'EOF'
+fn bad(p: *int) -> boolean {
+    return atomic_cas(p, "hello", 1);
+}
+EOF
+    local stderr
+    stderr="$("$BINARY" emit -o "$ll" llvm "$src" 2>&1 1>/dev/null || true)"
+    if ! echo "$stderr" | grep -q "E0806"; then
+        echo "[test]   missing E0806 for non-int atomic_cas expected arg"
+        echo "         stderr was: $stderr" | head -5
+        return 1
+    fi
+    if [ -f "$ll" ] && grep -qE "cmpxchg ptr" "$ll"; then
+        echo "[test]   regression: emitted 'cmpxchg ptr' for non-int expected arg"
+        return 1
+    fi
+    return 0
+}
+
+# ---- E0806: type-error on non-int third arg (`new`) ----
+test_atomic_cas_rejects_non_int_new() {
+    local src="$SCRATCH/bad_cas_new.sfn"
+    local ll="$SCRATCH/bad_cas_new.ll"
+    cat > "$src" <<'EOF'
+fn bad(p: *int) -> boolean {
+    return atomic_cas(p, 0, "hello");
+}
+EOF
+    local stderr
+    stderr="$("$BINARY" emit -o "$ll" llvm "$src" 2>&1 1>/dev/null || true)"
+    if ! echo "$stderr" | grep -q "E0806"; then
+        echo "[test]   missing E0806 for non-int atomic_cas new arg"
+        echo "         stderr was: $stderr" | head -5
+        return 1
+    fi
+    if [ -f "$ll" ] && grep -qE "cmpxchg ptr" "$ll"; then
+        echo "[test]   regression: emitted 'cmpxchg ptr' for non-int new arg"
+        return 1
+    fi
+    return 0
+}
+
+run_test "atomic_cas emits cmpxchg + extractvalue with seq_cst seq_cst, align 8" \
+    test_cas_emits_expected_ir
+run_test "issue verification regex matches ≥ 2 cmpxchg/extractvalue lines" \
+    test_verification_regex_counts_at_least_two
+run_test "atomic_cas with non-pointer first argument reports E0806" \
+    test_atomic_cas_rejects_non_pointer_arg
+run_test "atomic_cas with non-int expected (arg 1) reports E0806" \
+    test_atomic_cas_rejects_non_int_expected
+run_test "atomic_cas with non-int new (arg 2) reports E0806" \
+    test_atomic_cas_rejects_non_int_new
+
+echo "[summary] $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi

--- a/compiler/tests/unit/atomic_cas_test.sfn
+++ b/compiler/tests/unit/atomic_cas_test.sfn
@@ -1,0 +1,39 @@
+// Unit tests for the `atomic_cas` builtin (M0-Atomics.3, issue
+// #333). The same CI-budget constraint that
+// `atomic_load_store_test.sfn` and `atomic_add_sub_test.sfn` document
+// applies here verbatim — importing `lower_atomic_builtin` pulls in
+// `lower_expression` and the rest of `compiler/src/llvm/expression_lowering/native/core`,
+// which blows the per-test 180s GitHub Actions budget. So this file
+// pins the predicate surface that gates whether the LLVM lowering
+// for `atomic_cas` runs at all, and the actual IR shape (the
+// `cmpxchg ptr ..., i64 ..., i64 ... seq_cst seq_cst, align 8` line
+// followed by the `extractvalue { i64, i1 } %cmpxchg_result, 1`
+// line) gets pinned end-to-end in
+// `compiler/tests/e2e/test_atomic_cas_compile.sh`. The type-error
+// rejections on the second and third arguments are pinned in that
+// same e2e file via `[fatal] [E0806]` stderr probes.
+import { is_atomic_builtin } from "../../src/llvm/atomics";
+
+// ── Predicate recognises atomic_cas ──
+test "atomics: is_atomic_builtin recognises atomic_cas" {
+    assert is_atomic_builtin("atomic_cas");
+}
+
+// Whitespace tolerance: `lower_atomic_builtin` calls `trim_text`
+// before dispatching, so the predicate must accept the same surface
+// that the dispatch hook sees in practice.
+test "atomics: is_atomic_builtin recognises atomic_cas after trim" {
+    assert is_atomic_builtin(" atomic_cas ");
+}
+
+// Defence against a future regression that loosens the predicate
+// to a startsWith / endsWith match — only the exact six reserved
+// names should fire the dispatch hook, even for plausible
+// near-misses around the `atomic_cas` name.
+test "atomics: is_atomic_builtin rejects partial atomic_cas names" {
+    assert ! is_atomic_builtin("cas");
+    assert ! is_atomic_builtin("atomic_ca");
+    assert ! is_atomic_builtin("atomic_casx");
+    assert ! is_atomic_builtin("atomic_compare_and_swap");
+    assert ! is_atomic_builtin("cmpxchg");
+}


### PR DESCRIPTION
## Summary

- Adds `atomic_cas(ptr: *int, expected: int, new: int) -> bool` to `compiler/src/llvm/atomics.sfn`, lowering to:
  ```llvm
  %tA = cmpxchg ptr <p>, i64 <expected>, i64 <new> seq_cst seq_cst, align 8
  %tB = extractvalue { i64, i1 } %tA, 1
  ```
- Returns the success bit only (i1 → Sailfin `boolean`); the cmpxchg aggregate's `i64` value slot is discarded. v0 ships strong cmpxchg with `seq_cst` for both success and failure orderings — weak cmpxchg, failure-ordering relaxation, and a `Result`-shaped return are post-1.0 per the issue notes.
- Reuses the dispatch hook + `E0806` diagnostic surface from M0-Atomics.1 (#331). Three argument slots (`*int`, `int`, `int`) each get a typed-result + `[fatal] [E0806]` rejection path. SSA temp names use the existing counter so the cmpxchg + extractvalue pair stays deterministic.

## Implementation notes

- New helper `_lower_atomic_cas` mirrors the structure of `_lower_atomic_rmw` (M0-Atomics.2): pull each arg through `lower_expression`, type-check it, then emit. Two SSA temps come out of the lowering — one for the cmpxchg aggregate, one for the extracted i1 success bit.
- Module-level header + `is_atomic_builtin` dispatch comment updated; the previous "M0-Atomics.3 will fill in atomic_cas" sentinel arm is replaced with a generic "if a future name lacks a dispatch arm, fall through to a `[fatal]` diagnostic" guard.

## Test plan

- [x] Unit: `compiler/tests/unit/atomic_cas_test.sfn` — 3 cases pinning the `is_atomic_builtin("atomic_cas")` predicate surface (recognise, whitespace tolerance, near-miss rejection). The IR shape can't be pinned from a unit test because importing `lower_atomic_builtin` pulls in the full LLVM-lowering stack and blows the per-test 180s CI budget — same constraint documented in `atomic_load_store_test.sfn` / `atomic_add_sub_test.sfn`. The IR shape gets pinned end-to-end in the e2e harness instead.
- [x] E2E: `compiler/tests/e2e/test_atomic_cas_compile.sh` + `fixtures/atomic_cas_basic.sfn` — drives `sfn emit llvm` against a fixture that calls `atomic_cas` both from a return and from an `if` condition, asserts both the `cmpxchg ptr ... i64 ... i64 ... seq_cst seq_cst, align 8` line and the `extractvalue { i64, i1 } ..., 1` line, and pins `E0806` rejection on each of the three argument slots (5 cases total).
- [x] `make test-unit` (84/84 passed)
- [x] `make test-e2e` (43/43 passed)
- [x] Smoke from issue verification block: `grep -cE 'cmpxchg ptr.*i64.*seq_cst seq_cst|extractvalue \{ i64, i1 \}'` against the fixture's emitted IR returns `4` (≥ 2).
- [ ] `make check` (running locally — will follow up if it fails)

Closes #333

---
_Generated by [Claude Code](https://claude.ai/code/session_01LeHf3vsF7tCXFhEQJwuXpE)_