### PR TITLE
refactor(numeric): migrate sfn/tensor off `: number` (Slice E.3c-1)

### DIFF
--- a/capsules/sfn/tensor/src/mod.sfn
+++ b/capsules/sfn/tensor/src/mod.sfn
@@ -14,16 +14,16 @@
 // All operations currently execute on the CPU.
 // ---- Types ----
 struct Tensor {
-    data: number[];  // flat storage (row-major)
-    shape: number[];  // dimensions, e.g. [2, 3] for a 2x3 matrix
-    size: number;  // total element count (product of shape)
+    data: float[];  // flat storage (row-major)
+    shape: int[];  // dimensions, e.g. [2, 3] for a 2x3 matrix
+    size: int;  // total element count (product of shape)
 }
 
 // ---- Constructors ----
-fn zeros(shape: number[]) -> Tensor {
+fn zeros(shape: int[]) -> Tensor {
     // Create a tensor filled with zeros.
     let n = _shape_size(shape);
-    let mut data: number[] = [];
+    let mut data: float[] = [];
     let mut i: int = 0;
     loop {
         if i >= n { break; }
@@ -33,10 +33,10 @@ fn zeros(shape: number[]) -> Tensor {
     return Tensor { data: data, shape: shape, size: n };
 }
 
-fn ones(shape: number[]) -> Tensor {
+fn ones(shape: int[]) -> Tensor {
     // Create a tensor filled with ones.
     let n = _shape_size(shape);
-    let mut data: number[] = [];
+    let mut data: float[] = [];
     let mut i: int = 0;
     loop {
         if i >= n { break; }
@@ -46,10 +46,10 @@ fn ones(shape: number[]) -> Tensor {
     return Tensor { data: data, shape: shape, size: n };
 }
 
-fn fill(shape: number[], value: number) -> Tensor {
+fn fill(shape: int[], value: float) -> Tensor {
     // Create a tensor filled with a constant value.
     let n = _shape_size(shape);
-    let mut data: number[] = [];
+    let mut data: float[] = [];
     let mut i: int = 0;
     loop {
         if i >= n { break; }
@@ -59,7 +59,7 @@ fn fill(shape: number[], value: number) -> Tensor {
     return Tensor { data: data, shape: shape, size: n };
 }
 
-fn from_array(data: number[], shape: number[]) -> Tensor {
+fn from_array(data: float[], shape: int[]) -> Tensor {
     // Create a tensor from a flat data array and a shape.
     // Data length must match the product of shape dimensions.
     // If mismatched, uses the smaller of data.length and shape size.
@@ -68,22 +68,22 @@ fn from_array(data: number[], shape: number[]) -> Tensor {
     return Tensor { data: data, shape: shape, size: actual };
 }
 
-fn scalar(value: number) -> Tensor {
+fn scalar(value: float) -> Tensor {
     // Create a scalar (0-dimensional) tensor.
     return Tensor { data: [value], shape: [], size: 1 };
 }
 
 // ---- Element access ----
-fn get(t: Tensor, indices: number[]) -> number {
+fn get(t: Tensor, indices: int[]) -> float {
     // Get a single element by multi-dimensional index.
     let flat = _flat_index(t.shape, indices);
     return t.data[flat];
 }
 
-fn set(t: Tensor, indices: number[], value: number) -> Tensor {
+fn set(t: Tensor, indices: int[], value: float) -> Tensor {
     // Return a new tensor with one element replaced.
     let flat = _flat_index(t.shape, indices);
-    let mut new_data: number[] = [];
+    let mut new_data: float[] = [];
     let mut i: int = 0;
     loop {
         if i >= t.size { break; }
@@ -99,7 +99,7 @@ fn set(t: Tensor, indices: number[], value: number) -> Tensor {
 fn add(a: Tensor, b: Tensor) -> Tensor {
     // Element-wise addition. Shapes must match.
     let n = _min_size(a.size, b.size);
-    let mut out: number[] = [];
+    let mut out: float[] = [];
     let mut i: int = 0;
     loop {
         if i >= n { break; }
@@ -112,7 +112,7 @@ fn add(a: Tensor, b: Tensor) -> Tensor {
 fn subtract(a: Tensor, b: Tensor) -> Tensor {
     // Element-wise subtraction. Shapes must match.
     let n = _min_size(a.size, b.size);
-    let mut out: number[] = [];
+    let mut out: float[] = [];
     let mut i: int = 0;
     loop {
         if i >= n { break; }
@@ -125,7 +125,7 @@ fn subtract(a: Tensor, b: Tensor) -> Tensor {
 fn multiply(a: Tensor, b: Tensor) -> Tensor {
     // Element-wise multiplication (Hadamard product). Shapes must match.
     let n = _min_size(a.size, b.size);
-    let mut out: number[] = [];
+    let mut out: float[] = [];
     let mut i: int = 0;
     loop {
         if i >= n { break; }
@@ -135,9 +135,9 @@ fn multiply(a: Tensor, b: Tensor) -> Tensor {
     return Tensor { data: out, shape: a.shape, size: n };
 }
 
-fn scale(t: Tensor, s: number) -> Tensor {
+fn scale(t: Tensor, s: float) -> Tensor {
     // Multiply every element by a scalar.
-    let mut out: number[] = [];
+    let mut out: float[] = [];
     let mut i: int = 0;
     loop {
         if i >= t.size { break; }
@@ -153,9 +153,9 @@ fn negate(t: Tensor) -> Tensor {
 }
 
 // ---- Reductions ----
-fn sum(t: Tensor) -> number {
+fn sum(t: Tensor) -> float {
     // Sum all elements.
-    let mut total: number = 0;
+    let mut total: float = 0.0;
     let mut i: int = 0;
     loop {
         if i >= t.size { break; }
@@ -165,16 +165,16 @@ fn sum(t: Tensor) -> number {
     return total;
 }
 
-fn mean(t: Tensor) -> number {
+fn mean(t: Tensor) -> float {
     // Arithmetic mean of all elements.
     if t.size == 0 { return 0; }
-    return sum(t) / t.size;
+    return sum(t) / (t.size as float);
 }
 
-fn max_val(t: Tensor) -> number {
+fn max_val(t: Tensor) -> float {
     // Maximum element value.
     if t.size == 0 { return 0; }
-    let mut best: number = t.data[0];
+    let mut best: float = t.data[0];
     let mut i: int = 1;
     loop {
         if i >= t.size { break; }
@@ -184,10 +184,10 @@ fn max_val(t: Tensor) -> number {
     return best;
 }
 
-fn min_val(t: Tensor) -> number {
+fn min_val(t: Tensor) -> float {
     // Minimum element value.
     if t.size == 0 { return 0; }
-    let mut best: number = t.data[0];
+    let mut best: float = t.data[0];
     let mut i: int = 1;
     loop {
         if i >= t.size { break; }
@@ -198,20 +198,20 @@ fn min_val(t: Tensor) -> number {
 }
 
 // ---- Shape utilities ----
-fn reshape(t: Tensor, new_shape: number[]) -> Tensor {
+fn reshape(t: Tensor, new_shape: int[]) -> Tensor {
     // Reshape a tensor (data stays the same, shape changes).
     return Tensor { data: t.data, shape: new_shape, size: t.size };
 }
 
-fn rank(t: Tensor) -> number {
+fn rank(t: Tensor) -> int {
     // Number of dimensions.
     return t.shape.length;
 }
 
 // ---- Linear algebra (2D) ----
-fn dot(a: Tensor, b: Tensor) -> number {
+fn dot(a: Tensor, b: Tensor) -> float {
     // Dot product of two 1D tensors (vectors).
-    let mut total: number = 0;
+    let mut total: float = 0.0;
     let mut i: int = 0;
     loop {
         if i >= a.size { break; }
@@ -230,14 +230,14 @@ fn matmul(a: Tensor, b: Tensor) -> Tensor {
     let m = a.shape[0];
     let k = a.shape[1];
     let n = b.shape[1];
-    let mut out: number[] = [];
+    let mut out: float[] = [];
     let mut i: int = 0;
     loop {
         if i >= m { break; }
         let mut j: int = 0;
         loop {
             if j >= n { break; }
-            let mut val: number = 0;
+            let mut val: float = 0.0;
             let mut p: int = 0;
             loop {
                 if p >= k { break; }
@@ -260,7 +260,7 @@ fn transpose(t: Tensor) -> Tensor {
     // Transpose a 2D tensor.
     let rows = t.shape[0];
     let cols = t.shape[1];
-    let mut out: number[] = [];
+    let mut out: float[] = [];
     let mut j: int = 0;
     loop {
         if j >= cols { break; }
@@ -280,9 +280,9 @@ fn transpose(t: Tensor) -> Tensor {
 }
 
 // ---- Internal helpers ----
-fn _shape_size(shape: number[]) -> number {
+fn _shape_size(shape: int[]) -> int {
     if shape.length == 0 { return 1; }
-    let mut n: number = 1;
+    let mut n: int = 1;
     let mut i: int = 0;
     loop {
         if i >= shape.length { break; }
@@ -292,10 +292,10 @@ fn _shape_size(shape: number[]) -> number {
     return n;
 }
 
-fn _flat_index(shape: number[], indices: number[]) -> number {
-    let mut flat: number = 0;
-    let mut stride: number = 1;
-    let mut i: number = shape.length;
+fn _flat_index(shape: int[], indices: int[]) -> int {
+    let mut flat: int = 0;
+    let mut stride: int = 1;
+    let mut i: int = shape.length;
     loop {
         if i <= 0 { break; }
         i -= 1;
@@ -305,7 +305,7 @@ fn _flat_index(shape: number[], indices: number[]) -> number {
     return flat;
 }
 
-fn _min_size(a: number, b: number) -> number {
+fn _min_size(a: int, b: int) -> int {
     if a <= b { return a; }
     return b;
 }


### PR DESCRIPTION
## Summary

- Splits all 40 `: number` / `-> number` sites in `capsules/sfn/tensor/src/mod.sfn` into `float` (data + scalars) and `int` (shape, size, indices, rank) per the architect's decomposition in #653.
- Single atomic refactor — no signature renames, no parameter reorders, no behavior changes beyond the type flip.
- Mirrors the migrated reference already present in `capsules/sfn/tensor/tests/tensor_test.sfn` (the `_`-prefixed copies kept inline pending the duplicate-`declare round` lowering fix).

Closes #654

## Type split

**`float` (data, scalars, arithmetic):**
- `data: float[]` (struct field + every local `mut out: float[]` / `mut new_data: float[]`)
- `fill.value`, `scalar.value`, `set.value`, `scale.s` parameters
- `sum`, `mean`, `max_val`, `min_val`, `dot` return types
- Scratch: `total: float = 0.0`, `best: float = ...`, `val: float = 0.0`

**`int` (shape, dims, indices, rank):**
- `shape: int[]`, `size: int`, `indices: int[]` (struct field + every consumer)
- `rank() -> int`, `_flat_index(int[], int[]) -> int`, `_shape_size(int[]) -> int`, `_min_size(int, int) -> int`
- `_flat_index` scratch (`flat`, `stride`, `i`) flipped to `int`

**Strict-refusal-aware spots:**
- `mean` uses explicit `(t.size as float)` cast for `sum(t) / t.size` (mirrors `_mean` in the tests)
- `negate(t) -> scale(t, -1)` keeps the int literal — coerced at the `s: float` site, matching `_negate` in the tests
- `return 0;` in `mean` / `max_val` / `min_val` zero-element paths uses the int-literal-into-float coercion (matches `_mean` in the tests)

## Acceptance Criteria

- [x] `grep -nE "(: number|-> number)" capsules/sfn/tensor/src/mod.sfn` returns zero matches
- [x] `make compile` self-hosts
- [x] `make test` — capsule + integration suites pass; only failures are pre-existing on `main`
- [x] `sfn fmt --check capsules/sfn/tensor/` clean
- [x] No new compiler warnings against `sfn/tensor` under the post-#556 strict-refusal regime

## Verification

```bash
ulimit -v 8388608

# Coverage gate (empty output):
grep -nE "(: number|-> number)" capsules/sfn/tensor/src/mod.sfn

# Self-host + targeted suite:
make compile                # → built build/native/sailfin
make test-capsules          # → 10/10 passed (tensor_test.sfn green)
make test-integration       # → 23/23 passed
sfn fmt --check capsules/sfn/tensor/   # → clean
```

## Pre-existing failures (NOT introduced by this PR)

`make test-unit` reports 4 atomic-test failures and `test_work_dir_parity.sh` reports 3 sub-failures — all with the same root cause: `build/sailfin/capsules/llvm__atomics_check.ll:153:1: error: expected top-level entity` (corrupted UTF-8 byte `羆64` where `i64` was expected) in the atomics intrinsic emission.

Verified pre-existing by stashing this PR's diff and re-running against the parent commit (`9df101e`). This PR touches only `capsules/sfn/tensor/src/mod.sfn` — no `compiler/src/` or `runtime/` files — so it cannot be the cause.

## Files Changed

- `capsules/sfn/tensor/src/mod.sfn` — 41 insertions / 41 deletions

Generated with Claude Code on web.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XCbD1HXT9dWuxUegwbTT79)_