### PR TITLE
refactor(numeric): flip parser off `: number` (Slice E.3a-bulk-2)

### DIFF
--- a/compiler/src/parser/declarations.sfn
+++ b/compiler/src/parser/declarations.sfn
@@ -150,12 +150,12 @@ fn parse_decorators(parser: Parser) -> DecoratorParseResult {
             let paren_result = collect_parenthesized(current);
             if paren_result.success {
                 let mut segment_tokens: Token[] = [];
-                let mut angle: number = 0;
-                let mut paren: number = 0;
-                let mut brace: number = 0;
-                let mut bracket: number = 0;
+                let mut angle: int = 0;
+                let mut paren: int = 0;
+                let mut brace: int = 0;
+                let mut bracket: int = 0;
 
-                let mut index: number = 0;
+                let mut index: int = 0;
                 loop {
                     if index >= paren_result.tokens.length { break; }
                     let tok = paren_result.tokens[index];
@@ -316,7 +316,7 @@ fn parse_type_parameter_clause(parser: Parser) -> TypeParameterParseResult {
 
     current = parser_advance_raw(current);
     let mut collected: Token[] = [];
-    let mut depth: number = 1;
+    let mut depth: int = 1;
 
     loop {
         let tok = parser_peek_raw(current);
@@ -337,7 +337,7 @@ fn parse_type_parameter_clause(parser: Parser) -> TypeParameterParseResult {
 
     let slices = split_token_slices_by_comma(collected);
     let mut parameters: TypeParameter[] = [];
-    let mut index: number = 0;
+    let mut index: int = 0;
     loop {
         if index >= slices.length { break; }
         let slice_tokens = trim_token_edges(slices[index]);
@@ -398,7 +398,7 @@ fn parse_implements_clause(parser: Parser) -> ImplementsParseResult {
 
     let mut implements_types: TypeAnnotation[] = [];
     let entries = split_tokens_by_comma(capture.tokens);
-    let mut index: number = 0;
+    let mut index: int = 0;
     loop {
         if index >= entries.length { break; }
         let text = trim_text(entries[index]);
@@ -609,7 +609,7 @@ fn parse_specifier_list(initial_parser: Parser) -> SpecifierListParseResult {
     parser = skip_trivia(parser);
     parser = consume_symbol(parser, "{");
 
-    let mut spec_count: number = 0;
+    let mut spec_count: int = 0;
     let mut spec_names: string[] = [];
     let mut spec_aliases: string[] = [];
     parser = skip_trivia(parser);
@@ -655,7 +655,7 @@ fn parse_specifier_list(initial_parser: Parser) -> SpecifierListParseResult {
     // Build NamedSpecifier array from parallel string arrays
     // (avoids struct .push() which the first-pass binary can't lower)
     let mut specifiers: NamedSpecifier[] = [];
-    let mut _si: number = 0;
+    let mut _si: int = 0;
     loop {
         if _si >= spec_count { break; }
         let mut _a: string? = null;
@@ -679,7 +679,7 @@ fn parse_specifier_list(initial_parser: Parser) -> SpecifierListParseResult {
 
 fn build_import_specifiers(values: NamedSpecifier[]) -> ImportSpecifier[] {
     let mut result: ImportSpecifier[] = [];
-    let mut index: number = 0;
+    let mut index: int = 0;
     loop {
         if index >= values.length { break; }
         let entry = values[index];
@@ -693,7 +693,7 @@ fn build_import_specifiers(values: NamedSpecifier[]) -> ImportSpecifier[] {
 
 fn build_export_specifiers(values: NamedSpecifier[]) -> ExportSpecifier[] {
     let mut result: ExportSpecifier[] = [];
-    let mut index: number = 0;
+    let mut index: int = 0;
     loop {
         if index >= values.length { break; }
         let entry = values[index];
@@ -739,7 +739,7 @@ fn parse_variable(initial_parser: Parser) -> StatementParseResult {
         statement_tokens = append_token(statement_tokens, separator_token);
         parser = separator_result.parser;
         let capture = collect_until(skip_trivia(parser), ["=", ";"]);
-        let mut index: number = 0;
+        let mut index: int = 0;
         loop {
             if index >= capture.tokens.length { break; }
             statement_tokens = append_token(statement_tokens, capture.tokens[index]);
@@ -760,7 +760,7 @@ fn parse_variable(initial_parser: Parser) -> StatementParseResult {
         statement_tokens = append_token(statement_tokens, assign);
         parser = parser_advance_raw(parser);
         let capture = collect_until(skip_trivia(parser), [";"]);
-        let mut index: number = 0;
+        let mut index: int = 0;
         loop {
             if index >= capture.tokens.length { break; }
             statement_tokens = append_token(statement_tokens, capture.tokens[index]);
@@ -1682,9 +1682,9 @@ fn parse_unknown(initial_parser: Parser) -> StatementParseResult {
     parser = skip_trivia(parser);
     let mut tokens: Token[] = [];
     let mut current = parser;
-    let mut depth: number = 0;
-    let iteration_limit: number = 16384;
-    let mut iteration_count: number = 0;
+    let mut depth: int = 0;
+    let iteration_limit: int = 16384;
+    let mut iteration_count: int = 0;
     let mut truncated: boolean = false;
 
     loop {

--- a/compiler/src/parser/expressions.sfn
+++ b/compiler/src/parser/expressions.sfn
@@ -145,10 +145,10 @@ fn expression_tokens_consume_type_separator(state: ExpressionTokens, accept_colo
 fn expression_tokens_collect_until(state: ExpressionTokens, terminators: string[]) -> ExpressionCollectResult {
     let mut current = state;
     let mut collected: Token[] = [];
-    let mut angle: number = 0;
-    let mut paren: number = 0;
-    let mut brace: number = 0;
-    let mut bracket: number = 0;
+    let mut angle: int = 0;
+    let mut paren: int = 0;
+    let mut brace: int = 0;
+    let mut bracket: int = 0;
 
     loop {
         if expression_tokens_is_at_end(current) {
@@ -215,7 +215,7 @@ fn collect_expression_block(state: ExpressionTokens) -> ExpressionBlockParseResu
     }
 
     let mut tokens: Token[] = [];
-    let mut depth: number = 0;
+    let mut depth: int = 0;
 
     loop {
         if expression_tokens_is_at_end(current) {
@@ -306,7 +306,7 @@ fn expression_from_single_token(token: Token) -> Expression? {
 // ============================================================================
 // Pratt Parser - Binary Precedence Climbing
 // ============================================================================
-fn parse_expression_bp(state: ExpressionTokens, min_precedence: number) -> ExpressionParseResult {
+fn parse_expression_bp(state: ExpressionTokens, min_precedence: int) -> ExpressionParseResult {
     let prefix_result = parse_prefix_expression(state);
     if !prefix_result.success { return prefix_result; }
 
@@ -1216,7 +1216,7 @@ fn parse_lambda_parameter_list(state: ExpressionTokens) -> LambdaParameterListPa
 //   9   + -
 //  10   * / %
 //  11   unary !   (logical NOT)
-fn binary_precedence(op: string) -> number {
+fn binary_precedence(op: string) -> int {
     if op == ".." { return 0; }
     if op == "||" { return 1; }
     if op == "&&" { return 2; }
@@ -1249,7 +1249,7 @@ fn binary_precedence(op: string) -> number {
     return -1;
 }
 
-fn unary_precedence() -> number { return 11; }
+fn unary_precedence() -> int { return 11; }
 
 // ============================================================================
 // Expression Normalization
@@ -1306,7 +1306,7 @@ fn strip_surrounding_quotes_expr(text: string) -> string {
 fn looks_like_number_expr(text: string) -> boolean {
     if text.length == 0 { return false; }
     let mut has_decimal: boolean = false;
-    let mut index: number = 0;
+    let mut index: int = 0;
     if char_at(text, 0) == "-" {
         if text.length == 1 { return false; }
         index = 1;
@@ -1382,11 +1382,11 @@ fn parse_block_for_lambda(parser: Parser) -> BlockParseResult {
     }
 
     let start_index = current.index;
-    let mut block_end_index: number = start_index;
+    let mut block_end_index: int = start_index;
     current = parser_advance_raw(current);
 
     // Simple block collection - just collect tokens until matching }
-    let mut depth: number = 1;
+    let mut depth: int = 1;
     loop {
         current = skip_trivia(current);
         let tok = parser_peek_raw(current);

--- a/compiler/src/parser/statements.sfn
+++ b/compiler/src/parser/statements.sfn
@@ -81,7 +81,7 @@ fn parse_decorators_stub(parser: Parser) -> DecoratorParseResult {
         // Skip arguments if present
         let after = parser_peek_raw(current);
         if symbol_matches(after, "(") {
-            let mut depth: number = 1;
+            let mut depth: int = 1;
             current = parser_advance_raw(current);
             loop {
                 let tok = parser_peek_raw(current);
@@ -123,7 +123,7 @@ fn parse_block(initial_parser: Parser) -> BlockParseResult {
 
     let start_index = parser.index;
     let mut current = parser_advance_raw(parser);
-    let mut block_end_index: number = start_index;
+    let mut block_end_index: int = start_index;
     let mut statements: Statement[] = [];
 
     loop {
@@ -171,9 +171,9 @@ fn parse_block(initial_parser: Parser) -> BlockParseResult {
 }
 
 fn trim_block_tokens_local(tokens: Token[]) -> Token[] {
-    let mut depth: number = 0;
-    let mut index: number = 0;
-    let mut end: number = tokens.length;
+    let mut depth: int = 0;
+    let mut index: int = 0;
+    let mut end: int = tokens.length;
     loop {
         if index >= tokens.length { break; }
         let token = tokens[index];
@@ -806,7 +806,7 @@ fn parse_match_case(parser: Parser) -> MatchCaseParseResult {
         current = parser_advance_raw(current);
 
         let capture = collect_until(current, [";", ",", "}"]);
-        let mut index: number = 0;
+        let mut index: int = 0;
         loop {
             if index >= capture.tokens.length { break; }
             block_tokens = append_token(block_tokens, capture.tokens[index]);
@@ -856,7 +856,7 @@ fn parse_match_case(parser: Parser) -> MatchCaseParseResult {
         let expression = expression_from_tokens(trimmed_expression_tokens);
 
         let mut block_tokens: Token[] = [];
-        let mut index: number = 0;
+        let mut index: int = 0;
         loop {
             if index >= capture.tokens.length { break; }
             block_tokens = append_token(block_tokens, capture.tokens[index]);
@@ -955,7 +955,7 @@ fn parse_with_statement(parser: Parser, decorators: Decorator[]) -> BlockStateme
     current = clauses_capture.parser;
     let clause_slices = split_token_slices_by_comma(clauses_capture.tokens);
     let mut clauses: WithClause[] = [];
-    let mut index: number = 0;
+    let mut index: int = 0;
     loop {
         if index >= clause_slices.length { break; }
         let slice_tokens = trim_token_edges(clause_slices[index]);
@@ -1023,7 +1023,7 @@ fn parse_return_statement(parser: Parser) -> BlockStatementParseResult {
         expression = expression_from_tokens(capture.tokens);
     }
 
-    let mut index: number = 0;
+    let mut index: int = 0;
     loop {
         if index >= capture.tokens.length { break; }
         statement_tokens = append_token(statement_tokens, capture.tokens[index]);
@@ -1076,7 +1076,7 @@ fn parse_throw_statement(parser: Parser) -> BlockStatementParseResult {
         };
     }
 
-    let mut index: number = 0;
+    let mut index: int = 0;
     loop {
         if index >= capture.tokens.length { break; }
         statement_tokens = append_token(statement_tokens, capture.tokens[index]);
@@ -1218,15 +1218,15 @@ fn parse_try_statement(parser: Parser) -> BlockStatementParseResult {
 // `line` / `column` (small positive number). Sailfin's `/`
 // operator is float division so we extract digits via repeated
 // subtraction — same shape as `compiler/src/main.sfn:number_to_string`.
-fn _assert_int_to_string(value: number) -> string {
+fn _assert_int_to_string(value: int) -> string {
     if value <= 0 { return "0"; }
     let digits = "0123456789";
-    let mut remaining: number = value;
+    let mut remaining: int = value;
     let mut output: string = "";
     loop {
         if remaining <= 0 { break; }
-        let mut temp: number = remaining;
-        let mut quotient: number = 0;
+        let mut temp: int = remaining;
+        let mut quotient: int = 0;
         loop {
             if temp < 10 { break; }
             temp -= 10;
@@ -1274,7 +1274,7 @@ fn parse_assert_statement(parser: Parser) -> BlockStatementParseResult {
         };
     }
 
-    let mut index: number = 0;
+    let mut index: int = 0;
     loop {
         if index >= capture.tokens.length { break; }
         statement_tokens = append_token(statement_tokens, capture.tokens[index]);
@@ -1387,7 +1387,7 @@ fn parse_expression_statement(parser: Parser, decorators: Decorator[]) -> BlockS
     }
 
     let mut statement_tokens: Token[] = [];
-    let mut token_index: number = 0;
+    let mut token_index: int = 0;
     loop {
         if token_index >= capture.tokens.length { break; }
         statement_tokens = append_token(statement_tokens, capture.tokens[token_index]);
@@ -1440,9 +1440,9 @@ fn parse_unknown_statement(initial_parser: Parser) -> StatementParseResult {
     parser = skip_trivia(parser);
     let mut tokens: Token[] = [];
     let mut current = parser;
-    let mut depth: number = 0;
-    let iteration_limit: number = 16384;
-    let mut iteration_count: number = 0;
+    let mut depth: int = 0;
+    let iteration_limit: int = 16384;
+    let mut iteration_count: int = 0;
     let mut truncated: boolean = false;
 
     loop {

--- a/compiler/src/parser/token_utils.sfn
+++ b/compiler/src/parser/token_utils.sfn
@@ -104,7 +104,7 @@ fn strip_surrounding_quotes_local(text: string) -> string {
 fn decode_string_literal_escapes_local(text: string) -> string {
     if text.length == 0 { return ""; }
     let mut decoded: string = "";
-    let mut index: number = 0;
+    let mut index: int = 0;
     loop {
         if index >= text.length { break; }
         let ch = char_at(text, index);
@@ -190,7 +190,7 @@ fn is_trivia_token(token: Token) -> boolean {
 
 fn is_whitespace_lexeme(text: string) -> boolean {
     if text.length == 0 { return false; }
-    let mut index: number = 0;
+    let mut index: int = 0;
     loop {
         if index >= text.length { break; }
         let ch = char_at(text, index);
@@ -212,9 +212,9 @@ fn is_trim_whitespace_local(ch: string) -> boolean {
 // ============================================================================
 // Token Array Operations
 // ============================================================================
-fn token_slice(tokens: Token[], start: number, end: number) -> Token[] {
+fn token_slice(tokens: Token[], start: int, end: int) -> Token[] {
     let mut result: Token[] = [];
-    let mut index: number = start;
+    let mut index: int = start;
     loop {
         if index >= end { break; }
         result = append_token(result, tokens[index]);
@@ -224,8 +224,8 @@ fn token_slice(tokens: Token[], start: number, end: number) -> Token[] {
 }
 
 fn trim_token_edges(tokens: Token[]) -> Token[] {
-    let mut start: number = 0;
-    let mut end: number = tokens.length;
+    let mut start: int = 0;
+    let mut end: int = tokens.length;
 
     loop {
         if start >= end { break; }
@@ -251,9 +251,9 @@ fn trim_token_edges(tokens: Token[]) -> Token[] {
 }
 
 fn trim_block_tokens(tokens: Token[]) -> Token[] {
-    let mut depth: number = 0;
-    let mut index: number = 0;
-    let mut end: number = tokens.length;
+    let mut depth: int = 0;
+    let mut index: int = 0;
+    let mut end: int = tokens.length;
     loop {
         if index >= tokens.length { break; }
         let token = tokens[index];
@@ -273,7 +273,7 @@ fn trim_block_tokens(tokens: Token[]) -> Token[] {
 }
 
 fn filter_trivia(tokens: Token[]) -> Token[] {
-    let mut index: number = 0;
+    let mut index: int = 0;
     let mut filtered: Token[] = [];
 
     loop {
@@ -297,9 +297,9 @@ fn filter_trivia(tokens: Token[]) -> Token[] {
 // ============================================================================
 fn tokens_to_text(tokens: Token[]) -> string {
     let mut text: string = "";
-    let mut index: number = 0;
-    let limit: number = 8192;
-    let max_tokens: number = 512;
+    let mut index: int = 0;
+    let limit: int = 8192;
+    let max_tokens: int = 512;
     let mut truncated: boolean = false;
     loop {
         if index >= tokens.length { break; }
@@ -335,7 +335,7 @@ fn source_span_from_tokens(tokens: Token[]) -> SourceSpan? {
     let mut end_column = last.column;
 
     let lexeme = last.lexeme;
-    let mut index: number = 0;
+    let mut index: int = 0;
     loop {
         if index >= lexeme.length { break; }
         let ch = char_at(lexeme, index);
@@ -360,9 +360,9 @@ fn source_span_from_tokens(tokens: Token[]) -> SourceSpan? {
 fn collect_until(parser: Parser, terminators: string[]) -> CaptureResult {
     let mut current = parser;
     let mut captured: Token[] = [];
-    let mut paren_depth: number = 0;
-    let mut brace_depth: number = 0;
-    let mut bracket_depth: number = 0;
+    let mut paren_depth: int = 0;
+    let mut brace_depth: int = 0;
+    let mut bracket_depth: int = 0;
 
     loop {
         let token = parser_peek_raw(current);
@@ -416,10 +416,10 @@ fn collect_until(parser: Parser, terminators: string[]) -> CaptureResult {
 fn collect_type_annotation_until(parser: Parser, terminators: string[]) -> CaptureResult {
     let mut current = parser;
     let mut captured: Token[] = [];
-    let mut paren_depth: number = 0;
-    let mut brace_depth: number = 0;
-    let mut bracket_depth: number = 0;
-    let mut angle_depth: number = 0;
+    let mut paren_depth: int = 0;
+    let mut brace_depth: int = 0;
+    let mut bracket_depth: int = 0;
+    let mut angle_depth: int = 0;
 
     loop {
         let token = parser_peek_raw(current);
@@ -486,7 +486,7 @@ fn collect_parenthesized(parser: Parser) -> ParenthesizedParseResult {
 
     current = parser_advance_raw(current);
     let mut tokens: Token[] = [];
-    let mut depth: number = 1;
+    let mut depth: int = 1;
 
     loop {
         let token = parser_peek_raw(current);
@@ -526,9 +526,9 @@ fn collect_pattern_until_arrow(parser: Parser) -> PatternCaptureResult {
     // Track balancing of (), {}, [] so nested separators inside a pattern
     // (e.g. `SomeStruct { a: b }` or `func(x: 1)`) are not mistaken for the
     // pattern-to-body separator.
-    let mut paren_depth: number = 0;
-    let mut brace_depth: number = 0;
-    let mut bracket_depth: number = 0;
+    let mut paren_depth: int = 0;
+    let mut brace_depth: int = 0;
+    let mut bracket_depth: int = 0;
 
     loop {
         let token = parser_peek_raw(current);
@@ -603,12 +603,12 @@ fn collect_pattern_until_arrow(parser: Parser) -> PatternCaptureResult {
 fn split_tokens_by_comma(tokens: Token[]) -> string[] {
     let mut parts: string[] = [];
     let mut segment: string = "";
-    let mut angle: number = 0;
-    let mut paren: number = 0;
-    let mut brace: number = 0;
-    let mut bracket: number = 0;
+    let mut angle: int = 0;
+    let mut paren: int = 0;
+    let mut brace: int = 0;
+    let mut bracket: int = 0;
 
-    let mut index: number = 0;
+    let mut index: int = 0;
     loop {
         if index >= tokens.length { break; }
         let token = tokens[index];
@@ -654,12 +654,12 @@ fn split_tokens_by_comma(tokens: Token[]) -> string[] {
 fn split_token_slices_by_comma(tokens: Token[]) -> Token[][] {
     let mut parts: Token[][] = [];
     let mut segment: Token[] = [];
-    let mut angle: number = 0;
-    let mut paren: number = 0;
-    let mut brace: number = 0;
-    let mut bracket: number = 0;
+    let mut angle: int = 0;
+    let mut paren: int = 0;
+    let mut brace: int = 0;
+    let mut bracket: int = 0;
 
-    let mut index: number = 0;
+    let mut index: int = 0;
     loop {
         if index >= tokens.length { break; }
         let token = tokens[index];
@@ -701,13 +701,13 @@ fn split_token_slices_by_comma(tokens: Token[]) -> Token[][] {
 // ============================================================================
 // Top-Level Search Functions
 // ============================================================================
-fn find_top_level_symbol(tokens: Token[], symbol: string) -> number {
-    let mut angle: number = 0;
-    let mut paren: number = 0;
-    let mut brace: number = 0;
-    let mut bracket: number = 0;
+fn find_top_level_symbol(tokens: Token[], symbol: string) -> int {
+    let mut angle: int = 0;
+    let mut paren: int = 0;
+    let mut brace: int = 0;
+    let mut bracket: int = 0;
 
-    let mut index: number = 0;
+    let mut index: int = 0;
     loop {
         if index >= tokens.length { break; }
         let token = tokens[index];
@@ -738,13 +738,13 @@ fn find_top_level_symbol(tokens: Token[], symbol: string) -> number {
     return -1;
 }
 
-fn find_top_level_identifier(tokens: Token[], keyword: string) -> number {
-    let mut angle: number = 0;
-    let mut paren: number = 0;
-    let mut brace: number = 0;
-    let mut bracket: number = 0;
+fn find_top_level_identifier(tokens: Token[], keyword: string) -> int {
+    let mut angle: int = 0;
+    let mut paren: int = 0;
+    let mut brace: int = 0;
+    let mut bracket: int = 0;
 
-    let mut index: number = 0;
+    let mut index: int = 0;
     loop {
         if index >= tokens.length { break; }
         let token = tokens[index];
@@ -777,13 +777,13 @@ fn find_top_level_identifier(tokens: Token[], keyword: string) -> number {
     return -1;
 }
 
-fn find_top_level_colon(tokens: Token[]) -> number {
-    let mut angle: number = 0;
-    let mut paren: number = 0;
-    let mut brace: number = 0;
-    let mut bracket: number = 0;
+fn find_top_level_colon(tokens: Token[]) -> int {
+    let mut angle: int = 0;
+    let mut paren: int = 0;
+    let mut brace: int = 0;
+    let mut bracket: int = 0;
 
-    let mut index: number = 0;
+    let mut index: int = 0;
     loop {
         if index >= tokens.length { break; }
         let token = tokens[index];


### PR DESCRIPTION
## Summary

- Migrate all 100 `: number` / `-> number` sites under `compiler/src/parser/` to `: int`.
- Every parser site is integer-shaped per the slice E.3a audit (#560): token indices, span offsets, depth/paren/brace/bracket counters, AST-node indices, iteration limits, and precedence levels — zero `float` decisions, zero alias-coverage seams.
- No new shadow surfaces: parser/utils.sfn imports `char_at`/`char_code` directly from the prelude (no local re-definitions), so the cross-module signature-mismatch hazard called out on #561/#576 does not apply here.

Closes #563.

## Acceptance Criteria

- [x] `grep -rnE "(: number|-> number)" compiler/src/parser/ --include='*.sfn' | grep -v "// alias-coverage"` returns zero matches.
- [x] `make compile` self-hosts.
- [x] `make test` passes (unit + integration + e2e + capsules — last terminal banners: `e2e: 56/56 passed`, `capsules: 10/10 passed`).
- [x] `sfn fmt --check` clean on every modified file.

## Verification

```
$ grep -rnE "(: number|-> number)" compiler/src/parser/ --include='*.sfn' | grep -v "// alias-coverage"
ZERO MATCHES

$ make compile
[rebuild] build stamp: 0.5.10-alpha.18+dev.88b5350
[rebuild] built build/native/sailfin
[compile] built build/native/sailfin

$ build/native/sailfin run examples/basics/hello-world.sfn
Hello, Sailfin!

$ make test
... e2e: 56/56 passed, 0 failed
... capsules: 10/10 passed, 0 failed

$ build/native/sailfin fmt --check compiler/src/parser/
EXIT=0
```

## Files Changed

- `compiler/src/parser/token_utils.sfn` — 53 sites
- `compiler/src/parser/statements.sfn` — 19 sites
- `compiler/src/parser/declarations.sfn` — 17 sites
- `compiler/src/parser/expressions.sfn` — 11 sites

100 lines changed (100 insertions / 100 deletions), zero non-mechanical edits.

## Notes

The build surfaces the expected `ABI primitive mismatch: callee expects i64 (int) but caller produced double (float)` warnings at parser ↔ ast and parser ↔ typecheck call boundaries. Per the issue body these are absorbed by the transitional warning regime and will collapse as the remaining slice E.3a sub-issues (#562b children, ast/typecheck flips) land.

---
_Generated by [Claude Code](https://claude.ai/code/session_01E6fMi4wZ1tbGEzEUU1wkcv)_