### PR TITLE
refactor(numeric): migrate sfn/nn off `: number` (Slice E.3c-4)

### DIFF
--- a/capsules/sfn/nn/src/mod.sfn
+++ b/capsules/sfn/nn/src/mod.sfn
@@ -12,15 +12,15 @@
 // Training loops and automatic differentiation are planned for a future
 // release once the `gpu` effect runtime is available.
 // ---- Activation functions ----
-fn relu(x: number) -> number {
+fn relu(x: float) -> float {
     // Rectified linear unit: max(0, x).
     if x > 0 { return x; }
     return 0;
 }
 
-fn relu_array(input: number[]) -> number[] {
+fn relu_array(input: float[]) -> float[] {
     // Apply ReLU element-wise.
-    let mut out: number[] = [];
+    let mut out: float[] = [];
     let mut i: int = 0;
     loop {
         if i >= input.length { break; }
@@ -30,7 +30,7 @@ fn relu_array(input: number[]) -> number[] {
     return out;
 }
 
-fn leaky_relu(x: number, alpha: number = 0.01) -> number {
+fn leaky_relu(x: float, alpha: float = 0.01) -> float {
     // Leaky ReLU: x if x > 0, else alpha * x.
     if x > 0 { return x; }
     return alpha * x;
@@ -42,18 +42,18 @@ fn leaky_relu(x: number, alpha: number = 0.01) -> number {
 // (up to 0.12 absolute error, wrong curvature everywhere) make it
 // unsuitable as an activation function — it would produce incorrect
 // gradients and misleading outputs.
-fn step(x: number) -> number {
+fn step(x: float) -> float {
     // Heaviside step function.
     if x >= 0 { return 1; }
     return 0;
 }
 
 // ---- Normalization ----
-fn normalize(input: number[]) -> number[] {
+fn normalize(input: float[]) -> float[] {
     // Min-max normalization to [0, 1] range.
     if input.length == 0 { return []; }
-    let mut min_v: number = input[0];
-    let mut max_v: number = input[0];
+    let mut min_v: float = input[0];
+    let mut max_v: float = input[0];
     let mut i: int = 1;
     loop {
         if i >= input.length { break; }
@@ -63,7 +63,7 @@ fn normalize(input: number[]) -> number[] {
     }
     let range = max_v - min_v;
     if range == 0 { return input; }
-    let mut out: number[] = [];
+    let mut out: float[] = [];
     i = 0;
     loop {
         if i >= input.length { break; }
@@ -73,10 +73,10 @@ fn normalize(input: number[]) -> number[] {
     return out;
 }
 
-fn standardize(input: number[], mean_val: number, std_val: number) -> number[] {
+fn standardize(input: float[], mean_val: float, std_val: float) -> float[] {
     // Z-score standardization: (x - mean) / std.
     if std_val == 0 { return input; }
-    let mut out: number[] = [];
+    let mut out: float[] = [];
     let mut i: int = 0;
     loop {
         if i >= input.length { break; }
@@ -87,11 +87,11 @@ fn standardize(input: number[], mean_val: number, std_val: number) -> number[] {
 }
 
 // ---- Utility ----
-fn argmax(input: number[]) -> number {
+fn argmax(input: float[]) -> int {
     // Index of the maximum value.
     if input.length == 0 { return -1; }
     let mut best_idx: int = 0;
-    let mut best_val: number = input[0];
+    let mut best_val: float = input[0];
     let mut i: int = 1;
     loop {
         if i >= input.length { break; }
@@ -104,11 +104,11 @@ fn argmax(input: number[]) -> number {
     return best_idx;
 }
 
-fn argmin(input: number[]) -> number {
+fn argmin(input: float[]) -> int {
     // Index of the minimum value.
     if input.length == 0 { return -1; }
     let mut best_idx: int = 0;
-    let mut best_val: number = input[0];
+    let mut best_val: float = input[0];
     let mut i: int = 1;
     loop {
         if i >= input.length { break; }
@@ -121,9 +121,9 @@ fn argmin(input: number[]) -> number {
     return best_idx;
 }
 
-fn one_hot(index: number, size: number) -> number[] {
+fn one_hot(index: int, size: int) -> float[] {
     // Create a one-hot encoded vector.
-    let mut out: number[] = [];
+    let mut out: float[] = [];
     let mut i: int = 0;
     loop {
         if i >= size { break; }
@@ -133,7 +133,7 @@ fn one_hot(index: number, size: number) -> number[] {
     return out;
 }
 
-fn clip(x: number, lo: number, hi: number) -> number {
+fn clip(x: float, lo: float, hi: float) -> float {
     // Clip a value to [lo, hi].
     if x < lo { return lo; }
     if x > hi { return hi; }

--- a/capsules/sfn/nn/tests/nn_test.sfn
+++ b/capsules/sfn/nn/tests/nn_test.sfn
@@ -1,122 +1,43 @@
 // Tests for sfn/nn capsule functions.
 //
-// Moved from compiler/tests/unit/nn_test.sfn. Helpers stay inlined here:
-// switching to `import { ... } from "../src/mod"` currently surfaces a
-// duplicate-`declare round` LLVM error caused by the array-indexing
-// lowering. Once that compiler bug is fixed, this file should drop the
-// `_`-prefixed copies and import the real capsule API.
-// -- Helpers copied from sfn/nn --
-fn _relu(x: float) -> float {
-    if x > 0 { return x; }
-    return 0;
-}
+// Imports the real sfn/nn API directly via the sibling src/mod.sfn. The
+// previous version inlined `_`-prefixed helper copies to dodge a
+// duplicate-`declare round` LLVM error that fired when the API used the
+// deprecated number alias; the post-#556 strict-refusal regime plus the
+// float-typed API in #657 lets the real capsule be imported clean.
+import {
+    relu,
+    leaky_relu,
+    step,
+    argmax,
+    argmin,
+    one_hot,
+    clip
+} from "../src/mod";
 
-fn _leaky_relu(x: float, alpha: float) -> float {
-    if x > 0 { return x; }
-    return alpha * x;
-}
-
-fn _step(x: float) -> float {
-    if x >= 0 { return 1; }
-    return 0;
-}
-
-fn _normalize(input: float[]) -> float[] {
-    if input.length == 0 { return []; }
-    let mut min_v: float = input[0];
-    let mut max_v: float = input[0];
-    let mut i: int = 1;
-    loop {
-        if i >= input.length { break; }
-        if input[i] < min_v { min_v = input[i]; }
-        if input[i] > max_v { max_v = input[i]; }
-        i += 1;
-    }
-    let range = max_v - min_v;
-    if range == 0 { return input; }
-    let mut out: float[] = [];
-    i = 0;
-    loop {
-        if i >= input.length { break; }
-        out.push((input[i] - min_v) / range);
-        i += 1;
-    }
-    return out;
-}
-
-fn _argmax(input: float[]) -> int {
-    if input.length == 0 { return -1; }
-    let mut best_idx: int = 0;
-    let mut best_val: float = input[0];
-    let mut i: int = 1;
-    loop {
-        if i >= input.length { break; }
-        if input[i] > best_val {
-            best_val = input[i];
-            best_idx = i;
-        }
-        i += 1;
-    }
-    return best_idx;
-}
-
-fn _argmin(input: float[]) -> int {
-    if input.length == 0 { return -1; }
-    let mut best_idx: int = 0;
-    let mut best_val: float = input[0];
-    let mut i: int = 1;
-    loop {
-        if i >= input.length { break; }
-        if input[i] < best_val {
-            best_val = input[i];
-            best_idx = i;
-        }
-        i += 1;
-    }
-    return best_idx;
-}
-
-fn _one_hot(index: int, size: int) -> float[] {
-    let mut out: float[] = [];
-    let mut i: int = 0;
-    loop {
-        if i >= size { break; }
-        if i == index { out.push(1); } else { out.push(0); }
-        i += 1;
-    }
-    return out;
-}
-
-fn _clip(x: float, lo: float, hi: float) -> float {
-    if x < lo { return lo; }
-    if x > hi { return hi; }
-    return x;
-}
-
-// -- Tests --
 test "nn: relu activation" {
-    assert _relu(5) == 5;
-    assert _relu(0) == 0;
-    assert _relu(-3) == 0;
-    assert _relu(0.5) == 0.5;
+    assert relu(5) == 5;
+    assert relu(0) == 0;
+    assert relu(-3) == 0;
+    assert relu(0.5) == 0.5;
 }
 
 test "nn: leaky_relu activation" {
-    assert _leaky_relu(5, 0.01) == 5;
-    assert _leaky_relu(0, 0.01) == 0;
+    assert leaky_relu(5, 0.01) == 5;
+    assert leaky_relu(0, 0.01) == 0;
     // -3 * 0.01 = -0.03 (use tolerance for floating point)
-    let lr1 = _leaky_relu(-3, 0.01);
+    let lr1 = leaky_relu(-3, 0.01);
     assert lr1 < -0.02 && lr1 > -0.04;
     // -2 * 0.1 = -0.2
-    let lr2 = _leaky_relu(-2, 0.1);
+    let lr2 = leaky_relu(-2, 0.1);
     assert lr2 < -0.19 && lr2 > -0.21;
 }
 
 test "nn: step function" {
-    assert _step(1) == 1;
-    assert _step(0) == 1;
-    assert _step(-1) == 0;
-    assert _step(0.001) == 1;
+    assert step(1) == 1;
+    assert step(0) == 1;
+    assert step(-1) == 0;
+    assert step(0.001) == 1;
 }
 
 test "nn: normalize inline computation" {
@@ -145,21 +66,21 @@ test "nn: normalize inline computation" {
 }
 
 test "nn: argmax returns index of maximum" {
-    assert _argmax([1, 3, 2]) == 1;
-    assert _argmax([5]) == 0;
-    assert _argmax([1, 2, 3, 4, 5]) == 4;
-    assert _argmax([]) == -1;
+    assert argmax([1, 3, 2]) == 1;
+    assert argmax([5]) == 0;
+    assert argmax([1, 2, 3, 4, 5]) == 4;
+    assert argmax([]) == -1;
 }
 
 test "nn: argmin returns index of minimum" {
-    assert _argmin([3, 1, 2]) == 1;
-    assert _argmin([5]) == 0;
-    assert _argmin([5, 4, 3, 2, 1]) == 4;
-    assert _argmin([]) == -1;
+    assert argmin([3, 1, 2]) == 1;
+    assert argmin([5]) == 0;
+    assert argmin([5, 4, 3, 2, 1]) == 4;
+    assert argmin([]) == -1;
 }
 
 test "nn: one_hot encoding" {
-    let oh = _one_hot(2, 5);
+    let oh = one_hot(2, 5);
     assert oh.length == 5;
     assert oh[0] == 0;
     assert oh[1] == 0;
@@ -167,16 +88,16 @@ test "nn: one_hot encoding" {
     assert oh[3] == 0;
     assert oh[4] == 0;
 
-    let oh0 = _one_hot(0, 3);
+    let oh0 = one_hot(0, 3);
     assert oh0[0] == 1;
     assert oh0[1] == 0;
     assert oh0[2] == 0;
 }
 
 test "nn: clip constrains value to range" {
-    assert _clip(5, 0, 10) == 5;
-    assert _clip(-5, 0, 10) == 0;
-    assert _clip(15, 0, 10) == 10;
-    assert _clip(0, 0, 1) == 0;
-    assert _clip(1, 0, 1) == 1;
+    assert clip(5, 0, 10) == 5;
+    assert clip(-5, 0, 10) == 0;
+    assert clip(15, 0, 10) == 10;
+    assert clip(0, 0, 1) == 0;
+    assert clip(1, 0, 1) == 1;
 }


### PR DESCRIPTION
## Summary

- Migrates the 18 `: number` / `-> number` sites in `capsules/sfn/nn/src/mod.sfn` off the deprecated `number` alias per the Slice E.3c architect type-split.
- Drops the `_`-prefixed inline helper copies in `capsules/sfn/nn/tests/nn_test.sfn` and imports the real `sfn/nn` API directly; the duplicate-`declare round` LLVM error that previously blocked this no longer reproduces under the post-#556 strict-refusal regime + float-typed signatures.

Closes #657

## Type split (per architect call)

- `relu`, `leaky_relu`, `step`, `normalize`, `clip`, `relu_array`, `standardize` → `float` (activation / normalization inputs and outputs)
- `argmax`, `argmin` → `int` (return an index)
- `one_hot(index: int, size: int) -> float[]`

## Acceptance Criteria

- [x] `grep -rnE "(: number|-> number)" capsules/sfn/nn/` returns zero matches (modulo any `// alias-coverage`-tagged opt-out).
- [x] `nn_test.sfn` imports `relu`, `argmax`, `one_hot`, etc. directly from `sfn/nn` — no inline helper copies remain.
- [x] `make compile` self-hosts.
- [x] Targeted `build/native/sailfin test capsules/sfn/nn/tests/` passes (all 8 tests).
- [x] `sfn fmt --check capsules/sfn/nn/` clean.
- [x] No new strict-refusal warnings against `sfn/nn` during compilation.
- [ ] Full `make test` regression — running locally; CI will confirm.

## Verification

```bash
ulimit -v 8388608

grep -rnE "(: number|-> number)" capsules/sfn/nn/ | grep -v "// alias-coverage"
# → empty

build/native/sailfin test capsules/sfn/nn/tests/nn_test.sfn
# → PASS  (all 8 tests passed)

build/native/sailfin fmt --check capsules/sfn/nn/
# → clean
```

## Files Changed

- `capsules/sfn/nn/src/mod.sfn` — 18 `: number` / `-> number` sites flipped to `float` / `int` per the type plan.
- `capsules/sfn/nn/tests/nn_test.sfn` — replaced 8 `_`-prefixed inline helpers with a real `import { … } from "../src/mod";` and switched call sites to the un-prefixed names.

## Context

- Parent: #653 (Slice E.3c) · Epic: #424 (Slice E — retire `number`)
- Release tracker: #518 (v0.6.0)
- Predecessor regime: PR #651 (#556 — symmetric int↔float arithmetic refusal)
- Sibling commits in the same slice: #663 (sfn/tensor), #664 (sfn/test), #665 (sfn/cli)

## Notes

The architect's contingency plan (keep inline helpers as `: float` if the import still fires the LLVM bug) wasn't needed — the post-#556 compiler accepts the import cleanly. No new bug filed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01JuCSmvEJ3mq9fbEjshbQzo)_