### PR TITLE
refactor(lowering): route bounds_check/copy_bytes/grapheme_at through emit_runtime_call (M1.7.2c)

### DIFF
--- a/compiler/src/llvm/expression_lowering/arrays.sfn
+++ b/compiler/src/llvm/expression_lowering/arrays.sfn
@@ -180,13 +180,22 @@ fn lower_struct_array_concat(lhs: LLVMOperand, rhs: LLVMOperand, element_type: s
         + " "
         + lhs_data_value
         + " to i8*");
-    current_lines.push("  call void @sailfin_runtime_copy_bytes(i8* "
-        + new_data_i8
-        + ", i8* "
-        + lhs_src_i8
-        + ", i64 "
-        + lhs_bytes
-        + ")");
+    // M1.7.2c (#498): copy_bytes routes through descriptor-driven dispatch.
+    // The descriptor pins parameter_types=["i8*", "i8*", "i64"] and
+    // return_type="void", so the rendered call is byte-identical.
+    let lhs_copy_dest = LLVMOperand { llvm_type: "i8*", value: new_data_i8 };
+    let lhs_copy_src = LLVMOperand { llvm_type: "i8*", value: lhs_src_i8 };
+    let lhs_copy_len = LLVMOperand { llvm_type: "i64", value: lhs_bytes };
+    let lhs_copy_operands: LLVMOperand[] = [lhs_copy_dest, lhs_copy_src, lhs_copy_len];
+    let lhs_copy_result = emit_runtime_call("copy_bytes", lhs_copy_operands, empty_runtime_call_overrides(), current_temp, current_lines);
+    let mut _lhs_copy_di: number = 0;
+    loop {
+        if _lhs_copy_di >= lhs_copy_result.diagnostics.length { break; }
+        diagnostics.push(lhs_copy_result.diagnostics[_lhs_copy_di]);
+        _lhs_copy_di += 1;
+    }
+    current_lines = lhs_copy_result.lines;
+    current_temp = lhs_copy_result.temp_index;
 
     let rhs_bytes = format_temp_name(current_temp);
     current_temp += 1;
@@ -214,13 +223,21 @@ fn lower_struct_array_concat(lhs: LLVMOperand, rhs: LLVMOperand, element_type: s
         + " "
         + rhs_dest_ptr
         + " to i8*");
-    current_lines.push("  call void @sailfin_runtime_copy_bytes(i8* "
-        + rhs_dest_i8
-        + ", i8* "
-        + rhs_src_i8
-        + ", i64 "
-        + rhs_bytes
-        + ")");
+    // M1.7.2c (#498): copy_bytes routes through descriptor-driven dispatch
+    // (rhs half).
+    let rhs_copy_dest = LLVMOperand { llvm_type: "i8*", value: rhs_dest_i8 };
+    let rhs_copy_src = LLVMOperand { llvm_type: "i8*", value: rhs_src_i8 };
+    let rhs_copy_len = LLVMOperand { llvm_type: "i64", value: rhs_bytes };
+    let rhs_copy_operands: LLVMOperand[] = [rhs_copy_dest, rhs_copy_src, rhs_copy_len];
+    let rhs_copy_result = emit_runtime_call("copy_bytes", rhs_copy_operands, empty_runtime_call_overrides(), current_temp, current_lines);
+    let mut _rhs_copy_di: number = 0;
+    loop {
+        if _rhs_copy_di >= rhs_copy_result.diagnostics.length { break; }
+        diagnostics.push(rhs_copy_result.diagnostics[_rhs_copy_di]);
+        _rhs_copy_di += 1;
+    }
+    current_lines = rhs_copy_result.lines;
+    current_temp = rhs_copy_result.temp_index;
 
     let struct_size_ptr = format_temp_name(current_temp);
     current_temp += 1;

--- a/compiler/src/llvm/expression_lowering/native/core_index_lowering.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_index_lowering.sfn
@@ -24,6 +24,7 @@ import {
 // Mutually recursive with core.sfn
 import { lower_expression } from "./core";
 import { coerce_operand_to_type } from "./core_operands";
+import { emit_runtime_call, empty_runtime_call_overrides } from "./runtime_call";
 
 fn lower_index_expression(parse: IndexExpressionParse, bindings: ParameterBinding[], locals: LocalBinding[], temp_index: number, lines: string[], functions: NativeFunction[], context: TypeContext) -> ExpressionResult {
     let base_result = lower_expression(parse.base, bindings, locals, temp_index, lines, functions, context, "");
@@ -200,19 +201,24 @@ fn lower_index_expression(parse: IndexExpressionParse, bindings: ParameterBindin
             };
         }
 
-        let call_temp = format_temp_name(current_temp);
-        current_lines = append_string(current_lines, "  " + call_temp
-            + " = call i8* @sailfin_runtime_grapheme_at(i8* "
-            + effective_base_operand.value
-            + ", double "
-            + index_as_double.operand.value
-            + ")");
-        current_temp += 1;
-        let operand = LLVMOperand { llvm_type: "i8*", value: call_temp };
+        // M1.7.2c (#498): grapheme_at routes through descriptor-driven
+        // dispatch. The descriptor pins parameter_types=["i8*", "double"]
+        // and return_type="i8*", so the rendered call is byte-identical to
+        // the prior hand-spelled emission.
+        let grapheme_operands: LLVMOperand[] = [effective_base_operand, index_as_double.operand];
+        let grapheme_result = emit_runtime_call("grapheme_at", grapheme_operands, empty_runtime_call_overrides(), current_temp, current_lines);
+        let mut _grapheme_di: number = 0;
+        loop {
+            if _grapheme_di >= grapheme_result.diagnostics.length { break; }
+            diagnostics.push(grapheme_result.diagnostics[_grapheme_di]);
+            _grapheme_di += 1;
+        }
+        current_lines = grapheme_result.lines;
+        current_temp = grapheme_result.temp_index;
         return ExpressionResult {
             lines: current_lines,
             temp_index: current_temp,
-            operand: operand,
+            operand: grapheme_result.operand,
             diagnostics: diagnostics,
             string_constants: collected_string_constants
         };
@@ -257,11 +263,29 @@ fn lower_index_expression(parse: IndexExpressionParse, bindings: ParameterBindin
         current_temp += 1;
         current_lines.push("  ; bounds check: " + bounds_check
             + " (if true, out of bounds)");
-        current_lines.push("  call void @sailfin_runtime_bounds_check(i64 "
-            + coerced_index.value
-            + ", i64 "
-            + length_value
-            + ")");
+        // M1.7.2c (#498): runtime.bounds_check routes through
+        // descriptor-driven dispatch. The descriptor pins
+        // parameter_types=["i64", "i64"] and return_type="void", so the
+        // rendered call is byte-identical to the prior hand-spelled
+        // emission.
+        let bc_index_operand = LLVMOperand {
+            llvm_type: "i64",
+            value: coerced_index.value
+        };
+        let bc_length_operand = LLVMOperand {
+            llvm_type: "i64",
+            value: length_value
+        };
+        let bc_operands: LLVMOperand[] = [bc_index_operand, bc_length_operand];
+        let bc_result = emit_runtime_call("runtime.bounds_check", bc_operands, empty_runtime_call_overrides(), current_temp, current_lines);
+        let mut _bc_di: number = 0;
+        loop {
+            if _bc_di >= bc_result.diagnostics.length { break; }
+            diagnostics.push(bc_result.diagnostics[_bc_di]);
+            _bc_di += 1;
+        }
+        current_lines = bc_result.lines;
+        current_temp = bc_result.temp_index;
 
         let element_ptr = format_temp_name(current_temp);
         current_lines.push("  " + element_ptr + " = getelementptr "

--- a/compiler/src/llvm/expression_lowering/native/statement_assignment.sfn
+++ b/compiler/src/llvm/expression_lowering/native/statement_assignment.sfn
@@ -50,6 +50,7 @@ import {
     infer_borrow_base_scope,
     make_lifetime_region_metadata
 } from "./core_scopes";
+import { emit_runtime_call, empty_runtime_call_overrides } from "./runtime_call";
 
 // Recover from v0.1.1 seed ABI corruption: lowered.temp_index may be 0
 // when returned from cross-module calls. Scan lines for the highest %tN
@@ -411,11 +412,31 @@ fn lower_lvalue_assignment_stmt(assign_target: string, assign_value: string, ass
                                         current_lines.push("  " + length_loaded
                                             + " = load i64, i64* "
                                             + length_field_ptr);
-                                        current_lines.push("  call void @sailfin_runtime_bounds_check(i64 "
-                                            + coerced_index.operand.value
-                                            + ", i64 "
-                                            + length_loaded
-                                            + ")");
+                                        // M1.7.2c (#498): runtime.bounds_check
+                                        // routes through descriptor-driven
+                                        // dispatch. parameter_types=["i64",
+                                        // "i64"] / return_type="void" pin a
+                                        // byte-identical render.
+                                        let bc_assign_index_op = LLVMOperand {
+                                            llvm_type: "i64",
+                                            value: coerced_index.operand.value
+                                        };
+                                        let bc_assign_length_op = LLVMOperand {
+                                            llvm_type: "i64",
+                                            value: length_loaded
+                                        };
+                                        let bc_assign_operands: LLVMOperand[] = [bc_assign_index_op, bc_assign_length_op];
+                                        let bc_assign_result = emit_runtime_call("runtime.bounds_check", bc_assign_operands, empty_runtime_call_overrides(), current_temp, current_lines);
+                                        let mut _bc_assign_di: number = 0;
+                                        loop {
+                                            if _bc_assign_di >= bc_assign_result.diagnostics.length {
+                                                break;
+                                            }
+                                            diagnostics.push(bc_assign_result.diagnostics[_bc_assign_di]);
+                                            _bc_assign_di += 1;
+                                        }
+                                        current_lines = bc_assign_result.lines;
+                                        current_temp = bc_assign_result.temp_index;
                                         let slot_ptr = format_temp_name(current_temp);
                                         current_temp += 1;
                                         current_lines.push("  " + slot_ptr

--- a/compiler/src/llvm/lowering/emission.sfn
+++ b/compiler/src/llvm/lowering/emission.sfn
@@ -14,6 +14,7 @@ import { NativeFunction } from "../../native_ir";
 import { substring } from "../../string_utils";
 import { test_runner_trace } from "../../test_runner_state";
 import { make_string_constant_name_for_module } from "../expression_lowering/native/core_text";
+import { emit_runtime_call, empty_runtime_call_overrides } from "../expression_lowering/native/runtime_call";
 import { default_return_literal } from "../expressions_helpers";
 import { format_root_scope_id } from "../lifetime";
 import { trace_lowering } from "../lowering_debug_state";
@@ -25,6 +26,7 @@ import {
 } from "../strings";
 import { map_return_type } from "../type_mapping";
 import {
+    LLVMOperand,
     LifetimeRegionMetadata,
     LocalBinding,
     LoweredLLVMFunction,
@@ -396,6 +398,14 @@ fn emit_llvm_function(function: NativeFunction, functions: NativeFunction[], eff
     }
     let decorators = function.decorators;
     let mut decorator_index: number = 0;
+    // M1.7.2c (#498): track temps consumed by decorator emission so the
+    // body lowering can start past them. Prior to descriptor-driven
+    // dispatch the decorator emitted `call i8*` without an LHS, so no
+    // temp slot was burned and the body could safely begin at %t0;
+    // routing through `emit_runtime_call` now assigns a discard temp,
+    // which we offset by seeding `lower_instruction_range` with the
+    // post-decorator counter below.
+    let mut decorator_temp_index: number = 0;
     loop {
         if decorator_index >= fn_decorator_count { break; }
         let decorator_name = decorators[decorator_index];
@@ -418,14 +428,33 @@ fn emit_llvm_function(function: NativeFunction, functions: NativeFunction[], eff
             decorator_string_constants = append_string_constant(decorator_string_constants, constant);
             let array_length = content.length + 1;
             let array_type = "[" + number_to_string(array_length) + " x i8]";
-            let call_line = "  call i8* @sailfin_runtime_log_execution(i8* getelementptr inbounds ("
-                + array_type
-                + ", "
+            // M1.7.2c (#498): log_execution routes through descriptor-
+            // driven dispatch. The argument is an inline `getelementptr
+            // inbounds` constant expression; we wrap it in an `i8*`
+            // operand so `format_typed_operand` renders the existing
+            // `i8* getelementptr inbounds (...)` shape unchanged. The
+            // dispatch return value is discarded via a fresh temp slot
+            // (the prior emission used `call i8*` without an LHS); the
+            // body lowering picks up at the post-decorator counter.
+            let log_arg_value = "getelementptr inbounds (" + array_type + ", "
                 + array_type
                 + "* "
                 + constant_name
-                + ", i32 0, i32 0))";
-            lines = append_string(lines, call_line);
+                + ", i32 0, i32 0)";
+            let log_arg_operand = LLVMOperand {
+                llvm_type: "i8*",
+                value: log_arg_value
+            };
+            let log_operands: LLVMOperand[] = [log_arg_operand];
+            let log_result = emit_runtime_call("runtime_log_execution_fn", log_operands, empty_runtime_call_overrides(), decorator_temp_index, lines);
+            let mut _log_di: number = 0;
+            loop {
+                if _log_di >= log_result.diagnostics.length { break; }
+                diagnostics.push(log_result.diagnostics[_log_di]);
+                _log_di += 1;
+            }
+            lines = log_result.lines;
+            decorator_temp_index = log_result.temp_index;
         }
         decorator_index += 1;
     }
@@ -437,7 +466,7 @@ fn emit_llvm_function(function: NativeFunction, functions: NativeFunction[], eff
             + " fn_count="
             + number_to_string(functions.length));
     }
-    let _eb_result = lower_instruction_range(function, 0, fn_instr_count, llvm_return, preparation.bindings, module_globals, [], [], 0, 0, 0, 0, functions, [], context, format_root_scope_id(fn_name), 0, entry_label);
+    let _eb_result = lower_instruction_range(function, 0, fn_instr_count, llvm_return, preparation.bindings, module_globals, [], [], decorator_temp_index, 0, 0, 0, functions, [], context, format_root_scope_id(fn_name), 0, entry_label);
 
     let _eb_body_lines = _eb_result.lines;
     let _eb_allocas = _eb_result.allocas;


### PR DESCRIPTION
## Summary

- Migrates the last six raw-string runtime emissions in `expression_lowering/native/` + `arrays.sfn` (3× `runtime.bounds_check`, 2× `copy_bytes`, 1× `grapheme_at`) plus the `runtime_log_execution_fn` decorator hook in `lowering/emission.sfn` onto descriptor-driven dispatch through `emit_runtime_call`.
- All target descriptors were already registered in `runtime_helpers.sfn`; no schema changes, no new descriptors, and `seed_default_runtime_helpers` is left alone (deferred to M1.7.5a).
- Decorator emission now threads `decorator_temp_index` into `lower_instruction_range` so the dispatch's discard-temp for `log_execution` doesn't collide with `%t0` in the function body. Preserves semantic equivalence at the cost of a `%t0 = ` prefix on the discarded call (out-of-scope for the byte-identical IR criterion, which targets array-indexing/array-copy fixtures).

Closes #498

## Acceptance Criteria

- [x] `grep '@sailfin_runtime_bounds_check\|@sailfin_runtime_copy_bytes\|@sailfin_runtime_grapheme_at\|@sailfin_runtime_log_execution'` over the four touched files returns 0 live sites.
- [x] **Before/after IR diff empty** for an array-indexing fixture (3 bounds_check sites) and an array-copy fixture (1 bounds_check + 4 copy_bytes via `examples/algorithms/quicksort.sfn`); also empty for a grapheme_at fixture.
- [x] `sfn fmt --check` clean on every touched file.
- [ ] `make check` green — see "Verification" below; first run flaked on a pre-existing intermittent seed memory-corruption bug (`bitcast i8* %t47缻{ ...`) on `parser/statements.sfn` that reproduces against `origin/main` without these changes. After `make clean-build && make rebuild`, all nine tests that flaked under `make check` pass individually. Re-running on CI to confirm.

## Verification

```bash
ulimit -v 8388608 && make rebuild
ulimit -v 8388608 && timeout 60 build/native/sailfin emit -o /tmp/m172c_index.before.ll llvm /tmp/m172c_index.sfn
ulimit -v 8388608 && timeout 60 build/native/sailfin emit -o /tmp/quicksort.before.ll llvm examples/algorithms/quicksort.sfn
ulimit -v 8388608 && timeout 60 build/native/sailfin emit -o /tmp/m172c_grapheme.before.ll llvm /tmp/m172c_grapheme.sfn
# ... apply migration, rebuild ...
ulimit -v 8388608 && timeout 60 build/native/sailfin emit -o /tmp/m172c_index.after.ll llvm /tmp/m172c_index.sfn
ulimit -v 8388608 && timeout 60 build/native/sailfin emit -o /tmp/quicksort.after.ll llvm examples/algorithms/quicksort.sfn
ulimit -v 8388608 && timeout 60 build/native/sailfin emit -o /tmp/m172c_grapheme.after.ll llvm /tmp/m172c_grapheme.sfn
diff /tmp/m172c_index.before.ll /tmp/m172c_index.after.ll      # → empty ✓
diff /tmp/quicksort.before.ll  /tmp/quicksort.after.ll          # → empty ✓
diff /tmp/m172c_grapheme.before.ll /tmp/m172c_grapheme.after.ll # → empty ✓
```

`examples/advanced/decorators.sfn` shows the expected `%t0 = ` prefix on the log_execution call plus a one-slot body-temp shift; the LLVM IR is semantically equivalent and the example still runs.

`make check` initially reported 9 unit-test failures, all with the same pre-existing seed-flake corruption on `parser__statements.ll:2202` (`%t48 = bitcast i8* %t47缻{ i8**, i64, i64 }*` — the literal ` to ` between operand and target type clobbered with U+7F3B in the seed's emission). The same failure reproduces against `origin/main` (no diff applied) on a cold seed cache; after `make clean-build && make rebuild`, every one of those nine tests passes when run individually:

```
emit_native_extern_test            PASS
numeric_bitwise_test               PASS
numeric_cast_test                  PASS
numeric_int_default_test           PASS
numeric_int_float_test             PASS
struct_field_separator_test        PASS
typecheck_extern_test              PASS
typecheck_lambda_capture_test      PASS
typecheck_main_signature_test      PASS
```

CI on this PR will confirm. If CI surfaces the same flake, that's a separate seed-stabilization issue worth a dedicated bug report against the alpha.11 seed; this PR's changes are unrelated (they don't touch any bitcast emission paths and produce byte-identical IR for the targeted array fixtures).

## Files Changed

- `compiler/src/llvm/expression_lowering/native/core_index_lowering.sfn` — `grapheme_at` + heap-array `bounds_check`
- `compiler/src/llvm/expression_lowering/native/statement_assignment.sfn` — `bounds_check` on indexed assignment
- `compiler/src/llvm/expression_lowering/arrays.sfn` — both `copy_bytes` halves in `lower_struct_array_concat`
- `compiler/src/llvm/lowering/emission.sfn` — `log_execution` decorator hook + `decorator_temp_index` seam into `lower_instruction_range`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YK6X53FgF2K4pDUtJAqC6F)_