### PR TITLE
fix(effect-check): bare print()/console() ![io] detection + docs cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -466,10 +466,13 @@ verification.
 
 ### Adoption Levers (in priority order)
 
-1. **Effect enforcement as compilation gate** — the #1 prerequisite. `validate_effects()`
-   exists in `effect_checker.sfn` but is NOT called from the compilation pipeline in
-   `main.sfn`. Until this ships, "compiler-enforced effects" is aspirational. This is the
-   top item in the Effect System Hardening track on the roadmap.
+1. **Effect enforcement as compilation gate** — the #1 prerequisite. Wiring is in place:
+   `validate_and_render_effects` and `validate_and_render_effects_with_capabilities` are
+   called from every relevant entry point in `compiler/src/main.sfn` (single-file check,
+   emit-native, emit-llvm, multi-file orchestrators). Remaining work is *coverage*, not
+   *wiring* — see #613 for the open headline-integrity gaps (bare `print()` detection
+   hole, macOS arm64 exit-code corruption, capsule capability gate). Until those close,
+   "compile-time enforcement" is real on Linux x86_64 but partial on macOS arm64.
 
 2. **llms.txt** — a canonical single-file language reference at `llms.txt` (also served
    at `sailfin.dev/llms.txt`) designed for LLM context windows. Update it with every

--- a/compiler/src/effect_checker.sfn
+++ b/compiler/src/effect_checker.sfn
@@ -635,6 +635,21 @@ fn collect_effects_from_expression(expression: Expression?, imports: ImportSymbo
                     effect: "net", description: "serve call", trigger: callee_trigger
                 });
             }
+            // Bare `print(...)` / `console(...)` are the Call-form
+            // analog of the Member-form `print.info(...)` paths
+            // handled below in the "Member" branch. Without this
+            // Call-side check, a capability-less
+            // `fn main() { print("hi"); }` slips through `sfn check`
+            // despite the README's first example asserting exactly
+            // the opposite. Closes #614.
+            let mut _print_or_console: boolean = false;
+            if name == "print" { _print_or_console = true; }
+            if name == "console" { _print_or_console = true; }
+            if _print_or_console {
+                required = append_requirement(required, EffectRequirement {
+                    effect: "io", description: "print/console helper usage", trigger: callee_trigger
+                });
+            }
             // Phase E: cross-module call resolution. The imports
             // table is per-program-localized (alias-rewritten,
             // scope-filtered) so a direct `Identifier` lookup is

--- a/compiler/tests/integration/assert_fail_record_test.sfn
+++ b/compiler/tests/integration/assert_fail_record_test.sfn
@@ -24,7 +24,7 @@
 // documented in the issue's verification block; running it here
 // would make this whole file fail and defeat the regression
 // guard.
-test "assert_fail_record: pass output containing the word panic is not flagged" {
+test "assert_fail_record: pass output containing the word panic is not flagged" ![io] {
     let diagnostic_text = "panic: divide by zero (this is just a string, not a real panic)";
     print(diagnostic_text);
     print("error: another false-positive trigger word");

--- a/compiler/tests/unit/effect_checker_test.sfn
+++ b/compiler/tests/unit/effect_checker_test.sfn
@@ -484,6 +484,51 @@ test "effect violation: bare sleep() Call carets at the callee for clock effect"
     assert trig.lexeme == "sleep";
 }
 
+test "effect violation: bare print() Call carets at the callee for io effect" {
+    // Closes #614. The Member-form `print.info(...)` already trips
+    // E0400 (covered by "effect violation: print.<x> Member call
+    // carets at print" above). The bare Call-form was uncovered
+    // because the Call-with-Identifier branch in `effect_checker.sfn`
+    // skipped over `print` / `console`. This test locks the parity in.
+    let stmt = _routine_with_bare_call("noisy", [], 4, "print", 7, 5);
+    let program = Program { statements: [stmt] };
+    let violations = validate_effects(program);
+    assert violations.length == 1;
+    let v = violations[0];
+    let mut found_io: boolean = false;
+    let mut i: int = 0;
+    loop {
+        if i >= v.missing_effects.length { break; }
+        if v.missing_effects[i] == "io" { found_io = true; }
+        i += 1;
+    }
+    assert found_io;
+    assert v.trigger != null;
+    let trig: Token? = v.trigger;
+    assert trig.line == 7;
+    assert trig.column == 5;
+    assert trig.lexeme == "print";
+}
+
+test "effect violation: bare console() Call carets at the callee for io effect" {
+    let stmt = _routine_with_bare_call("chatty", [], 12, "console", 14, 3);
+    let program = Program { statements: [stmt] };
+    let violations = validate_effects(program);
+    assert violations.length == 1;
+    let v = violations[0];
+    let mut found_io: boolean = false;
+    let mut i: int = 0;
+    loop {
+        if i >= v.missing_effects.length { break; }
+        if v.missing_effects[i] == "io" { found_io = true; }
+        i += 1;
+    }
+    assert found_io;
+    assert v.trigger != null;
+    let trig: Token? = v.trigger;
+    assert trig.lexeme == "console";
+}
+
 test "effect violation: AST trigger overrides signature fallback" {
     // Lock the precedence rule in: when the body walker captures a
     // per-call-site trigger, that trigger wins over the signature


### PR DESCRIPTION
First two commits against the compiler integrity gaps tracked in #613.

## Summary

- **#614** — `fix(effect-check): detect bare print()/console() calls as [io]`. The Call-with-Identifier branch in `effect_checker.sfn` was missing `print` / `console` even though it already covered `spawn` / `sleep` / `serve`. Adds the two name checks plus two regression tests paralleling the existing `bare spawn() Call carets` / `bare sleep() Call carets` peers.
- **#621** — `docs(claude): remove stale "validate_effects not wired" claim`. The LLM & Agent Adoption Strategy section claimed `validate_effects()` is not called from the pipeline; it actually is, at 9 sites in `main.sfn`. Re-anchored the #1 prerequisite at the remaining headline-integrity gaps tracked under #613.

## Verification

Run on Linux x86_64 with the freshly-built `build/native/sailfin` (0.5.10-alpha.19+dev.d4b8879.dirty):

```bash
ulimit -v 8388608

# Bare print() without [io] — now caught
cat > /tmp/bare.sfn << 'EOF'
fn main() {
    print("hi");
}
EOF
build/native/sailfin check /tmp/bare.sfn
# error[E0400]: function `main` is missing required effects: [io]
#   --> /tmp/bare.sfn:2:5
#  2 |     print("hi");
#    |     ^^^^^
# exit=1

# Same source with [io] — still passes
cat > /tmp/ok.sfn << 'EOF'
fn main() [io] { print("hi"); }
EOF
build/native/sailfin check /tmp/ok.sfn  # exit=0
```

Full unit suite: `make test-unit` — **95/95 PASS**, includes the two new test cases inside `effect_checker_test.sfn`.

Formatting: `sfn fmt --check` on both touched `.sfn` files exits 0.

## Test plan

- [x] `make compile` succeeds
- [x] `make test-unit` passes (95/95)
- [x] Bare `print("hi")` without `[io]` produces `error[E0400]` and exits 1
- [x] Bare `print("hi")` with `[io]` declared exits 0
- [x] Bare `console("hi")` without `[io]` produces `error[E0400]` and exits 1
- [x] `sfn fmt --check` clean on touched files
- [ ] Integration / e2e — not run in this session; CI to confirm

Closes #614
Closes #621
Part of #613

https://claude.ai/code/session_01DGxmyQF7AkU3HkM2jeBHRC

---
_Generated by [Claude Code](https://claude.ai/code/session_01DGxmyQF7AkU3HkM2jeBHRC)_