### PR TITLE
refactor(cli): rewrite cli_test.sfn against public API (#355)

### DIFF
--- a/capsules/sfn/cli/src/parser.sfn
+++ b/capsules/sfn/cli/src/parser.sfn
@@ -8,12 +8,19 @@
 // reported as `"unknown_flag"`, `"missing_value"`,
 // `"unexpected_positional"`, or `"missing_required"`.
 //
+// For every non-`missing_value` failure, `error.message` is the full
+// two-line stderr text `run()` would print — the diagnostic line plus
+// the `run '<prog> --help' for usage` hint, joined with a newline. This
+// lets callers of `parse()` assert on the help-hint format without
+// reaching for the private `_help_hint` helper. `missing_value`
+// historically suppressed the hint and continues to do so.
+//
 // `run()` is the historical exiting variant kept for binary entry
 // points. It now delegates to `parse()` and applies the print +
 // `process.exit()` policy:
 //   * `--help`/`-h` -> print help, exit 0
 //   * `--version`/`-V` -> print version, exit 0
-//   * parse failures -> print to stderr, exit 2
+//   * parse failures -> print `error.message` to stderr, exit 2
 // Its observable behavior (stderr text, exit codes) is byte-identical
 // to the pre-`parse()` implementation.
 import { _format_help } from "./help";
@@ -76,8 +83,8 @@ fn parse(cmd: Command, argv: string[]) -> ParseResult {
             let flag_name = substring(token, 2, token.length);
             let f = _find_flag_long(active, flag_name);
             if f.long_name.length == 0 {
-                return _err_result(cmd.name, subcmd_name, pos_names, pos_values, fl_names, fl_values, fl_present, "unknown_flag", "error: unknown flag --"
-                    + flag_name, flag_name, "");
+                return _err_result(cmd.name, subcmd_name, pos_names, pos_values, fl_names, fl_values, fl_present, "unknown_flag", _with_hint(cmd.name, subcmd_name, "error: unknown flag --"
+                    + flag_name), flag_name, "");
             }
             fl_names.push(f.long_name);
             fl_present.push(true);
@@ -95,8 +102,8 @@ fn parse(cmd: Command, argv: string[]) -> ParseResult {
             let short = substring(token, 1, token.length);
             let f = _find_flag_short(active, short);
             if f.long_name.length == 0 {
-                return _err_result(cmd.name, subcmd_name, pos_names, pos_values, fl_names, fl_values, fl_present, "unknown_flag", "error: unknown flag -"
-                    + short, short, "");
+                return _err_result(cmd.name, subcmd_name, pos_names, pos_values, fl_names, fl_values, fl_present, "unknown_flag", _with_hint(cmd.name, subcmd_name, "error: unknown flag -"
+                    + short), short, "");
             }
             fl_names.push(f.long_name);
             fl_present.push(true);
@@ -116,9 +123,9 @@ fn parse(cmd: Command, argv: string[]) -> ParseResult {
                 pos_values.push(token);
                 pos_idx += 1;
             } else {
-                return _err_result(cmd.name, subcmd_name, pos_names, pos_values, fl_names, fl_values, fl_present, "unexpected_positional", "error: unexpected argument '"
+                return _err_result(cmd.name, subcmd_name, pos_names, pos_values, fl_names, fl_values, fl_present, "unexpected_positional", _with_hint(cmd.name, subcmd_name, "error: unexpected argument '"
                     + token
-                    + "'", "", token);
+                    + "'"), "", token);
             }
         }
         idx += 1;
@@ -132,9 +139,9 @@ fn parse(cmd: Command, argv: string[]) -> ParseResult {
             pos_names.push(a.name);
             pos_values.push(a.default_value);
         } else {
-            return _err_result(cmd.name, subcmd_name, pos_names, pos_values, fl_names, fl_values, fl_present, "missing_required", "error: missing required argument <"
+            return _err_result(cmd.name, subcmd_name, pos_names, pos_values, fl_names, fl_values, fl_present, "missing_required", _with_hint(cmd.name, subcmd_name, "error: missing required argument <"
                 + a.name
-                + ">", "", a.name);
+                + ">"), "", a.name);
         }
         pos_idx += 1;
     }
@@ -161,7 +168,6 @@ fn run(cmd: Command, argv: string[]) -> Matches ![io] {
 
     let subcmd_name = result.matches.subcommand_name;
     let active = _resolve_active(cmd, subcmd_name);
-    let help_cmd = _help_hint(cmd.name, subcmd_name);
     let kind = result.error.kind;
 
     if strings_equal(kind, "help_requested") {
@@ -185,15 +191,18 @@ fn run(cmd: Command, argv: string[]) -> Matches ![io] {
         process.exit(0);
     }
 
-    // Parse failure: print the structured error message, then a help
-    // hint for everything except missing_value (which historically
-    // omitted the hint).
+    // Parse failure: `error.message` already contains the help-hint
+    // suffix for every kind except `missing_value` (which historically
+    // omits the hint), so a single stderr write reproduces the
+    // pre-parse() stderr exactly.
     print.err(result.error.message);
-    if !strings_equal(kind, "missing_value") {
-        print.err("run '" + help_cmd + "' for usage");
-    }
     process.exit(2);
     return result.matches;
+}
+
+fn _with_hint(cmd_name: string, subcmd_name: string, first_line: string) -> string {
+    return first_line + "\nrun '" + _help_hint(cmd_name, subcmd_name)
+        + "' for usage";
 }
 
 fn _ok_error() -> ParseError {

--- a/capsules/sfn/cli/tests/cli_test.sfn
+++ b/capsules/sfn/cli/tests/cli_test.sfn
@@ -1,546 +1,55 @@
-// Tests for sfn/cli capsule — argument parsing, match accessors, and help generation.
+// Tests for sfn/cli capsule — argument parsing, match accessors, help
+// generation, and styling.
 //
-// Functions are inlined here because standalone test files cannot import
-// from capsules directly. These mirror the public API in src/mod.sfn.
-// ---- Inlined types ----
-struct Arg {
-    name: string;
-    description: string;
-    is_optional: boolean;
-    default_value: string;
-}
+// Imports the capsule's public API directly so any breaking surface
+// change shows up here. The companion `parser_test.sfn` covers the
+// non-exiting `parse()` error paths in detail; this file focuses on
+// the happy-path public surface and the help/style helpers.
+import {
+    Matches,
+    arg,
+    arg_optional,
+    bold,
+    command,
+    flag,
+    flag_short,
+    flag_value,
+    flag_value_short,
+    get,
+    get_or,
+    green,
+    has,
+    has_flag,
+    help,
+    parse,
+    red,
+    subcommand,
+    with_arg,
+    with_flag,
+    with_subcommand,
+    with_version
+} from "../src/mod";
 
-struct Flag {
-    long_name: string;
-    short_name: string;
-    description: string;
-    takes_value: boolean;
-}
-
-struct Command {
-    name: string;
-    description: string;
-    version: string;
-    args: Arg[];
-    flags: Flag[];
-    subcmds: Command[];
-}
-
-struct Matches {
-    command_name: string;
-    subcommand_name: string;
-    positional_names: string[];
-    positional_values: string[];
-    flag_names: string[];
-    flag_values: string[];
-    flag_present: boolean[];
-}
-
-// ---- Inlined builders ----
-fn _arg(name: string, description: string) -> Arg {
-    return Arg {
-        name: name,
-        description: description,
-        is_optional: false,
-        default_value: ""
-    };
-}
-
-fn _arg_optional(name: string, description: string, default_value: string) -> Arg {
-    return Arg {
-        name: name,
-        description: description,
-        is_optional: true,
-        default_value: default_value
-    };
-}
-
-fn _flag(long_name: string, description: string) -> Flag {
-    return Flag {
-        long_name: long_name,
-        short_name: "",
-        description: description,
-        takes_value: false
-    };
-}
-
-fn _flag_value(long_name: string, description: string) -> Flag {
-    return Flag {
-        long_name: long_name,
-        short_name: "",
-        description: description,
-        takes_value: true
-    };
-}
-
-fn _flag_short(long_name: string, short_name: string, description: string) -> Flag {
-    return Flag {
-        long_name: long_name,
-        short_name: short_name,
-        description: description,
-        takes_value: false
-    };
-}
-
-fn _flag_value_short(long_name: string, short_name: string, description: string) -> Flag {
-    return Flag {
-        long_name: long_name,
-        short_name: short_name,
-        description: description,
-        takes_value: true
-    };
-}
-
-fn _command(name: string, description: string) -> Command {
-    let empty_args: Arg[] = [];
-    let empty_flags: Flag[] = [];
-    let empty_cmds: Command[] = [];
-    return Command {
-        name: name,
-        description: description,
-        version: "",
-        args: empty_args,
-        flags: empty_flags,
-        subcmds: empty_cmds
-    };
-}
-
-fn _with_version(cmd: Command, version: string) -> Command {
-    return Command {
-        name: cmd.name,
-        description: cmd.description,
-        version: version,
-        args: cmd.args,
-        flags: cmd.flags,
-        subcmds: cmd.subcmds
-    };
-}
-
-fn _with_arg(cmd: Command, a: Arg) -> Command {
-    let mut new_args: Arg[] = [];
+fn _contains(text: string, needle: string) -> boolean {
+    if needle.length > text.length { return false; }
+    let limit = text.length - needle.length;
     let mut i: int = 0;
     loop {
-        if i >= cmd.args.length { break; }
-        new_args.push(cmd.args[i]);
-        i += 1;
-    }
-    new_args.push(a);
-    return Command {
-        name: cmd.name,
-        description: cmd.description,
-        version: cmd.version,
-        args: new_args,
-        flags: cmd.flags,
-        subcmds: cmd.subcmds
-    };
-}
-
-fn _with_flag(cmd: Command, f: Flag) -> Command {
-    let mut new_flags: Flag[] = [];
-    let mut i: int = 0;
-    loop {
-        if i >= cmd.flags.length { break; }
-        new_flags.push(cmd.flags[i]);
-        i += 1;
-    }
-    new_flags.push(f);
-    return Command {
-        name: cmd.name,
-        description: cmd.description,
-        version: cmd.version,
-        args: cmd.args,
-        flags: new_flags,
-        subcmds: cmd.subcmds
-    };
-}
-
-fn _with_subcommand(cmd: Command, sub: Command) -> Command {
-    let mut new_subs: Command[] = [];
-    let mut i: int = 0;
-    loop {
-        if i >= cmd.subcmds.length { break; }
-        new_subs.push(cmd.subcmds[i]);
-        i += 1;
-    }
-    new_subs.push(sub);
-    return Command {
-        name: cmd.name,
-        description: cmd.description,
-        version: cmd.version,
-        args: cmd.args,
-        flags: cmd.flags,
-        subcmds: new_subs
-    };
-}
-
-// ---- Inlined match accessors ----
-fn _get(m: Matches, name: string) -> string {
-    let mut i: int = 0;
-    loop {
-        if i >= m.positional_names.length { break; }
-        if strings_equal(m.positional_names[i], name) {
-            return m.positional_values[i];
+        if i > limit { break; }
+        if strings_equal(substring(text, i, i + needle.length), needle) {
+            return true;
         }
-        i += 1;
-    }
-    i = 0;
-    loop {
-        if i >= m.flag_names.length { break; }
-        if strings_equal(m.flag_names[i], name) { return m.flag_values[i]; }
-        i += 1;
-    }
-    return "";
-}
-
-fn _get_or(m: Matches, name: string, default_value: string) -> string {
-    let mut i: int = 0;
-    loop {
-        if i >= m.positional_names.length { break; }
-        if strings_equal(m.positional_names[i], name) {
-            return m.positional_values[i];
-        }
-        i += 1;
-    }
-    i = 0;
-    loop {
-        if i >= m.flag_names.length { break; }
-        if strings_equal(m.flag_names[i], name) { return m.flag_values[i]; }
-        i += 1;
-    }
-    return default_value;
-}
-
-fn _has_flag(m: Matches, name: string) -> boolean {
-    let mut i: int = 0;
-    loop {
-        if i >= m.flag_names.length { break; }
-        if strings_equal(m.flag_names[i], name) { return true; }
         i += 1;
     }
     return false;
 }
-
-fn _has(m: Matches, name: string) -> boolean {
-    let mut i: int = 0;
-    loop {
-        if i >= m.positional_names.length { break; }
-        if strings_equal(m.positional_names[i], name) { return true; }
-        i += 1;
-    }
-    i = 0;
-    loop {
-        if i >= m.flag_names.length { break; }
-        if strings_equal(m.flag_names[i], name) { return true; }
-        i += 1;
-    }
-    return false;
-}
-
-fn _subcommand(m: Matches) -> string { return m.subcommand_name; }
-
-// ---- Inlined parser (non-exiting version for tests) ----
-// This version returns a Matches struct without calling process.exit(),
-// so tests can exercise parse logic without terminating.
-fn _starts_with(text: string, prefix: string) -> boolean {
-    if prefix.length > text.length { return false; }
-    return strings_equal(substring(text, 0, prefix.length), prefix);
-}
-
-fn _find_flag_long(cmd: Command, name: string) -> Flag {
-    let mut i: int = 0;
-    loop {
-        if i >= cmd.flags.length { break; }
-        if strings_equal(cmd.flags[i].long_name, name) {
-            return cmd.flags[i];
-        }
-        i += 1;
-    }
-    return Flag {
-        long_name: "",
-        short_name: "",
-        description: "",
-        takes_value: false
-    };
-}
-
-fn _find_flag_short(cmd: Command, name: string) -> Flag {
-    let mut i: int = 0;
-    loop {
-        if i >= cmd.flags.length { break; }
-        if strings_equal(cmd.flags[i].short_name, name) {
-            return cmd.flags[i];
-        }
-        i += 1;
-    }
-    return Flag {
-        long_name: "",
-        short_name: "",
-        description: "",
-        takes_value: false
-    };
-}
-
-fn _resolve_active(cmd: Command, subcmd_name: string) -> Command {
-    if subcmd_name.length == 0 { return cmd; }
-    let mut i: int = 0;
-    loop {
-        if i >= cmd.subcmds.length { break; }
-        if strings_equal(cmd.subcmds[i].name, subcmd_name) {
-            return cmd.subcmds[i];
-        }
-        i += 1;
-    }
-    return cmd;
-}
-
-fn _parse(cmd: Command, argv: string[]) -> Matches {
-    // Non-exiting parser for tests. Returns empty matches on error
-    // instead of calling process.exit().
-    let mut pos_names: string[] = [];
-    let mut pos_values: string[] = [];
-    let mut fl_names: string[] = [];
-    let mut fl_values: string[] = [];
-    let mut fl_present: boolean[] = [];
-    let mut subcmd_name: string = "";
-
-    let mut idx: int = 1;
-
-    if idx < argv.length {
-        let first = argv[idx];
-        if !_starts_with(first, "-") {
-            let mut si: int = 0;
-            loop {
-                if si >= cmd.subcmds.length { break; }
-                if strings_equal(cmd.subcmds[si].name, first) {
-                    subcmd_name = first;
-                    idx += 1;
-                    break;
-                }
-                si += 1;
-            }
-        }
-    }
-
-    let active = _resolve_active(cmd, subcmd_name);
-
-    let mut pos_idx: int = 0;
-    loop {
-        if idx >= argv.length { break; }
-        let token = argv[idx];
-
-        if _starts_with(token, "--") {
-            let flag_name = substring(token, 2, token.length);
-            let f = _find_flag_long(active, flag_name);
-            if f.long_name.length > 0 {
-                fl_names.push(f.long_name);
-                fl_present.push(true);
-                if f.takes_value {
-                    idx += 1;
-                    if idx < argv.length { fl_values.push(argv[idx]); } else {
-                        fl_values.push("");
-                    }
-                } else { fl_values.push("true"); }
-            }
-        } else if _starts_with(token, "-") && token.length > 1 {
-            let short = substring(token, 1, token.length);
-            let f = _find_flag_short(active, short);
-            if f.long_name.length > 0 {
-                fl_names.push(f.long_name);
-                fl_present.push(true);
-                if f.takes_value {
-                    idx += 1;
-                    if idx < argv.length { fl_values.push(argv[idx]); } else {
-                        fl_values.push("");
-                    }
-                } else { fl_values.push("true"); }
-            }
-        } else {
-            if pos_idx < active.args.length {
-                pos_names.push(active.args[pos_idx].name);
-                pos_values.push(token);
-                pos_idx += 1;
-            }
-        }
-        idx += 1;
-    }
-
-    // Fill optional arg defaults.
-    loop {
-        if pos_idx >= active.args.length { break; }
-        let a = active.args[pos_idx];
-        if a.is_optional {
-            pos_names.push(a.name);
-            pos_values.push(a.default_value);
-        }
-        pos_idx += 1;
-    }
-
-    return Matches {
-        command_name: cmd.name,
-        subcommand_name: subcmd_name,
-        positional_names: pos_names,
-        positional_values: pos_values,
-        flag_names: fl_names,
-        flag_values: fl_values,
-        flag_present: fl_present
-    };
-}
-
-// ---- Inlined help formatter ----
-fn _help_hint(root_name: string, subcmd_name: string) -> string {
-    if subcmd_name.length > 0 {
-        return root_name + " " + subcmd_name + " --help";
-    }
-    return root_name + " --help";
-}
-
-fn _pad(text: string, width: int) -> string {
-    if text.length >= width { return text + "  "; }
-    let mut out: string = text;
-    let mut i: int = text.length;
-    loop {
-        if i >= width { break; }
-        out = out + " ";
-        i += 1;
-    }
-    return out;
-}
-
-fn _flag_label(f: Flag) -> string {
-    let mut label: string = "";
-    if f.short_name.length > 0 { label = "-" + f.short_name + ", "; } else {
-        label = "    ";
-    }
-    label = label + "--" + f.long_name;
-    if f.takes_value { label = label + " <value>"; }
-    return label;
-}
-
-fn _max_name_width(cmd: Command) -> int {
-    let mut max: int = 0;
-    let mut i: int = 0;
-    loop {
-        if i >= cmd.subcmds.length { break; }
-        if cmd.subcmds[i].name.length > max {
-            max = cmd.subcmds[i].name.length;
-        }
-        i += 1;
-    }
-    return max;
-}
-
-fn _max_arg_width(cmd: Command) -> int {
-    let mut max: int = 0;
-    let mut i: int = 0;
-    loop {
-        if i >= cmd.args.length { break; }
-        let w = cmd.args[i].name.length + 2;
-        if w > max { max = w; }
-        i += 1;
-    }
-    return max;
-}
-
-fn _max_flag_width(cmd: Command) -> int {
-    let mut max: int = 0;
-    let built_in_help = 10;
-    let built_in_version = 13;
-    if built_in_help > max { max = built_in_help; }
-    if built_in_version > max { max = built_in_version; }
-    let mut i: int = 0;
-    loop {
-        if i >= cmd.flags.length { break; }
-        let w = _flag_label(cmd.flags[i]).length;
-        if w > max { max = w; }
-        i += 1;
-    }
-    return max;
-}
-
-fn _format_help(cmd: Command, program: string) -> string {
-    let mut out: string = "";
-    if cmd.description.length > 0 { out = out + cmd.description + "\n\n"; }
-    out = out + "usage:\n";
-    out = out + "  " + program;
-    if cmd.subcmds.length > 0 { out = out + " <command>"; }
-    if cmd.flags.length > 0 { out = out + " [options]"; }
-    let mut ai: int = 0;
-    loop {
-        if ai >= cmd.args.length { break; }
-        let a = cmd.args[ai];
-        if a.is_optional { out = out + " [" + a.name + "]"; } else {
-            out = out + " <" + a.name + ">";
-        }
-        ai += 1;
-    }
-    out = out + "\n";
-    if cmd.subcmds.length > 0 {
-        out = out + "\ncommands:\n";
-        let col_width = _max_name_width(cmd) + 2;
-        let mut si: int = 0;
-        loop {
-            if si >= cmd.subcmds.length { break; }
-            let sub = cmd.subcmds[si];
-            out = out + "  " + _pad(sub.name, col_width) + sub.description
-                + "\n";
-            si += 1;
-        }
-    }
-    if cmd.args.length > 0 {
-        out = out + "\narguments:\n";
-        let arg_width = _max_arg_width(cmd) + 2;
-        ai = 0;
-        loop {
-            if ai >= cmd.args.length { break; }
-            let a = cmd.args[ai];
-            let label = "<" + a.name + ">";
-            out = out + "  " + _pad(label, arg_width) + a.description;
-            if a.is_optional {
-                out = out + " (default: " + a.default_value + ")";
-            }
-            out = out + "\n";
-            ai += 1;
-        }
-    }
-    out = out + "\noptions:\n";
-    let flag_width = _max_flag_width(cmd) + 2;
-    let mut fi: int = 0;
-    loop {
-        if fi >= cmd.flags.length { break; }
-        let f = cmd.flags[fi];
-        let label = _flag_label(f);
-        out = out + "  " + _pad(label, flag_width) + f.description + "\n";
-        fi += 1;
-    }
-    out = out + "  " + _pad("-h, --help", flag_width)
-        + "Show this help message\n";
-    if cmd.version.length > 0 {
-        out = out + "  " + _pad("-V, --version", flag_width) + "Show version\n";
-    }
-    return out;
-}
-
-// ---- Inlined ANSI helpers ----
-fn _esc() -> string { return ""; }
-
-fn _ansi_wrap(code: string, text: string) -> string {
-    let e = _esc();
-    if e.length == 0 { return text; }
-    return e + "[" + code + "m" + text + e + "[0m";
-}
-
-fn _bold(text: string) -> string { return _ansi_wrap("1", text); }
-
-fn _red(text: string) -> string { return _ansi_wrap("31", text); }
-
-fn _green(text: string) -> string { return _ansi_wrap("32", text); }
 
 // ======================================================================
 // Tests
 // ======================================================================
 // ---- Builder tests ----
 test "cli: arg creates required positional" {
-    let a = _arg("file", "Source file");
+    let a = arg("file", "Source file");
     assert strings_equal(a.name, "file");
     assert strings_equal(a.description, "Source file");
     assert a.is_optional == false;
@@ -548,41 +57,41 @@ test "cli: arg creates required positional" {
 }
 
 test "cli: arg_optional creates optional positional with default" {
-    let a = _arg_optional("path", "Directory", ".");
+    let a = arg_optional("path", "Directory", ".");
     assert strings_equal(a.name, "path");
     assert a.is_optional == true;
     assert strings_equal(a.default_value, ".");
 }
 
 test "cli: flag creates boolean flag" {
-    let f = _flag("verbose", "Enable verbose output");
+    let f = flag("verbose", "Enable verbose output");
     assert strings_equal(f.long_name, "verbose");
     assert strings_equal(f.short_name, "");
     assert f.takes_value == false;
 }
 
 test "cli: flag_value creates value flag" {
-    let f = _flag_value("output", "Output path");
+    let f = flag_value("output", "Output path");
     assert strings_equal(f.long_name, "output");
     assert f.takes_value == true;
 }
 
 test "cli: flag_short creates flag with short alias" {
-    let f = _flag_short("verbose", "v", "Verbose output");
+    let f = flag_short("verbose", "v", "Verbose output");
     assert strings_equal(f.long_name, "verbose");
     assert strings_equal(f.short_name, "v");
     assert f.takes_value == false;
 }
 
 test "cli: flag_value_short creates value flag with short alias" {
-    let f = _flag_value_short("output", "o", "Output file");
+    let f = flag_value_short("output", "o", "Output file");
     assert strings_equal(f.long_name, "output");
     assert strings_equal(f.short_name, "o");
     assert f.takes_value == true;
 }
 
 test "cli: command creates empty command" {
-    let c = _command("myapp", "My application");
+    let c = command("myapp", "My application");
     assert strings_equal(c.name, "myapp");
     assert strings_equal(c.description, "My application");
     assert strings_equal(c.version, "");
@@ -592,31 +101,31 @@ test "cli: command creates empty command" {
 }
 
 test "cli: with_version sets version" {
-    let c = _with_version(_command("myapp", "desc"), "1.2.3");
+    let c = with_version(command("myapp", "desc"), "1.2.3");
     assert strings_equal(c.version, "1.2.3");
 }
 
 test "cli: with_arg adds positional argument" {
-    let c = _with_arg(_command("myapp", "desc"), _arg("file", "Source"));
+    let c = with_arg(command("myapp", "desc"), arg("file", "Source"));
     assert c.args.length == 1;
     assert strings_equal(c.args[0].name, "file");
 }
 
 test "cli: with_flag adds flag" {
-    let c = _with_flag(_command("myapp", "desc"), _flag("verbose", "Verbose"));
+    let c = with_flag(command("myapp", "desc"), flag("verbose", "Verbose"));
     assert c.flags.length == 1;
     assert strings_equal(c.flags[0].long_name, "verbose");
 }
 
 test "cli: with_subcommand adds subcommand" {
-    let sub = _command("build", "Build the project");
-    let c = _with_subcommand(_command("myapp", "desc"), sub);
+    let sub = command("build", "Build the project");
+    let c = with_subcommand(command("myapp", "desc"), sub);
     assert c.subcmds.length == 1;
     assert strings_equal(c.subcmds[0].name, "build");
 }
 
 test "cli: builders chain preserves all fields" {
-    let c = _with_flag(_with_arg(_with_version(_command("myapp", "desc"), "0.1.0"), _arg("file", "Source")), _flag("verbose", "Verbose"));
+    let c = with_flag(with_arg(with_version(command("myapp", "desc"), "0.1.0"), arg("file", "Source")), flag("verbose", "Verbose"));
     assert strings_equal(c.name, "myapp");
     assert strings_equal(c.version, "0.1.0");
     assert c.args.length == 1;
@@ -625,126 +134,129 @@ test "cli: builders chain preserves all fields" {
 
 // ---- Parsing tests ----
 test "cli: parse single positional argument" {
-    let cmd = _with_arg(_command("app", "desc"), _arg("file", "Source file"));
+    let cmd = with_arg(command("app", "desc"), arg("file", "Source file"));
     let argv: string[] = ["app", "hello.sfn"];
-    let m = _parse(cmd, argv);
-    assert strings_equal(_get(m, "file"), "hello.sfn");
+    let m = parse(cmd, argv).matches;
+    assert strings_equal(get(m, "file"), "hello.sfn");
 }
 
 test "cli: parse multiple positional arguments" {
-    let cmd = _with_arg(_with_arg(_command("app", "desc"), _arg("src", "Source")), _arg("dst", "Destination"));
+    let cmd = with_arg(with_arg(command("app", "desc"), arg("src", "Source")), arg("dst", "Destination"));
     let argv: string[] = ["app", "a.sfn", "b.sfn"];
-    let m = _parse(cmd, argv);
-    assert strings_equal(_get(m, "src"), "a.sfn");
-    assert strings_equal(_get(m, "dst"), "b.sfn");
+    let m = parse(cmd, argv).matches;
+    assert strings_equal(get(m, "src"), "a.sfn");
+    assert strings_equal(get(m, "dst"), "b.sfn");
 }
 
 test "cli: parse optional positional uses default when missing" {
-    let cmd = _with_arg(_command("app", "desc"), _arg_optional("path", "Directory", "."));
+    let cmd = with_arg(command("app", "desc"), arg_optional("path", "Directory", "."));
     let argv: string[] = ["app"];
-    let m = _parse(cmd, argv);
-    assert strings_equal(_get(m, "path"), ".");
+    let m = parse(cmd, argv).matches;
+    assert strings_equal(get(m, "path"), ".");
 }
 
 test "cli: parse optional positional uses provided value" {
-    let cmd = _with_arg(_command("app", "desc"), _arg_optional("path", "Directory", "."));
+    let cmd = with_arg(command("app", "desc"), arg_optional("path", "Directory", "."));
     let argv: string[] = ["app", "src/"];
-    let m = _parse(cmd, argv);
-    assert strings_equal(_get(m, "path"), "src/");
+    let m = parse(cmd, argv).matches;
+    assert strings_equal(get(m, "path"), "src/");
 }
 
 test "cli: parse long boolean flag" {
-    let cmd = _with_flag(_command("app", "desc"), _flag("verbose", "Verbose"));
+    let cmd = with_flag(command("app", "desc"), flag("verbose", "Verbose"));
     let argv: string[] = ["app", "--verbose"];
-    let m = _parse(cmd, argv);
-    assert _has_flag(m, "verbose") == true;
+    let m = parse(cmd, argv).matches;
+    assert has_flag(m, "verbose") == true;
 }
 
 test "cli: parse long value flag" {
-    let cmd = _with_flag(_command("app", "desc"), _flag_value("output", "Out"));
+    let cmd = with_flag(command("app", "desc"), flag_value("output", "Out"));
     let argv: string[] = ["app", "--output", "build/out"];
-    let m = _parse(cmd, argv);
-    assert strings_equal(_get(m, "output"), "build/out");
+    let m = parse(cmd, argv).matches;
+    assert strings_equal(get(m, "output"), "build/out");
 }
 
 test "cli: parse short boolean flag" {
-    let cmd = _with_flag(_command("app", "desc"), _flag_short("verbose", "v", "Verbose"));
+    let cmd = with_flag(command("app", "desc"), flag_short("verbose", "v", "Verbose"));
     let argv: string[] = ["app", "-v"];
-    let m = _parse(cmd, argv);
-    assert _has_flag(m, "verbose") == true;
+    let m = parse(cmd, argv).matches;
+    assert has_flag(m, "verbose") == true;
 }
 
 test "cli: parse short value flag" {
-    let cmd = _with_flag(_command("app", "desc"), _flag_value_short("output", "o", "Out"));
+    let cmd = with_flag(command("app", "desc"), flag_value_short("output", "o", "Out"));
     let argv: string[] = ["app", "-o", "build/out"];
-    let m = _parse(cmd, argv);
-    assert strings_equal(_get(m, "output"), "build/out");
+    let m = parse(cmd, argv).matches;
+    assert strings_equal(get(m, "output"), "build/out");
 }
 
 test "cli: parse mixed flags and positionals" {
-    let cmd = _with_flag(_with_flag(_with_arg(_command("app", "desc"), _arg("file", "Source")), _flag("verbose", "Verbose")), _flag_value_short("output", "o", "Output"));
+    let cmd = with_flag(with_flag(with_arg(command("app", "desc"), arg("file", "Source")), flag("verbose", "Verbose")), flag_value_short("output", "o", "Output"));
     let argv: string[] = ["app", "--verbose", "-o", "out.bin", "main.sfn"];
-    let m = _parse(cmd, argv);
-    assert strings_equal(_get(m, "file"), "main.sfn");
-    assert _has_flag(m, "verbose") == true;
-    assert strings_equal(_get(m, "output"), "out.bin");
+    let m = parse(cmd, argv).matches;
+    assert strings_equal(get(m, "file"), "main.sfn");
+    assert has_flag(m, "verbose") == true;
+    assert strings_equal(get(m, "output"), "out.bin");
 }
 
 test "cli: parse subcommand" {
-    let sub = _with_arg(_command("build", "Build"), _arg("file", "Source"));
-    let cmd = _with_subcommand(_command("app", "desc"), sub);
+    let sub = with_arg(command("build", "Build"), arg("file", "Source"));
+    let cmd = with_subcommand(command("app", "desc"), sub);
     let argv: string[] = ["app", "build", "main.sfn"];
-    let m = _parse(cmd, argv);
-    assert strings_equal(_subcommand(m), "build");
-    assert strings_equal(_get(m, "file"), "main.sfn");
+    let m = parse(cmd, argv).matches;
+    assert strings_equal(subcommand(m), "build");
+    assert strings_equal(get(m, "file"), "main.sfn");
 }
 
 test "cli: parse subcommand with flags" {
-    let sub = _with_flag(_with_arg(_command("build", "Build"), _arg("file", "Source")), _flag_value_short("output", "o", "Output"));
-    let cmd = _with_subcommand(_command("app", "desc"), sub);
+    let sub = with_flag(with_arg(command("build", "Build"), arg("file", "Source")), flag_value_short("output", "o", "Output"));
+    let cmd = with_subcommand(command("app", "desc"), sub);
     let argv: string[] = ["app", "build", "-o", "a.out", "main.sfn"];
-    let m = _parse(cmd, argv);
-    assert strings_equal(_subcommand(m), "build");
-    assert strings_equal(_get(m, "output"), "a.out");
-    assert strings_equal(_get(m, "file"), "main.sfn");
+    let m = parse(cmd, argv).matches;
+    assert strings_equal(subcommand(m), "build");
+    assert strings_equal(get(m, "output"), "a.out");
+    assert strings_equal(get(m, "file"), "main.sfn");
 }
 
 test "cli: no subcommand returns empty string" {
-    let cmd = _with_subcommand(_command("app", "desc"), _command("build", "Build"));
+    let cmd = with_subcommand(command("app", "desc"), command("build", "Build"));
     let argv: string[] = ["app"];
-    let m = _parse(cmd, argv);
-    assert strings_equal(_subcommand(m), "");
+    let m = parse(cmd, argv).matches;
+    assert strings_equal(subcommand(m), "");
 }
 
 test "cli: unknown token treated as positional when no args defined" {
-    // When a non-flag token doesn't match a subcommand and no args are
-    // defined, _parse skips it (the real run() would exit with an error).
-    let cmd = _command("app", "desc");
+    // Public `parse()` reports the same error `run()` would have exited
+    // on: an unexpected positional. (The pre-rewrite inlined `_parse`
+    // silently skipped the token; the public API surfaces it.)
+    let cmd = command("app", "desc");
     let argv: string[] = ["app", "unknown"];
-    let m = _parse(cmd, argv);
-    assert m.positional_values.length == 0;
+    let r = parse(cmd, argv);
+    assert r.ok == false;
+    assert strings_equal(r.error.kind, "unexpected_positional");
+    assert r.matches.positional_values.length == 0;
 }
 
 // ---- Match accessor tests ----
 test "cli: get returns empty string for missing name" {
-    let cmd = _with_arg(_command("app", "desc"), _arg("file", "Source"));
+    let cmd = with_arg(command("app", "desc"), arg("file", "Source"));
     let argv: string[] = ["app", "test.sfn"];
-    let m = _parse(cmd, argv);
-    assert strings_equal(_get(m, "nonexistent"), "");
+    let m = parse(cmd, argv).matches;
+    assert strings_equal(get(m, "nonexistent"), "");
 }
 
 test "cli: get_or returns default for missing name" {
-    let cmd = _with_arg(_command("app", "desc"), _arg("file", "Source"));
+    let cmd = with_arg(command("app", "desc"), arg("file", "Source"));
     let argv: string[] = ["app", "test.sfn"];
-    let m = _parse(cmd, argv);
-    assert strings_equal(_get_or(m, "missing", "fallback"), "fallback");
+    let m = parse(cmd, argv).matches;
+    assert strings_equal(get_or(m, "missing", "fallback"), "fallback");
 }
 
 test "cli: get_or returns actual value when present" {
-    let cmd = _with_arg(_command("app", "desc"), _arg("file", "Source"));
+    let cmd = with_arg(command("app", "desc"), arg("file", "Source"));
     let argv: string[] = ["app", "test.sfn"];
-    let m = _parse(cmd, argv);
-    assert strings_equal(_get_or(m, "file", "fallback"), "test.sfn");
+    let m = parse(cmd, argv).matches;
+    assert strings_equal(get_or(m, "file", "fallback"), "test.sfn");
 }
 
 test "cli: get_or returns empty string when explicitly provided as empty" {
@@ -764,41 +276,41 @@ test "cli: get_or returns empty string when explicitly provided as empty" {
         flag_present: fp
     };
     // get_or should return "" (the actual value), NOT the default.
-    assert strings_equal(_get_or(m, "file", "fallback"), "");
+    assert strings_equal(get_or(m, "file", "fallback"), "");
 }
 
 test "cli: has_flag returns false for missing flag" {
-    let cmd = _with_flag(_command("app", "desc"), _flag("verbose", "V"));
+    let cmd = with_flag(command("app", "desc"), flag("verbose", "V"));
     let argv: string[] = ["app"];
-    let m = _parse(cmd, argv);
-    assert _has_flag(m, "verbose") == false;
+    let m = parse(cmd, argv).matches;
+    assert has_flag(m, "verbose") == false;
 }
 
 test "cli: has returns true for present positional" {
-    let cmd = _with_arg(_command("app", "desc"), _arg("file", "Source"));
+    let cmd = with_arg(command("app", "desc"), arg("file", "Source"));
     let argv: string[] = ["app", "main.sfn"];
-    let m = _parse(cmd, argv);
-    assert _has(m, "file") == true;
+    let m = parse(cmd, argv).matches;
+    assert has(m, "file") == true;
 }
 
 test "cli: has returns true for present flag" {
-    let cmd = _with_flag(_command("app", "desc"), _flag("verbose", "V"));
+    let cmd = with_flag(command("app", "desc"), flag("verbose", "V"));
     let argv: string[] = ["app", "--verbose"];
-    let m = _parse(cmd, argv);
-    assert _has(m, "verbose") == true;
+    let m = parse(cmd, argv).matches;
+    assert has(m, "verbose") == true;
 }
 
 test "cli: has returns false for missing name" {
-    let cmd = _command("app", "desc");
+    let cmd = command("app", "desc");
     let argv: string[] = ["app"];
-    let m = _parse(cmd, argv);
-    assert _has(m, "anything") == false;
+    let m = parse(cmd, argv).matches;
+    assert has(m, "anything") == false;
 }
 
 // ---- Help formatting tests ----
 test "cli: help contains command description" {
-    let cmd = _command("myapp", "My cool app");
-    let h = _format_help(cmd, "myapp");
+    let cmd = command("myapp", "My cool app");
+    let h = help(cmd);
     // Description should appear at the top.
     let mut found: boolean = false;
     if h.length >= 11 {
@@ -808,152 +320,95 @@ test "cli: help contains command description" {
 }
 
 test "cli: help contains usage line" {
-    let cmd = _command("myapp", "desc");
-    let h = _format_help(cmd, "myapp");
-    // Should contain "usage:" somewhere.
-    let mut i: int = 0;
-    let mut found: boolean = false;
-    loop {
-        if i + 6 > h.length { break; }
-        if strings_equal(substring(h, i, i + 6), "usage:") {
-            found = true;
-            break;
-        }
-        i += 1;
-    }
-    assert found == true;
+    let cmd = command("myapp", "desc");
+    let h = help(cmd);
+    assert _contains(h, "usage:") == true;
 }
 
 test "cli: help lists subcommands" {
-    let cmd = _with_subcommand(_command("myapp", "desc"), _command("build", "Build the project"));
-    let h = _format_help(cmd, "myapp");
-    // Should contain "commands:" section and "build".
-    let mut i: int = 0;
-    let mut found_cmds: boolean = false;
-    loop {
-        if i + 9 > h.length { break; }
-        if strings_equal(substring(h, i, i + 9), "commands:") {
-            found_cmds = true;
-            break;
-        }
-        i += 1;
-    }
-    assert found_cmds == true;
-    i = 0;
-    let mut found_build: boolean = false;
-    loop {
-        if i + 5 > h.length { break; }
-        if strings_equal(substring(h, i, i + 5), "build") {
-            found_build = true;
-            break;
-        }
-        i += 1;
-    }
-    assert found_build == true;
+    let cmd = with_subcommand(command("myapp", "desc"), command("build", "Build the project"));
+    let h = help(cmd);
+    assert _contains(h, "commands:") == true;
+    assert _contains(h, "build") == true;
 }
 
 test "cli: help lists arguments" {
-    let cmd = _with_arg(_command("myapp", "desc"), _arg("file", "Source file"));
-    let h = _format_help(cmd, "myapp");
-    let mut i: int = 0;
-    let mut found: boolean = false;
-    loop {
-        if i + 10 > h.length { break; }
-        if strings_equal(substring(h, i, i + 10), "arguments:") {
-            found = true;
-            break;
-        }
-        i += 1;
-    }
-    assert found == true;
+    let cmd = with_arg(command("myapp", "desc"), arg("file", "Source file"));
+    let h = help(cmd);
+    assert _contains(h, "arguments:") == true;
 }
 
 test "cli: help lists flags" {
-    let cmd = _with_flag(_command("myapp", "desc"), _flag_short("verbose", "v", "Verbose output"));
-    let h = _format_help(cmd, "myapp");
-    let mut i: int = 0;
-    let mut found: boolean = false;
-    loop {
-        if i + 8 > h.length { break; }
-        if strings_equal(substring(h, i, i + 8), "options:") {
-            found = true;
-            break;
-        }
-        i += 1;
-    }
-    assert found == true;
+    let cmd = with_flag(command("myapp", "desc"), flag_short("verbose", "v", "Verbose output"));
+    let h = help(cmd);
+    assert _contains(h, "options:") == true;
 }
 
 test "cli: help always includes -h/--help" {
-    let cmd = _command("myapp", "desc");
-    let h = _format_help(cmd, "myapp");
-    let mut i: int = 0;
-    let mut found: boolean = false;
-    loop {
-        if i + 10 > h.length { break; }
-        if strings_equal(substring(h, i, i + 10), "-h, --help") {
-            found = true;
-            break;
-        }
-        i += 1;
-    }
-    assert found == true;
+    let cmd = command("myapp", "desc");
+    let h = help(cmd);
+    assert _contains(h, "-h, --help") == true;
 }
 
 test "cli: help includes --version when version is set" {
-    let cmd = _with_version(_command("myapp", "desc"), "1.0.0");
-    let h = _format_help(cmd, "myapp");
-    let mut i: int = 0;
-    let mut found: boolean = false;
-    loop {
-        if i + 13 > h.length { break; }
-        if strings_equal(substring(h, i, i + 13), "-V, --version") {
-            found = true;
-            break;
-        }
-        i += 1;
-    }
-    assert found == true;
+    let cmd = with_version(command("myapp", "desc"), "1.0.0");
+    let h = help(cmd);
+    assert _contains(h, "-V, --version") == true;
 }
 
 // ---- Help hint tests ----
+// The help-hint format is exercised via `parse()`'s `error.message`,
+// which carries the same two-line stderr text `run()` would print
+// (diagnostic + help hint) for every non-`missing_value` error path.
+// See parser_test.sfn for the per-`error.kind` matrix.
 test "cli: help hint without subcommand" {
-    assert strings_equal(_help_hint("app", ""), "app --help");
+    let cmd = command("app", "desc");
+    let argv: string[] = ["app", "--bogus"];
+    let r = parse(cmd, argv);
+    assert r.ok == false;
+    assert _contains(r.error.message, "run 'app --help' for usage") == true;
 }
 
 test "cli: help hint with subcommand" {
-    assert strings_equal(_help_hint("app", "build"), "app build --help");
+    let sub = command("build", "Build");
+    let cmd = with_subcommand(command("app", "desc"), sub);
+    let argv: string[] = ["app", "build", "--bogus"];
+    let r = parse(cmd, argv);
+    assert r.ok == false;
+    assert _contains(r.error.message, "run 'app build --help' for usage") == true;
 }
 
 // ---- ANSI styling tests ----
 test "cli: ansi_wrap degrades to plain text when esc is empty" {
-    // With _esc() returning "", styling should be a no-op.
-    assert strings_equal(_bold("hello"), "hello");
-    assert strings_equal(_red("error"), "error");
-    assert strings_equal(_green("ok"), "ok");
+    // With `_esc()` returning "" in the capsule, styling is a no-op.
+    assert strings_equal(bold("hello"), "hello");
+    assert strings_equal(red("error"), "error");
+    assert strings_equal(green("ok"), "ok");
 }
 
 // ---- Flag label formatting tests ----
+// The private `_flag_label` helper renders into `help()` output, so we
+// assert the expected label appears verbatim there.
 test "cli: flag_label long only" {
-    let f = _flag("verbose", "Verbose");
-    let label = _flag_label(f);
-    assert strings_equal(label, "    --verbose");
+    let cmd = with_flag(command("app", "desc"), flag("verbose", "Verbose"));
+    let h = help(cmd);
+    assert _contains(h, "    --verbose") == true;
 }
 
 test "cli: flag_label with short alias" {
-    let f = _flag_short("verbose", "v", "Verbose");
-    let label = _flag_label(f);
-    assert strings_equal(label, "-v, --verbose");
+    let cmd = with_flag(command("app", "desc"), flag_short("verbose", "v", "Verbose"));
+    let h = help(cmd);
+    assert _contains(h, "-v, --verbose") == true;
 }
 
 test "cli: flag_label with value" {
-    let f = _flag_value("output", "Output");
-    let label = _flag_label(f);
-    assert strings_equal(label, "    --output <value>");
+    let cmd = with_flag(command("app", "desc"), flag_value("output", "Output"));
+    let h = help(cmd);
+    assert _contains(h, "    --output <value>") == true;
 }
 
 test "cli: flag_label with short and value" {
-    let f = _flag_value_short("output", "o", "Output");
-    let label = _flag_label(f);
-    assert strings_equal(label, "-o, --output <value>");
+    let cmd = with_flag(command("app", "desc"), flag_value_short("output", "o", "Output"));
+    let h = help(cmd);
+    assert _contains(h, "-o, --output <value>") == true;
 }

--- a/capsules/sfn/cli/tests/cli_test.sfn
+++ b/capsules/sfn/cli/tests/cli_test.sfn
@@ -238,24 +238,34 @@ test "cli: unknown token treated as positional when no args defined" {
 }
 
 // ---- Match accessor tests ----
+// These tests assert that accessors handle absent names correctly. An
+// `r.ok` precheck guards against parse() regressing to returning empty
+// matches alongside an error — which would silently satisfy assertions
+// like `get(..., "missing") == ""`.
 test "cli: get returns empty string for missing name" {
     let cmd = with_arg(command("app", "desc"), arg("file", "Source"));
     let argv: string[] = ["app", "test.sfn"];
-    let m = parse(cmd, argv).matches;
+    let r = parse(cmd, argv);
+    assert r.ok == true;
+    let m = r.matches;
     assert strings_equal(get(m, "nonexistent"), "");
 }
 
 test "cli: get_or returns default for missing name" {
     let cmd = with_arg(command("app", "desc"), arg("file", "Source"));
     let argv: string[] = ["app", "test.sfn"];
-    let m = parse(cmd, argv).matches;
+    let r = parse(cmd, argv);
+    assert r.ok == true;
+    let m = r.matches;
     assert strings_equal(get_or(m, "missing", "fallback"), "fallback");
 }
 
 test "cli: get_or returns actual value when present" {
     let cmd = with_arg(command("app", "desc"), arg("file", "Source"));
     let argv: string[] = ["app", "test.sfn"];
-    let m = parse(cmd, argv).matches;
+    let r = parse(cmd, argv);
+    assert r.ok == true;
+    let m = r.matches;
     assert strings_equal(get_or(m, "file", "fallback"), "test.sfn");
 }
 
@@ -282,28 +292,36 @@ test "cli: get_or returns empty string when explicitly provided as empty" {
 test "cli: has_flag returns false for missing flag" {
     let cmd = with_flag(command("app", "desc"), flag("verbose", "V"));
     let argv: string[] = ["app"];
-    let m = parse(cmd, argv).matches;
+    let r = parse(cmd, argv);
+    assert r.ok == true;
+    let m = r.matches;
     assert has_flag(m, "verbose") == false;
 }
 
 test "cli: has returns true for present positional" {
     let cmd = with_arg(command("app", "desc"), arg("file", "Source"));
     let argv: string[] = ["app", "main.sfn"];
-    let m = parse(cmd, argv).matches;
+    let r = parse(cmd, argv);
+    assert r.ok == true;
+    let m = r.matches;
     assert has(m, "file") == true;
 }
 
 test "cli: has returns true for present flag" {
     let cmd = with_flag(command("app", "desc"), flag("verbose", "V"));
     let argv: string[] = ["app", "--verbose"];
-    let m = parse(cmd, argv).matches;
+    let r = parse(cmd, argv);
+    assert r.ok == true;
+    let m = r.matches;
     assert has(m, "verbose") == true;
 }
 
 test "cli: has returns false for missing name" {
     let cmd = command("app", "desc");
     let argv: string[] = ["app"];
-    let m = parse(cmd, argv).matches;
+    let r = parse(cmd, argv);
+    assert r.ok == true;
+    let m = r.matches;
     assert has(m, "anything") == false;
 }
 

--- a/capsules/sfn/cli/tests/parser_test.sfn
+++ b/capsules/sfn/cli/tests/parser_test.sfn
@@ -106,7 +106,7 @@ test "parse: unknown long flag yields unknown_flag" {
     let r = parse(cmd, argv);
     assert r.ok == false;
     assert strings_equal(r.error.kind, "unknown_flag");
-    assert strings_equal(r.error.message, "error: unknown flag --bogus");
+    assert strings_equal(r.error.message, "error: unknown flag --bogus\nrun 'app --help' for usage");
     assert strings_equal(r.error.flag_name, "bogus");
     assert strings_equal(r.error.arg_name, "");
 }
@@ -117,11 +117,12 @@ test "parse: unknown short flag yields unknown_flag" {
     let r = parse(cmd, argv);
     assert r.ok == false;
     assert strings_equal(r.error.kind, "unknown_flag");
-    assert strings_equal(r.error.message, "error: unknown flag -x");
+    assert strings_equal(r.error.message, "error: unknown flag -x\nrun 'app --help' for usage");
     assert strings_equal(r.error.flag_name, "x");
 }
 
 // ---- "missing_value" ----
+// `missing_value` historically omits the help-hint suffix — single-line.
 test "parse: long flag missing value yields missing_value" {
     let cmd = with_flag(command("app", "desc"), flag_value("output", "Output path"));
     let argv: string[] = ["app", "--output"];
@@ -149,7 +150,7 @@ test "parse: extra positional yields unexpected_positional" {
     let r = parse(cmd, argv);
     assert r.ok == false;
     assert strings_equal(r.error.kind, "unexpected_positional");
-    assert strings_equal(r.error.message, "error: unexpected argument 'extra'");
+    assert strings_equal(r.error.message, "error: unexpected argument 'extra'\nrun 'app --help' for usage");
     assert strings_equal(r.error.arg_name, "extra");
     assert strings_equal(r.error.flag_name, "");
 }
@@ -161,7 +162,7 @@ test "parse: omitted required positional yields missing_required" {
     let r = parse(cmd, argv);
     assert r.ok == false;
     assert strings_equal(r.error.kind, "missing_required");
-    assert strings_equal(r.error.message, "error: missing required argument <file>");
+    assert strings_equal(r.error.message, "error: missing required argument <file>\nrun 'app --help' for usage");
     assert strings_equal(r.error.arg_name, "file");
 }
 


### PR DESCRIPTION
## Summary

- Rewrites `capsules/sfn/cli/tests/cli_test.sfn` against the public `sfn/cli` API; deletes ~250 lines of duplicated private helpers (`_command`/`_with_*`/`_arg`/`_flag`/`_parse`/`_format_help`/…). All 47 test blocks are preserved.
- Closes the residual `error.message` gap from #774: `parse()` now carries the full two-line stderr text `run()` would print for non-`missing_value` errors (diagnostic + `run '<prog> --help' for usage`), so callers can assert on the help-hint format through the public API.
- `run()` collapses to a single `print.err` — stderr text and exit codes stay byte-identical.

Closes #355

## Acceptance Criteria

- [x] No `_command` / `_with_*` / `_arg` / `_flag` private helpers remain in `cli_test.sfn` (`grep` confirms none).
- [x] All `test "..." { ... }` blocks call into the public `sfn/cli` API.
- [x] Same number of `test` blocks before and after (47 in `cli_test.sfn`, 15 in `parser_test.sfn`), covering the same cases. The 4 `_flag_label` tests now assert against `help()` output; the 2 help-hint tests now assert against `parse().error.message`; the "unknown token" test now asserts `parse()` surfaces `unexpected_positional`.
- [x] `parse()`'s `error.message` includes the help-hint suffix for `unknown_flag` / `unexpected_positional` / `missing_required`; `missing_value` stays single-line.
- [x] `run()`'s observable behavior unchanged (single `print.err`, same exit codes).
- [x] `build/native/sailfin test capsules/sfn/cli/tests/` passes (47 + 15 = 62 tests green).
- [x] `sfn fmt --check capsules/sfn/cli/` is clean.
- [ ] `make check` — see "verification" note below.

## Verification

```bash
ulimit -v 8388608 && timeout 60 build/native/sailfin test capsules/sfn/cli/tests/
#   PASS  (all 47 tests passed)
#   PASS  (all 15 tests passed)

ulimit -v 8388608 && timeout 30 build/native/sailfin fmt --check capsules/sfn/cli/
#   (clean)
```

`make test` was kicked off but not yet observed to completion in this session; opening as draft so CI runs `make check` end-to-end. Will flip ready-for-review once CI is green.

## Files Changed

- `capsules/sfn/cli/src/parser.sfn` — enrich `parse()` `error.message`; simplify `run()`.
- `capsules/sfn/cli/tests/cli_test.sfn` — rewrite against public API (−723 / +163).
- `capsules/sfn/cli/tests/parser_test.sfn` — update `error.message` assertions for the enriched format.

## Decision Note

Mid-pickup, I surfaced that #774's actual delivery left `error.message` as a single line, while the architect's #355 plan assumed it would carry the full hinted text. Per [the user's call](https://github.com/SailfinIO/sailfin/issues/355#issuecomment-4555348291) ("seems like a small discrepancy"), I bundled the small alignment fix here rather than spawning yet another follow-up issue. The change is ~10 lines in `parser.sfn`, fixes a real gap against #774's own AC, and `run()`'s stderr remains byte-identical.

[Generated by Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MKAzt9v24Eeu5CA5GGpW1x)_