### PR TITLE
feat(cli): NO_COLOR / TTY-aware Style in sfn/cli

### DIFF
--- a/capsules/sfn/cli/src/mod.sfn
+++ b/capsules/sfn/cli/src/mod.sfn
@@ -28,19 +28,24 @@
 //
 // Internal layout — this barrel re-exports the public surface. Sources
 // live in:
-//   - types.sfn       Arg, Flag, Command, Matches, ParseError, ParseResult
+//   - types.sfn       Arg, Flag, Command, Matches, ParseError,
+//                     ParseResult, Style
 //   - builder.sfn     arg, arg_optional, flag*, command, with_*
 //   - parser.sfn      parse() (pure, non-exiting), run() (exiting wrapper) + private parser helpers
 //   - matches.sfn     get, get_or, has_flag, has, subcommand, positionals
 //   - help.sfn        help, print_help, _format_help, width helpers
-//   - style.sfn       bold, dim, color helpers, _esc, _ansi_wrap
+//   - style.sfn       bold, dim, color helpers, no_color_active,
+//                     style_for_stream, style_with_mode,
+//                     style_resolve, paint, paint_* helpers,
+//                     _esc, _ansi_wrap, _no_color_from_value
 //   - print.sfn       print_error, print_warn, print_success, print_hint
 //   - exit_codes.sfn  EXIT_OK, EXIT_BUILD_FAIL, EXIT_USAGE,
 //                     EXIT_NOT_FOUND, EXIT_INTERNAL
 //
 // Visibility: underscore-prefixed names (`_format_help`, `_pad`, `_esc`,
 // `_ansi_wrap`, `_starts_with`, `_find_flag_long`, `_find_flag_short`,
-// `_resolve_active`, `_help_hint`, `_flag_label`, `_max_*_width`) are
+// `_resolve_active`, `_help_hint`, `_flag_label`, `_max_*_width`,
+// `_no_color_from_value`, `_style_disabled`, `_style_enabled`) are
 // private capsule helpers by convention and are intentionally NOT
 // re-exported from `mod.sfn`. The pre-split `mod.sfn` had no explicit
 // `export {}` block, so Sailfin's default "export everything" rule made
@@ -56,7 +61,8 @@ export {
     Command,
     Matches,
     ParseError,
-    ParseResult
+    ParseResult,
+    Style
 } from "./types";
 
 // ---- Builders ----
@@ -101,7 +107,22 @@ export {
     blue,
     magenta,
     cyan,
-    gray
+    gray,
+    no_color_active,
+    style_for_stream,
+    style_with_mode,
+    style_resolve,
+    paint,
+    paint_bold,
+    paint_dim,
+    paint_underline,
+    paint_red,
+    paint_green,
+    paint_yellow,
+    paint_blue,
+    paint_magenta,
+    paint_cyan,
+    paint_gray
 } from "./style";
 
 // ---- Styled diagnostic helpers ----

--- a/capsules/sfn/cli/src/style.sfn
+++ b/capsules/sfn/cli/src/style.sfn
@@ -4,6 +4,16 @@
 // unescaper does not support \xHH escapes, so these functions degrade
 // gracefully to plain text. Once \xHH or char_from_code() support lands,
 // swap the _esc() helper to return the real ESC character.
+//
+// Style policy (issue #792 / 1.3) lives alongside the wrap helpers:
+// `Style` is constructed via `style_for_stream`, `style_with_mode`, or
+// `style_resolve`, and the `paint*` family consults `Style.enabled`
+// to decide whether to apply ANSI codes. The legacy single-arg
+// helpers (`bold`, `red`, …) stay in place — they unconditionally
+// emit plain text today via `_esc()` returning "" — so existing
+// callers keep working while new code threads a `Style` through.
+import { Style } from "./types";
+
 fn _esc() -> string {
     // Returns the ANSI escape prefix. Currently returns empty string
     // because the bootstrap compiler does not support \xHH escapes.
@@ -45,3 +55,122 @@ fn magenta(text: string) -> string { return _ansi_wrap("35", text); }
 fn cyan(text: string) -> string { return _ansi_wrap("36", text); }
 
 fn gray(text: string) -> string { return _ansi_wrap("90", text); }
+
+// ── NO_COLOR / TTY-aware Style (issue #792, proposal §7 Issue 1.3) ────
+//
+// `Style` policy resolution. The current implementation gates colored
+// output on the `NO_COLOR` env var (see https://no-color.org/) and
+// caller-supplied `--color=auto|always|never` modes. TTY detection
+// will join the `"auto"` gate once Sailfin exposes an `isatty`
+// primitive; until then, `"auto"` returns enabled iff `NO_COLOR` is
+// not set in the environment.
+//
+// All policy helpers are pure with respect to their arguments except
+// for the env-var read in `no_color_active`, `style_for_stream`, and
+// `style_with_mode`. `style_resolve` is the fully-pure variant for
+// tests and callers that already have the `NO_COLOR` value from
+// another channel.
+fn _no_color_from_value(raw: string) -> boolean {
+    // Per https://no-color.org/: any non-empty value disables color.
+    return raw.length > 0;
+}
+
+fn no_color_active() -> boolean ![io] {
+    // True iff the `NO_COLOR` environment variable is set to any
+    // non-empty value, per the no-color.org convention.
+    let raw = env.get("NO_COLOR");
+    return _no_color_from_value(raw);
+}
+
+fn _style_disabled(stream: string, mode: string) -> Style {
+    return Style { enabled: false, mode: mode, stream: stream };
+}
+
+fn _style_enabled(stream: string, mode: string) -> Style {
+    return Style { enabled: true, mode: mode, stream: stream };
+}
+
+fn style_for_stream(stream: string) -> Style ![io] {
+    // Build an "auto"-mode Style for the named stream. Disabled when
+    // `NO_COLOR` is set in the environment. The `stream` value is
+    // carried on the result so downstream helpers (e.g. `print_diag`
+    // in issue 1.4) can pick the right output handle.
+    if no_color_active() { return _style_disabled(stream, "auto"); }
+    return _style_enabled(stream, "auto");
+}
+
+fn style_with_mode(stream: string, mode: string) -> Style ![io] {
+    // Build a Style from an explicit `--color=auto|always|never` mode.
+    // `"always"` and `"never"` are honored verbatim; any other value
+    // (including the canonical `"auto"`) falls through to
+    // `style_for_stream`'s environment-aware detection.
+    if mode == "always" { return _style_enabled(stream, "always"); }
+    if mode == "never" { return _style_disabled(stream, "never"); }
+    return style_for_stream(stream);
+}
+
+fn style_resolve(stream: string, mode: string, no_color_value: string) -> Style {
+    // Fully-pure variant of `style_with_mode`. Useful for tests and
+    // for callers that have already resolved `NO_COLOR` through their
+    // own channel (e.g. a wrapper that snapshots env vars at startup).
+    // `no_color_value` is the raw env-var value — an empty string
+    // means "NO_COLOR unset", per the no-color.org convention.
+    if mode == "always" { return _style_enabled(stream, "always"); }
+    if mode == "never" { return _style_disabled(stream, "never"); }
+    if _no_color_from_value(no_color_value) {
+        return _style_disabled(stream, "auto");
+    }
+    return _style_enabled(stream, "auto");
+}
+
+// ── Style-aware wrap helpers ──────────────────────────────────────
+//
+// `paint(s, code, text)` is the building block: when `s.enabled` is
+// false it returns the text unmodified; otherwise it applies the
+// ANSI sequence for `code`. Named convenience helpers below cover
+// the colors that diagnostic rendering (issue 1.4) will use; rarer
+// codes can be reached through `paint` directly.
+fn paint(s: Style, code: string, text: string) -> string {
+    if !s.enabled { return text; }
+    return _ansi_wrap(code, text);
+}
+
+fn paint_bold(s: Style, text: string) -> string {
+    return paint(s, "1", text);
+}
+
+fn paint_dim(s: Style, text: string) -> string {
+    return paint(s, "2", text);
+}
+
+fn paint_underline(s: Style, text: string) -> string {
+    return paint(s, "4", text);
+}
+
+fn paint_red(s: Style, text: string) -> string {
+    return paint(s, "31", text);
+}
+
+fn paint_green(s: Style, text: string) -> string {
+    return paint(s, "32", text);
+}
+
+fn paint_yellow(s: Style, text: string) -> string {
+    return paint(s, "33", text);
+}
+
+fn paint_blue(s: Style, text: string) -> string {
+    return paint(s, "34", text);
+}
+
+fn paint_magenta(s: Style, text: string) -> string {
+    return paint(s, "35", text);
+}
+
+fn paint_cyan(s: Style, text: string) -> string {
+    return paint(s, "36", text);
+}
+
+fn paint_gray(s: Style, text: string) -> string {
+    return paint(s, "90", text);
+}

--- a/capsules/sfn/cli/src/types.sfn
+++ b/capsules/sfn/cli/src/types.sfn
@@ -66,3 +66,22 @@ struct ParseResult {
     matches: Matches;
     error: ParseError;
 }
+
+// Style carries the resolved policy for emitting ANSI escape codes to
+// a given stream. `enabled` is the single gate every style helper
+// consults — when false, the helpers return plain text. `mode`
+// records how the policy was decided so callers can surface it
+// in `--verbose` / debug output (`"auto"` | `"always"` | `"never"`).
+// `stream` is the stream name the style targets (`"stdout"` |
+// `"stderr"`) — kept on the struct so callers don't have to thread
+// it separately when wiring `print_diag` (issue #793 / 1.4).
+//
+// `Style` values are constructed via `style_for_stream`,
+// `style_with_mode`, or `style_resolve` in `style.sfn`. The struct
+// is intentionally a plain value type with no internal state so it
+// is safe to pass through the call stack without ownership concerns.
+struct Style {
+    enabled: boolean;
+    mode: string;
+    stream: string;
+}

--- a/capsules/sfn/cli/tests/style_test.sfn
+++ b/capsules/sfn/cli/tests/style_test.sfn
@@ -1,0 +1,171 @@
+// Tests for sfn/cli — NO_COLOR / TTY-aware Style policy (issue #792).
+//
+// Covers:
+//   - `Style` struct exported via the capsule barrel.
+//   - `no_color_active()` agrees with the running env.
+//   - `style_for_stream(stream)` returns enabled iff `NO_COLOR` is unset.
+//   - `style_with_mode` honors `--color=always|never`; falls through
+//     to env detection for `"auto"` and unknown modes.
+//   - `style_resolve` (pure variant) honors all three modes with an
+//     explicit `NO_COLOR` value, independent of the running env.
+//   - Style-aware `paint*` helpers emit plain text when disabled and
+//     either ANSI (when `_esc()` is non-empty) or plain text (when
+//     `_esc()` is empty, the bootstrap default) when enabled.
+//
+// The tests are written to pass regardless of whether the host env
+// has `NO_COLOR` set — env-sensitive assertions branch on the actual
+// runtime value, while the bulk of coverage exercises the pure
+// `style_resolve` entry point so the contract is locked even when
+// the runner env varies. The `Verification` block on the issue
+// invokes this file once with `NO_COLOR=1` and once without to
+// confirm both branches in practice.
+import {
+    Style,
+    bold,
+    no_color_active,
+    paint,
+    paint_bold,
+    paint_dim,
+    paint_red,
+    paint_yellow,
+    red,
+    style_for_stream,
+    style_resolve,
+    style_with_mode
+} from "../src/mod";
+
+// ── Style struct shape ────────────────────────────────────────────
+test "style: Style fields default to disabled-stderr-auto via style_resolve" {
+    let s = style_resolve("stderr", "auto", "1");
+    assert s.enabled == false;
+    assert strings_equal(s.mode, "auto");
+    assert strings_equal(s.stream, "stderr");
+}
+
+// ── style_resolve: --color=never always wins ─────────────────────
+test "style: style_resolve(never) disables regardless of NO_COLOR=unset" {
+    let s = style_resolve("stdout", "never", "");
+    assert s.enabled == false;
+    assert strings_equal(s.mode, "never");
+    assert strings_equal(s.stream, "stdout");
+}
+
+test "style: style_resolve(never) disables regardless of NO_COLOR=set" {
+    let s = style_resolve("stderr", "never", "1");
+    assert s.enabled == false;
+    assert strings_equal(s.mode, "never");
+}
+
+// ── style_resolve: --color=always always wins ────────────────────
+test "style: style_resolve(always) enables regardless of NO_COLOR=set" {
+    let s = style_resolve("stderr", "always", "1");
+    assert s.enabled == true;
+    assert strings_equal(s.mode, "always");
+    assert strings_equal(s.stream, "stderr");
+}
+
+test "style: style_resolve(always) enables regardless of NO_COLOR=unset" {
+    let s = style_resolve("stdout", "always", "");
+    assert s.enabled == true;
+    assert strings_equal(s.mode, "always");
+}
+
+// ── style_resolve: --color=auto defers to NO_COLOR ───────────────
+test "style: style_resolve(auto) disables when NO_COLOR=1" {
+    let s = style_resolve("stderr", "auto", "1");
+    assert s.enabled == false;
+    assert strings_equal(s.mode, "auto");
+}
+
+test "style: style_resolve(auto) enables when NO_COLOR is empty" {
+    let s = style_resolve("stderr", "auto", "");
+    assert s.enabled == true;
+    assert strings_equal(s.mode, "auto");
+}
+
+test "style: style_resolve treats any non-empty NO_COLOR as set" {
+    // Per https://no-color.org/: any non-empty value disables color.
+    let s_zero = style_resolve("stderr", "auto", "0");
+    assert s_zero.enabled == false;
+    let s_no = style_resolve("stderr", "auto", "no");
+    assert s_no.enabled == false;
+}
+
+test "style: style_resolve falls through to auto for unknown modes" {
+    // Unknown --color= values shouldn't crash; behave like "auto".
+    let s = style_resolve("stderr", "rainbow", "1");
+    assert s.enabled == false;
+    assert strings_equal(s.mode, "auto");
+}
+
+// ── stream is preserved verbatim ─────────────────────────────────
+test "style: style_resolve preserves arbitrary stream label" {
+    let s = style_resolve("custom", "always", "");
+    assert strings_equal(s.stream, "custom");
+}
+
+// ── paint* helpers: disabled style emits plain text ──────────────
+test "style: paint returns plain text when style.enabled is false" {
+    let s = style_resolve("stderr", "never", "");
+    assert strings_equal(paint(s, "31", "hello"), "hello");
+    assert strings_equal(paint_bold(s, "x"), "x");
+    assert strings_equal(paint_red(s, "err"), "err");
+    assert strings_equal(paint_dim(s, "y"), "y");
+    assert strings_equal(paint_yellow(s, "warn"), "warn");
+}
+
+// ── paint* helpers: enabled style applies ANSI (when supported) ──
+//
+// The bootstrap `_esc()` returns "" today, so even an enabled Style
+// produces plain text. We assert the output equals what `_ansi_wrap`
+// would produce for the same code — when ESC eventually becomes a
+// real character, this same assertion exercises the ANSI path
+// without test changes. The legacy single-arg `bold(text)` / `red(text)`
+// helpers route through the same `_ansi_wrap` and so produce the
+// identical output, which is what we compare against.
+test "style: paint with enabled style matches legacy bold output" {
+    let s = style_resolve("stderr", "always", "");
+    assert strings_equal(paint_bold(s, "hello"), bold("hello"));
+    assert strings_equal(paint_red(s, "err"), red("err"));
+}
+
+// ── env-sensitive: no_color_active agrees with running env ───────
+//
+// These three tests branch on the actual `NO_COLOR` value so the
+// same suite passes whether the runner sets it or not. The issue's
+// verification block runs the suite once in each state.
+test "style: no_color_active reflects NO_COLOR env" ![io] {
+    let raw = env.get("NO_COLOR");
+    let active = no_color_active();
+    if raw.length > 0 { assert active == true; } else { assert active == false; }
+}
+
+test "style: style_for_stream returns disabled when NO_COLOR is set" ![io] {
+    let raw = env.get("NO_COLOR");
+    let s = style_for_stream("stderr");
+    assert strings_equal(s.mode, "auto");
+    assert strings_equal(s.stream, "stderr");
+    if raw.length > 0 { assert s.enabled == false; } else {
+        assert s.enabled == true;
+    }
+}
+
+test "style: style_with_mode(auto) matches style_for_stream" ![io] {
+    let auto = style_with_mode("stdout", "auto");
+    let direct = style_for_stream("stdout");
+    assert auto.enabled == direct.enabled;
+    assert strings_equal(auto.mode, direct.mode);
+    assert strings_equal(auto.stream, direct.stream);
+}
+
+test "style: style_with_mode(always) ignores env" ![io] {
+    let s = style_with_mode("stderr", "always");
+    assert s.enabled == true;
+    assert strings_equal(s.mode, "always");
+}
+
+test "style: style_with_mode(never) ignores env" ![io] {
+    let s = style_with_mode("stderr", "never");
+    assert s.enabled == false;
+    assert strings_equal(s.mode, "never");
+}


### PR DESCRIPTION
## Summary

Adds a `Style` struct plus stream-aware constructors so `sfn/cli`
consumers (and the compiler later, in Phase 2/3 of the CLI
Modularization Epic) can produce ANSI-styled output that automatically
degrades to plain text when `NO_COLOR` is set or the caller passes
`--color=never`. Groundwork for `print_diag` (issue #793, proposal §7
Issue 1.4).

- `Style { enabled, mode, stream }` in `capsules/sfn/cli/src/types.sfn`.
- `style_for_stream(stream) [io]` — "auto" mode, gated by `NO_COLOR`.
- `style_with_mode(stream, mode) [io]` — honors `--color=auto|always|never`.
- `style_resolve(stream, mode, no_color_value)` — pure variant for
  tests and callers that already snapshotted env state.
- `no_color_active() [io]` — `NO_COLOR` probe per
  [no-color.org](https://no-color.org/).
- `paint(s, code, text)` + `paint_bold` / `paint_red` / etc. —
  style-aware wrappers that emit plain text when `style.enabled` is
  false.
- Legacy single-arg helpers (`bold`, `red`, …) untouched; they already
  emit plain text via the bootstrap `_esc() == ""` stub.
- New `capsules/sfn/cli/tests/style_test.sfn` covers both `NO_COLOR`
  env states and the three `--color` modes (17 tests).

TTY detection joins the "auto" gate once Sailfin exposes an `isatty`
primitive; today "auto" trusts `NO_COLOR` + caller-explicit modes.

Closes #792

## Acceptance Criteria

- [x] `Style` struct, `style_for_stream`, `no_color_active` exported via `mod.sfn`.
- [x] `style_for_stream("stderr")` returns a disabled style when `NO_COLOR` is set.
- [x] Existing color helpers emit plain text when the active `Style` is disabled (via `paint*` family; legacy single-arg helpers already plain-text via the bootstrap `_esc()` stub).
- [x] `--color=never` forces disabled; `--color=always` forces enabled; `--color=auto` defers to `NO_COLOR` detection.
- [x] New `tests/style_test.sfn` covers both env states and the three `--color` modes.
- [x] `make compile` succeeds.
- [x] CLI capsule tests pass (`cli_test.sfn`, `parser_test.sfn`, `style_test.sfn`).
- [x] `sfn fmt --check capsules/sfn/cli/` clean.

## Verification

```bash
ulimit -v 8388608 && make compile
# → [compile] built build/native/sailfin

ulimit -v 8388608 && NO_COLOR=1 timeout 60 build/native/sailfin test capsules/sfn/cli/tests/style_test.sfn
# → PASS (all 17 tests passed)

ulimit -v 8388608 && timeout 60 build/native/sailfin test capsules/sfn/cli/tests/style_test.sfn
# → PASS (all 17 tests passed)

ulimit -v 8388608 && timeout 60 build/native/sailfin test capsules/sfn/cli/tests/cli_test.sfn
# → PASS (all 47 tests passed)

ulimit -v 8388608 && timeout 60 build/native/sailfin test capsules/sfn/cli/tests/parser_test.sfn
# → PASS (all 15 tests passed)

ulimit -v 8388608 && timeout 1800 make test-capsules
# → ═══ capsules: 15/15 passed, 0 failed ═══

ulimit -v 8388608 && timeout 30 build/native/sailfin fmt --check capsules/sfn/cli/
# → clean (no output)
```

## Files Changed

- `capsules/sfn/cli/src/types.sfn` — `Style` struct.
- `capsules/sfn/cli/src/style.sfn` — `no_color_active`, `style_for_stream`, `style_with_mode`, `style_resolve`, `paint*` family.
- `capsules/sfn/cli/src/mod.sfn` — re-export new public surface.
- `capsules/sfn/cli/tests/style_test.sfn` (NEW) — 17 tests covering struct shape, mode resolution, env interaction, and style-aware wrap helpers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DjBYXLeLvqDVkZJJcgyx4q)_