### PR TITLE
refactor(lowering): route spawn/await family through descriptor dispatch (M1.7.4, #500)

### DIFF
--- a/compiler/src/llvm/lowering/lowering_phase_render.sfn
+++ b/compiler/src/llvm/lowering/lowering_phase_render.sfn
@@ -20,6 +20,7 @@ import {
     render_vtable_constants,
     render_vtable_type_definitions
 } from "../rendering_helpers";
+import { async_runtime_declare_lines } from "../runtime_helpers";
 import { TraitMetadata, TypeContext } from "../types";
 import { number_to_string, starts_with } from "../utils";
 import { sfn_abi_hash_decimal } from "./abi_hash";
@@ -98,8 +99,17 @@ fn render_llvm_preamble(module_name: string, type_context: TypeContext, trait_me
         lines.push("");
     }
 
-    // Async/future runtime types
-    lines = extend_string_lines(lines, ["%SailfinFutureNumber = type opaque", "%SailfinFutureInt = type opaque", "%SailfinFutureBool = type opaque", "%SailfinFuturePtr = type opaque", "%SailfinFutureVoid = type opaque", "%SailfinFutureString = type opaque", "", "declare %SailfinFutureNumber* @sailfin_runtime_spawn_number(double ()*)", "declare %SailfinFutureNumber* @sailfin_runtime_spawn_number_ctx(double (i8*)*, i8*)", "declare double @sailfin_runtime_await_number(%SailfinFutureNumber*)", "declare %SailfinFutureInt* @sailfin_runtime_spawn_int(i64 ()*)", "declare %SailfinFutureInt* @sailfin_runtime_spawn_int_ctx(i64 (i8*)*, i8*)", "declare i64 @sailfin_runtime_await_int(%SailfinFutureInt*)", "declare %SailfinFutureBool* @sailfin_runtime_spawn_bool(i1 ()*)", "declare %SailfinFutureBool* @sailfin_runtime_spawn_bool_ctx(i1 (i8*)*, i8*)", "declare i1 @sailfin_runtime_await_bool(%SailfinFutureBool*)", "declare %SailfinFuturePtr* @sailfin_runtime_spawn_ptr(i8* ()*)", "declare %SailfinFuturePtr* @sailfin_runtime_spawn_ptr_ctx(i8* (i8*)*, i8*)", "declare i8* @sailfin_runtime_await_ptr(%SailfinFuturePtr*)", "declare %SailfinFutureVoid* @sailfin_runtime_spawn_void(void ()*)", "declare %SailfinFutureVoid* @sailfin_runtime_spawn_void_ctx(void (i8*)*, i8*)", "declare void @sailfin_runtime_await_void(%SailfinFutureVoid*)", "declare %SailfinFutureString* @sailfin_runtime_spawn_string(i8* ()*)", "declare %SailfinFutureString* @sailfin_runtime_spawn_string_ctx(i8* (i8*)*, i8*)", "declare i8* @sailfin_runtime_await_string(%SailfinFutureString*)", "", "; Enum tag reader for seedcheck - reads i32 tag from NativeInstruction array", "declare double @sailfin_enum_tag_from_instruction_array(i8*, double)", "",]);
+    // Async/future runtime types. Opaque-type defs and the seedcheck
+    // enum-tag reader declare stay inline — they are not function
+    // declares the descriptor dispatch handles (#500 / M1.7.4 scope
+    // `Out:`). The 18 spawn/await `declare` lines are sourced from the
+    // runtime helper registry via `async_runtime_declare_lines`, which
+    // walks the descriptors in registration order so the emitted IR
+    // stays byte-for-byte stable as the M4 concurrency work later
+    // extends or replaces the typed variants.
+    lines = extend_string_lines(lines, ["%SailfinFutureNumber = type opaque", "%SailfinFutureInt = type opaque", "%SailfinFutureBool = type opaque", "%SailfinFuturePtr = type opaque", "%SailfinFutureVoid = type opaque", "%SailfinFutureString = type opaque", ""]);
+    lines = extend_string_lines(lines, async_runtime_declare_lines());
+    lines = extend_string_lines(lines, ["", "; Enum tag reader for seedcheck - reads i32 tag from NativeInstruction array", "declare double @sailfin_enum_tag_from_instruction_array(i8*, double)", ""]);
 
     // Vtable type definitions
     let vtable_type_lines = render_vtable_type_definitions(type_context);

--- a/compiler/src/llvm/mod.sfn
+++ b/compiler/src/llvm/mod.sfn
@@ -116,7 +116,8 @@ export {
 export {
     runtime_helper_descriptors,
     find_runtime_helper,
-    append_runtime_helper
+    append_runtime_helper,
+    async_runtime_declare_lines
 } from "./runtime_helpers";
 
 // Re-export type mapping functions

--- a/compiler/src/llvm/runtime_helpers.sfn
+++ b/compiler/src/llvm/runtime_helpers.sfn
@@ -75,7 +75,7 @@
 // and Epic #450 for the milestone-level sequencing.
 //
 import { RuntimeHelperDescriptor } from "./types";
-import { trim_text } from "./utils";
+import { join_with_separator, trim_text } from "./utils";
 
 // =============================================================================
 // Runtime Helper Registry
@@ -216,6 +216,76 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
     // `spawn_*` / `await_*` flavors (real pthread implementations) keep
     // their descriptors below. Re-introduce these only when the
     // structured-concurrency runtime (#500, roadmap M4) actually lands.
+    //
+    // M1.7.4 (#500): typed async spawn/await descriptors. Source of
+    // truth for the `declare`-line emission previously hardcoded in
+    // `lowering_phase_render.sfn`. Order matters — `async_runtime_declare_lines`
+    // walks the registry in declaration order, and the integration suite
+    // pins the resulting `declare` sequence byte-for-byte. Effects stay
+    // empty until the M4 concurrency runtime wires up capability
+    // gating; today's hardcoded declares emit no capability metadata
+    // so leaving these empty keeps the preamble IR identical.
+    //
+    // Six future types in lockstep: number (double), int (i64),
+    // bool (i1), ptr (i8*), void, string (i8*). The `int` variant
+    // was added post-grooming under PR #677 — the architect's count
+    // of 5+5+5=15 in the issue body assumed 5 types; the actual code
+    // tracks 6, so this batch registers 6+6+6=18 entries.
+    descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
+        target: "spawn_number", symbol: "sailfin_runtime_spawn_number", return_type: "%SailfinFutureNumber*", parameter_types: ["double ()*"], effects: [], native_signature: null, c_abi_return_type: null
+    });
+    descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
+        target: "spawn_number_ctx", symbol: "sailfin_runtime_spawn_number_ctx", return_type: "%SailfinFutureNumber*", parameter_types: ["double (i8*)*", "i8*"], effects: [], native_signature: null, c_abi_return_type: null
+    });
+    descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
+        target: "await_number", symbol: "sailfin_runtime_await_number", return_type: "double", parameter_types: ["%SailfinFutureNumber*"], effects: [], native_signature: null, c_abi_return_type: null
+    });
+    descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
+        target: "spawn_int", symbol: "sailfin_runtime_spawn_int", return_type: "%SailfinFutureInt*", parameter_types: ["i64 ()*"], effects: [], native_signature: null, c_abi_return_type: null
+    });
+    descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
+        target: "spawn_int_ctx", symbol: "sailfin_runtime_spawn_int_ctx", return_type: "%SailfinFutureInt*", parameter_types: ["i64 (i8*)*", "i8*"], effects: [], native_signature: null, c_abi_return_type: null
+    });
+    descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
+        target: "await_int", symbol: "sailfin_runtime_await_int", return_type: "i64", parameter_types: ["%SailfinFutureInt*"], effects: [], native_signature: null, c_abi_return_type: null
+    });
+    descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
+        target: "spawn_bool", symbol: "sailfin_runtime_spawn_bool", return_type: "%SailfinFutureBool*", parameter_types: ["i1 ()*"], effects: [], native_signature: null, c_abi_return_type: null
+    });
+    descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
+        target: "spawn_bool_ctx", symbol: "sailfin_runtime_spawn_bool_ctx", return_type: "%SailfinFutureBool*", parameter_types: ["i1 (i8*)*", "i8*"], effects: [], native_signature: null, c_abi_return_type: null
+    });
+    descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
+        target: "await_bool", symbol: "sailfin_runtime_await_bool", return_type: "i1", parameter_types: ["%SailfinFutureBool*"], effects: [], native_signature: null, c_abi_return_type: null
+    });
+    descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
+        target: "spawn_ptr", symbol: "sailfin_runtime_spawn_ptr", return_type: "%SailfinFuturePtr*", parameter_types: ["i8* ()*"], effects: [], native_signature: null, c_abi_return_type: null
+    });
+    descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
+        target: "spawn_ptr_ctx", symbol: "sailfin_runtime_spawn_ptr_ctx", return_type: "%SailfinFuturePtr*", parameter_types: ["i8* (i8*)*", "i8*"], effects: [], native_signature: null, c_abi_return_type: null
+    });
+    descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
+        target: "await_ptr", symbol: "sailfin_runtime_await_ptr", return_type: "i8*", parameter_types: ["%SailfinFuturePtr*"], effects: [], native_signature: null, c_abi_return_type: null
+    });
+    descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
+        target: "spawn_void", symbol: "sailfin_runtime_spawn_void", return_type: "%SailfinFutureVoid*", parameter_types: ["void ()*"], effects: [], native_signature: null, c_abi_return_type: null
+    });
+    descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
+        target: "spawn_void_ctx", symbol: "sailfin_runtime_spawn_void_ctx", return_type: "%SailfinFutureVoid*", parameter_types: ["void (i8*)*", "i8*"], effects: [], native_signature: null, c_abi_return_type: null
+    });
+    descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
+        target: "await_void", symbol: "sailfin_runtime_await_void", return_type: "void", parameter_types: ["%SailfinFutureVoid*"], effects: [], native_signature: null, c_abi_return_type: null
+    });
+    descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
+        target: "spawn_string", symbol: "sailfin_runtime_spawn_string", return_type: "%SailfinFutureString*", parameter_types: ["i8* ()*"], effects: [], native_signature: null, c_abi_return_type: null
+    });
+    descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
+        target: "spawn_string_ctx", symbol: "sailfin_runtime_spawn_string_ctx", return_type: "%SailfinFutureString*", parameter_types: ["i8* (i8*)*", "i8*"], effects: [], native_signature: null, c_abi_return_type: null
+    });
+    descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
+        target: "await_string", symbol: "sailfin_runtime_await_string", return_type: "i8*", parameter_types: ["%SailfinFutureString*"], effects: [], native_signature: null, c_abi_return_type: null
+    });
+
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
         target: "runtime_create_capability_grant", symbol: "sailfin_runtime_create_capability_grant", return_type: "i8*", parameter_types: ["i8*"], effects: [], native_signature: null, c_abi_return_type: null
     });
@@ -814,4 +884,62 @@ fn effective_helper_declare_return_type(descriptor: RuntimeHelperDescriptor) -> 
         if abi.length > 0 { return abi; }
     }
     return descriptor.return_type;
+}
+
+// Render the `declare`-line block for the typed spawn/await runtime
+// family (M1.7.4 / #500). Drives the preamble declares previously
+// hardcoded in `lowering_phase_render.sfn` from the descriptor
+// registry, so the registry is the single source of truth for the
+// concurrency ABI. Order tracks `runtime_helper_descriptors()`
+// declaration order — the integration suite pins the resulting IR
+// sequence byte-for-byte.
+fn async_runtime_declare_lines() -> string[] {
+    let mut lines: string[] = [];
+    let descriptors = runtime_helper_descriptors();
+    let mut index: int = 0;
+    loop {
+        if index >= descriptors.length { break; }
+        let descriptor = descriptors[index];
+        if is_async_runtime_target(descriptor.target) {
+            let declare_return = effective_helper_declare_return_type(descriptor);
+            let mut parameter_text: string = "";
+            if descriptor.parameter_types.length > 0 {
+                parameter_text = join_with_separator(descriptor.parameter_types, ", ");
+            }
+            lines.push("declare " + declare_return + " @" + descriptor.symbol
+                + "("
+                + parameter_text
+                + ")");
+        }
+        index += 1;
+    }
+    return lines;
+}
+
+// True when the descriptor target names one of the typed spawn/await
+// runtime helpers driven by `async_runtime_declare_lines`. Membership
+// is enumerated rather than prefix-matched so the legacy adapter-layer
+// `spawn_task` target (kept for parity with pre-#617 untyped spawn
+// callers) and any future spawn-family additions stay out of the
+// preamble emission until they explicitly opt in here.
+fn is_async_runtime_target(target: string) -> boolean {
+    if target == "spawn_number" { return true; }
+    if target == "spawn_number_ctx" { return true; }
+    if target == "await_number" { return true; }
+    if target == "spawn_int" { return true; }
+    if target == "spawn_int_ctx" { return true; }
+    if target == "await_int" { return true; }
+    if target == "spawn_bool" { return true; }
+    if target == "spawn_bool_ctx" { return true; }
+    if target == "await_bool" { return true; }
+    if target == "spawn_ptr" { return true; }
+    if target == "spawn_ptr_ctx" { return true; }
+    if target == "await_ptr" { return true; }
+    if target == "spawn_void" { return true; }
+    if target == "spawn_void_ctx" { return true; }
+    if target == "await_void" { return true; }
+    if target == "spawn_string" { return true; }
+    if target == "spawn_string_ctx" { return true; }
+    if target == "await_string" { return true; }
+    return false;
 }


### PR DESCRIPTION
## Summary

- Register the 18 typed spawn/await variants as `RuntimeHelperDescriptor`s in `compiler/src/llvm/runtime_helpers.sfn` (10 spawn + 5 spawn-ctx + 5 await with the architect-specified shapes, plus the post-grooming `int` family).
- Add `async_runtime_declare_lines` (plus the `is_async_runtime_target` filter) that walks the registry in declaration order and emits the `declare`-line block previously hardcoded in `lowering_phase_render.sfn`.
- Refactor the 100+ KiB hardcoded `extend_string_lines([...])` at `compiler/src/llvm/lowering/lowering_phase_render.sfn:101` into three short calls — opaque-type defs inline, registry-driven declares in the middle, seedcheck enum-tag declare inline (matches the issue's scope `Out:` clause exactly).
- Wire `async_runtime_declare_lines` through `compiler/src/llvm/mod.sfn` for cross-module discoverability.

Closes #500

## Acceptance Criteria

- [x] `grep -E 'target: "spawn_(number|bool|ptr|void|string)' compiler/src/llvm/runtime_helpers.sfn` returns **10** entries
- [x] `grep -E 'target: "await_' compiler/src/llvm/runtime_helpers.sfn` returns **6** entries (architect specified 5; PR #677 added `SailfinFutureInt` post-grooming so the live block already declares `await_int`. Migrating it is required to satisfy criterion 3 below — see "Deviation from issue".)
- [x] `grep -c '@sailfin_runtime_spawn_\|@sailfin_runtime_await_' compiler/src/llvm/lowering/lowering_phase_render.sfn` returns **0**
- [x] **Before/after IR diff empty** — `diff /tmp/m174.before.ll /tmp/m174.after.ll` on `compiler/tests/integration/async_await_test.sfn` produces zero bytes; the 18 spawn/await declares emit in the same byte-for-byte order.
- [x] `make check` green — stage2 == stage3 fixed point, unit 100/100, integration 26/26, e2e 69/69, capsules 13/13 on both first-pass and seedcheck binaries.
- [x] `sfn fmt --check` clean on all three touched files.

## Deviation from issue

The issue's architect-verified count (5 base + 5 ctx + 5 await = 15) was correct at grooming time (2026-05-08). PR #677 (2026-05-19, `fix(async): add SailfinFutureInt for async fn -> int returns`) added a sixth future type and three more declares to the hardcoded block. The migration must include the `int` family to satisfy criterion 3 (zero hardcoded raw IR), so this PR registers 18 descriptors instead of 15. The spawn grep (`spawn_(number|bool|ptr|void|string)`) still returns exactly 10 because its regex never matched `int` to begin with; only the broader `await_` grep ticks up from 5 to 6. The descriptor-table comment documents this asymmetry.

`effects: []` on every new descriptor is intentional: today's hardcoded declares emit no capability-comment metadata, so empty effects keep the preamble IR byte-identical. The M4 concurrency redesign will fill in `["spawn"]` when capability gating actually wires up at the call sites.

## Verification

```bash
# Captured pre-change baseline with seed-built binary (no source changes loaded)
ulimit -v 8388608 && timeout 60 build/native/sailfin emit llvm \
  compiler/tests/integration/async_await_test.sfn > /tmp/m174.before.ll  # 303 lines

# … apply the change, rebuild …
ulimit -v 8388608 && make compile                                         # ✅ self-hosts

# Re-emit and diff
ulimit -v 8388608 && timeout 60 build/native/sailfin emit llvm \
  compiler/tests/integration/async_await_test.sfn > /tmp/m174.after.ll   # 303 lines
diff /tmp/m174.before.ll /tmp/m174.after.ll                              # empty ✓

# Format + full validation
ulimit -v 8388608 && build/native/sailfin fmt --check \
  compiler/src/llvm/runtime_helpers.sfn compiler/src/llvm/mod.sfn \
  compiler/src/llvm/lowering/lowering_phase_render.sfn                   # ✅ clean
ulimit -v 8388608 && make check                                          # ✅ stage2 == stage3 fixed point
```

## Files Changed

- `compiler/src/llvm/runtime_helpers.sfn` (+128/-1) — 18 new descriptors + `async_runtime_declare_lines` + `is_async_runtime_target` + `join_with_separator` import.
- `compiler/src/llvm/lowering/lowering_phase_render.sfn` (+13/-1) — replace hardcoded block, import `async_runtime_declare_lines`.
- `compiler/src/llvm/mod.sfn` (+2/-1) — re-export `async_runtime_declare_lines`.

Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BzkVVrL678yeKk7nrHKNmM)_