### PR TITLE
ci: pin macOS runners to macos-15 ahead of macos-latest migration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: macos-latest
+          # Pinned to macos-15: the `macos-latest` label migrates to macOS 26
+          # starting 2026-06-15. Keep CI on the known-good image; macOS 26 is
+          # being trialed in nightly-selfhost.yml before we adopt it here.
+          - os: macos-15
             package_label: macos-arm64
             asset_os: macos
             asset_arch: arm64

--- a/.github/workflows/nightly-selfhost.yml
+++ b/.github/workflows/nightly-selfhost.yml
@@ -48,7 +48,10 @@ jobs:
           - os: ubuntu-24.04
             package_label: linux-x86_64
             clang: clang-18
-          - os: macos-latest
+          # Trialing macos-26 ahead of the 2026-06-15 `macos-latest` migration:
+          # nightly is the early-warning canary for fixed-point / determinism
+          # breakage on the new image before CI and release jobs adopt it.
+          - os: macos-26
             package_label: macos-arm64
             clang: clang
     steps:

--- a/.github/workflows/release-branches.yml
+++ b/.github/workflows/release-branches.yml
@@ -45,7 +45,10 @@ jobs:
             fail-fast: false
             matrix:
                 include:
-                    - os: macos-latest
+                    # Pinned to macos-15: `macos-latest` migrates to macOS 26
+                    # on 2026-06-15. Seed-producing build; keep the toolchain
+                    # stable rather than letting the image shift mid-cycle.
+                    - os: macos-15
                       package_label: macos-arm64
                       clang: clang
                     - os: ubuntu-24.04

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -49,7 +49,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: macos-latest
+          # Pinned to macos-15: `macos-latest` migrates to macOS 26 on
+          # 2026-06-15. These jobs produce the shipped macos-arm64 binaries
+          # (pinned as seeds), so the build toolchain must not shift silently.
+          - os: macos-15
             package_label: macos-arm64
             clang: clang
           - os: ubuntu-24.04


### PR DESCRIPTION
## Why

GitHub is migrating the `macos-latest` runner label from **macOS 15** to **macOS 26**, starting **2026-06-15** and completing ~30 days later ([GitHub Changelog, 2026-05-14](https://github.blog/changelog/2026-05-14-github-actions-upcoming-image-migrations/)). Staying on macOS 15 requires targeting the `macos-15` label explicitly.

Four of our workflows ride `macos-latest` to build the `macos-arm64` package. Two of them (`release-tag`, `release-branches`) produce the **shipped `macos-arm64` binaries that get pinned as seeds** — so a silent toolchain shift (newer Xcode/clang/`brew llvm`) landing mid-alpha-cycle could perturb the fixed-point rebuild check, Mach-O `LC_UUID` determinism handling, and the known-partial macOS effect enforcement (#613) without warning.

The migration stays arm64→arm64, so the `macos-arm64` packaging label is unaffected; the risk is purely behavioral.

## What

| Workflow | Change | Rationale |
|---|---|---|
| `ci.yml` | `macos-latest` → `macos-15` | Keep PR CI on the known-good image |
| `release-tag.yml` | `macos-latest` → `macos-15` | Seed-producing build — no silent toolchain shift |
| `release-branches.yml` | `macos-latest` → `macos-15` | Seed-producing build — same |
| `nightly-selfhost.yml` | `macos-latest` → `macos-26` | **Canary**: early-warning on fixed-point / determinism breakage on the new image before CI/release adopt it |

## Follow-up

Once nightly-selfhost has run a few cycles green on `macos-26`, adopt it in CI and the release builds deliberately (separate PR). `macos-15` arm64 images remain available well past the migration window.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DKvCJ37hnNysjaf6tqeHSr)_