### PR TITLE
M2.12a — pivot prelude facade onto runtime/sfn/* imports (#407)

### DIFF
--- a/runtime/prelude.sfn
+++ b/runtime/prelude.sfn
@@ -3,6 +3,28 @@
 // Runtime facade for Sailfin programs emitted by the self-hosted compiler.
 // These helpers delegate to the bootstrap runtime so Sailfin sources can run
 // without bespoke Python shims once the compiler self-hosts.
+//
+// M2.12a (#407): the facade is pivoting off the magic `runtime.*` namespace
+// onto direct imports from the Sailfin-native `runtime/sfn/*.sfn` modules.
+// This PR is mechanical alias replacement only — bindings whose Sailfin-side
+// signature already matches the new `sfn_*` entry points flip to the
+// imported symbol; everything else continues to resolve through the
+// `runtime.X` registry until M2.12b audits each caller. The `runtime`
+// namespace continues to resolve for any path not yet migrated.
+import { sfn_array_sfn_map } from "./sfn/array";
+import { sfn_sleep } from "./sfn/clock";
+import { sfn_throw } from "./sfn/exception";
+import { sfn_print_sfn } from "./sfn/io";
+import { sfn_process_run } from "./sfn/process";
+import { sfn_str_sfn_concat } from "./sfn/string";
+import {
+    sfn_is_array,
+    sfn_is_boolean,
+    sfn_is_callable,
+    sfn_is_number,
+    sfn_is_string
+} from "./sfn/type_meta";
+
 let console = runtime.console;
 let fs = runtime.fs;
 let http = runtime.http;
@@ -11,7 +33,7 @@ let websocket = runtime.websocket;
 let runtime_create_capability_grant = runtime.create_capability_grant;
 let runtime_create_filesystem_bridge = runtime.create_filesystem_bridge;
 let runtime_create_http_bridge = runtime.create_http_bridge;
-let runtime_sleep_fn = runtime.sleep;
+let runtime_sleep_fn = sfn_sleep;
 let runtime_monotonic_millis_fn = runtime.monotonic_millis;
 let runtime_log_execution_fn = runtime.logExecution;
 let runtime_to_debug_string_fn = runtime.to_debug_string;


### PR DESCRIPTION
## Summary

- Adds explicit imports of seven new Sailfin-native runtime modules (`clock`, `exception`, `io`, `string`, `array`, `process`, `type_meta`) at the top of `runtime/prelude.sfn`, making the facade's dependency on the Sailfin runtime layer visible in source rather than only via the magic `runtime.*` namespace.
- Mechanically flips `let runtime_sleep_fn = runtime.sleep;` to `let runtime_sleep_fn = sfn_sleep;` — the only alias whose Sailfin-side signature already matches its sfn-module counterpart `(float) -> void [clock]`, so no caller changes are required.
- Every other `runtime.X` alias continues to resolve through the helper registry until M2.12b audits each caller and removes the dead delegates (`Out:` scope per the issue).

Closes #407

## Acceptance Criteria

- [x] `runtime/prelude.sfn` imports from at least four new `runtime/sfn/*.sfn` modules (7 imported: `array`, `clock`, `exception`, `io`, `process`, `string`, `type_meta`).
- [x] No `runtime.` reference in `prelude.sfn` resolves to a symbol that doesn't exist in either C or Sailfin runtime (only `runtime.sleep` was changed; it now points at `sfn_sleep` which is defined in `runtime/sfn/clock.sfn`).
- [x] `make compile` passes (clean rebuild from the pinned v0.7.0-alpha.5 seed).
- [x] `make test` passes — unit 101/101, integration 26/26, e2e 76/76, capsules 13/13.

## Verification

```bash
ulimit -v 8388608 && make clean-build && make compile && make test
# All suites green.

grep -c '^import' runtime/prelude.sfn
# 7  (was 0 at baseline)

build/native/sailfin fmt --check runtime/prelude.sfn
# clean
```

## Files Changed

- `runtime/prelude.sfn` — +23/-1: seven `import { ... } from "./sfn/*";` lines, one alias binding flipped from the magic namespace to the imported symbol, plus a header comment describing the M2.12a → M2.12b sequencing.

## Notes for Reviewers

- Only `sfn_sleep` has a Sailfin-level signature that lines up cleanly with the existing alias use site. The `sfn_is_*` / `sfn_resolve_type` / `sfn_instance_of` / `sfn_throw` / `sfn_str_sfn_*` / `sfn_array_sfn_*` exports use `* u8` parameters today (per the M1.A.2 deferred aggregate-typed flip), while the prelude's callers pass `string` / `any`. Routing those through the magic namespace today is functionally identical to flipping them — the descriptor registry already overrides the LLVM symbol to the new `sfn_*` name via `native_signature` (PR #749) — so leaving them alone keeps this PR truly mechanical.
- M2.12b will audit each caller, drop the dead `runtime_*_fn` delegates, and (where the type system permits) flip the remaining bindings.

## Out of Scope

- Caller audit + dead-delegate cleanup (M2.12b, per the issue's `Out:` list).
- `@runtime` global deletion in `runtime_globals.ll` (M3).


---
_Generated by [Claude Code](https://claude.ai/code/session_014kqT8ubgg3hrp73zUokmJ6)_