### PR TITLE
M2.7c — pin zero has_exception polling in call emission (#406)

### DIFF
--- a/compiler/tests/e2e/test_call_emission_no_polling.sh
+++ b/compiler/tests/e2e/test_call_emission_no_polling.sh
@@ -62,7 +62,20 @@ run_test() {
 emit_llvm() {
     local source="$1"
     local out="$2"
-    "$BINARY" emit -o "$out" llvm "$source" > /dev/null 2>&1
+    local log="$3"
+    "$BINARY" emit -o "$out" llvm "$source" > "$log" 2>&1
+}
+
+# Dump a captured emit log to the test output stream, prefixed for
+# readability. Called from each test on emit failure so CI logs show
+# the compiler diagnostic without needing a local rerun.
+dump_emit_log() {
+    local log="$1"
+    if [ -s "$log" ]; then
+        sed 's/^/[test]     /' "$log"
+    else
+        echo "[test]     (emit produced no stderr/stdout)"
+    fi
 }
 
 # Count `call` instructions targeting a symbol. Matches the LLVM
@@ -76,21 +89,39 @@ emit_llvm() {
 # spaces) immediately preceding the symbol mention — `declare` lines
 # don't contain that token, but every call site does.
 #
-# `grep -c` exits non-zero on zero matches (and prints `0`), so we
-# swallow the exit status with `|| true` and trust `grep -c`'s own
-# count output.
+# Exits the script (non-zero) when the IR file is missing or grep
+# reports an error other than "no matches" (exit 1). Returning an
+# empty string here would let the caller's `[ "$count" -ne 0 ]`
+# comparison silently pass on a missing file, masking the very
+# regression this test guards against. `grep -c` exit codes:
+#   0 — at least one match (count > 0)
+#   1 — no matches (count == 0)
+#   2 — file I/O or pattern error — propagate as a hard failure
 count_call_sites() {
     local ll="$1"
     local symbol="$2"
-    grep -cE "[[:space:]]call[[:space:]].*@${symbol}\b" "$ll" 2>/dev/null || true
+    if [ ! -r "$ll" ]; then
+        echo "[count_call_sites] IR file missing or unreadable: $ll" >&2
+        exit 1
+    fi
+    local count
+    local rc=0
+    count="$(grep -cE "[[:space:]]call[[:space:]].*@${symbol}\b" "$ll")" || rc=$?
+    if [ "$rc" -ne 0 ] && [ "$rc" -ne 1 ]; then
+        echo "[count_call_sites] grep failed (exit $rc) on $ll" >&2
+        exit 1
+    fi
+    printf '%s' "${count:-0}"
 }
 
 # ---- (1) heavy compiler module: lowering_core.sfn ----
 test_lowering_core_no_polling() {
     local source="$REPO_ROOT/compiler/src/llvm/lowering/lowering_core.sfn"
     local ll="$SCRATCH/lowering_core.ll"
-    if ! emit_llvm "$source" "$ll"; then
+    local log="$SCRATCH/lowering_core.emit.log"
+    if ! emit_llvm "$source" "$ll" "$log"; then
         echo "[test]   sfn emit llvm failed for lowering_core.sfn"
+        dump_emit_log "$log"
         return 1
     fi
     local count
@@ -108,8 +139,10 @@ test_lowering_core_no_polling() {
 test_instructions_try_no_polling() {
     local source="$REPO_ROOT/compiler/src/llvm/lowering/instructions_try.sfn"
     local ll="$SCRATCH/instructions_try.ll"
-    if ! emit_llvm "$source" "$ll"; then
+    local log="$SCRATCH/instructions_try.emit.log"
+    if ! emit_llvm "$source" "$ll" "$log"; then
         echo "[test]   sfn emit llvm failed for instructions_try.sfn"
+        dump_emit_log "$log"
         return 1
     fi
     local count
@@ -142,8 +175,10 @@ fn main() ![io] {
 }
 SFN
     local ll="$SCRATCH/try_catch.ll"
-    if ! emit_llvm "$fixture" "$ll"; then
+    local log="$SCRATCH/try_catch.emit.log"
+    if ! emit_llvm "$fixture" "$ll" "$log"; then
         echo "[test]   sfn emit llvm failed for try/catch fixture"
+        dump_emit_log "$log"
         return 1
     fi
     local count
@@ -183,8 +218,10 @@ fn main() ![io] {
 }
 SFN
     local ll="$SCRATCH/pure_calls.ll"
-    if ! emit_llvm "$fixture" "$ll"; then
+    local log="$SCRATCH/pure_calls.emit.log"
+    if ! emit_llvm "$fixture" "$ll" "$log"; then
         echo "[test]   sfn emit llvm failed for pure-calls fixture"
+        dump_emit_log "$log"
         return 1
     fi
     local count

--- a/compiler/tests/e2e/test_call_emission_no_polling.sh
+++ b/compiler/tests/e2e/test_call_emission_no_polling.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+# End-to-end test for M2.7c — call-site exception polling removal
+# (issue #406, epic #389). Pins that compiler-emitted IR contains zero
+# `call ... @sailfin_runtime_has_exception` instructions, the
+# per-call-site polling that the legacy TLS-based try/catch path
+# emitted after every function call inside a try body.
+#
+# What this PR ships, end-to-end (in concert with M2.7a/#400 and
+# M2.7b/#404):
+#
+#   1. The legacy TLS-polling shape — `clear_exception` at try entry,
+#      `has_exception` poll + branch after every call in the try body,
+#      `take_exception` at catch entry, and a propagate-poll on the
+#      merge edge — was replaced wholesale by inline setjmp/longjmp
+#      primitives when `instructions_try.sfn` was rewritten (PR #733).
+#      The "two instructions per call site on the happy path" (the
+#      `has_exception` call + the conditional branch on its result)
+#      promised in #406's description are already gone in the current
+#      compiler.
+#   2. This test locks that property in: compiler-emitted IR for the
+#      heavy modules and a representative try/catch fixture contains
+#      zero `call ... @sailfin_runtime_has_exception` lines. A future
+#      regression that reintroduces per-call-site polling will fail
+#      this test before it lands.
+#
+# We deliberately check `call` lines, not `declare` lines — the
+# compiler-side `RuntimeHelperDescriptor` for `has_exception` stays
+# registered for ABI completeness (and the C symbol stays exported
+# until M3 deletes the C runtime body), so a `declare i1
+# @sailfin_runtime_has_exception()` may still surface in some emitted
+# modules. What MUST be zero is the call site count — if the IR ever
+# `call`s the symbol, the polling has crept back into emission.
+#
+# Usage:
+#   compiler/tests/e2e/test_call_emission_no_polling.sh <compiler-binary>
+
+set -euo pipefail
+
+BINARY="${1:?usage: test_call_emission_no_polling.sh <compiler-binary>}"
+BINARY="$(realpath "$BINARY")"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+PASS=0
+FAIL=0
+
+SCRATCH="$(mktemp -d -t sfn-call-no-polling-XXXXXX)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+run_test() {
+    local name="$1"
+    shift
+    if "$@"; then
+        echo "[test] PASS: $name"
+        PASS=$((PASS + 1))
+    else
+        echo "[test] FAIL: $name"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+emit_llvm() {
+    local source="$1"
+    local out="$2"
+    "$BINARY" emit -o "$out" llvm "$source" > /dev/null 2>&1
+}
+
+# Count `call` instructions targeting a symbol. Matches the LLVM
+# call shapes that show up in compiler-emitted IR:
+#
+#   %t = call <ty> @sailfin_runtime_has_exception()
+#        call void @sailfin_runtime_has_exception()
+#
+# but NOT `declare i1 @sailfin_runtime_has_exception()`. We pick the
+# narrowest disambiguator: the literal substring ` call ` (with bounding
+# spaces) immediately preceding the symbol mention — `declare` lines
+# don't contain that token, but every call site does.
+#
+# `grep -c` exits non-zero on zero matches (and prints `0`), so we
+# swallow the exit status with `|| true` and trust `grep -c`'s own
+# count output.
+count_call_sites() {
+    local ll="$1"
+    local symbol="$2"
+    grep -cE "[[:space:]]call[[:space:]].*@${symbol}\b" "$ll" 2>/dev/null || true
+}
+
+# ---- (1) heavy compiler module: lowering_core.sfn ----
+test_lowering_core_no_polling() {
+    local source="$REPO_ROOT/compiler/src/llvm/lowering/lowering_core.sfn"
+    local ll="$SCRATCH/lowering_core.ll"
+    if ! emit_llvm "$source" "$ll"; then
+        echo "[test]   sfn emit llvm failed for lowering_core.sfn"
+        return 1
+    fi
+    local count
+    count="$(count_call_sites "$ll" "sailfin_runtime_has_exception")"
+    if [ "$count" -ne 0 ]; then
+        echo "[test]   expected 0 has_exception call sites in lowering_core.ll, got $count:"
+        grep -nE "[[:space:]]call[[:space:]].*@sailfin_runtime_has_exception\b" "$ll" \
+            | head -20 | sed 's/^/[test]     /'
+        return 1
+    fi
+    return 0
+}
+
+# ---- (2) heavy compiler module: instructions_try.sfn (the migration target) ----
+test_instructions_try_no_polling() {
+    local source="$REPO_ROOT/compiler/src/llvm/lowering/instructions_try.sfn"
+    local ll="$SCRATCH/instructions_try.ll"
+    if ! emit_llvm "$source" "$ll"; then
+        echo "[test]   sfn emit llvm failed for instructions_try.sfn"
+        return 1
+    fi
+    local count
+    count="$(count_call_sites "$ll" "sailfin_runtime_has_exception")"
+    if [ "$count" -ne 0 ]; then
+        echo "[test]   expected 0 has_exception call sites in instructions_try.ll, got $count:"
+        grep -nE "[[:space:]]call[[:space:]].*@sailfin_runtime_has_exception\b" "$ll" \
+            | head -20 | sed 's/^/[test]     /'
+        return 1
+    fi
+    return 0
+}
+
+# ---- (3) try/catch fixture: ensure the emission path that USES try
+#         doesn't reintroduce polling at any call site ----
+test_try_catch_fixture_no_polling() {
+    local fixture="$SCRATCH/try_catch.sfn"
+    cat > "$fixture" <<'SFN'
+fn helper(x: int) -> int { return x + 1; }
+
+fn main() ![io] {
+    try {
+        let a: int = helper(1);
+        let b: int = helper(a);
+        let c: int = helper(b);
+        print("ok");
+    } catch (e) {
+        print("caught: " + e);
+    }
+}
+SFN
+    local ll="$SCRATCH/try_catch.ll"
+    if ! emit_llvm "$fixture" "$ll"; then
+        echo "[test]   sfn emit llvm failed for try/catch fixture"
+        return 1
+    fi
+    local count
+    count="$(count_call_sites "$ll" "sailfin_runtime_has_exception")"
+    if [ "$count" -ne 0 ]; then
+        echo "[test]   expected 0 has_exception call sites in try/catch fixture IR, got $count"
+        echo "[test]   (this is the regression that M2.7c guards against: a"
+        echo "[test]    rewrite of instructions_try.sfn must not re-emit"
+        echo "[test]    per-call-site polling alongside the setjmp/longjmp path)"
+        grep -nE "[[:space:]]call[[:space:]].*@sailfin_runtime_has_exception\b" "$ll" \
+            | head -20 | sed 's/^/[test]     /'
+        return 1
+    fi
+    return 0
+}
+
+# ---- (4) representative non-try module: pure function-call traffic
+#         must also be polling-free (catches the worst case where a
+#         future change would emit polling unconditionally after every
+#         call, not just inside try bodies) ----
+test_pure_call_traffic_no_polling() {
+    local fixture="$SCRATCH/pure_calls.sfn"
+    cat > "$fixture" <<'SFN'
+fn add(a: int, b: int) -> int { return a + b; }
+fn mul(a: int, b: int) -> int { return a * b; }
+
+fn compute(seed: int) -> int {
+    let a: int = add(seed, 1);
+    let b: int = mul(a, 2);
+    let c: int = add(b, mul(seed, 3));
+    return c;
+}
+
+fn main() ![io] {
+    let result: int = compute(7);
+    print("done");
+}
+SFN
+    local ll="$SCRATCH/pure_calls.ll"
+    if ! emit_llvm "$fixture" "$ll"; then
+        echo "[test]   sfn emit llvm failed for pure-calls fixture"
+        return 1
+    fi
+    local count
+    count="$(count_call_sites "$ll" "sailfin_runtime_has_exception")"
+    if [ "$count" -ne 0 ]; then
+        echo "[test]   expected 0 has_exception call sites in pure-calls IR, got $count:"
+        grep -nE "[[:space:]]call[[:space:]].*@sailfin_runtime_has_exception\b" "$ll" \
+            | head -20 | sed 's/^/[test]     /'
+        return 1
+    fi
+    return 0
+}
+
+run_test "no has_exception polling in lowering_core.sfn IR" \
+    test_lowering_core_no_polling
+run_test "no has_exception polling in instructions_try.sfn IR" \
+    test_instructions_try_no_polling
+run_test "no has_exception polling in try/catch fixture IR" \
+    test_try_catch_fixture_no_polling
+run_test "no has_exception polling in pure call-traffic IR" \
+    test_pure_call_traffic_no_polling
+
+echo "[summary] $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi


### PR DESCRIPTION
## Summary

Final phase of the M2.7 exception migration trilogy (#400 → #404 → #406).
Adds a regression test pinning that compiler-emitted IR contains zero
`call ... @sailfin_runtime_has_exception` instructions — the legacy
per-call-site polling that the TLS-based try/catch path emitted after
every function call inside a try body.

**Why this is just a test, not a polling-deletion patch:** the polling
was already removed wholesale when `instructions_try.sfn` was rewritten
for setjmp/longjmp in PR #733 (M2.7b). #733's notes deferred this
deletion to M2.7c "so a regression bisect can localize whether a bug is
in try emission or call-site polling removal" — but the rewrite removed
both the try-body polling shape and the after-call polling in the same
change. There is no remaining `emit_runtime_call("has_exception", ...)`
call site anywhere in `compiler/src/`. The "two instructions per call
site on the happy path" promised in #406's description are already
gone in `main`; this PR ratifies that with a regression gate.

Closes #406

## Acceptance Criteria

- [x] **Emitted IR for a heavy module (`compiler/src/llvm/lowering/lowering_core.sfn`) has zero `call i1 @sailfin_runtime_has_exception` lines.** Verified — see the
      `test_lowering_core_no_polling` case in the new test.
- [x] **`make bench` shows a measurable reduction in per-module IR line count.**
      Delivered by PR #733 (M2.7b) — the wholesale rewrite of
      `instructions_try.sfn` removed every `has_exception` poll site
      from both the in-try and post-merge propagate paths. There is no
      additional reduction in this PR; the test simply locks the
      property in. `make bench` runs to completion (149/149 modules
      within budget, slowest `llvm__runtime_helpers` at 10s).
- [x] **`make compile` passes.** Self-host from v0.7.0-alpha.4 seed.
- [x] **`make test` passes.** 73/73 e2e (including the new test),
      13/13 capsules, full unit + integration green.

## Scope adjustment

The issue's `Files Affected` lists
`compiler/src/llvm/expression_lowering/native/core_call_emission.sfn`,
but a pre-flight audit (`grep -n exception
compiler/src/llvm/expression_lowering/native/core_call_emission.sfn`)
returned zero hits — the file has never contained `has_exception`
polling. The polling that #406 was groomed to remove lived in
`instructions_try.sfn` (the legacy `emit_runtime_call("has_exception",
...)` sites at the pre-#733 lines 290 and 417), and that file was fully
rewritten by #733. The "Files Affected" entry is stale from when M2.7c
was groomed before #733 landed.

Similarly, the issue scope put the new test under
`compiler/tests/perf/`, but no `perf/` subdirectory exists in the test
tree and `make test-e2e` only auto-discovers `compiler/tests/e2e/test_*.sh`.
Creating a new subdirectory plus a Makefile target for a single
regression test would be more scaffolding than the test deserves, so it
lands under `compiler/tests/e2e/` alongside the M2.7b runtime test
(`test_try_catch_frames.sh`). The auto-discovery picks it up
without further wiring.

## Verification

```bash
ulimit -v 8388608 && make compile && make test
# → 73/73 e2e, 13/13 capsules, full suite green

bash compiler/tests/e2e/test_call_emission_no_polling.sh build/native/sailfin
# → [test] PASS: no has_exception polling in lowering_core.sfn IR
#   [test] PASS: no has_exception polling in instructions_try.sfn IR
#   [test] PASS: no has_exception polling in try/catch fixture IR
#   [test] PASS: no has_exception polling in pure call-traffic IR
#   [summary] 4 passed, 0 failed

ulimit -v 8388608 && build/native/sailfin emit -o /tmp/lc.ll llvm \
  compiler/src/llvm/lowering/lowering_core.sfn
grep -cE '[[:space:]]call[[:space:]].*@sailfin_runtime_has_exception\b' /tmp/lc.ll
# → 0
```

The test deliberately matches `call` lines (not `declare` lines): the
compiler-side `RuntimeHelperDescriptor` for `has_exception` stays
registered for ABI completeness until M3 retires the C runtime body, so
a stray `declare i1 @sailfin_runtime_has_exception()` may still surface
in some modules. The polling regression — what M2.7c actually guards —
is a `call` to that symbol.

## Files Changed

- `compiler/tests/e2e/test_call_emission_no_polling.sh` (new, 213
  lines) — four cases pinning zero `has_exception` call sites in IR
  emitted from two heavy compiler modules
  (`lowering_core.sfn`, `instructions_try.sfn`), a try/catch fixture
  (the path that previously emitted polling after every call inside
  the try body), and a pure-call-traffic fixture (worst case: a
  regression that emits polling unconditionally, not just inside try
  bodies).

## Notes for review

- Pickup precheck (Phase 1.5) confirmed predecessor #404 (PR #733
  merge commit `9c439486`) is an ancestor of the pinned seed
  `v0.7.0-alpha.4`, so self-hosting picks up the polling-removed
  `instructions_try.sfn`. The legacy TLS-polling shape is no longer
  reachable from any code path in `main`.
- Unblocked items the issue listed as "Out:" remain out — this PR
  doesn't touch C runtime symbols (M3) and doesn't retire the
  `clear_exception` / `has_exception` / `take_exception` /
  `set_exception` entries in `effects.sfn`'s Try/Throw helper lists.
  The in-source comment in `effects.sfn:552-553` ("M2.7c retires the
  legacy entries once every emission site has cut over") becomes
  forward-looking; a follow-up cleanup wave can flip those without
  needing the same trilogy coordination.

---
_Generated by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_013reMCRzn3CxzWQ4P4nb1x8)_