### PR TITLE
refactor(numeric): migrate sfn/layers off `: number` (Slice E.3c-5)

### DIFF
--- a/capsules/sfn/layers/src/mod.sfn
+++ b/capsules/sfn/layers/src/mod.sfn
@@ -15,14 +15,14 @@
 //   let output = forward(layer, input);
 // ---- Layer types ----
 struct Linear {
-    weights: number[];  // flat [out_features, in_features] row-major
-    biases: number[];  // [out_features]
-    in_features: number;
-    out_features: number;
+    weights: float[];  // flat [out_features, in_features] row-major
+    biases: float[];  // [out_features]
+    in_features: int;
+    out_features: int;
 }
 
 struct ReLULayer {
-    size: number;  // expected input size (for documentation)
+    size: int;  // expected input size (for documentation)
 }
 
 struct SequentialLayer {
@@ -35,23 +35,23 @@ struct SequentialLayer {
 }
 
 // ---- Constructors ----
-fn linear(in_features: number, out_features: number) -> Linear {
+fn linear(in_features: int, out_features: int) -> Linear {
     // Create a linear (fully connected) layer with zero-initialized parameters.
     // In practice, weights should be initialized with small random values.
     // Random initialization will use the `rand` effect once available.
     let weight_count = in_features * out_features;
-    let mut weights: number[] = [];
-    let mut biases: number[] = [];
+    let mut weights: float[] = [];
+    let mut biases: float[] = [];
     let mut i: int = 0;
     loop {
         if i >= weight_count { break; }
-        weights.push(0);
+        weights.push(0.0);
         i += 1;
     }
     i = 0;
     loop {
         if i >= out_features { break; }
-        biases.push(0);
+        biases.push(0.0);
         i += 1;
     }
     return Linear {
@@ -62,7 +62,7 @@ fn linear(in_features: number, out_features: number) -> Linear {
     };
 }
 
-fn relu_layer(size: number) -> ReLULayer {
+fn relu_layer(size: int) -> ReLULayer {
     return ReLULayer { size: size };
 }
 
@@ -71,14 +71,14 @@ fn sequential(linears: Linear[], relu_after: boolean[]) -> SequentialLayer {
 }
 
 // ---- Forward pass ----
-fn forward_linear(layer: Linear, input: number[]) -> number[] {
+fn forward_linear(layer: Linear, input: float[]) -> float[] {
     // Forward pass for a linear layer: output = input * W^T + bias
     // input: [in_features], output: [out_features]
-    let mut output: number[] = [];
-    let mut o: number = 0;
+    let mut output: float[] = [];
+    let mut o: int = 0;
     loop {
         if o >= layer.out_features { break; }
-        let mut val: number = layer.biases[o];
+        let mut val: float = layer.biases[o];
         let mut j: int = 0;
         loop {
             if j >= layer.in_features { break; }
@@ -91,22 +91,24 @@ fn forward_linear(layer: Linear, input: number[]) -> number[] {
     return output;
 }
 
-fn forward_relu(input: number[]) -> number[] {
+fn forward_relu(input: float[]) -> float[] {
     // Apply ReLU activation: max(0, x) for each element.
-    let mut output: number[] = [];
+    let mut output: float[] = [];
     let mut i: int = 0;
     loop {
         if i >= input.length { break; }
-        if input[i] > 0 { output.push(input[i]); } else { output.push(0); }
+        if input[i] > 0 { output.push(input[i]); } else {
+            output.push(0.0);
+        }
         i += 1;
     }
     return output;
 }
 
-fn forward_sequential(model: SequentialLayer, input: number[]) -> number[] {
+fn forward_sequential(model: SequentialLayer, input: float[]) -> float[] {
     // Forward pass through a sequential model.
     // relu_after must have the same length as linears.
-    let mut current: number[] = input;
+    let mut current: float[] = input;
     let mut i: int = 0;
     let n = model.linears.length;
     loop {
@@ -121,7 +123,7 @@ fn forward_sequential(model: SequentialLayer, input: number[]) -> number[] {
 }
 
 // ---- Parameter access ----
-fn parameter_count(layer: Linear) -> number {
+fn parameter_count(layer: Linear) -> int {
     // Total trainable parameters (weights + biases).
     return layer.in_features * layer.out_features + layer.out_features;
 }

--- a/capsules/sfn/layers/tests/layers_test.sfn
+++ b/capsules/sfn/layers/tests/layers_test.sfn
@@ -1,84 +1,20 @@
 // Tests for sfn/layers capsule functions.
 //
-// Moved from compiler/tests/unit/nn_layers_test.sfn. The "nn_" prefix was
-// originally a workaround for the same-name-struct + capsule auto-resolution
-// SIGSEGV documented in docs/proposals/colon-type-annotations.md. The bug
-// no longer reproduces from `capsules/<scope>/<name>/tests/`, so the file
-// is renamed back to its natural `layers_test.sfn` here.
-//
-// Helpers remain inlined: switching to `import { ... } from "../src/mod"`
-// currently surfaces a duplicate-`declare round` LLVM error caused by the
-// array-indexing lowering used in `forward_linear`. Once that compiler bug
-// is fixed, this file should drop the `_`-prefixed copies and import the
-// real capsule API.
-// -- Types and helpers copied from sfn/layers --
-struct Linear {
-    weights: float[];
-    biases: float[];
-    in_features: int;
-    out_features: int;
-}
+// Imports the real sfn/layers API directly via the sibling src/mod.sfn. The
+// previous version inlined `_`-prefixed helper copies to dodge a
+// duplicate-`declare round` LLVM error that fired when the API used the
+// deprecated number alias; the post-#556 strict-refusal regime plus the
+// float-typed API in #658 lets the real capsule be imported clean.
+import {
+    Linear,
+    linear,
+    forward_linear,
+    forward_relu,
+    parameter_count
+} from "../src/mod";
 
-fn _linear(in_features: int, out_features: int) -> Linear {
-    let weight_count = in_features * out_features;
-    let mut weights: float[] = [];
-    let mut biases: float[] = [];
-    let mut i: int = 0;
-    loop {
-        if i >= weight_count { break; }
-        weights.push(0);
-        i += 1;
-    }
-    i = 0;
-    loop {
-        if i >= out_features { break; }
-        biases.push(0);
-        i += 1;
-    }
-    return Linear {
-        weights: weights,
-        biases: biases,
-        in_features: in_features,
-        out_features: out_features
-    };
-}
-
-fn _forward_linear(layer: Linear, input: float[]) -> float[] {
-    let mut output: float[] = [];
-    let mut o: int = 0;
-    loop {
-        if o >= layer.out_features { break; }
-        let mut val: float = layer.biases[o];
-        let mut j: int = 0;
-        loop {
-            if j >= layer.in_features { break; }
-            val = val + input[j] * layer.weights[o * layer.in_features + j];
-            j += 1;
-        }
-        output.push(val);
-        o += 1;
-    }
-    return output;
-}
-
-fn _forward_relu(input: float[]) -> float[] {
-    let mut output: float[] = [];
-    let mut i: int = 0;
-    loop {
-        if i >= input.length { break; }
-        if input[i] > 0 { output.push(input[i]); } else { output.push(0); }
-        i += 1;
-    }
-    return output;
-}
-
-fn _parameter_count(layer: Linear) -> int {
-    return layer.in_features * layer.out_features + layer.out_features;
-}
-
-// -- Tests --
 test "layers: linear constructor creates zero-initialized layer" {
-    let layer = _linear(3, 2);
+    let layer = linear(3, 2);
     assert layer.in_features == 3;
     assert layer.out_features == 2;
     assert layer.weights.length == 6;
@@ -88,21 +24,21 @@ test "layers: linear constructor creates zero-initialized layer" {
 }
 
 test "layers: parameter_count includes weights and biases" {
-    let layer = _linear(3, 2);
+    let layer = linear(3, 2);
     // 3*2 weights + 2 biases = 8
-    assert _parameter_count(layer) == 8;
+    assert parameter_count(layer) == 8;
 
-    let big = _linear(10, 5);
+    let big = linear(10, 5);
     // 10*5 + 5 = 55
-    assert _parameter_count(big) == 55;
+    assert parameter_count(big) == 55;
 }
 
 test "layers: forward_linear with zero weights produces bias output" {
-    let layer = _linear(3, 2);
-    // Fractional literals to match the `: number[]` ABI; post-#599 the
+    let layer = linear(3, 2);
+    // Fractional literals to match the `float[]` ABI; post-#599 the
     // bare-integer `[1, 2, 3]` would lower as `int[]` and mismatch.
     let input = [1.0, 2.0, 3.0];
-    let output = _forward_linear(layer, input);
+    let output = forward_linear(layer, input);
     assert output.length == 2;
     // Zero weights and zero biases => all outputs are 0
     assert output[0] == 0;
@@ -118,7 +54,7 @@ test "layers: forward_linear with custom weights" {
         out_features: 1
     };
     let input = [4.0, 5.0];
-    let output = _forward_linear(layer, input);
+    let output = forward_linear(layer, input);
     // 4*2 + 5*3 + 1 = 8 + 15 + 1 = 24
     assert output.length == 1;
     assert output[0] == 24;
@@ -135,7 +71,7 @@ test "layers: forward_linear with multiple outputs" {
         out_features: 2
     };
     let input = [3.0, 7.0];
-    let output = _forward_linear(layer, input);
+    let output = forward_linear(layer, input);
     assert output.length == 2;
     // output[0] = 3*1 + 7*0 + 10 = 13
     assert output[0] == 13;
@@ -144,7 +80,7 @@ test "layers: forward_linear with multiple outputs" {
 }
 
 test "layers: forward_relu zeroes negative values" {
-    let result = _forward_relu([3.0, -1.0, 0.0, 5.0, -2.0]);
+    let result = forward_relu([3.0, -1.0, 0.0, 5.0, -2.0]);
     assert result.length == 5;
     assert result[0] == 3;
     assert result[1] == 0;
@@ -154,7 +90,7 @@ test "layers: forward_relu zeroes negative values" {
 }
 
 test "layers: forward_relu with all positive values" {
-    let result = _forward_relu([1.0, 2.0, 3.0]);
+    let result = forward_relu([1.0, 2.0, 3.0]);
     assert result[0] == 1;
     assert result[1] == 2;
     assert result[2] == 3;
@@ -169,16 +105,16 @@ test "layers: linear then relu pipeline" {
         out_features: 1
     };
     // input [3, 5] => 3*1 + 5*(-1) + 0 = -2
-    let linear_out = _forward_linear(layer, [3.0, 5.0]);
+    let linear_out = forward_linear(layer, [3.0, 5.0]);
     assert linear_out[0] == -2;
-    let relu_out = _forward_relu(linear_out);
+    let relu_out = forward_relu(linear_out);
     // ReLU(-2) = 0
     assert relu_out[0] == 0;
 
     // input [5, 3] => 5*1 + 3*(-1) + 0 = 2
-    let linear_out2 = _forward_linear(layer, [5.0, 3.0]);
+    let linear_out2 = forward_linear(layer, [5.0, 3.0]);
     assert linear_out2[0] == 2;
-    let relu_out2 = _forward_relu(linear_out2);
+    let relu_out2 = forward_relu(linear_out2);
     // ReLU(2) = 2
     assert relu_out2[0] == 2;
 }


### PR DESCRIPTION
## Summary

- Migrate the 18 `: number` / `-> number` sites in `capsules/sfn/layers/src/mod.sfn` off the deprecated `number` alias.
- Type split per the architect: weights/biases/activations → `float`/`float[]`; layer counts and dims → `int`.
- `layers_test.sfn` drops its inline `_`-prefixed helper copies and imports the real `Linear` / `linear` / `forward_linear` / `forward_relu` / `parameter_count` API — the duplicate-`declare round` LLVM error no longer reproduces post-#556 with a float-typed API (same outcome as sfn/nn in #657).

Closes #658

## Acceptance Criteria

- [x] `grep -rnE "(: number|-> number)" capsules/sfn/layers/` returns zero matches.
- [x] `layers_test.sfn` imports the real API directly — no inline helper copies remain.
- [x] `make compile` self-hosts.
- [x] `make test` passes (including `capsules/sfn/layers/tests/`).
- [x] `sfn fmt --check capsules/sfn/layers/` clean.
- [x] No new compiler warnings against `sfn/layers` under the post-#556 strict-refusal regime.

## Verification

```bash
$ grep -rnE "(: number|-> number)" capsules/sfn/layers/ | grep -v "// alias-coverage"
# (empty)

$ ulimit -v 8388608 && build/native/sailfin test capsules/sfn/layers/tests/
  PASS  (all 8 tests passed)

$ ulimit -v 8388608 && make compile
[compile] build/native/sailfin up-to-date

$ ulimit -v 8388608 && make test
═══ e2e: 60/60 passed, 0 failed ═══
[test] PASS: layers_test.sfn
═══ capsules: 10/10 passed, 0 failed ═══

$ ulimit -v 8388608 && build/native/sailfin fmt --check capsules/sfn/layers/
# (empty)
```

## Files Changed

- `capsules/sfn/layers/src/mod.sfn` — 18 site flips + `0.0` literals for the zero-fill pushes.
- `capsules/sfn/layers/tests/layers_test.sfn` — drop inline `_`-prefixed helpers, import the real API.

## Notes

The Notes-for-Claude contingency (keep helpers as `: float` if the duplicate-`declare round` LLVM error re-fires) did not need to be exercised — the real-API import compiles and tests pass clean, same as sfn/nn after the float-typed migration in #657.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GpQ5c3J8EWuQcZbnKFZGyW)_