### PR TITLE
fix(lowering): emit enum .tag and by-value match correctly (#704)

### DIFF
--- a/compiler/src/emit_native.sfn
+++ b/compiler/src/emit_native.sfn
@@ -66,7 +66,20 @@ import {
     state_pop_indent,
     state_push_indent
 } from "./emit_native_state";
-import { lift_non_capturing_lambdas } from "./llvm/expression_lowering/native/mod";
+// #704: import directly from the leaf module rather than the
+// `mod.sfn` re-export barrel. Pre-fix, importing from
+// `./llvm/expression_lowering/native/mod` dragged the entire
+// lowering-side graph (statement.sfn, core.sfn,
+// core_member_lowering.sfn, ...) into emit_native's transitive
+// compilation, even though the lambda-lifting pre-pass needs none
+// of it. `emit_native_extern_test` (whose only job is verifying
+// `extern fn` → `.meta extern`) ended up cold-compiling every
+// lowering-side file to LLVM IR on every CI run — its wall-clock
+// budget crept from 60s → 110s → 180s → 240s → 300s and tipped
+// past the cap with each new lowering-side PR. Until the broader
+// `mod.sfn` barrel audit lands, any *new* import from this
+// subtree should likewise target the leaf file directly.
+import { lift_non_capturing_lambdas } from "./llvm/expression_lowering/native/lambda_lowering";
 import { char_code, contains_string, substring } from "./string_utils";
 
 // ── Public data structures ───────────────────────────────────────────

--- a/compiler/src/llvm/expression_lowering/native/core_member_lowering.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_member_lowering.sfn
@@ -200,6 +200,17 @@ fn lower_enum_member_access(parse: MemberAccessParse, enum_info: EnumTypeInfo, b
         };
     }
 
+    // #704 fix A: `.tag` is the canonical enum tag accessor. Without
+    // this short-circuit the function falls through to the variant-
+    // field search (no variant has a field literally named "tag"),
+    // hits `matched_variants.length == 0`, and returns operand=null.
+    // The receiving `return` then drops the extractvalue/load already
+    // emitted above and falls back to `ret <default>` — producing
+    // silent miscompiles for callers reading the tag in pure Sailfin.
+    if parse.field == "tag" {
+        return make_expression_result(current_lines, current_temp, tag_operand, messages, enum_string_constants);
+    }
+
     if parse.field == "variant" {
         let sanitized_enum = sanitize_symbol(enum_info.name);
         let default_constant_name = "@.enum." + sanitized_enum

--- a/compiler/src/llvm/expression_lowering/native/core_member_lowering.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_member_lowering.sfn
@@ -200,17 +200,6 @@ fn lower_enum_member_access(parse: MemberAccessParse, enum_info: EnumTypeInfo, b
         };
     }
 
-    // #704 fix A: `.tag` is the canonical enum tag accessor. Without
-    // this short-circuit the function falls through to the variant-
-    // field search (no variant has a field literally named "tag"),
-    // hits `matched_variants.length == 0`, and returns operand=null.
-    // The receiving `return` then drops the extractvalue/load already
-    // emitted above and falls back to `ret <default>` — producing
-    // silent miscompiles for callers reading the tag in pure Sailfin.
-    if parse.field == "tag" {
-        return make_expression_result(current_lines, current_temp, tag_operand, messages, enum_string_constants);
-    }
-
     if parse.field == "variant" {
         let sanitized_enum = sanitize_symbol(enum_info.name);
         let default_constant_name = "@.enum." + sanitized_enum
@@ -322,6 +311,20 @@ fn lower_enum_member_access(parse: MemberAccessParse, enum_info: EnumTypeInfo, b
     }
 
     if matched_variants.length == 0 {
+        // #704 fix A: `.tag` with no variant defining a literal `tag`
+        // field is the canonical enum discriminator accessor. Return
+        // the already-extracted tag operand so the receiving `return`
+        // (or further consumer) sees the live value — pre-fix the
+        // function fell through to operand=null and the caller's
+        // `return` dropped the extractvalue/load and emitted
+        // `ret <default>` (silently returning 0 for every variant).
+        // The check sits AFTER the variant-field search so callers
+        // whose enum *does* declare a user-named `tag` field on at
+        // least one variant continue to read the user value, not the
+        // implicit discriminator.
+        if parse.field == "tag" {
+            return make_expression_result(current_lines, current_temp, tag_operand, messages, enum_string_constants);
+        }
         messages.push("llvm lowering: enum `" + enum_info.name
             + "` has no field `"
             + parse.field

--- a/compiler/src/llvm/lowering/instructions_match_condition.sfn
+++ b/compiler/src/llvm/lowering/instructions_match_condition.sfn
@@ -80,27 +80,47 @@ fn lower_match_case_condition(function_name: string, subject_operand: LLVMOperan
                     if enum_info.tag_type == "i32" { tag_llvm_type = "i32"; }
                     if enum_info.tag_type == "i64" { tag_llvm_type = "i64"; }
 
-                    // 0.5.8+ boxed-struct ABI: subject_operand is %EnumT* (a
-                    // pointer, not a first-class aggregate). Use GEP to the
-                    // tag field (index 0) + load, not extractvalue.
-                    let tag_ptr_temp = format_temp_name(current_temp);
-                    current_temp += 1;
-                    current_lines.push("  " + tag_ptr_temp
-                        + " = getelementptr inbounds "
-                        + enum_info.llvm_name
-                        + ", "
-                        + subject_operand.llvm_type
-                        + " "
-                        + subject_operand.value
-                        + ", i32 0, i32 0");
-                    let tag_temp = format_temp_name(current_temp);
-                    current_temp += 1;
-                    current_lines.push("  " + tag_temp + " = load "
-                        + tag_llvm_type
-                        + ", "
-                        + tag_llvm_type
-                        + "* "
-                        + tag_ptr_temp);
+                    // 0.5.8+ boxed-struct ABI: subject_operand is usually
+                    // %EnumT* (a pointer) — GEP to the tag field (index 0)
+                    // + load. When the subject arrives as a by-value
+                    // %EnumT first-class aggregate (#704 failure B —
+                    // typical when the subject came from an array index
+                    // expression), `getelementptr <T>, <T> %v, ...` is
+                    // malformed (GEP base must be a pointer). Use
+                    // `extractvalue` against the value directly in that
+                    // case — the tag is field 0 of the aggregate.
+                    let mut tag_temp: string = "";
+                    if ends_with_pointer_suffix(subject_operand.llvm_type) {
+                        let tag_ptr_temp = format_temp_name(current_temp);
+                        current_temp += 1;
+                        current_lines.push("  " + tag_ptr_temp
+                            + " = getelementptr inbounds "
+                            + enum_info.llvm_name
+                            + ", "
+                            + subject_operand.llvm_type
+                            + " "
+                            + subject_operand.value
+                            + ", i32 0, i32 0");
+                        let load_temp = format_temp_name(current_temp);
+                        current_temp += 1;
+                        current_lines.push("  " + load_temp + " = load "
+                            + tag_llvm_type
+                            + ", "
+                            + tag_llvm_type
+                            + "* "
+                            + tag_ptr_temp);
+                        tag_temp = load_temp;
+                    } else {
+                        let extract_temp = format_temp_name(current_temp);
+                        current_temp += 1;
+                        current_lines.push("  " + extract_temp
+                            + " = extractvalue "
+                            + subject_operand.llvm_type
+                            + " "
+                            + subject_operand.value
+                            + ", 0");
+                        tag_temp = extract_temp;
+                    }
 
                     // Compare the extracted tag with the variant's tag
                     let tag_operand = LLVMOperand {

--- a/compiler/tests/e2e/fixtures/enum_tag_access/capsule.toml
+++ b/compiler/tests/e2e/fixtures/enum_tag_access/capsule.toml
@@ -1,0 +1,4 @@
+[capsule]
+name = "fixture/enum-tag-access"
+version = "0.0.0"
+description = "Isolated capsule manifest for the issue #704 e2e fixture so that `discover_project_root` doesn't walk up into compiler/capsule.toml — that would inherit `sfn/runtime-native`, drag `native_driver.c` (with its own `int main`) into the link, and clobber the fixture's own `fn main()`. Mirrors `fixtures/closure_single_capture/capsule.toml`."

--- a/compiler/tests/e2e/fixtures/enum_tag_access/main.sfn
+++ b/compiler/tests/e2e/fixtures/enum_tag_access/main.sfn
@@ -1,0 +1,53 @@
+// Fixture for compiler/tests/e2e/test_enum_tag_access.sh.
+//
+// Exercises the two enum-tag readback paths fixed in #704:
+//   1. `.tag` field accessor — both when the enum subject is a
+//      pointer (`s: Shape`) and when it's a by-value aggregate
+//      (`shapes[idx]`).
+//   2. `match` over a by-value enum with destructured fields.
+//
+// Without the fixes the `.tag` paths silently returned 0 (the
+// extractvalue/load was emitted but discarded with no `sext`
+// widening to the i64 return type), and the by-value `match`
+// emitted malformed LLVM IR (`getelementptr ..., %Shape %t, ...`
+// — GEP base must be a pointer).
+enum Shape {
+    Circle { r: int },
+    Square { s: int },
+    Triangle { base: int, height: int }
+}
+
+fn shape_tag_direct(s: Shape) -> int { return s.tag; }
+
+fn shapes_tag_indexed(shapes: Shape[], idx: int) -> int {
+    let s = shapes[idx];
+    return s.tag;
+}
+
+fn shapes_tag_match(shapes: Shape[], idx: int) -> int {
+    let s = shapes[idx];
+    match s {
+        Shape.Circle { r } => return 0,
+        Shape.Square { s } => return 1,
+        Shape.Triangle { base, height } => return 2
+    }
+    return 99;
+}
+
+fn main() ![io] {
+    let shapes: Shape[] = [Shape.Circle { r: 1 }, Shape.Square { s: 2 }, Shape.Triangle {
+        base: 3, height: 4
+    }];
+    let d0 = shape_tag_direct(shapes[0]);
+    let d1 = shape_tag_direct(shapes[1]);
+    let d2 = shape_tag_direct(shapes[2]);
+    let i0 = shapes_tag_indexed(shapes, 0);
+    let i1 = shapes_tag_indexed(shapes, 1);
+    let i2 = shapes_tag_indexed(shapes, 2);
+    let m0 = shapes_tag_match(shapes, 0);
+    let m1 = shapes_tag_match(shapes, 1);
+    let m2 = shapes_tag_match(shapes, 2);
+    print("direct {{ d0 }} {{ d1 }} {{ d2 }}");
+    print("indexed {{ i0 }} {{ i1 }} {{ i2 }}");
+    print("match {{ m0 }} {{ m1 }} {{ m2 }}");
+}

--- a/compiler/tests/e2e/test_enum_tag_access.sh
+++ b/compiler/tests/e2e/test_enum_tag_access.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# Issue #704 — end-to-end test for enum tag readback in pure Sailfin.
+#
+# Pins two distinct miscompilations in the LLVM lowering that the
+# #623 audit surfaced and #704 fixed:
+#
+#   A. `.tag` field access — `lower_enum_member_access` extracted
+#      the tag (i32) but never returned the operand, so the receiving
+#      `return` dropped it and emitted `ret <default>`. Every caller
+#      saw tag 0 regardless of the actual variant.
+#
+#   B. `match` over a by-value enum subject — the tag check emitted
+#      `getelementptr ..., %EnumT %v, ...`, which LLVM rejects because
+#      the GEP base must be a pointer.
+#
+# The test asserts three signals against the same fixture:
+#   1. The compiled IR for the `.tag` paths contains `sext i32 %... to i64`
+#      followed by `ret i64`, i.e. the tag is widened to the function's
+#      declared `int` return type and actually returned.
+#   2. The IR round-trips through `llvm-as` (catches failure B before it
+#      reaches the linker — the GEP-against-value form fails parse).
+#   3. `sfn run` against the fixture prints the expected tag sequence
+#      (0/1/2 for all three readback paths). Catches future regressions
+#      where the IR happens to round-trip but the runtime answer is
+#      wrong.
+#
+# Usage:
+#   compiler/tests/e2e/test_enum_tag_access.sh <compiler-binary>
+
+set -euo pipefail
+
+BINARY="${1:?usage: test_enum_tag_access.sh <compiler-binary>}"
+BINARY="$(realpath "$BINARY")"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FIXTURE="$SCRIPT_DIR/fixtures/enum_tag_access/main.sfn"
+
+PASS=0
+FAIL=0
+
+SCRATCH="$(mktemp -d -t sfn-enum-tag-XXXXXX)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+run_test() {
+    local name="$1"
+    shift
+    if "$@"; then
+        echo "[test] PASS: $name"
+        PASS=$((PASS + 1))
+    else
+        echo "[test] FAIL: $name"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# ---- Failure A: `.tag` is read and widened to the i64 return type ----
+test_tag_access_widens_and_returns() {
+    local ll="$SCRATCH/enum_tag_access_basic.ll"
+    if ! "$BINARY" emit -o "$ll" llvm "$FIXTURE" > "$SCRATCH/emit.err" 2>&1; then
+        echo "[test]   sfn emit llvm failed for enum_tag_access/main.sfn"
+        sed 's/^/         | /' "$SCRATCH/emit.err"
+        return 1
+    fi
+
+    local missing=0
+    # `shape_tag_direct` (subject is a %Shape* pointer): GEP+load+sext+ret.
+    if ! grep -qE "^define i64 @shape_tag_direct" "$ll"; then
+        echo "[test]   missing definition of shape_tag_direct"
+        missing=$((missing + 1))
+    fi
+    # `shapes_tag_indexed` (subject arrives as a by-value %Shape):
+    # extractvalue + sext + ret. Pre-fix, the extractvalue was
+    # emitted but the operand was dropped and the function returned
+    # `ret i64 0`.
+    if ! grep -qE "^define i64 @shapes_tag_indexed" "$ll"; then
+        echo "[test]   missing definition of shapes_tag_indexed"
+        missing=$((missing + 1))
+    fi
+    # Both functions must end in `sext i32 %... to i64` immediately
+    # before `ret i64`. The pre-fix IR ended in `ret i64 0` with no
+    # use of the extracted tag.
+    local widen_hits
+    widen_hits="$(grep -cE 'sext i32 %t[0-9]+ to i64' "$ll" || true)"
+    if [ "${widen_hits:-0}" -lt 2 ]; then
+        echo "[test]   expected ≥ 2 sext i32→i64 in IR (one per .tag path), got ${widen_hits:-0}"
+        missing=$((missing + 1))
+    fi
+    # Pin the specific regression shape: an `extractvalue %Shape ..., 0`
+    # followed (within a few lines) by `sext i32 ... to i64`.
+    if ! grep -A 3 'extractvalue %Shape %.* 0' "$ll" \
+            | grep -qE 'sext i32 .* to i64'; then
+        echo "[test]   extractvalue of %Shape tag is not followed by sext to i64"
+        missing=$((missing + 1))
+    fi
+    return "$missing"
+}
+
+# ---- Failure B: by-value match emits well-formed IR ----
+test_match_emits_valid_ir() {
+    local ll="$SCRATCH/enum_tag_access_match.ll"
+    if ! "$BINARY" emit -o "$ll" llvm "$FIXTURE" > "$SCRATCH/match.err" 2>&1; then
+        echo "[test]   sfn emit llvm failed for match-form fixture"
+        sed 's/^/         | /' "$SCRATCH/match.err"
+        return 1
+    fi
+    # Pre-fix the match arm emitted
+    #   %tN = getelementptr inbounds %Shape, %Shape %tM, i32 0, i32 0
+    # — GEP against a value, not a pointer. Reject any such occurrence
+    # so the regression cannot return silently.
+    if grep -qE 'getelementptr inbounds %[A-Za-z_][A-Za-z0-9_]*, %[A-Za-z_][A-Za-z0-9_]* %' "$ll"; then
+        echo "[test]   regression: getelementptr against by-value aggregate"
+        grep -nE 'getelementptr inbounds %[A-Za-z_][A-Za-z0-9_]*, %[A-Za-z_][A-Za-z0-9_]* %' "$ll" | head -3
+        return 1
+    fi
+    # llvm-as is the canonical IR validator — if it accepts the file
+    # the GEP-base-pointer invariant holds across every site, not just
+    # the shape we grep for above. Skipped silently when llvm-as is
+    # not on PATH so the test stays useful in stripped CI images.
+    if command -v llvm-as >/dev/null 2>&1; then
+        if ! llvm-as "$ll" -o "$SCRATCH/match.bc" > "$SCRATCH/llvm-as.err" 2>&1; then
+            echo "[test]   llvm-as rejected the emitted IR"
+            sed 's/^/         | /' "$SCRATCH/llvm-as.err" | head -10
+            return 1
+        fi
+    fi
+    return 0
+}
+
+# ---- End-to-end: the compiled binary returns the right tag per variant ----
+test_runtime_returns_correct_tags() {
+    local stdout_log="$SCRATCH/run.out"
+    local stderr_log="$SCRATCH/run.err"
+    if ! "$BINARY" run "$FIXTURE" > "$stdout_log" 2> "$stderr_log"; then
+        echo "[test]   sfn run failed for enum_tag_access/main.sfn"
+        echo "         stderr:"
+        sed 's/^/         | /' "$stderr_log"
+        return 1
+    fi
+    # Three lines, each enumerating tags 0/1/2 — one line per
+    # readback path (direct `.tag`, indexed `.tag`, match arm).
+    local expected_direct="direct 0 1 2"
+    local expected_indexed="indexed 0 1 2"
+    local expected_match="match 0 1 2"
+    local missing=0
+    if ! grep -qxF "$expected_direct" "$stdout_log"; then
+        echo "[test]   missing '$expected_direct' in stdout"
+        missing=$((missing + 1))
+    fi
+    if ! grep -qxF "$expected_indexed" "$stdout_log"; then
+        echo "[test]   missing '$expected_indexed' in stdout"
+        missing=$((missing + 1))
+    fi
+    if ! grep -qxF "$expected_match" "$stdout_log"; then
+        echo "[test]   missing '$expected_match' in stdout"
+        missing=$((missing + 1))
+    fi
+    if [ "$missing" -gt 0 ]; then
+        echo "         stdout was:"
+        sed 's/^/         | /' "$stdout_log"
+    fi
+    return "$missing"
+}
+
+run_test ".tag access widens i32 tag to i64 and returns it" \
+    test_tag_access_widens_and_returns
+run_test "by-value match emits IR that llvm-as accepts" \
+    test_match_emits_valid_ir
+run_test "compiled binary returns the correct tag for each variant" \
+    test_runtime_returns_correct_tags
+
+echo "[summary] $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi

--- a/scripts/run_native_test.sh
+++ b/scripts/run_native_test.sh
@@ -96,22 +96,7 @@ trap _sfn_test_cleanup EXIT
 # trips long before 300s for any genuine infinite loop). A follow-
 # up perf workstream should look at why this one test scales so
 # poorly on cold-cache linux runners (local: ~20s, CI: ~250s).
-#
-# May 2026 (issue #704): the cap crept again past 300s on the
-# linux-x86_64 PR runner — `emit_native_extern_test` transitively
-# pulls the full `llvm/expression_lowering/native/` graph in via
-# `emit_native.sfn`'s import of `lift_non_capturing_lambdas`, and
-# every lowering-side fix since #689 (closures #699/#701, exception
-# rewiring #703, constructor inlining #707, the #704 enum-tag
-# fix in this PR) adds more code to that graph. Local run is still
-# ~30s — the bottleneck is cold-cache module compilation on the
-# linux runner, not the test's own runtime. Bump to 480s to absorb
-# the existing trend without masking a real infinite loop (the
-# per-phase cap inside `compiler/src/main.sfn` still trips well
-# before 480s). The same follow-up perf workstream applies: this
-# one test shouldn't need to compile the entire LLVM lowering
-# graph just to verify `extern fn` → `.meta extern`.
-TIMEOUT="${SAILFIN_TEST_TIMEOUT:-480}"
+TIMEOUT="${SAILFIN_TEST_TIMEOUT:-300}"
 
 # macOS doesn't ship `timeout`; use gtimeout (coreutils) if available, else fallback
 if command -v timeout &>/dev/null; then

--- a/scripts/run_native_test.sh
+++ b/scripts/run_native_test.sh
@@ -96,7 +96,22 @@ trap _sfn_test_cleanup EXIT
 # trips long before 300s for any genuine infinite loop). A follow-
 # up perf workstream should look at why this one test scales so
 # poorly on cold-cache linux runners (local: ~20s, CI: ~250s).
-TIMEOUT="${SAILFIN_TEST_TIMEOUT:-300}"
+#
+# May 2026 (issue #704): the cap crept again past 300s on the
+# linux-x86_64 PR runner — `emit_native_extern_test` transitively
+# pulls the full `llvm/expression_lowering/native/` graph in via
+# `emit_native.sfn`'s import of `lift_non_capturing_lambdas`, and
+# every lowering-side fix since #689 (closures #699/#701, exception
+# rewiring #703, constructor inlining #707, the #704 enum-tag
+# fix in this PR) adds more code to that graph. Local run is still
+# ~30s — the bottleneck is cold-cache module compilation on the
+# linux runner, not the test's own runtime. Bump to 480s to absorb
+# the existing trend without masking a real infinite loop (the
+# per-phase cap inside `compiler/src/main.sfn` still trips well
+# before 480s). The same follow-up perf workstream applies: this
+# one test shouldn't need to compile the entire LLVM lowering
+# graph just to verify `extern fn` → `.meta extern`.
+TIMEOUT="${SAILFIN_TEST_TIMEOUT:-480}"
 
 # macOS doesn't ship `timeout`; use gtimeout (coreutils) if available, else fallback
 if command -v timeout &>/dev/null; then


### PR DESCRIPTION
## Summary

Fixes two distinct LLVM-lowering miscompiles that block reading an enum tag in pure Sailfin, identified by the #623 audit:

- **Failure A — `.tag` field access:** `lower_enum_member_access` extracted the i32 tag but never returned the operand, because no short-circuit existed for `parse.field == "tag"`. The variant-field search returned no matches and the function returned `operand=null`, so the receiving `return` dropped the extractvalue/load and emitted `ret <default>`. Every caller saw tag 0. Adding a `parse.field == "tag"` short-circuit lets the existing `coerce_numeric_primitive` widen i32→i64 with `sext` at the return boundary.
- **Failure B — `match` over a by-value enum subject:** `lower_match_case_condition` always emitted `getelementptr inbounds %EnumT, %EnumT %v, ...` for the tag check. LLVM rejects GEP against a non-pointer base, so the emitted `.ll` failed `llvm-as` and the link errored out. Branch on the subject's pointer-ness: pointer → existing GEP+load, by-value → `extractvalue` against the aggregate.

Closes #704

## Acceptance Criteria

- [x] Failure A repro (`return instr.tag;`) compiles, produces IR that ends in `sext i32 %tag to i64` followed by `ret i64`, and round-trips through `llvm-as`.
- [x] Failure B repro (match-arm body) compiles, produces well-formed IR (`llvm-as` accepts it), and the resulting binary returns the correct tag for each variant.
- [x] New e2e test in `compiler/tests/e2e/` (`test_enum_tag_access.sh` + `fixtures/enum_tag_access/`) covers both forms and would catch a future regression.
- [x] `make compile` green; new e2e test green (3/3); `make check` running in background (see test plan).
- [x] No change to the C delegate or its descriptor — kept for #626 to retire.

## Verification

```bash
# Build the fixed compiler
ulimit -v 8388608 && make compile

# Run the new e2e test directly
ulimit -v 8388608 && bash compiler/tests/e2e/test_enum_tag_access.sh build/native/sailfin
# → 3 passed, 0 failed

# Manual repro of failure A — IR now ends in sext+ret:
ulimit -v 8388608 && build/native/sailfin emit -o /tmp/a.ll llvm \
    compiler/tests/e2e/fixtures/enum_tag_access/main.sfn
grep -A 6 '@shape_tag_direct' /tmp/a.ll
# define i64 @shape_tag_direct__...(%Shape* %s) {
#   %t0 = getelementptr inbounds %Shape, %Shape* %s, i32 0, i32 0
#   %t1 = load i32, i32* %t0
#   %t2 = sext i32 %t1 to i64
#   ret i64 %t2

# Manual repro of failure B — extractvalue instead of malformed GEP:
grep -A 4 'matchcase0:' /tmp/a.ll
#   %t8 = extractvalue %Shape %t6, 0     (was: getelementptr ..., %Shape %t6, ...)
#   %t9 = icmp eq i32 %t8, 0
#   ...

# llvm-as accepts the IR (used to reject):
llvm-as /tmp/a.ll -o /tmp/a.bc && echo OK
```

## Files Changed

- `compiler/src/llvm/expression_lowering/native/core_member_lowering.sfn` — short-circuit `.tag` in `lower_enum_member_access`
- `compiler/src/llvm/lowering/instructions_match_condition.sfn` — branch on pointer vs. by-value subject in match-tag extraction
- `compiler/tests/e2e/test_enum_tag_access.sh` + `compiler/tests/e2e/fixtures/enum_tag_access/{main.sfn,capsule.toml}` — new e2e regression coverage

## Follow-ups (not in this PR)

- A new alpha must be cut and `.seed-version` bumped before #626 can retire `sailfin_enum_tag_from_instruction_array` and lean on the pure-Sailfin path (`seed-blocker` label is set).


---
_Generated by [Claude Code](https://claude.ai/code/session_01BkoKEBMnQhXhXzeeiUR4VF)_