### PR TITLE
feat(runtime): executable-path + runtime-root resolution in exec.sfn (#468)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -823,6 +823,28 @@ rebuild:
 		echo "[rebuild] staging exception.o..."; \
 		$(CLANG) -O2 -Wno-override-module -c build/native/obj/runtime/exception.ll -o build/native/obj/runtime/exception.o; \
 	fi
+	@# Stage exec.o (Sailfin-native executable-path + runtime-root
+	@# resolution from runtime/sfn/platform/exec.sfn). Issue #468
+	@# (epic #451 M5.3 prerequisite) ships `@exe_path` /
+	@# `@binary_dir` / `@resolve_runtime_root` as the pure-Sailfin
+	@# replacement for the `_resolve_runtime_root(argv0)` block in
+	@# `runtime/native/src/native_driver.c`. The legacy link path
+	@# (`_clang_compile_runtime_objects` in `compiler/src/cli_main.sfn`)
+	@# resolves those symbols against this staged .o; the runtime-
+	@# capsule path reaches exec.sfn through `runtime/native/
+	@# capsule.toml`'s `sfn-sources` array instead. Empty staging
+	@# today is benign — no user surface dispatches through this
+	@# module — but M5.3's `@main` lowering will be the first
+	@# internal caller and a missing staged artifact then surfaces
+	@# at link time as "undefined reference to `exe_path`".
+	@if [ ! -f build/native/obj/runtime/exec.ll ]; then \
+		echo "[rebuild] staging exec.ll..."; \
+		$(NATIVE_OUT) emit -o build/native/obj/runtime/exec.ll llvm runtime/sfn/platform/exec.sfn >/dev/null; \
+	fi
+	@if [ ! -f build/native/obj/runtime/exec.o ]; then \
+		echo "[rebuild] staging exec.o..."; \
+		$(CLANG) -O2 -Wno-override-module -c build/native/obj/runtime/exec.ll -o build/native/obj/runtime/exec.o; \
+	fi
 	@# Write build stamp (version + git hash for dev builds).
 	@# `version.sfn::resolve_compiler_version` reads this file
 	@# first, so without it the binary would report whatever stale

--- a/compiler/src/cli_main.sfn
+++ b/compiler/src/cli_main.sfn
@@ -386,6 +386,40 @@ fn _runtime_exception_path(root: string) -> string ![io] {
     return "";
 }
 
+// Issue #468 (M5.3 prerequisite per epic #451) ships the Sailfin
+// equivalents of `_resolve_runtime_root(argv0)` and the per-OS
+// executable-path block in `runtime/native/src/native_driver.c`.
+// The new module `runtime/sfn/platform/exec.sfn` exports
+// `@binary_dir`, `@exe_path`, and `@resolve_runtime_root`; the
+// legacy `sfn run` / `sfn build` link path (this function's
+// caller, `_clang_compile_runtime_objects`) needs the staged `.o`
+// to resolve them once any user program (or the M5.3 entry-point
+// lowering once it lands) reaches the symbols. The runtime-
+// capsule path reaches exec.sfn through `runtime/native/
+// capsule.toml`'s `sfn-sources` array instead. Search order
+// mirrors `_runtime_clock_path` so bundled installs and in-tree
+// dev builds both find the staged object. Empty return is benign
+// today (no user surface dispatches through this module yet) but
+// becomes fail-loud once M5.3 wires `@main` to call `@exe_path` —
+// the linker then reports "undefined reference to `exe_path`"
+// and the missing staged artifact surfaces immediately.
+fn _runtime_exec_path(root: string) -> string ![io] {
+    let bundled = _path_join(root, "native/obj/exec.o");
+    if fs.exists(bundled) { return bundled; }
+    let bundled_nested = _path_join(root, "native/obj/runtime/exec.o");
+    if fs.exists(bundled_nested) { return bundled_nested; }
+    let parent = _dirname(root);
+    let fallback = _path_join(parent, "build/native/obj/exec.o");
+    if fs.exists(fallback) { return fallback; }
+    let fallback_nested = _path_join(parent, "build/native/obj/runtime/exec.o");
+    if fs.exists(fallback_nested) { return fallback_nested; }
+    let selfhost_fallback = _path_join(parent, "build/selfhost/native/obj/exec.o");
+    if fs.exists(selfhost_fallback) { return selfhost_fallback; }
+    let selfhost_fallback_nested = _path_join(parent, "build/selfhost/native/obj/runtime/exec.o");
+    if fs.exists(selfhost_fallback_nested) { return selfhost_fallback_nested; }
+    return "";
+}
+
 // Last `/`-separated segment of a path. Returns the input itself
 // when there's no slash. Used for naming runtime obj outputs after
 // their source basename, matching the legacy `_clang_compile_runtime_objects`
@@ -715,24 +749,26 @@ fn _clang_compile_runtime_objects(runtime_root: string, out_dir: string, opt_fla
     // Build (or reuse) cached runtime object files so repeated `test` invocations
     // don't recompile the runtime C sources per test file.
     //
-    // Return shape: `[runtime_obj, arena_obj, globals_obj, prelude_obj, clock_obj, process_obj, exception_obj]`.
+    // Return shape: `[runtime_obj, arena_obj, globals_obj, prelude_obj, clock_obj, process_obj, exception_obj, exec_obj]`.
     // The trailing `clock_obj` slot is the PR 2 (#397) addition for the
     // Sailfin-native `@sfn_sleep` definition; `process_obj` is the M2.9
     // (#405) addition for `@sfn_process_run`; `exception_obj` is the
     // M2.7b (#404) addition for the frame-based exception primitives
     // (`sfn_exception_push_frame` / `sfn_exception_pop_frame` /
-    // `sfn_take_exception` / `sfn_throw`). Empty `clock_obj` /
-    // `process_obj` / `exception_obj` entries are tolerated when the
+    // `sfn_take_exception` / `sfn_throw`); `exec_obj` is the #468
+    // addition for `@exe_path` / `@binary_dir` / `@resolve_runtime_root`
+    // (M5.3 prerequisite). Empty `clock_obj` / `process_obj` /
+    // `exception_obj` / `exec_obj` entries are tolerated when the
     // corresponding `runtime/sfn/*.sfn` module has not yet been staged
     // into the runtime bundle — callers skip empty entries when
     // assembling the link line. Any of the first four going empty
     // signals a failed runtime compile and propagates back to the
     // caller as a hard fail.
     if runtime_root.length == 0 {
-        return ["", "", "", "", "", "", ""];
+        return ["", "", "", "", "", "", "", ""];
     }
     if !_runtime_bundle_exists(runtime_root) {
-        return ["", "", "", "", "", ""];
+        return ["", "", "", "", "", "", "", ""];
     }
 
     let include_dir = _path_join(runtime_root, "native/include");
@@ -743,6 +779,7 @@ fn _clang_compile_runtime_objects(runtime_root: string, out_dir: string, opt_fla
     let clock_obj = _runtime_clock_path(runtime_root);
     let process_obj = _runtime_process_path(runtime_root);
     let exception_obj = _runtime_exception_path(runtime_root);
+    let exec_obj = _runtime_exec_path(runtime_root);
 
     let runtime_obj = _path_join(out_dir, "sailfin_runtime" + opt_flag + ".o");
     let arena_obj = _path_join(out_dir, "sailfin_arena" + opt_flag + ".o");
@@ -752,7 +789,7 @@ fn _clang_compile_runtime_objects(runtime_root: string, out_dir: string, opt_fla
         let rc = process.run(["clang", opt_flag, "-Wno-override-module", "-I"
             + include_dir, "-c", runtime_src, "-o", runtime_obj,]);
         if rc != 0 {
-            return ["", "", "", "", "", "", ""];
+            return ["", "", "", "", "", "", "", ""];
         }
     }
 
@@ -760,18 +797,18 @@ fn _clang_compile_runtime_objects(runtime_root: string, out_dir: string, opt_fla
         let rc_arena = process.run(["clang", opt_flag, "-Wno-override-module", "-I"
             + include_dir, "-c", arena_src, "-o", arena_obj,]);
         if rc_arena != 0 {
-            return ["", "", "", "", "", "", ""];
+            return ["", "", "", "", "", "", "", ""];
         }
     }
 
     if !fs.exists(globals_obj) {
         let rc2 = process.run(["clang", opt_flag, "-Wno-override-module", "-c", runtime_ir, "-o", globals_obj,]);
         if rc2 != 0 {
-            return ["", "", "", "", "", "", ""];
+            return ["", "", "", "", "", "", "", ""];
         }
     }
 
-    return [runtime_obj, arena_obj, globals_obj, prelude_obj, clock_obj, process_obj, exception_obj];
+    return [runtime_obj, arena_obj, globals_obj, prelude_obj, clock_obj, process_obj, exception_obj, exec_obj];
 }
 
 fn _clang_link_with_opt(ll_path: string, out_path: string, runtime_root: string, runtime_capsules: RuntimeCapsuleArtifacts[], opt_flag: string, cache_dir: string, binary_dir: string) -> int ![io] {
@@ -884,6 +921,18 @@ fn _clang_link_multi_with_opt(ll_paths: string[], out_path: string, runtime_root
         // reference to `sfn_exception_push_frame`" so the missing
         // staged artifact surfaces immediately.
         let exception_obj = cached[6];
+        // #468 (M5.3 prereq): `exec_obj` carries the Sailfin-native
+        // `@exe_path` / `@binary_dir` / `@resolve_runtime_root`
+        // helpers. Same empty-string fallback contract as
+        // `clock_obj` / `process_obj` / `exception_obj` — user
+        // programs that don't `extern fn exe_path()` (today, that
+        // is every user program; M5.3's lowered `@main` will be the
+        // first internal caller) don't reach the symbols and the
+        // link succeeds either way. Once M5.3 lands, the symbols
+        // become unconditionally referenced and a missing staged
+        // artifact surfaces immediately as "undefined reference to
+        // `exe_path`".
+        let exec_obj = cached[7];
         let mut _missing: boolean = false;
         if runtime_obj.length == 0 { _missing = true; }
         if arena_obj.length == 0 { _missing = true; }
@@ -900,6 +949,7 @@ fn _clang_link_multi_with_opt(ll_paths: string[], out_path: string, runtime_root
         if clock_obj.length > 0 { runtime_objs.push(clock_obj); }
         if process_obj.length > 0 { runtime_objs.push(process_obj); }
         if exception_obj.length > 0 { runtime_objs.push(exception_obj); }
+        if exec_obj.length > 0 { runtime_objs.push(exec_obj); }
         runtime_link_libs.push("-lm");
     }
 

--- a/compiler/tests/e2e/fixtures/exec_path_probe.sfn
+++ b/compiler/tests/e2e/fixtures/exec_path_probe.sfn
@@ -1,0 +1,37 @@
+// Fixture for compiler/tests/e2e/test_runtime_exec_path.sh.
+//
+// Prints the result of `exe_path()` from `runtime/sfn/platform/
+// exec.sfn` so the shell wrapper can compare it against the
+// fixture binary's own canonicalized path. The fixture lives in
+// `compiler/tests/e2e/fixtures/` and the shell test compiles it
+// into a scratch dir, runs it, and checks the printed path
+// resolves back to the just-built binary.
+//
+// `extern fn` rather than an `import` because the seed compiler's
+// cross-module signature resolver (issue #306) does not yet hand
+// back return-type info for runtime/sfn modules — same reason the
+// unit test at `compiler/tests/unit/runtime_exec_path_test.sfn`
+// uses an extern shim. The Sailfin function's `string` return
+// lowers to `i8*` at the LLVM level (the seed has not yet
+// flipped `string` -> `{i8*, i64}` for parameters; see the
+// M1.A.2 note in `runtime/sfn/string.sfn`), so the `* u8`-typed
+// extern binds bit-for-bit to the same symbol.
+extern fn exe_path() -> * u8;
+
+extern fn strlen(s: * u8) -> usize;
+
+fn main() -> int ![io] {
+    let path: * u8 = exe_path();
+    if path as i64 == 0 {
+        print("[exec_path_probe] exe_path returned NULL");
+        return 1;
+    }
+    let len: usize = strlen(path);
+    if len as i64 == 0 {
+        print("[exec_path_probe] exe_path returned empty string");
+        return 1;
+    }
+    let path_str: string = path as string;
+    print(path_str);
+    return 0;
+}

--- a/compiler/tests/e2e/test_runtime_exec_path.sh
+++ b/compiler/tests/e2e/test_runtime_exec_path.sh
@@ -1,0 +1,272 @@
+#!/usr/bin/env bash
+# End-to-end test for `runtime/sfn/platform/exec.sfn` — the
+# Sailfin-native executable-path + runtime-root resolution
+# helpers shipped under issue #468 (M5.3 prerequisite per epic
+# #451).
+#
+# Pinned shape:
+#
+#   1. typecheck   — `sfn check runtime/sfn/platform/exec.sfn`
+#                    reports `ok`.
+#   2. fmt         — `sfn fmt --check runtime/sfn/platform/exec.sfn`
+#                    is canonical.
+#   3. emit shape — the module emits `define i8* @exe_path()` and
+#                    `define i8* @binary_dir(i8* %exe)` and
+#                    `define i8* @resolve_runtime_root(i8* %exe_path)`
+#                    at unmangled names so the staged `.o` resolves
+#                    when downstream callers (`extern fn`-declared or
+#                    the M5.3 `@main` lowering) reach the symbols.
+#   4. extern decls — `runtime/sfn/platform/libc.sfn` carries
+#                    `declare i32 @_NSGetExecutablePath(i8*, i32*)`
+#                    and `declare i32 @GetModuleFileNameA(i8*, i8*, i32)`
+#                    when emitted standalone. Criterion 4 of the
+#                    issue: declarations parse cleanly on Linux even
+#                    though they're never called there. Pinning the
+#                    `declare` shape here so a future widening of
+#                    the accept-list doesn't accidentally drop them.
+#   5. round-trip  — the fixture binary at
+#                    `compiler/tests/e2e/fixtures/exec_path_probe.sfn`
+#                    builds via `sfn build`, runs, and prints a
+#                    path whose `realpath` matches the fixture's
+#                    own `realpath`. This pins the
+#                    `readlink("/proc/self/exe")` Linux happy path
+#                    end-to-end.
+#
+# Platform coverage. macOS and Windows are out of scope for the
+# round-trip (`exe_path` returns the empty string on those
+# platforms today — see the body comments in `exec.sfn` for the
+# follow-up plan). The first four checks still pass cross-
+# platform because they only exercise compile-time shape.
+
+set -euo pipefail
+
+BINARY="${1:?usage: test_runtime_exec_path.sh <compiler-binary>}"
+BINARY="$(realpath "$BINARY")"
+PASS=0
+FAIL=0
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+MODULE="$REPO_ROOT/runtime/sfn/platform/exec.sfn"
+LIBC_MODULE="$REPO_ROOT/runtime/sfn/platform/libc.sfn"
+FIXTURE="$REPO_ROOT/compiler/tests/e2e/fixtures/exec_path_probe.sfn"
+
+SCRATCH="$(mktemp -d -t sfn-runtime-exec-XXXXXX)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+run_test() {
+    local name="$1"
+    shift
+    if "$@"; then
+        echo "[test] PASS: $name"
+        PASS=$((PASS + 1))
+    else
+        echo "[test] FAIL: $name"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+test_check_clean() {
+    local log="$SCRATCH/check.log"
+    if ! "$BINARY" check "$MODULE" > "$log" 2>&1; then
+        echo "[test]   sfn check exited non-zero on exec.sfn:"
+        cat "$log"
+        return 1
+    fi
+    if ! grep -q "checked .* ok" "$log"; then
+        echo "[test]   sfn check did not report 'ok':"
+        cat "$log"
+        return 1
+    fi
+    return 0
+}
+
+test_fmt_clean() {
+    if ! "$BINARY" fmt --check "$MODULE" > /dev/null 2>&1; then
+        echo "[test]   $MODULE needs formatting (run: sfn fmt --write $MODULE)"
+        return 1
+    fi
+    return 0
+}
+
+test_emit_define_shape() {
+    local ll="$SCRATCH/exec.ll"
+    local log="$SCRATCH/emit.log"
+    if ! "$BINARY" emit -o "$ll" llvm "$MODULE" > "$log" 2>&1; then
+        echo "[test]   sfn emit llvm failed on exec.sfn:"
+        cat "$log"
+        return 1
+    fi
+
+    local missing=0
+    # Unmangled symbol names so the staged .o resolves at link time
+    # for both `extern fn`-declared user callers (today) and the
+    # M5.3 `@main` lowering (planned).
+    if ! grep -qE '^define i8\* @exe_path\(\) \{' "$ll"; then
+        echo "[test]   missing 'define i8* @exe_path() {'"
+        grep -nE '^define .* @exe_path' "$ll" || echo "[test]   (no @exe_path define)"
+        missing=$((missing + 1))
+    fi
+    if ! grep -qE '^define i8\* @binary_dir\(i8\* %exe\) \{' "$ll"; then
+        echo "[test]   missing 'define i8* @binary_dir(i8* %exe) {'"
+        grep -nE '^define .* @binary_dir' "$ll" || echo "[test]   (no @binary_dir define)"
+        missing=$((missing + 1))
+    fi
+    if ! grep -qE '^define i8\* @resolve_runtime_root\(i8\* %exe_path\) \{' "$ll"; then
+        echo "[test]   missing 'define i8* @resolve_runtime_root(i8* %exe_path) {'"
+        grep -nE '^define .* @resolve_runtime_root' "$ll" || echo "[test]   (no @resolve_runtime_root define)"
+        missing=$((missing + 1))
+    fi
+    # Bodies must actually call the systems primitives — the whole
+    # point of the M5.3 prereq is replacing native_driver.c's C-side
+    # `readlink` / `realpath` / `getenv` / `strrchr` calls.
+    if ! grep -qE '^[[:space:]]+%[^ ]+ = call i64 @readlink\(' "$ll"; then
+        echo "[test]   missing 'call i64 @readlink(...)' in exec.sfn body"
+        missing=$((missing + 1))
+    fi
+    if ! grep -qE '^[[:space:]]+%[^ ]+ = call i8\* @strrchr\(' "$ll"; then
+        echo "[test]   missing 'call i8* @strrchr(...)' in exec.sfn body"
+        missing=$((missing + 1))
+    fi
+    if ! grep -qE '^[[:space:]]+%[^ ]+ = call i8\* @realpath\(' "$ll"; then
+        echo "[test]   missing 'call i8* @realpath(...)' in exec.sfn body"
+        missing=$((missing + 1))
+    fi
+    if ! grep -qE '^[[:space:]]+%[^ ]+ = call i8\* @getenv\(' "$ll"; then
+        echo "[test]   missing 'call i8* @getenv(...)' in exec.sfn body"
+        missing=$((missing + 1))
+    fi
+    return "$missing"
+}
+
+test_platform_extern_decls() {
+    # Criterion 4 of #468: `_NSGetExecutablePath` and
+    # `GetModuleFileNameA` extern declarations parse cleanly on
+    # Linux. The declarations live in `runtime/sfn/platform/libc.sfn`;
+    # we emit the module standalone and verify the `declare` lines
+    # surface in the IR. Unused declarations don't trigger link
+    # errors (clang/ld only complains about unresolved *calls*),
+    # so emitting them now lets a follow-up macOS/Windows wire-up
+    # start from "add a call site" rather than "extend libc.sfn".
+    local ll="$SCRATCH/libc.ll"
+    local log="$SCRATCH/libc-emit.log"
+    if ! "$BINARY" emit -o "$ll" llvm "$LIBC_MODULE" > "$log" 2>&1; then
+        echo "[test]   sfn emit llvm failed on libc.sfn:"
+        cat "$log"
+        return 1
+    fi
+    local missing=0
+    if ! grep -qE '^declare i32 @_NSGetExecutablePath\(i8\* %buf, i32\* %bufsize\)' "$ll"; then
+        echo "[test]   missing '_NSGetExecutablePath' declaration in libc.ll"
+        grep -nE '_NSGetExecutablePath' "$ll" || echo "[test]   (no _NSGetExecutablePath references)"
+        missing=$((missing + 1))
+    fi
+    if ! grep -qE '^declare i32 @GetModuleFileNameA\(i8\* %handle, i8\* %buf, i32 %size\)' "$ll"; then
+        echo "[test]   missing 'GetModuleFileNameA' declaration in libc.ll"
+        grep -nE 'GetModuleFileNameA' "$ll" || echo "[test]   (no GetModuleFileNameA references)"
+        missing=$((missing + 1))
+    fi
+    # The new POSIX additions used by exec.sfn must also surface.
+    if ! grep -qE '^declare i64 @readlink\(i8\* %path, i8\* %buf, i64 %bufsize\)' "$ll"; then
+        echo "[test]   missing 'readlink' declaration in libc.ll"
+        missing=$((missing + 1))
+    fi
+    if ! grep -qE '^declare i8\* @realpath\(i8\* %path, i8\* %resolved\)' "$ll"; then
+        echo "[test]   missing 'realpath' declaration in libc.ll"
+        missing=$((missing + 1))
+    fi
+    if ! grep -qE '^declare i8\* @strrchr\(i8\* %s, i32 %c\)' "$ll"; then
+        echo "[test]   missing 'strrchr' declaration in libc.ll"
+        missing=$((missing + 1))
+    fi
+    if ! grep -qE '^declare i8\* @memset\(i8\* %dst, i32 %byte, i64 %n\)' "$ll"; then
+        echo "[test]   missing 'memset' declaration in libc.ll"
+        missing=$((missing + 1))
+    fi
+    return "$missing"
+}
+
+test_fixture_round_trip() {
+    # End-to-end Linux round-trip: build the probe binary via
+    # `sfn build`, run it, and confirm the printed path's
+    # `realpath` matches the just-built binary's `realpath`.
+    # macOS / Windows: `exe_path` returns "" today on those
+    # platforms (see the module header), so this round-trip is
+    # gated to Linux. The shape-only checks above still run
+    # cross-platform.
+    case "$(uname -s)" in
+        Linux) ;;
+        *)
+            echo "[test]   skipping round-trip on $(uname -s) (Linux-only today; see exec.sfn header)"
+            return 0
+            ;;
+    esac
+
+    # Copy the fixture out of the repo tree before building. When
+    # `sfn build` runs on a source inside the workspace it auto-
+    # discovers `runtime/native/capsule.toml` as a runtime dep,
+    # which routes the link through `_clang_compile_runtime_capsule_objects`
+    # — that helper compiles every `c-sources` entry, including
+    # `native_driver.c` whose `main` then collides with the
+    # fixture's `main` at link time. Building from outside the
+    # workspace falls through to the legacy `_clang_compile_runtime_objects`
+    # path which only stages the runtime helpers we explicitly
+    # need (prelude / clock / process / exception / exec — plus
+    # sailfin_runtime.c / arena.c, neither of which defines
+    # `main`). The same workaround would not be needed once
+    # native_driver.c retires under M5.
+    local fixture_copy="$SCRATCH/exec_path_probe.sfn"
+    cp "$FIXTURE" "$fixture_copy"
+
+    local probe_bin="$SCRATCH/exec_path_probe"
+    local build_log="$SCRATCH/probe-build.log"
+    if ! "$BINARY" build -o "$probe_bin" "$fixture_copy" > "$build_log" 2>&1; then
+        echo "[test]   sfn build failed on $fixture_copy:"
+        cat "$build_log"
+        return 1
+    fi
+    if [ ! -x "$probe_bin" ]; then
+        echo "[test]   expected executable at $probe_bin not produced"
+        return 1
+    fi
+
+    local probe_out
+    if ! probe_out="$("$probe_bin")"; then
+        echo "[test]   probe binary exited non-zero:"
+        "$probe_bin" || true
+        return 1
+    fi
+    if [ -z "$probe_out" ]; then
+        echo "[test]   probe binary produced no output"
+        return 1
+    fi
+
+    # The probe prints the path on one line. Compare canonical
+    # forms — the probe's `readlink("/proc/self/exe")` already
+    # returns an absolute path, so a plain `realpath` match is
+    # sufficient and resilient to symlinked scratch dirs (some
+    # macOS / Linux temp roots are symlinks to /private/tmp or
+    # similar).
+    local probe_resolved
+    probe_resolved="$(realpath "$probe_out" 2>/dev/null || echo "$probe_out")"
+    local expected_resolved
+    expected_resolved="$(realpath "$probe_bin")"
+    if [ "$probe_resolved" != "$expected_resolved" ]; then
+        echo "[test]   probe printed path does not resolve to fixture binary:"
+        echo "[test]     printed   : $probe_out"
+        echo "[test]     resolved  : $probe_resolved"
+        echo "[test]     expected  : $expected_resolved"
+        return 1
+    fi
+    return 0
+}
+
+run_test "sfn check runtime/sfn/platform/exec.sfn passes" test_check_clean
+run_test "sfn fmt --check runtime/sfn/platform/exec.sfn is canonical" test_fmt_clean
+run_test "sfn emit llvm produces unmangled defines + extern calls" test_emit_define_shape
+run_test "libc.sfn declares _NSGetExecutablePath + GetModuleFileNameA + POSIX additions" test_platform_extern_decls
+run_test "exec_path_probe fixture round-trips its own path" test_fixture_round_trip
+
+echo "[summary] $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi

--- a/compiler/tests/unit/runtime_exec_path_test.sfn
+++ b/compiler/tests/unit/runtime_exec_path_test.sfn
@@ -1,0 +1,77 @@
+// compiler/tests/unit/runtime_exec_path_test.sfn
+//
+// Unit coverage for `runtime/sfn/platform/exec.sfn::binary_dir`
+// — the pure dirname helper shipped under issue #468 as part of
+// the M5.3 entry-point migration (epic #451).
+//
+// `binary_dir` is the algorithmic core of `exe_path` /
+// `resolve_runtime_root`: the entry-point lowering computes the
+// running binary's path, then asks `binary_dir` for the
+// directory prefix, then asks `resolve_runtime_root` to walk
+// upward looking for a runtime bundle. Of those three steps
+// only `binary_dir` is pure (no syscalls, no env reads, no fs
+// probes), so it's the only one cheap to test in unit form.
+// The other two land coverage in
+// `compiler/tests/e2e/test_runtime_exec_path.sh`, which builds
+// a fixture binary that calls `exe_path` and verifies the
+// printed path resolves back to the fixture.
+//
+// Why an `extern fn` re-declaration instead of an `import`?
+//   The seed compiler's cross-module signature resolver (issue
+//   #306) does not yet hand back the return-type info needed to
+//   call into `runtime/sfn/platform/exec.sfn` directly from a
+//   compiler/tests/unit/ test file. Every other unit test that
+//   exercises a runtime/sfn module uses the same workaround
+//   (compare the inlined-extern pattern in
+//   `runtime/sfn/process.sfn` and friends — same #306 cause).
+//   Once #306 closes a follow-up flips this to:
+//     `import { binary_dir } from "../../../runtime/sfn/platform/exec";`
+//   without touching the test bodies. The Sailfin function's
+//   `string`-typed signature lowers to `i8* @binary_dir(i8*)`
+//   at the LLVM level (the seed has not yet flipped
+//   `string` -> `{i8*, i64}` for parameters; see the M1.A.2
+//   note in `runtime/sfn/string.sfn`), so the `* u8`-typed
+//   extern below binds to the same symbol bit-for-bit.
+//
+// Why `strcmp` rather than `==`?
+//   The new compiler lowers `string` to a `{i8*, i64}`
+//   aggregate at the call site, but `binary_dir`'s `* u8`
+//   return preserves only the pointer — no length field is
+//   populated when we cast `* u8 as string`. `==` on strings
+//   compares lengths first, so the literal `"foo"` (length 3)
+//   never equals the returned pointer cast (length 0).
+//   `strcmp(a, b) == 0` reads NUL-terminated bytes, which both
+//   sides preserve. When the `string`-aggregate flip lands
+//   (M1.A.2), this helper can move back to `==`. The issue
+//   spec writes the assertions as `==` for readability; the
+//   `strcmp` wrapper preserves the semantics.
+extern fn binary_dir(exe: * u8) -> * u8;
+
+extern fn strcmp(a: * u8, b: * u8) -> i32;
+
+fn equal_cstr(a: * u8, b: * u8) -> bool { return strcmp(a, b) == 0; }
+
+test "binary_dir: empty input passes through" {
+    let r: * u8 = binary_dir("" as * u8);
+    assert equal_cstr(r, "" as * u8);
+}
+
+test "binary_dir: bare filename returns dot" {
+    let r: * u8 = binary_dir("sailfin" as * u8);
+    assert equal_cstr(r, "." as * u8);
+}
+
+test "binary_dir: slashed path returns dirname" {
+    let r: * u8 = binary_dir("/foo/bar/sailfin" as * u8);
+    assert equal_cstr(r, "/foo/bar" as * u8);
+}
+
+test "binary_dir: root-relative single segment returns slash" {
+    let r: * u8 = binary_dir("/sailfin" as * u8);
+    assert equal_cstr(r, "/" as * u8);
+}
+
+test "binary_dir: single-component relative path returns dot" {
+    let r: * u8 = binary_dir("hello.sfn" as * u8);
+    assert equal_cstr(r, "." as * u8);
+}

--- a/runtime/native/capsule.toml
+++ b/runtime/native/capsule.toml
@@ -55,7 +55,7 @@ ll-sources = ["ir/runtime_globals.ll"]
 # and the formerly-load-bearing allowlist is gone.
 #
 # Single-line array per the parser limitation noted above.
-sfn-sources = ["../sfn/memory/arena.sfn", "../sfn/memory/rc.sfn", "../sfn/string.sfn", "../sfn/array.sfn", "../sfn/clock.sfn", "../sfn/process.sfn", "../sfn/io.sfn", "../sfn/exception.sfn"]
+sfn-sources = ["../sfn/memory/arena.sfn", "../sfn/memory/rc.sfn", "../sfn/string.sfn", "../sfn/array.sfn", "../sfn/clock.sfn", "../sfn/process.sfn", "../sfn/io.sfn", "../sfn/exception.sfn", "../sfn/platform/exec.sfn"]
 include-dirs = ["include"]
 link-libs = ["-lm"]
 

--- a/runtime/sfn/platform/exec.sfn
+++ b/runtime/sfn/platform/exec.sfn
@@ -1,0 +1,326 @@
+// runtime/sfn/platform/exec.sfn
+//
+// Sailfin-native executable-path + runtime-root resolution
+// (M5.3 prerequisite per epic #451; issue #468). Provides the
+// pure-Sailfin equivalents of `_resolve_runtime_root(argv0)` and
+// the per-OS executable-path resolution block currently in
+// `runtime/native/src/native_driver.c:396-557`. When the
+// `@main` lowering (M5.3) replaces `native_driver.c`'s entry
+// point, this module is what the lowered `main` calls before
+// delegating to `sailfin_cli_main_with_paths`.
+//
+// Module surface
+//   - `exe_path() -> string ![io]` — absolute path of the
+//     currently-running binary. Uses `readlink("/proc/self/exe")`
+//     on Linux. Returns `""` when the lookup fails (callers
+//     layer their own fallback, typically `realpath(argv[0])`).
+//   - `binary_dir(exe: string) -> string` — pure dirname: the
+//     prefix of `exe` up to (but excluding) the final `/`.
+//     Returns `""` for empty input, `"."` for a bare filename,
+//     `"/"` for a root-relative single-component path. Matches
+//     `_dirname_dup` in native_driver.c byte-for-byte.
+//   - `resolve_runtime_root(exe_path: string) -> string ![io]`
+//     — honors `$SAILFIN_RUNTIME_ROOT` first, then walks
+//     `<dir>/runtime`, `<dir>/../runtime`,
+//     `<dir>/../../runtime` in that exact order. Returns the
+//     first existing canonicalized path or `""`. Order
+//     preserves dev-tree (`build/native/`), installed-tree
+//     (`~/.local/bin/sailfin` next to `~/.local/runtime/`), and
+//     packaged-bundle layouts — `_resolve_runtime_root` in
+//     native_driver.c documents the same walk.
+//
+// Platform coverage
+//   Linux is the only platform validated end-to-end in this PR.
+//   The macOS path requires `_NSGetExecutablePath` (declared in
+//   `runtime/sfn/platform/libc.sfn` as criterion 4 of #468 but
+//   not called from this body) and the Windows path requires
+//   `GetModuleFileNameA` (same disposition). Sailfin lacks
+//   `cfg(target_os)` (issue #468 `Out:` scope) and a static link
+//   against an unresolved macOS / Windows symbol from a Linux
+//   build fails immediately, so adding the call here would break
+//   the Linux CI link. A follow-up issue wires macOS support
+//   once one of three things lands: (1) a per-OS C stub library
+//   that resolves the missing symbols to noop returns on the
+//   other platform, (2) Sailfin weak-symbol attributes, or
+//   (3) `cfg(target_os)`. macOS users in the interim set
+//   `SAILFIN_RUNTIME_ROOT` explicitly — `resolve_runtime_root`
+//   honors the override before walking, so the runtime resolves
+//   without `exe_path`.
+//
+// Naming
+//   No `_sfn_` infix on the canonical `exe_path` / `binary_dir`
+//   / `resolve_runtime_root` exports because the C runtime
+//   currently exposes them as static helpers inside
+//   `native_driver.c` (no external symbol). There is therefore
+//   no link-time namespace collision to dodge — unlike the
+//   `sfn_arena_sfn_*` / `sfn_str_sfn_*` workarounds in
+//   `runtime/sfn/memory/arena.sfn` and `runtime/sfn/string.sfn`,
+//   which had to coexist with already-shipping C symbols of the
+//   same name.
+//
+// Effects
+//   `exe_path` and `resolve_runtime_root` carry `![io]` (they
+//   read process state and filesystem). `binary_dir` is pure —
+//   no syscalls, no allocations beyond `malloc` for the result
+//   buffer (`malloc` itself is not effect-gated per the §3.6
+//   effect-on-wrapper rule, mirroring `runtime/sfn/string.sfn`
+//   which malloc's freely).
+//
+// Why inline the externs rather than import from `./libc`?
+//   Same rationale as `runtime/sfn/memory/arena.sfn` /
+//   `runtime/sfn/memory/rc.sfn` / `runtime/sfn/string.sfn` /
+//   `runtime/sfn/process.sfn` / `runtime/sfn/exception.sfn`:
+//   the seed compiler reaches the cross-module extern resolver
+//   through a path that issue #306 has not closed yet,
+//   surfacing as `cannot resolve return type for call to …`
+//   fatals during emission. Inlining the declarations keeps
+//   this module self-contained for every seed. Once #306
+//   closes, a follow-up PR flips these to imports without
+//   touching the bodies. The same declarations also live in
+//   `runtime/sfn/platform/libc.sfn` for discoverability and
+//   for the eventual cross-module-import flip.
+//
+// Seed-compiler cast quirk
+//   The pinned seed (0.7.0-alpha.2) mis-lowers
+//   `<string_literal> as * u8` / `<string_literal> as string`:
+//   the IR materializes the `{i8*, i64}` aggregate but then
+//   emits `ret i8* null` / `store i8* null` for the cast
+//   result, silently zeroing the pointer. Pass literals
+//   directly to extern args instead (e.g. `readlink("/proc/
+//   self/exe", buf, n)`), or assign to a `string`-typed local
+//   first and then cast the local (`let s: string = "..."; let
+//   p: * u8 = s as * u8;` works because the load extracts the
+//   data pointer through the alloca slot). Return-position
+//   string literals work without the cast (the function's
+//   declared `string` return type triggers the correct
+//   extractvalue). Every place this file departs from the
+//   "obvious" cast pattern is following this rule — the
+//   workaround unblocks the M5.3 prereq without needing a
+//   seed bump.
+//
+// Pinned by
+//   - `compiler/tests/unit/runtime_exec_path_test.sfn`
+//     (binary_dir semantics — empty, bare, slashed, root cases)
+//   - `compiler/tests/e2e/test_runtime_exec_path.sh` (full
+//     `exe_path` round-trip via a fixture binary that prints
+//     its own path and asserts the printed path resolves)
+extern fn malloc(size: usize) -> * u8;
+
+extern fn free(ptr: * u8) -> void;
+
+extern fn memcpy(dst: * u8, src: * u8, n: usize) -> * u8;
+
+extern fn memset(dst: * u8, byte: i32, n: usize) -> * u8;
+
+extern fn strrchr(s: * u8, c: i32) -> * u8;
+
+extern fn getenv(name: * u8) -> * u8;
+
+extern fn readlink(path: * u8, buf: * u8, bufsize: usize) -> i64;
+
+extern fn realpath(path: * u8, resolved: * u8) -> * u8;
+
+// `sailfin_intrinsic_fs_exists` is the existing C runtime helper
+// that backs the prelude's `fs.exists` surface (stat-based; true
+// for files and directories alike). M3.1 replaces this with a
+// pure-Sailfin `sfn_fs_exists` via `runtime/sfn/adapters/
+// filesystem.sfn`; until then this is the canonical "does this
+// path exist on disk" probe and is what the issue's `Context`
+// section explicitly recommends.
+extern fn sailfin_intrinsic_fs_exists(path: * u8) -> bool;
+
+// `sailfin_runtime_string_concat` is the C runtime's
+// NUL-terminated concat. Used to build the
+// `<exe_dir>/runtime` / `<exe_dir>/../runtime` / ...
+// candidate strings without rolling a manual concat loop here.
+// M2.4b's pure-Sailfin concat is keyed on the M1.A.2
+// aggregate-by-value parameter flip; until that lands, this C
+// trampoline is the only way to produce a fresh NUL-terminated
+// buffer from two `* u8` inputs.
+extern fn sailfin_runtime_string_concat(a: * u8, b: * u8) -> * u8;
+
+// `memcmp` is needed for the empty-string check in
+// `resolve_runtime_root`'s `$SAILFIN_RUNTIME_ROOT` override
+// branch — the C original treats an empty env value as "not
+// set" (`override && override[0] != '\0'`). Sailfin lacks a
+// `*ptr` deref syntax for reading a single byte, so the
+// canonical equivalent is `memcmp(override, "", 1) != 0`,
+// which compares one byte against a NUL-only literal. The
+// libc prototype lives in `runtime/sfn/platform/libc.sfn`;
+// inlining is the same #306 workaround as the rest of this
+// file's externs.
+extern fn memcmp(a: * u8, b: * u8, n: usize) -> i32;
+
+// `binary_dir(exe)` returns the directory component of `exe` —
+// the prefix up to (but excluding) the trailing `/`. Pure
+// (no syscalls). Mirrors `_dirname_dup` in native_driver.c:
+//   - `""`             -> `""`     (empty input passes through)
+//   - `"sailfin"`      -> `"."`    (no slash)
+//   - `"/x"`           -> `"/"`    (slash is the first byte)
+//   - `"/foo/bar/x"`   -> `"/foo/bar"`
+//
+// Allocation: a fresh `malloc`'d NUL-terminated buffer for the
+// slashed and rooted cases. The non-slashed and empty cases
+// return literal pointers (`"."` and `""`) — those live in the
+// `.rodata` section and need no free. Callers that care about
+// the allocation distinction should `strdup`-on-write rather
+// than freeing unconditionally.
+//
+// `47` is the ASCII code for `/`. The seed compiler does not
+// yet accept char literals (`'/'`), so the byte value is inlined
+// directly — same convention as the `127` / `65280` masks in
+// `runtime/sfn/process.sfn`'s wait-status decoder.
+fn binary_dir(exe: string) -> string {
+    // Going through a `string`-typed local first sidesteps the
+    // seed's `<literal> as * u8` cast bug — `exe as * u8` works
+    // here because `exe` is an alloca-backed parameter, not a
+    // raw literal expression. See the cast-quirk note in the
+    // module header.
+    let p: * u8 = exe as * u8;
+    if p as i64 == 0 { return ""; }
+    let slash: * u8 = strrchr(p, 47);
+    if slash as i64 == 0 { return "."; }
+    if slash as i64 == p as i64 { return "/"; }
+    let len: i64 = (slash as i64) - (p as i64);
+    let buf: * u8 = malloc((len + 1) as usize);
+    if buf as i64 == 0 { return ""; }
+    memcpy(buf, p, len as usize);
+    let term: * u8 = buf + len;
+    memset(term, 0, 1 as usize);
+    // `buf as string` lowers correctly — the seed's cast bug is
+    // specific to the *literal* path; pointer-to-string casts on
+    // alloca-backed `* u8` slots extract via load and pass
+    // through unmodified.
+    return buf as string;
+}
+
+// `exe_path()` returns the absolute path of the currently
+// running binary, or `""` if the lookup fails. Today's body
+// uses Linux's `/proc/self/exe` symlink — the most reliable
+// source on Linux because it works even when `argv[0]` is a
+// bare `$PATH` name (the user typed `sailfin` rather than
+// `./sailfin` or `/usr/local/bin/sailfin`).
+//
+// macOS / Windows: see the module header. Both platforms have
+// their externs declared in `runtime/sfn/platform/libc.sfn` for
+// the follow-up wire-up; this body returns `""` on those
+// platforms today and callers fall back to
+// `SAILFIN_RUNTIME_ROOT` (honored by `resolve_runtime_root`).
+//
+// Buffer sizing: 4096 covers Linux's `PATH_MAX`. macOS uses
+// `PATH_MAX = 1024` but the larger Linux constant subsumes it
+// and the few extra kilobytes are negligible at the single
+// call site (program startup). The buffer is zero-initialized
+// so the returned `* u8 as string` views a properly
+// NUL-terminated byte sequence regardless of how many bytes
+// `readlink` actually wrote.
+fn exe_path() -> string ![io] {
+    let buf_size: usize = 4096 as usize;
+    let buf: * u8 = malloc(buf_size);
+    if buf as i64 == 0 { return ""; }
+    memset(buf, 0, buf_size);
+    // The seed mis-lowers `let proc_self_exe: * u8 = "/proc/self/
+    // exe" as * u8;` to `store i8* null` (the literal aggregate
+    // is built but the cast then zeros the pointer). Passing
+    // the literal directly to `readlink` triggers the correct
+    // `extractvalue` lowering at the call site — see the cast-
+    // quirk note in the module header.
+    let s_proc: string = "/proc/self/exe";
+    let n: i64 = readlink(s_proc as * u8, buf, buf_size);
+    if n > 0 { return buf as string; }
+    free(buf);
+    return "";
+}
+
+// `resolve_runtime_root(exe_path)` finds the runtime bundle for
+// the running binary. Honors `$SAILFIN_RUNTIME_ROOT` first
+// (operator override for unusual install layouts and CI
+// scratch dirs); otherwise walks three candidates relative to
+// `binary_dir(exe_path)` in this exact order:
+//
+//   1. `<exe_dir>/runtime`         — dev-tree (the binary at
+//                                     `build/native/sailfin`
+//                                     sits next to
+//                                     `build/native/runtime/`).
+//   2. `<exe_dir>/../runtime`      — installed tree (binary at
+//                                     `~/.local/bin/sailfin`
+//                                     sits next to
+//                                     `~/.local/runtime/`).
+//   3. `<exe_dir>/../../runtime`   — packaged-bundle layout
+//                                     (binary nested two
+//                                     levels deep under a
+//                                     distribution prefix).
+//
+// Each candidate is `fs.exists`-probed; the first hit is
+// canonicalized via `realpath` and returned. Returns `""`
+// when none of the three exist — callers that need a
+// hard-fail diagnostic (e.g. `sfn build` linking against a
+// missing prelude) layer that themselves; the contract here
+// is purely "first existing path or empty".
+//
+// `realpath(candidate, null)` instructs libc to allocate the
+// resolved buffer with `malloc` and return ownership to us;
+// the caller (`runtime/sfn/cli/entry.sfn` once M5.3 lands)
+// holds the pointer for the lifetime of the process and never
+// frees it (the buffer is leaked, matching the C runtime's
+// `_canonicalize_existing_path` behavior). If `realpath`
+// fails, the un-canonicalized concat is returned — the caller
+// gets a valid string either way.
+fn resolve_runtime_root(exe_path: string) -> string ![io] {
+    // Per the cast-quirk note in the module header, route every
+    // string literal through a `string`-typed local first so the
+    // `as * u8` cast picks up the alloca-backed slot rather than
+    // the broken literal-cast path.
+    let s_env: string = "SAILFIN_RUNTIME_ROOT";
+    let override_val: * u8 = getenv(s_env as * u8);
+    if override_val as i64 != 0 {
+        // Mirror the C original (`override && override[0] != '\0'`):
+        // empty env value is treated as "not set" and falls through
+        // to the dir-walk. `memcmp(override, "", 1)` compares the
+        // first byte against NUL — non-zero means a real string.
+        let s_empty: string = "";
+        if memcmp(override_val, s_empty as * u8, 1 as usize) != 0 {
+            return override_val as string;
+        }
+    }
+    let exe_dir_str: string = binary_dir(exe_path);
+    let exe_dir: * u8 = exe_dir_str as * u8;
+    let mut idx: i32 = 0;
+    loop {
+        if idx >= 3 { break; }
+        let suffix: * u8 = _candidate_suffix(idx);
+        let candidate: * u8 = sailfin_runtime_string_concat(exe_dir, suffix);
+        if sailfin_intrinsic_fs_exists(candidate) {
+            let canon: * u8 = realpath(candidate, null);
+            if canon as i64 != 0 { return canon as string; }
+            return candidate as string;
+        }
+        idx = idx + 1;
+    }
+    return "";
+}
+
+// Path-suffix lookup table for `resolve_runtime_root`'s walk.
+// Indexes 0..2 produce the dev-tree, installed-tree, and
+// packaged-bundle suffixes in the documented order. Pulled
+// out as a separate function so the dir-walk loop can index
+// without materializing a top-level `string[]` literal — the
+// seed compiler does not yet handle literal arrays of slash-
+// prefixed strings at module scope (verified during M2.7a
+// bring-up), and a switch-on-index dispatch is the cheapest
+// workaround until that bug closes.
+fn _candidate_suffix(idx: i32) -> * u8 {
+    // Route through `string`-typed locals to dodge the seed's
+    // `<literal> as * u8` cast bug — see the cast-quirk note in
+    // the module header. The slot-load makes the cast safe.
+    if idx == 0 {
+        let s0: string = "/runtime";
+        return s0 as * u8;
+    }
+    if idx == 1 {
+        let s1: string = "/../runtime";
+        return s1 as * u8;
+    }
+    let s2: string = "/../../runtime";
+    return s2 as * u8;
+}

--- a/runtime/sfn/platform/libc.sfn
+++ b/runtime/sfn/platform/libc.sfn
@@ -59,6 +59,24 @@ extern fn memcmp(a: * u8, b: * u8, n: usize) -> i32;
 // — the `c` arg is `int` so callers pass `0..255` as `i32`.
 extern fn memchr(s: * u8, c: i32, n: usize) -> * u8;
 
+// `memset(dst, byte, n)` writes the low 8 bits of `byte` into the
+// first `n` bytes of `dst`, returning `dst`. Used by adapters that
+// zero-initialize buffers (`runtime/sfn/exception.sfn` zeros its
+// JMPBUF) or write a single NUL terminator into a freshly
+// allocated string buffer (`runtime/sfn/platform/exec.sfn`'s
+// dirname computation). The libc prototype is `void *memset(void
+// *s, int c, size_t n)` — the `c` arg is `int` so callers pass
+// `0..255` as `i32`.
+extern fn memset(dst: * u8, byte: i32, n: usize) -> * u8;
+
+// `strrchr(s, c)` scans the NUL-terminated string `s` for the
+// last occurrence of the byte `c` (passed as i32 per the libc
+// prototype `char *strrchr(const char *s, int c)`), returning a
+// pointer into `s` at the match or `* u8` null when not found.
+// `runtime/sfn/platform/exec.sfn::binary_dir` uses this to locate
+// the trailing path separator without writing a manual scan loop.
+extern fn strrchr(s: * u8, c: i32) -> * u8;
+
 // ── Raw I/O (file-descriptor based) ───────────────────────────
 // `write`/`read` are POSIX, returning ssize_t (i64 on every
 // platform Sailfin currently targets). Negative returns signal
@@ -82,6 +100,30 @@ extern fn fclose(f: * File) -> i32;
 extern fn fread(buf: * u8, size: usize, nmemb: usize, f: * File) -> usize;
 
 extern fn fwrite(buf: * u8, size: usize, nmemb: usize, f: * File) -> usize;
+
+// `readlink(path, buf, bufsize)` reads the contents of the
+// symbolic link `path` into `buf` (up to `bufsize` bytes,
+// without NUL-terminating). Returns the byte count on success
+// or -1 on error. POSIX prototype `ssize_t readlink(const char
+// *path, char *buf, size_t bufsize)`; ssize_t lowers to i64 on
+// every Sailfin target (mirrors the `write`/`read` convention
+// above). `runtime/sfn/platform/exec.sfn` uses this against
+// `"/proc/self/exe"` to recover the running binary's absolute
+// path on Linux without consulting `argv[0]` (which is
+// `$PATH`-relative when the user typed a bare command name).
+extern fn readlink(path: * u8, buf: * u8, bufsize: usize) -> i64;
+
+// `realpath(path, resolved)` returns the canonical absolute form
+// of `path`. When `resolved` is non-null, the result is written
+// there and the same pointer is returned (truncated to
+// `PATH_MAX` per POSIX). When `resolved` is null, libc allocates
+// the result with `malloc` and the caller must `free` it.
+// Returns null and sets `errno` on failure. POSIX prototype:
+// `char *realpath(const char *path, char *resolved_path)`.
+// `runtime/sfn/platform/exec.sfn` uses this to canonicalize the
+// runtime-root candidates the dir-walk produces so dev-tree and
+// installed-bin layouts both surface the same path string.
+extern fn realpath(path: * u8, resolved: * u8) -> * u8;
 
 // ── Environment ───────────────────────────────────────────────
 // Returns a NUL-terminated C string owned by the libc environ
@@ -126,3 +168,43 @@ extern fn getenv(name: * u8) -> * u8;
 extern fn setjmp(env: * JmpBuf) -> i32;
 
 extern fn longjmp(env: * JmpBuf, val: i32) -> void;
+
+// ── Platform-specific executable-path APIs ────────────────────
+// The next two declarations live in libc.sfn for discoverability
+// alongside `readlink` / `realpath` (the cross-platform exe-path
+// trio). They are **declarations only** in this PR — the body of
+// `runtime/sfn/platform/exec.sfn::exe_path` calls only the
+// POSIX-portable `readlink("/proc/self/exe")` path today, because
+// Sailfin has no `cfg(target_os)` story (issue #468 `Out:` scope)
+// and a static link against an unresolved macOS / Windows symbol
+// from a Linux build would fail at link time.
+//
+// Why declare them anyway: criterion 4 of #468 pins the
+// "declarations parse cleanly on Linux even though they're never
+// called there" contract, and shipping them now lets a follow-up
+// macOS-validation issue start from "wire the call site" rather
+// than "extend libc.sfn". Unused `declare` lines do not trigger a
+// link error in clang/ld; only an actual `call` to an unresolved
+// symbol would. The follow-up issue that wires macOS support
+// will either land a per-OS stub library (the architect's likely
+// answer once the C runtime retires under M3) or extend Sailfin
+// with weak-symbol attributes / `cfg(target_os)`.
+//
+// Type-discipline notes for the accept-list (see file header):
+//   - `_NSGetExecutablePath`'s second arg is `uint32_t *bufsize`
+//     in `<mach-o/dyld.h>`. `u32` / `* u32` are not in the
+//     accept-list yet; `* i32` lowers to the same `i32*` LLVM
+//     pointer and matches the C call shape bit-for-bit (the
+//     pointee width is 32 bits regardless of sign). Sign only
+//     matters for arithmetic, not pointer-to-pointer.
+//   - `GetModuleFileNameA`'s `size` arg and return value are
+//     Windows `DWORD` (`u32`); same `i32` substitution applies.
+//   - Windows `HMODULE handle` is an opaque pointer; `* u8` is
+//     the canonical Sailfin spelling for an opaque byte-pointer
+//     handle (the opaque-pointee rule on uppercase identifiers
+//     would also work via `* HMODULE`, but using `* u8` keeps the
+//     declaration self-contained — exec.sfn callers pass `null`
+//     to mean "the current process" per the Win32 docs).
+extern fn _NSGetExecutablePath(buf: * u8, bufsize: * i32) -> i32;
+
+extern fn GetModuleFileNameA(handle: * u8, buf: * u8, size: i32) -> i32;


### PR DESCRIPTION
## Summary

- Ships `runtime/sfn/platform/exec.sfn` with the pure-Sailfin `exe_path()` / `binary_dir()` / `resolve_runtime_root()` helpers — the M5.3 prerequisite per epic #451. They mirror native_driver.c's `_resolve_runtime_root(argv0)` and per-OS exe-path block byte-for-byte (Linux path validated end-to-end; macOS/Windows extern declarations parked in libc.sfn for the follow-up wire-up).
- Extends `runtime/sfn/platform/libc.sfn` with `readlink` / `realpath` / `strrchr` / `memset` plus the macOS-only `_NSGetExecutablePath` and Windows-only `GetModuleFileNameA` declarations (criterion 4 — parse cleanly on Linux even though they're never called there today).
- Wires the new module through the build: `runtime/native/capsule.toml`'s `sfn-sources` array picks up `exec.sfn`; Makefile + `compiler/src/cli_main.sfn` (`_runtime_exec_path`, `_clang_compile_runtime_objects` tuple extension) mirror the clock/process/exception staging precedent so `sfn build` of user fixtures can resolve `@exe_path` via the legacy runtime-objects link path.

Closes #468

## Acceptance Criteria

- [x] `runtime/sfn/platform/exec.sfn` exists, formats clean (`sfn fmt --check`), typechecks.
- [x] The unit test passes: `sfn test compiler/tests/unit/runtime_exec_path_test.sfn`.
- [x] The e2e test passes: `compiler/tests/e2e/test_runtime_exec_path.sh`. The harness binary at `compiler/tests/e2e/fixtures/exec_path_probe.sfn` is built by the test, prints its own absolute path, and the test asserts the printed path resolves to the harness binary.
- [x] `_NSGetExecutablePath` and `GetModuleFileNameA` extern declarations parse cleanly on Linux even though they're never called there. The declarations live in libc.sfn; exec.sfn's body uses only Linux-safe calls today, so no link error surfaces. (See "Surprises" below for the cfg(target_os) gap.)
- [x] `make compile && make test-unit && make test-e2e` all pass.
- [x] `runtime/sfn/platform/exec.sfn` is listed in `runtime/native/capsule.toml`'s `sfn-sources` so the symbols link into `build/native/sailfin`.

## Verification

```bash
ulimit -v 8388608 && make compile
ulimit -v 8388608 && timeout 30 build/native/sailfin fmt --check runtime/sfn/platform/exec.sfn
ulimit -v 8388608 && make test-unit             # 101/101 passed
ulimit -v 8388608 && make test-e2e              # 70/70 passed (incl. new test_runtime_exec_path.sh)
ulimit -v 8388608 && make test-integration      # 26/26 passed
```

## Files Changed

- **New** `runtime/sfn/platform/exec.sfn` — `exe_path` / `binary_dir` / `resolve_runtime_root` (~290 lines including header doc).
- **Extend** `runtime/sfn/platform/libc.sfn` — adds `readlink`, `realpath`, `strrchr`, `memset`, `_NSGetExecutablePath`, `GetModuleFileNameA` extern declarations.
- **Update** `runtime/native/capsule.toml` — appends `../sfn/platform/exec.sfn` to `sfn-sources`.
- **New** `compiler/tests/unit/runtime_exec_path_test.sfn` — five `binary_dir` semantics tests (empty / bare / slashed / root / relative).
- **New** `compiler/tests/e2e/test_runtime_exec_path.sh` — five checks (typecheck, fmt, IR shape, platform-extern declarations, end-to-end fixture round-trip).
- **New** `compiler/tests/e2e/fixtures/exec_path_probe.sfn` — small main that prints `exe_path()`.
- **Update** `Makefile` — stages `build/native/obj/runtime/exec.{ll,o}` (mirrors clock/process/exception precedent).
- **Update** `compiler/src/cli_main.sfn` — adds `_runtime_exec_path()` and extends `_clang_compile_runtime_objects`'s tuple so user `sfn build` can resolve `@exe_path` via the legacy runtime-objects link path.

## Surprises / Follow-ups for grooming

These weren't blockers — flagging so a future pass can decide what's worth filing.

1. **Seed cast bug (0.7.0-alpha.2).** `<string_literal> as * u8` and `<string_literal> as string` mis-lower to `store i8* null` / `ret i8* null` — the IR builds the `{i8*, i64}` aggregate but the cast result silently zeros the pointer. Workaround documented in the exec.sfn header: route literals through `string`-typed locals first (or pass them directly to extern args). Every body in exec.sfn follows the workaround. Worth filing as a seed bug for a future fix-and-pin pass.

2. **Cross-module signature resolver (#306).** The unit test re-declares `binary_dir` as an `extern fn` because the seed's signature resolver doesn't hand back return-type info for runtime/sfn imports — same #306 workaround every other runtime/sfn module uses. Re-flagging here in case prioritization shifts.

3. **macOS / Windows `exe_path`.** Criterion 4 asks for the declarations to "parse cleanly on Linux even though they're never called there." Calling them on Linux *would* fail at static-link time (no libSystem / Win32 on the Linux link line). Out of scope per the issue's `Out:` list, but the macOS gap means macOS users today fall back to `SAILFIN_RUNTIME_ROOT` until one of (a) a per-OS C stub library, (b) Sailfin weak-symbol attributes, or (c) `cfg(target_os)` lands. Worth a follow-up issue once an M3 adapter PR has stub-library precedent to copy.

4. **Files Affected drift.** The issue's `Files Affected` list didn't mention `compiler/src/cli_main.sfn` or `Makefile`, but the e2e acceptance criterion (5: full round-trip via `sfn build` of a fixture) requires the legacy runtime-link path to know about `exec.o` — same pattern clock/process/exception followed. Adding `_runtime_exec_path()` and a Makefile staging block is the minimal mechanical change needed to honor criterion 5.

5. **Fixture build path requires copy-out.** When `sfn build` runs on a source inside the workspace, it auto-discovers `runtime/native/capsule.toml` as a runtime dep and routes through `_clang_compile_runtime_capsule_objects` — which compiles every `c-sources` entry including `native_driver.c`, whose `main` then collides with the fixture's `main`. The e2e test copies the fixture into a scratch dir first to fall back to `_clang_compile_runtime_objects` (which doesn't include native_driver.c). This auto-discovery quirk goes away once native_driver.c retires under M5; documented in the test itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KyTQdthWmNtainEZYND3iK)_