### PR TITLE
refactor(numeric): flip effect_* cluster off `: number`

### DIFF
--- a/compiler/src/effect_checker.sfn
+++ b/compiler/src/effect_checker.sfn
@@ -185,7 +185,7 @@ fn validate_effects(program: Program) -> EffectViolation[] {
 fn validate_effects_with_imports(program: Program, imports: ImportSymbolTable) -> EffectViolation[] {
     let local_imports = localize_import_symbols_for_program(program, imports);
     let mut violations: EffectViolation[] = [];
-    let mut index: number = 0;
+    let mut index: int = 0;
     loop {
         if index >= program.statements.length { break; }
         violations = append_violations(violations, analyze_statement(program.statements[index], local_imports));
@@ -214,7 +214,7 @@ fn validate_effects_with_imports(program: Program, imports: ImportSymbolTable) -
 fn validate_capsule_capabilities(program: Program, capabilities_required: string[]) -> CapabilityViolation[] {
     let mut violations: CapabilityViolation[] = [];
     if capabilities_required.length == 0 { return violations; }
-    let mut index: number = 0;
+    let mut index: int = 0;
     loop {
         if index >= program.statements.length { break; }
         violations = _append_capability_violations(violations, _analyze_statement_capabilities(program.statements[index], capabilities_required));
@@ -247,7 +247,7 @@ fn _analyze_statement_capabilities(statement: Statement, capabilities: string[])
     }
     if statement.variant == "StructDeclaration" {
         let mut issues: CapabilityViolation[] = [];
-        let mut method_index: number = 0;
+        let mut method_index: int = 0;
         loop {
             if method_index >= statement.methods.length { break; }
             let method = statement.methods[method_index];
@@ -270,7 +270,7 @@ fn _analyze_routine_capabilities(signature: FunctionSignature, name: string, cap
     // surface) and flag the contradiction with the existing E0403
     // diagnostic.
     let mut has_concrete_effect: boolean = false;
-    let mut probe: number = 0;
+    let mut probe: int = 0;
     loop {
         if probe >= signature.effects.length { break; }
         if !is_universally_allowed_effect(signature.effects[probe]) {
@@ -280,7 +280,7 @@ fn _analyze_routine_capabilities(signature: FunctionSignature, name: string, cap
         probe += 1;
     }
     let mut excess: string[] = [];
-    let mut i: number = 0;
+    let mut i: int = 0;
     loop {
         if i >= signature.effects.length { break; }
         let effect = signature.effects[i];
@@ -310,7 +310,7 @@ fn _analyze_routine_capabilities(signature: FunctionSignature, name: string, cap
 
 fn _append_capability_violations(violations: CapabilityViolation[], new_violations: CapabilityViolation[]) -> CapabilityViolation[] {
     let mut result = violations;
-    let mut i: number = 0;
+    let mut i: int = 0;
     loop {
         if i >= new_violations.length { break; }
         result.push(new_violations[i]);
@@ -338,7 +338,7 @@ fn analyze_statement(statement: Statement, imports: ImportSymbolTable) -> Effect
     }
     if statement.variant == "StructDeclaration" {
         let mut issues: EffectViolation[] = [];
-        let mut index: number = 0;
+        let mut index: int = 0;
         loop {
             if index >= statement.methods.length { break; }
             let method = statement.methods[index];
@@ -372,14 +372,14 @@ fn is_program_entry_point(signature: FunctionSignature) -> boolean {
 fn analyze_routine(signature: FunctionSignature, body: Block, decorators: Decorator[], name: string, imports: ImportSymbolTable) -> EffectViolation[] {
     let names = decorator_names(decorators);
     let mut declared: string[] = [];
-    let mut declared_index: number = 0;
+    let mut declared_index: int = 0;
     loop {
         if declared_index >= signature.effects.length { break; }
         declared = append_unique_effect(declared, signature.effects[declared_index]);
         declared_index += 1;
     }
     let mut requires_io_from_decorators: boolean = false;
-    let mut decorator_index: number = 0;
+    let mut decorator_index: int = 0;
     loop {
         if decorator_index >= names.length { break; }
         let decorator_name = names[decorator_index];
@@ -399,7 +399,7 @@ fn analyze_routine(signature: FunctionSignature, body: Block, decorators: Decora
     let required = required_effects(body, imports);
     let mut missing: string[] = [];
     let mut missing_requirements: EffectRequirement[] = [];
-    let mut index: number = 0;
+    let mut index: int = 0;
     loop {
         if index >= required.length { break; }
         let requirement = required[index];
@@ -462,7 +462,7 @@ fn analyze_routine(signature: FunctionSignature, body: Block, decorators: Decora
 // synthesized expressions). The caller passes signature_token as the
 // fallback so the violation always carries a source location.
 fn _first_requirement_trigger(missing_requirements: EffectRequirement[], fallback: Token?) -> Token? {
-    let mut i: number = 0;
+    let mut i: int = 0;
     loop {
         if i >= missing_requirements.length { break; }
         let req = missing_requirements[i];
@@ -478,7 +478,7 @@ fn required_effects(body: Block, imports: ImportSymbolTable) -> EffectRequiremen
 
 fn collect_effects_from_block(block: Block, imports: ImportSymbolTable) -> EffectRequirement[] {
     let mut required: EffectRequirement[] = [];
-    let mut index: number = 0;
+    let mut index: int = 0;
     loop {
         if index >= block.statements.length { break; }
         required = merge_requirements(required, collect_effects_from_statement(block.statements[index], imports));
@@ -500,7 +500,7 @@ fn collect_effects_from_optional_statement(statement: Statement?, imports: Impor
 fn collect_effects_from_statement(statement: Statement, imports: ImportSymbolTable) -> EffectRequirement[] {
     if statement.variant == "WithStatement" {
         let mut required = collect_effects_from_block(statement.body, imports);
-        let mut clause_index: number = 0;
+        let mut clause_index: int = 0;
         loop {
             if clause_index >= statement.clauses.length { break; }
             let clause = statement.clauses[clause_index];
@@ -520,7 +520,7 @@ fn collect_effects_from_statement(statement: Statement, imports: ImportSymbolTab
     }
     if statement.variant == "MatchStatement" {
         let mut required = collect_effects_from_expression(statement.expression, imports);
-        let mut case_index: number = 0;
+        let mut case_index: int = 0;
         loop {
             if case_index >= statement.cases.length { break; }
             required = merge_requirements(required, collect_effects_from_match_case(statement.cases[case_index], imports));
@@ -553,7 +553,7 @@ fn collect_effects_from_statement(statement: Statement, imports: ImportSymbolTab
     }
     if statement.variant == "StructDeclaration" {
         let mut required: EffectRequirement[] = [];
-        let mut method_index: number = 0;
+        let mut method_index: int = 0;
         loop {
             if method_index >= statement.methods.length { break; }
             required = merge_requirements(required, collect_effects_from_block(statement.methods[method_index].body, imports));
@@ -595,7 +595,7 @@ fn _propagate_imported_callee_effects(name: string, imports: ImportSymbolTable, 
     if entry.effects.length == 0 { return base; }
     let mut required = base;
     let prefix = "imported `" + name + "` declares ![";
-    let mut e: number = 0;
+    let mut e: int = 0;
     loop {
         if e >= entry.effects.length { break; }
         let effect = entry.effects[e];
@@ -651,7 +651,7 @@ fn collect_effects_from_expression(expression: Expression?, imports: ImportSymbo
         // and emits the right requirement (`fs` → io, `http` → net,
         // etc.). Don't re-analyze the callee here; doing so would
         // double-count every Member-callee effect.
-        let mut argument_index: number = 0;
+        let mut argument_index: int = 0;
         loop {
             if argument_index >= expression.arguments.length { break; }
             required = merge_requirements(required, collect_effects_from_expression(expression.arguments[argument_index], imports));
@@ -706,7 +706,7 @@ fn collect_effects_from_expression(expression: Expression?, imports: ImportSymbo
     }
     if expression.variant == "Array" {
         let mut required: EffectRequirement[] = [];
-        let mut element_index: number = 0;
+        let mut element_index: int = 0;
         loop {
             if element_index >= expression.elements.length { break; }
             required = merge_requirements(required, collect_effects_from_expression(expression.elements[element_index], imports));
@@ -716,7 +716,7 @@ fn collect_effects_from_expression(expression: Expression?, imports: ImportSymbo
     }
     if expression.variant == "Object" {
         let mut required: EffectRequirement[] = [];
-        let mut field_index: number = 0;
+        let mut field_index: int = 0;
         loop {
             if field_index >= expression.fields.length { break; }
             required = merge_requirements(required, collect_effects_from_expression(expression.fields[field_index].value, imports));
@@ -726,7 +726,7 @@ fn collect_effects_from_expression(expression: Expression?, imports: ImportSymbo
     }
     if expression.variant == "Struct" {
         let mut required: EffectRequirement[] = [];
-        let mut field_index: number = 0;
+        let mut field_index: int = 0;
         loop {
             if field_index >= expression.fields.length { break; }
             required = merge_requirements(required, collect_effects_from_expression(expression.fields[field_index].value, imports));
@@ -811,7 +811,7 @@ fn contains_code(text: string, needle: string) -> boolean {
     if needle.length == 0 { return true; }
     if text.length < needle.length { return false; }
 
-    let mut index: number = 0;
+    let mut index: int = 0;
     let mut in_line_comment: boolean = false;
     let mut in_block_comment: boolean = false;
     let mut in_string_quote: string = "";
@@ -896,7 +896,7 @@ fn contains_code(text: string, needle: string) -> boolean {
 
 fn append_violations(violations: EffectViolation[], new_violations: EffectViolation[]) -> EffectViolation[] {
     let mut result = violations;
-    let mut index: number = 0;
+    let mut index: int = 0;
     loop {
         if index >= new_violations.length { break; }
         result.push(new_violations[index]);
@@ -917,7 +917,7 @@ fn append_unique_effect(effects: string[], effect: string) -> string[] {
 }
 
 fn contains_effect(effects: string[], effect: string) -> boolean {
-    let mut index: number = 0;
+    let mut index: int = 0;
     loop {
         if index >= effects.length { break; }
         if effects[index] == effect { return true; }
@@ -933,7 +933,7 @@ fn append_requirement(collection: EffectRequirement[], item: EffectRequirement) 
 
 fn merge_requirements(base: EffectRequirement[], additions: EffectRequirement[]) -> EffectRequirement[] {
     let mut result = base;
-    let mut index: number = 0;
+    let mut index: int = 0;
     loop {
         if index >= additions.length { break; }
         result.push(additions[index]);
@@ -943,7 +943,7 @@ fn merge_requirements(base: EffectRequirement[], additions: EffectRequirement[])
 }
 
 fn contains_requirement_for_effect(requirements: EffectRequirement[], effect: string) -> boolean {
-    let mut index: number = 0;
+    let mut index: int = 0;
     loop {
         if index >= requirements.length { break; }
         if requirements[index].effect == effect { return true; }

--- a/compiler/src/effect_imports.sfn
+++ b/compiler/src/effect_imports.sfn
@@ -77,8 +77,8 @@ fn empty_import_symbols() -> ImportSymbolTable {
 fn append_import_function(table: ImportSymbolTable, name: string, effects: string[]) -> ImportSymbolTable {
     if name.length == 0 { return table; }
     let mut updated = table;
-    let mut existing_index: number = -1;
-    let mut i: number = 0;
+    let mut existing_index: int = -1;
+    let mut i: int = 0;
     loop {
         if i >= updated.functions.length { break; }
         if updated.functions[i].name == name {
@@ -88,7 +88,7 @@ fn append_import_function(table: ImportSymbolTable, name: string, effects: strin
         i += 1;
     }
     let mut effects_copy: string[] = [];
-    let mut j: number = 0;
+    let mut j: int = 0;
     loop {
         if j >= effects.length { break; }
         effects_copy.push(effects[j]);
@@ -113,7 +113,7 @@ fn append_import_function(table: ImportSymbolTable, name: string, effects: strin
 // at the table sizes this path sees (a few hundred imports per
 // compilation unit, called once per `Call` expression in the body).
 fn lookup_imported_function(table: ImportSymbolTable, name: string) -> ImportedFunctionSignature? {
-    let mut i: number = 0;
+    let mut i: int = 0;
     loop {
         if i >= table.functions.length { break; }
         if table.functions[i].name == name { return table.functions[i]; }
@@ -144,12 +144,12 @@ fn lookup_imported_function(table: ImportSymbolTable, name: string) -> ImportedF
 // global table + program in-memory and assert the localized result.
 fn localize_import_symbols_for_program(program: Program, table: ImportSymbolTable) -> ImportSymbolTable {
     let mut local = empty_import_symbols();
-    let mut i: number = 0;
+    let mut i: int = 0;
     loop {
         if i >= program.statements.length { break; }
         let statement = program.statements[i];
         if statement.variant == "ImportDeclaration" {
-            let mut s: number = 0;
+            let mut s: int = 0;
             loop {
                 if s >= statement.import_specifiers.length { break; }
                 let spec = statement.import_specifiers[s];

--- a/compiler/src/effect_taxonomy.sfn
+++ b/compiler/src/effect_taxonomy.sfn
@@ -32,7 +32,7 @@ fn canonical_effects() -> string[] {
 
 fn is_canonical_effect(name: string) -> boolean {
     let canonical = canonical_effects();
-    let mut i: number = 0;
+    let mut i: int = 0;
     loop {
         if i >= canonical.length { break; }
         if canonical[i] == name { return true; }


### PR DESCRIPTION
## Summary

- Flip the 32 residual `: number` loop-index sites in the `effect_*` cluster (`effect_checker.sfn` 25, `effect_imports.sfn` 6, `effect_taxonomy.sfn` 1) to `: int`.
- `llvm/effects.sfn` (the original 32-site carve-out called out in #585's scope) was already swept by PR #588 — confirmed clean by the audit grep, no further work needed there.
- All sites are uniform `let mut <name>: number = <int>;` loop counter declarations, so a surgical `sed 's/: number =/: int =/g'` over the three files is exact. Pre-edit and post-edit greps agree on the 32-site count.

Closes #585

## Acceptance Criteria

- [x] All `: number` / `-> number` sites in the three listed files flip to `: int`, except `// alias-coverage` rows.
- [x] `make compile` self-hosts on top of merged #581.
- [x] `make test` passes — full e2e + capsules + unit/integration all green (0 failed).
- [x] `sfn fmt --check` clean on every touched file.
- [x] `clang -O2 -c build/sailfin/capsules/token.ll -o /tmp/token.o` succeeds.
- [x] `ulimit -v 8388608 && timeout 30 build/native/sailfin run examples/basics/hello-world.sfn` prints the example's greeting. (Issue body says "Hello, world!" — the example was renamed upstream to print "Hello, Sailfin!"; smoke intent satisfied.)
- [x] Audit grep produces zero output (confirmed `AUDIT CLEAN — zero residual`).

## Verification

```bash
$ ulimit -v 8388608 && make compile
[compile] built build/native/sailfin
# 7 pre-existing ABI primitive mismatch warnings (the umbrella #550
# warning regime — unrelated boundaries elsewhere in the codebase).

$ ulimit -v 8388608 && timeout 30 build/native/sailfin run examples/basics/hello-world.sfn
Hello, Sailfin!

$ clang -O2 -c build/sailfin/capsules/token.ll -o /tmp/token.o
# (one harmless -Woverride-module warning) — succeeds.

$ ulimit -v 8388608 && make test
═══ e2e: 56/56 passed, 0 failed ═══
═══ capsules: 10/10 passed, 0 failed ═══
# (every section reports `failed: 0`.)

$ grep -nE "(: number|-> number)" \
    compiler/src/effect_checker.sfn \
    compiler/src/effect_imports.sfn \
    compiler/src/effect_taxonomy.sfn \
    compiler/src/llvm/effects.sfn \
    | grep -v "// alias-coverage"
# AUDIT CLEAN — zero residual
```

## Files Changed

- `compiler/src/effect_checker.sfn` (25 flips)
- `compiler/src/effect_imports.sfn` (6 flips)
- `compiler/src/effect_taxonomy.sfn` (1 flip)

Diff is mechanically 32 substitutions of `: number =` → `: int =`; +32/-32 with no other changes.

## Notes for Future Grooming

- The scope-shrink comment on #585 was accurate — the `llvm/effects.sfn` line in the original scope table (32 sites) was already swept by PR #588. The remaining work fit comfortably in `size:s`.
- Acceptance-criteria text on the issue references `Hello, world!`; the upstream example now prints `Hello, Sailfin!`. Worth a one-line touch-up in the next groomed bulk to keep the boilerplate accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GduQcCBh5sUzNHsjNGtu2w)_