### PR TITLE
feat(lowering): host-aware errno-location sentinel (Linux/macOS) — #877 prerequisite

### DIFF
--- a/compiler/src/llvm/expression_lowering/native/core_call_emission.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_call_emission.sfn
@@ -5,7 +5,7 @@
 import { NativeFunction, NativeParameter } from "../../../native_ir";
 import { find_last_index_of_char, substring } from "../../../string_utils";
 import { format_temp_name, format_typed_operand } from "../../expressions_helpers";
-import { trace_lowering } from "../../lowering_debug_state";
+import { errno_locator_symbol, trace_lowering } from "../../lowering_debug_state";
 import { merge_string_constants } from "../../strings";
 import { find_interface_info_by_name } from "../../type_context_queries";
 import { ends_with_pointer_suffix, strip_pointer_suffix } from "../../type_mapping";
@@ -644,6 +644,35 @@ fn coerce_and_emit_call(trimmed_target: string, operands: LLVMOperand[], expecte
             result_diagnostics.push("llvm lowering: malformed trait dispatch target `"
                 + trimmed_target
                 + "`");
+        }
+    }
+
+    // errno-location sentinel (#877, epic #763): emit a `call` to the
+    // host's concrete locator symbol — `@__errno_location` on Linux/glibc,
+    // `@__error` on Darwin/macOS — chosen at emit time. The same compiler
+    // source thus links on both platforms when built natively (the IR is
+    // target-neutral; the host clang resolves the symbol). The result is an
+    // `i32*` that feeds straight into `sailfin_intrinsic_pointer_read_i32`.
+    // The concrete symbol's `declare` is emitted via its registry descriptor
+    // when the post-lowering call-target scan sees this call line.
+    if helper_descriptor != null {
+        if helper_descriptor.symbol == "sailfin_intrinsic_errno_location" {
+            let _en_symbol = errno_locator_symbol();
+            let _en_tmp = format_temp_name(result_temp);
+            result_lines.push("  " + _en_tmp + " = call i32* @" + _en_symbol
+                + "()");
+            result_temp = result_temp + 1;
+            let _en_operand = LLVMOperand {
+                llvm_type: "i32*",
+                value: _en_tmp
+            };
+            return ExpressionResult {
+                lines: result_lines,
+                temp_index: result_temp,
+                operand: _en_operand,
+                diagnostics: result_diagnostics,
+                string_constants: collected_string_constants
+            };
         }
     }
 

--- a/compiler/src/llvm/lowering_debug_state.sfn
+++ b/compiler/src/llvm/lowering_debug_state.sfn
@@ -54,9 +54,14 @@
 // **Back-compat.** `_legacy_flag_file` keeps `touch
 // build/sailfin/.trace_lowering` working for one release. Drop the
 // shim in the release after #312 ships.
-import { _env_flag, _legacy_flag_file } from "../cli_commands_utils";
+import { _env_flag, _legacy_flag_file, _shell_read_cmd } from "../cli_commands_utils";
 
-export { trace_lowering, trace_call_lowering, skip_module_globals };
+export {
+    trace_lowering,
+    trace_call_lowering,
+    skip_module_globals,
+    errno_locator_symbol
+};
 
 // Per-flag cache cells. `_X_initialized` flips from false to true on
 // the first call to the flag's probe; `_X_value` is the resolved
@@ -70,6 +75,12 @@ let mut _trace_call_lowering_initialized: boolean = false;
 let mut _trace_call_lowering_value: boolean = false;
 let mut _skip_module_globals_initialized: boolean = false;
 let mut _skip_module_globals_value: boolean = false;
+// Cache for the host's `errno`-location C symbol (#877, epic #763).
+// `_errno_locator_initialized` flips to true after the one-time
+// `uname -s` probe; `_errno_locator_value` holds the resolved symbol
+// name (`__errno_location` on Linux/glibc, `__error` on Darwin).
+let mut _errno_locator_initialized: boolean = false;
+let mut _errno_locator_value: string = "";
 
 // True when the user requested LLVM-lowering stderr trace via
 // `SAILFIN_TRACE_LOWERING=1` (or the legacy `.trace_lowering` file).
@@ -112,4 +123,28 @@ fn skip_module_globals() -> boolean ![io] {
         _skip_module_globals_initialized = true;
     }
     return _skip_module_globals_value;
+}
+
+// The host's C symbol for the thread-local `errno` slot address
+// (#877, epic #763). glibc exposes `int *__errno_location(void)`;
+// Darwin/macOS exposes `int *__error(void)`. The `sailfin_intrinsic_
+// errno_location` sentinel's lowering branch
+// (`core_call_emission.sfn`) reads this to emit the correct
+// `call i32* @<sym>()` so the same compiler source links on both
+// Linux and macOS when built natively per platform (CI emits target-
+// neutral IR resolved by the host clang). Defaults to the glibc
+// spelling on any non-Darwin or empty `uname` so the dominant Linux
+// leg is never wrong — only an explicit `Darwin` flips to `__error`.
+// Probed once via `uname -s` and cached (the lowering hot path may
+// hit this per errno read); mirrors the lazy-init contract of the
+// trace toggles above.
+fn errno_locator_symbol() -> string ![io] {
+    if !_errno_locator_initialized {
+        let os = _shell_read_cmd("uname -s");
+        if os == "Darwin" { _errno_locator_value = "__error"; } else {
+            _errno_locator_value = "__errno_location";
+        }
+        _errno_locator_initialized = true;
+    }
+    return _errno_locator_value;
 }

--- a/compiler/src/llvm/rendering.sfn
+++ b/compiler/src/llvm/rendering.sfn
@@ -191,6 +191,17 @@ fn render_runtime_helper_declarations(used_targets: string[], local_functions: N
             if descriptor.target == "sailfin_intrinsic_pointer_read_i64" {
                 _preamble_inlined = true;
             }
+            // #877: the errno-location sentinel never appears as a real
+            // `call @sailfin_intrinsic_errno_location(` — the lowering
+            // branch emits the concrete `__errno_location`/`__error`
+            // instead. The source-text walker still picks the sentinel
+            // target up from the call expression in `clock.sfn`, so skip
+            // it here to avoid a bogus `declare` to a symbol that does
+            // not exist. The concrete locator's declare is emitted via
+            // its own descriptor row when the line scan sees the call.
+            if descriptor.target == "sailfin_intrinsic_errno_location" {
+                _preamble_inlined = true;
+            }
             if _preamble_inlined {
                 index += 1;
                 continue;

--- a/compiler/src/llvm/runtime_helpers.sfn
+++ b/compiler/src/llvm/runtime_helpers.sfn
@@ -254,15 +254,19 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
     // `declare i32* @__errno_location()` / `@__error()` for whichever
     // symbol the sentinel branch actually emits on the build host —
     // the scan matches `descriptor.symbol` against emitted `call`
-    // lines, so only the host's locator (the one with a real call
-    // site) is ever declared; the other descriptor stays inert. They
-    // are NOT skipped in `rendering.sfn` (unlike the sentinel) because
-    // their declare is exactly what we want.
+    // lines and the declare loop declares `symbol`, so only the host's
+    // locator (the one with a real call site) is ever declared; the
+    // other descriptor stays inert. Their `target`s are deliberately
+    // dotted (member-style) so `runtime_helper_call_names()` does NOT
+    // seed `__errno_location` / `__error` as bare source-level globals
+    // — otherwise `__error()` would typecheck on Linux and then fail
+    // to link. Callers must go through the host-aware sentinel; these
+    // rows are internal-only.
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "__errno_location", symbol: "__errno_location", return_type: "i32*", parameter_types: [], effects: [], native_signature: null, c_abi_return_type: null
+        target: "intrinsic.errno_location.glibc", symbol: "__errno_location", return_type: "i32*", parameter_types: [], effects: [], native_signature: null, c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "__error", symbol: "__error", return_type: "i32*", parameter_types: [], effects: [], native_signature: null, c_abi_return_type: null
+        target: "intrinsic.errno_location.darwin", symbol: "__error", return_type: "i32*", parameter_types: [], effects: [], native_signature: null, c_abi_return_type: null
     });
 
     // Network intrinsics

--- a/compiler/src/llvm/runtime_helpers.sfn
+++ b/compiler/src/llvm/runtime_helpers.sfn
@@ -229,6 +229,42 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
         target: "sailfin_intrinsic_pointer_read_i64", symbol: "sailfin_intrinsic_pointer_read_i64", return_type: "i64", parameter_types: ["i8*"], effects: [], native_signature: null, c_abi_return_type: null
     });
 
+    // errno-location sentinel (#877, epic #763). Resolves the
+    // thread-local `errno` slot's address. The concrete C symbol is
+    // host-dependent — glibc exposes `int *__errno_location(void)`,
+    // while Darwin/macOS exposes `int *__error(void)` — so the
+    // call-emission dispatcher (`coerce_and_emit_call` in
+    // `core_call_emission.sfn`) special-cases this symbol and emits a
+    // `call i32* @__errno_location()` or `call i32* @__error()`
+    // chosen by host detection at emit time, returning an `i32*` that
+    // feeds straight into `sailfin_intrinsic_pointer_read_i32`. This
+    // is the first host-conditional symbol selection in lowering and
+    // is what lets `runtime/sfn/clock.sfn` read `errno` without
+    // hardcoding the glibc-only locator (which broke the macOS link —
+    // see #876/#882). Empty effects: choosing/reading the locator is
+    // not a capability. The declare loop in `rendering.sfn` skips the
+    // sentinel target; the concrete locator's `declare` is emitted by
+    // the lowering branch itself.
+    descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
+        target: "sailfin_intrinsic_errno_location", symbol: "sailfin_intrinsic_errno_location", return_type: "i32*", parameter_types: [], effects: [], native_signature: null, c_abi_return_type: null
+    });
+    // Concrete errno-locator C symbols backing the sentinel above.
+    // These exist only so the post-lowering call-target scan
+    // (`collect_runtime_helper_targets_from_lines`) emits a matching
+    // `declare i32* @__errno_location()` / `@__error()` for whichever
+    // symbol the sentinel branch actually emits on the build host —
+    // the scan matches `descriptor.symbol` against emitted `call`
+    // lines, so only the host's locator (the one with a real call
+    // site) is ever declared; the other descriptor stays inert. They
+    // are NOT skipped in `rendering.sfn` (unlike the sentinel) because
+    // their declare is exactly what we want.
+    descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
+        target: "__errno_location", symbol: "__errno_location", return_type: "i32*", parameter_types: [], effects: [], native_signature: null, c_abi_return_type: null
+    });
+    descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
+        target: "__error", symbol: "__error", return_type: "i32*", parameter_types: [], effects: [], native_signature: null, c_abi_return_type: null
+    });
+
     // Network intrinsics
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
         target: "net_request", symbol: "sailfin_intrinsic_net_request", return_type: "i8*", parameter_types: ["i8*", "i8*", "i8*"], effects: ["net"], native_signature: null, c_abi_return_type: null

--- a/compiler/tests/e2e/test_errno_locator_platform.sh
+++ b/compiler/tests/e2e/test_errno_locator_platform.sh
@@ -130,9 +130,13 @@ test_linux_load() {
 }
 
 test_linux_no_darwin_symbol() {
-    if grep -qE '@__error\b' "$LL_LINUX"; then
-        echo "[test]   unexpected '@__error' in Linux-path IR:"
-        grep -nE '@__error\b' "$LL_LINUX"
+    # Anchor on the trailing `(` rather than `\b`: BSD/macOS `grep -E`
+    # treats `\b` as a literal backspace, not a word boundary (see
+    # test_runtime_libc_skeleton.sh:95-102), and this test runs on the
+    # macos-arm64 CI leg.
+    if grep -qE '@__error\(' "$LL_LINUX"; then
+        echo "[test]   unexpected '@__error(' in Linux-path IR:"
+        grep -nE '@__error\(' "$LL_LINUX"
         return 1
     fi
     return 0
@@ -157,9 +161,11 @@ test_darwin_declare() {
 }
 
 test_darwin_no_linux_symbol() {
-    if grep -qE '@__errno_location\b' "$LL_DARWIN"; then
-        echo "[test]   unexpected '@__errno_location' in Darwin-path IR:"
-        grep -nE '@__errno_location\b' "$LL_DARWIN"
+    # Anchor on `(` not `\b` for BSD/macOS `grep -E` portability — see
+    # test_linux_no_darwin_symbol above.
+    if grep -qE '@__errno_location\(' "$LL_DARWIN"; then
+        echo "[test]   unexpected '@__errno_location(' in Darwin-path IR:"
+        grep -nE '@__errno_location\(' "$LL_DARWIN"
         return 1
     fi
     return 0

--- a/compiler/tests/e2e/test_errno_locator_platform.sh
+++ b/compiler/tests/e2e/test_errno_locator_platform.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+# End-to-end test for the host-aware errno-location sentinel (#877, epic #763).
+#
+# `sailfin_intrinsic_errno_location` is a registry sentinel whose lowering
+# branch (`core_call_emission.sfn`) emits a `call` to the host's concrete
+# `errno`-slot locator — `@__errno_location` on Linux/glibc, `@__error` on
+# Darwin/macOS — chosen at emit time from `uname -s`. This lets the same
+# compiler source link on both platforms when built natively, and is what
+# unblocks `runtime/sfn/clock.sfn` reading `errno` without hardcoding the
+# glibc-only symbol (which broke the macOS link — see #876/#882).
+#
+# The test is host-independent: it forces BOTH platform paths via a `uname`
+# shim on PATH, so it asserts the same thing whether CI runs it on Linux or
+# macOS hardware. For each forced platform it pins:
+#
+#   1. typecheck       — `sfn check <fixture>` reports `ok` (the sentinel is
+#                        seeded into the resolution scope; no extern needed).
+#   2. locator call    — emitted IR contains `call i32* @<sym>()`.
+#   3. locator declare — emitted IR contains `declare i32* @<sym>()` (so the
+#                        call resolves; emitted via the concrete descriptor).
+#   4. load i32        — the pointer-read deref following the locator call.
+#   5. no other symbol — the opposite platform's locator does NOT appear.
+#   6. no sentinel leak — no `call`/`declare` targets the sentinel name
+#                        (`sailfin_intrinsic_errno_location`); it must vanish
+#                        into the concrete locator.
+
+set -euo pipefail
+
+BINARY="${1:?usage: test_errno_locator_platform.sh <compiler-binary>}"
+BINARY="$(realpath "$BINARY")"
+PASS=0
+FAIL=0
+
+SCRATCH="$(mktemp -d -t sfn-errno-locator-XXXXXX)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+# Fixture mirrors the real consumer shape (clock.sfn): chain the locator
+# sentinel into the pointer-read intrinsic, exactly as `errno()` does.
+FIXTURE="$SCRATCH/errno_locator.sfn"
+cat > "$FIXTURE" <<'EOF'
+fn read_errno() -> i32 {
+    return sailfin_intrinsic_pointer_read_i32(sailfin_intrinsic_errno_location());
+}
+
+fn main() -> void {
+    let e: i32 = read_errno();
+}
+EOF
+
+# A `uname` shim that reports the requested OS for `-s` and delegates every
+# other invocation to the real binary, so the compiler's `uname -s` probe
+# resolves to our forced platform without disturbing anything else.
+make_uname_shim() {
+    local dir="$1" os="$2"
+    mkdir -p "$dir"
+    cat > "$dir/uname" <<SHIM
+#!/bin/sh
+if [ "\$1" = "-s" ]; then echo "$os"; exit 0; fi
+exec /usr/bin/uname "\$@"
+SHIM
+    chmod +x "$dir/uname"
+}
+
+run_test() {
+    local name="$1"
+    shift
+    if "$@"; then
+        echo "[test] PASS: $name"
+        PASS=$((PASS + 1))
+    else
+        echo "[test] FAIL: $name"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+test_check_clean() {
+    local log="$SCRATCH/check.log"
+    if ! "$BINARY" check "$FIXTURE" > "$log" 2>&1; then
+        echo "[test]   sfn check exited non-zero on fixture:"
+        cat "$log"
+        return 1
+    fi
+    return 0
+}
+
+# Emit IR with `uname -s` forced to $1 ("Linux" | "Darwin"); writes to $2.
+emit_for_os() {
+    local os="$1" out="$2"
+    local shimdir="$SCRATCH/shim-$os"
+    local log="$SCRATCH/emit-$os.log"
+    make_uname_shim "$shimdir" "$os"
+    if ! PATH="$shimdir:$PATH" "$BINARY" emit -o "$out" llvm "$FIXTURE" > "$log" 2>&1; then
+        echo "[test]   sfn emit llvm failed (uname=$os):"
+        cat "$log"
+        return 1
+    fi
+    return 0
+}
+
+LL_LINUX="$SCRATCH/errno_linux.ll"
+LL_DARWIN="$SCRATCH/errno_darwin.ll"
+
+test_emit_linux() { emit_for_os "Linux" "$LL_LINUX"; }
+test_emit_darwin() { emit_for_os "Darwin" "$LL_DARWIN"; }
+
+# --- Linux path: @__errno_location, not @__error ---
+
+test_linux_call() {
+    if ! grep -qE 'call i32\* @__errno_location\(\)' "$LL_LINUX"; then
+        echo "[test]   missing 'call i32* @__errno_location()' on the Linux path"
+        return 1
+    fi
+    return 0
+}
+
+test_linux_declare() {
+    if ! grep -qE 'declare i32\* @__errno_location\(\)' "$LL_LINUX"; then
+        echo "[test]   missing 'declare i32* @__errno_location()' on the Linux path"
+        return 1
+    fi
+    return 0
+}
+
+test_linux_load() {
+    if ! grep -qE 'load i32, i32\* %' "$LL_LINUX"; then
+        echo "[test]   missing 'load i32, i32* %…' (errno deref) on the Linux path"
+        return 1
+    fi
+    return 0
+}
+
+test_linux_no_darwin_symbol() {
+    if grep -qE '@__error\b' "$LL_LINUX"; then
+        echo "[test]   unexpected '@__error' in Linux-path IR:"
+        grep -nE '@__error\b' "$LL_LINUX"
+        return 1
+    fi
+    return 0
+}
+
+# --- Darwin path: @__error, not @__errno_location ---
+
+test_darwin_call() {
+    if ! grep -qE 'call i32\* @__error\(\)' "$LL_DARWIN"; then
+        echo "[test]   missing 'call i32* @__error()' on the Darwin path"
+        return 1
+    fi
+    return 0
+}
+
+test_darwin_declare() {
+    if ! grep -qE 'declare i32\* @__error\(\)' "$LL_DARWIN"; then
+        echo "[test]   missing 'declare i32* @__error()' on the Darwin path"
+        return 1
+    fi
+    return 0
+}
+
+test_darwin_no_linux_symbol() {
+    if grep -qE '@__errno_location\b' "$LL_DARWIN"; then
+        echo "[test]   unexpected '@__errno_location' in Darwin-path IR:"
+        grep -nE '@__errno_location\b' "$LL_DARWIN"
+        return 1
+    fi
+    return 0
+}
+
+# --- The sentinel name must never appear as a real symbol ---
+
+test_no_sentinel_leak() {
+    local n
+    n="$(grep -cE '(call|declare) .*@sailfin_intrinsic_errno_location' "$LL_LINUX" "$LL_DARWIN" 2>/dev/null | awk -F: '{s+=$2} END {print s+0}')"
+    if [ "$n" != "0" ]; then
+        echo "[test]   expected 0 call/declare of the sentinel symbol, found $n:"
+        grep -nE '(call|declare) .*@sailfin_intrinsic_errno_location' "$LL_LINUX" "$LL_DARWIN" || true
+        return 1
+    fi
+    return 0
+}
+
+run_test "sfn check passes on the errno-locator fixture" test_check_clean
+run_test "sfn emit llvm produces IR (uname=Linux)" test_emit_linux
+run_test "sfn emit llvm produces IR (uname=Darwin)" test_emit_darwin
+run_test "Linux path calls @__errno_location" test_linux_call
+run_test "Linux path declares @__errno_location" test_linux_declare
+run_test "Linux path derefs via 'load i32'" test_linux_load
+run_test "Linux path omits @__error" test_linux_no_darwin_symbol
+run_test "Darwin path calls @__error" test_darwin_call
+run_test "Darwin path declares @__error" test_darwin_declare
+run_test "Darwin path omits @__errno_location" test_darwin_no_linux_symbol
+run_test "sentinel symbol never emitted as call/declare" test_no_sentinel_leak
+
+echo "[summary] $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi


### PR DESCRIPTION
## Summary

Adds a `sailfin_intrinsic_errno_location` registry sentinel whose lowering branch emits a `call` to the host's concrete `errno`-slot locator — `@__errno_location` on Linux/glibc, `@__error` on Darwin/macOS — chosen at emit time from `uname -s`. The compiler emits target-neutral IR resolved by the host clang and CI builds natively per platform, so the same source now links on both.

**This is the seed-blocker prerequisite for #877, not #877 itself.** While picking up #877 (tighten `sfn_sleep`'s EINTR loop to a precise `errno() == EINTR` check) I found the original XS scope is impossible: `runtime/sfn/clock.sfn` is a linked `sfn-source` on **every** target, so consuming `errno()` pulls the glibc-only `__errno_location` into the macOS compiler link — the exact undefined-`___errno_location` failure PR #882 hit and explicitly deferred. The fix is to move the platform-symbol choice into the compiler (the only place that knows the host). That new capability must ship in the **pinned seed** before `clock.sfn` can call it (stage-1 of `make compile` compiles `clock.sfn` with the seed), so it lands as its own PR.

Sequence (mirrors #875 → seed → #876): **this PR → cut alpha + `/pin-seed` → PR-B (the `clock.sfn` EINTR rewrite, closes #877)**.

## Changes
- **`runtime_helpers.sfn`** — register the `sailfin_intrinsic_errno_location` sentinel + inert `__errno_location`/`__error` descriptor rows, so the post-lowering call-target scan emits a `declare` for whichever locator the branch actually emits on the build host.
- **`core_call_emission.sfn`** — sentinel branch (sibling to the #875 pointer-read branch) emitting `call i32* @<locator>()`, returning an `i32*` that feeds straight into `sailfin_intrinsic_pointer_read_i32`.
- **`lowering_debug_state.sfn`** — cached one-shot `uname -s` host probe (`errno_locator_symbol`), defaulting to the glibc spelling on any non-Darwin/empty result so the dominant Linux leg is never wrong.
- **`rendering.sfn`** — suppress the bogus sentinel `declare` (the source-text walker still picks the sentinel name up from a caller; the concrete locator's declare comes via its own descriptor).
- **`test_errno_locator_platform.sh`** (new) — host-independent e2e driving **both** platform paths via a `uname` shim.

## Verification
```
ulimit -v 8388608 && make compile        # self-hosts ✓
ulimit -v 8388608 && make check           # stage2 == stage3 fixed point ✓ ; e2e-sh 79/79 ✓
bash compiler/tests/e2e/test_errno_locator_platform.sh build/native/sailfin   # 11/11 ✓
bash compiler/tests/e2e/test_errno_reader.sh build/native/sailfin             # 6/6 ✓ (no regression)
bash compiler/tests/e2e/test_pointer_read_intrinsic.sh build/native/sailfin   # 7/7 ✓ (no regression)
sfn fmt --check <all four touched .sfn>   # clean
```

Emitted IR, confirmed both paths (Linux real `uname`, Darwin via shim):
```
; Linux                          ; Darwin
declare i32* @__errno_location() declare i32* @__error()
%t0 = call i32* @__errno_location()  %t0 = call i32* @__error()
%t3 = load i32, i32* %t2         %t3 = load i32, i32* %t2
```
No bogus `@sailfin_intrinsic_errno_location` symbol in either; the opposite platform's locator never appears.

> **macOS gate:** this PR leaves `clock.sfn` untouched, so the macos-arm64 leg is unchanged here. The Darwin emit path is exercised on Linux via the `uname` shim; the binding macOS CI validation arrives with PR-B (which adds the real `clock.sfn` consumer).

Refs #877, #763. First host-conditional symbol selection in lowering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VKKT42Z6uJypLyUuG2TXEL)_