### PR TITLE
refactor(numeric): migrate sfn/losses off `: number` (Slice E.3c-6)

### DIFF
--- a/capsules/sfn/losses/src/mod.sfn
+++ b/capsules/sfn/losses/src/mod.sfn
@@ -8,12 +8,12 @@
 //
 //   let loss = mse(predictions, targets);
 // ---- Regression losses ----
-fn mse(predictions: number[], targets: number[]) -> number {
+fn mse(predictions: float[], targets: float[]) -> float {
     // Mean Squared Error: (1/n) * sum((pred - target)^2).
-    if predictions.length == 0 || targets.length == 0 { return 0; }
+    if predictions.length == 0 || targets.length == 0 { return 0.0; }
     let n = predictions.length;
-    if targets.length < n { return 0; }
-    let mut total: number = 0;
+    if targets.length < n { return 0.0; }
+    let mut total: float = 0.0;
     let mut i: int = 0;
     loop {
         if i >= n { break; }
@@ -24,34 +24,34 @@ fn mse(predictions: number[], targets: number[]) -> number {
     return total / (predictions.length as float);
 }
 
-fn mae(predictions: number[], targets: number[]) -> number {
+fn mae(predictions: float[], targets: float[]) -> float {
     // Mean Absolute Error: (1/n) * sum(|pred - target|).
-    if predictions.length == 0 || targets.length == 0 { return 0; }
+    if predictions.length == 0 || targets.length == 0 { return 0.0; }
     let n = predictions.length;
-    if targets.length < n { return 0; }
-    let mut total: number = 0;
+    if targets.length < n { return 0.0; }
+    let mut total: float = 0.0;
     let mut i: int = 0;
     loop {
         if i >= n { break; }
         let diff = predictions[i] - targets[i];
-        if diff < 0 { total = total - diff; } else { total = total + diff; }
+        if diff < 0.0 { total = total - diff; } else { total = total + diff; }
         i += 1;
     }
     return total / (predictions.length as float);
 }
 
-fn huber(predictions: number[], targets: number[], delta: number = 1) -> number {
+fn huber(predictions: float[], targets: float[], delta: float = 1.0) -> float {
     // Huber loss: quadratic for small errors, linear for large errors.
     // Combines the best properties of MSE and MAE.
-    if predictions.length == 0 || targets.length == 0 { return 0; }
+    if predictions.length == 0 || targets.length == 0 { return 0.0; }
     let n = predictions.length;
-    if targets.length < n { return 0; }
-    let mut total: number = 0;
+    if targets.length < n { return 0.0; }
+    let mut total: float = 0.0;
     let mut i: int = 0;
     loop {
         if i >= n { break; }
         let diff = predictions[i] - targets[i];
-        let mut a: number = diff;
+        let mut a: float = diff;
         if a < 0.0 { a = 0.0 - a; }
         if a <= delta { total = total + 0.5 * diff * diff; } else {
             total = total + delta * (a - 0.5 * delta);
@@ -62,18 +62,18 @@ fn huber(predictions: number[], targets: number[], delta: number = 1) -> number 
 }
 
 // ---- Classification losses ----
-fn hinge(predictions: number[], targets: number[]) -> number {
+fn hinge(predictions: float[], targets: float[]) -> float {
     // Hinge loss for binary classification (SVM-style).
     // Targets should be +1 or -1.
-    if predictions.length == 0 || targets.length == 0 { return 0; }
+    if predictions.length == 0 || targets.length == 0 { return 0.0; }
     let n = predictions.length;
-    if targets.length < n { return 0; }
-    let mut total: number = 0;
+    if targets.length < n { return 0.0; }
+    let mut total: float = 0.0;
     let mut i: int = 0;
     loop {
         if i >= n { break; }
         let margin = 1.0 - targets[i] * predictions[i];
-        if margin > 0 { total = total + margin; }
+        if margin > 0.0 { total = total + margin; }
         i += 1;
     }
     return total / (predictions.length as float);
@@ -84,13 +84,13 @@ fn hinge(predictions: number[], targets: number[]) -> number {
 // A placeholder with an incorrect approximation was removed to avoid
 // silently producing wrong training signals.
 // ---- Utility ----
-fn squared_error(prediction: number, target: number) -> number {
+fn squared_error(prediction: float, target: float) -> float {
     // Single-sample squared error.
     let diff = prediction - target;
     return diff * diff;
 }
 
-fn absolute_error(prediction: number, target: number) -> number {
+fn absolute_error(prediction: float, target: float) -> float {
     // Single-sample absolute error.
     let diff = prediction - target;
     if diff < 0.0 { return 0.0 - diff; }

--- a/capsules/sfn/losses/tests/losses_test.sfn
+++ b/capsules/sfn/losses/tests/losses_test.sfn
@@ -3,14 +3,13 @@
 // Moved from compiler/tests/unit/losses_test.sfn. The previous version
 // re-implemented every helper with `_`-prefixed copies; this version imports
 // the real capsule API directly via the sibling src/mod.sfn.
-
 import {
     mse,
     mae,
     huber,
     hinge,
     squared_error,
-    absolute_error,
+    absolute_error
 } from "../src/mod";
 
 test "losses: mse computes mean squared error" {


### PR DESCRIPTION
## Summary
- Flip the 11 `: number` / `-> number` sites in `capsules/sfn/losses/src/mod.sfn` to explicit `float` / `float[]` per the architect split for slice E.3c-6 (predictions, targets, loss values, huber `delta`).
- Promote integer literals (`0`, `1`) to `0.0` / `1.0` in returns and comparisons against `float` operands to satisfy the post-#556 strict-refusal regime.
- Reformat `capsules/sfn/losses/tests/losses_test.sfn` to satisfy `sfn fmt --check capsules/sfn/losses/` (pre-existing drift in the import list and leading blank line; included so the suite passes the directory-wide check called out in the acceptance criteria).

Closes #659

## Acceptance Criteria
- [x] `grep -nE "(: number|-> number)" capsules/sfn/losses/src/mod.sfn` returns zero matches (modulo any `// alias-coverage`-tagged opt-out).
- [x] `make compile` self-hosts.
- [x] `make test` passes (one transient e2e flake on `test_runtime_array.sh` reproduced clean on rerun — unrelated to this change).
- [x] `sfn fmt --check capsules/sfn/losses/` clean.
- [x] No new compiler warnings against `sfn/losses` under the post-#556 strict-refusal regime.

## Verification
```bash
ulimit -v 8388608

grep -nE "(: number|-> number)" capsules/sfn/losses/src/mod.sfn | grep -v "// alias-coverage"
# → empty (exit 1)

make compile          # ✓ built build/native/sailfin
make test-unit        # ✓ all passed (covered by full make test)
make test-integration # ✓ all passed
make test-e2e         # ✓ 60/60 passed on rerun (one prior run hit a transient flake)
make test-capsules    # ✓ 10/10 passed (losses_test.sfn ✓)
build/native/sailfin fmt --check capsules/sfn/losses/   # ✓ clean
```

## Files Changed
- `capsules/sfn/losses/src/mod.sfn` — 11 number→float / int sites flipped, integer-literal promotions for strict-refusal compatibility.
- `capsules/sfn/losses/tests/losses_test.sfn` — formatter pass only (pre-existing drift).

## Notes for reviewer
- One e2e test (`test_runtime_array.sh`) failed in the first `make test` run and passed cleanly when re-run both in isolation and as part of a full `make test-e2e` re-execution. The test does not touch `capsules/sfn/losses` and the failure mode looked timing-related; flagging it here for transparency rather than as a code change.

Generated with Claude Code.

---
_Generated by [Claude Code](https://claude.ai/code/session_015Z6ygFVLNBJqAcFSmmNgtE)_