### PR TITLE
docs(site): drive roadmap page from GitHub milestones

### DIFF
--- a/.github/workflows/architect-review.lock.yml
+++ b/.github/workflows/architect-review.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"eb7aaa96892a9ef5f7accbaa759d6c2bc1e6341717ca1f192d59c1eeafeeb06a","compiler_version":"v0.72.1","strict":true,"agent_id":"claude","agent_model":"claude-opus-4-7"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"74c3f65098cb22c2e1828a1c1a42115b7404b0c0bdf26d98d4fcd4bcaf3108d5","compiler_version":"v0.72.1","strict":true,"agent_id":"claude","agent_model":"claude-opus-4-7"}
 # gh-aw-manifest: {"version":1,"secrets":["ANTHROPIC_API_KEY","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"34e114876b0b11c390a56381ad16ebd13914f8d5","version":"v4"},{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/setup-node","sha":"49933ea5288caeca8642d1e84afbd3f7d6820020","version":"v4"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"bc56a0cad2f450c562810785ef38649c04db812a","version":"v0.72.1"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.41"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.41"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.41"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -57,10 +57,13 @@
 
 name: "Sailfin Architect Review"
 "on":
-  issues:
-    types:
-    - labeled
-  # skip-if-no-match: label:needs-design # Skip-if-no-match processed as search check in pre-activation job
+  workflow_dispatch:
+    inputs:
+      aw_context:
+        default: ""
+        description: Agent caller context (used internally by Agentic Workflows).
+        required: false
+        type: string
 
 permissions: {}
 
@@ -72,14 +75,11 @@ run-name: "Sailfin Architect Review"
 
 jobs:
   activation:
-    needs: pre_activation
-    if: needs.pre_activation.outputs.activated == 'true'
     runs-on: ubuntu-slim
     permissions:
       actions: read
       contents: read
     outputs:
-      body: ${{ steps.sanitized.outputs.body }}
       comment_id: ""
       comment_repo: ""
       engine_id: ${{ steps.generate_aw_info.outputs.engine_id }}
@@ -88,8 +88,6 @@ jobs:
       secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
       setup-trace-id: ${{ steps.setup.outputs.trace-id }}
       stale_lock_file_failed: ${{ steps.check-lock-file.outputs.stale_lock_file_failed == 'true' }}
-      text: ${{ steps.sanitized.outputs.text }}
-      title: ${{ steps.sanitized.outputs.title }}
     steps:
       - name: Setup Scripts
         id: setup
@@ -97,7 +95,6 @@ jobs:
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}
-          trace-id: ${{ needs.pre_activation.outputs.setup-trace-id }}
         env:
           GH_AW_SETUP_WORKFLOW_NAME: "Sailfin Architect Review"
           GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/architect-review.lock.yml@${{ github.ref }}
@@ -176,17 +173,6 @@ jobs:
             setupGlobals(core, github, context, exec, io, getOctokit);
             const { main } = require('${{ runner.temp }}/gh-aw/actions/check_version_updates.cjs');
             await main();
-      - name: Compute current body text
-        id: sanitized
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        env:
-          GH_AW_ALLOWED_DOMAINS: "*.githubusercontent.com,anthropic.com,api.anthropic.com,api.github.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,cdn.playwright.dev,codeload.github.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,files.pythonhosted.org,ghcr.io,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,lfs.github.com,objects.githubusercontent.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,playwright.download.prss.microsoft.com,ppa.launchpad.net,pypi.org,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,sentry.io,statsig.anthropic.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com"
-        with:
-          script: |
-            const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
-            setupGlobals(core, github, context, exec, io, getOctokit);
-            const { main } = require('${{ runner.temp }}/gh-aw/actions/compute_text.cjs');
-            await main();
       - name: Create prompt with built-in context
         env:
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
@@ -203,20 +189,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_562954f6b1413ef1_EOF'
+          cat << 'GH_AW_PROMPT_e7bdd87c908e0d9b_EOF'
           <system>
-          GH_AW_PROMPT_562954f6b1413ef1_EOF
+          GH_AW_PROMPT_e7bdd87c908e0d9b_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_562954f6b1413ef1_EOF'
+          cat << 'GH_AW_PROMPT_e7bdd87c908e0d9b_EOF'
           <safe-output-tools>
           Tools: add_comment, add_labels(max:3), remove_labels(max:2), missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_562954f6b1413ef1_EOF
+          GH_AW_PROMPT_e7bdd87c908e0d9b_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_562954f6b1413ef1_EOF'
+          cat << 'GH_AW_PROMPT_e7bdd87c908e0d9b_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if __GH_AW_GITHUB_ACTOR__ }}
@@ -245,13 +231,13 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_562954f6b1413ef1_EOF
+          GH_AW_PROMPT_e7bdd87c908e0d9b_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_562954f6b1413ef1_EOF'
+          cat << 'GH_AW_PROMPT_e7bdd87c908e0d9b_EOF'
           </system>
           {{#runtime-import .github/workflows/shared/build-mcp-server.md}}
           {{#runtime-import .github/workflows/architect-review.md}}
-          GH_AW_PROMPT_562954f6b1413ef1_EOF
+          GH_AW_PROMPT_e7bdd87c908e0d9b_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -278,7 +264,6 @@ jobs:
           GH_AW_GITHUB_RUN_ID: ${{ github.run_id }}
           GH_AW_GITHUB_WORKSPACE: ${{ github.workspace }}
           GH_AW_MCP_CLI_SERVERS_LIST: '- `safeoutputs` — run `safeoutputs --help` to see available tools'
-          GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED: ${{ needs.pre_activation.outputs.activated }}
         with:
           script: |
             const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
@@ -298,8 +283,7 @@ jobs:
                 GH_AW_GITHUB_REPOSITORY: process.env.GH_AW_GITHUB_REPOSITORY,
                 GH_AW_GITHUB_RUN_ID: process.env.GH_AW_GITHUB_RUN_ID,
                 GH_AW_GITHUB_WORKSPACE: process.env.GH_AW_GITHUB_WORKSPACE,
-                GH_AW_MCP_CLI_SERVERS_LIST: process.env.GH_AW_MCP_CLI_SERVERS_LIST,
-                GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED: process.env.GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED
+                GH_AW_MCP_CLI_SERVERS_LIST: process.env.GH_AW_MCP_CLI_SERVERS_LIST
               }
             });
       - name: Validate prompt placeholders
@@ -451,9 +435,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_90bb46a8af4735ad_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_d7f3a400207e91ad_EOF'
           {"add_comment":{"max":1},"add_labels":{"max":3},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"remove_labels":{"max":2},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_90bb46a8af4735ad_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_d7f3a400207e91ad_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -679,7 +663,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host --add-host host.docker.internal:127.0.0.1 --user '"${MCP_GATEWAY_UID}"':'"${MCP_GATEWAY_GID}"' --group-add '"${DOCKER_SOCK_GID}"' -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.3.6'
           
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_81b831967c1613ae_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_b69f4731d67e5e00_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -722,7 +706,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_81b831967c1613ae_EOF
+          GH_AW_MCP_CONFIG_b69f4731d67e5e00_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1332,49 +1316,6 @@ jobs:
                 core.setFailed(msg);
               }
             }
-
-  pre_activation:
-    runs-on: ubuntu-slim
-    outputs:
-      activated: ${{ steps.check_membership.outputs.is_team_member == 'true' && steps.check_skip_if_no_match.outputs.skip_no_match_check_ok == 'true' }}
-      matched_command: ''
-      setup-trace-id: ${{ steps.setup.outputs.trace-id }}
-    steps:
-      - name: Setup Scripts
-        id: setup
-        uses: github/gh-aw-actions/setup@bc56a0cad2f450c562810785ef38649c04db812a # v0.72.1
-        with:
-          destination: ${{ runner.temp }}/gh-aw/actions
-          job-name: ${{ github.job }}
-        env:
-          GH_AW_SETUP_WORKFLOW_NAME: "Sailfin Architect Review"
-          GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/architect-review.lock.yml@${{ github.ref }}
-          GH_AW_INFO_VERSION: "2.1.126"
-      - name: Check team membership for workflow
-        id: check_membership
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        env:
-          GH_AW_REQUIRED_ROLES: "admin,maintainer,write"
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
-            setupGlobals(core, github, context, exec, io, getOctokit);
-            const { main } = require('${{ runner.temp }}/gh-aw/actions/check_membership.cjs');
-            await main();
-      - name: Check skip-if-no-match query
-        id: check_skip_if_no_match
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        env:
-          GH_AW_SKIP_QUERY: "label:needs-design"
-          GH_AW_WORKFLOW_NAME: "Sailfin Architect Review"
-          GH_AW_SKIP_MIN_MATCHES: "1"
-        with:
-          script: |
-            const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
-            setupGlobals(core, github, context, exec, io, getOctokit);
-            const { main } = require('${{ runner.temp }}/gh-aw/actions/check_skip_if_no_match.cjs');
-            await main();
 
   safe_outputs:
     needs:

--- a/.github/workflows/architect-review.md
+++ b/.github/workflows/architect-review.md
@@ -5,11 +5,12 @@ description: |
   pipeline, and pre-1.0 stabilization goals. Approves designs or requests
   discussion before implementation begins.
 
+# DISABLED 2026-05-08: gh-aw workflows are paused due to runaway cost.
+# Manual dispatch only — no event triggers. Re-enable by restoring the
+# original `issues: [labeled]` trigger + skip-if-no-match clause and
+# recompiling the lock file with `gh aw compile`.
 on:
-  issues:
-    types: [labeled]
-  # Only fire on the label that matters; skip the boot for any other label event.
-  skip-if-no-match: 'label:needs-design'
+  workflow_dispatch:
 
 imports:
   - shared/build-mcp-server.md

--- a/.github/workflows/engineer.lock.yml
+++ b/.github/workflows/engineer.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"8f7b7f740621866523dd5863a2b68231abdeff6c102b8ad954021dddebd124a6","compiler_version":"v0.72.1","strict":true,"agent_id":"claude","agent_model":"claude-opus-4-7"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"3977ac2d47d91482e9822728883b3749017c284771cc3312e86924b3fc577803","compiler_version":"v0.72.1","strict":true,"agent_id":"claude","agent_model":"claude-opus-4-7"}
 # gh-aw-manifest: {"version":1,"secrets":["ANTHROPIC_API_KEY","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"34e114876b0b11c390a56381ad16ebd13914f8d5","version":"v4"},{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/setup-node","sha":"49933ea5288caeca8642d1e84afbd3f7d6820020","version":"v4"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"bc56a0cad2f450c562810785ef38649c04db812a","version":"v0.72.1"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.41"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.41"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.41"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -58,10 +58,13 @@
 
 name: "Sailfin Engineer"
 "on":
-  issues:
-    types:
-    - labeled
-  # skip-if-no-match: label:design-approved,type:bug # Skip-if-no-match processed as search check in pre-activation job
+  workflow_dispatch:
+    inputs:
+      aw_context:
+        default: ""
+        description: Agent caller context (used internally by Agentic Workflows).
+        required: false
+        type: string
 
 permissions: {}
 
@@ -73,14 +76,11 @@ run-name: "Sailfin Engineer"
 
 jobs:
   activation:
-    needs: pre_activation
-    if: needs.pre_activation.outputs.activated == 'true'
     runs-on: ubuntu-slim
     permissions:
       actions: read
       contents: read
     outputs:
-      body: ${{ steps.sanitized.outputs.body }}
       comment_id: ""
       comment_repo: ""
       engine_id: ${{ steps.generate_aw_info.outputs.engine_id }}
@@ -89,8 +89,6 @@ jobs:
       secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
       setup-trace-id: ${{ steps.setup.outputs.trace-id }}
       stale_lock_file_failed: ${{ steps.check-lock-file.outputs.stale_lock_file_failed == 'true' }}
-      text: ${{ steps.sanitized.outputs.text }}
-      title: ${{ steps.sanitized.outputs.title }}
     steps:
       - name: Setup Scripts
         id: setup
@@ -98,7 +96,6 @@ jobs:
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}
-          trace-id: ${{ needs.pre_activation.outputs.setup-trace-id }}
         env:
           GH_AW_SETUP_WORKFLOW_NAME: "Sailfin Engineer"
           GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/engineer.lock.yml@${{ github.ref }}
@@ -177,17 +174,6 @@ jobs:
             setupGlobals(core, github, context, exec, io, getOctokit);
             const { main } = require('${{ runner.temp }}/gh-aw/actions/check_version_updates.cjs');
             await main();
-      - name: Compute current body text
-        id: sanitized
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        env:
-          GH_AW_ALLOWED_DOMAINS: "*.githubusercontent.com,anthropic.com,api.anthropic.com,api.github.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,cdn.playwright.dev,codeload.github.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,files.pythonhosted.org,ghcr.io,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,lfs.github.com,objects.githubusercontent.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,playwright.download.prss.microsoft.com,ppa.launchpad.net,pypi.org,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,sentry.io,statsig.anthropic.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com"
-        with:
-          script: |
-            const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
-            setupGlobals(core, github, context, exec, io, getOctokit);
-            const { main } = require('${{ runner.temp }}/gh-aw/actions/compute_text.cjs');
-            await main();
       - name: Create prompt with built-in context
         env:
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
@@ -204,24 +190,24 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_9f6051c4e391ba99_EOF'
+          cat << 'GH_AW_PROMPT_8a9aec3fdf588b29_EOF'
           <system>
-          GH_AW_PROMPT_9f6051c4e391ba99_EOF
+          GH_AW_PROMPT_8a9aec3fdf588b29_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_9f6051c4e391ba99_EOF'
+          cat << 'GH_AW_PROMPT_8a9aec3fdf588b29_EOF'
           <safe-output-tools>
           Tools: add_comment, create_pull_request, add_labels(max:3), push_to_pull_request_branch, missing_tool, missing_data, noop
-          GH_AW_PROMPT_9f6051c4e391ba99_EOF
+          GH_AW_PROMPT_8a9aec3fdf588b29_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_push_to_pr_branch.md"
-          cat << 'GH_AW_PROMPT_9f6051c4e391ba99_EOF'
+          cat << 'GH_AW_PROMPT_8a9aec3fdf588b29_EOF'
           </safe-output-tools>
-          GH_AW_PROMPT_9f6051c4e391ba99_EOF
+          GH_AW_PROMPT_8a9aec3fdf588b29_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_9f6051c4e391ba99_EOF'
+          cat << 'GH_AW_PROMPT_8a9aec3fdf588b29_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if __GH_AW_GITHUB_ACTOR__ }}
@@ -250,13 +236,13 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_9f6051c4e391ba99_EOF
+          GH_AW_PROMPT_8a9aec3fdf588b29_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_9f6051c4e391ba99_EOF'
+          cat << 'GH_AW_PROMPT_8a9aec3fdf588b29_EOF'
           </system>
           {{#runtime-import .github/workflows/shared/build-mcp-server.md}}
           {{#runtime-import .github/workflows/engineer.md}}
-          GH_AW_PROMPT_9f6051c4e391ba99_EOF
+          GH_AW_PROMPT_8a9aec3fdf588b29_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -283,7 +269,6 @@ jobs:
           GH_AW_GITHUB_RUN_ID: ${{ github.run_id }}
           GH_AW_GITHUB_WORKSPACE: ${{ github.workspace }}
           GH_AW_MCP_CLI_SERVERS_LIST: '- `safeoutputs` — run `safeoutputs --help` to see available tools'
-          GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED: ${{ needs.pre_activation.outputs.activated }}
         with:
           script: |
             const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
@@ -303,8 +288,7 @@ jobs:
                 GH_AW_GITHUB_REPOSITORY: process.env.GH_AW_GITHUB_REPOSITORY,
                 GH_AW_GITHUB_RUN_ID: process.env.GH_AW_GITHUB_RUN_ID,
                 GH_AW_GITHUB_WORKSPACE: process.env.GH_AW_GITHUB_WORKSPACE,
-                GH_AW_MCP_CLI_SERVERS_LIST: process.env.GH_AW_MCP_CLI_SERVERS_LIST,
-                GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED: process.env.GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED
+                GH_AW_MCP_CLI_SERVERS_LIST: process.env.GH_AW_MCP_CLI_SERVERS_LIST
               }
             });
       - name: Validate prompt placeholders
@@ -460,9 +444,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_0aacaef7d4c0cb51_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_14cff15a1fe2947d_EOF'
           {"add_comment":{"max":1},"add_labels":{"max":3},"create_pull_request":{"max":1,"max_patch_files":100,"max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","CLAUDE.md","AGENTS.md"]},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"push_to_pull_request_branch":{"if_no_changes":"warn","max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","CLAUDE.md","AGENTS.md"]},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_0aacaef7d4c0cb51_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_14cff15a1fe2947d_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -732,7 +716,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host --add-host host.docker.internal:127.0.0.1 --user '"${MCP_GATEWAY_UID}"':'"${MCP_GATEWAY_GID}"' --group-add '"${DOCKER_SOCK_GID}"' -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.3.6'
           
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_9b26c21c0ed351b5_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_86b6cbf08602ca91_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -772,7 +756,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_9b26c21c0ed351b5_EOF
+          GH_AW_MCP_CONFIG_86b6cbf08602ca91_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1382,49 +1366,6 @@ jobs:
                 core.setFailed(msg);
               }
             }
-
-  pre_activation:
-    runs-on: ubuntu-slim
-    outputs:
-      activated: ${{ steps.check_membership.outputs.is_team_member == 'true' && steps.check_skip_if_no_match.outputs.skip_no_match_check_ok == 'true' }}
-      matched_command: ''
-      setup-trace-id: ${{ steps.setup.outputs.trace-id }}
-    steps:
-      - name: Setup Scripts
-        id: setup
-        uses: github/gh-aw-actions/setup@bc56a0cad2f450c562810785ef38649c04db812a # v0.72.1
-        with:
-          destination: ${{ runner.temp }}/gh-aw/actions
-          job-name: ${{ github.job }}
-        env:
-          GH_AW_SETUP_WORKFLOW_NAME: "Sailfin Engineer"
-          GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/engineer.lock.yml@${{ github.ref }}
-          GH_AW_INFO_VERSION: "2.1.126"
-      - name: Check team membership for workflow
-        id: check_membership
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        env:
-          GH_AW_REQUIRED_ROLES: "admin,maintainer,write"
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
-            setupGlobals(core, github, context, exec, io, getOctokit);
-            const { main } = require('${{ runner.temp }}/gh-aw/actions/check_membership.cjs');
-            await main();
-      - name: Check skip-if-no-match query
-        id: check_skip_if_no_match
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        env:
-          GH_AW_SKIP_QUERY: "label:design-approved,type:bug"
-          GH_AW_WORKFLOW_NAME: "Sailfin Engineer"
-          GH_AW_SKIP_MIN_MATCHES: "1"
-        with:
-          script: |
-            const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
-            setupGlobals(core, github, context, exec, io, getOctokit);
-            const { main } = require('${{ runner.temp }}/gh-aw/actions/check_skip_if_no_match.cjs');
-            await main();
 
   safe_outputs:
     needs:

--- a/.github/workflows/engineer.md
+++ b/.github/workflows/engineer.md
@@ -4,13 +4,12 @@ description: |
   Triggered on issues labeled 'design-approved' or 'type:bug'. Creates a
   branch, implements changes in Sailfin (.sfn), adds tests, and opens a PR.
 
+# DISABLED 2026-05-08: gh-aw workflows are paused due to runaway cost.
+# Manual dispatch only — no event triggers. Re-enable by restoring the
+# original `issues: [labeled]` trigger + skip-if-no-match clause and
+# recompiling the lock file with `gh aw compile`.
 on:
-  issues:
-    types: [labeled]
-  # Short-circuit before booting the agent: the only labels that should ever
-  # trigger work here are design-approved or type:bug. Anything else, exit at
-  # the workflow level — saves the first-turn cost of writing a noop.
-  skip-if-no-match: 'label:design-approved,type:bug'
+  workflow_dispatch:
 
 imports:
   - shared/build-mcp-server.md

--- a/.github/workflows/issue-triage.lock.yml
+++ b/.github/workflows/issue-triage.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"670ef20f832a37696b2b4392ba07604ea6cc420fd313630432c2649a40ca378e","compiler_version":"v0.72.1","strict":true,"agent_id":"claude","agent_model":"claude-haiku-4-5"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"4b6603de65eb12bebef936d31244732dd24be8aca483a5cdaa53fd9b20678239","compiler_version":"v0.72.1","strict":true,"agent_id":"claude","agent_model":"claude-haiku-4-5"}
 # gh-aw-manifest: {"version":1,"secrets":["ANTHROPIC_API_KEY","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"34e114876b0b11c390a56381ad16ebd13914f8d5","version":"v4"},{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/setup-node","sha":"49933ea5288caeca8642d1e84afbd3f7d6820020","version":"v4"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"bc56a0cad2f450c562810785ef38649c04db812a","version":"v0.72.1"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.41"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.41"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.41"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -57,10 +57,13 @@
 
 name: "Sailfin Issue Triage"
 "on":
-  issues:
-    types:
-    - opened
-    - reopened
+  workflow_dispatch:
+    inputs:
+      aw_context:
+        default: ""
+        description: Agent caller context (used internally by Agentic Workflows).
+        required: false
+        type: string
 
 permissions: {}
 
@@ -72,14 +75,11 @@ run-name: "Sailfin Issue Triage"
 
 jobs:
   activation:
-    needs: pre_activation
-    if: needs.pre_activation.outputs.activated == 'true'
     runs-on: ubuntu-slim
     permissions:
       actions: read
       contents: read
     outputs:
-      body: ${{ steps.sanitized.outputs.body }}
       comment_id: ""
       comment_repo: ""
       engine_id: ${{ steps.generate_aw_info.outputs.engine_id }}
@@ -88,8 +88,6 @@ jobs:
       secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
       setup-trace-id: ${{ steps.setup.outputs.trace-id }}
       stale_lock_file_failed: ${{ steps.check-lock-file.outputs.stale_lock_file_failed == 'true' }}
-      text: ${{ steps.sanitized.outputs.text }}
-      title: ${{ steps.sanitized.outputs.title }}
     steps:
       - name: Setup Scripts
         id: setup
@@ -97,7 +95,6 @@ jobs:
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}
-          trace-id: ${{ needs.pre_activation.outputs.setup-trace-id }}
         env:
           GH_AW_SETUP_WORKFLOW_NAME: "Sailfin Issue Triage"
           GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/issue-triage.lock.yml@${{ github.ref }}
@@ -176,17 +173,6 @@ jobs:
             setupGlobals(core, github, context, exec, io, getOctokit);
             const { main } = require('${{ runner.temp }}/gh-aw/actions/check_version_updates.cjs');
             await main();
-      - name: Compute current body text
-        id: sanitized
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        env:
-          GH_AW_ALLOWED_DOMAINS: "*.githubusercontent.com,anthropic.com,api.anthropic.com,api.github.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,cdn.playwright.dev,codeload.github.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,files.pythonhosted.org,ghcr.io,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,lfs.github.com,objects.githubusercontent.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,playwright.download.prss.microsoft.com,ppa.launchpad.net,pypi.org,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,sentry.io,statsig.anthropic.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com"
-        with:
-          script: |
-            const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
-            setupGlobals(core, github, context, exec, io, getOctokit);
-            const { main } = require('${{ runner.temp }}/gh-aw/actions/compute_text.cjs');
-            await main();
       - name: Create prompt with built-in context
         env:
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
@@ -203,20 +189,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_e2ad472191594777_EOF'
+          cat << 'GH_AW_PROMPT_1bde04bd706c43a3_EOF'
           <system>
-          GH_AW_PROMPT_e2ad472191594777_EOF
+          GH_AW_PROMPT_1bde04bd706c43a3_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_e2ad472191594777_EOF'
+          cat << 'GH_AW_PROMPT_1bde04bd706c43a3_EOF'
           <safe-output-tools>
           Tools: add_comment, update_issue, add_labels(max:5), missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_e2ad472191594777_EOF
+          GH_AW_PROMPT_1bde04bd706c43a3_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_e2ad472191594777_EOF'
+          cat << 'GH_AW_PROMPT_1bde04bd706c43a3_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if __GH_AW_GITHUB_ACTOR__ }}
@@ -245,13 +231,13 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_e2ad472191594777_EOF
+          GH_AW_PROMPT_1bde04bd706c43a3_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_e2ad472191594777_EOF'
+          cat << 'GH_AW_PROMPT_1bde04bd706c43a3_EOF'
           </system>
           {{#runtime-import .github/workflows/shared/build-mcp-server.md}}
           {{#runtime-import .github/workflows/issue-triage.md}}
-          GH_AW_PROMPT_e2ad472191594777_EOF
+          GH_AW_PROMPT_1bde04bd706c43a3_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -278,7 +264,6 @@ jobs:
           GH_AW_GITHUB_RUN_ID: ${{ github.run_id }}
           GH_AW_GITHUB_WORKSPACE: ${{ github.workspace }}
           GH_AW_MCP_CLI_SERVERS_LIST: '- `safeoutputs` — run `safeoutputs --help` to see available tools'
-          GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED: ${{ needs.pre_activation.outputs.activated }}
         with:
           script: |
             const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
@@ -298,8 +283,7 @@ jobs:
                 GH_AW_GITHUB_REPOSITORY: process.env.GH_AW_GITHUB_REPOSITORY,
                 GH_AW_GITHUB_RUN_ID: process.env.GH_AW_GITHUB_RUN_ID,
                 GH_AW_GITHUB_WORKSPACE: process.env.GH_AW_GITHUB_WORKSPACE,
-                GH_AW_MCP_CLI_SERVERS_LIST: process.env.GH_AW_MCP_CLI_SERVERS_LIST,
-                GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED: process.env.GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED
+                GH_AW_MCP_CLI_SERVERS_LIST: process.env.GH_AW_MCP_CLI_SERVERS_LIST
               }
             });
       - name: Validate prompt placeholders
@@ -451,9 +435,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_fa7faa6131f2b4f0_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_b2226b24bf685c5a_EOF'
           {"add_comment":{"max":1},"add_labels":{"max":5},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"report_incomplete":{},"update_issue":{"allow_body":true,"max":1}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_fa7faa6131f2b4f0_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_b2226b24bf685c5a_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -714,7 +698,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host --add-host host.docker.internal:127.0.0.1 --user '"${MCP_GATEWAY_UID}"':'"${MCP_GATEWAY_GID}"' --group-add '"${DOCKER_SOCK_GID}"' -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.3.6'
           
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_002801812340e2ff_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_50929fdc96cc0840_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -757,7 +741,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_002801812340e2ff_EOF
+          GH_AW_MCP_CONFIG_50929fdc96cc0840_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1367,36 +1351,6 @@ jobs:
                 core.setFailed(msg);
               }
             }
-
-  pre_activation:
-    runs-on: ubuntu-slim
-    outputs:
-      activated: ${{ steps.check_membership.outputs.is_team_member == 'true' }}
-      matched_command: ''
-      setup-trace-id: ${{ steps.setup.outputs.trace-id }}
-    steps:
-      - name: Setup Scripts
-        id: setup
-        uses: github/gh-aw-actions/setup@bc56a0cad2f450c562810785ef38649c04db812a # v0.72.1
-        with:
-          destination: ${{ runner.temp }}/gh-aw/actions
-          job-name: ${{ github.job }}
-        env:
-          GH_AW_SETUP_WORKFLOW_NAME: "Sailfin Issue Triage"
-          GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/issue-triage.lock.yml@${{ github.ref }}
-          GH_AW_INFO_VERSION: "2.1.126"
-      - name: Check team membership for workflow
-        id: check_membership
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        env:
-          GH_AW_REQUIRED_ROLES: "admin,maintainer,write"
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
-            setupGlobals(core, github, context, exec, io, getOctokit);
-            const { main } = require('${{ runner.temp }}/gh-aw/actions/check_membership.cjs');
-            await main();
 
   safe_outputs:
     needs:

--- a/.github/workflows/issue-triage.md
+++ b/.github/workflows/issue-triage.md
@@ -5,9 +5,12 @@ description: |
   initial analysis notes. Routes feature requests to architect review and
   fast-tracks bugs to engineering.
 
+# DISABLED 2026-05-08: gh-aw workflows are paused due to runaway cost.
+# Manual dispatch only — no event triggers. Re-enable by restoring the
+# original `issues: [opened, reopened]` trigger and recompiling the lock
+# file with `gh aw compile`.
 on:
-  issues:
-    types: [opened, reopened]
+  workflow_dispatch:
 
 imports:
   - shared/build-mcp-server.md

--- a/.github/workflows/nightly-grooming.lock.yml
+++ b/.github/workflows/nightly-grooming.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"c9d17730e4afe4d8e4e3d3cc674eb984da2124c98c8b879d54c8f6972b66ee80","compiler_version":"v0.72.1","strict":true,"agent_id":"claude","agent_model":"claude-haiku-4-5"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"220dedc13bbdefea0cd585be638d7dc3be6ad595ed4b9285612ec5caa00e9740","compiler_version":"v0.72.1","strict":true,"agent_id":"claude","agent_model":"claude-haiku-4-5"}
 # gh-aw-manifest: {"version":1,"secrets":["ANTHROPIC_API_KEY","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"34e114876b0b11c390a56381ad16ebd13914f8d5","version":"v4"},{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/setup-node","sha":"49933ea5288caeca8642d1e84afbd3f7d6820020","version":"v4"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"bc56a0cad2f450c562810785ef38649c04db812a","version":"v0.72.1"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.41"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.41"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.41"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -60,9 +60,6 @@
 
 name: "Sailfin Nightly Grooming"
 "on":
-  schedule:
-  - cron: "9 5 * * *"
-    # Friendly format: daily (scattered)
   workflow_dispatch:
     inputs:
       aw_context:
@@ -195,20 +192,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_5a798bb9d3862ae4_EOF'
+          cat << 'GH_AW_PROMPT_7ab1cf9642317f96_EOF'
           <system>
-          GH_AW_PROMPT_5a798bb9d3862ae4_EOF
+          GH_AW_PROMPT_7ab1cf9642317f96_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_5a798bb9d3862ae4_EOF'
+          cat << 'GH_AW_PROMPT_7ab1cf9642317f96_EOF'
           <safe-output-tools>
           Tools: add_comment, create_issue, add_labels(max:3), missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_5a798bb9d3862ae4_EOF
+          GH_AW_PROMPT_7ab1cf9642317f96_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_5a798bb9d3862ae4_EOF'
+          cat << 'GH_AW_PROMPT_7ab1cf9642317f96_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if __GH_AW_GITHUB_ACTOR__ }}
@@ -237,13 +234,13 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_5a798bb9d3862ae4_EOF
+          GH_AW_PROMPT_7ab1cf9642317f96_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_5a798bb9d3862ae4_EOF'
+          cat << 'GH_AW_PROMPT_7ab1cf9642317f96_EOF'
           </system>
           {{#runtime-import .github/workflows/shared/build-mcp-server.md}}
           {{#runtime-import .github/workflows/nightly-grooming.md}}
-          GH_AW_PROMPT_5a798bb9d3862ae4_EOF
+          GH_AW_PROMPT_7ab1cf9642317f96_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -325,8 +322,6 @@ jobs:
       contents: read
       issues: read
       pull-requests: read
-    concurrency:
-      group: "gh-aw-claude-${{ github.workflow }}"
     env:
       DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
       GH_AW_ASSETS_ALLOWED_EXTS: ""
@@ -443,9 +438,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_12bdda91a2d219fd_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_491246350b1fddca_EOF'
           {"add_comment":{"max":1},"add_labels":{"max":3},"create_issue":{"max":1},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_12bdda91a2d219fd_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_491246350b1fddca_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -685,7 +680,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host --add-host host.docker.internal:127.0.0.1 --user '"${MCP_GATEWAY_UID}"':'"${MCP_GATEWAY_GID}"' --group-add '"${DOCKER_SOCK_GID}"' -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.3.6'
           
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_a27b449b824ae522_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_6e46251853f990f6_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -728,7 +723,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_a27b449b824ae522_EOF
+          GH_AW_MCP_CONFIG_6e46251853f990f6_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true

--- a/.github/workflows/nightly-grooming.md
+++ b/.github/workflows/nightly-grooming.md
@@ -8,8 +8,11 @@ description: |
   autonomously from a hardcoded priority list. Grooming produces issues only.
   Engineering never runs without an architect-approved, focus-referenced issue.
 
+# DISABLED 2026-05-08: gh-aw workflows are paused due to runaway cost.
+# Manual dispatch only — no scheduled runs. Re-enable by restoring the
+# original `on:` triggers (`schedule: daily` + `workflow_dispatch:`) and
+# recompiling the lock file with `gh aw compile`.
 on:
-  schedule: daily
   workflow_dispatch:
 
 imports:

--- a/.github/workflows/planner.lock.yml
+++ b/.github/workflows/planner.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"d90d857923ada66e1f289cdff7d76a72e83aeda0b9312c9d04fb9c4063d854fb","compiler_version":"v0.72.1","strict":true,"agent_id":"claude","agent_model":"claude-opus-4-7"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"6761687df1f3062a926ca5d35a8ec3fadf246d527d00f8b77284ac3d8bd0c161","compiler_version":"v0.72.1","strict":true,"agent_id":"claude","agent_model":"claude-opus-4-7"}
 # gh-aw-manifest: {"version":1,"secrets":["ANTHROPIC_API_KEY","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"34e114876b0b11c390a56381ad16ebd13914f8d5","version":"v4"},{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/setup-node","sha":"49933ea5288caeca8642d1e84afbd3f7d6820020","version":"v4"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"bc56a0cad2f450c562810785ef38649c04db812a","version":"v0.72.1"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.41"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.41"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.41"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -61,9 +61,6 @@
 
 name: "Sailfin Planner"
 "on":
-  schedule:
-  - cron: "52 3 * * 1"
-    # Friendly format: weekly on monday (scattered)
   workflow_dispatch:
     inputs:
       aw_context:
@@ -197,21 +194,21 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_984f28936eb4eadc_EOF'
+          cat << 'GH_AW_PROMPT_65b26cdf763e5cbc_EOF'
           <system>
-          GH_AW_PROMPT_984f28936eb4eadc_EOF
+          GH_AW_PROMPT_65b26cdf763e5cbc_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/repo_memory_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_984f28936eb4eadc_EOF'
+          cat << 'GH_AW_PROMPT_65b26cdf763e5cbc_EOF'
           <safe-output-tools>
           Tools: add_comment, create_issue, update_issue, add_labels(max:3), missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_984f28936eb4eadc_EOF
+          GH_AW_PROMPT_65b26cdf763e5cbc_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_984f28936eb4eadc_EOF'
+          cat << 'GH_AW_PROMPT_65b26cdf763e5cbc_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if __GH_AW_GITHUB_ACTOR__ }}
@@ -240,13 +237,13 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_984f28936eb4eadc_EOF
+          GH_AW_PROMPT_65b26cdf763e5cbc_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_984f28936eb4eadc_EOF'
+          cat << 'GH_AW_PROMPT_65b26cdf763e5cbc_EOF'
           </system>
           {{#runtime-import .github/workflows/shared/build-mcp-server.md}}
           {{#runtime-import .github/workflows/planner.md}}
-          GH_AW_PROMPT_984f28936eb4eadc_EOF
+          GH_AW_PROMPT_65b26cdf763e5cbc_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -340,8 +337,6 @@ jobs:
       contents: read
       issues: read
       pull-requests: read
-    concurrency:
-      group: "gh-aw-claude-${{ github.workflow }}"
     env:
       DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
       GH_AW_ASSETS_ALLOWED_EXTS: ""
@@ -468,9 +463,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_e68a1fb66c2f30e2_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_d4ae4c002a9a86f6_EOF'
           {"add_comment":{"max":1},"add_labels":{"max":3},"create_issue":{"max":1},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"push_repo_memory":{"memories":[{"dir":"/tmp/gh-aw/repo-memory/default","id":"default","max_file_count":100,"max_file_size":10240,"max_patch_size":10240}]},"report_incomplete":{},"update_issue":{"allow_body":true,"max":1}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_e68a1fb66c2f30e2_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_d4ae4c002a9a86f6_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -765,7 +760,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host --add-host host.docker.internal:127.0.0.1 --user '"${MCP_GATEWAY_UID}"':'"${MCP_GATEWAY_GID}"' --group-add '"${DOCKER_SOCK_GID}"' -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.3.6'
           
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_cab0669728892fd3_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_b3e5b1abe7119989_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -808,7 +803,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_cab0669728892fd3_EOF
+          GH_AW_MCP_CONFIG_b3e5b1abe7119989_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true

--- a/.github/workflows/planner.md
+++ b/.github/workflows/planner.md
@@ -9,8 +9,11 @@ description: |
   human must apply the `focus:approved` label before grooming and engineering
   will act on the focus.
 
+# DISABLED 2026-05-08: gh-aw workflows are paused due to runaway cost.
+# Manual dispatch only — no scheduled runs. Re-enable by restoring the
+# original `on:` triggers (`schedule: weekly on monday` + `workflow_dispatch:`)
+# and recompiling the lock file with `gh aw compile`.
 on:
-  schedule: weekly on monday
   workflow_dispatch:
 
 imports:

--- a/.github/workflows/release-notes.lock.yml
+++ b/.github/workflows/release-notes.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"813e8bb2be734c6c841a4280b1f5377c3c3cb08429e9137980ac34948245b678","compiler_version":"v0.72.1","strict":true,"agent_id":"claude","agent_model":"claude-haiku-4-5"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"5712f722952c21229de70bbfa735962f08a391348dcd3b6d512c55d77521954a","compiler_version":"v0.72.1","strict":true,"agent_id":"claude","agent_model":"claude-haiku-4-5"}
 # gh-aw-manifest: {"version":1,"secrets":["ANTHROPIC_API_KEY","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"34e114876b0b11c390a56381ad16ebd13914f8d5","version":"v4"},{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/setup-node","sha":"49933ea5288caeca8642d1e84afbd3f7d6820020","version":"v4"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"bc56a0cad2f450c562810785ef38649c04db812a","version":"v0.72.1"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.41"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.41"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.41"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -56,9 +56,13 @@
 
 name: "Sailfin Release Notes Generator"
 "on":
-  release:
-    types:
-    - published
+  workflow_dispatch:
+    inputs:
+      aw_context:
+        default: ""
+        description: Agent caller context (used internally by Agentic Workflows).
+        required: false
+        type: string
 
 permissions: {}
 
@@ -70,8 +74,6 @@ run-name: "Sailfin Release Notes Generator"
 
 jobs:
   activation:
-    needs: pre_activation
-    if: needs.pre_activation.outputs.activated == 'true'
     runs-on: ubuntu-slim
     permissions:
       actions: read
@@ -92,7 +94,6 @@ jobs:
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}
-          trace-id: ${{ needs.pre_activation.outputs.setup-trace-id }}
         env:
           GH_AW_SETUP_WORKFLOW_NAME: "Sailfin Release Notes Generator"
           GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/release-notes.lock.yml@${{ github.ref }}
@@ -188,20 +189,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_cb079eac1a3c18cf_EOF'
+          cat << 'GH_AW_PROMPT_371fe36c631470df_EOF'
           <system>
-          GH_AW_PROMPT_cb079eac1a3c18cf_EOF
+          GH_AW_PROMPT_371fe36c631470df_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_cb079eac1a3c18cf_EOF'
+          cat << 'GH_AW_PROMPT_371fe36c631470df_EOF'
           <safe-output-tools>
           Tools: add_comment, missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_cb079eac1a3c18cf_EOF
+          GH_AW_PROMPT_371fe36c631470df_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_cb079eac1a3c18cf_EOF'
+          cat << 'GH_AW_PROMPT_371fe36c631470df_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if __GH_AW_GITHUB_ACTOR__ }}
@@ -230,13 +231,13 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_cb079eac1a3c18cf_EOF
+          GH_AW_PROMPT_371fe36c631470df_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_cb079eac1a3c18cf_EOF'
+          cat << 'GH_AW_PROMPT_371fe36c631470df_EOF'
           </system>
           {{#runtime-import .github/workflows/shared/build-mcp-server.md}}
           {{#runtime-import .github/workflows/release-notes.md}}
-          GH_AW_PROMPT_cb079eac1a3c18cf_EOF
+          GH_AW_PROMPT_371fe36c631470df_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -264,7 +265,6 @@ jobs:
           GH_AW_GITHUB_RUN_ID: ${{ github.run_id }}
           GH_AW_GITHUB_WORKSPACE: ${{ github.workspace }}
           GH_AW_MCP_CLI_SERVERS_LIST: '- `safeoutputs` — run `safeoutputs --help` to see available tools'
-          GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED: ${{ needs.pre_activation.outputs.activated }}
         with:
           script: |
             const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
@@ -285,8 +285,7 @@ jobs:
                 GH_AW_GITHUB_REPOSITORY: process.env.GH_AW_GITHUB_REPOSITORY,
                 GH_AW_GITHUB_RUN_ID: process.env.GH_AW_GITHUB_RUN_ID,
                 GH_AW_GITHUB_WORKSPACE: process.env.GH_AW_GITHUB_WORKSPACE,
-                GH_AW_MCP_CLI_SERVERS_LIST: process.env.GH_AW_MCP_CLI_SERVERS_LIST,
-                GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED: process.env.GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED
+                GH_AW_MCP_CLI_SERVERS_LIST: process.env.GH_AW_MCP_CLI_SERVERS_LIST
               }
             });
       - name: Validate prompt placeholders
@@ -323,8 +322,6 @@ jobs:
       contents: read
       issues: read
       pull-requests: read
-    concurrency:
-      group: "gh-aw-claude-${{ github.workflow }}"
     env:
       DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
       GH_AW_ASSETS_ALLOWED_EXTS: ""
@@ -441,9 +438,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_0bc412892aa0e2cf_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_d6c905cb789ed696_EOF'
           {"add_comment":{"max":1},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_0bc412892aa0e2cf_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_d6c905cb789ed696_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -629,7 +626,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host --add-host host.docker.internal:127.0.0.1 --user '"${MCP_GATEWAY_UID}"':'"${MCP_GATEWAY_GID}"' --group-add '"${DOCKER_SOCK_GID}"' -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.3.6'
           
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_5a87634cc0f05f00_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_7e693fc8b79047d9_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -672,7 +669,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_5a87634cc0f05f00_EOF
+          GH_AW_MCP_CONFIG_7e693fc8b79047d9_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1282,36 +1279,6 @@ jobs:
                 core.setFailed(msg);
               }
             }
-
-  pre_activation:
-    runs-on: ubuntu-slim
-    outputs:
-      activated: ${{ steps.check_membership.outputs.is_team_member == 'true' }}
-      matched_command: ''
-      setup-trace-id: ${{ steps.setup.outputs.trace-id }}
-    steps:
-      - name: Setup Scripts
-        id: setup
-        uses: github/gh-aw-actions/setup@bc56a0cad2f450c562810785ef38649c04db812a # v0.72.1
-        with:
-          destination: ${{ runner.temp }}/gh-aw/actions
-          job-name: ${{ github.job }}
-        env:
-          GH_AW_SETUP_WORKFLOW_NAME: "Sailfin Release Notes Generator"
-          GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/release-notes.lock.yml@${{ github.ref }}
-          GH_AW_INFO_VERSION: "2.1.126"
-      - name: Check team membership for workflow
-        id: check_membership
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        env:
-          GH_AW_REQUIRED_ROLES: "admin,maintainer,write"
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
-            setupGlobals(core, github, context, exec, io, getOctokit);
-            const { main } = require('${{ runner.temp }}/gh-aw/actions/check_membership.cjs');
-            await main();
 
   safe_outputs:
     needs:

--- a/.github/workflows/release-notes.md
+++ b/.github/workflows/release-notes.md
@@ -4,9 +4,12 @@ description: |
   published.  Analyzes all commits since the previous tag and posts a
   structured changelog as a comment on the release.
 
+# DISABLED 2026-05-08: gh-aw workflows are paused due to runaway cost.
+# Manual dispatch only — no event triggers. Re-enable by restoring the
+# original `release: [published]` trigger and recompiling the lock file
+# with `gh aw compile`.
 on:
-  release:
-    types: [published]
+  workflow_dispatch:
 
 imports:
   - shared/build-mcp-server.md

--- a/site/src/pages/roadmap.astro
+++ b/site/src/pages/roadmap.astro
@@ -6,140 +6,128 @@ type Status = "done" | "in-progress" | "planned";
 interface RoadmapItem {
   label: string;
   status: Status;
+  url?: string;
 }
 
 interface RoadmapCategory {
   title: string;
   description?: string;
   items: RoadmapItem[];
+  url?: string;
+  open?: number;
+  closed?: number;
 }
 
-const v1Categories: RoadmapCategory[] = [
-  {
-    title: "Phase 1: Runtime Enablement — Systems Primitives",
-    description: "Language features that unblock the pure Sailfin runtime rewrite. Nothing in the runtime can be ported without these.",
-    items: [
-      { label: "extern fn with typed linker-resolved symbols (parser ✓, type-checker registration ✓ with E0801–E0805 C-ABI validation, native-IR emitter ✓, LLVM declare lowering ✓; cross-module call-site resolution deferred to the follow-up call-resolver workstream)", status: "done" },
-      { label: "int (i64) and float (f64) numeric types — Slices A + B + C shipped: annotated locals/params/returns lower correctly, extern accept-list admits int/float plus i16/u16/u32/u64/isize/f32, arithmetic/comparison dispatch verified, and bitwise/shift operators (& | ^ << >>) lower to LLVM and/or/xor/shl/ashr. Slices D (as casts + tighten dominant_type) and E (bare-literal defaulting + number retirement) tracked in docs/runtime_architecture.md §3.7", status: "in-progress" },
-      { label: "Raw pointer types (*T, *const T, *mut T) — enforced, not just parsed", status: "planned" },
-      { label: "Result<T, E> type and ? error propagation operator", status: "planned" },
-      { label: "Bitwise operators on integer types (&, |, ^, >>, <<) — shipped 2026-05-02 as numeric Slice B; lex/parse/lower to LLVM and/or/xor/shl/ashr i64", status: "done" },
-      { label: "${} string interpolation replacing {{ }}", status: "planned" },
-    ],
-  },
-  {
-    title: "Phase 2: Runtime Enablement — Containers & Resources",
-    description: "Higher-level features needed to express typed containers, resource handles, and higher-order operations in the runtime.",
-    items: [
-      { label: "Closures with captured variables (not just non-capturing lambdas)", status: "planned" },
-      { label: "Generic type constraints (fn sort<T: Comparable>(arr: Array<T>))", status: "planned" },
-      { label: "Deterministic drop emission — compiler emits scope-exit drop calls for owned values", status: "planned" },
-      { label: "Complete generic type inference", status: "planned" },
-      { label: "Interface conformance validation with variance checks", status: "planned" },
-    ],
-  },
-  {
-    title: "Phase 3: Sailfin-Native Runtime",
-    description: "Replace the C runtime with pure Sailfin. Depends on Phase 1 and 2 compiler features being shipped.",
-    items: [
-      { label: "Core memory management — arena allocator, string/array allocation in Sailfin", status: "planned" },
-      { label: "String subsystem — {ptr, len, cap} layout, concat, append, substring, grapheme ops", status: "planned" },
-      { label: "Array/collection subsystem — typed Array<T>, Slice<T>, push, concat, map/filter/reduce", status: "planned" },
-      { label: "File I/O subsystem — fs.read, fs.write, fs.exists, directory ops via extern fn", status: "planned" },
-      { label: "Process execution — posix_spawnp/CreateProcessA via extern fn", status: "planned" },
-      { label: "Exception subsystem — replace TLS-flag polling or migrate to Result<T, E> internally", status: "planned" },
-      { label: "Time/clock subsystem — clock_gettime/mach_absolute_time via extern fn", status: "planned" },
-      { label: "Crypto subsystem — SHA-256, Base64 in pure Sailfin (bitwise int ops)", status: "planned" },
-      { label: "Native CLI driver — replace native_driver.c with Sailfin entry point", status: "planned" },
-      { label: "Remove the C runtime once parity and performance gates are met", status: "planned" },
-    ],
-  },
-  {
-    title: "Phase 4: Structured Concurrency",
-    description: "Concurrency primitives with capability tracking. Requires Phase 1-2 features plus atomic intrinsics.",
-    items: [
-      { label: "Atomic intrinsics (atomic_add, atomic_cas, memory fences)", status: "planned" },
-      { label: "await expression parsing and lowering", status: "planned" },
-      { label: "routine { } block parsing and lowering", status: "planned" },
-      { label: "channel() as the core concurrency primitive", status: "planned" },
-      { label: "spawn expression", status: "planned" },
-      { label: "Runtime task scheduler and work queue", status: "planned" },
-    ],
-  },
-  {
-    title: "Effect System Hardening",
-    description: "Make the effect system world-class — Sailfin's core differentiator. Can progress in parallel with runtime work.",
-    items: [
-      { label: "Wire effect checker into compilation gate — violations block compilation, not just diagnostics", status: "planned" },
-      { label: "Hierarchical effect enforcement (io.fs, net.http, etc.)", status: "planned" },
-      { label: "Effect polymorphism for generics (fn map<T, E>(f: Fn ![E]) ![E])", status: "planned" },
-      { label: "Transitive call-graph enforcement (if A calls B ![net], A needs ![net])", status: "planned" },
-      { label: "--fix workflow for automatically inserting missing effect annotations", status: "planned" },
-      { label: "gpu and rand effect enforcement", status: "planned" },
-      { label: "Capsule-level capability enforcement via capsule.toml", status: "planned" },
-    ],
-  },
-  {
-    title: "Compiler Stabilization",
-    description: "Build pipeline and LLVM backend correctness.",
-    items: [
-      { label: "Eliminate the Python fixup script", status: "done" },
-      { label: "Make build.sh the sole clean build path with no post-processing", status: "done" },
-      { label: "Pass make check with no fallbacks", status: "done" },
-      { label: "Deterministic self-hosting — stage2 == stage3 fixed-point verified", status: "done" },
-      { label: "Stabilize control-flow LLVM lowering (loop/if/break headers)", status: "planned" },
-      { label: "Richer diagnostics Phase 1 — severity, file_path, structured load warnings (W01xx)", status: "done" },
-      { label: "Richer diagnostics Phase 2 — multi-span, fix-it hints, source-location labels", status: "planned" },
-    ],
-  },
-  {
-    title: "Tooling & Developer Workflow",
-    description: "CLI tools and build toolchain modernization.",
-    items: [
-      { label: "sfn fmt — code formatter (token-stream, one style, CI-enforced)", status: "done" },
-      { label: "sfn check — fast type and effect analysis", status: "done" },
-      { label: "Unified capsule resolver across sfn build / sfn run / sfn check / sfn test (Stage B PR1+PR2 — textual import inliner deleted)", status: "done" },
-      { label: "Retired llvm-objcopy --weaken in sfn test (Stage B PR3 — path-norm fix; libextract reframed as Stage G)", status: "done" },
-      { label: "Content-addressed build cache for sfn build / sfn run (Stage C PR1–PR1f — content keying + per-source dep manifests + --no-cache/--clean/--cache-trace flags + sfn build --json schema-versioned report)", status: "done" },
-      { label: "Standard per-capsule artifact layout (Stage C2 — build/capsules/<scope>/<name>/{manifest.json, ir/, obj/, bin/})", status: "in-progress" },
-      { label: "sfn package replaces tools/package.sh (Stage C4)", status: "planned" },
-      { label: "sfn bench + sfn bootstrap replace shell scripts (Stage C5)", status: "planned" },
-      { label: "sfn vet — static analyzer", status: "planned" },
-      { label: "sfn audit — dependency capability surface analysis", status: "planned" },
-      { label: "Replace the sfn shell wrapper with a Sailfin-native CLI binary", status: "planned" },
-      { label: "Remove Python tooling and scripts from the release pipeline", status: "planned" },
-      { label: "Remove Python runtime shims", status: "done" },
-    ],
-  },
-  {
-    title: "LLM & Agent Adoption",
-    description: "Make Sailfin the language agents reach for when they need verifiable code. Structured tooling and training-data presence.",
-    items: [
-      { label: "llms.txt — canonical single-file language reference for LLM context windows", status: "in-progress" },
-      { label: "Structured diagnostics (sfn check --json) — machine-readable error output", status: "planned" },
-      { label: "MCP server wrapping the compiler for agentic compile-check-fix loops", status: "planned" },
-      { label: "50+ Rosetta Code / classic algorithm ports as training-data corpus", status: "planned" },
-    ],
-  },
-  {
-    title: "Release Pipeline Hardening",
-    description: "Supply-chain security and reproducible builds.",
-    items: [
-      { label: "Signed checksums and provenance metadata with release artifacts", status: "planned" },
-      { label: "Installer CI that validates install.sh against staging artifacts", status: "planned" },
-      { label: "Only self-hosted compiler artifacts in build and release workflows", status: "planned" },
-    ],
-  },
-  {
-    title: "Documentation",
-    description: "Docs, spec, and examples aligned with compiler reality.",
-    items: [
-      { label: "Align README, status, roadmap, and spec with compiler reality", status: "done" },
-      { label: "Expand site docs to production-quality coverage", status: "in-progress" },
-      { label: "Remove legacy compiler-stage references from docs and examples", status: "planned" },
-    ],
-  },
+// GitHub API types
+interface ApiMilestone {
+  number: number;
+  title: string;
+  description: string | null;
+  open_issues: number;
+  closed_issues: number;
+  state: "open" | "closed";
+  html_url: string;
+  updated_at: string;
+}
+
+interface ApiIssue {
+  number: number;
+  title: string;
+  state: "open" | "closed";
+  labels: { name: string }[];
+  html_url: string;
+  pull_request?: unknown;
+}
+
+const REPO = "SailfinIO/sailfin";
+// Logical roadmap order (milestone numbers). Anything not in this list is appended.
+const DISPLAY_ORDER: number[] = [8, 7, 10, 6];
+
+const ghHeaders: Record<string, string> = {
+  "User-Agent": "sailfin-roadmap-builder",
+  Accept: "application/vnd.github+json",
+};
+if (import.meta.env.GITHUB_TOKEN) {
+  ghHeaders.Authorization = `Bearer ${import.meta.env.GITHUB_TOKEN}`;
+}
+
+async function fetchMilestones(): Promise<ApiMilestone[]> {
+  try {
+    const res = await fetch(
+      `https://api.github.com/repos/${REPO}/milestones?state=open&per_page=100`,
+      { headers: ghHeaders },
+    );
+    if (!res.ok) throw new Error(`GitHub API ${res.status}: ${res.statusText}`);
+    return (await res.json()) as ApiMilestone[];
+  } catch (err) {
+    console.warn("[roadmap] milestone fetch failed:", err);
+    return [];
+  }
+}
+
+async function fetchEpicsForMilestone(milestoneNumber: number): Promise<ApiIssue[]> {
+  try {
+    const res = await fetch(
+      `https://api.github.com/repos/${REPO}/issues?milestone=${milestoneNumber}&labels=epic&state=all&per_page=100`,
+      { headers: ghHeaders },
+    );
+    if (!res.ok) throw new Error(`GitHub API ${res.status}: ${res.statusText}`);
+    const data = (await res.json()) as ApiIssue[];
+    return data.filter((i) => !i.pull_request);
+  } catch (err) {
+    console.warn(`[roadmap] epic fetch failed for milestone ${milestoneNumber}:`, err);
+    return [];
+  }
+}
+
+function epicStatus(issue: ApiIssue): Status {
+  if (issue.state === "closed") return "done";
+  if (issue.labels.some((l) => l.name === "in-progress")) return "in-progress";
+  return "planned";
+}
+
+function cleanEpicTitle(title: string): string {
+  return title.replace(/^Epic:\s*/i, "");
+}
+
+const apiMilestones = await fetchMilestones();
+const apiAvailable = apiMilestones.length > 0;
+
+// Order: explicit DISPLAY_ORDER first, then any remaining milestones by number.
+const ordered: ApiMilestone[] = [
+  ...DISPLAY_ORDER
+    .map((n) => apiMilestones.find((m) => m.number === n))
+    .filter((m): m is ApiMilestone => Boolean(m)),
+  ...apiMilestones
+    .filter((m) => !DISPLAY_ORDER.includes(m.number))
+    .sort((a, b) => a.number - b.number),
 ];
+
+const epicsByMilestone = await Promise.all(
+  ordered.map((m) => fetchEpicsForMilestone(m.number)),
+);
+
+const v1Categories: RoadmapCategory[] = ordered.map((m, idx) => {
+  const epics = epicsByMilestone[idx] ?? [];
+  const items: RoadmapItem[] = epics.map((e) => ({
+    label: cleanEpicTitle(e.title),
+    status: epicStatus(e),
+    url: e.html_url,
+  }));
+  return {
+    title: m.title,
+    description: m.description ?? undefined,
+    items,
+    url: m.html_url,
+    open: m.open_issues,
+    closed: m.closed_issues,
+  };
+});
+
+// Aggregate progress across all v1 milestones (issue-level, not milestone-level).
+const v1IssuesOpen = v1Categories.reduce((s, c) => s + (c.open ?? 0), 0);
+const v1IssuesClosed = v1Categories.reduce((s, c) => s + (c.closed ?? 0), 0);
+const v1IssuesTotal = v1IssuesOpen + v1IssuesClosed;
 
 const postV1Ai: RoadmapCategory = {
   title: "Enterprise Hardening & AI Integration",
@@ -167,32 +155,32 @@ const postV1Platform: RoadmapCategory = {
 };
 
 const exploration: RoadmapItem[] = [
+  { label: "Structured concurrency — atomics, await, routine, channel, spawn, scheduler", status: "planned" },
+  { label: "Effect system hardening — wire validate_effects() into compilation gate, hierarchical effects, polymorphism", status: "planned" },
+  { label: "Phase 2 containers — closures with capture, generic constraints, drop emission", status: "planned" },
+  { label: "Documentation expansion — production-quality site coverage, remove legacy stage references", status: "planned" },
+  { label: "LLM adoption levers — llms.txt, sfn check --json, MCP server, Rosetta Code corpus", status: "planned" },
+  { label: "Release pipeline hardening — signed checksums, installer CI, self-hosted-only artifacts", status: "planned" },
   { label: "unsafe capability enforcement", status: "planned" },
   { label: "Currency literals ($0.05) and time literals (1s, 150ms)", status: "planned" },
   { label: "Notebook and interactive tooling", status: "planned" },
   { label: "Effect handlers (algebraic effect semantics)", status: "planned" },
-  { label: "Capability-scoped sandboxing for capsule execution", status: "planned" },
 ];
-
-// Helpers
-function countByStatus(items: RoadmapItem[]) {
-  const done = items.filter(i => i.status === "done").length;
-  const inProgress = items.filter(i => i.status === "in-progress").length;
-  const planned = items.filter(i => i.status === "planned").length;
-  return { done, inProgress, planned, total: items.length };
-}
 
 function percent(done: number, total: number) {
   return total === 0 ? 0 : Math.round((done / total) * 100);
 }
 
-// Aggregate 1.0 stats
-const allV1Items = v1Categories.flatMap(c => c.items);
-const v1Stats = countByStatus(allV1Items);
-const v1Percent = percent(v1Stats.done, v1Stats.total);
+const v1Percent = percent(v1IssuesClosed, v1IssuesTotal);
 
 const statusLabel = (s: Status) =>
   s === "done" ? "Done" : s === "in-progress" ? "In progress" : "Planned";
+
+const lastUpdated = new Date().toLocaleDateString("en-US", {
+  year: "numeric",
+  month: "long",
+  day: "numeric",
+});
 ---
 
 <BaseLayout title="Roadmap" description="Sailfin's development roadmap toward 1.0 and beyond.">
@@ -206,7 +194,7 @@ const statusLabel = (s: Status) =>
           Sailfin's path from alpha to a stable 1.0 release and beyond.
         </p>
         <p class="meta">
-          Last updated April 16, 2026
+          Live data from <a href={`https://github.com/${REPO}/milestones`}>GitHub milestones</a>. Built {lastUpdated}.
         </p>
       </header>
 
@@ -217,45 +205,79 @@ const statusLabel = (s: Status) =>
         <span class="legend-item"><span class="status-dot planned" aria-hidden="true"></span> Planned</span>
       </div>
 
+      {!apiAvailable && (
+        <div class="api-warning">
+          Could not load milestone data from GitHub at build time. View the live state directly on
+          <a href={`https://github.com/${REPO}/milestones`}>GitHub milestones</a>.
+        </div>
+      )}
+
       <!-- 1.0 Overview -->
-      <section class="v1-overview">
-        <div class="v1-overview-header">
-          <h2>Release 1.0</h2>
-          <span class="v1-stat">{v1Stats.done} of {v1Stats.total} milestones complete</span>
-        </div>
-        <div class="progress-bar-track" role="progressbar" aria-valuenow={v1Stats.done} aria-valuemin={0} aria-valuemax={v1Stats.total} aria-label={`Release 1.0 progress: ${v1Stats.done} of ${v1Stats.total} milestones complete`}>
-          <div class="progress-bar-fill" style={`width: ${v1Percent}%`}></div>
-        </div>
-      </section>
+      {apiAvailable && (
+        <section class="v1-overview">
+          <div class="v1-overview-header">
+            <h2>Release 1.0</h2>
+            <span class="v1-stat">{v1IssuesClosed} of {v1IssuesTotal} issues closed across {v1Categories.length} milestones</span>
+          </div>
+          <div
+            class="progress-bar-track"
+            role="progressbar"
+            aria-valuenow={v1IssuesClosed}
+            aria-valuemin={0}
+            aria-valuemax={v1IssuesTotal}
+            aria-label={`Release 1.0 progress: ${v1IssuesClosed} of ${v1IssuesTotal} issues closed`}
+          >
+            <div class="progress-bar-fill" style={`width: ${v1Percent}%`}></div>
+          </div>
+        </section>
+      )}
 
       <!-- 1.0 Categories -->
       <div class="categories">
         {v1Categories.map((cat) => {
-          const stats = countByStatus(cat.items);
-          const pct = percent(stats.done, stats.total);
+          const total = (cat.open ?? 0) + (cat.closed ?? 0);
+          const closed = cat.closed ?? 0;
+          const pct = percent(closed, total);
           return (
             <section class="category-card">
               <div class="category-header">
                 <div>
-                  <h3>{cat.title}</h3>
+                  <h3>
+                    {cat.url ? <a href={cat.url} class="category-link">{cat.title}</a> : cat.title}
+                  </h3>
                   {cat.description && <p class="category-desc">{cat.description}</p>}
                 </div>
-                <span class="category-count">{stats.done}/{stats.total}</span>
+                <span class="category-count">{closed}/{total}</span>
               </div>
-              <div class="progress-bar-track small" role="progressbar" aria-valuenow={stats.done} aria-valuemin={0} aria-valuemax={stats.total} aria-label={`${cat.title} progress: ${stats.done} of ${stats.total} complete`}>
+              <div
+                class="progress-bar-track small"
+                role="progressbar"
+                aria-valuenow={closed}
+                aria-valuemin={0}
+                aria-valuemax={total}
+                aria-label={`${cat.title} progress: ${closed} of ${total} issues closed`}
+              >
                 <div
                   class:list={["progress-bar-fill", { empty: pct === 0 }]}
                   style={`width: ${Math.max(pct, 0)}%`}
                 ></div>
               </div>
-              <ul class="item-list">
-                {cat.items.map((item) => (
-                  <li class:list={["item", item.status]}>
-                    <span class={`status-dot ${item.status}`} aria-label={statusLabel(item.status)}></span>
-                    <span class="item-label">{item.label}</span>
-                  </li>
-                ))}
-              </ul>
+              {cat.items.length > 0 ? (
+                <ul class="item-list">
+                  {cat.items.map((item) => (
+                    <li class:list={["item", item.status]}>
+                      <span class={`status-dot ${item.status}`} aria-label={statusLabel(item.status)}></span>
+                      {item.url
+                        ? <a class="item-label item-link" href={item.url}>{item.label}</a>
+                        : <span class="item-label">{item.label}</span>}
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <p class="empty-note">
+                  No epics yet. {cat.url && <a href={cat.url}>View milestone on GitHub</a>}
+                </p>
+              )}
             </section>
           );
         })}
@@ -291,8 +313,10 @@ const statusLabel = (s: Status) =>
 
       <!-- Exploration Backlog -->
       <section class="exploration">
-        <h2>Exploration Backlog</h2>
-        <p class="section-desc">Under consideration with no committed milestone.</p>
+        <h2>Backlog & Exploration</h2>
+        <p class="section-desc">
+          Workstreams without architected GitHub milestones yet. Some will graduate into milestones once design work lands; others stay exploratory.
+        </p>
         <ul class="item-list exploration-list">
           {exploration.map((item) => (
             <li class:list={["item", item.status]}>
@@ -312,7 +336,7 @@ const statusLabel = (s: Status) =>
           or ABI should reference a written proposal in <code>docs/proposals/</code> before implementation begins.
         </p>
         <div class="contribute-actions">
-          <a href="https://github.com/SailfinIO/sailfin/issues" class="btn btn-primary">Open an Issue</a>
+          <a href={`https://github.com/${REPO}/issues`} class="btn btn-primary">Open an Issue</a>
           <a href="/docs/contributing/guide" class="btn btn-secondary">Contributor Guide</a>
         </div>
       </section>
@@ -368,6 +392,18 @@ const statusLabel = (s: Status) =>
     gap: 0.4rem;
     font-size: 0.85rem;
     color: var(--color-text-secondary);
+  }
+
+  /* API warning */
+  .api-warning {
+    padding: 0.75rem 1rem;
+    margin-bottom: 1.5rem;
+    border: 1px solid var(--color-border);
+    border-left: 3px solid var(--color-primary);
+    border-radius: 4px;
+    background: var(--color-bg-alt);
+    color: var(--color-text-secondary);
+    font-size: 0.9rem;
   }
 
   /* Status dots */
@@ -475,6 +511,16 @@ const statusLabel = (s: Status) =>
     color: var(--color-text);
   }
 
+  .category-link {
+    color: inherit;
+    text-decoration: none;
+  }
+
+  .category-link:hover {
+    color: var(--color-primary);
+    text-decoration: underline;
+  }
+
   .category-desc {
     font-size: 0.825rem;
     color: var(--color-text-tertiary);
@@ -491,6 +537,13 @@ const statusLabel = (s: Status) =>
     border-radius: 10px;
     white-space: nowrap;
     flex-shrink: 0;
+  }
+
+  .empty-note {
+    font-size: 0.85rem;
+    color: var(--color-text-tertiary);
+    margin: 0;
+    padding: 0.4rem 0;
   }
 
   /* Item lists */
@@ -520,6 +573,16 @@ const statusLabel = (s: Status) =>
 
   .item.planned .item-label {
     color: var(--color-text-secondary);
+  }
+
+  .item-link {
+    color: inherit;
+    text-decoration: none;
+  }
+
+  .item-link:hover {
+    color: var(--color-primary);
+    text-decoration: underline;
   }
 
   /* Post-1.0 */

--- a/site/src/pages/roadmap.astro
+++ b/site/src/pages/roadmap.astro
@@ -16,6 +16,8 @@ interface RoadmapCategory {
   url?: string;
   open?: number;
   closed?: number;
+  epicsLoadFailed?: boolean;
+  state?: "open" | "closed";
 }
 
 // GitHub API types
@@ -54,7 +56,7 @@ if (import.meta.env.GITHUB_TOKEN) {
 async function fetchMilestones(): Promise<ApiMilestone[]> {
   try {
     const res = await fetch(
-      `https://api.github.com/repos/${REPO}/milestones?state=open&per_page=100`,
+      `https://api.github.com/repos/${REPO}/milestones?state=all&per_page=100`,
       { headers: ghHeaders },
     );
     if (!res.ok) throw new Error(`GitHub API ${res.status}: ${res.statusText}`);
@@ -65,7 +67,9 @@ async function fetchMilestones(): Promise<ApiMilestone[]> {
   }
 }
 
-async function fetchEpicsForMilestone(milestoneNumber: number): Promise<ApiIssue[]> {
+// Returns null on fetch failure so the UI can distinguish "no epics yet"
+// from "could not load epics" — empty array is the former.
+async function fetchEpicsForMilestone(milestoneNumber: number): Promise<ApiIssue[] | null> {
   try {
     const res = await fetch(
       `https://api.github.com/repos/${REPO}/issues?milestone=${milestoneNumber}&labels=epic&state=all&per_page=100`,
@@ -76,7 +80,7 @@ async function fetchEpicsForMilestone(milestoneNumber: number): Promise<ApiIssue
     return data.filter((i) => !i.pull_request);
   } catch (err) {
     console.warn(`[roadmap] epic fetch failed for milestone ${milestoneNumber}:`, err);
-    return [];
+    return null;
   }
 }
 
@@ -93,12 +97,18 @@ function cleanEpicTitle(title: string): string {
 const apiMilestones = await fetchMilestones();
 const apiAvailable = apiMilestones.length > 0;
 
+// Hide milestones with no items at all (open_issues + closed_issues == 0).
+// These are usually retired placeholders and contribute no signal.
+const populatedMilestones = apiMilestones.filter(
+  (m) => m.open_issues + m.closed_issues > 0,
+);
+
 // Order: explicit DISPLAY_ORDER first, then any remaining milestones by number.
 const ordered: ApiMilestone[] = [
   ...DISPLAY_ORDER
-    .map((n) => apiMilestones.find((m) => m.number === n))
+    .map((n) => populatedMilestones.find((m) => m.number === n))
     .filter((m): m is ApiMilestone => Boolean(m)),
-  ...apiMilestones
+  ...populatedMilestones
     .filter((m) => !DISPLAY_ORDER.includes(m.number))
     .sort((a, b) => a.number - b.number),
 ];
@@ -108,7 +118,9 @@ const epicsByMilestone = await Promise.all(
 );
 
 const v1Categories: RoadmapCategory[] = ordered.map((m, idx) => {
-  const epics = epicsByMilestone[idx] ?? [];
+  const epicResult = epicsByMilestone[idx];
+  const epicsLoadFailed = epicResult === null;
+  const epics = epicResult ?? [];
   const items: RoadmapItem[] = epics.map((e) => ({
     label: cleanEpicTitle(e.title),
     status: epicStatus(e),
@@ -121,13 +133,17 @@ const v1Categories: RoadmapCategory[] = ordered.map((m, idx) => {
     url: m.html_url,
     open: m.open_issues,
     closed: m.closed_issues,
+    epicsLoadFailed,
+    state: m.state,
   };
 });
 
-// Aggregate progress across all v1 milestones (issue-level, not milestone-level).
-const v1IssuesOpen = v1Categories.reduce((s, c) => s + (c.open ?? 0), 0);
-const v1IssuesClosed = v1Categories.reduce((s, c) => s + (c.closed ?? 0), 0);
-const v1IssuesTotal = v1IssuesOpen + v1IssuesClosed;
+// Aggregate progress across all v1 milestones. Note: open_issues / closed_issues
+// from the milestone API counts both issues *and* PRs attached to the milestone,
+// so the UI labels these as "items" rather than "issues".
+const v1ItemsOpen = v1Categories.reduce((s, c) => s + (c.open ?? 0), 0);
+const v1ItemsClosed = v1Categories.reduce((s, c) => s + (c.closed ?? 0), 0);
+const v1ItemsTotal = v1ItemsOpen + v1ItemsClosed;
 
 const postV1Ai: RoadmapCategory = {
   title: "Enterprise Hardening & AI Integration",
@@ -171,7 +187,7 @@ function percent(done: number, total: number) {
   return total === 0 ? 0 : Math.round((done / total) * 100);
 }
 
-const v1Percent = percent(v1IssuesClosed, v1IssuesTotal);
+const v1Percent = percent(v1ItemsClosed, v1ItemsTotal);
 
 const statusLabel = (s: Status) =>
   s === "done" ? "Done" : s === "in-progress" ? "In progress" : "Planned";
@@ -194,7 +210,7 @@ const lastUpdated = new Date().toLocaleDateString("en-US", {
           Sailfin's path from alpha to a stable 1.0 release and beyond.
         </p>
         <p class="meta">
-          Live data from <a href={`https://github.com/${REPO}/milestones`}>GitHub milestones</a>. Built {lastUpdated}.
+          Built {lastUpdated} from <a href={`https://github.com/${REPO}/milestones`}>GitHub milestones</a> at deploy time.
         </p>
       </header>
 
@@ -217,15 +233,15 @@ const lastUpdated = new Date().toLocaleDateString("en-US", {
         <section class="v1-overview">
           <div class="v1-overview-header">
             <h2>Release 1.0</h2>
-            <span class="v1-stat">{v1IssuesClosed} of {v1IssuesTotal} issues closed across {v1Categories.length} milestones</span>
+            <span class="v1-stat">{v1ItemsClosed} of {v1ItemsTotal} items closed across {v1Categories.length} milestones</span>
           </div>
           <div
             class="progress-bar-track"
             role="progressbar"
-            aria-valuenow={v1IssuesClosed}
+            aria-valuenow={v1ItemsClosed}
             aria-valuemin={0}
-            aria-valuemax={v1IssuesTotal}
-            aria-label={`Release 1.0 progress: ${v1IssuesClosed} of ${v1IssuesTotal} issues closed`}
+            aria-valuemax={v1ItemsTotal}
+            aria-label={`Release 1.0 progress: ${v1ItemsClosed} of ${v1ItemsTotal} items closed`}
           >
             <div class="progress-bar-fill" style={`width: ${v1Percent}%`}></div>
           </div>
@@ -255,14 +271,18 @@ const lastUpdated = new Date().toLocaleDateString("en-US", {
                 aria-valuenow={closed}
                 aria-valuemin={0}
                 aria-valuemax={total}
-                aria-label={`${cat.title} progress: ${closed} of ${total} issues closed`}
+                aria-label={`${cat.title} progress: ${closed} of ${total} items closed`}
               >
                 <div
                   class:list={["progress-bar-fill", { empty: pct === 0 }]}
                   style={`width: ${Math.max(pct, 0)}%`}
                 ></div>
               </div>
-              {cat.items.length > 0 ? (
+              {cat.epicsLoadFailed ? (
+                <p class="empty-note epics-error">
+                  Could not load epics for this milestone. {cat.url && <a href={cat.url}>View milestone on GitHub</a>}
+                </p>
+              ) : cat.items.length > 0 ? (
                 <ul class="item-list">
                   {cat.items.map((item) => (
                     <li class:list={["item", item.status]}>
@@ -544,6 +564,12 @@ const lastUpdated = new Date().toLocaleDateString("en-US", {
     color: var(--color-text-tertiary);
     margin: 0;
     padding: 0.4rem 0;
+  }
+
+  .empty-note.epics-error {
+    color: var(--color-text-secondary);
+    border-left: 2px solid var(--color-primary);
+    padding-left: 0.6rem;
   }
 
   /* Item lists */


### PR DESCRIPTION
## Summary

This PR does two things:

### 1. Drive the roadmap page from GitHub milestones (primary)

- `site/src/pages/roadmap.astro` no longer hardcodes the v1 category list. At build time it fetches milestones + their epic-labeled issues from the GitHub API and renders one card per milestone with a live progress bar.
- Display order is fixed via `DISPLAY_ORDER = [8, 7, 10, 6]`; any new milestone not in the list appends in number order, so adding a future milestone needs no code change.
- Speculative roadmap text that had no architected backing in GitHub (Phase 2/4, Effect System Hardening, Documentation, LLM & Agent Adoption, Release Pipeline Hardening, Compiler Stabilization) was demoted into a "Backlog & Exploration" list until those workstreams earn epic-level architecture.

#### Result

Aggregate: **7 of 75 items closed across 4 milestones (9%)**

| Card | Issues | Epics shown |
|---|---|---|
| Runtime Enablement — Systems Primitives | 0/7 | #371 |
| Sailfin-Native Runtime | 6/53 | #389, #390, #450, #451 (planned) + #322, #323 (done) |
| Tooling & Developer Workflow | 0/13 | #340, #351, #362 |
| 1.0 — General Availability | 1/2 | #345 |

#### Copilot review feedback addressed

- Reworded "issues" → "items" since `open_issues` / `closed_issues` from the milestone API counts both issues and PRs
- Reworded "Live data from GitHub" to "Built {date} from GitHub milestones at deploy time" since data is build-time, not runtime
- `fetchEpicsForMilestone` now returns `null` on fetch failure (vs an empty array meaning "no epics yet"); UI distinguishes the two with a "Could not load epics" notice
- Switched milestone fetch from `state=open` to `state=all` so completed milestones still count toward 1.0 progress; filters out empty (0/0) milestones so retired placeholders don't pad the grid

### 2. Disable all gh-aw agentic workflows (urgent)

Cost emergency: the agentic workflows had been racking up ~$100/hr in API charges with limited value. All 7 (planner, architect-review, engineer, issue-triage, nightly-grooming, pr-review, release-notes) now have `on: workflow_dispatch:` only — no schedule, no event triggers. Original triggers documented in comments for easy re-enable. `gh aw compile` was run so the `.lock.yml` files Actions executes are in sync.

Non-agentic workflows (ci.yml, release.yml, sync-labels.yml, capsule-release.yml, nightly-selfhost.yml, release-tag.yml, release-branches.yml, sync-project.yml) are untouched.

## Test plan

- [x] `npm run build` succeeds; `dist/roadmap/index.html` renders all 4 cards with correct counts and epic links
- [x] Aggregate progress bar shows 7/75 (9%)
- [x] Closed epics (#322, #323) render with `done` status; open ones render `planned`
- [x] Card titles + epic items link to the right GitHub URLs
- [x] `gh aw compile` produces 7 lock files with `workflow_dispatch:` only
- [ ] Reviewer: confirm the Cloudflare preview renders correctly in a browser
- [ ] Reviewer: after merge, verify no scheduled gh-aw runs trigger overnight

## Side-effects

- Updated milestone descriptions on #6 and #7 to drop references to deleted milestones (Phase 2, Effect System Hardening). The descriptions render on the live page so they had to match reality.
- Unrelated pre-existing build error from `dl_B59QGVNE.mjs` (some other page) trying to read `compiler/capsule.toml` from `site/` cwd. The build still completes 61/61 pages and the roadmap is unaffected; worth fixing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)