### PR TITLE
chore(capsules/sfn/cli): bump version to 0.2.0

### DIFF
--- a/capsules/sfn/cli/capsule.toml
+++ b/capsules/sfn/cli/capsule.toml
@@ -1,6 +1,6 @@
 [capsule]
 name = "sfn/cli"
-version = "0.1.1"
+version = "0.2.0"
 description = "CLI argument parsing and terminal output for Sailfin"
 
 [dependencies]


### PR DESCRIPTION
## Summary

- Bumps `capsules/sfn/cli/capsule.toml` version from `0.1.1` to `0.2.0`
- Marks the start of the API expansion phase (Phase 1 issues will add API additively under this version)
- No code changes — manifest bump only

Closes #353

## Acceptance Criteria

- [x] `capsules/sfn/cli/capsule.toml` declares `version = "0.2.0"`
- [ ] `make compile` passes (CI will verify — no `.sfn` files changed, seed not locally available)

## Verification

```bash
grep version capsules/sfn/cli/capsule.toml
# version = "0.2.0"
```

## Files Changed

- `capsules/sfn/cli/capsule.toml` — version bumped from `0.1.1` to `0.2.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0186dgVrcB1WACEx6ht9T2an)_