### PR TITLE
refactor(numeric): flip native_ir_api + native_ir_utils_parse off `: number` (#582)

### DIFF
--- a/compiler/src/native_ir_api.sfn
+++ b/compiler/src/native_ir_api.sfn
@@ -42,13 +42,13 @@ import {
 
 fn select_text_artifact(artifacts: NativeArtifact[]) -> NativeArtifact? {
     if artifacts == null { return null; }
-    let mut max_items: number = artifacts.length;
+    let mut max_items: int = artifacts.length;
     let mut _if356: boolean = false;
     if max_items != max_items { _if356 = true; }
     if max_items < 0 { _if356 = true; }
     if _if356 { return null; }
     if max_items > 10000 { max_items = 10000; }
-    let mut index: number = 0;
+    let mut index: int = 0;
     loop {
         if index >= max_items { break; }
         let artifact = artifacts[index];
@@ -60,13 +60,13 @@ fn select_text_artifact(artifacts: NativeArtifact[]) -> NativeArtifact? {
 
 fn select_layout_manifest_artifact(artifacts: NativeArtifact[]) -> NativeArtifact? {
     if artifacts == null { return null; }
-    let mut max_items: number = artifacts.length;
+    let mut max_items: int = artifacts.length;
     let mut _if357: boolean = false;
     if max_items != max_items { _if357 = true; }
     if max_items < 0 { _if357 = true; }
     if _if357 { return null; }
     if max_items > 10000 { max_items = 10000; }
-    let mut index: number = 0;
+    let mut index: int = 0;
     loop {
         if index >= max_items { break; }
         let artifact = artifacts[index];
@@ -80,7 +80,7 @@ fn parse_native_artifact(text: string) -> ParseNativeResult {
     return parse_native_artifact_impl(text, true, true);
 }
 
-fn parse_native_function_count_from_text(text: string) -> number {
+fn parse_native_function_count_from_text(text: string) -> int {
     let parsed = parse_native_artifact_impl(text, false, false);
     if parsed.functions == null { return -1; }
     return parsed.functions.length;
@@ -117,7 +117,7 @@ fn parse_native_imports_for_import(text: string) -> NativeImport[] {
     // (llvm/imports.sfn) discards them.
     let lines = split_lines(text);
     let mut imports: NativeImport[] = [];
-    let mut index: number = 0;
+    let mut index: int = 0;
     loop {
         if index >= lines.length { break; }
         let line = trim_text(lines[index]);
@@ -181,7 +181,7 @@ fn parse_layout_manifest(text: string) -> LayoutManifest {
     let mut diagnostics: string[] = [];
     let mut structs: NativeStruct[] = [];
     let mut enums: NativeEnum[] = [];
-    let mut index: number = 0;
+    let mut index: int = 0;
 
     loop {
         if index >= lines.length { break; }
@@ -219,7 +219,7 @@ fn parse_layout_manifest(text: string) -> LayoutManifest {
             let body = strip_prefix(line, ".layout ");
             let struct_header = strip_prefix(body, "struct ");
             let header_result = parse_struct_layout_header(struct_header);
-            let mut _ci: number = 0;
+            let mut _ci: int = 0;
             loop {
                 if _ci >= header_result.diagnostics.length { break; }
                 diagnostics.push(header_result.diagnostics[_ci]);
@@ -262,7 +262,7 @@ fn parse_layout_manifest(text: string) -> LayoutManifest {
                     if is_struct_header { break; }
 
                     let field_result = parse_struct_layout_field(tail, struct_name);
-                    let mut _ci: number = 0;
+                    let mut _ci: int = 0;
                     loop {
                         if _ci >= field_result.diagnostics.length { break; }
                         diagnostics.push(field_result.diagnostics[_ci]);
@@ -295,7 +295,7 @@ fn parse_layout_manifest(text: string) -> LayoutManifest {
             let body = strip_prefix(line, ".layout ");
             let enum_header = strip_prefix(body, "enum ");
             let header_result = parse_enum_layout_header(enum_header);
-            let mut _ci: number = 0;
+            let mut _ci: int = 0;
             loop {
                 if _ci >= header_result.diagnostics.length { break; }
                 diagnostics.push(header_result.diagnostics[_ci]);
@@ -328,7 +328,7 @@ fn parse_layout_manifest(text: string) -> LayoutManifest {
                             continue;
                         }
                         let variant_result = parse_enum_variant_layout(variant_text, enum_name);
-                        let mut _ci: number = 0;
+                        let mut _ci: int = 0;
                         loop {
                             if _ci >= variant_result.diagnostics.length {
                                 break;
@@ -344,7 +344,7 @@ fn parse_layout_manifest(text: string) -> LayoutManifest {
                         let body = strip_prefix(variant_line, ".layout ");
                         let payload_text = strip_prefix(body, "payload ");
                         let payload_result = parse_enum_payload_layout(payload_text, enum_name);
-                        let mut _ci: number = 0;
+                        let mut _ci: int = 0;
                         loop {
                             if _ci >= payload_result.diagnostics.length {
                                 break;

--- a/compiler/src/native_ir_utils_parse.sfn
+++ b/compiler/src/native_ir_utils_parse.sfn
@@ -161,7 +161,7 @@ fn parse_import_specifiers(text: string) -> NativeImportSpecifier[] {
     if trimmed.length == 0 { return []; }
     let entries = split_comma_separated(trimmed);
     let mut specifiers: NativeImportSpecifier[] = [];
-    let mut index: number = 0;
+    let mut index: int = 0;
     loop {
         if index >= entries.length { break; }
         let parsed = parse_single_specifier(entries[index]);
@@ -195,7 +195,7 @@ fn parse_decorator_name(line: string) -> string? {
     let tail = trim_text(strip_prefix(trimmed, ".decorator"));
     if tail.length == 0 { return null; }
     if tail[0] != "@" { return null; }
-    let mut index: number = 1;
+    let mut index: int = 1;
     loop {
         if index >= tail.length { break; }
         let ch = tail[index];
@@ -208,12 +208,12 @@ fn parse_decorator_name(line: string) -> string? {
     return name;
 }
 
-fn parse_interface_definition(lines: string[], start_index: number) -> InterfaceParseResult {
+fn parse_interface_definition(lines: string[], start_index: int) -> InterfaceParseResult {
     let mut diagnostics: string[] = [];
     let header = trim_text(lines[start_index]);
     let name_text = trim_text(strip_prefix(header, ".interface "));
     let header_parse = parse_interface_header(name_text);
-    let mut _ci: number = 0;
+    let mut _ci: int = 0;
     loop {
         if _ci >= header_parse.diagnostics.length { break; }
         diagnostics.push(header_parse.diagnostics[_ci]);
@@ -262,7 +262,7 @@ fn parse_interface_definition(lines: string[], start_index: number) -> Interface
         }
         if starts_with(raw_line, ".sig ") {
             let signature_parse = parse_interface_signature(strip_prefix(raw_line, ".sig "), interface_name);
-            let mut _ci: number = 0;
+            let mut _ci: int = 0;
             loop {
                 if _ci >= signature_parse.diagnostics.length { break; }
                 diagnostics.push(signature_parse.diagnostics[_ci]);
@@ -385,7 +385,7 @@ fn parse_interface_signature(text: string, interface_name: string) -> InterfaceS
 
     let head = trim_text(substring(remainder, 0, paren_index));
     let name_parse = parse_header_name_and_remainder(head);
-    let mut _ci: number = 0;
+    let mut _ci: int = 0;
     loop {
         if _ci >= name_parse.diagnostics.length { break; }
         diagnostics.push(name_parse.diagnostics[_ci]);
@@ -410,7 +410,7 @@ fn parse_interface_signature(text: string, interface_name: string) -> InterfaceS
     let parameter_text = trim_text(parameters_section);
     if parameter_text.length > 0 {
         let entries = split_parameter_entries(parameter_text);
-        let mut entry_index: number = 0;
+        let mut entry_index: int = 0;
         loop {
             if entry_index >= entries.length { break; }
             let parsed = parse_parameter_entry(entries[entry_index], null);
@@ -566,7 +566,7 @@ fn parse_enum_variant_line(text: string) -> NativeEnumVariant? {
     let fields_segment = substring(trimmed, brace_index + 1, close_index);
     let entries = split_enum_field_entries(fields_segment);
     let mut fields: NativeEnumVariantField[] = [];
-    let mut index: number = 0;
+    let mut index: int = 0;
     loop {
         if index >= entries.length { break; }
         let entry = trim_trailing_delimiters(trim_text(entries[index]));
@@ -585,8 +585,8 @@ fn parse_enum_variant_line(text: string) -> NativeEnumVariant? {
 fn split_enum_field_entries(text: string) -> string[] {
     let mut entries: string[] = [];
     let mut current: string = "";
-    let mut depth: number = 0;
-    let mut index: number = 0;
+    let mut depth: int = 0;
+    let mut index: int = 0;
     loop {
         if index >= text.length { break; }
         let ch = text[index];
@@ -627,8 +627,8 @@ fn parse_enum_variant_field(text: string) -> NativeEnumVariantField? {
     }
     let colon_idx = index_of(trimmed, ": ");
     let legacy_arrow_idx = index_of(trimmed, " -> ");
-    let mut arrow_index: number = -1;
-    let mut sep_len: number = 2;
+    let mut arrow_index: int = -1;
+    let mut sep_len: int = 2;
     if colon_idx >= 0 {
         arrow_index = colon_idx;
         sep_len = 2;
@@ -665,8 +665,8 @@ fn parse_struct_field_line(text: string) -> NativeStructField? {
     }
     let colon_idx = index_of(trimmed, ": ");
     let legacy_arrow_idx = index_of(trimmed, " -> ");
-    let mut arrow_index: number = -1;
-    let mut sep_len: number = 2;
+    let mut arrow_index: int = -1;
+    let mut sep_len: int = 2;
     if colon_idx >= 0 {
         arrow_index = colon_idx;
         sep_len = 2;
@@ -714,7 +714,7 @@ fn parse_let_instruction(line: string, span: NativeSourceSpan?, value_span: Nati
 
 fn parse_binding_components(text: string) -> BindingComponents {
     let mut name: string = "";
-    let mut index: number = 0;
+    let mut index: int = 0;
     loop {
         if index >= text.length { break; }
         let ch = text[index];
@@ -788,7 +788,7 @@ fn parse_parameter_entry(body: string, span: NativeSourceSpan?) -> NativeParamet
         trimmed = trim_text(strip_prefix(trimmed, "mut "));
     }
     let mut name: string = "";
-    let mut index: number = 0;
+    let mut index: int = 0;
     loop {
         if index >= trimmed.length { break; }
         let ch = trimmed[index];
@@ -846,7 +846,7 @@ fn line_looks_like_parameter_entry(text: string) -> boolean {
     if starts_with(trimmed, ";") { return false; }
     let arrow_index = index_of(trimmed, "->");
     let colon_index = index_of(trimmed, ":");
-    let mut sep_index: number = -1;
+    let mut sep_index: int = -1;
     if colon_index >= 0 { sep_index = colon_index; }
     if arrow_index >= 0 {
         if sep_index < 0 { sep_index = arrow_index; } else if arrow_index < sep_index {
@@ -882,8 +882,8 @@ fn line_looks_like_parameter_entry(text: string) -> boolean {
 fn split_parameter_entries(body: string) -> string[] {
     let mut entries: string[] = [];
     let mut current: string = "";
-    let mut index: number = 0;
-    let mut depth: number = 0;
+    let mut index: int = 0;
+    let mut depth: int = 0;
     let mut quote: string = "";
 
     loop {


### PR DESCRIPTION
## Summary

Slice E.3a-bulk-1b child 3 — flips the residual `: number` → `: int` sites in the `native_ir_api` / `native_ir_utils_parse` cluster. Scope was shrunk by PR #588's broader sweep from 4 files to 2 files (~31 sites).

- `native_ir_api.sfn` (12 sites): `parse_native_function_count_from_text` return type plus loop indices, `max_items`, and diagnostic-copy counters.
- `native_ir_utils_parse.sfn` (19 sites): `parse_interface_definition` `start_index` parameter plus loop indices, depths, separator lengths, and diagnostic-copy counters.

All sites describe counts, positions, or separator lengths — disposition `int` per `docs/proposals/slice-e3a-semantic-audit.md`. No `: float` sites in this cluster.

Closes #582

## Acceptance Criteria

- [x] All `: number` / `-> number` sites in the listed files flip to `: int` (no `: float` in this slice; no `// alias-coverage` rows in scope).
- [x] `make compile` self-hosts on top of merged #580 (PR #587) + #581 (PRs #588/#595).
- [x] `make test` passes (unit + integration + e2e + capsules).
- [x] `sfn fmt --check` clean on changed files (full-tree `fmt` is unaffected by this PR — it OOMs under the 8GB cap on `stage2-native string_concat`, a pre-existing issue, not introduced here).
- [x] `clang -O2 -c build/sailfin/capsules/token.ll -o /tmp/token.o` succeeds — the #578 OOM failure mode stays absent.
- [x] `build/native/sailfin run examples/basics/hello-world.sfn` prints cleanly (no `bounds_check failed: index=-9223372036854775808`).
- [x] Audit grep across the 4 cluster files returns zero non-alias-coverage matches.

## Verification

```bash
ulimit -v 8388608
make compile                                                    # ✓ built build/native/sailfin
make test                                                       # ✓ all suites pass (56/56 e2e, 10/10 capsules)
build/native/sailfin fmt --check \
    compiler/src/native_ir_api.sfn \
    compiler/src/native_ir_utils_parse.sfn                      # ✓ clean

clang -O2 -c build/sailfin/capsules/token.ll -o /tmp/token.o    # ✓ OK
build/native/sailfin run examples/basics/hello-world.sfn        # ✓ "Hello, Sailfin!"

grep -nE "(: number|-> number)" \
    compiler/src/native_ir.sfn \
    compiler/src/native_ir_api.sfn \
    compiler/src/native_ir_utils_parse.sfn \
    compiler/src/native_ir_utils_text.sfn \
  | grep -v "// alias-coverage"                                 # ✓ zero matches
```

## Files Changed

- `compiler/src/native_ir_api.sfn` (12 sites)
- `compiler/src/native_ir_utils_parse.sfn` (19 sites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_012PAfAjCkPuayCPqrNH1CzB)_