### PR TITLE
docs(proposals): swap sfn/cli Issue 0.5.2 ↔ 1.1 dependency order

### DIFF
--- a/docs/proposals/cli-modularization-epic.md
+++ b/docs/proposals/cli-modularization-epic.md
@@ -557,7 +557,15 @@ Every issue below uses the contract from
 - **Acceptance:** all tests pass; `_arg`/`_flag`/etc. private
   helpers removed; coverage is the same set of cases.
 - **Size:** S. **Type:** refactor. **Depends on:** 0.5.1 (and any
-  fix issue it spawns).
+  fix issue it spawns), and Issue 1.1 (non-exiting `parse()` is
+  required so the parser-error tests and the `_help_hint`-driven
+  tests can be re-expressed against the public surface without
+  triggering `process.exit()` mid-test). The original ordering
+  (0.5.2 before 1.1) assumed cross-capsule imports would be the
+  load-bearing blocker; #508/PR #523 closed that, and the actual
+  load-bearing blocker turned out to be coverage of error paths
+  that `run()` services via `process.exit()`. Swapping the
+  dependency keeps "no coverage regression" honest.
 
 ### Phase 1 — capsule API expansion
 
@@ -577,7 +585,13 @@ Every issue below uses the contract from
   4. New `tests/parser_test.sfn` covers each `error.kind`.
 - **Files:** `capsules/sfn/cli/src/{parser,types,mod}.sfn`,
   `capsules/sfn/cli/tests/parser_test.sfn` (new).
-- **Size:** M. **Type:** feature. **Depends on:** 0.5.2.
+- **Size:** M. **Type:** feature. **Depends on:** 0.5.1. (Originally
+  listed as depending on 0.5.2; the dependency was inverted after
+  the cross-capsule import gap closed in #508 and the actual blocker
+  for 0.5.2 was found to be the absence of a non-exiting parse
+  variant. `parse()` itself is additive and can ship against the
+  existing inlined-helper test file — 0.5.2 rewrites that file
+  afterwards.)
 
 #### Issue 1.2 — Exit code constants
 - **Goal:** Define `EXIT_OK = 0`, `EXIT_BUILD_FAIL = 1`,


### PR DESCRIPTION
## Summary

- Swap the dependency order between Phase 0.5.2 (test rewrite, #355) and Phase 1.1 (non-exiting `parse()` variant, newly filed #774) in `docs/proposals/cli-modularization-epic.md`.
- Companion to filing #774 and flipping #355 → `blocked`.

## Why

While picking up #355 I found that the original sequencing (0.5.2 before 1.1) assumed the cross-capsule import gap would be the load-bearing blocker. PR #523 (closing #508) closed that gap. The actual load-bearing blocker is coverage of parser-error paths.

When I mapped every test in `capsules/sfn/cli/tests/cli_test.sfn` to the public `sfn/cli` surface, **3 of 51 tests cannot be expressed via the current public API** without `process.exit()`-aborting the test-file's process:

1. `cli: unknown token treated as positional when no args defined` — uses the inlined non-exiting `_parse`. The public `run()` would `process.exit(2)` on the same input. The test comment itself says *"the real run() would exit with an error"*.
2. `cli: help hint without subcommand` + `cli: help hint with subcommand` — call inlined `_help_hint`, which is only used internally by `run()` immediately before `process.exit(2)`. Not in the public re-export set.

Architect review picked option C (reorder) over option A (drop tests) and option B (split #355 into two issues): `parse()` is additive and can ship against the existing inlined-helper test file in `cli_test.sfn`, so there's no chicken-and-egg. With `parse()` in hand, the #355 rewrite becomes mechanical and preserves all 51 tests with zero coverage loss.

## Changes

- `docs/proposals/cli-modularization-epic.md` §7:
  - Issue 0.5.2 `Depends on:` now includes Issue 1.1, with a one-paragraph explanation of why the swap.
  - Issue 1.1 `Depends on:` now reads `0.5.1` (was `0.5.2`), with the matching explanation.

No code, no test, no compiler changes — proposal-only.

## Verification

- N/A. Markdown edit only; `make check` / `make test` not exercised.

## Related

- #355 — flipped to `blocked` with a comment explaining the reorder.
- #774 — new Phase 1.1 issue, `claude-ready`, M / type:feature, sub-issue of epic #351.
- #351 — epic; #774 added as a sub-issue.

## Files Changed

- `docs/proposals/cli-modularization-epic.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01RrHRahYPE6mwY6iHPxphpU)_