### PR TITLE
refactor(lowering): add c_abi_return_type + post-call coercion (#638)

### DIFF
--- a/compiler/src/llvm/expression_lowering/arrays.sfn
+++ b/compiler/src/llvm/expression_lowering/arrays.sfn
@@ -145,7 +145,8 @@ fn lower_struct_array_concat(lhs: LLVMOperand, rhs: LLVMOperand, element_type: s
         parameter_types: [],
         return_type: "",
         symbol: "",
-        return_attributes: "noalias"
+        return_attributes: "noalias",
+        c_abi_return_type: ""
     };
     let buffer_operands: LLVMOperand[] = [buffer_size_operand];
     let buffer_result = emit_runtime_call("alloc_struct", buffer_operands, buffer_overrides, current_temp, current_lines);

--- a/compiler/src/llvm/expression_lowering/native/core_call_lowering.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_call_lowering.sfn
@@ -181,7 +181,8 @@ fn lower_call_expression(target: string, arguments: string[], bindings: Paramete
                         return_type: receiver_type,
                         parameter_types: expected_params,
                         effects: [],
-                        native_signature: null
+                        native_signature: null,
+                        c_abi_return_type: null
                     };
                     function_entry = null;
                 }
@@ -265,7 +266,8 @@ fn lower_call_expression(target: string, arguments: string[], bindings: Paramete
                         return_type: operands[0].llvm_type,
                         parameter_types: expected_params,
                         effects: [],
-                        native_signature: null
+                        native_signature: null,
+                        c_abi_return_type: null
                     };
                 }
             }

--- a/compiler/src/llvm/expression_lowering/native/core_call_resolution.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_call_resolution.sfn
@@ -139,7 +139,8 @@ fn resolve_call_method_target(trimmed_target: string, arguments: string[], bindi
                                     return_type: receiver_operand.llvm_type,
                                     parameter_types: [receiver_operand.llvm_type, receiver_operand.llvm_type],
                                     effects: [],
-                                    native_signature: null
+                                    native_signature: null,
+                                    c_abi_return_type: null
                                 };
                             }
                         }
@@ -304,7 +305,8 @@ fn resolve_call_method_target(trimmed_target: string, arguments: string[], bindi
                                                     return_type: _pre_am_type,
                                                     parameter_types: [_pre_am_type, _pre_am_type],
                                                     effects: [],
-                                                    native_signature: null
+                                                    native_signature: null,
+                                                    c_abi_return_type: null
                                                 };
                                             }
                                         }
@@ -423,7 +425,8 @@ fn resolve_parsed_method_dispatch(result_target: string, arguments: string[], bi
                                 return_type: base_operand.llvm_type,
                                 parameter_types: [base_operand.llvm_type, base_operand.llvm_type],
                                 effects: [],
-                                native_signature: null
+                                native_signature: null,
+                                c_abi_return_type: null
                             };
                         }
                     } else {
@@ -438,7 +441,8 @@ fn resolve_parsed_method_dispatch(result_target: string, arguments: string[], bi
                             return_type: base_operand.llvm_type,
                             parameter_types: [base_operand.llvm_type, array_element_type],
                             effects: [],
-                            native_signature: null
+                            native_signature: null,
+                            c_abi_return_type: null
                         };
                     }
                 }
@@ -682,7 +686,8 @@ fn resolve_parsed_method_dispatch(result_target: string, arguments: string[], bi
                                     return_type: base_operand.llvm_type,
                                     parameter_types: [base_operand.llvm_type, base_operand.llvm_type],
                                     effects: [],
-                                    native_signature: null
+                                    native_signature: null,
+                                    c_abi_return_type: null
                                 };
                             }
                         } else {
@@ -705,7 +710,8 @@ fn resolve_parsed_method_dispatch(result_target: string, arguments: string[], bi
                                     return_type: base_operand.llvm_type,
                                     parameter_types: [base_operand.llvm_type, array_element_type],
                                     effects: [],
-                                    native_signature: null
+                                    native_signature: null,
+                                    c_abi_return_type: null
                                 };
                             }
                         }

--- a/compiler/src/llvm/expression_lowering/native/core_literals_lowering.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_literals_lowering.sfn
@@ -1004,7 +1004,8 @@ fn box_aggregate_operand(operand: LLVMOperand, expected_pointer_type: string, te
         parameter_types: [],
         return_type: "",
         symbol: "",
-        return_attributes: "noalias"
+        return_attributes: "noalias",
+        c_abi_return_type: ""
     };
     let box_operands: LLVMOperand[] = [box_size_operand];
     let box_result = emit_runtime_call("alloc_struct", box_operands, box_overrides, current_temp - 1, current_lines);

--- a/compiler/src/llvm/expression_lowering/native/core_operands.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_operands.sfn
@@ -737,7 +737,8 @@ fn coerce_numeric_primitive(operand: LLVMOperand, operand_type: string, target: 
                 parameter_types: [],
                 return_type: "",
                 symbol: "",
-                return_attributes: "noalias"
+                return_attributes: "noalias",
+                c_abi_return_type: ""
             };
             let i8c_operands: LLVMOperand[] = [i8c_size_operand];
             let i8c_result = emit_runtime_call("alloc_struct", i8c_operands, i8c_overrides, temp_index, current_lines);
@@ -935,7 +936,8 @@ fn coerce_pointer_or_struct(operand: LLVMOperand, operand_type: string, target: 
                         parameter_types: [],
                         return_type: "",
                         symbol: "",
-                        return_attributes: "noalias"
+                        return_attributes: "noalias",
+                        c_abi_return_type: ""
                     };
                     let alloc_operands_a: LLVMOperand[] = [alloc_size_op_a];
                     let alloc_result_a = emit_runtime_call("alloc_struct", alloc_operands_a, alloc_overrides_a, temp_index
@@ -1047,7 +1049,8 @@ fn coerce_pointer_or_struct(operand: LLVMOperand, operand_type: string, target: 
             parameter_types: [],
             return_type: "",
             symbol: "",
-            return_attributes: "noalias"
+            return_attributes: "noalias",
+            c_abi_return_type: ""
         };
         let alloc_operands_b: LLVMOperand[] = [alloc_size_op_b];
         let alloc_result_b = emit_runtime_call("alloc_struct", alloc_operands_b, alloc_overrides_b, temp_index
@@ -1155,7 +1158,8 @@ fn coerce_general_fallback(operand: LLVMOperand, operand_type: string, target: s
                         parameter_types: [],
                         return_type: "",
                         symbol: "",
-                        return_attributes: "noalias"
+                        return_attributes: "noalias",
+                        c_abi_return_type: ""
                     };
                     let alloc_operands_c: LLVMOperand[] = [alloc_size_op_c];
                     let alloc_result_c = emit_runtime_call("alloc_struct", alloc_operands_c, alloc_overrides_c, temp_index
@@ -1253,7 +1257,8 @@ fn coerce_general_fallback(operand: LLVMOperand, operand_type: string, target: s
                             parameter_types: [],
                             return_type: "",
                             symbol: "",
-                            return_attributes: "noalias"
+                            return_attributes: "noalias",
+                            c_abi_return_type: ""
                         };
                         let alloc_operands_d: LLVMOperand[] = [alloc_size_op_d];
                         let alloc_result_d = emit_runtime_call("alloc_struct", alloc_operands_d, alloc_overrides_d, local_temp
@@ -1337,7 +1342,8 @@ fn coerce_general_fallback(operand: LLVMOperand, operand_type: string, target: s
                                 parameter_types: [],
                                 return_type: "",
                                 symbol: "",
-                                return_attributes: "noalias"
+                                return_attributes: "noalias",
+                                c_abi_return_type: ""
                             };
                             let alloc_operands_e: LLVMOperand[] = [alloc_size_op_e];
                             let alloc_result_e = emit_runtime_call("alloc_struct", alloc_operands_e, alloc_overrides_e, local_temp
@@ -1528,7 +1534,8 @@ fn coerce_general_fallback(operand: LLVMOperand, operand_type: string, target: s
                     parameter_types: [],
                     return_type: "",
                     symbol: "",
-                    return_attributes: "noalias"
+                    return_attributes: "noalias",
+                    c_abi_return_type: ""
                 };
                 let alloc_operands_f: LLVMOperand[] = [alloc_size_op_f];
                 let alloc_result_f = emit_runtime_call("alloc_struct", alloc_operands_f, alloc_overrides_f, temp_index
@@ -1622,7 +1629,8 @@ fn coerce_general_fallback(operand: LLVMOperand, operand_type: string, target: s
                     parameter_types: [],
                     return_type: "",
                     symbol: "",
-                    return_attributes: "noalias"
+                    return_attributes: "noalias",
+                    c_abi_return_type: ""
                 };
                 let alloc_operands_g: LLVMOperand[] = [alloc_size_op_g];
                 let alloc_result_g = emit_runtime_call("alloc_struct", alloc_operands_g, alloc_overrides_g, temp_index

--- a/compiler/src/llvm/expression_lowering/native/runtime_call.sfn
+++ b/compiler/src/llvm/expression_lowering/native/runtime_call.sfn
@@ -110,6 +110,25 @@ fn _resolve_call_return_type(overrides: RuntimeCallOverrides, descriptor: Runtim
     return "";
 }
 
+// Resolve the LLVM type the C runtime symbol actually returns.
+// Precedence: descriptor's `c_abi_return_type` when non-null and
+// non-empty, else falls back to the caller-visible return type
+// (`_resolve_call_return_type`). When the two differ,
+// `emit_runtime_call` emits the LLVM `call` against the ABI type
+// and a post-call coercion into the caller-visible type, decoupling
+// the user-facing return shape from the C body's actual ABI. See
+// issue #638 (mechanism) and #634 (monotonic_millis motivation:
+// the C symbol returns `double`, but Sailfin should see `i64`).
+fn _resolve_abi_return_type(overrides: RuntimeCallOverrides, descriptor: RuntimeHelperDescriptor?) -> string {
+    if descriptor != null {
+        let mut abi: string? = descriptor.c_abi_return_type;
+        if abi != null {
+            if abi.length > 0 { return abi; }
+        }
+    }
+    return _resolve_call_return_type(overrides, descriptor);
+}
+
 // Resolve the effective parameter-type list. Empty result is valid
 // (zero-arg helpers); coercion walk handles it.
 fn _resolve_call_parameter_types(overrides: RuntimeCallOverrides, descriptor: RuntimeHelperDescriptor?) -> string[] {
@@ -126,6 +145,7 @@ fn emit_runtime_call(target: string, operands: LLVMOperand[], overrides: Runtime
     let descriptor = find_runtime_helper(target);
     let call_symbol = _resolve_call_symbol(overrides, descriptor, target);
     let return_type = _resolve_call_return_type(overrides, descriptor);
+    let abi_return_type = _resolve_abi_return_type(overrides, descriptor);
     let parameter_types = _resolve_call_parameter_types(overrides, descriptor);
 
     let mut result_lines: string[] = lines;
@@ -247,20 +267,46 @@ fn emit_runtime_call(target: string, operands: LLVMOperand[], overrides: Runtime
     if overrides.return_attributes.length > 0 {
         return_decoration = overrides.return_attributes + " ";
     }
+    // The LLVM `call` is rendered against the C ABI return type so
+    // the linker resolves to the symbol with its true SysV register
+    // class (`%rax` for i64, `%xmm0` for double, etc.). When the
+    // descriptor's `c_abi_return_type` matches `return_type` (i.e.
+    // the field is null, which is the entire registry today),
+    // `abi_return_type == return_type` and the render is identical
+    // to the pre-#638 shape — no observable behavior change.
     result_lines.push("  " + temp_name + " = call " + return_decoration
-        + return_type
+        + abi_return_type
         + " @"
         + call_symbol
         + "("
         + argument_text
         + ")");
-    let result_operand = LLVMOperand {
-        llvm_type: return_type,
+    let mut result_operand: LLVMOperand = LLVMOperand {
+        llvm_type: abi_return_type,
         value: temp_name
     };
+    let mut next_temp: int = result_temp + 1;
+
+    // Post-call coercion: when the descriptor opts into a different
+    // C ABI return type than the caller-visible one, splice in a
+    // coercion (`fptosi double to i64`, `sitofp i64 to double`, etc.)
+    // so the LLVMOperand handed back to the caller carries
+    // `return_type`. `coerce_operand_to_type` already handles numeric
+    // `double ↔ i64` (issue #638 scope); other directions surface
+    // as a coercion diagnostic and the operand falls back to the
+    // raw C-ABI value rather than emitting malformed IR. See
+    // `_resolve_abi_return_type` for the precedence rules.
+    if abi_return_type != return_type {
+        let coercion = coerce_operand_to_type(result_operand, return_type, next_temp, result_lines, true, null);
+        result_diagnostics = extend_string_array(result_diagnostics, coercion.diagnostics);
+        result_lines = coercion.lines;
+        next_temp = coercion.temp_index;
+        if coercion.operand != null { result_operand = coercion.operand; }
+    }
+
     return ExpressionResult {
         lines: result_lines,
-        temp_index: result_temp + 1,
+        temp_index: next_temp,
         operand: result_operand,
         diagnostics: result_diagnostics,
         string_constants: empty_constants

--- a/compiler/src/llvm/expression_lowering/native/runtime_call.sfn
+++ b/compiler/src/llvm/expression_lowering/native/runtime_call.sfn
@@ -66,11 +66,21 @@ import { coerce_operand_to_type } from "./core_operands";
 //   today's emission carries `noalias` (e.g., `alloc_struct`) preserve
 //   the attribute through this per-call-site override during M1.7
 //   migrations. Ignored when `return_type == "void"`.
+// - `c_abi_return_type`: when non-empty, replaces the descriptor's
+//   `c_abi_return_type`. Mirrors the precedence pattern of
+//   `return_type` / `symbol`: lets a migrating (or test) call site
+//   exercise the ABI-coercion path without editing the production
+//   registry. When `c_abi_return_type` differs from the resolved
+//   `return_type`, `emit_runtime_call` splices in a post-call
+//   coercion. See issue #638 review for why the override path is
+//   preferred over a `__sfn_test_*` fixture descriptor in the
+//   production registry (Copilot review).
 struct RuntimeCallOverrides {
     parameter_types: string[];
     return_type: string;
     symbol: string;
     return_attributes: string;
+    c_abi_return_type: string;
 }
 
 // Convenience constructor for the common "no overrides" case.
@@ -79,7 +89,8 @@ fn empty_runtime_call_overrides() -> RuntimeCallOverrides {
         parameter_types: [],
         return_type: "",
         symbol: "",
-        return_attributes: ""
+        return_attributes: "",
+        c_abi_return_type: ""
     };
 }
 
@@ -120,6 +131,9 @@ fn _resolve_call_return_type(overrides: RuntimeCallOverrides, descriptor: Runtim
 // issue #638 (mechanism) and #634 (monotonic_millis motivation:
 // the C symbol returns `double`, but Sailfin should see `i64`).
 fn _resolve_abi_return_type(overrides: RuntimeCallOverrides, descriptor: RuntimeHelperDescriptor?) -> string {
+    if overrides.c_abi_return_type.length > 0 {
+        return overrides.c_abi_return_type;
+    }
     if descriptor != null {
         let mut abi: string? = descriptor.c_abi_return_type;
         if abi != null {

--- a/compiler/src/llvm/rendering.sfn
+++ b/compiler/src/llvm/rendering.sfn
@@ -9,7 +9,7 @@ import {
     extract_struct_type_from_llvm,
     render_interface_signature
 } from "./rendering_helpers";
-import { runtime_helper_descriptors } from "./runtime_helpers";
+import { effective_helper_declare_return_type, runtime_helper_descriptors } from "./runtime_helpers";
 import { map_parameter_type, map_return_type } from "./type_mapping";
 import { RuntimeHelperDescriptor, TraitMetadata, TypeContext } from "./types";
 import {
@@ -154,8 +154,19 @@ fn render_runtime_helper_declarations(used_targets: string[], local_functions: N
             if descriptor.parameter_types.length > 0 {
                 parameter_text = join_with_separator(descriptor.parameter_types, ", ");
             }
-            let line = "declare " + descriptor.return_type + " @"
-                + effective_symbol
+            // The `declare` line must use the C body's true ABI return
+            // type, not the caller-visible `return_type`. When the
+            // descriptor opts into the post-call coercion mechanism
+            // (`c_abi_return_type` set, #638), `emit_runtime_call`
+            // renders `call <abi> @sym(...)`; this line keeps the
+            // declare aligned so the IR validates and the linker
+            // resolves the C symbol with its true register class.
+            // For descriptors without a coercion opt-in (the entire
+            // registry today) this collapses to `descriptor.return_type`
+            // and the emitted line is byte-identical to the pre-#638
+            // shape.
+            let declare_return = effective_helper_declare_return_type(descriptor);
+            let line = "declare " + declare_return + " @" + effective_symbol
                 + "("
                 + parameter_text
                 + ")";
@@ -185,7 +196,7 @@ fn render_runtime_helper_declarations(used_targets: string[], local_functions: N
                     if sanitized_target != effective_symbol {
                         if !string_array_contains(declared_symbols, sanitized_target) {
                             if !string_array_contains(local_symbols, sanitized_target) {
-                                let alias_line = "declare " + descriptor.return_type
+                                let alias_line = "declare " + declare_return
                                     + " @"
                                     + sanitized_target
                                     + "("

--- a/compiler/src/llvm/runtime_helpers.sfn
+++ b/compiler/src/llvm/runtime_helpers.sfn
@@ -85,11 +85,11 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
     // Raw print: writes to stdout with no prefix, no decoration.
     // Used by the compiler itself for artifact output and CLI messages.
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "print", symbol: "sailfin_runtime_print_raw", return_type: "void", parameter_types: ["i8*"], effects: ["io"], native_signature: null
+        target: "print", symbol: "sailfin_runtime_print_raw", return_type: "void", parameter_types: ["i8*"], effects: ["io"], native_signature: null, c_abi_return_type: null
     });
     // Raw stderr print: writes to stderr with no prefix, no decoration.
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "print.err", symbol: "sailfin_runtime_print_err", return_type: "void", parameter_types: ["i8*"], effects: ["io"], native_signature: null
+        target: "print.err", symbol: "sailfin_runtime_print_err", return_type: "void", parameter_types: ["i8*"], effects: ["io"], native_signature: null, c_abi_return_type: null
     });
 
     // Prefixed print variants — print.err/print.warn/print.error write to
@@ -97,38 +97,38 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
     // Compiler diagnostics should use print.err() so they do not pollute
     // stdout (LLVM IR output, program output, etc.).
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "print.info", symbol: "sailfin_runtime_print_info", return_type: "void", parameter_types: ["i8*"], effects: ["io"], native_signature: null
+        target: "print.info", symbol: "sailfin_runtime_print_info", return_type: "void", parameter_types: ["i8*"], effects: ["io"], native_signature: null, c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "print.error", symbol: "sailfin_runtime_print_error", return_type: "void", parameter_types: ["i8*"], effects: ["io"], native_signature: null
+        target: "print.error", symbol: "sailfin_runtime_print_error", return_type: "void", parameter_types: ["i8*"], effects: ["io"], native_signature: null, c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "print.warn", symbol: "sailfin_runtime_print_warn", return_type: "void", parameter_types: ["i8*"], effects: ["io"], native_signature: null
+        target: "print.warn", symbol: "sailfin_runtime_print_warn", return_type: "void", parameter_types: ["i8*"], effects: ["io"], native_signature: null, c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "console.info", symbol: "sailfin_runtime_print_raw", return_type: "void", parameter_types: ["i8*"], effects: ["io"], native_signature: null
+        target: "console.info", symbol: "sailfin_runtime_print_raw", return_type: "void", parameter_types: ["i8*"], effects: ["io"], native_signature: null, c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "console.log", symbol: "sailfin_runtime_print_raw", return_type: "void", parameter_types: ["i8*"], effects: ["io"], native_signature: null
+        target: "console.log", symbol: "sailfin_runtime_print_raw", return_type: "void", parameter_types: ["i8*"], effects: ["io"], native_signature: null, c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "console.error", symbol: "sailfin_runtime_print_error", return_type: "void", parameter_types: ["i8*"], effects: ["io"], native_signature: null
+        target: "console.error", symbol: "sailfin_runtime_print_error", return_type: "void", parameter_types: ["i8*"], effects: ["io"], native_signature: null, c_abi_return_type: null
     });
 
     // IO intrinsics
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "io_read", symbol: "sailfin_intrinsic_io_read", return_type: "i8*", parameter_types: ["i8*"], effects: ["io"], native_signature: null
+        target: "io_read", symbol: "sailfin_intrinsic_io_read", return_type: "i8*", parameter_types: ["i8*"], effects: ["io"], native_signature: null, c_abi_return_type: null
     });
 
     // Filesystem intrinsics
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "fs.read", symbol: "sailfin_intrinsic_fs_read", return_type: "i8*", parameter_types: ["i8*"], effects: ["io"], native_signature: null
+        target: "fs.read", symbol: "sailfin_intrinsic_fs_read", return_type: "i8*", parameter_types: ["i8*"], effects: ["io"], native_signature: null, c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "fs.write", symbol: "sailfin_intrinsic_fs_write", return_type: "void", parameter_types: ["i8*", "i8*"], effects: ["io"], native_signature: null
+        target: "fs.write", symbol: "sailfin_intrinsic_fs_write", return_type: "void", parameter_types: ["i8*", "i8*"], effects: ["io"], native_signature: null, c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "fs.exists", symbol: "sailfin_intrinsic_fs_exists", return_type: "i1", parameter_types: ["i8*"], effects: ["io"], native_signature: null
+        target: "fs.exists", symbol: "sailfin_intrinsic_fs_exists", return_type: "i1", parameter_types: ["i8*"], effects: ["io"], native_signature: null, c_abi_return_type: null
     });
 
     // Arena mark / rewind. Phase 5a (`docs/proposals/phase-5a-arena-reset.md`)
@@ -153,21 +153,21 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
     // `sailfin_intrinsic_runtime_arena_mark()` (or a friendlier
     // alias added at that time).
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "sailfin_intrinsic_runtime_arena_mark", symbol: "sailfin_intrinsic_runtime_arena_mark", return_type: "double", parameter_types: [], effects: [], native_signature: null
+        target: "sailfin_intrinsic_runtime_arena_mark", symbol: "sailfin_intrinsic_runtime_arena_mark", return_type: "double", parameter_types: [], effects: [], native_signature: null, c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "sailfin_intrinsic_runtime_arena_rewind", symbol: "sailfin_intrinsic_runtime_arena_rewind", return_type: "void", parameter_types: ["double"], effects: [], native_signature: null
+        target: "sailfin_intrinsic_runtime_arena_rewind", symbol: "sailfin_intrinsic_runtime_arena_rewind", return_type: "void", parameter_types: ["double"], effects: [], native_signature: null, c_abi_return_type: null
     });
 
     // Network intrinsics
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "net_request", symbol: "sailfin_intrinsic_net_request", return_type: "i8*", parameter_types: ["i8*", "i8*", "i8*"], effects: ["net"], native_signature: null
+        target: "net_request", symbol: "sailfin_intrinsic_net_request", return_type: "i8*", parameter_types: ["i8*", "i8*", "i8*"], effects: ["net"], native_signature: null, c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "http.get", symbol: "sailfin_intrinsic_http_get", return_type: "i8*", parameter_types: ["i8*"], effects: ["net"], native_signature: null
+        target: "http.get", symbol: "sailfin_intrinsic_http_get", return_type: "i8*", parameter_types: ["i8*"], effects: ["net"], native_signature: null, c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "http.post", symbol: "sailfin_intrinsic_http_post", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: ["net"], native_signature: null
+        target: "http.post", symbol: "sailfin_intrinsic_http_post", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: ["net"], native_signature: null, c_abi_return_type: null
     });
 
     // Concurrency intrinsics. Sleep call sites route through the
@@ -181,10 +181,10 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
     // opaque-handle sizing). When that lands, `sailfin_runtime_sleep`
     // disappears from both the C runtime and `platform/libc.sfn`.
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "sleep", symbol: "sfn_sleep", return_type: "void", parameter_types: ["double"], effects: ["clock"], native_signature: null
+        target: "sleep", symbol: "sfn_sleep", return_type: "void", parameter_types: ["double"], effects: ["clock"], native_signature: null, c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "runtime_sleep_fn", symbol: "sfn_sleep", return_type: "void", parameter_types: ["double"], effects: ["clock"], native_signature: null
+        target: "runtime_sleep_fn", symbol: "sfn_sleep", return_type: "void", parameter_types: ["double"], effects: ["clock"], native_signature: null, c_abi_return_type: null
     });
     // Type signature for the C entrypoint `sailfin_runtime_sleep`,
     // which `runtime/sfn/clock.sfn`'s `sfn_sleep` body imports
@@ -196,16 +196,16 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
     // signature makes the call lowering type-correct for any
     // future caller.
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "sailfin_runtime_sleep", symbol: "sailfin_runtime_sleep", return_type: "void", parameter_types: ["double"], effects: ["clock"], native_signature: null
+        target: "sailfin_runtime_sleep", symbol: "sailfin_runtime_sleep", return_type: "void", parameter_types: ["double"], effects: ["clock"], native_signature: null, c_abi_return_type: null
     });
 
     // Monotonic clock for profiling/timing.
     // Support both the prelude binding name and direct calls.
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "runtime_monotonic_millis_fn", symbol: "sailfin_runtime_monotonic_millis", return_type: "double", parameter_types: [], effects: ["clock"], native_signature: null
+        target: "runtime_monotonic_millis_fn", symbol: "sailfin_runtime_monotonic_millis", return_type: "double", parameter_types: [], effects: ["clock"], native_signature: null, c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "monotonic_millis", symbol: "sailfin_runtime_monotonic_millis", return_type: "double", parameter_types: [], effects: ["clock"], native_signature: null
+        target: "monotonic_millis", symbol: "sailfin_runtime_monotonic_millis", return_type: "double", parameter_types: [], effects: ["clock"], native_signature: null, c_abi_return_type: null
     });
     // Untyped `channel` / `spawn` / `parallel` descriptors removed under
     // issue #617 — their C bridges were silent no-ops and the
@@ -214,22 +214,22 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
     // their descriptors below. Re-introduce these only when the
     // structured-concurrency runtime (#500, roadmap M4) actually lands.
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "runtime_create_capability_grant", symbol: "sailfin_runtime_create_capability_grant", return_type: "i8*", parameter_types: ["i8*"], effects: [], native_signature: null
+        target: "runtime_create_capability_grant", symbol: "sailfin_runtime_create_capability_grant", return_type: "i8*", parameter_types: ["i8*"], effects: [], native_signature: null, c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "runtime_create_filesystem_bridge", symbol: "sailfin_runtime_create_filesystem_bridge", return_type: "i8*", parameter_types: ["i8*"], effects: ["io"], native_signature: null
+        target: "runtime_create_filesystem_bridge", symbol: "sailfin_runtime_create_filesystem_bridge", return_type: "i8*", parameter_types: ["i8*"], effects: ["io"], native_signature: null, c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "runtime_create_http_bridge", symbol: "sailfin_runtime_create_http_bridge", return_type: "i8*", parameter_types: ["i8*"], effects: ["net"], native_signature: null
+        target: "runtime_create_http_bridge", symbol: "sailfin_runtime_create_http_bridge", return_type: "i8*", parameter_types: ["i8*"], effects: ["net"], native_signature: null, c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "runtime_log_execution_fn", symbol: "sailfin_runtime_log_execution", return_type: "i8*", parameter_types: ["i8*"], effects: ["io"], native_signature: null
+        target: "runtime_log_execution_fn", symbol: "sailfin_runtime_log_execution", return_type: "i8*", parameter_types: ["i8*"], effects: ["io"], native_signature: null, c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "runtime_to_debug_string_fn", symbol: "sailfin_runtime_to_debug_string", return_type: "i8*", parameter_types: ["i8*"], effects: [], native_signature: null
+        target: "runtime_to_debug_string_fn", symbol: "sailfin_runtime_to_debug_string", return_type: "i8*", parameter_types: ["i8*"], effects: [], native_signature: null, c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "runtime_raise_value_error_fn", symbol: "sailfin_runtime_raise_value_error", return_type: "void", parameter_types: ["i8*"], effects: [], native_signature: null
+        target: "runtime_raise_value_error_fn", symbol: "sailfin_runtime_raise_value_error", return_type: "void", parameter_types: ["i8*"], effects: [], native_signature: null, c_abi_return_type: null
     });
     // Issue #364: structured assertion failure record. The desugared
     // `assert e;` lowering routes through this trampoline so the test
@@ -239,40 +239,40 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
     // line/col; it clamps + forwards to `sailfin_assert_fail` whose
     // ABI matches the spec's `(*const u8, i64, i64, *const u8)`.
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "runtime_assert_fail_fn", symbol: "runtime_assert_fail_fn", return_type: "void", parameter_types: ["i8*", "double", "double", "i8*"], effects: [], native_signature: null
+        target: "runtime_assert_fail_fn", symbol: "runtime_assert_fail_fn", return_type: "void", parameter_types: ["i8*", "double", "double", "i8*"], effects: [], native_signature: null, c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "runtime_is_string_fn", symbol: "sailfin_runtime_is_string", return_type: "i1", parameter_types: ["i8*"], effects: [], native_signature: null
+        target: "runtime_is_string_fn", symbol: "sailfin_runtime_is_string", return_type: "i1", parameter_types: ["i8*"], effects: [], native_signature: null, c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "runtime_is_number_fn", symbol: "sailfin_runtime_is_number", return_type: "i1", parameter_types: ["i8*"], effects: [], native_signature: null
+        target: "runtime_is_number_fn", symbol: "sailfin_runtime_is_number", return_type: "i1", parameter_types: ["i8*"], effects: [], native_signature: null, c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "runtime_is_boolean_fn", symbol: "sailfin_runtime_is_boolean", return_type: "i1", parameter_types: ["i8*"], effects: [], native_signature: null
+        target: "runtime_is_boolean_fn", symbol: "sailfin_runtime_is_boolean", return_type: "i1", parameter_types: ["i8*"], effects: [], native_signature: null, c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "runtime_is_void_fn", symbol: "sailfin_runtime_is_void", return_type: "i1", parameter_types: ["i8*"], effects: [], native_signature: null
+        target: "runtime_is_void_fn", symbol: "sailfin_runtime_is_void", return_type: "i1", parameter_types: ["i8*"], effects: [], native_signature: null, c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "runtime.bounds_check", symbol: "sailfin_runtime_bounds_check", return_type: "void", parameter_types: ["i64", "i64"], effects: [], native_signature: null
+        target: "runtime.bounds_check", symbol: "sailfin_runtime_bounds_check", return_type: "void", parameter_types: ["i64", "i64"], effects: [], native_signature: null, c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "runtime_is_array_fn", symbol: "sailfin_runtime_is_array", return_type: "i1", parameter_types: ["i8*"], effects: [], native_signature: null
+        target: "runtime_is_array_fn", symbol: "sailfin_runtime_is_array", return_type: "i1", parameter_types: ["i8*"], effects: [], native_signature: null, c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "runtime_is_callable_fn", symbol: "sailfin_runtime_is_callable", return_type: "i1", parameter_types: ["i8*"], effects: [], native_signature: null
+        target: "runtime_is_callable_fn", symbol: "sailfin_runtime_is_callable", return_type: "i1", parameter_types: ["i8*"], effects: [], native_signature: null, c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "runtime_resolve_runtime_type_fn", symbol: "sailfin_runtime_resolve_type", return_type: "i8*", parameter_types: ["i8*"], effects: [], native_signature: null
+        target: "runtime_resolve_runtime_type_fn", symbol: "sailfin_runtime_resolve_type", return_type: "i8*", parameter_types: ["i8*"], effects: [], native_signature: null, c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "runtime_instance_of_fn", symbol: "sailfin_runtime_instance_of", return_type: "i1", parameter_types: ["i8*", "i8*"], effects: [], native_signature: null
+        target: "runtime_instance_of_fn", symbol: "sailfin_runtime_instance_of", return_type: "i1", parameter_types: ["i8*", "i8*"], effects: [], native_signature: null, c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "runtime_serve_fn", symbol: "sailfin_runtime_serve", return_type: "void", parameter_types: ["i8*", "i8*"], effects: ["io", "net"], native_signature: null
+        target: "runtime_serve_fn", symbol: "sailfin_runtime_serve", return_type: "void", parameter_types: ["i8*", "i8*"], effects: ["io", "net"], native_signature: null, c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "runtime_char_code_fn", symbol: "sailfin_runtime_char_code", return_type: "double", parameter_types: ["i8*"], effects: [], native_signature: null
+        target: "runtime_char_code_fn", symbol: "sailfin_runtime_char_code", return_type: "double", parameter_types: ["i8*"], effects: [], native_signature: null, c_abi_return_type: null
     });
 
     // Process helpers
@@ -282,95 +282,95 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
     // exported for seed-compiled IR; the registry only points the
     // new compiler at v2.
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "process.run", symbol: "sailfin_runtime_process_run_v2", return_type: "double", parameter_types: ["{ i8**, i64, i64 }*"], effects: ["io"], native_signature: null
+        target: "process.run", symbol: "sailfin_runtime_process_run_v2", return_type: "double", parameter_types: ["{ i8**, i64, i64 }*"], effects: ["io"], native_signature: null, c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "process.exit", symbol: "sailfin_runtime_process_exit", return_type: "void", parameter_types: ["double"], effects: ["io"], native_signature: null
+        target: "process.exit", symbol: "sailfin_runtime_process_exit", return_type: "void", parameter_types: ["double"], effects: ["io"], native_signature: null, c_abi_return_type: null
     });
 
     // Filesystem adapters
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "fs_read_file", symbol: "sailfin_adapter_fs_read_file", return_type: "i8*", parameter_types: ["i8*"], effects: ["io"], native_signature: null
+        target: "fs_read_file", symbol: "sailfin_adapter_fs_read_file", return_type: "i8*", parameter_types: ["i8*"], effects: ["io"], native_signature: null, c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "fs.readFile", symbol: "sailfin_adapter_fs_read_file", return_type: "i8*", parameter_types: ["i8*"], effects: ["io"], native_signature: null
+        target: "fs.readFile", symbol: "sailfin_adapter_fs_read_file", return_type: "i8*", parameter_types: ["i8*"], effects: ["io"], native_signature: null, c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "fs_write_file", symbol: "sailfin_adapter_fs_write_file", return_type: "void", parameter_types: ["i8*", "i8*"], effects: ["io"], native_signature: null
+        target: "fs_write_file", symbol: "sailfin_adapter_fs_write_file", return_type: "void", parameter_types: ["i8*", "i8*"], effects: ["io"], native_signature: null, c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "fs.writeFile", symbol: "sailfin_adapter_fs_write_file", return_type: "void", parameter_types: ["i8*", "i8*"], effects: ["io"], native_signature: null
+        target: "fs.writeFile", symbol: "sailfin_adapter_fs_write_file", return_type: "void", parameter_types: ["i8*", "i8*"], effects: ["io"], native_signature: null, c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "fs_append_file", symbol: "sailfin_adapter_fs_append_file", return_type: "void", parameter_types: ["i8*", "i8*"], effects: ["io"], native_signature: null
+        target: "fs_append_file", symbol: "sailfin_adapter_fs_append_file", return_type: "void", parameter_types: ["i8*", "i8*"], effects: ["io"], native_signature: null, c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "fs.appendFile", symbol: "sailfin_adapter_fs_append_file", return_type: "void", parameter_types: ["i8*", "i8*"], effects: ["io"], native_signature: null
+        target: "fs.appendFile", symbol: "sailfin_adapter_fs_append_file", return_type: "void", parameter_types: ["i8*", "i8*"], effects: ["io"], native_signature: null, c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "fs_write_lines", symbol: "sailfin_adapter_fs_write_lines_v2", return_type: "void", parameter_types: ["i8*", "{ i8**, i64, i64 }*"], effects: ["io"], native_signature: null
+        target: "fs_write_lines", symbol: "sailfin_adapter_fs_write_lines_v2", return_type: "void", parameter_types: ["i8*", "{ i8**, i64, i64 }*"], effects: ["io"], native_signature: null, c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "fs.writeLines", symbol: "sailfin_adapter_fs_write_lines_v2", return_type: "void", parameter_types: ["i8*", "{ i8**, i64, i64 }*"], effects: ["io"], native_signature: null
+        target: "fs.writeLines", symbol: "sailfin_adapter_fs_write_lines_v2", return_type: "void", parameter_types: ["i8*", "{ i8**, i64, i64 }*"], effects: ["io"], native_signature: null, c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "fs_list_directory", symbol: "sailfin_adapter_fs_list_directory_v2", return_type: "{ i8**, i64, i64 }*", parameter_types: ["i8*"], effects: ["io"], native_signature: null
+        target: "fs_list_directory", symbol: "sailfin_adapter_fs_list_directory_v2", return_type: "{ i8**, i64, i64 }*", parameter_types: ["i8*"], effects: ["io"], native_signature: null, c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "fs.listDirectory", symbol: "sailfin_adapter_fs_list_directory_v2", return_type: "{ i8**, i64, i64 }*", parameter_types: ["i8*"], effects: ["io"], native_signature: null
+        target: "fs.listDirectory", symbol: "sailfin_adapter_fs_list_directory_v2", return_type: "{ i8**, i64, i64 }*", parameter_types: ["i8*"], effects: ["io"], native_signature: null, c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "fs_delete_file", symbol: "sailfin_adapter_fs_delete_file", return_type: "i1", parameter_types: ["i8*"], effects: ["io"], native_signature: null
+        target: "fs_delete_file", symbol: "sailfin_adapter_fs_delete_file", return_type: "i1", parameter_types: ["i8*"], effects: ["io"], native_signature: null, c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "fs.deleteFile", symbol: "sailfin_adapter_fs_delete_file", return_type: "i1", parameter_types: ["i8*"], effects: ["io"], native_signature: null
+        target: "fs.deleteFile", symbol: "sailfin_adapter_fs_delete_file", return_type: "i1", parameter_types: ["i8*"], effects: ["io"], native_signature: null, c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "fs_create_directory", symbol: "sailfin_adapter_fs_create_directory", return_type: "i1", parameter_types: ["i8*", "i1"], effects: ["io"], native_signature: null
+        target: "fs_create_directory", symbol: "sailfin_adapter_fs_create_directory", return_type: "i1", parameter_types: ["i8*", "i1"], effects: ["io"], native_signature: null, c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "fs.createDirectory", symbol: "sailfin_adapter_fs_create_directory", return_type: "i1", parameter_types: ["i8*", "i1"], effects: ["io"], native_signature: null
+        target: "fs.createDirectory", symbol: "sailfin_adapter_fs_create_directory", return_type: "i1", parameter_types: ["i8*", "i1"], effects: ["io"], native_signature: null, c_abi_return_type: null
     });
 
     // HTTP adapters (distinct from intrinsics for adapter infrastructure)
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "http_get", symbol: "sailfin_adapter_http_get", return_type: "i8*", parameter_types: ["i8*"], effects: ["net"], native_signature: null
+        target: "http_get", symbol: "sailfin_adapter_http_get", return_type: "i8*", parameter_types: ["i8*"], effects: ["net"], native_signature: null, c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "http_post", symbol: "sailfin_adapter_http_post", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: ["net"], native_signature: null
+        target: "http_post", symbol: "sailfin_adapter_http_post", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: ["net"], native_signature: null, c_abi_return_type: null
     });
 
     // Serve adapters
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "serve_start", symbol: "sailfin_adapter_serve_start", return_type: "void", parameter_types: ["i8*", "i32"], effects: ["net", "io"], native_signature: null
+        target: "serve_start", symbol: "sailfin_adapter_serve_start", return_type: "void", parameter_types: ["i8*", "i32"], effects: ["net", "io"], native_signature: null, c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "serve_handler_dispatch", symbol: "sailfin_adapter_serve_handler_dispatch", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: ["net", "io"], native_signature: null
+        target: "serve_handler_dispatch", symbol: "sailfin_adapter_serve_handler_dispatch", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: ["net", "io"], native_signature: null, c_abi_return_type: null
     });
 
     // Concurrency adapters
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "spawn_task", symbol: "sailfin_adapter_spawn_task", return_type: "i8*", parameter_types: ["i8*"], effects: ["spawn"], native_signature: null
+        target: "spawn_task", symbol: "sailfin_adapter_spawn_task", return_type: "i8*", parameter_types: ["i8*"], effects: ["spawn"], native_signature: null, c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "channel_create", symbol: "sailfin_adapter_channel_create", return_type: "i8*", parameter_types: ["i32"], effects: [], native_signature: null
+        target: "channel_create", symbol: "sailfin_adapter_channel_create", return_type: "i8*", parameter_types: ["i32"], effects: [], native_signature: null, c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "channel_send", symbol: "sailfin_adapter_channel_send", return_type: "void", parameter_types: ["i8*", "i8*"], effects: ["channel"], native_signature: null
+        target: "channel_send", symbol: "sailfin_adapter_channel_send", return_type: "void", parameter_types: ["i8*", "i8*"], effects: ["channel"], native_signature: null, c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "channel_receive", symbol: "sailfin_adapter_channel_receive", return_type: "i8*", parameter_types: ["i8*"], effects: ["channel"], native_signature: null
+        target: "channel_receive", symbol: "sailfin_adapter_channel_receive", return_type: "i8*", parameter_types: ["i8*"], effects: ["channel"], native_signature: null, c_abi_return_type: null
     });
 
     // Collection helpers
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "runtime_array_map_fn", symbol: "sailfin_runtime_array_map", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: [], native_signature: null
+        target: "runtime_array_map_fn", symbol: "sailfin_runtime_array_map", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: [], native_signature: null, c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "runtime_array_filter_fn", symbol: "sailfin_runtime_array_filter", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: [], native_signature: null
+        target: "runtime_array_filter_fn", symbol: "sailfin_runtime_array_filter", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: [], native_signature: null, c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "runtime_array_reduce_fn", symbol: "sailfin_runtime_array_reduce", return_type: "i8*", parameter_types: ["i8*", "i8*", "i8*"], effects: [], native_signature: null
+        target: "runtime_array_reduce_fn", symbol: "sailfin_runtime_array_reduce", return_type: "i8*", parameter_types: ["i8*", "i8*", "i8*"], effects: [], native_signature: null, c_abi_return_type: null
     });
 
     // String utility helpers
@@ -393,13 +393,13 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
     // IR (which still carries the legacy `symbol` names) keeps
     // linking through the legacy bodies during the cutover.
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "substring", symbol: "substring", return_type: "i8*", parameter_types: ["i8*", "double", "double"], effects: [], native_signature: "sfn_str_slice"
+        target: "substring", symbol: "substring", return_type: "i8*", parameter_types: ["i8*", "double", "double"], effects: [], native_signature: "sfn_str_slice", c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "substring_unchecked", symbol: "substring_unchecked", return_type: "i8*", parameter_types: ["i8*", "double", "double"], effects: [], native_signature: "sfn_str_slice"
+        target: "substring_unchecked", symbol: "substring_unchecked", return_type: "i8*", parameter_types: ["i8*", "double", "double"], effects: [], native_signature: "sfn_str_slice", c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "string.length", symbol: "sailfin_runtime_string_length", return_type: "i64", parameter_types: ["i8*"], effects: [], native_signature: "sfn_str_len"
+        target: "string.length", symbol: "sailfin_runtime_string_length", return_type: "i64", parameter_types: ["i8*"], effects: [], native_signature: "sfn_str_len", c_abi_return_type: null
     });
     // M1.A — string.concat parameters lock to the SfnString aggregate
     // ABI. The new symbol `sailfin_runtime_string_concat_v2` accepts
@@ -424,13 +424,13 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
     // through the legacy entrypoint while fresh emission lands on the
     // canonical name.
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "string.concat", symbol: "sailfin_runtime_string_concat_v2", return_type: "i8*", parameter_types: ["{i8*, i64}", "{i8*, i64}"], effects: [], native_signature: "sfn_str_concat"
+        target: "string.concat", symbol: "sailfin_runtime_string_concat_v2", return_type: "i8*", parameter_types: ["{i8*, i64}", "{i8*, i64}"], effects: [], native_signature: "sfn_str_concat", c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "string.append", symbol: "sailfin_runtime_string_append", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: [], native_signature: null
+        target: "string.append", symbol: "sailfin_runtime_string_append", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: [], native_signature: null, c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "string.drop", symbol: "sailfin_runtime_string_drop", return_type: "void", parameter_types: ["i8*"], effects: [], native_signature: null
+        target: "string.drop", symbol: "sailfin_runtime_string_drop", return_type: "void", parameter_types: ["i8*"], effects: [], native_signature: null, c_abi_return_type: null
     });
     // Scope-exit drop helper for owned RC locals (M1.5.2, issue #326).
     // Emit_scope_drops generates `call void @sfn_rc_release(i8* %ptr)` for
@@ -438,40 +438,40 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
     // C-side stub is a no-op until M2 ships real RC semantics — calling
     // it against arena pointers (everything pre-M1.5.5) must not free.
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "rc.release", symbol: "sfn_rc_release", return_type: "void", parameter_types: ["i8*"], effects: [], native_signature: null
+        target: "rc.release", symbol: "sfn_rc_release", return_type: "void", parameter_types: ["i8*"], effects: [], native_signature: null, c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "number.to_string", symbol: "sailfin_runtime_number_to_string", return_type: "i8*", parameter_types: ["double"], effects: [], native_signature: null
+        target: "number.to_string", symbol: "sailfin_runtime_number_to_string", return_type: "i8*", parameter_types: ["double"], effects: [], native_signature: null, c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "string.to_number", symbol: "sailfin_runtime_string_to_number", return_type: "double", parameter_types: ["i8*"], effects: [], native_signature: null
+        target: "string.to_number", symbol: "sailfin_runtime_string_to_number", return_type: "double", parameter_types: ["i8*"], effects: [], native_signature: null, c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "strings_equal", symbol: "strings_equal", return_type: "i1", parameter_types: ["i8*", "i8*"], effects: [], native_signature: "sfn_str_eq"
+        target: "strings_equal", symbol: "strings_equal", return_type: "i1", parameter_types: ["i8*", "i8*"], effects: [], native_signature: "sfn_str_eq", c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "char_code", symbol: "char_code", return_type: "i64", parameter_types: ["i8*"], effects: [], native_signature: null
+        target: "char_code", symbol: "char_code", return_type: "i64", parameter_types: ["i8*"], effects: [], native_signature: null, c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "number_to_string", symbol: "number_to_string", return_type: "i8*", parameter_types: ["double"], effects: [], native_signature: null
+        target: "number_to_string", symbol: "number_to_string", return_type: "i8*", parameter_types: ["double"], effects: [], native_signature: null, c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "runtime_grapheme_count_fn", symbol: "sailfin_runtime_grapheme_count", return_type: "double", parameter_types: ["i8*"], effects: [], native_signature: null
+        target: "runtime_grapheme_count_fn", symbol: "sailfin_runtime_grapheme_count", return_type: "double", parameter_types: ["i8*"], effects: [], native_signature: null, c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "runtime_grapheme_at_fn", symbol: "sailfin_runtime_grapheme_at", return_type: "i8*", parameter_types: ["i8*", "double"], effects: [], native_signature: null
+        target: "runtime_grapheme_at_fn", symbol: "sailfin_runtime_grapheme_at", return_type: "i8*", parameter_types: ["i8*", "double"], effects: [], native_signature: null, c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "grapheme_at", symbol: "sailfin_runtime_grapheme_at", return_type: "i8*", parameter_types: ["i8*", "double"], effects: [], native_signature: null
+        target: "grapheme_at", symbol: "sailfin_runtime_grapheme_at", return_type: "i8*", parameter_types: ["i8*", "double"], effects: [], native_signature: null, c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "is_whitespace_char", symbol: "sailfin_runtime_is_whitespace_char", return_type: "i1", parameter_types: ["i8"], effects: [], native_signature: null
+        target: "is_whitespace_char", symbol: "sailfin_runtime_is_whitespace_char", return_type: "i1", parameter_types: ["i8"], effects: [], native_signature: null, c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "is_decimal_digit", symbol: "sailfin_runtime_is_decimal_digit", return_type: "i1", parameter_types: ["i8"], effects: [], native_signature: null
+        target: "is_decimal_digit", symbol: "sailfin_runtime_is_decimal_digit", return_type: "i1", parameter_types: ["i8"], effects: [], native_signature: null, c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "is_alpha_char", symbol: "sailfin_runtime_is_alpha_char", return_type: "i1", parameter_types: ["i8"], effects: [], native_signature: null
+        target: "is_alpha_char", symbol: "sailfin_runtime_is_alpha_char", return_type: "i1", parameter_types: ["i8"], effects: [], native_signature: null, c_abi_return_type: null
     });
 
     // M1.2 (#461): SfnString method descriptors registered with their
@@ -486,16 +486,16 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
     // caller is connected. `parameter_types` use the SfnString aggregate
     // shape (`{i8*, i64}`) — matches the M1.A lock-in for fresh emission.
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "string.starts_with", symbol: "sfn_str_starts_with", return_type: "i1", parameter_types: ["{i8*, i64}", "{i8*, i64}"], effects: [], native_signature: "sfn_str_starts_with"
+        target: "string.starts_with", symbol: "sfn_str_starts_with", return_type: "i1", parameter_types: ["{i8*, i64}", "{i8*, i64}"], effects: [], native_signature: "sfn_str_starts_with", c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "string.ends_with", symbol: "sfn_str_ends_with", return_type: "i1", parameter_types: ["{i8*, i64}", "{i8*, i64}"], effects: [], native_signature: "sfn_str_ends_with"
+        target: "string.ends_with", symbol: "sfn_str_ends_with", return_type: "i1", parameter_types: ["{i8*, i64}", "{i8*, i64}"], effects: [], native_signature: "sfn_str_ends_with", c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "string.contains", symbol: "sfn_str_contains", return_type: "i1", parameter_types: ["{i8*, i64}", "{i8*, i64}"], effects: [], native_signature: "sfn_str_contains"
+        target: "string.contains", symbol: "sfn_str_contains", return_type: "i1", parameter_types: ["{i8*, i64}", "{i8*, i64}"], effects: [], native_signature: "sfn_str_contains", c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "string.repeat", symbol: "sfn_str_repeat", return_type: "i8*", parameter_types: ["{i8*, i64}", "i64"], effects: [], native_signature: "sfn_str_repeat"
+        target: "string.repeat", symbol: "sfn_str_repeat", return_type: "i8*", parameter_types: ["{i8*, i64}", "i64"], effects: [], native_signature: "sfn_str_repeat", c_abi_return_type: null
     });
 
     // Array/collection helpers (generic using i8* for element type).
@@ -524,13 +524,13 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
     // `SfnArray*` which is ABI-compatible at the System V x86_64
     // register level (linker resolves by symbol name only).
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "append_string", symbol: "sailfin_runtime_append_string_v2", return_type: "{ i8**, i64, i64 }*", parameter_types: ["{ i8**, i64, i64 }*", "i8*"], effects: [], native_signature: "sfn_array_push_string"
+        target: "append_string", symbol: "sailfin_runtime_append_string_v2", return_type: "{ i8**, i64, i64 }*", parameter_types: ["{ i8**, i64, i64 }*", "i8*"], effects: [], native_signature: "sfn_array_push_string", c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "concat", symbol: "sailfin_runtime_concat_v2", return_type: "{ i8**, i64, i64 }*", parameter_types: ["{ i8**, i64, i64 }*", "{ i8**, i64, i64 }*"], effects: [], native_signature: "sfn_array_concat"
+        target: "concat", symbol: "sailfin_runtime_concat_v2", return_type: "{ i8**, i64, i64 }*", parameter_types: ["{ i8**, i64, i64 }*", "{ i8**, i64, i64 }*"], effects: [], native_signature: "sfn_array_concat", c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "copy_bytes", symbol: "sailfin_runtime_copy_bytes", return_type: "void", parameter_types: ["i8*", "i8*", "i64"], effects: [], native_signature: null
+        target: "copy_bytes", symbol: "sailfin_runtime_copy_bytes", return_type: "void", parameter_types: ["i8*", "i8*", "i64"], effects: [], native_signature: null, c_abi_return_type: null
     });
 
     // M1.B v2 byte-wise push: takes data, len, cap pointers + elem_size.
@@ -543,19 +543,19 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
     // module ships a matching `sfn_array_sfn_push_slot` under the
     // `_sfn_` infix.
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "array_push_slot", symbol: "sailfin_runtime_array_push_slot_v2", return_type: "i8*", parameter_types: ["i8**", "i64*", "i64*", "i64"], effects: [], native_signature: "sfn_array_push_slot"
+        target: "array_push_slot", symbol: "sailfin_runtime_array_push_slot_v2", return_type: "i8*", parameter_types: ["i8**", "i64*", "i64*", "i64"], effects: [], native_signature: "sfn_array_push_slot", c_abi_return_type: null
     });
 
     // Generic field accessor for opaque imported types
     // Takes object pointer and field name, returns field value as i8*
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "get_field", symbol: "sailfin_runtime_get_field", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: [], native_signature: null
+        target: "get_field", symbol: "sailfin_runtime_get_field", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: [], native_signature: null, c_abi_return_type: null
     });
 
     // String persistence helper for Stage2 memory management
     // Marks string pointers as persistent so they survive across LLVM function boundaries
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "mark_persistent", symbol: "sailfin_runtime_mark_persistent", return_type: "void", parameter_types: ["i8*"], effects: [], native_signature: null
+        target: "mark_persistent", symbol: "sailfin_runtime_mark_persistent", return_type: "void", parameter_types: ["i8*"], effects: [], native_signature: null, c_abi_return_type: null
     });
 
     // M1.7.2a (issue #496): heap allocation primitive registered for
@@ -568,7 +568,7 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
     // because the descriptor schema deliberately has no slot for
     // call-site attributes (epic #494 forbids extending it).
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "alloc_struct", symbol: "sailfin_runtime_alloc_struct", return_type: "i8*", parameter_types: ["i64"], effects: [], native_signature: null
+        target: "alloc_struct", symbol: "sailfin_runtime_alloc_struct", return_type: "i8*", parameter_types: ["i64"], effects: [], native_signature: null, c_abi_return_type: null
     });
 
     // M1.7.2a (issue #496): arena-aware free for boxed return values.
@@ -578,63 +578,63 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
     // metadata; the runtime exposes the matching arena-aware entrypoint
     // here. Already declared via `lowering_phase_render.sfn:167`.
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "runtime.free", symbol: "sailfin_runtime_free", return_type: "void", parameter_types: ["i8*"], effects: [], native_signature: null
+        target: "runtime.free", symbol: "sailfin_runtime_free", return_type: "void", parameter_types: ["i8*"], effects: [], native_signature: null, c_abi_return_type: null
     });
 
     // Exceptions (stage2-native minimal)
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "set_exception", symbol: "sailfin_runtime_set_exception", return_type: "void", parameter_types: ["i8*"], effects: [], native_signature: null
+        target: "set_exception", symbol: "sailfin_runtime_set_exception", return_type: "void", parameter_types: ["i8*"], effects: [], native_signature: null, c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "clear_exception", symbol: "sailfin_runtime_clear_exception", return_type: "void", parameter_types: [], effects: [], native_signature: null
+        target: "clear_exception", symbol: "sailfin_runtime_clear_exception", return_type: "void", parameter_types: [], effects: [], native_signature: null, c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "has_exception", symbol: "sailfin_runtime_has_exception", return_type: "i1", parameter_types: [], effects: [], native_signature: null
+        target: "has_exception", symbol: "sailfin_runtime_has_exception", return_type: "i1", parameter_types: [], effects: [], native_signature: null, c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "try_enter", symbol: "sailfin_runtime_try_enter", return_type: "i32", parameter_types: ["i8**"], effects: [], native_signature: null
+        target: "try_enter", symbol: "sailfin_runtime_try_enter", return_type: "i32", parameter_types: ["i8**"], effects: [], native_signature: null, c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "try_leave", symbol: "sailfin_runtime_try_leave", return_type: "void", parameter_types: ["i8*"], effects: [], native_signature: null
+        target: "try_leave", symbol: "sailfin_runtime_try_leave", return_type: "void", parameter_types: ["i8*"], effects: [], native_signature: null, c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "throw", symbol: "sailfin_runtime_throw", return_type: "void", parameter_types: ["i8*"], effects: [], native_signature: null
+        target: "throw", symbol: "sailfin_runtime_throw", return_type: "void", parameter_types: ["i8*"], effects: [], native_signature: null, c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "take_exception", symbol: "sailfin_runtime_take_exception", return_type: "i8*", parameter_types: [], effects: [], native_signature: null
+        target: "take_exception", symbol: "sailfin_runtime_take_exception", return_type: "i8*", parameter_types: [], effects: [], native_signature: null, c_abi_return_type: null
     });
 
     // ---- Package-manager primitives ----
     // SHA-256 hashing
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "crypto.sha256", symbol: "sailfin_runtime_sha256_hex", return_type: "i8*", parameter_types: ["i8*", "i64"], effects: [], native_signature: null
+        target: "crypto.sha256", symbol: "sailfin_runtime_sha256_hex", return_type: "i8*", parameter_types: ["i8*", "i64"], effects: [], native_signature: null, c_abi_return_type: null
     });
 
     // Base64 encode/decode
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "base64.encode", symbol: "sailfin_runtime_base64_encode", return_type: "i8*", parameter_types: ["i8*", "i64"], effects: [], native_signature: null
+        target: "base64.encode", symbol: "sailfin_runtime_base64_encode", return_type: "i8*", parameter_types: ["i8*", "i64"], effects: [], native_signature: null, c_abi_return_type: null
     });
 
     // HTTP helpers (curl subprocess)
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "http.get_body", symbol: "sailfin_runtime_http_get", return_type: "i8*", parameter_types: ["i8*"], effects: ["net"], native_signature: null
+        target: "http.get_body", symbol: "sailfin_runtime_http_get", return_type: "i8*", parameter_types: ["i8*"], effects: ["net"], native_signature: null, c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "http.post_json", symbol: "sailfin_runtime_http_post_json", return_type: "i8*", parameter_types: ["i8*", "i8*", "i8*"], effects: ["net"], native_signature: null
+        target: "http.post_json", symbol: "sailfin_runtime_http_post_json", return_type: "i8*", parameter_types: ["i8*", "i8*", "i8*"], effects: ["net"], native_signature: null, c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "http.download", symbol: "sailfin_runtime_http_download", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: ["net", "io"], native_signature: null
+        target: "http.download", symbol: "sailfin_runtime_http_download", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: ["net", "io"], native_signature: null, c_abi_return_type: null
     });
 
     // Environment & path helpers
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "env.get", symbol: "sailfin_runtime_getenv", return_type: "i8*", parameter_types: ["i8*"], effects: ["io"], native_signature: null
+        target: "env.get", symbol: "sailfin_runtime_getenv", return_type: "i8*", parameter_types: ["i8*"], effects: ["io"], native_signature: null, c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "env.home", symbol: "sailfin_runtime_home_dir", return_type: "i8*", parameter_types: [], effects: ["io"], native_signature: null
+        target: "env.home", symbol: "sailfin_runtime_home_dir", return_type: "i8*", parameter_types: [], effects: ["io"], native_signature: null, c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "fs.read_bytes", symbol: "sailfin_runtime_read_file_bytes", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: ["io"], native_signature: null
+        target: "fs.read_bytes", symbol: "sailfin_runtime_read_file_bytes", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: ["io"], native_signature: null, c_abi_return_type: null
     });
     // Prelude functions called directly by their original name.
     // These are defined in runtime/prelude.sfn and compiled into
@@ -645,17 +645,34 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
     // "monotonic_millis" → sailfin_runtime_monotonic_millis) so it
     // is not duplicated here.
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "find_char", symbol: "find_char", return_type: "i64", parameter_types: ["i8*", "i8*", "i64"], effects: [], native_signature: null
+        target: "find_char", symbol: "find_char", return_type: "i64", parameter_types: ["i8*", "i8*", "i64"], effects: [], native_signature: null, c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "string_starts_with", symbol: "string_starts_with", return_type: "i1", parameter_types: ["i8*", "i8*"], effects: [], native_signature: null
+        target: "string_starts_with", symbol: "string_starts_with", return_type: "i1", parameter_types: ["i8*", "i8*"], effects: [], native_signature: null, c_abi_return_type: null
     });
 
     // Enum tag reader — reads the i32 tag from a NativeInstruction array element.
     // Used by get_instruction_tag in lowering_native_helpers.sfn for the seedcheck
     // binary which cannot use match or the fixup pass to read enum tags.
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "sailfin_enum_tag_from_instruction_array", symbol: "sailfin_enum_tag_from_instruction_array", return_type: "double", parameter_types: ["i8*", "double"], effects: [], native_signature: null
+        target: "sailfin_enum_tag_from_instruction_array", symbol: "sailfin_enum_tag_from_instruction_array", return_type: "double", parameter_types: ["i8*", "double"], effects: [], native_signature: null, c_abi_return_type: null
+    });
+
+    // Test-only fixture descriptor for the `c_abi_return_type` coercion
+    // path (#638). Exercised exclusively by
+    // `compiler/tests/unit/runtime_helper_abi_coercion_test.sfn`. The
+    // `__sfn_test_*` prefix keeps it unambiguously test-scoped, and
+    // because `render_runtime_helper_declarations` only emits declares
+    // for `used_targets` no production IR ever references the symbol.
+    // Mirrors the monotonic_millis worked example from the #634 RCA:
+    // the C body returns `double`, but Sailfin code receives `i64`,
+    // so `emit_runtime_call` must emit the call against `double` and
+    // then coerce to `i64`. Issue B (the registry flip cleanup) is
+    // free to delete this fixture once a real helper exercises the
+    // same coercion path; until then, this is the only descriptor
+    // with a non-null `c_abi_return_type` in the registry.
+    descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
+        target: "__sfn_test_abi_coercion_double_to_i64", symbol: "__sfn_test_abi_coercion_double_to_i64", return_type: "i64", parameter_types: [], effects: [], native_signature: null, c_abi_return_type: "double"
     });
 
     return descriptors;

--- a/compiler/src/llvm/runtime_helpers.sfn
+++ b/compiler/src/llvm/runtime_helpers.sfn
@@ -658,23 +658,6 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
         target: "sailfin_enum_tag_from_instruction_array", symbol: "sailfin_enum_tag_from_instruction_array", return_type: "double", parameter_types: ["i8*", "double"], effects: [], native_signature: null, c_abi_return_type: null
     });
 
-    // Test-only fixture descriptor for the `c_abi_return_type` coercion
-    // path (#638). Exercised exclusively by
-    // `compiler/tests/unit/runtime_helper_abi_coercion_test.sfn`. The
-    // `__sfn_test_*` prefix keeps it unambiguously test-scoped, and
-    // because `render_runtime_helper_declarations` only emits declares
-    // for `used_targets` no production IR ever references the symbol.
-    // Mirrors the monotonic_millis worked example from the #634 RCA:
-    // the C body returns `double`, but Sailfin code receives `i64`,
-    // so `emit_runtime_call` must emit the call against `double` and
-    // then coerce to `i64`. Issue B (the registry flip cleanup) is
-    // free to delete this fixture once a real helper exercises the
-    // same coercion path; until then, this is the only descriptor
-    // with a non-null `c_abi_return_type` in the registry.
-    descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "__sfn_test_abi_coercion_double_to_i64", symbol: "__sfn_test_abi_coercion_double_to_i64", return_type: "i64", parameter_types: [], effects: [], native_signature: null, c_abi_return_type: "double"
-    });
-
     return descriptors;
 }
 
@@ -694,4 +677,21 @@ fn find_runtime_helper(target: string) -> RuntimeHelperDescriptor? {
         index += 1;
     }
     return null;
+}
+
+// LLVM return type for `declare`-line emission. Mirrors the
+// `_resolve_abi_return_type` precedence on the call-site
+// (`expression_lowering/native/runtime_call.sfn`): if the
+// descriptor declares a distinct C ABI return type, use it,
+// otherwise fall back to the user-visible `return_type`. This
+// keeps `declare <T> @sym(...)` aligned with `call <T> @sym(...)`
+// when Issue B flips individual helpers — without this helper the
+// `declare` line would mismatch the C body's true ABI and produce
+// invalid IR (#638 review comment).
+fn effective_helper_declare_return_type(descriptor: RuntimeHelperDescriptor) -> string {
+    let mut abi: string? = descriptor.c_abi_return_type;
+    if abi != null {
+        if abi.length > 0 { return abi; }
+    }
+    return descriptor.return_type;
 }

--- a/compiler/src/llvm/types.sfn
+++ b/compiler/src/llvm/types.sfn
@@ -76,6 +76,19 @@ struct RuntimeHelperDescriptor {
     // by populating this field; until then it stays `null` and
     // the C symbol is used. See issue #392.
     native_signature: string?;
+    // Optional C-ABI return type. When non-null and different from
+    // `return_type`, the lowering emits the `call` against this type
+    // (i.e. the type the C runtime symbol actually returns) and then
+    // injects a post-call coercion into `return_type` at the call
+    // site. This decouples the user-visible return type from the C
+    // ABI without requiring a synchronized C-runtime flip — see
+    // issue #638 (and #634's monotonic_millis worked example, where
+    // the C body returns `double` while Sailfin should see `i64`).
+    // Stays `null` everywhere today; per-helper flips land in
+    // follow-up issues. Only numeric `double ↔ i64` coercion is
+    // supported in this PR; struct/pointer coercion arrives if/when
+    // a future helper needs it.
+    c_abi_return_type: string?;
 }
 
 // =============================================================================

--- a/compiler/tests/unit/runtime_call_dispatch_test.sfn
+++ b/compiler/tests/unit/runtime_call_dispatch_test.sfn
@@ -100,7 +100,8 @@ test "emit_runtime_call: alloc_struct with noalias return attribute renders attr
         parameter_types: [],
         return_type: "",
         symbol: "",
-        return_attributes: "noalias"
+        return_attributes: "noalias",
+        c_abi_return_type: ""
     };
     let result = emit_runtime_call("alloc_struct", operands, overrides, 0, []);
     assert result.lines.length == 1;

--- a/compiler/tests/unit/runtime_helper_abi_coercion_test.sfn
+++ b/compiler/tests/unit/runtime_helper_abi_coercion_test.sfn
@@ -1,0 +1,75 @@
+// compiler/tests/unit/runtime_helper_abi_coercion_test.sfn
+//
+// Regression coverage for the `c_abi_return_type` decoupling
+// introduced in issue #638. The registry can now declare a helper's
+// LLVM caller-visible return type independently from the C ABI's
+// actual return slot. `emit_runtime_call` is expected to render the
+// `call` line against the C ABI type and splice in a post-call
+// coercion (`fptosi double to i64`, etc.) so the LLVMOperand handed
+// back to the caller carries the declared return type.
+//
+// The fixture descriptor lives in `runtime_helpers.sfn` under
+// `target: "__sfn_test_abi_coercion_double_to_i64"` with
+// `return_type: "i64", c_abi_return_type: "double"`. It is the only
+// descriptor in the entire registry with a non-null
+// `c_abi_return_type` today; every other helper keeps
+// `c_abi_return_type: null`, so `_resolve_abi_return_type` collapses
+// onto `_resolve_call_return_type` and no observable behavior shift
+// rides on this PR (see #638 acceptance criteria).
+//
+// The expected IR shape, matching `coerce_numeric_primitive`'s
+// `double → i64` lowering (`core_operands.sfn:433-454`), is:
+//
+//   %t0 = call double @__sfn_test_abi_coercion_double_to_i64()
+//   %t1 = call double @round(double %t0)
+//   %t2 = fptosi double %t1 to i64
+//
+// The returned operand is `{ llvm_type: "i64", value: "%t2" }`. The
+// `round + fptosi` pair is canonical Sailfin rounding semantics; the
+// `fptosi` line is the lowering specifically called out by #638's
+// acceptance criteria.
+import { emit_runtime_call, empty_runtime_call_overrides } from "../../src/llvm/expression_lowering/native/runtime_call";
+import { LLVMOperand } from "../../src/llvm/types";
+
+test "emit_runtime_call: c_abi_return_type=double, return_type=i64 emits call+coercion" ![io] {
+    let operands: LLVMOperand[] = [];
+    let result = emit_runtime_call("__sfn_test_abi_coercion_double_to_i64", operands, empty_runtime_call_overrides(), 0, []);
+
+    // The call must land against the C ABI return type so the
+    // linker resolves to the `double`-returning symbol in `%xmm0`
+    // rather than the i64 register class. This is the #634 bug
+    // class the mechanism fixes.
+    assert result.lines.length == 3;
+    assert result.lines[0] == "  %t0 = call double @__sfn_test_abi_coercion_double_to_i64()";
+    assert result.lines[1] == "  %t1 = call double @round(double %t0)";
+    assert result.lines[2] == "  %t2 = fptosi double %t1 to i64";
+
+    // Caller-visible operand has the declared return type, not the
+    // C ABI type — call sites don't need to know about the coercion.
+    assert result.operand != null;
+    assert result.operand.llvm_type == "i64";
+    assert result.operand.value == "%t2";
+
+    // Three temps consumed: %t0 (call), %t1 (round), %t2 (fptosi).
+    assert result.temp_index == 3;
+    assert result.diagnostics.length == 0;
+}
+
+test "emit_runtime_call: c_abi_return_type=null collapses onto pre-#638 shape (no coercion)" ![io] {
+    // monotonic_millis is the worked example from #634: today it
+    // still declares both fields as `double` (registry flip lives in
+    // a follow-up). Until then this test pins the no-coercion shape
+    // so any accidental change to `_resolve_abi_return_type`'s
+    // default surfaces as a fixture failure rather than miscompiled
+    // timing code.
+    let operands: LLVMOperand[] = [];
+    let result = emit_runtime_call("monotonic_millis", operands, empty_runtime_call_overrides(), 0, []);
+
+    assert result.lines.length == 1;
+    assert result.lines[0] == "  %t0 = call double @sailfin_runtime_monotonic_millis()";
+    assert result.operand != null;
+    assert result.operand.llvm_type == "double";
+    assert result.operand.value == "%t0";
+    assert result.temp_index == 1;
+    assert result.diagnostics.length == 0;
+}

--- a/compiler/tests/unit/runtime_helper_abi_coercion_test.sfn
+++ b/compiler/tests/unit/runtime_helper_abi_coercion_test.sfn
@@ -7,15 +7,16 @@
 // `call` line against the C ABI type and splice in a post-call
 // coercion (`fptosi double to i64`, etc.) so the LLVMOperand handed
 // back to the caller carries the declared return type.
+// `render_runtime_helper_declarations` follows suit so the `declare`
+// line matches the C body's true ABI.
 //
-// The fixture descriptor lives in `runtime_helpers.sfn` under
-// `target: "__sfn_test_abi_coercion_double_to_i64"` with
-// `return_type: "i64", c_abi_return_type: "double"`. It is the only
-// descriptor in the entire registry with a non-null
-// `c_abi_return_type` today; every other helper keeps
-// `c_abi_return_type: null`, so `_resolve_abi_return_type` collapses
-// onto `_resolve_call_return_type` and no observable behavior shift
-// rides on this PR (see #638 acceptance criteria).
+// To avoid polluting the production registry with test-only entries
+// (#641 review comment), the coercion-path coverage uses
+// `RuntimeCallOverrides.c_abi_return_type` to inject the ABI return
+// type at the call site. The declaration-rendering coverage exercises
+// `effective_helper_declare_return_type` directly against a
+// synthesized descriptor — neither test reaches into the production
+// helper registry.
 //
 // The expected IR shape, matching `coerce_numeric_primitive`'s
 // `double → i64` lowering (`core_operands.sfn:433-454`), is:
@@ -28,12 +29,28 @@
 // `round + fptosi` pair is canonical Sailfin rounding semantics; the
 // `fptosi` line is the lowering specifically called out by #638's
 // acceptance criteria.
-import { emit_runtime_call, empty_runtime_call_overrides } from "../../src/llvm/expression_lowering/native/runtime_call";
-import { LLVMOperand } from "../../src/llvm/types";
+import {
+    RuntimeCallOverrides,
+    emit_runtime_call,
+    empty_runtime_call_overrides
+} from "../../src/llvm/expression_lowering/native/runtime_call";
+import { effective_helper_declare_return_type } from "../../src/llvm/runtime_helpers";
+import { LLVMOperand, RuntimeHelperDescriptor } from "../../src/llvm/types";
 
 test "emit_runtime_call: c_abi_return_type=double, return_type=i64 emits call+coercion" ![io] {
     let operands: LLVMOperand[] = [];
-    let result = emit_runtime_call("__sfn_test_abi_coercion_double_to_i64", operands, empty_runtime_call_overrides(), 0, []);
+    let overrides = RuntimeCallOverrides {
+        parameter_types: [],
+        return_type: "i64",
+        symbol: "__sfn_test_abi_coercion_double_to_i64",
+        return_attributes: "",
+        c_abi_return_type: "double"
+    };
+    // Target name is intentionally unknown to `find_runtime_helper`;
+    // every effective property comes from `overrides`. This is the
+    // override-driven path the fixture-descriptor approach was
+    // replaced with in response to Copilot review of #641.
+    let result = emit_runtime_call("__sfn_test_abi_coercion_double_to_i64", operands, overrides, 0, []);
 
     // The call must land against the C ABI return type so the
     // linker resolves to the `double`-returning symbol in `%xmm0`
@@ -72,4 +89,41 @@ test "emit_runtime_call: c_abi_return_type=null collapses onto pre-#638 shape (n
     assert result.operand.value == "%t0";
     assert result.temp_index == 1;
     assert result.diagnostics.length == 0;
+}
+
+test "effective_helper_declare_return_type: c_abi_return_type wins when set" {
+    // Mirrors the declaration-rendering wiring in
+    // `render_runtime_helper_declarations`. When a descriptor opts
+    // into the ABI coercion mechanism, the `declare` line uses the
+    // C body's true return type rather than the caller-visible one
+    // — without this, the IR would carry `declare i64 @sym(...)`
+    // pointed at a `double`-returning C body and the linker would
+    // mis-resolve the register class.
+    let fixture = RuntimeHelperDescriptor {
+        target: "__fixture",
+        symbol: "__fixture",
+        return_type: "i64",
+        parameter_types: [],
+        effects: [],
+        native_signature: null,
+        c_abi_return_type: "double"
+    };
+    assert effective_helper_declare_return_type(fixture) == "double";
+}
+
+test "effective_helper_declare_return_type: null c_abi_return_type collapses onto return_type" {
+    // Default-path regression: the entire registry has
+    // `c_abi_return_type: null` today (#638 is strictly additive),
+    // so the helper must hand back `descriptor.return_type` to keep
+    // every declared line byte-identical to the pre-#638 shape.
+    let fixture = RuntimeHelperDescriptor {
+        target: "__fixture",
+        symbol: "__fixture",
+        return_type: "i64",
+        parameter_types: [],
+        effects: [],
+        native_signature: null,
+        c_abi_return_type: null
+    };
+    assert effective_helper_declare_return_type(fixture) == "i64";
 }


### PR DESCRIPTION
## Summary

- Adds optional `c_abi_return_type: string?` to `RuntimeHelperDescriptor` and threads a post-call coercion through `emit_runtime_call`, so the registry can declare a helper's caller-visible return type independently from the C function's actual ABI.
- Strictly additive: every existing helper sets `c_abi_return_type: null`, so `_resolve_abi_return_type` collapses onto `_resolve_call_return_type` and the rendered IR is byte-identical to the pre-change shape. No observable behavior change in this PR.
- Unblocks the proper fix for the `monotonic_millis` mismatch from #634 (C returns `double` in `%xmm0`, Sailfin reads `i64` in `%rax` → NaN timing values → `number_to_string`'s digit loop hangs). The actual registry flips that resolve #634 land in a follow-up issue (issue B) once this mechanism is in place.

Closes #638

## Acceptance Criteria

- [x] `RuntimeHelperDescriptor` carries `c_abi_return_type: string?`.
- [x] Every literal in `runtime_helpers.sfn` supplies the new field (all `null` in this PR; the one test-only fixture descriptor sets `c_abi_return_type: "double"`).
- [x] `emit_runtime_call` emits a post-call coercion when `c_abi_return_type` is set and differs from `return_type`.
- [x] Unit test under `compiler/tests/unit/runtime_helper_abi_coercion_test.sfn` exercises the coercion path (asserts `call double @... → round → fptosi double to i64`) and pins the no-coercion default on `monotonic_millis`.
- [x] `make compile` self-hosts (no behavior change expected since every existing literal sets `null`).
- [x] `make test` passes (unit + integration + e2e + capsules).
- [x] `make check` clean — stage2 vs stage3 LLVM IR is a fixed point (`[check] stage2 == stage3: compiler is a fixed point ✓`).
- [x] `sfn fmt --check` clean on every touched file.

## Verification

```bash
ulimit -v 8388608
make compile       # self-hosts cleanly
make test          # unit + integration + 57/57 e2e + 10/10 capsules, including the two new regression tests
make check         # stage2 tests pass; stage3 IR is bit-identical to stage2 (fixed point)

# Sanity: every literal now padded.
grep -c 'c_abi_return_type: null' compiler/src/llvm/runtime_helpers.sfn
# 115
grep -c 'c_abi_return_type: "double"' compiler/src/llvm/runtime_helpers.sfn
# 1 (the test fixture)
```

The new test output:

```
RUN  emit_runtime_callc_abi_return_typedoublereturn_typei64emitscallcoercion
RUN  emit_runtime_callc_abi_return_typenullcollapsesontopre638shapenocoercion
PASS  (all 2 tests passed)
```

The existing `runtime_call_dispatch_test.sfn` (6 cases) keeps passing — confirms the null-default path is unchanged.

## Files Changed

- `compiler/src/llvm/types.sfn` — adds `c_abi_return_type: string?` field with a doc-block describing the mechanism and the `double ↔ i64` scope limit.
- `compiler/src/llvm/runtime_helpers.sfn` — pads all 115 existing literals with `c_abi_return_type: null`; adds one test-only fixture descriptor (`__sfn_test_abi_coercion_double_to_i64`) used by the new regression test.
- `compiler/src/llvm/expression_lowering/native/runtime_call.sfn` — new `_resolve_abi_return_type` resolver; `emit_runtime_call` renders the `call` against the ABI type and splices a post-call coercion via `coerce_operand_to_type` (which already handles `double → i64` and `i64 → double`).
- `compiler/src/llvm/expression_lowering/native/core_call_lowering.sfn`, `compiler/src/llvm/expression_lowering/native/core_call_resolution.sfn` — pads the 8 inline `RuntimeHelperDescriptor` literals so the new field round-trips through the type checker. Not on the issue's "Files Affected" list, but unavoidable: adding a field to the struct requires every literal site to supply it. Flagged for review.
- `compiler/tests/unit/runtime_helper_abi_coercion_test.sfn` — new regression coverage.

## Notes for review

- The fixture descriptor (`__sfn_test_abi_coercion_double_to_i64`) lives in `runtime_helpers.sfn` because `emit_runtime_call` resolves descriptors via `find_runtime_helper`. The `__sfn_test_*` prefix and the surrounding comment-block keep it unambiguously test-scoped, and because `render_runtime_helper_declarations` only emits declares for actually-called targets, no production IR ever references it. Issue B is free to delete the fixture once a real helper exercises the coercion path.
- `_resolve_abi_return_type` lives next to `_resolve_call_return_type` and falls back to it when the descriptor's `c_abi_return_type` is null/empty — that's why every existing call site is byte-identical even though the resolver runs unconditionally.
- The post-call coercion reuses `coerce_operand_to_type` with `allow_widen=true`. That avoids triggering the ABI-mismatch warning at the synthesized seam (#550): the coercion is an explicit, descriptor-declared boundary, not an accidental implicit cast.
