### PR TITLE
feat(runtime): replace curl HTTP path with socket adapter (no TLS, v0)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1130,7 +1130,7 @@ ci-cross-windows:
 		"$$WIN_OBJ/runtime/filesystem.o" \
 		"$$WIN_OBJ/runtime/http.o" \
 		$$SHIM_O \
-		-lm -lpthread; \
+		-lm -lpthread -lws2_32; \
 	\
 	echo "[cross-windows] built $$WIN_OUT"; \
 	ls -lh "$$WIN_OUT"; \

--- a/Makefile
+++ b/Makefile
@@ -864,6 +864,29 @@ rebuild:
 		echo "[rebuild] staging filesystem.o..."; \
 		$(CLANG) -O2 -Wno-override-module -c build/native/obj/runtime/filesystem.ll -o build/native/obj/runtime/filesystem.o; \
 	fi
+	@# Stage http.o (Sailfin-native socket HTTP client from
+	@# runtime/sfn/adapters/http.sfn). M3 (issue #818, epic #390)
+	@# flips the `http.get_body` / `http.post_json` / `http.download`
+	@# descriptor rows' `native_signature` (and the `http_get` /
+	@# `http_post` aliases) to `sfn_http_get` / `sfn_http_post` /
+	@# `sfn_http_post2` / `sfn_http_download`, replacing the curl
+	@# subprocess path with a pure-Sailfin socket client (HTTP only,
+	@# no TLS for v0). The legacy `sfn run` / `sfn build` link path
+	@# (`_clang_compile_runtime_objects` in
+	@# `compiler/src/cli_main.sfn`) resolves those symbols against
+	@# this staged .o; the runtime-capsule path reaches http.sfn
+	@# through `runtime/native/capsule.toml`'s `sfn-sources` array
+	@# instead. Without this staging, any user program touching
+	@# `http.*` fails at link with "undefined reference to
+	@# `sfn_http_get`".
+	@if [ ! -f build/native/obj/runtime/http.ll ]; then \
+		echo "[rebuild] staging http.ll..."; \
+		$(NATIVE_OUT) emit -o build/native/obj/runtime/http.ll llvm runtime/sfn/adapters/http.sfn >/dev/null; \
+	fi
+	@if [ ! -f build/native/obj/runtime/http.o ]; then \
+		echo "[rebuild] staging http.o..."; \
+		$(CLANG) -O2 -Wno-override-module -c build/native/obj/runtime/http.ll -o build/native/obj/runtime/http.o; \
+	fi
 	@# Stage exec.o (Sailfin-native executable-path + runtime-root
 	@# resolution from runtime/sfn/platform/exec.sfn). Issue #468
 	@# (epic #451 M5.3 prerequisite) ships `@exe_path` /
@@ -964,6 +987,7 @@ ci-cross-windows:
 	EXEC_LL="build/native/obj/runtime/exec.ll"; \
 	EXCEPTION_LL="build/native/obj/runtime/exception.ll"; \
 	FILESYSTEM_LL="build/native/obj/runtime/filesystem.ll"; \
+	HTTP_LL="build/native/obj/runtime/http.ll"; \
 	if [ ! -d "$$SAVED_DIR" ] || [ ! -f "$$SAVED_DIR/program.ll" ]; then \
 		echo "[cross-windows][error] missing $$SAVED_DIR/*.ll + program.ll — run 'make rebuild' first" >&2; \
 		exit 1; \
@@ -990,6 +1014,10 @@ ci-cross-windows:
 	fi; \
 	if [ ! -f "$$FILESYSTEM_LL" ]; then \
 		echo "[cross-windows][error] missing $$FILESYSTEM_LL — 'make rebuild' should have emitted it (M3.1a, #814)" >&2; \
+		exit 1; \
+	fi; \
+	if [ ! -f "$$HTTP_LL" ]; then \
+		echo "[cross-windows][error] missing $$HTTP_LL — 'make rebuild' should have emitted it (M3, #818)" >&2; \
 		exit 1; \
 	fi; \
 	echo "[cross-windows] using saved sfn build IR layout ($$SAVED_DIR)"; \
@@ -1061,6 +1089,10 @@ ci-cross-windows:
 	$(CLANG) -target x86_64-w64-mingw32 $(NATIVE_OPT) -fno-delete-null-pointer-checks \
 		-c "$$FILESYSTEM_LL" -o "$$WIN_OBJ/runtime/filesystem.o"; \
 	\
+		echo "[cross-windows] compiling http (Sailfin-native socket HTTP client, M3 #818)..."; \
+		$(CLANG) -target x86_64-w64-mingw32 $(NATIVE_OPT) -fno-delete-null-pointer-checks \
+			-c "$$HTTP_LL" -o "$$WIN_OBJ/runtime/http.o"; \
+		\
 	echo "[cross-windows] compiling C runtime..."; \
 	$(MINGW_CC) -O2 -I runtime/native/include -c runtime/native/src/sailfin_arena.c \
 		-o "$$WIN_OBJ/sailfin_arena.o"; \
@@ -1096,6 +1128,7 @@ ci-cross-windows:
 		"$$WIN_OBJ/runtime/exec.o" \
 		"$$WIN_OBJ/runtime/exception.o" \
 		"$$WIN_OBJ/runtime/filesystem.o" \
+		"$$WIN_OBJ/runtime/http.o" \
 		$$SHIM_O \
 		-lm -lpthread; \
 	\
@@ -1134,6 +1167,10 @@ ci-cross-windows:
 	if [ -f "$$WIN_OBJ/runtime/filesystem.o" ]; then \
 		mkdir -p "$$INSTALLER_DIR/runtime/native/obj"; \
 		cp -f "$$WIN_OBJ/runtime/filesystem.o" "$$INSTALLER_DIR/runtime/native/obj/filesystem.o"; \
+	fi; \
+	if [ -f "$$WIN_OBJ/runtime/http.o" ]; then \
+		mkdir -p "$$INSTALLER_DIR/runtime/native/obj"; \
+		cp -f "$$WIN_OBJ/runtime/http.o" "$$INSTALLER_DIR/runtime/native/obj/http.o"; \
 	fi; \
 	tar -czf "dist/installer-$(MINGW_TARGET).tar.gz" -C "$$INSTALLER_DIR" .; \
 	echo "[cross-windows] done: dist/installer-$(MINGW_TARGET).tar.gz"

--- a/compiler/src/cli_main.sfn
+++ b/compiler/src/cli_main.sfn
@@ -883,6 +883,41 @@ fn _runtime_filesystem_path(root: string) -> string ![io] {
     return "";
 }
 
+// M3 (issue #818, epic #390) mirrors the M3.1a filesystem migration
+// above: the descriptor flips in
+// `compiler/src/llvm/runtime_helpers.sfn` route `http.get_body` /
+// `http.post_json` / `http.download` (and the `http_get` /
+// `http_post` aliases) to `sfn_http_get` / `sfn_http_post` /
+// `sfn_http_post2` / `sfn_http_download`, defined in
+// `runtime/sfn/adapters/http.sfn` (the pure-Sailfin socket client
+// that replaces the curl subprocess path, HTTP only — no TLS for
+// v0). The `sfn run` / `sfn build` link path (this function's
+// caller, `_clang_compile_runtime_objects`) needs the staged `.o`
+// to resolve those symbols whenever a user program reaches an
+// `http.*` call site. The runtime-capsule path reaches http.sfn
+// through `runtime/native/capsule.toml`'s `sfn-sources` array
+// instead. Search order mirrors `_runtime_filesystem_path` so
+// bundled installs and in-tree dev builds both find the staged
+// object. Empty return becomes fail-loud at link time as "undefined
+// reference to `sfn_http_get`" the moment any user program touches
+// `http.get_body` — same fail-loud contract as the filesystem path.
+fn _runtime_http_path(root: string) -> string ![io] {
+    let bundled = _path_join(root, "native/obj/http.o");
+    if fs.exists(bundled) { return bundled; }
+    let bundled_nested = _path_join(root, "native/obj/runtime/http.o");
+    if fs.exists(bundled_nested) { return bundled_nested; }
+    let parent = _dirname(root);
+    let fallback = _path_join(parent, "build/native/obj/http.o");
+    if fs.exists(fallback) { return fallback; }
+    let fallback_nested = _path_join(parent, "build/native/obj/runtime/http.o");
+    if fs.exists(fallback_nested) { return fallback_nested; }
+    let selfhost_fallback = _path_join(parent, "build/selfhost/native/obj/http.o");
+    if fs.exists(selfhost_fallback) { return selfhost_fallback; }
+    let selfhost_fallback_nested = _path_join(parent, "build/selfhost/native/obj/runtime/http.o");
+    if fs.exists(selfhost_fallback_nested) { return selfhost_fallback_nested; }
+    return "";
+}
+
 // Last `/`-separated segment of a path. Returns the input itself
 // when there's no slash. Used for naming runtime obj outputs after
 // their source basename, matching the legacy `_clang_compile_runtime_objects`
@@ -1224,18 +1259,22 @@ fn _clang_compile_runtime_objects(runtime_root: string, out_dir: string, opt_fla
     // for `@sfn_type_register` / `@sfn_resolve_type` / `@sfn_instance_of`
     // and the five primitive type guards; `filesystem_obj` is the M3.1a
     // (#814) addition for `@sfn_fs_read_file` / `@sfn_fs_write_file` /
-    // `@sfn_fs_append_file`. Empty `clock_obj` / `process_obj` /
+    // `@sfn_fs_append_file`; `http_obj` is the M3 (#818) addition for
+    // `@sfn_http_get` / `@sfn_http_post` / `@sfn_http_post2` /
+    // `@sfn_http_download` (the pure-Sailfin socket HTTP client).
+    // Empty `clock_obj` / `process_obj` /
     // `exception_obj` / `exec_obj` / `type_meta_obj` / `filesystem_obj`
+    // / `http_obj`
     // entries are tolerated when the corresponding `runtime/sfn/*.sfn`
     // module has not yet been staged into the runtime bundle —
     // callers skip empty entries when assembling the link line. Any
     // of the first four going empty signals a failed runtime compile
     // and propagates back to the caller as a hard fail.
     if runtime_root.length == 0 {
-        return ["", "", "", "", "", "", "", "", "", ""];
+        return ["", "", "", "", "", "", "", "", "", "", ""];
     }
     if !_runtime_bundle_exists(runtime_root) {
-        return ["", "", "", "", "", "", "", "", "", ""];
+        return ["", "", "", "", "", "", "", "", "", "", ""];
     }
 
     let include_dir = _path_join(runtime_root, "native/include");
@@ -1249,6 +1288,7 @@ fn _clang_compile_runtime_objects(runtime_root: string, out_dir: string, opt_fla
     let exec_obj = _runtime_exec_path(runtime_root);
     let type_meta_obj = _runtime_type_meta_path(runtime_root);
     let filesystem_obj = _runtime_filesystem_path(runtime_root);
+    let http_obj = _runtime_http_path(runtime_root);
 
     let runtime_obj = _path_join(out_dir, "sailfin_runtime" + opt_flag + ".o");
     let arena_obj = _path_join(out_dir, "sailfin_arena" + opt_flag + ".o");
@@ -1258,7 +1298,7 @@ fn _clang_compile_runtime_objects(runtime_root: string, out_dir: string, opt_fla
         let rc = process.run(["clang", opt_flag, "-Wno-override-module", "-I"
             + include_dir, "-c", runtime_src, "-o", runtime_obj,]);
         if rc != 0 {
-            return ["", "", "", "", "", "", "", "", "", ""];
+            return ["", "", "", "", "", "", "", "", "", "", ""];
         }
     }
 
@@ -1266,18 +1306,18 @@ fn _clang_compile_runtime_objects(runtime_root: string, out_dir: string, opt_fla
         let rc_arena = process.run(["clang", opt_flag, "-Wno-override-module", "-I"
             + include_dir, "-c", arena_src, "-o", arena_obj,]);
         if rc_arena != 0 {
-            return ["", "", "", "", "", "", "", "", "", ""];
+            return ["", "", "", "", "", "", "", "", "", "", ""];
         }
     }
 
     if !fs.exists(globals_obj) {
         let rc2 = process.run(["clang", opt_flag, "-Wno-override-module", "-c", runtime_ir, "-o", globals_obj,]);
         if rc2 != 0 {
-            return ["", "", "", "", "", "", "", "", "", ""];
+            return ["", "", "", "", "", "", "", "", "", "", ""];
         }
     }
 
-    return [runtime_obj, arena_obj, globals_obj, prelude_obj, clock_obj, process_obj, exception_obj, exec_obj, type_meta_obj, filesystem_obj];
+    return [runtime_obj, arena_obj, globals_obj, prelude_obj, clock_obj, process_obj, exception_obj, exec_obj, type_meta_obj, filesystem_obj, http_obj];
 }
 
 fn _clang_link_with_opt(ll_path: string, out_path: string, runtime_root: string, runtime_capsules: RuntimeCapsuleArtifacts[], opt_flag: string, cache_dir: string, binary_dir: string) -> int ![io] {
@@ -1426,6 +1466,16 @@ fn _clang_link_multi_with_opt(ll_paths: string[], out_path: string, runtime_root
         // reference to `sfn_fs_read_file`" so the missing staged
         // artifact surfaces immediately.
         let filesystem_obj = cached[9];
+        // M3 (#818): `http_obj` carries the Sailfin-native socket HTTP
+        // client (`@sfn_http_get` / `@sfn_http_post` / `@sfn_http_post2`
+        // / `@sfn_http_download`). Same empty-string fallback contract
+        // as `filesystem_obj` — user programs without an `http.*` call
+        // site don't reach the symbols and the link succeeds either way;
+        // user programs that touch `http.get_body` / `http.post_json` /
+        // `http.download` fail loudly at link time with "undefined
+        // reference to `sfn_http_get`" so the missing staged artifact
+        // surfaces immediately.
+        let http_obj = cached[10];
         let mut _missing: boolean = false;
         if runtime_obj.length == 0 { _missing = true; }
         if arena_obj.length == 0 { _missing = true; }
@@ -1445,6 +1495,7 @@ fn _clang_link_multi_with_opt(ll_paths: string[], out_path: string, runtime_root
         if exec_obj.length > 0 { runtime_objs.push(exec_obj); }
         if type_meta_obj.length > 0 { runtime_objs.push(type_meta_obj); }
         if filesystem_obj.length > 0 { runtime_objs.push(filesystem_obj); }
+        if http_obj.length > 0 { runtime_objs.push(http_obj); }
         runtime_link_libs.push("-lm");
     }
 

--- a/compiler/src/cli_main.sfn
+++ b/compiler/src/cli_main.sfn
@@ -1247,7 +1247,7 @@ fn _clang_compile_runtime_objects(runtime_root: string, out_dir: string, opt_fla
     // Build (or reuse) cached runtime object files so repeated `test` invocations
     // don't recompile the runtime C sources per test file.
     //
-    // Return shape: `[runtime_obj, arena_obj, globals_obj, prelude_obj, clock_obj, process_obj, exception_obj, exec_obj, type_meta_obj, filesystem_obj]`.
+    // Return shape: `[runtime_obj, arena_obj, globals_obj, prelude_obj, clock_obj, process_obj, exception_obj, exec_obj, type_meta_obj, filesystem_obj, http_obj]`.
     // The trailing `clock_obj` slot is the PR 2 (#397) addition for the
     // Sailfin-native `@sfn_sleep` definition; `process_obj` is the M2.9
     // (#405) addition for `@sfn_process_run`; `exception_obj` is the

--- a/compiler/src/llvm/runtime_helpers.sfn
+++ b/compiler/src/llvm/runtime_helpers.sfn
@@ -655,12 +655,17 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
         target: "fs.symlink", symbol: "sailfin_adapter_fs_symlink", return_type: "i1", parameter_types: ["i8*", "i8*"], effects: ["io"], native_signature: null, c_abi_return_type: null
     });
 
-    // HTTP adapters (distinct from intrinsics for adapter infrastructure)
+    // HTTP adapters (distinct from intrinsics for adapter infrastructure).
+    // M3 (#818): flipped to the Sailfin-native socket client in
+    // `runtime/sfn/adapters/http.sfn`. The legacy C `symbol`s
+    // (`sailfin_adapter_http_*`, no-op stubs) stay for seed compat; the
+    // `native_signature` override routes calls to `sfn_http_get` /
+    // `sfn_http_post2` (the 2-arg POST wrapper matching this row's arity).
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "http_get", symbol: "sailfin_adapter_http_get", return_type: "i8*", parameter_types: ["i8*"], effects: ["net"], native_signature: null, c_abi_return_type: null
+        target: "http_get", symbol: "sailfin_adapter_http_get", return_type: "i8*", parameter_types: ["i8*"], effects: ["net"], native_signature: "sfn_http_get", c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "http_post", symbol: "sailfin_adapter_http_post", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: ["net"], native_signature: null, c_abi_return_type: null
+        target: "http_post", symbol: "sailfin_adapter_http_post", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: ["net"], native_signature: "sfn_http_post2", c_abi_return_type: null
     });
 
     // Serve adapters
@@ -1016,15 +1021,21 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
         target: "base64.encode", symbol: "base64_encode__capsules__sfn__crypto__src__mod", return_type: "i8*", parameter_types: ["i8*"], effects: [], native_signature: null, c_abi_return_type: null
     });
 
-    // HTTP helpers (curl subprocess)
+    // HTTP helpers. M3 (#818): flipped from the curl-subprocess C path
+    // to the Sailfin-native socket client in
+    // `runtime/sfn/adapters/http.sfn` (HTTP/1.1, no TLS for v0). The
+    // legacy curl `symbol`s stay exported for seed compat; the
+    // `native_signature` override routes `http.get_body` /
+    // `http.post_json` / `http.download` to `sfn_http_get` /
+    // `sfn_http_post` (url, body, auth_header) / `sfn_http_download`.
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "http.get_body", symbol: "sailfin_runtime_http_get", return_type: "i8*", parameter_types: ["i8*"], effects: ["net"], native_signature: null, c_abi_return_type: null
+        target: "http.get_body", symbol: "sailfin_runtime_http_get", return_type: "i8*", parameter_types: ["i8*"], effects: ["net"], native_signature: "sfn_http_get", c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "http.post_json", symbol: "sailfin_runtime_http_post_json", return_type: "i8*", parameter_types: ["i8*", "i8*", "i8*"], effects: ["net"], native_signature: null, c_abi_return_type: null
+        target: "http.post_json", symbol: "sailfin_runtime_http_post_json", return_type: "i8*", parameter_types: ["i8*", "i8*", "i8*"], effects: ["net"], native_signature: "sfn_http_post", c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "http.download", symbol: "sailfin_runtime_http_download", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: ["net", "io"], native_signature: null, c_abi_return_type: null
+        target: "http.download", symbol: "sailfin_runtime_http_download", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: ["net", "io"], native_signature: "sfn_http_download", c_abi_return_type: null
     });
 
     // Environment & path helpers

--- a/compiler/tests/e2e/test_runtime_adapter_http.sh
+++ b/compiler/tests/e2e/test_runtime_adapter_http.sh
@@ -1,0 +1,241 @@
+#!/usr/bin/env bash
+# End-to-end test for runtime/sfn/adapters/http.sfn — the
+# Sailfin-native HTTP/1.1 socket client adapter (M3 #818, epic
+# #390). Replaces the curl-subprocess HTTP path with a pure-Sailfin
+# socket client (HTTP only, no TLS for v0).
+#
+# Mirrors test_runtime_adapter_filesystem.sh's structure: typecheck
+# + fmt + emit-shape on the source module, an IR routing probe that
+# the flipped `http.get_body` registry row lowers to `@sfn_http_get`
+# (not the legacy curl `@sailfin_runtime_http_get`), and a
+# behavioral round-trip — a real GET against a localhost listener
+# through the `sfn run` link path.
+#
+# Usage:
+#   compiler/tests/e2e/test_runtime_adapter_http.sh <compiler-binary>
+
+set -euo pipefail
+
+BINARY="${1:?usage: test_runtime_adapter_http.sh <compiler-binary>}"
+BINARY="$(realpath "$BINARY")"
+PASS=0
+FAIL=0
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+MODULE="$REPO_ROOT/runtime/sfn/adapters/http.sfn"
+
+SCRATCH="$(mktemp -d -t sfn-runtime-http-XXXXXX)"
+LISTENER_PID=""
+cleanup() {
+    if [ -n "$LISTENER_PID" ]; then
+        kill "$LISTENER_PID" 2>/dev/null || true
+        wait "$LISTENER_PID" 2>/dev/null || true
+    fi
+    rm -rf "$SCRATCH"
+}
+trap cleanup EXIT
+
+run_test() {
+    local name="$1"
+    shift
+    if "$@"; then
+        echo "[test] PASS: $name"
+        PASS=$((PASS + 1))
+    else
+        echo "[test] FAIL: $name"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# ---- Test: source module typechecks cleanly ----
+test_check_clean() {
+    local log="$SCRATCH/check.log"
+    if ! "$BINARY" check "$MODULE" > "$log" 2>&1; then
+        echo "[test]   sfn check exited non-zero on http.sfn:"
+        cat "$log"
+        return 1
+    fi
+    if ! grep -q "checked .* ok" "$log"; then
+        echo "[test]   sfn check did not report 'ok':"
+        cat "$log"
+        return 1
+    fi
+    return 0
+}
+
+# ---- Test: source module is fmt-canonical ----
+test_fmt_clean() {
+    if ! "$BINARY" fmt --check "$MODULE" > /dev/null 2>&1; then
+        echo "[test]   $MODULE needs formatting (run: sfn fmt --write $MODULE)"
+        return 1
+    fi
+    return 0
+}
+
+# ---- Test: emitted IR carries a `define` for every sfn_http_* export ----
+test_emit_define_shape() {
+    local ll="$SCRATCH/http.ll"
+    local log="$SCRATCH/emit.log"
+    if ! "$BINARY" emit -o "$ll" llvm "$MODULE" > "$log" 2>&1; then
+        echo "[test]   sfn emit llvm failed on runtime/sfn/adapters/http.sfn:"
+        cat "$log"
+        return 1
+    fi
+    local missing=0
+    for sym in sfn_http_get sfn_http_post sfn_http_post2 sfn_http_download; do
+        if ! grep -qE "^define .* @${sym}\(" "$ll"; then
+            echo "[test]   missing 'define ... @${sym}(' in http.ll"
+            missing=$((missing + 1))
+        fi
+    done
+    # The BSD-sockets surface must lower to libc declares.
+    for sym in socket connect send recv close; do
+        if ! grep -qE "^declare .* @${sym}\(" "$ll"; then
+            echo "[test]   missing 'declare ... @${sym}(' in http.ll"
+            missing=$((missing + 1))
+        fi
+    done
+    return "$missing"
+}
+
+# ---- Test: compiled probe routes http.get_body through @sfn_http_get ----
+test_probe_flipped() {
+    local probe="$SCRATCH/http_probe.sfn"
+    cat > "$probe" <<'PROBE'
+fn fetch(url: string) -> string ![net] {
+    return http.get_body(url);
+}
+
+fn main() -> int ![net, io] {
+    let body = fetch("http://127.0.0.1:9/");
+    print(body);
+    return 0;
+}
+PROBE
+    local ll="$SCRATCH/http_probe.ll"
+    local log="$SCRATCH/http_probe.log"
+    if ! "$BINARY" emit -o "$ll" llvm "$probe" > "$log" 2>&1; then
+        echo "[test]   sfn emit llvm failed on http_probe.sfn:"
+        cat "$log"
+        return 1
+    fi
+    local missing=0
+    # Anchor on a non-identifier follow char (portable across GNU/BSD
+    # grep — see the filesystem adapter test for the `\b` caveat).
+    if ! grep -qE "@sfn_http_get([^A-Za-z0-9_]|$)" "$ll"; then
+        echo "[test]   http_probe.sfn does not reference @sfn_http_get"
+        missing=$((missing + 1))
+    fi
+    # Legacy curl entrypoint must not be CALLED (declares tolerated for
+    # seed compat; only call sites are forbidden).
+    if grep -qE "call [^\"]*@sailfin_runtime_http_get\(" "$ll"; then
+        echo "[test]   http_probe.sfn still calls @sailfin_runtime_http_get (expected the sfn_http_* flip)"
+        missing=$((missing + 1))
+    fi
+    return "$missing"
+}
+
+# ---- Behavioral: GET + POST round-trip against a localhost listener ----
+#
+# Starts a Python TCP listener that loops one-response-per-connection,
+# speaking just enough HTTP/1.1 to answer the adapter (echoing POST
+# bodies back), then compiles + runs a probe that GETs and POSTs
+# through the flipped registry rows. Exercises the full socket stack —
+# connect / send / recv / status-check / body-extraction — for both
+# `sfn_http_get` and `sfn_http_post`.
+test_get_round_trip() {
+    local port=18097
+    local server="$SCRATCH/server.py"
+    cat > "$server" <<PYEOF
+import socket, sys
+srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+srv.bind(("127.0.0.1", ${port}))
+srv.listen(4)
+srv.settimeout(20)
+print("ready", flush=True)
+try:
+    while True:
+        conn, _ = srv.accept()
+        data = b""
+        while b"\r\n\r\n" not in data:
+            chunk = conn.recv(4096)
+            if not chunk:
+                break
+            data += chunk
+        head, _, rest = data.partition(b"\r\n\r\n")
+        clen = 0
+        for line in head.split(b"\r\n"):
+            if line.lower().startswith(b"content-length:"):
+                clen = int(line.split(b":", 1)[1].strip())
+        while len(rest) < clen:
+            more = conn.recv(4096)
+            if not more:
+                break
+            rest += more
+        if head.startswith(b"POST"):
+            body = b"POST_BODY:" + rest
+        else:
+            body = b"GET_OK"
+        resp = b"HTTP/1.1 200 OK\r\nContent-Length: %d\r\nConnection: close\r\n\r\n%s" % (len(body), body)
+        conn.sendall(resp)
+        conn.close()
+except Exception:
+    pass
+PYEOF
+    local ready="$SCRATCH/ready.log"
+    python3 "$server" > "$ready" 2>&1 &
+    LISTENER_PID=$!
+
+    # Wait for the listener to report ready (max ~5s).
+    local waited=0
+    while ! grep -q "ready" "$ready" 2>/dev/null; do
+        sleep 0.2
+        waited=$((waited + 1))
+        if [ "$waited" -gt 25 ]; then
+            echo "[test]   listener never reported ready:"
+            cat "$ready"
+            return 1
+        fi
+    done
+
+    local probe="$SCRATCH/get_probe.sfn"
+    cat > "$probe" <<PROBE
+fn main() -> int ![net, io] {
+    let body = http.get_body("http://127.0.0.1:${port}/hello");
+    print(body);
+    let posted = http.post_json("http://127.0.0.1:${port}/echo", "{\"k\":\"v\"}", "");
+    print(posted);
+    return 0;
+}
+PROBE
+    local out="$SCRATCH/get_probe.out"
+    if ! "$BINARY" run "$probe" > "$out" 2>&1; then
+        echo "[test]   sfn run get_probe.sfn failed:"
+        cat "$out"
+        return 1
+    fi
+    if ! grep -q "GET_OK" "$out"; then
+        echo "[test]   expected 'GET_OK' in the GET response body, got:"
+        cat "$out"
+        return 1
+    fi
+    # The listener echoes the POST body back as POST_BODY:<body>.
+    if ! grep -q 'POST_BODY:{"k":"v"}' "$out"; then
+        echo "[test]   expected 'POST_BODY:{\"k\":\"v\"}' in the POST response body, got:"
+        cat "$out"
+        return 1
+    fi
+    return 0
+}
+
+run_test "sfn check runtime/sfn/adapters/http.sfn passes" test_check_clean
+run_test "sfn fmt --check runtime/sfn/adapters/http.sfn is canonical" test_fmt_clean
+run_test "sfn emit llvm defines every sfn_http_* export + socket declares" test_emit_define_shape
+run_test "http.get_body lowers to @sfn_http_get (not the curl path)" test_probe_flipped
+run_test "GET + POST round-trip against a localhost listener returns the body" test_get_round_trip
+
+echo "[summary] $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi

--- a/compiler/tests/e2e/test_runtime_adapter_http.sh
+++ b/compiler/tests/e2e/test_runtime_adapter_http.sh
@@ -144,15 +144,17 @@ PROBE
 # connect / send / recv / status-check / body-extraction — for both
 # `sfn_http_get` and `sfn_http_post`.
 test_get_round_trip() {
-    local port=18097
     local server="$SCRATCH/server.py"
-    cat > "$server" <<PYEOF
+    cat > "$server" <<'PYEOF'
 import socket, sys
 srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-srv.bind(("127.0.0.1", ${port}))
+# Bind to an ephemeral port (0) and report it — avoids flaky
+# collisions with whatever else is live on a shared CI runner.
+srv.bind(("127.0.0.1", 0))
 srv.listen(4)
 srv.settimeout(20)
+print("PORT=%d" % srv.getsockname()[1], flush=True)
 print("ready", flush=True)
 try:
     while True:
@@ -198,6 +200,14 @@ PYEOF
             return 1
         fi
     done
+
+    local port
+    port="$(grep -oE 'PORT=[0-9]+' "$ready" | head -1 | cut -d= -f2)"
+    if [ -z "$port" ]; then
+        echo "[test]   listener did not report a port:"
+        cat "$ready"
+        return 1
+    fi
 
     local probe="$SCRATCH/get_probe.sfn"
     cat > "$probe" <<PROBE

--- a/runtime/native/capsule.toml
+++ b/runtime/native/capsule.toml
@@ -55,7 +55,7 @@ ll-sources = ["ir/runtime_globals.ll"]
 # and the formerly-load-bearing allowlist is gone.
 #
 # Single-line array per the parser limitation noted above.
-sfn-sources = ["../sfn/memory/arena.sfn", "../sfn/memory/rc.sfn", "../sfn/string.sfn", "../sfn/array.sfn", "../sfn/clock.sfn", "../sfn/process.sfn", "../sfn/io.sfn", "../sfn/exception.sfn", "../sfn/type_meta.sfn", "../sfn/platform/exec.sfn", "../sfn/adapters/filesystem.sfn"]
+sfn-sources = ["../sfn/memory/arena.sfn", "../sfn/memory/rc.sfn", "../sfn/string.sfn", "../sfn/array.sfn", "../sfn/clock.sfn", "../sfn/process.sfn", "../sfn/io.sfn", "../sfn/exception.sfn", "../sfn/type_meta.sfn", "../sfn/platform/exec.sfn", "../sfn/adapters/filesystem.sfn", "../sfn/adapters/http.sfn"]
 include-dirs = ["include"]
 link-libs = ["-lm"]
 

--- a/runtime/sfn/adapters/http.sfn
+++ b/runtime/sfn/adapters/http.sfn
@@ -1,0 +1,522 @@
+// runtime/sfn/adapters/http.sfn
+//
+// First-wave Sailfin-native HTTP/1.1 client adapter (M3, #818 —
+// epic #390 / tracker #321). Replaces the curl-subprocess HTTP
+// path (`sailfin_runtime_http_get` / `_post_json` / `_download`
+// in `runtime/native/src/sailfin_runtime.c`, which shell out to
+// `curl -sfS`) with a pure-Sailfin socket client built on the
+// BSD-sockets surface declared in `runtime/sfn/platform/net.sfn`.
+// Mirrors the migration shape of `runtime/sfn/adapters/filesystem.sfn`
+// (M3.1, #814/#815) and `runtime/sfn/process.sfn` (M2.9).
+//
+// Scope: HTTP only — NO TLS for v0 (Option A per the epic). An
+// `https://` URL is rejected (returns null); capsules needing
+// HTTPS stay on the legacy curl path until a 1.1 TLS story lands.
+//
+// ABI. `compiler/src/llvm/runtime_helpers.sfn` flips the curl
+// registry rows by setting `native_signature` to the symbols
+// defined here, exactly as the `fs.*` rows were flipped to
+// `sfn_fs_*` (the legacy C `symbol` stays for seed compat):
+//   - `http.get_body`  (url)               -> `sfn_http_get`
+//   - `http.post_json` (url, body, auth)   -> `sfn_http_post`
+//   - `http.download`  (url, output_path)  -> `sfn_http_download`
+//   - `http_get`       (url)               -> `sfn_http_get`
+//   - `http_post`      (request, body)      -> `sfn_http_post2`
+// All descriptors keep their existing `i8*`-in / `i8*`-out shape
+// (raw NUL-terminated `* u8` buffers, no arena threading) — the
+// same plain-pointer ABI the `sfn_fs_*` adapters use. The issue's
+// `*Arena` / `SfnString` shorthand would require retyping the
+// descriptors to the aggregate ABI and threading an arena through
+// `core_call_lowering.sfn` (not in this issue's Files Affected);
+// matching the proven `fs.*` raw-pointer shape keeps the flip
+// self-contained.
+//
+// The two POST arities exist because the registry carries two
+// rows of different arity: `http.post_json` is (url, body,
+// auth_header) and the `http_post` alias is (request, body). The
+// alias points at `sfn_http_post2`, a 2-arg wrapper that forwards
+// to `sfn_http_post` with an empty auth header.
+//
+// Return semantics (matching the curl bodies they replace):
+//   - get / post: the response BODY (headers stripped), null on a
+//     socket/connect failure or an HTTP status >= 400 (mirrors
+//     curl `-f`).
+//   - download: the literal `"ok"` on success, null on failure
+//     (mirrors `sailfin_runtime_http_download`'s contract). Writes
+//     the body to `output_path` in binary mode.
+//
+// Host resolution (v0): numeric dotted-quad IPv4 (`atoi` per octet)
+// plus a `localhost` -> 127.0.0.1 special case. Real DNS
+// (`getaddrinfo`) is a follow-up wave — the v0 smoke test targets a
+// localhost listener, so name resolution is deliberately minimal.
+//
+// Effects: `![net]` for get/post, `![net, io]` for download (it
+// opens a file). The flipped descriptors carry the same effects, so
+// calling `http.get_body` / `http.post_json` without `![net]` (or
+// `http.download` without `![net, io]`) on the call chain remains a
+// compile-time error after the flip.
+//
+// Why inline the externs rather than `import` from
+// `../platform/net.sfn` / `../platform/libc.sfn`? Same rationale as
+// every other `runtime/sfn/*.sfn` module (see `filesystem.sfn`
+// header, ~line 108): the seed compiler reaches the cross-module
+// extern resolver through a path #306 has not closed, so inlining
+// the declarations keeps this module self-contained for every seed.
+// A follow-up PR flips these to imports once #306 lands, without
+// touching the bodies. Declaring the same C symbol in two modules
+// is safe — each emits its own LLVM `declare` and the linker
+// resolves both to the single libc / libc-socket entrypoint (see
+// the `net.sfn` symbol-collision note).
+//
+// Decimal byte constants (no char/octal literals in the seed):
+//   46 = '.'   47 = '/'   58 = ':'   32 = ' '   48 = '0'
+//   111 = 'o'  107 = 'k'
+// AF_INET = 2, SOCK_STREAM = 1 (identical on Linux x86_64 and
+// macOS arm64, the two targets this runtime builds for).
+//
+// Pinned by `compiler/tests/e2e/test_runtime_adapter_http.sh`
+// (typecheck + fmt + emit-define shape over the exports + an IR
+// routing probe + a behavioral round-trip against a localhost
+// listener).
+// ── libc memory + string helpers ──────────────────────────────
+extern fn malloc(size: usize) -> * u8;
+
+extern fn free(ptr: * u8) -> void;
+
+extern fn realloc(ptr: * u8, new_size: usize) -> * u8;
+
+extern fn memset(dst: * u8, byte: i32, n: usize) -> * u8;
+
+extern fn memcpy(dst: * u8, src: * u8, n: usize) -> * u8;
+
+extern fn strlen(s: * u8) -> usize;
+
+extern fn strchr(s: * u8, c: i32) -> * u8;
+
+extern fn strstr(haystack: * u8, needle: * u8) -> * u8;
+
+extern fn strcmp(a: * u8, b: * u8) -> i32;
+
+// C `int atoi(const char *)` — parses a leading decimal integer,
+// stops at the first non-digit. Declared `-> i32` to match the C
+// 32-bit return (a 64-bit declaration would read undefined upper
+// bits); octet / port values fit comfortably.
+extern fn atoi(s: * u8) -> i32;
+
+// ── BSD sockets (libc) ────────────────────────────────────────
+// `addr` is spelled `* u8` (the `net.sfn` opaque-handle policy:
+// adapters cast the family-specific sockaddr struct through `* u8`
+// at the call site). Identical C ABI to `const struct sockaddr *`.
+extern fn socket(domain: i32, ty: i32, protocol: i32) -> i32;
+
+extern fn connect(sockfd: i32, addr: * u8, addrlen: i32) -> i32;
+
+extern fn send(sockfd: i32, buf: * u8, len: i64, flags: i32) -> i64;
+
+extern fn recv(sockfd: i32, buf: * u8, len: i64, flags: i32) -> i64;
+
+extern fn close(fd: i32) -> i32;
+
+// ── libc stdio (download write path) ──────────────────────────
+extern fn fopen(path: * u8, mode: * u8) -> * File;
+
+extern fn fwrite(buf: * u8, size: usize, nmemb: usize, f: * File) -> usize;
+
+extern fn fclose(f: * File) -> i32;
+
+// `_ptr_off(p, off)` — byte-stride pointer arithmetic for a
+// variable offset. Mirrors `filesystem.sfn`'s `(buf as i64) + len`
+// idiom; centralized here because the HTTP paths offset by runtime
+// values throughout (recv cursor, response scan, sockaddr fields).
+fn _ptr_off(p: * u8, off: i64) -> * u8 {
+    let addr: i64 = (p as i64) + off;
+    return addr as * u8;
+}
+
+// `_strdup_n(src, n)` — copy `n` bytes from `src` into a fresh
+// libc-`malloc`'d NUL-terminated buffer the caller owns. Returns
+// null on OOM. `n == 0` yields a valid empty string.
+fn _strdup_n(src: * u8, n: i64) -> * u8 {
+    let buf: * u8 = malloc((n + 1) as usize);
+    if buf as i64 == 0 { return null; }
+    if n > 0 { memcpy(buf, src, n as usize); }
+    memset(_ptr_off(buf, n), 0, 1 as usize);
+    return buf;
+}
+
+// `_uint_to_str(value)` — render a non-negative i64 as a freshly
+// allocated decimal string (used for the POST `Content-Length`
+// header). Returns null on OOM.
+fn _uint_to_str(value: i64) -> * u8 {
+    if value <= 0 {
+        let zero: * u8 = malloc(2 as usize);
+        if zero as i64 == 0 { return null; }
+        memset(_ptr_off(zero, 0), 48, 1 as usize);
+        memset(_ptr_off(zero, 1), 0, 1 as usize);
+        return zero;
+    }
+    let mut count: i64 = 0;
+    let mut probe: i64 = value;
+    loop {
+        if probe == 0 { break; }
+        probe = probe / 10;
+        count = count + 1;
+    }
+    let buf: * u8 = malloc((count + 1) as usize);
+    if buf as i64 == 0 { return null; }
+    memset(_ptr_off(buf, count), 0, 1 as usize);
+    let mut remaining: i64 = value;
+    let mut idx: i64 = count - 1;
+    loop {
+        if remaining == 0 { break; }
+        let digit: i64 = remaining % 10;
+        memset(_ptr_off(buf, idx), (48 + digit) as i32, 1 as usize);
+        remaining = remaining / 10;
+        idx = idx - 1;
+    }
+    return buf;
+}
+
+// `_host_ip4(host, out)` — resolve `host` to four IPv4 octets,
+// written to `out[0..4]`. Handles the `localhost` alias and numeric
+// dotted-quad addresses; returns false on anything else (no DNS in
+// v0). `out` must point at >= 4 writable bytes.
+fn _host_ip4(host: * u8, out: * u8) -> bool {
+    let localhost: string = "localhost";
+    if strcmp(host, localhost as * u8) == 0 {
+        memset(_ptr_off(out, 0), 127, 1 as usize);
+        memset(_ptr_off(out, 1), 0, 1 as usize);
+        memset(_ptr_off(out, 2), 0, 1 as usize);
+        memset(_ptr_off(out, 3), 1, 1 as usize);
+        return true;
+    }
+    let mut cursor: * u8 = host;
+    let mut i: i64 = 0;
+    loop {
+        if i >= 4 { break; }
+        let octet: i64 = atoi(cursor) as i64;
+        memset(_ptr_off(out, i), octet as i32, 1 as usize);
+        if i < 3 {
+            let dot: * u8 = strchr(cursor, 46);
+            if dot as i64 == 0 { return false; }
+            cursor = _ptr_off(dot, 1);
+        }
+        i = i + 1;
+    }
+    return true;
+}
+
+// `_connect_tcp(host, port)` — build an IPv4 `sockaddr_in`, open a
+// stream socket, and connect. Returns the connected fd, or -1 on
+// any failure. The 16-byte sockaddr is built byte-wise: family
+// AF_INET (low byte 2, the rest zero), `sin_port` in network byte
+// order (big-endian), then the four address octets, then the
+// 8-byte zero pad left from the initial `memset`.
+fn _connect_tcp(host: * u8, port: i64) -> i32 ![net] {
+    let addr: * u8 = malloc(16 as usize);
+    if addr as i64 == 0 { return 0 - 1; }
+    memset(addr, 0, 16 as usize);
+    // sin_family = AF_INET (2), little-endian u16 -> byte0 = 2.
+    memset(_ptr_off(addr, 0), 2, 1 as usize);
+    // sin_port (network byte order = big-endian).
+    memset(_ptr_off(addr, 2), ((port >> 8) & 255) as i32, 1 as usize);
+    memset(_ptr_off(addr, 3), (port & 255) as i32, 1 as usize);
+    // sin_addr octets at offset 4..8.
+    if _host_ip4(host, _ptr_off(addr, 4)) {
+        let fd: i32 = socket(2, 1, 0);
+        if fd < 0 {
+            free(addr);
+            return 0 - 1;
+        }
+        let rc: i32 = connect(fd, addr, 16);
+        free(addr);
+        if rc != 0 {
+            close(fd);
+            return 0 - 1;
+        }
+        return fd;
+    }
+    free(addr);
+    return 0 - 1;
+}
+
+// `_send_all(fd, buf, total)` — write `total` bytes, retrying on
+// short sends. Returns false if `send` ever fails.
+fn _send_all(fd: i32, buf: * u8, total: i64) -> bool ![net] {
+    let mut sent: i64 = 0;
+    loop {
+        if sent >= total { break; }
+        let n: i64 = send(fd, _ptr_off(buf, sent), total - sent, 0);
+        if n <= 0 { return false; }
+        sent = sent + n;
+    }
+    return true;
+}
+
+// `_recv_all(fd)` — drain the socket into a growing libc buffer
+// (doubling like `filesystem.sfn`'s slurp), NUL-terminated and
+// caller-owned. Returns null on OOM. Loops until `recv` returns 0
+// (peer closed — guaranteed by the request's `Connection: close`)
+// or an error.
+fn _recv_all(fd: i32) -> * u8 ![net] {
+    let mut capacity: i64 = 8192;
+    let mut len: i64 = 0;
+    let mut buf: * u8 = malloc((capacity + 1) as usize);
+    if buf as i64 == 0 { return null; }
+    let chunk: i64 = 8192;
+    loop {
+        if len + chunk > capacity {
+            let new_cap: i64 = capacity * 2;
+            let new_buf: * u8 = realloc(buf, (new_cap + 1) as usize);
+            if new_buf as i64 == 0 {
+                free(buf);
+                return null;
+            }
+            buf = new_buf;
+            capacity = new_cap;
+        }
+        let n: i64 = recv(fd, _ptr_off(buf, len), chunk, 0);
+        if n <= 0 { break; }
+        len = len + n;
+    }
+    memset(_ptr_off(buf, len), 0, 1 as usize);
+    return buf;
+}
+
+// `_extract_body(resp)` — given a raw HTTP response buffer, check
+// the status line and return a fresh copy of the body (everything
+// after the first `\r\n\r\n`). Returns null when the status code is
+// >= 400 (mirrors curl `-f`) or when no header terminator is found.
+// `resp` is left untouched; the caller frees it.
+fn _extract_body(resp: * u8) -> * u8 {
+    if resp as i64 == 0 { return null; }
+    // Status code: the first space precedes "NNN reason".
+    let space: * u8 = strchr(resp, 32);
+    if space as i64 != 0 {
+        let code: i64 = atoi(_ptr_off(space, 1)) as i64;
+        if code >= 400 { return null; }
+    }
+    let terminator: string = "\r\n\r\n";
+    let header_end: * u8 = strstr(resp, terminator as * u8);
+    if header_end as i64 == 0 { return null; }
+    let body_start: * u8 = _ptr_off(header_end, 4);
+    let body_len: i64 = strlen(body_start) as i64;
+    return _strdup_n(body_start, body_len);
+}
+
+// `_http_send(url, is_post, body, auth_header)` — the shared
+// request/response core. Parses `url` (scheme/host/port/path),
+// connects, writes the request head (plus body for POST), drains
+// the response, and returns the extracted body (or null on any
+// failure). `auth_header`, when non-null and non-empty, is emitted
+// as an `Authorization:` header (POST only).
+fn _http_send(url: * u8, is_post: bool, body: * u8, auth_header: * u8) -> * u8 ![net] {
+    // Reject TLS — no HTTPS in v0.
+    let https: string = "https://";
+    if (strstr(url, https as * u8) as i64) == (url as i64) { return null; }
+
+    // Locate the authority: skip past "scheme://" if present.
+    let sep: string = "://";
+    let mut host_start: * u8 = url;
+    let scheme: * u8 = strstr(url, sep as * u8);
+    if scheme as i64 != 0 { host_start = _ptr_off(scheme, 3); }
+
+    // Path begins at the first '/' after the authority; default "/".
+    let slash: * u8 = strchr(host_start, 47);
+    let mut authority_len: i64 = 0;
+    if slash as i64 != 0 {
+        authority_len = (slash as i64) - (host_start as i64);
+    } else { authority_len = strlen(host_start) as i64; }
+    let authority: * u8 = _strdup_n(host_start, authority_len);
+    if authority as i64 == 0 { return null; }
+
+    // Split host:port (terminate host in place at the colon).
+    let mut port: i64 = 80;
+    let colon: * u8 = strchr(authority, 58);
+    if colon as i64 != 0 {
+        port = atoi(_ptr_off(colon, 1)) as i64;
+        memset(colon, 0, 1 as usize);
+    }
+
+    let root: string = "/";
+    let mut path: * u8 = root as * u8;
+    if slash as i64 != 0 { path = slash; }
+
+    let fd: i32 = _connect_tcp(authority, port);
+    if fd < 0 {
+        free(authority);
+        return null;
+    }
+
+    // ── Build and send the request head ──
+    let host_line: string = " HTTP/1.1\r\nHost: ";
+    let tail: string = "\r\nConnection: close\r\n\r\n";
+    let path_len: i64 = strlen(path) as i64;
+    let host_len: i64 = strlen(authority) as i64;
+
+    if is_post {
+        let verb: string = "POST ";
+        let ctype: string = "\r\nContent-Type: application/json\r\nContent-Length: ";
+        let body_len: i64 = strlen(body) as i64;
+        let clen: * u8 = _uint_to_str(body_len);
+        if clen as i64 == 0 {
+            free(authority);
+            close(fd);
+            return null;
+        }
+        // Optional Authorization header.
+        let auth_label: string = "\r\nAuthorization: ";
+        let mut has_auth: bool = false;
+        let mut auth_len: i64 = 0;
+        if auth_header as i64 != 0 {
+            auth_len = strlen(auth_header) as i64;
+            if auth_len > 0 { has_auth = true; }
+        }
+        let mut total: i64 = (strlen(verb as * u8) as i64) + path_len + (strlen(host_line as * u8) as i64)
+            + host_len
+            + (strlen(ctype as * u8) as i64)
+            + (strlen(clen) as i64)
+            + (strlen(tail as * u8) as i64);
+        if has_auth {
+            total = total + (strlen(auth_label as * u8) as i64) + auth_len;
+        }
+        let head: * u8 = malloc((total + 1) as usize);
+        if head as i64 == 0 {
+            free(clen);
+            free(authority);
+            close(fd);
+            return null;
+        }
+        let mut off: i64 = 0;
+        off = _append(head, off, verb as * u8);
+        off = _append(head, off, path);
+        off = _append(head, off, host_line as * u8);
+        off = _append(head, off, authority);
+        off = _append(head, off, ctype as * u8);
+        off = _append(head, off, clen);
+        if has_auth {
+            off = _append(head, off, auth_label as * u8);
+            off = _append(head, off, auth_header);
+        }
+        off = _append(head, off, tail as * u8);
+        memset(_ptr_off(head, off), 0, 1 as usize);
+        free(clen);
+
+        let head_ok: bool = _send_all(fd, head, off);
+        free(head);
+        if head_ok {
+            if _send_all(fd, body, body_len) {
+                // fall through to recv
+            } else {
+                free(authority);
+                close(fd);
+                return null;
+            }
+        } else {
+            free(authority);
+            close(fd);
+            return null;
+        }
+    } else {
+        let verb: string = "GET ";
+        let total: i64 = (strlen(verb as * u8) as i64) + path_len + (strlen(host_line as * u8) as i64)
+            + host_len
+            + (strlen(tail as * u8) as i64);
+        let head: * u8 = malloc((total + 1) as usize);
+        if head as i64 == 0 {
+            free(authority);
+            close(fd);
+            return null;
+        }
+        let mut off: i64 = 0;
+        off = _append(head, off, verb as * u8);
+        off = _append(head, off, path);
+        off = _append(head, off, host_line as * u8);
+        off = _append(head, off, authority);
+        off = _append(head, off, tail as * u8);
+        memset(_ptr_off(head, off), 0, 1 as usize);
+
+        let head_ok: bool = _send_all(fd, head, off);
+        free(head);
+        if head_ok {
+            // fall through to recv
+        } else {
+            free(authority);
+            close(fd);
+            return null;
+        }
+    }
+
+    free(authority);
+    let resp: * u8 = _recv_all(fd);
+    close(fd);
+    let result: * u8 = _extract_body(resp);
+    if resp as i64 != 0 { free(resp); }
+    return result;
+}
+
+// `_append(dst, off, src)` — copy the NUL-terminated `src` into
+// `dst` at byte offset `off`, returning the new offset. The caller
+// pre-sizes `dst` from the summed piece lengths.
+fn _append(dst: * u8, off: i64, src: * u8) -> i64 {
+    let n: i64 = strlen(src) as i64;
+    memcpy(_ptr_off(dst, off), src, n as usize);
+    return off + n;
+}
+
+// `sfn_http_get(url)` — GET `url`, returning a caller-owned copy of
+// the response body. Null on a null url, connect failure, or HTTP
+// status >= 400.
+fn sfn_http_get(url: * u8) -> * u8 ![net] {
+    if url as i64 == 0 { return null; }
+    return _http_send(url, false, null, null);
+}
+
+// `sfn_http_post(url, body, auth_header)` — POST `body` to `url`
+// with `Content-Type: application/json`. When `auth_header` is
+// non-empty it is sent verbatim as the `Authorization:` value
+// (matching the curl `sailfin_runtime_http_post_json` contract).
+// Returns a caller-owned copy of the response body, null on
+// failure or status >= 400.
+fn sfn_http_post(url: * u8, body: * u8, auth_header: * u8) -> * u8 ![net] {
+    if url as i64 == 0 { return null; }
+    if body as i64 == 0 { return null; }
+    return _http_send(url, true, body, auth_header);
+}
+
+// `sfn_http_post2(url, body)` — 2-arg POST for the `http_post`
+// registry alias; forwards to `sfn_http_post` with no auth header.
+fn sfn_http_post2(url: * u8, body: * u8) -> * u8 ![net] {
+    return sfn_http_post(url, body, null);
+}
+
+// `sfn_http_download(url, output_path)` — GET `url` and write the
+// body to `output_path` in binary mode. Returns the literal `"ok"`
+// on success, null on failure (matching the curl
+// `sailfin_runtime_http_download` contract).
+fn sfn_http_download(url: * u8, output_path: * u8) -> * u8 ![net, io] {
+    if url as i64 == 0 { return null; }
+    if output_path as i64 == 0 { return null; }
+    let body: * u8 = _http_send(url, false, null, null);
+    if body as i64 == 0 { return null; }
+
+    let mode: string = "wb";
+    let f: * File = fopen(output_path, mode as * u8);
+    if f as i64 == 0 {
+        free(body);
+        return null;
+    }
+    let body_len: i64 = strlen(body) as i64;
+    if body_len > 0 {
+        fwrite(body, 1 as usize, body_len as usize, f);
+    }
+    fclose(f);
+    free(body);
+
+    let ok: * u8 = malloc(3 as usize);
+    if ok as i64 == 0 { return null; }
+    memset(_ptr_off(ok, 0), 111, 1 as usize);
+    memset(_ptr_off(ok, 1), 107, 1 as usize);
+    memset(_ptr_off(ok, 2), 0, 1 as usize);
+    return ok;
+}

--- a/runtime/sfn/adapters/http.sfn
+++ b/runtime/sfn/adapters/http.sfn
@@ -45,10 +45,19 @@
 //     (mirrors `sailfin_runtime_http_download`'s contract). Writes
 //     the body to `output_path` in binary mode.
 //
-// Host resolution (v0): numeric dotted-quad IPv4 (`atoi` per octet)
-// plus a `localhost` -> 127.0.0.1 special case. Real DNS
-// (`getaddrinfo`) is a follow-up wave — the v0 smoke test targets a
-// localhost listener, so name resolution is deliberately minimal.
+// Host resolution (v0): numeric dotted-quad IPv4 (`atoi` per octet,
+// each validated to 0..255) plus a `localhost` -> 127.0.0.1 special
+// case. Real DNS (`getaddrinfo`) is a follow-up wave — the v0 smoke
+// test targets a localhost listener, so name resolution is
+// deliberately minimal.
+//
+// v0 limitations (follow-up waves): no DNS, no `Transfer-Encoding:
+// chunked` decoding (the v0 contract is `Content-Length` responses;
+// a chunked response would surface its raw chunk framing as the
+// body), and no redirect following. Response bodies are length-
+// tracked end-to-end (`_recv_all` -> `_extract_body`), so binary
+// payloads with embedded NULs download faithfully even though the
+// get/post `i8*` return is also NUL-terminated for string use.
 //
 // Effects: `![net]` for get/post, `![net, io]` for download (it
 // opens a file). The flipped descriptors carry the same effects, so
@@ -195,6 +204,11 @@ fn _host_ip4(host: * u8, out: * u8) -> bool {
     loop {
         if i >= 4 { break; }
         let octet: i64 = atoi(cursor) as i64;
+        // Reject malformed octets — `atoi` happily returns values
+        // outside 0..255 (or negative), which would silently
+        // wrap/truncate into one byte and connect to an unintended
+        // address.
+        if octet < 0 || octet > 255 { return false; }
         memset(_ptr_off(out, i), octet as i32, 1 as usize);
         if i < 3 {
             let dot: * u8 = strchr(cursor, 46);
@@ -208,35 +222,57 @@ fn _host_ip4(host: * u8, out: * u8) -> bool {
 
 // `_connect_tcp(host, port)` — build an IPv4 `sockaddr_in`, open a
 // stream socket, and connect. Returns the connected fd, or -1 on
-// any failure. The 16-byte sockaddr is built byte-wise: family
-// AF_INET (low byte 2, the rest zero), `sin_port` in network byte
-// order (big-endian), then the four address octets, then the
-// 8-byte zero pad left from the initial `memset`.
+// any failure.
+//
+// `sockaddr_in` byte layout differs across the two targets this
+// runtime builds for, and the platform-agnostic emitted IR cannot
+// branch on it, so we try both layouts (fresh socket each time,
+// first success wins):
+//   - Linux:     `sin_family` is a u16 at offset 0 → low byte = 2
+//                (AF_INET), high byte 0.
+//   - macOS/BSD: `sin_len` (u8) at offset 0, `sin_family` (u8) at
+//                offset 1 → byte0 = 16 (struct size), byte1 = 2.
+// On Linux the macOS layout yields `sin_family = 16 | (2<<8) = 528`
+// (EAFNOSUPPORT) and vice-versa, so the wrong-layout attempt fails
+// fast without connecting anywhere. For localhost (the v0 target)
+// the live attempt succeeds or refuses immediately, so the extra
+// attempt costs nothing observable. `sin_port` is big-endian
+// (network byte order); the four address octets sit at offset 4.
 fn _connect_tcp(host: * u8, port: i64) -> i32 ![net] {
-    let addr: * u8 = malloc(16 as usize);
-    if addr as i64 == 0 { return 0 - 1; }
-    memset(addr, 0, 16 as usize);
-    // sin_family = AF_INET (2), little-endian u16 -> byte0 = 2.
-    memset(_ptr_off(addr, 0), 2, 1 as usize);
-    // sin_port (network byte order = big-endian).
-    memset(_ptr_off(addr, 2), ((port >> 8) & 255) as i32, 1 as usize);
-    memset(_ptr_off(addr, 3), (port & 255) as i32, 1 as usize);
-    // sin_addr octets at offset 4..8.
-    if _host_ip4(host, _ptr_off(addr, 4)) {
-        let fd: i32 = socket(2, 1, 0);
-        if fd < 0 {
+    let mut attempt: i64 = 0;
+    loop {
+        if attempt >= 2 { break; }
+        let addr: * u8 = malloc(16 as usize);
+        if addr as i64 == 0 { return 0 - 1; }
+        memset(addr, 0, 16 as usize);
+        if attempt == 0 {
+            // Linux: u16 sin_family at offset 0.
+            memset(_ptr_off(addr, 0), 2, 1 as usize);
+        } else {
+            // macOS/BSD: u8 sin_len at 0, u8 sin_family at 1.
+            memset(_ptr_off(addr, 0), 16, 1 as usize);
+            memset(_ptr_off(addr, 1), 2, 1 as usize);
+        }
+        // sin_port (network byte order = big-endian).
+        memset(_ptr_off(addr, 2), ((port >> 8) & 255) as i32, 1 as usize);
+        memset(_ptr_off(addr, 3), (port & 255) as i32, 1 as usize);
+        // sin_addr octets at offset 4..8.
+        if _host_ip4(host, _ptr_off(addr, 4)) {
+            let fd: i32 = socket(2, 1, 0);
+            if fd < 0 {
+                free(addr);
+                return 0 - 1;
+            }
+            let rc: i32 = connect(fd, addr, 16);
+            free(addr);
+            if rc == 0 { return fd; }
+            close(fd);
+        } else {
             free(addr);
             return 0 - 1;
         }
-        let rc: i32 = connect(fd, addr, 16);
-        free(addr);
-        if rc != 0 {
-            close(fd);
-            return 0 - 1;
-        }
-        return fd;
+        attempt = attempt + 1;
     }
-    free(addr);
     return 0 - 1;
 }
 
@@ -253,12 +289,16 @@ fn _send_all(fd: i32, buf: * u8, total: i64) -> bool ![net] {
     return true;
 }
 
-// `_recv_all(fd)` — drain the socket into a growing libc buffer
-// (doubling like `filesystem.sfn`'s slurp), NUL-terminated and
-// caller-owned. Returns null on OOM. Loops until `recv` returns 0
-// (peer closed — guaranteed by the request's `Connection: close`)
-// or an error.
-fn _recv_all(fd: i32) -> * u8 ![net] {
+// `_recv_all(fd, len_slot)` — drain the socket into a growing libc
+// buffer (doubling like `filesystem.sfn`'s slurp), NUL-terminated
+// and caller-owned, writing the exact byte count received through
+// `len_slot` (so binary bodies with embedded NULs are length-known,
+// not `strlen`-truncated). Returns null on OOM or a `recv` error
+// (`n < 0`); a clean EOF (`n == 0`, guaranteed by the request's
+// `Connection: close`) ends the loop and returns the buffer. The
+// trailing NUL keeps the buffer usable as a C string for the
+// text-body get/post paths.
+fn _recv_all(fd: i32, len_slot: * i64) -> * u8 ![net] {
     let mut capacity: i64 = 8192;
     let mut len: i64 = 0;
     let mut buf: * u8 = malloc((capacity + 1) as usize);
@@ -276,19 +316,39 @@ fn _recv_all(fd: i32) -> * u8 ![net] {
             capacity = new_cap;
         }
         let n: i64 = recv(fd, _ptr_off(buf, len), chunk, 0);
-        if n <= 0 { break; }
+        // Distinguish a socket error from a clean close: a partial
+        // buffer from an errored socket must not look like success.
+        if n < 0 {
+            free(buf);
+            return null;
+        }
+        if n == 0 { break; }
         len = len + n;
     }
     memset(_ptr_off(buf, len), 0, 1 as usize);
+    atomic_store(len_slot, len);
     return buf;
 }
 
-// `_extract_body(resp)` — given a raw HTTP response buffer, check
-// the status line and return a fresh copy of the body (everything
-// after the first `\r\n\r\n`). Returns null when the status code is
-// >= 400 (mirrors curl `-f`) or when no header terminator is found.
-// `resp` is left untouched; the caller frees it.
-fn _extract_body(resp: * u8) -> * u8 {
+// `_extract_body(resp, total_len, body_len_slot)` — given a raw
+// HTTP response buffer of `total_len` bytes, check the status line
+// and return a fresh copy of the body (everything after the first
+// `\r\n\r\n`), writing the body's exact byte length through
+// `body_len_slot`. The length is computed as `total_len - body_off`
+// (NOT `strlen`), so bodies containing embedded NULs are copied
+// whole — required for `http.download` to be a faithful binary
+// download. Returns null when the status code is >= 400 (mirrors
+// curl `-f`) or when no header terminator is found. The status line
+// and headers are ASCII (no NUL before the body), so `strchr` /
+// `strstr` over them are safe. `resp` is left untouched; the caller
+// frees it.
+//
+// v0 limitation: `Transfer-Encoding: chunked` is not decoded — the
+// raw chunk framing would be returned as the body. The v0 contract
+// targets `Content-Length` responses (e.g. the localhost listener);
+// chunked decoding is a follow-up wave.
+fn _extract_body(resp: * u8, total_len: i64, body_len_slot: * i64) -> * u8 {
+    atomic_store(body_len_slot, 0);
     if resp as i64 == 0 { return null; }
     // Status code: the first space precedes "NNN reason".
     let space: * u8 = strchr(resp, 32);
@@ -299,9 +359,13 @@ fn _extract_body(resp: * u8) -> * u8 {
     let terminator: string = "\r\n\r\n";
     let header_end: * u8 = strstr(resp, terminator as * u8);
     if header_end as i64 == 0 { return null; }
-    let body_start: * u8 = _ptr_off(header_end, 4);
-    let body_len: i64 = strlen(body_start) as i64;
-    return _strdup_n(body_start, body_len);
+    let body_off: i64 = ((header_end as i64) - (resp as i64)) + 4;
+    let body_len: i64 = total_len - body_off;
+    if body_len < 0 { return null; }
+    let body: * u8 = _strdup_n(_ptr_off(resp, body_off), body_len);
+    if body as i64 == 0 { return null; }
+    atomic_store(body_len_slot, body_len);
+    return body;
 }
 
 // `_http_send(url, is_post, body, auth_header)` — the shared
@@ -310,7 +374,7 @@ fn _extract_body(resp: * u8) -> * u8 {
 // the response, and returns the extracted body (or null on any
 // failure). `auth_header`, when non-null and non-empty, is emitted
 // as an `Authorization:` header (POST only).
-fn _http_send(url: * u8, is_post: bool, body: * u8, auth_header: * u8) -> * u8 ![net] {
+fn _http_send(url: * u8, is_post: bool, body: * u8, auth_header: * u8, body_len_slot: * i64) -> * u8 ![net] {
     // Reject TLS — no HTTPS in v0.
     let https: string = "https://";
     if (strstr(url, https as * u8) as i64) == (url as i64) { return null; }
@@ -448,9 +512,10 @@ fn _http_send(url: * u8, is_post: bool, body: * u8, auth_header: * u8) -> * u8 !
     }
 
     free(authority);
-    let resp: * u8 = _recv_all(fd);
+    let mut total_len: i64 = 0;
+    let resp: * u8 = _recv_all(fd, & total_len);
     close(fd);
-    let result: * u8 = _extract_body(resp);
+    let result: * u8 = _extract_body(resp, total_len, body_len_slot);
     if resp as i64 != 0 { free(resp); }
     return result;
 }
@@ -469,7 +534,10 @@ fn _append(dst: * u8, off: i64, src: * u8) -> i64 {
 // status >= 400.
 fn sfn_http_get(url: * u8) -> * u8 ![net] {
     if url as i64 == 0 { return null; }
-    return _http_send(url, false, null, null);
+    // get/post return an `i8*` C string, so the body length is
+    // unused here — pass a throwaway slot.
+    let mut body_len: i64 = 0;
+    return _http_send(url, false, null, null, & body_len);
 }
 
 // `sfn_http_post(url, body, auth_header)` — POST `body` to `url`
@@ -481,7 +549,8 @@ fn sfn_http_get(url: * u8) -> * u8 ![net] {
 fn sfn_http_post(url: * u8, body: * u8, auth_header: * u8) -> * u8 ![net] {
     if url as i64 == 0 { return null; }
     if body as i64 == 0 { return null; }
-    return _http_send(url, true, body, auth_header);
+    let mut body_len: i64 = 0;
+    return _http_send(url, true, body, auth_header, & body_len);
 }
 
 // `sfn_http_post2(url, body)` — 2-arg POST for the `http_post`
@@ -493,11 +562,14 @@ fn sfn_http_post2(url: * u8, body: * u8) -> * u8 ![net] {
 // `sfn_http_download(url, output_path)` — GET `url` and write the
 // body to `output_path` in binary mode. Returns the literal `"ok"`
 // on success, null on failure (matching the curl
-// `sailfin_runtime_http_download` contract).
+// `sailfin_runtime_http_download` contract). Uses the exact body
+// length reported by `_http_send` (not `strlen`), so binary
+// payloads with embedded NULs are written whole.
 fn sfn_http_download(url: * u8, output_path: * u8) -> * u8 ![net, io] {
     if url as i64 == 0 { return null; }
     if output_path as i64 == 0 { return null; }
-    let body: * u8 = _http_send(url, false, null, null);
+    let mut body_len: i64 = 0;
+    let body: * u8 = _http_send(url, false, null, null, & body_len);
     if body as i64 == 0 { return null; }
 
     let mode: string = "wb";
@@ -506,7 +578,6 @@ fn sfn_http_download(url: * u8, output_path: * u8) -> * u8 ![net, io] {
         free(body);
         return null;
     }
-    let body_len: i64 = strlen(body) as i64;
     if body_len > 0 {
         fwrite(body, 1 as usize, body_len as usize, f);
     }


### PR DESCRIPTION
## Summary
- New `runtime/sfn/adapters/http.sfn`: a pure-Sailfin HTTP/1.1 client on the BSD-sockets surface (`socket`/`connect`/`send`/`recv`/`close`), replacing the curl-subprocess path. **HTTP only — HTTPS is rejected (no TLS for v0, Option A per epic #390).**
- Flipped the 5 curl registry rows to the `sfn_http_*` symbols; added the adapter to `sfn-sources`; wired its object into the runtime link path + build staging (mirroring the #814 filesystem migration).

Closes #818

## What changed
| File | Change |
|---|---|
| `runtime/sfn/adapters/http.sfn` (new) | `sfn_http_get`, `sfn_http_post(url, body, auth)`, `sfn_http_post2` (2-arg alias), `sfn_http_download`. URL parse → IPv4 sockaddr build → connect → request build/send → recv loop → status check + body extraction. Caller-owned `malloc` buffers (same raw-pointer ABI as `sfn_fs_*`). |
| `compiler/src/llvm/runtime_helpers.sfn` | Flip `http.get_body` / `http.post_json` / `http.download` + the `http_get` / `http_post` aliases to `sfn_http_*` via `native_signature`. Legacy curl C symbols stay exported for seed compat. |
| `runtime/native/capsule.toml` | Add `http.sfn` to `sfn-sources`. |
| `compiler/src/cli_main.sfn` + `Makefile` | `_runtime_http_path` + `http_obj` in the runtime link list, and `http.o` build staging (Linux + Windows-cross). |
| `compiler/tests/e2e/test_runtime_adapter_http.sh` (new) | typecheck/fmt/emit-shape + IR routing probe + GET/POST round-trip against a localhost listener. |

## Acceptance Criteria
- [x] `sfn_http_get` / `sfn_http_post` perform a real socket request against a localhost listener (e2e GET+POST round-trip passes).
- [x] curl registry rows point at `sfn_http_*`.
- [x] `sfn fmt --check` clean on all touched `.sfn`.
- [x] `make compile` self-hosts; new e2e passes (5/5). _`make check` re-run in progress — see note._

## Verification
```
$ bash compiler/tests/e2e/test_runtime_adapter_http.sh build/native/sailfin
[test] PASS: sfn check runtime/sfn/adapters/http.sfn passes
[test] PASS: sfn fmt --check runtime/sfn/adapters/http.sfn is canonical
[test] PASS: sfn emit llvm defines every sfn_http_* export + socket declares
[test] PASS: http.get_body lowers to @sfn_http_get (not the curl path)
[test] PASS: GET + POST round-trip against a localhost listener returns the body
[summary] 5 passed, 0 failed
```
`make rebuild` self-hosts green; the seedcheck binary builds and runs hello-world.

## Notes / scope
- **Files Affected was extended** beyond the issue's 4-file list to include `cli_main.sfn` + `Makefile` (approved). The `sfn run`/`sfn build` link path uses a hardcoded runtime-object list + build staging — without wiring `http.o` there, `sfn_http_get` never links. This is exactly the plumbing the analogous #814 (filesystem) required.
- **ABI:** descriptors keep the raw `i8*`-in/`i8*`-out shape (no arena threading), matching the `sfn_fs_*` adapters. The issue's `*Arena`/`SfnString` shorthand would require retyping descriptors + threading an arena through `core_call_lowering.sfn` (out of scope).
- **Host resolution (v0):** dotted-quad IPv4 + `localhost` special-case; real DNS (`getaddrinfo`) is a follow-up.
- The full `make check` was interrupted by a session restart at the second-pass suite stage; I'm re-running it and will confirm green (CI also runs it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0183ebeffW5gXUrEkRAxTJ1s)_