### PR TITLE
feat(build): stage runtime/sfn/platform/*.sfn-asm artifacts (#414)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -845,6 +845,37 @@ rebuild:
 		echo "[rebuild] staging exec.o..."; \
 		$(CLANG) -O2 -Wno-override-module -c build/native/obj/runtime/exec.ll -o build/native/obj/runtime/exec.o; \
 	fi
+	@# Stage import-context for `runtime/sfn/platform/*.sfn` extern-fn
+	@# modules. `runtime/sfn/clock.sfn` imports `nanosleep` from
+	@# `./platform/posix`, and `runtime/sfn/io.sfn` imports `write`
+	@# from `./platform/libc`; without these `.sfn-asm` artifacts on
+	@# disk, `collect_imported_module_context_for_module`
+	@# (compiler/src/llvm/imports.sfn) falls back to empty native text
+	@# and `render_imported_function_declarations` cannot emit the
+	@# extern's source-of-truth signature. Today's fallback is the
+	@# `seed_default_runtime_helpers` workaround (a forced `nanosleep`
+	@# entry in the helper preamble emits `declare i32 @nanosleep(i8*,
+	@# i8*)` with opaque-pointee types); staging here lets the import
+	@# path emit the proper `declare i32 @nanosleep(%Timespec*,
+	@# %Timespec*)` from posix.sfn instead. Issue #414 closes that
+	@# arc; the workaround entry retires in the same PR. Layout
+	@# manifests are extern-fn-only (no structs/enums), so the
+	@# companion file is intentionally empty — stage_capsule_imports
+	@# does the same when `_cr_extract_layout_manifest` finds no
+	@# `.layout` lines in the emitted asm.
+	@mkdir -p build/native/import-context/runtime/sfn/platform
+	@for mod in libc posix pthread net; do \
+		asm_path="build/native/import-context/runtime/sfn/platform/$$mod.sfn-asm"; \
+		manifest_path="build/native/import-context/runtime/sfn/platform/$$mod.layout-manifest"; \
+		if [ ! -f "$$asm_path" ]; then \
+			echo "[rebuild] staging runtime/sfn/platform/$$mod.sfn-asm..."; \
+			$(NATIVE_OUT) emit --module-name "runtime/sfn/platform/$$mod" -o "$$asm_path" native "runtime/sfn/platform/$$mod.sfn" >/dev/null; \
+		fi; \
+		if [ ! -f "$$manifest_path" ]; then \
+			grep '^\.layout' "$$asm_path" > "$$manifest_path" 2>/dev/null || :; \
+			[ -f "$$manifest_path" ] || touch "$$manifest_path"; \
+		fi; \
+	done
 	@# Write build stamp (version + git hash for dev builds).
 	@# `version.sfn::resolve_compiler_version` reads this file
 	@# first, so without it the binary would report whatever stale

--- a/Makefile
+++ b/Makefile
@@ -864,12 +864,22 @@ rebuild:
 	@# does the same when `_cr_extract_layout_manifest` finds no
 	@# `.layout` lines in the emitted asm.
 	@mkdir -p build/native/import-context/runtime/sfn/platform
-	@for mod in libc posix pthread net; do \
+	@set -e; \
+	for mod in libc posix pthread net; do \
 		asm_path="build/native/import-context/runtime/sfn/platform/$$mod.sfn-asm"; \
 		manifest_path="build/native/import-context/runtime/sfn/platform/$$mod.layout-manifest"; \
 		if [ ! -f "$$asm_path" ]; then \
 			echo "[rebuild] staging runtime/sfn/platform/$$mod.sfn-asm..."; \
-			$(NATIVE_OUT) emit --module-name "runtime/sfn/platform/$$mod" -o "$$asm_path" native "runtime/sfn/platform/$$mod.sfn" >/dev/null; \
+			if ! $(NATIVE_OUT) emit --module-name "runtime/sfn/platform/$$mod" -o "$$asm_path" native "runtime/sfn/platform/$$mod.sfn" >/dev/null; then \
+				echo "[rebuild][error] emit native failed for runtime/sfn/platform/$$mod.sfn" >&2; \
+				rm -f "$$asm_path"; \
+				exit 1; \
+			fi; \
+			if [ ! -s "$$asm_path" ]; then \
+				echo "[rebuild][error] emit native produced empty $$asm_path" >&2; \
+				rm -f "$$asm_path"; \
+				exit 1; \
+			fi; \
 		fi; \
 		if [ ! -f "$$manifest_path" ]; then \
 			grep '^\.layout' "$$asm_path" > "$$manifest_path" 2>/dev/null || :; \

--- a/compiler/src/llvm/lowering/lowering_helpers.sfn
+++ b/compiler/src/llvm/lowering/lowering_helpers.sfn
@@ -739,17 +739,6 @@ fn seed_default_runtime_helpers(initial: string[]) -> string[] {
     helpers = append_unique_effect(helpers, "runtime_resolve_runtime_type_fn");
     helpers = append_unique_effect(helpers, "runtime_serve_fn");
     helpers = append_unique_effect(helpers, "runtime_sleep_fn");
-    // libc `nanosleep`, called from `runtime/sfn/clock.sfn::sfn_sleep`
-    // (PR 2 of the sleep migration, issue #397). Without the
-    // helper-preamble entry the per-symbol descriptor's call-emit path
-    // produces `call i32 @nanosleep(...)` without a paired
-    // `declare i32 @nanosleep(i8*, i8*)`, which clang rejects as
-    // "use of undefined value '@nanosleep'". Retires when issue #306
-    // Phase B lands typecheck-level cross-module extern resolution
-    // (at which point the per-symbol descriptor + this preamble entry
-    // both retire together, mirroring the `sailfin_runtime_sleep`
-    // cleanup PR 2 already did).
-    helpers = append_unique_effect(helpers, "nanosleep");
     helpers = append_unique_effect(helpers, "runtime_to_debug_string_fn");
     helpers = append_unique_effect(helpers, "runtime_create_capability_grant");
     helpers = append_unique_effect(helpers, "runtime_create_filesystem_bridge");

--- a/compiler/src/llvm/runtime_helpers.sfn
+++ b/compiler/src/llvm/runtime_helpers.sfn
@@ -189,15 +189,14 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
         target: "runtime_sleep_fn", symbol: "sfn_sleep", return_type: "void", parameter_types: ["double"], effects: ["clock"], native_signature: null, c_abi_return_type: null
     });
     // Per-symbol signature for libc `nanosleep`, called from
-    // `runtime/sfn/clock.sfn::sfn_sleep`. Without this descriptor
-    // the call lowering falls into the cross-module extern path
-    // (issue #306 Phase B is still open), which can't resolve the
-    // `i32` return type and emits a `[fatal]` diagnostic — the
-    // wrapper body then ships missing its `nanosleep` call and
-    // `sleep()` becomes a no-op (PR #692 CI repro). The pointee
-    // type lowers to `i8*` through the opaque-pointee rule, so the
-    // descriptor describes the C-ABI shape rather than the
-    // `%Timespec*` Sailfin sees at the call site.
+    // `runtime/sfn/clock.sfn::sfn_sleep`. Provides the typed
+    // C-ABI signature for the call-site lowering even though the
+    // `declare` line itself is now contributed by the import path
+    // (`build/native/import-context/runtime/sfn/platform/posix.sfn-asm`,
+    // staged by `make compile`). The pointee type lowers to `i8*`
+    // through the opaque-pointee rule, so the descriptor describes
+    // the C-ABI shape rather than the `%Timespec*` Sailfin sees at
+    // the call site.
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
         target: "nanosleep", symbol: "nanosleep", return_type: "i32", parameter_types: ["i8*", "i8*"], effects: [], native_signature: null, c_abi_return_type: null
     });

--- a/compiler/src/llvm/runtime_helpers.sfn
+++ b/compiler/src/llvm/runtime_helpers.sfn
@@ -188,15 +188,23 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
         target: "runtime_sleep_fn", symbol: "sfn_sleep", return_type: "void", parameter_types: ["double"], effects: ["clock"], native_signature: null, c_abi_return_type: null
     });
-    // Per-symbol signature for libc `nanosleep`, called from
-    // `runtime/sfn/clock.sfn::sfn_sleep`. Provides the typed
-    // C-ABI signature for the call-site lowering even though the
-    // `declare` line itself is now contributed by the import path
-    // (`build/native/import-context/runtime/sfn/platform/posix.sfn-asm`,
-    // staged by `make compile`). The pointee type lowers to `i8*`
-    // through the opaque-pointee rule, so the descriptor describes
-    // the C-ABI shape rather than the `%Timespec*` Sailfin sees at
-    // the call site.
+    // Per-symbol fallback signature for libc `nanosleep`, called from
+    // `runtime/sfn/clock.sfn::sfn_sleep`. In the common path the
+    // staged `build/native/import-context/runtime/sfn/platform/posix.sfn-asm`
+    // artifact makes the imported function entry win at call resolution
+    // (issue #633 — `core_call_resolution.sfn` prefers the function
+    // entry over the descriptor and clears `result_helper`), and the
+    // `declare` is emitted by `render_imported_function_declarations`
+    // with the `%Timespec*` source-level signature; meanwhile
+    // `render_runtime_helper_declarations` skips the descriptor via the
+    // `target == symbol` shadow check in `rendering.sfn`. The descriptor
+    // is retained as the legacy fallback for emits run against a build
+    // tree without staged platform artifacts (e.g. a partial seedcheck
+    // sandbox), where the call-site lowering falls back to the descriptor
+    // signature and the `declare` lands as `i32 @nanosleep(i8*, i8*)`
+    // through the opaque-pointee rule. Retires together with the
+    // fallback path once cross-module extern resolution lands (#306
+    // Phase B).
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
         target: "nanosleep", symbol: "nanosleep", return_type: "i32", parameter_types: ["i8*", "i8*"], effects: [], native_signature: null, c_abi_return_type: null
     });


### PR DESCRIPTION
## Summary
- `make compile` now stages `.sfn-asm` import-context for the four extern-fn platform modules (`libc`, `posix`, `pthread`, `net`) under `build/native/import-context/runtime/sfn/platform/`.
- `collect_imported_module_context_for_module` resolves `runtime/sfn/clock.sfn`'s `nanosleep` import from the staged `posix.sfn-asm`, and `render_imported_function_declarations` emits `declare i32 @nanosleep(%Timespec*, %Timespec*)` from the source-of-truth signature — no more `i8*` opaque-pointee fallback from the runtime-helper descriptor.
- Removes the `nanosleep` workaround entry from `seed_default_runtime_helpers` (`lowering_helpers.sfn:752`) and its explanatory comment. The dynamic helper walker (enabled by #741) keeps `nanosleep` in `used_targets` via the call site in `sfn_sleep`. The descriptor in `runtime_helpers.sfn` stays — it still types the call site — but the workaround comment retires.

Closes #414

## Note on symbol naming
The issue body references `sailfin_runtime_sleep` as the workaround symbol, but PR #692 (M2.11, sleep migration) replaced that C trampoline with the libc `nanosleep` call routed through `posix.sfn`. The workaround retiring here is `nanosleep` — conceptually identical: an artifact-pipeline self-sufficiency fix that replaces a forced helper-preamble entry.

## Acceptance Criteria
- [x] `build/native/import-context/runtime/sfn/platform/libc.sfn-asm` exists after `make compile`
- [x] declare comes from the import path, not the helper preamble — verified `declare i32 @nanosleep(%Timespec*, %Timespec*)` with proper `%Timespec*` types from posix.sfn
- [x] `"nanosleep"` (was: `"sailfin_runtime_sleep"`) entry removed from `seed_default_runtime_helpers`
- [x] Workaround comment removed from `runtime_helpers.sfn` (descriptor preserved)
- [x] `bash compiler/tests/e2e/test_runtime_clock_skeleton.sh build/native/sailfin` reports 5/5 passed (issue mentions 4 — test was updated to 5 by PR #692)
- [x] `make compile` passes
- [x] `make test` passes (212/212: 101 unit + 26 integration + 72 e2e + 13 capsules)
- [x] `make check` passes locally (exit 0; seedcheck fixed-point validated)

## Verification

```bash
$ ulimit -v 8388608 && make compile FORCE=1
[rebuild] staging runtime/sfn/platform/libc.sfn-asm...
[rebuild] staging runtime/sfn/platform/posix.sfn-asm...
[rebuild] staging runtime/sfn/platform/pthread.sfn-asm...
[rebuild] staging runtime/sfn/platform/net.sfn-asm...

$ ls build/native/import-context/runtime/sfn/platform/
libc.layout-manifest    libc.sfn-asm
net.layout-manifest     net.sfn-asm
posix.layout-manifest   posix.sfn-asm
pthread.layout-manifest pthread.sfn-asm

$ grep '^\.fn nanosleep' build/native/import-context/runtime/sfn/platform/posix.sfn-asm
.fn nanosleep(req: * Timespec, rem: * Timespec) -> i32

$ ulimit -v 8388608 && timeout 30 build/native/sailfin emit -o /tmp/clock.ll llvm runtime/sfn/clock.sfn
$ grep -E "^declare i32 @nanosleep" /tmp/clock.ll
declare i32 @nanosleep(%Timespec*, %Timespec*)

$ ulimit -v 8388608 && bash compiler/tests/e2e/test_runtime_clock_skeleton.sh build/native/sailfin
[test] PASS: sfn check runtime/sfn/clock.sfn passes
[test] PASS: sfn fmt --check runtime/sfn/clock.sfn is canonical
[test] PASS: sfn emit llvm produces sfn_sleep wrapper over @nanosleep
[test] PASS: sfn emit llvm declares the nanosleep import
[test] PASS: sailfin_runtime_sleep is fully retired from clock.sfn emission
[summary] 5 passed, 0 failed

$ ulimit -v 8388608 && make test
═══ unit: 101/101 passed, 0 failed ═══
═══ integration: 26/26 passed, 0 failed ═══
═══ e2e: 72/72 passed, 0 failed ═══
═══ capsules: 13/13 passed, 0 failed ═══

$ ulimit -v 8388608 && make check
# exit 0 (seedcheck fixed-point validates)
```

## Files Changed
- `Makefile` — `rebuild` target stages platform `.sfn-asm` + companion empty `.layout-manifest` files (extern-fn-only, no structs/enums)
- `compiler/src/llvm/lowering/lowering_helpers.sfn` — remove the `nanosleep` entry + workaround comment at line 742-752
- `compiler/src/llvm/runtime_helpers.sfn` — update the nanosleep-descriptor comment; descriptor itself preserved

## Audit
Confirmed that `nanosleep` was the only entry in `seed_default_runtime_helpers` added as a workaround for a missing import-context artifact. Other entries fall into separate categories (runtime C entrypoints, prelude helpers, compiler-emitted helpers) — none are extern declarations awaiting their own platform-module artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)