### PR TITLE
refactor(numeric): re-migrate remaining alias-coverage tests post-#599

### DIFF
--- a/compiler/tests/integration/async_advanced_test.sfn
+++ b/compiler/tests/integration/async_advanced_test.sfn
@@ -16,9 +16,9 @@ test "async_adv: string return" {
 // ---------------------------------------------------------------------------
 // Async with computation
 // ---------------------------------------------------------------------------
-async fn compute_sum(n: number) -> number {  // alias-coverage: test relies on int-array literal path pending int[] literal fix
-    let mut total: number = 0;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
-    let mut i: number = 1;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+async fn compute_sum(n: int) -> number {
+    let mut total: int = 0;
+    let mut i: int = 1;
     loop {
         if i > n { break; }
         total += i;
@@ -36,9 +36,7 @@ test "async_adv: computation in async" {
 // ---------------------------------------------------------------------------
 // Multiple async calls with different types
 // ---------------------------------------------------------------------------
-async fn get_number() -> number {  // alias-coverage: test relies on int-array literal path pending int[] literal fix
-    return 42;
-}
+async fn get_number() -> number { return 42; }
 
 async fn get_string() -> string { return "hello"; }
 
@@ -61,13 +59,9 @@ test "async_adv: multiple async different types" {
 // ---------------------------------------------------------------------------
 // Async result used in further computation
 // ---------------------------------------------------------------------------
-async fn compute_a() -> number {  // alias-coverage: test relies on int-array literal path pending int[] literal fix
-    return 10;
-}
+async fn compute_a() -> number { return 10; }
 
-async fn compute_b() -> number {  // alias-coverage: test relies on int-array literal path pending int[] literal fix
-    return 20;
-}
+async fn compute_b() -> number { return 20; }
 
 test "async_adv: results combined" {
     let fa = compute_a();
@@ -81,7 +75,7 @@ test "async_adv: results combined" {
 // ---------------------------------------------------------------------------
 // Async with conditional logic
 // ---------------------------------------------------------------------------
-async fn conditional_async(flag: boolean) -> number {  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+async fn conditional_async(flag: boolean) -> number {
     if flag { return 100; }
     return 0;
 }
@@ -100,11 +94,11 @@ test "async_adv: conditional false" {
 // Async with struct return
 // ---------------------------------------------------------------------------
 struct AsyncResult {
-    value: number;  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+    value: int;
     label: string;
 }
 
-async fn compute_with_label(v: number, l: string) -> AsyncResult {  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+async fn compute_with_label(v: int, l: string) -> AsyncResult {
     return AsyncResult { value: v * 2, label: l };
 }
 
@@ -118,17 +112,11 @@ test "async_adv: struct return" {
 // ---------------------------------------------------------------------------
 // Sequential await pattern
 // ---------------------------------------------------------------------------
-async fn step1() -> number {  // alias-coverage: test relies on int-array literal path pending int[] literal fix
-    return 5;
-}
+async fn step1() -> number { return 5; }
 
-async fn step2(input: number) -> number {  // alias-coverage: test relies on int-array literal path pending int[] literal fix
-    return input * 3;
-}
+async fn step2(input: number) -> number { return input * 3; }
 
-async fn step3(input: number) -> number {  // alias-coverage: test relies on int-array literal path pending int[] literal fix
-    return input + 10;
-}
+async fn step3(input: number) -> number { return input + 10; }
 
 test "async_adv: sequential steps" {
     let f1 = step1();

--- a/compiler/tests/integration/async_await_test.sfn
+++ b/compiler/tests/integration/async_await_test.sfn
@@ -1,10 +1,6 @@
-async fn computeTask1() -> number {  // alias-coverage: test relies on int-array literal path pending int[] literal fix
-    return 21;
-}
+async fn computeTask1() -> number { return 21; }
 
-async fn computeTask2() -> number {  // alias-coverage: test relies on int-array literal path pending int[] literal fix
-    return 21;
-}
+async fn computeTask2() -> number { return 21; }
 
 test "async: await futures" {
     let future1 = computeTask1();

--- a/compiler/tests/integration/async_params_test.sfn
+++ b/compiler/tests/integration/async_params_test.sfn
@@ -1,6 +1,4 @@
-async fn add(x: number, y: number) -> number {  // alias-coverage: test relies on int-array literal path pending int[] literal fix
-    return x + y;
-}
+async fn add(x: int, y: int) -> number { return x + y; }
 
 test "async: params" {
     let fut = add(20, 22);

--- a/compiler/tests/unit/extend_native_functions_inplace_test.sfn
+++ b/compiler/tests/unit/extend_native_functions_inplace_test.sfn
@@ -29,7 +29,7 @@
 // See docs/build-performance.md Phase 1b and the aliasing commentary at
 // lowering_core.sfn:565-578 for the full rationale.
 test "runtime contract: mut binding shares storage with input (no copy)" {
-    let original: number[] = [1, 2, 3];  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+    let original: int[] = [1, 2, 3];
     let mut alias_view = original;
     alias_view.push(4);
     // Read through alias_view so the unused-binding check sees it.
@@ -48,7 +48,7 @@ test "runtime contract: push on array extends in place (amortized)" {
     // regressed to allocate-and-copy, extend_native_functions_inplace
     // would lose its optimization (and its contract — the returned array
     // would no longer alias dst).
-    let arr: number[] = [];  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+    let arr: int[] = [];
     let mut view = arr;
     let mut i: int = 0;
     loop {
@@ -91,8 +91,8 @@ test "runtime contract: appending through returned alias is visible through inpu
 }
 
 test "runtime contract: empty src leaves dst unchanged" {
-    let dst: number[] = [42];  // alias-coverage: test relies on int-array literal path pending int[] literal fix
-    let src: number[] = [];  // alias-coverage: test relies on int-array literal path pending int[] literal fix
+    let dst: int[] = [42];
+    let src: int[] = [];
     let mut out = dst;
     let mut i: int = 0;
     loop {


### PR DESCRIPTION
## Summary

- Removes the `// alias-coverage: test relies on int-array literal path pending int[] literal fix` workaround comments from the four test files that still carried them.
- Flips `: number` → `: int` (and `value: number` → `value: int` on the `AsyncResult` struct field) on lines where the migration is mechanically safe.
- Leaves `step1`/`step2`/`step3` (async_advanced) and `computeTask1`/`computeTask2` (async_await) at `-> number` with `number` params: flipping these exposes two independent pre-existing async-ABI bugs that are out of scope for this issue (see "Notes" below).

Closes #636

## Acceptance Criteria

- [x] `grep -rln "alias-coverage: test relies on int-array literal path pending int\[\] literal fix" compiler/` returns zero matches.
- [x] `make compile` passes (compiler self-hosts).
- [x] `make test` passes (no regressions — unit 99/99, integration 23/23, e2e 60/60, capsules 10/10).
- [x] `sfn fmt --check` clean on every touched `.sfn` file.

## Verification

```bash
$ grep -rln "alias-coverage: test relies on int-array literal path pending int\[\] literal fix" compiler/
(none)

$ ulimit -v 8388608 && make compile
[compile] built build/native/sailfin

$ ulimit -v 8388608 && make test
═══ unit: 99/99 passed, 0 failed ═══
═══ integration: 23/23 passed, 0 failed ═══
═══ e2e: 60/60 passed, 0 failed ═══
═══ capsules: 10/10 passed, 0 failed ═══

$ ulimit -v 8388608 && build/seed/bin/sailfin fmt --check <touched files>
(clean)
```

## Files Changed

- `compiler/tests/integration/async_advanced_test.sfn` — flipped `compute_sum`/`compute_with_label` params, `AsyncResult.value`, local `total`/`i` to `int`; collapsed single-statement async bodies via formatter; tags removed.
- `compiler/tests/integration/async_await_test.sfn` — tags removed; signatures unchanged (kept `-> number`).
- `compiler/tests/integration/async_params_test.sfn` — `add(x: int, y: int) -> number`; tag removed.
- `compiler/tests/unit/extend_native_functions_inplace_test.sfn` — three `number[]` array literals flipped to `int[]`; tags removed.

`pure_assert_smoke_test.sfn` had no remaining `pending int[] literal fix` tags at pickup time, so no change.

## Notes / Surprises (worth recording for future grooming)

1. **Tag drift since grooming.** The issue cited 31 tagged lines across 5 files. At pickup time only 19 remained (and `pure_assert_smoke_test.sfn` had zero). The drift didn't affect the migration — the acceptance criterion is "zero matches", which we hit either way — but `/triage` may want to recheck whether other multi-file tag-removal issues have similar drift.

2. **The verbatim sed in the issue's Verification block is too narrow.** It uses `^fn ` and so silently skips every tagged `async fn` return type. Running the literal sed leaves `-> number` on every async signature even though the issue's English-language scope says "`-> number` → `-> int` on `fn` lines". A future groom of this template should use `^(async )?fn ` (or just `fn ` somewhere on the line) so the actual and intended migrations match.

3. **Two pre-existing async-ABI bugs surfaced when I tried to follow the broader intent and flip async return types and number↔int crossings:**
   - `async fn ... -> int { return <int>; }` fails at `await` — `assert out == 42` fails on `async fn add(x: int, y: int) -> int { return x + y; }`. The future ABI appears to allocate a `number`-sized slot for scalar returns, so reading the result back as `int` produces garbage.
   - When `step1() -> number` is followed by `step2(input: int) -> number`, the `await` of `step1` produces a `number`, and the implicit `number`→`int` coercion at the `step2` param boundary clobbers the value (final assertion `v3 == 25` failed).

   Both of these are independent of #636 (the issue is consistency cleanup, not a bug fix), so this PR sidesteps them by leaving the relevant signatures at `number`. They are worth filing as separate `type:bug` issues — they will block any future attempt to make the async corpus fully `int`-typed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013Y9R6f19Bn75HFw6Bypari)_