### PR TITLE
refactor(rendering): retire per-target alias declare path (M1.7.5b, #502)

### DIFF
--- a/compiler/src/llvm/rendering.sfn
+++ b/compiler/src/llvm/rendering.sfn
@@ -266,56 +266,18 @@ fn render_runtime_helper_declarations(used_targets: string[], local_functions: N
                 + ")";
             lines.push(line);
             declared_symbols.push(effective_symbol);
-            // Also declare the target name if it differs from the effective
-            // symbol. This only satisfies IR validation (clang frontend);
-            // actual linking requires a runtime-side wrapper/alias for the
-            // target name.
-            //
-            // M2.4a (#396): when `native_signature` flipped the
-            // effective symbol, the descriptor's `symbol` field IS
-            // the legacy target name (e.g. `strings_equal`) — its
-            // only role now is to record what the C body used to be
-            // called for archeology. Emitting a `declare` for it
-            // would re-introduce the very dead reference the
-            // migration is trying to clear (acceptance criterion
-            // "the C symbols become unreferenced"). Skip the alias
-            // path whenever the symbol was flipped.
-            let mut emit_target_alias: boolean = true;
-            if effective_symbol != descriptor.symbol {
-                emit_target_alias = false;
-            }
-            if emit_target_alias {
-                if descriptor.target != effective_symbol {
-                    let sanitized_target = sanitize_symbol(descriptor.target);
-                    if sanitized_target != effective_symbol {
-                        // Issue #633: when an imported user function
-                        // already supplies a declare for the alias name
-                        // (e.g. `is_decimal_digit` exported from the
-                        // parser utilities, `monotonic_millis` exported
-                        // from the prelude wrapper), the imported declare
-                        // carries the source-level signature and would
-                        // otherwise be duplicated by this alias line.
-                        // The main `effective_symbol` declare above stays
-                        // intact so the C entrypoint (`sailfin_runtime_*`)
-                        // is still resolved for the wrapper's internal
-                        // call.
-                        if !string_array_contains(imported_symbols, sanitized_target) {
-                            if !string_array_contains(declared_symbols, sanitized_target) {
-                                if !string_array_contains(local_symbols, sanitized_target) {
-                                    let alias_line = "declare " + declare_return
-                                        + " @"
-                                        + sanitized_target
-                                        + "("
-                                        + parameter_text
-                                        + ")";
-                                    lines.push(alias_line);
-                                    declared_symbols.push(sanitized_target);
-                                }
-                            }
-                        }
-                    }
-                }
-            }
+            // M1.7.5b (#502): the per-target alias `declare` branch was
+            // retired here. It only mattered during the M2.4a coexistence
+            // period, when descriptor `target` names sometimes differed
+            // from the effective symbol the lowering actually emitted a
+            // `call` against. With the two-walker model live (M1.7.5a /
+            // #501 — `collect_runtime_helper_targets` plus the post-
+            // lowering `collect_runtime_helper_targets_from_lines` scan
+            // in `lowering_helpers.sfn`), every real call site is
+            // observed against its actual emitted symbol, so the alias
+            // declare became redundant. See
+            // `docs/conventions/runtime-helpers.md` for the descriptor-
+            // only contract that supersedes it.
         }
         index += 1;
     }

--- a/compiler/src/llvm/runtime_helpers.sfn
+++ b/compiler/src/llvm/runtime_helpers.sfn
@@ -3,6 +3,12 @@
 // Runtime helper descriptor definitions for LLVM lowering. These describe
 // the external C runtime functions that Sailfin code can call.
 //
+// New helpers must follow the descriptor-only contract documented in
+// `docs/conventions/runtime-helpers.md`: populate `native_signature`,
+// register the call site through `emit_runtime_call`, and add a
+// C trampoline only when a legitimate parameter-shape bridge is
+// required — never as the migration vehicle.
+//
 // =============================================================================
 // `native_signature` Rollout Plan (issue #461 / Epic #450 — M1)
 // =============================================================================

--- a/docs/conventions/runtime-helpers.md
+++ b/docs/conventions/runtime-helpers.md
@@ -1,0 +1,112 @@
+# Runtime Helper Conventions
+
+This is the canonical reference for adding new entries to the runtime
+helper registry in `compiler/src/llvm/runtime_helpers.sfn` and routing
+their call sites through the LLVM lowering. It supersedes the
+per-target alias `declare` path that was retired in M1.7.5b (#502).
+
+---
+
+## Descriptor-only contract
+
+New runtime helpers populate `native_signature` only. ABI shims (C
+trampolines) remain only for legitimate parameter-shape bridging —
+never as the migration vehicle.
+
+In practice this means:
+
+- **`native_signature` is the canonical name.** Set it to a
+  `sfn_<domain>_<op>` symbol (e.g. `sfn_str_concat`,
+  `sfn_array_push_slot`). The LLVM lowering emits the `call` against
+  that symbol; the linker resolves it to the helper's body, whether
+  that body lives in `runtime/sfn/...` (Sailfin-native) or
+  `runtime/native/src/...` (C, as a temporary bridge).
+- **`symbol` records the legacy C entrypoint** (typically
+  `sailfin_runtime_*`) for archeology. Once `native_signature` is
+  populated the alias declare for `symbol` is no longer emitted —
+  call sites flow through `native_signature` exclusively.
+- **`target`** is the lookup key used by `emit_runtime_call`. It
+  matches what the lowering writes as `runtime.<op>` in the
+  `.sfn-asm` IR; the dispatch maps it back to a descriptor at
+  emit time.
+
+## C trampolines are not the migration vehicle
+
+A C trampoline (`runtime/native/src/sailfin_runtime.c`) is justified
+only when the calling convention or parameter shape genuinely cannot
+be expressed in the source language we are migrating to. Examples
+that qualify:
+
+- A helper that needs to bridge a Sailfin `String` slot to a C
+  `const char *` while the Sailfin-side allocator is still in the
+  legacy ABI.
+- An intrinsic that calls into a libc surface (`memcpy`, `setjmp`)
+  with a fixed register class that the Sailfin source cannot yet
+  produce directly.
+
+A trampoline is **not** justified merely because the Sailfin body
+"is not written yet." That is the migration itself — write the
+Sailfin body, register it under `native_signature`, and route the
+call sites through `emit_runtime_call`. Adding a C trampoline as a
+permanent stand-in re-introduces exactly the legacy surface
+M1.7.5a / M1.7.5b worked to retire.
+
+## Call-site dispatch
+
+Every helper call site goes through `emit_runtime_call`
+(`compiler/src/llvm/expression_lowering/native/runtime_call.sfn`).
+The dispatch:
+
+1. Looks up the descriptor by `target`.
+2. Selects `native_signature` (preferred) or `symbol` (legacy).
+3. Emits the `call <type> @<symbol>(...)` line plus any pre/post
+   coercions described by the descriptor's `c_abi_return_type` or
+   `parameter_types` rows.
+
+The two collection passes (`collect_runtime_helper_targets` in
+`compiler/src/llvm/effects.sfn` and the post-lowering
+`collect_runtime_helper_targets_from_lines` in
+`compiler/src/llvm/lowering/lowering_helpers.sfn`) observe the
+emitted IR and add the discovered targets to `used_targets`. The
+preamble's `render_runtime_helper_declarations` then emits a single
+`declare` per used target's effective symbol — no aliases, no
+per-target fallbacks.
+
+## When the registry is the wrong tool
+
+The runtime helper registry is for descriptors that:
+
+- Are referenced by lowering at known call sites
+  (`emit_runtime_call` or the `expression_lowering/native/*`
+  modules), and
+- Need a `declare` line in every module that calls them.
+
+It is **not** the right place for:
+
+- Preamble-inlined declares (spawn/await family, arena primitives,
+  the rc-release helper, `sailfin_enum_tag_from_instruction_array`).
+  Those are emitted unconditionally by `render_llvm_preamble`
+  (`lowering_phase_render.sfn:110-112` and `:173-185`); the
+  preamble-inline filter in `render_runtime_helper_declarations`
+  skips them to avoid the `llvm-as: invalid redefinition` failure
+  #740 caught. New preamble-inlined helpers extend that filter
+  list rather than adding a descriptor.
+- Helpers reached only through prelude module-level let bindings
+  (`runtime_array_map_fn = runtime.array_map`, etc.). These are
+  invisible to both walkers and remain in
+  `seed_default_runtime_helpers` (`lowering_helpers.sfn`) with an
+  in-line WHY comment explaining why dynamic discovery cannot see
+  them.
+- `extern fn` declares emitted by the user-facing extern path. The
+  type-checker registration handles those; the runtime helper
+  registry is not involved.
+
+---
+
+## References
+
+- `compiler/src/llvm/runtime_helpers.sfn` — descriptor registry.
+- `compiler/src/llvm/rendering.sfn:render_runtime_helper_declarations` — preamble emission.
+- `compiler/src/llvm/lowering/lowering_helpers.sfn:collect_runtime_helper_targets_from_lines` — post-lowering scan that observes every emitted call site.
+- `compiler/src/llvm/lowering/lowering_helpers.sfn:seed_default_runtime_helpers` — last-resort top-up list for genuinely undiscoverable helpers (each entry carries a WHY comment).
+- Issues: #501 (M1.7.5a — dynamic discovery), #502 (M1.7.5b — alias path retired), #461 / Epic #450 — `native_signature` rollout history.


### PR DESCRIPTION
## Summary

- Deletes the `emit_target_alias` branch in `render_runtime_helper_declarations` (`compiler/src/llvm/rendering.sfn`) that emitted a redundant per-target alias declare during the M2.4a coexistence period. With the two-walker model live (#501 / PR #745), every real call site is observed against its actual emitted symbol — the alias declare is no longer needed.
- Adds `docs/conventions/runtime-helpers.md` codifying the descriptor-only contract for new helpers: populate `native_signature`, route through `emit_runtime_call`, and treat C trampolines as parameter-shape bridges only — never as the migration vehicle. Folds the M1.7.6 work item from epic #494 into a docs deliverable.
- Updates the `runtime_helpers.sfn` header comment to point at the new conventions doc.

Closes #502.

This is the final code sub-issue of epic #494 from the M1.7 dispatch architecture; sub-issue #721 (M1.7.2d, routing `sfn_str_concat_arena` through `emit_runtime_call`) is separate work and will close the epic when it ships.

## Acceptance criteria

- [x] The `if emit_target_alias` block is gone from `compiler/src/llvm/rendering.sfn` (`grep -n 'emit_target_alias\|alias_line' compiler/src/llvm/` returns nothing).
- [x] `docs/conventions/runtime-helpers.md` exists and is linked from `compiler/src/llvm/runtime_helpers.sfn`'s header comment.
- [x] **Full-IR declare sweep across `examples/basics/*.sfn` + `examples/concurrency/*.sfn`**: 48 alias declares drop; every dropped symbol verified to have zero `call` sites across all 19 fixtures (dead declares only). All fixtures still validate with `llvm-as`. This mirrors the IR-diff trade-off PR #745 documented — smaller IR, same callable surface, no module loses a needed declare.
- [x] `make check` green (full pipeline: stage2 == stage3 fixed point + 76/76 e2e + 13/13 capsules).
- [x] `sfn fmt --check` clean on `compiler/src/llvm/rendering.sfn` and `compiler/src/llvm/runtime_helpers.sfn`.
- [ ] **Epic #494 closes** — gated on #721 (M1.7.2d) also merging. This PR closes its own sub-issue.

## IR-diff note

The issue's verification snippet expected an empty `diff` against PR #501's baseline. Empirically the diff is non-empty in the same shape as PR #745: 48 dropped declares across the 19 fixtures, **all dead** — verified by grepping `call .* @<sym>(` against every fixture's emitted IR (zero hits for every dropped symbol). The acceptance criterion's parenthetical ("no module's preamble loses a needed declare") is satisfied: every dropped declare was for a symbol no module actually calls. Sample of dropped symbols: `@fsread`, `@fsreadFile`, `@runtime_array_filter_fn`, `@runtime_array_map_fn`, `@is_decimal_digit`, `@sfn_take_exception_frame`, `@stringconcat`, … — all `descriptor.target` sanitized aliases that the C body was once reached through.

## Verification

```bash
$ ulimit -v 8388608 && make compile
[rebuild] built build/native/sailfin (0.7.0-alpha.5+dev.<sha>.dirty)

$ ulimit -v 8388608 && make check
═══ unit: 101/101 passed, 0 failed ═══
═══ integration: 26/26 passed, 0 failed ═══
═══ e2e: 76/76 passed, 0 failed ═══
═══ capsules: 13/13 passed, 0 failed ═══
[check] stage2 == stage3: compiler is a fixed point ✓
[check] promoted seedcheck → build/native/sailfin

$ ulimit -v 8388608 && build/native/sailfin fmt --check \
    compiler/src/llvm/rendering.sfn \
    compiler/src/llvm/runtime_helpers.sfn
# clean

# IR-diff sweep — 48 declares dropped, all dead (zero call sites)
$ diff /tmp/m175b/declares.before_issue /tmp/m175b/declares.after_issue | grep '^<' | grep -oP '@[A-Za-z_][A-Za-z0-9_]*' | sort -u > /tmp/dropped.txt
$ wc -l /tmp/dropped.txt  # 48

$ while read sym; do
    grep -h "call .* ${sym}(" /tmp/m175b/calls/*.ll 2>/dev/null | grep -v '^declare ' | head -1
  done < /tmp/dropped.txt
# (no output — none are called)

# All 19 fixtures' IR still validates
$ for f in /tmp/m175b/calls/*.ll; do llvm-as "$f" -o /tmp/v.bc 2>/dev/null || echo FAIL: $f; done
# (no FAIL output)
```

## Files Changed

- `compiler/src/llvm/rendering.sfn` (-44 lines): delete `emit_target_alias` branch + its comment block, replace with a short pointer to `docs/conventions/runtime-helpers.md`.
- `compiler/src/llvm/runtime_helpers.sfn` (+6 lines): header comment points at the new conventions doc.
- `docs/conventions/runtime-helpers.md` (new, +95 lines): codifies the descriptor-only contract for new helpers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QniwD8HgcpG2NMMWVeMy89)_