### PR TITLE
refactor(lowering): route core_operands coercion sites through emit_runtime_call (M1.7.2e)

### DIFF
--- a/compiler/src/llvm/expression_lowering/native/core_operands.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_operands.sfn
@@ -838,7 +838,11 @@ fn coerce_pointer_or_struct(operand: LLVMOperand, operand_type: string, target: 
             // byte-for-byte. Operand pre-coerced to `i8*` (matched in
             // the outer `operand_type == "i8*"` guard);
             // `emit_runtime_call`'s argument-coercion walk is a
-            // no-op here.
+            // no-op here. The result temp name is pre-computed
+            // (matching the `alloc_struct` pattern at line 1018)
+            // so the aggregate build can reference it without
+            // unwrapping `sl_result.operand`.
+            let len_temp = format_temp_name(temp_index);
             let sl_operands: LLVMOperand[] = [operand];
             let sl_result = emit_runtime_call("string.length", sl_operands, empty_runtime_call_overrides(), temp_index, current_lines);
             let mut _sl_di: int = 0;
@@ -848,7 +852,6 @@ fn coerce_pointer_or_struct(operand: LLVMOperand, operand_type: string, target: 
                 _sl_di += 1;
             }
             current_lines = sl_result.lines;
-            let len_value = sl_result.operand.value;
             let agg0 = format_temp_name(sl_result.temp_index);
             current_lines.push("  " + agg0
                 + " = insertvalue {i8*, i64} undef, i8* "
@@ -857,7 +860,7 @@ fn coerce_pointer_or_struct(operand: LLVMOperand, operand_type: string, target: 
             let agg1 = format_temp_name(sl_result.temp_index + 1);
             current_lines.push("  " + agg1 + " = insertvalue {i8*, i64} " + agg0
                 + ", i64 "
-                + len_value
+                + len_temp
                 + ", 1");
             let coerced = LLVMOperand { llvm_type: "{i8*, i64}", value: agg1 };
             return CoercionResult {
@@ -889,7 +892,12 @@ fn coerce_pointer_or_struct(operand: LLVMOperand, operand_type: string, target: 
             // byte-for-byte. Both call sites are pre-coerced to their
             // descriptor parameter types (`double` here, `i8*` for the
             // length recovery), so `emit_runtime_call`'s
-            // argument-coercion walk is a no-op at each step.
+            // argument-coercion walk is a no-op at each step. Result
+            // temp names are pre-computed (matching the `alloc_struct`
+            // pattern at line 1018) so the aggregate build can
+            // reference them without unwrapping nullable operands.
+            let as_string = format_temp_name(temp_index);
+            let len_temp = format_temp_name(temp_index + 1);
             let nts_operands: LLVMOperand[] = [operand];
             let nts_result = emit_runtime_call("number.to_string", nts_operands, empty_runtime_call_overrides(), temp_index, current_lines);
             let mut _nts_di: int = 0;
@@ -899,7 +907,6 @@ fn coerce_pointer_or_struct(operand: LLVMOperand, operand_type: string, target: 
                 _nts_di += 1;
             }
             current_lines = nts_result.lines;
-            let as_string = nts_result.operand.value;
             let sl_operand = LLVMOperand {
                 llvm_type: "i8*",
                 value: as_string
@@ -913,7 +920,6 @@ fn coerce_pointer_or_struct(operand: LLVMOperand, operand_type: string, target: 
                 _sl_di += 1;
             }
             current_lines = sl_result.lines;
-            let len_value = sl_result.operand.value;
             let agg0 = format_temp_name(sl_result.temp_index);
             current_lines.push("  " + agg0
                 + " = insertvalue {i8*, i64} undef, i8* "
@@ -922,7 +928,7 @@ fn coerce_pointer_or_struct(operand: LLVMOperand, operand_type: string, target: 
             let agg1 = format_temp_name(sl_result.temp_index + 1);
             current_lines.push("  " + agg1 + " = insertvalue {i8*, i64} " + agg0
                 + ", i64 "
-                + len_value
+                + len_temp
                 + ", 1");
             let coerced = LLVMOperand { llvm_type: "{i8*, i64}", value: agg1 };
             return CoercionResult {
@@ -940,8 +946,13 @@ fn coerce_pointer_or_struct(operand: LLVMOperand, operand_type: string, target: 
             // argument-coercion walk is a no-op for both the
             // `number.to_string` and `string.length` descriptors.
             // `native_signature` resolves to `sfn_number_to_str` /
-            // `sfn_str_len` byte-for-byte.
+            // `sfn_str_len` byte-for-byte. Result temp names are
+            // pre-computed (matching the `alloc_struct` pattern at
+            // line 1018) so the aggregate build can reference them
+            // without unwrapping nullable operands.
             let as_double = format_temp_name(temp_index);
+            let as_string = format_temp_name(temp_index + 1);
+            let len_temp = format_temp_name(temp_index + 2);
             current_lines.push("  " + as_double + " = sitofp i64 " + operand.value
                 + " to double");
             let cast_operand = LLVMOperand {
@@ -958,7 +969,6 @@ fn coerce_pointer_or_struct(operand: LLVMOperand, operand_type: string, target: 
                 _nts_di += 1;
             }
             current_lines = nts_result.lines;
-            let as_string = nts_result.operand.value;
             let sl_operand = LLVMOperand {
                 llvm_type: "i8*",
                 value: as_string
@@ -972,7 +982,6 @@ fn coerce_pointer_or_struct(operand: LLVMOperand, operand_type: string, target: 
                 _sl_di += 1;
             }
             current_lines = sl_result.lines;
-            let len_value = sl_result.operand.value;
             let agg0 = format_temp_name(sl_result.temp_index);
             current_lines.push("  " + agg0
                 + " = insertvalue {i8*, i64} undef, i8* "
@@ -981,7 +990,7 @@ fn coerce_pointer_or_struct(operand: LLVMOperand, operand_type: string, target: 
             let agg1 = format_temp_name(sl_result.temp_index + 1);
             current_lines.push("  " + agg1 + " = insertvalue {i8*, i64} " + agg0
                 + ", i64 "
-                + len_value
+                + len_temp
                 + ", 1");
             let coerced = LLVMOperand { llvm_type: "{i8*, i64}", value: agg1 };
             return CoercionResult {

--- a/compiler/src/llvm/expression_lowering/native/core_operands.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_operands.sfn
@@ -413,19 +413,25 @@ fn coerce_numeric_primitive(operand: LLVMOperand, operand_type: string, target: 
     }
     if target == "double" {
         if operand_type == "i8*" {
-            let temp_name = format_temp_name(temp_index);
-            current_lines.push("  " + temp_name
-                + " = call double @sfn_str_to_number(i8* "
-                + operand.value
-                + ")");
-            let coerced = LLVMOperand {
-                llvm_type: "double",
-                value: temp_name
-            };
+            // M1.7.2e (#722): route `i8* → double` through descriptor
+            // dispatch. The `string.to_number` descriptor's
+            // `native_signature` resolves the effective LLVM symbol to
+            // `sfn_str_to_number`, preserving the M2.5 swap byte-for-byte.
+            // Operand pre-coerced to `i8*` (matched in the outer
+            // `operand_type == "i8*"` guard); `emit_runtime_call`'s
+            // argument-coercion walk is a no-op here.
+            let stn_operands: LLVMOperand[] = [operand];
+            let stn_result = emit_runtime_call("string.to_number", stn_operands, empty_runtime_call_overrides(), temp_index, current_lines);
+            let mut _stn_di: int = 0;
+            loop {
+                if _stn_di >= stn_result.diagnostics.length { break; }
+                diagnostics.push(stn_result.diagnostics[_stn_di]);
+                _stn_di += 1;
+            }
             return CoercionResult {
-                lines: current_lines,
-                temp_index: temp_index + 1,
-                operand: coerced,
+                lines: stn_result.lines,
+                temp_index: stn_result.temp_index,
+                operand: stn_result.operand,
                 diagnostics: diagnostics
             };
         }
@@ -689,35 +695,57 @@ fn coerce_numeric_primitive(operand: LLVMOperand, operand_type: string, target: 
     }
     if target == "i8*" {
         if operand_type == "double" {
-            let temp_name = format_temp_name(temp_index);
-            current_lines.push("  " + temp_name
-                + " = call i8* @sfn_number_to_str(double "
-                + operand.value
-                + ")");
-            let coerced = LLVMOperand { llvm_type: "i8*", value: temp_name };
+            // M1.7.2e (#722): route `double → i8*` through descriptor
+            // dispatch. The `number.to_string` descriptor's
+            // `native_signature` resolves to `sfn_number_to_str`,
+            // preserving the M2.5 swap byte-for-byte. Operand
+            // pre-coerced to `double` (matched in the outer
+            // `operand_type == "double"` guard); `emit_runtime_call`'s
+            // argument-coercion walk is a no-op here.
+            let nts_operands: LLVMOperand[] = [operand];
+            let nts_result = emit_runtime_call("number.to_string", nts_operands, empty_runtime_call_overrides(), temp_index, current_lines);
+            let mut _nts_di: int = 0;
+            loop {
+                if _nts_di >= nts_result.diagnostics.length { break; }
+                diagnostics.push(nts_result.diagnostics[_nts_di]);
+                _nts_di += 1;
+            }
             return CoercionResult {
-                lines: current_lines,
-                temp_index: temp_index + 1,
-                operand: coerced,
+                lines: nts_result.lines,
+                temp_index: nts_result.temp_index,
+                operand: nts_result.operand,
                 diagnostics: diagnostics
             };
         }
     }
     if target == "i8*" {
         if operand_type == "i64" {
+            // M1.7.2e (#722): route `i64 → i8*` (sitofp then stringify)
+            // through descriptor dispatch. The intermediate `sitofp`
+            // pre-coerces the operand to `double`; emit_runtime_call's
+            // argument-coercion walk is a no-op for the
+            // `number.to_string` descriptor. The native_signature
+            // resolves to `sfn_number_to_str` byte-for-byte.
             let as_double = format_temp_name(temp_index);
-            let as_string = format_temp_name(temp_index + 1);
             current_lines.push("  " + as_double + " = sitofp i64 " + operand.value
                 + " to double");
-            current_lines.push("  " + as_string
-                + " = call i8* @sfn_number_to_str(double "
-                + as_double
-                + ")");
-            let coerced = LLVMOperand { llvm_type: "i8*", value: as_string };
+            let cast_operand = LLVMOperand {
+                llvm_type: "double",
+                value: as_double
+            };
+            let nts_operands: LLVMOperand[] = [cast_operand];
+            let nts_result = emit_runtime_call("number.to_string", nts_operands, empty_runtime_call_overrides(), temp_index
+                + 1, current_lines);
+            let mut _nts_di: int = 0;
+            loop {
+                if _nts_di >= nts_result.diagnostics.length { break; }
+                diagnostics.push(nts_result.diagnostics[_nts_di]);
+                _nts_di += 1;
+            }
             return CoercionResult {
-                lines: current_lines,
-                temp_index: temp_index + 2,
-                operand: coerced,
+                lines: nts_result.lines,
+                temp_index: nts_result.temp_index,
+                operand: nts_result.operand,
                 diagnostics: diagnostics
             };
         }
@@ -803,31 +831,38 @@ fn coerce_pointer_or_struct(operand: LLVMOperand, operand_type: string, target: 
     }
     if operand_type == "i8*" {
         if target == "{i8*, i64}" {
-            // M2.4a (#396): length recovery for the legacy `i8*` →
-            // `{i8*, i64}` shim routes through `@sfn_str_len`
-            // (`runtime/sfn/string.sfn`) instead of the C
-            // `@sailfin_runtime_string_length` entrypoint. The body
-            // still trampolines through the C scanner until the
-            // aggregate-typed locals flip lands; the symbol swap
-            // is the migration unit.
-            let len_temp = format_temp_name(temp_index);
-            current_lines.push("  " + len_temp + " = call i64 @sfn_str_len(i8* "
-                + operand.value
-                + ")");
-            let agg0 = format_temp_name(temp_index + 1);
+            // M2.4a (#396) + M1.7.2e (#722): length recovery for the
+            // legacy `i8*` → `{i8*, i64}` shim routes through the
+            // `string.length` descriptor; its `native_signature`
+            // resolves to `sfn_str_len`, preserving the M2.4a swap
+            // byte-for-byte. Operand pre-coerced to `i8*` (matched in
+            // the outer `operand_type == "i8*"` guard);
+            // `emit_runtime_call`'s argument-coercion walk is a
+            // no-op here.
+            let sl_operands: LLVMOperand[] = [operand];
+            let sl_result = emit_runtime_call("string.length", sl_operands, empty_runtime_call_overrides(), temp_index, current_lines);
+            let mut _sl_di: int = 0;
+            loop {
+                if _sl_di >= sl_result.diagnostics.length { break; }
+                diagnostics.push(sl_result.diagnostics[_sl_di]);
+                _sl_di += 1;
+            }
+            current_lines = sl_result.lines;
+            let len_value = sl_result.operand.value;
+            let agg0 = format_temp_name(sl_result.temp_index);
             current_lines.push("  " + agg0
                 + " = insertvalue {i8*, i64} undef, i8* "
                 + operand.value
                 + ", 0");
-            let agg1 = format_temp_name(temp_index + 2);
+            let agg1 = format_temp_name(sl_result.temp_index + 1);
             current_lines.push("  " + agg1 + " = insertvalue {i8*, i64} " + agg0
                 + ", i64 "
-                + len_temp
+                + len_value
                 + ", 1");
             let coerced = LLVMOperand { llvm_type: "{i8*, i64}", value: agg1 };
             return CoercionResult {
                 lines: current_lines,
-                temp_index: temp_index + 3,
+                temp_index: sl_result.temp_index + 2,
                 operand: coerced,
                 diagnostics: diagnostics
             };
@@ -846,60 +881,112 @@ fn coerce_pointer_or_struct(operand: LLVMOperand, operand_type: string, target: 
     // is recoverable, matching the SfnString invariant.
     if target == "{i8*, i64}" {
         if operand_type == "double" {
-            let as_string = format_temp_name(temp_index);
-            current_lines.push("  " + as_string
-                + " = call i8* @sfn_number_to_str(double "
-                + operand.value
-                + ")");
-            let len_temp = format_temp_name(temp_index + 1);
-            current_lines.push("  " + len_temp + " = call i64 @sfn_str_len(i8* "
-                + as_string
-                + ")");
-            let agg0 = format_temp_name(temp_index + 2);
+            // M1.7.2e (#722): route the M2.8 `double → {i8*, i64}`
+            // numeric-to-aggregate chain through descriptor dispatch.
+            // The `number.to_string` and `string.length` descriptors'
+            // `native_signature` fields resolve to `sfn_number_to_str`
+            // / `sfn_str_len`, preserving the M2.5 / M2.4a swaps
+            // byte-for-byte. Both call sites are pre-coerced to their
+            // descriptor parameter types (`double` here, `i8*` for the
+            // length recovery), so `emit_runtime_call`'s
+            // argument-coercion walk is a no-op at each step.
+            let nts_operands: LLVMOperand[] = [operand];
+            let nts_result = emit_runtime_call("number.to_string", nts_operands, empty_runtime_call_overrides(), temp_index, current_lines);
+            let mut _nts_di: int = 0;
+            loop {
+                if _nts_di >= nts_result.diagnostics.length { break; }
+                diagnostics.push(nts_result.diagnostics[_nts_di]);
+                _nts_di += 1;
+            }
+            current_lines = nts_result.lines;
+            let as_string = nts_result.operand.value;
+            let sl_operand = LLVMOperand {
+                llvm_type: "i8*",
+                value: as_string
+            };
+            let sl_operands: LLVMOperand[] = [sl_operand];
+            let sl_result = emit_runtime_call("string.length", sl_operands, empty_runtime_call_overrides(), nts_result.temp_index, current_lines);
+            let mut _sl_di: int = 0;
+            loop {
+                if _sl_di >= sl_result.diagnostics.length { break; }
+                diagnostics.push(sl_result.diagnostics[_sl_di]);
+                _sl_di += 1;
+            }
+            current_lines = sl_result.lines;
+            let len_value = sl_result.operand.value;
+            let agg0 = format_temp_name(sl_result.temp_index);
             current_lines.push("  " + agg0
                 + " = insertvalue {i8*, i64} undef, i8* "
                 + as_string
                 + ", 0");
-            let agg1 = format_temp_name(temp_index + 3);
+            let agg1 = format_temp_name(sl_result.temp_index + 1);
             current_lines.push("  " + agg1 + " = insertvalue {i8*, i64} " + agg0
                 + ", i64 "
-                + len_temp
+                + len_value
                 + ", 1");
             let coerced = LLVMOperand { llvm_type: "{i8*, i64}", value: agg1 };
             return CoercionResult {
                 lines: current_lines,
-                temp_index: temp_index + 4,
+                temp_index: sl_result.temp_index + 2,
                 operand: coerced,
                 diagnostics: diagnostics
             };
         }
         if operand_type == "i64" {
+            // M1.7.2e (#722): route the M2.8 `i64 → {i8*, i64}` chain
+            // (sitofp then stringify then length recovery) through
+            // descriptor dispatch. The intermediate `sitofp`
+            // pre-coerces to `double`; `emit_runtime_call`'s
+            // argument-coercion walk is a no-op for both the
+            // `number.to_string` and `string.length` descriptors.
+            // `native_signature` resolves to `sfn_number_to_str` /
+            // `sfn_str_len` byte-for-byte.
             let as_double = format_temp_name(temp_index);
             current_lines.push("  " + as_double + " = sitofp i64 " + operand.value
                 + " to double");
-            let as_string = format_temp_name(temp_index + 1);
-            current_lines.push("  " + as_string
-                + " = call i8* @sfn_number_to_str(double "
-                + as_double
-                + ")");
-            let len_temp = format_temp_name(temp_index + 2);
-            current_lines.push("  " + len_temp + " = call i64 @sfn_str_len(i8* "
-                + as_string
-                + ")");
-            let agg0 = format_temp_name(temp_index + 3);
+            let cast_operand = LLVMOperand {
+                llvm_type: "double",
+                value: as_double
+            };
+            let nts_operands: LLVMOperand[] = [cast_operand];
+            let nts_result = emit_runtime_call("number.to_string", nts_operands, empty_runtime_call_overrides(), temp_index
+                + 1, current_lines);
+            let mut _nts_di: int = 0;
+            loop {
+                if _nts_di >= nts_result.diagnostics.length { break; }
+                diagnostics.push(nts_result.diagnostics[_nts_di]);
+                _nts_di += 1;
+            }
+            current_lines = nts_result.lines;
+            let as_string = nts_result.operand.value;
+            let sl_operand = LLVMOperand {
+                llvm_type: "i8*",
+                value: as_string
+            };
+            let sl_operands: LLVMOperand[] = [sl_operand];
+            let sl_result = emit_runtime_call("string.length", sl_operands, empty_runtime_call_overrides(), nts_result.temp_index, current_lines);
+            let mut _sl_di: int = 0;
+            loop {
+                if _sl_di >= sl_result.diagnostics.length { break; }
+                diagnostics.push(sl_result.diagnostics[_sl_di]);
+                _sl_di += 1;
+            }
+            current_lines = sl_result.lines;
+            let len_value = sl_result.operand.value;
+            let agg0 = format_temp_name(sl_result.temp_index);
             current_lines.push("  " + agg0
                 + " = insertvalue {i8*, i64} undef, i8* "
                 + as_string
                 + ", 0");
-            let agg1 = format_temp_name(temp_index + 4);
+            let agg1 = format_temp_name(sl_result.temp_index + 1);
             current_lines.push("  " + agg1 + " = insertvalue {i8*, i64} " + agg0
                 + ", i64 "
-                + len_temp
+                + len_value
                 + ", 1");
             let coerced = LLVMOperand { llvm_type: "{i8*, i64}", value: agg1 };
             return CoercionResult {
                 lines: current_lines,
-                temp_index: temp_index + 5,
+                temp_index: sl_result.temp_index + 2,
                 operand: coerced,
                 diagnostics: diagnostics
             };


### PR DESCRIPTION
## Summary

- Migrate every raw `@sfn_str_len` / `@sfn_number_to_str` / `@sfn_str_to_number` emission in `coerce_numeric_primitive` and `coerce_pointer_or_struct` to descriptor-driven dispatch through `emit_runtime_call`.
- Closes the M1.7.2b scope gap surfaced by Copilot review on PR #720 (#497's `In:` scope was limited to `core_strings.sfn` / `core_ops_lowering.sfn` / `core_member_lowering.sfn`).
- Pre-compute the result temp names so the aggregate-build sites don't need to unwrap nullable `emit_runtime_call` operands — matches the existing `alloc_struct` / `mark_persistent` pattern in the same file (`core_operands.sfn:1018`).
- Document the recursion-safety contract at each migrated site — the operand is pre-coerced to the descriptor's parameter type, so `emit_runtime_call`'s argument-coercion walk is a no-op (no risk of infinite recursion through `coerce_operand_to_type`).

Closes #722

## Scope Note

The issue body's `In:` list cited 4 sites against the file as it existed when the issue was groomed. Two intervening landings have since shifted the surface:

- **M2.5 wave-2 (#403 / PR #747)** renamed `@sailfin_runtime_number_to_string` → `@sfn_number_to_str` and `@sailfin_runtime_string_to_number` → `@sfn_str_to_number`. The three originally-named sites at lines ~418 / ~694 / ~713 still exist with the renamed symbols.
- **M2.8 (#401 / PR #725)** added a numeric → `{i8*, i64}` aggregate chain inside `coerce_pointer_or_struct` (4 new raw emissions: 2× `@sfn_number_to_str`, 2× `@sfn_str_len`).

This PR migrates all 8 live sites — the 4 from the original `In:` (now with renamed symbols) plus the 4 M2.8 descendants in the same coercion blocks. Migrating only the original 4 would leave the `{i8*, i64}` chain half-descriptor-driven and still match `@sfn_str_len` in the acceptance grep (lines 855 / 886). The descriptors' `native_signature` fields resolve the effective LLVM symbol unchanged, so the migration is byte-for-byte safe.

## Acceptance Criteria

- [x] `grep -nE '@sailfin_runtime_number_to_string|@sailfin_runtime_string_to_number|@sfn_str_len' compiler/src/llvm/expression_lowering/native/core_operands.sfn` returns 0 live sites
- [x] Before/after IR diff empty for `examples/basics/loops.sfn`, `examples/basics/hello-world.sfn`, `examples/basics/structs.sfn`
- [x] A short comment at each migrated site documents the recursion-safety contract (pre-coerced operand → no-op inner coercion)
- [x] `sfn fmt --check` clean
- [x] CI green (`Build + Test [linux-x86_64]`, `Build + Test [macos-arm64]`, CodeQL, Copilot review all passing on the initial commit)

## Verification

```bash
# Acceptance grep: 0 live sites
$ grep -nE '@sailfin_runtime_number_to_string|@sailfin_runtime_string_to_number|@sfn_str_len' \
    compiler/src/llvm/expression_lowering/native/core_operands.sfn
(no matches)

# All 8 sites now dispatch through emit_runtime_call:
$ grep -nE 'emit_runtime_call\("(string\.length|number\.to_string|string\.to_number)"' \
    compiler/src/llvm/expression_lowering/native/core_operands.sfn
# 1× string.to_number  (i8* → double in coerce_numeric_primitive)
# 2× number.to_string  (double → i8*, i64 → i8* in coerce_pointer_or_struct)
# 1× string.length     (i8* → {i8*, i64} shim)
# 2× number.to_string  (M2.8 double/i64 → {i8*, i64})
# 2× string.length     (M2.8 length recovery inside numeric → aggregate)

# IR diff: byte-for-byte identical
$ diff /tmp/before.loops.ll   /tmp/after.loops.ll    # empty
$ diff /tmp/before.hello.ll   /tmp/after.hello.ll    # empty
$ diff /tmp/before.structs.ll /tmp/after.structs.ll  # empty

# sfn fmt --check clean
$ ulimit -v 8388608 && build/native/sailfin fmt --check \
    compiler/src/llvm/expression_lowering/native/core_operands.sfn
(clean)

# Local test suites (against the rebuild from this branch):
$ make test-unit         # 101/101 pass
$ make test-integration  # 26/26 pass
$ make test-capsules     # 13/13 pass
```

## Files Changed

- `compiler/src/llvm/expression_lowering/native/core_operands.sfn`
