### PR TITLE
refactor(typecheck): add ExpressionStatement branch + expression walker skeleton

### DIFF
--- a/compiler/src/typecheck.sfn
+++ b/compiler/src/typecheck.sfn
@@ -347,15 +347,16 @@ fn check_statement(statement: Statement, bindings: SymbolEntry[], interfaces: St
         };
     }
     if statement.variant == "ForStatement" {
+        let target_diags = walk_expression(statement.clause.target, bindings);
         let iter_diags = walk_expression(statement.clause.iterable, bindings);
         let body_diags = check_block(statement.body, bindings, interfaces);
         return ScopeResult {
             bindings: bindings,
-            diagnostics: iter_diags.concat(body_diags)
+            diagnostics: target_diags.concat(iter_diags).concat(body_diags)
         };
     }
     if statement.variant == "MatchStatement" {
-        let mut diagnostics: Diagnostic[] = [];
+        let mut diagnostics = walk_expression(statement.expression, bindings);
         let mut index: int = 0;
         loop {
             if index >= statement.cases.length { break; }
@@ -730,12 +731,13 @@ fn walk_statement_expressions(statement: Statement, bindings: SymbolEntry[]) -> 
         return diagnostics;
     }
     if statement.variant == "ForStatement" {
-        let mut diagnostics = walk_expression(statement.clause.iterable, bindings);
+        let mut diagnostics = walk_expression(statement.clause.target, bindings);
+        diagnostics = diagnostics.concat(walk_expression(statement.clause.iterable, bindings));
         diagnostics = diagnostics.concat(walk_block_expressions(statement.body, bindings));
         return diagnostics;
     }
     if statement.variant == "MatchStatement" {
-        let mut diagnostics: Diagnostic[] = [];
+        let mut diagnostics = walk_expression(statement.expression, bindings);
         let mut index: int = 0;
         loop {
             if index >= statement.cases.length { break; }
@@ -748,7 +750,15 @@ fn walk_statement_expressions(statement: Statement, bindings: SymbolEntry[]) -> 
         return diagnostics;
     }
     if statement.variant == "WithStatement" {
-        return walk_block_expressions(statement.body, bindings);
+        let mut diagnostics: Diagnostic[] = [];
+        let mut clause_index: int = 0;
+        loop {
+            if clause_index >= statement.clauses.length { break; }
+            diagnostics = diagnostics.concat(walk_expression(statement.clauses[clause_index].expression, bindings));
+            clause_index += 1;
+        }
+        diagnostics = diagnostics.concat(walk_block_expressions(statement.body, bindings));
+        return diagnostics;
     }
     if statement.variant == "LoopStatement" {
         return walk_block_expressions(statement.body, bindings);

--- a/compiler/src/typecheck.sfn
+++ b/compiler/src/typecheck.sfn
@@ -6,6 +6,7 @@
 import {
     Block,
     EnumVariant,
+    Expression,
     FieldDeclaration,
     FunctionSignature,
     MethodDeclaration,
@@ -181,7 +182,12 @@ fn check_program_scopes(program: Program, interfaces: Statement[]) -> Diagnostic
 // level and recursive same-frame callers pass it through unchanged.
 fn check_statement(statement: Statement, bindings: SymbolEntry[], interfaces: Statement[], scope_start: int) -> ScopeResult {
     if statement.variant == "VariableDeclaration" {
-        return register_local_symbol(bindings, statement.name, "variable", statement.span, scope_start);
+        let registration = register_local_symbol(bindings, statement.name, "variable", statement.span, scope_start);
+        let walk_diags = walk_expression(statement.initializer, bindings);
+        return ScopeResult {
+            bindings: registration.bindings,
+            diagnostics: registration.diagnostics.concat(walk_diags)
+        };
     }
     if statement.variant == "FunctionDeclaration" {
         let registration = register_local_symbol(bindings, statement.signature.name, "function", statement.signature.name_span, scope_start);
@@ -342,9 +348,11 @@ fn check_statement(statement: Statement, bindings: SymbolEntry[], interfaces: St
         };
     }
     if statement.variant == "ForStatement" {
+        let iter_diags = walk_expression(statement.clause.iterable, bindings);
+        let body_diags = check_block(statement.body, bindings, interfaces);
         return ScopeResult {
             bindings: bindings,
-            diagnostics: check_block(statement.body, bindings, interfaces)
+            diagnostics: iter_diags.concat(body_diags)
         };
     }
     if statement.variant == "MatchStatement" {
@@ -353,6 +361,8 @@ fn check_statement(statement: Statement, bindings: SymbolEntry[], interfaces: St
         loop {
             if index >= statement.cases.length { break; }
             let case = statement.cases[index];
+            diagnostics = diagnostics.concat(walk_expression(case.pattern, bindings));
+            diagnostics = diagnostics.concat(walk_expression(case.guard, bindings));
             let _blk_diags = check_block(case.body, bindings, interfaces);
             let mut _ci: int = 0;
             loop {
@@ -365,7 +375,8 @@ fn check_statement(statement: Statement, bindings: SymbolEntry[], interfaces: St
         return ScopeResult { bindings: bindings, diagnostics: diagnostics };
     }
     if statement.variant == "IfStatement" {
-        let mut diagnostics = check_block(statement.then_block, bindings, interfaces);
+        let mut diagnostics = walk_expression(statement.condition, bindings);
+        diagnostics = diagnostics.concat(check_block(statement.then_block, bindings, interfaces));
         if statement.else_branch != null {
             let branch = statement.else_branch;
             if branch.body != null {
@@ -408,6 +419,18 @@ fn check_statement(statement: Statement, bindings: SymbolEntry[], interfaces: St
         return ScopeResult {
             bindings: registration.bindings,
             diagnostics: diagnostics
+        };
+    }
+    if statement.variant == "ExpressionStatement" {
+        return ScopeResult {
+            bindings: bindings,
+            diagnostics: walk_expression(statement.expression, bindings)
+        };
+    }
+    if statement.variant == "ReturnStatement" {
+        return ScopeResult {
+            bindings: bindings,
+            diagnostics: walk_expression(statement.expression, bindings)
         };
     }
     if statement.variant == "Unknown" {
@@ -601,4 +624,172 @@ fn type_text_compatible(expected: string, got: string) -> boolean {
         if starts_with(expected, "fn(") { return true; }
     }
     return false;
+}
+
+// Expression walker — issue #809 (#616 sub-issue 1).
+//
+// The typechecker historically only visited statements; expression
+// positions (call arguments, return values, let-initializers, match
+// patterns, …) were invisible to it. This walker mirrors the structure
+// of `collect_effects_from_expression` in `effect_checker.sfn` so the
+// resolution pass in issue D can hook diagnostics onto the same
+// traversal points without touching the recursion shape.
+//
+// The walker is intentionally non-emitting in this issue: every variant
+// returns `[]`. Wiring it into `check_statement` here ensures the
+// pre-enforcement traversal is exercised by `make check`, so issue D
+// only adds the diagnostic logic and not the plumbing.
+fn walk_expression(expression: Expression?, bindings: SymbolEntry[]) -> Diagnostic[] {
+    if expression == null { return []; }
+    if expression.variant == "Call" {
+        let mut diagnostics = walk_expression(expression.callee, bindings);
+        let mut index: int = 0;
+        loop {
+            if index >= expression.arguments.length { break; }
+            diagnostics = diagnostics.concat(walk_expression(expression.arguments[index], bindings));
+            index += 1;
+        }
+        return diagnostics;
+    }
+    if expression.variant == "Binary" {
+        let mut diagnostics = walk_expression(expression.left, bindings);
+        diagnostics = diagnostics.concat(walk_expression(expression.right, bindings));
+        return diagnostics;
+    }
+    if expression.variant == "Unary" {
+        return walk_expression(expression.operand, bindings);
+    }
+    if expression.variant == "Member" {
+        return walk_expression(expression.object, bindings);
+    }
+    if expression.variant == "Index" {
+        let mut diagnostics = walk_expression(expression.sequence, bindings);
+        diagnostics = diagnostics.concat(walk_expression(expression.index, bindings));
+        return diagnostics;
+    }
+    if expression.variant == "Array" {
+        let mut diagnostics: Diagnostic[] = [];
+        let mut index: int = 0;
+        loop {
+            if index >= expression.elements.length { break; }
+            diagnostics = diagnostics.concat(walk_expression(expression.elements[index], bindings));
+            index += 1;
+        }
+        return diagnostics;
+    }
+    if expression.variant == "Object" {
+        let mut diagnostics: Diagnostic[] = [];
+        let mut index: int = 0;
+        loop {
+            if index >= expression.fields.length { break; }
+            diagnostics = diagnostics.concat(walk_expression(expression.fields[index].value, bindings));
+            index += 1;
+        }
+        return diagnostics;
+    }
+    if expression.variant == "Struct" {
+        let mut diagnostics: Diagnostic[] = [];
+        let mut index: int = 0;
+        loop {
+            if index >= expression.fields.length { break; }
+            diagnostics = diagnostics.concat(walk_expression(expression.fields[index].value, bindings));
+            index += 1;
+        }
+        return diagnostics;
+    }
+    if expression.variant == "Lambda" {
+        return walk_block_expressions(expression.body, bindings);
+    }
+    if expression.variant == "Range" {
+        let mut diagnostics = walk_expression(expression.start, bindings);
+        diagnostics = diagnostics.concat(walk_expression(expression.end, bindings));
+        return diagnostics;
+    }
+    if expression.variant == "Cast" {
+        return walk_expression(expression.operand, bindings);
+    }
+    return [];
+}
+
+// Walks expressions inside a block — used by `walk_expression`'s Lambda
+// branch so expression positions inside lambda bodies are visited too.
+// Top-level statement traversal still flows through `check_block` →
+// `check_statement`; this helper is only the expression-positions
+// recursion for lambda bodies (which `check_block` never descends into).
+fn walk_block_expressions(block: Block, bindings: SymbolEntry[]) -> Diagnostic[] {
+    let mut diagnostics: Diagnostic[] = [];
+    let mut index: int = 0;
+    loop {
+        if index >= block.statements.length { break; }
+        diagnostics = diagnostics.concat(walk_statement_expressions(block.statements[index], bindings));
+        index += 1;
+    }
+    return diagnostics;
+}
+
+fn walk_statement_expressions(statement: Statement, bindings: SymbolEntry[]) -> Diagnostic[] {
+    if statement.variant == "ExpressionStatement" {
+        return walk_expression(statement.expression, bindings);
+    }
+    if statement.variant == "ReturnStatement" {
+        return walk_expression(statement.expression, bindings);
+    }
+    if statement.variant == "ThrowStatement" {
+        return walk_expression(statement.expression, bindings);
+    }
+    if statement.variant == "VariableDeclaration" {
+        return walk_expression(statement.initializer, bindings);
+    }
+    if statement.variant == "IfStatement" {
+        let mut diagnostics = walk_expression(statement.condition, bindings);
+        diagnostics = diagnostics.concat(walk_block_expressions(statement.then_block, bindings));
+        if statement.else_branch != null {
+            let branch = statement.else_branch;
+            if branch.body != null {
+                diagnostics = diagnostics.concat(walk_block_expressions(branch.body, bindings));
+            }
+            if branch.statement != null {
+                diagnostics = diagnostics.concat(walk_statement_expressions(branch.statement, bindings));
+            }
+        }
+        return diagnostics;
+    }
+    if statement.variant == "ForStatement" {
+        let mut diagnostics = walk_expression(statement.clause.iterable, bindings);
+        diagnostics = diagnostics.concat(walk_block_expressions(statement.body, bindings));
+        return diagnostics;
+    }
+    if statement.variant == "MatchStatement" {
+        let mut diagnostics: Diagnostic[] = [];
+        let mut index: int = 0;
+        loop {
+            if index >= statement.cases.length { break; }
+            let case = statement.cases[index];
+            diagnostics = diagnostics.concat(walk_expression(case.pattern, bindings));
+            diagnostics = diagnostics.concat(walk_expression(case.guard, bindings));
+            diagnostics = diagnostics.concat(walk_block_expressions(case.body, bindings));
+            index += 1;
+        }
+        return diagnostics;
+    }
+    if statement.variant == "WithStatement" {
+        return walk_block_expressions(statement.body, bindings);
+    }
+    if statement.variant == "LoopStatement" {
+        return walk_block_expressions(statement.body, bindings);
+    }
+    if statement.variant == "BlockStatement" {
+        return walk_block_expressions(statement.body, bindings);
+    }
+    if statement.variant == "TryStatement" {
+        let mut diagnostics = walk_block_expressions(statement.try_block, bindings);
+        if statement.catch_block != null {
+            diagnostics = diagnostics.concat(walk_block_expressions(statement.catch_block, bindings));
+        }
+        if statement.finally_block != null {
+            diagnostics = diagnostics.concat(walk_block_expressions(statement.finally_block, bindings));
+        }
+        return diagnostics;
+    }
+    return [];
 }

--- a/compiler/tests/unit/typecheck_expression_walk_test.sfn
+++ b/compiler/tests/unit/typecheck_expression_walk_test.sfn
@@ -7,7 +7,7 @@
 //
 //   * Walking is reached for expression-statement, return-value, and
 //     let-initializer positions (the walker no longer falls through to
-//     the silent no-op return at typecheck.sfn:430).
+//     the silent no-op return at the end of `check_statement`).
 //   * `typecheck_diagnostics` still reports zero unknown-identifier
 //     diagnostics for calls to names that don't resolve in scope, so
 //     the seed compiler's compile output is unchanged.
@@ -55,6 +55,24 @@ test "typecheck walker: nested call in argument emits no diagnostics" {
 test "typecheck walker: call inside if condition emits no diagnostics" {
     // Exercises the IfStatement branch addition that walks `condition`.
     let source = "fn main() { if notarealfunction() { } }";
+    let program = parse_program(source);
+    let diagnostics = typecheck_diagnostics(program);
+    assert _count_all(diagnostics) == 0;
+}
+
+test "typecheck walker: call inside match scrutinee emits no diagnostics" {
+    // Pins coverage of `MatchStatement.expression` (the scrutinee) —
+    // the position effect_checker.collect_effects_from_statement walks
+    // but the original #809 PR forgot. Restated here so Issue D doesn't
+    // need to re-add the branch.
+    let source = "fn main() { match notarealfunction() { _ => {} } }";
+    let program = parse_program(source);
+    let diagnostics = typecheck_diagnostics(program);
+    assert _count_all(diagnostics) == 0;
+}
+
+test "typecheck walker: call inside for-iterable emits no diagnostics" {
+    let source = "fn main() { for x in notarealfunction() { } }";
     let program = parse_program(source);
     let diagnostics = typecheck_diagnostics(program);
     assert _count_all(diagnostics) == 0;

--- a/compiler/tests/unit/typecheck_expression_walk_test.sfn
+++ b/compiler/tests/unit/typecheck_expression_walk_test.sfn
@@ -1,0 +1,71 @@
+// Unit tests for the typecheck expression walker (issue #809).
+//
+// Issue #809 adds an `ExpressionStatement` branch to `check_statement`
+// and a `walk_expression` recursive visitor. The walker is intentionally
+// non-emitting in this issue — issue D (#616 sub-issue 4) will flip on
+// resolution diagnostics. These tests pin the pre-enforcement state:
+//
+//   * Walking is reached for expression-statement, return-value, and
+//     let-initializer positions (the walker no longer falls through to
+//     the silent no-op return at typecheck.sfn:430).
+//   * `typecheck_diagnostics` still reports zero unknown-identifier
+//     diagnostics for calls to names that don't resolve in scope, so
+//     the seed compiler's compile output is unchanged.
+//
+// When issue D lands these assertions are updated to expect the
+// resolution diagnostic (E0xxx, code TBD by issue D).
+import { parse_program } from "../../src/parser/mod";
+import { typecheck_diagnostics } from "../../src/typecheck";
+import { Diagnostic } from "../../src/typecheck_types";
+
+fn _count_all(diagnostics: Diagnostic[]) -> int { return diagnostics.length; }
+
+test "typecheck walker: bare call expression statement emits no diagnostics" {
+    // `notarealfunction` is unbound; the walker reaches it but issue D
+    // hasn't enabled resolution yet, so this must still typecheck clean.
+    let source = "fn main() { notarealfunction(\"hi\"); }";
+    let program = parse_program(source);
+    let diagnostics = typecheck_diagnostics(program);
+    assert _count_all(diagnostics) == 0;
+}
+
+test "typecheck walker: call inside return value emits no diagnostics" {
+    let source = "fn main() -> number { return notarealfunction(); }";  // alias-coverage: legacy `-> number` retained until §3 reform lands
+    let program = parse_program(source);
+    let diagnostics = typecheck_diagnostics(program);
+    assert _count_all(diagnostics) == 0;
+}
+
+test "typecheck walker: call in let initializer emits no diagnostics" {
+    let source = "fn main() { let x = notarealfunction(\"hi\"); }";
+    let program = parse_program(source);
+    let diagnostics = typecheck_diagnostics(program);
+    assert _count_all(diagnostics) == 0;
+}
+
+test "typecheck walker: nested call in argument emits no diagnostics" {
+    // Exercises walker recursion into `Call.arguments` — the walker
+    // visits both the outer call and the inner call, but neither emits.
+    let source = "fn main() { outer(inner(\"hi\")); }";
+    let program = parse_program(source);
+    let diagnostics = typecheck_diagnostics(program);
+    assert _count_all(diagnostics) == 0;
+}
+
+test "typecheck walker: call inside if condition emits no diagnostics" {
+    // Exercises the IfStatement branch addition that walks `condition`.
+    let source = "fn main() { if notarealfunction() { } }";
+    let program = parse_program(source);
+    let diagnostics = typecheck_diagnostics(program);
+    assert _count_all(diagnostics) == 0;
+}
+
+test "typecheck walker: call inside lambda body emits no diagnostics" {
+    // Exercises the Lambda branch which descends into `body` via
+    // `walk_block_expressions`. The lambda body's ExpressionStatement
+    // must be reached by the walker.
+    let source = "fn main() { let f = () => { notarealfunction(); }; }";
+    let program = parse_program(source);
+    let diagnostics = typecheck_diagnostics(program);
+    assert _count_all(diagnostics) == 0;
+}


### PR DESCRIPTION
## Summary
- Add `ExpressionStatement` and `ReturnStatement` branches to `check_statement`, and route `VariableDeclaration` initializers, `IfStatement` conditions, `ForStatement` iterables, and `MatchStatement` patterns/guards through a new `walk_expression` recursive visitor.
- The walker mirrors the structure of `collect_effects_from_expression` (effect_checker.sfn) — `Call`, `Binary`, `Unary`, `Member`, `Index`, `Array`, `Object`, `Struct`, `Lambda`, `Range`, `Cast` — and descends into lambda bodies via `walk_block_expressions` (which `check_block` never visits).
- Every variant returns `[]` for now. This is sub-issue 1 of #616; issue D flips on resolution diagnostics and tightens the new test assertions.

Closes #809.

## Acceptance Criteria
- [x] `walk_expression` exists and is reached for `Call` exprs in expression statements, return values, and let-initializers.
- [x] New unit test `typecheck_expression_walk_test.sfn` asserts `typecheck_diagnostics` is still empty for `fn main() { notarealfunction("hi"); }` (documents pre-enforcement state; updated in Issue D).
- [x] All 50 examples and `make check`-equivalent test suites still pass (behavior unchanged — walker emits nothing).
- [x] `make compile` passes.
- [x] `make test` passes.
- [x] `sfn fmt --check` clean on every touched `.sfn` file.

## Verification
```
ulimit -v 8388608 && make compile           # built build/native/sailfin
ulimit -v 8388608 && make test-unit         # ═══ unit: 103/103 passed, 0 failed ═══
ulimit -v 8388608 && make test-integration  # ═══ integration: 27/27 passed, 0 failed ═══
ulimit -v 8388608 && make test              # e2e 78/78, capsules 14/14, all sub-summaries 0 failed
build/native/sailfin fmt --check compiler/src/typecheck.sfn \
    compiler/tests/unit/typecheck_expression_walk_test.sfn  # exit 0
```

## Files Changed
- `compiler/src/typecheck.sfn` — `Expression` import; `ExpressionStatement`/`ReturnStatement` branches; condition/iterable/pattern walking inside existing `If`/`For`/`Match`/`VariableDeclaration` branches; new `walk_expression`, `walk_block_expressions`, `walk_statement_expressions` helpers.
- `compiler/tests/unit/typecheck_expression_walk_test.sfn` — new; pins the pre-enforcement state for 6 walker positions (bare call, return value, let-initializer, nested call arg, if-condition, lambda body).

## Notes for follow-ups
- The walker handles `Throw`, `Loop`, `Block`, `With`, and `Try` statements in `walk_statement_expressions` as well — these aren't required by the issue but were free to add and keep lambda-body recursion correct under any valid statement shape.
- `MatchStatement` pattern walking includes `case.guard` because guards are full expressions and adding it here costs nothing while saving an Issue D follow-up edit.


---
_Generated by [Claude Code](https://claude.ai/code/session_012YchZyKdoULpyKwbrEPp5Y)_