### PR TITLE
chore(commands): sync project board status on label flips

### DIFF
--- a/.claude/commands/groom.md
+++ b/.claude/commands/groom.md
@@ -116,13 +116,27 @@ EOF
 )"
 ```
 
-Capture the issue numbers. After all are created, set up dependencies:
+Capture the issue numbers. After each `gh issue create`, sync the board so
+the new card lands in the column matching its starting labels (typically
+"Ready" because the issue body carries `claude-ready`):
+
+```bash
+.claude/scripts/sync-project-status.sh <new-issue-number> --from-labels
+```
+
+Then set up dependencies. For any issue that depends on a sibling that
+hasn't merged yet, add the `blocked` label and resync — the helper will
+move that card from "Ready" into the "Blocked" column:
 
 ```bash
 # For each issue blocked by an earlier one:
 gh issue edit <N> --add-label "blocked"
 # (and reference the blocker in the body — the gh CLI doesn't have native dependency support)
+.claude/scripts/sync-project-status.sh <N> --from-labels   # → Blocked
 ```
+
+If a sync call exits non-zero, capture the issue number and surface it in
+the Phase 5 report so the human knows the board is out of sync.
 
 ### Attach issues to the parent epic as native sub-issues
 
@@ -177,3 +191,7 @@ Suggest: `/pickup` to start working the queue, or `/triage` to verify hygiene.
 - **Title format follows `docs/conventions/issue-naming.md`** — Conventional Commit shape for sub-tasks, `Epic:` prefix for epics, `Tracking:` for trackers.
 - **Don't create issues for work that's already in progress** — check `gh issue list` first to avoid duplicates.
 - **When grooming an existing epic issue, attach every created issue as a native sub-issue of that epic** via the REST `/sub_issues` endpoint. Body cross-references do not populate the parent's Sub-issues panel and leave the roadmap UI incomplete. Use `-F sub_issue_id=<int>` (not `-f`) — the field must be typed.
+- **Every created or relabeled issue must end Phase 4 with a board sync.** Run
+  `.claude/scripts/sync-project-status.sh <N> --from-labels` after each
+  `gh issue create` and after any follow-up `gh issue edit` that adds
+  `blocked`. The Sailfin Tracker (Project #4) must reflect the labels.

--- a/.claude/commands/pickup.md
+++ b/.claude/commands/pickup.md
@@ -46,15 +46,23 @@ If no pickable issue exists, report: "No claude-ready issues available. Run `/tr
 
 ## Phase 2: CLAIM AND BRANCH
 
-Mark the issue as in-progress and create a branch:
+Mark the issue as in-progress, sync the project board, and create a branch:
 
 ```bash
 # Claim it
 gh issue edit <N> --add-label "in-progress" --remove-label "claude-ready"
 
+# Move the card on the Sailfin Tracker (Project #4) to match.
+# The helper derives the column from the current labels; with the edit
+# above that resolves to "In progress".
+.claude/scripts/sync-project-status.sh <N> --from-labels
+
 # Branch name: claude/<N>-<slugified-title>
 git checkout -b claude/<N>-<slug>
 ```
+
+If the project sync exits non-zero, do not abort the pickup — note the drift
+and surface it in the Phase 6 report so a human can reconcile.
 
 Read the full issue body to extract:
 - Goal
@@ -83,7 +91,15 @@ Based on the issue's `type:*` label, follow the appropriate workflow. Use the is
 gh issue comment <N> --body "Scope adjustment needed: <reason>. Pausing for human input."
 ```
 
-Then mark the issue with `needs-grooming` and remove `in-progress`. Do not silently expand scope.
+Then mark the issue with `needs-grooming`, remove `in-progress`, and resync the
+board so the card moves out of the "In progress" column:
+
+```bash
+gh issue edit <N> --add-label "needs-grooming" --remove-label "in-progress"
+.claude/scripts/sync-project-status.sh <N> --from-labels
+```
+
+Do not silently expand scope.
 
 ---
 
@@ -173,3 +189,7 @@ If anything was deferred or scope was adjusted mid-flight, surface it explicitly
 - **Always link the issue in the PR.** `Closes #N` ensures auto-close on merge.
 - **Always apply `ulimit -v 8388608`** before running the compiler.
 - **One issue per session.** Don't try to bundle multiple issues — they were sized to be standalone.
+- **Every label flip must be paired with a board sync.** Run
+  `.claude/scripts/sync-project-status.sh <N> --from-labels` after any
+  `gh issue edit ... --add-label/--remove-label` so the Sailfin Tracker
+  board (Project #4) stays in sync with the labels.

--- a/.claude/commands/sweep.md
+++ b/.claude/commands/sweep.md
@@ -96,8 +96,14 @@ For each issue in the `blocked` pool:
    ```bash
    gh issue edit <N> --remove-label blocked --add-label claude-ready
    gh issue comment <N> --body "Auto-sweep: blocker(s) resolved — <list resolved #N references>. Marking ready for pickup."
+
+   # Move the card on the Sailfin Tracker (Project #4) out of the
+   # Blocked column. The helper derives the new column from the
+   # post-edit labels — here that resolves to "Ready".
+   .claude/scripts/sync-project-status.sh <N> --from-labels
    ```
-5. If `--dry-run` is set: do not edit or comment. Record the intended flip in the report.
+5. If `--dry-run` is set: do not edit, comment, or sync. Record the intended
+   flip (label change AND target column) in the report.
 
 ---
 
@@ -209,7 +215,11 @@ Dry run: changes <previewed | applied>
 - **Don't modify issue bodies.** Only labels and comments.
 - **Be conservative with prose blockers.** Anything not a hard `#N` reference stays blocked until a human confirms.
 - **Always leave a comment when flipping a label.** Future-you needs the audit trail.
-- **In `--dry-run` mode, make zero writes.** No labels, no comments. Print intended actions only.
+- **Every label flip must be paired with a board sync** via
+  `.claude/scripts/sync-project-status.sh <N> --from-labels`. Surface any
+  non-zero exit under "Concerns" so a human can reconcile the column.
+- **In `--dry-run` mode, make zero writes.** No labels, no comments, no
+  board syncs. Print intended actions only.
 - **Read `.github/AGENTS.md` for cap context.** Default budget = 2 matches the autonomous-pipeline cap; `--greedy` raises it for human-coordinated parallel sessions.
 
 ---

--- a/.claude/commands/triage.md
+++ b/.claude/commands/triage.md
@@ -46,6 +46,16 @@ For each issue, check:
 
 ## Phase 3: APPLY ACTIONS
 
+Every label flip in this phase MUST be followed by a board sync so the card
+moves to the matching column on the Sailfin Tracker (Project #4). Use:
+
+```bash
+.claude/scripts/sync-project-status.sh <N> --from-labels
+```
+
+The helper derives the column from the post-edit labels with strict
+precedence: `in-progress` > `blocked` > `needs-grooming` > `claude-ready`.
+
 For each issue with hygiene failures:
 
 ```bash
@@ -55,6 +65,9 @@ gh issue comment <N> --body "Auto-triage: missing the following sections require
 - <list of failed checks>
 
 Run \`/groom\` to flesh this out, or close if no longer relevant."
+
+# Move the card to "To triage" so the board reflects the new state
+.claude/scripts/sync-project-status.sh <N> --from-labels
 ```
 
 For state issues:
@@ -63,13 +76,15 @@ For state issues:
 # Blocker resolved — clear the blocked label
 gh issue edit <N> --remove-label "blocked" --add-label "claude-ready"
 gh issue comment <N> --body "Auto-triage: blocking issue #<M> is closed. Marking ready for pickup."
+.claude/scripts/sync-project-status.sh <N> --from-labels   # → Ready
 
-# Stale claude-ready — flag for review
+# Stale claude-ready — flag for review (no label change, no board move)
 gh issue comment <N> --body "Auto-triage: this issue has been claude-ready for 30+ days without pickup. Likely stale — review priority or close."
 
 # Orphaned in-progress — release back to the queue
 gh issue edit <N> --remove-label "in-progress" --add-label "claude-ready"
 gh issue comment <N> --body "Auto-triage: in-progress label was set but no active branch found. Releasing back to queue."
+.claude/scripts/sync-project-status.sh <N> --from-labels   # → Ready
 ```
 
 For `L` sized issues that snuck through (no `size:l` label exists in the
@@ -78,7 +93,12 @@ canonical scheme — anything that would be L gets `epic` instead):
 ```bash
 gh issue edit <N> --remove-label "claude-ready" --add-label "needs-grooming,epic"
 gh issue comment <N> --body "Auto-triage: this issue is L-sized; the canonical scheme has no \`size:l\`. Marking as \`epic\` + \`needs-grooming\`. Run \`/groom #<N>\` to decompose into XS/S/M children."
+.claude/scripts/sync-project-status.sh <N> --from-labels   # → To triage
 ```
+
+If a sync call exits non-zero, capture the issue number and surface it under
+"Concerns" in the Phase 4 report — the label flip stands but the board is
+out of sync and a human should reconcile it.
 
 ---
 
@@ -124,3 +144,6 @@ Concerns:
 - **Don't modify issue bodies.** Only labels and comments.
 - **Be conservative on staleness.** 30 days is the floor — never mark something stale at <30 days.
 - **If you change a label, leave a comment explaining why.** Future-you needs to understand the audit trail.
+- **Every label flip must be paired with a board sync.** Run
+  `.claude/scripts/sync-project-status.sh <N> --from-labels` after every
+  `gh issue edit` so Project #4 (Sailfin Tracker) keeps tracking the labels.

--- a/.claude/scripts/sync-project-status.sh
+++ b/.claude/scripts/sync-project-status.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Sync the Sailfin Tracker (org project SailfinIO/4) Status field for an issue.
+#
+# Usage:
+#   .claude/scripts/sync-project-status.sh <issue-number> [--from-labels|--status <name>]
+#
+# Defaults to --from-labels when no mode is given.
+#
+# Label precedence (when --from-labels):
+#   in-progress  > blocked > needs-grooming > claude-ready
+#
+# Status names accepted with --status:
+#   triage | backlog | ready | blocked | in-progress | in-review | done
+#
+# Idempotent: adds the issue to the project if not already there, then sets Status.
+# Exits non-zero on real failures so callers can surface drift in their reports.
+
+set -euo pipefail
+
+# Project + field IDs are stable per project; resolved once via:
+#   gh project field-list 4 --owner SailfinIO
+#   gh api graphql -f query='query{node(id:"<status-field-id>"){...on ProjectV2SingleSelectField{options{id name}}}}'
+PROJECT_ID="PVT_kwDOCLW9dM4BTN6N"
+STATUS_FIELD_ID="PVTSSF_lADOCLW9dM4BTN6NzhAhbTE"
+REPO="${SAILFIN_REPO:-SailfinIO/sailfin}"
+
+if [[ $# -lt 1 ]]; then
+  echo "usage: $0 <issue-number> [--from-labels|--status <name>]" >&2
+  exit 2
+fi
+
+issue_number="$1"
+shift
+
+mode="from-labels"
+forced_status=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --from-labels) mode="from-labels"; shift ;;
+    --status)      mode="forced"; forced_status="${2:-}"; shift 2 ;;
+    *) echo "error: unknown arg '$1'" >&2; exit 2 ;;
+  esac
+done
+
+option_id_for() {
+  case "$1" in
+    triage|"To triage")        echo "f971fb55" ;;
+    backlog|"Backlog")         echo "f75ad846" ;;
+    ready|"Ready")             echo "856cdede" ;;
+    blocked|"Blocked")         echo "8cc85b1a" ;;
+    in-progress|"In progress") echo "47fc9ee4" ;;
+    in-review|"In review")     echo "5ef0dc97" ;;
+    done|"Done")               echo "98236657" ;;
+    *) return 1 ;;
+  esac
+}
+
+if [[ "$mode" == "forced" ]]; then
+  status_name="$forced_status"
+  option_id="$(option_id_for "$status_name")" || {
+    echo "error: unknown status '$status_name'" >&2
+    echo "valid: triage|backlog|ready|blocked|in-progress|in-review|done" >&2
+    exit 2
+  }
+else
+  # Derive from current labels with strict precedence.
+  labels_json="$(gh api "repos/$REPO/issues/$issue_number" --jq '[.labels[].name]')"
+  has() { echo "$labels_json" | jq -e --arg n "$1" 'index($n) != null' >/dev/null; }
+
+  if has "in-progress"; then
+    status_name="In progress"; option_id="47fc9ee4"
+  elif has "blocked"; then
+    status_name="Blocked"; option_id="8cc85b1a"
+  elif has "needs-grooming"; then
+    status_name="To triage"; option_id="f971fb55"
+  elif has "claude-ready"; then
+    status_name="Ready"; option_id="856cdede"
+  else
+    echo "issue #$issue_number has no status-bearing label; leaving project status untouched" >&2
+    exit 0
+  fi
+fi
+
+issue_node_id="$(gh api "repos/$REPO/issues/$issue_number" --jq .node_id)"
+
+item_id="$(gh api graphql \
+  -f query='mutation($project:ID!,$content:ID!){
+    addProjectV2ItemById(input:{projectId:$project,contentId:$content}){item{id}}
+  }' \
+  -f project="$PROJECT_ID" \
+  -f content="$issue_node_id" \
+  --jq '.data.addProjectV2ItemById.item.id')"
+
+gh api graphql \
+  -f query='mutation($project:ID!,$item:ID!,$field:ID!,$value:String!){
+    updateProjectV2ItemFieldValue(input:{
+      projectId:$project, itemId:$item, fieldId:$field,
+      value:{singleSelectOptionId:$value}
+    }){projectV2Item{id}}
+  }' \
+  -f project="$PROJECT_ID" \
+  -f item="$item_id" \
+  -f field="$STATUS_FIELD_ID" \
+  -f value="$option_id" \
+  --jq '.data.updateProjectV2ItemFieldValue.projectV2Item.id' >/dev/null
+
+echo "issue #$issue_number → $status_name"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -247,6 +247,14 @@ diagram live in **`docs/conventions/issue-naming.md`**. Quick orientation:
 | `area:compiler` / `area:runtime` / `area:lowering` / `area:build` / `area:agents` / … | Subsystem the issue touches |
 | `epic` / `tracking` | Parent or coordination issue (not directly implementable) |
 
+Labels are mirrored to the **Sailfin Tracker** project board (org project
+SailfinIO/4) Status field. Slash commands that flip labels MUST follow the
+edit with `.claude/scripts/sync-project-status.sh <N> --from-labels` so the
+card moves to the matching column. Mapping (with strict precedence):
+`in-progress` > `blocked` > `needs-grooming` > `claude-ready` →
+`In progress` / `Blocked` / `To triage` / `Ready`. Closed issues land in
+`Done` automatically.
+
 ### When to use what
 
 | Situation | Command |


### PR DESCRIPTION
## Summary

- Add `.claude/scripts/sync-project-status.sh` — idempotent helper that adds an issue to **Sailfin Tracker** (org project SailfinIO/4) and sets its Status column. Two modes: `--from-labels` (derive from current labels) or `--status <name>` (force).
- Wire `/pickup`, `/triage`, `/sweep`, and `/groom` to call the helper after every `gh issue edit` / `gh issue create` so the board column always tracks the labels.
- Add a one-paragraph note in `CLAUDE.md` next to the labels table so future sessions know about the helper and its precedence mapping.

### Mapping

Strict precedence: `in-progress` > `blocked` > `needs-grooming` > `claude-ready` maps to **In progress** / **Blocked** / **To triage** / **Ready**. Closed issues land in **Done** automatically.

### Behavior notes

- `/sweep --dry-run` already suppressed label writes; it now suppresses sync writes too.
- The helper exits non-zero on real failures (e.g. HTTP 404). Commands surface that drift in their reports rather than aborting.

## Test plan

- [x] `488` (claude-ready) → moved to Ready on the board
- [x] `487` (has `blocked`) → resolves to Blocked under `--from-labels`
- [x] `487 --status blocked` (forced mode) → Blocked
- [x] `999999 --from-labels` → exits 1 with HTTP 404 so callers can detect drift
- [ ] Next `/pickup` run lands the claimed issue in **In progress**
- [ ] Next `/triage` / `/sweep` cycle moves cards out of Blocked when blockers close

🤖 Generated with [Claude Code](https://claude.com/claude-code)