### PR TITLE
fix(lowering): flip 6 semantic-integer runtime helpers to i64 (#639)

### DIFF
--- a/compiler/src/llvm/expression_lowering/native/core_call_emission.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_call_emission.sfn
@@ -572,18 +572,46 @@ fn coerce_and_emit_call(trimmed_target: string, operands: LLVMOperand[], expecte
     if _trace_ccl {
         print.err("call_lowering: checkpoint-I temp_name=" + temp_name);
     }
-    let call_line = "  " + temp_name + " = call " + llvm_return + " @"
+    // Issue #639: honor the descriptor's `c_abi_return_type` when it
+    // differs from the caller-visible `return_type`. This mirrors the
+    // mechanism `emit_runtime_call` already implements (#638), but is
+    // also needed here because user-written calls to helpers like
+    // `monotonic_millis()` flow through this legacy path rather than
+    // `emit_runtime_call`. Without this, a registry entry with
+    // `return_type: "i64", c_abi_return_type: "double"` would emit
+    // `call i64 @sym(...)` against a `double`-returning C function —
+    // the exact register-class mismatch (%rax vs %xmm0) that
+    // crashed PR #637.
+    let mut abi_return_type: string = llvm_return;
+    if helper_descriptor != null {
+        let mut abi: string? = helper_descriptor.c_abi_return_type;
+        if abi != null {
+            if abi.length > 0 { abi_return_type = abi; }
+        }
+    }
+    let call_line = "  " + temp_name + " = call " + abi_return_type + " @"
         + call_symbol
         + "("
         + argument_text
         + ")";
     result_lines.push(call_line);
-    let operand = LLVMOperand { llvm_type: llvm_return, value: temp_name };
+    let mut result_operand: LLVMOperand = LLVMOperand {
+        llvm_type: abi_return_type,
+        value: temp_name
+    };
+    let mut next_temp: int = result_temp + 1;
+    if abi_return_type != llvm_return {
+        let coercion = coerce_operand_to_type(result_operand, llvm_return, next_temp, result_lines, true, null);
+        result_diagnostics = extend_string_array(result_diagnostics, coercion.diagnostics);
+        result_lines = coercion.lines;
+        next_temp = coercion.temp_index;
+        if coercion.operand != null { result_operand = coercion.operand; }
+    }
     if _trace_ccl { print.err("call_lowering: checkpoint-K returning"); }
     return ExpressionResult {
         lines: result_lines,
-        temp_index: result_temp + 1,
-        operand: operand,
+        temp_index: next_temp,
+        operand: result_operand,
         diagnostics: result_diagnostics,
         string_constants: collected_string_constants
     };

--- a/compiler/src/llvm/runtime_helpers.sfn
+++ b/compiler/src/llvm/runtime_helpers.sfn
@@ -153,7 +153,7 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
     // `sailfin_intrinsic_runtime_arena_mark()` (or a friendlier
     // alias added at that time).
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "sailfin_intrinsic_runtime_arena_mark", symbol: "sailfin_intrinsic_runtime_arena_mark", return_type: "double", parameter_types: [], effects: [], native_signature: null, c_abi_return_type: null
+        target: "sailfin_intrinsic_runtime_arena_mark", symbol: "sailfin_intrinsic_runtime_arena_mark", return_type: "i64", parameter_types: [], effects: [], native_signature: null, c_abi_return_type: "double"
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
         target: "sailfin_intrinsic_runtime_arena_rewind", symbol: "sailfin_intrinsic_runtime_arena_rewind", return_type: "void", parameter_types: ["double"], effects: [], native_signature: null, c_abi_return_type: null
@@ -202,10 +202,10 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
     // Monotonic clock for profiling/timing.
     // Support both the prelude binding name and direct calls.
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "runtime_monotonic_millis_fn", symbol: "sailfin_runtime_monotonic_millis", return_type: "double", parameter_types: [], effects: ["clock"], native_signature: null, c_abi_return_type: null
+        target: "runtime_monotonic_millis_fn", symbol: "sailfin_runtime_monotonic_millis", return_type: "i64", parameter_types: [], effects: ["clock"], native_signature: null, c_abi_return_type: "double"
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "monotonic_millis", symbol: "sailfin_runtime_monotonic_millis", return_type: "double", parameter_types: [], effects: ["clock"], native_signature: null, c_abi_return_type: null
+        target: "monotonic_millis", symbol: "sailfin_runtime_monotonic_millis", return_type: "i64", parameter_types: [], effects: ["clock"], native_signature: null, c_abi_return_type: "double"
     });
     // Untyped `channel` / `spawn` / `parallel` descriptors removed under
     // issue #617 — their C bridges were silent no-ops and the
@@ -272,7 +272,7 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
         target: "runtime_serve_fn", symbol: "sailfin_runtime_serve", return_type: "void", parameter_types: ["i8*", "i8*"], effects: ["io", "net"], native_signature: null, c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "runtime_char_code_fn", symbol: "sailfin_runtime_char_code", return_type: "double", parameter_types: ["i8*"], effects: [], native_signature: null, c_abi_return_type: null
+        target: "runtime_char_code_fn", symbol: "sailfin_runtime_char_code", return_type: "i64", parameter_types: ["i8*"], effects: [], native_signature: null, c_abi_return_type: "double"
     });
 
     // Process helpers
@@ -282,7 +282,7 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
     // exported for seed-compiled IR; the registry only points the
     // new compiler at v2.
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "process.run", symbol: "sailfin_runtime_process_run_v2", return_type: "double", parameter_types: ["{ i8**, i64, i64 }*"], effects: ["io"], native_signature: null, c_abi_return_type: null
+        target: "process.run", symbol: "sailfin_runtime_process_run_v2", return_type: "i64", parameter_types: ["{ i8**, i64, i64 }*"], effects: ["io"], native_signature: null, c_abi_return_type: "double"
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
         target: "process.exit", symbol: "sailfin_runtime_process_exit", return_type: "void", parameter_types: ["double"], effects: ["io"], native_signature: null, c_abi_return_type: null
@@ -456,7 +456,7 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
         target: "number_to_string", symbol: "number_to_string", return_type: "i8*", parameter_types: ["double"], effects: [], native_signature: null, c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "runtime_grapheme_count_fn", symbol: "sailfin_runtime_grapheme_count", return_type: "double", parameter_types: ["i8*"], effects: [], native_signature: null, c_abi_return_type: null
+        target: "runtime_grapheme_count_fn", symbol: "sailfin_runtime_grapheme_count", return_type: "i64", parameter_types: ["i8*"], effects: [], native_signature: null, c_abi_return_type: "double"
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
         target: "runtime_grapheme_at_fn", symbol: "sailfin_runtime_grapheme_at", return_type: "i8*", parameter_types: ["i8*", "double"], effects: [], native_signature: null, c_abi_return_type: null
@@ -655,7 +655,7 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
     // Used by get_instruction_tag in lowering_native_helpers.sfn for the seedcheck
     // binary which cannot use match or the fixup pass to read enum tags.
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "sailfin_enum_tag_from_instruction_array", symbol: "sailfin_enum_tag_from_instruction_array", return_type: "double", parameter_types: ["i8*", "double"], effects: [], native_signature: null, c_abi_return_type: null
+        target: "sailfin_enum_tag_from_instruction_array", symbol: "sailfin_enum_tag_from_instruction_array", return_type: "i64", parameter_types: ["i8*", "double"], effects: [], native_signature: null, c_abi_return_type: "double"
     });
 
     return descriptors;

--- a/compiler/tests/e2e/test_runtime_int_helpers_legacy_path.sh
+++ b/compiler/tests/e2e/test_runtime_int_helpers_legacy_path.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+# End-to-end regression test for the `c_abi_return_type` post-call
+# coercion in the legacy `coerce_and_emit_call` path (extended under
+# issue #639). User-written calls to helpers like `monotonic_millis()`
+# flow through `core_call_lowering` → `core_call_emission.coerce_and_emit_call`,
+# NOT through `emit_runtime_call`. That makes this path the *actual*
+# fix surface for #634: the unit-level coverage in
+# `compiler/tests/unit/runtime_int_helpers_test.sfn` and
+# `compiler/tests/unit/runtime_helper_abi_coercion_test.sfn` exercises
+# `emit_runtime_call` only, which would let a future refactor silently
+# regress `coerce_and_emit_call`'s coercion logic — the regression
+# would re-introduce the `%xmm0`/`%rax` register-class mismatch that
+# crashed PR #637 (see #641 RCA).
+#
+# This shell test compiles a minimal program with `sfn emit llvm` and
+# greps the emitted IR for the three landmarks of the post-call
+# coercion sequence:
+#
+#   1. `call double @sailfin_runtime_monotonic_millis()` — the call
+#      lands against the C ABI return type (`%xmm0`), not against the
+#      caller-visible `i64`.
+#   2. `call double @round(double ...)` — the canonical Sailfin
+#      rounding step (`coerce_numeric_primitive`'s `double → i64`
+#      lowering).
+#   3. `fptosi double ... to i64` — the final conversion that hands
+#      the caller an `i64`-typed operand.
+#
+# Also asserts the let-binding allocas are `i64`, and that NO ABI
+# primitive mismatch warning fires (the headline #634 ask).
+#
+# Usage:
+#   compiler/tests/e2e/test_runtime_int_helpers_legacy_path.sh <compiler-binary>
+
+set -euo pipefail
+
+BINARY="${1:?usage: test_runtime_int_helpers_legacy_path.sh <compiler-binary>}"
+BINARY="$(realpath "$BINARY")"
+
+PASS=0
+FAIL=0
+
+SCRATCH="$(mktemp -d -t sfn-int-helpers-XXXXXX)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+run_test() {
+    local name="$1"
+    shift
+    if "$@"; then
+        echo "[test] PASS: $name"
+        PASS=$((PASS + 1))
+    else
+        echo "[test] FAIL: $name"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# The minimal #634 reproducer from the issue body. `monotonic_millis()`
+# is the worked example; flowing it through `--emit llvm` exercises the
+# legacy call-emission path because the call site is user-written
+# (not an internally-synthesized lowering call that uses
+# `emit_runtime_call` directly).
+write_fixture() {
+    local src="$1"
+    cat > "$src" <<'EOF'
+import { monotonic_millis } from "runtime/prelude";
+
+fn _ms_since(start_ms: int) -> int {
+    let end_ms = monotonic_millis();
+    let delta = end_ms - start_ms;
+    if delta < 0 { return 0; }
+    return delta;
+}
+
+fn main() ![io, clock] {
+    let t0 = monotonic_millis();
+    let elapsed = _ms_since(t0);
+    print.info("ok");
+}
+EOF
+}
+
+# ---- 1. The emitted IR exhibits the three-landmark coercion sequence ----
+test_legacy_path_emits_call_double_then_round_then_fptosi() {
+    local src="$SCRATCH/let_int_infer.sfn"
+    local ll="$SCRATCH/let_int_infer.ll"
+    write_fixture "$src"
+
+    if ! "$BINARY" --emit llvm "$src" > "$ll" 2> "$SCRATCH/stderr.log"; then
+        echo "[test]   sfn --emit llvm failed"
+        cat "$SCRATCH/stderr.log" | head -10
+        return 1
+    fi
+
+    local missing=0
+    if ! grep -qE 'call double @sailfin_runtime_monotonic_millis\(\)' "$ll"; then
+        echo "[test]   missing 'call double @sailfin_runtime_monotonic_millis()' in emitted IR"
+        echo "         (registry flip not honored by coerce_and_emit_call — #637 register-class mismatch will return)"
+        missing=$((missing + 1))
+    fi
+    if ! grep -qE 'call double @round\(double' "$ll"; then
+        echo "[test]   missing 'call double @round(double ...)' coercion step in emitted IR"
+        missing=$((missing + 1))
+    fi
+    if ! grep -qE 'fptosi double .* to i64' "$ll"; then
+        echo "[test]   missing 'fptosi double ... to i64' final conversion in emitted IR"
+        missing=$((missing + 1))
+    fi
+    return "$missing"
+}
+
+# ---- 2. The let-binding alloca is i64 (callers see the declared type) ----
+test_let_binding_alloca_is_i64() {
+    local src="$SCRATCH/let_int_infer.sfn"
+    local ll="$SCRATCH/let_int_infer.ll"
+    write_fixture "$src"
+
+    if ! "$BINARY" --emit llvm "$src" > "$ll" 2> /dev/null; then
+        echo "[test]   sfn --emit llvm failed"
+        return 1
+    fi
+
+    # Both `let t0 = monotonic_millis()` in `main` and `let end_ms = monotonic_millis()`
+    # in `_ms_since` allocate i64 locals. Two i64 functions × two i64 allocas
+    # each gives ≥ 4 lines (the issue's headline assertion is `alloca i64`).
+    local hits
+    hits="$(grep -cE '^\s*%[a-zA-Z_][a-zA-Z0-9_]* = alloca i64' "$ll" || true)"
+    if [ "${hits:-0}" -lt 4 ]; then
+        echo "[test]   expected ≥ 4 'alloca i64' lines (let bindings for monotonic_millis()), found $hits"
+        return 1
+    fi
+    return 0
+}
+
+# ---- 3. No ABI primitive mismatch warnings (#634 headline) ----
+test_no_abi_primitive_mismatch_warning() {
+    local src="$SCRATCH/let_int_infer.sfn"
+    local ll="$SCRATCH/let_int_infer.ll"
+    write_fixture "$src"
+
+    # Capture both stdout and stderr — the ABI mismatch warning is
+    # printed to stderr by the lowering, but capturing both makes the
+    # assertion robust against future routing changes.
+    local combined
+    combined="$("$BINARY" --emit llvm "$src" 2>&1 > "$ll" || true)"
+    local hits
+    hits="$(echo "$combined" | grep -cE 'ABI primitive mismatch' || true)"
+    if [ "${hits:-0}" -gt 0 ]; then
+        echo "[test]   expected 0 'ABI primitive mismatch' warnings, found $hits"
+        echo "         (#634 headline ask — monotonic_millis() → int should not warn)"
+        return 1
+    fi
+    return 0
+}
+
+# ---- 4. The declare line matches the C ABI (not the caller-visible type) ----
+test_declare_line_matches_c_abi() {
+    local src="$SCRATCH/let_int_infer.sfn"
+    local ll="$SCRATCH/let_int_infer.ll"
+    write_fixture "$src"
+
+    if ! "$BINARY" --emit llvm "$src" > "$ll" 2> /dev/null; then
+        echo "[test]   sfn --emit llvm failed"
+        return 1
+    fi
+
+    # `declare double` must match the C function body (linker resolves
+    # to a `double`-returning symbol). A `declare i64` here would
+    # produce the `%rax`-vs-`%xmm0` mismatch that crashed #637 even
+    # though the call site itself uses `call double`.
+    if ! grep -qE '^declare double @sailfin_runtime_monotonic_millis\(\)' "$ll"; then
+        echo "[test]   missing 'declare double @sailfin_runtime_monotonic_millis()' — declare must match C ABI"
+        return 1
+    fi
+    if grep -qE '^declare i64 @sailfin_runtime_monotonic_millis\(\)' "$ll"; then
+        echo "[test]   regression: 'declare i64 @sailfin_runtime_monotonic_millis()' emitted — would mis-link"
+        return 1
+    fi
+    return 0
+}
+
+run_test "legacy coerce_and_emit_call emits 'call double + round + fptosi to i64' for monotonic_millis()" \
+    test_legacy_path_emits_call_double_then_round_then_fptosi
+run_test "let bindings for monotonic_millis() lower to 'alloca i64'" \
+    test_let_binding_alloca_is_i64
+run_test "monotonic_millis() lowering emits zero 'ABI primitive mismatch' warnings" \
+    test_no_abi_primitive_mismatch_warning
+run_test "declare line for sailfin_runtime_monotonic_millis matches C ABI ('declare double')" \
+    test_declare_line_matches_c_abi
+
+echo "[summary] $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi

--- a/compiler/tests/unit/runtime_helper_abi_coercion_test.sfn
+++ b/compiler/tests/unit/runtime_helper_abi_coercion_test.sfn
@@ -73,17 +73,20 @@ test "emit_runtime_call: c_abi_return_type=double, return_type=i64 emits call+co
 }
 
 test "emit_runtime_call: c_abi_return_type=null collapses onto pre-#638 shape (no coercion)" ![io] {
-    // monotonic_millis is the worked example from #634: today it
-    // still declares both fields as `double` (registry flip lives in
-    // a follow-up). Until then this test pins the no-coercion shape
-    // so any accidental change to `_resolve_abi_return_type`'s
-    // default surfaces as a fixture failure rather than miscompiled
-    // timing code.
-    let operands: LLVMOperand[] = [];
-    let result = emit_runtime_call("monotonic_millis", operands, empty_runtime_call_overrides(), 0, []);
+    // `string.to_number` is the canonical genuinely-fractional helper
+    // (#639 explicitly carves it out of the flip set), so its
+    // descriptor will continue to declare matching `return_type` and
+    // `c_abi_return_type: null` for the foreseeable future. Pinning
+    // its render here guarantees any accidental change to
+    // `_resolve_abi_return_type`'s default surfaces as a fixture
+    // failure rather than silently inserting a coercion at every
+    // `string.to_number` call site.
+    let operand = LLVMOperand { llvm_type: "i8*", value: "%s" };
+    let operands: LLVMOperand[] = [operand];
+    let result = emit_runtime_call("string.to_number", operands, empty_runtime_call_overrides(), 0, []);
 
     assert result.lines.length == 1;
-    assert result.lines[0] == "  %t0 = call double @sailfin_runtime_monotonic_millis()";
+    assert result.lines[0] == "  %t0 = call double @sailfin_runtime_string_to_number(i8* %s)";
     assert result.operand != null;
     assert result.operand.llvm_type == "double";
     assert result.operand.value == "%t0";

--- a/compiler/tests/unit/runtime_int_helpers_test.sfn
+++ b/compiler/tests/unit/runtime_int_helpers_test.sfn
@@ -1,0 +1,164 @@
+// compiler/tests/unit/runtime_int_helpers_test.sfn
+//
+// Regression coverage for the six semantic-integer runtime helpers
+// flipped under issue #639 (closing #634). Each entry below previously
+// declared `return_type: "double", c_abi_return_type: null`, which
+// forced every `let x = helper(...); let y: int = x;` site to trip
+// `coerce_numeric_primitive`'s ABI-mismatch warning before silently
+// rounding+fptosi'ing. After the flip:
+//
+//   - `return_type` becomes `"i64"` — what callers see, no warning.
+//   - `c_abi_return_type` becomes `"double"` — the C function in
+//     `runtime/native/src/sailfin_runtime.c` is unchanged, so the
+//     emitted `call` still lands against `%xmm0` (#637's RCA in PR
+//     #641's body documents why flipping the C ABI in lockstep
+//     mis-compiles under the seed).
+//   - `emit_runtime_call` splices a `call @round + fptosi` pair so
+//     the LLVMOperand the call site receives carries `i64`.
+//
+// Each test below pins exactly that three-line render shape for one
+// flipped helper, with the temp-index advance counted (call + round
+// + fptosi = 3 temps consumed). Together they form the bit-identity
+// fence that catches any drift in either the registry or the
+// coercion-injection path.
+import { emit_runtime_call, empty_runtime_call_overrides } from "../../src/llvm/expression_lowering/native/runtime_call";
+import { LLVMOperand } from "../../src/llvm/types";
+
+fn _i8ptr_operand(value: string) -> LLVMOperand {
+    return LLVMOperand { llvm_type: "i8*", value: value };
+}
+
+fn _argv_operand(value: string) -> LLVMOperand {
+    // SfnArray-shaped argv buffer per the M1.B v2 ABI
+    // (`runtime_helpers.sfn:285` parameter type).
+    return LLVMOperand { llvm_type: "{ i8**, i64, i64 }*", value: value };
+}
+
+fn _double_operand(value: string) -> LLVMOperand {
+    return LLVMOperand { llvm_type: "double", value: value };
+}
+
+test "runtime int helper: monotonic_millis emits call+round+fptosi to i64" ![io] {
+    let operands: LLVMOperand[] = [];
+    let result = emit_runtime_call("monotonic_millis", operands, empty_runtime_call_overrides(), 0, []);
+
+    assert result.lines.length == 3;
+    assert result.lines[0] == "  %t0 = call double @sailfin_runtime_monotonic_millis()";
+    assert result.lines[1] == "  %t1 = call double @round(double %t0)";
+    assert result.lines[2] == "  %t2 = fptosi double %t1 to i64";
+
+    assert result.operand != null;
+    assert result.operand.llvm_type == "i64";
+    assert result.operand.value == "%t2";
+    assert result.temp_index == 3;
+    assert result.diagnostics.length == 0;
+}
+
+test "runtime int helper: runtime_monotonic_millis_fn alias matches monotonic_millis render" ![io] {
+    // The prelude binds `runtime.monotonic_millis` to the
+    // `runtime_monotonic_millis_fn` alias, so this entry must flip
+    // in lockstep with `monotonic_millis` — otherwise prelude
+    // callers regress while bare-target callers heal.
+    let operands: LLVMOperand[] = [];
+    let result = emit_runtime_call("runtime_monotonic_millis_fn", operands, empty_runtime_call_overrides(), 0, []);
+
+    assert result.lines.length == 3;
+    assert result.lines[0] == "  %t0 = call double @sailfin_runtime_monotonic_millis()";
+    assert result.lines[1] == "  %t1 = call double @round(double %t0)";
+    assert result.lines[2] == "  %t2 = fptosi double %t1 to i64";
+
+    assert result.operand != null;
+    assert result.operand.llvm_type == "i64";
+    assert result.operand.value == "%t2";
+    assert result.temp_index == 3;
+    assert result.diagnostics.length == 0;
+}
+
+test "runtime int helper: runtime_char_code_fn emits call+round+fptosi to i64" ![io] {
+    let s = _i8ptr_operand("%s");
+    let operands: LLVMOperand[] = [s];
+    let result = emit_runtime_call("runtime_char_code_fn", operands, empty_runtime_call_overrides(), 0, []);
+
+    assert result.lines.length == 3;
+    assert result.lines[0] == "  %t0 = call double @sailfin_runtime_char_code(i8* %s)";
+    assert result.lines[1] == "  %t1 = call double @round(double %t0)";
+    assert result.lines[2] == "  %t2 = fptosi double %t1 to i64";
+
+    assert result.operand != null;
+    assert result.operand.llvm_type == "i64";
+    assert result.operand.value == "%t2";
+    assert result.temp_index == 3;
+    assert result.diagnostics.length == 0;
+}
+
+test "runtime int helper: process.run emits call+round+fptosi to i64" ![io] {
+    let argv = _argv_operand("%argv");
+    let operands: LLVMOperand[] = [argv];
+    let result = emit_runtime_call("process.run", operands, empty_runtime_call_overrides(), 0, []);
+
+    assert result.lines.length == 3;
+    assert result.lines[0] == "  %t0 = call double @sailfin_runtime_process_run_v2({ i8**, i64, i64 }* %argv)";
+    assert result.lines[1] == "  %t1 = call double @round(double %t0)";
+    assert result.lines[2] == "  %t2 = fptosi double %t1 to i64";
+
+    assert result.operand != null;
+    assert result.operand.llvm_type == "i64";
+    assert result.operand.value == "%t2";
+    assert result.temp_index == 3;
+    assert result.diagnostics.length == 0;
+}
+
+test "runtime int helper: runtime_grapheme_count_fn emits call+round+fptosi to i64" ![io] {
+    let s = _i8ptr_operand("%s");
+    let operands: LLVMOperand[] = [s];
+    let result = emit_runtime_call("runtime_grapheme_count_fn", operands, empty_runtime_call_overrides(), 0, []);
+
+    assert result.lines.length == 3;
+    assert result.lines[0] == "  %t0 = call double @sailfin_runtime_grapheme_count(i8* %s)";
+    assert result.lines[1] == "  %t1 = call double @round(double %t0)";
+    assert result.lines[2] == "  %t2 = fptosi double %t1 to i64";
+
+    assert result.operand != null;
+    assert result.operand.llvm_type == "i64";
+    assert result.operand.value == "%t2";
+    assert result.temp_index == 3;
+    assert result.diagnostics.length == 0;
+}
+
+test "runtime int helper: sailfin_enum_tag_from_instruction_array emits call+round+fptosi to i64" ![io] {
+    // Two-argument helper; param_types `["i8*", "double"]` are
+    // intentionally unchanged (the second argument is a numeric
+    // index that already flows through the legacy double path —
+    // out of scope per #639).
+    let buf = _i8ptr_operand("%buf");
+    let idx = _double_operand("%idx");
+    let operands: LLVMOperand[] = [buf, idx];
+    let result = emit_runtime_call("sailfin_enum_tag_from_instruction_array", operands, empty_runtime_call_overrides(), 0, []);
+
+    assert result.lines.length == 3;
+    assert result.lines[0] == "  %t0 = call double @sailfin_enum_tag_from_instruction_array(i8* %buf, double %idx)";
+    assert result.lines[1] == "  %t1 = call double @round(double %t0)";
+    assert result.lines[2] == "  %t2 = fptosi double %t1 to i64";
+
+    assert result.operand != null;
+    assert result.operand.llvm_type == "i64";
+    assert result.operand.value == "%t2";
+    assert result.temp_index == 3;
+    assert result.diagnostics.length == 0;
+}
+
+test "runtime int helper: sailfin_intrinsic_runtime_arena_mark emits call+round+fptosi to i64" ![io] {
+    let operands: LLVMOperand[] = [];
+    let result = emit_runtime_call("sailfin_intrinsic_runtime_arena_mark", operands, empty_runtime_call_overrides(), 0, []);
+
+    assert result.lines.length == 3;
+    assert result.lines[0] == "  %t0 = call double @sailfin_intrinsic_runtime_arena_mark()";
+    assert result.lines[1] == "  %t1 = call double @round(double %t0)";
+    assert result.lines[2] == "  %t2 = fptosi double %t1 to i64";
+
+    assert result.operand != null;
+    assert result.operand.llvm_type == "i64";
+    assert result.operand.value == "%t2";
+    assert result.temp_index == 3;
+    assert result.diagnostics.length == 0;
+}


### PR DESCRIPTION
## Summary

- Flips seven registry entries (six logical helpers; `monotonic_millis` has both a bare-name and `runtime_*_fn` alias) from `return_type: "double", c_abi_return_type: null` to `return_type: "i64", c_abi_return_type: "double"`. Callers now see the semantically-correct `int` while the C ABI stays untouched in `runtime/native/src/sailfin_runtime.c` — the call lands against `%xmm0` exactly as #637's RCA prescribes, then a `round + fptosi` pair carries the value into `%rax`-shaped `i64`.
- Extends the `c_abi_return_type` post-call coercion mechanism from `emit_runtime_call` (#638) into the legacy `coerce_and_emit_call` path. **Discovered scope addition** (not in #639's `Files Affected`) but unavoidable: user-written `monotonic_millis()` calls in the compiler source flow through the legacy path, not through `emit_runtime_call`. Without this, the registry flip would emit `call i64 @sailfin_runtime_monotonic_millis()` against a `double`-returning C symbol — the exact `%rax`-vs-`%xmm0` register class mismatch that crashed PR #637. The added logic mirrors `emit_runtime_call` exactly.
- Adds `runtime_int_helpers_test.sfn` pinning the three-line render shape per flipped helper. Migrates the existing `runtime_helper_abi_coercion_test.sfn` no-coercion fixture from `monotonic_millis` (now coerced) to `string.to_number` (still genuinely `double`).

Closes #634
Closes #639

## Acceptance Criteria

- [x] All six helpers in the audit table declare `return_type: "i64", c_abi_return_type: "double"`.
- [x] `compiler/tests/unit/runtime_int_helpers_test.sfn` exists and passes — every flipped helper has a pinning test (7 tests, including both monotonic_millis aliases).
- [x] The minimal #634 reproducer compiles with **zero** `ABI primitive mismatch` warnings (verified: count = 0).
- [x] In emitted IR, the call site shows `call double @sailfin_runtime_monotonic_millis()` followed by `fptosi double %tN to i64`, and the let binding is `alloca i64` (verified — see Verification below).
- [x] `make compile` self-hosts.
- [x] `make test` — see "Pre-existing failures" note below.
- [x] #634 closes via this PR's `Closes #634` line.
- [x] `sfn fmt --check` clean on every touched file.

## Verification

```bash
# Reproducer from #634
cat > /tmp/let_int_infer.sfn <<'EOF'
import { monotonic_millis } from "runtime/prelude";
fn _ms_since(start_ms: int) -> int {
    let end_ms = monotonic_millis();
    let delta = end_ms - start_ms;
    if delta < 0 { return 0; }
    return delta;
}
fn main() [io, clock] {
    let t0 = monotonic_millis();
    let elapsed = _ms_since(t0);
    print.info("ok");
}
EOF

build/native/sailfin --emit llvm /tmp/let_int_infer.sfn 2>&1 | grep -c "ABI primitive mismatch"
# → 0

build/native/sailfin --emit llvm /tmp/let_int_infer.sfn 2>/dev/null | \
    grep -E "alloca i64|fptosi double.*to i64|call double @sailfin_runtime_monotonic"
# →   %l0 = alloca i64
# →   %l1 = alloca i64
# →   %t0 = call double @sailfin_runtime_monotonic_millis()
# →   %t2 = fptosi double %t1 to i64
# →   (same shape for the second function)
```

Test results in the remote-execution sandbox:

- `runtime_int_helpers_test.sfn` — **PASS** (all 7 tests)
- `runtime_helper_abi_coercion_test.sfn` — **PASS** (all 4 tests, including the no-coercion default migrated to `string.to_number`)
- `runtime_call_dispatch_test.sfn` — **PASS** (all 6 tests, regression for the unaffected `emit_runtime_call` paths)
- `make compile` — self-hosts; 3 transitional `ABI primitive mismatch` warnings emitted by the seed compiling the new source (the seed's baked-in registry still says these helpers return `double`; the next seed bump retires them).
- `make test-e2e` — 57/57 pass
- `make test-capsules` — 10/10 pass

## Pre-existing test failures (not caused by this PR)

`make test-unit` reports 13 failures and `make test-integration` reports 2 failures in this remote-execution environment. **All 15 failures are pre-existing on `main` at HEAD** (`7d9f1390`, the seed-pin commit) — verified by running both the seed binary (`build/seed/bin/sailfin`) and a clean rebuild without this PR's changes; both reproduce the exact same failure set. CI for PR #643 was green on the same source, so these appear to be environmental (platform, build-cache, or runtime-link differences specific to the sandbox).

Failures (identical between baseline and with-PR runs):
- Unit: `abi_hash_determinism`, `build_cache`, `emit_guarded_scope_drops`, `emit_native_extern`, `numeric_bitwise`, `numeric_cast`, `numeric_int_default`, `numeric_int_float`, `parser_block_let`, `struct_field_separator`, `typecheck_extern`, `typecheck_lambda_capture`, `typecheck_main_signature`
- Integration: `numeric_abi_mismatch`, `test_runner_json`

CI on this PR should be the source of truth for `make test` / `make check` AC verification.

## Files Changed

- `compiler/src/llvm/runtime_helpers.sfn` — six descriptor literals flipped (seven entries; `monotonic_millis` has two aliases).
- `compiler/src/llvm/expression_lowering/native/core_call_emission.sfn` — `coerce_and_emit_call` honors `helper_descriptor.c_abi_return_type`. Mirrors `emit_runtime_call` (#641): emit `call` against ABI type, splice coercion via `coerce_operand_to_type` when ABI differs from caller-visible. **Not on #639's `Files Affected` list** — see Summary for why this was unavoidable.
- `compiler/tests/unit/runtime_int_helpers_test.sfn` (new) — pinning test for each of the seven flipped registry entries.
- `compiler/tests/unit/runtime_helper_abi_coercion_test.sfn` — no-coercion default fixture migrated from `monotonic_millis` (now coerced) to `string.to_number` (still genuinely `double`).

## Notes for review

- The legacy-path coercion extension is the minimum change required to satisfy the explicit AC ("In emitted IR, the call site shows `call double @... fptosi`"). Without it, the registry flip alone produces the broken `call i64` shape — the exact PR #637 failure. The `Files Affected` list in the issue didn't anticipate this because the migration of all call sites to `emit_runtime_call` is still incomplete (only `arrays`, `statement`, and `core_operands` use the new entry point; user-written compiler-source calls still flow through `coerce_and_emit_call`).
- `runtime/prelude.sfn` was inspected per the issue's `In:` clause — the three wrappers (`monotonic_millis`, `char_code`, `grapheme_count`) already declare `-> int`. No changes needed.
- The two non-prelude-wrapped flipped helpers (`sailfin_intrinsic_runtime_arena_mark`, `sailfin_enum_tag_from_instruction_array`) are reached via bare-target calls; the regression test exercises that path directly via `emit_runtime_call` with the bare target name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Peh4tG64NK4KVTQpPZzRZK)_