### PR TITLE
feat(cli): add exit code constants to sfn/cli capsule

### DIFF
--- a/capsules/sfn/cli/src/exit_codes.sfn
+++ b/capsules/sfn/cli/src/exit_codes.sfn
@@ -1,5 +1,37 @@
 // sfn/cli — exit code constants.
 //
-// Reserved for Phase 1 (Issue 1.2). Will host `EXIT_OK`,
-// `EXIT_BUILD_FAIL`, `EXIT_USAGE`, `EXIT_NOT_FOUND`, and `EXIT_INTERNAL`
-// once typed flags and the non-exiting `parse()` variant land.
+// Stable named constants for `process.exit()` codes used by the CLI
+// capsule and (eventually) the Sailfin compiler driver. Codes follow
+// the loose tooling convention shared by Rust/Cargo and POSIX
+// `sysexits.h`:
+//
+//   * `EXIT_OK`         — success.
+//   * `EXIT_BUILD_FAIL` — generic "operation failed" (compile error,
+//                         test failure, etc.).
+//   * `EXIT_USAGE`      — invalid CLI usage: unknown flag, missing
+//                         required argument, unexpected positional.
+//   * `EXIT_NOT_FOUND`  — the requested input (file, capsule,
+//                         subcommand) does not exist. Lets CI scripts
+//                         distinguish missing-input from a real build
+//                         failure without parsing stderr.
+//   * `EXIT_INTERNAL`   — internal compiler/CLI bug. Matches sysexits.h
+//                         `EX_SOFTWARE` so monitoring tools that already
+//                         understand 70 keep working.
+//
+// Phase 1 (Issue #791): `parser.run()` adopts `EXIT_OK` and `EXIT_USAGE`
+// in place of the literals it already emits. The remaining constants
+// are declared here so downstream callers and the compiler-side
+// adoption (Phase 2/3) have a single source of truth.
+let EXIT_OK: int = 0;
+let EXIT_BUILD_FAIL: int = 1;
+let EXIT_USAGE: int = 2;
+let EXIT_NOT_FOUND: int = 3;
+let EXIT_INTERNAL: int = 70;
+
+export {
+    EXIT_OK,
+    EXIT_BUILD_FAIL,
+    EXIT_USAGE,
+    EXIT_NOT_FOUND,
+    EXIT_INTERNAL
+};

--- a/capsules/sfn/cli/src/mod.sfn
+++ b/capsules/sfn/cli/src/mod.sfn
@@ -35,7 +35,8 @@
 //   - help.sfn        help, print_help, _format_help, width helpers
 //   - style.sfn       bold, dim, color helpers, _esc, _ansi_wrap
 //   - print.sfn       print_error, print_warn, print_success, print_hint
-//   - exit_codes.sfn  reserved for Phase 1 (Issue 1.2)
+//   - exit_codes.sfn  EXIT_OK, EXIT_BUILD_FAIL, EXIT_USAGE,
+//                     EXIT_NOT_FOUND, EXIT_INTERNAL
 //
 // Visibility: underscore-prefixed names (`_format_help`, `_pad`, `_esc`,
 // `_ansi_wrap`, `_starts_with`, `_find_flag_long`, `_find_flag_short`,
@@ -110,3 +111,12 @@ export {
     print_success,
     print_hint
 } from "./print";
+
+// ---- Exit code constants ----
+export {
+    EXIT_OK,
+    EXIT_BUILD_FAIL,
+    EXIT_USAGE,
+    EXIT_NOT_FOUND,
+    EXIT_INTERNAL
+} from "./exit_codes";

--- a/capsules/sfn/cli/src/parser.sfn
+++ b/capsules/sfn/cli/src/parser.sfn
@@ -23,6 +23,7 @@
 //   * parse failures -> print `error.message` to stderr, exit 2
 // Its observable behavior (stderr text, exit codes) is byte-identical
 // to the pre-`parse()` implementation.
+import { EXIT_OK, EXIT_USAGE } from "./exit_codes";
 import { _format_help } from "./help";
 import {
     Command,
@@ -174,7 +175,7 @@ fn run(cmd: Command, argv: string[]) -> Matches ![io] {
         if subcmd_name.length > 0 {
             print(_format_help(active, cmd.name + " " + subcmd_name));
         } else { print(_format_help(cmd, cmd.name)); }
-        process.exit(0);
+        process.exit(EXIT_OK);
     }
     if strings_equal(kind, "version_requested") {
         if subcmd_name.length > 0 {
@@ -188,7 +189,7 @@ fn run(cmd: Command, argv: string[]) -> Matches ![io] {
                 print(cmd.name + " " + cmd.version);
             } else { print(cmd.name); }
         }
-        process.exit(0);
+        process.exit(EXIT_OK);
     }
 
     // Parse failure: `error.message` already contains the help-hint
@@ -196,7 +197,7 @@ fn run(cmd: Command, argv: string[]) -> Matches ![io] {
     // omits the hint), so a single stderr write reproduces the
     // pre-parse() stderr exactly.
     print.err(result.error.message);
-    process.exit(2);
+    process.exit(EXIT_USAGE);
     return result.matches;
 }
 


### PR DESCRIPTION
## Summary

- Define `EXIT_OK = 0`, `EXIT_BUILD_FAIL = 1`, `EXIT_USAGE = 2`, `EXIT_NOT_FOUND = 3`, `EXIT_INTERNAL = 70` in `capsules/sfn/cli/src/exit_codes.sfn`.
- Re-export the constants from the capsule barrel (`capsules/sfn/cli/src/mod.sfn`).
- Replace the `process.exit(0)` / `process.exit(2)` literals in `parser.run()` with `EXIT_OK` / `EXIT_USAGE`. Exit behavior is byte-identical.

Codes follow the loose tooling convention (Rust/Cargo + `sysexits.h`): `1` is the generic "operation failed" code, `2` is reserved for usage errors, `3` distinguishes "input not found" so CI can branch on missing-file vs compile-failure without scraping stderr, and `70` matches `EX_SOFTWARE` for internal panics.

Closes #791

## Acceptance Criteria

- [x] Constants exported from `exit_codes.sfn` and re-exported via `mod.sfn`.
- [x] `run()` uses the named constants — no remaining `process.exit(2)` literals in the parser body.
- [x] Existing `cli_test.sfn` / `parser_test.sfn` tests pass unchanged (proves byte-identical exit behavior).
- [x] `make compile` succeeds.
- [x] `make test` passes with no regressions.
- [x] `sfn fmt --check` clean on every touched `.sfn` file.

## Verification

```
ulimit -v 8388608 && make compile
  → [compile] built build/native/sailfin

ulimit -v 8388608 && timeout 60 build/native/sailfin test capsules/sfn/cli/tests/
  → PASS (all 15 tests passed)

ulimit -v 8388608 && make test
  → e2e: 78/78 passed, 0 failed
  → capsules: 14/14 passed, 0 failed

ulimit -v 8388608 && timeout 30 build/native/sailfin fmt --check capsules/sfn/cli/
  → clean
```

## Files Changed

- `capsules/sfn/cli/src/exit_codes.sfn` — declare and export the five constants.
- `capsules/sfn/cli/src/parser.sfn` — import `EXIT_OK`/`EXIT_USAGE` and substitute the literals in `run()`.
- `capsules/sfn/cli/src/mod.sfn` — re-export the constants and refresh the layout docstring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01QH4EuBJM9osTKdMtfPGT2n)_