### PR TITLE
chore(project): auto-sync Sailfin Tracker fields from labels

### DIFF
--- a/.github/workflows/sync-project.yml
+++ b/.github/workflows/sync-project.yml
@@ -1,0 +1,94 @@
+name: Sync Project
+
+# Keeps the Sailfin Tracker (org project #4) in lockstep with issue labels.
+#
+# - On `issues.opened` / `issues.reopened` — add the issue to the project.
+# - On `issues.labeled` / `issues.unlabeled` — recompute Priority / Size
+#   single-select fields from the issue's labels.
+# - `workflow_dispatch` — backfill all open issues (idempotent).
+#
+# Labels are the source of truth (.github/labels.yml). Project fields are
+# derived; views can group / filter on them without re-deriving from labels.
+#
+# This is a regular Actions workflow, not a gh-aw agent: deterministic shell,
+# no LLM, no API key. The work is delegated to scripts/sync-issue-to-project.sh
+# so it's runnable locally.
+#
+# Auth: org-scoped Project V2 cannot be modified with the default GITHUB_TOKEN.
+# Provide a PAT (or fine-grained token) with `project` and `read:org` scopes
+# as `PROJECT_SYNC_TOKEN`. Falls back to `RELEASE_PAT`. If neither is set the
+# job logs a warning and exits 0 — labels remain canonical, the project just
+# gets out of sync until the secret is added.
+
+on:
+  issues:
+    types: [opened, reopened, labeled, unlabeled, edited]
+  workflow_dispatch:
+    inputs:
+      backfill:
+        description: 'Re-sync every open issue (idempotent)'
+        type: boolean
+        default: false
+      issue:
+        description: 'Sync a specific issue number (ignored if backfill is true)'
+        type: string
+        required: false
+
+permissions:
+  contents: read
+  issues: read
+
+concurrency:
+  # Serialize per-issue. Backfill / dispatch runs share a single slot.
+  group: sync-project-${{ github.event.issue.number || inputs.issue || 'backfill' }}
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve token
+        id: tok
+        env:
+          PROJECT_SYNC_TOKEN: ${{ secrets.PROJECT_SYNC_TOKEN }}
+          RELEASE_PAT: ${{ secrets.RELEASE_PAT }}
+        run: |
+          if [[ -n "${PROJECT_SYNC_TOKEN:-}" ]]; then
+            echo "source=PROJECT_SYNC_TOKEN" >> "$GITHUB_OUTPUT"
+            echo "have=true" >> "$GITHUB_OUTPUT"
+          elif [[ -n "${RELEASE_PAT:-}" ]]; then
+            echo "source=RELEASE_PAT" >> "$GITHUB_OUTPUT"
+            echo "have=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::no PROJECT_SYNC_TOKEN or RELEASE_PAT secret available; skipping project sync"
+            echo "have=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Sync (single issue)
+        if: ${{ steps.tok.outputs.have == 'true' && github.event_name == 'issues' }}
+        env:
+          GH_TOKEN: ${{ secrets.PROJECT_SYNC_TOKEN || secrets.RELEASE_PAT }}
+          GH_REPO: ${{ github.repository }}
+          PROJECT_OWNER: SailfinIO
+          PROJECT_NUMBER: '4'
+        run: scripts/sync-issue-to-project.sh "${{ github.event.issue.number }}"
+
+      - name: Sync (workflow_dispatch — single issue)
+        if: ${{ steps.tok.outputs.have == 'true' && github.event_name == 'workflow_dispatch' && inputs.backfill != true && inputs.issue != '' }}
+        env:
+          GH_TOKEN: ${{ secrets.PROJECT_SYNC_TOKEN || secrets.RELEASE_PAT }}
+          GH_REPO: ${{ github.repository }}
+          PROJECT_OWNER: SailfinIO
+          PROJECT_NUMBER: '4'
+        run: scripts/sync-issue-to-project.sh "${{ inputs.issue }}"
+
+      - name: Sync (workflow_dispatch — backfill all open)
+        if: ${{ steps.tok.outputs.have == 'true' && github.event_name == 'workflow_dispatch' && inputs.backfill == true }}
+        env:
+          GH_TOKEN: ${{ secrets.PROJECT_SYNC_TOKEN || secrets.RELEASE_PAT }}
+          GH_REPO: ${{ github.repository }}
+          PROJECT_OWNER: SailfinIO
+          PROJECT_NUMBER: '4'
+        run: scripts/sync-issue-to-project.sh --all-open

--- a/docs/conventions/issue-naming.md
+++ b/docs/conventions/issue-naming.md
@@ -210,7 +210,7 @@ Every open issue is tracked on the **Sailfin Tracker** project
 
 | Field | Source | Notes |
 |-------|--------|-------|
-| Status | manual | `To triage` → `Backlog` → `Ready` → `In progress` → `In review` → `Done` |
+| Status | derived from issue state + labels | See **Status mapping** below |
 | Priority | `priority:*` label | `Critical`/`High`/`Medium`/`Low` mirror the four `priority:*` labels |
 | Size | `size:*` label | `XS`/`S`/`M` mirror the three `size:*` labels (no L; L items must be groomed down or promoted to `epic`) |
 | Milestone | `milestone` field | Phase marker — `M1`, `M1.5`, `M2`, `M3`, `Effect System Hardening`, `1.0` |
@@ -218,9 +218,28 @@ Every open issue is tracked on the **Sailfin Tracker** project
 | Start / Target date | manual | Use on epics, not leaf issues — leaf issues are sized in hours, not days |
 | Parent issue / Sub-issues progress | auto | Inherits from the GitHub native parent/child relationship |
 
+### Status mapping
+
+Status is derived from issue state plus labels. First match wins:
+
+| Signal | Status |
+|--------|--------|
+| Issue closed (or PR merged for linked PRs) | `Done` |
+| `in-progress` label | `In progress` |
+| `blocked` label | `Blocked` |
+| `claude-ready` label (no blocker) | `Ready` |
+| `needs-grooming` / `needs-design` / `design-approved` | `Backlog` |
+| No matching signal | (left alone — usually `To triage`) |
+
+Notable invariants:
+
+- **`blocked` beats `claude-ready`.** A blocked-but-groomed issue lands in `Blocked`, not `Ready`, so the Ready column is always pickable.
+- **`In review` is intentionally not auto-set** for issues. An issue with `in-progress` keeps that status across PR-open → review → merge → close transitions; the PR side of GitHub already tracks review state.
+- **No signal → no change.** The sync never bounces an item back to `To triage`. If a maintainer manually moves an item to `Backlog`, it stays put until a label gives the workflow a stronger signal.
+
 Labels are canonical. The `Sync Project` workflow (`.github/workflows/sync-project.yml`)
-auto-adds new issues to the project and recomputes the Priority/Size fields
-from labels on every issue event. To backfill or repair drift, run
+auto-adds new issues to the project and recomputes Priority/Size/Status from
+labels on every issue event. To backfill or repair drift, run
 `scripts/sync-issue-to-project.sh --all-open` locally or trigger the
 workflow with `backfill=true`.
 

--- a/docs/conventions/issue-naming.md
+++ b/docs/conventions/issue-naming.md
@@ -203,6 +203,49 @@ checks at least one of them:
 
 ---
 
+## Project board
+
+Every open issue is tracked on the **Sailfin Tracker** project
+(org project #4: `https://github.com/orgs/SailfinIO/projects/4`).
+
+| Field | Source | Notes |
+|-------|--------|-------|
+| Status | manual | `To triage` → `Backlog` → `Ready` → `In progress` → `In review` → `Done` |
+| Priority | `priority:*` label | `Critical`/`High`/`Medium`/`Low` mirror the four `priority:*` labels |
+| Size | `size:*` label | `XS`/`S`/`M` mirror the three `size:*` labels (no L; L items must be groomed down or promoted to `epic`) |
+| Milestone | `milestone` field | Phase marker — `M1`, `M1.5`, `M2`, `M3`, `Effect System Hardening`, `1.0` |
+| Iteration | manual | 2-week cadence, Monday-start. Optional per-issue (set on epics or in-flight work) |
+| Start / Target date | manual | Use on epics, not leaf issues — leaf issues are sized in hours, not days |
+| Parent issue / Sub-issues progress | auto | Inherits from the GitHub native parent/child relationship |
+
+Labels are canonical. The `Sync Project` workflow (`.github/workflows/sync-project.yml`)
+auto-adds new issues to the project and recomputes the Priority/Size fields
+from labels on every issue event. To backfill or repair drift, run
+`scripts/sync-issue-to-project.sh --all-open` locally or trigger the
+workflow with `backfill=true`.
+
+The workflow needs a PAT with `project` + `read:org` scopes, stored as
+`PROJECT_SYNC_TOKEN` (falls back to `RELEASE_PAT`). If neither secret is
+available the workflow no-ops — labels stay correct, only the project
+view goes stale.
+
+## Milestones
+
+Milestones are phase markers, not calendar deadlines. Every `epic` issue
+should carry exactly one milestone; sub-task issues inherit the milestone
+of their parent epic via the GitHub parent/child link.
+
+| Milestone | Track IDs | Captures |
+|-----------|-----------|----------|
+| `M1: Compiler Stabilization` | `M0`, `M1`, `T1` | Phase 1 systems primitives, build pipeline correctness, compiler perf |
+| `M1.5: Drop Emission` | `M1.5` | Deterministic scope-exit drops; hard prereq for M2 |
+| `M2: Runtime in Sailfin` | `M2` | Replace C runtime with pure Sailfin (arena, string, array, io, exception, …) |
+| `M3: Structured Concurrency` | `M3` | `routine`/`await`/`channel`/`spawn` plus atomic intrinsics |
+| `Effect System Hardening` | `EFF` | Compile-gate enforcement, hierarchical effects, transitive call-graph checking — runs in parallel with runtime work |
+| `1.0 — General Availability` | `T7` | Pure Sailfin toolchain, no C runtime, all enforcement gates active |
+
+---
+
 ## Track ID directory
 
 Reserved track IDs (extend by editing the roadmap, then this list):

--- a/scripts/sync-issue-to-project.sh
+++ b/scripts/sync-issue-to-project.sh
@@ -60,8 +60,10 @@ if [[ -z "${GH_TOKEN:-}" ]]; then
 fi
 
 run_query() {
-  # $1 = jq-style query for variables, $2 = graphql query
-  # Reads stdin as variables JSON.
+  # $1 = GraphQL query string. Variables JSON is read from stdin and merged
+  # into the request body. Returns the raw `gh api` response on stdout —
+  # callers must check `.errors` and `.data.*` themselves; this helper does
+  # not classify failures.
   local query="$1"
   gh api graphql --input - <<EOF
 {
@@ -71,12 +73,35 @@ run_query() {
 EOF
 }
 
+# Run a GraphQL mutation and abort the script if the response carries
+# `errors[]` or is missing the expected payload key. Echoes a short diagnostic
+# to stderr and returns non-zero so callers (and CI) see the failure.
+#   $1 = GraphQL query string
+#   $2 = jq path to the expected non-null field (e.g. ".data.foo.bar.id")
+#   $3 = human label for log output
+# Reads variables JSON from stdin.
+run_mutation() {
+  local query="$1" expect="$2" label="$3"
+  local resp
+  resp=$(run_query "$query")
+  if jq -e '.errors? // empty | length > 0' <<<"$resp" >/dev/null; then
+    echo "::error::$label failed: $(jq -c '.errors' <<<"$resp")" >&2
+    return 1
+  fi
+  if ! jq -e "$expect // empty | length > 0" <<<"$resp" >/dev/null; then
+    echo "::error::$label returned no $expect: $(jq -c '.' <<<"$resp")" >&2
+    return 1
+  fi
+  return 0
+}
+
 # ---- 1) Resolve project metadata once ----------------------------------
 PROJECT_META_QUERY='query($owner: String!, $number: Int!) {
   organization(login: $owner) {
     projectV2(number: $number) {
       id
-      fields(first: 50) {
+      fields(first: 100) {
+        pageInfo { hasNextPage }
         nodes {
           ... on ProjectV2SingleSelectField { id name options { id name } }
         }
@@ -87,6 +112,14 @@ PROJECT_META_QUERY='query($owner: String!, $number: Int!) {
 
 PROJECT_META=$(jq -n --arg owner "$PROJECT_OWNER" --argjson number "$PROJECT_NUMBER" \
   '{owner: $owner, number: $number}' | run_query "$PROJECT_META_QUERY")
+
+# Guard against a future where the project has more than 100 fields and the
+# ones we need fall outside the first page. Cheaper to fail loud than silently
+# skip the sync.
+if [[ "$(echo "$PROJECT_META" | jq -r '.data.organization.projectV2.fields.pageInfo.hasNextPage // false')" == "true" ]]; then
+  echo "::error::project has >100 fields; bump fields(first:) and re-run" >&2
+  exit 1
+fi
 
 PROJECT_ID=$(echo "$PROJECT_META" | jq -r '.data.organization.projectV2.id // empty')
 if [[ -z "$PROJECT_ID" ]]; then
@@ -203,10 +236,13 @@ sync_one() {
   local add_resp
   add_resp=$(jq -n --arg projectId "$PROJECT_ID" --arg contentId "$node_id" \
     '{projectId: $projectId, contentId: $contentId}' | run_query "$add_query")
+  if jq -e '.errors? // empty | length > 0' <<<"$add_resp" >/dev/null; then
+    echo "::error::add-to-project failed for #$num: $(jq -c '.errors' <<<"$add_resp")" >&2
+    return 1
+  fi
   item_id=$(jq -r '.data.addProjectV2ItemById.item.id // empty' <<<"$add_resp")
   if [[ -z "$item_id" ]]; then
-    echo "::warning::add-to-project failed for #$num" >&2
-    echo "$add_resp" >&2
+    echo "::error::add-to-project returned no item id for #$num: $(jq -c '.' <<<"$add_resp")" >&2
     return 1
   fi
 
@@ -239,7 +275,8 @@ sync_one() {
       jq -n --arg projectId "$PROJECT_ID" --arg itemId "$item_id" \
             --arg fieldId "$field_id" --arg optionId "$opt_id" \
         '{projectId: $projectId, itemId: $itemId, fieldId: $fieldId, optionId: $optionId}' \
-        | run_query "$set_query" >/dev/null
+        | run_mutation "$set_query" '.data.updateProjectV2ItemFieldValue.projectV2Item.id' \
+            "set $field_name=$opt_name on #$num" || return 1
       echo "  → #$num $field_name=$opt_name"
     else
       local clear_query='mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!) {
@@ -249,7 +286,8 @@ sync_one() {
       }'
       jq -n --arg projectId "$PROJECT_ID" --arg itemId "$item_id" --arg fieldId "$field_id" \
         '{projectId: $projectId, itemId: $itemId, fieldId: $fieldId}' \
-        | run_query "$clear_query" >/dev/null
+        | run_mutation "$clear_query" '.data.clearProjectV2ItemFieldValue.projectV2Item.id' \
+            "clear $field_name on #$num" || return 1
       echo "  → #$num $field_name=(cleared)"
     fi
   }

--- a/scripts/sync-issue-to-project.sh
+++ b/scripts/sync-issue-to-project.sh
@@ -109,8 +109,10 @@ option_id() {
 
 PRIORITY_FIELD_ID=$(field_id "Priority")
 SIZE_FIELD_ID=$(field_id "Size")
+STATUS_FIELD_ID=$(field_id "Status")
 [[ -n "$PRIORITY_FIELD_ID" ]] || { echo "::error::Priority field not found" >&2; exit 1; }
 [[ -n "$SIZE_FIELD_ID"     ]] || { echo "::error::Size field not found"     >&2; exit 1; }
+[[ -n "$STATUS_FIELD_ID"   ]] || { echo "::error::Status field not found"   >&2; exit 1; }
 
 # label name -> option name
 priority_option_for_label() {
@@ -121,6 +123,44 @@ priority_option_for_label() {
     priority:low)      echo "Low" ;;
     *) echo "" ;;
   esac
+}
+
+# Resolve Status from issue state + labels (label-driven; matches the rest of
+# the agentic pipeline, which is label-driven). Precedence (first match wins):
+#   closed                                       → Done
+#   in-progress                                  → In progress
+#   blocked                                      → Blocked
+#   claude-ready                                 → Ready
+#   needs-grooming / needs-design / design-approved → Backlog
+#   else                                         → (empty — keep current value;
+#                                                   don't bounce items back to
+#                                                   To triage on every event)
+#
+# "In review" is intentionally not auto-set: an issue with `in-progress` keeps
+# that status across the PR-open → review → merge → close transitions; the PR
+# board (not the issue board) tracks review state.
+status_for_issue() {
+  local state="$1"; shift
+  local labels=("$@")
+  # Treat any non-OPEN state as Done. gh returns CLOSED for issues and MERGED
+  # for PRs (gh issue view silently falls back to PR data on PR numbers).
+  [[ "$state" != "OPEN" ]] && { echo "Done"; return; }
+  local l
+  for l in "${labels[@]}"; do
+    [[ "$l" == "in-progress" ]] && { echo "In progress"; return; }
+  done
+  for l in "${labels[@]}"; do
+    [[ "$l" == "blocked" ]] && { echo "Blocked"; return; }
+  done
+  for l in "${labels[@]}"; do
+    [[ "$l" == "claude-ready" ]] && { echo "Ready"; return; }
+  done
+  for l in "${labels[@]}"; do
+    case "$l" in
+      needs-grooming|needs-design|design-approved) echo "Backlog"; return ;;
+    esac
+  done
+  echo ""  # no signal — leave Status alone
 }
 size_option_for_label() {
   case "$1" in
@@ -136,16 +176,21 @@ sync_one() {
   local num="$1"
   local node_id labels item_id
 
-  local issue_json
+  local issue_json state
   issue_json=$(gh issue view "$num" --repo "$GH_REPO" --json number,id,labels,state 2>/dev/null) || {
     echo "::warning::issue #$num not found in $GH_REPO; skipping" >&2
     return 0
   }
   node_id=$(jq -r '.id' <<<"$issue_json")
   labels=$(jq -r '[.labels[].name] | join(",")' <<<"$issue_json")
+  state=$(jq -r '.state' <<<"$issue_json")
+
+  IFS=',' read -ra LBLS <<<"$labels"
+  local status_opt
+  status_opt=$(status_for_issue "$state" "${LBLS[@]}")
 
   if [[ "$DRY_RUN" -eq 1 ]]; then
-    echo "would sync #$num (labels: $labels)"
+    echo "would sync #$num (state: $state, labels: $labels, status: ${status_opt:-<leave alone>})"
     return 0
   fi
 
@@ -167,7 +212,6 @@ sync_one() {
 
   # Resolve which option each field should be (empty string => clear)
   local priority_opt="" size_opt=""
-  IFS=',' read -ra LBLS <<<"$labels"
   for l in "${LBLS[@]}"; do
     local p s
     p=$(priority_option_for_label "$l")
@@ -212,6 +256,13 @@ sync_one() {
 
   set_or_clear "$PRIORITY_FIELD_ID" "Priority" "$priority_opt"
   set_or_clear "$SIZE_FIELD_ID"     "Size"     "$size_opt"
+
+  # Status: only set when we have a signal — never clear, since a maintainer
+  # may have manually placed an item in To triage / Backlog and we shouldn't
+  # bounce it on every label edit.
+  if [[ -n "$status_opt" ]]; then
+    set_or_clear "$STATUS_FIELD_ID" "Status" "$status_opt"
+  fi
 }
 
 # ---- 3) Drive ----------------------------------------------------------

--- a/scripts/sync-issue-to-project.sh
+++ b/scripts/sync-issue-to-project.sh
@@ -1,0 +1,226 @@
+#!/usr/bin/env bash
+# Sync a single issue to the Sailfin Tracker project (org project #4):
+#   - Add the issue to the project (idempotent)
+#   - Mirror its priority:* / size:* labels into the project Priority / Size
+#     single-select fields (idempotent; clears the field if no matching label
+#     is present)
+#
+# Labels are the source of truth (see .github/labels.yml). This script keeps
+# project fields in lockstep so views can group / filter on them.
+#
+# Usage:
+#   scripts/sync-issue-to-project.sh <issue-number>
+#   scripts/sync-issue-to-project.sh --all-open                # backfill loop
+#   scripts/sync-issue-to-project.sh --dry-run <issue-number>  # preview only
+#
+# Environment:
+#   GH_TOKEN          PAT with `project`, `read:org`, and repo scopes.
+#                     Defaults to RELEASE_PAT or GITHUB_TOKEN if set.
+#   GH_REPO           Defaults to SailfinIO/sailfin.
+#   PROJECT_OWNER     Org login. Defaults to SailfinIO.
+#   PROJECT_NUMBER    Project V2 number. Defaults to 4.
+#
+# Requirements: gh, jq.
+
+set -euo pipefail
+
+DRY_RUN=0
+ALL_OPEN=0
+ISSUE=""
+GH_REPO_DEFAULT="SailfinIO/sailfin"
+PROJECT_OWNER="${PROJECT_OWNER:-SailfinIO}"
+PROJECT_NUMBER="${PROJECT_NUMBER:-4}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run)   DRY_RUN=1; shift ;;
+    --all-open)  ALL_OPEN=1; shift ;;
+    -h|--help)
+      sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    --) shift; ISSUE="${1:-}"; shift || true ;;
+    *)
+      if [[ -z "$ISSUE" ]]; then ISSUE="$1"; shift
+      else echo "unknown arg: $1" >&2; exit 2
+      fi
+      ;;
+  esac
+done
+
+for tool in gh jq; do
+  command -v "$tool" >/dev/null 2>&1 || { echo "missing dependency: $tool" >&2; exit 2; }
+done
+
+GH_REPO="${GH_REPO:-$GH_REPO_DEFAULT}"
+export GH_TOKEN="${GH_TOKEN:-${RELEASE_PAT:-${GITHUB_TOKEN:-}}}"
+if [[ -z "${GH_TOKEN:-}" ]]; then
+  echo "::error::no GH_TOKEN / RELEASE_PAT / GITHUB_TOKEN available" >&2
+  exit 2
+fi
+
+run_query() {
+  # $1 = jq-style query for variables, $2 = graphql query
+  # Reads stdin as variables JSON.
+  local query="$1"
+  gh api graphql --input - <<EOF
+{
+  "query": $(printf '%s' "$query" | jq -Rs .),
+  "variables": $(cat)
+}
+EOF
+}
+
+# ---- 1) Resolve project metadata once ----------------------------------
+PROJECT_META_QUERY='query($owner: String!, $number: Int!) {
+  organization(login: $owner) {
+    projectV2(number: $number) {
+      id
+      fields(first: 50) {
+        nodes {
+          ... on ProjectV2SingleSelectField { id name options { id name } }
+        }
+      }
+    }
+  }
+}'
+
+PROJECT_META=$(jq -n --arg owner "$PROJECT_OWNER" --argjson number "$PROJECT_NUMBER" \
+  '{owner: $owner, number: $number}' | run_query "$PROJECT_META_QUERY")
+
+PROJECT_ID=$(echo "$PROJECT_META" | jq -r '.data.organization.projectV2.id // empty')
+if [[ -z "$PROJECT_ID" ]]; then
+  echo "::error::could not resolve project ${PROJECT_OWNER}#${PROJECT_NUMBER}" >&2
+  echo "$PROJECT_META" >&2
+  exit 1
+fi
+
+field_id() {
+  echo "$PROJECT_META" | jq -r --arg n "$1" \
+    '.data.organization.projectV2.fields.nodes[] | select(.name==$n) | .id // empty'
+}
+option_id() {
+  # $1 = field name, $2 = option name
+  echo "$PROJECT_META" | jq -r --arg n "$1" --arg o "$2" \
+    '.data.organization.projectV2.fields.nodes[]
+       | select(.name==$n).options[]
+       | select(.name==$o).id // empty'
+}
+
+PRIORITY_FIELD_ID=$(field_id "Priority")
+SIZE_FIELD_ID=$(field_id "Size")
+[[ -n "$PRIORITY_FIELD_ID" ]] || { echo "::error::Priority field not found" >&2; exit 1; }
+[[ -n "$SIZE_FIELD_ID"     ]] || { echo "::error::Size field not found"     >&2; exit 1; }
+
+# label name -> option name
+priority_option_for_label() {
+  case "$1" in
+    priority:critical) echo "Critical" ;;
+    priority:high)     echo "High" ;;
+    priority:medium)   echo "Medium" ;;
+    priority:low)      echo "Low" ;;
+    *) echo "" ;;
+  esac
+}
+size_option_for_label() {
+  case "$1" in
+    size:xs) echo "XS" ;;
+    size:s)  echo "S" ;;
+    size:m)  echo "M" ;;
+    *) echo "" ;;
+  esac
+}
+
+# ---- 2) Sync one issue --------------------------------------------------
+sync_one() {
+  local num="$1"
+  local node_id labels item_id
+
+  local issue_json
+  issue_json=$(gh issue view "$num" --repo "$GH_REPO" --json number,id,labels,state 2>/dev/null) || {
+    echo "::warning::issue #$num not found in $GH_REPO; skipping" >&2
+    return 0
+  }
+  node_id=$(jq -r '.id' <<<"$issue_json")
+  labels=$(jq -r '[.labels[].name] | join(",")' <<<"$issue_json")
+
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    echo "would sync #$num (labels: $labels)"
+    return 0
+  fi
+
+  # Add to project (idempotent — addProjectV2ItemById returns the existing item)
+  local add_query='mutation($projectId: ID!, $contentId: ID!) {
+    addProjectV2ItemById(input: {projectId: $projectId, contentId: $contentId}) {
+      item { id }
+    }
+  }'
+  local add_resp
+  add_resp=$(jq -n --arg projectId "$PROJECT_ID" --arg contentId "$node_id" \
+    '{projectId: $projectId, contentId: $contentId}' | run_query "$add_query")
+  item_id=$(jq -r '.data.addProjectV2ItemById.item.id // empty' <<<"$add_resp")
+  if [[ -z "$item_id" ]]; then
+    echo "::warning::add-to-project failed for #$num" >&2
+    echo "$add_resp" >&2
+    return 1
+  fi
+
+  # Resolve which option each field should be (empty string => clear)
+  local priority_opt="" size_opt=""
+  IFS=',' read -ra LBLS <<<"$labels"
+  for l in "${LBLS[@]}"; do
+    local p s
+    p=$(priority_option_for_label "$l")
+    s=$(size_option_for_label "$l")
+    [[ -n "$p" && -z "$priority_opt" ]] && priority_opt="$p"
+    [[ -n "$s" && -z "$size_opt"     ]] && size_opt="$s"
+  done
+
+  set_or_clear() {
+    # $1 = field id, $2 = field name, $3 = option name (or empty to clear)
+    local field_id="$1" field_name="$2" opt_name="$3"
+    if [[ -n "$opt_name" ]]; then
+      local opt_id
+      opt_id=$(option_id "$field_name" "$opt_name")
+      if [[ -z "$opt_id" ]]; then
+        echo "::warning::no option '$opt_name' on field '$field_name'" >&2
+        return 0
+      fi
+      local set_query='mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+        updateProjectV2ItemFieldValue(input: {
+          projectId: $projectId, itemId: $itemId, fieldId: $fieldId,
+          value: { singleSelectOptionId: $optionId }
+        }) { projectV2Item { id } }
+      }'
+      jq -n --arg projectId "$PROJECT_ID" --arg itemId "$item_id" \
+            --arg fieldId "$field_id" --arg optionId "$opt_id" \
+        '{projectId: $projectId, itemId: $itemId, fieldId: $fieldId, optionId: $optionId}' \
+        | run_query "$set_query" >/dev/null
+      echo "  → #$num $field_name=$opt_name"
+    else
+      local clear_query='mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!) {
+        clearProjectV2ItemFieldValue(input: {
+          projectId: $projectId, itemId: $itemId, fieldId: $fieldId
+        }) { projectV2Item { id } }
+      }'
+      jq -n --arg projectId "$PROJECT_ID" --arg itemId "$item_id" --arg fieldId "$field_id" \
+        '{projectId: $projectId, itemId: $itemId, fieldId: $fieldId}' \
+        | run_query "$clear_query" >/dev/null
+      echo "  → #$num $field_name=(cleared)"
+    fi
+  }
+
+  set_or_clear "$PRIORITY_FIELD_ID" "Priority" "$priority_opt"
+  set_or_clear "$SIZE_FIELD_ID"     "Size"     "$size_opt"
+}
+
+# ---- 3) Drive ----------------------------------------------------------
+if [[ "$ALL_OPEN" -eq 1 ]]; then
+  mapfile -t NUMBERS < <(gh issue list --repo "$GH_REPO" --state open --limit 500 --json number --jq '.[].number')
+  echo "syncing ${#NUMBERS[@]} open issues"
+  for n in "${NUMBERS[@]}"; do sync_one "$n"; done
+  echo "done"
+else
+  [[ -n "$ISSUE" ]] || { echo "usage: $0 <issue-number> | --all-open" >&2; exit 2; }
+  sync_one "$ISSUE"
+fi


### PR DESCRIPTION
## Summary

The Sailfin Tracker org project (#4) had Priority/Size/Estimate/Iteration/Start/Target fields configured, but they were empty and the option vocabularies didn't match the canonical labels in `.github/labels.yml`. This PR bolts the project to the label registry so views can group/filter without re-deriving from labels.

- `scripts/sync-issue-to-project.sh` — idempotent worker. Adds an issue to the project, then mirrors `priority:*`/`size:*` labels into the Priority/Size single-select fields (clears the field when no matching label exists). Supports `--all-open` for backfill and `--dry-run`.
- `.github/workflows/sync-project.yml` — runs the script on every issue event (`opened`/`reopened`/`labeled`/`unlabeled`/`edited`) plus `workflow_dispatch` with a backfill toggle. Auths via `PROJECT_SYNC_TOKEN` (preferred) with `RELEASE_PAT` fallback; no-ops gracefully if neither secret is present.
- `docs/conventions/issue-naming.md` — adds **Project board** and **Milestones** sections that document the field/label mapping, the new milestones (`M1`, `M1.5`, `M2`, `M3`, `Effect System Hardening`, `1.0`), and how iteration/start/target dates apply.

## Out-of-band changes (already applied via GraphQL)

These are project-side state that doesn't live in the repo, applied directly in the same session. The workflow above keeps them in lockstep going forward:

- **Project metadata**: short description set, README populated.
- **Priority field**: renamed `P0`/`P1`/`P2` → `Critical`/`High`/`Medium` and added `Low` (now matches `priority:*` labels exactly).
- **Size field**: trimmed to `XS`/`S`/`M` (no items used the orphan `L`/`XL` options).
- **6 milestones created**: `M1: Compiler Stabilization`, `M1.5: Drop Emission`, `M2: Runtime in Sailfin`, `M3: Structured Concurrency`, `Effect System Hardening`, `1.0 — General Availability`.
- **10 epics labelled + assigned to milestones** (#322 → M1.5, #389 → M2, #390/#323 → M3, #371/#340/#344/#351/#362 → M1, #345 → 1.0). The 8 epics that were missing the `epic` label now carry it.
- **117 field values backfilled** across 50 open issues so existing items already reflect their labels.

## Required follow-up (one click each)

1. **Add `PROJECT_SYNC_TOKEN` secret** (or confirm `RELEASE_PAT` has `project` + `read:org` scopes). If neither has the right scopes the workflow logs a warning and exits 0 — labels stay correct, only the project view goes stale.
2. **Add upcoming iterations** in the project UI when ready to plan beyond Iteration 3 (the GraphQL API doesn't expose iteration creation).

## Test plan

- [x] `scripts/sync-issue-to-project.sh --dry-run 395` — emits `would sync #395 (labels: ...)` without writing
- [x] `scripts/sync-issue-to-project.sh 395` — sets Priority=High, Size=M
- [x] `scripts/sync-issue-to-project.sh 411` — clears Priority/Size on an issue with no matching labels (idempotent)
- [ ] Workflow run on next labelled issue mirrors changes within seconds
- [ ] `gh workflow run sync-project.yml -f backfill=true` re-syncs all open issues with no diff vs the manual backfill

🤖 Generated with [Claude Code](https://claude.com/claude-code)