### PR TITLE
docs(runtime): link #766 tracking issue from sfn_array_sfn_map stub (#481)

### DIFF
--- a/runtime/sfn/array.sfn
+++ b/runtime/sfn/array.sfn
@@ -144,14 +144,17 @@ fn sfn_array_sfn_push_slot(data_ptr: * * u8, len_ptr: * i64, cap_ptr: * i64, ele
 }
 
 // `sfn_array_sfn_map(arr) -> arr` — placeholder per §2.3.3. Real
-// bodies require closures-with-capture (roadmap §0 item 5) plus
-// generic constraints (roadmap §2). Tracked as part of M2 epic #389;
-// a follow-up issue will land once the closure-capture milestone has
-// a concrete plan. Today the prelude's `array.map`/`filter`/`reduce`
-// stubs continue to forward to the C `sailfin_runtime_array_map`
-// trampoline (which itself returns the input array unchanged), so
-// this stub matches that observable behavior — preserve it byte-for-
-// byte until the spec body lights up.
+// bodies are tracked in #766 and gated on generic constraints
+// (post-1.0). Closures-with-capture (Epic #450 M1.5) has now
+// landed — env-capturing lambda emission shipped via #699 — so
+// the call-site closure surface is available; the remaining
+// blocker is the typed `SfnArray<T>` / `(T) -> U` signature shape,
+// which depends on generics. Until #766 ships real bodies, the
+// prelude's `array.map`/`filter`/`reduce` stubs continue to
+// forward to the C `sailfin_runtime_array_map` trampoline (which
+// itself returns the input array unchanged), so these stubs match
+// that observable behavior — preserve them byte-for-byte until
+// the spec body lights up.
 fn sfn_array_sfn_map(arr: * u8) -> * u8 { return arr; }
 
 fn sfn_array_sfn_filter(arr: * u8) -> * u8 { return arr; }


### PR DESCRIPTION
## Summary

Closes the third acceptance criterion of #481 — "If map/filter/reduce
stubbed, a follow-up tracking issue is filed and linked from the array
module." Files the follow-up issue (#766, real bodies for
`sfn_array_sfn_map`/`filter`/`reduce`, gated on generics) and updates
the stub comment in `runtime/sfn/array.sfn` to link it and acknowledge
that closures-with-capture (Epic #450 M1.5) has now landed via #699.

Closes #481

## Background — relationship to #399 / #466

`runtime/sfn/array.sfn` itself, the canonical `sfn_array_*` C trampolines,
the user-emission flip in `compiler/src/llvm/runtime_helpers.sfn`, the
e2e test `compiler/tests/e2e/test_runtime_array.sh`, and the
`runtime/native/capsule.toml` wiring all shipped under M2.6 via #466
(closing #399, the duplicate sibling issue filed earlier the same day).
#481's "In" scope therefore overlaps #466 entirely except for the
follow-up tracking requirement, which #466 explicitly deferred (PR
description: "the closure-gated stubs ... match the prelude's existing
return-input behaviour until closures-with-capture lights up real
bodies").

This PR ships the residual delta and lets #481 close.

## Acceptance Criteria (from #481)

- [x] `runtime/sfn/array.sfn` exposes the documented public symbols with
      `{ data, len, cap }` layout. — landed in #466 as `sfn_array_sfn_*`
      proof-of-life exports; bare canonical `sfn_array_*` names live as
      C trampolines until M3 per the established M2 coexistence pattern.
- [x] `compiler/tests/e2e/test_runtime_array.sh` exists and exercises
      create/push/concat/slice; covers map/filter/reduce in stub form.
      Test landed in #466; 7/7 passing.
- [x] If map/filter/reduce stubbed, a follow-up tracking issue is filed
      and linked from the array module. — **this PR**: #766 filed; comment
      updated.
- [x] `make compile` passes.
- [x] `make test` passes.

## Verification

```bash
ulimit -v 8388608
make compile                                                # self-hosts ✓
bash compiler/tests/e2e/test_runtime_array.sh build/native/sailfin
#   7 passed, 0 failed
make test
#   ═══ e2e: 77/77 passed, 0 failed ═══
#   ═══ capsules: 13/13 passed, 0 failed ═══
#   real    11m40.197s

build/native/sailfin fmt --check runtime/sfn/array.sfn ; echo $?
#   0
```

## Files Changed

- `runtime/sfn/array.sfn` — comment update on the map/filter/reduce stub
  block linking #766 and acknowledging closures-with-capture (#699) has
  landed. No code change; the three stubs remain byte-identical.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MaxGvJrZayFzrYwN3GTZ93)_