### PR TITLE
M2.4a — runtime/sfn/string.sfn wave 1a (sfn_str_len/eq/slice/to_cstr/from_cstr)

### DIFF
--- a/compiler/src/llvm/expression_lowering/native/core_member_lowering.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_member_lowering.sfn
@@ -693,9 +693,13 @@ fn lower_member_access(parse: MemberAccessParse, bindings: ParameterBinding[], l
             };
         }
         if base_operand.llvm_type == "i8*" {
+            // M2.4a (#396): legacy `i8*` `s.length` lowers to the
+            // Sailfin-native `@sfn_str_len` (`runtime/sfn/string.sfn`)
+            // instead of the C `@sailfin_runtime_string_length`. The
+            // aggregate fast path above (extractvalue) is unchanged.
             let length_temp = format_temp_name(current_temp);
             current_lines.push("  " + length_temp
-                + " = call i64 @sailfin_runtime_string_length(i8* "
+                + " = call i64 @sfn_str_len(i8* "
                 + base_operand.value
                 + ")");
             current_temp += 1;

--- a/compiler/src/llvm/expression_lowering/native/core_member_lowering.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_member_lowering.sfn
@@ -694,9 +694,15 @@ fn lower_member_access(parse: MemberAccessParse, bindings: ParameterBinding[], l
         }
         if base_operand.llvm_type == "i8*" {
             // M2.4a (#396): legacy `i8*` `s.length` lowers to the
-            // Sailfin-native `@sfn_str_len` (`runtime/sfn/string.sfn`)
-            // instead of the C `@sailfin_runtime_string_length`. The
-            // aggregate fast path above (extractvalue) is unchanged.
+            // canonical `@sfn_str_len` instead of the C
+            // `@sailfin_runtime_string_length`. During the M2.4a
+            // coexistence period that bare symbol is provided by the
+            // C trampoline in `runtime/native/src/sailfin_runtime.c`;
+            // the Sailfin proof-of-life module
+            // `runtime/sfn/string.sfn` exports `sfn_str_sfn_len`
+            // alongside it. M2.4b retires the trampoline and the
+            // Sailfin export takes over the bare name. The aggregate
+            // fast path above (extractvalue) is unchanged.
             let length_temp = format_temp_name(current_temp);
             current_lines.push("  " + length_temp
                 + " = call i64 @sfn_str_len(i8* "

--- a/compiler/src/llvm/expression_lowering/native/core_operands.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_operands.sfn
@@ -65,13 +65,15 @@ fn emit_comparison_instruction(symbol: string, left_operand: LLVMOperand, right_
             if right_is_string {
                 if !left_is_null {
                     if !right_is_null {
-                        // M1.A: `strings_equal` is still on the legacy
-                        // `i8*` ABI in this PR, so an aggregate operand
-                        // here needs its data pointer extracted before
-                        // the call. The slow `strlen`-based comparison
-                        // path remains correct because the aggregate's
-                        // data pointer is NUL-terminated by the literal
-                        // lowering.
+                        // M2.4a (#396): the call routes to
+                        // `@sfn_str_eq` (defined in
+                        // `runtime/sfn/string.sfn`) instead of the
+                        // legacy `@strings_equal` C entrypoint. Both
+                        // exports are still backed by the same
+                        // NUL-terminated `i8*` ABI for now — the
+                        // aggregate-by-value rewrite lands with M2.4b
+                        // — so the operand-extraction shim below is
+                        // unchanged from the M1.A landing.
                         let mut next_index = temp_index;
                         let mut left_ptr_value = left_operand.value;
                         if left_operand.llvm_type == "{i8*, i64}" {
@@ -95,7 +97,7 @@ fn emit_comparison_instruction(symbol: string, left_operand: LLVMOperand, right_
                         }
                         let compare_temp = format_temp_name(next_index);
                         current_lines.push("  " + compare_temp
-                            + " = call i1 @strings_equal(i8* "
+                            + " = call i1 @sfn_str_eq(i8* "
                             + left_ptr_value
                             + ", i8* "
                             + right_ptr_value
@@ -760,9 +762,15 @@ fn coerce_pointer_or_struct(operand: LLVMOperand, operand_type: string, target: 
     }
     if operand_type == "i8*" {
         if target == "{i8*, i64}" {
+            // M2.4a (#396): length recovery for the legacy `i8*` →
+            // `{i8*, i64}` shim routes through `@sfn_str_len`
+            // (`runtime/sfn/string.sfn`) instead of the C
+            // `@sailfin_runtime_string_length` entrypoint. The body
+            // still trampolines through the C scanner until the
+            // aggregate-typed locals flip lands; the symbol swap
+            // is the migration unit.
             let len_temp = format_temp_name(temp_index);
-            current_lines.push("  " + len_temp
-                + " = call i64 @sailfin_runtime_string_length(i8* "
+            current_lines.push("  " + len_temp + " = call i64 @sfn_str_len(i8* "
                 + operand.value
                 + ")");
             let agg0 = format_temp_name(temp_index + 1);

--- a/compiler/src/llvm/expression_lowering/native/core_operands.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_operands.sfn
@@ -66,14 +66,22 @@ fn emit_comparison_instruction(symbol: string, left_operand: LLVMOperand, right_
                 if !left_is_null {
                     if !right_is_null {
                         // M2.4a (#396): the call routes to
-                        // `@sfn_str_eq` (defined in
-                        // `runtime/sfn/string.sfn`) instead of the
-                        // legacy `@strings_equal` C entrypoint. Both
+                        // `@sfn_str_eq` instead of the legacy
+                        // `@strings_equal` C entrypoint. During the
+                        // M2.4a coexistence period the canonical
+                        // `sfn_str_eq` symbol is provided by the C
+                        // trampoline in
+                        // `runtime/native/src/sailfin_runtime.c`;
+                        // the Sailfin proof-of-life module
+                        // `runtime/sfn/string.sfn` exports
+                        // `sfn_str_sfn_eq` alongside it. M2.4b
+                        // retires the trampoline and the Sailfin
+                        // export takes over the bare name. Both
                         // exports are still backed by the same
                         // NUL-terminated `i8*` ABI for now — the
-                        // aggregate-by-value rewrite lands with M2.4b
-                        // — so the operand-extraction shim below is
-                        // unchanged from the M1.A landing.
+                        // aggregate-by-value rewrite lands with
+                        // M2.4b — so the operand-extraction shim
+                        // below is unchanged from the M1.A landing.
                         let mut next_index = temp_index;
                         let mut left_ptr_value = left_operand.value;
                         if left_operand.llvm_type == "{i8*, i64}" {

--- a/compiler/src/llvm/rendering.sfn
+++ b/compiler/src/llvm/rendering.sfn
@@ -118,21 +118,35 @@ fn render_runtime_helper_declarations(used_targets: string[], local_functions: N
         if index >= descriptors.length { break; }
         let descriptor = descriptors[index];
         if string_array_contains(used_targets, descriptor.target) {
+            // M1.C / M2.4a: when `native_signature` is populated the
+            // call-emission path (`coerce_and_emit_call` in
+            // `core_call_emission.sfn`) routes the call to that symbol
+            // instead of `descriptor.symbol`. The declare we emit here
+            // has to follow suit so the freshly-emitted call lands on
+            // a declared name the linker can resolve. The C body
+            // backing `descriptor.symbol` is intentionally left
+            // undeclared in this module — seed-built IR that still
+            // calls it carries its own declare line.
+            let mut effective_symbol = descriptor.symbol;
+            let mut _native_sig: string? = descriptor.native_signature;
+            if _native_sig != null {
+                if _native_sig.length > 0 { effective_symbol = _native_sig; }
+            }
             // Skip if this helper is actually defined locally (not just a runtime intrinsic)
-            if string_array_contains(local_symbols, descriptor.symbol) {
+            if string_array_contains(local_symbols, effective_symbol) {
                 index += 1;
                 continue;
             }
             // Some helper targets intentionally alias the same runtime symbol.
             // Avoid emitting duplicate declarations for the same symbol.
-            if string_array_contains(declared_symbols, descriptor.symbol) {
+            if string_array_contains(declared_symbols, effective_symbol) {
                 index += 1;
                 continue;
             }
             // Emit capability metadata comment if the intrinsic has effects
             if descriptor.effects.length > 0 {
                 let effects_text = join_with_separator(descriptor.effects, ", ");
-                lines.push("; intrinsic " + descriptor.symbol
+                lines.push("; intrinsic " + effective_symbol
                     + " requires capabilities: !["
                     + effects_text
                     + "]");
@@ -141,28 +155,46 @@ fn render_runtime_helper_declarations(used_targets: string[], local_functions: N
             if descriptor.parameter_types.length > 0 {
                 parameter_text = join_with_separator(descriptor.parameter_types, ", ");
             }
-            let line = "declare " + descriptor.return_type + " @" + descriptor.symbol
+            let line = "declare " + descriptor.return_type + " @"
+                + effective_symbol
                 + "("
                 + parameter_text
                 + ")";
             lines.push(line);
-            declared_symbols.push(descriptor.symbol);
-            // Also declare the target name if it differs from the symbol.
-            // This only satisfies IR validation (clang frontend); actual linking
-            // requires a runtime-side wrapper/alias for the target name.
-            if descriptor.target != descriptor.symbol {
-                let sanitized_target = sanitize_symbol(descriptor.target);
-                if sanitized_target != descriptor.symbol {
-                    if !string_array_contains(declared_symbols, sanitized_target) {
-                        if !string_array_contains(local_symbols, sanitized_target) {
-                            let alias_line = "declare " + descriptor.return_type
-                                + " @"
-                                + sanitized_target
-                                + "("
-                                + parameter_text
-                                + ")";
-                            lines.push(alias_line);
-                            declared_symbols.push(sanitized_target);
+            declared_symbols.push(effective_symbol);
+            // Also declare the target name if it differs from the effective
+            // symbol. This only satisfies IR validation (clang frontend);
+            // actual linking requires a runtime-side wrapper/alias for the
+            // target name.
+            //
+            // M2.4a (#396): when `native_signature` flipped the
+            // effective symbol, the descriptor's `symbol` field IS
+            // the legacy target name (e.g. `strings_equal`) — its
+            // only role now is to record what the C body used to be
+            // called for archeology. Emitting a `declare` for it
+            // would re-introduce the very dead reference the
+            // migration is trying to clear (acceptance criterion
+            // "the C symbols become unreferenced"). Skip the alias
+            // path whenever the symbol was flipped.
+            let mut emit_target_alias: boolean = true;
+            if effective_symbol != descriptor.symbol {
+                emit_target_alias = false;
+            }
+            if emit_target_alias {
+                if descriptor.target != effective_symbol {
+                    let sanitized_target = sanitize_symbol(descriptor.target);
+                    if sanitized_target != effective_symbol {
+                        if !string_array_contains(declared_symbols, sanitized_target) {
+                            if !string_array_contains(local_symbols, sanitized_target) {
+                                let alias_line = "declare " + descriptor.return_type
+                                    + " @"
+                                    + sanitized_target
+                                    + "("
+                                    + parameter_text
+                                    + ")";
+                                lines.push(alias_line);
+                                declared_symbols.push(sanitized_target);
+                            }
                         }
                     }
                 }
@@ -191,6 +223,18 @@ fn render_imported_function_declarations(imported_functions: NativeFunction[], l
         let descriptor = helper_descriptors[helper_index];
         if string_array_contains(runtime_helpers, descriptor.target) {
             helper_symbols.push(descriptor.symbol);
+            // M2.4a: a flipped descriptor's effective symbol is the
+            // `native_signature`, not `symbol` — treat both as
+            // already-declared so the imported-function pass below
+            // doesn't emit a stray `declare` for either name.
+            let mut _native_sig: string? = descriptor.native_signature;
+            if _native_sig != null {
+                if _native_sig.length > 0 {
+                    if !string_array_contains(helper_symbols, _native_sig) {
+                        helper_symbols.push(_native_sig);
+                    }
+                }
+            }
             let helper_target = sanitize_symbol(descriptor.target);
             if !string_array_contains(helper_symbols, helper_target) {
                 helper_symbols.push(helper_target);

--- a/compiler/src/llvm/runtime_helpers.sfn
+++ b/compiler/src/llvm/runtime_helpers.sfn
@@ -308,15 +308,21 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
     //
     // M2.4a (#396): the four string descriptors below carry a
     // `native_signature` populated with the matching `sfn_str_*`
-    // export from `runtime/sfn/string.sfn`. The migration mechanism
+    // canonical name. During the M2.4a coexistence period those
+    // bare canonical symbols are *defined by C trampolines* in
+    // `runtime/native/src/sailfin_runtime.c`; the proof-of-life
+    // Sailfin module `runtime/sfn/string.sfn` ships the same
+    // five operations under the `sfn_str_sfn_*` infix to avoid a
+    // link-time collision (mirrors the arena module's
+    // `sfn_arena_sfn_*` namespace). M2.4b retires the C
+    // trampolines and renames the Sailfin exports to the bare
+    // form. The migration mechanism
     // (`render_runtime_helper_declarations` in `rendering.sfn` and
     // `coerce_and_emit_call` in `core_call_emission.sfn`) prefers
-    // the Sailfin-native symbol over `symbol` whenever it is set,
-    // so freshly-emitted IR reaches the new exports while seed-
-    // built IR (which still carries the C symbol names) keeps
-    // linking through the legacy bodies during the cutover. The
-    // C symbols below stay live in `runtime/native/src/sailfin_runtime.c`
-    // until `make compile`'s seed bumps past this PR.
+    // the `native_signature` over `symbol` whenever it is set, so
+    // freshly-emitted IR reaches the new exports while seed-built
+    // IR (which still carries the legacy `symbol` names) keeps
+    // linking through the legacy bodies during the cutover.
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
         target: "substring", symbol: "substring", return_type: "i8*", parameter_types: ["i8*", "double", "double"], effects: [], native_signature: "sfn_str_slice"
     });

--- a/compiler/src/llvm/runtime_helpers.sfn
+++ b/compiler/src/llvm/runtime_helpers.sfn
@@ -305,14 +305,26 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
     });
 
     // String utility helpers
+    //
+    // M2.4a (#396): the four string descriptors below carry a
+    // `native_signature` populated with the matching `sfn_str_*`
+    // export from `runtime/sfn/string.sfn`. The migration mechanism
+    // (`render_runtime_helper_declarations` in `rendering.sfn` and
+    // `coerce_and_emit_call` in `core_call_emission.sfn`) prefers
+    // the Sailfin-native symbol over `symbol` whenever it is set,
+    // so freshly-emitted IR reaches the new exports while seed-
+    // built IR (which still carries the C symbol names) keeps
+    // linking through the legacy bodies during the cutover. The
+    // C symbols below stay live in `runtime/native/src/sailfin_runtime.c`
+    // until `make compile`'s seed bumps past this PR.
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "substring", symbol: "substring", return_type: "i8*", parameter_types: ["i8*", "double", "double"], effects: [], native_signature: null
+        target: "substring", symbol: "substring", return_type: "i8*", parameter_types: ["i8*", "double", "double"], effects: [], native_signature: "sfn_str_slice"
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "substring_unchecked", symbol: "substring_unchecked", return_type: "i8*", parameter_types: ["i8*", "double", "double"], effects: [], native_signature: null
+        target: "substring_unchecked", symbol: "substring_unchecked", return_type: "i8*", parameter_types: ["i8*", "double", "double"], effects: [], native_signature: "sfn_str_slice"
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "string.length", symbol: "sailfin_runtime_string_length", return_type: "i64", parameter_types: ["i8*"], effects: [], native_signature: null
+        target: "string.length", symbol: "sailfin_runtime_string_length", return_type: "i64", parameter_types: ["i8*"], effects: [], native_signature: "sfn_str_len"
     });
     // M1.A — string.concat parameters lock to the SfnString aggregate
     // ABI. The new symbol `sailfin_runtime_string_concat_v2` accepts
@@ -348,7 +360,7 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
         target: "string.to_number", symbol: "sailfin_runtime_string_to_number", return_type: "double", parameter_types: ["i8*"], effects: [], native_signature: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "strings_equal", symbol: "strings_equal", return_type: "i1", parameter_types: ["i8*", "i8*"], effects: [], native_signature: null
+        target: "strings_equal", symbol: "strings_equal", return_type: "i1", parameter_types: ["i8*", "i8*"], effects: [], native_signature: "sfn_str_eq"
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
         target: "char_code", symbol: "char_code", return_type: "double", parameter_types: ["i8*"], effects: [], native_signature: null

--- a/compiler/tests/e2e/test_runtime_string_basic.sh
+++ b/compiler/tests/e2e/test_runtime_string_basic.sh
@@ -145,7 +145,15 @@ test_user_emission_is_flipped() {
         return 1
     fi
     local found=0
-    for sym in sailfin_runtime_string_length sailfin_runtime_substring strings_equal; do
+    # Legacy descriptor symbols match `runtime_helpers.sfn` exactly:
+    # `string.length` → `sailfin_runtime_string_length`, `substring`
+    # → `substring`, `substring_unchecked` → `substring_unchecked`,
+    # `strings_equal` → `strings_equal`. `\b` treats `_` as a word
+    # char, so `@substring\b` matches the bare symbol but not
+    # `@substring_unchecked` (no boundary between `g` and `_`),
+    # which means each entry below is a tight, non-overlapping
+    # regression target.
+    for sym in sailfin_runtime_string_length substring substring_unchecked strings_equal; do
         if grep -qE "@${sym}\b" "$ll"; then
             echo "[test]   user emission still references @${sym} (expected the sfn_str_* flip)"
             grep -nE "@${sym}\b" "$ll" | head -3
@@ -210,7 +218,7 @@ run_test "sfn fmt --check runtime/sfn/string.sfn is canonical" test_fmt_clean
 run_test "sfn emit llvm produces define for every sfn_str_sfn_* export" test_emit_define_shape
 run_test "sfn emit llvm does not collide with C trampoline sfn_str_* names" test_no_bare_sfn_str_define
 run_test "sfn emit llvm declares memcmp and memchr trampolines" test_emit_libc_declares
-run_test "user emission no longer calls @sailfin_runtime_string_length / @substring / @strings_equal" test_user_emission_is_flipped
+run_test "user emission no longer calls @sailfin_runtime_string_length / @substring / @substring_unchecked / @strings_equal" test_user_emission_is_flipped
 run_test "compiler binary exports defined sfn_str_* and sfn_str_sfn_* symbols" test_compiler_binary_exports_sfn_str
 run_test "runtime/native/capsule.toml sfn-sources lists the string module" test_manifest_lists_string
 run_test "scripts/build.sh RUNTIME_SFN_ALLOW lists the string module" test_build_allowlist_lists_string

--- a/compiler/tests/e2e/test_runtime_string_basic.sh
+++ b/compiler/tests/e2e/test_runtime_string_basic.sh
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+# End-to-end test for runtime/sfn/string.sfn — the first wave of
+# Sailfin-defined SfnString operations linked into the compiler
+# binary (issue #396, epic #389 M2.4a).
+#
+# Mirrors test_runtime_memory_arena.sh's structure: typecheck +
+# fmt + emit-shape on the source module, plus a compiled-IR
+# regression that the new compiler routes string `==`, `s.length`,
+# and substring/length-coercion call sites through the
+# `sfn_str_*` family instead of the legacy
+# `sailfin_runtime_string_length` / `strings_equal` /
+# `substring_unchecked` C entrypoints.
+#
+# When M2.4b retires the trampoline bodies and ships the real
+# arena-backed concat/append helpers, the emit-shape assertions
+# stay — they pin the migration symbol surface, not the body
+# strategy.
+
+set -euo pipefail
+
+BINARY="${1:?usage: test_runtime_string_basic.sh <compiler-binary>}"
+BINARY="$(realpath "$BINARY")"
+PASS=0
+FAIL=0
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+MODULE="$REPO_ROOT/runtime/sfn/string.sfn"
+
+SCRATCH="$(mktemp -d -t sfn-runtime-string-XXXXXX)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+run_test() {
+    local name="$1"
+    shift
+    if "$@"; then
+        echo "[test] PASS: $name"
+        PASS=$((PASS + 1))
+    else
+        echo "[test] FAIL: $name"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# ---- Test: source module typechecks cleanly ----
+test_check_clean() {
+    local log="$SCRATCH/check.log"
+    if ! "$BINARY" check "$MODULE" > "$log" 2>&1; then
+        echo "[test]   sfn check exited non-zero on string.sfn:"
+        cat "$log"
+        return 1
+    fi
+    if ! grep -q "checked .* ok" "$log"; then
+        echo "[test]   sfn check did not report 'ok':"
+        cat "$log"
+        return 1
+    fi
+    return 0
+}
+
+# ---- Test: source module is fmt-canonical ----
+test_fmt_clean() {
+    if ! "$BINARY" fmt --check "$MODULE" > /dev/null 2>&1; then
+        echo "[test]   $MODULE needs formatting (run: sfn fmt --write $MODULE)"
+        return 1
+    fi
+    return 0
+}
+
+# ---- Test: emitted IR carries a `define` for every sfn_str_sfn_* export ----
+#
+# The Sailfin module exports the `_sfn_` infix family
+# (`sfn_str_sfn_len`, ...) so its definitions coexist with the C
+# trampolines that own the bare `sfn_str_*` namespace —
+# `runtime/native/src/sailfin_runtime.c` defines those for the
+# new compiler emission and the test linker. M2.4b retires the C
+# trampolines and renames these exports to the bare form.
+test_emit_define_shape() {
+    local ll="$SCRATCH/string.ll"
+    local log="$SCRATCH/emit.log"
+    if ! "$BINARY" emit -o "$ll" llvm "$MODULE" > "$log" 2>&1; then
+        echo "[test]   sfn emit llvm failed on runtime/sfn/string.sfn:"
+        cat "$log"
+        return 1
+    fi
+    local missing=0
+    for sym in sfn_str_sfn_len sfn_str_sfn_eq sfn_str_sfn_slice sfn_str_sfn_to_cstr sfn_str_sfn_from_cstr; do
+        if ! grep -qE "^define .* @${sym}\(" "$ll"; then
+            echo "[test]   missing 'define ... @${sym}(' in string.ll"
+            missing=$((missing + 1))
+        fi
+    done
+    return "$missing"
+}
+
+# ---- Test: emitted IR does NOT collide with C trampolines ----
+#
+# Coexistence regression: a regression that flips a Sailfin export
+# to a bare `sfn_str_*` define would collide with the C trampoline
+# at link time and break `make compile`. Pin the `_sfn_` infix as
+# the marker until M2.4b removes the C trampolines.
+test_no_bare_sfn_str_define() {
+    local ll="$SCRATCH/string.ll"
+    if [ ! -f "$ll" ]; then
+        echo "[test]   $ll missing — test_emit_define_shape must run first"
+        return 1
+    fi
+    local found=0
+    for sym in sfn_str_len sfn_str_eq sfn_str_slice sfn_str_to_cstr sfn_str_from_cstr; do
+        if grep -qE "^define .* @${sym}\(" "$ll"; then
+            echo "[test]   collision risk: string.sfn emits 'define ... @${sym}(', conflicts with C trampoline"
+            found=$((found + 1))
+        fi
+    done
+    return "$found"
+}
+
+# ---- Test: emitted IR declares the libc/runtime trampolines bodies use ----
+test_emit_libc_declares() {
+    local ll="$SCRATCH/string.ll"
+    if [ ! -f "$ll" ]; then
+        echo "[test]   $ll missing — test_emit_define_shape must run first"
+        return 1
+    fi
+    local missing=0
+    # `memchr` is the new libc declaration this PR adds (used by
+    # the architect-spec body of sfn_str_from_cstr in M2.4b).
+    # `memcmp` is already in libc.sfn and rides alongside.
+    for sym in memcmp memchr; do
+        if ! grep -qE "^declare .* @${sym}\(" "$ll"; then
+            echo "[test]   missing 'declare ... @${sym}(' in string.ll"
+            missing=$((missing + 1))
+        fi
+    done
+    return "$missing"
+}
+
+# ---- Test: compiled hello-world IR no longer references the legacy C symbols ----
+test_user_emission_is_flipped() {
+    local hello="$REPO_ROOT/examples/basics/hello-world.sfn"
+    local ll="$SCRATCH/hello.ll"
+    local log="$SCRATCH/hello-emit.log"
+    if ! "$BINARY" emit -o "$ll" llvm "$hello" > "$log" 2>&1; then
+        echo "[test]   sfn emit llvm failed on hello-world.sfn:"
+        cat "$log"
+        return 1
+    fi
+    local found=0
+    for sym in sailfin_runtime_string_length sailfin_runtime_substring strings_equal; do
+        if grep -qE "@${sym}\b" "$ll"; then
+            echo "[test]   user emission still references @${sym} (expected the sfn_str_* flip)"
+            grep -nE "@${sym}\b" "$ll" | head -3
+            found=$((found + 1))
+        fi
+    done
+    return "$found"
+}
+
+# ---- Test: compiler binary exports both name families ----
+#
+# The C trampolines (`sailfin_runtime.c`) own the canonical
+# `sfn_str_*` names — those are what the new compiler emission
+# calls and what the test linker resolves against. The Sailfin
+# module owns the `sfn_str_sfn_*` infix family — proof of life
+# for the migration. Both must show up as defined text symbols.
+test_compiler_binary_exports_sfn_str() {
+    local nm_log
+    nm_log="$(nm "$BINARY" 2>/dev/null || true)"
+    if [ -z "$nm_log" ]; then
+        echo "[test]   nm produced no output for $BINARY (stripped binary?)"
+        return 1
+    fi
+    local missing=0
+    for sym in sfn_str_len sfn_str_eq sfn_str_slice sfn_str_to_cstr sfn_str_from_cstr sfn_str_sfn_len sfn_str_sfn_eq sfn_str_sfn_slice sfn_str_sfn_to_cstr sfn_str_sfn_from_cstr; do
+        # Require a defined text symbol (` T ` / ` t `). The optional
+        # `_` prefix accommodates macOS Mach-O while staying tight
+        # against substring collisions. A here-string avoids the
+        # `echo | grep -q` SIGPIPE-under-pipefail trap that fires
+        # when grep -q closes stdin after the first match.
+        if ! grep -qE "[[:space:]][Tt][[:space:]]_?${sym}\$" <<< "$nm_log"; then
+            echo "[test]   compiler binary does not export defined symbol ${sym}"
+            missing=$((missing + 1))
+        fi
+    done
+    return "$missing"
+}
+
+# ---- Test: capsule.toml + build.sh stay in lockstep on the new module ----
+test_manifest_lists_string() {
+    local manifest="$REPO_ROOT/runtime/native/capsule.toml"
+    if ! grep -qE '^sfn-sources = \[.*"\.\./sfn/string\.sfn".*\]' "$manifest"; then
+        echo "[test]   sfn-sources does not list ../sfn/string.sfn:"
+        grep -nE 'sfn-sources' "$manifest" || true
+        return 1
+    fi
+    return 0
+}
+
+test_build_allowlist_lists_string() {
+    local build_script="$REPO_ROOT/scripts/build.sh"
+    if ! grep -qE '^\s*"\$RUNTIME_SRC/sfn/string\.sfn"' "$build_script"; then
+        echo "[test]   RUNTIME_SFN_ALLOW does not list runtime/sfn/string.sfn:"
+        grep -nE 'RUNTIME_SFN_ALLOW' "$build_script" || true
+        return 1
+    fi
+    return 0
+}
+
+run_test "sfn check runtime/sfn/string.sfn passes" test_check_clean
+run_test "sfn fmt --check runtime/sfn/string.sfn is canonical" test_fmt_clean
+run_test "sfn emit llvm produces define for every sfn_str_sfn_* export" test_emit_define_shape
+run_test "sfn emit llvm does not collide with C trampoline sfn_str_* names" test_no_bare_sfn_str_define
+run_test "sfn emit llvm declares memcmp and memchr trampolines" test_emit_libc_declares
+run_test "user emission no longer calls @sailfin_runtime_string_length / @substring / @strings_equal" test_user_emission_is_flipped
+run_test "compiler binary exports defined sfn_str_* and sfn_str_sfn_* symbols" test_compiler_binary_exports_sfn_str
+run_test "runtime/native/capsule.toml sfn-sources lists the string module" test_manifest_lists_string
+run_test "scripts/build.sh RUNTIME_SFN_ALLOW lists the string module" test_build_allowlist_lists_string
+
+echo "[summary] $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi

--- a/runtime/native/capsule.toml
+++ b/runtime/native/capsule.toml
@@ -58,7 +58,7 @@ ll-sources = ["ir/runtime_globals.ll"]
 #      breaking byte-identical determinism.
 #
 # Single-line array per the parser limitation noted above.
-sfn-sources = ["../sfn/memory/arena.sfn"]
+sfn-sources = ["../sfn/memory/arena.sfn", "../sfn/string.sfn"]
 include-dirs = ["include"]
 link-libs = ["-lm"]
 

--- a/runtime/native/src/sailfin_runtime.c
+++ b/runtime/native/src/sailfin_runtime.c
@@ -2116,7 +2116,12 @@ bool sfn_str_eq(const char *a, const char *b)
 
 char *sfn_str_slice(const char *text, double start, double end)
 {
-    return sailfin_runtime_substring_unchecked((char *)text, (int64_t)start, (int64_t)end);
+    /* Route through `_clamp_to_i64` (defined later in this file,
+     * forward-declared at the top) so NaN / out-of-range doubles
+     * produce defined results — matches `substring_unchecked`'s
+     * own double→i64 discipline. A direct `(int64_t)` cast would
+     * be UB for those inputs. */
+    return sailfin_runtime_substring_unchecked((char *)text, _clamp_to_i64(start), _clamp_to_i64(end));
 }
 
 /* `sfn_str_to_cstr` / `sfn_str_from_cstr` are pure ABI bridges in

--- a/runtime/native/src/sailfin_runtime.c
+++ b/runtime/native/src/sailfin_runtime.c
@@ -2071,6 +2071,71 @@ void sfn_sleep(double milliseconds)
     sailfin_runtime_sleep(milliseconds);
 }
 
+/* M2.4a (#396): SfnString migration trampolines. After the
+ * runtime-helper registry flip in compiler/src/llvm/runtime_helpers.sfn,
+ * fresh compiler emission lowers `s.length`, `a == b` (string),
+ * `substring(...)`, and the `i8*` to `{i8*, i64}` length-recovery
+ * shim in core_operands.sfn to `@sfn_str_*` calls instead of the
+ * legacy `@sailfin_runtime_string_length` / `@strings_equal` /
+ * `@substring_unchecked` C entrypoints. These four trampolines
+ * provide the new symbol surface against the existing C bodies so
+ * test binaries (scripts/run_native_test.sh only links the
+ * runtime/native/src C sources) and the compiler binary itself
+ * resolve at link time without depending on a Sailfin-side
+ * definition that lives outside the test linker's reach.
+ *
+ * The Sailfin definition site is runtime/sfn/string.sfn, which
+ * exports the same five operations under the `sfn_str_sfn_*`
+ * infix to coexist (mirrors runtime/sfn/memory/arena.sfn's
+ * `sfn_arena_sfn_*` parallel namespace). M2.4b retires these
+ * trampolines once the aggregate-by-value parameter flip
+ * (M1.A.2) lands and the Sailfin bodies become the sole
+ * definition site — at that point the `_sfn_` infix is removed
+ * in a single rollback-safe PR.
+ *
+ * sfn_str_eq routes through `_strings_equal_fast` (this file)
+ * rather than `strings_equal` (defined in runtime/prelude.sfn)
+ * to keep the C trampoline link-self-sufficient: every test
+ * binary links sailfin_runtime.o, but the prelude .o does not
+ * always reach the link line on every code path (e.g. the
+ * standalone `sfn test <project>` flow assembles the link from
+ * the project's CWD without a guaranteed prelude.o probe). */
+int64_t sailfin_runtime_string_length(char *text);
+
+char *sailfin_runtime_substring_unchecked(char *text, int64_t start, int64_t end);
+
+int64_t sfn_str_len(const char *s)
+{
+    return sailfin_runtime_string_length((char *)s);
+}
+
+bool sfn_str_eq(const char *a, const char *b)
+{
+    return _strings_equal_fast(a, b);
+}
+
+char *sfn_str_slice(const char *text, double start, double end)
+{
+    return sailfin_runtime_substring_unchecked((char *)text, (int64_t)start, (int64_t)end);
+}
+
+/* `sfn_str_to_cstr` / `sfn_str_from_cstr` are pure ABI bridges in
+ * the M2.4a wave: the legacy `i8*` ABI's data pointer is itself
+ * NUL-terminated (the literal lowering in `core_strings.sfn`
+ * always writes a trailing 0 past the byte payload), so the
+ * boundary is the identity function. M2.4b replaces these with
+ * arena-routed copies once SfnString stops carrying its
+ * NUL-termination guarantee. */
+const char *sfn_str_to_cstr(const char *s)
+{
+    return s;
+}
+
+const char *sfn_str_from_cstr(const char *s)
+{
+    return s;
+}
+
 /* Check if a string pointer looks like a corrupted double-encoded value.
    On macOS ARM64, valid user-space pointers are < 0x800000000000.
    Double-encoded pointers (via ptrtoint→sitofp→double→bitcast back) produce

--- a/runtime/sfn/platform/libc.sfn
+++ b/runtime/sfn/platform/libc.sfn
@@ -47,6 +47,15 @@ extern fn memcpy(dst: * u8, src: * u8, n: usize) -> * u8;
 
 extern fn memcmp(a: * u8, b: * u8, n: usize) -> i32;
 
+// `memchr(s, c, n)` scans the first `n` bytes of `s` for the byte
+// `c`, returning a pointer to the match or `* u8` null when not
+// found. Used by `runtime/sfn/string.sfn`'s `sfn_str_from_cstr` to
+// recover the byte length of a NUL-terminated buffer without a
+// libc `strlen` call. The libc prototype is
+// `void *memchr(const void *s, int c, size_t n)` — the `c` arg is
+// `int` so callers pass `0..255` as `i32`.
+extern fn memchr(s: * u8, c: i32, n: usize) -> * u8;
+
 // ── Raw I/O (file-descriptor based) ───────────────────────────
 // `write`/`read` are POSIX, returning ssize_t (i64 on every
 // platform Sailfin currently targets). Negative returns signal

--- a/runtime/sfn/platform/libc.sfn
+++ b/runtime/sfn/platform/libc.sfn
@@ -49,11 +49,14 @@ extern fn memcmp(a: * u8, b: * u8, n: usize) -> i32;
 
 // `memchr(s, c, n)` scans the first `n` bytes of `s` for the byte
 // `c`, returning a pointer to the match or `* u8` null when not
-// found. Used by `runtime/sfn/string.sfn`'s `sfn_str_from_cstr` to
-// recover the byte length of a NUL-terminated buffer without a
-// libc `strlen` call. The libc prototype is
-// `void *memchr(const void *s, int c, size_t n)` — the `c` arg is
-// `int` so callers pass `0..255` as `i32`.
+// found. Declared here ahead of M2.4b: the planned aggregate-shape
+// body of `runtime/sfn/string.sfn::sfn_str_sfn_from_cstr` (renamed
+// to `sfn_str_from_cstr` once the C trampolines retire) uses
+// `memchr` to recover the byte length of a NUL-terminated buffer
+// without a libc `strlen` call. The current M2.4a body is a
+// proof-of-life identity wrapper and does not yet call this. The
+// libc prototype is `void *memchr(const void *s, int c, size_t n)`
+// — the `c` arg is `int` so callers pass `0..255` as `i32`.
 extern fn memchr(s: * u8, c: i32, n: usize) -> * u8;
 
 // ── Raw I/O (file-descriptor based) ───────────────────────────

--- a/runtime/sfn/string.sfn
+++ b/runtime/sfn/string.sfn
@@ -1,0 +1,109 @@
+// runtime/sfn/string.sfn
+//
+// First wave of Sailfin-native `SfnString` operations (M2.4a, #396).
+// The module pins the future shape of the five non-allocating
+// `sfn_str_*` helpers — `len`, `eq`, `slice`, `to_cstr`,
+// `from_cstr` — and ships into the compiler binary alongside the
+// C runtime so the migration footprint is visible at link time.
+//
+// Status: trampoline bodies. The architect plan in
+// `docs/runtime_architecture.md` §2.2 specifies these helpers
+// against the SfnString aggregate (`{i8*, i64}` by value) so
+// `sfn_str_len` is a single field load and `sfn_str_eq` is a length
+// compare + `memcmp`. Today's Sailfin frontend lowers `string` to
+// `i8*` for parameters/locals (M1.A only locked the literal/aggregate
+// shape, not the type-mapping flip slated for M1.A.2), so these
+// bodies still bridge through the legacy NUL-terminated C
+// entrypoints. The function *names* are the migration unit — once
+// M1.A.2 lands the bodies can be rewritten in-place over the
+// aggregate shape without touching any caller.
+//
+// Naming: every export uses the `sfn_str_sfn_*` infix so the
+// Sailfin module coexists with the C runtime's matching
+// `sfn_str_*` exports without a link-time collision (mirrors the
+// arena module's `sfn_arena_sfn_*` infix; see
+// `runtime/sfn/memory/arena.sfn` for the same rationale). The
+// canonical user-facing names — the ones the new compiler emits
+// `call`s against — are `sfn_str_*` (no infix), provided by the C
+// trampolines in `runtime/native/src/sailfin_runtime.c`. This
+// module's exports are presence-only proof of life today and the
+// migration unit for M2.4b: when the aggregate-typed parameter
+// flip lands, the C trampolines retire and these `_sfn_` names
+// rename to the bare canonical form in a single rollback-safe PR.
+//
+// Effects: none. String primitives live below the I/O layer (same
+// discipline as `runtime/sfn/memory/arena.sfn`). The `![io]`
+// annotations attach to *adapters* that wrap these primitives,
+// never to the primitives themselves.
+//
+// Why inline the libc externs? The same reason `arena.sfn` does:
+// the released seed compiler snapshots `runtime/sfn/platform/libc.sfn`
+// at build time. Inlining keeps this module self-contained for
+// every seed, regardless of which libc declarations have shipped.
+// Once the seed catches up, a follow-up PR can flip these to a
+// cross-module import without touching the bodies.
+extern fn memcmp(a: * u8, b: * u8, n: usize) -> i32;
+
+extern fn memchr(s: * u8, c: i32, n: usize) -> * u8;
+
+// Trampolines into the legacy C runtime. M2.4b (the concat/append
+// wave gated on #328 drop emission) replaces these with native
+// arena-backed Sailfin bodies; until then the C bodies do the
+// allocation work and these wrappers exist only to give this
+// module a legal Sailfin call surface for its proof-of-life
+// emission.
+extern fn sailfin_runtime_string_length(s: * u8) -> i64;
+
+extern fn strings_equal(a: * u8, b: * u8) -> bool;
+
+extern fn substring_unchecked(text: * u8, start: f64, end: f64) -> * u8;
+
+// `sfn_str_sfn_len(s)` — Sailfin-side length recovery for the
+// SfnString aggregate. Architect spec
+// (`runtime_architecture.md` §2.2): direct field access on the
+// aggregate's `len` slot, no runtime call. Today's bodies still
+// trampoline through the C scanner because the aggregate-typed
+// parameter flip (M1.A.2) hasn't landed yet; the legacy `i8*`
+// fallback path on the compiler side keeps consuming
+// NUL-terminated buffers.
+fn sfn_str_sfn_len(s: * u8) -> i64 {
+    return sailfin_runtime_string_length(s);
+}
+
+// `sfn_str_sfn_eq(a, b)` — byte-for-byte equality for two
+// SfnStrings. Architect spec: `len` compare followed by
+// `memcmp(a.data, b.data, a.len)`. Today's body delegates to the
+// C `strings_equal` entrypoint to avoid a second comparison
+// strategy until the aggregate flip lands.
+fn sfn_str_sfn_eq(a: * u8, b: * u8) -> bool { return strings_equal(a, b); }
+
+// `sfn_str_sfn_slice(text, start, end)` — non-owning view over
+// `text[start..end]`. Architect spec returns
+// `SfnSlice { data: text.data + start, len: end - start }`,
+// strictly non-allocating. Today's body still allocates a fresh
+// NUL-terminated buffer in the runtime arena (delegating to the
+// legacy `substring_unchecked` C entrypoint) because the rest of
+// the compiler hasn't grown an `SfnSlice` operand type yet. The
+// `f64` start/end shape mirrors the registry signature so call-
+// site arguments don't need a coercion shim during the flip.
+fn sfn_str_sfn_slice(text: * u8, start: f64, end: f64) -> * u8 {
+    return substring_unchecked(text, start, end);
+}
+
+// `sfn_str_sfn_to_cstr(s)` — NUL-terminated C string view of `s`.
+// Today's strings already carry a trailing NUL (the literal
+// lowering in `core_strings.sfn::lower_string_literal` writes one
+// past the byte payload), so the boundary is the identity
+// function. M2.4b reworks the body once the aggregate carries
+// arbitrary (potentially non-terminated) byte ranges and an arena
+// must be threaded for the copy.
+fn sfn_str_sfn_to_cstr(s: * u8) -> * u8 { return s; }
+
+// `sfn_str_sfn_from_cstr(s)` — adopt a NUL-terminated C buffer as
+// an SfnString. The architect spec scans for the NUL terminator
+// with `memchr` to recover the byte length and constructs the
+// aggregate `{s, len}` view; today's body still hands back the
+// bare `i8*` because there's no SfnString slot to populate.
+// `memchr` is declared above so the M2.4b body rewrite (over the
+// aggregate shape) doesn't need to add it then.
+fn sfn_str_sfn_from_cstr(s: * u8) -> * u8 { return s; }

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -470,6 +470,7 @@ if [[ "$IS_WORKER" -eq 0 ]]; then
     # imports only from files already in the list.
     RUNTIME_SFN_ALLOW=(
         "$RUNTIME_SRC/sfn/memory/arena.sfn"
+        "$RUNTIME_SRC/sfn/string.sfn"
     )
     while IFS= read -r -d '' f; do
         case "$f" in


### PR DESCRIPTION
## Summary

- Ships the first wave of Sailfin-native `SfnString` operations (M2.4a, #396): `sfn_str_len`, `sfn_str_eq`, `sfn_str_slice`, `sfn_str_to_cstr`, `sfn_str_from_cstr`.
- Flips the four affected runtime-helper descriptors (`string.length`, `strings_equal`, `substring`, `substring_unchecked`) via M1.C `native_signature` so fresh compiler emission routes through the new `sfn_str_*` symbols and the legacy C entrypoints disappear from user IR.
- Lands matching C trampolines in `runtime/native/src/sailfin_runtime.c` so test binaries and the standalone `sfn test <project>` flow link against the canonical names; the Sailfin module exports under the `sfn_str_sfn_*` infix (mirroring `runtime/sfn/memory/arena.sfn`'s parallel namespace) for proof-of-life coexistence.

Closes #396

## Acceptance Criteria

- [x] Compiled `"a" == "a"` lowers to `call i1 @sfn_str_eq(...)` not `@strings_equal`.
- [x] `s.length` on `{i8*, i64}` operands stays a direct `extractvalue`, no runtime call (unchanged from M1.A; only the legacy `i8*` path flipped to `@sfn_str_len`).
- [x] The four C symbols (`sailfin_runtime_string_length` / `substring` / `strings_equal`) become unreferenced in user emission — `grep -c` returns `0` against `examples/basics/hello-world.sfn`.
- [x] `make compile` passes.
- [x] `make test` passes (88 unit + 20 integration + 53 e2e — verified locally).

## Verification

```bash
ulimit -v 8388608 && make compile
ulimit -v 8388608 && make test
ulimit -v 8388608 && build/native/sailfin emit llvm examples/basics/hello-world.sfn | grep -c sailfin_runtime_string_length
# => 0
ulimit -v 8388608 && bash compiler/tests/e2e/test_runtime_string_basic.sh build/native/sailfin
# => [summary] 9 passed, 0 failed
nm build/native/sailfin | grep -E ' T (sfn_str_len|sfn_str_eq|sfn_str_slice|sfn_str_to_cstr|sfn_str_from_cstr|sfn_str_sfn_)'
# => both name families present (5 + 5)
```

## Files Changed

**Compiler:**
- `compiler/src/llvm/runtime_helpers.sfn` — populate `native_signature` on the four string descriptors.
- `compiler/src/llvm/rendering.sfn` — declare emitter prefers `effective_symbol` (native_signature when set) and skips the legacy-target alias declare on flipped descriptors so the C symbols drop from fresh user emission.
- `compiler/src/llvm/expression_lowering/native/core_operands.sfn` — string equality and the `i8*`→`{i8*, i64}` length-recovery shim emit `@sfn_str_eq` / `@sfn_str_len`.
- `compiler/src/llvm/expression_lowering/native/core_member_lowering.sfn` — legacy `i8*` `s.length` path emits `@sfn_str_len`.

**Runtime:**
- `runtime/sfn/string.sfn` (new) — five Sailfin proof-of-life exports under the `sfn_str_sfn_*` infix.
- `runtime/sfn/platform/libc.sfn` — `extern fn memchr` for the M2.4b body rewrite.
- `runtime/native/src/sailfin_runtime.c` — five `sfn_str_*` C trampolines (canonical names; route through `_strings_equal_fast` to stay link-self-sufficient).
- `runtime/native/capsule.toml` + `scripts/build.sh` — keep the sfn-sources / RUNTIME_SFN_ALLOW lockstep pair extended with the new module.

**Tests:**
- `compiler/tests/e2e/test_runtime_string_basic.sh` (new) — typecheck + fmt + emit-shape + namespace-coexistence + user-emission flip + binary-exports + manifest/allowlist lockstep (9 assertions, all pass).

## Notes / Deviations from the Issue

- The issue's "In:" specified the Sailfin functions as `sfn_str_*` (no infix) on the `SfnString` aggregate-by-value ABI. The frontend lowers `string` to `i8*` for parameters/locals today (M1.A only locked the literal/aggregate shape, not the M1.A.2 type-mapping flip), so the bodies had to take `* u8`. To avoid a link-time collision with the C trampolines that test binaries need, the Sailfin exports use the `sfn_str_sfn_*` infix — same pattern as the arena module. M2.4b retires the C trampolines and renames these exports to the bare canonical form once the aggregate-typed parameter flip lands.
- `sfn_str_eq` routes through `_strings_equal_fast` (defined in this same C file) rather than `strings_equal` (defined in `runtime/prelude.sfn`). The standalone `sfn test <project>` link path doesn't always have prelude.o on its probe list, so the trampoline has to stay link-self-sufficient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013nZ1Lzdsa6tKWvFLGUSc4C)_