### PR TITLE
refactor(test): drop inlined helpers in sfn/test for runtime + sfn/fmt

### DIFF
--- a/capsules/sfn/test/capsule.toml
+++ b/capsules/sfn/test/capsule.toml
@@ -4,6 +4,13 @@ version = "0.2.1"
 description = "Test assertion helpers and utilities for Sailfin"
 
 [dependencies]
+# `sfn/fmt::find` replaces the hand-rolled `_find_in_string` helper
+# the capsule used to inline. The matching `sfn/strings` capsule the
+# proposal cited (`docs/proposals/test-infra-epic/02-phases.md`,
+# issue 1.3) does not exist; integer formatting goes through the
+# runtime intrinsic `number_to_string` instead — the same formatter
+# `pure_assert_eq_float` already uses for fractional inputs.
+"sfn/fmt" = "*"
 
 [capabilities]
 required = ["io"]

--- a/capsules/sfn/test/src/mod.sfn
+++ b/capsules/sfn/test/src/mod.sfn
@@ -23,36 +23,16 @@
 // over the caller's effect row when row-polymorphic effects ship
 // post-1.0. Until then, `pure_assert_*` is the production-ready
 // interim — see issue #370 / proposal §P3.
+import { find } from "sfn/fmt";
+
 // ---------------------------------------------------------------------------
 // Internal helpers
 // ---------------------------------------------------------------------------
-fn _number_to_string(value: int) -> string {
-    if value == 0 { return "0"; }
-    let mut is_negative: boolean = false;
-    let mut remaining: int = value;
-    if value < 0 {
-        is_negative = true;
-        remaining = 0 - value;
-    }
-    let mut output: string = "";
-    let digits = "0123456789";
-    loop {
-        if remaining <= 0 { break; }
-        let mut temp: int = remaining;
-        let mut quotient: int = 0;
-        loop {
-            if temp < 10 { break; }
-            temp -= 10;
-            quotient += 1;
-        }
-        let ch = substring(digits, temp, temp + 1);
-        output = ch + output;
-        remaining = quotient;
-    }
-    if is_negative { output = "-" + output; }
-    return output;
-}
-
+// Integer formatting goes through the runtime intrinsic `number_to_string`,
+// which already renders integers via `%.15g` (no trailing `.0`). The
+// previous file-local `_number_to_string` duplicated that with a slow
+// integer-only fallback; removing it keeps a single formatter for both
+// int and float assertion diagnostics.
 fn _bool_to_string(value: boolean) -> string {
     if value { return "true"; }
     return "false";
@@ -144,22 +124,8 @@ fn assert_lte(actual: float, threshold: float, label: string) ![io] {
 // ---------------------------------------------------------------------------
 // String content assertions
 // ---------------------------------------------------------------------------
-fn _find_in_string(haystack: string, needle: string) -> int {
-    if needle.length == 0 { return 0; }
-    if needle.length > haystack.length { return -1; }
-    let mut i: int = 0;
-    let limit = haystack.length - needle.length;
-    loop {
-        if i > limit { return -1; }
-        let slice = substring(haystack, i, i + needle.length);
-        if slice == needle { return i; }
-        i += 1;
-    }
-    return -1;
-}
-
 fn assert_contains(haystack: string, needle: string, label: string) ![io] {
-    if _find_in_string(haystack, needle) >= 0 { return; }
+    if find(haystack, needle, 0) >= 0 { return; }
     print.err("ASSERTION FAILED: " + label);
     print.err("  expected to contain: \"" + needle + "\"");
     print.err("  actual:              \"" + haystack + "\"");
@@ -167,7 +133,7 @@ fn assert_contains(haystack: string, needle: string, label: string) ![io] {
 }
 
 fn assert_not_contains(haystack: string, needle: string, label: string) ![io] {
-    if _find_in_string(haystack, needle) < 0 { return; }
+    if find(haystack, needle, 0) < 0 { return; }
     print.err("ASSERTION FAILED: " + label);
     print.err("  expected not to contain: \"" + needle + "\"");
     print.err("  actual:                  \"" + haystack + "\"");
@@ -214,8 +180,8 @@ fn assert_approx(actual: float, expected: float, tolerance: float, label: string
 fn assert_length(actual_length: int, expected_length: int, label: string) ![io] {
     if actual_length == expected_length { return; }
     print.err("ASSERTION FAILED: " + label);
-    print.err("  expected length: " + _number_to_string(expected_length));
-    print.err("  actual length:   " + _number_to_string(actual_length));
+    print.err("  expected length: " + number_to_string(expected_length));
+    print.err("  actual length:   " + number_to_string(actual_length));
     assert false;
 }
 
@@ -223,7 +189,7 @@ fn assert_empty(actual_length: int, label: string) ![io] {
     if actual_length == 0 { return; }
     print.err("ASSERTION FAILED: " + label);
     print.err("  expected empty (length 0)");
-    print.err("  actual length: " + _number_to_string(actual_length));
+    print.err("  actual length: " + number_to_string(actual_length));
     assert false;
 }
 
@@ -314,9 +280,9 @@ fn _pure_fail(message: string) -> AssertFailure {
 fn pure_assert_eq_int(actual: int, expected: int, label: string) -> AssertFailure ![pure] {
     if actual == expected { return _pure_ok(); }
     let message = "ASSERTION FAILED: " + label + "; expected: "
-        + _number_to_string(expected)
+        + number_to_string(expected)
         + "; actual: "
-        + _number_to_string(actual);
+        + number_to_string(actual);
     return _pure_fail(message);
 }
 
@@ -333,14 +299,12 @@ fn pure_assert_eq_string(actual: string, expected: string, label: string) -> Ass
 fn pure_assert_eq_float(actual: float, expected: float, tolerance: float, label: string) -> AssertFailure ![pure] {
     let diff = _abs(actual - expected);
     if diff <= tolerance { return _pure_ok(); }
-    // Use the runtime's `%.15g`-format `number_to_string` here rather
-    // than the file-local `_number_to_string` (integer-only, repeated
-    // subtraction). Float comparisons routinely receive fractional
-    // inputs, and the integer-only formatter would mangle non-integer
-    // values in the diagnostic message and risk runaway loops on large
-    // doubles. Other helpers stay on `_number_to_string` because they
-    // operate on integer-shaped inputs in practice (counts, lengths,
-    // boolean-equivalent ints).
+    // The runtime's `%.15g`-format `number_to_string` is the single
+    // formatter used across every numeric assertion in this module:
+    // it renders integer-shaped inputs without a trailing `.0` and
+    // preserves useful precision for fractional inputs. Issue #846
+    // removed the file-local `_number_to_string` int-only fallback
+    // — there is now no asymmetry between the int and float paths.
     let message = "ASSERTION FAILED: " + label + "; expected: "
         + number_to_string(expected)
         + " +/- "


### PR DESCRIPTION
## Summary

- Delete `_number_to_string` and `_find_in_string` from `capsules/sfn/test/src/mod.sfn` (~40 LOC). Integer formatting now uses the runtime intrinsic `number_to_string` — the same `%.15g` formatter `pure_assert_eq_float` already uses, so the int / float diagnostic paths are no longer split.
- `assert_contains` / `assert_not_contains` call `find` from `sfn/fmt` via `import { find } from "sfn/fmt"`.
- `capsules/sfn/test/capsule.toml` declares `[dependencies] "sfn/fmt" = "*"`. The proposal also cited `sfn/strings`, but that capsule does not exist; the runtime intrinsic covers the number-to-string need without it.

Closes #846

## Acceptance Criteria

- [x] `_number_to_string` and `_find_in_string` are gone from `capsules/sfn/test/src/mod.sfn`.
- [x] `capsules/sfn/test/capsule.toml` declares `sfn/fmt` (the `sfn/strings` half of the proposal does not exist; runtime intrinsic substitutes — see notes below).
- [x] `pure_assert_eq_float` still routes its diagnostic through the runtime `number_to_string`, preserving the float-vs-int split implicit in the original CAVEAT (now unified: every numeric assertion uses the runtime formatter).
- [x] `make compile` passes.
- [x] `make test` passes (`═══ e2e: 79/79 passed, 0 failed ═══`, `═══ capsules: 14/14 passed, 0 failed ═══`, unit + integration reached normally — `make test` is sequential and would have short-circuited on a failure before e2e ran).
- [x] `sfn fmt --check` clean on `capsules/sfn/test/src/mod.sfn` (verified with both the pinned seed `0.7.0-alpha.9` and the freshly-built native compiler).

## Verification

```bash
ulimit -v 8388608 && make clean-build && make compile     # green
ulimit -v 8388608 && make test                            # all four phases green
ulimit -v 8388608 && build/native/sailfin fmt --check capsules/sfn/test/src/mod.sfn  # exit 0
```

## Notes for reviewers

- **`sfn/strings` capsule does not exist.** The proposal at `docs/proposals/test-infra-epic/02-phases.md` (Phase 1, issue 1.3) cited `sfn/strings + sfn/fmt`; only `sfn/fmt` ships. The runtime intrinsic `number_to_string` (already used by `pure_assert_eq_float` per the issue's CAVEAT) substitutes for the missing `sfn/strings` formatter. The TOML dep block carries a comment explaining this.
- **First cross-capsule library import in the workspace.** Pre-existing capsules import only relative paths or `runtime/prelude`; this PR introduces `import { find } from "sfn/fmt"` between two `kind = "library"` workspace members. `make compile` and `make test` both pass because neither pulls in `sfn/test` transitively (the compiler depends on `sfn/runtime-native` only, and `make test-capsules` skips `sfn/test` because it has no `tests/` dir).
- **Resolver gap surfaced while verifying.** A standalone `sfn build -p capsules/sfn/test` with the dep declared falls into a workspace-member-to-workspace-member lookup gap: `_cr_locate_capsule_src` in `compiler/src/capsule_resolver.sfn:828` joins `<project_root>/capsules/<scope>/<name>/src`, which doesn't exist for a workspace member, and the workspace-implicit walker is short-circuited because the spec is already in `excluded_specs` (declared manifest deps). Filing a separate compiler-source fix is in order (out of scope for this XS refactor — issue 1.3 explicitly disallows compiler-source changes). The PR keeps the dep declaration because it expresses the correct intent and `make compile` / `make test` are unaffected.

## Files Changed

- `capsules/sfn/test/src/mod.sfn` — drop `_number_to_string`, drop `_find_in_string`, add `import { find } from "sfn/fmt"`, re-point five call sites, refresh comments (-56 / +27).
- `capsules/sfn/test/capsule.toml` — declare `sfn/fmt` dep with explanatory comment (+7).

---
_Generated by [Claude Code](https://claude.ai/code/session_01MFMSQT3ZwfBuu5yXj8RFHZ)_