### PR TITLE
refactor(runtime): drop _arena suffix from sfn_str_concat / sfn_str_append (#715)

### DIFF
--- a/compiler/src/llvm/expression_lowering/native/core_ops_lowering.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_ops_lowering.sfn
@@ -415,7 +415,7 @@ fn lower_binary_operation(expression: string, match: OperatorMatch, bindings: Pa
             let agg_name = format_temp_name(current_temp);
             current_temp += 1;
             current_lines.push("  " + agg_name
-                + " = call {i8*, i64} @sfn_str_concat_arena({i8*, i64} "
+                + " = call {i8*, i64} @sfn_str_concat({i8*, i64} "
                 + lhs_agg.operand.value
                 + ", {i8*, i64} "
                 + rhs_agg.operand.value
@@ -638,7 +638,7 @@ fn lower_binary_operation(expression: string, match: OperatorMatch, bindings: Pa
             // call site in this file for the full migration note).
             let agg_name = format_temp_name(current_temp);
             let line = "  " + agg_name
-                + " = call {i8*, i64} @sfn_str_concat_arena({i8*, i64} "
+                + " = call {i8*, i64} @sfn_str_concat({i8*, i64} "
                 + lhs_agg.operand.value
                 + ", {i8*, i64} "
                 + rhs_agg.operand.value

--- a/compiler/src/llvm/expression_lowering/native/core_strings.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_strings.sfn
@@ -156,7 +156,7 @@ fn emit_string_concat(left: LLVMOperand, right: LLVMOperand, temp_index: int, li
     // is the global pointer slot primed at module load.
     let agg_name = format_temp_name(right_aligned.temp_index);
     let line = "  " + agg_name
-        + " = call {i8*, i64} @sfn_str_concat_arena({i8*, i64} "
+        + " = call {i8*, i64} @sfn_str_concat({i8*, i64} "
         + left_aligned.operand.value
         + ", {i8*, i64} "
         + right_aligned.operand.value

--- a/compiler/src/llvm/runtime_helpers.sfn
+++ b/compiler/src/llvm/runtime_helpers.sfn
@@ -578,13 +578,15 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
         target: "string.length", symbol: "sailfin_runtime_string_length", return_type: "i64", parameter_types: ["i8*"], effects: [], native_signature: "sfn_str_len", c_abi_return_type: null
     });
     // M1.A — string.concat parameters lock to the SfnString aggregate
-    // ABI. The seed's call sites still emit
-    // `call i8* @sfn_str_concat({i8*, i64}, {i8*, i64})`, which keeps
-    // linking through the 2-arg C trampoline `sfn_str_concat`.
+    // ABI. Wave 1 pre-#714 emitted
+    // `call i8* @sfn_str_concat({i8*, i64}, {i8*, i64})` against a
+    // 2-arg C trampoline; #714 (M2.4b) introduced the 3-arg arena-
+    // aware ABI under the `_arena` suffix to coexist with the seed's
+    // 2-arg emission; #715 retired the 2-arg trampoline and promoted
+    // the arena-aware function to the bare canonical name.
     //
-    // M2.4b (#398): the descriptor now points at the arena-aware
-    // entrypoint `sfn_str_concat_arena`. The full call shape is
-    //   call {i8*, i64} @sfn_str_concat_arena({i8*, i64}, {i8*, i64}, ptr)
+    // The call shape is now
+    //   call {i8*, i64} @sfn_str_concat({i8*, i64}, {i8*, i64}, ptr)
     // where the third operand is `ptr @sfn_default_arena` (a global
     // pointer slot defined in `runtime/native/src/sailfin_runtime.c`,
     // primed at module load by a `__attribute__((constructor))`).
@@ -594,19 +596,16 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
     // recover the legacy `i8*` operand so the rest of the lowering
     // pipeline (which still treats string locals as `i8*`) is unchanged.
     //
-    // We deliberately do NOT reuse the bare `sfn_str_concat` symbol —
-    // the seed-built first-pass binary's IR still emits 2-arg calls
-    // against that name, and the C trampoline at that symbol keeps the
-    // 2-arg shape so the self-host link stays green. Once a future
-    // seed cut adopts the new ABI, a follow-up `seed-blocker` issue
-    // renames `sfn_str_concat_arena` back to the bare canonical name
-    // in a single rollback-safe PR.
+    // The C runtime keeps a thin `sfn_str_concat_arena` trampoline
+    // alive for one more release cycle so seed v0.7.0-alpha.7 (which
+    // still emits the `_arena` suffix in IR) links cleanly; the next
+    // seed bump retires that forwarder in a follow-up PR.
     //
     // `native_signature` is left equal to `symbol` so the declare /
-    // call paths uniformly use the arena-aware name with no special-
+    // call paths uniformly use the canonical name with no special-
     // casing in `rendering.sfn` / `emit_runtime_call`.
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "string.concat", symbol: "sfn_str_concat_arena", return_type: "{i8*, i64}", parameter_types: ["{i8*, i64}", "{i8*, i64}", "ptr"], effects: [], native_signature: "sfn_str_concat_arena", c_abi_return_type: null
+        target: "string.concat", symbol: "sfn_str_concat", return_type: "{i8*, i64}", parameter_types: ["{i8*, i64}", "{i8*, i64}", "ptr"], effects: [], native_signature: "sfn_str_concat", c_abi_return_type: null
     });
     // M2.4b (#398): `string.append` descriptor parked at the arena-
     // aware shape. No compiler emission site calls it today (the
@@ -614,12 +613,13 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
     // against `sailfin_runtime_string_append`, not via this descriptor),
     // so `native_signature` stays null — leaving the row as metadata
     // until the first caller wires through. The C symbol
-    // `sfn_str_append_arena` is defined alongside `sfn_str_concat_arena`
-    // for surface-area completeness. First parameter is `ptr` (opaque)
-    // so the eventual caller can decide whether it's an `i8**` legacy
-    // pointer or a real `{i8*, i64}*` once the SfnString flip lands.
+    // `sfn_str_append` (renamed from `sfn_str_append_arena` in #715) is
+    // defined alongside `sfn_str_concat` for surface-area completeness.
+    // First parameter is `ptr` (opaque) so the eventual caller can decide
+    // whether it's an `i8**` legacy pointer or a real `{i8*, i64}*` once
+    // the SfnString flip lands.
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "string.append", symbol: "sfn_str_append_arena", return_type: "void", parameter_types: ["ptr", "{i8*, i64}", "ptr"], effects: [], native_signature: null, c_abi_return_type: null
+        target: "string.append", symbol: "sfn_str_append", return_type: "void", parameter_types: ["ptr", "{i8*, i64}", "ptr"], effects: [], native_signature: null, c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
         target: "string.drop", symbol: "sailfin_runtime_string_drop", return_type: "void", parameter_types: ["i8*"], effects: [], native_signature: null, c_abi_return_type: null

--- a/compiler/tests/e2e/test_runtime_string_allocating.sh
+++ b/compiler/tests/e2e/test_runtime_string_allocating.sh
@@ -6,14 +6,15 @@
 #      typechecks / fmt-checks cleanly after the wave-1b
 #      additions.
 #   2. The emitted IR for a `let s = a + b` source defines the
-#      arena-aware call shape:
-#        %t = call {i8*, i64} @sfn_str_concat_arena({i8*, i64} ...,
-#                                                   {i8*, i64} ...,
-#                                                   ptr @sfn_default_arena)
+#      arena-aware call shape (#715 renamed the symbol from
+#      `sfn_str_concat_arena` to the bare canonical name):
+#        %t = call {i8*, i64} @sfn_str_concat({i8*, i64} ...,
+#                                             {i8*, i64} ...,
+#                                             ptr @sfn_default_arena)
 #        %p = extractvalue {i8*, i64} %t, 0
-#      and no longer emits the old 2-arg `@sfn_str_concat(...)`
-#      or any `@sailfin_runtime_string_concat*` form for fresh
-#      user emission.
+#      and no longer emits the legacy 2-arg `@sfn_str_concat(...)`
+#      shape, the `_arena`-suffixed transitional name, or any
+#      `@sailfin_runtime_string_concat*` form for fresh user emission.
 #   3. The global declare `@sfn_default_arena = external global ptr`
 #      lands in every emitted module (driven by
 #      `lowering_phase_render.sfn`).
@@ -21,9 +22,9 @@
 #      `sfn_str_sfn_append` proof-of-life symbols alongside the
 #      wave-1a infix family.
 #   5. The compiler binary exports the canonical C-side
-#      `sfn_str_concat_arena` / `sfn_str_append_arena` text
-#      symbols and the `sfn_default_arena` global symbol so the
-#      link surface is intact.
+#      `sfn_str_concat` / `sfn_str_append` text symbols and the
+#      `sfn_default_arena` global symbol so the link surface is
+#      intact.
 
 set -euo pipefail
 
@@ -114,8 +115,10 @@ SAILFIN_EOF
     fi
     # The full call shape must appear verbatim — the `, ptr @sfn_default_arena)`
     # tail is the discriminator that catches a regression to the 2-arg form.
-    if ! grep -qE 'call \{i8\*, i64\} @sfn_str_concat_arena\(\{i8\*, i64\} [^,]+, \{i8\*, i64\} [^,]+, ptr @sfn_default_arena\)' "$ll"; then
-        echo "[test]   expected 'call {i8*, i64} @sfn_str_concat_arena(..., ptr @sfn_default_arena)' in emitted IR:"
+    # `\b` anchors the symbol so a regression to the `_arena`-suffixed
+    # transitional name (#715) also fails this grep.
+    if ! grep -qE 'call \{i8\*, i64\} @sfn_str_concat\b\(\{i8\*, i64\} [^,]+, \{i8\*, i64\} [^,]+, ptr @sfn_default_arena\)' "$ll"; then
+        echo "[test]   expected 'call {i8*, i64} @sfn_str_concat(..., ptr @sfn_default_arena)' in emitted IR:"
         grep -nE 'call .* @sfn_str_concat' "$ll" | head -5
         return 1
     fi
@@ -128,11 +131,17 @@ SAILFIN_EOF
         return 1
     fi
     # Defensive regression: no fresh emission should call the legacy
-    # 2-arg `@sfn_str_concat` or the old `@sailfin_runtime_string_concat*`
-    # symbols from a user-level concat expression.
+    # 2-arg `@sfn_str_concat`, the `_arena`-suffixed transitional name
+    # (#715), or the old `@sailfin_runtime_string_concat*` symbols
+    # from a user-level concat expression.
     if grep -qE '= call i8\* @sfn_str_concat\(' "$ll"; then
         echo "[test]   regressed: fresh emission still uses the 2-arg @sfn_str_concat shape"
         grep -nE '= call i8\* @sfn_str_concat\(' "$ll" | head -3
+        return 1
+    fi
+    if grep -qE '@sfn_str_concat_arena\b' "$ll"; then
+        echo "[test]   regressed: fresh emission still uses the transitional @sfn_str_concat_arena name"
+        grep -nE '@sfn_str_concat_arena' "$ll" | head -3
         return 1
     fi
     if grep -qE '@sailfin_runtime_string_concat' "$ll"; then
@@ -155,8 +164,8 @@ test_global_declare_present() {
         echo "[test]   expected '@sfn_default_arena = external global ptr' declare in emitted IR"
         return 1
     fi
-    if ! grep -qE '^declare \{i8\*, i64\} @sfn_str_concat_arena\(\{i8\*, i64\}, \{i8\*, i64\}, ptr\)' "$ll"; then
-        echo "[test]   expected declare for @sfn_str_concat_arena with 3-arg ptr-tail signature"
+    if ! grep -qE '^declare \{i8\*, i64\} @sfn_str_concat\(\{i8\*, i64\}, \{i8\*, i64\}, ptr\)' "$ll"; then
+        echo "[test]   expected declare for @sfn_str_concat with 3-arg ptr-tail signature"
         grep -nE 'declare .* @sfn_str_concat' "$ll" | head -3
         return 1
     fi
@@ -172,7 +181,13 @@ test_compiler_binary_exports_arena_symbols() {
         return 1
     fi
     local missing=0
-    for sym in sfn_str_concat_arena sfn_str_append_arena; do
+    # #715: the canonical names are now bare `sfn_str_concat` /
+    # `sfn_str_append`. The `_arena`-suffixed forwarders stay
+    # exported one more release cycle so seed-built IR (which still
+    # emits the `_arena` suffix) keeps linking through the renamed
+    # bodies; this loop pins both name forms until the next seed
+    # bump retires the transitional forwarders.
+    for sym in sfn_str_concat sfn_str_append sfn_str_concat_arena sfn_str_append_arena; do
         if ! grep -qE "[[:space:]][Tt][[:space:]]_?${sym}\$" <<< "$nm_log"; then
             echo "[test]   compiler binary does not export defined text symbol ${sym}"
             missing=$((missing + 1))
@@ -197,9 +212,9 @@ test_compiler_binary_exports_arena_symbols() {
 run_test "sfn check runtime/sfn/string.sfn passes" test_check_clean
 run_test "sfn fmt --check runtime/sfn/string.sfn is canonical" test_fmt_clean
 run_test "sfn emit llvm produces define for every new sfn_str_sfn_* export" test_emit_define_shape
-run_test "let s = a + b lowers to arena-aware @sfn_str_concat_arena call" test_concat_lowers_to_arena_form
-run_test "emitted IR declares @sfn_default_arena and @sfn_str_concat_arena" test_global_declare_present
-run_test "compiler binary exports sfn_str_concat_arena / sfn_str_append_arena / sfn_default_arena" test_compiler_binary_exports_arena_symbols
+run_test "let s = a + b lowers to arena-aware @sfn_str_concat call" test_concat_lowers_to_arena_form
+run_test "emitted IR declares @sfn_default_arena and @sfn_str_concat" test_global_declare_present
+run_test "compiler binary exports sfn_str_concat / sfn_str_append (+ transitional _arena forwarders) / sfn_default_arena" test_compiler_binary_exports_arena_symbols
 
 echo ""
 echo "[summary] $PASS passed, $FAIL failed"

--- a/compiler/tests/e2e/test_runtime_string_allocating.sh
+++ b/compiler/tests/e2e/test_runtime_string_allocating.sh
@@ -115,9 +115,13 @@ SAILFIN_EOF
     fi
     # The full call shape must appear verbatim — the `, ptr @sfn_default_arena)`
     # tail is the discriminator that catches a regression to the 2-arg form.
-    # `\b` anchors the symbol so a regression to the `_arena`-suffixed
-    # transitional name (#715) also fails this grep.
-    if ! grep -qE 'call \{i8\*, i64\} @sfn_str_concat\b\(\{i8\*, i64\} [^,]+, \{i8\*, i64\} [^,]+, ptr @sfn_default_arena\)' "$ll"; then
+    # We anchor the symbol on the literal `\(` rather than a `\b` word
+    # boundary: BSD/macOS `grep -E` treats `\b` as a backspace (see
+    # `test_runtime_libc_skeleton.sh` lines 95-102), and the `(` that
+    # follows the symbol is unambiguous in LLVM call lines — a regression
+    # to `@sfn_str_concat_arena(` cannot collide because the `_arena`
+    # bytes appear before the `(`, not after `@sfn_str_concat`.
+    if ! grep -qE 'call \{i8\*, i64\} @sfn_str_concat\(\{i8\*, i64\} [^,]+, \{i8\*, i64\} [^,]+, ptr @sfn_default_arena\)' "$ll"; then
         echo "[test]   expected 'call {i8*, i64} @sfn_str_concat(..., ptr @sfn_default_arena)' in emitted IR:"
         grep -nE 'call .* @sfn_str_concat' "$ll" | head -5
         return 1
@@ -139,9 +143,12 @@ SAILFIN_EOF
         grep -nE '= call i8\* @sfn_str_concat\(' "$ll" | head -3
         return 1
     fi
-    if grep -qE '@sfn_str_concat_arena\b' "$ll"; then
+    # Anchor on the literal `(` for portability; `\b` is GNU-only and
+    # the BSD/macOS `grep -E` would treat it as a backspace (see
+    # `test_runtime_libc_skeleton.sh` lines 95-102).
+    if grep -qE '@sfn_str_concat_arena\(' "$ll"; then
         echo "[test]   regressed: fresh emission still uses the transitional @sfn_str_concat_arena name"
-        grep -nE '@sfn_str_concat_arena' "$ll" | head -3
+        grep -nE '@sfn_str_concat_arena\(' "$ll" | head -3
         return 1
     fi
     if grep -qE '@sailfin_runtime_string_concat' "$ll"; then

--- a/compiler/tests/e2e/test_string_aggregate_shape.sh
+++ b/compiler/tests/e2e/test_string_aggregate_shape.sh
@@ -177,8 +177,11 @@ test_string_concat_uses_aggregate_abi() {
         echo "[test]   regression: fresh emission still calls the 2-arg @sfn_str_concat shape"
         return 1
     fi
+    # Anchor on the literal `(` for portability; `\b` is GNU-only and
+    # the BSD/macOS `grep -E` would treat it as a backspace (see
+    # `test_runtime_libc_skeleton.sh` lines 95-102).
     local legacy_arena_called
-    legacy_arena_called="$(grep -cE '@sfn_str_concat_arena\b' "$LL" || true)"
+    legacy_arena_called="$(grep -cE '@sfn_str_concat_arena\(' "$LL" || true)"
     if [ "${legacy_arena_called:-0}" -ne 0 ]; then
         echo "[test]   regression: fresh emission still references @sfn_str_concat_arena (post-#715 transitional name)"
         return 1

--- a/compiler/tests/e2e/test_string_aggregate_shape.sh
+++ b/compiler/tests/e2e/test_string_aggregate_shape.sh
@@ -6,13 +6,13 @@
 #   - Literals lower to `{i8*, i64}` aggregates (data ptr + byte length).
 #   - `s.length` resolves to a direct `extractvalue ..., 1` (no
 #     `sailfin_runtime_string_length` call).
-#   - `+` on strings emits
-#     `call i8* @sfn_str_concat({i8*, i64} ..., {i8*, i64} ...)`.
-#     The `sfn_str_concat` C trampoline forwards to
-#     `sailfin_runtime_string_concat_v2` (kept link-stable for seed-
-#     compiled IR until the floor seed bumps); the legacy
-#     `sailfin_runtime_string_concat(char*, char*)` entrypoint stays
-#     exported so seed-compiled IR with the legacy ABI links too.
+#   - `+` on strings emits the arena-aware aggregate call shape
+#     (renamed in #715 to the bare canonical symbol):
+#       call {i8*, i64} @sfn_str_concat({i8*, i64}, {i8*, i64}, ptr @sfn_default_arena)
+#     followed by an `extractvalue {i8*, i64} %t, 0` that recovers
+#     the legacy `i8*` operand. The C-side `sfn_str_concat_arena`
+#     forwarder still exports (so seed-built IR keeps linking) but
+#     fresh emission must reach the bare symbol.
 #   - No consumer re-extracts a literal as `[N x i8]` (regression guard
 #     against the legacy `bitcast i8* to [N x i8]*` consumer pattern).
 #
@@ -138,26 +138,30 @@ test_no_array_consumer_pattern() {
 }
 
 # A6 — `string.concat` declared with the arena-aware SfnString ABI
-# and called the same way. M2.4b (#398) flipped the call shape to
+# and called the same way. M2.4b (#398) introduced the call shape
 #   call {i8*, i64} @sfn_str_concat_arena({i8*, i64}, {i8*, i64}, ptr @sfn_default_arena)
 # followed by an `extractvalue {i8*, i64} %t, 0` that recovers the
-# legacy `i8*` operand for the rest of the lowering pipeline. The
-# 2-arg `sfn_str_concat` trampoline stays exported so seed-compiled
-# IR keeps linking until the next seed bump retires both together;
-# fresh emission must not reach that trampoline directly nor the
-# legacy `sailfin_runtime_string_concat_v2` entrypoint.
+# legacy `i8*` operand for the rest of the lowering pipeline. #715
+# retired the legacy 2-arg `sfn_str_concat` trampoline and promoted
+# the arena-aware function to the bare canonical name, so the
+# emitted shape is now
+#   call {i8*, i64} @sfn_str_concat({i8*, i64}, {i8*, i64}, ptr @sfn_default_arena)
+# Fresh emission must reach the bare `@sfn_str_concat` symbol — not
+# the `_arena`-suffixed transitional forwarder, not the (now-deleted)
+# 2-arg shape, and not the legacy `sailfin_runtime_string_concat_v2`
+# entrypoint.
 test_string_concat_uses_aggregate_abi() {
     emit_ir_once || return 1
     local declared
-    declared="$(grep -cE '^declare \{i8\*, i64\} @sfn_str_concat_arena\(\{i8\*, i64\}, \{i8\*, i64\}, ptr\)' "$LL" || true)"
+    declared="$(grep -cE '^declare \{i8\*, i64\} @sfn_str_concat\(\{i8\*, i64\}, \{i8\*, i64\}, ptr\)' "$LL" || true)"
     if [ "${declared:-0}" -ne 1 ]; then
-        echo "[test]   expected exactly one arena-shape declare for sfn_str_concat_arena, got ${declared:-0}"
+        echo "[test]   expected exactly one arena-shape declare for sfn_str_concat, got ${declared:-0}"
         return 1
     fi
     local called
-    called="$(grep -cE 'call \{i8\*, i64\} @sfn_str_concat_arena\(\{i8\*, i64\} [^,]+, \{i8\*, i64\} [^,]+, ptr @sfn_default_arena\)' "$LL" || true)"
+    called="$(grep -cE 'call \{i8\*, i64\} @sfn_str_concat\(\{i8\*, i64\} [^,]+, \{i8\*, i64\} [^,]+, ptr @sfn_default_arena\)' "$LL" || true)"
     if [ "${called:-0}" -lt 1 ]; then
-        echo "[test]   expected at least one arena-shape call to sfn_str_concat_arena, got ${called:-0}"
+        echo "[test]   expected at least one arena-shape call to sfn_str_concat, got ${called:-0}"
         return 1
     fi
     # The result extract that gives downstream `i8*` consumers the data ptr.
@@ -171,6 +175,12 @@ test_string_concat_uses_aggregate_abi() {
     legacy_2arg_called="$(grep -cE 'call i8\* @sfn_str_concat\(' "$LL" || true)"
     if [ "${legacy_2arg_called:-0}" -ne 0 ]; then
         echo "[test]   regression: fresh emission still calls the 2-arg @sfn_str_concat shape"
+        return 1
+    fi
+    local legacy_arena_called
+    legacy_arena_called="$(grep -cE '@sfn_str_concat_arena\b' "$LL" || true)"
+    if [ "${legacy_arena_called:-0}" -ne 0 ]; then
+        echo "[test]   regression: fresh emission still references @sfn_str_concat_arena (post-#715 transitional name)"
         return 1
     fi
     local legacy_v2_called

--- a/compiler/tests/unit/runtime_call_dispatch_test.sfn
+++ b/compiler/tests/unit/runtime_call_dispatch_test.sfn
@@ -51,23 +51,23 @@ fn _ptr_operand(value: string) -> LLVMOperand {
     return LLVMOperand { llvm_type: "ptr", value: value };
 }
 
-test "emit_runtime_call: string.concat renders SfnString-aggregate call to sfn_str_concat_arena" ![io] {
-    // M2.4b (#398): the descriptor now points at the arena-aware
-    // `sfn_str_concat_arena` entrypoint with a third `ptr` argument
-    // that fresh user emission populates with `ptr @sfn_default_arena`.
-    // The return type is the SfnString aggregate `{i8*, i64}`; the
-    // hardcoded call-site emitters follow the `call` with an
-    // `extractvalue` to recover the legacy `i8*` operand. This
-    // fixture pins the call shape itself; the extract step lives in
-    // the call-site emitters and is covered by the e2e test
-    // `test_runtime_string_allocating.sh`.
+test "emit_runtime_call: string.concat renders SfnString-aggregate call to sfn_str_concat" ![io] {
+    // M2.4b (#398) + #715: the descriptor points at the arena-aware
+    // `sfn_str_concat` entrypoint (bare name post-#715 rename) with a
+    // third `ptr` argument that fresh user emission populates with
+    // `ptr @sfn_default_arena`. The return type is the SfnString
+    // aggregate `{i8*, i64}`; the hardcoded call-site emitters follow
+    // the `call` with an `extractvalue` to recover the legacy `i8*`
+    // operand. This fixture pins the call shape itself; the extract
+    // step lives in the call-site emitters and is covered by the e2e
+    // test `test_runtime_string_allocating.sh`.
     let lhs = _sfn_string_operand("%a");
     let rhs = _sfn_string_operand("%b");
     let arena = _ptr_operand("@sfn_default_arena");
     let operands: LLVMOperand[] = [lhs, rhs, arena];
     let result = emit_runtime_call("string.concat", operands, empty_runtime_call_overrides(), 0, []);
     assert result.lines.length == 1;
-    assert result.lines[0] == "  %t0 = call {i8*, i64} @sfn_str_concat_arena({i8*, i64} %a, {i8*, i64} %b, ptr @sfn_default_arena)";
+    assert result.lines[0] == "  %t0 = call {i8*, i64} @sfn_str_concat({i8*, i64} %a, {i8*, i64} %b, ptr @sfn_default_arena)";
     assert result.temp_index == 1;
     assert result.operand != null;
     assert result.diagnostics.length == 0;

--- a/runtime/native/include/sailfin_runtime.h
+++ b/runtime/native/include/sailfin_runtime.h
@@ -132,6 +132,15 @@ extern "C"
     // (the address of the global pointer declared below) so these
     // signatures receive `SfnArena **` and dereference once. See
     // sailfin_runtime.c for the full migration note.
+    //
+    // #715 (post-#714 rename): the canonical names are the bare
+    // `sfn_str_concat` / `sfn_str_append`. The `_arena`-suffixed
+    // declarations are transitional trampolines kept until the
+    // seed cut after #715 lands — seed v0.7.0-alpha.7 still emits
+    // `@sfn_str_concat_arena` IR against this entrypoint. The next
+    // seed bump retires both `_arena` declarations in a follow-up.
+    SfnString sfn_str_concat(SfnString a, SfnString b, SfnArena **arena_slot);
+    void sfn_str_append(SfnString *dst, SfnString suffix, SfnArena **arena_slot);
     SfnString sfn_str_concat_arena(SfnString a, SfnString b, SfnArena **arena_slot);
     void sfn_str_append_arena(SfnString *dst, SfnString suffix, SfnArena **arena_slot);
     extern SfnArena *sfn_default_arena;

--- a/runtime/native/src/sailfin_runtime.c
+++ b/runtime/native/src/sailfin_runtime.c
@@ -2051,7 +2051,7 @@ void sailfin_runtime_print_error(char *msg) { _print_line(stderr, "[error] ", ms
  * verbatim to the legacy `sailfin_runtime_print_*` entrypoints —
  * today's SfnString.data is NUL-terminated end-to-end (literal
  * lowering writes a trailing 0 past the byte payload, and the
- * arena-routed concat in `sfn_str_concat_arena` preserves the +1
+ * arena-routed concat in `sfn_str_concat` preserves the +1
  * NUL byte), so the legacy `char *`-consuming bodies remain
  * correct without a second formatting strategy. Once M2.4b/M2.8
  * length-aware print bodies arrive, the forwarding here retires
@@ -2461,24 +2461,10 @@ char **sailfin_runtime_get_environ(void)
     return environ;
 }
 
-/* M1.2 (#461): SfnString migration trampoline for string concatenation.
- * Mirrors the M2.4a wave-1 trampolines above (`sfn_str_len`, `sfn_str_eq`,
- * `sfn_str_slice`). The compiler's runtime_helpers.sfn registry now
- * carries `native_signature: "sfn_str_concat"` for `string.concat`, and
- * the hardcoded direct-emission sites in
- * `expression_lowering/native/{core_ops_lowering,core_strings}.sfn`
- * call `@sfn_str_concat` for fresh emission. Seed-built IR that still
- * targets `@sailfin_runtime_string_concat_v2` keeps linking through
- * the legacy entrypoint defined later in this file. */
-char *sfn_str_concat(SfnString a, SfnString b)
-{
-    return sailfin_runtime_string_concat_v2(a, b);
-}
-
 /* M2.4b (#398): arena-aware concat. The new compiler emits
- *   %t = call {i8*, i64} @sfn_str_concat_arena({i8*, i64} a,
- *                                              {i8*, i64} b,
- *                                              ptr @sfn_default_arena)
+ *   %t = call {i8*, i64} @sfn_str_concat({i8*, i64} a,
+ *                                        {i8*, i64} b,
+ *                                        ptr @sfn_default_arena)
  *   %p = extractvalue {i8*, i64} %t, 0
  * at every `let s = a + b` site. The third argument is the
  * address of the global pointer `sfn_default_arena` (declared
@@ -2491,11 +2477,15 @@ char *sfn_str_concat(SfnString a, SfnString b)
  * the result as a C string), memcpy both payloads, write the
  * trailing NUL, and return the aggregate `{data, a.len + b.len}`.
  *
- * The 2-arg `sfn_str_concat` trampoline above stays for seed-
- * built IR that already emits the old shape; once the next seed
- * adopts the new ABI we can rename `sfn_str_concat_arena` back
- * to `sfn_str_concat` in a single rollback-safe PR (tracked as a
- * follow-up `seed-blocker` issue). */
+ * History: #714 (M2.4b) introduced this entrypoint under the
+ * `_arena` suffix and kept a legacy 2-arg `sfn_str_concat`
+ * trampoline alive so the pre-arena seed could still link.
+ * #715 retires that legacy 2-arg trampoline and promotes the
+ * arena-aware function to the bare canonical name; the
+ * `sfn_str_concat_arena` forwarder below survives one more
+ * release cycle so seed v0.7.0-alpha.7 — which still emits
+ * `@sfn_str_concat_arena` IR — keeps linking. The next seed
+ * bump retires that forwarder in a follow-up PR. */
 /* M2.4b (#398) — concat-limit / overflow gate shared between the
  * arena-aware `sfn_str_concat_arena` and `sfn_str_append_arena`
  * entrypoints. Mirrors the legacy `sailfin_runtime_string_concat`
@@ -2542,7 +2532,7 @@ static size_t _sfn_str_check_concat_limit(size_t alen, size_t blen, const char *
     return alen + blen;
 }
 
-SfnString sfn_str_concat_arena(SfnString a, SfnString b, SfnArena **arena_slot)
+SfnString sfn_str_concat(SfnString a, SfnString b, SfnArena **arena_slot)
 {
     /* Design note on `SAILFIN_USE_ARENA` opt-out: the arena-aware
      * path is the M1 minimal-viable design per
@@ -2551,8 +2541,8 @@ SfnString sfn_str_concat_arena(SfnString a, SfnString b, SfnArena **arena_slot)
      * allocations route through this arena"). The env var stays
      * meaningful for the LEGACY C entrypoints (`_rt_malloc` and the
      * 2-arg `sailfin_runtime_string_concat`); fresh user emission
-     * targeting `@sfn_str_concat_arena` is unconditionally
-     * arena-backed by design. Documented as a deliberate scope
+     * targeting `@sfn_str_concat` (post-#715 rename) is
+     * unconditionally arena-backed by design. Documented as a deliberate scope
      * delta in PR #714 (see Copilot review reply). */
     SfnArena *arena;
     if (arena_slot != NULL && *arena_slot != NULL)
@@ -2659,7 +2649,7 @@ SfnString sfn_str_concat_arena(SfnString a, SfnString b, SfnArena **arena_slot)
  * `string` locals become aggregates and the peephole moves into
  * `core_ops_lowering`). Shipping the body now closes the wave 1b
  * surface area so the migration is mechanically complete. */
-void sfn_str_append_arena(SfnString *dst, SfnString suffix, SfnArena **arena_slot)
+void sfn_str_append(SfnString *dst, SfnString suffix, SfnArena **arena_slot)
 {
     if (dst == NULL)
     {
@@ -2704,7 +2694,7 @@ void sfn_str_append_arena(SfnString *dst, SfnString suffix, SfnArena **arena_slo
     }
 
     /* Decode tagged immediate codepoint encoding for the suffix
-     * (same rationale as `sfn_str_concat_arena` above — the
+     * (same rationale as `sfn_str_concat` above — the
      * pre-M1.A.2 frontend can present `b.data` as a tagged
      * pointer when the source value is a 1-codepoint literal). */
     unsigned char suffix_imm_buf[5] = {0};
@@ -2717,7 +2707,7 @@ void sfn_str_append_arena(SfnString *dst, SfnString suffix, SfnArena **arena_slo
     }
 
     /* Apply the shared limit/overflow gate (same as
-     * `sfn_str_concat_arena` — Copilot review feedback on PR #714). */
+     * `sfn_str_concat` — Copilot review feedback on PR #714). */
     size_t old_sz = dst->len < 0 ? 0 : (size_t)dst->len;
     size_t suffix_sz = suffix.len < 0 ? 0 : (size_t)suffix.len;
     size_t new_sz = _sfn_str_check_concat_limit(old_sz, suffix_sz, "string_append");
@@ -2741,9 +2731,28 @@ void sfn_str_append_arena(SfnString *dst, SfnString suffix, SfnArena **arena_slo
     dst->len = new_len;
 }
 
+/* #715: transitional `_arena`-suffixed forwarders. Seed
+ * v0.7.0-alpha.7 still emits `@sfn_str_concat_arena` /
+ * `@sfn_str_append_arena` IR (its baked-in
+ * runtime_helpers descriptor predates the bare-name rename).
+ * Until the next seed bump pins a binary that emits the bare
+ * symbols, the seed-built first-pass binary needs these symbols
+ * to resolve at link time. The bodies are one-line forwards to
+ * the canonical entrypoints; both forwarders retire in a
+ * follow-up PR once `.seed-version` advances. */
+SfnString sfn_str_concat_arena(SfnString a, SfnString b, SfnArena **arena_slot)
+{
+    return sfn_str_concat(a, b, arena_slot);
+}
+
+void sfn_str_append_arena(SfnString *dst, SfnString suffix, SfnArena **arena_slot)
+{
+    sfn_str_append(dst, suffix, arena_slot);
+}
+
 /* `@sfn_default_arena` — the IR-visible global pointer that
- * every fresh `sfn_str_concat_arena` / `sfn_str_append_arena`
- * call site passes as the arena argument. The declaration in
+ * every fresh `sfn_str_concat` / `sfn_str_append` call site
+ * passes as the arena argument. The declaration in
  * `compiler/src/llvm/lowering/lowering_phase_render.sfn` is
  * `@sfn_default_arena = external global ptr`; the storage is
  * 8 bytes on 64-bit (a single `SfnArena *`). The constructor
@@ -2762,12 +2771,12 @@ __attribute__((constructor(101))) static void _sfn_default_arena_init(void)
     /* Skip the pre-fetch when the legacy `SAILFIN_USE_ARENA=0`
      * opt-out is set so we don't force `sfn_arena_global()` to
      * spin up the page chain at module load (Copilot review
-     * feedback on PR #714). The fallback in `sfn_str_concat_arena`
-     * / `sfn_str_append_arena` still hits `sfn_arena_global()`
+     * feedback on PR #714). The fallback in `sfn_str_concat`
+     * / `sfn_str_append` still hits `sfn_arena_global()`
      * lazily on the first call, so this gate only saves the
      * eager init; the new arena-aware path remains
      * arena-backed by design (see the design note inside
-     * `sfn_str_concat_arena`). */
+     * `sfn_str_concat`). */
     if (!sfn_arena_enabled())
     {
         return;

--- a/runtime/sfn/string.sfn
+++ b/runtime/sfn/string.sfn
@@ -67,16 +67,18 @@ extern fn strings_equal(a: * u8, b: * u8) -> bool;
 
 extern fn substring_unchecked(text: * u8, start: f64, end: f64) -> * u8;
 
-// M2.4b (#398): the C-side allocating ops. The Sailfin trampolines
-// below preserve the `sfn_str_sfn_*` infix pattern (proof-of-life
-// presence under the Sailfin namespace) while the canonical
-// `sfn_str_concat_arena` / `sfn_str_append_arena` symbols live on
-// the C side. The two `* u8` parameters mirror the wave-1a pattern
-// — today's Sailfin frontend can't pass / return the SfnString
-// aggregate by value, so the bodies bridge through the legacy
-// NUL-terminated concat. The user IR emission lands directly on
-// `@sfn_str_concat_arena` (the C entrypoint with the new arena-
-// aware ABI); these wrappers are not on the hot path.
+// M2.4b (#398) + #715: the C-side allocating ops. The Sailfin
+// trampolines below preserve the `sfn_str_sfn_*` infix pattern
+// (proof-of-life presence under the Sailfin namespace) while the
+// canonical `sfn_str_concat` / `sfn_str_append` symbols live on
+// the C side (#715 promoted these from their interim `_arena`
+// suffix to the bare canonical names). The two `* u8` parameters
+// mirror the wave-1a pattern — today's Sailfin frontend can't
+// pass / return the SfnString aggregate by value, so the bodies
+// bridge through the legacy NUL-terminated concat. The user IR
+// emission lands directly on `@sfn_str_concat` (the C entrypoint
+// with the new arena-aware ABI); these wrappers are not on the
+// hot path.
 extern fn sailfin_runtime_string_concat(a: * u8, b: * u8) -> * u8;
 
 extern fn sailfin_runtime_string_append(buf: * u8, suffix: * u8) -> * u8;
@@ -177,7 +179,7 @@ fn sfn_str_sfn_from_cstr(s: * u8) -> * u8 { return s; }
 // Sailfin frontend can't take an SfnString aggregate by value
 // (M1.A.2 hasn't landed). The user-emission hot path bypasses
 // this wrapper entirely and lands on the C entrypoint
-// `sfn_str_concat_arena`, which has the real arena ABI.
+// `sfn_str_concat`, which has the real arena ABI.
 fn sfn_str_sfn_concat(a: * u8, b: * u8) -> * u8 {
     return sailfin_runtime_string_concat(a, b);
 }


### PR DESCRIPTION
## Summary

- Promotes the arena-aware concat/append entrypoints from their interim `_arena` suffix to the bare canonical names per `docs/runtime_architecture.md` §2.2.2.
- Retires the legacy 2-arg `char *sfn_str_concat(SfnString, SfnString)` trampoline left over from pre-#714 seeds.
- Flips the compiler emission (`runtime_helpers.sfn` descriptor + the three hardcoded call sites in `core_ops_lowering.sfn` and `core_strings.sfn`) to emit `@sfn_str_concat({i8*, i64}, {i8*, i64}, ptr)` against the bare symbol.

Closes #715

## Acceptance Criteria

- [x] `let s = a + b` lowers to `call {i8*, i64} @sfn_str_concat({i8*, i64} ..., {i8*, i64} ..., ptr @sfn_default_arena)` — bare `@sfn_str_concat`, no `_arena` suffix.
- [x] The legacy 2-arg `char *sfn_str_concat(SfnString, SfnString)` C symbol no longer exists in `nm build/native/sailfin`.
- [x] `make compile` passes.
- [x] `make test` passes — unit 5/5 · integration 5/5 · 8/8 (work-dir-parity 4/4) · e2e 77/77 · capsules 13/13.

## Verification

```text
$ build/native/sailfin emit -o /tmp/ac1.ll llvm examples/basics/hello-world.sfn
$ grep -E '@sfn_str_concat\b|@sfn_str_concat_arena\b' /tmp/ac1.ll
declare {i8*, i64} @sfn_str_concat({i8*, i64}, {i8*, i64}, ptr)

$ nm build/native/sailfin | grep -E ' T sfn_str_concat(_arena)?$'
0000000000065030 T sfn_str_concat
0000000000065720 T sfn_str_concat_arena   # transitional forwarder (see below)
```

The `nm` output deviates from the issue's expected single-line result. See "Scope adjustment" below for why the transitional forwarder is necessary.

## Scope adjustment — transitional `_arena` forwarders

The issue assumed the rename would be one-shot (`sfn_str_concat_arena` symbol gone, bare symbol present). In practice the pinned seed v0.7.0-alpha.7 still emits `@sfn_str_concat_arena` IR against this runtime — its baked-in `runtime_helpers` descriptor predates this rename. Dropping the `_arena` C symbol entirely would break the self-host link at Phase A (`<seed> build -p compiler` -> IR with `@sfn_str_concat_arena` -> link against new C runtime).

To keep `make compile` green, the rename keeps thin one-line `sfn_str_concat_arena` / `sfn_str_append_arena` forwarders in `runtime/native/src/sailfin_runtime.c`:

```c
SfnString sfn_str_concat_arena(SfnString a, SfnString b, SfnArena **arena_slot) {
    return sfn_str_concat(a, b, arena_slot);
}
```

This mirrors how PR #714 handled the prior transition (it kept the 2-arg `sfn_str_concat` trampoline alive for pre-arena seeds). The forwarders retire in a follow-up PR once `.seed-version` advances to a seed that emits the bare symbols — which is exactly the `seed-blocker` workflow.

I'll open the follow-up issue (or one already exists alongside the next `/pin-seed`) so the forwarders don't outlive their purpose.

## Files Changed

**C runtime:**
- `runtime/native/include/sailfin_runtime.h` — declare bare + transitional `_arena` symbols.
- `runtime/native/src/sailfin_runtime.c` — delete legacy 2-arg trampoline; rename `sfn_str_concat_arena` -> `sfn_str_concat` and `sfn_str_append_arena` -> `sfn_str_append`; add one-line transitional `_arena` forwarders.

**Compiler:**
- `compiler/src/llvm/runtime_helpers.sfn` — `string.concat` / `string.append` descriptors flip `symbol` + `native_signature` to the bare names.
- `compiler/src/llvm/expression_lowering/native/core_ops_lowering.sfn` (×2) and `core_strings.sfn` (×1) — call sites emit bare `@sfn_str_concat`.

**Runtime (Sailfin):**
- `runtime/sfn/string.sfn` — comment refresh; no semantic change.

**Tests:**
- `compiler/tests/unit/runtime_call_dispatch_test.sfn` — fixture expects bare `@sfn_str_concat`.
- `compiler/tests/e2e/test_runtime_string_allocating.sh` — pins bare symbol in IR + nm; explicit regression guard for the `_arena` transitional name.
- `compiler/tests/e2e/test_string_aggregate_shape.sh` — same, plus regression guard for the now-removed 2-arg shape.

Closes #715

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ter3Ry7h7n34adJUGzVSwC)_