### PR TITLE
refactor(lowering): inline NativeInstruction payload-read helpers

### DIFF
--- a/compiler/src/llvm/lowering/instructions.sfn
+++ b/compiler/src/llvm/lowering/instructions.sfn
@@ -52,7 +52,7 @@ import { lower_let_instruction } from "./instructions_let";
 import { append_loop_context, last_loop_context, lower_loop_instruction } from "./instructions_loops";
 import { lower_match_instruction } from "./instructions_match";
 import { lower_throw_instruction, lower_try_instruction } from "./instructions_try";
-import { get_instruction_condition, get_instruction_tag, get_instruction_text } from "./lowering_native_helpers";
+import { get_instruction_tag } from "./lowering_native_helpers";
 import { find_last_label } from "./phi";
 
 fn lower_instruction_range(function: NativeFunction, start_index: int, end: int, llvm_return: string, bindings: ParameterBinding[], locals: LocalBinding[], allocas: string[], lines: string[], temp_index: int, block_counter: int, next_local_id: int, next_region_id: int, functions: NativeFunction[], loop_stack: LoopContext[], context: TypeContext, scope_id: string, scope_depth: int, current_label: string) -> BlockLoweringResult ![io] {
@@ -221,7 +221,7 @@ fn lower_instruction_range(function: NativeFunction, start_index: int, end: int,
         }
         if !_tag_handled {
             if _instr_tag == 1 {
-                let _raw_expr = get_instruction_text(function.instructions, index);
+                let _raw_expr = instruction.expression;
                 let trimmed_expression = trim_text(_raw_expr);
                 let mut handled_inline_let: boolean = false;
 
@@ -560,7 +560,7 @@ fn lower_instruction_range(function: NativeFunction, start_index: int, end: int,
         // compiled get_instruction_tag lacks the fixup) to lower instructions.
         if !_tag_handled {
             if _instr_tag == 21 {
-                let _raw_expr_21 = get_instruction_text(function.instructions, index);
+                let _raw_expr_21 = instruction.expression;
                 let trimmed_21 = trim_text(_raw_expr_21);
                 // Detect return instructions that the tag couldn't distinguish
                 let mut _is_ret_21: boolean = false;

--- a/compiler/src/llvm/lowering/instructions_for.sfn
+++ b/compiler/src/llvm/lowering/instructions_for.sfn
@@ -47,7 +47,6 @@ import {
     extend_mutations
 } from "./instructions_helpers";
 import { append_loop_context, collect_loop_structure } from "./instructions_loops";
-import { get_instruction_for_iterable, get_instruction_for_target } from "./lowering_native_helpers";
 import { collect_mutation_names, find_mutation_for_name } from "./phi";
 
 // Lower a range-based for loop (e.g., `for i in 0..10`).
@@ -315,8 +314,8 @@ fn lower_for_instruction(function: NativeFunction, start_index: int, llvm_return
 
     let instruction = function.instructions[start_index];
 
-    let for_target_text = get_instruction_for_target(function.instructions, start_index);
-    let for_iterable_text = get_instruction_for_iterable(function.instructions, start_index);
+    let for_target_text = instruction.target;
+    let for_iterable_text = instruction.iterable;
 
     let mut raw_target = trim_text(for_target_text);
     raw_target = strip_mut_prefix(raw_target);

--- a/compiler/src/llvm/lowering/instructions_loops.sfn
+++ b/compiler/src/llvm/lowering/instructions_loops.sfn
@@ -34,7 +34,7 @@ import {
     extend_lifetime_regions,
     extend_mutations
 } from "./instructions_helpers";
-import { get_instruction_condition, get_instruction_tag } from "./lowering_native_helpers";
+import { get_instruction_tag } from "./lowering_native_helpers";
 import { collect_mutation_names, find_mutation_for_name } from "./phi";
 
 fn collect_loop_structure(instructions: NativeInstruction[], start_index: int, end: int, function_name: string) -> LoopStructure {
@@ -168,7 +168,7 @@ fn lower_loop_instruction(function: NativeFunction, start_index: int, llvm_retur
             let third_body_tag = get_instruction_tag(function.instructions, structure.body_start
                 + 2);
             if third_body_tag == 5 {
-                let raw_exit_cond = trim_text(get_instruction_condition(function.instructions, structure.body_start));
+                let raw_exit_cond = trim_text(function.instructions[structure.body_start].condition);
                 if raw_exit_cond.length > 0 {
                     loop_exit_condition = sanitize_if_condition_text(raw_exit_cond);
                     if debug_loop {

--- a/compiler/src/llvm/lowering/lowering_native_helpers.sfn
+++ b/compiler/src/llvm/lowering/lowering_native_helpers.sfn
@@ -233,18 +233,10 @@ fn get_enum_name_at(enums: NativeEnum[], idx: int) -> string {
 }
 
 // ── NativeInstruction field accessors ────────────────────────────────
-// The seed v0.1.1 compiles enum field access as sailfin_runtime_get_field
-// which is a runtime stub returning empty data.  These helpers use
-// explicit array indexing; the fixup pass replaces their bodies.
 fn get_instruction_tag(instructions: NativeInstruction[], idx: int) -> int {
-    // Enum tag accessor. The seed v0.1.1 can't compile this correctly;
-    // _fix_struct_construction_helpers replaces the body for the first-pass
-    // binary. Once a new seed is cut from a working binary, this source
-    // implementation takes over and the fixup is no longer needed.
-    //
-    // For the seedcheck (compiled by the first-pass binary without fixups),
-    // we delegate to a C runtime function that reads the i32 tag directly
-    // from the array element's memory.
+    // Delegates to a C runtime helper that reads the i32 tag directly from
+    // the array element's memory. Cleaning up this last C delegate is
+    // tracked separately (see #620 epic / #620d).
     return sailfin_enum_tag_from_instruction_array(instructions, idx);
 }
 

--- a/compiler/src/llvm/lowering/lowering_native_helpers.sfn
+++ b/compiler/src/llvm/lowering/lowering_native_helpers.sfn
@@ -248,18 +248,6 @@ fn get_instruction_tag(instructions: NativeInstruction[], idx: int) -> int {
     return sailfin_enum_tag_from_instruction_array(instructions, idx);
 }
 
-fn get_instruction_text(instructions: NativeInstruction[], idx: int) -> string {
-    // Seed drops this; fixup pass replaces with payload[0] read
-    let instr = instructions[idx];
-    return instr.expression;
-}
-
-fn get_instruction_condition(instructions: NativeInstruction[], idx: int) -> string {
-    // Seed drops this; fixup pass replaces with payload[0] read
-    let instr = instructions[idx];
-    return instr.condition;
-}
-
 fn get_instruction_let_name(instructions: NativeInstruction[], idx: int) -> string {
     let instr = instructions[idx];
     return instr.name;
@@ -278,18 +266,6 @@ fn get_instruction_let_type(instructions: NativeInstruction[], idx: int) -> stri
 fn get_instruction_let_value(instructions: NativeInstruction[], idx: int) -> string? {
     let instr = instructions[idx];
     return instr.value;
-}
-
-fn get_instruction_for_target(instructions: NativeInstruction[], idx: int) -> string {
-    // Seed drops this; fixup pass replaces with payload[0] read
-    let instr = instructions[idx];
-    return instr.target;
-}
-
-fn get_instruction_for_iterable(instructions: NativeInstruction[], idx: int) -> string {
-    // Seed drops this; fixup pass replaces with payload[1] read
-    let instr = instructions[idx];
-    return instr.iterable;
 }
 
 // ── NativeFunction field accessors ───────────────────────────────────


### PR DESCRIPTION
## Summary

- Replace the four `get_instruction_*` payload-read helpers in `lowering_native_helpers.sfn` with direct field reads on the `NativeInstruction` enum value at the call sites (`.expression` / `.condition` / `.target` / `.iterable`).
- Delete the helpers and their `// Seed drops this; fixup pass replaces body` annotations.
- Net change: −24 helper lines, −2 unused imports.

The #623 audit confirmed the pinned seed (`v0.7.0-alpha.1`) lowers enum field access to a tag-checked `select` with `null` defaults for non-matching variants, matching the helper's prior runtime semantics.

Closes #625

## Acceptance Criteria

- [x] Four payload-read helpers deleted; their annotations gone.
- [x] Callers read `.expression` / `.condition` / `.target` / `.iterable` directly.
- [x] `make compile && make check` green.

## Verification

```bash
ulimit -v 8388608 && make compile     # built build/native/sailfin
ulimit -v 8388608 && make test        # all suites passed (e2e 63/63, capsules 13/13)
ulimit -v 8388608 && make check       # stage2 == stage3 fixed point ✓
ulimit -v 8388608 && sfn fmt --check  # clean on all touched files

grep -rn "get_instruction_text\|get_instruction_condition\|get_instruction_for_target\|get_instruction_for_iterable" compiler/ runtime/
# → zero matches
```

## Files Changed

- `compiler/src/llvm/lowering/lowering_native_helpers.sfn` — deleted four helpers
- `compiler/src/llvm/lowering/instructions.sfn` — 2 call sites + pruned import
- `compiler/src/llvm/lowering/instructions_loops.sfn` — 1 call site + pruned import
- `compiler/src/llvm/lowering/instructions_for.sfn` — 2 call sites + removed import

`instructions_try.sfn` (listed speculatively in the issue) had no callers; left untouched.

Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012HMxEXuXNaDtoeREhDMm4r)_