### PR TITLE
refactor(numeric): flip emit_native + emitter_sailfin clusters off `: number`

### DIFF
--- a/compiler/src/emit_native.sfn
+++ b/compiler/src/emit_native.sfn
@@ -97,7 +97,7 @@ fn emit_native_with_module_name(program: Program, module_name: string) -> EmitNa
     state = state_emit_line(state, module_line);
     if program.statements.length > 0 { state = state_emit_blank(state); }
 
-    let mut index: number = 0;
+    let mut index: int = 0;
     loop {
         if index >= program.statements.length { break; }
         state = emit_statement(state, program.statements[index]);
@@ -141,7 +141,7 @@ fn emit_native_text_with_module_name(program: Program, module_name: string) -> s
     state = state_emit_line(state, module_line);
     if program.statements.length > 0 { state = state_emit_blank(state); }
 
-    let mut index: number = 0;
+    let mut index: int = 0;
     loop {
         if index >= program.statements.length { break; }
         state = emit_statement(state, program.statements[index]);
@@ -421,7 +421,7 @@ fn emit_interface(state: NativeState, statement: Statement) -> NativeState {
     header = header + format_type_parameters(statement.type_parameters);
     current = state_emit_line(current, header);
     current = state_push_indent(current);
-    let mut index: number = 0;
+    let mut index: int = 0;
     loop {
         if index >= statement.members.length { break; }
         let signature = statement.members[index];
@@ -444,7 +444,7 @@ fn emit_enum(state: NativeState, statement: Statement) -> NativeState {
     current = emit_layout_lines(current, enum_layout.lines);
     current = state_push_indent(current);
     current = state_merge_diagnostics(current, enum_layout.diagnostics);
-    let mut index: number = 0;
+    let mut index: int = 0;
     loop {
         if index >= statement.variants.length { break; }
         current = state_emit_line(current, ".variant " + format_enum_variant(statement.variants[index]));
@@ -470,14 +470,14 @@ fn emit_struct(state: NativeState, statement: Statement) -> NativeState {
     current = state_push_indent(current);
     current = state_merge_diagnostics(current, struct_layout.diagnostics);
 
-    let mut index: number = 0;
+    let mut index: int = 0;
     loop {
         if index >= statement.fields.length { break; }
         current = state_emit_line(current, ".field " + format_field(statement.fields[index]));
         index += 1;
     }
 
-    let mut method_index: number = 0;
+    let mut method_index: int = 0;
     loop {
         if method_index >= statement.methods.length { break; }
         current = emit_method(current, statement.methods[method_index]);
@@ -508,7 +508,7 @@ fn emit_method(state: NativeState, method: MethodDeclaration) -> NativeState {
 fn emit_with(state: NativeState, statement: Statement) -> NativeState {
     let mut current = emit_decorators(state, statement.decorators);
     let mut line: string = ".with ";
-    let mut index: number = 0;
+    let mut index: int = 0;
     loop {
         if index >= statement.clauses.length { break; }
         if index > 0 { line = line + ", "; }
@@ -546,7 +546,7 @@ fn emit_match(state: NativeState, statement: Statement) -> NativeState {
     let mut current = emit_decorators(state, statement.decorators);
     current = state_emit_line(current, ".match " + format_expression(statement.expression));
     current = state_push_indent(current);
-    let mut index: number = 0;
+    let mut index: int = 0;
     loop {
         if index >= statement.cases.length { break; }
         current = emit_match_case(current, statement.cases[index]);
@@ -629,7 +629,7 @@ fn emit_block(state: NativeState, block: Block) -> NativeState {
         return state_emit_line(state, "noop");
     }
     let mut current = state;
-    let mut index: number = 0;
+    let mut index: int = 0;
     loop {
         if index >= block.statements.length { break; }
         current = emit_statement(current, block.statements[index]);
@@ -640,7 +640,7 @@ fn emit_block(state: NativeState, block: Block) -> NativeState {
 
 fn emit_decorators(state: NativeState, decorators: Decorator[]) -> NativeState {
     let mut current = state;
-    let mut index: number = 0;
+    let mut index: int = 0;
     loop {
         if index >= decorators.length { break; }
         current = state_emit_line(current, ".decorator " + format_decorator(decorators[index]));
@@ -667,7 +667,7 @@ fn emit_signature_metadata(state: NativeState, signature: FunctionSignature) -> 
 
 fn emit_parameter_metadata(state: NativeState, parameters: Parameter[]) -> NativeState {
     let mut current = state;
-    let mut index: number = 0;
+    let mut index: int = 0;
     loop {
         if index >= parameters.length { break; }
         let parameter = parameters[index];
@@ -690,7 +690,7 @@ fn emit_parameter_metadata(state: NativeState, parameters: Parameter[]) -> Nativ
 // ── Symbol helpers ───────────────────────────────────────────────────
 fn collect_entry_points(program: Program) -> string[] {
     let mut entries: string[] = [];
-    let mut index: number = 0;
+    let mut index: int = 0;
     loop {
         if index >= program.statements.length { break; }
         let statement = program.statements[index];
@@ -730,7 +730,7 @@ fn is_test_symbol_char(ch: string) -> boolean {
 fn sanitize_test_name_for_symbol(name: string) -> string {
     if name.length == 0 { return "unnamed"; }
     let mut out: string = "";
-    let mut index: number = 0;
+    let mut index: int = 0;
     loop {
         if index >= name.length { break; }
         let ch = name[index];
@@ -755,7 +755,7 @@ fn test_function_symbol(test_name: string) -> string {
 
 fn count_exported_symbols(program: Program) -> int {
     let mut count: int = 0;
-    let mut index: number = 0;
+    let mut index: int = 0;
     loop {
         if index >= program.statements.length { break; }
         let stmt = program.statements[index];
@@ -787,13 +787,13 @@ fn count_exported_symbols(program: Program) -> int {
 fn collect_reexport_violations(program: Program) -> string[] {
     let local_defs = collect_local_definition_names(program);
     let mut violations: string[] = [];
-    let mut index: number = 0;
+    let mut index: int = 0;
     loop {
         if index >= program.statements.length { break; }
         let statement = program.statements[index];
         if statement.variant == "ExportDeclaration" {
             if statement.source.length == 0 {
-                let mut spec_index: number = 0;
+                let mut spec_index: int = 0;
                 loop {
                     if spec_index >= statement.export_specifiers.length {
                         break;
@@ -818,7 +818,7 @@ fn collect_reexport_violations(program: Program) -> string[] {
 
 fn collect_local_definition_names(program: Program) -> string[] {
     let mut names: string[] = [];
-    let mut index: number = 0;
+    let mut index: int = 0;
     loop {
         if index >= program.statements.length { break; }
         let stmt = program.statements[index];
@@ -856,12 +856,12 @@ fn collect_local_definition_names(program: Program) -> string[] {
 // otherwise the original name).  Returns "" if no matching import is
 // found.
 fn find_local_import_source(program: Program, name: string) -> string {
-    let mut index: number = 0;
+    let mut index: int = 0;
     loop {
         if index >= program.statements.length { break; }
         let stmt = program.statements[index];
         if stmt.variant == "ImportDeclaration" {
-            let mut spec_index: number = 0;
+            let mut spec_index: int = 0;
             loop {
                 if spec_index >= stmt.import_specifiers.length { break; }
                 let spec = stmt.import_specifiers[spec_index];
@@ -912,7 +912,7 @@ fn format_reexport_violation(symbol: string, origin: string) -> string {
 }
 
 fn report_reexport_violations(violations: string[]) ![io] {
-    let mut index: number = 0;
+    let mut index: int = 0;
     loop {
         if index >= violations.length { break; }
         print.err("[emit-native] " + violations[index]);

--- a/compiler/src/emit_native_format.sfn
+++ b/compiler/src/emit_native_format.sfn
@@ -74,7 +74,7 @@ fn format_expression(expression: Expression) -> string {
     }
     if expression.variant == "Call" {
         let mut rendered: string[] = [];
-        let mut index: number = 0;
+        let mut index: int = 0;
         loop {
             if index >= expression.arguments.length { break; }
             rendered.push(format_expression(expression.arguments[index]));
@@ -92,7 +92,7 @@ fn format_expression(expression: Expression) -> string {
     }
     if expression.variant == "Object" {
         let mut rendered: string[] = [];
-        let mut index: number = 0;
+        let mut index: int = 0;
         loop {
             if index >= expression.fields.length { break; }
             let field = expression.fields[index];
@@ -103,7 +103,7 @@ fn format_expression(expression: Expression) -> string {
     }
     if expression.variant == "Struct" {
         let mut rendered: string[] = [];
-        let mut index: number = 0;
+        let mut index: int = 0;
         loop {
             if index >= expression.fields.length { break; }
             let field = expression.fields[index];
@@ -135,7 +135,7 @@ fn format_expression(expression: Expression) -> string {
         // Multi-line expressions cause null array literals in the LLVM
         // lowering due to instruction gathering issues in the compiled binary.
         let mut normalized: string = "";
-        let mut ri: number = 0;
+        let mut ri: int = 0;
         loop {
             if ri >= raw_text.length { break; }
             let rch = raw_text[ri];
@@ -155,7 +155,7 @@ fn format_expression(expression: Expression) -> string {
 fn format_array_expression(elements: Expression[]) -> string {
     let annotation = infer_array_element_type(elements);
     let mut rendered: string[] = [];
-    let mut index: number = 0;
+    let mut index: int = 0;
     loop {
         if index >= elements.length { break; }
         rendered.push(format_expression(elements[index]));
@@ -173,7 +173,7 @@ fn format_array_expression(elements: Expression[]) -> string {
 fn infer_array_element_type(elements: Expression[]) -> string {
     if elements.length == 0 { return ""; }
     let mut candidate: string = "";
-    let mut index: number = 0;
+    let mut index: int = 0;
     loop {
         if index >= elements.length { break; }
         let element_type = infer_expression_type(elements[index]);
@@ -250,7 +250,7 @@ fn format_function_signature(signature: FunctionSignature) -> string {
 fn format_parameters(parameters: Parameter[]) -> string {
     if parameters.length == 0 { return ""; }
     let mut parts: string[] = [];
-    let mut index: number = 0;
+    let mut index: int = 0;
     loop {
         if index >= parameters.length { break; }
         let parameter = parameters[index];
@@ -273,7 +273,7 @@ fn format_parameters(parameters: Parameter[]) -> string {
 fn format_type_parameters(parameters: TypeParameter[]) -> string {
     if parameters.length == 0 { return ""; }
     let mut parts: string[] = [];
-    let mut index: number = 0;
+    let mut index: int = 0;
     loop {
         if index >= parameters.length { break; }
         let parameter = parameters[index];
@@ -298,7 +298,7 @@ fn format_field(field: FieldDeclaration) -> string {
 fn format_enum_variant(variant: EnumVariant) -> string {
     if variant.fields.length == 0 { return variant.name; }
     let mut parts: string[] = [];
-    let mut index: number = 0;
+    let mut index: int = 0;
     loop {
         if index >= variant.fields.length { break; }
         parts.push(format_field(variant.fields[index]));
@@ -312,7 +312,7 @@ fn format_decorator(decorator: Decorator) -> string {
     let mut line: string = "@" + decorator.name;
     if decorator.arguments.length == 0 { return line; }
     let mut parts: string[] = [];
-    let mut index: number = 0;
+    let mut index: int = 0;
     loop {
         if index >= decorator.arguments.length { break; }
         let argument = decorator.arguments[index];
@@ -345,7 +345,7 @@ fn format_native_specifier(name: string, alias: string?) -> string {
 
 fn render_native_specifiers(specifiers: ImportSpecifier[]) -> string {
     let mut parts: string[] = [];
-    let mut index: number = 0;
+    let mut index: int = 0;
     loop {
         if index >= specifiers.length { break; }
         parts.push(format_native_specifier(specifiers[index].name, specifiers[index].alias));
@@ -356,7 +356,7 @@ fn render_native_specifiers(specifiers: ImportSpecifier[]) -> string {
 
 fn render_export_specifiers(specifiers: ExportSpecifier[]) -> string {
     let mut parts: string[] = [];
-    let mut index: number = 0;
+    let mut index: int = 0;
     loop {
         if index >= specifiers.length { break; }
         parts.push(format_native_specifier(specifiers[index].name, specifiers[index].alias));

--- a/compiler/src/emit_native_state.sfn
+++ b/compiler/src/emit_native_state.sfn
@@ -57,7 +57,7 @@ fn builder_new() -> TextBuilder {
 
 fn builder_emit_line(builder: TextBuilder, line: string) -> TextBuilder {
     let mut prefix: string = "";
-    let mut count: number = 0;
+    let mut count: int = 0;
     loop {
         if count >= builder.indent { break; }
         prefix = prefix + "    ";
@@ -146,7 +146,7 @@ fn state_add_diagnostic(state: NativeState, message: string) -> NativeState {
 fn state_merge_diagnostics(state: NativeState, entries: string[]) -> NativeState {
     if entries.length == 0 { return state; }
     let mut combined: string[] = state.diagnostics;
-    let mut index: number = 0;
+    let mut index: int = 0;
     loop {
         if index >= entries.length { break; }
         combined.push(entries[index]);
@@ -161,8 +161,8 @@ fn state_merge_diagnostics(state: NativeState, entries: string[]) -> NativeState
 
 // ── String / array utility functions ─────────────────────────────────
 fn trim_text(value: string) -> string {
-    let mut start: number = 0;
-    let mut end: number = value.length;
+    let mut start: int = 0;
+    let mut end: int = value.length;
     loop {
         if start >= end { break; }
         let ch = value[start];
@@ -197,7 +197,7 @@ fn is_trim_char(ch: string) -> boolean {
 }
 
 fn trim_right(value: string) -> string {
-    let mut end: number = value.length;
+    let mut end: int = value.length;
     loop {
         if end <= 0 { break; }
         let ch = value[end - 1];
@@ -214,15 +214,15 @@ fn trim_right(value: string) -> string {
     return substring(value, 0, end);
 }
 
-fn number_to_string(value: number) -> string {
+fn number_to_string(value: number) -> string {  // alias-coverage: seed-ABI constraint — seed binary generated declare double for this name; flip in lockstep with seed bump (Slice E.3a follow-up)
     if value == 0 { return "0"; }
-    let mut remaining: number = value;
+    let mut remaining: number = value;  // alias-coverage: seed-ABI constraint
     let mut output: string = "";
     let digits = "0123456789";
     loop {
         if remaining <= 0 { break; }
-        let mut temp: number = remaining;
-        let mut quotient: number = 0;
+        let mut temp: number = remaining;  // alias-coverage: seed-ABI constraint
+        let mut quotient: number = 0;  // alias-coverage: seed-ABI constraint
         loop {
             if temp < 10 { break; }
             temp -= 10;
@@ -243,8 +243,8 @@ fn quote_string(value: string) -> string {
     // calls this on every string literal in the .sfn-asm output, so a few
     // long literals would blow the seedcheck memory cap.
     let mut chunks: string[] = ["\""];
-    let mut chunk_start: number = 0;
-    let mut index: number = 0;
+    let mut chunk_start: int = 0;
+    let mut index: int = 0;
     loop {
         if index >= value.length { break; }
         let ch = substring(value, index, index + 1);
@@ -268,7 +268,7 @@ fn quote_string(value: string) -> string {
     }
     chunks.push("\"");
     let mut result: string = chunks[0];
-    let mut i: number = 1;
+    let mut i: int = 1;
     loop {
         if i >= chunks.length { break; }
         result = result + chunks[i];
@@ -297,7 +297,7 @@ fn join_with_separator(values: string[], separator: string) -> string {
     if values == null { return ""; }
     if values.length == 0 { return ""; }
     let mut result: string = values[0];
-    let mut index: number = 1;
+    let mut index: int = 1;
     loop {
         if index >= values.length { break; }
         result = result + separator + values[index];
@@ -309,7 +309,7 @@ fn join_with_separator(values: string[], separator: string) -> string {
 fn join_type_annotations(values: TypeAnnotation[]) -> string {
     if values.length == 0 { return ""; }
     let mut parts: string[] = [];
-    let mut index: number = 0;
+    let mut index: int = 0;
     loop {
         if index >= values.length { break; }
         parts.push(values[index].text);

--- a/compiler/src/emitter_sailfin.sfn
+++ b/compiler/src/emitter_sailfin.sfn
@@ -67,7 +67,7 @@ fn emit_program(program: Program) -> string {
     // Ensure the emitted program can reference the runtime, but avoid duplicating
     // the import when we roundtrip an already-emitted module.
     let mut has_runtime_import: boolean = false;
-    let mut scan: number = 0;
+    let mut scan: int = 0;
     loop {
         if scan >= program.statements.length { break; }
         let statement = program.statements[scan];
@@ -87,7 +87,7 @@ fn emit_program(program: Program) -> string {
         builder = builder_emit_line(builder, "import() from \"sailfin/runtime\";");
     }
 
-    let mut index: number = 0;
+    let mut index: int = 0;
     loop {
         if index >= program.statements.length { break; }
 
@@ -198,7 +198,7 @@ fn emit_test(builder: TextBuilder, statement: Statement) -> TextBuilder {
 
 fn format_import_specifiers(specifiers: ImportSpecifier[]) -> string {
     let mut parts: string[] = [];
-    let mut index: number = 0;
+    let mut index: int = 0;
     loop {
         if index >= specifiers.length { break; }
         let entry = format_specifier_entry(specifiers[index].name, specifiers[index].alias);
@@ -210,7 +210,7 @@ fn format_import_specifiers(specifiers: ImportSpecifier[]) -> string {
 
 fn format_export_specifiers(specifiers: ExportSpecifier[]) -> string {
     let mut parts: string[] = [];
-    let mut index: number = 0;
+    let mut index: int = 0;
     loop {
         if index >= specifiers.length { break; }
         let entry = format_specifier_entry(specifiers[index].name, specifiers[index].alias);
@@ -241,7 +241,7 @@ fn emit_interface(builder: TextBuilder, statement: Statement) -> TextBuilder {
     header = header + format_type_parameters(statement.type_parameters);
     current = builder_emit_line(current, header);
     current = emit_block_start(current);
-    let mut index: number = 0;
+    let mut index: int = 0;
     loop {
         if index >= statement.members.length { break; }
         let signature = statement.members[index];
@@ -258,7 +258,7 @@ fn emit_enum(builder: TextBuilder, statement: Statement) -> TextBuilder {
     let mut header: string = "enum " + statement.name;
     header = header + format_type_parameters(statement.type_parameters);
     current = emit_block_header(current, header);
-    let mut index: number = 0;
+    let mut index: int = 0;
     loop {
         if index >= statement.variants.length { break; }
         let variant = statement.variants[index];
@@ -278,7 +278,7 @@ fn emit_struct(builder: TextBuilder, statement: Statement) -> TextBuilder {
     }
     current = emit_block_header(current, header);
 
-    let mut field_index: number = 0;
+    let mut field_index: int = 0;
     loop {
         if field_index >= statement.fields.length { break; }
         current = builder_emit_line(current, format_field(statement.fields[field_index])
@@ -286,7 +286,7 @@ fn emit_struct(builder: TextBuilder, statement: Statement) -> TextBuilder {
         field_index += 1;
     }
 
-    let mut method_index: number = 0;
+    let mut method_index: int = 0;
     loop {
         if method_index >= statement.methods.length { break; }
         let method = statement.methods[method_index];
@@ -326,7 +326,7 @@ fn emit_block_body(builder: TextBuilder, block: Block) -> TextBuilder {
     }
 
     let mut current = builder;
-    let mut index: number = 0;
+    let mut index: int = 0;
     loop {
         if index >= block.statements.length { break; }
         current = emit_block_statement(current, block.statements[index]);
@@ -392,7 +392,7 @@ fn emit_block_statement(builder: TextBuilder, statement: Statement) -> TextBuild
 fn emit_with(builder: TextBuilder, statement: Statement) -> TextBuilder {
     let mut current = emit_decorators(builder, statement.decorators);
     let mut line: string = "with ";
-    let mut index: number = 0;
+    let mut index: int = 0;
     loop {
         if index >= statement.clauses.length { break; }
         if index > 0 { line = line + ", "; }
@@ -440,7 +440,7 @@ fn emit_match(builder: TextBuilder, statement: Statement) -> TextBuilder {
     let mut current = emit_decorators(builder, statement.decorators);
     let header = "match " + format_expression(statement.expression);
     current = emit_block_header(current, header);
-    let mut index: number = 0;
+    let mut index: int = 0;
     loop {
         if index >= statement.cases.length { break; }
         current = emit_match_case(current, statement.cases[index]);
@@ -493,7 +493,7 @@ fn emit_decorators_then_line(builder: TextBuilder, decorators: Decorator[], line
 
 fn emit_decorators(builder: TextBuilder, decorators: Decorator[]) -> TextBuilder {
     let mut current = builder;
-    let mut index: number = 0;
+    let mut index: int = 0;
     loop {
         if index >= decorators.length { break; }
         current = builder_emit_line(current, format_decorator(decorators[index]));
@@ -506,7 +506,7 @@ fn format_decorator(decorator: Decorator) -> string {
     let mut line: string = "@" + decorator.name;
     if decorator.arguments.length == 0 { return line; }
     let mut parts: string[] = [];
-    let mut index: number = 0;
+    let mut index: int = 0;
     loop {
         if index >= decorator.arguments.length { break; }
         parts.push(format_decorator_argument(decorator.arguments[index]));
@@ -564,7 +564,7 @@ fn format_field(field: FieldDeclaration) -> string {
 fn format_enum_variant(variant: EnumVariant) -> string {
     if variant.fields.length == 0 { return variant.name; }
     let mut parts: string[] = [];
-    let mut index: number = 0;
+    let mut index: int = 0;
     loop {
         if index >= variant.fields.length { break; }
         parts.push(format_field(variant.fields[index]));
@@ -576,7 +576,7 @@ fn format_enum_variant(variant: EnumVariant) -> string {
 fn format_parameters(parameters: Parameter[]) -> string {
     if parameters.length == 0 { return ""; }
     let mut parts: string[] = [];
-    let mut index: number = 0;
+    let mut index: int = 0;
     loop {
         if index >= parameters.length { break; }
         parts.push(format_parameter(parameters[index]));
@@ -602,7 +602,7 @@ fn format_parameter(parameter: Parameter) -> string {
 fn format_type_parameters(parameters: TypeParameter[]) -> string {
     if parameters.length == 0 { return ""; }
     let mut names: string[] = [];
-    let mut index: number = 0;
+    let mut index: int = 0;
     loop {
         if index >= parameters.length { break; }
         let parameter = parameters[index];
@@ -624,7 +624,7 @@ fn format_effects(effects: string[]) -> string {
 fn join_type_annotations(values: TypeAnnotation[]) -> string {
     if values.length == 0 { return ""; }
     let mut parts: string[] = [];
-    let mut index: number = 0;
+    let mut index: int = 0;
     loop {
         if index >= values.length { break; }
         parts.push(values[index].text);

--- a/compiler/src/emitter_sailfin_expr.sfn
+++ b/compiler/src/emitter_sailfin_expr.sfn
@@ -63,7 +63,7 @@ fn format_expression(expression: Expression) -> string {
     }
     if expression.variant == "Call" {
         let mut rendered: string[] = [];
-        let mut index: number = 0;
+        let mut index: int = 0;
         loop {
             if index >= expression.arguments.length { break; }
             rendered.push(format_expression(expression.arguments[index]));
@@ -79,7 +79,7 @@ fn format_expression(expression: Expression) -> string {
     }
     if expression.variant == "Array" {
         let mut rendered: string[] = [];
-        let mut index: number = 0;
+        let mut index: int = 0;
         loop {
             if index >= expression.elements.length { break; }
             rendered.push(format_expression(expression.elements[index]));
@@ -90,7 +90,7 @@ fn format_expression(expression: Expression) -> string {
     }
     if expression.variant == "Object" {
         let mut rendered: string[] = [];
-        let mut index: number = 0;
+        let mut index: int = 0;
         loop {
             if index >= expression.fields.length { break; }
             let field = expression.fields[index];
@@ -104,7 +104,7 @@ fn format_expression(expression: Expression) -> string {
     if expression.variant == "Struct" {
         let type_name = join_with_separator(expression.type_name, ".");
         let mut rendered: string[] = [];
-        let mut index: number = 0;
+        let mut index: int = 0;
         loop {
             if index >= expression.fields.length { break; }
             let field = expression.fields[index];
@@ -152,7 +152,7 @@ fn format_lambda_expression(expression: Expression) -> string {
 
 fn format_lambda_parameters(parameters: Parameter[]) -> string {
     let mut rendered: string[] = [];
-    let mut index: number = 0;
+    let mut index: int = 0;
     loop {
         if index >= parameters.length { break; }
         let param = parameters[index];
@@ -168,7 +168,7 @@ fn format_lambda_parameters(parameters: Parameter[]) -> string {
 fn format_lambda_body(body: Block) -> string {
     let mut lines: string[] = [];
     if body.statements.length == 0 { lines.push("// empty body"); } else {
-        let mut index: number = 0;
+        let mut index: int = 0;
         loop {
             if index >= body.statements.length { break; }
             lines.push(format_lambda_statement(body.statements[index]));
@@ -203,13 +203,13 @@ fn format_lambda_statement(statement: Statement) -> string {
     return "// TODO: unsupported lambda statement: " + statement.variant;
 }
 
-fn indent_lines(lines: string[], depth: number) -> string[] {
+fn indent_lines(lines: string[], depth: int) -> string[] {
     let mut result: string[] = [];
-    let mut index: number = 0;
+    let mut index: int = 0;
     loop {
         if index >= lines.length { break; }
         let mut prefix: string = "";
-        let mut count: number = 0;
+        let mut count: int = 0;
         loop {
             if count >= depth { break; }
             prefix = prefix + "    ";


### PR DESCRIPTION
## Summary

- Flips 67 `: number` sites to `: int` across `emit_native.sfn` (20), `emit_native_format.sfn` (12), `emit_native_state.sfn` (13), `emitter_sailfin.sfn` (17), and `emitter_sailfin_expr.sfn` (9). All sites are integer loop counters, indices, and offsets.
- Keeps `emit_native_state.sfn::number_to_string(value: number) -> string` and its local `remaining` / `temp` / `quotient` declarations on `: number` under the same `// alias-coverage: seed-ABI constraint` carve-out as `compiler/src/llvm/utils.sfn:131::number_to_string`. See the "Surprise" note below.
- `emit_native_layout.sfn` and `emitter_sailfin_utils.sfn` had zero `: number` sites after rebase on #582 / #601 — no edits needed.

Closes #583

## Acceptance Criteria

- [x] All `: number` / `-> number` sites in the seven listed files flip to `: int`, except `// alias-coverage` rows.
- [x] `make compile` self-hosts on top of merged #580 + #581 + #582.
- [x] `make test` passes (95/95 unit, 23/23 integration, 56/56 e2e, 10/10 capsules).
- [x] `sfn fmt --check` clean (touched files + `compiler/`).
- [x] `clang -O2 -c build/sailfin/capsules/token.ll -o /tmp/token.o` succeeds.
- [x] `ulimit -v 8388608 && timeout 30 build/native/sailfin run examples/basics/hello-world.sfn` prints the example output (`Hello, Sailfin!` — the issue's "Hello, world!" wording is a typo in the issue body; the actual `examples/basics/hello-world.sfn` source prints "Hello, Sailfin!").
- [x] Audit grep produces zero output (excluding `// alias-coverage` rows).

## Verification

```bash
$ grep -nE "(: number|-> number)" \
    compiler/src/emit_native.sfn \
    compiler/src/emit_native_format.sfn \
    compiler/src/emit_native_state.sfn \
    compiler/src/emit_native_layout.sfn \
    compiler/src/emitter_sailfin.sfn \
    compiler/src/emitter_sailfin_expr.sfn \
    compiler/src/emitter_sailfin_utils.sfn \
    | grep -v "// alias-coverage"
# (no output)

$ ulimit -v 8388608 && make compile
[compile] built build/native/sailfin

$ ulimit -v 8388608 && make test
═══ unit:        95/95 passed, 0 failed ═══
═══ integration: 23/23 passed, 0 failed ═══
═══ e2e:         56/56 passed, 0 failed ═══
═══ capsules:    10/10 passed, 0 failed ═══

$ ulimit -v 8388608 && build/native/sailfin fmt --check compiler/
# clean

$ clang -O2 -c build/sailfin/capsules/token.ll -o /tmp/token.o
warning: overriding the module target triple with x86_64-pc-linux-gnu [-Woverride-module]
1 warning generated.   # benign

$ ulimit -v 8388608 && timeout 30 build/native/sailfin run examples/basics/hello-world.sfn
Hello, Sailfin!
```

## Files Changed

- `compiler/src/emit_native.sfn`
- `compiler/src/emit_native_format.sfn`
- `compiler/src/emit_native_state.sfn`
- `compiler/src/emitter_sailfin.sfn`
- `compiler/src/emitter_sailfin_expr.sfn`

## Surprise — worth recording for future grooming

The issue's `## Required in pinned seed` section said "None. Alias-equivalent under #550's warning regime; parent #579 is not a seed-blocker." That is *almost* correct, but the audit missed one row: `emit_native_state.sfn::number_to_string`. The pinned seed (`v0.5.10-alpha.18`) hard-codes the calling convention for every function literally named `number_to_string`, regardless of module — it emits `declare i8* @number_to_string__<module>(double)` for every cross-module call site. Flipping the parameter to `: int` produces a definition with `i64 %value` while every importer keeps calling it with `double`, and the receiver reads garbage out of the FP register.

Concrete failure mode before the alias-coverage carve-out went in:

- `emit_native_format.sfn` (caller, compiled by seed) generated `call i8* @number_to_string__emit_native_state(double %t2)`.
- `emit_native_state.sfn` (callee, compiled by seed against my flipped signature) generated `define i8* @number_to_string__emit_native_state(i64 %value)`.
- At runtime, `i64 %value` was loaded from `XMM0` instead of `RDI`, so e.g. the enum-payload-size accumulator in `compiler/src/llvm/rendering.sfn::550` received a stale pointer (~`0x55b…`), which then propagated into `%TokenKind = type { i32, [5887720753463 x i128] }` in every downstream `.ll` and crashed clang's instruction selector with `LLVM ERROR: out of memory` (the SelectionDAG was asked to materialize an array type 94T elements long).

I matched the precedent in `compiler/src/llvm/utils.sfn:131` exactly — same comment text, same per-row coverage on `value` and on `remaining` / `temp` / `quotient`. Once the seed is bumped past whatever release fixes the symbol-name-to-ABI mapping, both `number_to_string` definitions (here and in `llvm/utils.sfn`) can flip together. Recommend flagging that lockstep in the next `Required in pinned seed` row for whichever Slice E.3a follow-up tackles the remaining alias-coverage rows.

The second function-signature flip in scope — `emitter_sailfin_expr.sfn::indent_lines(lines, depth: int)` — is *not* affected, because the symbol is not in the seed's hard-coded ABI table; the seed correctly emits `declare ... @indent_lines__emitter_sailfin_expr(..., i64)` matching the new signature. Confirmed by inspecting `build/sailfin/capsules/emitter_sailfin_expr.ll`.

Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gf9doXiXBuYpoQGyYyXgom)_