### PR TITLE
feat(cli): add --check-determinism flag to sfn build

### DIFF
--- a/compiler/src/build_report.sfn
+++ b/compiler/src/build_report.sfn
@@ -250,4 +250,245 @@ fn build_report_to_json(report: BuildReport) -> string {
         + "}";
 }
 
-export { BuildReport, empty_build_report, build_report_to_json };
+// -------------------------------------------------------------------
+// Determinism diff (issue #779)
+// -------------------------------------------------------------------
+//
+// `sfn build --check-determinism` runs the build twice and compares
+// the two results. The pure helper below consumes pre-loaded
+// snapshots (one per pass) and produces a structured diff; the CLI
+// orchestrator (`cli_main.sfn`) is responsible for the I/O — reading
+// each pass's per-capsule `build/capsules/<scope>/<name>/manifest.json`
+// sidecar (which carries `modules[*].{slug, cache_key}` per Stage
+// C2c) and shasumming the linked binary, then assembling a
+// `DeterminismSnapshot` for each pass.
+//
+// Splitting the I/O out keeps the comparator unit-testable without
+// filesystem setup — the test passes hand-built snapshots through
+// `compare_for_determinism` and asserts on the resulting diff.
+struct DeterminismModule {
+    slug: string;
+    cache_key: string;
+}
+
+struct DeterminismSnapshot {
+    binary_path: string;
+    binary_sha256: string;
+    modules: DeterminismModule[];
+}
+
+// One module that differed between the two passes. `kind`
+// distinguishes:
+//   - "differ"     — both passes saw the slug but cache_keys differ
+//   - "only_in_a"  — slug present in pass A's modules, missing in B
+//   - "only_in_b"  — slug present in pass B's modules, missing in A
+//
+// `cache_key_a` / `cache_key_b` are `""` for the "missing" side.
+struct DeterminismModuleDiff {
+    slug: string;
+    kind: string;
+    cache_key_a: string;
+    cache_key_b: string;
+}
+
+struct DeterminismDiff {
+    matched: boolean;
+    binary_match: boolean;
+    binary_sha256_a: string;
+    binary_sha256_b: string;
+    binary_path_a: string;
+    binary_path_b: string;
+    module_diffs: DeterminismModuleDiff[];
+}
+
+fn empty_determinism_snapshot() -> DeterminismSnapshot {
+    let empty: DeterminismModule[] = [];
+    return DeterminismSnapshot {
+        binary_path: "",
+        binary_sha256: "",
+        modules: empty
+    };
+}
+
+fn make_determinism_module(slug: string, cache_key: string) -> DeterminismModule {
+    return DeterminismModule { slug: slug, cache_key: cache_key };
+}
+
+// Internal helper for `compare_for_determinism`. Sailfin doesn't
+// yet have proper option types, so this struct doubles as one:
+// `found=false` means "no entry for this slug in the list".
+struct _DetLookup {
+    found: boolean;
+    cache_key: string;
+}
+
+fn _find_module_cache_key(modules: DeterminismModule[], slug: string) -> _DetLookup {
+    let mut i: int = 0;
+    loop {
+        if i >= modules.length { break; }
+        if modules[i].slug == slug {
+            return _DetLookup {
+                found: true,
+                cache_key: modules[i].cache_key
+            };
+        }
+        i += 1;
+    }
+    return _DetLookup { found: false, cache_key: "" };
+}
+
+// Pure comparator. The caller (cli_main.sfn) loads each pass's
+// sidecar and binary sha256 first, then invokes this.
+//
+// Match semantics: `matched=true` iff (a) both binary sha256 digests
+// are non-empty and equal AND (b) the two `modules` lists agree on
+// every slug + cache_key pair (set equality with paired values).
+//
+// A pass with an empty `binary_sha256` is a hard mismatch: an empty
+// digest means `sha256sum` failed (file missing, tool not on PATH,
+// etc.), and reporting "match" in that case would be a false
+// negative. The CLI catches the empty case earlier with a clearer
+// diagnostic; the defense-in-depth here protects the unit-tested
+// surface.
+fn compare_for_determinism(a: DeterminismSnapshot, b: DeterminismSnapshot) -> DeterminismDiff {
+    let mut binary_match: boolean = a.binary_sha256 == b.binary_sha256;
+    if a.binary_sha256.length == 0 { binary_match = false; }
+    if b.binary_sha256.length == 0 { binary_match = false; }
+
+    let mut diffs: DeterminismModuleDiff[] = [];
+
+    let mut i: int = 0;
+    loop {
+        if i >= a.modules.length { break; }
+        let ma = a.modules[i];
+        let lookup_b = _find_module_cache_key(b.modules, ma.slug);
+        if lookup_b.found {
+            if ma.cache_key != lookup_b.cache_key {
+                diffs.push(DeterminismModuleDiff {
+                    slug: ma.slug, kind: "differ", cache_key_a: ma.cache_key, cache_key_b: lookup_b.cache_key
+                });
+            }
+        } else {
+            diffs.push(DeterminismModuleDiff {
+                slug: ma.slug, kind: "only_in_a", cache_key_a: ma.cache_key, cache_key_b: ""
+            });
+        }
+        i += 1;
+    }
+
+    let mut j: int = 0;
+    loop {
+        if j >= b.modules.length { break; }
+        let mb = b.modules[j];
+        let lookup_a = _find_module_cache_key(a.modules, mb.slug);
+        if !lookup_a.found {
+            diffs.push(DeterminismModuleDiff {
+                slug: mb.slug, kind: "only_in_b", cache_key_a: "", cache_key_b: mb.cache_key
+            });
+        }
+        j += 1;
+    }
+
+    let matched = binary_match && diffs.length == 0;
+
+    return DeterminismDiff {
+        matched: matched,
+        binary_match: binary_match,
+        binary_sha256_a: a.binary_sha256,
+        binary_sha256_b: b.binary_sha256,
+        binary_path_a: a.binary_path,
+        binary_path_b: b.binary_path,
+        module_diffs: diffs
+    };
+}
+
+// JSON encoder for `--json` mode. Schema version stays at "1" to
+// match the build-report family — the determinism diff is a new
+// top-level command output, not a breaking change to BuildReport.
+// Field order is stable for byte-deterministic test fixtures.
+fn determinism_diff_to_json(diff: DeterminismDiff) -> string {
+    let mut entries: string = "[";
+    let mut i: int = 0;
+    loop {
+        if i >= diff.module_diffs.length { break; }
+        if i > 0 { entries = entries + ","; }
+        let d = diff.module_diffs[i];
+        entries = entries + "{" + _br_json_string_field("slug", d.slug) + ","
+            + _br_json_string_field("kind", d.kind)
+            + ","
+            + _br_json_string_field("cache_key_a", d.cache_key_a)
+            + ","
+            + _br_json_string_field("cache_key_b", d.cache_key_b)
+            + "}";
+        i += 1;
+    }
+    entries = entries + "]";
+
+    return "{" + _br_json_string_field("schema_version", "1") + ","
+        + _br_json_string_field("command", "build")
+        + ","
+        + _br_json_string_field("check", "determinism")
+        + ","
+        + _br_json_bool_field("matched", diff.matched)
+        + ","
+        + _br_json_bool_field("binary_match", diff.binary_match)
+        + ","
+        + _br_json_string_field("binary_sha256_a", diff.binary_sha256_a)
+        + ","
+        + _br_json_string_field("binary_sha256_b", diff.binary_sha256_b)
+        + ","
+        + _br_json_string_field("binary_path_a", diff.binary_path_a)
+        + ","
+        + _br_json_string_field("binary_path_b", diff.binary_path_b)
+        + ","
+        + _br_json_field("module_diffs", entries)
+        + "}";
+}
+
+// Human-readable summary for default (non-`--json`) mode. The
+// orchestrator prepends/appends its own context lines; this helper
+// only renders the structured diff itself.
+fn determinism_diff_to_text(diff: DeterminismDiff) -> string {
+    if diff.matched {
+        return "[determinism] match: binary sha256 + " + _br_number_to_string(diff.module_diffs.length)
+            + " module diff(s)\n";
+    }
+    let mut out: string = "[determinism] MISMATCH\n";
+    if !diff.binary_match {
+        out = out + "  binary a: " + diff.binary_path_a + " sha256=" + diff.binary_sha256_a
+            + "\n";
+        out = out + "  binary b: " + diff.binary_path_b + " sha256=" + diff.binary_sha256_b
+            + "\n";
+    }
+    let mut i: int = 0;
+    loop {
+        if i >= diff.module_diffs.length { break; }
+        let d = diff.module_diffs[i];
+        out = out + "  module " + d.slug + " [" + d.kind + "]";
+        if d.kind == "differ" {
+            out = out + ": a=" + d.cache_key_a + " b=" + d.cache_key_b;
+        } else if d.kind == "only_in_a" {
+            out = out + ": cache_key=" + d.cache_key_a;
+        } else if d.kind == "only_in_b" {
+            out = out + ": cache_key=" + d.cache_key_b;
+        }
+        out = out + "\n";
+        i += 1;
+    }
+    return out;
+}
+
+export {
+    BuildReport,
+    DeterminismDiff,
+    DeterminismModule,
+    DeterminismModuleDiff,
+    DeterminismSnapshot,
+    build_report_to_json,
+    compare_for_determinism,
+    determinism_diff_to_json,
+    determinism_diff_to_text,
+    empty_build_report,
+    empty_determinism_snapshot,
+    make_determinism_module
+};

--- a/compiler/src/cli_main.sfn
+++ b/compiler/src/cli_main.sfn
@@ -367,14 +367,32 @@ fn _sidecar_path_for_capsule(capsule_name: string) -> string {
 }
 
 // Parse the `modules` array out of a capsule artifact `manifest.json`
-// string. The manifest's JSON shape is fixed by
-// `capsule_artifact.sfn::_ca_json_module_entry` — a flat array of
-// `{"slug":"X","ir_path":"Y","cache_key":"Z"}` objects with no
-// embedded whitespace — so a naive substring scan is sufficient.
-// `slug` and `cache_key` values are produced by the compiler
-// (slug = module path; cache_key = sha256 hex) and don't contain
-// `"` or `]` characters. Returns `[]` if the `modules` field is
-// absent or the array is empty.
+// string.
+//
+// CONTRACT: this parser is intentionally minimal and assumes the
+// exact JSON shape emitted by `capsule_artifact.sfn::_ca_json_module_entry`:
+//   `{"slug":"X","ir_path":"Y","cache_key":"Z"}`
+// flat objects with no whitespace inside the `modules` array. The
+// two fields it extracts have constrained value spaces by
+// construction:
+//   - `slug` is produced by `module_name_from_path`, which
+//     emits `/`-separated path components without `"`, `\`, or `]`.
+//   - `cache_key` is the sha256 hex of `CacheKey.digest` — strictly
+//     `[0-9a-f]{64}` or `""` (caching disabled / digest rejected).
+// `ir_path` is skipped entirely; the embedded `]`-or-`"` risk for
+// arbitrary path strings is irrelevant since this parser never
+// reads it.
+//
+// If/when manifest emission gains fields with arbitrary string
+// content (or `modules` entries grow nested arrays), swap this
+// helper for `capsules/sfn/json` — that's the deferred path the
+// architect verdict on #341 left open.
+//
+// Returns `[]` if the `modules` field is absent or the array is
+// empty. The `_do_determinism_check` caller separately verifies
+// that the sidecar FILE exists when one is expected, so an empty
+// return here means "manifest exists but has no module entries"
+// (a `-p` build with zero deps), never "manifest missing".
 fn _extract_modules_from_manifest_json(content: string) -> DeterminismModule[] {
     let mut out: DeterminismModule[] = [];
     let modules_marker = "\"modules\":[";
@@ -473,6 +491,19 @@ fn _pass2_out_path(pass2_work_dir: string, is_library: boolean) -> string {
 // `--check-determinism` (no recursion). Forces `--work-dir` to a
 // sibling of pass 1's; never propagates `-o` (pass 2 derives from
 // its own work-dir).
+//
+// In `--json` mode pass 2's stdout/stderr are routed to `/dev/null`
+// through `sh -c "<argv> >/dev/null 2>&1"` so the orchestrator's
+// determinism-diff JSON line stays the sole structured output on
+// stdout (alongside pass 1's BuildReport JSON that the existing
+// build path already emits). Without this, pass 2 would print its
+// own `build` BuildReport JSON and the `[capsule-artifact] ...`
+// stderr lines to the same stream the caller is parsing, breaking
+// the "one line per logical event" contract of `--json`.
+//
+// In non-`--json` mode pass 2's output is left to inherit so a
+// human watching the build sees both passes' `built:` / cache
+// summary lines.
 fn _run_determinism_pass2(self_exe: string, capsule_path: string, input_path: string, pass2_work_dir: string, cache_trace_flag: boolean, json_flag: boolean) -> int ![io] {
     let mut args: string[] = [];
     args.push(self_exe);
@@ -485,6 +516,20 @@ fn _run_determinism_pass2(self_exe: string, capsule_path: string, input_path: st
         args.push("-p");
         args.push(capsule_path);
     } else { args.push(input_path); }
+    if json_flag {
+        // Shell-quote each arg so paths with spaces / metacharacters
+        // (e.g. `--work-dir "with spaces"`) survive the wrapper.
+        let mut cmd: string = "";
+        let mut i: int = 0;
+        loop {
+            if i >= args.length { break; }
+            if i > 0 { cmd = cmd + " "; }
+            cmd = cmd + _shell_single_quote_arg(args[i]);
+            i += 1;
+        }
+        cmd = cmd + " >/dev/null 2>&1";
+        return process.run(["sh", "-c", cmd]);
+    }
     return process.run(args);
 }
 
@@ -493,6 +538,14 @@ fn _run_determinism_pass2(self_exe: string, capsule_path: string, input_path: st
 // no-sidecar case (positional builds, compiler self-host) —
 // fall through to an empty list and let the binary sha256
 // carry the determinism check.
+//
+// The caller (`_do_determinism_check`) is responsible for
+// verifying that the sidecar exists when `sidecar_path` is
+// non-empty BEFORE calling this helper. A missing sidecar at a
+// non-empty path is a bug (the build was supposed to write it)
+// and would silently downgrade the check to binary-only here,
+// hiding the failure. Pre-checking lets the orchestrator surface
+// the missing-sidecar case as a hard error.
 fn _read_sidecar_modules(sidecar_path: string) -> DeterminismModule[] ![io] {
     let empty: DeterminismModule[] = [];
     if sidecar_path.length == 0 { return empty; }
@@ -520,7 +573,23 @@ fn _do_determinism_check(pass1_out: string, is_library: boolean, cap_capsule_nam
     // Capsules without scope/name form (compiler self-host) get
     // an empty list from `_read_sidecar_modules`; pass 2 will see
     // the same empty list later, so the comparison stays symmetric.
+    //
+    // When `sidecar_path` IS non-empty (`-p` build with safe
+    // scope/name), the file must exist — `_emit_capsule_artifact_sidecar`
+    // ran just before we entered this function. A missing file
+    // here means the sidecar emitter failed silently (or the file
+    // was concurrently deleted) and would silently downgrade the
+    // check to binary-only, hiding the failure. Surface it.
     let sidecar_path = _sidecar_path_for_capsule(cap_capsule_name);
+    if sidecar_path.length > 0 {
+        if !fs.exists(sidecar_path) {
+            if !json_flag {
+                print.err("[determinism] expected pass-1 sidecar missing: "
+                    + sidecar_path);
+            }
+            return 1;
+        }
+    }
     let pass1_modules = _read_sidecar_modules(sidecar_path);
     let pass1_snap = DeterminismSnapshot {
         binary_path: pass1_out,
@@ -557,7 +626,17 @@ fn _do_determinism_check(pass1_out: string, is_library: boolean, cap_capsule_nam
         return 1;
     }
     // Sidecar path is the same as pass 1's; pass 2 overwrote the
-    // file in place, so this read returns pass 2's data.
+    // file in place, so this read returns pass 2's data. Same
+    // missing-file invariant as pass 1.
+    if sidecar_path.length > 0 {
+        if !fs.exists(sidecar_path) {
+            if !json_flag {
+                print.err("[determinism] expected pass-2 sidecar missing: "
+                    + sidecar_path);
+            }
+            return 1;
+        }
+    }
     let pass2_modules = _read_sidecar_modules(sidecar_path);
     let pass2_snap = DeterminismSnapshot {
         binary_path: pass2_out,
@@ -1717,8 +1796,10 @@ fn sailfin_cli_main(argv: string[]) -> int ![io, clock] {
         // at `build/capsules/<scope>/<name>/manifest.json` is the
         // ONE artifact that's not virtualized by `--work-dir`;
         // pass 2 overwrites pass 1's sidecar, so the orchestrator
-        // snapshots pass 1's `module_events` in-memory before
-        // running pass 2 (see below).
+        // reads pass 1's sidecar off disk BEFORE invoking pass 2
+        // (see `_do_determinism_check` below). For capsules whose
+        // name isn't in scope/name form, no sidecar is written and
+        // the check degrades to a binary-sha256 comparison.
         let mut check_determinism_flag: boolean = false;
 
         // Parse args: support -o OUTPUT and -p PATH in any combination.

--- a/compiler/src/cli_main.sfn
+++ b/compiler/src/cli_main.sfn
@@ -8,7 +8,19 @@ import {
     cache_stats_is_empty,
     resolve_build_cache_config
 } from "./build_cache";
-import { BuildReport, build_report_to_json, empty_build_report } from "./build_report";
+import {
+    BuildReport,
+    DeterminismDiff,
+    DeterminismModule,
+    DeterminismSnapshot,
+    build_report_to_json,
+    compare_for_determinism,
+    determinism_diff_to_json,
+    determinism_diff_to_text,
+    empty_build_report,
+    empty_determinism_snapshot,
+    make_determinism_module
+} from "./build_report";
 import { emit_compiler_build_stamp_if_applicable } from "./build_stamp";
 import {
     CapsuleArtifactManifest,
@@ -47,6 +59,7 @@ import {
 import {
     _env_flag,
     _legacy_flag_file,
+    _sha256_of_file_cmd,
     _shell_read_cmd,
     _shell_single_quote_arg
 } from "./cli_commands_utils";
@@ -126,7 +139,7 @@ fn _usage() -> string {
     out = out + "\n";
     out = out + "build & run:\n";
     out = out
-        + "  sfn build [-o OUTPUT] [--no-cache] [--clean] [--cache-trace] [--json] [--work-dir DIR] (<file.sfn> | -p <capsule-path>)\n";
+        + "  sfn build [-o OUTPUT] [--no-cache] [--clean] [--cache-trace] [--json] [--work-dir DIR] [--check-determinism] (<file.sfn> | -p <capsule-path>)\n";
     out = out
         + "  sfn run   [--no-cache] [--clean] [--cache-trace] (<file.sfn> | <exe>)\n";
     out = out
@@ -304,6 +317,260 @@ fn _emit_build_report(input_path: string, out_path: string, kind: string, exit_c
 fn _ensure_dir(path: string) ![io] {
     // best-effort; ignore false.
     fs.createDirectory(path, true);
+}
+
+// -------------------------------------------------------------------
+// Determinism check (issue #779)
+// -------------------------------------------------------------------
+//
+// `sfn build --check-determinism` runs the build twice and compares
+// the two passes. The second pass re-invokes this same compiler
+// binary as a subprocess with a sibling `--work-dir` so the
+// two passes don't stomp each other's intermediate artifacts.
+//
+// The helpers below capture pass 1's snapshot by parsing the
+// per-capsule sidecar JSON off disk (the same source pass 2 will
+// read), then drive pass 2 as a subprocess against a sibling
+// `--work-dir`, then snapshot pass 2 the same way, and emit the
+// diff.
+//
+// Pass 1's sidecar is overwritten on disk by pass 2 (sidecars are
+// always written under `build/capsules/<scope>/<name>/manifest.json`
+// regardless of `--work-dir`), so the orchestrator reads pass 1's
+// sidecar BEFORE invoking pass 2. Using the same `_read_sidecar_modules`
+// path for both passes keeps the comparison symmetric: capsules
+// whose `[capsule].name` isn't in scope/name form (the compiler
+// self-host's `name = "sailfin"` is the canonical example —
+// `_emit_capsule_artifact_sidecar` skips emission in that case)
+// produce empty module lists on BOTH sides, so the check
+// gracefully degrades to a binary-sha256 comparison. Pulling pass
+// 1's modules from the in-memory `module_events` instead would
+// inject the full module list into the pass 1 snapshot while
+// pass 2 stayed empty, surfacing every module as `only_in_a`
+// even on a perfectly deterministic self-host build.
+//
+// The pure comparator (`compare_for_determinism` in `build_report.sfn`)
+// is unit-tested independently in
+// `compiler/tests/unit/build_report_determinism_test.sfn`.
+// Resolve the capsule's sidecar path for `-p` builds, or `""` for
+// positional builds and capsules whose `[capsule].name` isn't in
+// safe scope/name form (the compiler self-host's `name = "sailfin"`
+// is the canonical example — single-segment, so no sidecar). When
+// this returns `""`, the determinism check falls back to comparing
+// only the binary sha256.
+fn _sidecar_path_for_capsule(capsule_name: string) -> string {
+    if capsule_name.length == 0 { return ""; }
+    let parts = parse_scope_name(capsule_name);
+    if parts.scope.length == 0 { return ""; }
+    if !is_safe_scope_name(parts.scope, parts.name) { return ""; }
+    return capsule_artifact_manifest_path(parts.scope, parts.name);
+}
+
+// Parse the `modules` array out of a capsule artifact `manifest.json`
+// string. The manifest's JSON shape is fixed by
+// `capsule_artifact.sfn::_ca_json_module_entry` — a flat array of
+// `{"slug":"X","ir_path":"Y","cache_key":"Z"}` objects with no
+// embedded whitespace — so a naive substring scan is sufficient.
+// `slug` and `cache_key` values are produced by the compiler
+// (slug = module path; cache_key = sha256 hex) and don't contain
+// `"` or `]` characters. Returns `[]` if the `modules` field is
+// absent or the array is empty.
+fn _extract_modules_from_manifest_json(content: string) -> DeterminismModule[] {
+    let mut out: DeterminismModule[] = [];
+    let modules_marker = "\"modules\":[";
+    let modules_start = _find_substring_from(content, modules_marker, 0);
+    if modules_start < 0 { return out; }
+    let array_start = modules_start + modules_marker.length;
+    // The first `]` after the array start closes the modules array.
+    // Slug + cache_key values are sha256 hex or path slugs and
+    // cannot contain `]`, so this naive scan is safe for the
+    // generated JSON shape.
+    let array_end = _find_substring_from(content, "]", array_start);
+    if array_end < 0 { return out; }
+
+    let slug_marker = "\"slug\":\"";
+    let cache_key_marker = "\"cache_key\":\"";
+    let mut pos = array_start;
+    loop {
+        if pos >= array_end { break; }
+        let slug_start = _find_substring_from(content, slug_marker, pos);
+        if slug_start < 0 { break; }
+        if slug_start >= array_end { break; }
+        let svs = slug_start + slug_marker.length;
+        let sve = _find_substring_from(content, "\"", svs);
+        if sve < 0 { break; }
+        if sve > array_end { break; }
+        let slug = substring(content, svs, sve);
+
+        let ck_start = _find_substring_from(content, cache_key_marker, sve);
+        if ck_start < 0 { break; }
+        if ck_start >= array_end { break; }
+        let cvs = ck_start + cache_key_marker.length;
+        let cve = _find_substring_from(content, "\"", cvs);
+        if cve < 0 { break; }
+        if cve > array_end { break; }
+        let cache_key = substring(content, cvs, cve);
+
+        out.push(make_determinism_module(slug, cache_key));
+        pos = cve + 1;
+    }
+    return out;
+}
+
+// Naive substring search from `from`. The `index_of` helper in
+// `string_utils.sfn` only searches from index 0; this returns
+// the absolute offset relative to `haystack`'s start, or `-1`
+// when `needle` isn't present.
+fn _find_substring_from(haystack: string, needle: string, from: int) -> int {
+    if needle.length == 0 { return from; }
+    if from < 0 { return -1; }
+    if from > haystack.length { return -1; }
+    let limit = haystack.length - needle.length;
+    if from > limit { return -1; }
+    let mut i: int = from;
+    loop {
+        if i > limit { break; }
+        let mut j: int = 0;
+        let mut matches: boolean = true;
+        loop {
+            if j >= needle.length { break; }
+            if haystack[i + j] != needle[j] {
+                matches = false;
+                break;
+            }
+            j += 1;
+        }
+        if matches { return i; }
+        i += 1;
+    }
+    return -1;
+}
+
+// Derive pass 2's work-dir from pass 1's. A sibling directory
+// keeps the two builds completely isolated (cache entries write
+// to a shared `build/cache/v1` root by design — that's what the
+// determinism check exercises — but intermediate `.ll` / `.o` /
+// binary outputs never collide). When pass 1 has no `--work-dir`,
+// pass 2 falls back to `build/det-pass2`.
+fn _derive_pass2_work_dir(pass1_work_dir: string) -> string {
+    if pass1_work_dir.length == 0 { return "build/det-pass2"; }
+    return pass1_work_dir + "-pass2";
+}
+
+// Compute pass 2's effective binary path. Pass 2 always provides
+// `--work-dir`, so the default `out_path` derivation in the build
+// subcommand routes through the `work_dir.length > 0` branch:
+// `<work_dir>/sailfin/program.o` for libraries, `<work_dir>/native/sailfin`
+// for binaries.
+fn _pass2_out_path(pass2_work_dir: string, is_library: boolean) -> string {
+    if is_library { return pass2_work_dir + "/sailfin/program.o"; }
+    return pass2_work_dir + "/native/sailfin";
+}
+
+// Reconstruct the second pass's argv and invoke it as a subprocess.
+// Intentionally omits `--no-cache` (per the architect's lean —
+// pass 2 with cache is the realistic regression mode) and
+// `--check-determinism` (no recursion). Forces `--work-dir` to a
+// sibling of pass 1's; never propagates `-o` (pass 2 derives from
+// its own work-dir).
+fn _run_determinism_pass2(self_exe: string, capsule_path: string, input_path: string, pass2_work_dir: string, cache_trace_flag: boolean, json_flag: boolean) -> int ![io] {
+    let mut args: string[] = [];
+    args.push(self_exe);
+    args.push("build");
+    args.push("--work-dir");
+    args.push(pass2_work_dir);
+    if cache_trace_flag { args.push("--cache-trace"); }
+    if json_flag { args.push("--json"); }
+    if capsule_path.length > 0 {
+        args.push("-p");
+        args.push(capsule_path);
+    } else { args.push(input_path); }
+    return process.run(args);
+}
+
+// Read pass 2's sidecar (now overwritten on disk by the subprocess)
+// and extract its module list. `""` sidecar_path covers the
+// no-sidecar case (positional builds, compiler self-host) —
+// fall through to an empty list and let the binary sha256
+// carry the determinism check.
+fn _read_sidecar_modules(sidecar_path: string) -> DeterminismModule[] ![io] {
+    let empty: DeterminismModule[] = [];
+    if sidecar_path.length == 0 { return empty; }
+    if !fs.exists(sidecar_path) { return empty; }
+    let content = fs.readFile(sidecar_path);
+    return _extract_modules_from_manifest_json(content);
+}
+
+// Run the full determinism orchestration after a successful first
+// pass: snapshot pass 1, run pass 2, snapshot pass 2, diff, emit.
+// Returns the process exit code: 0 on match, non-zero on mismatch
+// or pass-2 failure.
+fn _do_determinism_check(pass1_out: string, is_library: boolean, cap_capsule_name: string, work_dir: string, capsule_path: string, input_path: string, binary_dir: string, cache_trace_flag: boolean, json_flag: boolean) -> int ![io] {
+    let pass1_sha = _sha256_of_file_cmd(pass1_out);
+    if pass1_sha.length == 0 {
+        if !json_flag {
+            print.err("[determinism] failed to sha256 first-pass binary: "
+                + pass1_out);
+        }
+        return 1;
+    }
+    // Read pass 1's sidecar BEFORE pass 2 runs — pass 2 will
+    // overwrite the same `build/capsules/<scope>/<name>/manifest.json`
+    // path because sidecar emission isn't gated by `--work-dir`.
+    // Capsules without scope/name form (compiler self-host) get
+    // an empty list from `_read_sidecar_modules`; pass 2 will see
+    // the same empty list later, so the comparison stays symmetric.
+    let sidecar_path = _sidecar_path_for_capsule(cap_capsule_name);
+    let pass1_modules = _read_sidecar_modules(sidecar_path);
+    let pass1_snap = DeterminismSnapshot {
+        binary_path: pass1_out,
+        binary_sha256: pass1_sha,
+        modules: pass1_modules
+    };
+
+    let pass2_work_dir = _derive_pass2_work_dir(work_dir);
+    let pass2_out = _pass2_out_path(pass2_work_dir, is_library);
+    let self_exe = binary_dir + "/sailfin";
+    if binary_dir.length == 0 {
+        if !json_flag {
+            print.err("[determinism] cannot locate self binary (empty binary_dir)");
+        }
+        return 1;
+    }
+
+    let pass2_rc = _run_determinism_pass2(self_exe, capsule_path, input_path, pass2_work_dir, cache_trace_flag, json_flag);
+    if pass2_rc != 0 {
+        if !json_flag {
+            print.err("[determinism] pass-2 build failed (exit="
+                + number_to_string(pass2_rc)
+                + ")");
+        }
+        return pass2_rc;
+    }
+
+    let pass2_sha = _sha256_of_file_cmd(pass2_out);
+    if pass2_sha.length == 0 {
+        if !json_flag {
+            print.err("[determinism] failed to sha256 second-pass binary: "
+                + pass2_out);
+        }
+        return 1;
+    }
+    // Sidecar path is the same as pass 1's; pass 2 overwrote the
+    // file in place, so this read returns pass 2's data.
+    let pass2_modules = _read_sidecar_modules(sidecar_path);
+    let pass2_snap = DeterminismSnapshot {
+        binary_path: pass2_out,
+        binary_sha256: pass2_sha,
+        modules: pass2_modules
+    };
+
+    let diff = compare_for_determinism(pass1_snap, pass2_snap);
+    if json_flag { print(determinism_diff_to_json(diff)); } else {
+        print(determinism_diff_to_text(diff));
+    }
+    if diff.matched { return 0; }
+    return 1;
 }
 
 fn _runtime_bundle_exists(root: string) -> boolean ![io] {
@@ -1423,7 +1690,7 @@ fn sailfin_cli_main(argv: string[]) -> int ![io, clock] {
 
     if is_build {
         // build [-o OUTPUT] [--no-cache] [--clean] [--cache-trace] [--json]
-        //       [--work-dir DIR] (file | -p <capsule-path>)
+        //       [--work-dir DIR] [--check-determinism] (file | -p <capsule-path>)
         let mut out_path: string = "";
         let mut input_path: string = "";
         let mut capsule_path: string = "";
@@ -1441,6 +1708,18 @@ fn sailfin_cli_main(argv: string[]) -> int ![io, clock] {
         // PR7 / #383); `make check`'s stage2/stage3 fixed-point now
         // routes through this flag.
         let mut work_dir: string = "";
+        // `--check-determinism` (issue #779) runs the build twice
+        // and compares per-module cache_keys + the linked binary's
+        // sha256, exiting non-zero on mismatch. Pass 2 is driven
+        // by re-executing this same compiler binary as a subprocess
+        // with a sibling `--work-dir` so the two passes don't
+        // stomp each other's artifacts. The sidecar manifest.json
+        // at `build/capsules/<scope>/<name>/manifest.json` is the
+        // ONE artifact that's not virtualized by `--work-dir`;
+        // pass 2 overwrites pass 1's sidecar, so the orchestrator
+        // snapshots pass 1's `module_events` in-memory before
+        // running pass 2 (see below).
+        let mut check_determinism_flag: boolean = false;
 
         // Parse args: support -o OUTPUT and -p PATH in any combination.
         let mut bi: int = 1;
@@ -1492,6 +1771,11 @@ fn sailfin_cli_main(argv: string[]) -> int ![io, clock] {
                 }
                 work_dir = args[bi + 1];
                 bi += 2;
+                continue;
+            }
+            if strings_equal(a, "--check-determinism") {
+                check_determinism_flag = true;
+                bi += 1;
                 continue;
             }
             let mut is_help_flag: boolean = false;
@@ -1738,6 +2022,9 @@ fn sailfin_cli_main(argv: string[]) -> int ![io, clock] {
             // `[capsule].name == "sailfin"` inside the helper,
             // so foreign capsule builds are a no-op.
             emit_compiler_build_stamp_if_applicable(cap_capsule_name, cap_version, work_dir);
+            if check_determinism_flag {
+                return _do_determinism_check(out_path, true, cap_capsule_name, work_dir, capsule_path, input_path, binary_dir, cache_trace_flag, json_flag);
+            }
             return 0;
         }
 
@@ -1770,6 +2057,9 @@ fn sailfin_cli_main(argv: string[]) -> int ![io, clock] {
         // shelling out to git. Gated on `[capsule].name == "sailfin"`
         // inside the helper, so foreign capsule builds are a no-op.
         emit_compiler_build_stamp_if_applicable(cap_capsule_name, cap_version, work_dir);
+        if check_determinism_flag {
+            return _do_determinism_check(exe_path, false, cap_capsule_name, work_dir, capsule_path, input_path, binary_dir, cache_trace_flag, json_flag);
+        }
         return 0;
     }
 

--- a/compiler/tests/unit/build_report_determinism_test.sfn
+++ b/compiler/tests/unit/build_report_determinism_test.sfn
@@ -1,0 +1,310 @@
+// Issue #779 regression tests for `compare_for_determinism` and the
+// determinism-diff encoders in `compiler/src/build_report.sfn`.
+//
+// The comparator is intentionally pure: the CLI orchestrator
+// (`cli_main.sfn`) reads the per-pass `manifest.json` sidecars and
+// shasums the linked binary, then hands the resulting snapshots to
+// the helper. Keeping the comparator I/O-free lets these unit tests
+// drive every interesting code path without filesystem fixtures —
+// the synthetic perturbation case the issue's third acceptance
+// criterion calls out is exactly what `compare_for_determinism`
+// turns into a structured diff.
+import {
+    DeterminismDiff,
+    DeterminismModule,
+    DeterminismModuleDiff,
+    DeterminismSnapshot,
+    compare_for_determinism,
+    determinism_diff_to_json,
+    determinism_diff_to_text,
+    empty_determinism_snapshot,
+    make_determinism_module
+} from "../../src/build_report";
+
+// --------------------------------------------------------------
+// empty_determinism_snapshot
+// --------------------------------------------------------------
+test "empty_determinism_snapshot: zero-valued fields" {
+    let s = empty_determinism_snapshot();
+    assert s.binary_path == "";
+    assert s.binary_sha256 == "";
+    assert s.modules.length == 0;
+}
+
+// --------------------------------------------------------------
+// compare_for_determinism — match path
+// --------------------------------------------------------------
+test "compare_for_determinism: identical snapshots produce matched=true" {
+    let a = DeterminismSnapshot {
+        binary_path: "build/native/sailfin",
+        binary_sha256: "deadbeef",
+        modules: [make_determinism_module("sfn/math/mod", "aa"), make_determinism_module("sfn/io/mod", "bb")]
+    };
+    let b = DeterminismSnapshot {
+        binary_path: "build/det-pass2/native/sailfin",
+        binary_sha256: "deadbeef",
+        modules: [make_determinism_module("sfn/math/mod", "aa"), make_determinism_module("sfn/io/mod", "bb")]
+    };
+    let diff = compare_for_determinism(a, b);
+    assert diff.matched;
+    assert diff.binary_match;
+    assert diff.module_diffs.length == 0;
+}
+
+test "compare_for_determinism: snapshots agree on modules in different order" {
+    let a = DeterminismSnapshot {
+        binary_path: "a",
+        binary_sha256: "ff",
+        modules: [make_determinism_module("sfn/math/mod", "aa"), make_determinism_module("sfn/io/mod", "bb")]
+    };
+    let b = DeterminismSnapshot {
+        binary_path: "b",
+        binary_sha256: "ff",
+        modules: [make_determinism_module("sfn/io/mod", "bb"), make_determinism_module("sfn/math/mod", "aa")]
+    };
+    let diff = compare_for_determinism(a, b);
+    assert diff.matched;
+    assert diff.module_diffs.length == 0;
+}
+
+// --------------------------------------------------------------
+// compare_for_determinism — binary mismatch
+// --------------------------------------------------------------
+test "compare_for_determinism: binary sha mismatch flips matched=false" {
+    let a = DeterminismSnapshot {
+        binary_path: "a",
+        binary_sha256: "aa",
+        modules: []
+    };
+    let b = DeterminismSnapshot {
+        binary_path: "b",
+        binary_sha256: "bb",
+        modules: []
+    };
+    let diff = compare_for_determinism(a, b);
+    assert ! diff.matched;
+    assert ! diff.binary_match;
+    assert diff.binary_sha256_a == "aa";
+    assert diff.binary_sha256_b == "bb";
+}
+
+test "compare_for_determinism: empty sha treated as binary mismatch" {
+    let a = DeterminismSnapshot {
+        binary_path: "a",
+        binary_sha256: "",
+        modules: []
+    };
+    let b = DeterminismSnapshot {
+        binary_path: "b",
+        binary_sha256: "",
+        modules: []
+    };
+    let diff = compare_for_determinism(a, b);
+    // Two empty digests must NOT report a match — empty digest
+    // means sha256sum failed, and we'd be silently approving a
+    // build where we couldn't actually verify the binary.
+    assert ! diff.matched;
+    assert ! diff.binary_match;
+}
+
+// --------------------------------------------------------------
+// compare_for_determinism — module diff path
+// --------------------------------------------------------------
+test "compare_for_determinism: synthetic cache_key perturbation names the slug" {
+    // The third acceptance criterion: a fixture that perturbs one
+    // module's cache_key must surface in the diff and name the
+    // differing slug.
+    let a = DeterminismSnapshot {
+        binary_path: "a",
+        binary_sha256: "ff",
+        modules: [make_determinism_module("sfn/math/mod", "aa"), make_determinism_module("sfn/io/mod", "bb"), make_determinism_module("sfn/net/mod", "cc")]
+    };
+    let b = DeterminismSnapshot {
+        binary_path: "b",
+        binary_sha256: "ff",
+        modules: [make_determinism_module("sfn/math/mod", "aa"), make_determinism_module("sfn/io/mod", "bb-perturbed"), make_determinism_module("sfn/net/mod", "cc")]
+    };
+    let diff = compare_for_determinism(a, b);
+    assert ! diff.matched;
+    // Binary still matches; only the module diff fails.
+    assert diff.binary_match;
+    assert diff.module_diffs.length == 1;
+    let entry = diff.module_diffs[0];
+    assert entry.slug == "sfn/io/mod";
+    assert entry.kind == "differ";
+    assert entry.cache_key_a == "bb";
+    assert entry.cache_key_b == "bb-perturbed";
+}
+
+test "compare_for_determinism: module only in a surfaces as only_in_a" {
+    let a = DeterminismSnapshot {
+        binary_path: "a",
+        binary_sha256: "ff",
+        modules: [make_determinism_module("sfn/math/mod", "aa"), make_determinism_module("sfn/io/mod", "bb")]
+    };
+    let b = DeterminismSnapshot {
+        binary_path: "b",
+        binary_sha256: "ff",
+        modules: [make_determinism_module("sfn/math/mod", "aa")]
+    };
+    let diff = compare_for_determinism(a, b);
+    assert ! diff.matched;
+    assert diff.module_diffs.length == 1;
+    assert diff.module_diffs[0].slug == "sfn/io/mod";
+    assert diff.module_diffs[0].kind == "only_in_a";
+    assert diff.module_diffs[0].cache_key_a == "bb";
+    assert diff.module_diffs[0].cache_key_b == "";
+}
+
+test "compare_for_determinism: module only in b surfaces as only_in_b" {
+    let a = DeterminismSnapshot {
+        binary_path: "a",
+        binary_sha256: "ff",
+        modules: [make_determinism_module("sfn/math/mod", "aa")]
+    };
+    let b = DeterminismSnapshot {
+        binary_path: "b",
+        binary_sha256: "ff",
+        modules: [make_determinism_module("sfn/math/mod", "aa"), make_determinism_module("sfn/extra/mod", "zz")]
+    };
+    let diff = compare_for_determinism(a, b);
+    assert ! diff.matched;
+    assert diff.module_diffs.length == 1;
+    assert diff.module_diffs[0].slug == "sfn/extra/mod";
+    assert diff.module_diffs[0].kind == "only_in_b";
+    assert diff.module_diffs[0].cache_key_a == "";
+    assert diff.module_diffs[0].cache_key_b == "zz";
+}
+
+// --------------------------------------------------------------
+// determinism_diff_to_json
+// --------------------------------------------------------------
+test "determinism_diff_to_json: includes schema_version and check=determinism" {
+    let a = empty_determinism_snapshot();
+    let b = empty_determinism_snapshot();
+    let diff = compare_for_determinism(a, b);
+    let json = determinism_diff_to_json(diff);
+    assert _contains(json, "\"schema_version\":\"1\"");
+    assert _contains(json, "\"check\":\"determinism\"");
+    assert _contains(json, "\"command\":\"build\"");
+}
+
+test "determinism_diff_to_json: matched=true serializes literally on match" {
+    let a = DeterminismSnapshot {
+        binary_path: "a",
+        binary_sha256: "ff",
+        modules: []
+    };
+    let b = DeterminismSnapshot {
+        binary_path: "b",
+        binary_sha256: "ff",
+        modules: []
+    };
+    let diff = compare_for_determinism(a, b);
+    let json = determinism_diff_to_json(diff);
+    assert _contains(json, "\"matched\":true");
+    assert _contains(json, "\"binary_match\":true");
+    assert _contains(json, "\"module_diffs\":[]");
+}
+
+test "determinism_diff_to_json: matched=false on cache_key mismatch" {
+    let a = DeterminismSnapshot {
+        binary_path: "a",
+        binary_sha256: "ff",
+        modules: [make_determinism_module("sfn/io/mod", "bb")]
+    };
+    let b = DeterminismSnapshot {
+        binary_path: "b",
+        binary_sha256: "ff",
+        modules: [make_determinism_module("sfn/io/mod", "bb-perturbed")]
+    };
+    let diff = compare_for_determinism(a, b);
+    let json = determinism_diff_to_json(diff);
+    assert _contains(json, "\"matched\":false");
+    assert _contains(json, "\"slug\":\"sfn/io/mod\"");
+    assert _contains(json, "\"kind\":\"differ\"");
+    assert _contains(json, "\"cache_key_a\":\"bb\"");
+    assert _contains(json, "\"cache_key_b\":\"bb-perturbed\"");
+}
+
+test "determinism_diff_to_json: binary mismatch surfaces both sha256s" {
+    let a = DeterminismSnapshot {
+        binary_path: "build/native/sailfin",
+        binary_sha256: "aa",
+        modules: []
+    };
+    let b = DeterminismSnapshot {
+        binary_path: "build/det-pass2/native/sailfin",
+        binary_sha256: "bb",
+        modules: []
+    };
+    let diff = compare_for_determinism(a, b);
+    let json = determinism_diff_to_json(diff);
+    assert _contains(json, "\"binary_match\":false");
+    assert _contains(json, "\"binary_sha256_a\":\"aa\"");
+    assert _contains(json, "\"binary_sha256_b\":\"bb\"");
+    assert _contains(json, "\"binary_path_a\":\"build/native/sailfin\"");
+}
+
+// --------------------------------------------------------------
+// determinism_diff_to_text
+// --------------------------------------------------------------
+test "determinism_diff_to_text: match path prints concise success line" {
+    let a = DeterminismSnapshot {
+        binary_path: "a",
+        binary_sha256: "ff",
+        modules: []
+    };
+    let b = DeterminismSnapshot {
+        binary_path: "b",
+        binary_sha256: "ff",
+        modules: []
+    };
+    let diff = compare_for_determinism(a, b);
+    let text = determinism_diff_to_text(diff);
+    assert _contains(text, "[determinism] match");
+}
+
+test "determinism_diff_to_text: mismatch names the differing slug" {
+    let a = DeterminismSnapshot {
+        binary_path: "a",
+        binary_sha256: "ff",
+        modules: [make_determinism_module("sfn/io/mod", "bb")]
+    };
+    let b = DeterminismSnapshot {
+        binary_path: "b",
+        binary_sha256: "ff",
+        modules: [make_determinism_module("sfn/io/mod", "bb-perturbed")]
+    };
+    let diff = compare_for_determinism(a, b);
+    let text = determinism_diff_to_text(diff);
+    assert _contains(text, "[determinism] MISMATCH");
+    assert _contains(text, "sfn/io/mod");
+    assert _contains(text, "[differ]");
+    assert _contains(text, "bb-perturbed");
+}
+
+// --------------------------------------------------------------
+// Helpers
+// --------------------------------------------------------------
+fn _contains(haystack: string, needle: string) -> boolean {
+    if needle.length == 0 { return true; }
+    if haystack.length < needle.length { return false; }
+    let mut i: int = 0;
+    loop {
+        if i + needle.length > haystack.length { break; }
+        let mut j: int = 0;
+        let mut matches: boolean = true;
+        loop {
+            if j >= needle.length { break; }
+            if haystack[i + j] != needle[j] {
+                matches = false;
+                break;
+            }
+            j += 1;
+        }
+        if matches { return true; }
+        i += 1;
+    }
+    return false;
+}


### PR DESCRIPTION
## Summary

- Adds `sfn build --check-determinism`: runs the build twice and compares per-module `cache_key`s (from the per-capsule `manifest.json` sidecars) plus the linked binary's sha256, exiting non-zero on mismatch.
- Pass 2 re-invokes this same compiler binary as a subprocess against a sibling `--work-dir` so the two passes don't stomp each other's intermediate artifacts. Pass 2 intentionally runs **with cache** (per the architect's verdict on #341) — the realistic regression mode is the cache storing non-canonical artifacts.
- The diff helper (`compare_for_determinism` in `build_report.sfn`) is pure and unit-tested. The CLI orchestrator handles file I/O.

Closes #779

## Design notes

Both passes parse modules from the on-disk `build/capsules/<scope>/<name>/manifest.json` sidecar — pass 1's snapshot is taken BEFORE pass 2 runs (pass 2 overwrites the same file in place since sidecar emission isn't gated by `--work-dir`). Using the same source for both keeps the comparison symmetric: capsules whose `[capsule].name` isn't in scope/name form (the compiler self-host's `name = "sailfin"` is the canonical case — `_emit_capsule_artifact_sidecar` skips emission) get empty module lists on both sides, so the check gracefully degrades to a binary-sha256 comparison. Pulling pass 1's modules from in-memory `module_events` instead would have injected the full module list into pass 1 while pass 2 stayed empty.

## Acceptance criteria

- [x] `sfn build --help` lists `--check-determinism`.
- [x] `build/native/sailfin build -p compiler --check-determinism --work-dir build/det-check` on a clean checkout exits 0.
- [x] A targeted regression test (synthetic perturbation of one module's `cache_key`) causes exit-non-zero with a diff naming the differing module slug — covered by `compare_for_determinism: synthetic cache_key perturbation names the slug`.
- [x] Output respects `--json` mode: the determinism diff is emitted as a structured JSON object with `schema_version`/`check:"determinism"`/`module_diffs`.
- [x] Flag composes with `--work-dir DIR` — pass 1 uses `<work_dir>`, pass 2 uses `<work_dir>-pass2`.
- [x] `make compile && make test` pass.
- [x] `sfn fmt --check` clean on every touched `.sfn` file.

## Verification

```bash
ulimit -v 8388608
timeout 1800 make compile
build/native/sailfin build -p compiler --check-determinism --work-dir build/det-check
# exit 0; "[determinism] match: binary sha256 + 0 module diff(s)"
```

Full suite: `make test` → 102/102 unit, 27/27 integration, 77/77 e2e, 14/14 capsules.
Determinism unit tests: `compiler/tests/unit/build_report_determinism_test.sfn` → 14/14 pass.

## Files Changed

- `compiler/src/build_report.sfn` — new `DeterminismSnapshot` / `DeterminismDiff` types, pure `compare_for_determinism(a, b)` plus `determinism_diff_to_json` / `determinism_diff_to_text` encoders.
- `compiler/src/cli_main.sfn` — flag parse + usage update; helpers `_extract_modules_from_manifest_json`, `_sidecar_path_for_capsule`, `_derive_pass2_work_dir`, `_pass2_out_path`, `_run_determinism_pass2`, `_read_sidecar_modules`, `_do_determinism_check`; orchestration call from both library and binary success paths.
- `compiler/tests/unit/build_report_determinism_test.sfn` — 14 unit tests covering match, binary-sha mismatch, module-only-in-a / only-in-b / differ cases, JSON and text encoders.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TKhbKUJuSNo15qM4owHE5L)_