### PR TITLE
fix(async): refuse test compile on `[fatal]` ABI primitive mismatch (#675)

### DIFF
--- a/compiler/src/llvm/lowering/entrypoints_tests_writer.sfn
+++ b/compiler/src/llvm/lowering/entrypoints_tests_writer.sfn
@@ -78,7 +78,10 @@ import {
     string_array_contains
 } from "../utils";
 import { emit_llvm_function } from "./emission";
-import { lower_to_llvm_lines_with_parsed_context_for_tests } from "./lowering_core";
+import {
+    has_fatal_lowering_diagnostic,
+    lower_to_llvm_lines_with_parsed_context_for_tests
+} from "./lowering_core";
 import {
     empty_trait_metadata,
     extend_native_enums,
@@ -138,6 +141,14 @@ fn write_llvm_ir_for_tests_from_text_with_context(native_text: string, module_na
         print.err("test llvm: no lines emitted from native text");
         return false;
     }
+    // Refuse to write IR when any lowering pass surfaced a `[fatal]`
+    // diagnostic (issue #675). The non-test entry points
+    // (`write_llvm_ir`, `compile_native_text_to_llvm_file`) already
+    // gate on this — the test path bypassed the gate, so a `[fatal]`
+    // ABI primitive mismatch at a call site (e.g. `number → int`
+    // coercion across an `await` boundary) was emitted to stderr but
+    // then the partial IR ran the corrupted call anyway.
+    if has_fatal_lowering_diagnostic(lowered_lines.diagnostics) { return false; }
     let ir = _join_llvm_lines_linear(lowered_lines.lines);
     if ir.length == 0 {
         print.err("test llvm: empty IR after join from native text");

--- a/compiler/tests/e2e/fixtures/async_coerce_refusal_basic.sfn
+++ b/compiler/tests/e2e/fixtures/async_coerce_refusal_basic.sfn
@@ -1,0 +1,19 @@
+// Fixture for compiler/tests/e2e/test_async_coerce_refusal.sh
+// (issue #675): mixed `number → int` signatures across an `await`
+// boundary must be refused with a `[fatal]` diagnostic and the #556
+// fix-it phrasing, not silently miscompiled.
+async fn step1() -> number { return 5; }
+
+async fn step2(input: int) -> number { return input * 3; }
+
+async fn step3(input: int) -> number { return input + 10; }
+
+test "async coerce refusal: number→int across await" {
+    let f1 = step1();
+    let v1 = await f1;
+    let f2 = step2(v1);
+    let v2 = await f2;
+    let f3 = step3(v2);
+    let v3 = await f3;
+    assert v3 == 25;
+}

--- a/compiler/tests/e2e/fixtures/async_coerce_widen_basic.sfn
+++ b/compiler/tests/e2e/fixtures/async_coerce_widen_basic.sfn
@@ -1,0 +1,22 @@
+// Fixture for compiler/tests/e2e/test_async_coerce_refusal.sh
+// (issue #675): the reverse direction (`int → number`) is widening,
+// which the #556 strict-refusal regime intentionally leaves silent
+// (sitofp) until the residual double-ABI helper descriptors flip.
+// This fixture pins that asymmetry — it must compile cleanly and the
+// assertion must hold, demonstrating that the new fatal-diagnostic
+// gate in `write_llvm_ir_for_tests_from_text_with_context` doesn't
+// over-refuse safe widening.
+async fn produce_int() -> int { return 5; }
+
+async fn double_widening(input: number) -> int {
+    let doubled = input + 3;
+    return doubled as int;
+}
+
+test "async coerce widen: int→number across await" {
+    let f1 = produce_int();
+    let v1 = await f1;
+    let f2 = double_widening(v1);
+    let v2 = await f2;
+    assert v2 == 8;
+}

--- a/compiler/tests/e2e/test_async_coerce_refusal.sh
+++ b/compiler/tests/e2e/test_async_coerce_refusal.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# Regression test for issue #675: the `[fatal]` ABI primitive mismatch
+# diagnostic must halt test-mode compilation, not just print to stderr.
+#
+# Pre-fix, `write_llvm_ir_for_tests_from_text_with_context` (the
+# entrypoint behind `sfn test`) skipped the `has_fatal_lowering_-
+# diagnostic` gate that `write_llvm_ir` and
+# `compile_native_text_to_llvm_file` honor. Result: a `number → int`
+# coercion across an `await` boundary (e.g. `step1() -> number`
+# followed by `step2(input: int)`) emitted the `[fatal]` diagnostic
+# to stderr, then wrote partial IR that ran the corrupted call site
+# anyway — the final assertion observed garbage. The picker for #673
+# hit this and sidestepped by leaving the chain at uniform `number`.
+#
+# This test pins two behaviours:
+#   1. The narrowing case (`number → int`) refuses to compile, exits
+#      non-zero, and surfaces the canonical #556 fix-it phrasing.
+#   2. The widening case (`int → number`) keeps the asymmetric silent
+#      sitofp behaviour — the new gate must not over-refuse.
+#
+# Usage:
+#   compiler/tests/e2e/test_async_coerce_refusal.sh <compiler-binary>
+
+set -euo pipefail
+
+BINARY="${1:?usage: test_async_coerce_refusal.sh <compiler-binary>}"
+BINARY="$(realpath "$BINARY")"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REFUSE_FIXTURE="$SCRIPT_DIR/fixtures/async_coerce_refusal_basic.sfn"
+WIDEN_FIXTURE="$SCRIPT_DIR/fixtures/async_coerce_widen_basic.sfn"
+
+if [ ! -f "$REFUSE_FIXTURE" ]; then
+    echo "[test] FAIL: missing fixture $REFUSE_FIXTURE"
+    exit 1
+fi
+if [ ! -f "$WIDEN_FIXTURE" ]; then
+    echo "[test] FAIL: missing fixture $WIDEN_FIXTURE"
+    exit 1
+fi
+
+PASS=0
+FAIL=0
+
+SCRATCH="$(mktemp -d -t sfn-async-coerce-XXXXXX)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+ulimit -v 8388608 2>/dev/null || true
+
+run_test() {
+    local name="$1"
+    shift
+    if "$@"; then
+        echo "[test] PASS: $name"
+        PASS=$((PASS + 1))
+    else
+        echo "[test] FAIL: $name"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# ---- Narrowing direction (number → int across await): must refuse ----
+test_number_to_int_emits_fatal_and_exits_nonzero() {
+    local out="$SCRATCH/refuse.out"
+    set +e
+    "$BINARY" test "$REFUSE_FIXTURE" > "$out" 2>&1
+    local rc=$?
+    set -e
+    if [ "$rc" -eq 0 ]; then
+        echo "[test]   sfn test exited 0 — compilation should have refused"
+        sed 's/^/[test]     /' "$out" | tail -20
+        return 1
+    fi
+    local missing=0
+    if ! grep -qE "ABI primitive mismatch" "$out"; then
+        echo "[test]   missing 'ABI primitive mismatch' in stderr"
+        missing=$((missing + 1))
+    fi
+    if ! grep -qE "add \`as float\` or \`as int\` to disambiguate" "$out"; then
+        echo "[test]   missing #556 fix-it phrasing in stderr"
+        missing=$((missing + 1))
+    fi
+    if ! grep -qE "callee expects .*\(int\) but caller produced .*\(float\)" "$out"; then
+        echo "[test]   missing int/float kind detail in stderr"
+        missing=$((missing + 1))
+    fi
+    if ! grep -qE "compile failed for" "$out"; then
+        echo "[test]   missing 'compile failed for' refusal marker"
+        missing=$((missing + 1))
+    fi
+    # The assertion in the fixture must never run — if it did, the
+    # gate is bypassed and the value clobber message would surface.
+    if grep -qE "assertion failed" "$out"; then
+        echo "[test]   assertion ran — gate bypassed, IR was written and executed"
+        missing=$((missing + 1))
+    fi
+    return "$missing"
+}
+
+# ---- Widening direction (int → number across await): must compile ----
+test_int_to_number_compiles_and_runs() {
+    local out="$SCRATCH/widen.out"
+    set +e
+    "$BINARY" test "$WIDEN_FIXTURE" > "$out" 2>&1
+    local rc=$?
+    set -e
+    if [ "$rc" -ne 0 ]; then
+        echo "[test]   sfn test exited $rc — widening direction must remain silent"
+        sed 's/^/[test]     /' "$out" | tail -20
+        return 1
+    fi
+    # No fatal diagnostic should surface for the widening direction.
+    if grep -qE "ABI primitive mismatch" "$out"; then
+        echo "[test]   widening direction surfaced ABI mismatch (over-refusal)"
+        return 1
+    fi
+    if ! grep -qE "PASS" "$out"; then
+        echo "[test]   widening fixture did not report PASS"
+        sed 's/^/[test]     /' "$out" | tail -20
+        return 1
+    fi
+    return 0
+}
+
+run_test "number→int across await refuses with #556 fix-it" \
+    test_number_to_int_emits_fatal_and_exits_nonzero
+run_test "int→number across await keeps silent widening" \
+    test_int_to_number_compiles_and_runs
+
+echo "[summary] pass=$PASS fail=$FAIL"
+if [ "$FAIL" -ne 0 ]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

- `write_llvm_ir_for_tests_from_text_with_context` (the entry point behind `sfn test`) skipped the `has_fatal_lowering_diagnostic` gate that the non-test entry points (`write_llvm_ir`, `compile_native_text_to_llvm_file`) already honor. Result: the `[fatal]` ABI primitive-mismatch diagnostic emitted by the #556 strict-refusal regime printed to stderr, then partial IR was written and executed — the silently-corrupted `step2(v1)` call site (the picker's repro from #673) surfaced as a runtime assertion failure instead of a compile-time refusal.
- Add the same gate in the test writer. The asymmetric `int → float` widening still goes through silently (the strict regime intentionally leaves that direction on `sitofp` until the residual double-ABI helper descriptors flip), so the new gate refuses the narrowing direction without over-refusing safe widening.

Closes #675

## Acceptance Criteria

- [x] Regression test added — `compiler/tests/e2e/test_async_coerce_refusal.sh` covers both directions and pins the #556 fix-it phrasing.
- [x] Picker's exact repro now emits a `[fatal]` diagnostic with the #556 fix-it phrasing and exits non-zero (path (b) from the issue).
- [x] `make compile` self-hosts.
- [x] `make test` passes (unit 99/99 + integration 24/24 + e2e 61/61 + capsules 10/10).
- [x] `sfn fmt --check` clean on touched `.sfn` files.

## Verification

```bash
ulimit -v 8388608

# Picker's exact repro now refuses with the canonical fix-it:
cat > /tmp/await_coerce.sfn <<'EOF'
async fn step1() -> number { return 5; }
async fn step2(input: int) -> number { return input * 3; }
async fn step3(input: int) -> number { return input + 10; }

test "async: number→int coercion across await" {
    let f1 = step1(); let v1 = await f1;
    let f2 = step2(v1); let v2 = await f2;
    let f3 = step3(v2); let v3 = await f3;
    assert v3 == 25;
}
EOF
build/native/sailfin test /tmp/await_coerce.sfn
# exit 1; stderr:
#   llvm lowering [fatal]: ABI primitive mismatch: callee expects `i64` (int)
#     but caller produced `double` (float) — add `as float` or `as int` to disambiguate
#   llvm lowering [fatal]: unable to coerce argument 0 (expected `i64`, got `double`) for call to `step2`
#   test runner: compile failed for /tmp/await_coerce.sfn

bash compiler/tests/e2e/test_async_coerce_refusal.sh build/native/sailfin
# [test] PASS: number→int across await refuses with #556 fix-it
# [test] PASS: int→number across await keeps silent widening
# [summary] pass=2 fail=0

make compile
make test
build/native/sailfin fmt --check compiler/src/llvm/lowering/entrypoints_tests_writer.sfn
```

## Files Changed

- `compiler/src/llvm/lowering/entrypoints_tests_writer.sfn` — add the `has_fatal_lowering_diagnostic` gate.
- `compiler/tests/e2e/test_async_coerce_refusal.sh` — new e2e regression test.
- `compiler/tests/e2e/fixtures/async_coerce_refusal_basic.sfn` — narrowing-direction fixture.
- `compiler/tests/e2e/fixtures/async_coerce_widen_basic.sfn` — widening-direction fixture (asymmetric silent path stays silent).

## Notes for the reviewer

- Once this lands, tag `seed-blocker` so the next alpha pin picks up the new gate before any downstream migration relies on it (the issue body called this out under "Required in pinned seed").
- The companion bug (`SailfinFutureInt`) already merged as #677. With this PR landed, the `step1/step2/step3` chain in `compiler/tests/integration/async_advanced_test.sfn` and the `computeTask1/2` pair in `async_await_test.sfn` should be safe to flip to mixed int/number signatures in a follow-up XS issue.


---
_Generated by [Claude Code](https://claude.ai/code/session_012kPztZYhmzcTUbpr64Jw6K)_