### PR TITLE
refactor(numeric): flip make_native_*_layout chain off `: number` (#580)

### DIFF
--- a/compiler/src/llvm/lowering/lowering_native_helpers.sfn
+++ b/compiler/src/llvm/lowering/lowering_native_helpers.sfn
@@ -87,7 +87,7 @@ fn make_native_import(module_path: string) -> NativeImport {
     };
 }
 
-fn make_native_struct_layout(sz: number, al: number, flds: NativeStructLayoutField[]) -> NativeStructLayout {
+fn make_native_struct_layout(sz: int, al: int, flds: NativeStructLayoutField[]) -> NativeStructLayout {
     return NativeStructLayout { size: sz, align: al, fields: flds };
 }
 
@@ -109,7 +109,7 @@ fn make_native_struct_field(fname: string, ftype: string) -> NativeStructField {
     };
 }
 
-fn make_native_struct_layout_field(lf_name: string, lf_type: string, lf_offset: number, lf_size: number, lf_align: number) -> NativeStructLayoutField {
+fn make_native_struct_layout_field(lf_name: string, lf_type: string, lf_offset: int, lf_size: int, lf_align: int) -> NativeStructLayoutField {
     return NativeStructLayoutField {
         name: lf_name,
         type_annotation: lf_type,
@@ -128,7 +128,7 @@ fn make_native_enum_variant(vname: string) -> NativeEnumVariant {
     return NativeEnumVariant { name: vname, fields: [] };
 }
 
-fn make_native_enum_layout(esize: number, ealign: number, etag_type: string, etag_size: number, etag_align: number, evariants: NativeEnumVariantLayout[]) -> NativeEnumLayout {
+fn make_native_enum_layout(esize: int, ealign: int, etag_type: string, etag_size: int, etag_align: int, evariants: NativeEnumVariantLayout[]) -> NativeEnumLayout {
     return NativeEnumLayout {
         size: esize,
         align: ealign,
@@ -139,7 +139,7 @@ fn make_native_enum_layout(esize: number, ealign: number, etag_type: string, eta
     };
 }
 
-fn make_native_enum_variant_layout(vlname: string, vltag: number, vloffset: number, vlsize: number, vlalign: number) -> NativeEnumVariantLayout {
+fn make_native_enum_variant_layout(vlname: string, vltag: int, vloffset: int, vlsize: int, vlalign: int) -> NativeEnumVariantLayout {
     return NativeEnumVariantLayout {
         name: vlname,
         tag: vltag,
@@ -150,7 +150,7 @@ fn make_native_enum_variant_layout(vlname: string, vltag: number, vloffset: numb
     };
 }
 
-fn make_native_enum_variant_layout_with_fields(vlname: string, vltag: number, vloffset: number, vlsize: number, vlalign: number, vlfields: NativeStructLayoutField[]) -> NativeEnumVariantLayout {
+fn make_native_enum_variant_layout_with_fields(vlname: string, vltag: int, vloffset: int, vlsize: int, vlalign: int, vlfields: NativeStructLayoutField[]) -> NativeEnumVariantLayout {
     return NativeEnumVariantLayout {
         name: vlname,
         tag: vltag,
@@ -229,7 +229,7 @@ fn append_instruction_to_function(func: NativeFunction, instr: NativeInstruction
 // ── NativeInstruction constructors ───────────────────────────────────
 // NativeInstruction construction helpers (seed v0.1.1 drops enum variant constructors)
 // Tags: Return=0, Expression=1, If=3, Else=4, EndIf=5, Loop=8, EndLoop=9, Break=10, Continue=11, Unknown=21
-fn make_instruction_text(tag_val: number, text: string) -> NativeInstruction {
+fn make_instruction_text(tag_val: int, text: string) -> NativeInstruction {
     // Seed drops this; fixup pass replaces body
     if tag_val == 0 {
         return NativeInstruction.Return { expression: text, span: null };
@@ -249,7 +249,7 @@ fn make_instruction_text(tag_val: number, text: string) -> NativeInstruction {
     return NativeInstruction.Unknown { text: text };
 }
 
-fn make_instruction_simple(tag_val: number) -> NativeInstruction {
+fn make_instruction_simple(tag_val: int) -> NativeInstruction {
     // Seed drops this; fixup pass replaces body
     if tag_val == 4 { return NativeInstruction.Else(); }
     if tag_val == 5 { return NativeInstruction.EndIf(); }
@@ -267,7 +267,7 @@ fn make_instruction_for(target: string, iterable: string) -> NativeInstruction {
 }
 
 // ── NativeEnum field accessors ───────────────────────────────────────
-fn get_enum_name_at(enums: NativeEnum[], idx: number) -> string {
+fn get_enum_name_at(enums: NativeEnum[], idx: int) -> string {
     let e = enums[idx];
     return e.name;
 }
@@ -276,7 +276,7 @@ fn get_enum_name_at(enums: NativeEnum[], idx: number) -> string {
 // The seed v0.1.1 compiles enum field access as sailfin_runtime_get_field
 // which is a runtime stub returning empty data.  These helpers use
 // explicit array indexing; the fixup pass replaces their bodies.
-fn get_instruction_tag(instructions: NativeInstruction[], idx: number) -> number {
+fn get_instruction_tag(instructions: NativeInstruction[], idx: int) -> int {
     // Enum tag accessor. The seed v0.1.1 can't compile this correctly;
     // _fix_struct_construction_helpers replaces the body for the first-pass
     // binary. Once a new seed is cut from a working binary, this source
@@ -288,108 +288,108 @@ fn get_instruction_tag(instructions: NativeInstruction[], idx: number) -> number
     return sailfin_enum_tag_from_instruction_array(instructions, idx);
 }
 
-fn get_instruction_text(instructions: NativeInstruction[], idx: number) -> string {
+fn get_instruction_text(instructions: NativeInstruction[], idx: int) -> string {
     // Seed drops this; fixup pass replaces with payload[0] read
     let instr = instructions[idx];
     return instr.expression;
 }
 
-fn get_instruction_condition(instructions: NativeInstruction[], idx: number) -> string {
+fn get_instruction_condition(instructions: NativeInstruction[], idx: int) -> string {
     // Seed drops this; fixup pass replaces with payload[0] read
     let instr = instructions[idx];
     return instr.condition;
 }
 
-fn get_instruction_let_name(instructions: NativeInstruction[], idx: number) -> string {
+fn get_instruction_let_name(instructions: NativeInstruction[], idx: int) -> string {
     let instr = instructions[idx];
     return instr.name;
 }
 
-fn get_instruction_let_mutable(instructions: NativeInstruction[], idx: number) -> boolean {
+fn get_instruction_let_mutable(instructions: NativeInstruction[], idx: int) -> boolean {
     let instr = instructions[idx];
     return instr.mutable;
 }
 
-fn get_instruction_let_type(instructions: NativeInstruction[], idx: number) -> string {
+fn get_instruction_let_type(instructions: NativeInstruction[], idx: int) -> string {
     let instr = instructions[idx];
     return instr.type_annotation;
 }
 
-fn get_instruction_let_value(instructions: NativeInstruction[], idx: number) -> string? {
+fn get_instruction_let_value(instructions: NativeInstruction[], idx: int) -> string? {
     let instr = instructions[idx];
     return instr.value;
 }
 
-fn get_instruction_for_target(instructions: NativeInstruction[], idx: number) -> string {
+fn get_instruction_for_target(instructions: NativeInstruction[], idx: int) -> string {
     // Seed drops this; fixup pass replaces with payload[0] read
     let instr = instructions[idx];
     return instr.target;
 }
 
-fn get_instruction_for_iterable(instructions: NativeInstruction[], idx: number) -> string {
+fn get_instruction_for_iterable(instructions: NativeInstruction[], idx: int) -> string {
     // Seed drops this; fixup pass replaces with payload[1] read
     let instr = instructions[idx];
     return instr.iterable;
 }
 
 // ── NativeFunction field accessors ───────────────────────────────────
-fn get_function_name_at(functions: NativeFunction[], idx: number) -> string {
+fn get_function_name_at(functions: NativeFunction[], idx: int) -> string {
     let f = functions[idx];
     return f.name;
 }
 
-fn get_function_return_type_at(functions: NativeFunction[], idx: number) -> string {
+fn get_function_return_type_at(functions: NativeFunction[], idx: int) -> string {
     let f = functions[idx];
     return f.return_type;
 }
 
-fn get_function_is_async_at(functions: NativeFunction[], idx: number) -> boolean {
+fn get_function_is_async_at(functions: NativeFunction[], idx: int) -> boolean {
     let f = functions[idx];
     return f.is_async;
 }
 
-fn get_function_is_extern_at(functions: NativeFunction[], idx: number) -> boolean {
+fn get_function_is_extern_at(functions: NativeFunction[], idx: int) -> boolean {
     let f = functions[idx];
     return f.is_extern;
 }
 
-fn get_function_parameters_at(functions: NativeFunction[], idx: number) -> NativeParameter[] {
+fn get_function_parameters_at(functions: NativeFunction[], idx: int) -> NativeParameter[] {
     let f = functions[idx];
     return f.parameters;
 }
 
-fn get_function_instructions_at(functions: NativeFunction[], idx: number) -> NativeInstruction[] {
+fn get_function_instructions_at(functions: NativeFunction[], idx: int) -> NativeInstruction[] {
     let f = functions[idx];
     return f.instructions;
 }
 
-fn get_function_effects_at(functions: NativeFunction[], idx: number) -> string[] {
+fn get_function_effects_at(functions: NativeFunction[], idx: int) -> string[] {
     let f = functions[idx];
     return f.effects;
 }
 
-fn get_function_decorators_at(functions: NativeFunction[], idx: number) -> string[] {
+fn get_function_decorators_at(functions: NativeFunction[], idx: int) -> string[] {
     let f = functions[idx];
     return f.decorators;
 }
 
 // ── NativeStruct field accessors ─────────────────────────────────────
-fn get_struct_name_at(structs: NativeStruct[], idx: number) -> string {
+fn get_struct_name_at(structs: NativeStruct[], idx: int) -> string {
     let s = structs[idx];
     return s.name;
 }
 
-fn get_struct_fields_at(structs: NativeStruct[], idx: number) -> NativeStructField[] {
+fn get_struct_fields_at(structs: NativeStruct[], idx: int) -> NativeStructField[] {
     let s = structs[idx];
     return s.fields;
 }
 
-fn get_struct_field_name_at(fields: NativeStructField[], idx: number) -> string {
+fn get_struct_field_name_at(fields: NativeStructField[], idx: int) -> string {
     let f = fields[idx];
     return f.name;
 }
 
-fn get_struct_field_type_at(fields: NativeStructField[], idx: number) -> string {
+fn get_struct_field_type_at(fields: NativeStructField[], idx: int) -> string {
     let f = fields[idx];
     return f.type_annotation;
 }
@@ -397,7 +397,7 @@ fn get_struct_field_type_at(fields: NativeStructField[], idx: number) -> string 
 // ── Import append helper ─────────────────────────────────────────────
 fn append_native_import(arr: NativeImport[], item: NativeImport) -> NativeImport[] {
     let mut result: NativeImport[] = [];
-    let mut i: number = 0;
+    let mut i: int = 0;
     loop {
         if i >= arr.length { break; }
         result = result.push(arr[i]);

--- a/compiler/src/llvm/lowering/lowering_recovery.sfn
+++ b/compiler/src/llvm/lowering/lowering_recovery.sfn
@@ -78,8 +78,8 @@ fn recover_native_functions_light(native_text: string) -> NativeFunction[] {
     let mut functions: NativeFunction[] = [];
     let mut current: NativeFunction? = null;
     let mut current_struct_name: string = "";
-    let mut index: number = 0;
-    let mut fn_count: number = 0;
+    let mut index: int = 0;
+    let mut fn_count: int = 0;
     loop {
         if index >= lines.length { break; }
         let line = trim_text_local(lines[index]);
@@ -152,8 +152,8 @@ fn recover_native_functions_light(native_text: string) -> NativeFunction[] {
         let param_text_raw = trim_text_local(substring(line, 7, line.length));
         let param_colon_idx = index_of(param_text_raw, ": ");
         let param_legacy_arrow_idx = index_of(param_text_raw, " -> ");
-        let mut param_arrow_idx: number = -1;
-        let mut param_sep_len: number = 2;
+        let mut param_arrow_idx: int = -1;
+        let mut param_sep_len: int = 2;
         if param_colon_idx >= 0 {
             param_arrow_idx = param_colon_idx;
             param_sep_len = 2;
@@ -383,7 +383,7 @@ fn recover_native_functions_light(native_text: string) -> NativeFunction[] {
         // the seed degenerate-if bug drops all nested/else-if branches.
         // We use a score (need 3 of 3) instead of nested AND conditions.
         let _ml_net_depth = net_unquoted_brace_depth(line);
-        let mut _gather_score: number = 0;
+        let mut _gather_score: int = 0;
         if is_eval { _gather_score += 1; }
         if _ml_net_depth > 0 { _gather_score += 1; }
         // Only gather when there is a positive unquoted brace depth
@@ -393,8 +393,8 @@ fn recover_native_functions_light(native_text: string) -> NativeFunction[] {
         if is_eval {
             _eval_gathered = trim_text_local(substring(line, 5, line.length));
         }
-        let mut _eval_brace_depth: number = 1;
-        let mut _gi: number = index + 1;
+        let mut _eval_brace_depth: int = 1;
+        let mut _gi: int = index + 1;
         loop {
             if _gather_score < 3 { break; }
             if _gi >= lines.length { break; }
@@ -453,7 +453,7 @@ fn recover_native_functions_light(native_text: string) -> NativeFunction[] {
         // (e.g. `eval line = line + " => {"`).  Misidentifying eval lines as inline
         // cases corrupts the instruction list and causes a 2-cycle oscillation in
         // the self-hosting fixed-point check.
-        let mut _inline_score: number = 0;
+        let mut _inline_score: int = 0;
         if is_inline_case { _inline_score += 1; }
         if !is_eval { _inline_score += 1; }
         if !is_match_kw { _inline_score += 1; }
@@ -485,7 +485,7 @@ fn recover_native_functions_light(native_text: string) -> NativeFunction[] {
 fn recover_native_imports_light(native_text: string) -> NativeImport[] {
     let lines = split_lines_local(native_text);
     let mut imports: NativeImport[] = [];
-    let mut index: number = 0;
+    let mut index: int = 0;
     loop {
         if index >= lines.length { break; }
         let line = trim_text_local(lines[index]);
@@ -518,10 +518,10 @@ fn recover_native_structs_light(native_text: string) -> NativeStruct[] {
     let mut struct_methods: NativeFunction[] = [];
     let mut struct_layout: NativeStructLayout? = null;
     let mut layout_fields: NativeStructLayoutField[] = [];
-    let mut layout_size: number = 0;
-    let mut layout_align: number = 0;
+    let mut layout_size: int = 0;
+    let mut layout_align: int = 0;
 
-    let mut index: number = 0;
+    let mut index: int = 0;
     loop {
         if index >= lines.length { break; }
         let line = trim_text_local(lines[index]);
@@ -545,8 +545,8 @@ fn recover_native_structs_light(native_text: string) -> NativeStruct[] {
         let field_text = trim_text_local(substring(line, 7, line.length));
         let field_colon_idx = index_of(field_text, ": ");
         let field_legacy_arrow_idx = index_of(field_text, " -> ");
-        let mut field_arrow_idx: number = -1;
-        let mut field_sep_len: number = 2;
+        let mut field_arrow_idx: int = -1;
+        let mut field_sep_len: int = 2;
         if field_colon_idx >= 0 {
             field_arrow_idx = field_colon_idx;
             field_sep_len = 2;
@@ -721,7 +721,7 @@ fn recover_functions_for_lowering(current_functions: NativeFunction[], native_te
                 }
 
                 let mut has_body_instructions = false;
-                let mut body_index: number = 0;
+                let mut body_index: int = 0;
                 loop {
                     if body_index >= initial_function_count { break; }
                     let function = safe_functions[body_index];
@@ -737,7 +737,7 @@ fn recover_functions_for_lowering(current_functions: NativeFunction[], native_te
                 }
                 if !has_body_instructions { use_expected = true; }
 
-                let mut index: number = 0;
+                let mut index: int = 0;
                 loop {
                     let mut _if245: boolean = false;
                     if index >= initial_function_count { _if245 = true; }
@@ -768,7 +768,7 @@ fn recover_functions_for_lowering(current_functions: NativeFunction[], native_te
                     let light_functions = recover_native_functions_light(expected_source_text);
                     let light_count = sanitize_collection_length(light_functions.length, 200000);
                     let mut light_has_body = false;
-                    let mut light_index: number = 0;
+                    let mut light_index: int = 0;
                     loop {
                         if light_index >= light_count { break; }
                         let function = light_functions[light_index];
@@ -846,23 +846,23 @@ fn recover_native_enums_light(native_text: string) -> NativeEnum[] {
     let mut enum_name: string = "";
     let mut variants: NativeEnumVariant[] = [];
     let mut variant_layouts: NativeEnumVariantLayout[] = [];
-    let mut layout_size: number = 0;
-    let mut layout_align: number = 0;
+    let mut layout_size: int = 0;
+    let mut layout_align: int = 0;
     let mut layout_tag_type: string = "i32";
-    let mut layout_tag_size: number = 4;
-    let mut layout_tag_align: number = 4;
+    let mut layout_tag_size: int = 4;
+    let mut layout_tag_align: int = 4;
     let mut has_layout: boolean = false;
 
     // Deferred variant layout — accumulate payload fields before flushing.
     let mut pending_vl_name: string = "";
-    let mut pending_vl_tag: number = 0;
-    let mut pending_vl_offset: number = 0;
-    let mut pending_vl_size: number = 0;
-    let mut pending_vl_align: number = 0;
+    let mut pending_vl_tag: int = 0;
+    let mut pending_vl_offset: int = 0;
+    let mut pending_vl_size: int = 0;
+    let mut pending_vl_align: int = 0;
     let mut pending_vl_fields: NativeStructLayoutField[] = [];
     let mut has_pending_vl: boolean = false;
 
-    let mut index: number = 0;
+    let mut index: int = 0;
     loop {
         if index >= lines.length { break; }
         let line = trim_text_local(lines[index]);

--- a/compiler/src/native_ir_parser.sfn
+++ b/compiler/src/native_ir_parser.sfn
@@ -56,7 +56,7 @@ fn parse_native_artifact_impl(text: string, include_instructions: boolean, inclu
     let mut pending_value_span: NativeSourceSpan? = null;
     let mut pending_decorators: string[] = [];
 
-    let mut index: number = 0;
+    let mut index: int = 0;
     loop {
         if index >= lines.length { break; }
         let raw_line = lines[index];
@@ -112,7 +112,7 @@ fn parse_native_artifact_impl(text: string, include_instructions: boolean, inclu
                 pending_decorators = [];
             }
             let struct_result = parse_struct_definition(lines, index, include_instructions);
-            let mut _ci: number = 0;
+            let mut _ci: int = 0;
             loop {
                 if _ci >= struct_result.diagnostics.length { break; }
                 diagnostics.push(struct_result.diagnostics[_ci]);
@@ -130,7 +130,7 @@ fn parse_native_artifact_impl(text: string, include_instructions: boolean, inclu
                 pending_decorators = [];
             }
             let interface_result = parse_interface_definition(lines, index);
-            let mut _ci: number = 0;
+            let mut _ci: int = 0;
             loop {
                 if _ci >= interface_result.diagnostics.length { break; }
                 diagnostics.push(interface_result.diagnostics[_ci]);
@@ -148,7 +148,7 @@ fn parse_native_artifact_impl(text: string, include_instructions: boolean, inclu
                 pending_decorators = [];
             }
             let enum_result = parse_enum_definition(lines, index);
-            let mut _ci: number = 0;
+            let mut _ci: int = 0;
             loop {
                 if _ci >= enum_result.diagnostics.length { break; }
                 diagnostics.push(enum_result.diagnostics[_ci]);
@@ -220,7 +220,7 @@ fn parse_native_artifact_impl(text: string, include_instructions: boolean, inclu
             if trimmed[0] == "'" { _if358 = true; }
             if _if358 {
                 let quote = trimmed[0];
-                let mut scan: number = 1;
+                let mut scan: int = 1;
                 let mut escaping: boolean = false;
                 loop {
                     if scan >= trimmed.length { break; }
@@ -300,7 +300,7 @@ fn parse_native_artifact_impl(text: string, include_instructions: boolean, inclu
         if starts_with(line, ".param ") {
             if current != null {
                 let mut combined: string = strip_prefix(line, ".param ");
-                let mut lookahead: number = index + 1;
+                let mut lookahead: int = index + 1;
                 loop {
                     if lookahead >= lines.length { break; }
                     let continuation_raw = lines[lookahead];
@@ -322,7 +322,7 @@ fn parse_native_artifact_impl(text: string, include_instructions: boolean, inclu
                     diagnostics.push("unable to parse parameter line: " + line);
                     pending_span = null;
                 } else {
-                    let mut entry_index: number = 0;
+                    let mut entry_index: int = 0;
                     let mut span_consumed: boolean = false;
                     loop {
                         if entry_index >= entries.length { break; }
@@ -406,7 +406,7 @@ fn parse_native_artifact_impl(text: string, include_instructions: boolean, inclu
             }
             continue;
         }
-        let mut instruction_index: number = 0;
+        let mut instruction_index: int = 0;
         loop {
             if instruction_index >= instructions.length { break; }
             current = append_instruction(current, instructions[instruction_index]);

--- a/compiler/src/native_ir_parser_defs.sfn
+++ b/compiler/src/native_ir_parser_defs.sfn
@@ -144,8 +144,8 @@ fn append_struct_layout_field(fields: NativeStructLayoutField[], field: NativeSt
     return fields;
 }
 
-fn find_enum_variant_layout(variants: NativeEnumVariantLayout[], name: string) -> number {
-    let mut index: number = 0;
+fn find_enum_variant_layout(variants: NativeEnumVariantLayout[], name: string) -> int {
+    let mut index: int = 0;
     loop {
         if index >= variants.length { break; }
         if variants[index].name == name { return index; }
@@ -154,9 +154,9 @@ fn find_enum_variant_layout(variants: NativeEnumVariantLayout[], name: string) -
     return -1;
 }
 
-fn update_enum_variant_fields(variants: NativeEnumVariantLayout[], index: number, field: NativeStructLayoutField) -> NativeEnumVariantLayout[] {
+fn update_enum_variant_fields(variants: NativeEnumVariantLayout[], index: int, field: NativeStructLayoutField) -> NativeEnumVariantLayout[] {
     let mut result: NativeEnumVariantLayout[] = [];
-    let mut current_index: number = 0;
+    let mut current_index: int = 0;
     loop {
         if current_index >= variants.length { break; }
         if current_index == index {
@@ -176,12 +176,12 @@ fn update_enum_variant_fields(variants: NativeEnumVariantLayout[], index: number
     return result;
 }
 
-fn parse_struct_definition(lines: string[], start_index: number, include_instructions: boolean) -> StructParseResult {
+fn parse_struct_definition(lines: string[], start_index: int, include_instructions: boolean) -> StructParseResult {
     let mut diagnostics: string[] = [];
     let header = trim_text(lines[start_index]);
     let name_text = trim_text(strip_prefix(header, ".struct "));
     let header_parse = parse_struct_header(name_text);
-    let mut _ci: number = 0;
+    let mut _ci: int = 0;
     loop {
         if _ci >= header_parse.diagnostics.length { break; }
         diagnostics.push(header_parse.diagnostics[_ci]);
@@ -205,8 +205,8 @@ fn parse_struct_definition(lines: string[], start_index: number, include_instruc
     let mut method_pending_value_span: NativeSourceSpan? = null;
     let mut method_pending_decorators: string[] = [];
     let mut struct_layout_fields: NativeStructLayoutField[] = [];
-    let mut struct_layout_size: number = 0;
-    let mut struct_layout_align: number = 0;
+    let mut struct_layout_size: int = 0;
+    let mut struct_layout_align: int = 0;
     let mut struct_layout_header_success: boolean = false;
     let mut struct_layout_reported_missing_header: boolean = false;
     let mut index = start_index + 1;
@@ -330,7 +330,7 @@ fn parse_struct_definition(lines: string[], start_index: number, include_instruc
                     + raw_line);
                 method_pending_value_span = null;
             }
-            let mut instruction_index: number = 0;
+            let mut instruction_index: int = 0;
             loop {
                 if instruction_index >= method_instruction_result.instructions.length {
                     break;
@@ -345,7 +345,7 @@ fn parse_struct_definition(lines: string[], start_index: number, include_instruc
             let body = strip_prefix(raw_line, ".layout ");
             if starts_with(body, "struct ") {
                 let header_result = parse_struct_layout_header(strip_prefix(body, "struct "));
-                let mut _ci: number = 0;
+                let mut _ci: int = 0;
                 loop {
                     if _ci >= header_result.diagnostics.length { break; }
                     diagnostics.push(header_result.diagnostics[_ci]);
@@ -376,7 +376,7 @@ fn parse_struct_definition(lines: string[], start_index: number, include_instruc
                 if is_struct_header {
                     let header_text = trim_text(strip_prefix(tail, "struct"));
                     let header_result = parse_struct_layout_header(header_text);
-                    let mut _ci: number = 0;
+                    let mut _ci: int = 0;
                     loop {
                         if _ci >= header_result.diagnostics.length { break; }
                         diagnostics.push(header_result.diagnostics[_ci]);
@@ -397,7 +397,7 @@ fn parse_struct_definition(lines: string[], start_index: number, include_instruc
                 }
 
                 let field_result = parse_struct_layout_field(tail, struct_name);
-                let mut _ci: number = 0;
+                let mut _ci: int = 0;
                 loop {
                     if _ci >= field_result.diagnostics.length { break; }
                     diagnostics.push(field_result.diagnostics[_ci]);
@@ -498,7 +498,7 @@ fn parse_struct_definition(lines: string[], start_index: number, include_instruc
     };
 }
 
-fn parse_enum_definition(lines: string[], start_index: number) -> EnumParseResult {
+fn parse_enum_definition(lines: string[], start_index: int) -> EnumParseResult {
     let mut diagnostics: string[] = [];
     let header = trim_text(lines[start_index]);
     let name_text = trim_text(strip_prefix(header, ".enum "));
@@ -519,11 +519,11 @@ fn parse_enum_definition(lines: string[], start_index: number) -> EnumParseResul
 
     let mut variants: NativeEnumVariant[] = [];
     let mut enum_layout_variants: NativeEnumVariantLayout[] = [];
-    let mut enum_layout_size: number = 0;
-    let mut enum_layout_align: number = 0;
+    let mut enum_layout_size: int = 0;
+    let mut enum_layout_align: int = 0;
     let mut enum_layout_tag_type: string = "";
-    let mut enum_layout_tag_size: number = 0;
-    let mut enum_layout_tag_align: number = 0;
+    let mut enum_layout_tag_size: int = 0;
+    let mut enum_layout_tag_align: int = 0;
     let mut enum_layout_header_success: boolean = false;
     let mut enum_layout_reported_missing_header: boolean = false;
     let mut index = start_index + 1;
@@ -567,7 +567,7 @@ fn parse_enum_definition(lines: string[], start_index: number) -> EnumParseResul
             let body = strip_prefix(raw_line, ".layout ");
             if starts_with(body, "enum ") {
                 let header_result = parse_enum_layout_header(strip_prefix(body, "enum "));
-                let mut _ci: number = 0;
+                let mut _ci: int = 0;
                 loop {
                     if _ci >= header_result.diagnostics.length { break; }
                     diagnostics.push(header_result.diagnostics[_ci]);
@@ -608,7 +608,7 @@ fn parse_enum_definition(lines: string[], start_index: number) -> EnumParseResul
                 }
 
                 let variant_result = parse_enum_variant_layout(variant_text, enum_name);
-                let mut _ci: number = 0;
+                let mut _ci: int = 0;
                 loop {
                     if _ci >= variant_result.diagnostics.length { break; }
                     diagnostics.push(variant_result.diagnostics[_ci]);
@@ -637,7 +637,7 @@ fn parse_enum_definition(lines: string[], start_index: number) -> EnumParseResul
             }
             if starts_with(body, "payload ") {
                 let payload_result = parse_enum_payload_layout(strip_prefix(body, "payload "), enum_name);
-                let mut _ci: number = 0;
+                let mut _ci: int = 0;
                 loop {
                     if _ci >= payload_result.diagnostics.length { break; }
                     diagnostics.push(payload_result.diagnostics[_ci]);

--- a/compiler/src/native_ir_parser_instructions.sfn
+++ b/compiler/src/native_ir_parser_instructions.sfn
@@ -42,7 +42,7 @@ fn update_instruction_depth_state(state: InstructionDepthState, text: string) ->
     let mut in_string = state.in_string;
     let mut escaping = state.escaping;
 
-    let mut index: number = 0;
+    let mut index: int = 0;
     loop {
         if index >= text.length { break; }
         let ch = text[index];
@@ -153,7 +153,7 @@ fn is_native_directive_line(line: string) -> boolean {
     return starts_with(trimmed, ".");
 }
 
-fn gather_instruction(lines: string[], start_index: number) -> InstructionGatherResult {
+fn gather_instruction(lines: string[], start_index: int) -> InstructionGatherResult {
     if start_index >= lines.length {
         return InstructionGatherResult { text: "", lines_consumed: 0 };
     }

--- a/compiler/src/native_ir_utils_layout.sfn
+++ b/compiler/src/native_ir_utils_layout.sfn
@@ -34,7 +34,7 @@ fn parse_decimal_number(text: string) -> NumberParseResult {
         return NumberParseResult { success: false, value: 0 };
     }
     let mut value: int = 0;
-    let mut index: number = 0;
+    let mut index: int = 0;
     let mut negative: boolean = false;
     if trimmed[0] == "-" {
         negative = true;
@@ -82,9 +82,9 @@ fn parse_struct_layout_header(text: string) -> StructLayoutHeaderParse {
     let mut size_found: boolean = false;
     let mut align_found: boolean = false;
     let mut name_value: string = "";
-    let mut size_value: number = 0;
-    let mut align_value: number = 0;
-    let mut index: number = 0;
+    let mut size_value: int = 0;
+    let mut align_value: int = 0;
+    let mut index: int = 0;
     loop {
         if index >= tokens.length { break; }
         let token = tokens[index];
@@ -183,10 +183,10 @@ fn parse_struct_layout_field(text: string, struct_name: string) -> StructLayoutF
     let mut offset_found: boolean = false;
     let mut size_found: boolean = false;
     let mut align_found: boolean = false;
-    let mut offset_value: number = 0;
-    let mut size_value: number = 0;
-    let mut align_value: number = 0;
-    let mut index: number = 1;
+    let mut offset_value: int = 0;
+    let mut size_value: int = 0;
+    let mut align_value: int = 0;
+    let mut index: int = 1;
     loop {
         if index >= tokens.length { break; }
         let token = tokens[index];
@@ -308,11 +308,11 @@ fn parse_enum_layout_header(text: string) -> EnumLayoutHeaderParse {
     let mut tag_type: string = "";
     let mut tag_size_found: boolean = false;
     let mut tag_align_found: boolean = false;
-    let mut size_value: number = 0;
-    let mut align_value: number = 0;
-    let mut tag_size_value: number = 0;
-    let mut tag_align_value: number = 0;
-    let mut index: number = 0;
+    let mut size_value: int = 0;
+    let mut align_value: int = 0;
+    let mut tag_size_value: int = 0;
+    let mut tag_align_value: int = 0;
+    let mut index: int = 0;
     loop {
         if index >= tokens.length { break; }
         let token = tokens[index];
@@ -452,11 +452,11 @@ fn parse_enum_variant_layout(text: string, enum_name: string) -> EnumLayoutVaria
     let mut offset_found: boolean = false;
     let mut size_found: boolean = false;
     let mut align_found: boolean = false;
-    let mut tag_value: number = 0;
-    let mut offset_value: number = 0;
-    let mut size_value: number = 0;
-    let mut align_value: number = 0;
-    let mut index: number = 1;
+    let mut tag_value: int = 0;
+    let mut offset_value: int = 0;
+    let mut size_value: int = 0;
+    let mut align_value: int = 0;
+    let mut index: int = 1;
     loop {
         if index >= tokens.length { break; }
         let token = tokens[index];
@@ -619,10 +619,10 @@ fn parse_enum_payload_layout(text: string, enum_name: string) -> EnumLayoutPaylo
     let mut offset_found: boolean = false;
     let mut size_found: boolean = false;
     let mut align_found: boolean = false;
-    let mut offset_value: number = 0;
-    let mut size_value: number = 0;
-    let mut align_value: number = 0;
-    let mut index: number = 1;
+    let mut offset_value: int = 0;
+    let mut size_value: int = 0;
+    let mut align_value: int = 0;
+    let mut index: int = 1;
     loop {
         if index >= tokens.length { break; }
         let token = tokens[index];


### PR DESCRIPTION
## Summary

Slice E.3a-bulk-1b **child 1 of #579**. Flips 108 `: number` / `-> number` sites to `: int` across the `make_native_*_layout` cross-boundary chain — the callees in `lowering_native_helpers.sfn` + `lowering_recovery.sfn` plus every caller in `native_ir_parser{,_defs,_instructions}.sfn` + `native_ir_utils_layout.sfn`. Sized exactly to the call graph the parent epic identified.

- Fixes the `clang -O2` OOM on `build/sailfin/capsules/token.ll` (garbage layout numbers becoming `[5918676352055 x i128]`).
- Fixes the runtime `bounds_check failed: index=-9223372036854775808` (i64 bits arriving as `double`, `fptosi(NaN) == INT64_MIN`).
- Parallel-safe with child 2 (string-utils shadow chain).

Closes #580

## Acceptance Criteria

- [x] All `: number` / `-> number` sites in the 6 listed files flip to `: int`. No `// alias-coverage` rows in this scope (zero rows touched).
- [x] `make compile` self-hosts.
- [x] `make test` passes (unit + integration + e2e 56/56 + capsules 10/10).
- [x] `sfn fmt --check` clean on every modified file.
- [x] `clang -O2 -c build/sailfin/capsules/token.ll -o /tmp/token.o` succeeds (no OOM — #578 failure mode).
- [x] `build/native/sailfin run examples/basics/hello-world.sfn` prints `Hello, Sailfin!` (no `bounds_check failed: index=-9223372036854775808`).
- [x] Audit grep on the 6 files returns zero matches.

## Verification

```bash
$ ulimit -v 8388608 && make compile
... [compile] built build/native/sailfin

$ ulimit -v 8388608 && make test
═══ e2e: 56/56 passed, 0 failed ═══
═══ capsules: 10/10 passed, 0 failed ═══

$ build/native/sailfin fmt --check compiler/src/llvm/lowering/lowering_native_helpers.sfn \
    compiler/src/llvm/lowering/lowering_recovery.sfn \
    compiler/src/native_ir_parser.sfn \
    compiler/src/native_ir_parser_defs.sfn \
    compiler/src/native_ir_parser_instructions.sfn \
    compiler/src/native_ir_utils_layout.sfn
# exit 0

$ clang -O2 -c build/sailfin/capsules/token.ll -o /tmp/token.o
# exit 0 (was OOM under #578)

$ ulimit -v 8388608 && timeout 30 build/native/sailfin run examples/basics/hello-world.sfn
Hello, Sailfin!
# (was bounds_check failed: index=-9223372036854775808 under #578)

$ grep -nE "(: number|-> number)" <6 files> | grep -v "// alias-coverage"
# zero matches
```

## Files Changed

| File | Sites |
| --- | --- |
| `compiler/src/llvm/lowering/lowering_native_helpers.sfn` | 30 (callee — defines `make_native_struct_layout`, `make_native_struct_layout_field`, `make_native_enum_layout`, `make_native_enum_variant_layout*`) |
| `compiler/src/llvm/lowering/lowering_recovery.sfn` | 26 (callee — light recovery parsers) |
| `compiler/src/native_ir_parser.sfn` | 8 (caller — loop indices feed layout calls) |
| `compiler/src/native_ir_parser_defs.sfn` | 20 (caller) |
| `compiler/src/native_ir_parser_instructions.sfn` | 2 (caller) |
| `compiler/src/native_ir_utils_layout.sfn` | 22 (caller — consumes layout shape downstream) |
| **Total** | **108** (`108 insertions(+), 108 deletions(-)`) |

## Out of scope (intentional, per #580)

- `compiler/src/native_ir.sfn`, `native_ir_api.sfn`, `native_ir_utils_parse.sfn`, `native_ir_utils_text.sfn` — child 3.
- Other `compiler/src/llvm/lowering/` files outside the table — stays in #564 scope.
- `// alias-coverage: C-ABI boundary` rows in `cli_main.sfn`.
- `compiler/src/parser/` (#563) and `compiler/src/llvm/expression_lowering/` (#565).

Remaining `[warning] ABI primitive mismatch: callee expects 'i64' (int) but caller produced 'double' (float)` lines emitted during compile are the still-unflipped neighbours (children 2 and 3) under #550's warning regime — they don't break self-hosting.

https://claude.ai/code/session_01RZJhoN2DKCSMgNK1E6Mpup

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZJhoN2DKCSMgNK1E6Mpup)_