### PR TITLE
feat(test-runner): add `--json` jsonl event stream to `sfn test` (#368)

### DIFF
--- a/compiler/src/cli_commands.sfn
+++ b/compiler/src/cli_commands.sfn
@@ -3,7 +3,7 @@
 // CLI command handlers extracted from cli_main.sfn to keep
 // sailfin_cli_main under ~500 .sfn-asm instructions (avoids seed OOM).
 import { AssertFailure, _empty_assert_failure, _parse_assert_failure_record } from "./assert_failure";
-import { Statement } from "./ast";
+import { Program, Statement } from "./ast";
 import { is_safe_scope_name, parse_scope_name } from "./capsule_artifact";
 import {
     TestCapsuleResolution,
@@ -49,7 +49,16 @@ import {
     number_to_string
 } from "./main";
 import { LayoutManifest } from "./native_ir";
+import { parse_program } from "./parser/mod";
 import { substring } from "./string_utils";
+import {
+    TestEntry,
+    collect_test_entries,
+    locate_failing_test,
+    render_start_event,
+    render_summary_event,
+    render_test_event
+} from "./test_runner_json";
 import { enter_test_runner_mode, exit_test_runner_mode } from "./test_runner_state";
 import {
     toml_add_dependency,
@@ -353,10 +362,206 @@ fn _find_test_group(groups: TestGroup[], key: string) -> number {
     return -1;
 }
 
-fn handle_test_command(args: string[], runtime_root: string) -> number ![io] {
+// Synthesize an `AssertFailure` for a test that was skipped or for
+// which we have no `fail.bin` record. `present=true` so the JSON
+// emitter still attaches an `assertion` object — consumers can
+// inspect `message` for the runner's reason (compile failed, link
+// failed, process aborted before reaching this test, etc.). The
+// `line`/`col` are 0 because the failure is not pinned to a
+// specific source location.
+fn _synthetic_assert_failure(file: string, message: string) -> AssertFailure {
+    return AssertFailure {
+        present: true,
+        file: file,
+        line: 0,
+        col: 0,
+        message: message
+    };
+}
+
+// Per-file outcome buckets used by the JSON emitter. The runner
+// drives these as it processes each file; they're consumed at the
+// bottom of the loop iteration to emit per-test events without
+// re-entering the per-file branches.
+struct TestFileOutcome {
+    kind: string;
+    failed_index: number;
+    failure: AssertFailure;
+    elapsed_ms: number;
+}
+
+fn _outcome_all_pass(elapsed_ms: number) -> TestFileOutcome {
+    return TestFileOutcome {
+        kind: "pass",
+        failed_index: -1,
+        failure: _empty_assert_failure(),
+        elapsed_ms: elapsed_ms
+    };
+}
+
+fn _outcome_failed_at(failed_index: number, failure: AssertFailure, elapsed_ms: number) -> TestFileOutcome {
+    return TestFileOutcome {
+        kind: "fail",
+        failed_index: failed_index,
+        failure: failure,
+        elapsed_ms: elapsed_ms
+    };
+}
+
+fn _outcome_setup_failure(failure: AssertFailure) -> TestFileOutcome {
+    return TestFileOutcome {
+        kind: "setup_failed",
+        failed_index: -1,
+        failure: failure,
+        elapsed_ms: 0
+    };
+}
+
+// Even-distribution slice for per-test `duration_ms`. A file's
+// binary executes every test in one process, so per-test wall time
+// is not directly observable; spec §11 documents the
+// even-distribution approximation used here. Returns 0 when the
+// file produced no test entries.
+fn _trj_per_test_duration(file_elapsed_ms: number, test_count: number) -> number {
+    if test_count <= 0 { return 0; }
+    if file_elapsed_ms <= 0 { return 0; }
+    let mut quotient: number = 0;
+    let mut remaining: number = file_elapsed_ms;
+    loop {
+        if remaining < test_count { break; }
+        remaining -= test_count;
+        quotient += 1;
+    }
+    return quotient;
+}
+
+// Emit one jsonl `test` event per entry in `entries`, attributing
+// outcomes per `outcome.kind`. Stdout-only — caller must not have
+// mixed any human banner output into the same stream.
+fn _emit_file_test_events(entries: TestEntry[], outcome: TestFileOutcome) -> number ![io] {
+    let total_in_file = entries.length;
+    let per_test_ms = _trj_per_test_duration(outcome.elapsed_ms, total_in_file);
+    let mut passed: number = 0;
+    let mut failed: number = 0;
+    let mut skipped: number = 0;
+    let mut idx: number = 0;
+    loop {
+        if idx >= entries.length { break; }
+        let entry = entries[idx];
+        let mut status: string = "pass";
+        let mut event_failure: AssertFailure = _empty_assert_failure();
+        if strings_equal(outcome.kind, "pass") {
+            status = "pass";
+            passed += 1;
+        } else if strings_equal(outcome.kind, "setup_failed") {
+            status = "skip";
+            event_failure = outcome.failure;
+            skipped += 1;
+        } else {
+            // outcome.kind == "fail"
+            if outcome.failed_index < 0 {
+                // Couldn't pin the failure to a specific test; flag the
+                // first entry as the failing one and skip the rest. See
+                // spec §11 for the attribution rule.
+                if idx == 0 {
+                    status = "fail";
+                    event_failure = outcome.failure;
+                    failed += 1;
+                } else {
+                    status = "skip";
+                    skipped += 1;
+                }
+            } else {
+                if idx < outcome.failed_index {
+                    status = "pass";
+                    passed += 1;
+                } else if idx == outcome.failed_index {
+                    status = "fail";
+                    event_failure = outcome.failure;
+                    failed += 1;
+                } else {
+                    status = "skip";
+                    skipped += 1;
+                }
+            }
+        }
+        let line = render_test_event(entry.name, entry.file, entry.line, status, per_test_ms, entry.effects, event_failure);
+        print(line);
+        idx += 1;
+    }
+    // Pack pass/fail/skip into the outcome's `failed_index` slot via
+    // a side-effect-free encoding for the caller's running totals.
+    // Returning a struct from this function would force the caller
+    // into another pattern-match; instead we expose three accessors
+    // on a small typed counter.
+    return passed * 1000000 + failed * 1000 + skipped;
+}
+
+fn _trj_decode_passed(packed: number) -> number {
+    let mut p: number = packed;
+    if p < 0 { p = 0 - p; }
+    let mut count: number = 0;
+    loop {
+        if p < 1000000 { break; }
+        p -= 1000000;
+        count += 1;
+    }
+    return count;
+}
+
+fn _trj_decode_failed(packed: number) -> number {
+    let mut p: number = packed;
+    if p < 0 { p = 0 - p; }
+    // Strip the millions slot.
+    loop {
+        if p < 1000000 { break; }
+        p -= 1000000;
+    }
+    let mut count: number = 0;
+    loop {
+        if p < 1000 { break; }
+        p -= 1000;
+        count += 1;
+    }
+    return count;
+}
+
+fn _trj_decode_skipped(packed: number) -> number {
+    let mut p: number = packed;
+    if p < 0 { p = 0 - p; }
+    loop {
+        if p < 1000000 { break; }
+        p -= 1000000;
+    }
+    loop {
+        if p < 1000 { break; }
+        p -= 1000;
+    }
+    return p;
+}
+
+fn handle_test_command(args: string[], runtime_root: string) -> number ![io, clock] {
+    // Flag parser: `--json` is the only recognised flag for now.
+    // Positional args carry the optional `path` argument; preserves
+    // pre-existing behaviour where `sfn test [path]` accepts at most
+    // one positional. The flag may appear before or after the path.
+    let mut json_output: boolean = false;
+    let mut positional: string[] = [];
+    let mut ai: number = 1;
+    loop {
+        if ai >= args.length { break; }
+        let arg = args[ai];
+        if strings_equal(arg, "--json") { json_output = true; } else {
+            positional.push(arg);
+        }
+        ai += 1;
+    }
     let mut root: string = ".";
-    if args.length == 2 { root = args[1]; } else if args.length != 1 {
-        print("usage: sfn test [path]");
+    if positional.length == 1 { root = positional[0]; } else if positional.length > 1 {
+        // Usage hints belong on stderr in `--json` mode so the stdout
+        // jsonl stream stays clean. Mirrored on the human path for
+        // consistency.
+        print.err("usage: sfn test [--json] [path]");
         return 2;
     }
 
@@ -378,7 +583,13 @@ fn handle_test_command(args: string[], runtime_root: string) -> number ![io] {
 
     let test_files = _collect_test_files_cmd(root, 25);
     if test_files.length == 0 {
-        print("no Sailfin test files found under: " + root);
+        if json_output {
+            // Still produce a valid jsonl stream so consumers don't
+            // have to special-case empty discovery — start, no test
+            // events, summary with all zeros.
+            print(render_start_event(0));
+            print(render_summary_event(0, 0, 0, 0));
+        } else { print("no Sailfin test files found under: " + root); }
         exit_test_runner_mode();
         return 1;
     }
@@ -499,12 +710,54 @@ fn handle_test_command(args: string[], runtime_root: string) -> number ![io] {
     // same accumulating-allocation wall `sfn check` did pre-Phase-5a.
     let test_scratch_mark = sailfin_intrinsic_runtime_arena_mark();
 
+    // Pre-parse pass: only run in `--json` mode. Walks every test
+    // file once, parses it, and pulls out the
+    // `test "name" { ... }` declarations. Three reasons the runner
+    // needs this: (1) the `start` event's `total` must be exact
+    // before the first per-test event is emitted; (2) per-test
+    // names and source spans must be known even when the test
+    // binary aborts mid-suite (the harness calls every `test:`
+    // symbol in sequence and a single `assert false;` brings the
+    // whole process down via `abort()`); (3) compile failures
+    // still need attribution to the affected tests so consumers
+    // see a `skip` event per declaration. The non-`--json` path
+    // skips the extra read+parse and matches the previous
+    // behaviour exactly — a measurable saving for the ~75-file
+    // self-host suite where every read+parse cycle adds up.
+    let mut per_file_entries: TestEntry[][] = [];
+    let mut total_tests: number = 0;
+    if json_output {
+        let mut pi: number = 0;
+        loop {
+            if pi >= test_files.length { break; }
+            let pre_path = test_files[pi];
+            let pre_source = fs.readFile(pre_path);
+            let pre_program: Program = parse_program(pre_source);
+            let entries = collect_test_entries(pre_program, pre_path);
+            per_file_entries.push(entries);
+            total_tests += entries.length;
+            pi += 1;
+        }
+        print(render_start_event(total_tests));
+    }
+
+    let runner_start_ms = monotonic_millis();
+
+    let mut total_passed: number = 0;
+    let mut total_failed: number = 0;
+    let mut total_skipped: number = 0;
+    let mut overall_rc: number = 0;
+
     let mut index: number = 0;
     loop {
         if index >= test_files.length { break; }
         let path = test_files[index];
         let group_idx = file_group_index[index];
-        print("test: " + path);
+        // `per_file_entries` is only populated in `--json` mode;
+        // the human path doesn't read it.
+        let mut entries: TestEntry[] = [];
+        if json_output { entries = per_file_entries[index]; }
+        if !json_output { print("test: " + path); }
         let source = fs.readFile(path);
         let module_name = module_name_from_path(path);
 
@@ -513,12 +766,30 @@ fn handle_test_command(args: string[], runtime_root: string) -> number ![io] {
             _write_text_cmd(scratch_root + "/test-source-" + safe + ".sfn", source);
         }
 
+        let file_start_ms = monotonic_millis();
+
         if trace_runner { print.err("test runner: compile start"); }
         _clean_lowering_state(scratch_root);
         let empty_manifests: LayoutManifest[] = [];
         let _compiled = compile_tests_to_llvm_file_with_module_imports(source, module_name, ll_path, groups[group_idx].interfaces, empty_manifests, groups[group_idx].native_texts, groups[group_idx].function_effects, groups[group_idx].capabilities_required);
         if !_compiled {
-            print("test runner: compile failed for " + path);
+            // Stderr stays usable for compiler-internal diagnostics
+            // even in `--json` mode; the affected tests show up as
+            // `skip` events with a synthetic assertion message so
+            // consumers can correlate the stderr noise with the
+            // tests that didn't run.
+            print.err("test runner: compile failed for " + path);
+            if json_output {
+                let outcome = _outcome_setup_failure(_synthetic_assert_failure(path, "compile failed"));
+                let packed = _emit_file_test_events(entries, outcome);
+                total_passed += _trj_decode_passed(packed);
+                total_failed += _trj_decode_failed(packed);
+                total_skipped += _trj_decode_skipped(packed);
+                overall_rc = 1;
+                sailfin_intrinsic_runtime_arena_rewind(test_scratch_mark);
+                index += 1;
+                continue;
+            }
             exit_test_runner_mode();
             return 1;
         }
@@ -526,7 +797,21 @@ fn handle_test_command(args: string[], runtime_root: string) -> number ![io] {
         if trace_runner { print.err("test runner: link start"); }
         let link_rc = _clang_link_test_cmd_with_deps(ll_path, exe_path, runtime_root, groups[group_idx].dep_ll_paths);
         if link_rc != 0 {
-            print("link failed (clang exit=" + number_to_string(link_rc) + ")");
+            print.err("link failed (clang exit=" + number_to_string(link_rc)
+                + ")");
+            if json_output {
+                let outcome = _outcome_setup_failure(_synthetic_assert_failure(path, "link failed (clang exit="
+                    + number_to_string(link_rc)
+                    + ")"));
+                let packed = _emit_file_test_events(entries, outcome);
+                total_passed += _trj_decode_passed(packed);
+                total_failed += _trj_decode_failed(packed);
+                total_skipped += _trj_decode_skipped(packed);
+                if overall_rc == 0 { overall_rc = link_rc; }
+                sailfin_intrinsic_runtime_arena_rewind(test_scratch_mark);
+                index += 1;
+                continue;
+            }
             exit_test_runner_mode();
             return link_rc;
         }
@@ -549,12 +834,37 @@ fn handle_test_command(args: string[], runtime_root: string) -> number ![io] {
         // so a stale record from a previous iteration can't leak
         // into the next pass. `present=false` is the pass case.
         let failure = _consume_assert_failure_record(scratch_root);
+        let file_elapsed_ms = monotonic_millis() - file_start_ms;
         if run_rc != 0 {
+            if json_output {
+                let mut effective = failure;
+                if !effective.present {
+                    effective = _synthetic_assert_failure(path, "test process exited with code "
+                        + number_to_string(run_rc));
+                }
+                let failed_index = locate_failing_test(entries, effective);
+                let outcome = _outcome_failed_at(failed_index, effective, file_elapsed_ms);
+                let packed = _emit_file_test_events(entries, outcome);
+                total_passed += _trj_decode_passed(packed);
+                total_failed += _trj_decode_failed(packed);
+                total_skipped += _trj_decode_skipped(packed);
+                if overall_rc == 0 { overall_rc = run_rc; }
+                sailfin_intrinsic_runtime_arena_rewind(test_scratch_mark);
+                index += 1;
+                continue;
+            }
             if failure.present {
                 print("test failed: " + _format_assert_failure(path, failure));
             } else { print("test failed: " + path); }
             exit_test_runner_mode();
             return run_rc;
+        }
+        if json_output {
+            let outcome = _outcome_all_pass(file_elapsed_ms);
+            let packed = _emit_file_test_events(entries, outcome);
+            total_passed += _trj_decode_passed(packed);
+            total_failed += _trj_decode_failed(packed);
+            total_skipped += _trj_decode_skipped(packed);
         }
         // Phase 5a: rewind arena scratch back to the per-test
         // mark. Per-iteration allocations (parsed test AST,
@@ -565,8 +875,12 @@ fn handle_test_command(args: string[], runtime_root: string) -> number ![io] {
         sailfin_intrinsic_runtime_arena_rewind(test_scratch_mark);
         index += 1;
     }
+    if json_output {
+        let runner_elapsed_ms = monotonic_millis() - runner_start_ms;
+        print(render_summary_event(total_passed, total_failed, total_skipped, runner_elapsed_ms));
+    }
     exit_test_runner_mode();
-    return 0;
+    return overall_rc;
 }
 
 // ═══════════════════════════════════════════════════════════════════

--- a/compiler/src/test_runner_json.sfn
+++ b/compiler/src/test_runner_json.sfn
@@ -1,0 +1,293 @@
+// compiler/src/test_runner_json.sfn
+//
+// JSON-line event emitters for `sfn test --json`. Pure module: no I/O,
+// no global state. The CLI orchestrator (`cli_commands.sfn`) is
+// responsible for writing the rendered strings to stdout, one event
+// per line.
+//
+// Wire format (jsonl, schema-versioned):
+//
+//   {"event":"start","total":N,"schema_version":1}
+//   {"event":"test","name":"...","file":"...","line":N,
+//    "status":"pass"|"fail"|"skip","duration_ms":N,"effects":[...],
+//    "assertion":{...}?}
+//   {"event":"summary","passed":N,"failed":N,"skipped":N,"duration_ms":N}
+//
+// Issue #368 (P6 — sfn test --json event stream).
+//
+// Schema version policy: bump `TEST_RUNNER_JSON_SCHEMA_VERSION` on any
+// breaking change to the wire format. Consumers SHOULD refuse to
+// process unknown versions rather than try to compatibilize. New
+// optional fields can be added without a bump because consumers ignore
+// unknown keys; new event kinds, removed fields, or repurposed field
+// types are breaking.
+//
+// `AssertFailure` is the typed shape from `assert_failure.sfn`
+// (issue #364). Both this module and the human-readable test runner
+// (in `cli_commands.sfn`) consume it without copying — keep its
+// definition in `assert_failure.sfn`.
+import { AssertFailure } from "./assert_failure";
+import { Program, SourceSpan, Statement } from "./ast";
+import { substring } from "./string_utils";
+
+// Bumped only on a breaking change to any of the three event shapes.
+// Consumers (the planned MCP `sailfin_test_runner` tool, CI scrapers,
+// the `assert_compiles` integration) hard-fail on unknown values.
+let TEST_RUNNER_JSON_SCHEMA_VERSION: number = 1;
+
+// One test entry collected from a parsed source file. Populated by
+// `collect_test_entries` before the test binary runs so the runner
+// can emit per-test events even when the binary aborts mid-suite
+// (a failing `assert e;` kills the whole test process).
+struct TestEntry {
+    name: string;
+    file: string;
+    line: number;
+    effects: string[];
+}
+
+fn _trj_empty_effects() -> string[] {
+    let out: string[] = [];
+    return out;
+}
+
+fn _trj_make_test_entry(name: string, file: string, line: number, effects: string[]) -> TestEntry {
+    return TestEntry {
+        name: name,
+        file: file,
+        line: line,
+        effects: effects
+    };
+}
+
+// -------------------------------------------------------------------
+// Primitive JSON encoders
+// -------------------------------------------------------------------
+// Mirrors `diagnostics_json.sfn`'s escaper: same six escapes
+// (`\"`, `\\`, `\n`, `\r`, `\t`) plus a literal-passthrough for
+// everything else. Test names and effect labels are ASCII-clean by
+// the lexer, so a minimal escaper is sufficient.
+fn _trj_escape_string(s: string) -> string {
+    let mut out: string = "";
+    let mut i: number = 0;
+    loop {
+        if i >= s.length { break; }
+        let ch = substring(s, i, i + 1);
+        if ch == "\"" { out = out + "\\\""; } else if ch == "\\" {
+            out = out + "\\\\";
+        } else if ch == "\n" { out = out + "\\n"; } else if ch == "\r" {
+            out = out + "\\r";
+        } else if ch == "\t" { out = out + "\\t"; } else { out = out + ch; }
+        i += 1;
+    }
+    return out;
+}
+
+fn _trj_quote(s: string) -> string {
+    return "\"" + _trj_escape_string(s) + "\"";
+}
+
+fn _trj_field(name: string, value: string) -> string {
+    return _trj_quote(name) + ":" + value;
+}
+
+fn _trj_string_field(name: string, value: string) -> string {
+    return _trj_field(name, _trj_quote(value));
+}
+
+fn _trj_number_field(name: string, value: number) -> string {
+    return _trj_field(name, _trj_number_to_string(value));
+}
+
+// Local copy of `number_to_string` to keep this module pure (no `main`
+// dependency). Same algorithm as `diagnostics_json.sfn`'s
+// `_dj_number_to_string`.
+fn _trj_number_to_string(value: number) -> string {
+    if value == 0 { return "0"; }
+    let mut working: number = value;
+    let mut negative: boolean = false;
+    if working < 0 {
+        negative = true;
+        working = 0 - working;
+    }
+    let digits = "0123456789";
+    let mut remaining: number = working;
+    let mut output: string = "";
+    loop {
+        if remaining <= 0 { break; }
+        let mut temp: number = remaining;
+        let mut quotient: number = 0;
+        loop {
+            if temp < 10 { break; }
+            temp -= 10;
+            quotient += 1;
+        }
+        let ch = substring(digits, temp, temp + 1);
+        output = ch + output;
+        remaining = quotient;
+    }
+    if negative { output = "-" + output; }
+    return output;
+}
+
+fn _trj_join(parts: string[], sep: string) -> string {
+    if parts.length == 0 { return ""; }
+    let mut out = parts[0];
+    let mut i: number = 1;
+    loop {
+        if i >= parts.length { break; }
+        out = out + sep + parts[i];
+        i += 1;
+    }
+    return out;
+}
+
+fn _trj_render_string_array(values: string[]) -> string {
+    if values.length == 0 { return "[]"; }
+    let mut parts: string[] = [];
+    let mut i: number = 0;
+    loop {
+        if i >= values.length { break; }
+        parts.push(_trj_quote(values[i]));
+        i += 1;
+    }
+    return "[" + _trj_join(parts, ",") + "]";
+}
+
+// -------------------------------------------------------------------
+// AssertFailure → JSON object
+// -------------------------------------------------------------------
+// Render `AssertFailure` as the inner `assertion` object. Field order
+// is stable so golden-file tests stay diff-clean even though jsonl
+// semantics don't require it. The runner only attaches this object
+// when `failure.present` is true; the encoder itself is total and
+// ignores `present`.
+fn render_assert_failure_json(failure: AssertFailure) -> string {
+    let mut parts: string[] = [];
+    parts.push(_trj_string_field("file", failure.file));
+    parts.push(_trj_number_field("line", failure.line));
+    parts.push(_trj_number_field("col", failure.col));
+    parts.push(_trj_string_field("message", failure.message));
+    return "{" + _trj_join(parts, ",") + "}";
+}
+
+// -------------------------------------------------------------------
+// Top-level event emitters
+// -------------------------------------------------------------------
+// First line of a `sfn test --json` run. Emitted exactly once,
+// before any `test` event. `total` is the count of test declarations
+// across every file the runner will execute; consumers use it to
+// drive a progress bar without buffering the whole stream.
+fn render_start_event(total: number) -> string {
+    let mut parts: string[] = [];
+    parts.push(_trj_string_field("event", "start"));
+    parts.push(_trj_number_field("total", total));
+    parts.push(_trj_number_field("schema_version", TEST_RUNNER_JSON_SCHEMA_VERSION));
+    return "{" + _trj_join(parts, ",") + "}";
+}
+
+// One per test. `status` is `"pass"`, `"fail"`, or `"skip"`. The
+// optional `assertion` object is attached when `failure.present` is
+// true; the runner currently sets it only on the failing test (the
+// process aborts on the first failure, so per-test attribution past
+// that point is "skip" with no assertion). `duration_ms` is the
+// wall-clock time the runner observed for this test; for tests that
+// share a file's binary process, the per-test slice is approximated
+// by even-distribution of the file's run time over its tests. See
+// the spec for the full schema.
+fn render_test_event(name: string, file: string, line: number, status: string, duration_ms: number, effects: string[], failure: AssertFailure) -> string {
+    let mut parts: string[] = [];
+    parts.push(_trj_string_field("event", "test"));
+    parts.push(_trj_string_field("name", name));
+    parts.push(_trj_string_field("file", file));
+    parts.push(_trj_number_field("line", line));
+    parts.push(_trj_string_field("status", status));
+    parts.push(_trj_number_field("duration_ms", duration_ms));
+    parts.push(_trj_field("effects", _trj_render_string_array(effects)));
+    if failure.present {
+        parts.push(_trj_field("assertion", render_assert_failure_json(failure)));
+    }
+    return "{" + _trj_join(parts, ",") + "}";
+}
+
+// Final line of a `sfn test --json` run. Emitted exactly once, after
+// the last `test` event. `duration_ms` is the wall-clock time of the
+// whole runner invocation.
+fn render_summary_event(passed: number, failed: number, skipped: number, duration_ms: number) -> string {
+    let mut parts: string[] = [];
+    parts.push(_trj_string_field("event", "summary"));
+    parts.push(_trj_number_field("passed", passed));
+    parts.push(_trj_number_field("failed", failed));
+    parts.push(_trj_number_field("skipped", skipped));
+    parts.push(_trj_number_field("duration_ms", duration_ms));
+    return "{" + _trj_join(parts, ",") + "}";
+}
+
+// -------------------------------------------------------------------
+// Pre-run parse pass: collect test names + spans
+// -------------------------------------------------------------------
+// Walk a parsed `Program` and pick out each `TestDeclaration` in
+// source order. The runner uses this ahead of compilation so it can
+// emit per-test events even when the test binary aborts mid-suite,
+// and so the `start` event's `total` count is exact rather than an
+// estimate. Returns an empty array if `program.statements` contains
+// no test declarations (the runner should still emit a summary in
+// that case).
+fn collect_test_entries(program: Program, file_path: string) -> TestEntry[] {
+    let mut out: TestEntry[] = [];
+    let mut i: number = 0;
+    loop {
+        if i >= program.statements.length { break; }
+        let stmt = program.statements[i];
+        if stmt.variant == "TestDeclaration" {
+            let mut line: number = 0;
+            if stmt.name_span != null {
+                let span: SourceSpan? = stmt.name_span;
+                line = span.start_line;
+            }
+            out.push(_trj_make_test_entry(stmt.name, file_path, line, stmt.effects));
+        }
+        i += 1;
+    }
+    return out;
+}
+
+// Map an assertion failure record back to a test in this file. The
+// record's `line` field is the assert statement's source line; pick
+// the test whose `line` is the largest line ≤ failure.line (i.e. the
+// closest preceding test in source order). Returns `-1` when the
+// failure record is absent or when no test precedes the recorded
+// line — the runner falls back to treating the first not-yet-passed
+// test as the failing one in those cases.
+fn locate_failing_test(entries: TestEntry[], failure: AssertFailure) -> number {
+    if !failure.present { return -1; }
+    if failure.line <= 0 { return -1; }
+    let mut best_index: number = -1;
+    let mut best_line: number = -1;
+    let mut i: number = 0;
+    loop {
+        if i >= entries.length { break; }
+        let entry_line = entries[i].line;
+        if entry_line > 0 {
+            if entry_line <= failure.line {
+                if entry_line > best_line {
+                    best_line = entry_line;
+                    best_index = i;
+                }
+            }
+        }
+        i += 1;
+    }
+    return best_index;
+}
+
+export {
+    TEST_RUNNER_JSON_SCHEMA_VERSION,
+    TestEntry,
+    collect_test_entries,
+    locate_failing_test,
+    render_assert_failure_json,
+    render_start_event,
+    render_summary_event,
+    render_test_event
+};

--- a/compiler/tests/integration/test_runner_json_test.sfn
+++ b/compiler/tests/integration/test_runner_json_test.sfn
@@ -1,0 +1,188 @@
+// Issue #368 / P6: golden-output check for the `sfn test --json`
+// event stream emitters.
+//
+// This file is the contract pin for the wire format documented in
+// `site/src/content/docs/docs/reference/spec/11-testing.md`. Each
+// test below exercises one event kind on a known input and
+// asserts on the exact rendered string. If any of these flip,
+// either the schema is changing on purpose (bump
+// `TEST_RUNNER_JSON_SCHEMA_VERSION` and update the spec) or the
+// emitter is drifting (fix the emitter).
+//
+// The end-to-end smoke path — driving the actual binary with a
+// mixed pass/fail fixture — lives in the issue's verification
+// block; reproducing it here would require subprocess piping
+// that integration tests intentionally avoid.
+import { AssertFailure, _empty_assert_failure } from "../../src/assert_failure";
+import { Program, Statement } from "../../src/ast";
+import { parse_program } from "../../src/parser/mod";
+import {
+    TEST_RUNNER_JSON_SCHEMA_VERSION,
+    TestEntry,
+    collect_test_entries,
+    locate_failing_test,
+    render_assert_failure_json,
+    render_start_event,
+    render_summary_event,
+    render_test_event
+} from "../../src/test_runner_json";
+
+fn _empty_effects() -> string[] {
+    let out: string[] = [];
+    return out;
+}
+
+fn _failure(file: string, line: number, col: number, message: string) -> AssertFailure {
+    return AssertFailure {
+        present: true,
+        file: file,
+        line: line,
+        col: col,
+        message: message
+    };
+}
+
+// --------------------------------------------------------------
+// Schema version constant
+// --------------------------------------------------------------
+test "test_runner_json: schema version is 1 (consumers hard-fail on unknown)" {
+    assert TEST_RUNNER_JSON_SCHEMA_VERSION == 1;
+}
+
+// --------------------------------------------------------------
+// `start` event
+// --------------------------------------------------------------
+test "test_runner_json: start event golden shape" {
+    let line = render_start_event(7);
+    assert line == "{\"event\":\"start\",\"total\":7,\"schema_version\":1}";
+}
+
+test "test_runner_json: start event handles zero-test discovery" {
+    let line = render_start_event(0);
+    assert line == "{\"event\":\"start\",\"total\":0,\"schema_version\":1}";
+}
+
+// --------------------------------------------------------------
+// `summary` event
+// --------------------------------------------------------------
+test "test_runner_json: summary event golden shape" {
+    let line = render_summary_event(40, 1, 1, 1284);
+    assert line == "{\"event\":\"summary\",\"passed\":40,\"failed\":1,\"skipped\":1,\"duration_ms\":1284}";
+}
+
+test "test_runner_json: summary all-zero shape (empty discovery)" {
+    let line = render_summary_event(0, 0, 0, 0);
+    assert line == "{\"event\":\"summary\",\"passed\":0,\"failed\":0,\"skipped\":0,\"duration_ms\":0}";
+}
+
+// --------------------------------------------------------------
+// `test` event — pass case (no `assertion` field)
+// --------------------------------------------------------------
+test "test_runner_json: test event pass shape omits assertion" {
+    let effects: string[] = ["io"];
+    let nothing = _empty_assert_failure();
+    let line = render_test_event("answer", "foo_test.sfn", 3, "pass", 12, effects, nothing);
+    assert line == "{\"event\":\"test\",\"name\":\"answer\",\"file\":\"foo_test.sfn\",\"line\":3,\"status\":\"pass\",\"duration_ms\":12,\"effects\":[\"io\"]}";
+}
+
+test "test_runner_json: test event with empty effects renders []" {
+    let nothing = _empty_assert_failure();
+    let line = render_test_event("plain", "bar_test.sfn", 1, "pass", 0, _empty_effects(), nothing);
+    assert line == "{\"event\":\"test\",\"name\":\"plain\",\"file\":\"bar_test.sfn\",\"line\":1,\"status\":\"pass\",\"duration_ms\":0,\"effects\":[]}";
+}
+
+test "test_runner_json: test event with multiple effects preserves order" {
+    let effects: string[] = ["io", "net", "clock"];
+    let nothing = _empty_assert_failure();
+    let line = render_test_event("multi", "x.sfn", 5, "pass", 1, effects, nothing);
+    assert line == "{\"event\":\"test\",\"name\":\"multi\",\"file\":\"x.sfn\",\"line\":5,\"status\":\"pass\",\"duration_ms\":1,\"effects\":[\"io\",\"net\",\"clock\"]}";
+}
+
+// --------------------------------------------------------------
+// `test` event — fail case (assertion attached from AssertFailure)
+// --------------------------------------------------------------
+test "test_runner_json: test event fail shape attaches assertion" {
+    let failure = _failure("foo_test.sfn", 8, 12, "expected x == 42");
+    let line = render_test_event("breaks", "foo_test.sfn", 7, "fail", 3, _empty_effects(), failure);
+    assert line == "{\"event\":\"test\",\"name\":\"breaks\",\"file\":\"foo_test.sfn\",\"line\":7,\"status\":\"fail\",\"duration_ms\":3,\"effects\":[],\"assertion\":{\"file\":\"foo_test.sfn\",\"line\":8,\"col\":12,\"message\":\"expected x == 42\"}}";
+}
+
+// --------------------------------------------------------------
+// AssertFailure → JSON
+// --------------------------------------------------------------
+test "test_runner_json: assertion shape is {file,line,col,message} in stable order" {
+    let failure = _failure("path/to/test.sfn", 12, 3, "boom");
+    let line = render_assert_failure_json(failure);
+    assert line == "{\"file\":\"path/to/test.sfn\",\"line\":12,\"col\":3,\"message\":\"boom\"}";
+}
+
+test "test_runner_json: assertion message escapes embedded quotes" {
+    let failure = _failure("t.sfn", 1, 1, "got \"ok\"");
+    let line = render_assert_failure_json(failure);
+    assert line == "{\"file\":\"t.sfn\",\"line\":1,\"col\":1,\"message\":\"got \\\"ok\\\"\"}";
+}
+
+test "test_runner_json: assertion message escapes backslashes" {
+    let failure = _failure("t.sfn", 1, 1, "C:\\path");
+    let line = render_assert_failure_json(failure);
+    assert line == "{\"file\":\"t.sfn\",\"line\":1,\"col\":1,\"message\":\"C:\\\\path\"}";
+}
+
+// --------------------------------------------------------------
+// Pre-run pass: collect_test_entries
+// --------------------------------------------------------------
+test "test_runner_json: collect_test_entries finds every test in source order" {
+    let source = "test \"first\" { assert true; }\n"
+        + "test \"second\" ![io] { assert true; }\n"
+        + "fn helper() { return; }\n"
+        + "test \"third\" { assert true; }\n";
+    let program: Program = parse_program(source);
+    let entries = collect_test_entries(program, "fixture.sfn");
+    assert entries.length == 3;
+    assert entries[0].name == "first";
+    assert entries[0].file == "fixture.sfn";
+    assert entries[0].line == 1;
+    assert entries[0].effects.length == 0;
+    assert entries[1].name == "second";
+    assert entries[1].line == 2;
+    assert entries[1].effects.length == 1;
+    assert entries[1].effects[0] == "io";
+    assert entries[2].name == "third";
+    assert entries[2].line == 4;
+}
+
+test "test_runner_json: collect_test_entries returns empty when no tests" {
+    let source = "fn nothing_to_see() -> number { return 0; }\n";
+    let program: Program = parse_program(source);
+    let entries = collect_test_entries(program, "no_tests.sfn");
+    assert entries.length == 0;
+}
+
+// --------------------------------------------------------------
+// locate_failing_test attribution rule
+// --------------------------------------------------------------
+test "test_runner_json: locate_failing_test picks closest preceding test" {
+    let source = "test \"a\" { assert true; }\n"
+        + "test \"b\" { assert true; }\n"
+        + "test \"c\" { assert true; }\n";
+    let program: Program = parse_program(source);
+    let entries = collect_test_entries(program, "f.sfn");
+    let failure = _failure("f.sfn", 2, 12, "boom");
+    // Test `b` is on line 2; failure at line 2 maps to index 1.
+    assert locate_failing_test(entries, failure) == 1;
+}
+
+test "test_runner_json: locate_failing_test returns -1 when failure absent" {
+    let entries: TestEntry[] = [];
+    let nothing = _empty_assert_failure();
+    assert locate_failing_test(entries, nothing) == -1;
+}
+
+test "test_runner_json: locate_failing_test returns -1 when no test precedes line 0" {
+    let source = "test \"only\" { assert true; }\n";
+    let program: Program = parse_program(source);
+    let entries = collect_test_entries(program, "f.sfn");
+    let failure = _failure("f.sfn", 0, 0, "synthetic — no record");
+    // failure.line == 0 → no preceding test, falls back to -1.
+    assert locate_failing_test(entries, failure) == -1;
+}

--- a/site/src/content/docs/docs/reference/spec/11-testing.md
+++ b/site/src/content/docs/docs/reference/spec/11-testing.md
@@ -19,3 +19,132 @@ test "name" ![effects] {
 - `assert expr;` is a statement form (no parens) and fails with the expression text
 
 ---
+
+## Test runner JSON output
+
+`sfn test --json` emits a machine-readable [JSON Lines](https://jsonlines.org/)
+event stream on stdout — one event per line, with no human banner output.
+Stderr remains usable for compiler-internal diagnostics that don't fit the
+schema (e.g. "compiler crashed" stack traces, `[trace]` runner logs).
+
+The stream is the canonical contract that CI tooling, the planned MCP
+`sailfin_test_runner` tool, and the `assert_compiles` integration consume to
+verify generated code passes its tests without scraping human-readable
+output.
+
+### Event shapes
+
+Three event kinds, schema-versioned:
+
+```jsonc
+// First line — exactly once per run.
+{"event":"start","total":42,"schema_version":1}
+
+// One per test, in source order.
+{"event":"test","name":"answer is 42","file":"path/to/foo_test.sfn",
+ "line":3,"status":"pass","duration_ms":12,"effects":["io"]}
+
+// `assertion` is attached when status == "fail" or when the runner
+// synthesised a skip/fail reason (compile failure, link failure,
+// process aborted before this test ran).
+{"event":"test","name":"breaks","file":"path/to/foo_test.sfn",
+ "line":7,"status":"fail","duration_ms":3,"effects":[],
+ "assertion":{"file":"path/to/foo_test.sfn","line":8,"col":12,
+              "message":"expected x == 42, got 41"}}
+
+// Last line — exactly once per run.
+{"event":"summary","passed":40,"failed":1,"skipped":1,"duration_ms":1284}
+```
+
+### Field semantics
+
+| Event     | Field            | Type      | Meaning                                                         |
+|-----------|------------------|-----------|-----------------------------------------------------------------|
+| `start`   | `total`          | integer   | Count of test declarations the runner discovered up front.      |
+| `start`   | `schema_version` | integer   | Currently `1`. Bumped only on a breaking change.                |
+| `test`    | `name`           | string    | The literal `test "..."` name from source.                      |
+| `test`    | `file`           | string    | Source file path, as discovered by `sfn test`.                  |
+| `test`    | `line`           | integer   | 1-based source line of the `test` keyword.                      |
+| `test`    | `status`         | string    | `"pass"`, `"fail"`, or `"skip"`.                                |
+| `test`    | `duration_ms`    | integer   | Wall-clock time approximation; see *Timing approximation* below.|
+| `test`    | `effects`        | string[]  | Effects declared on the test, e.g. `["io", "net"]`.             |
+| `test`    | `assertion`      | object?   | Present on `"fail"` and on synthesised `"skip"` reasons.        |
+| `summary` | `passed`         | integer   | Tests with `status == "pass"`.                                  |
+| `summary` | `failed`         | integer   | Tests with `status == "fail"`.                                  |
+| `summary` | `skipped`        | integer   | Tests with `status == "skip"`.                                  |
+| `summary` | `duration_ms`    | integer   | Wall-clock time of the entire `sfn test --json` invocation.     |
+
+The optional `assertion` object carries the typed
+[`AssertFailure`](https://github.com/SailfinIO/sailfin/blob/main/compiler/src/assert_failure.sfn)
+record:
+
+```jsonc
+{"file":"...","line":N,"col":N,"message":"..."}
+```
+
+When the runner cannot pin a failure to a specific source location (e.g. the
+file's compile or link step failed, or the test process aborted with no
+`fail.bin` record), `line` and `col` are `0` and `message` carries a
+synthesised reason (`"compile failed"`, `"link failed (clang exit=1)"`,
+`"test process exited with code 134"`, etc.).
+
+### Status attribution rule
+
+The Sailfin test runner compiles every `test "..." { ... }` block in a file
+into a single binary harness; an `assert false;` aborts the process via
+`abort()` and unblocks no later tests. The JSON attribution rule reflects
+that:
+
+- Tests in a file whose binary exits `0` are all marked `"pass"`.
+- When the binary exits non-zero with a `fail.bin` record, the runner
+  matches the assertion's `line` to the test whose `line` is the largest
+  ≤ the failure line (the closest preceding test in source order). That
+  test is marked `"fail"`; tests earlier in the file are marked `"pass"`;
+  tests later in the file are marked `"skip"`.
+- When the binary exits non-zero with no `fail.bin` record, the first test
+  in the file is marked `"fail"` with a synthesised `assertion.message`,
+  and the rest are marked `"skip"`.
+- When a file's compile or link fails, every test in that file is marked
+  `"skip"` with a synthesised `assertion.message`. The runner continues to
+  the next file so consumers see a full per-test stream.
+
+### Timing approximation
+
+`duration_ms` on a `test` event is the file's wall-clock execution time
+divided evenly across the file's tests. Per-test wall time is not
+directly observable today because every test in a file runs inside one
+process; consumers should treat `duration_ms` as an indication of
+roughly-balanced cost rather than a precise per-test measurement. The
+`summary.duration_ms` field is the total wall time of the `sfn test --json`
+invocation and is exact.
+
+### Schema version policy
+
+`schema_version` is a monotonically increasing integer attached to the
+`start` event. The current version is `1`.
+
+- Adding optional fields to existing events is **not** a breaking change.
+  Consumers are expected to ignore unknown fields.
+- Adding new event kinds is **not** a breaking change. Consumers should
+  ignore unknown `event` discriminators rather than fail.
+- Removing fields, repurposing field types, changing field semantics, or
+  changing event ordering is breaking. The version is bumped in lockstep.
+
+Consumers SHOULD hard-fail (refuse to process the stream) on an unknown
+`schema_version` rather than try to compatibilize forward-incompatible
+output.
+
+### Stream contract
+
+For any `sfn test --json` invocation:
+
+- The first line on stdout is always a `start` event.
+- The last line on stdout is always a `summary` event.
+- Every line between is a `test` event in source-discovery order.
+- Stdout contains nothing else — no human banners, no progress lines.
+- Stderr may contain anything (compiler diagnostics, runner traces).
+
+Consumers that pipe into `jq -c` can rely on every line being a complete
+JSON object with no trailing whitespace.
+
+---


### PR DESCRIPTION
## Summary

- Adds `--json` to `sfn test`, emitting one schema-versioned JSON event per line on stdout.
- New `compiler/src/test_runner_json.sfn` module owns the wire format (start / test / summary), the `AssertFailure` → JSON encoder, and the pre-run parse pass that pulls `TestDeclaration` names + spans before the binary runs.
- Spec section "Test runner JSON output" lands in `site/src/content/docs/docs/reference/spec/11-testing.md` with field semantics, attribution rule, timing approximation, and the schema-version policy.

Closes #368

## Acceptance Criteria

- [x] `sfn test --json path/to/tests/` emits exactly the three event kinds, one per line.
- [x] First line is `start`, last line is `summary`, all middle lines are `test` events.
- [x] `schema_version` is present on the `start` event and equal to `1`.
- [x] Failed tests carry an `assertion` object populated from P2's typed `AssertFailure` record.
- [x] No human banner output appears on stdout when `--json` is set.
- [x] Stderr remains usable for compiler-internal diagnostics.
- [x] New "Test runner JSON output" subsection added to `11-testing.md`.
- [x] `sfn test --json … | jq -c '.event'` shows `start`, then N `test` lines, then `summary`.
- [x] `make compile && make test && make check` passes.
- [x] `sfn fmt --check` is clean on every touched `.sfn` file.

## Verification

```bash
ulimit -v 8388608
make compile

cat <<'SFN' > /tmp/json_smoke.sfn
test "passes" { assert true; }
test "fails" { assert false; }
SFN
timeout 60 build/native/sailfin test --json /tmp/json_smoke.sfn 2>/dev/null | tee /tmp/events.jsonl
jq -e '.event == "start" and .schema_version == 1' < <(head -1 /tmp/events.jsonl)
jq -e '.event == "summary"' < <(tail -1 /tmp/events.jsonl)
grep -c '"event":"test"' /tmp/events.jsonl   # 2
```

Output:
```
{"event":"start","total":2,"schema_version":1}
{"event":"test","name":"passes","file":"/tmp/json_smoke.sfn","line":1,"status":"pass","duration_ms":175,"effects":[]}
{"event":"test","name":"fails","file":"/tmp/json_smoke.sfn","line":2,"status":"fail","duration_ms":175,"effects":[],"assertion":{"file":"","line":2,"col":16,"message":"assertion failed"}}
{"event":"summary","passed":1,"failed":1,"skipped":0,"duration_ms":350}
```

Full validation:
- `make compile` — built.
- `make test` — all categories green (unit 87/87, integration 20/20, e2e 51/51, capsules 10/10).
- `make check` — first-pass + seedcheck + stage3 all green; `stage2 == stage3: compiler is a fixed point ✓`.

## Files Changed

- `compiler/src/cli_commands.sfn` — `--json` flag plumbing in `handle_test_command` (pre-parse pass, per-file outcome buckets, jsonl emission, suppress human banner). Effect signature now `![io, clock]` for `monotonic_millis`.
- `compiler/src/test_runner_json.sfn` (new) — pure module: schema constant, `TestEntry` shape, JSON primitives, `render_start_event` / `render_test_event` / `render_summary_event` / `render_assert_failure_json`, `collect_test_entries`, `locate_failing_test`.
- `compiler/tests/integration/test_runner_json_test.sfn` (new) — 17 golden-output tests pinning every event shape + escaping + the pre-run / attribution helpers.
- `site/src/content/docs/docs/reference/spec/11-testing.md` — new "Test runner JSON output" subsection (event shapes, field semantics, attribution rule, timing approximation, schema-version policy, stream contract).

## Notes

- Per-test `duration_ms` is approximated by even-distribution of the file's wall time across its tests; spec §11 documents this since the harness runs every test in one process and per-test wall time is not directly observable today.
- Compile / link failures surface as `"skip"` events with a synthesised assertion (e.g. `"compile failed"`) so consumers see a complete per-test stream — the runner continues to the next file in `--json` mode rather than short-circuiting like the human path.
- The pre-parse pass that builds `TestEntry[]` for each file is gated behind `json_output` to avoid charging the human path for the extra read+parse on every test file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018ipV4HDy4LTmoZP3WXaZxY)_