### PR TITLE
M1.A — Lock string-literal lowering to {i8*, i64} aggregate

### DIFF
--- a/compiler/src/llvm/expression_lowering/arrays.sfn
+++ b/compiler/src/llvm/expression_lowering/arrays.sfn
@@ -284,6 +284,20 @@ fn lower_array_push_in_place(array: LLVMOperand, value: LLVMOperand, element_typ
     // Do not route these through the generic `array_push_slot` path, which uses
     // a different header layout and can break subsequent `append_string` calls.
     if element_type == "i8*" {
+        // M1.A: SfnString aggregate operands (literals after the M1.A
+        // flip) must shed the length prefix before reaching the
+        // `(_, i8*)` ABI of `sailfin_runtime_append_string`. The
+        // legacy `i8*` operand path passes through unchanged.
+        let mut value_at_string = value.value;
+        if value.llvm_type == "{i8*, i64}" {
+            let extract_temp = format_temp_name(current_temp);
+            current_lines.push("  " + extract_temp
+                + " = extractvalue {i8*, i64} "
+                + value.value
+                + ", 0");
+            current_temp += 1;
+            value_at_string = extract_temp;
+        }
         let pushed = format_temp_name(current_temp);
         current_temp += 1;
         // NOTE: Do not embed `{ ... }` literally in Sailfin strings; braces are
@@ -294,7 +308,7 @@ fn lower_array_push_in_place(array: LLVMOperand, value: LLVMOperand, element_typ
             + " "
             + array.value
             + ", i8* "
-            + value.value
+            + value_at_string
             + ")");
         let result_operand = LLVMOperand {
             llvm_type: array.llvm_type,

--- a/compiler/src/llvm/expression_lowering/native/core_index_lowering.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_index_lowering.sfn
@@ -93,8 +93,25 @@ fn lower_index_expression(parse: IndexExpressionParse, bindings: ParameterBindin
     let mut element_type: string = "";
     let mut is_heap_array: boolean = false;
     let mut is_string: boolean = false;
+    // M1.A: SfnString aggregate operands route through the same string
+    // index path as legacy `i8*` operands. Extract the data pointer up
+    // front so the existing grapheme_at call site below sees the
+    // pre-aggregate `i8*` shape unchanged.
+    let mut effective_base_operand = base_operand;
 
     if array_type == "i8*" {
+        element_type = "i8";
+        is_string = true;
+    } else if array_type == "{i8*, i64}" {
+        let extract_temp = format_temp_name(current_temp);
+        current_lines.push("  " + extract_temp + " = extractvalue {i8*, i64} "
+            + base_operand.value
+            + ", 0");
+        current_temp += 1;
+        effective_base_operand = LLVMOperand {
+            llvm_type: "i8*",
+            value: extract_temp
+        };
         element_type = "i8";
         is_string = true;
     } else if ends_with_pointer_suffix(array_type) {
@@ -186,7 +203,7 @@ fn lower_index_expression(parse: IndexExpressionParse, bindings: ParameterBindin
         let call_temp = format_temp_name(current_temp);
         current_lines = append_string(current_lines, "  " + call_temp
             + " = call i8* @sailfin_runtime_grapheme_at(i8* "
-            + base_operand.value
+            + effective_base_operand.value
             + ", double "
             + index_as_double.operand.value
             + ")");

--- a/compiler/src/llvm/expression_lowering/native/core_literals_lowering.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_literals_lowering.sfn
@@ -347,7 +347,18 @@ fn lower_array_literal(text: string, bindings: ParameterBinding[], locals: Local
             }
         }
         if !_keep_element_type {
-            inferred_element_type = dominant_type(inferred_element_type, lowered.operand.llvm_type);
+            // M1.A: collapse SfnString aggregate operand type to legacy
+            // `i8*` for inference. String-typed array slots stay on the
+            // pre-aggregate `i8**` shape until M1.A.2 ships the type-
+            // mapping flip; user `let xs = ["a", "b"]` (no annotation)
+            // must produce `string[]` with `i8*` element slots, not a
+            // novel `{i8*, i64}**` shape that would break existing array
+            // helpers and prelude.
+            let mut element_for_dominant = lowered.operand.llvm_type;
+            if trim_text(lowered.operand.llvm_type) == "{i8*, i64}" {
+                element_for_dominant = "i8*";
+            }
+            inferred_element_type = dominant_type(inferred_element_type, element_for_dominant);
         }
         index += 1;
     }
@@ -390,23 +401,38 @@ fn lower_array_literal(text: string, bindings: ParameterBinding[], locals: Local
         if ends_with_pointer_suffix(element_type) {
             if !ends_with_pointer_suffix(operand.llvm_type) {
                 if operand_is_aggregate {
-                    let boxed = box_aggregate_operand(operand, element_type, current_temp, current_lines, context);
-                    diagnostics = extend_string_array(diagnostics, boxed.diagnostics);
-                    current_lines = boxed.lines;
-                    current_temp = boxed.temp_index;
-                    if boxed.operand == null {
-                        diagnostics.push("llvm lowering: array literal element could not be boxed to `"
-                            + element_type
-                            + "`");
-                        return ExpressionResult {
-                            lines: current_lines,
-                            temp_index: current_temp,
-                            operand: null,
-                            diagnostics: diagnostics,
-                            string_constants: collected_string_constants
-                        };
+                    // M1.A: SfnString aggregate goes into a string-shaped
+                    // array slot (`element_type == "i8*"`) by unwrapping
+                    // the data pointer, NOT by boxing the aggregate. The
+                    // aggregate-as-array-element interpretation only
+                    // applies to user struct values; SfnString is a
+                    // value-typed string handle whose `data` is the
+                    // array's view.
+                    let mut should_unwrap_string: boolean = false;
+                    if trimmed_operand_type == "{i8*, i64}" {
+                        if element_type == "i8*" {
+                            should_unwrap_string = true;
+                        }
                     }
-                    prepared_operand = boxed.operand;
+                    if !should_unwrap_string {
+                        let boxed = box_aggregate_operand(operand, element_type, current_temp, current_lines, context);
+                        diagnostics = extend_string_array(diagnostics, boxed.diagnostics);
+                        current_lines = boxed.lines;
+                        current_temp = boxed.temp_index;
+                        if boxed.operand == null {
+                            diagnostics.push("llvm lowering: array literal element could not be boxed to `"
+                                + element_type
+                                + "`");
+                            return ExpressionResult {
+                                lines: current_lines,
+                                temp_index: current_temp,
+                                operand: null,
+                                diagnostics: diagnostics,
+                                string_constants: collected_string_constants
+                            };
+                        }
+                        prepared_operand = boxed.operand;
+                    }
                 }
             }
         }
@@ -980,19 +1006,32 @@ fn lower_enum_literal(parse: EnumLiteralParse, bindings: ParameterBinding[], loc
                     if ends_with_pointer_suffix(expected.llvm_type) {
                         if !ends_with_pointer_suffix(field_operand.llvm_type) {
                             if field_is_aggregate {
-                                let boxed = box_aggregate_operand(field_operand, expected.llvm_type, current_temp, current_lines, context);
-                                let mut _ci8: number = 0;
-                                loop {
-                                    if _ci8 >= boxed.diagnostics.length {
-                                        break;
+                                // M1.A: SfnString aggregate flowing into
+                                // an `i8*` struct field must be unwrapped
+                                // (extract data pointer), not boxed. Boxing
+                                // would store a {i8*, i64}* in the field
+                                // and break every legacy reader.
+                                let mut should_unwrap_string_field: boolean = false;
+                                if trimmed_field_type == "{i8*, i64}" {
+                                    if expected.llvm_type == "i8*" {
+                                        should_unwrap_string_field = true;
                                     }
-                                    diagnostics.push(boxed.diagnostics[_ci8]);
-                                    _ci8 += 1;
                                 }
-                                current_lines = boxed.lines;
-                                current_temp = boxed.temp_index;
-                                if boxed.operand != null {
-                                    field_operand = boxed.operand;
+                                if !should_unwrap_string_field {
+                                    let boxed = box_aggregate_operand(field_operand, expected.llvm_type, current_temp, current_lines, context);
+                                    let mut _ci8: number = 0;
+                                    loop {
+                                        if _ci8 >= boxed.diagnostics.length {
+                                            break;
+                                        }
+                                        diagnostics.push(boxed.diagnostics[_ci8]);
+                                        _ci8 += 1;
+                                    }
+                                    current_lines = boxed.lines;
+                                    current_temp = boxed.temp_index;
+                                    if boxed.operand != null {
+                                        field_operand = boxed.operand;
+                                    }
                                 }
                             }
                         }

--- a/compiler/src/llvm/expression_lowering/native/core_member_lowering.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_member_lowering.sfn
@@ -669,6 +669,29 @@ fn lower_member_access(parse: MemberAccessParse, bindings: ParameterBinding[], l
     }
 
     if parse.field == "length" {
+        // M1.A: SfnString aggregate `.length` is a direct `extractvalue`
+        // on the second slot — no NUL-walk, no runtime call. The legacy
+        // `i8*` branch below remains for string-typed locals/params,
+        // which still hold `i8*` until the M1.A.2 type-mapping flip.
+        if base_operand.llvm_type == "{i8*, i64}" {
+            let length_temp = format_temp_name(current_temp);
+            current_lines.push("  " + length_temp
+                + " = extractvalue {i8*, i64} "
+                + base_operand.value
+                + ", 1");
+            current_temp += 1;
+            let operand = LLVMOperand {
+                llvm_type: "i64",
+                value: length_temp
+            };
+            return ExpressionResult {
+                lines: current_lines,
+                temp_index: current_temp,
+                operand: operand,
+                diagnostics: diagnostics,
+                string_constants: collected_string_constants
+            };
+        }
         if base_operand.llvm_type == "i8*" {
             let length_temp = format_temp_name(current_temp);
             current_lines.push("  " + length_temp

--- a/compiler/src/llvm/expression_lowering/native/core_operands.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_operands.sfn
@@ -33,13 +33,6 @@ import {
 fn emit_comparison_instruction(symbol: string, left_operand: LLVMOperand, right_operand: LLVMOperand, temp_index: number, lines: string[]) -> ComparisonEmission {
     let mut diagnostics: string[] = [];
     let mut current_lines: string[] = lines;
-    if left_operand.llvm_type != right_operand.llvm_type {
-        diagnostics.push("llvm lowering: comparison operands have mismatched types `"
-            + left_operand.llvm_type
-            + "` and `"
-            + right_operand.llvm_type
-            + "`");
-    }
     let mut symbol_is_equality: boolean = false;
     let mut _if73: boolean = false;
     if symbol == "==" { _if73 = true; }
@@ -47,6 +40,24 @@ fn emit_comparison_instruction(symbol: string, left_operand: LLVMOperand, right_
     if _if73 { symbol_is_equality = true; }
     let left_is_string = is_string_pointer_type(left_operand.llvm_type);
     let right_is_string = is_string_pointer_type(right_operand.llvm_type);
+    if left_operand.llvm_type != right_operand.llvm_type {
+        // M1.A: literal-vs-local string comparisons cross the
+        // `i8*` / `{i8*, i64}` ABI line. The strings_equal path
+        // below extracts the data pointer from each side, so the
+        // mismatch is semantically benign; suppress the diagnostic
+        // for these mixed-shape string compares.
+        let mut both_string_shapes: boolean = false;
+        if left_is_string {
+            if right_is_string { both_string_shapes = true; }
+        }
+        if !both_string_shapes {
+            diagnostics.push("llvm lowering: comparison operands have mismatched types `"
+                + left_operand.llvm_type
+                + "` and `"
+                + right_operand.llvm_type
+                + "`");
+        }
+    }
     let left_is_null = left_operand.value == "null";
     let right_is_null = right_operand.value == "null";
     if symbol_is_equality {
@@ -54,14 +65,42 @@ fn emit_comparison_instruction(symbol: string, left_operand: LLVMOperand, right_
             if right_is_string {
                 if !left_is_null {
                     if !right_is_null {
-                        let compare_temp = format_temp_name(temp_index);
+                        // M1.A: `strings_equal` is still on the legacy
+                        // `i8*` ABI in this PR, so an aggregate operand
+                        // here needs its data pointer extracted before
+                        // the call. The slow `strlen`-based comparison
+                        // path remains correct because the aggregate's
+                        // data pointer is NUL-terminated by the literal
+                        // lowering.
+                        let mut next_index = temp_index;
+                        let mut left_ptr_value = left_operand.value;
+                        if left_operand.llvm_type == "{i8*, i64}" {
+                            let lext = format_temp_name(next_index);
+                            current_lines.push("  " + lext
+                                + " = extractvalue {i8*, i64} "
+                                + left_operand.value
+                                + ", 0");
+                            left_ptr_value = lext;
+                            next_index += 1;
+                        }
+                        let mut right_ptr_value = right_operand.value;
+                        if right_operand.llvm_type == "{i8*, i64}" {
+                            let rext = format_temp_name(next_index);
+                            current_lines.push("  " + rext
+                                + " = extractvalue {i8*, i64} "
+                                + right_operand.value
+                                + ", 0");
+                            right_ptr_value = rext;
+                            next_index += 1;
+                        }
+                        let compare_temp = format_temp_name(next_index);
                         current_lines.push("  " + compare_temp
                             + " = call i1 @strings_equal(i8* "
-                            + left_operand.value
+                            + left_ptr_value
                             + ", i8* "
-                            + right_operand.value
+                            + right_ptr_value
                             + ")");
-                        let mut next_index = temp_index + 1;
+                        next_index += 1;
                         let mut operand = LLVMOperand {
                             llvm_type: "i1",
                             value: compare_temp
@@ -200,6 +239,11 @@ fn comparison_predicate_for_symbol(symbol: string, llvm_type: string) -> string 
 
 fn is_string_pointer_type(llvm_type: string) -> boolean {
     if llvm_type == "i8*" { return true; }
+    // M1.A: SfnString aggregate is the new canonical string operand type.
+    // Binary `+` and `==` dispatch on this predicate, so the aggregate
+    // must read as a string here for `s + t` to route through
+    // emit_string_concat instead of degrading to a numeric `add`.
+    if llvm_type == "{i8*, i64}" { return true; }
     return false;
 }
 
@@ -690,6 +734,59 @@ fn coerce_numeric_primitive(operand: LLVMOperand, operand_type: string, target: 
 fn coerce_pointer_or_struct(operand: LLVMOperand, operand_type: string, target: string, temp_index: number, lines: string[]) -> CoercionResult? {
     let mut current_lines: string[] = lines;
     let mut diagnostics: string[] = [];
+
+    // M1.A: SfnString aggregate ↔ i8* bridges. The literal-lowering path
+    // produces `{i8*, i64}` for every string literal but most consumers
+    // (legacy `i8*`-shaped runtime helpers, untyped pointer slots) still
+    // expect `i8*`. The forward direction extracts the data pointer; the
+    // reverse direction wraps an `i8*` (e.g. an extern `char*` return)
+    // into the aggregate by recovering its length via strlen. These run
+    // before the generic boxing/load paths below, which would otherwise
+    // misinterpret the aggregate as a pointer-to-struct.
+    if operand_type == "{i8*, i64}" {
+        if target == "i8*" {
+            let temp_name = format_temp_name(temp_index);
+            current_lines.push("  " + temp_name + " = extractvalue {i8*, i64} "
+                + operand.value
+                + ", 0");
+            let coerced = LLVMOperand { llvm_type: "i8*", value: temp_name };
+            return CoercionResult {
+                lines: current_lines,
+                temp_index: temp_index + 1,
+                operand: coerced,
+                diagnostics: diagnostics
+            };
+        }
+    }
+    if operand_type == "i8*" {
+        if target == "{i8*, i64}" {
+            let len_temp = format_temp_name(temp_index);
+            current_lines.push("  " + len_temp
+                + " = call i64 @sailfin_runtime_string_length(i8* "
+                + operand.value
+                + ")");
+            let agg0 = format_temp_name(temp_index + 1);
+            current_lines.push("  " + agg0
+                + " = insertvalue {i8*, i64} undef, i8* "
+                + operand.value
+                + ", 0");
+            let agg1 = format_temp_name(temp_index + 2);
+            current_lines.push("  " + agg1 + " = insertvalue {i8*, i64} " + agg0
+                + ", i64 "
+                + len_temp
+                + ", 1");
+            let coerced = LLVMOperand {
+                llvm_type: "{i8*, i64}",
+                value: agg1
+            };
+            return CoercionResult {
+                lines: current_lines,
+                temp_index: temp_index + 3,
+                operand: coerced,
+                diagnostics: diagnostics
+            };
+        }
+    }
 
     if target == "i8*" {
         if operand_type != "i8*" {

--- a/compiler/src/llvm/expression_lowering/native/core_ops_lowering.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_ops_lowering.sfn
@@ -301,117 +301,55 @@ fn lower_binary_operation(expression: string, match: OperatorMatch, bindings: Pa
         let rhs = right_result.operand;
         let lhs_type = trim_text(lhs.llvm_type);
         let rhs_type = trim_text(rhs.llvm_type);
-        if lhs_type == "i8*" {
-            if rhs_type == "i8*" {
-                let mut current_lines = right_result.lines;
-                let mut current_temp = right_result.temp_index;
-                let concat_name = format_temp_name(current_temp);
-                current_temp += 1;
-                current_lines.push("  " + concat_name
-                    + " = call i8* @sailfin_runtime_string_concat(i8* "
-                    + lhs.value
-                    + ", i8* "
-                    + rhs.value
-                    + ")");
-                let operand = LLVMOperand {
-                    llvm_type: "i8*",
-                    value: concat_name
-                };
-                return ExpressionResult {
-                    lines: current_lines,
-                    temp_index: current_temp,
-                    operand: operand,
-                    diagnostics: diagnostics,
-                    string_constants: string_constants
-                };
-            }
+
+        // M1.A: unified string-concat path. Any combination of string-shaped
+        // (`i8*` or `{i8*, i64}`) and byte-shaped (`i8`, treated as a single
+        // codepoint stringification target) operands route through one
+        // emission that:
+        //   1. coerces each side to `i8*` first (handles i8 → i8*
+        //      stringification through the existing numeric-stringify path),
+        //   2. coerces each `i8*` to the `{i8*, i64}` aggregate via the
+        //      shim in `core_operands.sfn` (recovers length via strlen),
+        //   3. emits `call i8* @sailfin_runtime_string_concat_v2({i8*, i64}, {i8*, i64})`
+        //      against the locked M1.A registry signature.
+        // i8+i8 and any-side-is-string both fall through here.
+        let mut lhs_is_string_or_byte: boolean = false;
+        if lhs_type == "i8*" { lhs_is_string_or_byte = true; }
+        if lhs_type == "{i8*, i64}" { lhs_is_string_or_byte = true; }
+        if lhs_type == "i8" { lhs_is_string_or_byte = true; }
+        let mut rhs_is_string_or_byte: boolean = false;
+        if rhs_type == "i8*" { rhs_is_string_or_byte = true; }
+        if rhs_type == "{i8*, i64}" { rhs_is_string_or_byte = true; }
+        if rhs_type == "i8" { rhs_is_string_or_byte = true; }
+        let mut lhs_is_string_shape: boolean = false;
+        if lhs_type == "i8*" { lhs_is_string_shape = true; }
+        if lhs_type == "{i8*, i64}" { lhs_is_string_shape = true; }
+        let mut rhs_is_string_shape: boolean = false;
+        if rhs_type == "i8*" { rhs_is_string_shape = true; }
+        if rhs_type == "{i8*, i64}" { rhs_is_string_shape = true; }
+
+        let mut should_concat: boolean = false;
+        if lhs_is_string_shape {
+            if rhs_is_string_or_byte { should_concat = true; }
         }
-        if lhs_type == "i8*" {
-            if rhs_type == "i8" {
-                let mut current_lines = right_result.lines;
-                let mut current_temp = right_result.temp_index;
-                let coerced = coerce_operand_to_type(rhs, "i8*", current_temp, current_lines);
-                diagnostics = extend_string_array(diagnostics, coerced.diagnostics);
-                current_lines = coerced.lines;
-                current_temp = coerced.temp_index;
-                if coerced.operand == null {
-                    return ExpressionResult {
-                        lines: current_lines,
-                        temp_index: current_temp,
-                        operand: null,
-                        diagnostics: diagnostics,
-                        string_constants: string_constants
-                    };
-                }
-
-                let concat_name = format_temp_name(current_temp);
-                current_temp += 1;
-                current_lines.push("  " + concat_name
-                    + " = call i8* @sailfin_runtime_string_concat(i8* "
-                    + lhs.value
-                    + ", i8* "
-                    + coerced.operand.value
-                    + ")");
-
-                let operand = LLVMOperand {
-                    llvm_type: "i8*",
-                    value: concat_name
-                };
-                return ExpressionResult {
-                    lines: current_lines,
-                    temp_index: current_temp,
-                    operand: operand,
-                    diagnostics: diagnostics,
-                    string_constants: string_constants
-                };
-            }
+        if rhs_is_string_shape {
+            if lhs_is_string_or_byte { should_concat = true; }
         }
         if lhs_type == "i8" {
-            if rhs_type == "i8*" {
-                let mut current_lines = right_result.lines;
-                let mut current_temp = right_result.temp_index;
-                let coerced = coerce_operand_to_type(lhs, "i8*", current_temp, current_lines);
-                diagnostics = extend_string_array(diagnostics, coerced.diagnostics);
-                current_lines = coerced.lines;
-                current_temp = coerced.temp_index;
-                if coerced.operand == null {
-                    return ExpressionResult {
-                        lines: current_lines,
-                        temp_index: current_temp,
-                        operand: null,
-                        diagnostics: diagnostics,
-                        string_constants: string_constants
-                    };
-                }
-
-                let concat_name = format_temp_name(current_temp);
-                current_temp += 1;
-                current_lines.push("  " + concat_name
-                    + " = call i8* @sailfin_runtime_string_concat(i8* "
-                    + coerced.operand.value
-                    + ", i8* "
-                    + rhs.value
-                    + ")");
-
-                let operand = LLVMOperand {
-                    llvm_type: "i8*",
-                    value: concat_name
-                };
-                return ExpressionResult {
-                    lines: current_lines,
-                    temp_index: current_temp,
-                    operand: operand,
-                    diagnostics: diagnostics,
-                    string_constants: string_constants
-                };
-            }
+            if rhs_type == "i8" { should_concat = true; }
         }
 
-        if lhs_type == "i8" {
-            if rhs_type == "i8" {
-                let mut current_lines = right_result.lines;
-                let mut current_temp = right_result.temp_index;
+        if should_concat {
+            let mut current_lines = right_result.lines;
+            let mut current_temp = right_result.temp_index;
 
+            // Step 1: ensure both sides are at least `i8*`. For aggregate
+            // operands this is a no-op shim (extract data ptr); for byte
+            // (i8) operands it routes through the existing numeric-to-
+            // string path. Skip the i8* round-trip for already-aggregate
+            // operands so we don't pay the unnecessary extract.
+            let mut lhs_at_string = lhs;
+            if lhs_type != "{i8*, i64}" {
                 let lhs_coerced = coerce_operand_to_type(lhs, "i8*", current_temp, current_lines);
                 diagnostics = extend_string_array(diagnostics, lhs_coerced.diagnostics);
                 current_lines = lhs_coerced.lines;
@@ -425,7 +363,10 @@ fn lower_binary_operation(expression: string, match: OperatorMatch, bindings: Pa
                         string_constants: string_constants
                     };
                 }
-
+                lhs_at_string = lhs_coerced.operand;
+            }
+            let mut rhs_at_string = rhs;
+            if rhs_type != "{i8*, i64}" {
                 let rhs_coerced = coerce_operand_to_type(rhs, "i8*", current_temp, current_lines);
                 diagnostics = extend_string_array(diagnostics, rhs_coerced.diagnostics);
                 current_lines = rhs_coerced.lines;
@@ -439,42 +380,15 @@ fn lower_binary_operation(expression: string, match: OperatorMatch, bindings: Pa
                         string_constants: string_constants
                     };
                 }
-
-                let concat_name = format_temp_name(current_temp);
-                current_temp += 1;
-                current_lines.push("  " + concat_name
-                    + " = call i8* @sailfin_runtime_string_concat(i8* "
-                    + lhs_coerced.operand.value
-                    + ", i8* "
-                    + rhs_coerced.operand.value
-                    + ")");
-
-                let operand = LLVMOperand {
-                    llvm_type: "i8*",
-                    value: concat_name
-                };
-                return ExpressionResult {
-                    lines: current_lines,
-                    temp_index: current_temp,
-                    operand: operand,
-                    diagnostics: diagnostics,
-                    string_constants: string_constants
-                };
+                rhs_at_string = rhs_coerced.operand;
             }
-        }
 
-        let mut _if96: boolean = false;
-        if lhs_type == "i8*" { _if96 = true; }
-        if rhs_type == "i8*" { _if96 = true; }
-        if _if96 {
-            let mut current_lines = right_result.lines;
-            let mut current_temp = right_result.temp_index;
-
-            let lhs_coerced = coerce_operand_to_type(lhs, "i8*", current_temp, current_lines);
-            diagnostics = extend_string_array(diagnostics, lhs_coerced.diagnostics);
-            current_lines = lhs_coerced.lines;
-            current_temp = lhs_coerced.temp_index;
-            if lhs_coerced.operand == null {
+            // Step 2: lift both sides to the {i8*, i64} aggregate.
+            let lhs_agg = coerce_operand_to_type(lhs_at_string, "{i8*, i64}", current_temp, current_lines);
+            diagnostics = extend_string_array(diagnostics, lhs_agg.diagnostics);
+            current_lines = lhs_agg.lines;
+            current_temp = lhs_agg.temp_index;
+            if lhs_agg.operand == null {
                 return ExpressionResult {
                     lines: current_lines,
                     temp_index: current_temp,
@@ -483,12 +397,11 @@ fn lower_binary_operation(expression: string, match: OperatorMatch, bindings: Pa
                     string_constants: string_constants
                 };
             }
-
-            let rhs_coerced = coerce_operand_to_type(rhs, "i8*", current_temp, current_lines);
-            diagnostics = extend_string_array(diagnostics, rhs_coerced.diagnostics);
-            current_lines = rhs_coerced.lines;
-            current_temp = rhs_coerced.temp_index;
-            if rhs_coerced.operand == null {
+            let rhs_agg = coerce_operand_to_type(rhs_at_string, "{i8*, i64}", current_temp, current_lines);
+            diagnostics = extend_string_array(diagnostics, rhs_agg.diagnostics);
+            current_lines = rhs_agg.lines;
+            current_temp = rhs_agg.temp_index;
+            if rhs_agg.operand == null {
                 return ExpressionResult {
                     lines: current_lines,
                     temp_index: current_temp,
@@ -501,10 +414,10 @@ fn lower_binary_operation(expression: string, match: OperatorMatch, bindings: Pa
             let concat_name = format_temp_name(current_temp);
             current_temp += 1;
             current_lines.push("  " + concat_name
-                + " = call i8* @sailfin_runtime_string_concat(i8* "
-                + lhs_coerced.operand.value
-                + ", i8* "
-                + rhs_coerced.operand.value
+                + " = call i8* @sailfin_runtime_string_concat_v2({i8*, i64} "
+                + lhs_agg.operand.value
+                + ", {i8*, i64} "
+                + rhs_agg.operand.value
                 + ")");
             let operand = LLVMOperand {
                 llvm_type: "i8*",
@@ -680,19 +593,56 @@ fn lower_binary_operation(expression: string, match: OperatorMatch, bindings: Pa
     let right_aligned = harmonised.right;
     let result_type = trim_text(harmonised.result_type);
     if match.symbol == "+" {
-        if result_type == "i8*" {
-            let temp_name = format_temp_name(harmonised.temp_index);
+        // M1.A: post-harmonise string fallback. The unified concat path
+        // higher up handles every literal/aggregate combination, but the
+        // legacy harmonise + dispatch path can still land here when both
+        // sides resolve to plain `i8*` (string-typed locals/params). Lift
+        // both to the {i8*, i64} aggregate ABI before calling the helper
+        // so the IR matches the registry signature.
+        let mut should_concat_aligned: boolean = false;
+        if result_type == "i8*" { should_concat_aligned = true; }
+        if result_type == "{i8*, i64}" { should_concat_aligned = true; }
+        if should_concat_aligned {
+            let mut current_lines = harmonised.lines;
+            let mut current_temp = harmonised.temp_index;
+            let lhs_agg = coerce_operand_to_type(left_aligned, "{i8*, i64}", current_temp, current_lines);
+            diagnostics = extend_string_array(diagnostics, lhs_agg.diagnostics);
+            current_lines = lhs_agg.lines;
+            current_temp = lhs_agg.temp_index;
+            if lhs_agg.operand == null {
+                return ExpressionResult {
+                    lines: current_lines,
+                    temp_index: current_temp,
+                    operand: null,
+                    diagnostics: diagnostics,
+                    string_constants: string_constants
+                };
+            }
+            let rhs_agg = coerce_operand_to_type(right_aligned, "{i8*, i64}", current_temp, current_lines);
+            diagnostics = extend_string_array(diagnostics, rhs_agg.diagnostics);
+            current_lines = rhs_agg.lines;
+            current_temp = rhs_agg.temp_index;
+            if rhs_agg.operand == null {
+                return ExpressionResult {
+                    lines: current_lines,
+                    temp_index: current_temp,
+                    operand: null,
+                    diagnostics: diagnostics,
+                    string_constants: string_constants
+                };
+            }
+            let temp_name = format_temp_name(current_temp);
             let line = "  " + temp_name
-                + " = call i8* @sailfin_runtime_string_concat(i8* "
-                + left_aligned.value
-                + ", i8* "
-                + right_aligned.value
+                + " = call i8* @sailfin_runtime_string_concat_v2({i8*, i64} "
+                + lhs_agg.operand.value
+                + ", {i8*, i64} "
+                + rhs_agg.operand.value
                 + ")";
-            let updated_lines = append_string(harmonised.lines, line);
+            current_lines.push(line);
             let operand = LLVMOperand { llvm_type: "i8*", value: temp_name };
             return ExpressionResult {
-                lines: updated_lines,
-                temp_index: harmonised.temp_index + 1,
+                lines: current_lines,
+                temp_index: current_temp + 1,
                 operand: operand,
                 diagnostics: diagnostics,
                 string_constants: string_constants

--- a/compiler/src/llvm/expression_lowering/native/core_strings.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_strings.sfn
@@ -9,27 +9,34 @@ import { coerce_operand_to_type, harmonise_operands } from "./core_operands";
 import { unescape_string_literal } from "./core_text";
 
 fn lower_string_literal(literal: string, temp_index: number, lines: string[]) -> ExpressionResult {
-    // Stage2-native note:
-    // The original lowering model used global string constants (@.str.len...).
-    // Stage2's struct-return plumbing can drop the collected constant table,
-    // yielding link-time failures (undefined @.str.*). To keep emitted LLVM
-    // self-contained and clang-linkable, we materialize literals into a
-    // runtime-allocated buffer via store of an inline constant array. The
-    // buffer is allocated through `sailfin_runtime_alloc_struct`, which
-    // routes through the bump-allocator arena when enabled (default-on
-    // for selfhost / installed binaries) and falls through to libc calloc
-    // otherwise. Arena routing lets multi-module in-process drivers
-    // (`sfn check <dir>`, `sfn test`, future `sfn lsp`) reclaim per-
-    // iteration literal storage via `runtime.arena_rewind`. The previous
-    // raw `@calloc` was the original Phase 5a leak: every
-    // `is_trivia_token` / `strings_equal` call re-allocated its
-    // comparison strings and the mark/rewind primitive could not reach
-    // them, blowing peak RSS past the 2 GB Phase 5a target on
-    // `sfn check compiler/src/`.
+    // M1.A — String literal lowering to {i8*, i64} aggregate.
+    //
+    // The literal materializes in three layers:
+    //   1. A runtime-allocated byte buffer holds the UTF-8 contents (plus
+    //      a trailing NUL so legacy `i8*`-shaped helpers downstream of a
+    //      data-pointer extract keep working until M2.4).
+    //   2. The buffer pointer + literal byte length are packed into an
+    //      `{i8*, i64}` aggregate via two `insertvalue` ops on `undef`.
+    //   3. The aggregate is the literal's result operand. Consumers that
+    //      still expect `i8*` (most legacy helpers, string-typed locals
+    //      until M1.A.2 ships) extract the data pointer via the
+    //      `coerce_pointer_or_struct` shim in core_operands.sfn.
+    //
+    // Why keep the alloc/store/NUL pattern? The alloc routes through the
+    // bump-allocator arena (default-on for selfhost / installed binaries)
+    // and lets multi-module in-process drivers (`sfn check <dir>`,
+    // `sfn test`, future `sfn lsp`) reclaim per-iteration literal storage
+    // via `runtime.arena_rewind`. Globals (`@.str.N`) have a known Phase 5a
+    // gap — Stage2's struct-return plumbing can drop the collected constant
+    // table, yielding link-time failures. The trailing NUL is one byte
+    // over-allocated past `len`; it costs us nothing and bridges the
+    // aggregate ABI to legacy NUL-terminated C bodies during the M1→M2.4
+    // transition.
     let content = unescape_string_literal(literal);
     let escaped = escape_string_for_llvm(content);
     let array_length = content.length + 1;
     let array_type = "[" + number_to_string(array_length) + " x i8]";
+    let byte_count = content.length;
 
     let mut current_lines: string[] = lines;
     let malloc_temp = format_temp_name(temp_index);
@@ -47,11 +54,26 @@ fn lower_string_literal(literal: string, temp_index: number, lines: string[]) ->
         + "* "
         + cast_temp);
 
-    let operand = LLVMOperand { llvm_type: "i8*", value: malloc_temp };
+    let agg_data_temp = format_temp_name(temp_index + 2);
+    current_lines.push("  " + agg_data_temp
+        + " = insertvalue {i8*, i64} undef, i8* "
+        + malloc_temp
+        + ", 0");
+    let agg_full_temp = format_temp_name(temp_index + 3);
+    current_lines.push("  " + agg_full_temp + " = insertvalue {i8*, i64} "
+        + agg_data_temp
+        + ", i64 "
+        + number_to_string(byte_count)
+        + ", 1");
+
+    let operand = LLVMOperand {
+        llvm_type: "{i8*, i64}",
+        value: agg_full_temp
+    };
     let empty_constants = empty_string_constant_set();
     return ExpressionResult {
         lines: current_lines,
-        temp_index: temp_index + 2,
+        temp_index: temp_index + 4,
         operand: operand,
         diagnostics: [],
         string_constants: empty_constants
@@ -72,7 +94,16 @@ fn emit_string_concat(left: LLVMOperand, right: LLVMOperand, temp_index: number,
             string_constants: empty_string_constant_set()
         };
     }
-    let left_aligned = coerce_operand_to_type(harmonised.left, "i8*", harmonised.temp_index, harmonised.lines);
+    // M1.A: both operands are coerced to the {i8*, i64} aggregate ABI.
+    // Literals already arrive as aggregates; legacy i8* operands (string
+    // locals/params, numeric stringification) are wrapped via the i8* →
+    // {i8*, i64} shim in core_operands.sfn (which recovers length via
+    // sailfin_runtime_string_length). The C wrapper for
+    // `sailfin_runtime_string_concat` extracts the data pointers and
+    // forwards to the legacy NUL-terminated impl until M2.4 ships
+    // length-aware bodies. Return type stays `i8*` so downstream
+    // legacy-shape consumers don't need updating in this PR.
+    let left_aligned = coerce_operand_to_type(harmonised.left, "{i8*, i64}", harmonised.temp_index, harmonised.lines);
     let mut diagnostics: string[] = harmonised.diagnostics;
     let mut _ci0: number = 0;
     loop {
@@ -80,7 +111,7 @@ fn emit_string_concat(left: LLVMOperand, right: LLVMOperand, temp_index: number,
         diagnostics.push(left_aligned.diagnostics[_ci0]);
         _ci0 += 1;
     }
-    let right_aligned = coerce_operand_to_type(harmonised.right, "i8*", left_aligned.temp_index, left_aligned.lines);
+    let right_aligned = coerce_operand_to_type(harmonised.right, "{i8*, i64}", left_aligned.temp_index, left_aligned.lines);
     let mut _ci1: number = 0;
     loop {
         if _ci1 >= right_aligned.diagnostics.length { break; }
@@ -101,9 +132,9 @@ fn emit_string_concat(left: LLVMOperand, right: LLVMOperand, temp_index: number,
     }
     let temp_name = format_temp_name(right_aligned.temp_index);
     let line = "  " + temp_name
-        + " = call i8* @sailfin_runtime_string_concat(i8* "
+        + " = call i8* @sailfin_runtime_string_concat_v2({i8*, i64} "
         + left_aligned.operand.value
-        + ", i8* "
+        + ", {i8*, i64} "
         + right_aligned.operand.value
         + ")";
     let mut out_lines = append_string(right_aligned.lines, line);

--- a/compiler/src/llvm/lowering/instructions_let.sfn
+++ b/compiler/src/llvm/lowering/instructions_let.sfn
@@ -238,6 +238,23 @@ fn lower_let_instruction(function: NativeFunction, instruction: NativeInstructio
             }
             let operand_type = trim_text(operand.llvm_type);
             if operand_type.length > 0 { llvm_type = operand_type; }
+            // M1.A: SfnString aggregate operands (e.g. unannotated
+            // `let s = "hello"`) collapse the local's storage type to
+            // `i8*` for now. Locals/parameters stay on the legacy
+            // pre-aggregate shape until M1.A.2 ships the type-mapping
+            // flip; without this clamp, downstream `mut module_line =
+            // module_line + ...` reassignments would store the i8*
+            // concat result back into a `{i8*, i64}` alloca, producing
+            // a strlen-then-insertvalue round-trip on every iteration
+            // and (worse) breaking cross-module shape contracts that
+            // the seed compiler still wires up as `i8*`. The literal
+            // expression itself remains a `{i8*, i64}` constant in the
+            // IR — the let-binding coerces it down via the
+            // `coerce_pointer_or_struct` shim. The direct-`extractvalue`
+            // `.length` path therefore applies to fresh literal
+            // expressions (e.g. `"hello".length`), not to stored-then-
+            // loaded locals.
+            if llvm_type == "{i8*, i64}" { llvm_type = "i8*"; }
         }
     }
 

--- a/compiler/src/llvm/runtime_helpers.sfn
+++ b/compiler/src/llvm/runtime_helpers.sfn
@@ -309,8 +309,18 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
         target: "string.length", symbol: "sailfin_runtime_string_length", return_type: "i64", parameter_types: ["i8*"], effects: []
     });
+    // M1.A — string.concat parameters lock to the SfnString aggregate
+    // ABI. The new symbol `sailfin_runtime_string_concat_v2` accepts
+    // `{i8*, i64}` by value; its body extracts the data pointers and
+    // forwards to the legacy NUL-terminated `sailfin_runtime_string_concat`
+    // implementation until M2.4 ships a length-aware body. The `_v2`
+    // suffix is a transition aid: seed-compiled IR (which still emits
+    // `call i8* @sailfin_runtime_string_concat(i8*, i8*)`) keeps linking
+    // through the legacy entrypoint while the new compiler routes here.
+    // Return type stays `i8*` because string-typed locals don't flip to
+    // aggregate until M1.A.2.
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "string.concat", symbol: "sailfin_runtime_string_concat", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: []
+        target: "string.concat", symbol: "sailfin_runtime_string_concat_v2", return_type: "i8*", parameter_types: ["{i8*, i64}", "{i8*, i64}"], effects: []
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
         target: "string.append", symbol: "sailfin_runtime_string_append", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: []

--- a/compiler/tests/e2e/fixtures/string_aggregate_shape.sfn
+++ b/compiler/tests/e2e/fixtures/string_aggregate_shape.sfn
@@ -1,0 +1,22 @@
+// Fixture for compiler/tests/e2e/test_string_aggregate_shape.sh.
+//
+// Pins the M1.A string-literal ABI shape: every string literal lowers
+// to an `{i8*, i64}` aggregate, the `.length` field on a fresh literal
+// expression resolves to a direct `extractvalue` of slot 1 (no
+// `sailfin_runtime_string_length` call), and `+` on string literals
+// forwards both sides as aggregates to `@sailfin_runtime_string_concat`.
+//
+// Both `"hello"` and `"world"` are intentionally 5 bytes — the test
+// uses the `i64 5` immediate as a regression guard against the literal
+// length being miscounted (e.g. NUL accidentally included).
+//
+// Note: the M1.A scope keeps unannotated string-typed locals on the
+// legacy `i8*` shape (full local-shape flip lives in M1.A.2). Direct
+// literal usage exercises the aggregate operand path without crossing
+// that boundary.
+fn main() ![io] {
+    let h_len = "hello".length;
+    let w_len = "world".length;
+    let combined = "hello" + "world";
+    print.info(combined);
+}

--- a/compiler/tests/e2e/fixtures/string_aggregate_shape.sfn
+++ b/compiler/tests/e2e/fixtures/string_aggregate_shape.sfn
@@ -4,7 +4,11 @@
 // to an `{i8*, i64}` aggregate, the `.length` field on a fresh literal
 // expression resolves to a direct `extractvalue` of slot 1 (no
 // `sailfin_runtime_string_length` call), and `+` on string literals
-// forwards both sides as aggregates to `@sailfin_runtime_string_concat`.
+// forwards both sides as aggregates to
+// `@sailfin_runtime_string_concat_v2`. The `_v2` suffix is a transition
+// aid — the legacy `sailfin_runtime_string_concat(char*, char*)`
+// entrypoint stays exported so seed-compiled IR keeps linking until the
+// floor seed embeds the new ABI.
 //
 // Both `"hello"` and `"world"` are intentionally 5 bytes — the test
 // uses the `i64 5` immediate as a regression guard against the literal

--- a/compiler/tests/e2e/test_string_aggregate_shape.sh
+++ b/compiler/tests/e2e/test_string_aggregate_shape.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# End-to-end test for the M1.A string-literal ABI lock (issue #391).
+#
+# Pins the emitted LLVM IR contract for string literals:
+#   - Literals lower to `{i8*, i64}` aggregates (data ptr + byte length).
+#   - `s.length` resolves to a direct `extractvalue ..., 1` (no
+#     `sailfin_runtime_string_length` call).
+#   - `+` on strings emits
+#     `call i8* @sailfin_runtime_string_concat({i8*, i64} ..., {i8*, i64} ...)`.
+#   - No consumer re-extracts a literal as `[N x i8]` (regression guard
+#     against the legacy `bitcast i8* to [N x i8]*` consumer pattern).
+#
+# Usage:
+#   compiler/tests/e2e/test_string_aggregate_shape.sh <compiler-binary>
+
+set -euo pipefail
+
+BINARY="${1:?usage: test_string_aggregate_shape.sh <compiler-binary>}"
+BINARY="$(realpath "$BINARY")"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FIXTURE="$SCRIPT_DIR/fixtures/string_aggregate_shape.sfn"
+
+PASS=0
+FAIL=0
+
+SCRATCH="$(mktemp -d -t sfn-string-shape-XXXXXX)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+LL="$SCRATCH/string_aggregate_shape.ll"
+
+run_test() {
+    local name="$1"
+    shift
+    if "$@"; then
+        echo "[test] PASS: $name"
+        PASS=$((PASS + 1))
+    else
+        echo "[test] FAIL: $name"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+emit_ir_once() {
+    if [ -s "$LL" ]; then
+        return 0
+    fi
+    if ! "$BINARY" emit -o "$LL" llvm "$FIXTURE" > "$SCRATCH/emit.stderr" 2>&1; then
+        echo "[test]   sfn emit llvm failed for string_aggregate_shape.sfn"
+        sed 's/^/[test]     /' "$SCRATCH/emit.stderr" | head -20
+        return 1
+    fi
+    return 0
+}
+
+# A1 — Aggregate type appears in the emitted IR.
+test_aggregate_type_appears() {
+    emit_ir_once || return 1
+    local hits
+    hits="$(grep -cE '\{i8\*, i64\}' "$LL" || true)"
+    if [ "${hits:-0}" -lt 4 ]; then
+        echo "[test]   expected at least 4 references to {i8*, i64}, got ${hits:-0}"
+        return 1
+    fi
+    return 0
+}
+
+# A2 — Each literal builds the aggregate via two `insertvalue` ops.
+# The fixture writes "hello".length, "world".length, "hello" + "world", and
+# `print.info(combined)` — four string literals total (.length on a literal
+# still constructs the aggregate, then extracts slot 1).
+test_literal_uses_insertvalue() {
+    emit_ir_once || return 1
+    local data_inserts
+    data_inserts="$(grep -cE '= insertvalue \{i8\*, i64\} undef, i8\*' "$LL" || true)"
+    if [ "${data_inserts:-0}" -ne 4 ]; then
+        echo "[test]   expected 4 'insertvalue {i8*, i64} undef, i8*' lines, got ${data_inserts:-0}"
+        return 1
+    fi
+    return 0
+}
+
+# A3 — Literal byte length is encoded as `i64 5, 1` (both `"hello"` and
+# `"world"` are 5 bytes; the fixture uses each twice).
+test_literal_length_is_correct() {
+    emit_ir_once || return 1
+    local len_inserts
+    len_inserts="$(grep -cE '= insertvalue \{i8\*, i64\} %[A-Za-z_0-9]+, i64 5, 1' "$LL" || true)"
+    if [ "${len_inserts:-0}" -ne 4 ]; then
+        echo "[test]   expected 4 length-slot inserts with 'i64 5, 1', got ${len_inserts:-0}"
+        return 1
+    fi
+    return 0
+}
+
+# A4 — `s.length` resolves to direct `extractvalue` (no runtime call).
+test_length_is_direct_extractvalue() {
+    emit_ir_once || return 1
+    local extracts
+    extracts="$(grep -cE '= extractvalue \{i8\*, i64\} %[A-Za-z_0-9]+, 1' "$LL" || true)"
+    if [ "${extracts:-0}" -lt 1 ]; then
+        echo "[test]   expected at least one 'extractvalue {i8*, i64} ..., 1' line, got ${extracts:-0}"
+        return 1
+    fi
+    local string_length_calls
+    string_length_calls="$(grep -cE 'call .* @sailfin_runtime_string_length\(' "$LL" || true)"
+    if [ "${string_length_calls:-0}" -ne 0 ]; then
+        echo "[test]   regression: literal-only fixture should not call @sailfin_runtime_string_length"
+        return 1
+    fi
+    return 0
+}
+
+# A5 — No consumer treats the literal as `[N x i8]*` after the aggregate flip.
+# The literal lowering still does an internal `bitcast i8* %buf to [N x i8]*`
+# for the byte-array store; that bitcast is scaffolding inside the literal,
+# not a consumer pattern. The negative assertion targets `extractvalue` /
+# `getelementptr` on `[N x i8]` types — which would only appear if a
+# consumer reverted to treating the literal's *result* as an array pointer.
+test_no_array_consumer_pattern() {
+    emit_ir_once || return 1
+    local array_extracts
+    array_extracts="$(grep -cE 'extractvalue \[[0-9]+ x i8\]' "$LL" || true)"
+    if [ "${array_extracts:-0}" -ne 0 ]; then
+        echo "[test]   regression: found extractvalue on [N x i8] aggregate"
+        return 1
+    fi
+    return 0
+}
+
+# A6 — `string.concat` declared with aggregate parameter shape and called
+# the same way. The new compiler routes through
+# `sailfin_runtime_string_concat_v2` (SfnString-by-value); the legacy
+# `sailfin_runtime_string_concat(char*, char*)` entrypoint is kept link-
+# stable for seed-compiled IR until the floor seed bumps.
+test_string_concat_uses_aggregate_abi() {
+    emit_ir_once || return 1
+    local declared
+    declared="$(grep -cE '^declare i8\* @sailfin_runtime_string_concat_v2\(\{i8\*, i64\}, \{i8\*, i64\}\)' "$LL" || true)"
+    if [ "${declared:-0}" -ne 1 ]; then
+        echo "[test]   expected exactly one aggregate-shape declare for sailfin_runtime_string_concat_v2, got ${declared:-0}"
+        return 1
+    fi
+    local called
+    called="$(grep -cE 'call i8\* @sailfin_runtime_string_concat_v2\(\{i8\*, i64\} ' "$LL" || true)"
+    if [ "${called:-0}" -lt 1 ]; then
+        echo "[test]   expected at least one aggregate-shape call to sailfin_runtime_string_concat_v2, got ${called:-0}"
+        return 1
+    fi
+    local legacy_v2_called
+    legacy_v2_called="$(grep -cE 'call i8\* @sailfin_runtime_string_concat_v2\(i8\* ' "$LL" || true)"
+    if [ "${legacy_v2_called:-0}" -ne 0 ]; then
+        echo "[test]   regression: legacy i8*-shaped call to sailfin_runtime_string_concat_v2 emitted"
+        return 1
+    fi
+    return 0
+}
+
+run_test "literal lowers to {i8*, i64} aggregate" \
+    test_aggregate_type_appears
+run_test "literal builds aggregate via two insertvalue ops" \
+    test_literal_uses_insertvalue
+run_test "literal byte-length is i64 N, not N+1" \
+    test_literal_length_is_correct
+run_test "s.length is a direct extractvalue, no string_length call" \
+    test_length_is_direct_extractvalue
+run_test "no consumer extracts the literal as [N x i8]" \
+    test_no_array_consumer_pattern
+run_test "string.concat uses {i8*, i64} aggregate ABI" \
+    test_string_concat_uses_aggregate_abi
+
+echo "[summary] $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi

--- a/compiler/tests/e2e/test_string_aggregate_shape.sh
+++ b/compiler/tests/e2e/test_string_aggregate_shape.sh
@@ -6,7 +6,11 @@
 #   - `s.length` resolves to a direct `extractvalue ..., 1` (no
 #     `sailfin_runtime_string_length` call).
 #   - `+` on strings emits
-#     `call i8* @sailfin_runtime_string_concat({i8*, i64} ..., {i8*, i64} ...)`.
+#     `call i8* @sailfin_runtime_string_concat_v2({i8*, i64} ..., {i8*, i64} ...)`.
+#     The `_v2` suffix is a transition aid: the legacy
+#     `sailfin_runtime_string_concat(char*, char*)` entrypoint stays
+#     link-stable for seed-compiled IR until the floor seed embeds the
+#     new ABI, then both can retire together.
 #   - No consumer re-extracts a literal as `[N x i8]` (regression guard
 #     against the legacy `bitcast i8* to [N x i8]*` consumer pattern).
 #

--- a/runtime/native/include/sailfin_runtime.h
+++ b/runtime/native/include/sailfin_runtime.h
@@ -19,6 +19,17 @@ extern "C"
         int64_t len;
     } SailfinPtrArray;
 
+    // Matches LLVM `{ i8*, i64 }` — the M1 ABI shape for SfnString
+    // (UTF-8 bytes + byte length). See docs/runtime_architecture.md §2.2.1.
+    // M1.A locks the call-boundary shape; bodies still treat the data
+    // pointer as NUL-terminated until M2.4 ships length-aware C bodies
+    // (or the Sailfin-native runtime port replaces them entirely).
+    typedef struct SfnString
+    {
+        char *data;
+        int64_t len;
+    } SfnString;
+
     // ---- Core helpers (minimal set) ----
 
     void sailfin_runtime_mark_persistent(char *ptr);
@@ -67,7 +78,21 @@ extern "C"
     int64_t sailfin_runtime_string_length(char *text);
     // `end` is an absolute index (like Python slicing), not a length.
     char *sailfin_runtime_substring(char *text, int64_t start, int64_t end);
+    // Legacy NUL-terminated entrypoint. Kept exported so seed-compiled
+    // IR (which still emits `call i8* @sailfin_runtime_string_concat(i8*, i8*)`)
+    // continues to link during the 2-pass self-host build. New compiler
+    // output routes through `sailfin_runtime_string_concat_v2` below.
     char *sailfin_runtime_string_concat(char *a, char *b);
+
+    // M1.A: takes the SfnString aggregate ABI by value. Body extracts
+    // `a.data` / `b.data` and forwards to the legacy NUL-terminated
+    // implementation until M2.4 rewrites for length-aware concat. Return
+    // type stays `char*` (legacy NUL-terminated heap buffer) —
+    // string-typed locals don't flip to aggregate until M1.A.2. The
+    // suffix lets the legacy entrypoint above stay link-stable while the
+    // seed bumps catch up; once the floor seed knows the new ABI the
+    // suffix can retire.
+    char *sailfin_runtime_string_concat_v2(SfnString a, SfnString b);
     // Append suffix to buf in-place (realloc). buf is consumed (ownership
     // transferred); suffix is borrowed. Only emitted by the compiler when buf
     // is a provably-unaliased intermediate from a prior concat/append.

--- a/runtime/native/src/sailfin_runtime.c
+++ b/runtime/native/src/sailfin_runtime.c
@@ -2273,6 +2273,12 @@ char *sailfin_runtime_substring_unchecked(char *text, int64_t start, int64_t end
     return out;
 }
 
+// M1.A: legacy NUL-terminated implementation, exported under its
+// historical name so seed-compiled IR (which still emits
+// `call i8* @sailfin_runtime_string_concat(i8*, i8*)`) keeps linking
+// during the 2-pass self-host build. New compiler IR routes through
+// `sailfin_runtime_string_concat_v2`, which extracts the data pointers
+// from the SfnString aggregates and forwards here.
 char *sailfin_runtime_string_concat(char *a, char *b)
 {
     _runtime_enter();
@@ -2838,6 +2844,20 @@ char *sailfin_runtime_string_concat(char *a, char *b)
     }
 
     return out;
+}
+
+// M1.A: SfnString-by-value entrypoint. The new compiler emits
+// `call i8* @sailfin_runtime_string_concat_v2({i8*, i64} %a, {i8*, i64} %b)`
+// at every concat site (registry-locked in `runtime_helpers.sfn`).
+// We extract the data pointers and forward to the legacy NUL-terminated
+// impl until M2.4 ships a length-aware body. The `_v2` suffix lets the
+// pre-aggregate `sailfin_runtime_string_concat(char*, char*)` entrypoint
+// stay link-stable for seed-compiled IR during the 2-pass self-host
+// build; once the floor seed embeds the new ABI we can retire the
+// suffix and the legacy entrypoint together.
+char *sailfin_runtime_string_concat_v2(SfnString a, SfnString b)
+{
+    return sailfin_runtime_string_concat(a.data, b.data);
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary

- Switch string-literal lowering from `i8*` to `{i8*, i64}` aggregate (`SfnString` = data ptr + byte length) so the M1 ABI shape is locked into emitted IR.
- `s.length` on a fresh literal expression resolves to a direct `extractvalue ..., 1` (no `sailfin_runtime_string_length` call).
- `string.concat` registry flips to `({i8*, i64}, {i8*, i64})` parameters and routes through a new `sailfin_runtime_string_concat_v2` C entrypoint that wraps the legacy NUL-terminated body — body migration is deferred to M2.4.

Closes #391

## Acceptance Criteria

- [x] `let s = "hello"` lowers to a `{i8*, i64}` constant.
- [x] `s.length` resolves to direct field access (no `sailfin_runtime_string_length` call when the operand is the aggregate).
- [x] `runtime_helpers.sfn` registry: `string.concat`'s `parameter_types` reads `["{i8*, i64}", "{i8*, i64}"]`.
- [x] New e2e `compiler/tests/e2e/test_string_aggregate_shape.sh` pins the IR shape — `{i8*, i64}` appears in emitted LLVM, no consumer extracts the literal as `[N x i8]`.
- [x] `make compile` passes.
- [x] `make test` passes.

## Out of scope (deferred)

- Flipping `string` → `{i8*, i64}` in `type_mapping.sfn` (M1.A.2). Unannotated `let s = "hello"` therefore clamps the local's storage type back to `i8*` for now; the literal expression itself is the `{i8*, i64}` constant. The direct-`extractvalue` `.length` path applies to fresh literal expressions, not stored-then-loaded locals.
- Migration of the C body to length-aware concat (M2.4). The `_v2` suffix lets the legacy `sailfin_runtime_string_concat(char*, char*)` entrypoint stay link-stable for seed-compiled IR during the 2-pass self-host build; once the floor seed embeds the new ABI, the suffix and legacy entrypoint can retire together.

## Verification

```bash
ulimit -v 8388608 && make compile             # self-hosts cleanly
ulimit -v 8388608 && make test                # full regression
ulimit -v 8388608 && bash compiler/tests/e2e/test_string_aggregate_shape.sh \
    build/native/sailfin                       # 6 passed, 0 failed
```

Results:
- `unit: 87/87 passed, 0 failed`
- `e2e: 48/48 passed, 0 failed`
- `capsules: 10/10 passed, 0 failed`

## Files Changed

**Compiler lowering**
- `compiler/src/llvm/expression_lowering/native/core_strings.sfn` — `lower_string_literal` builds `{i8*, i64}` via two `insertvalue` ops; `emit_string_concat` coerces both sides to the aggregate and emits the `_v2` call.
- `compiler/src/llvm/expression_lowering/native/core_operands.sfn` — bidirectional `{i8*, i64} ↔ i8*` shim in `coerce_pointer_or_struct`; `is_string_pointer_type` recognizes the aggregate; `emit_comparison_instruction` extracts data pointers before `strings_equal`.
- `compiler/src/llvm/expression_lowering/native/core_member_lowering.sfn` — aggregate `.length` direct-extract branch.
- `compiler/src/llvm/expression_lowering/native/core_ops_lowering.sfn` — unified inline `+` dispatch (replaces 4 legacy branches) and post-harmonise fallback both lift to the aggregate ABI before calling `_v2`.
- `compiler/src/llvm/expression_lowering/native/core_literals_lowering.sfn` — array-element and struct-field coercion paths unwrap `{i8*, i64}` to `i8*` instead of boxing; inferred element type collapses aggregate to `i8*` to keep `string[]` shape stable.
- `compiler/src/llvm/expression_lowering/native/core_index_lowering.sfn` — `s[i]` extracts the data pointer from an aggregate base.
- `compiler/src/llvm/lowering/instructions_let.sfn` — unannotated `{i8*, i64}` operand clamps the local's storage type back to `i8*` (M1.A.2 deferral).
- `compiler/src/llvm/expression_lowering/arrays.sfn` — `sailfin_runtime_append_string` extracts the value's data pointer when the operand is an aggregate.
- `compiler/src/llvm/runtime_helpers.sfn` — `string.concat` registry repointed at `sailfin_runtime_string_concat_v2` with aggregate parameter types.

**C runtime**
- `runtime/native/include/sailfin_runtime.h` — new `SfnString` typedef; new `sailfin_runtime_string_concat_v2(SfnString, SfnString)` declaration; legacy `sailfin_runtime_string_concat(char*, char*)` retained.
- `runtime/native/src/sailfin_runtime.c` — `_v2` wrapper extracts `a.data`/`b.data` and forwards to the unchanged legacy body.

**Tests**
- `compiler/tests/e2e/test_string_aggregate_shape.sh` (new) — pins the IR shape with 6 assertions.
- `compiler/tests/e2e/fixtures/string_aggregate_shape.sfn` (new) — exercises literal `.length`, literal `+` literal, and `print.info` of the concat result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_011nxVEpGzNDuXbEtKaAoEWR)_