### PR TITLE
refactor(lowering): inline NativeInstruction constructor helpers

### DIFF
--- a/compiler/src/llvm/lowering/lowering_native_helpers.sfn
+++ b/compiler/src/llvm/lowering/lowering_native_helpers.sfn
@@ -226,46 +226,6 @@ fn append_instruction_to_function(func: NativeFunction, instr: NativeInstruction
     return update_function_instructions(func, instrs);
 }
 
-// ── NativeInstruction constructors ───────────────────────────────────
-// NativeInstruction construction helpers (seed v0.1.1 drops enum variant constructors)
-// Tags: Return=0, Expression=1, If=3, Else=4, EndIf=5, Loop=8, EndLoop=9, Break=10, Continue=11, Unknown=21
-fn make_instruction_text(tag_val: int, text: string) -> NativeInstruction {
-    // Seed drops this; fixup pass replaces body
-    if tag_val == 0 {
-        return NativeInstruction.Return { expression: text, span: null };
-    }
-    if tag_val == 1 {
-        return NativeInstruction.Expression { expression: text, span: null };
-    }
-    if tag_val == 3 {
-        return NativeInstruction.If { condition: text };
-    }
-    if tag_val == 12 {
-        return NativeInstruction.Match { expression: text };
-    }
-    if tag_val == 13 {
-        return NativeInstruction.Case { pattern: text, guard: null };
-    }
-    return NativeInstruction.Unknown { text: text };
-}
-
-fn make_instruction_simple(tag_val: int) -> NativeInstruction {
-    // Seed drops this; fixup pass replaces body
-    if tag_val == 4 { return NativeInstruction.Else(); }
-    if tag_val == 5 { return NativeInstruction.EndIf(); }
-    if tag_val == 7 { return NativeInstruction.EndFor(); }
-    if tag_val == 8 { return NativeInstruction.Loop(); }
-    if tag_val == 9 { return NativeInstruction.EndLoop(); }
-    if tag_val == 10 { return NativeInstruction.Break(); }
-    if tag_val == 14 { return NativeInstruction.EndMatch(); }
-    return NativeInstruction.Continue();
-}
-
-fn make_instruction_for(target: string, iterable: string) -> NativeInstruction {
-    // Seed drops this; fixup pass replaces body
-    return NativeInstruction.For { target: target, iterable: iterable };
-}
-
 // ── NativeEnum field accessors ───────────────────────────────────────
 fn get_enum_name_at(enums: NativeEnum[], idx: int) -> string {
     let e = enums[idx];

--- a/compiler/src/llvm/lowering/lowering_recovery.sfn
+++ b/compiler/src/llvm/lowering/lowering_recovery.sfn
@@ -36,9 +36,6 @@ import {
     append_instruction_to_function,
     append_native_import,
     append_param_to_function,
-    make_instruction_for,
-    make_instruction_simple,
-    make_instruction_text,
     make_native_enum,
     make_native_enum_layout,
     make_native_enum_variant,
@@ -371,9 +368,14 @@ fn recover_native_functions_light(native_text: string) -> NativeFunction[] {
         }
 
         // --- Instruction parsing ---
-        let mut next_instruction: NativeInstruction = make_instruction_text(21, line);
+        let mut next_instruction: NativeInstruction = NativeInstruction.Unknown {
+            text: line
+        };
         if is_eval {
-            next_instruction = make_instruction_text(1, trim_text_local(substring(line, 5, line.length)));
+            next_instruction = NativeInstruction.Expression {
+                expression: trim_text_local(substring(line, 5, line.length)),
+                span: null
+            };
         }
         // --- Multiline struct literal gathering for eval instructions ---
         // When an eval line has an unquoted '{' with no matching '}', gather
@@ -415,37 +417,65 @@ fn recover_native_functions_light(native_text: string) -> NativeFunction[] {
             _gi += 1;
         }
         if _gather_score >= 3 {
-            next_instruction = make_instruction_text(1, trim_text_local(_eval_gathered));
+            next_instruction = NativeInstruction.Expression {
+                expression: trim_text_local(_eval_gathered),
+                span: null
+            };
             index = _gi - 1;
         }
         if is_dotreturn {
-            next_instruction = make_instruction_text(0, trim_text_local(substring(line, 7, line.length)));
+            next_instruction = NativeInstruction.Return {
+                expression: trim_text_local(substring(line, 7, line.length)),
+                span: null
+            };
         }
         if is_ret_space {
-            next_instruction = make_instruction_text(0, trim_text_local(substring(line, 4, line.length)));
+            next_instruction = NativeInstruction.Return {
+                expression: trim_text_local(substring(line, 4, line.length)),
+                span: null
+            };
         }
-        if is_ret_bare { next_instruction = make_instruction_text(0, ""); }
-        if is_else_kw { next_instruction = make_instruction_simple(4); }
-        if is_endif_kw { next_instruction = make_instruction_simple(5); }
+        if is_ret_bare {
+            next_instruction = NativeInstruction.Return {
+                expression: "",
+                span: null
+            };
+        }
+        if is_else_kw { next_instruction = NativeInstruction.Else(); }
+        if is_endif_kw { next_instruction = NativeInstruction.EndIf(); }
         if is_if_kw {
-            next_instruction = make_instruction_text(3, trim_text_local(substring(line, 4, line.length)));
+            next_instruction = NativeInstruction.If {
+                condition: trim_text_local(substring(line, 4, line.length))
+            };
         }
-        if is_loop_kw { next_instruction = make_instruction_simple(8); }
-        if is_endloop_kw { next_instruction = make_instruction_simple(9); }
+        if is_loop_kw { next_instruction = NativeInstruction.Loop(); }
+        if is_endloop_kw { next_instruction = NativeInstruction.EndLoop(); }
         if is_for_kw {
             if for_in_idx >= 0 {
-                next_instruction = make_instruction_for(for_target_raw, for_iterable_raw);
+                next_instruction = NativeInstruction.For {
+                    target: for_target_raw,
+                    iterable: for_iterable_raw
+                };
             }
         }
-        if is_endfor_kw { next_instruction = make_instruction_simple(7); }
-        if is_break_kw { next_instruction = make_instruction_simple(10); }
-        if is_continue_kw { next_instruction = make_instruction_simple(11); }
-        if is_match_kw {
-            next_instruction = make_instruction_text(12, match_expr_raw);
+        if is_endfor_kw { next_instruction = NativeInstruction.EndFor(); }
+        if is_break_kw { next_instruction = NativeInstruction.Break(); }
+        if is_continue_kw {
+            next_instruction = NativeInstruction.Continue();
         }
-        if is_endmatch_kw { next_instruction = make_instruction_simple(14); }
+        if is_match_kw {
+            next_instruction = NativeInstruction.Match {
+                expression: match_expr_raw
+            };
+        }
+        if is_endmatch_kw {
+            next_instruction = NativeInstruction.EndMatch();
+        }
         if is_case_kw {
-            next_instruction = make_instruction_text(13, case_pattern_raw);
+            next_instruction = NativeInstruction.Case {
+                pattern: case_pattern_raw,
+                guard: null
+            };
         }
         // Inline match case: `pattern => body,` — emit Case + body instructions.
         // Must NOT fire on `.case` or `.match` lines that happen to contain ` => `.
@@ -462,13 +492,22 @@ fn recover_native_functions_light(native_text: string) -> NativeFunction[] {
         if !is_fn_start { _inline_score += 1; }
         if !is_fn_end { _inline_score += 1; }
         if _inline_score >= 7 {
-            let case_instr = make_instruction_text(13, inline_pattern_raw);
+            let case_instr = NativeInstruction.Case {
+                pattern: inline_pattern_raw,
+                guard: null
+            };
             current = append_instruction_to_function(current, case_instr);
             if inline_body_is_return {
-                next_instruction = make_instruction_text(0, inline_return_expr);
+                next_instruction = NativeInstruction.Return {
+                    expression: inline_return_expr,
+                    span: null
+                };
             }
             if !inline_body_is_return {
-                next_instruction = make_instruction_text(1, inline_body_raw);
+                next_instruction = NativeInstruction.Expression {
+                    expression: inline_body_raw,
+                    span: null
+                };
             }
         }
 


### PR DESCRIPTION
## Summary
- Replaces the three `make_instruction_text` / `make_instruction_simple` / `make_instruction_for` helpers in `lowering_native_helpers.sfn` with direct `NativeInstruction.<Variant> { ... }` construction at every call site in `lowering_recovery.sfn`.
- Deletes the helpers and their stale `// Seed drops this; fixup pass replaces body` annotations — the seed-divergence audit in #623 confirmed the current pinned seed (`v0.6.0`) compiles direct variant construction to the same IR.

Closes #624

## Acceptance Criteria
- [x] Three constructor helpers deleted; their annotations gone.
- [x] `lowering_recovery.sfn` constructs `NativeInstruction` variants directly.
- [x] `make compile && make check` green.
- [x] No new failures in `compiler/tests/e2e/`.

## Verification
```bash
ulimit -v 8388608 && make compile && make check
# unit: 100/100 passed, 0 failed (after one flake retry)
# integration: 13/13 passed, 0 failed
# e2e: 62/62 passed, 0 failed
# capsules: 13/13 passed, 0 failed
# stage2 == stage3: compiler is a fixed point ✓

grep -rn "make_instruction_" compiler/src/ runtime/
# (empty — zero hits)
```

## Files Changed
- `compiler/src/llvm/lowering/lowering_native_helpers.sfn` — deleted three helpers and the `// Seed drops this …` block (-40 lines)
- `compiler/src/llvm/lowering/lowering_recovery.sfn` — inlined ~30 call sites; dropped the three imports (+64/-25 lines net)

## Notes
- One transient `emit_native_extern_test.sfn` SIGSEGV under parallel unit runs on the first pass; isolated re-run passed and the second `make check` was clean end-to-end. Tracking informally — does not appear caused by this change (no overlap with extern lowering).


---
_Generated by [Claude Code](https://claude.ai/code/session_01UwQoWpirUoL8rwMztDV2Cu)_