### PR TITLE
M2.7b — migrate instructions_try.sfn to frame-based catches (#404)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -807,6 +807,22 @@ rebuild:
 		echo "[rebuild] staging process.o..."; \
 		$(CLANG) -O2 -Wno-override-module -c build/native/obj/runtime/process.ll -o build/native/obj/runtime/process.o; \
 	fi
+	@# Stage exception.o (Sailfin-native frame primitives from
+	@# runtime/sfn/exception.sfn). M2.7b (issue #404) ships the
+	@# compiler-emission migration that inlines `sfn_exception_push_frame`
+	@# + `setjmp` + `sfn_exception_pop_frame` at every user try block;
+	@# the legacy link path (`_clang_compile_runtime_objects` in
+	@# `compiler/src/cli_main.sfn`) resolves those symbols against this
+	@# staged .o. The runtime-capsule path reaches exception.sfn through
+	@# `runtime/native/capsule.toml`'s `sfn-sources` array instead.
+	@if [ ! -f build/native/obj/runtime/exception.ll ]; then \
+		echo "[rebuild] staging exception.ll..."; \
+		$(NATIVE_OUT) emit -o build/native/obj/runtime/exception.ll llvm runtime/sfn/exception.sfn >/dev/null; \
+	fi
+	@if [ ! -f build/native/obj/runtime/exception.o ]; then \
+		echo "[rebuild] staging exception.o..."; \
+		$(CLANG) -O2 -Wno-override-module -c build/native/obj/runtime/exception.ll -o build/native/obj/runtime/exception.o; \
+	fi
 	@# Write build stamp (version + git hash for dev builds).
 	@# `version.sfn::resolve_compiler_version` reads this file
 	@# first, so without it the binary would report whatever stale

--- a/compiler/src/cli_main.sfn
+++ b/compiler/src/cli_main.sfn
@@ -353,6 +353,39 @@ fn _runtime_process_path(root: string) -> string ![io] {
     return "";
 }
 
+// M2.7b (issue #404) mirrors the M2.11 clock and M2.9 process
+// migrations above: the compiler-emission migration in
+// `compiler/src/llvm/lowering/instructions_try.sfn` now emits inline
+// `sfn_exception_push_frame` + `setjmp` + `sfn_exception_pop_frame`
+// at every user try block, and `sfn_throw` (longjmp) at every throw
+// site. Those symbols are defined in the Sailfin-native module
+// `runtime/sfn/exception.sfn`; the legacy `sfn run` / `sfn build`
+// link path (this function's caller, `_clang_compile_runtime_objects`)
+// needs the staged `.o` to resolve them. The runtime-capsule path
+// reaches the source through `runtime/native/capsule.toml`'s
+// `sfn-sources` array instead. Search order mirrors
+// `_runtime_clock_path` so bundled installs and in-tree dev builds
+// both find the staged object. Empty return surfaces as "undefined
+// reference to `sfn_exception_push_frame`" (and friends) at link
+// time once any user code with a `try` block reaches the linker —
+// same fail-loud contract as the clock path.
+fn _runtime_exception_path(root: string) -> string ![io] {
+    let bundled = _path_join(root, "native/obj/exception.o");
+    if fs.exists(bundled) { return bundled; }
+    let bundled_nested = _path_join(root, "native/obj/runtime/exception.o");
+    if fs.exists(bundled_nested) { return bundled_nested; }
+    let parent = _dirname(root);
+    let fallback = _path_join(parent, "build/native/obj/exception.o");
+    if fs.exists(fallback) { return fallback; }
+    let fallback_nested = _path_join(parent, "build/native/obj/runtime/exception.o");
+    if fs.exists(fallback_nested) { return fallback_nested; }
+    let selfhost_fallback = _path_join(parent, "build/selfhost/native/obj/exception.o");
+    if fs.exists(selfhost_fallback) { return selfhost_fallback; }
+    let selfhost_fallback_nested = _path_join(parent, "build/selfhost/native/obj/runtime/exception.o");
+    if fs.exists(selfhost_fallback_nested) { return selfhost_fallback_nested; }
+    return "";
+}
+
 // Last `/`-separated segment of a path. Returns the input itself
 // when there's no slash. Used for naming runtime obj outputs after
 // their source basename, matching the legacy `_clang_compile_runtime_objects`
@@ -682,17 +715,21 @@ fn _clang_compile_runtime_objects(runtime_root: string, out_dir: string, opt_fla
     // Build (or reuse) cached runtime object files so repeated `test` invocations
     // don't recompile the runtime C sources per test file.
     //
-    // Return shape: `[runtime_obj, arena_obj, globals_obj, prelude_obj, clock_obj, process_obj]`.
+    // Return shape: `[runtime_obj, arena_obj, globals_obj, prelude_obj, clock_obj, process_obj, exception_obj]`.
     // The trailing `clock_obj` slot is the PR 2 (#397) addition for the
     // Sailfin-native `@sfn_sleep` definition; `process_obj` is the M2.9
-    // (#405) addition for `@sfn_process_run`. Empty `clock_obj` /
-    // `process_obj` entries are tolerated when the corresponding
-    // `runtime/sfn/*.sfn` module has not yet been staged into the runtime
-    // bundle — callers skip empty entries when assembling the link line.
-    // Any of the first four going empty signals a failed runtime compile
-    // and propagates back to the caller as a hard fail.
+    // (#405) addition for `@sfn_process_run`; `exception_obj` is the
+    // M2.7b (#404) addition for the frame-based exception primitives
+    // (`sfn_exception_push_frame` / `sfn_exception_pop_frame` /
+    // `sfn_take_exception` / `sfn_throw`). Empty `clock_obj` /
+    // `process_obj` / `exception_obj` entries are tolerated when the
+    // corresponding `runtime/sfn/*.sfn` module has not yet been staged
+    // into the runtime bundle — callers skip empty entries when
+    // assembling the link line. Any of the first four going empty
+    // signals a failed runtime compile and propagates back to the
+    // caller as a hard fail.
     if runtime_root.length == 0 {
-        return ["", "", "", "", "", ""];
+        return ["", "", "", "", "", "", ""];
     }
     if !_runtime_bundle_exists(runtime_root) {
         return ["", "", "", "", "", ""];
@@ -705,6 +742,7 @@ fn _clang_compile_runtime_objects(runtime_root: string, out_dir: string, opt_fla
     let prelude_obj = _runtime_prelude_path(runtime_root);
     let clock_obj = _runtime_clock_path(runtime_root);
     let process_obj = _runtime_process_path(runtime_root);
+    let exception_obj = _runtime_exception_path(runtime_root);
 
     let runtime_obj = _path_join(out_dir, "sailfin_runtime" + opt_flag + ".o");
     let arena_obj = _path_join(out_dir, "sailfin_arena" + opt_flag + ".o");
@@ -714,7 +752,7 @@ fn _clang_compile_runtime_objects(runtime_root: string, out_dir: string, opt_fla
         let rc = process.run(["clang", opt_flag, "-Wno-override-module", "-I"
             + include_dir, "-c", runtime_src, "-o", runtime_obj,]);
         if rc != 0 {
-            return ["", "", "", "", "", ""];
+            return ["", "", "", "", "", "", ""];
         }
     }
 
@@ -722,18 +760,18 @@ fn _clang_compile_runtime_objects(runtime_root: string, out_dir: string, opt_fla
         let rc_arena = process.run(["clang", opt_flag, "-Wno-override-module", "-I"
             + include_dir, "-c", arena_src, "-o", arena_obj,]);
         if rc_arena != 0 {
-            return ["", "", "", "", "", ""];
+            return ["", "", "", "", "", "", ""];
         }
     }
 
     if !fs.exists(globals_obj) {
         let rc2 = process.run(["clang", opt_flag, "-Wno-override-module", "-c", runtime_ir, "-o", globals_obj,]);
         if rc2 != 0 {
-            return ["", "", "", "", "", ""];
+            return ["", "", "", "", "", "", ""];
         }
     }
 
-    return [runtime_obj, arena_obj, globals_obj, prelude_obj, clock_obj, process_obj];
+    return [runtime_obj, arena_obj, globals_obj, prelude_obj, clock_obj, process_obj, exception_obj];
 }
 
 fn _clang_link_with_opt(ll_path: string, out_path: string, runtime_root: string, runtime_capsules: RuntimeCapsuleArtifacts[], opt_flag: string, cache_dir: string, binary_dir: string) -> int ![io] {
@@ -837,6 +875,15 @@ fn _clang_link_multi_with_opt(ll_paths: string[], out_path: string, runtime_root
         // `@sfn_process_run` definition. Same empty-string fallback
         // contract as `clock_obj`.
         let process_obj = cached[5];
+        // M2.7b (#404): `exception_obj` carries the Sailfin-native
+        // frame-based exception primitives. Same empty-string
+        // fallback contract as `clock_obj` / `process_obj` — user
+        // programs without a `try` block don't reach the symbols
+        // and the link succeeds either way; user programs with
+        // a `try` block fail loudly at link time with "undefined
+        // reference to `sfn_exception_push_frame`" so the missing
+        // staged artifact surfaces immediately.
+        let exception_obj = cached[6];
         let mut _missing: boolean = false;
         if runtime_obj.length == 0 { _missing = true; }
         if arena_obj.length == 0 { _missing = true; }
@@ -852,6 +899,7 @@ fn _clang_link_multi_with_opt(ll_paths: string[], out_path: string, runtime_root
         runtime_objs.push(prelude_obj);
         if clock_obj.length > 0 { runtime_objs.push(clock_obj); }
         if process_obj.length > 0 { runtime_objs.push(process_obj); }
+        if exception_obj.length > 0 { runtime_objs.push(exception_obj); }
         runtime_link_libs.push("-lm");
     }
 

--- a/compiler/src/llvm/effects.sfn
+++ b/compiler/src/llvm/effects.sfn
@@ -547,9 +547,18 @@ fn collect_instruction_runtime_helper_targets(instruction: NativeInstruction) ->
         return helpers;
     }
     if instruction.variant == "Try" {
-        return ["clear_exception", "has_exception", "take_exception"];
+        // M2.7b (#404): emit declares for the new frame primitives alongside
+        // the legacy TLS-polling family so both APIs coexist during the
+        // transition. M2.7c retires the legacy entries once every emission
+        // site has cut over.
+        return ["clear_exception", "has_exception", "take_exception", "sfn_exception_push_frame", "sfn_exception_pop_frame", "sfn_take_exception_frame", "setjmp"];
     }
-    if instruction.variant == "Throw" { return ["set_exception"]; }
+    if instruction.variant == "Throw" {
+        // M2.7b (#404): `lower_throw_instruction` emits `call void
+        // @sfn_throw` (longjmp); declare the legacy `set_exception` symbol
+        // too so seed-compiled call sites that still call it link cleanly.
+        return ["set_exception", "sfn_throw_frame"];
+    }
     return [];
 }
 

--- a/compiler/src/llvm/lowering/instructions_try.sfn
+++ b/compiler/src/llvm/lowering/instructions_try.sfn
@@ -7,7 +7,7 @@ import { lower_expression } from "../expression_lowering/native/core";
 import { coerce_operand_to_type } from "../expression_lowering/native/core_operands";
 import { append_local_binding } from "../expression_lowering/native/core_scopes";
 import { emit_runtime_call, empty_runtime_call_overrides } from "../expression_lowering/native/runtime_call";
-import { default_return_literal, format_local_pointer_name, format_temp_name } from "../expressions_helpers";
+import { format_local_pointer_name, format_temp_name } from "../expressions_helpers";
 import { make_child_scope_id } from "../lifetime";
 import { empty_string_constant_set, merge_string_constants } from "../strings";
 import {
@@ -177,24 +177,29 @@ fn lower_throw_instruction(function_name: string, instruction: NativeInstruction
         };
     }
 
-    // M1.7.3 (#499): route through descriptor-driven dispatch. The
-    // `set_exception` descriptor declares `["i8*"]` parameter types
-    // and a `void` return; the coerced operand already carries `i8*`,
-    // so emit_runtime_call renders byte-identically with the prior
-    // hand-spelled emission.
-    let set_exc_operands: LLVMOperand[] = [coerced.operand];
-    let set_exc_call = emit_runtime_call("set_exception", set_exc_operands, empty_runtime_call_overrides(), current_temp, current_lines);
+    // M2.7b (#404): route the throw through the frame-based primitive
+    // `sfn_throw`, which writes the message into the top frame's
+    // message_addr slot, pops the chain head, then `longjmp`s back to
+    // the matching `setjmp` save point emitted at the user's try entry.
+    // Control transfers to the catch body in the dominator function;
+    // the `ret` that the legacy TLS-polling path emitted after
+    // `set_exception` would be dead anyway (longjmp does not return),
+    // so we follow with `unreachable` to make that explicit and to
+    // let LLVM's branch folding prune the trailing block. The legacy
+    // `sailfin_runtime_set_exception` symbol stays declared via the
+    // helper registry so seed-compiled call sites still link; M2.7c
+    // retires the C body once every emission site has cut over.
+    let throw_operands: LLVMOperand[] = [coerced.operand];
+    let throw_call = emit_runtime_call("sfn_throw_frame", throw_operands, empty_runtime_call_overrides(), current_temp, current_lines);
     let mut _ci_se: int = 0;
     loop {
-        if _ci_se >= set_exc_call.diagnostics.length { break; }
-        diagnostics.push(set_exc_call.diagnostics[_ci_se]);
+        if _ci_se >= throw_call.diagnostics.length { break; }
+        diagnostics.push(throw_call.diagnostics[_ci_se]);
         _ci_se += 1;
     }
-    current_lines = set_exc_call.lines;
-    current_temp = set_exc_call.temp_index;
-    if llvm_return == "void" { current_lines.push("  ret void"); } else {
-        current_lines.push("  ret " + llvm_return + " " + default_return_literal(llvm_return));
-    }
+    current_lines = throw_call.lines;
+    current_temp = throw_call.temp_index;
+    current_lines.push("  unreachable");
     return ThrowLoweringResult {
         lines: current_lines,
         temp_index: current_temp,
@@ -225,28 +230,42 @@ fn lower_try_instruction(function: NativeFunction, start_index: int, llvm_return
     let mut lifetime_regions: LifetimeRegionMetadata[] = [];
     let mut collected_string_constants: StringConstant[] = empty_string_constant_set();
 
-    // Reset exception state at start of try.
-    // M1.7.3 (#499): route through descriptor-driven dispatch.
-    let clear_exc_call = emit_runtime_call("clear_exception", [], empty_runtime_call_overrides(), current_temp, current_lines);
-    let mut _ci_ce: int = 0;
-    loop {
-        if _ci_ce >= clear_exc_call.diagnostics.length { break; }
-        diagnostics.push(clear_exc_call.diagnostics[_ci_ce]);
-        _ci_ce += 1;
-    }
-    current_lines = clear_exc_call.lines;
-    current_temp = clear_exc_call.temp_index;
+    // M2.7b (#404): frame-based exception emission. The legacy
+    // TLS-polling shape (`clear_exception` + try body + `has_exception`
+    // poll + `take_exception` in catch + post-merge propagate poll) is
+    // replaced by inline setjmp / push_frame / pop_frame primitives
+    // that bind the save point to the user function's own stack
+    // frame. The decomposed primitives in `runtime/sfn/exception.sfn`
+    // (`sfn_exception_push_frame`, `sfn_exception_pop_frame`,
+    // `sfn_take_exception`) are safe to call as regular functions —
+    // only `setjmp` itself must live inline in the user `define` so
+    // its save point stays live across the throw. See the UB caveat
+    // comment in the M2.7a module file header.
+    // Frame and jmp_buf are stack-allocated in the function prologue.
+    // SfnExceptionFrame layout `{ i64, i64, i64 }` (prev_addr,
+    // jmp_buf_addr, message_addr) is encoded as `[3 x i64]` so user
+    // modules don't need the named struct type — the call into
+    // `sfn_exception_push_frame` accepts an `i8*` and link-time
+    // opaque-pointer resolution lands on the `%SfnExceptionFrame*`
+    // define in exception.sfn. The jmp_buf is `[32 x i64]` = 256
+    // bytes, matching the literal in `sfn_exception_alloc_frame`
+    // (oversized for Linux x86_64 / macOS arm64 — see the JMPBUF_SIZE
+    // note in the M2.7a module header).
+    let frame_pointer = format_local_pointer_name(current_next_local);
+    current_next_local += 1;
+    let jmpbuf_pointer = format_local_pointer_name(current_next_local);
+    current_next_local += 1;
+    current_allocas.push("  " + frame_pointer + " = alloca [3 x i64]");
+    current_allocas.push("  " + jmpbuf_pointer + " = alloca [32 x i64]");
 
     let try_label_alloc = allocate_block_label("try", current_block_counter);
     let try_label = try_label_alloc.label;
     current_block_counter = try_label_alloc.next_counter;
 
     let mut catch_label: string = "";
-    if structure.catch_index != -1 {
-        let catch_label_alloc = allocate_block_label("catch", current_block_counter);
-        catch_label = catch_label_alloc.label;
-        current_block_counter = catch_label_alloc.next_counter;
-    }
+    let catch_label_alloc = allocate_block_label("catch", current_block_counter);
+    catch_label = catch_label_alloc.label;
+    current_block_counter = catch_label_alloc.next_counter;
 
     let mut finally_label: string = "";
     if structure.finally_index != -1 {
@@ -259,7 +278,84 @@ fn lower_try_instruction(function: NativeFunction, start_index: int, llvm_return
     let merge_label = merge_label_alloc.label;
     current_block_counter = merge_label_alloc.next_counter;
 
-    current_lines.push("  br label %" + try_label);
+    // Cast frame and jmpbuf allocas to i8* for the runtime ABI.
+    let frame_i8 = format_temp_name(current_temp);
+    current_temp += 1;
+    current_lines.push("  " + frame_i8 + " = bitcast [3 x i64]* "
+        + frame_pointer
+        + " to i8*");
+    let jmpbuf_i8 = format_temp_name(current_temp);
+    current_temp += 1;
+    current_lines.push("  " + jmpbuf_i8 + " = bitcast [32 x i64]* "
+        + jmpbuf_pointer
+        + " to i8*");
+
+    // Initialize frame.jmp_buf_addr (slot index 1) with ptrtoint of
+    // jmpbuf. The chain-mutation primitive populates prev_addr; the
+    // message_addr slot (index 2) starts zero so `sfn_take_exception`
+    // observes "no message" until `sfn_throw` writes one.
+    let jmpbuf_slot_ptr = format_temp_name(current_temp);
+    current_temp += 1;
+    current_lines.push("  " + jmpbuf_slot_ptr
+        + " = getelementptr [3 x i64], [3 x i64]* "
+        + frame_pointer
+        + ", i64 0, i64 1");
+    let jmpbuf_addr_i64 = format_temp_name(current_temp);
+    current_temp += 1;
+    current_lines.push("  " + jmpbuf_addr_i64 + " = ptrtoint i8* " + jmpbuf_i8
+        + " to i64");
+    current_lines.push("  store i64 " + jmpbuf_addr_i64 + ", i64* "
+        + jmpbuf_slot_ptr);
+    let msg_slot_ptr = format_temp_name(current_temp);
+    current_temp += 1;
+    current_lines.push("  " + msg_slot_ptr
+        + " = getelementptr [3 x i64], [3 x i64]* "
+        + frame_pointer
+        + ", i64 0, i64 2");
+    current_lines.push("  store i64 0, i64* " + msg_slot_ptr);
+
+    // Push the frame onto the chain head. Safe to call as a regular
+    // function — only mutates the global chain head pointer, no
+    // setjmp state involved.
+    let frame_operand: LLVMOperand = LLVMOperand {
+        llvm_type: "i8*",
+        value: frame_i8
+    };
+    let push_call = emit_runtime_call("sfn_exception_push_frame", [frame_operand], empty_runtime_call_overrides(), current_temp, current_lines);
+    let mut _ci_push: int = 0;
+    loop {
+        if _ci_push >= push_call.diagnostics.length { break; }
+        diagnostics.push(push_call.diagnostics[_ci_push]);
+        _ci_push += 1;
+    }
+    current_lines = push_call.lines;
+    current_temp = push_call.temp_index;
+
+    // Inline `setjmp` — this is the load-bearing call site. The save
+    // point must live inside the user function's `define` so its
+    // stored stack pointer / register file stays valid until the
+    // matching `longjmp` from `sfn_throw` fires.
+    let setjmp_temp = format_temp_name(current_temp);
+    let jmpbuf_operand: LLVMOperand = LLVMOperand {
+        llvm_type: "i8*",
+        value: jmpbuf_i8
+    };
+    let setjmp_call = emit_runtime_call("setjmp", [jmpbuf_operand], empty_runtime_call_overrides(), current_temp, current_lines);
+    let mut _ci_sj: int = 0;
+    loop {
+        if _ci_sj >= setjmp_call.diagnostics.length { break; }
+        diagnostics.push(setjmp_call.diagnostics[_ci_sj]);
+        _ci_sj += 1;
+    }
+    current_lines = setjmp_call.lines;
+    current_temp = setjmp_call.temp_index;
+    let first_call_temp = format_temp_name(current_temp);
+    current_temp += 1;
+    current_lines.push("  " + first_call_temp + " = icmp eq i32 " + setjmp_temp
+        + ", 0");
+    current_lines.push("  br i1 " + first_call_temp + ", label %" + try_label
+        + ", label %"
+        + catch_label);
 
     // Try block
     current_lines.push(try_label + ":");
@@ -282,67 +378,68 @@ fn lower_try_instruction(function: NativeFunction, start_index: int, llvm_return
     collected_string_constants = merge_string_constants(collected_string_constants, try_result.string_constants);
 
     if !try_result.terminated {
-        // M1.7.3 (#499): route through descriptor-driven dispatch.
-        // Capture the temp name first so the subsequent `br i1` keeps
-        // referencing the same SSA value emit_runtime_call binds at
-        // `current_temp`.
-        let has_exc = format_temp_name(current_temp);
-        let has_exc_call = emit_runtime_call("has_exception", [], empty_runtime_call_overrides(), current_temp, current_lines);
-        let mut _ci_he: int = 0;
+        // Normal try exit: pop the frame off the chain (longjmp did
+        // not fire) then branch to finally/merge.
+        let pop_call = emit_runtime_call("sfn_exception_pop_frame", [frame_operand], empty_runtime_call_overrides(), current_temp, current_lines);
+        let mut _ci_pop: int = 0;
         loop {
-            if _ci_he >= has_exc_call.diagnostics.length { break; }
-            diagnostics.push(has_exc_call.diagnostics[_ci_he]);
-            _ci_he += 1;
+            if _ci_pop >= pop_call.diagnostics.length { break; }
+            diagnostics.push(pop_call.diagnostics[_ci_pop]);
+            _ci_pop += 1;
         }
-        current_lines = has_exc_call.lines;
-        current_temp = has_exc_call.temp_index;
+        current_lines = pop_call.lines;
+        current_temp = pop_call.temp_index;
         let normal_target = merge_label;
         if structure.finally_index != -1 { normal_target = finally_label; }
-        if structure.catch_index != -1 {
-            current_lines.push("  br i1 " + has_exc + ", label %" + catch_label
-                + ", label %"
-                + normal_target);
-        } else {
-            // No catch: proceed to normal target; any pending exception will be propagated after finally/merge.
-            current_lines.push("  br label %" + normal_target);
-        }
+        current_lines.push("  br label %" + normal_target);
     }
 
+    // Catch / exception landing pad. setjmp returns non-zero here
+    // after `sfn_throw` longjmps back; the frame has already been
+    // popped by `sfn_throw` (architect §2.4.2: throw pops before
+    // longjmp). When the source has no `catch` block we still need
+    // the landing label so the setjmp branch has a valid target —
+    // the synthesized body re-throws into the outer frame so the
+    // exception is not silently swallowed.
+    current_lines.push(catch_label + ":");
+    let catch_scope_id = make_child_scope_id(scope_id, catch_label);
+
+    // Catch-entry guarded drops (M1.5.4, issue #328). For every
+    // owned rc local descended from the try scope, emit a
+    // sentinel-gated `call void @sfn_rc_release(i8* %t)` so locals
+    // that may have been initialized before the throw fired are
+    // still released. The walk uses `try_result.locals` (post-try-
+    // body lowering) so M1.5.5 escape-promotion flips to "rc" are
+    // visible here. When no rc-eligible bindings exist the helper
+    // emits zero lines and the catch label remains the active
+    // block; otherwise the helper terminates on a fresh `skipN`
+    // block which becomes the catch body's active label.
+    let _guarded = emit_guarded_scope_drops(try_result.locals, try_scope_id, current_temp, current_block_counter);
+    current_lines = extend_string_array(current_lines, _guarded.lines);
+    current_temp = _guarded.next_temp;
+    current_block_counter = _guarded.next_block_counter;
+    let mut catch_active_label: string = catch_label;
+    if _guarded.final_label.length > 0 {
+        catch_active_label = _guarded.final_label;
+    }
+
+    // After the M1.5.4 guarded drops fire, pull the exception
+    // message off the just-popped frame via `sfn_take_exception(frame)`
+    // (consumes the slot — see the architect §2.4.2 / legacy C
+    // `sailfin_runtime_take_exception` symmetry). The result is an
+    // `i8*` carrying the thrown string.
+    let exception_temp = format_temp_name(current_temp);
+    let take_call = emit_runtime_call("sfn_take_exception_frame", [frame_operand], empty_runtime_call_overrides(), current_temp, current_lines);
+    let mut _ci_te: int = 0;
+    loop {
+        if _ci_te >= take_call.diagnostics.length { break; }
+        diagnostics.push(take_call.diagnostics[_ci_te]);
+        _ci_te += 1;
+    }
+    current_lines = take_call.lines;
+    current_temp = take_call.temp_index;
+
     if structure.catch_index != -1 {
-        // Catch block
-        current_lines.push(catch_label + ":");
-        let catch_scope_id = make_child_scope_id(scope_id, catch_label);
-        // M1.7.3 (#499): route through descriptor-driven dispatch.
-        let exception_temp = format_temp_name(current_temp);
-        let take_exc_call = emit_runtime_call("take_exception", [], empty_runtime_call_overrides(), current_temp, current_lines);
-        let mut _ci_te: int = 0;
-        loop {
-            if _ci_te >= take_exc_call.diagnostics.length { break; }
-            diagnostics.push(take_exc_call.diagnostics[_ci_te]);
-            _ci_te += 1;
-        }
-        current_lines = take_exc_call.lines;
-        current_temp = take_exc_call.temp_index;
-
-        // Catch-entry guarded drops (M1.5.4, issue #328). For every
-        // owned rc local descended from the try scope, emit a
-        // sentinel-gated `call void @sfn_rc_release(i8* %t)` so locals
-        // that may have been initialized before the throw fired are
-        // still released. The walk uses `try_result.locals` (post-try-
-        // body lowering) so M1.5.5 escape-promotion flips to "rc" are
-        // visible here. When no rc-eligible bindings exist the helper
-        // emits zero lines and the catch label remains the active
-        // block; otherwise the helper terminates on a fresh `skipN`
-        // block which becomes the catch body's active label.
-        let _guarded = emit_guarded_scope_drops(try_result.locals, try_scope_id, current_temp, current_block_counter);
-        current_lines = extend_string_array(current_lines, _guarded.lines);
-        current_temp = _guarded.next_temp;
-        current_block_counter = _guarded.next_block_counter;
-        let mut catch_active_label: string = catch_label;
-        if _guarded.final_label.length > 0 {
-            catch_active_label = _guarded.final_label;
-        }
-
         let mut catch_locals: LocalBinding[] = current_locals;
         let trimmed_name = trim_text(structure.catch_name);
         if trimmed_name.length > 0 {
@@ -382,6 +479,26 @@ fn lower_try_instruction(function: NativeFunction, start_index: int, llvm_return
             if structure.finally_index != -1 { target = finally_label; }
             current_lines.push("  br label %" + target);
         }
+    } else {
+        // No catch block — re-throw into the outer frame so the
+        // exception is not silently swallowed. The frame has already
+        // been popped by `sfn_throw`, so the outer frame is now the
+        // chain head and a second `sfn_throw` longjmps into it. If
+        // no outer frame exists `sfn_throw` calls abort().
+        let exception_operand: LLVMOperand = LLVMOperand {
+            llvm_type: "i8*",
+            value: exception_temp
+        };
+        let rethrow_call = emit_runtime_call("sfn_throw_frame", [exception_operand], empty_runtime_call_overrides(), current_temp, current_lines);
+        let mut _ci_rt: int = 0;
+        loop {
+            if _ci_rt >= rethrow_call.diagnostics.length { break; }
+            diagnostics.push(rethrow_call.diagnostics[_ci_rt]);
+            _ci_rt += 1;
+        }
+        current_lines = rethrow_call.lines;
+        current_temp = rethrow_call.temp_index;
+        current_lines.push("  unreachable");
     }
 
     if structure.finally_index != -1 {
@@ -411,34 +528,11 @@ fn lower_try_instruction(function: NativeFunction, start_index: int, llvm_return
 
     current_lines.push(merge_label + ":");
 
-    // If an exception is still pending after try/catch/finally, propagate it.
-    // M1.7.3 (#499): route through descriptor-driven dispatch.
-    let has_exc_after = format_temp_name(current_temp);
-    let has_exc_after_call = emit_runtime_call("has_exception", [], empty_runtime_call_overrides(), current_temp, current_lines);
-    let mut _ci_ha: int = 0;
-    loop {
-        if _ci_ha >= has_exc_after_call.diagnostics.length { break; }
-        diagnostics.push(has_exc_after_call.diagnostics[_ci_ha]);
-        _ci_ha += 1;
-    }
-    current_lines = has_exc_after_call.lines;
-    current_temp = has_exc_after_call.temp_index;
-    let propagate_label_alloc = allocate_block_label("try.propagate", current_block_counter);
-    let propagate_label = propagate_label_alloc.label;
-    current_block_counter = propagate_label_alloc.next_counter;
-    let continue_label_alloc = allocate_block_label("try.continue", current_block_counter);
-    let continue_label = continue_label_alloc.label;
-    current_block_counter = continue_label_alloc.next_counter;
-    current_lines.push("  br i1 " + has_exc_after + ", label %"
-        + propagate_label
-        + ", label %"
-        + continue_label);
-    current_lines.push(propagate_label + ":");
-    if llvm_return == "void" { current_lines.push("  ret void"); } else {
-        current_lines.push("  ret " + llvm_return + " " + default_return_literal(llvm_return));
-    }
-    current_lines.push(continue_label + ":");
-
+    // No has_exception polling on the merge path — the longjmp-based
+    // throw transfers control directly to the catch_label so any
+    // exception that crossed the try body has already been handled
+    // (or re-thrown into the outer frame). M2.7c removes the call-site
+    // polling that used to detect exceptions across function returns.
     return BlockLoweringResult {
         lines: current_lines,
         allocas: current_allocas,

--- a/compiler/src/llvm/lowering/instructions_try.sfn
+++ b/compiler/src/llvm/lowering/instructions_try.sfn
@@ -258,6 +258,23 @@ fn lower_try_instruction(function: NativeFunction, start_index: int, llvm_return
     current_allocas.push("  " + frame_pointer + " = alloca [3 x i64]");
     current_allocas.push("  " + jmpbuf_pointer + " = alloca [32 x i64]");
 
+    // When the source includes a `finally` block, allocate a "pending
+    // exception" slot that the exception landing pad uses to defer
+    // rethrow until after the finally body runs. The legacy emission
+    // ran finally on both the normal and exceptional paths and then
+    // re-checked TLS state to decide whether to propagate; the
+    // frame-based emission gets the same effect by storing the message
+    // here when the exception is not caught and reading it back after
+    // finally completes. The slot is only needed when finally exists —
+    // without finally, the catch landing pad either consumes the
+    // exception (catch present) or rethrows immediately (no catch).
+    let mut pending_pointer: string = "";
+    if structure.finally_index != -1 {
+        pending_pointer = format_local_pointer_name(current_next_local);
+        current_next_local += 1;
+        current_allocas.push("  " + pending_pointer + " = alloca i8*");
+    }
+
     let try_label_alloc = allocate_block_label("try", current_block_counter);
     let try_label = try_label_alloc.label;
     current_block_counter = try_label_alloc.next_counter;
@@ -313,6 +330,13 @@ fn lower_try_instruction(function: NativeFunction, start_index: int, llvm_return
         + frame_pointer
         + ", i64 0, i64 2");
     current_lines.push("  store i64 0, i64* " + msg_slot_ptr);
+
+    // Initialize the pending-exception slot to null on every try
+    // entry — the normal path leaves it null so the post-finally
+    // load returns null and falls through to merge.
+    if pending_pointer.length > 0 {
+        current_lines.push("  store i8* null, i8** " + pending_pointer);
+    }
 
     // Push the frame onto the chain head. Safe to call as a regular
     // function — only mutates the global chain head pointer, no
@@ -480,25 +504,37 @@ fn lower_try_instruction(function: NativeFunction, start_index: int, llvm_return
             current_lines.push("  br label %" + target);
         }
     } else {
-        // No catch block — re-throw into the outer frame so the
-        // exception is not silently swallowed. The frame has already
-        // been popped by `sfn_throw`, so the outer frame is now the
-        // chain head and a second `sfn_throw` longjmps into it. If
-        // no outer frame exists `sfn_throw` calls abort().
-        let exception_operand: LLVMOperand = LLVMOperand {
-            llvm_type: "i8*",
-            value: exception_temp
-        };
-        let rethrow_call = emit_runtime_call("sfn_throw_frame", [exception_operand], empty_runtime_call_overrides(), current_temp, current_lines);
-        let mut _ci_rt: int = 0;
-        loop {
-            if _ci_rt >= rethrow_call.diagnostics.length { break; }
-            diagnostics.push(rethrow_call.diagnostics[_ci_rt]);
-            _ci_rt += 1;
+        // No catch block. The exception is not handled here, but if
+        // a `finally` block exists it must still run before the
+        // exception propagates — per the documented try/finally
+        // guarantee in `docs/error-handling.md` (cleanup runs even
+        // when the try body throws). Save the message into the
+        // pending slot and branch into `finally`; the finally tail
+        // loads the slot and routes a non-null value through
+        // `rethrow` (sfn_throw → longjmp to outer frame, or abort()
+        // if no outer frame exists). With no finally either, rethrow
+        // immediately from the landing pad — there is no cleanup to
+        // run, so deferral would just be dead code.
+        if structure.finally_index != -1 {
+            current_lines.push("  store i8* " + exception_temp + ", i8** "
+                + pending_pointer);
+            current_lines.push("  br label %" + finally_label);
+        } else {
+            let exception_operand: LLVMOperand = LLVMOperand {
+                llvm_type: "i8*",
+                value: exception_temp
+            };
+            let rethrow_call = emit_runtime_call("sfn_throw_frame", [exception_operand], empty_runtime_call_overrides(), current_temp, current_lines);
+            let mut _ci_rt: int = 0;
+            loop {
+                if _ci_rt >= rethrow_call.diagnostics.length { break; }
+                diagnostics.push(rethrow_call.diagnostics[_ci_rt]);
+                _ci_rt += 1;
+            }
+            current_lines = rethrow_call.lines;
+            current_temp = rethrow_call.temp_index;
+            current_lines.push("  unreachable");
         }
-        current_lines = rethrow_call.lines;
-        current_temp = rethrow_call.temp_index;
-        current_lines.push("  unreachable");
     }
 
     if structure.finally_index != -1 {
@@ -522,7 +558,46 @@ fn lower_try_instruction(function: NativeFunction, start_index: int, llvm_return
         collected_string_constants = merge_string_constants(collected_string_constants, finally_result.string_constants);
 
         if !finally_result.terminated {
-            current_lines.push("  br label %" + merge_label);
+            // After the finally body runs, check the pending-exception
+            // slot. A null slot means the try/catch path completed
+            // normally (catch consumed any exception, or the try body
+            // finished without throwing) — fall through to merge. A
+            // non-null slot means the exception was uncaught (try +
+            // finally with no catch); rethrow it now so the next outer
+            // try frame (or abort()) sees it. The rethrow lives in its
+            // own basic block so finally's `br i1` has a single-
+            // statement successor matching the merge edge.
+            let rethrow_label_alloc = allocate_block_label("rethrow", current_block_counter);
+            let rethrow_label = rethrow_label_alloc.label;
+            current_block_counter = rethrow_label_alloc.next_counter;
+            let pending_load_temp = format_temp_name(current_temp);
+            current_temp += 1;
+            current_lines.push("  " + pending_load_temp + " = load i8*, i8** "
+                + pending_pointer);
+            let is_null_temp = format_temp_name(current_temp);
+            current_temp += 1;
+            current_lines.push("  " + is_null_temp + " = icmp eq i8* "
+                + pending_load_temp
+                + ", null");
+            current_lines.push("  br i1 " + is_null_temp + ", label %"
+                + merge_label
+                + ", label %"
+                + rethrow_label);
+            current_lines.push(rethrow_label + ":");
+            let pending_operand: LLVMOperand = LLVMOperand {
+                llvm_type: "i8*",
+                value: pending_load_temp
+            };
+            let rethrow_call = emit_runtime_call("sfn_throw_frame", [pending_operand], empty_runtime_call_overrides(), current_temp, current_lines);
+            let mut _ci_rrt: int = 0;
+            loop {
+                if _ci_rrt >= rethrow_call.diagnostics.length { break; }
+                diagnostics.push(rethrow_call.diagnostics[_ci_rrt]);
+                _ci_rrt += 1;
+            }
+            current_lines = rethrow_call.lines;
+            current_temp = rethrow_call.temp_index;
+            current_lines.push("  unreachable");
         }
     }
 

--- a/compiler/src/llvm/lowering/lowering_helpers.sfn
+++ b/compiler/src/llvm/lowering/lowering_helpers.sfn
@@ -801,5 +801,18 @@ fn seed_default_runtime_helpers(initial: string[]) -> string[] {
     helpers = append_unique_effect(helpers, "process.handle_read_stderr");
     helpers = append_unique_effect(helpers, "process.handle_wait");
     helpers = append_unique_effect(helpers, "is_decimal_digit");
+    // M2.7b (#404): frame-based exception primitives emitted inline at
+    // every user try-block entry / leave / catch and at every throw.
+    // Declared unconditionally so the user IR carries paired
+    // `declare void @sfn_exception_push_frame(i8*)` etc. — without
+    // these the inline `setjmp` and frame-management calls would link
+    // through an undeclared symbol path the way the legacy
+    // `sailfin_runtime_*` exception family does. Coexists with the
+    // legacy entries until M2.7c retires them.
+    helpers = append_unique_effect(helpers, "sfn_exception_push_frame");
+    helpers = append_unique_effect(helpers, "sfn_exception_pop_frame");
+    helpers = append_unique_effect(helpers, "sfn_take_exception_frame");
+    helpers = append_unique_effect(helpers, "sfn_throw_frame");
+    helpers = append_unique_effect(helpers, "setjmp");
     return helpers;
 }

--- a/compiler/src/llvm/runtime_helpers.sfn
+++ b/compiler/src/llvm/runtime_helpers.sfn
@@ -689,6 +689,36 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
         target: "take_exception", symbol: "sailfin_runtime_take_exception", return_type: "i8*", parameter_types: [], effects: [], native_signature: null, c_abi_return_type: null
     });
 
+    // M2.7b (#404): frame-based exception primitives from
+    // `runtime/sfn/exception.sfn`. `instructions_try.sfn` emits inline
+    // `sfn_exception_push_frame` + `setjmp` + `sfn_exception_pop_frame`
+    // at every user try block, and `sfn_throw` (longjmp) for every throw.
+    // Pointer params are typed `i8*` because user modules do not see the
+    // `%SfnExceptionFrame` named type — the opaque-pointer rule at link
+    // time resolves to the `%SfnExceptionFrame*` define in exception.sfn.
+    // Coexists with the legacy TLS-polling family above until M2.7c
+    // retires the C runtime symbols.
+    descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
+        target: "sfn_exception_push_frame", symbol: "sfn_exception_push_frame", return_type: "void", parameter_types: ["i8*"], effects: [], native_signature: null, c_abi_return_type: null
+    });
+    descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
+        target: "sfn_exception_pop_frame", symbol: "sfn_exception_pop_frame", return_type: "void", parameter_types: ["i8*"], effects: [], native_signature: null, c_abi_return_type: null
+    });
+    // Distinct target key from the zero-arg legacy `take_exception` so
+    // both descriptors coexist in the registry.
+    descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
+        target: "sfn_take_exception_frame", symbol: "sfn_take_exception", return_type: "i8*", parameter_types: ["i8*"], effects: [], native_signature: null, c_abi_return_type: null
+    });
+    descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
+        target: "sfn_throw_frame", symbol: "sfn_throw", return_type: "void", parameter_types: ["i8*"], effects: [], native_signature: null, c_abi_return_type: null
+    });
+    // libc setjmp — the inline setjmp call site lives in user code at
+    // each try entry. Declared via the helper registry so every emitting
+    // module carries a paired `declare i32 @setjmp(i8*)`.
+    descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
+        target: "setjmp", symbol: "setjmp", return_type: "i32", parameter_types: ["i8*"], effects: [], native_signature: null, c_abi_return_type: null
+    });
+
     // ---- Package-manager primitives ----
     // SHA-256 hashing
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {

--- a/compiler/tests/e2e/test_drop_emission_try_catch.sh
+++ b/compiler/tests/e2e/test_drop_emission_try_catch.sh
@@ -175,8 +175,9 @@ test_catch_entry_emission_path_present() {
     # `emit_guarded_scope_drops(try_result.locals, try_scope_id, ...)`
     # unconditionally. When the helper emits no lines (no rc-eligible
     # bindings), the IR is unchanged from M1.5.3. When it emits lines,
-    # they appear between the take-exception call and the catch
-    # variable's store.
+    # they appear between the catch-entry guarded drops and the
+    # take-exception call (M2.7b #404: catch-entry order is now
+    # guarded_drops → sfn_take_exception → bind).
     #
     # Today no fixture produces an rc + non-consumed try-body local
     # (`return ident` promotes-and-consumes; nothing else flips
@@ -184,8 +185,8 @@ test_catch_entry_emission_path_present() {
     # contains no guarded drops. The unit test
     # `compiler/tests/unit/emit_guarded_scope_drops_test.sfn` exhausts
     # the IR-shape variants; here we just verify the catch handler
-    # itself is still well-formed (one take-exception + one
-    # exception-store inside `catch1:`).
+    # itself is still well-formed (one frame-based take-exception +
+    # one exception-store inside `catch1:`).
     local ll="$SCRATCH/try_catch_machinery.ll"
     if ! emit_ir "$ll"; then
         echo "[test]   sfn emit llvm failed (machinery case)"
@@ -195,8 +196,11 @@ test_catch_entry_emission_path_present() {
     rc_block="$(awk '/^define i8\* @try_with_rc/{flag=1} flag{print} /^\}/{if(flag){flag=0}}' "$ll")"
     local catch_body
     catch_body="$(echo "$rc_block" | awk '/^catch[0-9]+:/{flag=1; next} /^[a-zA-Z0-9._]+:/{flag=0} flag{print}')"
-    if ! echo "$catch_body" | grep -qE 'call i8\* @sailfin_runtime_take_exception'; then
-        echo "[test]   catch handler missing take_exception call"
+    # M2.7b (#404): the frame-based emission calls @sfn_take_exception
+    # with the per-try frame pointer as its single i8* argument; the
+    # legacy zero-arg @sailfin_runtime_take_exception is gone.
+    if ! echo "$catch_body" | grep -qE 'call i8\* @sfn_take_exception\(i8\* %t[0-9]+\)'; then
+        echo "[test]   catch handler missing frame-based take_exception call"
         return 1
     fi
     if ! echo "$catch_body" | grep -qE 'store i8\* %t[0-9]+, i8\*\* %l[0-9]+'; then

--- a/compiler/tests/e2e/test_try_catch_frames.sh
+++ b/compiler/tests/e2e/test_try_catch_frames.sh
@@ -1,0 +1,242 @@
+#!/usr/bin/env bash
+# End-to-end test for M2.7b frame-based try/catch compiler emission
+# (issue #404, epic #389). Pins both the inline IR shape and the runtime
+# catch behavior — the latter guards the silent-no-op failure mode that
+# IR pinning alone cannot detect (see the file-header "Setjmp/longjmp
+# safety" note in `runtime/sfn/exception.sfn`).
+#
+# What the M2.7b PR ships, end-to-end:
+#
+#   1. inline IR shape — every compiler-emitted `try { ... }` block
+#      contains, inside the user function's `define`:
+#        (a) `call void @sfn_exception_push_frame(i8* %frame)` at try entry
+#        (b) `call i32 @setjmp(i8* %jmp_buf)` immediately after, whose
+#            return value is branched on (0 → try body, non-zero → catch)
+#        (c) `call void @sfn_exception_pop_frame(i8* %frame)` on the
+#            normal try-exit edge (suppressed when the body terminates
+#            via `throw` or `return` — those paths unwind through
+#            longjmp or the function epilogue)
+#      The IR must NOT contain `call i32 @sfn_try_enter(...)` — calling
+#      that as a regular function is C11 UB (glibc silently no-ops the
+#      longjmp). The runtime symbol stays exported for ABI completeness;
+#      only compiler-emitted try sites are constrained.
+#
+#   2. runtime catch behavior — `try { throw "boom"; } catch (e) { print(e); }`
+#      compiles, links, runs, prints `boom`, and exits 0. This guards
+#      the silent-no-op failure mode that a regression dropping the
+#      inline emission (e.g. reverting to `call i32 @sfn_try_enter`)
+#      would surface here instead of at link time.
+#
+# Usage:
+#   compiler/tests/e2e/test_try_catch_frames.sh <compiler-binary>
+
+set -euo pipefail
+
+BINARY="${1:?usage: test_try_catch_frames.sh <compiler-binary>}"
+BINARY="$(realpath "$BINARY")"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+PASS=0
+FAIL=0
+
+SCRATCH="$(mktemp -d -t sfn-try-catch-frames-XXXXXX)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+run_test() {
+    local name="$1"
+    shift
+    if "$@"; then
+        echo "[test] PASS: $name"
+        PASS=$((PASS + 1))
+    else
+        echo "[test] FAIL: $name"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# Fixture: a single function with try/catch that throws and prints the
+# caught message. Used by both the IR-shape pins and the runtime test.
+FIXTURE="$SCRATCH/try_catch_runtime.sfn"
+cat > "$FIXTURE" <<'SFN'
+fn main() ![io] {
+    try {
+        throw "boom";
+    } catch (e) {
+        print(e);
+    }
+}
+SFN
+
+emit_runtime_ir() {
+    local out="$1"
+    "$BINARY" emit -o "$out" llvm "$FIXTURE" > /dev/null 2>&1
+}
+
+# ---- (1) push_frame at try entry, inside the user function's define ----
+test_push_frame_in_user_function() {
+    local ll="$SCRATCH/runtime.ll"
+    if ! emit_runtime_ir "$ll"; then
+        echo "[test]   sfn emit llvm failed for runtime fixture"
+        return 1
+    fi
+    local main_block
+    main_block="$(awk '/^define void @sailfin_user_main/{flag=1} flag{print} /^\}/{if(flag){flag=0; exit}}' "$ll")"
+    local push_count
+    push_count="$(echo "$main_block" | grep -cE 'call void @sfn_exception_push_frame\(i8\* %t[0-9]+\)' || true)"
+    if [ "${push_count:-0}" -ne 1 ]; then
+        echo "[test]   main: expected 1 'call void @sfn_exception_push_frame(i8* %tN)', got $push_count"
+        echo "[test]   main block was:"
+        echo "$main_block" | sed 's/^/[test]     /'
+        return 1
+    fi
+    return 0
+}
+
+# ---- (2) setjmp inline in user function, branched on ----
+test_setjmp_inline_branch() {
+    local ll="$SCRATCH/runtime.ll"
+    if [ ! -f "$ll" ]; then
+        echo "[test]   $ll missing"
+        return 1
+    fi
+    local main_block
+    main_block="$(awk '/^define void @sailfin_user_main/{flag=1} flag{print} /^\}/{if(flag){flag=0; exit}}' "$ll")"
+    # Exactly one inline setjmp call.
+    local setjmp_count
+    setjmp_count="$(echo "$main_block" | grep -cE 'call i32 @setjmp\(i8\* %t[0-9]+\)' || true)"
+    if [ "${setjmp_count:-0}" -ne 1 ]; then
+        echo "[test]   main: expected 1 'call i32 @setjmp(i8* %tN)', got $setjmp_count"
+        return 1
+    fi
+    # The result must feed an icmp eq + br to (try, catch).
+    if ! echo "$main_block" | grep -qE 'icmp eq i32 %t[0-9]+, 0'; then
+        echo "[test]   main: missing 'icmp eq i32 ..., 0' after setjmp"
+        return 1
+    fi
+    if ! echo "$main_block" | grep -qE 'br i1 %t[0-9]+, label %try[0-9]+, label %catch[0-9]+'; then
+        echo "[test]   main: missing 'br i1 ..., label %tryN, label %catchN' after icmp"
+        return 1
+    fi
+    return 0
+}
+
+# ---- (3) push_frame is immediately followed by setjmp (no intervening calls) ----
+test_push_frame_precedes_setjmp() {
+    local ll="$SCRATCH/runtime.ll"
+    if [ ! -f "$ll" ]; then
+        echo "[test]   $ll missing"
+        return 1
+    fi
+    local main_block
+    main_block="$(awk '/^define void @sailfin_user_main/{flag=1} flag{print} /^\}/{if(flag){flag=0; exit}}' "$ll")"
+    local push_line setjmp_line
+    push_line="$(echo "$main_block" | grep -nE 'call void @sfn_exception_push_frame' | head -1 | cut -d: -f1)"
+    setjmp_line="$(echo "$main_block" | grep -nE 'call i32 @setjmp' | head -1 | cut -d: -f1)"
+    if [ -z "$push_line" ] || [ -z "$setjmp_line" ]; then
+        echo "[test]   could not locate push_frame and setjmp in main"
+        return 1
+    fi
+    if [ "$push_line" -ge "$setjmp_line" ]; then
+        echo "[test]   push_frame (line=$push_line) must precede setjmp (line=$setjmp_line)"
+        return 1
+    fi
+    return 0
+}
+
+# ---- (4) no legacy sfn_try_enter call site in compiler emission ----
+test_no_sfn_try_enter_call_site() {
+    local ll="$SCRATCH/runtime.ll"
+    if [ ! -f "$ll" ]; then
+        echo "[test]   $ll missing"
+        return 1
+    fi
+    # The compiler must not lower a try block as `call i32 @sfn_try_enter(...)`.
+    # That pattern is C11 UB — glibc silently no-ops the longjmp on a
+    # returned-frame setjmp save point. The runtime symbol is still
+    # defined in `runtime/sfn/exception.sfn` for ABI completeness; we
+    # just must not call it from generated user code.
+    local main_block
+    main_block="$(awk '/^define void @sailfin_user_main/{flag=1} flag{print} /^\}/{if(flag){flag=0; exit}}' "$ll")"
+    local count
+    count="$(echo "$main_block" | grep -cE 'call i32 @sfn_try_enter\(' || true)"
+    if [ "${count:-0}" -ne 0 ]; then
+        echo "[test]   main contains $count call(s) to @sfn_try_enter — must be inline-emitted instead"
+        return 1
+    fi
+    return 0
+}
+
+# ---- (5) catch handler reads message via @sfn_take_exception(frame) ----
+test_catch_take_exception_frame() {
+    local ll="$SCRATCH/runtime.ll"
+    if [ ! -f "$ll" ]; then
+        echo "[test]   $ll missing"
+        return 1
+    fi
+    local main_block
+    main_block="$(awk '/^define void @sailfin_user_main/{flag=1} flag{print} /^\}/{if(flag){flag=0; exit}}' "$ll")"
+    local catch_body
+    catch_body="$(echo "$main_block" | awk '/^catch[0-9]+:/{flag=1; next} /^[a-zA-Z0-9._]+:/{flag=0} flag{print}')"
+    if ! echo "$catch_body" | grep -qE 'call i8\* @sfn_take_exception\(i8\* %t[0-9]+\)'; then
+        echo "[test]   catch handler missing 'call i8* @sfn_take_exception(i8* %tN)'"
+        echo "[test]   catch body was:"
+        echo "$catch_body" | sed 's/^/[test]     /'
+        return 1
+    fi
+    return 0
+}
+
+# ---- (6) runtime catch behavior: throw "boom" → catch prints "boom", exit 0 ----
+test_runtime_catch_behavior() {
+    # Compiles the fixture end-to-end, runs it, and asserts stdout
+    # contains "boom" with exit code 0. This is the load-bearing
+    # functional assertion that IR pinning alone cannot make — a
+    # regression that loses the inline-setjmp distinction (e.g. by
+    # accidentally re-emitting `call i32 @sfn_try_enter(...)`) produces
+    # IR that links but silently no-ops the longjmp, leaving `main`
+    # to fall through past the catch handler with an unset exit code.
+    local out_bin="$SCRATCH/runtime.out"
+    local build_log="$SCRATCH/build.log"
+    if ! "$BINARY" build -o "$out_bin" "$FIXTURE" > "$build_log" 2>&1; then
+        echo "[test]   sfn build failed for runtime fixture:"
+        cat "$build_log" | sed 's/^/[test]     /'
+        return 1
+    fi
+    if [ ! -x "$out_bin" ]; then
+        echo "[test]   build produced no executable at $out_bin"
+        return 1
+    fi
+    local run_log="$SCRATCH/run.log"
+    local rc=0
+    "$out_bin" > "$run_log" 2>&1 || rc=$?
+    if [ "$rc" -ne 0 ]; then
+        echo "[test]   runtime binary exited non-zero (rc=$rc):"
+        cat "$run_log" | sed 's/^/[test]     /'
+        return 1
+    fi
+    if ! grep -q "boom" "$run_log"; then
+        echo "[test]   runtime stdout missing 'boom':"
+        cat "$run_log" | sed 's/^/[test]     /'
+        return 1
+    fi
+    return 0
+}
+
+run_test "push_frame fires at try entry inside user function" \
+    test_push_frame_in_user_function
+run_test "setjmp inline in user function, branched on return value" \
+    test_setjmp_inline_branch
+run_test "push_frame immediately precedes setjmp" \
+    test_push_frame_precedes_setjmp
+run_test "no compiler-emitted call to @sfn_try_enter" \
+    test_no_sfn_try_enter_call_site
+run_test "catch handler reads message via @sfn_take_exception(frame)" \
+    test_catch_take_exception_frame
+run_test "runtime: try { throw \"boom\" } catch (e) { print(e) } prints boom, exit 0" \
+    test_runtime_catch_behavior
+
+echo "[summary] $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi

--- a/compiler/tests/e2e/test_try_catch_frames.sh
+++ b/compiler/tests/e2e/test_try_catch_frames.sh
@@ -141,6 +141,29 @@ test_push_frame_precedes_setjmp() {
         echo "[test]   push_frame (line=$push_line) must precede setjmp (line=$setjmp_line)"
         return 1
     fi
+    # Adjacency: AC #3 spells "immediately followed by" — the only
+    # statements allowed between push_frame and setjmp are non-`call`
+    # instructions (e.g. operand prep). Any intervening `call` line
+    # means an extra side-effecting runtime call snuck into the
+    # critical path, which would invalidate the architect's intent
+    # that setjmp lands directly after the chain mutation. The
+    # current emission inserts nothing between the two; this
+    # assertion guards a regression that splices a call between them.
+    # Skip the between-range check when setjmp is on the very next
+    # line (push_line + 1 == setjmp_line) — sed treats `N,M p` with
+    # M < N as "from N onwards", which would falsely include setjmp
+    # itself.
+    if [ "$setjmp_line" -gt "$((push_line + 1))" ]; then
+        local between
+        between="$(echo "$main_block" | sed -n "$((push_line + 1)),$((setjmp_line - 1))p")"
+        local intervening_calls
+        intervening_calls="$(echo "$between" | grep -cE '^\s*(%[a-zA-Z0-9_.]+ = )?call ' || true)"
+        if [ "${intervening_calls:-0}" -ne 0 ]; then
+            echo "[test]   push_frame must be immediately followed by setjmp; found $intervening_calls intervening 'call' line(s):"
+            echo "$between" | sed 's/^/[test]     /'
+            return 1
+        fi
+    fi
     return 0
 }
 
@@ -235,6 +258,104 @@ run_test "catch handler reads message via @sfn_take_exception(frame)" \
     test_catch_take_exception_frame
 run_test "runtime: try { throw \"boom\" } catch (e) { print(e) } prints boom, exit 0" \
     test_runtime_catch_behavior
+
+# ---- (7) runtime: try { throw "x" } catch + finally runs finally before merge ----
+test_runtime_try_catch_finally() {
+    # Mirrors the documented try/catch/finally guarantee: even when
+    # the try body throws, finally runs after the catch handler.
+    # The legacy TLS-polling emission honored this; the M2.7b
+    # frame-based emission preserves it by branching catch_body →
+    # finally → merge.
+    local fixture2="$SCRATCH/try_catch_finally.sfn"
+    cat > "$fixture2" <<'SFN'
+fn main() ![io] {
+    try {
+        throw "boom";
+    } catch (e) {
+        print("caught: " + e);
+    } finally {
+        print("cleanup");
+    }
+}
+SFN
+    local out_bin="$SCRATCH/try_catch_finally.out"
+    local build_log="$SCRATCH/tcf_build.log"
+    if ! "$BINARY" build -o "$out_bin" "$fixture2" > "$build_log" 2>&1; then
+        echo "[test]   sfn build failed for try/catch/finally fixture:"
+        cat "$build_log" | sed 's/^/[test]     /'
+        return 1
+    fi
+    local run_log="$SCRATCH/tcf_run.log"
+    local rc=0
+    "$out_bin" > "$run_log" 2>&1 || rc=$?
+    if [ "$rc" -ne 0 ]; then
+        echo "[test]   try/catch/finally binary exited non-zero (rc=$rc):"
+        cat "$run_log" | sed 's/^/[test]     /'
+        return 1
+    fi
+    if ! grep -q "caught: boom" "$run_log"; then
+        echo "[test]   missing 'caught: boom' in stdout:"
+        cat "$run_log" | sed 's/^/[test]     /'
+        return 1
+    fi
+    if ! grep -q "cleanup" "$run_log"; then
+        echo "[test]   missing 'cleanup' from finally block in stdout:"
+        cat "$run_log" | sed 's/^/[test]     /'
+        return 1
+    fi
+    return 0
+}
+
+# ---- (8) runtime: try { throw "x" } finally (no catch) runs finally then propagates ----
+test_runtime_try_finally_no_catch() {
+    # Per the documented try/finally guarantee, the finally block
+    # runs even when the try body throws and there is no catch. The
+    # uncaught throw should then propagate to abort() (no outer
+    # frame in `main`). This guards the M2.7b regression flagged in
+    # PR #733 review: the catch landing pad must route through
+    # finally instead of rethrowing immediately.
+    local fixture3="$SCRATCH/try_finally_no_catch.sfn"
+    cat > "$fixture3" <<'SFN'
+fn main() ![io] {
+    try {
+        throw "boom";
+    } finally {
+        print("cleanup ran");
+    }
+}
+SFN
+    local out_bin="$SCRATCH/try_finally_no_catch.out"
+    local build_log="$SCRATCH/tfnc_build.log"
+    if ! "$BINARY" build -o "$out_bin" "$fixture3" > "$build_log" 2>&1; then
+        echo "[test]   sfn build failed for try/finally fixture:"
+        cat "$build_log" | sed 's/^/[test]     /'
+        return 1
+    fi
+    local run_log="$SCRATCH/tfnc_run.log"
+    local rc=0
+    "$out_bin" > "$run_log" 2>&1 || rc=$?
+    # We expect the binary to abort (sfn_throw with empty chain),
+    # which on Linux surfaces as a non-zero exit. The functional
+    # contract is that "cleanup ran" must appear in stdout BEFORE
+    # the process terminates — finally runs even though the
+    # exception is unhandled.
+    if ! grep -q "cleanup ran" "$run_log"; then
+        echo "[test]   finally block did not run before uncaught throw propagated (rc=$rc):"
+        cat "$run_log" | sed 's/^/[test]     /'
+        return 1
+    fi
+    if [ "$rc" -eq 0 ]; then
+        echo "[test]   expected non-zero exit from uncaught throw after finally, got rc=0:"
+        cat "$run_log" | sed 's/^/[test]     /'
+        return 1
+    fi
+    return 0
+}
+
+run_test "runtime: try { throw } catch + finally runs finally after catch" \
+    test_runtime_try_catch_finally
+run_test "runtime: try { throw } finally (no catch) runs finally before propagating" \
+    test_runtime_try_finally_no_catch
 
 echo "[summary] $PASS passed, $FAIL failed"
 if [ "$FAIL" -gt 0 ]; then


### PR DESCRIPTION
## Summary

Switches the compiler's try/catch lowering from TLS polling
(`sailfin_runtime_set_exception` + `has_exception` checks) to the
frame-based primitives shipped in M2.7a (#400, PR #729). Part 2 of 3 of
the M2.7 exception migration.

- **Try entry** emits, inline in the user function's `define`:
  `sfn_exception_push_frame(frame)` → `setjmp(jmp_buf)` → branch on
  setjmp return (`0` → try body, non-zero → catch body)
- **Normal try exit** emits `sfn_exception_pop_frame(frame)`
- **Catch entry** runs the existing M1.5.4 guarded drops, then
  `sfn_take_exception(frame)` pulls the message into the catch
  variable's slot
- **Throw** emits `sfn_throw(msg)` + `unreachable` (longjmp transfers
  control directly to the matching setjmp save point in a dominator
  function)

### UB caveat (controls AC #3)

Calling `sfn_try_enter` as a regular function and then throwing across
the boundary is C11 §7.13.2 UB — glibc's pointer-mangled longjmp
silently no-ops the throw. The setjmp save point must live **inside the
user function's `define`** so its stored stack pointer stays valid
across the throw. The decomposed M2.7a primitives
(`sfn_exception_push_frame`, `sfn_exception_pop_frame`,
`sfn_take_exception`, `sfn_throw`) are designed to be safe to call as
regular functions; only `setjmp` itself is inlined at the user's try
entry. See the M2.7a module header for the empirical UB reproducer.

### Runtime integration

`runtime/sfn/exception.sfn` is now staged as
`build/native/obj/runtime/exception.o` and threaded through
`_clang_compile_runtime_objects` (the legacy `sfn run` / `sfn build`
link path) alongside the existing clock.o / process.o slots. The
runtime-capsule path picks it up through
`runtime/native/capsule.toml`'s `sfn-sources` array as before.

Closes #404

## Acceptance Criteria

- [x] Every existing try/catch test continues to function
      (`test_drop_emission_try_catch.sh` + integration suite)
- [x] New compiler-emitted try blocks use the frame primitives by
      **inlining**; legacy `sailfin_runtime_set_exception` calls inside
      lowered user code are still tolerated by the runtime (both APIs
      coexist during this PR — legacy `sailfin_runtime_*` exception
      family stays declared via the helper registry)
- [x] **IR pinning (inline form):** the IR emitted for each
      `try { ... }` contains, inside the user function's `define`:
      (a) exactly one `call void @sfn_exception_push_frame(i8* %frame)`
      at try entry, immediately followed by
      (b) exactly one `call i32 @setjmp(i8* %jmp_buf)` whose return is
      branched on (`0` → try body label, non-zero → catch body label),
      and (c) `call void @sfn_exception_pop_frame(i8* %frame)` on the
      normal try-exit edge.
      The IR contains zero `call i32 @sfn_try_enter(...)` at
      compiler-emitted sites
- [x] **Runtime catch-behavior test:** the new e2e compiles and runs
      `fn main() [io] { try { throw "boom"; } catch (e) { print(e); } }`
      and asserts stdout contains `boom`, exit code 0
- [x] #328 (init-sentinel guarded drops) is honored at catch entry —
      the M1.5.4 `emit_guarded_scope_drops` call still fires between
      the catch-entry label and the take-exception call
- [x] `make compile` passes (self-host from v0.7.0-alpha.2 seed)
- [x] `make test` passes (208/208 — 100 unit + 26 integration + 69 e2e
      + 13 capsules), no regressions

## Verification

```bash
ulimit -v 8388608 && make compile && make test
# Inline emission pin — setjmp must appear inside the user function's
# define, NOT a call to @sfn_try_enter:
build/native/sailfin emit -o /tmp/v.ll llvm \
  compiler/tests/e2e/fixtures/drop_emission_try_catch_basic.sfn
grep -c 'call i32 @setjmp' /tmp/v.ll       # → 2 (one per try)
grep -c 'call i32 @sfn_try_enter' /tmp/v.ll # → 0
# Runtime catch behavior:
bash compiler/tests/e2e/test_try_catch_frames.sh build/native/sailfin
# → [summary] 6 passed, 0 failed
# M2.7a regression check:
bash compiler/tests/e2e/test_runtime_exception_frames.sh build/native/sailfin
# → [summary] 12 passed, 0 failed
# Examples:
build/native/sailfin run examples/basics/try-catch-finally.sfn
# → "Something went wrong: Simulated failure" + "Shutting down cleanly."
build/native/sailfin run examples/advanced/encapsulation-struct.sfn
# → "Error: Insufficient funds." (cross-function throw caught in main)
```

## Files Changed

- `compiler/src/llvm/lowering/instructions_try.sfn` — try-entry +
  try-leave + catch-entry + throw emission rewrite
- `compiler/src/llvm/runtime_helpers.sfn` — 5 new descriptors for the
  frame primitives (`sfn_exception_push_frame`, `sfn_exception_pop_frame`,
  `sfn_take_exception_frame`, `sfn_throw_frame`, `setjmp`)
- `compiler/src/llvm/lowering/lowering_helpers.sfn` — seed the new
  targets so every emitting module carries the paired `declare` lines
- `compiler/src/llvm/effects.sfn` — register the new helpers for
  `Try` / `Throw` instruction variants
- `compiler/src/cli_main.sfn` — add `_runtime_exception_path` +
  exception.o slot in `_clang_compile_runtime_objects`
- `Makefile` — stage `build/native/obj/runtime/exception.o` alongside
  prelude/clock/process
- `compiler/tests/e2e/test_try_catch_frames.sh` (new) — pins the inline
  IR shape (push_frame + setjmp + branch + no `sfn_try_enter`) **and**
  exercises end-to-end catch behavior
- `compiler/tests/e2e/test_drop_emission_try_catch.sh` — update the
  catch-handler assertion to expect the frame-based
  `sfn_take_exception(frame)` instead of the legacy zero-arg
  `sailfin_runtime_take_exception()`

## Notes for review

- **Out-of-scope deferrals (M2.7c):** `has_exception` polling deletion
  in call emission lands separately so a regression bisect can
  localize whether a bug is in try emission or call-site polling
  removal. Compiler-side `@[always_inline]` attribute parsing stays
  deferred — direct inline emission of the decomposed primitives in
  `instructions_try.sfn` is the path of least resistance and avoids
  needing a parser extension.
- **Early-return-inside-try:** the current implementation does not
  emit `pop_frame` on an early `return` inside a try body. The
  existing fixture `try_with_rc` has this pattern and continues to
  work for IR-shape assertions; runtime safety in that case would
  require plumbing pop_frame into the scope drop framework. The
  AC #4 fixture does not exercise early return, and no in-tree
  test does either, so this is documented as a follow-up rather
  than a blocker. The compiler source itself uses no try/catch
  blocks, so self-hosting is not affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KY9CJqt2fUQcUNuCwH1HxW)_