### PR TITLE
fix(lowering): infer int[] from integer-literal array elements (#599)

### DIFF
--- a/capsules/sfn/layers/tests/layers_test.sfn
+++ b/capsules/sfn/layers/tests/layers_test.sfn
@@ -11,9 +11,7 @@
 // array-indexing lowering used in `forward_linear`. Once that compiler bug
 // is fixed, this file should drop the `_`-prefixed copies and import the
 // real capsule API.
-
 // -- Types and helpers copied from sfn/layers --
-
 struct Linear {
     weights: number[];
     biases: number[];
@@ -38,8 +36,10 @@ fn _linear(in_features: number, out_features: number) -> Linear {
         i += 1;
     }
     return Linear {
-        weights: weights, biases: biases,
-        in_features: in_features, out_features: out_features,
+        weights: weights,
+        biases: biases,
+        in_features: in_features,
+        out_features: out_features
     };
 }
 
@@ -66,11 +66,7 @@ fn _forward_relu(input: number[]) -> number[] {
     let mut i: number = 0;
     loop {
         if i >= input.length { break; }
-        if input[i] > 0 {
-            output.push(input[i]);
-        } else {
-            output.push(0);
-        }
+        if input[i] > 0 { output.push(input[i]); } else { output.push(0); }
         i += 1;
     }
     return output;
@@ -81,7 +77,6 @@ fn _parameter_count(layer: Linear) -> number {
 }
 
 // -- Tests --
-
 test "layers: linear constructor creates zero-initialized layer" {
     let layer = _linear(3, 2);
     assert layer.in_features == 3;
@@ -104,7 +99,9 @@ test "layers: parameter_count includes weights and biases" {
 
 test "layers: forward_linear with zero weights produces bias output" {
     let layer = _linear(3, 2);
-    let input = [1, 2, 3];
+    // Fractional literals to match the `: number[]` ABI; post-#599 the
+    // bare-integer `[1, 2, 3]` would lower as `int[]` and mismatch.
+    let input = [1.0, 2.0, 3.0];
     let output = _forward_linear(layer, input);
     assert output.length == 2;
     // Zero weights and zero biases => all outputs are 0
@@ -115,12 +112,12 @@ test "layers: forward_linear with zero weights produces bias output" {
 test "layers: forward_linear with custom weights" {
     // 2 inputs, 1 output: weights=[2, 3], bias=[1]
     let layer = Linear {
-        weights: [2, 3],
-        biases: [1],
+        weights: [2.0, 3.0],
+        biases: [1.0],
         in_features: 2,
-        out_features: 1,
+        out_features: 1
     };
-    let input = [4, 5];
+    let input = [4.0, 5.0];
     let output = _forward_linear(layer, input);
     // 4*2 + 5*3 + 1 = 8 + 15 + 1 = 24
     assert output.length == 1;
@@ -132,12 +129,12 @@ test "layers: forward_linear with multiple outputs" {
     // weights = [1, 0, 0, 1] (identity-like)
     // biases = [10, 20]
     let layer = Linear {
-        weights: [1, 0, 0, 1],
-        biases: [10, 20],
+        weights: [1.0, 0.0, 0.0, 1.0],
+        biases: [10.0, 20.0],
         in_features: 2,
-        out_features: 2,
+        out_features: 2
     };
-    let input = [3, 7];
+    let input = [3.0, 7.0];
     let output = _forward_linear(layer, input);
     assert output.length == 2;
     // output[0] = 3*1 + 7*0 + 10 = 13
@@ -147,7 +144,7 @@ test "layers: forward_linear with multiple outputs" {
 }
 
 test "layers: forward_relu zeroes negative values" {
-    let result = _forward_relu([3, -1, 0, 5, -2]);
+    let result = _forward_relu([3.0, -1.0, 0.0, 5.0, -2.0]);
     assert result.length == 5;
     assert result[0] == 3;
     assert result[1] == 0;
@@ -157,7 +154,7 @@ test "layers: forward_relu zeroes negative values" {
 }
 
 test "layers: forward_relu with all positive values" {
-    let result = _forward_relu([1, 2, 3]);
+    let result = _forward_relu([1.0, 2.0, 3.0]);
     assert result[0] == 1;
     assert result[1] == 2;
     assert result[2] == 3;
@@ -166,20 +163,20 @@ test "layers: forward_relu with all positive values" {
 test "layers: linear then relu pipeline" {
     // Simulate a simple linear -> relu pipeline
     let layer = Linear {
-        weights: [1, -1],
-        biases: [0],
+        weights: [1.0, -1.0],
+        biases: [0.0],
         in_features: 2,
-        out_features: 1,
+        out_features: 1
     };
     // input [3, 5] => 3*1 + 5*(-1) + 0 = -2
-    let linear_out = _forward_linear(layer, [3, 5]);
+    let linear_out = _forward_linear(layer, [3.0, 5.0]);
     assert linear_out[0] == -2;
     let relu_out = _forward_relu(linear_out);
     // ReLU(-2) = 0
     assert relu_out[0] == 0;
 
     // input [5, 3] => 5*1 + 3*(-1) + 0 = 2
-    let linear_out2 = _forward_linear(layer, [5, 3]);
+    let linear_out2 = _forward_linear(layer, [5.0, 3.0]);
     assert linear_out2[0] == 2;
     let relu_out2 = _forward_relu(linear_out2);
     // ReLU(2) = 2

--- a/compiler/src/emit_native_format.sfn
+++ b/compiler/src/emit_native_format.sfn
@@ -186,8 +186,39 @@ fn infer_array_element_type(elements: Expression[]) -> string {
     return candidate;
 }
 
+// Discriminate integer-vs-float for `NumberLiteral.value`. The lexer captures
+// number tokens as `digits` (integer) or `digits.digits` (float) — no
+// scientific notation, no hex/octal — so the presence of `.` is sufficient.
+// Keeping this aligned with the scalar default from Slice E.1 (#488): bare
+// integer literals are `int`, bare fractional literals are `float`. Without
+// this discrimination, `let arr: int[] = [42]` lowers as `{ double*, i64, i64 }*`
+// and `arr[0]` reads `i64` over a `double` bit pattern — issue #599.
+fn _number_literal_kind(value: string) -> string {
+    let mut i: int = 0;
+    loop {
+        if i >= value.length { break; }
+        if value[i] == "." { return "float"; }
+        i += 1;
+    }
+    return "int";
+}
+
 fn infer_expression_type(expression: Expression) -> string {
-    if expression.variant == "NumberLiteral" { return "number"; }
+    if expression.variant == "NumberLiteral" {
+        return _number_literal_kind(expression.value);
+    }
+    if expression.variant == "Unary" {
+        // Signed numeric literals parse as `Unary { -, NumberLiteral }`.
+        // For element-type inference the sign is irrelevant — `-3` has
+        // the same numeric kind as `3`. Without this recursion,
+        // `[1, 2, -3]` would mix `int` with `""` from `infer_array_element_type`
+        // and fall back to the pre-#599 `double` element default, defeating
+        // the int-array fix at any call site with a negative literal.
+        if expression.operand.variant == "NumberLiteral" {
+            return _number_literal_kind(expression.operand.value);
+        }
+        return "";
+    }
     if expression.variant == "BooleanLiteral" { return "boolean"; }
     if expression.variant == "StringLiteral" { return "string"; }
     if expression.variant == "Struct" {

--- a/compiler/src/llvm/expression_lowering/native/core_literals_lowering.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_literals_lowering.sfn
@@ -262,6 +262,46 @@ fn lower_array_literal(text: string, bindings: ParameterBinding[], locals: Local
             inferred_element_type = expected_element_type;
         }
     }
+    // Issue #599 belt-and-suspenders: when the `let`-binding annotation
+    // resolves to `double` AND the parsed `.sfn-asm` metadata resolves to
+    // `i64` (or vice versa), prefer the `let`-binding annotation. The
+    // pre-fix emitter labelled every integer literal as `#element:number`
+    // (→ `double`), so `let arr: int[] = [42]` produced `double` metadata
+    // overriding the `i64` expected — issue #599 itself. The post-fix
+    // emitter labels integer literals as `#element:int` (→ `i64`), which
+    // newly conflicts with `let powers: number[] = [1000000000000000, ...]`
+    // in `compiler/src/llvm/utils.sfn:134` and the analogous table in
+    // `compiler/src/llvm/expression_lowering/native/core_text.sfn:17`
+    // (both legitimately need `double` storage for use in `double`
+    // arithmetic). Limiting the override to the `i64`↔`double` pair
+    // keeps struct/enum element handling (the `_keep_element_type`
+    // ABI logic at line ~330) untouched and avoids overriding the
+    // pointer/string element paths.
+    if expected_element_type.length > 0 {
+        if metadata.element_type.length > 0 {
+            if expected_element_type != metadata.element_type {
+                let mut _expected_is_numeric: boolean = false;
+                if expected_element_type == "i64" {
+                    _expected_is_numeric = true;
+                }
+                if expected_element_type == "double" {
+                    _expected_is_numeric = true;
+                }
+                let mut _metadata_is_numeric: boolean = false;
+                if metadata.element_type == "i64" {
+                    _metadata_is_numeric = true;
+                }
+                if metadata.element_type == "double" {
+                    _metadata_is_numeric = true;
+                }
+                if _expected_is_numeric {
+                    if _metadata_is_numeric {
+                        inferred_element_type = expected_element_type;
+                    }
+                }
+            }
+        }
+    }
     // Slice E.1 (#488): bare integer literals default to `int` (i64) at
     // scalar context, but unannotated array literals keep the pre-E.1
     // `double` element default so the existing `number[]` corpus

--- a/compiler/tests/e2e/fixtures/array_aggregate_shape.sfn
+++ b/compiler/tests/e2e/fixtures/array_aggregate_shape.sfn
@@ -9,7 +9,12 @@
 // `sailfin_runtime_concat` / `_append_string` / `_array_push_slot`
 // symbols stay exported for seed-compiled IR.
 fn main() ![io] {
-    let xs = [1, 2, 3];
+    // Fractional literals to pin the `{ double*, i64, i64 }*` shape
+    // independently of the integer-literal default. After #599 the
+    // integer-literal default flipped to `int` (`i64`), so a bare
+    // `[1, 2, 3]` here would lower as `{ i64*, i64, i64 }*` and miss
+    // the double-array shape assertion B2 below.
+    let xs = [1.0, 2.0, 3.0];
     let len = xs.length;
     let words = ["one", "two"];
     print.info(words[0]);

--- a/compiler/tests/e2e/test_array_aggregate_shape.sh
+++ b/compiler/tests/e2e/test_array_aggregate_shape.sh
@@ -74,8 +74,12 @@ test_three_field_aggregate_appears() {
     return 0
 }
 
-# B2 — `let xs = [1, 2, 3]` lowers to a `{ double*, i64, i64 }*` (numeric
-# literals lower to double under the bootstrap number ABI).
+# B2 — `let xs = [1.0, 2.0, 3.0]` lowers to a `{ double*, i64, i64 }*`
+# (fractional literals select the `float` element kind via the
+# emit-native inference, which `map_primitive_type` lowers to `double`).
+# The fixture uses fractional literals on purpose so the shape assertion
+# is independent of the post-#599 integer-literal default flip from
+# `double` to `i64`.
 test_numeric_literal_uses_value_typed_data_slot() {
     emit_ir_once || return 1
     local hits
@@ -227,7 +231,7 @@ test_no_legacy_two_field_array_shape() {
 
 run_test 'emitted IR contains the { T*, i64, i64 } aggregate type' \
     test_three_field_aggregate_appears
-run_test 'numeric literal [1, 2, 3] lowers to { double*, i64, i64 }' \
+run_test 'numeric literal [1.0, 2.0, 3.0] lowers to { double*, i64, i64 }' \
     test_numeric_literal_uses_value_typed_data_slot
 run_test 'string literal ["one", "two"] lowers to { i8**, i64, i64 }' \
     test_string_array_uses_pointer_typed_data_slot

--- a/compiler/tests/integration/recursion_test.sfn
+++ b/compiler/tests/integration/recursion_test.sfn
@@ -1,25 +1,25 @@
-fn _quicksort(arr: number[]) -> number[] {  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+fn _quicksort(arr: int[]) -> int[] {
     if arr.length <= 1 { return arr; }
     let pivot = arr[0];
-    let mut less: number[] = [];  // alias-coverage: test relies on int-array literal path pending int[] literal fix
-    let mut equal: number[] = [];  // alias-coverage: test relies on int-array literal path pending int[] literal fix
-    let mut greater: number[] = [];  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+    let mut less: int[] = [];
+    let mut equal: int[] = [];
+    let mut greater: int[] = [];
     for x in arr {
-        if x < pivot { less.push(x); } else if x == pivot {
-            equal.push(x);
-        } else { greater.push(x); }
+        if x < pivot { less.push(x); } else if x == pivot { equal.push(x); } else {
+            greater.push(x);
+        }
     }
     let sorted_less = _quicksort(less);
     let sorted_greater = _quicksort(greater);
-    let mut result: number[] = [];  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+    let mut result: int[] = [];
     for n in sorted_less { result.push(n); }
     for n in equal { result.push(n); }
     for n in sorted_greater { result.push(n); }
     return result;
 }
 
-fn _is_sorted(arr: number[]) -> boolean {  // alias-coverage: test relies on int-array literal path pending int[] literal fix
-    let mut i: number = 0;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+fn _is_sorted(arr: int[]) -> boolean {
+    let mut i: int = 0;
     loop {
         if i + 1 >= arr.length { break; }
         if arr[i] > arr[i + 1] { return false; }
@@ -29,7 +29,7 @@ fn _is_sorted(arr: number[]) -> boolean {  // alias-coverage: test relies on int
 }
 
 test "recursion: quicksort empty array" {
-    let mut empty: number[] = [];  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+    let mut empty: int[] = [];
     let sorted = _quicksort(empty);
     assert sorted.length == 0;
 }

--- a/compiler/tests/integration/struct_enum_composition_test.sfn
+++ b/compiler/tests/integration/struct_enum_composition_test.sfn
@@ -15,11 +15,11 @@ fn _color_name(c: Color) -> string {
 }
 
 struct Pixel {
-    x: number;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
-    y: number;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+    x: int;
+    y: int;
     color: Color;
 
-    fn move_to(self, nx: number, ny: number) -> Pixel {  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+    fn move_to(self, nx: int, ny: int) -> Pixel {
         return Pixel { x: nx, y: ny, color: self.color };
     }
 
@@ -33,16 +33,16 @@ struct Pixel {
     }
 }
 
-fn _num(n: number) -> string {  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+fn _num(n: int) -> string {
     if n == 0 { return "0"; }
     let mut result: string = "";
-    let mut remaining: number = n;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+    let mut remaining: int = n;
     if remaining < 0 { remaining = 0 - remaining; }
     let digits = "0123456789";
     loop {
         if remaining <= 0 { break; }
-        let mut temp: number = remaining;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
-        let mut quotient: number = 0;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+        let mut temp: int = remaining;
+        let mut quotient: int = 0;
         loop {
             if temp < 10 { break; }
             temp -= 10;
@@ -88,24 +88,18 @@ test "composition: enum through function produces correct string" {
 // Struct containing struct
 // ---------------------------------------------------------------------------
 struct Bounds {
-    min_x: number;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
-    min_y: number;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
-    max_x: number;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
-    max_y: number;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+    min_x: int;
+    min_y: int;
+    max_x: int;
+    max_y: int;
 
-    fn width(self) -> number {  // alias-coverage: test relies on int-array literal path pending int[] literal fix
-        return self.max_x - self.min_x;
-    }
+    fn width(self) -> number { return self.max_x - self.min_x; }
 
-    fn height(self) -> number {  // alias-coverage: test relies on int-array literal path pending int[] literal fix
-        return self.max_y - self.min_y;
-    }
+    fn height(self) -> number { return self.max_y - self.min_y; }
 
-    fn area(self) -> number {  // alias-coverage: test relies on int-array literal path pending int[] literal fix
-        return self.width() * self.height();
-    }
+    fn area(self) -> number { return self.width() * self.height(); }
 
-    fn contains_point(self, px: number, py: number) -> boolean {  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+    fn contains_point(self, px: int, py: int) -> boolean {
         if px < self.min_x { return false; }
         if px > self.max_x { return false; }
         if py < self.min_y { return false; }
@@ -123,11 +117,11 @@ fn _compute_bounds(pixels: Pixel[]) -> Bounds {
             max_y: 0
         };
     }
-    let mut min_x: number = pixels[0].x;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
-    let mut min_y: number = pixels[0].y;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
-    let mut max_x: number = pixels[0].x;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
-    let mut max_y: number = pixels[0].y;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
-    let mut i: number = 1;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+    let mut min_x: int = pixels[0].x;
+    let mut min_y: int = pixels[0].y;
+    let mut max_x: int = pixels[0].x;
+    let mut max_y: int = pixels[0].y;
+    let mut i: int = 1;
     loop {
         if i >= pixels.length { break; }
         let p = pixels[i];
@@ -192,17 +186,17 @@ enum Op {
     Mul
 }
 
-fn _apply_op(op: Op, a: number, b: number) -> number {  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+fn _apply_op(op: Op, a: int, b: int) -> int {
     if op == Op.Add { return a + b; }
     if op == Op.Sub { return a - b; }
     if op == Op.Mul { return a * b; }
     return 0;
 }
 
-fn _apply_ops_to_array(ops: Op[], values: number[]) -> number {  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+fn _apply_ops_to_array(ops: Op[], values: int[]) -> int {
     if values.length == 0 { return 0; }
-    let mut result: number = values[0];  // alias-coverage: test relies on int-array literal path pending int[] literal fix
-    let mut i: number = 0;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+    let mut result: int = values[0];
+    let mut i: int = 0;
     loop {
         if i >= ops.length { break; }
         if i + 1 >= values.length { break; }

--- a/compiler/tests/unit/function_signatures_test.sfn
+++ b/compiler/tests/unit/function_signatures_test.sfn
@@ -6,15 +6,15 @@
 // ---------------------------------------------------------------------------
 // Functions with many parameters
 // ---------------------------------------------------------------------------
-fn _add5(a: number, b: number, c: number, d: number, e: number) -> number {  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+fn _add5(a: int, b: int, c: int, d: int, e: int) -> int {
     return a + b + c + d + e;
 }
 
-fn _add6(a: number, b: number, c: number, d: number, e: number, f: number) -> number {  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+fn _add6(a: int, b: int, c: int, d: int, e: int, f: int) -> int {
     return a + b + c + d + e + f;
 }
 
-fn _weighted6(a: number, b: number, c: number, d: number, e: number, f: number) -> number {  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+fn _weighted6(a: int, b: int, c: int, d: int, e: int, f: int) -> int {
     return a * 1 + b * 2 + c * 3 + d * 4 + e * 5 + f * 6;
 }
 
@@ -33,17 +33,17 @@ test "fn_sig: six parameter weighted sum" {
 // ---------------------------------------------------------------------------
 // Mixed parameter types (number, string, boolean)
 // ---------------------------------------------------------------------------
-fn _format_entry(name: string, value: number, active: boolean) -> string {  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+fn _format_entry(name: string, value: int, active: boolean) -> string {
     let mut result: string = name + "=";
     if active {
-        let mut remaining: number = value;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+        let mut remaining: int = value;
         if remaining == 0 { return result + "0*"; }
         let digits = "0123456789";
         let mut num_str: string = "";
         loop {
             if remaining <= 0 { break; }
-            let mut temp: number = remaining;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
-            let mut quotient: number = 0;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+            let mut temp: int = remaining;
+            let mut quotient: int = 0;
             loop {
                 if temp < 10 { break; }
                 temp -= 10;
@@ -72,13 +72,13 @@ test "fn_sig: mixed types zero active" {
 // ---------------------------------------------------------------------------
 // Functions returning boolean
 // ---------------------------------------------------------------------------
-fn _in_range(val: number, min: number, max: number) -> boolean {  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+fn _in_range(val: int, min: int, max: int) -> boolean {
     if val < min { return false; }
     if val > max { return false; }
     return true;
 }
 
-fn _all_positive(a: number, b: number, c: number) -> boolean {  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+fn _all_positive(a: int, b: int, c: int) -> boolean {
     if a <= 0 { return false; }
     if b <= 0 { return false; }
     if c <= 0 { return false; }
@@ -103,28 +103,28 @@ test "fn_sig: boolean return all positive" {
 // ---------------------------------------------------------------------------
 // Functions calling functions with different signatures
 // ---------------------------------------------------------------------------
-fn _compute_score(base: number, multiplier: number) -> number {  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+fn _compute_score(base: int, multiplier: int) -> int {
     return base * multiplier;
 }
 
-fn _apply_bonus(score: number, has_bonus: boolean) -> number {  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+fn _apply_bonus(score: int, has_bonus: boolean) -> int {
     if has_bonus { return score + 100; }
     return score;
 }
 
-fn _format_score(label: string, score: number) -> string {  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+fn _format_score(label: string, score: int) -> string {
     return label + ": " + _num_str(score);
 }
 
-fn _num_str(n: number) -> string {  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+fn _num_str(n: int) -> string {
     if n == 0 { return "0"; }
     let mut result: string = "";
-    let mut rem: number = n;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+    let mut rem: int = n;
     let digits = "0123456789";
     loop {
         if rem <= 0 { break; }
-        let mut temp: number = rem;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
-        let mut q: number = 0;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+        let mut temp: int = rem;
+        let mut q: int = 0;
         loop {
             if temp < 10 { break; }
             temp -= 10;
@@ -136,7 +136,7 @@ fn _num_str(n: number) -> string {  // alias-coverage: test relies on int-array 
     return result;
 }
 
-fn _full_pipeline(name: string, base: number, mult: number, bonus: boolean) -> string {  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+fn _full_pipeline(name: string, base: int, mult: int, bonus: boolean) -> string {
     let score = _compute_score(base, mult);
     let final_score = _apply_bonus(score, bonus);
     return _format_score(name, final_score);
@@ -153,9 +153,9 @@ test "fn_sig: multi-function pipeline without bonus" {
 // ---------------------------------------------------------------------------
 // Function with array parameter and number return
 // ---------------------------------------------------------------------------
-fn _array_stats_sum(arr: number[]) -> number {  // alias-coverage: test relies on int-array literal path pending int[] literal fix
-    let mut total: number = 0;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
-    let mut i: number = 0;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+fn _array_stats_sum(arr: int[]) -> int {
+    let mut total: int = 0;
+    let mut i: int = 0;
     loop {
         if i >= arr.length { break; }
         total += arr[i];
@@ -164,10 +164,10 @@ fn _array_stats_sum(arr: number[]) -> number {  // alias-coverage: test relies o
     return total;
 }
 
-fn _array_stats_max(arr: number[]) -> number {  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+fn _array_stats_max(arr: int[]) -> int {
     if arr.length == 0 { return 0; }
-    let mut best: number = arr[0];  // alias-coverage: test relies on int-array literal path pending int[] literal fix
-    let mut i: number = 1;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+    let mut best: int = arr[0];
+    let mut i: int = 1;
     loop {
         if i >= arr.length { break; }
         if arr[i] > best { best = arr[i]; }
@@ -176,10 +176,10 @@ fn _array_stats_max(arr: number[]) -> number {  // alias-coverage: test relies o
     return best;
 }
 
-fn _array_stats_min(arr: number[]) -> number {  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+fn _array_stats_min(arr: int[]) -> int {
     if arr.length == 0 { return 0; }
-    let mut best: number = arr[0];  // alias-coverage: test relies on int-array literal path pending int[] literal fix
-    let mut i: number = 1;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+    let mut best: int = arr[0];
+    let mut i: int = 1;
     loop {
         if i >= arr.length { break; }
         if arr[i] < best { best = arr[i]; }
@@ -220,7 +220,7 @@ test "fn_sig: array stats combined" {
 fn _longest_string(arr: string[]) -> string {
     if arr.length == 0 { return ""; }
     let mut best: string = arr[0];
-    let mut i: number = 1;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+    let mut i: int = 1;
     loop {
         if i >= arr.length { break; }
         if arr[i].length > best.length { best = arr[i]; }

--- a/compiler/tests/unit/int_array_literal_test.sfn
+++ b/compiler/tests/unit/int_array_literal_test.sfn
@@ -1,0 +1,67 @@
+// Regression test: array literals of integer-shaped `NumberLiteral`
+// elements must lower as `i64` storage, not `double`.
+//
+// Background: `infer_expression_type` in
+// `compiler/src/emit_native_format.sfn` previously returned `"number"` for
+// every `NumberLiteral` regardless of whether the literal was integral
+// (`42`) or fractional (`42.0`). The downstream `.sfn-asm` therefore carried
+// `#element:number` for `[42]`, which `parse_array_literal_metadata` maps
+// via `map_primitive_type` to `"double"`. `lower_array_literal` then stored
+// the literal as `double 42.0` inside a `{ double*, i64, i64 }*` header,
+// while `let arr: int[]` allocated a `{ i64*, i64, i64 }*` slot. The
+// resulting bitcast of the header pointer left the underlying bytes
+// untouched, so `arr[0]` read the `i64` interpretation of the `double 42.0`
+// bit pattern (4_631_107_791_820_423_168) instead of 42 — issue #599.
+//
+// After the fix, `infer_expression_type` introspects the literal text and
+// returns `"int"` for integers / `"float"` for fractionals, so `[42]` emits
+// as `[#element:int, 42]` and lowers as `i64` storage.
+test "int[] literal indexed access returns the stored value" {
+    let arr: int[] = [42];
+    let x = arr[0];
+    // Direct equality — catches the bit-pattern bug. The `double 42.0`
+    // misinterpretation produces 4_631_107_791_820_423_168 as i64, which
+    // is neither 42 nor 0.
+    assert x == 42;
+    // Defensive against a stale uninitialized read masquerading as 0.
+    assert x != 0;
+}
+
+test "int[] literal multi-element with varying digit counts" {
+    let arr: int[] = [1, 22, 333, 4444];
+    assert arr[0] == 1;
+    assert arr[1] == 22;
+    assert arr[2] == 333;
+    assert arr[3] == 4444;
+}
+
+test "int[] literal — annotated zero and large value" {
+    let arr: int[] = [0, 9007199254740992];
+    assert arr[0] == 0;
+    assert arr[1] == 9007199254740992;
+}
+
+test "int[] inferred from integer-literal elements (no annotation)" {
+    // Slice E.1 (#488) scalar default extends to arrays: an unannotated
+    // array of integer literals infers `int[]`, not `float[]`.
+    let arr = [1, 2, 3];
+    assert arr[0] == 1;
+    assert arr[1] == 2;
+    assert arr[2] == 3;
+}
+
+test "float[] literal continues to round-trip (no regression on legacy path)" {
+    // The pre-existing `number[]` corpus must still compile. `: number[]`
+    // → `: float[]` → `double` storage, and `42.0` retains its value
+    // through the round-trip.
+    let arr: number[] = [42.0];
+    let x = arr[0];
+    assert x == 42.0;
+}
+
+test "float[] inferred from fractional-literal elements (no annotation)" {
+    let arr = [1.5, 2.5, 3.5];
+    assert arr[0] == 1.5;
+    assert arr[1] == 2.5;
+    assert arr[2] == 3.5;
+}

--- a/compiler/tests/unit/loop_edge_cases_test.sfn
+++ b/compiler/tests/unit/loop_edge_cases_test.sfn
@@ -5,9 +5,9 @@
 // ---------------------------------------------------------------------------
 // Loop with zero iterations (exit condition checked before body)
 // ---------------------------------------------------------------------------
-fn _zero_iter_loop(limit: number) -> number {  // alias-coverage: test relies on int-array literal path pending int[] literal fix
-    let mut count: number = 0;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
-    let mut i: number = 0;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+fn _zero_iter_loop(limit: int) -> int {
+    let mut count: int = 0;
+    let mut i: int = 0;
     loop {
         if i >= limit { break; }
         count += 1;
@@ -29,8 +29,8 @@ test "loop_edge: one iteration" { assert _zero_iter_loop(1) == 1; }
 // ---------------------------------------------------------------------------
 // Loop with multiple break points from different branches
 // ---------------------------------------------------------------------------
-fn _multi_break(arr: number[]) -> number {  // alias-coverage: test relies on int-array literal path pending int[] literal fix
-    let mut i: number = 0;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+fn _multi_break(arr: int[]) -> int {
+    let mut i: int = 0;
     let mut found_neg: boolean = false;
     let mut found_big: boolean = false;
     loop {
@@ -66,19 +66,19 @@ test "loop_edge: multi break no special" {
 }
 
 test "loop_edge: multi break empty array" {
-    let mut data: number[] = [];  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+    let mut data: int[] = [];
     assert _multi_break(data) == 0;
 }
 
 // ---------------------------------------------------------------------------
 // Nested loop with break in outer from inner condition
 // ---------------------------------------------------------------------------
-fn _find_in_matrix(rows: number, cols: number, target: number) -> number {  // alias-coverage: test relies on int-array literal path pending int[] literal fix
-    let mut i: number = 0;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
-    let mut found_at: number = -1;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+fn _find_in_matrix(rows: int, cols: int, target: int) -> int {
+    let mut i: int = 0;
+    let mut found_at: int = -1;
     loop {
         if i >= rows { break; }
-        let mut j: number = 0;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+        let mut j: int = 0;
         loop {
             if j >= cols { break; }
             let val = i * cols + j;
@@ -114,9 +114,9 @@ test "loop_edge: find in matrix not found" {
 // ---------------------------------------------------------------------------
 // While-like loop with compound condition
 // ---------------------------------------------------------------------------
-fn _gcd(a: number, b: number) -> number {  // alias-coverage: test relies on int-array literal path pending int[] literal fix
-    let mut x: number = a;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
-    let mut y: number = b;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+fn _gcd(a: int, b: int) -> int {
+    let mut x: int = a;
+    let mut y: int = b;
     loop {
         if y == 0 { break; }
         let temp = y;
@@ -137,9 +137,9 @@ test "loop_edge: gcd one is zero" { assert _gcd(5, 0) == 5; }
 // ---------------------------------------------------------------------------
 // Countdown loop (decrementing counter)
 // ---------------------------------------------------------------------------
-fn _countdown_sum(start: number) -> number {  // alias-coverage: test relies on int-array literal path pending int[] literal fix
-    let mut total: number = 0;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
-    let mut n: number = start;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+fn _countdown_sum(start: int) -> int {
+    let mut total: int = 0;
+    let mut n: int = start;
     loop {
         if n <= 0 { break; }
         total += n;
@@ -155,9 +155,9 @@ test "loop_edge: countdown sum from 0" { assert _countdown_sum(0) == 0; }
 // ---------------------------------------------------------------------------
 // Loop with continue and mutation after continue (dead code after continue)
 // ---------------------------------------------------------------------------
-fn _skip_multiples_of_3(n: number) -> number {  // alias-coverage: test relies on int-array literal path pending int[] literal fix
-    let mut sum: number = 0;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
-    let mut i: number = 1;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+fn _skip_multiples_of_3(n: int) -> int {
+    let mut sum: int = 0;
+    let mut i: int = 1;
     loop {
         if i > n { break; }
         if i % 3 == 0 {
@@ -185,7 +185,7 @@ test "loop_edge: skip multiples of 3 up to 3" {
 // ---------------------------------------------------------------------------
 fn _build_until_long(parts: string[]) -> string {
     let mut result: string = "";
-    let mut i: number = 0;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+    let mut i: int = 0;
     loop {
         if i >= parts.length { break; }
         result = result + parts[i];
@@ -215,17 +215,17 @@ test "loop_edge: string build no early termination" {
 // ---------------------------------------------------------------------------
 // Double loop with independent counters (phi isolation)
 // ---------------------------------------------------------------------------
-fn _independent_loops(a: number, b: number) -> number {  // alias-coverage: test relies on int-array literal path pending int[] literal fix
-    let mut sum_a: number = 0;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
-    let mut i: number = 0;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+fn _independent_loops(a: int, b: int) -> int {
+    let mut sum_a: int = 0;
+    let mut i: int = 0;
     loop {
         if i >= a { break; }
         sum_a += i + 1;
         i += 1;
     }
 
-    let mut sum_b: number = 0;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
-    let mut j: number = 0;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+    let mut sum_b: int = 0;
+    let mut j: int = 0;
     loop {
         if j >= b { break; }
         sum_b += j + 1;
@@ -251,8 +251,8 @@ test "loop_edge: independent loops both zero" {
 // ---------------------------------------------------------------------------
 // Loop with return from middle (not break)
 // ---------------------------------------------------------------------------
-fn _find_first_even(arr: number[]) -> number {  // alias-coverage: test relies on int-array literal path pending int[] literal fix
-    let mut i: number = 0;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+fn _find_first_even(arr: int[]) -> int {
+    let mut i: int = 0;
     loop {
         if i >= arr.length { break; }
         if arr[i] % 2 == 0 { return arr[i]; }

--- a/compiler/tests/unit/loops_test.sfn
+++ b/compiler/tests/unit/loops_test.sfn
@@ -1,6 +1,6 @@
-fn _sum_to(n: number) -> number {  // alias-coverage: test relies on int-array literal path pending int[] literal fix
-    let mut total: number = 0;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
-    let mut i: number = 1;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+fn _sum_to(n: int) -> int {
+    let mut total: int = 0;
+    let mut i: int = 1;
     loop {
         if i > n { break; }
         total += i;
@@ -9,9 +9,9 @@ fn _sum_to(n: number) -> number {  // alias-coverage: test relies on int-array l
     return total;
 }
 
-fn _count_evens_up_to(n: number) -> number {  // alias-coverage: test relies on int-array literal path pending int[] literal fix
-    let mut count: number = 0;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
-    let mut i: number = 0;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+fn _count_evens_up_to(n: int) -> int {
+    let mut count: int = 0;
+    let mut i: int = 0;
     loop {
         if i > n { break; }
         if i % 2 == 0 { count += 1; }
@@ -20,8 +20,8 @@ fn _count_evens_up_to(n: number) -> number {  // alias-coverage: test relies on 
     return count;
 }
 
-fn _first_multiple_of_seven(limit: number) -> number {  // alias-coverage: test relies on int-array literal path pending int[] literal fix
-    let mut i: number = 1;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+fn _first_multiple_of_seven(limit: int) -> int {
+    let mut i: int = 1;
     loop {
         if i > limit { return -1; }
         if i % 7 == 0 { return i; }
@@ -30,14 +30,14 @@ fn _first_multiple_of_seven(limit: number) -> number {  // alias-coverage: test 
     return -1;
 }
 
-fn _sum_array(arr: number[]) -> number {  // alias-coverage: test relies on int-array literal path pending int[] literal fix
-    let mut total: number = 0;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+fn _sum_array(arr: int[]) -> int {
+    let mut total: int = 0;
     for n in arr { total += n; }
     return total;
 }
 
-fn _count_positive(arr: number[]) -> number {  // alias-coverage: test relies on int-array literal path pending int[] literal fix
-    let mut count: number = 0;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+fn _count_positive(arr: int[]) -> int {
+    let mut count: int = 0;
     for n in arr {
         if n > 0 { count += 1; }
     }
@@ -68,7 +68,7 @@ test "loops: for-in sums array elements" {
 }
 
 test "loops: for-in with empty array" {
-    let mut empty: number[] = [];  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+    let mut empty: int[] = [];
     assert _sum_array(empty) == 0;
 }
 
@@ -78,8 +78,8 @@ test "loops: for-in counts positive elements" {
 }
 
 test "loops: continue skips iteration body" {
-    let mut evens: number = 0;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
-    let mut i: number = 0;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+    let mut evens: int = 0;
+    let mut i: int = 0;
     loop {
         if i >= 10 { break; }
         i += 1;
@@ -90,11 +90,11 @@ test "loops: continue skips iteration body" {
 }
 
 test "loops: nested loops accumulate correctly" {
-    let mut total: number = 0;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
-    let mut i: number = 0;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+    let mut total: int = 0;
+    let mut i: int = 0;
     loop {
         if i >= 3 { break; }
-        let mut j: number = 0;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+        let mut j: int = 0;
         loop {
             if j >= 3 { break; }
             total += 1;

--- a/compiler/tests/unit/match_advanced_test.sfn
+++ b/compiler/tests/unit/match_advanced_test.sfn
@@ -5,8 +5,8 @@
 // ---------------------------------------------------------------------------
 // Match with computation in block bodies
 // ---------------------------------------------------------------------------
-fn _compute_via_match(op: number, a: number, b: number) -> number {  // alias-coverage: test relies on int-array literal path pending int[] literal fix
-    let mut result: number = 0;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+fn _compute_via_match(op: int, a: int, b: int) -> int {
+    let mut result: int = 0;
     match op {
         1: {
             result = a + b;
@@ -64,7 +64,7 @@ enum HttpStatus {
     ServerError
 }
 
-fn _status_code(s: HttpStatus) -> number {  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+fn _status_code(s: HttpStatus) -> int {
     match s {
         HttpStatus.Ok: return 200,
         HttpStatus.Created: return 201,
@@ -104,7 +104,7 @@ test "match_adv: enum with wildcard" {
 // ---------------------------------------------------------------------------
 // Note: Sailfin only has float division (no integer types yet),
 // so scores must be exact multiples of 10 for match arms to hit.
-fn _grade_letter(score: number) -> string {  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+fn _grade_letter(score: int) -> string {
     let bracket = score / 10;
     let mut letter: string = "F";
     match bracket {
@@ -143,9 +143,9 @@ test "match_adv: grade F" { assert _grade_letter(50) == "F"; }
 // ---------------------------------------------------------------------------
 // Match in a loop (repeated dispatch)
 // ---------------------------------------------------------------------------
-fn _process_commands(commands: number[]) -> number {  // alias-coverage: test relies on int-array literal path pending int[] literal fix
-    let mut accumulator: number = 0;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
-    let mut i: number = 0;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+fn _process_commands(commands: int[]) -> int {
+    let mut accumulator: int = 0;
+    let mut i: int = 0;
     loop {
         if i >= commands.length { break; }
         let cmd = commands[i];
@@ -190,7 +190,7 @@ test "match_adv: command processing with reset" {
 }
 
 test "match_adv: command processing empty" {
-    let mut cmds: number[] = [];  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+    let mut cmds: int[] = [];
     assert _process_commands(cmds) == 0;
 }
 
@@ -236,7 +236,7 @@ test "match_adv: log prefix all levels" {
 // ---------------------------------------------------------------------------
 // Nested match (match result drives another match)
 // ---------------------------------------------------------------------------
-fn _priority_level(level: LogLevel) -> number {  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+fn _priority_level(level: LogLevel) -> int {
     match level {
         LogLevel.Debug: return 0,
         LogLevel.Info: return 1,

--- a/compiler/tests/unit/nested_control_flow_test.sfn
+++ b/compiler/tests/unit/nested_control_flow_test.sfn
@@ -6,11 +6,11 @@
 // ---------------------------------------------------------------------------
 // Nested loops with break from inner vs outer
 // ---------------------------------------------------------------------------
-fn _find_pair_sum(arr: number[], target: number) -> number {  // alias-coverage: test relies on int-array literal path pending int[] literal fix
-    let mut i: number = 0;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+fn _find_pair_sum(arr: int[], target: int) -> int {
+    let mut i: int = 0;
     loop {
         if i >= arr.length { break; }
-        let mut j: number = i + 1;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+        let mut j: int = i + 1;
         loop {
             if j >= arr.length { break; }
             if arr[i] + arr[j] == target { return arr[i] * 100 + arr[j]; }
@@ -35,12 +35,12 @@ test "nested_cf: nested loop break returns -1 when no pair" {
 // ---------------------------------------------------------------------------
 // Triple-nested loop with continue in middle
 // ---------------------------------------------------------------------------
-fn _triple_nested_count(limit: number) -> number {  // alias-coverage: test relies on int-array literal path pending int[] literal fix
-    let mut count: number = 0;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
-    let mut i: number = 0;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+fn _triple_nested_count(limit: int) -> int {
+    let mut count: int = 0;
+    let mut i: int = 0;
     loop {
         if i >= limit { break; }
-        let mut j: number = 0;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+        let mut j: int = 0;
         loop {
             if j >= limit { break; }
             // Use temp var to avoid operator precedence bug:
@@ -50,7 +50,7 @@ fn _triple_nested_count(limit: number) -> number {  // alias-coverage: test reli
                 j += 1;
                 continue;
             }
-            let mut k: number = 0;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+            let mut k: int = 0;
             loop {
                 if k >= limit { break; }
                 count += 1;
@@ -71,9 +71,9 @@ test "nested_cf: triple nested loop with continue" {
 // ---------------------------------------------------------------------------
 // Loop with multiple mutable variables and conditional updates (SSA stress)
 // ---------------------------------------------------------------------------
-fn _collatz_steps(start: number) -> number {  // alias-coverage: test relies on int-array literal path pending int[] literal fix
-    let mut n: number = start;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
-    let mut steps: number = 0;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+fn _collatz_steps(start: int) -> int {
+    let mut n: int = start;
+    let mut steps: int = 0;
     loop {
         if n <= 1 { break; }
         if n % 2 == 0 { n = n / 2; } else { n = n * 3 + 1; }
@@ -89,12 +89,10 @@ test "nested_cf: collatz steps for 1" { assert _collatz_steps(1) == 0; }
 // ---------------------------------------------------------------------------
 // Early return from deeply nested branches
 // ---------------------------------------------------------------------------
-fn _classify_triple(a: number, b: number, c: number) -> string {  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+fn _classify_triple(a: int, b: int, c: int) -> string {
     if a > 0 {
         if b > 0 {
-            if c > 0 { return "all positive"; } else {
-                return "c non-positive";
-            }
+            if c > 0 { return "all positive"; } else { return "c non-positive"; }
         } else {
             if c > 0 { return "b non-positive"; } else {
                 return "b and c non-positive";
@@ -132,9 +130,9 @@ test "nested_cf: classify triple a and b non-positive" {
 // ---------------------------------------------------------------------------
 // Loop with conditional break vs continue (SSA predecessor labels)
 // ---------------------------------------------------------------------------
-fn _first_above_threshold(arr: number[], threshold: number) -> number {  // alias-coverage: test relies on int-array literal path pending int[] literal fix
-    let mut result: number = -1;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
-    let mut i: number = 0;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+fn _first_above_threshold(arr: int[], threshold: int) -> int {
+    let mut result: int = -1;
+    let mut i: int = 0;
     loop {
         if i >= arr.length { break; }
         if arr[i] <= threshold {
@@ -160,7 +158,7 @@ test "nested_cf: first above threshold no match" {
 // ---------------------------------------------------------------------------
 // Mutable variable reassigned across multiple if/else branches (phi stress)
 // ---------------------------------------------------------------------------
-fn _categorize_score(score: number) -> string {  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+fn _categorize_score(score: int) -> string {
     let mut grade: string = "F";
     let mut note: string = "none";
     if score >= 90 {
@@ -194,9 +192,9 @@ test "nested_cf: score categorization F" {
 // ---------------------------------------------------------------------------
 // Loop building an array with conditional pushes
 // ---------------------------------------------------------------------------
-fn _filter_and_transform(input: number[]) -> number[] {  // alias-coverage: test relies on int-array literal path pending int[] literal fix
-    let mut result: number[] = [];  // alias-coverage: test relies on int-array literal path pending int[] literal fix
-    let mut i: number = 0;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+fn _filter_and_transform(input: int[]) -> int[] {
+    let mut result: int[] = [];
+    let mut i: int = 0;
     loop {
         if i >= input.length { break; }
         let val = input[i];
@@ -223,25 +221,25 @@ test "nested_cf: filter and transform mixed array" {
 // ---------------------------------------------------------------------------
 // Multiple sequential loops (tests phi reset between loops)
 // ---------------------------------------------------------------------------
-fn _multi_loop_accumulate(n: number) -> number {  // alias-coverage: test relies on int-array literal path pending int[] literal fix
-    let mut sum1: number = 0;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
-    let mut i: number = 0;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+fn _multi_loop_accumulate(n: int) -> int {
+    let mut sum1: int = 0;
+    let mut i: int = 0;
     loop {
         if i >= n { break; }
         sum1 += i;
         i += 1;
     }
 
-    let mut sum2: number = 0;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
-    let mut j: number = 0;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+    let mut sum2: int = 0;
+    let mut j: int = 0;
     loop {
         if j >= n { break; }
         sum2 += j * 2;
         j += 1;
     }
 
-    let mut sum3: number = 0;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
-    let mut k: number = 0;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+    let mut sum3: int = 0;
+    let mut k: int = 0;
     loop {
         if k >= n { break; }
         sum3 += k * k;

--- a/compiler/tests/unit/ssa_mutations_test.sfn
+++ b/compiler/tests/unit/ssa_mutations_test.sfn
@@ -4,8 +4,8 @@
 // ---------------------------------------------------------------------------
 // Mutable variable modified in both branches, used after merge
 // ---------------------------------------------------------------------------
-fn _branch_merge_value(x: number) -> number {  // alias-coverage: test relies on int-array literal path pending int[] literal fix
-    let mut result: number = 0;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+fn _branch_merge_value(x: int) -> int {
+    let mut result: int = 0;
     if x > 10 { result = x * 2; } else { result = x + 100; }
     // Use result after the merge point — requires correct phi
     return result + 1;
@@ -22,9 +22,9 @@ test "ssa_mut: branch merge else-path" {
 // ---------------------------------------------------------------------------
 // Multiple mutable variables modified in same if/else
 // ---------------------------------------------------------------------------
-fn _multi_var_branch(a: number, b: number) -> number {  // alias-coverage: test relies on int-array literal path pending int[] literal fix
-    let mut x: number = a;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
-    let mut y: number = b;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+fn _multi_var_branch(a: int, b: int) -> int {
+    let mut x: int = a;
+    let mut y: int = b;
     if a > b {
         x = x + 10;
         y = y - 10;
@@ -48,9 +48,9 @@ test "ssa_mut: multi var branch else" {
 // ---------------------------------------------------------------------------
 // Mutable variable modified in loop then used in branch
 // ---------------------------------------------------------------------------
-fn _loop_then_branch(n: number) -> string {  // alias-coverage: test relies on int-array literal path pending int[] literal fix
-    let mut total: number = 0;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
-    let mut i: number = 0;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+fn _loop_then_branch(n: int) -> string {
+    let mut total: int = 0;
+    let mut i: int = 0;
     loop {
         if i >= n { break; }
         total += i;
@@ -68,16 +68,14 @@ test "ssa_mut: loop then branch medium" {
     assert _loop_then_branch(5) == "medium";
 }
 
-test "ssa_mut: loop then branch low" {
-    assert _loop_then_branch(2) == "low";
-}
+test "ssa_mut: loop then branch low" { assert _loop_then_branch(2) == "low"; }
 
 // ---------------------------------------------------------------------------
 // Swap pattern (classic phi stress test)
 // ---------------------------------------------------------------------------
-fn _swap_if_needed(a: number, b: number) -> number {  // alias-coverage: test relies on int-array literal path pending int[] literal fix
-    let mut x: number = a;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
-    let mut y: number = b;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+fn _swap_if_needed(a: int, b: int) -> int {
+    let mut x: int = a;
+    let mut y: int = b;
     if x > y {
         let tmp = x;
         x = y;
@@ -96,9 +94,9 @@ test "ssa_mut: no swap when already ordered" {
 // ---------------------------------------------------------------------------
 // Accumulator modified inside nested if within loop
 // ---------------------------------------------------------------------------
-fn _weighted_sum(values: number[], weights: number[]) -> number {  // alias-coverage: test relies on int-array literal path pending int[] literal fix
-    let mut sum: number = 0;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
-    let mut i: number = 0;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+fn _weighted_sum(values: int[], weights: int[]) -> int {
+    let mut sum: int = 0;
+    let mut i: int = 0;
     let limit = values.length;
     loop {
         if i >= limit { break; }
@@ -125,10 +123,10 @@ test "ssa_mut: weighted sum with partial weights" {
 // ---------------------------------------------------------------------------
 // Boolean flag toggled across iterations
 // ---------------------------------------------------------------------------
-fn _alternating_sum(arr: number[]) -> number {  // alias-coverage: test relies on int-array literal path pending int[] literal fix
-    let mut total: number = 0;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+fn _alternating_sum(arr: int[]) -> int {
+    let mut total: int = 0;
     let mut add_flag: boolean = true;
-    let mut i: number = 0;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+    let mut i: int = 0;
     loop {
         if i >= arr.length { break; }
         if add_flag { total += arr[i]; } else { total -= arr[i]; }
@@ -152,9 +150,9 @@ test "ssa_mut: alternating sum single element" {
 // ---------------------------------------------------------------------------
 // String built incrementally with conditional append
 // ---------------------------------------------------------------------------
-fn _build_csv(values: number[]) -> string {  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+fn _build_csv(values: int[]) -> string {
     let mut result: string = "";
-    let mut i: number = 0;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+    let mut i: int = 0;
     loop {
         if i >= values.length { break; }
         if i > 0 { result = result + ","; }
@@ -177,15 +175,15 @@ test "ssa_mut: build csv single element" {
 }
 
 test "ssa_mut: build csv empty" {
-    let mut vals: number[] = [];  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+    let mut vals: int[] = [];
     assert _build_csv(vals) == "";
 }
 
 // ---------------------------------------------------------------------------
 // Variable assigned in one branch only (tests phi with entry value)
 // ---------------------------------------------------------------------------
-fn _optional_update(x: number) -> number {  // alias-coverage: test relies on int-array literal path pending int[] literal fix
-    let mut result: number = x;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+fn _optional_update(x: int) -> int {
+    let mut result: int = x;
     if x > 50 { result = result - 50; }
     // If x <= 50, result stays as x (phi merges original with modified)
     return result * 2;


### PR DESCRIPTION
## Summary
- **Primary fix** (`compiler/src/emit_native_format.sfn`): `_number_literal_kind` introspects `NumberLiteral.value` for `.` so the emitter labels integer literals as `#element:int` (→ `i64`) and fractional literals as `#element:float` (→ `double`). Adds `Unary` recursion so `[-3, ...]` still infers `int[]`.
- **Belt-and-suspenders** (`core_literals_lowering.sfn`): when the `let`-binding annotation and the parsed `.sfn-asm` metadata disagree on `i64`↔`double`, prefer the binding annotation. Guards both directions (legacy seed `#element:number` for `int[]` bindings, AND the new emitter's `#element:int` for `number[]` bindings — needed for `let powers: number[] = [1000000000000000, ...]` in `compiler/src/llvm/utils.sfn:134` and `core_text.sfn:17`).
- **Test corpus migration** (absorbed from #566's deferred follow-up): re-migrates the `// alias-coverage: ...` tagged tests from `: number` back to `: int`/`-> int` so the post-fix call sites match parameter ABIs, and updates `capsules/sfn/layers/tests/layers_test.sfn` + `compiler/tests/e2e/fixtures/array_aggregate_shape.sfn` to use explicit fractional literals where the `: number[]` ABI is the intent.
- **Regression coverage** (`compiler/tests/unit/int_array_literal_test.sfn`): annotated single/multi-element cases, unannotated inference (`[1, 2, 3]` → `int[]`, `[1.5, ...]` → `float[]`), legacy-path round-trip (`: number[] = [42.0]`).

Closes #599

## Acceptance Criteria

- [x] Reproducer passes: `let arr: int[] = [42]; let x = arr[0]; assert x == 42` succeeds, `assert x != 0` succeeds.
- [x] Emitted `.sfn-asm` for `let arr: int[] = [42]` contains `#element:int` (verified `.let arr : int[] = [#element:int, 42]`).
- [x] Emitted LLVM IR for `let arr: int[] = [42]` allocates `{ i64*, i64, i64 }*` and stores `i64 42` (verified `store i64 42, i64* %t8`).
- [x] `let arr = [42]` (no annotation) infers `: int[]` — Slice E.1 (#488) scalar default extends to arrays.
- [x] `let arr = [42.0]` (no annotation) infers `: float[]` (a.k.a. `: number[]`).
- [x] `let arr: number[] = [42.0]; arr[0]` continues to compile and return `42.0` (no regression in the legacy path).
- [x] Regression test added under `compiler/tests/unit/int_array_literal_test.sfn`.
- [x] `make compile` self-hosts.
- [x] `make test` passes (unit 96/96, integration 23/23, e2e 57/57, capsules 10/10).
- [x] `sfn fmt --check` clean on every touched `.sfn` file.

## Verification

```bash
ulimit -v 8388608

# Reproducer
cat > /tmp/int_arr_repro.sfn <<'EOF'
test "int[] literal indexed access" {
    let arr: int[] = [42];
    let x = arr[0];
    assert x == 42;
    assert x != 0;
}

test "int[] inferred from int-literal elements" {
    let arr = [1, 2, 3];
    assert arr[0] == 1;
    assert arr[2] == 3;
}

test "number[] still works (no regression)" {
    let arr: number[] = [42.0];
    let x = arr[0];
    assert x == 42.0;
}
EOF
build/native/sailfin test /tmp/int_arr_repro.sfn
# → PASS  (all 3 tests passed)

# .sfn-asm shape check
build/native/sailfin emit -o /tmp/repro.asm native /tmp/int_arr_repro.sfn
grep "#element:" /tmp/repro.asm
# →     .let arr : int[] = [#element:int, 42]
#       .let arr = [#element:int, 1, 2, 3]
#       .let arr : number[] = [#element:float, 42.0]

# LLVM IR shape check
build/native/sailfin emit -o /tmp/repro.ll llvm /tmp/int_arr_repro.sfn
grep -E "store i64 42|store double 42" /tmp/repro.ll
# →   store i64 42, i64* %t8
#     store double 42.0, double* %t8

make compile        # self-hosts
make test           # unit 96/96, integration 23/23, e2e 57/57, capsules 10/10
sfn fmt --check     # clean
```

## Files Changed

**Compiler (~73 lines):**
- `compiler/src/emit_native_format.sfn` — `_number_literal_kind` + `Unary` handling.
- `compiler/src/llvm/expression_lowering/native/core_literals_lowering.sfn` — narrow `i64`↔`double` precedence override.

**New regression test:**
- `compiler/tests/unit/int_array_literal_test.sfn`.

**Test corpus migration** (re-migrate `: number` → `: int`, remove `// alias-coverage` tags):
- `compiler/tests/unit/{function_signatures,loop_edge_cases,loops,match_advanced,nested_control_flow,ssa_mutations}_test.sfn`
- `compiler/tests/integration/{recursion,struct_enum_composition}_test.sfn`

**ABI-preserving literal updates** (integer → fractional where the `: number[]` ABI is intent):
- `capsules/sfn/layers/tests/layers_test.sfn`
- `compiler/tests/e2e/fixtures/array_aggregate_shape.sfn`
- `compiler/tests/e2e/test_array_aggregate_shape.sh` (assertion text + comment)

## Notes for reviewers

- The architect noted the belt-and-suspenders fix at `core_literals_lowering.sfn:245-275` as "optional but worth considering". I landed it narrow (i64↔double only) because it's load-bearing for the `powers: number[]` constant tables in compiler source — without it, those arrays produce the same bit-pattern bug as the issue describes, breaking `number_to_string` (which produces corrupted IR text and cascades into `emit_*_scope_drops` test timeouts).
- Test migration absorbed from #566's deferred follow-up because the failing tagged tests block `make test`. The diff is balanced (line-for-line annotation flips) — net ~134 lines across 8 test files. No semantics changed; the integer arithmetic these helpers exercise is equally well-typed under `int`.
- `#634` (function-call return-type inference) and `#633` (cross-module `declare` ignores `: int`) remain open as separate sibling bugs per the architect's explicit "don't widen scope" guidance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013zVrcxsric2M5xMKmcA1u8)_