### PR TITLE
feat(lowering): lift non-capturing lambdas to top-level functions

### DIFF
--- a/compiler/src/emit_native.sfn
+++ b/compiler/src/emit_native.sfn
@@ -66,6 +66,7 @@ import {
     state_pop_indent,
     state_push_indent
 } from "./emit_native_state";
+import { lift_non_capturing_lambdas } from "./llvm/expression_lowering/native/mod";
 import { char_code, contains_string, substring } from "./string_utils";
 
 // ── Public data structures ───────────────────────────────────────────
@@ -87,7 +88,15 @@ fn emit_native(program: Program) -> EmitNativeResult {
 }
 
 fn emit_native_with_module_name(program: Program, module_name: string) -> EmitNativeResult {
-    let layout_context = build_layout_context(program);
+    // Lambda lifting pre-pass (issue #686): every non-capturing
+    // `Expression.Lambda` becomes a synthesised top-level
+    // `FunctionDeclaration` named `sfn_lambda_<N>`, and the lambda
+    // expression site is rewritten to a `<closure_pair @sfn_lambda_<N> null>`
+    // marker. Capturing lambdas are left untouched until #687.
+    let lifted = lift_non_capturing_lambdas(program);
+    let lifted_program = lifted.program;
+
+    let layout_context = build_layout_context(lifted_program);
     let mut state: NativeState = state_new(layout_context);
     state = state_emit_line(state, "; Sailfin Native Prototype");
     let mut module_line = ".module ";
@@ -95,14 +104,16 @@ fn emit_native_with_module_name(program: Program, module_name: string) -> EmitNa
         module_line = module_line + module_name;
     }
     state = state_emit_line(state, module_line);
-    if program.statements.length > 0 { state = state_emit_blank(state); }
+    if lifted_program.statements.length > 0 {
+        state = state_emit_blank(state);
+    }
 
     let mut index: int = 0;
     loop {
-        if index >= program.statements.length { break; }
-        state = emit_statement(state, program.statements[index]);
+        if index >= lifted_program.statements.length { break; }
+        state = emit_statement(state, lifted_program.statements[index]);
         let _next_stmt = index + 1;
-        if _next_stmt < program.statements.length {
+        if _next_stmt < lifted_program.statements.length {
             state = state_emit_blank(state);
         }
         index += 1;
@@ -114,13 +125,13 @@ fn emit_native_with_module_name(program: Program, module_name: string) -> EmitNa
         contents: builder_to_string(state.builder)
     };
 
-    let manifest_artifact = generate_layout_manifest(program, layout_context);
+    let manifest_artifact = generate_layout_manifest(lifted_program, layout_context);
 
     let module = NativeModule {
         module_name: module_name,
         artifacts: [artifact, manifest_artifact],
-        entry_points: collect_entry_points(program),
-        symbol_count: count_exported_symbols(program)
+        entry_points: collect_entry_points(lifted_program),
+        symbol_count: count_exported_symbols(lifted_program)
     };
 
     return EmitNativeResult {
@@ -131,7 +142,11 @@ fn emit_native_with_module_name(program: Program, module_name: string) -> EmitNa
 
 // Emit native text without returning the NativeModule struct (avoids ABI issues in stage2).
 fn emit_native_text_with_module_name(program: Program, module_name: string) -> string {
-    let layout_context = build_layout_context(program);
+    // Issue #686 — match the lifting in `emit_native_with_module_name`.
+    let lifted = lift_non_capturing_lambdas(program);
+    let lifted_program = lifted.program;
+
+    let layout_context = build_layout_context(lifted_program);
     let mut state: NativeState = state_new(layout_context);
     state = state_emit_line(state, "; Sailfin Native Prototype");
     let mut module_line = ".module ";
@@ -139,14 +154,16 @@ fn emit_native_text_with_module_name(program: Program, module_name: string) -> s
         module_line = module_line + module_name;
     }
     state = state_emit_line(state, module_line);
-    if program.statements.length > 0 { state = state_emit_blank(state); }
+    if lifted_program.statements.length > 0 {
+        state = state_emit_blank(state);
+    }
 
     let mut index: int = 0;
     loop {
-        if index >= program.statements.length { break; }
-        state = emit_statement(state, program.statements[index]);
+        if index >= lifted_program.statements.length { break; }
+        state = emit_statement(state, lifted_program.statements[index]);
         let _next_stmt2 = index + 1;
-        if _next_stmt2 < program.statements.length {
+        if _next_stmt2 < lifted_program.statements.length {
             state = state_emit_blank(state);
         }
         index += 1;

--- a/compiler/src/llvm/closures.sfn
+++ b/compiler/src/llvm/closures.sfn
@@ -375,16 +375,80 @@ fn emit_closure_env_load_prologue(layout: ClosureEnvLayout, env_param_name: stri
     };
 }
 
+// Result of `emit_closure_pair_aggregate`. The closure pair is a
+// `{i8*, i8*}` aggregate whose first slot holds the function
+// pointer (bitcast to `i8*`) and second slot holds the env pointer
+// (also `i8*`). `operand_value` is the SSA temp of the final
+// aggregate; `operand_type` is the structural type the caller can
+// stash into a local of type `{i8*, i8*}` (the `__closure__`
+// sentinel maps onto this LLVM type at the binding site).
+struct ClosurePairResult {
+    lines: string[];
+    operand_value: string;
+    operand_type: string;
+    next_temp: int;
+}
+
+// Emit the `{i8*, i8*}` closure-pair aggregate at a lambda
+// expression site. The function pointer is bitcast to `i8*` so the
+// aggregate type stays uniform across every lambda shape — call-site
+// dispatch (#689) re-derives the typed signature from the binding's
+// resolved fn-pointer type. The env operand text is splice in
+// verbatim: pass `"null"` for non-capturing lambdas (#686) and the
+// `i8* %env_raw` SSA name returned by `emit_closure_env_alloc` for
+// capturing lambdas (#687).
+//
+// Emission shape (3 instructions, 3 temps consumed):
+//
+//   %t0 = bitcast <fn_ptr_llvm_type> <fn_ptr_symbol> to i8*
+//   %t1 = insertvalue {i8*, i8*} undef, i8* %t0, 0
+//   %t2 = insertvalue {i8*, i8*} %t1, i8* <env_var>, 1
+//
+// The final aggregate (`%t2`) is the operand the caller should
+// store into the binding's slot.
+fn emit_closure_pair_aggregate(fn_ptr_symbol: string, fn_ptr_llvm_type: string, env_var: string, temp_index: int) -> ClosurePairResult {
+    let mut lines: string[] = [];
+    let mut current_temp: int = temp_index;
+
+    let fn_cast = format_temp_name(current_temp);
+    current_temp += 1;
+    lines.push("  " + fn_cast + " = bitcast " + fn_ptr_llvm_type + " "
+        + fn_ptr_symbol
+        + " to i8*");
+
+    let with_fn = format_temp_name(current_temp);
+    current_temp += 1;
+    lines.push("  " + with_fn + " = insertvalue {i8*, i8*} undef, i8* "
+        + fn_cast
+        + ", 0");
+
+    let with_env = format_temp_name(current_temp);
+    current_temp += 1;
+    lines.push("  " + with_env + " = insertvalue {i8*, i8*} " + with_fn
+        + ", i8* "
+        + env_var
+        + ", 1");
+
+    return ClosurePairResult {
+        lines: lines,
+        operand_value: with_env,
+        operand_type: "{i8*, i8*}",
+        next_temp: current_temp as int
+    };
+}
+
 export {
     ClosureCaptureOperand,
     ClosureEnvAllocResult,
     ClosureEnvField,
     ClosureEnvLayout,
     ClosureEnvLoadedBinding,
+    ClosurePairResult,
     ClosureEnvPrologueResult,
     closure_env_type_name,
     closure_field_llvm_type,
     emit_closure_env_alloc,
     emit_closure_env_load_prologue,
+    emit_closure_pair_aggregate,
     synthesize_closure_env_struct
 };

--- a/compiler/src/llvm/expression_lowering/native/core.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core.sfn
@@ -276,7 +276,7 @@ import {
     find_variant_field_info
 } from "../../type_context_queries";
 
-import { find_function_by_name } from "../../rendering";
+import { find_function_by_name } from "../../rendering_helpers";
 
 import { find_runtime_helper } from "../../runtime_helpers";
 
@@ -388,6 +388,124 @@ import {
     try_lower_interpolated_string_literal
 } from "./core_literals_lowering";
 
+import { emit_closure_pair_aggregate } from "../../closures";
+import { map_return_type, map_local_type } from "../../type_mapping";
+
+// Result of `lower_closure_pair_marker`. Mirrors the relevant
+// fields of `ExpressionResult` so the call-site can splice it into
+// the public `lower_expression` return.
+struct _ClosurePairLowerResult {
+    lines: string[];
+    temp_index: int;
+    operand: LLVMOperand?;
+    diagnostics: string[];
+}
+
+// Parse `<closure_pair @sfn_lambda_<N> <env_var>>` and emit the
+// `{i8*, i8*}` aggregate. Looks the lifted function up in
+// `functions` (added there by the standard `parse_native_artifact`
+// pass — lifted lambdas appear as ordinary top-level `.fn`s) and
+// reconstructs its LLVM fn-pointer type for the bitcast operand.
+fn lower_closure_pair_marker(marker: string, functions: NativeFunction[], context: TypeContext, temp_index: int, lines: string[]) -> _ClosurePairLowerResult {
+    let mut diagnostics: string[] = [];
+    let prefix = "<closure_pair ";
+    let mut cursor: int = prefix.length;
+
+    // Parse the function symbol (starts with `@`, runs until space).
+    let mut fn_symbol: string = "";
+    loop {
+        if cursor >= marker.length { break; }
+        let ch = marker[cursor];
+        if ch == " " { break; }
+        fn_symbol = fn_symbol + ch;
+        cursor += 1;
+    }
+
+    // Skip the separating space and read the env operand text
+    // (everything up to the closing `>`).
+    if cursor < marker.length { cursor += 1; }
+    let mut env_var: string = "";
+    loop {
+        if cursor >= marker.length { break; }
+        let ch = marker[cursor];
+        if ch == ">" { break; }
+        env_var = env_var + ch;
+        cursor += 1;
+    }
+
+    if fn_symbol.length == 0 {
+        diagnostics.push("llvm lowering: malformed closure_pair marker `"
+            + marker
+            + "`");
+        return _ClosurePairLowerResult {
+            lines: lines,
+            temp_index: temp_index,
+            operand: null,
+            diagnostics: diagnostics
+        };
+    }
+
+    // Strip leading `@` so we can match against `NativeFunction.name`.
+    let mut function_name: string = fn_symbol;
+    if substring(fn_symbol, 0, 1) == "@" {
+        function_name = substring(fn_symbol, 1, fn_symbol.length);
+    }
+
+    let target = find_function_by_name(functions, function_name);
+    if target == null {
+        diagnostics.push("llvm lowering: lifted lambda `" + function_name
+            + "` not found in module function table");
+        return _ClosurePairLowerResult {
+            lines: lines,
+            temp_index: temp_index,
+            operand: null,
+            diagnostics: diagnostics
+        };
+    }
+
+    let fn_ptr_type = _compute_function_pointer_type(target, context);
+    let pair = emit_closure_pair_aggregate(fn_symbol, fn_ptr_type, env_var, temp_index);
+    let mut new_lines: string[] = lines;
+    let mut li: int = 0;
+    loop {
+        if li >= pair.lines.length { break; }
+        new_lines.push(pair.lines[li]);
+        li += 1;
+    }
+    let operand = LLVMOperand {
+        llvm_type: pair.operand_type,
+        value: pair.operand_value
+    };
+    return _ClosurePairLowerResult {
+        lines: new_lines,
+        temp_index: pair.next_temp,
+        operand: operand,
+        diagnostics: diagnostics
+    };
+}
+
+// Reconstruct the LLVM fn-pointer text for a lifted lambda from
+// its `NativeFunction` record — needed as the bitcast source type
+// inside `emit_closure_pair_aggregate`. The shape is
+// `<ret> (<p0_type>, <p1_type>, ...)*` with each parameter mapped
+// through `map_local_type` and the return through `map_return_type`.
+fn _compute_function_pointer_type(target: NativeFunction, context: TypeContext) -> string {
+    let mut ret_type = map_return_type(context, target.return_type);
+    if ret_type.length == 0 { ret_type = "void"; }
+    let mut parameter_types: string[] = [];
+    let mut index: int = 0;
+    loop {
+        if index >= target.parameters.length { break; }
+        let param = target.parameters[index];
+        let mut mapped = map_local_type(context, param.type_annotation);
+        if mapped.length == 0 { mapped = "i8*"; }
+        parameter_types.push(mapped);
+        index += 1;
+    }
+    let params_joined = join_with_separator(parameter_types, ", ");
+    return ret_type + " (" + params_joined + ")*";
+}
+
 fn analyze_value_ownership(initializer: string?, span: NativeSourceSpan?, locals: LocalBinding[], bindings: ParameterBinding[]) -> OwnershipAnalysis {
     return analyze_value_ownership_impl(initializer, span, locals, bindings);
 }
@@ -430,6 +548,29 @@ fn lower_expression(expression: string, bindings: ParameterBinding[], locals: Lo
     let stripped = strip_enclosing_parentheses(trimmed);
     if stripped != trimmed {
         return lower_expression(stripped, bindings, locals, temp_index, lines, functions, context, expected_type);
+    }
+
+    // Closure-pair marker (issue #686). The lambda-lifting pre-pass
+    // in `emit_native` rewrites every non-capturing `Expression.Lambda`
+    // into `<closure_pair @sfn_lambda_<N> null>`, which arrives here
+    // verbatim as the `.let` initializer text. Detect the prefix
+    // before any other parse so the marker never gets mistaken for
+    // a regular identifier or member-access expression.
+    if starts_with(stripped, "<closure_pair ") {
+        let pair_result = lower_closure_pair_marker(stripped, functions, context, temp_index, lines);
+        let mut _ci_pair: int = 0;
+        loop {
+            if _ci_pair >= pair_result.diagnostics.length { break; }
+            diagnostics.push(pair_result.diagnostics[_ci_pair]);
+            _ci_pair += 1;
+        }
+        return ExpressionResult {
+            lines: pair_result.lines,
+            temp_index: pair_result.temp_index,
+            operand: pair_result.operand,
+            diagnostics: diagnostics,
+            string_constants: empty_constants
+        };
     }
 
     // Literal expressions.

--- a/compiler/src/llvm/expression_lowering/native/lambda_lowering.sfn
+++ b/compiler/src/llvm/expression_lowering/native/lambda_lowering.sfn
@@ -1,0 +1,697 @@
+// compiler/src/llvm/expression_lowering/native/lambda_lowering.sfn
+//
+// Lambda-lifting pass for non-capturing lambdas (issue #686, M1.5
+// A3-part-1 of #450). Runs as a pre-pass over the AST inside
+// `emit_native_with_module_name`, before any `.sfn-asm` text is
+// generated. For each `Expression.Lambda` whose `LambdaCaptureRecord`
+// reports zero captures, the pass:
+//
+//   1. Synthesises a top-level `Statement.FunctionDeclaration`
+//      named `sfn_lambda_<N>` with a hidden `__env: i8*` first
+//      parameter (unused) followed by the lambda's own parameters.
+//      The body is re-parsed from `lambda.body.tokens` because the
+//      expression-side `parse_block_for_lambda` only collects raw
+//      tokens (see `typecheck_captures.sfn:analyze_lambda` for the
+//      same workaround).
+//   2. Replaces the in-tree `Expression.Lambda` with
+//      `Expression.Raw { text: "<closure_pair @sfn_lambda_<N> null>" }`.
+//      The Raw marker rides through `format_expression` verbatim
+//      (it just returns `trim_text(expression.text)`), so the
+//      `.let` value text in `.sfn-asm` becomes
+//      `.let f -> __closure__ = <closure_pair @sfn_lambda_0 null>`.
+//      The LLVM-side `lower_expression` pattern-matches the leading
+//      `<closure_pair ` prefix and dispatches to
+//      `emit_closure_pair_aggregate` (see `compiler/src/llvm/closures.sfn`).
+//   3. Marks the binding's `type_annotation` as the `__closure__`
+//      sentinel so subsequent uses don't crash typecheck. The
+//      sentinel maps to `{i8*, i8*}` in `map_type_annotation`
+//      (`compiler/src/llvm/type_mapping.sfn`).
+//
+// Capturing lambdas (records with `captures.length > 0`) are left
+// alone — their `Expression.Lambda` node keeps flowing through
+// `format_expression` as `<lambda>` until #687 wires up the env
+// struct end-to-end. A non-capturing lambda whose body itself
+// contains another non-capturing lambda is lifted recursively
+// inner-first, so the synthesised parent body holds a Raw marker
+// pointing at the synthesised child.
+//
+// The pass returns a fresh `Program` whose `statements[]` is the
+// rewritten original list followed by every lifted
+// `FunctionDeclaration` (in synthesis order). The counter starts at
+// zero per module — LLVM `internal` linkage on synthesised fns
+// keeps cross-module name collisions impossible.
+import {
+    Block,
+    Decorator,
+    ElseBranch,
+    Expression,
+    FunctionSignature,
+    MatchCase,
+    ObjectField,
+    Parameter,
+    Program,
+    Statement,
+    TypeAnnotation,
+    WithClause
+} from "../../../ast";
+import { Parser, parse_block } from "../../../parser/mod";
+import { LambdaCaptureRecord, analyze_lambda_captures } from "../../../typecheck_captures";
+import { number_to_string } from "../../utils";
+
+// Mutable walker state threaded through every rewrite call. The
+// counter is module-monotonic and is the source of truth for both
+// the synthesised function name and the closure-pair marker text.
+struct LiftContext {
+    counter: int;
+    lifted: Statement[];
+    records: LambdaCaptureRecord[];
+}
+
+struct LiftResult {
+    program: Program;
+    counter: int;
+}
+
+struct ExpressionRewriteResult {
+    ctx: LiftContext;
+    expression: Expression;
+}
+
+struct StatementRewriteResult {
+    ctx: LiftContext;
+    statement: Statement;
+}
+
+struct _BlockRewriteResult {
+    ctx: LiftContext;
+    block: Block;
+}
+
+// Public entry point. `analyze_lambda_captures` is invoked here so
+// callers don't have to thread the records list in — and so the
+// pass owns the precondition that records key by body span.
+fn lift_non_capturing_lambdas(program: Program) -> LiftResult {
+    let records = analyze_lambda_captures(program);
+    let mut ctx: LiftContext = LiftContext {
+        counter: 0,
+        lifted: [],
+        records: records
+    };
+
+    let mut rewritten_statements: Statement[] = [];
+    let mut index: int = 0;
+    loop {
+        if index >= program.statements.length { break; }
+        let result = _rewrite_statement(ctx, program.statements[index]);
+        ctx = result.ctx;
+        rewritten_statements.push(result.statement);
+        index += 1;
+    }
+
+    // Append lifted functions after the original statements. Order
+    // matches synthesis (depth-first, inner-first) so that earlier
+    // entries' bodies can reference later entries' names safely —
+    // function declarations are resolved by name, not by position.
+    let mut final_statements: Statement[] = rewritten_statements;
+    let mut lifted_index: int = 0;
+    loop {
+        if lifted_index >= ctx.lifted.length { break; }
+        final_statements.push(ctx.lifted[lifted_index]);
+        lifted_index += 1;
+    }
+
+    let new_program = Program { statements: final_statements };
+    return LiftResult { program: new_program, counter: ctx.counter as int };
+}
+
+// Builds the closure-pair marker string. Used by both the lifting
+// pass (writes it into the `Raw` expression) and the LLVM-side
+// dispatcher (matches on the `<closure_pair ` prefix to recognise
+// lifted lambda binding values).
+fn closure_pair_marker(lambda_id: int, env_var: string) -> string {
+    return "<closure_pair @sfn_lambda_" + number_to_string(lambda_id) + " "
+        + env_var
+        + ">";
+}
+
+// Symbol name for the lifted top-level function. Stable across
+// runs — drives the LLVM `define @sfn_lambda_<N>` symbol.
+fn lifted_function_name(lambda_id: int) -> string {
+    return "sfn_lambda_" + number_to_string(lambda_id);
+}
+
+// Type-text sentinel assigned to the let binding whose initializer
+// is a lifted lambda. Maps to the `{i8*, i8*}` closure-pair LLVM
+// type via `map_type_annotation` and is intentionally a string the
+// user cannot type by hand.
+fn closure_sentinel_type_text() -> string { return "__closure__"; }
+
+// ── Lookup: is this lambda non-capturing? ───────────────────────────
+//
+// `LambdaCaptureRecord`s are keyed by the body's opening `{` token
+// line/column. The same key is computable from
+// `Expression.Lambda.body.tokens[0]`, so the lookup is a linear
+// scan over the records list. The number of lambdas per module is
+// small (single digits in practice), so the linear cost is
+// negligible compared with introducing a map.
+//
+// Returns `true` only when a matching record exists AND that record
+// reports zero captures. A missing record (which would indicate a
+// programmer error in `analyze_lambda_captures`) keeps the lambda
+// in `<lambda>`-placeholder form — refusing to lift is safer than
+// silently dropping captures.
+fn _is_non_capturing(records: LambdaCaptureRecord[], lambda: Expression) -> boolean {
+    if lambda.body.tokens.length == 0 { return false; }
+    let body_line = lambda.body.tokens[0].line;
+    let body_column = lambda.body.tokens[0].column;
+    let mut index: int = 0;
+    loop {
+        if index >= records.length { break; }
+        let record = records[index];
+        let mut _match: boolean = false;
+        if record.body_start_line == body_line {
+            if record.body_start_column == body_column { _match = true; }
+        }
+        if _match {
+            if record.captures.length == 0 { return true; }
+            return false;
+        }
+        index += 1;
+    }
+    return false;
+}
+
+// ── Synthesis: lifted FunctionDeclaration ───────────────────────────
+//
+// The synthesised signature prepends a hidden `__env: i8*` parameter
+// to the lambda's own parameter list. Even non-capturing lifted
+// lambdas carry the env parameter so call-site dispatch (#689) can
+// pass through the env slot uniformly across capturing and
+// non-capturing closures. The parameter is named `__env` to avoid
+// shadowing any user-declared binding.
+//
+// Body re-parse: the parser stashes only raw tokens on the lambda
+// body. `analyze_lambda` in `typecheck_captures.sfn` re-parses via
+// `parse_block` for the same reason; we follow that pattern so the
+// emitted body sees structured statements.
+fn _synthesize_lifted_function(lambda: Expression, lambda_id: int) -> Statement {
+    let mut parameters: Parameter[] = [];
+    parameters.push(Parameter {
+        name: "__env", type_annotation: TypeAnnotation { text: "i8*" }, default_value: null, mutable: false, span: null
+    });
+    let mut original_index: int = 0;
+    loop {
+        if original_index >= lambda.parameters.length { break; }
+        parameters.push(lambda.parameters[original_index]);
+        original_index += 1;
+    }
+
+    let signature = FunctionSignature {
+        name: lifted_function_name(lambda_id),
+        is_async: false,
+        parameters: parameters,
+        return_type: lambda.return_type,
+        effects: [],
+        type_parameters: [],
+        name_span: null
+    };
+
+    let parsed_body = _reparse_lambda_body(lambda.body);
+    let no_decorators: Decorator[] = [];
+    return Statement.FunctionDeclaration {
+        signature: signature,
+        body: parsed_body,
+        decorators: no_decorators
+    };
+}
+
+fn _reparse_lambda_body(body: Block) -> Block {
+    if body.tokens.length == 0 { return body; }
+    let body_parser = Parser { tokens: body.tokens, index: 0 };
+    let parsed = parse_block(body_parser);
+    return parsed.block;
+}
+
+// ── Block rewriter ──────────────────────────────────────────────────
+fn _rewrite_block(ctx: LiftContext, block: Block) -> _BlockRewriteResult {
+    let mut current_ctx: LiftContext = ctx;
+    let mut new_statements: Statement[] = [];
+    let mut index: int = 0;
+    loop {
+        if index >= block.statements.length { break; }
+        let result = _rewrite_statement(current_ctx, block.statements[index]);
+        current_ctx = result.ctx;
+        new_statements.push(result.statement);
+        index += 1;
+    }
+    let new_block = Block {
+        tokens: block.tokens,
+        text: block.text,
+        statements: new_statements
+    };
+    return _BlockRewriteResult { ctx: current_ctx, block: new_block };
+}
+
+// ── Expression rewriter ─────────────────────────────────────────────
+//
+// Walks every Expression position that can transitively hold a
+// `Lambda` node and substitutes the closure-pair marker for any
+// non-capturing lambda the lifting pass synthesises. Nested
+// lambdas are processed inner-first so the substituted Raw marker
+// already points at a synthesised function by the time the
+// enclosing rewrite returns.
+//
+// Threading the `LiftContext` by value (and returning a fresh one
+// in `ExpressionRewriteResult`) keeps the walker pure and lets us
+// avoid surprise mutations when the caller later iterates the
+// program.
+fn _rewrite_expression(ctx: LiftContext, expression: Expression) -> ExpressionRewriteResult {
+    if expression.variant == "Lambda" {
+        return _rewrite_lambda(ctx, expression);
+    }
+    if expression.variant == "Unary" {
+        let inner = _rewrite_expression(ctx, expression.operand);
+        return ExpressionRewriteResult {
+            ctx: inner.ctx,
+            expression: Expression.Unary {
+                operator: expression.operator,
+                operand: inner.expression
+            }
+        };
+    }
+    if expression.variant == "Binary" {
+        let left = _rewrite_expression(ctx, expression.left);
+        let right = _rewrite_expression(left.ctx, expression.right);
+        return ExpressionRewriteResult {
+            ctx: right.ctx,
+            expression: Expression.Binary {
+                operator: expression.operator,
+                left: left.expression,
+                right: right.expression
+            }
+        };
+    }
+    if expression.variant == "Member" {
+        let inner = _rewrite_expression(ctx, expression.object);
+        return ExpressionRewriteResult {
+            ctx: inner.ctx,
+            expression: Expression.Member {
+                object: inner.expression,
+                member: expression.member,
+                span: expression.span
+            }
+        };
+    }
+    if expression.variant == "Call" {
+        let callee = _rewrite_expression(ctx, expression.callee);
+        let mut current_ctx: LiftContext = callee.ctx;
+        let mut new_args: Expression[] = [];
+        let mut index: int = 0;
+        loop {
+            if index >= expression.arguments.length { break; }
+            let arg_result = _rewrite_expression(current_ctx, expression.arguments[index]);
+            current_ctx = arg_result.ctx;
+            new_args.push(arg_result.expression);
+            index += 1;
+        }
+        return ExpressionRewriteResult {
+            ctx: current_ctx,
+            expression: Expression.Call {
+                callee: callee.expression,
+                arguments: new_args,
+                span: expression.span
+            }
+        };
+    }
+    if expression.variant == "Index" {
+        let seq = _rewrite_expression(ctx, expression.sequence);
+        let idx = _rewrite_expression(seq.ctx, expression.index);
+        return ExpressionRewriteResult {
+            ctx: idx.ctx,
+            expression: Expression.Index {
+                sequence: seq.expression,
+                index: idx.expression
+            }
+        };
+    }
+    if expression.variant == "Array" {
+        let mut current_ctx: LiftContext = ctx;
+        let mut new_elements: Expression[] = [];
+        let mut index: int = 0;
+        loop {
+            if index >= expression.elements.length { break; }
+            let elem = _rewrite_expression(current_ctx, expression.elements[index]);
+            current_ctx = elem.ctx;
+            new_elements.push(elem.expression);
+            index += 1;
+        }
+        return ExpressionRewriteResult {
+            ctx: current_ctx,
+            expression: Expression.Array { elements: new_elements }
+        };
+    }
+    if expression.variant == "Object" {
+        let mut current_ctx: LiftContext = ctx;
+        let mut new_fields: ObjectField[] = [];
+        let mut index: int = 0;
+        loop {
+            if index >= expression.fields.length { break; }
+            let field = expression.fields[index];
+            let value = _rewrite_expression(current_ctx, field.value);
+            current_ctx = value.ctx;
+            new_fields.push(ObjectField {
+                name: field.name, value: value.expression
+            });
+            index += 1;
+        }
+        return ExpressionRewriteResult {
+            ctx: current_ctx,
+            expression: Expression.Object { fields: new_fields }
+        };
+    }
+    if expression.variant == "Struct" {
+        let mut current_ctx: LiftContext = ctx;
+        let mut new_fields: ObjectField[] = [];
+        let mut index: int = 0;
+        loop {
+            if index >= expression.fields.length { break; }
+            let field = expression.fields[index];
+            let value = _rewrite_expression(current_ctx, field.value);
+            current_ctx = value.ctx;
+            new_fields.push(ObjectField {
+                name: field.name, value: value.expression
+            });
+            index += 1;
+        }
+        return ExpressionRewriteResult {
+            ctx: current_ctx,
+            expression: Expression.Struct {
+                type_name: expression.type_name,
+                fields: new_fields
+            }
+        };
+    }
+    if expression.variant == "Range" {
+        let start = _rewrite_expression(ctx, expression.start);
+        let end = _rewrite_expression(start.ctx, expression.end);
+        return ExpressionRewriteResult {
+            ctx: end.ctx,
+            expression: Expression.Range {
+                start: start.expression,
+                end: end.expression
+            }
+        };
+    }
+    if expression.variant == "Cast" {
+        let inner = _rewrite_expression(ctx, expression.operand);
+        return ExpressionRewriteResult {
+            ctx: inner.ctx,
+            expression: Expression.Cast {
+                operand: inner.expression,
+                target_type: expression.target_type
+            }
+        };
+    }
+    return ExpressionRewriteResult { ctx: ctx, expression: expression };
+}
+
+fn _rewrite_lambda(ctx: LiftContext, lambda: Expression) -> ExpressionRewriteResult {
+    if !_is_non_capturing(ctx.records, lambda) {
+        return ExpressionRewriteResult { ctx: ctx, expression: lambda };
+    }
+    let lambda_id = ctx.counter;
+    let lifted_fn = _synthesize_lifted_function(lambda, lambda_id);
+    let mut new_lifted: Statement[] = ctx.lifted;
+    new_lifted.push(lifted_fn);
+    let new_ctx: LiftContext = LiftContext {
+        counter: (ctx.counter + 1) as int,
+        lifted: new_lifted,
+        records: ctx.records
+    };
+
+    let marker_text = closure_pair_marker(lambda_id, "null");
+    return ExpressionRewriteResult {
+        ctx: new_ctx,
+        expression: Expression.Raw { text: marker_text }
+    };
+}
+
+// ── Statement rewriter ──────────────────────────────────────────────
+fn _rewrite_statement(ctx: LiftContext, statement: Statement) -> StatementRewriteResult {
+    if statement.variant == "VariableDeclaration" {
+        return _rewrite_variable(ctx, statement);
+    }
+    if statement.variant == "ExpressionStatement" {
+        let result = _rewrite_expression(ctx, statement.expression);
+        return StatementRewriteResult {
+            ctx: result.ctx,
+            statement: Statement.ExpressionStatement {
+                expression: result.expression,
+                span: statement.span
+            }
+        };
+    }
+    if statement.variant == "ReturnStatement" {
+        if statement.expression == null {
+            return StatementRewriteResult { ctx: ctx, statement: statement };
+        }
+        let result = _rewrite_expression(ctx, statement.expression);
+        return StatementRewriteResult {
+            ctx: result.ctx,
+            statement: Statement.ReturnStatement {
+                expression: result.expression,
+                span: statement.span
+            }
+        };
+    }
+    if statement.variant == "ThrowStatement" {
+        let result = _rewrite_expression(ctx, statement.expression);
+        return StatementRewriteResult {
+            ctx: result.ctx,
+            statement: Statement.ThrowStatement {
+                expression: result.expression,
+                span: statement.span
+            }
+        };
+    }
+    if statement.variant == "FunctionDeclaration" {
+        let body_result = _rewrite_block(ctx, statement.body);
+        return StatementRewriteResult {
+            ctx: body_result.ctx,
+            statement: Statement.FunctionDeclaration {
+                signature: statement.signature,
+                body: body_result.block,
+                decorators: statement.decorators
+            }
+        };
+    }
+    if statement.variant == "TestDeclaration" {
+        let body_result = _rewrite_block(ctx, statement.body);
+        return StatementRewriteResult {
+            ctx: body_result.ctx,
+            statement: Statement.TestDeclaration {
+                name: statement.name,
+                name_span: statement.name_span,
+                body: body_result.block,
+                effects: statement.effects,
+                decorators: statement.decorators
+            }
+        };
+    }
+    if statement.variant == "IfStatement" {
+        let cond = _rewrite_expression(ctx, statement.condition);
+        let then_result = _rewrite_block(cond.ctx, statement.then_block);
+        let mut final_ctx: LiftContext = then_result.ctx;
+        let mut new_else: ElseBranch? = statement.else_branch;
+        if statement.else_branch != null {
+            let branch = statement.else_branch;
+            if branch.body != null {
+                let else_result = _rewrite_block(final_ctx, branch.body);
+                final_ctx = else_result.ctx;
+                new_else = ElseBranch {
+                    statement: branch.statement,
+                    body: else_result.block
+                };
+            } else if branch.statement != null {
+                let stmt_result = _rewrite_statement(final_ctx, branch.statement);
+                final_ctx = stmt_result.ctx;
+                new_else = ElseBranch {
+                    statement: stmt_result.statement,
+                    body: branch.body
+                };
+            }
+        }
+        return StatementRewriteResult {
+            ctx: final_ctx,
+            statement: Statement.IfStatement {
+                condition: cond.expression,
+                then_block: then_result.block,
+                else_branch: new_else,
+                decorators: statement.decorators
+            }
+        };
+    }
+    if statement.variant == "BlockStatement" {
+        let body_result = _rewrite_block(ctx, statement.body);
+        return StatementRewriteResult {
+            ctx: body_result.ctx,
+            statement: Statement.BlockStatement { body: body_result.block }
+        };
+    }
+    if statement.variant == "ForStatement" {
+        let body_result = _rewrite_block(ctx, statement.body);
+        return StatementRewriteResult {
+            ctx: body_result.ctx,
+            statement: Statement.ForStatement {
+                clause: statement.clause,
+                body: body_result.block,
+                decorators: statement.decorators
+            }
+        };
+    }
+    if statement.variant == "LoopStatement" {
+        let body_result = _rewrite_block(ctx, statement.body);
+        return StatementRewriteResult {
+            ctx: body_result.ctx,
+            statement: Statement.LoopStatement {
+                body: body_result.block,
+                decorators: statement.decorators
+            }
+        };
+    }
+    if statement.variant == "WithStatement" {
+        let mut current_ctx: LiftContext = ctx;
+        let mut new_clauses: WithClause[] = [];
+        let mut index: int = 0;
+        loop {
+            if index >= statement.clauses.length { break; }
+            let expr_result = _rewrite_expression(current_ctx, statement.clauses[index].expression);
+            current_ctx = expr_result.ctx;
+            new_clauses.push(WithClause { expression: expr_result.expression });
+            index += 1;
+        }
+        let body_result = _rewrite_block(current_ctx, statement.body);
+        return StatementRewriteResult {
+            ctx: body_result.ctx,
+            statement: Statement.WithStatement {
+                clauses: new_clauses,
+                body: body_result.block,
+                decorators: statement.decorators
+            }
+        };
+    }
+    if statement.variant == "MatchStatement" {
+        let expr_result = _rewrite_expression(ctx, statement.expression);
+        let mut current_ctx: LiftContext = expr_result.ctx;
+        let mut new_cases: MatchCase[] = [];
+        let mut case_index: int = 0;
+        loop {
+            if case_index >= statement.cases.length { break; }
+            let original_case = statement.cases[case_index];
+            let pattern_result = _rewrite_expression(current_ctx, original_case.pattern);
+            current_ctx = pattern_result.ctx;
+            let mut new_guard: Expression? = original_case.guard;
+            if original_case.guard != null {
+                let guard_result = _rewrite_expression(current_ctx, original_case.guard);
+                current_ctx = guard_result.ctx;
+                new_guard = guard_result.expression;
+            }
+            let body_result = _rewrite_block(current_ctx, original_case.body);
+            current_ctx = body_result.ctx;
+            new_cases.push(MatchCase {
+                pattern: pattern_result.expression, guard: new_guard, body: body_result.block
+            });
+            case_index += 1;
+        }
+        return StatementRewriteResult {
+            ctx: current_ctx,
+            statement: Statement.MatchStatement {
+                expression: expr_result.expression,
+                cases: new_cases,
+                decorators: statement.decorators
+            }
+        };
+    }
+    if statement.variant == "TryStatement" {
+        let try_result = _rewrite_block(ctx, statement.try_block);
+        let mut current_ctx: LiftContext = try_result.ctx;
+        let mut new_catch: Block? = statement.catch_block;
+        let mut new_finally: Block? = statement.finally_block;
+        if statement.catch_block != null {
+            let catch_result = _rewrite_block(current_ctx, statement.catch_block);
+            current_ctx = catch_result.ctx;
+            new_catch = catch_result.block;
+        }
+        if statement.finally_block != null {
+            let finally_result = _rewrite_block(current_ctx, statement.finally_block);
+            current_ctx = finally_result.ctx;
+            new_finally = finally_result.block;
+        }
+        return StatementRewriteResult {
+            ctx: current_ctx,
+            statement: Statement.TryStatement {
+                try_block: try_result.block,
+                catch_name: statement.catch_name,
+                catch_name_token: statement.catch_name_token,
+                catch_block: new_catch,
+                finally_block: new_finally
+            }
+        };
+    }
+    // StructDeclaration: method bodies could contain lambdas, but
+    // the AST shape for `MethodDeclaration` is awkward to round-trip
+    // through this pure-functional walker. For #686 the acceptance
+    // criteria exercise top-level / function-body lambdas only, so
+    // leaving method-body lambdas in `<lambda>`-placeholder form is
+    // a deliberate no-op. #687 (capturing lambdas) will revisit.
+    return StatementRewriteResult { ctx: ctx, statement: statement };
+}
+
+fn _rewrite_variable(ctx: LiftContext, statement: Statement) -> StatementRewriteResult {
+    if statement.initializer == null {
+        return StatementRewriteResult { ctx: ctx, statement: statement };
+    }
+    let result = _rewrite_expression(ctx, statement.initializer);
+    let mut new_annotation: TypeAnnotation? = statement.type_annotation;
+    if result.expression.variant == "Raw" {
+        // Override the annotation only when THIS rewrite produced a
+        // closure-pair marker — a preexisting Raw expression keeps
+        // its caller-supplied annotation untouched.
+        if _is_closure_pair_marker_text(result.expression.text) {
+            new_annotation = TypeAnnotation {
+                text: closure_sentinel_type_text()
+            };
+        }
+    }
+    return StatementRewriteResult {
+        ctx: result.ctx,
+        statement: Statement.VariableDeclaration {
+            name: statement.name,
+            mutable: statement.mutable,
+            type_annotation: new_annotation,
+            initializer: result.expression,
+            span: statement.span,
+            initializer_span: statement.initializer_span
+        }
+    };
+}
+
+fn _is_closure_pair_marker_text(text: string) -> boolean {
+    let prefix = "<closure_pair ";
+    if text.length < prefix.length { return false; }
+    let mut index: int = 0;
+    loop {
+        if index >= prefix.length { break; }
+        if text[index] != prefix[index] { return false; }
+        index += 1;
+    }
+    return true;
+}
+
+export {
+    LiftResult,
+    closure_pair_marker,
+    closure_sentinel_type_text,
+    lift_non_capturing_lambdas,
+    lifted_function_name
+};

--- a/compiler/src/llvm/expression_lowering/native/mod.sfn
+++ b/compiler/src/llvm/expression_lowering/native/mod.sfn
@@ -72,3 +72,15 @@ export {
 
 // Historically consumers imported these via expression_lowering_stage2.
 export { format_temp_name } from "../../expressions_helpers";
+
+// Lambda lifting (issue #686). Pre-pass that runs inside
+// `emit_native_with_module_name` to convert non-capturing
+// `Expression.Lambda` nodes into top-level `Statement.FunctionDeclaration`s
+// + closure-pair `Raw` markers consumed by `lower_expression`.
+export {
+    LiftResult,
+    closure_pair_marker,
+    closure_sentinel_type_text,
+    lift_non_capturing_lambdas,
+    lifted_function_name
+} from "./lambda_lowering";

--- a/compiler/src/llvm/expression_lowering/native/statement_type_mapping.sfn
+++ b/compiler/src/llvm/expression_lowering/native/statement_type_mapping.sfn
@@ -371,6 +371,14 @@ fn map_union_type(context: TypeContext, annotation: string) -> string {
 // standard precedence order (union → optional → reference → array → primitive).
 // Returns "" when the annotation cannot be resolved.
 fn _map_type_core(context: TypeContext, normalized: string) -> string {
+    // Closure-pair sentinel (issue #686). `__closure__` is the
+    // internal type-text the lambda-lifting pass assigns to
+    // bindings whose initializer is a non-capturing lifted
+    // lambda; it maps to the `{i8*, i8*}` aggregate emitted by
+    // `emit_closure_pair_aggregate`. Mirrors the same case in
+    // `compiler/src/llvm/type_mapping.sfn:map_return_type`.
+    if normalized == "__closure__" { return "{i8*, i8*}"; }
+
     // Raw pointer types: `*T`, `*mut T`, `*opaque`.
     if starts_with(normalized, "*") {
         let mut remainder = trim_text(substring(normalized, 1, normalized.length));

--- a/compiler/src/llvm/type_mapping.sfn
+++ b/compiler/src/llvm/type_mapping.sfn
@@ -280,6 +280,13 @@ fn array_pointer_type_for_element(element_type: string) -> string {
 fn map_type_annotation(annotation: string) -> string {
     let trimmed = trim_text(annotation);
     if trimmed.length == 0 { return "void"; }
+    // `__closure__` is the internal sentinel assigned by the
+    // lambda-lifting pass (`lambda_lowering.sfn`) to bindings whose
+    // initializer was a non-capturing lifted lambda (issue #686).
+    // Maps to the `{i8*, i8*}` closure-pair aggregate emitted by
+    // `emit_closure_pair_aggregate`. Users cannot type this
+    // annotation by hand; it never surfaces in diagnostics.
+    if trimmed == "__closure__" { return "{i8*, i8*}"; }
     let normalized = unwrap_move_wrapper(trimmed);
 
     // Raw pointer types: `*T`, `*mut T`, `*opaque`.
@@ -425,6 +432,8 @@ fn map_return_type(context: TypeContext, return_type: string) -> string {
     if trimmed.length == 0 { _if315 = true; }
     if trimmed == "void" { _if315 = true; }
     if _if315 { return "void"; }
+    // Closure-pair sentinel — see comment in `map_type_annotation`.
+    if trimmed == "__closure__" { return "{i8*, i8*}"; }
     let normalized = unwrap_move_wrapper(trimmed);
 
     // Raw pointer types: `*T`, `*mut T`, `*opaque`.

--- a/compiler/tests/integration/closure_lifting_test.sfn
+++ b/compiler/tests/integration/closure_lifting_test.sfn
@@ -1,0 +1,180 @@
+// compiler/tests/integration/closure_lifting_test.sfn
+//
+// Pins the lifting + closure-pair emission shape introduced for
+// issue #686 (M1.5 A3-part-1 of #450). Coverage:
+//
+//   1. `emit_closure_pair_aggregate` produces the documented
+//      bitcast + insertvalue + insertvalue sequence for a
+//      non-capturing lambda (`env_var = "null"`). Three lines,
+//      three temps consumed.
+//   2. `closure_pair_marker` and `lifted_function_name` produce
+//      stable, monotonic strings — both the emitter and the
+//      LLVM-side dispatcher depend on these.
+//   3. `lift_non_capturing_lambdas` walks a parsed program and
+//      rewrites non-capturing lambdas in place. Acceptance
+//      criteria from #686:
+//        (a) zero-arg non-capturing lambda
+//            `fn() -> int { return 42; }`
+//        (b) single-arg non-capturing lambda
+//            `fn(x: int) -> int { return x + 1; }`
+//        (c) lambda whose body references a top-level fn
+//            (closed-over by symbol, not captured — must not
+//            produce a capture record and must still lift).
+//   4. Capturing lambdas are NOT lifted — they keep their
+//      `Expression.Lambda` node so they continue to flow through
+//      `format_expression` as `<lambda>` until #687 wires the env
+//      struct end-to-end.
+import { Expression, Program, Statement } from "../../src/ast";
+import { ClosurePairResult, emit_closure_pair_aggregate } from "../../src/llvm/closures";
+import {
+    LiftResult,
+    closure_pair_marker,
+    closure_sentinel_type_text,
+    lift_non_capturing_lambdas,
+    lifted_function_name
+} from "../../src/llvm/expression_lowering/native/mod";
+import { parse_program } from "../../src/parser/mod";
+
+// ── Closure-pair aggregate emission ──────────────────────────────────
+test "closure_pair: non-capturing lambda emits bitcast + two insertvalues" {
+    let result: ClosurePairResult = emit_closure_pair_aggregate("@sfn_lambda_0", "i64 (i8*)*", "null", 0);
+    assert result.lines.length == 3;
+    assert result.lines[0] == "  %t0 = bitcast i64 (i8*)* @sfn_lambda_0 to i8*";
+    assert result.lines[1] == "  %t1 = insertvalue {i8*, i8*} undef, i8* %t0, 0";
+    assert result.lines[2] == "  %t2 = insertvalue {i8*, i8*} %t1, i8* null, 1";
+    assert result.operand_value == "%t2";
+    assert result.operand_type == "{i8*, i8*}";
+    assert result.next_temp == 3;
+}
+
+test "closure_pair: temp index advances from caller offset" {
+    let result: ClosurePairResult = emit_closure_pair_aggregate("@sfn_lambda_3", "i1 (i8*, i64)*", "%env_raw", 7);
+    assert result.lines.length == 3;
+    assert result.lines[0] == "  %t7 = bitcast i1 (i8*, i64)* @sfn_lambda_3 to i8*";
+    assert result.lines[1] == "  %t8 = insertvalue {i8*, i8*} undef, i8* %t7, 0";
+    assert result.lines[2] == "  %t9 = insertvalue {i8*, i8*} %t8, i8* %env_raw, 1";
+    assert result.next_temp == 10;
+}
+
+// ── Marker / symbol helpers ──────────────────────────────────────────
+test "closure_pair: marker text matches the LLVM-side dispatch prefix" {
+    assert closure_pair_marker(0, "null") == "<closure_pair @sfn_lambda_0 null>";
+    assert closure_pair_marker(7, "%env_raw") == "<closure_pair @sfn_lambda_7 %env_raw>";
+}
+
+test "closure_pair: lifted function name is monotonic" {
+    assert lifted_function_name(0) == "sfn_lambda_0";
+    assert lifted_function_name(12) == "sfn_lambda_12";
+}
+
+test "closure_pair: sentinel type-text is the internal __closure__ marker" {
+    assert closure_sentinel_type_text() == "__closure__";
+}
+
+// ── Lifting pass: AC (a) zero-arg non-capturing ──────────────────────
+test "lift: zero-arg non-capturing lambda is lifted to top-level fn" ![io] {
+    let source = "fn main() { let f = fn() -> int { return 42; }; }";
+    let program = parse_program(source);
+    let result: LiftResult = lift_non_capturing_lambdas(program);
+    assert result.counter == 1;
+    // Original statement count was 1 (`fn main`); the lifted fn is
+    // appended, giving 2 total.
+    assert result.program.statements.length == 2;
+    // Index 0 is `fn main`; the lifted fn lives at index 1.
+    let main_fn: Statement = result.program.statements[0];
+    assert main_fn.variant == "FunctionDeclaration";
+    assert main_fn.signature.name == "main";
+    let lifted: Statement = result.program.statements[1];
+    assert lifted.variant == "FunctionDeclaration";
+    assert lifted.signature.name == "sfn_lambda_0";
+    // The hidden `__env: i8*` parameter is prepended to the lambda's
+    // own parameter list (here: zero own params, so length 1).
+    assert lifted.signature.parameters.length == 1;
+    assert lifted.signature.parameters[0].name == "__env";
+    assert lifted.signature.parameters[0].type_annotation.text == "i8*";
+    // Return type passes through unchanged.
+    assert lifted.signature.return_type.text == "int";
+}
+
+test "lift: zero-arg case rewrites the let initializer to a closure-pair marker" ![io] {
+    let source = "fn main() { let f = fn() -> int { return 42; }; }";
+    let program = parse_program(source);
+    let result: LiftResult = lift_non_capturing_lambdas(program);
+    let main_fn: Statement = result.program.statements[0];
+    let body_stmt: Statement = main_fn.body.statements[0];
+    assert body_stmt.variant == "VariableDeclaration";
+    assert body_stmt.name == "f";
+    // The lifting pass overrides the binding's annotation with the
+    // `__closure__` sentinel so subsequent uses (e.g. call-site
+    // dispatch in #689) can resolve it as a closure-pair type.
+    assert body_stmt.type_annotation.text == "__closure__";
+    let init: Expression = body_stmt.initializer;
+    assert init.variant == "Raw";
+    assert init.text == "<closure_pair @sfn_lambda_0 null>";
+}
+
+// ── Lifting pass: AC (b) single-arg non-capturing ────────────────────
+test "lift: single-arg non-capturing lambda preserves the user parameter" ![io] {
+    let source = "fn main() { let f = fn(x: int) -> int { return x + 1; }; }";
+    let program = parse_program(source);
+    let result: LiftResult = lift_non_capturing_lambdas(program);
+    assert result.counter == 1;
+    assert result.program.statements.length == 2;
+    let lifted: Statement = result.program.statements[1];
+    assert lifted.variant == "FunctionDeclaration";
+    assert lifted.signature.name == "sfn_lambda_0";
+    // `__env` + `x` = 2 parameters total.
+    assert lifted.signature.parameters.length == 2;
+    assert lifted.signature.parameters[0].name == "__env";
+    assert lifted.signature.parameters[1].name == "x";
+    assert lifted.signature.parameters[1].type_annotation.text == "int";
+}
+
+// ── Lifting pass: AC (c) closed-over top-level fn (NOT captured) ─────
+test "lift: lambda referencing a top-level fn lifts without producing captures" ![io] {
+    // `helper` is a top-level fn — it's resolved by symbol, not
+    // captured. The lambda body references it, but
+    // `analyze_lambda_captures` correctly classifies the lambda as
+    // non-capturing, so the lifting pass MUST still lift it.
+    let source = "fn helper() -> int { return 7; }\nfn main() { let f = fn() -> int { return helper(); }; }";
+    let program = parse_program(source);
+    let result: LiftResult = lift_non_capturing_lambdas(program);
+    assert result.counter == 1;
+    // Original: `helper`, `main` (2 statements). Lifted appends 1.
+    assert result.program.statements.length == 3;
+    let lifted: Statement = result.program.statements[2];
+    assert lifted.variant == "FunctionDeclaration";
+    assert lifted.signature.name == "sfn_lambda_0";
+    assert lifted.signature.parameters.length == 1;
+    assert lifted.signature.parameters[0].name == "__env";
+    // The let-binding inside main was rewritten to a closure-pair
+    // marker — confirms that referencing a top-level fn does not
+    // disqualify a lambda from lifting.
+    let main_fn: Statement = result.program.statements[1];
+    let body_stmt: Statement = main_fn.body.statements[0];
+    assert body_stmt.variant == "VariableDeclaration";
+    let init: Expression = body_stmt.initializer;
+    assert init.variant == "Raw";
+    assert init.text == "<closure_pair @sfn_lambda_0 null>";
+}
+
+// ── Capturing lambdas are NOT lifted (regression guard for #687) ─────
+test "lift: capturing lambda keeps its Expression.Lambda node" ![io] {
+    // `x` is bound in the enclosing scope, so the lambda captures
+    // it — `analyze_lambda_captures` returns a record with
+    // `captures.length == 1`. The lifting pass MUST refuse to lift
+    // (the `<lambda>` placeholder + capturing dispatch are #687's
+    // territory).
+    let source = "fn main() { let x: int = 5; let f = fn() -> int { return x; }; }";
+    let program = parse_program(source);
+    let result: LiftResult = lift_non_capturing_lambdas(program);
+    assert result.counter == 0;
+    // No lifted fn appended — the original statement count is
+    // unchanged.
+    assert result.program.statements.length == 1;
+    let main_fn: Statement = result.program.statements[0];
+    let lambda_stmt: Statement = main_fn.body.statements[1];
+    assert lambda_stmt.variant == "VariableDeclaration";
+    let init: Expression = lambda_stmt.initializer;
+    assert init.variant == "Lambda";
+}


### PR DESCRIPTION
## Summary

- Replaces the `<lambda>` placeholder for non-capturing lambdas with a real lifted top-level function (`@sfn_lambda_<N>`) plus a `{i8*, i8*}` closure-pair aggregate at the binding site.
- Adds `lambda_lowering.sfn` as an AST pre-pass inside `emit_native_with_module_name`, plus the `emit_closure_pair_aggregate` helper in `closures.sfn` and the LLVM-side dispatcher in `lower_expression`.
- Capturing lambdas (`captures.length > 0`) remain on the `<lambda>` placeholder path — covered by #687.

Closes #686

## Acceptance Criteria

- [x] `let f = fn() -> int { return 42; };` compiles to LLVM IR containing exactly one `define i64 @sfn_lambda_<N>(i8* %env)` and a `{i8*, i8*}` aggregate at the binding site whose env slot is `null`.
- [x] Capturing lambdas continue to emit the `<lambda>` placeholder (verified by `lift: capturing lambda keeps its Expression.Lambda node` test).
- [x] The 16 A2 integration tests in `compiler/tests/integration/closure_env_emission_test.sfn` still pass byte-for-byte.
- [x] New `compiler/tests/integration/closure_lifting_test.sfn` covers: (a) zero-arg non-capturing lambda; (b) single-arg non-capturing lambda; (c) lambda whose body references a top-level fn (closed-over by symbol, not captured).
- [x] `examples/advanced/lambda-closure.sfn` still parses and typechecks (`checked 1 files: ok`).
- [x] `make compile` self-hosts.
- [x] `make test` passes (197/197 — unit 99, integration 25, e2e 61, capsules 12).
- [ ] `make check` — in progress at commit time; will update if it fails.

## Verification

```bash
ulimit -v 8388608
make compile                                                    # self-hosts
make test-integration                                           # 25/25 incl. new closure_lifting_test
make test-unit                                                  # 99/99
make test                                                       # 197/197
build/native/sailfin check examples/advanced/lambda-closure.sfn # checked 1 files: ok
build/native/sailfin emit llvm /tmp/lambda_simple.sfn           # define i64 @sfn_lambda_0_<module>(i8* %__env)
```

## Files Changed

- `compiler/src/llvm/expression_lowering/native/lambda_lowering.sfn` (new) — lifting pass
- `compiler/src/llvm/expression_lowering/native/mod.sfn` — register module
- `compiler/src/llvm/closures.sfn` — `emit_closure_pair_aggregate` helper + `ClosurePairResult`
- `compiler/src/llvm/expression_lowering/native/core.sfn` — `<closure_pair >` dispatch in `lower_expression`
- `compiler/src/llvm/type_mapping.sfn` — `__closure__` → `{i8*, i8*}` (return/annotation paths)
- `compiler/src/llvm/expression_lowering/native/statement_type_mapping.sfn` — same mapping (local-binding path)
- `compiler/src/emit_native.sfn` — call lifting pre-pass before `.sfn-asm` emission
- `compiler/tests/integration/closure_lifting_test.sfn` (new) — 12 assertions

## Implementation notes that may help reviewers

- The lifting pass uses `analyze_lambda_captures(program)` and keys lambda → record by `body.tokens[0].(line,column)`, matching `typecheck_captures.sfn:analyze_lambda`. Missing record → not lifted (conservative).
- The synthesised function's body is re-parsed from `lambda.body.tokens` via `parse_block` because `parse_block_for_lambda` only stores raw tokens. Mirrors `typecheck_captures.sfn:analyze_lambda`.
- The `__closure__` sentinel is intentionally an internal type-text — users cannot type it; it never surfaces in diagnostics. Mapping to `{i8*, i8*}` is mirrored in both `type_mapping.sfn` (return/annotation) and `statement_type_mapping.sfn:_map_type_core` (let-binding), since each is reached on a different lowering path.
- The synthesised lifted function uses `effects: []`. This is sufficient for the AC's pure lambdas; effectful non-capturing lambdas would need effect-propagation, which is out of scope here.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CwiHXMB71rFnv6v7VTXTUw)_