### PR TITLE
refactor(lowering): split skip_effects flag (helper-collection flip deferred to #740)

### DIFF
--- a/compiler/src/llvm/effects.sfn
+++ b/compiler/src/llvm/effects.sfn
@@ -547,21 +547,17 @@ fn collect_instruction_runtime_helper_targets(instruction: NativeInstruction) ->
         return helpers;
     }
     if instruction.variant == "Try" {
-        // M2.7c retirement (#737): legacy TLS-polling family
-        // (`clear_exception`, `has_exception`, `take_exception`) removed —
-        // they have no live emission sites in `compiler/src/` or
-        // `runtime/` (only the descriptor table in `runtime_helpers.sfn`
-        // still references them), so the M2.7b coexistence is a no-op in
-        // practice. Frame primitives are the only family the walker
-        // needs to declare for try-blocks.
-        return ["sfn_exception_push_frame", "sfn_exception_pop_frame", "sfn_take_exception_frame", "setjmp"];
+        // M2.7b (#404): emit declares for the new frame primitives alongside
+        // the legacy TLS-polling family so both APIs coexist during the
+        // transition. M2.7c retires the legacy entries once every emission
+        // site has cut over.
+        return ["clear_exception", "has_exception", "take_exception", "sfn_exception_push_frame", "sfn_exception_pop_frame", "sfn_take_exception_frame", "setjmp"];
     }
     if instruction.variant == "Throw" {
-        // M2.7c retirement (#737): legacy `set_exception` symbol removed
-        // alongside its Try-side counterparts above.
-        // `lower_throw_instruction` emits `call void @sfn_throw_frame`
-        // (longjmp); no live call sites reference the legacy name.
-        return ["sfn_throw_frame"];
+        // M2.7b (#404): `lower_throw_instruction` emits `call void
+        // @sfn_throw` (longjmp); declare the legacy `set_exception` symbol
+        // too so seed-compiled call sites that still call it link cleanly.
+        return ["set_exception", "sfn_throw_frame"];
     }
     return [];
 }

--- a/compiler/src/llvm/effects.sfn
+++ b/compiler/src/llvm/effects.sfn
@@ -547,17 +547,21 @@ fn collect_instruction_runtime_helper_targets(instruction: NativeInstruction) ->
         return helpers;
     }
     if instruction.variant == "Try" {
-        // M2.7b (#404): emit declares for the new frame primitives alongside
-        // the legacy TLS-polling family so both APIs coexist during the
-        // transition. M2.7c retires the legacy entries once every emission
-        // site has cut over.
-        return ["clear_exception", "has_exception", "take_exception", "sfn_exception_push_frame", "sfn_exception_pop_frame", "sfn_take_exception_frame", "setjmp"];
+        // M2.7c retirement (#737): legacy TLS-polling family
+        // (`clear_exception`, `has_exception`, `take_exception`) removed —
+        // they have no live emission sites in `compiler/src/` or
+        // `runtime/` (only the descriptor table in `runtime_helpers.sfn`
+        // still references them), so the M2.7b coexistence is a no-op in
+        // practice. Frame primitives are the only family the walker
+        // needs to declare for try-blocks.
+        return ["sfn_exception_push_frame", "sfn_exception_pop_frame", "sfn_take_exception_frame", "setjmp"];
     }
     if instruction.variant == "Throw" {
-        // M2.7b (#404): `lower_throw_instruction` emits `call void
-        // @sfn_throw` (longjmp); declare the legacy `set_exception` symbol
-        // too so seed-compiled call sites that still call it link cleanly.
-        return ["set_exception", "sfn_throw_frame"];
+        // M2.7c retirement (#737): legacy `set_exception` symbol removed
+        // alongside its Try-side counterparts above.
+        // `lower_throw_instruction` emits `call void @sfn_throw_frame`
+        // (longjmp); no live call sites reference the legacy name.
+        return ["sfn_throw_frame"];
     }
     return [];
 }

--- a/compiler/src/llvm/lowering/lowering_core.sfn
+++ b/compiler/src/llvm/lowering/lowering_core.sfn
@@ -513,23 +513,29 @@ fn lower_to_llvm_lines_with_parsed_context(native_module: NativeModule, parse_in
     if debug_lowering { print.err("emit-llvm: phase=context_functions"); }
 
     // ── Effect analysis ─────────────────────────────────────────────
-    let skip_effects = true;
+    // Helper collection runs by default. Flag exists as an emergency
+    // back-off if a future module destabilizes the dynamic walker.
+    let skip_helper_collection = false;
+    // Bootstrap guard (commit 65b065ad, "make check completes binary not
+    // valid"): effect analysis currently introduces instability in
+    // selfhost/native lowering for some modules. Keep disabled by default.
+    let skip_effect_propagation = true;
     let mut runtime_helpers: string[] = [];
     let mut _if255: boolean = false;
     if !is_test_module {
-        if !skip_effects { _if255 = true; }
+        if !skip_helper_collection { _if255 = true; }
     }
     if _if255 {
         if debug_lowering { print.err("emit-llvm: phase=helpers_start"); }
         runtime_helpers = collect_runtime_helper_targets(local_functions);
         if debug_lowering { print.err("emit-llvm: phase=helpers_done"); }
     } else if trace {
-        print.err("test llvm: skipping runtime helper collection for inlined tests");
+        print.err("test llvm: skipping runtime helper collection for test module");
     }
     runtime_helpers = seed_default_runtime_helpers(runtime_helpers);
     let mut direct_effects: FunctionEffectEntry[] = [];
     let mut aggregated_effects: FunctionEffectEntry[] = [];
-    if !skip_effects {
+    if !skip_effect_propagation {
         if debug_lowering { print.err("emit-llvm: phase=direct_effects"); }
         direct_effects = collect_direct_function_effects(context_functions);
         aggregated_effects = direct_effects;

--- a/compiler/src/llvm/lowering/lowering_core.sfn
+++ b/compiler/src/llvm/lowering/lowering_core.sfn
@@ -513,9 +513,16 @@ fn lower_to_llvm_lines_with_parsed_context(native_module: NativeModule, parse_in
     if debug_lowering { print.err("emit-llvm: phase=context_functions"); }
 
     // ── Effect analysis ─────────────────────────────────────────────
-    // Helper collection runs by default. Flag exists as an emergency
-    // back-off if a future module destabilizes the dynamic walker.
-    let skip_helper_collection = false;
+    // Helper collection is currently gated off. Flipping this flag to
+    // `false` re-enables `collect_runtime_helper_targets` so the dynamic
+    // walker discovers per-module runtime-helper declares (unblocking
+    // #501 / #414). Blocked on a determinism bug surfaced when the
+    // walker runs on `compiler/src/parser/expressions.sfn`: the 20x
+    // emit-sweep e2e test under `make check` reliably observes a
+    // character/mangling-suffix drop in an extracted function name
+    // (see #737 for the diagnosis). Track the bug fix separately;
+    // this flag exists so the flip is a one-line change once resolved.
+    let skip_helper_collection = true;
     // Bootstrap guard (commit 65b065ad, "make check completes binary not
     // valid"): effect analysis currently introduces instability in
     // selfhost/native lowering for some modules. Keep disabled by default.


### PR DESCRIPTION
Refs #737 #740

## Status

Structural progress shipped. Helper-collection flip deferred to #740 (the determinism bug investigation).

## Summary

Three commits trace the diagnostic arc:

1. **`split skip_effects into helper-collection + effect-propagation flags`** (`lowering_core.sfn`, +10/-4) — the structural split exactly as scoped in #737. Replaces the single `skip_effects = true` flag with two independent flags: `skip_helper_collection` and `skip_effect_propagation`. Bootstrap-guard comment preserved verbatim on the effect-propagation side (citing commit `65b065ad`).

2. **`retire legacy *_exception walker carve-out (M2.7c)`** (`effects.sfn`, +13/-9) — and its revert. The M2.7c retirement was an attempt to neutralize the IR-diff drift on `try-catch-finally.sfn` that surfaced when the walker activated. It succeeded on that gate, but the walker-enabled state also surfaced a deeper determinism flake (#740) that blocked `make check`. With the walker deferred (commit 3 below), M2.7c is no longer needed; revert keeps the PR minimal.

3. **`defer helper-collection flip pending #740`** (`lowering_core.sfn`, +10/-3) — pins `skip_helper_collection = true`. Documents the determinism flake on `parser/expressions.sfn` (character drop + mangling-suffix loss in extracted call targets) and points to #740 for the fix.

Net effect: the structural split is in place so the eventual flip is a one-line change. No behavior change vs `main` until #740 lands.

## Acceptance Criteria (current state)

- [x] `grep "skip_effects = true" compiler/src/llvm/lowering/lowering_core.sfn` is empty (the variable was split into two).
- [x] **IR-diff invariant: byte-identical `emit-llvm` output** across all 17 fixtures (every `examples/basics/*.sfn` plus `compiler/tests/integration/async_await_test.sfn` and `compiler/tests/integration/closure_env_emission_test.sfn`). With the walker deferred, this is trivially satisfied — no behavior change vs `main`.
- [x] `sfn fmt --check` clean on both touched files.
- [x] `make compile` succeeds from seed `v0.7.0-alpha.3`.
- [x] `make test-unit` — 101/101 passed.
- [x] `make check` — full pipeline clean (linux-x86_64 locally verified; macOS CI parity expected after this push).

## Deviation from issue contract

The original issue's stated goal included "the runtime-helper auto-collection pass (`collect_runtime_helper_targets`) is restored to live." This PR delivers the structural prerequisite but **defers the actual flip** to #740 because re-enabling the walker reproducibly triggers a non-deterministic IR emission on `compiler/src/parser/expressions.sfn`:

```
< @expression_tokens_advance__parser__expressions
> @epression_tokens_advance
```

Both a character drop and the mangling-suffix loss arise only with the walker enabled. The 20x emit-sweep e2e test (`compiler/tests/e2e/test_runtime_array.sh`) catches this under `make check` load. The flake passes in isolation, fails reliably under the full check pipeline — symptom of a latent memory/aliasing bug exposed by the walker's additional allocations.

The deferral commit pins the flag and points the comment + commit message at #740 so the next picker has full context. The flip itself remains a one-line change.

## Files Changed

- `compiler/src/llvm/lowering/lowering_core.sfn` (+20, -7 net across 2 commits)
- `compiler/src/llvm/effects.sfn` (net zero — M2.7c added then reverted)

## Follow-up

- #740 — `bug(lowering): collect_runtime_helper_targets introduces non-deterministic IR on heavy modules`. Filed as `claude-ready` `size:m` `priority:high` `seed-blocker`. Repro and candidate root-cause surfaces are in the issue body.
- Once #740 closes: flip `skip_helper_collection = false`, re-apply (or re-derive) the M2.7c retirement (or its equivalent) to keep IR-diff zero, cut a fresh seed, `/pin-seed`, then #501 becomes pickable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)