### PR TITLE
chore(release): add release-tracking labels + tracking-issue convention

### DIFF
--- a/.claude/commands/pin-seed.md
+++ b/.claude/commands/pin-seed.md
@@ -1,0 +1,233 @@
+# Pin the Seed Version
+
+Open a PR bumping `.seed-version` (the repo-root pin file consumed by
+`make fetch-seed`, `ci.yml`, `nightly-selfhost.yml`, and
+`release-branches.yml`) to a newer Sailfin release.
+
+This is the **manual half** of the release loop. `/release` cuts a new
+alpha; `/pin-seed` adopts it as the build seed once the binary is
+uploaded. The two are deliberately separate — auto-pinning every
+release would force unnecessary CI recompiles. See
+`docs/conventions/issue-naming.md` "Seed pinning" for the convention.
+
+## Target: $ARGUMENTS
+
+Parse `$ARGUMENTS` as an optional target version (with or without
+leading `v`) plus optional flags:
+
+- `--dry-run` — print intended actions but don't write or push.
+
+If no version arg is given, pick the **most recently published release
+tag** (this is the most recent prerelease for the project; not the
+"latest stable" non-prerelease that `gh release view --json` would
+return).
+
+Examples:
+- `/pin-seed` — pin to the most recently published release
+- `/pin-seed v0.5.10-alpha.12` — pin to a specific version
+- `/pin-seed --dry-run` — preview only
+
+---
+
+## Phase 1: RESOLVE TARGET
+
+1. Read the current pin:
+   ```bash
+   cat .seed-version
+   ```
+2. If `$ARGUMENTS` provides a version, use it (strip leading `v`).
+   Otherwise, list recent releases and pick the most recent:
+   ```
+   mcp__github__list_releases owner=SailfinIO repo=sailfin perPage=5
+   ```
+   Take `items[0].tag_name`, strip the leading `v`. Do not use
+   `get_latest_release` — it returns only non-prereleases, which
+   doesn't match Sailfin's alpha cadence.
+3. Verify the target release has a binary uploaded. The release-tag
+   workflow (`release-tag.yml`) takes a few minutes after `release.yml`
+   finishes — check that the release has assets:
+   ```bash
+   gh release view "v<TARGET>" --json assets --jq '.assets | length'
+   ```
+   If 0 assets, `release-tag.yml` hasn't finished — abort with
+   "binaries not yet uploaded for v<TARGET>; retry once
+   release-tag.yml completes" and stop. Don't pin against a release
+   the seed-fetch can't actually download.
+4. If `target == current`: report no-op and stop.
+
+---
+
+## Phase 2: VERIFY THE SEED FETCHES
+
+Before opening the PR, confirm the target binary actually downloads:
+
+```bash
+ulimit -v 8388608
+SEED_VERSION="<target>" make fetch-seed
+```
+
+This is non-destructive — it installs into `build/seed/versions/` and
+doesn't touch `.seed-version`. If the fetch fails (404, checksum,
+network), abort. If it succeeds, the binary is on disk and we know the
+pin is valid.
+
+If `--dry-run`, skip this phase.
+
+---
+
+## Phase 3: GATHER CONTEXT FOR THE PR BODY
+
+1. **Closed `seed-blocker` issues since the last pin.** Use the
+   commit timestamp of the last `.seed-version` change as the
+   since-date:
+   ```bash
+   last_pin_at="$(git log -1 --format=%cI .seed-version)"
+   ```
+   Then:
+   ```
+   mcp__github__search_issues query='repo:SailfinIO/sailfin is:issue is:closed label:seed-blocker closed:>=<last_pin_at>'
+   ```
+   Surface the list — these are usually *why* the pin is being bumped.
+
+2. **Open `seed-blocker` issues.** Note them as "still open after this
+   pin" — they may be intentional (their fix lands in a future seed)
+   or accidental (the pin is being made before they close, in which
+   case ask the user to confirm).
+
+3. **Compare URL.** `https://github.com/SailfinIO/sailfin/compare/v<current>...v<target>`
+
+---
+
+## Phase 4: BRANCH AND COMMIT
+
+The pin commit lives off `main`, not the user's current `claude/*`
+working branch — pinning is its own concern, not piggybacked on a
+feature.
+
+```bash
+git fetch origin main
+git checkout -b chore/pin-seed-v<TARGET> origin/main
+```
+
+If the branch already exists locally, switch to it instead and rebase
+on origin/main.
+
+```bash
+echo "<TARGET>" > .seed-version
+git add .seed-version
+git commit -m "chore: bump seed to v<TARGET>"
+```
+
+If `--dry-run`, stop here without committing.
+
+---
+
+## Phase 5: PUSH AND OPEN PR
+
+```bash
+git push -u origin chore/pin-seed-v<TARGET>
+```
+
+Open the PR (draft):
+
+```
+mcp__github__create_pull_request
+  owner=SailfinIO repo=sailfin
+  head=chore/pin-seed-v<TARGET> base=main
+  title='chore: bump seed to v<TARGET>'
+  draft=true
+  body=<see template below>
+```
+
+PR body template:
+
+```markdown
+## Summary
+
+Bumps `.seed-version` from `<current>` → `<target>`.
+
+`make fetch-seed` was run locally against the target and succeeded —
+the binary downloads cleanly.
+
+## Closed `seed-blocker` issues since the last pin
+
+- #<N> — <title>
+- ...
+
+(or "None" if the search returned empty)
+
+## Still open after this pin
+
+- #<N> — <title> (`seed-blocker` open; intentional / will be addressed in a later seed)
+- ...
+
+## Comparison
+
+https://github.com/SailfinIO/sailfin/compare/v<current>...v<target>
+
+## Verification
+
+- [ ] `make fetch-seed` succeeded locally
+- [ ] CI green on this PR
+- [ ] (optional) `make compile` succeeds against the new seed locally
+
+https://claude.ai/code/session_<session-id>
+```
+
+---
+
+## Phase 6: SWITCH BACK
+
+After pushing, switch back to the user's prior branch so the rest of
+their session isn't on `chore/pin-seed-*`:
+
+```bash
+git checkout -
+```
+
+Report:
+- The PR URL
+- "Merge once CI is green; rebase your working branch onto `main`
+  afterwards to pick up the new seed."
+
+---
+
+## Constraints
+
+- **Never amend or force-push the pin commit.** If review feedback
+  comes in, add a follow-up commit on the branch.
+- **Never bump the pin to a version whose binary hasn't uploaded.**
+  This breaks `make fetch-seed` for everyone. Phase 1 step 3 enforces
+  this.
+- **Never auto-merge.** A human must review the pin — even a one-line
+  change to `.seed-version` cascades through CI, nightly self-host,
+  and the release-branches workflow.
+- **Don't bundle other changes.** The pin is its own PR. If the user
+  wants to drag in other fixes, they can rebase their feature branch
+  on top after merge.
+- **In `--dry-run`, make zero writes.** Print intended actions only;
+  no branch creation, no commits, no pushes, no PR.
+- **Don't pin from a `claude/*` branch onto itself.** Always branch
+  off `main`. The current branch is unaffected.
+
+---
+
+## When NOT to run /pin-seed
+
+- The new release is a routine alpha that fixes nothing the working
+  set needs.
+- A `seed-blocker` issue is still open and the pin would skip past it
+  without resolving (unless the user explicitly wants to defer).
+- `release-tag.yml` is still running for the target release — wait
+  for it.
+- The current pin is < 5 alphas behind and CI/nightly are green —
+  the pin is doing its job; don't churn it.
+
+## When to run /pin-seed
+
+- A `seed-blocker` issue just closed and the fix shipped in the latest
+  alpha.
+- Downstream work needs a feature/fix that landed in a recent alpha.
+- A `bump=patch` was just cut (almost always implies a hotfix-pin).
+- The pin is far enough behind `main` that nightly self-host shows
+  drift between seed and trunk.

--- a/.claude/commands/release-plan.md
+++ b/.claude/commands/release-plan.md
@@ -1,0 +1,220 @@
+# Plan a Release Cycle
+
+Open or sync the **tracking issue** for an upcoming release version.
+Idempotent — re-running the same version reconciles the checklist with
+current `release:*` label state.
+
+This is the open / curate phase of release management. The cut phase
+lives in `/release`. See `docs/conventions/issue-naming.md` "Release
+tracking" for the convention.
+
+## Target: $ARGUMENTS
+
+Parse `$ARGUMENTS` as a target version (with or without leading `v`)
+plus optional flags:
+
+- `--candidates` — also surface unlabeled issues that look like
+  candidates for the release (open epics in matching theme milestones,
+  `priority:high` items in the active focus issue's workstream).
+- `--dry-run` — print intended actions but make no changes.
+
+Examples:
+- `/release-plan v0.6.0` — open or sync `Release: v0.6.0`
+- `/release-plan 0.6.0 --candidates` — same plus a candidates list
+- `/release-plan v1.0.0 --dry-run` — preview only
+
+If `$ARGUMENTS` is empty: infer the target as the next minor of the
+current version in `compiler/capsule.toml` (e.g. `0.5.10-alpha.11` →
+`0.6.0`). Confirm with the user before proceeding.
+
+---
+
+## Phase 1: RESOLVE TARGET
+
+Parse `vX.Y.Z`. Map the version to the **gating label** it represents:
+
+| Target shape | Gating label |
+|---|---|
+| `vX.Y.0` where Y > current minor (next minor) | `release:next-minor` |
+| `v1.0.0` | `release:1.0` |
+| `vX.Y.Z` matching the active beta promotion | `release:beta` |
+| `vX.Y.Z` matching the active rc promotion | `release:rc` |
+| `vX.Y.Z` matching the active stable promotion | `release:stable` |
+
+If the version doesn't fit any of the above (e.g. a patch-line bump
+mid-cycle), there's no specific label gate; surface that and ask the
+user whether to proceed (most patch lines don't need a tracking issue).
+
+---
+
+## Phase 2: LOOK UP THE TRACKING ISSUE
+
+Search for an exact-title match:
+
+```
+mcp__github__search_issues query='repo:SailfinIO/sailfin is:issue in:title "Release: vX.Y.Z"'
+```
+
+- **Found** → switch to UPDATE mode (Phase 3b).
+- **Not found** → switch to CREATE mode (Phase 3a).
+
+---
+
+## Phase 3a: CREATE MODE
+
+If no tracking issue exists for the target:
+
+1. Pull every currently-open issue holding the gating label:
+
+   ```
+   mcp__github__search_issues query='repo:SailfinIO/sailfin is:open label:release:<gate>'
+   ```
+
+2. Compose the issue body:
+
+   ```markdown
+   ## Goal
+
+   Track what must close before **vX.Y.Z** is cut.
+
+   ## Scope summary
+
+   <one paragraph — ask the user to fill, or seed from the active focus
+   issue if one exists>
+
+   ## Must close before cut
+
+   - [ ] #<N> — <title>  (`release:<gate>`, size:_, priority:_)
+   - [ ] ...
+
+   ## Cut gate
+
+   This is a curated cut. `/release` will list every open item under
+   `release:<gate>` and require explicit override before dispatching.
+
+   ## Soft signals (non-blocking)
+
+   - Items under `release:<soft>` may roll forward to a later cycle.
+
+   ## Cross-references
+
+   - Convention: `docs/conventions/issue-naming.md` "Release tracking"
+   - Cut workflow: `.github/workflows/release.yml`
+   - `/release` skill: `.claude/commands/release.md`
+   ```
+
+3. Create the issue:
+
+   ```
+   mcp__github__issue_write title='Release: vX.Y.Z' labels=['tracking']
+   ```
+
+4. Report what was created with the issue URL.
+
+---
+
+## Phase 3b: UPDATE MODE
+
+If the tracking issue already exists:
+
+1. Read the current body. Parse the `## Must close before cut` section.
+   Extract every `- [ ] #N` and `- [x] #N` line.
+2. Pull the current open + recently-closed labeled set:
+
+   ```
+   mcp__github__search_issues query='repo:SailfinIO/sailfin label:release:<gate>'
+   ```
+
+3. Reconcile:
+   - **In body, now closed** → flip `- [ ]` to `- [x]`. Keep the line.
+   - **In body, no longer labeled, still open** → flag as drift, leave
+     the line, mention in the report. Don't auto-remove (human decision).
+   - **Newly labeled, missing from body** → append a new `- [ ]` line
+     under "Must close before cut".
+
+4. If anything changed, edit the body and post a summary comment:
+
+   ```
+   Auto-sync (release-plan):
+     ✓ ticked N items as closed (#A, #B)
+     + added N newly-labeled items (#C, #D)
+     ⚠ N drift items (in checklist but no longer labeled): #E
+   ```
+
+5. If nothing changed, no edit and no comment — just report.
+
+---
+
+## Phase 4: CANDIDATES MODE (optional, when `--candidates` is set)
+
+Surface unlabeled issues that *might* belong on this release's gate:
+
+1. **From theme milestones.** For the active theme milestones (#6, #7,
+   #8, #10, plus any matching the gating label by topic), list
+   open epic issues without any `release:*` label.
+2. **From priority.** Open `priority:high` and `priority:critical`
+   issues without any `release:*` label.
+3. **From the focus issue.** If a `focus:approved` issue exists, its
+   workstream targets are likely candidates; list them.
+
+Print as "consider applying `release:<gate>`":
+
+```
+Candidates for release:<gate> (not currently labeled):
+  - #N — <title>  (rationale: open epic in milestone "M", priority:high)
+  - ...
+```
+
+**Don't auto-apply labels.** Recommendation only — the human decides.
+
+---
+
+## Phase 5: REPORT
+
+Concise summary:
+
+```
+Release Plan — vX.Y.Z (gate: release:<gate>)
+Tracking issue: <created | updated | unchanged> (#<N>)
+
+Must-close set:
+  Open:    N issues
+  Closed:  N items ticked
+  Drift:   N (review)
+
+Candidates (if --candidates):
+  ...
+
+Dry run: changes <previewed | applied>
+```
+
+---
+
+## Constraints
+
+- **Idempotent.** Running the command twice in a row should be a no-op.
+- **Only writes the tracking issue body, the `tracking` label, and
+  optional comments.** Never auto-applies `release:*` labels — that's
+  triage, not planning.
+- **Never closes issues.** Same convention as `/triage` and `/sweep`.
+- **One tracking issue per version.** If two exist with the same title,
+  surface the conflict and stop — don't pick one.
+- **In `--dry-run`, make zero writes.** Print intended actions only.
+- **Read `docs/conventions/issue-naming.md` "Release tracking" before
+  acting.** It's the source of truth for the gating-label table.
+
+---
+
+## Why this command exists
+
+`/release` cuts a release. `/release-plan` opens the cycle and keeps
+the tracking issue current as work flows. The two commands bookend
+the curated-release flow:
+
+```
+plan ──▶ curate (label, /sweep auto-tick) ──▶ /release
+```
+
+Without this command, opening a tracking issue is manual boilerplate
+and the checklist drifts. With it, planning is one command per cycle
+plus passive maintenance via `/sweep`.

--- a/.claude/commands/release-plan.md
+++ b/.claude/commands/release-plan.md
@@ -70,7 +70,14 @@ If no tracking issue exists for the target:
    mcp__github__search_issues query='repo:SailfinIO/sailfin is:open label:release:<gate>'
    ```
 
-2. Compose the issue body:
+2. Pull open `seed-blocker` issues — they often correlate with what
+   should ship in the same cycle:
+
+   ```
+   mcp__github__search_issues query='repo:SailfinIO/sailfin is:open label:seed-blocker'
+   ```
+
+3. Compose the issue body:
 
    ```markdown
    ## Goal
@@ -87,6 +94,11 @@ If no tracking issue exists for the target:
    - [ ] #<N> — <title>  (`release:<gate>`, size:_, priority:_)
    - [ ] ...
 
+   ## Seed blockers (must close before the next seed bump)
+
+   - [ ] #<N> — <title>  (`seed-blocker`)
+   - [ ] ...
+
    ## Cut gate
 
    This is a curated cut. `/release` will list every open item under
@@ -99,8 +111,10 @@ If no tracking issue exists for the target:
    ## Cross-references
 
    - Convention: `docs/conventions/issue-naming.md` "Release tracking"
+     and "Seed pinning"
    - Cut workflow: `.github/workflows/release.yml`
    - `/release` skill: `.claude/commands/release.md`
+   - `/pin-seed` skill: `.claude/commands/pin-seed.md`
    ```
 
 3. Create the issue:
@@ -117,20 +131,22 @@ If no tracking issue exists for the target:
 
 If the tracking issue already exists:
 
-1. Read the current body. Parse the `## Must close before cut` section.
-   Extract every `- [ ] #N` and `- [x] #N` line.
-2. Pull the current open + recently-closed labeled set:
+1. Read the current body. Parse both `## Must close before cut` and
+   `## Seed blockers` sections. Extract every `- [ ] #N` and `- [x] #N`
+   line in each.
+2. Pull the current sets:
 
    ```
    mcp__github__search_issues query='repo:SailfinIO/sailfin label:release:<gate>'
+   mcp__github__search_issues query='repo:SailfinIO/sailfin label:seed-blocker'
    ```
 
-3. Reconcile:
+3. Reconcile each section independently:
    - **In body, now closed** → flip `- [ ]` to `- [x]`. Keep the line.
    - **In body, no longer labeled, still open** → flag as drift, leave
      the line, mention in the report. Don't auto-remove (human decision).
    - **Newly labeled, missing from body** → append a new `- [ ]` line
-     under "Must close before cut".
+     under the matching section.
 
 4. If anything changed, edit the body and post a summary comment:
 

--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -13,27 +13,34 @@ The workflow accepts two inputs:
 - **channel**: `alpha` | `beta` | `rc` | `stable`
 - **bump**: `prerelease` | `patch` | `minor` | `major`
 
-## Release tracking (curated cuts)
+## Release tracking (curated vs uncurated cuts)
 
-Some cuts are **uncurated** — they take whatever happens to be on `main`:
+Exactly one combination is **uncurated** — it takes whatever is on `main`
+without any pre-flight checks:
 
-- `channel=alpha bump=prerelease` (the routine daily bump)
+- `channel=alpha bump=prerelease` (the routine daily alpha bump)
 
-Some cuts are **curated** — they gate on `release:*` labels and a tracking issue:
+**Every other combination is curated.** That includes any `bump=patch`,
+`bump=minor`, `bump=major`, and any channel that isn't `alpha` (i.e. any
+promotion to `beta`, `rc`, or `stable`).
 
-- Any `bump=minor` or `bump=major`
-- Any channel promotion: `alpha → beta`, `beta → rc`, `rc → stable`, anything to `stable`
+For curated cuts, look up the tracking issue titled exactly
+`Release: vX.Y.Z` (e.g. `Release: v0.6.0`) and check the matching
+`release:*` label set:
 
-For curated cuts, look for a tracking issue titled exactly
-`Release: vX.Y.Z` (e.g. `Release: v0.6.0`) and the matching `release:*` label
-set:
+| Curated cut | Hard gate label | Soft gate (mention but don't block) |
+|---|---|---|
+| `bump=patch` (any channel) | (none — confirm intent) | open `release:next-minor` items will roll forward to the next patch |
+| `bump=minor` (any channel) | `release:next-minor` | open `release:1.0` items |
+| `bump=major` | `release:1.0` (when target is 1.0.0) | — |
+| Promotion to `channel=beta` | `release:beta` | open `release:next-minor` items |
+| Promotion to `channel=rc` | `release:rc` | open `release:beta` items |
+| Promotion to `channel=stable` | `release:stable` | open `release:rc` items |
 
-| Cut | Label that must be empty (no open issues) |
-|---|---|
-| `bump=minor` (any channel) | `release:next-minor` |
-| `channel=beta` promotion | `release:beta` |
-| `channel=rc` promotion | `release:rc` |
-| `channel=stable` promotion (or any stable cut) | `release:stable` |
+A "hard gate" means: list every open issue holding the label and require
+explicit override before dispatch. A "soft gate" means: mention as context
+but don't ask twice. The gate is always advisory — the human can always
+override.
 
 See `docs/conventions/issue-naming.md` "Release tracking" for the convention.
 
@@ -68,17 +75,17 @@ Next:    X.Y.Z-channel.M
 
 ### 4. Run the release-tracking gate (curated cuts only)
 
-If the cut is curated (per the table above), do all of these before
-dispatching:
+If the cut is curated (per the table above — i.e. anything other than
+`channel=alpha bump=prerelease`), do all of these before dispatching:
 
-a. **List open issues holding the gating label.** Use the GitHub MCP tools:
+a. **List open issues holding the hard-gate label.** Use the GitHub MCP tools:
 
    ```
    mcp__github__search_issues query="repo:SailfinIO/sailfin is:open label:release:<gate>"
    ```
 
-   where `<gate>` is `next-minor` | `beta` | `rc` | `stable`. For a stable
-   promotion, also check `release:rc`. For 1.0, also check `release:1.0`.
+   where `<gate>` is `next-minor` | `beta` | `rc` | `stable` | `1.0`. Also
+   list the soft-gate label as advisory context (per the table above).
 
 b. **Look up the tracking issue.** Search for the exact title:
 

--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -13,46 +13,139 @@ The workflow accepts two inputs:
 - **channel**: `alpha` | `beta` | `rc` | `stable`
 - **bump**: `prerelease` | `patch` | `minor` | `major`
 
+## Release tracking (curated cuts)
+
+Some cuts are **uncurated** — they take whatever happens to be on `main`:
+
+- `channel=alpha bump=prerelease` (the routine daily bump)
+
+Some cuts are **curated** — they gate on `release:*` labels and a tracking issue:
+
+- Any `bump=minor` or `bump=major`
+- Any channel promotion: `alpha → beta`, `beta → rc`, `rc → stable`, anything to `stable`
+
+For curated cuts, look for a tracking issue titled exactly
+`Release: vX.Y.Z` (e.g. `Release: v0.6.0`) and the matching `release:*` label
+set:
+
+| Cut | Label that must be empty (no open issues) |
+|---|---|
+| `bump=minor` (any channel) | `release:next-minor` |
+| `channel=beta` promotion | `release:beta` |
+| `channel=rc` promotion | `release:rc` |
+| `channel=stable` promotion (or any stable cut) | `release:stable` |
+
+See `docs/conventions/issue-naming.md` "Release tracking" for the convention.
+
 ## What to do
 
-1. Read the current version from `compiler/capsule.toml`.
+### 1. Read the current version
 
-2. Ask the user what kind of release they want if not already clear from
-   context.  Common scenarios:
-   - "cut an alpha" → channel=alpha, bump=prerelease
-   - "new patch alpha" → channel=alpha, bump=patch
-   - "promote to beta" → channel=beta, bump=prerelease
-   - "promote to rc" → channel=rc, bump=prerelease
-   - "ship it" / "GA release" → channel=stable, bump=prerelease
-   - "minor release" → channel=alpha, bump=minor (or ask which channel)
+```bash
+sed -n 's/^version *= *"\([^"]*\)"/\1/p' compiler/capsule.toml
+```
 
-3. Show the user what the version transition will be:
+### 2. Confirm the user's intent
+
+Ask the user what kind of release they want if not already clear from
+context.  Common scenarios:
+- "cut an alpha" → `channel=alpha bump=prerelease` (uncurated)
+- "new patch alpha" → `channel=alpha bump=patch` (curated — `bump=patch`)
+- "promote to beta" → `channel=beta bump=prerelease` (curated — promotion)
+- "promote to rc" → `channel=rc bump=prerelease` (curated — promotion)
+- "ship it" / "GA release" → `channel=stable bump=prerelease` (curated — promotion)
+- "minor release" → `channel=alpha bump=minor` (curated — minor) or ask which channel
+
+### 3. Compute the target version
+
+Apply the version math from the workflow (see "Version math reference" below)
+to derive the target. State the transition explicitly:
+
+```
+Current: X.Y.Z-channel.N
+Next:    X.Y.Z-channel.M
+```
+
+### 4. Run the release-tracking gate (curated cuts only)
+
+If the cut is curated (per the table above), do all of these before
+dispatching:
+
+a. **List open issues holding the gating label.** Use the GitHub MCP tools:
+
    ```
-   Current: X.Y.Z-channel.N
-   Next:    X.Y.Z-channel.M
+   mcp__github__search_issues query="repo:SailfinIO/sailfin is:open label:release:<gate>"
    ```
 
-4. Once confirmed, dispatch the workflow:
-   ```bash
-   gh workflow run release.yml \
-     -f channel=<channel> \
-     -f bump=<bump>
+   where `<gate>` is `next-minor` | `beta` | `rc` | `stable`. For a stable
+   promotion, also check `release:rc`. For 1.0, also check `release:1.0`.
+
+b. **Look up the tracking issue.** Search for the exact title:
+
+   ```
+   mcp__github__search_issues query="repo:SailfinIO/sailfin is:issue in:title \"Release: v<X.Y.Z>\""
    ```
 
-   Or for a dry run first:
-   ```bash
-   gh workflow run release.yml \
-     -f channel=<channel> \
-     -f bump=<bump> \
-     -f dry_run=true
+   If the tracking issue exists, link it in the dispatch summary. If it
+   doesn't exist for a curated cut, point that out — usually it should.
+   Don't auto-create it; that's a human-or-`/groom` decision.
+
+c. **Surface the gap to the user.** Present a short list:
+
+   ```
+   Curated cut: vX.Y.Z (channel=<c> bump=<b>)
+   Tracking issue: Release: vX.Y.Z (#NNN)  [or: not found]
+   Open `release:<gate>` items (N):
+     - #NNN <title> (size:_, priority:_)
+     - ...
    ```
 
-5. After dispatching, let the user know:
-   - The workflow has been triggered
-   - They can monitor it at: https://github.com/SailfinIO/sailfin/actions/workflows/release.yml
-   - The release-notes agentic workflow will post a structured changelog
-     comment on the release once it's published (supplementing the
-     auto-generated notes)
+d. **Require explicit override if anything is open.** Ask the user:
+   "N items are still open under `release:<gate>`. Cut anyway, or wait?"
+   Do not dispatch unless the user explicitly says cut anyway. If they
+   wait, stop and surface the open list — don't try to fix anything.
+
+For uncurated cuts (`channel=alpha bump=prerelease`), skip the gate entirely
+and proceed to dispatch.
+
+### 5. Dispatch the workflow
+
+```bash
+gh workflow run release.yml \
+  -f channel=<channel> \
+  -f bump=<bump>
+```
+
+Or for a dry run first:
+```bash
+gh workflow run release.yml \
+  -f channel=<channel> \
+  -f bump=<bump> \
+  -f dry_run=true
+```
+
+### 6. After dispatching
+
+Tell the user:
+- The workflow has been triggered.
+- They can monitor it at: https://github.com/SailfinIO/sailfin/actions/workflows/release.yml
+- The release-notes agentic workflow (`release-notes.md`) will post a
+  structured changelog comment on the release once it's published.
+
+If a tracking issue exists for the target version and this cut is curated,
+post a brief comment on the tracking issue (use
+`mcp__github__add_issue_comment`):
+
+```
+Cutting **vX.Y.Z** now (channel=<c> bump=<b>).
+Workflow: <run URL once available>
+Compare: https://github.com/SailfinIO/sailfin/compare/<prev_tag>...v<X.Y.Z>
+```
+
+If the cut is `bump=minor` or any `channel=stable` promotion, also remind
+the user to consider closing the tracking issue once the release publishes
+successfully (the release-notes generator can do this in a follow-up; don't
+auto-close from the skill).
 
 ## Version math reference
 
@@ -77,3 +170,6 @@ Given current version `0.5.0-alpha.22`:
   `release-tag.yml` after the tag is created.
 - An agentic workflow (`release-notes.md`) generates structured release notes
   once the GitHub Release is published.
+- The release-tracking gate is intentionally a soft gate — `/release` will
+  list open items and ask, but never refuse to dispatch. The human always
+  has the final call.

--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -154,6 +154,29 @@ the user to consider closing the tracking issue once the release publishes
 successfully (the release-notes generator can do this in a follow-up; don't
 auto-close from the skill).
 
+### 7. Suggest `/pin-seed` if the cut warrants it
+
+After the dispatch summary, suggest running `/pin-seed` as a follow-up
+when **any** of these is true:
+
+- The cut is `bump=patch` (almost always implies a hotfix-pin).
+- A `seed-blocker` issue closed since the current `.seed-version` was
+  set:
+  ```bash
+  last_pin_at="$(git log -1 --format=%cI .seed-version)"
+  ```
+  ```
+  mcp__github__search_issues query='repo:SailfinIO/sailfin is:issue is:closed label:seed-blocker closed:>=<last_pin_at>'
+  ```
+- The cut is a non-alpha promotion (beta/rc/stable) — usually the
+  pin should advance to the promoted version.
+
+When suggesting, mention that `/pin-seed` should be run **after**
+`release-tag.yml` finishes uploading binaries (a few minutes), and
+that the pin is its own PR off `main` — not a piggyback on the cut
+commit. See `docs/conventions/issue-naming.md` "Seed pinning" for
+the convention.
+
 ## Version math reference
 
 Given current version `0.5.0-alpha.22`:

--- a/.claude/commands/sweep.md
+++ b/.claude/commands/sweep.md
@@ -110,15 +110,16 @@ For each issue in the `blocked` pool:
 ## Phase 2b: SYNC RELEASE TRACKING ISSUES
 
 If any of the issues newly closed by the anchor merges carries a
-`release:*` label, the corresponding `Release: vX.Y.Z` tracking issue
-needs its checklist updated. This is a passive sync — `/release-plan`
-is the active equivalent for cycle bookkeeping.
+`release:*` or `seed-blocker` label, the corresponding `Release: vX.Y.Z`
+tracking issue needs its checklist updated. This is a passive sync —
+`/release-plan` is the active equivalent for cycle bookkeeping.
 
 For each newly-closed issue:
 
 1. Get its labels:
    ```bash
-   gh issue view <N> --json labels --jq '.labels[].name' | grep '^release:'
+   gh issue view <N> --json labels --jq '.labels[].name' \
+     | grep -E '^(release:|seed-blocker$)'
    ```
 2. For each `release:<gate>` label found, locate the tracking issue:
    ```
@@ -127,19 +128,19 @@ For each newly-closed issue:
    Map `release:<gate>` to the matching tracking issue title — typically
    the one whose target version corresponds to the gate. If multiple
    match (e.g. an item gates both `release:beta` and `release:1.0`),
-   update each.
-3. Read the tracking issue body. In the `## Must close before cut`
-   section, find any `- [ ] #N — ...` line for the closed issue and
-   flip it to `- [x] #N — ...`. Leave everything else untouched.
+   update each. Tick the matching `## Must close before cut` line.
+3. For `seed-blocker`, tick the matching line in the `## Seed blockers`
+   section of the same tracking issue (if present). Also surface in
+   the report so the user knows a `/pin-seed` may be appropriate.
 4. Edit the body and post a one-line comment:
    ```
-   Auto-sweep: #<N> closed via PR #<M> — ticked.
+   Auto-sweep: #<N> closed via PR #<M> — ticked (release:<gate>, seed-blocker).
    ```
-5. If the closed issue isn't in the checklist, mention it in the report
+5. If the closed issue isn't in any checklist, mention it in the report
    under "Concerns" (likely means it was labeled after the tracking
    issue was created without `/release-plan` re-running).
 
-If no newly-closed issue carries a `release:*` label, skip this phase
+If no newly-closed issue carries either label, skip this phase
 entirely. **In `--dry-run`, make zero writes.**
 
 ---

--- a/.claude/commands/sweep.md
+++ b/.claude/commands/sweep.md
@@ -107,6 +107,43 @@ For each issue in the `blocked` pool:
 
 ---
 
+## Phase 2b: SYNC RELEASE TRACKING ISSUES
+
+If any of the issues newly closed by the anchor merges carries a
+`release:*` label, the corresponding `Release: vX.Y.Z` tracking issue
+needs its checklist updated. This is a passive sync — `/release-plan`
+is the active equivalent for cycle bookkeeping.
+
+For each newly-closed issue:
+
+1. Get its labels:
+   ```bash
+   gh issue view <N> --json labels --jq '.labels[].name' | grep '^release:'
+   ```
+2. For each `release:<gate>` label found, locate the tracking issue:
+   ```
+   mcp__github__search_issues query='repo:SailfinIO/sailfin is:issue in:title "Release: v" label:tracking'
+   ```
+   Map `release:<gate>` to the matching tracking issue title — typically
+   the one whose target version corresponds to the gate. If multiple
+   match (e.g. an item gates both `release:beta` and `release:1.0`),
+   update each.
+3. Read the tracking issue body. In the `## Must close before cut`
+   section, find any `- [ ] #N — ...` line for the closed issue and
+   flip it to `- [x] #N — ...`. Leave everything else untouched.
+4. Edit the body and post a one-line comment:
+   ```
+   Auto-sweep: #<N> closed via PR #<M> — ticked.
+   ```
+5. If the closed issue isn't in the checklist, mention it in the report
+   under "Concerns" (likely means it was labeled after the tracking
+   issue was created without `/release-plan` re-running).
+
+If no newly-closed issue carries a `release:*` label, skip this phase
+entirely. **In `--dry-run`, make zero writes.**
+
+---
+
 ## Phase 3: AUDIT CLAUDE-READY
 
 For each issue in the `claude-ready` pool:

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -164,6 +164,29 @@ labels:
     color: "b60205"
     description: "Must close before the next seed binary is cut"
 
+  # --- Release gating --------------------------------------------------
+  # Intent labels consumed by `/release`. Alpha→alpha prerelease bumps
+  # are uncurated and ignore these. The labels gate `bump=minor`
+  # cuts and any channel promotion (alpha→beta→rc→stable). One issue
+  # may carry multiple release:* labels (e.g. `release:beta` AND
+  # `release:1.0`). See docs/conventions/issue-naming.md "Release
+  # tracking".
+  - name: release:next-minor
+    color: "0e8a16"
+    description: "Must close before the next bump=minor cut (next 0.X.0)"
+  - name: release:beta
+    color: "0e8a16"
+    description: "Must close before the next promotion to channel=beta"
+  - name: release:rc
+    color: "0e8a16"
+    description: "Must close before the next promotion to channel=rc"
+  - name: release:stable
+    color: "0e8a16"
+    description: "Must close before the next promotion to channel=stable"
+  - name: release:1.0
+    color: "0e8a16"
+    description: "Must close before 1.0 GA (long-horizon gate)"
+
   # --- GitHub defaults we keep -----------------------------------------
   - name: good first issue
     color: "7057ff"

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -165,12 +165,14 @@ labels:
     description: "Must close before the next seed binary is cut"
 
   # --- Release gating --------------------------------------------------
-  # Intent labels consumed by `/release`. Alpha→alpha prerelease bumps
-  # are uncurated and ignore these. The labels gate `bump=minor`
-  # cuts and any channel promotion (alpha→beta→rc→stable). One issue
-  # may carry multiple release:* labels (e.g. `release:beta` AND
-  # `release:1.0`). See docs/conventions/issue-naming.md "Release
-  # tracking".
+  # Intent labels consumed by `/release`. The single uncurated combo is
+  # `channel=alpha bump=prerelease` (the routine daily alpha) — every
+  # other combination is curated and consults these labels:
+  #   * any `bump=patch` / `bump=minor` / `bump=major`
+  #   * any promotion to channel=beta / rc / stable
+  # One issue may carry multiple release:* labels (e.g. `release:beta`
+  # AND `release:1.0`). See docs/conventions/issue-naming.md
+  # "Release tracking".
   - name: release:next-minor
     color: "0e8a16"
     description: "Must close before the next bump=minor cut (next 0.X.0)"

--- a/.github/workflows/release-notes.lock.yml
+++ b/.github/workflows/release-notes.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"1e86de52f96c43231e93ab7f95717ecbb1262b85fcf666ccd6dd510f90326af2","compiler_version":"v0.72.1","strict":true,"agent_id":"claude","agent_model":"claude-haiku-4-5"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"6b63baf116a0b88c129f1a3ab010ad17cd3bdee273117ae258980def24cdacac","compiler_version":"v0.72.1","strict":true,"agent_id":"claude","agent_model":"claude-haiku-4-5"}
 # gh-aw-manifest: {"version":1,"secrets":["ANTHROPIC_API_KEY","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"34e114876b0b11c390a56381ad16ebd13914f8d5","version":"v4"},{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/setup-node","sha":"49933ea5288caeca8642d1e84afbd3f7d6820020","version":"v4"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"bc56a0cad2f450c562810785ef38649c04db812a","version":"v0.72.1"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.41"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.41"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.41"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -59,6 +59,7 @@ name: "Sailfin Release Notes Generator"
   release:
     types:
     - published
+  # roles: all # Roles processed as role check in pre-activation job
   workflow_dispatch:
     inputs:
       aw_context:
@@ -77,8 +78,6 @@ run-name: "Sailfin Release Notes Generator"
 
 jobs:
   activation:
-    needs: pre_activation
-    if: needs.pre_activation.outputs.activated == 'true'
     runs-on: ubuntu-slim
     permissions:
       actions: read
@@ -99,7 +98,6 @@ jobs:
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}
-          trace-id: ${{ needs.pre_activation.outputs.setup-trace-id }}
         env:
           GH_AW_SETUP_WORKFLOW_NAME: "Sailfin Release Notes Generator"
           GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/release-notes.lock.yml@${{ github.ref }}
@@ -195,20 +193,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_da52a69a643d5b60_EOF'
+          cat << 'GH_AW_PROMPT_09bde2b90533ee98_EOF'
           <system>
-          GH_AW_PROMPT_da52a69a643d5b60_EOF
+          GH_AW_PROMPT_09bde2b90533ee98_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_da52a69a643d5b60_EOF'
+          cat << 'GH_AW_PROMPT_09bde2b90533ee98_EOF'
           <safe-output-tools>
           Tools: add_comment, missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_da52a69a643d5b60_EOF
+          GH_AW_PROMPT_09bde2b90533ee98_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_da52a69a643d5b60_EOF'
+          cat << 'GH_AW_PROMPT_09bde2b90533ee98_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if __GH_AW_GITHUB_ACTOR__ }}
@@ -237,13 +235,13 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_da52a69a643d5b60_EOF
+          GH_AW_PROMPT_09bde2b90533ee98_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_da52a69a643d5b60_EOF'
+          cat << 'GH_AW_PROMPT_09bde2b90533ee98_EOF'
           </system>
           {{#runtime-import .github/workflows/shared/build-mcp-server.md}}
           {{#runtime-import .github/workflows/release-notes.md}}
-          GH_AW_PROMPT_da52a69a643d5b60_EOF
+          GH_AW_PROMPT_09bde2b90533ee98_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -271,7 +269,6 @@ jobs:
           GH_AW_GITHUB_RUN_ID: ${{ github.run_id }}
           GH_AW_GITHUB_WORKSPACE: ${{ github.workspace }}
           GH_AW_MCP_CLI_SERVERS_LIST: '- `safeoutputs` — run `safeoutputs --help` to see available tools'
-          GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED: ${{ needs.pre_activation.outputs.activated }}
         with:
           script: |
             const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
@@ -292,8 +289,7 @@ jobs:
                 GH_AW_GITHUB_REPOSITORY: process.env.GH_AW_GITHUB_REPOSITORY,
                 GH_AW_GITHUB_RUN_ID: process.env.GH_AW_GITHUB_RUN_ID,
                 GH_AW_GITHUB_WORKSPACE: process.env.GH_AW_GITHUB_WORKSPACE,
-                GH_AW_MCP_CLI_SERVERS_LIST: process.env.GH_AW_MCP_CLI_SERVERS_LIST,
-                GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED: process.env.GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED
+                GH_AW_MCP_CLI_SERVERS_LIST: process.env.GH_AW_MCP_CLI_SERVERS_LIST
               }
             });
       - name: Validate prompt placeholders
@@ -448,9 +444,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_189d33b39c0590dc_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_4bce466a3e9cbc93_EOF'
           {"add_comment":{"max":1},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_189d33b39c0590dc_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_4bce466a3e9cbc93_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -636,7 +632,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host --add-host host.docker.internal:127.0.0.1 --user '"${MCP_GATEWAY_UID}"':'"${MCP_GATEWAY_GID}"' --group-add '"${DOCKER_SOCK_GID}"' -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.3.6'
           
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_90374140ecef388d_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_ab434a1f742ad668_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -679,7 +675,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_90374140ecef388d_EOF
+          GH_AW_MCP_CONFIG_ab434a1f742ad668_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1289,36 +1285,6 @@ jobs:
                 core.setFailed(msg);
               }
             }
-
-  pre_activation:
-    runs-on: ubuntu-slim
-    outputs:
-      activated: ${{ steps.check_membership.outputs.is_team_member == 'true' }}
-      matched_command: ''
-      setup-trace-id: ${{ steps.setup.outputs.trace-id }}
-    steps:
-      - name: Setup Scripts
-        id: setup
-        uses: github/gh-aw-actions/setup@bc56a0cad2f450c562810785ef38649c04db812a # v0.72.1
-        with:
-          destination: ${{ runner.temp }}/gh-aw/actions
-          job-name: ${{ github.job }}
-        env:
-          GH_AW_SETUP_WORKFLOW_NAME: "Sailfin Release Notes Generator"
-          GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/release-notes.lock.yml@${{ github.ref }}
-          GH_AW_INFO_VERSION: "2.1.126"
-      - name: Check team membership for workflow
-        id: check_membership
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        env:
-          GH_AW_REQUIRED_ROLES: "admin,maintainer,write"
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
-            setupGlobals(core, github, context, exec, io, getOctokit);
-            const { main } = require('${{ runner.temp }}/gh-aw/actions/check_membership.cjs');
-            await main();
 
   safe_outputs:
     needs:

--- a/.github/workflows/release-notes.lock.yml
+++ b/.github/workflows/release-notes.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"5712f722952c21229de70bbfa735962f08a391348dcd3b6d512c55d77521954a","compiler_version":"v0.72.1","strict":true,"agent_id":"claude","agent_model":"claude-haiku-4-5"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"1e86de52f96c43231e93ab7f95717ecbb1262b85fcf666ccd6dd510f90326af2","compiler_version":"v0.72.1","strict":true,"agent_id":"claude","agent_model":"claude-haiku-4-5"}
 # gh-aw-manifest: {"version":1,"secrets":["ANTHROPIC_API_KEY","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"34e114876b0b11c390a56381ad16ebd13914f8d5","version":"v4"},{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/setup-node","sha":"49933ea5288caeca8642d1e84afbd3f7d6820020","version":"v4"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"bc56a0cad2f450c562810785ef38649c04db812a","version":"v0.72.1"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.41"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.41"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.41"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -56,6 +56,9 @@
 
 name: "Sailfin Release Notes Generator"
 "on":
+  release:
+    types:
+    - published
   workflow_dispatch:
     inputs:
       aw_context:
@@ -74,6 +77,8 @@ run-name: "Sailfin Release Notes Generator"
 
 jobs:
   activation:
+    needs: pre_activation
+    if: needs.pre_activation.outputs.activated == 'true'
     runs-on: ubuntu-slim
     permissions:
       actions: read
@@ -94,6 +99,7 @@ jobs:
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}
+          trace-id: ${{ needs.pre_activation.outputs.setup-trace-id }}
         env:
           GH_AW_SETUP_WORKFLOW_NAME: "Sailfin Release Notes Generator"
           GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/release-notes.lock.yml@${{ github.ref }}
@@ -189,20 +195,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_371fe36c631470df_EOF'
+          cat << 'GH_AW_PROMPT_da52a69a643d5b60_EOF'
           <system>
-          GH_AW_PROMPT_371fe36c631470df_EOF
+          GH_AW_PROMPT_da52a69a643d5b60_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_371fe36c631470df_EOF'
+          cat << 'GH_AW_PROMPT_da52a69a643d5b60_EOF'
           <safe-output-tools>
           Tools: add_comment, missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_371fe36c631470df_EOF
+          GH_AW_PROMPT_da52a69a643d5b60_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_371fe36c631470df_EOF'
+          cat << 'GH_AW_PROMPT_da52a69a643d5b60_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if __GH_AW_GITHUB_ACTOR__ }}
@@ -231,13 +237,13 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_371fe36c631470df_EOF
+          GH_AW_PROMPT_da52a69a643d5b60_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_371fe36c631470df_EOF'
+          cat << 'GH_AW_PROMPT_da52a69a643d5b60_EOF'
           </system>
           {{#runtime-import .github/workflows/shared/build-mcp-server.md}}
           {{#runtime-import .github/workflows/release-notes.md}}
-          GH_AW_PROMPT_371fe36c631470df_EOF
+          GH_AW_PROMPT_da52a69a643d5b60_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -265,6 +271,7 @@ jobs:
           GH_AW_GITHUB_RUN_ID: ${{ github.run_id }}
           GH_AW_GITHUB_WORKSPACE: ${{ github.workspace }}
           GH_AW_MCP_CLI_SERVERS_LIST: '- `safeoutputs` — run `safeoutputs --help` to see available tools'
+          GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED: ${{ needs.pre_activation.outputs.activated }}
         with:
           script: |
             const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
@@ -285,7 +292,8 @@ jobs:
                 GH_AW_GITHUB_REPOSITORY: process.env.GH_AW_GITHUB_REPOSITORY,
                 GH_AW_GITHUB_RUN_ID: process.env.GH_AW_GITHUB_RUN_ID,
                 GH_AW_GITHUB_WORKSPACE: process.env.GH_AW_GITHUB_WORKSPACE,
-                GH_AW_MCP_CLI_SERVERS_LIST: process.env.GH_AW_MCP_CLI_SERVERS_LIST
+                GH_AW_MCP_CLI_SERVERS_LIST: process.env.GH_AW_MCP_CLI_SERVERS_LIST,
+                GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED: process.env.GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED
               }
             });
       - name: Validate prompt placeholders
@@ -322,6 +330,8 @@ jobs:
       contents: read
       issues: read
       pull-requests: read
+    concurrency:
+      group: "gh-aw-claude-${{ github.workflow }}"
     env:
       DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
       GH_AW_ASSETS_ALLOWED_EXTS: ""
@@ -438,9 +448,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_d6c905cb789ed696_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_189d33b39c0590dc_EOF'
           {"add_comment":{"max":1},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_d6c905cb789ed696_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_189d33b39c0590dc_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -626,7 +636,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host --add-host host.docker.internal:127.0.0.1 --user '"${MCP_GATEWAY_UID}"':'"${MCP_GATEWAY_GID}"' --group-add '"${DOCKER_SOCK_GID}"' -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.3.6'
           
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_7e693fc8b79047d9_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_90374140ecef388d_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -669,7 +679,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_7e693fc8b79047d9_EOF
+          GH_AW_MCP_CONFIG_90374140ecef388d_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1279,6 +1289,36 @@ jobs:
                 core.setFailed(msg);
               }
             }
+
+  pre_activation:
+    runs-on: ubuntu-slim
+    outputs:
+      activated: ${{ steps.check_membership.outputs.is_team_member == 'true' }}
+      matched_command: ''
+      setup-trace-id: ${{ steps.setup.outputs.trace-id }}
+    steps:
+      - name: Setup Scripts
+        id: setup
+        uses: github/gh-aw-actions/setup@bc56a0cad2f450c562810785ef38649c04db812a # v0.72.1
+        with:
+          destination: ${{ runner.temp }}/gh-aw/actions
+          job-name: ${{ github.job }}
+        env:
+          GH_AW_SETUP_WORKFLOW_NAME: "Sailfin Release Notes Generator"
+          GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/release-notes.lock.yml@${{ github.ref }}
+          GH_AW_INFO_VERSION: "2.1.126"
+      - name: Check team membership for workflow
+        id: check_membership
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          GH_AW_REQUIRED_ROLES: "admin,maintainer,write"
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
+            setupGlobals(core, github, context, exec, io, getOctokit);
+            const { main } = require('${{ runner.temp }}/gh-aw/actions/check_membership.cjs');
+            await main();
 
   safe_outputs:
     needs:

--- a/.github/workflows/release-notes.md
+++ b/.github/workflows/release-notes.md
@@ -7,10 +7,17 @@ description: |
 # Re-enabled 2026-05-09: release notes only fire on release publish, which
 # is at most a few times a day. Cost is bounded — Haiku summarizing a
 # day's worth of commits per release is the cheapest of the gh-aw set.
+#
+# `roles: all` skips gh-aw's default team-membership pre-check. The
+# release-publish trigger already requires write access to fire (releases
+# can't be created from forks), and the empty token gh-aw hands the
+# pre_activation job under `permissions: {}` would otherwise make the
+# membership check fail open-False and silently no-op the workflow.
 on:
   release:
     types: [published]
   workflow_dispatch:
+  roles: all
 
 imports:
   - shared/build-mcp-server.md

--- a/.github/workflows/release-notes.md
+++ b/.github/workflows/release-notes.md
@@ -4,11 +4,12 @@ description: |
   published.  Analyzes all commits since the previous tag and posts a
   structured changelog as a comment on the release.
 
-# DISABLED 2026-05-08: gh-aw workflows are paused due to runaway cost.
-# Manual dispatch only — no event triggers. Re-enable by restoring the
-# original `release: [published]` trigger and recompiling the lock file
-# with `gh aw compile`.
+# Re-enabled 2026-05-09: release notes only fire on release publish, which
+# is at most a few times a day. Cost is bounded — Haiku summarizing a
+# day's worth of commits per release is the cheapest of the gh-aw set.
 on:
+  release:
+    types: [published]
   workflow_dispatch:
 
 imports:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -568,6 +568,7 @@ The compiler must always compile itself. Breaking changes require:
 - **Release notes:** `.github/workflows/release-notes.md` — agentic workflow that posts structured, categorized changelog comments on published releases (supplements the auto-generated notes from `gh release create`)
 - **Artifacts:** `dist/` is used for packaged artifacts; `release-tag.yml` builds and uploads platform binaries
 - **Claude skill:** Use `/release` to trigger a new release from Claude Code
+- **Release tracking:** Alpha→alpha prerelease bumps are uncurated. Minor bumps and channel promotions (alpha→beta→rc→stable) gate on the `release:*` label namespace and a per-cycle tracking issue titled `Release: vX.Y.Z`. `/release` looks both up before dispatching. See `docs/conventions/issue-naming.md` "Release tracking".
 
 ### Triggering a Release
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -567,8 +567,8 @@ The compiler must always compile itself. Breaking changes require:
 - **Release automation:** `.github/workflows/release.yml` — manually triggered via `workflow_dispatch`, pure bash, no Python dependencies
 - **Release notes:** `.github/workflows/release-notes.md` — agentic workflow that posts structured, categorized changelog comments on published releases (supplements the auto-generated notes from `gh release create`)
 - **Artifacts:** `dist/` is used for packaged artifacts; `release-tag.yml` builds and uploads platform binaries
-- **Claude skill:** Use `/release` to trigger a new release from Claude Code
-- **Release tracking:** Alpha→alpha prerelease bumps are uncurated. Minor bumps and channel promotions (alpha→beta→rc→stable) gate on the `release:*` label namespace and a per-cycle tracking issue titled `Release: vX.Y.Z`. `/release` looks both up before dispatching. See `docs/conventions/issue-naming.md` "Release tracking".
+- **Claude skills:** `/release-plan vX.Y.Z` opens or syncs the per-cycle tracking issue and is idempotent. `/release` cuts the release and gates on the tracking issue + `release:*` labels for curated cuts. `/sweep` auto-ticks the tracking-issue checklist when a labeled issue closes via a merged PR.
+- **Release tracking:** Only `channel=alpha bump=prerelease` is uncurated — every other combo (any patch/minor/major bump, any non-alpha channel) consults the `release:*` label namespace and the per-cycle `Release: vX.Y.Z` tracking issue. See `docs/conventions/issue-naming.md` "Release tracking".
 
 ### Triggering a Release
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -567,8 +567,9 @@ The compiler must always compile itself. Breaking changes require:
 - **Release automation:** `.github/workflows/release.yml` — manually triggered via `workflow_dispatch`, pure bash, no Python dependencies
 - **Release notes:** `.github/workflows/release-notes.md` — agentic workflow that posts structured, categorized changelog comments on published releases (supplements the auto-generated notes from `gh release create`)
 - **Artifacts:** `dist/` is used for packaged artifacts; `release-tag.yml` builds and uploads platform binaries
-- **Claude skills:** `/release-plan vX.Y.Z` opens or syncs the per-cycle tracking issue and is idempotent. `/release` cuts the release and gates on the tracking issue + `release:*` labels for curated cuts. `/sweep` auto-ticks the tracking-issue checklist when a labeled issue closes via a merged PR.
+- **Claude skills:** `/release-plan vX.Y.Z` opens or syncs the per-cycle tracking issue and is idempotent. `/release` cuts the release and gates on the tracking issue + `release:*` labels for curated cuts. `/sweep` auto-ticks the tracking-issue checklist when a labeled issue closes via a merged PR. `/pin-seed [vX.Y.Z]` opens the one-line PR bumping `.seed-version` once a release's binary is uploaded.
 - **Release tracking:** Only `channel=alpha bump=prerelease` is uncurated — every other combo (any patch/minor/major bump, any non-alpha channel) consults the `release:*` label namespace and the per-cycle `Release: vX.Y.Z` tracking issue. See `docs/conventions/issue-naming.md` "Release tracking".
+- **Seed pinning is separate from release cutting.** `release.yml` deliberately doesn't touch `.seed-version`. The `seed-blocker` label tracks "must close before next seed bump" issues; `/release-plan` consults it; `/sweep` auto-ticks it; `/pin-seed` opens the bump PR once `release-tag.yml` finishes uploading binaries. See `docs/conventions/issue-naming.md` "Seed pinning".
 
 ### Triggering a Release
 

--- a/docs/conventions/issue-naming.md
+++ b/docs/conventions/issue-naming.md
@@ -307,6 +307,66 @@ dispatch.
 Don't open a tracking issue for routine alpha bumps. The cost is in the
 curation, not the issue.
 
+## Seed pinning
+
+The Sailfin compiler self-hosts from a released seed binary. The pin
+lives at `.seed-version` (single-line file at repo root) and is read by
+`make fetch-seed`, `ci.yml`, `nightly-selfhost.yml`, and
+`release-branches.yml`. **Bumping the pin is a separate concern from
+cutting a release** — `release.yml` deliberately doesn't touch
+`.seed-version` because the new binary doesn't exist at tag-creation
+time and most alpha releases shouldn't be pinned.
+
+### `seed-blocker` label
+
+Apply `seed-blocker` to any issue whose fix or feature must land
+**before the next seed bump**. Examples:
+
+- A miscompilation in the current seed that breaks downstream work.
+- A new compiler feature the next workstream depends on.
+- A test-runner / CI fix needed before nightly self-host can pass.
+
+`/release-plan` lists open `seed-blocker` issues alongside the
+release-gating set when opening a tracking issue. `/sweep` auto-ticks
+matching checklist items when a `seed-blocker` issue closes via a
+merged PR.
+
+### When to bump the pin
+
+Run `/pin-seed [vX.Y.Z]`:
+
+- A `seed-blocker` issue just closed and the fix shipped in the latest
+  alpha.
+- Downstream work needs a feature/fix that landed in a recent alpha.
+- A `bump=patch` was just cut (almost always implies a hotfix-pin).
+- Nightly self-host shows drift between the seed and trunk that the
+  build cache can't smooth over.
+
+### When NOT to bump the pin
+
+- A routine alpha that fixes nothing the current working set needs.
+- A `seed-blocker` issue is still open (unless deferring is intentional).
+- `release-tag.yml` is still running for the target — wait for the
+  binary upload.
+- The current pin is < 5 alphas behind and CI is green — the pin is
+  working; don't churn it.
+
+### Patch-a-seed flow (hotfix)
+
+When a current-seed bug breaks downstream work:
+
+1. Land the fix on `main` (regular PR + merge).
+2. `/release` with `channel=alpha bump=prerelease` to cut an alpha
+   containing the fix.
+3. Wait for `release-tag.yml` to upload the binary (a few minutes).
+4. `/pin-seed` to open the one-line bump PR.
+5. Merge the pin PR → CI/nightly/`make fetch-seed` start using it.
+6. Rebase the blocked branch onto `main`.
+
+The pin PR lives off `main` (never `claude/*`), is reviewed even though
+it's one line, and is never auto-merged — it cascades through every
+workflow that reads `.seed-version`.
+
 ## Milestones
 
 Milestones are phase markers, not calendar deadlines. Every `epic` issue

--- a/docs/conventions/issue-naming.md
+++ b/docs/conventions/issue-naming.md
@@ -248,6 +248,49 @@ The workflow needs a PAT with `project` + `read:org` scopes, stored as
 available the workflow no-ops — labels stay correct, only the project
 view goes stale.
 
+## Release tracking
+
+Milestones group long-lived **themes** (and feed `site/src/pages/roadmap.astro`).
+They span many releases. To answer "what ships in version X" we use a separate
+axis: the **`release:*` label namespace** plus a **per-cycle tracking issue**.
+
+### When release tracking applies
+
+- **Alpha→alpha prerelease bumps** (`channel=alpha bump=prerelease`) are
+  uncurated. They take whatever happens to be on `main`. Ignore release:* labels.
+- **Minor bumps** (`bump=minor`) and **channel promotions** (alpha→beta,
+  beta→rc, rc→stable, anything→stable) are curated. `/release` gates on the
+  matching `release:*` label set.
+
+### Labels
+
+| Label | Gate |
+|-------|------|
+| `release:next-minor` | Must close before the next `bump=minor` cut (the next 0.X.0). |
+| `release:beta` | Must close before the next promotion to `channel=beta`. |
+| `release:rc` | Must close before the next promotion to `channel=rc`. |
+| `release:stable` | Must close before the next promotion to `channel=stable`. |
+| `release:1.0` | Must close before 1.0 GA. Long-horizon. |
+
+Multiple labels may co-exist on one issue (e.g. an item may gate both the
+beta promotion *and* the 1.0 GA). The labels are intent — they declare *when*
+something must ship, not *what theme it belongs to* (that's the milestone).
+
+### Tracking issue (`Release: vX.Y.Z`)
+
+For each meaningful upcoming version, open one tracking issue titled exactly
+`Release: vX.Y.Z` (e.g. `Release: v0.6.0`, `Release: v1.0.0`). Apply the
+`tracking` label. Body is a checklist of "must close before cutting" items
+linking to the issues/PRs holding the corresponding `release:*` label.
+
+`/release` looks up the tracking issue by title when the bump/channel combo
+is curated, surfaces unfinished items, requires explicit confirmation if any
+are open, and posts a comment on the tracking issue after a successful
+dispatch.
+
+Don't open a tracking issue for routine alpha bumps. The cost is in the
+curation, not the issue.
+
 ## Milestones
 
 Milestones are phase markers, not calendar deadlines. Every `epic` issue

--- a/docs/conventions/issue-naming.md
+++ b/docs/conventions/issue-naming.md
@@ -256,25 +256,41 @@ axis: the **`release:*` label namespace** plus a **per-cycle tracking issue**.
 
 ### When release tracking applies
 
-- **Alpha→alpha prerelease bumps** (`channel=alpha bump=prerelease`) are
-  uncurated. They take whatever happens to be on `main`. Ignore release:* labels.
-- **Minor bumps** (`bump=minor`) and **channel promotions** (alpha→beta,
-  beta→rc, rc→stable, anything→stable) are curated. `/release` gates on the
-  matching `release:*` label set.
+There is exactly one **uncurated** combination — it takes whatever is on
+`main` and skips the release-tracking gate entirely:
+
+- `channel=alpha bump=prerelease` (the routine daily alpha bump)
+
+**Every other combination is curated** and consults the `release:*` labels:
+
+- Any `bump=patch`, `bump=minor`, or `bump=major` (in any channel)
+- Any promotion to a non-alpha channel (`beta`, `rc`, `stable`)
+
+For curated cuts `/release` lists the open items under the matching
+`release:*` label and the tracking issue, and requires explicit
+confirmation before dispatching. The gate is advisory — the human always
+has the final call.
 
 ### Labels
 
-| Label | Gate |
-|-------|------|
-| `release:next-minor` | Must close before the next `bump=minor` cut (the next 0.X.0). |
-| `release:beta` | Must close before the next promotion to `channel=beta`. |
-| `release:rc` | Must close before the next promotion to `channel=rc`. |
-| `release:stable` | Must close before the next promotion to `channel=stable`. |
-| `release:1.0` | Must close before 1.0 GA. Long-horizon. |
+| Label | Hard gate at | Soft signal at |
+|-------|--------------|----------------|
+| `release:next-minor` | `bump=minor` (next 0.X.0) | `bump=patch`, beta promotion |
+| `release:beta` | promotion to `channel=beta` | rc promotion |
+| `release:rc` | promotion to `channel=rc` | stable promotion |
+| `release:stable` | promotion to `channel=stable` | — |
+| `release:1.0` | `bump=major` to 1.0.0 | `bump=minor` |
 
 Multiple labels may co-exist on one issue (e.g. an item may gate both the
 beta promotion *and* the 1.0 GA). The labels are intent — they declare *when*
 something must ship, not *what theme it belongs to* (that's the milestone).
+"Hard gate" means `/release` lists every open issue holding the label and
+requires explicit override; "soft signal" means it's mentioned as context
+but doesn't block.
+
+`bump=patch` cuts have no hard label gate — they're curated only in the
+sense that `/release` confirms the user wants a new patch line (rather
+than another alpha prerelease).
 
 ### Tracking issue (`Release: vX.Y.Z`)
 


### PR DESCRIPTION
## Summary

Adds a per-release tracking axis on top of the existing theme milestones (which feed `site/src/pages/roadmap.astro` and stay untouched), so we can answer **"what's in version X?"** without disturbing the roadmap or curating every alpha bump.

### Why

- Theme milestones (#7 Sailfin-Native Runtime, #10 Tooling & Developer Workflow, etc.) span many releases — they're the wrong axis for release content.
- Auto-generated release notes are always "everything since the last tag." Fine for alpha churn, useless for promotions or minor bumps.
- There was no way to say "this PR/issue must land before 0.6.0" or "must land before beta" — the curation only happened at workflow-dispatch time, with no record.

### What this PR adds

**1. `release:*` label namespace** (`.github/labels.yml`)
- `release:next-minor` — must close before the next `bump=minor` cut
- `release:beta` / `release:rc` / `release:stable` — must close before the next promotion to that channel
- `release:1.0` — long-horizon GA gate

Labels can co-exist on one issue (an item may gate both `release:beta` *and* `release:1.0`).

**2. Tracking-issue convention** (`docs/conventions/issue-naming.md`, new "Release tracking" section)

For each meaningful upcoming version, open one tracking issue titled exactly `Release: vX.Y.Z`, apply the `tracking` label, body is a checklist of "must close before cutting" items. Same shape as #321.

Don't open one for routine alpha bumps — alpha→alpha prerelease bumps are explicitly uncurated and ignore the labels.

**3. `/release` skill rewrite** (`.claude/commands/release.md`)

Before dispatching a curated cut (any `bump=minor`/`bump=major`/`bump=patch`, or any channel promotion), the skill now:

- Searches for open issues with the matching `release:*` label.
- Looks up the tracking issue by title (`Release: vX.Y.Z`).
- Lists the gap and requires explicit override if anything is open.
- After dispatch, posts a comment on the tracking issue with the new tag and compare URL.

Routine alpha→alpha prerelease bumps skip the gate entirely. The gate is intentionally soft — it surfaces and asks, never refuses.

**4. `release-notes.md` agentic workflow re-enabled** (`.github/workflows/release-notes.md` + `.lock.yml`)

It was paused along with the other gh-aw workflows in #491 due to runaway cost. The cost concern doesn't apply here — releases publish at most a few times a day and Haiku summarizing a day of commits per release is the cheapest of the gh-aw set. Restored the `release: [published]` trigger and recompiled the lock file with `gh aw compile` (matched against compiler v0.72.1, the version pinned by the rest of the repo's `gh-aw-actions/setup` references — `actions-lock.json` is unchanged).

**5. CLAUDE.md** gets one bullet in the "Versioning & Releases" section pointing at the new convention.

### What this PR explicitly does *not* change

- Theme milestones (#6, #7, #8, #10, …) and `roadmap.astro`. The roadmap still reads themes from milestones; release tracking is a parallel axis.
- The `release.yml` workflow itself — the gate is in the skill, not the workflow. The workflow stays a dumb dispatcher.
- Existing labels, the project board, or the agentic pipeline tier rules.

## Test plan

- [ ] `Sync Labels` workflow picks up the five new `release:*` labels on merge to `main`.
- [ ] Open a `Release: v0.6.0` tracking issue (manual, post-merge) and label one open issue with `release:next-minor` to dry-run the `/release` flow.
- [ ] Run `/release` with `channel=alpha bump=prerelease` (uncurated) — confirm it skips the gate and dispatches.
- [ ] Run `/release` with `channel=alpha bump=minor` (curated) — confirm it surfaces the open `release:next-minor` items and requires confirmation.
- [ ] Trigger the next real release after merge and confirm `release-notes.md` runs on `release: published` and posts a categorized changelog comment.
- [ ] CI: `Sync Labels` workflow exits clean on the new label set.

https://claude.ai/code/session_01UbvqYozrh9AzWdvTfpoL84

---
_Generated by [Claude Code](https://claude.ai/code/session_01UbvqYozrh9AzWdvTfpoL84)_