### PR TITLE
refactor(lowering): route number-coercion family through emit_runtime_call (M1.7.2b)

### DIFF
--- a/compiler/src/llvm/expression_lowering/native/core_member_lowering.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_member_lowering.sfn
@@ -51,6 +51,7 @@ import {
 import { lower_expression } from "./core";
 import { lower_inline_gep_field_access } from "./core_member_helpers";
 import { sanitize_symbol } from "./core_text";
+import { emit_runtime_call, empty_runtime_call_overrides } from "./runtime_call";
 
 fn make_expression_result(lines: string[], temp_index: int, operand: LLVMOperand?, diagnostics: string[], string_constants: StringConstant[]) -> ExpressionResult {
     return ExpressionResult {
@@ -106,14 +107,22 @@ fn lower_dynamic_member_access(field: string, base_operand: LLVMOperand, temp_in
     current_temp = pointer_result.temp_index;
     let field_pointer = pointer_result.pointer;
 
+    // M1.7.2b (#497): route get_field through descriptor dispatch.
     let call_temp = format_temp_name(current_temp);
-    current_lines.push("  " + call_temp
-        + " = call i8* @sailfin_runtime_get_field(i8* "
-        + base_operand.value
-        + ", i8* "
-        + field_pointer
-        + ")");
-    current_temp += 1;
+    let field_pointer_operand = LLVMOperand {
+        llvm_type: "i8*",
+        value: field_pointer
+    };
+    let gf_operands: LLVMOperand[] = [base_operand, field_pointer_operand];
+    let gf_result = emit_runtime_call("get_field", gf_operands, empty_runtime_call_overrides(), current_temp, current_lines);
+    let mut _gf_di: int = 0;
+    loop {
+        if _gf_di >= gf_result.diagnostics.length { break; }
+        diagnostics.push(gf_result.diagnostics[_gf_di]);
+        _gf_di += 1;
+    }
+    current_lines = gf_result.lines;
+    current_temp = gf_result.temp_index;
 
     let mut _if70: boolean = false;
     if field == "align" { _if70 = true; }
@@ -127,14 +136,19 @@ fn lower_dynamic_member_access(field: string, base_operand: LLVMOperand, temp_in
     if field == "len" { _if70 = true; }
     if field == "length" { _if70 = true; }
     if _if70 {
-        let double_temp = format_temp_name(current_temp);
-        current_lines.push("  " + double_temp
-            + " = call double @sailfin_runtime_string_to_number(i8* "
-            + call_temp
-            + ")");
-        current_temp += 1;
-        let operand = LLVMOperand { llvm_type: "double", value: double_temp };
-        return make_expression_result(current_lines, current_temp, operand, diagnostics, dynamic_string_constants);
+        // M1.7.2b (#497): route string→number through descriptor dispatch.
+        let gf_operand = LLVMOperand { llvm_type: "i8*", value: call_temp };
+        let stn_operands: LLVMOperand[] = [gf_operand];
+        let stn_result = emit_runtime_call("string.to_number", stn_operands, empty_runtime_call_overrides(), current_temp, current_lines);
+        let mut _stn_di: int = 0;
+        loop {
+            if _stn_di >= stn_result.diagnostics.length { break; }
+            diagnostics.push(stn_result.diagnostics[_stn_di]);
+            _stn_di += 1;
+        }
+        current_lines = stn_result.lines;
+        current_temp = stn_result.temp_index;
+        return make_expression_result(current_lines, current_temp, stn_result.operand, diagnostics, dynamic_string_constants);
     }
 
     let operand = LLVMOperand { llvm_type: "i8*", value: call_temp };
@@ -711,17 +725,25 @@ fn lower_member_access(parse: MemberAccessParse, bindings: ParameterBinding[], l
             // alongside it. M2.4b retires the trampoline and the
             // Sailfin export takes over the bare name. The aggregate
             // fast path above (extractvalue) is unchanged.
-            let length_temp = format_temp_name(current_temp);
-            current_lines.push("  " + length_temp
-                + " = call i64 @sfn_str_len(i8* "
-                + base_operand.value
-                + ")");
-            current_temp += 1;
-            let operand = LLVMOperand { llvm_type: "i64", value: length_temp };
+            //
+            // M1.7.2b (#497): route through descriptor dispatch. The
+            // `string.length` descriptor's `native_signature` field
+            // resolves the effective LLVM symbol to `sfn_str_len`,
+            // preserving the M2.4a swap byte-for-byte.
+            let sl_operands: LLVMOperand[] = [base_operand];
+            let sl_result = emit_runtime_call("string.length", sl_operands, empty_runtime_call_overrides(), current_temp, current_lines);
+            let mut _sl_di: int = 0;
+            loop {
+                if _sl_di >= sl_result.diagnostics.length { break; }
+                diagnostics.push(sl_result.diagnostics[_sl_di]);
+                _sl_di += 1;
+            }
+            current_lines = sl_result.lines;
+            current_temp = sl_result.temp_index;
             return ExpressionResult {
                 lines: current_lines,
                 temp_index: current_temp,
-                operand: operand,
+                operand: sl_result.operand,
                 diagnostics: diagnostics,
                 string_constants: collected_string_constants
             };

--- a/compiler/src/llvm/expression_lowering/native/core_member_lowering.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_member_lowering.sfn
@@ -108,7 +108,6 @@ fn lower_dynamic_member_access(field: string, base_operand: LLVMOperand, temp_in
     let field_pointer = pointer_result.pointer;
 
     // M1.7.2b (#497): route get_field through descriptor dispatch.
-    let call_temp = format_temp_name(current_temp);
     let field_pointer_operand = LLVMOperand {
         llvm_type: "i8*",
         value: field_pointer
@@ -123,6 +122,14 @@ fn lower_dynamic_member_access(field: string, base_operand: LLVMOperand, temp_in
     }
     current_lines = gf_result.lines;
     current_temp = gf_result.temp_index;
+    if gf_result.operand == null {
+        return make_expression_result(current_lines, current_temp, null, diagnostics, dynamic_string_constants);
+    }
+    // Take the actual call result rather than recomputing the SSA temp
+    // name — `emit_runtime_call` may have consumed temps for argument
+    // coercion before rendering the call, so the result temp index can
+    // drift from the pre-call `current_temp`.
+    let call_result_value = gf_result.operand.value;
 
     let mut _if70: boolean = false;
     if field == "align" { _if70 = true; }
@@ -137,7 +144,10 @@ fn lower_dynamic_member_access(field: string, base_operand: LLVMOperand, temp_in
     if field == "length" { _if70 = true; }
     if _if70 {
         // M1.7.2b (#497): route string→number through descriptor dispatch.
-        let gf_operand = LLVMOperand { llvm_type: "i8*", value: call_temp };
+        let gf_operand = LLVMOperand {
+            llvm_type: "i8*",
+            value: call_result_value
+        };
         let stn_operands: LLVMOperand[] = [gf_operand];
         let stn_result = emit_runtime_call("string.to_number", stn_operands, empty_runtime_call_overrides(), current_temp, current_lines);
         let mut _stn_di: int = 0;
@@ -151,7 +161,7 @@ fn lower_dynamic_member_access(field: string, base_operand: LLVMOperand, temp_in
         return make_expression_result(current_lines, current_temp, stn_result.operand, diagnostics, dynamic_string_constants);
     }
 
-    let operand = LLVMOperand { llvm_type: "i8*", value: call_temp };
+    let operand = LLVMOperand { llvm_type: "i8*", value: call_result_value };
     return make_expression_result(current_lines, current_temp, operand, diagnostics, dynamic_string_constants);
 }
 

--- a/compiler/src/llvm/expression_lowering/native/core_strings.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_strings.sfn
@@ -190,17 +190,14 @@ fn coerce_operand_to_string(operand: LLVMOperand, temp_index: int, lines: string
     }
 
     if operand.llvm_type == "double" {
-        let temp_name = format_temp_name(temp_index);
-        let mut out_lines = append_string(lines, "  " + temp_name
-            + " = call i8* @sailfin_runtime_number_to_string(double "
-            + operand.value
-            + ")");
-        let out_operand = LLVMOperand { llvm_type: "i8*", value: temp_name };
+        // M1.7.2b (#497): route number→string through descriptor dispatch.
+        let nts_operands: LLVMOperand[] = [operand];
+        let nts_result = emit_runtime_call("number.to_string", nts_operands, empty_runtime_call_overrides(), temp_index, lines);
         return ExpressionResult {
-            lines: out_lines,
-            temp_index: temp_index + 1,
-            operand: out_operand,
-            diagnostics: [],
+            lines: nts_result.lines,
+            temp_index: nts_result.temp_index,
+            operand: nts_result.operand,
+            diagnostics: nts_result.diagnostics,
             string_constants: empty_constants
         };
     }
@@ -211,17 +208,19 @@ fn coerce_operand_to_string(operand: LLVMOperand, temp_index: int, lines: string
             + " = sitofp i64 "
             + operand.value
             + " to double");
-        let call_temp = format_temp_name(temp_index + 1);
-        out_lines.push("  " + call_temp
-            + " = call i8* @sailfin_runtime_number_to_string(double "
-            + cast_temp
-            + ")");
-        let out_operand = LLVMOperand { llvm_type: "i8*", value: call_temp };
+        // M1.7.2b (#497): route number→string through descriptor dispatch.
+        let cast_operand = LLVMOperand {
+            llvm_type: "double",
+            value: cast_temp
+        };
+        let nts_operands: LLVMOperand[] = [cast_operand];
+        let nts_result = emit_runtime_call("number.to_string", nts_operands, empty_runtime_call_overrides(), temp_index
+            + 1, out_lines);
         return ExpressionResult {
-            lines: out_lines,
-            temp_index: temp_index + 2,
-            operand: out_operand,
-            diagnostics: [],
+            lines: nts_result.lines,
+            temp_index: nts_result.temp_index,
+            operand: nts_result.operand,
+            diagnostics: nts_result.diagnostics,
             string_constants: empty_constants
         };
     }
@@ -232,17 +231,19 @@ fn coerce_operand_to_string(operand: LLVMOperand, temp_index: int, lines: string
             + " = sitofp i32 "
             + operand.value
             + " to double");
-        let call_temp = format_temp_name(temp_index + 1);
-        out_lines.push("  " + call_temp
-            + " = call i8* @sailfin_runtime_number_to_string(double "
-            + cast_temp
-            + ")");
-        let out_operand = LLVMOperand { llvm_type: "i8*", value: call_temp };
+        // M1.7.2b (#497): route number→string through descriptor dispatch.
+        let cast_operand = LLVMOperand {
+            llvm_type: "double",
+            value: cast_temp
+        };
+        let nts_operands: LLVMOperand[] = [cast_operand];
+        let nts_result = emit_runtime_call("number.to_string", nts_operands, empty_runtime_call_overrides(), temp_index
+            + 1, out_lines);
         return ExpressionResult {
-            lines: out_lines,
-            temp_index: temp_index + 2,
-            operand: out_operand,
-            diagnostics: [],
+            lines: nts_result.lines,
+            temp_index: nts_result.temp_index,
+            operand: nts_result.operand,
+            diagnostics: nts_result.diagnostics,
             string_constants: empty_constants
         };
     }
@@ -250,22 +251,24 @@ fn coerce_operand_to_string(operand: LLVMOperand, temp_index: int, lines: string
     if operand.llvm_type == "i8" {
         let as_i64 = format_temp_name(temp_index);
         let as_double = format_temp_name(temp_index + 1);
-        let as_string = format_temp_name(temp_index + 2);
         let mut out_lines = append_string(lines, "  " + as_i64 + " = sext i8 "
             + operand.value
             + " to i64");
         out_lines.push("  " + as_double + " = sitofp i64 " + as_i64
             + " to double");
-        out_lines.push("  " + as_string
-            + " = call i8* @sailfin_runtime_number_to_string(double "
-            + as_double
-            + ")");
-        let out_operand = LLVMOperand { llvm_type: "i8*", value: as_string };
+        // M1.7.2b (#497): route number→string through descriptor dispatch.
+        let cast_operand = LLVMOperand {
+            llvm_type: "double",
+            value: as_double
+        };
+        let nts_operands: LLVMOperand[] = [cast_operand];
+        let nts_result = emit_runtime_call("number.to_string", nts_operands, empty_runtime_call_overrides(), temp_index
+            + 2, out_lines);
         return ExpressionResult {
-            lines: out_lines,
-            temp_index: temp_index + 3,
-            operand: out_operand,
-            diagnostics: [],
+            lines: nts_result.lines,
+            temp_index: nts_result.temp_index,
+            operand: nts_result.operand,
+            diagnostics: nts_result.diagnostics,
             string_constants: empty_constants
         };
     }


### PR DESCRIPTION
## Summary

Migrates the live runtime helper call sites in the number-coercion family
from raw-string IR emission to descriptor-driven dispatch through
`emit_runtime_call` (M1.7.1, #495):

- **`compiler/src/llvm/expression_lowering/native/core_strings.sfn`** —
  4 `@sailfin_runtime_number_to_string` sites in `coerce_operand_to_string`
  (`double` / `i64` / `i32` / `i8` branches). Each preserves the existing
  `sext`/`sitofp` prelude and only swaps the trailing call-emission line.

- **`compiler/src/llvm/expression_lowering/native/core_member_lowering.sfn`** —
  + `@sailfin_runtime_get_field` (`lower_dynamic_member_access`)
  + `@sailfin_runtime_string_to_number` (numeric-coercion branch)
  + `@sfn_str_len` (legacy `i8*` `.length` path in `lower_member_access`)

  Adds an import for `emit_runtime_call` / `empty_runtime_call_overrides`
  from `./runtime_call`.

The `string.length` descriptor's `native_signature` field already
resolves to `sfn_str_len`, so the M2.4a swap is preserved byte-for-byte
through `emit_runtime_call`'s symbol-resolution precedence
(`overrides.symbol` → `descriptor.native_signature` → `descriptor.symbol`).

No descriptor schema or registry edits — every target was already
registered (`string.length`, `number.to_string`, `string.to_number`,
`get_field`). `seed_default_runtime_helpers` is untouched (deferred to
M1.7.5a, per epic #494).

Closes #497

## Acceptance Criteria

- [x] The file-scoped grep from #497's acceptance criterion is clean:
  ```bash
  grep -nE '@sailfin_runtime_string_concat_v2|@sailfin_runtime_number_to_string|@sailfin_runtime_string_to_number|@sailfin_runtime_get_field|@sfn_str_len' \
    compiler/src/llvm/expression_lowering/native/core_strings.sfn \
    compiler/src/llvm/expression_lowering/native/core_ops_lowering.sfn \
    compiler/src/llvm/expression_lowering/native/core_member_lowering.sfn
  ```
  → 0 live sites in the 3 issue-scoped files. Two `//`-prefixed comment references remain — in `core_member_lowering.sfn:716` describing the descriptor's resolved symbol, and `core_ops_lowering.sfn:306` referencing the historical pre-M2.4b concat shape.
- [x] **Before/after IR diff empty** for `examples/basics/loops.sfn` (exercises `number_to_string` via `{{attempts}}` interpolation, plus `sfn_str_len` via the legacy `i8*` shim in `core_operands.sfn`), `examples/basics/hello-world.sfn`, and `examples/basics/structs.sfn`
- [x] `make check` green (exit 0)
- [x] `sfn fmt --check` clean

## Verification

```bash
ulimit -v 8388608 && make rebuild
ulimit -v 8388608 && timeout 60 build/native/sailfin emit -o /tmp/m172b/loops.before.ll  llvm examples/basics/loops.sfn
ulimit -v 8388608 && timeout 60 build/native/sailfin emit -o /tmp/m172b/hello.before.ll  llvm examples/basics/hello-world.sfn
ulimit -v 8388608 && timeout 60 build/native/sailfin emit -o /tmp/m172b/struct.before.ll llvm examples/basics/structs.sfn
# ... apply migration, make rebuild ...
ulimit -v 8388608 && timeout 60 build/native/sailfin emit -o /tmp/m172b/loops.after.ll   llvm examples/basics/loops.sfn
ulimit -v 8388608 && timeout 60 build/native/sailfin emit -o /tmp/m172b/hello.after.ll   llvm examples/basics/hello-world.sfn
ulimit -v 8388608 && timeout 60 build/native/sailfin emit -o /tmp/m172b/struct.after.ll  llvm examples/basics/structs.sfn

diff /tmp/m172b/loops.before.ll  /tmp/m172b/loops.after.ll   # → empty
diff /tmp/m172b/hello.before.ll  /tmp/m172b/hello.after.ll   # → empty
diff /tmp/m172b/struct.before.ll /tmp/m172b/struct.after.ll  # → empty

ulimit -v 8388608 && make check   # → exit 0
ulimit -v 8388608 && build/native/sailfin fmt --check \
  compiler/src/llvm/expression_lowering/native/core_strings.sfn \
  compiler/src/llvm/expression_lowering/native/core_member_lowering.sfn
# → clean
```

## Migration Pattern

Each call site follows the M1.7.2a (#524) shape:

```sfn
let foo_operands: LLVMOperand[] = [...];
let foo_result = emit_runtime_call("<target>", foo_operands, empty_runtime_call_overrides(), current_temp, current_lines);
let mut _foo_di: int = 0;
loop {
    if _foo_di >= foo_result.diagnostics.length { break; }
    diagnostics.push(foo_result.diagnostics[_foo_di]);
    _foo_di += 1;
}
current_lines = foo_result.lines;
current_temp = foo_result.temp_index;
```

Downstream consumers take the actual call result via `foo_result.operand.value` rather than recomputing `format_temp_name(pre_call_temp)` — this is robust to `emit_runtime_call` consuming temps for argument coercion before rendering the call (b60a9379 hardens the `get_field` site per Copilot review).

For the `coerce_operand_to_string` integer branches, the existing
`sext`/`sitofp` prelude stays manual — the migrated `emit_runtime_call`
receives a `double` operand and walks the no-op coercion path
(`operand_type == target` early-return at `core_operands.sfn:1889`), so
IR is byte-identical.

## Files Changed

- `compiler/src/llvm/expression_lowering/native/core_strings.sfn` (+38 / −47)
- `compiler/src/llvm/expression_lowering/native/core_member_lowering.sfn` (+63 / −16)

## Notes for Review

- **Concat sites out of #497's grep scope.** The issue body lists `string_concat_v2` sites in `core_strings.sfn` (~line 135) and `core_ops_lowering.sfn` (~lines 417, 636). Those helpers have already moved to `@sfn_str_concat_arena` (M2.4b, #714), whose `string.concat` descriptor takes a third `ptr` arg (`@sfn_default_arena`). The AC's grep only targets `@sailfin_runtime_string_concat_v2` — already 0 live sites — so this PR strictly meets the contract. Filed as **#721 (M1.7.2d)** for follow-up.

- **`core_operands.sfn` sites out of #497's `In:` scope.** Per Copilot review (https://github.com/SailfinIO/sailfin/pull/720#discussion_r3288635348): the same number-coercion symbol family has 4 more live sites in `core_operands.sfn` (`string_to_number` at L418, `number_to_string` at L694 + L713, `sfn_str_len` at L814). These live inside `coerce_operand_to_type` / `coerce_pointer_or_struct`, which `emit_runtime_call` itself uses for argument coercion — migration is recursion-safe in practice but worth documenting at each site. Filed as **#722 (M1.7.2e)** for follow-up. The issue contract for #497 (file-scoped to the 3 listed files) is unaffected.

- Two comment-only references to the migrated symbol names remain (one
  in each of `core_member_lowering.sfn:716` and `core_ops_lowering.sfn:306`)
  — they describe the descriptor's resolved symbol / the historical
  shape and are intentionally left in place to keep the diff minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)