### PR TITLE
feat(test-runner): wire host-capsule resolver context for sfn test

### DIFF
--- a/capsules/sfn/json/tests/json_test.sfn
+++ b/capsules/sfn/json/tests/json_test.sfn
@@ -1,160 +1,90 @@
 // Tests for sfn/json capsule constructors and accessors.
 //
-// Moved from compiler/tests/unit/json_structs_test.sfn. Helpers and the
-// JsonValue struct stay inlined here. Skip stringify_pretty — it routes
-// through `number_to_string`/`char_code` paths the test runner doesn't
-// link to today. When `import { ... } from "../src/mod"` is safe, switch
-// to the real capsule API and grow coverage to the parse/stringify roundtrip.
-
-struct JsonValue {
-    kind: string;
-    string_value: string;
-    number_value: number;
-    bool_value: boolean;
-    items: JsonValue[];
-    keys: string[];
-    values: JsonValue[];
-}
-
-fn _string_val(value: string) -> JsonValue {
-    return JsonValue {
-        kind: "string", string_value: value, number_value: 0,
-        bool_value: false, items: [], keys: [], values: [],
-    };
-}
-
-fn _number_val(value: number) -> JsonValue {
-    return JsonValue {
-        kind: "number", string_value: "", number_value: value,
-        bool_value: false, items: [], keys: [], values: [],
-    };
-}
-
-fn _bool_val(value: boolean) -> JsonValue {
-    return JsonValue {
-        kind: "boolean", string_value: "", number_value: 0,
-        bool_value: value, items: [], keys: [], values: [],
-    };
-}
-
-fn _null_val() -> JsonValue {
-    return JsonValue {
-        kind: "null", string_value: "", number_value: 0,
-        bool_value: false, items: [], keys: [], values: [],
-    };
-}
-
-fn _array_val(items: JsonValue[]) -> JsonValue {
-    return JsonValue {
-        kind: "array", string_value: "", number_value: 0,
-        bool_value: false, items: items, keys: [], values: [],
-    };
-}
-
-fn _object_val(keys: string[], values: JsonValue[]) -> JsonValue {
-    return JsonValue {
-        kind: "object", string_value: "", number_value: 0,
-        bool_value: false, items: [], keys: keys, values: values,
-    };
-}
-
-// -- New accessor functions --
-
-fn _has_key(obj: JsonValue, key: string) -> boolean {
-    if !strings_equal(obj.kind, "object") { return false; }
-    let mut i: number = 0;
-    loop {
-        if i >= obj.keys.length { break; }
-        if strings_equal(obj.keys[i], key) { return true; }
-        i += 1;
-    }
-    return false;
-}
-
-fn _get_bool(obj: JsonValue, key: string) -> boolean {
-    if !strings_equal(obj.kind, "object") { return false; }
-    let mut i: number = 0;
-    loop {
-        if i >= obj.keys.length { break; }
-        if strings_equal(obj.keys[i], key) {
-            return obj.values[i].bool_value;
-        }
-        i += 1;
-    }
-    return false;
-}
-
-fn _get_value(obj: JsonValue, key: string) -> JsonValue {
-    if !strings_equal(obj.kind, "object") { return _null_val(); }
-    let mut i: number = 0;
-    loop {
-        if i >= obj.keys.length { break; }
-        if strings_equal(obj.keys[i], key) {
-            return obj.values[i];
-        }
-        i += 1;
-    }
-    return _null_val();
-}
-
-fn _array_length(value: JsonValue) -> number {
-    if !strings_equal(value.kind, "array") { return 0; }
-    return value.items.length;
-}
-
-fn _array_at(value: JsonValue, index: number) -> JsonValue {
-    if !strings_equal(value.kind, "array") { return _null_val(); }
-    if index < 0 || index >= value.items.length { return _null_val(); }
-    return value.items[index];
-}
+// P1 (#363): rewritten to import the host capsule's public API
+// instead of inlining a private copy of the struct + helpers. The
+// runner now resolves capsule-relative imports (`../src/mod`) plus
+// host-name imports, so test fixtures can exercise the real API
+// surface end-to-end.
+import {
+    JsonValue,
+    array_at,
+    array_length,
+    array_val,
+    bool_val,
+    get_bool,
+    get_value,
+    has_key,
+    null_val,
+    number_val,
+    object_val,
+    parse,
+    string_val,
+    stringify
+} from "../src/mod";
 
 // -- Tests --
-
 test "json: has_key on object" {
-    let obj = _object_val(["name", "age"], [_string_val("Alice"), _number_val(30)]);
-    assert _has_key(obj, "name") == true;
-    assert _has_key(obj, "age") == true;
-    assert _has_key(obj, "missing") == false;
+    let obj = object_val(["name", "age"], [string_val("Alice"), number_val(30)]);
+    assert has_key(obj, "name") == true;
+    assert has_key(obj, "age") == true;
+    assert has_key(obj, "missing") == false;
 }
 
 test "json: has_key on non-object" {
-    let arr = _array_val([_number_val(1)]);
-    assert _has_key(arr, "key") == false;
+    let arr = array_val([number_val(1)]);
+    assert has_key(arr, "key") == false;
 }
 
 test "json: get_bool" {
-    let obj = _object_val(["active", "name"], [_bool_val(true), _string_val("test")]);
-    assert _get_bool(obj, "active") == true;
-    assert _get_bool(obj, "name") == false;
-    assert _get_bool(obj, "missing") == false;
+    let obj = object_val(["active", "name"], [bool_val(true), string_val("test")]);
+    assert get_bool(obj, "active") == true;
+    assert get_bool(obj, "name") == false;
+    assert get_bool(obj, "missing") == false;
 }
 
 test "json: get_value returns correct type" {
-    let obj = _object_val(["count"], [_number_val(42)]);
-    let val = _get_value(obj, "count");
+    let obj = object_val(["count"], [number_val(42)]);
+    let val = get_value(obj, "count");
     assert strings_equal(val.kind, "number");
     assert val.number_value == 42;
 }
 
 test "json: get_value returns null for missing key" {
-    let obj = _object_val(["a"], [_string_val("b")]);
-    let val = _get_value(obj, "missing");
+    let obj = object_val(["a"], [string_val("b")]);
+    let val = get_value(obj, "missing");
     assert strings_equal(val.kind, "null");
 }
 
 test "json: array_length" {
-    let arr = _array_val([_number_val(1), _number_val(2), _number_val(3)]);
-    assert _array_length(arr) == 3;
-    assert _array_length(_null_val()) == 0;
-    assert _array_length(_array_val([])) == 0;
+    let arr = array_val([number_val(1), number_val(2), number_val(3)]);
+    assert array_length(arr) == 3;
+    assert array_length(null_val()) == 0;
+    assert array_length(array_val([])) == 0;
 }
 
 test "json: array_at" {
-    let arr = _array_val([_string_val("a"), _string_val("b"), _string_val("c")]);
-    let first = _array_at(arr, 0);
+    let arr = array_val([string_val("a"), string_val("b"), string_val("c")]);
+    let first = array_at(arr, 0);
     assert strings_equal(first.string_value, "a");
-    let last = _array_at(arr, 2);
+    let last = array_at(arr, 2);
     assert strings_equal(last.string_value, "c");
-    let oob = _array_at(arr, 5);
+    let oob = array_at(arr, 5);
     assert strings_equal(oob.kind, "null");
+}
+
+test "json: stringify primitives" {
+    assert strings_equal(stringify(string_val("hi")), "\"hi\"");
+    assert strings_equal(stringify(bool_val(true)), "true");
+    assert strings_equal(stringify(null_val()), "null");
+}
+
+test "json: parse / stringify roundtrip on object" {
+    let original = object_val(["k"], [string_val("v")]);
+    let text = stringify(original);
+    let parsed: JsonValue = parse(text);
+    assert strings_equal(parsed.kind, "object");
+    assert has_key(parsed, "k");
+    let v = get_value(parsed, "k");
+    assert strings_equal(v.kind, "string");
+    assert strings_equal(v.string_value, "v");
 }

--- a/compiler/src/capsule_resolver.sfn
+++ b/compiler/src/capsule_resolver.sfn
@@ -52,7 +52,8 @@ import {
 import {
     CapsuleArtifactLayout,
     capsule_artifact_layout_from_specs,
-    ir_path_for_slug
+    ir_path_for_slug,
+    parse_scope_name
 } from "./capsule_artifact";
 import {
     compile_to_llvm_file_with_module,
@@ -140,17 +141,28 @@ struct CapsuleSource {
 // files the link needs). Empty consumer / `walk_project_src=false`
 // preserves the legacy entry-driven enumeration, so end-user
 // builds and the existing self-host paths are unaffected.
+//
+// P1 (#363): `include_host_as_dep` opts the resolver into walking
+// the host capsule's `<project_root>/src/` as if it were a
+// manifest-declared dep. Set by `sfn test` so a test file in
+// `<project>/tests/` can `import { fn } from "<capsule_name>"` and
+// have the resolver stage + compile the host capsule under slug
+// `<capsule_name>/<stem>`. The build path (`sfn build`) keeps this
+// off — the host capsule's entry source is already compiled
+// directly, so re-enumerating it as a dep would double-emit.
 struct ResolverConsumer {
     scope: string;
     name: string;
     walk_project_src: boolean;
+    include_host_as_dep: boolean;
 }
 
 fn empty_resolver_consumer() -> ResolverConsumer {
     return ResolverConsumer {
         scope: "",
         name: "",
-        walk_project_src: false
+        walk_project_src: false,
+        include_host_as_dep: false
     };
 }
 
@@ -895,6 +907,48 @@ fn _cr_collect_capsule_sources(src_dir: string, spec: string) -> CapsuleSource[]
         }
     }
     return out;
+}
+
+// P1 (#363): enumerate every .sfn source under
+// `<project_root>/src/` and tag it with the host capsule's
+// `[capsule].name` as the spec, so a test file in `<project>/tests/`
+// can `import { fn } from "<capsule_name>"` and have the resolver
+// stage + compile the source under slug `<capsule_name>/<stem>`.
+// Returns empty when the manifest is missing, has no `[capsule].name`,
+// or the name is unsafe (path traversal) — callers fall through to
+// relative-import / workspace-implicit walks. Skipped when
+// `<project_root>/src/` doesn't exist.
+//
+// Slug shape mirrors `_cr_collect_capsule_sources(src_dir, spec)`:
+// for `[capsule].name = "my-app"` and `<project_root>/src/mod.sfn`
+// the resolver produces `slug = "my-app/mod"`. The test source's
+// `import { fn } from "my-app";` resolves to provider slug
+// `my-app/mod` via `resolve_import_artifact_slug`'s `<base>/mod`
+// fallback, which is what makes the link line resolve.
+fn _cr_enumerate_host_capsule_sources(project_root: string) -> CapsuleSource[] ![io] {
+    let mut out: CapsuleSource[] = [];
+    if project_root.length == 0 { return out; }
+    let manifest_path = _cr_path_join(project_root, "capsule.toml");
+    if !fs.exists(manifest_path) { return out; }
+    let manifest_text = fs.readFile(manifest_path);
+    let capsule_name = toml_get_name(manifest_text);
+    if capsule_name.length == 0 { return out; }
+    // Reject path-traversal / separator characters in the name. The
+    // helper is shared with `_cr_locate_capsule_src`'s scope/name
+    // gates; passing each segment through `_cr_is_safe_segment`
+    // mirrors what `parse_scope_name` + `is_safe_scope_name` would
+    // do for scope-form names, while also accepting single-segment
+    // names like `"my-app"` (which `parse_scope_name` rejects).
+    let parts = parse_scope_name(capsule_name);
+    if parts.scope.length > 0 {
+        if !_cr_is_safe_segment(parts.scope) { return out; }
+        if !_cr_is_safe_segment(parts.name) { return out; }
+    } else {
+        if !_cr_is_safe_segment(capsule_name) { return out; }
+    }
+    let src_dir = _cr_path_join(project_root, "src");
+    if !fs.exists(src_dir) { return out; }
+    return _cr_collect_capsule_sources(src_dir, capsule_name);
 }
 
 // Enumerate every .sfn source file for every dep declared in the project's
@@ -2812,6 +2866,266 @@ fn collect_scoped_import_specs(source: string) -> string[] {
     return out;
 }
 
+// P1 (#363): scan one source file for `import { ... } from "<spec>";`
+// (and the `export { ... } from "..."` re-export shape) and return
+// true if any spec equals `target` or starts with `target + "/"`. Used
+// by `_cr_resolve_and_dedupe` to decide whether the host-capsule
+// enumeration is needed. Cheap: collected specs go through the same
+// comment-aware scanner that `collect_scoped_import_specs` shares with
+// the existing relative-import / workspace-implicit walks; the only
+// difference here is the post-filter (the existing scanner drops bare-
+// name specs like `"my-app"` because those don't have a `/`).
+//
+// `target` should be the manifest's `[capsule].name`. `target/sub`
+// matches the same prefix-relationship the import resolver applies
+// when it canonicalises a scoped import down to its `scope/name`
+// slug, so an `import { ... } from "<host>/util"` also gates the
+// host enumeration on (a future submodule layout would land under
+// `<host>/util.sfn` or `<host>/util/mod.sfn`, both of which the host
+// walker captures).
+fn _cr_source_imports_host(source: string, target: string) -> boolean {
+    if target.length == 0 { return false; }
+    let source_len = source.length;
+    if source_len == 0 { return false; }
+    let mut steps: number = 0;
+    let max_steps = source_len * 6 + 1000;
+    let mut i: number = 0;
+    let mut in_string: boolean = false;
+    let mut escaping: boolean = false;
+    let mut in_line_comment: boolean = false;
+    let mut in_block_comment: boolean = false;
+    loop {
+        if i >= source_len { break; }
+        steps += 1;
+        if steps > max_steps { break; }
+        let ch = _cr_byte_at(source, i);
+        if in_line_comment {
+            if ch == "\n" { in_line_comment = false; }
+            i += 1;
+            continue;
+        }
+        if in_block_comment {
+            if ch == "*" {
+                if i + 1 < source_len {
+                    if _cr_byte_at(source, i + 1) == "/" {
+                        in_block_comment = false;
+                        i += 2;
+                        continue;
+                    }
+                }
+            }
+            i += 1;
+            continue;
+        }
+        if in_string {
+            if escaping {
+                escaping = false;
+                i += 1;
+                continue;
+            }
+            if ch == "\\" {
+                escaping = true;
+                i += 1;
+                continue;
+            }
+            if ch == "\"" {
+                in_string = false;
+                i += 1;
+                continue;
+            }
+            i += 1;
+            continue;
+        }
+        if ch == "/" {
+            if i + 1 < source_len {
+                let next = _cr_byte_at(source, i + 1);
+                if next == "/" {
+                    in_line_comment = true;
+                    i += 2;
+                    continue;
+                }
+                if next == "*" {
+                    in_block_comment = true;
+                    i += 2;
+                    continue;
+                }
+            }
+        }
+        if ch == "\"" {
+            in_string = true;
+            i += 1;
+            continue;
+        }
+        let mut _is_dep_keyword: boolean = false;
+        if _cr_word_matches(source, i, "import") { _is_dep_keyword = true; }
+        if _cr_word_matches(source, i, "export") { _is_dep_keyword = true; }
+        if _is_dep_keyword {
+            // Walk forward to the `from "..."` token and pull the spec.
+            // Mirrors `collect_scoped_import_specs`'s tokenising loop —
+            // duplicated here to avoid running the broader scanner
+            // (allocates a string array) when a single literal-match
+            // probe is all we need.
+            let mut j: number = i;
+            let mut s_in_string: boolean = false;
+            let mut s_escaping: boolean = false;
+            let mut s_in_line_comment: boolean = false;
+            let mut s_in_block_comment: boolean = false;
+            let mut spec: string = "";
+            let mut stmt_end: number = -1;
+            loop {
+                if j >= source_len { break; }
+                steps += 1;
+                if steps > max_steps { break; }
+                let cj = _cr_byte_at(source, j);
+                if s_in_line_comment {
+                    if cj == "\n" { s_in_line_comment = false; }
+                    j += 1;
+                    continue;
+                }
+                if s_in_block_comment {
+                    if cj == "*" {
+                        if j + 1 < source_len {
+                            if _cr_byte_at(source, j + 1) == "/" {
+                                s_in_block_comment = false;
+                                j += 2;
+                                continue;
+                            }
+                        }
+                    }
+                    j += 1;
+                    continue;
+                }
+                if s_in_string {
+                    if s_escaping {
+                        s_escaping = false;
+                        j += 1;
+                        continue;
+                    }
+                    if cj == "\\" {
+                        s_escaping = true;
+                        j += 1;
+                        continue;
+                    }
+                    if cj == "\"" {
+                        s_in_string = false;
+                        j += 1;
+                        continue;
+                    }
+                    j += 1;
+                    continue;
+                }
+                if cj == "/" {
+                    if j + 1 < source_len {
+                        let nj = _cr_byte_at(source, j + 1);
+                        if nj == "/" {
+                            s_in_line_comment = true;
+                            j += 2;
+                            continue;
+                        }
+                        if nj == "*" {
+                            s_in_block_comment = true;
+                            j += 2;
+                            continue;
+                        }
+                    }
+                }
+                if cj == "\"" {
+                    s_in_string = true;
+                    j += 1;
+                    continue;
+                }
+                if spec.length == 0 {
+                    if _cr_word_matches(source, j, "from") {
+                        let mut k = j + 4;
+                        loop {
+                            if k >= source_len { break; }
+                            let wk = _cr_byte_at(source, k);
+                            let mut ws: boolean = false;
+                            if wk == " " { ws = true; }
+                            if wk == "\t" { ws = true; }
+                            if wk == "\n" { ws = true; }
+                            if wk == "\r" { ws = true; }
+                            if !ws { break; }
+                            k += 1;
+                        }
+                        if k < source_len {
+                            if _cr_byte_at(source, k) == "\"" {
+                                k += 1;
+                                let start = k;
+                                let mut esc: boolean = false;
+                                loop {
+                                    if k >= source_len { break; }
+                                    let sk = _cr_byte_at(source, k);
+                                    if esc {
+                                        esc = false;
+                                        k += 1;
+                                        continue;
+                                    }
+                                    if sk == "\\" {
+                                        esc = true;
+                                        k += 1;
+                                        continue;
+                                    }
+                                    if sk == "\"" {
+                                        spec = substring(source, start, k);
+                                        break;
+                                    }
+                                    k += 1;
+                                }
+                            }
+                        }
+                    }
+                }
+                if cj == ";" {
+                    stmt_end = j + 1;
+                    break;
+                }
+                j += 1;
+            }
+            if stmt_end > 0 {
+                if spec.length > 0 {
+                    if strings_equal(spec, target) { return true; }
+                    if spec.length > target.length {
+                        if substring(spec, 0, target.length) == target {
+                            if substring(spec, target.length, target.length + 1) == "/" {
+                                return true;
+                            }
+                        }
+                    }
+                }
+                i = stmt_end;
+                continue;
+            }
+        }
+        i += 1;
+    }
+    return false;
+}
+
+// P1 (#363): scan every test entry once and report whether any of
+// them imports the host capsule by its `[capsule].name`. The host-
+// capsule enumeration is gated on this so the resolver doesn't
+// stage extra `<name>/<rel>` slugs for capsules whose tests only
+// reach the host source via `../src/...` relative imports — those
+// already produce path-shaped slugs through the relative-import
+// walker, and shadowing them with `<name>/...` slugs would race
+// the build cache (which keys IR by source content + dep manifests
+// only, not by slug — see `cache_key_for`).
+fn _cr_any_entry_imports_host(entry_paths: string[], capsule_name: string) -> boolean ![io] {
+    if capsule_name.length == 0 { return false; }
+    let mut i: number = 0;
+    loop {
+        if i >= entry_paths.length { break; }
+        let entry = entry_paths[i];
+        if fs.exists(entry) {
+            let source = fs.readFile(entry);
+            if _cr_source_imports_host(source, capsule_name) { return true; }
+        }
+        i += 1;
+    }
+    return false;
+}
+
 // Look up a workspace member src dir from a scoped import spec like
 // "sfn/http". Submodule paths ("sfn/http/client") strip the trailing
 // segments down to the canonical "scope/name" before lookup so the spec
@@ -3092,6 +3406,57 @@ fn _cr_resolve_and_dedupe(entry_paths: string[], consumer: ResolverConsumer) -> 
             if di >= dep_sources.length { break; }
             sources.push(dep_sources[di]);
             di += 1;
+        }
+        // P1 (#363): when `consumer.include_host_as_dep` is set
+        // (currently `sfn test`) AND at least one test entry
+        // imports the host capsule by its `[capsule].name`,
+        // enumerate `<project_root>/src/` and tag each source with
+        // the manifest's name as the spec. Without this gate, a
+        // capsule whose tests only reach the host via `../src/...`
+        // (path-shaped slug) would still get a parallel
+        // `<name>/<rel>` enumeration, and `cache_key_for`'s
+        // slug-blind keying would race the two compiles on the same
+        // cache entry — every test in the resolver-driven `make
+        // test` suite then surfaces undefined references for the
+        // shape that lost the race. The build path keeps this off
+        // (`empty_resolver_consumer()`) because the host capsule's
+        // entry source is compiled directly via the single-file
+        // `compile_to_llvm_file_with_module` path, so re-
+        // enumerating it here would double-emit.
+        if consumer.include_host_as_dep {
+            let manifest_path = _cr_path_join(project_root, "capsule.toml");
+            if fs.exists(manifest_path) {
+                let manifest_text = fs.readFile(manifest_path);
+                let host_name = toml_get_name(manifest_text);
+                if host_name.length > 0 {
+                    if _cr_any_entry_imports_host(entry_paths, host_name) {
+                        let host_sources = _cr_enumerate_host_capsule_sources(project_root);
+                        let mut hi: number = 0;
+                        loop {
+                            if hi >= host_sources.length { break; }
+                            let candidate = host_sources[hi];
+                            // Filter by source_path — the relative-
+                            // import walker may have already emitted
+                            // the same source under a path-shaped
+                            // slug; the slug-collision detector
+                            // doesn't catch that case because the
+                            // slugs differ.
+                            let mut already_seen: boolean = false;
+                            let mut sj: number = 0;
+                            loop {
+                                if sj >= sources.length { break; }
+                                if strings_equal(sources[sj].source_path, candidate.source_path) {
+                                    already_seen = true;
+                                    break;
+                                }
+                                sj += 1;
+                            }
+                            if !already_seen { sources.push(candidate); }
+                            hi += 1;
+                        }
+                    }
+                }
+            }
         }
     }
 

--- a/compiler/src/capsule_resolver.sfn
+++ b/compiler/src/capsule_resolver.sfn
@@ -53,6 +53,7 @@ import {
     CapsuleArtifactLayout,
     capsule_artifact_layout_from_specs,
     ir_path_for_slug,
+    is_safe_scope_name,
     parse_scope_name
 } from "./capsule_artifact";
 import {
@@ -933,16 +934,17 @@ fn _cr_enumerate_host_capsule_sources(project_root: string) -> CapsuleSource[] !
     let manifest_text = fs.readFile(manifest_path);
     let capsule_name = toml_get_name(manifest_text);
     if capsule_name.length == 0 { return out; }
-    // Reject path-traversal / separator characters in the name. The
-    // helper is shared with `_cr_locate_capsule_src`'s scope/name
-    // gates; passing each segment through `_cr_is_safe_segment`
-    // mirrors what `parse_scope_name` + `is_safe_scope_name` would
-    // do for scope-form names, while also accepting single-segment
-    // names like `"my-app"` (which `parse_scope_name` rejects).
+    // Reject path-traversal / separator characters in the name.
+    // For scope-form names (`acme/router`, `acme/router/middleware/auth`),
+    // delegate to `is_safe_scope_name` so submodule capsule names with
+    // multi-segment `name` parts (the second `/` onward survives in
+    // `parts.name`) round-trip — `_cr_is_safe_segment` would reject
+    // any `/`. Single-segment names like `"my-app"` don't go through
+    // `parse_scope_name` (it returns empty for no-slash inputs) so
+    // those still need a direct safe-segment check.
     let parts = parse_scope_name(capsule_name);
     if parts.scope.length > 0 {
-        if !_cr_is_safe_segment(parts.scope) { return out; }
-        if !_cr_is_safe_segment(parts.name) { return out; }
+        if !is_safe_scope_name(parts.scope, parts.name) { return out; }
     } else {
         if !_cr_is_safe_segment(capsule_name) { return out; }
     }

--- a/compiler/src/cli_commands.sfn
+++ b/compiler/src/cli_commands.sfn
@@ -6,10 +6,10 @@ import { AssertFailure, _empty_assert_failure, _parse_assert_failure_record } fr
 import { Program, Statement } from "./ast";
 import { is_safe_scope_name, parse_scope_name } from "./capsule_artifact";
 import {
+    ResolverConsumer,
     TestCapsuleResolution,
     discover_project_root,
     discover_workspace_root,
-    empty_resolver_consumer,
     prepare_project_capsules_for_test
 } from "./capsule_resolver";
 import {
@@ -29,6 +29,7 @@ import {
     _has_prefix_cmd,
     _legacy_flag_file,
     _looks_like_test_file_cmd,
+    _path_join_cmd,
     _resolve_capsule_name_cmd,
     _sanitize_filename_cmd,
     _sha256_of_file_cmd,
@@ -352,6 +353,74 @@ fn _test_group_key(file_path: string) -> string ![io] {
     return project_root + "::" + workspace_root;
 }
 
+// P1 (#363): build a `ResolverConsumer` for a test group. The
+// consumer is keyed off the host capsule's manifest so:
+//
+//   - intra-capsule `.ll` outputs route under
+//     `build/capsules/<scope>/<name>/ir/` when the manifest's
+//     `[capsule].name` is in `scope/name` form (matches what
+//     `sfn build -p <capsule>` does for production builds);
+//   - the resolver enumerates `<project_root>/src/` as if it were a
+//     manifest-declared dep (`include_host_as_dep = true`), so a
+//     test file in `<project>/tests/` can `import { fn } from
+//     "<capsule_name>"` and resolve to the host capsule's source.
+//
+// Standalone test files outside any capsule.toml (or any test where
+// the manifest has no `[capsule].name`) get an empty consumer with
+// `include_host_as_dep = true`. The host enumeration is a no-op
+// without a name, so the resolver falls back to the legacy
+// relative-import / workspace-implicit walks the test runner has
+// always relied on.
+fn _test_resolver_consumer_for_group(file_path: string) -> ResolverConsumer ![io] {
+    let dir = _dirname_cmd(file_path);
+    let project_root = discover_project_root(dir);
+    if project_root.length == 0 {
+        return ResolverConsumer {
+            scope: "",
+            name: "",
+            walk_project_src: false,
+            include_host_as_dep: true
+        };
+    }
+    let manifest_path = _path_join_cmd(project_root, "capsule.toml");
+    if !fs.exists(manifest_path) {
+        return ResolverConsumer {
+            scope: "",
+            name: "",
+            walk_project_src: false,
+            include_host_as_dep: true
+        };
+    }
+    let manifest_text = fs.readFile(manifest_path);
+    let capsule_name = toml_get_name(manifest_text);
+    if capsule_name.length == 0 {
+        return ResolverConsumer {
+            scope: "",
+            name: "",
+            walk_project_src: false,
+            include_host_as_dep: true
+        };
+    }
+    let parts = parse_scope_name(capsule_name);
+    if !is_safe_scope_name(parts.scope, parts.name) {
+        // Single-segment / unsafe names route through the legacy
+        // flat layout but still get host enumeration so a manifest
+        // with `[capsule].name = "my-app"` can self-host its tests.
+        return ResolverConsumer {
+            scope: "",
+            name: "",
+            walk_project_src: false,
+            include_host_as_dep: true
+        };
+    }
+    return ResolverConsumer {
+        scope: parts.scope,
+        name: parts.name,
+        walk_project_src: false,
+        include_host_as_dep: true
+    };
+}
+
 fn _find_test_group(groups: TestGroup[], key: string) -> number {
     let mut i: number = 0;
     loop {
@@ -647,18 +716,27 @@ fn handle_test_command(args: string[], runtime_root: string) -> number ![io, clo
                 + number_to_string(groups[gi].entry_paths.length)
                 + ")");
         }
-        // `sfn test` does not yet take `-p`, so the consumer is
-        // empty and per-capsule `.ll` routing falls back to the
-        // legacy flat layout (Stage C2b2). Test-time link continues
-        // to consume `build/sailfin/capsules/<mangled>.ll` until
-        // `sfn test -p` ships.
+        // P1 (#363): derive the resolver consumer from the host
+        // capsule's manifest so a test file in `<project>/tests/`
+        // can import the host capsule by its `[capsule].name` (e.g.
+        // `import { fn } from "my-app"`) — not just by relative
+        // path (`../src/mod`). `include_host_as_dep = true` opts
+        // the resolver into enumerating `<project_root>/src/` with
+        // `<capsule_name>/<stem>` slugs, which matches what the
+        // test source's import-path normalizer resolves the bare
+        // capsule name to. Standalone test files outside any
+        // capsule.toml (the compiler's own `compiler/tests/` suite
+        // is the canonical case) get an empty consumer that still
+        // walks workspace-implicit imports — matching the prior
+        // `empty_resolver_consumer()` behavior.
         // Stage D PR3: `sfn test` runs from the legacy `make test`
         // path that does not thread `binary_dir` through, so pass
         // an empty `sailfin_exe`. The resolver falls back to the
         // in-process compile path that has worked for tests since
         // Stage C2c — test fixtures stay well below the per-module
         // count where arena pressure becomes an issue.
-        let resolution = prepare_project_capsules_for_test(groups[gi].entry_paths, empty_resolver_consumer(), "", "");
+        let consumer = _test_resolver_consumer_for_group(groups[gi].entry_paths[0]);
+        let resolution = prepare_project_capsules_for_test(groups[gi].entry_paths, consumer, "", "");
         if resolution.staging_failed {
             // Resolver already emitted a structured error to stderr
             // (slug collision, stage-write, or compile failure).

--- a/compiler/src/cli_commands.sfn
+++ b/compiler/src/cli_commands.sfn
@@ -724,11 +724,17 @@ fn handle_test_command(args: string[], runtime_root: string) -> number ![io, clo
         // the resolver into enumerating `<project_root>/src/` with
         // `<capsule_name>/<stem>` slugs, which matches what the
         // test source's import-path normalizer resolves the bare
-        // capsule name to. Standalone test files outside any
-        // capsule.toml (the compiler's own `compiler/tests/` suite
-        // is the canonical case) get an empty consumer that still
-        // walks workspace-implicit imports — matching the prior
-        // `empty_resolver_consumer()` behavior.
+        // capsule name to. Tests that don't import the host by
+        // name — the compiler's own `compiler/tests/` suite is the
+        // canonical case, since those tests reach `compiler/src/`
+        // exclusively via `../../src/X` relative imports — fail
+        // the in-resolver `_cr_any_entry_imports_host` gate, so
+        // host-enum stays a no-op and the resolver behaves the
+        // same as the prior `empty_resolver_consumer()` path.
+        // Standalone test files outside any `capsule.toml`
+        // (project_root empty) get a fully empty consumer for the
+        // same reason — there's no manifest, no `[capsule].name`,
+        // and so nothing for host-enum to walk.
         // Stage D PR3: `sfn test` runs from the legacy `make test`
         // path that does not thread `binary_dir` through, so pass
         // an empty `sailfin_exe`. The resolver falls back to the

--- a/compiler/src/cli_main.sfn
+++ b/compiler/src/cli_main.sfn
@@ -1300,7 +1300,8 @@ fn sailfin_cli_main(argv: string[]) -> number ![io, clock] {
         let mut consumer = ResolverConsumer {
             scope: "",
             name: "",
-            walk_project_src: walk_src
+            walk_project_src: walk_src,
+            include_host_as_dep: false
         };
         if cap_capsule_name.length > 0 {
             let parts0 = parse_scope_name(cap_capsule_name);
@@ -1308,7 +1309,8 @@ fn sailfin_cli_main(argv: string[]) -> number ![io, clock] {
                 consumer = ResolverConsumer {
                     scope: parts0.scope,
                     name: parts0.name,
-                    walk_project_src: walk_src
+                    walk_project_src: walk_src,
+                    include_host_as_dep: false
                 };
             }
         }

--- a/compiler/tests/fixtures/p1_user_capsule/capsule.toml
+++ b/compiler/tests/fixtures/p1_user_capsule/capsule.toml
@@ -1,0 +1,17 @@
+# P1 (#363) regression fixture: a single-segment capsule name (not
+# scope/name form) that the resolver must still surface to its own
+# tests by bare name. The user-style ergonomic case `sfn build` end
+# users hit when they declare `[capsule].name = "my-app"` rather than
+# `"acme/my-app"`.
+[capsule]
+name = "my-app"
+version = "0.1.0"
+
+[dependencies]
+
+[capabilities]
+required = []
+
+[build]
+entry = "src/mod.sfn"
+kind = "library"

--- a/compiler/tests/fixtures/p1_user_capsule/src/mod.sfn
+++ b/compiler/tests/fixtures/p1_user_capsule/src/mod.sfn
@@ -1,0 +1,5 @@
+// P1 (#363) regression fixture: the host capsule's only public
+// function. The companion test in `tests/x_test.sfn` calls this
+// via `import { my_fn } from "my-app";` to exercise the runner's
+// bare-name resolver wiring.
+fn my_fn(x: number) -> number { return x + 1; }

--- a/compiler/tests/fixtures/p1_user_capsule/tests/x_test.sfn
+++ b/compiler/tests/fixtures/p1_user_capsule/tests/x_test.sfn
@@ -1,0 +1,10 @@
+// P1 (#363) regression fixture: a user-style capsule whose tests
+// import the host capsule by its bare `[capsule].name`. Regresses
+// the gap where the runner's resolver pass used
+// `empty_resolver_consumer()`, which left the host capsule's
+// `src/` invisible to its own tests outside any workspace.toml.
+import { my_fn } from "my-app";
+
+test "my_fn adds one" { assert my_fn(2) == 3; }
+
+test "my_fn handles negatives" { assert my_fn(-1) == 0; }


### PR DESCRIPTION
## Summary

- `sfn test` now threads the test group's host capsule (`[capsule].name`) into the resolver pass, replacing the `empty_resolver_consumer()` shortcut at `compiler/src/cli_commands.sfn:406`. Tests can now `import { ... } from "<capsule_name>"` and have the resolver stage + compile the host capsule under matching `<name>/<stem>` slugs — a P1 precondition for the broader test-infra epic (#362).
- Adds a new `ResolverConsumer.include_host_as_dep` flag and the `_cr_enumerate_host_capsule_sources` helper, gated by `_cr_any_entry_imports_host` so capsules whose tests only reach the host via `../src/...` (path-shaped slug) — the compiler's own self-tests are the canonical case — don't pay the extra emission. The gate avoids the slug-blind `cache_key_for` racing two parallel emits on the same source.
- Rewrites `capsules/sfn/json/tests/json_test.sfn` to import the real `JsonValue` + accessors via `../src/mod` instead of inlining a private copy, and grows two new tests (stringify primitives + parse/stringify roundtrip) that exercise the public API end-to-end.
- New fixture `compiler/tests/fixtures/p1_user_capsule/` regresses the user-style standalone case: `[capsule].name = "my-app"`, no workspace.toml, tests `import { my_fn } from "my-app";`.

Closes #363

## Acceptance Criteria

- [x] `ulimit -v 8388608 && timeout 60 build/native/sailfin test capsules/sfn/json/tests/` passes after `json_test.sfn` is rewritten to `import` rather than inline `JsonValue` (9/9 tests pass).
- [x] A user-style fixture (`compiler/tests/fixtures/p1_user_capsule/`) with `capsule.toml` declaring name `my-app` plus `tests/x_test.sfn` containing `import { my_fn } from "my-app";` resolves and runs under `sfn test` (2/2 tests pass).
- [x] `make compile` passes (clean build from seed).
- [x] `make test` passes (454/454 tests pass; workspace-implicit imports for in-tree compiler tests still work).
- [x] `make check` passes — 908 tests across both first-pass and seedcheck binaries; stage2 == stage3 fixed-point check ✓.
- [x] `sfn fmt --check` is clean on every touched `.sfn` file.

## Verification

```bash
ulimit -v 8388608

# Clean build from seed
make compile  # ✓

# Acceptance: json capsule with rewritten test
timeout 60 build/native/sailfin test capsules/sfn/json/tests/
# → all 9 tests passed

# Acceptance: standalone my-app fixture
timeout 60 build/native/sailfin test compiler/tests/fixtures/p1_user_capsule/tests/
# → all 2 tests passed

# Self-tests still pass (compiler tests use `../../src/X` relative imports;
# the gate skips host-enum for them).
make test
# → 454/454 tests pass

# Self-host validation — first-pass build, full test suite, seedcheck
# build, full test suite again, stage2==stage3 IR comparison.
make check
# → 908/908 tests pass; "stage2 == stage3: compiler is a fixed point ✓"

# Formatter clean
build/native/sailfin fmt --check capsules/sfn/json/tests/json_test.sfn \
    compiler/src/capsule_resolver.sfn compiler/src/cli_commands.sfn \
    compiler/src/cli_main.sfn compiler/tests/fixtures/p1_user_capsule/src/mod.sfn \
    compiler/tests/fixtures/p1_user_capsule/tests/x_test.sfn
# → exit 0
```

## Files Changed

- `compiler/src/capsule_resolver.sfn` — `ResolverConsumer.include_host_as_dep`, `_cr_enumerate_host_capsule_sources`, `_cr_any_entry_imports_host` + gate inside `_cr_resolve_and_dedupe`.
- `compiler/src/cli_commands.sfn` — `_test_resolver_consumer_for_group` builds the per-group consumer from the manifest's `[capsule].name`; replaces the prior `empty_resolver_consumer()` call site.
- `compiler/src/cli_main.sfn` — both build-side `ResolverConsumer` constructors now set `include_host_as_dep: false` so `sfn build` is unchanged.
- `capsules/sfn/json/tests/json_test.sfn` — imports public API via `../src/mod`; adds two roundtrip tests.
- `compiler/tests/fixtures/p1_user_capsule/{capsule.toml,src/mod.sfn,tests/x_test.sfn}` — new regression fixture.

## Notes

- Discovered (and worked around with the `_cr_any_entry_imports_host` gate) a pre-existing limitation in `cache_key_for`: it doesn't include slug in the cache key, so when the same source is enumerated under two different slugs the two compiles race on one cache entry. A proper fix is to bump the cache schema to v2 with slug in the key — out of scope for this PR but worth filing as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)