### PR TITLE
feat(cli): add non-exiting parse() variant alongside run()

### DIFF
--- a/capsules/sfn/cli/src/mod.sfn
+++ b/capsules/sfn/cli/src/mod.sfn
@@ -28,9 +28,9 @@
 //
 // Internal layout — this barrel re-exports the public surface. Sources
 // live in:
-//   - types.sfn       Arg, Flag, Command, Matches
+//   - types.sfn       Arg, Flag, Command, Matches, ParseError, ParseResult
 //   - builder.sfn     arg, arg_optional, flag*, command, with_*
-//   - parser.sfn      run() (exiting parse) + private parser helpers
+//   - parser.sfn      parse() (pure, non-exiting), run() (exiting wrapper) + private parser helpers
 //   - matches.sfn     get, get_or, has_flag, has, subcommand, positionals
 //   - help.sfn        help, print_help, _format_help, width helpers
 //   - style.sfn       bold, dim, color helpers, _esc, _ansi_wrap
@@ -53,7 +53,9 @@ export {
     Arg,
     Flag,
     Command,
-    Matches
+    Matches,
+    ParseError,
+    ParseResult
 } from "./types";
 
 // ---- Builders ----
@@ -72,7 +74,7 @@ export {
 } from "./builder";
 
 // ---- Parsing ----
-export { run } from "./parser";
+export { parse, run } from "./parser";
 
 // ---- Match accessors ----
 export {

--- a/capsules/sfn/cli/src/parser.sfn
+++ b/capsules/sfn/cli/src/parser.sfn
@@ -1,21 +1,33 @@
-// sfn/cli — argv parser (exiting variant).
+// sfn/cli — argv parser.
 //
-// `run()` walks `argv` against a `Command` definition, returning a
-// populated `Matches`. Built-in `--help`/`-h` and `--version`/`-V`
-// are recognised and trigger `process.exit(0)`. Unknown flags,
-// missing values, and missing required positionals print to stderr
-// and `process.exit(2)`.
+// `parse()` is the pure, non-exiting workhorse: it walks `argv`
+// against a `Command` definition and returns a `ParseResult` for
+// every input. It never calls `process.exit()` and never prints. Help
+// and version requests are reported as `ParseError.kind ==
+// "help_requested"` / `"version_requested"`; parse failures are
+// reported as `"unknown_flag"`, `"missing_value"`,
+// `"unexpected_positional"`, or `"missing_required"`.
 //
-// A non-exiting `parse()` variant is planned for Phase 1 (Issue 1.1).
+// `run()` is the historical exiting variant kept for binary entry
+// points. It now delegates to `parse()` and applies the print +
+// `process.exit()` policy:
+//   * `--help`/`-h` -> print help, exit 0
+//   * `--version`/`-V` -> print version, exit 0
+//   * parse failures -> print to stderr, exit 2
+// Its observable behavior (stderr text, exit codes) is byte-identical
+// to the pre-`parse()` implementation.
 import { _format_help } from "./help";
-import { Command, Flag, Matches } from "./types";
+import {
+    Command,
+    Flag,
+    Matches,
+    ParseError,
+    ParseResult
+} from "./types";
 
-fn run(cmd: Command, argv: string[]) -> Matches ![io] {
-    // Parse command-line arguments against the command definition.
-    // Prints help/version and exits when --help/-h or --version/-V is given.
-    // Prints an error and exits with code 2 on invalid input.
-    // Note: this function calls process.exit() directly and cannot be
-    // wrapped in try/catch for error recovery.
+fn parse(cmd: Command, argv: string[]) -> ParseResult {
+    // Pure, non-exiting argv parser. Returns a ParseResult that
+    // describes either successful matches or a structured error.
     let mut pos_names: string[] = [];
     let mut pos_values: string[] = [];
     let mut fl_names: string[] = [];
@@ -43,38 +55,20 @@ fn run(cmd: Command, argv: string[]) -> Matches ![io] {
         }
     }
 
-    // Resolve which command definition to parse against.
     let active = _resolve_active(cmd, subcmd_name);
 
-    // Build the help hint command string.
-    let help_cmd = _help_hint(cmd.name, subcmd_name);
-
-    // Parse remaining args.
     let mut pos_idx: int = 0;
     loop {
         if idx >= argv.length { break; }
         let token = argv[idx];
 
-        // Check built-in flags.
+        // Built-in flags surface as non-ok results so the caller can
+        // decide how to render help/version.
         if strings_equal(token, "--help") || strings_equal(token, "-h") {
-            if subcmd_name.length > 0 {
-                print(_format_help(active, cmd.name + " " + subcmd_name));
-            } else { print(_format_help(cmd, cmd.name)); }
-            process.exit(0);
+            return _err_result(cmd.name, subcmd_name, pos_names, pos_values, fl_names, fl_values, fl_present, "help_requested", "", "", "");
         }
         if strings_equal(token, "--version") || strings_equal(token, "-V") {
-            if subcmd_name.length > 0 {
-                if active.version.length > 0 {
-                    print(cmd.name + " " + subcmd_name + " " + active.version);
-                } else if cmd.version.length > 0 {
-                    print(cmd.name + " " + subcmd_name + " " + cmd.version);
-                } else { print(cmd.name + " " + subcmd_name); }
-            } else {
-                if cmd.version.length > 0 {
-                    print(cmd.name + " " + cmd.version);
-                } else { print(cmd.name); }
-            }
-            process.exit(0);
+            return _err_result(cmd.name, subcmd_name, pos_names, pos_values, fl_names, fl_values, fl_present, "version_requested", "", "", "");
         }
 
         if _starts_with(token, "--") {
@@ -82,17 +76,17 @@ fn run(cmd: Command, argv: string[]) -> Matches ![io] {
             let flag_name = substring(token, 2, token.length);
             let f = _find_flag_long(active, flag_name);
             if f.long_name.length == 0 {
-                print.err("error: unknown flag --" + flag_name);
-                print.err("run '" + help_cmd + "' for usage");
-                process.exit(2);
+                return _err_result(cmd.name, subcmd_name, pos_names, pos_values, fl_names, fl_values, fl_present, "unknown_flag", "error: unknown flag --"
+                    + flag_name, flag_name, "");
             }
             fl_names.push(f.long_name);
             fl_present.push(true);
             if f.takes_value {
                 idx += 1;
                 if idx >= argv.length {
-                    print.err("error: flag --" + flag_name + " requires a value");
-                    process.exit(2);
+                    return _err_result(cmd.name, subcmd_name, pos_names, pos_values, fl_names, fl_values, fl_present, "missing_value", "error: flag --"
+                        + flag_name
+                        + " requires a value", flag_name, "");
                 }
                 fl_values.push(argv[idx]);
             } else { fl_values.push("true"); }
@@ -101,17 +95,17 @@ fn run(cmd: Command, argv: string[]) -> Matches ![io] {
             let short = substring(token, 1, token.length);
             let f = _find_flag_short(active, short);
             if f.long_name.length == 0 {
-                print.err("error: unknown flag -" + short);
-                print.err("run '" + help_cmd + "' for usage");
-                process.exit(2);
+                return _err_result(cmd.name, subcmd_name, pos_names, pos_values, fl_names, fl_values, fl_present, "unknown_flag", "error: unknown flag -"
+                    + short, short, "");
             }
             fl_names.push(f.long_name);
             fl_present.push(true);
             if f.takes_value {
                 idx += 1;
                 if idx >= argv.length {
-                    print.err("error: flag -" + short + " requires a value");
-                    process.exit(2);
+                    return _err_result(cmd.name, subcmd_name, pos_names, pos_values, fl_names, fl_values, fl_present, "missing_value", "error: flag -"
+                        + short
+                        + " requires a value", short, "");
                 }
                 fl_values.push(argv[idx]);
             } else { fl_values.push("true"); }
@@ -122,15 +116,15 @@ fn run(cmd: Command, argv: string[]) -> Matches ![io] {
                 pos_values.push(token);
                 pos_idx += 1;
             } else {
-                print.err("error: unexpected argument '" + token + "'");
-                print.err("run '" + help_cmd + "' for usage");
-                process.exit(2);
+                return _err_result(cmd.name, subcmd_name, pos_names, pos_values, fl_names, fl_values, fl_present, "unexpected_positional", "error: unexpected argument '"
+                    + token
+                    + "'", "", token);
             }
         }
         idx += 1;
     }
 
-    // Validate required positional arguments.
+    // Validate required positional arguments and fill optional defaults.
     loop {
         if pos_idx >= active.args.length { break; }
         let a = active.args[pos_idx];
@@ -138,14 +132,14 @@ fn run(cmd: Command, argv: string[]) -> Matches ![io] {
             pos_names.push(a.name);
             pos_values.push(a.default_value);
         } else {
-            print.err("error: missing required argument <" + a.name + ">");
-            print.err("run '" + help_cmd + "' for usage");
-            process.exit(2);
+            return _err_result(cmd.name, subcmd_name, pos_names, pos_values, fl_names, fl_values, fl_present, "missing_required", "error: missing required argument <"
+                + a.name
+                + ">", "", a.name);
         }
         pos_idx += 1;
     }
 
-    return Matches {
+    let matches = Matches {
         command_name: cmd.name,
         subcommand_name: subcmd_name,
         positional_names: pos_names,
@@ -153,6 +147,83 @@ fn run(cmd: Command, argv: string[]) -> Matches ![io] {
         flag_names: fl_names,
         flag_values: fl_values,
         flag_present: fl_present
+    };
+    return ParseResult { ok: true, matches: matches, error: _ok_error() };
+}
+
+fn run(cmd: Command, argv: string[]) -> Matches ![io] {
+    // Exiting wrapper around `parse()`. Prints help/version and exits
+    // when --help/-h or --version/-V is given. Prints an error and
+    // exits with code 2 on invalid input. Cannot be wrapped in
+    // try/catch for error recovery — use `parse()` for that.
+    let result = parse(cmd, argv);
+    if result.ok { return result.matches; }
+
+    let subcmd_name = result.matches.subcommand_name;
+    let active = _resolve_active(cmd, subcmd_name);
+    let help_cmd = _help_hint(cmd.name, subcmd_name);
+    let kind = result.error.kind;
+
+    if strings_equal(kind, "help_requested") {
+        if subcmd_name.length > 0 {
+            print(_format_help(active, cmd.name + " " + subcmd_name));
+        } else { print(_format_help(cmd, cmd.name)); }
+        process.exit(0);
+    }
+    if strings_equal(kind, "version_requested") {
+        if subcmd_name.length > 0 {
+            if active.version.length > 0 {
+                print(cmd.name + " " + subcmd_name + " " + active.version);
+            } else if cmd.version.length > 0 {
+                print(cmd.name + " " + subcmd_name + " " + cmd.version);
+            } else { print(cmd.name + " " + subcmd_name); }
+        } else {
+            if cmd.version.length > 0 {
+                print(cmd.name + " " + cmd.version);
+            } else { print(cmd.name); }
+        }
+        process.exit(0);
+    }
+
+    // Parse failure: print the structured error message, then a help
+    // hint for everything except missing_value (which historically
+    // omitted the hint).
+    print.err(result.error.message);
+    if !strings_equal(kind, "missing_value") {
+        print.err("run '" + help_cmd + "' for usage");
+    }
+    process.exit(2);
+    return result.matches;
+}
+
+fn _ok_error() -> ParseError {
+    return ParseError {
+        kind: "ok",
+        message: "",
+        flag_name: "",
+        arg_name: ""
+    };
+}
+
+fn _err_result(command_name: string, subcommand_name: string, pos_names: string[], pos_values: string[], fl_names: string[], fl_values: string[], fl_present: boolean[], kind: string, message: string, flag_name: string, arg_name: string) -> ParseResult {
+    let matches = Matches {
+        command_name: command_name,
+        subcommand_name: subcommand_name,
+        positional_names: pos_names,
+        positional_values: pos_values,
+        flag_names: fl_names,
+        flag_values: fl_values,
+        flag_present: fl_present
+    };
+    return ParseResult {
+        ok: false,
+        matches: matches,
+        error: ParseError {
+            kind: kind,
+            message: message,
+            flag_name: flag_name,
+            arg_name: arg_name
+        }
     };
 }
 

--- a/capsules/sfn/cli/src/types.sfn
+++ b/capsules/sfn/cli/src/types.sfn
@@ -34,3 +34,35 @@ struct Matches {
     flag_values: string[];
     flag_present: boolean[];
 }
+
+// ParseError describes why `parse()` did not return successful matches.
+//
+// `kind` is one of: "ok", "help_requested", "version_requested",
+// "unknown_flag", "missing_value", "unexpected_positional",
+// "missing_required". String discriminants are used until proper sum
+// types land post-1.0.
+//
+// `message` carries the human-readable text that `run()` would print
+// to stderr (empty for "help_requested" / "version_requested", where
+// `run()` formats the help/version output itself).
+//
+// `flag_name` / `arg_name` carry the offending name when applicable,
+// otherwise empty.
+struct ParseError {
+    kind: string;
+    message: string;
+    flag_name: string;
+    arg_name: string;
+}
+
+// ParseResult is the non-exiting return shape of `parse()`. On success
+// `ok` is true and `matches` is the parsed `Matches`; on any other
+// outcome (including help/version requests) `ok` is false and `error`
+// describes what happened. `matches` still reflects whatever was
+// accumulated before the early exit so callers can inspect partial
+// state.
+struct ParseResult {
+    ok: boolean;
+    matches: Matches;
+    error: ParseError;
+}

--- a/capsules/sfn/cli/tests/parser_test.sfn
+++ b/capsules/sfn/cli/tests/parser_test.sfn
@@ -1,0 +1,190 @@
+// Tests for sfn/cli `parse()` — the non-exiting parser variant added
+// in Issue #774 (Phase 1 of the CLI Modularization Epic, #351).
+//
+// These tests exercise the structured ParseResult/ParseError surface
+// so test files can assert on parser error paths without triggering
+// `process.exit()`, which would tear down the whole test process. The
+// happy-path coverage continues to live in `cli_test.sfn`; here we
+// focus on every `ParseError.kind` plus a couple of success-shape
+// assertions that document the contract.
+//
+// `cli_test.sfn` is intentionally NOT touched in this issue — the
+// inlined `_parse` helper it uses stays in place until #355 rewrites
+// it to import `parse()` directly.
+import {
+    arg,
+    arg_optional,
+    command,
+    flag,
+    flag_short,
+    flag_value,
+    flag_value_short,
+    parse,
+    with_arg,
+    with_flag,
+    with_subcommand
+} from "../src/mod";
+
+// ---- "ok" — successful parse ----
+test "parse: success sets ok=true and error.kind=\"ok\"" {
+    let cmd = with_arg(command("app", "desc"), arg("file", "Source"));
+    let argv: string[] = ["app", "main.sfn"];
+    let r = parse(cmd, argv);
+    assert r.ok == true;
+    assert strings_equal(r.error.kind, "ok");
+    assert strings_equal(r.error.message, "");
+    assert strings_equal(r.error.flag_name, "");
+    assert strings_equal(r.error.arg_name, "");
+}
+
+test "parse: success matches struct mirrors run() shape" {
+    let cmd = with_flag(with_arg(command("app", "desc"), arg("file", "Source")), flag_short("verbose", "v", "Verbose"));
+    let argv: string[] = ["app", "-v", "main.sfn"];
+    let r = parse(cmd, argv);
+    assert r.ok == true;
+    assert strings_equal(r.matches.command_name, "app");
+    assert strings_equal(r.matches.subcommand_name, "");
+    assert r.matches.positional_names.length == 1;
+    assert strings_equal(r.matches.positional_names[0], "file");
+    assert strings_equal(r.matches.positional_values[0], "main.sfn");
+    assert r.matches.flag_names.length == 1;
+    assert strings_equal(r.matches.flag_names[0], "verbose");
+}
+
+// ---- "help_requested" ----
+test "parse: --help yields help_requested without printing" {
+    let cmd = command("app", "desc");
+    let argv: string[] = ["app", "--help"];
+    let r = parse(cmd, argv);
+    assert r.ok == false;
+    assert strings_equal(r.error.kind, "help_requested");
+    // parse() must not produce a printable message — run() formats it.
+    assert strings_equal(r.error.message, "");
+}
+
+test "parse: -h yields help_requested" {
+    let cmd = command("app", "desc");
+    let argv: string[] = ["app", "-h"];
+    let r = parse(cmd, argv);
+    assert r.ok == false;
+    assert strings_equal(r.error.kind, "help_requested");
+}
+
+test "parse: subcommand --help records subcommand_name" {
+    let sub = command("build", "Build the project");
+    let cmd = with_subcommand(command("app", "desc"), sub);
+    let argv: string[] = ["app", "build", "--help"];
+    let r = parse(cmd, argv);
+    assert r.ok == false;
+    assert strings_equal(r.error.kind, "help_requested");
+    // run() relies on subcommand_name to pick the right help target.
+    assert strings_equal(r.matches.subcommand_name, "build");
+}
+
+// ---- "version_requested" ----
+test "parse: --version yields version_requested" {
+    let cmd = command("app", "desc");
+    let argv: string[] = ["app", "--version"];
+    let r = parse(cmd, argv);
+    assert r.ok == false;
+    assert strings_equal(r.error.kind, "version_requested");
+    assert strings_equal(r.error.message, "");
+}
+
+test "parse: -V yields version_requested" {
+    let cmd = command("app", "desc");
+    let argv: string[] = ["app", "-V"];
+    let r = parse(cmd, argv);
+    assert r.ok == false;
+    assert strings_equal(r.error.kind, "version_requested");
+}
+
+// ---- "unknown_flag" ----
+test "parse: unknown long flag yields unknown_flag" {
+    let cmd = command("app", "desc");
+    let argv: string[] = ["app", "--bogus"];
+    let r = parse(cmd, argv);
+    assert r.ok == false;
+    assert strings_equal(r.error.kind, "unknown_flag");
+    assert strings_equal(r.error.message, "error: unknown flag --bogus");
+    assert strings_equal(r.error.flag_name, "bogus");
+    assert strings_equal(r.error.arg_name, "");
+}
+
+test "parse: unknown short flag yields unknown_flag" {
+    let cmd = command("app", "desc");
+    let argv: string[] = ["app", "-x"];
+    let r = parse(cmd, argv);
+    assert r.ok == false;
+    assert strings_equal(r.error.kind, "unknown_flag");
+    assert strings_equal(r.error.message, "error: unknown flag -x");
+    assert strings_equal(r.error.flag_name, "x");
+}
+
+// ---- "missing_value" ----
+test "parse: long flag missing value yields missing_value" {
+    let cmd = with_flag(command("app", "desc"), flag_value("output", "Output path"));
+    let argv: string[] = ["app", "--output"];
+    let r = parse(cmd, argv);
+    assert r.ok == false;
+    assert strings_equal(r.error.kind, "missing_value");
+    assert strings_equal(r.error.message, "error: flag --output requires a value");
+    assert strings_equal(r.error.flag_name, "output");
+}
+
+test "parse: short flag missing value yields missing_value" {
+    let cmd = with_flag(command("app", "desc"), flag_value_short("output", "o", "Out"));
+    let argv: string[] = ["app", "-o"];
+    let r = parse(cmd, argv);
+    assert r.ok == false;
+    assert strings_equal(r.error.kind, "missing_value");
+    assert strings_equal(r.error.message, "error: flag -o requires a value");
+    assert strings_equal(r.error.flag_name, "o");
+}
+
+// ---- "unexpected_positional" ----
+test "parse: extra positional yields unexpected_positional" {
+    let cmd = command("app", "desc");
+    let argv: string[] = ["app", "extra"];
+    let r = parse(cmd, argv);
+    assert r.ok == false;
+    assert strings_equal(r.error.kind, "unexpected_positional");
+    assert strings_equal(r.error.message, "error: unexpected argument 'extra'");
+    assert strings_equal(r.error.arg_name, "extra");
+    assert strings_equal(r.error.flag_name, "");
+}
+
+// ---- "missing_required" ----
+test "parse: omitted required positional yields missing_required" {
+    let cmd = with_arg(command("app", "desc"), arg("file", "Source"));
+    let argv: string[] = ["app"];
+    let r = parse(cmd, argv);
+    assert r.ok == false;
+    assert strings_equal(r.error.kind, "missing_required");
+    assert strings_equal(r.error.message, "error: missing required argument <file>");
+    assert strings_equal(r.error.arg_name, "file");
+}
+
+test "parse: omitted required positional after a flag yields missing_required" {
+    let cmd = with_flag(with_arg(command("app", "desc"), arg("file", "Source")), flag("verbose", "Verbose"));
+    let argv: string[] = ["app", "--verbose"];
+    let r = parse(cmd, argv);
+    assert r.ok == false;
+    assert strings_equal(r.error.kind, "missing_required");
+    assert strings_equal(r.error.arg_name, "file");
+    // Partial matches should still reflect the flag we consumed before
+    // the missing-required diagnostic — useful for richer recovery in
+    // future callers.
+    assert r.matches.flag_names.length == 1;
+    assert strings_equal(r.matches.flag_names[0], "verbose");
+}
+
+test "parse: optional positional missing still ok" {
+    let cmd = with_arg(command("app", "desc"), arg_optional("path", "Directory", "."));
+    let argv: string[] = ["app"];
+    let r = parse(cmd, argv);
+    assert r.ok == true;
+    assert strings_equal(r.error.kind, "ok");
+    assert r.matches.positional_values.length == 1;
+    assert strings_equal(r.matches.positional_values[0], ".");
+}


### PR DESCRIPTION
## Summary

- Adds `fn parse(cmd, argv) -> ParseResult` to `sfn/cli` — pure, no `process.exit`, no I/O — so test files and library callers can exercise parser error paths without tearing down the host process.
- Introduces `ParseResult { ok, matches, error }` and `ParseError { kind, message, flag_name, arg_name }` covering the seven discriminants: `ok`, `help_requested`, `version_requested`, `unknown_flag`, `missing_value`, `unexpected_positional`, `missing_required`.
- Refactors `run()` into a thin wrapper that calls `parse()` and applies the historical print + `process.exit()` policy. Stderr text and exit codes are byte-identical to the prior implementation.
- New `capsules/sfn/cli/tests/parser_test.sfn` (15 tests) covers every `error.kind` plus two success-shape assertions and imports `parse()` directly via `../src/mod`.

Phase 1 of the CLI Modularization Epic (#351).

Closes #774

## Acceptance Criteria

- [x] `ParseResult { ok, matches, error }` defined in `types.sfn`.
- [x] `ParseError { kind, message, flag_name, arg_name }` defined in `types.sfn`. `kind` covers `ok`, `help_requested`, `version_requested`, `unknown_flag`, `missing_value`, `unexpected_positional`, `missing_required`.
- [x] `parse(cmd, argv)` returns a populated `ParseResult` for every input — never calls `process.exit()`, never prints.
- [x] On success: `result.ok == true` and `result.matches` mirrors what `run()` would return.
- [x] On `--help`/`-h`: `result.ok == false`, `error.kind == "help_requested"`, no help text printed.
- [x] On `--version`/`-V`: `result.ok == false`, `error.kind == "version_requested"`.
- [x] Each former `process.exit(2)` path sets `error.kind`, `error.message`, and `error.flag_name` / `error.arg_name` appropriately.
- [x] `run()` is refactored to call `parse()` and apply print + exit. Observable behavior unchanged — verified by the existing 47 tests in `cli_test.sfn` continuing to pass without modification.
- [x] New `parser_test.sfn` covers every `error.kind` (15 tests, calls `parse()` only — never `run()`).
- [x] `mod.sfn` re-exports `parse`, `ParseResult`, `ParseError`.
- [x] `make compile` succeeds.
- [x] `make test` passes with no regressions.
- [x] `sfn fmt --check` clean.

## Verification

```bash
ulimit -v 8388608 && make compile
# [compile] built build/native/sailfin

ulimit -v 8388608 && timeout 60 build/native/sailfin test capsules/sfn/cli/tests/
# parser_test.sfn: PASS (all 15 tests passed)
# cli_test.sfn:    PASS (all 47 tests passed)

ulimit -v 8388608 && make test
# capsules: 14/14 passed, 0 failed
# e2e: 77/77 passed, 0 failed

ulimit -v 8388608 && timeout 30 build/native/sailfin fmt --check capsules/sfn/cli/
# (clean)
```

## Files Changed

- `capsules/sfn/cli/src/types.sfn` — add `ParseError`, `ParseResult` structs.
- `capsules/sfn/cli/src/parser.sfn` — add pure `parse()`; refactor `run()` to delegate.
- `capsules/sfn/cli/src/mod.sfn` — re-export `parse`, `ParseError`, `ParseResult`.
- `capsules/sfn/cli/tests/parser_test.sfn` — NEW. 15 tests, one per `error.kind` plus two success-shape assertions.

## Notes

- `cli_test.sfn` is intentionally untouched per the issue's `Out:` scope. Its inlined `_parse` helper will be replaced with imports of the real `parse()` in #355.
- For the `unknown_flag` / `missing_value` short-flag paths, `error.flag_name` carries the short letter the user typed (consistent with the long-flag case carrying the typed name). This keeps `flag_name` predictable: it's always the literal token minus its dash prefix, regardless of long vs short form.
- `parse()` returns *partial* matches accumulated before an early exit (verified by `"omitted required positional after a flag"` test). Useful for future error-recovery callers.

https://claude.ai/code

---
_Generated by [Claude Code](https://claude.ai/code/session_01XWdFgPZmhLaqN5tX5KJahz)_