### PR TITLE
fix(compiler): recover temp indexes in operand lowering

### DIFF
--- a/compiler/src/llvm/expression_lowering/native/core_operands.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_operands.sfn
@@ -34,6 +34,7 @@ import {
     emit_runtime_call,
     empty_runtime_call_overrides
 } from "./runtime_call";
+import { recover_temp_from_lines } from "./temp_recovery";
 
 fn emit_comparison_instruction(symbol: string, left_operand: LLVMOperand, right_operand: LLVMOperand, temp_index: number, lines: string[]) -> ComparisonEmission {
     let mut diagnostics: string[] = [];
@@ -1864,7 +1865,7 @@ fn coerce_operand_to_type(operand: LLVMOperand, target_type: string, temp_index:
     if target.length == 0 {
         return CoercionResult {
             lines: current_lines,
-            temp_index: temp_index,
+            temp_index: recover_temp_from_lines(current_lines, temp_index),
             operand: operand,
             diagnostics: diagnostics
         };
@@ -1872,7 +1873,7 @@ fn coerce_operand_to_type(operand: LLVMOperand, target_type: string, temp_index:
     if operand_type == target {
         return CoercionResult {
             lines: current_lines,
-            temp_index: temp_index,
+            temp_index: recover_temp_from_lines(current_lines, temp_index),
             operand: operand,
             diagnostics: diagnostics
         };
@@ -1911,7 +1912,7 @@ fn coerce_operand_to_type(operand: LLVMOperand, target_type: string, temp_index:
             diagnostics.push(abi_diag);
             return CoercionResult {
                 lines: current_lines,
-                temp_index: temp_index,
+                temp_index: recover_temp_from_lines(current_lines, temp_index),
                 operand: null,
                 diagnostics: diagnostics
             };
@@ -1919,11 +1920,32 @@ fn coerce_operand_to_type(operand: LLVMOperand, target_type: string, temp_index:
     }
 
     let numeric = coerce_numeric_primitive(operand, operand_type, target, temp_index, current_lines);
-    if numeric != null { return numeric; }
+    if numeric != null {
+        return CoercionResult {
+            lines: numeric.lines,
+            temp_index: recover_temp_from_lines(numeric.lines, numeric.temp_index),
+            operand: numeric.operand,
+            diagnostics: numeric.diagnostics
+        };
+    }
     let pointer = coerce_pointer_or_struct(operand, operand_type, target, temp_index, current_lines);
-    if pointer != null { return pointer; }
+    if pointer != null {
+        return CoercionResult {
+            lines: pointer.lines,
+            temp_index: recover_temp_from_lines(pointer.lines, pointer.temp_index),
+            operand: pointer.operand,
+            diagnostics: pointer.diagnostics
+        };
+    }
     let general = coerce_general_fallback(operand, operand_type, target, temp_index, current_lines);
-    if general != null { return general; }
+    if general != null {
+        return CoercionResult {
+            lines: general.lines,
+            temp_index: recover_temp_from_lines(general.lines, general.temp_index),
+            operand: general.operand,
+            diagnostics: general.diagnostics
+        };
+    }
     diagnostics.push("llvm lowering: unable to coerce operand of type `"
         + operand.llvm_type
         + "` to `"
@@ -1931,7 +1953,7 @@ fn coerce_operand_to_type(operand: LLVMOperand, target_type: string, temp_index:
         + "`");
     return CoercionResult {
         lines: current_lines,
-        temp_index: temp_index,
+        temp_index: recover_temp_from_lines(current_lines, temp_index),
         operand: null,
         diagnostics: diagnostics
     };
@@ -2016,7 +2038,7 @@ fn harmonise_operands(left: LLVMOperand, right: LLVMOperand, temp_index: number,
     if left_operand.llvm_type == right_operand.llvm_type {
         return BinaryAlignmentResult {
             lines: current_lines,
-            temp_index: current_temp,
+            temp_index: recover_temp_from_lines(current_lines, current_temp),
             left: left_operand,
             right: right_operand,
             diagnostics: diagnostics,
@@ -2043,7 +2065,7 @@ fn harmonise_operands(left: LLVMOperand, right: LLVMOperand, temp_index: number,
             + "`");
         return BinaryAlignmentResult {
             lines: left_coercion.lines,
-            temp_index: left_coercion.temp_index,
+            temp_index: recover_temp_from_lines(left_coercion.lines, left_coercion.temp_index),
             left: null,
             right: null,
             diagnostics: diagnostics,
@@ -2069,7 +2091,7 @@ fn harmonise_operands(left: LLVMOperand, right: LLVMOperand, temp_index: number,
             + "`");
         return BinaryAlignmentResult {
             lines: right_coercion.lines,
-            temp_index: right_coercion.temp_index,
+            temp_index: recover_temp_from_lines(right_coercion.lines, right_coercion.temp_index),
             left: null,
             right: null,
             diagnostics: diagnostics,
@@ -2082,7 +2104,7 @@ fn harmonise_operands(left: LLVMOperand, right: LLVMOperand, temp_index: number,
 
     return BinaryAlignmentResult {
         lines: current_lines,
-        temp_index: current_temp,
+        temp_index: recover_temp_from_lines(current_lines, current_temp),
         left: left_operand,
         right: right_operand,
         diagnostics: diagnostics,

--- a/compiler/src/llvm/expression_lowering/native/statement.sfn
+++ b/compiler/src/llvm/expression_lowering/native/statement.sfn
@@ -6,12 +6,6 @@
 // `prepare_parameters`.  Type mapping, suspension detection, async ABI helpers,
 // and expression parsing live in sibling submodules.
 import { NativeFunction, NativeInstruction, NativeSourceSpan } from "../../../native_ir";
-import {
-    char_at,
-    char_code,
-    find_last_index_of_char,
-    substring
-} from "../../../string_utils";
 import { test_runner_trace } from "../../../test_runner_state";
 import { default_return_literal, is_simple_identifier } from "../../expressions_helpers";
 // `format_root_scope_id` lives in the lifetime utilities module; the
@@ -75,6 +69,7 @@ import { lower_lvalue_assignment_stmt } from "./statement_assignment";
 import { parse_assignment_expression, parse_inline_let_expression } from "./statement_parsing";
 import { detect_suspension_conflicts } from "./statement_suspension";
 import { map_parameter_type, map_struct_type_annotation } from "./statement_type_mapping";
+import { recover_temp_from_lines } from "./temp_recovery";
 
 fn find_parameter_binding(bindings: ParameterBinding[], name: string) -> ParameterBinding? {
     return bindings_find_parameter_binding(bindings, name);
@@ -94,41 +89,6 @@ fn reset_local_consumption(locals: LocalBinding[], name: string) -> LocalBinding
 
 fn update_local_ownership(locals: LocalBinding[], name: string, ownership: OwnershipInfo?) -> LocalBinding[] {
     return bindings_update_local_ownership(locals, name, ownership);
-}
-
-// ---------------------------------------------------------------------------
-// SSA temp counter recovery
-// ---------------------------------------------------------------------------
-// Recover from v0.1.1 seed ABI corruption: lowered.temp_index may be 0
-// when returned from cross-module calls (e.g. lower_expression,
-// coerce_operand_to_type). Scan emitted lines for the highest %tN
-// definition and use max(found+1, floor) as the recovered counter.
-fn _recover_temp_from_lines(lines: string[], floor: number) -> number {
-    let mut result: number = floor;
-    let mut ri: number = 0;
-    loop {
-        if ri >= lines.length { break; }
-        let rl = lines[ri];
-        if starts_with(rl, "  %t") {
-            let mut rn: number = 0;
-            let mut rj: number = 4;
-            let mut rvalid: boolean = false;
-            loop {
-                if rj >= rl.length { break; }
-                let rc = char_code(char_at(rl, rj));
-                if rc < 48 { break; }
-                if rc > 57 { break; }
-                rn = rn * 10 + (rc - 48);
-                rvalid = true;
-                rj += 1;
-            }
-            if rvalid {
-                if rn >= result { result = rn + 1; }
-            }
-        }
-        ri += 1;
-    }
-    return result;
 }
 
 // Helpers: build binding structs for the IPC read-back loops.
@@ -261,7 +221,7 @@ fn lower_expression_statement(function_name: string, instruction: NativeInstruct
             string_constants = lowered.string_constants;
             current_lines = lowered.lines;
             current_temp = lowered.temp_index;
-            current_temp = _recover_temp_from_lines(current_lines, current_temp);
+            current_temp = recover_temp_from_lines(current_lines, current_temp);
             if lowered.operand == null {
                 diagnostics.push("llvm lowering: failed to lower assignment expression for `"
                     + trimmed_assign_target
@@ -276,7 +236,7 @@ fn lower_expression_statement(function_name: string, instruction: NativeInstruct
                 }
                 current_lines = coerced.lines;
                 current_temp = coerced.temp_index;
-                current_temp = _recover_temp_from_lines(current_lines, current_temp);
+                current_temp = recover_temp_from_lines(current_lines, current_temp);
                 if coerced.operand == null {
                     diagnostics.push("llvm lowering: unable to coerce assignment value for `"
                         + trimmed_assign_target
@@ -386,7 +346,7 @@ fn lower_expression_statement(function_name: string, instruction: NativeInstruct
     let consumption = ownership_analysis.consumption;
 
     let _lowered = lower_expression(expression, current_bindings, current_locals, current_temp, current_lines, functions, context, "");
-    current_temp = _recover_temp_from_lines(current_lines, current_temp);
+    current_temp = recover_temp_from_lines(current_lines, current_temp);
     if consumption != null {
         if consumption.kind == "local" {
             current_locals = mark_local_consumed(current_locals, consumption.name);
@@ -539,7 +499,7 @@ fn lower_return_instruction(function: NativeFunction, instruction: NativeInstruc
             bind_i += 1;
         }
     }
-    current_temp = _recover_temp_from_lines(current_lines, current_temp);
+    current_temp = recover_temp_from_lines(current_lines, current_temp);
     let lowered = lower_expression(instr_expression, current_bindings, current_locals, current_temp, current_lines, functions, context, safe_llvm_return);
     if debug_lowering {
         print.err("emit-llvm: lower_return post_lower_expr fn=" + fn_name);
@@ -552,7 +512,7 @@ fn lower_return_instruction(function: NativeFunction, instruction: NativeInstruc
     }
     current_lines = lowered.lines;
     current_temp = lowered.temp_index;
-    current_temp = _recover_temp_from_lines(current_lines, current_temp);
+    current_temp = recover_temp_from_lines(current_lines, current_temp);
     let string_constants = lowered.string_constants;
 
     if debug_lowering {
@@ -645,7 +605,7 @@ fn lower_return_instruction(function: NativeFunction, instruction: NativeInstruc
     }
     current_lines = coerced.lines;
     current_temp = coerced.temp_index;
-    current_temp = _recover_temp_from_lines(current_lines, current_temp);
+    current_temp = recover_temp_from_lines(current_lines, current_temp);
     if coerced.operand == null {
         diagnostics.push("llvm lowering: unable to coerce return expression to `"
             + safe_llvm_return

--- a/compiler/src/llvm/expression_lowering/native/statement_assignment.sfn
+++ b/compiler/src/llvm/expression_lowering/native/statement_assignment.sfn
@@ -3,7 +3,7 @@
 // Assignment handling extracted from statement.sfn to keep each function
 // under ~500 .sfn-asm instructions (avoids seed OOM).
 import { NativeFunction, NativeInstruction, NativeSourceSpan } from "../../../native_ir";
-import { index_of, substring } from "../../../string_utils";
+import { substring } from "../../../string_utils";
 import { default_return_literal, format_temp_name, is_simple_identifier } from "../../expressions_helpers";
 import { empty_string_constant_set, merge_string_constants } from "../../strings";
 import { find_struct_field_index, find_struct_info_by_llvm_type } from "../../type_context_queries";
@@ -52,55 +52,7 @@ import {
 } from "./core_scopes";
 import { find_substring_from } from "./core_text";
 import { emit_runtime_call, empty_runtime_call_overrides } from "./runtime_call";
-
-// Recover from v0.1.1 seed ABI corruption: lowered.temp_index may be 0
-// when returned from cross-module calls. Scan lines for the highest %tN
-// definition and use max(found+1, floor) as the recovered counter.
-fn _recover_assign_temp(lines: string[], floor: number) -> number {
-    let mut result: number = floor;
-    let mut ri: number = 0;
-    loop {
-        if ri >= lines.length { break; }
-        let rl = lines[ri];
-        if starts_with(rl, "  %t") {
-            let after_t = substring(rl, 4, rl.length);
-            let space = index_of(after_t, " ");
-            if space > 0 {
-                let num_str = substring(after_t, 0, space);
-                let rn = _assign_parse_int(num_str);
-                if rn >= result { result = rn + 1; }
-            }
-        }
-        ri += 1;
-    }
-    return result;
-}
-
-fn _assign_parse_int(text: string) -> number {
-    let len = text.length;
-    if len == 0 { return 0; }
-    let mut result: number = 0;
-    let mut i: number = 0;
-    loop {
-        if i >= len { break; }
-        let ch = substring(text, i, i + 1);
-        let mut digit: number = -1;
-        if ch == "0" { digit = 0; }
-        if ch == "1" { digit = 1; }
-        if ch == "2" { digit = 2; }
-        if ch == "3" { digit = 3; }
-        if ch == "4" { digit = 4; }
-        if ch == "5" { digit = 5; }
-        if ch == "6" { digit = 6; }
-        if ch == "7" { digit = 7; }
-        if ch == "8" { digit = 8; }
-        if ch == "9" { digit = 9; }
-        if digit < 0 { break; }
-        result = result * 10 + digit;
-        i += 1;
-    }
-    return result;
-}
+import { recover_temp_from_lines } from "./temp_recovery";
 
 // Handles deref (*ptr = value), member access (obj.field = value), and
 // array index (arr[i] = value) assignments. Returns ExpressionStatementResult.
@@ -133,7 +85,7 @@ fn lower_lvalue_assignment_stmt(assign_target: string, assign_value: string, ass
         string_constants = lowered_value.string_constants;
         current_lines = lowered_value.lines;
         current_temp = lowered_value.temp_index;
-        current_temp = _recover_assign_temp(current_lines, current_temp);
+        current_temp = recover_temp_from_lines(current_lines, current_temp);
         if lowered_value.operand == null {
             diagnostics.push("llvm lowering: failed to lower assignment value for deref target `"
                 + assign_target
@@ -176,7 +128,7 @@ fn lower_lvalue_assignment_stmt(assign_target: string, assign_value: string, ass
         }
         current_lines = lowered_ptr.lines;
         current_temp = lowered_ptr.temp_index;
-        current_temp = _recover_assign_temp(current_lines, current_temp);
+        current_temp = recover_temp_from_lines(current_lines, current_temp);
         if lowered_ptr.operand == null {
             diagnostics.push("llvm lowering: deref assignment pointer `"
                 + pointer_text
@@ -226,7 +178,7 @@ fn lower_lvalue_assignment_stmt(assign_target: string, assign_value: string, ass
         }
         current_lines = coerced.lines;
         current_temp = coerced.temp_index;
-        current_temp = _recover_assign_temp(current_lines, current_temp);
+        current_temp = recover_temp_from_lines(current_lines, current_temp);
         if coerced.operand == null {
             diagnostics.push("llvm lowering: unable to coerce deref assignment value to `"
                 + element_type
@@ -281,7 +233,7 @@ fn lower_lvalue_assignment_stmt(assign_target: string, assign_value: string, ass
         string_constants = lowered.string_constants;
         current_lines = lowered.lines;
         current_temp = lowered.temp_index;
-        current_temp = _recover_assign_temp(current_lines, current_temp);
+        current_temp = recover_temp_from_lines(current_lines, current_temp);
         if lowered.operand == null {
             diagnostics.push("llvm lowering: failed to lower assignment value for member `"
                 + assign_target
@@ -296,7 +248,7 @@ fn lower_lvalue_assignment_stmt(assign_target: string, assign_value: string, ass
             }
             current_lines = base_result.lines;
             current_temp = base_result.temp_index;
-            current_temp = _recover_assign_temp(current_lines, current_temp);
+            current_temp = recover_temp_from_lines(current_lines, current_temp);
             if base_result.operand == null {
                 diagnostics.push("llvm lowering: member access assignment base `"
                     + member_parse.base
@@ -351,7 +303,7 @@ fn lower_lvalue_assignment_stmt(assign_target: string, assign_value: string, ass
                         }
                         current_lines = array_result.lines;
                         current_temp = array_result.temp_index;
-                        current_temp = _recover_assign_temp(current_lines, current_temp);
+                        current_temp = recover_temp_from_lines(current_lines, current_temp);
                         if array_result.operand != null {
                             let array_operand = array_result.operand;
                             let element_type = array_pointer_element_type(array_operand.llvm_type);
@@ -367,7 +319,7 @@ fn lower_lvalue_assignment_stmt(assign_target: string, assign_value: string, ass
                                 }
                                 current_lines = index_result.lines;
                                 current_temp = index_result.temp_index;
-                                current_temp = _recover_assign_temp(current_lines, current_temp);
+                                current_temp = recover_temp_from_lines(current_lines, current_temp);
                                 if index_result.operand != null {
                                     // Slice E.1.5 (#528): array index coercion
                                     // legitimately widens double → i64 today
@@ -385,7 +337,7 @@ fn lower_lvalue_assignment_stmt(assign_target: string, assign_value: string, ass
                                     }
                                     current_lines = coerced_index.lines;
                                     current_temp = coerced_index.temp_index;
-                                    current_temp = _recover_assign_temp(current_lines, current_temp);
+                                    current_temp = recover_temp_from_lines(current_lines, current_temp);
                                     if coerced_index.operand != null {
                                         let data_field_ptr = format_temp_name(current_temp);
                                         current_temp += 1;
@@ -514,7 +466,7 @@ fn lower_lvalue_assignment_stmt(assign_target: string, assign_value: string, ass
                         }
                         current_lines = coerced.lines;
                         current_temp = coerced.temp_index;
-                        current_temp = _recover_assign_temp(current_lines, current_temp);
+                        current_temp = recover_temp_from_lines(current_lines, current_temp);
                         // Slice E.1.5 (#528): location-aware follow-up so the
                         // struct + field name is in the build log alongside
                         // the type-shape detail emitted by `coerce_operand_to_type`.
@@ -603,7 +555,7 @@ fn lower_lvalue_assignment_stmt(assign_target: string, assign_value: string, ass
         string_constants = lowered.string_constants;
         current_lines = lowered.lines;
         current_temp = lowered.temp_index;
-        current_temp = _recover_assign_temp(current_lines, current_temp);
+        current_temp = recover_temp_from_lines(current_lines, current_temp);
         if lowered.operand == null {
             diagnostics.push("llvm lowering: failed to lower assignment value for array index `"
                 + assign_target
@@ -618,7 +570,7 @@ fn lower_lvalue_assignment_stmt(assign_target: string, assign_value: string, ass
             }
             current_lines = base_result.lines;
             current_temp = base_result.temp_index;
-            current_temp = _recover_assign_temp(current_lines, current_temp);
+            current_temp = recover_temp_from_lines(current_lines, current_temp);
             if base_result.operand == null {
                 diagnostics.push("llvm lowering: array index assignment base `"
                     + index_parse.base
@@ -633,7 +585,7 @@ fn lower_lvalue_assignment_stmt(assign_target: string, assign_value: string, ass
                 }
                 current_lines = index_result.lines;
                 current_temp = index_result.temp_index;
-                current_temp = _recover_assign_temp(current_lines, current_temp);
+                current_temp = recover_temp_from_lines(current_lines, current_temp);
                 if index_result.operand == null {
                     diagnostics.push("llvm lowering: array index `"
                         + index_parse.index
@@ -659,7 +611,7 @@ fn lower_lvalue_assignment_stmt(assign_target: string, assign_value: string, ass
                         }
                         current_lines = coerced.lines;
                         current_temp = coerced.temp_index;
-                        current_temp = _recover_assign_temp(current_lines, current_temp);
+                        current_temp = recover_temp_from_lines(current_lines, current_temp);
                         if coerced.operand != null {
                             // Slice E.1.5 (#528): array index coerce, exempt
                             // (see comment at the subscripted-lvalue site
@@ -675,7 +627,7 @@ fn lower_lvalue_assignment_stmt(assign_target: string, assign_value: string, ass
                             }
                             current_lines = coerced_index.lines;
                             current_temp = coerced_index.temp_index;
-                            current_temp = _recover_assign_temp(current_lines, current_temp);
+                            current_temp = recover_temp_from_lines(current_lines, current_temp);
                             if coerced_index.operand == null {
                                 diagnostics.push("llvm lowering: unable to coerce array index to i64 for `"
                                     + assign_target

--- a/compiler/src/llvm/expression_lowering/native/temp_recovery.sfn
+++ b/compiler/src/llvm/expression_lowering/native/temp_recovery.sfn
@@ -1,0 +1,37 @@
+// compiler/src/llvm/expression_lowering/native/temp_recovery.sfn
+//
+// Shared SSA temp counter recovery for LLVM lowering paths that cross the
+// self-hosted compiler's module ABI boundary.
+import { char_at, char_code } from "../../../string_utils";
+import { starts_with } from "../../utils";
+
+// Recover from seed ABI corruption: result temp_index fields can be stale when
+// returned from cross-module calls. Scan emitted lines for the highest %tN
+// definition and use max(found+1, floor) as the recovered counter.
+fn recover_temp_from_lines(lines: string[], floor: number) -> number {
+    let mut result: number = floor;
+    let mut ri: number = 0;
+    loop {
+        if ri >= lines.length { break; }
+        let rl = lines[ri];
+        if starts_with(rl, "  %t") {
+            let mut rn: number = 0;
+            let mut rj: number = 4;
+            let mut rvalid: boolean = false;
+            loop {
+                if rj >= rl.length { break; }
+                let rc = char_code(char_at(rl, rj));
+                if rc < 48 { break; }
+                if rc > 57 { break; }
+                rn = rn * 10 + (rc - 48);
+                rvalid = true;
+                rj += 1;
+            }
+            if rvalid {
+                if rn >= result { result = rn + 1; }
+            }
+        }
+        ri += 1;
+    }
+    return result;
+}

--- a/compiler/src/llvm/lowering/instructions_condition.sfn
+++ b/compiler/src/llvm/lowering/instructions_condition.sfn
@@ -2,7 +2,7 @@
 //
 // Shared condition-lowering utilities used by if, loop, and match instruction handlers.
 import { NativeFunction, NativeInstruction, NativeSourceSpan } from "../../native_ir";
-import { char_code, grapheme_at, substring } from "../../string_utils";
+import { substring } from "../../string_utils";
 import { lower_expression } from "../expression_lowering/native/core";
 import { detect_suspension_conflicts } from "../expression_lowering/native/statement_suspension";
 import { recover_temp_from_lines } from "../expression_lowering/native/temp_recovery";

--- a/compiler/src/llvm/lowering/instructions_condition.sfn
+++ b/compiler/src/llvm/lowering/instructions_condition.sfn
@@ -5,6 +5,7 @@ import { NativeFunction, NativeInstruction, NativeSourceSpan } from "../../nativ
 import { char_code, grapheme_at, substring } from "../../string_utils";
 import { lower_expression } from "../expression_lowering/native/core";
 import { detect_suspension_conflicts } from "../expression_lowering/native/statement_suspension";
+import { recover_temp_from_lines } from "../expression_lowering/native/temp_recovery";
 import { find_local_binding, find_parameter_binding } from "../expressions_bindings";
 import { default_return_literal, format_temp_name } from "../expressions_helpers";
 import { is_number_literal, normalise_number_literal } from "../expressions_literals";
@@ -17,13 +18,7 @@ import {
     StringConstant,
     TypeContext
 } from "../types";
-import {
-    index_of,
-    number_to_string,
-    starts_with,
-    trim_text
-} from "../utils";
-import { _parse_int_from_string } from "./instructions_helpers";
+import { number_to_string, starts_with, trim_text } from "../utils";
 
 fn allocate_block_label(prefix: string, counter: number) -> BlockLabelResult {
     return BlockLabelResult {
@@ -43,25 +38,7 @@ fn lower_condition_to_i1(function_name: string, expression: string, bindings: Pa
     }
     let mut current_lines: string[] = lowered.lines;
     let mut current_temp: number = lowered.temp_index;
-    // Recover from v0.1.1 seed ABI corruption: lowered.temp_index may be 0.
-    // Scan lines for the highest %tN assignment and use that to recover current_temp.
-    {
-        let mut _scan_i: number = 0;
-        loop {
-            if _scan_i >= current_lines.length { break; }
-            let _scan_line = current_lines[_scan_i];
-            if starts_with(_scan_line, "  %t") {
-                let _after_t = substring(_scan_line, 4, _scan_line.length);
-                let _space = index_of(_after_t, " ");
-                if _space > 0 {
-                    let _num_str = substring(_after_t, 0, _space);
-                    let _num = _parse_int_from_string(_num_str);
-                    if _num >= current_temp { current_temp = _num + 1; }
-                }
-            }
-            _scan_i += 1;
-        }
-    }
+    current_temp = recover_temp_from_lines(current_lines, current_temp);
 
     let string_constants = lowered.string_constants;
 

--- a/compiler/tests/integration/numeric_abi_mismatch_test.sfn
+++ b/compiler/tests/integration/numeric_abi_mismatch_test.sfn
@@ -9,7 +9,7 @@
 // and the coerce path's behaviour so a future Slice E.2 (#489a–d)
 // migration that leaves the tree inconsistent fails loudly instead of
 // producing corrupt LLVM IR with split ABI shapes.
-import { coerce_operand_to_type } from "../../src/llvm/expression_lowering/native/core_operands";
+import { coerce_operand_to_type, harmonise_operands } from "../../src/llvm/expression_lowering/native/core_operands";
 import { numeric_type_kind } from "../../src/llvm/type_mapping";
 import { LLVMOperand } from "../../src/llvm/types";
 
@@ -120,6 +120,35 @@ test "coerce_operand_to_type: silently coerces double → i64 when widening is a
     let mut lines: string[] = [];
     let result = coerce_operand_to_type(operand, "i64", 0, lines, true);
     assert result.operand != null;
+}
+
+// -------------------------------------------------------------------
+// Temp-index recovery across module boundaries (#543)
+// -------------------------------------------------------------------
+test "coerce_operand_to_type: recovers temp_index from existing emitted lines" ![io] {
+    let operand = _make_operand("i64", "%t1");
+    let mut lines: string[] = [];
+    lines.push("  %t0 = add i64 1, 2");
+    lines.push("  %t1 = add i64 %t0, 3");
+
+    let result = coerce_operand_to_type(operand, "i64", 0, lines, false);
+
+    assert result.operand != null;
+    assert result.temp_index == 2;
+}
+
+test "harmonise_operands: recovers temp_index from existing emitted lines" {
+    let left = _make_operand("i64", "%t0");
+    let right = _make_operand("i64", "%t1");
+    let mut lines: string[] = [];
+    lines.push("  %t0 = add i64 1, 2");
+    lines.push("  %t1 = add i64 %t0, 3");
+
+    let result = harmonise_operands(left, right, 0, lines);
+
+    assert result.left != null;
+    assert result.right != null;
+    assert result.temp_index == 2;
 }
 
 // -------------------------------------------------------------------

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,6 +1,6 @@
 # Status
 
-Updated: May 8, 2026 (Stage C complete through C4 migration; Stage D PR1–PR5 shipped; Stage E PR1–PR7 shipped — PR1–1f / #254–#259, C2a / #261, C2b1 / #262, C2b2 / #263, C2c / #264, C4 v1 / #265, C4b / #266, C4 migration / #267, D PR1 / #268, D PR2 / #269, D PR3 / #271, D PR4 / #272, D PR5 / #273, E PR1 / #274, E PR2 / #277, E PR3 / #278, E PR4 / #280, E PR5 / #378, E PR6 / #382, E PR7 / #383; seed pinned to v0.5.10-alpha.7)
+Updated: May 11, 2026 (Stage C complete through C4 migration; Stage D PR1–PR5 shipped; Stage E PR1–PR7 shipped; lowering temp-index recovery fix for #543 staged — PR1–1f / #254–#259, C2a / #261, C2b1 / #262, C2b2 / #263, C2c / #264, C4 v1 / #265, C4b / #266, C4 migration / #267, D PR1 / #268, D PR2 / #269, D PR3 / #271, D PR4 / #272, D PR5 / #273, E PR1 / #274, E PR2 / #277, E PR3 / #278, E PR4 / #280, E PR5 / #378, E PR6 / #382, E PR7 / #383; seed pinned to v0.5.10-alpha.13)
 
 This document tracks what works today and what is in progress. It is the source
 of truth — consult it before editing docs, examples, or making claims about
@@ -8,6 +8,14 @@ feature availability.
 
 ## Build Pipeline (Current)
 
+- **LLVM lowering temp-index recovery fix (#543, 2026-05-11).**
+  `coerce_operand_to_type` and `harmonise_operands` now recover
+  returned SSA temp counters by scanning emitted `%tN` definitions on
+  every exit path, including diagnostic/null-operand returns. The
+  recovery scan is shared by statement, assignment, condition, and
+  operand lowering paths so cross-module ABI-width corruption cannot
+  leave callers with stale `temp_index` values during the numeric
+  migration.
 - `<seed> build -p compiler` is the sole build driver for the compiler's
   self-build. The Sailfin-native driver (in `compiler/src/cli_main.sfn` +
   `compiler/src/capsule_resolver.sfn`) walks the binary capsule's


### PR DESCRIPTION
### Motivation
- Prevent stale `temp_index` values returned across self-hosted module boundaries from producing duplicate or misordered `%tN` temps in emitted LLVM IR by consolidating the recovery logic and ensuring every exit path recovers a usable counter. 

### Description
- Add a shared helper `recover_temp_from_lines` in `compiler/src/llvm/expression_lowering/native/temp_recovery.sfn` that scans emitted lines for the highest `%tN` and returns a safe next temp index. 
- Update `coerce_operand_to_type` so every return path (no-op, ABI-mismatch, numeric/pointer/general subresults, and failure) recovers `temp_index` from the emitted `lines` before returning. 
- Update `harmonise_operands` to recover returned `temp_index` for same-type, failure, and success exits. 
- Replace duplicated scanning code with calls to `recover_temp_from_lines` in `statement.sfn`, `statement_assignment.sfn`, and `instructions_condition.sfn`, and update `docs/status.md` to record the fix for #543. 

### Testing
- Ran `git diff --check` and `ulimit -v 8388608 && make compile`, both succeeded. 
- Ran formatter checks with `build/native/sailfin fmt --check` on affected files and fixed formatting, which passed. 
- Ran `ulimit -v 8388608 && make test`, which completed successfully (`unit/integration/e2e` suites ran; unit: 94/94 passed, integration/e2e mostly passed). 
- Ran the seed vs native emit verification for `examples/basics/hello-world.sfn` and the files were identical (seed vs native emit diff returned no differences). 
- Ran `ulimit -v 8388608 && make check` (full check including seedcheck); it failed once in the seedcheck phase on a non-deterministic 20x emit-sweep iteration (one transient IR corruption observed), but re-running the exact failing seedcheck e2e script `compiler/tests/e2e/test_runtime_array.sh build/native/sailfin-seedcheck` passed; the transient non-determinism is noted as a residual concern in the PR description.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a013e17f44c8324905f442a88d3d8c9)