### PR TITLE
feat(test): pure_assert_* family returning AssertFailure (P3, #370)

### DIFF
--- a/capsules/sfn/test/src/mod.sfn
+++ b/capsules/sfn/test/src/mod.sfn
@@ -333,12 +333,20 @@ fn pure_assert_eq_string(actual: string, expected: string, label: string) -> Ass
 fn pure_assert_eq_float(actual: number, expected: number, tolerance: number, label: string) -> AssertFailure ![pure] {
     let diff = _abs(actual - expected);
     if diff <= tolerance { return _pure_ok(); }
+    // Use the runtime's `%.15g`-format `number_to_string` here rather
+    // than the file-local `_number_to_string` (integer-only, repeated
+    // subtraction). Float comparisons routinely receive fractional
+    // inputs, and the integer-only formatter would mangle non-integer
+    // values in the diagnostic message and risk runaway loops on large
+    // doubles. Other helpers stay on `_number_to_string` because they
+    // operate on integer-shaped inputs in practice (counts, lengths,
+    // boolean-equivalent ints).
     let message = "ASSERTION FAILED: " + label + "; expected: "
-        + _number_to_string(expected)
+        + number_to_string(expected)
         + " +/- "
-        + _number_to_string(tolerance)
+        + number_to_string(tolerance)
         + "; actual: "
-        + _number_to_string(actual);
+        + number_to_string(actual);
     return _pure_fail(message);
 }
 

--- a/capsules/sfn/test/src/mod.sfn
+++ b/capsules/sfn/test/src/mod.sfn
@@ -5,11 +5,27 @@
 // `assert` keyword with more descriptive failure output.
 //
 // Requires ![io] for diagnostic printing on failure.
-
+//
+// Two API tiers (per `docs/proposals/test-infra-epic/03-capsule-api.md`):
+//
+//   1. Legacy `assert_*` — `![io]`. Prints diagnostics on mismatch via
+//      `print.err`, then `assert false` to fail the test.
+//   2. `pure_assert_*` — `![pure]`. Returns an `AssertFailure` record
+//      with `present == true` on mismatch (effectively
+//      `Result<(), AssertFailure>` until that type ships). The capsule
+//      body never prints; consumers (today: a hand-rolled `if r.present
+//      { assert false; }`; tomorrow: 1.4's `expect()` matcher) decide
+//      how to surface the failure. This lets a test calling only
+//      `pure_assert_*` stay `![pure]` even though the capsule manifest
+//      keeps `required = ["io"]` for the legacy tier.
+//
+// Both tiers collapse into a single generic `assert_eq` parameterized
+// over the caller's effect row when row-polymorphic effects ship
+// post-1.0. Until then, `pure_assert_*` is the production-ready
+// interim — see issue #370 / proposal §P3.
 // ---------------------------------------------------------------------------
 // Internal helpers
 // ---------------------------------------------------------------------------
-
 fn _number_to_string(value: number) -> string {
     if value == 0 { return "0"; }
     let mut is_negative: boolean = false;
@@ -33,9 +49,7 @@ fn _number_to_string(value: number) -> string {
         output = ch + output;
         remaining = quotient;
     }
-    if is_negative {
-        output = "-" + output;
-    }
+    if is_negative { output = "-" + output; }
     return output;
 }
 
@@ -52,7 +66,6 @@ fn _abs(x: number) -> number {
 // ---------------------------------------------------------------------------
 // Equality assertions
 // ---------------------------------------------------------------------------
-
 fn assert_eq(actual: number, expected: number, label: string) ![io] {
     if actual == expected { return; }
     print.err("ASSERTION FAILED: " + label);
@@ -96,7 +109,6 @@ fn assert_bool_eq(actual: boolean, expected: boolean, label: string) ![io] {
 // ---------------------------------------------------------------------------
 // Comparison assertions
 // ---------------------------------------------------------------------------
-
 fn assert_gt(actual: number, threshold: number, label: string) ![io] {
     if actual > threshold { return; }
     print.err("ASSERTION FAILED: " + label);
@@ -132,7 +144,6 @@ fn assert_lte(actual: number, threshold: number, label: string) ![io] {
 // ---------------------------------------------------------------------------
 // String content assertions
 // ---------------------------------------------------------------------------
-
 fn _find_in_string(haystack: string, needle: string) -> number {
     if needle.length == 0 { return 0; }
     if needle.length > haystack.length { return -1; }
@@ -187,12 +198,12 @@ fn assert_ends_with(text: string, suffix: string, label: string) ![io] {
 // ---------------------------------------------------------------------------
 // Approximate equality (for floating-point / tolerance comparisons)
 // ---------------------------------------------------------------------------
-
 fn assert_approx(actual: number, expected: number, tolerance: number, label: string) ![io] {
     let diff = _abs(actual - expected);
     if diff <= tolerance { return; }
     print.err("ASSERTION FAILED: " + label);
-    print.err("  expected: " + _number_to_string(expected) + " +/- " + _number_to_string(tolerance));
+    print.err("  expected: " + _number_to_string(expected) + " +/- "
+        + _number_to_string(tolerance));
     print.err("  actual:   " + _number_to_string(actual));
     assert false;
 }
@@ -200,7 +211,6 @@ fn assert_approx(actual: number, expected: number, tolerance: number, label: str
 // ---------------------------------------------------------------------------
 // Array length assertions
 // ---------------------------------------------------------------------------
-
 fn assert_length(actual_length: number, expected_length: number, label: string) ![io] {
     if actual_length == expected_length { return; }
     print.err("ASSERTION FAILED: " + label);
@@ -228,7 +238,6 @@ fn assert_not_empty(actual_length: number, label: string) ![io] {
 // ---------------------------------------------------------------------------
 // Boolean assertions
 // ---------------------------------------------------------------------------
-
 fn assert_true(value: boolean, label: string) ![io] {
     if value { return; }
     print.err("ASSERTION FAILED: " + label);
@@ -243,4 +252,115 @@ fn assert_false(value: boolean, label: string) ![io] {
     print.err("  expected: false");
     print.err("  actual:   true");
     assert false;
+}
+
+// ---------------------------------------------------------------------------
+// Pure-effect assertions (issue #370 / proposal §P3)
+// ---------------------------------------------------------------------------
+//
+// The `pure_assert_*` family returns an `AssertFailure` record instead
+// of printing. Each helper is `![pure]` so a `![pure]` test calling
+// only these functions stays `![pure]` end-to-end. The capsule
+// manifest still declares `required = ["io"]` because the legacy tier
+// above (`assert_eq`, `assert_str_eq`, etc.) needs `print.err`; that
+// surface describes what the capsule's *own* functions can do, not
+// what every caller must declare.
+//
+// `AssertFailure` mirrors the shape used by P2 in
+// `compiler/src/cli_commands.sfn` (issue #364). The `present` field
+// is the discriminator: `present == false` is the "Ok(())" case,
+// `present == true` carries the diagnostic. When `Result<T, E>`
+// lands (1.0 critical-path Phase 1), the helpers move to
+// `Result<(), AssertFailure>` — `present == false` maps to `Ok(())`
+// and `present == true` to `Err(failure)` with no shape change.
+// At that point the duplicate definition here and in `cli_commands.sfn`
+// folds into a shared module.
+//
+// `file` / `line` / `col` stay empty / 0 today: Sailfin lacks
+// `__file__` / `__line__` macros, and a plain `fn` body cannot reach
+// out for the call-site span. 1.4's `expect()` matcher is parsed
+// directly and can attach those fields. Until then, `message` carries
+// the `label` plus a stringified expected/actual pair so a manual
+// `if r.present { assert false; }` consumer still gets actionable
+// output through P2's structured failure record.
+struct AssertFailure {
+    present: boolean;
+    file: string;
+    line: number;
+    col: number;
+    message: string;
+}
+
+fn _pure_ok() -> AssertFailure {
+    return AssertFailure {
+        present: false,
+        file: "",
+        line: 0,
+        col: 0,
+        message: ""
+    };
+}
+
+fn _pure_fail(message: string) -> AssertFailure {
+    return AssertFailure {
+        present: true,
+        file: "",
+        line: 0,
+        col: 0,
+        message: message
+    };
+}
+
+fn pure_assert_eq_int(actual: number, expected: number, label: string) -> AssertFailure ![pure] {
+    if actual == expected { return _pure_ok(); }
+    let message = "ASSERTION FAILED: " + label + "; expected: "
+        + _number_to_string(expected)
+        + "; actual: "
+        + _number_to_string(actual);
+    return _pure_fail(message);
+}
+
+fn pure_assert_eq_string(actual: string, expected: string, label: string) -> AssertFailure ![pure] {
+    if actual == expected { return _pure_ok(); }
+    let message = "ASSERTION FAILED: " + label + "; expected: \"" + expected
+        + "\""
+        + "; actual: \""
+        + actual
+        + "\"";
+    return _pure_fail(message);
+}
+
+fn pure_assert_eq_float(actual: number, expected: number, tolerance: number, label: string) -> AssertFailure ![pure] {
+    let diff = _abs(actual - expected);
+    if diff <= tolerance { return _pure_ok(); }
+    let message = "ASSERTION FAILED: " + label + "; expected: "
+        + _number_to_string(expected)
+        + " +/- "
+        + _number_to_string(tolerance)
+        + "; actual: "
+        + _number_to_string(actual);
+    return _pure_fail(message);
+}
+
+fn pure_assert_eq_bool(actual: boolean, expected: boolean, label: string) -> AssertFailure ![pure] {
+    if actual == expected { return _pure_ok(); }
+    let message = "ASSERTION FAILED: " + label + "; expected: "
+        + _bool_to_string(expected)
+        + "; actual: "
+        + _bool_to_string(actual);
+    return _pure_fail(message);
+}
+
+fn pure_assert_true(value: boolean, label: string) -> AssertFailure ![pure] {
+    if value { return _pure_ok(); }
+    let message = "ASSERTION FAILED: " + label
+        + "; expected: true; actual: false";
+    return _pure_fail(message);
+}
+
+fn pure_assert_false(value: boolean, label: string) -> AssertFailure ![pure] {
+    if !value { return _pure_ok(); }
+    let message = "ASSERTION FAILED: " + label
+        + "; expected: false; actual: true";
+    return _pure_fail(message);
 }

--- a/compiler/src/effect_checker.sfn
+++ b/compiler/src/effect_checker.sfn
@@ -262,19 +262,37 @@ fn _analyze_statement_capabilities(statement: Statement, capabilities: string[])
 
 fn _analyze_routine_capabilities(signature: FunctionSignature, name: string, capabilities: string[]) -> CapabilityViolation[] {
     if signature.effects.length == 0 { return []; }
+    // `pure` is the only universally allowed effect, but only when it
+    // stands alone. `![pure, io]` is semantically contradictory — `pure`
+    // declares "no effects", so mixing it with concrete effects is a
+    // user error. We detect that here so the excess check below can let
+    // `pure` fall through (it's never in the capsule capability
+    // surface) and flag the contradiction with the existing E0403
+    // diagnostic.
+    let mut has_concrete_effect: boolean = false;
+    let mut probe: number = 0;
+    loop {
+        if probe >= signature.effects.length { break; }
+        if !is_universally_allowed_effect(signature.effects[probe]) {
+            has_concrete_effect = true;
+            break;
+        }
+        probe += 1;
+    }
     let mut excess: string[] = [];
     let mut i: number = 0;
     loop {
         if i >= signature.effects.length { break; }
         let effect = signature.effects[i];
-        // `pure` is a sentinel for "explicitly empty effect set" — it
-        // never appears in the capsule capability surface but is
-        // always allowed on a function or test signature. See
-        // `effect_taxonomy.is_universally_allowed_effect` for the
-        // rationale (proposal: docs/proposals/test-infra-epic §P3).
+        // `pure` standing alone (no concrete-effect peer) is the empty
+        // effect set; allow it regardless of the capability surface.
+        // `pure` mixed with concrete effects falls through and gets
+        // flagged as excess below.
         if is_universally_allowed_effect(effect) {
-            i += 1;
-            continue;
+            if !has_concrete_effect {
+                i += 1;
+                continue;
+            }
         }
         if !contains_effect(capabilities, effect) {
             excess = append_unique_effect(excess, effect);

--- a/compiler/src/effect_checker.sfn
+++ b/compiler/src/effect_checker.sfn
@@ -46,6 +46,7 @@ import {
     localize_import_symbols_for_program,
     lookup_imported_function
 } from "./effect_imports";
+import { is_universally_allowed_effect } from "./effect_taxonomy";
 import { substring } from "./string_utils";
 import { Token, TokenKind } from "./token";
 
@@ -266,6 +267,15 @@ fn _analyze_routine_capabilities(signature: FunctionSignature, name: string, cap
     loop {
         if i >= signature.effects.length { break; }
         let effect = signature.effects[i];
+        // `pure` is a sentinel for "explicitly empty effect set" — it
+        // never appears in the capsule capability surface but is
+        // always allowed on a function or test signature. See
+        // `effect_taxonomy.is_universally_allowed_effect` for the
+        // rationale (proposal: docs/proposals/test-infra-epic §P3).
+        if is_universally_allowed_effect(effect) {
+            i += 1;
+            continue;
+        }
         if !contains_effect(capabilities, effect) {
             excess = append_unique_effect(excess, effect);
         }

--- a/compiler/src/effect_taxonomy.sfn
+++ b/compiler/src/effect_taxonomy.sfn
@@ -41,4 +41,24 @@ fn is_canonical_effect(name: string) -> boolean {
     return false;
 }
 
-export { canonical_effects, is_canonical_effect };
+// `pure` is a sentinel meaning "this routine declares no effects" —
+// always allowed regardless of the capsule's capability surface, and
+// never satisfies a real effect requirement. Documented in the test-
+// infrastructure proposal
+// (`docs/proposals/test-infra-epic/01-preconditions.md` §P3) as the
+// annotation `![pure]` for `pure_assert_*` matchers and pure tests.
+//
+// Distinct from the canonical taxonomy: `pure` is not a capability the
+// capsule manifest can grant or deny; it's a no-op marker that makes
+// the empty effect set explicit at the call site. Adding it to
+// `canonical_effects()` would conflate the two concepts and break the
+// 1.0 lock on the canonical six.
+fn is_universally_allowed_effect(name: string) -> boolean {
+    return name == "pure";
+}
+
+export {
+    canonical_effects,
+    is_canonical_effect,
+    is_universally_allowed_effect
+};

--- a/compiler/tests/integration/pure_assert_smoke_test.sfn
+++ b/compiler/tests/integration/pure_assert_smoke_test.sfn
@@ -99,11 +99,11 @@ fn pure_assert_eq_float(actual: number, expected: number, tolerance: number, lab
     let diff = _abs(actual - expected);
     if diff <= tolerance { return _pure_ok(); }
     let message = "ASSERTION FAILED: " + label + "; expected: "
-        + _number_to_string(expected)
+        + number_to_string(expected)
         + " +/- "
-        + _number_to_string(tolerance)
+        + number_to_string(tolerance)
         + "; actual: "
-        + _number_to_string(actual);
+        + number_to_string(actual);
     return _pure_fail(message);
 }
 
@@ -177,6 +177,23 @@ test "pure_assert: eq_string mismatch yields failure" ![pure] {
 
 test "pure_assert: eq_float beyond tolerance yields failure" ![pure] {
     let r = pure_assert_eq_float(10, 0, 1, "wide-gap");
+    assert r.present;
+    assert r.message.length > 0;
+}
+
+// Fractional float coverage — the integer-only `_number_to_string`
+// would mangle these values in diagnostics and risk a runaway loop on
+// large doubles, so `pure_assert_eq_float` stringifies via the
+// runtime's `%.15g` `number_to_string`. These two cases lock in both
+// the within-tolerance and beyond-tolerance paths for non-integer
+// inputs.
+test "pure_assert: eq_float fractional within tolerance matches" ![pure] {
+    let r = pure_assert_eq_float(0.5, 0.6, 0.2, "fractional-close");
+    assert ! r.present;
+}
+
+test "pure_assert: eq_float fractional beyond tolerance yields failure" ![pure] {
+    let r = pure_assert_eq_float(0.5, 0.6, 0.05, "fractional-gap");
     assert r.present;
     assert r.message.length > 0;
 }

--- a/compiler/tests/integration/pure_assert_smoke_test.sfn
+++ b/compiler/tests/integration/pure_assert_smoke_test.sfn
@@ -1,0 +1,200 @@
+// Issue #370 (P3): pure_assert_* smoke — round-trips the
+// `pure_assert_*` family annotated `![pure]`, exercises both the
+// match (Ok) and mismatch (Err) paths, and locks in that `sfn check`
+// accepts the `![pure]` annotation as a no-op effect.
+//
+// Helpers are inlined here to mirror the existing capsule-test
+// pattern (`capsules/sfn/json/tests/json_test.sfn`'s "When `import {
+// ... } from "../src/mod"` is safe, switch to the real capsule API"
+// note). Once cross-capsule imports stabilise for integration tests,
+// these inline copies fold back into a single `import { ... } from
+// "../../../capsules/sfn/test/src/mod"`. The shape and effect rows
+// here match `capsules/sfn/test/src/mod.sfn` exactly so the eventual
+// switch is a 1:1 swap.
+struct AssertFailure {
+    present: boolean;
+    file: string;
+    line: number;
+    col: number;
+    message: string;
+}
+
+fn _number_to_string(value: number) -> string {
+    if value == 0 { return "0"; }
+    let mut is_negative: boolean = false;
+    let mut remaining: number = value;
+    if value < 0 {
+        is_negative = true;
+        remaining = 0 - value;
+    }
+    let mut output: string = "";
+    let digits = "0123456789";
+    loop {
+        if remaining <= 0 { break; }
+        let mut temp: number = remaining;
+        let mut quotient: number = 0;
+        loop {
+            if temp < 10 { break; }
+            temp -= 10;
+            quotient += 1;
+        }
+        let ch = substring(digits, temp, temp + 1);
+        output = ch + output;
+        remaining = quotient;
+    }
+    if is_negative { output = "-" + output; }
+    return output;
+}
+
+fn _bool_to_string(value: boolean) -> string {
+    if value { return "true"; }
+    return "false";
+}
+
+fn _abs(x: number) -> number {
+    if x < 0 { return 0 - x; }
+    return x;
+}
+
+fn _pure_ok() -> AssertFailure {
+    return AssertFailure {
+        present: false,
+        file: "",
+        line: 0,
+        col: 0,
+        message: ""
+    };
+}
+
+fn _pure_fail(message: string) -> AssertFailure {
+    return AssertFailure {
+        present: true,
+        file: "",
+        line: 0,
+        col: 0,
+        message: message
+    };
+}
+
+fn pure_assert_eq_int(actual: number, expected: number, label: string) -> AssertFailure ![pure] {
+    if actual == expected { return _pure_ok(); }
+    let message = "ASSERTION FAILED: " + label + "; expected: "
+        + _number_to_string(expected)
+        + "; actual: "
+        + _number_to_string(actual);
+    return _pure_fail(message);
+}
+
+fn pure_assert_eq_string(actual: string, expected: string, label: string) -> AssertFailure ![pure] {
+    if actual == expected { return _pure_ok(); }
+    let message = "ASSERTION FAILED: " + label + "; expected: \"" + expected
+        + "\""
+        + "; actual: \""
+        + actual
+        + "\"";
+    return _pure_fail(message);
+}
+
+fn pure_assert_eq_float(actual: number, expected: number, tolerance: number, label: string) -> AssertFailure ![pure] {
+    let diff = _abs(actual - expected);
+    if diff <= tolerance { return _pure_ok(); }
+    let message = "ASSERTION FAILED: " + label + "; expected: "
+        + _number_to_string(expected)
+        + " +/- "
+        + _number_to_string(tolerance)
+        + "; actual: "
+        + _number_to_string(actual);
+    return _pure_fail(message);
+}
+
+fn pure_assert_eq_bool(actual: boolean, expected: boolean, label: string) -> AssertFailure ![pure] {
+    if actual == expected { return _pure_ok(); }
+    let message = "ASSERTION FAILED: " + label + "; expected: "
+        + _bool_to_string(expected)
+        + "; actual: "
+        + _bool_to_string(actual);
+    return _pure_fail(message);
+}
+
+fn pure_assert_true(value: boolean, label: string) -> AssertFailure ![pure] {
+    if value { return _pure_ok(); }
+    let message = "ASSERTION FAILED: " + label
+        + "; expected: true; actual: false";
+    return _pure_fail(message);
+}
+
+fn pure_assert_false(value: boolean, label: string) -> AssertFailure ![pure] {
+    if !value { return _pure_ok(); }
+    let message = "ASSERTION FAILED: " + label
+        + "; expected: false; actual: true";
+    return _pure_fail(message);
+}
+
+// --- Match paths: every helper returns present == false on equality. ---
+test "pure_assert: eq_int matches" ![pure] {
+    let r = pure_assert_eq_int(42, 42, "answer");
+    assert ! r.present;
+    assert r.message.length == 0;
+}
+
+test "pure_assert: eq_string matches" ![pure] {
+    let r = pure_assert_eq_string("hello", "hello", "greeting");
+    assert ! r.present;
+}
+
+test "pure_assert: eq_float within tolerance matches" ![pure] {
+    let r = pure_assert_eq_float(1, 1, 0, "exact");
+    assert ! r.present;
+}
+
+test "pure_assert: eq_bool matches" ![pure] {
+    let r = pure_assert_eq_bool(true, true, "flag");
+    assert ! r.present;
+}
+
+test "pure_assert: true matches" ![pure] {
+    let r = pure_assert_true(true, "is_set");
+    assert ! r.present;
+}
+
+test "pure_assert: false matches" ![pure] {
+    let r = pure_assert_false(false, "is_clear");
+    assert ! r.present;
+}
+
+// --- Mismatch paths: every helper returns present == true with a populated message. ---
+test "pure_assert: eq_int mismatch yields failure" ![pure] {
+    let r = pure_assert_eq_int(1, 2, "off-by-one");
+    assert r.present;
+    assert r.message.length > 0;
+}
+
+test "pure_assert: eq_string mismatch yields failure" ![pure] {
+    let r = pure_assert_eq_string("foo", "bar", "names");
+    assert r.present;
+    assert r.message.length > 0;
+}
+
+test "pure_assert: eq_float beyond tolerance yields failure" ![pure] {
+    let r = pure_assert_eq_float(10, 0, 1, "wide-gap");
+    assert r.present;
+    assert r.message.length > 0;
+}
+
+test "pure_assert: eq_bool mismatch yields failure" ![pure] {
+    let r = pure_assert_eq_bool(true, false, "flag");
+    assert r.present;
+    assert r.message.length > 0;
+}
+
+test "pure_assert: true mismatch yields failure" ![pure] {
+    let r = pure_assert_true(false, "should_be_set");
+    assert r.present;
+    assert r.message.length > 0;
+}
+
+test "pure_assert: false mismatch yields failure" ![pure] {
+    let r = pure_assert_false(true, "should_be_clear");
+    assert r.present;
+    assert r.message.length > 0;
+}


### PR DESCRIPTION
## Summary

- Adds the `pure_assert_*` assertion family to `sfn/test` — matchers that return an `AssertFailure` record instead of printing, so a `![pure]` test stays pure end-to-end. The capsule manifest is **unchanged** (`required = ["io"]` still describes what the legacy `assert_*` tier does, not what every caller must declare).
- Six helpers, each `![pure]`: `pure_assert_eq_int / _string / _float / _bool`, plus `pure_assert_true / pure_assert_false` for symmetry.
- Recognises `![pure]` as a no-op effect annotation in the checker so the helpers (capsule caps `["io"]`) and the smoke test (compiler caps `["io", "clock"]`) compile cleanly without listing `pure` as a manifest capability.

Closes #370

## Acceptance Criteria

- [x] `capsules/sfn/test/src/mod.sfn` exports the four `pure_assert_eq_*` helpers (and `pure_assert_true`/`pure_assert_false` — they fit cleanly).
- [x] Each helper is `![pure]` — no `print.*`, no `io.*`, and no compiler complaint about effect mismatch.
- [x] On match: returns the "Ok" shape (`AssertFailure { present: false, ... }`).
- [x] On mismatch: returns the "Err" shape with `message` populated from `label` + stringified expected/actual; `file`/`line`/`col` stay 0/empty (Sailfin lacks `__file__`/`__line__` macros today; 1.4's `expect()` will populate them).
- [x] `compiler/tests/integration/pure_assert_smoke_test.sfn` calls only `pure_assert_*`, every test is annotated `![pure]`, and `sfn check` accepts the annotation.
- [x] `capsules/sfn/test/capsule.toml` is unchanged (still `required = ["io"]`).
- [x] `make compile && make test && make check` passes.
- [x] `sfn fmt --check` is clean.

## Verification

```bash
ulimit -v 8388608
make compile                                                      # ok
build/native/sailfin test compiler/tests/integration/pure_assert_smoke_test.sfn
#   PASS  (all 12 tests passed)

make test
#   ═══ unit: 85/85 passed, 0 failed ═══
#   ═══ integration: 19/19 passed, 0 failed ═══
#   ═══ e2e: 45/45 passed, 0 failed ═══
#   ═══ capsules: 10/10 passed, 0 failed ═══

make check
#   [check] stage2 == stage3: compiler is a fixed point ✓
#   [check] promoted seedcheck → build/native/sailfin

build/native/sailfin fmt --check capsules/sfn/test/src/    # clean
build/native/sailfin fmt --check compiler/src/effect_checker.sfn \
                                  compiler/src/effect_taxonomy.sfn \
                                  compiler/tests/integration/pure_assert_smoke_test.sfn   # clean
```

(Note: `make test-unit` initially showed a flake in `atomic_add_sub_test.sfn`; passed cleanly on retry. Unrelated to this change.)

## Files Changed

- `capsules/sfn/test/src/mod.sfn` — six new `pure_assert_*` helpers + `AssertFailure` struct (mirrors P2's shape from `compiler/src/cli_commands.sfn`; both fold into a shared module post-1.0 when `Result<T, E>` ships).
- `compiler/src/effect_taxonomy.sfn` — new `is_universally_allowed_effect("pure")` sentinel. Documented as distinct from the canonical-six lock.
- `compiler/src/effect_checker.sfn` — `_analyze_routine_capabilities` skips `pure` from the excess-effect check.
- `compiler/tests/integration/pure_assert_smoke_test.sfn` — new. 12 tests (6 match × 6 mismatch) all annotated `![pure]`, helpers inlined to mirror the existing `sfn/json` capsule-test pattern.

## Scope notes

The issue's `Files Affected` listed only the capsule and the new smoke test, but satisfying "`sfn check` accepts the annotation" required allowing `![pure]` through the capability cross-check. That's a 12-line surgical change in `effect_checker.sfn` + a 4-line export in `effect_taxonomy.sfn`; everything else stays as-is. The canonical-six lock (`canonical_effects()` and its existing unit-test assertions) is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017oMGUHdVGdPHcRMsWUhbkQ)_