### PR TITLE
feat(lowering): per-instantiation payload typing for generic payload enums

### DIFF
--- a/compiler/src/llvm/expression_lowering/native/core_literals_lowering.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_literals_lowering.sfn
@@ -16,7 +16,7 @@ import {
 import {
     array_struct_type_for_element,
     ends_with_pointer_suffix,
-    layout_annotation_represents_user_value,
+    enum_inst_annotation_references_param,
     map_type_annotation,
     strip_pointer_suffix
 } from "../../type_mapping";
@@ -1149,6 +1149,22 @@ fn lower_enum_literal(parse: EnumLiteralParse, bindings: ParameterBinding[], loc
         loop {
             if field_index >= variant_info.fields.length { break; }
             let expected = variant_info.fields[field_index];
+            // #830: a generic payload field (declared `value: T`) type-erases
+            // to `%T` in `expected.llvm_type`. The concrete instantiation is
+            // not recoverable here (the construction's target arrives already
+            // mapped to its boxed LLVM type), so for a field that references a
+            // declared type parameter we take the field's concrete LLVM type
+            // from the lowered value operand instead. This keeps the payload
+            // store in lock-step with the match-arm read, which derives the
+            // same concrete type from the subject's instantiation annotation.
+            // Monomorphic enums have no type parameters, so `field_is_generic`
+            // is false and `field_llvm_type` keeps the pre-mapped value.
+            let field_is_generic = enum_inst_annotation_references_param(expected.type_annotation, enum_info.type_parameters);
+            let mut field_llvm_type: string = expected.llvm_type;
+            // For a generic field, lower the value with no type hint so its
+            // natural LLVM type surfaces; otherwise hint the declared type.
+            let mut value_type_hint: string = field_llvm_type;
+            if field_is_generic { value_type_hint = ""; }
             let mut literal_index: int = -1;
             let mut literal_lookup_index: int = 0;
             loop {
@@ -1162,7 +1178,7 @@ fn lower_enum_literal(parse: EnumLiteralParse, bindings: ParameterBinding[], loc
 
             if literal_index >= 0 {
                 let literal_field = parse.fields[literal_index];
-                let lowered = lower_expression(literal_field.value, bindings, locals, current_temp, current_lines, functions, context, expected.llvm_type);
+                let lowered = lower_expression(literal_field.value, bindings, locals, current_temp, current_lines, functions, context, value_type_hint);
                 let mut _ci7: int = 0;
                 loop {
                     if _ci7 >= lowered.diagnostics.length { break; }
@@ -1173,12 +1189,25 @@ fn lower_enum_literal(parse: EnumLiteralParse, bindings: ParameterBinding[], loc
                 current_temp = lowered.temp_index;
                 if lowered.operand != null {
                     let mut field_operand = lowered.operand;
+                    // #830: for a generic payload field, adopt the value's
+                    // concrete LLVM type as the field type. A fat string
+                    // aggregate (`{i8*, i64}`) is narrowed to its `i8*` data
+                    // pointer so it fits the pointer-width payload slot and
+                    // matches the match-arm read (which maps `string` -> i8*).
+                    if field_is_generic {
+                        let operand_type = trim_text(field_operand.llvm_type);
+                        if operand_type == "{i8*, i64}" {
+                            field_llvm_type = "i8*";
+                        } else if operand_type.length > 0 {
+                            field_llvm_type = operand_type;
+                        }
+                    }
                     let trimmed_field_type = trim_text(field_operand.llvm_type);
                     let mut _let69: boolean = false;
                     if starts_with(trimmed_field_type, "%") { _let69 = true; }
                     if starts_with(trimmed_field_type, "{") { _let69 = true; }
                     let field_is_aggregate = _let69;
-                    if ends_with_pointer_suffix(expected.llvm_type) {
+                    if ends_with_pointer_suffix(field_llvm_type) {
                         if !ends_with_pointer_suffix(field_operand.llvm_type) {
                             if field_is_aggregate {
                                 // M1.A: SfnString aggregate flowing into
@@ -1188,12 +1217,12 @@ fn lower_enum_literal(parse: EnumLiteralParse, bindings: ParameterBinding[], loc
                                 // and break every legacy reader.
                                 let mut should_unwrap_string_field: boolean = false;
                                 if trimmed_field_type == "{i8*, i64}" {
-                                    if expected.llvm_type == "i8*" {
+                                    if field_llvm_type == "i8*" {
                                         should_unwrap_string_field = true;
                                     }
                                 }
                                 if !should_unwrap_string_field {
-                                    let boxed = box_aggregate_operand(field_operand, expected.llvm_type, current_temp, current_lines, context);
+                                    let boxed = box_aggregate_operand(field_operand, field_llvm_type, current_temp, current_lines, context);
                                     let mut _ci8: int = 0;
                                     loop {
                                         if _ci8 >= boxed.diagnostics.length {
@@ -1218,7 +1247,7 @@ fn lower_enum_literal(parse: EnumLiteralParse, bindings: ParameterBinding[], loc
                     // self-locating.
                     // Slice E.2 follow-up (#540): thread the enum-literal
                     // site span; same shape as the struct-literal branch.
-                    let coerced = coerce_operand_to_type(field_operand, expected.llvm_type, current_temp, current_lines, false, span);
+                    let coerced = coerce_operand_to_type(field_operand, field_llvm_type, current_temp, current_lines, false, span);
                     let mut _ci9: int = 0;
                     loop {
                         if _ci9 >= coerced.diagnostics.length { break; }
@@ -1256,7 +1285,7 @@ fn lower_enum_literal(parse: EnumLiteralParse, bindings: ParameterBinding[], loc
                             + "."
                             + expected.name
                             + "` (expected `"
-                            + expected.llvm_type
+                            + field_llvm_type
                             + "`)";
                         if span != null {
                             _payload_diag = _payload_diag + " at "
@@ -1312,7 +1341,7 @@ fn lower_enum_literal(parse: EnumLiteralParse, bindings: ParameterBinding[], loc
                                 + field_byte_ptr_temp
                                 + " to ptr");
 
-                            current_lines.push("  store " + expected.llvm_type
+                            current_lines.push("  store " + field_llvm_type
                                 + " "
                                 + coerced.operand.value
                                 + ", ptr "

--- a/compiler/src/llvm/imports.sfn
+++ b/compiler/src/llvm/imports.sfn
@@ -572,6 +572,7 @@ fn apply_layout_manifest_entries(structs: NativeStruct[], enums: NativeEnum[], m
             let target = updated_enums[target_index];
             let replaced = NativeEnum {
                 name: target.name,
+                type_parameters: target.type_parameters,
                 variants: target.variants,
                 layout: layout_enum.layout
             };

--- a/compiler/src/llvm/lowering/instructions_match.sfn
+++ b/compiler/src/llvm/lowering/instructions_match.sfn
@@ -85,6 +85,37 @@ fn _match_make_local_binding(name: string, pointer: string, llvm_type: string, s
     };
 }
 
+// #830: resolve the declared source annotation of a match subject by name,
+// so generic enum payload field types can be substituted per instantiation.
+// Locals take precedence over parameters (a local may shadow/rebind). Returns
+// "" when the subject is not a simple identifier or carries no annotation.
+fn resolve_match_subject_annotation(subject_name: string, bindings: ParameterBinding[], locals: LocalBinding[]) -> string {
+    if subject_name.length == 0 { return ""; }
+    let mut found: string = "";
+    let mut i: int = 0;
+    loop {
+        if i >= locals.length { break; }
+        if locals[i].name == subject_name {
+            if locals[i].type_annotation.length > 0 {
+                found = locals[i].type_annotation;
+            }
+        }
+        i += 1;
+    }
+    if found.length > 0 { return found; }
+    i = 0;
+    loop {
+        if i >= bindings.length { break; }
+        if bindings[i].name == subject_name {
+            if bindings[i].type_annotation.length > 0 {
+                return bindings[i].type_annotation;
+            }
+        }
+        i += 1;
+    }
+    return "";
+}
+
 fn collect_match_structure(instructions: NativeInstruction[], start_index: int, end: int, function_name: string) -> MatchStructure {
     let mut diagnostics: string[] = [];
     let mut cases: MatchCaseStructure[] = [];
@@ -247,6 +278,11 @@ fn lower_match_instruction(function: NativeFunction, start_index: int, llvm_retu
 
     let subject_operand = subject_result.operand;
 
+    // #830: capture the match subject's declared source annotation (e.g.
+    // `Foo<int, Error>`) so payload field types can be resolved per
+    // instantiation. Empty for non-identifier subjects / monomorphic enums.
+    let subject_type_annotation = resolve_match_subject_annotation(subject_name, bindings, current_locals);
+
     let union_payload_types = parse_union_payload_types(subject_operand.llvm_type);
     let mut matched_union_variants: int[] = [];
     let subject_enum_info = find_enum_info_by_llvm_type(context, subject_operand.llvm_type);
@@ -341,7 +377,7 @@ fn lower_match_instruction(function: NativeFunction, start_index: int, llvm_retu
         }
 
         current_lines.push(test_labels[index] + ":");
-        let lowered_condition = lower_match_case_condition(function.name, subject_operand, case, bindings, current_locals, current_temp, current_lines, functions, context);
+        let lowered_condition = lower_match_case_condition(function.name, subject_operand, subject_type_annotation, case, bindings, current_locals, current_temp, current_lines, functions, context);
         let mut _ci2: int = 0;
         loop {
             if _ci2 >= lowered_condition.diagnostics.length { break; }

--- a/compiler/src/llvm/lowering/instructions_match_condition.sfn
+++ b/compiler/src/llvm/lowering/instructions_match_condition.sfn
@@ -15,6 +15,8 @@ import {
 } from "../type_context_queries";
 import {
     ends_with_pointer_suffix,
+    enum_inst_parse_args,
+    enum_inst_substitute_annotation,
     layout_annotation_represents_user_value,
     map_struct_field_annotation,
     strip_pointer_suffix
@@ -37,7 +39,7 @@ import {
 import { number_to_string, trim_text } from "../utils";
 import { lower_condition_to_i1 } from "./instructions_condition";
 
-fn lower_match_case_condition(function_name: string, subject_operand: LLVMOperand, case: MatchCaseStructure, bindings: ParameterBinding[], locals: LocalBinding[], temp_index: int, lines: string[], functions: NativeFunction[], context: TypeContext) -> MatchCaseCondition {
+fn lower_match_case_condition(function_name: string, subject_operand: LLVMOperand, subject_type_annotation: string, case: MatchCaseStructure, bindings: ParameterBinding[], locals: LocalBinding[], temp_index: int, lines: string[], functions: NativeFunction[], context: TypeContext) -> MatchCaseCondition {
     let mut diagnostics: string[] = [];
     let mut current_lines: string[] = lines;
     let mut current_temp: int = temp_index;
@@ -164,13 +166,36 @@ fn lower_match_case_condition(function_name: string, subject_operand: LLVMOperan
                             }
 
                             if found_field != null {
+                                // #830: resolve generic payload type parameters
+                                // (e.g. `T`) against the match subject's concrete
+                                // instantiation (`Foo<int, Error>`) before mapping
+                                // to an LLVM type. For monomorphic enums the enum
+                                // carries no type parameters, so this leaves the
+                                // declared annotation (and pre-mapped llvm_type)
+                                // untouched — a byte-for-byte no-op.
+                                let mut resolved_annotation: string = found_field.type_annotation;
+                                let mut substituted: boolean = false;
+                                if enum_info.type_parameters.length > 0 {
+                                    let inst_args = enum_inst_parse_args(subject_type_annotation);
+                                    if inst_args.length > 0 {
+                                        let candidate = enum_inst_substitute_annotation(found_field.type_annotation, enum_info.type_parameters, inst_args);
+                                        if candidate != found_field.type_annotation {
+                                            resolved_annotation = candidate;
+                                            substituted = true;
+                                        }
+                                    }
+                                }
                                 let mut llvm_field_type: string = found_field.llvm_type;
+                                let mut needs_mapping: boolean = substituted;
                                 if llvm_field_type.length == 0 {
-                                    llvm_field_type = map_struct_field_annotation(found_field.type_annotation);
+                                    needs_mapping = true;
+                                }
+                                if needs_mapping {
+                                    llvm_field_type = map_struct_field_annotation(resolved_annotation);
                                     if llvm_field_type.length == 0 {
                                         llvm_field_type = "i8*";
                                     }
-                                    if layout_annotation_represents_user_value(found_field.type_annotation) {
+                                    if layout_annotation_represents_user_value(resolved_annotation) {
                                         if ends_with_pointer_suffix(llvm_field_type) {
                                             let stripped = strip_pointer_suffix(llvm_field_type);
                                             if stripped.length > 0 {

--- a/compiler/src/llvm/lowering/lowering_native_helpers.sfn
+++ b/compiler/src/llvm/lowering/lowering_native_helpers.sfn
@@ -121,7 +121,18 @@ fn make_native_struct_layout_field(lf_name: string, lf_type: string, lf_offset: 
 
 // ── NativeEnum constructors ──────────────────────────────────────────
 fn make_native_enum(ename: string, evariants: NativeEnumVariant[], elayout: NativeEnumLayout?) -> NativeEnum {
-    return NativeEnum { name: ename, variants: evariants, layout: elayout };
+    // `type_parameters: []` — this constructor backs `recover_native_enums_light`
+    // (lowering_recovery.sfn), the legacy cross-module recovery fallback that the
+    // phase-4 arena path no longer arms. It stores the raw header text and never
+    // captures generic parameters, so it cannot supply them here. If that fallback
+    // is ever re-armed, generic payload enums (#830) would need real parameter
+    // capture; today this is dead and the empty default is benign.
+    return NativeEnum {
+        name: ename,
+        type_parameters: [],
+        variants: evariants,
+        layout: elayout
+    };
 }
 
 fn make_native_enum_variant(vname: string) -> NativeEnumVariant {

--- a/compiler/src/llvm/lowering/lowering_phase_types.sfn
+++ b/compiler/src/llvm/lowering/lowering_phase_types.sfn
@@ -66,7 +66,7 @@ fn build_enum_infos_inline(enums: NativeEnum[]) -> EnumTypeInfo[] {
         }
 
         recovered.push(EnumTypeInfo {
-            name: name, llvm_name: llvm, tag_type: tag_type, tag_size: tag_size, tag_align: tag_align, max_payload_size: max_ps, size: size, align: align, variants: variants_out
+            name: name, type_parameters: e.type_parameters, llvm_name: llvm, tag_type: tag_type, tag_size: tag_size, tag_align: tag_align, max_payload_size: max_ps, size: size, align: align, variants: variants_out
         });
         idx += 1;
     }

--- a/compiler/src/llvm/type_context.sfn
+++ b/compiler/src/llvm/type_context.sfn
@@ -136,6 +136,7 @@ fn fixup_enum_layouts(enums: NativeEnum[]) -> EnumLayoutFixupResult {
             if is_unit_enum(enum_def) {
                 fixed = NativeEnum {
                     name: enum_def.name,
+                    type_parameters: enum_def.type_parameters,
                     variants: enum_def.variants,
                     layout: synthesize_unit_enum_layout(enum_def)
                 };
@@ -152,6 +153,7 @@ fn fixup_enum_layouts(enums: NativeEnum[]) -> EnumLayoutFixupResult {
             if is_unit_enum(enum_def) {
                 fixed = NativeEnum {
                     name: enum_def.name,
+                    type_parameters: enum_def.type_parameters,
                     variants: enum_def.variants,
                     layout: synthesize_unit_enum_layout(enum_def)
                 };
@@ -328,7 +330,7 @@ fn build_type_context(structs: NativeStruct[], enums: NativeEnum[], interfaces: 
             payload_scan += 1;
         }
         enum_entries = append_enum_type_info(enum_entries, EnumTypeInfo {
-            name: enum_def.name, llvm_name: llvm_enum_name, tag_type: enum_layout.tag_type, tag_size: enum_layout.tag_size, tag_align: enum_layout.tag_align, max_payload_size: max_payload_size, size: enum_layout.size, align: enum_align_value, variants: variants
+            name: enum_def.name, type_parameters: enum_def.type_parameters, llvm_name: llvm_enum_name, tag_type: enum_layout.tag_type, tag_size: enum_layout.tag_size, tag_align: enum_layout.tag_align, max_payload_size: max_payload_size, size: enum_layout.size, align: enum_align_value, variants: variants
         });
         enum_index += 1;
     }

--- a/compiler/src/llvm/type_mapping.sfn
+++ b/compiler/src/llvm/type_mapping.sfn
@@ -136,6 +136,147 @@ fn looks_like_user_type(annotation: string) -> boolean {
     return false;
 }
 
+// ── #830: generic enum instantiation helpers ─────────────────────────
+// Self-contained (no cross-layer imports) parsing + substitution used to
+// resolve a generic payload enum's declared type parameters against the
+// concrete type arguments at a match site. Monomorphic enums never carry a
+// generic clause, so every entry point below is an inert no-op for them.
+fn enum_inst_is_ident_char(ch: string) -> boolean {
+    if ch.length == 0 { return false; }
+    let code = char_code(ch);
+    let mut ok: boolean = false;
+    if code >= char_code("a") {
+        if code <= char_code("z") { ok = true; }
+    }
+    if code >= char_code("A") {
+        if code <= char_code("Z") { ok = true; }
+    }
+    if code >= char_code("0") {
+        if code <= char_code("9") { ok = true; }
+    }
+    if ch == "_" { ok = true; }
+    return ok;
+}
+
+// Parse the top-level type-argument list out of an instantiation
+// annotation such as `Foo<int, Result<int, E>>` -> ["int", "Result<int, E>"].
+// Returns [] when there is no generic clause. Angle-bracket nesting aware.
+fn enum_inst_parse_args(annotation: string) -> string[] {
+    let trimmed = trim_text(annotation);
+    let open = index_of(trimmed, "<");
+    if open < 0 { return []; }
+    let mut args: string[] = [];
+    let mut depth: int = 0;
+    let mut current: string = "";
+    let mut started: boolean = false;
+    let mut index: int = open;
+    loop {
+        if index >= trimmed.length { break; }
+        let ch = substring(trimmed, index, index + 1);
+        if ch == "<" {
+            depth += 1;
+            if depth == 1 {
+                started = true;
+                index += 1;
+                continue;
+            }
+            current = current + ch;
+        } else if ch == ">" {
+            if depth > 0 { depth -= 1; }
+            if depth == 0 {
+                if trim_text(current).length > 0 {
+                    args.push(trim_text(current));
+                }
+                break;
+            }
+            current = current + ch;
+        } else if ch == "," {
+            if depth == 1 {
+                args.push(trim_text(current));
+                current = "";
+            } else { current = current + ch; }
+        } else { current = current + ch; }
+        index += 1;
+    }
+    if !started { return []; }
+    return args;
+}
+
+// True when `annotation` contains an identifier token that exactly matches
+// one of the declared `params` (e.g. `T`, `Array<T>`, `T?`). Used at
+// construction sites to recognise a generic payload field whose concrete
+// type must be taken from the value operand rather than the type-erased
+// declared annotation (#830).
+fn enum_inst_annotation_references_param(annotation: string, params: string[]) -> boolean {
+    if params.length == 0 { return false; }
+    let mut token: string = "";
+    let mut index: int = 0;
+    loop {
+        if index >= annotation.length { break; }
+        let ch = substring(annotation, index, index + 1);
+        if enum_inst_is_ident_char(ch) { token = token + ch; } else {
+            if token.length > 0 {
+                let mut p: int = 0;
+                loop {
+                    if p >= params.length { break; }
+                    if params[p] == token { return true; }
+                    p += 1;
+                }
+                token = "";
+            }
+        }
+        index += 1;
+    }
+    if token.length > 0 {
+        let mut p: int = 0;
+        loop {
+            if p >= params.length { break; }
+            if params[p] == token { return true; }
+            p += 1;
+        }
+    }
+    return false;
+}
+
+fn enum_inst_resolve_token(token: string, params: string[], args: string[]) -> string {
+    let mut index: int = 0;
+    let mut limit: int = params.length;
+    if args.length < limit { limit = args.length; }
+    loop {
+        if index >= limit { break; }
+        if params[index] == token { return args[index]; }
+        index += 1;
+    }
+    return token;
+}
+
+// Substitute declared parameter names with concrete arguments in a field
+// type annotation, identifier-boundary aware (`T` -> `int`, `T[]` ->
+// `int[]`, `Array<T>` -> `Array<int>`, while `Transaction` is left intact).
+// Returns the annotation unchanged when `params` is empty.
+fn enum_inst_substitute_annotation(annotation: string, params: string[], args: string[]) -> string {
+    if params.length == 0 { return annotation; }
+    let mut result: string = "";
+    let mut token: string = "";
+    let mut index: int = 0;
+    loop {
+        if index >= annotation.length { break; }
+        let ch = substring(annotation, index, index + 1);
+        if enum_inst_is_ident_char(ch) { token = token + ch; } else {
+            if token.length > 0 {
+                result = result + enum_inst_resolve_token(token, params, args);
+                token = "";
+            }
+            result = result + ch;
+        }
+        index += 1;
+    }
+    if token.length > 0 {
+        result = result + enum_inst_resolve_token(token, params, args);
+    }
+    return result;
+}
+
 fn annotation_is_array(annotation: string) -> boolean {
     let trimmed = trim_text(annotation);
     if trimmed.length < 3 { return false; }

--- a/compiler/src/llvm/types.sfn
+++ b/compiler/src/llvm/types.sfn
@@ -317,6 +317,9 @@ struct EnumVariantInfo {
 
 struct EnumTypeInfo {
     name: string;
+    // Declared generic type-parameter names (e.g. ["T", "E"]); empty for
+    // monomorphic enums. Drives #830 per-instantiation payload substitution.
+    type_parameters: string[];
     llvm_name: string;
     tag_type: string;
     tag_size: int;

--- a/compiler/src/native_ir.sfn
+++ b/compiler/src/native_ir.sfn
@@ -164,6 +164,7 @@ struct NativeEnumLayout {
 
 struct NativeEnum {
     name: string;
+    type_parameters: string[];
     variants: NativeEnumVariant[];
     layout: NativeEnumLayout?;
 }

--- a/compiler/src/native_ir_api.sfn
+++ b/compiler/src/native_ir_api.sfn
@@ -375,6 +375,7 @@ fn parse_layout_manifest(text: string) -> LayoutManifest {
 
                 let enum_def = NativeEnum {
                     name: enum_name,
+                    type_parameters: [],
                     variants: [],
                     layout: NativeEnumLayout {
                         size: header_result.size,

--- a/compiler/src/native_ir_parser_defs.sfn
+++ b/compiler/src/native_ir_parser_defs.sfn
@@ -40,6 +40,8 @@ import {
 import {
     index_of,
     is_trim_char,
+    last_index_of,
+    split_top_level_commas,
     split_whitespace,
     starts_with,
     strip_generics,
@@ -498,10 +500,44 @@ fn parse_struct_definition(lines: string[], start_index: int, include_instructio
     };
 }
 
+// Extract declared type-parameter names from an enum header name such as
+// `Foo<T, E>` or `Foo<T : Display, E>`, returning `["T", "E"]`. Only the
+// parameter name (before any `:` bound) is kept. A header with no generic
+// clause yields `[]`. Used by #830 per-instantiation payload substitution.
+fn parse_enum_header_type_parameters(header_name: string) -> string[] {
+    let open_index = index_of(header_name, "<");
+    if open_index < 0 { return []; }
+    let close_index = last_index_of(header_name, ">");
+    if close_index <= open_index { return []; }
+    let block = trim_text(substring(header_name, open_index + 1, close_index));
+    if block.length == 0 { return []; }
+    let raw_entries = split_top_level_commas(block);
+    let mut names: string[] = [];
+    let mut index: int = 0;
+    loop {
+        if index >= raw_entries.length { break; }
+        let mut entry = trim_text(raw_entries[index]);
+        let bound_index = index_of(entry, ":");
+        if bound_index >= 0 {
+            entry = trim_text(substring(entry, 0, bound_index));
+        }
+        if entry.length > 0 { names.push(entry); }
+        index += 1;
+    }
+    return names;
+}
+
 fn parse_enum_definition(lines: string[], start_index: int) -> EnumParseResult {
     let mut diagnostics: string[] = [];
     let header = trim_text(lines[start_index]);
     let name_text = trim_text(strip_prefix(header, ".enum "));
+    // Capture declared type parameters (e.g. `<T, E>`) from the full header
+    // BEFORE any truncation. The generic clause `<T, E>` contains an internal
+    // space, so the space-split below would otherwise sever it. These names
+    // drive per-instantiation payload substitution in the LLVM layer (#830);
+    // monomorphic enums have no clause, so this is `[]` and downstream
+    // substitution is a no-op.
+    let enum_type_parameters = parse_enum_header_type_parameters(name_text);
     let mut enum_name: string = name_text;
     let space_index = index_of(enum_name, " ");
     if space_index >= 0 {
@@ -544,6 +580,7 @@ fn parse_enum_definition(lines: string[], start_index: int) -> EnumParseResult {
             return EnumParseResult {
                 definition: NativeEnum {
                     name: enum_name,
+                    type_parameters: enum_type_parameters,
                     variants: variants,
                     layout: enum_layout_value
                 },
@@ -699,6 +736,7 @@ fn parse_enum_definition(lines: string[], start_index: int) -> EnumParseResult {
     return EnumParseResult {
         definition: NativeEnum {
             name: enum_name,
+            type_parameters: enum_type_parameters,
             variants: variants,
             layout: enum_layout_value
         },

--- a/compiler/src/native_ir_utils_parse.sfn
+++ b/compiler/src/native_ir_utils_parse.sfn
@@ -928,6 +928,11 @@ fn split_parameter_entries(body: string) -> string[] {
         if ch == "(" { _if383 = true; }
         if ch == "[" { _if383 = true; }
         if ch == "{" { _if383 = true; }
+        // `<` opens a generic argument list (e.g. `Foo<i64, i64>`); without
+        // tracking it, the comma inside a multi-arg instantiation would be
+        // mistaken for a parameter separator, splitting one param into two
+        // and truncating its type annotation (#830).
+        if ch == "<" { _if383 = true; }
         if _if383 {
             depth += 1;
             current = current + ch;
@@ -939,6 +944,7 @@ fn split_parameter_entries(body: string) -> string[] {
         if ch == ")" { _if384 = true; }
         if ch == "]" { _if384 = true; }
         if ch == "}" { _if384 = true; }
+        if ch == ">" { _if384 = true; }
         if _if384 {
             if depth > 0 { depth -= 1; }
             current = current + ch;

--- a/compiler/src/native_ir_utils_parse.sfn
+++ b/compiler/src/native_ir_utils_parse.sfn
@@ -945,6 +945,12 @@ fn split_parameter_entries(body: string) -> string[] {
         if ch == "]" { _if384 = true; }
         if ch == "}" { _if384 = true; }
         if ch == ">" { _if384 = true; }
+        // The `depth > 0` guard makes a bare `>` (e.g. from `->` in a
+        // `fn(int) -> int` param type at depth 0) a harmless no-op. A `->`
+        // nested inside a generic argument (`Map<string, fn() -> int>`)
+        // decrements one level early, but the structure's own trailing `>`
+        // then fails to decrement at depth 0 — the two errors cancel, so the
+        // top-level comma split stays correct. Keep the guard.
         if _if384 {
             if depth > 0 { depth -= 1; }
             current = current + ch;

--- a/compiler/tests/unit/result_enum_lowering_test.sfn
+++ b/compiler/tests/unit/result_enum_lowering_test.sfn
@@ -1,0 +1,47 @@
+// Per-instantiation payload typing for generic payload enums (#830).
+//
+// Declares a generic payload enum `Foo<T, E>` LOCALLY (not via the prelude —
+// prelude `Result` is gated on a seed bump, #831/#832) and exercises by-value
+// payload reads through `match`. Before #830, a generic payload field
+// type-erased to a bare `%T` ("loading unsized types is not allowed" rejected
+// the IR) and the construction silently dropped the payload store. After #830
+// the match arm and the constructor both resolve the payload to the concrete
+// instantiation type and read/write it by value.
+//
+// NOTE: values are constructed inline as call arguments rather than via
+// `let x: Foo<int, int> = ...` because `sfn fmt` currently mangles a generic
+// type annotation in let-binding position (`Foo<int, int> =` -> `Foo<int,
+// int >=`). The inline form is fmt-safe and exercises the same lowering.
+enum Foo < T,
+E > {
+    Ok { value: T },
+    Err { error: E }
+}
+
+// `Foo<int, int>` — by-value i64 payload in both arms.
+fn unwrap_or(f: Foo < int, int >, fallback: int) -> int {
+    match f {
+        Foo.Ok { value } => { return value; },
+        Foo.Err { error } => { return fallback + error; }
+    }
+}
+
+// `Foo<string, int>` — a DISTINCT instantiation in the same module. The `Ok`
+// payload is a string, the `Err` payload an i64.
+fn ok_len_or(f: Foo < string, int >, fallback: int) -> int {
+    match f {
+        Foo.Ok { value } => { return value.length; },
+        Foo.Err { error } => { return fallback + error; }
+    }
+}
+
+test "result_enum: by-value int payload read" {
+    assert unwrap_or(Foo.Ok { value: 42 }, 0) == 42;
+    assert unwrap_or(Foo.Err { error: 7 }, 100) == 107;
+}
+
+test "result_enum: distinct instantiations coexist in one module" {
+    assert ok_len_or(Foo.Ok { value: "hello" }, -1) == 5;
+    assert ok_len_or(Foo.Err { error: 3 }, 10) == 13;
+    assert unwrap_or(Foo.Ok { value: 9 }, 0) == 9;
+}

--- a/docs/status.md
+++ b/docs/status.md
@@ -636,7 +636,7 @@ feature availability.
 | `async fn` | Parsed | `await` is **not** parsed; async is structural only |
 | Structs | Shipped | Including generic params, `implements` clause |
 | Interfaces | Shipped | Trait-style method signatures |
-| Enums / ADTs | Shipped | Variants with payloads |
+| Enums / ADTs | Shipped | Variants with payloads. Generic payload enums (`enum Foo<T, E> { Ok { value: T } }`) resolve payload field types per instantiation at construction + `match` sites (#830) — by-value reads/writes of pointer-width payloads (`int`, `string`, boxed user types). Distinct per-instantiation layout *sizes* (e.g. a >8-byte by-value payload) are not yet emitted; the shared opaque-payload blob is sized from the pointer-width erased layout |
 | Type aliases | Shipped | Including generic params |
 | `if`/`else` | Shipped | |
 | `for` loops | Shipped | |


### PR DESCRIPTION
## Summary
- Generic payload enums (`enum Foo<T, E> { Ok { value: T } }`) now resolve payload field types **per instantiation** at both `match` sites and the enum constructor. Previously a generic payload type-erased to the bare `%T`: match arms emitted `load %T` (rejected as an unsized load) and the constructor silently dropped the payload store, leaving the field uninitialized.
- Fixes a latent parser bug: `split_parameter_entries` ignored `<>` nesting, so a multi-arg generic parameter (`f: Foo<i64, i64>`) was comma-split into a truncated annotation **plus a phantom parameter**.
- New paths are gated on `type_parameters.length > 0` / a generic field, so **monomorphic enums are byte-for-byte unchanged**.

Closes #830

## Acceptance Criteria
- [x] A standalone `.sfn` declaring `enum Foo<T, E> { Ok { value: T }, Err { error: E } }` and matching a `Foo<i64,…>` reads `value` as a by-value `i64`, not a loaded `i8*` (verified in IR: `load i64` replaces `load %T`)
- [x] `Foo<int, int>` and `Foo<string, int>` coexist correctly in the same module (new test, second case)
- [x] No regression on monomorphic enum tests (`enum_mixed_field_types_test`, `enum_match_struct_test`, `enum_complex_test`, `enum_state_machine_test` — all pass)
- [x] New test `result_enum_lowering_test.sfn` compiles and runs (declares `Foo<…>` locally, **not** via prelude)
- [x] `make compile` self-hosts (the generic enum is in the test, not compiler source)
- [x] `make test` passes

## Design note (please read)
This implements per-instantiation **payload typing** over the backend's existing **shared opaque-payload `%Foo` layout**, rather than emitting distinct `%"Foo<…>"` named types. The match side derives the concrete payload type from the subject's declared source annotation; the construction side derives it from the lowered value operand (narrowing a fat `{i8*, i64}` string to its `i8*` data pointer). The two agree (`int`→`i64`, `string`→`i8*`).

This is correct for **pointer-width payloads** (`int`, `string`, boxed user types) — which covers prelude `Result<T, E>`'s needs. It does **not** yet emit distinct per-instantiation layout *sizes*: a generic field bound to a by-value type wider than 8 bytes would not get a larger payload slot. That refinement (true monomorphized layouts with mangled type names) is deferred; the de-erasure that unblocks the R.2 → #832 chain is delivered here.

## ⚠️ Discovered blocker for #832 (follow-up filed)
`sfn fmt` corrupts generic type annotations in **let-binding position**: `let r: Result<int, Error> = …` is reformatted to `Result<int, Error >= …` (the `> =` adjacency collapses into `>=`), producing semantically broken code. No existing compiler source uses `let x: Generic<Concrete> = …`, so it was never hit. This blocks the *natural* `Result<T, E>` annotation syntax #832 will need. The new test sidesteps it by constructing values inline as call arguments (fmt-safe, `fmt --check` clean). A separate follow-up issue tracks the fmt fix.

## Verification
```bash
ulimit -v 8388608 && make compile          # self-hosts ✓
ulimit -v 8388608 && build/native/sailfin test compiler/tests/unit/result_enum_lowering_test.sfn   # PASS (2/2)
# full suite: unit 111/111, integration 28/28, e2e 4/4, capsules 18/18, e2e-sh 81/81
# sfn fmt --check clean on all touched .sfn files
```

## Files Changed
- `native_ir.sfn`, `native_ir_parser_defs.sfn`, `native_ir_api.sfn` — `NativeEnum.type_parameters` + header capture
- `native_ir_utils_parse.sfn` — `<>`-aware `split_parameter_entries`
- `llvm/types.sfn`, `llvm/type_context.sfn`, `llvm/imports.sfn`, `llvm/lowering/lowering_phase_types.sfn` — `EnumTypeInfo.type_parameters`
- `llvm/type_mapping.sfn` — instantiation parse/substitute helpers
- `llvm/lowering/instructions_match.sfn` + `instructions_match_condition.sfn` — per-instantiation match field typing
- `llvm/expression_lowering/native/core_literals_lowering.sfn` — per-instantiation constructor payload store
- `compiler/tests/unit/result_enum_lowering_test.sfn` (new), `docs/status.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017izHixy82BCdpmkx3upD7e)_