### PR TITLE
feat(commands): add /sweep for post-merge issue coordination

### DIFF
--- a/.claude/commands/sweep.md
+++ b/.claude/commands/sweep.md
@@ -1,0 +1,206 @@
+# Sweep Blocker State and Coordinate Next Picks
+
+Post-merge issue-tracker reconciliation. Sweep newly-resolved blockers, audit `claude-ready` hygiene, and recommend the next 1-3 issues to dispatch via `/pickup` based on a configurable concurrency budget and file-collision analysis.
+
+This is the focused, event-driven sibling of `/triage`. Run it after every PR merge while you're coordinating multiple `/pickup` sessions.
+
+## Target: $ARGUMENTS
+
+Parse `$ARGUMENTS` as a mix of flags and numbers:
+
+**Flags** (tokens starting with `--`):
+- `--greedy` (bare) — raise the concurrency budget from `2` to `4`
+- `--greedy=N` — set the concurrency budget to `N` (no upper bound)
+- `--dry-run` — preview label flips and recommendations; do not modify any issue or post comments
+
+**Bare numbers** — treat each as a PR or issue number that just merged or closed; the command resolves PR → linked issue(s) automatically.
+
+Examples:
+- `/sweep` — auto-detect closed issues/PRs in the last 24h, default budget = 2
+- `/sweep 367` — anchor on PR/issue #367, default budget = 2
+- `/sweep --greedy 367 332` — anchor on two merges, budget = 4
+- `/sweep --greedy=6 --dry-run` — preview-only, budget = 6, auto-detect merges
+
+If parsing yields no flags and no numbers: budget = 2, auto-detect merges, real (non-dry) run.
+
+---
+
+## Phase 1: GATHER
+
+Resolve the merge anchor set.
+
+If `$ARGUMENTS` includes bare numbers, use them directly:
+
+```bash
+for N in <numbers>; do
+  gh issue view $N --json number,title,state,closingIssuesReferences,closedAt 2>/dev/null \
+    || gh pr view $N --json number,title,state,closingIssuesReferences,mergedAt
+done
+```
+
+Otherwise, auto-detect merges in the last 24h:
+
+```bash
+gh pr list --state merged --limit 20 \
+  --json number,title,closingIssuesReferences,mergedAt \
+  | jq '[.[] | select(.mergedAt > (now - 86400 | todate))]'
+```
+
+For each anchor PR, extract the closed issue numbers from `closingIssuesReferences` — these are the `Closes #N` references. The set of newly-closed issues is the trigger for unblocking dependents.
+
+Pull the candidate pools:
+
+```bash
+gh issue list --label blocked --state open \
+  --json number,title,labels,body,assignees --limit 100
+
+gh issue list --label claude-ready --state open \
+  --json number,title,labels,body,assignees --limit 100
+
+gh pr list --label agent-authored --state open \
+  --json number,title,headRefName,files --limit 20
+```
+
+If `agent-authored` returns zero PRs, also check for any open PR on a `claude/*` branch (the human-driven `/pickup` flow). Those count toward the budget the same way.
+
+---
+
+## Phase 2: SWEEP BLOCKERS
+
+For each issue in the `blocked` pool:
+
+1. Parse the `## Blocked by` section of the body. Extract every `#N` reference via regex (`#\d+`).
+2. For each `#N`, check its state: `gh issue view N --json state,stateReason` (works for both issues and PRs).
+3. Classify each blocker:
+   - **Hard reference (#N)** — closed = resolved; open = still blocking
+   - **Prose reference** (e.g., "Slice E", "M3 — runtime/native/ deletion") — always ambiguous; never auto-flip on prose alone
+4. If all hard references are closed AND no prose references remain unresolved:
+   ```bash
+   gh issue edit <N> --remove-label blocked --add-label claude-ready
+   gh issue comment <N> --body "Auto-sweep: blocker(s) resolved — <list resolved #N references>. Marking ready for pickup."
+   ```
+5. If `--dry-run` is set: do not edit or comment. Record the intended flip in the report.
+
+---
+
+## Phase 3: AUDIT CLAUDE-READY
+
+For each issue in the `claude-ready` pool:
+
+1. Parse `## Files Affected` from the body. Extract path-shaped tokens.
+2. For each path not marked "New:", verify it exists in the working tree:
+   ```bash
+   test -f <path> || flag "missing-file"
+   ```
+3. Sanity-check for "appears already shipped" signals (heuristic only):
+   - If the issue's goal mentions a symbol/function to delete or remove, `grep` to confirm it still exists.
+   - If the issue describes adding a file/feature, `grep` for evidence the work shipped under a different name.
+4. Never modify labels or body in this phase — `claude-ready` hygiene is `/triage`'s job. Only report findings here.
+
+---
+
+## Phase 4: BUDGET
+
+Compute concurrency:
+
+```
+budget     = 4 if --greedy bare
+           = N if --greedy=N
+           = 2 otherwise
+
+in_flight  = count of open agent-authored PRs + open claude/* branch PRs
+free_slots = max(0, budget - in_flight)
+```
+
+Cache the union of files touched across all in-flight PRs as `IN_FLIGHT_FILES` for collision analysis:
+
+```bash
+gh pr view <N> --json files | jq -r '.files[].path'
+```
+
+---
+
+## Phase 5: COLLISION ANALYSIS
+
+For each pickable `claude-ready` issue (exclude any with `in-progress` or assignees):
+
+1. Parse `## Files Affected` from the body.
+2. **Hard collision** — issue's files intersect `IN_FLIGHT_FILES`. Exclude from "dispatch now" recommendations; surface as "after #X merges".
+3. **Peer collision** — issue's files intersect another candidate's files. Note as "sequence after peer" rather than parallel.
+4. Score the remaining candidates:
+
+   | Signal | Weight |
+   |---|---|
+   | `priority:critical` label | +100 |
+   | `priority:high` label | +50 |
+   | Closes an epic on merge | +30 |
+   | Unblocks ≥2 downstream issues | +20 per |
+   | `size:xs` | +10 |
+   | `size:s` | +5 |
+   | `size:m` | 0 |
+   | Track diversity (different epic/area than already in-flight) | +15 |
+
+5. Pick the top `free_slots` candidates that have no hard collision with each other.
+
+---
+
+## Phase 6: REPORT
+
+Produce a concise report:
+
+```
+Sweep Report — <date>
+Budget: <N>  |  In-flight: <N>  |  Free slots: <N>
+
+Anchor merges:
+  ✓ PR #<N> — <title>   (closed #<M>, #<K>)
+  ✓ PR #<N> — <title>   (closed #<M>)
+
+Unblocked (label flipped):
+  ✓ #<N> — <title>      (blockers resolved: #<X>, #<Y>)
+
+Still blocked:
+  ⏸ #<N> — <title>      (waiting on: #<X> open, "Slice E" ambiguous)
+
+Audit findings (claude-ready hygiene):
+  ⚠ #<N> — <title>      (missing file: <path>)
+  ⚠ #<N> — <title>      (symbol "<name>" appears removed — verify scope)
+
+Top picks for free slots:
+  1. #<N> — <title> (size, type) — <one-line rationale>
+  2. #<N> — <title> (size, type) — <one-line rationale>
+
+Suggested sequence:
+  Now (parallel):  #<N>  ‖  #<M>
+  After #<X>:      #<Y>  (rebases onto <file>)
+  After all:       #<Z>  (closes epic #<E>)
+
+Concerns / human input needed:
+  ? <ambiguous prose blocker>
+  ? <conflicting signal>
+
+Dry run: changes <previewed | applied>
+```
+
+---
+
+## Constraints
+
+- **Don't dispatch work.** This command is a coordination layer. Dispatch happens via `/pickup` in separate sessions.
+- **Don't close issues.** Same convention as `/triage`. Closing is a human decision.
+- **Don't modify issue bodies.** Only labels and comments.
+- **Be conservative with prose blockers.** Anything not a hard `#N` reference stays blocked until a human confirms.
+- **Always leave a comment when flipping a label.** Future-you needs the audit trail.
+- **In `--dry-run` mode, make zero writes.** No labels, no comments. Print intended actions only.
+- **Read `.github/AGENTS.md` for cap context.** Default budget = 2 matches the autonomous-pipeline cap; `--greedy` raises it for human-coordinated parallel sessions.
+
+---
+
+## Why this command exists
+
+After every PR merge, the next coordination move is mechanical:
+1. Some `blocked` issue's `#N` reference just resolved — flip it.
+2. Some in-flight files just freed — recompute collision-safe candidates.
+3. Some epic just gained a closer — surface that for the next `/pickup`.
+
+`/triage` audits the whole queue and is too broad for this. `/pickup` claims a single issue and is too narrow. `/sweep` is the bridge: invoked after every merge, it produces the to-do list for the next `/pickup` calls in your other sessions.

--- a/.claude/commands/sweep.md
+++ b/.claude/commands/sweep.md
@@ -16,7 +16,7 @@ Parse `$ARGUMENTS` as a mix of flags and numbers:
 **Bare numbers** — treat each as a PR or issue number that just merged or closed; the command resolves PR → linked issue(s) automatically.
 
 Examples:
-- `/sweep` — auto-detect closed issues/PRs in the last 24h, default budget = 2
+- `/sweep` — auto-detect merged PRs in the last 24h (and their linked issues), default budget = 2
 - `/sweep 367` — anchor on PR/issue #367, default budget = 2
 - `/sweep --greedy 367 332` — anchor on two merges, budget = 4
 - `/sweep --greedy=6 --dry-run` — preview-only, budget = 6, auto-detect merges
@@ -29,14 +29,22 @@ If parsing yields no flags and no numbers: budget = 2, auto-detect merges, real 
 
 Resolve the merge anchor set.
 
-If `$ARGUMENTS` includes bare numbers, use them directly:
+If `$ARGUMENTS` includes bare numbers, use them directly. Try `gh pr view` first
+because `closingIssuesReferences` and `mergedAt` are PR-only fields, and
+`gh issue view <N>` resolves PRs as issues (they share a number space) — so
+querying `gh issue view` first would silently skip the PR-specific data.
 
 ```bash
 for N in <numbers>; do
-  gh issue view $N --json number,title,state,closingIssuesReferences,closedAt 2>/dev/null \
-    || gh pr view $N --json number,title,state,closingIssuesReferences,mergedAt
+  # PR-first: PRs carry mergedAt + closingIssuesReferences.
+  gh pr view $N --json number,title,state,closingIssuesReferences,mergedAt 2>/dev/null \
+    || gh issue view $N --json number,title,state,closedAt
 done
 ```
+
+For raw issue anchors (closed manually, no PR), there's no
+`closingIssuesReferences` to expand — treat the issue itself as the
+closed trigger.
 
 Otherwise, auto-detect merges in the last 24h:
 
@@ -57,11 +65,21 @@ gh issue list --label blocked --state open \
 gh issue list --label claude-ready --state open \
   --json number,title,labels,body,assignees --limit 100
 
+# gh pr list does not support --json files; just list PRs here. Phase 4
+# fetches file lists per PR via gh pr view.
 gh pr list --label agent-authored --state open \
-  --json number,title,headRefName,files --limit 20
+  --json number,title,headRefName --limit 20
 ```
 
-If `agent-authored` returns zero PRs, also check for any open PR on a `claude/*` branch (the human-driven `/pickup` flow). Those count toward the budget the same way.
+Always include open PRs on a `claude/*` branch (the human-driven `/pickup` flow) in the in-flight set — they count toward the budget the same way as `agent-authored` PRs, and both categories can be live simultaneously:
+
+```bash
+gh pr list --state open \
+  --json number,title,headRefName \
+  --jq '[.[] | select(.headRefName | startswith("claude/"))]'
+```
+
+The in-flight set is the union of the two queries (de-duped by PR number).
 
 ---
 


### PR DESCRIPTION
## Summary

Adds `/sweep` — a focused, event-driven coordination command that sits between `/triage` (broad audit) and `/pickup` (single-issue dispatch). Run after every PR merge to keep the issue queue accurate without manual blocker hunting.

The command codifies the post-merge flow we've been doing manually:
1. Some `blocked` issue's `#N` reference just resolved — flip it to `claude-ready`.
2. Some in-flight files just freed up — recompute collision-safe candidates.
3. Some epic just gained a closer — surface that for the next `/pickup`.

## Phases

- **GATHER** — resolve anchor merges (args or 24h auto-detect); pull blocked / claude-ready / in-flight pools
- **SWEEP BLOCKERS** — parse `## Blocked by`, flip when all `#N` blockers closed, conservative on prose
- **AUDIT CLAUDE-READY** — verify `Files Affected` paths still exist; flag stale issues (report-only, no label changes)
- **BUDGET** — compute free slots, cache `IN_FLIGHT_FILES`
- **COLLISION ANALYSIS** — score candidates, exclude hard collisions, sequence peer collisions
- **REPORT** — anchor merges + unblocked + still-blocked + audit findings + top picks + sequence + concerns

## Flags

- `--greedy` (bare) → budget = 4
- `--greedy=N` → budget = N (no upper bound) — for human-coordinated parallel `/pickup` sessions
- `--dry-run` → preview only, zero writes

Default budget = 2 matches the autonomous engineer cap from `.github/AGENTS.md`.

## Constraints baked in

- No auto-close, no body edits, no silent label flips
- Audit-trail comment on every flip
- Prose blockers (e.g. "Slice E") stay blocked until a human confirms
- Defers dispatch to `/pickup` — `/sweep` only produces the to-do list

## Test plan

- [ ] Invoke `/sweep` with no args after the next PR merge — confirm it auto-detects via 24h window
- [ ] Invoke `/sweep <pr-number>` after a known merge — confirm anchor parsing
- [ ] Invoke `/sweep --dry-run` — confirm zero writes (no label or comment changes on any issue)
- [ ] Invoke `/sweep --greedy=4` while ≥2 PRs are in flight — confirm budget arithmetic
- [ ] Confirm prose-only blockers (e.g. "Slice E") stay blocked when all `#N` references close

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012xB3214bRzb4SvtziXKLwF)_