### PR TITLE
feat(runtime-abi): populate native_signature for 5 SfnString helpers (M1.2)

### DIFF
--- a/compiler/src/llvm/expression_lowering/native/core_ops_lowering.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_ops_lowering.sfn
@@ -414,7 +414,7 @@ fn lower_binary_operation(expression: string, match: OperatorMatch, bindings: Pa
             let concat_name = format_temp_name(current_temp);
             current_temp += 1;
             current_lines.push("  " + concat_name
-                + " = call i8* @sailfin_runtime_string_concat_v2({i8*, i64} "
+                + " = call i8* @sfn_str_concat({i8*, i64} "
                 + lhs_agg.operand.value
                 + ", {i8*, i64} "
                 + rhs_agg.operand.value
@@ -633,7 +633,7 @@ fn lower_binary_operation(expression: string, match: OperatorMatch, bindings: Pa
             }
             let temp_name = format_temp_name(current_temp);
             let line = "  " + temp_name
-                + " = call i8* @sailfin_runtime_string_concat_v2({i8*, i64} "
+                + " = call i8* @sfn_str_concat({i8*, i64} "
                 + lhs_agg.operand.value
                 + ", {i8*, i64} "
                 + rhs_agg.operand.value

--- a/compiler/src/llvm/expression_lowering/native/core_strings.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_strings.sfn
@@ -131,8 +131,7 @@ fn emit_string_concat(left: LLVMOperand, right: LLVMOperand, temp_index: number,
         };
     }
     let temp_name = format_temp_name(right_aligned.temp_index);
-    let line = "  " + temp_name
-        + " = call i8* @sailfin_runtime_string_concat_v2({i8*, i64} "
+    let line = "  " + temp_name + " = call i8* @sfn_str_concat({i8*, i64} "
         + left_aligned.operand.value
         + ", {i8*, i64} "
         + right_aligned.operand.value

--- a/compiler/src/llvm/runtime_helpers.sfn
+++ b/compiler/src/llvm/runtime_helpers.sfn
@@ -2,6 +2,78 @@
 //
 // Runtime helper descriptor definitions for LLVM lowering. These describe
 // the external C runtime functions that Sailfin code can call.
+//
+// =============================================================================
+// `native_signature` Rollout Plan (issue #461 / Epic #450 — M1)
+// =============================================================================
+//
+// Each `RuntimeHelperDescriptor` carries an optional `native_signature`
+// field (#392). When populated, the LLVM lowering emits calls to that
+// canonical Sailfin-native symbol (`sfn_*`) instead of the legacy C
+// entrypoint (`symbol`, typically `sailfin_runtime_*`). This is the
+// per-helper hand-off that lets the M2.4a / M2.6 string and array
+// migrations land one descriptor at a time, with `null` entries
+// continuing to route through the legacy C bodies until their pilot
+// PR lands.
+//
+// **Naming scheme** — the canonical name uses the `sfn_<domain>_<op>`
+// shape, mirroring the populated entries already in this file:
+//   - `sfn_str_*`   — string ops      (e.g. `sfn_str_len`, `sfn_str_eq`,
+//                     `sfn_str_slice`, `sfn_str_concat`,
+//                     `sfn_str_starts_with`, `sfn_str_ends_with`,
+//                     `sfn_str_contains`, `sfn_str_repeat`)
+//   - `sfn_array_*` — array/collection ops (e.g. `sfn_array_concat`,
+//                     `sfn_array_push_string`, `sfn_array_push_slot`)
+//   - `sfn_fs_*`    — filesystem ops  (next wave; `fs.*` descriptors)
+//   - `sfn_net_*`   — network ops     (after fs)
+//   - `sfn_clock_*` — clock/time ops  (last; mostly already routed
+//                     through `sfn_sleep` via direct emission)
+//
+// **Prioritization order** for the remaining ~107 descriptors, picked
+// to surface ABI hazards earliest in cheap pilots and defer the
+// effect-bearing surfaces (which need capability wiring on the
+// runtime side) to the back of the queue:
+//   1. **string** — smallest ABI surface, no effects, exercised by
+//      every test. Wave 1 (M2.4a, #430): `sfn_str_len`, `sfn_str_eq`,
+//      `sfn_str_slice`, `sfn_str_to_cstr`, `sfn_str_from_cstr`.
+//      Wave 1b (this PR, #461): `sfn_str_concat` + four method
+//      registrations (`starts_with`, `ends_with`, `contains`,
+//      `repeat`) staged for follow-up.
+//   2. **array** — landed in M2.6 (#466): `sfn_array_concat`,
+//      `sfn_array_push_string`, `sfn_array_push_slot`. Remaining
+//      array helpers (map / filter / reduce / runtime_array_*_fn)
+//      are next.
+//   3. **fs** — `fs.read`, `fs.write`, `fs.exists`, … require
+//      bridging the `![io]` capability before flipping their
+//      descriptors; descriptor metadata can land first, the
+//      `symbol`→`native_signature` flip lands once the capability
+//      bridge ships.
+//   4. **net** — `http.get`, `http.post`, websocket bridges. Same
+//      capability-first ordering as fs.
+//   5. **clock** — `sleep`, `monotonic_millis`. Mostly already
+//      routed through `sfn_sleep` via direct emission; the
+//      descriptor flip is the cleanup step.
+//
+// **Rollout checklist** for the remaining ~107 descriptors —
+// follow-up PRs slot underneath this comment as additional waves
+// land. Each wave should:
+//   * Pick a small batch (5–10 helpers, single domain).
+//   * For each helper that has hardcoded LLVM call sites in
+//     `compiler/src/llvm/expression_lowering/native/*`, mirror
+//     the M2.4a / M2.6 pattern: add a C trampoline in
+//     `runtime/native/src/sailfin_runtime.c` that forwards to the
+//     legacy `sailfin_runtime_*` body, update the hardcoded
+//     `@sailfin_runtime_*` sites to call `@sfn_<domain>_<op>`,
+//     then populate the descriptor's `native_signature`.
+//   * For descriptors with no callers yet (pre-registered method
+//     entries), populate `native_signature` directly — they are
+//     pure metadata until consumer code starts looking them up.
+//   * Run `make compile && make test` per batch.
+//   * Update the prioritization list above as waves land.
+//
+// See `docs/runtime_audit.md` for the C→Sailfin migration tracker
+// and Epic #450 for the milestone-level sequencing.
+//
 import { RuntimeHelperDescriptor } from "./types";
 import { trim_text } from "./utils";
 
@@ -342,8 +414,20 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
     // through the legacy entrypoint while the new compiler routes here.
     // Return type stays `i8*` because string-typed locals don't flip to
     // aggregate until M1.A.2.
+    //
+    // M1.2 (#461): `native_signature` flipped to `sfn_str_concat` —
+    // the canonical Sailfin-native name. The C trampoline lives in
+    // `runtime/native/src/sailfin_runtime.c` (alongside the M2.4a
+    // wave-1 trampolines `sfn_str_len` / `sfn_str_eq` /
+    // `sfn_str_slice`) and forwards to `sailfin_runtime_string_concat_v2`.
+    // The hardcoded direct-emission sites in
+    // `expression_lowering/native/{core_ops_lowering,core_strings}.sfn`
+    // were updated to call `@sfn_str_concat` so seed-built IR (which
+    // still emits `@sailfin_runtime_string_concat_v2`) keeps linking
+    // through the legacy entrypoint while fresh emission lands on the
+    // canonical name.
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "string.concat", symbol: "sailfin_runtime_string_concat_v2", return_type: "i8*", parameter_types: ["{i8*, i64}", "{i8*, i64}"], effects: [], native_signature: null
+        target: "string.concat", symbol: "sailfin_runtime_string_concat_v2", return_type: "i8*", parameter_types: ["{i8*, i64}", "{i8*, i64}"], effects: [], native_signature: "sfn_str_concat"
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
         target: "string.append", symbol: "sailfin_runtime_string_append", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: [], native_signature: null
@@ -391,6 +475,30 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
         target: "is_alpha_char", symbol: "sailfin_runtime_is_alpha_char", return_type: "i1", parameter_types: ["i8"], effects: [], native_signature: null
+    });
+
+    // M1.2 (#461): SfnString method descriptors registered with their
+    // canonical `sfn_str_*` `native_signature` populated up front. None
+    // of these are in `seed_default_runtime_helpers` and no compiler
+    // emission site currently looks them up, so the entries are pure
+    // metadata until a follow-up PR wires the method-dispatch path
+    // through `find_runtime_helper`. The shape mirrors the populated
+    // wave-1 trampolines (`sfn_str_len` / `sfn_str_eq` / `sfn_str_slice`)
+    // so the consumer code (`coerce_and_emit_call`,
+    // `render_runtime_helper_declarations`) routes uniformly once a
+    // caller is connected. `parameter_types` use the SfnString aggregate
+    // shape (`{i8*, i64}`) — matches the M1.A lock-in for fresh emission.
+    descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
+        target: "string.starts_with", symbol: "sfn_str_starts_with", return_type: "i1", parameter_types: ["{i8*, i64}", "{i8*, i64}"], effects: [], native_signature: "sfn_str_starts_with"
+    });
+    descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
+        target: "string.ends_with", symbol: "sfn_str_ends_with", return_type: "i1", parameter_types: ["{i8*, i64}", "{i8*, i64}"], effects: [], native_signature: "sfn_str_ends_with"
+    });
+    descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
+        target: "string.contains", symbol: "sfn_str_contains", return_type: "i1", parameter_types: ["{i8*, i64}", "{i8*, i64}"], effects: [], native_signature: "sfn_str_contains"
+    });
+    descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
+        target: "string.repeat", symbol: "sfn_str_repeat", return_type: "i8*", parameter_types: ["{i8*, i64}", "i64"], effects: [], native_signature: "sfn_str_repeat"
     });
 
     // Array/collection helpers (generic using i8* for element type).

--- a/compiler/tests/e2e/test_string_aggregate_shape.sh
+++ b/compiler/tests/e2e/test_string_aggregate_shape.sh
@@ -1,16 +1,18 @@
 #!/usr/bin/env bash
-# End-to-end test for the M1.A string-literal ABI lock (issue #391).
+# End-to-end test for the M1.A string-literal ABI lock (issue #391)
+# and the M1.2 `sfn_str_concat` registry flip (issue #461).
 #
 # Pins the emitted LLVM IR contract for string literals:
 #   - Literals lower to `{i8*, i64}` aggregates (data ptr + byte length).
 #   - `s.length` resolves to a direct `extractvalue ..., 1` (no
 #     `sailfin_runtime_string_length` call).
 #   - `+` on strings emits
-#     `call i8* @sailfin_runtime_string_concat_v2({i8*, i64} ..., {i8*, i64} ...)`.
-#     The `_v2` suffix is a transition aid: the legacy
+#     `call i8* @sfn_str_concat({i8*, i64} ..., {i8*, i64} ...)`.
+#     The `sfn_str_concat` C trampoline forwards to
+#     `sailfin_runtime_string_concat_v2` (kept link-stable for seed-
+#     compiled IR until the floor seed bumps); the legacy
 #     `sailfin_runtime_string_concat(char*, char*)` entrypoint stays
-#     link-stable for seed-compiled IR until the floor seed embeds the
-#     new ABI, then both can retire together.
+#     exported so seed-compiled IR with the legacy ABI links too.
 #   - No consumer re-extracts a literal as `[N x i8]` (regression guard
 #     against the legacy `bitcast i8* to [N x i8]*` consumer pattern).
 #
@@ -132,28 +134,30 @@ test_no_array_consumer_pattern() {
 }
 
 # A6 — `string.concat` declared with aggregate parameter shape and called
-# the same way. The new compiler routes through
-# `sailfin_runtime_string_concat_v2` (SfnString-by-value); the legacy
-# `sailfin_runtime_string_concat(char*, char*)` entrypoint is kept link-
-# stable for seed-compiled IR until the floor seed bumps.
+# the same way. The new compiler routes through `sfn_str_concat` (the
+# canonical Sailfin-native name from the M1.2 registry flip, #461),
+# whose C trampoline forwards to `sailfin_runtime_string_concat_v2`
+# (SfnString-by-value). The legacy `sailfin_runtime_string_concat_v2`
+# symbol stays exported so seed-compiled IR keeps linking until the
+# floor seed bumps and both retire together.
 test_string_concat_uses_aggregate_abi() {
     emit_ir_once || return 1
     local declared
-    declared="$(grep -cE '^declare i8\* @sailfin_runtime_string_concat_v2\(\{i8\*, i64\}, \{i8\*, i64\}\)' "$LL" || true)"
+    declared="$(grep -cE '^declare i8\* @sfn_str_concat\(\{i8\*, i64\}, \{i8\*, i64\}\)' "$LL" || true)"
     if [ "${declared:-0}" -ne 1 ]; then
-        echo "[test]   expected exactly one aggregate-shape declare for sailfin_runtime_string_concat_v2, got ${declared:-0}"
+        echo "[test]   expected exactly one aggregate-shape declare for sfn_str_concat, got ${declared:-0}"
         return 1
     fi
     local called
-    called="$(grep -cE 'call i8\* @sailfin_runtime_string_concat_v2\(\{i8\*, i64\} ' "$LL" || true)"
+    called="$(grep -cE 'call i8\* @sfn_str_concat\(\{i8\*, i64\} ' "$LL" || true)"
     if [ "${called:-0}" -lt 1 ]; then
-        echo "[test]   expected at least one aggregate-shape call to sailfin_runtime_string_concat_v2, got ${called:-0}"
+        echo "[test]   expected at least one aggregate-shape call to sfn_str_concat, got ${called:-0}"
         return 1
     fi
     local legacy_v2_called
-    legacy_v2_called="$(grep -cE 'call i8\* @sailfin_runtime_string_concat_v2\(i8\* ' "$LL" || true)"
+    legacy_v2_called="$(grep -cE 'call i8\* @sailfin_runtime_string_concat_v2\(' "$LL" || true)"
     if [ "${legacy_v2_called:-0}" -ne 0 ]; then
-        echo "[test]   regression: legacy i8*-shaped call to sailfin_runtime_string_concat_v2 emitted"
+        echo "[test]   regression: fresh emission still calls sailfin_runtime_string_concat_v2 directly"
         return 1
     fi
     return 0

--- a/runtime/native/src/sailfin_runtime.c
+++ b/runtime/native/src/sailfin_runtime.c
@@ -2141,6 +2141,20 @@ const char *sfn_str_from_cstr(const char *s)
     return s;
 }
 
+/* M1.2 (#461): SfnString migration trampoline for string concatenation.
+ * Mirrors the M2.4a wave-1 trampolines above (`sfn_str_len`, `sfn_str_eq`,
+ * `sfn_str_slice`). The compiler's runtime_helpers.sfn registry now
+ * carries `native_signature: "sfn_str_concat"` for `string.concat`, and
+ * the hardcoded direct-emission sites in
+ * `expression_lowering/native/{core_ops_lowering,core_strings}.sfn`
+ * call `@sfn_str_concat` for fresh emission. Seed-built IR that still
+ * targets `@sailfin_runtime_string_concat_v2` keeps linking through
+ * the legacy entrypoint defined later in this file. */
+char *sfn_str_concat(SfnString a, SfnString b)
+{
+    return sailfin_runtime_string_concat_v2(a, b);
+}
+
 /* Check if a string pointer looks like a corrupted double-encoded value.
    On macOS ARM64, valid user-space pointers are < 0x800000000000.
    Double-encoded pointers (via ptrtoint→sitofp→double→bitcast back) produce


### PR DESCRIPTION
## Summary

Kicks off the SfnString `native_signature` pilot from Epic #450 (M1, sub-task B):
- Five string-domain `RuntimeHelperDescriptor` entries now carry a populated `native_signature` — `string.concat` flipped to `sfn_str_concat`, plus four method descriptors (`string.starts_with`, `string.ends_with`, `string.contains`, `string.repeat`) registered with their canonical `sfn_str_*` names.
- `runtime_helpers.sfn` gains a header comment block documenting the naming scheme (`sfn_<domain>_<op>`), prioritization order (string → array → fs → net → clock), and a rollout checklist so the remaining ~107 descriptors can land piecemeal.
- `string.concat` follows the M2.4a / M2.6 migration pattern end-to-end: a new `sfn_str_concat` C trampoline forwards to `sailfin_runtime_string_concat_v2`, the three hardcoded LLVM call sites in `core_ops_lowering.sfn` / `core_strings.sfn` flip from `@sailfin_runtime_string_concat_v2` to `@sfn_str_concat`, and the e2e shape test (`test_string_aggregate_shape.sh`) was updated to pin the new declare/call surface.

The four method descriptors are pure metadata until consumer code wires method dispatch through `find_runtime_helper` — they are intentionally absent from `seed_default_runtime_helpers` so no declares are emitted prematurely.

Closes #461

## Acceptance Criteria

- [x] 9+ helpers total are populated (4 string + 3 array existing + 5 new = 12 total; original criterion was written before #466 added the array trio).
- [x] Rollout-plan comment block present at the top of `runtime_helpers.sfn`.
- [x] `make compile` clean.
- [x] `make test` passes.

## Verification

```bash
ulimit -v 8388608

grep -cE 'native_signature\s*:\s*"' compiler/src/llvm/runtime_helpers.sfn
# → 12 (7 pre-existing + 5 new from this PR)

make compile      # → built build/native/sailfin

make test
# → unit:        88/88 passed
# → integration: 20/20 passed
# → e2e:         54/54 passed
# → capsules:    10/10 passed
```

## Files Changed

- `compiler/src/llvm/runtime_helpers.sfn` — header comment + 4 new descriptors + `string.concat` flip
- `compiler/src/llvm/expression_lowering/native/core_ops_lowering.sfn` — 2 hardcoded call sites updated
- `compiler/src/llvm/expression_lowering/native/core_strings.sfn` — 1 hardcoded call site updated
- `runtime/native/src/sailfin_runtime.c` — `sfn_str_concat` C trampoline added
- `compiler/tests/e2e/test_string_aggregate_shape.sh` — pinned to the new `@sfn_str_concat` declare/call shape

## Notes for Reviewers

The original issue's `Out:` clause anticipated this would be metadata-only, but `string.concat` has hardcoded direct-emission call sites in the lowering pipeline. Setting its `native_signature` flips the helper preamble's declare from `@sailfin_runtime_string_concat_v2` to `@sfn_str_concat`, which would leave the hardcoded call sites without a declare. Following the established M2.4a (#430) / M2.6 (#466) pattern, this PR closes that gap with a C trampoline + call-site updates. The four method descriptors that have no callers stay metadata-only as the issue expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013itUCWnnMtAJm5wSPYAV6x)_