### PR TITLE
feat(runtime): arena-aware sfn_str_concat / sfn_str_append (M2.4b, #398)

### DIFF
--- a/compiler/src/llvm/expression_lowering/native/core_ops_lowering.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_ops_lowering.sfn
@@ -404,15 +404,28 @@ fn lower_binary_operation(expression: string, match: OperatorMatch, bindings: Pa
                 };
             }
 
-            let concat_name = format_temp_name(current_temp);
+            // M2.4b (#398): arena-aware concat. The call returns
+            // the SfnString aggregate `{i8*, i64}`; an immediate
+            // `extractvalue` recovers the data pointer so the rest
+            // of the lowering pipeline (which still treats string
+            // operands as `i8*`) is unchanged. The third call
+            // argument is the address of the global pointer
+            // `@sfn_default_arena`, primed at module load by the
+            // C constructor in `runtime/native/src/sailfin_runtime.c`.
+            let agg_name = format_temp_name(current_temp);
             current_temp += 1;
-            current_lines.push("  " + concat_name
-                + " = call i8* @sfn_str_concat({i8*, i64} "
+            current_lines.push("  " + agg_name
+                + " = call {i8*, i64} @sfn_str_concat_arena({i8*, i64} "
                 + lhs_agg.operand.value
                 + ", {i8*, i64} "
                 + rhs_agg.operand.value
-                + ")");
-            let operand = LLVMOperand { llvm_type: "i8*", value: concat_name };
+                + ", ptr @sfn_default_arena)");
+            let data_name = format_temp_name(current_temp);
+            current_temp += 1;
+            current_lines.push("  " + data_name + " = extractvalue {i8*, i64} "
+                + agg_name
+                + ", 0");
+            let operand = LLVMOperand { llvm_type: "i8*", value: data_name };
             return ExpressionResult {
                 lines: current_lines,
                 temp_index: current_temp,
@@ -621,18 +634,25 @@ fn lower_binary_operation(expression: string, match: OperatorMatch, bindings: Pa
                     string_constants: string_constants
                 };
             }
-            let temp_name = format_temp_name(current_temp);
-            let line = "  " + temp_name
-                + " = call i8* @sfn_str_concat({i8*, i64} "
+            // M2.4b (#398): arena-aware concat (see the earlier
+            // call site in this file for the full migration note).
+            let agg_name = format_temp_name(current_temp);
+            let line = "  " + agg_name
+                + " = call {i8*, i64} @sfn_str_concat_arena({i8*, i64} "
                 + lhs_agg.operand.value
                 + ", {i8*, i64} "
                 + rhs_agg.operand.value
-                + ")";
+                + ", ptr @sfn_default_arena)";
             current_lines.push(line);
-            let operand = LLVMOperand { llvm_type: "i8*", value: temp_name };
+            let data_name = format_temp_name(current_temp + 1);
+            let extract_line = "  " + data_name + " = extractvalue {i8*, i64} "
+                + agg_name
+                + ", 0";
+            current_lines.push(extract_line);
+            let operand = LLVMOperand { llvm_type: "i8*", value: data_name };
             return ExpressionResult {
                 lines: current_lines,
-                temp_index: current_temp + 1,
+                temp_index: current_temp + 2,
                 operand: operand,
                 diagnostics: diagnostics,
                 string_constants: string_constants

--- a/compiler/src/llvm/expression_lowering/native/core_strings.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_strings.sfn
@@ -148,17 +148,29 @@ fn emit_string_concat(left: LLVMOperand, right: LLVMOperand, temp_index: int, li
             string_constants: empty_string_constant_set()
         };
     }
-    let temp_name = format_temp_name(right_aligned.temp_index);
-    let line = "  " + temp_name + " = call i8* @sfn_str_concat({i8*, i64} "
+    // M2.4b (#398): arena-aware concat. Returns the SfnString
+    // aggregate `{i8*, i64}`; the immediate `extractvalue`
+    // recovers the data pointer for the rest of the lowering
+    // pipeline (string operands stay typed as `i8*` until the
+    // M1.A.2 flip lands). The third operand `ptr @sfn_default_arena`
+    // is the global pointer slot primed at module load.
+    let agg_name = format_temp_name(right_aligned.temp_index);
+    let line = "  " + agg_name
+        + " = call {i8*, i64} @sfn_str_concat_arena({i8*, i64} "
         + left_aligned.operand.value
         + ", {i8*, i64} "
         + right_aligned.operand.value
-        + ")";
+        + ", ptr @sfn_default_arena)";
     let mut out_lines = append_string(right_aligned.lines, line);
-    let operand = LLVMOperand { llvm_type: "i8*", value: temp_name };
+    let data_name = format_temp_name(right_aligned.temp_index + 1);
+    let extract_line = "  " + data_name + " = extractvalue {i8*, i64} "
+        + agg_name
+        + ", 0";
+    out_lines = append_string(out_lines, extract_line);
+    let operand = LLVMOperand { llvm_type: "i8*", value: data_name };
     return ExpressionResult {
         lines: out_lines,
-        temp_index: right_aligned.temp_index + 1,
+        temp_index: right_aligned.temp_index + 2,
         operand: operand,
         diagnostics: diagnostics,
         string_constants: empty_string_constant_set()

--- a/compiler/src/llvm/lowering/lowering_phase_render.sfn
+++ b/compiler/src/llvm/lowering/lowering_phase_render.sfn
@@ -177,6 +177,17 @@ fn render_llvm_preamble(module_name: string, type_context: TypeContext, trait_me
 
     // Runtime global
     lines.push("@runtime = external global i8**");
+
+    // M2.4b (#398): the arena-aware string concat / append entrypoints
+    // (`@sfn_str_concat_arena` / `@sfn_str_append_arena`) take a third
+    // `ptr` argument that the call sites populate with
+    // `ptr @sfn_default_arena`. The slot is an `SfnArena *` defined in
+    // `runtime/native/src/sailfin_runtime.c` and primed at module load
+    // by a `__attribute__((constructor))` calling `sfn_arena_global()`.
+    // Declaring it here keeps every emitted module's IR self-consistent
+    // — even modules that never call concat carry the declare so
+    // linker behaviour is uniform.
+    lines.push("@sfn_default_arena = external global ptr");
     lines.push("");
 
     // ABI version globals (issue #392 / M1.C; issue #462). Every

--- a/compiler/src/llvm/runtime_helpers.sfn
+++ b/compiler/src/llvm/runtime_helpers.sfn
@@ -457,32 +457,48 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
         target: "string.length", symbol: "sailfin_runtime_string_length", return_type: "i64", parameter_types: ["i8*"], effects: [], native_signature: "sfn_str_len", c_abi_return_type: null
     });
     // M1.A — string.concat parameters lock to the SfnString aggregate
-    // ABI. The new symbol `sailfin_runtime_string_concat_v2` accepts
-    // `{i8*, i64}` by value; its body extracts the data pointers and
-    // forwards to the legacy NUL-terminated `sailfin_runtime_string_concat`
-    // implementation until M2.4 ships a length-aware body. The `_v2`
-    // suffix is a transition aid: seed-compiled IR (which still emits
-    // `call i8* @sailfin_runtime_string_concat(i8*, i8*)`) keeps linking
-    // through the legacy entrypoint while the new compiler routes here.
-    // Return type stays `i8*` because string-typed locals don't flip to
-    // aggregate until M1.A.2.
+    // ABI. The seed's call sites still emit
+    // `call i8* @sfn_str_concat({i8*, i64}, {i8*, i64})`, which keeps
+    // linking through the 2-arg C trampoline `sfn_str_concat`.
     //
-    // M1.2 (#461): `native_signature` flipped to `sfn_str_concat` —
-    // the canonical Sailfin-native name. The C trampoline lives in
-    // `runtime/native/src/sailfin_runtime.c` (alongside the M2.4a
-    // wave-1 trampolines `sfn_str_len` / `sfn_str_eq` /
-    // `sfn_str_slice`) and forwards to `sailfin_runtime_string_concat_v2`.
-    // The hardcoded direct-emission sites in
-    // `expression_lowering/native/{core_ops_lowering,core_strings}.sfn`
-    // were updated to call `@sfn_str_concat` so seed-built IR (which
-    // still emits `@sailfin_runtime_string_concat_v2`) keeps linking
-    // through the legacy entrypoint while fresh emission lands on the
-    // canonical name.
+    // M2.4b (#398): the descriptor now points at the arena-aware
+    // entrypoint `sfn_str_concat_arena`. The full call shape is
+    //   call {i8*, i64} @sfn_str_concat_arena({i8*, i64}, {i8*, i64}, ptr)
+    // where the third operand is `ptr @sfn_default_arena` (a global
+    // pointer slot defined in `runtime/native/src/sailfin_runtime.c`,
+    // primed at module load by a `__attribute__((constructor))`).
+    // Return type is the SfnString aggregate `{i8*, i64}`; the call-
+    // site emitters in `expression_lowering/native/{core_ops_lowering,
+    // core_strings}.sfn` follow the `call` with an `extractvalue` to
+    // recover the legacy `i8*` operand so the rest of the lowering
+    // pipeline (which still treats string locals as `i8*`) is unchanged.
+    //
+    // We deliberately do NOT reuse the bare `sfn_str_concat` symbol —
+    // the seed-built first-pass binary's IR still emits 2-arg calls
+    // against that name, and the C trampoline at that symbol keeps the
+    // 2-arg shape so the self-host link stays green. Once a future
+    // seed cut adopts the new ABI, a follow-up `seed-blocker` issue
+    // renames `sfn_str_concat_arena` back to the bare canonical name
+    // in a single rollback-safe PR.
+    //
+    // `native_signature` is left equal to `symbol` so the declare /
+    // call paths uniformly use the arena-aware name with no special-
+    // casing in `rendering.sfn` / `emit_runtime_call`.
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "string.concat", symbol: "sailfin_runtime_string_concat_v2", return_type: "i8*", parameter_types: ["{i8*, i64}", "{i8*, i64}"], effects: [], native_signature: "sfn_str_concat", c_abi_return_type: null
+        target: "string.concat", symbol: "sfn_str_concat_arena", return_type: "{i8*, i64}", parameter_types: ["{i8*, i64}", "{i8*, i64}", "ptr"], effects: [], native_signature: "sfn_str_concat_arena", c_abi_return_type: null
     });
+    // M2.4b (#398): `string.append` descriptor parked at the arena-
+    // aware shape. No compiler emission site calls it today (the
+    // existing string_append peephole runs in `lowering_helpers_mangling.sfn`
+    // against `sailfin_runtime_string_append`, not via this descriptor),
+    // so `native_signature` stays null — leaving the row as metadata
+    // until the first caller wires through. The C symbol
+    // `sfn_str_append_arena` is defined alongside `sfn_str_concat_arena`
+    // for surface-area completeness. First parameter is `ptr` (opaque)
+    // so the eventual caller can decide whether it's an `i8**` legacy
+    // pointer or a real `{i8*, i64}*` once the SfnString flip lands.
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "string.append", symbol: "sailfin_runtime_string_append", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: [], native_signature: null, c_abi_return_type: null
+        target: "string.append", symbol: "sfn_str_append_arena", return_type: "void", parameter_types: ["ptr", "{i8*, i64}", "ptr"], effects: [], native_signature: null, c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
         target: "string.drop", symbol: "sailfin_runtime_string_drop", return_type: "void", parameter_types: ["i8*"], effects: [], native_signature: null, c_abi_return_type: null

--- a/compiler/tests/e2e/test_runtime_string_allocating.sh
+++ b/compiler/tests/e2e/test_runtime_string_allocating.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+# End-to-end test for the M2.4b (#398) string concat / append
+# arena-aware wave. Verifies that:
+#
+#   1. The Sailfin module `runtime/sfn/string.sfn` still
+#      typechecks / fmt-checks cleanly after the wave-1b
+#      additions.
+#   2. The emitted IR for a `let s = a + b` source defines the
+#      arena-aware call shape:
+#        %t = call {i8*, i64} @sfn_str_concat_arena({i8*, i64} ...,
+#                                                   {i8*, i64} ...,
+#                                                   ptr @sfn_default_arena)
+#        %p = extractvalue {i8*, i64} %t, 0
+#      and no longer emits the old 2-arg `@sfn_str_concat(...)`
+#      or any `@sailfin_runtime_string_concat*` form for fresh
+#      user emission.
+#   3. The global declare `@sfn_default_arena = external global ptr`
+#      lands in every emitted module (driven by
+#      `lowering_phase_render.sfn`).
+#   4. The Sailfin module exports the new `sfn_str_sfn_concat` /
+#      `sfn_str_sfn_append` proof-of-life symbols alongside the
+#      wave-1a infix family.
+#   5. The compiler binary exports the canonical C-side
+#      `sfn_str_concat_arena` / `sfn_str_append_arena` text
+#      symbols and the `sfn_default_arena` global symbol so the
+#      link surface is intact.
+
+set -euo pipefail
+
+BINARY="${1:?usage: test_runtime_string_allocating.sh <compiler-binary>}"
+BINARY="$(realpath "$BINARY")"
+PASS=0
+FAIL=0
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+MODULE="$REPO_ROOT/runtime/sfn/string.sfn"
+
+SCRATCH="$(mktemp -d -t sfn-runtime-string-alloc-XXXXXX)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+run_test() {
+    local name="$1"
+    shift
+    if "$@"; then
+        echo "[test] PASS: $name"
+        PASS=$((PASS + 1))
+    else
+        echo "[test] FAIL: $name"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# ---- Test: source module typechecks cleanly ----
+test_check_clean() {
+    local log="$SCRATCH/check.log"
+    if ! "$BINARY" check "$MODULE" > "$log" 2>&1; then
+        echo "[test]   sfn check exited non-zero on string.sfn:"
+        cat "$log"
+        return 1
+    fi
+    if ! grep -q "checked .* ok" "$log"; then
+        echo "[test]   sfn check did not report 'ok':"
+        cat "$log"
+        return 1
+    fi
+    return 0
+}
+
+# ---- Test: source module is fmt-canonical ----
+test_fmt_clean() {
+    if ! "$BINARY" fmt --check "$MODULE" > /dev/null 2>&1; then
+        echo "[test]   $MODULE needs formatting (run: sfn fmt --write $MODULE)"
+        return 1
+    fi
+    return 0
+}
+
+# ---- Test: emitted IR carries a `define` for every new sfn_str_sfn_* export ----
+test_emit_define_shape() {
+    local ll="$SCRATCH/string.ll"
+    local log="$SCRATCH/emit.log"
+    if ! "$BINARY" emit -o "$ll" llvm "$MODULE" > "$log" 2>&1; then
+        echo "[test]   sfn emit llvm failed on runtime/sfn/string.sfn:"
+        cat "$log"
+        return 1
+    fi
+    local missing=0
+    for sym in sfn_str_sfn_concat sfn_str_sfn_append; do
+        if ! grep -qE "^define .* @${sym}\(" "$ll"; then
+            echo "[test]   missing 'define ... @${sym}(' in string.ll"
+            missing=$((missing + 1))
+        fi
+    done
+    return "$missing"
+}
+
+# ---- Test: a `let s = a + b` source lowers to the arena-aware call shape ----
+test_concat_lowers_to_arena_form() {
+    local fixture="$SCRATCH/concat_fixture.sfn"
+    cat > "$fixture" <<'SAILFIN_EOF'
+fn build_greeting() -> string {
+    let lhs = "hello, ";
+    let rhs = "world";
+    let combined = lhs + rhs;
+    return combined;
+}
+SAILFIN_EOF
+    local ll="$SCRATCH/concat_fixture.ll"
+    local log="$SCRATCH/concat_fixture.log"
+    if ! "$BINARY" emit -o "$ll" llvm "$fixture" > "$log" 2>&1; then
+        echo "[test]   sfn emit llvm failed on concat fixture:"
+        cat "$log"
+        return 1
+    fi
+    # The full call shape must appear verbatim — the `, ptr @sfn_default_arena)`
+    # tail is the discriminator that catches a regression to the 2-arg form.
+    if ! grep -qE 'call \{i8\*, i64\} @sfn_str_concat_arena\(\{i8\*, i64\} [^,]+, \{i8\*, i64\} [^,]+, ptr @sfn_default_arena\)' "$ll"; then
+        echo "[test]   expected 'call {i8*, i64} @sfn_str_concat_arena(..., ptr @sfn_default_arena)' in emitted IR:"
+        grep -nE 'call .* @sfn_str_concat' "$ll" | head -5
+        return 1
+    fi
+    # The extractvalue must follow so downstream `i8*` consumers stay happy.
+    # Temp names are `%tN` in the compiler's format_temp_name scheme, but
+    # accept any LLVM-valid local identifier to keep the test robust against
+    # naming changes.
+    if ! grep -qE '= extractvalue \{i8\*, i64\} %[A-Za-z_][A-Za-z0-9_]*, 0' "$ll"; then
+        echo "[test]   expected 'extractvalue {i8*, i64} %tN, 0' following the arena call"
+        return 1
+    fi
+    # Defensive regression: no fresh emission should call the legacy
+    # 2-arg `@sfn_str_concat` or the old `@sailfin_runtime_string_concat*`
+    # symbols from a user-level concat expression.
+    if grep -qE '= call i8\* @sfn_str_concat\(' "$ll"; then
+        echo "[test]   regressed: fresh emission still uses the 2-arg @sfn_str_concat shape"
+        grep -nE '= call i8\* @sfn_str_concat\(' "$ll" | head -3
+        return 1
+    fi
+    if grep -qE '@sailfin_runtime_string_concat' "$ll"; then
+        echo "[test]   fresh emission references the legacy @sailfin_runtime_string_concat* family"
+        grep -nE '@sailfin_runtime_string_concat' "$ll" | head -3
+        return 1
+    fi
+    return 0
+}
+
+# ---- Test: every emitted module declares @sfn_default_arena ----
+test_global_declare_present() {
+    local fixture="$SCRATCH/concat_fixture.sfn"
+    local ll="$SCRATCH/concat_fixture.ll"
+    if [ ! -f "$ll" ]; then
+        echo "[test]   $ll missing — test_concat_lowers_to_arena_form must run first"
+        return 1
+    fi
+    if ! grep -qE '^@sfn_default_arena = external global ptr$' "$ll"; then
+        echo "[test]   expected '@sfn_default_arena = external global ptr' declare in emitted IR"
+        return 1
+    fi
+    if ! grep -qE '^declare \{i8\*, i64\} @sfn_str_concat_arena\(\{i8\*, i64\}, \{i8\*, i64\}, ptr\)' "$ll"; then
+        echo "[test]   expected declare for @sfn_str_concat_arena with 3-arg ptr-tail signature"
+        grep -nE 'declare .* @sfn_str_concat' "$ll" | head -3
+        return 1
+    fi
+    return 0
+}
+
+# ---- Test: the compiler binary exports the new symbols ----
+test_compiler_binary_exports_arena_symbols() {
+    local nm_log
+    nm_log="$(nm "$BINARY" 2>/dev/null || true)"
+    if [ -z "$nm_log" ]; then
+        echo "[test]   nm produced no output for $BINARY (stripped binary?)"
+        return 1
+    fi
+    local missing=0
+    for sym in sfn_str_concat_arena sfn_str_append_arena; do
+        if ! grep -qE "[[:space:]][Tt][[:space:]]_?${sym}\$" <<< "$nm_log"; then
+            echo "[test]   compiler binary does not export defined text symbol ${sym}"
+            missing=$((missing + 1))
+        fi
+    done
+    # The global arena pointer slot must show up as a data symbol
+    # (' D ' / ' d ' / ' B ' / ' b ' / ' S ' / ' s ') — not a text symbol.
+    if ! grep -qE "[[:space:]][BbDdSs][[:space:]]_?sfn_default_arena\$" <<< "$nm_log"; then
+        echo "[test]   compiler binary does not export defined data symbol sfn_default_arena"
+        missing=$((missing + 1))
+    fi
+    # And the Sailfin-side proof-of-life infix exports.
+    for sym in sfn_str_sfn_concat sfn_str_sfn_append; do
+        if ! grep -qE "[[:space:]][Tt][[:space:]]_?${sym}\$" <<< "$nm_log"; then
+            echo "[test]   compiler binary does not export defined text symbol ${sym}"
+            missing=$((missing + 1))
+        fi
+    done
+    return "$missing"
+}
+
+run_test "sfn check runtime/sfn/string.sfn passes" test_check_clean
+run_test "sfn fmt --check runtime/sfn/string.sfn is canonical" test_fmt_clean
+run_test "sfn emit llvm produces define for every new sfn_str_sfn_* export" test_emit_define_shape
+run_test "let s = a + b lowers to arena-aware @sfn_str_concat_arena call" test_concat_lowers_to_arena_form
+run_test "emitted IR declares @sfn_default_arena and @sfn_str_concat_arena" test_global_declare_present
+run_test "compiler binary exports sfn_str_concat_arena / sfn_str_append_arena / sfn_default_arena" test_compiler_binary_exports_arena_symbols
+
+echo ""
+echo "[summary] $PASS passed, $FAIL failed"
+exit "$FAIL"

--- a/compiler/tests/e2e/test_string_aggregate_shape.sh
+++ b/compiler/tests/e2e/test_string_aggregate_shape.sh
@@ -133,25 +133,40 @@ test_no_array_consumer_pattern() {
     return 0
 }
 
-# A6 — `string.concat` declared with aggregate parameter shape and called
-# the same way. The new compiler routes through `sfn_str_concat` (the
-# canonical Sailfin-native name from the M1.2 registry flip, #461),
-# whose C trampoline forwards to `sailfin_runtime_string_concat_v2`
-# (SfnString-by-value). The legacy `sailfin_runtime_string_concat_v2`
-# symbol stays exported so seed-compiled IR keeps linking until the
-# floor seed bumps and both retire together.
+# A6 — `string.concat` declared with the arena-aware SfnString ABI
+# and called the same way. M2.4b (#398) flipped the call shape to
+#   call {i8*, i64} @sfn_str_concat_arena({i8*, i64}, {i8*, i64}, ptr @sfn_default_arena)
+# followed by an `extractvalue {i8*, i64} %t, 0` that recovers the
+# legacy `i8*` operand for the rest of the lowering pipeline. The
+# 2-arg `sfn_str_concat` trampoline stays exported so seed-compiled
+# IR keeps linking until the next seed bump retires both together;
+# fresh emission must not reach that trampoline directly nor the
+# legacy `sailfin_runtime_string_concat_v2` entrypoint.
 test_string_concat_uses_aggregate_abi() {
     emit_ir_once || return 1
     local declared
-    declared="$(grep -cE '^declare i8\* @sfn_str_concat\(\{i8\*, i64\}, \{i8\*, i64\}\)' "$LL" || true)"
+    declared="$(grep -cE '^declare \{i8\*, i64\} @sfn_str_concat_arena\(\{i8\*, i64\}, \{i8\*, i64\}, ptr\)' "$LL" || true)"
     if [ "${declared:-0}" -ne 1 ]; then
-        echo "[test]   expected exactly one aggregate-shape declare for sfn_str_concat, got ${declared:-0}"
+        echo "[test]   expected exactly one arena-shape declare for sfn_str_concat_arena, got ${declared:-0}"
         return 1
     fi
     local called
-    called="$(grep -cE 'call i8\* @sfn_str_concat\(\{i8\*, i64\} ' "$LL" || true)"
+    called="$(grep -cE 'call \{i8\*, i64\} @sfn_str_concat_arena\(\{i8\*, i64\} [^,]+, \{i8\*, i64\} [^,]+, ptr @sfn_default_arena\)' "$LL" || true)"
     if [ "${called:-0}" -lt 1 ]; then
-        echo "[test]   expected at least one aggregate-shape call to sfn_str_concat, got ${called:-0}"
+        echo "[test]   expected at least one arena-shape call to sfn_str_concat_arena, got ${called:-0}"
+        return 1
+    fi
+    # The result extract that gives downstream `i8*` consumers the data ptr.
+    local extracted
+    extracted="$(grep -cE '= extractvalue \{i8\*, i64\} %[A-Za-z_][A-Za-z0-9_]*, 0' "$LL" || true)"
+    if [ "${extracted:-0}" -lt 1 ]; then
+        echo "[test]   expected at least one extractvalue following the arena call, got ${extracted:-0}"
+        return 1
+    fi
+    local legacy_2arg_called
+    legacy_2arg_called="$(grep -cE 'call i8\* @sfn_str_concat\(' "$LL" || true)"
+    if [ "${legacy_2arg_called:-0}" -ne 0 ]; then
+        echo "[test]   regression: fresh emission still calls the 2-arg @sfn_str_concat shape"
         return 1
     fi
     local legacy_v2_called

--- a/compiler/tests/unit/runtime_call_dispatch_test.sfn
+++ b/compiler/tests/unit/runtime_call_dispatch_test.sfn
@@ -47,13 +47,27 @@ fn _i64_operand(value: string) -> LLVMOperand {
     return LLVMOperand { llvm_type: "i64", value: value };
 }
 
-test "emit_runtime_call: string.concat renders SfnString-aggregate call to sfn_str_concat" ![io] {
+fn _ptr_operand(value: string) -> LLVMOperand {
+    return LLVMOperand { llvm_type: "ptr", value: value };
+}
+
+test "emit_runtime_call: string.concat renders SfnString-aggregate call to sfn_str_concat_arena" ![io] {
+    // M2.4b (#398): the descriptor now points at the arena-aware
+    // `sfn_str_concat_arena` entrypoint with a third `ptr` argument
+    // that fresh user emission populates with `ptr @sfn_default_arena`.
+    // The return type is the SfnString aggregate `{i8*, i64}`; the
+    // hardcoded call-site emitters follow the `call` with an
+    // `extractvalue` to recover the legacy `i8*` operand. This
+    // fixture pins the call shape itself; the extract step lives in
+    // the call-site emitters and is covered by the e2e test
+    // `test_runtime_string_allocating.sh`.
     let lhs = _sfn_string_operand("%a");
     let rhs = _sfn_string_operand("%b");
-    let operands: LLVMOperand[] = [lhs, rhs];
+    let arena = _ptr_operand("@sfn_default_arena");
+    let operands: LLVMOperand[] = [lhs, rhs, arena];
     let result = emit_runtime_call("string.concat", operands, empty_runtime_call_overrides(), 0, []);
     assert result.lines.length == 1;
-    assert result.lines[0] == "  %t0 = call i8* @sfn_str_concat({i8*, i64} %a, {i8*, i64} %b)";
+    assert result.lines[0] == "  %t0 = call {i8*, i64} @sfn_str_concat_arena({i8*, i64} %a, {i8*, i64} %b, ptr @sfn_default_arena)";
     assert result.temp_index == 1;
     assert result.operand != null;
     assert result.diagnostics.length == 0;

--- a/runtime/native/include/sailfin_runtime.h
+++ b/runtime/native/include/sailfin_runtime.h
@@ -4,6 +4,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include "sailfin_arena.h"
+
 #ifdef __cplusplus
 extern "C"
 {
@@ -107,6 +109,15 @@ extern "C"
     // transferred); suffix is borrowed. Only emitted by the compiler when buf
     // is a provably-unaliased intermediate from a prior concat/append.
     char *sailfin_runtime_string_append(char *buf, char *suffix);
+
+    // M2.4b (#398): arena-aware concat / append entrypoints. The
+    // compiler's fresh emission passes `ptr @sfn_default_arena`
+    // (the address of the global pointer declared below) so these
+    // signatures receive `SfnArena **` and dereference once. See
+    // sailfin_runtime.c for the full migration note.
+    SfnString sfn_str_concat_arena(SfnString a, SfnString b, SfnArena **arena_slot);
+    void sfn_str_append_arena(SfnString *dst, SfnString suffix, SfnArena **arena_slot);
+    extern SfnArena *sfn_default_arena;
     // Drop/free a runtime-owned string (no-op for non-owned/persistent values).
     void sailfin_runtime_string_drop(char *text);
     // Scope-exit drop helper for owned RC locals (M1.5.2 / issue #326).

--- a/runtime/native/src/sailfin_runtime.c
+++ b/runtime/native/src/sailfin_runtime.c
@@ -2095,6 +2095,204 @@ char *sfn_str_concat(SfnString a, SfnString b)
     return sailfin_runtime_string_concat_v2(a, b);
 }
 
+/* M2.4b (#398): arena-aware concat. The new compiler emits
+ *   %t = call {i8*, i64} @sfn_str_concat_arena({i8*, i64} a,
+ *                                              {i8*, i64} b,
+ *                                              ptr @sfn_default_arena)
+ *   %p = extractvalue {i8*, i64} %t, 0
+ * at every `let s = a + b` site. The third argument is the
+ * address of the global pointer `sfn_default_arena` (declared
+ * below), so the C signature receives `SfnArena **` and
+ * dereferences once. The constructor `_sfn_default_arena_init`
+ * primes the slot at module load.
+ *
+ * Body: bump `a.len + b.len + 1` bytes in the arena (the +1
+ * keeps NUL-termination for legacy callers that still treat
+ * the result as a C string), memcpy both payloads, write the
+ * trailing NUL, and return the aggregate `{data, a.len + b.len}`.
+ *
+ * The 2-arg `sfn_str_concat` trampoline above stays for seed-
+ * built IR that already emits the old shape; once the next seed
+ * adopts the new ABI we can rename `sfn_str_concat_arena` back
+ * to `sfn_str_concat` in a single rollback-safe PR (tracked as a
+ * follow-up `seed-blocker` issue). */
+SfnString sfn_str_concat_arena(SfnString a, SfnString b, SfnArena **arena_slot)
+{
+    SfnArena *arena;
+    if (arena_slot != NULL && *arena_slot != NULL)
+    {
+        arena = *arena_slot;
+    }
+    else
+    {
+        /* Defensive: if the constructor hasn't run yet (rare —
+         * static-init order would have to be very unusual) or the
+         * slot pointer is NULL (defensive coding), fall back to
+         * the process-global arena directly. The arena module's
+         * pthread_once guard makes this safe under any thread. */
+        arena = sfn_arena_global();
+        if (arena_slot != NULL && *arena_slot == NULL)
+        {
+            *arena_slot = arena;
+        }
+    }
+
+    /* The pre-M1.A.2 frontend lowers `string` to `i8*` for locals
+     * and parameters, which means the legacy runtime's tagged
+     * immediate codepoint encoding (a single-codepoint "string"
+     * encoded as `((uint64_t)codepoint << 32)`, recognised by
+     * `_is_immediate_codepoint_string`) reaches us in the
+     * `{i8*, i64}` aggregate's data slot. Decode those into a
+     * stack buffer before the memcpy so we never dereference the
+     * tagged pointer as a real address.
+     *
+     * `_is_immediate_codepoint_string` covers BOTH the
+     * upper-32-bits encoding (e.g. `0x6800000000` for 'h') and
+     * the near-null ASCII encoding (e.g. `(char *)0x2e` for '.').
+     * `_utf8_encode` writes 1-4 UTF-8 bytes for any valid
+     * codepoint, matching the byte length the caller computed via
+     * `sfn_str_len` / `sailfin_runtime_string_length` (both walk
+     * `_utf8_encode` for immediate inputs and return the same byte
+     * count). */
+    unsigned char a_imm_buf[5] = {0};
+    unsigned char b_imm_buf[5] = {0};
+    const char *a_data = a.data;
+    const char *b_data = b.data;
+    uint32_t a_cp = 0;
+    uint32_t b_cp = 0;
+    if (_is_immediate_codepoint_string(a.data, &a_cp))
+    {
+        _utf8_encode(a_cp, a_imm_buf);
+        a_data = (const char *)a_imm_buf;
+    }
+    if (_is_immediate_codepoint_string(b.data, &b_cp))
+    {
+        _utf8_encode(b_cp, b_imm_buf);
+        b_data = (const char *)b_imm_buf;
+    }
+
+    int64_t total = a.len + b.len;
+    /* +1 keeps the trailing NUL so legacy `i8*` callers (the
+     * extractvalue at every call site discards the length but
+     * passes the data pointer to code that may strlen it) stay
+     * correct. The NUL byte sits at index `total` inside the
+     * `total + 1`-byte arena allocation. */
+    char *data = (char *)sfn_arena_alloc(arena, (size_t)(total + 1), 1);
+    if (data == NULL)
+    {
+        SfnString empty = {NULL, 0};
+        return empty;
+    }
+    if (a.len > 0 && a_data != NULL)
+    {
+        memcpy(data, a_data, (size_t)a.len);
+    }
+    if (b.len > 0 && b_data != NULL)
+    {
+        memcpy(data + a.len, b_data, (size_t)b.len);
+    }
+    data[total] = '\0';
+
+    SfnString result;
+    result.data = data;
+    result.len = total;
+    return result;
+}
+
+/* M2.4b (#398): arena-aware in-place append.
+ *
+ * Compiler-emitted optimization for chained concatenation where
+ * the buffer is a known-unaliased intermediate (the same
+ * peephole that drives `sailfin_runtime_string_append`). The
+ * arena-tip realloc path inside `sfn_arena_realloc` extends in
+ * place when `dst->data` is the most-recent allocation; otherwise
+ * it allocates fresh and copies. Either way the updated `data`
+ * and `len` are written through `dst`.
+ *
+ * No call sites in the compiler emit this yet — the descriptor
+ * row in `runtime_helpers.sfn` is metadata + symbol parking for
+ * the first caller (likely the M1.A.2 type-mapping flip when
+ * `string` locals become aggregates and the peephole moves into
+ * `core_ops_lowering`). Shipping the body now closes the wave 1b
+ * surface area so the migration is mechanically complete. */
+void sfn_str_append_arena(SfnString *dst, SfnString suffix, SfnArena **arena_slot)
+{
+    if (dst == NULL)
+    {
+        return;
+    }
+    if (suffix.len == 0 || suffix.data == NULL)
+    {
+        return;
+    }
+
+    SfnArena *arena;
+    if (arena_slot != NULL && *arena_slot != NULL)
+    {
+        arena = *arena_slot;
+    }
+    else
+    {
+        arena = sfn_arena_global();
+        if (arena_slot != NULL && *arena_slot == NULL)
+        {
+            *arena_slot = arena;
+        }
+    }
+
+    /* Decode tagged immediate codepoint encoding for the suffix
+     * (same rationale as `sfn_str_concat_arena` above — the
+     * pre-M1.A.2 frontend can present `b.data` as a tagged
+     * pointer when the source value is a 1-codepoint literal). */
+    unsigned char suffix_imm_buf[5] = {0};
+    const char *suffix_data = suffix.data;
+    uint32_t suffix_cp = 0;
+    if (_is_immediate_codepoint_string(suffix.data, &suffix_cp))
+    {
+        _utf8_encode(suffix_cp, suffix_imm_buf);
+        suffix_data = (const char *)suffix_imm_buf;
+    }
+
+    int64_t old_len = dst->len;
+    int64_t new_len = old_len + suffix.len;
+    /* +1 on both old_size / new_size keeps the trailing NUL. */
+    char *grown = (char *)sfn_arena_realloc(arena,
+                                            dst->data,
+                                            (size_t)(old_len + 1),
+                                            (size_t)(new_len + 1),
+                                            1);
+    if (grown == NULL)
+    {
+        return;
+    }
+    memcpy(grown + old_len, suffix_data, (size_t)suffix.len);
+    grown[new_len] = '\0';
+
+    dst->data = grown;
+    dst->len = new_len;
+}
+
+/* `@sfn_default_arena` — the IR-visible global pointer that
+ * every fresh `sfn_str_concat_arena` / `sfn_str_append_arena`
+ * call site passes as the arena argument. The declaration in
+ * `compiler/src/llvm/lowering/lowering_phase_render.sfn` is
+ * `@sfn_default_arena = external global ptr`; the storage is
+ * 8 bytes on 64-bit (a single `SfnArena *`). The constructor
+ * below primes the slot at module load by snapshotting
+ * `sfn_arena_global()`.
+ *
+ * Constructor priority 101: runs before any default-priority
+ * (>= 65535) constructor, so other static initializers that
+ * touch string concatenation see a populated slot. The defensive
+ * fallback inside the arena-aware functions handles the unlikely
+ * case where a lower-priority constructor allocates before us. */
+SfnArena *sfn_default_arena = NULL;
+
+__attribute__((constructor(101))) static void _sfn_default_arena_init(void)
+{
+    sfn_default_arena = sfn_arena_global();
+}
+
 /* Check if a string pointer looks like a corrupted double-encoded value.
    On macOS ARM64, valid user-space pointers are < 0x800000000000.
    Double-encoded pointers (via ptrtoint→sitofp→double→bitcast back) produce

--- a/runtime/native/src/sailfin_runtime.c
+++ b/runtime/native/src/sailfin_runtime.c
@@ -61,6 +61,7 @@ extern char **environ;
 static bool _env_enabled(const char *name);
 static int _env_int(const char *name, int fallback);
 static int64_t _clamp_to_i64(double v);
+static inline int _is_corrupted_string_ptr(const char *ptr);
 
 static void _print_line(FILE *stream, const char *prefix, const char *msg);
 
@@ -2116,8 +2117,64 @@ char *sfn_str_concat(SfnString a, SfnString b)
  * adopts the new ABI we can rename `sfn_str_concat_arena` back
  * to `sfn_str_concat` in a single rollback-safe PR (tracked as a
  * follow-up `seed-blocker` issue). */
+/* M2.4b (#398) — concat-limit / overflow gate shared between the
+ * arena-aware `sfn_str_concat_arena` and `sfn_str_append_arena`
+ * entrypoints. Mirrors the legacy `sailfin_runtime_string_concat`
+ * guard (around line 2725 of this file) so the new ABI path can't
+ * silently exhaust the arena with a runaway concatenation.
+ *
+ * Returns the validated total byte count, or raises ValueError
+ * (which aborts the process via `sailfin_runtime_raise_value_error`)
+ * on limit-exceeded / overflow. The legacy guard's exact env-var
+ * default (`SAILFIN_MAX_STRING_CONCAT=20000000`) and message
+ * format are preserved; the only difference is the diagnostic
+ * label, which the caller supplies so concat vs append shows up
+ * correctly in stderr. */
+static size_t _sfn_str_check_concat_limit(size_t alen, size_t blen, const char *label)
+{
+    static int concat_limit_init = 0;
+    static size_t concat_limit = 0;
+    if (!concat_limit_init)
+    {
+        concat_limit_init = 1;
+        int limit = _env_int("SAILFIN_MAX_STRING_CONCAT", 20000000);
+        if (limit < 0)
+        {
+            limit = 0;
+        }
+        concat_limit = (size_t)limit;
+    }
+    if (concat_limit > 0 && (alen + blen) > concat_limit)
+    {
+        fprintf(stderr,
+                "[stage2-native] %s limit exceeded (alen=%zu blen=%zu limit=%zu)\n",
+                label, alen, blen, concat_limit);
+        fflush(stderr);
+        sailfin_runtime_raise_value_error("string concat limit exceeded");
+    }
+    if (alen > SIZE_MAX - blen)
+    {
+        fprintf(stderr,
+                "[stage2-native] %s overflow (alen=%zu blen=%zu)\n",
+                label, alen, blen);
+        fflush(stderr);
+        sailfin_runtime_raise_value_error("string concat overflow");
+    }
+    return alen + blen;
+}
+
 SfnString sfn_str_concat_arena(SfnString a, SfnString b, SfnArena **arena_slot)
 {
+    /* Design note on `SAILFIN_USE_ARENA` opt-out: the arena-aware
+     * path is the M1 minimal-viable design per
+     * `docs/runtime_architecture.md` §2.1.1 ("the compiler emits a
+     * global `@sfn_default_arena` ... all string and array
+     * allocations route through this arena"). The env var stays
+     * meaningful for the LEGACY C entrypoints (`_rt_malloc` and the
+     * 2-arg `sailfin_runtime_string_concat`); fresh user emission
+     * targeting `@sfn_str_concat_arena` is unconditionally
+     * arena-backed by design. Documented as a deliberate scope
+     * delta in PR #714 (see Copilot review reply). */
     SfnArena *arena;
     if (arena_slot != NULL && *arena_slot != NULL)
     {
@@ -2171,7 +2228,15 @@ SfnString sfn_str_concat_arena(SfnString a, SfnString b, SfnArena **arena_slot)
         b_data = (const char *)b_imm_buf;
     }
 
-    int64_t total = a.len + b.len;
+    /* Apply the same limit/overflow gate the legacy
+     * `sailfin_runtime_string_concat` uses (Copilot review feedback
+     * on PR #714). Without this, a runaway concat would exhaust the
+     * arena's page chain instead of raising a ValueError. */
+    size_t alen = a.len < 0 ? 0 : (size_t)a.len;
+    size_t blen = b.len < 0 ? 0 : (size_t)b.len;
+    size_t total_sz = _sfn_str_check_concat_limit(alen, blen, "string_concat");
+    int64_t total = (int64_t)total_sz;
+
     /* +1 keeps the trailing NUL so legacy `i8*` callers (the
      * extractvalue at every call site discards the length but
      * passes the data pointer to code that may strlen it) stay
@@ -2226,6 +2291,25 @@ void sfn_str_append_arena(SfnString *dst, SfnString suffix, SfnArena **arena_slo
         return;
     }
 
+    /* Defensive: refuse to realloc through a corrupted or
+     * immediate-codepoint `dst->data` pointer (Copilot review
+     * feedback on PR #714). The legacy
+     * `sailfin_runtime_string_append` falls back to a fresh
+     * concat in this case rather than reallocating; we degrade to
+     * a no-op + leave `dst` untouched here because no caller
+     * currently routes through this entrypoint (the existing
+     * peephole still emits `@sailfin_runtime_string_append`). The
+     * first real caller — #717 — will replace this branch with
+     * the fresh-concat fallback. */
+    if (dst->data != NULL && _is_corrupted_string_ptr(dst->data))
+    {
+        return;
+    }
+    if (_is_immediate_codepoint_string(dst->data, NULL))
+    {
+        return;
+    }
+
     SfnArena *arena;
     if (arena_slot != NULL && *arena_slot != NULL)
     {
@@ -2253,8 +2337,14 @@ void sfn_str_append_arena(SfnString *dst, SfnString suffix, SfnArena **arena_slo
         suffix_data = (const char *)suffix_imm_buf;
     }
 
+    /* Apply the shared limit/overflow gate (same as
+     * `sfn_str_concat_arena` — Copilot review feedback on PR #714). */
+    size_t old_sz = dst->len < 0 ? 0 : (size_t)dst->len;
+    size_t suffix_sz = suffix.len < 0 ? 0 : (size_t)suffix.len;
+    size_t new_sz = _sfn_str_check_concat_limit(old_sz, suffix_sz, "string_append");
     int64_t old_len = dst->len;
-    int64_t new_len = old_len + suffix.len;
+    int64_t new_len = (int64_t)new_sz;
+
     /* +1 on both old_size / new_size keeps the trailing NUL. */
     char *grown = (char *)sfn_arena_realloc(arena,
                                             dst->data,
@@ -2290,6 +2380,19 @@ SfnArena *sfn_default_arena = NULL;
 
 __attribute__((constructor(101))) static void _sfn_default_arena_init(void)
 {
+    /* Skip the pre-fetch when the legacy `SAILFIN_USE_ARENA=0`
+     * opt-out is set so we don't force `sfn_arena_global()` to
+     * spin up the page chain at module load (Copilot review
+     * feedback on PR #714). The fallback in `sfn_str_concat_arena`
+     * / `sfn_str_append_arena` still hits `sfn_arena_global()`
+     * lazily on the first call, so this gate only saves the
+     * eager init; the new arena-aware path remains
+     * arena-backed by design (see the design note inside
+     * `sfn_str_concat_arena`). */
+    if (!sfn_arena_enabled())
+    {
+        return;
+    }
     sfn_default_arena = sfn_arena_global();
 }
 

--- a/runtime/sfn/string.sfn
+++ b/runtime/sfn/string.sfn
@@ -58,6 +58,20 @@ extern fn strings_equal(a: * u8, b: * u8) -> bool;
 
 extern fn substring_unchecked(text: * u8, start: f64, end: f64) -> * u8;
 
+// M2.4b (#398): the C-side allocating ops. The Sailfin trampolines
+// below preserve the `sfn_str_sfn_*` infix pattern (proof-of-life
+// presence under the Sailfin namespace) while the canonical
+// `sfn_str_concat_arena` / `sfn_str_append_arena` symbols live on
+// the C side. The two `* u8` parameters mirror the wave-1a pattern
+// — today's Sailfin frontend can't pass / return the SfnString
+// aggregate by value, so the bodies bridge through the legacy
+// NUL-terminated concat. The user IR emission lands directly on
+// `@sfn_str_concat_arena` (the C entrypoint with the new arena-
+// aware ABI); these wrappers are not on the hot path.
+extern fn sailfin_runtime_string_concat(a: * u8, b: * u8) -> * u8;
+
+extern fn sailfin_runtime_string_append(buf: * u8, suffix: * u8) -> * u8;
+
 // `sfn_str_sfn_len(s)` — Sailfin-side length recovery for the
 // SfnString aggregate. Architect spec
 // (`runtime_architecture.md` §2.2): direct field access on the
@@ -107,3 +121,32 @@ fn sfn_str_sfn_to_cstr(s: * u8) -> * u8 { return s; }
 // `memchr` is declared above so the M2.4b body rewrite (over the
 // aggregate shape) doesn't need to add it then.
 fn sfn_str_sfn_from_cstr(s: * u8) -> * u8 { return s; }
+
+// `sfn_str_sfn_concat(a, b)` — proof-of-life Sailfin trampoline
+// for the M2.4b allocating wave. Architect spec
+// (`runtime_architecture.md` §2.2): bump `a.len + b.len` bytes
+// into the supplied arena, memcpy both payloads, return the
+// `SfnString` aggregate. Today's body delegates to the legacy
+// NUL-terminated `sailfin_runtime_string_concat` because the
+// Sailfin frontend can't take an SfnString aggregate by value
+// (M1.A.2 hasn't landed). The user-emission hot path bypasses
+// this wrapper entirely and lands on the C entrypoint
+// `sfn_str_concat_arena`, which has the real arena ABI.
+fn sfn_str_sfn_concat(a: * u8, b: * u8) -> * u8 {
+    return sailfin_runtime_string_concat(a, b);
+}
+
+// `sfn_str_sfn_append(buf, suffix)` — proof-of-life append
+// trampoline. Architect spec:
+// `(*SfnString, SfnString, *Arena) -> void`, using
+// `sfn_arena_realloc`'s grow-if-at-tip path for the chained-
+// concat fast lane. Today's body returns the new buffer (legacy
+// pointer convention) because the Sailfin frontend can't
+// declare a `*SfnString` out-parameter yet. The compiler
+// currently has no callers of `string.append` (the descriptor
+// row is metadata + symbol parking for the first caller), so
+// this trampoline is purely for symmetric namespace
+// presence — same as wave 1a's slice/from_cstr.
+fn sfn_str_sfn_append(buf: * u8, suffix: * u8) -> * u8 {
+    return sailfin_runtime_string_append(buf, suffix);
+}


### PR DESCRIPTION
## Summary

- Ships C-side `sfn_str_concat_arena(SfnString, SfnString, SfnArena**)` and `sfn_str_append_arena(SfnString*, SfnString, SfnArena**)` with arena bump + memcpy semantics per `docs/runtime_architecture.md` §2.2. Both helpers decode the legacy tagged immediate-codepoint encoding (`(codepoint << 32)` pseudo-pointers from `_is_immediate_codepoint_string`) before memcpy so they stay compatible with single-char strings that the pre-M1.A.2 lowering surfaces from `grapheme_at`.
- Defines `@sfn_default_arena` as a process-global `SfnArena *` slot, primed at module load by a priority-101 constructor calling `sfn_arena_global()`. The slot is declared in every emitted module via `lowering_phase_render.sfn` so the linker resolves it uniformly.
- Updates the `string.concat` runtime helper descriptor to the arena-aware shape: `{i8*, i64} sfn_str_concat_arena({i8*, i64}, {i8*, i64}, ptr)`. Call-site emitters in `core_ops_lowering.sfn` (×2) and `core_strings.sfn` follow the call with `extractvalue {i8*, i64} %t, 0` to recover the legacy `i8*` operand — string locals stay typed `i8*` until M1.A.2, so the rest of the lowering pipeline is unchanged. The 2-arg `sfn_str_concat` trampoline stays exported so seed-compiled IR keeps linking.
- `string.append` descriptor parked at the arena-aware shape, but `native_signature: null`. No compiler emission site routes through it today (the existing string_append peephole runs against `sailfin_runtime_string_append` in `lowering_helpers_mangling.sfn`); the symbol exists for namespace-completeness and as a parking spot for the first caller.

Closes #398

## Acceptance Criteria

- [x] `let s = a + b` lowers to `call {i8*, i64} @sfn_str_concat_arena({i8*, i64}, {i8*, i64}, ptr @sfn_default_arena)` followed by `extractvalue {i8*, i64} %t, 0`. **Pragmatic reading of AC #1** (confirmed with reviewer before implementing): the IR symbol is `@sfn_str_concat_arena`, not the bare `@sfn_str_concat`, so the seed-compiled first-pass binary keeps linking through the 2-arg `sfn_str_concat` trampoline. A follow-up `seed-blocker` issue will rename to `@sfn_str_concat` after the next seed cut adopts the new ABI.
- [x] Drop emission plumbing intact. Concat results are **not** flipped to `allocation_kind = "rc"` in this PR — same conservative interpretation as PR #409 (M1.5.4): the #328 catch-entry guarded drops will fire if/when the M1.5.5 promotion gate ever marks a concat result `rc`, but the gate doesn't fire today so the helper emits zero new releases on the existing corpus. Keeping ABI migration separate from ownership-model decisions matches the change-discipline rule.
- [x] Determinism: 20× emit-sweep on `compiler/src/llvm/lowering/lowering_core.sfn` → 1 distinct SHA-256 hash. Project-wide `scripts/diag_determinism_sweep.sh` reports `81/81 modules deterministic`.
- [x] `make compile` passes.
- [x] `make test` passes: **100/100 unit · 25/25 integration · 65/65 e2e · 13/13 capsule**.

## Verification

```bash
ulimit -v 8388608 && make compile
ulimit -v 8388608 && make test
ulimit -v 8388608 && bash compiler/tests/e2e/test_runtime_string_allocating.sh build/native/sailfin
#   => [summary] 6 passed, 0 failed
ulimit -v 8388608 && bash compiler/tests/e2e/test_string_aggregate_shape.sh build/native/sailfin
#   => [summary] 6 passed, 0 failed
bash scripts/diag_determinism_sweep.sh --iters 20 --jobs 4
#   => 81/81 deterministic
build/native/sailfin emit -o /tmp/concat.ll llvm <(echo 'fn main() [io] { let r = "a" + "b"; print.info(r); }')
#   => declare {i8*, i64} @sfn_str_concat_arena({i8*, i64}, {i8*, i64}, ptr)
#   => @sfn_default_arena = external global ptr
#   => %tN = call {i8*, i64} @sfn_str_concat_arena({i8*, i64} %a, {i8*, i64} %b, ptr @sfn_default_arena)
#   => %tN+1 = extractvalue {i8*, i64} %tN, 0
```

## Files Changed

**Sailfin runtime:**
- `runtime/sfn/string.sfn` — `sfn_str_sfn_concat` / `sfn_str_sfn_append` proof-of-life trampolines (mirrors the wave-1a `_sfn_` infix pattern).

**C runtime:**
- `runtime/native/src/sailfin_runtime.c` — `sfn_str_concat_arena`, `sfn_str_append_arena`, `sfn_default_arena` global + constructor.
- `runtime/native/include/sailfin_runtime.h` — prototypes for the new symbols, `sailfin_arena.h` include.

**Compiler:**
- `compiler/src/llvm/runtime_helpers.sfn` — `string.concat` flipped to the arena-aware descriptor; `string.append` updated to the new shape (metadata-only).
- `compiler/src/llvm/expression_lowering/native/core_ops_lowering.sfn` — both `+` call sites emit the new shape + extract.
- `compiler/src/llvm/expression_lowering/native/core_strings.sfn` — `emit_string_concat` emits the new shape + extract.
- `compiler/src/llvm/lowering/lowering_phase_render.sfn` — emits `@sfn_default_arena = external global ptr` in every module.

**Tests:**
- `compiler/tests/e2e/test_runtime_string_allocating.sh` (new) — 6 assertions on the arena-aware IR shape.
- `compiler/tests/e2e/test_string_aggregate_shape.sh` — updated to the new shape (+ extractvalue + regression guard against the 2-arg legacy symbol).
- `compiler/tests/unit/runtime_call_dispatch_test.sfn` — fixture updated to pin the new emit output.

## Scope deviation from the issue

The issue's `In:` listed only `runtime/sfn/string.sfn`, `compiler/src/llvm/runtime_helpers.sfn`, and the new e2e test. Satisfying AC #1 unavoidably also touches `core_ops_lowering.sfn`, `core_strings.sfn`, `lowering_phase_render.sfn`, the C runtime source/header. Confirmed with reviewer before implementing.

## Bug found and fixed during implementation

First implementation crashed in memcpy from `decode_string_literal_escapes_local`. Root cause: Sailfin's legacy runtime encodes single-codepoint strings as a tagged pointer `(codepoint << 32)` (see `_is_immediate_codepoint_string`). `char_at("hello", 0)` returns `(0x68 << 32) = 0x6800000000` as its `i8*`. The 2-arg `sailfin_runtime_string_concat` handles this via the legacy path; the new arena helpers must decode the immediate encoding before the memcpy. Fixed in both `sfn_str_concat_arena` and `sfn_str_append_arena` — they call `_is_immediate_codepoint_string` + `_utf8_encode` into a 5-byte stack buffer when applicable, then memcpy from there. The byte length `sfn_str_len` already returns matches the encoded byte count, so no length adjustment is needed.

This is worth feeding back into grooming: the existing `sfn_str_*` C trampolines that route data pointers from `i8*`-typed Sailfin operands all need this guard until the M1.A.2 type-mapping flip retires the immediate-codepoint encoding entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GcB9X9FqduZ6hLHrxNKwmu)_