### PR TITLE
refactor(typecheck): drop dead `type_text_compatible` helper

### DIFF
--- a/compiler/src/typecheck.sfn
+++ b/compiler/src/typecheck.sfn
@@ -578,27 +578,3 @@ fn _trim_main_type_text(text: string) -> string {
     }
     return result;
 }
-
-// Type-text compatibility predicate. Returns true when a value whose
-// inferred type-text is `got` can flow into a binding whose annotated
-// type-text is `expected` without a typecheck error.
-//
-// Today the only non-trivial rule is the `__closure__` ⇔ fn-pointer
-// equivalence: lambdas (after #686 lifts them) carry the internal
-// `__closure__` sentinel as their type-text; any `fn(...) -> R`-typed
-// binding accepts that sentinel because the runtime closure ABI is
-// uniform. Arity / return-type checking against the lifted signature
-// is intentionally deferred to a post-M1.5 follow-up — wire #689
-// (call-site dispatch) will need the structured form anyway.
-//
-// Callers (today: none; #689 will be the first consumer) should fall
-// back to a plain text-equality check for any other pair; the
-// preemptive rule lives here so the sentinel doesn't bleed past the
-// type-text layer into diagnostics or downstream emission.
-fn type_text_compatible(expected: string, got: string) -> boolean {
-    if strings_equal(expected, got) { return true; }
-    if strings_equal(got, "__closure__") {
-        if starts_with(expected, "fn(") { return true; }
-    }
-    return false;
-}

--- a/compiler/src/typecheck.sfn
+++ b/compiler/src/typecheck.sfn
@@ -15,7 +15,6 @@ import {
     TypeAnnotation,
     TypeParameter
 } from "./ast";
-import { starts_with } from "./string_utils";
 import { Token, TokenKind } from "./token";
 import {
     Diagnostic,

--- a/compiler/tests/unit/parser_function_types_test.sfn
+++ b/compiler/tests/unit/parser_function_types_test.sfn
@@ -8,17 +8,8 @@
 // four spellings called out in the issue's acceptance criteria so a
 // later refactor (or any change to whitespace handling in
 // `tokens_to_text`) cannot silently drop the annotation.
-//
-// The companion compat rule in `compiler/src/typecheck.sfn`
-// (`type_text_compatible`) recognises `__closure__` (the sentinel
-// #686 will attach to lifted lambdas) as a subtype of any
-// `fn(...) -> R`-typed binding. The test below pins that predicate
-// directly — there is no caller yet (call-site dispatch is #689)
-// but the helper is the load-bearing piece that lets #689 enforce
-// assignment compat without re-litigating the closure ABI.
 import { Block, Program, Statement } from "../../src/ast";
 import { parse_program } from "../../src/parser/mod";
-import { type_text_compatible } from "../../src/typecheck";
 
 // -------------------------------------------------------------------
 // Helpers
@@ -124,40 +115,4 @@ test "fn-types: zero-arg fn() -> int annotation parses" {
     let decl = _first_variable_decl(body);
     assert decl.type_annotation != null;
     assert strings_equal(decl.type_annotation.text, "fn() -> int");
-}
-
-// -------------------------------------------------------------------
-// Compat-rule pin: `__closure__` ⇔ `fn(...) -> R`. The helper is
-// preemptive — no caller wires it through assignment-compat today
-// (#689 will be the first consumer) — but the predicate itself
-// must be correct so the sentinel can flow cleanly into any
-// fn-pointer binding once dispatch lands.
-// -------------------------------------------------------------------
-test "fn-types compat: __closure__ flows into fn(int) -> int" {
-    assert type_text_compatible("fn(int) -> int", "__closure__");
-}
-
-test "fn-types compat: __closure__ flows into fn() -> int (zero-arg)" {
-    assert type_text_compatible("fn() -> int", "__closure__");
-}
-
-test "fn-types compat: identical type texts are compatible" {
-    assert type_text_compatible("fn(int) -> int", "fn(int) -> int");
-    assert type_text_compatible("int", "int");
-}
-
-test "fn-types compat: __closure__ does NOT flow into a non-fn-type" {
-    // The sentinel is wildcard-like only for fn-pointer expected
-    // types. A binding annotated with, say, `int` must reject a
-    // closure-typed value — otherwise lambda values would silently
-    // flow into integer slots once an assignment-compat caller wires
-    // through.
-    assert ! type_text_compatible("int", "__closure__");
-    assert ! type_text_compatible("string", "__closure__");
-}
-
-test "fn-types compat: distinct concrete types are NOT compatible" {
-    // Negative anchor — the helper must not collapse to "always true."
-    assert ! type_text_compatible("int", "string");
-    assert ! type_text_compatible("fn(int) -> int", "fn(int) -> string");
 }


### PR DESCRIPTION
## Summary

- Delete `fn type_text_compatible` and its header comment from `compiler/src/typecheck.sfn` — the helper was added in #695 in anticipation of being load-bearing for #689, but #689 shipped a file-local structural walk in the lowering layer (`compiler/src/llvm/expression_lowering/native/core_call_resolution.sfn:94`) instead. Per #698, fn-pointer compat is not a type-text-layer concern.
- Drop the five compat-helper tests and the orphaned import/comment block from `compiler/tests/unit/parser_function_types_test.sfn`. Parser regression tests for fn-pointer annotations (acceptance criteria a–d from #688) remain intact.

Closes #790

## Acceptance Criteria

- [x] `compiler/src/typecheck.sfn` no longer defines `type_text_compatible` and no longer carries its header comment.
- [x] `grep -r "type_text_compatible" compiler/ runtime/` returns zero hits.
- [x] `sfn fmt --check compiler/src/ runtime/` is green.
- [x] `make compile` self-hosts.
- [x] `make test` passes (unit + integration + e2e).
- [x] `make check` passes (stage2 == stage3 fixed-point).

## Verification

```bash
ulimit -v 8388608 && make compile
# → built build/native/sailfin

ulimit -v 8388608 && make test
# → unit/integration/e2e all green, ═══ e2e: 77/77 ═══, ═══ capsules: 14/14 ═══

ulimit -v 8388608 && make check
# → [check] stage2 == stage3: compiler is a fixed point ✓

grep -r "type_text_compatible" compiler/ runtime/
# → (no output)

ulimit -v 8388608 && timeout 30 build/native/sailfin fmt --check compiler/src/ runtime/
# → clean
```

## Files Changed

- `compiler/src/typecheck.sfn` (-24 lines)
- `compiler/tests/unit/parser_function_types_test.sfn` (-45 lines)

Net: 69 lines deleted, 0 added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BCkhHEmFDy4FrjrYaRCV5k)_