### PR TITLE
docs(runtime): retire "C runtime" framing across status/spec/site

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ Sailfin is a systems language with compile-time capability enforcement. The repo
 
 Note: the codebase may still contain historical `stage2` names in internal paths; prefer “native compiler” terminology.
 
-The binary's entry point is the Sailfin-emitted `@main` (M5, #451) — no C code participates in startup. Supporting C runtime helpers (strings, arrays, exceptions, crypto) still live under `runtime/native/src/`; M3 will port them into Sailfin and delete the directory before 1.0.
+The binary's entry point is the Sailfin-emitted `@main` (M5, #451) — no C code participates in startup. Supporting C runtime helpers (strings, arrays, exceptions, the C arena, crypto) still live under `runtime/native/src/`; M3 will port them into Sailfin and delete the directory before 1.0.
 
 **Language pillars:** (1) effect types (`![io, net, model, clock]`) for compile-time capability enforcement, (2) capability-based security via capsule manifests and dependency auditing, (3) structured concurrency (planned). AI integration is a library-level concern (`sfn/ai` capsule, post-1.0) gated by the `![model]` effect — not language-level syntax.
 
@@ -89,7 +89,7 @@ Do not market or document ownership/borrowing as a shipped feature. Sailfin's sa
 
 ### Runtime Bridges
 
-Startup is Sailfin-native: the compiler emits `@main` directly (M5, #451). Supporting helpers under `runtime/native/src/` (strings, arrays, exceptions, crypto) remain in C until M3 ports them.
+Startup is Sailfin-native: the compiler emits `@main` directly (M5, #451). Supporting helpers under `runtime/native/src/` (strings, arrays, exceptions, the C arena, crypto) remain in C until M3 ports them.
 
 ### Testing Philosophy
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ Sailfin is a systems language with compile-time capability enforcement. The repo
 
 Note: the codebase may still contain historical `stage2` names in internal paths; prefer “native compiler” terminology.
 
-The runtime currently ships as C under `runtime/native/` and is planned to move into Sailfin for the 1.0 release.
+The binary's entry point is the Sailfin-emitted `@main` (M5, #451) — no C code participates in startup. Supporting C runtime helpers (strings, arrays, exceptions, crypto) still live under `runtime/native/src/`; M3 will port them into Sailfin and delete the directory before 1.0.
 
 **Language pillars:** (1) effect types (`![io, net, model, clock]`) for compile-time capability enforcement, (2) capability-based security via capsule manifests and dependency auditing, (3) structured concurrency (planned). AI integration is a library-level concern (`sfn/ai` capsule, post-1.0) gated by the `![model]` effect — not language-level syntax.
 
@@ -60,7 +60,7 @@ The compiler (`compiler/src/`) follows this flow:
 - `compiler/src/ast.sfn` — Canonical AST node definitions
 - `compiler/src/native_ir.sfn` — `.sfn-asm` intermediate representation
 - `runtime/prelude.sfn` — Sailfin-native runtime (collections, strings, type checks)
-- `runtime/native/` — Current C runtime implementation (planned to move into Sailfin pre-1.0)
+- `runtime/native/` — Supporting C runtime helpers (M3 will port the remainder into Sailfin; the entry point already lives in Sailfin)
 
 ### Effect System
 
@@ -89,7 +89,7 @@ Do not market or document ownership/borrowing as a shipped feature. Sailfin's sa
 
 ### Runtime Bridges
 
-The runtime currently ships as C under `runtime/native/`.
+Startup is Sailfin-native: the compiler emits `@main` directly (M5, #451). Supporting helpers under `runtime/native/src/` (strings, arrays, exceptions, crypto) remain in C until M3 ports them.
 
 ### Testing Philosophy
 
@@ -311,7 +311,7 @@ make test-e2e
 
 - `compiler/src/llvm/` — LLVM IR generation (lowering, rendering, runtime helpers)
 - `compiler/tests/` — Sailfin-native unit/integration/e2e suites
-- `runtime/native/` — C runtime linked into the native compiler
+- `runtime/native/` — Supporting C helpers linked into the native compiler (entry point already in Sailfin; M3 will retire the rest)
 
 ### Running Examples
 
@@ -396,8 +396,7 @@ rewrite can begin. This is the critical path to 1.0:
 
 **Phase 3 — Runtime migration (depends on Phase 1 + 2):**
 - Port ~90 runtime ABI functions from C to Sailfin (strings, arrays, I/O, exceptions, crypto)
-- Replace `native_driver.c` with a Sailfin entry point
-- Remove `runtime/native/` entirely
+- Remove `runtime/native/` entirely (the C entry point `native_driver.c` was already replaced by the Sailfin-emitted `@main` in M5, #451)
 
 **Phase 4 — Structured concurrency (depends on Phase 1-2 + atomics):**
 - Atomic intrinsics (`atomic_add`, `atomic_cas`, fences)

--- a/README.md
+++ b/README.md
@@ -171,10 +171,12 @@ and a pure Sailfin runtime. The critical path:
   annotations.
 - **Capability auditing (`sfn audit`)** — recursive capability analysis of
   a dependency tree before deployment.
-- **Sailfin-native runtime** — the current C runtime under `runtime/native/`
-  is being replaced module-by-module with Sailfin (`runtime/sfn/`). The
-  first module (`memory/arena.sfn`) is already linked into the compiler;
-  the full rewrite (~90 ABI functions) is a hard 1.0 prerequisite.
+- **Sailfin-native runtime** — the binary's entry point is now the
+  Sailfin-emitted `@main` (M5, #451); the remaining C helpers under
+  `runtime/native/src/` are being replaced module-by-module with
+  Sailfin (`runtime/sfn/`). `memory/arena.sfn`, `memory/rc.sfn`, and
+  `clock.sfn` are already linked into the compiler; the full rewrite
+  (~90 ABI functions) is a hard 1.0 prerequisite.
 
 After 1.0, focus shifts to ecosystem growth: an `sfn/ai` capsule for
 model invocation gated by `![model]`, taint types (`Secret<T>`, `PII<T>`)

--- a/docs/conventions/issue-naming.md
+++ b/docs/conventions/issue-naming.md
@@ -404,7 +404,7 @@ of their parent epic via the GitHub parent/child link.
 | `M2: Runtime in Sailfin` | `M2` | Replace C runtime with pure Sailfin (arena, string, array, io, exception, …) |
 | `M3: Structured Concurrency` | `M3` | `routine`/`await`/`channel`/`spawn` plus atomic intrinsics |
 | `Effect System Hardening` | `EFF` | Compile-gate enforcement, hierarchical effects, transitive call-graph checking — runs in parallel with runtime work |
-| `1.0 — General Availability` | `T7` | Pure Sailfin toolchain (M5 retired `native_driver.c`; M3 retires the rest), all enforcement gates active |
+| `1.0 — General Availability` | `T7` | Pure Sailfin toolchain (M5 retired `native_driver.c`; remaining C helpers retire pre-1.0), all enforcement gates active |
 
 ---
 

--- a/docs/conventions/issue-naming.md
+++ b/docs/conventions/issue-naming.md
@@ -404,7 +404,7 @@ of their parent epic via the GitHub parent/child link.
 | `M2: Runtime in Sailfin` | `M2` | Replace C runtime with pure Sailfin (arena, string, array, io, exception, …) |
 | `M3: Structured Concurrency` | `M3` | `routine`/`await`/`channel`/`spawn` plus atomic intrinsics |
 | `Effect System Hardening` | `EFF` | Compile-gate enforcement, hierarchical effects, transitive call-graph checking — runs in parallel with runtime work |
-| `1.0 — General Availability` | `T7` | Pure Sailfin toolchain, no C runtime, all enforcement gates active |
+| `1.0 — General Availability` | `T7` | Pure Sailfin toolchain (M5 retired `native_driver.c`; M3 retires the rest), all enforcement gates active |
 
 ---
 
@@ -462,7 +462,7 @@ Reserved track IDs (extend by editing the roadmap, then this list):
 | `M1`  | Phase 1 systems primitives (extern fn, integer types, raw pointers) |
 | `M1.5`| Drop emission |
 | `M2`  | Core runtime in Sailfin |
-| `M3`  | Capability adapters + delete C runtime |
+| `M3`  | Capability adapters (filesystem, HTTP, model) + port remaining C helpers to Sailfin |
 | `T1`  | Per-module memory budget under 800 MB |
 | `T2`  | Build performance — pipeline parallelism |
 | `T3`  | Build performance — IR caching |

--- a/docs/proposals/tooling.md
+++ b/docs/proposals/tooling.md
@@ -545,7 +545,7 @@ and developer workflow"):
 4. Tooling and developer workflow
    - [x] Remove Python runtime shims
    - [ ] Replace sfn shell wrapper with Sailfin-native CLI binary
-   - [ ] Replace C native_driver with Sailfin-native CLI entrypoint
+   - [x] Replace C native_driver with Sailfin-native CLI entrypoint (M5, #451, 2026-05-25)
    --- NEW (this proposal) ---
    - [ ] Enhance Diagnostic struct (severity, secondary spans, suggestions)
    - [ ] Implement `sfn fmt` (token-stream formatter, no config)

--- a/docs/runtime_architecture.md
+++ b/docs/runtime_architecture.md
@@ -2005,8 +2005,7 @@ run without the C runtime linked.
 **Unblocks:** Clean runtime — every runtime source file is Sailfin.
 
 **Fast-fail criteria:**
-1. `find runtime/ -name '*.c' -o -name '*.h'` returns only `native_driver.c`
-   (deleted at M5).
+1. `find runtime/ -name '*.c' -o -name '*.h'` returns empty (`native_driver.c` was deleted in M5; the M3 deliverables above remove the rest).
 2. `make check` passes.
 3. `sfn/fs`, `sfn/http`, `sfn/crypto`, `sfn/os` capsules pass their tests.
 
@@ -2031,22 +2030,27 @@ typed `Channel<T>`.
 3. `parallel` test runs 4 tasks concurrently and collects results.
 4. `serve` test handles 10 concurrent HTTP requests on a test port.
 
-### 4.9 M5 — Native CLI and Driver
+### 4.9 M5 — Native CLI and Driver ✅ Shipped 2026-05-25 (epic #451)
 
 **Compiler prereqs:** M2 (core runtime), M3 (adapters).
 
+**Status:** Shipped. The compiler emits the `@main(i32, i8**)` entry
+point directly; `native_driver.c` and its Windows MinGW cross-compile
+rules have been deleted. The remaining items below (delete
+`runtime_globals.ll`, drop the empty directory) are folded into M3.
+
 **Deliverables:**
-1. Sailfin-native CLI entrypoint replaces `native_driver.c`.
+1. Sailfin-native CLI entry point replaces `native_driver.c`. ✅
 2. Subcommand dispatch (`run`, `emit`, `test`, `build`, `init`, etc.) is
-   implemented in Sailfin.
-3. Delete `runtime/native/src/native_driver.c`.
-4. Delete `runtime/native/ir/runtime_globals.ll`.
-5. `runtime/native/` directory is empty or removed entirely.
+   implemented in Sailfin. ✅
+3. Delete `runtime/native/src/native_driver.c`. ✅
+4. Delete `runtime/native/ir/runtime_globals.ll`. (M3)
+5. `runtime/native/` directory is empty or removed entirely. (M3)
 
 **Fast-fail criteria:**
-1. `build/native/sailfin run examples/basics/hello-world.sfn` works without any
-   C runtime files.
-2. `make check` passes using a compiler built with zero C runtime.
+1. `build/native/sailfin run examples/basics/hello-world.sfn` works without
+   a C entry point. ✅
+2. `make check` passes with the Sailfin-emitted `@main`. ✅
 
 ---
 
@@ -2263,11 +2267,11 @@ The following are explicitly **not** in scope for the 1.0 runtime:
 - `capsules/sfn/sync/` (unstub)
 - `compiler/src/llvm/runtime_helpers.sfn` (add scheduler symbols)
 
-### M5 (Native CLI + Driver)
-- `runtime/native/src/native_driver.c` (delete)
-- `runtime/native/ir/runtime_globals.ll` (delete)
-- `compiler/src/cli_main.sfn` (becomes the true entrypoint)
-- `compiler/src/cli_main.sfn` C-driver compile step (remove — formerly the now-retired prior `scripts/build.sh`)
+### M5 (Native CLI + Driver) — Shipped 2026-05-25 (#451)
+- `runtime/native/src/native_driver.c` (deleted ✅)
+- `runtime/native/ir/runtime_globals.ll` (deferred to M3)
+- `compiler/src/cli_main.sfn` (now the true entrypoint via the Sailfin-emitted `@main`)
+- `compiler/src/cli_main.sfn` C-driver compile step (removed ✅)
 
 ---
 
@@ -2303,11 +2307,13 @@ sole exception is the M0.5 arena in C, which is explicitly disposable.
 | `runtime/native/src/sailfin_sha256.c` | SHA-256 helper | M3 (moved to `runtime/sfn/crypto.sfn`) |
 | `runtime/native/src/sailfin_base64.c` | Base64 helper | M3 (moved to `runtime/sfn/crypto.sfn`) |
 | `runtime/native/include/sailfin_runtime.h` | Current C runtime header | M3 |
-| `runtime/native/src/native_driver.c` | CLI entrypoint | M5 |
-| `runtime/native/ir/runtime_globals.ll` | LLVM stub | M5 |
+| `runtime/native/src/native_driver.c` | CLI entrypoint | **Deleted 2026-05-25 in M5 (#451)** |
+| `runtime/native/ir/runtime_globals.ll` | LLVM stub | M3 |
 
-At end-of-M5, `runtime/native/` is empty and removed. Every line of
-Sailfin toolchain source is `.sfn`.
+The Sailfin-emitted `@main` (M5) replaced `native_driver.c`. The
+remaining helpers above port to Sailfin during M3; at end-of-M3,
+`runtime/native/` is empty and removed and every line of Sailfin
+toolchain source is `.sfn`.
 
 ---
 

--- a/docs/runtime_audit.md
+++ b/docs/runtime_audit.md
@@ -8,6 +8,14 @@
 > **Status delta since 2026-04-15** (keep this list short; once an item is
 > fully shipped fold it into the body and remove the bullet here):
 >
+> - **M5 shipped — Sailfin-native entry point (2026-05-25, epic #451).**
+>   `runtime/native/src/native_driver.c` and its build-system references
+>   are gone. The compiler emits the `@main(i32, i8**)` entry directly,
+>   resolves the runtime root in Sailfin, and dispatches the CLI through
+>   `sailfin_cli_main__cli_main`. No C code participates in startup. The
+>   remaining C helpers under `runtime/native/src/` (strings, arrays,
+>   exceptions, crypto) remain pending M3.
+>
 > - **M2 closed — prelude facade audit shipped 2026-05-26 (M2.12b,
 >   issue #408).** Closes the M2 milestone. `runtime/prelude.sfn` no
 >   longer goes through the magic `runtime.X` namespace for the M2.10
@@ -286,8 +294,9 @@ requests in `compiler/src/llvm/runtime_helpers.sfn`.
 ## Executive Summary
 
 - The C runtime is **~6,000 lines** (`runtime/native/src/sailfin_runtime.c`)
-  plus a ~500-line C driver (`native_driver.c`) and small crypto helpers for
-  SHA-256 and base64.
+  plus small crypto helpers for SHA-256 and base64. The ~500-line C driver
+  `native_driver.c` was retired in M5 (#451, 2026-05-25) — the binary's
+  entry point is now the Sailfin-emitted `@main`.
 - Core surfaces (print, sleep, strings, arrays, process spawn, filesystem,
   exceptions, futures-via-pthreads) are **implemented and working**.
 - Effect-capability adapters (`sailfin_adapter_*`), reflection
@@ -312,9 +321,10 @@ requests in `compiler/src/llvm/runtime_helpers.sfn`.
 
 - Primary toolchain: the self-hosted native compiler. `make compile` produces
   `build/native/sailfin` (statically links the C runtime).
-- Runtime root: discovered by `native_driver.c:_resolve_runtime_root()` — walks
-  up from `argv[0]` looking for a sibling `runtime/` directory, or honors
-  `SAILFIN_RUNTIME_ROOT`.
+- Runtime root: discovered by the Sailfin-emitted entry-point prologue
+  (previously `native_driver.c:_resolve_runtime_root()`; retired in M5,
+  #451) — walks up from `argv[0]` looking for a sibling `runtime/`
+  directory, or honors `SAILFIN_RUNTIME_ROOT`.
 - Python runtime shims were removed from the repository pre-1.0.
 - Legacy Python compiler artifacts (`compiler/build/**`) remain only for
   emergency recovery and must be removed before 1.0.
@@ -528,9 +538,10 @@ Fixing the compiler to emit typed, ownership-aware IR retires them wholesale.
   `compiler/src/llvm/expression_lowering/native/core_strings.sfn`).
 - Exception lowering uses the `set_exception`/`has_exception`/`take_exception`
   trio, not the `try_enter`/`throw` setjmp path.
-- The C `native_driver` resolves the runtime root, detects CLI-subcommand
-  invocation vs legacy `sailfin file.sfn` usage, and calls into the Sailfin-
-  native CLI (`sailfin_cli_main__cli_main`) built from `compiler/src/`.
+- The Sailfin-emitted `@main` (M5, #451; previously `native_driver.c`)
+  resolves the runtime root, detects CLI-subcommand invocation vs legacy
+  `sailfin file.sfn` usage, and calls into the Sailfin-native CLI
+  (`sailfin_cli_main__cli_main`) built from `compiler/src/`.
 
 ## The Memory Management Crisis (Blocks Perf, Not Just Rewrite)
 
@@ -717,7 +728,7 @@ Entrypoints that are C-based today and must be gone by 1.0:
 
 - `runtime/native/src/sailfin_runtime.c` (~6,015 lines)
 - `runtime/native/include/sailfin_runtime.h`
-- `runtime/native/src/native_driver.c` (~504 lines)
+- `runtime/native/src/native_driver.c` — **REMOVED 2026-05-25 in M5 (#451)**. The binary's entry point is now the Sailfin-emitted `@main`.
 - `runtime/native/src/sailfin_sha256.c` + `.h`
 - `runtime/native/src/sailfin_base64.c` + `.h`
 - `runtime/native/ir/runtime_globals.ll` (small LLVM stub file)
@@ -738,7 +749,7 @@ Entrypoints that are C-based today and must be gone by 1.0:
       integration tests covering the concurrency roadmap items.
 - [ ] Reflection and type metadata (`is_*`, `resolve_type`, `instance_of`,
       `get_field`) are implemented against a real runtime type registry.
-- [ ] Sailfin-native CLI replaces `native_driver.c`.
+- [x] Sailfin-native CLI replaces `native_driver.c`. **Shipped 2026-05-25 in M5 (#451).** The compiler emits `@main` directly; `native_driver.c` is deleted.
 - [ ] Memory management is a first-class runtime primitive (arena, RC, or
       hybrid — decision documented in `runtime_abi.md`). `string_drop` and an
       equivalent `array_drop` (or their native-ABI equivalents) are enabled
@@ -782,8 +793,11 @@ Reordered from the previous audit to reflect the April 2026 reality.
 - **M4 — Scheduler and concurrency in Sailfin.** `spawn`, `channel`,
   `parallel`, `serve`. Integrates with the (by-then-shipped) `routine`/`await`
   language features.
-- **M5 — Native CLI and driver.** Replace `native_driver.c` with a Sailfin-
-  native entrypoint; remove `runtime/native/` entirely.
+- **M5 — Native CLI and driver.** **Shipped 2026-05-25 (#451).** Replaced
+  `native_driver.c` with a Sailfin-native `@main` entry point emitted
+  directly by the compiler. Removing `runtime/native/` entirely is folded
+  into M3 once the remaining C support helpers (`sailfin_runtime.c`,
+  crypto, includes) port to Sailfin.
 
 Decoupling M0 from M1-M5 is intentional: M0 is language-level work that has
 value even if the runtime rewrite slips. Everything downstream compounds on

--- a/docs/runtime_audit.md
+++ b/docs/runtime_audit.md
@@ -293,10 +293,11 @@ requests in `compiler/src/llvm/runtime_helpers.sfn`.
 
 ## Executive Summary
 
-- The C runtime is **~6,000 lines** (`runtime/native/src/sailfin_runtime.c`)
-  plus small crypto helpers for SHA-256 and base64. The ~500-line C driver
-  `native_driver.c` was retired in M5 (#451, 2026-05-25) — the binary's
-  entry point is now the Sailfin-emitted `@main`.
+- The C runtime is **~9,000 lines** (`runtime/native/src/sailfin_runtime.c`),
+  the M0.5 disposable C arena (`sailfin_arena.c`), and small crypto helpers
+  for SHA-256 and base64. The ~500-line C driver `native_driver.c` was
+  retired in M5 (#451, 2026-05-25) — the binary's entry point is now the
+  Sailfin-emitted `@main`.
 - Core surfaces (print, sleep, strings, arrays, process spawn, filesystem,
   exceptions, futures-via-pthreads) are **implemented and working**.
 - Effect-capability adapters (`sailfin_adapter_*`), reflection
@@ -726,7 +727,8 @@ prerequisites ship should confirm or reject it.
 
 Entrypoints that are C-based today and must be gone by 1.0:
 
-- `runtime/native/src/sailfin_runtime.c` (~6,015 lines)
+- `runtime/native/src/sailfin_runtime.c` (~9,000 lines)
+- `runtime/native/src/sailfin_arena.c` (M0.5 disposable C arena — deleted at M3 once the Sailfin `runtime/sfn/memory/arena.sfn` subsumes every caller)
 - `runtime/native/include/sailfin_runtime.h`
 - `runtime/native/src/native_driver.c` — **REMOVED 2026-05-25 in M5 (#451)**. The binary's entry point is now the Sailfin-emitted `@main`.
 - `runtime/native/src/sailfin_sha256.c` + `.h`

--- a/docs/status.md
+++ b/docs/status.md
@@ -719,9 +719,9 @@ The following capsules ship as part of the Sailfin standard library under
 - The binary's entry point is the Sailfin-emitted `@main` (M5, #451;
   shipped 2026-05-25); the compiler-emitted prologue resolves the runtime
   root and dispatches the CLI. Supporting helpers — strings, arrays,
-  exceptions, crypto, the `sfn_*` C trampolines listed under the M2.12
-  audit below — still live under `runtime/native/src/` as C and are
-  linked into the native compiler binary; M3 ports the rest.
+  exceptions, the C arena, crypto, the `sfn_*` C trampolines listed under
+  the M2.12 audit below — still live under `runtime/native/src/` as C and
+  are linked into the native compiler binary; M3 ports the rest.
 - The native CLI locates a bundled runtime next to the executable (override with
   `SAILFIN_RUNTIME_ROOT`).
 - Legacy Python runtime shims have been removed; the toolchain does not rely on

--- a/docs/status.md
+++ b/docs/status.md
@@ -716,8 +716,12 @@ The following capsules ship as part of the Sailfin standard library under
 
 ## Runtime (Current)
 
-- The runtime is implemented in C under `runtime/native/` and linked into the
-  native compiler binary.
+- The binary's entry point is the Sailfin-emitted `@main` (M5, #451;
+  shipped 2026-05-25); the compiler-emitted prologue resolves the runtime
+  root and dispatches the CLI. Supporting helpers — strings, arrays,
+  exceptions, crypto, the `sfn_*` C trampolines listed under the M2.12
+  audit below — still live under `runtime/native/src/` as C and are
+  linked into the native compiler binary; M3 ports the rest.
 - The native CLI locates a bundled runtime next to the executable (override with
   `SAILFIN_RUNTIME_ROOT`).
 - Legacy Python runtime shims have been removed; the toolchain does not rely on
@@ -733,10 +737,11 @@ The following capsules ship as part of the Sailfin standard library under
   Implemented in `compiler/src/llvm/expression_lowering/native/core_strings.sfn`
   and `core_ops_lowering.sfn`; runtime entry point in
   `runtime/native/src/sailfin_runtime.c`.
-- **The C runtime will be replaced by a pure Sailfin runtime before 1.0.** No C
-  shim — the entire runtime (~90 ABI functions across strings, arrays, I/O,
-  exceptions, crypto, time, and process execution) will be rewritten in Sailfin.
-  This is a hard prerequisite for the 1.0 release.
+- **The remaining C helpers will be replaced by Sailfin in M3 before 1.0.**
+  The entry-point cutover already shipped in M5 (#451). M3 ports the
+  ~90 ABI functions still in C (strings, arrays, I/O, exceptions, crypto,
+  time, and process execution) into `runtime/sfn/*.sfn`, then deletes
+  `runtime/native/`. This is a hard prerequisite for the 1.0 release.
 
 ### Runtime Migration Prerequisites
 

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -52,7 +52,8 @@ sailfin/
 │  └─ *.py                       # legacy bootstrap sources (emergency only)
 ├─ runtime/
 │  ├─ prelude.sfn                # Sailfin-visible runtime surface
-│  ├─ native/                    # C runtime implementation
+│  ├─ native/                    # Supporting C runtime helpers (entry point is Sailfin; M3 retires the rest)
+│  └─ sfn/                       # Sailfin-native runtime modules (clock, memory, process, type_meta, …)
 │  └─ (no Python shims)          # Python runtime shims removed pre-1.0
 ├─ docs/
 ├─ examples/

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -53,7 +53,7 @@ sailfin/
 ├─ runtime/
 │  ├─ prelude.sfn                # Sailfin-visible runtime surface
 │  ├─ native/                    # Supporting C runtime helpers (entry point is Sailfin; M3 retires the rest)
-│  └─ sfn/                       # Sailfin-native runtime modules (clock, memory, process, type_meta, …)
+│  ├─ sfn/                       # Sailfin-native runtime modules (clock, memory, process, type_meta, …)
 │  └─ (no Python shims)          # Python runtime shims removed pre-1.0
 ├─ docs/
 ├─ examples/

--- a/site/src/content/docs/docs/contributing/architecture.md
+++ b/site/src/content/docs/docs/contributing/architecture.md
@@ -37,10 +37,11 @@ Source (.sfn)
 
 ## Runtime
 
-The runtime currently ships as C under `runtime/native/` and is planned to migrate to Sailfin before 1.0.
+The binary's entry point is the Sailfin-emitted `@main` (M5, #451; shipped 2026-05-25) — no C code participates in startup. Supporting helpers under `runtime/native/src/` remain in C until M3 ports them into Sailfin.
 
 - `runtime/prelude.sfn` — Sailfin-native prelude (collections, strings, type checks)
-- `runtime/native/` — C runtime implementation
+- `runtime/sfn/` — Sailfin-native runtime modules (`clock.sfn`, `memory/arena.sfn`, `memory/rc.sfn`, `process.sfn`, `type_meta.sfn`, …)
+- `runtime/native/` — Supporting C helpers pending M3 (strings, arrays, exceptions, crypto)
 
 ## Self-Hosting
 

--- a/site/src/content/docs/docs/contributing/architecture.md
+++ b/site/src/content/docs/docs/contributing/architecture.md
@@ -41,7 +41,7 @@ The binary's entry point is the Sailfin-emitted `@main` (M5, #451; shipped 2026-
 
 - `runtime/prelude.sfn` — Sailfin-native prelude (collections, strings, type checks)
 - `runtime/sfn/` — Sailfin-native runtime modules (`clock.sfn`, `memory/arena.sfn`, `memory/rc.sfn`, `process.sfn`, `type_meta.sfn`, …)
-- `runtime/native/` — Supporting C helpers pending M3 (strings, arrays, exceptions, crypto)
+- `runtime/native/` — Supporting C helpers pending M3 (strings, arrays, exceptions, the C arena, crypto)
 
 ## Self-Hosting
 

--- a/site/src/content/docs/docs/contributing/style-guide.md
+++ b/site/src/content/docs/docs/contributing/style-guide.md
@@ -22,7 +22,8 @@ compiler/          # The self-hosted compiler
   tests/           # Unit, integration, and e2e tests
 runtime/           # Runtime libraries
   prelude.sfn      # Sailfin-native prelude
-  native/          # C runtime (pre-1.0)
+  sfn/             # Sailfin-native runtime modules (clock, memory, process, type_meta, …)
+  native/          # Supporting C helpers (entry point already in Sailfin; M3 retires the rest)
 docs/              # Language documentation
 examples/          # Example programs
 scripts/           # Build and release tooling

--- a/site/src/content/docs/docs/reference/cli.md
+++ b/site/src/content/docs/docs/reference/cli.md
@@ -421,7 +421,7 @@ These environment variables influence the behavior of `sfn` and the Makefile bui
 
 | Variable | Scope | Description |
 |---|---|---|
-| `SAILFIN_RUNTIME_ROOT` | `sfn` binary | Override the directory where `sfn` looks for the bundled C runtime. By default, the runtime is resolved relative to the executable. |
+| `SAILFIN_RUNTIME_ROOT` | `sfn` binary | Override the directory where `sfn` looks for the bundled runtime. By default, the runtime is resolved relative to the executable. |
 | `SFN_REGISTRY` | `sfn add` / `sfn publish` | Override the package registry base URL for this shell. Takes precedence over `~/.sfn/config.toml`. See [`sfn config`](#sfn-config-getsetunsetlist-key-value). |
 | `SFN_TOKEN` | `sfn publish` | Bearer token used when uploading a capsule. Takes precedence over `~/.sfn/credentials` written by `sfn login`. |
 | `PREFIX` | Makefile | Installation prefix. Defaults to `$HOME/.local`. The binary is installed to `$(PREFIX)/bin`. |

--- a/site/src/content/docs/docs/reference/runtime-abi.md
+++ b/site/src/content/docs/docs/reference/runtime-abi.md
@@ -112,9 +112,11 @@ define i32 @main(i32 %argc, i8** %argv) {
 }
 ```
 
-`nm build/native/sailfin | grep -E ' T main$'` shows exactly one
-`@main` definition, sourced from `compiler/src/llvm/lowering/`
-(see `runtime_audit.md` for the pipeline trace).
+In LLVM IR the entry symbol is spelled `@main`; after linking, tools
+like `nm` show it without the `@` sigil. `nm build/native/sailfin |
+grep -E ' T main$'` shows exactly one `T main` row, sourced from the
+Sailfin-emitted definition in `compiler/src/llvm/lowering/` (see
+`runtime_audit.md` for the pipeline trace).
 `SAILFIN_TRACE_ARGV` prints the argv vector observed by
 `sailfin_cli_main` for entry-point debugging.
 

--- a/site/src/content/docs/docs/reference/runtime-abi.md
+++ b/site/src/content/docs/docs/reference/runtime-abi.md
@@ -94,6 +94,37 @@ union for `any`/`dynamic` interop boundaries; its 16-byte payload
 inlines an `SfnString` or a 64-bit scalar, and out-of-line values
 store their pointer in the first 8 bytes.
 
+## Entry Point
+
+Since M5 ([#451](https://github.com/SailfinIO/sailfin/issues/451),
+shipped 2026-05-25) the binary's entry point is the
+Sailfin-emitted `@main` — no C driver participates in startup.
+The compiler emits exactly one definition matching the platform
+contract:
+
+```llvm
+define i32 @main(i32 %argc, i8** %argv) {
+  ; resolve runtime root (walks up from argv[0] looking for a
+  ; sibling `runtime/` directory, honouring SAILFIN_RUNTIME_ROOT)
+  ; marshal argv into SfnArray<SfnString>
+  ; call into the Sailfin CLI: sailfin_cli_main__cli_main
+  ; return i32 exit status
+}
+```
+
+`nm build/native/sailfin | grep -E ' T main$'` shows exactly one
+`@main` definition, sourced from `compiler/src/llvm/lowering/`
+(see `runtime_audit.md` for the pipeline trace).
+`SAILFIN_TRACE_ARGV` prints the argv vector observed by
+`sailfin_cli_main` for entry-point debugging.
+
+The previous C entry point (`runtime/native/src/native_driver.c`)
+and its Windows MinGW cross-compile rules were deleted as part of
+M5; the symbols its `extern` decls referenced
+(`compile_to_sailfin` / `compile_to_llvm`, `_resolve_runtime_root`,
+`SailfinPtrArray` construction helpers) are now reached entirely
+through Sailfin code paths.
+
 ## ABI Versioning
 
 Every emitted Sailfin LLVM module defines two global symbols with


### PR DESCRIPTION
## Summary

- `native_driver.c` was deleted in M5 (#451, 2026-05-25); the binary's entry point is now the Sailfin-emitted `@main`. The docs still framed the C entry point as "currently shipped" / "to be replaced" — accurate pre-M5 but now misleading.
- Present-tenses every doc location that talked about M5: `CLAUDE.md`, `README.md`, the runtime audit + architecture docs, status.md's Runtime (Current) summary, both style guides, the contributing/architecture page, the CLI reference, and the conventions table.
- Adds a new "Entry Point" section to `site/.../reference/runtime-abi.md` documenting the `@main(i32, i8**)` contract.

Closes #475

## Acceptance Criteria

- [x] `grep -rn "currently ships as C\|C runtime under runtime/native" CLAUDE.md README.md docs/runtime_audit.md docs/runtime_architecture.md docs/status.md docs/style-guide.md site/src/content/docs/docs/contributing/ site/src/content/docs/docs/reference/` returns empty.
- [x] `grep -rn "native_driver"` across the listed paths returns matches only in finished-tense / past-tense contexts (e.g. "retired in M5", "deleted 2026-05-25", "previously `native_driver.c`").
- [x] `docs/runtime_audit.md`'s Pre-1.0 Acceptance Checklist box for "Sailfin-native CLI replaces `native_driver.c`" is checked.
- [x] `docs/proposals/tooling.md:548`'s checkbox is flipped.
- [x] `cd site && npm run build` passes (61 pages built in 9.91s).
- [x] No code change in this issue — `make compile` was not required and was not run.

## Verification

```bash
cd site && npm run build && cd ..  # → 61 pages built, no errors
grep -rn "currently ships as C\|C runtime under runtime/native" \
  CLAUDE.md README.md docs/runtime_audit.md docs/runtime_architecture.md \
  docs/status.md docs/style-guide.md \
  site/src/content/docs/docs/contributing/ \
  site/src/content/docs/docs/reference/  # → empty
```

## Files Changed

- `CLAUDE.md` (4 paragraphs reworded: Project Overview, Critical Files, Runtime Bridges, Key Files, Phase 3 sequencing)
- `README.md` (the "Sailfin-native runtime" What's Coming bullet now leads with the shipped M5 entry point)
- `docs/runtime_audit.md` (Status delta entry, executive summary, toolchain snapshot, M5 milestone description, removal inventory, acceptance checklist)
- `docs/runtime_architecture.md` (§4.9 marked Shipped, deliverables ticked, file inventory + subsystem audit updated)
- `docs/status.md` (Runtime (Current) summary; M3-vs-M5 framing on the C-replacement bullet)
- `docs/style-guide.md` + `site/.../contributing/style-guide.md` (repo-layout block adds `runtime/sfn/` and downgrades `runtime/native/` to "supporting C helpers")
- `site/.../contributing/architecture.md` (Runtime section)
- `site/.../reference/cli.md` (`SAILFIN_RUNTIME_ROOT` description)
- `site/.../reference/runtime-abi.md` (new "Entry Point" section)
- `docs/conventions/issue-naming.md` (M3 and 1.0-GA milestone rows)
- `docs/proposals/tooling.md` (line 548 checkbox)

The `sfn/crypto` and `sfn/http` rows in `docs/status.md` still mention "via C runtime" — those are M3 work, not M5, and the issue body explicitly leaves them for M3 grooming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01X1Y8hhbp5vu45iv195EttQ)_