### PR TITLE
feat(build): sfn build self-stamps build/native/.build-stamp (#516)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -904,31 +904,36 @@ rebuild:
 			[ -f "$$manifest_path" ] || touch "$$manifest_path"; \
 		fi; \
 	done
-	@# Write build stamp (version + git hash for dev builds).
-	@# `version.sfn::resolve_compiler_version` reads this file
-	@# first, so without it the binary would report whatever stale
-	@# stamp the previous build left on disk.
-	@cap_version=$$(sed -n 's/^version *= *"\([^"]*\)"/\1/p' compiler/capsule.toml); \
-	if [ -z "$$cap_version" ]; then \
-		echo "[rebuild][warn] could not extract version from compiler/capsule.toml; skipping build stamp" >&2; \
-	else \
-		git_tag=$$(git describe --exact-match --tags HEAD 2>/dev/null || true); \
-		if [ -n "$$git_tag" ]; then \
-			build_version="$$cap_version"; \
+	@# Build stamp: epic #513 phase 0.3 / issue #516 moved this into
+	@# `compiler/src/build_stamp.sfn::emit_compiler_build_stamp_if_applicable`,
+	@# called from `cli_main.sfn`'s `is_build` post-link path. The
+	@# block below is a transition bridge — once `/pin-seed` advances
+	@# past #516 (tracked by #757) the helper writes the stamp during
+	@# `sfn build -p compiler` and the `[ ! -f ... ]` guard makes
+	@# this whole block a no-op. Delete after #757 closes.
+	@if [ ! -f build/native/.build-stamp ]; then \
+		cap_version=$$(sed -n 's/^version *= *"\([^"]*\)"/\1/p' compiler/capsule.toml); \
+		if [ -z "$$cap_version" ]; then \
+			echo "[rebuild][warn] could not extract version from compiler/capsule.toml; skipping build stamp" >&2; \
 		else \
-			git_hash=$$(git rev-parse --short HEAD 2>/dev/null || true); \
-			git_dirty=""; \
-			if [ -n "$$git_hash" ]; then \
-				if ! git diff --quiet HEAD -- 2>/dev/null; then \
-					git_dirty=".dirty"; \
-				fi; \
-				build_version="$${cap_version}+dev.$${git_hash}$${git_dirty}"; \
+			git_tag=$$(git describe --exact-match --tags HEAD 2>/dev/null || true); \
+			if [ -n "$$git_tag" ]; then \
+				build_version="$$cap_version"; \
 			else \
-				build_version="$${cap_version}+dev"; \
+				git_hash=$$(git rev-parse --short HEAD 2>/dev/null || true); \
+				git_dirty=""; \
+				if [ -n "$$git_hash" ]; then \
+					if ! git diff --quiet HEAD -- 2>/dev/null; then \
+						git_dirty=".dirty"; \
+					fi; \
+					build_version="$${cap_version}+dev.$${git_hash}$${git_dirty}"; \
+				else \
+					build_version="$${cap_version}+dev"; \
+				fi; \
 			fi; \
+			echo "$$build_version" > build/native/.build-stamp; \
+			echo "[rebuild] build stamp (transition bridge): $$build_version"; \
 		fi; \
-		echo "$$build_version" > build/native/.build-stamp; \
-		echo "[rebuild] build stamp: $$build_version"; \
 	fi
 	@echo "[rebuild] built $(NATIVE_OUT)"
 

--- a/Makefile
+++ b/Makefile
@@ -700,6 +700,13 @@ rebuild:
 	@# recipe line. The `&&` chain ensures every diagnostic
 	@# message reaches the user before we exit.
 	@rm -f build/sailfin/program build/sailfin/program.ll
+	@# Invalidate any stale stamp from a prior rebuild so the
+	@# helper (post-#757) or the transition bridge below
+	@# always writes a fresh stamp reflecting the current git
+	@# HEAD + dirty state. Without this, `make rebuild` after a
+	@# new commit would leave the previous hash on disk and
+	@# `sfn --version` would report the wrong provenance.
+	@rm -f build/native/.build-stamp
 	@seed=$$(cat build/.seed-resolved); \
 	echo "[rebuild] running sfn build -p compiler (seed=$$seed)..."; \
 	build_rc=0; \
@@ -910,7 +917,10 @@ rebuild:
 	@# block below is a transition bridge — once `/pin-seed` advances
 	@# past #516 (tracked by #757) the helper writes the stamp during
 	@# `sfn build -p compiler` and the `[ ! -f ... ]` guard makes
-	@# this whole block a no-op. Delete after #757 closes.
+	@# this whole block a no-op. Delete only after BOTH #757 closes
+	@# (seed has the helper) AND #758 closes (self-host miscompilation
+	@# when `build/native/.build-stamp` is absent) — the bridge masks
+	@# #758 by guaranteeing the stamp always exists.
 	@if [ ! -f build/native/.build-stamp ]; then \
 		cap_version=$$(sed -n 's/^version *= *"\([^"]*\)"/\1/p' compiler/capsule.toml); \
 		if [ -z "$$cap_version" ]; then \

--- a/compiler/src/build_stamp.sfn
+++ b/compiler/src/build_stamp.sfn
@@ -1,0 +1,103 @@
+// compiler/src/build_stamp.sfn
+//
+// Build-stamp generation for `sfn build -p compiler`. Phase 0.3 of
+// epic #513 (Makefile slim-down): moves the assembly of the
+// `<capsule_version>+dev.<short_hash>[.dirty]` string out of the
+// Makefile shell shim (Makefile:907-932, now deleted) and into the
+// compiler driver itself.
+//
+// `version.sfn::resolve_compiler_version` consults
+// `<binary_dir>/.build-stamp` first when reporting `sfn --version`,
+// so the four cases below match the deleted Makefile shim
+// byte-for-byte:
+//   - tag at HEAD               → "<version>"
+//   - clean commit              → "<version>+dev.<short_hash>"
+//   - dirty working tree        → "<version>+dev.<short_hash>.dirty"
+//   - no git available at all   → "<version>+dev"
+//
+// Only the compiler capsule (`[capsule].name == "sailfin"`)
+// self-stamps; foreign capsule builds via `sfn build -p <other>`
+// never touch `.build-stamp`. The capsule-name gate is enforced
+// by `emit_compiler_build_stamp_if_applicable` below — the
+// other entry points (`compose_build_stamp_from`,
+// `compose_build_stamp`, `write_build_stamp`) are gate-agnostic
+// so tests can pin the four-case truth table without spawning a
+// build.
+import { _shell_read_cmd } from "./cli_commands_utils";
+
+// Pure formatter — the four-case truth table. Tests drive every
+// branch through this function so they don't depend on the
+// ambient git state of the checkout.
+fn compose_build_stamp_from(capsule_version: string, git_tag: string, git_hash: string, git_dirty: boolean) -> string {
+    if capsule_version.length == 0 { return ""; }
+    if git_tag.length > 0 { return capsule_version; }
+    if git_hash.length == 0 { return capsule_version + "+dev"; }
+    let mut suffix: string = "";
+    if git_dirty { suffix = ".dirty"; }
+    return capsule_version + "+dev." + git_hash + suffix;
+}
+
+// IO wrapper: shells out to read the tag, short-hash, and dirty
+// state, then funnels through the pure formatter. The git probes
+// all redirect stderr to /dev/null so a missing-`.git` checkout
+// (or an unborn HEAD) collapses cleanly to `<version>+dev`.
+fn compose_build_stamp(capsule_version: string) -> string ![io] {
+    if capsule_version.length == 0 { return ""; }
+    let git_tag = _shell_read_cmd("git describe --exact-match --tags HEAD 2>/dev/null");
+    let mut git_hash: string = "";
+    let mut git_dirty: boolean = false;
+    if git_tag.length == 0 {
+        git_hash = _shell_read_cmd("git rev-parse --short HEAD 2>/dev/null");
+        if git_hash.length > 0 {
+            // `git diff --quiet HEAD --` exits 0 on clean, non-zero
+            // on dirty. We wrap in `sh -c` and redirect both
+            // streams so the dirty probe never leaks output into
+            // the build log.
+            let dirty_rc = process.run(["sh", "-c", "git diff --quiet HEAD -- >/dev/null 2>&1"]);
+            if dirty_rc != 0 { git_dirty = true; }
+        }
+    }
+    return compose_build_stamp_from(capsule_version, git_tag, git_hash, git_dirty);
+}
+
+// Compose the canonical stamp path. Mirrors `sfn build --work-dir`:
+// an empty `work_dir` keeps the legacy in-tree
+// `build/native/.build-stamp` path; a non-empty value virtualizes
+// the stamp under `<work_dir>/native/.build-stamp`. The path stays
+// in lockstep with `version.sfn::resolve_compiler_version`'s
+// `<binary_dir>/.build-stamp` lookup (binary_dir is `build/native/`
+// in a repo checkout).
+fn compiler_stamp_path(work_dir: string) -> string {
+    if work_dir.length == 0 { return "build/native/.build-stamp"; }
+    if work_dir[work_dir.length - 1] == "/" {
+        return work_dir + "native/.build-stamp";
+    }
+    return work_dir + "/native/.build-stamp";
+}
+
+// Write the stamp string to `stamp_path` (with a trailing newline,
+// matching the deleted Makefile shim's `echo` behaviour). Returns
+// `true` on a successful write, `false` when either argument is
+// empty.
+fn write_build_stamp(stamp_path: string, capsule_version: string) -> boolean ![io] {
+    if stamp_path.length == 0 { return false; }
+    if capsule_version.length == 0 { return false; }
+    let stamp = compose_build_stamp(capsule_version);
+    if stamp.length == 0 { return false; }
+    fs.writeFile(stamp_path, stamp + "\n");
+    return true;
+}
+
+// Driver-side entry point. Gates on `[capsule].name == "sailfin"`
+// so only the compiler's own `sfn build -p compiler` writes a
+// stamp; foreign capsule builds never touch `.build-stamp`. Called
+// once per successful build from `cli_main.sfn`'s `is_build`
+// branch (both the library and the binary post-link paths) after
+// `_emit_capsule_artifact_sidecar`. Best-effort: a failed write
+// surfaces inside `fs.writeFile` itself and does not poison the
+// build, which has already produced the artifact.
+fn emit_compiler_build_stamp_if_applicable(cap_capsule_name: string, capsule_version: string, work_dir: string) ![io] {
+    if !strings_equal(cap_capsule_name, "sailfin") { return; }
+    let stamp_path = compiler_stamp_path(work_dir);
+    write_build_stamp(stamp_path, capsule_version);
+}

--- a/compiler/src/build_stamp.sfn
+++ b/compiler/src/build_stamp.sfn
@@ -3,12 +3,16 @@
 // Build-stamp generation for `sfn build -p compiler`. Phase 0.3 of
 // epic #513 (Makefile slim-down): moves the assembly of the
 // `<capsule_version>+dev.<short_hash>[.dirty]` string out of the
-// Makefile shell shim (Makefile:907-932, now deleted) and into the
-// compiler driver itself.
+// Makefile shell shim and into the compiler driver itself. The
+// original shim is preserved in `Makefile`'s rebuild target as a
+// guarded transition bridge (no-op once the stamp file exists)
+// until #757 (`/pin-seed` past this PR, so the seed contains the
+// helper below) and #758 (self-host miscompilation when the
+// stamp is absent) both close.
 //
 // `version.sfn::resolve_compiler_version` consults
 // `<binary_dir>/.build-stamp` first when reporting `sfn --version`,
-// so the four cases below match the deleted Makefile shim
+// so the four cases below match the prior Makefile shim
 // byte-for-byte:
 //   - tag at HEAD               → "<version>"
 //   - clean commit              → "<version>+dev.<short_hash>"
@@ -76,9 +80,13 @@ fn compiler_stamp_path(work_dir: string) -> string {
 }
 
 // Write the stamp string to `stamp_path` (with a trailing newline,
-// matching the deleted Makefile shim's `echo` behaviour). Returns
-// `true` on a successful write, `false` when either argument is
-// empty.
+// matching the prior Makefile shim's `echo` behaviour). Returns
+// `false` for the empty-input guards (no stamp_path, no version,
+// or `compose_build_stamp` declined). Returns `true` once
+// `fs.writeFile` has been invoked — that helper is void-returning
+// across the codebase and is treated as fire-and-forget; an
+// underlying disk error surfaces through the runtime, not the
+// return value.
 fn write_build_stamp(stamp_path: string, capsule_version: string) -> boolean ![io] {
     if stamp_path.length == 0 { return false; }
     if capsule_version.length == 0 { return false; }

--- a/compiler/src/cli_main.sfn
+++ b/compiler/src/cli_main.sfn
@@ -9,6 +9,7 @@ import {
     resolve_build_cache_config
 } from "./build_cache";
 import { BuildReport, build_report_to_json, empty_build_report } from "./build_report";
+import { emit_compiler_build_stamp_if_applicable } from "./build_stamp";
 import {
     CapsuleArtifactManifest,
     CapsuleArtifactModule,
@@ -1731,6 +1732,12 @@ fn sailfin_cli_main(argv: string[]) -> int ![io, clock] {
             // Stage C2a: per-capsule artifact sidecar for `-p` builds.
             // No-op for positional builds (cap_capsule_name == "").
             _emit_capsule_artifact_sidecar(cap_capsule_name, cap_version, "library", cap_entry_relative, out_path, capsule_result);
+            // Epic #513 Phase 0.3 / issue #516: the compiler
+            // self-stamps `build/native/.build-stamp` here so the
+            // Makefile can stop shelling out to git. Gated on
+            // `[capsule].name == "sailfin"` inside the helper,
+            // so foreign capsule builds are a no-op.
+            emit_compiler_build_stamp_if_applicable(cap_capsule_name, cap_version, work_dir);
             return 0;
         }
 
@@ -1758,6 +1765,11 @@ fn sailfin_cli_main(argv: string[]) -> int ![io, clock] {
         // Stage C2a: per-capsule artifact sidecar for `-p` builds.
         // No-op for positional builds (cap_capsule_name == "").
         _emit_capsule_artifact_sidecar(cap_capsule_name, cap_version, "binary", cap_entry_relative, exe_path, capsule_result);
+        // Epic #513 Phase 0.3 / issue #516: the compiler self-stamps
+        // `build/native/.build-stamp` here so the Makefile can stop
+        // shelling out to git. Gated on `[capsule].name == "sailfin"`
+        // inside the helper, so foreign capsule builds are a no-op.
+        emit_compiler_build_stamp_if_applicable(cap_capsule_name, cap_version, work_dir);
         return 0;
     }
 

--- a/compiler/tests/integration/build_stamp_test.sfn
+++ b/compiler/tests/integration/build_stamp_test.sfn
@@ -1,0 +1,135 @@
+// compiler/tests/integration/build_stamp_test.sfn
+//
+// Pins the four-case truth table for `compiler/src/build_stamp.sfn`
+// (epic #513 Phase 0.3 / issue #516). The pure formatter
+// `compose_build_stamp_from` is exercised directly so the test
+// doesn't depend on the ambient git state of the checkout; the
+// IO surface (`compose_build_stamp`, `write_build_stamp`,
+// `compiler_stamp_path`, `emit_compiler_build_stamp_if_applicable`)
+// is pinned by separate behavioural cases that only assert
+// state-independent invariants.
+import {
+    compiler_stamp_path,
+    compose_build_stamp,
+    compose_build_stamp_from,
+    emit_compiler_build_stamp_if_applicable,
+    write_build_stamp
+} from "../../src/build_stamp";
+
+// ---------------------------------------------------------------------------
+// (a) tag at HEAD → bare "<version>"
+// ---------------------------------------------------------------------------
+test "build_stamp: tag at HEAD yields bare version" {
+    let s = compose_build_stamp_from("0.5.10-alpha.11", "v0.5.10-alpha.11", "abc1234", false);
+    assert s == "0.5.10-alpha.11";
+}
+
+test "build_stamp: tag wins even when hash + dirty would otherwise apply" {
+    // A tag at HEAD is the canonical release shape; the dirty
+    // flag and short-hash must NOT bleed into a tagged build.
+    let s = compose_build_stamp_from("1.2.3", "v1.2.3", "deadbee", true);
+    assert s == "1.2.3";
+}
+
+// ---------------------------------------------------------------------------
+// (b) clean commit → "<version>+dev.<hash>"
+// ---------------------------------------------------------------------------
+test "build_stamp: clean commit appends +dev.<hash>" {
+    let s = compose_build_stamp_from("0.5.10-alpha.11", "", "abc1234", false);
+    assert s == "0.5.10-alpha.11+dev.abc1234";
+}
+
+// ---------------------------------------------------------------------------
+// (c) dirty commit → "<version>+dev.<hash>.dirty"
+// ---------------------------------------------------------------------------
+test "build_stamp: dirty commit appends +dev.<hash>.dirty" {
+    let s = compose_build_stamp_from("0.5.10-alpha.11", "", "abc1234", true);
+    assert s == "0.5.10-alpha.11+dev.abc1234.dirty";
+}
+
+// ---------------------------------------------------------------------------
+// (d) no git available → bare "<version>+dev"
+// ---------------------------------------------------------------------------
+test "build_stamp: empty tag + empty hash yields +dev only" {
+    let s = compose_build_stamp_from("0.5.10-alpha.11", "", "", false);
+    assert s == "0.5.10-alpha.11+dev";
+}
+
+test "build_stamp: empty hash with dirty=true still yields bare +dev" {
+    // `dirty` can only be true when a hash was successfully read;
+    // belt-and-braces: an inconsistent input must NOT produce
+    // `+dev..dirty` or any other malformed shape.
+    let s = compose_build_stamp_from("0.5.10-alpha.11", "", "", true);
+    assert s == "0.5.10-alpha.11+dev";
+}
+
+// ---------------------------------------------------------------------------
+// Empty-input guards
+// ---------------------------------------------------------------------------
+test "build_stamp: empty capsule_version returns empty string" {
+    assert compose_build_stamp_from("", "v1.0.0", "abc1234", false) == "";
+    assert compose_build_stamp_from("", "", "", false) == "";
+}
+
+test "build_stamp: write_build_stamp rejects empty stamp_path" ![io] {
+    let wrote = write_build_stamp("", "0.5.10-alpha.11");
+    assert wrote == false;
+}
+
+test "build_stamp: write_build_stamp rejects empty capsule_version" ![io] {
+    let wrote = write_build_stamp("build/sailfin/.build_stamp_test_unused", "");
+    assert wrote == false;
+}
+
+// ---------------------------------------------------------------------------
+// compiler_stamp_path: work_dir routing
+// ---------------------------------------------------------------------------
+test "build_stamp: empty work_dir maps to legacy in-tree path" {
+    assert compiler_stamp_path("") == "build/native/.build-stamp";
+}
+
+test "build_stamp: explicit work_dir virtualizes the stamp under <work_dir>/native/" {
+    assert compiler_stamp_path("/tmp/seedcheck") == "/tmp/seedcheck/native/.build-stamp";
+}
+
+test "build_stamp: trailing-slash work_dir does not double the separator" {
+    assert compiler_stamp_path("/tmp/seedcheck/") == "/tmp/seedcheck/native/.build-stamp";
+}
+
+// ---------------------------------------------------------------------------
+// Behavioural pins for the IO surface
+// ---------------------------------------------------------------------------
+test "build_stamp: compose_build_stamp guards empty capsule_version" ![io] {
+    // Regardless of git state, an empty version must not produce
+    // a stamp string. (Pinning the IO wrapper too because the
+    // pure formatter is also exercised on this branch.)
+    assert compose_build_stamp("") == "";
+}
+
+test "build_stamp: compose_build_stamp output starts with the capsule version" ![io] {
+    // Whatever git state the checkout is in, the output must
+    // begin with the version we passed in. The four shapes are
+    // pinned by the pure-formatter tests above; this pin guards
+    // against the IO wrapper accidentally swallowing or
+    // re-ordering its inputs.
+    let s = compose_build_stamp("1.2.3");
+    assert s.length >= 5;
+    assert substring(s, 0, 5) == "1.2.3";
+}
+
+test "build_stamp: emit_compiler_build_stamp_if_applicable is a no-op for foreign capsules" ![io] {
+    // The capsule-name gate is the only thing keeping
+    // end-user `sfn build -p someother/cap` from clobbering
+    // `build/native/.build-stamp`. Pin the gate here: writing
+    // with a non-`sailfin` name to a path that does not exist
+    // must NOT create the file.
+    // The gate check happens before any path composition, so the
+    // canonical assertion is that the would-be path is never
+    // written. Compose that path the same way the helper would
+    // (see `compiler_stamp_path("build/sailfin/.build_stamp_test_workdir")`)
+    // and confirm it's absent both before and after the call.
+    let would_be = "build/sailfin/.build_stamp_test_workdir/native/.build-stamp";
+    if fs.exists(would_be) { fs.deleteFile(would_be); }
+    emit_compiler_build_stamp_if_applicable("someother/capsule", "9.9.9", "build/sailfin/.build_stamp_test_workdir");
+    assert fs.exists(would_be) == false;
+}


### PR DESCRIPTION
## Summary

Epic #513 phase 0.3: moves the `<version>+dev.<short_hash>[.dirty]` stamp
assembly out of the 25-line `Makefile` shell shim and into
`compiler/src/build_stamp.sfn`. The helper fires from `cli_main.sfn`'s
`is_build` post-link path, gated on `[capsule].name == "sailfin"` so only
the compiler's own `sfn build -p compiler` self-stamps; foreign capsule
builds are a no-op.

Closes #516

## What's wired
- `compiler/src/build_stamp.sfn` — new module with three layers:
  - `compose_build_stamp_from(...)` — **pure** formatter for the four-case truth table (tag / clean / dirty / no-git).
  - `compose_build_stamp(...)` — IO wrapper that shells out via `_shell_read_cmd` + `process.run` to read tag/hash/dirty state.
  - `compiler_stamp_path(work_dir)` — empty `work_dir` keeps the legacy `build/native/.build-stamp` path; non-empty virtualizes under `<work_dir>/native/.build-stamp`.
  - `write_build_stamp(...)` — combines the above and writes with a trailing newline (matching the deleted `echo` shim).
  - `emit_compiler_build_stamp_if_applicable(...)` — the capsule-name gate; this is what `cli_main.sfn` calls.
- `compiler/src/cli_main.sfn` — one import + two call sites (library and binary post-link blocks).
- `compiler/tests/integration/build_stamp_test.sfn` — 15 tests pinning the truth table, empty-input guards, path routing, and the capsule-name gate (foreign-capsule no-op).

## What the Makefile does now
The original shell shim is wrapped in a `[ ! -f build/native/.build-stamp ]` guard as a **transition bridge**, not a permanent fixture. Two follow-ups must close before the bridge becomes safe to delete:

1. **#757** — `/pin-seed` past this PR. Until the seed contains `build_stamp.sfn::emit_compiler_build_stamp_if_applicable`, `make rebuild`'s `<seed> build -p compiler` won't self-stamp.
2. **#758** — Self-host bug surfaced by removing the bridge: `cli_main.sfn` emits an unmangled `compile_to_sailfin` reference when `build/native/.build-stamp` is absent and the build cache is empty, breaking the link. Reproducer in the issue. The root cause is mysterious (the compiler version contributes to cache keys but should not affect symbol mangling); the bridge ensures a stamp file always exists so the bug stays masked while #758 is investigated.

Once both close, the bridge in `Makefile`'s rebuild target reduces to `@echo "[rebuild] built $(NATIVE_OUT)"` in a 1-line follow-up.

## Verification

```bash
ulimit -v 8388608

# 1. Helper writes the canonical stamp via the new binary
make clean-build && make compile
cat build/native/.build-stamp
#  0.7.0-alpha.5+dev.4dc8cb0.dirty     (via the transition bridge today;
#                                       via the helper post-#757)
build/native/sailfin --version
#  sfn 0.7.0-alpha.5+dev.4dc8cb0.dirty

# 2. Helper actually fires when the NEW binary self-builds
WORK=$(mktemp -d)
build/native/sailfin build -p compiler --work-dir "$WORK"
cat "$WORK/native/.build-stamp"
#  0.7.0-alpha.5+dev.4dc8cb0.dirty   (written by the helper, not the Makefile)

# 3. Capsule-name gate: foreign capsule build does NOT write a stamp
rm -f build/native/.build-stamp
build/native/sailfin build -p /tmp/test-foreign-cap -o /tmp/out.o
test ! -f build/native/.build-stamp && echo OK
test ! -f /tmp/test-foreign-cap/native/.build-stamp && echo OK

# 4. Integration test pins the four-case truth table + IO surface
build/native/sailfin test compiler/tests/integration/build_stamp_test.sfn
#  PASS (all 15 tests passed)

# 5. Format check
build/native/sailfin fmt --check compiler/src/build_stamp.sfn \
    compiler/src/cli_main.sfn compiler/tests/integration/build_stamp_test.sfn
#  exit=0
```

## Acceptance criteria from #516

- [x] `compiler/src/build_stamp.sfn` exports `write_build_stamp` matching the signature.
- [x] `sfn build -p compiler` writes `build/native/.build-stamp` with the four canonical shapes (verified via the new binary; see #757 for the seed-side activation).
- [x] `sfn build -p someother/capsule` does NOT write any `.build-stamp` (gated by `cap_capsule_name == "sailfin"`).
- [x] `sfn --version` reports the stamp text verbatim.
- [x] `make compile` passes.
- [x] `make test` passes (with #758 noted as a pre-existing bug surfaced by stamp-less builds; the bridge masks it).
- [ ] **Defer** to follow-ups: full deletion of the Makefile shim. The shim is preserved as a guarded bridge until #757 closes (seed has the helper) AND #758 closes (compiler no longer miscompiles without a stamp file). See PR description above.

## Files Changed
- `compiler/src/build_stamp.sfn` (new, 104 lines)
- `compiler/src/cli_main.sfn` (1 import + 2 call sites + comments)
- `compiler/tests/integration/build_stamp_test.sfn` (new, 137 lines, 15 tests)
- `Makefile` (shim wrapped in `[ ! -f ... ]` guard with deletion-tracking comment)

## Followups
- **#757** — `/pin-seed` past this PR so the seed has the helper
- **#758** — Fix the self-host miscompilation that the stamp file's presence masks


---
_Generated by [Claude Code](https://claude.ai/code/session_01KTPE9gvANbiUVkfSFUwANN)_