### PR TITLE
fix(lowering): skip preamble-inlined declares for #740 helper walker flip

### DIFF
--- a/compiler/src/llvm/lowering/lowering_core.sfn
+++ b/compiler/src/llvm/lowering/lowering_core.sfn
@@ -513,16 +513,21 @@ fn lower_to_llvm_lines_with_parsed_context(native_module: NativeModule, parse_in
     if debug_lowering { print.err("emit-llvm: phase=context_functions"); }
 
     // ── Effect analysis ─────────────────────────────────────────────
-    // Helper collection is currently gated off. Flipping this flag to
-    // `false` re-enables `collect_runtime_helper_targets` so the dynamic
-    // walker discovers per-module runtime-helper declares (unblocking
-    // #501 / #414). Blocked on a determinism bug surfaced when the
-    // walker runs on `compiler/src/parser/expressions.sfn`: the 20x
-    // emit-sweep e2e test under `make check` reliably observes a
-    // character/mangling-suffix drop in an extracted function name
-    // (see #737 for the diagnosis). Track the bug fix separately;
-    // this flag exists so the flip is a one-line change once resolved.
-    let skip_helper_collection = true;
+    // Helper collection is now ON (#740 closed the duplicate-declare
+    // failure that previously gated this). `collect_runtime_helper_targets`
+    // walks every function in `local_functions`, extracting call targets
+    // and surfacing per-module runtime-helper declares so the linker
+    // resolves them without relying on the conservative
+    // `seed_default_runtime_helpers` baseline alone (unblocking #501 / #414).
+    //
+    // The walker can discover targets that are already declared inline
+    // by `render_llvm_preamble` (the typed spawn/await family from
+    // `async_runtime_declare_lines` and the seedcheck enum-tag reader);
+    // `render_runtime_helper_declarations` filters those out so the
+    // emitted IR never carries duplicate `declare` lines. See the
+    // matching skip block in `compiler/src/llvm/rendering.sfn` if a
+    // future preamble-inlined declare needs the same treatment.
+    let skip_helper_collection = false;
     // Bootstrap guard (commit 65b065ad, "make check completes binary not
     // valid"): effect analysis currently introduces instability in
     // selfhost/native lowering for some modules. Keep disabled by default.

--- a/compiler/src/llvm/rendering.sfn
+++ b/compiler/src/llvm/rendering.sfn
@@ -9,7 +9,11 @@ import {
     extract_struct_type_from_llvm,
     render_interface_signature
 } from "./rendering_helpers";
-import { effective_helper_declare_return_type, runtime_helper_descriptors } from "./runtime_helpers";
+import {
+    effective_helper_declare_return_type,
+    is_async_runtime_target,
+    runtime_helper_descriptors
+} from "./runtime_helpers";
 import { map_parameter_type, map_return_type } from "./type_mapping";
 import { RuntimeHelperDescriptor, TraitMetadata, TypeContext } from "./types";
 import {
@@ -137,6 +141,41 @@ fn render_runtime_helper_declarations(used_targets: string[], local_functions: N
         if index >= descriptors.length { break; }
         let descriptor = descriptors[index];
         if string_array_contains(used_targets, descriptor.target) {
+            // Issue #740: skip helpers that are unconditionally declared
+            // inline by `render_llvm_preamble` (in
+            // `lowering_phase_render.sfn`). When the dynamic helper-
+            // collection walker (`collect_runtime_helper_targets`) is
+            // enabled it discovers these targets and adds them to
+            // `used_targets`; without this filter the loop below would
+            // emit a duplicate `declare` line that llvm-as rejects with
+            // "invalid redefinition of function" — silently breaking the
+            // `--work-dir` parallel-emit retry cascade and the
+            // 20× emit-sweep determinism gate.
+            //
+            // Two preamble-inlined declare sets must be excluded:
+            //   1. The typed spawn/await runtime family
+            //      (`async_runtime_declare_lines()` walks every
+            //      descriptor where `is_async_runtime_target` is true
+            //      and emits its declare directly into the preamble).
+            //   2. `sailfin_enum_tag_from_instruction_array` — the
+            //      seedcheck enum-tag reader has its declare hardcoded
+            //      in the preamble for separate-compilation visibility.
+            //
+            // Both sets are emitted by the preamble even when the walker
+            // is off (see `lowering_phase_render.sfn:110-112`), so
+            // skipping them here never strips a declare the module
+            // actually needs.
+            let mut _preamble_inlined: boolean = false;
+            if is_async_runtime_target(descriptor.target) {
+                _preamble_inlined = true;
+            }
+            if descriptor.target == "sailfin_enum_tag_from_instruction_array" {
+                _preamble_inlined = true;
+            }
+            if _preamble_inlined {
+                index += 1;
+                continue;
+            }
             // M1.C / M2.4a: when `native_signature` is populated the
             // call-emission path (`coerce_and_emit_call` in
             // `core_call_emission.sfn`) routes the call to that symbol


### PR DESCRIPTION
## Summary

Re-enable `collect_runtime_helper_targets` by flipping `skip_helper_collection = false` and skip preamble-inlined declares (async spawn/await family + `sailfin_enum_tag_from_instruction_array`) in `render_runtime_helper_declarations` so the walker's discovery of these symbols no longer produces duplicate `declare` lines that `llvm-as` rejects.

Closes #740

## Root Cause

`render_llvm_preamble` (`lowering_phase_render.sfn:110-112`) unconditionally inlines two sets of function declares for every emitted module:
1. The typed spawn/await runtime family via `async_runtime_declare_lines()`.
2. `sailfin_enum_tag_from_instruction_array` (the seedcheck enum-tag reader).

When the walker is enabled, it traverses every function in `local_functions`, extracts call targets via `extract_all_call_targets`, and adds them to `used_targets`. `render_runtime_helper_declarations` then iterates `runtime_helper_descriptors()` and emits a `declare` for every target in `used_targets` — including the ones the preamble already declared inline.

Result: `declare double @sailfin_enum_tag_from_instruction_array(i8*, double)` appears twice in `compiler/src/llvm/lowering/lowering_native_helpers.sfn`'s emitted IR, which `llvm-as` rejects with `invalid redefinition of function`. The parallel-emit retry cascade hits the validator on every attempt, exhausts its 3-retry budget, and the build link step fails downstream with hundreds of "undefined reference" errors as modules that depend on `lowering_native_helpers.sfn`'s symbols can't link.

The fix filters the preamble-inlined targets out of the helper declare loop in `render_runtime_helper_declarations`. The skip is symmetric — walker-off baseline output is unchanged (the targets aren't in `used_targets`), walker-on output stops emitting duplicates.

## Acceptance Criteria

- [x] With `skip_helper_collection = false`, `make compile && make check` from seed `v0.7.0-alpha.3` completes the first-pass test suite (212/212) plus the seedcheck unit (101/101), seedcheck integration (26/26), the 20× emit-sweep on `parser/expressions.sfn` in both phases, and the `test_work_dir_parity.sh` SHA-256 byte-equality check.
- [x] Reproduction confirmed first: with the unmodified `skip_helper_collection = false` source, `sfn build -p compiler --work-dir <DIR>` reliably reports `capsule-resolver: failed to lower llvm/lowering/lowering_native_helpers to LLVM IR` and the link step fails with hundreds of undefined-reference errors. After the fix, the same command succeeds.
- [x] No regression on `examples/basics/try-catch-finally.sfn` — IR emit is byte-identical across iterations and `llvm-as` validates.
- [ ] `make check` clean end-to-end on macos-arm64 (gated on CI).

## Verification

```bash
ulimit -v 8388608 && make compile
ulimit -v 8388608 && make check
ulimit -v 8388608 && bash compiler/tests/e2e/test_runtime_array.sh build/native/sailfin
ulimit -v 8388608 && bash compiler/tests/e2e/test_work_dir_parity.sh build/native/sailfin
```

## Files Changed

- `compiler/src/llvm/rendering.sfn` — skip preamble-inlined targets in `render_runtime_helper_declarations`; import `is_async_runtime_target` from `./runtime_helpers`.
- `compiler/src/llvm/lowering/lowering_core.sfn` — flip `skip_helper_collection = false`; refresh comment to point at the fix and document the contract with the preamble.

Unblocks #501 / #414 — once a seed bump captures this fix, the `seed_default_runtime_helpers` baseline can be retired in favor of dynamic discovery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0174efCU4VM6pjX9JRnQTCAX)_