### PR TITLE
feat(runtime): add __errno_location extern and errno() reader helper

### DIFF
--- a/compiler/tests/e2e/test_errno_reader.sh
+++ b/compiler/tests/e2e/test_errno_reader.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# End-to-end test for the Sailfin-native errno() reader (#876, epic #763).
+#
+# `runtime/sfn/platform/errno.sfn` declares `__errno_location() -> * i32`
+# (glibc's thread-local errno locator) and an `errno() -> i32` helper that
+# dereferences the returned pointer via the `sailfin_intrinsic_pointer_read_i32`
+# registry sentinel (#875). The sentinel lowers directly to an LLVM `load i32`
+# — there is no C symbol behind it. This test pins that shape against the
+# *real shipped module* (not a scratch fixture):
+#
+#   1. typecheck  — `sfn check errno.sfn` reports `ok`. The bare intrinsic
+#                   call resolves because its name is a runtime-helper call
+#                   name seeded into the E0420 resolution scope; the extern
+#                   passes the C-ABI accept-list (E0801–E0805).
+#   2. locator    — emitted IR declares + calls `i32* @__errno_location()`.
+#   3. load i32   — emitted IR contains `load i32, i32* %…` (the deref).
+#   4. no call    — no `call` instruction targets the pointer-read sentinel.
+#   5. no declare — no `declare …@sailfin_intrinsic_pointer_read_i32` line,
+#                   so the sentinel never links to a nonexistent symbol.
+
+set -euo pipefail
+
+BINARY="${1:?usage: test_errno_reader.sh <compiler-binary>}"
+BINARY="$(realpath "$BINARY")"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+ERRNO_SFN="$REPO_ROOT/runtime/sfn/platform/errno.sfn"
+PASS=0
+FAIL=0
+
+SCRATCH="$(mktemp -d -t sfn-errno-XXXXXX)"
+trap 'rm -rf "$SCRATCH"' EXIT
+LL="$SCRATCH/errno.ll"
+
+run_test() {
+    local name="$1"
+    shift
+    if "$@"; then
+        echo "[test] PASS: $name"
+        PASS=$((PASS + 1))
+    else
+        echo "[test] FAIL: $name"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+test_check_clean() {
+    local log="$SCRATCH/check.log"
+    if ! "$BINARY" check "$ERRNO_SFN" > "$log" 2>&1; then
+        echo "[test]   sfn check exited non-zero on errno.sfn:"
+        cat "$log"
+        return 1
+    fi
+    return 0
+}
+
+test_emit() {
+    local log="$SCRATCH/emit.log"
+    if ! "$BINARY" emit -o "$LL" llvm "$ERRNO_SFN" > "$log" 2>&1; then
+        echo "[test]   sfn emit llvm failed on errno.sfn:"
+        cat "$log"
+        return 1
+    fi
+    return 0
+}
+
+test_locator_call() {
+    if ! grep -qE 'call i32\* @__errno_location\(\)' "$LL"; then
+        echo "[test]   missing 'call i32* @__errno_location()' in emitted IR"
+        return 1
+    fi
+    return 0
+}
+
+test_load_i32() {
+    if ! grep -qE 'load i32, i32\* %' "$LL"; then
+        echo "[test]   missing 'load i32, i32* %…' (the errno deref) in emitted IR"
+        return 1
+    fi
+    return 0
+}
+
+test_no_call_sentinel() {
+    if grep -qE 'call .*@sailfin_intrinsic_pointer_read_i32' "$LL"; then
+        echo "[test]   pointer-read sentinel was emitted as a 'call' rather than a 'load':"
+        grep -nE 'call .*@sailfin_intrinsic_pointer_read_i32' "$LL"
+        return 1
+    fi
+    return 0
+}
+
+test_no_declare_sentinel() {
+    local n
+    n="$(grep -cE 'declare .*@sailfin_intrinsic_pointer_read_i32' "$LL" || true)"
+    if [ "$n" != "0" ]; then
+        echo "[test]   expected 0 'declare …@sailfin_intrinsic_pointer_read_i32' lines, found $n:"
+        grep -nE 'declare .*@sailfin_intrinsic_pointer_read_i32' "$LL"
+        return 1
+    fi
+    return 0
+}
+
+run_test "sfn check passes on runtime/sfn/platform/errno.sfn" test_check_clean
+run_test "sfn emit llvm produces IR" test_emit
+run_test "errno() calls i32* @__errno_location()" test_locator_call
+run_test "the deref lowers to 'load i32'" test_load_i32
+run_test "pointer-read sentinel is not emitted as 'call'" test_no_call_sentinel
+run_test "no 'declare' for the pointer-read sentinel" test_no_declare_sentinel
+
+echo "[summary] $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi

--- a/runtime/native/capsule.toml
+++ b/runtime/native/capsule.toml
@@ -55,7 +55,7 @@ ll-sources = ["ir/runtime_globals.ll"]
 # and the formerly-load-bearing allowlist is gone.
 #
 # Single-line array per the parser limitation noted above.
-sfn-sources = ["../sfn/memory/arena.sfn", "../sfn/memory/rc.sfn", "../sfn/string.sfn", "../sfn/array.sfn", "../sfn/clock.sfn", "../sfn/process.sfn", "../sfn/io.sfn", "../sfn/exception.sfn", "../sfn/type_meta.sfn", "../sfn/platform/exec.sfn", "../sfn/platform/errno.sfn", "../sfn/adapters/filesystem.sfn"]
+sfn-sources = ["../sfn/memory/arena.sfn", "../sfn/memory/rc.sfn", "../sfn/string.sfn", "../sfn/array.sfn", "../sfn/clock.sfn", "../sfn/process.sfn", "../sfn/io.sfn", "../sfn/exception.sfn", "../sfn/type_meta.sfn", "../sfn/platform/exec.sfn", "../sfn/adapters/filesystem.sfn"]
 include-dirs = ["include"]
 link-libs = ["-lm"]
 

--- a/runtime/native/capsule.toml
+++ b/runtime/native/capsule.toml
@@ -55,7 +55,7 @@ ll-sources = ["ir/runtime_globals.ll"]
 # and the formerly-load-bearing allowlist is gone.
 #
 # Single-line array per the parser limitation noted above.
-sfn-sources = ["../sfn/memory/arena.sfn", "../sfn/memory/rc.sfn", "../sfn/string.sfn", "../sfn/array.sfn", "../sfn/clock.sfn", "../sfn/process.sfn", "../sfn/io.sfn", "../sfn/exception.sfn", "../sfn/type_meta.sfn", "../sfn/platform/exec.sfn", "../sfn/adapters/filesystem.sfn"]
+sfn-sources = ["../sfn/memory/arena.sfn", "../sfn/memory/rc.sfn", "../sfn/string.sfn", "../sfn/array.sfn", "../sfn/clock.sfn", "../sfn/process.sfn", "../sfn/io.sfn", "../sfn/exception.sfn", "../sfn/type_meta.sfn", "../sfn/platform/exec.sfn", "../sfn/platform/errno.sfn", "../sfn/adapters/filesystem.sfn"]
 include-dirs = ["include"]
 link-libs = ["-lm"]
 

--- a/runtime/sfn/platform/errno.sfn
+++ b/runtime/sfn/platform/errno.sfn
@@ -24,6 +24,19 @@
 // conditional split is deferred (tracked under #763). The EINTR
 // retry rewrite and the `clock_gettime` field reader that also
 // consume pointer-read intrinsics are separate issues.
+//
+// Status: typecheck + emit smoke module. Deliberately NOT listed in
+// `runtime/native/capsule.toml` `sfn-sources` — exactly like its
+// siblings `posix.sfn` / `libc.sfn` / `net.sfn` / `pthread.sfn`,
+// which are also not yet linked. `sfn-sources` registration forces a
+// link on every target, and `__errno_location` is glibc-only: on
+// macOS arm64 (Darwin uses `__error`) the link fails with an
+// undefined `___errno_location`. The module gets wired into
+// `sfn-sources` once a consumer exists *and* the macOS `__error`
+// platform split lands (both deferred under #763). Until then this
+// file proves the reader type-checks and lowers to a `load i32` on
+// Linux x86_64 (the epic's stated gate); the e2e shape test is
+// `compiler/tests/e2e/test_errno_reader.sh`.
 extern fn __errno_location() -> * i32;
 
 // Read the calling thread's current `errno` value. Pure: a raw

--- a/runtime/sfn/platform/errno.sfn
+++ b/runtime/sfn/platform/errno.sfn
@@ -1,0 +1,36 @@
+// runtime/sfn/platform/errno.sfn
+//
+// Pure-Sailfin `errno` reader for Linux/glibc. Companion to
+// `runtime/sfn/platform/posix.sfn` and `libc.sfn`; see `libc.sfn`
+// for the long-form extern rationale (type discipline, `unsafe`
+// policy, formatter pointer spelling, opaque-pointee rule).
+//
+// glibc exposes the thread-local `errno` slot through a function
+// `int *__errno_location(void)` rather than a global symbol, so a
+// precise read is two steps: call the locator to obtain the
+// `int *`, then dereference it. The dereference uses the
+// `sailfin_intrinsic_pointer_read_i32` registry sentinel (#875),
+// which lowers directly to an LLVM `load i32` — there is no C
+// symbol behind it. The locator's `* i32` result is already an
+// `i32*`, so the load needs no leading bitcast.
+//
+// Type discipline: `__errno_location() -> * i32` obeys the v0
+// C-ABI accept-list enforced by `check_extern_signature` in
+// `compiler/src/typecheck_types.sfn` (E0801–E0805) — `i32` is an
+// extern primitive, so `* i32` is an accepted pointer return.
+//
+// Scope (epic #763, #876): this is the narrow Linux x86_64 reader.
+// macOS arm64 spells the locator `__error`; that platform-
+// conditional split is deferred (tracked under #763). The EINTR
+// retry rewrite and the `clock_gettime` field reader that also
+// consume pointer-read intrinsics are separate issues.
+extern fn __errno_location() -> * i32;
+
+// Read the calling thread's current `errno` value. Pure: a raw
+// memory load is not an `io`/`net`/`clock` capability — the effect
+// lives on the upstream syscall that set `errno`, not on observing
+// it here (matches the empty-effects rule the pointer-read
+// intrinsic ships with).
+fn errno() -> i32 {
+    return sailfin_intrinsic_pointer_read_i32(__errno_location());
+}


### PR DESCRIPTION
## Summary

- New `runtime/sfn/platform/errno.sfn`: declares the Linux/glibc `__errno_location() -> * i32` extern and a pure `errno() -> i32` helper that dereferences the returned pointer via the `sailfin_intrinsic_pointer_read_i32` registry sentinel (#875), which lowers directly to an LLVM `load i32` — no C symbol behind it.
- New `compiler/tests/e2e/test_errno_reader.sh` pinning the IR shape against the real shipped module.

Closes #876

## Scope deviation (macOS link)

The issue listed registering the module in `runtime/native/capsule.toml` `sfn-sources` as **In** scope, but `sfn-sources` forces a link on **every** target and `__errno_location` is glibc-only — macOS arm64 (Darwin uses `__error`) failed CI to link with an undefined `___errno_location`, even though nothing calls `errno()` yet. That directly conflicts with the issue's **Out**-of-scope note (macOS `__error` platform split deferred under #763).

Per maintainer decision, this PR **does not** add `errno.sfn` to `sfn-sources` — mirroring the sibling extern modules (`posix.sfn` / `libc.sfn` / `net.sfn` / `pthread.sfn`), which are also deliberately unlinked until they have a consumer. The reader still type-checks and lowers correctly on Linux x86_64 (the epic's stated gate). `sfn-sources` wiring is deferred to the issue that adds a consumer + the macOS `__error` split.

## Acceptance Criteria

- [x] `errno()` type-checks; the `__errno_location` extern passes the C-ABI accept-list (`i32` is an extern primitive, so `* i32` is an accepted pointer return — E0801–E0805 clean).
- [x] Emitted IR for `errno()` contains `call i32* @__errno_location()` followed by `load i32, i32* %…` — and **no** `call` to a pointer-read sentinel.
- [x] `make compile` passes (compiler self-hosts).
- [x] `make check` passes (stage2 == stage3 fixed point).
- [x] `sfn fmt --check` clean on every touched `.sfn` file.
- [~] ~~Register in `sfn-sources`~~ — deferred (see *Scope deviation* above); would break the macOS link without the out-of-scope platform split.

## Implementation notes

- The bare `sailfin_intrinsic_pointer_read_i32(...)` call type-checks because runtime-helper target names are seeded into the E0420 resolution scope via `load_prelude_global_names(runtime_helper_call_names())` — the same mechanism #875's fixture relied on.
- `__errno_location()` returns `i32*`; the lowering coerces the operand to the intrinsic's `i8*` param then bitcasts back to `i32*` before the `load i32` (a correct round-trip LLVM folds away).
- Seed gate (Phase 1.5): verified #875's full implementation is present at the pinned seed tag `v0.7.0-alpha.10`, so the seed understands the sentinel.

## Files Changed

- `runtime/sfn/platform/errno.sfn` (new)
- `compiler/tests/e2e/test_errno_reader.sh` (new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
