### PR TITLE
refactor(numeric): migrate sfn/cli off `: number` (Slice E.3c-3)

### DIFF
--- a/capsules/sfn/cli/src/builder.sfn
+++ b/capsules/sfn/cli/src/builder.sfn
@@ -100,7 +100,7 @@ fn with_version(cmd: Command, version: string) -> Command {
 fn with_arg(cmd: Command, a: Arg) -> Command {
     // Add a positional argument to the command.
     let mut new_args: Arg[] = [];
-    let mut i: number = 0;
+    let mut i: int = 0;
     loop {
         if i >= cmd.args.length { break; }
         new_args.push(cmd.args[i]);
@@ -120,7 +120,7 @@ fn with_arg(cmd: Command, a: Arg) -> Command {
 fn with_flag(cmd: Command, f: Flag) -> Command {
     // Add a flag to the command.
     let mut new_flags: Flag[] = [];
-    let mut i: number = 0;
+    let mut i: int = 0;
     loop {
         if i >= cmd.flags.length { break; }
         new_flags.push(cmd.flags[i]);
@@ -140,7 +140,7 @@ fn with_flag(cmd: Command, f: Flag) -> Command {
 fn with_subcommand(cmd: Command, sub: Command) -> Command {
     // Add a subcommand to the command.
     let mut new_subs: Command[] = [];
-    let mut i: number = 0;
+    let mut i: int = 0;
     loop {
         if i >= cmd.subcmds.length { break; }
         new_subs.push(cmd.subcmds[i]);

--- a/capsules/sfn/cli/src/help.sfn
+++ b/capsules/sfn/cli/src/help.sfn
@@ -31,7 +31,7 @@ fn _format_help(cmd: Command, program: string) -> string {
     out = out + "  " + program;
     if cmd.subcmds.length > 0 { out = out + " <command>"; }
     if cmd.flags.length > 0 { out = out + " [options]"; }
-    let mut ai: number = 0;
+    let mut ai: int = 0;
     loop {
         if ai >= cmd.args.length { break; }
         let a = cmd.args[ai];
@@ -46,7 +46,7 @@ fn _format_help(cmd: Command, program: string) -> string {
     if cmd.subcmds.length > 0 {
         out = out + "\ncommands:\n";
         let col_width = _max_name_width(cmd) + 2;
-        let mut si: number = 0;
+        let mut si: int = 0;
         loop {
             if si >= cmd.subcmds.length { break; }
             let sub = cmd.subcmds[si];
@@ -77,7 +77,7 @@ fn _format_help(cmd: Command, program: string) -> string {
     // Flags.
     out = out + "\noptions:\n";
     let flag_width = _max_flag_width(cmd) + 2;
-    let mut fi: number = 0;
+    let mut fi: int = 0;
     loop {
         if fi >= cmd.flags.length { break; }
         let f = cmd.flags[fi];
@@ -105,9 +105,9 @@ fn _flag_label(f: Flag) -> string {
     return label;
 }
 
-fn _max_name_width(cmd: Command) -> number {
-    let mut max: number = 0;
-    let mut i: number = 0;
+fn _max_name_width(cmd: Command) -> int {
+    let mut max: int = 0;
+    let mut i: int = 0;
     loop {
         if i >= cmd.subcmds.length { break; }
         if cmd.subcmds[i].name.length > max {
@@ -118,9 +118,9 @@ fn _max_name_width(cmd: Command) -> number {
     return max;
 }
 
-fn _max_arg_width(cmd: Command) -> number {
-    let mut max: number = 0;
-    let mut i: number = 0;
+fn _max_arg_width(cmd: Command) -> int {
+    let mut max: int = 0;
+    let mut i: int = 0;
     loop {
         if i >= cmd.args.length { break; }
         // +2 for the angle brackets.
@@ -131,13 +131,13 @@ fn _max_arg_width(cmd: Command) -> number {
     return max;
 }
 
-fn _max_flag_width(cmd: Command) -> number {
-    let mut max: number = 0;
+fn _max_flag_width(cmd: Command) -> int {
+    let mut max: int = 0;
     let built_in_help = 10;  // "-h, --help"
     let built_in_version = 13;  // "-V, --version"
     if built_in_help > max { max = built_in_help; }
     if built_in_version > max { max = built_in_version; }
-    let mut i: number = 0;
+    let mut i: int = 0;
     loop {
         if i >= cmd.flags.length { break; }
         let w = _flag_label(cmd.flags[i]).length;
@@ -147,11 +147,11 @@ fn _max_flag_width(cmd: Command) -> number {
     return max;
 }
 
-fn _pad(text: string, width: number) -> string {
+fn _pad(text: string, width: int) -> string {
     // Right-pad text with spaces to the given width.
     if text.length >= width { return text + "  "; }
     let mut out: string = text;
-    let mut i: number = text.length;
+    let mut i: int = text.length;
     loop {
         if i >= width { break; }
         out = out + " ";

--- a/capsules/sfn/cli/src/matches.sfn
+++ b/capsules/sfn/cli/src/matches.sfn
@@ -8,7 +8,7 @@ import { Matches } from "./types";
 fn get(m: Matches, name: string) -> string {
     // Get the value of a positional argument or value flag by name.
     // Returns empty string if not found.
-    let mut i: number = 0;
+    let mut i: int = 0;
     loop {
         if i >= m.positional_names.length { break; }
         if strings_equal(m.positional_names[i], name) {
@@ -20,9 +20,7 @@ fn get(m: Matches, name: string) -> string {
     i = 0;
     loop {
         if i >= m.flag_names.length { break; }
-        if strings_equal(m.flag_names[i], name) {
-            return m.flag_values[i];
-        }
+        if strings_equal(m.flag_names[i], name) { return m.flag_values[i]; }
         i += 1;
     }
     return "";
@@ -33,7 +31,7 @@ fn get_or(m: Matches, name: string, default_value: string) -> string {
     // argument was not provided. Unlike `get()`, this correctly distinguishes
     // between "not provided" and "provided as empty string" by checking
     // whether the name exists in the parsed matches.
-    let mut i: number = 0;
+    let mut i: int = 0;
     loop {
         if i >= m.positional_names.length { break; }
         if strings_equal(m.positional_names[i], name) {
@@ -44,9 +42,7 @@ fn get_or(m: Matches, name: string, default_value: string) -> string {
     i = 0;
     loop {
         if i >= m.flag_names.length { break; }
-        if strings_equal(m.flag_names[i], name) {
-            return m.flag_values[i];
-        }
+        if strings_equal(m.flag_names[i], name) { return m.flag_values[i]; }
         i += 1;
     }
     return default_value;
@@ -54,7 +50,7 @@ fn get_or(m: Matches, name: string, default_value: string) -> string {
 
 fn has_flag(m: Matches, name: string) -> boolean {
     // Returns true if a boolean flag was present on the command line.
-    let mut i: number = 0;
+    let mut i: int = 0;
     loop {
         if i >= m.flag_names.length { break; }
         if strings_equal(m.flag_names[i], name) { return true; }
@@ -65,7 +61,7 @@ fn has_flag(m: Matches, name: string) -> boolean {
 
 fn has(m: Matches, name: string) -> boolean {
     // Returns true if any argument or flag with the given name was provided.
-    let mut i: number = 0;
+    let mut i: int = 0;
     loop {
         if i >= m.positional_names.length { break; }
         if strings_equal(m.positional_names[i], name) { return true; }

--- a/capsules/sfn/cli/src/parser.sfn
+++ b/capsules/sfn/cli/src/parser.sfn
@@ -24,13 +24,13 @@ fn run(cmd: Command, argv: string[]) -> Matches ![io] {
     let mut subcmd_name: string = "";
 
     // Skip argv[0] (the program name).
-    let mut idx: number = 1;
+    let mut idx: int = 1;
 
     // Check for subcommand at argv[1].
     if idx < argv.length {
         let first = argv[idx];
         if !_starts_with(first, "-") {
-            let mut si: number = 0;
+            let mut si: int = 0;
             loop {
                 if si >= cmd.subcmds.length { break; }
                 if strings_equal(cmd.subcmds[si].name, first) {
@@ -50,7 +50,7 @@ fn run(cmd: Command, argv: string[]) -> Matches ![io] {
     let help_cmd = _help_hint(cmd.name, subcmd_name);
 
     // Parse remaining args.
-    let mut pos_idx: number = 0;
+    let mut pos_idx: int = 0;
     loop {
         if idx >= argv.length { break; }
         let token = argv[idx];
@@ -162,7 +162,7 @@ fn _starts_with(text: string, prefix: string) -> boolean {
 }
 
 fn _find_flag_long(cmd: Command, name: string) -> Flag {
-    let mut i: number = 0;
+    let mut i: int = 0;
     loop {
         if i >= cmd.flags.length { break; }
         if strings_equal(cmd.flags[i].long_name, name) {
@@ -179,7 +179,7 @@ fn _find_flag_long(cmd: Command, name: string) -> Flag {
 }
 
 fn _find_flag_short(cmd: Command, name: string) -> Flag {
-    let mut i: number = 0;
+    let mut i: int = 0;
     loop {
         if i >= cmd.flags.length { break; }
         if strings_equal(cmd.flags[i].short_name, name) {
@@ -198,7 +198,7 @@ fn _find_flag_short(cmd: Command, name: string) -> Flag {
 fn _resolve_active(cmd: Command, subcmd_name: string) -> Command {
     // Return the subcommand definition if matched, otherwise the root command.
     if subcmd_name.length == 0 { return cmd; }
-    let mut i: number = 0;
+    let mut i: int = 0;
     loop {
         if i >= cmd.subcmds.length { break; }
         if strings_equal(cmd.subcmds[i].name, subcmd_name) {


### PR DESCRIPTION
## Summary

- Flip all 27 `: number` / `-> number` sites in `capsules/sfn/cli/src/` to `int` — every site is integer-shaped (column widths, argv positions, indices, loop counters).
- Per-file: `help.sfn` (14: column widths + loop counters), `parser.sfn` (6: argv/positional indices, flag-search counters), `matches.sfn` (4: name-search loops), `builder.sfn` (3: with_arg/with_flag/with_subcommand copy loops).
- Formatter incidentally collapsed two short `if … { return …; }` bodies in `matches.sfn` — canonical fmt output, no semantic change.

Closes #656

## Acceptance Criteria

- [x] `grep -rnE "(: number|-> number)" capsules/sfn/cli/src/` returns zero matches (modulo `// alias-coverage` opt-outs — none in this capsule)
- [x] `make compile` self-hosts
- [x] `make test` passes (e2e 60/60, capsules 10/10, plus all unit/integration subgroups `0 failed`)
- [x] `sfn fmt --check capsules/sfn/cli/` clean
- [x] No new compiler warnings against `sfn/cli` under the post-#556 strict-refusal regime

## Verification

```bash
ulimit -v 8388608

grep -rnE "(: number|-> number)" capsules/sfn/cli/src/ | grep -v "// alias-coverage"
# → empty

make compile     # built build/native/sailfin
make test        # ═══ e2e: 60/60 passed, 0 failed ═══
                 # ═══ capsules: 10/10 passed, 0 failed ═══
sfn fmt --check capsules/sfn/cli/    # exit 0
```

## Files Changed

- `capsules/sfn/cli/src/help.sfn` — 14 sites
- `capsules/sfn/cli/src/parser.sfn` — 6 sites
- `capsules/sfn/cli/src/matches.sfn` — 4 sites
- `capsules/sfn/cli/src/builder.sfn` — 3 sites

## Context

- Parent: #653 (Slice E.3c)
- Epic: #424 (Slice E — retire `number`)
- Release tracker: #518 (v0.6.0)


---
_Generated by [Claude Code](https://claude.ai/code/session_01UFDUBiLA5jNTt2ZeCvbZT8)_