### PR TITLE
fix(lowering): scope helper-symbol filter to actually-emitted helpers

### DIFF
--- a/compiler/src/llvm/lowering/lowering_phase_render.sfn
+++ b/compiler/src/llvm/lowering/lowering_phase_render.sfn
@@ -130,7 +130,7 @@ fn render_llvm_preamble(module_name: string, type_context: TypeContext, trait_me
 
     // Imported function declarations
     if debug_lowering { print.err("emit-llvm: phase=render_imports"); }
-    let imported_declarations = render_imported_function_declarations(imported_functions, local_functions, type_context);
+    let imported_declarations = render_imported_function_declarations(imported_functions, local_functions, type_context, runtime_helpers);
     if imported_declarations != null {
         if imported_declarations.length > 0 {
             lines = extend_string_lines(lines, imported_declarations);

--- a/compiler/src/llvm/rendering.sfn
+++ b/compiler/src/llvm/rendering.sfn
@@ -176,18 +176,25 @@ fn render_runtime_helper_declarations(used_targets: string[], local_functions: N
 // =============================================================================
 // Imported Function Declarations
 // =============================================================================
-fn render_imported_function_declarations(imported_functions: NativeFunction[], local_functions: NativeFunction[], context: TypeContext) -> string[] {
+fn render_imported_function_declarations(imported_functions: NativeFunction[], local_functions: NativeFunction[], context: TypeContext, runtime_helpers: string[]) -> string[] {
     if imported_functions.length == 0 { return []; }
-    // Get all runtime helper symbols to avoid duplicates
+    // Collect runtime helper symbols to avoid duplicate declares — but only
+    // for descriptors whose target was actually emitted by
+    // render_runtime_helper_declarations (i.e. listed in runtime_helpers).
+    // Otherwise an imported function aliasing an unused descriptor would be
+    // silently dropped from both paths and vanish from the preamble.
     let helper_descriptors = runtime_helper_descriptors();
     let mut helper_symbols: string[] = [];
     let mut helper_index: number = 0;
     loop {
         if helper_index >= helper_descriptors.length { break; }
-        helper_symbols.push(helper_descriptors[helper_index].symbol);
-        let helper_target = sanitize_symbol(helper_descriptors[helper_index].target);
-        if !string_array_contains(helper_symbols, helper_target) {
-            helper_symbols.push(helper_target);
+        let descriptor = helper_descriptors[helper_index];
+        if string_array_contains(runtime_helpers, descriptor.target) {
+            helper_symbols.push(descriptor.symbol);
+            let helper_target = sanitize_symbol(descriptor.target);
+            if !string_array_contains(helper_symbols, helper_target) {
+                helper_symbols.push(helper_target);
+            }
         }
         helper_index += 1;
     }


### PR DESCRIPTION
## Summary
- `render_imported_function_declarations` now takes `runtime_helpers: string[]` and only filters out imported declares for descriptors whose `target` is in that list — matching what `render_runtime_helper_declarations` actually emits, so an imported alias of an unused descriptor no longer disappears from both paths.
- Call site in `lowering_phase_render.sfn` updated to thread `runtime_helpers` through.
- The `"sailfin_runtime_sleep"` workaround in `seed_default_runtime_helpers` is intentionally left in place; per the issue scope, it goes away with the follow-on artifact-pipeline issue.

Closes #413

## Acceptance Criteria
- [x] `render_imported_function_declarations` signature updated to accept `runtime_helpers: string[]` as the fourth parameter
- [x] `helper_symbols` only includes symbols from descriptors whose `target` is in `runtime_helpers`
- [x] `bash compiler/tests/e2e/test_runtime_clock_skeleton.sh build/native/sailfin` reports 4 passed, 0 failed (including the I1 declare assertion)
- [x] `make compile` passes (self-host invariant)
- [x] `make test` passes
- [x] `sfn fmt --check compiler/src/llvm/rendering.sfn compiler/src/llvm/lowering/lowering_phase_render.sfn` exits 0

## Verification
```bash
$ ulimit -v 8388608 && timeout 30 build/native/sailfin emit llvm runtime/sfn/clock.sfn | grep -E "^declare void @sailfin_runtime_sleep"
declare void @sailfin_runtime_sleep(double)

$ ulimit -v 8388608 && timeout 30 build/native/sailfin emit llvm runtime/sfn/clock.sfn | grep "^declare" | sort | uniq -d
# (empty — no duplicate declare lines)

$ ulimit -v 8388608 && bash compiler/tests/e2e/test_runtime_clock_skeleton.sh build/native/sailfin
[test] PASS: sfn check runtime/sfn/clock.sfn passes
[test] PASS: sfn fmt --check runtime/sfn/clock.sfn is canonical
[test] PASS: sfn emit llvm produces sfn_sleep wrapper over imported sleep trampoline
[test] PASS: sfn emit llvm declares sailfin_runtime_sleep trampoline
[summary] 4 passed, 0 failed

$ ulimit -v 8388608 && make test
... ═══ e2e: 48/48 passed, 0 failed ═══
... ═══ capsules: 10/10 passed, 0 failed ═══

$ sfn fmt --check compiler/src/llvm/rendering.sfn compiler/src/llvm/lowering/lowering_phase_render.sfn
# exit 0
```

## Files Changed
- `compiler/src/llvm/rendering.sfn` — `render_imported_function_declarations` signature + filter loop now scoped to `runtime_helpers`
- `compiler/src/llvm/lowering/lowering_phase_render.sfn` — call site passes `runtime_helpers`

## Notes
- The verification snippet in the issue used `awk '{print $NF}'` which extracts only the trailing parameter (`double)`, `i64)`, …) and surfaces spurious "duplicates" that aren't actually duplicate declares. Used the line-level / symbol-level checks above to confirm there are no real duplicates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JNFXDrofvAdWbrEk5VUQJU)_