### PR TITLE
fix: replace prelude find_char with find_char_local to fix alpha.16 CI failures

### DIFF
--- a/compiler/src/lock.sfn
+++ b/compiler/src/lock.sfn
@@ -13,6 +13,8 @@
 //
 // Each entry under [packages] maps a capsule display name to its locked
 // version and integrity hash, space-separated within the quoted value.
+import { find_char_local } from "./string_utils";
+
 // ---- Internal helpers ----
 fn _lock_trim(text: string) -> string {
     let mut start: int = 0;
@@ -84,21 +86,21 @@ fn _lock_parse(text: string) -> _LockEntry[] {
         if line.length == 0 { continue; }
         if line[0] == "#" { continue; }
         if line[0] == "[" {
-            let close = find_char(line, "]", 0);
+            let close = find_char_local(line, "]", 0);
             if close > 0 {
                 section = _lock_trim(substring(line, 1, close));
             }
             continue;
         }
         if !strings_equal(section, "packages") { continue; }
-        let eq_pos = find_char(line, "=", 0);
+        let eq_pos = find_char_local(line, "=", 0);
         if eq_pos < 0 { continue; }
         let key = _lock_trim(substring(line, 0, eq_pos));
         let value = _lock_trim(substring(line, eq_pos + 1, line.length));
         let capsule_name = _lock_strip_quotes(key);
         let raw_value = _lock_strip_quotes(value);
         // Split "version hash" on first space
-        let space_pos = find_char(raw_value, " ", 0);
+        let space_pos = find_char_local(raw_value, " ", 0);
         let mut ver: string = raw_value;
         let mut integrity: string = "";
         if space_pos > 0 {

--- a/compiler/src/string_utils.sfn
+++ b/compiler/src/string_utils.sfn
@@ -70,6 +70,24 @@ fn char_code_at_text(text: string, index: int) -> int {
     return char_code(char_at(text, index));
 }
 
+// Pure-Sailfin reimplementation of prelude find_char. Callers that import
+// this avoid the stale-seed ABI mismatch that occurs when the seed binary's
+// compiled-in registry predates a prelude type flip (number→int). Uses only
+// char_code_at_text, whose registry signature has been stable across seeds.
+fn find_char_local(text: string, ch: string, start: int) -> int {
+    if ch.length == 0 { return -1; }
+    let needle = char_code_at_text(ch, 0);
+    let len = text.length;
+    let mut i: int = start;
+    if i < 0 { i = 0; }
+    loop {
+        if i >= len { break; }
+        if char_code_at_text(text, i) == needle { return i; }
+        i += 1;
+    }
+    return -1;
+}
+
 fn index_of(value: string, target: string) -> int {
     if target.length == 0 { return 0; }
     let _search_limit = value.length - target.length;
@@ -151,6 +169,7 @@ export {
     clamp,
     substring,
     find_char,
+    find_char_local,
     grapheme_count,
     grapheme_at,
     char_code,

--- a/compiler/src/string_utils.sfn
+++ b/compiler/src/string_utils.sfn
@@ -70,10 +70,11 @@ fn char_code_at_text(text: string, index: int) -> int {
     return char_code(char_at(text, index));
 }
 
-// Pure-Sailfin reimplementation of prelude find_char. Callers that import
-// this avoid the stale-seed ABI mismatch that occurs when the seed binary's
-// compiled-in registry predates a prelude type flip (number→int). Uses only
-// char_code_at_text, whose registry signature has been stable across seeds.
+// Single-byte ASCII character search — intentional subset of prelude find_char.
+// Avoids the stale-seed ABI mismatch (seed registry says find_char→double;
+// prelude defines find_char→int). Does NOT implement prelude's backslash-escape
+// shorthands (e.g. "\\n" → '\n'). Callers must pass the literal character;
+// search targets in toml_parser and lock ("]", "=", " ") require no escaping.
 fn find_char_local(text: string, ch: string, start: int) -> int {
     if ch.length == 0 { return -1; }
     let needle = char_code_at_text(ch, 0);

--- a/compiler/src/toml_parser.sfn
+++ b/compiler/src/toml_parser.sfn
@@ -2,6 +2,8 @@
 //
 // Minimal TOML parser for capsule.toml manifests. Provides a string-based API
 // so callers never need to allocate the SailToml struct across modules.
+import { find_char_local } from "./string_utils";
+
 struct SailToml {
     name: string;
     version: string;
@@ -183,13 +185,13 @@ fn _parse_toml_internal(text: string) -> SailToml {
         if line.length == 0 { continue; }
         if line[0] == "#" { continue; }
         if line[0] == "[" {
-            let close = find_char(line, "]", 0);
+            let close = find_char_local(line, "]", 0);
             if close > 0 {
                 section = _toml_trim(substring(line, 1, close));
             }
             continue;
         }
-        let eq_pos = find_char(line, "=", 0);
+        let eq_pos = find_char_local(line, "=", 0);
         if eq_pos < 0 { continue; }
         let key = _toml_trim(substring(line, 0, eq_pos));
         let value = _toml_trim(substring(line, eq_pos + 1, line.length));
@@ -398,7 +400,7 @@ fn toml_get_target_triples(text: string) -> string {
         i += 1;
         if line.length == 0 { continue; }
         if line[0] != "[" { continue; }
-        let close = find_char(line, "]", 0);
+        let close = find_char_local(line, "]", 0);
         if close <= 0 { continue; }
         let section = _toml_trim(substring(line, 1, close));
         if section.length <= prefix.length { continue; }
@@ -437,14 +439,14 @@ fn toml_get_string_array(text: string, section: string, key: string) -> string {
         if line.length == 0 { continue; }
         if line[0] == "#" { continue; }
         if line[0] == "[" {
-            let close = find_char(line, "]", 0);
+            let close = find_char_local(line, "]", 0);
             if close > 0 {
                 current_section = _toml_trim(substring(line, 1, close));
             }
             continue;
         }
         if !strings_equal(current_section, section) { continue; }
-        let eq_pos = find_char(line, "=", 0);
+        let eq_pos = find_char_local(line, "=", 0);
         if eq_pos < 0 { continue; }
         let line_key = _toml_trim(substring(line, 0, eq_pos));
         let stripped_key = _toml_strip_quotes(line_key);
@@ -497,14 +499,14 @@ fn toml_get_string(text: string, section: string, key: string) -> string {
         if line.length == 0 { continue; }
         if line[0] == "#" { continue; }
         if line[0] == "[" {
-            let close = find_char(line, "]", 0);
+            let close = find_char_local(line, "]", 0);
             if close > 0 {
                 current_section = _toml_trim(substring(line, 1, close));
             }
             continue;
         }
         if !strings_equal(current_section, section) { continue; }
-        let eq_pos = find_char(line, "=", 0);
+        let eq_pos = find_char_local(line, "=", 0);
         if eq_pos < 0 { continue; }
         let line_key = _toml_trim(substring(line, 0, eq_pos));
         let stripped_key = _toml_strip_quotes(line_key);


### PR DESCRIPTION
## Summary

- Adds `find_char_local` to `string_utils.sfn` as a pure-Sailfin reimplementation (no prelude call) using only `char_code_at_text`, whose registry signature is stable across seeds
- Routes all `find_char` call sites in `toml_parser.sfn` (7 sites) and `lock.sfn` (3 sites) through `find_char_local`
- Removes the two debug test files created during investigation

## Root Cause

The alpha.15 seed was cut before PR #576 flipped `find_char`'s return type from `number` (double/f64) to `int` (i64). When the seed compiles `toml_parser.sfn` and `lock.sfn`, it emits `declare double @find_char` using its stale registry, while the actual prelude defines `i64 @find_char`. This ABI mismatch causes nondeterministic failures on CI (callee returns i64 in `rax`; caller reads `xmm0` expecting double).

A thin wrapper in `string_utils.sfn` would not fix this — the seed would still emit `declare double @find_char` for any call to the prelude symbol, even from inside `string_utils.sfn`. The pure reimplementation avoids this by never referencing the prelude's `find_char` at all.

## Acceptance Criteria

- [x] 94/94 unit tests pass on first-pass binary
- [x] Self-host compile succeeds (`make compile`)
- [x] All 5 previously-failing tests pass: `lock_test`, `manifest_workspace_test`, `runtime_capsule_resolver_test`, `toml_dependencies_test`, `version_resolution_test`

## Verification

```
$ ulimit -v 8388608 && make compile
[rebuild] built build/native/sailfin   # 2 ABI warnings (down from 13)

$ ulimit -v 8388608 && make test-unit
═══ unit: 94/94 passed, 0 failed ═══
```

## Files Changed

- `compiler/src/string_utils.sfn` — add `find_char_local` pure reimplementation + export
- `compiler/src/toml_parser.sfn` — import `find_char_local`, replace 7 call sites
- `compiler/src/lock.sfn` — import `find_char_local`, replace 3 call sites

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XDg38sahSpKY6fm1A5XKtF)_