### PR TITLE
test(lowering): pin hardcoded @sailfin_runtime_* call sites (#727)

### DIFF
--- a/compiler/src/llvm/lowering/emission.sfn
+++ b/compiler/src/llvm/lowering/emission.sfn
@@ -607,6 +607,12 @@ fn emit_llvm_function(function: NativeFunction, functions: NativeFunction[], eff
         // and exit with code 1 on OOM rather than passing NULL into
         // user code where `argv.length` would crash on the first deref.
         if user_param_count > 0 {
+            // Registry bypass: the `_start`/main wrapper is one-shot IR
+            // with a bespoke (i32, i8**) → i8* shape that doesn't fit
+            // `emit_runtime_call`'s descriptor model. If a descriptor is
+            // ever registered for `argv_to_string_array`, update this
+            // emission AND the test_lowering_no_bare_runtime_emissions
+            // allowlist in lockstep — see #727.
             wrapper_lines.push("  %argv_arr_i8 = call i8* @sailfin_runtime_argv_to_string_array(i32 %argc, i8** %argv)");
             wrapper_lines.push("  %argv_is_null = icmp eq i8* %argv_arr_i8, null");
             wrapper_lines.push("  br i1 %argv_is_null, label %main.argv_oom, label %main.argv_ok");
@@ -672,6 +678,12 @@ fn emit_llvm_function(function: NativeFunction, functions: NativeFunction[], eff
         // message that `sfn_throw` stashed on the frame, then exit 1.
         wrapper_lines.push("main.catch:");
         wrapper_lines.push("  %msg = call i8* @sfn_take_exception(i8* %frame_i8)");
+        // Registry bypass: the catch tail of the `_start`/main wrapper
+        // is one-shot IR; the descriptor registry's call-site dispatch
+        // doesn't model the wrapper-only `(i8*) -> void` panic path.
+        // If a descriptor is registered for `panic_emit`, update this
+        // emission AND the test_lowering_no_bare_runtime_emissions
+        // allowlist in lockstep — see #727.
         wrapper_lines.push("  call void @sailfin_runtime_panic_emit(i8* %msg)");
         wrapper_lines.push("  ret i32 1");
         wrapper_lines.push("}");

--- a/compiler/src/llvm/runtime_helpers.sfn
+++ b/compiler/src/llvm/runtime_helpers.sfn
@@ -64,6 +64,18 @@
 // follow-up PRs slot underneath this comment as additional waves
 // land. Each wave should:
 //   * Pick a small batch (5–10 helpers, single domain).
+//   * **Before flipping `native_signature`**, grep both
+//     `compiler/src/llvm/lowering/` and
+//     `compiler/src/llvm/expression_lowering/native/` for hardcoded
+//     `@sailfin_runtime_<symbol>` call strings — these bypass the
+//     descriptor's `effective_symbol` resolution and must be updated
+//     in lockstep with the flip, or the wave PR will link-fail
+//     against the old symbol (see #727 and the M2.8 print.err
+//     wrapper post-mortem). The audit is mechanised by
+//     `compiler/tests/e2e/test_lowering_no_bare_runtime_emissions.sh`;
+//     any new hardcoded emission must either route through the
+//     registry or land in the test's allowlist with a
+//     `// Registry bypass: …` source comment.
 //   * For each helper that has hardcoded LLVM call sites in
 //     `compiler/src/llvm/expression_lowering/native/*`, mirror
 //     the M2.4a / M2.6 pattern: add a C trampoline in

--- a/compiler/tests/e2e/fixtures/runtime_emission_allowlist.txt
+++ b/compiler/tests/e2e/fixtures/runtime_emission_allowlist.txt
@@ -1,0 +1,23 @@
+# Hardcoded `@sailfin_runtime_*` call-site emissions that bypass the
+# runtime descriptor registry in `compiler/src/llvm/runtime_helpers.sfn`.
+#
+# Issue #727 pins this allowlist so any future descriptor flip that
+# changes a `native_signature` for one of these symbols will fail
+# `test_lowering_no_bare_runtime_emissions.sh` until the bypass is
+# updated in lockstep. Line numbers are intentionally pinned — a
+# moved call site forces the author to re-justify the bypass.
+#
+# Each entry: `<repo-relative path>:<line>:<full source line>`.
+# Every allowlist entry must carry a one-line `// Registry bypass: …`
+# comment immediately above the call site in the source. If you remove
+# an entry, also delete the bypass comment.
+#
+# To remove an entry from the allowlist:
+#   1. Register the helper in `runtime_helpers.sfn` (add a descriptor).
+#   2. Either route the emission through `emit_runtime_call` (the M1.7
+#      dispatch path) or read `effective_symbol` off the descriptor
+#      (see `rendering.sfn` / `core_call_emission.sfn`).
+#   3. Delete the bypass comment AND the allowlist line in the same PR.
+
+compiler/src/llvm/lowering/emission.sfn:616:            wrapper_lines.push("  %argv_arr_i8 = call i8* @sailfin_runtime_argv_to_string_array(i32 %argc, i8** %argv)");
+compiler/src/llvm/lowering/emission.sfn:687:        wrapper_lines.push("  call void @sailfin_runtime_panic_emit(i8* %msg)");

--- a/compiler/tests/e2e/test_lowering_no_bare_runtime_emissions.sh
+++ b/compiler/tests/e2e/test_lowering_no_bare_runtime_emissions.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# End-to-end audit for issue #727 — pin the hardcoded
+# `@sailfin_runtime_*` call-site emissions under the LLVM lowering
+# directories against an explicit allowlist.
+#
+# Why this exists:
+#
+# The runtime helper descriptor registry in
+# `compiler/src/llvm/runtime_helpers.sfn` is the single source of truth
+# for runtime call symbols. Each descriptor carries a `symbol`
+# (legacy C entrypoint) and an optional `native_signature` (canonical
+# Sailfin-native `sfn_*` entrypoint). Call-site emission resolves the
+# symbol through `effective_symbol = native_signature ?? symbol` so a
+# single descriptor flip migrates every call site in lockstep.
+#
+# Hardcoded `@sailfin_runtime_*` strings pushed straight into the
+# emitted IR (via `lines.push("…")` or `wrapper_lines.push("…")`)
+# bypass that resolution. When M2.4a/M2.6/M2.8 flipped descriptors,
+# the bypass sites linked against the *old* symbol and the wave PR
+# crashed with `use of undefined value '@sailfin_runtime_print_err'`.
+# The lockstep update was caught by hand, not by tooling.
+#
+# This test mechanises the guard: every match against the audit grep
+# must appear in the allowlist (with the exact line number), and every
+# allowlist entry must be matched by an actual line. A new
+# hardcoded emission lands → the test fails until the author either
+# (a) routes it through the descriptor registry or (b) adds it to
+# the allowlist with a one-line bypass comment in the source.
+#
+# Allowlist format: `compiler/tests/e2e/fixtures/runtime_emission_allowlist.txt`
+# Each non-comment line is the verbatim `grep -nE` output
+# (`<repo-rel path>:<line>:<source line>`).
+#
+# Usage:
+#   compiler/tests/e2e/test_lowering_no_bare_runtime_emissions.sh <compiler-binary>
+#
+# The compiler binary argument is accepted but unused — this is a
+# pure source-audit test. We take it so the e2e harness can pass
+# `$(NATIVE_BIN)` uniformly to every shell test.
+
+set -euo pipefail
+
+# Argument is accepted for harness uniformity; not used.
+: "${1:-}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+ALLOWLIST="$SCRIPT_DIR/fixtures/runtime_emission_allowlist.txt"
+
+if [ ! -f "$ALLOWLIST" ]; then
+    echo "[test] FAIL: allowlist missing at $ALLOWLIST"
+    exit 1
+fi
+
+# Audit grep: catches any `call ... @sailfin_runtime_…` literal inside
+# a pushed IR string. The `[^"]*` between `call` and `@` keeps the
+# match within a single emitted IR token so comment lines that happen
+# to mention the symbol elsewhere don't trip the audit; pure
+# `// …` comment lines are dropped below for the same reason.
+ACTUAL="$(cd "$REPO_ROOT" && \
+    grep -rnE 'call [^"]*@sailfin_runtime_' \
+        compiler/src/llvm/lowering/ \
+        compiler/src/llvm/expression_lowering/native/ 2>/dev/null \
+    | grep -vE ':[[:space:]]*//' \
+    | sort || true)"
+
+EXPECTED="$(grep -vE '^[[:space:]]*(#|$)' "$ALLOWLIST" | sort)"
+
+if [ "$ACTUAL" = "$EXPECTED" ]; then
+    matches="$(printf '%s\n' "$ACTUAL" | grep -c '.' || true)"
+    echo "[test] PASS: $matches allowlisted runtime emission(s) match audit"
+    exit 0
+fi
+
+echo "[test] FAIL: runtime emission audit drift"
+echo "[test]   Allowlist: $ALLOWLIST"
+echo "[test]   Audit:     grep -rnE 'call [^\"]*@sailfin_runtime_' \\"
+echo "[test]                compiler/src/llvm/lowering/ \\"
+echo "[test]                compiler/src/llvm/expression_lowering/native/"
+echo "[test]"
+echo "[test]   Diff (expected vs actual):"
+diff <(printf '%s\n' "$EXPECTED") <(printf '%s\n' "$ACTUAL") \
+    | sed 's/^/[test]     /' || true
+echo "[test]"
+echo "[test]   To fix:"
+echo "[test]     - New emission?  Route it through the descriptor"
+echo "[test]       registry (emit_runtime_call / effective_symbol)"
+echo "[test]       or add the verbatim grep line to the allowlist"
+echo "[test]       with a '// Registry bypass: …' source comment."
+echo "[test]     - Moved line?    Re-justify the bypass and update"
+echo "[test]       the allowlist's pinned line number."
+echo "[test]     - Removed?       Delete the allowlist entry too."
+exit 1

--- a/compiler/tests/e2e/test_lowering_no_bare_runtime_emissions.sh
+++ b/compiler/tests/e2e/test_lowering_no_bare_runtime_emissions.sh
@@ -40,8 +40,15 @@
 
 set -euo pipefail
 
-# Argument is accepted for harness uniformity; not used.
-: "${1:-}"
+# Argument required for harness uniformity (every e2e shell test
+# takes the compiler binary as $1, even when unused — keeps
+# accidental mis-invocations like `bash …test.sh` from silently
+# passing).
+BINARY="${1:?usage: test_lowering_no_bare_runtime_emissions.sh <compiler-binary>}"
+if [ ! -e "$BINARY" ]; then
+    echo "[test] FAIL: compiler binary not found at $BINARY"
+    exit 1
+fi
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
@@ -66,28 +73,63 @@ ACTUAL="$(cd "$REPO_ROOT" && \
 
 EXPECTED="$(grep -vE '^[[:space:]]*(#|$)' "$ALLOWLIST" | sort)"
 
-if [ "$ACTUAL" = "$EXPECTED" ]; then
-    matches="$(printf '%s\n' "$ACTUAL" | grep -c '.' || true)"
-    echo "[test] PASS: $matches allowlisted runtime emission(s) match audit"
-    exit 0
+if [ "$ACTUAL" != "$EXPECTED" ]; then
+    echo "[test] FAIL: runtime emission audit drift"
+    echo "[test]   Allowlist: $ALLOWLIST"
+    echo "[test]   Audit:     grep -rnE 'call [^\"]*@sailfin_runtime_' \\"
+    echo "[test]                compiler/src/llvm/lowering/ \\"
+    echo "[test]                compiler/src/llvm/expression_lowering/native/"
+    echo "[test]"
+    echo "[test]   Diff (expected vs actual):"
+    diff <(printf '%s\n' "$EXPECTED") <(printf '%s\n' "$ACTUAL") \
+        | sed 's/^/[test]     /' || true
+    echo "[test]"
+    echo "[test]   To fix:"
+    echo "[test]     - New emission?  Route it through the descriptor"
+    echo "[test]       registry (emit_runtime_call / effective_symbol)"
+    echo "[test]       or add the verbatim grep line to the allowlist"
+    echo "[test]       with a '// Registry bypass: …' source comment."
+    echo "[test]     - Moved line?    Re-justify the bypass and update"
+    echo "[test]       the allowlist's pinned line number."
+    echo "[test]     - Removed?       Delete the allowlist entry too."
+    exit 1
 fi
 
-echo "[test] FAIL: runtime emission audit drift"
-echo "[test]   Allowlist: $ALLOWLIST"
-echo "[test]   Audit:     grep -rnE 'call [^\"]*@sailfin_runtime_' \\"
-echo "[test]                compiler/src/llvm/lowering/ \\"
-echo "[test]                compiler/src/llvm/expression_lowering/native/"
-echo "[test]"
-echo "[test]   Diff (expected vs actual):"
-diff <(printf '%s\n' "$EXPECTED") <(printf '%s\n' "$ACTUAL") \
-    | sed 's/^/[test]     /' || true
-echo "[test]"
-echo "[test]   To fix:"
-echo "[test]     - New emission?  Route it through the descriptor"
-echo "[test]       registry (emit_runtime_call / effective_symbol)"
-echo "[test]       or add the verbatim grep line to the allowlist"
-echo "[test]       with a '// Registry bypass: …' source comment."
-echo "[test]     - Moved line?    Re-justify the bypass and update"
-echo "[test]       the allowlist's pinned line number."
-echo "[test]     - Removed?       Delete the allowlist entry too."
-exit 1
+# Bypass-comment invariant: every allowlisted entry must carry a
+# `// Registry bypass:` justification within the 10 lines immediately
+# preceding the call site. The fixture file documents this invariant
+# (`Every allowlist entry must carry a one-line // Registry bypass: …
+# comment immediately above the call site`); enforcing it here keeps
+# the docs honest and the audit's signal/noise ratio high.
+missing_marker=""
+while IFS= read -r entry; do
+    [ -z "$entry" ] && continue
+    file="${entry%%:*}"
+    rest="${entry#*:}"
+    line_no="${rest%%:*}"
+    if [ -z "$file" ] || [ -z "$line_no" ]; then continue; fi
+    start=$(( line_no - 10 ))
+    if [ "$start" -lt 1 ]; then start=1; fi
+    end=$(( line_no - 1 ))
+    if [ "$end" -lt 1 ]; then end=1; fi
+    if ! sed -n "${start},${end}p" "$REPO_ROOT/$file" \
+            | grep -qE '//[[:space:]]*Registry bypass:'; then
+        missing_marker="${missing_marker}${file}:${line_no}\n"
+    fi
+done <<EOF
+$EXPECTED
+EOF
+
+if [ -n "$missing_marker" ]; then
+    echo "[test] FAIL: allowlist invariant violated — missing bypass comment"
+    echo "[test]   The fixture file requires each allowlisted call site to"
+    echo "[test]   carry a '// Registry bypass: …' comment within the 10"
+    echo "[test]   lines immediately above the call. These entries are"
+    echo "[test]   missing it:"
+    printf '%b' "$missing_marker" | sed 's/^/[test]     - /'
+    exit 1
+fi
+
+matches="$(printf '%s\n' "$ACTUAL" | grep -c '.' || true)"
+echo "[test] PASS: $matches allowlisted runtime emission(s) match audit"
+exit 0


### PR DESCRIPTION
## Summary

- Adds `compiler/tests/e2e/test_lowering_no_bare_runtime_emissions.sh` — a line-pinned audit against `compiler/tests/e2e/fixtures/runtime_emission_allowlist.txt` that locks every hardcoded `@sailfin_runtime_*` call-site emission under `compiler/src/llvm/lowering/` and `compiler/src/llvm/expression_lowering/native/`.
- Documents the two existing bypasses (`argv_to_string_array` + `panic_emit`, both in the `_start`/main wrapper) with one-line `// Registry bypass: …` source comments and a corresponding allowlist entry.
- Extends the rollout checklist in `compiler/src/llvm/runtime_helpers.sfn` with an explicit "grep the lowering directories before flipping `native_signature`" step that points at the new test.

Mechanises the lockstep guard that M2.4a / M2.6 / M2.8 only got away with via hand-greps — the M2.8 print.err post-mortem motivated #727.

Closes #727

## Acceptance Criteria

- [x] `grep -rE '"call .* @sailfin_runtime_' compiler/src/llvm/lowering/ compiler/src/llvm/expression_lowering/native/` returns either zero matches or a documented allowlist.
- [x] `compiler/tests/e2e/test_lowering_no_bare_runtime_emissions.sh` runs as part of `make test` and pins the allowlist size.
- [x] The rollout checklist in `runtime_helpers.sfn` includes the new audit step.
- [x] `make compile` passes.
- [x] `make test` passes.

## Verification

```bash
ulimit -v 8388608 && make compile && make test
# → e2e: 78/78 passed, capsules: 14/14 passed

bash compiler/tests/e2e/test_lowering_no_bare_runtime_emissions.sh build/native/sailfin
# → [test] PASS: 2 allowlisted runtime emission(s) match audit
```

## Files Changed

- `compiler/src/llvm/lowering/emission.sfn` — bypass justification comments at the two `_start`/main wrapper call sites
- `compiler/src/llvm/runtime_helpers.sfn` — rollout checklist amendment
- `compiler/tests/e2e/test_lowering_no_bare_runtime_emissions.sh` (new) — audit test
- `compiler/tests/e2e/fixtures/runtime_emission_allowlist.txt` (new) — pinned allowlist

## Notes

The issue's exact regex (`'"call .* @sailfin_runtime_'`) returns zero matches today — the M2.8 sites in `add_test_harness_lines` are already clean. The audit grep in the test is slightly broader (`'call [^"]*@sailfin_runtime_'`) to catch lines whose indentation pushes `"  call` past a literal `"call`, which is exactly the shape of both remaining bypasses in `emission.sfn`. Pure `// …` comment lines are excluded so the harmless backtick reference in `core_ops_lowering.sfn` doesn't need allowlisting.

---
_Generated by [Claude Code](https://claude.ai/code/session_01M1sG2u3UGpMrLjDpW93Jjm)_