### PR TITLE
feat(runtime): env.get / env.home SfnString aggregate ABI (M2.8b, #726)

### DIFF
--- a/compiler/src/llvm/expression_lowering/native/core_call_lowering.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_call_lowering.sfn
@@ -440,6 +440,25 @@ fn lower_call_expression(target: string, arguments: string[], bindings: Paramete
         }
     }
 
+    // M2.8b (#726): splice `ptr @sfn_default_arena` as the trailing
+    // arg for env.get / env.home so the SfnString aggregate trampolines
+    // can NUL-marshal the name and wrap the result. Mirrors the
+    // `sfn_str_concat` arena-threading pattern from #714. The
+    // descriptors carry `parameter_types` with the trailing `ptr` slot;
+    // the user-facing source still passes only `name` / `()`, so the
+    // operand-count gate above sees the pre-injection list and only
+    // post-gate emission sees the spliced operand.
+    let mut _env_target_match: boolean = false;
+    if trimmed_target == "env.get" { _env_target_match = true; }
+    if trimmed_target == "env.home" { _env_target_match = true; }
+    if _env_target_match {
+        let arena_operand = LLVMOperand {
+            llvm_type: "ptr",
+            value: "@sfn_default_arena"
+        };
+        operands.push(arena_operand);
+    }
+
     // Phase 4: Coerce operands and emit the call (delegated to core_call_emission)
     return coerce_and_emit_call(trimmed_target, operands, expected_params, llvm_return, is_trait_dispatch, is_closure_dispatch, is_array_concat, array_concat_element_type, is_array_push, array_push_element_type, method_operand, helper_descriptor, function_entry, current_temp, current_lines, diagnostics, collected_string_constants, bindings, locals, context);
 }

--- a/compiler/src/llvm/runtime_helpers.sfn
+++ b/compiler/src/llvm/runtime_helpers.sfn
@@ -869,16 +869,20 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
     });
 
     // Environment & path helpers
-    // M2.8 (#401): native_signature flipped to the Sailfin-native
-    // sfn_getenv / sfn_home_dir C trampolines. The legacy i8* ABI
-    // is preserved on parameter_types and return_type; the
-    // SfnString aggregate flip needs arena threading at the call
-    // site and waits on a follow-up wave.
+    // M2.8b (#726): SfnString aggregate ABI flip for env.get / env.home.
+    // `parameter_types` carries the `{i8*, i64}` aggregate (name) plus
+    // the trailing `ptr` slot threaded as `ptr @sfn_default_arena` by
+    // the call-site dispatch in `core_call_lowering.sfn` (mirrors the
+    // `sfn_str_concat` arena-threading pattern from #714).
+    // `return_type` returns the SfnString aggregate; downstream
+    // consumers fall back to the existing `{i8*, i64} → i8*`
+    // extractvalue coercion in `coerce_pointer_or_struct` for the
+    // legacy `i8*` string-typed locals.
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "env.get", symbol: "sailfin_runtime_getenv", return_type: "i8*", parameter_types: ["i8*"], effects: ["io"], native_signature: "sfn_getenv", c_abi_return_type: null
+        target: "env.get", symbol: "sailfin_runtime_getenv", return_type: "{i8*, i64}", parameter_types: ["{i8*, i64}", "ptr"], effects: ["io"], native_signature: "sfn_getenv", c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "env.home", symbol: "sailfin_runtime_home_dir", return_type: "i8*", parameter_types: [], effects: ["io"], native_signature: "sfn_home_dir", c_abi_return_type: null
+        target: "env.home", symbol: "sailfin_runtime_home_dir", return_type: "{i8*, i64}", parameter_types: ["ptr"], effects: ["io"], native_signature: "sfn_home_dir", c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
         target: "fs.read_bytes", symbol: "sailfin_runtime_read_file_bytes", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: ["io"], native_signature: null, c_abi_return_type: null

--- a/compiler/tests/e2e/test_runtime_io_extended.sh
+++ b/compiler/tests/e2e/test_runtime_io_extended.sh
@@ -193,6 +193,21 @@ PROBE
             found=$((found + 1))
         fi
     done
+    # M2.8b (#726): env.get / env.home must lower against the
+    # SfnString aggregate ABI with the trailing arena slot. Pin the
+    # exact call shape so a regression that drops the arena thread or
+    # reverts the aggregate flip is caught at the IR layer rather
+    # than as a downstream segfault.
+    if ! grep -qE 'call \{i8\*, i64\} @sfn_getenv\(\{i8\*, i64\} .+, ptr @sfn_default_arena\)' "$ll"; then
+        echo "[test]   io_probe.sfn does not lower env.get to call {i8*, i64} @sfn_getenv({i8*, i64} ..., ptr @sfn_default_arena)"
+        grep -nE '@sfn_getenv\b' "$ll" | head -3
+        found=$((found + 1))
+    fi
+    if ! grep -qE 'call \{i8\*, i64\} @sfn_home_dir\(ptr @sfn_default_arena\)' "$ll"; then
+        echo "[test]   io_probe.sfn does not lower env.home to call {i8*, i64} @sfn_home_dir(ptr @sfn_default_arena)"
+        grep -nE '@sfn_home_dir\b' "$ll" | head -3
+        found=$((found + 1))
+    fi
     return "$((missing + found))"
 }
 

--- a/docs/runtime_architecture.md
+++ b/docs/runtime_architecture.md
@@ -2212,6 +2212,8 @@ The following are explicitly **not** in scope for the 1.0 runtime:
 | `sailfin_runtime_sha256_hex` | `sfn/crypto` capsule | M3 |
 | `sailfin_runtime_base64_encode` | `sfn/crypto` capsule | M3 |
 | `sailfin_runtime_http_get/post_json/download` | `sfn_http_get/post` | M3 |
+| `sailfin_runtime_getenv` | `sfn_getenv` | **M2.8b (#726) shipped SfnString aggregate ABI + arena-threaded marshalling; legacy `i8*` entrypoint retained for seed compatibility.** |
+| `sailfin_runtime_home_dir` | `sfn_home_dir` | **M2.8b (#726) shipped SfnString aggregate ABI + arena-threaded marshalling; legacy `i8*` entrypoint retained for seed compatibility.** |
 
 ## Appendix B: Compiler Files Affected by Milestone
 

--- a/runtime/native/include/sailfin_runtime.h
+++ b/runtime/native/include/sailfin_runtime.h
@@ -444,12 +444,16 @@ extern "C"
     // Environment & path helpers.
     char *sailfin_runtime_getenv(const char *name);
     char *sailfin_runtime_home_dir(void);
-    /* M2.8 (#401): symbol-flip trampolines for `env.get` / `env.home`.
-     * Same legacy `i8*` ABI as the entrypoints above — the aggregate
-     * `SfnString` flip on these waits for the arena-threading wave
-     * (a follow-up under M2.8). Bodies forward verbatim. */
-    char *sfn_getenv(const char *name);
-    char *sfn_home_dir(void);
+    /* M2.8b (#726): SfnString aggregate ABI for `env.get` / `env.home`.
+     * The compiler's runtime_helpers.sfn descriptors carry
+     * `parameter_types: ["{i8*, i64}", "ptr"]` / `["ptr"]` and
+     * `return_type: "{i8*, i64}"`; the call-site dispatch in
+     * `core_call_lowering.sfn` splices `ptr @sfn_default_arena` as
+     * the trailing arg (mirrors `sfn_str_concat` from #714). Bodies
+     * NUL-marshal the name through the arena, call `getenv`, and
+     * wrap the libc result via `sfn_str_from_cstr` + `sfn_str_len`. */
+    SfnString sfn_getenv(SfnString name, SfnArena **arena_slot);
+    SfnString sfn_home_dir(SfnArena **arena_slot);
     char *sailfin_runtime_read_file_bytes(const char *path, int64_t *out_length);
 
     // Misc stubs.

--- a/runtime/native/src/sailfin_runtime.c
+++ b/runtime/native/src/sailfin_runtime.c
@@ -8117,16 +8117,82 @@ char *sailfin_runtime_home_dir(void)
     return strdup(home);
 }
 
-/* M2.8 (#401): symbol-flip trampolines for `env.get` / `env.home`.
- * The compiler's runtime_helpers.sfn registry carries
- * `native_signature: "sfn_getenv"` / `"sfn_home_dir"` on the two
- * descriptors, so fresh user emission lands on these symbols. The
- * `parameter_types` / `return_type` stay at the legacy `i8*` shape
- * (no SfnString aggregate flip yet — that wave needs arena
- * threading, deferred under M2.8). Bodies forward verbatim. */
-char *sfn_getenv(const char *name) { return sailfin_runtime_getenv(name); }
+/* M2.8b (#726): SfnString aggregate ABI for `env.get` / `env.home`.
+ * The runtime_helpers.sfn descriptors carry
+ * `parameter_types: ["{i8*, i64}", "ptr"]` (env.get) /
+ * `parameter_types: ["ptr"]` (env.home) and
+ * `return_type: "{i8*, i64}"`. The compiler's call-site dispatch
+ * splices `ptr @sfn_default_arena` as the trailing arg (mirrors
+ * `sfn_str_concat` from #714); the bodies below NUL-marshal the
+ * name through the arena and wrap the libc result via
+ * `sfn_str_from_cstr` + `sfn_str_len`. The legacy
+ * `sailfin_runtime_getenv` / `sailfin_runtime_home_dir` entrypoints
+ * stay exported above so seed-built IR (which still emits the legacy
+ * `i8*` ABI) keeps linking through the 2-pass self-host build. */
+SfnString sfn_getenv(SfnString name, SfnArena **arena_slot)
+{
+    SfnString result = {NULL, 0};
+    if (name.data == NULL || name.len <= 0)
+        return result;
 
-char *sfn_home_dir(void) { return sailfin_runtime_home_dir(); }
+    /* Resolve arena — mirrors `sfn_str_concat`'s slot/fallback gate. */
+    SfnArena *arena;
+    if (arena_slot != NULL && *arena_slot != NULL)
+    {
+        arena = *arena_slot;
+    }
+    else
+    {
+        arena = sfn_arena_global();
+        if (arena_slot != NULL && *arena_slot == NULL)
+        {
+            *arena_slot = arena;
+        }
+    }
+
+    /* NUL-marshal `name` into the arena so getenv() sees a clean C
+     * string regardless of the aggregate's NUL invariant. Today's
+     * SfnString.data is NUL-terminated (literal lowering writes a
+     * trailing 0; arena-routed concat preserves it), but the spec'd
+     * invariant only covers `len` bytes — copying through the arena
+     * keeps the contract independent of the data slot's terminator. */
+    size_t nlen = (size_t)name.len;
+    char *cname = (char *)sfn_arena_alloc(arena, nlen + 1, 1);
+    if (cname == NULL)
+        return result;
+    if (nlen > 0)
+        memcpy(cname, name.data, nlen);
+    cname[nlen] = '\0';
+
+    const char *val = getenv(cname);
+    if (val == NULL)
+        return result;
+
+    /* Wrap the libc-owned pointer via `sfn_str_from_cstr` (identity
+     * bridge in the M2.4a wave). `getenv()` guarantees a
+     * NUL-terminated buffer stable until the next mutating call on
+     * the same key, so the aggregate's data slot keeps the
+     * literal/concat NUL-termination invariant. Length recovered via
+     * `sfn_str_len` (the `native_signature` flip from M2.4a routes
+     * through `sailfin_runtime_string_length` for safe walking). */
+    const char *wrapped = sfn_str_from_cstr(val);
+    result.data = (char *)wrapped;
+    result.len = sfn_str_len(wrapped);
+    return result;
+}
+
+SfnString sfn_home_dir(SfnArena **arena_slot)
+{
+#if defined(_WIN32)
+    static const char k_home_name[] = "USERPROFILE";
+#else
+    static const char k_home_name[] = "HOME";
+#endif
+    SfnString name;
+    name.data = (char *)k_home_name;
+    name.len = (int64_t)(sizeof(k_home_name) - 1);
+    return sfn_getenv(name, arena_slot);
+}
 
 char *sailfin_runtime_read_file_bytes(const char *path, int64_t *out_length)
 {

--- a/runtime/native/src/sailfin_runtime.c
+++ b/runtime/native/src/sailfin_runtime.c
@@ -8150,6 +8150,23 @@ SfnString sfn_getenv(SfnString name, SfnArena **arena_slot)
         }
     }
 
+    /* Decode pre-M1.A.2 tagged immediate-codepoint inputs into a
+     * stack buffer before the memcpy, mirroring `sfn_str_concat`'s
+     * handling: single-codepoint "strings" (e.g. literal `"X"`) are
+     * lowered to `((uint64_t)codepoint << 32)` rather than a real
+     * pointer; dereferencing `name.data` directly would segfault.
+     * `_utf8_encode` writes 1-4 UTF-8 bytes for the codepoint and
+     * the byte length matches what `sfn_str_len` returned at the
+     * call site. */
+    unsigned char name_imm_buf[5] = {0};
+    const char *name_data = name.data;
+    uint32_t name_cp = 0;
+    if (_is_immediate_codepoint_string(name.data, &name_cp))
+    {
+        _utf8_encode(name_cp, name_imm_buf);
+        name_data = (const char *)name_imm_buf;
+    }
+
     /* NUL-marshal `name` into the arena so getenv() sees a clean C
      * string regardless of the aggregate's NUL invariant. Today's
      * SfnString.data is NUL-terminated (literal lowering writes a
@@ -8161,7 +8178,7 @@ SfnString sfn_getenv(SfnString name, SfnArena **arena_slot)
     if (cname == NULL)
         return result;
     if (nlen > 0)
-        memcpy(cname, name.data, nlen);
+        memcpy(cname, name_data, nlen);
     cname[nlen] = '\0';
 
     const char *val = getenv(cname);

--- a/runtime/sfn/io.sfn
+++ b/runtime/sfn/io.sfn
@@ -121,15 +121,23 @@ fn sfn_print_error_sfn(msg: * u8) -> void ![io] {
 }
 
 // `sfn_getenv_sfn(name)` — environment-variable read. Architect
-// spec marshals `name` to a NUL-terminated buffer in an arena and
-// wraps the result through `sfn_str_from_cstr`; today's body
-// passes the NUL-terminated legacy pointer through directly since
-// SfnString.data already carries a trailing NUL (literal lowering
-// + arena-routed concat preserve it).
+// spec: `(SfnString, *Arena) -> SfnString` — NUL-marshal name into
+// the arena, call `extern fn getenv`, wrap result via
+// `sfn_str_from_cstr`. M2.8b (#726) shipped the aggregate ABI on
+// the bare C trampoline (`sfn_getenv` in `sailfin_runtime.c`); the
+// `_sfn_` infix proof-of-life body below keeps the legacy `* u8`
+// shape because the Sailfin frontend can't take SfnString
+// aggregate parameters or a `*SfnArena` slot today (M1.A.2). The
+// user-emission hot path bypasses this wrapper entirely and lands
+// on `@sfn_getenv` against the real aggregate ABI.
 fn sfn_getenv_sfn(name: * u8) -> * u8 ![io] {
     return sailfin_runtime_getenv(name);
 }
 
 // `sfn_home_dir_sfn()` — `getenv("HOME")` (or `USERPROFILE` on
-// Windows; the C trampoline handles the platform fork).
+// Windows; the C trampoline handles the platform fork). Architect
+// spec: `(*Arena) -> SfnString` — `sfn_getenv("HOME", arena)`. Same
+// proof-of-life constraint as `sfn_getenv_sfn`: the bare
+// `sfn_home_dir` trampoline carries the aggregate ABI; this body
+// stays a `* u8` forwarder until M1.A.2.
 fn sfn_home_dir_sfn() -> * u8 ![io] { return sailfin_runtime_home_dir(); }


### PR DESCRIPTION
## Summary

Finishes the M2.8 (#401) deferral: flips `env.get` / `env.home` from the
legacy `i8*` ABI to the SfnString aggregate `{i8*, i64}` return with
arena-threaded marshalling, matching `docs/runtime_architecture.md` §2.8.
Mirrors the `sfn_str_concat` arena-threading pattern from #714.

- `runtime_helpers.sfn`: `env.get` descriptor → `parameter_types: ["{i8*, i64}", "ptr"]`, `return_type: "{i8*, i64}"`; `env.home` → `parameter_types: ["ptr"]`, same return.
- `core_call_lowering.sfn`: splice `ptr @sfn_default_arena` as the trailing operand for both helpers after the argument-count gate, before Phase 4 emission.
- `sailfin_runtime.c` / `.h`: rewrite the trampolines to accept the SfnString aggregate plus the `SfnArena **` slot; NUL-marshal `name` through the arena, call `getenv`, wrap the libc result via `sfn_str_from_cstr` + `sfn_str_len`. Legacy `sailfin_runtime_getenv` / `sailfin_runtime_home_dir` entrypoints stay exported for seed-compiled IR.
- `runtime/sfn/io.sfn`: refresh the `sfn_getenv_sfn` / `sfn_home_dir_sfn` proof-of-life comments to reflect the new aggregate ABI; bodies stay `* u8` forwarders to the legacy entrypoints until M1.A.2 lands aggregate-typed parameters.
- `test_runtime_io_extended.sh`: extend the probe to pin the exact aggregate-shape call IR for both helpers.
- `docs/runtime_architecture.md`: add Appendix A status lines for `sfn_getenv` / `sfn_home_dir`.

Closes #726

## Acceptance Criteria

- [x] `env.get("HOME")` lowers to `call {i8*, i64} @sfn_getenv({i8*, i64} %name, ptr @sfn_default_arena)`.
- [x] `env.home()` lowers to `call {i8*, i64} @sfn_home_dir(ptr @sfn_default_arena)`.
- [x] Fresh user emission no longer references `@sailfin_runtime_getenv` / `@sailfin_runtime_home_dir`.
- [x] `capsules/sfn/os/src/mod.sfn` still compiles (returns env value as `string`; the existing `{i8*, i64} → i8*` extractvalue coercion in `coerce_pointer_or_struct` recovers the data pointer).
- [x] `make compile` passes.
- [x] `make test` passes — e2e: 77/77, capsules: 14/14, plus full unit/integration suites.

## Verification

```bash
$ ulimit -v 8388608 && build/native/sailfin emit -o /tmp/probe.ll llvm /tmp/env_probe.sfn \
    && grep -E '@sfn_(getenv|home_dir)|@sailfin_runtime_(getenv|home_dir)' /tmp/probe.ll
declare {i8*, i64} @sfn_getenv({i8*, i64}, ptr)
declare {i8*, i64} @sfn_home_dir(ptr)
  %t0 = call {i8*, i64} @sfn_home_dir(ptr @sfn_default_arena)
  %t6 = call {i8*, i64} @sfn_getenv({i8*, i64} %t5, ptr @sfn_default_arena)

$ ulimit -v 8388608 && bash compiler/tests/e2e/test_runtime_io_extended.sh build/native/sailfin
[test] PASS: sfn check runtime/sfn/io.sfn passes
[test] PASS: sfn fmt --check runtime/sfn/io.sfn is canonical
[test] PASS: sfn emit llvm produces define for every sfn_*_sfn_* export
[test] PASS: sfn emit llvm does not collide with C trampoline ... names
[test] PASS: hello-world.sfn lowers print() to @sfn_print({i8*, i64} ...)
[test] PASS: probe binary routes every print/console/env site through @sfn_*
[test] PASS: compiler binary exports defined sfn_print* / sfn_getenv / sfn_home_dir and _sfn_ infix symbols
[test] PASS: runtime/native/capsule.toml sfn-sources lists the io module
[test] PASS: hello-world.sfn still prints correctly end-to-end
[summary] 9 passed, 0 failed

$ ulimit -v 8388608 && make test    # excerpt
═══ e2e: 77/77 passed, 0 failed ═══
═══ capsules: 14/14 passed, 0 failed ═══
```

## Files Changed

- `compiler/src/llvm/runtime_helpers.sfn`
- `compiler/src/llvm/expression_lowering/native/core_call_lowering.sfn`
- `runtime/native/src/sailfin_runtime.c`
- `runtime/native/include/sailfin_runtime.h`
- `runtime/sfn/io.sfn`
- `compiler/tests/e2e/test_runtime_io_extended.sh`
- `docs/runtime_architecture.md`
