### PR TITLE
chore(commands): set GitHub native Type field when creating or triaging issues

### DIFF
--- a/.claude/commands/groom.md
+++ b/.claude/commands/groom.md
@@ -116,13 +116,23 @@ EOF
 )"
 ```
 
-Capture the issue numbers. After each `gh issue create`, sync the board so
-the new card lands in the column matching its starting labels (typically
-"Ready" because the issue body carries `claude-ready`):
+Capture the issue numbers. After each `gh issue create`:
 
+1. Sync the board so the new card lands in the correct column:
 ```bash
 .claude/scripts/sync-project-status.sh <new-issue-number> --from-labels
 ```
+
+2. Set the GitHub native Type field to match the `type:*` label:
+```bash
+# Derive from the label: type:feature → Feature, type:bug → Bug, everything else → Task
+.claude/scripts/set-issue-type.sh <new-issue-number> <Feature|Task|Bug>
+```
+
+The mapping from `type:*` label to GitHub Type:
+- `type:feature` → `Feature`
+- `type:bug` → `Bug`
+- `type:refactor`, `type:perf`, `type:docs`, `type:tech-debt`, epics, tracking → `Task`
 
 Then set up dependencies. For any issue that depends on a sibling that
 hasn't merged yet, add the `blocked` label and resync — the helper will
@@ -195,3 +205,7 @@ Suggest: `/pickup` to start working the queue, or `/triage` to verify hygiene.
   `.claude/scripts/sync-project-status.sh <N> --from-labels` after each
   `gh issue create` and after any follow-up `gh issue edit` that adds
   `blocked`. The Sailfin Tracker (Project #4) must reflect the labels.
+- **Every created issue must have its GitHub native Type field set.** Run
+  `.claude/scripts/set-issue-type.sh <N> <Feature|Task|Bug>` immediately after
+  the board sync. Derive the type from the `type:*` label: `type:feature` →
+  `Feature`, `type:bug` → `Bug`, everything else → `Task`.

--- a/.claude/commands/triage.md
+++ b/.claude/commands/triage.md
@@ -35,6 +35,8 @@ For each issue, check:
 - [ ] Has `## Verification` with a runnable command
 - [ ] Has a `size:*` label (XS/S/M — never L)
 - [ ] Has a `type:*` label (feature/bug/perf/refactor)
+- [ ] Has the GitHub native **Type** field set (Feature / Task / Bug) — check via
+  `gh api graphql -f query='query{repository(owner:"SailfinIO",name:"sailfin"){issue(number:<N>){issueType{name}}}}'`
 
 ### State checks
 - Is it `claude-ready` but actually stale (no update in 30+ days)?
@@ -96,6 +98,17 @@ gh issue comment <N> --body "Auto-triage: this issue is L-sized; the canonical s
 .claude/scripts/sync-project-status.sh <N> --from-labels   # → To triage
 ```
 
+For issues whose GitHub native **Type** field is `null`:
+
+```bash
+# Derive from type:* label; set silently (no board sync needed — Type is not a label)
+# type:feature → Feature, type:bug → Bug, everything else → Task
+.claude/scripts/set-issue-type.sh <N> <Feature|Task|Bug>
+```
+
+This is a **silent fix** — no label edit, no comment, no board sync required.
+Apply it to all issues with a null type regardless of other state.
+
 If a sync call exits non-zero, capture the issue number and surface it under
 "Concerns" in the Phase 4 report — the label flip stands but the board is
 out of sync and a human should reconcile it.
@@ -147,3 +160,6 @@ Concerns:
 - **Every label flip must be paired with a board sync.** Run
   `.claude/scripts/sync-project-status.sh <N> --from-labels` after every
   `gh issue edit` so Project #4 (Sailfin Tracker) keeps tracking the labels.
+- **Always fix a null GitHub Type field** — run
+  `.claude/scripts/set-issue-type.sh <N> <Feature|Task|Bug>` for any issue
+  whose `issueType` is null. No board sync or comment needed for this fix.

--- a/.claude/scripts/set-issue-type.sh
+++ b/.claude/scripts/set-issue-type.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Set the GitHub native issue Type field for a single issue.
+#
+# Usage:
+#   .claude/scripts/set-issue-type.sh <issue-number> <Feature|Task|Bug>
+#
+# The type is set via the GraphQL updateIssue mutation.  The type IDs below
+# are stable for the SailfinIO org.  Resolve them with:
+#   gh api graphql -f query='query{repository(owner:"SailfinIO",name:"sailfin"){issueTypes(first:10){nodes{id name}}}}'
+#
+# Mapping (from type:* labels):
+#   type:feature                          → Feature
+#   type:bug                              → Bug
+#   type:refactor / type:perf / type:docs
+#     / type:tech-debt / epic / tracking  → Task
+#
+# Exits non-zero on API failure so callers can surface it in reports.
+
+set -euo pipefail
+
+REPO="${SAILFIN_REPO:-SailfinIO/sailfin}"
+
+TYPE_FEATURE="IT_kwDOCLW9dM4BOQXt"
+TYPE_TASK="IT_kwDOCLW9dM4BOQXm"
+TYPE_BUG="IT_kwDOCLW9dM4BOQXp"
+
+if [[ $# -lt 2 ]]; then
+  echo "usage: $0 <issue-number> <Feature|Task|Bug>" >&2
+  exit 2
+fi
+
+issue_number="$1"
+type_name="$2"
+
+case "$type_name" in
+  Feature) type_id="$TYPE_FEATURE" ;;
+  Bug)     type_id="$TYPE_BUG" ;;
+  Task)    type_id="$TYPE_TASK" ;;
+  *)
+    echo "error: unknown type '$type_name'; expected Feature, Task, or Bug" >&2
+    exit 2
+    ;;
+esac
+
+node_id="$(gh api "repos/$REPO/issues/$issue_number" --jq '.node_id')"
+
+gh api graphql -f query="
+  mutation {
+    updateIssue(input: { id: \"$node_id\", issueTypeId: \"$type_id\" }) {
+      issue { number issueType { name } }
+    }
+  }" --jq '.data.updateIssue.issue | "issue #\(.number) type → \(.issueType.name)"'


### PR DESCRIPTION
## Summary

- Adds `.claude/scripts/set-issue-type.sh <N> <Feature|Task|Bug>` — a thin GraphQL wrapper that sets the GitHub native issue Type field (separate from `type:*` labels) via `updateIssue`
- Wires it into `/groom` Phase 4: call after board sync for every created issue
- Wires it into `/triage` Phase 2 (hygiene check) and Phase 3 (silent fix for null types)
- Retroactively set the Type field on all 88 open issues during this session (87 were null, 1 was wrong)

Closes #506

## Type mapping

| `type:*` label | GitHub Type |
|---|---|
| `type:feature` | Feature |
| `type:bug` | Bug |
| `type:refactor`, `type:perf`, `type:docs`, `type:tech-debt`, epics, tracking, `[aw]` | Task |

## Test plan

- [x] `.claude/scripts/set-issue-type.sh 495 Feature` → `issue #495 type → Feature`
- [x] All 88 open issues now have non-null Type (verified via GraphQL audit)
- [x] `/groom` instructions updated with type-setting step and Constraints entry
- [x] `/triage` instructions updated with null-type hygiene check and silent remediation

🤖 Generated with [Claude Code](https://claude.com/claude-code)