### PR TITLE
refactor(numeric): flip ast/decorator_semantics/lexer/main leaves off `: number` (#586)

### DIFF
--- a/compiler/src/ast.sfn
+++ b/compiler/src/ast.sfn
@@ -178,7 +178,7 @@ struct DecoratorArgument {
 
 fn decorator_names(decorators: Decorator[]) -> string[] {
     let mut names: string[] = [];
-    let mut index: number = 0;
+    let mut index: int = 0;
     loop {
         if index >= decorators.length { break; }
         names.push(decorators[index].name);

--- a/compiler/src/decorator_semantics.sfn
+++ b/compiler/src/decorator_semantics.sfn
@@ -12,7 +12,7 @@ fn infer_effects(existing: string[], decorator_names: string[]) -> string[] {
     let mut effects = clone_effects(existing);
     let mut requires_io: boolean = contains_effect(effects, "io");
 
-    let mut index: number = 0;
+    let mut index: int = 0;
     loop {
         if index >= decorator_names.length { break; }
         let name = decorator_names[index];
@@ -36,7 +36,7 @@ fn append_string(collection: string[], item: string) -> string[] {
 
 fn clone_effects(effects: string[]) -> string[] {
     let mut clone: string[] = [];
-    let mut index: number = 0;
+    let mut index: int = 0;
     loop {
         if index >= effects.length { break; }
         clone.push(effects[index]);
@@ -46,7 +46,7 @@ fn clone_effects(effects: string[]) -> string[] {
 }
 
 fn contains_effect(effects: string[], effect: string) -> boolean {
-    let mut index: number = 0;
+    let mut index: int = 0;
     loop {
         if index >= effects.length { break; }
         if effects[index] == effect { return true; }

--- a/compiler/src/lexer.sfn
+++ b/compiler/src/lexer.sfn
@@ -26,7 +26,7 @@ fn lex(source: string) -> Token[] ![io] {
     };
 
     let tokens: Token[] = [];
-    let mut guard: number = 0;
+    let mut guard: int = 0;
     let max_guard = length * 8 + 1000;
 
     loop {
@@ -357,7 +357,7 @@ fn is_double_quote(ch: string) -> boolean { return ch == "\""; }
 
 fn is_backslash(ch: string) -> boolean { return ch == "\\"; }
 
-fn slice(text: string, start: number, end: number) -> string {
+fn slice(text: string, start: int, end: int) -> string {
     let text_len = text.length;
     let mut safe_start = start;
     let mut safe_end = end;
@@ -368,7 +368,7 @@ fn slice(text: string, start: number, end: number) -> string {
     return substring_unchecked(text, safe_start, safe_end);
 }
 
-fn byte_at(text: string, index: number) -> string {
+fn byte_at(text: string, index: int) -> string {
     let text_len = text.length;
     if text_len == 0 { return ""; }
     if index < 0 { return ""; }

--- a/compiler/src/main.sfn
+++ b/compiler/src/main.sfn
@@ -40,14 +40,14 @@ import {
     typecheck_has_errors
 } from "./typecheck";
 
-fn _ms_since(start_ms: number) -> number {
+fn _ms_since(start_ms: int) -> int {
     let end_ms = monotonic_millis();
     let delta = end_ms - start_ms;
     if delta < 0 { return 0; }
     return delta;
 }
 
-fn _timing_line(module_name: string, phase: string, elapsed_ms: number) -> string {
+fn _timing_line(module_name: string, phase: string, elapsed_ms: int) -> string {
     // Format is stable and grep/awk-friendly.
     // Emitted to stderr via print.err by the caller.
     return "[timing] module=" + module_name + " phase=" + phase + " ms="
@@ -84,7 +84,7 @@ fn module_name_from_path(source_path: string) -> string {
 
     // Normalize path separators so we can reason about prefixes.
     let mut normalized: string = "";
-    let mut index: number = 0;
+    let mut index: int = 0;
     loop {
         if index >= source_path.length { break; }
         let ch = source_path[index];
@@ -99,9 +99,9 @@ fn module_name_from_path(source_path: string) -> string {
     // - .../runtime/prelude.sfn         -> runtime/prelude
     let compiler_prefix = "compiler/src/";
     let runtime_prefix = "runtime/";
-    let mut start: number = 0;
+    let mut start: int = 0;
 
-    let mut last_compiler: number = -1;
+    let mut last_compiler: int = -1;
     let compiler_search_limit = normalized.length - compiler_prefix.length;
     index = 0;
     loop {
@@ -112,7 +112,7 @@ fn module_name_from_path(source_path: string) -> string {
         index += 1;
     }
     if last_compiler >= 0 { start = last_compiler + compiler_prefix.length; } else {
-        let mut last_runtime: number = -1;
+        let mut last_runtime: int = -1;
         let runtime_search_limit = normalized.length - runtime_prefix.length;
         index = 0;
         loop {
@@ -130,15 +130,15 @@ fn module_name_from_path(source_path: string) -> string {
 
     // Find the end of the module name by stripping the extension from the last
     // path segment.
-    let mut last_slash: number = -1;
+    let mut last_slash: int = -1;
     index = start;
     loop {
         if index >= normalized.length { break; }
         if normalized[index] == "/" { last_slash = index; }
         index += 1;
     }
-    let mut end: number = normalized.length;
-    let mut dot_index: number = -1;
+    let mut end: int = normalized.length;
+    let mut dot_index: int = -1;
     index = normalized.length;
     let dot_limit = last_slash + 1;
     loop {
@@ -291,7 +291,7 @@ fn compile_to_llvm_with_module_timed(source: string, module_name: string) -> str
     let t1 = monotonic_millis();
     let skip_typecheck = _env_flag("SAILFIN_SKIP_TYPECHECK")
         || _legacy_flag_file("build/sailfin/.skip_typecheck");
-    let mut t_typecheck: number = 0;
+    let mut t_typecheck: int = 0;
     if !skip_typecheck {
         t_typecheck = _ms_since(t1);
         if typecheck_has_errors(program) {
@@ -383,7 +383,7 @@ fn compile_tests_to_llvm_file_with_module_imports(source: string, module_name: s
     let program: Program = parse_program(source);
     let diagnostics = typecheck_diagnostics_with_imports(program, imported_interfaces);
     let mut has_errors: boolean = false;
-    let mut di: number = 0;
+    let mut di: int = 0;
     loop {
         if di >= diagnostics.length { break; }
         if strings_equal(diagnostics[di].severity, "error") {
@@ -535,7 +535,7 @@ fn compile_to_llvm_file_with_module(source: string, module_name: string, out_pat
 // `error[E0001]: ... --> file:line:col` like `sfn check`.
 fn _emit_typecheck_diagnostics(entries: Diagnostic[], source: string, file_path: string) ![io] {
     let lines = split_source_lines(source);
-    let mut index: number = 0;
+    let mut index: int = 0;
     loop {
         if index >= entries.length { break; }
         // Stamp file_path in place so the renderer's `--> file:line:col`
@@ -549,21 +549,28 @@ fn _emit_typecheck_diagnostics(entries: Diagnostic[], source: string, file_path:
     }
 }
 
-fn number_to_string(value: number) -> string {
+// Seed alpha.18 compiled cross-module importers (cli_main, cli_commands,
+// capsule_resolver, tools/check) with `declare i8* @number_to_string__main(double)`.
+// Flipping the definition to `int` while the importers still emit `double`
+// call-sites produces an i64↔double mismatch the linker silently accepts and
+// runtime executes as garbage (`xargs -P <pointer-bit-pattern>`). Same
+// carve-out pattern as `emit_native_state.sfn:217`. Flip in lockstep with a
+// seed bump past this PR (tracked under #579's wrap / #567).
+fn number_to_string(value: number) -> string {  // alias-coverage: seed-ABI constraint — see banner above
     if value == 0 { return "0"; }
-    let mut working: number = value;
+    let mut working: number = value;  // alias-coverage: seed-ABI constraint — see number_to_string banner
     let mut negative: boolean = false;
     if working < 0 {
         negative = true;
         working = 0 - working;
     }
     let digits = "0123456789";
-    let mut remaining: number = working;
+    let mut remaining: number = working;  // alias-coverage: seed-ABI constraint — see number_to_string banner
     let mut output: string = "";
     loop {
         if remaining <= 0 { break; }
-        let mut temp: number = remaining;
-        let mut quotient: number = 0;
+        let mut temp: number = remaining;  // alias-coverage: seed-ABI constraint — see number_to_string banner
+        let mut quotient: number = 0;  // alias-coverage: seed-ABI constraint — see number_to_string banner
         loop {
             if temp < 10 { break; }
             temp -= 10;
@@ -577,9 +584,9 @@ fn number_to_string(value: number) -> string {
     return output;
 }
 
-fn repeat_character(ch: string, count: number) -> string {
+fn repeat_character(ch: string, count: int) -> string {
     if count <= 0 { return ""; }
-    let mut index: number = 0;
+    let mut index: int = 0;
     let mut result: string = "";
     loop {
         if index >= count { break; }


### PR DESCRIPTION
## Summary

Slice E.3a-bulk-1b **child 7** — the tail PR after #580 / #581 / #582 / #583 / #584 / #585. Flips ~21 of 26 `: number` / `-> number` sites across `compiler/src/{ast,decorator_semantics,lexer,main}.sfn` to `: int` per the audit dispositions in `docs/proposals/slice-e3a-semantic-audit.md`.

The remaining 5 sites live in `main.sfn`'s `number_to_string` and its locals; they retain `: number` with `// alias-coverage` tags because **seed alpha.18 compiled cross-module importers** (`cli_main`, `cli_commands`, `capsule_resolver`, `tools/check`) with `declare i8* @number_to_string__main(double)`. Flipping the definition to `int` while those importers still emit `double` call-sites produced an i64↔double mismatch the linker silently accepted and runtime executed as garbage — concretely `xargs -P <pointer-bit-pattern>` in `_cr_run_parallel_emit`, which fanned out into the same failure mode #578 surfaced. Matches the carve-out pattern already used at `emit_native_state.sfn:217`; flips in lockstep with a future seed bump under #579's wrap / #567.

`repeat_character` was on the same suspect list initially, but a tree-wide grep shows zero actual callers anywhere in `compiler/src/` (only stale forward declarations in a few `.ll` files), so it flips cleanly to `int`.

Closes #586.

## Acceptance Criteria

- [x] All `: number` / `-> number` sites in the four listed files flip to `: int` (or `: float` per audit dispositions), except `// alias-coverage` rows.
- [x] `make compile` self-hosts on top of all six prior children merged.
- [x] `make test` passes.
- [x] `sfn fmt --check` clean.
- [x] `clang -O2 -c build/sailfin/capsules/token.ll -o /tmp/token.o` succeeds.
- [x] `ulimit -v 8388608 && timeout 30 build/native/sailfin run examples/basics/hello-world.sfn` prints `Hello, Sailfin!` (issue body had outdated "Hello, world!" text; the actual example source prints "Hello, Sailfin!").
- [x] Audit grep on the 21 umbrella-scope files returns zero non-`alias-coverage` matches.

## Verification

```bash
ulimit -v 8388608
make compile               # 1 ABI mismatch warning (down from 13); succeeds
make test                  # 95 unit + 23 integration + 56 e2e + 10 capsule, all pass
sfn fmt --check compiler/  # clean

clang -O2 -c build/sailfin/capsules/token.ll -o /tmp/token.o   # exit 0
ulimit -v 8388608 && timeout 30 build/native/sailfin run examples/basics/hello-world.sfn
# Hello, Sailfin!  (exit 0)

# Umbrella audit grep — zero on all 21 #579 scope files
grep -rnE "(: number|-> number)" compiler/src/ --include='*.sfn' \
  | grep -v "compiler/src/parser/\|compiler/src/llvm/expression_lowering/" \
  | grep -v "// alias-coverage"
# (remaining hits are out-of-scope #563/#564/#565 territory and tools/)
```

## Files Changed

- `compiler/src/ast.sfn` — 1 site flipped (`decorator_names` index)
- `compiler/src/decorator_semantics.sfn` — 3 sites flipped (loop indices)
- `compiler/src/lexer.sfn` — 3 sites flipped (`guard`, `slice`, `byte_at`)
- `compiler/src/main.sfn` — 14 of 19 sites flipped to `int`; 5 sites in `number_to_string` carry `// alias-coverage` tags with a banner documenting the seed-ABI constraint

## Notes for grooming / follow-up

- The 5 alias-coverage sites in `number_to_string` should flip to `int` in lockstep with a seed bump that includes this PR (so the seed-compiled importers re-emit with `i64` call-sites). Tracked implicitly under #579's wrap and the alpha.16/17/18 → next-seed cycle (#567 / `/pin-seed`).
- The "audit says int, seed says no" disagreement here is exactly the failure mode `/pickup` Phase 1.5 was supposed to catch, but the umbrella explicitly marked itself as "not a seed-blocker". This PR documents the constraint inline so a future audit refresh can pick it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CEk5RaNe55vUgLKcwQS4F1)_