### PR TITLE
refactor(diagnostics): thread NativeSourceSpan through coerce + struct/enum-literal lowering

### DIFF
--- a/compiler/src/llvm/expression_lowering/native/core.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core.sfn
@@ -1005,7 +1005,11 @@ fn lower_expression(expression: string, bindings: ParameterBinding[], locals: Lo
             // Verify this is actually an enum by checking context
             let enum_info = resolve_enum_info_for_literal(context, enum_parse.enum_name);
             if enum_info != null {
-                let lowered_enum = lower_enum_literal(enum_parse, bindings, locals, temp_index, lines, functions, context, expected_type);
+                // Slice E.2 follow-up (#540): `lower_expression` does not
+                // yet carry the enclosing source span — wiring it through is
+                // out of scope per the issue's `Out:` section. Pass `null`;
+                // the ABI mismatch diagnostic falls back to its bare form.
+                let lowered_enum = lower_enum_literal(enum_parse, bindings, locals, temp_index, lines, functions, context, expected_type, null);
                 let mut _ci2: number = 0;
                 loop {
                     if _ci2 >= lowered_enum.diagnostics.length { break; }
@@ -1040,7 +1044,7 @@ fn lower_expression(expression: string, bindings: ParameterBinding[], locals: Lo
                 string_constants: empty_constants
             };
         }
-        let lowered_struct = lower_struct_literal(struct_parse, bindings, locals, temp_index, lines, functions, context, expected_type);
+        let lowered_struct = lower_struct_literal(struct_parse, bindings, locals, temp_index, lines, functions, context, expected_type, null);
         let mut _ci4: number = 0;
         loop {
             if _ci4 >= lowered_struct.diagnostics.length { break; }

--- a/compiler/src/llvm/expression_lowering/native/core_call_emission.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_call_emission.sfn
@@ -124,7 +124,7 @@ fn coerce_and_emit_call(trimmed_target: string, operands: LLVMOperand[], expecte
                     }
                 }
             }
-            let coerced = coerce_operand_to_type(operand, target_type, result_temp, result_lines, _arg_allow_widen);
+            let coerced = coerce_operand_to_type(operand, target_type, result_temp, result_lines, _arg_allow_widen, null);
             result_diagnostics = extend_string_array(result_diagnostics, coerced.diagnostics);
             result_lines = coerced.lines;
             result_temp = coerced.temp_index;
@@ -235,7 +235,7 @@ fn coerce_and_emit_call(trimmed_target: string, operands: LLVMOperand[], expecte
                 // widens i64 literals to double[] receivers (see Slice E.1
                 // comment above). Slice E.1.5 (#528) leaves this site exempt
                 // from the ABI primitive kind check.
-                let push_value_coerced = coerce_operand_to_type(final_operands[1], array_push_element_type, result_temp, result_lines, true);
+                let push_value_coerced = coerce_operand_to_type(final_operands[1], array_push_element_type, result_temp, result_lines, true, null);
                 let mut _ci_apc: number = 0;
                 loop {
                     if _ci_apc >= push_value_coerced.diagnostics.length {

--- a/compiler/src/llvm/expression_lowering/native/core_call_lowering.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_call_lowering.sfn
@@ -125,7 +125,7 @@ fn lower_call_expression(target: string, arguments: string[], bindings: Paramete
                 diagnostics: []
             };
 
-            return lower_enum_literal(enum_parse, bindings, locals, temp_index, lines, functions, context, "");
+            return lower_enum_literal(enum_parse, bindings, locals, temp_index, lines, functions, context, "", null);
         }
     }
 

--- a/compiler/src/llvm/expression_lowering/native/core_index_lowering.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_index_lowering.sfn
@@ -69,7 +69,7 @@ fn lower_index_expression(parse: IndexExpressionParse, bindings: ParameterBindin
 
     let index_operand = index_result.operand;
 
-    let index_coercion = coerce_operand_to_type(index_operand, "i64", current_temp, current_lines, true);
+    let index_coercion = coerce_operand_to_type(index_operand, "i64", current_temp, current_lines, true, null);
     let mut _ci1: number = 0;
     loop {
         if _ci1 >= index_coercion.diagnostics.length { break; }
@@ -181,7 +181,7 @@ fn lower_index_expression(parse: IndexExpressionParse, bindings: ParameterBindin
     }
 
     if is_string {
-        let index_as_double = coerce_operand_to_type(index_operand, "double", current_temp, current_lines, true);
+        let index_as_double = coerce_operand_to_type(index_operand, "double", current_temp, current_lines, true, null);
         let mut _ci2: number = 0;
         loop {
             if _ci2 >= index_as_double.diagnostics.length { break; }

--- a/compiler/src/llvm/expression_lowering/native/core_literals_lowering.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_literals_lowering.sfn
@@ -1,7 +1,7 @@
 // compiler/src/llvm/expression_lowering/native/core_literals_lowering.sfn
 //
 // Literal/cast/interpolation lowering extracted from core.sfn.
-import { NativeFunction } from "../../../native_ir";
+import { NativeFunction, NativeSourceSpan } from "../../../native_ir";
 import { substring } from "../../../string_utils";
 import { default_return_literal, format_temp_name } from "../../expressions_helpers";
 import { empty_string_constant_set, merge_string_constants } from "../../strings";
@@ -67,6 +67,15 @@ import {
     emit_runtime_call,
     empty_runtime_call_overrides
 } from "./runtime_call";
+
+// Slice E.2 follow-up (#540): mirrors `format_coerce_span_location` in
+// `core_operands.sfn`. Inline rather than imported to avoid a cyclic
+// dependency through `core_ownership.sfn`.
+fn _format_literal_span(span: NativeSourceSpan) -> string {
+    let start = number_to_string(span.start_line) + ":" + number_to_string(span.start_column);
+    let end = number_to_string(span.end_line) + ":" + number_to_string(span.end_column);
+    return start + "-" + end;
+}
 
 fn lower_array_literal(text: string, bindings: ParameterBinding[], locals: LocalBinding[], temp_index: number, lines: string[], functions: NativeFunction[], context: TypeContext, expected_type: string) -> ExpressionResult {
     let mut diagnostics: string[] = [];
@@ -454,7 +463,7 @@ fn lower_array_literal(text: string, bindings: ParameterBinding[], locals: Local
         }
         // Slice E.1.5 (#528): array literal element coerce — exempt
         // (array-element store is not in the slice's strict scope).
-        let coerced = coerce_operand_to_type(prepared_operand, element_type, current_temp, current_lines, true);
+        let coerced = coerce_operand_to_type(prepared_operand, element_type, current_temp, current_lines, true, null);
         diagnostics = extend_string_array(diagnostics, coerced.diagnostics);
         current_lines = coerced.lines;
         current_temp = coerced.temp_index;
@@ -674,7 +683,13 @@ fn lower_array_literal(text: string, bindings: ParameterBinding[], locals: Local
     };
 }
 
-fn lower_struct_literal(parse: StructLiteralParse, bindings: ParameterBinding[], locals: LocalBinding[], temp_index: number, lines: string[], functions: NativeFunction[], context: TypeContext, expected_type: string) -> ExpressionResult {
+// Slice E.2 follow-up (#540): `span` carries the struct-literal site's
+// source location so the ABI primitive mismatch diagnostic emitted by
+// `coerce_operand_to_type` (and the local follow-up below) can name a
+// `line:col` instead of firing bare. Pre-#540 callers (every `lower_expression`
+// fan-out) thread `null` until they pick up an enclosing span — see the
+// issue's `Out:` section for the deferred plumbing.
+fn lower_struct_literal(parse: StructLiteralParse, bindings: ParameterBinding[], locals: LocalBinding[], temp_index: number, lines: string[], functions: NativeFunction[], context: TypeContext, expected_type: string, span: NativeSourceSpan?) -> ExpressionResult {
     let mut diagnostics: string[] = parse.diagnostics;
     let mut current_lines: string[] = lines;
     let mut current_temp: number = temp_index;
@@ -762,7 +777,10 @@ fn lower_struct_literal(parse: StructLiteralParse, bindings: ParameterBinding[],
                 // a struct-field write; strict ABI primitive kind check, with
                 // a location-aware follow-up so the failing struct + field
                 // is in the build log next to the type-shape detail.
-                let coerced = coerce_operand_to_type(lowered.operand, expected.llvm_type, current_temp, current_lines, false);
+                // Slice E.2 follow-up (#540): thread the struct-literal site
+                // span so the bare ABI primitive mismatch diagnostic from
+                // `coerce_operand_to_type` carries a `line:col`.
+                let coerced = coerce_operand_to_type(lowered.operand, expected.llvm_type, current_temp, current_lines, false, span);
                 let mut _ci6: number = 0;
                 loop {
                     if _ci6 >= coerced.diagnostics.length { break; }
@@ -792,7 +810,10 @@ fn lower_struct_literal(parse: StructLiteralParse, bindings: ParameterBinding[],
                     // this push enriches the diagnostic stream for future
                     // renderers that surface non-fatal-yet-fatal-tagged
                     // entries in the build report.
-                    diagnostics.push(_lit_diag_prefix
+                    // Slice E.2 follow-up (#540): when the caller threaded a
+                    // span, attach the same `line:col` here so the follow-up
+                    // diagnostic colocates with the bare mismatch detail.
+                    let mut _lit_diag = _lit_diag_prefix
                         + "unable to coerce value (got `"
                         + lowered.operand.llvm_type
                         + "`) into struct literal field `"
@@ -801,7 +822,11 @@ fn lower_struct_literal(parse: StructLiteralParse, bindings: ParameterBinding[],
                         + expected.name
                         + "` (expected `"
                         + expected.llvm_type
-                        + "`)");
+                        + "`)";
+                    if span != null {
+                        _lit_diag = _lit_diag + " at " + _format_literal_span(span);
+                    }
+                    diagnostics.push(_lit_diag);
                 }
                 if coerced.operand != null {
                     value_operand = coerced.operand;
@@ -996,7 +1021,9 @@ fn box_aggregate_operand(operand: LLVMOperand, expected_pointer_type: string, te
     };
 }
 
-fn lower_enum_literal(parse: EnumLiteralParse, bindings: ParameterBinding[], locals: LocalBinding[], temp_index: number, lines: string[], functions: NativeFunction[], context: TypeContext, expected_type: string) -> ExpressionResult {
+// Slice E.2 follow-up (#540): `span` mirrors the threading in
+// `lower_struct_literal`. Pre-#540 callers pass `null`.
+fn lower_enum_literal(parse: EnumLiteralParse, bindings: ParameterBinding[], locals: LocalBinding[], temp_index: number, lines: string[], functions: NativeFunction[], context: TypeContext, expected_type: string, span: NativeSourceSpan?) -> ExpressionResult {
     let mut diagnostics: string[] = parse.diagnostics;
     let mut current_lines: string[] = lines;
     let mut current_temp: number = temp_index;
@@ -1152,7 +1179,9 @@ fn lower_enum_literal(parse: EnumLiteralParse, bindings: ParameterBinding[], loc
                     // a location-aware follow-up that names the enum +
                     // variant + field so partial-migration breakage is
                     // self-locating.
-                    let coerced = coerce_operand_to_type(field_operand, expected.llvm_type, current_temp, current_lines, false);
+                    // Slice E.2 follow-up (#540): thread the enum-literal
+                    // site span; same shape as the struct-literal branch.
+                    let coerced = coerce_operand_to_type(field_operand, expected.llvm_type, current_temp, current_lines, false, span);
                     let mut _ci9: number = 0;
                     loop {
                         if _ci9 >= coerced.diagnostics.length { break; }
@@ -1180,7 +1209,7 @@ fn lower_enum_literal(parse: EnumLiteralParse, bindings: ParameterBinding[], loc
                         // the diagnostic stream rather than stderr. The
                         // ABI-shape detail itself is already on stderr from
                         // `coerce_operand_to_type`.
-                        diagnostics.push(_payload_diag_prefix
+                        let mut _payload_diag = _payload_diag_prefix
                             + "unable to coerce value (got `"
                             + field_operand.llvm_type
                             + "`) into enum payload field `"
@@ -1191,7 +1220,12 @@ fn lower_enum_literal(parse: EnumLiteralParse, bindings: ParameterBinding[], loc
                             + expected.name
                             + "` (expected `"
                             + expected.llvm_type
-                            + "`)");
+                            + "`)";
+                        if span != null {
+                            _payload_diag = _payload_diag + " at "
+                                + _format_literal_span(span);
+                        }
+                        diagnostics.push(_payload_diag);
                     }
                     if coerced.operand != null {
                         if alloca_ptr != null {

--- a/compiler/src/llvm/expression_lowering/native/core_operands.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_operands.sfn
@@ -6,6 +6,7 @@
 // `harmonise_operands`), emits comparison instructions for equality and
 // relational operators (`emit_comparison_instruction`, `emit_boolean_and`),
 // and provides local variable loading (`load_local_operand`).
+import { NativeSourceSpan } from "../../../native_ir";
 import { char_code } from "../../../string_utils";
 import { default_return_literal, format_temp_name } from "../../expressions_helpers";
 import { trace_lowering } from "../../lowering_debug_state";
@@ -35,6 +36,16 @@ import {
     empty_runtime_call_overrides
 } from "./runtime_call";
 import { recover_temp_from_lines } from "./temp_recovery";
+
+// Slice E.2 follow-up (#540): tiny inline formatter so coerce diagnostics
+// can attach a source span without crossing the `core_ownership` →
+// `core_operands` boundary (which would introduce a cyclic import).
+// Mirrors `format_span_location` in shape — `start_line:start_col-end_line:end_col`.
+fn format_coerce_span_location(span: NativeSourceSpan) -> string {
+    let start = number_to_string(span.start_line) + ":" + number_to_string(span.start_column);
+    let end = number_to_string(span.end_line) + ":" + number_to_string(span.end_column);
+    return start + "-" + end;
+}
 
 fn emit_comparison_instruction(symbol: string, left_operand: LLVMOperand, right_operand: LLVMOperand, temp_index: number, lines: string[]) -> ComparisonEmission {
     let mut diagnostics: string[] = [];
@@ -1851,7 +1862,7 @@ fn coerce_general_fallback(operand: LLVMOperand, operand_type: string, target: s
 // Slice E.3 (#490) re-applies #296 — once every `: number` site in the
 // compiler source has migrated to `: int`/`: float`, the symmetric rejection
 // generalises to the permissive sites above as well.
-fn coerce_operand_to_type(operand: LLVMOperand, target_type: string, temp_index: number, lines: string[], allow_widen: boolean) -> CoercionResult ![io] {
+fn coerce_operand_to_type(operand: LLVMOperand, target_type: string, temp_index: number, lines: string[], allow_widen: boolean, span: NativeSourceSpan?) -> CoercionResult ![io] {
     let debug_coerce = trace_lowering();
     if debug_coerce {
         print.err("emit-llvm: coerce_operand entry operand_type=" + operand.llvm_type
@@ -1899,7 +1910,11 @@ fn coerce_operand_to_type(operand: LLVMOperand, target_type: string, temp_index:
             if to_kind == "int" { _kind_check = true; }
         }
         if _kind_check {
-            let abi_diag = "llvm lowering [fatal]: ABI primitive mismatch: callee expects `"
+            // Slice E.2 follow-up (#540): when the caller threads a
+            // `NativeSourceSpan`, attach it to the diagnostic so the
+            // failing site is locatable in the source. Pre-#540 callers
+            // pass `null` and continue producing the bare message.
+            let mut abi_diag = "llvm lowering [fatal]: ABI primitive mismatch: callee expects `"
                 + target
                 + "` ("
                 + to_kind
@@ -1908,6 +1923,9 @@ fn coerce_operand_to_type(operand: LLVMOperand, target_type: string, temp_index:
                 + "` ("
                 + from_kind
                 + ")";
+            if span != null {
+                abi_diag = abi_diag + " at " + format_coerce_span_location(span);
+            }
             print.err(abi_diag);
             diagnostics.push(abi_diag);
             return CoercionResult {
@@ -2050,7 +2068,7 @@ fn harmonise_operands(left: LLVMOperand, right: LLVMOperand, temp_index: number,
     // `1 + 2.0` or `arr.length + 0.5` legitimately widen i64 → double here.
     // Slice E.3 (#490) reapplies #296 and removes this opt-out once every
     // `: number` site in the compiler source has migrated to `: int`/`: float`.
-    let left_coercion = coerce_operand_to_type(left_operand, target_type, current_temp, current_lines, true);
+    let left_coercion = coerce_operand_to_type(left_operand, target_type, current_temp, current_lines, true, null);
     let mut _ci0: number = 0;
     loop {
         if _ci0 >= left_coercion.diagnostics.length { break; }
@@ -2076,7 +2094,7 @@ fn harmonise_operands(left: LLVMOperand, right: LLVMOperand, temp_index: number,
     current_lines = left_coercion.lines;
     current_temp = left_coercion.temp_index;
 
-    let right_coercion = coerce_operand_to_type(right_operand, target_type, current_temp, current_lines, true);
+    let right_coercion = coerce_operand_to_type(right_operand, target_type, current_temp, current_lines, true, null);
     let mut _ci1: number = 0;
     loop {
         if _ci1 >= right_coercion.diagnostics.length { break; }

--- a/compiler/src/llvm/expression_lowering/native/core_ops_lowering.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_ops_lowering.sfn
@@ -41,7 +41,7 @@ import {
 import { lines_end_with_terminator, strip_enclosing_parentheses } from "./core_operators";
 
 fn lower_logical_not_with_operand(operand: LLVMOperand, temp_index: number, lines: string[], diagnostics: string[], string_constants: StringConstant[]) -> ExpressionResult {
-    let coerced = coerce_operand_to_type(operand, "i1", temp_index, lines, true);
+    let coerced = coerce_operand_to_type(operand, "i1", temp_index, lines, true, null);
     let mut current_diagnostics: string[] = diagnostics;
     let mut _ci0: number = 0;
     loop {
@@ -123,7 +123,7 @@ fn lower_ternary_expression(parse: TernaryParseResult, bindings: ParameterBindin
         };
     }
 
-    let cond_bool = coerce_operand_to_type(cond_result.operand, "i1", cond_result.temp_index, cond_result.lines, true);
+    let cond_bool = coerce_operand_to_type(cond_result.operand, "i1", cond_result.temp_index, cond_result.lines, true, null);
     diagnostics = extend_string_array(diagnostics, cond_bool.diagnostics);
     if cond_bool.operand == null {
         return ExpressionResult {
@@ -357,7 +357,7 @@ fn lower_binary_operation(expression: string, match: OperatorMatch, bindings: Pa
             // operands so we don't pay the unnecessary extract.
             let mut lhs_at_string = lhs;
             if lhs_type != "{i8*, i64}" {
-                let lhs_coerced = coerce_operand_to_type(lhs, "i8*", current_temp, current_lines, true);
+                let lhs_coerced = coerce_operand_to_type(lhs, "i8*", current_temp, current_lines, true, null);
                 diagnostics = extend_string_array(diagnostics, lhs_coerced.diagnostics);
                 current_lines = lhs_coerced.lines;
                 current_temp = lhs_coerced.temp_index;
@@ -374,7 +374,7 @@ fn lower_binary_operation(expression: string, match: OperatorMatch, bindings: Pa
             }
             let mut rhs_at_string = rhs;
             if rhs_type != "{i8*, i64}" {
-                let rhs_coerced = coerce_operand_to_type(rhs, "i8*", current_temp, current_lines, true);
+                let rhs_coerced = coerce_operand_to_type(rhs, "i8*", current_temp, current_lines, true, null);
                 diagnostics = extend_string_array(diagnostics, rhs_coerced.diagnostics);
                 current_lines = rhs_coerced.lines;
                 current_temp = rhs_coerced.temp_index;
@@ -391,7 +391,7 @@ fn lower_binary_operation(expression: string, match: OperatorMatch, bindings: Pa
             }
 
             // Step 2: lift both sides to the {i8*, i64} aggregate.
-            let lhs_agg = coerce_operand_to_type(lhs_at_string, "{i8*, i64}", current_temp, current_lines, true);
+            let lhs_agg = coerce_operand_to_type(lhs_at_string, "{i8*, i64}", current_temp, current_lines, true, null);
             diagnostics = extend_string_array(diagnostics, lhs_agg.diagnostics);
             current_lines = lhs_agg.lines;
             current_temp = lhs_agg.temp_index;
@@ -404,7 +404,7 @@ fn lower_binary_operation(expression: string, match: OperatorMatch, bindings: Pa
                     string_constants: string_constants
                 };
             }
-            let rhs_agg = coerce_operand_to_type(rhs_at_string, "{i8*, i64}", current_temp, current_lines, true);
+            let rhs_agg = coerce_operand_to_type(rhs_at_string, "{i8*, i64}", current_temp, current_lines, true, null);
             diagnostics = extend_string_array(diagnostics, rhs_agg.diagnostics);
             current_lines = rhs_agg.lines;
             current_temp = rhs_agg.temp_index;
@@ -455,7 +455,7 @@ fn lower_binary_operation(expression: string, match: OperatorMatch, bindings: Pa
                 let mut current_lines = right_result.lines;
                 let mut current_temp = right_result.temp_index;
 
-                let lhs_coerced = coerce_operand_to_type(lhs, "double", current_temp, current_lines, true);
+                let lhs_coerced = coerce_operand_to_type(lhs, "double", current_temp, current_lines, true, null);
                 diagnostics = extend_string_array(diagnostics, lhs_coerced.diagnostics);
                 current_lines = lhs_coerced.lines;
                 current_temp = lhs_coerced.temp_index;
@@ -469,7 +469,7 @@ fn lower_binary_operation(expression: string, match: OperatorMatch, bindings: Pa
                     };
                 }
 
-                let rhs_coerced = coerce_operand_to_type(rhs, "double", current_temp, current_lines, true);
+                let rhs_coerced = coerce_operand_to_type(rhs, "double", current_temp, current_lines, true, null);
                 diagnostics = extend_string_array(diagnostics, rhs_coerced.diagnostics);
                 current_lines = rhs_coerced.lines;
                 current_temp = rhs_coerced.temp_index;
@@ -529,7 +529,7 @@ fn lower_binary_operation(expression: string, match: OperatorMatch, bindings: Pa
                     let mut current_temp = right_result.temp_index;
                     let mut rhs_i64 = rhs;
                     if rhs_type != "i64" {
-                        let coerced = coerce_operand_to_type(rhs, "i64", current_temp, current_lines, true);
+                        let coerced = coerce_operand_to_type(rhs, "i64", current_temp, current_lines, true, null);
                         diagnostics = extend_string_array(diagnostics, coerced.diagnostics);
                         current_lines = coerced.lines;
                         current_temp = coerced.temp_index;
@@ -612,7 +612,7 @@ fn lower_binary_operation(expression: string, match: OperatorMatch, bindings: Pa
         if should_concat_aligned {
             let mut current_lines = harmonised.lines;
             let mut current_temp = harmonised.temp_index;
-            let lhs_agg = coerce_operand_to_type(left_aligned, "{i8*, i64}", current_temp, current_lines, true);
+            let lhs_agg = coerce_operand_to_type(left_aligned, "{i8*, i64}", current_temp, current_lines, true, null);
             diagnostics = extend_string_array(diagnostics, lhs_agg.diagnostics);
             current_lines = lhs_agg.lines;
             current_temp = lhs_agg.temp_index;
@@ -625,7 +625,7 @@ fn lower_binary_operation(expression: string, match: OperatorMatch, bindings: Pa
                     string_constants: string_constants
                 };
             }
-            let rhs_agg = coerce_operand_to_type(right_aligned, "{i8*, i64}", current_temp, current_lines, true);
+            let rhs_agg = coerce_operand_to_type(right_aligned, "{i8*, i64}", current_temp, current_lines, true, null);
             diagnostics = extend_string_array(diagnostics, rhs_agg.diagnostics);
             current_lines = rhs_agg.lines;
             current_temp = rhs_agg.temp_index;
@@ -949,7 +949,7 @@ fn lower_comparison_operation(expression: string, match: OperatorMatch, bindings
                     if right_is_pointer { _if109 = true; }
                 }
                 if _if109 {
-                    let coercion = coerce_operand_to_type(right_operand, "i8", alignment_temp, alignment_lines, true);
+                    let coercion = coerce_operand_to_type(right_operand, "i8", alignment_temp, alignment_lines, true, null);
                     diagnostics = extend_string_array(diagnostics, coercion.diagnostics);
                     if coercion.operand == null {
                         return ExpressionResult {
@@ -969,7 +969,7 @@ fn lower_comparison_operation(expression: string, match: OperatorMatch, bindings
                         if left_is_pointer { _elif111 = true; }
                     }
                     if _elif111 {
-                        let coercion = coerce_operand_to_type(left_operand, "i8", alignment_temp, alignment_lines, true);
+                        let coercion = coerce_operand_to_type(left_operand, "i8", alignment_temp, alignment_lines, true, null);
                         diagnostics = extend_string_array(diagnostics, coercion.diagnostics);
                         if coercion.operand == null {
                             return ExpressionResult {
@@ -1067,7 +1067,7 @@ fn lower_logical_and(expression: string, match: OperatorMatch, bindings: Paramet
         };
     }
 
-    let left_bool = coerce_operand_to_type(left_result.operand, "i1", left_result.temp_index, left_result.lines, true);
+    let left_bool = coerce_operand_to_type(left_result.operand, "i1", left_result.temp_index, left_result.lines, true, null);
     diagnostics = extend_string_array(diagnostics, left_bool.diagnostics);
     string_constants = merge_string_constants(string_constants, left_result.string_constants);
     if left_bool.operand == null {
@@ -1116,7 +1116,7 @@ fn lower_logical_and(expression: string, match: OperatorMatch, bindings: Paramet
         };
     }
 
-    let right_bool = coerce_operand_to_type(right_result.operand, "i1", right_result.temp_index, right_result.lines, true);
+    let right_bool = coerce_operand_to_type(right_result.operand, "i1", right_result.temp_index, right_result.lines, true, null);
     diagnostics = extend_string_array(diagnostics, right_bool.diagnostics);
     string_constants = merge_string_constants(string_constants, right_result.string_constants);
     if right_bool.operand == null {
@@ -1198,7 +1198,7 @@ fn lower_logical_or(expression: string, match: OperatorMatch, bindings: Paramete
         };
     }
 
-    let left_bool = coerce_operand_to_type(left_result.operand, "i1", left_result.temp_index, left_result.lines, true);
+    let left_bool = coerce_operand_to_type(left_result.operand, "i1", left_result.temp_index, left_result.lines, true, null);
     diagnostics = extend_string_array(diagnostics, left_bool.diagnostics);
     string_constants = merge_string_constants(string_constants, left_result.string_constants);
     if left_bool.operand == null {
@@ -1250,7 +1250,7 @@ fn lower_logical_or(expression: string, match: OperatorMatch, bindings: Paramete
         };
     }
 
-    let right_bool = coerce_operand_to_type(right_result.operand, "i1", right_result.temp_index, right_result.lines, true);
+    let right_bool = coerce_operand_to_type(right_result.operand, "i1", right_result.temp_index, right_result.lines, true, null);
     diagnostics = extend_string_array(diagnostics, right_bool.diagnostics);
     string_constants = merge_string_constants(string_constants, right_result.string_constants);
     if right_bool.operand == null {

--- a/compiler/src/llvm/expression_lowering/native/core_strings.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_strings.sfn
@@ -120,7 +120,7 @@ fn emit_string_concat(left: LLVMOperand, right: LLVMOperand, temp_index: number,
     // forwards to the legacy NUL-terminated impl until M2.4 ships
     // length-aware bodies. Return type stays `i8*` so downstream
     // legacy-shape consumers don't need updating in this PR.
-    let left_aligned = coerce_operand_to_type(harmonised.left, "{i8*, i64}", harmonised.temp_index, harmonised.lines, true);
+    let left_aligned = coerce_operand_to_type(harmonised.left, "{i8*, i64}", harmonised.temp_index, harmonised.lines, true, null);
     let mut diagnostics: string[] = harmonised.diagnostics;
     let mut _ci0: number = 0;
     loop {
@@ -128,7 +128,7 @@ fn emit_string_concat(left: LLVMOperand, right: LLVMOperand, temp_index: number,
         diagnostics.push(left_aligned.diagnostics[_ci0]);
         _ci0 += 1;
     }
-    let right_aligned = coerce_operand_to_type(harmonised.right, "{i8*, i64}", left_aligned.temp_index, left_aligned.lines, true);
+    let right_aligned = coerce_operand_to_type(harmonised.right, "{i8*, i64}", left_aligned.temp_index, left_aligned.lines, true, null);
     let mut _ci1: number = 0;
     loop {
         if _ci1 >= right_aligned.diagnostics.length { break; }

--- a/compiler/src/llvm/expression_lowering/native/runtime_call.sfn
+++ b/compiler/src/llvm/expression_lowering/native/runtime_call.sfn
@@ -167,7 +167,7 @@ fn emit_runtime_call(target: string, operands: LLVMOperand[], overrides: Runtime
             target_type = parameter_types[index];
         }
         if target_type.length == 0 { coerced_operands.push(operand); } else {
-            let coerced = coerce_operand_to_type(operand, target_type, result_temp, result_lines, true);
+            let coerced = coerce_operand_to_type(operand, target_type, result_temp, result_lines, true, null);
             result_diagnostics = extend_string_array(result_diagnostics, coerced.diagnostics);
             result_lines = coerced.lines;
             result_temp = coerced.temp_index;

--- a/compiler/src/llvm/expression_lowering/native/statement.sfn
+++ b/compiler/src/llvm/expression_lowering/native/statement.sfn
@@ -227,7 +227,7 @@ fn lower_expression_statement(function_name: string, instruction: NativeInstruct
                     + trimmed_assign_target
                     + "`");
             } else {
-                let coerced = coerce_operand_to_type(lowered.operand, binding.llvm_type, current_temp, current_lines, true);
+                let coerced = coerce_operand_to_type(lowered.operand, binding.llvm_type, current_temp, current_lines, true, null);
                 let mut _ci13: number = 0;
                 loop {
                     if _ci13 >= coerced.diagnostics.length { break; }
@@ -593,7 +593,7 @@ fn lower_return_instruction(function: NativeFunction, instruction: NativeInstruc
     if debug_lowering {
         print.err("emit-llvm: lower_return pre_coerce_call fn=" + fn_name);
     }
-    let coerced = coerce_operand_to_type(operand, safe_llvm_return, current_temp, current_lines, true);
+    let coerced = coerce_operand_to_type(operand, safe_llvm_return, current_temp, current_lines, true, null);
     if debug_lowering {
         print.err("emit-llvm: lower_return post_coerce fn=" + fn_name);
     }

--- a/compiler/src/llvm/expression_lowering/native/statement_assignment.sfn
+++ b/compiler/src/llvm/expression_lowering/native/statement_assignment.sfn
@@ -169,7 +169,7 @@ fn lower_lvalue_assignment_stmt(assign_target: string, assign_value: string, ass
         // Pass `allow_widen=true` to preserve today's silent int↔float
         // coercion behaviour. The reapply of #296 in Slice E.3 (#490)
         // generalises the rejection here too.
-        let coerced = coerce_operand_to_type(lowered_value.operand, element_type, current_temp, current_lines, true);
+        let coerced = coerce_operand_to_type(lowered_value.operand, element_type, current_temp, current_lines, true, null);
         let mut _ci2: number = 0;
         loop {
             if _ci2 >= coerced.diagnostics.length { break; }
@@ -326,7 +326,7 @@ fn lower_lvalue_assignment_stmt(assign_target: string, assign_value: string, ass
                                     // (`arr[index]` with `index: number` is
                                     // common). Exempt from the ABI primitive
                                     // kind diagnostic.
-                                    let coerced_index = coerce_operand_to_type(index_result.operand, "i64", current_temp, current_lines, true);
+                                    let coerced_index = coerce_operand_to_type(index_result.operand, "i64", current_temp, current_lines, true, null);
                                     let mut _sci2: number = 0;
                                     loop {
                                         if _sci2 >= coerced_index.diagnostics.length {
@@ -457,7 +457,7 @@ fn lower_lvalue_assignment_stmt(assign_target: string, assign_value: string, ass
                         // migration that flips one struct field's type from
                         // `: number` to `: int` while its writers still
                         // produce doubles surfaces here loudly.
-                        let coerced = coerce_operand_to_type(lowered.operand, field_info.llvm_type, current_temp, current_lines, false);
+                        let coerced = coerce_operand_to_type(lowered.operand, field_info.llvm_type, current_temp, current_lines, false, null);
                         let mut _ci5: number = 0;
                         loop {
                             if _ci5 >= coerced.diagnostics.length { break; }
@@ -602,7 +602,7 @@ fn lower_lvalue_assignment_stmt(assign_target: string, assign_value: string, ass
                         // `allow_widen=true` to preserve today's behaviour;
                         // Slice E.3 (#490) tightens this once the migration
                         // completes.
-                        let coerced = coerce_operand_to_type(lowered.operand, element_type, current_temp, current_lines, true);
+                        let coerced = coerce_operand_to_type(lowered.operand, element_type, current_temp, current_lines, true, null);
                         let mut _ci9: number = 0;
                         loop {
                             if _ci9 >= coerced.diagnostics.length { break; }
@@ -616,7 +616,7 @@ fn lower_lvalue_assignment_stmt(assign_target: string, assign_value: string, ass
                             // Slice E.1.5 (#528): array index coerce, exempt
                             // (see comment at the subscripted-lvalue site
                             // above).
-                            let coerced_index = coerce_operand_to_type(index_result.operand, "i64", current_temp, current_lines, true);
+                            let coerced_index = coerce_operand_to_type(index_result.operand, "i64", current_temp, current_lines, true, null);
                             let mut _ci10: number = 0;
                             loop {
                                 if _ci10 >= coerced_index.diagnostics.length {

--- a/compiler/src/llvm/lowering/instructions_for_range.sfn
+++ b/compiler/src/llvm/lowering/instructions_for_range.sfn
@@ -129,7 +129,7 @@ fn lower_for_range(function: NativeFunction, structure: LoopStructure, raw_targe
         };
     }
 
-    let start_coerced = coerce_operand_to_type(start_result.operand, "double", current_temp, current_lines, true);
+    let start_coerced = coerce_operand_to_type(start_result.operand, "double", current_temp, current_lines, true, null);
     let mut _ci12: number = 0;
     loop {
         if _ci12 >= start_coerced.diagnostics.length { break; }
@@ -161,7 +161,7 @@ fn lower_for_range(function: NativeFunction, structure: LoopStructure, raw_targe
     }
     let start_operand = start_coerced.operand;
 
-    let end_coerced = coerce_operand_to_type(end_result.operand, "double", current_temp, current_lines, true);
+    let end_coerced = coerce_operand_to_type(end_result.operand, "double", current_temp, current_lines, true, null);
     let mut _ci13: number = 0;
     loop {
         if _ci13 >= end_coerced.diagnostics.length { break; }
@@ -231,7 +231,7 @@ fn lower_for_range(function: NativeFunction, structure: LoopStructure, raw_targe
             };
         }
 
-        let stride_coerced = coerce_operand_to_type(stride_result.operand, "double", current_temp, current_lines, true);
+        let stride_coerced = coerce_operand_to_type(stride_result.operand, "double", current_temp, current_lines, true, null);
         let mut _ci15: number = 0;
         loop {
             if _ci15 >= stride_coerced.diagnostics.length { break; }

--- a/compiler/src/llvm/lowering/instructions_let.sfn
+++ b/compiler/src/llvm/lowering/instructions_let.sfn
@@ -394,7 +394,7 @@ fn lower_let_instruction(function: NativeFunction, instruction: NativeInstructio
             }
         } else {
             // Types differ — coerce and use the returned struct.
-            let coerced = coerce_operand_to_type(operand, llvm_type, current_temp, current_lines, true);
+            let coerced = coerce_operand_to_type(operand, llvm_type, current_temp, current_lines, true, null);
             let mut _ci20: number = 0;
             loop {
                 if _ci20 >= coerced.diagnostics.length { break; }

--- a/compiler/src/llvm/lowering/instructions_try.sfn
+++ b/compiler/src/llvm/lowering/instructions_try.sfn
@@ -153,7 +153,7 @@ fn lower_throw_instruction(function_name: string, instruction: NativeInstruction
         };
     }
 
-    let coerced = coerce_operand_to_type(lowered_expr.operand, "i8*", current_temp, current_lines, true);
+    let coerced = coerce_operand_to_type(lowered_expr.operand, "i8*", current_temp, current_lines, true, null);
     let mut _ci1: number = 0;
     loop {
         if _ci1 >= coerced.diagnostics.length { break; }

--- a/compiler/tests/integration/numeric_abi_mismatch_test.sfn
+++ b/compiler/tests/integration/numeric_abi_mismatch_test.sfn
@@ -51,7 +51,7 @@ fn _make_operand(llvm_type: string, value: string) -> LLVMOperand {
 test "coerce_operand_to_type: refuses double → i64 when widening is disallowed" ![io] {
     let operand = _make_operand("double", "%t0");
     let mut lines: string[] = [];
-    let result = coerce_operand_to_type(operand, "i64", 0, lines, false);
+    let result = coerce_operand_to_type(operand, "i64", 0, lines, false, null);
     assert result.operand == null;
     // The diagnostic carries the `[fatal]` sentinel so the emit-level
     // entrypoints fail the build instead of writing partial IR.
@@ -99,7 +99,7 @@ test "coerce_operand_to_type: keeps i64 → double silent in this slice" ![io] {
     // tightens the check to symmetric once the migration completes.
     let operand = _make_operand("i64", "%t1");
     let mut lines: string[] = [];
-    let result = coerce_operand_to_type(operand, "double", 0, lines, false);
+    let result = coerce_operand_to_type(operand, "double", 0, lines, false, null);
     assert result.operand != null;
 }
 
@@ -109,7 +109,7 @@ test "coerce_operand_to_type: keeps i64 → double silent in this slice" ![io] {
 test "coerce_operand_to_type: silently widens i64 → double when widening is allowed" ![io] {
     let operand = _make_operand("i64", "%t2");
     let mut lines: string[] = [];
-    let result = coerce_operand_to_type(operand, "double", 0, lines, true);
+    let result = coerce_operand_to_type(operand, "double", 0, lines, true, null);
     // Existing behaviour (sitofp) preserved for arithmetic harmonisation
     // and the explicit `arr.push(...)` value-shape adjust.
     assert result.operand != null;
@@ -118,7 +118,7 @@ test "coerce_operand_to_type: silently widens i64 → double when widening is al
 test "coerce_operand_to_type: silently coerces double → i64 when widening is allowed" ![io] {
     let operand = _make_operand("double", "%t3");
     let mut lines: string[] = [];
-    let result = coerce_operand_to_type(operand, "i64", 0, lines, true);
+    let result = coerce_operand_to_type(operand, "i64", 0, lines, true, null);
     assert result.operand != null;
 }
 
@@ -157,7 +157,7 @@ test "harmonise_operands: recovers temp_index from existing emitted lines" {
 test "coerce_operand_to_type: same-type passthrough is a no-op in strict mode" ![io] {
     let operand = _make_operand("i64", "%t4");
     let mut lines: string[] = [];
-    let result = coerce_operand_to_type(operand, "i64", 0, lines, false);
+    let result = coerce_operand_to_type(operand, "i64", 0, lines, false, null);
     assert result.operand != null;
     assert result.diagnostics.length == 0;
 }
@@ -171,6 +171,6 @@ test "coerce_operand_to_type: i1 → double bypasses the strict diagnostic" ![io
     // to keep this path silent until Slice E.3 (#490) tightens it.
     let operand = _make_operand("i1", "%t5");
     let mut lines: string[] = [];
-    let result = coerce_operand_to_type(operand, "double", 0, lines, false);
+    let result = coerce_operand_to_type(operand, "double", 0, lines, false, null);
     assert result.operand != null;
 }

--- a/compiler/tests/integration/numeric_struct_literal_diagnostic_test.sfn
+++ b/compiler/tests/integration/numeric_struct_literal_diagnostic_test.sfn
@@ -1,0 +1,94 @@
+// Slice E.2 follow-up (#540): regression coverage for the location-aware
+// ABI primitive mismatch diagnostic threaded through
+// `coerce_operand_to_type`, `lower_struct_literal`, and `lower_enum_literal`.
+//
+// The plumbing exists so that — once `lower_expression` learns to forward
+// the enclosing source span (deferred per the issue's `Out:` section) — the
+// 938 bare diagnostics observed during the #529 attempt automatically gain
+// `line:col` enrichment. These tests pin down the chokepoint behaviour now:
+// when a caller threads a span, the diagnostic carries `start:col-end:col`;
+// when the span is `null`, the existing bare format is preserved.
+import { coerce_operand_to_type } from "../../src/llvm/expression_lowering/native/core_operands";
+import { LLVMOperand } from "../../src/llvm/types";
+import { NativeSourceSpan } from "../../src/native_ir";
+
+fn _operand(llvm_type: string, value: string) -> LLVMOperand {
+    return LLVMOperand { llvm_type: llvm_type, value: value };
+}
+
+fn _span(line: int, col: int) -> NativeSourceSpan {
+    return NativeSourceSpan {
+        start_line: line,
+        start_column: col,
+        end_line: line,
+        end_column: col + 1
+    };
+}
+
+fn _contains(text: string, needle: string) -> boolean {
+    if needle.length == 0 { return true; }
+    if needle.length > text.length { return false; }
+    let mut i: number = 0;
+    let limit = text.length - needle.length;
+    loop {
+        if i > limit { break; }
+        if substring(text, i, i + needle.length) == needle { return true; }
+        i += 1;
+    }
+    return false;
+}
+
+// -------------------------------------------------------------------
+// `coerce_operand_to_type` span enrichment
+// -------------------------------------------------------------------
+test "coerce_operand_to_type: bare diagnostic when span is null" ![io] {
+    let operand = _operand("double", "%t0");
+    let mut lines: string[] = [];
+    let result = coerce_operand_to_type(operand, "i64", 0, lines, false, null);
+    assert result.operand == null;
+    assert result.diagnostics.length >= 1;
+    let mut saw_bare: boolean = false;
+    let mut idx: number = 0;
+    loop {
+        if idx >= result.diagnostics.length { break; }
+        let diag = result.diagnostics[idx];
+        if _contains(diag, "ABI primitive mismatch") {
+            // The bare form does NOT include the " at " suffix.
+            if !_contains(diag, " at ") { saw_bare = true; }
+        }
+        idx += 1;
+    }
+    assert saw_bare;
+}
+
+test "coerce_operand_to_type: span-aware diagnostic carries line:col" ![io] {
+    let operand = _operand("double", "%t1");
+    let mut lines: string[] = [];
+    let span = _span(42, 17);
+    let result = coerce_operand_to_type(operand, "i64", 0, lines, false, span);
+    assert result.operand == null;
+    let mut saw_location: boolean = false;
+    let mut idx: number = 0;
+    loop {
+        if idx >= result.diagnostics.length { break; }
+        let diag = result.diagnostics[idx];
+        if _contains(diag, "ABI primitive mismatch") {
+            // Expect "...at 42:17-42:18" with the threaded span.
+            if _contains(diag, " at 42:17") { saw_location = true; }
+        }
+        idx += 1;
+    }
+    assert saw_location;
+}
+
+test "coerce_operand_to_type: span ignored when widening is allowed" ![io] {
+    // The span only enriches the strict-mode refusal. Permissive coercion
+    // succeeds and returns no diagnostic regardless of whether a span was
+    // threaded.
+    let operand = _operand("double", "%t2");
+    let mut lines: string[] = [];
+    let span = _span(7, 3);
+    let result = coerce_operand_to_type(operand, "i64", 0, lines, true, span);
+    assert result.operand != null;
+    assert result.diagnostics.length == 0;
+}


### PR DESCRIPTION
## Summary

- `coerce_operand_to_type`, `lower_struct_literal`, `lower_enum_literal` now accept an optional `NativeSourceSpan?`. When threaded, the ABI primitive mismatch diagnostic carries `line:col-line:col` instead of firing bare.
- Existing callers pass `null` — `lower_expression`-level plumbing is out of scope per the issue's `Out:` section.
- Adds `numeric_struct_literal_diagnostic_test.sfn` pinning the chokepoint: `null` span → bare format; threaded span → `" at <line>:<col>-…"` enrichment.

Closes #540

## Acceptance Criteria

- [x] `lower_struct_literal`, `lower_enum_literal`, and `coerce_operand_to_type` all accept an optional `NativeSourceSpan?` parameter.
- [x] Every caller of those functions passes a span when one is in scope, `null` otherwise. (Only the struct/enum literal paths inside `core_literals_lowering.sfn` had a span available — they forward the param into `coerce_operand_to_type`. All other call sites pass `null`.)
- [x] `make compile` self-hosts on alpha.13 — verified.
- [x] `make test` — 88/94 unit tests pass on this branch; the 6 failures (`abi_version_test`, `atomic_*_test`, `runtime_call_dispatch_test`) are **pre-existing macOS link failures** that also fail with the unmodified seed compiler (`build/seed/bin/sailfin test compiler/tests/unit/abi_version_test.sfn` reproduces the same `link failed (clang exit=1)`). Not regressions from this PR.
- [x] `sfn fmt --check compiler/src/ runtime/` clean (verified separately because `sfn fmt --write` has a pre-existing bug that corrupts `core_operands.sfn` — formatting was applied via Edit, then `--check` validated).
- [x] New integration test asserts the location-aware diagnostic via `coerce_operand_to_type` (the chokepoint the struct-literal path lowers through).
- [ ] Negative spot-check with E.2-hot (#530) mid-flight — deferred until #530 lands.

## Verification

\`\`\`bash
( ulimit -v 8388608 2>/dev/null || true ) && make compile     # ✓ self-hosts
( ulimit -v 8388608 2>/dev/null || true ) && make test        # ✓ deltas vs main = 0 (the 6 failures repro on the unmodified seed)
build/native/sailfin fmt --check compiler/src/ runtime/        # ✓ exit 0
\`\`\`

## Notes for reviewers

- The verification spot-check in the issue body (`build/native/sailfin check /tmp/badstruct.sfn | grep "badstruct.sfn:[0-9]+:[0-9]+"`) requires file-path plumbing **and** span-threading through `lower_expression`. Both are out of scope here (the issue explicitly defers `lower_expression` plumbing). This PR delivers the plumbing primitives so the follow-up that threads spans through `lower_expression` becomes trivial.
- `format_coerce_span_location` is duplicated as `_format_literal_span` in `core_literals_lowering.sfn` to avoid a cyclic import through `core_ownership.sfn` (which is where the existing `format_span_location` lives). Both are tiny one-liners; collapsing them to a single shared helper is a follow-up worth doing once the import graph is cleaned up.
- `sfn fmt --write` corrupts `core_operands.sfn` (truncates 768 → 351 lines, drops imports + opens). This is a pre-existing bug in the installed compiler unrelated to this PR. Worked around by applying edits directly via Edit; `fmt --check` confirms the result is canonical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)