### PR TITLE
feat(test): structured assertion-failure record (P2, #364)

### DIFF
--- a/compiler/src/cli_commands.sfn
+++ b/compiler/src/cli_commands.sfn
@@ -48,6 +48,7 @@ import {
     number_to_string
 } from "./main";
 import { LayoutManifest } from "./native_ir";
+import { split_lines } from "./native_ir_utils_text";
 import { substring } from "./string_utils";
 import { enter_test_runner_mode, exit_test_runner_mode } from "./test_runner_state";
 import {
@@ -256,6 +257,130 @@ fn _clean_lowering_state(dir: string) -> number ![io] {
         fs.deleteFile(full);
     }
     return 0;
+}
+
+// Issue #364: typed assertion-failure record. Replaces the
+// stdout-grep heuristic in scripts/run_native_test.sh.
+//
+// `sailfin_assert_fail` (runtime/native/src/sailfin_runtime.c)
+// writes a newline-delimited key:value record (magic "SFAF",
+// version, file, line, col, msg) to ${SAILFIN_TEST_SCRATCH}/fail.bin
+// when an `assert e;` failure fires inside a test process. The
+// runner reads the file after the child exits, parses it into
+// AssertFailure, and surfaces typed file:line:col attribution to
+// the caller — no regex, no false positives from the literal word
+// "panic" landing in test stdout.
+//
+// `present` is the source-of-truth gate: a missing or unparseable
+// file leaves it false and the runner falls back to the previous
+// "exit code != 0 means failed" path. The struct is intentionally
+// shared with P3 / 1.1 / 1.5 (per issue #364's notes); keep its
+// shape stable.
+struct AssertFailure {
+    present: boolean;
+    file: string;
+    line: number;
+    col: number;
+    message: string;
+}
+
+fn _empty_assert_failure() -> AssertFailure {
+    return AssertFailure {
+        present: false,
+        file: "",
+        line: 0,
+        col: 0,
+        message: ""
+    };
+}
+
+// Decimal parser used only for the `line:` / `col:` fields of the
+// assert-fail record. Defensive: any non-digit char (including a
+// stray '\r' from a CRLF round-trip on Windows) falls back to 0
+// rather than aborting the runner.
+fn _af_parse_decimal(text: string) -> number {
+    if text.length == 0 { return 0; }
+    let mut value: number = 0;
+    let mut index: number = 0;
+    let mut negative: boolean = false;
+    if text[0] == "-" {
+        negative = true;
+        index = 1;
+    }
+    loop {
+        if index >= text.length { break; }
+        let ch = text[index];
+        if ch == "0" { value = value * 10; } else if ch == "1" {
+            value = value * 10 + 1;
+        } else if ch == "2" { value = value * 10 + 2; } else if ch == "3" {
+            value = value * 10 + 3;
+        } else if ch == "4" { value = value * 10 + 4; } else if ch == "5" {
+            value = value * 10 + 5;
+        } else if ch == "6" { value = value * 10 + 6; } else if ch == "7" {
+            value = value * 10 + 7;
+        } else if ch == "8" { value = value * 10 + 8; } else if ch == "9" {
+            value = value * 10 + 9;
+        } else { break; }
+        index += 1;
+    }
+    if negative { value = 0 - value; }
+    return value;
+}
+
+// Strip a leading "key:" from `line` and return the value, or "" if
+// the prefix doesn't match. Avoids importing `starts_with` here.
+fn _af_strip_prefix(line: string, prefix: string) -> string {
+    if line.length < prefix.length { return ""; }
+    let head = substring(line, 0, prefix.length);
+    if !strings_equal(head, prefix) { return ""; }
+    return substring(line, prefix.length, line.length);
+}
+
+// Parse the contents of fail.bin into an AssertFailure. Returns an
+// `_empty_assert_failure()` (present=false) when the bytes don't
+// match the SFAF v:1 shape — that case is treated by the caller as
+// "no structured failure info" and the runner falls back to
+// exit-code-only reporting.
+fn _parse_assert_failure_record(bytes: string) -> AssertFailure {
+    let mut out = _empty_assert_failure();
+    if bytes.length < 5 { return out; }
+    let lines = split_lines(bytes);
+    if lines.length < 6 { return out; }
+    if !strings_equal(lines[0], "SFAF") { return out; }
+    if !strings_equal(lines[1], "v:1") { return out; }
+    out.file = _af_strip_prefix(lines[2], "file:");
+    let line_text = _af_strip_prefix(lines[3], "line:");
+    let col_text = _af_strip_prefix(lines[4], "col:");
+    out.line = _af_parse_decimal(line_text);
+    out.col = _af_parse_decimal(col_text);
+    out.message = _af_strip_prefix(lines[5], "msg:");
+    out.present = true;
+    return out;
+}
+
+// Read + clear the per-test fail.bin record. Always called after
+// `process.run` returns; deletes the file so the next iteration
+// starts from a clean slate (multiple tests share one scratch_root
+// across the loop). Returns an empty failure when the file is
+// missing — the common pass case.
+fn _consume_assert_failure_record(scratch_root: string) -> AssertFailure ![io] {
+    let path = scratch_root + "/fail.bin";
+    if !fs.exists(path) { return _empty_assert_failure(); }
+    let bytes = fs.readFile(path);
+    fs.deleteFile(path);
+    return _parse_assert_failure_record(bytes);
+}
+
+// Format an AssertFailure for human-readable test runner output.
+// Matches the shape `path:line:col: message` so editors / CI
+// log-renderers can hyperlink the location.
+fn _format_assert_failure(test_path: string, failure: AssertFailure) -> string {
+    let mut location = test_path;
+    if failure.file.length > 0 { location = failure.file; }
+    return location + ":" + number_to_string(failure.line) + ":"
+        + number_to_string(failure.col)
+        + ": "
+        + failure.message;
 }
 
 // One distinct `(project_root, workspace_root)` resolution group for
@@ -486,14 +611,29 @@ fn handle_test_command(args: string[], runtime_root: string) -> number ![io] {
             exit_test_runner_mode();
             return link_rc;
         }
+        // Issue #364: clear any leftover assert-fail record from the
+        // previous iteration before spawning. The record is keyed
+        // off SAILFIN_TEST_SCRATCH on the C-runtime side, so we
+        // wire scratch_root through `env` rather than `process.run`
+        // directly — this works whether or not the parent shell
+        // (e.g. run_native_test.sh) already exported the env var.
+        let fail_record_path = scratch_root + "/fail.bin";
+        if fs.exists(fail_record_path) { fs.deleteFile(fail_record_path); }
+
         if trace_runner { print.err("test runner: exec start"); }
-        let run_rc = process.run([exe_path]);
+        let run_rc = process.run(["env", "SAILFIN_TEST_SCRATCH=" + scratch_root, exe_path]);
         if trace_runner {
             print.err("test runner: exec done (exit=" + number_to_string(run_rc)
                 + ")");
         }
+        // Always consume the record (deletes fail.bin if present)
+        // so a stale record from a previous iteration can't leak
+        // into the next pass. `present=false` is the pass case.
+        let failure = _consume_assert_failure_record(scratch_root);
         if run_rc != 0 {
-            print("test failed: " + path);
+            if failure.present {
+                print("test failed: " + _format_assert_failure(path, failure));
+            } else { print("test failed: " + path); }
             exit_test_runner_mode();
             return run_rc;
         }

--- a/compiler/src/llvm/lowering/lowering_helpers.sfn
+++ b/compiler/src/llvm/lowering/lowering_helpers.sfn
@@ -704,6 +704,7 @@ fn seed_default_runtime_helpers(initial: string[]) -> string[] {
     helpers = append_unique_effect(helpers, "strings_equal");
     helpers = append_unique_effect(helpers, "char_code");
     helpers = append_unique_effect(helpers, "runtime_raise_value_error_fn");
+    helpers = append_unique_effect(helpers, "runtime_assert_fail_fn");
     helpers = append_unique_effect(helpers, "runtime.bounds_check");
     // Phase 5a: arena mark/rewind for in-process multi-module tools.
     // No-op when SAILFIN_USE_ARENA is unset; declared unconditionally

--- a/compiler/src/llvm/runtime_helpers.sfn
+++ b/compiler/src/llvm/runtime_helpers.sfn
@@ -162,6 +162,16 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
         target: "runtime_raise_value_error_fn", symbol: "sailfin_runtime_raise_value_error", return_type: "void", parameter_types: ["i8*"], effects: []
     });
+    // Issue #364: structured assertion failure record. The desugared
+    // `assert e;` lowering routes through this trampoline so the test
+    // runner can read a typed `(file, line, col, message)` record
+    // instead of grep'ping stdout for "fail|panic|error" matches.
+    // The trampoline takes Sailfin `number` (i.e. LLVM `double`) for
+    // line/col; it clamps + forwards to `sailfin_assert_fail` whose
+    // ABI matches the spec's `(*const u8, i64, i64, *const u8)`.
+    descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
+        target: "runtime_assert_fail_fn", symbol: "runtime_assert_fail_fn", return_type: "void", parameter_types: ["i8*", "double", "double", "i8*"], effects: []
+    });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
         target: "runtime_is_string_fn", symbol: "sailfin_runtime_is_string", return_type: "i1", parameter_types: ["i8*"], effects: []
     });

--- a/compiler/src/parser/statements.sfn
+++ b/compiler/src/parser/statements.sfn
@@ -1196,6 +1196,33 @@ fn parse_try_statement(parser: Parser) -> BlockStatementParseResult {
     };
 }
 
+// Integer-to-string for non-negative values, used to embed line/col
+// in the desugared assert call site. Local copy to avoid widening
+// the parser's import surface; the value is always a token's
+// `line` / `column` (small positive number). Sailfin's `/`
+// operator is float division so we extract digits via repeated
+// subtraction — same shape as `compiler/src/main.sfn:number_to_string`.
+fn _assert_int_to_string(value: number) -> string {
+    if value <= 0 { return "0"; }
+    let digits = "0123456789";
+    let mut remaining: number = value;
+    let mut output: string = "";
+    loop {
+        if remaining <= 0 { break; }
+        let mut temp: number = remaining;
+        let mut quotient: number = 0;
+        loop {
+            if temp < 10 { break; }
+            temp -= 10;
+            quotient += 1;
+        }
+        let ch = substring(digits, temp, temp + 1);
+        output = ch + output;
+        remaining = quotient;
+    }
+    return output;
+}
+
 fn parse_assert_statement(parser: Parser) -> BlockStatementParseResult {
     let original = parser;
     let mut current = skip_trivia(parser);
@@ -1206,6 +1233,15 @@ fn parse_assert_statement(parser: Parser) -> BlockStatementParseResult {
             success: false
         };
     }
+
+    // Stash the assert keyword's source location so the desugared
+    // failure call can carry it as i64-shaped (lowered to LLVM
+    // `double`) line/col arguments. The test runner reads the
+    // typed record `sailfin_assert_fail` writes and surfaces the
+    // file:line:col attribution without any stdout grep.
+    let assert_token = parser_peek_raw(current);
+    let assert_line = assert_token.line;
+    let assert_col = assert_token.column;
 
     let mut statement_tokens: Token[] = [];
     statement_tokens = append_token(statement_tokens, parser_peek_raw(current));
@@ -1243,12 +1279,22 @@ fn parse_assert_statement(parser: Parser) -> BlockStatementParseResult {
 
     let condition = expression_from_tokens(trimmed);
 
+    // Issue #364: route through the structured-failure helper so the
+    // test runner can read a typed AssertFailure record instead of
+    // grep'ping stdout. The runtime function clamps double→i64,
+    // writes a record to fd 3 / `${SAILFIN_TEST_SCRATCH}/fail.bin`,
+    // then takes the same abort path as the legacy raise helper —
+    // so non-test callers see no behavior change.
     let fail_call = Expression.Call {
         callee: Expression.Identifier {
-            name: "runtime_raise_value_error_fn",
+            name: "runtime_assert_fail_fn",
             span: null
         },
-        arguments: [Expression.StringLiteral { value: "assertion failed" }],
+        arguments: [Expression.StringLiteral { value: "" }, Expression.NumberLiteral {
+            value: _assert_int_to_string(assert_line)
+        }, Expression.NumberLiteral {
+            value: _assert_int_to_string(assert_col)
+        }, Expression.StringLiteral { value: "assertion failed" }],
         span: null
     };
     let fail_statement = Statement.ExpressionStatement {

--- a/compiler/tests/integration/assert_fail_record_test.sfn
+++ b/compiler/tests/integration/assert_fail_record_test.sfn
@@ -1,0 +1,40 @@
+// Issue #364: structured assertion-failure record round-trip.
+//
+// This test does NOT trigger an assertion failure itself — that
+// would crash the test process and short-circuit subsequent
+// assertions. It exists for two reasons:
+//
+//   1. Regression guard against the old grep heuristic in
+//      `scripts/run_native_test.sh` (lines 178-196 pre-#364): a
+//      test whose pass output contains the literal word "panic"
+//      must not be flagged as failing. The bash heuristic matched
+//      `(fail|error|panic|abort)` against stdout and would have
+//      tripped on this file's output below.
+//
+//   2. Smoke-test that the new lowering still type-checks and
+//      executes for an `assert true;` no-op call. The structured
+//      record path (sailfin_assert_fail) only fires when the
+//      condition is false; the typed sink (fd 3 / fail.bin) stays
+//      empty for passing asserts, which is exactly what the test
+//      runner's _consume_assert_failure_record relies on for the
+//      pass case.
+//
+// The negative path (a deliberately-failing test that *does*
+// produce a fail.bin record) is exercised by the smoke command
+// documented in the issue's verification block; running it here
+// would make this whole file fail and defeat the regression
+// guard.
+test "assert_fail_record: pass output containing the word panic is not flagged" {
+    let diagnostic_text = "panic: divide by zero (this is just a string, not a real panic)";
+    print(diagnostic_text);
+    print("error: another false-positive trigger word");
+    print("aborted: yet another");
+    print("operation failed: and one more");
+    assert diagnostic_text.length > 0;
+}
+
+test "assert_fail_record: passing asserts leave no record behind" {
+    assert 1 + 1 == 2;
+    assert "ok" == "ok";
+    assert true;
+}

--- a/runtime/native/include/sailfin_runtime.h
+++ b/runtime/native/include/sailfin_runtime.h
@@ -260,6 +260,28 @@ extern "C"
     void *sailfin_runtime_to_debug_string(void *value);
     void sailfin_runtime_raise_value_error(void *message);
 
+    /* Structured assertion failure hook.
+     *
+     * Replaces the stdout-grep heuristic in scripts/run_native_test.sh:
+     * a failing `assert` lowers to a call into this helper, which
+     * writes a typed record describing (file, line, col, message)
+     * before the process aborts. The test runner consumes the
+     * record after the test exits and surfaces a typed
+     * AssertFailure to the caller — no regex matching.
+     *
+     * Sink resolution (first match wins):
+     *   1. `SAILFIN_TEST_FAIL_FD` env var set to an open writable fd.
+     *   2. `${SAILFIN_TEST_SCRATCH}/fail.bin` (append).
+     *   3. No sink → write nothing. Non-test callers see the same
+     *      abort path as `sailfin_runtime_raise_value_error`.
+     *
+     * Wire format: newline-delimited key:value text, NUL-free so the
+     * record survives Sailfin's NUL-terminated string read path.
+     * Documented next to the helper implementation in
+     * sailfin_runtime.c.
+     */
+    void sailfin_assert_fail(const char *file, int64_t line, int64_t col, const char *msg);
+
     // ---- Exceptions (native runtime minimal) ----
 
     // Exception state helpers (used by native lowering).

--- a/runtime/native/src/sailfin_runtime.c
+++ b/runtime/native/src/sailfin_runtime.c
@@ -58,6 +58,7 @@ extern char **environ;
 
 static bool _env_enabled(const char *name);
 static int _env_int(const char *name, int fallback);
+static int64_t _clamp_to_i64(double v);
 
 static void _print_line(FILE *stream, const char *prefix, const char *msg);
 
@@ -6225,6 +6226,139 @@ void sailfin_runtime_raise_value_error(void *message)
 void runtime_raise_value_error_fn(void *message)
 {
     sailfin_runtime_raise_value_error(message);
+}
+
+/* sailfin_assert_fail — structured assertion-failure record writer.
+ *
+ * Wire format (newline-delimited key:value, ASCII / UTF-8, NUL-free):
+ *
+ *   line 1: "SFAF"            (magic; sentinel for the runner's reader)
+ *   line 2: "v:1"             (format version; future readers gate on it)
+ *   line 3: "file:<path>"     (test source path; may be empty)
+ *   line 4: "line:<decimal>"  (signed decimal line number, 1-based)
+ *   line 5: "col:<decimal>"   (signed decimal column, 1-based)
+ *   line 6: "msg:<text>"      (assertion message; UTF-8, no embedded \n)
+ *
+ * Each line is terminated with a single '\n'. The record is
+ * NUL-free on purpose: the test runner reads the file via
+ * `fs.readFile`, which goes through Sailfin's NUL-terminated string
+ * ABI. A length-prefixed binary record would survive `read(2)` but
+ * be truncated at the first 0x00 inside any little-endian integer
+ * field. Text avoids that whole class of bug; ints are still
+ * unambiguous because every line has an explicit key prefix and the
+ * value is bounded by the next '\n'. Forward-compat is via the
+ * version line: readers that don't recognise `v:N` skip the record
+ * entirely instead of misinterpreting unknown fields.
+ *
+ * Sink resolution (first match wins):
+ *   1. SAILFIN_TEST_FAIL_FD set to a writable fd (parent opens before
+ *      spawn; child inherits the fd unchanged via posix_spawnp).
+ *   2. ${SAILFIN_TEST_SCRATCH}/fail.bin (append).
+ *   3. No sink → caller is not a test runner; write nothing. The
+ *      diagnostic still hits stderr via sailfin_runtime_raise_value_error
+ *      and the process aborts — same observable behavior as before.
+ *
+ * Append mode is intentional: a single test process that triggers
+ * multiple `assert false` calls before aborting will leave one
+ * record per call, in order. The runner reads the first valid one
+ * (consistent with C's "first crash wins" stack-unwind expectation).
+ */
+static FILE *_sfn_open_assert_fail_sink(int *out_fd_borrowed)
+{
+    /* Returns a FILE* the caller must fclose unless `*out_fd_borrowed`
+     * is non-zero, in which case the caller must `fflush` only —
+     * closing would close the parent's fd. */
+    *out_fd_borrowed = 0;
+    const char *fd_env = getenv("SAILFIN_TEST_FAIL_FD");
+    if (fd_env && *fd_env)
+    {
+        char *end = NULL;
+        long parsed = strtol(fd_env, &end, 10);
+        if (end != fd_env && parsed >= 0 && parsed <= 65535)
+        {
+#if defined(_WIN32)
+            FILE *fp = _fdopen((int)parsed, "ab");
+#else
+            FILE *fp = fdopen((int)parsed, "ab");
+#endif
+            if (fp)
+            {
+                *out_fd_borrowed = 1;
+                return fp;
+            }
+        }
+    }
+    const char *scratch = getenv("SAILFIN_TEST_SCRATCH");
+    if (scratch && *scratch)
+    {
+        size_t need = strlen(scratch) + sizeof("/fail.bin");
+        char *path = (char *)malloc(need);
+        if (!path)
+            return NULL;
+        snprintf(path, need, "%s/fail.bin", scratch);
+        FILE *fp = fopen(path, "ab");
+        free(path);
+        return fp;
+    }
+    return NULL;
+}
+
+/* Replace any '\n' in `s` with ' ' so the value cannot leak across
+ * record-line boundaries. Returns a freshly-malloc'd buffer the
+ * caller must free, or NULL on allocation failure. */
+static char *_sfn_strip_newlines(const char *s)
+{
+    if (!s)
+        s = "";
+    size_t n = strlen(s);
+    char *out = (char *)malloc(n + 1);
+    if (!out)
+        return NULL;
+    for (size_t i = 0; i < n; i++)
+    {
+        char c = s[i];
+        out[i] = (c == '\n' || c == '\r') ? ' ' : c;
+    }
+    out[n] = '\0';
+    return out;
+}
+
+void sailfin_assert_fail(const char *file, int64_t line, int64_t col, const char *msg)
+{
+    int fd_borrowed = 0;
+    FILE *sink = _sfn_open_assert_fail_sink(&fd_borrowed);
+    if (sink)
+    {
+        char *file_clean = _sfn_strip_newlines(file ? file : "");
+        char *msg_clean = _sfn_strip_newlines(msg ? msg : "assertion failed");
+        if (file_clean && msg_clean)
+        {
+            fprintf(
+                sink,
+                "SFAF\nv:1\nfile:%s\nline:%lld\ncol:%lld\nmsg:%s\n",
+                file_clean,
+                (long long)line,
+                (long long)col,
+                msg_clean);
+        }
+        free(file_clean);
+        free(msg_clean);
+        fflush(sink);
+        if (!fd_borrowed)
+            fclose(sink);
+    }
+    sailfin_runtime_raise_value_error((void *)(msg ? msg : "assertion failed"));
+}
+
+/* Sailfin-callable trampoline: the parser emits
+ *   runtime_assert_fail_fn(file, line, col, msg)
+ * with line/col passed as Sailfin `number` (LLVM `double`). The
+ * spec-defined symbol (`sailfin_assert_fail`) takes int64_t, so we
+ * clamp/convert here. Mirrors `substring_unchecked`'s double→i64
+ * trampoline. */
+void runtime_assert_fail_fn(const char *file, double line, double col, const char *msg)
+{
+    sailfin_assert_fail(file, _clamp_to_i64(line), _clamp_to_i64(col), msg);
 }
 
 /* Wrapper: the compiler may emit calls to substring_unchecked with double

--- a/runtime/prelude.sfn
+++ b/runtime/prelude.sfn
@@ -18,6 +18,7 @@ let runtime_spawn_fn = runtime.spawn;
 let runtime_log_execution_fn = runtime.logExecution;
 let runtime_to_debug_string_fn = runtime.to_debug_string;
 let runtime_raise_value_error_fn = runtime.raise_value_error;
+let runtime_assert_fail_fn = runtime.assert_fail;
 let runtime_is_string_fn = runtime.is_string;
 let runtime_is_number_fn = runtime.is_number;
 let runtime_is_boolean_fn = runtime.is_boolean;

--- a/scripts/run_native_test.sh
+++ b/scripts/run_native_test.sh
@@ -102,51 +102,28 @@ _run_once() {
 
 _run_once
 
-# Retry policy. Three classes of transient failure justify a retry:
+# Retry policy. Issue #364 deleted the regex-classified retry that
+# matched on stdout patterns like "no such file or directory" /
+# "link failed" — those patterns are now redundant because the
+# structured assert-fail record (see
+# `runtime/native/src/sailfin_runtime.c:sailfin_assert_fail` and
+# `compiler/src/cli_commands.sfn:_consume_assert_failure_record`)
+# gives the runner an exit-code-driven failure path with typed
+# attribution; transient I/O flakes still surface as a non-zero
+# exit, but masking them via `case "$output"` regexes was hiding
+# real compile failures and producing flake-like behavior.
 #
-#   1. Signal-kill (137 OOM, 139 segfault) — transient under CI memory
-#      pressure. Original retry case.
-#   2. Transient compile-emit failures — exit 1 with telltale patterns
-#      indicating the compiler couldn't durably emit a capsule .ll
-#      file or clang couldn't find one at link time. These manifest
-#      under sustained memory/IO pressure during the seedcheck phase
-#      of `make check` after the seedcheck binary has just consumed
-#      ~5–10 minutes of resources building itself. Each test in
-#      isolation passes; the same test in the long sequential loop
-#      sometimes silently emits an empty/partial .ll that clang then
-#      can't link. This is the same class of flake that
-#      `scripts/build.sh` mitigates via `EMIT_RETRIES=3` for the seed
-#      compile path. The patterns we match here are I/O-shaped, not
-#      assertion-shaped, so we never mask real test-logic failures —
-#      a missing-effect or wrong-line assertion failure would bubble
-#      up as an `assertion failed` line that none of these patterns
-#      catch.
-#   3. Future: timeouts (124) — currently fail loud so we can spot
-#      genuine compile-time regressions instead of papering over
-#      them. Extend if/when needed.
-#
-# Override with SAILFIN_TEST_RETRY=0 to disable retries entirely
-# (useful for diagnosing flakes vs real failures during perf work).
-_should_retry_on_io_pressure() {
-    if [ "${SAILFIN_TEST_RETRY:-1}" = "0" ]; then return 1; fi
-    if [ $RC_INNER -ne 1 ]; then return 1; fi
-    case "$output" in
-        *"no such file or directory"*) return 0 ;;
-        *"link failed"*) return 0 ;;
-        *"fs.writeLines failed"*) return 0 ;;
-        *"capsule-resolver: failed to lower"*) return 0 ;;
-        *"empty llvm output"*) return 0 ;;
-        *"emit-llvm-file:"*) return 0 ;;
-    esac
-    return 1
-}
-
-if [ $RC_INNER -eq 137 ] || [ $RC_INNER -eq 139 ]; then
-    echo "[test] RETRY: $BASENAME (exit code $RC_INNER, retrying once)"
-    _run_once
-elif _should_retry_on_io_pressure; then
-    echo "[test] RETRY: $BASENAME (transient I/O-pressure failure, retrying once)"
-    _run_once
+# What stays: signal-kill retry (137 OOM, 139 segfault). These are
+# transient under sustained CI memory pressure during the
+# seedcheck phase of `make check`, and they don't depend on stdout
+# inspection. Override with SAILFIN_TEST_RETRY=0 to disable
+# retries entirely (useful when diagnosing flake vs real failure
+# during perf work).
+if [ "${SAILFIN_TEST_RETRY:-1}" != "0" ]; then
+    if [ $RC_INNER -eq 137 ] || [ $RC_INNER -eq 139 ]; then
+        echo "[test] RETRY: $BASENAME (exit code $RC_INNER, retrying once)"
+        _run_once
+    fi
 fi
 
 if [ $RC_INNER -ne 0 ]; then
@@ -169,28 +146,13 @@ if [ $RC_INNER -ne 0 ]; then
     exit 1
 fi
 
-# The binary must produce SOME output — a silent exit is not a pass
-if [ -z "$output" ]; then
-    echo "[test] FAIL: $BASENAME (no output — binary is non-functional)"
-    exit 1
-fi
-
-# Check for test pass indicators
-if grep -qiE "pass|ok|success" <<< "$output"; then
-    echo "[test] PASS: $BASENAME"
-    exit 0
-fi
-
-# If there's output but no pass indicator, check for explicit failures.
-# Use identifier-safe boundary matching to avoid false positives from
-# identifiers like "runtime_raise_value_error_fn" in debug trace output.
-# Avoids grep -P (PCRE) since BSD grep on macOS doesn't support it.
-if grep -qiE '(^|[^[:alnum:]_])(fail(ed|ure)?|error|panic|abort)([^[:alnum:]_]|$)' <<< "$output"; then
-    echo "[test] FAIL: $BASENAME"
-    echo "$output" | tail -5
-    exit 1
-fi
-
-# Output exists but no clear pass/fail — treat as pass (test ran without error)
+# Issue #364: pass/fail is decided by exit code alone. The previous
+# "grep stdout for fail|panic|error" heuristic produced false
+# positives whenever a test legitimately printed those words (e.g. a
+# test that prints the literal word "panic" as part of its
+# assertions about diagnostic output). The compiler now writes a
+# structured AssertFailure record on `assert false`, and the test
+# runner inside `compiler/src/cli_commands.sfn` reads it before
+# returning a non-zero exit code — so a clean exit IS a clean test.
 echo "[test] PASS: $BASENAME"
 exit 0


### PR DESCRIPTION
## Summary

- Replace the fragile stdout-grep heuristic in `scripts/run_native_test.sh` with a typed runtime hook (`sailfin_assert_fail`) that writes a structured (file, line, col, message) record to `${SAILFIN_TEST_SCRATCH}/fail.bin`.
- The test runner in `compiler/src/cli_commands.sfn` reads the record after each test and surfaces `path:line:col: message` attribution — no regex, no false positives when a passing test prints "panic" / "fail" / "error" / "abort".
- Non-test callers see no behavior change: with neither `SAILFIN_TEST_FAIL_FD` nor `SAILFIN_TEST_SCRATCH` set, no record is written and `assert false` aborts with the same diagnostic as before.

Closes #364

## Wire format

Newline-delimited key:value text (NUL-free, so `fs.readFile`'s NUL-terminated string ABI doesn't truncate the record):

```
SFAF
v:1
file:<path>
line:<decimal>
col:<decimal>
msg:<text>
```

Picked text over length-prefixed binary because little-endian integers would contain 0x00 bytes that get clipped by `fs.readFile`. Forward-compat is via the `v:N` line — readers that don't recognise the version skip the record.

## Acceptance Criteria

- [x] `runtime/native/src/sailfin_runtime.c` declares `sailfin_assert_fail(file, line, col, msg)` with the four-argument signature and writes a typed record to fd 3 (or `SAILFIN_TEST_SCRATCH`/fail.bin) on each call.
- [x] `runtime/prelude.sfn` exposes the binding (`runtime_assert_fail_fn`) and the existing `assert` lowering routes through it (parser/statements.sfn:parse_assert_statement now emits a call to it with line/col extracted from the assert token).
- [x] `compiler/src/cli_commands.sfn` reads the record (`_consume_assert_failure_record`), populates a typed `AssertFailure { file, line, col, message }`, and the test runner reports failures with `path:line:col: message` attribution.
- [x] `scripts/run_native_test.sh:178-196` (grep heuristic) deleted; regex-driven I/O-pressure retry classes deleted; signal-kill (137/139) retry stays.
- [x] A test that prints the literal word "panic" in normal output is NOT flagged as failing — covered by `compiler/tests/integration/assert_fail_record_test.sfn`.
- [x] `assert false` in non-test code aborts with the same diagnostic shape as today (sink resolution falls through; `sailfin_runtime_raise_value_error` is still the final call).
- [x] `make compile && make test` passes locally.
- [x] `sfn fmt --check` clean on every touched `.sfn` file.

## Verification

```bash
ulimit -v 8388608
make compile                         # built build/native/sailfin
make test                            # 0 failures (incl. new assert_fail_record_test.sfn)

# Smoke: deliberately-failing test produces a structured record
mkdir -p /tmp/sfn_test_scratch && rm -f /tmp/sfn_test_scratch/fail.bin
echo 'test "fails" { assert false; }' > /tmp/fail_smoke.sfn
SAILFIN_TEST_SCRATCH=/tmp/sfn_test_scratch \
  timeout 60 build/native/sailfin test /tmp/fail_smoke.sfn 2>&1 | tail -3
# → "test failed: /tmp/fail_smoke.sfn:1:16: assertion failed"

# Inspect the wire format directly
cat /tmp/sfn_direct/fail.bin
# SFAF
# v:1
# file:
# line:1
# col:16
# msg:assertion failed
```

`make check` was running at commit time; CI will re-run it on this PR.

## Files Changed

- `runtime/native/include/sailfin_runtime.h` — declare `sailfin_assert_fail`.
- `runtime/native/src/sailfin_runtime.c` — implement `sailfin_assert_fail` + double-trampoline `runtime_assert_fail_fn`.
- `runtime/prelude.sfn` — bind `runtime_assert_fail_fn`.
- `compiler/src/parser/statements.sfn` — `parse_assert_statement` emits `runtime_assert_fail_fn("", line, col, "assertion failed")`.
- `compiler/src/llvm/runtime_helpers.sfn` — descriptor (target → symbol mapping with `["i8*", "double", "double", "i8*"]` types).
- `compiler/src/llvm/lowering/lowering_helpers.sfn` — append `runtime_assert_fail_fn` to the canonical helper list.
- `compiler/src/cli_commands.sfn` — `AssertFailure` struct + parser + per-test consume; threads `SAILFIN_TEST_SCRATCH` into the child via `env`.
- `scripts/run_native_test.sh` — delete grep heuristic + regex-driven retry; keep signal-kill retry.
- `compiler/tests/integration/assert_fail_record_test.sfn` — regression guard.

## Notes for reviewers

- The C-side `sailfin_assert_fail(file, line: i64, col: i64, msg)` matches the issue spec exactly; the Sailfin-callable trampoline `runtime_assert_fail_fn(file, line: double, col: double, msg)` clamps doubles to int64 (mirroring `substring_unchecked`'s shape), since Sailfin's `number` type lowers to LLVM `double`.
- For now, the parser passes `file=""` because the parser doesn't carry the source path; the test runner already knows it and substitutes `test_path` when `failure.file` is empty in `_format_assert_failure`. Adding file threading is a follow-up if needed.
- `SAILFIN_TEST_FAIL_FD` is implemented in the C runtime but not yet wired by the test runner (we use the scratch-file path because Sailfin's `process.run` doesn't expose fd inheritance). The fd path is reserved for follow-up work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UdiYBiAmiKok7T4xayuewD)_