### PR TITLE
refactor(build): collapse Makefile test-* loops into one sfn test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,21 @@ else
 endif
 	@echo "[install] installed $(DESTDIR)$(BINDIR)/$(INSTALL_NAME)$(EXE_EXT)"
 
-test: test-unit test-integration test-e2e test-capsules
+# Issue #848 (epic #840 Phase 1.2): the four suite shell loops
+# collapsed into one `sfn test` invocation that walks every path,
+# tallies per-suite, and emits the per-suite `═══ <name>: N/M ═══`
+# banners directly. `test-unit` / `test-integration` / `test-e2e` /
+# `test-capsules` keep their names as aliases over the same runner
+# with different paths. The legacy e2e `test_*.sh` scripts still
+# run from `make test` / `make test-e2e` via `test-e2e-sh` — Phase
+# 3.1 migrates them and retires the .sh branch.
+test:
+	@if [ ! -x $(NATIVE_BIN) ]; then \
+		echo "[test] missing $(NATIVE_BIN); running make compile"; \
+		$(MAKE) compile; \
+	fi
+	@$(NATIVE_BIN) test compiler/tests/unit compiler/tests/integration compiler/tests/e2e capsules
+	@$(MAKE) test-e2e-sh
 
 # =============================================================================
 # Seed management (download a released compiler)
@@ -192,82 +206,66 @@ fetch-seed:
 	@"$(FETCHED_SEED)" version
 	@echo "[fetch-seed] hint: make compile SEED=$(FETCHED_SEED)"
 
+# Aliases over the unified runner (issue #848). Each suite still
+# runs as one `sfn test` invocation; the per-suite banner the
+# Makefile loops used to emit now comes from `_emit_suite_banners`
+# in `handle_test_command`.
 test-unit:
 	@if [ ! -x $(NATIVE_BIN) ]; then \
 		echo "[test-unit] missing $(NATIVE_BIN); running make compile"; \
 		$(MAKE) compile; \
 	fi
-	@pass=0; fail=0; failed_files=""; \
-	files=$$(find compiler/tests/unit -name '*_test.sfn' -print | sort); \
-	if [ -z "$$files" ]; then \
-		echo "[test-unit] no *_test.sfn files found under compiler/tests/unit"; \
-		exit 1; \
-	fi; \
-	for f in $$files; do \
-		if bash scripts/run_native_test.sh $(NATIVE_BIN) "$$f"; then \
-			pass=$$((pass + 1)); \
-		else \
-			fail=$$((fail + 1)); \
-			failed_files="$$failed_files  $$(basename $$f)\n"; \
-		fi; \
-	done; \
-	total=$$((pass + fail)); \
-	echo ""; \
-	echo "═══ unit: $$pass/$$total passed, $$fail failed ═══"; \
-	if [ $$fail -gt 0 ]; then \
-		echo ""; \
-		printf '%b' "$$failed_files"; \
-		exit 1; \
-	fi
+	@$(NATIVE_BIN) test compiler/tests/unit
 
 test-integration:
 	@if [ ! -x $(NATIVE_BIN) ]; then \
 		echo "[test-integration] missing $(NATIVE_BIN); running make compile"; \
 		$(MAKE) compile; \
 	fi
-	@pass=0; fail=0; failed_files=""; \
-	files=$$(find compiler/tests/integration -name '*_test.sfn' -print | sort); \
-	if [ -z "$$files" ]; then \
-		echo "[test-integration] no *_test.sfn files found under compiler/tests/integration"; \
-		exit 1; \
-	fi; \
-	for f in $$files; do \
-		if bash scripts/run_native_test.sh $(NATIVE_BIN) "$$f"; then \
-			pass=$$((pass + 1)); \
-		else \
-			fail=$$((fail + 1)); \
-			failed_files="$$failed_files  $$(basename $$f)\n"; \
-		fi; \
-	done; \
-	total=$$((pass + fail)); \
-	echo ""; \
-	echo "═══ integration: $$pass/$$total passed, $$fail failed ═══"; \
-	if [ $$fail -gt 0 ]; then \
-		echo ""; \
-		printf '%b' "$$failed_files"; \
-		exit 1; \
-	fi
+	@$(NATIVE_BIN) test compiler/tests/integration
 
+# The legacy e2e `test_*.sh` scripts still run alongside the `.sfn`
+# tests until Phase 3.1 migrates them (see
+# `docs/proposals/test-infra-epic/02-phases.md` Phase 3.1). Until
+# then `test-e2e-sh` keeps the bash-driven scripts on the same
+# `make test-e2e` / `make test` paths they were on before #848.
 test-e2e:
 	@if [ ! -x $(NATIVE_BIN) ]; then \
 		echo "[test-e2e] missing $(NATIVE_BIN); running make compile"; \
 		$(MAKE) compile; \
 	fi
+	@$(NATIVE_BIN) test compiler/tests/e2e
+	@$(MAKE) test-e2e-sh
+
+# Per-capsule tests live alongside each capsule under
+# `capsules/<scope>/<name>/tests/*_test.sfn`. The unified runner's
+# directory BFS walks every nested `tests/` dir from `capsules/`,
+# so passing just `capsules` matches the prior
+# `find capsules -path '*/tests/*_test.sfn'` discovery.
+test-capsules:
+	@if [ ! -x $(NATIVE_BIN) ]; then \
+		echo "[test-capsules] missing $(NATIVE_BIN); running make compile"; \
+		$(MAKE) compile; \
+	fi
+	@$(NATIVE_BIN) test capsules
+
+# Internal: the legacy e2e `.sh` script loop. Phase 3.1 (parent
+# epic #840) ports each `test_*.sh` to a `_test.sfn` peer and
+# deletes both this target and the source scripts. Until then it
+# emits a `═══ e2e-sh: N/M passed ═══` banner shaped like the
+# runner's own per-suite banners so log scrubbers see one format
+# across the suite.
+.PHONY: test-e2e-sh
+test-e2e-sh:
 	@pass=0; fail=0; failed_files=""; \
-	files=$$(find compiler/tests/e2e -name '*_test.sfn' -print | sort); \
+	files=$$(find compiler/tests/e2e -name 'test_*.sh' -print | sort); \
 	if [ -z "$$files" ]; then \
-		echo "[test-e2e] no *_test.sfn files found under compiler/tests/e2e"; \
-		exit 1; \
+		echo "[test-e2e-sh] no test_*.sh scripts found under compiler/tests/e2e"; \
+		echo ""; \
+		echo "═══ e2e-sh: 0/0 passed, 0 failed ═══"; \
+		exit 0; \
 	fi; \
 	for f in $$files; do \
-		if bash scripts/run_native_test.sh $(NATIVE_BIN) "$$f"; then \
-			pass=$$((pass + 1)); \
-		else \
-			fail=$$((fail + 1)); \
-			failed_files="$$failed_files  $$(basename $$f)\n"; \
-		fi; \
-	done; \
-	for f in $$(find compiler/tests/e2e -name 'test_*.sh' -print | sort); do \
 		if bash "$$f" $(NATIVE_BIN); then \
 			pass=$$((pass + 1)); \
 		else \
@@ -277,42 +275,7 @@ test-e2e:
 	done; \
 	total=$$((pass + fail)); \
 	echo ""; \
-	echo "═══ e2e: $$pass/$$total passed, $$fail failed ═══"; \
-	if [ $$fail -gt 0 ]; then \
-		echo ""; \
-		printf '%b' "$$failed_files"; \
-		exit 1; \
-	fi
-
-# Per-capsule tests live alongside each capsule under
-# `capsules/<scope>/<name>/tests/*_test.sfn`. Discovered by
-# walking every `tests/` dir under `capsules/`. A capsule without a
-# `tests/` dir is silently skipped; the suite as a whole only fails
-# if at least one *_test.sfn exists somewhere and any of them fail.
-test-capsules:
-	@if [ ! -x $(NATIVE_BIN) ]; then \
-		echo "[test-capsules] missing $(NATIVE_BIN); running make compile"; \
-		$(MAKE) compile; \
-	fi
-	@pass=0; fail=0; failed_files=""; \
-	files=$$(find capsules -path '*/tests/*_test.sfn' -print 2>/dev/null | sort); \
-	if [ -z "$$files" ]; then \
-		echo "[test-capsules] no *_test.sfn files under capsules/*/tests"; \
-		echo ""; \
-		echo "═══ capsules: 0/0 passed, 0 failed ═══"; \
-		exit 0; \
-	fi; \
-	for f in $$files; do \
-		if bash scripts/run_native_test.sh $(NATIVE_BIN) "$$f"; then \
-			pass=$$((pass + 1)); \
-		else \
-			fail=$$((fail + 1)); \
-			failed_files="$$failed_files  $$(basename $$f)\n"; \
-		fi; \
-	done; \
-	total=$$((pass + fail)); \
-	echo ""; \
-	echo "═══ capsules: $$pass/$$total passed, $$fail failed ═══"; \
+	echo "═══ e2e-sh: $$pass/$$total passed, $$fail failed ═══"; \
 	if [ $$fail -gt 0 ]; then \
 		echo ""; \
 		printf '%b' "$$failed_files"; \

--- a/Makefile
+++ b/Makefile
@@ -155,8 +155,15 @@ test:
 		echo "[test] missing $(NATIVE_BIN); running make compile"; \
 		$(MAKE) compile; \
 	fi
-	@$(NATIVE_BIN) test compiler/tests/unit compiler/tests/integration compiler/tests/e2e capsules
-	@$(MAKE) test-e2e-sh
+	@# Run the unified runner, then the legacy e2e .sh scripts, and
+	@# surface a non-zero status if *either* failed. The `.sh` scripts
+	@# must still run even when a `.sfn` suite fails — matches the
+	@# pre-#848 `test-e2e` loop, which ran its `.sh` branch after the
+	@# `.sfn` branch regardless of `.sfn` failures.
+	@rc=0; \
+	$(NATIVE_BIN) test compiler/tests/unit compiler/tests/integration compiler/tests/e2e capsules || rc=$$?; \
+	$(MAKE) test-e2e-sh || rc=$$?; \
+	exit $$rc
 
 # =============================================================================
 # Seed management (download a released compiler)
@@ -234,8 +241,10 @@ test-e2e:
 		echo "[test-e2e] missing $(NATIVE_BIN); running make compile"; \
 		$(MAKE) compile; \
 	fi
-	@$(NATIVE_BIN) test compiler/tests/e2e
-	@$(MAKE) test-e2e-sh
+	@rc=0; \
+	$(NATIVE_BIN) test compiler/tests/e2e || rc=$$?; \
+	$(MAKE) test-e2e-sh || rc=$$?; \
+	exit $$rc
 
 # Per-capsule tests live alongside each capsule under
 # `capsules/<scope>/<name>/tests/*_test.sfn`. The unified runner's

--- a/compiler/src/cli_commands.sfn
+++ b/compiler/src/cli_commands.sfn
@@ -36,6 +36,7 @@ import {
     _shell_read_cmd,
     _shell_single_quote_arg,
     _string_contains_cmd,
+    _suite_name_from_path,
     _toml_trim_cmd,
     _write_text_cmd
 } from "./cli_commands_utils";
@@ -490,6 +491,57 @@ fn _find_test_group(groups: TestGroup[], key: string) -> int {
     return -1;
 }
 
+// `TestSuite`: per-positional-path bucket for banner emission.
+// Each positional `path` passed to `sfn test` becomes one suite;
+// the runner walks `path` for `*_test.sfn` files, runs them, and
+// emits a `═══ <name>: N/M passed, K failed ═══` banner per suite
+// after the test loop completes. Issue #848 (parent epic #840
+// Phase 1.2): consolidates the four Makefile shell loops
+// (`test-unit` / `test-integration` / `test-e2e` / `test-capsules`)
+// into a single `sfn test` invocation that emits the same banners
+// the loops used to.
+struct TestSuite {
+    name: string;
+    path: string;
+    pass_count: int;
+    fail_count: int;
+    failed_files: string[];
+}
+
+// Emit the per-suite `═══ <name>: N/M passed, K failed ═══` banner
+// for every suite, followed by an indented failed-files list when
+// the suite has failures. Format matches the pre-#848 Makefile
+// shell-loop output at `Makefile:215-220, 243-248, 279-284, 314-319`
+// exactly so log scrubbers and human readers see no diff. Called
+// once at end-of-run from `handle_test_command` only in non-JSON
+// mode — JSON consumers parse the structured summary event
+// instead.
+fn _emit_suite_banners(suites: TestSuite[]) ![io] {
+    let mut bi: int = 0;
+    loop {
+        if bi >= suites.length { break; }
+        let s = suites[bi];
+        let total = s.pass_count + s.fail_count;
+        print("");
+        print("═══ " + s.name + ": " + number_to_string(s.pass_count)
+            + "/"
+            + number_to_string(total)
+            + " passed, "
+            + number_to_string(s.fail_count)
+            + " failed ═══");
+        if s.fail_count > 0 {
+            print("");
+            let mut fi: int = 0;
+            loop {
+                if fi >= s.failed_files.length { break; }
+                print("  " + s.failed_files[fi]);
+                fi += 1;
+            }
+        }
+        bi += 1;
+    }
+}
+
 // Synthesize an `AssertFailure` for a test that was skipped or for
 // which we have no `fail.bin` record. `present=true` so the JSON
 // emitter still attaches an `assertion` object — consumers can
@@ -720,9 +772,12 @@ fn _should_retry_test(exit_code: int, retries_disabled: boolean) -> boolean {
 
 fn handle_test_command(args: string[], runtime_root: string) -> int ![io, clock] {
     // Flag parser: `--json` is the only recognised flag for now.
-    // Positional args carry the optional `path` argument; preserves
-    // pre-existing behaviour where `sfn test [path]` accepts at most
-    // one positional. The flag may appear before or after the path.
+    // Positional args carry one or more suite paths; each becomes a
+    // labelled `TestSuite` whose pass/fail tally gets its own
+    // `═══ <name>: N/M passed ═══` banner at end-of-run. Issue #848
+    // (parent epic #840 Phase 1.2): consolidates the four Makefile
+    // shell loops into a single invocation, so passing multiple
+    // positional paths replaced the prior single-path constraint.
     let mut json_output: boolean = false;
     let mut positional: string[] = [];
     let mut ai: int = 1;
@@ -734,13 +789,40 @@ fn handle_test_command(args: string[], runtime_root: string) -> int ![io, clock]
         }
         ai += 1;
     }
-    let mut root: string = ".";
-    if positional.length == 1 { root = positional[0]; } else if positional.length > 1 {
-        // Usage hints belong on stderr in `--json` mode so the stdout
-        // jsonl stream stays clean. Mirrored on the human path for
-        // consistency.
-        print.err("usage: sfn test [--json] [path]");
-        return 2;
+
+    // Build the suite list. Zero positional args defaults to a
+    // single "." suite (matches pre-#848 behaviour). One or more
+    // positionals become one suite each, named by their basename.
+    let mut suites: TestSuite[] = [];
+    if positional.length == 0 {
+        let empty_failed: string[] = [];
+        suites.push(TestSuite {
+            name: ".", path: ".", pass_count: 0, fail_count: 0, failed_files: empty_failed
+        });
+    } else {
+        let mut spi: int = 0;
+        loop {
+            if spi >= positional.length { break; }
+            let sp = positional[spi];
+            let sn = _suite_name_from_path(sp);
+            let empty_failed: string[] = [];
+            suites.push(TestSuite {
+                name: sn, path: sp, pass_count: 0, fail_count: 0, failed_files: empty_failed
+            });
+            spi += 1;
+        }
+    }
+
+    // Per-suite banner suppression rule: a single positional `.sfn`
+    // file path runs in legacy single-file mode (no banner). Every
+    // other shape — zero positionals, one directory, multiple
+    // paths — emits banners. Keeps `sfn test path/to/x_test.sfn`
+    // (the shape `scripts/run_native_test.sh` calls) byte-compatible
+    // with pre-#848 output so the wrapper's last-mile callers don't
+    // see decoration they weren't parsing before.
+    let mut emit_banners: boolean = true;
+    if positional.length == 1 && _ends_with_cmd(positional[0], ".sfn") {
+        emit_banners = false;
     }
 
     _ensure_dir_cmd("build");
@@ -759,7 +841,28 @@ fn handle_test_command(args: string[], runtime_root: string) -> int ![io, clock]
         || _legacy_flag_file("build/sailfin/.trace_test_runner");
     enter_test_runner_mode(trace_runner);
 
-    let test_files = _collect_test_files_cmd(root, 25);
+    // Walk each suite's path for `_test.sfn` files. `file_suite_index`
+    // tracks the originating suite per file so the loop can attribute
+    // pass/fail counts back to the right banner. The flat `test_files`
+    // list keeps the existing resolver-group partition + arena-mark
+    // loop shape downstream — only the upstream collection step
+    // fans out to multiple roots.
+    let mut test_files: string[] = [];
+    let mut file_suite_index: int[] = [];
+    let mut csi: int = 0;
+    loop {
+        if csi >= suites.length { break; }
+        let suite_files = _collect_test_files_cmd(suites[csi].path, 25);
+        let mut sfi: int = 0;
+        loop {
+            if sfi >= suite_files.length { break; }
+            test_files.push(suite_files[sfi]);
+            file_suite_index.push(csi);
+            sfi += 1;
+        }
+        csi += 1;
+    }
+
     if test_files.length == 0 {
         if json_output {
             // Still produce a valid jsonl stream so consumers don't
@@ -767,9 +870,30 @@ fn handle_test_command(args: string[], runtime_root: string) -> int ![io, clock]
             // events, summary with all zeros.
             print(render_start_event(0));
             print(render_summary_event(0, 0, 0, 0));
-        } else { print("no Sailfin test files found under: " + root); }
+            exit_test_runner_mode();
+            return 1;
+        }
+        // Human path: surface a hint for each suite that turned up
+        // empty (mirrors the per-target `[test-X] no *_test.sfn files`
+        // hints the four collapsed Makefile loops used to emit), then
+        // fall through to the empty-banner emission below so the
+        // suite tallies still print 0/0/0 — matches the pre-#848
+        // `test-capsules` behaviour where an empty `capsules/`
+        // produced a banner and exited 0. The other suite targets
+        // historically exited 1 on empty discovery; the unified
+        // runner standardises on the `test-capsules` shape because
+        // the banner already carries the "0/0 passed" signal.
+        let mut hi: int = 0;
+        loop {
+            if hi >= suites.length { break; }
+            print("[test-" + suites[hi].name
+                + "] no *_test.sfn files found under "
+                + suites[hi].path);
+            hi += 1;
+        }
+        if emit_banners { _emit_suite_banners(suites); }
         exit_test_runner_mode();
-        return 1;
+        return 0;
     }
 
     let ll_path = scratch_root + "/test.ll";
@@ -993,9 +1117,14 @@ fn handle_test_command(args: string[], runtime_root: string) -> int ![io, clock]
             // ...)`. Emit the same shape so callers parsing test
             // output (CI log scrubbers, human readers) see consistent
             // attribution regardless of which stage failed.
-            print("[test] FAIL: " + _package_basename(path) + " (exit code 1)");
-            exit_test_runner_mode();
-            return 1;
+            let cf_basename = _package_basename(path);
+            print("[test] FAIL: " + cf_basename + " (exit code 1)");
+            suites[file_suite_index[index]].fail_count += 1;
+            suites[file_suite_index[index]].failed_files.push(cf_basename);
+            if overall_rc == 0 { overall_rc = 1; }
+            sailfin_intrinsic_runtime_arena_rewind(test_scratch_mark);
+            index += 1;
+            continue;
         }
 
         if trace_runner { print.err("test runner: link start"); }
@@ -1021,11 +1150,16 @@ fn handle_test_command(args: string[], runtime_root: string) -> int ![io, clock]
             // attribution consistent across every failure stage so
             // tooling (CI scrubbers, human readers, future grep-based
             // log audits) sees one shape.
-            print("[test] FAIL: " + _package_basename(path) + " (exit code "
+            let lf_basename = _package_basename(path);
+            print("[test] FAIL: " + lf_basename + " (exit code "
                 + number_to_string(link_rc)
                 + ")");
-            exit_test_runner_mode();
-            return link_rc;
+            suites[file_suite_index[index]].fail_count += 1;
+            suites[file_suite_index[index]].failed_files.push(lf_basename);
+            if overall_rc == 0 { overall_rc = link_rc; }
+            sailfin_intrinsic_runtime_arena_rewind(test_scratch_mark);
+            index += 1;
+            continue;
         }
         // Issue #364: clear any leftover assert-fail record from the
         // previous iteration before spawning. The record is keyed
@@ -1108,14 +1242,19 @@ fn handle_test_command(args: string[], runtime_root: string) -> int ![io, clock]
             // `test failed:` lines already carry the per-step
             // attribution the grep heuristic was reconstructing
             // post-hoc.
-            print("[test] FAIL: " + _package_basename(path) + " (exit code "
+            let rf_basename = _package_basename(path);
+            print("[test] FAIL: " + rf_basename + " (exit code "
                 + number_to_string(run_rc)
                 + ")");
             if failure.present {
                 print("test failed: " + _format_assert_failure(path, failure));
             } else { print("test failed: " + path); }
-            exit_test_runner_mode();
-            return run_rc;
+            suites[file_suite_index[index]].fail_count += 1;
+            suites[file_suite_index[index]].failed_files.push(rf_basename);
+            if overall_rc == 0 { overall_rc = run_rc; }
+            sailfin_intrinsic_runtime_arena_rewind(test_scratch_mark);
+            index += 1;
+            continue;
         }
         if json_output {
             let outcome = _outcome_all_pass(file_elapsed_ms as int);
@@ -1129,6 +1268,7 @@ fn handle_test_command(args: string[], runtime_root: string) -> int ![io, clock]
             // on the human path; the JSON path emits structured
             // per-test events instead.
             print("[test] PASS: " + _package_basename(path));
+            suites[file_suite_index[index]].pass_count += 1;
         }
         // Phase 5a: rewind arena scratch back to the per-test
         // mark. Per-iteration allocations (parsed test AST,
@@ -1142,6 +1282,13 @@ fn handle_test_command(args: string[], runtime_root: string) -> int ![io, clock]
     if json_output {
         let runner_elapsed_ms = monotonic_millis() - runner_start_ms;
         print(render_summary_event(total_passed, total_failed, total_skipped, runner_elapsed_ms));
+    } else if emit_banners {
+        // Per-suite banners. Suppressed in `--json` mode (the
+        // structured summary event is the source of truth there)
+        // and suppressed in legacy single-`.sfn`-file mode
+        // (`scripts/run_native_test.sh` and friends — `emit_banners`
+        // gates the call site).
+        _emit_suite_banners(suites);
     }
     exit_test_runner_mode();
     return overall_rc;

--- a/compiler/src/cli_commands.sfn
+++ b/compiler/src/cli_commands.sfn
@@ -35,6 +35,7 @@ import {
     _sha256_of_file_cmd,
     _shell_read_cmd,
     _shell_single_quote_arg,
+    _sort_strings_cmd,
     _string_contains_cmd,
     _suite_name_from_path,
     _toml_trim_cmd,
@@ -770,7 +771,22 @@ fn _should_retry_test(exit_code: int, retries_disabled: boolean) -> boolean {
     return false;
 }
 
-fn handle_test_command(args: string[], runtime_root: string) -> int ![io, clock] {
+// Resolve the path to this compiler binary so the multi-file runner
+// can re-invoke itself (`<self> test <file>`) once per test for
+// process isolation. Mirrors `_resolve_self_path` in `cli_main.sfn`:
+// prefer `<binary_dir>/sailfin` (computed by `fn main` from
+// `exe_path()` / `realpath(argv[0])` on every platform), fall back to
+// the Linux `/proc/self/exe` symlink when no binary_dir was threaded
+// through.
+fn _resolve_test_self_path(binary_dir: string) -> string ![io] {
+    if binary_dir.length > 0 {
+        let candidate = _path_join_cmd(binary_dir, "sailfin");
+        if fs.exists(candidate) { return candidate; }
+    }
+    return _shell_read_cmd("readlink -f /proc/self/exe");
+}
+
+fn handle_test_command(args: string[], runtime_root: string, binary_dir: string) -> int ![io, clock] {
     // Flag parser: `--json` is the only recognised flag for now.
     // Positional args carry one or more suite paths; each becomes a
     // labelled `TestSuite` whose pass/fail tally gets its own
@@ -852,7 +868,10 @@ fn handle_test_command(args: string[], runtime_root: string) -> int ![io, clock]
     let mut csi: int = 0;
     loop {
         if csi >= suites.length { break; }
-        let suite_files = _collect_test_files_cmd(suites[csi].path, 25);
+        // Sort within each suite so the run order is deterministic
+        // across platforms (`fs.listDirectory` returns entries in
+        // filesystem order). Matches the pre-#848 `find ... | sort`.
+        let suite_files = _sort_strings_cmd(_collect_test_files_cmd(suites[csi].path, 25));
         let mut sfi: int = 0;
         loop {
             if sfi >= suite_files.length { break; }
@@ -864,25 +883,23 @@ fn handle_test_command(args: string[], runtime_root: string) -> int ![io, clock]
     }
 
     if test_files.length == 0 {
+        // Empty discovery exits 0 in BOTH modes (issue #848). The
+        // pre-#848 split — JSON returned 1, the human path printed
+        // "no Sailfin test files found" and also returned 1, while
+        // the Makefile's `test-capsules` loop special-cased an empty
+        // `capsules/` to exit 0 — left the runner and the Makefile
+        // disagreeing. The unified runner standardises on the
+        // `test-capsules` shape: an empty suite is a benign 0/0/0,
+        // not a failure. The all-zeros JSON summary / `0/0 passed`
+        // banner is the "no tests" signal consumers read; the exit
+        // code stays 0 so a legitimately-empty suite (e.g. a capsule
+        // with no `tests/` dir) doesn't fail the build.
         if json_output {
-            // Still produce a valid jsonl stream so consumers don't
-            // have to special-case empty discovery — start, no test
-            // events, summary with all zeros.
             print(render_start_event(0));
             print(render_summary_event(0, 0, 0, 0));
             exit_test_runner_mode();
-            return 1;
+            return 0;
         }
-        // Human path: surface a hint for each suite that turned up
-        // empty (mirrors the per-target `[test-X] no *_test.sfn files`
-        // hints the four collapsed Makefile loops used to emit), then
-        // fall through to the empty-banner emission below so the
-        // suite tallies still print 0/0/0 — matches the pre-#848
-        // `test-capsules` behaviour where an empty `capsules/`
-        // produced a banner and exited 0. The other suite targets
-        // historically exited 1 on empty discovery; the unified
-        // runner standardises on the `test-capsules` shape because
-        // the banner already carries the "0/0 passed" signal.
         let mut hi: int = 0;
         loop {
             if hi >= suites.length { break; }
@@ -894,6 +911,68 @@ fn handle_test_command(args: string[], runtime_root: string) -> int ![io, clock]
         if emit_banners { _emit_suite_banners(suites); }
         exit_test_runner_mode();
         return 0;
+    }
+
+    // Multi-file isolation (issue #848). When more than one test file
+    // runs in this invocation, compile + link + run each in a fresh
+    // `<self> test <file>` subprocess and aggregate the exit codes
+    // into the per-suite banners. The single-shared in-process path
+    // below groups every test under one resolver pass whose
+    // `native_texts` is the UNION of every test's imports — and tests
+    // with conflicting expectations for the same symbol cannot
+    // coexist in that union. The canonical case: `number_to_string`
+    // resolves to the `![pure]` int-signature import for
+    // `cross_module_int_signature_test` (pinning the #633 fix) but to
+    // the `double` runtime-helper descriptor for `pure_assert_smoke_test`
+    // — one resolver group can only pick one, so the loser fails with
+    // an ABI mismatch. Per-file subprocesses give each test its own
+    // resolver pass (its own imports only), which is exactly what the
+    // retired `scripts/run_native_test.sh` per-file loop did. JSON
+    // mode keeps the single-process path so the jsonl stream stays a
+    // single ordered document; `--json` callers run one file at a
+    // time today.
+    if test_files.length > 1 && !json_output {
+        let self_exe = _resolve_test_self_path(binary_dir);
+        // Same signal-kill retry gate the in-process path uses: a
+        // child killed by SIGKILL/SIGSEGV (137/139) under transient
+        // CI memory pressure is retried once before being counted as
+        // a failure. Without this the per-child subprocess path would
+        // be flakier than the in-process path (which retries the test
+        // exec internally) — a child OOM-killed mid-compile dies
+        // before its in-process retry can fire, so the parent must
+        // re-run the whole child. `SAILFIN_TEST_RETRY=0` opts out.
+        let sub_retries_disabled = _test_retries_disabled();
+        let mut overall_rc: int = 0;
+        let mut ti: int = 0;
+        loop {
+            if ti >= test_files.length { break; }
+            let path = test_files[ti];
+            let suite_idx = file_suite_index[ti];
+            // Per-test scratch so concurrent or sequential children
+            // never clobber each other's `.ll` / `test` / `fail.bin`
+            // (mirrors the retired wrapper's `mktemp -d`). The child
+            // re-reads `SAILFIN_TEST_SCRATCH` via `_test_scratch_root`.
+            let child_scratch = scratch_root + "/sub-" + number_to_string(ti);
+            _ensure_dir_cmd(child_scratch);
+            let mut rc = process.run(["env", "SAILFIN_TEST_SCRATCH="
+                + child_scratch, self_exe, "test", path]);
+            if _should_retry_test(rc, sub_retries_disabled) {
+                print("[test] RETRY: " + _package_basename(path)
+                    + " (exit code "
+                    + number_to_string(rc)
+                    + ", retrying once)");
+                rc = process.run(["env", "SAILFIN_TEST_SCRATCH=" + child_scratch, self_exe, "test", path]);
+            }
+            if rc == 0 { suites[suite_idx].pass_count += 1; } else {
+                suites[suite_idx].fail_count += 1;
+                suites[suite_idx].failed_files.push(_package_basename(path));
+                if overall_rc == 0 { overall_rc = rc; }
+            }
+            ti += 1;
+        }
+        if emit_banners { _emit_suite_banners(suites); }
+        exit_test_runner_mode();
+        return overall_rc;
     }
 
     let ll_path = scratch_root + "/test.ll";

--- a/compiler/src/cli_commands_utils.sfn
+++ b/compiler/src/cli_commands_utils.sfn
@@ -21,6 +21,7 @@ export {
     _collect_test_files_cmd,
     _collect_sfn_files_cmd,
     _strip_trailing_slashes_cmd,
+    _suite_name_from_path,
     _curl_post_json_cmd,
     _curl_download_cmd,
     _sha256_of_file_cmd,
@@ -252,6 +253,28 @@ fn _strip_trailing_slashes_cmd(path: string) -> string {
         result = substring(result, 0, result.length - 1);
     }
     return result;
+}
+
+// Derive a per-suite banner label from a positional path passed to
+// `sfn test`. Trims trailing slashes (so `compiler/tests/unit/`
+// yields the same label as `compiler/tests/unit`) and returns the
+// path's basename. Empty input degenerates to `.` so the banner
+// always carries a non-empty label. Pure (no I/O) so it's covered
+// by a fast unit test in
+// `compiler/tests/unit/cli_path_normalization_test.sfn`.
+fn _suite_name_from_path(path: string) -> string {
+    let trimmed = _strip_trailing_slashes_cmd(path);
+    if trimmed.length == 0 { return "."; }
+    let mut last_slash: int = -1;
+    let mut i: int = 0;
+    loop {
+        if i >= trimmed.length { break; }
+        if substring(trimmed, i, i + 1) == "/" { last_slash = i; }
+        i += 1;
+    }
+    if last_slash < 0 { return trimmed; }
+    if last_slash == trimmed.length - 1 { return trimmed; }
+    return substring(trimmed, last_slash + 1, trimmed.length);
 }
 
 fn _collect_sfn_files_cmd(root: string, max_depth: int) -> string[] ![io] {

--- a/compiler/src/cli_commands_utils.sfn
+++ b/compiler/src/cli_commands_utils.sfn
@@ -2,7 +2,7 @@
 //
 // Utility functions for CLI command handlers: path, string, file, and
 // network operations.
-import { find_char_local, substring } from "./string_utils";
+import { char_code_at_text, find_char_local, substring } from "./string_utils";
 
 export {
     _ends_with_cmd,
@@ -21,6 +21,7 @@ export {
     _collect_test_files_cmd,
     _collect_sfn_files_cmd,
     _strip_trailing_slashes_cmd,
+    _sort_strings_cmd,
     _suite_name_from_path,
     _curl_post_json_cmd,
     _curl_download_cmd,
@@ -262,6 +263,53 @@ fn _strip_trailing_slashes_cmd(path: string) -> string {
 // always carries a non-empty label. Pure (no I/O) so it's covered
 // by a fast unit test in
 // `compiler/tests/unit/cli_path_normalization_test.sfn`.
+// Lexicographic byte-wise less-than (mirrors `_string_lt` in
+// `build_cache.sfn`). Used to give `sfn test`'s file discovery a
+// stable, platform-independent order — `fs.listDirectory` returns
+// entries in filesystem order, which varies across platforms, so
+// the runner sorts the collected paths to match the old
+// `find ... | sort` Makefile behaviour.
+fn _string_lt_cmd(a: string, b: string) -> boolean {
+    let mut i: int = 0;
+    loop {
+        if i >= a.length || i >= b.length { break; }
+        let ca = char_code_at_text(a, i);
+        let cb = char_code_at_text(b, i);
+        if ca < cb { return true; }
+        if ca > cb { return false; }
+        i += 1;
+    }
+    return a.length < b.length;
+}
+
+// Insertion sort over a string array (N is small — at most the test
+// count of one suite). Returns a new sorted array; input is left
+// untouched.
+fn _sort_strings_cmd(input: string[]) -> string[] {
+    let mut out: string[] = [];
+    let mut copy_i: int = 0;
+    loop {
+        if copy_i >= input.length { break; }
+        out.push(input[copy_i]);
+        copy_i += 1;
+    }
+    let mut k: int = 1;
+    loop {
+        if k >= out.length { break; }
+        let cur = out[k];
+        let mut j: int = k - 1;
+        loop {
+            if j < 0 { break; }
+            if !_string_lt_cmd(cur, out[j]) { break; }
+            out[j + 1] = out[j];
+            j -= 1;
+        }
+        out[j + 1] = cur;
+        k += 1;
+    }
+    return out;
+}
+
 fn _suite_name_from_path(path: string) -> string {
     let trimmed = _strip_trailing_slashes_cmd(path);
     if trimmed.length == 0 { return "."; }

--- a/compiler/src/cli_main.sfn
+++ b/compiler/src/cli_main.sfn
@@ -2255,7 +2255,9 @@ fn sailfin_cli_main(argv: string[]) -> int ![io, clock] {
         return run_rc;
     }
 
-    if is_test { return handle_test_command(args, runtime_root); }
+    if is_test {
+        return handle_test_command(args, runtime_root, binary_dir);
+    }
 
     if is_help {
         print(_usage());

--- a/compiler/tests/unit/cli_path_normalization_test.sfn
+++ b/compiler/tests/unit/cli_path_normalization_test.sfn
@@ -8,7 +8,11 @@
 // — to gate this regression. Each invocation costs ~2 min on Linux
 // CI. This unit test gates the same logic in milliseconds, so the
 // e2e test now runs the canonical scenario exactly once.
-import { _collect_test_files_cmd, _strip_trailing_slashes_cmd } from "../../src/cli_commands_utils";
+import {
+    _collect_test_files_cmd,
+    _strip_trailing_slashes_cmd,
+    _suite_name_from_path
+} from "../../src/cli_commands_utils";
 
 test "path-norm: bare directory unchanged" {
     assert _strip_trailing_slashes_cmd("compiler/src") == "compiler/src";
@@ -92,4 +96,35 @@ test "collect-test-files: trailing-slash and bare root produce identical lists" 
         assert bare[i] == with_slash[i];
         i += 1;
     }
+}
+
+// `_suite_name_from_path` derives the per-suite banner label that
+// `_emit_suite_banners` prints (issue #848 — the four Makefile
+// shell-loop banners moved into `handle_test_command`). Same
+// canonical labels regardless of how the user spells the path —
+// trailing slashes, bare names, relative prefixes, all collapse to
+// the directory's basename.
+test "suite-name: bare directory yields basename" {
+    assert _suite_name_from_path("compiler/tests/unit") == "unit";
+    assert _suite_name_from_path("compiler/tests/integration") == "integration";
+    assert _suite_name_from_path("compiler/tests/e2e") == "e2e";
+}
+
+test "suite-name: single segment returns itself" {
+    assert _suite_name_from_path("capsules") == "capsules";
+}
+
+test "suite-name: trailing slash stripped" {
+    assert _suite_name_from_path("compiler/tests/unit/") == "unit";
+    assert _suite_name_from_path("capsules///") == "capsules";
+}
+
+test "suite-name: empty path degenerates to '.'" {
+    assert _suite_name_from_path("") == ".";
+}
+
+test "suite-name: dot stays dot" { assert _suite_name_from_path(".") == "."; }
+
+test "suite-name: relative prefix discarded" {
+    assert _suite_name_from_path("./foo/bar") == "bar";
 }

--- a/site/src/content/docs/docs/learn/testing.md
+++ b/site/src/content/docs/docs/learn/testing.md
@@ -230,7 +230,7 @@ sfn test src/parser_test.sfn
 sfn test tests/unit/
 
 # Run multiple suites in one invocation — each path becomes a labelled
-# suite with its own `═══ <name>: N/M passed ═══` banner at end-of-run
+# suite with its own `═══ <name>: N/M passed, K failed ═══` banner at end-of-run
 sfn test tests/unit tests/integration tests/e2e
 
 # Note: --filter is not yet supported; run a specific file to narrow scope

--- a/site/src/content/docs/docs/learn/testing.md
+++ b/site/src/content/docs/docs/learn/testing.md
@@ -229,6 +229,10 @@ sfn test src/parser_test.sfn
 # Run tests in a directory (recursive)
 sfn test tests/unit/
 
+# Run multiple suites in one invocation — each path becomes a labelled
+# suite with its own `═══ <name>: N/M passed ═══` banner at end-of-run
+sfn test tests/unit tests/integration tests/e2e
+
 # Note: --filter is not yet supported; run a specific file to narrow scope
 sfn test src/math_test.sfn
 ```

--- a/site/src/content/docs/docs/reference/cli.md
+++ b/site/src/content/docs/docs/reference/cli.md
@@ -47,22 +47,25 @@ sfn run src/main.sfn
 
 ---
 
-### `sfn test [path]`
+### `sfn test [path...]`
 
 Discover and run Sailfin test files. Test files follow the `*_test.sfn` naming convention. Without a path argument, `sfn test` discovers all `*_test.sfn` files under the current directory.
+
+Multiple path arguments group tests into named **suites** for reporting: each path becomes a suite labelled by its basename, and the runner emits a per-suite `═══ <name>: N/M passed, K failed ═══` banner at end-of-run. The repository `make test` target uses this to run unit / integration / e2e / capsule tests in one invocation.
 
 **Usage:**
 
 ```bash
-sfn test [path]
+sfn test [--json] [path...]
 ```
 
 **Examples:**
 
 ```bash
 sfn test                                  # run all *_test.sfn files found
-sfn test compiler/tests/unit/             # run tests in a specific directory
-sfn test compiler/tests/unit/arrays_test.sfn  # run a single test file
+sfn test compiler/tests/unit/             # one suite, banner labelled "unit"
+sfn test compiler/tests/unit/arrays_test.sfn  # single file (no banner)
+sfn test compiler/tests/unit compiler/tests/integration capsules  # three suites
 ```
 
 > **Note:** `--filter` is not yet supported. To narrow test scope, pass a specific file or directory path.


### PR DESCRIPTION
## Summary
- Collapse the four `Makefile` test-suite shell loops into a single `sfn test <path...>` invocation per make target; `test-unit` / `test-integration` / `test-e2e` / `test-capsules` keep their names as aliases over the unified runner.
- Per-suite `═══ <name>: N/M passed, K failed ═══` banners move from the bash loops into `handle_test_command` via a new `TestSuite` struct + `_emit_suite_banners` helper.
- In multi-file mode the runner spawns one `<self> test <file>` subprocess per test, so each test gets its own resolver pass (per-file isolation, exactly like the retired `scripts/run_native_test.sh` loop). This keeps `make test → sfn test` as a single shell-out while avoiding cross-test resolver pollution.
- The legacy `compiler/tests/e2e/test_*.sh` scripts move to a new internal `test-e2e-sh` target on the same `make test` / `make test-e2e` paths until Phase 3.1 (#849+) migrates them.

Closes #848

## Acceptance Criteria
- [x] `make test` shells out to the runner exactly once.
- [x] `test-unit`/`test-integration`/`test-e2e`/`test-capsules` keep their names but become aliases over one runner with different paths.
- [x] The per-suite pass/fail banners still appear, now emitted by the runner.
- [x] `make compile` passes.
- [x] `make test` passes — **green end-to-end** (see Verification).
- [x] `sfn fmt --check` clean on touched `.sfn` files.

## Why per-file subprocess isolation
The first cut ran all tests in one process under a single group resolver pass whose `native_texts` is the **union** of every test's imports. Two tests have conflicting expectations for `number_to_string`: `cross_module_int_signature_test` needs the int-signature import to win (pinning the #633 fix), while `pure_assert_smoke_test` needs the `double` runtime-helper descriptor. A single resolver group can only pick one, so the loser failed with an ABI mismatch. This is a **pre-existing** bug in the runner's directory mode — it reproduces under plain `sfn test compiler/tests/integration` on `main`'s binary; the old per-file bash loop simply never exercised directory mode.

The fix re-invokes the compiler per test (`<self> test <file>`), giving each test its own resolver pass over its own imports — the same isolation the retired wrapper provided. Signal-kill (137/139) retry mirrors the in-process path so a child OOM-killed under CI memory pressure is retried once.

## Copilot review (#861) — all 5 addressed
1. & 2. `Makefile` `test` / `test-e2e` capture the runner exit code so `test-e2e-sh` still runs when a `.sfn` suite fails.
3. Empty-discovery exit code aligned: both JSON and human paths return 0 (matches the `test-capsules`-on-empty precedent).
4. Test files sorted (`_sort_strings_cmd`) for deterministic, platform-independent run order (matches the old `find ... | sort`).
5. Docs banner format corrected to `N/M passed, K failed`.

## Verification
```bash
ulimit -v 8388608 && make compile && make test
```
Local run (exit 0):
```
═══ unit: 104/104 passed, 0 failed ═══
═══ integration: 28/28 passed, 0 failed ═══
═══ e2e: 4/4 passed, 0 failed ═══
═══ capsules: 16/16 passed, 0 failed ═══
═══ e2e-sh: 75/75 passed, 0 failed ═══
```
Both previously-failing tests (`pure_assert_smoke_test`, `cross_module_int_signature_test`) now pass in the full suite. `sfn fmt --check` clean on all touched `.sfn` files.

## Files Changed
- `compiler/src/cli_commands.sfn` — `TestSuite` struct + `_emit_suite_banners`; multi-positional path parsing; per-file subprocess isolation w/ signal-kill retry; sorted, deterministic discovery; aligned empty-discovery exit code.
- `compiler/src/cli_commands_utils.sfn` — `_suite_name_from_path` + `_sort_strings_cmd` helpers.
- `compiler/src/cli_main.sfn` — thread `binary_dir` into `handle_test_command` so it can resolve its own path for re-invocation.
- `compiler/tests/unit/cli_path_normalization_test.sfn` — 6 new tests for `_suite_name_from_path`.
- `Makefile` — collapsed `test` recipe + four suite aliases + internal `test-e2e-sh` target (exit-code-aware).
- `site/src/content/docs/docs/reference/cli.md` + `learn/testing.md` — documented `sfn test <path...>` multi-suite invocation and banner format.

Generated with [Claude Code](https://claude.com/claude-code)