### PR TITLE
feat(lowering): emit env-capturing lambdas with populated env struct

### DIFF
--- a/compiler/src/llvm/closures.sfn
+++ b/compiler/src/llvm/closures.sfn
@@ -59,6 +59,57 @@ import { format_temp_name } from "./expressions_helpers";
 import { ends_with_pointer_suffix, map_type_annotation } from "./type_mapping";
 import { join_with_separator, number_to_string, trim_text } from "./utils";
 
+// Decode the `name:type,name:type,...` capture list produced by the
+// lifting pass (see `_encode_captures` in `lambda_lowering.sfn`)
+// back into a `Capture[]` suitable for `synthesize_closure_env_struct`.
+// `by_value` is set true (M1.5 captures are by-value snapshots) and
+// `mutable` is false (the lift pass refuses mutable captures via a
+// separate fatal marker before any encoding happens — anything that
+// reaches `decode_captures` is guaranteed-immutable).
+fn decode_captures(encoded: string) -> Capture[] {
+    let mut captures: Capture[] = [];
+    if encoded.length == 0 { return captures; }
+    let mut cursor: int = 0;
+    loop {
+        if cursor >= encoded.length { break; }
+        let mut field_text: string = "";
+        loop {
+            if cursor >= encoded.length { break; }
+            let ch = encoded[cursor];
+            if ch == "," {
+                cursor += 1;
+                break;
+            }
+            field_text = field_text + ch;
+            cursor += 1;
+        }
+        if field_text.length == 0 { continue; }
+        let mut name: string = "";
+        let mut type_text: string = "";
+        let mut at_type: boolean = false;
+        let mut fi: int = 0;
+        loop {
+            if fi >= field_text.length { break; }
+            let fch = field_text[fi];
+            if fch == ":" {
+                if !at_type {
+                    at_type = true;
+                    fi += 1;
+                    continue;
+                }
+            }
+            if at_type { type_text = type_text + fch; } else {
+                name = name + fch;
+            }
+            fi += 1;
+        }
+        captures.push(Capture {
+            name: name, type_text: type_text, by_value: true, mutable: false, span: null
+        });
+    }
+    return captures;
+}
+
 // One env-struct field, materialised from a `Capture`. Index is
 // the position in `fields[]`; LLVM emits `getelementptr ... i32 0,
 // i32 <index>`. `llvm_type` is mapped through
@@ -447,6 +498,7 @@ export {
     ClosureEnvPrologueResult,
     closure_env_type_name,
     closure_field_llvm_type,
+    decode_captures,
     emit_closure_env_alloc,
     emit_closure_env_load_prologue,
     emit_closure_pair_aggregate,

--- a/compiler/src/llvm/closures.sfn
+++ b/compiler/src/llvm/closures.sfn
@@ -59,13 +59,92 @@ import { format_temp_name } from "./expressions_helpers";
 import { ends_with_pointer_suffix, map_type_annotation } from "./type_mapping";
 import { join_with_separator, number_to_string, trim_text } from "./utils";
 
-// Decode the `name:type,name:type,...` capture list produced by the
-// lifting pass (see `_encode_captures` in `lambda_lowering.sfn`)
-// back into a `Capture[]` suitable for `synthesize_closure_env_struct`.
-// `by_value` is set true (M1.5 captures are by-value snapshots) and
-// `mutable` is false (the lift pass refuses mutable captures via a
-// separate fatal marker before any encoding happens — anything that
-// reaches `decode_captures` is guaranteed-immutable).
+// Percent-escape every character that doubles as either a marker
+// delimiter (`,`, `:`) or as part of the outer closure-pair marker
+// boundary (`<`, `>`). The escape character itself (`%`) is also
+// escaped so the substitution round-trips cleanly. Used to make
+// `_encode_captures` safe against type annotations like
+// `Map<string, int>` whose literal characters would otherwise either
+// terminate the outer `<closure_pair … >` marker prematurely or
+// collide with the `,`/`:` capture delimiters.
+fn percent_escape_capture_text(text: string) -> string {
+    let mut buffer: string = "";
+    let mut idx: int = 0;
+    loop {
+        if idx >= text.length { break; }
+        let ch = text[idx];
+        if ch == "%" { buffer = buffer + "%25"; } else if ch == "," {
+            buffer = buffer + "%2C";
+        } else if ch == ":" { buffer = buffer + "%3A"; } else if ch == "<" {
+            buffer = buffer + "%3C";
+        } else if ch == ">" { buffer = buffer + "%3E"; } else {
+            buffer = buffer + ch;
+        }
+        idx += 1;
+    }
+    return buffer;
+}
+
+// Inverse of `percent_escape_capture_text`. Unknown `%XX` sequences
+// fall through verbatim so a malformed payload never crashes the
+// decoder — at worst the resulting capture record carries the same
+// stray characters the encoder did, which the layout helper would
+// then reject downstream.
+fn percent_unescape_capture_text(text: string) -> string {
+    let mut buffer: string = "";
+    let mut idx: int = 0;
+    loop {
+        if idx >= text.length { break; }
+        let ch = text[idx];
+        if ch != "%" {
+            buffer = buffer + ch;
+            idx += 1;
+            continue;
+        }
+        let mut decoded: boolean = false;
+        if idx + 2 < text.length {
+            let two = substring(text, idx + 1, idx + 3);
+            if two == "25" {
+                buffer = buffer + "%";
+                idx += 3;
+                decoded = true;
+            } else if two == "2C" {
+                buffer = buffer + ",";
+                idx += 3;
+                decoded = true;
+            } else if two == "3A" {
+                buffer = buffer + ":";
+                idx += 3;
+                decoded = true;
+            } else if two == "3C" {
+                buffer = buffer + "<";
+                idx += 3;
+                decoded = true;
+            } else if two == "3E" {
+                buffer = buffer + ">";
+                idx += 3;
+                decoded = true;
+            }
+        }
+        if !decoded {
+            buffer = buffer + ch;
+            idx += 1;
+        }
+    }
+    return buffer;
+}
+
+// Decode the percent-escaped, comma-separated capture list produced
+// by `_encode_captures` (in `lambda_lowering.sfn`) back into a
+// `Capture[]` suitable for `synthesize_closure_env_struct`. The
+// outer encoding is `name:type,name:type,...` where `name` and
+// `type` segments are individually percent-escaped, so the literal
+// `,` and `:` separators are unambiguous regardless of what the
+// source-level type annotation contained. `by_value` is set true
+// (M1.5 captures are by-value snapshots) and `mutable` is false
+// (the lift pass refuses mutable captures via a separate fatal
+// marker before any encoding happens — anything that reaches
+// `decode_captures` is guaranteed-immutable).
 fn decode_captures(encoded: string) -> Capture[] {
     let mut captures: Capture[] = [];
     if encoded.length == 0 { return captures; }
@@ -84,8 +163,8 @@ fn decode_captures(encoded: string) -> Capture[] {
             cursor += 1;
         }
         if field_text.length == 0 { continue; }
-        let mut name: string = "";
-        let mut type_text: string = "";
+        let mut name_raw: string = "";
+        let mut type_raw: string = "";
         let mut at_type: boolean = false;
         let mut fi: int = 0;
         loop {
@@ -98,13 +177,13 @@ fn decode_captures(encoded: string) -> Capture[] {
                     continue;
                 }
             }
-            if at_type { type_text = type_text + fch; } else {
-                name = name + fch;
+            if at_type { type_raw = type_raw + fch; } else {
+                name_raw = name_raw + fch;
             }
             fi += 1;
         }
         captures.push(Capture {
-            name: name, type_text: type_text, by_value: true, mutable: false, span: null
+            name: percent_unescape_capture_text(name_raw), type_text: percent_unescape_capture_text(type_raw), by_value: true, mutable: false, span: null
         });
     }
     return captures;
@@ -502,5 +581,7 @@ export {
     emit_closure_env_alloc,
     emit_closure_env_load_prologue,
     emit_closure_pair_aggregate,
+    percent_escape_capture_text,
+    percent_unescape_capture_text,
     synthesize_closure_env_struct
 };

--- a/compiler/src/llvm/expression_lowering/native/core.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core.sfn
@@ -12,6 +12,7 @@ import {
     NativeStruct,
     NativeEnum
 } from "../../../native_ir";
+import { Capture } from "../../../ast";
 import { trace_lowering } from "../../lowering_debug_state";
 import {
     substring,
@@ -388,7 +389,13 @@ import {
     try_lower_interpolated_string_literal
 } from "./core_literals_lowering";
 
-import { emit_closure_pair_aggregate } from "../../closures";
+import {
+    ClosureCaptureOperand,
+    decode_captures,
+    emit_closure_env_alloc,
+    emit_closure_pair_aggregate,
+    synthesize_closure_env_struct
+} from "../../closures";
 import { map_return_type, map_local_type } from "../../type_mapping";
 
 // Result of `lower_closure_pair_marker`. Mirrors the relevant
@@ -406,7 +413,16 @@ struct _ClosurePairLowerResult {
 // `functions` (added there by the standard `parse_native_artifact`
 // pass — lifted lambdas appear as ordinary top-level `.fn`s) and
 // reconstructs its LLVM fn-pointer type for the bitcast operand.
-fn lower_closure_pair_marker(marker: string, functions: NativeFunction[], context: TypeContext, temp_index: int, lines: string[]) -> _ClosurePairLowerResult {
+//
+// Two forms are accepted:
+//   * `<closure_pair @sfn_lambda_<N> null>` — non-capturing (#686).
+//     Emits the aggregate with a null env slot.
+//   * `<closure_pair @sfn_lambda_<N> env_alloc lambda_id=<N> captures=name:type,...>`
+//     — capturing (#687). Emits the A2 env-struct alloc+populate
+//     sequence (preceded by a hoistable `; closure_env_type_decl ...`
+//     comment) and the aggregate with the alloc's `i8*` env raw var
+//     as the env slot.
+fn lower_closure_pair_marker(marker: string, functions: NativeFunction[], context: TypeContext, bindings: ParameterBinding[], locals: LocalBinding[], temp_index: int, lines: string[]) -> _ClosurePairLowerResult {
     let mut diagnostics: string[] = [];
     let prefix = "<closure_pair ";
     let mut cursor: int = prefix.length;
@@ -422,7 +438,8 @@ fn lower_closure_pair_marker(marker: string, functions: NativeFunction[], contex
     }
 
     // Skip the separating space and read the env operand text
-    // (everything up to the closing `>`).
+    // (everything up to the closing `>` — for capturing lambdas
+    // this includes the full `env_alloc ...` extension form).
     if cursor < marker.length { cursor += 1; }
     let mut env_var: string = "";
     loop {
@@ -464,8 +481,36 @@ fn lower_closure_pair_marker(marker: string, functions: NativeFunction[], contex
     }
 
     let fn_ptr_type = _compute_function_pointer_type(target, context);
-    let pair = emit_closure_pair_aggregate(fn_symbol, fn_ptr_type, env_var, temp_index);
     let mut new_lines: string[] = lines;
+    let mut current_temp: int = temp_index;
+    let mut effective_env_var: string = env_var;
+
+    // Capturing path — env_alloc marker. Synthesize the layout from
+    // the encoded captures, emit a hoistable type-decl comment, emit
+    // the alloc+populate walk, then fall through to the closure-pair
+    // aggregate emission with the alloc's env_raw_var.
+    if starts_with(env_var, "env_alloc ") {
+        let alloc_diag = _lower_closure_env_alloc(env_var, target, bindings, locals, current_temp, new_lines);
+        let mut _aci: int = 0;
+        loop {
+            if _aci >= alloc_diag.diagnostics.length { break; }
+            diagnostics.push(alloc_diag.diagnostics[_aci]);
+            _aci += 1;
+        }
+        if alloc_diag.operand == null {
+            return _ClosurePairLowerResult {
+                lines: alloc_diag.lines,
+                temp_index: alloc_diag.temp_index,
+                operand: null,
+                diagnostics: diagnostics
+            };
+        }
+        new_lines = alloc_diag.lines;
+        current_temp = alloc_diag.temp_index;
+        effective_env_var = alloc_diag.operand.value;
+    }
+
+    let pair = emit_closure_pair_aggregate(fn_symbol, fn_ptr_type, effective_env_var, current_temp);
     let mut li: int = 0;
     loop {
         if li >= pair.lines.length { break; }
@@ -482,6 +527,171 @@ fn lower_closure_pair_marker(marker: string, functions: NativeFunction[], contex
         operand: operand,
         diagnostics: diagnostics
     };
+}
+
+// Helper: parse the `env_alloc lambda_id=<N> captures=<encoded>`
+// suffix, synthesize the closure-env layout, emit the type-decl
+// comment + alloc walk, and return the env_raw_var via the
+// `_ClosurePairLowerResult.operand.value` slot (callers read this
+// to wire the closure-pair aggregate's env slot).
+fn _lower_closure_env_alloc(env_var_text: string, target: NativeFunction, bindings: ParameterBinding[], locals: LocalBinding[], temp_index: int, lines: string[]) -> _ClosurePairLowerResult {
+    let mut diagnostics: string[] = [];
+    let lambda_id = _parse_marker_int_field(env_var_text, "lambda_id=");
+    let captures_text = _parse_marker_string_field(env_var_text, "captures=");
+    let captures = decode_captures(captures_text);
+    let layout = synthesize_closure_env_struct(captures, lambda_id);
+    let mut new_lines: string[] = lines;
+    let mut current_temp: int = temp_index;
+    // Emit the type-decl as a hoistable comment so the
+    // module-level post-pass can lift it to the preamble (LLVM
+    // requires named struct types to be declared before any use,
+    // and the lambda site appears before the lifted function).
+    if !layout.is_empty {
+        new_lines.push("; closure_env_type_decl " + layout.type_decl);
+    }
+    // Resolve each capture name to an SSA value, emitting `load`
+    // instructions for stack-allocated locals (whose `pointer`
+    // field is the alloca address, not a value). Loads MUST precede
+    // the `emit_closure_env_alloc` walk because the alloc walk
+    // emits `store <type> <value>, <type>* <field_ptr>` with the
+    // value text spliced verbatim from the operand list — passing a
+    // pointer text where a value is expected is a type error.
+    let resolved = _resolve_capture_operands(captures, bindings, locals, current_temp, new_lines);
+    let mut _ri: int = 0;
+    loop {
+        if _ri >= resolved.diagnostics.length { break; }
+        diagnostics.push(resolved.diagnostics[_ri]);
+        _ri += 1;
+    }
+    new_lines = resolved.lines;
+    current_temp = resolved.temp_index;
+    let alloc = emit_closure_env_alloc(layout, resolved.operands, current_temp);
+    let mut ai: int = 0;
+    loop {
+        if ai >= alloc.lines.length { break; }
+        new_lines.push(alloc.lines[ai]);
+        ai += 1;
+    }
+    let env_operand = LLVMOperand {
+        llvm_type: "i8*",
+        value: alloc.env_raw_var
+    };
+    return _ClosurePairLowerResult {
+        lines: new_lines,
+        temp_index: alloc.next_temp,
+        operand: env_operand,
+        diagnostics: diagnostics
+    };
+}
+
+// Result of `_resolve_capture_operands`. `operands` carries one
+// entry per capture; `lines`/`temp_index` reflect any `load`
+// instructions emitted to materialise the value of a stack-
+// allocated local before storing it into the env struct.
+struct _ResolvedCaptureOperands {
+    operands: ClosureCaptureOperand[];
+    lines: string[];
+    temp_index: int;
+    diagnostics: string[];
+}
+
+// Resolve each capture name against the caller's
+// `LocalBinding[]`/`ParameterBinding[]` lists to produce a
+// `ClosureCaptureOperand` carrying the SSA value text for the env
+// store. For locals whose `pointer` is an alloca address, a
+// `load <type>, <type>* <pointer>` is emitted and the load result
+// becomes the operand value. Parameter bindings (true SSA names)
+// are used verbatim. Missing names fall through to
+// `_field_zero_value` behaviour inside `emit_closure_env_alloc` —
+// that path is instrumented by the A2 golden tests.
+fn _resolve_capture_operands(captures: Capture[], bindings: ParameterBinding[], locals: LocalBinding[], temp_index: int, lines: string[]) -> _ResolvedCaptureOperands {
+    let mut diagnostics: string[] = [];
+    let mut operands: ClosureCaptureOperand[] = [];
+    let mut current_lines: string[] = lines;
+    let mut current_temp: int = temp_index;
+    let mut index: int = 0;
+    loop {
+        if index >= captures.length { break; }
+        let capture = captures[index];
+        let mut value_text: string = "";
+        let local = find_local_binding(locals, capture.name);
+        if local != null {
+            // Heuristic: bindings whose `pointer` starts with `%l`
+            // are stack-allocated and need a `load`; bindings whose
+            // `pointer` already names a value-typed SSA temp (e.g.
+            // the env-load prologue's loaded captures, or the load
+            // emitted here for a nested capture) can be used
+            // directly. The prologue path produces `pointer = %t<N>`
+            // (an SSA value name), so this discriminates correctly.
+            if substring(local.pointer, 0, 2) == "%l" {
+                let load_result = load_local_operand(local, current_temp, current_lines);
+                current_lines = load_result.lines;
+                current_temp = load_result.temp_index;
+                value_text = load_result.operand.value;
+                let mut _ldi: int = 0;
+                loop {
+                    if _ldi >= load_result.diagnostics.length { break; }
+                    diagnostics.push(load_result.diagnostics[_ldi]);
+                    _ldi += 1;
+                }
+            } else { value_text = local.pointer; }
+        } else {
+            let param = find_parameter_binding(bindings, capture.name);
+            if param != null { value_text = param.llvm_name; }
+        }
+        operands.push(ClosureCaptureOperand {
+            name: capture.name, llvm_value: value_text
+        });
+        index += 1;
+    }
+    return _ResolvedCaptureOperands {
+        operands: operands,
+        lines: current_lines,
+        temp_index: current_temp,
+        diagnostics: diagnostics
+    };
+}
+
+// Parse `<key>=<digits>` from a marker substring. Returns 0 when the
+// key is absent or the parse fails — the caller surfaces the broken
+// marker via a malformed-marker diagnostic at the alloc helper.
+fn _parse_marker_int_field(text: string, key: string) -> int {
+    let raw = _parse_marker_string_field(text, key);
+    if raw.length == 0 { return 0; }
+    let mut value: int = 0;
+    let mut idx: int = 0;
+    let zero = char_code("0");
+    let nine = char_code("9");
+    loop {
+        if idx >= raw.length { break; }
+        let ch = raw[idx];
+        let code = char_code(ch);
+        if code < zero { break; }
+        if code > nine { break; }
+        value = value * 10 + (code - zero);
+        idx += 1;
+    }
+    return value;
+}
+
+// Parse `<key>=<value>` where the value runs to the next space, the
+// trailing `>` of the marker, or end-of-string. Returns the empty
+// string when the key is absent.
+fn _parse_marker_string_field(text: string, key: string) -> string {
+    let key_start = index_of(text, key);
+    if key_start < 0 { return ""; }
+    let value_start = key_start + key.length;
+    let mut cursor: int = value_start;
+    let mut value: string = "";
+    loop {
+        if cursor >= text.length { break; }
+        let ch = text[cursor];
+        if ch == " " { break; }
+        if ch == ">" { break; }
+        value = value + ch;
+        cursor += 1;
+    }
+    return value;
 }
 
 // Reconstruct the LLVM fn-pointer text for a lifted lambda from
@@ -555,9 +765,11 @@ fn lower_expression(expression: string, bindings: ParameterBinding[], locals: Lo
     // into `<closure_pair @sfn_lambda_<N> null>`, which arrives here
     // verbatim as the `.let` initializer text. Detect the prefix
     // before any other parse so the marker never gets mistaken for
-    // a regular identifier or member-access expression.
+    // a regular identifier or member-access expression. Capturing
+    // lambdas (#687) use the same prefix with an extended env_alloc
+    // payload — handled by `lower_closure_pair_marker`.
     if starts_with(stripped, "<closure_pair ") {
-        let pair_result = lower_closure_pair_marker(stripped, functions, context, temp_index, lines);
+        let pair_result = lower_closure_pair_marker(stripped, functions, context, bindings, locals, temp_index, lines);
         let mut _ci_pair: int = 0;
         loop {
             if _ci_pair >= pair_result.diagnostics.length { break; }
@@ -568,6 +780,31 @@ fn lower_expression(expression: string, bindings: ParameterBinding[], locals: Lo
             lines: pair_result.lines,
             temp_index: pair_result.temp_index,
             operand: pair_result.operand,
+            diagnostics: diagnostics,
+            string_constants: empty_constants
+        };
+    }
+
+    // Mutable-capture refusal (issue #687). The lifting pass emits
+    // this marker in place of a real closure pair when the lambda's
+    // capture set contains a `mutable` binding. The `[fatal]` prefix
+    // matches the sentinel scanned by
+    // `lowering_core.sfn:has_fatal_lowering_diagnostic` — IR writes
+    // are skipped, the build exits non-zero.
+    if starts_with(stripped, "<closure_pair_fatal_mutable ") {
+        let cap_name = _parse_marker_string_field(stripped, "name=");
+        let lam_id = _parse_marker_int_field(stripped, "lambda_id=");
+        let mut name_for_diag: string = cap_name;
+        if name_for_diag.length == 0 { name_for_diag = "<unknown>"; }
+        diagnostics.push("llvm lowering [fatal]: capturing lambda #"
+            + number_to_string(lam_id)
+            + " has mutable capture `"
+            + name_for_diag
+            + "` (not yet supported, see #687)");
+        return ExpressionResult {
+            lines: lines,
+            temp_index: temp_index,
+            operand: null,
             diagnostics: diagnostics,
             string_constants: empty_constants
         };

--- a/compiler/src/llvm/expression_lowering/native/lambda_lowering.sfn
+++ b/compiler/src/llvm/expression_lowering/native/lambda_lowering.sfn
@@ -57,6 +57,7 @@ import {
 } from "../../../ast";
 import { Parser, parse_block } from "../../../parser/mod";
 import { LambdaCaptureRecord, analyze_lambda_captures } from "../../../typecheck_captures";
+import { percent_escape_capture_text } from "../../closures";
 import { number_to_string } from "../../utils";
 
 // Mutable walker state threaded through every rewrite call. The
@@ -226,12 +227,17 @@ fn _is_non_capturing(records: LambdaCaptureRecord[], lambda: Expression) -> bool
 // ── Capture encoding for marker text ────────────────────────────────
 //
 // Captures are serialised as `name:type,name:type,...` inside the
-// closure-pair env_alloc marker and the env-load prologue marker. The
-// LLVM-side dispatchers rebuild a `Capture[]` from the encoded list
-// (via `decode_captures` in `closures.sfn`) and feed it to
-// `synthesize_closure_env_struct`. Empty `type_text` is preserved as
-// an empty segment after the `:` — the helper maps that back to the
-// `i8*` opaque-pointer field.
+// closure-pair env_alloc marker and the env-load prologue marker.
+// Each `name` and `type` segment is percent-escaped via
+// `percent_escape_capture_text`, so the literal `,`/`:` delimiters
+// stay unambiguous even when a type annotation contains them (e.g.
+// `Map<string, Result<int, Error>>`). The escape also encodes `<`
+// and `>` so a generic-typed capture cannot terminate the outer
+// `<closure_pair … >` marker prematurely. The LLVM-side dispatchers
+// rebuild a `Capture[]` from the encoded list (via `decode_captures`
+// in `closures.sfn`), which reverses the same escape. Empty
+// `type_text` is preserved as an empty segment after the `:` — the
+// helper maps that back to the `i8*` opaque-pointer field.
 fn _encode_captures(captures: Capture[]) -> string {
     let mut buffer: string = "";
     let mut index: int = 0;
@@ -239,7 +245,8 @@ fn _encode_captures(captures: Capture[]) -> string {
         if index >= captures.length { break; }
         let capture = captures[index];
         if index > 0 { buffer = buffer + ","; }
-        buffer = buffer + capture.name + ":" + capture.type_text;
+        buffer = buffer + percent_escape_capture_text(capture.name) + ":"
+            + percent_escape_capture_text(capture.type_text);
         index += 1;
     }
     return buffer;

--- a/compiler/src/llvm/expression_lowering/native/lambda_lowering.sfn
+++ b/compiler/src/llvm/expression_lowering/native/lambda_lowering.sfn
@@ -42,6 +42,7 @@
 // keeps cross-module name collisions impossible.
 import {
     Block,
+    Capture,
     Decorator,
     ElseBranch,
     Expression,
@@ -124,13 +125,51 @@ fn lift_non_capturing_lambdas(program: Program) -> LiftResult {
     return LiftResult { program: new_program, counter: ctx.counter as int };
 }
 
-// Builds the closure-pair marker string. Used by both the lifting
-// pass (writes it into the `Raw` expression) and the LLVM-side
-// dispatcher (matches on the `<closure_pair ` prefix to recognise
-// lifted lambda binding values).
+// Builds the closure-pair marker string for non-capturing lambdas
+// (env_var is typically "null"). Used by both the lifting pass
+// (writes it into the `Raw` expression) and the LLVM-side dispatcher
+// (matches on the `<closure_pair ` prefix to recognise lifted lambda
+// binding values).
 fn closure_pair_marker(lambda_id: int, env_var: string) -> string {
     return "<closure_pair @sfn_lambda_" + number_to_string(lambda_id) + " "
         + env_var
+        + ">";
+}
+
+// Builds the closure-pair marker string for capturing lambdas.
+// `captures_text` is the encoded `name:type,name:type,...` list
+// produced by `_encode_captures` — the LLVM-side dispatcher rebuilds
+// the `Capture[]` from it before invoking the A2 env helpers.
+fn closure_pair_env_alloc_marker(lambda_id: int, captures_text: string) -> string {
+    return "<closure_pair @sfn_lambda_" + number_to_string(lambda_id)
+        + " env_alloc lambda_id="
+        + number_to_string(lambda_id)
+        + " captures="
+        + captures_text
+        + ">";
+}
+
+// Marker for the env-load prologue spliced as the first statement of
+// the lifted capturing lambda body. Recognised in
+// `lower_instruction_range`: emits the A2 load-prologue lines and
+// registers `ClosureEnvLoadedBinding` entries as locals so capture
+// names resolve against the prologue temps.
+fn closure_env_load_prologue_marker(lambda_id: int, captures_text: string) -> string {
+    return "<closure_env_load_prologue lambda_id=" + number_to_string(lambda_id)
+        + " captures="
+        + captures_text
+        + ">";
+}
+
+// Marker for refusing IR emission on a capturing lambda whose
+// `LambdaCaptureRecord` contains a mutable binding. The lowering
+// side recognises the prefix and pushes a `llvm lowering [fatal]:`
+// diagnostic naming the offender — the build then refuses to write
+// IR. See acceptance criterion #5 in issue #687.
+fn closure_pair_fatal_mutable_marker(lambda_id: int, capture_name: string) -> string {
+    return "<closure_pair_fatal_mutable lambda_id=" + number_to_string(lambda_id)
+        + " name="
+        + capture_name
         + ">";
 }
 
@@ -146,7 +185,7 @@ fn lifted_function_name(lambda_id: int) -> string {
 // user cannot type by hand.
 fn closure_sentinel_type_text() -> string { return "__closure__"; }
 
-// ── Lookup: is this lambda non-capturing? ───────────────────────────
+// ── Lookup: locate the LambdaCaptureRecord for this lambda ──────────
 //
 // `LambdaCaptureRecord`s are keyed by the body's opening `{` token
 // line/column. The same key is computable from
@@ -154,14 +193,8 @@ fn closure_sentinel_type_text() -> string { return "__closure__"; }
 // scan over the records list. The number of lambdas per module is
 // small (single digits in practice), so the linear cost is
 // negligible compared with introducing a map.
-//
-// Returns `true` only when a matching record exists AND that record
-// reports zero captures. A missing record (which would indicate a
-// programmer error in `analyze_lambda_captures`) keeps the lambda
-// in `<lambda>`-placeholder form — refusing to lift is safer than
-// silently dropping captures.
-fn _is_non_capturing(records: LambdaCaptureRecord[], lambda: Expression) -> boolean {
-    if lambda.body.tokens.length == 0 { return false; }
+fn _find_capture_record(records: LambdaCaptureRecord[], lambda: Expression) -> LambdaCaptureRecord? {
+    if lambda.body.tokens.length == 0 { return null; }
     let body_line = lambda.body.tokens[0].line;
     let body_column = lambda.body.tokens[0].column;
     let mut index: int = 0;
@@ -172,13 +205,64 @@ fn _is_non_capturing(records: LambdaCaptureRecord[], lambda: Expression) -> bool
         if record.body_start_line == body_line {
             if record.body_start_column == body_column { _match = true; }
         }
-        if _match {
-            if record.captures.length == 0 { return true; }
-            return false;
-        }
+        if _match { return record; }
         index += 1;
     }
+    return null;
+}
+
+// True only when a matching record exists AND that record reports
+// zero captures. A missing record (which would indicate a programmer
+// error in `analyze_lambda_captures`) keeps the lambda in
+// `<lambda>`-placeholder form — refusing to lift is safer than
+// silently dropping captures.
+fn _is_non_capturing(records: LambdaCaptureRecord[], lambda: Expression) -> boolean {
+    let record = _find_capture_record(records, lambda);
+    if record == null { return false; }
+    if record.captures.length == 0 { return true; }
     return false;
+}
+
+// ── Capture encoding for marker text ────────────────────────────────
+//
+// Captures are serialised as `name:type,name:type,...` inside the
+// closure-pair env_alloc marker and the env-load prologue marker. The
+// LLVM-side dispatchers rebuild a `Capture[]` from the encoded list
+// (via `decode_captures` in `closures.sfn`) and feed it to
+// `synthesize_closure_env_struct`. Empty `type_text` is preserved as
+// an empty segment after the `:` — the helper maps that back to the
+// `i8*` opaque-pointer field.
+fn _encode_captures(captures: Capture[]) -> string {
+    let mut buffer: string = "";
+    let mut index: int = 0;
+    loop {
+        if index >= captures.length { break; }
+        let capture = captures[index];
+        if index > 0 { buffer = buffer + ","; }
+        buffer = buffer + capture.name + ":" + capture.type_text;
+        index += 1;
+    }
+    return buffer;
+}
+
+// ── Mutable-capture refusal ─────────────────────────────────────────
+//
+// Returns the name of the first mutable capture, or the empty string
+// when every capture is immutable. The lifting pass uses this to
+// emit a `closure_pair_fatal_mutable_marker` instead of a real
+// closure-pair so the LLVM-side dispatcher can surface a
+// `llvm lowering [fatal]:` diagnostic naming the offender. M1.5 ABI
+// freezes captures as by-value snapshots; mutable-capture semantics
+// require additional infrastructure (heap-allocated cells) that
+// lands post-M1.
+fn _find_mutable_capture_name(captures: Capture[]) -> string {
+    let mut index: int = 0;
+    loop {
+        if index >= captures.length { break; }
+        if captures[index].mutable { return captures[index].name; }
+        index += 1;
+    }
+    return "";
 }
 
 // ── Synthesis: lifted FunctionDeclaration ───────────────────────────
@@ -195,6 +279,17 @@ fn _is_non_capturing(records: LambdaCaptureRecord[], lambda: Expression) -> bool
 // `parse_block` for the same reason; we follow that pattern so the
 // emitted body sees structured statements.
 fn _synthesize_lifted_function(lambda: Expression, lambda_id: int) -> Statement {
+    return _synthesize_lifted_function_with_captures(lambda, lambda_id, []);
+}
+
+// Synthesise the lifted top-level function. When `captures.length > 0`,
+// prepends a `Statement.ExpressionStatement` wrapping the env-load
+// prologue marker as the first statement of the body. The marker is
+// recognised by `lower_instruction_range` (see #687 in
+// `instructions.sfn`): it emits the A2 prologue lines and registers
+// the loaded SSA temps as `LocalBinding[]` so capture references in
+// the body resolve through the existing name-resolution path.
+fn _synthesize_lifted_function_with_captures(lambda: Expression, lambda_id: int, captures: Capture[]) -> Statement {
     let mut parameters: Parameter[] = [];
     parameters.push(Parameter {
         name: "__env", type_annotation: TypeAnnotation { text: "i8*" }, default_value: null, mutable: false, span: null
@@ -217,11 +312,41 @@ fn _synthesize_lifted_function(lambda: Expression, lambda_id: int) -> Statement 
     };
 
     let parsed_body = _reparse_lambda_body(lambda.body);
+    let body_with_prologue = _prepend_capture_prologue(parsed_body, lambda_id, captures);
     let no_decorators: Decorator[] = [];
     return Statement.FunctionDeclaration {
         signature: signature,
-        body: parsed_body,
+        body: body_with_prologue,
         decorators: no_decorators
+    };
+}
+
+// Prepend the env-load prologue marker statement to a re-parsed
+// lambda body when the lambda has captures. Non-capturing lambdas
+// return the block unchanged so #686's IR shape is preserved.
+//
+// The marker is rendered into `.sfn-asm` by `format_expression`'s
+// Raw-expression passthrough (`<closure_env_load_prologue ...>` is
+// emitted verbatim) and recognised at lowering time by an
+// expression-statement prefix check.
+fn _prepend_capture_prologue(body: Block, lambda_id: int, captures: Capture[]) -> Block {
+    if captures.length == 0 { return body; }
+    let marker_text = closure_env_load_prologue_marker(lambda_id, _encode_captures(captures));
+    let prologue_stmt = Statement.ExpressionStatement {
+        expression: Expression.Raw { text: marker_text },
+        span: null
+    };
+    let mut new_statements: Statement[] = [prologue_stmt];
+    let mut index: int = 0;
+    loop {
+        if index >= body.statements.length { break; }
+        new_statements.push(body.statements[index]);
+        index += 1;
+    }
+    return Block {
+        tokens: body.tokens,
+        text: body.text,
+        statements: new_statements
     };
 }
 
@@ -416,11 +541,47 @@ fn _rewrite_expression(ctx: LiftContext, expression: Expression) -> ExpressionRe
 }
 
 fn _rewrite_lambda(ctx: LiftContext, lambda: Expression) -> ExpressionRewriteResult {
-    if !_is_non_capturing(ctx.records, lambda) {
+    let record = _find_capture_record(ctx.records, lambda);
+    if record == null {
+        // No record means `analyze_lambda_captures` did not see this
+        // lambda — leave it untouched so the placeholder fallback in
+        // `format_expression` (or a downstream pass) handles it.
         return ExpressionRewriteResult { ctx: ctx, expression: lambda };
     }
+
+    // Non-capturing path — unchanged from #686.
+    if record.captures.length == 0 {
+        let lambda_id = ctx.counter;
+        let lifted_fn = _synthesize_lifted_function(lambda, lambda_id);
+        let mut new_lifted: Statement[] = ctx.lifted;
+        new_lifted.push(lifted_fn);
+        let new_ctx: LiftContext = LiftContext {
+            counter: (ctx.counter + 1) as int,
+            lifted: new_lifted,
+            records: ctx.records
+        };
+        let marker_text = closure_pair_marker(lambda_id, "null");
+        return ExpressionRewriteResult {
+            ctx: new_ctx,
+            expression: Expression.Raw { text: marker_text }
+        };
+    }
+
+    // Capturing path (#687). Mutable captures are unsupported in M1.5
+    // — emit the fatal marker and DO NOT advance the counter or
+    // synthesise a lifted function (the lambda site would otherwise
+    // reference a sfn_lambda_<N> symbol that does not exist).
+    let mutable_name = _find_mutable_capture_name(record.captures);
+    if mutable_name.length > 0 {
+        let fatal_text = closure_pair_fatal_mutable_marker(ctx.counter, mutable_name);
+        return ExpressionRewriteResult {
+            ctx: ctx,
+            expression: Expression.Raw { text: fatal_text }
+        };
+    }
+
     let lambda_id = ctx.counter;
-    let lifted_fn = _synthesize_lifted_function(lambda, lambda_id);
+    let lifted_fn = _synthesize_lifted_function_with_captures(lambda, lambda_id, record.captures);
     let mut new_lifted: Statement[] = ctx.lifted;
     new_lifted.push(lifted_fn);
     let new_ctx: LiftContext = LiftContext {
@@ -428,8 +589,7 @@ fn _rewrite_lambda(ctx: LiftContext, lambda: Expression) -> ExpressionRewriteRes
         lifted: new_lifted,
         records: ctx.records
     };
-
-    let marker_text = closure_pair_marker(lambda_id, "null");
+    let marker_text = closure_pair_env_alloc_marker(lambda_id, _encode_captures(record.captures));
     return ExpressionRewriteResult {
         ctx: new_ctx,
         expression: Expression.Raw { text: marker_text }
@@ -690,6 +850,9 @@ fn _is_closure_pair_marker_text(text: string) -> boolean {
 
 export {
     LiftResult,
+    closure_env_load_prologue_marker,
+    closure_pair_env_alloc_marker,
+    closure_pair_fatal_mutable_marker,
     closure_pair_marker,
     closure_sentinel_type_text,
     lift_non_capturing_lambdas,

--- a/compiler/src/llvm/expression_lowering/native/mod.sfn
+++ b/compiler/src/llvm/expression_lowering/native/mod.sfn
@@ -73,12 +73,18 @@ export {
 // Historically consumers imported these via expression_lowering_stage2.
 export { format_temp_name } from "../../expressions_helpers";
 
-// Lambda lifting (issue #686). Pre-pass that runs inside
-// `emit_native_with_module_name` to convert non-capturing
-// `Expression.Lambda` nodes into top-level `Statement.FunctionDeclaration`s
-// + closure-pair `Raw` markers consumed by `lower_expression`.
+// Lambda lifting (issues #686 + #687). Pre-pass that runs inside
+// `emit_native_with_module_name` to convert `Expression.Lambda`
+// nodes into top-level `Statement.FunctionDeclaration`s plus a
+// closure-pair `Raw` marker consumed by `lower_expression`.
+// Capturing lambdas (#687) carry an env-alloc marker at the
+// lambda site and an env-load prologue marker as the first body
+// statement of the lifted function.
 export {
     LiftResult,
+    closure_env_load_prologue_marker,
+    closure_pair_env_alloc_marker,
+    closure_pair_fatal_mutable_marker,
     closure_pair_marker,
     closure_sentinel_type_text,
     lift_non_capturing_lambdas,

--- a/compiler/src/llvm/lowering/entrypoints.sfn
+++ b/compiler/src/llvm/lowering/entrypoints.sfn
@@ -248,7 +248,11 @@ fn lower_to_llvm_ir_from_text(native_text: string, module_name: string) -> strin
 // Returns true on success. Unlike `lower_to_llvm_ir_from_text`, this prints
 // lines directly rather than joining into one huge string and returning it —
 // avoids `_join_llvm_lines_linear` memory amplification for very large LLVM
-// outputs.
+// outputs. Refuses to print and returns false when any lowering pass surfaced
+// a `[fatal]` diagnostic — the IR may look complete but a side-effecting
+// expression could have been silently dropped (e.g. a capturing lambda with
+// a mutable capture, issue #687) and printing the partial output would
+// silently miscompile.
 fn print_llvm_ir_from_text(native_text: string, module_name: string) -> boolean ![io] {
     if native_text.length == 0 { return false; }
     let parse = parse_native_artifact(native_text);
@@ -275,6 +279,16 @@ fn print_llvm_ir_from_text(native_text: string, module_name: string) -> boolean 
             + " diagnostics="
             + number_to_string(parse.diagnostics.length)
             + ")");
+        return false;
+    }
+    if has_fatal_lowering_diagnostic(lowered_lines.diagnostics) {
+        let mut _fpi: int = 0;
+        loop {
+            if _fpi >= lowered_lines.diagnostics.length { break; }
+            let _pdiag = lowered_lines.diagnostics[_fpi];
+            if index_of(_pdiag, "[fatal]") >= 0 { print.err(_pdiag); }
+            _fpi += 1;
+        }
         return false;
     }
     let lines = lowered_lines.lines;

--- a/compiler/src/llvm/lowering/instructions.sfn
+++ b/compiler/src/llvm/lowering/instructions.sfn
@@ -230,9 +230,11 @@ fn lower_instruction_range(function: NativeFunction, start_index: int, end: int,
                 // expression-statement marker to every capturing
                 // lifted function. Recognise it before any other parse
                 // so the A2 prologue runs as the first instruction —
-                // its loaded `ClosureEnvLoadedBinding[]` entries are
-                // appended to `current_locals` so capture references
-                // in the body resolve through standard name lookup.
+                // its loaded SSA temps are appended to
+                // `current_bindings` as `ParameterBinding` entries so
+                // capture references resolve to the loaded values
+                // verbatim, without `find_local_binding` emitting an
+                // extra `load` indirection on the prologue temp.
                 let prologue_prefix = "<closure_env_load_prologue ";
                 if trimmed_expression.length >= prologue_prefix.length {
                     let mut _is_prologue: boolean = true;

--- a/compiler/src/llvm/lowering/instructions.sfn
+++ b/compiler/src/llvm/lowering/instructions.sfn
@@ -10,6 +10,11 @@
 import { NativeFunction, NativeInstruction } from "../../native_ir";
 import { substring } from "../../string_utils";
 import { test_runner_trace } from "../../test_runner_state";
+import {
+    decode_captures,
+    emit_closure_env_load_prologue,
+    synthesize_closure_env_struct
+} from "../closures";
 import { append_local_binding } from "../expression_lowering/native/core_scopes";
 import { lower_expression_statement, lower_return_instruction } from "../expression_lowering/native/statement";
 import { parse_inline_let_expression } from "../expression_lowering/native/statement_parsing";
@@ -219,34 +224,72 @@ fn lower_instruction_range(function: NativeFunction, start_index: int, end: int,
                 let _raw_expr = get_instruction_text(function.instructions, index);
                 let trimmed_expression = trim_text(_raw_expr);
                 let mut handled_inline_let: boolean = false;
+
+                // Capturing-lambda env-load prologue (issue #687). The
+                // lifting pass prepends a `<closure_env_load_prologue ...>`
+                // expression-statement marker to every capturing
+                // lifted function. Recognise it before any other parse
+                // so the A2 prologue runs as the first instruction —
+                // its loaded `ClosureEnvLoadedBinding[]` entries are
+                // appended to `current_locals` so capture references
+                // in the body resolve through standard name lookup.
+                let prologue_prefix = "<closure_env_load_prologue ";
+                if trimmed_expression.length >= prologue_prefix.length {
+                    let mut _is_prologue: boolean = true;
+                    let mut _pi: int = 0;
+                    loop {
+                        if _pi >= prologue_prefix.length { break; }
+                        if trimmed_expression[_pi] != prologue_prefix[_pi] {
+                            _is_prologue = false;
+                            break;
+                        }
+                        _pi += 1;
+                    }
+                    if _is_prologue {
+                        let prologue_result = _lower_closure_env_load_prologue_marker(trimmed_expression, current_bindings, current_temp, current_lines);
+                        diagnostics = extend_string_array(diagnostics, prologue_result.diagnostics);
+                        current_lines = prologue_result.lines;
+                        current_bindings = prologue_result.bindings;
+                        current_temp = prologue_result.temp_index;
+                        // Don't bump `index` or set `_tag_handled` here —
+                        // the surrounding tag==1 block does both at its
+                        // tail. We only need `handled_inline_let = true`
+                        // to short-circuit the let / expression-statement
+                        // fallbacks below.
+                        handled_inline_let = true;
+                    }
+                }
+
                 if trimmed_expression.length >= 4 {
                     let prefix = substring(trimmed_expression, 0, 4);
-                    if prefix == "let " {
-                        let inline_parse = parse_inline_let_expression(trimmed_expression);
-                        diagnostics = extend_string_array(diagnostics, inline_parse.diagnostics);
-                        if inline_parse.success {
-                            let inline_instruction = NativeInstruction.Let {
-                                name: inline_parse.name,
-                                mutable: inline_parse.mutable,
-                                type_annotation: inline_parse.type_annotation,
-                                value: inline_parse.initializer,
-                                span: null,
-                                value_span: null
-                            };
-                            let lowered = lower_let_instruction(function, inline_instruction, current_bindings, current_locals, current_allocas, current_lines, current_temp, current_next_local, current_next_region, functions, context, scope_id, scope_depth, active_label);
-                            diagnostics = extend_string_array(diagnostics, lowered.diagnostics);
-                            collected_lifetime_regions = extend_lifetime_regions(collected_lifetime_regions, lowered.lifetime_regions);
-                            collected_lifetime_regions = apply_lifetime_release_events(collected_lifetime_regions, lowered.lifetime_releases);
-                            current_lines = lowered.lines;
-                            current_allocas = lowered.allocas;
-                            current_locals = lowered.locals;
-                            current_bindings = lowered.bindings;
-                            current_temp = lowered.temp_index;
-                            current_next_local = lowered.next_local_id;
-                            current_next_region = lowered.next_region_id;
-                            current_mutations = extend_mutations(current_mutations, lowered.mutations);
-                            collected_string_constants = merge_string_constants(collected_string_constants, lowered.string_constants);
-                            handled_inline_let = true;
+                    if !handled_inline_let {
+                        if prefix == "let " {
+                            let inline_parse = parse_inline_let_expression(trimmed_expression);
+                            diagnostics = extend_string_array(diagnostics, inline_parse.diagnostics);
+                            if inline_parse.success {
+                                let inline_instruction = NativeInstruction.Let {
+                                    name: inline_parse.name,
+                                    mutable: inline_parse.mutable,
+                                    type_annotation: inline_parse.type_annotation,
+                                    value: inline_parse.initializer,
+                                    span: null,
+                                    value_span: null
+                                };
+                                let lowered = lower_let_instruction(function, inline_instruction, current_bindings, current_locals, current_allocas, current_lines, current_temp, current_next_local, current_next_region, functions, context, scope_id, scope_depth, active_label);
+                                diagnostics = extend_string_array(diagnostics, lowered.diagnostics);
+                                collected_lifetime_regions = extend_lifetime_regions(collected_lifetime_regions, lowered.lifetime_regions);
+                                collected_lifetime_regions = apply_lifetime_release_events(collected_lifetime_regions, lowered.lifetime_releases);
+                                current_lines = lowered.lines;
+                                current_allocas = lowered.allocas;
+                                current_locals = lowered.locals;
+                                current_bindings = lowered.bindings;
+                                current_temp = lowered.temp_index;
+                                current_next_local = lowered.next_local_id;
+                                current_next_region = lowered.next_region_id;
+                                current_mutations = extend_mutations(current_mutations, lowered.mutations);
+                                collected_string_constants = merge_string_constants(collected_string_constants, lowered.string_constants);
+                                handled_inline_let = true;
+                            }
                         }
                     }
                 }
@@ -673,4 +716,96 @@ fn lower_instruction_range(function: NativeFunction, start_index: int, end: int,
         mutations: current_mutations,
         string_constants: collected_string_constants
     };
+}
+
+// ── Capturing-lambda env-load prologue (#687) ──────────────────────────
+//
+// Result of `_lower_closure_env_load_prologue_marker`. The
+// `bindings` field is the input list with one `ParameterBinding`
+// per loaded capture appended. ParameterBinding (not LocalBinding)
+// is used so identifier resolution returns the loaded SSA temp
+// directly without emitting a spurious `load` — captures are
+// already true SSA values after the A2 prologue, not stack
+// allocations needing further dereference.
+struct _ClosureEnvPrologueLowerResult {
+    lines: string[];
+    bindings: ParameterBinding[];
+    temp_index: int;
+    diagnostics: string[];
+}
+
+// Parse a `<closure_env_load_prologue lambda_id=<N> captures=<encoded>>`
+// marker and emit the A2 env-load prologue (one bitcast + one
+// GEP+load per capture). The hidden `__env: i8*` parameter is named
+// `%__env` after `sanitize_symbol` (see
+// `prepare_parameters_from_function`); we hardcode that name here
+// rather than threading the binding through.
+fn _lower_closure_env_load_prologue_marker(marker: string, bindings: ParameterBinding[], temp_index: int, lines: string[]) -> _ClosureEnvPrologueLowerResult {
+    let mut diagnostics: string[] = [];
+    let lambda_id = _parse_prologue_int(marker, "lambda_id=");
+    let captures_text = _parse_prologue_string(marker, "captures=");
+    let captures = decode_captures(captures_text);
+    let layout = synthesize_closure_env_struct(captures, lambda_id);
+    let mut new_lines: string[] = lines;
+    if !layout.is_empty {
+        new_lines.push("; closure_env_type_decl " + layout.type_decl);
+    }
+    let prologue = emit_closure_env_load_prologue(layout, "%__env", temp_index);
+    let mut li: int = 0;
+    loop {
+        if li >= prologue.lines.length { break; }
+        new_lines.push(prologue.lines[li]);
+        li += 1;
+    }
+    let mut new_bindings: ParameterBinding[] = bindings;
+    let mut bi: int = 0;
+    loop {
+        if bi >= prologue.bindings.length { break; }
+        let loaded = prologue.bindings[bi];
+        new_bindings.push(ParameterBinding {
+            name: loaded.name, llvm_name: loaded.llvm_name, llvm_type: loaded.llvm_type, type_annotation: captures[bi].type_text, consumed: false, span: null
+        });
+        bi += 1;
+    }
+    return _ClosureEnvPrologueLowerResult {
+        lines: new_lines,
+        bindings: new_bindings,
+        temp_index: prologue.next_temp,
+        diagnostics: diagnostics
+    };
+}
+
+fn _parse_prologue_int(text: string, key: string) -> int {
+    let raw = _parse_prologue_string(text, key);
+    if raw.length == 0 { return 0; }
+    let mut value: int = 0;
+    let mut idx: int = 0;
+    let zero_code = char_code("0");
+    let nine_code = char_code("9");
+    loop {
+        if idx >= raw.length { break; }
+        let code = char_code(raw[idx]);
+        if code < zero_code { break; }
+        if code > nine_code { break; }
+        value = value * 10 + (code - zero_code);
+        idx += 1;
+    }
+    return value;
+}
+
+fn _parse_prologue_string(text: string, key: string) -> string {
+    let key_start = index_of(text, key);
+    if key_start < 0 { return ""; }
+    let value_start = key_start + key.length;
+    let mut cursor: int = value_start;
+    let mut value: string = "";
+    loop {
+        if cursor >= text.length { break; }
+        let ch = text[cursor];
+        if ch == " " { break; }
+        if ch == ">" { break; }
+        value = value + ch;
+        cursor += 1;
+    }
+    return value;
 }

--- a/compiler/src/llvm/lowering/lowering_core.sfn
+++ b/compiler/src/llvm/lowering/lowering_core.sfn
@@ -283,6 +283,11 @@ fn compile_native_text_to_llvm_file(native_text: string, module_name: string, ou
             if index_of(_diag, "[fatal]") >= 0 { print.err(_diag); }
             _fdi += 1;
         }
+        // Drop any stale `.ll` from a previous successful build so
+        // downstream tooling that only stats `out_path` cannot mistake
+        // it for fresh output (mirrors the empty-native-text branch in
+        // `compile_to_llvm_file_with_module`).
+        if fs.exists(out_path) { fs.deleteFile(out_path); }
         return false;
     }
     let lowered_count = lowered_lines.lines.length;

--- a/compiler/src/llvm/lowering/lowering_core.sfn
+++ b/compiler/src/llvm/lowering/lowering_core.sfn
@@ -57,7 +57,13 @@ import {
     TraitMetadata,
     TypeContext
 } from "../types";
-import { index_of, number_to_string, sanitize_symbol } from "../utils";
+import {
+    index_of,
+    number_to_string,
+    sanitize_symbol,
+    starts_with,
+    trim_text
+} from "../utils";
 import {
     collect_defined_function_symbols,
     extend_native_enums,
@@ -262,11 +268,23 @@ fn compile_native_text_to_llvm_file(native_text: string, module_name: string, ou
         return false;
     }
     // Refuse to write IR when any lowering pass surfaced a `[fatal]`
-    // diagnostic. Currently issued by `core_call_emission.sfn` for
-    // calls whose return type cannot be resolved (issue #306) — a
+    // diagnostic. Issued by `core_call_emission.sfn` for calls whose
+    // return type cannot be resolved (issue #306) and by
+    // `lower_expression`'s `<closure_pair_fatal_mutable ...>` handler
+    // for capturing lambdas with mutable captures (issue #687). A
     // partial IR file with the side-effecting call silently dropped
-    // would be worse than no output at all.
-    if has_fatal_lowering_diagnostic(lowered_lines.diagnostics) { return false; }
+    // would be worse than no output at all. Print every fatal so the
+    // user sees the underlying cause before the build aborts.
+    if has_fatal_lowering_diagnostic(lowered_lines.diagnostics) {
+        let mut _fdi: int = 0;
+        loop {
+            if _fdi >= lowered_lines.diagnostics.length { break; }
+            let _diag = lowered_lines.diagnostics[_fdi];
+            if index_of(_diag, "[fatal]") >= 0 { print.err(_diag); }
+            _fdi += 1;
+        }
+        return false;
+    }
     let lowered_count = lowered_lines.lines.length;
     if lowered_count > 0 {
         let defined = collect_defined_function_symbols(lowered_lines.lines);
@@ -553,6 +571,15 @@ fn lower_to_llvm_lines_with_parsed_context(native_module: NativeModule, parse_in
     lines = extend_string_lines(lines, function_result.lines);
     diagnostics = extend_string_lines_checked(diagnostics, function_result.diagnostics, "function lowering");
 
+    // Capturing-lambda env type decls (#687). The lambda-site
+    // env_alloc marker and the lifted-function prologue marker each
+    // emit a `; closure_env_type_decl %sfn_closure_env_<N> = type {...}`
+    // hint inline with the using function's IR. LLVM requires named
+    // struct types to be declared at module scope BEFORE any use, so
+    // we lift the hints to the preamble — right after the
+    // `source_filename` line — with dedup by type name.
+    lines = hoist_closure_env_type_decls(lines);
+
     if timing {
         print.err("test llvm: phase=functions ms=" + number_to_string(monotonic_millis() - start_ms));
     }
@@ -635,4 +662,115 @@ fn lower_to_llvm_lines_with_parsed_context(native_module: NativeModule, parse_in
         capability_manifest: manifest,
         string_constants: all_string_constants
     };
+}
+
+// Hoist `; closure_env_type_decl %T = type { ... }` hint comments
+// from inside function bodies up to the module preamble (issue #687).
+// Each lambda's hint is emitted twice — once at the lambda-site
+// alloc and once at the lifted-function load prologue — so the
+// dedup table tracks the LLVM type name (`%sfn_closure_env_<N>`)
+// and skips duplicates. The hoist inserts the unique decls
+// immediately after the `source_filename = "..."` line, which
+// guarantees they appear before any function body that references
+// the named type.
+fn hoist_closure_env_type_decls(lines: string[]) -> string[] {
+    let hint_prefix = "; closure_env_type_decl ";
+    let mut hoisted: string[] = [];
+    let mut seen_names: string[] = [];
+    let mut filtered: string[] = [];
+    let mut index: int = 0;
+    loop {
+        if index >= lines.length { break; }
+        let line = lines[index];
+        let trimmed = trim_text(line);
+        if starts_with(trimmed, hint_prefix) {
+            let decl_text = trim_text(substring(trimmed, hint_prefix.length, trimmed.length));
+            let type_name = _hoist_extract_type_name(decl_text);
+            if type_name.length > 0 {
+                let mut already: boolean = false;
+                let mut _si: int = 0;
+                loop {
+                    if _si >= seen_names.length { break; }
+                    if seen_names[_si] == type_name {
+                        already = true;
+                        break;
+                    }
+                    _si += 1;
+                }
+                if !already {
+                    seen_names.push(type_name);
+                    hoisted.push(decl_text);
+                }
+            }
+            // Drop the hint line — it has been hoisted (or was a duplicate).
+        } else { filtered.push(line); }
+        index += 1;
+    }
+    if hoisted.length == 0 { return lines; }
+
+    // Find the insertion point: the line right after `source_filename = `.
+    let mut insert_after: int = -1;
+    let mut fi: int = 0;
+    loop {
+        if fi >= filtered.length { break; }
+        if starts_with(trim_text(filtered[fi]), "source_filename = ") {
+            insert_after = fi;
+            break;
+        }
+        fi += 1;
+    }
+
+    let mut result: string[] = [];
+    let mut ri: int = 0;
+    loop {
+        if ri >= filtered.length { break; }
+        result.push(filtered[ri]);
+        if ri == insert_after {
+            result.push("");
+            let mut hi: int = 0;
+            loop {
+                if hi >= hoisted.length { break; }
+                result.push(hoisted[hi]);
+                hi += 1;
+            }
+        }
+        ri += 1;
+    }
+    // Fallback: if we never found a source_filename anchor, prepend.
+    if insert_after < 0 {
+        let mut prepended: string[] = [];
+        let mut hi2: int = 0;
+        loop {
+            if hi2 >= hoisted.length { break; }
+            prepended.push(hoisted[hi2]);
+            hi2 += 1;
+        }
+        prepended.push("");
+        let mut _fi2: int = 0;
+        loop {
+            if _fi2 >= filtered.length { break; }
+            prepended.push(filtered[_fi2]);
+            _fi2 += 1;
+        }
+        return prepended;
+    }
+    return result;
+}
+
+// Extract `%T` from `%T = type { ... }`. The name spans from the
+// leading `%` up to (but not including) the first space.
+fn _hoist_extract_type_name(decl: string) -> string {
+    let trimmed = trim_text(decl);
+    if trimmed.length == 0 { return ""; }
+    if trimmed[0] != "%" { return ""; }
+    let mut cursor: int = 0;
+    let mut name: string = "";
+    loop {
+        if cursor >= trimmed.length { break; }
+        let ch = trimmed[cursor];
+        if ch == " " { break; }
+        name = name + ch;
+        cursor += 1;
+    }
+    return name;
 }

--- a/compiler/tests/integration/closure_lifting_test.sfn
+++ b/compiler/tests/integration/closure_lifting_test.sfn
@@ -24,8 +24,19 @@
 //      `Expression.Lambda` node so they continue to flow through
 //      `format_expression` as `<lambda>` until #687 wires the env
 //      struct end-to-end.
-import { Expression, Program, Statement } from "../../src/ast";
-import { ClosurePairResult, emit_closure_pair_aggregate } from "../../src/llvm/closures";
+import {
+    Capture,
+    Expression,
+    Program,
+    Statement
+} from "../../src/ast";
+import {
+    ClosurePairResult,
+    decode_captures,
+    emit_closure_pair_aggregate,
+    percent_escape_capture_text,
+    percent_unescape_capture_text
+} from "../../src/llvm/closures";
 import {
     LiftResult,
     closure_pair_marker,
@@ -217,9 +228,11 @@ test "lift #687: shadowing — capture `x` resolves to prologue, not outer" ![io
     // outer SSA value. At the AST level, this manifests as the
     // lifted function body's prologue marker naming `x` as a
     // capture. The LLVM-side splice (in
-    // `_lower_closure_env_load_prologue_marker`) appends a
-    // `LocalBinding` named `x` to the lifted function's locals so
-    // `find_local_binding` finds it before any module-global `x`.
+    // `_lower_closure_env_load_prologue_marker`) appends each
+    // loaded capture to the lifted function's
+    // `ParameterBinding[]` (not `LocalBinding[]`) so identifier
+    // resolution reads the env-loaded SSA temp directly without
+    // emitting a redundant `load` against a fake alloca pointer.
     let source = "fn main() { let x: int = 1; let f = fn(y: int) -> int { return x + y; }; }";
     let program = parse_program(source);
     let result: LiftResult = lift_non_capturing_lambdas(program);
@@ -258,4 +271,42 @@ test "lift #687: mutable capture is refused with a fatal marker" ![io] {
     let init: Expression = lambda_stmt.initializer;
     assert init.variant == "Raw";
     assert init.text == "<closure_pair_fatal_mutable lambda_id=0 name=x>";
+}
+
+// ── Capture-payload percent escape round-trip ────────────────────────
+//
+// The marker payload's `name:type,name:type,...` shape would be
+// ambiguous if a type annotation contained `,` or `:` (e.g. a future
+// generic like `Map<string, int>`), and a literal `>` in the payload
+// would terminate the outer `<closure_pair … >` marker prematurely.
+// `_encode_captures` percent-escapes those characters; `decode_captures`
+// reverses the escape. The round-trip must preserve the original
+// `Capture.name` / `Capture.type_text` exactly so the env-struct
+// layout agrees between the lambda site and the lifted function's
+// prologue.
+test "captures: percent_escape round-trips the delimiter character set" {
+    assert percent_escape_capture_text("Map<string, int>") == "Map%3Cstring%2C int%3E";
+    assert percent_unescape_capture_text("Map%3Cstring%2C int%3E") == "Map<string, int>";
+    assert percent_escape_capture_text("a:b") == "a%3Ab";
+    assert percent_unescape_capture_text("a%3Ab") == "a:b";
+    assert percent_escape_capture_text("100%") == "100%25";
+    assert percent_unescape_capture_text("100%25") == "100%";
+    // No-op for the common case so simple types stay byte-for-byte
+    // identical with the pre-escape encoding.
+    assert percent_escape_capture_text("int") == "int";
+    assert percent_escape_capture_text("boolean") == "boolean";
+    assert percent_escape_capture_text("User_Type") == "User_Type";
+}
+
+test "captures: decode_captures recovers generic-typed entries" {
+    // Hand-rolled the encoded form so we don't depend on the lift
+    // pass's encoder being run against a parsed program that the
+    // grammar may not yet accept.
+    let encoded = "items:Map%3Cstring%2C int%3E,handler:fn(int) -%3E boolean";
+    let decoded: Capture[] = decode_captures(encoded);
+    assert decoded.length == 2;
+    assert decoded[0].name == "items";
+    assert decoded[0].type_text == "Map<string, int>";
+    assert decoded[1].name == "handler";
+    assert decoded[1].type_text == "fn(int) -> boolean";
 }

--- a/compiler/tests/integration/closure_lifting_test.sfn
+++ b/compiler/tests/integration/closure_lifting_test.sfn
@@ -158,23 +158,104 @@ test "lift: lambda referencing a top-level fn lifts without producing captures" 
     assert init.text == "<closure_pair @sfn_lambda_0 null>";
 }
 
-// ── Capturing lambdas are NOT lifted (regression guard for #687) ─────
-test "lift: capturing lambda keeps its Expression.Lambda node" ![io] {
-    // `x` is bound in the enclosing scope, so the lambda captures
-    // it — `analyze_lambda_captures` returns a record with
-    // `captures.length == 1`. The lifting pass MUST refuse to lift
-    // (the `<lambda>` placeholder + capturing dispatch are #687's
-    // territory).
+// ── Capturing lambdas: env_alloc marker + prologue body (issue #687) ─
+//
+// With #687 in place, capturing lambdas are lifted exactly like
+// non-capturing ones except (a) the closure-pair marker carries an
+// `env_alloc lambda_id=<N> captures=<encoded>` payload, and (b) the
+// lifted body's first statement is a `<closure_env_load_prologue ...>`
+// marker whose LLVM lowering emits the A2 prologue and registers the
+// loaded SSA temps as local bindings.
+test "lift #687: single-int-capturing lambda lifts and emits env_alloc marker" ![io] {
     let source = "fn main() { let x: int = 5; let f = fn() -> int { return x; }; }";
     let program = parse_program(source);
     let result: LiftResult = lift_non_capturing_lambdas(program);
-    assert result.counter == 0;
-    // No lifted fn appended — the original statement count is
-    // unchanged.
-    assert result.program.statements.length == 1;
+    assert result.counter == 1;
+    assert result.program.statements.length == 2;
+
+    // The lambda site receives an env_alloc closure-pair marker.
     let main_fn: Statement = result.program.statements[0];
     let lambda_stmt: Statement = main_fn.body.statements[1];
     assert lambda_stmt.variant == "VariableDeclaration";
     let init: Expression = lambda_stmt.initializer;
-    assert init.variant == "Lambda";
+    assert init.variant == "Raw";
+    assert init.text == "<closure_pair @sfn_lambda_0 env_alloc lambda_id=0 captures=x:int>";
+
+    // The lifted fn carries the env-load prologue marker as its
+    // first body statement.
+    let lifted: Statement = result.program.statements[1];
+    assert lifted.variant == "FunctionDeclaration";
+    assert lifted.signature.name == "sfn_lambda_0";
+    assert lifted.body.statements.length >= 1;
+    let prologue: Statement = lifted.body.statements[0];
+    assert prologue.variant == "ExpressionStatement";
+    assert prologue.expression.variant == "Raw";
+    assert prologue.expression.text == "<closure_env_load_prologue lambda_id=0 captures=x:int>";
+}
+
+test "lift #687: multi-typed captures preserve A1 first-use order" ![io] {
+    let source = "fn main() { let a: int = 1; let b: boolean = true; let c: string = \"s\"; let f = fn() -> int { if b { return a + c.length; } return a; }; }";
+    let program = parse_program(source);
+    let result: LiftResult = lift_non_capturing_lambdas(program);
+    assert result.counter == 1;
+    assert result.program.statements.length == 2;
+    let main_fn: Statement = result.program.statements[0];
+    let lambda_stmt: Statement = main_fn.body.statements[3];
+    let init: Expression = lambda_stmt.initializer;
+    assert init.variant == "Raw";
+    // A1's walk records captures in first-use order; the lambda
+    // body reads `b` first (in the if-condition), then `a`, then
+    // `c`. The marker must reflect that ordering verbatim so the
+    // env-struct field indices stay consistent across the
+    // lambda-site alloc and the lifted-body prologue.
+    assert init.text == "<closure_pair @sfn_lambda_0 env_alloc lambda_id=0 captures=b:boolean,a:int,c:string>";
+}
+
+test "lift #687: shadowing — capture `x` resolves to prologue, not outer" ![io] {
+    // Acceptance criterion: outer `let x = 1; let f = fn(y) { return x + y; };`
+    // — the capture `x` must bind to the prologue temp, not any
+    // outer SSA value. At the AST level, this manifests as the
+    // lifted function body's prologue marker naming `x` as a
+    // capture. The LLVM-side splice (in
+    // `_lower_closure_env_load_prologue_marker`) appends a
+    // `LocalBinding` named `x` to the lifted function's locals so
+    // `find_local_binding` finds it before any module-global `x`.
+    let source = "fn main() { let x: int = 1; let f = fn(y: int) -> int { return x + y; }; }";
+    let program = parse_program(source);
+    let result: LiftResult = lift_non_capturing_lambdas(program);
+    assert result.counter == 1;
+    let lifted: Statement = result.program.statements[1];
+    assert lifted.signature.parameters.length == 2;
+    assert lifted.signature.parameters[0].name == "__env";
+    assert lifted.signature.parameters[1].name == "y";
+    let prologue: Statement = lifted.body.statements[0];
+    assert prologue.expression.text == "<closure_env_load_prologue lambda_id=0 captures=x:int>";
+    // The user's `return x + y;` statement still appears AFTER the
+    // prologue — name resolution at lower time picks up the
+    // prologue's `x` binding (appended to locals) over any outer
+    // module-global.
+    assert lifted.body.statements.length == 2;
+    let user_return: Statement = lifted.body.statements[1];
+    assert user_return.variant == "ReturnStatement";
+}
+
+test "lift #687: mutable capture is refused with a fatal marker" ![io] {
+    // Per the M1.5 capture freeze, mutable captures are not yet
+    // supported. The lifting pass emits a
+    // `closure_pair_fatal_mutable` marker instead of synthesising a
+    // lifted function — the LLVM-side handler turns it into a
+    // `llvm lowering [fatal]:` diagnostic and the build refuses to
+    // write IR.
+    let source = "fn main() { let mut x: int = 1; let f = fn() -> int { return x; }; }";
+    let program = parse_program(source);
+    let result: LiftResult = lift_non_capturing_lambdas(program);
+    // Mutable-capture refusal short-circuits before counter advance
+    // so the lambda_id stays at 0 (the first available slot).
+    assert result.counter == 0;
+    assert result.program.statements.length == 1;
+    let main_fn: Statement = result.program.statements[0];
+    let lambda_stmt: Statement = main_fn.body.statements[1];
+    let init: Expression = lambda_stmt.initializer;
+    assert init.variant == "Raw";
+    assert init.text == "<closure_pair_fatal_mutable lambda_id=0 name=x>";
 }


### PR DESCRIPTION
## Summary

Extends the #686 lifting pass to handle **capturing** lambdas — alloc + populate the env struct at the lambda expression site, splice the A2 env-load prologue into the lifted function body, and rewrite name resolution so capture references resolve to prologue-loaded SSA temps instead of outer-scope names.

Closes #687

## Approach

- **Lift pass** (`lambda_lowering.sfn`) — for each `Expression.Lambda` whose `LambdaCaptureRecord.captures.length > 0`:
  - Emits a `<closure_pair @sfn_lambda_<N> env_alloc lambda_id=<N> captures=name:type,...>` marker at the lambda site.
  - Synthesises a top-level `sfn_lambda_<N>` `FunctionDeclaration` with a `<closure_env_load_prologue ...>` `Statement.ExpressionStatement` prepended to its body.
  - Mutable captures short-circuit to a `<closure_pair_fatal_mutable ...>` marker without advancing the counter or synthesising a lifted function.

- **Lambda-site lowering** (`core.sfn:lower_closure_pair_marker`) — when the env-payload starts with `env_alloc `, parses the encoded captures, calls `synthesize_closure_env_struct` + `emit_closure_env_alloc` + `emit_closure_pair_aggregate`, and resolves capture-name operands against `LocalBinding[]`/`ParameterBinding[]` (emitting a `load` for stack-allocated locals before stashing the value into the env struct).

- **Lifted-function prologue** (`instructions.sfn`) — `lower_instruction_range` recognises the `<closure_env_load_prologue ...>` expression-statement marker, calls `emit_closure_env_load_prologue`, and appends each `ClosureEnvLoadedBinding` to `current_bindings` (ParameterBinding, not LocalBinding, so identifier resolution returns the loaded SSA temp directly without an extra `load`).

- **Mutable-capture refusal** (`core.sfn:lower_expression`) — detects the fatal marker and pushes `llvm lowering [fatal]: capturing lambda #<N> has mutable capture \`<name>\` (not yet supported, see #687)`. `compile_native_text_to_llvm_file` and `print_llvm_ir_from_text` now print every `[fatal]` diagnostic to stderr before refusing to write IR.

- **Closure-env type decl hoist** (`lowering_core.sfn:hoist_closure_env_type_decls`) — the lambda-site marker and the prologue marker each emit a `; closure_env_type_decl %T = type { ... }` hint comment inline; a post-pass lifts unique decls to right after `source_filename = ...` so LLVM sees named struct types declared before any function uses them.

## Acceptance Criteria

- [x] Capturing lambda (single capture) emits: env-struct type decl + alloc+populate sequence + bitcast at binding site, and load-prologue at top of lifted function body. IR shape matches the A2 golden tests' alloc/load patterns byte-for-byte.
- [x] Multi-capture lambda emits captures in deterministic order (A1 first-use order — verified in test "lift #687: multi-typed captures preserve A1 first-use order").
- [x] Capture references inside the lambda body resolve to prologue temps via SSA rewrite; outer-scope SSA values are not referenced inside the lifted function.
- [x] Shadowing test: outer `x` and a capture also named `x` resolve correctly — capture references bind to the prologue temp.
- [x] Mutable-capture refusal: emits a `llvm lowering [fatal]:` diagnostic naming the capture and refuses to emit IR.
- [x] All 17 A2 integration tests in `closure_env_emission_test.sfn` still pass byte-for-byte (helper API untouched).
- [x] All #686 lifting tests still pass (non-capturing path unchanged).
- [x] `make compile` self-hosts (verified locally).
- [x] `make test-integration` passes (25/25, verified locally).

## Verification

```bash
ulimit -v 8388608
make compile                                                  # self-hosts ✓
build/native/sailfin test compiler/tests/integration/closure_lifting_test.sfn        # 13/13 PASS
build/native/sailfin test compiler/tests/integration/closure_env_emission_test.sfn   # 17/17 PASS (A2 byte-for-byte invariant)
make test-integration                                         # 25/25 PASS
```

End-to-end smoke (single-int capture):

```llvm
%sfn_closure_env_0 = type { i64 }
...
define void @sailfin_user_main__test_capture() {
block.entry:
  %l0 = alloca i64
  store i64 10, i64* %l0
  %t0 = load i64, i64* %l0
  %t1 = getelementptr %sfn_closure_env_0, %sfn_closure_env_0* null, i32 1
  %t2 = ptrtoint %sfn_closure_env_0* %t1 to i64
  %t3 = call noalias i8* @sailfin_runtime_alloc_struct(i64 %t2)
  %t4 = bitcast i8* %t3 to %sfn_closure_env_0*
  %t5 = getelementptr inbounds %sfn_closure_env_0, %sfn_closure_env_0* %t4, i32 0, i32 0
  store i64 %t0, i64* %t5
  ...
}
define i64 @sfn_lambda_0__test_capture(i8* %__env, i64 %y) {
block.entry:
  %t0 = bitcast i8* %__env to %sfn_closure_env_0*
  %t1 = getelementptr inbounds %sfn_closure_env_0, %sfn_closure_env_0* %t0, i32 0, i32 0
  %t2 = load i64, i64* %t1
  %t3 = add i64 %t2, %y
  ret i64 %t3
}
```

Mutable-capture refusal:

```
$ build/native/sailfin emit --module-name m -o /tmp/m.ll llvm <mutable-capture.sfn>
llvm lowering [fatal]: capturing lambda #0 has mutable capture `x` (not yet supported, see #687)
$ echo $?
1
$ ls /tmp/m.ll
ls: cannot access '/tmp/m.ll': No such file or directory
```

## Files Changed

- `compiler/src/llvm/expression_lowering/native/lambda_lowering.sfn` — capturing-lambda lift path, prologue-marker synthesis, mutable refusal
- `compiler/src/llvm/closures.sfn` — `decode_captures` helper
- `compiler/src/llvm/expression_lowering/native/core.sfn` — extended `lower_closure_pair_marker` for env_alloc form, fatal-marker handler
- `compiler/src/llvm/expression_lowering/native/mod.sfn` — re-exports
- `compiler/src/llvm/lowering/instructions.sfn` — prologue-marker handler in `lower_instruction_range`
- `compiler/src/llvm/lowering/lowering_core.sfn` — `hoist_closure_env_type_decls` post-pass + fatal print
- `compiler/src/llvm/lowering/entrypoints.sfn` — print fatals from `print_llvm_ir_from_text`
- `compiler/tests/integration/closure_lifting_test.sfn` — four new tests (single capture, multi-typed order, shadowing, mutable refusal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NitwbR5Z2AriP5VQhLjpUz)_