### PR TITLE
refactor(lowering): read NativeInstruction tag via Sailfin match (#626)

### DIFF
--- a/compiler/src/llvm/lowering/lowering_native_helpers.sfn
+++ b/compiler/src/llvm/lowering/lowering_native_helpers.sfn
@@ -234,10 +234,39 @@ fn get_enum_name_at(enums: NativeEnum[], idx: int) -> string {
 
 // ── NativeInstruction field accessors ────────────────────────────────
 fn get_instruction_tag(instructions: NativeInstruction[], idx: int) -> int {
-    // Delegates to a C runtime helper that reads the i32 tag directly from
-    // the array element's memory. Cleaning up this last C delegate is
-    // tracked separately (see #620 epic / #620d).
-    return sailfin_enum_tag_from_instruction_array(instructions, idx);
+    let instr = instructions[idx];
+    match instr {
+        NativeInstruction.Return { expression, span } => return 0,
+        NativeInstruction.Expression { expression, span } => return 1,
+        NativeInstruction.Let {
+            name,
+            mutable,
+            type_annotation,
+            value,
+            span,
+            value_span
+        } => return 2,
+        NativeInstruction.If { condition } => return 3,
+        NativeInstruction.Else => return 4,
+        NativeInstruction.EndIf => return 5,
+        NativeInstruction.For { target, iterable } => return 6,
+        NativeInstruction.EndFor => return 7,
+        NativeInstruction.Loop => return 8,
+        NativeInstruction.EndLoop => return 9,
+        NativeInstruction.Break => return 10,
+        NativeInstruction.Continue => return 11,
+        NativeInstruction.Match { expression } => return 12,
+        NativeInstruction.Case { pattern, guard } => return 13,
+        NativeInstruction.EndMatch => return 14,
+        NativeInstruction.Try => return 15,
+        NativeInstruction.Catch { name } => return 16,
+        NativeInstruction.Finally => return 17,
+        NativeInstruction.EndTry => return 18,
+        NativeInstruction.Throw { expression, span } => return 19,
+        NativeInstruction.Noop => return 20,
+        NativeInstruction.Unknown { text } => return 21
+    }
+    return 21;
 }
 
 fn get_instruction_let_name(instructions: NativeInstruction[], idx: int) -> string {

--- a/compiler/src/llvm/lowering/lowering_phase_render.sfn
+++ b/compiler/src/llvm/lowering/lowering_phase_render.sfn
@@ -99,17 +99,16 @@ fn render_llvm_preamble(module_name: string, type_context: TypeContext, trait_me
         lines.push("");
     }
 
-    // Async/future runtime types. Opaque-type defs and the seedcheck
-    // enum-tag reader declare stay inline — they are not function
-    // declares the descriptor dispatch handles (#500 / M1.7.4 scope
-    // `Out:`). The 18 spawn/await `declare` lines are sourced from the
-    // runtime helper registry via `async_runtime_declare_lines`, which
-    // walks the descriptors in registration order so the emitted IR
-    // stays byte-for-byte stable as the M4 concurrency work later
-    // extends or replaces the typed variants.
+    // Async/future runtime types. Opaque-type defs stay inline — they
+    // are not function declares the descriptor dispatch handles
+    // (#500 / M1.7.4 scope `Out:`). The 18 spawn/await `declare` lines
+    // are sourced from the runtime helper registry via
+    // `async_runtime_declare_lines`, which walks the descriptors in
+    // registration order so the emitted IR stays byte-for-byte stable
+    // as the M4 concurrency work later extends or replaces the typed
+    // variants.
     lines = extend_string_lines(lines, ["%SailfinFutureNumber = type opaque", "%SailfinFutureInt = type opaque", "%SailfinFutureBool = type opaque", "%SailfinFuturePtr = type opaque", "%SailfinFutureVoid = type opaque", "%SailfinFutureString = type opaque", ""]);
     lines = extend_string_lines(lines, async_runtime_declare_lines());
-    lines = extend_string_lines(lines, ["", "; Enum tag reader for seedcheck - reads i32 tag from NativeInstruction array", "declare double @sailfin_enum_tag_from_instruction_array(i8*, double)", ""]);
 
     // Vtable type definitions
     let vtable_type_lines = render_vtable_type_definitions(type_context);

--- a/compiler/src/llvm/rendering.sfn
+++ b/compiler/src/llvm/rendering.sfn
@@ -157,10 +157,7 @@ fn render_runtime_helper_declarations(used_targets: string[], local_functions: N
             //      (`async_runtime_declare_lines()` walks every
             //      descriptor where `is_async_runtime_target` is true
             //      and emits its declare directly into the preamble).
-            //   2. `sailfin_enum_tag_from_instruction_array` — the
-            //      seedcheck enum-tag reader has its declare hardcoded
-            //      in the preamble for separate-compilation visibility.
-            //   3. Arena-allocation primitives + the rc-release helper
+            //   2. Arena-allocation primitives + the rc-release helper
             //      (`alloc_struct` / `runtime.free` / `rc.release`).
             //      `render_llvm_preamble` (`lowering_phase_render.sfn:
             //      173-185`) writes their declares inline so the
@@ -179,9 +176,6 @@ fn render_runtime_helper_declarations(used_targets: string[], local_functions: N
             // actually needs.
             let mut _preamble_inlined: boolean = false;
             if is_async_runtime_target(descriptor.target) {
-                _preamble_inlined = true;
-            }
-            if descriptor.target == "sailfin_enum_tag_from_instruction_array" {
                 _preamble_inlined = true;
             }
             if descriptor.target == "alloc_struct" { _preamble_inlined = true; }

--- a/compiler/src/llvm/runtime_helpers.sfn
+++ b/compiler/src/llvm/runtime_helpers.sfn
@@ -898,13 +898,6 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
         target: "string_starts_with", symbol: "string_starts_with", return_type: "i1", parameter_types: ["i8*", "i8*"], effects: [], native_signature: null, c_abi_return_type: null
     });
 
-    // Enum tag reader — reads the i32 tag from a NativeInstruction array element.
-    // Used by get_instruction_tag in lowering_native_helpers.sfn for the seedcheck
-    // binary which cannot use match or the fixup pass to read enum tags.
-    descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "sailfin_enum_tag_from_instruction_array", symbol: "sailfin_enum_tag_from_instruction_array", return_type: "i64", parameter_types: ["i8*", "double"], effects: [], native_signature: null, c_abi_return_type: "double"
-    });
-
     return descriptors;
 }
 

--- a/compiler/tests/unit/runtime_int_helpers_test.sfn
+++ b/compiler/tests/unit/runtime_int_helpers_test.sfn
@@ -140,28 +140,6 @@ test "runtime int helper: runtime_grapheme_count_fn emits call+round+fptosi to i
     assert result.diagnostics.length == 0;
 }
 
-test "runtime int helper: sailfin_enum_tag_from_instruction_array emits call+round+fptosi to i64" ![io] {
-    // Two-argument helper; param_types `["i8*", "double"]` are
-    // intentionally unchanged (the second argument is a numeric
-    // index that already flows through the legacy double path —
-    // out of scope per #639).
-    let buf = _i8ptr_operand("%buf");
-    let idx = _double_operand("%idx");
-    let operands: LLVMOperand[] = [buf, idx];
-    let result = emit_runtime_call("sailfin_enum_tag_from_instruction_array", operands, empty_runtime_call_overrides(), 0, []);
-
-    assert result.lines.length == 3;
-    assert result.lines[0] == "  %t0 = call double @sailfin_enum_tag_from_instruction_array(i8* %buf, double %idx)";
-    assert result.lines[1] == "  %t1 = call double @round(double %t0)";
-    assert result.lines[2] == "  %t2 = fptosi double %t1 to i64";
-
-    assert result.operand != null;
-    assert result.operand.llvm_type == "i64";
-    assert result.operand.value == "%t2";
-    assert result.temp_index == 3;
-    assert result.diagnostics.length == 0;
-}
-
 test "runtime int helper: sailfin_intrinsic_runtime_arena_mark emits call+round+fptosi to i64" ![io] {
     let operands: LLVMOperand[] = [];
     let result = emit_runtime_call("sailfin_intrinsic_runtime_arena_mark", operands, empty_runtime_call_overrides(), 0, []);


### PR DESCRIPTION
## Summary

- Rewrites `get_instruction_tag` in `compiler/src/llvm/lowering/lowering_native_helpers.sfn` to use a `match NativeInstruction` returning each variant's integer tag, eliminating the C delegate `sailfin_enum_tag_from_instruction_array`.
- Drops the descriptor in `compiler/src/llvm/runtime_helpers.sfn`, the hardcoded `declare double @sailfin_enum_tag_from_instruction_array` line in `lowering_phase_render.sfn`, and the matching preamble-inlined skip in `rendering.sfn`.
- Removes the now-orphaned `runtime_int_helpers_test.sfn` test case that exercised `emit_runtime_call` dispatch for this helper (the `c_abi_return_type: "double"` coercion path is still covered by the sibling `runtime_grapheme_count_fn` test).
- Per the issue `Out:` scope, the C function in `runtime/native/src/sailfin_runtime.c:8430` stays in place — `#620f` retires it after `#620e` cleans up the consumer-side `tag == 21` fallback.

Closes #626

## Seed gate

The grooming comment on #626 (issue comment 4509123020) noted both candidate bare forms miscompile under `v0.6.0`. PR #708 (merged 2026-05-21, closes #704) fixed both — the `.tag`-field `sext` widening at the return boundary and the by-value match `extractvalue` path. `v0.7.0-alpha.1` was the first seed binary carrying the fix; `.seed-version` is currently pinned at `0.7.0-alpha.7`, which is well past the fix.

Per the architect comment: with both forms fixed, prefer the `match` body — it documents intent and doesn't rely on the `i32→i64` widening being correct for every callable position.

## Acceptance Criteria

- [x] `get_instruction_tag` no longer calls `sailfin_enum_tag_from_instruction_array`.
- [x] No `declare ... @sailfin_enum_tag_from_instruction_array` in emitted LLVM IR.
- [x] `make compile && make check` green (e2e 77/77, capsules 13/13, stage2 == stage3 fixed-point check, seedcheck promoted).
- [x] `compiler/tests/e2e/` still passes; integration tests still pass.
- [x] `runtime_helpers.sfn` annotation removed.

## Verification

```bash
ulimit -v 8388608 && make compile && make check
# → e2e: 77/77 passed, 0 failed
# → capsules: 13/13 passed, 0 failed
# → stage2 == stage3: compiler is a fixed point ✓
# → promoted seedcheck → build/native/sailfin

grep -rn "sailfin_enum_tag_from_instruction_array" compiler/src/   # → zero hits
build/native/sailfin emit -o /tmp/hello.ll llvm examples/basics/hello-world.sfn
grep -c "sailfin_enum_tag_from_instruction_array" /tmp/hello.ll     # → 0
```

## Files Changed

- `compiler/src/llvm/lowering/lowering_native_helpers.sfn` — rewrite `get_instruction_tag` using `match NativeInstruction`
- `compiler/src/llvm/lowering/lowering_phase_render.sfn` — drop the hardcoded `declare` line
- `compiler/src/llvm/rendering.sfn` — drop the preamble-inlined skip
- `compiler/src/llvm/runtime_helpers.sfn` — drop the descriptor + comment
- `compiler/tests/unit/runtime_int_helpers_test.sfn` — drop the now-orphaned dispatch test

## Follow-ups (not in this PR)

- Consumer-side `tag == 21` salvage cleanup in `instructions.sfn` / `instructions_loops.sfn` → #620e
- Delete the C function in `runtime/native/src/sailfin_runtime.c:8430` → #620f


---
_Generated by [Claude Code](https://claude.ai/code/session_0199M8jsLqqvYjUNxZvce7C7)_