### PR TITLE
fix(lowering): downgrade E.1.5 strict refusal to warning (#550)

### DIFF
--- a/compiler/src/llvm/expression_lowering/native/core_operands.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_operands.sfn
@@ -1838,18 +1838,25 @@ fn coerce_general_fallback(operand: LLVMOperand, operand_type: string, target: s
     return null;
 }
 
-// Slice E.1.5 (#528): `coerce_operand_to_type` is the single chokepoint for
-// numeric ABI shape decisions. `allow_widen` selects the slice's strict scope:
+// Slice E.1.5 (#528, relaxed by #550): `coerce_operand_to_type` is the
+// single chokepoint for numeric ABI shape decisions. `allow_widen`
+// selects the kind-check's strictness:
 //
-//   • `allow_widen = false` — the strict mode used by ABI-boundary callsites:
-//     function call arguments (`core_call_emission.sfn`), struct-field
-//     assignment (`statement_assignment.sfn`), and struct-literal field
-//     initialization (`core_literals_lowering.sfn`). When the operand and
-//     target disagree on `numeric_type_kind` along the asymmetric direction
-//     (operand=`float`, target=`int`), the coercion refuses with a `[fatal]`
-//     diagnostic instead of silently emitting `fptosi`.
+//   • `allow_widen = false` — the boundary mode used by call args
+//     (`core_call_emission.sfn`), struct-field assignment
+//     (`statement_assignment.sfn`), and struct-literal field
+//     initialization (`core_literals_lowering.sfn`). When operand and
+//     target disagree on `numeric_type_kind` along the asymmetric
+//     direction (operand=`float`, target=`int`), the coercion logs a
+//     `[warning]` diagnostic and FALLS THROUGH to silent `round +
+//     fptosi` widening via `coerce_numeric_primitive`. The fatal
+//     refusal landed in #528 was downgraded in #550 because the
+//     cluster-internal boundary is effectively all of `compiler/src/
+//     llvm/` (~100 files) and cannot be flipped atomically during the
+//     Slice E.2 source migration — see `docs/runtime_architecture.md`
+//     §3.7 line 1404 and the #530 cluster-flip post-mortem.
 //
-//   • `allow_widen = true` — the permissive mode used by every other
+//   • `allow_widen = true` — permissive mode used by every other
 //     callsite, including arithmetic harmonisation (`harmonise_operands`),
 //     the `arr.push(...)` value-shape adjust, pointer-deref stores, lvalue
 //     assignments to locals, array-element stores, array-index → i64
@@ -1859,9 +1866,11 @@ fn coerce_general_fallback(operand: LLVMOperand, operand_type: string, target: s
 //     #489a–d) flips the call-arg site to permissive mode for the small set
 //     of legitimate i64 ↔ f64 widens during the partial migration.
 //
-// Slice E.3 (#490) re-applies #296 — once every `: number` site in the
-// compiler source has migrated to `: int`/`: float`, the symmetric rejection
-// generalises to the permissive sites above as well.
+// Slice E.3 (#490) re-applies #296 symmetrically — once every `: number`
+// site in the compiler source has migrated to `: int`/`: float`, the
+// rejection re-promotes to `[fatal]` and extends to the permissive
+// sites above. The `numeric_type_kind` helper stays in place as the
+// chokepoint for that re-enablement.
 fn coerce_operand_to_type(operand: LLVMOperand, target_type: string, temp_index: number, lines: string[], allow_widen: boolean, span: NativeSourceSpan?) -> CoercionResult ![io] {
     let debug_coerce = trace_lowering();
     if debug_coerce {
@@ -1890,18 +1899,32 @@ fn coerce_operand_to_type(operand: LLVMOperand, target_type: string, temp_index:
         };
     }
 
-    // ABI primitive kind check: refuse silent float → int coercion at
+    // ABI primitive kind check: observe silent float → int coercion at
     // boundaries that don't opt in to widening. The asymmetric rule
     // (operand kind=float, target kind=int) catches the Slice E.2 partial
     // migration mismatch — a callee parameter flipped from `: number`
     // (double) to `: int` (i64) while a caller still has a `double` in
-    // hand. The reverse direction (operand=int, target=float) keeps
-    // silently widening today: every existing `arr.length`-into-`:number`
-    // callsite relies on it, and the symmetric rejection rides on
-    // Slice E.3 (#490) once every `: number` site in the compiler source
-    // has migrated. The `[fatal]` sentinel propagates to the emit-level
-    // entrypoints which scan diagnostics for it and exit non-zero rather
-    // than writing a partial IR file.
+    // hand.
+    //
+    // #550 (relief valve): the diagnostic is emitted as `[warning]`
+    // (NOT `[fatal]`) and control falls through to the normal
+    // `coerce_numeric_primitive` path below, which emits `round +
+    // fptosi` for `double → i64`. `has_fatal_lowering_diagnostic`
+    // (lowering_core.sfn:294) scans for `[fatal]` only, so emission
+    // continues. The fatal refusal landed in #528 turned out to be
+    // intractable during the Slice E.2 source migration — the cluster
+    // boundary spans the entire `compiler/src/llvm/` tree (~100 files),
+    // not the named cluster of ~30 the original plan assumed, so a
+    // staged flip cannot avoid mixed-kind boundaries mid-migration.
+    // See `docs/runtime_architecture.md:1404` for the original
+    // sequencing constraint (strict refusal rides on E.3) that #528
+    // violated. #490 (Slice E.3) re-promotes the diagnostic to
+    // `[fatal]` symmetrically once E.2 completes.
+    //
+    // The reverse direction (operand=int, target=float) keeps silently
+    // widening today: every existing `arr.length`-into-`:number`
+    // callsite relies on it; the symmetric rejection also rides on
+    // #490.
     if !allow_widen {
         let from_kind = numeric_type_kind(operand_type);
         let to_kind = numeric_type_kind(target);
@@ -1910,11 +1933,10 @@ fn coerce_operand_to_type(operand: LLVMOperand, target_type: string, temp_index:
             if to_kind == "int" { _kind_check = true; }
         }
         if _kind_check {
-            // Slice E.2 follow-up (#540): when the caller threads a
-            // `NativeSourceSpan`, attach it to the diagnostic so the
-            // failing site is locatable in the source. Pre-#540 callers
-            // pass `null` and continue producing the bare message.
-            let mut abi_diag = "llvm lowering [fatal]: ABI primitive mismatch: callee expects `"
+            // #540 threads a `NativeSourceSpan` so the failing site is
+            // locatable in source; pre-#540 callers pass `null` and
+            // continue producing the bare message.
+            let mut abi_diag = "llvm lowering [warning]: ABI primitive mismatch: callee expects `"
                 + target
                 + "` ("
                 + to_kind
@@ -1928,40 +1950,54 @@ fn coerce_operand_to_type(operand: LLVMOperand, target_type: string, temp_index:
             }
             print.err(abi_diag);
             diagnostics.push(abi_diag);
-            return CoercionResult {
-                lines: current_lines,
-                temp_index: recover_temp_from_lines(current_lines, temp_index),
-                operand: null,
-                diagnostics: diagnostics
-            };
+            // Fall through to coerce_numeric_primitive below — see #550.
         }
     }
 
     let numeric = coerce_numeric_primitive(operand, operand_type, target, temp_index, current_lines);
     if numeric != null {
+        // Merge so any kind-check warning pushed above survives (#550).
+        let mut _nd_i: number = 0;
+        loop {
+            if _nd_i >= numeric.diagnostics.length { break; }
+            diagnostics.push(numeric.diagnostics[_nd_i]);
+            _nd_i += 1;
+        }
         return CoercionResult {
             lines: numeric.lines,
             temp_index: recover_temp_from_lines(numeric.lines, numeric.temp_index),
             operand: numeric.operand,
-            diagnostics: numeric.diagnostics
+            diagnostics: diagnostics
         };
     }
     let pointer = coerce_pointer_or_struct(operand, operand_type, target, temp_index, current_lines);
     if pointer != null {
+        let mut _pd_i: number = 0;
+        loop {
+            if _pd_i >= pointer.diagnostics.length { break; }
+            diagnostics.push(pointer.diagnostics[_pd_i]);
+            _pd_i += 1;
+        }
         return CoercionResult {
             lines: pointer.lines,
             temp_index: recover_temp_from_lines(pointer.lines, pointer.temp_index),
             operand: pointer.operand,
-            diagnostics: pointer.diagnostics
+            diagnostics: diagnostics
         };
     }
     let general = coerce_general_fallback(operand, operand_type, target, temp_index, current_lines);
     if general != null {
+        let mut _gd_i: number = 0;
+        loop {
+            if _gd_i >= general.diagnostics.length { break; }
+            diagnostics.push(general.diagnostics[_gd_i]);
+            _gd_i += 1;
+        }
         return CoercionResult {
             lines: general.lines,
             temp_index: recover_temp_from_lines(general.lines, general.temp_index),
             operand: general.operand,
-            diagnostics: general.diagnostics
+            diagnostics: diagnostics
         };
     }
     diagnostics.push("llvm lowering: unable to coerce operand of type `"

--- a/compiler/tests/integration/numeric_abi_mismatch_test.sfn
+++ b/compiler/tests/integration/numeric_abi_mismatch_test.sfn
@@ -1,14 +1,16 @@
-// Slice E.1.5 (#528): regression coverage for the ABI primitive kind
-// diagnostic. Exercises both `numeric_type_kind` (the new helper in
-// `type_mapping.sfn`) and `coerce_operand_to_type`'s strict-mode rejection
-// of int↔float coercion at call boundaries.
+// Slice E.1.5 (#528, relaxed by #550): regression coverage for the ABI
+// primitive kind diagnostic. Exercises both `numeric_type_kind` (the
+// helper in `type_mapping.sfn`) and `coerce_operand_to_type`'s
+// boundary-mode behaviour on int↔float coercion.
 //
-// Today's compiler tree is internally consistent — no `: number` consumer
-// receives an `: int` value — so the diagnostic fires only on a
-// hand-edited mismatch. These tests pin down the helper's classification
-// and the coerce path's behaviour so a future Slice E.2 (#489a–d)
-// migration that leaves the tree inconsistent fails loudly instead of
-// producing corrupt LLVM IR with split ABI shapes.
+// During the Slice E.2 source migration window the boundary-mode
+// kind check emits a `[warning]` diagnostic and falls through to silent
+// `round + fptosi` widening. The fatal refusal landed in #528 was
+// downgraded by #550 — the cluster-internal boundary turned out to span
+// all of `compiler/src/llvm/` and could not be flipped atomically, so
+// the diagnostic provides visibility without aborting emission. Slice
+// E.3 (#490) re-promotes the diagnostic to `[fatal]` symmetrically once
+// every `: number` site has migrated.
 import { coerce_operand_to_type, harmonise_operands } from "../../src/llvm/expression_lowering/native/core_operands";
 import { numeric_type_kind } from "../../src/llvm/type_mapping";
 import { LLVMOperand } from "../../src/llvm/types";
@@ -48,22 +50,36 @@ fn _make_operand(llvm_type: string, value: string) -> LLVMOperand {
     return LLVMOperand { llvm_type: llvm_type, value: value };
 }
 
-test "coerce_operand_to_type: refuses double → i64 when widening is disallowed" ![io] {
+test "coerce_operand_to_type: warns + silently widens double → i64 in boundary mode" ![io] {
     let operand = _make_operand("double", "%t0");
     let mut lines: string[] = [];
     let result = coerce_operand_to_type(operand, "i64", 0, lines, false, null);
-    assert result.operand == null;
-    // The diagnostic carries the `[fatal]` sentinel so the emit-level
-    // entrypoints fail the build instead of writing partial IR.
+    // #550: the kind-check now logs a warning and falls through to
+    // `round + fptosi`. Coercion succeeds with a non-null operand and
+    // the i64 LLVM type. The fatal refusal returns in #490 once Slice
+    // E.2 completes the source migration.
+    assert result.operand != null;
+    assert result.operand.llvm_type == "i64";
+    // The diagnostic carries the `[warning]` tag — NOT `[fatal]` —
+    // so `has_fatal_lowering_diagnostic` (lowering_core.sfn:294) does
+    // not trip and emission continues.
+    let mut found_warning = false;
     let mut found_fatal = false;
     let mut i: number = 0;
     loop {
         if i >= result.diagnostics.length { break; }
         let diag = result.diagnostics[i];
+        let mut _has_warning = false;
         let mut _has_fatal = false;
         let mut _has_double = false;
         let mut _has_i64 = false;
         let mut j: number = 0;
+        loop {
+            if j + 9 > diag.length { break; }
+            if substring(diag, j, j + 9) == "[warning]" { _has_warning = true; }
+            j += 1;
+        }
+        j = 0;
         loop {
             if j + 7 > diag.length { break; }
             if substring(diag, j, j + 7) == "[fatal]" { _has_fatal = true; }
@@ -81,14 +97,16 @@ test "coerce_operand_to_type: refuses double → i64 when widening is disallowed
             if substring(diag, j, j + 3) == "i64" { _has_i64 = true; }
             j += 1;
         }
-        if _has_fatal {
+        if _has_warning {
             if _has_double {
-                if _has_i64 { found_fatal = true; }
+                if _has_i64 { found_warning = true; }
             }
         }
+        if _has_fatal { found_fatal = true; }
         i += 1;
     }
-    assert found_fatal;
+    assert found_warning;
+    assert ! found_fatal;
 }
 
 test "coerce_operand_to_type: keeps i64 → double silent in this slice" ![io] {

--- a/compiler/tests/integration/numeric_struct_literal_diagnostic_test.sfn
+++ b/compiler/tests/integration/numeric_struct_literal_diagnostic_test.sfn
@@ -89,9 +89,9 @@ test "coerce_operand_to_type: span-aware diagnostic carries line:col" ![io] {
 }
 
 test "coerce_operand_to_type: span ignored when widening is allowed" ![io] {
-    // The span only enriches the strict-mode refusal. Permissive coercion
-    // succeeds and returns no diagnostic regardless of whether a span was
-    // threaded.
+    // The span only enriches the boundary-mode warning (#550). Permissive
+    // coercion bypasses the kind check entirely, so it succeeds and
+    // returns no diagnostic regardless of whether a span was threaded.
     let operand = _operand("double", "%t2");
     let mut lines: string[] = [];
     let span = _span(7, 3);

--- a/compiler/tests/integration/numeric_struct_literal_diagnostic_test.sfn
+++ b/compiler/tests/integration/numeric_struct_literal_diagnostic_test.sfn
@@ -1,13 +1,16 @@
-// Slice E.2 follow-up (#540): regression coverage for the location-aware
-// ABI primitive mismatch diagnostic threaded through
+// Slice E.2 follow-up (#540, relaxed by #550): regression coverage for the
+// location-aware ABI primitive mismatch diagnostic threaded through
 // `coerce_operand_to_type`, `lower_struct_literal`, and `lower_enum_literal`.
 //
 // The plumbing exists so that — once `lower_expression` learns to forward
-// the enclosing source span (deferred per the issue's `Out:` section) — the
+// the enclosing source span (deferred per #540's `Out:` section) — the
 // 938 bare diagnostics observed during the #529 attempt automatically gain
-// `line:col` enrichment. These tests pin down the chokepoint behaviour now:
-// when a caller threads a span, the diagnostic carries `start:col-end:col`;
-// when the span is `null`, the existing bare format is preserved.
+// `line:col` enrichment. These tests pin down the chokepoint behaviour: when
+// a caller threads a span, the diagnostic carries `start:col-end:col`; when
+// the span is `null`, the existing bare format is preserved. #550 downgraded
+// the diagnostic severity from `[fatal]` to `[warning]` and routed the
+// kind-check through `coerce_numeric_primitive`, so coercion now succeeds
+// (operand != null) while the diagnostic still carries the span enrichment.
 import { coerce_operand_to_type } from "../../src/llvm/expression_lowering/native/core_operands";
 import { LLVMOperand } from "../../src/llvm/types";
 import { NativeSourceSpan } from "../../src/native_ir";
@@ -45,7 +48,9 @@ test "coerce_operand_to_type: bare diagnostic when span is null" ![io] {
     let operand = _operand("double", "%t0");
     let mut lines: string[] = [];
     let result = coerce_operand_to_type(operand, "i64", 0, lines, false, null);
-    assert result.operand == null;
+    // #550: warning + fall-through to coerce_numeric_primitive — operand is
+    // now non-null; the diagnostic is preserved verbatim for tooling grep.
+    assert result.operand != null;
     assert result.diagnostics.length >= 1;
     let mut saw_bare: boolean = false;
     let mut idx: number = 0;
@@ -66,7 +71,9 @@ test "coerce_operand_to_type: span-aware diagnostic carries line:col" ![io] {
     let mut lines: string[] = [];
     let span = _span(42, 17);
     let result = coerce_operand_to_type(operand, "i64", 0, lines, false, span);
-    assert result.operand == null;
+    // #550: warning + fall-through — operand non-null but span enrichment
+    // still attaches to the diagnostic for #540's location plumbing.
+    assert result.operand != null;
     let mut saw_location: boolean = false;
     let mut idx: number = 0;
     loop {

--- a/docs/runtime_architecture.md
+++ b/docs/runtime_architecture.md
@@ -1550,24 +1550,41 @@ i64 length helper).
        the new `compiler/tests/e2e/test_numeric_int_default.sh`
        and `compiler/tests/unit/numeric_int_default_test.sfn`.
        Closes scalar L1; array L1 closes after E.2.
-    2. **E.1.5 (2026-05-10, #528):** Refuse silent
-       `float → int` coercion at ABI boundaries. Adds
-       `numeric_type_kind` to `compiler/src/llvm/type_mapping.sfn`
-       (returns `"int"` / `"float"` / `"other"`) and extends
-       `coerce_operand_to_type` in
-       `compiler/src/llvm/expression_lowering/native/core_operands.sfn`
-       so call-arg coercion and struct-field writes default to a
-       strict mode that rejects mismatch with a `[fatal]` ABI
-       primitive diagnostic. The rule is asymmetric — only
-       `caller=double, callee=i64` fires today, because the
-       reverse direction (`arr.length` into a `: number` slot)
-       still happens pervasively in the existing tree and is
-       deferred to E.3. The new `@[abi_widen]` parameter
-       attribute is parsed by `parse_single_parameter` and
-       plumbed through `NativeParameter.attributes` as a
-       per-parameter opt-out used by Slice E.2 to bridge the
-       small set of legitimate i64↔f64 widens during the partial
-       migration; #489d audits and removes all uses. Verified by
+    2. **E.1.5 (2026-05-10, #528; relaxed 2026-05-11, #550):**
+       Observe (not refuse) silent `float → int` coercion at ABI
+       boundaries. Adds `numeric_type_kind` to
+       `compiler/src/llvm/type_mapping.sfn` (returns `"int"` /
+       `"float"` / `"other"`) and extends `coerce_operand_to_type`
+       in `compiler/src/llvm/expression_lowering/native/core_operands.sfn`
+       so call-arg coercion and struct-field writes log a
+       `[warning]` ABI primitive diagnostic on mismatch. The
+       rule is asymmetric — only `caller=double, callee=i64`
+       fires today.
+
+       The original #528 design refused the mismatch with a
+       `[fatal]` diagnostic, on the theory that the existing
+       internally-consistent tree wouldn't trigger it and the
+       refusal would catch partial-migration mistakes during
+       E.2. Three #530 pickup attempts proved this assumption
+       wrong: the cluster-internal boundary spans effectively
+       all of `compiler/src/llvm/` (~100 files, not the named
+       cluster of ~30), so a staged flip cannot avoid
+       mixed-kind boundaries mid-migration (302 unique
+       `float → i64` mismatches observed against a 23-file
+       cluster scope on 2026-05-11). #550 downgraded the
+       diagnostic to `[warning]` and routed control through the
+       existing `coerce_numeric_primitive` `round + fptosi`
+       path, preserving visibility without aborting emission.
+       The fatal refusal re-promotes symmetrically in #490 once
+       E.2 completes. See lines 1399–1411 above for the original
+       sequencing constraint that #528 violated.
+
+       The `@[abi_widen]` parameter attribute is parsed by
+       `parse_single_parameter` and plumbed through
+       `NativeParameter.attributes` as a per-parameter opt-out
+       used by Slice E.2 to bridge the small set of legitimate
+       i64↔f64 widens during the partial migration; #489d
+       audits and removes all uses. Verified by
        `compiler/tests/integration/numeric_abi_mismatch_test.sfn`.
     3. **E.2 (next):** Audit-and-migrate every `: number`
        annotation in `compiler/src/*.sfn` and


### PR DESCRIPTION
## Summary

- Downgrade the E.1.5 ABI primitive kind-check from `[fatal]` to `[warning]` and remove the `operand: null` early-return so control falls through to `coerce_numeric_primitive`'s `round + fptosi` path.
- `has_fatal_lowering_diagnostic` only trips on `[fatal]`, so emission continues with full stderr visibility for the partial-migration boundary crossings.
- Unblocks #530 (three failed pickup attempts confirmed the cluster-internal boundary spans ~100 files of `compiler/src/llvm/`, far larger than the named scope #528 was designed against). The fatal refusal re-promotes symmetrically in #490 once Slice E.2 completes.

Closes #550

## Acceptance Criteria

- [x] `coerce_operand_to_type`'s kind-check no longer returns `operand: null` — falls through to `coerce_numeric_primitive`.
- [x] `has_fatal_lowering_diagnostic` (entrypoints.sfn:103) does NOT trip on the kind-mismatch diagnostic.
- [x] `numeric_abi_mismatch_test.sfn` updated to expect warning + successful coercion.
- [x] `make compile` self-hosts on the alpha.14 seed.
- [x] `make test` passes — 94 unit + 23 integration + 56 e2e + 10 capsules.
- [ ] `make check` exits 0 — **running in parallel; will comment when done**.
- [x] `sfn fmt --check` clean on every touched `.sfn` file.
- [x] **Critical regression test:** see Verification below — 0 fatal ABI mismatches against the 78-file `claude/530-…` WIP branch (was 302+ pre-#550); 10 warning ABI mismatches replace them.
- [x] `build/native/sailfin emit examples/basics/hello-world.sfn` byte-identical to baseline (md5 `1982ca5cb18bb4981aca501e7fb8a026`).
- [x] Source comment references `docs/runtime_architecture.md:1404` and #490 for re-enable.
- [x] `docs/runtime_architecture.md` updated.

## Verification

```bash
ulimit -v 8388608

# Baseline (alpha.14 seed self-hosts unchanged tree)
build/native/sailfin emit examples/basics/hello-world.sfn > /tmp/pre.ll
md5sum /tmp/pre.ll
# 1982ca5cb18bb4981aca501e7fb8a026  /tmp/pre.ll

# After applying the rollback
make compile

# Semantic-no-op check on existing tree
build/native/sailfin emit examples/basics/hello-world.sfn > /tmp/post.ll
md5sum /tmp/post.ll
# 1982ca5cb18bb4981aca501e7fb8a026  /tmp/post.ll  ← matches

# Targeted integration tests (both updated, both pass)
build/native/sailfin test compiler/tests/integration/numeric_abi_mismatch_test.sfn
# PASS (all 11 tests passed)
build/native/sailfin test compiler/tests/integration/numeric_struct_literal_diagnostic_test.sfn
# PASS (all 3 tests passed)

# Full suite
make test
# ═══ unit: 94/94 passed ═══  integration: 23/23 ═══  e2e: 56/56 ═══  capsules: 10/10 ═══

# Critical regression test against #530 WIP branch
git worktree add /tmp/rollback-test origin/claude/530-flip-instruction-lowering-cluster-int
cd /tmp/rollback-test
/path/to/build/native/sailfin build -p compiler --work-dir /tmp/iter1-rollback-build
# 0 fatal ABI primitive mismatches  ← unblock confirmed (was 302+ pre-#550)
# 10 warning ABI primitive mismatches  ← visibility preserved
```

## Files Changed

- `compiler/src/llvm/expression_lowering/native/core_operands.sfn` — kind-check downgrade + fall-through plumbing in `coerce_operand_to_type` (the 3 return paths merge outer diagnostics with inner so the warning survives).
- `compiler/tests/integration/numeric_abi_mismatch_test.sfn` — flip assertions from `result.operand == null` + `[fatal]` to `result.operand != null` + `[warning]`.
- `compiler/tests/integration/numeric_struct_literal_diagnostic_test.sfn` — same mechanical flip for the two span-threading tests (this file wasn't in the issue's Files Affected list but tests the same diagnostic path).
- `docs/runtime_architecture.md` — clarify the E.1.5 → #550 relaxation; re-state the E.3 re-enablement plan.

## Notes for review

- The issue's Files Affected listed only `numeric_abi_mismatch_test.sfn`, but `numeric_struct_literal_diagnostic_test.sfn` (added in #540 for span threading) exercises the same diagnostic path and needed the same flip. This is a mechanical extension of the same fix, not a scope expansion.
- The critical regression test against the 78-file `claude/530-…` WIP branch surfaced 9404 unrelated `[fatal] cannot resolve return type` diagnostics. Those are a separate signature-table propagation issue (the WIP branch flips parameter types from `number` to `int` and the typechecker doesn't propagate the return type through some calls). They're out of scope for #550 — #530's eventual PR will need to address them.
- Once this lands, cut alpha.15 (`gh workflow run release.yml -f channel=alpha -f bump=prerelease`) and `/pin-seed v0.5.10-alpha.15`. Then #530 becomes pickable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)