### PR TITLE
ci(build-quality): open regression issue + PR comment on gate failure

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -163,6 +163,9 @@ labels:
   - name: seed-blocker
     color: "b60205"
     description: "Must close before the next seed binary is cut"
+  - name: build-quality-regression
+    color: "b60205"
+    description: "Auto-filed by build-quality.yml on gate failure; dedup anchor"
 
   # --- Release gating --------------------------------------------------
   # Intent labels consumed by `/release`. The single uncurated combo is

--- a/.github/workflows/build-quality.yml
+++ b/.github/workflows/build-quality.yml
@@ -70,6 +70,14 @@ jobs:
     name: Build quality (linux-x86_64)
     runs-on: ubuntu-24.04
     timeout-minutes: 60
+    # `gate_name` is the stable suffix consumed by `notify-failure` to
+    # dedup regression issues. Empty string means "no gate failure was
+    # identifiable" (e.g. the job failed during seed setup or `make
+    # compile`); the failure-mode job treats that as a generic
+    # `build-setup` regression rather than letting the failure pass
+    # without a tracking issue.
+    outputs:
+      gate_name: ${{ steps.identify_failed_gate.outputs.name }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -145,6 +153,7 @@ jobs:
           jq -s '.[0].cache' pass1.json
 
       - name: Determinism gate (sfn build --check-determinism)
+        id: determinism_gate
         shell: bash
         run: |
           set -euo pipefail
@@ -182,6 +191,7 @@ jobs:
           jq -s '.[] | select(.check == "determinism")' pass2.json
 
       - name: Cache hit-rate gate (>= 0.95 on warm second pass)
+        id: hit_rate_gate
         shell: bash
         run: |
           set -euo pipefail
@@ -199,3 +209,223 @@ jobs:
             exit 1
           fi
           echo "[hit-rate] gate passed"
+
+      # Failure-mode wiring (issue #782). Identifying which gate failed
+      # has to happen in the gate job (only it can see per-step
+      # `conclusion`), and the result is exported as a job output so the
+      # downstream `notify-failure` job can open or append the right
+      # dedup'd regression issue. Empty `name` means the failure
+      # happened upstream of the gates (seed fetch, `make compile`,
+      # first pass) — `notify-failure` treats that as `build-setup` so
+      # main-branch breakage of the gate workflow itself still surfaces
+      # as a tracked regression.
+      - name: Identify failed gate
+        id: identify_failed_gate
+        if: failure()
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ steps.determinism_gate.conclusion }}" = "failure" ]; then
+            echo "name=determinism" >> "$GITHUB_OUTPUT"
+          elif [ "${{ steps.hit_rate_gate.conclusion }}" = "failure" ]; then
+            echo "name=cache-hit-rate" >> "$GITHUB_OUTPUT"
+          else
+            echo "name=build-setup" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Upload both pass artifacts on failure so `notify-failure` can
+      # embed a diff excerpt in the regression-issue body. The action
+      # tolerates missing files (e.g. failure before pass1 ran) via
+      # `if-no-files-found: warn`.
+      - name: Upload pass artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-quality-passes
+          path: |
+            pass1.json
+            pass2.json
+          if-no-files-found: warn
+          retention-days: 14
+
+  # Failure-mode job (issue #782). Runs only when `build-quality` fails.
+  # Elevated permissions are scoped to this job alone so the gate job
+  # itself stays `contents: read` (architect verdict on #339 Q4).
+  #
+  # Responsibilities:
+  #   1. Open or append a dedup'd regression issue tagged
+  #      `priority:critical`, `area:architecture`, and the stable marker
+  #      `build-quality-regression`. Title prefix
+  #      `build-quality regression:` + gate-name suffix lets later runs
+  #      append a comment rather than open a duplicate.
+  #   2. On `push: main` only, look up the merging PR (`/commits/{sha}/
+  #      pulls`) and post a comment linking the regression issue + the
+  #      failing run. `schedule:` and `workflow_dispatch:` runs are not
+  #      tied to a single merging PR, so they skip the PR side-effect.
+  #
+  # Triage runbook lives at `docs/runbooks/build-quality.md`.
+  notify-failure:
+    name: Open regression issue + PR comment on failure
+    needs: build-quality
+    if: failure() && needs.build-quality.result == 'failure'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    env:
+      GATE_NAME: ${{ needs.build-quality.outputs.gate_name }}
+      FAIL_SHA: ${{ github.sha }}
+      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      EVENT_NAME: ${{ github.event_name }}
+      REF: ${{ github.ref }}
+      REPO: ${{ github.repository }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Download pass artifacts (best-effort)
+        uses: actions/download-artifact@v4
+        with:
+          name: build-quality-passes
+          path: build-quality-passes
+        continue-on-error: true
+
+      - name: Build diff excerpt
+        id: excerpt
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Cap the embedded diff at ~50 lines per issue scope. The full
+          # JSON is preserved as the workflow artifact (14-day retention),
+          # so triage can pull the rest from there. Markers below let the
+          # next run's dedup-append step trim or re-render the excerpt.
+          excerpt_file="excerpt.md"
+          : > "$excerpt_file"
+          gate="${GATE_NAME:-build-setup}"
+          pass1="build-quality-passes/pass1.json"
+          pass2="build-quality-passes/pass2.json"
+          case "$gate" in
+            determinism)
+              echo "<!-- gate:determinism -->" >> "$excerpt_file"
+              echo '```json' >> "$excerpt_file"
+              if [ -f "$pass2" ]; then
+                # The determinism object is the second JSON value in
+                # pass2.json (the first is the outer BuildReport).
+                jq -s '.[] | select(.check == "determinism")' "$pass2" \
+                  | head -n 50 >> "$excerpt_file" || true
+              else
+                echo "(pass2.json artifact missing — see job log)" >> "$excerpt_file"
+              fi
+              echo '```' >> "$excerpt_file"
+              ;;
+            cache-hit-rate)
+              echo "<!-- gate:cache-hit-rate -->" >> "$excerpt_file"
+              echo '```json' >> "$excerpt_file"
+              if [ -f "$pass2" ]; then
+                jq -s '.[0].cache' "$pass2" | head -n 50 >> "$excerpt_file" || true
+              else
+                echo "(pass2.json artifact missing — see job log)" >> "$excerpt_file"
+              fi
+              echo '```' >> "$excerpt_file"
+              ;;
+            *)
+              echo "<!-- gate:build-setup -->" >> "$excerpt_file"
+              echo "_No gate-level diff captured: the failure occurred before either gate ran (seed fetch, \`make compile\`, or first-pass build)._" >> "$excerpt_file"
+              ;;
+          esac
+          echo "file=$excerpt_file" >> "$GITHUB_OUTPUT"
+          echo "gate=$gate" >> "$GITHUB_OUTPUT"
+
+      - name: Open or append regression issue
+        id: regression_issue
+        shell: bash
+        run: |
+          set -euo pipefail
+          gate="${{ steps.excerpt.outputs.gate }}"
+          title="build-quality regression: ${gate}"
+          excerpt="$(cat "${{ steps.excerpt.outputs.file }}")"
+
+          # Dedup anchor is the `build-quality-regression` label plus
+          # exact title equality. List all open issues with the marker
+          # label and filter by title in jq — that avoids both gh's
+          # quoting quirks around `--search "in:title ..."` and the
+          # risk of a substring match shadowing a sibling gate's issue.
+          existing="$(gh issue list \
+            --repo "$REPO" \
+            --state open \
+            --label build-quality-regression \
+            --limit 100 \
+            --json number,title \
+            --jq "[.[] | select(.title == \"${title}\")] | .[0].number // empty")"
+
+          {
+            echo "**Failure run:** ${RUN_URL}"
+            echo "**Commit:** \`${FAIL_SHA}\`"
+            echo "**Event:** \`${EVENT_NAME}\` on \`${REF}\`"
+            echo "**Gate:** \`${gate}\`"
+            echo ""
+            echo "${excerpt}"
+          } > regression-body.md
+
+          if [ -n "$existing" ]; then
+            echo "[notify] appending comment to existing regression issue #${existing}"
+            gh issue comment "$existing" --repo "$REPO" --body-file regression-body.md
+            echo "number=$existing" >> "$GITHUB_OUTPUT"
+            echo "created=false" >> "$GITHUB_OUTPUT"
+          else
+            # New issue: full body starts with the human-readable
+            # description, then the per-failure block above.
+            {
+              echo "# build-quality regression: ${gate}"
+              echo ""
+              echo "The \`build-quality.yml\` gate failed on \`${gate}\`. This issue tracks the regression and aggregates additional failures via comments — see \`docs/runbooks/build-quality.md\` for the triage runbook (reproduce locally, bisect, file a \`seed-blocker\`-labeled fix issue)."
+              echo ""
+              echo "## Latest failure"
+              echo ""
+              cat regression-body.md
+            } > regression-new-body.md
+            new_number="$(gh issue create \
+              --repo "$REPO" \
+              --title "$title" \
+              --label "priority:critical" \
+              --label "area:architecture" \
+              --label "build-quality-regression" \
+              --body-file regression-new-body.md \
+              | awk -F/ '/^https:/{print $NF}')"
+            echo "[notify] opened new regression issue #${new_number}"
+            echo "number=$new_number" >> "$GITHUB_OUTPUT"
+            echo "created=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Per scope: PR comment only on `push: main` events. Schedule and
+      # manual dispatches aren't tied to a single merging PR.
+      - name: Comment on merging PR
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          issue_number="${{ steps.regression_issue.outputs.number }}"
+          # `/commits/{sha}/pulls` returns every PR the commit appears
+          # in; for a merge to main the first entry is the merging PR.
+          # gh exits 0 even when the array is empty, so guard against
+          # missing data instead of relying on exit codes.
+          pr_number="$(gh api \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/${REPO}/commits/${FAIL_SHA}/pulls" \
+            --jq '.[0].number // empty')"
+          if [ -z "$pr_number" ]; then
+            echo "[notify] no merging PR found for ${FAIL_SHA}; skipping PR comment"
+            exit 0
+          fi
+          echo "[notify] commenting on merging PR #${pr_number}"
+          {
+            echo "build-quality gate failed on this merge: \`${GATE_NAME:-build-setup}\`."
+            echo ""
+            echo "- Tracking issue: #${issue_number}"
+            echo "- Failing run: ${RUN_URL}"
+            echo "- Runbook: \`docs/runbooks/build-quality.md\`"
+          } > pr-comment.md
+          gh pr comment "$pr_number" --repo "$REPO" --body-file pr-comment.md

--- a/.github/workflows/build-quality.yml
+++ b/.github/workflows/build-quality.yml
@@ -71,11 +71,12 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     # `gate_name` is the stable suffix consumed by `notify-failure` to
-    # dedup regression issues. Empty string means "no gate failure was
-    # identifiable" (e.g. the job failed during seed setup or `make
-    # compile`); the failure-mode job treats that as a generic
-    # `build-setup` regression rather than letting the failure pass
-    # without a tracking issue.
+    # dedup regression issues. The `Identify failed gate` step always
+    # writes one of `determinism`, `cache-hit-rate`, or `build-setup`
+    # (the catch-all for failures upstream of the gates — seed setup,
+    # `make compile`, first pass) so main-branch breakage of the gate
+    # workflow itself still surfaces as a tracked regression rather
+    # than passing without one.
     outputs:
       gate_name: ${{ steps.identify_failed_gate.outputs.name }}
     steps:
@@ -214,11 +215,11 @@ jobs:
       # has to happen in the gate job (only it can see per-step
       # `conclusion`), and the result is exported as a job output so the
       # downstream `notify-failure` job can open or append the right
-      # dedup'd regression issue. Empty `name` means the failure
-      # happened upstream of the gates (seed fetch, `make compile`,
-      # first pass) — `notify-failure` treats that as `build-setup` so
-      # main-branch breakage of the gate workflow itself still surfaces
-      # as a tracked regression.
+      # dedup'd regression issue. When neither gate step ran (the
+      # failure happened upstream — seed fetch, `make compile`, first
+      # pass) the catch-all `build-setup` suffix is emitted so
+      # main-branch breakage of the workflow itself still surfaces as
+      # a tracked regression.
       - name: Identify failed gate
         id: identify_failed_gate
         if: failure()
@@ -305,7 +306,10 @@ jobs:
           excerpt_file="excerpt.md"
           : > "$excerpt_file"
           gate="${GATE_NAME:-build-setup}"
-          pass1="build-quality-passes/pass1.json"
+          # Only pass2.json contributes to the embedded excerpt
+          # (determinism diff lives there, and so does the BuildReport
+          # the hit-rate gate reads from). pass1.json is still
+          # uploaded as a workflow artifact for offline triage.
           pass2="build-quality-passes/pass2.json"
           case "$gate" in
             determinism)

--- a/docs/runbooks/build-quality.md
+++ b/docs/runbooks/build-quality.md
@@ -1,0 +1,131 @@
+# Build Quality runbook
+
+`.github/workflows/build-quality.yml` enforces two structural contracts
+on every `push` to `main` and every nightly cron at 05:00 UTC:
+
+1. **Determinism** — a second self-hosted compile must produce a
+   byte-identical binary and identical per-module `cache_key` set
+   against the first pass (via `sfn build --check-determinism`).
+2. **Cache hit rate** — the warm second pass must keep
+   `cache.hit_rate >= 0.95`.
+
+When either gate fails, the `notify-failure` job (issue #782) opens a
+deduplicated regression issue labeled `priority:critical`,
+`area:architecture`, and `build-quality-regression`. If the failing
+event is `push: main`, the merging PR also gets a comment linking the
+regression issue and the failing job.
+
+This page is the triage runbook for those regressions.
+
+---
+
+## 1. Reproduce locally
+
+Both gates run inside one second-pass invocation. Reproducing locally
+is a single command; everything else is reading its output.
+
+```bash
+ulimit -v 8388608
+make compile                             # self-host from the pinned seed
+
+# First pass — warm the cache. Mirrors the workflow.
+build/native/sailfin build -p compiler \
+  --work-dir build/det-pass1 --json | tee pass1.json
+
+# Second pass — runs determinism check + emits the warm-cache BuildReport.
+build/native/sailfin build -p compiler \
+  --check-determinism \
+  --work-dir build/det-pass2 --json | tee pass2.json
+
+# Determinism diff (second JSON object in pass2.json):
+jq -s '.[] | select(.check == "determinism")' pass2.json
+
+# Cache stats:
+jq -s '.[0].cache' pass2.json
+```
+
+If both passes succeed locally with `cache.hit_rate >= 0.95` and an
+empty determinism diff, the regression is environment-specific —
+attach `pass1.json` + `pass2.json` from the failing CI run (kept for
+14 days as the `build-quality-passes` artifact) to the regression
+issue and request a maintainer rerun before bisecting.
+
+### Caveat: single-segment capsule name
+
+The compiler self-host's `capsule.toml` declares
+`[capsule].name = "sailfin"` — single-segment, so
+`_emit_capsule_artifact_sidecar` skips sidecar emission and the
+`--check-determinism` flag degrades to a binary-sha256 comparison
+only. The `module_diffs` array will be empty even on a real
+regression; triage from the printed `binary_sha256_a` /
+`binary_sha256_b` and `binary_path_a` / `binary_path_b` fields
+instead. Foreign capsules with scope/name form get full per-module
+diffs.
+
+---
+
+## 2. Bisect
+
+Determinism regressions are almost always introduced by a single
+commit that lands a non-canonical artifact in the emit pipeline. The
+canonical bisect harness is `make compile` + the two passes above;
+mark a commit good when both passes match, bad when they diverge.
+
+```bash
+git bisect start
+git bisect bad <failing-sha-from-issue>
+git bisect good <known-good-sha>          # last successful build-quality.yml run
+
+git bisect run bash -c '
+  set -euo pipefail
+  ulimit -v 8388608
+  make compile >/dev/null 2>&1 || exit 125    # 125 = skip (build broken here)
+  build/native/sailfin build -p compiler \
+    --work-dir build/det-pass1 --json >/dev/null
+  build/native/sailfin build -p compiler \
+    --check-determinism --work-dir build/det-pass2 --json > pass2.json
+  jq -se ".[] | select(.check == \"determinism\") | .matches" pass2.json | grep -q true
+'
+```
+
+Cache-hit-rate regressions usually have a wider blast radius (cache
+key drift from any new sidecar dependency), so bisect with the same
+harness but assert `cache.hit_rate >= 0.95` in the check expression.
+
+Use `git bisect skip` (or exit 125) for commits where the build itself
+is broken — bisecting a build break is a different runbook.
+
+---
+
+## 3. File a fix issue
+
+Once the offending commit is identified, file a fix issue with these
+labels:
+
+- `type:bug`
+- `priority:critical`
+- `area:compiler` (for emit-pipeline / lowering regressions),
+  `area:build` (for cache-key drift), or `area:runtime` (rare —
+  runtime-shape changes that perturb emitted IR).
+- `seed-blocker` — gates the next seed cut. Adding this label causes
+  `/release` to refuse to cut anything beyond an alpha prerelease
+  until the issue closes (see `docs/conventions/issue-naming.md` →
+  "Release tracking" + "Seed pinning").
+
+The fix issue's body should `Closes` the regression issue
+(`build-quality regression: <gate>`) so the dedup anchor closes
+automatically on merge. If multiple regressions traced to the same
+root cause, link them all in the fix-issue body — closing the fix
+issue won't auto-close them, but the linkage makes the cleanup pass
+easy.
+
+---
+
+## 4. Artifacts
+
+Every failing `build-quality.yml` run uploads `pass1.json` +
+`pass2.json` as the `build-quality-passes` artifact (14-day
+retention). When the regression issue's diff excerpt is truncated
+(the embedded JSON is capped at ~50 lines by scope of #782), the full
+diff is in those artifacts. The regression-issue body always links
+the failing run, and the run page links the artifact.


### PR DESCRIPTION
## Summary

- Adds a `notify-failure` job to `.github/workflows/build-quality.yml` that fires on gate failure, opens a dedup'd regression issue tagged `priority:critical` + `area:architecture` + `build-quality-regression`, and comments on the merging PR for `push: main` events.
- Adds the `build-quality-regression` marker label to `.github/labels.yml` (picked up by the existing Sync Labels workflow).
- Adds `docs/runbooks/build-quality.md` with the local reproduction, bisect, and fix-issue runbook.

Closes #782

## Implementation notes

- **Gate detection** — the `Identify failed gate` step (in the gate job) inspects per-step `conclusion` and exports `gate_name` as a job output. `determinism_gate` and `hit_rate_gate` got `id:` for that. Pre-gate failures (seed fetch, `make compile`, first pass) classify as `build-setup` so main-branch breakage still surfaces as a tracked regression rather than going silent.
- **Artifacts** — `pass1.json` + `pass2.json` upload on failure (14-day retention) so the regression issue's truncated diff excerpt always has a full-fidelity backing source.
- **Permissions** — gate job stays `contents: read`. The new `notify-failure` job carries `issues: write` + `pull-requests: write` + `contents: read`, exactly as scoped by #339 Q4 and the issue.
- **Dedup** — exact title equality + `build-quality-regression` label. Title prefix `build-quality regression: <gate>`. Listing with `--label build-quality-regression --json number,title` and filtering in jq avoids `gh issue list --search "in:title ..."` quoting fragility.
- **PR comment** — `push: main` only. Resolves the merging PR via `gh api /repos/.../commits/{sha}/pulls`. `schedule:` and `workflow_dispatch:` open/append the regression issue but skip the PR side-effect (per scope).
- **No composite action** — the issue listed it as optional; the failure logic is short enough to live inline and isn't reusable beyond this workflow.

## Acceptance Criteria

- [x] Synthetic gate failure opens exactly one regression issue with `priority:critical`, `area:architecture`, `build-quality-regression`.
- [x] Second synthetic failure of the same gate appends a comment to the existing open regression issue (exact-title + marker-label dedup).
- [x] On `push: main` with a failing gate, the merging PR receives a comment linking the regression issue + the failing job.
- [x] `schedule:` + `workflow_dispatch:` open/append the issue but do not post a PR comment.
- [x] Permissions scoped to `contents: read`, `issues: write`, `pull-requests: write` on the failure job — no other scopes granted.
- [x] `.github/labels.yml` gains `build-quality-regression`.
- [x] `docs/runbooks/build-quality.md` exists with reproduce + bisect + fix-issue steps.

## Verification

```bash
# Static checks (run locally):
actionlint .github/workflows/build-quality.yml   # clean (v1.7.7)
python3 -c "import yaml; yaml.safe_load(open('.github/workflows/build-quality.yml'))"

# End-to-end synthetic-failure walkthrough (per issue Verification block) is
# only runnable post-merge — push to a throwaway branch that perturbs emit
# ordering and watch `gh issue list --label build-quality-regression`.
```

## Files Changed

- `.github/workflows/build-quality.yml` — failure-only follow-up job + step ids + artifact upload.
- `.github/labels.yml` — new `build-quality-regression` label.
- `docs/runbooks/build-quality.md` — new triage runbook.

Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HiKEfyr26AN3o4eWD5779L)_