### PR TITLE
docs(cli): drop deleted LLVM trace env vars, rephrase SAILFIN_TRACE_ARGV

### DIFF
--- a/site/src/content/docs/docs/reference/cli.md
+++ b/site/src/content/docs/docs/reference/cli.md
@@ -441,9 +441,7 @@ These variables enable verbose runtime diagnostics. They are intended for compil
 
 | Variable | Description |
 |---|---|
-| `SAILFIN_TRACE_ARGV` | Print the argument vector received by the native driver on startup. |
-| `SAILFIN_TRACE_EMIT_LLVM` | Trace LLVM IR emission. |
-| `SAILFIN_TRACE_EMIT_LLVM_PATH` | Write emitted LLVM IR to the given file path. |
+| `SAILFIN_TRACE_ARGV` | Print the argument vector received by `sailfin_cli_main` on startup (honored by the Sailfin entry point in `compiler/src/cli_main.sfn`). |
 | `SAILFIN_TRACE_CRASH` | Enable extended crash diagnostics. |
 | `SAILFIN_TRACE_ALLOC_STATS` | Print allocation statistics on exit. |
 | `SAILFIN_TRACE_LARGE_ARRAY_BACKTRACE` | Capture backtraces for unusually large array allocations. |


### PR DESCRIPTION
## Summary

- Drop the `SAILFIN_TRACE_EMIT_LLVM` and `SAILFIN_TRACE_EMIT_LLVM_PATH` rows from `site/src/content/docs/docs/reference/cli.md` — the C-side helpers behind them were deleted with `native_driver.c` in PR #753.
- Rephrase the `SAILFIN_TRACE_ARGV` row: the env var is still honored, but by `sailfin_cli_main` in `compiler/src/cli_main.sfn` (the Sailfin entry point), not by the now-deleted native driver.

Closes #467

## Acceptance Criteria

- [x] `grep -n "SAILFIN_TRACE_EMIT_LLVM" site/src/content/docs/docs/reference/cli.md` returns empty.
- [x] `SAILFIN_TRACE_ARGV` row in `cli.md` no longer mentions "native driver"; describes the Sailfin implementation path (`sailfin_cli_main` in `compiler/src/cli_main.sfn`).
- [ ] `make check` passes — running in CI; trivially satisfied since the diff only touches a docs `.md` file under `site/` that the Makefile does not consume.

## Verification

```bash
$ grep -n "SAILFIN_TRACE_EMIT_LLVM" site/src/content/docs/docs/reference/cli.md
# (empty — exit 1)
```

## Files Changed

- `site/src/content/docs/docs/reference/cli.md` — drop 2 rows, rephrase 1


---
_Generated by [Claude Code](https://claude.ai/code/session_01FQn87a9WZfF4u9Paa1QpVi)_