### PR TITLE
refactor(typecheck): add is_builtin_call_name allowlist helper

### DIFF
--- a/compiler/src/typecheck_types.sfn
+++ b/compiler/src/typecheck_types.sfn
@@ -619,6 +619,79 @@ fn is_extern_primitive_type(text: string) -> boolean {
     return _ret;
 }
 
+// Pure: identifier-form call names that the typechecker's expression
+// walker treats as "no resolution required" — the auto-injection
+// envelope for the #616 decomposition (Issue B). When walker
+// resolution lights up in Issue D (#616 sub-issue 4), any
+// `Call.callee.variant == "Identifier"` whose name returns `true`
+// here short-circuits unknown-identifier diagnostic emission so the
+// 50 examples (per #549) keep compiling clean. The accept-list
+// discipline mirrors `is_extern_primitive_type` above: each member
+// documented inline so the rationale travels with the code.
+//
+// Issue B intentionally introduces the helper without rewiring
+// effect_checker.sfn:623-652 to consume it (see Issue B `Out:`); the
+// inline checks there continue to drive effect injection until a
+// future dedup pass lands.
+//
+// Members of the envelope:
+//   `print`    — bare-form I/O builtin. Member-form `print.info`/
+//                `print.error`/… emits via the effect_checker Member
+//                branch; the bare Call-form is the README first
+//                example and `examples/basics/hello-world.sfn`.
+//                effect_checker.sfn:646 already injects `![io]`.
+//   `console`  — bare-form I/O builtin paired with `print` in the
+//                README envelope. effect_checker.sfn:647 injects `![io]`.
+//   `assert`   — test-and-spec assertion builtin. Surfaces in every
+//                unit/integration test under `compiler/tests/` and in
+//                `examples/` cookbook entries; never a user-defined
+//                function. Audit note (#616): missing from the
+//                pre-existing effect_checker inline list — Issue D will
+//                consume this envelope to keep `assert` calls clean.
+//   `spawn`    — parsed-but-unenforced concurrency keyword (runtime
+//                Phase 4). Appears in `examples/concurrency/*` in
+//                call form. effect_checker.sfn:623 already injects
+//                `![io]` so the walker must skip resolution.
+//   `sleep`    — parsed-but-unenforced clock primitive.
+//                effect_checker.sfn:628 injects `![clock]`.
+//   `serve`    — parsed-but-unenforced server primitive.
+//                effect_checker.sfn:633 injects `![net]`.
+//   `channel`  — parsed-but-unenforced channel constructor (Phase 4).
+//                Appears in concurrency examples in call form;
+//                resolves to a Sailfin runtime primitive when the
+//                concurrency runtime ships.
+//   `send`     — parsed-but-unenforced channel send (Phase 4).
+//                Appears in concurrency examples in call form.
+//   `receive`  — parsed-but-unenforced channel receive (Phase 4).
+//                Appears in concurrency examples in call form.
+//   `await`    — parsed-but-unenforced await primitive (Phase 4).
+//                Pairs with `spawn` in concurrency examples in call form.
+//
+// Intentionally NOT in the envelope (Issue D will surface these as
+// unknown-identifier diagnostics so user code can shadow them):
+//   `len`, `panic` — audit (#616) flagged these as inline gaps in
+//   effect_checker today, but they are library/runtime functions, not
+//   language-level builtins. Resolution should go through the import
+//   table once Issue C threads it in.
+//   Member-form builtins (`string.concat`, `array.push`, `fs.exists`,
+//   …) — out of #616 Issue B scope. Member resolution is handled
+//   through the Member branch of the walker, not this Call-identifier
+//   shortcut.
+fn is_builtin_call_name(name: string) -> boolean {
+    let mut _ret: boolean = false;
+    if strings_equal(name, "print") { _ret = true; }
+    if strings_equal(name, "console") { _ret = true; }
+    if strings_equal(name, "assert") { _ret = true; }
+    if strings_equal(name, "spawn") { _ret = true; }
+    if strings_equal(name, "sleep") { _ret = true; }
+    if strings_equal(name, "serve") { _ret = true; }
+    if strings_equal(name, "channel") { _ret = true; }
+    if strings_equal(name, "send") { _ret = true; }
+    if strings_equal(name, "receive") { _ret = true; }
+    if strings_equal(name, "await") { _ret = true; }
+    return _ret;
+}
+
 // Pure: identifiers that v0 accepts as opaque-pointer pointees behind
 // a leading `*`. The v0 rule is "starts with an uppercase ASCII letter
 // and contains only identifier characters." This is intentionally

--- a/compiler/src/typecheck_types.sfn
+++ b/compiler/src/typecheck_types.sfn
@@ -648,24 +648,50 @@ fn is_extern_primitive_type(text: string) -> boolean {
 //                function. Audit note (#616): missing from the
 //                pre-existing effect_checker inline list — Issue D will
 //                consume this envelope to keep `assert` calls clean.
-//   `spawn`    — parsed-but-unenforced concurrency keyword (runtime
-//                Phase 4). Appears in `examples/concurrency/*` in
-//                call form. effect_checker.sfn:623 already injects
-//                `![io]` so the walker must skip resolution.
-//   `sleep`    — parsed-but-unenforced clock primitive.
+//   `spawn`    — planned concurrency keyword (keywords.md `### spawn`,
+//                "Planned (language keyword)"); the prelude historically
+//                exposed `spawn(task, name)` as a free function. Bare
+//                Call-form exercised by `effect_checker_test.sfn:450`
+//                ("bare spawn() Call carets at the callee identifier")
+//                and `tests/e2e/test_sync_rejects_unimplemented_concurrency.sh`.
+//                effect_checker.sfn:623 already injects `![io]`.
+//   `sleep`    — clock primitive. Bare Call-form in `examples/concurrency/
+//                producer-consumer.sfn:13`, `examples/advanced/
+//                multithreaded-task.sfn:7`, and `effect_checker_test.sfn:466`.
 //                effect_checker.sfn:628 injects `![clock]`.
-//   `serve`    — parsed-but-unenforced server primitive.
+//   `serve`    — net primitive. Bare Call-form in `examples/web/
+//                http-server.sfn:6`, `rest-api.sfn:14`, and `examples/
+//                advanced/web-server-with-concurrency.sfn:23`.
 //                effect_checker.sfn:633 injects `![net]`.
-//   `channel`  — parsed-but-unenforced channel constructor (Phase 4).
-//                Appears in concurrency examples in call form;
-//                resolves to a Sailfin runtime primitive when the
-//                concurrency runtime ships.
-//   `send`     — parsed-but-unenforced channel send (Phase 4).
-//                Appears in concurrency examples in call form.
-//   `receive`  — parsed-but-unenforced channel receive (Phase 4).
-//                Appears in concurrency examples in call form.
-//   `await`    — parsed-but-unenforced await primitive (Phase 4).
-//                Pairs with `spawn` in concurrency examples in call form.
+//   `channel`  — channel constructor. Bare Call-form in `examples/
+//                concurrency/channels.sfn:6`, `producer-consumer.sfn:7`,
+//                `dynamic-task-scheduling.sfn:6`, and rejected by
+//                `tests/e2e/test_sync_rejects_unimplemented_concurrency.sh`
+//                pending the structured-concurrency runtime.
+//   `send`     — Channel.send. Today only appears as Member-form
+//                (`buffer.send(...)`, `examples/concurrency/channels.sfn:9`).
+//                Included defensively in the identifier-call allowlist
+//                because the typechecker walker runs before keyword/method
+//                disambiguation — if a user writes `send(buffer, value)`
+//                thinking it's a free function (the same misuse caught
+//                by `test_sync_rejects_unimplemented_concurrency.sh`),
+//                the rejection diagnostic must come from the
+//                concurrency-unimplemented gate, not a spurious
+//                unknown-identifier error from Issue D.
+//   `receive`  — Channel.receive. Same shape as `send`: today only
+//                Member-form (`messages.receive()` in `channels.sfn:12`,
+//                `producer-consumer.sfn:19`, `dynamic-task-scheduling.sfn:11`).
+//                Included for the same defensive reason.
+//   `await`    — unary prefix operator in the grammar (grammar.md L233:
+//                `Unary = ("!" | "-" | "+" | "await") Unary`). Today
+//                used as `await messages.receive()` in `examples/
+//                concurrency/channels.sfn:12`, not as `await(...)`.
+//                Included in the identifier-call allowlist defensively:
+//                until the lexer reserves `await` as a keyword token,
+//                the parser may construct `Call(callee=Identifier(
+//                "await"), …)` from `await(expr)`-style input, and the
+//                walker should not surface unknown-identifier there
+//                while concurrency remains under construction.
 //
 // Intentionally NOT in the envelope (Issue D will surface these as
 // unknown-identifier diagnostics so user code can shadow them):

--- a/compiler/tests/unit/typecheck_builtin_allowlist_test.sfn
+++ b/compiler/tests/unit/typecheck_builtin_allowlist_test.sfn
@@ -1,0 +1,76 @@
+// Unit tests for the typecheck builtin-call allowlist (issue #810).
+//
+// Issue #810 centralizes the auto-injection envelope (previously
+// scattered as hardcoded names in effect_checker.sfn:623-652) into a
+// single `is_builtin_call_name` helper on `typecheck_types.sfn`. The
+// envelope establishes which bare `Identifier(...)` call names the
+// expression walker (#809) must treat as "no resolution required"
+// once Issue D (#616 sub-issue 4) flips on unknown-identifier
+// diagnostics. Until then the helper is dead code — these tests pin
+// the envelope contents so the flip-day change in Issue D is a
+// one-call rewire, not a re-audit of which names belong.
+//
+// Mirror the issue's documented envelope: print/console/assert
+// (bare-form builtins) plus the parsed-but-unenforced concurrency
+// keywords (spawn/sleep/serve/channel/send/receive/await). Two
+// negatives close the contract: `notarealfunction` (the universal
+// "user typo" stand-in used by the walker tests) and `len` (a
+// library helper flagged by the #616 audit as missing from the
+// pre-existing inline list, deliberately kept out of the envelope so
+// user code can shadow it).
+import { is_builtin_call_name } from "../../src/typecheck_types";
+
+test "builtin allowlist: print is in envelope" {
+    assert is_builtin_call_name("print") == true;
+}
+
+test "builtin allowlist: console is in envelope" {
+    assert is_builtin_call_name("console") == true;
+}
+
+test "builtin allowlist: assert is in envelope" {
+    assert is_builtin_call_name("assert") == true;
+}
+
+test "builtin allowlist: spawn is in envelope" {
+    assert is_builtin_call_name("spawn") == true;
+}
+
+test "builtin allowlist: sleep is in envelope" {
+    assert is_builtin_call_name("sleep") == true;
+}
+
+test "builtin allowlist: serve is in envelope" {
+    assert is_builtin_call_name("serve") == true;
+}
+
+test "builtin allowlist: channel is in envelope" {
+    assert is_builtin_call_name("channel") == true;
+}
+
+test "builtin allowlist: send is in envelope" {
+    assert is_builtin_call_name("send") == true;
+}
+
+test "builtin allowlist: receive is in envelope" {
+    assert is_builtin_call_name("receive") == true;
+}
+
+test "builtin allowlist: await is in envelope" {
+    assert is_builtin_call_name("await") == true;
+}
+
+test "builtin allowlist: notarealfunction is not in envelope" {
+    // Matches the walker test fixture in typecheck_expression_walk_test.sfn.
+    // Issue D will surface this as an unknown-identifier diagnostic; the
+    // envelope must not absorb it.
+    assert is_builtin_call_name("notarealfunction") == false;
+}
+
+test "builtin allowlist: len is not in envelope" {
+    // Audit note from grooming #616: `len` and `panic` are library
+    // helpers, not language-level builtins. They stay out of the
+    // envelope so user code can shadow them and Issue D can surface
+    // unresolved references through the normal import-table path.
+    assert is_builtin_call_name("len") == false;
+}


### PR DESCRIPTION
## Summary
- Adds `is_builtin_call_name(name: string) -> boolean` on `compiler/src/typecheck_types.sfn`, centralizing the documented auto-injection envelope (`print`, `console`, `assert` builtins + `spawn`, `sleep`, `serve`, `channel`, `send`, `receive`, `await` parsed-but-unenforced concurrency keywords) as the single source of truth for Issue D's walker-resolution flip.
- Doc comment mirrors the accept-list discipline of `is_extern_primitive_type` (typecheck_types.sfn:602): every member justified inline, every intentional omission (`len`, `panic`, member-form builtins) documented.
- Adds `compiler/tests/unit/typecheck_builtin_allowlist_test.sfn` with 12 tests (10 envelope members + 2 negatives).
- Scope-faithful: does NOT change `effect_checker.sfn:623-652` (Out: of #810) — the helper is intentionally dead code until Issue D wires it in.

Closes #810

## Acceptance Criteria
- [x] `is_builtin_call_name("print") == true`, `is_builtin_call_name("notarealfunction") == false`, `is_builtin_call_name("spawn") == true`
- [x] Unit test `typecheck_builtin_allowlist_test.sfn` covers each envelope member + two negatives
- [x] `make compile` passes
- [x] `make test` passes
- [x] `sfn fmt --check` clean on every touched `.sfn` file

## Verification
```bash
ulimit -v 8388608 && make compile      # built build/native/sailfin
ulimit -v 8388608 && make test-unit    # unit: 105/105 passed
ulimit -v 8388608 && make test-integration  # integration: 28/28 passed
ulimit -v 8388608 && build/native/sailfin fmt --check \
  compiler/src/typecheck_types.sfn \
  compiler/tests/unit/typecheck_builtin_allowlist_test.sfn   # exit 0
```

(One flake on first `make test` run — `closure_lifting_test.sfn` — cleared on re-run; passes in isolation. Unrelated to this change.)

## Files Changed
- `compiler/src/typecheck_types.sfn` — new `is_builtin_call_name` helper + doc block
- `compiler/tests/unit/typecheck_builtin_allowlist_test.sfn` — new (12 tests)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Q8qySwEfBUwv3oF7PqGm5c)_