### PR TITLE
chore(codex): add Codex repo hooks, skills, and prompts to mirror Claude agent workflows

### DIFF
--- a/.codex/README.md
+++ b/.codex/README.md
@@ -1,0 +1,51 @@
+# Codex setup for Sailfin
+
+This directory mirrors the high-value parts of the Claude Code setup using Codex-native repository artifacts where available and prompt templates where Codex does not yet provide Claude-style custom slash commands.
+
+## What is configured
+
+- `config.toml` enables repo-local hooks, hierarchical `AGENTS.md` handling, long-running goals, and the two Sailfin skills.
+- `hooks.json` wires lifecycle events to small shell scripts under `hooks/`.
+- `skills/` contains reusable Sailfin workflows for safe verification and issue pickup.
+- `prompts/` contains copy/paste prompts for Codex web or CLI sessions.
+
+## Local setup
+
+From the repository root, start Codex normally:
+
+```bash
+codex
+```
+
+Then confirm the session sees the repo configuration:
+
+```text
+/status
+```
+
+If your Codex build does not auto-load repo-local skills or hooks, paste the relevant prompt from `prompts/` and explicitly mention the `SKILL.md` file named in that prompt.
+
+## Web setup
+
+Codex web should be given the same repository context plus one of the prompts in `prompts/`. For the closest equivalent to Claude's `/pickup`, paste `prompts/pickup.md` and optionally append an issue number.
+
+## Safety behavior
+
+The hooks are intentionally conservative:
+
+- `SessionStart` adds a compact compiler/seed/branch snapshot.
+- `UserPromptSubmit` adds branch, dirty-file count, and unpushed commit count.
+- `PreToolUse` blocks `make`, `build/native/sailfin`, and `build/native/sailfin-seedcheck` commands unless the command includes `ulimit -v 8388608`.
+
+The memory cap duplicates the project rule in `AGENTS.md` because uncapped Sailfin compiler runs can exhaust local WSL or IDE hosts.
+
+## Issue pickup workflow
+
+Use `prompts/pickup.md` for autonomous issue work. It instructs Codex to:
+
+1. Query `claude-ready` issues and rank them with the same priority order as Claude's `/pickup` command.
+2. Verify pinned-seed freshness before claiming compiler/runtime work.
+3. Claim the issue, sync the project board with the existing repository helper, and branch as `codex/<issue>-<slug>`.
+4. Implement, verify, commit, and open a PR with `Closes #<issue>`.
+
+The GitHub/project scripts remain in `.claude/scripts/` for now because they are repository automation rather than Claude-only logic.

--- a/.codex/README.md
+++ b/.codex/README.md
@@ -5,7 +5,7 @@ This directory mirrors the high-value parts of the Claude Code setup using Codex
 ## What is configured
 
 - `config.toml` enables repo-local hooks, hierarchical `AGENTS.md` handling, long-running goals, and the two Sailfin skills.
-- `hooks.json` wires lifecycle events to small shell scripts under `hooks/`.
+- `config.toml` wires lifecycle events to small shell scripts under `hooks/`.
 - `skills/` contains reusable Sailfin workflows for safe verification and issue pickup.
 - `prompts/` contains copy/paste prompts for Codex web or CLI sessions.
 

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,27 @@
+# Sailfin project-local Codex configuration.
+#
+# Codex reads AGENTS.md automatically. This file enables the repo-local
+# affordances that mirror the existing Claude Code setup where current Codex
+# builds support them.
+
+# Lifecycle hooks are intentionally small wrappers around scripts in
+# .codex/hooks/ so the behavior can be reviewed and tested outside Codex.
+hooks = ".codex/hooks.json"
+
+[features]
+# Preserve nested AGENTS.md scoping/precedence when future child AGENTS.md files
+# are added under compiler/, runtime/, docs/, or site/.
+child_agents_md = true
+# Enables the hook file above in CLI builds that still gate hooks behind a flag.
+codex_hooks = true
+# Useful for long-running web/CLI sessions that are driving an issue to PR.
+goals = true
+
+# Repo-local skills are intentionally duplicated from the Claude workflow at a
+# smaller granularity. If your Codex build does not auto-discover repo skills,
+# mention the relevant SKILL.md file explicitly in the prompt.
+[[skills.config]]
+path = ".codex/skills/sailfin-check/SKILL.md"
+
+[[skills.config]]
+path = ".codex/skills/sailfin-pickup/SKILL.md"

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -4,16 +4,14 @@
 # affordances that mirror the existing Claude Code setup where current Codex
 # builds support them.
 
-# Lifecycle hooks are intentionally small wrappers around scripts in
-# .codex/hooks/ so the behavior can be reviewed and tested outside Codex.
-hooks = ".codex/hooks.json"
-
 [features]
 # Preserve nested AGENTS.md scoping/precedence when future child AGENTS.md files
 # are added under compiler/, runtime/, docs/, or site/.
 child_agents_md = true
-# Enables the hook file above in CLI builds that still gate hooks behind a flag.
-codex_hooks = true
+# Hide the expected warning for the intentionally enabled child-agent feature.
+suppress_unstable_features_warning = true
+# Enables the hook tables below in CLI builds that still gate hooks behind a flag.
+hooks = true
 # Useful for long-running web/CLI sessions that are driving an issue to PR.
 goals = true
 
@@ -22,6 +20,31 @@ goals = true
 # mention the relevant SKILL.md file explicitly in the prompt.
 [[skills.config]]
 path = ".codex/skills/sailfin-check/SKILL.md"
+enabled = true
 
 [[skills.config]]
 path = ".codex/skills/sailfin-pickup/SKILL.md"
+enabled = true
+
+# Lifecycle hooks are intentionally small wrappers around scripts in
+# .codex/hooks/ so the behavior can be reviewed and tested outside Codex.
+[[hooks.SessionStart]]
+matcher = ""
+
+[[hooks.SessionStart.hooks]]
+type = "command"
+command = ".codex/hooks/session-start.sh"
+
+[[hooks.UserPromptSubmit]]
+matcher = ""
+
+[[hooks.UserPromptSubmit.hooks]]
+type = "command"
+command = ".codex/hooks/inject-git-context.sh"
+
+[[hooks.PreToolUse]]
+matcher = "Bash|Shell|LocalShell|exec_command"
+
+[[hooks.PreToolUse.hooks]]
+type = "command"
+command = ".codex/hooks/check-ulimit.sh"

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,35 @@
+{
+  "SessionStart": [
+    {
+      "matcher": "",
+      "hooks": [
+        {
+          "type": "command",
+          "command": ".codex/hooks/session-start.sh"
+        }
+      ]
+    }
+  ],
+  "UserPromptSubmit": [
+    {
+      "matcher": "",
+      "hooks": [
+        {
+          "type": "command",
+          "command": ".codex/hooks/inject-git-context.sh"
+        }
+      ]
+    }
+  ],
+  "PreToolUse": [
+    {
+      "matcher": "Bash|Shell|LocalShell|exec_command",
+      "hooks": [
+        {
+          "type": "command",
+          "command": ".codex/hooks/check-ulimit.sh"
+        }
+      ]
+    }
+  ]
+}

--- a/.codex/hooks/check-ulimit.sh
+++ b/.codex/hooks/check-ulimit.sh
@@ -42,7 +42,8 @@ PY
 
 needs_cap=0
 
-if [[ "$cmd" =~ (^|[[:space:];&|])(make)([[:space:]]+(compile|rebuild|check|test|test-unit|test-integration|bench|clean-build))?([[:space:];&|]|$) ]]; then
+make_re='(^|[;&|()`])[[:space:]]*make[[:space:]]+(compile|rebuild|check|test|test-unit|test-integration|test-e2e|bench|clean-build)([[:space:]]|$|[;&|])'
+if [[ "$cmd" =~ $make_re ]]; then
   needs_cap=1
 fi
 

--- a/.codex/hooks/check-ulimit.sh
+++ b/.codex/hooks/check-ulimit.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Codex PreToolUse hook: block make/compiler commands that omit Sailfin's 8GB
+# virtual-memory cap. The compiler can otherwise exhaust local WSL/IDE hosts.
+
+set -euo pipefail
+
+payload=$(cat || true)
+cmd=$(
+  PAYLOAD="$payload" python3 - <<'PY'
+import json
+import os
+
+payload = os.environ.get("PAYLOAD", "")
+try:
+    data = json.loads(payload) if payload.strip() else {}
+except json.JSONDecodeError:
+    data = {}
+
+candidates = []
+
+def collect(value):
+    if isinstance(value, str):
+        candidates.append(value)
+    elif isinstance(value, list):
+        candidates.extend(str(part) for part in value)
+    elif isinstance(value, dict):
+        for key in ("command", "cmd", "script", "input", "args"):
+            if key in value:
+                collect(value[key])
+
+collect(data)
+for key in ("tool_input", "toolInput", "params", "arguments"):
+    collect(data.get(key))
+
+print(" ".join(candidates))
+PY
+)
+
+# If Codex passes no structured payload for this version, do not block unknown
+# commands. The guidance still lives in AGENTS.md and the session-start hook.
+[[ -z "${cmd// }" ]] && exit 0
+
+needs_cap=0
+
+if [[ "$cmd" =~ (^|[[:space:];&|])(make)([[:space:]]+(compile|rebuild|check|test|test-unit|test-integration|bench|clean-build))?([[:space:];&|]|$) ]]; then
+  needs_cap=1
+fi
+
+if [[ "$cmd" =~ (^|[[:space:];&|])((\./)?build/native/sailfin(-seedcheck)?)([[:space:];&|]|$) ]]; then
+  needs_cap=1
+fi
+
+if [[ "$needs_cap" -eq 1 && ! "$cmd" =~ ulimit[[:space:]]+-v[[:space:]]+8388608 ]]; then
+  cat >&2 <<'MSG'
+Sailfin compiler invocations require an 8GB memory cap.
+Prepend `ulimit -v 8388608 && ` to the command and try again.
+MSG
+  exit 2
+fi
+
+exit 0

--- a/.codex/hooks/check-ulimit.sh
+++ b/.codex/hooks/check-ulimit.sh
@@ -4,6 +4,14 @@
 
 set -euo pipefail
 
+# Fail open if python3 isn't available: a missing dependency must not block every
+# Bash tool call. Surface a one-time breadcrumb on stderr so the user can
+# install python3 and restore the safety guard.
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "[check-ulimit] python3 not found — compiler-safety guard disabled. Install python3 to re-enable." >&2
+  exit 0
+fi
+
 payload=$(cat || true)
 cmd=$(
   PAYLOAD="$payload" python3 - <<'PY'

--- a/.codex/hooks/inject-git-context.sh
+++ b/.codex/hooks/inject-git-context.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Codex UserPromptSubmit hook: append fast git state to each prompt so the agent
+# has branch/dirty/unpushed context without spending a turn on git status.
+
+set -euo pipefail
+
+repo_root=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+cd "$repo_root"
+
+git rev-parse --git-dir >/dev/null 2>&1 || exit 0
+
+branch=$(git branch --show-current 2>/dev/null || printf 'detached')
+dirty=$(git status --porcelain 2>/dev/null | wc -l | tr -d ' ')
+
+if git rev-parse '@{upstream}' >/dev/null 2>&1; then
+  unpushed=$(git rev-list --count '@{upstream}..HEAD' 2>/dev/null || printf '0')
+else
+  unpushed='no-upstream'
+fi
+
+printf '<git-context branch="%s" dirty="%s" unpushed="%s" />\n' \
+  "$branch" "$dirty" "$unpushed"

--- a/.codex/hooks/session-start.sh
+++ b/.codex/hooks/session-start.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Codex SessionStart hook: emit a compact project snapshot that keeps Sailfin's
+# self-hosted compiler constraints visible at the start of every session.
+
+set -euo pipefail
+
+repo_root=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+cd "$repo_root"
+
+printf '## Sailfin Codex session bootstrap\n'
+
+if [[ -x build/native/sailfin ]]; then
+  version=$(ulimit -v 8388608 2>/dev/null; timeout 5 build/native/sailfin version 2>/dev/null | head -n1 || true)
+  if [[ -n "$version" ]]; then
+    printf -- '- compiler: build/native/sailfin present — %s\n' "$version"
+  else
+    printf -- '- compiler: build/native/sailfin present — version probe failed\n'
+  fi
+else
+  printf -- '- compiler: build/native/sailfin MISSING — run `ulimit -v 8388608 && make compile` to self-host from the seed\n'
+fi
+
+if compgen -G 'build/seed/*' >/dev/null; then
+  printf -- '- seed: build/seed present\n'
+else
+  printf -- '- seed: MISSING — run `make fetch-seed` if a build needs the released seed\n'
+fi
+
+if [[ -x build/native/sailfin-seedcheck ]]; then
+  printf -- '- seedcheck: build/native/sailfin-seedcheck present\n'
+else
+  printf -- '- seedcheck: not built (only needed for `make check`)\n'
+fi
+
+branch=$(git branch --show-current 2>/dev/null || printf '(detached)')
+printf -- '- branch: %s\n' "$branch"
+
+version_pin=$(sed -n 's/^version[[:space:]]*=[[:space:]]*"\([^"]*\)".*/version = \1/p' compiler/capsule.toml 2>/dev/null | head -n1 || true)
+[[ -n "$version_pin" ]] && printf -- '- capsule: %s\n' "$version_pin"
+
+cat <<'MSG'
+
+Reminders:
+- Always prefix Sailfin compiler or make invocations with `ulimit -v 8388608 &&`.
+- Prefer feature branches named `codex/<issue-or-topic>-<slug>`.
+- Status source of truth: docs/status.md. Roadmap: site/src/pages/roadmap.astro.
+- For issue pickup, use .codex/prompts/pickup.md as the web/CLI prompt template.
+MSG

--- a/.codex/prompts/check.md
+++ b/.codex/prompts/check.md
@@ -1,0 +1,7 @@
+# Codex Check Prompt
+
+```text
+Verify the current Sailfin working tree.
+
+Follow AGENTS.md and .codex/skills/sailfin-check/SKILL.md. Inspect the diff, identify what changed, choose the smallest sufficient verification ladder, and run the checks. Prefix every Sailfin compiler or make command with `ulimit -v 8388608 &&`. Report exact commands and results.
+```

--- a/.codex/prompts/pickup.md
+++ b/.codex/prompts/pickup.md
@@ -1,0 +1,20 @@
+# Codex Pickup Prompt
+
+Use this prompt in Codex web or CLI when you want the Claude `/pickup` experience.
+
+```text
+Pick up the next Sailfin issue and drive it to a pull request.
+
+Follow this repository's AGENTS.md and use the Sailfin pickup workflow in .codex/skills/sailfin-pickup/SKILL.md. If I provide an issue number, use that issue; otherwise select the highest-priority pickable `claude-ready` issue.
+
+Required workflow:
+1. Query GitHub issues with `gh` and choose/validate the issue.
+2. Run the pinned-seed freshness gate before claiming compiler/runtime work.
+3. Claim the issue, sync the project status, and create a `codex/<issue>-<slug>` branch.
+4. Restate the issue goal, scope, acceptance criteria, files affected, and verification plan.
+5. Implement the smallest focused change that satisfies the issue.
+6. Run the issue's verification commands plus the Sailfin safety checks from .codex/skills/sailfin-check/SKILL.md.
+7. Commit the changes and open a PR with `Closes #<issue>`.
+
+Never run Sailfin compiler or make verification commands without `ulimit -v 8388608 &&`.
+```

--- a/.codex/prompts/plan-feature.md
+++ b/.codex/prompts/plan-feature.md
@@ -1,0 +1,7 @@
+# Codex Feature Planning Prompt
+
+```text
+Plan a Sailfin language/compiler feature before implementation.
+
+Read docs/status.md, the relevant language spec files under site/src/content/docs/docs/reference/, and the compiler pipeline under compiler/src/. Produce an implementation plan in pipeline order (lexer/parser, AST, type checker, effect checker, emitter, LLVM lowering, tests, docs). Identify self-hosting risks, seed dependencies, and verification commands. Do not edit code until I approve the plan.
+```

--- a/.codex/skills/sailfin-check/SKILL.md
+++ b/.codex/skills/sailfin-check/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: sailfin-check
+description: Run Sailfin compiler and test verification safely with the required memory cap.
+---
+
+# Sailfin Check Skill
+
+Use this skill whenever a task touches Sailfin compiler sources, runtime code, tests, or docs that describe implementation status.
+
+## Safety invariant
+
+- Prefix every `make` target that may compile or test Sailfin with `ulimit -v 8388608 &&`.
+- Prefix direct compiler invocations with `ulimit -v 8388608 && timeout 60` for single test files or examples.
+- If `.sfn` files under `compiler/src/` or `runtime/` changed, run the formatter before final verification.
+
+## Verification ladder
+
+1. Documentation/config-only change: run a fast syntax/readability check when available, otherwise `git diff --check`.
+2. Test-only or example change: run the targeted test first, then `ulimit -v 8388608 && make test` when a compiler binary exists.
+3. Compiler/runtime source change: run `ulimit -v 8388608 && make compile` before `ulimit -v 8388608 && make test`; use `make check` when time allows.
+4. Structural compiler change: run `ulimit -v 8388608 && make clean-build` before rebuilding.
+
+## Reporting
+
+In the final response, list the exact command for every check and mark environment limitations separately from agent errors.

--- a/.codex/skills/sailfin-pickup/SKILL.md
+++ b/.codex/skills/sailfin-pickup/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: sailfin-pickup
+description: Pick up a ready Sailfin GitHub issue and drive it through branch, implementation, verification, and PR handoff.
+---
+
+# Sailfin Pickup Skill
+
+Use this skill when the user asks Codex to pick up an issue, work the next item, or emulate Claude's `/pickup` flow.
+
+## Issue selection
+
+1. Query ready issues:
+   ```bash
+   gh issue list --label "claude-ready" --state open --json number,title,labels,assignees,body --limit 50
+   ```
+2. Filter out blocked, in-progress, assigned, or externally blocked work.
+3. Rank remaining issues by:
+   - `priority:critical`
+   - `priority:high`
+   - `type:bug`
+   - `type:perf`
+   - smallest `size:*` (`XS` before `S` before `M`)
+   - lowest issue number
+
+If the user supplied an issue number, fetch it directly with `gh issue view <N> --json number,title,labels,assignees,body,state` and validate the same pickability rules.
+
+## Seed freshness gate
+
+Before claiming compiler or runtime work, read `.seed-version`, fetch the matching `v<seed>` tag, and verify every issue/PR listed in `## Required in pinned seed` has at least one closing or merge commit that is an ancestor of the seed tag. If not, comment on the issue and stop without claiming it.
+
+## Claim and branch
+
+```bash
+gh issue edit <N> --add-label "in-progress" --remove-label "claude-ready"
+.claude/scripts/sync-project-status.sh <N> --from-labels || true
+git switch -c codex/<N>-<slug>
+```
+
+The project sync helper remains under `.claude/scripts/` because it is provider-neutral repository automation.
+
+## Implementation rules
+
+- Restate the issue goal, scope, acceptance criteria, files affected, and verification plan before editing.
+- For multi-pass compiler changes, implement in pipeline order: lexer, parser, AST, type checker, effect checker, native emitter, LLVM lowering, tests.
+- Keep changes focused and update `docs/status.md` first when behavior changes.
+- Add or update Sailfin-native tests beside related coverage under `compiler/tests/`.
+
+## PR handoff
+
+- Run the verification commands from the issue body plus the Sailfin check ladder.
+- Commit atomically with a Conventional Commit style message, for example `fix(compiler): handle ...`.
+- Open a PR whose body includes scope, issue link (`Closes #N`), verification commands, and any residual concerns.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,3 +28,10 @@
 - History mixes imperative commits and Conventional Commit prefixes; favor `feat(compiler): …`, `fix(bootstrap): …`, etc., for clarity.
 - Keep commits atomic, mention touched capsules, and co-author doc changes in the same PR.
 - Pull requests should summarize scope, link issues, list verification commands, and attach screenshots or trace snippets when behavior shifts.
+
+## Codex Workflow Notes
+
+- Codex-specific repository setup lives under `.codex/`: `config.toml` enables hooks/skills, `hooks/` mirrors the Claude session and memory-cap safeguards, `skills/` holds reusable Sailfin workflows, and `prompts/` contains web/CLI prompt templates.
+- For autonomous issue pickup in Codex web or CLI, use `.codex/prompts/pickup.md`; it mirrors the Claude `/pickup` flow but branches as `codex/<issue>-<slug>`.
+- Before running Sailfin compiler or make verification commands from Codex, preserve the safety invariant: `ulimit -v 8388608 && <command>`.
+- If Codex does not auto-load repo-local skills/hooks in a given environment, explicitly mention the relevant `.codex/skills/*/SKILL.md` file in the prompt and follow `.codex/README.md`.


### PR DESCRIPTION
### Motivation

- Enable using OpenAI Codex in this repository by mirroring the existing Claude agent tooling and safe workflow patterns so Codex sessions can pick up issues, run verification, and follow the same safety gates. 
- Provide repo-local configuration, lifecycle hooks, and small reusable skills/prompts so Codex can be used reliably in both CLI and web contexts while preserving the project's `ulimit` safety invariant. 
- Make it easy to fall back to explicit prompts or skill files when a Codex build does not auto-discover repo-local artifacts. 

### Description

- Added a `.codex/` directory with `config.toml` and `hooks.json` to enable repo-local Codex hooks and register two skills (`sailfin-check`, `sailfin-pickup`).
- Implemented lifecycle hook scripts under `.codex/hooks/`: `session-start.sh` (session bootstrap snapshot), `inject-git-context.sh` (append branch/dirty/unpushed info), and `check-ulimit.sh` (PreToolUse guard that blocks compiler/make commands missing `ulimit -v 8388608`).
- Added lightweight skill definitions in `.codex/skills/` (SKILL.md) and user-facing prompt templates in `.codex/prompts/` for pickup, verification, and feature planning workflows, plus documentation in `.codex/README.md` and a short note added to `AGENTS.md` referencing the Codex setup. 

### Testing

- Verified repository sanity via `git diff --check` and shell syntax validation with `bash -n .codex/hooks/*.sh`, both of which succeeded. 
- Validated `hooks.json` with `python3 -m json.tool` and parsed `config.toml` with `tomllib` in Python, both of which succeeded. 
- Exercised the PreToolUse guard by running `printf '%s' '{"tool_input":{"command":"make test"}}' | .codex/hooks/check-ulimit.sh` which exited as blocked (expected), and then ran the allowed variant `printf '%s' '{"tool_input":{"command":"ulimit -v 8388608 && make test"}}' | .codex/hooks/check-ulimit.sh` which permitted execution, and both behaved as intended. 
- Ran the session bootstrap and git-context hooks (`.codex/hooks/session-start.sh` and `.codex/hooks/inject-git-context.sh`) to confirm they produce the expected compact status and `<git-context .../>` lines, respectively.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00b370dd708324a73ee88b81467aaa)