### PR TITLE
M1.B — Lock array-literal lowering to {T*, i64, i64} aggregate

### DIFF
--- a/compiler/src/llvm/expression_lowering/arrays.sfn
+++ b/compiler/src/llvm/expression_lowering/arrays.sfn
@@ -251,6 +251,21 @@ fn lower_struct_array_concat(lhs: LLVMOperand, rhs: LLVMOperand, element_type: s
         + ", i32 0, i32 1");
     current_lines.push("  store i64 " + total_length + ", i64* " + new_len_field);
 
+    // M1.B (#393): cap == len for the freshly concatenated buffer. The
+    // backing store is sized exactly to total_length so any subsequent
+    // push past this point will trigger an in-place grow via the v2
+    // helpers.
+    let new_cap_field = format_temp_name(current_temp);
+    current_temp += 1;
+    current_lines.push("  " + new_cap_field + " = getelementptr "
+        + array_struct_type
+        + ", "
+        + array_struct_type
+        + "* "
+        + new_struct_ptr
+        + ", i32 0, i32 2");
+    current_lines.push("  store i64 " + total_length + ", i64* " + new_cap_field);
+
     let result_operand = LLVMOperand {
         llvm_type: lhs.llvm_type,
         value: new_struct_ptr
@@ -279,14 +294,14 @@ fn lower_array_push_in_place(array: LLVMOperand, value: LLVMOperand, element_typ
         };
     }
 
-    // IMPORTANT: `i8*` arrays are the runtime's "string array" ABI and are
-    // backed by `SailfinPtrArray` helpers that carry a hidden capacity header.
-    // Do not route these through the generic `array_push_slot` path, which uses
-    // a different header layout and can break subsequent `append_string` calls.
+    // IMPORTANT: `i8*` arrays are the runtime's "string array" ABI. M1.B
+    // (#393) routes these through the v2 entrypoint which understands the
+    // 3-field {i8**, i64, i64} struct layout and grows in place via
+    // realloc — no hidden capacity header.
     if element_type == "i8*" {
         // M1.A: SfnString aggregate operands (literals after the M1.A
         // flip) must shed the length prefix before reaching the
-        // `(_, i8*)` ABI of `sailfin_runtime_append_string`. The
+        // `(_, i8*)` ABI of `sailfin_runtime_append_string_v2`. The
         // legacy `i8*` operand path passes through unchanged.
         let mut value_at_string = value.value;
         if value.llvm_type == "{i8*, i64}" {
@@ -303,7 +318,7 @@ fn lower_array_push_in_place(array: LLVMOperand, value: LLVMOperand, element_typ
         // NOTE: Do not embed `{ ... }` literally in Sailfin strings; braces are
         // treated as interpolation markers. Use `array.llvm_type` instead.
         current_lines.push("  " + pushed + " = call " + array.llvm_type
-            + " @sailfin_runtime_append_string("
+            + " @sailfin_runtime_append_string_v2("
             + array.llvm_type
             + " "
             + array.value
@@ -358,6 +373,17 @@ fn lower_array_push_in_place(array: LLVMOperand, value: LLVMOperand, element_typ
         + " "
         + array.value
         + ", i32 0, i32 1");
+    // M1.B (#393): cap pointer (offset 2) threads through the v2
+    // push helper so realloc-induced cap bumps land back in the
+    // struct in lockstep with the new len.
+    let cap_ptr = format_temp_name(current_temp);
+    current_temp += 1;
+    current_lines.push("  " + cap_ptr + " = getelementptr " + array_struct_type
+        + ", "
+        + array.llvm_type
+        + " "
+        + array.value
+        + ", i32 0, i32 2");
     // Compute element size in bytes.
     let element_size_ptr = format_temp_name(current_temp);
     current_temp += 1;
@@ -387,10 +413,12 @@ fn lower_array_push_in_place(array: LLVMOperand, value: LLVMOperand, element_typ
     let slot_i8 = format_temp_name(current_temp);
     current_temp += 1;
     current_lines.push("  " + slot_i8
-        + " = call i8* @sailfin_runtime_array_push_slot(i8** "
+        + " = call i8* @sailfin_runtime_array_push_slot_v2(i8** "
         + data_ptr_i8
         + ", i64* "
         + len_ptr
+        + ", i64* "
+        + cap_ptr
         + ", i64 "
         + element_size_value
         + ")");

--- a/compiler/src/llvm/expression_lowering/native/core_literals_lowering.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_literals_lowering.sfn
@@ -602,6 +602,21 @@ fn lower_array_literal(text: string, bindings: ParameterBinding[], locals: Local
     current_lines.push("  store i64 " + length_text + ", i64* "
         + length_field_pointer);
 
+    // M1.B (#393): cap field at offset 2 — for a literal `[a, b, c]`,
+    // cap == len. The runtime's v2 push helpers will grow the backing
+    // buffer (and update cap) when callers append past this point.
+    let cap_field_pointer = format_temp_name(current_temp);
+    current_lines.push("  " + cap_field_pointer + " = getelementptr "
+        + struct_type
+        + ", "
+        + struct_type
+        + "* "
+        + struct_pointer
+        + ", i32 0, i32 2");
+    current_temp += 1;
+    current_lines.push("  store i64 " + length_text + ", i64* "
+        + cap_field_pointer);
+
     let operand = LLVMOperand {
         llvm_type: struct_type + "*",
         value: struct_pointer

--- a/compiler/src/llvm/expression_lowering/native/core_type_mapping.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_type_mapping.sfn
@@ -158,7 +158,9 @@ fn map_array_pointer_type(context: TypeContext, annotation: string) -> string {
             }
         }
     }
-    return "{ " + element_type + "*, i64 }*";
+    // M1.B (#393): array shape gains an explicit cap field. Mirrors
+    // `array_pointer_type_for_element` in compiler/src/llvm/type_mapping.sfn.
+    return "{ " + element_type + "*, i64, i64 }*";
 }
 
 fn unwrap_move_wrapper(annotation: string) -> string {

--- a/compiler/src/llvm/expression_lowering/native/statement_type_mapping.sfn
+++ b/compiler/src/llvm/expression_lowering/native/statement_type_mapping.sfn
@@ -212,7 +212,9 @@ fn map_array_pointer_type(context: TypeContext, annotation: string) -> string {
             }
         }
     }
-    return "{ " + element_type + "*, i64 }*";
+    // M1.B (#393): array shape gains an explicit cap field. Mirrors
+    // `array_pointer_type_for_element` in compiler/src/llvm/type_mapping.sfn.
+    return "{ " + element_type + "*, i64, i64 }*";
 }
 
 // ---------------------------------------------------------------------------

--- a/compiler/src/llvm/runtime_helpers.sfn
+++ b/compiler/src/llvm/runtime_helpers.sfn
@@ -207,8 +207,13 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
     });
 
     // Process helpers
+    // M1.B (#393): SfnArray ABI — heap-boxed `{ T*, i64, i64 }*` with
+    // explicit cap. Routes through `_v2` C entrypoints that read/write
+    // cap directly (no hidden header). Legacy entrypoints stay
+    // exported for seed-compiled IR; the registry only points the
+    // new compiler at v2.
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "process.run", symbol: "sailfin_runtime_process_run", return_type: "double", parameter_types: ["{ i8**, i64 }*"], effects: ["io"]
+        target: "process.run", symbol: "sailfin_runtime_process_run_v2", return_type: "double", parameter_types: ["{ i8**, i64, i64 }*"], effects: ["io"]
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
         target: "process.exit", symbol: "sailfin_runtime_process_exit", return_type: "void", parameter_types: ["double"], effects: ["io"]
@@ -234,16 +239,16 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
         target: "fs.appendFile", symbol: "sailfin_adapter_fs_append_file", return_type: "void", parameter_types: ["i8*", "i8*"], effects: ["io"]
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "fs_write_lines", symbol: "sailfin_adapter_fs_write_lines", return_type: "void", parameter_types: ["i8*", "{ i8**, i64 }*"], effects: ["io"]
+        target: "fs_write_lines", symbol: "sailfin_adapter_fs_write_lines_v2", return_type: "void", parameter_types: ["i8*", "{ i8**, i64, i64 }*"], effects: ["io"]
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "fs.writeLines", symbol: "sailfin_adapter_fs_write_lines", return_type: "void", parameter_types: ["i8*", "{ i8**, i64 }*"], effects: ["io"]
+        target: "fs.writeLines", symbol: "sailfin_adapter_fs_write_lines_v2", return_type: "void", parameter_types: ["i8*", "{ i8**, i64, i64 }*"], effects: ["io"]
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "fs_list_directory", symbol: "sailfin_adapter_fs_list_directory", return_type: "{ i8**, i64 }*", parameter_types: ["i8*"], effects: ["io"]
+        target: "fs_list_directory", symbol: "sailfin_adapter_fs_list_directory_v2", return_type: "{ i8**, i64, i64 }*", parameter_types: ["i8*"], effects: ["io"]
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "fs.listDirectory", symbol: "sailfin_adapter_fs_list_directory", return_type: "{ i8**, i64 }*", parameter_types: ["i8*"], effects: ["io"]
+        target: "fs.listDirectory", symbol: "sailfin_adapter_fs_list_directory_v2", return_type: "{ i8**, i64, i64 }*", parameter_types: ["i8*"], effects: ["io"]
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
         target: "fs_delete_file", symbol: "sailfin_adapter_fs_delete_file", return_type: "i1", parameter_types: ["i8*"], effects: ["io"]
@@ -370,19 +375,28 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
         target: "is_alpha_char", symbol: "sailfin_runtime_is_alpha_char", return_type: "i1", parameter_types: ["i8"], effects: []
     });
 
-    // Array/collection helpers (generic using i8* for element type)
+    // Array/collection helpers (generic using i8* for element type).
+    // M1.B (#393): SfnArray ABI — `{ T*, i64, i64 }*` with explicit cap.
+    // Routes through `_v2` C entrypoints. Legacy `sailfin_runtime_concat`
+    // / `_append_string` / `_array_push_slot` stay exported so the seed-
+    // compiled first-pass IR (which still uses the 2-field shape) keeps
+    // linking; once the floor seed bumps to a release that emits the
+    // 3-field shape, the legacy symbols can retire.
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "append_string", symbol: "sailfin_runtime_append_string", return_type: "{ i8**, i64 }*", parameter_types: ["{ i8**, i64 }*", "i8*"], effects: []
+        target: "append_string", symbol: "sailfin_runtime_append_string_v2", return_type: "{ i8**, i64, i64 }*", parameter_types: ["{ i8**, i64, i64 }*", "i8*"], effects: []
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "concat", symbol: "sailfin_runtime_concat", return_type: "{ i8**, i64 }*", parameter_types: ["{ i8**, i64 }*", "{ i8**, i64 }*"], effects: []
+        target: "concat", symbol: "sailfin_runtime_concat_v2", return_type: "{ i8**, i64, i64 }*", parameter_types: ["{ i8**, i64, i64 }*", "{ i8**, i64, i64 }*"], effects: []
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
         target: "copy_bytes", symbol: "sailfin_runtime_copy_bytes", return_type: "void", parameter_types: ["i8*", "i8*", "i64"], effects: []
     });
 
+    // M1.B v2 byte-wise push: takes data, len, cap pointers + elem_size.
+    // Cap moves into the struct, so the registry signature gains an
+    // `i64*` (cap pointer) compared to the legacy 3-arg form.
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "array_push_slot", symbol: "sailfin_runtime_array_push_slot", return_type: "i8*", parameter_types: ["i8**", "i64*", "i64"], effects: []
+        target: "array_push_slot", symbol: "sailfin_runtime_array_push_slot_v2", return_type: "i8*", parameter_types: ["i8**", "i64*", "i64*", "i64"], effects: []
     });
 
     // Generic field accessor for opaque imported types

--- a/compiler/src/llvm/type_mapping.sfn
+++ b/compiler/src/llvm/type_mapping.sfn
@@ -259,12 +259,17 @@ fn layout_annotation_represents_user_value(annotation: string) -> boolean {
 // =============================================================================
 // Array Type Helpers
 // =============================================================================
+// M1.B (#393): array struct shape is the {T*, i64, i64} aggregate
+// (data, len, cap). Cap is exposed inline so push/append paths can
+// grow the buffer in place without consulting the legacy hidden
+// header. See docs/runtime_architecture.md §2.3 and the v2 runtime
+// helpers in runtime/native/src/sailfin_runtime.c.
 fn array_struct_type_for_element(element_type: string) -> string {
-    return "{ " + element_type + "*, i64 }";
+    return "{ " + element_type + "*, i64, i64 }";
 }
 
 fn array_pointer_type_for_element(element_type: string) -> string {
-    return "{ " + element_type + "*, i64 }*";
+    return "{ " + element_type + "*, i64, i64 }*";
 }
 
 // =============================================================================

--- a/compiler/tests/e2e/fixtures/array_aggregate_shape.sfn
+++ b/compiler/tests/e2e/fixtures/array_aggregate_shape.sfn
@@ -1,0 +1,16 @@
+// Fixture for compiler/tests/e2e/test_array_aggregate_shape.sh.
+//
+// Pins the M1.B array-literal ABI shape: every array literal lowers to
+// an `{ T*, i64, i64 }*` aggregate (data, len, cap), the `.length` field
+// resolves to a GEP+load of slot 1, and the cap field at slot 2 is
+// initialized to len for a fresh literal so callers that grow the
+// buffer via the v2 push helpers see the right starting capacity.
+// String arrays go through the `_v2` runtime entrypoints; the legacy
+// `sailfin_runtime_concat` / `_append_string` / `_array_push_slot`
+// symbols stay exported for seed-compiled IR.
+fn main() ![io] {
+    let xs = [1, 2, 3];
+    let len = xs.length;
+    let words = ["one", "two"];
+    print.info(words[0]);
+}

--- a/compiler/tests/e2e/test_array_aggregate_shape.sh
+++ b/compiler/tests/e2e/test_array_aggregate_shape.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+# End-to-end test for the M1.B array-literal ABI lock (issue #393).
+#
+# Pins the emitted LLVM IR contract for array literals and the runtime
+# helper signatures that consume them:
+#   - `let xs = [1, 2, 3]` materializes a `{ T*, i64, i64 }*` aggregate
+#     (data, len, cap). Pointer arrays (`string[]`) widen the data slot
+#     to `T**`; value arrays use `T*` directly. Both shapes carry the
+#     extra cap field at offset 2.
+#   - The literal lowering writes all three slots: a `getelementptr
+#     ..., i32 0, i32 0` for data, `..., i32 0, i32 1` for len, and a
+#     fresh `..., i32 0, i32 2` for cap. Cap is initialized to len so
+#     callers that grow the buffer via the v2 push helpers see the
+#     correct starting capacity.
+#   - `xs.length` resolves to slot 1 of the array struct.
+#   - The runtime registry routes `concat` / `append_string` /
+#     `array_push_slot` / `process.run` / `fs.writeLines` /
+#     `fs.listDirectory` to their `_v2` C entrypoints. Legacy
+#     `sailfin_runtime_concat` / `sailfin_runtime_append_string` /
+#     `sailfin_runtime_array_push_slot` symbols stay link-stable for
+#     seed-compiled IR until the floor seed catches up.
+#
+# Usage:
+#   compiler/tests/e2e/test_array_aggregate_shape.sh <compiler-binary>
+
+set -euo pipefail
+
+BINARY="${1:?usage: test_array_aggregate_shape.sh <compiler-binary>}"
+BINARY="$(realpath "$BINARY")"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FIXTURE="$SCRIPT_DIR/fixtures/array_aggregate_shape.sfn"
+
+PASS=0
+FAIL=0
+
+SCRATCH="$(mktemp -d -t sfn-array-shape-XXXXXX)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+LL="$SCRATCH/array_aggregate_shape.ll"
+
+run_test() {
+    local name="$1"
+    shift
+    if "$@"; then
+        echo "[test] PASS: $name"
+        PASS=$((PASS + 1))
+    else
+        echo "[test] FAIL: $name"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+emit_ir_once() {
+    if [ -s "$LL" ]; then
+        return 0
+    fi
+    if ! "$BINARY" emit -o "$LL" llvm "$FIXTURE" > "$SCRATCH/emit.stderr" 2>&1; then
+        echo "[test]   sfn emit llvm failed for array_aggregate_shape.sfn"
+        sed 's/^/[test]     /' "$SCRATCH/emit.stderr" | head -20
+        return 1
+    fi
+    return 0
+}
+
+# B1 — Three-field aggregate type appears in the emitted IR.
+test_three_field_aggregate_appears() {
+    emit_ir_once || return 1
+    local hits
+    hits="$(grep -cE '\{ [^}]*\*, i64, i64 \}' "$LL" || true)"
+    if [ "${hits:-0}" -lt 4 ]; then
+        echo "[test]   expected at least 4 references to { T*, i64, i64 }, got ${hits:-0}"
+        return 1
+    fi
+    return 0
+}
+
+# B2 — `let xs = [1, 2, 3]` lowers to a `{ double*, i64, i64 }*` (numeric
+# literals lower to double under the bootstrap number ABI).
+test_numeric_literal_uses_value_typed_data_slot() {
+    emit_ir_once || return 1
+    local hits
+    hits="$(grep -cE '\{ double\*, i64, i64 \}' "$LL" || true)"
+    if [ "${hits:-0}" -lt 1 ]; then
+        echo "[test]   expected the numeric array literal to surface as { double*, i64, i64 }"
+        return 1
+    fi
+    return 0
+}
+
+# B3 — String-array literal `["one", "two"]` lowers to `{ i8**, i64, i64 }*`
+# (pointer-typed data slot).
+test_string_array_uses_pointer_typed_data_slot() {
+    emit_ir_once || return 1
+    local hits
+    hits="$(grep -cE '\{ i8\*\*, i64, i64 \}' "$LL" || true)"
+    if [ "${hits:-0}" -lt 1 ]; then
+        echo "[test]   expected the string array literal to surface as { i8**, i64, i64 }"
+        return 1
+    fi
+    return 0
+}
+
+# B4 — Cap slot (i32 0, i32 2) is written by the literal lowering.
+# Without the M1.B flip the literal would only GEP slots 0 and 1; the
+# presence of slot 2 access pins that cap is being initialized.
+test_literal_writes_cap_slot() {
+    emit_ir_once || return 1
+    local cap_geps
+    cap_geps="$(grep -cE '= getelementptr \{ [^}]*\*, i64, i64 \}, \{ [^}]*\*, i64, i64 \}\* %[A-Za-z_0-9]+, i32 0, i32 2' "$LL" || true)"
+    if [ "${cap_geps:-0}" -lt 1 ]; then
+        echo "[test]   expected at least one GEP to slot 2 (cap) on the new shape, got ${cap_geps:-0}"
+        return 1
+    fi
+    return 0
+}
+
+# B5 — The cap value stored for a 3-element literal is `i64 3` (matches
+# the literal length so post-literal grow goes through the v2 push
+# helpers' realloc branch).
+test_literal_cap_value_matches_length() {
+    emit_ir_once || return 1
+    # Find any `i32 0, i32 2` GEP and check the next-line store wrote
+    # `i64 3`. Use awk to walk paired lines so we don't false-positive
+    # on unrelated `i64 3` constants elsewhere.
+    if ! awk '
+        /= getelementptr \{ [^}]*\*, i64, i64 \},.*, i32 0, i32 2$/ {
+            getline next_line
+            if (next_line ~ /^[[:space:]]+store i64 3, i64\* /) {
+                found = 1
+            }
+        }
+        END { exit found ? 0 : 1 }
+    ' "$LL"; then
+        echo "[test]   expected at least one cap-slot store with i64 3 immediately after a slot-2 GEP"
+        return 1
+    fi
+    return 0
+}
+
+# B6 — `xs.length` resolves to slot 1 of the array struct. Either GEP+load
+# or whole-struct load + extractvalue is acceptable; both surface the
+# value without a runtime call.
+test_length_reads_slot_one() {
+    emit_ir_once || return 1
+    local gep_load
+    gep_load="$(grep -cE '= getelementptr \{ [^}]*\*, i64, i64 \},.*, i32 0, i32 1' "$LL" || true)"
+    local extract_one
+    extract_one="$(grep -cE '= extractvalue \{ [^}]*\*, i64, i64 \} %[A-Za-z_0-9]+, 1' "$LL" || true)"
+    local total=$((gep_load + extract_one))
+    if [ "${total:-0}" -lt 1 ]; then
+        echo "[test]   expected at least one slot-1 access (GEP or extractvalue) on the new shape"
+        return 1
+    fi
+    return 0
+}
+
+# B7 — Runtime helpers route through their `_v2` symbols with the new
+# 3-field signature. Legacy `sailfin_runtime_concat(i8**, i64)` /
+# `_append_string(i8**, i64)` / `_array_push_slot(i8**, i64*, i64)`
+# decls must not appear in new compiler output. (The C runtime keeps
+# them exported for seed-compiled IR; this test only inspects the IR
+# emitted by the *new* compiler.)
+test_v2_runtime_helpers_in_registry() {
+    emit_ir_once || return 1
+    local concat_v2
+    concat_v2="$(grep -cE '^declare \{ i8\*\*, i64, i64 \}\* @sailfin_runtime_concat_v2' "$LL" || true)"
+    local append_v2
+    append_v2="$(grep -cE '^declare \{ i8\*\*, i64, i64 \}\* @sailfin_runtime_append_string_v2' "$LL" || true)"
+    if [ "${concat_v2:-0}" -lt 1 ] || [ "${append_v2:-0}" -lt 1 ]; then
+        echo "[test]   expected v2 declares for concat and append_string"
+        echo "[test]     concat_v2=${concat_v2}, append_v2=${append_v2}"
+        return 1
+    fi
+    local legacy_concat
+    legacy_concat="$(grep -cE '^declare \{ i8\*\*, i64 \}\* @sailfin_runtime_concat\(' "$LL" || true)"
+    if [ "${legacy_concat:-0}" -ne 0 ]; then
+        echo "[test]   regression: legacy 2-field concat declare emitted"
+        return 1
+    fi
+    return 0
+}
+
+# B8 — `array_push_slot_v2` declare carries the cap pointer parameter
+# (the legacy 3-arg form gains an `i64*` for cap).
+test_array_push_slot_v2_signature() {
+    emit_ir_once || return 1
+    local hits
+    hits="$(grep -cE '^declare i8\* @sailfin_runtime_array_push_slot_v2\(i8\*\*, i64\*, i64\*, i64\)' "$LL" || true)"
+    if [ "${hits:-0}" -lt 1 ]; then
+        echo "[test]   expected array_push_slot_v2 declare with (i8**, i64*, i64*, i64) signature"
+        return 1
+    fi
+    return 0
+}
+
+# B9 — No legacy 2-field array shape leaks into the new IR. The seed-
+# compiled first-pass binary still emits the legacy shape internally,
+# but a fresh emit from the new compiler must be uniform.
+test_no_legacy_two_field_array_shape() {
+    emit_ir_once || return 1
+    # Match `{ T*, i64 }` only when not followed by `, i64 }` (the cap
+    # field). Use grep -P-style assertion (perl-compat) if available;
+    # otherwise fall back to a stricter pattern that excludes the new
+    # shape via a positive match for the trailing `}`.
+    local legacy_count
+    legacy_count="$(grep -cE '\{ [^{}]+\*, i64 \}[^*]' "$LL" || true)"
+    if [ "${legacy_count:-0}" -gt 0 ]; then
+        echo "[test]   regression: legacy 2-field array shape `{ T*, i64 }` survived into new IR (count=${legacy_count})"
+        grep -nE '\{ [^{}]+\*, i64 \}[^*]' "$LL" | head -5 | sed 's/^/[test]     /'
+        return 1
+    fi
+    return 0
+}
+
+run_test 'emitted IR contains the { T*, i64, i64 } aggregate type' \
+    test_three_field_aggregate_appears
+run_test 'numeric literal [1, 2, 3] lowers to { double*, i64, i64 }' \
+    test_numeric_literal_uses_value_typed_data_slot
+run_test 'string literal ["one", "two"] lowers to { i8**, i64, i64 }' \
+    test_string_array_uses_pointer_typed_data_slot
+run_test 'literal lowering writes the cap slot (i32 0, i32 2)' \
+    test_literal_writes_cap_slot
+run_test 'cap slot stores i64 3 for a 3-element literal' \
+    test_literal_cap_value_matches_length
+run_test 'xs.length reads slot 1 of the array struct' \
+    test_length_reads_slot_one
+run_test 'runtime helpers route through their _v2 symbols' \
+    test_v2_runtime_helpers_in_registry
+run_test 'array_push_slot_v2 declare carries the cap pointer parameter' \
+    test_array_push_slot_v2_signature
+run_test 'no legacy { T*, i64 } 2-field array shape leaks into new IR' \
+    test_no_legacy_two_field_array_shape
+
+echo "[summary] $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi

--- a/runtime/native/include/sailfin_runtime.h
+++ b/runtime/native/include/sailfin_runtime.h
@@ -30,6 +30,32 @@ extern "C"
         int64_t len;
     } SfnString;
 
+    // Matches LLVM `{ T*, i64, i64 }` — the M1 ABI shape for SfnArray
+    // (data pointer + element count + capacity). See
+    // docs/runtime_architecture.md §2.3.1. M1.B (#393) locks the call-
+    // boundary shape; the legacy SailfinPtrArray with hidden 2-word /
+    // canary header stays exported for seed-compiled IR. New compiler
+    // output routes through `_v2` entrypoints that read/write `cap`
+    // directly from the struct, so the hidden-header logic in
+    // `_alloc_array` becomes dead code on the new call paths.
+    //
+    // `data` is `void*` here so the same struct can carry pointer-
+    // typed elements (`char**` for string arrays — i.e., LLVM
+    // `{i8**, i64, i64}`) or value-typed elements (`int64_t*` for
+    // `{i64*, i64, i64}`, etc.). Each v2 entrypoint that consumes
+    // an `SfnArray` interprets `data` according to the Sailfin
+    // call site that emitted the call — a string-array helper
+    // treats `data` as `char**`, an `i64`-array helper treats it
+    // as `int64_t*`, and the polymorphic byte-wise helpers
+    // (`array_push_slot_v2`) expose `data` to the caller as
+    // `void**` so the caller can keep its element type.
+    typedef struct SfnArray
+    {
+        void *data;
+        int64_t len;
+        int64_t cap;
+    } SfnArray;
+
     // ---- Core helpers (minimal set) ----
 
     void sailfin_runtime_mark_persistent(char *ptr);
@@ -131,15 +157,40 @@ extern "C"
 
     // ---- Array helpers ----
 
-    // For `{ i8**, i64 }*` concatenation, native IR uses `@sailfin_runtime_concat({i8**,i64}*,{i8**,i64}*)`.
+    // Legacy (M1 pre-cap) entrypoints. Kept exported so seed-compiled IR
+    // (which still emits `{ i8**, i64 }*` array shapes) keeps linking
+    // through the 2-pass self-host build. New compiler output (post #393)
+    // routes through the `_v2` family below — those bodies read/write
+    // capacity directly from the SfnArray struct's `cap` field instead
+    // of the hidden 2-word + canary header that `_alloc_array` plants
+    // in the legacy buffers.
     SailfinPtrArray *sailfin_runtime_concat(SailfinPtrArray *a, SailfinPtrArray *b);
     SailfinPtrArray *sailfin_runtime_append_string(SailfinPtrArray *a, char *text);
     SailfinPtrArray *sailfin_runtime_array_push(SailfinPtrArray *array, char *value);
+
+    // M1.B v2 array helpers — accept the SfnArray struct (heap-boxed) by
+    // pointer, with `cap` exposed inline. Bodies allocate plain malloc'd
+    // backing storage (no hidden header / canary slots) and grow via
+    // realloc when `len == cap`. Legacy entrypoints above remain the
+    // first-pass / seed-compiled IR's link target.
+    SfnArray *sailfin_runtime_concat_v2(SfnArray *a, SfnArray *b);
+    SfnArray *sailfin_runtime_append_string_v2(SfnArray *a, char *text);
 
     // Generic (byte-wise) array push for non-pointer element types.
     // Mutates the backing buffer to ensure capacity and returns a pointer to the
     // newly appended slot (caller writes the element bytes there).
     char *sailfin_runtime_array_push_slot(char **data_ptr_ptr, int64_t *len_ptr, int64_t elem_size);
+
+    // M1.B v2 byte-wise push: takes an explicit cap pointer. Grows by
+    // realloc when `*len_ptr == *cap_ptr` (doubling cap, minimum 8) and
+    // writes the new buffer back through `*data_ptr` and the new
+    // capacity through `*cap_ptr`. Returns a pointer to the slot for
+    // the just-incremented length so the caller can store the new
+    // element. No hidden header, no canary slots.
+    char *sailfin_runtime_array_push_slot_v2(void **data_ptr,
+                                             int64_t *len_ptr,
+                                             int64_t *cap_ptr,
+                                             int64_t elem_size);
 
     // ---- Byte helpers ----
 
@@ -151,6 +202,11 @@ extern "C"
     // ---- Process helpers ----
     // Execute a command (argv[0] is program). Returns the exit code.
     double sailfin_runtime_process_run(SailfinPtrArray *argv);
+
+    // M1.B v2: same contract as `sailfin_runtime_process_run`, but
+    // accepts the SfnArray ABI (cap-bearing) for argv. Body decomposes
+    // and forwards to the legacy implementation pathway.
+    double sailfin_runtime_process_run_v2(SfnArray *argv);
 
     // Terminate the process with the given exit code. Never returns.
     void sailfin_runtime_process_exit(double code);
@@ -247,6 +303,10 @@ extern "C"
     void sailfin_adapter_fs_write_file(void *path, void *contents);
     void sailfin_adapter_fs_append_file(void *path, void *contents);
     SailfinPtrArray *sailfin_adapter_fs_list_directory(void *path);
+
+    // M1.B v2 fs adapters — SfnArray-shaped string arrays.
+    void sailfin_adapter_fs_write_lines_v2(void *path, SfnArray *lines);
+    SfnArray *sailfin_adapter_fs_list_directory_v2(void *path);
     bool sailfin_adapter_fs_delete_file(void *path);
     bool sailfin_adapter_fs_create_directory(void *path, bool recursive);
     bool sailfin_intrinsic_fs_exists(void *path);

--- a/runtime/native/src/sailfin_runtime.c
+++ b/runtime/native/src/sailfin_runtime.c
@@ -6543,13 +6543,17 @@ static SfnArray *_sfn_array_alloc_v2(int64_t initial_cap, size_t elem_size)
     if (initial_cap > 0)
     {
         size_t bytes = (size_t)initial_cap * elem_size;
-        if (bytes / elem_size != (size_t)initial_cap)
+        if (elem_size != 0 && bytes / elem_size != (size_t)initial_cap)
         {
-            return NULL; /* overflow */
+            /* multiplication overflow — free the struct so malloc-mode
+             * doesn't leak. `_rt_free` is a no-op under arena mode. */
+            _rt_free(out);
+            return NULL;
         }
         out->data = _rt_calloc((size_t)initial_cap, elem_size);
         if (!out->data)
         {
+            _rt_free(out);
             return NULL;
         }
         out->cap = initial_cap;
@@ -6605,7 +6609,21 @@ SfnArray *sailfin_runtime_append_string_v2(SfnArray *a, char *text)
     int64_t cap = a->cap < 0 ? 0 : a->cap;
     if (len >= cap)
     {
-        int64_t new_cap = cap < 8 ? 8 : cap * 2;
+        /* Take `max(cap*2, len+1, 8)` so a corrupted `len > cap` state
+         * (e.g., ABI mismatch) can't realloc to a too-small buffer
+         * and then write past the new tail. The doubling overflow
+         * guard catches `cap * 2` wrapping past INT64_MAX. */
+        int64_t doubled = cap < 8 ? 8 : cap * 2;
+        if (doubled < cap)
+        {
+            return NULL;
+        }
+        int64_t need = len + 1;
+        int64_t new_cap = doubled > need ? doubled : need;
+        if (new_cap < 0 || (size_t)new_cap > SIZE_MAX / sizeof(char *))
+        {
+            return NULL; /* multiplication overflow */
+        }
         size_t old_bytes = (size_t)cap * sizeof(char *);
         size_t new_bytes = (size_t)new_cap * sizeof(char *);
         void *new_data = _rt_realloc(a->data, old_bytes, new_bytes);
@@ -6648,13 +6666,25 @@ char *sailfin_runtime_array_push_slot_v2(void **data_ptr, int64_t *len_ptr,
     }
     if (len >= cap)
     {
-        int64_t new_cap = cap < 8 ? 8 : cap * 2;
+        /* Take `max(cap*2, len+1, 8)`. `len > cap` shouldn't happen
+         * under normal compiler emission, but a corrupted struct
+         * (uninitialized cap, ABI mismatch with seed-compiled IR)
+         * would otherwise let the slot at `[len]` land past the
+         * realloc'd buffer's end. The grow rule guarantees
+         * `new_cap >= len + 1` so the write below is in-bounds. */
+        int64_t doubled = cap < 8 ? 8 : cap * 2;
+        if (doubled < cap)
+        {
+            return NULL;
+        }
+        int64_t need = len + 1;
+        int64_t new_cap = doubled > need ? doubled : need;
+        if (new_cap < 0 || (size_t)new_cap > SIZE_MAX / (size_t)elem_size)
+        {
+            return NULL; /* multiplication overflow */
+        }
         size_t old_bytes = (size_t)cap * (size_t)elem_size;
         size_t new_bytes = (size_t)new_cap * (size_t)elem_size;
-        if (new_bytes / (size_t)elem_size != (size_t)new_cap)
-        {
-            return NULL; /* overflow */
-        }
         void *new_data = _rt_realloc(*data_ptr, old_bytes, new_bytes);
         if (!new_data)
         {

--- a/runtime/native/src/sailfin_runtime.c
+++ b/runtime/native/src/sailfin_runtime.c
@@ -6516,3 +6516,289 @@ double sailfin_enum_tag_from_instruction_array(void *arr_ptr, double idx)
         (struct SailfnNativeInstruction *)hdr->data + i;
     return (double)elem->tag;
 }
+
+/* =====================================================================
+ * M1.B v2 array helpers — accept the SfnArray ABI (`{T*, i64, i64}*`)
+ * and use only plain malloc/realloc for backing storage. The legacy
+ * `_alloc_array` / `_array_check_canary` / hidden-header path stays
+ * exclusively bound to the `SailfinPtrArray` entrypoints above; v2
+ * callers (post-#393 compiler IR) never touch it. The bodies are
+ * intentionally simple — once the legacy entrypoints retire (M3 per
+ * docs/runtime_architecture.md §2.3), these can absorb any growth-
+ * amortization heuristics that the hidden-header path used to
+ * provide. For now linear copy on concat / doubling on push is
+ * sufficient for the workloads new-compiler IR exercises.
+ * ===================================================================== */
+
+static SfnArray *_sfn_array_alloc_v2(int64_t initial_cap, size_t elem_size)
+{
+    SfnArray *out = (SfnArray *)_rt_malloc(sizeof(SfnArray));
+    if (!out)
+    {
+        return NULL;
+    }
+    out->data = NULL;
+    out->len = 0;
+    out->cap = 0;
+    if (initial_cap > 0)
+    {
+        size_t bytes = (size_t)initial_cap * elem_size;
+        if (bytes / elem_size != (size_t)initial_cap)
+        {
+            return NULL; /* overflow */
+        }
+        out->data = _rt_calloc((size_t)initial_cap, elem_size);
+        if (!out->data)
+        {
+            return NULL;
+        }
+        out->cap = initial_cap;
+    }
+    return out;
+}
+
+SfnArray *sailfin_runtime_concat_v2(SfnArray *a, SfnArray *b)
+{
+    int64_t alen = (a && a->len > 0) ? a->len : 0;
+    int64_t blen = (b && b->len > 0) ? b->len : 0;
+    int64_t total = alen + blen;
+    SfnArray *out = _sfn_array_alloc_v2(total, sizeof(char *));
+    if (!out)
+    {
+        return NULL;
+    }
+    out->len = total;
+    char **buf = (char **)out->data;
+    if (buf)
+    {
+        if (a && a->data)
+        {
+            char **adata = (char **)a->data;
+            for (int64_t i = 0; i < alen; i++)
+            {
+                buf[i] = adata[i];
+            }
+        }
+        if (b && b->data)
+        {
+            char **bdata = (char **)b->data;
+            for (int64_t j = 0; j < blen; j++)
+            {
+                buf[alen + j] = bdata[j];
+            }
+        }
+    }
+    return out;
+}
+
+SfnArray *sailfin_runtime_append_string_v2(SfnArray *a, char *text)
+{
+    if (!a)
+    {
+        a = _sfn_array_alloc_v2(0, sizeof(char *));
+        if (!a)
+        {
+            return NULL;
+        }
+    }
+    int64_t len = a->len < 0 ? 0 : a->len;
+    int64_t cap = a->cap < 0 ? 0 : a->cap;
+    if (len >= cap)
+    {
+        int64_t new_cap = cap < 8 ? 8 : cap * 2;
+        size_t old_bytes = (size_t)cap * sizeof(char *);
+        size_t new_bytes = (size_t)new_cap * sizeof(char *);
+        void *new_data = _rt_realloc(a->data, old_bytes, new_bytes);
+        if (!new_data)
+        {
+            return NULL;
+        }
+        /* Zero the freshly grown tail so unused slots read as NULL. */
+        memset((char *)new_data + old_bytes, 0, new_bytes - old_bytes);
+        a->data = new_data;
+        a->cap = new_cap;
+    }
+    ((char **)a->data)[len] = text;
+    a->len = len + 1;
+    return a;
+}
+
+char *sailfin_runtime_array_push_slot_v2(void **data_ptr, int64_t *len_ptr,
+                                         int64_t *cap_ptr, int64_t elem_size)
+{
+    if (!data_ptr || !len_ptr || !cap_ptr)
+    {
+        return NULL;
+    }
+    if (elem_size <= 0 || elem_size > (int64_t)(1024 * 1024))
+    {
+        return NULL;
+    }
+    int64_t len = *len_ptr;
+    int64_t cap = *cap_ptr;
+    if (len < 0)
+    {
+        len = 0;
+        *len_ptr = 0;
+    }
+    if (cap < 0)
+    {
+        cap = 0;
+        *cap_ptr = 0;
+    }
+    if (len >= cap)
+    {
+        int64_t new_cap = cap < 8 ? 8 : cap * 2;
+        size_t old_bytes = (size_t)cap * (size_t)elem_size;
+        size_t new_bytes = (size_t)new_cap * (size_t)elem_size;
+        if (new_bytes / (size_t)elem_size != (size_t)new_cap)
+        {
+            return NULL; /* overflow */
+        }
+        void *new_data = _rt_realloc(*data_ptr, old_bytes, new_bytes);
+        if (!new_data)
+        {
+            return NULL;
+        }
+        memset((char *)new_data + old_bytes, 0, new_bytes - old_bytes);
+        *data_ptr = new_data;
+        *cap_ptr = new_cap;
+        cap = new_cap;
+    }
+    char *base = (char *)(*data_ptr);
+    char *slot = base + (size_t)len * (size_t)elem_size;
+    *len_ptr = len + 1;
+    return slot;
+}
+
+double sailfin_runtime_process_run_v2(SfnArray *argv)
+{
+    /* The legacy body reads `data` / `len` only — no hidden-header
+     * lookups, no canary checks. Stack-temp a SailfinPtrArray that
+     * mirrors the SfnArray's data pointer and length so we can reuse
+     * the legacy implementation without duplicating the fork/exec
+     * logic. The temp lives only on this frame; we never let the
+     * legacy body grow or reallocate it. */
+    if (!argv)
+    {
+        return 127.0;
+    }
+    SailfinPtrArray temp;
+    temp.data = (char **)argv->data;
+    temp.len = argv->len;
+    return sailfin_runtime_process_run(&temp);
+}
+
+void sailfin_adapter_fs_write_lines_v2(void *path, SfnArray *lines)
+{
+    /* Same shim strategy as `process_run_v2` — legacy body only reads
+     * data/len, stack-temp a SailfinPtrArray and forward. */
+    if (!lines)
+    {
+        return;
+    }
+    SailfinPtrArray temp;
+    temp.data = (char **)lines->data;
+    temp.len = lines->len;
+    sailfin_adapter_fs_write_lines(path, &temp);
+}
+
+SfnArray *sailfin_adapter_fs_list_directory_v2(void *path)
+{
+    /* Production path: build the SfnArray fresh with malloc-backed
+     * storage. Mirrors the legacy `sailfin_adapter_fs_list_directory`
+     * behaviour (sorted entry names, omits "." and "..") but never
+     * routes through `_alloc_array` / hidden header / canary slots. */
+    const char *path_str = (const char *)path;
+    if (!path_str || path_str[0] == '\0')
+    {
+        path_str = ".";
+    }
+
+    DIR *dir = opendir(path_str);
+    if (!dir)
+    {
+        return _sfn_array_alloc_v2(0, sizeof(char *));
+    }
+
+    size_t cap = 32;
+    size_t len = 0;
+    char **names = (char **)calloc(cap, sizeof(char *));
+    if (!names)
+    {
+        closedir(dir);
+        return NULL;
+    }
+
+    struct dirent *entry = NULL;
+    while ((entry = readdir(dir)) != NULL)
+    {
+        const char *name = entry->d_name;
+        if (!name)
+        {
+            continue;
+        }
+        if (strcmp(name, ".") == 0 || strcmp(name, "..") == 0)
+        {
+            continue;
+        }
+        if (len >= cap)
+        {
+            size_t next_cap = cap * 2;
+            char **next = (char **)realloc(names, next_cap * sizeof(char *));
+            if (!next)
+            {
+                for (size_t i = 0; i < len; i++)
+                {
+                    free(names[i]);
+                }
+                free(names);
+                closedir(dir);
+                return NULL;
+            }
+            memset(next + cap, 0, (next_cap - cap) * sizeof(char *));
+            names = next;
+            cap = next_cap;
+        }
+        char *copy = strdup(name);
+        if (!copy)
+        {
+            for (size_t i = 0; i < len; i++)
+            {
+                free(names[i]);
+            }
+            free(names);
+            closedir(dir);
+            return NULL;
+        }
+        names[len++] = copy;
+    }
+    closedir(dir);
+
+    if (len > 1)
+    {
+        qsort(names, len, sizeof(char *), _cmp_cstr_ptr);
+    }
+
+    SfnArray *out = _sfn_array_alloc_v2((int64_t)len, sizeof(char *));
+    if (!out)
+    {
+        for (size_t i = 0; i < len; i++)
+        {
+            free(names[i]);
+        }
+        free(names);
+        return NULL;
+    }
+    char **out_data = (char **)out->data;
+    for (size_t i = 0; i < len; i++)
+    {
+        if (out_data)
+        {
+            out_data[i] = names[i];
+        }
+    }
+    out->len = (int64_t)len;
+    free(names);
+    return out;
+}


### PR DESCRIPTION
## Summary

- Lock array-literal lowering to the M1 ABI shape `{ T*, i64, i64 }*` (data, len, cap). Cap is now exposed inline so push / append paths can grow the buffer in place via realloc, no hidden header.
- Add `_v2` C runtime entrypoints (`concat_v2`, `append_string_v2`, `array_push_slot_v2`, `process_run_v2`, `fs_write_lines_v2`, `fs_list_directory_v2`) that accept the 3-field shape directly and never call the legacy 2-word + canary header path. Legacy entrypoints stay exported so seed-compiled IR (still on the 2-field shape) keeps linking through the 2-pass self-host build.
- Flip the runtime helper registry (`runtime_helpers.sfn`) to route `concat` / `append_string` / `array_push_slot` / `process.run` / `fs.writeLines` / `fs.listDirectory` to the v2 symbols with new 3-field parameter / return types.

Closes #393

## Acceptance Criteria

- [x] `let xs = [1, 2, 3]` lowers to a `{i64*, i64, i64}` aggregate (numeric literals lower to `double*` under the bootstrap number ABI; the structural shape is identical).
- [x] `xs.length` resolves to slot 1 of the array struct (verified via `extractvalue` on the loaded aggregate; both GEP+load and load+extractvalue surface the value without a runtime call).
- [x] The hidden 2-word header and canary slot logic in `sailfin_runtime.c` becomes dead code on the new call paths (`_array_check_canary` / `_alloc_array` are unreachable from any `_v2` body; legacy entrypoints retain their hidden-header path so seed-compiled IR keeps working — deletion deferred to M3 per the issue).
- [x] New `compiler/tests/e2e/test_array_aggregate_shape.sh` pins the IR shape (9 sub-tests, all passing).
- [x] `make compile` passes (self-host).
- [x] `make test` passes (e2e 51/51, capsules 10/10, plus all unit / integration sub-suites green).

## Verification

```bash
ulimit -v 8388608 && make compile     # self-hosts
ulimit -v 8388608 && make test        # all green: e2e 51/51, capsules 10/10
build/native/sailfin emit llvm examples/basics/hello-world.sfn | grep -E '\{ i.*\*, i64, i64 \}' | head -5
# declare double @sailfin_runtime_process_run_v2({ i8**, i64, i64 }*)
# declare void @sailfin_adapter_fs_write_lines_v2(i8*, { i8**, i64, i64 }*)
# declare { i8**, i64, i64 }* @sailfin_adapter_fs_list_directory_v2(i8*)
# declare { i8**, i64, i64 }* @sailfin_runtime_append_string_v2({ i8**, i64, i64 }*, i8*)
# declare { i8**, i64, i64 }* @sailfin_runtime_concat_v2({ i8**, i64, i64 }*, { i8**, i64, i64 }*)

compiler/tests/e2e/test_array_aggregate_shape.sh build/native/sailfin
# [test] PASS: emitted IR contains the { T*, i64, i64 } aggregate type
# [test] PASS: numeric literal [1, 2, 3] lowers to { double*, i64, i64 }
# [test] PASS: string literal ["one", "two"] lowers to { i8**, i64, i64 }
# [test] PASS: literal lowering writes the cap slot (i32 0, i32 2)
# [test] PASS: cap slot stores i64 3 for a 3-element literal
# [test] PASS: xs.length reads slot 1 of the array struct
# [test] PASS: runtime helpers route through their _v2 symbols
# [test] PASS: array_push_slot_v2 declare carries the cap pointer parameter
# [test] PASS: no legacy { T*, i64 } 2-field array shape leaks into new IR
# [summary] 9 passed, 0 failed
```

## Files Changed

Compiler:
- `compiler/src/llvm/type_mapping.sfn` — central helper flipped to 3-field shape
- `compiler/src/llvm/expression_lowering/native/core_literals_lowering.sfn` — literal lowering writes cap slot
- `compiler/src/llvm/expression_lowering/arrays.sfn` — concat writes cap; push reads cap and routes through `array_push_slot_v2` / `append_string_v2`
- `compiler/src/llvm/expression_lowering/native/{statement,core}_type_mapping.sfn` — annotation mappers flipped
- `compiler/src/llvm/runtime_helpers.sfn` — registry flipped for 7 entries

Runtime:
- `runtime/native/include/sailfin_runtime.h` — `SfnArray` typedef + 6 v2 declarations
- `runtime/native/src/sailfin_runtime.c` — 6 v2 bodies + `_sfn_array_alloc_v2` helper

Tests:
- `compiler/tests/e2e/fixtures/array_aggregate_shape.sfn` — fixture
- `compiler/tests/e2e/test_array_aggregate_shape.sh` — 9 IR-shape assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01X8vaPdhziypJyXkM68Uw9j)_