### PR TITLE
fix(sync): remove unimplemented channel/parallel/spawn surface

### DIFF
--- a/capsules/sfn/sync/src/mod.sfn
+++ b/capsules/sfn/sync/src/mod.sfn
@@ -1,30 +1,30 @@
 // sfn/sync — Concurrency and synchronization primitives for Sailfin.
 //
-// Provides channels for inter-task communication, parallel execution,
-// and task spawning. All operations require the `io` effect.
-
-fn channel(capacity: number = 0) -> any ![io] {
-    // Create a bounded channel for inter-task communication.
-    // Capacity of 0 means unbuffered (synchronous handoff).
-    return runtime.channel(capacity);
-}
-
-fn parallel(tasks: any[]) -> any[] ![io] {
-    // Run multiple tasks concurrently and collect results.
-    // Returns an array of results in the same order as the input tasks.
-    // Each task is a zero-argument function.
-    //
-    // Usage:
-    //   let results = parallel([
-    //       fn() { fetch_user(1) },
-    //       fn() { fetch_user(2) },
-    //   ]);
-    return runtime.parallel(tasks);
-}
-
-fn spawn(task: any, name: string = "") -> void ![io] {
-    // Spawn a task to run concurrently in the background.
-    // The task runs on the runtime's task scheduler.
-    // Use channels to communicate results back.
-    runtime.spawn(task, name);
-}
+// The untyped `channel`, `parallel`, and `spawn` exports were removed
+// (issue #617, a sub-task of #613) because the structured-concurrency
+// runtime they fronted is not yet implemented: their C bridges
+// (`sailfin_runtime_{channel,parallel,spawn}`) silently returned NULL
+// / no-op'd, so callers built and ran but did nothing concurrent. The
+// project's `llms.txt` rule forbids "parsed but unenforced" surface, so
+// the entire untyped wrapper layer is gone — the prelude wrappers,
+// this capsule's exports, and the LLVM lowering descriptors that
+// bridged them to the C runtime. Any caller that names `channel`,
+// `parallel`, or `spawn` now fails the LLVM lowering pass with a
+// `llvm lowering [fatal]: cannot resolve return type for call to ...`
+// diagnostic. The regression test
+// `compiler/tests/e2e/test_sync_rejects_unimplemented_concurrency.sh`
+// pins the visible-failure surface. (`sfn check` itself still accepts
+// these — that's the open undefined-identifier gap tracked under #616.)
+//
+// Migration:
+//   - For task-style concurrency, use the typed `spawn_*` / `await_*`
+//     primitives backed by real pthread implementations in
+//     `runtime/native/src/sailfin_runtime.c` (e.g. `spawn_number`,
+//     `spawn_string`, `spawn_bool`, `spawn_ptr`, `spawn_void`, plus
+//     `_ctx` variants for closures).
+//   - For channels / `parallel(...)`, wait for the structured-
+//     concurrency runtime (tracked under #500, roadmap M4).
+//
+// The capsule intentionally stays in the workspace as an empty shell
+// so the `sfn/sync` name remains reserved for when the real runtime
+// ships and re-introduces these exports with working implementations.

--- a/compiler/src/llvm/lowering/lowering_helpers.sfn
+++ b/compiler/src/llvm/lowering/lowering_helpers.sfn
@@ -724,7 +724,6 @@ fn seed_default_runtime_helpers(initial: string[]) -> string[] {
     helpers = append_unique_effect(helpers, "runtime_array_map_fn");
     helpers = append_unique_effect(helpers, "runtime_array_filter_fn");
     helpers = append_unique_effect(helpers, "runtime_array_reduce_fn");
-    helpers = append_unique_effect(helpers, "runtime_channel_fn");
     helpers = append_unique_effect(helpers, "runtime_char_code_fn");
     helpers = append_unique_effect(helpers, "runtime_grapheme_at_fn");
     helpers = append_unique_effect(helpers, "runtime_grapheme_count_fn");
@@ -737,7 +736,6 @@ fn seed_default_runtime_helpers(initial: string[]) -> string[] {
     helpers = append_unique_effect(helpers, "runtime_is_void_fn");
     helpers = append_unique_effect(helpers, "runtime_log_execution_fn");
     helpers = append_unique_effect(helpers, "runtime_monotonic_millis_fn");
-    helpers = append_unique_effect(helpers, "runtime_parallel_fn");
     helpers = append_unique_effect(helpers, "runtime_resolve_runtime_type_fn");
     helpers = append_unique_effect(helpers, "runtime_serve_fn");
     helpers = append_unique_effect(helpers, "runtime_sleep_fn");
@@ -749,7 +747,6 @@ fn seed_default_runtime_helpers(initial: string[]) -> string[] {
     // preamble has to take over. Disappears when PR 2 retires the
     // C trampoline.
     helpers = append_unique_effect(helpers, "sailfin_runtime_sleep");
-    helpers = append_unique_effect(helpers, "runtime_spawn_fn");
     helpers = append_unique_effect(helpers, "runtime_to_debug_string_fn");
     helpers = append_unique_effect(helpers, "runtime_create_capability_grant");
     helpers = append_unique_effect(helpers, "runtime_create_filesystem_bridge");

--- a/compiler/src/llvm/runtime_helpers.sfn
+++ b/compiler/src/llvm/runtime_helpers.sfn
@@ -207,15 +207,12 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
         target: "monotonic_millis", symbol: "sailfin_runtime_monotonic_millis", return_type: "double", parameter_types: [], effects: ["clock"], native_signature: null
     });
-    descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "runtime_channel_fn", symbol: "sailfin_runtime_channel", return_type: "i8*", parameter_types: ["double"], effects: ["io"], native_signature: null
-    });
-    descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "runtime_spawn_fn", symbol: "sailfin_runtime_spawn", return_type: "void", parameter_types: ["i8*", "i8*"], effects: ["io"], native_signature: null
-    });
-    descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "runtime_parallel_fn", symbol: "sailfin_runtime_parallel", return_type: "i8*", parameter_types: ["i8*"], effects: ["io"], native_signature: null
-    });
+    // Untyped `channel` / `spawn` / `parallel` descriptors removed under
+    // issue #617 — their C bridges were silent no-ops and the
+    // `sfn/sync` exports that fronted them are gone. The typed
+    // `spawn_*` / `await_*` flavors (real pthread implementations) keep
+    // their descriptors below. Re-introduce these only when the
+    // structured-concurrency runtime (#500, roadmap M4) actually lands.
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
         target: "runtime_create_capability_grant", symbol: "sailfin_runtime_create_capability_grant", return_type: "i8*", parameter_types: ["i8*"], effects: [], native_signature: null
     });

--- a/compiler/tests/e2e/test_sync_rejects_unimplemented_concurrency.sh
+++ b/compiler/tests/e2e/test_sync_rejects_unimplemented_concurrency.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# E2E regression test for issue #617 (sub-task of #613).
+#
+# Background: `capsules/sfn/sync/src/mod.sfn` used to export
+# untyped `channel(...)`, `parallel(...)`, and `spawn(...)`, and
+# `runtime/prelude.sfn` exposed identically-named prelude wrappers,
+# all delegating to `sailfin_runtime_{channel,parallel,spawn}` —
+# three C bridges that silently returned NULL / no-op'd. Programs
+# built, ran, and did nothing concurrent. The project's `llms.txt`
+# rule forbids "parsed but unenforced" surface, so the entire
+# untyped wrapper layer was deleted: the `sfn/sync` capsule exports,
+# the prelude wrappers, the prelude `runtime.channel/_spawn/_parallel`
+# bindings, and the LLVM lowering descriptors that pointed at them.
+# The three C stub bodies in `runtime/native/src/sailfin_runtime.c`
+# stay until a new seed without those references is pinned (a
+# `seed-blocker` follow-up); freshly-built compilers no longer emit
+# any reference to them.
+#
+# Acceptance: any caller that mentions `channel` / `parallel` /
+# `spawn` (whether via `import { ... } from "sfn/sync"` or via the
+# prelude name itself) must visibly fail at compile time rather
+# than silently linking to a NULL-returning runtime trap. The
+# diagnostic comes from the LLVM lowering pass: it cannot resolve
+# the call's return type now that the descriptor that bridged the
+# name to a C symbol is gone.
+#
+# `sfn check` is intentionally NOT used here — it does not yet flag
+# undefined function identifiers (tracked as #616). The active
+# rejection path is `sfn build`, which exits non-zero and emits a
+# `llvm lowering [fatal]: cannot resolve return type for call to ...`
+# diagnostic the moment lowering tries to compile a call to a
+# now-unknown name.
+#
+# The typed `spawn_*` / `await_*` runtime variants below are not
+# exercised here — they have working pthread implementations and
+# are unaffected by this change.
+#
+# Usage:
+#   compiler/tests/e2e/test_sync_rejects_unimplemented_concurrency.sh <compiler-binary>
+
+set -euo pipefail
+
+BINARY="${1:?usage: test_sync_rejects_unimplemented_concurrency.sh <compiler-binary>}"
+BINARY="$(realpath "$BINARY")"
+PASS=0
+FAIL=0
+
+SCRATCH="$(mktemp -d -t sfn-sync-rejects-XXXXXX)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+run_test() {
+    local name="$1"
+    shift
+    if "$@"; then
+        echo "[test] PASS: $name"
+        PASS=$((PASS + 1))
+    else
+        echo "[test] FAIL: $name"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# Run `sfn build` against the supplied source and confirm the
+# lowering diagnostic is emitted and names the offending symbol.
+# The build is invoked from a directory OUTSIDE the source tree
+# (we use the scratch dir as cwd) so the driver does not stumble
+# onto a workspace capsule and try to compile it instead.
+#
+# We deliberately do NOT assert a non-zero exit code or absence of
+# an output binary. Both hold for the value-returning cases
+# (`channel` / `parallel` — `sfn build` exits 1 and produces no
+# binary), but the void-returning `spawn` case stumbles past the
+# fatal diagnostic and still emits a (broken) binary with rc=0.
+# That divergence is a separate lowering / driver bug to file as
+# a follow-up; here we just verify the failure is *visible*
+# (grep-checkable on stdout+stderr), which is the explicit
+# acceptance criterion in #617.
+assert_build_rejects() {
+    local label="$1"
+    local source="$2"
+    local symbol="$3"
+
+    local src_path="$SCRATCH/${label}.sfn"
+    local out_path="$SCRATCH/${label}.out"
+    local log_path="$SCRATCH/${label}.log"
+    printf '%s\n' "$source" > "$src_path"
+
+    ( cd "$SCRATCH" && "$BINARY" build -o "$out_path" "$src_path" ) \
+        > "$log_path" 2>&1 || true
+
+    if ! grep -q "cannot resolve" "$log_path"; then
+        echo "[test]   diagnostic for ${label}.sfn did not mention 'cannot resolve'" >&2
+        echo "[test]   output:" >&2
+        sed 's/^/[test]     /' "$log_path" >&2
+        return 1
+    fi
+
+    if ! grep -q "\`${symbol}\`" "$log_path"; then
+        echo "[test]   diagnostic for ${label}.sfn did not name '\`${symbol}\`'" >&2
+        echo "[test]   output:" >&2
+        sed 's/^/[test]     /' "$log_path" >&2
+        return 1
+    fi
+
+    return 0
+}
+
+test_channel_via_sfn_sync_rejected() {
+    assert_build_rejects "channel_import_caller" \
+'import { channel } from "sfn/sync";
+
+fn main() ![io] {
+    let _ch = channel(0);
+}' \
+        "channel"
+}
+
+test_parallel_via_sfn_sync_rejected() {
+    assert_build_rejects "parallel_import_caller" \
+'import { parallel } from "sfn/sync";
+
+fn main() ![io] {
+    let _results = parallel([]);
+}' \
+        "parallel"
+}
+
+test_spawn_via_sfn_sync_rejected() {
+    assert_build_rejects "spawn_import_caller" \
+'import { spawn } from "sfn/sync";
+
+fn main() ![io] {
+    spawn(0, "worker");
+}' \
+        "spawn"
+}
+
+# The prelude no longer exposes a top-level `channel` / `parallel` /
+# `spawn` wrapper either, so a program that names them without any
+# import must also be rejected. This guards the second silent-NULL
+# surface (the unqualified prelude name) — pre-#617 this was the
+# path most users actually hit when they wrote `spawn(...)` thinking
+# of the keyword form.
+test_channel_via_prelude_name_rejected() {
+    assert_build_rejects "channel_prelude_caller" \
+'fn main() ![io] {
+    let _ch = channel(0);
+}' \
+        "channel"
+}
+
+test_spawn_via_prelude_name_rejected() {
+    assert_build_rejects "spawn_prelude_caller" \
+'fn main() ![io] {
+    spawn(0, "worker");
+}' \
+        "spawn"
+}
+
+run_test "sfn build rejects sfn/sync.channel import (#617)" test_channel_via_sfn_sync_rejected
+run_test "sfn build rejects sfn/sync.parallel import (#617)" test_parallel_via_sfn_sync_rejected
+run_test "sfn build rejects sfn/sync.spawn import (#617)" test_spawn_via_sfn_sync_rejected
+run_test "sfn build rejects bare prelude channel() (#617)" test_channel_via_prelude_name_rejected
+run_test "sfn build rejects bare prelude spawn() (#617)" test_spawn_via_prelude_name_rejected
+
+echo "[summary] $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi

--- a/runtime/native/include/sailfin_runtime.h
+++ b/runtime/native/include/sailfin_runtime.h
@@ -224,6 +224,18 @@ extern "C"
     // Additional prelude/runtime helpers (currently minimal implementations).
     void sailfin_runtime_copy_bytes(char *dest, char *src, int64_t length);
     char *sailfin_runtime_log_execution(char *value);
+    // Issue #617: these three untyped exports are deprecated stubs
+    // (silent NULL/no-op). The Sailfin-level wrappers in `sfn/sync`,
+    // the prelude `runtime.channel/_spawn/_parallel` bindings, and
+    // the LLVM lowering descriptors that reached them are all gone,
+    // so freshly-built compilers no longer emit calls to these
+    // symbols. They remain DECLARED here only because the currently
+    // pinned seed's pre-built `prelude.o` still calls them; remove
+    // both the declarations and the definitions below once a new
+    // seed without those references is pinned. Tracked as a
+    // `seed-blocker` cleanup. The typed `spawn_*` / `await_*`
+    // variants further down are real pthread implementations and
+    // are unaffected.
     char *sailfin_runtime_channel(double capacity);
     char *sailfin_runtime_parallel(char *thunk);
     void sailfin_runtime_spawn(char *thunk, char *name);

--- a/runtime/native/src/sailfin_runtime.c
+++ b/runtime/native/src/sailfin_runtime.c
@@ -4715,6 +4715,19 @@ char *sailfin_runtime_log_execution(char *value)
     return value;
 }
 
+// Issue #617: the Sailfin-level entry points to these three stubs
+// (the `sfn/sync` `channel` / `parallel` / `spawn` exports, the
+// prelude `runtime.channel/_spawn/_parallel` bindings, and the
+// LLVM lowering descriptors that pointed at them) have all been
+// removed, so freshly-built compilers never emit a call to any
+// of the three. The stub bodies remain ONLY because the currently
+// pinned seed's pre-built `prelude.o` still has unresolved
+// references to these symbols and would refuse to link
+// otherwise — they are seed-blocker cleanup once a new seed
+// without those references is pinned. Callers that want
+// concurrency today must use the typed `spawn_*` / `await_*`
+// variants below (real pthread implementations); structured
+// concurrency proper is tracked under #500 (roadmap M4).
 char *sailfin_runtime_channel(double capacity)
 {
     (void)capacity;

--- a/runtime/prelude.sfn
+++ b/runtime/prelude.sfn
@@ -13,8 +13,6 @@ let runtime_create_filesystem_bridge = runtime.create_filesystem_bridge;
 let runtime_create_http_bridge = runtime.create_http_bridge;
 let runtime_sleep_fn = runtime.sleep;
 let runtime_monotonic_millis_fn = runtime.monotonic_millis;
-let runtime_channel_fn = runtime.channel;
-let runtime_spawn_fn = runtime.spawn;
 let runtime_log_execution_fn = runtime.logExecution;
 let runtime_to_debug_string_fn = runtime.to_debug_string;
 let runtime_raise_value_error_fn = runtime.raise_value_error;
@@ -29,7 +27,6 @@ let runtime_resolve_runtime_type_fn = runtime.resolve_runtime_type;
 let runtime_instance_of_fn = runtime.instance_of;
 let runtime_serve_fn = runtime.serve;
 let runtime_char_code_fn = runtime.char_code;
-let runtime_parallel_fn = runtime.parallel;
 let runtime_array_map_fn = runtime.array_map;
 let runtime_array_filter_fn = runtime.array_filter;
 let runtime_array_reduce_fn = runtime.array_reduce;
@@ -83,18 +80,6 @@ struct TypeDescriptor {
 fn sleep(milliseconds: int) ![clock] { runtime_sleep_fn(milliseconds); }
 
 fn monotonic_millis() -> int ![clock] { return runtime_monotonic_millis_fn(); }
-
-fn channel < T > (capacity: int = 0) -> any ![io] {
-    return runtime_channel_fn(capacity);
-}
-
-fn parallel(tasks: any[]) -> any[] ![io] {
-    return runtime_parallel_fn(tasks);
-}
-
-fn spawn(task: any, name: string = "") -> void ![io] {
-    runtime_spawn_fn(task, name);
-}
 
 fn logExecution(callable: any) -> any {
     return runtime_log_execution_fn(callable);


### PR DESCRIPTION
## Summary

- Removes the three silent-NULL untyped concurrency entries (`channel` / `parallel` / `spawn`) from `sfn/sync`, the prelude wrappers, the prelude `runtime.X` bindings, and the LLVM lowering descriptors that bridged them to the C runtime. Freshly-built compilers never emit a call to `sailfin_runtime_{channel,parallel,spawn}` again.
- Adds `compiler/tests/e2e/test_sync_rejects_unimplemented_concurrency.sh` (5 cases) pinning the now-visible `llvm lowering [fatal]: cannot resolve return type for call to ...` diagnostic that fires on every removed name.
- Keeps the three C stub bodies (and header declarations) for now — the currently pinned seed's pre-built `prelude.o` still references them, so deleting them right now breaks the bootstrap link. That's a `seed-blocker` cleanup once a new seed without those references is pinned.

Closes #617

## Acceptance Criteria

- [x] **Decision recorded in this thread: trap-at-runtime vs reject-at-compile-time.** Reject at compile time — per the grooming comment on #617.
- [x] **Chosen behavior implemented and covered by a test.** Implemented as a removal of the Sailfin-level entry points plus the lowering descriptors; covered by the new e2e test (5 sub-cases).
- [x] **`sfn check` continues to accept programs that call `channel`/`spawn`/`parallel` (until decision says otherwise).** Verified — `sfn check` still says `ok` on these inputs; the undefined-identifier gap is the open #616 investigation and is intentionally out of scope here.
- [x] **At least one example or test that previously silently returned NULL now visibly fails (and the failure is grep-checkable).** The new e2e test greps for `cannot resolve` and the offending symbol name on five distinct sample callers.

## Verification

```bash
$ ulimit -v 8388608 && make compile
[compile] built build/native/sailfin

$ ulimit -v 8388608 && bash compiler/tests/e2e/test_sync_rejects_unimplemented_concurrency.sh build/native/sailfin
[test] PASS: sfn build rejects sfn/sync.channel import (#617)
[test] PASS: sfn build rejects sfn/sync.parallel import (#617)
[test] PASS: sfn build rejects sfn/sync.spawn import (#617)
[test] PASS: sfn build rejects bare prelude channel() (#617)
[test] PASS: sfn build rejects bare prelude spawn() (#617)
[summary] 5 passed, 0 failed

$ ulimit -v 8388608 && make test
═══ unit: 95/95 passed, 0 failed ═══
═══ integration: 23/23 passed, 0 failed ═══
═══ e2e: 57/57 passed, 0 failed ═══
═══ capsules: 10/10 passed, 0 failed ═══
```

`sfn fmt --check` is clean on every modified `.sfn` file
(`runtime/prelude.sfn`, `capsules/sfn/sync/src/mod.sfn`,
`compiler/src/llvm/runtime_helpers.sfn`,
`compiler/src/llvm/lowering/lowering_helpers.sfn`).

## Files Changed

- `capsules/sfn/sync/src/mod.sfn` — three `channel` / `parallel` / `spawn` exports replaced with a migration note pointing at the typed `spawn_*` / `await_*` primitives and #500.
- `runtime/prelude.sfn` — drops `let runtime_channel_fn = runtime.channel;` plus the `_spawn` / `_parallel` siblings AND the three `fn channel<T>` / `fn parallel` / `fn spawn` wrappers.
- `compiler/src/llvm/runtime_helpers.sfn` — drops the three `RuntimeHelperDescriptor` entries that mapped `runtime_channel_fn` / `runtime_spawn_fn` / `runtime_parallel_fn` to the C symbols. Leaves a tombstone comment.
- `compiler/src/llvm/lowering/lowering_helpers.sfn` — drops the three `append_unique_effect(helpers, "runtime_channel_fn" / ...)` lines so the helper preamble no longer emits unconditional `declare` lines for these symbols.
- `runtime/native/include/sailfin_runtime.h` — keeps the three declarations; adds a comment flagging them as the `seed-blocker` cleanup.
- `runtime/native/src/sailfin_runtime.c` — keeps the three stub bodies; adds a comment with the same flag.
- `compiler/tests/e2e/test_sync_rejects_unimplemented_concurrency.sh` — new e2e regression test.

## Notes for the reviewer

- I had to expand the issue's `## Files Affected` list. The grooming comment specified three locations (`mod.sfn`, `sailfin_runtime.c:4718-4734`, plus a test); shipping a coherent "compile-time reject" actually requires touching `runtime/prelude.sfn` (which had identically-named wrappers and the `runtime.X` bindings) and the two lowering files (which still had hardcoded descriptors bridging the names to the C runtime). Leaving any of those in place produced either a still-resolvable `channel(...)` call or a `sfn build` that crashed during the prelude.ll re-emit. Calling that out here in case the reviewer wants those split into a follow-up — happy to do so if asked.
- The C stub deletion (the literal lines `4718-4734` from the issue body) is **not** in this PR. The currently pinned seed's `prelude.o` has unresolved references to those symbols and link fails the moment they're gone. A new seed cut on top of this commit, then `/pin-seed`, then a follow-up PR can delete the stubs. Both layers carry comments saying so.
- The e2e test deliberately doesn't assert non-zero exit code or absence of an output binary. The void-returning `spawn` case stumbles past the lowering fatal and still emits a (broken) binary with rc=0 — a separate driver bug worth a dedicated issue. The grep-checkable diagnostic is what the issue acceptance criteria explicitly asked for.
- During implementation I had to manually delete `build/sailfin/sfn__runtime-native__sailfin_runtime.c-O2.o` once because the build cache held a stale object compiled before I reverted a C-stub deletion attempt. Worth noting if anyone else gets a confusing link error mid-iteration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LpS842ZH3cAfQdEdRiYtLX)_