### PR TITLE
refactor(numeric): sync char_code/find_char registry rows to i64 (#571 WIP)

### DIFF
--- a/compiler/src/llvm/runtime_helpers.sfn
+++ b/compiler/src/llvm/runtime_helpers.sfn
@@ -453,7 +453,7 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
         target: "strings_equal", symbol: "strings_equal", return_type: "i1", parameter_types: ["i8*", "i8*"], effects: [], native_signature: "sfn_str_eq"
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "char_code", symbol: "char_code", return_type: "double", parameter_types: ["i8*"], effects: [], native_signature: null
+        target: "char_code", symbol: "char_code", return_type: "i64", parameter_types: ["i8*"], effects: [], native_signature: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
         target: "number_to_string", symbol: "number_to_string", return_type: "i8*", parameter_types: ["double"], effects: [], native_signature: null
@@ -648,7 +648,7 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
     // "monotonic_millis" → sailfin_runtime_monotonic_millis) so it
     // is not duplicated here.
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "find_char", symbol: "find_char", return_type: "double", parameter_types: ["i8*", "i8*", "double"], effects: [], native_signature: null
+        target: "find_char", symbol: "find_char", return_type: "i64", parameter_types: ["i8*", "i8*", "i64"], effects: [], native_signature: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
         target: "string_starts_with", symbol: "string_starts_with", return_type: "i1", parameter_types: ["i8*", "i8*"], effects: [], native_signature: null

--- a/docs/proposals/slice-e3a-semantic-audit.md
+++ b/docs/proposals/slice-e3a-semantic-audit.md
@@ -442,3 +442,23 @@ The tests-bulk issue should add `// alias-coverage:` tags or migrate these files
 | `compiler/tests/unit/variables_test.sfn` | `alias-coverage candidate` | Test source currently exercises legacy number annotations during migration. |
 | `compiler/tests/unit/version_resolution_test.sfn` | `alias-coverage candidate` | Test source currently exercises legacy number annotations during migration. |
 | `compiler/tests/unit/workspace_resolver_test.sfn` | `alias-coverage candidate` | Test source currently exercises legacy number annotations during migration. |
+
+## Appendix: LLVM runtime helper registry coupling
+
+Issue: #571 (E.3a-prep-3b). The `RuntimeHelperDescriptor` rows in `compiler/src/llvm/runtime_helpers.sfn` whose `target == symbol` define the LLVM calling convention every caller emits for that helper — the registry IS the ABI for those entries, because the symbol the linker resolves is the prelude wrapper itself. Whenever the prelude flips `: number` → `: int` for one of these rows, the registry row must flip in lockstep or callers emit `declare double @<name>` against a `define i64 @<name>` and the linker silently accepts the mismatch (runtime gets garbage).
+
+This appendix enumerates the seven prelude-mirror rows (those where `target == symbol`) and their migration disposition for Slice E.3a.
+
+| Line | Row | `target == symbol` | Current `parameter_types` / `return_type` | `native_signature` | Disposition for E.3a |
+| --- | --- | --- | --- | --- | --- |
+| 399 | `substring` | `substring` | `["i8*", "double", "double"] -> "i8*"` | `sfn_str_slice` | **Keep `double`.** The C trampoline `sfn_str_slice` in `runtime/native/src/sailfin_runtime.c:2127` is declared `char *sfn_str_slice(const char *text, double start, double end)`. Because `native_signature` routes callers to `@sfn_str_slice` (not the prelude wrapper), the registry's `parameter_types` describe the C ABI, not the prelude. Flipping these to `i64` would create a *new* declare/define mismatch with the C runtime. `substring(text, int, int)` callers fall through the #550 `coerce_numeric_primitive` path (`round + fptosi`) at each callsite. A future runtime-side change can flip the C signature to `i64` and the registry together; that's tracked separately as a runtime-audit follow-up. |
+| 402 | `substring_unchecked` | `substring_unchecked` | `["i8*", "double", "double"] -> "i8*"` | `sfn_str_slice` | **Keep `double`.** Same rationale as `substring` — both rows resolve to the same C trampoline. |
+| 453 | `strings_equal` | `strings_equal` | `["i8*", "i8*"] -> "i1"` | `sfn_str_eq` | **No flip needed.** Already on pointer/boolean types. The boolean return is `i1` regardless of the numeric reform. |
+| 456 | `char_code` | `char_code` | `["i8*"] -> "double"` | `null` | **Flipped to `i64` (this issue).** No `native_signature` — callers resolve directly to the prelude-defined `@char_code`. The #561 prelude flip changes the wrapper to `-> int`, so the registry's return must flip together to keep declare/define coherent. |
+| 459 | `number_to_string` | `number_to_string` | `["double"] -> "i8*"` | `null` | **Keep `double`.** `number_to_string` is the float-printing helper. `number` (float) remains a real type after E.3a — `number` becomes an alias for `float`, not `int`. The parameter type stays `double` indefinitely. |
+| 651 | `find_char` | `find_char` | `["i8*", "i8*", "double"] -> "double"` | `null` | **Flipped to `i64` (this issue).** Both the start-index parameter and the index return flip together. Same reasoning as `char_code` — no `native_signature`, callers resolve directly to the prelude wrapper. |
+| 654 | `string_starts_with` | `string_starts_with` | `["i8*", "i8*"] -> "i1"` | `null` | **No flip needed.** Already on pointer/boolean types. |
+
+**Sequencing.** This issue (E.3a-prep-3b) lands between #560 (semantic audit) and #561 (prelude flip). After this issue closes, #561 re-picks against `claude/task-561-8E1ga` and the prelude flip lines up declare/define for `char_code` and `find_char` in one cycle.
+
+**Coupling rule for downstream bulk PRs.** Every bulk PR in the E.3a series (#562 / #563 / #564 / #565 / #566) that touches a prelude function appearing in this appendix MUST check whether the corresponding registry row needs a parallel flip. The deeper fix — derive registry signatures from the prelude AST so this coupling can't drift — is filed as a post-1.0 hardening item (see #571 body).


### PR DESCRIPTION
## Status: DRAFT — pickup paused for human input

Issue: #571 (re-labeled `needs-grooming`). Full diagnostic and three options for the human decision are in [the pause comment](https://github.com/SailfinIO/sailfin/issues/571#issuecomment-4446362463). This PR exists to preserve the work-in-progress; **do not merge as-is** — it regresses 5 unit tests on `main`.

## Summary

- Flip 2 prelude-mirror rows in `compiler/src/llvm/runtime_helpers.sfn` from `double` to `i64`:
  - line 456 `char_code` — `return_type: "double"` → `"i64"`
  - line 651 `find_char` — `return_type` and 3rd parameter `"double"` → `"i64"`
- Keep `substring` / `substring_unchecked` (lines 399 / 402) on `double` — verified `sfn_str_slice` in `runtime/native/src/sailfin_runtime.c:2127` is declared `char *sfn_str_slice(const char *, double, double)`; flipping these would create a new C-ABI mismatch.
- Add a registry-coupling appendix to `docs/proposals/slice-e3a-semantic-audit.md` enumerating all 7 prelude-mirror rows with their disposition.

Refs #571
Refs #561

## Acceptance criteria status

- [x] 4 rows at `compiler/src/llvm/runtime_helpers.sfn:399, 402, 456, 651` carry the correct type per the Notes section (`substring`/`substring_unchecked` stay `double` because `sfn_str_slice` C ABI is `double`; `char_code` / `find_char` flip to `i64`).
- [x] `make compile` self-hosts.
- [ ] **`make test` passes** — fails 5 unit tests (including 2 of the 3 listed canaries: `lock_test.sfn`, `runtime_capsule_resolver_test.sfn`). Verified to pass on plain `main` before this PR's edits, so the regression is caused by this PR.
- [x] `sfn fmt --check` clean on `compiler/src/llvm/runtime_helpers.sfn`.
- [x] Registry-coupling appendix landed in `docs/proposals/slice-e3a-semantic-audit.md`.
- [x] `grep -nE 'target: "(char_code|find_char)".*"double"' compiler/src/llvm/runtime_helpers.sfn` → zero output.

## Why `make test` regresses (root cause)

The registry/prelude coupling is **bidirectional**. With this PR on `main` (without #561's prelude flip):

```
define double @char_code(i8*)      <- prelude on main, UNCHANGED (#561 hasn't merged)
declare i64 @char_code(i8*)        <- registry, flipped by this PR
%t = call i64 @char_code(i8* %s)   <- caller emission
%code = sitofp i64 %t to double    <- silent return-value widening (#550 reverse path)
```

LLVM accepts the size-matched declare/define mismatch silently; the call returns the IEEE bit-pattern of a `double` (e.g. `0x4050800000000000` for `65.0`) which `sitofp` then converts as a positive integer to ~`4.63e18` — `find_char(...) == -1` always evaluates false, walking past line ends, asserting in lock / toml / version parsing tests.

This is the **mirror image** of the failure mode that paused #561 (where the prelude was `i64` and the registry was still `double`). Both directions break the same way.

## Verification

```bash
ulimit -v 8388608
make rebuild   # self-hosts cleanly with expected #550 warning chorus
make test      # 5 unit FAILs: lock_test, manifest_workspace_test,
               # runtime_capsule_resolver_test, toml_dependencies_test,
               # version_resolution_test
ulimit -v 8388608 && timeout 30 build/seed/bin/sailfin fmt --check \
  compiler/src/llvm/runtime_helpers.sfn   # clean
grep -nE 'target: "(char_code|find_char)".*"double"' \
  compiler/src/llvm/runtime_helpers.sfn   # zero output
```

## Decision needed

See the pause comment on #571 for three options:
- **A.** Land #571 + #561 together (stacked PR or merge-queue group).
- **B.** Reverse sequencing (#561 first) — same intermediate-state problem.
- **C.** Expand #571's `In:` to also flip `char_code` / `find_char` prelude signatures — single coherent landing point.

## Files Changed

- `compiler/src/llvm/runtime_helpers.sfn` — 2 row edits (lines 456, 651).
- `docs/proposals/slice-e3a-semantic-audit.md` — registry-coupling appendix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016DPjGkWG8cfRVmRveBFQQN)_