### PR TITLE
fix(lowering): cross-module : int exports honor source signature (#633)

### DIFF
--- a/compiler/src/llvm/expression_lowering/native/core_call_lowering.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_call_lowering.sfn
@@ -153,14 +153,26 @@ fn lower_call_expression(target: string, arguments: string[], bindings: Paramete
     let is_trait_dispatch = sig.is_trait_dispatch;
     diagnostics = extend_string_array(diagnostics, sig.diagnostics);
 
+    // Issue #633: when `resolve_call_signature` chose the function
+    // entry over a colliding runtime-helper row, drop our own
+    // `helper_descriptor` so the fallback `find_runtime_helper` below
+    // and `coerce_and_emit_call` downstream do not re-fetch the helper
+    // and re-apply its `native_signature` / `c_abi_return_type`
+    // coercion against the function entry's signature.
+    if sig.helper_overridden { helper_descriptor = null; }
+
     // If helper_descriptor is still null, try looking up the target as a
     // runtime helper.  This covers module-level let bindings like
     // `let runtime_char_code_fn = runtime.char_code` where the call uses
     // the binding name directly (no dot — so resolve_call_method_target
-    // doesn't detect it as a method call).
+    // doesn't detect it as a method call). Skip when the resolver
+    // already deferred the helper to a function entry (#633) so we
+    // don't reintroduce the override we just rejected.
     if helper_descriptor == null {
-        let fallback_helper = find_runtime_helper(trimmed_target);
-        if fallback_helper != null { helper_descriptor = fallback_helper; }
+        if !sig.helper_overridden {
+            let fallback_helper = find_runtime_helper(trimmed_target);
+            if fallback_helper != null { helper_descriptor = fallback_helper; }
+        }
     }
 
     // Re-derive helper_descriptor for concat after signature resolution

--- a/compiler/src/llvm/expression_lowering/native/core_call_resolution.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_call_resolution.sfn
@@ -808,6 +808,7 @@ fn resolve_call_signature(trimmed_target: string, helper_descriptor: RuntimeHelp
         result_helper = find_runtime_helper(result_target);
     }
 
+    let mut helper_overridden: boolean = false;
     if !is_trait_dispatch {
         // Issue #633: when a runtime-helper descriptor and a user-defined
         // function entry (local or imported) both match the call target,
@@ -852,11 +853,20 @@ fn resolve_call_signature(trimmed_target: string, helper_descriptor: RuntimeHelp
                 }
                 expected_params = collect_parameter_types(context, function_entry.parameters, result_target);
             }
-            // Drop the helper descriptor when the function entry wins so
-            // downstream emission (`coerce_and_emit_call`) doesn't apply
-            // the helper's `c_abi_return_type` coercion against a
-            // signature it no longer owns.
+            // Signal the caller (lower_call_expression) that the helper
+            // descriptor was deferred to the function entry so it can
+            // drop its own `helper_descriptor` variable. Clearing
+            // `result_helper` locally is insufficient — the outer scope
+            // keeps the Phase-1 helper from `resolve_call_method_target`
+            // and re-runs `find_runtime_helper(trimmed_target)` whenever
+            // it's null, which would otherwise let
+            // `coerce_and_emit_call` reapply the helper's
+            // `native_signature` / `c_abi_return_type` coercion against
+            // the function entry's signature.
             result_helper = null;
+            if find_runtime_helper(result_target) != null {
+                helper_overridden = true;
+            }
         } else if result_helper != null {
             let descriptor = result_helper;
             llvm_return = descriptor.return_type;
@@ -890,7 +900,8 @@ fn resolve_call_signature(trimmed_target: string, helper_descriptor: RuntimeHelp
         llvm_return: llvm_return,
         expected_params: expected_params,
         is_trait_dispatch: is_trait_dispatch,
-        diagnostics: result_diagnostics
+        diagnostics: result_diagnostics,
+        helper_overridden: helper_overridden
     };
 }
 

--- a/compiler/src/llvm/expression_lowering/native/core_call_resolution.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_call_resolution.sfn
@@ -809,12 +809,24 @@ fn resolve_call_signature(trimmed_target: string, helper_descriptor: RuntimeHelp
     }
 
     if !is_trait_dispatch {
-        if result_helper != null {
-            let descriptor = result_helper;
-            llvm_return = descriptor.return_type;
-            expected_params = descriptor.parameter_types;
-            function_entry = null;
-        } else if function_entry != null {
+        // Issue #633: when a runtime-helper descriptor and a user-defined
+        // function entry (local or imported) both match the call target,
+        // the function entry is the source of truth. The registry rows
+        // for `target == symbol` mirror clusters
+        // (e.g. `number_to_string`, `char_code`, `find_char`) used to
+        // win unconditionally, which forced every cross-module call to
+        // adopt the registry's hand-typed C ABI signature. That collided
+        // with the imported function's actual parameter types whenever
+        // a source-level annotation diverged from the registry — flipping
+        // `utils.sfn:number_to_string` to `value: int` made the importer
+        // emit `(double)` against an `i64`-typed `define` and corrupted
+        // `prelude.ll`. Preferring the function entry routes the
+        // signature through the import-context interface so a source
+        // annotation flip is a pure source change with no registry sync.
+        // Method-form calls (`runtime.foo()`), bare calls in capsules
+        // that have no user-defined function entry, and other cases
+        // where `function_entry` is null continue to use the registry.
+        if function_entry != null {
             result_target = function_entry.name;
             if function_entry.is_async {
                 let future_return = future_pointer_type_for_return_type(function_entry.return_type);
@@ -840,6 +852,15 @@ fn resolve_call_signature(trimmed_target: string, helper_descriptor: RuntimeHelp
                 }
                 expected_params = collect_parameter_types(context, function_entry.parameters, result_target);
             }
+            // Drop the helper descriptor when the function entry wins so
+            // downstream emission (`coerce_and_emit_call`) doesn't apply
+            // the helper's `c_abi_return_type` coercion against a
+            // signature it no longer owns.
+            result_helper = null;
+        } else if result_helper != null {
+            let descriptor = result_helper;
+            llvm_return = descriptor.return_type;
+            expected_params = descriptor.parameter_types;
         } else {
             result_diagnostics.push("llvm lowering: call to unknown function `"
                 + result_target

--- a/compiler/src/llvm/lowering/lowering_phase_render.sfn
+++ b/compiler/src/llvm/lowering/lowering_phase_render.sfn
@@ -121,7 +121,7 @@ fn render_llvm_preamble(module_name: string, type_context: TypeContext, trait_me
 
     // Runtime helper declarations
     if debug_lowering { print.err("emit-llvm: phase=render_helpers"); }
-    let helper_declarations = render_runtime_helper_declarations(runtime_helpers, local_functions);
+    let helper_declarations = render_runtime_helper_declarations(runtime_helpers, local_functions, imported_functions);
     if helper_declarations != null {
         if helper_declarations.length > 0 {
             lines = extend_string_lines(lines, helper_declarations);

--- a/compiler/src/llvm/rendering.sfn
+++ b/compiler/src/llvm/rendering.sfn
@@ -98,7 +98,7 @@ fn render_trait_metadata_comments(metadata: TraitMetadata) -> string[] {
 // =============================================================================
 // Runtime Helper Declarations
 // =============================================================================
-fn render_runtime_helper_declarations(used_targets: string[], local_functions: NativeFunction[]) -> string[] {
+fn render_runtime_helper_declarations(used_targets: string[], local_functions: NativeFunction[], imported_functions: NativeFunction[]) -> string[] {
     if used_targets.length == 0 { return []; }
     // Build list of local function symbols to avoid declaring helpers that are defined locally
     let mut local_symbols: string[] = [];
@@ -107,6 +107,26 @@ fn render_runtime_helper_declarations(used_targets: string[], local_functions: N
         if local_index >= local_functions.length { break; }
         local_symbols.push(sanitize_symbol(local_functions[local_index].name));
         local_index += 1;
+    }
+
+    // Issue #633: build the set of imported user-function names so the
+    // helper-declare loop can defer to the imported declare when both
+    // sources resolve to the same symbol. The imported declare carries
+    // the source-level signature parsed from the upstream `.sfn-asm`
+    // interface (e.g. `: int` → `i64`), while the registry rows are
+    // hand-typed and historically static. When they disagree the
+    // imported declare must win so the cross-module call lands on a
+    // declare/define pair with matching parameter ABIs. Helpers whose
+    // effective symbol does NOT collide with any imported function
+    // (the bulk of the registry — `sailfin_runtime_*` C entrypoints,
+    // `runtime_*_fn` aliases, intrinsic stubs) continue to emit
+    // unchanged.
+    let mut imported_symbols: string[] = [];
+    let mut imported_index: int = 0;
+    loop {
+        if imported_index >= imported_functions.length { break; }
+        imported_symbols.push(sanitize_symbol(imported_functions[imported_index].name));
+        imported_index += 1;
     }
 
     let mut lines: string[] = [];
@@ -133,6 +153,26 @@ fn render_runtime_helper_declarations(used_targets: string[], local_functions: N
             }
             // Skip if this helper is actually defined locally (not just a runtime intrinsic)
             if string_array_contains(local_symbols, effective_symbol) {
+                index += 1;
+                continue;
+            }
+            // Issue #633: skip when an imported user function shadows the
+            // helper. The imported declare emitted by
+            // `render_imported_function_declarations` already carries the
+            // source-level signature and would otherwise collide with the
+            // registry's hand-typed shape after symbol mangling renames
+            // `@<sym>` to `@<sym>__<module>`. Limit the skip to
+            // `target == symbol` mirror rows so the helper's alias-declare
+            // path below (which handles `target != symbol` C entrypoints
+            // like `monotonic_millis` → `sailfin_runtime_monotonic_millis`)
+            // is not affected.
+            let mut _shadowed_by_import: boolean = false;
+            if descriptor.target == descriptor.symbol {
+                if string_array_contains(imported_symbols, effective_symbol) {
+                    _shadowed_by_import = true;
+                }
+            }
+            if _shadowed_by_import {
                 index += 1;
                 continue;
             }
@@ -194,16 +234,29 @@ fn render_runtime_helper_declarations(used_targets: string[], local_functions: N
                 if descriptor.target != effective_symbol {
                     let sanitized_target = sanitize_symbol(descriptor.target);
                     if sanitized_target != effective_symbol {
-                        if !string_array_contains(declared_symbols, sanitized_target) {
-                            if !string_array_contains(local_symbols, sanitized_target) {
-                                let alias_line = "declare " + declare_return
-                                    + " @"
-                                    + sanitized_target
-                                    + "("
-                                    + parameter_text
-                                    + ")";
-                                lines.push(alias_line);
-                                declared_symbols.push(sanitized_target);
+                        // Issue #633: when an imported user function
+                        // already supplies a declare for the alias name
+                        // (e.g. `is_decimal_digit` exported from the
+                        // parser utilities, `monotonic_millis` exported
+                        // from the prelude wrapper), the imported declare
+                        // carries the source-level signature and would
+                        // otherwise be duplicated by this alias line.
+                        // The main `effective_symbol` declare above stays
+                        // intact so the C entrypoint (`sailfin_runtime_*`)
+                        // is still resolved for the wrapper's internal
+                        // call.
+                        if !string_array_contains(imported_symbols, sanitized_target) {
+                            if !string_array_contains(declared_symbols, sanitized_target) {
+                                if !string_array_contains(local_symbols, sanitized_target) {
+                                    let alias_line = "declare " + declare_return
+                                        + " @"
+                                        + sanitized_target
+                                        + "("
+                                        + parameter_text
+                                        + ")";
+                                    lines.push(alias_line);
+                                    declared_symbols.push(sanitized_target);
+                                }
                             }
                         }
                     }
@@ -220,39 +273,20 @@ fn render_runtime_helper_declarations(used_targets: string[], local_functions: N
 // =============================================================================
 fn render_imported_function_declarations(imported_functions: NativeFunction[], local_functions: NativeFunction[], context: TypeContext, runtime_helpers: string[]) -> string[] {
     if imported_functions.length == 0 { return []; }
-    // Collect runtime helper symbols to avoid duplicate declares — but only
-    // for descriptors whose target was actually emitted by
-    // render_runtime_helper_declarations (i.e. listed in runtime_helpers).
-    // Otherwise an imported function aliasing an unused descriptor would be
-    // silently dropped from both paths and vanish from the preamble.
-    let helper_descriptors = runtime_helper_descriptors();
-    let mut helper_symbols: string[] = [];
-    let mut helper_index: int = 0;
-    loop {
-        if helper_index >= helper_descriptors.length { break; }
-        let descriptor = helper_descriptors[helper_index];
-        if string_array_contains(runtime_helpers, descriptor.target) {
-            helper_symbols.push(descriptor.symbol);
-            // M2.4a: a flipped descriptor's effective symbol is the
-            // `native_signature`, not `symbol` — treat both as
-            // already-declared so the imported-function pass below
-            // doesn't emit a stray `declare` for either name.
-            let mut _native_sig: string? = descriptor.native_signature;
-            if _native_sig != null {
-                if _native_sig.length > 0 {
-                    if !string_array_contains(helper_symbols, _native_sig) {
-                        helper_symbols.push(_native_sig);
-                    }
-                }
-            }
-            let helper_target = sanitize_symbol(descriptor.target);
-            if !string_array_contains(helper_symbols, helper_target) {
-                helper_symbols.push(helper_target);
-            }
-        }
-        helper_index += 1;
-    }
-
+    // Issue #633: previously this pass collected the runtime-helper
+    // symbol set and skipped imported declares that collided with any
+    // helper, deferring to the registry-emitted declare. That caused
+    // every cross-module call to a `target == symbol` mirror row
+    // (`number_to_string`, `char_code`, `find_char`, etc.) to adopt the
+    // registry's hand-typed C ABI signature, silently overriding the
+    // imported function's source-level types. After this fix the
+    // imported declare wins and `render_runtime_helper_declarations`
+    // takes the symmetric skip when a `target == symbol` row collides
+    // with an imported user function — so the registry retains its
+    // role for true C entrypoints (`sailfin_runtime_*`, `runtime_*_fn`
+    // aliases) but no longer overrules the source-of-truth signature
+    // for Sailfin functions that happen to mirror a legacy helper name.
+    //
     // Get all local function symbols to avoid redefinitions
     let mut local_symbols: string[] = [];
     let mut local_index: int = 0;
@@ -269,15 +303,9 @@ fn render_imported_function_declarations(imported_functions: NativeFunction[], l
         if index >= imported_functions.length { break; }
         let function = imported_functions[index];
         let sanitized_name = sanitize_symbol(function.name);
-        // Skip if this function is already declared as a runtime helper or defined locally
-        let mut _if285: boolean = false;
-        if string_array_contains(helper_symbols, sanitized_name) {
-            _if285 = true;
-        }
+        // Skip if this function is defined locally — emitting a declare
+        // alongside the local define produces an LLVM redefinition error.
         if string_array_contains(local_symbols, sanitized_name) {
-            _if285 = true;
-        }
-        if _if285 {
             index += 1;
             continue;
         }

--- a/compiler/src/llvm/types.sfn
+++ b/compiler/src/llvm/types.sfn
@@ -778,6 +778,16 @@ struct CallSignatureResolution {
     expected_params: string[];
     is_trait_dispatch: boolean;
     diagnostics: string[];
+    // Issue #633: when a user-defined function entry wins over a
+    // colliding `target == symbol` runtime-helper row, signal the
+    // caller to drop its `helper_descriptor` so downstream emission
+    // (`coerce_and_emit_call`) does not re-fetch the helper via
+    // `find_runtime_helper` and re-apply its `native_signature` /
+    // `c_abi_return_type` coercion against the function entry's
+    // signature. The legacy precedence let the helper coercion slip
+    // through unconditionally; this flag carries the precedence
+    // decision across the function boundary.
+    helper_overridden: boolean;
 }
 
 // Wraps the output of `lower_all_functions` so the orchestrator can

--- a/compiler/tests/e2e/cross_module_int_signature_test.sfn
+++ b/compiler/tests/e2e/cross_module_int_signature_test.sfn
@@ -1,0 +1,39 @@
+// Runtime regression for issue #633.
+//
+// The bug: a `target == symbol` mirror row in `runtime_helpers.sfn`
+// (e.g. the pre-fix `number_to_string` row with
+// `parameter_types: ["double"]`) overrode the imported function entry
+// in `resolve_call_signature`, causing every importer to emit
+// `declare i8* @sym__<mod>(double)` against a `define ... (i64 %value)`.
+// Calls passed `double` bits to an `i64` parameter, producing garbage.
+//
+// This test imports three `: int` cross-module functions and asserts
+// that their results match the values produced by an identical
+// same-module path. If the cross-module call's parameter ABI is wrong,
+// the imported callee reads garbage and the assertions trip.
+import {
+    cross_module_int_double,
+    cross_module_int_sum_pair,
+    cross_module_int_identity
+} from "./fixtures/cross_module_int_signature_shared";
+
+test "cross-module int parameter: identity round-trip" {
+    assert cross_module_int_identity(0) == 0;
+    assert cross_module_int_identity(1) == 1;
+    assert cross_module_int_identity(42) == 42;
+    assert cross_module_int_identity(-7) == -7;
+    assert cross_module_int_identity(1000000) == 1000000;
+}
+
+test "cross-module int parameter: simple arithmetic" {
+    assert cross_module_int_double(0) == 0;
+    assert cross_module_int_double(21) == 42;
+    assert cross_module_int_double(-5) == -10;
+    assert cross_module_int_double(1000) == 2000;
+}
+
+test "cross-module int parameter: multi-argument call" {
+    assert cross_module_int_sum_pair(10, 32) == 42;
+    assert cross_module_int_sum_pair(0, 0) == 0;
+    assert cross_module_int_sum_pair(-3, 8) == 5;
+}

--- a/compiler/tests/e2e/cross_module_int_signature_test.sfn
+++ b/compiler/tests/e2e/cross_module_int_signature_test.sfn
@@ -1,20 +1,28 @@
 // Runtime regression for issue #633.
 //
 // The bug: a `target == symbol` mirror row in `runtime_helpers.sfn`
-// (e.g. the pre-fix `number_to_string` row with
+// (e.g. the `number_to_string` row with
 // `parameter_types: ["double"]`) overrode the imported function entry
 // in `resolve_call_signature`, causing every importer to emit
 // `declare i8* @sym__<mod>(double)` against a `define ... (i64 %value)`.
 // Calls passed `double` bits to an `i64` parameter, producing garbage.
 //
-// This test imports three `: int` cross-module functions and asserts
-// that their results match the values produced by an identical
-// same-module path. If the cross-module call's parameter ABI is wrong,
-// the imported callee reads garbage and the assertions trip.
+// `number_to_string` is the headline collision case — its fixture
+// alias takes `: int` and returns `int`, so the pre-fix `(double)`
+// override surfaces as both a parameter-ABI mismatch (caller passes
+// `double` bits, callee reads `i64`) and a return-ABI mismatch (caller
+// expects `i8*`, callee returns `i64`). Either of those would corrupt
+// the assertions below; together they reliably fail-fast pre-fix.
+//
+// The remaining `cross_module_int_*` calls are non-colliding
+// baselines that pin the regular `: int` shape — they keep working
+// pre-fix and post-fix, and exist so a future regression that breaks
+// the non-collision path also surfaces here.
 import {
     cross_module_int_double,
     cross_module_int_sum_pair,
-    cross_module_int_identity
+    cross_module_int_identity,
+    number_to_string
 } from "./fixtures/cross_module_int_signature_shared";
 
 test "cross-module int parameter: identity round-trip" {
@@ -36,4 +44,18 @@ test "cross-module int parameter: multi-argument call" {
     assert cross_module_int_sum_pair(10, 32) == 42;
     assert cross_module_int_sum_pair(0, 0) == 0;
     assert cross_module_int_sum_pair(-3, 8) == 5;
+}
+
+test "cross-module int parameter: name collides with runtime-helper registry row (#633)" {
+    // `number_to_string` is the `target == symbol` mirror row that
+    // pre-fix overrode the imported function entry. The fixture
+    // returns `value + 100` against an `: int` parameter; pre-fix the
+    // caller would coerce these literals to `double` and the callee
+    // would interpret the `double` bit pattern as `i64`, producing
+    // garbage. Post-fix the imported signature wins and the literals
+    // are passed as `i64` end-to-end.
+    assert number_to_string(0) == 100;
+    assert number_to_string(42) == 142;
+    assert number_to_string(-50) == 50;
+    assert number_to_string(1000) == 1100;
 }

--- a/compiler/tests/e2e/fixtures/cross_module_int_signature_shared.sfn
+++ b/compiler/tests/e2e/fixtures/cross_module_int_signature_shared.sfn
@@ -1,0 +1,28 @@
+// Cross-module `: int` fixture for issue #633.
+//
+// Pairs with `compiler/tests/e2e/cross_module_int_signature_test.sfn`
+// (runtime correctness) and
+// `compiler/tests/e2e/test_cross_module_int_signature.sh` (LLVM IR
+// declare/call shape). The compiler must emit `declare i8* @... (i64)`
+// in the importer's IR, not `(double)` — the bug surfaced when
+// `compiler/src/llvm/runtime_helpers.sfn` carried a `target == symbol`
+// mirror row for a function that also lives in user-defined Sailfin
+// source, which silently overrode the imported function's parameter
+// types with the registry's hand-typed `["double"]`.
+//
+// All entry points here use `: int` parameters and `-> int` returns so
+// the fixture exercises the post-flip cross-module shape regardless of
+// what `compiler/src/llvm/utils.sfn:number_to_string` currently uses.
+fn cross_module_int_double(value: int) -> int { return value + value; }
+
+fn cross_module_int_sum_pair(left: int, right: int) -> int {
+    return left + right;
+}
+
+fn cross_module_int_identity(value: int) -> int { return value; }
+
+export {
+    cross_module_int_double,
+    cross_module_int_sum_pair,
+    cross_module_int_identity
+};

--- a/compiler/tests/e2e/fixtures/cross_module_int_signature_shared.sfn
+++ b/compiler/tests/e2e/fixtures/cross_module_int_signature_shared.sfn
@@ -3,16 +3,30 @@
 // Pairs with `compiler/tests/e2e/cross_module_int_signature_test.sfn`
 // (runtime correctness) and
 // `compiler/tests/e2e/test_cross_module_int_signature.sh` (LLVM IR
-// declare/call shape). The compiler must emit `declare i8* @... (i64)`
-// in the importer's IR, not `(double)` — the bug surfaced when
-// `compiler/src/llvm/runtime_helpers.sfn` carried a `target == symbol`
-// mirror row for a function that also lives in user-defined Sailfin
-// source, which silently overrode the imported function's parameter
-// types with the registry's hand-typed `["double"]`.
+// declare/call shape).
 //
-// All entry points here use `: int` parameters and `-> int` returns so
-// the fixture exercises the post-flip cross-module shape regardless of
-// what `compiler/src/llvm/utils.sfn:number_to_string` currently uses.
+// The first three exports are plain `: int` cross-module functions
+// that the importer can call without invoking any runtime-helper
+// machinery. They pin the baseline shape:
+// `declare i64 @<sym>__<mod>(i64...)`.
+//
+// `shadow_number_to_string` is the headline #633 regression. Its
+// name collides with the `target == symbol` mirror row at
+// `compiler/src/llvm/runtime_helpers.sfn` for `number_to_string`
+// (registry: `parameter_types: ["double"]`, `return_type: "i8*"`).
+// Pre-fix, `resolve_call_signature` preferred the registry row over
+// the imported function entry and `render_runtime_helper_declarations`
+// emitted the bare `@number_to_string(double)` declare while
+// `render_imported_function_declarations` skipped its own declare on
+// the helper-symbols collision. After mangling, the importer's IR
+// ended up with `declare i8* @number_to_string__<mod>(double)` and
+// `call ... (double %x)` against an `i64`-typed callee define —
+// silent ABI mismatch that corrupted `prelude.ll` validation. Post-fix
+// the imported function entry wins and the importer emits
+// `declare i64 @number_to_string__<mod>(i64)` plus matching call
+// sites. The fixture's `number_to_string` deliberately returns `int`
+// (LLVM `i64`) so the divergence from the registry's `i8*` return
+// type also surfaces if the fix regresses.
 fn cross_module_int_double(value: int) -> int { return value + value; }
 
 fn cross_module_int_sum_pair(left: int, right: int) -> int {
@@ -21,8 +35,15 @@ fn cross_module_int_sum_pair(left: int, right: int) -> int {
 
 fn cross_module_int_identity(value: int) -> int { return value; }
 
+// Name collides with the `target == symbol` runtime-helper mirror row
+// for `number_to_string`. Exposes an `: int` parameter and `-> int`
+// return so the pre-fix `(double)` registry override surfaces as a
+// concrete ABI mismatch instead of an invisible divergence.
+fn number_to_string(value: int) -> int { return value + 100; }
+
 export {
     cross_module_int_double,
     cross_module_int_sum_pair,
-    cross_module_int_identity
+    cross_module_int_identity,
+    number_to_string
 };

--- a/compiler/tests/e2e/test_cross_module_int_signature.sh
+++ b/compiler/tests/e2e/test_cross_module_int_signature.sh
@@ -3,18 +3,21 @@
 # (issue #633).
 #
 # A `target == symbol` mirror row in `compiler/src/llvm/runtime_helpers.sfn`
-# (e.g. the pre-fix `number_to_string` entry with
-# `parameter_types: ["double"]`) would override the imported function's
-# parameter types in `resolve_call_signature` and the imported declare
-# would be skipped by `render_imported_function_declarations` in favor
-# of the registry's `(double)` declare. After mangling, the cross-module
-# declare/call landed as `@sym__<mod>(double)` against an `i64`-typed
-# `define` — silent ABI mismatch.
+# (e.g. the `number_to_string` entry with
+# `parameter_types: ["double"], return_type: "i8*"`) used to override
+# the imported function's parameter types in `resolve_call_signature`
+# and the imported declare was skipped by
+# `render_imported_function_declarations` in favor of the registry's
+# `(double)` declare. After mangling, the cross-module declare/call
+# landed as `@sym__<mod>(double)` against an `i64`-typed `define` —
+# silent ABI mismatch.
 #
-# This test compiles a two-file fixture (one defines `: int` exports,
-# the other imports + calls them) and asserts that the importer's IR
-# carries `(i64)` declares and call sites. If the bug regresses, grep
-# for `(double)` will find a hit and this test fails.
+# This test compiles a two-file fixture (one defines `: int` exports
+# AND a deliberately-colliding `number_to_string`, the other imports +
+# calls them) and asserts that the importer's IR carries `(i64)`
+# declares and call sites with the full parameter list pinned. If the
+# bug regresses, grep for `(double)` will find a hit and this test
+# fails.
 #
 # Usage:
 #   compiler/tests/e2e/test_cross_module_int_signature.sh <compiler-binary>
@@ -89,81 +92,150 @@ emit_importer_ll() {
     return 0
 }
 
-# Shared fixture's `.sfn-asm` records `: int` parameter annotations. The
-# producer side is already correct upstream of #633; this assertion just
-# pins it so a future regression on the emit-native side surfaces here
-# instead of as a noisy IR mismatch downstream.
+# Module suffix used by the mangling phase for the shared fixture.
+# Hard-coding it keeps the assertions surgical: any drift in the
+# mangling scheme breaks this test loudly, which is the right outcome.
+MOD_SUFFIX="fixtures__cross_module_int_signature_shared"
+
+# Shared fixture's `.sfn-asm` records `: int` parameter annotations
+# AND the colliding `number_to_string` export. The producer side is
+# already correct upstream of #633; this assertion just pins it so a
+# future regression on the emit-native side surfaces here instead of
+# as a noisy IR mismatch downstream.
 test_shared_asm_declares_int_parameters() {
     emit_shared_asm || return 1
-    local hits
-    hits="$(grep -cE '^\.param value: int' "$SHARED_ASM" || true)"
-    if [ "${hits:-0}" -lt 2 ]; then
-        echo "[test]   expected at least two .param entries with type int, got ${hits:-0}"
-        sed 's/^/[test]     /' "$SHARED_ASM" | head -20
+    local int_params
+    int_params="$(grep -cE '^\.param value: int' "$SHARED_ASM" || true)"
+    if [ "${int_params:-0}" -lt 3 ]; then
+        echo "[test]   expected at least three .param entries with type int (identity + double + number_to_string), got ${int_params:-0}"
+        sed 's/^/[test]     /' "$SHARED_ASM" | head -30
+        return 1
+    fi
+    if ! grep -qE '^\.fn number_to_string\(value: int\) -> int' "$SHARED_ASM"; then
+        echo "[test]   expected number_to_string export header to read `.fn number_to_string(value: int) -> int`"
+        grep -E '^\.fn number_to_string' "$SHARED_ASM" | sed 's/^/[test]     /'
         return 1
     fi
     return 0
 }
 
-# The headline #633 assertion: importer-side declares for `: int`
-# exports carry `(i64)` parameters, not `(double)`. The grep checks all
-# three fixture symbols at once.
+# Headline #633 assertion: each cross-module declare carries the
+# exact `(i64...)` parameter list — including the two-argument case
+# and the colliding `number_to_string` row. Matching the full
+# parameter list (not just the prefix) ensures a regression that
+# emits `(double)` for any single argument fails this test.
 test_importer_declares_int_signatures() {
     emit_importer_ll || return 1
-    local symbols=( \
-        "cross_module_int_double" \
-        "cross_module_int_sum_pair" \
-        "cross_module_int_identity" \
-    )
-    local mod_suffix="fixtures__cross_module_int_signature_shared"
     local missing=0
-    for sym in "${symbols[@]}"; do
-        local mangled="${sym}__${mod_suffix}"
-        local needle="^declare i64 @${mangled}\\("
+
+    # Single i64 parameter (`cross_module_int_double`,
+    # `cross_module_int_identity`, and the colliding
+    # `number_to_string`).
+    local single_i64=( \
+        "cross_module_int_double" \
+        "cross_module_int_identity" \
+        "number_to_string" \
+    )
+    for sym in "${single_i64[@]}"; do
+        local mangled="${sym}__${MOD_SUFFIX}"
+        local needle="^declare i64 @${mangled}\\(i64\\)$"
         if ! grep -qE "$needle" "$IMPORTER_LL"; then
-            echo "[test]   missing declare line: ${mangled}"
+            echo "[test]   missing or mismatched declare for ${mangled}: expected 'declare i64 @${mangled}(i64)'"
+            grep -E "^declare .* @${mangled}\\(" "$IMPORTER_LL" \
+                | sed 's/^/[test]     actual: /' | head -3
             missing=$((missing + 1))
         fi
     done
+
+    # Two i64 parameters (`cross_module_int_sum_pair`).
+    local pair_mangled="cross_module_int_sum_pair__${MOD_SUFFIX}"
+    local pair_needle="^declare i64 @${pair_mangled}\\(i64, i64\\)$"
+    if ! grep -qE "$pair_needle" "$IMPORTER_LL"; then
+        echo "[test]   missing or mismatched declare for ${pair_mangled}: expected 'declare i64 @${pair_mangled}(i64, i64)'"
+        grep -E "^declare .* @${pair_mangled}\\(" "$IMPORTER_LL" \
+            | sed 's/^/[test]     actual: /' | head -3
+        missing=$((missing + 1))
+    fi
+
     if [ "$missing" -gt 0 ]; then
-        echo "[test]   declares observed in importer IR:"
-        grep -E '^declare .* @(cross_module_int_|cross_module_int_)' "$IMPORTER_LL" \
-            | sed 's/^/[test]     /' | head -10
         return 1
     fi
     return 0
 }
 
-# Call sites must also use `(i64 ...)`. A regression where the declare
-# is `(i64)` but the call site is `(double ...)` would still pass the
-# previous test but produce a malformed IR; this guard pins both ends.
+# Importer call sites must also use `(i64 ...)` arguments. A regression
+# where the declare is `(i64)` but the call site is `(double ...)`
+# would still pass the declare test but produce malformed IR; this
+# guard pins both ends.
 test_importer_call_sites_use_int() {
     emit_importer_ll || return 1
+    local cross_pattern="@(cross_module_int_[a-z_]+|number_to_string)__${MOD_SUFFIX}"
+
+    # No call site may pass `double` to any of our fixtures.
     local double_calls
-    double_calls="$(grep -cE 'call .* @cross_module_int_[a-z_]+__fixtures__cross_module_int_signature_shared\(double' "$IMPORTER_LL" || true)"
+    double_calls="$(grep -cE "call .* ${cross_pattern}\\(double" "$IMPORTER_LL" || true)"
     if [ "${double_calls:-0}" -gt 0 ]; then
         echo "[test]   regression: $double_calls cross-module call site(s) still use (double ...) instead of (i64 ...)"
-        grep -nE 'call .* @cross_module_int_[a-z_]+__fixtures__cross_module_int_signature_shared\(' "$IMPORTER_LL" \
+        grep -nE "call .* ${cross_pattern}\\(" "$IMPORTER_LL" \
             | sed 's/^/[test]     /' | head -10
         return 1
     fi
+
+    # Headline: the colliding `number_to_string` import must call with
+    # `(i64 ...)`. Pinning the literal symbol AND the leading `i64`
+    # argument keyword guards against the registry-driven `(double)`
+    # regression specifically.
+    local nts_int_calls
+    nts_int_calls="$(grep -cE "call i64 @number_to_string__${MOD_SUFFIX}\\(i64 " "$IMPORTER_LL" || true)"
+    if [ "${nts_int_calls:-0}" -lt 1 ]; then
+        echo "[test]   expected at least one (i64 ...) call to the colliding number_to_string import"
+        grep -nE "@number_to_string__${MOD_SUFFIX}\\(" "$IMPORTER_LL" \
+            | sed 's/^/[test]     /' | head -10
+        return 1
+    fi
+
+    # Sanity: every cross-module call must use `(i64 ...)` or `(i64,
+    # i64 ...)`. The earlier negative grep covers `double`; this
+    # positive grep ensures at least one matching call site exists per
+    # fixture symbol so the test does not silently degrade if the
+    # importer stops emitting calls altogether.
     local int_calls
-    int_calls="$(grep -cE 'call i64 @cross_module_int_[a-z_]+__fixtures__cross_module_int_signature_shared\(i64' "$IMPORTER_LL" || true)"
-    if [ "${int_calls:-0}" -lt 1 ]; then
-        echo "[test]   expected at least one (i64 ...) cross-module call site, got ${int_calls:-0}"
-        grep -nE 'call .* @cross_module_int_[a-z_]+__fixtures__cross_module_int_signature_shared\(' "$IMPORTER_LL" \
+    int_calls="$(grep -cE "call i64 ${cross_pattern}\\(i64" "$IMPORTER_LL" || true)"
+    if [ "${int_calls:-0}" -lt 4 ]; then
+        echo "[test]   expected at least four (i64 ...) cross-module call sites, got ${int_calls:-0}"
+        grep -nE "call .* ${cross_pattern}\\(" "$IMPORTER_LL" \
             | sed 's/^/[test]     /' | head -10
         return 1
     fi
     return 0
 }
 
-run_test 'shared fixture .sfn-asm declares int parameters' \
+# The colliding `number_to_string` import must NOT be shadowed by the
+# `target == symbol` registry row's `(double)` declare. Specifically,
+# the importer's IR must not contain a bare `declare i8* @number_to_string(double)`
+# line. Pre-fix, the registry path emitted that line and the imported
+# declare was skipped, producing a declare/define mismatch after
+# mangling.
+test_importer_does_not_emit_registry_double_declare() {
+    emit_importer_ll || return 1
+    local stray_double
+    stray_double="$(grep -cE '^declare i8\* @number_to_string\(double\)' "$IMPORTER_LL" || true)"
+    if [ "${stray_double:-0}" -gt 0 ]; then
+        echo "[test]   regression: registry-driven 'declare i8* @number_to_string(double)' leaked into importer IR"
+        grep -nE '@number_to_string\(' "$IMPORTER_LL" | sed 's/^/[test]     /' | head -5
+        return 1
+    fi
+    return 0
+}
+
+run_test 'shared fixture .sfn-asm declares int parameters (incl. colliding number_to_string)' \
     test_shared_asm_declares_int_parameters
-run_test 'importer IR declares cross-module exports with (i64) parameters' \
+run_test 'importer IR declares cross-module exports with full (i64...) parameter lists' \
     test_importer_declares_int_signatures
 run_test 'importer IR call sites use (i64) arguments for cross-module : int exports' \
     test_importer_call_sites_use_int
+run_test 'importer IR does not emit the registry-driven (double) declare for colliding number_to_string' \
+    test_importer_does_not_emit_registry_double_declare
 
 echo "[summary] $PASS passed, $FAIL failed"
 if [ "$FAIL" -gt 0 ]; then

--- a/compiler/tests/e2e/test_cross_module_int_signature.sh
+++ b/compiler/tests/e2e/test_cross_module_int_signature.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# Pins the LLVM declare/call shape for cross-module `: int` exports
+# (issue #633).
+#
+# A `target == symbol` mirror row in `compiler/src/llvm/runtime_helpers.sfn`
+# (e.g. the pre-fix `number_to_string` entry with
+# `parameter_types: ["double"]`) would override the imported function's
+# parameter types in `resolve_call_signature` and the imported declare
+# would be skipped by `render_imported_function_declarations` in favor
+# of the registry's `(double)` declare. After mangling, the cross-module
+# declare/call landed as `@sym__<mod>(double)` against an `i64`-typed
+# `define` — silent ABI mismatch.
+#
+# This test compiles a two-file fixture (one defines `: int` exports,
+# the other imports + calls them) and asserts that the importer's IR
+# carries `(i64)` declares and call sites. If the bug regresses, grep
+# for `(double)` will find a hit and this test fails.
+#
+# Usage:
+#   compiler/tests/e2e/test_cross_module_int_signature.sh <compiler-binary>
+
+set -euo pipefail
+
+BINARY="${1:?usage: test_cross_module_int_signature.sh <compiler-binary>}"
+BINARY="$(realpath "$BINARY")"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SHARED_FIXTURE="$SCRIPT_DIR/fixtures/cross_module_int_signature_shared.sfn"
+IMPORTER_FIXTURE="$SCRIPT_DIR/cross_module_int_signature_test.sfn"
+
+if [ ! -f "$SHARED_FIXTURE" ]; then
+    echo "[test] FAIL: missing fixture $SHARED_FIXTURE"
+    exit 1
+fi
+if [ ! -f "$IMPORTER_FIXTURE" ]; then
+    echo "[test] FAIL: missing importer $IMPORTER_FIXTURE"
+    exit 1
+fi
+
+PASS=0
+FAIL=0
+
+SCRATCH="$(mktemp -d -t sfn-cross-int-XXXXXX)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+# Stage the importer's import-context so `sfn emit llvm` resolves the
+# `from "./fixtures/cross_module_int_signature_shared"` declaration.
+mkdir -p "$SCRATCH/build/native/import-context/fixtures"
+SHARED_ASM="$SCRATCH/build/native/import-context/fixtures/cross_module_int_signature_shared.sfn-asm"
+IMPORTER_LL="$SCRATCH/importer.ll"
+
+ulimit -v 8388608 2>/dev/null || true
+
+run_test() {
+    local name="$1"
+    shift
+    if "$@"; then
+        echo "[test] PASS: $name"
+        PASS=$((PASS + 1))
+    else
+        echo "[test] FAIL: $name"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+emit_shared_asm() {
+    if [ -s "$SHARED_ASM" ]; then return 0; fi
+    if ! ( cd "$SCRATCH" && "$BINARY" emit \
+            --module-name fixtures/cross_module_int_signature_shared \
+            -o "$SHARED_ASM" native "$SHARED_FIXTURE" \
+        ) > "$SCRATCH/shared.stderr" 2>&1; then
+        echo "[test]   sfn emit native (shared fixture) failed"
+        sed 's/^/[test]     /' "$SCRATCH/shared.stderr" | head -20
+        return 1
+    fi
+    return 0
+}
+
+emit_importer_ll() {
+    if [ -s "$IMPORTER_LL" ]; then return 0; fi
+    emit_shared_asm || return 1
+    if ! ( cd "$SCRATCH" && "$BINARY" emit \
+            --module-name cross_module_int_signature_test \
+            -o "$IMPORTER_LL" llvm "$IMPORTER_FIXTURE" \
+        ) > "$SCRATCH/importer.stderr" 2>&1; then
+        echo "[test]   sfn emit llvm (importer) failed"
+        sed 's/^/[test]     /' "$SCRATCH/importer.stderr" | head -20
+        return 1
+    fi
+    return 0
+}
+
+# Shared fixture's `.sfn-asm` records `: int` parameter annotations. The
+# producer side is already correct upstream of #633; this assertion just
+# pins it so a future regression on the emit-native side surfaces here
+# instead of as a noisy IR mismatch downstream.
+test_shared_asm_declares_int_parameters() {
+    emit_shared_asm || return 1
+    local hits
+    hits="$(grep -cE '^\.param value: int' "$SHARED_ASM" || true)"
+    if [ "${hits:-0}" -lt 2 ]; then
+        echo "[test]   expected at least two .param entries with type int, got ${hits:-0}"
+        sed 's/^/[test]     /' "$SHARED_ASM" | head -20
+        return 1
+    fi
+    return 0
+}
+
+# The headline #633 assertion: importer-side declares for `: int`
+# exports carry `(i64)` parameters, not `(double)`. The grep checks all
+# three fixture symbols at once.
+test_importer_declares_int_signatures() {
+    emit_importer_ll || return 1
+    local symbols=( \
+        "cross_module_int_double" \
+        "cross_module_int_sum_pair" \
+        "cross_module_int_identity" \
+    )
+    local mod_suffix="fixtures__cross_module_int_signature_shared"
+    local missing=0
+    for sym in "${symbols[@]}"; do
+        local mangled="${sym}__${mod_suffix}"
+        local needle="^declare i64 @${mangled}\\("
+        if ! grep -qE "$needle" "$IMPORTER_LL"; then
+            echo "[test]   missing declare line: ${mangled}"
+            missing=$((missing + 1))
+        fi
+    done
+    if [ "$missing" -gt 0 ]; then
+        echo "[test]   declares observed in importer IR:"
+        grep -E '^declare .* @(cross_module_int_|cross_module_int_)' "$IMPORTER_LL" \
+            | sed 's/^/[test]     /' | head -10
+        return 1
+    fi
+    return 0
+}
+
+# Call sites must also use `(i64 ...)`. A regression where the declare
+# is `(i64)` but the call site is `(double ...)` would still pass the
+# previous test but produce a malformed IR; this guard pins both ends.
+test_importer_call_sites_use_int() {
+    emit_importer_ll || return 1
+    local double_calls
+    double_calls="$(grep -cE 'call .* @cross_module_int_[a-z_]+__fixtures__cross_module_int_signature_shared\(double' "$IMPORTER_LL" || true)"
+    if [ "${double_calls:-0}" -gt 0 ]; then
+        echo "[test]   regression: $double_calls cross-module call site(s) still use (double ...) instead of (i64 ...)"
+        grep -nE 'call .* @cross_module_int_[a-z_]+__fixtures__cross_module_int_signature_shared\(' "$IMPORTER_LL" \
+            | sed 's/^/[test]     /' | head -10
+        return 1
+    fi
+    local int_calls
+    int_calls="$(grep -cE 'call i64 @cross_module_int_[a-z_]+__fixtures__cross_module_int_signature_shared\(i64' "$IMPORTER_LL" || true)"
+    if [ "${int_calls:-0}" -lt 1 ]; then
+        echo "[test]   expected at least one (i64 ...) cross-module call site, got ${int_calls:-0}"
+        grep -nE 'call .* @cross_module_int_[a-z_]+__fixtures__cross_module_int_signature_shared\(' "$IMPORTER_LL" \
+            | sed 's/^/[test]     /' | head -10
+        return 1
+    fi
+    return 0
+}
+
+run_test 'shared fixture .sfn-asm declares int parameters' \
+    test_shared_asm_declares_int_parameters
+run_test 'importer IR declares cross-module exports with (i64) parameters' \
+    test_importer_declares_int_signatures
+run_test 'importer IR call sites use (i64) arguments for cross-module : int exports' \
+    test_importer_call_sites_use_int
+
+echo "[summary] $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi


### PR DESCRIPTION
## Summary

- **`resolve_call_signature`** swaps the helper/function-entry precedence in `core_call_resolution.sfn` so a user-defined function entry (local or imported) wins over a colliding runtime-helper registry row. Sets a new `helper_overridden` flag on the result so the caller can drop its own helper descriptor.
- **`lower_call_expression`** in `core_call_lowering.sfn` honors `sig.helper_overridden` by clearing its `helper_descriptor` and skipping the fallback `find_runtime_helper` lookup. Without this thread the registry-driven `native_signature` / `c_abi_return_type` coercion in `coerce_and_emit_call` would silently re-apply against the function-entry signature, defeating the precedence fix.
- **`render_imported_function_declarations`** in `rendering.sfn` drops the helper-symbols skip; the imported declare always emits with the source-level signature parsed from the upstream `.sfn-asm` interface.
- **`render_runtime_helper_declarations`** takes a new `imported_functions` argument and skips (a) the main declare when a `target == symbol` mirror row collides with an imported user function and (b) the alias declare when the alias name collides. `target != symbol` C entrypoints (`sailfin_runtime_*`) continue to emit so wrapper bodies still link.

The bug: a `target == symbol` mirror row in `compiler/src/llvm/runtime_helpers.sfn` (e.g. `number_to_string` with `parameter_types: ["double"]`) overrode the imported function's source signature. Flipping `compiler/src/llvm/utils.sfn:131` to `value: int` left every importer emitting `declare i8* @number_to_string__llvm__utils(double)` against an `i64`-typed `define`, corrupting `prelude.ll` validation and cascading into self-host break.

Bare callers in capsule sources (`sfn/math`, `sfn/json`, `sfn/log`, `sfn/toml`) that rely on the registry to provide `number_to_string` keep working — `function_entry` is null for those sites and the helper path still resolves.

Closes #633

## Acceptance Criteria

- [ ] **Apply the one-line `: number` → `: int` flip to `compiler/src/llvm/utils.sfn:131`** — **deferred**. With the current pinned seed (alpha.21) baking in the buggy resolver, flipping the source here would corrupt the first-pass binary's IR before the fix gets a chance to run. After this PR merges and a new alpha is cut with this fix baked in, the flip becomes a clean follow-up source change.
- [x] **`make compile` produces `declare i8* @number_to_string__llvm__utils(i64)` in every importer's `.ll`** — verified by manually flipping `utils.sfn:131` against the freshly-built first-pass binary (see verification below). The flip itself is deferred per the criterion above.
- [x] **`make compile` produces `call i8* @number_to_string__llvm__utils(i64 %t)` at every call site** — same verification.
- [x] **`make compile` self-hosts and `prelude.ll` validates with `llvm-as`** — `make compile` self-hosts cleanly with the fix in place (no ABI-mismatch warning on the second pass); `prelude.ll` validation deferred until the flip lands.
- [x] **Regression test under `compiler/tests/unit/`** — implemented under `compiler/tests/e2e/` instead (unit tests in this codebase are single-file; the two-file fixture pattern lives in e2e). The fixture's `number_to_string(value: int)` export deliberately collides with the `target == symbol` runtime-helper mirror row so the regression exercises the exact precedence path #633 fixes; `test_cross_module_int_signature.sh` pins the full `(i64...)` declare/call shapes (not just the prefix) and verifies that the registry-driven `(double)` declare does not leak into importer IR.
- [x] **`make test` passes** — full suite green: unit 98/98, integration 23/23, e2e 60/60 (including the new regression), capsules 10/10.
- [x] **After this lands, #611 can be picked up without workarounds** — the cross-module declare path now honors `: int` annotations end-to-end, so #611's seedbump cleanup is unblocked once a new seed carries this fix.

## Verification

```bash
ulimit -v 8388608
make compile        # self-hosts cleanly

# IR-shape regression (the headline #633 assertion)
bash compiler/tests/e2e/test_cross_module_int_signature.sh build/native/sailfin
# [test] PASS: shared fixture .sfn-asm declares int parameters (incl. colliding number_to_string)
# [test] PASS: importer IR declares cross-module exports with full (i64...) parameter lists
# [test] PASS: importer IR call sites use (i64) arguments for cross-module : int exports
# [test] PASS: importer IR does not emit the registry-driven (double) declare for colliding number_to_string
# [summary] 4 passed, 0 failed

# Runtime regression — passes pre-fix only for non-colliding names;
# the colliding `number_to_string` collision case in particular reads
# `double` bits as `i64` pre-fix and trips its assertion.
bash scripts/run_native_test.sh build/native/sailfin \
    compiler/tests/e2e/cross_module_int_signature_test.sfn
# [test] PASS: cross_module_int_signature_test.sfn

# Direct issue reproducer (manually applied & reverted)
sed -i 's/fn number_to_string(value: number)/fn number_to_string(value: int)/' \
    compiler/src/llvm/utils.sfn
build/native/sailfin emit --module-name llvm/utils -o /tmp/utils.sfn-asm native \
    compiler/src/llvm/utils.sfn
# stage import context...
build/native/sailfin emit --module-name llvm/expressions_helpers \
    -o /tmp/exp.ll llvm compiler/src/llvm/expressions_helpers.sfn
grep number_to_string /tmp/exp.ll
# declare i8* @number_to_string__llvm__utils(i64)        ← was (double)
#   %t4 = call i8* @number_to_string__llvm__utils(i64 %index)
# define i8* @number_to_string__llvm__expressions_helpers(i64 %a0) {
#   %t0 = call i8* @number_to_string__llvm__utils(i64 %a0)
git checkout compiler/src/llvm/utils.sfn

make test
# ═══ unit: 98/98 passed, 0 failed ═══
# ═══ integration: 23/23 passed, 0 failed ═══
# ═══ e2e: 60/60 passed, 0 failed ═══
# ═══ capsules: 10/10 passed, 0 failed ═══
```

`sfn fmt --check` is clean on every modified `.sfn` file.

## Files Changed

- `compiler/src/llvm/expression_lowering/native/core_call_resolution.sfn` — precedence swap in `resolve_call_signature`; sets `helper_overridden`.
- `compiler/src/llvm/expression_lowering/native/core_call_lowering.sfn` — honors `sig.helper_overridden` by clearing `helper_descriptor` and skipping the fallback `find_runtime_helper`.
- `compiler/src/llvm/types.sfn` — adds `helper_overridden: boolean` field to `CallSignatureResolution`.
- `compiler/src/llvm/rendering.sfn` — drops helper-symbols skip in `render_imported_function_declarations`; adds `imported_functions` argument and dedup logic in `render_runtime_helper_declarations`.
- `compiler/src/llvm/lowering/lowering_phase_render.sfn` — threads `imported_functions` into the helper-declare call site.
- `compiler/tests/e2e/fixtures/cross_module_int_signature_shared.sfn` (new) — three `: int` baseline exports plus a deliberately-colliding `number_to_string` export.
- `compiler/tests/e2e/cross_module_int_signature_test.sfn` (new) — runtime correctness, including the colliding `number_to_string` case.
- `compiler/tests/e2e/test_cross_module_int_signature.sh` (new) — IR declare/call-shape pin with full parameter lists.

## Notes for review

- Initial commit (108272a) had a known gap that Copilot flagged: `resolve_call_signature` cleared its local `result_helper` but the outer scope re-fetched the registry row from the bare target name, letting `coerce_and_emit_call` re-apply `c_abi_return_type` / `native_signature` coercion. Follow-up commit (b9f640e) plumbs the `helper_overridden` flag through `CallSignatureResolution` so the caller can drop its own helper descriptor and skip the fallback lookup.
- Initial regression fixture used unique names (`cross_module_int_*`) that didn't collide with any registry row, so it didn't actually exercise the precedence path. Follow-up commit adds a `number_to_string(value: int)` export that collides directly with the `target == symbol` mirror row; pre-fix the call would pass `double` bits to the `i64` callee and the runtime assertions trip. The IR-shape test now pins the full `(i64...)` parameter list and a negative assertion that the registry's `declare i8* @number_to_string(double)` does not leak through.
- The issue framed this as a bug in the `.sfn-asm` consumer ("a code path that defaults to `double` when an imported function's signature can't be resolved"). The actual mechanism is a precedence problem: the consumer DID parse the imported signature correctly, but `resolve_call_signature` and `render_imported_function_declarations` deferred to the registry whenever a row existed. The architect's comment on #633 also missed that `number_to_string` does have a registry row (line 456) — it's in the `target == symbol` mirror cluster that #572 catalogs.
- This fix is the consumer-side counterpart to the registry-mirror approach proposed in #572 (Option C / hybrid). The registry rows for mirror clusters become a fallback for callers without an imported function entry rather than an unconditional override, which is exactly the property #572 wants for the prelude-mirror cluster. The implementation here doesn't ship #572's design doc — it just plugs the load-bearing path that surfaces in #611.
- The `: number` → `: int` flip on `utils.sfn:131` is deliberately not in this PR. The current pinned seed (alpha.21) has the old resolver baked in and would emit `(double)` declares against the fixed first-pass binary's `i64` define, corrupting self-host. Once a fresh alpha carries this fix, the flip is a one-line follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)