### PR TITLE
refactor(lowering): route exception family through emit_runtime_call (M1.7.3)

### DIFF
--- a/compiler/src/llvm/lowering/instructions_try.sfn
+++ b/compiler/src/llvm/lowering/instructions_try.sfn
@@ -6,6 +6,7 @@ import { char_code, grapheme_at, substring } from "../../string_utils";
 import { lower_expression } from "../expression_lowering/native/core";
 import { coerce_operand_to_type } from "../expression_lowering/native/core_operands";
 import { append_local_binding } from "../expression_lowering/native/core_scopes";
+import { emit_runtime_call, empty_runtime_call_overrides } from "../expression_lowering/native/runtime_call";
 import { default_return_literal, format_local_pointer_name, format_temp_name } from "../expressions_helpers";
 import { make_child_scope_id } from "../lifetime";
 import { empty_string_constant_set, merge_string_constants } from "../strings";
@@ -176,9 +177,21 @@ fn lower_throw_instruction(function_name: string, instruction: NativeInstruction
         };
     }
 
-    current_lines.push("  call void @sailfin_runtime_set_exception(i8* "
-        + coerced.operand.value
-        + ")");
+    // M1.7.3 (#499): route through descriptor-driven dispatch. The
+    // `set_exception` descriptor declares `["i8*"]` parameter types
+    // and a `void` return; the coerced operand already carries `i8*`,
+    // so emit_runtime_call renders byte-identically with the prior
+    // hand-spelled emission.
+    let set_exc_operands: LLVMOperand[] = [coerced.operand];
+    let set_exc_call = emit_runtime_call("set_exception", set_exc_operands, empty_runtime_call_overrides(), current_temp, current_lines);
+    let mut _ci_se: int = 0;
+    loop {
+        if _ci_se >= set_exc_call.diagnostics.length { break; }
+        diagnostics.push(set_exc_call.diagnostics[_ci_se]);
+        _ci_se += 1;
+    }
+    current_lines = set_exc_call.lines;
+    current_temp = set_exc_call.temp_index;
     if llvm_return == "void" { current_lines.push("  ret void"); } else {
         current_lines.push("  ret " + llvm_return + " " + default_return_literal(llvm_return));
     }
@@ -213,7 +226,16 @@ fn lower_try_instruction(function: NativeFunction, start_index: int, llvm_return
     let mut collected_string_constants: StringConstant[] = empty_string_constant_set();
 
     // Reset exception state at start of try.
-    current_lines.push("  call void @sailfin_runtime_clear_exception()");
+    // M1.7.3 (#499): route through descriptor-driven dispatch.
+    let clear_exc_call = emit_runtime_call("clear_exception", [], empty_runtime_call_overrides(), current_temp, current_lines);
+    let mut _ci_ce: int = 0;
+    loop {
+        if _ci_ce >= clear_exc_call.diagnostics.length { break; }
+        diagnostics.push(clear_exc_call.diagnostics[_ci_ce]);
+        _ci_ce += 1;
+    }
+    current_lines = clear_exc_call.lines;
+    current_temp = clear_exc_call.temp_index;
 
     let try_label_alloc = allocate_block_label("try", current_block_counter);
     let try_label = try_label_alloc.label;
@@ -260,10 +282,20 @@ fn lower_try_instruction(function: NativeFunction, start_index: int, llvm_return
     collected_string_constants = merge_string_constants(collected_string_constants, try_result.string_constants);
 
     if !try_result.terminated {
+        // M1.7.3 (#499): route through descriptor-driven dispatch.
+        // Capture the temp name first so the subsequent `br i1` keeps
+        // referencing the same SSA value emit_runtime_call binds at
+        // `current_temp`.
         let has_exc = format_temp_name(current_temp);
-        current_temp += 1;
-        current_lines.push("  " + has_exc
-            + " = call i1 @sailfin_runtime_has_exception()");
+        let has_exc_call = emit_runtime_call("has_exception", [], empty_runtime_call_overrides(), current_temp, current_lines);
+        let mut _ci_he: int = 0;
+        loop {
+            if _ci_he >= has_exc_call.diagnostics.length { break; }
+            diagnostics.push(has_exc_call.diagnostics[_ci_he]);
+            _ci_he += 1;
+        }
+        current_lines = has_exc_call.lines;
+        current_temp = has_exc_call.temp_index;
         let normal_target = merge_label;
         if structure.finally_index != -1 { normal_target = finally_label; }
         if structure.catch_index != -1 {
@@ -280,10 +312,17 @@ fn lower_try_instruction(function: NativeFunction, start_index: int, llvm_return
         // Catch block
         current_lines.push(catch_label + ":");
         let catch_scope_id = make_child_scope_id(scope_id, catch_label);
+        // M1.7.3 (#499): route through descriptor-driven dispatch.
         let exception_temp = format_temp_name(current_temp);
-        current_temp += 1;
-        current_lines.push("  " + exception_temp
-            + " = call i8* @sailfin_runtime_take_exception()");
+        let take_exc_call = emit_runtime_call("take_exception", [], empty_runtime_call_overrides(), current_temp, current_lines);
+        let mut _ci_te: int = 0;
+        loop {
+            if _ci_te >= take_exc_call.diagnostics.length { break; }
+            diagnostics.push(take_exc_call.diagnostics[_ci_te]);
+            _ci_te += 1;
+        }
+        current_lines = take_exc_call.lines;
+        current_temp = take_exc_call.temp_index;
 
         // Catch-entry guarded drops (M1.5.4, issue #328). For every
         // owned rc local descended from the try scope, emit a
@@ -373,10 +412,17 @@ fn lower_try_instruction(function: NativeFunction, start_index: int, llvm_return
     current_lines.push(merge_label + ":");
 
     // If an exception is still pending after try/catch/finally, propagate it.
+    // M1.7.3 (#499): route through descriptor-driven dispatch.
     let has_exc_after = format_temp_name(current_temp);
-    current_temp += 1;
-    current_lines.push("  " + has_exc_after
-        + " = call i1 @sailfin_runtime_has_exception()");
+    let has_exc_after_call = emit_runtime_call("has_exception", [], empty_runtime_call_overrides(), current_temp, current_lines);
+    let mut _ci_ha: int = 0;
+    loop {
+        if _ci_ha >= has_exc_after_call.diagnostics.length { break; }
+        diagnostics.push(has_exc_after_call.diagnostics[_ci_ha]);
+        _ci_ha += 1;
+    }
+    current_lines = has_exc_after_call.lines;
+    current_temp = has_exc_after_call.temp_index;
     let propagate_label_alloc = allocate_block_label("try.propagate", current_block_counter);
     let propagate_label = propagate_label_alloc.label;
     current_block_counter = propagate_label_alloc.next_counter;


### PR DESCRIPTION
## Summary

- Migrates the 5 hardcoded `@sailfin_runtime_*_exception*` raw-string emissions in `compiler/src/llvm/lowering/instructions_try.sfn` to `emit_runtime_call` (the descriptor-driven dispatch landed in #495).
- All four exception descriptors (`set_exception`, `clear_exception`, `has_exception`, `take_exception`) were already registered in `runtime_helpers.sfn`, so this is a pure call-site migration — no schema or registry edits.
- `try_enter`, `try_leave`, and `throw` have no live emission sites in the current files; their descriptors stay registered for the alias-declare path until #501 (M1.7.5b) retires it. `seed_default_runtime_helpers` is untouched.

Unblocks M2.7's frame-emission switch.

Closes #499

## Acceptance Criteria

- [x] `grep -c '@sailfin_runtime_(set|clear|has|take)_exception' compiler/src/llvm/lowering/instructions_try.sfn` returns 0
- [x] Before/after IR diff empty on a try/catch fixture
- [x] `make check` green; full e2e suite passes
- [x] `sfn fmt --check` clean

## Verification

```bash
# 1. No raw exception emissions remain
grep -c '@sailfin_runtime_set_exception\|@sailfin_runtime_clear_exception\|@sailfin_runtime_has_exception\|@sailfin_runtime_take_exception' \
  compiler/src/llvm/lowering/instructions_try.sfn
# → 0

# 2. IR byte-identical for try/catch fixtures
ulimit -v 8388608 && make rebuild   # original source
build/native/sailfin --emit llvm examples/basics/try-catch-finally.sfn > /tmp/before.ll
build/native/sailfin --emit llvm compiler/tests/e2e/fixtures/drop_emission_try_catch_basic.sfn > /tmp/drop.before.ll
# apply migration, rebuild
build/native/sailfin --emit llvm examples/basics/try-catch-finally.sfn > /tmp/after.ll
build/native/sailfin --emit llvm compiler/tests/e2e/fixtures/drop_emission_try_catch_basic.sfn > /tmp/drop.after.ll
diff /tmp/before.ll /tmp/after.ll                # → empty
diff /tmp/drop.before.ll /tmp/drop.after.ll      # → empty

# 3. Full validation
ulimit -v 8388608 && make check
# → stage2 == stage3 fixed-point ✓; e2e 62/62 passed; capsules 13/13 passed

# 4. Formatting
build/native/sailfin fmt --check compiler/src/llvm/lowering/instructions_try.sfn
# → clean
```

## Migration Pattern

Each call site follows the same shape as M1.7.2a (#524):

```sfn
let call_result = emit_runtime_call("<target>", operands, empty_runtime_call_overrides(), current_temp, current_lines);
// drain diagnostics into the enclosing collector
current_lines = call_result.lines;
current_temp = call_result.temp_index;
```

For non-void calls (`has_exception`, `take_exception`), the SSA temp name is captured with `format_temp_name(current_temp)` *before* the dispatch so subsequent `br i1` / store sites keep referencing the correct value — `emit_runtime_call` formats the same temp internally at `result_temp` and returns `result_temp + 1`, so the IR is byte-identical.

## Files Changed

- `compiler/src/llvm/lowering/instructions_try.sfn` (+59 / -13)

## Notes for review

- Phase 1.5 seed-freshness gate: predecessor #495 was merged before seed `v0.6.0` was cut (PR #511 merged 2026-05-08; v0.6.0 tagged 2026-05-19). A strict `git merge-base --is-ancestor` against the PR's merge SHA reports false due to upstream rebases on `main`, but `git show v0.6.0:compiler/src/llvm/expression_lowering/native/runtime_call.sfn` confirms `emit_runtime_call` and `empty_runtime_call_overrides` are both exported from the seed. May be worth tweaking the pickup precheck to verify *contents* rather than merge-SHA ancestry in cases where main has been linearised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dpi6WtE1GwXARivbnWUsy9)_