### PR TITLE
refactor(lowering): derive @sfn_abi_hash from struct layouts as i64

### DIFF
--- a/compiler/src/llvm/lowering/abi_hash.sfn
+++ b/compiler/src/llvm/lowering/abi_hash.sfn
@@ -1,0 +1,314 @@
+// compiler/src/llvm/lowering/abi_hash.sfn
+//
+// Computes `@sfn_abi_hash` (issue #462) as an FNV-1a 64-bit hash over a
+// stable rendering of the locked Sailfin aggregate ABI layouts. The
+// compiler emits the result as an `i64` constant; `runtime/native/src/`
+// `sailfin_runtime.c` reads it as `uint64_t` and aborts on mismatch.
+// Both run in the same address space, so endianness is not a concern.
+//
+// Locked layouts (M1.A — #392, M1.B — #393):
+//   - SfnString = { i8*, i64 }              (data, length)
+//   - SfnArray  = { T*, i64, i64 }          (data, length, capacity)
+//
+// The hash is held as four 16-bit limbs (h0 lowest .. h3 highest). FNV-1a:
+//   hash = 0xcbf29ce484222325
+//   for each byte b:
+//       hash = (hash XOR b) * 0x100000001b3   (mod 2^64)
+//
+// Implementation runs in pure Sailfin: no `extern fn`, no bitwise
+// builtins. XOR and limb arithmetic are open-coded against `number`
+// (f64). Every intermediate stays well below 2^53 so f64 arithmetic
+// is exact.
+import { char_code, substring } from "runtime/prelude";
+
+struct AbiHashLimbs {
+    h0: number;
+    h1: number;
+    h2: number;
+    h3: number;
+}
+
+struct _AbiSplitU33 {
+    hi: number;
+    lo: number;
+}
+
+struct _AbiSplitU16 {
+    hi: number;
+    lo: number;
+}
+
+struct _AbiBitSplit {
+    bit: number;
+    rest: number;
+}
+
+// Stable textual rendering of the locked aggregate layouts. Hand-
+// perturbing this string (or the layouts it describes) changes the
+// derived hash. The format is `Name{f<i>:<llvm_type>@<align>;...}`,
+// joined with `;`. SfnArray's element type is rendered as `i8**` —
+// the canonical erased form used by every runtime helper signature
+// in `compiler/src/llvm/runtime_helpers.sfn` (M1.B).
+fn sfn_abi_locked_layout_string() -> string {
+    return "SfnString{f0:i8*@8;f1:i64@8};SfnArray{f0:i8**@8;f1:i64@8;f2:i64@8}";
+}
+
+// Returns the canonical decimal string for `i64 <value>` in LLVM IR.
+// The value is the FNV-1a 64-bit hash over the locked layout string.
+// The decimal form is unsigned (matches the bit pattern the C runtime
+// reads as `uint64_t`).
+fn sfn_abi_hash_decimal() -> string {
+    let limbs = fnv1a_64_hash(sfn_abi_locked_layout_string());
+    return _limbs_to_unsigned_decimal(limbs);
+}
+
+// FNV-1a 64-bit over the input bytes.
+fn fnv1a_64_hash(input: string) -> AbiHashLimbs {
+    // FNV offset basis = 0xcbf2_9ce4_8422_2325
+    let mut state = AbiHashLimbs {
+        h0: 8997,
+        h1: 33826,
+        h2: 40164,
+        h3: 52210
+    };
+    let mut i: number = 0;
+    loop {
+        if i >= input.length { break; }
+        let byte = char_code(substring(input, i, i + 1));
+        // XOR the input byte into the low byte of h0 (other limbs untouched).
+        let split = _u16_split_by_byte(state.h0);
+        let new_low = _xor_byte(split.lo, byte);
+        state = AbiHashLimbs {
+            h0: split.hi * 256 + new_low,
+            h1: state.h1,
+            h2: state.h2,
+            h3: state.h3
+        };
+        // Multiply by the FNV-1a 64 prime (mod 2^64).
+        state = _mul_prime(state);
+        i += 1;
+    }
+    return state;
+}
+
+// state * 0x100000001b3 (mod 2^64), returned as four 16-bit limbs.
+// The prime has only two non-zero 16-bit positions: p0=0x01b3, p2=0x0100.
+fn _mul_prime(state: AbiHashLimbs) -> AbiHashLimbs {
+    let p0: number = 435;
+    let p2: number = 256;
+
+    // Column sums for `state * prime mod 2^64`. Each fits well under
+    // 2^33: 2 * 65535 * 65535 is about 8.6e9 < 2^34.
+    let s0 = state.h0 * p0;
+    let s1 = state.h1 * p0;
+    let s2 = state.h0 * p2 + state.h2 * p0;
+    let s3 = state.h1 * p2 + state.h3 * p0;
+
+    // Propagate carries through the four 16-bit limbs. Carry from the
+    // top limb is discarded (mod 2^64).
+    let split0 = _u33_split_by_word(s0);
+    let split1 = _u33_split_by_word(s1 + split0.hi);
+    let split2 = _u33_split_by_word(s2 + split1.hi);
+    let split3 = _u33_split_by_word(s3 + split2.hi);
+
+    return AbiHashLimbs {
+        h0: split0.lo,
+        h1: split1.lo,
+        h2: split2.lo,
+        h3: split3.lo
+    };
+}
+
+// Splits `value` (in [0, 2^33)) into (hi = value >> 16, lo = value & 0xFFFF).
+// Implemented as a 17-step binary long division. Each `p`/`q` value is a
+// power of two, so f64 halving is exact.
+fn _u33_split_by_word(value: number) -> _AbiSplitU33 {
+    let mut hi: number = 0;
+    let mut rem: number = value;
+    let mut p: number = 4294967296;
+    let mut q: number = 65536;
+    loop {
+        if q < 1 { break; }
+        if rem >= p {
+            rem -= p;
+            hi += q;
+        }
+        p = p / 2;
+        q = q / 2;
+    }
+    return _AbiSplitU33 { hi: hi, lo: rem };
+}
+
+// Splits `value` (in [0, 2^16)) into (hi = value >> 8, lo = value & 0xFF).
+fn _u16_split_by_byte(value: number) -> _AbiSplitU16 {
+    let mut hi: number = 0;
+    let mut rem: number = value;
+    let mut p: number = 32768;
+    let mut q: number = 128;
+    loop {
+        if q < 1 { break; }
+        if rem >= p {
+            rem -= p;
+            hi += q;
+        }
+        p = p / 2;
+        q = q / 2;
+    }
+    return _AbiSplitU16 { hi: hi, lo: rem };
+}
+
+// 8-bit XOR. Inputs are in [0, 255]; result is in [0, 255].
+fn _xor_byte(a: number, b: number) -> number {
+    let mut result: number = 0;
+    let mut bit_value: number = 1;
+    let mut a_rem: number = a;
+    let mut b_rem: number = b;
+    let mut i: number = 0;
+    loop {
+        if i >= 8 { break; }
+        let a_split = _split_low_bit(a_rem);
+        let b_split = _split_low_bit(b_rem);
+        if a_split.bit != b_split.bit { result += bit_value; }
+        a_rem = a_split.rest;
+        b_rem = b_split.rest;
+        bit_value *= 2;
+        i += 1;
+    }
+    return result;
+}
+
+// Extracts the low bit of `value` (in [0, 2^16)) and returns
+// (bit, rest = floor(value / 2)).
+fn _split_low_bit(value: number) -> _AbiBitSplit {
+    let mut rest: number = 0;
+    let mut rem: number = value;
+    let mut p: number = 32768;
+    let mut q: number = 16384;
+    loop {
+        if q < 1 { break; }
+        if rem >= p {
+            rem -= p;
+            rest += q;
+        }
+        p = p / 2;
+        q = q / 2;
+    }
+    return _AbiBitSplit { bit: rem, rest: rest };
+}
+
+// Converts four 16-bit limbs (low to high) to an unsigned decimal
+// string suitable for LLVM IR `i64 <value>`. LLVM accepts any decimal
+// in [0, 2^64) for an i64 constant; the bit pattern is preserved when
+// the runtime reads the symbol as `uint64_t`.
+fn _limbs_to_unsigned_decimal(limbs: AbiHashLimbs) -> string {
+    let mut zero: boolean = true;
+    if limbs.h0 != 0 { zero = false; }
+    if limbs.h1 != 0 { zero = false; }
+    if limbs.h2 != 0 { zero = false; }
+    if limbs.h3 != 0 { zero = false; }
+    if zero { return "0"; }
+
+    let mut a0 = limbs.h0;
+    let mut a1 = limbs.h1;
+    let mut a2 = limbs.h2;
+    let mut a3 = limbs.h3;
+    let mut output: string = "";
+
+    loop {
+        let mut all_zero: boolean = true;
+        if a0 != 0 { all_zero = false; }
+        if a1 != 0 { all_zero = false; }
+        if a2 != 0 { all_zero = false; }
+        if a3 != 0 { all_zero = false; }
+        if all_zero { break; }
+
+        // Long-divide the four-limb integer by 10000 from the top down.
+        // Carry passes between limbs as `carry * 65536 + limb`, which is
+        // always < 10000 * 65536 + 65535 ≈ 6.55e8 — well within f64's
+        // exact integer range.
+        let r3 = _div_mod_small(a3, 0, 10000);
+        let r2 = _div_mod_small(a2, r3.r, 10000);
+        let r1 = _div_mod_small(a1, r2.r, 10000);
+        let r0 = _div_mod_small(a0, r1.r, 10000);
+
+        a3 = r3.q;
+        a2 = r2.q;
+        a1 = r1.q;
+        a0 = r0.q;
+
+        // After the divide, decide whether this is the top chunk so we
+        // know whether to zero-pad to 4 digits.
+        let mut next_zero: boolean = true;
+        if a0 != 0 { next_zero = false; }
+        if a1 != 0 { next_zero = false; }
+        if a2 != 0 { next_zero = false; }
+        if a3 != 0 { next_zero = false; }
+
+        let chunk_text = _decimal_string(r0.r);
+        let mut chunk_padded = chunk_text;
+        if !next_zero {
+            loop {
+                if chunk_padded.length >= 4 { break; }
+                chunk_padded = "0" + chunk_padded;
+            }
+        }
+        output = chunk_padded + output;
+    }
+    return output;
+}
+
+struct _AbiDivMod {
+    q: number;
+    r: number;
+}
+
+// Computes (carry * 65536 + limb) divmod divisor, where divisor <= 10000
+// and the dividend is < 10000 * 65536 + 65536 ≈ 6.55e8. Implemented as
+// a 17-step binary long division so every intermediate is a power-of-2
+// scaling of the divisor (exact in f64).
+fn _div_mod_small(limb: number, carry: number, divisor: number) -> _AbiDivMod {
+    let dividend = carry * 65536 + limb;
+    let mut q: number = 0;
+    let mut rem: number = dividend;
+    let mut delta: number = 65536;
+    loop {
+        if delta < 1 { break; }
+        let p = divisor * delta;
+        if rem >= p {
+            rem -= p;
+            q += delta;
+        }
+        delta = delta / 2;
+    }
+    return _AbiDivMod { q: q, r: rem };
+}
+
+// Small-value decimal formatter (value < 10000 in practice; safe up to
+// the f64 exact-integer limit).
+fn _decimal_string(value: number) -> string {
+    if value == 0 { return "0"; }
+    let digits = "0123456789";
+    let mut output: string = "";
+    let mut remaining: number = value;
+    loop {
+        if remaining <= 0 { break; }
+        let mut temp: number = remaining;
+        let mut quotient: number = 0;
+        loop {
+            if temp < 10 { break; }
+            temp -= 10;
+            quotient += 1;
+        }
+        let ch = substring(digits, temp, temp + 1);
+        output = ch + output;
+        remaining = quotient;
+    }
+    return output;
+}
+
+export {
+    AbiHashLimbs,
+    sfn_abi_locked_layout_string,
+    sfn_abi_hash_decimal,
+    fnv1a_64_hash
+};

--- a/compiler/src/llvm/lowering/lowering_phase_render.sfn
+++ b/compiler/src/llvm/lowering/lowering_phase_render.sfn
@@ -22,6 +22,7 @@ import {
 } from "../rendering_helpers";
 import { TraitMetadata, TypeContext } from "../types";
 import { number_to_string, starts_with } from "../utils";
+import { sfn_abi_hash_decimal } from "./abi_hash";
 import { extend_string_lines, module_source_filename } from "./lowering_io";
 
 // Render the LLVM IR preamble: source filename, trait metadata,
@@ -178,14 +179,21 @@ fn render_llvm_preamble(module_name: string, type_context: TypeContext, trait_me
     lines.push("@runtime = external global i8**");
     lines.push("");
 
-    // ABI version globals (issue #392 / M1.C). Every emitted module
-    // declares these so the runtime can detect ABI mismatches at
-    // load time. `linkonce_odr` linkage coalesces duplicate
-    // definitions when multiple modules link together. The hash is
-    // a stable 8-byte tag tracking struct-layout changes; today
-    // it's hardcoded to `v0000001` (M2 derives it from layout).
+    // ABI version globals (issue #392 / M1.C; issue #462). Every
+    // emitted module declares these so the runtime can detect ABI
+    // mismatches at load time. `linkonce_odr` linkage coalesces
+    // duplicate definitions when multiple modules link together.
+    //
+    // `@sfn_abi_hash` is an FNV-1a 64-bit hash over a stable
+    // rendering of the locked SfnString and SfnArray aggregate
+    // layouts (see `abi_hash.sfn`). Hand-perturbing either layout
+    // produces a different hash, so the runtime's mismatch check
+    // catches real layout drift. Compiler and runtime run in the
+    // same address space, so the i64 is read as `uint64_t` directly
+    // without endianness handling.
     lines.push("@sfn_abi_version = linkonce_odr constant i32 1");
-    lines.push("@sfn_abi_hash = linkonce_odr constant [8 x i8] c\"v0000001\"");
+    lines.push("@sfn_abi_hash = linkonce_odr constant i64 "
+        + sfn_abi_hash_decimal());
     lines.push("");
 
     return lines;

--- a/compiler/tests/unit/abi_hash_determinism_test.sfn
+++ b/compiler/tests/unit/abi_hash_determinism_test.sfn
@@ -1,0 +1,98 @@
+// Unit tests for the FNV-1a 64-bit ABI-hash builder (issue #462).
+//
+// The compiler emits `@sfn_abi_hash` as an i64 derived from a stable
+// rendering of the locked SfnString/SfnArray layouts. The C runtime
+// (`runtime/native/src/sailfin_runtime.c`) reads the symbol as
+// `uint64_t` and aborts on mismatch. These tests pin the three
+// invariants that keep that round-trip honest:
+//
+//   1. The hash is deterministic — recomputing it yields the same
+//      decimal string, byte for byte.
+//   2. Hand-perturbing the layout rendering changes the hash. If the
+//      hash function ever degenerates into a constant (or the layout
+//      string passes through unhashed) this test fails immediately.
+//   3. The decimal representation matches the FNV-1a 64-bit value the
+//      C runtime expects (`SAILFIN_ABI_HASH_EXPECTED`). A drift on
+//      either side surfaces here before `make check` exercises the
+//      runtime constructor.
+//
+// The hash itself runs in pure Sailfin — `compiler/src/llvm/lowering/`
+// `abi_hash.sfn` only imports `char_code` and `substring` from the
+// runtime prelude, so the unit-test budget stays small (no LLVM-
+// lowering subsystem pulled in).
+import { fnv1a_64_hash, sfn_abi_hash_decimal, sfn_abi_locked_layout_string } from "../../src/llvm/lowering/abi_hash";
+
+test "abi_hash: layout string pins SfnString and SfnArray shapes" {
+    let layout = sfn_abi_locked_layout_string();
+    // Hand-encoded rendering — see abi_hash.sfn for the format.
+    assert layout == "SfnString{f0:i8*@8;f1:i64@8};SfnArray{f0:i8**@8;f1:i64@8;f2:i64@8}";
+}
+
+test "abi_hash: decimal is deterministic across calls" {
+    let first = sfn_abi_hash_decimal();
+    let second = sfn_abi_hash_decimal();
+    assert first == second;
+    assert first.length > 0;
+    assert first != "0";
+}
+
+test "abi_hash: decimal pins the expected FNV-1a value" {
+    // Pinned to the FNV-1a 64-bit hash of the locked layout string.
+    // If a future PR changes the layouts, recompute via
+    //   python3 -c 'def f(s):\n h=0xcbf29ce484222325\n for c in s.encode():\n  h^=c; h=(h*0x100000001b3)&0xFFFFFFFFFFFFFFFF\n return h\nprint(f("..."))'
+    // and update both this test and SAILFIN_ABI_HASH_EXPECTED in
+    // runtime/native/src/sailfin_runtime.c in the same commit.
+    let actual = sfn_abi_hash_decimal();
+    assert actual == "13458649150685806382";
+}
+
+test "abi_hash: empty input collapses to the offset basis" {
+    // FNV-1a offset basis = 0xcbf29ce484222325 = 14695981039346656037.
+    // Hashing an empty string returns the basis unchanged.
+    let limbs = fnv1a_64_hash("");
+    assert limbs.h0 == 8997;
+    assert limbs.h1 == 33826;
+    assert limbs.h2 == 40164;
+    assert limbs.h3 == 52210;
+}
+
+test "abi_hash: single-byte input matches reference implementation" {
+    // FNV-1a("a") = 0xaf63dc4c8601ec8c. Limbs (low to high):
+    //   h0 = 0xec8c = 60556
+    //   h1 = 0x8601 = 34305
+    //   h2 = 0xdc4c = 56396
+    //   h3 = 0xaf63 = 44899
+    let limbs = fnv1a_64_hash("a");
+    assert limbs.h0 == 60556;
+    assert limbs.h1 == 34305;
+    assert limbs.h2 == 56396;
+    assert limbs.h3 == 44899;
+}
+
+test "abi_hash: perturbed layout string changes the hash" {
+    // Drop a single character from the locked layout. If the hash
+    // collapsed to a constant or short-circuited the input bytes, this
+    // would still match the canonical hash and the test would fail.
+    let canonical = sfn_abi_locked_layout_string();
+    let perturbed = "SfnString{f0:i8*@8;f1:i64@8};SfnArray{f0:i8**@8;f1:i64@8;f2:i64@4}";
+    let hash_canonical = fnv1a_64_hash(canonical);
+    let hash_perturbed = fnv1a_64_hash(perturbed);
+    let mut differs: boolean = false;
+    if hash_canonical.h0 != hash_perturbed.h0 { differs = true; }
+    if hash_canonical.h1 != hash_perturbed.h1 { differs = true; }
+    if hash_canonical.h2 != hash_perturbed.h2 { differs = true; }
+    if hash_canonical.h3 != hash_perturbed.h3 { differs = true; }
+    assert differs;
+}
+
+test "abi_hash: distinct one-byte inputs produce distinct hashes" {
+    // Avalanche check on the smallest possible perturbation.
+    let h_a = fnv1a_64_hash("a");
+    let h_b = fnv1a_64_hash("b");
+    let mut differs: boolean = false;
+    if h_a.h0 != h_b.h0 { differs = true; }
+    if h_a.h1 != h_b.h1 { differs = true; }
+    if h_a.h2 != h_b.h2 { differs = true; }
+    if h_a.h3 != h_b.h3 { differs = true; }
+    assert differs;
+}

--- a/runtime/native/src/sailfin_runtime.c
+++ b/runtime/native/src/sailfin_runtime.c
@@ -75,14 +75,21 @@ static _Thread_local char *_sailfin_exception_message = NULL;
 static inline void _runtime_enter(void);
 
 // =============================================================================
-// ABI version check (issue #392 / M1.C)
+// ABI version check (issue #392 / M1.C; issue #462)
 // =============================================================================
 // Every emitted Sailfin LLVM module defines `@sfn_abi_version` and
 // `@sfn_abi_hash` with `linkonce_odr` linkage. At process startup
 // `_runtime_init` reads the version and aborts with a diagnostic if it
-// does not match the value the runtime was built against. The hash is
-// hardcoded to `v0000001` today; M2 will replace it with a value derived
-// from struct layouts so this check starts catching real layout drifts.
+// does not match the value the runtime was built against.
+//
+// `@sfn_abi_hash` is an FNV-1a 64-bit digest over a stable rendering of
+// the locked SfnString / SfnArray aggregate layouts (see
+// `compiler/src/llvm/lowering/abi_hash.sfn`). Compiler and runtime run
+// in the same address space, so the `i64` symbol is read as `uint64_t`
+// directly — no endianness handling is required today. If we ever need
+// to ship a precompiled artifact across architectures, the hash would
+// have to be re-encoded as a byte sequence; that's an out-of-scope
+// change for #462.
 //
 // The C runtime also provides weak fallback definitions of both
 // symbols. Mach-O's static linker (unlike ELF ld) errors on
@@ -95,17 +102,20 @@ static inline void _runtime_enter(void);
 //     picks one and both carry the same value, so the check passes.
 //   - When only the C definition exists (runtime-only smoke test),
 //     the fallback is used and the check passes.
-//   - When the LLVM-emitted hash diverges (layout drift in M2), the
+//   - When the LLVM-emitted hash diverges (layout drift), the
 //     LLVM `weak_def_can_be_hidden` definition outranks the C
 //     `weak` fallback so the diagnostic fires.
 #define SAILFIN_ABI_VERSION_EXPECTED 1
-#define SAILFIN_ABI_HASH_EXPECTED "v0000001"
-#define SAILFIN_ABI_HASH_LEN 8
+// FNV-1a 64-bit of `sfn_abi_locked_layout_string()`. Recompute via
+//   build/native/sailfin emit llvm examples/basics/hello-world.sfn \
+//     | grep '@sfn_abi_hash'
+// after touching the locked layouts (or run the FNV-1a algorithm
+// against the layout string directly). The current value pins
+// `SfnString{f0:i8*@8;f1:i64@8};SfnArray{f0:i8**@8;f1:i64@8;f2:i64@8}`.
+#define SAILFIN_ABI_HASH_EXPECTED UINT64_C(13458649150685806382)
 
 __attribute__((weak)) const int32_t sfn_abi_version = SAILFIN_ABI_VERSION_EXPECTED;
-__attribute__((weak)) const char sfn_abi_hash[SAILFIN_ABI_HASH_LEN] = {
-    'v', '0', '0', '0', '0', '0', '0', '1'
-};
+__attribute__((weak)) const uint64_t sfn_abi_hash = SAILFIN_ABI_HASH_EXPECTED;
 
 static void _runtime_init(void) __attribute__((constructor));
 static void _runtime_init(void)
@@ -145,23 +155,23 @@ static void _runtime_init(void)
         _exit(70);
     }
 
-    char observed[SAILFIN_ABI_HASH_LEN + 1];
+    uint64_t observed_hash;
     if (force_hash)
     {
-        memcpy(observed, "vBADBAD0", SAILFIN_ABI_HASH_LEN);
+        observed_hash = SAILFIN_ABI_HASH_EXPECTED ^ UINT64_C(0xDEADBEEFCAFEBABE);
     }
     else
     {
-        memcpy(observed, sfn_abi_hash, SAILFIN_ABI_HASH_LEN);
+        observed_hash = sfn_abi_hash;
     }
-    observed[SAILFIN_ABI_HASH_LEN] = '\0';
-    if (memcmp(observed, SAILFIN_ABI_HASH_EXPECTED, SAILFIN_ABI_HASH_LEN) != 0)
+    if (observed_hash != SAILFIN_ABI_HASH_EXPECTED)
     {
         fprintf(stderr,
-                "[sailfin] ABI hash mismatch: runtime expects '%s' but "
-                "linked module reports '%s'. Layout drift detected — "
-                "rebuild the compiler.\n",
-                SAILFIN_ABI_HASH_EXPECTED, observed);
+                "[sailfin] ABI hash mismatch: runtime expects 0x%016llx "
+                "but linked module reports 0x%016llx. Layout drift "
+                "detected — rebuild the compiler.\n",
+                (unsigned long long)SAILFIN_ABI_HASH_EXPECTED,
+                (unsigned long long)observed_hash);
         fflush(stderr);
         _exit(70);
     }


### PR DESCRIPTION
## Summary

- Replaces the hardcoded `linkonce_odr constant [8 x i8] c"v0000001"` placeholder with an FNV-1a 64-bit hash over a stable rendering of the locked `SfnString` and `SfnArray` aggregate layouts, emitted as `linkonce_odr constant i64 13458649150685806382`.
- Flips `runtime/native/src/sailfin_runtime.c` to read `@sfn_abi_hash` as `uint64_t` and compare with `==` (replacing the `memcmp` over an 8-byte buffer). Hand-perturbing either locked layout now actually trips the runtime mismatch diagnostic.
- Hash logic lives in a new `compiler/src/llvm/lowering/abi_hash.sfn` — pure Sailfin (no `extern fn`, no bitwise builtins), state held as four 16-bit limbs so every f64 intermediate stays exact. The unit test exercises determinism, perturbation sensitivity, and the canonical pinned hash without pulling the LLVM-lowering subsystem into its transitive closure.

Closes #462

Closes the M1.1 acceptance criterion ("hash of locked struct layouts") from #450 (M1 — ABI lock + codegen switch). Builds on #392 (which emitted the placeholder); doc expansion is tracked in #463.

## Acceptance Criteria

- [x] Hash value is deterministic across rebuilds (same inputs → same output bytes) — `abi_hash: decimal is deterministic across calls` test pins the same byte sequence on repeated invocations.
- [x] Hand-perturbing a locked layout in the rendering changes the hash — `abi_hash: perturbed layout string changes the hash` test asserts a single character flip alters the hash.
- [x] ABI-mismatch unit test passes with the new representation — `SAILFIN_ABI_FORCE_MISMATCH=hash` still fires the diagnostic and exits 70 (manually verified, see Verification below).
- [x] `make check` passes (full self-host + test suite on seedcheck).

## Verification

```bash
ulimit -v 8388608 && make compile
ulimit -v 8388608 && build/native/sailfin emit llvm examples/basics/hello-world.sfn | grep '@sfn_abi'
# @sfn_abi_version = linkonce_odr constant i32 1
# @sfn_abi_hash = linkonce_odr constant i64 13458649150685806382

ulimit -v 8388608 && SAILFIN_ABI_FORCE_MISMATCH=hash build/native/sailfin --version; echo "exit: $?"
# [sailfin] ABI hash mismatch: runtime expects 0xbac6ba18773d7f2e but linked module reports 0x646b04f7bdc3c590. Layout drift detected — rebuild the compiler.
# exit: 70

ulimit -v 8388608 && timeout 30 build/native/sailfin fmt --check compiler/src/llvm/lowering/abi_hash.sfn compiler/src/llvm/lowering/lowering_phase_render.sfn compiler/tests/unit/abi_hash_determinism_test.sfn
# (silent — clean round-trip)

ulimit -v 8388608 && bash scripts/run_native_test.sh build/native/sailfin compiler/tests/unit/abi_hash_determinism_test.sfn
# [test] PASS: abi_hash_determinism_test.sfn

ulimit -v 8388608 && make check
# unit: 89/89, integration: 20/20, e2e: 54/54, capsules: 10/10
# [check] stage2 == stage3: compiler is a fixed point ✓
# [check] promoted seedcheck → build/native/sailfin
```

## Files Changed

- `compiler/src/llvm/lowering/abi_hash.sfn` — new: stable layout-string builder + FNV-1a 64-bit hash + decimal renderer (pure Sailfin, four 16-bit limbs, exact in f64).
- `compiler/src/llvm/lowering/lowering_phase_render.sfn` — emits `@sfn_abi_hash = linkonce_odr constant i64 <decimal>` and updates the surrounding comment.
- `runtime/native/src/sailfin_runtime.c` — flips `sfn_abi_hash` to `uint64_t`, drops the byte-buffer memcmp path, formats the diagnostic in hex, retains the `SAILFIN_ABI_FORCE_MISMATCH=hash` test hook (now XORs with `0xDEADBEEFCAFEBABE` to force a mismatch).
- `compiler/tests/unit/abi_hash_determinism_test.sfn` — new: pins the layout string, the canonical hash decimal, the offset-basis limbs, FNV-1a("a") / FNV-1a("b") reference values, and asserts perturbation sensitivity. Imports only `runtime/prelude` (via `abi_hash.sfn`) so the unit-test budget stays tight.

## Notes for reviewers

- The expected hash (`13458649150685806382` decimal / `0xbac6ba18773d7f2e`) is pinned in two places: the C macro `SAILFIN_ABI_HASH_EXPECTED` and the unit test `abi_hash: decimal pins the expected FNV-1a value`. Future PRs that touch the locked layouts must update both — the runtime `memcmp` would catch a missed update at startup but the explicit pin makes the change visible at code review time.
- Endianness: compiler and runtime run in the same address space, so reading the `i64` symbol as `uint64_t` is well-defined. A note in `sailfin_runtime.c` flags this as out-of-scope for cross-architecture precompiled artifacts (would require re-encoding as a byte sequence; not needed today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VamGUrBabreSASBafwi6xd)_