### PR TITLE
refactor(numeric): migrate small capsules off `: number` (Slice E.3c-9)

### DIFF
--- a/capsules/sfn/http/src/mod.sfn
+++ b/capsules/sfn/http/src/mod.sfn
@@ -2,9 +2,7 @@
 //
 // Provides a unified API for making HTTP requests and serving HTTP responses.
 // All operations require the `net` effect; server operations also require `io`.
-
 // ---- Types ----
-
 struct Request {
     method: string;
     path: string;
@@ -13,28 +11,31 @@ struct Request {
 }
 
 struct Response {
-    status: number;
+    status: int;
     headers: string[];
     body: string;
 }
 
 struct ServerConfig {
-    port: number;
+    port: int;
     host: string;
 }
 
 // ---- Response helpers ----
-
 fn response(body: string) -> Response {
     return Response { status: 200, headers: [], body: body };
 }
 
-fn response_with_status(status: number, body: string) -> Response {
+fn response_with_status(status: int, body: string) -> Response {
     return Response { status: status, headers: [], body: body };
 }
 
 fn json_response(body: string) -> Response {
-    return Response { status: 200, headers: ["Content-Type: application/json"], body: body };
+    return Response {
+        status: 200,
+        headers: ["Content-Type: application/json"],
+        body: body
+    };
 }
 
 fn not_found(body: string = "Not Found") -> Response {
@@ -42,7 +43,6 @@ fn not_found(body: string = "Not Found") -> Response {
 }
 
 // ---- Client ----
-
 fn get(url: string) -> string ![net] {
     // HTTP GET request. Returns the response body as a string.
     return http.get_body(url);
@@ -54,7 +54,6 @@ fn post(url: string, body: string) -> string ![net] {
 }
 
 // ---- Server ----
-
 fn serve(handler: any, config: any?) -> void ![io, net] {
     // Start an HTTP server that dispatches requests to the handler function.
     //

--- a/capsules/sfn/json/src/mod.sfn
+++ b/capsules/sfn/json/src/mod.sfn
@@ -5,7 +5,7 @@
 struct JsonValue {
     kind: string;  // "string", "number", "boolean", "null", "array", "object"
     string_value: string;
-    number_value: number;
+    number_value: float;
     bool_value: boolean;
     items: JsonValue[];  // for arrays
     keys: string[];  // for objects
@@ -24,7 +24,7 @@ fn string_val(value: string) -> JsonValue {
     };
 }
 
-fn number_val(value: number) -> JsonValue {
+fn number_val(value: float) -> JsonValue {
     return JsonValue {
         kind: "number",
         string_value: "",
@@ -320,7 +320,7 @@ fn get_string(obj: JsonValue, key: string) -> string {
     return "";
 }
 
-fn get_number(obj: JsonValue, key: string) -> number {
+fn get_number(obj: JsonValue, key: string) -> float {
     if !strings_equal(obj.kind, "object") { return 0; }
     let mut i: int = 0;
     loop {

--- a/capsules/sfn/log/src/mod.sfn
+++ b/capsules/sfn/log/src/mod.sfn
@@ -12,25 +12,21 @@
 //   let log = logger("http.server");
 //   log_info(log, "listening", ["port", "8080", "tls", "true"]);
 //   // → [INFO] http.server: listening port=8080 tls=true
-
 // ---- Types ----
-
 struct Logger {
     name: string;
 }
 
 // ---- Logger creation ----
-
 fn logger(name: string) -> Logger {
     return Logger { name: name };
 }
 
 // ---- Formatting ----
-
 fn _format_fields(fields: string[]) -> string {
     // Fields are key-value pairs as a flat array: ["key1", "val1", "key2", "val2"]
     let mut out: string = "";
-    let mut i: number = 0;
+    let mut i: int = 0;
     loop {
         if i + 1 >= fields.length { break; }
         out = out + " " + fields[i] + "=" + fields[i + 1];
@@ -41,16 +37,13 @@ fn _format_fields(fields: string[]) -> string {
 
 fn _format_message(level: string, log: Logger, message: string, fields: string[]) -> string {
     let mut line: string = "[" + level + "]";
-    if log.name.length > 0 {
-        line = line + " " + log.name + ":";
-    }
+    if log.name.length > 0 { line = line + " " + log.name + ":"; }
     line = line + " " + message;
     line = line + _format_fields(fields);
     return line;
 }
 
 // ---- Leveled output (with logger) ----
-
 fn log_info(log: Logger, message: string, fields: string[] = []) -> void ![io] {
     print(_format_message("INFO", log, message, fields));
 }
@@ -68,7 +61,6 @@ fn log_debug(log: Logger, message: string, fields: string[] = []) -> void ![io] 
 }
 
 // ---- Convenience: leveled output without a logger ----
-
 fn info(message: string, fields: string[] = []) -> void ![io] {
     let root = Logger { name: "" };
     print(_format_message("INFO", root, message, fields));
@@ -90,8 +82,7 @@ fn debug(message: string, fields: string[] = []) -> void ![io] {
 }
 
 // ---- Timing ----
-
-fn timed(log: Logger, label: string) -> number ![io, clock] {
+fn timed(log: Logger, label: string) -> int ![io, clock] {
     // Start a timed operation. Returns a start timestamp in milliseconds.
     // Pass the result to `timed_end` to log the elapsed time.
     //
@@ -105,7 +96,7 @@ fn timed(log: Logger, label: string) -> number ![io, clock] {
     return start;
 }
 
-fn timed_end(log: Logger, label: string, start_millis: number) -> void ![io, clock] {
+fn timed_end(log: Logger, label: string, start_millis: int) -> void ![io, clock] {
     let elapsed = runtime.monotonic_millis() - start_millis;
     log_info(log, label + " completed", ["ms", number_to_string(elapsed)]);
 }

--- a/capsules/sfn/os/src/mod.sfn
+++ b/capsules/sfn/os/src/mod.sfn
@@ -2,7 +2,6 @@
 //
 // Provides access to environment variables, process execution, and
 // platform information. All operations require the `io` effect.
-
 fn env(name: string) -> string ![io] {
     // Read an environment variable. Returns an empty string if not set.
     return env.get(name);
@@ -13,13 +12,13 @@ fn home() -> string ![io] {
     return env.home();
 }
 
-fn exec(args: string[]) -> number ![io] {
+fn exec(args: string[]) -> int ![io] {
     // Execute a subprocess and wait for it to finish.
     // Returns the exit code (0 = success).
     return process.run(args);
 }
 
-fn exit(code: number) -> void ![io] {
+fn exit(code: int) -> void ![io] {
     // Terminate the current process with the given exit code.
     process.exit(code);
 }

--- a/capsules/sfn/time/src/mod.sfn
+++ b/capsules/sfn/time/src/mod.sfn
@@ -2,19 +2,18 @@
 //
 // Provides sleep, monotonic timing, and scheduling utilities.
 // All operations require the `clock` effect.
-
-fn sleep(milliseconds: number) -> void ![clock] {
+fn sleep(milliseconds: int) -> void ![clock] {
     // Pause execution for the given number of milliseconds.
     runtime.sleep(milliseconds);
 }
 
-fn now_millis() -> number ![clock] {
+fn now_millis() -> int ![clock] {
     // Returns the current monotonic time in milliseconds.
     // Useful for measuring elapsed time, not wall-clock time.
     return runtime.monotonic_millis();
 }
 
-fn elapsed(start_millis: number) -> number ![clock] {
+fn elapsed(start_millis: int) -> int ![clock] {
     // Returns the number of milliseconds elapsed since `start_millis`.
     return runtime.monotonic_millis() - start_millis;
 }


### PR DESCRIPTION
## Summary

Migrates the remaining 14 `: number` / `-> number` sites across five small single-file capsules (`http`, `json`, `log`, `time`, `os`) off the deprecated `number` alias.

- **http** (3 sites): `Response.status`, `ServerConfig.port`, `response_with_status` → `int` (status codes and port numbers).
- **json** (3 sites): `JsonValue.number_value` + the matched accessor pair (`number_val`, `get_number`) → `float`. Per the architect design call recorded on #653, the field name `number_value` is **preserved** and the type is retyped to `float` — alias-equivalent today, zero ABI shape change. Splitting into `int_value` + `float_value` is explicitly out of scope and may land as a follow-up tech-debt issue.
- **log** (3 sites): internal `i` counter, `timed` return, `timed_end` `start_millis` → `int`.
- **time** (3 sites): `sleep`, `now_millis`, `elapsed` → `int` millis.
- **os** (2 sites): `exec` return value, `exit` code → `int`.

Note: all three `json` sites operate on the `number_value` field rather than parser offsets — the file confirms `_parse_number` already accumulates into a `float` local. The grooming note's "most likely int for parser offsets" was a hypothesis to verify on the file; the file shows the dominant semantic is `float`, so all three move together.

Closes #662

## Acceptance Criteria

- [x] `grep -rnE "(: number|-> number)" capsules/sfn/{http,json,log,time,os}/` returns zero matches.
- [x] `JsonValue.number_value` field still exists with the same name; its type is now `float`.
- [x] `make compile` self-hosts.
- [x] `make test` passes.
- [x] `sfn fmt --check capsules/sfn/{http,json,log,time,os}/` clean.
- [x] No new compiler warnings against any of the five capsules under the post-#556 strict-refusal regime.

## Verification

```bash
$ for capsule in http json log time os; do
    grep -nE "(: number|-> number)" capsules/sfn/$capsule/src/mod.sfn | grep -v "// alias-coverage"
  done
# → all five empty

$ ulimit -v 8388608 && make compile
[compile] built build/native/sailfin

$ ulimit -v 8388608 && build/native/sailfin fmt --check capsules/sfn/{http,json,log,time,os}/src/mod.sfn
# exit 0

$ ulimit -v 8388608 && make test
═══ e2e: 60/60 passed, 0 failed ═══
═══ capsules: 10/10 passed, 0 failed ═══
```

## Files Changed

- `capsules/sfn/http/src/mod.sfn` — 3 sites → `int`
- `capsules/sfn/json/src/mod.sfn` — 3 sites → `float` (field name preserved)
- `capsules/sfn/log/src/mod.sfn` — 3 sites → `int`
- `capsules/sfn/time/src/mod.sfn` — 3 sites → `int`
- `capsules/sfn/os/src/mod.sfn` — 2 sites → `int`

Net diff: 5 files changed, 20 insertions(+), 32 deletions(−) — the deletions are formatter-driven collapses of blocks the formatter wanted tightened up while it was already touching these files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_014idcSWeD3aef7Phvbo39ZQ)_