### PR TITLE
feat(runtime): base64 Sailfin port (#817) + pointer-read intrinsics (#875)

### DIFF
--- a/capsules/sfn/crypto/src/mod.sfn
+++ b/capsules/sfn/crypto/src/mod.sfn
@@ -170,13 +170,51 @@ fn sha256(data: string) -> string {
 }
 
 fn base64_encode(data: string) -> string {
-    // Encode a string to base64.
-    // Delegates to the C runtime via the `base64.encode` runtime helper
-    // (see compiler/src/llvm/runtime_helpers.sfn). Port tracked by M3.6.
+    // Encode a string to standard RFC 4648 base64 (with `=` padding).
+    // Pure Sailfin: byte-oriented over the raw input, no effects. String
+    // indexing and `.length` are byte-oriented, so this encodes the raw
+    // UTF-8 bytes and matches `base64` for arbitrary content.
     //
     // Usage:
     //   let encoded = base64_encode("hello world");
     //   // encoded == "aGVsbG8gd29ybGQ="
     //
-    return base64.encode(data, data.length);
+    let alphabet: string[] = ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z", "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "+", "/",];
+
+    let mut bytes: int[] = [];
+    let mut bi: int = 0;
+    loop {
+        if bi >= data.length { break; }
+        bytes.push(char_code(data[bi]) & 255);
+        bi += 1;
+    }
+
+    let len: int = bytes.length;
+    let mut out: string = "";
+
+    // Full 3-byte groups → 4 base64 chars.
+    let mut i: int = 0;
+    loop {
+        if i + 2 >= len { break; }
+        let v: int = (bytes[i] << 16) | (bytes[i + 1] << 8) | bytes[i + 2];
+        out = out + alphabet[(v >> 18) & 63];
+        out = out + alphabet[(v >> 12) & 63];
+        out = out + alphabet[(v >> 6) & 63];
+        out = out + alphabet[v & 63];
+        i += 3;
+    }
+
+    // Trailing 1 or 2 bytes, padded with `=`.
+    if i < len {
+        let mut v: int = bytes[i] << 16;
+        if i + 1 < len { v = v | (bytes[i + 1] << 8); }
+        out = out + alphabet[(v >> 18) & 63];
+        out = out + alphabet[(v >> 12) & 63];
+        if i + 1 < len { out = out + alphabet[(v >> 6) & 63]; } else {
+            out = out + "=";
+        }
+        out = out + "=";
+    }
+
+    return out;
 }

--- a/capsules/sfn/crypto/tests/base64_test.sfn
+++ b/capsules/sfn/crypto/tests/base64_test.sfn
@@ -1,0 +1,42 @@
+// Tests for sfn/crypto base64 (pure-Sailfin, RFC 4648 standard alphabet).
+//
+// Known-answer vectors covering the empty string, all three padding
+// residues (0, 1, 2 trailing bytes), and a non-ASCII UTF-8 input to pin
+// the byte-oriented contract.
+import { base64_encode } from "../src/mod";
+
+test "base64_encode: empty string" { assert base64_encode("") == ""; }
+
+test "base64_encode: one trailing byte (two pad chars)" {
+    assert base64_encode("f") == "Zg==";
+}
+
+test "base64_encode: two trailing bytes (one pad char)" {
+    assert base64_encode("fo") == "Zm8=";
+}
+
+test "base64_encode: exact three-byte group (no padding)" {
+    assert base64_encode("foo") == "Zm9v";
+}
+
+test "base64_encode: four bytes" {
+    assert base64_encode("foob") == "Zm9vYg==";
+}
+
+test "base64_encode: five bytes" {
+    assert base64_encode("fooba") == "Zm9vYmE=";
+}
+
+test "base64_encode: six bytes" {
+    assert base64_encode("foobar") == "Zm9vYmFy";
+}
+
+test "base64_encode: ascii sentence" {
+    assert base64_encode("hello world") == "aGVsbG8gd29ybGQ=";
+}
+
+test "base64_encode: non-ASCII UTF-8 raw bytes" {
+    // "é" is the two UTF-8 bytes 0xc3 0xa9; byte-oriented indexing encodes
+    // them raw, matching `printf 'é' | base64`.
+    assert base64_encode("é") == "w6k=";
+}

--- a/compiler/src/llvm/expression_lowering/native/core_call_emission.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_call_emission.sfn
@@ -647,6 +647,55 @@ fn coerce_and_emit_call(trimmed_target: string, operands: LLVMOperand[], expecte
         }
     }
 
+    // Pointer-read intrinsics (#875, epic #763): lower directly to an LLVM
+    // `load` of the descriptor's width instead of a `call`. The load element
+    // type is driven by `return_type` ("i32"/"i64"), not by parsing the
+    // operand's pointee. An `i8*` (or otherwise mismatched) operand gets a
+    // leading `bitcast` to the matching pointer type; an already-typed
+    // `i32*`/`i64*` operand loads directly with no redundant bitcast.
+    if helper_descriptor != null {
+        let _pr_symbol = helper_descriptor.symbol;
+        if _pr_symbol == "sailfin_intrinsic_pointer_read_i32" || _pr_symbol == "sailfin_intrinsic_pointer_read_i64" {
+            if final_operands.length < 1 {
+                result_diagnostics.push("llvm lowering: " + _pr_symbol
+                    + " requires one pointer operand");
+            } else {
+                let _pr_elem = helper_descriptor.return_type;
+                let _pr_ptr_type = _pr_elem + "*";
+                let _pr_src = final_operands[0];
+                let mut _pr_ptr_value = _pr_src.value;
+                if _pr_src.llvm_type != _pr_ptr_type {
+                    let _pr_cast = format_temp_name(result_temp);
+                    result_lines.push("  " + _pr_cast + " = bitcast " + _pr_src.llvm_type
+                        + " "
+                        + _pr_src.value
+                        + " to "
+                        + _pr_ptr_type);
+                    _pr_ptr_value = _pr_cast;
+                    result_temp = result_temp + 1;
+                }
+                let _pr_loaded = format_temp_name(result_temp);
+                result_lines.push("  " + _pr_loaded + " = load " + _pr_elem
+                    + ", "
+                    + _pr_ptr_type
+                    + " "
+                    + _pr_ptr_value);
+                result_temp = result_temp + 1;
+                let _pr_operand = LLVMOperand {
+                    llvm_type: _pr_elem,
+                    value: _pr_loaded
+                };
+                return ExpressionResult {
+                    lines: result_lines,
+                    temp_index: result_temp,
+                    operand: _pr_operand,
+                    diagnostics: result_diagnostics,
+                    string_constants: collected_string_constants
+                };
+            }
+        }
+    }
+
     // Standard function call
     if _trace_ccl {
         print.err("call_lowering: checkpoint-F call_symbol target="

--- a/compiler/src/llvm/rendering.sfn
+++ b/compiler/src/llvm/rendering.sfn
@@ -181,6 +181,16 @@ fn render_runtime_helper_declarations(used_targets: string[], local_functions: N
             if descriptor.target == "alloc_struct" { _preamble_inlined = true; }
             if descriptor.target == "runtime.free" { _preamble_inlined = true; }
             if descriptor.target == "rc.release" { _preamble_inlined = true; }
+            // #875: pointer-read intrinsics lower to a raw `load`, not a
+            // `call`, so there is no symbol to declare. Skipping them keeps
+            // the declare loop from emitting a `declare` that links to
+            // nothing.
+            if descriptor.target == "sailfin_intrinsic_pointer_read_i32" {
+                _preamble_inlined = true;
+            }
+            if descriptor.target == "sailfin_intrinsic_pointer_read_i64" {
+                _preamble_inlined = true;
+            }
             if _preamble_inlined {
                 index += 1;
                 continue;

--- a/compiler/src/llvm/runtime_helpers.sfn
+++ b/compiler/src/llvm/runtime_helpers.sfn
@@ -212,6 +212,23 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
         target: "sailfin_intrinsic_runtime_arena_rewind", symbol: "sailfin_intrinsic_runtime_arena_rewind", return_type: "void", parameter_types: ["double"], effects: [], native_signature: null, c_abi_return_type: null
     });
 
+    // Pointer-read intrinsics (#875, epic #763). These lower directly to an
+    // LLVM `load` of the given width — there is no C symbol behind them. The
+    // call-emission dispatcher (`coerce_and_emit_call` in
+    // `core_call_emission.sfn`) special-cases these symbols before normal
+    // symbol resolution and emits `load i32`/`load i64` (with a leading
+    // `bitcast` when the operand isn't already the matching pointer type).
+    // Empty effects is intentional: a raw load is not a capability — the
+    // effect lives on the upstream syscall that produced the pointer. The
+    // declare loop in `rendering.sfn` skips them so no bogus
+    // `declare @sailfin_intrinsic_pointer_read_*` links to nothing.
+    descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
+        target: "sailfin_intrinsic_pointer_read_i32", symbol: "sailfin_intrinsic_pointer_read_i32", return_type: "i32", parameter_types: ["i8*"], effects: [], native_signature: null, c_abi_return_type: null
+    });
+    descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
+        target: "sailfin_intrinsic_pointer_read_i64", symbol: "sailfin_intrinsic_pointer_read_i64", return_type: "i64", parameter_types: ["i8*"], effects: [], native_signature: null, c_abi_return_type: null
+    });
+
     // Network intrinsics
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
         target: "net_request", symbol: "sailfin_intrinsic_net_request", return_type: "i8*", parameter_types: ["i8*", "i8*", "i8*"], effects: ["net"], native_signature: null, c_abi_return_type: null
@@ -918,9 +935,15 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
         target: "crypto.sha256", symbol: "sha256__capsules__sfn__crypto__src__mod", return_type: "i8*", parameter_types: ["i8*"], effects: [], native_signature: null, c_abi_return_type: null
     });
 
-    // Base64 encode/decode
+    // Base64 encode. M3 (#817): base64 encode now lives in pure Sailfin under
+    // `capsules/sfn/crypto/src/mod.sfn`; the `base64.encode` intrinsic resolves
+    // to that capsule's `base64_encode` rather than the C symbol
+    // `sailfin_runtime_base64_encode`. The capsule's `base64_encode()` does the
+    // work in-language, so this descriptor has no in-tree caller today. The C
+    // body stays linked for seed compat until M3.9 deletes
+    // `runtime/native/src/sailfin_base64.c`.
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "base64.encode", symbol: "sailfin_runtime_base64_encode", return_type: "i8*", parameter_types: ["i8*", "i64"], effects: [], native_signature: null, c_abi_return_type: null
+        target: "base64.encode", symbol: "base64_encode__capsules__sfn__crypto__src__mod", return_type: "i8*", parameter_types: ["i8*"], effects: [], native_signature: null, c_abi_return_type: null
     });
 
     // HTTP helpers (curl subprocess)

--- a/compiler/tests/e2e/test_pointer_read_intrinsic.sh
+++ b/compiler/tests/e2e/test_pointer_read_intrinsic.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# End-to-end test for the pointer-read intrinsics (#875, epic #763).
+#
+# `sailfin_intrinsic_pointer_read_i32` / `_i64` are registry sentinels that
+# lower directly to an LLVM `load` of the matching width — there is no C
+# symbol behind them. This test pins that shape:
+#
+#   1. typecheck   — `sfn check <fixture>` reports `ok` (the intrinsics are
+#                    declared as plain `extern fn`; no accept-list change).
+#   2. load i32    — emitted IR contains `load i32, i32* %…` for the i32 read.
+#   3. load i64    — emitted IR contains `load i64, i64* %…` for the i64 read.
+#   4. no call     — no `call` instruction targets either sentinel symbol.
+#   5. no declare  — no `declare …@sailfin_intrinsic_pointer_read_*` line, so
+#                    the sentinel never links to a nonexistent symbol.
+#   6. bitcast     — an `i8*` operand is bitcast to the matching pointer type
+#                    before the load (the conditional-bitcast edge).
+
+set -euo pipefail
+
+BINARY="${1:?usage: test_pointer_read_intrinsic.sh <compiler-binary>}"
+BINARY="$(realpath "$BINARY")"
+PASS=0
+FAIL=0
+
+SCRATCH="$(mktemp -d -t sfn-pointer-read-XXXXXX)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+FIXTURE="$SCRATCH/pointer_read.sfn"
+# The intrinsics are called bare (no `extern fn`) — like the arena-mark
+# prior art in `cli_check.sfn`. A bare call leaves no function entry, so the
+# lowering fallback resolves it against the runtime-helper registry and the
+# load-not-call branch fires. Declaring them `extern fn` would instead route
+# the call through normal extern resolution and emit a stray `declare`.
+cat > "$FIXTURE" <<'EOF'
+extern fn malloc(size: usize) -> * u8;
+
+fn read_i32(p: * u8) -> i32 {
+    return sailfin_intrinsic_pointer_read_i32(p);
+}
+
+fn read_i64(p: * u8) -> i64 {
+    return sailfin_intrinsic_pointer_read_i64(p);
+}
+
+fn main() -> void {
+    let p: * u8 = malloc(8 as usize);
+    let a: i32 = read_i32(p);
+    let b: i64 = read_i64(p);
+}
+EOF
+
+LL="$SCRATCH/pointer_read.ll"
+
+run_test() {
+    local name="$1"
+    shift
+    if "$@"; then
+        echo "[test] PASS: $name"
+        PASS=$((PASS + 1))
+    else
+        echo "[test] FAIL: $name"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+test_check_clean() {
+    local log="$SCRATCH/check.log"
+    if ! "$BINARY" check "$FIXTURE" > "$log" 2>&1; then
+        echo "[test]   sfn check exited non-zero on fixture:"
+        cat "$log"
+        return 1
+    fi
+    return 0
+}
+
+test_emit() {
+    local log="$SCRATCH/emit.log"
+    if ! "$BINARY" emit -o "$LL" llvm "$FIXTURE" > "$log" 2>&1; then
+        echo "[test]   sfn emit llvm failed on fixture:"
+        cat "$log"
+        return 1
+    fi
+    return 0
+}
+
+test_load_i32() {
+    if ! grep -qE 'load i32, i32\* %' "$LL"; then
+        echo "[test]   missing 'load i32, i32* %…' in emitted IR"
+        return 1
+    fi
+    return 0
+}
+
+test_load_i64() {
+    if ! grep -qE 'load i64, i64\* %' "$LL"; then
+        echo "[test]   missing 'load i64, i64* %…' in emitted IR"
+        return 1
+    fi
+    return 0
+}
+
+test_no_call() {
+    if grep -qE 'call .*@sailfin_intrinsic_pointer_read_(i32|i64)' "$LL"; then
+        echo "[test]   sentinel was emitted as a 'call' rather than a 'load':"
+        grep -nE 'call .*@sailfin_intrinsic_pointer_read_(i32|i64)' "$LL"
+        return 1
+    fi
+    return 0
+}
+
+test_no_declare() {
+    local n
+    n="$(grep -cE 'declare .*@sailfin_intrinsic_pointer_read_(i32|i64)' "$LL" || true)"
+    if [ "$n" != "0" ]; then
+        echo "[test]   expected 0 'declare …@sailfin_intrinsic_pointer_read_*' lines, found $n:"
+        grep -nE 'declare .*@sailfin_intrinsic_pointer_read_(i32|i64)' "$LL"
+        return 1
+    fi
+    return 0
+}
+
+test_bitcast_i8ptr() {
+    # The i8* operand must be bitcast to the matching pointer type before
+    # the load.
+    if ! grep -qE 'bitcast i8\* %.* to i32\*' "$LL"; then
+        echo "[test]   missing 'bitcast i8* … to i32*' for the i8* operand"
+        return 1
+    fi
+    if ! grep -qE 'bitcast i8\* %.* to i64\*' "$LL"; then
+        echo "[test]   missing 'bitcast i8* … to i64*' for the i8* operand"
+        return 1
+    fi
+    return 0
+}
+
+run_test "sfn check passes on the pointer-read fixture" test_check_clean
+run_test "sfn emit llvm produces IR" test_emit
+run_test "i32 read lowers to 'load i32'" test_load_i32
+run_test "i64 read lowers to 'load i64'" test_load_i64
+run_test "sentinels are not emitted as 'call'" test_no_call
+run_test "no 'declare' for the pointer-read sentinels" test_no_declare
+run_test "i8* operand is bitcast to the matching pointer type" test_bitcast_i8ptr
+
+echo "[summary] $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi


### PR DESCRIPTION
## Summary

Two M3 runtime-migration items (epic #390), landed together because #875 is the prerequisite that unblocks the rest of the adapter work.

### #817 — base64 → pure Sailfin
- Reimplemented `base64_encode` in `capsules/sfn/crypto/src/mod.sfn` (RFC 4648, byte-oriented, no effects), mirroring the SHA-256 port style.
- Flipped the `base64.encode` registry entry off the C symbol `sailfin_runtime_base64_encode` to the capsule function, so `sailfin_base64.c` can be deleted at M3.9.
- Added `capsules/sfn/crypto/tests/base64_test.sfn` (known-answer vectors for all three padding residues + a non-ASCII case).

### #875 — pointer-read intrinsics (the #763 unblocker)
- Added `sailfin_intrinsic_pointer_read_i32` / `_i64` registry sentinels.
- `core_call_emission.sfn`: load-not-call branch — bitcasts an `i8*` operand to the matching pointer type, then emits `load i32` / `load i64`, returning early before symbol resolution. Empty effects is intentional (a raw load is not a capability).
- `rendering.sfn`: declare-suppression so no bogus `declare` links to a nonexistent symbol.
- New e2e shape test `compiler/tests/e2e/test_pointer_read_intrinsic.sh`.

This is the first primitive epic #763 needs to read syscall out-params back (e.g. `clock_gettime` `tv_sec`/`tv_nsec`). It **carries `seed-blocker`**: it self-hosts on the current seed, but #819 (clock adapter) and #818 (HTTP socket client) can only consume it from runtime source after a seed cut + `/pin-seed`.

## Scope notes / discoveries
While scoping the M3 adapter wave (#390), the other Wave-1 items turned out blocked or empty:
- **#819 (clock)** is hard-blocked on #763 — proved via emitted IR that `clock_gettime` receives a heap copy of the `Timespec` while field-reads load from the original alloca, so kernel writes are invisible. #875 is the fix.
- **#818 (HTTP)** needs new `net.sfn` externs (`getaddrinfo`, `htons`, `inet_pton`) + manual `sockaddr_in` construction, and DNS read-back also depends on #763. Larger than a wave item.
- **model stub (M3.4)** has no registry entry or symbol to flip — nothing to wire.
- **#820 (dead-entry deletion)** is ready: 11 of 12 entries are zero-call-site; `http.post` intrinsic has a live call site in `capsules/sfn/http/src/mod.sfn:53` and must wait for #818.

## Test plan
- [x] `make check` green; `stage2 == stage3` fixed point (self-host verified)
- [x] `test_pointer_read_intrinsic.sh` — 7/7 (`load i32`/`load i64`, leading bitcast, no `declare`, no `call`)
- [x] base64 known-answer vectors pass (`""`, `Zg==`, `Zm8=`, `Zm9v`, `Zm9vYg==`, `Zm9vYmE=`, `Zm9vYmFy`, `aGVsbG8gd29ybGQ=`, `w6k=`)
- [x] `sfn fmt --check` clean on all touched `.sfn` files

Closes #817
Closes #875

---
_Generated by [Claude Code](https://claude.ai/code/session_018hrgzJFDFf8WziSYi8RukS)_