### PR TITLE
fix(build): wipe build/cache in #516 bridge to unblock release-tag.yml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -945,6 +945,18 @@ rebuild:
 			echo "[rebuild] build stamp (transition bridge): $$build_version"; \
 		fi; \
 	fi
+	@# Cache invalidation companion to the bridge above: the seed
+	@# (pre-#757) populated `build/cache/` while resolving
+	@# `compiler_version` from `compiler/capsule.toml` (no stamp file
+	@# existed yet — we deleted it at the top of `rebuild`). With
+	@# the bridge now writing the stamp, downstream `sfn build -p
+	@# compiler` invocations (e.g. `test_work_dir_parity.sh`) resolve
+	@# the SAME version string and hit the seed's cached `cli_main.o`
+	@# — which carries the unmangled-symbol miscompilation tracked
+	@# by #758. Wiping the cache forces those downstream callers to
+	@# re-compile through the freshly-built (correct) compiler.
+	@# Delete with the rest of the bridge once #757 + #758 close.
+	@rm -rf build/cache
 	@echo "[rebuild] built $(NATIVE_OUT)"
 
 # =============================================================================


### PR DESCRIPTION
## Summary

The `0.7.0-alpha.6` release dispatch failed because `release-tag.yml`'s `Build + Test` legs (both Linux and macOS) hit the #758 self-host miscompilation through a cache-poisoning path the #516 bridge didn't anticipate.

## Root cause

`make rebuild`:
1. Deletes `build/native/.build-stamp` (fresh-stamp invariant).
2. Runs `<seed> build -p compiler`. The seed resolves `compiler_version` for cache keys → no stamp file exists → falls through to `compiler/capsule.toml` → returns `0.7.0-alpha.6` (at tag time). The seed stores 150 entries keyed under `0.7.0-alpha.6`, including the miscompiled `cli_main.o` from #758.
3. The bridge writes a new stamp. On a tagged commit `git describe --exact-match` succeeds, so the bridge writes the **bare** capsule version — exactly `0.7.0-alpha.6`, byte-for-byte identical to what the seed used as the cache-key version.
4. `make test` → `test_work_dir_parity.sh` → freshly-built compiler runs `sfn build -p compiler --work-dir /tmp/...`. Its cache-key version is `0.7.0-alpha.6` (read from the stamp), which **matches** the seed's stored entries → **cache hit** on the broken `cli_main.o` → link fails with `undefined reference to compile_to_sailfin`.

My local repro of #516 didn't catch this because `compiler/capsule.toml` on the branch was `0.7.0-alpha.5` and the bridge wrote `0.7.0-alpha.5+dev.<hash>.dirty` — different from the seed's `0.7.0-alpha.5` fallback → cache miss → fresh compile → correct output. The tag-mode bare-stamp condition only manifests inside `release-tag.yml`.

## Fix

Wipe `build/cache` at the end of `rebuild`, scoped inside the bridge block so it goes away with the rest of the bridge once both #757 (seed bump) and #758 (compiler fix) close. Downstream callers re-compile through the freshly-built (correct) compiler instead of re-using the seed's miscompiled artifacts. The cache repopulates with the new binary's output on first use.

## Verification

```bash
ulimit -v 8388608
make clean-build && make compile
ls build/cache    # absent — wiped by bridge — correct

# Mode 1: dev-checkout (bridge writes <version>+dev.<hash>.dirty)
WORK=$(mktemp -d)
build/native/sailfin build -p compiler --work-dir "$WORK"
# built: <work>/native/sailfin   (was already passing)

# Mode 2: tag-mode (bridge writes bare capsule version — CI's failure pattern)
echo "0.7.0-alpha.5" > build/native/.build-stamp
WORK2=$(mktemp -d)
build/native/sailfin build -p compiler --work-dir "$WORK2"
# built: <work2>/native/sailfin   (was failing before this PR; passes now)
```

## Next steps after merge

1. Re-dispatch the release: `gh workflow run release.yml --repo SailfinIO/sailfin -f channel=alpha -f bump=prerelease` (the tag `v0.7.0-alpha.6` already exists from the failed first attempt, so we'd bump to `v0.7.0-alpha.7`).
2. Once `release-tag.yml` uploads platform binaries, run `/pin-seed v0.7.0-alpha.7` to advance the seed past #516 — that unblocks #757.

## Related

- #516 — added the bridge being patched
- #757 — delete the bridge entirely (blocked on seed bump + #758)
- #758 — the actual compiler bug this bridge masks

---
_Generated by [Claude Code](https://claude.ai/code/session_01KTPE9gvANbiUVkfSFUwANN)_