### PR TITLE
test(e2e): assert declare line in clock skeleton emit (#412)

### DIFF
--- a/compiler/tests/e2e/test_runtime_clock_skeleton.sh
+++ b/compiler/tests/e2e/test_runtime_clock_skeleton.sh
@@ -1,18 +1,26 @@
 #!/usr/bin/env bash
 # End-to-end test for runtime/sfn/clock.sfn.
 #
-# Mirrors test_runtime_io_skeleton.sh — verifies the clock wrapper
-# typechecks, formats, and emits the expected LLVM shape:
+# Mirrors test_runtime_io_skeleton.sh — runs four assertions against
+# the clock wrapper:
 #
-#   - The trampoline backing is declared as `declare void
-#     @sailfin_runtime_sleep(double)` (imported from libc.sfn).
-#   - The wrapper itself is defined as `define void
-#     @sfn_sleep(double ...)`.
-#   - The body emits `call void @sailfin_runtime_sleep(...)`.
+#   1. typecheck   — `sfn check runtime/sfn/clock.sfn` reports `ok`.
+#   2. fmt         — `sfn fmt --check runtime/sfn/clock.sfn` is canonical.
+#   3. define shape — emitted IR contains `define void @sfn_sleep(...)`
+#                     and `call void @sailfin_runtime_sleep(...)` in
+#                     the wrapper body (matching the void-typed declare).
+#   4. declare shape — emitted IR contains `declare void
+#                     @sailfin_runtime_sleep(double)` at line start.
+#                     The declare is currently produced by the helper
+#                     preamble workaround in
+#                     `compiler/src/llvm/lowering/lowering_helpers.sfn`
+#                     (the `sailfin_runtime_sleep` entry); without
+#                     this assertion, removing that entry would
+#                     silently emit invalid IR.
 #
-# When the libc-direct rewrite (PR 2) ships, this test updates to
-# expect `call void @nanosleep(...)` and the trampoline declaration
-# disappears.
+# When the libc-direct rewrite (PR 2) ships, the define/declare/call
+# assertions update to expect `call void @nanosleep(...)` and the
+# trampoline declaration disappears.
 
 set -euo pipefail
 
@@ -101,9 +109,31 @@ test_emit_wrapper_shape() {
     return "$missing"
 }
 
+test_emit_declare_shape() {
+    local ll="$SCRATCH/clock.ll"
+    if [ ! -f "$ll" ]; then
+        echo "[test]   $ll missing — test_emit_wrapper_shape must run first to produce it"
+        return 1
+    fi
+    # Anchored to line start so the call site (`call void
+    # @sailfin_runtime_sleep(...)`) does not accidentally satisfy
+    # this assertion. The declare is currently emitted via the
+    # `sailfin_runtime_sleep` entry in `seed_default_runtime_helpers`
+    # (compiler/src/llvm/lowering/lowering_helpers.sfn); removing
+    # that entry must trip this check, not pass it.
+    if ! grep -qE "^declare void @sailfin_runtime_sleep\(double\)" "$ll"; then
+        echo "[test]   missing imported trampoline declaration: declare void @sailfin_runtime_sleep(double)"
+        echo "[test]   --- declare lines mentioning sailfin_runtime_sleep ---"
+        grep -nE '^declare.*@sailfin_runtime_sleep' "$ll" || true
+        return 1
+    fi
+    return 0
+}
+
 run_test "sfn check runtime/sfn/clock.sfn passes" test_check_clean
 run_test "sfn fmt --check runtime/sfn/clock.sfn is canonical" test_fmt_clean
 run_test "sfn emit llvm produces sfn_sleep wrapper over imported sleep trampoline" test_emit_wrapper_shape
+run_test "sfn emit llvm declares sailfin_runtime_sleep trampoline" test_emit_declare_shape
 
 echo "[summary] $PASS passed, $FAIL failed"
 if [ "$FAIL" -gt 0 ]; then


### PR DESCRIPTION
## Summary
- Adds a fourth assertion to `compiler/tests/e2e/test_runtime_clock_skeleton.sh` that pins the `^declare void @sailfin_runtime_sleep(double)` line in the clock module's emitted IR.
- Updates the test header comment to enumerate the four assertions (typecheck, fmt, define shape, declare shape) and points at the `seed_default_runtime_helpers` workaround that currently produces the declare line.
- Establishes a regression gate before #413 (structural fix to `render_imported_function_declarations`) and #414 (build runtime/sfn/platform/ artifacts and remove the workaround) ship.

Closes #412

## Acceptance Criteria
- [x] `bash compiler/tests/e2e/test_runtime_clock_skeleton.sh build/native/sailfin` reports `4 passed, 0 failed`
- [x] The new assertion uses `grep -qE "^declare void @sailfin_runtime_sleep\(double\)" "$ll"` (anchored to line start to avoid matching the call site)
- [x] Removing the `"sailfin_runtime_sleep"` entry at `compiler/src/llvm/lowering/lowering_helpers.sfn:752` causes the new assertion to fail (verified locally: `3 passed, 1 failed`, exit 1)
- [x] `make compile` passes (no compiler source changes)
- [x] `make test` passes

## Verification
```
$ ulimit -v 8388608 && bash compiler/tests/e2e/test_runtime_clock_skeleton.sh build/native/sailfin
[test] PASS: sfn check runtime/sfn/clock.sfn passes
[test] PASS: sfn fmt --check runtime/sfn/clock.sfn is canonical
[test] PASS: sfn emit llvm produces sfn_sleep wrapper over imported sleep trampoline
[test] PASS: sfn emit llvm declares sailfin_runtime_sleep trampoline
[summary] 4 passed, 0 failed

# Regression check (with line 752 commented out, then reverted):
$ ulimit -v 8388608 && bash compiler/tests/e2e/test_runtime_clock_skeleton.sh build/native/sailfin
... [test] FAIL: sfn emit llvm declares sailfin_runtime_sleep trampoline
[summary] 3 passed, 1 failed   (exit 1)

$ ulimit -v 8388608 && make test
... ═══ e2e: 47/47 passed, 0 failed ═══
... ═══ capsules: 10/10 passed, 0 failed ═══
```

## Files Changed
- `compiler/tests/e2e/test_runtime_clock_skeleton.sh` — new `test_emit_declare_shape` run_test plus an updated header comment naming the four assertions.

## Notes for reviewer
- The issue's `In:` says "Add one grep assertion to `test_emit_wrapper_shape`", but the AC requires `4 passed, 0 failed` and the comment-update directive enumerates four assertions. To satisfy both, the new check is in a separate `test_emit_declare_shape` run_test placed adjacent to `test_emit_wrapper_shape`. It reuses the `$SCRATCH/clock.ll` produced by the wrapper test (declared invariant: wrapper test runs first); if you'd prefer it inline inside `test_emit_wrapper_shape` with `3 passed, 0 failed`, happy to flip it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QGR393FDr1eUHduapkUNsN)_