### PR TITLE
feat(compiler,runtime): add `thread_local` for top-level `let mut`

### DIFF
--- a/compiler/src/ast.sfn
+++ b/compiler/src/ast.sfn
@@ -209,6 +209,7 @@ enum Statement {
     VariableDeclaration {
         name: string;
         mutable: boolean;
+        is_thread_local: boolean;
         type_annotation: TypeAnnotation?;
         initializer: Expression?;
         span: SourceSpan?;

--- a/compiler/src/emit_native.sfn
+++ b/compiler/src/emit_native.sfn
@@ -403,6 +403,7 @@ fn emit_variable(state: NativeState, statement: Statement) -> NativeState {
     current = emit_initializer_span_if_present(current, statement.initializer_span);
 
     let mut line: string = ".let ";
+    if statement.is_thread_local { line = line + "thread_local "; }
     if statement.mutable { line = line + "mut "; }
     line = line + statement.name;
     line = append_optional_type_annotation(line, statement.type_annotation);

--- a/compiler/src/llvm/expression_lowering/native/lambda_lowering.sfn
+++ b/compiler/src/llvm/expression_lowering/native/lambda_lowering.sfn
@@ -835,6 +835,7 @@ fn _rewrite_variable(ctx: LiftContext, statement: Statement) -> StatementRewrite
         statement: Statement.VariableDeclaration {
             name: statement.name,
             mutable: statement.mutable,
+            is_thread_local: statement.is_thread_local,
             type_annotation: new_annotation,
             initializer: result.expression,
             span: statement.span,

--- a/compiler/src/llvm/lowering/instructions.sfn
+++ b/compiler/src/llvm/lowering/instructions.sfn
@@ -272,6 +272,7 @@ fn lower_instruction_range(function: NativeFunction, start_index: int, end: int,
                                 let inline_instruction = NativeInstruction.Let {
                                     name: inline_parse.name,
                                     mutable: inline_parse.mutable,
+                                    is_thread_local: false,
                                     type_annotation: inline_parse.type_annotation,
                                     value: inline_parse.initializer,
                                     span: null,

--- a/compiler/src/llvm/lowering/lowering_native_helpers.sfn
+++ b/compiler/src/llvm/lowering/lowering_native_helpers.sfn
@@ -241,6 +241,7 @@ fn get_instruction_tag(instructions: NativeInstruction[], idx: int) -> int {
         NativeInstruction.Let {
             name,
             mutable,
+            is_thread_local,
             type_annotation,
             value,
             span,

--- a/compiler/src/llvm/lowering/module_globals.sfn
+++ b/compiler/src/llvm/lowering/module_globals.sfn
@@ -96,6 +96,14 @@ fn _process_one_binding(binding: NativeBinding, context: TypeContext, scope_id: 
     let mut preamble_lines: string[] = [];
     let mut needs_init: boolean = false;
 
+    // `thread_local let mut` → `internal thread_local global` (#730).
+    // The TLS model defaults to `initial-exec` on LLVM, which is the
+    // ELF-TLS shape Linux x86_64 and macOS arm64 both link cleanly.
+    let mut global_qualifier: string = "internal global";
+    if binding.is_thread_local {
+        global_qualifier = "internal thread_local global";
+    }
+
     if llvm_type == "i8*" {
         let mut string_handled: boolean = false;
         if binding.value != null {
@@ -109,8 +117,8 @@ fn _process_one_binding(binding: NativeBinding, context: TypeContext, scope_id: 
                     + " x i8] c\""
                     + str_content
                     + "\\00\"";
-                let line2 = global_name
-                    + " = internal global i8* getelementptr (["
+                let line2 = global_name + " = " + global_qualifier
+                    + " i8* getelementptr (["
                     + number_to_string(str_len)
                     + " x i8], ["
                     + number_to_string(str_len)
@@ -123,7 +131,8 @@ fn _process_one_binding(binding: NativeBinding, context: TypeContext, scope_id: 
             }
         }
         if !string_handled {
-            preamble_lines.push(global_name + " = internal global i8* null");
+            preamble_lines.push(global_name + " = " + global_qualifier
+                + " i8* null");
             if binding.value != null { needs_init = true; }
         }
     } else {
@@ -160,7 +169,8 @@ fn _process_one_binding(binding: NativeBinding, context: TypeContext, scope_id: 
             }
             if !is_const { needs_init = true; }
         }
-        preamble_lines.push(global_name + " = internal global " + llvm_type
+        preamble_lines.push(global_name + " = " + global_qualifier + " "
+            + llvm_type
             + " "
             + initializer_text);
     }

--- a/compiler/src/native_ir.sfn
+++ b/compiler/src/native_ir.sfn
@@ -15,6 +15,7 @@ enum NativeInstruction {
     Let {
         name: string;
         mutable: boolean;
+        is_thread_local: boolean;
         type_annotation: string;
         value: string?;
         span: NativeSourceSpan?;
@@ -170,6 +171,7 @@ struct NativeEnum {
 struct NativeBinding {
     name: string;
     mutable: boolean;
+    is_thread_local: boolean;
     type_annotation: string;
     value: string?;
 }

--- a/compiler/src/native_ir_parser.sfn
+++ b/compiler/src/native_ir_parser.sfn
@@ -439,6 +439,7 @@ fn binding_from_instruction(instruction: NativeInstruction) -> NativeBinding {
     return NativeBinding {
         name: instruction.name,
         mutable: instruction.mutable,
+        is_thread_local: instruction.is_thread_local,
         type_annotation: instruction.type_annotation,
         value: instruction.value
     };

--- a/compiler/src/native_ir_parser_instructions.sfn
+++ b/compiler/src/native_ir_parser_instructions.sfn
@@ -410,7 +410,7 @@ fn parse_instruction(line: string, span: NativeSourceSpan?, value_span: NativeSo
         let parsed = parse_binding_components(body);
         return InstructionParseResult {
             instructions: [NativeInstruction.Let {
-                name: parsed.name, mutable: is_mutable, type_annotation: parsed.type_annotation, value: maybe_trim_trailing(parsed.value), span: span, value_span: value_span
+                name: parsed.name, mutable: is_mutable, is_thread_local: false, type_annotation: parsed.type_annotation, value: maybe_trim_trailing(parsed.value), span: span, value_span: value_span
             }],
             span_consumed: true,
             value_span_consumed: true

--- a/compiler/src/native_ir_utils_parse.sfn
+++ b/compiler/src/native_ir_utils_parse.sfn
@@ -695,8 +695,16 @@ fn parse_struct_field_line(text: string) -> NativeStructField? {
 
 fn parse_let_instruction(line: string, span: NativeSourceSpan?, value_span: NativeSourceSpan?) -> NativeInstruction {
     let body = trim_text(strip_prefix(line, ".let "));
+    let mut is_thread_local: boolean = false;
     let mut is_mutable: boolean = false;
     let mut remainder: string = body;
+    // `.let thread_local mut name -> type = init` — the storage-class prefix
+    // (when present) precedes `mut`, mirroring the source-level keyword
+    // ordering accepted by `parse_variable_with_storage`.
+    if starts_with(remainder, "thread_local ") {
+        is_thread_local = true;
+        remainder = trim_text(strip_prefix(remainder, "thread_local "));
+    }
     if starts_with(remainder, "mut ") {
         is_mutable = true;
         remainder = trim_text(strip_prefix(remainder, "mut "));
@@ -705,6 +713,7 @@ fn parse_let_instruction(line: string, span: NativeSourceSpan?, value_span: Nati
     return NativeInstruction.Let {
         name: parsed.name,
         mutable: is_mutable,
+        is_thread_local: is_thread_local,
         type_annotation: parsed.type_annotation,
         value: parsed.value,
         span: span,

--- a/compiler/src/parser/declarations.sfn
+++ b/compiler/src/parser/declarations.sfn
@@ -703,6 +703,14 @@ fn build_export_specifiers(values: NamedSpecifier[]) -> ExportSpecifier[] {
 // Variable Declaration
 // ============================================================================
 fn parse_variable(initial_parser: Parser) -> StatementParseResult {
+    return parse_variable_with_storage(initial_parser, false);
+}
+
+// Top-level `thread_local let mut` declarations dispatch through this entry
+// point. The `thread_local` keyword is consumed by the caller; `is_thread_local`
+// flips the AST flag so module-global lowering can emit
+// `internal thread_local global` instead of `internal global`.
+fn parse_variable_with_storage(initial_parser: Parser, is_thread_local: boolean) -> StatementParseResult {
     let mut parser: Parser = initial_parser;
     parser = skip_trivia(parser);
     let mut statement_tokens: Token[] = [];
@@ -779,6 +787,7 @@ fn parse_variable(initial_parser: Parser) -> StatementParseResult {
     let statement = Statement.VariableDeclaration {
         name: name,
         mutable: mutable_flag,
+        is_thread_local: is_thread_local,
         type_annotation: type_annotation,
         initializer: initializer,
         span: span,

--- a/compiler/src/parser/mod.sfn
+++ b/compiler/src/parser/mod.sfn
@@ -25,7 +25,8 @@ import {
     parse_test,
     parse_type_alias,
     parse_unknown,
-    parse_variable
+    parse_variable,
+    parse_variable_with_storage
 } from "./declarations";
 import {
     identifier_matches,
@@ -111,6 +112,20 @@ fn parse_statement(initial_parser: Parser) -> StatementParseResult {
     if identifier_matches(token, "let") {
         if decorators.length > 0 { return parse_unknown(original); }
         return parse_variable(parser);
+    }
+    // `thread_local let mut <name>: <type> = <init>;` — top-level storage
+    // class for module globals. Function-local `thread_local` is unsupported
+    // (allocas can't be TLS at the LLVM level), so only the top-level
+    // dispatcher recognizes this prefix; inside a block the keyword falls
+    // through to `parse_unknown` and surfaces as a normal parse error.
+    if identifier_matches(token, "thread_local") {
+        if decorators.length > 0 { return parse_unknown(original); }
+        let after_keyword = skip_trivia(parser_advance_raw(parser));
+        let next = parser_peek_raw(after_keyword);
+        if identifier_matches(next, "let") {
+            return parse_variable_with_storage(after_keyword, true);
+        }
+        return parse_unknown(original);
     }
     if identifier_matches(token, "test") {
         if decorators.length > 0 { return parse_unknown(original); }
@@ -408,6 +423,7 @@ export {
 
     // Variable declaration
     parse_variable,
+    parse_variable_with_storage,
 
     // Function declaration
     parse_function,

--- a/compiler/src/typecheck.sfn
+++ b/compiler/src/typecheck.sfn
@@ -36,6 +36,7 @@ import {
     make_main_signature_param_count_diagnostic,
     make_main_signature_param_type_diagnostic,
     make_removed_keyword_diagnostic,
+    make_thread_local_requires_mut_diagnostic,
     make_unsupported_statement_keyword_diagnostic,
     register_local_symbol,
     register_symbol
@@ -151,7 +152,18 @@ fn register_top_level_symbol(statement: Statement, existing: SymbolEntry[]) -> S
         return register_symbol(statement.name, "type", statement.name_span, existing);
     }
     if statement.variant == "VariableDeclaration" {
-        return register_symbol(statement.name, "variable", statement.span, existing);
+        let registration = register_symbol(statement.name, "variable", statement.span, existing);
+        if statement.is_thread_local {
+            if !statement.mutable {
+                let mut diagnostics = registration.diagnostics;
+                diagnostics.push(make_thread_local_requires_mut_diagnostic(statement.name));
+                return SymbolCollectionResult {
+                    symbols: registration.symbols,
+                    diagnostics: diagnostics
+                };
+            }
+        }
+        return registration;
     }
     return SymbolCollectionResult { symbols: existing, diagnostics: [] };
 }

--- a/compiler/src/typecheck_types.sfn
+++ b/compiler/src/typecheck_types.sfn
@@ -1149,6 +1149,27 @@ fn detect_unsupported_statement_keyword(text: string) -> string {
     return "while";
 }
 
+// `thread_local` is the storage-class annotation that flips a top-level
+// `let mut` from `internal global` to `internal thread_local global` at
+// LLVM lowering (#730). Immutable thread-local globals are useless — the
+// whole point of TLS is per-thread mutation — so a `thread_local let x`
+// (without `mut`) is rejected with E0807.
+fn make_thread_local_requires_mut_diagnostic(name: string) -> Diagnostic {
+    return Diagnostic {
+        code: "E0807",
+        severity: "error",
+        message: "`thread_local let " + name
+            + "` is missing `mut`; thread-local globals are per-thread"
+            + " mutable storage, so an immutable thread-local is a"
+            + " contradiction. Write `thread_local let mut "
+            + name
+            + ": <type> = <init>;` or drop the `thread_local` prefix.",
+        file_path: "",
+        primary: null,
+        suggestion: null
+    };
+}
+
 fn make_unsupported_statement_keyword_diagnostic(keyword: string) -> Diagnostic {
     let mut message: string = "`" + keyword
         + "` is reserved but not implemented;";

--- a/compiler/tests/e2e/fixtures/thread_local_basic.sfn
+++ b/compiler/tests/e2e/fixtures/thread_local_basic.sfn
@@ -1,0 +1,42 @@
+// Fixture for compiler/tests/e2e/test_thread_local_lowering.sh.
+//
+// Pins the storage-class round-trip for `thread_local let mut`
+// (#730). The fixture exercises three shapes that exercise the
+// distinct lowering branches in
+// `compiler/src/llvm/lowering/module_globals.sfn`:
+//
+//   - `head: i64` → `internal thread_local global i64 0`
+//     (non-string, integer initializer branch)
+//   - `flag: boolean = true` → `internal thread_local global i1 1`
+//     (boolean branch)
+//   - `temperature: float = 0.0` → `internal thread_local global
+//     double 0.0` (double branch)
+//
+// The surrounding `bump` / `take` functions also pin that
+// load/store sites against a thread-local global use the same
+// `@global.<name>` symbol as ordinary globals — `thread_local`
+// only changes the declaration line, not the use sites. The
+// scheduler (M4 #321) relies on this invariant so emit-side
+// reads/writes against TLS globals don't need any per-thread
+// indirection in the compiler.
+thread_local let mut head: i64 = 0;
+
+thread_local let mut flag: boolean = true;
+
+thread_local let mut temperature: float = 0.0;
+
+fn bump() -> i64 {
+    head = head + 1;
+    return head;
+}
+
+fn take_flag() -> boolean {
+    let captured = flag;
+    flag = false;
+    return captured;
+}
+
+fn record_temperature(value: float) -> float {
+    temperature = value;
+    return temperature;
+}

--- a/compiler/tests/e2e/fixtures/thread_local_basic.sfn
+++ b/compiler/tests/e2e/fixtures/thread_local_basic.sfn
@@ -40,3 +40,21 @@ fn record_temperature(value: float) -> float {
     temperature = value;
     return temperature;
 }
+
+// Helpers driven from the pthread C harness. Each pthread runs
+// `bump_n(N)` to increment the thread-local `head` N times; with
+// TLS isolation the return value equals N exactly, regardless of
+// what the sibling thread is doing. Without TLS the sibling
+// thread's increments leak in and the return value exceeds N on
+// at least one thread.
+fn bump_n(count: i64) -> i64 {
+    let mut i: i64 = 0;
+    loop {
+        if i >= count { break; }
+        head = head + 1;
+        i = i + 1;
+    }
+    return head;
+}
+
+fn read_head() -> i64 { return head; }

--- a/compiler/tests/e2e/test_runtime_exception_frames.sh
+++ b/compiler/tests/e2e/test_runtime_exception_frames.sh
@@ -24,13 +24,13 @@
 #                    runtime's `sailfin_runtime_throw` abort-on-empty
 #                    semantics).
 #   7. global pin — `@global.sfn_exception_frame_head_addr = internal
-#                   thread_local global i64 0` pins the per-thread
-#                   chain-head storage shape (#730). The `thread_local`
-#                   keyword in `runtime/sfn/exception.sfn` is the one-line
-#                   audit-able diff that flipped this from `internal
-#                   global`; this assertion catches a regression that
-#                   drops the TLS prefix, relocates the storage, or
-#                   drops the zero initializer.
+#                   global i64 0` pins the chain-head storage shape.
+#                   The TLS upgrade (compiler-side parser in #825;
+#                   runtime-side flip queued as a follow-up gated on the
+#                   next seed pin) replaces `internal global` with
+#                   `internal thread_local global` without touching
+#                   callers; this assertion catches a regression that
+#                   relocates the storage or drops the zero initializer.
 #   8. coexistence — the Sailfin-emitted symbols use canonical
 #                    architect names (`sfn_try_enter`, `sfn_throw`,
 #                    `sfn_take_exception`, …) which deliberately do NOT
@@ -345,14 +345,13 @@ test_frame_head_global() {
         echo "[test]   $ll missing — test_emit_define_shape must run first"
         return 1
     fi
-    # #730 flipped `internal global` to `internal thread_local global`
-    # via the `thread_local` storage-class annotation on the source
-    # `let mut` in `runtime/sfn/exception.sfn`. Pin the TLS shape so
-    # a regression that drops the prefix surfaces here instead of
-    # corrupting frames across spawn boundaries once the scheduler
-    # ships (M4 #321).
-    if ! grep -qE "^@global\.sfn_exception_frame_head_addr = internal thread_local global i64 0$" "$ll"; then
-        echo "[test]   missing '@global.sfn_exception_frame_head_addr = internal thread_local global i64 0':"
+    # The TLS upgrade (compiler-side parser in #825; runtime-side flip
+    # queued as a follow-up gated on the next seed pin) replaces
+    # `internal global` with `internal thread_local global` without
+    # touching callers. Pin the current shape so the follow-up is the
+    # advertised one-line audit-able diff.
+    if ! grep -qE "^@global\.sfn_exception_frame_head_addr = internal global i64 0$" "$ll"; then
+        echo "[test]   missing '@global.sfn_exception_frame_head_addr = internal global i64 0':"
         grep -E "^@global\." "$ll" || true
         return 1
     fi

--- a/compiler/tests/e2e/test_runtime_exception_frames.sh
+++ b/compiler/tests/e2e/test_runtime_exception_frames.sh
@@ -24,11 +24,13 @@
 #                    runtime's `sailfin_runtime_throw` abort-on-empty
 #                    semantics).
 #   7. global pin — `@global.sfn_exception_frame_head_addr = internal
-#                   global i64 0` pins the chain-head storage shape.
-#                   M2.7c's TLS upgrade flips `internal global` to
-#                   `internal thread_local global` without touching
-#                   callers; this assertion catches a regression that
-#                   relocates the storage or drops the zero initializer.
+#                   thread_local global i64 0` pins the per-thread
+#                   chain-head storage shape (#730). The `thread_local`
+#                   keyword in `runtime/sfn/exception.sfn` is the one-line
+#                   audit-able diff that flipped this from `internal
+#                   global`; this assertion catches a regression that
+#                   drops the TLS prefix, relocates the storage, or
+#                   drops the zero initializer.
 #   8. coexistence — the Sailfin-emitted symbols use canonical
 #                    architect names (`sfn_try_enter`, `sfn_throw`,
 #                    `sfn_take_exception`, …) which deliberately do NOT
@@ -343,11 +345,14 @@ test_frame_head_global() {
         echo "[test]   $ll missing — test_emit_define_shape must run first"
         return 1
     fi
-    # M2.7c flips `internal global` to `internal thread_local global`
-    # once Sailfin grows a thread_local annotation; pin the current
-    # shape so the upgrade is a one-line audit-able diff.
-    if ! grep -qE "^@global\.sfn_exception_frame_head_addr = internal global i64 0$" "$ll"; then
-        echo "[test]   missing '@global.sfn_exception_frame_head_addr = internal global i64 0':"
+    # #730 flipped `internal global` to `internal thread_local global`
+    # via the `thread_local` storage-class annotation on the source
+    # `let mut` in `runtime/sfn/exception.sfn`. Pin the TLS shape so
+    # a regression that drops the prefix surfaces here instead of
+    # corrupting frames across spawn boundaries once the scheduler
+    # ships (M4 #321).
+    if ! grep -qE "^@global\.sfn_exception_frame_head_addr = internal thread_local global i64 0$" "$ll"; then
+        echo "[test]   missing '@global.sfn_exception_frame_head_addr = internal thread_local global i64 0':"
         grep -E "^@global\." "$ll" || true
         return 1
     fi

--- a/compiler/tests/e2e/test_thread_local_lowering.sh
+++ b/compiler/tests/e2e/test_thread_local_lowering.sh
@@ -146,14 +146,22 @@ EOF
 }
 
 test_pthread_isolation_roundtrip() {
-    # End-to-end thread-isolation check against the actual driver
-    # for #730 — `runtime/sfn/exception.sfn`'s frame-head chain
-    # pointer. Two pthreads each push a frame; each verifies that
-    # `sfn_exception_frame_head()` returns *its own* frame rather
-    # than the sibling thread's. Before #730 (when the chain head
-    # was `internal global`), this would corrupt the cross-thread
-    # view; after #730 the TLS lowering keeps each thread's chain
-    # head isolated.
+    # End-to-end thread-isolation check for `thread_local let mut`
+    # (#825 / issue #730 criterion #4). Two pthreads each increment
+    # the fixture's `head` (a `thread_local let mut: i64`) N times
+    # via `bump_n(N)`; with TLS each thread sees exactly N as the
+    # final value, regardless of what the sibling is doing. Without
+    # TLS, sibling increments leak in and the return value exceeds
+    # N on at least one thread.
+    #
+    # We drive the fixture (not `runtime/sfn/exception.sfn`) because
+    # the runtime module's `let mut sfn_exception_frame_head_addr`
+    # cannot flip to `thread_local` in this PR — the pinned seed
+    # 0.7.0-alpha.8 compiles every entry in
+    # `runtime/native/capsule.toml`'s `sfn-sources` and predates the
+    # keyword. The runtime flip lands in a follow-up PR after the
+    # next seed pin (the audit-able one-liner the issue's #3
+    # criterion calls for).
     #
     # Skipped when `clang` or pthread linkage is unavailable —
     # mirrors the cross-frame roundtrip skip in
@@ -166,32 +174,35 @@ test_pthread_isolation_roundtrip() {
         return 0
     fi
 
-    local repo_root
-    repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
-    local module="$repo_root/runtime/sfn/exception.sfn"
-    local ll="$SCRATCH/exception.ll"
-    if ! "$BINARY" emit -o "$ll" llvm "$module" > /dev/null 2>&1; then
-        echo "[test]   sfn emit llvm failed for runtime/sfn/exception.sfn"
+    local ll="$SCRATCH/thread_local_basic.ll"
+    if [ ! -f "$ll" ]; then
+        echo "[test]   $ll missing — test_lowering_emits_thread_local_qualifier must run first"
+        return 1
+    fi
+
+    # Sailfin mangles top-level function symbols by appending the
+    # source-path components. Look up the actual mangled names so
+    # the test survives a rename of the fixture without a manual
+    # bump (the global `@global.head` is not mangled and is reached
+    # only from Sailfin code in the fixture).
+    local bump_sym
+    bump_sym="$(grep -oE 'define i64 @bump_n[A-Za-z0-9_]*' "$ll" | head -1 | awk '{print $3}' | sed 's/^@//')"
+    local read_sym
+    read_sym="$(grep -oE 'define i64 @read_head[A-Za-z0-9_]*' "$ll" | head -1 | awk '{print $3}' | sed 's/^@//')"
+    if [ -z "$bump_sym" ] || [ -z "$read_sym" ]; then
+        echo "[test]   could not resolve bump_n/read_head mangled symbols in $ll"
+        grep -E "^define i64" "$ll" || true
         return 1
     fi
 
     local harness="$SCRATCH/pthread_harness.c"
-    cat > "$harness" <<'CHARNESS'
-/* Thread-isolation harness for the `thread_local` storage class
- * (#730). Spawns two pthreads, each of which allocates and pushes
- * its own SfnExceptionFrame. The thread_local chain head must
- * resolve to the per-thread frame at each read site; if the head
- * is process-global (pre-#730) the two threads race and at least
- * one read returns the sibling's pointer.
- *
- * Synchronization. We don't use a barrier — the threads simply
- * push their frame, spin briefly (`sched_yield` + a small loop
- * that re-reads the head 1024 times), and then verify. The spin
- * gives the OS scheduler a window to interleave the writes; on a
- * pre-#730 binary at least one of those 1024 reads returns the
- * sibling thread's pointer, surfacing the bug deterministically
- * enough to fail CI. On a #730-correct binary every read returns
- * the local frame.
+    cat > "$harness" <<CHARNESS
+/* Thread-isolation harness for \`thread_local let mut\` (#825 /
+ * issue #730 criterion #4). Each pthread calls \`bump_n(N)\` on a
+ * Sailfin fixture whose \`head\` is a \`thread_local let mut: i64\`.
+ * Under TLS each thread's \`head\` starts at 0 and ends at N. Under
+ * a process-global \`let mut\` the threads' increments interleave
+ * and at least one thread's final read exceeds N.
  */
 #include <stdio.h>
 #include <stdint.h>
@@ -199,79 +210,60 @@ test_pthread_isolation_roundtrip() {
 #include <pthread.h>
 #include <sched.h>
 
-struct SfnExceptionFrame {
-    int64_t prev_addr;
-    int64_t jmp_buf_addr;
-    int64_t message_addr;
-};
-
-extern struct SfnExceptionFrame *sfn_exception_alloc_frame(void);
-extern void sfn_exception_free_frame(struct SfnExceptionFrame *frame);
-extern struct SfnExceptionFrame *sfn_exception_frame_head(void);
-extern void sfn_exception_push_frame(struct SfnExceptionFrame *frame);
-extern void sfn_exception_pop_frame(struct SfnExceptionFrame *frame);
+extern int64_t ${bump_sym}(int64_t count);
+extern int64_t ${read_sym}(void);
 
 void sailfin_runtime_mark_persistent(void *ptr) { (void)ptr; }
 
 struct WorkerArgs {
     int id;
-    int leak_count;  /* number of head() reads that didn't match the local frame */
+    int64_t bump_count;
+    int64_t observed_head;
 };
 
 static void *worker(void *raw) {
     struct WorkerArgs *args = (struct WorkerArgs *)raw;
-    args->leak_count = 0;
-
-    struct SfnExceptionFrame *frame = sfn_exception_alloc_frame();
-    if (!frame) {
-        args->leak_count = -1;
-        return NULL;
-    }
-
-    /* Each worker pushes; under TLS the head is its own frame.
-     * Under process-global storage the second writer overwrites
-     * the first and at least one of the 1024 reads below sees
-     * the sibling's pointer. */
-    sfn_exception_push_frame(frame);
-
-    for (int i = 0; i < 1024; ++i) {
-        if (i % 64 == 0) sched_yield();
-        struct SfnExceptionFrame *head = sfn_exception_frame_head();
-        if (head != frame) {
-            args->leak_count += 1;
-        }
-    }
-
-    sfn_exception_pop_frame(frame);
-    sfn_exception_free_frame(frame);
+    /* Yield once before and once mid-flight to give the scheduler
+     * a window to interleave the sibling thread's increments. */
+    sched_yield();
+    int64_t mid = ${bump_sym}(args->bump_count / 2);
+    sched_yield();
+    int64_t final_head = ${bump_sym}(args->bump_count - args->bump_count / 2);
+    (void)mid;
+    args->observed_head = final_head;
+    /* One more read after the increments to catch any post-write
+     * interleaving — under TLS this still equals bump_count. */
+    sched_yield();
+    args->observed_head = ${read_sym}();
     return NULL;
 }
 
 int main(void) {
     pthread_t t1, t2;
-    struct WorkerArgs a1 = { .id = 1, .leak_count = 0 };
-    struct WorkerArgs a2 = { .id = 2, .leak_count = 0 };
+    struct WorkerArgs a1 = { .id = 1, .bump_count = 1000, .observed_head = -1 };
+    struct WorkerArgs a2 = { .id = 2, .bump_count = 1000, .observed_head = -1 };
 
     if (pthread_create(&t1, NULL, worker, &a1) != 0) {
-        fprintf(stderr, "pthread_create #1 failed\n");
+        fprintf(stderr, "pthread_create #1 failed\\n");
         return 1;
     }
     if (pthread_create(&t2, NULL, worker, &a2) != 0) {
-        fprintf(stderr, "pthread_create #2 failed\n");
+        fprintf(stderr, "pthread_create #2 failed\\n");
         return 2;
     }
     pthread_join(t1, NULL);
     pthread_join(t2, NULL);
 
-    if (a1.leak_count < 0 || a2.leak_count < 0) {
-        fprintf(stderr, "alloc_frame returned NULL in a worker\n");
+    if (a1.observed_head != a1.bump_count) {
+        fprintf(stderr,
+                "TLS bleed: worker 1 expected head=%lld, got %lld\\n",
+                (long long)a1.bump_count, (long long)a1.observed_head);
         return 3;
     }
-    if (a1.leak_count != 0 || a2.leak_count != 0) {
+    if (a2.observed_head != a2.bump_count) {
         fprintf(stderr,
-                "TLS bleed: worker 1 saw %d non-local heads, worker 2 saw %d.\n"
-                "The frame-head chain pointer is not thread-local.\n",
-                a1.leak_count, a2.leak_count);
+                "TLS bleed: worker 2 expected head=%lld, got %lld\\n",
+                (long long)a2.bump_count, (long long)a2.observed_head);
         return 4;
     }
     return 0;
@@ -279,12 +271,7 @@ int main(void) {
 CHARNESS
 
     local bin="$SCRATCH/pthread_roundtrip"
-    local type_meta_o="$repo_root/build/native/obj/runtime/type_meta.o"
-    local extra_o=()
-    if [ -f "$type_meta_o" ]; then
-        extra_o+=("$type_meta_o")
-    fi
-    if ! "$clang_bin" -Wno-override-module "$harness" "$ll" "${extra_o[@]}" \
+    if ! "$clang_bin" -Wno-override-module "$harness" "$ll" \
             -o "$bin" -lm -lpthread 2>"$SCRATCH/clang.log"; then
         # No pthread linkage → skip (matches the runtime exception
         # roundtrip's `-lm` fallback policy). The IR-shape pin still
@@ -315,7 +302,7 @@ run_test "thread_local let without mut reports E0807" \
     test_immutable_thread_local_rejected_with_E0807
 run_test "thread_local let mut is accepted by typecheck" \
     test_mutable_thread_local_accepted
-run_test "two pthreads writing to exception.sfn's TLS frame head do not interfere" \
+run_test "two pthreads bumping a thread_local i64 head do not interfere" \
     test_pthread_isolation_roundtrip
 
 echo "[summary] $PASS passed, $FAIL failed"

--- a/compiler/tests/e2e/test_thread_local_lowering.sh
+++ b/compiler/tests/e2e/test_thread_local_lowering.sh
@@ -1,0 +1,324 @@
+#!/usr/bin/env bash
+# End-to-end test for the `thread_local` storage-class annotation
+# on top-level `let mut` declarations (#730).
+#
+# Pins the lowering shape: `thread_local let mut x: T = init;`
+# must emit `@global.x = internal thread_local global <T> <init>`
+# instead of the default `internal global` form. Three branches
+# of `_process_one_binding` in
+# `compiler/src/llvm/lowering/module_globals.sfn` matter — i64
+# (the runtime-driver case), i1 (boolean), and double (float) —
+# and the fixture exercises all three.
+#
+# Also pins the immutable rejection (`thread_local let x = ...`
+# without `mut`) as an E0807 diagnostic. The diagnostic is a
+# typecheck-level error rather than a parse error so the
+# diagnostic carries the symbol name and a fix-it hint; the
+# parser accepts the shape so its location info reaches the
+# diagnostic emitter.
+#
+# Usage:
+#   compiler/tests/e2e/test_thread_local_lowering.sh <compiler-binary>
+
+set -euo pipefail
+
+BINARY="${1:?usage: test_thread_local_lowering.sh <compiler-binary>}"
+BINARY="$(realpath "$BINARY")"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FIXTURE="$SCRIPT_DIR/fixtures/thread_local_basic.sfn"
+
+PASS=0
+FAIL=0
+
+SCRATCH="$(mktemp -d -t sfn-thread-local-XXXXXX)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+run_test() {
+    local name="$1"
+    shift
+    if "$@"; then
+        echo "[test] PASS: $name"
+        PASS=$((PASS + 1))
+    else
+        echo "[test] FAIL: $name"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+test_lowering_emits_thread_local_qualifier() {
+    local ll="$SCRATCH/thread_local_basic.ll"
+    if ! "$BINARY" emit -o "$ll" llvm "$FIXTURE" > /dev/null 2>&1; then
+        echo "[test]   sfn emit llvm failed for thread_local_basic.sfn"
+        return 1
+    fi
+
+    # i64 branch — the runtime-driver case
+    # (`runtime/sfn/exception.sfn`'s frame-head pointer).
+    if ! grep -qE '^@global\.head = internal thread_local global i64 0$' "$ll"; then
+        echo "[test]   missing '@global.head = internal thread_local global i64 0':"
+        grep -E '^@global\.' "$ll" || true
+        return 1
+    fi
+
+    # i1 (boolean) branch — pins that the branch picks up the TLS
+    # qualifier the same way the integer branch does.
+    if ! grep -qE '^@global\.flag = internal thread_local global i1 1$' "$ll"; then
+        echo "[test]   missing '@global.flag = internal thread_local global i1 1':"
+        grep -E '^@global\.' "$ll" || true
+        return 1
+    fi
+
+    # double (float) branch — pins the third lowering path. The
+    # initializer text is whatever `normalise_number_literal`
+    # produces for `0.0`, so match permissively on the qualifier
+    # and type prefix.
+    if ! grep -qE '^@global\.temperature = internal thread_local global double ' "$ll"; then
+        echo "[test]   missing '@global.temperature = internal thread_local global double ...':"
+        grep -E '^@global\.' "$ll" || true
+        return 1
+    fi
+
+    return 0
+}
+
+test_lowering_load_store_use_same_symbol() {
+    # `thread_local` only changes the declaration line; load/store
+    # sites still address the global through `@global.<name>`. The
+    # scheduler (#321) relies on this invariant.
+    local ll="$SCRATCH/thread_local_basic.ll"
+    if [ ! -f "$ll" ]; then
+        echo "[test]   $ll missing — test_lowering_emits_thread_local_qualifier must run first"
+        return 1
+    fi
+    if ! grep -qE 'load i64, i64\* @global\.head' "$ll"; then
+        echo "[test]   missing load against @global.head"
+        return 1
+    fi
+    if ! grep -qE 'store i64 .*, i64\* @global\.head' "$ll"; then
+        echo "[test]   missing store against @global.head"
+        return 1
+    fi
+    return 0
+}
+
+test_immutable_thread_local_rejected_with_E0807() {
+    local src="$SCRATCH/immutable_tls.sfn"
+    cat > "$src" <<'EOF'
+thread_local let frame: i64 = 0;
+
+fn main() -> i32 {
+    return 0;
+}
+EOF
+    local stderr
+    stderr="$("$BINARY" check "$src" 2>&1 || true)"
+    if ! echo "$stderr" | grep -q "E0807"; then
+        echo "[test]   missing E0807 for 'thread_local let' (no mut)"
+        echo "         stderr was: $stderr" | head -5
+        return 1
+    fi
+    if ! echo "$stderr" | grep -q "missing \`mut\`"; then
+        echo "[test]   E0807 missing 'missing \`mut\`' hint"
+        echo "         stderr was: $stderr" | head -5
+        return 1
+    fi
+    return 0
+}
+
+test_mutable_thread_local_accepted() {
+    # Sanity check that the same source minus the missing `mut`
+    # passes — guards against an overzealous diagnostic that fires
+    # on every thread_local declaration.
+    local src="$SCRATCH/mutable_tls.sfn"
+    cat > "$src" <<'EOF'
+thread_local let mut frame: i64 = 0;
+
+fn main() -> i32 {
+    return 0;
+}
+EOF
+    if ! "$BINARY" check "$src" > /dev/null 2>&1; then
+        echo "[test]   'thread_local let mut' check failed (should be accepted)"
+        "$BINARY" check "$src" 2>&1 | head -10
+        return 1
+    fi
+    return 0
+}
+
+test_pthread_isolation_roundtrip() {
+    # End-to-end thread-isolation check against the actual driver
+    # for #730 — `runtime/sfn/exception.sfn`'s frame-head chain
+    # pointer. Two pthreads each push a frame; each verifies that
+    # `sfn_exception_frame_head()` returns *its own* frame rather
+    # than the sibling thread's. Before #730 (when the chain head
+    # was `internal global`), this would corrupt the cross-thread
+    # view; after #730 the TLS lowering keeps each thread's chain
+    # head isolated.
+    #
+    # Skipped when `clang` or pthread linkage is unavailable —
+    # mirrors the cross-frame roundtrip skip in
+    # test_runtime_exception_frames.sh; the IR-shape assertions
+    # above still pin the contract.
+    local clang_bin
+    clang_bin="${CLANG:-clang}"
+    if ! command -v "$clang_bin" >/dev/null 2>&1; then
+        echo "[test]   clang not available — skipping pthread roundtrip"
+        return 0
+    fi
+
+    local repo_root
+    repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+    local module="$repo_root/runtime/sfn/exception.sfn"
+    local ll="$SCRATCH/exception.ll"
+    if ! "$BINARY" emit -o "$ll" llvm "$module" > /dev/null 2>&1; then
+        echo "[test]   sfn emit llvm failed for runtime/sfn/exception.sfn"
+        return 1
+    fi
+
+    local harness="$SCRATCH/pthread_harness.c"
+    cat > "$harness" <<'CHARNESS'
+/* Thread-isolation harness for the `thread_local` storage class
+ * (#730). Spawns two pthreads, each of which allocates and pushes
+ * its own SfnExceptionFrame. The thread_local chain head must
+ * resolve to the per-thread frame at each read site; if the head
+ * is process-global (pre-#730) the two threads race and at least
+ * one read returns the sibling's pointer.
+ *
+ * Synchronization. We don't use a barrier — the threads simply
+ * push their frame, spin briefly (`sched_yield` + a small loop
+ * that re-reads the head 1024 times), and then verify. The spin
+ * gives the OS scheduler a window to interleave the writes; on a
+ * pre-#730 binary at least one of those 1024 reads returns the
+ * sibling thread's pointer, surfacing the bug deterministically
+ * enough to fail CI. On a #730-correct binary every read returns
+ * the local frame.
+ */
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <pthread.h>
+#include <sched.h>
+
+struct SfnExceptionFrame {
+    int64_t prev_addr;
+    int64_t jmp_buf_addr;
+    int64_t message_addr;
+};
+
+extern struct SfnExceptionFrame *sfn_exception_alloc_frame(void);
+extern void sfn_exception_free_frame(struct SfnExceptionFrame *frame);
+extern struct SfnExceptionFrame *sfn_exception_frame_head(void);
+extern void sfn_exception_push_frame(struct SfnExceptionFrame *frame);
+extern void sfn_exception_pop_frame(struct SfnExceptionFrame *frame);
+
+void sailfin_runtime_mark_persistent(void *ptr) { (void)ptr; }
+
+struct WorkerArgs {
+    int id;
+    int leak_count;  /* number of head() reads that didn't match the local frame */
+};
+
+static void *worker(void *raw) {
+    struct WorkerArgs *args = (struct WorkerArgs *)raw;
+    args->leak_count = 0;
+
+    struct SfnExceptionFrame *frame = sfn_exception_alloc_frame();
+    if (!frame) {
+        args->leak_count = -1;
+        return NULL;
+    }
+
+    /* Each worker pushes; under TLS the head is its own frame.
+     * Under process-global storage the second writer overwrites
+     * the first and at least one of the 1024 reads below sees
+     * the sibling's pointer. */
+    sfn_exception_push_frame(frame);
+
+    for (int i = 0; i < 1024; ++i) {
+        if (i % 64 == 0) sched_yield();
+        struct SfnExceptionFrame *head = sfn_exception_frame_head();
+        if (head != frame) {
+            args->leak_count += 1;
+        }
+    }
+
+    sfn_exception_pop_frame(frame);
+    sfn_exception_free_frame(frame);
+    return NULL;
+}
+
+int main(void) {
+    pthread_t t1, t2;
+    struct WorkerArgs a1 = { .id = 1, .leak_count = 0 };
+    struct WorkerArgs a2 = { .id = 2, .leak_count = 0 };
+
+    if (pthread_create(&t1, NULL, worker, &a1) != 0) {
+        fprintf(stderr, "pthread_create #1 failed\n");
+        return 1;
+    }
+    if (pthread_create(&t2, NULL, worker, &a2) != 0) {
+        fprintf(stderr, "pthread_create #2 failed\n");
+        return 2;
+    }
+    pthread_join(t1, NULL);
+    pthread_join(t2, NULL);
+
+    if (a1.leak_count < 0 || a2.leak_count < 0) {
+        fprintf(stderr, "alloc_frame returned NULL in a worker\n");
+        return 3;
+    }
+    if (a1.leak_count != 0 || a2.leak_count != 0) {
+        fprintf(stderr,
+                "TLS bleed: worker 1 saw %d non-local heads, worker 2 saw %d.\n"
+                "The frame-head chain pointer is not thread-local.\n",
+                a1.leak_count, a2.leak_count);
+        return 4;
+    }
+    return 0;
+}
+CHARNESS
+
+    local bin="$SCRATCH/pthread_roundtrip"
+    local type_meta_o="$repo_root/build/native/obj/runtime/type_meta.o"
+    local extra_o=()
+    if [ -f "$type_meta_o" ]; then
+        extra_o+=("$type_meta_o")
+    fi
+    if ! "$clang_bin" -Wno-override-module "$harness" "$ll" "${extra_o[@]}" \
+            -o "$bin" -lm -lpthread 2>"$SCRATCH/clang.log"; then
+        # No pthread linkage → skip (matches the runtime exception
+        # roundtrip's `-lm` fallback policy). The IR-shape pin still
+        # carries the contract.
+        if grep -q "cannot find -lpthread" "$SCRATCH/clang.log"; then
+            echo "[test]   -lpthread unavailable — skipping pthread roundtrip"
+            return 0
+        fi
+        echo "[test]   clang failed to link pthread roundtrip:"
+        cat "$SCRATCH/clang.log"
+        return 1
+    fi
+
+    if ! "$bin" > "$SCRATCH/run.log" 2>&1; then
+        local rc=$?
+        echo "[test]   pthread roundtrip exited non-zero (rc=$rc):"
+        cat "$SCRATCH/run.log"
+        return 1
+    fi
+    return 0
+}
+
+run_test "thread_local let mut lowers to 'internal thread_local global'" \
+    test_lowering_emits_thread_local_qualifier
+run_test "thread_local globals share the @global.<name> symbol at use sites" \
+    test_lowering_load_store_use_same_symbol
+run_test "thread_local let without mut reports E0807" \
+    test_immutable_thread_local_rejected_with_E0807
+run_test "thread_local let mut is accepted by typecheck" \
+    test_mutable_thread_local_accepted
+run_test "two pthreads writing to exception.sfn's TLS frame head do not interfere" \
+    test_pthread_isolation_roundtrip
+
+echo "[summary] $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi

--- a/compiler/tests/unit/thread_local_global_test.sfn
+++ b/compiler/tests/unit/thread_local_global_test.sfn
@@ -1,0 +1,112 @@
+// Regression coverage for the `thread_local` storage-class annotation
+// on top-level `let mut` declarations (#730).
+//
+// `thread_local let mut x: T = init;` is the audit-able one-line knob
+// that flips a module global from `internal global` to
+// `internal thread_local global` at LLVM lowering. The driver is
+// `runtime/sfn/exception.sfn` — the M2.7a frame-head chain pointer
+// is process-global today and needs to flip to per-thread before
+// any concurrency primitive (`spawn`, M4 #321) can land without
+// corrupting frames across thread boundaries.
+//
+// These tests pin the parser/AST round-trip surface:
+//   - The keyword parses at the top level and sets `is_thread_local`
+//   - The keyword is rejected without `let` following it
+//   - `is_thread_local` defaults to `false` for ordinary `let` /
+//     `let mut`
+//   - The `mutable` flag is preserved alongside the storage class
+//
+// The LLVM-shape pin (`internal thread_local global`) lives in
+// `compiler/tests/e2e/test_thread_local_lowering.sh` — that test
+// runs the whole compiler pipeline against a fixture, which this
+// unit test deliberately does not, to keep parser regressions
+// independent of LLVM lowering.
+import { Program, Statement } from "../../src/ast";
+import { parse_program } from "../../src/parser/mod";
+
+fn _find_variable(program: Program, name: string) -> Statement {
+    let mut index: int = 0;
+    loop {
+        if index >= program.statements.length { break; }
+        let stmt = program.statements[index];
+        if stmt.variant == "VariableDeclaration" {
+            if stmt.name == name { return stmt; }
+        }
+        index += 1;
+    }
+    return program.statements[0];
+}
+
+fn _has_variable(program: Program, name: string) -> boolean {
+    let mut index: int = 0;
+    loop {
+        if index >= program.statements.length { break; }
+        let stmt = program.statements[index];
+        if stmt.variant == "VariableDeclaration" {
+            if stmt.name == name { return true; }
+        }
+        index += 1;
+    }
+    return false;
+}
+
+test "parser thread_local: top-level `thread_local let mut` sets is_thread_local" {
+    let source = "thread_local let mut frame_head: i64 = 0;";
+    let program = parse_program(source);
+    assert _has_variable(program, "frame_head");
+    let decl = _find_variable(program, "frame_head");
+    assert decl.is_thread_local == true;
+    assert decl.mutable == true;
+    assert decl.name == "frame_head";
+}
+
+test "parser thread_local: ordinary `let mut` leaves is_thread_local false" {
+    // Anchor the default — every existing module global today still
+    // lowers to `internal global`, not `internal thread_local global`.
+    let source = "let mut counter: i64 = 0;";
+    let program = parse_program(source);
+    let decl = _find_variable(program, "counter");
+    assert decl.is_thread_local == false;
+    assert decl.mutable == true;
+}
+
+test "parser thread_local: ordinary immutable `let` leaves is_thread_local false" {
+    let source = "let pi: float = 3.14;";
+    let program = parse_program(source);
+    let decl = _find_variable(program, "pi");
+    assert decl.is_thread_local == false;
+    assert decl.mutable == false;
+}
+
+test "parser thread_local: preserves type annotation through the prefix" {
+    // The keyword must not consume tokens that belong to the type
+    // annotation — i.e. `thread_local` is a pure prefix, not a
+    // pseudo-type wrapper.
+    let source = "thread_local let mut head: i64 = 0;";
+    let program = parse_program(source);
+    let decl = _find_variable(program, "head");
+    assert decl.is_thread_local == true;
+    assert decl.type_annotation != null;
+    assert decl.type_annotation.text == "i64";
+}
+
+test "parser thread_local: rejects bare `thread_local` without `let`" {
+    // `thread_local fn ...` (and any other non-`let` follower) must
+    // not silently turn into a VariableDeclaration. Today the
+    // dispatcher falls through to `parse_unknown`, which yields a
+    // Statement.Unknown rather than a structured declaration — the
+    // typecheck pass surfaces this as an error at compile time.
+    let source = "thread_local fn boom() {}";
+    let program = parse_program(source);
+    // No VariableDeclaration should have been produced.
+    let mut found_var: boolean = false;
+    let mut index: int = 0;
+    loop {
+        if index >= program.statements.length { break; }
+        if program.statements[index].variant == "VariableDeclaration" {
+            found_var = true;
+        }
+        index += 1;
+    }
+    assert found_var == false;
+}

--- a/docs/status.md
+++ b/docs/status.md
@@ -631,6 +631,7 @@ feature availability.
 | Feature | Status | Notes |
 |---|---|---|
 | `let` / `let mut` variables | Shipped | Type annotations optional; limited inference |
+| `thread_local let mut` (storage class) | Shipped | Top-level only; lowers to `internal thread_local global` (ELF TLS). Immutable `thread_local let` rejected with `E0807`. Unblocks per-thread runtime state for #321 (M4 scheduler) and #730's `runtime/sfn/exception.sfn` frame-head migration |
 | Functions (`fn`) | Shipped | Including generics, default params, decorators |
 | `async fn` | Parsed | `await` is **not** parsed; async is structural only |
 | Structs | Shipped | Including generic params, `implements` clause |

--- a/runtime/sfn/exception.sfn
+++ b/runtime/sfn/exception.sfn
@@ -81,16 +81,23 @@
 //
 // TLS. The architect spec calls for a thread-local
 // `current_frame` pointer. The `thread_local` storage-class
-// annotation (#730) flips the chain head onto ELF TLS:
-// `thread_local let mut sfn_exception_frame_head_addr: i64 = 0`
-// lowers to `@global.sfn_exception_frame_head_addr = internal
-// thread_local global i64 0`. The i64 slot stays for the same
-// pointer-field-layout reason that pins the rest of this module;
-// the cast at `sfn_exception_frame_head` lifts it back to
-// `* SfnExceptionFrame` at use sites. Sailfin has no `spawn`
-// yet, so the single-threaded reality already applies — but the
-// storage is now per-thread by construction, so the M4 (#321)
-// scheduler work no longer needs to revisit this file.
+// annotation ships in the compiler in #825, but the pinned seed
+// for this PR predates the keyword and can't parse it in this
+// runtime file (the seed compiles every entry in
+// `runtime/native/capsule.toml`'s `sfn-sources` as part of
+// `sfn build -p compiler`). The chain head therefore still rides
+// as a process-global mutable `let mut sfn_exception_frame_head_addr`
+// (i64 because the seed compiler drops pointer-typed top-level
+// mutables under the same field-layout limitation as struct
+// pointer fields). The flip to `thread_local let mut` is a
+// one-line follow-up PR that lands after the next seed pin —
+// the audit-able diff the M2.7a module header originally
+// promised. Tracking issue: #730 follow-up; depends on a seed
+// release that includes the #825 parser change. The existing C
+// runtime's try-stack is `_Thread_local`, but Sailfin has no
+// `spawn` yet, so the single-threaded reality already applies.
+// The TLS upgrade lands alongside scheduler / concurrency work
+// in M4 (#321).
 //
 // Effects. None. Exception primitives live below the I/O layer
 // (same discipline as `runtime/sfn/memory/arena.sfn` and
@@ -154,10 +161,10 @@ struct SfnExceptionFrame {
     message_addr: i64;
 }
 
-// Chain head (per-thread; see the file-header TLS note).
+// Chain head (process-global; see the file-header TLS note).
 // `0` means "no frame pending" — `sfn_throw` aborts in that
 // case rather than longjmp'ing to a stale buffer.
-thread_local let mut sfn_exception_frame_head_addr: i64 = 0;
+let mut sfn_exception_frame_head_addr: i64 = 0;
 
 // `sfn_exception_alloc_frame()` allocates a fresh frame plus
 // its JMPBUF_SIZE buffer. Returns the frame pointer; caller

--- a/runtime/sfn/exception.sfn
+++ b/runtime/sfn/exception.sfn
@@ -80,15 +80,17 @@
 // path works end-to-end on Linux x86_64.
 //
 // TLS. The architect spec calls for a thread-local
-// `current_frame` pointer. Sailfin lacks a `thread_local`
-// annotation today, so the chain head rides as a process-global
-// mutable `let mut sfn_exception_frame_head_addr` (i64 because
-// the seed compiler drops pointer-typed top-level mutables under
-// the same field-layout limitation as struct pointer fields).
-// The existing C runtime's try-stack is `_Thread_local`, but
-// Sailfin has no `spawn` yet, so the single-threaded reality
-// already applies. The TLS upgrade lands alongside scheduler /
-// concurrency work in M4 (#321).
+// `current_frame` pointer. The `thread_local` storage-class
+// annotation (#730) flips the chain head onto ELF TLS:
+// `thread_local let mut sfn_exception_frame_head_addr: i64 = 0`
+// lowers to `@global.sfn_exception_frame_head_addr = internal
+// thread_local global i64 0`. The i64 slot stays for the same
+// pointer-field-layout reason that pins the rest of this module;
+// the cast at `sfn_exception_frame_head` lifts it back to
+// `* SfnExceptionFrame` at use sites. Sailfin has no `spawn`
+// yet, so the single-threaded reality already applies — but the
+// storage is now per-thread by construction, so the M4 (#321)
+// scheduler work no longer needs to revisit this file.
 //
 // Effects. None. Exception primitives live below the I/O layer
 // (same discipline as `runtime/sfn/memory/arena.sfn` and
@@ -152,10 +154,10 @@ struct SfnExceptionFrame {
     message_addr: i64;
 }
 
-// Chain head (process-global; see the file-header TLS note).
+// Chain head (per-thread; see the file-header TLS note).
 // `0` means "no frame pending" — `sfn_throw` aborts in that
 // case rather than longjmp'ing to a stale buffer.
-let mut sfn_exception_frame_head_addr: i64 = 0;
+thread_local let mut sfn_exception_frame_head_addr: i64 = 0;
 
 // `sfn_exception_alloc_frame()` allocates a fresh frame plus
 // its JMPBUF_SIZE buffer. Returns the frame pointer; caller

--- a/site/src/content/docs/docs/reference/keywords.md
+++ b/site/src/content/docs/docs/reference/keywords.md
@@ -101,8 +101,8 @@ results.push("new item");
 Storage-class prefix for top-level `let mut` declarations. Flips the backing storage from a process-global to per-thread (ELF TLS): the binding lowers to `@global.<name> = internal thread_local global <T> <init>` instead of `internal global`. Reads and writes against the binding use the same `@global.<name>` symbol, so the prefix is invisible to call sites.
 
 ```sfn
-// Per-thread chain head for the M2.7 exception runtime
-thread_local let mut sfn_exception_frame_head_addr: i64 = 0;
+// Per-thread counter — each thread's storage starts at 0
+thread_local let mut request_counter: i64 = 0;
 ```
 
 `thread_local` is rejected on function-local `let` (an `alloca` is already stack-local and cannot be TLS) and on immutable bindings (`thread_local let x` reports `E0807` — an immutable thread-local is a contradiction). The prefix exists ahead of the M4 scheduler (#321) so per-thread runtime state ships before any concurrency primitive lands.

--- a/site/src/content/docs/docs/reference/keywords.md
+++ b/site/src/content/docs/docs/reference/keywords.md
@@ -94,6 +94,21 @@ results.push("new item");
 
 ---
 
+### `thread_local`
+
+**Status: Implemented**
+
+Storage-class prefix for top-level `let mut` declarations. Flips the backing storage from a process-global to per-thread (ELF TLS): the binding lowers to `@global.<name> = internal thread_local global <T> <init>` instead of `internal global`. Reads and writes against the binding use the same `@global.<name>` symbol, so the prefix is invisible to call sites.
+
+```sfn
+// Per-thread chain head for the M2.7 exception runtime
+thread_local let mut sfn_exception_frame_head_addr: i64 = 0;
+```
+
+`thread_local` is rejected on function-local `let` (an `alloca` is already stack-local and cannot be TLS) and on immutable bindings (`thread_local let x` reports `E0807` — an immutable thread-local is a contradiction). The prefix exists ahead of the M4 scheduler (#321) so per-thread runtime state ships before any concurrency primitive lands.
+
+---
+
 ### `struct`
 
 **Status: Implemented**

--- a/site/src/content/docs/docs/reference/spec/03-declarations.md
+++ b/site/src/content/docs/docs/reference/spec/03-declarations.md
@@ -20,6 +20,24 @@ Type annotations are optional; the compiler infers types where possible.
 Uninitialized bindings default to `null`. Variables, parameters, and struct
 fields use `:` for type annotations; only function return types use `->`.
 
+##### §3.1.1 Thread-local storage class
+
+Top-level `let mut` bindings accept a `thread_local` prefix that flips the
+backing storage from process-global to per-thread:
+
+```sfn
+thread_local let mut frame_head: i64 = 0;   // per-thread storage
+```
+
+`thread_local` is a storage-class annotation, not a type. It is only valid
+in front of a top-level `let mut` declaration — function-local `thread_local`
+is rejected (an `alloca` is already stack-local and cannot be TLS), and
+`thread_local let x` without `mut` is rejected with `E0807` (an immutable
+thread-local is a contradiction). At LLVM lowering the declaration emits
+`@global.<name> = internal thread_local global <T> <init>` instead of the
+default `internal global` form; reads and writes against the binding use the
+same `@global.<name>` symbol they would for an ordinary global.
+
 #### §3.2 Functions
 
 ```sfn


### PR DESCRIPTION
## Summary

- Adds a `thread_local` storage-class prefix for top-level `let mut` declarations. The flag lowers to `@global.<name> = internal thread_local global <T> <init>` instead of the default `internal global`, putting the binding on ELF TLS. Reads/writes keep the `@global.<name>` symbol, so call sites are unchanged.
- Typecheck rejects immutable `thread_local let` with the new `E0807` diagnostic. The parser only recognizes `thread_local` at the top level, so block-scoped `thread_local` falls through to `parse_unknown`.

Closes #730

## Scope split

**Runtime `runtime/sfn/exception.sfn` flip deferred to a follow-up PR.** The pinned seed (`0.7.0-alpha.8`) compiles every entry in `runtime/native/capsule.toml`'s `sfn-sources` as part of `sfn build -p compiler`, and it predates the `thread_local` keyword — putting the keyword in `exception.sfn` makes the seed fail with `[fatal]: ABI primitive mismatch`. The compiler-side feature ships in this PR; after merge + a fresh alpha + `.seed-version` bump, a one-line follow-up flips `exception.sfn` (the audit-able diff the issue's criterion #3 calls for). Phase 1.5's `## Required in pinned seed` precheck didn't catch this because it only checks predecessor-PR dependencies, not structural dependencies on the PR's own change.

## Acceptance Criteria

- [x] Parser accepts `thread_local let mut frame_head: * u8 = ...;` at top level; rejects `thread_local let x = ...` (immutable) with `E0807` (`thread_local requires let mut`).
- [x] LLVM lowering emits `@global.frame_head = internal thread_local global i8* null` (and the typed equivalents for `i64`, `i1`, `double`).
- [ ] **Deferred to follow-up PR:** `runtime/sfn/exception.sfn` flips `let mut sfn_exception_frame_head_addr` to `thread_local`, and the matching `internal thread_local global i64 0` assertion replaces the current `internal global i64 0` pin in `test_runtime_exception_frames.sh`. Gated on the next seed pin.
- [x] A runtime test spawns two pthreads (via `clang -lpthread`), each writes to a `thread_local let mut i64` (the fixture's `head`) via `bump_n`/`read_head` helpers, then reads back — values must not interfere. Skipped on platforms without pthread linkage. Driven by `compiler/tests/e2e/fixtures/thread_local_basic.sfn` rather than `exception.sfn` because the runtime can't flip yet (see above).
- [x] `make compile` passes.
- [x] `make test` passes.

## Verification

```bash
# Self-host and full test suite
ulimit -v 8388608 && make rebuild SEED_NATIVE=build/seed/bin/sailfin && make test
# → all green

# User-level smoke
cat > /tmp/tls_smoke.sfn <<'SFN'
thread_local let mut counter: i64 = 0;
fn bump() -> i64 { counter = counter + 1; return counter; }
fn main() -> i32 { bump(); bump(); return counter as i32; }
SFN
ulimit -v 8388608 && build/native/sailfin emit llvm /tmp/tls_smoke.sfn | grep "@global.counter"
# → @global.counter = internal thread_local global i64 0

# New thread_local e2e (5 tests, including the pthread isolation roundtrip)
compiler/tests/e2e/test_thread_local_lowering.sh build/native/sailfin
# → 5 passed, 0 failed

# Exception frames pin (still asserts pre-flip `internal global` until follow-up)
compiler/tests/e2e/test_runtime_exception_frames.sh build/native/sailfin
# → 12 passed, 0 failed
```

## Files Changed

- AST: `compiler/src/ast.sfn` — `Statement.VariableDeclaration` gains `is_thread_local`
- Parser: `compiler/src/parser/{declarations,mod}.sfn` — `parse_variable_with_storage` + top-level `thread_local` dispatch
- Native IR: `compiler/src/native_ir.sfn`, `compiler/src/native_ir_parser*.sfn`, `compiler/src/native_ir_utils_parse.sfn`, `compiler/src/emit_native.sfn` — `is_thread_local` flows through `.let` round-trip
- Typecheck: `compiler/src/typecheck.sfn`, `compiler/src/typecheck_types.sfn` — `E0807` for `thread_local let` without `mut`
- Lowering: `compiler/src/llvm/lowering/module_globals.sfn` — emits `internal thread_local global` when flagged; updates the lambda-rewrite and inline-let construction sites
- Runtime: `runtime/sfn/exception.sfn` — file-header `TLS.` note rewritten to point at the follow-up PR; `let mut sfn_exception_frame_head_addr` stays as-is for now
- Tests: `compiler/tests/unit/thread_local_global_test.sfn` (parser/AST roundtrip), `compiler/tests/e2e/test_thread_local_lowering.sh` + fixture (IR shape pin + pthread isolation roundtrip), `compiler/tests/e2e/test_runtime_exception_frames.sh` (comment updated; assertion unchanged)
- Docs: `docs/status.md`, `site/src/content/docs/docs/reference/keywords.md`, `site/src/content/docs/docs/reference/spec/03-declarations.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)