### PR TITLE
refactor(capsules): rename sfn/fmt to sfn/strings

### DIFF
--- a/capsules/sfn/strings/capsule.toml
+++ b/capsules/sfn/strings/capsule.toml
@@ -1,7 +1,7 @@
 [capsule]
 name = "sfn/strings"
 version = "0.2.0"
-description = "String formatting and manipulation for Sailfin"
+description = "String operations for Sailfin"
 
 [dependencies]
 

--- a/capsules/sfn/strings/capsule.toml
+++ b/capsules/sfn/strings/capsule.toml
@@ -1,6 +1,6 @@
 [capsule]
-name = "sfn/fmt"
-version = "0.1.1"
+name = "sfn/strings"
+version = "0.2.0"
 description = "String formatting and manipulation for Sailfin"
 
 [dependencies]

--- a/capsules/sfn/strings/src/mod.sfn
+++ b/capsules/sfn/strings/src/mod.sfn
@@ -1,4 +1,4 @@
-// sfn/fmt — String formatting and manipulation for Sailfin.
+// sfn/strings — String formatting and manipulation for Sailfin.
 //
 // Provides common string operations. No effects required — pure functions.
 fn trim(text: string) -> string {

--- a/capsules/sfn/strings/src/mod.sfn
+++ b/capsules/sfn/strings/src/mod.sfn
@@ -1,4 +1,4 @@
-// sfn/strings — String formatting and manipulation for Sailfin.
+// sfn/strings — String operations for Sailfin.
 //
 // Provides common string operations. No effects required — pure functions.
 fn trim(text: string) -> string {

--- a/capsules/sfn/strings/tests/strings_test.sfn
+++ b/capsules/sfn/strings/tests/strings_test.sfn
@@ -1,4 +1,4 @@
-// Tests for sfn/fmt capsule string-manipulation helpers.
+// Tests for sfn/strings capsule string-manipulation helpers.
 //
 // Moved from compiler/tests/unit/fmt_test.sfn. Helpers stay inlined here —
 // the original was constrained to functions that don't reach the prelude

--- a/capsules/sfn/test/capsule.toml
+++ b/capsules/sfn/test/capsule.toml
@@ -4,13 +4,14 @@ version = "0.2.2"
 description = "Test assertion helpers and utilities for Sailfin"
 
 [dependencies]
-# `sfn/fmt::find` replaces the hand-rolled `_find_in_string` helper
-# the capsule used to inline. The matching `sfn/strings` capsule the
-# proposal cited (`docs/proposals/test-infra-epic/02-phases.md`,
-# issue 1.3) does not exist; integer formatting goes through the
-# runtime intrinsic `number_to_string` instead — the same formatter
-# `pure_assert_eq_float` already uses for fractional inputs.
-"sfn/fmt" = "*"
+# `sfn/strings::find` replaces the hand-rolled `_find_in_string` helper
+# the capsule used to inline. That capsule was renamed (#856) from its
+# former `fmt` name to `strings` so its name matches its contents — pure
+# string ops, not formatters (the name the proposal cited in
+# `docs/proposals/test-infra-epic/02-phases.md`, issue 1.3). Integer
+# formatting still goes through the runtime intrinsic `number_to_string`,
+# the same formatter `pure_assert_eq_float` already uses for fractions.
+"sfn/strings" = "*"
 
 [capabilities]
 required = ["io"]

--- a/capsules/sfn/test/src/mod.sfn
+++ b/capsules/sfn/test/src/mod.sfn
@@ -23,7 +23,7 @@
 // over the caller's effect row when row-polymorphic effects ship
 // post-1.0. Until then, `pure_assert_*` is the production-ready
 // interim — see issue #370 / proposal §P3.
-import { find } from "sfn/fmt";
+import { find } from "sfn/strings";
 
 // ---------------------------------------------------------------------------
 // Internal helpers

--- a/compiler/src/cli_commands_utils.sfn
+++ b/compiler/src/cli_commands_utils.sfn
@@ -460,7 +460,6 @@ fn _extract_sfnpkg_cmd(content: string, dest_dir: string) -> void ![io] {
 fn _is_stdlib_capsule_cmd(name: string) -> boolean {
     if name == "cli" { return true; }
     if name == "crypto" { return true; }
-    if name == "fmt" { return true; }
     if name == "fs" { return true; }
     if name == "http" { return true; }
     if name == "json" { return true; }
@@ -472,6 +471,7 @@ fn _is_stdlib_capsule_cmd(name: string) -> boolean {
     if name == "nn" { return true; }
     if name == "os" { return true; }
     if name == "path" { return true; }
+    if name == "strings" { return true; }
     if name == "sync" { return true; }
     if name == "tensor" { return true; }
     if name == "test" { return true; }

--- a/compiler/src/toml_parser.sfn
+++ b/compiler/src/toml_parser.sfn
@@ -121,7 +121,7 @@ fn _is_stdlib(name: string) -> boolean {
     if strings_equal(name, "sync") { return true; }
     if strings_equal(name, "json") { return true; }
     if strings_equal(name, "crypto") { return true; }
-    if strings_equal(name, "fmt") { return true; }
+    if strings_equal(name, "strings") { return true; }
     if strings_equal(name, "log") { return true; }
     if strings_equal(name, "time") { return true; }
     if strings_equal(name, "math") { return true; }

--- a/compiler/tests/unit/stdlib_capsule_allowlist_test.sfn
+++ b/compiler/tests/unit/stdlib_capsule_allowlist_test.sfn
@@ -1,21 +1,21 @@
 // Regression tests for the stdlib capsule allowlist used by
 // _is_stdlib_capsule_cmd and _resolve_capsule_name_cmd.
 //
-// These guard against drift between the allowlist in cli_commands_utils.sfn
-// and the actual set of capsules shipped under `capsules/sfn/`. When a new
-// capsule is added to the tree, update the allowlist AND the list below
-// in lockstep. If this test fails, either add the capsule dir or remove
-// the stale allowlist entry.
+// These guard against drift between the production allowlists in
+// cli_commands_utils.sfn (`_is_stdlib_capsule_cmd`) and toml_parser.sfn
+// (`_is_stdlib`) and the actual set of capsules shipped under
+// `capsules/sfn/`. When a new capsule is added to the tree, update both
+// allowlists AND the list below in lockstep. If this test fails, either
+// add the capsule dir or remove the stale allowlist entry.
 //
 // The helpers are duplicated inline (mirroring `capsule_dep_resolution_test.sfn`)
 // because the test runner can't resolve `char_code` through the
 // `cli_commands_utils.sfn → string_utils.sfn → runtime/prelude` import
-// chain. Keep this in sync with cli_commands_utils.sfn.
+// chain. Keep this in sync with cli_commands_utils.sfn and toml_parser.sfn.
 // -- Inlined copy of _is_stdlib_capsule_cmd --
 fn _is_stdlib_capsule(name: string) -> boolean {
     if name == "cli" { return true; }
     if name == "crypto" { return true; }
-    if name == "fmt" { return true; }
     if name == "fs" { return true; }
     if name == "http" { return true; }
     if name == "json" { return true; }
@@ -27,6 +27,7 @@ fn _is_stdlib_capsule(name: string) -> boolean {
     if name == "nn" { return true; }
     if name == "os" { return true; }
     if name == "path" { return true; }
+    if name == "strings" { return true; }
     if name == "sync" { return true; }
     if name == "tensor" { return true; }
     if name == "test" { return true; }
@@ -55,7 +56,6 @@ fn _resolve_capsule_name(name: string) -> string {
 test "stdlib allowlist: every shipped sfn/* capsule is recognized" {
     assert _is_stdlib_capsule("cli");
     assert _is_stdlib_capsule("crypto");
-    assert _is_stdlib_capsule("fmt");
     assert _is_stdlib_capsule("fs");
     assert _is_stdlib_capsule("http");
     assert _is_stdlib_capsule("json");
@@ -67,6 +67,7 @@ test "stdlib allowlist: every shipped sfn/* capsule is recognized" {
     assert _is_stdlib_capsule("nn");
     assert _is_stdlib_capsule("os");
     assert _is_stdlib_capsule("path");
+    assert _is_stdlib_capsule("strings");
     assert _is_stdlib_capsule("sync");
     assert _is_stdlib_capsule("tensor");
     assert _is_stdlib_capsule("test");
@@ -93,7 +94,7 @@ test "stdlib allowlist: effect names and unknown names are rejected" {
 // -- Name normalization --
 test "resolve capsule name: bare stdlib name gets sfn/ scope" {
     assert _resolve_capsule_name("cli") == "sfn/cli";
-    assert _resolve_capsule_name("fmt") == "sfn/fmt";
+    assert _resolve_capsule_name("strings") == "sfn/strings";
     assert _resolve_capsule_name("toml") == "sfn/toml";
 }
 

--- a/workspace.toml
+++ b/workspace.toml
@@ -8,4 +8,4 @@
 # parser surfaces the literal entries via toml_get_workspace_members().
 
 [workspace]
-members = ["compiler", "runtime/native", "capsules/sfn/cli", "capsules/sfn/crypto", "capsules/sfn/fmt", "capsules/sfn/fs", "capsules/sfn/http", "capsules/sfn/json", "capsules/sfn/layers", "capsules/sfn/log", "capsules/sfn/losses", "capsules/sfn/math", "capsules/sfn/net", "capsules/sfn/nn", "capsules/sfn/os", "capsules/sfn/path", "capsules/sfn/prelude", "capsules/sfn/sync", "capsules/sfn/tensor", "capsules/sfn/test", "capsules/sfn/time", "capsules/sfn/toml"]
+members = ["compiler", "runtime/native", "capsules/sfn/cli", "capsules/sfn/crypto", "capsules/sfn/fs", "capsules/sfn/http", "capsules/sfn/json", "capsules/sfn/layers", "capsules/sfn/log", "capsules/sfn/losses", "capsules/sfn/math", "capsules/sfn/net", "capsules/sfn/nn", "capsules/sfn/os", "capsules/sfn/path", "capsules/sfn/prelude", "capsules/sfn/strings", "capsules/sfn/sync", "capsules/sfn/tensor", "capsules/sfn/test", "capsules/sfn/time", "capsules/sfn/toml"]


### PR DESCRIPTION
## Summary

- Rename the misnamed `sfn/fmt` capsule (pure string ops, no formatters) to `sfn/strings` in lockstep across the capsule tree, workspace manifest, both compiler stdlib allowlists, the mirrored regression test, and the sole consumer.
- `git mv` preserves history; manifest `name` → `sfn/strings` and version bumped `0.1.1` → `0.2.0` (breaking dep change).
- The consumer (`capsules/sfn/test`) now imports `find` from `sfn/strings`; its dependency comment no longer asserts `sfn/strings` is nonexistent.
- Follow-up commit drops "formatting" from the capsule's module header + manifest description (→ "String operations"), so the self-description matches the name (addresses Copilot review).

Closes #856

## Decision rationale

Grooming decision on #855: **rename rather than split**, because the capsule is pure string operations — mirroring Rust `std::str`, Go `strings`, Python `str`. The fully-qualified `from "sfn/strings"` import resolves through the `[workspace] members` list (via `workspace_member_for_spec`), **not** the `_is_stdlib` allowlist, so the current pinned seed (`0.7.0-alpha.9`) compiles the renamed tree. The allowlist updates only affect future bare-name shorthand (`from "strings"`) and ship in this PR to keep the in-tree allowlist test green.

## Acceptance Criteria

- [x] `capsules/sfn/fmt/` removed; `capsules/sfn/strings/` exists with `capsule.toml`, `src/mod.sfn`, `tests/strings_test.sfn`
- [x] `capsules/sfn/strings/capsule.toml` has `name = "sfn/strings"` and `version = "0.2.0"`
- [x] `grep -rn 'sfn/fmt' --include='*.sfn' --include='*.toml' compiler/ capsules/ runtime/ workspace.toml` returns zero results
- [x] Both production allowlists return `true` for `"strings"`; neither has a capsule-allowlist entry for `"fmt"` (the `sfn fmt` CLI subcommand check in `cli_main.sfn:1645` is intentionally preserved)
- [x] `stdlib_capsule_allowlist_test.sfn` asserts `_is_stdlib_capsule("strings")`, drops `("fmt")`, and asserts `_resolve_capsule_name("strings") == "sfn/strings"`
- [x] `capsules/sfn/test/src/mod.sfn` imports `find` from `"sfn/strings"`
- [x] `capsules/sfn/test/capsule.toml`'s dependency comment no longer asserts `sfn/strings` is nonexistent
- [x] `sfn fmt --check` clean on every touched `.sfn` file
- [x] `make compile` succeeds against the pinned seed (`0.7.0-alpha.9`)
- [x] `make test-unit` passes (105/105), including `stdlib_capsule_allowlist_test.sfn`
- [x] `make check` succeeds — full seedcheck round-trip, **e2e-sh 76/76**, **stage2 == stage3 fixed point ✓**
- [x] Commit body + closing comment on #855 record the decision rationale

## Verification

```bash
# zero stale references
grep -rn 'sfn/fmt' --include='*.sfn' --include='*.toml' compiler/ capsules/ runtime/ workspace.toml  # → no matches

# fmt round-trip
build/native/sailfin fmt --check capsules/sfn/strings/ capsules/sfn/test/ \
  compiler/src/cli_commands_utils.sfn compiler/src/toml_parser.sfn \
  compiler/tests/unit/stdlib_capsule_allowlist_test.sfn  # → exit 0

make compile      # → built build/native/sailfin
make test-unit    # → unit: 105/105 passed, 0 failed
make check        # → e2e-sh 76/76; stage2 == stage3: compiler is a fixed point ✓
```

## Files Changed

- `capsules/sfn/{fmt → strings}/{capsule.toml, src/mod.sfn, tests/{fmt → strings}_test.sfn}` (renamed)
- `workspace.toml` — members list
- `compiler/src/cli_commands_utils.sfn`, `compiler/src/toml_parser.sfn` — stdlib allowlists
- `compiler/tests/unit/stdlib_capsule_allowlist_test.sfn` — regression test + sync comment
- `capsules/sfn/test/{capsule.toml, src/mod.sfn}` — consumer

🤖 Generated with [Claude Code](https://claude.com/claude-code)