### PR TITLE
tech-debt(build): delete the #516 Makefile transition bridge

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -700,13 +700,6 @@ rebuild:
 	@# recipe line. The `&&` chain ensures every diagnostic
 	@# message reaches the user before we exit.
 	@rm -f build/sailfin/program build/sailfin/program.ll
-	@# Invalidate any stale stamp from a prior rebuild so the
-	@# helper (post-#757) or the transition bridge below
-	@# always writes a fresh stamp reflecting the current git
-	@# HEAD + dirty state. Without this, `make rebuild` after a
-	@# new commit would leave the previous hash on disk and
-	@# `sfn --version` would report the wrong provenance.
-	@rm -f build/native/.build-stamp
 	@seed=$$(cat build/.seed-resolved); \
 	echo "[rebuild] running sfn build -p compiler (seed=$$seed)..."; \
 	build_rc=0; \
@@ -911,52 +904,6 @@ rebuild:
 			[ -f "$$manifest_path" ] || touch "$$manifest_path"; \
 		fi; \
 	done
-	@# Build stamp: epic #513 phase 0.3 / issue #516 moved this into
-	@# `compiler/src/build_stamp.sfn::emit_compiler_build_stamp_if_applicable`,
-	@# called from `cli_main.sfn`'s `is_build` post-link path. The
-	@# block below is a transition bridge — once `/pin-seed` advances
-	@# past #516 (tracked by #757) the helper writes the stamp during
-	@# `sfn build -p compiler` and the `[ ! -f ... ]` guard makes
-	@# this whole block a no-op. Delete only after BOTH #757 closes
-	@# (seed has the helper) AND #758 closes (self-host miscompilation
-	@# when `build/native/.build-stamp` is absent) — the bridge masks
-	@# #758 by guaranteeing the stamp always exists.
-	@if [ ! -f build/native/.build-stamp ]; then \
-		cap_version=$$(sed -n 's/^version *= *"\([^"]*\)"/\1/p' compiler/capsule.toml); \
-		if [ -z "$$cap_version" ]; then \
-			echo "[rebuild][warn] could not extract version from compiler/capsule.toml; skipping build stamp" >&2; \
-		else \
-			git_tag=$$(git describe --exact-match --tags HEAD 2>/dev/null || true); \
-			if [ -n "$$git_tag" ]; then \
-				build_version="$$cap_version"; \
-			else \
-				git_hash=$$(git rev-parse --short HEAD 2>/dev/null || true); \
-				git_dirty=""; \
-				if [ -n "$$git_hash" ]; then \
-					if ! git diff --quiet HEAD -- 2>/dev/null; then \
-						git_dirty=".dirty"; \
-					fi; \
-					build_version="$${cap_version}+dev.$${git_hash}$${git_dirty}"; \
-				else \
-					build_version="$${cap_version}+dev"; \
-				fi; \
-			fi; \
-			echo "$$build_version" > build/native/.build-stamp; \
-			echo "[rebuild] build stamp (transition bridge): $$build_version"; \
-		fi; \
-	fi
-	@# Cache invalidation companion to the bridge above: the seed
-	@# (pre-#757) populated `build/cache/` while resolving
-	@# `compiler_version` from `compiler/capsule.toml` (no stamp file
-	@# existed yet — we deleted it at the top of `rebuild`). With
-	@# the bridge now writing the stamp, downstream `sfn build -p
-	@# compiler` invocations (e.g. `test_work_dir_parity.sh`) resolve
-	@# the SAME version string and hit the seed's cached `cli_main.o`
-	@# — which carries the unmangled-symbol miscompilation tracked
-	@# by #758. Wiping the cache forces those downstream callers to
-	@# re-compile through the freshly-built (correct) compiler.
-	@# Delete with the rest of the bridge once #757 + #758 close.
-	@rm -rf build/cache
 	@echo "[rebuild] built $(NATIVE_OUT)"
 
 # =============================================================================


### PR DESCRIPTION
## Summary

- Deletes the entire `#516` transition bridge from `Makefile`'s `rebuild` target — both the top-of-rebuild `rm -f build/native/.build-stamp` and the trailing `if [ ! -f build/native/.build-stamp ]; then …; fi` shell shim, plus the `#760` `rm -rf build/cache` companion that was added to mask `#758`.
- With `.seed-version` pinned to `v0.7.0-alpha.7`, the seed contains `compiler/src/build_stamp.sfn::emit_compiler_build_stamp_if_applicable`, so `cli_main.sfn`'s `is_build` post-link path now owns stamp writing on its own. The `Makefile` no longer shells out to `sed`, `git describe`, `git rev-parse`, or `git diff` (epic `#513` Phase 0.3's actual finish line).
- Diff: `1 file changed, 53 deletions(-)`.

Closes #757
Closes #758

## On #758 (the masked self-host miscompilation)

`#758` was blocking this PR per its scope. I posted a [full diagnosis](https://github.com/SailfinIO/sailfin/issues/758#issuecomment-4548658222) — the short version is that the bug existed in the **alpha.5 seed** (which is what built the alpha.6 release that `release-tag.yml` failed on), but the source changes that landed between alpha.5 and alpha.6 (most plausibly `#756`, M1.7.5b's retirement of the per-target alias declare path) closed the underlying mangling divergence. The alpha.7 seed inherits the fix.

Direct evidence on this branch:

```
$ grep -nE "compile_to_sailfin" build/cache/v1/61/.../mod.ll   # cli_main.ll, seeded by alpha.7
651:declare i8* @compile_to_sailfin__main(i8*)
9553:  %t1838 = call i8* @compile_to_sailfin__main(i8* %t1837)
9558:  %t1840 = call i8* @compile_to_sailfin__main(i8* %t1839)
15610:define i8* @compile_to_sailfin__cli_main(i8* %a0) {
15612:  %t0 = call i8* @compile_to_sailfin__main(i8* %a0)
```

Every call site is properly mangled to `@compile_to_sailfin__main`. The tag-mode simulation (stamp = bare `0.7.0-alpha.7`, downstream `sfn build -p compiler` cache-hits 150 of 150 on the seed's output) links cleanly — this was the exact pattern `#760`'s cache wipe was masking.

## Acceptance Criteria (from #757)

- [x] `.seed-version` is pinned to a release whose binary contains `emit_compiler_build_stamp_if_applicable` — `v0.7.0-alpha.7` (`#759`/`#516` is in `v0.7.0-alpha.6` and onward).
- [x] `#758` is closed and `make clean-build && rm -f build/native/.build-stamp && make compile && WORK=$(mktemp -d) && build/native/sailfin build -p compiler --work-dir "$WORK"` exits 0 — verified below.
- [x] The transition bridge block in `Makefile`'s rebuild target is removed in full.
- [x] `make clean-build && make rebuild` produces a `build/native/.build-stamp` matching `<version>+dev.<hash>[.dirty]` written by the helper — confirmed by removing the file and re-running rebuild (the helper, not a shim, re-creates it).
- [x] `build/native/sailfin --version` reports the stamp string verbatim.
- [ ] CI's Linux + macOS Build+Test jobs both pass — handled by this PR's CI run.

## Verification

All commands run on this branch with `ulimit -v 8388608` and the alpha.7 seed:

```bash
# Full AC repro (this is the #758 success criterion)
make clean-build
rm -f build/native/.build-stamp
make compile
cat build/native/.build-stamp
# → 0.7.0-alpha.7+dev.3f46786f.dirty   (written by emit_compiler_build_stamp_if_applicable)
build/native/sailfin --version
# → sfn 0.7.0-alpha.7+dev.3f46786f.dirty
WORK=$(mktemp -d)
build/native/sailfin build -p compiler --work-dir "$WORK"
# → built: $WORK/native/sailfin   (cache misses=150, exit 0)
ls -la "$WORK/native/sailfin"
# → -rwxr-xr-x ... 3180152 bytes

# Helper-not-shim invariant
rm -f build/native/.build-stamp
make rebuild
cat build/native/.build-stamp
# → 0.7.0-alpha.7+dev.3f46786f.dirty   (re-created by helper; no shell shim runs)

# Existing e2e regression
compiler/tests/e2e/test_work_dir_parity.sh build/native/sailfin
# → 4 passed, 0 failed
```

The four-case truth table from `#516` was spot-checked on (c) dirty working tree (the natural state of this branch — the helper writes `.dirty`) and (a) tag-at-HEAD via `echo "0.7.0-alpha.7" > build/native/.build-stamp` (also succeeds; details in the `#758` diagnosis comment). Cases (b) clean commit and (d) `git rm -rf .git` sandbox are exercised by the `compose_build_stamp_from` unit tests under `build_stamp.sfn` and aren't worth a workflow round-trip.

## Files Changed

- `Makefile` — single hunk under `rebuild`, plus the `#760` companion block. Net `-53` lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jwf6TL77nzHLnty8nmHAYm)_