### PR TITLE
refactor(numeric): clear residual `: number` matches in expression_lowering/

### DIFF
--- a/compiler/src/llvm/expression_lowering/native/core.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core.sfn
@@ -472,7 +472,7 @@ fn lower_expression(expression: string, bindings: ParameterBinding[], locals: Lo
         // (no annotation), `int`, or an explicit narrow integer LLVM
         // type (`i64`/`i32`/`i16`/`i8`). Decimal/fractional literals
         // and explicit `double`/`float` pressure (which is what the
-        // deprecated `: number` alias maps to once `map_primitive_type`
+        // deprecated `number` alias maps to once `map_primitive_type`
         // runs) fall through to the `double` path below.
         if is_integer_literal(stripped) {
             let mut integer_target: string = "";

--- a/compiler/src/llvm/expression_lowering/native/core_literals_lowering.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_literals_lowering.sfn
@@ -264,10 +264,10 @@ fn lower_array_literal(text: string, bindings: ParameterBinding[], locals: Local
     }
     // Slice E.1 (#488): bare integer literals default to `int` (i64) at
     // scalar context, but unannotated array literals keep the pre-E.1
-    // `double` element default so the existing `: number[]` corpus
+    // `double` element default so the existing `number[]` corpus
     // (compiler source, runtime/prelude.sfn, and every test fixture
-    // that types arrays as `: number[]`) lowers without churn.
-    // Once E.2 migrates every `: number` site to `: int`/`: float`,
+    // that types arrays as `number[]`) lowers without churn.
+    // Once E.2 migrates every `number`-typed site to `int`/`float`,
     // this fallback flips to `i64` (or, more cleanly, the array
     // literal grows a real type-inference pass that reads the
     // typecheck-derived binding type).

--- a/compiler/src/llvm/expression_lowering/native/core_member_lowering.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_member_lowering.sfn
@@ -127,13 +127,13 @@ fn lower_dynamic_member_access(field: string, base_operand: LLVMOperand, temp_in
     if field == "len" { _if70 = true; }
     if field == "length" { _if70 = true; }
     if _if70 {
-        let number_temp = format_temp_name(current_temp);
-        current_lines.push("  " + number_temp
+        let double_temp = format_temp_name(current_temp);
+        current_lines.push("  " + double_temp
             + " = call double @sailfin_runtime_string_to_number(i8* "
             + call_temp
             + ")");
         current_temp += 1;
-        let operand = LLVMOperand { llvm_type: "double", value: number_temp };
+        let operand = LLVMOperand { llvm_type: "double", value: double_temp };
         return make_expression_result(current_lines, current_temp, operand, diagnostics, dynamic_string_constants);
     }
 

--- a/compiler/src/llvm/expression_lowering/native/core_operands.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_operands.sfn
@@ -1867,8 +1867,8 @@ fn coerce_general_fallback(operand: LLVMOperand, operand_type: string, target: s
 //     unconditional; widens that still need to happen run through explicit
 //     `as int` / `as float` casts in source (#532).
 //
-// Slice E.3 (#490) re-applies #296 symmetrically — once every `: number`
-// site in the compiler source has migrated to `: int`/`: float`, the
+// Slice E.3 (#490) re-applies #296 symmetrically — once every `number`-typed
+// site in the compiler source has migrated to `int`/`float`, the
 // rejection re-promotes to `[fatal]` and extends to the permissive
 // sites above. The `numeric_type_kind` helper stays in place as the
 // chokepoint for that re-enablement.
@@ -1903,8 +1903,8 @@ fn coerce_operand_to_type(operand: LLVMOperand, target_type: string, temp_index:
     // ABI primitive kind check: observe silent float → int coercion at
     // boundaries that don't opt in to widening. The asymmetric rule
     // (operand kind=float, target kind=int) catches the Slice E.2 partial
-    // migration mismatch — a callee parameter flipped from `: number`
-    // (double) to `: int` (i64) while a caller still has a `double` in
+    // migration mismatch — a callee parameter flipped from `number`
+    // (double) to `int` (i64) while a caller still has a `double` in
     // hand.
     //
     // #550 (relief valve): the diagnostic is emitted as `[warning]`
@@ -2023,8 +2023,8 @@ fn coerce_operand_to_type(operand: LLVMOperand, target_type: string, temp_index:
 // correct side of int-vs-float for every same-kind expression.
 // Mixed `i64 + double` expressions still funnel through this rule
 // and silently widen — the rejection rides on E.3 once every
-// `: number` site in the compiler source has been migrated to
-// `: int`/`: float`, at which point the literal-typing seam below
+// `number`-typed site in the compiler source has been migrated to
+// `int`/`float`, at which point the literal-typing seam below
 // can refuse the coercion without breaking the runtime helper
 // helpers and `for i in 0..arr.length` patterns. Slice D shipped
 // the `as` cast lowering matrix so authors can spell the conversion
@@ -2104,7 +2104,7 @@ fn harmonise_operands(left: LLVMOperand, right: LLVMOperand, temp_index: int, li
     // Arithmetic harmonisation is the canonical exempted call site:
     // `1 + 2.0` or `arr.length + 0.5` legitimately widen i64 → double here.
     // Slice E.3 (#490) reapplies #296 and removes this opt-out once every
-    // `: number` site in the compiler source has migrated to `: int`/`: float`.
+    // `number`-typed site in the compiler source has migrated to `int`/`float`.
     let left_coercion = coerce_operand_to_type(left_operand, target_type, current_temp, current_lines, true, null);
     let mut _ci0: int = 0;
     loop {

--- a/compiler/src/llvm/expression_lowering/native/core_ops_lowering.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_ops_lowering.sfn
@@ -283,8 +283,8 @@ fn lower_binary_operation(expression: string, match: OperatorMatch, bindings: Pa
     // double` mixes still funnels through `dominant_type`'s
     // silent widening (L2 in `docs/runtime_architecture.md`
     // §3.7) — the rejection rides on Slice E.3 (#296) after
-    // every `: number` site in the compiler source has migrated
-    // to explicit `: int`/`: float`. Slice D's `as` casts let authors
+    // every `number`-typed site in the compiler source has migrated
+    // to explicit `int`/`float`. Slice D's `as` casts let authors
     // spell the conversion explicitly today.
     let mut _right_expected: string = "";
     if left_result.operand != null {

--- a/compiler/src/llvm/expression_lowering/native/core_strings.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_strings.sfn
@@ -47,9 +47,10 @@ fn lower_string_literal(literal: string, temp_index: int, lines: string[]) -> Ex
     // are not known to be unique pointers, unlike user-struct boxes
     // in `core_operands.sfn`); we preserve that exact shape by
     // leaving `RuntimeCallOverrides.return_attributes` empty.
+    let alloc_size_value = number_to_string(array_length);
     let alloc_size_operand = LLVMOperand {
         llvm_type: "i64",
-        value: number_to_string(array_length)
+        value: alloc_size_value
     };
     let alloc_operands: LLVMOperand[] = [alloc_size_operand];
     let alloc_result = emit_runtime_call("alloc_struct", alloc_operands, empty_runtime_call_overrides(), temp_index, current_lines);

--- a/compiler/src/llvm/expression_lowering/native/statement_assignment.sfn
+++ b/compiler/src/llvm/expression_lowering/native/statement_assignment.sfn
@@ -455,7 +455,7 @@ fn lower_lvalue_assignment_stmt(assign_target: string, assign_value: string, ass
                         // explicit ABI boundary in the issue's scope. Refuse
                         // silent int↔float coercion so a future partial
                         // migration that flips one struct field's type from
-                        // `: number` to `: int` while its writers still
+                        // `number` to `int` while its writers still
                         // produce doubles surfaces here loudly.
                         let coerced = coerce_operand_to_type(lowered.operand, field_info.llvm_type, current_temp, current_lines, false, null);
                         let mut _ci5: int = 0;


### PR DESCRIPTION
## Summary

Closes #565.

Earlier slice-E.3a sweeps (notably #588 plus the cluster flips in #586/#601/#602/#604/#605/#607) migrated every real `: number` annotation under `compiler/src/llvm/expression_lowering/` to `: int` or `: float`. What remained were 12 false-positive matches against the issue's acceptance grep:

- **10 prose comments** quoting `` `: number` `` while explaining the historical Slice E migration plan. Rewrote the backtick-quoted spelling to drop the leading `:` (`` `: number` `` → `` `number` `` or `` `number`-typed ``). Meaning preserved; the comments still document the same migration plan.
- **2 false-positive code lines** where a struct field initializer (`value:`) was followed by an identifier starting with `number_*`:
  - `core_member_lowering.sfn:136` — renamed local `number_temp` → `double_temp` (also more accurate now that `number` is a deprecated alias for `double`).
  - `core_strings.sfn:52` — extracted `number_to_string(array_length)` into a local `alloc_size_value` before using it in the struct literal.

Both code refactors are local and semantics-preserving (no IR change expected). The widely-used `number_to_string` utility function is left untouched.

## Acceptance Criteria

- [x] `grep -rnE "(: number|-> number)" compiler/src/llvm/expression_lowering/ --include='*.sfn' | grep -v "// alias-coverage"` returns zero matches.
- [x] `make compile` self-hosts.
- [x] `make test` passes (unit 95/95, integration 23/23, e2e 56/56, capsules 10/10).
- [x] `sfn fmt --check` clean on every modified file.
- [x] **No new fatal diagnostics**. Full rebuild shows 6 ABI-mismatch warnings vs. 8 at baseline — pre-existing and unrelated.

## Verification

```bash
ulimit -v 8388608
make compile                              # self-hosts
make test                                 # unit 95/95, integration 23/23,
                                          # e2e 56/56, capsules 10/10
sfn fmt --check compiler/src/llvm/expression_lowering/   # exit 0

grep -rnE "(: number|-> number)" \
    compiler/src/llvm/expression_lowering/ --include='*.sfn' \
    | grep -v "// alias-coverage"
# → zero matches

make compile 2>&1 | grep "ABI primitive mismatch" | wc -l
# → 6 (baseline 8; no new fatals)
```

## Files Changed

- `compiler/src/llvm/expression_lowering/native/core.sfn`
- `compiler/src/llvm/expression_lowering/native/core_literals_lowering.sfn`
- `compiler/src/llvm/expression_lowering/native/core_member_lowering.sfn`
- `compiler/src/llvm/expression_lowering/native/core_operands.sfn`
- `compiler/src/llvm/expression_lowering/native/core_ops_lowering.sfn`
- `compiler/src/llvm/expression_lowering/native/core_strings.sfn`
- `compiler/src/llvm/expression_lowering/native/statement_assignment.sfn`

## Notes for the reviewer

The issue's latest comment (2026-05-15) said ~12 residual sites remained after PR #588's broader sweep. That count matched what I found, but every single one was either prose inside `//` comments or a coincidental token sequence inside a field initializer — no real `: number` annotations were left. So the actual migration work was already done; this PR just clears the audit grep.

Tagged with `// alias-coverage` was considered for the two code lines but rejected — that tag is for *intentionally-kept* `: number` annotations (per #559's `core_text.sfn` literal-text predicates and the `statement_suspension.sfn` Future seam). For the false-positive lines here, a minimal local refactor was cleaner and removes the ambiguity for future audits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01WdJdPSjnYA2RAjZUM6tJPE)_