### PR TITLE
refactor(typecheck): thread ImportSymbolTable into walker name resolution

### DIFF
--- a/compiler/src/main.sfn
+++ b/compiler/src/main.sfn
@@ -36,6 +36,7 @@ import { Token } from "./token";
 import { toml_get_dependencies } from "./toml_parser";
 import {
     typecheck_diagnostics,
+    typecheck_diagnostics_with_import_symbols,
     typecheck_diagnostics_with_imports,
     typecheck_has_errors
 } from "./typecheck";
@@ -358,9 +359,13 @@ fn compile_to_llvm_with_module_timed(source: string, module_name: string) -> str
 // import-context the resolver pass produces:
 //
 //   - `imported_interfaces` from `load_imported_interfaces_from_paths`
-//     — fed into `typecheck_diagnostics_with_imports` so cross-module
+//     — paired with `imported_function_effects` and fed into
+//     `typecheck_diagnostics_with_import_symbols` so cross-module
 //     `implements` clauses are conformance-checked end to end (same
-//     wiring `sfn check` adopted in Track A2).
+//     wiring `sfn check` adopted in Track A2). Issue #811 added the
+//     `ImportSymbolTable` slot so the typecheck walker can resolve
+//     imported free-function callees ahead of issue D's enforcement
+//     flip.
 //   - `imported_manifests` reserved for layout-manifest plumbing —
 //     today `[]`; the test path doesn't currently exercise cross-
 //     module struct layout in any of the import-using tests, so
@@ -381,7 +386,7 @@ fn compile_tests_to_llvm_file_with_module_imports(source: string, module_name: s
     let trace = test_runner_trace();
     if trace { print.err("test compiler (imports): parse_program start"); }
     let program: Program = parse_program(source);
-    let diagnostics = typecheck_diagnostics_with_imports(program, imported_interfaces);
+    let diagnostics = typecheck_diagnostics_with_import_symbols(program, imported_interfaces, imported_function_effects);
     let mut has_errors: boolean = false;
     let mut di: int = 0;
     loop {

--- a/compiler/src/tools/check.sfn
+++ b/compiler/src/tools/check.sfn
@@ -33,7 +33,7 @@ import { ImportSymbolTable, empty_import_symbols } from "../effect_imports";
 import { number_to_string } from "../main";
 import { parse_program } from "../parser/mod";
 import { substring } from "../string_utils";
-import { typecheck_diagnostics_with_imports } from "../typecheck";
+import { typecheck_diagnostics_with_import_symbols } from "../typecheck";
 import { Diagnostic } from "../typecheck_types";
 
 // -------------------------------------------------------------------
@@ -79,16 +79,23 @@ fn check_source(source: string, file_path: string) -> CheckResult ![io] {
 
 // Cross-module-aware variant: `imported_interfaces` carries
 // `Statement.InterfaceDeclaration` values sourced from staged
-// `.sfn-asm` artifacts (see `typecheck_import_loader.sfn`). They are
-// passed through to `typecheck_diagnostics_with_imports` so cross-
-// module `implements` clauses are conformance-checked against the
-// real interface definitions instead of silently no-oping.
+// `.sfn-asm` artifacts (see `typecheck_import_loader.sfn`). Paired
+// with `function_effects`, they are passed through to
+// `typecheck_diagnostics_with_import_symbols` so cross-module
+// `implements` clauses are conformance-checked against the real
+// interface definitions and the typecheck walker can resolve
+// free-function callees against the same symbol surface the effect
+// checker sees (issue #811).
 //
 // Phase E: `function_effects` carries the per-build cross-module
 // effect symbol table built from the same `.sfn-asm` artifacts.
 // It is threaded into `validate_effects_with_imports` so a caller
 // missing `![<imported_callee_effect>]` produces an `E0402`
-// diagnostic alongside any in-module `E0400` / `E0401` findings.
+// diagnostic alongside any in-module `E0400` / `E0401` findings,
+// and into `typecheck_diagnostics_with_import_symbols` so issue D
+// (#812) can flip on `E0420` for undefined callees without a
+// follow-up wiring PR. Both entry points localize the global table
+// internally — callers always pass the loader-built global.
 //
 // Phase F: `capabilities_required` carries the project manifest's
 // `[capabilities] required = [...]` surface so `sfn check`
@@ -98,7 +105,7 @@ fn check_source(source: string, file_path: string) -> CheckResult ![io] {
 // keep working unchanged).
 fn check_source_with_imports(source: string, file_path: string, imported_interfaces: Statement[], function_effects: ImportSymbolTable, capabilities_required: string[]) -> CheckResult ![io] {
     let program = parse_program(source);
-    let type_diags = typecheck_diagnostics_with_imports(program, imported_interfaces);
+    let type_diags = typecheck_diagnostics_with_import_symbols(program, imported_interfaces, function_effects);
     let effect_violations = validate_effects_with_imports(program, function_effects);
     let capability_violations = validate_capsule_capabilities(program, capabilities_required);
 

--- a/compiler/src/typecheck.sfn
+++ b/compiler/src/typecheck.sfn
@@ -16,6 +16,7 @@ import {
     TypeAnnotation,
     TypeParameter
 } from "./ast";
+import { ImportSymbolTable, empty_import_symbols, lookup_imported_function } from "./effect_imports";
 import { Token, TokenKind } from "./token";
 import {
     Diagnostic,
@@ -62,12 +63,38 @@ fn typecheck_diagnostics(program: Program) -> Diagnostic[] {
 // is `interface_statement_from_native` which only emits
 // `Statement.InterfaceDeclaration`, but filtering at the API boundary
 // keeps the contract enforceable for future callers (e.g. `sfn lsp`).
+//
+// Back-compat entry point: existing callers that do not yet have an
+// `ImportSymbolTable` in scope keep working unchanged. Cross-module
+// free-function resolution is a no-op on this path — see
+// `typecheck_diagnostics_with_import_symbols` for the symbol-aware
+// variant introduced in issue #811.
 fn typecheck_diagnostics_with_imports(program: Program, imported_interfaces: Statement[]) -> Diagnostic[] {
+    return typecheck_diagnostics_with_import_symbols(program, imported_interfaces, empty_import_symbols());
+}
+
+// Symbol-aware variant — issue #811 (sub-issue 3 of #616).
+//
+// Threads an `ImportSymbolTable` through the scope walker so the
+// expression-position resolver introduced in issue #809 can lookup
+// imported free functions before issue D enables enforcement. The
+// walker computes the resolution boolean and discards it today; this
+// keeps observable behaviour identical (zero new diagnostics) while
+// pinning the plumbing so issue D only needs to add the emission
+// branch — not the plumbing.
+//
+// Callers that already build an import table during dependency
+// resolution (e.g. `compile_tests_to_llvm_file_with_module_imports`
+// in `main.sfn`) thread it through this entry point. Standalone or
+// pre-resolver call paths can keep using the 2-arg
+// `typecheck_diagnostics_with_imports` (which delegates here with an
+// empty table).
+fn typecheck_diagnostics_with_import_symbols(program: Program, imported_interfaces: Statement[], imported_function_effects: ImportSymbolTable) -> Diagnostic[] {
     let top_level = collect_top_level_symbols(program);
     let local_interfaces = collect_interface_definitions(program);
     let filtered_imports = _filter_interface_declarations(imported_interfaces);
     let combined_interfaces = local_interfaces.concat(filtered_imports);
-    let scoped_diagnostics = check_program_scopes(program, combined_interfaces);
+    let scoped_diagnostics = check_program_scopes(program, combined_interfaces, imported_function_effects);
 
     // Merge diagnostics using concat (avoids loop-with-if-break pattern that
     // the compiler lowers incorrectly — loops emit without exit conditions).
@@ -168,12 +195,12 @@ fn register_top_level_symbol(statement: Statement, existing: SymbolEntry[]) -> S
     return SymbolCollectionResult { symbols: existing, diagnostics: [] };
 }
 
-fn check_program_scopes(program: Program, interfaces: Statement[]) -> Diagnostic[] {
+fn check_program_scopes(program: Program, interfaces: Statement[], imports: ImportSymbolTable) -> Diagnostic[] {
     let mut bindings: SymbolEntry[] = [];
     let mut diagnostics: Diagnostic[] = [];
 
     for statement in program.statements {
-        let result = check_statement(statement, bindings, interfaces, 0);
+        let result = check_statement(statement, bindings, interfaces, 0, imports);
         bindings = result.bindings;
         let mut _ci: int = 0;
         loop {
@@ -191,10 +218,10 @@ fn check_program_scopes(program: Program, interfaces: Statement[]) -> Diagnostic
 // it as the parent-bindings length after `clone_bindings`, so a `let x` in a
 // nested block can shadow an enclosing `let x` without tripping E0001. Top-
 // level and recursive same-frame callers pass it through unchanged.
-fn check_statement(statement: Statement, bindings: SymbolEntry[], interfaces: Statement[], scope_start: int) -> ScopeResult {
+fn check_statement(statement: Statement, bindings: SymbolEntry[], interfaces: Statement[], scope_start: int, imports: ImportSymbolTable) -> ScopeResult {
     if statement.variant == "VariableDeclaration" {
         let registration = register_local_symbol(bindings, statement.name, "variable", statement.span, scope_start);
-        let walk_diags = walk_expression(statement.initializer, bindings);
+        let walk_diags = walk_expression(statement.initializer, bindings, imports);
         return ScopeResult {
             bindings: registration.bindings,
             diagnostics: registration.diagnostics.concat(walk_diags)
@@ -217,7 +244,7 @@ fn check_statement(statement: Statement, bindings: SymbolEntry[], interfaces: St
             diagnostics.push(_main_diags[_cim]);
             _cim += 1;
         }
-        let function_diagnostics = check_function_body(statement.signature, statement.body, interfaces);
+        let function_diagnostics = check_function_body(statement.signature, statement.body, interfaces, imports);
         let mut _ci2: int = 0;
         loop {
             if _ci2 >= function_diagnostics.length { break; }
@@ -279,7 +306,7 @@ fn check_statement(statement: Statement, bindings: SymbolEntry[], interfaces: St
         loop {
             if index >= statement.methods.length { break; }
             let method = statement.methods[index];
-            let _mb_diags = check_function_body(method.signature, method.body, interfaces);
+            let _mb_diags = check_function_body(method.signature, method.body, interfaces, imports);
             let mut _ci5: int = 0;
             loop {
                 if _ci5 >= _mb_diags.length { break; }
@@ -340,7 +367,7 @@ fn check_statement(statement: Statement, bindings: SymbolEntry[], interfaces: St
     if statement.variant == "TestDeclaration" {
         let registration = register_local_symbol(bindings, statement.name, "test", statement.name_span, scope_start);
         let mut diagnostics = registration.diagnostics;
-        let _blk_diags = check_block(statement.body, [], interfaces);
+        let _blk_diags = check_block(statement.body, [], interfaces, imports);
         let mut _ci: int = 0;
         loop {
             if _ci >= _blk_diags.length { break; }
@@ -355,27 +382,27 @@ fn check_statement(statement: Statement, bindings: SymbolEntry[], interfaces: St
     if statement.variant == "WithStatement" {
         return ScopeResult {
             bindings: bindings,
-            diagnostics: check_block(statement.body, bindings, interfaces)
+            diagnostics: check_block(statement.body, bindings, interfaces, imports)
         };
     }
     if statement.variant == "ForStatement" {
-        let target_diags = walk_expression(statement.clause.target, bindings);
-        let iter_diags = walk_expression(statement.clause.iterable, bindings);
-        let body_diags = check_block(statement.body, bindings, interfaces);
+        let target_diags = walk_expression(statement.clause.target, bindings, imports);
+        let iter_diags = walk_expression(statement.clause.iterable, bindings, imports);
+        let body_diags = check_block(statement.body, bindings, interfaces, imports);
         return ScopeResult {
             bindings: bindings,
             diagnostics: target_diags.concat(iter_diags).concat(body_diags)
         };
     }
     if statement.variant == "MatchStatement" {
-        let mut diagnostics = walk_expression(statement.expression, bindings);
+        let mut diagnostics = walk_expression(statement.expression, bindings, imports);
         let mut index: int = 0;
         loop {
             if index >= statement.cases.length { break; }
             let case = statement.cases[index];
-            diagnostics = diagnostics.concat(walk_expression(case.pattern, bindings));
-            diagnostics = diagnostics.concat(walk_expression(case.guard, bindings));
-            let _blk_diags = check_block(case.body, bindings, interfaces);
+            diagnostics = diagnostics.concat(walk_expression(case.pattern, bindings, imports));
+            diagnostics = diagnostics.concat(walk_expression(case.guard, bindings, imports));
+            let _blk_diags = check_block(case.body, bindings, interfaces, imports);
             let mut _ci: int = 0;
             loop {
                 if _ci >= _blk_diags.length { break; }
@@ -387,12 +414,12 @@ fn check_statement(statement: Statement, bindings: SymbolEntry[], interfaces: St
         return ScopeResult { bindings: bindings, diagnostics: diagnostics };
     }
     if statement.variant == "IfStatement" {
-        let mut diagnostics = walk_expression(statement.condition, bindings);
-        diagnostics = diagnostics.concat(check_block(statement.then_block, bindings, interfaces));
+        let mut diagnostics = walk_expression(statement.condition, bindings, imports);
+        diagnostics = diagnostics.concat(check_block(statement.then_block, bindings, interfaces, imports));
         if statement.else_branch != null {
             let branch = statement.else_branch;
             if branch.body != null {
-                let _blk_diags = check_block(branch.body, bindings, interfaces);
+                let _blk_diags = check_block(branch.body, bindings, interfaces, imports);
                 let mut _ci: int = 0;
                 loop {
                     if _ci >= _blk_diags.length { break; }
@@ -401,7 +428,7 @@ fn check_statement(statement: Statement, bindings: SymbolEntry[], interfaces: St
                 }
             }
             if branch.statement != null {
-                let result = check_statement(branch.statement, bindings, interfaces, scope_start);
+                let result = check_statement(branch.statement, bindings, interfaces, scope_start, imports);
                 let mut _ci2: int = 0;
                 loop {
                     if _ci2 >= result.diagnostics.length { break; }
@@ -415,7 +442,7 @@ fn check_statement(statement: Statement, bindings: SymbolEntry[], interfaces: St
     if statement.variant == "BlockStatement" {
         return ScopeResult {
             bindings: bindings,
-            diagnostics: check_block(statement.body, bindings, interfaces)
+            diagnostics: check_block(statement.body, bindings, interfaces, imports)
         };
     }
     if statement.variant == "TypeAliasDeclaration" {
@@ -436,13 +463,13 @@ fn check_statement(statement: Statement, bindings: SymbolEntry[], interfaces: St
     if statement.variant == "ExpressionStatement" {
         return ScopeResult {
             bindings: bindings,
-            diagnostics: walk_expression(statement.expression, bindings)
+            diagnostics: walk_expression(statement.expression, bindings, imports)
         };
     }
     if statement.variant == "ReturnStatement" {
         return ScopeResult {
             bindings: bindings,
-            diagnostics: walk_expression(statement.expression, bindings)
+            diagnostics: walk_expression(statement.expression, bindings, imports)
         };
     }
     if statement.variant == "Unknown" {
@@ -465,9 +492,9 @@ fn check_statement(statement: Statement, bindings: SymbolEntry[], interfaces: St
     return ScopeResult { bindings: bindings, diagnostics: [] };
 }
 
-fn check_function_body(signature: FunctionSignature, body: Block, interfaces: Statement[]) -> Diagnostic[] {
+fn check_function_body(signature: FunctionSignature, body: Block, interfaces: Statement[], imports: ImportSymbolTable) -> Diagnostic[] {
     let parameter_scope = seed_parameter_scope(signature);
-    let body_diagnostics = check_block(body, parameter_scope.bindings, interfaces);
+    let body_diagnostics = check_block(body, parameter_scope.bindings, interfaces, imports);
     let mut _result = parameter_scope.diagnostics;
     let mut _ci: int = 0;
     loop {
@@ -496,13 +523,13 @@ fn seed_parameter_scope(signature: FunctionSignature) -> ScopeResult {
     return ScopeResult { bindings: bindings, diagnostics: diagnostics };
 }
 
-fn check_block(block: Block, parent_bindings: SymbolEntry[], interfaces: Statement[]) -> Diagnostic[] {
+fn check_block(block: Block, parent_bindings: SymbolEntry[], interfaces: Statement[], imports: ImportSymbolTable) -> Diagnostic[] {
     let mut bindings = clone_bindings(parent_bindings);
     let scope_start = bindings.length;
     let mut diagnostics: Diagnostic[] = [];
 
     for statement in block.statements {
-        let result = check_statement(statement, bindings, interfaces, scope_start);
+        let result = check_statement(statement, bindings, interfaces, scope_start, imports);
         bindings = result.bindings;
         let mut _ci: int = 0;
         loop {
@@ -614,7 +641,8 @@ fn _trim_main_type_text(text: string) -> string {
     return result;
 }
 
-// Expression walker — issue #809 (#616 sub-issue 1).
+// Expression walker — issue #809 (#616 sub-issue 1), extended in
+// issue #811 (sub-issue 3) to thread the `ImportSymbolTable` through.
 //
 // The typechecker historically only visited statements; expression
 // positions (call arguments, return values, let-initializers, match
@@ -624,35 +652,46 @@ fn _trim_main_type_text(text: string) -> string {
 // traversal points without touching the recursion shape.
 //
 // The walker is intentionally non-emitting in this issue: every variant
-// returns `[]`. Wiring it into `check_statement` here ensures the
-// pre-enforcement traversal is exercised by `make check`, so issue D
-// only adds the diagnostic logic and not the plumbing.
-fn walk_expression(expression: Expression?, bindings: SymbolEntry[]) -> Diagnostic[] {
+// returns `[]`. The cross-module resolution lookup against `imports`
+// runs on the Call/Identifier branch (see `typecheck_walker_resolves_import`)
+// but its result is discarded. Issue D (#616 sub-issue 4) will promote
+// the resolution boolean to an undefined-callee diagnostic; this issue
+// pins the plumbing so issue D adds emission logic without re-doing
+// the traversal.
+fn walk_expression(expression: Expression?, bindings: SymbolEntry[], imports: ImportSymbolTable) -> Diagnostic[] {
     if expression == null { return []; }
     if expression.variant == "Call" {
-        let mut diagnostics = walk_expression(expression.callee, bindings);
+        let mut diagnostics = walk_expression(expression.callee, bindings, imports);
+        // Phase E1 wiring: resolve a free-function callee against the
+        // localized import table. The boolean is discarded — issue D
+        // will switch this to an emit-when-unresolved branch.
+        if expression.callee != null {
+            if expression.callee.variant == "Identifier" {
+                let _resolved = typecheck_walker_resolves_import(expression.callee.name, imports);
+            }
+        }
         let mut index: int = 0;
         loop {
             if index >= expression.arguments.length { break; }
-            diagnostics = diagnostics.concat(walk_expression(expression.arguments[index], bindings));
+            diagnostics = diagnostics.concat(walk_expression(expression.arguments[index], bindings, imports));
             index += 1;
         }
         return diagnostics;
     }
     if expression.variant == "Binary" {
-        let mut diagnostics = walk_expression(expression.left, bindings);
-        diagnostics = diagnostics.concat(walk_expression(expression.right, bindings));
+        let mut diagnostics = walk_expression(expression.left, bindings, imports);
+        diagnostics = diagnostics.concat(walk_expression(expression.right, bindings, imports));
         return diagnostics;
     }
     if expression.variant == "Unary" {
-        return walk_expression(expression.operand, bindings);
+        return walk_expression(expression.operand, bindings, imports);
     }
     if expression.variant == "Member" {
-        return walk_expression(expression.object, bindings);
+        return walk_expression(expression.object, bindings, imports);
     }
     if expression.variant == "Index" {
-        let mut diagnostics = walk_expression(expression.sequence, bindings);
-        diagnostics = diagnostics.concat(walk_expression(expression.index, bindings));
+        let mut diagnostics = walk_expression(expression.sequence, bindings, imports);
+        diagnostics = diagnostics.concat(walk_expression(expression.index, bindings, imports));
         return diagnostics;
     }
     if expression.variant == "Array" {
@@ -660,7 +699,7 @@ fn walk_expression(expression: Expression?, bindings: SymbolEntry[]) -> Diagnost
         let mut index: int = 0;
         loop {
             if index >= expression.elements.length { break; }
-            diagnostics = diagnostics.concat(walk_expression(expression.elements[index], bindings));
+            diagnostics = diagnostics.concat(walk_expression(expression.elements[index], bindings, imports));
             index += 1;
         }
         return diagnostics;
@@ -670,7 +709,7 @@ fn walk_expression(expression: Expression?, bindings: SymbolEntry[]) -> Diagnost
         let mut index: int = 0;
         loop {
             if index >= expression.fields.length { break; }
-            diagnostics = diagnostics.concat(walk_expression(expression.fields[index].value, bindings));
+            diagnostics = diagnostics.concat(walk_expression(expression.fields[index].value, bindings, imports));
             index += 1;
         }
         return diagnostics;
@@ -680,23 +719,35 @@ fn walk_expression(expression: Expression?, bindings: SymbolEntry[]) -> Diagnost
         let mut index: int = 0;
         loop {
             if index >= expression.fields.length { break; }
-            diagnostics = diagnostics.concat(walk_expression(expression.fields[index].value, bindings));
+            diagnostics = diagnostics.concat(walk_expression(expression.fields[index].value, bindings, imports));
             index += 1;
         }
         return diagnostics;
     }
     if expression.variant == "Lambda" {
-        return walk_block_expressions(expression.body, bindings);
+        return walk_block_expressions(expression.body, bindings, imports);
     }
     if expression.variant == "Range" {
-        let mut diagnostics = walk_expression(expression.start, bindings);
-        diagnostics = diagnostics.concat(walk_expression(expression.end, bindings));
+        let mut diagnostics = walk_expression(expression.start, bindings, imports);
+        diagnostics = diagnostics.concat(walk_expression(expression.end, bindings, imports));
         return diagnostics;
     }
     if expression.variant == "Cast" {
-        return walk_expression(expression.operand, bindings);
+        return walk_expression(expression.operand, bindings, imports);
     }
     return [];
+}
+
+// Resolution probe used by the typecheck walker (issue #811). Returns
+// whether `name` resolves to an imported free function in `imports`.
+// The walker calls this at every Call/Identifier site and discards the
+// result; issue D (#616 sub-issue 4) will promote the boolean to an
+// undefined-callee diagnostic. Exposed publicly so unit tests can pin
+// the symbol-aware path before emission flips on — see
+// `typecheck_imports_test.sfn`.
+fn typecheck_walker_resolves_import(name: string, imports: ImportSymbolTable) -> boolean {
+    let entry = lookup_imported_function(imports, name);
+    return entry != null;
 }
 
 // Walks expressions inside a block — used by `walk_expression`'s Lambda
@@ -704,59 +755,59 @@ fn walk_expression(expression: Expression?, bindings: SymbolEntry[]) -> Diagnost
 // Top-level statement traversal still flows through `check_block` →
 // `check_statement`; this helper is only the expression-positions
 // recursion for lambda bodies (which `check_block` never descends into).
-fn walk_block_expressions(block: Block, bindings: SymbolEntry[]) -> Diagnostic[] {
+fn walk_block_expressions(block: Block, bindings: SymbolEntry[], imports: ImportSymbolTable) -> Diagnostic[] {
     let mut diagnostics: Diagnostic[] = [];
     let mut index: int = 0;
     loop {
         if index >= block.statements.length { break; }
-        diagnostics = diagnostics.concat(walk_statement_expressions(block.statements[index], bindings));
+        diagnostics = diagnostics.concat(walk_statement_expressions(block.statements[index], bindings, imports));
         index += 1;
     }
     return diagnostics;
 }
 
-fn walk_statement_expressions(statement: Statement, bindings: SymbolEntry[]) -> Diagnostic[] {
+fn walk_statement_expressions(statement: Statement, bindings: SymbolEntry[], imports: ImportSymbolTable) -> Diagnostic[] {
     if statement.variant == "ExpressionStatement" {
-        return walk_expression(statement.expression, bindings);
+        return walk_expression(statement.expression, bindings, imports);
     }
     if statement.variant == "ReturnStatement" {
-        return walk_expression(statement.expression, bindings);
+        return walk_expression(statement.expression, bindings, imports);
     }
     if statement.variant == "ThrowStatement" {
-        return walk_expression(statement.expression, bindings);
+        return walk_expression(statement.expression, bindings, imports);
     }
     if statement.variant == "VariableDeclaration" {
-        return walk_expression(statement.initializer, bindings);
+        return walk_expression(statement.initializer, bindings, imports);
     }
     if statement.variant == "IfStatement" {
-        let mut diagnostics = walk_expression(statement.condition, bindings);
-        diagnostics = diagnostics.concat(walk_block_expressions(statement.then_block, bindings));
+        let mut diagnostics = walk_expression(statement.condition, bindings, imports);
+        diagnostics = diagnostics.concat(walk_block_expressions(statement.then_block, bindings, imports));
         if statement.else_branch != null {
             let branch = statement.else_branch;
             if branch.body != null {
-                diagnostics = diagnostics.concat(walk_block_expressions(branch.body, bindings));
+                diagnostics = diagnostics.concat(walk_block_expressions(branch.body, bindings, imports));
             }
             if branch.statement != null {
-                diagnostics = diagnostics.concat(walk_statement_expressions(branch.statement, bindings));
+                diagnostics = diagnostics.concat(walk_statement_expressions(branch.statement, bindings, imports));
             }
         }
         return diagnostics;
     }
     if statement.variant == "ForStatement" {
-        let mut diagnostics = walk_expression(statement.clause.target, bindings);
-        diagnostics = diagnostics.concat(walk_expression(statement.clause.iterable, bindings));
-        diagnostics = diagnostics.concat(walk_block_expressions(statement.body, bindings));
+        let mut diagnostics = walk_expression(statement.clause.target, bindings, imports);
+        diagnostics = diagnostics.concat(walk_expression(statement.clause.iterable, bindings, imports));
+        diagnostics = diagnostics.concat(walk_block_expressions(statement.body, bindings, imports));
         return diagnostics;
     }
     if statement.variant == "MatchStatement" {
-        let mut diagnostics = walk_expression(statement.expression, bindings);
+        let mut diagnostics = walk_expression(statement.expression, bindings, imports);
         let mut index: int = 0;
         loop {
             if index >= statement.cases.length { break; }
             let case = statement.cases[index];
-            diagnostics = diagnostics.concat(walk_expression(case.pattern, bindings));
-            diagnostics = diagnostics.concat(walk_expression(case.guard, bindings));
-            diagnostics = diagnostics.concat(walk_block_expressions(case.body, bindings));
+            diagnostics = diagnostics.concat(walk_expression(case.pattern, bindings, imports));
+            diagnostics = diagnostics.concat(walk_expression(case.guard, bindings, imports));
+            diagnostics = diagnostics.concat(walk_block_expressions(case.body, bindings, imports));
             index += 1;
         }
         return diagnostics;
@@ -766,25 +817,25 @@ fn walk_statement_expressions(statement: Statement, bindings: SymbolEntry[]) -> 
         let mut clause_index: int = 0;
         loop {
             if clause_index >= statement.clauses.length { break; }
-            diagnostics = diagnostics.concat(walk_expression(statement.clauses[clause_index].expression, bindings));
+            diagnostics = diagnostics.concat(walk_expression(statement.clauses[clause_index].expression, bindings, imports));
             clause_index += 1;
         }
-        diagnostics = diagnostics.concat(walk_block_expressions(statement.body, bindings));
+        diagnostics = diagnostics.concat(walk_block_expressions(statement.body, bindings, imports));
         return diagnostics;
     }
     if statement.variant == "LoopStatement" {
-        return walk_block_expressions(statement.body, bindings);
+        return walk_block_expressions(statement.body, bindings, imports);
     }
     if statement.variant == "BlockStatement" {
-        return walk_block_expressions(statement.body, bindings);
+        return walk_block_expressions(statement.body, bindings, imports);
     }
     if statement.variant == "TryStatement" {
-        let mut diagnostics = walk_block_expressions(statement.try_block, bindings);
+        let mut diagnostics = walk_block_expressions(statement.try_block, bindings, imports);
         if statement.catch_block != null {
-            diagnostics = diagnostics.concat(walk_block_expressions(statement.catch_block, bindings));
+            diagnostics = diagnostics.concat(walk_block_expressions(statement.catch_block, bindings, imports));
         }
         if statement.finally_block != null {
-            diagnostics = diagnostics.concat(walk_block_expressions(statement.finally_block, bindings));
+            diagnostics = diagnostics.concat(walk_block_expressions(statement.finally_block, bindings, imports));
         }
         return diagnostics;
     }

--- a/compiler/src/typecheck.sfn
+++ b/compiler/src/typecheck.sfn
@@ -16,7 +16,12 @@ import {
     TypeAnnotation,
     TypeParameter
 } from "./ast";
-import { ImportSymbolTable, empty_import_symbols, lookup_imported_function } from "./effect_imports";
+import {
+    ImportSymbolTable,
+    empty_import_symbols,
+    localize_import_symbols_for_program,
+    lookup_imported_function
+} from "./effect_imports";
 import { Token, TokenKind } from "./token";
 import {
     Diagnostic,
@@ -89,12 +94,23 @@ fn typecheck_diagnostics_with_imports(program: Program, imported_interfaces: Sta
 // pre-resolver call paths can keep using the 2-arg
 // `typecheck_diagnostics_with_imports` (which delegates here with an
 // empty table).
+//
+// The caller passes the GLOBAL symbol table the loader produced from
+// the dependency `.sfn-asm` artifacts; this entry localizes it once
+// against `program`'s `import { ... }` specifiers (alias rewrites +
+// scope filter) so the per-`Call` lookup keys directly off the
+// localized identifier name — mirroring `effect_checker.validate_-
+// effects_with_imports` (effect_checker.sfn:185). Without the
+// localization step issue D would treat any function exported by
+// any loaded dependency as resolved, including names this program
+// never imported.
 fn typecheck_diagnostics_with_import_symbols(program: Program, imported_interfaces: Statement[], imported_function_effects: ImportSymbolTable) -> Diagnostic[] {
+    let local_imports = localize_import_symbols_for_program(program, imported_function_effects);
     let top_level = collect_top_level_symbols(program);
     let local_interfaces = collect_interface_definitions(program);
     let filtered_imports = _filter_interface_declarations(imported_interfaces);
     let combined_interfaces = local_interfaces.concat(filtered_imports);
-    let scoped_diagnostics = check_program_scopes(program, combined_interfaces, imported_function_effects);
+    let scoped_diagnostics = check_program_scopes(program, combined_interfaces, local_imports);
 
     // Merge diagnostics using concat (avoids loop-with-if-break pattern that
     // the compiler lowers incorrectly — loops emit without exit conditions).

--- a/compiler/tests/unit/typecheck_imports_test.sfn
+++ b/compiler/tests/unit/typecheck_imports_test.sfn
@@ -311,12 +311,14 @@ test "typecheck walker: empty import table resolves nothing" {
     assert ! typecheck_walker_resolves_import("imported_helper", imports);
 }
 
-test "typecheck walker: import-symbol-aware path emits no diagnostics for imported callee" {
+test "typecheck walker: import-symbol-aware path emits no diagnostics for actually-imported callee" {
     // Pre-enforcement state: even with the import table threaded
-    // through, the walker discards its resolution result. Issue D
-    // will replace this assertion with one that expects the resolved
-    // call to be silent and the unresolved one to emit.
-    let source = "fn main() { imported_helper(\"hi\"); }";
+    // through, the walker discards its resolution result. The source
+    // includes an `import { imported_helper }` specifier so the
+    // entry point's `localize_import_symbols_for_program` retains
+    // the entry; issue D will replace this assertion with one that
+    // expects the resolved call to be silent.
+    let source = "import { imported_helper } from \"./helpers\";\nfn main() { imported_helper(\"hi\"); }";
     let program = parse_program(source);
     let imports = _make_imports_with_helper();
     let no_interfaces: Statement[] = [];
@@ -326,9 +328,27 @@ test "typecheck walker: import-symbol-aware path emits no diagnostics for import
 
 test "typecheck walker: import-symbol-aware path emits no diagnostics for unresolved callee" {
     // Companion to the test above — proves the walker is silent on
-    // calls that DON'T resolve in the table too. Issue D flips this
-    // to expect a diagnostic.
+    // calls that DON'T resolve in the (localized) table either.
+    // Issue D flips this to expect a diagnostic.
     let source = "fn main() { not_imported(\"hi\"); }";
+    let program = parse_program(source);
+    let imports = _make_imports_with_helper();
+    let no_interfaces: Statement[] = [];
+    let diagnostics = typecheck_diagnostics_with_import_symbols(program, no_interfaces, imports);
+    assert diagnostics.length == 0;
+}
+
+test "typecheck walker: localization drops globally-present but un-imported names" {
+    // Regression guard for the localization step — without the
+    // `localize_import_symbols_for_program` call inside
+    // `typecheck_diagnostics_with_import_symbols`, any function
+    // exported by any loaded dependency would resolve, even when the
+    // caller program never imported it. Today the walker emits
+    // nothing, so we assert via no-crash + zero diagnostics; issue D
+    // will switch this to expect the E0420 undefined-callee diagnostic
+    // (because the name is NOT in the localized table). Both shapes
+    // require the entry point to localize before traversal.
+    let source = "fn main() { imported_helper(\"hi\"); }";
     let program = parse_program(source);
     let imports = _make_imports_with_helper();
     let no_interfaces: Statement[] = [];

--- a/compiler/tests/unit/typecheck_imports_test.sfn
+++ b/compiler/tests/unit/typecheck_imports_test.sfn
@@ -8,7 +8,15 @@
 // test bodies — see check_tool_test.sfn preamble).
 //
 // See docs/proposals/check-architecture.md.
+import { Statement } from "../../src/ast";
+import { ImportSymbolTable, append_import_function, empty_import_symbols } from "../../src/effect_imports";
 import { NativeInterface, NativeInterfaceSignature, NativeParameter } from "../../src/native_ir";
+import { parse_program } from "../../src/parser/mod";
+import {
+    typecheck_diagnostics_with_import_symbols,
+    typecheck_diagnostics_with_imports,
+    typecheck_walker_resolves_import
+} from "../../src/typecheck";
 import {
     interface_statement_from_native,
     interfaces_from_native,
@@ -263,4 +271,79 @@ test "typecheck_imports: multiple natives are converted in order" {
     assert strings_equal(result[0].name, "A");
     assert strings_equal(result[1].name, "B");
     assert strings_equal(result[2].name, "C");
+}
+
+// -------------------------------------------------------------------
+// Tests — typecheck walker resolution probe (issue #811)
+//
+// Issue #811 threads the `ImportSymbolTable` through the typecheck
+// walker so issue D (#616 sub-issue 4) can promote unresolved-callee
+// lookups into diagnostics without re-doing the plumbing. These tests
+// pin the pre-enforcement state:
+//
+//   * The resolution probe `typecheck_walker_resolves_import` agrees
+//     with `lookup_imported_function` (true for imported names, false
+//     otherwise). This is the same lookup the walker uses internally.
+//   * Threading an import table through
+//     `typecheck_diagnostics_with_import_symbols` does NOT emit a new
+//     diagnostic for a program that calls an imported helper today —
+//     issue D will flip the emission gate.
+//   * The 2-arg back-compat entry point still works.
+// -------------------------------------------------------------------
+fn _make_imports_with_helper() -> ImportSymbolTable {
+    let mut table = empty_import_symbols();
+    let effects: string[] = ["io"];
+    return append_import_function(table, "imported_helper", effects);
+}
+
+test "typecheck walker: resolves imported callee against symbol table" {
+    let imports = _make_imports_with_helper();
+    assert typecheck_walker_resolves_import("imported_helper", imports);
+}
+
+test "typecheck walker: does not resolve unimported callee" {
+    let imports = _make_imports_with_helper();
+    assert ! typecheck_walker_resolves_import("not_imported", imports);
+}
+
+test "typecheck walker: empty import table resolves nothing" {
+    let imports = empty_import_symbols();
+    assert ! typecheck_walker_resolves_import("imported_helper", imports);
+}
+
+test "typecheck walker: import-symbol-aware path emits no diagnostics for imported callee" {
+    // Pre-enforcement state: even with the import table threaded
+    // through, the walker discards its resolution result. Issue D
+    // will replace this assertion with one that expects the resolved
+    // call to be silent and the unresolved one to emit.
+    let source = "fn main() { imported_helper(\"hi\"); }";
+    let program = parse_program(source);
+    let imports = _make_imports_with_helper();
+    let no_interfaces: Statement[] = [];
+    let diagnostics = typecheck_diagnostics_with_import_symbols(program, no_interfaces, imports);
+    assert diagnostics.length == 0;
+}
+
+test "typecheck walker: import-symbol-aware path emits no diagnostics for unresolved callee" {
+    // Companion to the test above — proves the walker is silent on
+    // calls that DON'T resolve in the table too. Issue D flips this
+    // to expect a diagnostic.
+    let source = "fn main() { not_imported(\"hi\"); }";
+    let program = parse_program(source);
+    let imports = _make_imports_with_helper();
+    let no_interfaces: Statement[] = [];
+    let diagnostics = typecheck_diagnostics_with_import_symbols(program, no_interfaces, imports);
+    assert diagnostics.length == 0;
+}
+
+test "typecheck walker: 2-arg back-compat path still typechecks clean" {
+    // The legacy 2-arg `typecheck_diagnostics_with_imports` must keep
+    // working — it now delegates to the 3-arg variant with an empty
+    // import table. The diagnostic count must be unchanged for the
+    // pre-issue-#811 callers.
+    let source = "fn main() { imported_helper(\"hi\"); }";
+    let program = parse_program(source);
+    let no_interfaces: Statement[] = [];
+    let diagnostics = typecheck_diagnostics_with_imports(program, no_interfaces);
+    assert diagnostics.length == 0;
 }


### PR DESCRIPTION
## Summary

Adds a symbol-aware typecheck entry point that threads the per-program-localized `ImportSymbolTable` through the scope walker introduced in #809, so issue D (#812, the enforcement flip) can promote unresolved-callee lookups into diagnostics without re-doing the plumbing.

- New entry `typecheck_diagnostics_with_import_symbols(program, imported_interfaces, imported_function_effects)` that threads the table through `check_program_scopes → check_statement → check_block → check_function_body → walk_expression` (plus the lambda-body helpers). It **localizes the global table internally** via `localize_import_symbols_for_program`, mirroring `effect_checker.validate_effects_with_imports` — callers always pass the loader-built global.
- New resolution probe `typecheck_walker_resolves_import(name, imports)` that the walker calls at every `Call/Identifier` site. The boolean is discarded today; issue D will swap the call site for an emit-when-unresolved branch.
- `typecheck_diagnostics_with_imports` (2-arg) is retained for back-compat and delegates to the new entry with `empty_import_symbols()`.
- Wired the two call sites that already have an `ImportSymbolTable` in scope:
  - `main.sfn` `compile_tests_to_llvm_file_with_module_imports` (the resolver-driven test compile path).
  - `tools/check.sfn` `check_source_with_imports` (the `sfn check` path) — required so #812's `E0420` flip fires correctly under `sfn check` instead of false-positiving on every imported callee.

Closes #811

## Acceptance Criteria

- [x] `typecheck_diagnostics_with_imports` retains its current 2-arg signature (back-compat); the symbol-aware path is additive.
- [x] A unit test builds an `ImportSymbolTable` with `imported_helper` and asserts the walker resolves it via `typecheck_walker_resolves_import` (the same probe the walker calls).
- [x] Import-using integration tests (`typecheck_imports_test.sfn`) still pass — all 24 tests (17 pre-existing + 7 new) green.
- [x] `make compile` passes.
- [x] `make test` passes (unit 104, integration 28, e2e 79, capsules 16 — all green).
- [x] `make check` self-hosts end-to-end (first-pass + seedcheck).
- [x] `sfn fmt --check` clean on every touched `.sfn` file.

## Verification

```bash
ulimit -v 8388608 && make compile && make test
# unit: 104/104 passed
# integration: 28/28 passed
# e2e: 79/79 passed
# capsules: 16/16 passed
```

## Files Changed

- `compiler/src/typecheck.sfn` — new entry point (with internal localization) + threaded `ImportSymbolTable` through walker + `typecheck_walker_resolves_import` probe
- `compiler/src/main.sfn` — call-site wiring at `compile_tests_to_llvm_file_with_module_imports`
- `compiler/src/tools/check.sfn` — wired the `sfn check` path to the symbol-aware entry point
- `compiler/tests/unit/typecheck_imports_test.sfn` — seven new tests pinning the symbol-aware path and the localization step

## Notes

- The walker's resolution lookup is non-emitting on this issue per design — issue D (#812) flips the emission gate. Tests therefore assert *zero* diagnostics on both resolved and unresolved callees today; issue D will rewrite these assertions.
- **Localization** is applied inside the entry point (per Copilot review feedback): without it the walker would resolve any function exported by any loaded dependency, even names the program never imported, and would miss `import { foo as bar }` alias rewrites.
- One integration test (`closure_lifting_test.sfn`) intermittently fails on the first `make test` run but passes on rerun and is unrelated to this change (no closure-handling code is touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3AwxhJeK9vsCKSZ5Qsaaj)_