### PR TITLE
feat(cli): add flag_required marker and missing-required diagnostic

### DIFF
--- a/capsules/sfn/cli/src/builder.sfn
+++ b/capsules/sfn/cli/src/builder.sfn
@@ -35,7 +35,8 @@ fn flag(long_name: string, description: string) -> Flag {
         long_name: long_name,
         short_name: "",
         description: description,
-        takes_value: false
+        takes_value: false,
+        required: false
     };
 }
 
@@ -45,7 +46,8 @@ fn flag_value(long_name: string, description: string) -> Flag {
         long_name: long_name,
         short_name: "",
         description: description,
-        takes_value: true
+        takes_value: true,
+        required: false
     };
 }
 
@@ -55,7 +57,8 @@ fn flag_short(long_name: string, short_name: string, description: string) -> Fla
         long_name: long_name,
         short_name: short_name,
         description: description,
-        takes_value: false
+        takes_value: false,
+        required: false
     };
 }
 
@@ -65,7 +68,22 @@ fn flag_value_short(long_name: string, short_name: string, description: string) 
         long_name: long_name,
         short_name: short_name,
         description: description,
-        takes_value: true
+        takes_value: true,
+        required: false
+    };
+}
+
+fn flag_required(f: Flag) -> Flag {
+    // Mark a flag as required. When the flag is absent from argv,
+    // `parse()` returns `ParseError { kind: "missing_required",
+    // flag_name: f.long_name }`. Help output annotates the flag as
+    // `(required)`. Chainable on any flag constructor.
+    return Flag {
+        long_name: f.long_name,
+        short_name: f.short_name,
+        description: f.description,
+        takes_value: f.takes_value,
+        required: true
     };
 }
 

--- a/capsules/sfn/cli/src/help.sfn
+++ b/capsules/sfn/cli/src/help.sfn
@@ -82,7 +82,9 @@ fn _format_help(cmd: Command, program: string) -> string {
         if fi >= cmd.flags.length { break; }
         let f = cmd.flags[fi];
         let label = _flag_label(f);
-        out = out + "  " + _pad(label, flag_width) + f.description + "\n";
+        out = out + "  " + _pad(label, flag_width) + f.description;
+        if f.required { out = out + " (required)"; }
+        out = out + "\n";
         fi += 1;
     }
     // Built-in flags.

--- a/capsules/sfn/cli/src/mod.sfn
+++ b/capsules/sfn/cli/src/mod.sfn
@@ -67,6 +67,7 @@ export {
     flag_value,
     flag_short,
     flag_value_short,
+    flag_required,
     command,
     with_version,
     with_arg,

--- a/capsules/sfn/cli/src/parser.sfn
+++ b/capsules/sfn/cli/src/parser.sfn
@@ -147,6 +147,20 @@ fn parse(cmd: Command, argv: string[]) -> ParseResult {
         pos_idx += 1;
     }
 
+    // Validate required flags. The kind `"missing_required"` is reused
+    // (per Issue #797 contract); callers disambiguate via `flag_name`
+    // (set for flag failures) vs `arg_name` (set for positional ones).
+    let mut rfi: int = 0;
+    loop {
+        if rfi >= active.flags.length { break; }
+        let rf = active.flags[rfi];
+        if rf.required && !_flag_seen(fl_names, rf.long_name) {
+            return _err_result(cmd.name, subcmd_name, pos_names, pos_values, fl_names, fl_values, fl_present, "missing_required", _with_hint(cmd.name, subcmd_name, "error: missing required flag --"
+                + rf.long_name), rf.long_name, "");
+        }
+        rfi += 1;
+    }
+
     let matches = Matches {
         command_name: cmd.name,
         subcommand_name: subcmd_name,
@@ -255,7 +269,8 @@ fn _find_flag_long(cmd: Command, name: string) -> Flag {
         long_name: "",
         short_name: "",
         description: "",
-        takes_value: false
+        takes_value: false,
+        required: false
     };
 }
 
@@ -272,7 +287,8 @@ fn _find_flag_short(cmd: Command, name: string) -> Flag {
         long_name: "",
         short_name: "",
         description: "",
-        takes_value: false
+        takes_value: false,
+        required: false
     };
 }
 
@@ -288,6 +304,16 @@ fn _resolve_active(cmd: Command, subcmd_name: string) -> Command {
         i += 1;
     }
     return cmd;
+}
+
+fn _flag_seen(fl_names: string[], long_name: string) -> boolean {
+    let mut i: int = 0;
+    loop {
+        if i >= fl_names.length { break; }
+        if strings_equal(fl_names[i], long_name) { return true; }
+        i += 1;
+    }
+    return false;
 }
 
 fn _help_hint(root_name: string, subcmd_name: string) -> string {

--- a/capsules/sfn/cli/src/types.sfn
+++ b/capsules/sfn/cli/src/types.sfn
@@ -14,6 +14,7 @@ struct Flag {
     short_name: string;
     description: string;
     takes_value: boolean;
+    required: boolean;
 }
 
 struct Command {
@@ -47,7 +48,9 @@ struct Matches {
 // `run()` formats the help/version output itself).
 //
 // `flag_name` / `arg_name` carry the offending name when applicable,
-// otherwise empty.
+// otherwise empty. `"missing_required"` is reused for both omitted
+// required positionals (with `arg_name` set) and omitted required
+// flags marked via `flag_required` (with `flag_name` set).
 struct ParseError {
     kind: string;
     message: string;

--- a/capsules/sfn/cli/tests/required_flag_test.sfn
+++ b/capsules/sfn/cli/tests/required_flag_test.sfn
@@ -1,0 +1,145 @@
+// Tests for `flag_required` — Issue #797 (Phase 1 of the CLI
+// Modularization Epic, #351).
+//
+// Covers the chainable `flag_required` marker, the parser's
+// `missing_required` diagnostic for absent required flags, and the
+// `(required)` annotation in rendered help output.
+import {
+    command,
+    flag,
+    flag_required,
+    flag_short,
+    flag_value,
+    flag_value_short,
+    get_or,
+    has_flag,
+    help,
+    parse,
+    with_flag
+} from "../src/mod";
+
+fn _contains(text: string, needle: string) -> boolean {
+    if needle.length > text.length { return false; }
+    let limit = text.length - needle.length;
+    let mut i: int = 0;
+    loop {
+        if i > limit { break; }
+        if strings_equal(substring(text, i, i + needle.length), needle) {
+            return true;
+        }
+        i += 1;
+    }
+    return false;
+}
+
+// ---- Builder ----
+test "flag_required: marker sets required and preserves other fields" {
+    let f = flag_required(flag_short("verbose", "v", "Verbose output"));
+    assert strings_equal(f.long_name, "verbose");
+    assert strings_equal(f.short_name, "v");
+    assert strings_equal(f.description, "Verbose output");
+    assert f.takes_value == false;
+    assert f.required == true;
+}
+
+test "flag_required: default-constructed flags are not required" {
+    let f = flag("verbose", "Verbose output");
+    assert f.required == false;
+}
+
+test "flag_required: chainable on flag_value" {
+    let f = flag_required(flag_value("output", "Output path"));
+    assert strings_equal(f.long_name, "output");
+    assert f.takes_value == true;
+    assert f.required == true;
+}
+
+test "flag_required: chainable on flag_value_short" {
+    let f = flag_required(flag_value_short("output", "o", "Output path"));
+    assert strings_equal(f.short_name, "o");
+    assert f.takes_value == true;
+    assert f.required == true;
+}
+
+// ---- Parser: present ----
+test "parse: required boolean flag present yields ok" {
+    let cmd = with_flag(command("app", "desc"), flag_required(flag("force", "Force")));
+    let argv: string[] = ["app", "--force"];
+    let r = parse(cmd, argv);
+    assert r.ok == true;
+    assert strings_equal(r.error.kind, "ok");
+    assert has_flag(r.matches, "force") == true;
+}
+
+test "parse: required value flag present yields ok" {
+    let cmd = with_flag(command("app", "desc"), flag_required(flag_value("output", "Output")));
+    let argv: string[] = ["app", "--output", "out.txt"];
+    let r = parse(cmd, argv);
+    assert r.ok == true;
+    assert strings_equal(r.error.kind, "ok");
+}
+
+// ---- Parser: absent ----
+test "parse: required flag absent yields missing_required with flag_name" {
+    let cmd = with_flag(command("app", "desc"), flag_required(flag("force", "Force")));
+    let argv: string[] = ["app"];
+    let r = parse(cmd, argv);
+    assert r.ok == false;
+    assert strings_equal(r.error.kind, "missing_required");
+    assert strings_equal(r.error.flag_name, "force");
+    assert strings_equal(r.error.arg_name, "");
+    assert strings_equal(r.error.message, "error: missing required flag --force\nrun 'app --help' for usage");
+}
+
+test "parse: required value flag absent yields missing_required" {
+    let cmd = with_flag(command("app", "desc"), flag_required(flag_value("output", "Output")));
+    let argv: string[] = ["app"];
+    let r = parse(cmd, argv);
+    assert r.ok == false;
+    assert strings_equal(r.error.kind, "missing_required");
+    assert strings_equal(r.error.flag_name, "output");
+}
+
+test "parse: non-required flag absent stays ok" {
+    let cmd = with_flag(command("app", "desc"), flag("verbose", "Verbose"));
+    let argv: string[] = ["app"];
+    let r = parse(cmd, argv);
+    assert r.ok == true;
+}
+
+test "parse: required flag absent — get_or default does NOT satisfy required" {
+    // Even though `get_or` would return the caller's default value for
+    // an absent flag, `parse()` rejects the input before any accessor
+    // runs. The default never gets a chance to satisfy `required`.
+    let cmd = with_flag(command("app", "desc"), flag_required(flag_value("output", "Output")));
+    let argv: string[] = ["app"];
+    let r = parse(cmd, argv);
+    assert r.ok == false;
+    assert strings_equal(r.error.kind, "missing_required");
+    // The partial matches do not contain the flag, so `get_or` would
+    // fall back to its default — but the caller never reaches that
+    // codepath because `ok` is false.
+    let fallback = get_or(r.matches, "output", "out.txt");
+    assert strings_equal(fallback, "out.txt");
+}
+
+// ---- Help annotation ----
+test "help: required flag is annotated with (required)" {
+    let cmd = with_flag(command("app", "desc"), flag_required(flag_short("force", "f", "Force the operation")));
+    let rendered = help(cmd);
+    assert _contains(rendered, "Force the operation (required)") == true;
+}
+
+test "help: non-required flag has no (required) suffix" {
+    let cmd = with_flag(command("app", "desc"), flag_short("verbose", "v", "Verbose output"));
+    let rendered = help(cmd);
+    assert _contains(rendered, "Verbose output (required)") == false;
+    assert _contains(rendered, "Verbose output") == true;
+}
+
+test "help: mixed required and non-required flags annotate only the required ones" {
+    let cmd = with_flag(with_flag(command("app", "desc"), flag_required(flag("force", "Force"))), flag("verbose", "Verbose"));
+    let rendered = help(cmd);
+    assert _contains(rendered, "Force (required)") == true;
+    assert _contains(rendered, "Verbose (required)") == false;
+}


### PR DESCRIPTION
## Summary

- Adds `flag_required(f)` — a chainable builder marker on any `Flag` constructed via `flag` / `flag_value` / `flag_short` / `flag_value_short`.
- Extends `parse()` to validate required flags after positional validation; absent required flags yield `ParseError { kind: "missing_required", flag_name: "<long_name>" }` (reusing the existing 1.1 kind; the `flag_name` vs `arg_name` field disambiguates flag-missing vs arg-missing).
- Annotates required flags with `(required)` in rendered help output.
- `Flag` struct gains a `required: boolean` field; all existing constructors initialize it to `false`.

Closes #797

## Acceptance Criteria

- [x] `flag_required` exported from `sfn/cli` and chainable on any builder.
- [x] Absent required flag yields `ParseResult { ok: false, error: ParseError { kind: "missing_required", flag_name: "..." } }`.
- [x] Help output for a required flag includes `(required)` (asserted against the rendered string in `help: required flag is annotated with (required)`).
- [x] Tests cover required-present (success), required-absent (failure), and that `get_or`'s default does NOT satisfy `required` (parse rejects before any accessor runs).
- [x] `make compile`, `make test`, `sfn fmt --check` all green.

## Verification

```bash
ulimit -v 8388608 && make compile
# [compile] build/native/sailfin up-to-date (sfn/cli is a library capsule, not a compiler dep)

ulimit -v 8388608 && timeout 60 build/native/sailfin test capsules/sfn/cli/tests/
# parser_test.sfn  — PASS (15/15)
# cli_test.sfn     — PASS (47/47)
# required_flag_test.sfn — PASS (13/13)

ulimit -v 8388608 && make test
# ═══ e2e: 79/79 passed, 0 failed ═══
# ═══ capsules: 15/15 passed, 0 failed ═══   (required_flag_test.sfn included)
# exit code 0

ulimit -v 8388608 && timeout 30 build/native/sailfin fmt --check capsules/sfn/cli/
# clean
```

## Files Changed

- `capsules/sfn/cli/src/types.sfn` — `Flag.required: boolean` field + docstring note that `"missing_required"` is shared.
- `capsules/sfn/cli/src/builder.sfn` — `flag_required(f)` + initialize `required: false` on existing constructors.
- `capsules/sfn/cli/src/parser.sfn` — required-flag validation pass after positional checks; `_flag_seen` helper; updated `Flag` literal in `_find_flag_*` fallbacks.
- `capsules/sfn/cli/src/help.sfn` — `(required)` suffix on flag rows.
- `capsules/sfn/cli/src/mod.sfn` — re-export `flag_required`.
- `capsules/sfn/cli/tests/required_flag_test.sfn` — NEW (13 tests).

## Notes

- The proposal at `docs/proposals/cli-modularization-epic.md` §7 names the diagnostic `missing_required_flag`, but the issue scope explicitly reuses 1.1's existing `"missing_required"` kind verbatim. Callers disambiguate via `flag_name` vs `arg_name`. If the proposal's split kind is desired later, it's a backwards-compatible refinement.
- Part of the [CLI Modularization Epic](https://github.com/SailfinIO/sailfin/issues/351).


---
_Generated by [Claude Code](https://claude.ai/code/session_017Ay9XvAg1GCfaE4ZCQEaH6)_