### PR TITLE
refactor(lowering): route sfn_str_concat through emit_runtime_call (M1.7.2d)

### DIFF
--- a/compiler/src/llvm/expression_lowering/native/core_ops_lowering.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_ops_lowering.sfn
@@ -39,6 +39,7 @@ import {
     harmonise_operands
 } from "./core_operands";
 import { lines_end_with_terminator, strip_enclosing_parentheses } from "./core_operators";
+import { emit_runtime_call, empty_runtime_call_overrides } from "./runtime_call";
 
 fn lower_logical_not_with_operand(operand: LLVMOperand, temp_index: int, lines: string[], diagnostics: string[], string_constants: StringConstant[]) -> ExpressionResult {
     let coerced = coerce_operand_to_type(operand, "i1", temp_index, lines, true, null);
@@ -404,22 +405,25 @@ fn lower_binary_operation(expression: string, match: OperatorMatch, bindings: Pa
                 };
             }
 
-            // M2.4b (#398): arena-aware concat. The call returns
-            // the SfnString aggregate `{i8*, i64}`; an immediate
-            // `extractvalue` recovers the data pointer so the rest
-            // of the lowering pipeline (which still treats string
-            // operands as `i8*`) is unchanged. The third call
-            // argument is the address of the global pointer
-            // `@sfn_default_arena`, primed at module load by the
-            // C constructor in `runtime/native/src/sailfin_runtime.c`.
+            // M1.7.2d (#721): route through descriptor-driven dispatch.
+            // The `string.concat` descriptor pins the three parameter
+            // types (`{i8*, i64}`, `{i8*, i64}`, `ptr`); the third
+            // operand `ptr @sfn_default_arena` is the global pointer
+            // slot primed at module load by the C constructor in
+            // `runtime/native/src/sailfin_runtime.c`. The downstream
+            // `extractvalue` (still owned by this lowering, not by
+            // the descriptor) recovers the data pointer so the rest
+            // of the pipeline keeps treating string operands as `i8*`.
+            let arena_operand = LLVMOperand {
+                llvm_type: "ptr",
+                value: "@sfn_default_arena"
+            };
+            let concat_operands: LLVMOperand[] = [lhs_agg.operand, rhs_agg.operand, arena_operand];
+            let concat_result = emit_runtime_call("string.concat", concat_operands, empty_runtime_call_overrides(), current_temp, current_lines);
+            diagnostics = extend_string_array(diagnostics, concat_result.diagnostics);
+            current_lines = concat_result.lines;
             let agg_name = format_temp_name(current_temp);
             current_temp += 1;
-            current_lines.push("  " + agg_name
-                + " = call {i8*, i64} @sfn_str_concat({i8*, i64} "
-                + lhs_agg.operand.value
-                + ", {i8*, i64} "
-                + rhs_agg.operand.value
-                + ", ptr @sfn_default_arena)");
             let data_name = format_temp_name(current_temp);
             current_temp += 1;
             current_lines.push("  " + data_name + " = extractvalue {i8*, i64} "
@@ -634,16 +638,18 @@ fn lower_binary_operation(expression: string, match: OperatorMatch, bindings: Pa
                     string_constants: string_constants
                 };
             }
-            // M2.4b (#398): arena-aware concat (see the earlier
-            // call site in this file for the full migration note).
+            // M1.7.2d (#721): route through descriptor-driven dispatch
+            // (see the earlier call site in this file for the full
+            // migration note).
+            let arena_operand = LLVMOperand {
+                llvm_type: "ptr",
+                value: "@sfn_default_arena"
+            };
+            let concat_operands: LLVMOperand[] = [lhs_agg.operand, rhs_agg.operand, arena_operand];
+            let concat_result = emit_runtime_call("string.concat", concat_operands, empty_runtime_call_overrides(), current_temp, current_lines);
+            diagnostics = extend_string_array(diagnostics, concat_result.diagnostics);
+            current_lines = concat_result.lines;
             let agg_name = format_temp_name(current_temp);
-            let line = "  " + agg_name
-                + " = call {i8*, i64} @sfn_str_concat({i8*, i64} "
-                + lhs_agg.operand.value
-                + ", {i8*, i64} "
-                + rhs_agg.operand.value
-                + ", ptr @sfn_default_arena)";
-            current_lines.push(line);
             let data_name = format_temp_name(current_temp + 1);
             let extract_line = "  " + data_name + " = extractvalue {i8*, i64} "
                 + agg_name

--- a/compiler/src/llvm/expression_lowering/native/core_strings.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_strings.sfn
@@ -148,20 +148,32 @@ fn emit_string_concat(left: LLVMOperand, right: LLVMOperand, temp_index: int, li
             string_constants: empty_string_constant_set()
         };
     }
-    // M2.4b (#398): arena-aware concat. Returns the SfnString
-    // aggregate `{i8*, i64}`; the immediate `extractvalue`
-    // recovers the data pointer for the rest of the lowering
-    // pipeline (string operands stay typed as `i8*` until the
-    // M1.A.2 flip lands). The third operand `ptr @sfn_default_arena`
-    // is the global pointer slot primed at module load.
+    // M1.7.2d (#721): route through descriptor-driven dispatch.
+    // The `string.concat` descriptor (runtime_helpers.sfn) pins the
+    // three parameter types (`{i8*, i64}`, `{i8*, i64}`, `ptr`) and
+    // resolves the symbol via `native_signature`; the call site
+    // contributes the operands, including the third
+    // `ptr @sfn_default_arena` — the global pointer slot primed at
+    // module load by the C constructor in
+    // `runtime/native/src/sailfin_runtime.c`. The downstream
+    // `extractvalue` (still owned by this lowering, not by the
+    // descriptor) recovers the data pointer so the rest of the
+    // pipeline keeps treating string operands as `i8*` until the
+    // M1.A.2 flip lands.
+    let arena_operand = LLVMOperand {
+        llvm_type: "ptr",
+        value: "@sfn_default_arena"
+    };
+    let concat_operands: LLVMOperand[] = [left_aligned.operand, right_aligned.operand, arena_operand];
+    let concat_result = emit_runtime_call("string.concat", concat_operands, empty_runtime_call_overrides(), right_aligned.temp_index, right_aligned.lines);
+    let mut _concat_di: int = 0;
+    loop {
+        if _concat_di >= concat_result.diagnostics.length { break; }
+        diagnostics.push(concat_result.diagnostics[_concat_di]);
+        _concat_di += 1;
+    }
     let agg_name = format_temp_name(right_aligned.temp_index);
-    let line = "  " + agg_name
-        + " = call {i8*, i64} @sfn_str_concat({i8*, i64} "
-        + left_aligned.operand.value
-        + ", {i8*, i64} "
-        + right_aligned.operand.value
-        + ", ptr @sfn_default_arena)";
-    let mut out_lines = append_string(right_aligned.lines, line);
+    let mut out_lines = concat_result.lines;
     let data_name = format_temp_name(right_aligned.temp_index + 1);
     let extract_line = "  " + data_name + " = extractvalue {i8*, i64} "
         + agg_name


### PR DESCRIPTION
## Summary

- Migrates the three remaining `@sfn_str_concat` raw-string emissions in `compiler/src/llvm/expression_lowering/native/` to descriptor-driven dispatch through `emit_runtime_call`.
- The `string.concat` descriptor in `runtime_helpers.sfn` already pins the three parameter types (`{i8*, i64}`, `{i8*, i64}`, `ptr`) and resolves the symbol via `native_signature`; call sites now only contribute operands.
- Brings epic #494 / M1.7 (centralize runtime helper call dispatch) one step closer to its headline "all `@sailfin_runtime_*` / `@sfn_*` raw-string emissions route through `emit_runtime_call`".

Closes #721

## Sites migrated

- `compiler/src/llvm/expression_lowering/native/core_strings.sfn` — `emit_string_concat` (1 site)
- `compiler/src/llvm/expression_lowering/native/core_ops_lowering.sfn` — 2 arithmetic-binary concat sites in `lower_binary_operation`

## Notes / discrepancies

The issue body refers to the symbol as `sfn_str_concat_arena`, but the actual emissions in current main use `sfn_str_concat` — the `_arena` suffix was dropped by #715 (#769) after this issue was groomed. The descriptor's `native_signature` field reflects the new name, so dispatch resolves correctly. The grep acceptance criterion was applied against `@sfn_str_concat\b` (the live symbol) to honor the issue's intent.

## Acceptance Criteria

- [x] `grep -nE '@sfn_str_concat\b' compiler/src/llvm/expression_lowering/native/core_strings.sfn compiler/src/llvm/expression_lowering/native/core_ops_lowering.sfn` returns 0 live sites
- [x] Before/after IR diff **empty** for `examples/basics/loops.sfn` (exercises `{{var}}` interpolation) and an explicit `+`-operator concat fixture
- [x] `make check` green (stage2 == stage3 fixed point on re-run + full e2e suite)
- [x] `sfn fmt --check` clean

## Verification

```bash
ulimit -v 8388608 && make rebuild
ulimit -v 8388608 && timeout 60 build/native/sailfin emit -o /tmp/before.ll  llvm examples/basics/loops.sfn   # (captured pre-change)
ulimit -v 8388608 && timeout 60 build/native/sailfin emit -o /tmp/after.ll   llvm examples/basics/loops.sfn
diff /tmp/before.ll /tmp/after.ll          # → empty

# Explicit `+` concat fixture: let a = "hello"; let b = "world"; let c = a + " " + b;
diff /tmp/before.plus.ll /tmp/after.plus.ll  # → empty

ulimit -v 8388608 && make check             # → exit 0
ulimit -v 8388608 && build/native/sailfin fmt --check \
  compiler/src/llvm/expression_lowering/native/core_strings.sfn \
  compiler/src/llvm/expression_lowering/native/core_ops_lowering.sfn  # → clean
```

The first `make check` invocation hit the known intermittent fixed-point WARN that the Makefile itself documents ("this may indicate intermittent IR corruption — rerun or investigate"). A clean re-run on identical source produced `stage2 == stage3 ✓`. Stashing my changes and running `make check` on unchanged main also produced a clean fixed point, confirming this isn't a divergence introduced by the migration.

## Files Changed

- `compiler/src/llvm/expression_lowering/native/core_strings.sfn`
- `compiler/src/llvm/expression_lowering/native/core_ops_lowering.sfn`

---

Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011cZV4vjsD2mCdszf89W61q)_