### PR TITLE
refactor(main): collapse `compile_to_llvm_file_with_module` to a single deterministic path

### DIFF
--- a/compiler/src/main.sfn
+++ b/compiler/src/main.sfn
@@ -29,7 +29,6 @@ import {
 import { lower_to_llvm_for_tests } from "./llvm/lowering/entrypoints_tests";
 import { write_llvm_ir_for_tests_from_text_with_context } from "./llvm/lowering/entrypoints_tests_writer";
 import { LayoutManifest } from "./native_ir";
-import { split_lines } from "./native_ir_utils_text";
 import { parse_program } from "./parser/mod";
 import { substring } from "./string_utils";
 import { test_runner_trace } from "./test_runner_state";
@@ -473,68 +472,6 @@ fn write_native_text_file_with_module(source: string, module_name: string, out_p
     return emit_native_text_to_file_with_module_name(program, module_name, out_path);
 }
 
-fn _has_prefix(value: string, prefix: string) -> boolean {
-    if prefix.length > value.length { return false; }
-    let mut index: number = 0;
-    loop {
-        if index >= prefix.length { break; }
-        if value[index] != prefix[index] { return false; }
-        index += 1;
-    }
-    return true;
-}
-
-fn _find_first_nonblank_line(text: string) -> string {
-    let lines = split_lines(text);
-    let mut index: number = 0;
-    loop {
-        let mut _if348: boolean = false;
-        if index >= lines.length { _if348 = true; }
-        if index >= 128 { _if348 = true; }
-        if _if348 { break; }
-        let line = lines[index];
-        if line.length > 0 { return line; }
-        index += 1;
-    }
-    return "";
-}
-
-fn _looks_like_llvm_text(text: string) -> boolean {
-    if text.length < 16 { return false; }
-    let lines = split_lines(text);
-    let mut index: number = 0;
-    loop {
-        let mut _if349: boolean = false;
-        if index >= lines.length { _if349 = true; }
-        if index >= 128 { _if349 = true; }
-        if _if349 { break; }
-        let line = lines[index];
-        if line.length == 0 {
-            index += 1;
-            continue;
-        }
-        let mut _if350: boolean = false;
-        if line[0] == " " { _if350 = true; }
-        if line[0] == "\t" { _if350 = true; }
-        if _if350 { return false; }
-        if _has_prefix(line, "source_filename =") { return true; }
-        if _has_prefix(line, "; ModuleID =") { return true; }
-        let mut _if351: boolean = false;
-        if _has_prefix(line, "target ") { _if351 = true; }
-        if _has_prefix(line, "declare ") { _if351 = true; }
-        if _has_prefix(line, "define ") { _if351 = true; }
-        if _if351 { return true; }
-        let mut _if352: boolean = false;
-        if line[0] == "%" { _if352 = true; }
-        if line[0] == "@" { _if352 = true; }
-        if line[0] == "!" { _if352 = true; }
-        if line[0] == ";" { _if352 = true; }
-        if _if352 { return true; }
-        return false;
-    }
-    return false;
-}
-
 // Compile and write LLVM IR directly, avoiding large return values.
 // Emits native text in memory and passes it straight into the lowering
 // pipeline — no intra-call IPC file between emit and lower, so the function
@@ -565,90 +502,10 @@ fn compile_to_llvm_file_with_module(source: string, module_name: string, out_pat
     if native_text.length == 0 {
         print.err("emit-llvm-file: empty native output for module "
             + module_name);
-        let cached_native_path = "build/native/import-context/" + module_name
-            + ".sfn-asm";
-        if fs.exists(cached_native_path) {
-            let cached_text = fs.readFile(cached_native_path);
-            let cached_ok = write_llvm_ir_from_native_text(cached_text, module_name, out_path);
-            if cached_ok {
-                if fs.exists(out_path) {
-                    let cached_contents = fs.readFile(out_path);
-                    if _looks_like_llvm_text(cached_contents) {
-                        print.err("emit-llvm-file: used cached native artifact fallback for module "
-                            + module_name);
-                        return true;
-                    }
-                }
-            }
-        }
-        let native_result = emit_native_with_module_name(program, module_name);
-        let fallback_ok = write_llvm_ir(native_result.module, out_path);
-        if fallback_ok {
-            if fs.exists(out_path) {
-                let contents = fs.readFile(out_path);
-                if _looks_like_llvm_text(contents) { return true; }
-            }
-        }
         return false;
     }
     if fs.exists(out_path) { fs.deleteFile(out_path); }
-    let ok = write_llvm_ir_from_native_text(native_text, module_name, out_path);
-    let mut output_valid: boolean = false;
-    // Check file content regardless of return value — the boolean return from
-    // cross-module calls can be corrupted by ABI issues in the seed compiler.
-    let _file_exists = fs.exists(out_path);
-    if _file_exists {
-        let written = fs.readFile(out_path);
-        // _looks_like_llvm_text may be miscompiled by the seed (loop/string
-        // comparison bugs).  Trust write_llvm_ir_from_native_text: if the
-        // file exists and has reasonable length it is valid LLVM IR produced
-        // by the lowering pipeline.
-        if written.length > 64 { output_valid = true; }
-        if !output_valid {
-            // Check if the content starts with a valid LLVM entity (just missing header).
-            // If it starts with garbage (e.g. mid-instruction due to array offset corruption),
-            // do NOT prepend a header — let the selfhost script's recovery handle it.
-            let _first_nonblank = _find_first_nonblank_line(written);
-            let mut _if353: boolean = false;
-            if _first_nonblank.length > 0 {
-                let mut _if355: boolean = false;
-                if _first_nonblank[0] == "%" { _if355 = true; }
-                if _first_nonblank[0] == "@" { _if355 = true; }
-                if _has_prefix(_first_nonblank, "declare ") { _if355 = true; }
-                if _has_prefix(_first_nonblank, "define ") { _if355 = true; }
-                if _has_prefix(_first_nonblank, "target ") { _if355 = true; }
-                if _if355 { _if353 = true; }
-            }
-            if _if353 {
-                let header = "source_filename = \"" + module_name + ".sfn\"\n\n";
-                fs.writeFile(out_path, header + written);
-                output_valid = true;
-                print.err("emit-llvm-file: prepended header for module "
-                    + module_name);
-            }
-        }
-        if !output_valid {
-            print.err("emit-llvm-file: malformed llvm output for module "
-                + module_name
-                + "; falling back");
-        }
-    }
-    if !output_valid {
-        if !ok {
-            print.err("emit-llvm-file: empty llvm output for module "
-                + module_name);
-        }
-        let native_result = emit_native_with_module_name(program, module_name);
-        let fallback_ok = write_llvm_ir(native_result.module, out_path);
-        if fallback_ok {
-            if fs.exists(out_path) {
-                let contents = fs.readFile(out_path);
-                if _looks_like_llvm_text(contents) { return true; }
-            }
-        }
-        return false;
-    }
-    return true;
+    return write_llvm_ir_from_native_text(native_text, module_name, out_path);
 }
 
 // Build-path typecheck diagnostic emission. Every `compile_to_*`

--- a/compiler/src/main.sfn
+++ b/compiler/src/main.sfn
@@ -502,9 +502,11 @@ fn compile_to_llvm_file_with_module(source: string, module_name: string, out_pat
     if native_text.length == 0 {
         print.err("emit-llvm-file: empty native output for module "
             + module_name);
+        // Drop any stale `.ll` from a previous build so downstream tooling
+        // that only stats `out_path` cannot mistake it for fresh output.
+        if fs.exists(out_path) { fs.deleteFile(out_path); }
         return false;
     }
-    if fs.exists(out_path) { fs.deleteFile(out_path); }
     return write_llvm_ir_from_native_text(native_text, module_name, out_path);
 }
 


### PR DESCRIPTION
## Summary

- Delete the fallback cascade in `compile_to_llvm_file_with_module`
  (`compiler/src/main.sfn`): the empty-output cached-artifact read,
  the post-write `_looks_like_llvm_text` "prepend header if it looks
  like a body" path, and the catastrophic re-run via
  `emit_native_with_module_name` + `write_llvm_ir`.
- Delete the dead helpers `_has_prefix`, `_find_first_nonblank_line`,
  `_looks_like_llvm_text` and the now-unused `split_lines` import.
- `compile_to_llvm_file_with_module` is now ~30 lines: parse →
  typecheck → effect-check → emit native text → write LLVM IR via
  `write_llvm_ir_from_native_text` → return that result.

Per `docs/proposals/build-architecture.md` §2.5 / §Stage D exit
criteria (loud-failure principle): the structured pipeline either
succeeds or fails. Every cascade arm masked real corruption signal
under the guise of recovery. Sequencing this before
[#344](https://github.com/SailfinIO/sailfin/issues/344)-step-4
deliberately keeps `bash scripts/build.sh` as the load-bearing
comparator behind `make check`, so any regression introduced by the
collapse is flagged by the existing fixed-point gate rather than
conflated with the driver flip.

Closes #380

## Acceptance Criteria

- [x] After the change, `compile_to_llvm_file_with_module` is ≤ 30 lines: parse → typecheck → effect-check → emit native text → write LLVM → return write result.
- [x] `_has_prefix`, `_find_first_nonblank_line`, `_looks_like_llvm_text` are deleted (no remaining callers — verified with `grep -rn`).
- [x] `make compile` succeeds.
- [x] `make check` succeeds and reports `stage2 == stage3: compiler is a fixed point`.
- [x] `make test` passes (run as part of `make check`).
- [x] All touched `.sfn` files pass `sfn fmt --check`.

## Verification

```bash
ulimit -v 8388608
make clean-build && make compile          # ✓ built build/native/sailfin
make check                                 # ✓ stage2 == stage3: compiler is a fixed point
                                           #   unit 87/87, integration 20/20, e2e 52/52, capsules 10/10
sfn fmt --check compiler/src/main.sfn      # ✓ exit 0

grep -rn "_looks_like_llvm_text\|_find_first_nonblank_line" compiler/src/ runtime/
# (no matches)
grep -rn "\b_has_prefix\b" compiler/src/ runtime/
# (no matches — only unrelated `_has_prefix_cmd` / `_af_has_prefix` remain, which are different helpers)
```

## Files Changed

- `compiler/src/main.sfn` — `+1 / −144`. Deleted lines 476–536 (helpers) and the cascade arms inside `compile_to_llvm_file_with_module`. Dropped the now-unused `split_lines` import.

## Notes

- `compile_to_llvm_file_with_module`'s skip-typecheck branch (out-of-scope per the issue) is unchanged — the env flag / legacy `.skip_typecheck` probe still works exactly as before.
- The cached-import-context **write** path in `capsule_resolver.sfn` is unchanged. Only the orphaned **read** fallback in `main.sfn` was deleted; with the cascade gone, the cache is consumed exclusively by the structured emit path that already runs upstream of this function.
- Callers of `compile_to_llvm_file_with_module` in `cli_main.sfn` and `capsule_resolver.sfn` already treat the return value as authoritative; no caller relied on the previous heuristic recovery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XtdmAYWPhS5cRNYNdWG1AJ)_