### PR TITLE
feat(fs): perms / mkdtemp / symlink / is_executable (P5 / #366)

### DIFF
--- a/capsules/sfn/fs/src/mod.sfn
+++ b/capsules/sfn/fs/src/mod.sfn
@@ -2,7 +2,6 @@
 //
 // Provides typed access to the local filesystem. All operations require
 // the `io` effect and are synchronous in the current runtime.
-
 fn read(path: string) -> string ![io] {
     // Read the entire contents of a file as a UTF-8 string.
     return fs.readFile(path);
@@ -37,4 +36,59 @@ fn mkdir(path: string) -> void ![io] {
 fn read_dir(path: string) -> string[] ![io] {
     // List the entries in a directory.
     return fs.listDirectory(path);
+}
+
+// ---------------------------------------------------------------------
+// P5 (#366): Phase 0 precondition — five POSIX primitives the test
+// infrastructure epic (#362) relies on. Until the canonical
+// `Result<(), IoError>` type ships (runtime-enablement Phase 1), the
+// state-changing helpers follow the existing capsule convention:
+// `boolean` for "did the call succeed", numeric for "what value was
+// observed". POSIX-only; Windows builds return a benign failure.
+// ---------------------------------------------------------------------
+fn set_perms(path: string, mode: int) -> boolean ![io] {
+    // chmod(2) wrapper. `mode` is masked to the lower 12 bits before
+    // the syscall so callers can pass either the canonical permission
+    // bits (e.g. `0o644` once octal literals ship; until then,
+    // decimal 420) or a full `st_mode` and get sensible behavior.
+    // TODO: switch to Result<(), IoError> once shipped.
+    return fs.set_perms(path, mode);
+}
+
+fn get_perms(path: string) -> int ![io] {
+    // Returns the lower 12 bits of `st_mode` (perm + sticky/setuid/
+    // setgid) or -1 on any error. The 12-bit mask matches
+    // `stat -c '%a'` and Rust's `Permissions::mode() & 0o7777`.
+    // TODO: switch to Result<int, IoError> once shipped.
+    return fs.get_perms(path);
+}
+
+fn mkdtemp(prefix: string) -> string ![io] {
+    // Creates a unique directory under `$TMPDIR` (or `/tmp`) with
+    // mode `0700` and returns its absolute path. Uses `mkdtemp(3)`
+    // directly so the kernel guarantees uniqueness. Returns an
+    // empty string on failure.
+    //
+    // If `prefix` contains a `/`, it is treated as a path-prefixed
+    // template (the caller picks the parent dir); otherwise the
+    // result lives under the system temp dir.
+    // TODO: switch to Result<string, IoError> once shipped.
+    return fs.mkdtemp(prefix);
+}
+
+fn is_executable(path: string) -> boolean ![io] {
+    // True iff the current process can `exec` the path. Maps to
+    // `access(path, X_OK)`. Permission errors and missing files
+    // both collapse to `false`, mirroring POSIX semantics and
+    // Rust's `std::fs::metadata(...).permissions().mode() & 0o111`
+    // probe.
+    return fs.is_executable(path);
+}
+
+fn symlink(target: string, link: string) -> boolean ![io] {
+    // Creates `link` pointing at `target`. Per POSIX, the target
+    // need not exist; dangling symlinks are intentionally allowed.
+    // Returns true on success.
+    // TODO: switch to Result<(), IoError> once shipped.
+    return fs.symlink(target, link);
 }

--- a/capsules/sfn/fs/tests/fs_test.sfn
+++ b/capsules/sfn/fs/tests/fs_test.sfn
@@ -1,0 +1,171 @@
+// Tests for sfn/fs — P5 (#366) gap-fill primitives. The five
+// POSIX wrappers (`set_perms`, `get_perms`, `mkdtemp`,
+// `is_executable`, `symlink`) are what Phase 2 fixtures and the
+// Phase 3 bash collapse depend on; without these the rest of the
+// test-infra epic (#362) can't land.
+//
+// Tests use `mkdtemp` itself to mint a per-test scratch dir so the
+// suite is hermetic — no fixed `/tmp/sfn-fs-test-…` paths, no
+// races between parallel test invocations. Cleanup uses
+// `process.run(["rm", "-rf", …])` since the capsule doesn't ship a
+// recursive remove yet (Out-of-scope per the issue).
+import {
+    set_perms,
+    get_perms,
+    mkdtemp,
+    is_executable,
+    symlink,
+    exists,
+    write,
+    read,
+    remove
+} from "../src/mod";
+
+// ---------------------------------------------------------------------
+// Permission constants. The seed parser doesn't yet accept octal
+// literals (`0o644`); decimal is the canonical form per the issue's
+// "do not block on parser changes" guidance. The comments document
+// the POSIX intent so the round-trip values aren't magic.
+// ---------------------------------------------------------------------
+//   420 = 0o644 = rw-r--r--   (typical regular-file perms)
+//   384 = 0o600 = rw-------   (private file)
+//   493 = 0o755 = rwxr-xr-x   (typical executable)
+//   448 = 0o700 = rwx------   (mkdtemp's documented mode)
+// ---------------------------------------------------------------------
+// ── set_perms / get_perms ──────────────────────────────────────────
+test "fs: set_perms + get_perms round-trip on a regular file" ![io] {
+    let scratch = mkdtemp("sfn-fs-test-perms-");
+    assert scratch.length > 0;
+    let target = scratch + "/file.txt";
+    write(target, "round-trip");
+
+    // 420 = 0o644
+    assert set_perms(target, 420);
+    assert get_perms(target) == 420;
+
+    // 384 = 0o600 — confirm we can flip an existing file's bits.
+    assert set_perms(target, 384);
+    assert get_perms(target) == 384;
+
+    process.run(["rm", "-rf", scratch]);
+}
+
+test "fs: set_perms returns false on a missing path" ![io] {
+    // chmod on a non-existent path must surface as `false`, not
+    // silently report success. The negative path is what callers
+    // rely on when they don't want to pre-check existence.
+    assert set_perms("/tmp/sfn-fs-test-missing-path-XXXX", 420) == false;
+}
+
+test "fs: get_perms returns -1 on a missing path" ![io] {
+    // Per the issue spec: missing files map to a sentinel error
+    // value, not a permission-bit collision. -1 is unambiguous
+    // because `st_mode & 07777` can never produce a negative.
+    assert get_perms("/tmp/sfn-fs-test-missing-path-XXXX") == -1;
+}
+
+// ── mkdtemp ────────────────────────────────────────────────────────
+test "fs: mkdtemp creates a unique directory with mode 0700" ![io] {
+    let path = mkdtemp("sfn-fs-test-mkd-");
+    assert path.length > 0;
+    assert exists(path);
+    // 448 = 0o700 — `mkdtemp(3)` is documented to create the dir
+    // with this mode regardless of umask.
+    assert get_perms(path) == 448;
+
+    process.run(["rmdir", path]);
+}
+
+test "fs: mkdtemp returns distinct paths across calls" ![io] {
+    // Kernel-side uniqueness — two calls in quick succession must
+    // never collide. This is the whole reason for using
+    // `mkdtemp(3)` instead of generate-then-mkdir.
+    let a = mkdtemp("sfn-fs-test-uniq-");
+    let b = mkdtemp("sfn-fs-test-uniq-");
+    assert a.length > 0;
+    assert b.length > 0;
+    assert strings_equal(a, b) == false;
+
+    process.run(["rmdir", a]);
+    process.run(["rmdir", b]);
+}
+
+// ── is_executable ──────────────────────────────────────────────────
+test "fs: is_executable returns true for /bin/sh" ![io] {
+    // `/bin/sh` is POSIX-mandated. If a host doesn't have it, the
+    // rest of the runtime's `process.run`-based tests would already
+    // be broken — so this is a safe sentinel.
+    assert is_executable("/bin/sh");
+}
+
+test "fs: is_executable returns false for /etc/passwd" ![io] {
+    // /etc/passwd exists on every POSIX system but is never `+x`.
+    assert is_executable("/etc/passwd") == false;
+}
+
+test "fs: is_executable returns false for a missing path" ![io] {
+    // Missing files collapse to `false` rather than surfacing an
+    // error — matches Rust's `Path::exists`-style probe APIs.
+    assert is_executable("/tmp/sfn-fs-test-missing-exec-XXXX") == false;
+}
+
+test "fs: is_executable tracks set_perms flips" ![io] {
+    let scratch = mkdtemp("sfn-fs-test-exec-");
+    let script = scratch + "/probe.sh";
+    write(script, "#!/bin/sh\nexit 0\n");
+
+    // 420 = 0o644 — readable but not executable.
+    assert set_perms(script, 420);
+    assert is_executable(script) == false;
+
+    // 493 = 0o755 — owner exec bit set.
+    assert set_perms(script, 493);
+    assert is_executable(script);
+
+    process.run(["rm", "-rf", scratch]);
+}
+
+// ── symlink ────────────────────────────────────────────────────────
+test "fs: symlink creates a link readable through the target" ![io] {
+    let scratch = mkdtemp("sfn-fs-test-link-");
+    let target = scratch + "/target.txt";
+    let link = scratch + "/alias";
+    write(target, "linked-content");
+
+    assert symlink(target, link);
+    // Read through the symlink — exercises both `symlink(2)`
+    // creating the link and the kernel resolving it on open.
+    assert strings_equal(read(link), "linked-content");
+
+    process.run(["rm", "-rf", scratch]);
+}
+
+test "fs: symlink accepts a dangling target" ![io] {
+    // POSIX `symlink(2)` does not require the target to exist;
+    // dangling links are valid. The C runtime preserves that.
+    let scratch = mkdtemp("sfn-fs-test-dangling-");
+    let link = scratch + "/dangling";
+    let nonexistent = scratch + "/never-created";
+
+    assert symlink(nonexistent, link);
+    // `fs.exists` follows symlinks, so a dangling link reads as
+    // non-existent through that surface. We use `test -L` (true
+    // for symlinks regardless of target) to confirm the link
+    // file itself was created.
+    assert process.run(["test", "-L", link]) == 0;
+
+    process.run(["rm", "-rf", scratch]);
+}
+
+test "fs: symlink returns false when link path already exists" ![io] {
+    // POSIX rejects `symlink(2)` when the `link` path already
+    // exists. The wrapper should surface that as `false`, not
+    // a silent overwrite.
+    let scratch = mkdtemp("sfn-fs-test-collision-");
+    let link = scratch + "/already-there";
+    write(link, "occupant");
+
+    assert symlink("/tmp", link) == false;
+
+    process.run(["rm", "-rf", scratch]);
+}

--- a/compiler/src/llvm/lowering/lowering_helpers.sfn
+++ b/compiler/src/llvm/lowering/lowering_helpers.sfn
@@ -769,6 +769,14 @@ fn seed_default_runtime_helpers(initial: string[]) -> string[] {
     helpers = append_unique_effect(helpers, "fs.writeLines");
     helpers = append_unique_effect(helpers, "fs.createDirectory");
     helpers = append_unique_effect(helpers, "fs.read_bytes");
+    // P5 (#366): five new fs adapters — perms, mkdtemp, is_executable,
+    // symlink. Separate-compilation needs the declare-tracking entry
+    // for the same reason readFile / writeFile have one above.
+    helpers = append_unique_effect(helpers, "fs.set_perms");
+    helpers = append_unique_effect(helpers, "fs.get_perms");
+    helpers = append_unique_effect(helpers, "fs.mkdtemp");
+    helpers = append_unique_effect(helpers, "fs.is_executable");
+    helpers = append_unique_effect(helpers, "fs.symlink");
     // Additional helpers used by the compiler but not auto-collected
     helpers = append_unique_effect(helpers, "monotonic_millis");
     helpers = append_unique_effect(helpers, "find_char");

--- a/compiler/src/llvm/runtime_helpers.sfn
+++ b/compiler/src/llvm/runtime_helpers.sfn
@@ -365,6 +365,28 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
         target: "fs.createDirectory", symbol: "sailfin_adapter_fs_create_directory", return_type: "i1", parameter_types: ["i8*", "i1"], effects: ["io"], native_signature: null, c_abi_return_type: null
     });
 
+    // P5 (#366): filesystem stdlib gap-fill. Permission ops, temp-dir
+    // creation, exec-bit probing, and symlinks — the five POSIX
+    // primitives ~12 e2e bash scripts depend on. The seed cannot
+    // produce these calls yet; the descriptors land first so once
+    // the next seed includes them, capsule-level `fs.set_perms(...)`
+    // calls lower through this table just like `fs.exists`.
+    descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
+        target: "fs.set_perms", symbol: "sailfin_adapter_fs_set_perms", return_type: "i1", parameter_types: ["i8*", "i64"], effects: ["io"], native_signature: null, c_abi_return_type: null
+    });
+    descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
+        target: "fs.get_perms", symbol: "sailfin_adapter_fs_get_perms", return_type: "i64", parameter_types: ["i8*"], effects: ["io"], native_signature: null, c_abi_return_type: null
+    });
+    descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
+        target: "fs.mkdtemp", symbol: "sailfin_adapter_fs_mkdtemp", return_type: "i8*", parameter_types: ["i8*"], effects: ["io"], native_signature: null, c_abi_return_type: null
+    });
+    descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
+        target: "fs.is_executable", symbol: "sailfin_adapter_fs_is_executable", return_type: "i1", parameter_types: ["i8*"], effects: ["io"], native_signature: null, c_abi_return_type: null
+    });
+    descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
+        target: "fs.symlink", symbol: "sailfin_adapter_fs_symlink", return_type: "i1", parameter_types: ["i8*", "i8*"], effects: ["io"], native_signature: null, c_abi_return_type: null
+    });
+
     // HTTP adapters (distinct from intrinsics for adapter infrastructure)
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
         target: "http_get", symbol: "sailfin_adapter_http_get", return_type: "i8*", parameter_types: ["i8*"], effects: ["net"], native_signature: null, c_abi_return_type: null

--- a/docs/runtime_audit.md
+++ b/docs/runtime_audit.md
@@ -284,6 +284,10 @@ survives until process exit. This is why per-module compiler RAM reaches
 | `sailfin_adapter_fs_list_directory` | ✅ | Returns `SailfinPtrArray` |
 | `sailfin_adapter_fs_delete_file` / `_create_directory` | ✅ | |
 | `sailfin_intrinsic_fs_exists` | ✅ | stat-based |
+| `sailfin_adapter_fs_set_perms` / `_get_perms` | ✅ | `chmod(2)` + `stat(2) & 07777`; POSIX-only (#366) |
+| `sailfin_adapter_fs_mkdtemp` | ✅ | `mkdtemp(3)` direct; POSIX-only (#366) |
+| `sailfin_adapter_fs_is_executable` | ✅ | `access(X_OK)`; POSIX-only (#366) |
+| `sailfin_adapter_fs_symlink` | ✅ | `symlink(2)`; dangling targets allowed; POSIX-only (#366) |
 
 ### HTTP / network
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -701,7 +701,7 @@ The following capsules ship as part of the Sailfin standard library under
 | `sfn/math` | `"math"` | Shipped | None | abs, min/max, clamp, floor/ceil/round, pow, sum/mean |
 | `sfn/path` | `"path"` | Shipped | None | Path join, dirname, basename, ext, normalize |
 | `sfn/toml` | `"toml"` | Shipped | None | TOML v1.0 parsing, serialization, dotted-path access |
-| `sfn/fs` | `"fs"` | Shipped | `io` | File read/write/append, exists, mkdir, read_dir |
+| `sfn/fs` | `"fs"` | Shipped | `io` | File read/write/append, exists, mkdir, read_dir, set_perms, get_perms, mkdtemp, is_executable, symlink |
 | `sfn/os` | `"os"` | Shipped | `io` | Env vars, home dir, exec, exit |
 | `sfn/log` | `"log"` | Shipped | `io`, `clock` | Structured leveled logging with named loggers |
 | `sfn/time` | `"time"` | Shipped | `clock` | Sleep, monotonic timing, elapsed |

--- a/llms.txt
+++ b/llms.txt
@@ -250,7 +250,7 @@ Declares external C symbols for linking.
 | sfn/math  | "math"      | None          | abs, min, max, clamp, pow, floor, ceil   |
 | sfn/path  | "path"      | None          | join, dirname, basename, ext, normalize  |
 | sfn/toml  | "toml"      | None          | TOML parsing and serialization           |
-| sfn/fs    | "fs"        | io            | File read/write/append, exists, mkdir    |
+| sfn/fs    | "fs"        | io            | File r/w/append, exists, mkdir, perms, symlink, mkdtemp |
 | sfn/os    | "os"        | io            | Env vars, home dir, exec, exit           |
 | sfn/log   | "log"       | io, clock     | Structured leveled logging               |
 | sfn/time  | "time"      | clock         | Sleep, monotonic timing, elapsed         |

--- a/runtime/native/include/sailfin_runtime.h
+++ b/runtime/native/include/sailfin_runtime.h
@@ -345,6 +345,14 @@ extern "C"
     bool sailfin_adapter_fs_create_directory(void *path, bool recursive);
     bool sailfin_intrinsic_fs_exists(void *path);
 
+    // P5 (#366): perms / mkdtemp / symlink / is_executable. POSIX-only;
+    // Windows builds stub to a benign failure return.
+    bool sailfin_adapter_fs_set_perms(void *path, int64_t mode);
+    int64_t sailfin_adapter_fs_get_perms(void *path);
+    void *sailfin_adapter_fs_mkdtemp(void *prefix);
+    bool sailfin_adapter_fs_is_executable(void *path);
+    bool sailfin_adapter_fs_symlink(void *target, void *link);
+
     // Arena mark/rewind. Phase 5a (`docs/proposals/phase-5a-arena-reset.md`)
     // exposes the existing bump-allocator's mark/rewind primitive to
     // Sailfin code so in-process multi-module tools (`sfn check`,

--- a/runtime/native/src/sailfin_runtime.c
+++ b/runtime/native/src/sailfin_runtime.c
@@ -6936,6 +6936,174 @@ bool sailfin_intrinsic_fs_exists(void *path)
 }
 
 /* ------------------------------------------------------------------ */
+/* P5 (#366): Filesystem stdlib gap-fill — perms / mkdtemp /          */
+/* symlink / is_executable. POSIX-only; Windows stubs return a        */
+/* benign failure code so callers under WSL/MSYS see a consistent     */
+/* "not supported" result rather than a link-time miss.               */
+/* ------------------------------------------------------------------ */
+
+/* fs.set_perms(path, mode) — `chmod(2)` equivalent. Returns true on  */
+/* success, false on any error. `mode` is interpreted as the POSIX    */
+/* permission bits (lower 12 bits of `mode_t`); higher bits are       */
+/* masked off before the syscall to keep the surface narrow.          */
+bool sailfin_adapter_fs_set_perms(void *path, int64_t mode)
+{
+    _runtime_enter();
+    const char *path_str = (const char *)path;
+    if (!path_str)
+    {
+        return false;
+    }
+#if defined(_WIN32)
+    (void)mode;
+    return false;
+#else
+    mode_t masked = (mode_t)(mode & 07777);
+    return chmod(path_str, masked) == 0;
+#endif
+}
+
+/* fs.get_perms(path) — returns the lower 12 bits of `st_mode`        */
+/* (perm + sticky/setuid/setgid). Returns -1 on any error. The        */
+/* 12-bit mask matches `stat -c '%a'` and Rust's                      */
+/* `Permissions::mode() & 0o7777` convention.                         */
+int64_t sailfin_adapter_fs_get_perms(void *path)
+{
+    _runtime_enter();
+    const char *path_str = (const char *)path;
+    if (!path_str)
+    {
+        return -1;
+    }
+    struct stat st;
+    if (stat(path_str, &st) != 0)
+    {
+        return -1;
+    }
+    return (int64_t)(st.st_mode & 07777);
+}
+
+/* fs.mkdtemp(prefix) — uses `mkdtemp(3)` so the kernel guarantees a  */
+/* unique name. The returned path is allocated via `malloc` and owned */
+/* by the Sailfin caller; mode is `0700` per `mkdtemp` semantics.     */
+/* Returns an empty malloc'd string on error (the Sailfin caller can  */
+/* check for zero length).                                            */
+void *sailfin_adapter_fs_mkdtemp(void *prefix)
+{
+    _runtime_enter();
+    const char *prefix_str = prefix ? (const char *)prefix : "";
+#if defined(_WIN32)
+    /* Windows lacks mkdtemp; the issue scopes this to POSIX.         */
+    char *empty = (char *)malloc(1);
+    if (empty)
+    {
+        empty[0] = '\0';
+    }
+    return empty;
+#else
+    /* Determine the parent directory. If `prefix` is absolute or     */
+    /* contains a `/`, treat it as a full template prefix; otherwise  */
+    /* anchor under `$TMPDIR` (or `/tmp`).                            */
+    const char *tmpdir = NULL;
+    bool has_dir = false;
+    for (const char *p = prefix_str; *p; p++)
+    {
+        if (*p == '/')
+        {
+            has_dir = true;
+            break;
+        }
+    }
+    if (!has_dir)
+    {
+        tmpdir = getenv("TMPDIR");
+        if (!tmpdir || tmpdir[0] == '\0')
+        {
+            tmpdir = "/tmp";
+        }
+    }
+
+    size_t prefix_len = strlen(prefix_str);
+    size_t dir_len = tmpdir ? strlen(tmpdir) : 0;
+    /* Layout: [dir] [/] [prefix] [XXXXXX] [\0]                       */
+    size_t needed = dir_len + (dir_len > 0 ? 1 : 0) + prefix_len + 6 + 1;
+    char *template_buf = (char *)malloc(needed);
+    if (!template_buf)
+    {
+        char *empty = (char *)malloc(1);
+        if (empty)
+        {
+            empty[0] = '\0';
+        }
+        return empty;
+    }
+    size_t off = 0;
+    if (dir_len > 0)
+    {
+        memcpy(template_buf + off, tmpdir, dir_len);
+        off += dir_len;
+        template_buf[off++] = '/';
+    }
+    memcpy(template_buf + off, prefix_str, prefix_len);
+    off += prefix_len;
+    memcpy(template_buf + off, "XXXXXX", 6);
+    off += 6;
+    template_buf[off] = '\0';
+
+    char *created = mkdtemp(template_buf);
+    if (!created)
+    {
+        free(template_buf);
+        char *empty = (char *)malloc(1);
+        if (empty)
+        {
+            empty[0] = '\0';
+        }
+        return empty;
+    }
+    /* `mkdtemp` returns the same buffer it mutated in place.         */
+    return created;
+#endif
+}
+
+/* fs.is_executable(path) — true iff the current process has         */
+/* execute access. Maps to `access(path, X_OK)`. Missing files and   */
+/* permission errors both collapse to `false` per the issue spec.    */
+bool sailfin_adapter_fs_is_executable(void *path)
+{
+    _runtime_enter();
+    const char *path_str = (const char *)path;
+    if (!path_str)
+    {
+        return false;
+    }
+#if defined(_WIN32)
+    return false;
+#else
+    return access(path_str, X_OK) == 0;
+#endif
+}
+
+/* fs.symlink(target, link) — creates `link` pointing at `target`.   */
+/* Per POSIX, the target need not exist; dangling symlinks are       */
+/* valid. Returns true on success.                                    */
+bool sailfin_adapter_fs_symlink(void *target, void *link)
+{
+    _runtime_enter();
+    const char *target_str = (const char *)target;
+    const char *link_str = (const char *)link;
+    if (!target_str || !link_str)
+    {
+        return false;
+    }
+#if defined(_WIN32)
+    return false;
+#else
+    return symlink(target_str, link_str) == 0;
+#endif
+}
+
+/* ------------------------------------------------------------------ */
 /* Phase 5a: arena mark / rewind                                      */
 /* ------------------------------------------------------------------ */
 

--- a/site/src/content/docs/docs/reference/standard-library.md
+++ b/site/src/content/docs/docs/reference/standard-library.md
@@ -540,16 +540,86 @@ fn write_report(path: string, lines: string[]) ![io] {
 
 ---
 
+#### `fs.set_perms(path: string, mode: int) -> boolean ![io]`
+
+Set POSIX permission bits on `path` — the `chmod(2)` wrapper. `mode` is masked to the lower 12 bits (perm + sticky/setuid/setgid). Returns `true` on success, `false` on any error (missing file, permission denied, etc.). POSIX-only; Windows returns `false`.
+
+```sfn
+fn make_executable(path: string) ![io] {
+    // 0o755 = rwxr-xr-x (octal literals are pending; decimal for now)
+    fs.set_perms(path, 493);
+}
+```
+
+Note: octal literals (`0o755`) are pending parser support. Until they land, pass the decimal equivalent.
+
+---
+
+#### `fs.get_perms(path: string) -> int ![io]`
+
+Return the lower 12 bits of `st_mode` for `path` — the `stat -c '%a'` equivalent. Returns `-1` on any error (missing file, permission denied, etc.).
+
+```sfn
+fn is_world_readable(path: string) -> boolean ![io] {
+    let mode = fs.get_perms(path);
+    if mode == -1 { return false; }
+    // 4 = 0o004 = world-readable bit
+    return (mode & 4) != 0;
+}
+```
+
+---
+
+#### `fs.mkdtemp(prefix: string) -> string ![io]`
+
+Create a unique directory under `$TMPDIR` (or `/tmp` if unset) with mode `0700`, using `mkdtemp(3)` so the kernel guarantees uniqueness. Returns the absolute path, or an empty string on failure.
+
+If `prefix` contains a `/`, it is treated as a path-prefixed template (the caller picks the parent dir); otherwise the result lives under the system temp dir.
+
+```sfn
+fn scratch_for_run() -> string ![io] {
+    return fs.mkdtemp("sfn-build-");
+}
+```
+
+POSIX-only; Windows returns an empty string.
+
+---
+
+#### `fs.is_executable(path: string) -> boolean ![io]`
+
+Return `true` iff the current process can `exec` the path — the `access(path, X_OK)` equivalent. Permission errors and missing files both collapse to `false`. POSIX-only; Windows returns `false`.
+
+```sfn
+fn find_in_path(name: string) -> string ![io] {
+    let candidate = "/usr/local/bin/" + name;
+    if fs.is_executable(candidate) { return candidate; }
+    return "";
+}
+```
+
+---
+
+#### `fs.symlink(target: string, link: string) -> boolean ![io]`
+
+Create a symbolic link at `link` pointing at `target` — the `symlink(2)` wrapper. Per POSIX, the target need not exist; dangling links are intentionally allowed. Returns `true` on success, `false` if `link` already exists or any other error occurs. POSIX-only; Windows returns `false`.
+
+```sfn
+fn pin_current_release(target: string, link: string) ![io] {
+    fs.symlink(target, link);
+}
+```
+
+---
+
 ### Filesystem — Planned
 
 The following filesystem helpers are planned for a future release and are not available today:
 
 - `fs.readLines(path: string) -> string[] ![io]` — read file as an array of lines
-- `fs.deleteFile(path: string) ![io]` — delete a file
-- `fs.listDir(path: string) -> string[] ![io]` — list directory contents
-- `fs.makeDir(path: string) ![io]` — create a directory (and parents)
 - `fs.move(src: string, dst: string) ![io]` — rename or move a file
 - `fs.copy(src: string, dst: string) ![io]` — copy a file
+- `fs.walk(path: string) -> string[] ![io]` — recursive directory walk
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds five POSIX `fs.*` primitives the test-infra epic depends on: `set_perms`, `get_perms`, `mkdtemp`, `is_executable`, `symlink`.
- Wires them end-to-end: C adapter → runtime-helper descriptor → lowering preamble → capsule export → test coverage.
- Unblocks Phase 2 fixtures (`with_tmp_dir`) and Phase 3 bash collapse (~12 scripts).

Closes #366

## Acceptance Criteria

- [x] `capsules/sfn/fs/src/mod.sfn` exports the five new functions with documented signatures (`boolean`/`int` shape; `Result<T, IoError>` deferred to runtime-enablement Phase 1).
- [x] `capsules/sfn/fs/tests/fs_test.sfn` covers every function: round-trip `set_perms`/`get_perms` on `0o644`; `mkdtemp` returns an existing path with mode `0700`; `is_executable` true for `/bin/sh`, false for `/etc/passwd`; `symlink` creates a link readable via the target.
- [x] Error type follows existing `fs.read` conventions (TODO comments mark the upgrade path to `Result<T, IoError>`).
- [x] `make compile && make test && make check` passes — including the stage2/stage3 fixed-point check.
- [x] `sfn fmt --check` is clean.

## Verification

```bash
ulimit -v 8388608

make compile                         # ✓ built build/native/sailfin
make test                            # ✓ 100 unit + 25 integration + 61 e2e + 13 capsules
sfn fmt --check capsules/sfn/fs      # ✓ clean
make check                           # ✓ stage2 == stage3 fixed point
```

The dedicated test file runs all 12 cases under both the seed-built and seedcheck-built compilers:

```
PASS: fs_test.sfn (12/12)
```

## Files Changed

- `runtime/native/src/sailfin_runtime.c` + `runtime/native/include/sailfin_runtime.h` — five `sailfin_adapter_fs_*` C functions (POSIX, Windows stubbed to a benign failure return).
- `compiler/src/llvm/runtime_helpers.sfn` — five runtime-helper descriptors against the `fs.*` target names.
- `compiler/src/llvm/lowering/lowering_helpers.sfn` — declare-tracking entries for cross-module emission.
- `capsules/sfn/fs/src/mod.sfn` — five Sailfin-level exports.
- `capsules/sfn/fs/tests/fs_test.sfn` — new test file (12 hermetic test cases).
- `docs/status.md`, `docs/runtime_audit.md`, `llms.txt`, `site/src/content/docs/docs/reference/standard-library.md` — doc surface updated.

## Implementation Notes

- `mkdtemp` calls `mkdtemp(3)` directly (kernel-guaranteed uniqueness, mode `0700` by spec), not generate-then-mkdir.
- `get_perms` returns `st_mode & 07777` (lower 12 bits), matching `stat -c '%a'`. Errors map to `-1`.
- `is_executable` uses `access(X_OK)`; missing files and permission errors both collapse to `false`.
- `symlink(target, link)` allows dangling targets per POSIX. Collision on an existing `link` path returns `false`.
- `set_perms` masks `mode` to the lower 12 bits before the syscall so callers can pass either canonical permission bits or a full `st_mode` and get sensible behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01T3DUb1DkLYLZ83vN4o4dU7)_