### PR TITLE
refactor(make): flip stage2/stage3 to driver --work-dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -417,9 +417,33 @@ check:
 	@$(MAKE) test NATIVE_BIN=build/native/sailfin
 	@echo "[check] first-pass tests passed — proceeding to seedcheck build..."
 	@echo "[check] verifying seed selfhost (stage2)..."
-	@SEED="build/native/sailfin" OUT="build/native/sailfin-seedcheck" OPT="$(NATIVE_OPT)" JOBS="$(BUILD_JOBS)" CLANG="$(CLANG)" MAX_TOTAL=3600 \
-		WORK_DIR="build/selfhost/native-seedcheck" \
-		bash scripts/build.sh
+	@# Stage E PR3: stage2 routes through `sfn build -p compiler
+	@# --work-dir <DIR>` (the same path `make rebuild` uses for the
+	@# first-pass binary), replacing the legacy
+	@# `bash scripts/build.sh` invocation. The driver virtualises
+	@# `<DIR>/native/import-context/` and the default
+	@# `<DIR>/native/sailfin` output, but the per-module `.ll`
+	@# scratch root is still the legacy `build/sailfin/capsules/`
+	@# unless `SAILFIN_TEST_SCRATCH` is set (see
+	@# `_cr_scratch_root` in `compiler/src/capsule_resolver.sfn`);
+	@# without that override, stage3 would clobber stage2's
+	@# `.ll` files and the fixed-point hash-diff below would be
+	@# vacuous. `--no-cache` keeps stage2 and stage3 truly
+	@# independent (they're built by different compiler
+	@# binaries with potentially identical version stamps, so a
+	@# shared cache would let one stage's IR satisfy the
+	@# other's lookup and silently bypass the fresh emit). The
+	@# `OPT="$(NATIVE_OPT)"` parameter no longer plumbs through:
+	@# the driver hardcodes `-O2` per `Makefile:619-620`. The
+	@# default `NATIVE_OPT` is also `-O2`, so most callers see
+	@# no behavioural change; CI overrides that lower the opt
+	@# level for stage2/stage3 are silently ignored under the
+	@# driver path until the driver grows an `--opt` flag.
+	@mkdir -p build/selfhost/native-seedcheck
+	@SAILFIN_TEST_SCRATCH="build/selfhost/native-seedcheck/scratch" \
+		build/native/sailfin build --no-cache -p compiler \
+			--work-dir build/selfhost/native-seedcheck \
+			-o build/native/sailfin-seedcheck
 	@echo "[check] validating seedcheck binary can run programs..."
 	@sc="build/native/sailfin-seedcheck"; \
 	to="$(TIMEOUT_CMD)"; \
@@ -439,12 +463,20 @@ check:
 	@$(MAKE) test NATIVE_BIN=build/native/sailfin-seedcheck
 	@echo ""
 	@echo "[check] stage2 tests passed — building stage3 for fixed-point comparison..."
-	@SEED="build/native/sailfin-seedcheck" OUT="build/native/sailfin-stage3" OPT="$(NATIVE_OPT)" JOBS="$(BUILD_JOBS)" CLANG="$(CLANG)" MAX_TOTAL=3600 \
-		WORK_DIR="build/selfhost/native-stage3" \
-		bash scripts/build.sh
+	@# Stage E PR3: same flip as stage2 — driver `--work-dir`
+	@# with `SAILFIN_TEST_SCRATCH` per-stage isolation and
+	@# `--no-cache` so stage3's IR is freshly emitted by the
+	@# stage2 binary rather than served from a cache that
+	@# stage2 (or `make compile`) populated. See the stage2
+	@# block above for the rationale.
+	@mkdir -p build/selfhost/native-stage3
+	@SAILFIN_TEST_SCRATCH="build/selfhost/native-stage3/scratch" \
+		build/native/sailfin-seedcheck build --no-cache -p compiler \
+			--work-dir build/selfhost/native-stage3 \
+			-o build/native/sailfin-stage3
 	@echo "[check] comparing stage2 vs stage3 LLVM IR (fixed-point check)..."
-	@s2="build/selfhost/native-seedcheck/raw"; \
-	s3="build/selfhost/native-stage3/raw"; \
+	@s2="build/selfhost/native-seedcheck/scratch/capsules"; \
+	s3="build/selfhost/native-stage3/scratch/capsules"; \
 	s2_hashes=$$(find "$$s2" -name '*.ll' -exec $(HASH_CMD) {} + 2>/dev/null | awk '{print $$1}' | LC_ALL=C sort | $(HASH_CMD) | awk '{print $$1}'); \
 	s3_hashes=$$(find "$$s3" -name '*.ll' -exec $(HASH_CMD) {} + 2>/dev/null | awk '{print $$1}' | LC_ALL=C sort | $(HASH_CMD) | awk '{print $$1}'); \
 	if [ "$$s2_hashes" = "$$s3_hashes" ]; then \

--- a/Makefile
+++ b/Makefile
@@ -440,6 +440,23 @@ check:
 	@# level for stage2/stage3 are silently ignored under the
 	@# driver path until the driver grows an `--opt` flag.
 	@mkdir -p build/selfhost/native-seedcheck
+	@# Wipe stale import-context + scratch artifacts so the
+	@# stage_capsule_imports cache-hit short-circuit (treats existing
+	@# `.sfn-asm` + `.layout-manifest` as authoritative without source-
+	@# change invalidation) cannot serve a previous run's IR.
+	@# Mirrors `make rebuild`'s `build/native/import-context` wipe at
+	@# Makefile:654-656; without it, a re-run after a source change
+	@# could compile against stale staged modules and silently
+	@# undermine the fixed-point hash-diff. Per-stage, narrow to the
+	@# two file shapes that matter (rather than `rm -rf` the whole
+	@# work-dir) so the directory mtime survives for incremental
+	@# tooling that watches it.
+	@if [ -d build/selfhost/native-seedcheck/native/import-context ]; then \
+		find build/selfhost/native-seedcheck/native/import-context -type f \( -name '*.sfn-asm' -o -name '*.layout-manifest' \) -delete; \
+	fi
+	@if [ -d build/selfhost/native-seedcheck/scratch/capsules ]; then \
+		find build/selfhost/native-seedcheck/scratch/capsules -type f -name '*.ll' -delete; \
+	fi
 	@SAILFIN_TEST_SCRATCH="build/selfhost/native-seedcheck/scratch" \
 		build/native/sailfin build --no-cache -p compiler \
 			--work-dir build/selfhost/native-seedcheck \
@@ -470,6 +487,17 @@ check:
 	@# stage2 (or `make compile`) populated. See the stage2
 	@# block above for the rationale.
 	@mkdir -p build/selfhost/native-stage3
+	@# Same wipe as stage2 — stage_capsule_imports's cache-hit
+	@# probe ignores source mtime, so stale staged modules from a
+	@# prior `make check` run would invisibly satisfy stage3 and
+	@# defeat the fixed-point comparison. See the stage2 block
+	@# above for the rationale.
+	@if [ -d build/selfhost/native-stage3/native/import-context ]; then \
+		find build/selfhost/native-stage3/native/import-context -type f \( -name '*.sfn-asm' -o -name '*.layout-manifest' \) -delete; \
+	fi
+	@if [ -d build/selfhost/native-stage3/scratch/capsules ]; then \
+		find build/selfhost/native-stage3/scratch/capsules -type f -name '*.ll' -delete; \
+	fi
 	@SAILFIN_TEST_SCRATCH="build/selfhost/native-stage3/scratch" \
 		build/native/sailfin-seedcheck build --no-cache -p compiler \
 			--work-dir build/selfhost/native-stage3 \


### PR DESCRIPTION
## Summary

- Replaces both `bash scripts/build.sh` invocations in `make check` (stage2 + stage3) with `sfn build -p compiler --work-dir <DIR>` calls — the same path `make rebuild` already uses for the first-pass binary.
- Per-stage isolation comes from `SAILFIN_TEST_SCRATCH=<DIR>/scratch` (the existing knob `_cr_scratch_root` honours), since the driver's `--work-dir` doesn't yet route the per-module `.ll` scratch root. Without that, stage3 would clobber stage2's `.ll` files in `build/sailfin/capsules/` and the fixed-point hash-diff would be vacuous.
- Adds `--no-cache` so stage2 and stage3 freshly emit their IR rather than serve from a build cache that `make compile` (or stage2) populated. The two stages are built by different compiler binaries with potentially identical version stamps; a shared cache would let one stage's IR satisfy the other's lookup and silently bypass the fresh emit.
- Adjusts the fixed-point hash-diff at `Makefile:445-469` to read from `build/selfhost/native-{seedcheck,stage3}/scratch/capsules/` instead of `.../raw/`.

Closes #382. Stage E PR3 of the `scripts/build.sh` retirement — once #344-step-5 lands, the script itself goes away.

## Behaviour change to flag

The driver hardcodes `-O2` for the selfhost link (per `Makefile:619-620`). The default `NATIVE_OPT` is also `-O2`, so most callers see no change, but CI overrides that lower the opt level for stage2/stage3 are silently ignored under the driver path until the driver grows an `--opt` flag.

## Acceptance Criteria — all met

- [x] No `bash scripts/build.sh` invocation remains in the `check` target (comments may still reference it; only live recipe lines must go).
- [x] Stage2 builds into `build/selfhost/native-seedcheck/` and produces `build/native/sailfin-seedcheck`.
- [x] Stage3 builds into `build/selfhost/native-stage3/` and produces `build/native/sailfin-stage3`.
- [x] Fixed-point hash-diff reads the correct `.ll` directory for each stage and reports `stage2 == stage3: compiler is a fixed point`.
- [x] `seedcheck` binary still passes the hello-world smoke test.
- [x] `make check` end-to-end succeeds. Full clean run on this branch:
  - Total: 19m31s wall-clock
  - `[check] seedcheck binary runs hello-world.sfn OK`
  - `[check] stage2 == stage3: compiler is a fixed point ✓`
  - All unit / integration / e2e / capsule test suites passed
  - Note: an earlier run hit one transient failure (`dist_manifest_test.sfn` — the documented seed-corruption flake at `compiler/src/capsule_resolver.sfn:1437-1455`, stray non-ASCII byte `羪 double* %l0` in emitted IR). Re-running the test passed on the next attempt; the second `make check` ran clean.
- [x] Wall-clock recorded:
  - Stage2: ~2m24s under the driver vs ~13min under `bash scripts/build.sh`
  - Stage3: ~2m22s under the driver vs ~13min under `bash scripts/build.sh`
  - ~5x speedup, no regression. The driver builds reuse the `make rebuild` machinery (subprocess-per-module emit, parallel staging, validator cascade) that `build.sh` doesn't have.

## Verification

```bash
ulimit -v 8388608

# Full make check (clean state)
find build/selfhost -delete; find build/sailfin -name '*.ll' -delete
rm -f build/native/sailfin-seedcheck build/native/sailfin-stage3
time make check 2>&1 | tee /tmp/check.log
# real    19m31.686s
# EXITCODE=0
grep "stage2 == stage3" /tmp/check.log
# [check] stage2 == stage3: compiler is a fixed point ✓

# No live build.sh refs in check recipe
awk '/^check:/,/^[a-z][a-zA-Z0-9_-]*:/' Makefile \
  | grep -v '^[[:space:]]*@#' \
  | grep 'bash scripts/build.sh' \
  || echo "ok: no live build.sh refs"
# ok: no live build.sh refs
```

## Files Changed

- `Makefile` — stage2 (`419-422` → driver `--work-dir`), stage3 (`442-444` → driver `--work-dir`), raw-dir paths (`446-447` → `scratch/capsules`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
