### PR TITLE
M2.8 — runtime/sfn/io.sfn extension (print*, getenv, home_dir) (#401)

### DIFF
--- a/compiler/src/llvm/expression_lowering/native/core_operands.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_operands.sfn
@@ -833,6 +833,76 @@ fn coerce_pointer_or_struct(operand: LLVMOperand, operand_type: string, target: 
             };
         }
     }
+    // M2.8 (#401): numeric -> SfnString coercion chain. After the
+    // print/console descriptors flipped to the `{i8*, i64}`
+    // aggregate ABI, `print(42)` / `print(3.14)` no longer match
+    // the legacy `i64`/`double` -> `i8*` paths above. Stringify the
+    // numeric operand via `sailfin_runtime_number_to_string`, then
+    // build the aggregate the same way the `i8*` -> `{i8*, i64}`
+    // shim does (length recovery via `sfn_str_len`). Both branches
+    // produce a fresh NUL-terminated heap buffer whose byte length
+    // is recoverable, matching the SfnString invariant.
+    if target == "{i8*, i64}" {
+        if operand_type == "double" {
+            let as_string = format_temp_name(temp_index);
+            current_lines.push("  " + as_string
+                + " = call i8* @sailfin_runtime_number_to_string(double "
+                + operand.value
+                + ")");
+            let len_temp = format_temp_name(temp_index + 1);
+            current_lines.push("  " + len_temp + " = call i64 @sfn_str_len(i8* "
+                + as_string
+                + ")");
+            let agg0 = format_temp_name(temp_index + 2);
+            current_lines.push("  " + agg0
+                + " = insertvalue {i8*, i64} undef, i8* "
+                + as_string
+                + ", 0");
+            let agg1 = format_temp_name(temp_index + 3);
+            current_lines.push("  " + agg1 + " = insertvalue {i8*, i64} " + agg0
+                + ", i64 "
+                + len_temp
+                + ", 1");
+            let coerced = LLVMOperand { llvm_type: "{i8*, i64}", value: agg1 };
+            return CoercionResult {
+                lines: current_lines,
+                temp_index: temp_index + 4,
+                operand: coerced,
+                diagnostics: diagnostics
+            };
+        }
+        if operand_type == "i64" {
+            let as_double = format_temp_name(temp_index);
+            current_lines.push("  " + as_double + " = sitofp i64 " + operand.value
+                + " to double");
+            let as_string = format_temp_name(temp_index + 1);
+            current_lines.push("  " + as_string
+                + " = call i8* @sailfin_runtime_number_to_string(double "
+                + as_double
+                + ")");
+            let len_temp = format_temp_name(temp_index + 2);
+            current_lines.push("  " + len_temp + " = call i64 @sfn_str_len(i8* "
+                + as_string
+                + ")");
+            let agg0 = format_temp_name(temp_index + 3);
+            current_lines.push("  " + agg0
+                + " = insertvalue {i8*, i64} undef, i8* "
+                + as_string
+                + ", 0");
+            let agg1 = format_temp_name(temp_index + 4);
+            current_lines.push("  " + agg1 + " = insertvalue {i8*, i64} " + agg0
+                + ", i64 "
+                + len_temp
+                + ", 1");
+            let coerced = LLVMOperand { llvm_type: "{i8*, i64}", value: agg1 };
+            return CoercionResult {
+                lines: current_lines,
+                temp_index: temp_index + 5,
+                operand: coerced,
+                diagnostics: diagnostics
+            };
+        }
+    }
 
     if target == "i8*" {
         if operand_type != "i8*" {

--- a/compiler/src/llvm/lowering/lowering_core.sfn
+++ b/compiler/src/llvm/lowering/lowering_core.sfn
@@ -193,6 +193,7 @@ fn lower_to_llvm_lines_with_parsed_context_for_tests(native_module: NativeModule
                 let msg = "  RUN  " + label;
                 let idx_s = number_to_string(test_idx);
                 let msg_arr_len = number_to_string(msg.length + 1);
+                let msg_byte_len = number_to_string(msg.length);
                 let escaped = escape_string_for_llvm(msg);
                 harness_globals = extend_string_lines(harness_globals, ["@.tname."
                     + idx_s
@@ -201,6 +202,11 @@ fn lower_to_llvm_lines_with_parsed_context_for_tests(native_module: NativeModule
                     + " x i8] c\""
                     + escaped
                     + "\\00\"",]);
+                // M2.8 (#401): the print.err descriptor flipped to
+                // `sfn_print_err` with the `{i8*, i64}` SfnString
+                // aggregate ABI, so the test harness builds the
+                // aggregate from the `i8*` GEP result (data pointer
+                // + byte length excluding NUL) before the call.
                 harness = extend_string_lines(harness, ["  %tn" + idx_s
                     + " = getelementptr ["
                     + msg_arr_len
@@ -208,9 +214,19 @@ fn lower_to_llvm_lines_with_parsed_context_for_tests(native_module: NativeModule
                     + msg_arr_len
                     + " x i8]* @.tname."
                     + idx_s
-                    + ", i64 0, i64 0", "  call void @sailfin_runtime_print_err(i8* %tn"
+                    + ", i64 0, i64 0", "  %tn"
                     + idx_s
-                    + ")", "  call void @"
+                    + ".agg0 = insertvalue {i8*, i64} undef, i8* %tn"
+                    + idx_s
+                    + ", 0", "  %tn"
+                    + idx_s
+                    + ".agg1 = insertvalue {i8*, i64} %tn"
+                    + idx_s
+                    + ".agg0, i64 "
+                    + msg_byte_len
+                    + ", 1", "  call void @sfn_print_err({i8*, i64} %tn"
+                    + idx_s
+                    + ".agg1)", "  call void @"
                     + sym
                     + "()",]);
                 test_idx += 1;
@@ -222,16 +238,22 @@ fn lower_to_llvm_lines_with_parsed_context_for_tests(native_module: NativeModule
         + " tests passed)";
     let pass_escaped = escape_string_for_llvm(pass_msg);
     let pass_len_s = number_to_string(pass_msg.length + 1);
+    let pass_byte_len = number_to_string(pass_msg.length);
     harness_globals = extend_string_lines(harness_globals, ["@.tpass = private unnamed_addr constant ["
         + pass_len_s
         + " x i8] c\""
         + pass_escaped
         + "\\00\"",]);
+    // M2.8 (#401): mirror the `@.tname` flip above — pack the
+    // `i8*` GEP result into a `{i8*, i64}` aggregate before
+    // calling the flipped `@sfn_print_err`.
     harness = extend_string_lines(harness, ["  %tp = getelementptr ["
         + pass_len_s
         + " x i8], ["
         + pass_len_s
-        + " x i8]* @.tpass, i64 0, i64 0", "  call void @sailfin_runtime_print_err(i8* %tp)", "  ret i32 0", "}",]);
+        + " x i8]* @.tpass, i64 0, i64 0", "  %tp.agg0 = insertvalue {i8*, i64} undef, i8* %tp, 0", "  %tp.agg1 = insertvalue {i8*, i64} %tp.agg0, i64 "
+        + pass_byte_len
+        + ", 1", "  call void @sfn_print_err({i8*, i64} %tp.agg1)", "  ret i32 0", "}",]);
 
     let mut updated = base;
     if updated.lines.length > 0 {

--- a/compiler/src/llvm/runtime_helpers.sfn
+++ b/compiler/src/llvm/runtime_helpers.sfn
@@ -84,12 +84,16 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
     let mut descriptors: RuntimeHelperDescriptor[] = [];
     // Raw print: writes to stdout with no prefix, no decoration.
     // Used by the compiler itself for artifact output and CLI messages.
+    // M2.8 (#401): flipped to the Sailfin-native sfn_print symbol via
+    // native_signature, parameter_types bumped to the SfnString
+    // aggregate ABI. The C trampoline in sailfin_runtime.c unpacks the
+    // aggregate and forwards to sailfin_runtime_print_raw.
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "print", symbol: "sailfin_runtime_print_raw", return_type: "void", parameter_types: ["i8*"], effects: ["io"], native_signature: null, c_abi_return_type: null
+        target: "print", symbol: "sailfin_runtime_print_raw", return_type: "void", parameter_types: ["{i8*, i64}"], effects: ["io"], native_signature: "sfn_print", c_abi_return_type: null
     });
     // Raw stderr print: writes to stderr with no prefix, no decoration.
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "print.err", symbol: "sailfin_runtime_print_err", return_type: "void", parameter_types: ["i8*"], effects: ["io"], native_signature: null, c_abi_return_type: null
+        target: "print.err", symbol: "sailfin_runtime_print_err", return_type: "void", parameter_types: ["{i8*, i64}"], effects: ["io"], native_signature: "sfn_print_err", c_abi_return_type: null
     });
 
     // Prefixed print variants — print.err/print.warn/print.error write to
@@ -97,22 +101,22 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
     // Compiler diagnostics should use print.err() so they do not pollute
     // stdout (LLVM IR output, program output, etc.).
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "print.info", symbol: "sailfin_runtime_print_info", return_type: "void", parameter_types: ["i8*"], effects: ["io"], native_signature: null, c_abi_return_type: null
+        target: "print.info", symbol: "sailfin_runtime_print_info", return_type: "void", parameter_types: ["{i8*, i64}"], effects: ["io"], native_signature: "sfn_print_info", c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "print.error", symbol: "sailfin_runtime_print_error", return_type: "void", parameter_types: ["i8*"], effects: ["io"], native_signature: null, c_abi_return_type: null
+        target: "print.error", symbol: "sailfin_runtime_print_error", return_type: "void", parameter_types: ["{i8*, i64}"], effects: ["io"], native_signature: "sfn_print_error", c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "print.warn", symbol: "sailfin_runtime_print_warn", return_type: "void", parameter_types: ["i8*"], effects: ["io"], native_signature: null, c_abi_return_type: null
+        target: "print.warn", symbol: "sailfin_runtime_print_warn", return_type: "void", parameter_types: ["{i8*, i64}"], effects: ["io"], native_signature: "sfn_print_warn", c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "console.info", symbol: "sailfin_runtime_print_raw", return_type: "void", parameter_types: ["i8*"], effects: ["io"], native_signature: null, c_abi_return_type: null
+        target: "console.info", symbol: "sailfin_runtime_print_raw", return_type: "void", parameter_types: ["{i8*, i64}"], effects: ["io"], native_signature: "sfn_print", c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "console.log", symbol: "sailfin_runtime_print_raw", return_type: "void", parameter_types: ["i8*"], effects: ["io"], native_signature: null, c_abi_return_type: null
+        target: "console.log", symbol: "sailfin_runtime_print_raw", return_type: "void", parameter_types: ["{i8*, i64}"], effects: ["io"], native_signature: "sfn_print", c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "console.error", symbol: "sailfin_runtime_print_error", return_type: "void", parameter_types: ["i8*"], effects: ["io"], native_signature: null, c_abi_return_type: null
+        target: "console.error", symbol: "sailfin_runtime_print_error", return_type: "void", parameter_types: ["{i8*, i64}"], effects: ["io"], native_signature: "sfn_print_error", c_abi_return_type: null
     });
 
     // IO intrinsics
@@ -708,11 +712,16 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
     });
 
     // Environment & path helpers
+    // M2.8 (#401): native_signature flipped to the Sailfin-native
+    // sfn_getenv / sfn_home_dir C trampolines. The legacy i8* ABI
+    // is preserved on parameter_types and return_type; the
+    // SfnString aggregate flip needs arena threading at the call
+    // site and waits on a follow-up wave.
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "env.get", symbol: "sailfin_runtime_getenv", return_type: "i8*", parameter_types: ["i8*"], effects: ["io"], native_signature: null, c_abi_return_type: null
+        target: "env.get", symbol: "sailfin_runtime_getenv", return_type: "i8*", parameter_types: ["i8*"], effects: ["io"], native_signature: "sfn_getenv", c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "env.home", symbol: "sailfin_runtime_home_dir", return_type: "i8*", parameter_types: [], effects: ["io"], native_signature: null, c_abi_return_type: null
+        target: "env.home", symbol: "sailfin_runtime_home_dir", return_type: "i8*", parameter_types: [], effects: ["io"], native_signature: "sfn_home_dir", c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
         target: "fs.read_bytes", symbol: "sailfin_runtime_read_file_bytes", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: ["io"], native_signature: null, c_abi_return_type: null

--- a/compiler/tests/e2e/test_runtime_io_extended.sh
+++ b/compiler/tests/e2e/test_runtime_io_extended.sh
@@ -1,0 +1,265 @@
+#!/usr/bin/env bash
+# End-to-end test for runtime/sfn/io.sfn's M2.8 extension —
+# Sailfin-defined print / console / env helpers linked into the
+# compiler binary (issue #401, epic #389 M2.8).
+#
+# Mirrors test_runtime_string_basic.sh's structure: typecheck +
+# fmt + emit-shape on the source module, plus a compiled-IR
+# regression that the new compiler routes `print.*` / `console.*`
+# / `env.get` / `env.home` call sites through the `sfn_print*` /
+# `sfn_getenv` / `sfn_home_dir` family instead of the legacy
+# `sailfin_runtime_print_*` / `sailfin_runtime_getenv` /
+# `sailfin_runtime_home_dir` C entrypoints.
+#
+# When a follow-up wave retires the trampoline bodies and ships
+# length-aware print bodies, the emit-shape assertions stay —
+# they pin the migration symbol surface, not the body strategy.
+
+set -euo pipefail
+
+BINARY="${1:?usage: test_runtime_io_extended.sh <compiler-binary>}"
+BINARY="$(realpath "$BINARY")"
+PASS=0
+FAIL=0
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+MODULE="$REPO_ROOT/runtime/sfn/io.sfn"
+
+SCRATCH="$(mktemp -d -t sfn-runtime-io-XXXXXX)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+run_test() {
+    local name="$1"
+    shift
+    if "$@"; then
+        echo "[test] PASS: $name"
+        PASS=$((PASS + 1))
+    else
+        echo "[test] FAIL: $name"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# ---- Test: source module typechecks cleanly ----
+test_check_clean() {
+    local log="$SCRATCH/check.log"
+    if ! "$BINARY" check "$MODULE" > "$log" 2>&1; then
+        echo "[test]   sfn check exited non-zero on io.sfn:"
+        cat "$log"
+        return 1
+    fi
+    if ! grep -q "checked .* ok" "$log"; then
+        echo "[test]   sfn check did not report 'ok':"
+        cat "$log"
+        return 1
+    fi
+    return 0
+}
+
+# ---- Test: source module is fmt-canonical ----
+test_fmt_clean() {
+    if ! "$BINARY" fmt --check "$MODULE" > /dev/null 2>&1; then
+        echo "[test]   $MODULE needs formatting (run: sfn fmt --write $MODULE)"
+        return 1
+    fi
+    return 0
+}
+
+# ---- Test: emitted IR carries a `define` for every sfn_*_sfn_* export ----
+#
+# The Sailfin module exports the `_sfn_` infix family
+# (`sfn_print_sfn`, `sfn_getenv_sfn`, ...) so its definitions
+# coexist with the C trampolines that own the bare `sfn_print*` /
+# `sfn_getenv` / `sfn_home_dir` namespace —
+# `runtime/native/src/sailfin_runtime.c` defines those for the new
+# compiler emission and the test linker. A follow-up wave retires
+# the C trampolines and renames these exports to the bare form.
+test_emit_define_shape() {
+    local ll="$SCRATCH/io.ll"
+    local log="$SCRATCH/emit.log"
+    if ! "$BINARY" emit -o "$ll" llvm "$MODULE" > "$log" 2>&1; then
+        echo "[test]   sfn emit llvm failed on runtime/sfn/io.sfn:"
+        cat "$log"
+        return 1
+    fi
+    local missing=0
+    for sym in sfn_print_sfn sfn_print_err_sfn sfn_print_info_sfn sfn_print_warn_sfn sfn_print_error_sfn sfn_getenv_sfn sfn_home_dir_sfn sfn_write_fd; do
+        if ! grep -qE "^define .* @${sym}\(" "$ll"; then
+            echo "[test]   missing 'define ... @${sym}(' in io.ll"
+            missing=$((missing + 1))
+        fi
+    done
+    return "$missing"
+}
+
+# ---- Test: emitted IR does NOT collide with C trampolines ----
+#
+# Coexistence regression: a regression that flips a Sailfin export
+# to a bare `sfn_print*` / `sfn_getenv` / `sfn_home_dir` define
+# would collide with the C trampoline at link time and break
+# `make compile`. Pin the `_sfn_` infix as the marker until the
+# follow-up wave removes the C trampolines.
+test_no_bare_canonical_define() {
+    local ll="$SCRATCH/io.ll"
+    if [ ! -f "$ll" ]; then
+        echo "[test]   $ll missing — test_emit_define_shape must run first"
+        return 1
+    fi
+    local found=0
+    for sym in sfn_print sfn_print_err sfn_print_info sfn_print_warn sfn_print_error sfn_getenv sfn_home_dir; do
+        if grep -qE "^define .* @${sym}\(" "$ll"; then
+            echo "[test]   collision risk: io.sfn emits 'define ... @${sym}(', conflicts with C trampoline"
+            found=$((found + 1))
+        fi
+    done
+    return "$found"
+}
+
+# ---- Test: compiled hello-world IR routes print through @sfn_print ----
+#
+# Acceptance criterion from #401 is phrased against `print.info`:
+# "`print.info("hello")` lowers to `call void
+# @sfn_print_info({i8*, i64} %s)` not `@sailfin_runtime_print_info`."
+# The `examples/basics/hello-world.sfn` source uses bare `print(...)`
+# rather than `print.info(...)`, so this test pins the analogous
+# bare-print flip; `test_full_probe_flipped` below covers the
+# `print.info` site explicitly.
+test_hello_world_flipped() {
+    local hello="$REPO_ROOT/examples/basics/hello-world.sfn"
+    local ll="$SCRATCH/hello.ll"
+    local log="$SCRATCH/hello-emit.log"
+    if ! "$BINARY" emit -o "$ll" llvm "$hello" > "$log" 2>&1; then
+        echo "[test]   sfn emit llvm failed on hello-world.sfn:"
+        cat "$log"
+        return 1
+    fi
+    # Must call the new sfn_print symbol against the SfnString
+    # aggregate ABI.
+    if ! grep -qE "call void @sfn_print\(\{i8\*, i64\}" "$ll"; then
+        echo "[test]   hello-world.sfn does not lower to @sfn_print({i8*, i64} ...)"
+        echo "[test]   ll head:"
+        grep -nE "@sfn_print\b|@sailfin_runtime_print_raw\b" "$ll" | head -5
+        return 1
+    fi
+    # And must not reference the legacy entrypoint.
+    if grep -qE "@sailfin_runtime_print_raw\b" "$ll"; then
+        echo "[test]   hello-world.sfn still references @sailfin_runtime_print_raw (expected the sfn_print flip)"
+        grep -nE "@sailfin_runtime_print_raw\b" "$ll" | head -3
+        return 1
+    fi
+    return 0
+}
+
+# ---- Test: compiled probe IR routes every print/console/env call site ----
+test_full_probe_flipped() {
+    local probe="$SCRATCH/io_probe.sfn"
+    cat > "$probe" <<'PROBE'
+fn main() -> int ![io] {
+    print("raw");
+    print.err("raw err");
+    print.info("info");
+    print.warn("warn");
+    print.error("error");
+    console.info("c info");
+    console.log("c log");
+    console.error("c error");
+    let _h = env.home();
+    let _v = env.get("HOME");
+    return 0;
+}
+PROBE
+    local ll="$SCRATCH/io_probe.ll"
+    local log="$SCRATCH/io_probe.log"
+    if ! "$BINARY" emit -o "$ll" llvm "$probe" > "$log" 2>&1; then
+        echo "[test]   sfn emit llvm failed on io_probe.sfn:"
+        cat "$log"
+        return 1
+    fi
+    local missing=0
+    # Required new symbols (note: console.info/log alias `sfn_print`;
+    # console.error aliases `sfn_print_error`).
+    for sym in sfn_print sfn_print_err sfn_print_info sfn_print_warn sfn_print_error sfn_getenv sfn_home_dir; do
+        if ! grep -qE "@${sym}\b" "$ll"; then
+            echo "[test]   io_probe.sfn does not reference @${sym}"
+            missing=$((missing + 1))
+        fi
+    done
+    # Banned legacy entrypoints.
+    local found=0
+    for sym in sailfin_runtime_print_raw sailfin_runtime_print_err sailfin_runtime_print_info sailfin_runtime_print_warn sailfin_runtime_print_error sailfin_runtime_getenv sailfin_runtime_home_dir; do
+        if grep -qE "@${sym}\b" "$ll"; then
+            echo "[test]   io_probe.sfn still references @${sym} (expected the sfn_* flip)"
+            grep -nE "@${sym}\b" "$ll" | head -3
+            found=$((found + 1))
+        fi
+    done
+    return "$((missing + found))"
+}
+
+# ---- Test: compiler binary exports both name families ----
+test_compiler_binary_exports() {
+    local nm_log
+    nm_log="$(nm "$BINARY" 2>/dev/null || true)"
+    if [ -z "$nm_log" ]; then
+        echo "[test]   nm produced no output for $BINARY (stripped binary?)"
+        return 1
+    fi
+    local missing=0
+    # Canonical C-trampoline names (the symbols the new compiler
+    # emission targets), plus the Sailfin proof-of-life `_sfn_`
+    # infix family.
+    for sym in sfn_print sfn_print_err sfn_print_info sfn_print_warn sfn_print_error sfn_getenv sfn_home_dir sfn_print_sfn sfn_print_err_sfn sfn_print_info_sfn sfn_print_warn_sfn sfn_print_error_sfn sfn_getenv_sfn sfn_home_dir_sfn; do
+        if ! grep -qE "[[:space:]][Tt][[:space:]]_?${sym}\$" <<< "$nm_log"; then
+            echo "[test]   compiler binary does not export defined symbol ${sym}"
+            missing=$((missing + 1))
+        fi
+    done
+    return "$missing"
+}
+
+# ---- Test: capsule.toml lists the io module ----
+test_manifest_lists_io() {
+    local manifest="$REPO_ROOT/runtime/native/capsule.toml"
+    if ! grep -qE '^sfn-sources = \[.*"\.\./sfn/io\.sfn".*\]' "$manifest"; then
+        echo "[test]   sfn-sources does not list ../sfn/io.sfn:"
+        grep -nE 'sfn-sources' "$manifest" || true
+        return 1
+    fi
+    return 0
+}
+
+# ---- Test: hello-world runs and produces expected output ----
+#
+# End-to-end behavior gate — the AC explicitly calls out that
+# `examples/basics/hello-world.sfn` must still print correctly
+# after the symbol flip. Compiles the example and runs it.
+test_hello_world_runs() {
+    local hello="$REPO_ROOT/examples/basics/hello-world.sfn"
+    local out
+    if ! out="$("$BINARY" run "$hello" 2>&1)"; then
+        echo "[test]   sfn run hello-world.sfn failed:"
+        echo "$out"
+        return 1
+    fi
+    if ! grep -q "Hello, Sailfin!" <<< "$out"; then
+        echo "[test]   hello-world output missing expected greeting:"
+        echo "$out"
+        return 1
+    fi
+    return 0
+}
+
+run_test "sfn check runtime/sfn/io.sfn passes" test_check_clean
+run_test "sfn fmt --check runtime/sfn/io.sfn is canonical" test_fmt_clean
+run_test "sfn emit llvm produces define for every sfn_*_sfn_* export" test_emit_define_shape
+run_test "sfn emit llvm does not collide with C trampoline sfn_print* / sfn_getenv / sfn_home_dir names" test_no_bare_canonical_define
+run_test "hello-world.sfn lowers print() to @sfn_print({i8*, i64} ...)" test_hello_world_flipped
+run_test "probe binary routes every print/console/env site through @sfn_*" test_full_probe_flipped
+run_test "compiler binary exports defined sfn_print* / sfn_getenv / sfn_home_dir and _sfn_ infix symbols" test_compiler_binary_exports
+run_test "runtime/native/capsule.toml sfn-sources lists the io module" test_manifest_lists_io
+run_test "hello-world.sfn still prints correctly end-to-end" test_hello_world_runs
+
+echo "[summary] $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi

--- a/compiler/tests/e2e/test_string_aggregate_shape.sh
+++ b/compiler/tests/e2e/test_string_aggregate_shape.sh
@@ -70,16 +70,20 @@ test_aggregate_type_appears() {
     return 0
 }
 
-# A2 — Each literal builds the aggregate via two `insertvalue` ops.
-# The fixture writes "hello".length, "world".length, "hello" + "world", and
-# `print.info(combined)` — four string literals total (.length on a literal
-# still constructs the aggregate, then extracts slot 1).
+# A2 — Each literal builds the aggregate via two `insertvalue` ops,
+# plus one `i8*`-to-aggregate coercion for the `combined` operand
+# passed into `print.info` after M2.8 (#401) flipped print to the
+# SfnString aggregate ABI. The fixture writes "hello".length,
+# "world".length, "hello" + "world", and `print.info(combined)`:
+#   - 4 string literals × 1 `undef, i8*` per literal = 4
+#   - 1 coercion shim (concat result is still legacy `i8*`,
+#     coerced to `{i8*, i64}` via `sfn_str_len` for the call) = 1
 test_literal_uses_insertvalue() {
     emit_ir_once || return 1
     local data_inserts
     data_inserts="$(grep -cE '= insertvalue \{i8\*, i64\} undef, i8\*' "$LL" || true)"
-    if [ "${data_inserts:-0}" -ne 4 ]; then
-        echo "[test]   expected 4 'insertvalue {i8*, i64} undef, i8*' lines, got ${data_inserts:-0}"
+    if [ "${data_inserts:-0}" -ne 5 ]; then
+        echo "[test]   expected 5 'insertvalue {i8*, i64} undef, i8*' lines, got ${data_inserts:-0}"
         return 1
     fi
     return 0

--- a/compiler/tests/unit/abi_version_test.sfn
+++ b/compiler/tests/unit/abi_version_test.sfn
@@ -56,26 +56,26 @@ test "abi_version: descriptor accepts native_signature: <string> (M2 flip)" {
 }
 
 // =============================================================================
-// Default descriptors — every shipped helper still uses the C ABI
+// Default descriptors — flipped helpers carry their sfn_* signature
 // =============================================================================
-// Until an M2.x sub-issue lands the per-helper flip, every default
-// descriptor `runtime_helper_descriptors()` returns must report
-// `native_signature == null`. These tests pin a representative sample
-// across the print / fs / net / clock effect classes so a regression
-// where someone accidentally drops the field-flip guard surfaces here
-// instead of on a subtle codegen miss downstream.
-test "abi_version: default `print` helper has native_signature == null" {
+// M2.8 (#401) flipped the print / console / env descriptors to
+// the Sailfin-native sfn_print* / sfn_getenv / sfn_home_dir
+// symbols. The pinned native_signature values below are the
+// migration unit — the underlying `symbol` field stays at the
+// legacy C entrypoint for archeology. Effect classes that have
+// not yet flipped (fs.* / net.* / etc.) still report null.
+test "abi_version: `print` helper carries native_signature sfn_print" {
     let helper = find_runtime_helper("print");
     assert helper != null;
     assert helper.symbol == "sailfin_runtime_print_raw";
-    assert helper.native_signature == null;
+    assert helper.native_signature == "sfn_print";
 }
 
-test "abi_version: default `print.err` helper has native_signature == null" {
+test "abi_version: `print.err` helper carries native_signature sfn_print_err" {
     let helper = find_runtime_helper("print.err");
     assert helper != null;
     assert helper.symbol == "sailfin_runtime_print_err";
-    assert helper.native_signature == null;
+    assert helper.native_signature == "sfn_print_err";
 }
 
 test "abi_version: default `fs.read` helper has native_signature == null" {

--- a/runtime/native/capsule.toml
+++ b/runtime/native/capsule.toml
@@ -55,7 +55,7 @@ ll-sources = ["ir/runtime_globals.ll"]
 # and the formerly-load-bearing allowlist is gone.
 #
 # Single-line array per the parser limitation noted above.
-sfn-sources = ["../sfn/memory/arena.sfn", "../sfn/memory/rc.sfn", "../sfn/string.sfn", "../sfn/array.sfn", "../sfn/clock.sfn", "../sfn/process.sfn"]
+sfn-sources = ["../sfn/memory/arena.sfn", "../sfn/memory/rc.sfn", "../sfn/string.sfn", "../sfn/array.sfn", "../sfn/clock.sfn", "../sfn/process.sfn", "../sfn/io.sfn"]
 include-dirs = ["include"]
 link-libs = ["-lm"]
 

--- a/runtime/native/include/sailfin_runtime.h
+++ b/runtime/native/include/sailfin_runtime.h
@@ -73,6 +73,23 @@ extern "C"
     void sailfin_runtime_print_warn(char *msg);
     void sailfin_runtime_print_error(char *msg);
 
+    /* M2.8 (#401): SfnString migration trampolines for the print
+     * family. Mirrors the M2.4a wave-1 trampolines (`sfn_str_len`,
+     * `sfn_str_eq`, ...). The compiler's runtime_helpers.sfn
+     * registry now carries `native_signature: "sfn_print*"` on the
+     * print/console descriptors, and fresh user emission lands on
+     * these symbols against the `{i8*, i64}` SfnString ABI. The
+     * bodies forward to the legacy `sailfin_runtime_print_*`
+     * entrypoints — today's SfnString.data is always NUL-terminated
+     * (literal lowering writes a trailing 0; arena-routed concat
+     * preserves the +1 byte), so the legacy `char*` consumers
+     * remain valid until the length-aware bodies arrive. */
+    void sfn_print(SfnString s);
+    void sfn_print_err(SfnString s);
+    void sfn_print_info(SfnString s);
+    void sfn_print_warn(SfnString s);
+    void sfn_print_error(SfnString s);
+
     /* `sailfin_runtime_sleep` and the `sfn_sleep` C trampoline were
      * deleted in PR 2 of the sleep migration (issue #397). The
      * `@sfn_sleep` symbol is now defined in Sailfin at
@@ -392,6 +409,12 @@ extern "C"
     // Environment & path helpers.
     char *sailfin_runtime_getenv(const char *name);
     char *sailfin_runtime_home_dir(void);
+    /* M2.8 (#401): symbol-flip trampolines for `env.get` / `env.home`.
+     * Same legacy `i8*` ABI as the entrypoints above — the aggregate
+     * `SfnString` flip on these waits for the arena-threading wave
+     * (a follow-up under M2.8). Bodies forward verbatim. */
+    char *sfn_getenv(const char *name);
+    char *sfn_home_dir(void);
     char *sailfin_runtime_read_file_bytes(const char *path, int64_t *out_length);
 
     // Misc stubs.

--- a/runtime/native/src/sailfin_runtime.c
+++ b/runtime/native/src/sailfin_runtime.c
@@ -1923,6 +1923,27 @@ void sailfin_runtime_print_info(char *msg) { _print_line(stdout, "[info] ", msg)
 void sailfin_runtime_print_warn(char *msg) { _print_line(stderr, "[warn] ", msg); }
 void sailfin_runtime_print_error(char *msg) { _print_line(stderr, "[error] ", msg); }
 
+/* M2.8 (#401): SfnString migration trampolines for the print
+ * family. Mirrors the M2.4a wave-1 trampolines above (`sfn_str_len`,
+ * `sfn_str_eq`, ...). The compiler's runtime_helpers.sfn registry
+ * carries `parameter_types: ["{i8*, i64}"]` + `native_signature:
+ * "sfn_print*"` on each descriptor, so fresh user emission produces
+ *   call void @sfn_print_info({i8*, i64} %s)
+ * with the SfnString aggregate passed by value. The bodies forward
+ * verbatim to the legacy `sailfin_runtime_print_*` entrypoints —
+ * today's SfnString.data is NUL-terminated end-to-end (literal
+ * lowering writes a trailing 0 past the byte payload, and the
+ * arena-routed concat in `sfn_str_concat_arena` preserves the +1
+ * NUL byte), so the legacy `char *`-consuming bodies remain
+ * correct without a second formatting strategy. Once M2.4b/M2.8
+ * length-aware print bodies arrive, the forwarding here retires
+ * in a single rollback-safe rename. */
+void sfn_print(SfnString s) { sailfin_runtime_print_raw(s.data); }
+void sfn_print_err(SfnString s) { sailfin_runtime_print_err(s.data); }
+void sfn_print_info(SfnString s) { sailfin_runtime_print_info(s.data); }
+void sfn_print_warn(SfnString s) { sailfin_runtime_print_warn(s.data); }
+void sfn_print_error(SfnString s) { sailfin_runtime_print_error(s.data); }
+
 // Debug: print a pointer value as hex to stderr
 void sailfin_runtime_debug_ptr(const char *label, const void *ptr)
 {
@@ -7743,6 +7764,17 @@ char *sailfin_runtime_home_dir(void)
         return NULL;
     return strdup(home);
 }
+
+/* M2.8 (#401): symbol-flip trampolines for `env.get` / `env.home`.
+ * The compiler's runtime_helpers.sfn registry carries
+ * `native_signature: "sfn_getenv"` / `"sfn_home_dir"` on the two
+ * descriptors, so fresh user emission lands on these symbols. The
+ * `parameter_types` / `return_type` stay at the legacy `i8*` shape
+ * (no SfnString aggregate flip yet — that wave needs arena
+ * threading, deferred under M2.8). Bodies forward verbatim. */
+char *sfn_getenv(const char *name) { return sailfin_runtime_getenv(name); }
+
+char *sfn_home_dir(void) { return sailfin_runtime_home_dir(); }
 
 char *sailfin_runtime_read_file_bytes(const char *path, int64_t *out_length)
 {

--- a/runtime/sfn/io.sfn
+++ b/runtime/sfn/io.sfn
@@ -1,11 +1,126 @@
 // runtime/sfn/io.sfn
 //
-// First Sailfin-native runtime service wrapper over the platform
-// extern layer. This module intentionally stays tiny: it proves
-// runtime modules can import `runtime/sfn/platform/*.sfn` declarations
-// and lower call sites against linker-resolved extern symbols.
+// Sailfin-native I/O service wrappers — M2.8 (#401, epic #389).
+// Two layers coexist in this module:
+//
+//   1. `sfn_write_fd` — the earlier proof-of-life shipped under
+//      M2.7 (#303). A direct call into `extern fn write` for any
+//      fd / buf / count tuple. The compiler does not lower any
+//      user-facing surface to this helper today; it exists so the
+//      runtime/sfn layer demonstrates that a Sailfin module can
+//      reach `runtime/sfn/platform/libc.sfn` declarations and
+//      compile against linker-resolved extern symbols.
+//
+//   2. The `sfn_print_sfn_*` / `sfn_getenv_sfn` / `sfn_home_dir_sfn`
+//      proof-of-life family (this PR). Mirrors the M2.4a string
+//      module's `sfn_str_sfn_*` infix discipline: the canonical
+//      user-facing names — the ones the new compiler emits `call`s
+//      against — are `sfn_print`, `sfn_print_err`, `sfn_print_info`,
+//      `sfn_print_warn`, `sfn_print_error`, `sfn_getenv`, and
+//      `sfn_home_dir`, provided by the C trampolines in
+//      `runtime/native/src/sailfin_runtime.c`. This module's
+//      exports use the `_sfn_` infix so the Sailfin definitions
+//      coexist with the C trampolines without a link-time
+//      collision (mirrors `runtime/sfn/memory/arena.sfn`'s
+//      `sfn_arena_sfn_*` parallel namespace). When the
+//      aggregate-typed parameter flip (M1.A.2) lands, the C
+//      trampolines retire and the bare `sfn_print*` /
+//      `sfn_getenv` / `sfn_home_dir` names move into this module
+//      in a single rollback-safe rename.
+//
+// Architect spec (`docs/runtime_architecture.md` §2.8):
+//   - `sfn_print(msg: SfnString) -> void` — `extern fn write` fd=1,
+//     buf=msg.data, len=msg.len.
+//   - `sfn_print_err(msg: SfnString) -> void` — fd=2.
+//   - `sfn_print_info / warn / error(msg: SfnString) -> void` —
+//     prepend prefix, delegate to `sfn_print` / `sfn_print_err`.
+//   - `sfn_getenv(name: SfnString, *Arena) -> SfnString` —
+//     NUL-marshal name, call `extern fn getenv`, wrap via
+//     `sfn_str_from_cstr`.
+//   - `sfn_home_dir(*Arena) -> SfnString` — `sfn_getenv("HOME", arena)`.
+//
+// Status: trampoline bodies. The bodies below take the legacy
+// `* u8` (NUL-terminated `i8*`) shape and forward to the existing C
+// runtime entrypoints. The Sailfin frontend lowers `string` to
+// `i8*` for parameters/locals today (M1.A only locked the
+// literal/aggregate shape, not the type-mapping flip slated for
+// M1.A.2), so SfnString aggregate parameters are not yet
+// expressible in Sailfin source. The function *names* are the
+// migration unit — once M1.A.2 lands the bodies can be rewritten
+// in-place against the aggregate shape (calling `write(1, msg.data,
+// msg.len)` and the like) without touching any caller. The C
+// trampolines in `sailfin_runtime.c` already accept the SfnString
+// aggregate today, so user emission is already calling the
+// canonical names against the canonical ABI.
+//
+// Effects: `![io]` on every adapter. The platform extern itself
+// (`write`, `getenv`) carries no effect annotation — adapters wrap
+// the primitive with the effect, matching the §3.6 effect-on-
+// wrapper rule.
+//
+// Why inline the libc externs? The same reason `arena.sfn` /
+// `string.sfn` do: the released seed compiler snapshots
+// `runtime/sfn/platform/libc.sfn` at build time. Inlining keeps
+// this module self-contained for every seed, regardless of which
+// libc declarations have shipped. Once the seed catches up, a
+// follow-up PR can flip these to a cross-module import without
+// touching the bodies.
 import { write } from "./platform/libc";
+
+extern fn sailfin_runtime_print_raw(msg: * u8) -> void;
+
+extern fn sailfin_runtime_print_err(msg: * u8) -> void;
+
+extern fn sailfin_runtime_print_info(msg: * u8) -> void;
+
+extern fn sailfin_runtime_print_warn(msg: * u8) -> void;
+
+extern fn sailfin_runtime_print_error(msg: * u8) -> void;
+
+extern fn sailfin_runtime_getenv(name: * u8) -> * u8;
+
+extern fn sailfin_runtime_home_dir() -> * u8;
 
 fn sfn_write_fd(fd: i32, buf: * u8, count: usize) -> i64 ![io] {
     return write(fd, buf, count);
 }
+
+// `sfn_print_sfn(msg)` — raw stdout. Architect spec writes the
+// `msg.len` bytes of the aggregate to fd=1 with a trailing
+// newline; today's body delegates to the C entrypoint so the
+// newline / flush policy stays consistent with the legacy printer.
+fn sfn_print_sfn(msg: * u8) -> void ![io] { sailfin_runtime_print_raw(msg); }
+
+// `sfn_print_err_sfn(msg)` — raw stderr.
+fn sfn_print_err_sfn(msg: * u8) -> void ![io] {
+    sailfin_runtime_print_err(msg);
+}
+
+// `sfn_print_info_sfn(msg)` — `[info]`-prefixed stdout.
+fn sfn_print_info_sfn(msg: * u8) -> void ![io] {
+    sailfin_runtime_print_info(msg);
+}
+
+// `sfn_print_warn_sfn(msg)` — `[warn]`-prefixed stderr.
+fn sfn_print_warn_sfn(msg: * u8) -> void ![io] {
+    sailfin_runtime_print_warn(msg);
+}
+
+// `sfn_print_error_sfn(msg)` — `[error]`-prefixed stderr.
+fn sfn_print_error_sfn(msg: * u8) -> void ![io] {
+    sailfin_runtime_print_error(msg);
+}
+
+// `sfn_getenv_sfn(name)` — environment-variable read. Architect
+// spec marshals `name` to a NUL-terminated buffer in an arena and
+// wraps the result through `sfn_str_from_cstr`; today's body
+// passes the NUL-terminated legacy pointer through directly since
+// SfnString.data already carries a trailing NUL (literal lowering
+// + arena-routed concat preserve it).
+fn sfn_getenv_sfn(name: * u8) -> * u8 ![io] {
+    return sailfin_runtime_getenv(name);
+}
+
+// `sfn_home_dir_sfn()` — `getenv("HOME")` (or `USERPROFILE` on
+// Windows; the C trampoline handles the platform fork).
+fn sfn_home_dir_sfn() -> * u8 ![io] { return sailfin_runtime_home_dir(); }

--- a/runtime/sfn/io.sfn
+++ b/runtime/sfn/io.sfn
@@ -58,13 +58,22 @@
 // the primitive with the effect, matching the §3.6 effect-on-
 // wrapper rule.
 //
-// Why inline the libc externs? The same reason `arena.sfn` /
-// `string.sfn` do: the released seed compiler snapshots
-// `runtime/sfn/platform/libc.sfn` at build time. Inlining keeps
-// this module self-contained for every seed, regardless of which
-// libc declarations have shipped. Once the seed catches up, a
-// follow-up PR can flip these to a cross-module import without
-// touching the bodies.
+// Extern declarations split across two surfaces:
+//
+//   - `write` from `runtime/sfn/platform/libc.sfn` (imported) —
+//     mirrors the pre-existing `sfn_write_fd` baseline. The seed
+//     compiler's libc snapshot has carried `write` since the
+//     `sfn_write_fd` proof-of-life shipped under M2.7 (#303), so
+//     the cross-module import resolves cleanly. Adapters that
+//     reach for new libc surfaces (e.g. `lseek` / `dup2`) that the
+//     seed snapshot may not yet declare should follow the
+//     `arena.sfn` / `string.sfn` discipline and inline locally.
+//
+//   - `sailfin_runtime_*` C runtime entrypoints (inlined below).
+//     These are *not* platform libc declarations — they're C
+//     trampolines defined in `runtime/native/src/sailfin_runtime.c`
+//     and not part of any `runtime/sfn/platform/*.sfn` skeleton.
+//     Inlining is the only declaration site available.
 import { write } from "./platform/libc";
 
 extern fn sailfin_runtime_print_raw(msg: * u8) -> void;


### PR DESCRIPTION
## Summary

- Flips the print / console / env runtime helper descriptors from the legacy `sailfin_runtime_*` C entrypoints to the Sailfin-native `sfn_print*` / `sfn_getenv` / `sfn_home_dir` symbols via `native_signature`. Print descriptors carry the SfnString aggregate ABI (`{i8*, i64}`); env helpers preserve the legacy `i8*` shape (arena-threaded SfnString return is deferred to a follow-up wave).
- Adds C trampolines in `runtime/native/src/sailfin_runtime.c` that accept the aggregate by value (`SfnString s`) and forward to the legacy entrypoints — SfnString.data is NUL-terminated end-to-end today, so the legacy `char *` bodies remain correct without a second formatting strategy.
- Extends `runtime/sfn/io.sfn` with the `sfn_print_sfn_*` / `sfn_getenv_sfn` / `sfn_home_dir_sfn` infix family — proof-of-life under the Sailfin namespace, mirroring M2.4a's `runtime/sfn/string.sfn` discipline. The module joins `sfn-sources` so it ships in every compiler binary.
- Adds `i64` / `double` → `{i8*, i64}` coercion chains to `coerce_operand_to_type` so `print(int_expr)` / `print(double_expr)` still compile after the ABI flip.
- Adapts the hardcoded test-harness emission in `lowering_core.sfn::add_test_harness_lines` to pack its `[N x i8]*` globals into `{i8*, i64}` before calling `@sfn_print_err`.

Closes #401

## Acceptance Criteria

- [x] `print.info("hello")` lowers to `call void @sfn_print_info({i8*, i64} %s)` not `@sailfin_runtime_print_info` (verified by `test_runtime_io_extended.sh::test_full_probe_flipped`).
- [x] `examples/basics/hello-world.sfn` still prints correctly (verified by `test_runtime_io_extended.sh::test_hello_world_runs` and manual run — output: `Hello, Sailfin!`).
- [x] `make compile` passes.
- [x] `make test` passes — `unit: 100/100`, `integration: 26/26`, `e2e: 67/67`, `capsules: 13/13` (206 total).

## Verification

```bash
ulimit -v 8388608 && make compile
ulimit -v 8388608 && make test
ulimit -v 8388608 && build/native/sailfin run examples/basics/hello-world.sfn
# => Hello, Sailfin!
ulimit -v 8388608 && build/native/sailfin emit -o /tmp/hello.ll llvm examples/basics/hello-world.sfn \
    && grep -E "@sfn_print\b|@sailfin_runtime_print" /tmp/hello.ll
# => declare void @sfn_print({i8*, i64})
# => call void @sfn_print({i8*, i64} %t3)
ulimit -v 8388608 && bash compiler/tests/e2e/test_runtime_io_extended.sh build/native/sailfin
# => [summary] 9 passed, 0 failed
```

## Files Changed

**Compiler:**
- `compiler/src/llvm/runtime_helpers.sfn` — populate `native_signature` + bump `parameter_types` to `{i8*, i64}` on the 8 print/console descriptors; populate `native_signature` (keep `i8*` ABI) on the 2 env descriptors.
- `compiler/src/llvm/expression_lowering/native/core_operands.sfn` — `i64` / `double` → `{i8*, i64}` coercion chains (number_to_string + `sfn_str_len`-recovered length).
- `compiler/src/llvm/lowering/lowering_core.sfn` — test-harness emission packs the test-name / pass-message `[N x i8]*` globals into the aggregate before calling `@sfn_print_err`.

**Runtime:**
- `runtime/sfn/io.sfn` — Sailfin proof-of-life under `_sfn_` infix for the seven new exports, alongside the existing `sfn_write_fd` baseline.
- `runtime/native/include/sailfin_runtime.h` — prototypes for `sfn_print(SfnString)` + variants and the two env trampolines.
- `runtime/native/src/sailfin_runtime.c` — five aggregate-accepting print trampolines forwarding to `sailfin_runtime_print_*`; two env-helper trampolines forwarding to the legacy `i8*` ABI.
- `runtime/native/capsule.toml` — append `../sfn/io.sfn` to `sfn-sources`.

**Tests:**
- `compiler/tests/e2e/test_runtime_io_extended.sh` (new) — 9 assertions: typecheck + fmt + emit-shape + namespace-coexistence + per-target call-site flip on a multi-call probe + hello-world end-to-end + binary-exports + manifest lockstep.
- `compiler/tests/e2e/test_string_aggregate_shape.sh` — bump the `insertvalue {i8*, i64} undef, i8*` count from 4 to 5 (the `combined` operand passed into the flipped `print.info` adds one `i8*` → `{i8*, i64}` coercion).
- `compiler/tests/unit/abi_version_test.sfn` — pin the new `native_signature` values on the `print` / `print.err` registry rows.

## Notes / Deviations from the Issue

- The issue's `In:` lists the architectural target signatures (`sfn_print(SfnString)`, `sfn_getenv(SfnString, *Arena) -> SfnString`, etc.). Today's Sailfin frontend can't take an SfnString aggregate by value or thread an arena pointer at the call site — same constraint M2.4a worked around. The bodies in `runtime/sfn/io.sfn` are therefore proof-of-life trampolines under the `_sfn_` infix; the C trampolines in `sailfin_runtime.c` carry the canonical `sfn_print*` / `sfn_getenv` / `sfn_home_dir` names against the aggregate ABI (print) or legacy ABI (env). A follow-up wave retires the C trampolines and renames the Sailfin exports to the bare canonical form once the aggregate-typed parameter flip (M1.A.2) and arena threading land.
- The env helpers preserve the legacy `i8*` ABI on `parameter_types` / `return_type` — the SfnString aggregate return needs the arena-threaded call-site lowering (NUL-marshal the name, wrap the result via `sfn_str_from_cstr`), which I treated as out-of-scope for this milestone to keep the size: S budget honest. The `native_signature` flip ships now so the migration symbol surface is locked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DHtB8BF29pRfo6g1fuAno8)_