### PR TITLE
feat(build-report): expose cache.hit_rate in BuildReport JSON (#780)

### DIFF
--- a/compiler/src/build_report.sfn
+++ b/compiler/src/build_report.sfn
@@ -43,7 +43,8 @@ import { substring } from "./string_utils";
 //     "invalid_keys": 0,
 //     "copy_failures": 0,
 //     "root": "build/cache/v1",
-//     "enabled": true
+//     "enabled": true,
+//     "hit_rate": 0.7500
 //   },
 //   "deps": {
 //     "count": 1,
@@ -64,6 +65,17 @@ import { substring } from "./string_utils";
 // produce legacy paths in this field. Field shape is unchanged
 // (string array of file paths); a *shape* change (entries become
 // objects, etc.) would require a v2.
+//
+// `cache.hit_rate` is a derived field computed as
+// `hits / (hits + misses)`, formatted with four fractional
+// digits (e.g. `0.9783`). Emitted last inside the cache
+// object so the addition is purely additive — consumers
+// reading by name keep working, and the field appears after
+// every counter so jq predicates like `.cache.hit_rate` work
+// without schema-version coordination. Zero-denominator case
+// (no lookups attempted) renders as `0.0000`, never `null`
+// and never a division error. `schema_version` stays at "1"
+// since the surface gains a field rather than reshaping one.
 //
 // `diagnostics` is reserved for future structured link errors
 // (proposal §4.11). Empty array today; consumers should treat
@@ -202,6 +214,34 @@ fn _br_json_string_array(values: string[]) -> string {
     return out + "]";
 }
 
+// Format `hits / (hits + misses)` as a JSON-number literal with
+// four fractional digits. Pure integer arithmetic: the compiler's
+// `+ string` concat path doesn't auto-stringify floats, and a
+// hand-rolled `%.15g` here would diverge from the per-build
+// determinism contract (#779). Truncates toward zero rather
+// than rounding — matches the floor semantics CI gates use when
+// comparing against a threshold like `>= 0.80`.
+//
+// Zero denominator (no lookups attempted) emits `0.0000`, not
+// `null` and not `nan`. Saturated cache (only hits, no misses)
+// emits `1.0000`.
+fn _br_format_hit_rate(hits: int, misses: int) -> string {
+    let denom: int = hits + misses;
+    if denom == 0 { return "0.0000"; }
+    // `int / int` widens to float in Sailfin; `as int` truncates
+    // back so the scaled value is a clean 0..10000 integer.
+    let scaled_float: float = (hits * 10000) / denom;
+    let mut scaled: int = scaled_float as int;
+    if scaled >= 10000 { return "1.0000"; }
+    if scaled < 0 { scaled = 0; }
+    let mut frac = _br_number_to_string(scaled);
+    loop {
+        if frac.length >= 4 { break; }
+        frac = "0" + frac;
+    }
+    return "0." + frac;
+}
+
 fn _br_json_cache_object(stats: CacheStats, root: string, enabled: boolean) -> string {
     return "{" + _br_json_number_field("hits", stats.hits) + ","
         + _br_json_number_field("misses", stats.misses)
@@ -215,6 +255,8 @@ fn _br_json_cache_object(stats: CacheStats, root: string, enabled: boolean) -> s
         + _br_json_string_field("root", root)
         + ","
         + _br_json_bool_field("enabled", enabled)
+        + ","
+        + _br_json_field("hit_rate", _br_format_hit_rate(stats.hits, stats.misses))
         + "}";
 }
 

--- a/compiler/src/build_report.sfn
+++ b/compiler/src/build_report.sfn
@@ -215,23 +215,27 @@ fn _br_json_string_array(values: string[]) -> string {
 }
 
 // Format `hits / (hits + misses)` as a JSON-number literal with
-// four fractional digits. Pure integer arithmetic: the compiler's
-// `+ string` concat path doesn't auto-stringify floats, and a
-// hand-rolled `%.15g` here would diverge from the per-build
-// determinism contract (#779). Truncates toward zero rather
-// than rounding — matches the floor semantics CI gates use when
-// comparing against a threshold like `>= 0.80`.
+// four fractional digits.
 //
-// Zero denominator (no lookups attempted) emits `0.0000`, not
-// `null` and not `nan`. Saturated cache (only hits, no misses)
-// emits `1.0000`.
+// Sailfin's `/` on `int` operands widens to float (see the note
+// above `_br_number_to_string` — `7 / 10` evaluates to `0.7`,
+// not `0`). We exploit that: `(hits * 10000) / denom` is a float
+// divide whose result lands in `[0.0, 10000.0]`, and `as int`
+// truncates back to a 4-digit integer the existing integer-only
+// `_br_number_to_string` can then stringify with manual
+// leading-zero padding. f64's 53-bit mantissa keeps the scaling
+// exact for any realistic counter — `hits * 10000` only loses
+// precision above ~9e14, far past anything a real build produces.
+//
+// Zero denominator (no lookups attempted) emits `0.0000`, never
+// `null` and never `nan`. Saturated cache (only hits, no misses)
+// emits `1.0000`. Truncates toward zero rather than rounding —
+// matches the floor semantics CI gates use when comparing
+// against a threshold like `>= 0.80`.
 fn _br_format_hit_rate(hits: int, misses: int) -> string {
     let denom: int = hits + misses;
     if denom == 0 { return "0.0000"; }
-    // `int / int` widens to float in Sailfin; `as int` truncates
-    // back so the scaled value is a clean 0..10000 integer.
-    let scaled_float: float = (hits * 10000) / denom;
-    let mut scaled: int = scaled_float as int;
+    let mut scaled: int = ((hits * 10000) / denom) as int;
     if scaled >= 10000 { return "1.0000"; }
     if scaled < 0 { scaled = 0; }
     let mut frac = _br_number_to_string(scaled);

--- a/compiler/tests/e2e/test_build_json_schema.sh
+++ b/compiler/tests/e2e/test_build_json_schema.sh
@@ -115,6 +115,19 @@ test_cold_cache_stats() {
 }
 run_test "cold build cache stats: hits=0 misses=1 stores=1 enabled=true" test_cold_cache_stats
 
+# ---- Test 4b: cold build hit_rate is numeric (0 / 1 = 0.0) ----
+# Issue #780: jq must read .cache.hit_rate as a number, never null
+# and never a division error. Cold build has misses=1 hits=0, so
+# the rate is exactly 0.0.
+test_cold_hit_rate_numeric() {
+    local raw
+    raw=$(jq -r .cache.hit_rate "$SCRATCH/cold.json")
+    [ "$raw" != "null" ] || return 1
+    # `jq -r number` canonicalises 0.0000 → 0; assert it parses as 0.
+    [ "$(jq -r '.cache.hit_rate == 0' "$SCRATCH/cold.json")" = "true" ]
+}
+run_test "cold build .cache.hit_rate is numeric and equal to 0" test_cold_hit_rate_numeric
+
 # ---- Test 5: deps.count matches deps.ll_paths.length ----
 test_deps_consistency() {
     local count
@@ -179,8 +192,10 @@ test_warm_cache_hit() {
     jq . "$SCRATCH/warm.json" > /dev/null 2>&1 || return 1
     [ "$(jq -r .cache.hits "$SCRATCH/warm.json")" = "1" ] || return 1
     [ "$(jq -r .cache.misses "$SCRATCH/warm.json")" = "0" ] || return 1
+    # #780: warm cache is fully saturated (1 hit, 0 misses) → 1.0.
+    [ "$(jq -r '.cache.hit_rate == 1' "$SCRATCH/warm.json")" = "true" ] || return 1
 }
-run_test "warm build cache.hits=1 misses=0" test_warm_cache_hit
+run_test "warm build cache.hits=1 misses=0 hit_rate=1.0" test_warm_cache_hit
 
 # ---- Test 9: --no-cache + --json composes ----
 test_json_with_no_cache() {
@@ -199,8 +214,13 @@ test_json_with_no_cache() {
     [ "$(jq -r .cache.misses "$SCRATCH/no_cache.json")" = "0" ] || return 1
     [ "$(jq -r .cache.stores "$SCRATCH/no_cache.json")" = "0" ] || return 1
     [ "$(jq -r .cache.enabled "$SCRATCH/no_cache.json")" = "false" ] || return 1
+    # #780: zero-denominator path must emit a numeric 0.0, not null.
+    local rate
+    rate=$(jq -r .cache.hit_rate "$SCRATCH/no_cache.json")
+    [ "$rate" != "null" ] || return 1
+    [ "$(jq -r '.cache.hit_rate == 0' "$SCRATCH/no_cache.json")" = "true" ] || return 1
 }
-run_test "sfn build --json --no-cache: counters all zero, enabled=false" test_json_with_no_cache
+run_test "sfn build --json --no-cache: counters all zero, enabled=false, hit_rate=0.0" test_json_with_no_cache
 
 # ---- Summary ----
 echo ""

--- a/compiler/tests/unit/build_report_test.sfn
+++ b/compiler/tests/unit/build_report_test.sfn
@@ -112,6 +112,107 @@ test "build_report_to_json: cache_enabled false serializes literally" {
     assert _contains(json, "\"enabled\":false");
 }
 
+// --------------------------------------------------------------
+// cache.hit_rate — additive derived field (#780)
+// --------------------------------------------------------------
+// JSON gains a `cache.hit_rate` numeric so CI gates can do
+// `jq '.cache.hit_rate >= 0.80'` without recomputing from
+// counters. Schema stays at "1" because the field is purely
+// additive (RFC 8259 "unknown trailing fields ignored").
+test "build_report_to_json: cache.hit_rate populated for typical mix" {
+    let mut r = empty_build_report();
+    // 78% hit rate — picked so the four-digit format is unambiguous.
+    r.cache = CacheStats {
+        hits: 78,
+        misses: 22,
+        stores: 22,
+        invalid_keys: 0,
+        copy_failures: 0
+    };
+    let json = build_report_to_json(r);
+    assert _contains(json, "\"hit_rate\":0.7800");
+}
+
+test "build_report_to_json: cache.hit_rate zero denominator emits 0.0000" {
+    // No cache activity at all — denominator is zero. Field must
+    // be a JSON number (not null) and must not raise a division
+    // error. Acceptance criterion from the issue body.
+    let json = build_report_to_json(empty_build_report());
+    assert _contains(json, "\"hit_rate\":0.0000");
+}
+
+test "build_report_to_json: cache.hit_rate saturated cache emits 1.0000" {
+    let mut r = empty_build_report();
+    r.cache = CacheStats {
+        hits: 7,
+        misses: 0,
+        stores: 0,
+        invalid_keys: 0,
+        copy_failures: 0
+    };
+    let json = build_report_to_json(r);
+    assert _contains(json, "\"hit_rate\":1.0000");
+}
+
+test "build_report_to_json: cache.hit_rate all-misses emits 0.0000" {
+    let mut r = empty_build_report();
+    r.cache = CacheStats {
+        hits: 0,
+        misses: 5,
+        stores: 0,
+        invalid_keys: 0,
+        copy_failures: 0
+    };
+    let json = build_report_to_json(r);
+    assert _contains(json, "\"hit_rate\":0.0000");
+}
+
+test "build_report_to_json: cache.hit_rate pads small fractions to four digits" {
+    let mut r = empty_build_report();
+    // 1/1000 = 0.001 — exercises the leading-zero padding path.
+    r.cache = CacheStats {
+        hits: 1,
+        misses: 999,
+        stores: 0,
+        invalid_keys: 0,
+        copy_failures: 0
+    };
+    let json = build_report_to_json(r);
+    assert _contains(json, "\"hit_rate\":0.0010");
+}
+
+test "build_report_to_json: cache.hit_rate truncates toward zero" {
+    let mut r = empty_build_report();
+    // 2/3 = 0.6666… — truncation (not rounding) matches the floor
+    // semantics CI gates use when comparing against a threshold.
+    r.cache = CacheStats {
+        hits: 2,
+        misses: 1,
+        stores: 0,
+        invalid_keys: 0,
+        copy_failures: 0
+    };
+    let json = build_report_to_json(r);
+    assert _contains(json, "\"hit_rate\":0.6666");
+}
+
+test "build_report_to_json: schema_version stays at '1' after hit_rate addition" {
+    // Acceptance criterion: schema_version must remain "1" because
+    // adding a field is not a breaking change. Lock it in so a
+    // future edit that bumps the version trips this test.
+    let mut r = empty_build_report();
+    r.cache = CacheStats {
+        hits: 3,
+        misses: 1,
+        stores: 1,
+        invalid_keys: 0,
+        copy_failures: 0
+    };
+    let json = build_report_to_json(r);
+    assert _contains(json, "\"schema_version\":\"1\"");
+    assert _contains(json, "\"hit_rate\":0.7500");
+}
+
 test "build_report_to_json: deps.count matches array length" {
     let mut r = empty_build_report();
     r.dep_ll_paths = ["a.ll", "b.ll", "c.ll"];


### PR DESCRIPTION
## Summary

- Adds a derived `cache.hit_rate` field to `sfn build --json` output, computed as `hits / (hits + misses)` with four fractional digits and a clean `0.0000` zero-denominator case.
- Field is emitted **last** inside the `cache` object so the addition is purely additive — `schema_version` stays at `"1"` and existing JSON consumers keep working.
- Formatting is pure integer arithmetic (truncate toward zero), matching the floor semantics CI gates use when comparing against a threshold like `>= 0.80`.

Closes #780

## Acceptance Criteria

- [x] `build/native/sailfin build -p compiler --json | jq '.cache.hit_rate'` returns a numeric value (not null) on a clean build.
- [x] Zero-denominator case: `hit_rate` is `0.0000` (numeric), not `null` and not a division error.
- [x] `schema_version` in the emitted JSON remains `"1"`.
- [x] New unit tests in `compiler/tests/unit/build_report_test.sfn` cover both the populated and zero-denominator cases (plus saturated, all-misses, small-fraction padding, truncation, and schema-version stability).
- [x] `make compile && make test` pass (unit 101/101, integration 27/27, e2e 77/77, capsules 14/14).
- [x] `sfn fmt --check` clean on touched `.sfn` files.

## Verification

```bash
ulimit -v 8388608
build/native/sailfin build -p compiler --json --work-dir /tmp/hit-rate \
  | jq '.cache.hit_rate, .schema_version, .cache'
# →
# 0.0266
# "1"
# {
#   "hits": 4,
#   "misses": 146,
#   "stores": 146,
#   "invalid_keys": 0,
#   "copy_failures": 0,
#   "root": "build/cache/v1",
#   "enabled": true,
#   "hit_rate": 0.0266
# }
```

E2E gates also exercise the cold (0 / 1 = 0.0), warm (1 / 1 = 1.0), and `--no-cache` (0 / 0 = 0.0) paths.

## Files Changed

- `compiler/src/build_report.sfn` — add `_br_format_hit_rate`, emit field last in `_br_json_cache_object`, document the derived field and zero-denominator semantics in the schema comment block.
- `compiler/tests/unit/build_report_test.sfn` — 7 new tests for the new field.
- `compiler/tests/e2e/test_build_json_schema.sh` — 3 new assertions covering cold / warm / `--no-cache` paths so downstream consumers can rely on the field being numeric, never null.

## Notes for reviewers

- The helper is kept private (`_br_format_hit_rate`) per the issue's "kept private if unused outside `build_report.sfn`" guidance — no in-process callers were identified that needed a public `cache_hit_rate(report) -> float`.
- The compiler-level codebase has no Sailfin-source float-to-string helper accessible from this module (`number_to_string` is integer-only), so the formatter uses integer scaling (`hits * 10000 / denom`) and manual leading-zero padding. This avoids a cross-module dependency on the runtime's `%.15g` path and keeps the output deterministic for the `#779` determinism gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NJn9ukRTR6XmU2KCaa4rwL)_