### PR TITLE
feat(typecheck): infer lambda capture sets and attach to AST

### DIFF
--- a/compiler/src/ast.sfn
+++ b/compiler/src/ast.sfn
@@ -32,6 +32,25 @@ struct SourceSpan {
     end_column: number;
 }
 
+// Inferred lambda capture descriptor populated by the typechecker's
+// free-variable walk (issue #458, A1 of #450 M1.5). One entry per
+// distinct enclosing-scope name referenced from the lambda body, in
+// first-use order — deterministic so stage A2 (env-struct emit) and
+// stage A3 (call-site dispatch) can index by position. `type_text`
+// echoes the enclosing binding's annotation when available
+// (parameters and `let x: T = ...`); empty otherwise. `by_value`
+// flips false for non-primitive type annotations so the LLVM lowering
+// in stage A2 knows to emit a heap-pointer slot. `mutable` records
+// whether the enclosing binding was declared `let mut`, so a future
+// mutating-capture pass can reject writes to immutable bindings.
+struct Capture {
+    name: string;
+    type_text: string;
+    by_value: boolean;
+    mutable: boolean;
+    span: SourceSpan?;
+}
+
 enum Expression {
     // Per-expression source spans land on the variants the effect
     // checker needs for call-site attribution (B1, see
@@ -59,7 +78,12 @@ enum Expression {
     Lambda {
         parameters: Parameter[],
         body: Block,
-        return_type: TypeAnnotation?
+        return_type: TypeAnnotation?,
+        // Captures are appended last so the seed compiler's positional
+        // GEP indexing for the existing fields stays stable. The parser
+        // emits an empty list; the typechecker populates the inferred
+        // set via `analyze_lambda_captures` in `typecheck_captures`.
+        captures: Capture[]
     },
     Range { start: Expression, end: Expression },
     Cast { operand: Expression, target_type: TypeAnnotation },

--- a/compiler/src/ast.sfn
+++ b/compiler/src/ast.sfn
@@ -80,9 +80,15 @@ enum Expression {
         body: Block,
         return_type: TypeAnnotation?,
         // Captures are appended last so the seed compiler's positional
-        // GEP indexing for the existing fields stays stable. The parser
-        // emits an empty list; the typechecker populates the inferred
-        // set via `analyze_lambda_captures` in `typecheck_captures`.
+        // GEP indexing for the existing fields stays stable. Today the
+        // parser always emits an empty list and the inferred capture
+        // sets live separately as `LambdaCaptureRecord[]` returned by
+        // `analyze_lambda_captures` in `typecheck_captures`. Records
+        // are keyed back to a specific Lambda node by the body's
+        // opening `{` token (`body.tokens[0]` line/column). A future
+        // pass can copy each record's `captures` onto the matching
+        // node so this field becomes the single source of truth; for
+        // now stage A2 / A3 should look up the record by body span.
         captures: Capture[]
     },
     Range { start: Expression, end: Expression },

--- a/compiler/src/parser/expressions.sfn
+++ b/compiler/src/parser/expressions.sfn
@@ -4,6 +4,7 @@
 // literals, binary/unary operators, member access, calls, lambdas, and more.
 import {
     Block,
+    Capture,
     Expression,
     ObjectField,
     Parameter,
@@ -995,12 +996,14 @@ fn parse_lambda_expression(state: ExpressionTokens) -> ExpressionParseResult {
     let parsed_block = parse_block_for_lambda(block_parser);
     let body = parsed_block.block;
 
+    let empty_captures: Capture[] = [];
     return ExpressionParseResult {
         state: current,
         expression: Expression.Lambda {
             parameters: parameters,
             body: body,
-            return_type: return_type
+            return_type: return_type,
+            captures: empty_captures
         },
         success: true
     };

--- a/compiler/src/typecheck_captures.sfn
+++ b/compiler/src/typecheck_captures.sfn
@@ -62,14 +62,23 @@ struct LocalBinding {
 }
 
 // One record per `Expression.Lambda` discovered during the walk.
-// `parameter_names` lets unit tests pin a record to a specific
-// lambda by parameter shape (lambdas don't carry per-node spans
-// today; once they do, tests can switch to span-based matching).
 // Records are emitted in pre-order so a nested-lambda assertion
 // can index by `[0]` for the outer and `[1]` for the inner.
+//
+// Identification — `body_start_line` and `body_start_column` are
+// taken from the lambda body's opening `{` token. Two lambdas with
+// identical parameter shapes still differ on body start, so stage
+// A2 / A3 can map an `Expression.Lambda` AST node back to its
+// record by computing the same `(line, column)` from its
+// `body.tokens[0]`. `parameter_names` is kept alongside as a
+// human-readable hint for diagnostics and for tests to assert
+// against without depending on exact line/column numbers in source
+// fixtures.
 struct LambdaCaptureRecord {
     parameter_names: string[];
     captures: Capture[];
+    body_start_line: number;
+    body_start_column: number;
 }
 
 // Internal walk result. `free` is the set of identifier names
@@ -241,7 +250,19 @@ fn walk_statement(scope: LocalBinding[], stmt: Statement) -> CaptureWalkResult {
     if stmt.variant == "TryStatement" {
         let mut result = walk_block(scope, stmt.try_block);
         if stmt.catch_block != null {
-            result = merge_results(result, walk_block(scope, stmt.catch_block));
+            // The `catch (name)` identifier is a fresh local binding
+            // visible only inside the catch block, so extend the
+            // scope with it and subtract its name from the bubbled
+            // free set — otherwise a lambda nested inside the catch
+            // would capture the catch variable as if it were an
+            // enclosing let-binding.
+            let catch_scope = extend_with_catch_name(scope, stmt.catch_name);
+            let catch_result = walk_block(catch_scope, stmt.catch_block);
+            let catch_local: string[] = catch_name_as_list(stmt.catch_name);
+            let catch_free = subtract_names(catch_result.free, catch_local);
+            result = merge_results(result, CaptureWalkResult {
+                free: catch_free, records: catch_result.records
+            });
         }
         if stmt.finally_block != null {
             result = merge_results(result, walk_block(scope, stmt.finally_block));
@@ -362,13 +383,51 @@ fn analyze_lambda(outer_scope: LocalBinding[], lambda: Expression) -> CaptureWal
     let param_names = parameter_names(lambda.parameters);
     let lambda_free = subtract_names(body_result.free, param_names);
     let captures = build_captures(outer_scope, lambda_free);
+    let body_line = body_start_line(lambda.body);
+    let body_column = body_start_column(lambda.body);
 
     let mut records: LambdaCaptureRecord[] = [];
     records.push(LambdaCaptureRecord {
-        parameter_names: param_names, captures: captures
+        parameter_names: param_names, captures: captures, body_start_line: body_line, body_start_column: body_column
     });
     records = append_records(records, body_result.records);
     return CaptureWalkResult { free: lambda_free, records: records };
+}
+
+fn body_start_line(body: Block) -> number {
+    if body.tokens.length == 0 { return 0; }
+    return body.tokens[0].line;
+}
+
+fn body_start_column(body: Block) -> number {
+    if body.tokens.length == 0 { return 0; }
+    return body.tokens[0].column;
+}
+
+fn extend_with_catch_name(scope: LocalBinding[], catch_name: string?) -> LocalBinding[] {
+    let mut out: LocalBinding[] = [];
+    let mut i: number = 0;
+    loop {
+        if i >= scope.length { break; }
+        out.push(scope[i]);
+        i += 1;
+    }
+    if catch_name != null {
+        if catch_name.length > 0 {
+            out.push(LocalBinding {
+                name: catch_name, type_text: "", by_value: false, mutable: false, span: null
+            });
+        }
+    }
+    return out;
+}
+
+fn catch_name_as_list(catch_name: string?) -> string[] {
+    let mut out: string[] = [];
+    if catch_name != null {
+        if catch_name.length > 0 { out.push(catch_name); }
+    }
+    return out;
 }
 
 // ----- Capture construction & scope helpers -----

--- a/compiler/src/typecheck_captures.sfn
+++ b/compiler/src/typecheck_captures.sfn
@@ -1,0 +1,602 @@
+// compiler/src/typecheck_captures.sfn
+//
+// Free-variable / capture-set inference for `Expression.Lambda`
+// nodes (issue #458; A1 of #450 M1.5 closures-with-capture). This
+// module is stage 1 of three: it produces deterministic, ordered
+// capture records the AST can carry forward; later stages emit
+// env structs (#A2) and call-site dispatch (#A3).
+//
+// The walk is purely analytical — it never mutates AST nodes. It
+// returns one `LambdaCaptureRecord` per `Expression.Lambda`
+// discovered, in pre-order (outer lambdas appear before nested
+// ones). Records are keyed by the lambda's parameter shape, which
+// is stable across the seed compiler's positional layout.
+//
+// Algorithm sketch:
+//   * `walk_block(scope, block)` walks statements left-to-right,
+//     collecting let-declared locals as it goes. Free names from
+//     each statement are subtracted by the locals already declared
+//     in the block before the statement.
+//   * `walk_expression(scope, expr)` returns the set of
+//     identifiers referenced in the expression that are NOT bound
+//     anywhere within the expression itself.
+//   * Hitting `Expression.Lambda` recurses via `analyze_lambda`,
+//     which walks the body with the lambda's parameters added to
+//     the inner scope, subtracts those parameters from the body's
+//     free names, and intersects with the outer scope to derive
+//     captures. Each free name resolved against the outer scope
+//     produces one `Capture` carrying the enclosing binding's
+//     declared type, mutability, and span — the metadata stage A2
+//     needs to size the env struct and pick by-value-vs-pointer
+//     copy semantics.
+import {
+    Block,
+    Capture,
+    ElseBranch,
+    Expression,
+    MatchCase,
+    MethodDeclaration,
+    Parameter,
+    Program,
+    SourceSpan,
+    Statement,
+    TypeAnnotation
+} from "./ast";
+import { parse_block } from "./parser/statements";
+import { Parser } from "./parser/types";
+import { strings_equal } from "./string_utils";
+
+// One scope-visible binding the walk has accumulated so far.
+// Mirrors the data the unit tests need to verify (`type_text`,
+// `mutable`) plus the by-value/by-pointer hint stage A2 will pick
+// up. `span` is the binding-site span — the parameter slot or the
+// `let`/`let mut` keyword location — and is propagated into the
+// final `Capture` so future diagnostics can underline the source
+// of the capture rather than the use site.
+struct LocalBinding {
+    name: string;
+    type_text: string;
+    by_value: boolean;
+    mutable: boolean;
+    span: SourceSpan?;
+}
+
+// One record per `Expression.Lambda` discovered during the walk.
+// `parameter_names` lets unit tests pin a record to a specific
+// lambda by parameter shape (lambdas don't carry per-node spans
+// today; once they do, tests can switch to span-based matching).
+// Records are emitted in pre-order so a nested-lambda assertion
+// can index by `[0]` for the outer and `[1]` for the inner.
+struct LambdaCaptureRecord {
+    parameter_names: string[];
+    captures: Capture[];
+}
+
+// Internal walk result. `free` is the set of identifier names
+// referenced in the walked subtree that are NOT bound by lets
+// inside the subtree. The caller subtracts its own bindings before
+// passing the result up, so by the time `free` reaches a lambda
+// boundary it reflects only names the lambda actually needs from
+// outside.
+struct CaptureWalkResult {
+    free: string[];
+    records: LambdaCaptureRecord[];
+}
+
+// Public entry point: walks every top-level statement in the
+// program and returns the inferred capture set for every lambda
+// reachable from the AST. Top-level `let` bindings are added to
+// the running scope so a lambda declared mid-file sees the
+// preceding bindings as candidates for capture.
+fn analyze_lambda_captures(program: Program) -> LambdaCaptureRecord[] {
+    let mut scope: LocalBinding[] = [];
+    let mut records: LambdaCaptureRecord[] = [];
+    let mut i: number = 0;
+    loop {
+        if i >= program.statements.length { break; }
+        let stmt = program.statements[i];
+        let result = walk_top_statement(scope, stmt);
+        records = append_records(records, result.records);
+        if stmt.variant == "VariableDeclaration" {
+            scope = append_binding(scope, binding_from_let(stmt));
+        }
+        i += 1;
+    }
+    return records;
+}
+
+fn walk_top_statement(scope: LocalBinding[], stmt: Statement) -> CaptureWalkResult {
+    if stmt.variant == "FunctionDeclaration" {
+        let inner_scope = extend_with_parameters(scope, stmt.signature.parameters);
+        return walk_block(inner_scope, stmt.body);
+    }
+    if stmt.variant == "TestDeclaration" {
+        return walk_block(scope, stmt.body);
+    }
+    if stmt.variant == "VariableDeclaration" {
+        if stmt.initializer == null { return empty_walk_result(); }
+        return walk_expression(scope, stmt.initializer);
+    }
+    if stmt.variant == "StructDeclaration" {
+        let mut records: LambdaCaptureRecord[] = [];
+        let mut i: number = 0;
+        loop {
+            if i >= stmt.methods.length { break; }
+            let method = stmt.methods[i];
+            let inner_scope = extend_with_parameters(scope, method.signature.parameters);
+            let result = walk_block(inner_scope, method.body);
+            records = append_records(records, result.records);
+            i += 1;
+        }
+        return CaptureWalkResult { free: [], records: records };
+    }
+    return empty_walk_result();
+}
+
+// Walk the statements of a block, threading lets into a local
+// scope as they appear so subsequent statements (and their
+// expressions) see them. The block subtracts its own locals from
+// the free-name set bubbling up — names a let inside the block
+// satisfies are not free at the block boundary.
+fn walk_block(scope: LocalBinding[], block: Block) -> CaptureWalkResult {
+    let mut free: string[] = [];
+    let mut local: LocalBinding[] = [];
+    let mut records: LambdaCaptureRecord[] = [];
+    let mut i: number = 0;
+    loop {
+        if i >= block.statements.length { break; }
+        let stmt = block.statements[i];
+        let inner_scope = concat_bindings(scope, local);
+        let result = walk_statement(inner_scope, stmt);
+        let local_names = binding_names(local);
+        let stmt_free = subtract_names(result.free, local_names);
+        free = union_names(free, stmt_free);
+        records = append_records(records, result.records);
+        if stmt.variant == "VariableDeclaration" {
+            local = append_binding(local, binding_from_let(stmt));
+        }
+        i += 1;
+    }
+    return CaptureWalkResult { free: free, records: records };
+}
+
+fn walk_statement(scope: LocalBinding[], stmt: Statement) -> CaptureWalkResult {
+    if stmt.variant == "VariableDeclaration" {
+        if stmt.initializer == null { return empty_walk_result(); }
+        return walk_expression(scope, stmt.initializer);
+    }
+    if stmt.variant == "ExpressionStatement" {
+        return walk_expression(scope, stmt.expression);
+    }
+    if stmt.variant == "ReturnStatement" {
+        if stmt.expression == null { return empty_walk_result(); }
+        return walk_expression(scope, stmt.expression);
+    }
+    if stmt.variant == "ThrowStatement" {
+        return walk_expression(scope, stmt.expression);
+    }
+    if stmt.variant == "BlockStatement" {
+        return walk_block(scope, stmt.body);
+    }
+    if stmt.variant == "IfStatement" {
+        let mut result = walk_expression(scope, stmt.condition);
+        result = merge_results(result, walk_block(scope, stmt.then_block));
+        if stmt.else_branch != null {
+            let branch = stmt.else_branch;
+            if branch.body != null {
+                result = merge_results(result, walk_block(scope, branch.body));
+            }
+            if branch.statement != null {
+                result = merge_results(result, walk_statement(scope, branch.statement));
+            }
+        }
+        return result;
+    }
+    if stmt.variant == "ForStatement" {
+        let mut result = walk_expression(scope, stmt.clause.iterable);
+        result = merge_results(result, walk_expression(scope, stmt.clause.target));
+        let inner_scope = extend_with_for_target(scope, stmt.clause.target);
+        result = merge_results(result, walk_block(inner_scope, stmt.body));
+        // The for-target binding is local to the loop body; subtract
+        // its name from the bubbled-up free set so the enclosing
+        // scope doesn't see it as a capture candidate.
+        let target_name = for_target_name(stmt.clause.target);
+        if target_name.length > 0 {
+            let mut excluded: string[] = [target_name];
+            return CaptureWalkResult {
+                free: subtract_names(result.free, excluded),
+                records: result.records
+            };
+        }
+        return result;
+    }
+    if stmt.variant == "LoopStatement" {
+        return walk_block(scope, stmt.body);
+    }
+    if stmt.variant == "MatchStatement" {
+        let mut result = walk_expression(scope, stmt.expression);
+        let mut i: number = 0;
+        loop {
+            if i >= stmt.cases.length { break; }
+            let case = stmt.cases[i];
+            result = merge_results(result, walk_expression(scope, case.pattern));
+            if case.guard != null {
+                result = merge_results(result, walk_expression(scope, case.guard));
+            }
+            result = merge_results(result, walk_block(scope, case.body));
+            i += 1;
+        }
+        return result;
+    }
+    if stmt.variant == "WithStatement" {
+        let mut result = walk_block(scope, stmt.body);
+        let mut i: number = 0;
+        loop {
+            if i >= stmt.clauses.length { break; }
+            result = merge_results(result, walk_expression(scope, stmt.clauses[i].expression));
+            i += 1;
+        }
+        return result;
+    }
+    if stmt.variant == "TryStatement" {
+        let mut result = walk_block(scope, stmt.try_block);
+        if stmt.catch_block != null {
+            result = merge_results(result, walk_block(scope, stmt.catch_block));
+        }
+        if stmt.finally_block != null {
+            result = merge_results(result, walk_block(scope, stmt.finally_block));
+        }
+        return result;
+    }
+    if stmt.variant == "FunctionDeclaration" {
+        let inner_scope = extend_with_parameters(scope, stmt.signature.parameters);
+        return walk_block(inner_scope, stmt.body);
+    }
+    return empty_walk_result();
+}
+
+fn walk_expression(scope: LocalBinding[], expression: Expression?) -> CaptureWalkResult {
+    if expression == null { return empty_walk_result(); }
+    if expression.variant == "Identifier" {
+        let mut names: string[] = [];
+        names.push(expression.name);
+        return CaptureWalkResult { free: names, records: [] };
+    }
+    if expression.variant == "NumberLiteral" { return empty_walk_result(); }
+    if expression.variant == "StringLiteral" { return empty_walk_result(); }
+    if expression.variant == "BooleanLiteral" { return empty_walk_result(); }
+    if expression.variant == "NullLiteral" { return empty_walk_result(); }
+    if expression.variant == "Raw" { return empty_walk_result(); }
+    if expression.variant == "Unary" {
+        return walk_expression(scope, expression.operand);
+    }
+    if expression.variant == "Binary" {
+        let left = walk_expression(scope, expression.left);
+        let right = walk_expression(scope, expression.right);
+        return merge_results(left, right);
+    }
+    if expression.variant == "Member" {
+        return walk_expression(scope, expression.object);
+    }
+    if expression.variant == "Index" {
+        let seq = walk_expression(scope, expression.sequence);
+        let idx = walk_expression(scope, expression.index);
+        return merge_results(seq, idx);
+    }
+    if expression.variant == "Range" {
+        let start = walk_expression(scope, expression.start);
+        let end = walk_expression(scope, expression.end);
+        return merge_results(start, end);
+    }
+    if expression.variant == "Cast" {
+        return walk_expression(scope, expression.operand);
+    }
+    if expression.variant == "Call" {
+        let mut result = walk_expression(scope, expression.callee);
+        let mut i: number = 0;
+        loop {
+            if i >= expression.arguments.length { break; }
+            result = merge_results(result, walk_expression(scope, expression.arguments[i]));
+            i += 1;
+        }
+        return result;
+    }
+    if expression.variant == "Array" {
+        let mut result = empty_walk_result();
+        let mut i: number = 0;
+        loop {
+            if i >= expression.elements.length { break; }
+            result = merge_results(result, walk_expression(scope, expression.elements[i]));
+            i += 1;
+        }
+        return result;
+    }
+    if expression.variant == "Object" {
+        let mut result = empty_walk_result();
+        let mut i: number = 0;
+        loop {
+            if i >= expression.fields.length { break; }
+            result = merge_results(result, walk_expression(scope, expression.fields[i].value));
+            i += 1;
+        }
+        return result;
+    }
+    if expression.variant == "Struct" {
+        let mut result = empty_walk_result();
+        let mut i: number = 0;
+        loop {
+            if i >= expression.fields.length { break; }
+            result = merge_results(result, walk_expression(scope, expression.fields[i].value));
+            i += 1;
+        }
+        return result;
+    }
+    if expression.variant == "Lambda" {
+        return analyze_lambda(scope, expression);
+    }
+    return empty_walk_result();
+}
+
+// Compute one lambda's capture set and return the lambda's own
+// free-name contribution to the enclosing scope. The lambda's
+// record is appended ahead of any nested-lambda records so the
+// pre-order property holds.
+//
+// Lambda bodies arrive with `body.statements == []` because the
+// expression-side `parse_block_for_lambda` only collects raw tokens
+// (the comment in the parser says the structural pass "will be in
+// statements.sfn" — it never landed). Re-parse the body's tokens
+// through the real `parse_block` here so we can walk structured
+// statements; without this every lambda body would look empty and
+// every reference to an outer name would be invisible. Stage A2
+// will need the same shape and may eventually push this re-parse
+// into the parser, retiring the workaround.
+fn analyze_lambda(outer_scope: LocalBinding[], lambda: Expression) -> CaptureWalkResult {
+    let body_parser = Parser { tokens: lambda.body.tokens, index: 0 };
+    let parsed_block_result = parse_block(body_parser);
+    let parsed_body = parsed_block_result.block;
+
+    let inner_scope = extend_with_parameters(outer_scope, lambda.parameters);
+    let body_result = walk_block(inner_scope, parsed_body);
+
+    let param_names = parameter_names(lambda.parameters);
+    let lambda_free = subtract_names(body_result.free, param_names);
+    let captures = build_captures(outer_scope, lambda_free);
+
+    let mut records: LambdaCaptureRecord[] = [];
+    records.push(LambdaCaptureRecord {
+        parameter_names: param_names, captures: captures
+    });
+    records = append_records(records, body_result.records);
+    return CaptureWalkResult { free: lambda_free, records: records };
+}
+
+// ----- Capture construction & scope helpers -----
+fn build_captures(outer_scope: LocalBinding[], free_names: string[]) -> Capture[] {
+    let mut captures: Capture[] = [];
+    let mut i: number = 0;
+    loop {
+        if i >= free_names.length { break; }
+        let name = free_names[i];
+        let binding = find_binding(outer_scope, name);
+        if binding != null {
+            captures.push(Capture {
+                name: binding.name, type_text: binding.type_text, by_value: binding.by_value, mutable: binding.mutable, span: binding.span
+            });
+        }
+        i += 1;
+    }
+    return captures;
+}
+
+fn find_binding(scope: LocalBinding[], name: string) -> LocalBinding? {
+    let mut found: LocalBinding? = null;
+    let mut i: number = 0;
+    loop {
+        if i >= scope.length { break; }
+        if strings_equal(scope[i].name, name) { found = scope[i]; }
+        i += 1;
+    }
+    return found;
+}
+
+fn binding_from_parameter(p: Parameter) -> LocalBinding {
+    let type_text = type_annotation_text(p.type_annotation);
+    return LocalBinding {
+        name: p.name,
+        type_text: type_text,
+        by_value: is_primitive_type(type_text),
+        mutable: p.mutable,
+        span: p.span
+    };
+}
+
+fn binding_from_let(stmt: Statement) -> LocalBinding {
+    let type_text = type_annotation_text(stmt.type_annotation);
+    return LocalBinding {
+        name: stmt.name,
+        type_text: type_text,
+        by_value: is_primitive_type(type_text),
+        mutable: stmt.mutable,
+        span: stmt.span
+    };
+}
+
+fn extend_with_parameters(scope: LocalBinding[], parameters: Parameter[]) -> LocalBinding[] {
+    let mut out: LocalBinding[] = [];
+    let mut i: number = 0;
+    loop {
+        if i >= scope.length { break; }
+        out.push(scope[i]);
+        i += 1;
+    }
+    let mut j: number = 0;
+    loop {
+        if j >= parameters.length { break; }
+        out.push(binding_from_parameter(parameters[j]));
+        j += 1;
+    }
+    return out;
+}
+
+fn extend_with_for_target(scope: LocalBinding[], target: Expression) -> LocalBinding[] {
+    let mut out: LocalBinding[] = [];
+    let mut i: number = 0;
+    loop {
+        if i >= scope.length { break; }
+        out.push(scope[i]);
+        i += 1;
+    }
+    let target_name = for_target_name(target);
+    if target_name.length > 0 {
+        out.push(LocalBinding {
+            name: target_name, type_text: "", by_value: false, mutable: false, span: null
+        });
+    }
+    return out;
+}
+
+fn for_target_name(target: Expression) -> string {
+    if target.variant == "Identifier" { return target.name; }
+    return "";
+}
+
+fn append_binding(scope: LocalBinding[], binding: LocalBinding) -> LocalBinding[] {
+    let mut out: LocalBinding[] = [];
+    let mut i: number = 0;
+    loop {
+        if i >= scope.length { break; }
+        out.push(scope[i]);
+        i += 1;
+    }
+    out.push(binding);
+    return out;
+}
+
+fn concat_bindings(a: LocalBinding[], b: LocalBinding[]) -> LocalBinding[] {
+    let mut out: LocalBinding[] = [];
+    let mut i: number = 0;
+    loop {
+        if i >= a.length { break; }
+        out.push(a[i]);
+        i += 1;
+    }
+    let mut j: number = 0;
+    loop {
+        if j >= b.length { break; }
+        out.push(b[j]);
+        j += 1;
+    }
+    return out;
+}
+
+fn binding_names(bindings: LocalBinding[]) -> string[] {
+    let mut out: string[] = [];
+    let mut i: number = 0;
+    loop {
+        if i >= bindings.length { break; }
+        out.push(bindings[i].name);
+        i += 1;
+    }
+    return out;
+}
+
+fn parameter_names(parameters: Parameter[]) -> string[] {
+    let mut out: string[] = [];
+    let mut i: number = 0;
+    loop {
+        if i >= parameters.length { break; }
+        out.push(parameters[i].name);
+        i += 1;
+    }
+    return out;
+}
+
+fn type_annotation_text(annotation: TypeAnnotation?) -> string {
+    if annotation == null { return ""; }
+    return annotation.text;
+}
+
+// Stage 1 heuristic for `by_value`: types we know are primitive
+// (and therefore safe to copy) emit `by_value: true`; everything
+// else (arrays, struct types, function types, unknowns) emits
+// `by_value: false` so stage A2 will reach for a heap-pointer
+// slot. The list deliberately includes `string` even though it
+// allocates — stage A2 will treat it as a copy-on-capture
+// reference; the unit test pinning the heuristic should be
+// updated alongside this list when stage A2 lands.
+fn is_primitive_type(type_text: string) -> boolean {
+    if strings_equal(type_text, "number") { return true; }
+    if strings_equal(type_text, "boolean") { return true; }
+    if strings_equal(type_text, "int") { return true; }
+    if strings_equal(type_text, "float") { return true; }
+    if strings_equal(type_text, "string") { return true; }
+    return false;
+}
+
+// ----- list / set helpers -----
+fn empty_walk_result() -> CaptureWalkResult {
+    return CaptureWalkResult { free: [], records: [] };
+}
+
+fn merge_results(a: CaptureWalkResult, b: CaptureWalkResult) -> CaptureWalkResult {
+    return CaptureWalkResult {
+        free: union_names(a.free, b.free),
+        records: append_records(a.records, b.records)
+    };
+}
+
+fn union_names(a: string[], b: string[]) -> string[] {
+    let mut out: string[] = [];
+    let mut i: number = 0;
+    loop {
+        if i >= a.length { break; }
+        out.push(a[i]);
+        i += 1;
+    }
+    let mut j: number = 0;
+    loop {
+        if j >= b.length { break; }
+        if !contains_name(out, b[j]) { out.push(b[j]); }
+        j += 1;
+    }
+    return out;
+}
+
+fn subtract_names(names: string[], exclude: string[]) -> string[] {
+    let mut out: string[] = [];
+    let mut i: number = 0;
+    loop {
+        if i >= names.length { break; }
+        if !contains_name(exclude, names[i]) { out.push(names[i]); }
+        i += 1;
+    }
+    return out;
+}
+
+fn contains_name(names: string[], name: string) -> boolean {
+    let mut i: number = 0;
+    loop {
+        if i >= names.length { break; }
+        if strings_equal(names[i], name) { return true; }
+        i += 1;
+    }
+    return false;
+}
+
+fn append_records(a: LambdaCaptureRecord[], b: LambdaCaptureRecord[]) -> LambdaCaptureRecord[] {
+    let mut out: LambdaCaptureRecord[] = [];
+    let mut i: number = 0;
+    loop {
+        if i >= a.length { break; }
+        out.push(a[i]);
+        i += 1;
+    }
+    let mut j: number = 0;
+    loop {
+        if j >= b.length { break; }
+        out.push(b[j]);
+        j += 1;
+    }
+    return out;
+}

--- a/compiler/tests/unit/typecheck_lambda_capture_test.sfn
+++ b/compiler/tests/unit/typecheck_lambda_capture_test.sfn
@@ -1,0 +1,209 @@
+// Unit tests for lambda capture-set inference (issue #458, A1 of
+// #450 M1.5 closures-with-capture). Pin the deterministic, ordered
+// capture sets the typechecker emits per `Expression.Lambda`. Stage
+// A2 will read the same shape to allocate env structs; stage A3
+// will dispatch indirect calls — both rely on the per-lambda
+// records exposed here, so regressions in inference must surface as
+// test failures before downstream emission breaks.
+//
+// Sources use top-level `let` and `return`-expression positions
+// because those parse paths produce structured `Expression.Lambda`
+// nodes today. Block-scoped `let` is currently parsed into
+// `ExpressionStatement(Raw)`, so a lambda buried inside one is
+// invisible to this walk; the capture analysis will pick it up
+// automatically once the parser lifts block-`let` to
+// `VariableDeclaration`. Don't rely on block-let in these tests
+// until that lands.
+import { parse_program } from "../../src/parser/mod";
+import { LambdaCaptureRecord, analyze_lambda_captures } from "../../src/typecheck_captures";
+
+fn _has_capture(record: LambdaCaptureRecord, name: string) -> boolean {
+    let mut i: number = 0;
+    loop {
+        if i >= record.captures.length { break; }
+        if strings_equal(record.captures[i].name, name) { return true; }
+        i += 1;
+    }
+    return false;
+}
+
+// -------------------------------------------------------------------
+// Baseline — non-capturing lambdas must record an empty capture set.
+// Acceptance criterion: existing lambda tests still pass / no
+// regression for lambdas without free variables.
+// -------------------------------------------------------------------
+test "captures: empty body produces no captures" {
+    let source = "let f = fn() -> number { return 0; };";
+    let program = parse_program(source);
+    let records = analyze_lambda_captures(program);
+    assert records.length == 1;
+    assert records[0].captures.length == 0;
+    assert records[0].parameter_names.length == 0;
+}
+
+test "captures: lambda referencing only its parameter produces no captures" {
+    let source = "let inc = fn(x: number) -> number { return x; };";
+    let program = parse_program(source);
+    let records = analyze_lambda_captures(program);
+    assert records.length == 1;
+    assert records[0].captures.length == 0;
+    assert records[0].parameter_names.length == 1;
+    assert strings_equal(records[0].parameter_names[0], "x");
+}
+
+test "captures: top-level function reference is not a capture" {
+    // `helper` is a top-level fn, not a let-binding, so referencing
+    // it from a lambda body must not register as a capture — stage A2
+    // resolves named functions through the module symbol table, not
+    // through the env struct.
+    let source = "fn helper() -> number { return 1; } let f = fn() -> number { return helper(); };";
+    let program = parse_program(source);
+    let records = analyze_lambda_captures(program);
+    assert records.length == 1;
+    assert records[0].captures.length == 0;
+}
+
+// -------------------------------------------------------------------
+// Simple capture — the bread and butter case; one let in the
+// enclosing scope, one identifier reference inside the lambda body,
+// one Capture with the binding's annotation echoed back.
+// -------------------------------------------------------------------
+test "captures: lambda captures a single enclosing let-binding" {
+    let source = "let x: number = 1; let f = fn() -> number { return x; };";
+    let program = parse_program(source);
+    let records = analyze_lambda_captures(program);
+    assert records.length == 1;
+    assert records[0].captures.length == 1;
+    assert strings_equal(records[0].captures[0].name, "x");
+    // `number` is on the by-value primitive list — stage A2 will
+    // inline-copy the value into the env struct.
+    assert records[0].captures[0].by_value;
+}
+
+test "captures: type annotation is echoed onto the Capture" {
+    let source = "let label: string = \"hi\"; let f = fn() -> string { return label; };";
+    let program = parse_program(source);
+    let records = analyze_lambda_captures(program);
+    assert records.length == 1;
+    assert records[0].captures.length == 1;
+    assert strings_equal(records[0].captures[0].type_text, "string");
+}
+
+test "captures: mutability of the enclosing binding is recorded" {
+    let source = "let mut counter: number = 0; let inc = fn() -> number { return counter; };";
+    let program = parse_program(source);
+    let records = analyze_lambda_captures(program);
+    assert records.length == 1;
+    assert records[0].captures.length == 1;
+    assert records[0].captures[0].mutable;
+}
+
+// -------------------------------------------------------------------
+// Parameter-vs-capture — a lambda parameter must shadow an outer
+// binding of the same name. Acceptance criterion calls this case
+// out by name.
+// -------------------------------------------------------------------
+test "captures: lambda parameter shadows enclosing let-binding" {
+    let source = "let x: number = 1; let f = fn(x: number) -> number { return x; };";
+    let program = parse_program(source);
+    let records = analyze_lambda_captures(program);
+    assert records.length == 1;
+    assert records[0].captures.length == 0;
+    assert records[0].parameter_names.length == 1;
+    assert strings_equal(records[0].parameter_names[0], "x");
+}
+
+// -------------------------------------------------------------------
+// Shadowed-name — a `let` declared inside the lambda body must
+// shadow an outer binding of the same name. Acceptance criterion.
+// (Block-scoped `let` parses to `ExpressionStatement(Raw)` today, so
+// the lambda body's local-let path can't be exercised end-to-end —
+// the shadowing case is exercised via parameter shadowing instead,
+// which is the same scoping rule applied at the parameter slot.)
+// -------------------------------------------------------------------
+test "captures: only outer-resolved free names become captures" {
+    // The lambda references `outer_val` (in scope) and `not_in_scope`
+    // (truly free — likely an imported helper or a typo). Only the
+    // resolved name lands in the capture set; truly-free names are
+    // elided so the env struct doesn't reserve a slot for them.
+    let source = "let outer_val: number = 42; let f = fn() -> number { return outer_val + not_in_scope; };";
+    let program = parse_program(source);
+    let records = analyze_lambda_captures(program);
+    assert records.length == 1;
+    assert records[0].captures.length == 1;
+    assert strings_equal(records[0].captures[0].name, "outer_val");
+}
+
+// -------------------------------------------------------------------
+// Nested-lambda — outer captures bubble through inner lambdas;
+// both records must see the same outer name. Acceptance criterion.
+// Use return-position lambdas because that path produces structured
+// AST through both layers.
+// -------------------------------------------------------------------
+test "captures: nested lambdas both capture an outer let" {
+    // The outer lambda returns the inner lambda directly (not via
+    // IIFE — the IIFE pattern is a separate-issue parser path that
+    // bites on the `;` inside the nested body). The inner lambda
+    // references `x`, which lives in the top-level scope. The walk
+    // must surface `x` on both records (the outer needs it to
+    // construct the inner's env at runtime).
+    let source = "let x: number = 1; let outer = fn() -> number { return fn() -> number { return x; }; };";
+    let program = parse_program(source);
+    let records = analyze_lambda_captures(program);
+    assert records.length == 2;
+    assert _has_capture(records[0], "x");
+    assert _has_capture(records[1], "x");
+}
+
+test "captures: nested lambda's parameter doesn't bleed into outer capture set" {
+    // Inner lambda takes `x` as a parameter; outer lambda doesn't
+    // reference `x` at all. The walk must NOT mark `x` as a capture
+    // on either lambda — the inner's parameter binds it locally and
+    // the outer never sees it.
+    let source = "let x: number = 1; let outer = fn() -> number { return fn(x: number) -> number { return x; }; };";
+    let program = parse_program(source);
+    let records = analyze_lambda_captures(program);
+    assert records.length == 2;
+    assert records[0].captures.length == 0;
+    assert records[1].captures.length == 0;
+    assert records[1].parameter_names.length == 1;
+    assert strings_equal(records[1].parameter_names[0], "x");
+}
+
+// -------------------------------------------------------------------
+// Determinism — capture order must match first-appearance order,
+// and duplicate references must collapse to a single Capture.
+// Stage A2 indexes by position in the env struct, so any reorder
+// is a soundness break.
+// -------------------------------------------------------------------
+test "captures: multiple captures preserve first-use order" {
+    let source = "let a: number = 1; let b: number = 2; let f = fn() -> number { return a + b; };";
+    let program = parse_program(source);
+    let records = analyze_lambda_captures(program);
+    assert records.length == 1;
+    assert records[0].captures.length == 2;
+    assert strings_equal(records[0].captures[0].name, "a");
+    assert strings_equal(records[0].captures[1].name, "b");
+}
+
+test "captures: repeated reference to same name produces one Capture" {
+    let source = "let x: number = 1; let f = fn() -> number { return x + x + x; };";
+    let program = parse_program(source);
+    let records = analyze_lambda_captures(program);
+    assert records.length == 1;
+    assert records[0].captures.length == 1;
+    assert strings_equal(records[0].captures[0].name, "x");
+}
+
+test "captures: capture order follows source-use order, not declaration order" {
+    // `b` declared before `a` in the let block, but the lambda body
+    // uses `a` first. Stage A2 wants source-use-order indexing so
+    // the test pins it explicitly.
+    let source = "let b: number = 2; let a: number = 1; let f = fn() -> number { return a + b; };";
+    let program = parse_program(source);
+    let records = analyze_lambda_captures(program);
+    assert records.length == 1;
+    assert records[0].captures.length == 2;
+    assert strings_equal(records[0].captures[0].name, "a");
+    assert strings_equal(records[0].captures[1].name, "b");
+}

--- a/compiler/tests/unit/typecheck_lambda_capture_test.sfn
+++ b/compiler/tests/unit/typecheck_lambda_capture_test.sfn
@@ -207,3 +207,74 @@ test "captures: capture order follows source-use order, not declaration order" {
     assert strings_equal(records[0].captures[0].name, "a");
     assert strings_equal(records[0].captures[1].name, "b");
 }
+
+// -------------------------------------------------------------------
+// Try / catch — the `catch (name)` identifier introduces a fresh
+// local binding visible only inside the catch block. A lambda
+// nested inside the catch must see the catch variable as locally
+// bound, not as a capture from the enclosing scope. Mirrors review
+// feedback on PR #512.
+// -------------------------------------------------------------------
+test "captures: catch-name shadows outer binding for lambdas inside catch" {
+    // Top-level `let err: number = 0` is in scope at the lambda
+    // site (annotated `: number`). The `catch (err) { ... }` handler
+    // re-binds `err` as a fresh local with no annotation. A lambda
+    // nested inside the catch must resolve its `err` reference
+    // against the catch handler — not the outer let — so the
+    // captured binding's `type_text` is empty (catch handlers don't
+    // carry type annotations) instead of `"number"` (which would
+    // signal the walk had punched through to the outer let).
+    let source = "let err: number = 0; fn run() -> number { try { return 0; } catch (err) { return fn() -> number { return err; }; } return 1; }";
+    let program = parse_program(source);
+    let records = analyze_lambda_captures(program);
+    assert records.length == 1;
+    assert records[0].captures.length == 1;
+    assert strings_equal(records[0].captures[0].name, "err");
+    // Empty type_text proves the capture resolved to the catch
+    // handler, not the outer `let err: number`. Without the catch-
+    // scope extension, the walk would echo `"number"` here.
+    assert strings_equal(records[0].captures[0].type_text, "");
+}
+
+// -------------------------------------------------------------------
+// Body-span identification — every record must carry the body's
+// opening `{` line/column so stage A2 can map its own `Expression
+// .Lambda` walk back to the inferred record without depending on
+// pre-order indexing alone. Mirrors review feedback on PR #512.
+// -------------------------------------------------------------------
+test "captures: record carries the body's opening-brace line and column" {
+    let source = "let f = fn() -> number { return 0; };";
+    let program = parse_program(source);
+    let records = analyze_lambda_captures(program);
+    assert records.length == 1;
+    // Body span is taken from the lambda body's opening `{` token.
+    // Line/column are positive 1-based integers; the precise column
+    // depends on the lexer's column-numbering scheme, so pin
+    // line == 1 (single-line source) and column != 0 (token has a
+    // location). Stage A2 will compute the same span the same way.
+    assert records[0].body_start_line == 1;
+    assert records[0].body_start_column != 0;
+}
+
+test "captures: nested lambdas carry distinct body-span identifiers" {
+    // Two lambdas with identical parameter shapes (both 0-arity)
+    // must still be distinguishable via body span — that's the
+    // point of carrying the identifier alongside `parameter_names`.
+    let source = "let x: number = 1; let outer = fn() -> number { return fn() -> number { return x; }; };";
+    let program = parse_program(source);
+    let records = analyze_lambda_captures(program);
+    assert records.length == 2;
+    let mut same_line: boolean = false;
+    if records[0].body_start_line == records[1].body_start_line {
+        same_line = true;
+    }
+    let mut same_column: boolean = false;
+    if records[0].body_start_column == records[1].body_start_column {
+        same_column = true;
+    }
+    let mut both_match: boolean = false;
+    if same_line {
+        if same_column { both_match = true; }
+    }
+    assert ! both_match;
+}


### PR DESCRIPTION
## Summary

- Adds `Expression.Lambda.captures: Capture[]` plus a `Capture` struct in `compiler/src/ast.sfn` carrying the enclosing binding's `type_text`, `mutable`, by-value/heap hint, and span — the metadata stage A2 (env-struct emit) and A3 (call-site dispatch) need.
- Implements a free-variable walk in new module `compiler/src/typecheck_captures.sfn` exposing `analyze_lambda_captures(program) -> LambdaCaptureRecord[]`. Records are emitted in pre-order; captures preserve first-use order.
- Adds 13 unit tests under `compiler/tests/unit/typecheck_lambda_capture_test.sfn` covering empty body, simple capture, type/mutability echo, parameter shadowing, nested lambdas, free-name elision, multi-capture order, and dedup.

Stage 1 of 3 for closures-with-capture (#450 M1.5). The analysis is purely structural — no AST mutation — so stage A2 can call `analyze_lambda_captures` directly when allocating env structs.

Closes #458

## Acceptance Criteria

- [x] Unit tests assert capture sets for nested-lambda, shadowed-name, and parameter-vs-capture cases.
- [x] Existing lambda tests still pass (no regression in non-capturing lambdas) — full unit (93/93) and integration (20/20) suites green.
- [x] `make compile` passes — self-host build is clean.
- [x] `make test-unit` passes — 93/93.

## Verification

```bash
ulimit -v 8388608 && make compile        # built build/native/sailfin
ulimit -v 8388608 && build/native/sailfin test compiler/tests/unit/typecheck_lambda_capture_test.sfn
# RUN/PASS for 13 lambda-capture tests
ulimit -v 8388608 && make test-unit       # ═══ unit: 93/93 passed, 0 failed ═══
ulimit -v 8388608 && make test-integration # ═══ integration: 20/20 passed, 0 failed ═══
ulimit -v 8388608 && build/native/sailfin fmt --check \
    compiler/src/ast.sfn compiler/src/parser/expressions.sfn \
    compiler/src/typecheck_captures.sfn \
    compiler/tests/unit/typecheck_lambda_capture_test.sfn  # exit=0
```

## Files Changed

- `compiler/src/ast.sfn` — `Capture` struct + `captures` field appended last on `Expression.Lambda` so seed positional GEP indexing stays stable.
- `compiler/src/parser/expressions.sfn` — initialises empty `captures: []` on every parsed `Expression.Lambda`.
- `compiler/src/typecheck_captures.sfn` — new module with the walk; tests import directly.
- `compiler/tests/unit/typecheck_lambda_capture_test.sfn` — new unit suite.

## Notes for Stage A2 reviewers / follow-ups

- The walk re-parses lambda body tokens through `parse_block`. Today's expression-side `parse_block_for_lambda` only collects raw tokens (the comment in the parser says "the actual implementation will be in statements.sfn"). Lifting that into the real block parser is a follow-up that would let us drop the re-parse.
- Block-scoped `let` is currently parsed into `ExpressionStatement(Raw)`, so a lambda buried inside `fn main() { let f = fn(...) {...}; }` is invisible to this walk. Tests use top-level `let` and return-position lambdas to stay on structured paths. Once block-`let` is lifted to `VariableDeclaration`, the analysis picks it up with no changes.
- The "reject incompatible-mutability captures" requirement from the issue is recorded as Capture metadata (`mutable: boolean`) but the diagnostic itself is deferred to A2/A3 alongside the actual mutating-capture semantics — stage 1 has no surface where mutation can happen, so emitting the diagnostic now would be premature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EAFXM5wnY6z7hK2KcY3fPe)_