### PR TITLE
fix(lowering): let shadows function parameter with the same name

### DIFF
--- a/compiler/src/llvm/expression_lowering/native/core.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core.sfn
@@ -1447,6 +1447,28 @@ fn lower_expression(expression: string, bindings: ParameterBinding[], locals: Lo
         return lower_member_access(member_parse, bindings, locals, temp_index, lines, functions, context, expected_type);
     }
 
+    // Locals are checked before parameters so a `let` that shadows a
+    // parameter with the same name resolves to the local (#697).
+    // `find_local_binding` walks the locals list newest-first, which
+    // matches lexical-scope expectations.
+    let local = find_local_binding(locals, stripped);
+    if local != null {
+        let load_result = load_local_operand(local, temp_index, lines);
+        let mut _ci5: int = 0;
+        loop {
+            if _ci5 >= load_result.diagnostics.length { break; }
+            diagnostics.push(load_result.diagnostics[_ci5]);
+            _ci5 += 1;
+        }
+        return ExpressionResult {
+            lines: load_result.lines,
+            temp_index: load_result.temp_index,
+            operand: load_result.operand,
+            diagnostics: diagnostics,
+            string_constants: empty_constants
+        };
+    }
+
     let parameter = find_parameter_binding(bindings, stripped);
     if dbg_expr {
         let mut param_found = "null";
@@ -1467,24 +1489,6 @@ fn lower_expression(expression: string, bindings: ParameterBinding[], locals: Lo
             lines: lines,
             temp_index: temp_index,
             operand: operand,
-            diagnostics: diagnostics,
-            string_constants: empty_constants
-        };
-    }
-
-    let local = find_local_binding(locals, stripped);
-    if local != null {
-        let load_result = load_local_operand(local, temp_index, lines);
-        let mut _ci5: int = 0;
-        loop {
-            if _ci5 >= load_result.diagnostics.length { break; }
-            diagnostics.push(load_result.diagnostics[_ci5]);
-            _ci5 += 1;
-        }
-        return ExpressionResult {
-            lines: load_result.lines,
-            temp_index: load_result.temp_index,
-            operand: load_result.operand,
             diagnostics: diagnostics,
             string_constants: empty_constants
         };

--- a/compiler/src/llvm/type_context_queries.sfn
+++ b/compiler/src/llvm/type_context_queries.sfn
@@ -238,6 +238,20 @@ fn resolve_struct_info_for_method_target(base: string, bindings: ParameterBindin
     let trimmed = trim_text(base);
     if trimmed.length == 0 { return null; }
     if is_simple_identifier(trimmed) {
+        // Locals before parameters so a `let` that shadows a parameter
+        // resolves to the local's type (#697).
+        let local = find_local_binding(locals, trimmed);
+        if local != null {
+            let info = resolve_struct_info_from_llvm_type(context, local.llvm_type);
+            if info != null { return info; }
+            // Fallback: check source type_annotation when llvm_type is i8*.
+            if local.type_annotation != null {
+                if local.type_annotation.length > 0 {
+                    let by_annotation = find_struct_info_by_name(context, local.type_annotation);
+                    if by_annotation != null { return by_annotation; }
+                }
+            }
+        }
         let parameter = find_parameter_binding(bindings, trimmed);
         if parameter != null {
             let info = resolve_struct_info_from_llvm_type(context, parameter.llvm_type);
@@ -247,18 +261,6 @@ fn resolve_struct_info_for_method_target(base: string, bindings: ParameterBindin
             if parameter.type_annotation != null {
                 if parameter.type_annotation.length > 0 {
                     let by_annotation = find_struct_info_by_name(context, parameter.type_annotation);
-                    if by_annotation != null { return by_annotation; }
-                }
-            }
-        }
-        let local = find_local_binding(locals, trimmed);
-        if local != null {
-            let info = resolve_struct_info_from_llvm_type(context, local.llvm_type);
-            if info != null { return info; }
-            // Fallback: check source type_annotation when llvm_type is i8*.
-            if local.type_annotation != null {
-                if local.type_annotation.length > 0 {
-                    let by_annotation = find_struct_info_by_name(context, local.type_annotation);
                     if by_annotation != null { return by_annotation; }
                 }
             }
@@ -274,9 +276,11 @@ fn resolve_interface_info_for_method_target(base: string, bindings: ParameterBin
     let trimmed = trim_text(base);
     if trimmed.length == 0 { return null; }
     if is_simple_identifier(trimmed) {
-        let parameter = find_parameter_binding(bindings, trimmed);
-        if parameter != null {
-            let mut type_name = parameter.llvm_type;
+        // Locals before parameters so a `let` that shadows a parameter
+        // resolves to the local's interface type (#697).
+        let local = find_local_binding(locals, trimmed);
+        if local != null {
+            let mut type_name = local.llvm_type;
             if substring(type_name, 0, 7) == "%trait." {
                 let interface_name = substring(type_name, 7, type_name.length);
                 let info = find_interface_info_by_name(context, interface_name);
@@ -285,9 +289,9 @@ fn resolve_interface_info_for_method_target(base: string, bindings: ParameterBin
             let info = find_interface_info_by_name(context, type_name);
             if info != null { return info; }
         }
-        let local = find_local_binding(locals, trimmed);
-        if local != null {
-            let mut type_name = local.llvm_type;
+        let parameter = find_parameter_binding(bindings, trimmed);
+        if parameter != null {
+            let mut type_name = parameter.llvm_type;
             if substring(type_name, 0, 7) == "%trait." {
                 let interface_name = substring(type_name, 7, type_name.length);
                 let info = find_interface_info_by_name(context, interface_name);

--- a/compiler/tests/integration/let_shadow_parameter_test.sfn
+++ b/compiler/tests/integration/let_shadow_parameter_test.sfn
@@ -1,0 +1,54 @@
+// Regression coverage for #697: a `let` that re-binds a function
+// parameter with the same name must shadow the parameter, and
+// subsequent reads of that name must resolve to the new local —
+// not the original parameter.
+//
+// Before the fix, identifier resolution in
+// `compiler/src/llvm/expression_lowering/native/core.sfn` searched
+// `find_parameter_binding` before `find_local_binding`, so the
+// parameter always won. The locals list already records bindings
+// newest-first; the fix is to consult it first and only fall
+// back to parameters when no local exists.
+struct _Box {
+    value: int
+}
+
+fn _shadow_primitive(x: int) -> int {
+    let new_x: int = 99;
+    let x = new_x;
+    return x;
+}
+
+fn _shadow_struct(b: _Box) -> int {
+    let new_b = _Box { value: 99 };
+    let b = new_b;
+    return b.value;
+}
+
+fn _nested_shadow(x: int) -> int {
+    let mut observed_inner: int = 0;
+    if x > 0 {
+        let x = 99;
+        observed_inner = x;
+    }
+    // The inner `let x = 99` is scoped to the if-block; after the
+    // block exits, `x` must resolve back to the parameter (= 42).
+    return x + observed_inner;
+}
+
+test "let-shadow: primitive parameter is shadowed by let" {
+    let result = _shadow_primitive(42);
+    assert result == 99;
+}
+
+test "let-shadow: struct parameter is shadowed by let" {
+    let result = _shadow_struct(_Box { value: 42 });
+    assert result == 99;
+}
+
+test "let-shadow: block-scoped shadow does not escape the block" {
+    let result = _nested_shadow(42);
+    // Inner observation == 99 (shadow visible), outer x == 42 (parameter
+    // restored after block exit). 42 + 99 == 141.
+    assert result == 141;
+}


### PR DESCRIPTION
## Summary

- Identifier resolution in the native LLVM lowering was checking `find_parameter_binding` before `find_local_binding`, so `let x = …` inside a function whose parameter was also named `x` silently miscompiled — subsequent reads of `x` returned the parameter value, not the local. Both primitive and struct-typed parameters were affected.
- Fixed by consulting the locals list first in `compiler/src/llvm/expression_lowering/native/core.sfn:lower_expression` (the locals list is already newest-first via `find_local_binding`).
- Applied the same flip to `resolve_struct_info_for_method_target` and `resolve_interface_info_for_method_target` in `compiler/src/llvm/type_context_queries.sfn` so member access on a shadowed struct-typed parameter (`let b = …; return b.value`) picks up the local's type, not the parameter's.
- Added a 3-case regression test in `compiler/tests/integration/let_shadow_parameter_test.sfn` covering the primitive, struct, and nested-block-scoped shapes called out in the issue.

Closes #697

## Acceptance Criteria

- [x] The repro prints `99`, not `42` (primitive `int` parameter shadow).
- [x] The struct variant (`Box`) also prints `99`.
- [x] Integration test pins each of the three shapes (primitive, struct, nested-block).
- [x] `make compile` self-hosts.
- [x] `make test` passes (no regressions).

## Verification

```bash
ulimit -v 8388608 && make compile             # self-hosts
ulimit -v 8388608 && make test                # all phases pass, exit 0
ulimit -v 8388608 && build/native/sailfin test \
  compiler/tests/integration/let_shadow_parameter_test.sfn
# → PASS (all 3 tests passed)

ulimit -v 8388608 && build/native/sailfin run /tmp/shadow_int.sfn      # 99 ✓
ulimit -v 8388608 && build/native/sailfin run /tmp/shadow_struct.sfn   # 99 ✓
```

## Files Changed

- `compiler/src/llvm/expression_lowering/native/core.sfn` — locals-first identifier resolution in `lower_expression`.
- `compiler/src/llvm/type_context_queries.sfn` — locals-first type resolution for method-target struct/interface dispatch.
- `compiler/tests/integration/let_shadow_parameter_test.sfn` — new regression test (primitive, struct, nested-block).

## Notes for reviewers

- Other binding-lookup sites in the lowering (`core_call_resolution.sfn:lower_call_callee`, `core_addressing.sfn:lower_address_of`, `statement_assignment.sfn`, closure-capture resolution at `core.sfn:617`, the `.concat` receiver path at `core.sfn:1324`) were already locals-first — no changes needed.
- The block-scoped lifetime behaviour is unchanged: the existing `LocalBinding.scope_id` mechanism still pops inner-block locals on scope exit, so a `let x` inside `if { … }` doesn't leak. The new nested-block test pins that invariant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018UWnrvQLCyvgrCc59cUNYm)_