### PR TITLE
fix(mcp): auto-build mcp-server on session start and fix .mcp.json config

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -29,7 +29,7 @@ fi
 
 if [[ ! -f tools/mcp-server/dist/index.js ]]; then
   echo "- mcp-server: building tools/mcp-server..."
-  (cd tools/mcp-server && npm ci --no-audit --no-fund --silent && npm run build --silent) 2>&1 | tail -3 || echo "  (mcp-server build failed — MCP tools unavailable)"
+  (cd tools/mcp-server && npm ci --no-audit --no-fund --silent && npm run build --silent) 2>&1 | tail -n 3 || echo "  (mcp-server build failed — MCP tools unavailable)"
 else
   echo "- mcp-server: tools/mcp-server/dist present"
 fi

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -27,6 +27,13 @@ else
   echo "- seedcheck: not built (only needed for \`make check\`)"
 fi
 
+if [[ ! -f tools/mcp-server/dist/index.js ]]; then
+  echo "- mcp-server: building tools/mcp-server..."
+  (cd tools/mcp-server && npm ci --no-audit --no-fund --silent && npm run build --silent) 2>&1 | tail -3 || echo "  (mcp-server build failed — MCP tools unavailable)"
+else
+  echo "- mcp-server: tools/mcp-server/dist present"
+fi
+
 branch=$(git branch --show-current 2>/dev/null || echo "(detached)")
 echo "- branch: $branch"
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,7 +5,6 @@
       "Read",
       "Grep",
       "Glob",
-
       "Bash(make *)",
       "Bash(ulimit *)",
       "Bash(build/native/sailfin *)",
@@ -13,7 +12,6 @@
       "Bash(build/native/sailfin-seedcheck *)",
       "Bash(timeout * build/native/sailfin-seedcheck *)",
       "Bash(timeout 120 valgrind --tool=memcheck --track-origins=yes --error-exitcode=0 build/native/sailfin-seedcheck test compiler/tests/unit/function_signatures_test.sfn)",
-
       "Bash(git status*)",
       "Bash(git log*)",
       "Bash(git diff*)",
@@ -34,7 +32,6 @@
       "Bash(git ls-files*)",
       "Bash(git push -u origin claude/*)",
       "Bash(git push origin claude/*)",
-
       "Bash(gh pr *)",
       "Bash(gh issue *)",
       "Bash(gh run *)",
@@ -42,7 +39,6 @@
       "Bash(gh workflow *)",
       "Bash(gh release view*)",
       "Bash(gh release list*)",
-
       "Bash(ls *)",
       "Bash(wc *)",
       "Bash(head *)",
@@ -64,9 +60,10 @@
       "Bash(stat *)",
       "Bash(file *)",
       "Bash(du -sh *)",
-
       "WebFetch(domain:sailfin.dev)",
+      "WebFetch(domain:sfn.dev)",
       "WebFetch(domain:docs.anthropic.com)",
+      "WebFetch(domain:code.claude.com)",
       "WebFetch(domain:github.com)",
       "WebFetch(domain:raw.githubusercontent.com)"
     ],
@@ -99,7 +96,10 @@
       {
         "matcher": "",
         "hooks": [
-          { "type": "command", "command": ".claude/hooks/session-start.sh" }
+          {
+            "type": "command",
+            "command": ".claude/hooks/session-start.sh"
+          }
         ]
       }
     ],
@@ -107,7 +107,10 @@
       {
         "matcher": "",
         "hooks": [
-          { "type": "command", "command": ".claude/hooks/inject-git-context.sh" }
+          {
+            "type": "command",
+            "command": ".claude/hooks/inject-git-context.sh"
+          }
         ]
       }
     ],
@@ -115,7 +118,10 @@
       {
         "matcher": "Bash",
         "hooks": [
-          { "type": "command", "command": ".claude/hooks/check-ulimit.sh" }
+          {
+            "type": "command",
+            "command": ".claude/hooks/check-ulimit.sh"
+          }
         ]
       }
     ]

--- a/.mcp.json
+++ b/.mcp.json
@@ -3,10 +3,7 @@
     "sailfin": {
       "type": "stdio",
       "command": "node",
-      "args": ["tools/mcp-server/dist/index.js"],
-      "env": {
-        "CLAUDE_PROJECT_DIR": "${workspaceFolder}"
-      }
+      "args": ["tools/mcp-server/dist/index.js"]
     }
   }
 }


### PR DESCRIPTION
## Summary

- **`.mcp.json`**: Remove the unresolvable `${workspaceFolder}` env var that was preventing the MCP server from loading. The server already falls back to `process.cwd()`, which is the project root in all contexts (local and cloud).
- **`session-start.sh`**: Auto-build `tools/mcp-server` if `dist/index.js` is missing. Runs `npm ci && npm run build` on first session start (or any fresh clone), then becomes a no-op once built.
- **`settings.json`**: Add `WebFetch` allowlist entries for `code.claude.com` (Claude Code docs) and `sfn.dev`; minor linter whitespace cleanup.

## Test plan

- [ ] Start a new session on a clean clone — session-start bootstrap output should show `mcp-server: building tools/mcp-server...`
- [ ] Start a second session — should show `mcp-server: tools/mcp-server/dist present` (no rebuild)
- [ ] Verify sailfin MCP tools load in the new session (e.g. `sailfin_version`)
- [ ] `/doctor` should show no MCP warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)