### PR TITLE
fix(cli): replace find_char (double ABI) with find_char_local to fix sfn package hang

### DIFF
--- a/compiler/src/cli_commands.sfn
+++ b/compiler/src/cli_commands.sfn
@@ -37,8 +37,7 @@ import {
     _shell_single_quote_arg,
     _string_contains_cmd,
     _toml_trim_cmd,
-    _write_text_cmd,
-    find_char
+    _write_text_cmd
 } from "./cli_commands_utils";
 import { DistManifest, dist_manifest_to_json, empty_dist_manifest } from "./dist_manifest";
 import { ImportSymbolTable, empty_import_symbols } from "./effect_imports";
@@ -51,7 +50,7 @@ import {
 } from "./main";
 import { LayoutManifest } from "./native_ir";
 import { parse_program } from "./parser/mod";
-import { substring } from "./string_utils";
+import { find_char_local, substring } from "./string_utils";
 import {
     TestEntry,
     collect_test_entries,
@@ -78,8 +77,8 @@ fn _is_safe_capsule_segment_cmd(value: string) -> boolean {
     if value.length == 0 { return false; }
     if strings_equal(value, ".") { return false; }
     if strings_equal(value, "..") { return false; }
-    if find_char(value, "/", 0) >= 0 { return false; }
-    if find_char(value, "\\", 0) >= 0 { return false; }
+    if find_char_local(value, "/", 0) >= 0 { return false; }
+    if find_char_local(value, "\\", 0) >= 0 { return false; }
     return true;
 }
 
@@ -88,8 +87,8 @@ fn _is_safe_capsule_version_cmd(value: string) -> boolean {
     if value.length == 0 { return false; }
     if strings_equal(value, ".") { return false; }
     if strings_equal(value, "..") { return false; }
-    if find_char(value, "/", 0) >= 0 { return false; }
-    if find_char(value, "\\", 0) >= 0 { return false; }
+    if find_char_local(value, "/", 0) >= 0 { return false; }
+    if find_char_local(value, "\\", 0) >= 0 { return false; }
     if _string_contains_cmd(value, "..") { return false; }
     return true;
 }
@@ -1293,7 +1292,7 @@ fn handle_publish_command(args: string[]) -> int ![io] {
     if fs.exists(header_tmp) {
         let headers = fs.readFile(header_tmp);
         process.run(["rm", "-f", header_tmp]);
-        let sp = find_char(headers, " ", 0);
+        let sp = find_char_local(headers, " ", 0);
         if sp >= 0 {
             if headers.length >= sp + 4 {
                 status = substring(headers, sp + 1, sp + 4);
@@ -2047,7 +2046,7 @@ fn handle_add_command(args: string[]) -> int ![io] {
     // shell pipeline below when fetching the index, and into the cache path
     // and download URL after. Rejecting path-traversal and directory-separator
     // characters early covers both the shell-injection and traversal risks.
-    let slash_pos = find_char(registry_name, "/", 0);
+    let slash_pos = find_char_local(registry_name, "/", 0);
     if slash_pos < 0 {
         print("invalid capsule id — expected scope/name format: "
             + registry_name);

--- a/compiler/src/string_utils.sfn
+++ b/compiler/src/string_utils.sfn
@@ -70,11 +70,10 @@ fn char_code_at_text(text: string, index: int) -> int {
     return char_code(char_at(text, index));
 }
 
-// Single-byte ASCII character search — intentional subset of prelude find_char.
-// Avoids the stale-seed ABI mismatch (seed registry says find_char→double;
-// prelude defines find_char→int). Does NOT implement prelude's backslash-escape
-// shorthands (e.g. "\\n" → '\n'). Callers must pass the literal character;
-// search targets in toml_parser and lock ("]", "=", " ") require no escaping.
+// Pure-Sailfin reimplementation of prelude find_char. Callers that import
+// this avoid the stale-seed ABI mismatch that occurs when the seed binary's
+// compiled-in registry predates a prelude type flip (number→int). Uses only
+// char_code_at_text, whose registry signature has been stable across seeds.
 fn find_char_local(text: string, ch: string, start: int) -> int {
     if ch.length == 0 { return -1; }
     let needle = char_code_at_text(ch, 0);

--- a/compiler/src/string_utils.sfn
+++ b/compiler/src/string_utils.sfn
@@ -70,10 +70,11 @@ fn char_code_at_text(text: string, index: int) -> int {
     return char_code(char_at(text, index));
 }
 
-// Pure-Sailfin reimplementation of prelude find_char. Callers that import
-// this avoid the stale-seed ABI mismatch that occurs when the seed binary's
-// compiled-in registry predates a prelude type flip (number→int). Uses only
-// char_code_at_text, whose registry signature has been stable across seeds.
+// Single-byte ASCII character search — intentional subset of prelude find_char.
+// Avoids the stale-seed ABI mismatch (seed registry says find_char→double;
+// prelude defines find_char→int). Does NOT implement prelude's backslash-escape
+// shorthands (e.g. "\\n" → '\n'). Callers must pass the literal character;
+// search targets in toml_parser and lock ("]", "=", " ") require no escaping.
 fn find_char_local(text: string, ch: string, start: int) -> int {
     if ch.length == 0 { return -1; }
     let needle = char_code_at_text(ch, 0);


### PR DESCRIPTION
## Summary

- Replaces all 6 `find_char` call sites in `cli_commands.sfn` with `find_char_local` from `string_utils`
- `find_char` (from `cli_commands_utils`) returns `double`; on x86_64, the callee places the return value in `xmm0` but callers expected `i64` in `rax` — causing garbage values to be read
- In `_is_safe_capsule_version_cmd` / `_is_safe_capsule_segment_cmd`, this produced a pointer-like garbage `i64` that, when used as a loop bound, caused an infinite CPU loop in `sfn package`
- `find_char_local` returns `int` (i64), matching caller expectations and eliminating the ABI mismatch

Closes #581

## Acceptance Criteria

- [x] `sfn package` (compiler mode) completes without hanging
- [x] `sfn package -p` (user capsule mode) completes
- [x] All 26 e2e package tests pass
- [x] All 94 unit tests pass
- [x] All 23 integration tests pass
- [x] `sfn fmt --check` passes on modified files

## Verification

```
$ ulimit -v 8388608 && make compile
[rebuild] built build/native/sailfin

$ bash compiler/tests/e2e/test_sfn_package.sh build/native/sailfin
[test] 26 passed, 0 failed

$ make test-unit
═══ unit: 94/94 passed, 0 failed ═══

$ make test-integration
═══ integration: 23/23 passed, 0 failed ═══
```

## Files Changed

- `compiler/src/cli_commands.sfn` — remove `find_char` import, add `find_char_local` import from `string_utils`, replace 6 call sites

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XDg38sahSpKY6fm1A5XKtF)_