### PR TITLE
test(ci): assert non-zero exit on missing-effect input

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,73 @@ jobs:
           (file build/native/sailfin || true)
           build/native/sailfin version || build/native/sailfin --version || true
 
+      # Regression guard for #615 / #807: assert the effect gate
+      # actually fails the build (non-zero exit + correct summary
+      # integers) on both Linux x86_64 and macOS arm64. The
+      # original report saw `error[E0400]` printed but the process
+      # exited 0 and the summary line printed garbage integers
+      # like "checked 22884130224 files: 22884131104 error",
+      # caused by a Bool/int ABI hazard since fixed by the i64
+      # C-ABI coercion family (#638/#641/#639) and the arm64 ABI
+      # fixes in 027735d9 / a476bf4b. The clean-file control
+      # ensures the gate is not just rejecting every input.
+      - name: Effect-gate exit-code smoke (#615 / #807)
+        shell: bash {0}
+        run: |
+          set -euo pipefail
+          BAD=compiler/tests/fixtures/cli/missing_effect.sfn
+          OK=compiler/tests/fixtures/cli/clean_effect.sfn
+          fail=0
+
+          # --- Missing-effect input must fail `sailfin check`. ---
+          if out="$(build/native/sailfin check "$BAD" 2>&1)"; then
+            echo "[effect-gate] FAIL: sailfin check on $BAD exited 0 (expected non-zero)."
+            echo "$out"
+            fail=$((fail + 1))
+          else
+            echo "[effect-gate] ok: sailfin check on $BAD exited non-zero."
+          fi
+          if ! echo "$out" | grep -q 'error\[E0400\]'; then
+            echo "[effect-gate] FAIL: missing E0400 diagnostic in output:"
+            echo "$out"
+            fail=$((fail + 1))
+          fi
+          if ! echo "$out" | grep -qE '^checked 1 files: 1 error$'; then
+            echo "[effect-gate] FAIL: summary line not 'checked 1 files: 1 error'."
+            echo "[effect-gate] (likely Bool/int ABI corruption — see #615 / #638 / #641)"
+            echo "$out" | grep -E '^checked ' || true
+            fail=$((fail + 1))
+          fi
+
+          # --- Missing-effect input must also fail `sailfin emit llvm`. ---
+          if build/native/sailfin emit llvm "$BAD" >/dev/null 2>&1; then
+            echo "[effect-gate] FAIL: sailfin emit llvm on $BAD exited 0 (expected non-zero)."
+            fail=$((fail + 1))
+          else
+            echo "[effect-gate] ok: sailfin emit llvm on $BAD exited non-zero."
+          fi
+
+          # --- Clean-file control must succeed. ---
+          if ! ok_out="$(build/native/sailfin check "$OK" 2>&1)"; then
+            echo "[effect-gate] FAIL: sailfin check on $OK exited non-zero (expected 0)."
+            echo "$ok_out"
+            fail=$((fail + 1))
+          else
+            echo "[effect-gate] ok: sailfin check on $OK exited 0."
+          fi
+          if ! echo "$ok_out" | grep -qE '^checked 1 files: ok$'; then
+            echo "[effect-gate] FAIL: clean-file summary not 'checked 1 files: ok'."
+            echo "$ok_out" | grep -E '^checked ' || true
+            fail=$((fail + 1))
+          fi
+
+          if [ "$fail" -gt 0 ]; then
+            echo ""
+            echo "[effect-gate] $fail assertion(s) failed. The effect gate is broken."
+            exit 1
+          fi
+          echo "[effect-gate] all assertions passed"
+
       - name: Check formatting (sfn fmt --check)
         shell: bash {0}
         run: |

--- a/compiler/tests/fixtures/cli/clean_effect.sfn
+++ b/compiler/tests/fixtures/cli/clean_effect.sfn
@@ -1,0 +1,11 @@
+// Control fixture for the CI effect-gate smoke step (#807).
+//
+// `main()` declares the `![io]` effect it requires, so the
+// compiler must accept it and exit zero with the summary
+// `checked 1 files: ok`. This is paired with
+// `missing_effect.sfn` to assert the effect gate distinguishes
+// between valid and invalid inputs (rather than failing every
+// time, which would mask a regression).
+fn main() ![io] {
+    print.info("clean effect declaration");
+}

--- a/compiler/tests/fixtures/cli/missing_effect.sfn
+++ b/compiler/tests/fixtures/cli/missing_effect.sfn
@@ -1,0 +1,15 @@
+// Fixture for the CI effect-gate exit-code smoke step (#807).
+//
+// `main()` calls `print.info(...)` without declaring the required
+// `![io]` effect. The compiler must reject this with diagnostic
+// `E0400` and exit with a non-zero status code. This locks in the
+// fix for the macOS arm64 Bool/int ABI corruption originally
+// reported in #615 (see #638/#641/#639 and commits 027735d9,
+// a476bf4b).
+//
+// Keep this file deliberately small — the CI step greps for an
+// exact summary line ("checked 1 files: 1 error"), so the input
+// must produce exactly one diagnostic.
+fn main() {
+    print.info("missing effect declaration");
+}


### PR DESCRIPTION
## Summary

- Add an "Effect-gate exit-code smoke" step to `ci.yml` that runs on both `ubuntu-24.04` and `macos-latest`/arm64 after the compiler is built.
- Step runs `sailfin check` / `sailfin emit llvm` on a fixture missing the `[io]` effect and asserts non-zero exit, an `error[E0400]` diagnostic, and the exact summary line `checked 1 files: 1 error` — the integer-corruption smoke from #615.
- A clean-file control asserts exit 0 / `checked 1 files: ok` so the gate can't silently fail every input.

Closes #807

## Acceptance Criteria

- [x] `ci.yml` has a step (running on both matrix entries) that fails the build if `sailfin check` on a missing-effect input exits `0`.
- [x] The step also asserts the summary integers are correct (greps for `checked 1 files: 1 error`, not a 10+ digit number).
- [x] The step asserts `sailfin emit llvm` on the same input exits non-zero.
- [x] A clean-file control asserts exit `0` / `checked 1 files: ok`.
- [x] The step passes on both the macOS arm64 and Linux x86_64 runners. *(verified against `sfn 0.7.0-alpha.8` locally on Linux x86_64; CI will exercise both matrix entries on this PR.)*

## Verification

Ran the exact shell logic the CI step uses against the pinned seed (`sfn 0.7.0-alpha.8`) locally:

```
[effect-gate] ok: sailfin check on …/missing_effect.sfn exited non-zero.
[effect-gate] ok: sailfin emit llvm on …/missing_effect.sfn exited non-zero.
[effect-gate] ok: sailfin check on …/clean_effect.sfn exited 0.
[effect-gate] all assertions passed
```

Raw `sailfin check` output on the bad fixture shows the headline-integrity check is meaningful — the summary reads `checked 1 files: 1 error`, exactly what the grep enforces.

## Files Changed

- `.github/workflows/ci.yml` — new "Effect-gate exit-code smoke (#615 / #807)" step after "Report compiler metadata".
- `compiler/tests/fixtures/cli/missing_effect.sfn` — calls `print.info` without declaring `[io]`.
- `compiler/tests/fixtures/cli/clean_effect.sfn` — control with `[io]` declared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_018YpAYR3oeCnbN4Q9XGZf3e)_