### PR TITLE
refactor(cli): retire legacy --emit MODE file.sfn dispatch (#472)

### DIFF
--- a/compiler/src/cli_main.sfn
+++ b/compiler/src/cli_main.sfn
@@ -1797,6 +1797,15 @@ fn sailfin_cli_main(argv: string[]) -> int ![io, clock] {
 
     if strings_equal(cmd, "guillermo") { return handle_guillermo_command(); }
 
+    // Bare-file dispatch: `sailfin <file.sfn>` (no subcommand) compiles
+    // and runs the file, matching the convention `python script.py` /
+    // `node script.js` set. Replaces the legacy C-driver fallback in
+    // `runtime/native/src/native_driver.c` that called
+    // `compile_to_sailfin` / `compile_to_llvm` directly (retired in M5.4 / #472).
+    if args.length == 1 && _ends_with(cmd, ".sfn") {
+        return sailfin_cli_main_with_paths(["run", cmd], runtime_root, binary_dir);
+    }
+
     print("unknown command: " + cmd);
     print(_usage());
 

--- a/compiler/tests/e2e/test_cli_bare_file_dispatch.sh
+++ b/compiler/tests/e2e/test_cli_bare_file_dispatch.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# End-to-end test for the bare-file CLI dispatch added in M5.4 (#472).
+#
+# Pins `sailfin <file.sfn>` (no subcommand) → routes through the
+# Sailfin CLI's catch-all positional handler, which compiles and
+# runs the file as if `sailfin run <file.sfn>` had been invoked.
+#
+# This replaces the legacy C-driver fallback (the pre-M5.4
+# `--emit MODE file.sfn` path that called `compile_to_sailfin` /
+# `compile_to_llvm` directly from `native_driver.c`). Without an
+# explicit regression test, future CLI refactors could silently
+# break this user-visible form — common enough that `python
+# script.py` / `node script.js` set the expectation.
+
+set -euo pipefail
+
+BINARY="${1:?usage: test_cli_bare_file_dispatch.sh <compiler-binary>}"
+BINARY="$(realpath "$BINARY")"
+PASS=0
+FAIL=0
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+HELLO="$REPO_ROOT/examples/basics/hello-world.sfn"
+if [ ! -f "$HELLO" ]; then
+    echo "[test] FATAL: missing fixture $HELLO"
+    exit 2
+fi
+
+SCRATCH="$(mktemp -d -t sfn-cli-bare-file-XXXXXX)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+run_test() {
+    local name="$1"
+    shift
+    if "$@"; then
+        echo "[test] PASS: $name"
+        PASS=$((PASS + 1))
+    else
+        echo "[test] FAIL: $name"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+test_bare_file_runs_hello_world() {
+    local out_log="$SCRATCH/bare-out.log"
+    local err_log="$SCRATCH/bare-err.log"
+    local rc=0
+    (cd "$REPO_ROOT" && "$BINARY" examples/basics/hello-world.sfn) \
+        > "$out_log" 2> "$err_log" || rc=$?
+    if [ "$rc" -ne 0 ]; then
+        echo "[test]   bare-file invocation exited with code $rc (expected 0)"
+        echo "[test]   stdout:"
+        cat "$out_log"
+        echo "[test]   stderr:"
+        cat "$err_log"
+        return 1
+    fi
+    if ! grep -qx "Hello, Sailfin!" "$out_log"; then
+        echo "[test]   stdout did not contain expected 'Hello, Sailfin!' line:"
+        cat "$out_log"
+        return 1
+    fi
+    return 0
+}
+
+test_bare_file_rejects_unknown_extension() {
+    # Sanity check: bare-file dispatch only triggers on `.sfn` extension.
+    # An unrelated single positional must still hit the "unknown command"
+    # branch and exit non-zero, NOT silently invoke `run` on a non-Sailfin
+    # path.
+    local out_log="$SCRATCH/unknown-out.log"
+    local err_log="$SCRATCH/unknown-err.log"
+    local rc=0
+    "$BINARY" not-a-known-subcommand > "$out_log" 2> "$err_log" || rc=$?
+    if [ "$rc" -eq 0 ]; then
+        echo "[test]   expected non-zero exit for unknown command, got 0"
+        echo "[test]   stdout:"
+        cat "$out_log"
+        return 1
+    fi
+    if ! grep -q "unknown command" "$out_log" "$err_log" 2>/dev/null; then
+        echo "[test]   expected 'unknown command' diagnostic, got:"
+        echo "[test]   stdout:"
+        cat "$out_log"
+        echo "[test]   stderr:"
+        cat "$err_log"
+        return 1
+    fi
+    return 0
+}
+
+run_test "bare-file 'sailfin <file.sfn>' compiles and runs (prints expected output)" \
+    test_bare_file_runs_hello_world
+run_test "single non-.sfn positional still falls through to 'unknown command'" \
+    test_bare_file_rejects_unknown_extension
+
+echo "[summary] $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi

--- a/runtime/native/src/native_driver.c
+++ b/runtime/native/src/native_driver.c
@@ -24,12 +24,11 @@
 #include "sailfin_arena.h"
 #include "sailfin_runtime.h"
 
-// Entry point exported by the native compiler IR.
-extern char *compile_to_sailfin(char *source);
-extern char *compile_to_llvm(char *source);
-// NOTE: `native_cli_main` has historically varied in symbol spelling across
+// `native_cli_main` has historically varied in symbol spelling across
 // compiler versions (plain vs module-suffixed). Call the stable mangled symbol
-// for the underlying CLI implementation instead.
+// for the underlying CLI implementation instead. The Sailfin CLI is the sole
+// entry point — the legacy C-side `--emit MODE file.sfn` fallback retired in
+// M5.4 (#472); see `compiler/src/cli_main.sfn` for the dispatch.
 extern int64_t sailfin_cli_main__cli_main(SailfinPtrArray *argv);
 
 // Optional process-exit arena telemetry. Gated on SAILFIN_DUMP_ARENA_STATS=1
@@ -257,47 +256,6 @@ static void _trace_ptr_array(const char *label, const SailfinPtrArray *argv)
     }
 }
 
-static void _print_usage(FILE *stream)
-{
-    fprintf(stream, "usage: sailfin [--emit sailfin|llvm] <file.sfn>\n");
-}
-
-static char *_read_file(const char *path)
-{
-    FILE *f = fopen(path, "rb");
-    if (!f)
-    {
-        return NULL;
-    }
-    if (fseek(f, 0, SEEK_END) != 0)
-    {
-        fclose(f);
-        return NULL;
-    }
-    long n = ftell(f);
-    if (n < 0)
-    {
-        fclose(f);
-        return NULL;
-    }
-    if (fseek(f, 0, SEEK_SET) != 0)
-    {
-        fclose(f);
-        return NULL;
-    }
-
-    char *buf = (char *)malloc((size_t)n + 1);
-    if (!buf)
-    {
-        fclose(f);
-        return NULL;
-    }
-    size_t read_n = fread(buf, 1, (size_t)n, f);
-    fclose(f);
-    buf[read_n] = '\0';
-    return buf;
-}
-
 static int _write_file(const char *path, const char *contents)
 {
     if (!path)
@@ -480,183 +438,98 @@ int main(int argc, char **argv)
         _arena_stats_capture_label(argc, argv);
         atexit(_arena_stats_atexit);
     }
-    // If invoked with an explicit subcommand/flag, delegate to the Sailfin-native CLI.
-    // Otherwise, preserve the legacy interface: `sailfin [--emit MODE] file.sfn`.
-    if (argc >= 2)
+
+    // Every invocation delegates to the Sailfin CLI. Bare-file
+    // `sailfin file.sfn` is handled by the CLI's catch-all positional
+    // dispatch (compiles and runs the file); the legacy C-side
+    // `--emit MODE file.sfn` fallback retired in M5.4 (#472).
+    char *runtime_root = _resolve_runtime_root(argv[0]);
+
+    // Resolve the binary's own directory so the Sailfin CLI can
+    // look for .build-stamp / capsule.toml relative to the binary
+    // rather than the current working directory.
+    char *binary_dir = NULL;
     {
-        const char *first = argv[1];
-        bool is_cli = false;
-
-        if (strcmp(first, "emit") == 0 || strcmp(first, "emit-llvm-file") == 0 || strcmp(first, "build") == 0 || strcmp(first, "run") == 0 || strcmp(first, "test") == 0 || strcmp(first, "check") == 0 || strcmp(first, "version") == 0 || strcmp(first, "init") == 0 || strcmp(first, "publish") == 0 || strcmp(first, "package") == 0 || strcmp(first, "add") == 0 || strcmp(first, "login") == 0 || strcmp(first, "config") == 0 || strcmp(first, "guillermo") == 0 || strcmp(first, "fmt") == 0)
-        {
-            is_cli = true;
-        }
-        else if (strcmp(first, "-h") == 0 || strcmp(first, "--help") == 0)
-        {
-            is_cli = true;
-        }
-        else if (strcmp(first, "--version") == 0 || strcmp(first, "-V") == 0)
-        {
-            is_cli = true;
-        }
-        else if (strcmp(first, "--emit") == 0)
-        {
-            // Support `sailfin --emit llvm file.sfn` through the Sailfin CLI layer as well.
-            is_cli = true;
-        }
-
-        if (is_cli)
-        {
-            char *runtime_root = _resolve_runtime_root(argv[0]);
-
-            // Resolve the binary's own directory so the Sailfin CLI can
-            // look for .build-stamp / capsule.toml relative to the binary
-            // rather than the current working directory.
-            char *binary_dir = NULL;
-            {
-                char resolved_exe[PATH_MAX];
-                int got_exe = 0;
+        char resolved_exe[PATH_MAX];
+        int got_exe = 0;
 #if defined(__linux__)
-                // /proc/self/exe is the most reliable source on Linux —
-                // works even when argv[0] is a bare name from $PATH.
-                ssize_t len = readlink("/proc/self/exe", resolved_exe, PATH_MAX - 1);
-                if (len > 0)
-                {
-                    resolved_exe[len] = '\0';
-                    got_exe = 1;
-                }
-#elif defined(__APPLE__)
-                uint32_t bufsize = PATH_MAX;
-                if (_NSGetExecutablePath(resolved_exe, &bufsize) == 0)
-                {
-                    // _NSGetExecutablePath may return a relative path; canonicalize.
-                    char canonical[PATH_MAX];
-                    if (realpath(resolved_exe, canonical))
-                    {
-                        memcpy(resolved_exe, canonical, strlen(canonical) + 1);
-                    }
-                    got_exe = 1;
-                }
-#elif defined(_WIN32)
-                DWORD len = GetModuleFileNameA(NULL, resolved_exe, PATH_MAX);
-                if (len > 0 && len < PATH_MAX)
-                {
-                    got_exe = 1;
-                }
-#endif
-                // Fallback: try realpath(argv[0]) — works when argv[0] is
-                // an absolute or relative path, but NOT a bare $PATH name.
-                if (!got_exe && argv[0] && realpath(argv[0], resolved_exe))
-                {
-                    got_exe = 1;
-                }
-                if (got_exe)
-                {
-                    binary_dir = _dirname_dup(resolved_exe);
-                }
-            }
-
-            SailfinPtrArray args;
-            int64_t extra = (runtime_root ? 2 : 0) + (binary_dir ? 2 : 0);
-            char **argv_copy = (char **)malloc(
-                sizeof(char *) * (size_t)(argc - 1 + extra + 1));
-            if (!argv_copy)
-            {
-                fprintf(stderr, "out of memory building native argv\n");
-                free(runtime_root);
-                free(binary_dir);
-                return 1;
-            }
-
-            int64_t out_index = 0;
-            if (runtime_root)
-            {
-                argv_copy[out_index++] = "--runtime-root";
-                argv_copy[out_index++] = runtime_root;
-            }
-            if (binary_dir)
-            {
-                argv_copy[out_index++] = "--binary-dir";
-                argv_copy[out_index++] = binary_dir;
-            }
-            for (int i = 1; i < argc; i++)
-            {
-                argv_copy[out_index++] = argv[i];
-            }
-            argv_copy[out_index] = NULL;
-
-            args.data = argv_copy;
-            args.len = out_index;
-
-            _trace_ptr_array("native-cli", &args);
-
-            int64_t rc = sailfin_cli_main__cli_main(&args);
-            free(argv_copy);
-            free(runtime_root);
-            free(binary_dir);
-            return (int)rc;
-        }
-    }
-
-    const char *emit = "sailfin";
-    const char *path = NULL;
-
-    if (argc == 2)
-    {
-        if (strcmp(argv[1], "-h") == 0 || strcmp(argv[1], "--help") == 0)
+        // /proc/self/exe is the most reliable source on Linux —
+        // works even when argv[0] is a bare name from $PATH.
+        ssize_t len = readlink("/proc/self/exe", resolved_exe, PATH_MAX - 1);
+        if (len > 0)
         {
-            _print_usage(stdout);
-            return 0;
+            resolved_exe[len] = '\0';
+            got_exe = 1;
         }
-        path = argv[1];
-    }
-    else if (argc == 4 && strcmp(argv[1], "--emit") == 0)
-    {
-        emit = argv[2];
-        path = argv[3];
-    }
-    else
-    {
-        _print_usage(stderr);
-        return 2;
-    }
-
-    if (strcmp(emit, "sailfin") != 0 && strcmp(emit, "llvm") != 0)
-    {
-        fprintf(stderr, "unknown --emit mode: %s\n", emit);
-        _print_usage(stderr);
-        return 2;
-    }
-
-    char *source = _read_file(path);
-    if (!source)
-    {
-        fprintf(stderr, "failed to read: %s\n", path);
-        return 3;
-    }
-
-    char *out = NULL;
-    if (strcmp(emit, "llvm") == 0)
-    {
-        out = compile_to_llvm(source);
-    }
-    else
-    {
-        out = compile_to_sailfin(source);
-    }
-    if (!out)
-    {
-        fprintf(stderr, "compiler returned NULL\n");
-        free(source);
-        return 4;
+#elif defined(__APPLE__)
+        uint32_t bufsize = PATH_MAX;
+        if (_NSGetExecutablePath(resolved_exe, &bufsize) == 0)
+        {
+            // _NSGetExecutablePath may return a relative path; canonicalize.
+            char canonical[PATH_MAX];
+            if (realpath(resolved_exe, canonical))
+            {
+                memcpy(resolved_exe, canonical, strlen(canonical) + 1);
+            }
+            got_exe = 1;
+        }
+#elif defined(_WIN32)
+        DWORD len = GetModuleFileNameA(NULL, resolved_exe, PATH_MAX);
+        if (len > 0 && len < PATH_MAX)
+        {
+            got_exe = 1;
+        }
+#endif
+        // Fallback: try realpath(argv[0]) — works when argv[0] is
+        // an absolute or relative path, but NOT a bare $PATH name.
+        if (!got_exe && argv[0] && realpath(argv[0], resolved_exe))
+        {
+            got_exe = 1;
+        }
+        if (got_exe)
+        {
+            binary_dir = _dirname_dup(resolved_exe);
+        }
     }
 
-    fputs(out, stdout);
-    if (out[0] && out[strlen(out) - 1] != '\n')
+    SailfinPtrArray args;
+    int64_t extra = (runtime_root ? 2 : 0) + (binary_dir ? 2 : 0);
+    int64_t passthrough = argc > 1 ? (int64_t)(argc - 1) : 0;
+    char **argv_copy = (char **)malloc(
+        sizeof(char *) * (size_t)(passthrough + extra + 1));
+    if (!argv_copy)
     {
-        fputc('\n', stdout);
+        fprintf(stderr, "out of memory building native argv\n");
+        free(runtime_root);
+        free(binary_dir);
+        return 1;
     }
 
-    free(source);
-    return 0;
+    int64_t out_index = 0;
+    if (runtime_root)
+    {
+        argv_copy[out_index++] = "--runtime-root";
+        argv_copy[out_index++] = runtime_root;
+    }
+    if (binary_dir)
+    {
+        argv_copy[out_index++] = "--binary-dir";
+        argv_copy[out_index++] = binary_dir;
+    }
+    for (int i = 1; i < argc; i++)
+    {
+        argv_copy[out_index++] = argv[i];
+    }
+    argv_copy[out_index] = NULL;
+
+    args.data = argv_copy;
+    args.len = out_index;
+
+    _trace_ptr_array("native-cli", &args);
+
+    int64_t rc = sailfin_cli_main__cli_main(&args);
+    free(argv_copy);
+    free(runtime_root);
+    free(binary_dir);
+    return (int)rc;
 }


### PR DESCRIPTION
## Summary

- M5.4 — the C driver no longer carries a legacy bare-file fallback that called the Sailfin compile entry points directly. Every invocation routes through the Sailfin CLI.
- `sailfin <file.sfn>` (no subcommand) now dispatches as `sailfin run <file>` via a one-line catch-all in `sailfin_cli_main`'s unknown-command branch, matching `python script.py` / `node script.js` convention.
- `--emit MODE file.sfn` keeps working through the CLI's existing `--emit` flag handling; the `compile_to_sailfin` / `compile_to_llvm` symbols remain defined in the binary (still called from the Sailfin `--emit` path).

Closes #472

## Changes

- **`runtime/native/src/native_driver.c`** (–166 net lines) — removes the `is_cli` whitelist + the 60-line legacy fallback block (lines 601-661 in the pre-change file). Every argv passes through the Sailfin CLI unconditionally. The two `extern char *compile_to_sailfin(char *)` / `compile_to_llvm(char *)` declarations are deleted along with `_print_usage` / `_read_file` (which only existed for the fallback).
- **`compiler/src/cli_main.sfn`** (+9 lines) — adds the bare-file dispatch hook: `if args.length == 1 && _ends_with(cmd, ".sfn") { return sailfin_cli_main_with_paths(["run", cmd], runtime_root, binary_dir); }`.

## Acceptance Criteria

- [x] `grep -n "compile_to_sailfin\|compile_to_llvm" runtime/native/src/native_driver.c runtime/native/include/sailfin_runtime.h` returns empty.
- [x] `build/native/sailfin --emit sailfin examples/basics/hello-world.sfn` still emits `.sfn-asm`.
- [x] `build/native/sailfin --emit llvm examples/basics/hello-world.sfn` still emits LLVM IR.
- [x] `build/native/sailfin examples/basics/hello-world.sfn` (bare-file legacy form) runs end-to-end and prints "Hello, Sailfin!".
- [x] `make compile && make test-e2e && make check` pass.

## Verification

```bash
$ grep -n "compile_to_sailfin\|compile_to_llvm" runtime/native/src/native_driver.c runtime/native/include/sailfin_runtime.h
# (empty)

$ nm build/native/sailfin | grep -E 'T (compile_to_sailfin|compile_to_llvm)$'
00000000000136a0 T compile_to_llvm
00000000000131a0 T compile_to_sailfin

$ build/native/sailfin --emit sailfin examples/basics/hello-world.sfn | head -3
// Generated by Sailfin self-hosted emitter
import() from "sailfin/runtime";
fn main() [io] { ...

$ build/native/sailfin --emit llvm examples/basics/hello-world.sfn | head -1
source_filename = "examples/basics/hello-world.sfn"

$ build/native/sailfin examples/basics/hello-world.sfn
Hello, Sailfin!
```

`make check` (full self-host validation):
- unit 101/101 ✓
- integration 26/26 ✓
- e2e 74/74 ✓
- capsules 13/13 ✓
- stage2 == stage3 fixed-point ✓
- seedcheck promoted to `build/native/sailfin` ✓

## Files Changed

- `runtime/native/src/native_driver.c` — main(): -85 lines (legacy fallback + is_cli gate), helpers: -41 lines (_print_usage, _read_file), declarations: -2 lines (externs)
- `compiler/src/cli_main.sfn` — +9 lines (bare-file dispatch)

## Deviations from issue scope

- The issue's `Scope` mentions deleting two `extern` declarations from `runtime/native/include/sailfin_runtime.h`. The declarations actually lived in `native_driver.c` itself (not the header); the grep acceptance criterion targeting both files is satisfied.
- The "~200 lines" target in the issue body would require also deleting pre-existing dead helpers (`_write_file`, `_trace_llvm_snippet`, `_trace_llvm_dump`, etc.) that fell out of use in prior refactors. Per `.claude/rules/change-discipline.md` ("Keep changes minimal and focused"), this PR leaves those unrelated cleanups for a follow-up — the resulting file is 537 lines (vs 662 pre-change). The dead helpers are `static` and the build does not use `-Werror`, so they do not break compilation.

## Surprise note (worth recording for future grooming)

First `make check` run produced a flaky `build_report_test.sfn` failure in `test-unit` against the seedcheck binary (1/101 failed); re-running individually and in a second full `make check` cycle passed cleanly. This test exercises pure JSON serialization with no race surface — recommend filing a follow-up bug to investigate test-runner ordering / harness state between successive `sfn test` invocations. The failure was not reproducible and unrelated to this PR's surface.

Part of epic #451 (M5 — Sailfin entry point replaces `native_driver.c`).

https://claude.ai/code/session_01UPgSvYQgwoCMPwQSZfS6sX

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPgSvYQgwoCMPwQSZfS6sX)_