### PR TITLE
refactor(cli): port test pass/fail + signal-kill retry into handle_test_command

### DIFF
--- a/compiler/src/cli_commands.sfn
+++ b/compiler/src/cli_commands.sfn
@@ -1048,10 +1048,26 @@ fn handle_test_command(args: string[], runtime_root: string) -> int ![io, clock]
         // through immediately. `SAILFIN_TEST_RETRY=0` opts out for
         // flake-vs-real-failure investigations.
         if _should_retry_test(run_rc, retries_disabled) {
-            let test_basename = _package_basename(path);
-            print("[test] RETRY: " + test_basename + " (exit code "
-                + number_to_string(run_rc)
-                + ", retrying once)");
+            // Banner is a human-mode artifact — the `--json` stream
+            // must stay pure jsonl so consumers don't have to filter
+            // out interleaved decoration. The retry itself still
+            // runs in JSON mode; we just don't announce it.
+            if !json_output {
+                let test_basename = _package_basename(path);
+                print("[test] RETRY: " + test_basename + " (exit code "
+                    + number_to_string(run_rc)
+                    + ", retrying once)");
+            }
+            // Clear any record the first attempt may have written so
+            // the post-retry `_consume_assert_failure_record` only
+            // sees what the retry produced. A 137/139 process usually
+            // dies before `sailfin_assert_fail` writes a record, but
+            // a test that asserts and *then* segfaults during teardown
+            // would otherwise leave a stale record that gets
+            // misattributed to the retry attempt's outcome.
+            if fs.exists(fail_record_path) {
+                fs.deleteFile(fail_record_path);
+            }
             run_rc = process.run(["env", "SAILFIN_TEST_SCRATCH=" + scratch_root, exe_path]);
         }
         if trace_runner {

--- a/compiler/src/cli_commands.sfn
+++ b/compiler/src/cli_commands.sfn
@@ -668,6 +668,56 @@ fn _trj_decode_skipped(packed: int) -> int {
     return p;
 }
 
+// Retry policy for the test-exec phase (per-test child process).
+//
+// History: `scripts/run_native_test.sh` previously implemented two
+// retry classes — a regex-classified I/O-pressure retry that
+// matched on stdout substrings ("no such file or directory", "link
+// failed", ...) and a signal-kill retry for exit codes 137/139.
+// Issue #364 deleted the regex retry (the structured assert-fail
+// record gave the runner an exit-code-driven failure path with
+// typed attribution, and the substring match was masking real
+// compile failures as flakes). The signal-kill retry survives —
+// transient 137 (OOM-SIGKILL) and 139 (SIGSEGV) surface under
+// sustained CI memory pressure during the seedcheck phase of
+// `make check`.
+//
+// Ported into the compiler so `sfn test` returns the correct
+// exit code with no bash post-processing (issue #845, parent
+// epic #840 phase 1.1). `SAILFIN_TEST_RETRY=0` disables retries
+// entirely for flake-vs-real-failure investigations during perf
+// work.
+enum RetryPolicy {
+    None,
+    SignalKill
+}
+
+fn _classify_test_retry(exit_code: int) -> RetryPolicy {
+    if exit_code == 137 { return RetryPolicy.SignalKill(); }
+    if exit_code == 139 { return RetryPolicy.SignalKill(); }
+    return RetryPolicy.None();
+}
+
+// Mirrors the bash `[ "${SAILFIN_TEST_RETRY:-1}" != "0" ]` gate:
+// retries are enabled by default, disabled only when the env var
+// is explicitly set to "0". Any other value (unset, "1", "true",
+// "false", arbitrary strings) leaves retries enabled — the bash
+// gate was a string-equality test against "0", not a boolean
+// parse, so this matches the prior wrapper's semantics exactly.
+fn _test_retries_disabled() -> boolean ![io] {
+    return _get_env_cmd("SAILFIN_TEST_RETRY") == "0";
+}
+
+fn _should_retry_test(exit_code: int, retries_disabled: boolean) -> boolean {
+    if retries_disabled { return false; }
+    let policy = _classify_test_retry(exit_code);
+    match policy {
+        RetryPolicy.None => return false,
+        RetryPolicy.SignalKill => return true
+    }
+    return false;
+}
+
 fn handle_test_command(args: string[], runtime_root: string) -> int ![io, clock] {
     // Flag parser: `--json` is the only recognised flag for now.
     // Positional args carry the optional `path` argument; preserves
@@ -886,6 +936,11 @@ fn handle_test_command(args: string[], runtime_root: string) -> int ![io, clock]
 
     let runner_start_ms = monotonic_millis();
 
+    // Read the retry gate once before the loop — env var lookups
+    // shell out via popen, and the gate is invariant for the
+    // duration of the invocation.
+    let retries_disabled = _test_retries_disabled();
+
     let mut total_passed: int = 0;
     let mut total_failed: int = 0;
     let mut total_skipped: int = 0;
@@ -933,6 +988,12 @@ fn handle_test_command(args: string[], runtime_root: string) -> int ![io, clock]
                 index += 1;
                 continue;
             }
+            // FAIL banner on compile failure: the bash wrapper
+            // surfaced this as `[test] FAIL: <basename> (exit code 1,
+            // ...)`. Emit the same shape so callers parsing test
+            // output (CI log scrubbers, human readers) see consistent
+            // attribution regardless of which stage failed.
+            print("[test] FAIL: " + _package_basename(path) + " (exit code 1)");
             exit_test_runner_mode();
             return 1;
         }
@@ -955,6 +1016,14 @@ fn handle_test_command(args: string[], runtime_root: string) -> int ![io, clock]
                 index += 1;
                 continue;
             }
+            // FAIL banner on link failure (issue #845). Same rationale
+            // as the compile-failure banner above — keep `[test] FAIL`
+            // attribution consistent across every failure stage so
+            // tooling (CI scrubbers, human readers, future grep-based
+            // log audits) sees one shape.
+            print("[test] FAIL: " + _package_basename(path) + " (exit code "
+                + number_to_string(link_rc)
+                + ")");
             exit_test_runner_mode();
             return link_rc;
         }
@@ -968,7 +1037,23 @@ fn handle_test_command(args: string[], runtime_root: string) -> int ![io, clock]
         if fs.exists(fail_record_path) { fs.deleteFile(fail_record_path); }
 
         if trace_runner { print.err("test runner: exec start"); }
-        let run_rc = process.run(["env", "SAILFIN_TEST_SCRATCH=" + scratch_root, exe_path]);
+        let mut run_rc = process.run(["env", "SAILFIN_TEST_SCRATCH="
+            + scratch_root, exe_path]);
+        // Signal-kill retry (ported from `scripts/run_native_test.sh`
+        // by issue #845). 137 (OOM-SIGKILL) / 139 (SIGSEGV) are
+        // transient under sustained CI memory pressure on the
+        // seedcheck phase of `make check`; retry once before
+        // declaring failure. Other classes — including timeouts
+        // (124), normal asserts (1), and unrelated signals — fall
+        // through immediately. `SAILFIN_TEST_RETRY=0` opts out for
+        // flake-vs-real-failure investigations.
+        if _should_retry_test(run_rc, retries_disabled) {
+            let test_basename = _package_basename(path);
+            print("[test] RETRY: " + test_basename + " (exit code "
+                + number_to_string(run_rc)
+                + ", retrying once)");
+            run_rc = process.run(["env", "SAILFIN_TEST_SCRATCH=" + scratch_root, exe_path]);
+        }
         if trace_runner {
             print.err("test runner: exec done (exit=" + number_to_string(run_rc)
                 + ")");
@@ -996,6 +1081,20 @@ fn handle_test_command(args: string[], runtime_root: string) -> int ![io, clock]
                 index += 1;
                 continue;
             }
+            // FAIL banner (issue #845): the bash wrapper used to emit
+            // this line; the compiler emits it now so `sfn test` is
+            // self-contained. The compiler's structured `test failed:`
+            // detail line follows for editor-hyperlinkable assertion
+            // attribution. The bash `grep -nE ... <<< "$output"`
+            // diagnostic excerpt has no in-process analog (we don't
+            // buffer the child's stdout/stderr), but the structured
+            // `test runner: compile failed`, `link failed`, and
+            // `test failed:` lines already carry the per-step
+            // attribution the grep heuristic was reconstructing
+            // post-hoc.
+            print("[test] FAIL: " + _package_basename(path) + " (exit code "
+                + number_to_string(run_rc)
+                + ")");
             if failure.present {
                 print("test failed: " + _format_assert_failure(path, failure));
             } else { print("test failed: " + path); }
@@ -1008,6 +1107,12 @@ fn handle_test_command(args: string[], runtime_root: string) -> int ![io, clock]
             total_passed += _trj_decode_passed(packed);
             total_failed += _trj_decode_failed(packed);
             total_skipped += _trj_decode_skipped(packed);
+        } else {
+            // PASS banner (issue #845): matches the bash wrapper's
+            // `[test] PASS: <basename>` output exactly. Emitted only
+            // on the human path; the JSON path emits structured
+            // per-test events instead.
+            print("[test] PASS: " + _package_basename(path));
         }
         // Phase 5a: rewind arena scratch back to the per-test
         // mark. Per-iteration allocations (parsed test AST,

--- a/scripts/run_native_test.sh
+++ b/scripts/run_native_test.sh
@@ -11,7 +11,6 @@ set -euo pipefail
 
 COMPILER="$1"
 TEST_FILE="$2"
-BASENAME="$(basename "$TEST_FILE")"
 
 # Per-invocation scratch dir, exported via `SAILFIN_TEST_SCRATCH` so
 # the test command + capsule resolver write `test.ll`, the linked
@@ -107,67 +106,24 @@ else
     TIMEOUT_CMD=""
 fi
 
-_run_once() {
-    if [ -n "$TIMEOUT_CMD" ]; then
-        output=$("$TIMEOUT_CMD" "$TIMEOUT" "$COMPILER" test "$TEST_FILE" 2>&1) && RC_INNER=0 || RC_INNER=$?
-    else
-        output=$("$COMPILER" test "$TEST_FILE" 2>&1) && RC_INNER=0 || RC_INNER=$?
-    fi
-}
-
-_run_once
-
-# Retry policy. Issue #364 deleted the regex-classified retry that
-# matched on stdout patterns like "no such file or directory" /
-# "link failed" — those patterns are now redundant because the
-# structured assert-fail record (see
-# `runtime/native/src/sailfin_runtime.c:sailfin_assert_fail` and
-# `compiler/src/cli_commands.sfn:_consume_assert_failure_record`)
-# gives the runner an exit-code-driven failure path with typed
-# attribution; transient I/O flakes still surface as a non-zero
-# exit, but masking them via `case "$output"` regexes was hiding
-# real compile failures and producing flake-like behavior.
+# Issue #845 (parent epic #840 phase 1.1): the per-test pass/fail
+# policy (signal-kill retry, FAIL/PASS banner, exit code) was ported
+# from this wrapper into `handle_test_command` in
+# `compiler/src/cli_commands.sfn`. The compiler now emits the
+# `[test] PASS: <basename>` / `[test] FAIL: <basename> (exit code N)`
+# banners directly, honours `SAILFIN_TEST_RETRY=0`, and retries
+# 137/139 in-process; the prior `grep -nE ... <<< "$output"`
+# diagnostic excerpt is superseded by the compiler's structured
+# `test runner: compile failed`, `link failed`, and `test failed:`
+# lines, which carry the per-stage attribution the grep heuristic
+# was reconstructing post-hoc.
 #
-# What stays: signal-kill retry (137 OOM, 139 segfault). These are
-# transient under sustained CI memory pressure during the
-# seedcheck phase of `make check`, and they don't depend on stdout
-# inspection. Override with SAILFIN_TEST_RETRY=0 to disable
-# retries entirely (useful when diagnosing flake vs real failure
-# during perf work).
-if [ "${SAILFIN_TEST_RETRY:-1}" != "0" ]; then
-    if [ $RC_INNER -eq 137 ] || [ $RC_INNER -eq 139 ]; then
-        echo "[test] RETRY: $BASENAME (exit code $RC_INNER, retrying once)"
-        _run_once
-    fi
+# What this wrapper still owns: scratch-dir setup with on-failure
+# preservation (lines above), and the outer `timeout` wall-clock
+# cap. The whole script is scheduled for deletion in phase 1.7
+# after the Makefile loop collapse in 1.2.
+if [ -n "$TIMEOUT_CMD" ]; then
+    "$TIMEOUT_CMD" "$TIMEOUT" "$COMPILER" test "$TEST_FILE"
+else
+    "$COMPILER" test "$TEST_FILE"
 fi
-
-if [ $RC_INNER -ne 0 ]; then
-    echo "[test] FAIL: $BASENAME (exit code $RC_INNER, timeout=$TIMEOUT)"
-    # When a test fails, the error of interest is rarely in the last 10 lines
-    # — link errors land 100+ lines back, behind a wall of clang's
-    # `-Woverride-module` warnings. Surface every line that smells like an
-    # error or signal-shaped cause (clang/ld diagnostics, resolver retries,
-    # missing files, OOM/abort), bounded to keep the CI log readable. The
-    # tail of the output still prints last so failure summaries that rely
-    # on the final lines (e.g. assertion messages) are not lost.
-    diag="$(grep -nE '^(clang(-[0-9]+)?|sh|/usr/bin/ld|ld)\.?: |error:|undefined reference| no such file|Killed|Aborted|abort\(\)|munmap_chunk|capsule-resolver:|\[emit retry\]|\[cache (copy-failed|store-failed|invalid-key)\]|test runner: compile failed|link failed|test failed:' <<< "$output" | head -40)"
-    if [ -n "$diag" ]; then
-        echo "[test] -- diagnostic excerpt --"
-        echo "$diag"
-        echo "[test] -- /diagnostic excerpt --"
-    fi
-    echo "[test] -- last 10 lines of output --"
-    echo "$output" | tail -10
-    exit 1
-fi
-
-# Issue #364: pass/fail is decided by exit code alone. The previous
-# "grep stdout for fail|panic|error" heuristic produced false
-# positives whenever a test legitimately printed those words (e.g. a
-# test that prints the literal word "panic" as part of its
-# assertions about diagnostic output). The compiler now writes a
-# structured AssertFailure record on `assert false`, and the test
-# runner inside `compiler/src/cli_commands.sfn` reads it before
-# returning a non-zero exit code — so a clean exit IS a clean test.
-echo "[test] PASS: $BASENAME"
-exit 0


### PR DESCRIPTION
## Summary
- Add a typed `RetryPolicy` enum in `compiler/src/cli_commands.sfn` capturing the surviving signal-kill (137/139) retry class. Honours `SAILFIN_TEST_RETRY=0` for flake-vs-real-failure investigations.
- Port the per-test `[test] PASS: <basename>` / `[test] FAIL: <basename> (exit code N)` banner from `scripts/run_native_test.sh` into `handle_test_command` — emitted on the human (non-`--json`) path at every failure stage (compile, link, exec) and on success.
- Drop the bash retry, diagnostic-excerpt grep, and PASS/FAIL echo blocks. The bash diagnostic excerpt is superseded by the compiler's structured `test runner: compile failed`, `link failed`, and `test failed:` lines, which already carry the per-stage attribution the grep heuristic was reconstructing post-hoc.

The wrapper still owns scratch-dir setup and the outer `timeout` wall-clock cap; phase 1.7 deletes the script entirely after the Makefile loop collapse in 1.2.

Closes #845

## Acceptance Criteria
- [x] `sfn test path/to/x_test.sfn` returns non-zero on assertion failure with no bash post-processing of its output.
- [x] The signal-kill (137/139) retry is represented as a typed `RetryPolicy` enum in `cli_commands.sfn`, not a bash conditional.
- [x] The retry+grep blocks are removed from `scripts/run_native_test.sh`.
- [x] `make compile` passes.
- [x] `make test` passes.
- [x] `sfn fmt --check` clean on touched `.sfn` files.

## Verification
```bash
$ ulimit -v 8388608 && make compile && make test
═══ unit: 104/104 passed, 0 failed ═══
═══ integration: 28/28 passed, 0 failed ═══
═══ e2e: 79/79 passed, 0 failed ═══
═══ capsules: 14/14 passed, 0 failed ═══

# Deliberately-failing test exits non-zero with the in-compiler FAIL banner:
$ ulimit -v 8388608 && timeout 60 build/native/sailfin test /tmp/failing_test.sfn
  RUN  deliberatelyfails
[value_error] assertion failed
[test] FAIL: failing_test.sfn (exit code 134)
test failed: /tmp/failing_test.sfn:2:5: assertion failed
exit=134

# Passing test emits the in-compiler PASS banner:
$ ulimit -v 8388608 && timeout 60 build/native/sailfin test /tmp/passing_test.sfn
  RUN  passes
  PASS  (all 1 tests passed)
[test] PASS: passing_test.sfn
exit=0

$ ulimit -v 8388608 && timeout 60 build/native/sailfin fmt --check compiler/src/cli_commands.sfn
# (no output, exit 0)
```

## Files Changed
- `compiler/src/cli_commands.sfn` — new `RetryPolicy` enum + `_classify_test_retry` / `_test_retries_disabled` / `_should_retry_test` helpers; `handle_test_command` reads the retry gate once, retries 137/139 around the test-exec `process.run`, and emits `[test] PASS: <basename>` / `[test] FAIL: <basename> (exit code N)` per file on the human path (at compile-fail, link-fail, and exec-fail stages).
- `scripts/run_native_test.sh` — delete retry block, diagnostic-excerpt grep, and PASS/FAIL echo; the wrapper now exec's the compiler directly (with the existing `timeout` cap) and propagates its exit code via `set -e`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZhz6Xd4QiLHq9QRPcnLAS)_