### PR TITLE
refactor(runtime): retire sailfin_enum_tag_from_instruction_array C helper (#628)

### DIFF
--- a/docs/conventions/runtime-helpers.md
+++ b/docs/conventions/runtime-helpers.md
@@ -84,13 +84,13 @@ The runtime helper registry is for descriptors that:
 It is **not** the right place for:
 
 - Preamble-inlined declares (spawn/await family, arena primitives,
-  the rc-release helper, `sailfin_enum_tag_from_instruction_array`).
-  Those are emitted unconditionally by `render_llvm_preamble`
-  (`lowering_phase_render.sfn:110-112` and `:173-185`); the
-  preamble-inline filter in `render_runtime_helper_declarations`
-  skips them to avoid the `llvm-as: invalid redefinition` failure
-  #740 caught. New preamble-inlined helpers extend that filter
-  list rather than adding a descriptor.
+  the rc-release helper). Those are emitted unconditionally by
+  `render_llvm_preamble` (`lowering_phase_render.sfn:110-112` and
+  `:173-185`); the preamble-inline filter in
+  `render_runtime_helper_declarations` skips them to avoid the
+  `llvm-as: invalid redefinition` failure #740 caught. New
+  preamble-inlined helpers extend that filter list rather than
+  adding a descriptor.
 - Helpers reached only through prelude module-level let bindings
   (`runtime_array_map_fn = runtime.array_map`, etc.). These are
   invisible to both walkers and remain in

--- a/docs/runtime_audit.md
+++ b/docs/runtime_audit.md
@@ -458,7 +458,6 @@ survives until process exit. This is why per-module compiler RAM reaches
 | `sailfin_runtime_sha256_hex` | ✅ | Separate file `sailfin_sha256.c` (~150 lines) |
 | `sailfin_runtime_base64_encode` | ✅ | Separate file `sailfin_base64.c` |
 | `sailfin_runtime_getenv` / `home_dir` / `read_file_bytes` | ✅ | Used by `sfn/os` and package manager |
-| `sailfin_enum_tag_from_instruction_array` | ✅ | Seedcheck workaround for reading `i32` enum tags when `match`/field-access is unavailable |
 
 ### Helpers the compiler declares but never emits (link-time landmines)
 

--- a/runtime/native/src/sailfin_runtime.c
+++ b/runtime/native/src/sailfin_runtime.c
@@ -8413,46 +8413,6 @@ void sailfin_runtime_debug_validate_identifier(void *expr_ptr, void *name_ptr)
     }
 }
 
-/* Read the i32 tag from a Sailfin enum passed by value.
-   Sailfin enums are laid out as { i32 tag, [4 x i8] pad, [N x i64] payload }.
-   The LLVM calling convention passes small structs in registers, but the ABI
-   maps to pointer-based access for the generic interface.
-
-   This function is called from get_instruction_tag in lowering_native_helpers.sfn
-   when the seedcheck binary cannot use match or field-access to read the tag.
-   The first-pass binary uses a fixup that reads the tag directly; the seedcheck
-   uses this C helper.
-
-   Arguments:
-     arr_ptr — pointer to an array header { elem_type*, i64 length }
-     idx     — element index (as double, Sailfin's number type)
-   Returns: tag value as double */
-/* NativeInstruction = { i32 tag, [4 x i8] pad, [6 x i64] payload }
-   Mirror the LLVM struct layout so sizeof() tracks any future changes. */
-struct SailfnNativeInstruction
-{
-    int32_t tag;
-    uint8_t _pad[4];
-    int64_t payload[6];
-};
-
-double sailfin_enum_tag_from_instruction_array(void *arr_ptr, double idx)
-{
-    struct
-    {
-        void *data;
-        int64_t length;
-    } *hdr = arr_ptr;
-    if (!hdr || !hdr->data)
-        return 21.0; /* Unknown */
-    int64_t i = (int64_t)idx;
-    if (i < 0 || i >= hdr->length)
-        return 21.0;
-    struct SailfnNativeInstruction *elem =
-        (struct SailfnNativeInstruction *)hdr->data + i;
-    return (double)elem->tag;
-}
-
 /* =====================================================================
  * M1.B v2 array helpers — accept the SfnArray ABI (`{T*, i64, i64}*`)
  * and use only plain malloc/realloc for backing storage. The legacy


### PR DESCRIPTION
## Summary

Final slice of epic #620: deletes the now-unused C helper `sailfin_enum_tag_from_instruction_array` along with its `SailfnNativeInstruction` shim struct, and removes its references from `docs/conventions/runtime-helpers.md` and `docs/runtime_audit.md`.

The Sailfin-side replacement landed in #626 (PR #768); consumer-side `tag == 21` salvage paths cleared in #627 (PR #770). With no remaining callers, the C delegate is dead weight.

After this change the repo has **zero** matches for `Seed drops this` / `fixup pass replaces body` / `sailfin_enum_tag_from_instruction_array` — the fixup-pass concept is fully retired.

Closes #628

## Acceptance Criteria

- [x] `runtime/native/src/sailfin_runtime.c` no longer defines `sailfin_enum_tag_from_instruction_array`.
- [x] Zero matches for `Seed drops this` / `fixup pass replaces body` / `sailfin_enum_tag_from_instruction_array` in `compiler/ runtime/ docs/ CLAUDE.md`.
- [x] `make compile && make check` green (stage2/stage3 fixed-point holds).
- [x] Documentation updated (`docs/runtime_audit.md`, `docs/conventions/runtime-helpers.md`).

## Verification

```bash
ulimit -v 8388608 && make compile && make check
# → 77/77 e2e, 13/13 capsules, stage2 == stage3 fixed point ✓

grep -rn "sailfin_enum_tag_from_instruction_array\|Seed drops this\|fixup pass replaces body" \
  compiler/ runtime/ docs/ CLAUDE.md
# → no output
```

## Files Changed

- `runtime/native/src/sailfin_runtime.c` — deleted helper + shim struct (40 lines)
- `docs/conventions/runtime-helpers.md` — removed preamble-inline reference
- `docs/runtime_audit.md` — removed runtime-audit row

## Notes

This closes the chain that began with epic #613 (compiler integrity gaps audit) and parent epic #620 (lowering-fixup retirement). All six slices (#623, #624, #625, #626, #627, #628) are now complete.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VWN6isaR33wyBKBa4VX77g)_