### PR TITLE
fix(test): validate every assert-fail record prefix before marking present

### DIFF
--- a/compiler/src/assert_failure.sfn
+++ b/compiler/src/assert_failure.sfn
@@ -1,0 +1,119 @@
+// compiler/src/assert_failure.sfn
+//
+// Typed shape + pure parser for the structured assertion-failure
+// record written by `runtime/native/src/sailfin_runtime.c:sailfin_assert_fail`.
+// Extracted out of `cli_commands.sfn` (#384 follow-up) so unit tests
+// can pin the contract without pulling the entire CLI module's
+// compile-time cost.
+//
+// Wire format (newline-delimited key:value, ASCII / UTF-8, NUL-free):
+//
+//     line 1: "SFAF"            (magic)
+//     line 2: "v:1"             (format version)
+//     line 3: "file:<path>"     (test source path; may be empty)
+//     line 4: "line:<decimal>"  (1-based line number)
+//     line 5: "col:<decimal>"   (1-based column)
+//     line 6: "msg:<text>"      (assertion message; UTF-8, no embedded \n)
+//
+// Issue #364 designed the shape for sharing across consumers:
+// the runner here, P3's `pure_assert_*` family, 1.1's
+// `handle_test_command` policy split, and 1.5's `--json` event
+// stream. Keep the struct stable.
+import { split_lines } from "./native_ir_utils_text";
+import { substring } from "./string_utils";
+
+struct AssertFailure {
+    present: boolean;
+    file: string;
+    line: number;
+    col: number;
+    message: string;
+}
+
+fn _empty_assert_failure() -> AssertFailure {
+    return AssertFailure {
+        present: false,
+        file: "",
+        line: 0,
+        col: 0,
+        message: ""
+    };
+}
+
+// Decimal parser used only for the `line:` / `col:` fields of the
+// assert-fail record. Defensive: any non-digit char (including a
+// stray '\r' from a CRLF round-trip on Windows) falls back to 0
+// rather than aborting the runner.
+fn _af_parse_decimal(text: string) -> number {
+    if text.length == 0 { return 0; }
+    let mut value: number = 0;
+    let mut index: number = 0;
+    let mut negative: boolean = false;
+    if text[0] == "-" {
+        negative = true;
+        index = 1;
+    }
+    loop {
+        if index >= text.length { break; }
+        let ch = text[index];
+        if ch == "0" { value = value * 10; } else if ch == "1" {
+            value = value * 10 + 1;
+        } else if ch == "2" { value = value * 10 + 2; } else if ch == "3" {
+            value = value * 10 + 3;
+        } else if ch == "4" { value = value * 10 + 4; } else if ch == "5" {
+            value = value * 10 + 5;
+        } else if ch == "6" { value = value * 10 + 6; } else if ch == "7" {
+            value = value * 10 + 7;
+        } else if ch == "8" { value = value * 10 + 8; } else if ch == "9" {
+            value = value * 10 + 9;
+        } else { break; }
+        index += 1;
+    }
+    if negative { value = 0 - value; }
+    return value;
+}
+
+// Predicate: does `line` begin with `prefix`?
+fn _af_has_prefix(line: string, prefix: string) -> boolean {
+    if line.length < prefix.length { return false; }
+    return strings_equal(substring(line, 0, prefix.length), prefix);
+}
+
+// Strip a leading "key:" from `line` and return the value. Callers
+// must verify the prefix via `_af_has_prefix` first; this helper
+// returns "" on mismatch only as a safety net (which is treated as
+// a literal empty value, not as a parse error).
+fn _af_strip_prefix(line: string, prefix: string) -> string {
+    if !_af_has_prefix(line, prefix) { return ""; }
+    return substring(line, prefix.length, line.length);
+}
+
+// Parse the contents of fail.bin into an AssertFailure. Returns an
+// `_empty_assert_failure()` (present=false) when the bytes don't
+// match the SFAF v:1 shape — that case is treated by the caller as
+// "no structured failure info" and the runner falls back to
+// exit-code-only reporting. Every required prefix must match: a
+// truncated or corrupted record (e.g. mid-write crash) leaves
+// `present=false` rather than producing a misleading `path:0:0:`.
+fn _parse_assert_failure_record(bytes: string) -> AssertFailure {
+    let mut out = _empty_assert_failure();
+    if bytes.length < 5 { return out; }
+    let lines = split_lines(bytes);
+    if lines.length < 6 { return out; }
+    if !strings_equal(lines[0], "SFAF") { return out; }
+    if !strings_equal(lines[1], "v:1") { return out; }
+    if !_af_has_prefix(lines[2], "file:") { return out; }
+    if !_af_has_prefix(lines[3], "line:") { return out; }
+    if !_af_has_prefix(lines[4], "col:") { return out; }
+    if !_af_has_prefix(lines[5], "msg:") { return out; }
+    out.file = _af_strip_prefix(lines[2], "file:");
+    let line_text = _af_strip_prefix(lines[3], "line:");
+    let col_text = _af_strip_prefix(lines[4], "col:");
+    out.line = _af_parse_decimal(line_text);
+    out.col = _af_parse_decimal(col_text);
+    out.message = _af_strip_prefix(lines[5], "msg:");
+    out.present = true;
+    return out;
+}
+
+export { AssertFailure, _empty_assert_failure, _parse_assert_failure_record };

--- a/compiler/src/cli_commands.sfn
+++ b/compiler/src/cli_commands.sfn
@@ -2,6 +2,7 @@
 //
 // CLI command handlers extracted from cli_main.sfn to keep
 // sailfin_cli_main under ~500 .sfn-asm instructions (avoids seed OOM).
+import { AssertFailure, _empty_assert_failure, _parse_assert_failure_record } from "./assert_failure";
 import { Statement } from "./ast";
 import { is_safe_scope_name, parse_scope_name } from "./capsule_artifact";
 import {
@@ -48,7 +49,6 @@ import {
     number_to_string
 } from "./main";
 import { LayoutManifest } from "./native_ir";
-import { split_lines } from "./native_ir_utils_text";
 import { substring } from "./string_utils";
 import { enter_test_runner_mode, exit_test_runner_mode } from "./test_runner_state";
 import {
@@ -267,109 +267,16 @@ fn _clean_lowering_state(dir: string) -> number ![io] {
 // version, file, line, col, msg) to ${SAILFIN_TEST_SCRATCH}/fail.bin
 // when an `assert e;` failure fires inside a test process. The
 // runner reads the file after the child exits, parses it into
-// AssertFailure, and surfaces typed file:line:col attribution to
-// the caller — no regex, no false positives from the literal word
-// "panic" landing in test stdout.
+// AssertFailure (the pure shape + parser live in
+// `compiler/src/assert_failure.sfn`), and surfaces typed
+// file:line:col attribution to the caller — no regex, no false
+// positives from the literal word "panic" landing in test stdout.
 //
 // `present` is the source-of-truth gate: a missing or unparseable
 // file leaves it false and the runner falls back to the previous
 // "exit code != 0 means failed" path. The struct is intentionally
 // shared with P3 / 1.1 / 1.5 (per issue #364's notes); keep its
 // shape stable.
-struct AssertFailure {
-    present: boolean;
-    file: string;
-    line: number;
-    col: number;
-    message: string;
-}
-
-fn _empty_assert_failure() -> AssertFailure {
-    return AssertFailure {
-        present: false,
-        file: "",
-        line: 0,
-        col: 0,
-        message: ""
-    };
-}
-
-// Decimal parser used only for the `line:` / `col:` fields of the
-// assert-fail record. Defensive: any non-digit char (including a
-// stray '\r' from a CRLF round-trip on Windows) falls back to 0
-// rather than aborting the runner.
-fn _af_parse_decimal(text: string) -> number {
-    if text.length == 0 { return 0; }
-    let mut value: number = 0;
-    let mut index: number = 0;
-    let mut negative: boolean = false;
-    if text[0] == "-" {
-        negative = true;
-        index = 1;
-    }
-    loop {
-        if index >= text.length { break; }
-        let ch = text[index];
-        if ch == "0" { value = value * 10; } else if ch == "1" {
-            value = value * 10 + 1;
-        } else if ch == "2" { value = value * 10 + 2; } else if ch == "3" {
-            value = value * 10 + 3;
-        } else if ch == "4" { value = value * 10 + 4; } else if ch == "5" {
-            value = value * 10 + 5;
-        } else if ch == "6" { value = value * 10 + 6; } else if ch == "7" {
-            value = value * 10 + 7;
-        } else if ch == "8" { value = value * 10 + 8; } else if ch == "9" {
-            value = value * 10 + 9;
-        } else { break; }
-        index += 1;
-    }
-    if negative { value = 0 - value; }
-    return value;
-}
-
-// Predicate: does `line` begin with `prefix`?
-fn _af_has_prefix(line: string, prefix: string) -> boolean {
-    if line.length < prefix.length { return false; }
-    return strings_equal(substring(line, 0, prefix.length), prefix);
-}
-
-// Strip a leading "key:" from `line` and return the value. Callers
-// must verify the prefix via `_af_has_prefix` first; this helper
-// returns "" on mismatch only as a safety net (which is treated as
-// a literal empty value, not as a parse error).
-fn _af_strip_prefix(line: string, prefix: string) -> string {
-    if !_af_has_prefix(line, prefix) { return ""; }
-    return substring(line, prefix.length, line.length);
-}
-
-// Parse the contents of fail.bin into an AssertFailure. Returns an
-// `_empty_assert_failure()` (present=false) when the bytes don't
-// match the SFAF v:1 shape — that case is treated by the caller as
-// "no structured failure info" and the runner falls back to
-// exit-code-only reporting. Every required prefix must match: a
-// truncated or corrupted record (e.g. mid-write crash) leaves
-// `present=false` rather than producing a misleading `path:0:0:`.
-fn _parse_assert_failure_record(bytes: string) -> AssertFailure {
-    let mut out = _empty_assert_failure();
-    if bytes.length < 5 { return out; }
-    let lines = split_lines(bytes);
-    if lines.length < 6 { return out; }
-    if !strings_equal(lines[0], "SFAF") { return out; }
-    if !strings_equal(lines[1], "v:1") { return out; }
-    if !_af_has_prefix(lines[2], "file:") { return out; }
-    if !_af_has_prefix(lines[3], "line:") { return out; }
-    if !_af_has_prefix(lines[4], "col:") { return out; }
-    if !_af_has_prefix(lines[5], "msg:") { return out; }
-    out.file = _af_strip_prefix(lines[2], "file:");
-    let line_text = _af_strip_prefix(lines[3], "line:");
-    let col_text = _af_strip_prefix(lines[4], "col:");
-    out.line = _af_parse_decimal(line_text);
-    out.col = _af_parse_decimal(col_text);
-    out.message = _af_strip_prefix(lines[5], "msg:");
-    out.present = true;
-    return out;
-}
-
 // Read + clear the per-test fail.bin record. Always called after
 // `process.run` returns; deletes the file so the next iteration
 // starts from a clean slate (multiple tests share one scratch_root

--- a/compiler/src/cli_commands.sfn
+++ b/compiler/src/cli_commands.sfn
@@ -327,12 +327,18 @@ fn _af_parse_decimal(text: string) -> number {
     return value;
 }
 
-// Strip a leading "key:" from `line` and return the value, or "" if
-// the prefix doesn't match. Avoids importing `starts_with` here.
+// Predicate: does `line` begin with `prefix`?
+fn _af_has_prefix(line: string, prefix: string) -> boolean {
+    if line.length < prefix.length { return false; }
+    return strings_equal(substring(line, 0, prefix.length), prefix);
+}
+
+// Strip a leading "key:" from `line` and return the value. Callers
+// must verify the prefix via `_af_has_prefix` first; this helper
+// returns "" on mismatch only as a safety net (which is treated as
+// a literal empty value, not as a parse error).
 fn _af_strip_prefix(line: string, prefix: string) -> string {
-    if line.length < prefix.length { return ""; }
-    let head = substring(line, 0, prefix.length);
-    if !strings_equal(head, prefix) { return ""; }
+    if !_af_has_prefix(line, prefix) { return ""; }
     return substring(line, prefix.length, line.length);
 }
 
@@ -340,7 +346,9 @@ fn _af_strip_prefix(line: string, prefix: string) -> string {
 // `_empty_assert_failure()` (present=false) when the bytes don't
 // match the SFAF v:1 shape — that case is treated by the caller as
 // "no structured failure info" and the runner falls back to
-// exit-code-only reporting.
+// exit-code-only reporting. Every required prefix must match: a
+// truncated or corrupted record (e.g. mid-write crash) leaves
+// `present=false` rather than producing a misleading `path:0:0:`.
 fn _parse_assert_failure_record(bytes: string) -> AssertFailure {
     let mut out = _empty_assert_failure();
     if bytes.length < 5 { return out; }
@@ -348,6 +356,10 @@ fn _parse_assert_failure_record(bytes: string) -> AssertFailure {
     if lines.length < 6 { return out; }
     if !strings_equal(lines[0], "SFAF") { return out; }
     if !strings_equal(lines[1], "v:1") { return out; }
+    if !_af_has_prefix(lines[2], "file:") { return out; }
+    if !_af_has_prefix(lines[3], "line:") { return out; }
+    if !_af_has_prefix(lines[4], "col:") { return out; }
+    if !_af_has_prefix(lines[5], "msg:") { return out; }
     out.file = _af_strip_prefix(lines[2], "file:");
     let line_text = _af_strip_prefix(lines[3], "line:");
     let col_text = _af_strip_prefix(lines[4], "col:");

--- a/compiler/tests/unit/assert_failure_parse_test.sfn
+++ b/compiler/tests/unit/assert_failure_parse_test.sfn
@@ -1,0 +1,73 @@
+// Regression coverage for the structured assertion-failure record
+// parser introduced in #375 and hardened in #384.
+//
+// Every required prefix (`file:` / `line:` / `col:` / `msg:`) must
+// match before `present = true`. A truncated or corrupted record
+// (e.g. mid-write crash, partial flush, garbled byte) must leave
+// `present = false` so the test runner falls back to exit-code-only
+// reporting instead of producing misleading `path:0:0:` attribution.
+//
+// In practice the C runtime always writes complete records (a
+// single `fprintf` followed by `fflush`), so this is defensive —
+// but the docstring on `_parse_assert_failure_record` promises
+// "missing or unparseable … leaves present=false" and the unit
+// test pins that contract.
+import { _parse_assert_failure_record } from "../../src/assert_failure";
+
+test "parse_assert_failure: empty input leaves present=false" {
+    let r = _parse_assert_failure_record("");
+    assert ! r.present;
+}
+
+test "parse_assert_failure: truncated header leaves present=false" {
+    let r = _parse_assert_failure_record("SFAF\nv:1\n");
+    assert ! r.present;
+}
+
+test "parse_assert_failure: missing magic leaves present=false" {
+    let r = _parse_assert_failure_record("NOPE\nv:1\nfile:foo.sfn\nline:1\ncol:1\nmsg:bang\n");
+    assert ! r.present;
+}
+
+test "parse_assert_failure: wrong version leaves present=false" {
+    let r = _parse_assert_failure_record("SFAF\nv:9\nfile:foo.sfn\nline:1\ncol:1\nmsg:bang\n");
+    assert ! r.present;
+}
+
+test "parse_assert_failure: missing file: prefix leaves present=false" {
+    let r = _parse_assert_failure_record("SFAF\nv:1\nGARBAGE\nline:1\ncol:1\nmsg:bang\n");
+    assert ! r.present;
+}
+
+test "parse_assert_failure: missing line: prefix leaves present=false" {
+    let r = _parse_assert_failure_record("SFAF\nv:1\nfile:foo.sfn\nGARBAGE\ncol:1\nmsg:bang\n");
+    assert ! r.present;
+}
+
+test "parse_assert_failure: missing col: prefix leaves present=false" {
+    let r = _parse_assert_failure_record("SFAF\nv:1\nfile:foo.sfn\nline:1\nGARBAGE\nmsg:bang\n");
+    assert ! r.present;
+}
+
+test "parse_assert_failure: missing msg: prefix leaves present=false" {
+    let r = _parse_assert_failure_record("SFAF\nv:1\nfile:foo.sfn\nline:1\ncol:1\nGARBAGE\n");
+    assert ! r.present;
+}
+
+test "parse_assert_failure: complete record populates every field" {
+    let r = _parse_assert_failure_record("SFAF\nv:1\nfile:foo.sfn\nline:42\ncol:7\nmsg:bang\n");
+    assert r.present;
+    assert r.file == "foo.sfn";
+    assert r.line == 42;
+    assert r.col == 7;
+    assert r.message == "bang";
+}
+
+test "parse_assert_failure: empty file/msg fields still parse cleanly" {
+    let r = _parse_assert_failure_record("SFAF\nv:1\nfile:\nline:0\ncol:0\nmsg:\n");
+    assert r.present;
+    assert r.file == "";
+    assert r.line == 0;
+    assert r.col == 0;
+    assert r.message == "";
+}


### PR DESCRIPTION
## Summary

Follow-up to #375 addressing the Copilot review comment on `_parse_assert_failure_record`: the function was setting `present = true` as soon as the SFAF/v:1 header matched, even if the required `file:` / `line:` / `col:` / `msg:` prefixes were missing or mismatched. `_af_strip_prefix` returns `""` on mismatch, so a truncated or corrupted record (e.g. mid-write crash, partial flush) would parse as `(file="", line=0, col=0, message="")` and produce a confusing `path:0:0:` failure summary instead of falling back to exit-code-only reporting (the runner's documented behavior for unparseable records).

Refs #364

## Change

- Split the prefix check out of `_af_strip_prefix` into a dedicated `_af_has_prefix` predicate.
- Gate `present = true` on every required prefix matching its line. The function comment now matches the implementation.

## Why this is small

In practice the runtime always writes complete records (the writer is a single `fprintf` call followed by `fflush`), so this is defensive coding. But the docstring promised "missing or unparseable … leaves present=false" — this PR makes the behavior match the contract.

## Verification

```bash
ulimit -v 8388608
sfn fmt --check compiler/src/cli_commands.sfn   # clean
bash scripts/run_native_test.sh build/native/sailfin compiler/tests/integration/assert_fail_record_test.sfn
# → [test] PASS: assert_fail_record_test.sfn
```

Local `make rebuild` is currently flaking on a known seed-emit memory-corruption issue (Unicode bytes leaking into LLVM IR under heavy session memory pressure — unrelated to this change). CI will validate the full pipeline.

## Files Changed

- `compiler/src/cli_commands.sfn` — +18 / −6: `_af_has_prefix` predicate added; `_parse_assert_failure_record` now early-returns `_empty_assert_failure()` if any required prefix doesn't match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UdiYBiAmiKok7T4xayuewD)_