### PR TITLE
refactor(lowering): route alloc_struct/mark_persistent/free through emit_runtime_call (M1.7.2a)

### DIFF
--- a/compiler/src/llvm/expression_lowering/arrays.sfn
+++ b/compiler/src/llvm/expression_lowering/arrays.sfn
@@ -11,6 +11,11 @@ import { strip_pointer_suffix } from "../type_mapping";
 import { array_struct_type_for_element } from "../type_mapping";
 import { ExpressionResult, LLVMOperand } from "../types";
 import { append_string, ends_with, trim_text } from "../utils";
+import {
+    RuntimeCallOverrides,
+    emit_runtime_call,
+    empty_runtime_call_overrides
+} from "./native/runtime_call";
 
 fn lower_struct_array_concat(lhs: LLVMOperand, rhs: LLVMOperand, element_type: string, lines: string[], temp_index: number) -> ExpressionResult {
     let mut current_lines = lines;
@@ -127,12 +132,31 @@ fn lower_struct_array_concat(lhs: LLVMOperand, rhs: LLVMOperand, element_type: s
         + ", "
         + total_length);
 
+    // M1.7.2a (#496): concat target buffer alloc routes through
+    // descriptor dispatch. The `noalias` return attribute is preserved
+    // because the buffer is freshly allocated and known not to alias
+    // its inputs (which are then memcpy'd into it).
     let new_raw_buffer = format_temp_name(current_temp);
+    let buffer_size_operand = LLVMOperand {
+        llvm_type: "i64",
+        value: total_bytes
+    };
+    let buffer_overrides = RuntimeCallOverrides {
+        parameter_types: [],
+        return_type: "",
+        symbol: "",
+        return_attributes: "noalias"
+    };
+    let buffer_operands: LLVMOperand[] = [buffer_size_operand];
+    let buffer_result = emit_runtime_call("alloc_struct", buffer_operands, buffer_overrides, current_temp, current_lines);
+    let mut _buffer_di: number = 0;
+    loop {
+        if _buffer_di >= buffer_result.diagnostics.length { break; }
+        diagnostics.push(buffer_result.diagnostics[_buffer_di]);
+        _buffer_di += 1;
+    }
+    current_lines = buffer_result.lines;
     current_temp += 1;
-    current_lines.push("  " + new_raw_buffer
-        + " = call noalias i8* @sailfin_runtime_alloc_struct(i64 "
-        + total_bytes
-        + ")");
     let new_data_ptr = format_temp_name(current_temp);
     current_temp += 1;
     current_lines.push("  " + new_data_ptr + " = bitcast i8* " + new_raw_buffer
@@ -213,12 +237,27 @@ fn lower_struct_array_concat(lhs: LLVMOperand, rhs: LLVMOperand, element_type: s
         + struct_size_ptr
         + " to i64");
 
+    // M1.7.2a (#496): concat result struct alloc routes through
+    // descriptor dispatch. No `noalias` here today — the original
+    // emission omitted the attribute and the IR diff is the
+    // correctness gate.
     let new_struct_raw = format_temp_name(current_temp);
+    let struct_concat_size_operand = LLVMOperand {
+        llvm_type: "i64",
+        value: struct_size_value
+    };
+    let struct_concat_operands: LLVMOperand[] = [struct_concat_size_operand];
+    let struct_concat_result = emit_runtime_call("alloc_struct", struct_concat_operands, empty_runtime_call_overrides(), current_temp, current_lines);
+    let mut _struct_concat_di: number = 0;
+    loop {
+        if _struct_concat_di >= struct_concat_result.diagnostics.length {
+            break;
+        }
+        diagnostics.push(struct_concat_result.diagnostics[_struct_concat_di]);
+        _struct_concat_di += 1;
+    }
+    current_lines = struct_concat_result.lines;
     current_temp += 1;
-    current_lines.push("  " + new_struct_raw
-        + " = call i8* @sailfin_runtime_alloc_struct(i64 "
-        + struct_size_value
-        + ")");
     let new_struct_ptr = format_temp_name(current_temp);
     current_temp += 1;
     current_lines.push("  " + new_struct_ptr + " = bitcast i8* "

--- a/compiler/src/llvm/expression_lowering/native/core.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core.sfn
@@ -197,6 +197,8 @@ export {
     harmonise_operands
 } from "./core_operands";
 
+import { emit_runtime_call, empty_runtime_call_overrides } from "./runtime_call";
+
 import {
     find_local_binding,
     infer_borrow_base_scope,
@@ -695,9 +697,24 @@ fn lower_expression(expression: string, bindings: ParameterBinding[], locals: Lo
                             // (Phase 5a follow-up), so this must route through
                             // the matching arena-aware free. Plain `@free` on
                             // an arena pointer corrupts glibc chunk metadata.
-                            awaited_lines2.push("  call void @sailfin_runtime_free(i8* "
-                                + result_temp
-                                + ")");
+                            // M1.7.2a (#496): routes through `emit_runtime_call`
+                            // so the call shape is owned by the descriptor table.
+                            let free_operand = LLVMOperand {
+                                llvm_type: "i8*",
+                                value: result_temp
+                            };
+                            let free_operands: LLVMOperand[] = [free_operand];
+                            let free_result = emit_runtime_call("runtime.free", free_operands, empty_runtime_call_overrides(), lowered.temp_index
+                                + 3, awaited_lines2);
+                            let mut _free_di: number = 0;
+                            loop {
+                                if _free_di >= free_result.diagnostics.length {
+                                    break;
+                                }
+                                diagnostics.push(free_result.diagnostics[_free_di]);
+                                _free_di += 1;
+                            }
+                            awaited_lines2 = free_result.lines;
                             let out_operand_unboxed = LLVMOperand {
                                 llvm_type: trimmed_expected,
                                 value: load_temp

--- a/compiler/src/llvm/expression_lowering/native/core_literals_lowering.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_literals_lowering.sfn
@@ -62,6 +62,11 @@ import {
     parse_interpolated_template,
     unescape_string_literal
 } from "./core_text";
+import {
+    RuntimeCallOverrides,
+    emit_runtime_call,
+    empty_runtime_call_overrides
+} from "./runtime_call";
 
 fn lower_array_literal(text: string, bindings: ParameterBinding[], locals: LocalBinding[], temp_index: number, lines: string[], functions: NativeFunction[], context: TypeContext, expected_type: string) -> ExpressionResult {
     let mut diagnostics: string[] = [];
@@ -514,11 +519,26 @@ fn lower_array_literal(text: string, bindings: ParameterBinding[], locals: Local
         + array_bytes);
     current_temp += 1;
 
+    // M1.7.2a (#496): array data buffer alloc routes through descriptor
+    // dispatch. No `noalias` here today — the buffer is later wrapped
+    // by a struct that owns it, and the buffer pointer escapes via a
+    // store into that struct's `data` field, so we deliberately
+    // mirror the existing call shape (no return attribute) to keep
+    // the IR diff empty.
     let raw_array_ptr = format_temp_name(current_temp);
-    current_lines.push("  " + raw_array_ptr
-        + " = call i8* @sailfin_runtime_alloc_struct(i64 "
-        + adjusted_array_bytes
-        + ")");
+    let raw_array_size_operand = LLVMOperand {
+        llvm_type: "i64",
+        value: adjusted_array_bytes
+    };
+    let raw_array_operands: LLVMOperand[] = [raw_array_size_operand];
+    let raw_array_result = emit_runtime_call("alloc_struct", raw_array_operands, empty_runtime_call_overrides(), current_temp, current_lines);
+    let mut _raw_array_di: number = 0;
+    loop {
+        if _raw_array_di >= raw_array_result.diagnostics.length { break; }
+        diagnostics.push(raw_array_result.diagnostics[_raw_array_di]);
+        _raw_array_di += 1;
+    }
+    current_lines = raw_array_result.lines;
     current_temp += 1;
 
     let data_pointer = format_temp_name(current_temp);
@@ -569,11 +589,22 @@ fn lower_array_literal(text: string, bindings: ParameterBinding[], locals: Local
         + " to i64");
     current_temp += 1;
 
+    // M1.7.2a (#496): SfnArray struct alloc routes through descriptor
+    // dispatch. Same shape as the buffer alloc above (no `noalias`).
     let raw_struct_ptr = format_temp_name(current_temp);
-    current_lines.push("  " + raw_struct_ptr
-        + " = call i8* @sailfin_runtime_alloc_struct(i64 "
-        + struct_bytes
-        + ")");
+    let struct_size_operand = LLVMOperand {
+        llvm_type: "i64",
+        value: struct_bytes
+    };
+    let struct_alloc_operands: LLVMOperand[] = [struct_size_operand];
+    let struct_alloc_result = emit_runtime_call("alloc_struct", struct_alloc_operands, empty_runtime_call_overrides(), current_temp, current_lines);
+    let mut _struct_alloc_di: number = 0;
+    loop {
+        if _struct_alloc_di >= struct_alloc_result.diagnostics.length { break; }
+        diagnostics.push(struct_alloc_result.diagnostics[_struct_alloc_di]);
+        _struct_alloc_di += 1;
+    }
+    current_lines = struct_alloc_result.lines;
     current_temp += 1;
 
     let struct_pointer = format_temp_name(current_temp);
@@ -863,12 +894,28 @@ fn box_aggregate_operand(operand: LLVMOperand, expected_pointer_type: string, te
         + size_ptr_temp
         + " to i64");
 
+    // M1.7.2a (#496): boxed-aggregate alloc routes through descriptor
+    // dispatch. The `noalias` return attribute is preserved at the
+    // call site through `RuntimeCallOverrides.return_attributes` to
+    // keep IR identical with the seed.
     let malloc_temp = format_temp_name(current_temp);
     current_temp += 1;
-    current_lines.push("  " + malloc_temp
-        + " = call noalias i8* @sailfin_runtime_alloc_struct(i64 "
-        + size_temp
-        + ")");
+    let box_size_operand = LLVMOperand { llvm_type: "i64", value: size_temp };
+    let box_overrides = RuntimeCallOverrides {
+        parameter_types: [],
+        return_type: "",
+        symbol: "",
+        return_attributes: "noalias"
+    };
+    let box_operands: LLVMOperand[] = [box_size_operand];
+    let box_result = emit_runtime_call("alloc_struct", box_operands, box_overrides, current_temp - 1, current_lines);
+    let mut _box_di: number = 0;
+    loop {
+        if _box_di >= box_result.diagnostics.length { break; }
+        diagnostics.push(box_result.diagnostics[_box_di]);
+        _box_di += 1;
+    }
+    current_lines = box_result.lines;
 
     let typed_ptr_temp = format_temp_name(current_temp);
     current_temp += 1;

--- a/compiler/src/llvm/expression_lowering/native/core_operands.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_operands.sfn
@@ -29,6 +29,11 @@ import {
     parse_union_payload_types,
     trim_text
 } from "./core_text";
+import {
+    RuntimeCallOverrides,
+    emit_runtime_call,
+    empty_runtime_call_overrides
+} from "./runtime_call";
 
 fn emit_comparison_instruction(symbol: string, left_operand: LLVMOperand, right_operand: LLVMOperand, temp_index: number, lines: string[]) -> ComparisonEmission {
     let mut diagnostics: string[] = [];
@@ -710,9 +715,30 @@ fn coerce_numeric_primitive(operand: LLVMOperand, operand_type: string, target: 
     }
     if target == "i8*" {
         if operand_type == "i8" {
+            // M1.7.2a (#496): char-to-cstring boxing routes through
+            // descriptor dispatch. The 2-byte allocation holds the char
+            // followed by a NUL terminator — preserves the `noalias`
+            // return attribute via per-call-site override.
             let malloc_temp = format_temp_name(temp_index);
-            current_lines.push("  " + malloc_temp
-                + " = call noalias i8* @sailfin_runtime_alloc_struct(i64 2)");
+            let i8c_size_operand = LLVMOperand {
+                llvm_type: "i64",
+                value: "2"
+            };
+            let i8c_overrides = RuntimeCallOverrides {
+                parameter_types: [],
+                return_type: "",
+                symbol: "",
+                return_attributes: "noalias"
+            };
+            let i8c_operands: LLVMOperand[] = [i8c_size_operand];
+            let i8c_result = emit_runtime_call("alloc_struct", i8c_operands, i8c_overrides, temp_index, current_lines);
+            let mut _i8c_di: number = 0;
+            loop {
+                if _i8c_di >= i8c_result.diagnostics.length { break; }
+                diagnostics.push(i8c_result.diagnostics[_i8c_di]);
+                _i8c_di += 1;
+            }
+            current_lines = i8c_result.lines;
             let char_ptr = format_temp_name(temp_index + 1);
             current_lines.push("  " + char_ptr + " = getelementptr i8, i8* "
                 + malloc_temp
@@ -879,6 +905,10 @@ fn coerce_pointer_or_struct(operand: LLVMOperand, operand_type: string, target: 
                 if starts_with(operand_type, "%") { _if75 = true; }
                 if starts_with(operand_type, "{") { _if75 = true; }
                 if _if75 {
+                    // M1.7.2a (#496): boxing pattern routes alloc_struct
+                    // and mark_persistent through `emit_runtime_call`. The
+                    // `noalias` return attribute is preserved through the
+                    // per-call-site override.
                     let size_ptr_temp = format_temp_name(temp_index);
                     let size_temp = format_temp_name(temp_index + 1);
                     let malloc_temp = format_temp_name(temp_index + 2);
@@ -894,10 +924,28 @@ fn coerce_pointer_or_struct(operand: LLVMOperand, operand_type: string, target: 
                         + "* "
                         + size_ptr_temp
                         + " to i64");
-                    current_lines.push("  " + malloc_temp
-                        + " = call noalias i8* @sailfin_runtime_alloc_struct(i64 "
-                        + size_temp
-                        + ")");
+                    let alloc_size_op_a = LLVMOperand {
+                        llvm_type: "i64",
+                        value: size_temp
+                    };
+                    let alloc_overrides_a = RuntimeCallOverrides {
+                        parameter_types: [],
+                        return_type: "",
+                        symbol: "",
+                        return_attributes: "noalias"
+                    };
+                    let alloc_operands_a: LLVMOperand[] = [alloc_size_op_a];
+                    let alloc_result_a = emit_runtime_call("alloc_struct", alloc_operands_a, alloc_overrides_a, temp_index
+                        + 2, current_lines);
+                    let mut _alloc_di_a: number = 0;
+                    loop {
+                        if _alloc_di_a >= alloc_result_a.diagnostics.length {
+                            break;
+                        }
+                        diagnostics.push(alloc_result_a.diagnostics[_alloc_di_a]);
+                        _alloc_di_a += 1;
+                    }
+                    current_lines = alloc_result_a.lines;
                     current_lines.push("  " + typed_ptr_temp + " = bitcast i8* "
                         + malloc_temp
                         + " to "
@@ -908,9 +956,20 @@ fn coerce_pointer_or_struct(operand: LLVMOperand, operand_type: string, target: 
                         + operand_type
                         + "* "
                         + typed_ptr_temp);
-                    current_lines.push("  call void @sailfin_runtime_mark_persistent(i8* "
-                        + malloc_temp
-                        + ")");
+                    let mp_op_a = LLVMOperand {
+                        llvm_type: "i8*",
+                        value: malloc_temp
+                    };
+                    let mp_operands_a: LLVMOperand[] = [mp_op_a];
+                    let mp_result_a = emit_runtime_call("mark_persistent", mp_operands_a, empty_runtime_call_overrides(), temp_index
+                        + 4, current_lines);
+                    let mut _mp_di_a: number = 0;
+                    loop {
+                        if _mp_di_a >= mp_result_a.diagnostics.length { break; }
+                        diagnostics.push(mp_result_a.diagnostics[_mp_di_a]);
+                        _mp_di_a += 1;
+                    }
+                    current_lines = mp_result_a.lines;
                     let boxed = LLVMOperand {
                         llvm_type: target,
                         value: typed_ptr_temp
@@ -962,6 +1021,8 @@ fn coerce_pointer_or_struct(operand: LLVMOperand, operand_type: string, target: 
         if _if83 { _if76 = true; }
     }
     if _if76 {
+        // M1.7.2a (#496): aggregate-to-i8* boxing routes alloc_struct
+        // and mark_persistent through `emit_runtime_call`.
         let size_ptr_temp = format_temp_name(temp_index);
         let size_temp = format_temp_name(temp_index + 1);
         let malloc_temp = format_temp_name(temp_index + 2);
@@ -975,10 +1036,26 @@ fn coerce_pointer_or_struct(operand: LLVMOperand, operand_type: string, target: 
             + "* "
             + size_ptr_temp
             + " to i64");
-        current_lines.push("  " + malloc_temp
-            + " = call noalias i8* @sailfin_runtime_alloc_struct(i64 "
-            + size_temp
-            + ")");
+        let alloc_size_op_b = LLVMOperand {
+            llvm_type: "i64",
+            value: size_temp
+        };
+        let alloc_overrides_b = RuntimeCallOverrides {
+            parameter_types: [],
+            return_type: "",
+            symbol: "",
+            return_attributes: "noalias"
+        };
+        let alloc_operands_b: LLVMOperand[] = [alloc_size_op_b];
+        let alloc_result_b = emit_runtime_call("alloc_struct", alloc_operands_b, alloc_overrides_b, temp_index
+            + 2, current_lines);
+        let mut _alloc_di_b: number = 0;
+        loop {
+            if _alloc_di_b >= alloc_result_b.diagnostics.length { break; }
+            diagnostics.push(alloc_result_b.diagnostics[_alloc_di_b]);
+            _alloc_di_b += 1;
+        }
+        current_lines = alloc_result_b.lines;
         current_lines.push("  " + typed_ptr_temp + " = bitcast i8* "
             + malloc_temp
             + " to "
@@ -989,9 +1066,17 @@ fn coerce_pointer_or_struct(operand: LLVMOperand, operand_type: string, target: 
             + operand_type
             + "* "
             + typed_ptr_temp);
-        current_lines.push("  call void @sailfin_runtime_mark_persistent(i8* "
-            + malloc_temp
-            + ")");
+        let mp_op_b = LLVMOperand { llvm_type: "i8*", value: malloc_temp };
+        let mp_operands_b: LLVMOperand[] = [mp_op_b];
+        let mp_result_b = emit_runtime_call("mark_persistent", mp_operands_b, empty_runtime_call_overrides(), temp_index
+            + 4, current_lines);
+        let mut _mp_di_b: number = 0;
+        loop {
+            if _mp_di_b >= mp_result_b.diagnostics.length { break; }
+            diagnostics.push(mp_result_b.diagnostics[_mp_di_b]);
+            _mp_di_b += 1;
+        }
+        current_lines = mp_result_b.lines;
         let boxed = LLVMOperand { llvm_type: "i8*", value: malloc_temp };
         return CoercionResult {
             lines: current_lines,
@@ -1042,6 +1127,8 @@ fn coerce_general_fallback(operand: LLVMOperand, operand_type: string, target: s
                 if starts_with(operand_type, "%") { _if85 = true; }
                 if starts_with(operand_type, "{") { _if85 = true; }
                 if _if85 {
+                    // M1.7.2a (#496): expected_value_type boxing routes
+                    // alloc_struct and mark_persistent through `emit_runtime_call`.
                     let size_ptr_temp = format_temp_name(temp_index);
                     let size_temp = format_temp_name(temp_index + 1);
                     let malloc_temp = format_temp_name(temp_index + 2);
@@ -1057,10 +1144,28 @@ fn coerce_general_fallback(operand: LLVMOperand, operand_type: string, target: s
                         + "* "
                         + size_ptr_temp
                         + " to i64");
-                    current_lines.push("  " + malloc_temp
-                        + " = call noalias i8* @sailfin_runtime_alloc_struct(i64 "
-                        + size_temp
-                        + ")");
+                    let alloc_size_op_c = LLVMOperand {
+                        llvm_type: "i64",
+                        value: size_temp
+                    };
+                    let alloc_overrides_c = RuntimeCallOverrides {
+                        parameter_types: [],
+                        return_type: "",
+                        symbol: "",
+                        return_attributes: "noalias"
+                    };
+                    let alloc_operands_c: LLVMOperand[] = [alloc_size_op_c];
+                    let alloc_result_c = emit_runtime_call("alloc_struct", alloc_operands_c, alloc_overrides_c, temp_index
+                        + 2, current_lines);
+                    let mut _alloc_di_c: number = 0;
+                    loop {
+                        if _alloc_di_c >= alloc_result_c.diagnostics.length {
+                            break;
+                        }
+                        diagnostics.push(alloc_result_c.diagnostics[_alloc_di_c]);
+                        _alloc_di_c += 1;
+                    }
+                    current_lines = alloc_result_c.lines;
                     current_lines.push("  " + typed_ptr_temp + " = bitcast i8* "
                         + malloc_temp
                         + " to "
@@ -1071,9 +1176,20 @@ fn coerce_general_fallback(operand: LLVMOperand, operand_type: string, target: s
                         + operand_type
                         + "* "
                         + typed_ptr_temp);
-                    current_lines.push("  call void @sailfin_runtime_mark_persistent(i8* "
-                        + malloc_temp
-                        + ")");
+                    let mp_op_c = LLVMOperand {
+                        llvm_type: "i8*",
+                        value: malloc_temp
+                    };
+                    let mp_operands_c: LLVMOperand[] = [mp_op_c];
+                    let mp_result_c = emit_runtime_call("mark_persistent", mp_operands_c, empty_runtime_call_overrides(), temp_index
+                        + 4, current_lines);
+                    let mut _mp_di_c: number = 0;
+                    loop {
+                        if _mp_di_c >= mp_result_c.diagnostics.length { break; }
+                        diagnostics.push(mp_result_c.diagnostics[_mp_di_c]);
+                        _mp_di_c += 1;
+                    }
+                    current_lines = mp_result_c.lines;
                     let boxed = LLVMOperand {
                         llvm_type: target,
                         value: typed_ptr_temp
@@ -1111,6 +1227,8 @@ fn coerce_general_fallback(operand: LLVMOperand, operand_type: string, target: s
                 if _elif78 {
                     let expected_value_type = strip_pointer_suffix(variant_type);
                     if expected_value_type == operand_type {
+                        // M1.7.2a (#496): union-variant boxing routes
+                        // alloc_struct and mark_persistent through `emit_runtime_call`.
                         let size_ptr_temp = format_temp_name(local_temp);
                         let size_temp = format_temp_name(local_temp + 1);
                         let malloc_temp = format_temp_name(local_temp + 2);
@@ -1126,10 +1244,28 @@ fn coerce_general_fallback(operand: LLVMOperand, operand_type: string, target: s
                             + "* "
                             + size_ptr_temp
                             + " to i64");
-                        local_lines.push("  " + malloc_temp
-                            + " = call noalias i8* @sailfin_runtime_alloc_struct(i64 "
-                            + size_temp
-                            + ")");
+                        let alloc_size_op_d = LLVMOperand {
+                            llvm_type: "i64",
+                            value: size_temp
+                        };
+                        let alloc_overrides_d = RuntimeCallOverrides {
+                            parameter_types: [],
+                            return_type: "",
+                            symbol: "",
+                            return_attributes: "noalias"
+                        };
+                        let alloc_operands_d: LLVMOperand[] = [alloc_size_op_d];
+                        let alloc_result_d = emit_runtime_call("alloc_struct", alloc_operands_d, alloc_overrides_d, local_temp
+                            + 2, local_lines);
+                        let mut _alloc_di_d: number = 0;
+                        loop {
+                            if _alloc_di_d >= alloc_result_d.diagnostics.length {
+                                break;
+                            }
+                            diagnostics.push(alloc_result_d.diagnostics[_alloc_di_d]);
+                            _alloc_di_d += 1;
+                        }
+                        local_lines = alloc_result_d.lines;
                         local_lines.push("  " + typed_ptr_temp
                             + " = bitcast i8* "
                             + malloc_temp
@@ -1142,9 +1278,22 @@ fn coerce_general_fallback(operand: LLVMOperand, operand_type: string, target: s
                             + operand_type
                             + "* "
                             + typed_ptr_temp);
-                        local_lines.push("  call void @sailfin_runtime_mark_persistent(i8* "
-                            + malloc_temp
-                            + ")");
+                        let mp_op_d = LLVMOperand {
+                            llvm_type: "i8*",
+                            value: malloc_temp
+                        };
+                        let mp_operands_d: LLVMOperand[] = [mp_op_d];
+                        let mp_result_d = emit_runtime_call("mark_persistent", mp_operands_d, empty_runtime_call_overrides(), local_temp
+                            + 4, local_lines);
+                        let mut _mp_di_d: number = 0;
+                        loop {
+                            if _mp_di_d >= mp_result_d.diagnostics.length {
+                                break;
+                            }
+                            diagnostics.push(mp_result_d.diagnostics[_mp_di_d]);
+                            _mp_di_d += 1;
+                        }
+                        local_lines = mp_result_d.lines;
                         has_value = true;
                         value_text = typed_ptr_temp;
                         local_temp += 4;
@@ -1161,6 +1310,9 @@ fn coerce_general_fallback(operand: LLVMOperand, operand_type: string, target: s
                         if starts_with(operand_type, "%") { _if89 = true; }
                         if starts_with(operand_type, "{") { _if89 = true; }
                         if _if89 {
+                            // M1.7.2a (#496): union-variant i8* boxing
+                            // routes alloc_struct and mark_persistent
+                            // through `emit_runtime_call`.
                             let size_ptr_temp = format_temp_name(local_temp);
                             let size_temp = format_temp_name(local_temp + 1);
                             let malloc_temp = format_temp_name(local_temp + 2);
@@ -1176,10 +1328,28 @@ fn coerce_general_fallback(operand: LLVMOperand, operand_type: string, target: s
                                 + "* "
                                 + size_ptr_temp
                                 + " to i64");
-                            local_lines.push("  " + malloc_temp
-                                + " = call noalias i8* @sailfin_runtime_alloc_struct(i64 "
-                                + size_temp
-                                + ")");
+                            let alloc_size_op_e = LLVMOperand {
+                                llvm_type: "i64",
+                                value: size_temp
+                            };
+                            let alloc_overrides_e = RuntimeCallOverrides {
+                                parameter_types: [],
+                                return_type: "",
+                                symbol: "",
+                                return_attributes: "noalias"
+                            };
+                            let alloc_operands_e: LLVMOperand[] = [alloc_size_op_e];
+                            let alloc_result_e = emit_runtime_call("alloc_struct", alloc_operands_e, alloc_overrides_e, local_temp
+                                + 2, local_lines);
+                            let mut _alloc_di_e: number = 0;
+                            loop {
+                                if _alloc_di_e >= alloc_result_e.diagnostics.length {
+                                    break;
+                                }
+                                diagnostics.push(alloc_result_e.diagnostics[_alloc_di_e]);
+                                _alloc_di_e += 1;
+                            }
+                            local_lines = alloc_result_e.lines;
                             local_lines.push("  " + typed_ptr_temp
                                 + " = bitcast i8* "
                                 + malloc_temp
@@ -1192,9 +1362,22 @@ fn coerce_general_fallback(operand: LLVMOperand, operand_type: string, target: s
                                 + operand_type
                                 + "* "
                                 + typed_ptr_temp);
-                            local_lines.push("  call void @sailfin_runtime_mark_persistent(i8* "
-                                + malloc_temp
-                                + ")");
+                            let mp_op_e = LLVMOperand {
+                                llvm_type: "i8*",
+                                value: malloc_temp
+                            };
+                            let mp_operands_e: LLVMOperand[] = [mp_op_e];
+                            let mp_result_e = emit_runtime_call("mark_persistent", mp_operands_e, empty_runtime_call_overrides(), local_temp
+                                + 4, local_lines);
+                            let mut _mp_di_e: number = 0;
+                            loop {
+                                if _mp_di_e >= mp_result_e.diagnostics.length {
+                                    break;
+                                }
+                                diagnostics.push(mp_result_e.diagnostics[_mp_di_e]);
+                                _mp_di_e += 1;
+                            }
+                            local_lines = mp_result_e.lines;
                             has_value = true;
                             value_text = malloc_temp;
                             local_temp += 4;
@@ -1321,6 +1504,8 @@ fn coerce_general_fallback(operand: LLVMOperand, operand_type: string, target: s
             if starts_with(operand.llvm_type, "%") { _if88 = true; }
             if starts_with(operand.llvm_type, "{") { _if88 = true; }
             if _if88 {
+                // M1.7.2a (#496): general-fallback i8* boxing routes
+                // alloc_struct and mark_persistent through `emit_runtime_call`.
                 let size_ptr_temp = format_temp_name(temp_index);
                 let size_temp = format_temp_name(temp_index + 1);
                 let malloc_temp = format_temp_name(temp_index + 2);
@@ -1334,10 +1519,28 @@ fn coerce_general_fallback(operand: LLVMOperand, operand_type: string, target: s
                     + "* "
                     + size_ptr_temp
                     + " to i64");
-                current_lines.push("  " + malloc_temp
-                    + " = call noalias i8* @sailfin_runtime_alloc_struct(i64 "
-                    + size_temp
-                    + ")");
+                let alloc_size_op_f = LLVMOperand {
+                    llvm_type: "i64",
+                    value: size_temp
+                };
+                let alloc_overrides_f = RuntimeCallOverrides {
+                    parameter_types: [],
+                    return_type: "",
+                    symbol: "",
+                    return_attributes: "noalias"
+                };
+                let alloc_operands_f: LLVMOperand[] = [alloc_size_op_f];
+                let alloc_result_f = emit_runtime_call("alloc_struct", alloc_operands_f, alloc_overrides_f, temp_index
+                    + 2, current_lines);
+                let mut _alloc_di_f: number = 0;
+                loop {
+                    if _alloc_di_f >= alloc_result_f.diagnostics.length {
+                        break;
+                    }
+                    diagnostics.push(alloc_result_f.diagnostics[_alloc_di_f]);
+                    _alloc_di_f += 1;
+                }
+                current_lines = alloc_result_f.lines;
                 current_lines.push("  " + typed_ptr_temp + " = bitcast i8* "
                     + malloc_temp
                     + " to "
@@ -1349,9 +1552,20 @@ fn coerce_general_fallback(operand: LLVMOperand, operand_type: string, target: s
                     + operand.llvm_type
                     + "* "
                     + typed_ptr_temp);
-                current_lines.push("  call void @sailfin_runtime_mark_persistent(i8* "
-                    + malloc_temp
-                    + ")");
+                let mp_op_f = LLVMOperand {
+                    llvm_type: "i8*",
+                    value: malloc_temp
+                };
+                let mp_operands_f: LLVMOperand[] = [mp_op_f];
+                let mp_result_f = emit_runtime_call("mark_persistent", mp_operands_f, empty_runtime_call_overrides(), temp_index
+                    + 4, current_lines);
+                let mut _mp_di_f: number = 0;
+                loop {
+                    if _mp_di_f >= mp_result_f.diagnostics.length { break; }
+                    diagnostics.push(mp_result_f.diagnostics[_mp_di_f]);
+                    _mp_di_f += 1;
+                }
+                current_lines = mp_result_f.lines;
                 let coerced = LLVMOperand {
                     llvm_type: "i8*",
                     value: malloc_temp
@@ -1384,6 +1598,8 @@ fn coerce_general_fallback(operand: LLVMOperand, operand_type: string, target: s
         if ends_with_pointer_suffix(target) {
             let expected_value_type = strip_pointer_suffix(target);
             if expected_value_type == operand.llvm_type {
+                // M1.7.2a (#496): typed-pointer boxing routes alloc_struct
+                // and mark_persistent through `emit_runtime_call`.
                 let size_ptr_temp = format_temp_name(temp_index);
                 let size_temp = format_temp_name(temp_index + 1);
                 let malloc_temp = format_temp_name(temp_index + 2);
@@ -1397,10 +1613,28 @@ fn coerce_general_fallback(operand: LLVMOperand, operand_type: string, target: s
                     + "* "
                     + size_ptr_temp
                     + " to i64");
-                current_lines.push("  " + malloc_temp
-                    + " = call noalias i8* @sailfin_runtime_alloc_struct(i64 "
-                    + size_temp
-                    + ")");
+                let alloc_size_op_g = LLVMOperand {
+                    llvm_type: "i64",
+                    value: size_temp
+                };
+                let alloc_overrides_g = RuntimeCallOverrides {
+                    parameter_types: [],
+                    return_type: "",
+                    symbol: "",
+                    return_attributes: "noalias"
+                };
+                let alloc_operands_g: LLVMOperand[] = [alloc_size_op_g];
+                let alloc_result_g = emit_runtime_call("alloc_struct", alloc_operands_g, alloc_overrides_g, temp_index
+                    + 2, current_lines);
+                let mut _alloc_di_g: number = 0;
+                loop {
+                    if _alloc_di_g >= alloc_result_g.diagnostics.length {
+                        break;
+                    }
+                    diagnostics.push(alloc_result_g.diagnostics[_alloc_di_g]);
+                    _alloc_di_g += 1;
+                }
+                current_lines = alloc_result_g.lines;
                 current_lines.push("  " + typed_ptr_temp + " = bitcast i8* "
                     + malloc_temp
                     + " to "
@@ -1412,9 +1646,20 @@ fn coerce_general_fallback(operand: LLVMOperand, operand_type: string, target: s
                     + operand.llvm_type
                     + "* "
                     + typed_ptr_temp);
-                current_lines.push("  call void @sailfin_runtime_mark_persistent(i8* "
-                    + malloc_temp
-                    + ")");
+                let mp_op_g = LLVMOperand {
+                    llvm_type: "i8*",
+                    value: malloc_temp
+                };
+                let mp_operands_g: LLVMOperand[] = [mp_op_g];
+                let mp_result_g = emit_runtime_call("mark_persistent", mp_operands_g, empty_runtime_call_overrides(), temp_index
+                    + 4, current_lines);
+                let mut _mp_di_g: number = 0;
+                loop {
+                    if _mp_di_g >= mp_result_g.diagnostics.length { break; }
+                    diagnostics.push(mp_result_g.diagnostics[_mp_di_g]);
+                    _mp_di_g += 1;
+                }
+                current_lines = mp_result_g.lines;
                 let mut pointer_value: string = typed_ptr_temp;
                 let mut next_index: number = temp_index + 4;
                 let typed_pointer_type = operand.llvm_type + "*";

--- a/compiler/src/llvm/expression_lowering/native/core_strings.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_strings.sfn
@@ -7,6 +7,7 @@ import { ExpressionResult, LLVMOperand, StringConstant } from "../../types";
 import { append_string, number_to_string } from "../../utils";
 import { coerce_operand_to_type, harmonise_operands } from "./core_operands";
 import { unescape_string_literal } from "./core_text";
+import { emit_runtime_call, empty_runtime_call_overrides } from "./runtime_call";
 
 fn lower_string_literal(literal: string, temp_index: number, lines: string[]) -> ExpressionResult {
     // M1.A — String literal lowering to {i8*, i64} aggregate.
@@ -39,11 +40,27 @@ fn lower_string_literal(literal: string, temp_index: number, lines: string[]) ->
     let byte_count = content.length;
 
     let mut current_lines: string[] = lines;
+    let mut diagnostics: string[] = [];
+    // M1.7.2a (#496): route through descriptor-driven dispatch. The
+    // alloc_struct emission here intentionally does *not* carry the
+    // `noalias` return attribute today (string-literal arena boxes
+    // are not known to be unique pointers, unlike user-struct boxes
+    // in `core_operands.sfn`); we preserve that exact shape by
+    // leaving `RuntimeCallOverrides.return_attributes` empty.
+    let alloc_size_operand = LLVMOperand {
+        llvm_type: "i64",
+        value: number_to_string(array_length)
+    };
+    let alloc_operands: LLVMOperand[] = [alloc_size_operand];
+    let alloc_result = emit_runtime_call("alloc_struct", alloc_operands, empty_runtime_call_overrides(), temp_index, current_lines);
+    let mut _alloc_di: number = 0;
+    loop {
+        if _alloc_di >= alloc_result.diagnostics.length { break; }
+        diagnostics.push(alloc_result.diagnostics[_alloc_di]);
+        _alloc_di += 1;
+    }
+    current_lines = alloc_result.lines;
     let malloc_temp = format_temp_name(temp_index);
-    current_lines.push("  " + malloc_temp
-        + " = call i8* @sailfin_runtime_alloc_struct(i64 "
-        + number_to_string(array_length)
-        + ")");
     let cast_temp = format_temp_name(temp_index + 1);
     current_lines.push("  " + cast_temp + " = bitcast i8* " + malloc_temp
         + " to "
@@ -75,7 +92,7 @@ fn lower_string_literal(literal: string, temp_index: number, lines: string[]) ->
         lines: current_lines,
         temp_index: temp_index + 4,
         operand: operand,
-        diagnostics: [],
+        diagnostics: diagnostics,
         string_constants: empty_constants
     };
 }

--- a/compiler/src/llvm/expression_lowering/native/runtime_call.sfn
+++ b/compiler/src/llvm/expression_lowering/native/runtime_call.sfn
@@ -58,10 +58,19 @@ import { coerce_operand_to_type } from "./core_operands";
 //   would otherwise be `descriptor.native_signature ?? descriptor.symbol`.
 //   Used during migrations whose source-level target name does not
 //   resolve to a descriptor key.
+// - `return_attributes`: when non-empty, renders between `call` and
+//   the return type — for example `"noalias"` produces
+//   `<temp> = call noalias <ret> @<symbol>(...)`. The descriptor schema
+//   intentionally has no slot for call-site return attributes (epic
+//   #494 forbids extending it), so allocator-style helpers whose
+//   today's emission carries `noalias` (e.g., `alloc_struct`) preserve
+//   the attribute through this per-call-site override during M1.7
+//   migrations. Ignored when `return_type == "void"`.
 struct RuntimeCallOverrides {
     parameter_types: string[];
     return_type: string;
     symbol: string;
+    return_attributes: string;
 }
 
 // Convenience constructor for the common "no overrides" case.
@@ -69,7 +78,8 @@ fn empty_runtime_call_overrides() -> RuntimeCallOverrides {
     return RuntimeCallOverrides {
         parameter_types: [],
         return_type: "",
-        symbol: ""
+        symbol: "",
+        return_attributes: ""
     };
 }
 
@@ -233,7 +243,13 @@ fn emit_runtime_call(target: string, operands: LLVMOperand[], overrides: Runtime
     }
 
     let temp_name = format_temp_name(result_temp);
-    result_lines.push("  " + temp_name + " = call " + return_type + " @"
+    let mut return_decoration: string = "";
+    if overrides.return_attributes.length > 0 {
+        return_decoration = overrides.return_attributes + " ";
+    }
+    result_lines.push("  " + temp_name + " = call " + return_decoration
+        + return_type
+        + " @"
         + call_symbol
         + "("
         + argument_text

--- a/compiler/src/llvm/expression_lowering/native/statement.sfn
+++ b/compiler/src/llvm/expression_lowering/native/statement.sfn
@@ -27,6 +27,7 @@ import { empty_string_constant_set } from "../../strings";
 // Import types from modular structure
 import {
     ExpressionStatementResult,
+    LLVMOperand,
     LifetimeRegionMetadata,
     LifetimeReleaseEvent,
     LocalBinding,
@@ -68,6 +69,7 @@ import {
     promote_local_to_rc
 } from "./core_scopes";
 import { is_heap_type } from "./core_type_mapping";
+import { emit_runtime_call, empty_runtime_call_overrides } from "./runtime_call";
 import { lower_lvalue_assignment_stmt } from "./statement_assignment";
 // Submodules extracted from this file
 import { parse_assignment_expression, parse_inline_let_expression } from "./statement_parsing";
@@ -683,11 +685,19 @@ fn lower_return_instruction(function: NativeFunction, instruction: NativeInstruc
     }
 
     let coerced_operand = coerced.operand;
-    // STAGE2 FIX: Mark string pointers as persistent before returning
+    // STAGE2 FIX: Mark string pointers as persistent before returning.
+    // M1.7.2a (#496): routes through `emit_runtime_call` so the call
+    // shape is owned by the descriptor table rather than hand-spelled.
     if coerced_operand.llvm_type == "i8*" {
-        current_lines.push("  call void @sailfin_runtime_mark_persistent(i8* "
-            + coerced_operand.value
-            + ")");
+        let mp_operands: LLVMOperand[] = [coerced_operand];
+        let mp_result = emit_runtime_call("mark_persistent", mp_operands, empty_runtime_call_overrides(), current_temp, current_lines);
+        let mut _mp_di: number = 0;
+        loop {
+            if _mp_di >= mp_result.diagnostics.length { break; }
+            diagnostics.push(mp_result.diagnostics[_mp_di]);
+            _mp_di += 1;
+        }
+        current_lines = mp_result.lines;
     }
     // M1.5.3 + M1.5.5: apply consumption and escape promotion *before*
     // computing scope-chain drops. The returned local is marked

--- a/compiler/src/llvm/runtime_helpers.sfn
+++ b/compiler/src/llvm/runtime_helpers.sfn
@@ -561,6 +561,29 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
         target: "mark_persistent", symbol: "sailfin_runtime_mark_persistent", return_type: "void", parameter_types: ["i8*"], effects: [], native_signature: null
     });
 
+    // M1.7.2a (issue #496): heap allocation primitive registered for
+    // `emit_runtime_call` dispatch. The seed already emits the matching
+    // `declare noalias i8* @sailfin_runtime_alloc_struct(i64)` line via
+    // `lowering_phase_render.sfn:164`, so adding this descriptor only
+    // unblocks the migration of the ~21 hand-spelled call sites — it
+    // does not introduce a new declare. The `noalias` return attribute
+    // is preserved at the call site through `RuntimeCallOverrides.return_attributes`
+    // because the descriptor schema deliberately has no slot for
+    // call-site attributes (epic #494 forbids extending it).
+    descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
+        target: "alloc_struct", symbol: "sailfin_runtime_alloc_struct", return_type: "i8*", parameter_types: ["i64"], effects: [], native_signature: null
+    });
+
+    // M1.7.2a (issue #496): arena-aware free for boxed return values.
+    // Today's only call site is `core.sfn:698`, where an awaited async
+    // result allocated through `sailfin_runtime_alloc_struct` is freed
+    // after the unboxing load. Plain `@free` corrupts arena chunk
+    // metadata; the runtime exposes the matching arena-aware entrypoint
+    // here. Already declared via `lowering_phase_render.sfn:167`.
+    descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
+        target: "runtime.free", symbol: "sailfin_runtime_free", return_type: "void", parameter_types: ["i8*"], effects: [], native_signature: null
+    });
+
     // Exceptions (stage2-native minimal)
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
         target: "set_exception", symbol: "sailfin_runtime_set_exception", return_type: "void", parameter_types: ["i8*"], effects: [], native_signature: null

--- a/compiler/tests/unit/runtime_call_dispatch_test.sfn
+++ b/compiler/tests/unit/runtime_call_dispatch_test.sfn
@@ -17,6 +17,15 @@
 //   - `runtime.bounds_check` — void return, two i64 args
 //   - `string.length`        — i64 return, single i8* arg,
 //                              `native_signature` flip to `sfn_str_len`
+//   - `alloc_struct`         — i8* return with `noalias` return-attribute
+//                              override (M1.7.2a, issue #496); pins the
+//                              `<temp> = call <attrs> <ret> @<sym>(<args>)`
+//                              render so allocator call-site migrations
+//                              don't drift in whitespace or attribute
+//                              placement.
+//   - `alloc_struct` (no attrs) — same descriptor without the override,
+//                              pins that the empty `return_attributes`
+//                              path stays attribute-free (no stray space).
 import {
     RuntimeCallOverrides,
     emit_runtime_call,
@@ -79,6 +88,34 @@ test "emit_runtime_call: string.length renders i64-return call to sfn_str_len" !
     let result = emit_runtime_call("string.length", operands, empty_runtime_call_overrides(), 0, []);
     assert result.lines.length == 1;
     assert result.lines[0] == "  %t0 = call i64 @sfn_str_len(i8* %s)";
+    assert result.temp_index == 1;
+    assert result.operand != null;
+    assert result.diagnostics.length == 0;
+}
+
+test "emit_runtime_call: alloc_struct with noalias return attribute renders attribute before return type" ![io] {
+    let size = _i64_operand("%size");
+    let operands: LLVMOperand[] = [size];
+    let overrides = RuntimeCallOverrides {
+        parameter_types: [],
+        return_type: "",
+        symbol: "",
+        return_attributes: "noalias"
+    };
+    let result = emit_runtime_call("alloc_struct", operands, overrides, 0, []);
+    assert result.lines.length == 1;
+    assert result.lines[0] == "  %t0 = call noalias i8* @sailfin_runtime_alloc_struct(i64 %size)";
+    assert result.temp_index == 1;
+    assert result.operand != null;
+    assert result.diagnostics.length == 0;
+}
+
+test "emit_runtime_call: alloc_struct without override renders no return attribute" ![io] {
+    let size = _i64_operand("%size");
+    let operands: LLVMOperand[] = [size];
+    let result = emit_runtime_call("alloc_struct", operands, empty_runtime_call_overrides(), 0, []);
+    assert result.lines.length == 1;
+    assert result.lines[0] == "  %t0 = call i8* @sailfin_runtime_alloc_struct(i64 %size)";
     assert result.temp_index == 1;
     assert result.operand != null;
     assert result.diagnostics.length == 0;


### PR DESCRIPTION
## Summary
- Migrates the largest hand-spelled runtime call-site family — ~21 `@sailfin_runtime_alloc_struct`, ~7 `@sailfin_runtime_mark_persistent`, and 1 `@sailfin_runtime_free` site — from raw-string IR emission to descriptor-driven dispatch through `emit_runtime_call`.
- Adds `alloc_struct` and `runtime.free` descriptors in `runtime_helpers.sfn` (`mark_persistent` reuses its existing entry).
- Extends `RuntimeCallOverrides` with a `return_attributes` slot so allocator sites whose seed emission carries `noalias` keep IR byte-identical (the descriptor schema stays untouched per epic #494; the per-call-site override is the opt-in seam).

Closes #496

## Acceptance Criteria
- [x] `grep -c '@sailfin_runtime_alloc_struct\|@sailfin_runtime_mark_persistent\|@sailfin_runtime_free' …` returns 0 for live sites in the targeted files (only one comment reference remains in `core.sfn:699`)
- [x] `grep 'target: "alloc_struct"' compiler/src/llvm/runtime_helpers.sfn` returns one descriptor
- [x] `grep 'target: "runtime.free"' compiler/src/llvm/runtime_helpers.sfn` returns one descriptor
- [x] Before/after IR diff is empty for `examples/basics/hello-world.sfn` AND struct-literal-heavy fixtures (`examples/advanced/encapsulation-struct.sfn`, `examples/types/recursive-types.sfn`) — covers both `noalias` and non-`noalias` `alloc_struct` shapes plus mark_persistent boxing
- [x] `make check` green: stage2 == stage3 fixed-point check ✓, full unit/integration/e2e suites pass on both first-pass binary and seedcheck
- [x] `sfn fmt --check` clean on every touched `.sfn`

## Verification
```bash
ulimit -v 8388608 && make rebuild
ulimit -v 8388608 && timeout 60 build/native/sailfin emit -o /tmp/m172a.before.ll llvm examples/basics/hello-world.sfn
# … apply migration …
ulimit -v 8388608 && make rebuild
ulimit -v 8388608 && timeout 60 build/native/sailfin emit -o /tmp/m172a.after.ll llvm examples/basics/hello-world.sfn
diff /tmp/m172a.before.ll /tmp/m172a.after.ll  # empty
ulimit -v 8388608 && make check                 # 55/55 e2e + 10/10 capsules + stage2==stage3 ✓
sfn fmt --check                                  # clean
```

## Files Changed
- `compiler/src/llvm/runtime_helpers.sfn` — `alloc_struct` + `runtime.free` descriptors
- `compiler/src/llvm/expression_lowering/native/runtime_call.sfn` — `RuntimeCallOverrides.return_attributes` field + render
- `compiler/src/llvm/expression_lowering/native/core_operands.sfn` — 8 alloc_struct + 7 mark_persistent boxing sites migrated
- `compiler/src/llvm/expression_lowering/native/core_literals_lowering.sfn` — 3 alloc_struct sites
- `compiler/src/llvm/expression_lowering/native/core_strings.sfn` — string-literal alloc_struct
- `compiler/src/llvm/expression_lowering/arrays.sfn` — concat buffer + struct allocs
- `compiler/src/llvm/expression_lowering/native/statement.sfn` — return-path mark_persistent
- `compiler/src/llvm/expression_lowering/native/core.sfn` — async-await `runtime.free`

## Notes for Reviewer
- Adding the import edge `core_operands ← runtime_call` introduces a dependency cycle with the existing `runtime_call ← core_operands` edge (the latter pulls in `coerce_operand_to_type`). The seed compiler resolves the cycle without complaint, so I left the structural cleanup for a follow-up.
- The `noalias` return attribute is preserved per-site through the new override rather than the descriptor — this matches today's mixed pattern (some `alloc_struct` sites carry `noalias`, others don't), and avoids extending `RuntimeHelperDescriptor` which the epic forbids.
- Boilerplate at each migrated site is intentionally inline (no `_emit_alloc_struct_with_mark` helper) to keep the diff structure transparent and the IR-diff gate easy to audit. A helper extraction is a fair follow-up if M1.7.2b/c land similar boxing patterns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FhYtuNV1AW93CCEbdcUxz2)_