### PR TITLE
feat(runtime): port fs list/delete/mkdir/read_bytes into filesystem adapter

### DIFF
--- a/compiler/src/llvm/runtime_helpers.sfn
+++ b/compiler/src/llvm/runtime_helpers.sfn
@@ -489,15 +489,20 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
     //
     // M3.1a (#814): `read_file` / `write_file` / `append_file`
     // flipped to the Sailfin-native `sfn_fs_*` adapters in
-    // `runtime/sfn/adapters/filesystem.sfn`. The legacy C
-    // `sailfin_adapter_fs_*` symbols stay exported throughout the
-    // M3 window so seed-built compiler IR continues to link; the
-    // `symbol` slots below preserve them as the registry's fall-
-    // back, while every fresh emission routes through
-    // `native_signature` per the `effective_symbol` resolution in
-    // `rendering.sfn`. The remaining `sailfin_adapter_fs_*` rows
-    // (list_directory / delete / create_directory / set_perms / …)
-    // flip in M3.1b (#815).
+    // `runtime/sfn/adapters/filesystem.sfn`. M3.1b (#815) extends
+    // the flip to `list_directory` / `delete_file` /
+    // `create_directory` (→ `sfn_fs_list_dir` / `sfn_fs_delete` /
+    // `sfn_fs_mkdir`) and `fs.read_bytes` (→ `sfn_fs_read_bytes`).
+    // The legacy C `sailfin_adapter_fs_*` /
+    // `sailfin_runtime_read_file_bytes` symbols stay exported
+    // throughout the M3 window so seed-built compiler IR continues
+    // to link; the `symbol` slots below preserve them as the
+    // registry's fall-back, while every fresh emission routes
+    // through `native_signature` per the `effective_symbol`
+    // resolution in `rendering.sfn`. The `set_perms` / `get_perms`
+    // / `mkdtemp` / `is_executable` / `symlink` rows remain on
+    // their C symbols — they are live (wrapped by the `sfn/fs`
+    // capsule) and get a follow-up adapter wave.
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
         target: "fs_read_file", symbol: "sailfin_adapter_fs_read_file", return_type: "i8*", parameter_types: ["i8*"], effects: ["io"], native_signature: "sfn_fs_read_file", c_abi_return_type: null
     });
@@ -523,22 +528,22 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
         target: "fs.writeLines", symbol: "sailfin_adapter_fs_write_lines_v2", return_type: "void", parameter_types: ["i8*", "{ i8**, i64, i64 }*"], effects: ["io"], native_signature: null, c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "fs_list_directory", symbol: "sailfin_adapter_fs_list_directory_v2", return_type: "{ i8**, i64, i64 }*", parameter_types: ["i8*"], effects: ["io"], native_signature: null, c_abi_return_type: null
+        target: "fs_list_directory", symbol: "sailfin_adapter_fs_list_directory_v2", return_type: "{ i8**, i64, i64 }*", parameter_types: ["i8*"], effects: ["io"], native_signature: "sfn_fs_list_dir", c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "fs.listDirectory", symbol: "sailfin_adapter_fs_list_directory_v2", return_type: "{ i8**, i64, i64 }*", parameter_types: ["i8*"], effects: ["io"], native_signature: null, c_abi_return_type: null
+        target: "fs.listDirectory", symbol: "sailfin_adapter_fs_list_directory_v2", return_type: "{ i8**, i64, i64 }*", parameter_types: ["i8*"], effects: ["io"], native_signature: "sfn_fs_list_dir", c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "fs_delete_file", symbol: "sailfin_adapter_fs_delete_file", return_type: "i1", parameter_types: ["i8*"], effects: ["io"], native_signature: null, c_abi_return_type: null
+        target: "fs_delete_file", symbol: "sailfin_adapter_fs_delete_file", return_type: "i1", parameter_types: ["i8*"], effects: ["io"], native_signature: "sfn_fs_delete", c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "fs.deleteFile", symbol: "sailfin_adapter_fs_delete_file", return_type: "i1", parameter_types: ["i8*"], effects: ["io"], native_signature: null, c_abi_return_type: null
+        target: "fs.deleteFile", symbol: "sailfin_adapter_fs_delete_file", return_type: "i1", parameter_types: ["i8*"], effects: ["io"], native_signature: "sfn_fs_delete", c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "fs_create_directory", symbol: "sailfin_adapter_fs_create_directory", return_type: "i1", parameter_types: ["i8*", "i1"], effects: ["io"], native_signature: null, c_abi_return_type: null
+        target: "fs_create_directory", symbol: "sailfin_adapter_fs_create_directory", return_type: "i1", parameter_types: ["i8*", "i1"], effects: ["io"], native_signature: "sfn_fs_mkdir", c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "fs.createDirectory", symbol: "sailfin_adapter_fs_create_directory", return_type: "i1", parameter_types: ["i8*", "i1"], effects: ["io"], native_signature: null, c_abi_return_type: null
+        target: "fs.createDirectory", symbol: "sailfin_adapter_fs_create_directory", return_type: "i1", parameter_types: ["i8*", "i1"], effects: ["io"], native_signature: "sfn_fs_mkdir", c_abi_return_type: null
     });
 
     // P5 (#366): filesystem stdlib gap-fill. Permission ops, temp-dir
@@ -940,7 +945,7 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
         target: "env.home", symbol: "sailfin_runtime_home_dir", return_type: "{i8*, i64}", parameter_types: ["ptr"], effects: ["io"], native_signature: "sfn_home_dir", c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "fs.read_bytes", symbol: "sailfin_runtime_read_file_bytes", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: ["io"], native_signature: null, c_abi_return_type: null
+        target: "fs.read_bytes", symbol: "sailfin_runtime_read_file_bytes", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: ["io"], native_signature: "sfn_fs_read_bytes", c_abi_return_type: null
     });
     // Prelude functions called directly by their original name.
     // These are defined in runtime/prelude.sfn and compiled into

--- a/compiler/tests/e2e/test_runtime_adapter_filesystem.sh
+++ b/compiler/tests/e2e/test_runtime_adapter_filesystem.sh
@@ -177,11 +177,15 @@ PROBE
 # cannot drop the `@sfn_fs_list_dir` call before the assertion runs.
 test_probe_flipped_m31b() {
     local probe="$SCRATCH/fs_probe_m31b.sfn"
+    # deleteFile maps to unlink (files only), so the probe targets a
+    # real file it just wrote — not the directory — to stay
+    # representative if the probe is ever executed.
     cat > "$probe" <<'PROBE'
 fn main() -> int ![io] {
     fs.createDirectory("/tmp/sfn_fs_probe_m31b/a/b", true);
+    fs.writeFile("/tmp/sfn_fs_probe_m31b/note.txt", "x");
     let entries = fs.listDirectory("/tmp/sfn_fs_probe_m31b");
-    fs.deleteFile("/tmp/sfn_fs_probe_m31b/a");
+    fs.deleteFile("/tmp/sfn_fs_probe_m31b/note.txt");
     return entries.length;
 }
 PROBE

--- a/compiler/tests/e2e/test_runtime_adapter_filesystem.sh
+++ b/compiler/tests/e2e/test_runtime_adapter_filesystem.sh
@@ -1,16 +1,17 @@
 #!/usr/bin/env bash
 # End-to-end test for runtime/sfn/adapters/filesystem.sfn — the
-# M3.1a Sailfin-native filesystem adapter (issue #814, epic #390).
+# Sailfin-native filesystem adapter (M3.1a #814 + M3.1b #815,
+# epic #390).
 #
 # Mirrors test_runtime_io_extended.sh's structure: typecheck + fmt
 # + emit-shape on the source module, plus a compiled-IR regression
 # that the new compiler routes `fs.readFile` / `fs.writeFile` /
-# `fs.appendFile` call sites through the `sfn_fs_*` adapter family
-# instead of the legacy `sailfin_adapter_fs_*` C entrypoints.
-#
-# When M3.1b retires more `sailfin_adapter_fs_*` rows (list_directory
-# / delete / mkdir), the emit-shape assertions stay — they pin the
-# migration symbol surface, not the body strategy.
+# `fs.appendFile` (M3.1a) and `fs.listDirectory` / `fs.deleteFile`
+# / `fs.createDirectory` (M3.1b) call sites through the `sfn_fs_*`
+# adapter family instead of the legacy `sailfin_adapter_fs_*` C
+# entrypoints. The M3.1b wave also adds a behavioral round-trip
+# that recursively creates a directory, enumerates it, and deletes
+# an entry through the flipped registry rows.
 
 set -euo pipefail
 
@@ -110,7 +111,8 @@ test_emit_define_shape() {
         return 1
     fi
     local missing=0
-    for sym in sfn_fs_read_file sfn_fs_write_file sfn_fs_append_file; do
+    for sym in sfn_fs_read_file sfn_fs_write_file sfn_fs_append_file \
+        sfn_fs_delete sfn_fs_mkdir sfn_fs_list_dir sfn_fs_read_bytes; do
         if ! grep -qE "^define .* @${sym}\(" "$ll"; then
             echo "[test]   missing 'define ... @${sym}(' in filesystem.ll"
             missing=$((missing + 1))
@@ -168,6 +170,128 @@ PROBE
     return "$((missing + found))"
 }
 
+# ---- Test: M3.1b probe routes fs.{listDirectory,deleteFile,createDirectory} ----
+#
+# Companion to test_probe_flipped for the #815 rows. The probe uses
+# the listing result in its return value so dead-code elimination
+# cannot drop the `@sfn_fs_list_dir` call before the assertion runs.
+test_probe_flipped_m31b() {
+    local probe="$SCRATCH/fs_probe_m31b.sfn"
+    cat > "$probe" <<'PROBE'
+fn main() -> int ![io] {
+    fs.createDirectory("/tmp/sfn_fs_probe_m31b/a/b", true);
+    let entries = fs.listDirectory("/tmp/sfn_fs_probe_m31b");
+    fs.deleteFile("/tmp/sfn_fs_probe_m31b/a");
+    return entries.length;
+}
+PROBE
+    local ll="$SCRATCH/fs_probe_m31b.ll"
+    local log="$SCRATCH/fs_probe_m31b.log"
+    if ! "$BINARY" emit -o "$ll" llvm "$probe" > "$log" 2>&1; then
+        echo "[test]   sfn emit llvm failed on fs_probe_m31b.sfn:"
+        cat "$log"
+        return 1
+    fi
+    local missing=0
+    for sym in sfn_fs_list_dir sfn_fs_delete sfn_fs_mkdir; do
+        if ! grep -qE "@${sym}([^A-Za-z0-9_]|$)" "$ll"; then
+            echo "[test]   fs_probe_m31b.sfn does not reference @${sym}"
+            missing=$((missing + 1))
+        fi
+    done
+    # Legacy C call sites must be gone (declares are tolerated for
+    # the list_dir trampoline; only `call` sites are forbidden).
+    local found=0
+    for sym in sailfin_adapter_fs_list_directory_v2 sailfin_adapter_fs_delete_file sailfin_adapter_fs_create_directory; do
+        if grep -qE "call [^\"]*@${sym}\(" "$ll"; then
+            echo "[test]   fs_probe_m31b.sfn still calls @${sym} (expected the sfn_fs_* flip)"
+            grep -nE "@${sym}\(" "$ll" | head -3
+            found=$((found + 1))
+        fi
+    done
+    return "$((missing + found))"
+}
+
+# ---- Test: list / delete / recursive-mkdir round-trip end-to-end ----
+#
+# The #815 behavior gate. One probe recursively creates a nested
+# directory, drops two files in the parent, enumerates it (writing
+# each entry to a listing file through the proven appendFile path),
+# deletes one file, then re-enumerates. The bash assertions inspect
+# the resulting on-disk state and the two listing files — exercising
+# the flipped sfn_fs_mkdir / sfn_fs_list_dir / sfn_fs_delete symbols
+# through the real `sfn run` link path.
+test_round_trip_list_delete_mkdir() {
+    local base="$SCRATCH/m31b"
+    local listing="$SCRATCH/listing.txt"
+    local listing2="$SCRATCH/listing2.txt"
+    local probe="$SCRATCH/m31b_probe.sfn"
+    local out_log="$SCRATCH/m31b.log"
+    cat > "$probe" <<PROBE
+fn main() -> int ![io] {
+    fs.createDirectory("${base}/x/y/z", true);
+    fs.writeFile("${base}/alpha.txt", "a");
+    fs.writeFile("${base}/beta.txt", "b");
+    let entries = fs.listDirectory("${base}");
+    let mut i = 0;
+    loop {
+        if i >= entries.length { break; }
+        fs.appendFile("${listing}", entries[i]);
+        fs.appendFile("${listing}", "\n");
+        i = i + 1;
+    }
+    fs.deleteFile("${base}/alpha.txt");
+    let after = fs.listDirectory("${base}");
+    let mut j = 0;
+    loop {
+        if j >= after.length { break; }
+        fs.appendFile("${listing2}", after[j]);
+        fs.appendFile("${listing2}", "\n");
+        j = j + 1;
+    }
+    return 0;
+}
+PROBE
+    if ! "$BINARY" run "$probe" > "$out_log" 2>&1; then
+        echo "[test]   sfn run m31b_probe.sfn failed:"
+        cat "$out_log"
+        return 1
+    fi
+    # Recursive mkdir materialized every parent component.
+    if [ ! -d "$base/x/y/z" ]; then
+        echo "[test]   recursive mkdir did not create $base/x/y/z"
+        return 1
+    fi
+    # First enumeration sees both files plus the nested dir 'x'.
+    local want
+    for want in alpha.txt beta.txt x; do
+        if ! grep -qx "$want" "$listing"; then
+            echo "[test]   first listing missing '$want':"
+            sed 's/^/[test]     /' "$listing"
+            return 1
+        fi
+    done
+    # delete removed alpha.txt from disk.
+    if [ -e "$base/alpha.txt" ]; then
+        echo "[test]   delete did not remove $base/alpha.txt"
+        return 1
+    fi
+    # Second enumeration drops alpha.txt but keeps beta.txt and x.
+    if grep -qx "alpha.txt" "$listing2"; then
+        echo "[test]   second listing still contains alpha.txt:"
+        sed 's/^/[test]     /' "$listing2"
+        return 1
+    fi
+    for want in beta.txt x; do
+        if ! grep -qx "$want" "$listing2"; then
+            echo "[test]   second listing missing '$want':"
+            sed 's/^/[test]     /' "$listing2"
+            return 1
+        fi
+    done
+    return 0
+}
+
 # ---- Test: compiler binary exports the sfn_fs_* family ----
 test_compiler_binary_exports() {
     local nm_log
@@ -177,7 +301,8 @@ test_compiler_binary_exports() {
         return 1
     fi
     local missing=0
-    for sym in sfn_fs_read_file sfn_fs_write_file sfn_fs_append_file; do
+    for sym in sfn_fs_read_file sfn_fs_write_file sfn_fs_append_file \
+        sfn_fs_delete sfn_fs_mkdir sfn_fs_list_dir sfn_fs_read_bytes; do
         if ! grep -qE "[[:space:]][Tt][[:space:]]_?${sym}\$" <<< "$nm_log"; then
             echo "[test]   compiler binary does not export defined symbol ${sym}"
             missing=$((missing + 1))
@@ -321,10 +446,12 @@ run_test "sfn fmt --check is canonical for both touched modules" test_fmt_clean
 run_test "libc.sfn declares stat/opendir/readdir/closedir/unlink/mkdir/rmdir" test_libc_declares_dir_stat_externs
 run_test "sfn emit llvm produces define for every sfn_fs_* export" test_emit_define_shape
 run_test "probe binary routes fs.{readFile,writeFile,appendFile} through @sfn_fs_*" test_probe_flipped
-run_test "compiler binary exports defined sfn_fs_read_file / write_file / append_file" test_compiler_binary_exports
+run_test "probe binary routes fs.{listDirectory,deleteFile,createDirectory} through @sfn_fs_*" test_probe_flipped_m31b
+run_test "compiler binary exports defined sfn_fs_* family (read/write/append + list/delete/mkdir/read_bytes)" test_compiler_binary_exports
 run_test "runtime/native/capsule.toml sfn-sources lists the adapter" test_manifest_lists_filesystem
 run_test "fs.writeFile / readFile / appendFile round-trip end-to-end" test_round_trip_file
 run_test "large-file round-trip exercises chunked-read grow path" test_round_trip_large_file
+run_test "fs.createDirectory / listDirectory / deleteFile round-trip end-to-end" test_round_trip_list_delete_mkdir
 
 echo "[summary] $PASS passed, $FAIL failed"
 if [ "$FAIL" -gt 0 ]; then

--- a/runtime/sfn/adapters/filesystem.sfn
+++ b/runtime/sfn/adapters/filesystem.sfn
@@ -20,11 +20,43 @@
 // will retype the parameters to `{i8*, i64}` without touching
 // these bodies' callers.
 //
-// Out (per #814 scope, deferred to M3.1b / #815):
-//   - `fs.list_directory` / `fs.delete_file` / `fs.create_directory`
-//   - `fs.read_bytes` (binary read returning byte array)
+// M3.1b (#815): the directory-listing, delete, create-directory,
+// and byte-read rows flip here too. The split mirrors the M3.1a
+// read-vs-write decision — portable, self-contained bodies land
+// in pure Sailfin; bodies that need a platform-specific struct
+// layout or a proven C hot path trampoline through the legacy C
+// adapter behind the new `sfn_fs_*` symbol name:
+//   - **`sfn_fs_delete`**: pure Sailfin — `unlink(path)`.
+//   - **`sfn_fs_mkdir`** (recursive): pure Sailfin — a forward
+//     component walk that NUL-terminates each `/`-bounded prefix
+//     of a writable scratch copy and `mkdir`s it, then probes the
+//     final path via `sailfin_intrinsic_fs_exists`. Avoids the
+//     `errno == EEXIST` check the C body uses (no `errno` access
+//     in Sailfin) by treating "directory exists afterward" as the
+//     success signal — equivalent outcome, no platform errno
+//     coupling.
+//   - **`sfn_fs_list_dir`**: trampolines to the legacy C
+//     `sailfin_adapter_fs_list_directory_v2`. Reading `dirent`'s
+//     `d_name` field needs a platform-specific byte offset (19 on
+//     Linux glibc, 21 on macOS arm64 — see the layout caveat in
+//     `libc.sfn`'s directory/stat block) and the result is an
+//     `SfnArray` (`{ i8**, i64, i64 }*`) the C adapter already
+//     builds with sorting + `.`/`..` filtering. Replicating both
+//     in Sailfin is a follow-up inline wave; the symbol flip lands
+//     against the canonical `sfn_fs_list_dir` name now (same shape
+//     as the M3.1a write/append trampolines).
+//   - **`sfn_fs_read_bytes`**: trampolines to the C
+//     `sailfin_runtime_read_file_bytes` (the read_bytes row's
+//     existing `symbol`). That body reports the true binary length
+//     through the `int64_t *out_length` out-param via `fseek`/
+//     `ftell` (neither extern is declared in `libc.sfn`; the
+//     `sfn_fs_read_file` chunked-read body cannot recover an
+//     embedded-NUL length). No `fs.read_bytes` call site exists in
+//     the tree yet, so the flip is pure forward surface — a
+//     follow-up wave inlines a binary-safe chunked body once a
+//     caller and e2e exist.
 //
-// Out (per #814 scope, deferred to M3.9):
+// Out (deferred to M3.9):
 //   - Deleting `runtime/native/src/sailfin_runtime.c`'s
 //     `sailfin_adapter_fs_*` bodies. They stay exported during the
 //     M3 window so seed-built compiler IR (which still calls them
@@ -114,6 +146,39 @@ extern fn fread(buf: * u8, size: usize, nmemb: usize, f: * File) -> usize;
 extern fn sailfin_adapter_fs_write_file(path: * u8, contents: * u8) -> void;
 
 extern fn sailfin_adapter_fs_append_file(path: * u8, contents: * u8) -> void;
+
+// M3.1b additions. `memcpy` / `strlen` / `strchr` back the
+// recursive `sfn_fs_mkdir` component walk; `unlink` / `mkdir` are
+// the POSIX primitives for delete + create (declared in
+// `libc.sfn`, inlined here per the #306 cross-module workaround in
+// the file header). `sailfin_intrinsic_fs_exists` is the existing
+// stat-based existence probe (also inlined by
+// `runtime/sfn/platform/exec.sfn`); `sfn_fs_mkdir` uses it to
+// report "directory exists afterward" without an `errno` read.
+extern fn memcpy(dst: * u8, src: * u8, n: usize) -> * u8;
+
+extern fn strlen(s: * u8) -> usize;
+
+extern fn strchr(s: * u8, c: i32) -> * u8;
+
+extern fn unlink(path: * u8) -> i32;
+
+extern fn mkdir(path: * u8, mode: i32) -> i32;
+
+extern fn sailfin_intrinsic_fs_exists(path: * u8) -> bool;
+
+// Legacy C adapters the M3.1b list/read_bytes flips trampoline
+// through (see the file header). `sailfin_adapter_fs_list_directory_v2`
+// returns an `SfnArray` (`{ i8**, i64, i64 }*`) — spelled `* u8`
+// here per the `runtime/sfn/array.sfn` convention (both lower to
+// the same pointer at the IR level). `sailfin_runtime_read_file_bytes`
+// is the read_bytes row's existing C `symbol`; its second arg is an
+// `int64_t *out_length` out-param, spelled `* u8` to stay on the
+// extern accept-list (it lowers to the same pointer). Both stay
+// exported until M3.9 retires `sailfin_runtime.c`.
+extern fn sailfin_adapter_fs_list_directory_v2(path: * u8) -> * u8;
+
+extern fn sailfin_runtime_read_file_bytes(path: * u8, out_length: * u8) -> * u8;
 
 // `sfn_fs_read_file(path)` — slurp the entire contents of `path`
 // into a freshly libc-`malloc`'d NUL-terminated buffer the
@@ -214,4 +279,103 @@ fn sfn_fs_write_file(path: * u8, contents: * u8) -> void ![io] {
 // `sfn_fs_write_file` above.
 fn sfn_fs_append_file(path: * u8, contents: * u8) -> void ![io] {
     sailfin_adapter_fs_append_file(path, contents);
+}
+
+// `sfn_fs_delete(path)` — remove the file (or empty directory)
+// named by `path`. Pure Sailfin: `unlink(2)` returns 0 on success,
+// -1 on error. Mirrors the C `sailfin_adapter_fs_delete_file`
+// null-guard + `unlink == 0` contract exactly.
+fn sfn_fs_delete(path: * u8) -> bool ![io] {
+    if path as i64 == 0 { return false; }
+    return unlink(path) == 0;
+}
+
+// `sfn_fs_mkdir(path, recursive)` — create the directory `path`.
+// When `recursive` is true, create every missing parent component
+// first (`mkdir -p` semantics).
+//
+// Non-recursive: a single `mkdir(path, 0o777)`. The result is
+// ignored in favor of probing `sailfin_intrinsic_fs_exists(path)`
+// — that collapses the "already existed" (`EEXIST`) and "just
+// created" cases into one `true` without reading `errno` (which
+// Sailfin cannot reach), matching the C body's
+// `errno == EEXIST ⇒ true` outcome.
+//
+// Recursive: walk the path forward, NUL-terminating at each `/`
+// of a writable scratch copy and `mkdir`ing the prefix so parents
+// materialize in order. The scratch copy is mandatory — `path`
+// may point into read-only `.rodata` (string literals), so the C
+// body copies before mutating and this port does the same.
+// Mid-walk `mkdir` failures are ignored (a parent that already
+// exists is the common case); the final
+// `sailfin_intrinsic_fs_exists` probe is the authoritative
+// success signal, so a genuine failure (e.g. a permission error
+// that prevents creation) still surfaces as `false`.
+//
+// `47` is ASCII `/` and `511` is `0o777`; both are inlined as
+// decimals because the seed compiler accepts neither char literals
+// (`'/'`) nor octal literals yet — same convention as
+// `runtime/sfn/platform/exec.sfn` (`47`) and
+// `runtime/sfn/process.sfn` (`127` / `65280`).
+fn sfn_fs_mkdir(path: * u8, recursive: bool) -> bool ![io] {
+    if path as i64 == 0 { return false; }
+
+    if recursive {
+        let n: i64 = strlen(path) as i64;
+        if n <= 0 { return false; }
+
+        // Duplicate `path` (including its trailing NUL) into a
+        // writable buffer so the `/`-rewrite walk never touches a
+        // read-only literal.
+        let scratch: * u8 = malloc((n + 1) as usize);
+        if scratch as i64 == 0 { return false; }
+        memcpy(scratch, path, (n + 1) as usize);
+
+        // Start one byte in so a leading `/` (absolute paths) does
+        // not produce an empty `mkdir("")` prefix; `strchr` then
+        // locates each subsequent separator.
+        let mut cursor: * u8 = scratch + 1;
+        loop {
+            let slash: * u8 = strchr(cursor, 47);
+            if slash as i64 == 0 { break; }
+            memset(slash, 0, 1 as usize);
+            mkdir(scratch, 511);
+            memset(slash, 47, 1 as usize);
+            cursor = slash + 1;
+        }
+        mkdir(scratch, 511);
+
+        let ok: bool = sailfin_intrinsic_fs_exists(scratch);
+        free(scratch);
+        return ok;
+    }
+
+    mkdir(path, 511);
+    return sailfin_intrinsic_fs_exists(path);
+}
+
+// `sfn_fs_list_dir(path)` — enumerate the entries of `path`,
+// returning a sorted `SfnArray` (`{ i8**, i64, i64 }*`, spelled
+// `* u8`) that omits `.` and `..`. Trampolines to the legacy C
+// `sailfin_adapter_fs_list_directory_v2`: reading `dirent.d_name`
+// needs a platform-specific byte offset and the sorted SfnArray
+// construction is non-trivial, so both are deferred to a follow-up
+// inline wave (see the file header). The symbol flip lands against
+// the canonical `sfn_fs_list_dir` name now.
+fn sfn_fs_list_dir(path: * u8) -> * u8 ![io] {
+    return sailfin_adapter_fs_list_directory_v2(path);
+}
+
+// `sfn_fs_read_bytes(path, out_length)` — slurp `path` into a
+// freshly allocated NUL-terminated buffer and write the true byte
+// count (binary-safe, embedded NULs counted) through the
+// `int64_t *out_length` out-param. Trampolines to the C
+// `sailfin_runtime_read_file_bytes`, whose `fseek`/`ftell` size
+// probe recovers a length the `sfn_fs_read_file` chunked body
+// cannot (its `strlen`-free NUL terminator hides embedded NULs).
+// No `fs.read_bytes` call site exists yet, so the flip is forward
+// surface; a follow-up wave inlines a binary-safe chunked body
+// once a caller and e2e land.
+fn sfn_fs_read_bytes(path: * u8, out_length: * u8) -> * u8 ![io] {
+    return sailfin_runtime_read_file_bytes(path, out_length);
 }

--- a/runtime/sfn/adapters/filesystem.sfn
+++ b/runtime/sfn/adapters/filesystem.sfn
@@ -281,10 +281,13 @@ fn sfn_fs_append_file(path: * u8, contents: * u8) -> void ![io] {
     sailfin_adapter_fs_append_file(path, contents);
 }
 
-// `sfn_fs_delete(path)` — remove the file (or empty directory)
-// named by `path`. Pure Sailfin: `unlink(2)` returns 0 on success,
-// -1 on error. Mirrors the C `sailfin_adapter_fs_delete_file`
-// null-guard + `unlink == 0` contract exactly.
+// `sfn_fs_delete(path)` — remove the file named by `path`. Pure
+// Sailfin: `unlink(2)` returns 0 on success, -1 on error. Files
+// only — `unlink` cannot remove directories (it fails with
+// `EISDIR` / `EPERM`); directory removal would need `rmdir`, which
+// the `fs.deleteFile` surface does not expose. Mirrors the C
+// `sailfin_adapter_fs_delete_file` null-guard + `unlink == 0`
+// contract exactly.
 fn sfn_fs_delete(path: * u8) -> bool ![io] {
     if path as i64 == 0 { return false; }
     return unlink(path) == 0;


### PR DESCRIPTION
## Summary
- Extends `runtime/sfn/adapters/filesystem.sfn` (M3.1b, #815) with `sfn_fs_delete`, `sfn_fs_mkdir` (recursive), `sfn_fs_list_dir`, and `sfn_fs_read_bytes`, and flips their runtime-helper registry rows off the C symbols.
- `sfn_fs_delete` / `sfn_fs_mkdir` are **pure Sailfin**; `sfn_fs_list_dir` / `sfn_fs_read_bytes` **trampoline** to the proven C symbols (deferring the `dirent.d_name` platform-offset walk and binary-length probe to a follow-up inline wave — same precedent as the M3.1a write/append trampolines).

Closes #815

## Implementation notes
- **`sfn_fs_delete(path)`** — pure Sailfin: null-guard + `unlink(path) == 0`, matching the C `sailfin_adapter_fs_delete_file` contract.
- **`sfn_fs_mkdir(path, recursive)`** — pure Sailfin: non-recursive does a single `mkdir`; recursive duplicates `path` into a writable scratch buffer (literals may be read-only `.rodata`), NUL-terminates each `/`-bounded prefix via `strchr`/`memset`, `mkdir`s it, then probes `sailfin_intrinsic_fs_exists` for the authoritative success signal. This avoids the `errno == EEXIST` check the C body uses — Sailfin has no `errno` access — while preserving the outcome.
- **`sfn_fs_list_dir(path)`** — trampolines to `sailfin_adapter_fs_list_directory_v2` (returns an `SfnArray`, spelled `* u8` per the `array.sfn` convention). Reading `dirent.d_name` needs a platform-specific byte offset (19 Linux glibc / 21 macOS arm64) and the sorted-`SfnArray` construction is non-trivial; both defer to a follow-up inline wave.
- **`sfn_fs_read_bytes(path, out_length)`** — trampolines to `sailfin_runtime_read_file_bytes`, whose `fseek`/`ftell` size probe reports a binary-safe length the chunked `sfn_fs_read_file` body cannot. No `fs.read_bytes` call site exists yet, so this is forward surface.
- Registry: 7 `native_signature` slots flipped (`fs_list_directory`/`fs.listDirectory` → `sfn_fs_list_dir`; `fs_delete_file`/`fs.deleteFile` → `sfn_fs_delete`; `fs_create_directory`/`fs.createDirectory` → `sfn_fs_mkdir`; `fs.read_bytes` → `sfn_fs_read_bytes`). Legacy C symbols stay as the `symbol` fall-back until M3.9 retires `sailfin_runtime.c`.

## `Out:`-scope audit
`set_perms` / `get_perms` / `mkdtemp` / `is_executable` / `symlink` are **live** — wrapped by the `sfn/fs` capsule (`capsules/sfn/fs/src/mod.sfn`). Per the issue, that means a **follow-up XS adapter wave**, *not* folding into M3.7.

## Acceptance Criteria
- [x] list/delete/mkdir/read_bytes registry rows point at `sfn_fs_*`
- [x] e2e covers directory enumeration + delete + recursive mkdir
- [x] `sfn fmt --check` clean
- [x] `make compile` && `make check` pass

## Verification
```bash
ulimit -v 8388608 && make compile && make check
#   → e2e-sh: 76/76 passed, 0 failed
#   → stage2 == stage3: compiler is a fixed point ✓
#     (the compiler driver itself calls fs.createDirectory/listDirectory/
#      deleteFile, so seedcheck exercises the flipped sfn_fs_* symbols
#      while building itself — fixed point confirms they work)

bash compiler/tests/e2e/test_runtime_adapter_filesystem.sh build/native/sailfin
#   → 12 passed, 0 failed
```

## Files Changed
- `runtime/sfn/adapters/filesystem.sfn` — 4 new functions + supporting externs
- `compiler/src/llvm/runtime_helpers.sfn` — 7 `native_signature` flips
- `compiler/tests/e2e/test_runtime_adapter_filesystem.sh` — M3.1b flip-probe + create/list/delete round-trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01N7BERxBrbo7kkwNQAZm1cU)_