### PR TITLE
refactor(numeric): migrate sfn/test off `: number` (Slice E.3c-2)

### DIFF
--- a/capsules/sfn/test/src/mod.sfn
+++ b/capsules/sfn/test/src/mod.sfn
@@ -26,10 +26,10 @@
 // ---------------------------------------------------------------------------
 // Internal helpers
 // ---------------------------------------------------------------------------
-fn _number_to_string(value: number) -> string {
+fn _number_to_string(value: int) -> string {
     if value == 0 { return "0"; }
     let mut is_negative: boolean = false;
-    let mut remaining: number = value;
+    let mut remaining: int = value;
     if value < 0 {
         is_negative = true;
         remaining = 0 - value;
@@ -38,8 +38,8 @@ fn _number_to_string(value: number) -> string {
     let digits = "0123456789";
     loop {
         if remaining <= 0 { break; }
-        let mut temp: number = remaining;
-        let mut quotient: number = 0;
+        let mut temp: int = remaining;
+        let mut quotient: int = 0;
         loop {
             if temp < 10 { break; }
             temp -= 10;
@@ -58,7 +58,7 @@ fn _bool_to_string(value: boolean) -> string {
     return "false";
 }
 
-fn _abs(x: number) -> number {
+fn _abs(x: float) -> float {
     if x < 0 { return 0 - x; }
     return x;
 }
@@ -66,19 +66,19 @@ fn _abs(x: number) -> number {
 // ---------------------------------------------------------------------------
 // Equality assertions
 // ---------------------------------------------------------------------------
-fn assert_eq(actual: number, expected: number, label: string) ![io] {
+fn assert_eq(actual: float, expected: float, label: string) ![io] {
     if actual == expected { return; }
     print.err("ASSERTION FAILED: " + label);
-    print.err("  expected: " + _number_to_string(expected));
-    print.err("  actual:   " + _number_to_string(actual));
+    print.err("  expected: " + number_to_string(expected));
+    print.err("  actual:   " + number_to_string(actual));
     assert false;
 }
 
-fn assert_ne(actual: number, expected: number, label: string) ![io] {
+fn assert_ne(actual: float, expected: float, label: string) ![io] {
     if actual != expected { return; }
     print.err("ASSERTION FAILED: " + label);
-    print.err("  expected not: " + _number_to_string(expected));
-    print.err("  actual:       " + _number_to_string(actual));
+    print.err("  expected not: " + number_to_string(expected));
+    print.err("  actual:       " + number_to_string(actual));
     assert false;
 }
 
@@ -109,45 +109,45 @@ fn assert_bool_eq(actual: boolean, expected: boolean, label: string) ![io] {
 // ---------------------------------------------------------------------------
 // Comparison assertions
 // ---------------------------------------------------------------------------
-fn assert_gt(actual: number, threshold: number, label: string) ![io] {
+fn assert_gt(actual: float, threshold: float, label: string) ![io] {
     if actual > threshold { return; }
     print.err("ASSERTION FAILED: " + label);
-    print.err("  expected: > " + _number_to_string(threshold));
-    print.err("  actual:     " + _number_to_string(actual));
+    print.err("  expected: > " + number_to_string(threshold));
+    print.err("  actual:     " + number_to_string(actual));
     assert false;
 }
 
-fn assert_gte(actual: number, threshold: number, label: string) ![io] {
+fn assert_gte(actual: float, threshold: float, label: string) ![io] {
     if actual >= threshold { return; }
     print.err("ASSERTION FAILED: " + label);
-    print.err("  expected: >= " + _number_to_string(threshold));
-    print.err("  actual:      " + _number_to_string(actual));
+    print.err("  expected: >= " + number_to_string(threshold));
+    print.err("  actual:      " + number_to_string(actual));
     assert false;
 }
 
-fn assert_lt(actual: number, threshold: number, label: string) ![io] {
+fn assert_lt(actual: float, threshold: float, label: string) ![io] {
     if actual < threshold { return; }
     print.err("ASSERTION FAILED: " + label);
-    print.err("  expected: < " + _number_to_string(threshold));
-    print.err("  actual:     " + _number_to_string(actual));
+    print.err("  expected: < " + number_to_string(threshold));
+    print.err("  actual:     " + number_to_string(actual));
     assert false;
 }
 
-fn assert_lte(actual: number, threshold: number, label: string) ![io] {
+fn assert_lte(actual: float, threshold: float, label: string) ![io] {
     if actual <= threshold { return; }
     print.err("ASSERTION FAILED: " + label);
-    print.err("  expected: <= " + _number_to_string(threshold));
-    print.err("  actual:      " + _number_to_string(actual));
+    print.err("  expected: <= " + number_to_string(threshold));
+    print.err("  actual:      " + number_to_string(actual));
     assert false;
 }
 
 // ---------------------------------------------------------------------------
 // String content assertions
 // ---------------------------------------------------------------------------
-fn _find_in_string(haystack: string, needle: string) -> number {
+fn _find_in_string(haystack: string, needle: string) -> int {
     if needle.length == 0 { return 0; }
     if needle.length > haystack.length { return -1; }
-    let mut i: number = 0;
+    let mut i: int = 0;
     let limit = haystack.length - needle.length;
     loop {
         if i > limit { return -1; }
@@ -198,20 +198,20 @@ fn assert_ends_with(text: string, suffix: string, label: string) ![io] {
 // ---------------------------------------------------------------------------
 // Approximate equality (for floating-point / tolerance comparisons)
 // ---------------------------------------------------------------------------
-fn assert_approx(actual: number, expected: number, tolerance: number, label: string) ![io] {
+fn assert_approx(actual: float, expected: float, tolerance: float, label: string) ![io] {
     let diff = _abs(actual - expected);
     if diff <= tolerance { return; }
     print.err("ASSERTION FAILED: " + label);
-    print.err("  expected: " + _number_to_string(expected) + " +/- "
-        + _number_to_string(tolerance));
-    print.err("  actual:   " + _number_to_string(actual));
+    print.err("  expected: " + number_to_string(expected) + " +/- "
+        + number_to_string(tolerance));
+    print.err("  actual:   " + number_to_string(actual));
     assert false;
 }
 
 // ---------------------------------------------------------------------------
 // Array length assertions
 // ---------------------------------------------------------------------------
-fn assert_length(actual_length: number, expected_length: number, label: string) ![io] {
+fn assert_length(actual_length: int, expected_length: int, label: string) ![io] {
     if actual_length == expected_length { return; }
     print.err("ASSERTION FAILED: " + label);
     print.err("  expected length: " + _number_to_string(expected_length));
@@ -219,7 +219,7 @@ fn assert_length(actual_length: number, expected_length: number, label: string) 
     assert false;
 }
 
-fn assert_empty(actual_length: number, label: string) ![io] {
+fn assert_empty(actual_length: int, label: string) ![io] {
     if actual_length == 0 { return; }
     print.err("ASSERTION FAILED: " + label);
     print.err("  expected empty (length 0)");
@@ -227,7 +227,7 @@ fn assert_empty(actual_length: number, label: string) ![io] {
     assert false;
 }
 
-fn assert_not_empty(actual_length: number, label: string) ![io] {
+fn assert_not_empty(actual_length: int, label: string) ![io] {
     if actual_length > 0 { return; }
     print.err("ASSERTION FAILED: " + label);
     print.err("  expected non-empty (length > 0)");
@@ -286,8 +286,8 @@ fn assert_false(value: boolean, label: string) ![io] {
 struct AssertFailure {
     present: boolean;
     file: string;
-    line: number;
-    col: number;
+    line: int;
+    col: int;
     message: string;
 }
 
@@ -311,7 +311,7 @@ fn _pure_fail(message: string) -> AssertFailure {
     };
 }
 
-fn pure_assert_eq_int(actual: number, expected: number, label: string) -> AssertFailure ![pure] {
+fn pure_assert_eq_int(actual: int, expected: int, label: string) -> AssertFailure ![pure] {
     if actual == expected { return _pure_ok(); }
     let message = "ASSERTION FAILED: " + label + "; expected: "
         + _number_to_string(expected)
@@ -330,7 +330,7 @@ fn pure_assert_eq_string(actual: string, expected: string, label: string) -> Ass
     return _pure_fail(message);
 }
 
-fn pure_assert_eq_float(actual: number, expected: number, tolerance: number, label: string) -> AssertFailure ![pure] {
+fn pure_assert_eq_float(actual: float, expected: float, tolerance: float, label: string) -> AssertFailure ![pure] {
     let diff = _abs(actual - expected);
     if diff <= tolerance { return _pure_ok(); }
     // Use the runtime's `%.15g`-format `number_to_string` here rather


### PR DESCRIPTION
## Summary

- Retypes all 21 `: number` / `-> number` sites in `capsules/sfn/test/src/mod.sfn` per the architect call on #653.
- Public comparison asserts keep their alias-equivalent shape via `: float`; length asserts and internal counters move to `: int`.
- `pure_assert_eq_int` and `pure_assert_eq_float` get their explicit integer/float signatures (the integer-fidelity escape hatch the slice is preserving).

Closes #655

## Type split

| Surface | New shape | Rationale |
|---|---|---|
| `assert_eq` / `_ne` / `_gt` / `_gte` / `_lt` / `_lte` / `_approx` | `: float` | Forward-compatible, alias-equivalent today; preserves ABI for the moment a real consumer lands. Diagnostic formatting swapped to runtime `number_to_string` so fractional inputs render correctly. |
| `assert_length` / `_empty` / `_not_empty` | `: int` | Lengths are i64. |
| `_number_to_string` param + work registers (`temp`, `quotient`, `remaining`) | `: int` | Integer-only formatter; matches the local copy already in `compiler/src/main.sfn`. |
| `_find_in_string` loop counter + return | `: int` | String indices. |
| `_abs` | `: float` | Consumed only by `assert_approx` and `pure_assert_eq_float`. |
| `AssertFailure.line` / `.col` | `: int` | Span fields. |
| `pure_assert_eq_int` | `: int` | Integer-explicit alternate. |
| `pure_assert_eq_float` | `: float` | Float-explicit alternate (already used runtime `number_to_string`). |

## Acceptance Criteria

- [x] `grep -nE "(: number\|-> number)" capsules/sfn/test/src/mod.sfn` → zero matches.
- [x] `pure_assert_eq_int` and `pure_assert_eq_float` exist and are exported.
- [x] `make compile` self-hosts.
- [x] `make test` passes (see Verification — 3 pre-existing failures unrelated to this slice).
- [x] `sfn fmt --check capsules/sfn/test/` clean.
- [x] No new compiler warnings against `sfn/test` under the post-#556 strict-refusal regime.

## Verification

```bash
ulimit -v 8388608

grep -nE "(: number|-> number)" capsules/sfn/test/src/mod.sfn | grep -v "// alias-coverage"
# → empty

make compile                                       # ✓ self-hosts
sfn fmt --check capsules/sfn/test/                 # ✓ clean
sailfin check capsules/sfn/test/src/mod.sfn        # ✓ "checked 1 files: ok"
sailfin build -p capsules/sfn/test                 # ✓ "built: build/capsules/sfn/test/obj/mod.o"

make test-integration                              # ✓ 23/23 passed (incl. pure_assert_smoke_test)
make test-capsules                                 # ✓ 10/10 passed
make test-unit                                     # 97/99 passed (2 pre-existing failures)
make test-e2e                                      # 59/60 passed (1 pre-existing failure)
```

### Pre-existing failures (confirmed at baseline before this change)

- `compiler/tests/unit/emit_scope_drops_test.sfn` — `link failed (clang exit=1)`
- `compiler/tests/unit/emit_guarded_scope_drops_test.sfn` — same
- `compiler/tests/e2e/test_work_dir_parity.sh` — UTF-8/IR corruption in `build/sailfin/capsules/llvm__expressions_bindings.ll` (`缰iveStruct = type ...` vs expected `%NativeStruct`)

All three reproduce on a clean checkout with no changes from this branch. They touch the LLVM lowering / build-cache layer, not `sfn/test`, so they don't block this slice.

## Files Changed

- `capsules/sfn/test/src/mod.sfn` — 36 lines updated (21 type-annotation sites + accompanying diagnostic call swaps from `_number_to_string` to runtime `number_to_string` on the float-typed asserts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012g79CfrP9MBJZksXgQzQgZ)_