### PR TITLE
refactor(runtime): migrate errno.sfn onto the host-aware errno-location sentinel

### DIFF
--- a/compiler/tests/e2e/test_errno_reader.sh
+++ b/compiler/tests/e2e/test_errno_reader.sh
@@ -1,22 +1,31 @@
 #!/usr/bin/env bash
-# End-to-end test for the Sailfin-native errno() reader (#876, epic #763).
+# End-to-end test for the Sailfin-native errno() reader (#876, #893,
+# epic #763).
 #
-# `runtime/sfn/platform/errno.sfn` declares `__errno_location() -> * i32`
-# (glibc's thread-local errno locator) and an `errno() -> i32` helper that
-# dereferences the returned pointer via the `sailfin_intrinsic_pointer_read_i32`
-# registry sentinel (#875). The sentinel lowers directly to an LLVM `load i32`
-# — there is no C symbol behind it. This test pins that shape against the
-# *real shipped module* (not a scratch fixture):
+# `runtime/sfn/platform/errno.sfn` defines `errno() -> i32` as a
+# *host-portable* reader: it calls the `sailfin_intrinsic_errno_location`
+# registry sentinel (#887/#890) to obtain the thread-local errno-slot
+# pointer, then dereferences it via the `sailfin_intrinsic_pointer_read_i32`
+# sentinel (#875). Neither sentinel is a C symbol — the locator folds into
+# the host's concrete locator (`@__errno_location` glibc / `@__error`
+# Darwin / `@_errno` Windows-mingw) at emit time, and the pointer-read
+# folds into a bare `load i32`.
 #
-#   1. typecheck  — `sfn check errno.sfn` reports `ok`. The bare intrinsic
-#                   call resolves because its name is a runtime-helper call
-#                   name seeded into the E0420 resolution scope; the extern
-#                   passes the C-ABI accept-list (E0801–E0805).
-#   2. locator    — emitted IR declares + calls `i32* @__errno_location()`.
-#   3. load i32   — emitted IR contains `load i32, i32* %…` (the deref).
-#   4. no call    — no `call` instruction targets the pointer-read sentinel.
-#   5. no declare — no `declare …@sailfin_intrinsic_pointer_read_i32` line,
-#                   so the sentinel never links to a nonexistent symbol.
+# This test pins that shape against the *real shipped module* (not a
+# scratch fixture). It is host-independent: it forces each platform path
+# via a `uname` shim on PATH (Linux/Darwin) and the `SAILFIN_TARGET_OS`
+# cross-compile override (Windows), so it asserts the same thing whether
+# CI runs it on Linux or macOS hardware. For each target it pins:
+#
+#   1. typecheck    — `sfn check errno.sfn` reports `ok`. The bare
+#                     intrinsic calls resolve because their names are
+#                     runtime-helper call names seeded into the E0420
+#                     resolution scope; no extern is needed.
+#   2. locator call — emitted IR contains `call i32* @<sym>()`.
+#   3. load i32     — emitted IR contains `load i32, i32* %…` (the deref).
+#   4. no other sym — the other platforms' locators do NOT appear.
+#   5. no sentinel  — no `call`/`declare` targets either sentinel name,
+#                     so neither links to a nonexistent symbol.
 
 set -euo pipefail
 
@@ -29,7 +38,24 @@ FAIL=0
 
 SCRATCH="$(mktemp -d -t sfn-errno-XXXXXX)"
 trap 'rm -rf "$SCRATCH"' EXIT
-LL="$SCRATCH/errno.ll"
+
+LL_LINUX="$SCRATCH/errno_linux.ll"
+LL_DARWIN="$SCRATCH/errno_darwin.ll"
+LL_WINDOWS="$SCRATCH/errno_windows.ll"
+
+# A `uname` shim that reports the requested OS for `-s` and delegates
+# every other invocation to the real binary, so the compiler's `uname -s`
+# probe resolves to our forced platform without disturbing anything else.
+make_uname_shim() {
+    local dir="$1" os="$2"
+    mkdir -p "$dir"
+    cat > "$dir/uname" <<SHIM
+#!/bin/sh
+if [ "\$1" = "-s" ]; then echo "$os"; exit 0; fi
+exec /usr/bin/uname "\$@"
+SHIM
+    chmod +x "$dir/uname"
+}
 
 run_test() {
     local name="$1"
@@ -53,58 +79,138 @@ test_check_clean() {
     return 0
 }
 
-test_emit() {
-    local log="$SCRATCH/emit.log"
-    if ! "$BINARY" emit -o "$LL" llvm "$ERRNO_SFN" > "$log" 2>&1; then
-        echo "[test]   sfn emit llvm failed on errno.sfn:"
+# Emit IR for the real errno.sfn with `uname -s` forced to $1
+# ("Linux" | "Darwin"); writes to $2.
+emit_for_os() {
+    local os="$1" out="$2"
+    local shimdir="$SCRATCH/shim-$os"
+    local log="$SCRATCH/emit-$os.log"
+    make_uname_shim "$shimdir" "$os"
+    if ! PATH="$shimdir:$PATH" "$BINARY" emit -o "$out" llvm "$ERRNO_SFN" > "$log" 2>&1; then
+        echo "[test]   sfn emit llvm failed (uname=$os):"
         cat "$log"
         return 1
     fi
     return 0
 }
 
-test_locator_call() {
-    if ! grep -qE 'call i32\* @__errno_location\(\)' "$LL"; then
-        echo "[test]   missing 'call i32* @__errno_location()' in emitted IR"
+# Emit IR with the cross-compile target override `SAILFIN_TARGET_OS`
+# set to $1; writes to $2. The override names the *target* OS and takes
+# precedence over the `uname -s` host probe (the `make ci-cross-windows`
+# path: a Linux host producing a Windows binary).
+emit_for_target_os() {
+    local target_os="$1" out="$2"
+    local log="$SCRATCH/emit-target-$target_os.log"
+    if ! SAILFIN_TARGET_OS="$target_os" "$BINARY" emit -o "$out" llvm "$ERRNO_SFN" > "$log" 2>&1; then
+        echo "[test]   sfn emit llvm failed (SAILFIN_TARGET_OS=$target_os):"
+        cat "$log"
         return 1
     fi
     return 0
 }
 
-test_load_i32() {
-    if ! grep -qE 'load i32, i32\* %' "$LL"; then
-        echo "[test]   missing 'load i32, i32* %…' (the errno deref) in emitted IR"
+test_emit_linux() { emit_for_os "Linux" "$LL_LINUX"; }
+test_emit_darwin() { emit_for_os "Darwin" "$LL_DARWIN"; }
+test_emit_windows() { emit_for_target_os "Windows" "$LL_WINDOWS"; }
+
+# --- Linux path: @__errno_location, not @__error / @_errno ---
+
+test_linux_call() {
+    if ! grep -qE 'call i32\* @__errno_location\(\)' "$LL_LINUX"; then
+        echo "[test]   missing 'call i32* @__errno_location()' on the Linux path"
         return 1
     fi
     return 0
 }
 
-test_no_call_sentinel() {
-    if grep -qE 'call .*@sailfin_intrinsic_pointer_read_i32' "$LL"; then
-        echo "[test]   pointer-read sentinel was emitted as a 'call' rather than a 'load':"
-        grep -nE 'call .*@sailfin_intrinsic_pointer_read_i32' "$LL"
+test_linux_load() {
+    if ! grep -qE 'load i32, i32\* %' "$LL_LINUX"; then
+        echo "[test]   missing 'load i32, i32* %…' (errno deref) on the Linux path"
         return 1
     fi
     return 0
 }
 
-test_no_declare_sentinel() {
+test_linux_no_other_symbol() {
+    # Anchor on the trailing `(` rather than `\b`: BSD/macOS `grep -E`
+    # treats `\b` as a literal backspace, not a word boundary, and this
+    # test runs on the macos-arm64 CI leg.
+    if grep -qE '@__error\(|@_errno\(' "$LL_LINUX"; then
+        echo "[test]   unexpected non-Linux locator in Linux-path IR:"
+        grep -nE '@__error\(|@_errno\(' "$LL_LINUX"
+        return 1
+    fi
+    return 0
+}
+
+# --- Darwin path: @__error, not @__errno_location / @_errno ---
+
+test_darwin_call() {
+    if ! grep -qE 'call i32\* @__error\(\)' "$LL_DARWIN"; then
+        echo "[test]   missing 'call i32* @__error()' on the Darwin path"
+        return 1
+    fi
+    return 0
+}
+
+test_darwin_no_other_symbol() {
+    if grep -qE '@__errno_location\(|@_errno\(' "$LL_DARWIN"; then
+        echo "[test]   unexpected non-Darwin locator in Darwin-path IR:"
+        grep -nE '@__errno_location\(|@_errno\(' "$LL_DARWIN"
+        return 1
+    fi
+    return 0
+}
+
+# --- Windows (cross-compile target override): @_errno, not the glibc
+#     or Darwin spellings. mingw-w64 exposes the errno slot as
+#     `int *_errno(void)`; the Linux-host cross-build must emit that. ---
+
+test_windows_call() {
+    if ! grep -qE 'call i32\* @_errno\(\)' "$LL_WINDOWS"; then
+        echo "[test]   missing 'call i32* @_errno()' on the Windows-target path"
+        return 1
+    fi
+    return 0
+}
+
+test_windows_no_other_symbol() {
+    if grep -qE '@__errno_location\(|@__error\(' "$LL_WINDOWS"; then
+        echo "[test]   unexpected non-Windows locator in Windows-target IR:"
+        grep -nE '@__errno_location\(|@__error\(' "$LL_WINDOWS"
+        return 1
+    fi
+    return 0
+}
+
+# --- Neither sentinel name may ever appear as a real symbol ---
+
+test_no_sentinel_leak() {
     local n
-    n="$(grep -cE 'declare .*@sailfin_intrinsic_pointer_read_i32' "$LL" || true)"
+    n="$(grep -cE '(call|declare) .*@sailfin_intrinsic_(errno_location|pointer_read_i32)' \
+            "$LL_LINUX" "$LL_DARWIN" "$LL_WINDOWS" 2>/dev/null \
+         | awk -F: '{s+=$2} END {print s+0}')"
     if [ "$n" != "0" ]; then
-        echo "[test]   expected 0 'declare …@sailfin_intrinsic_pointer_read_i32' lines, found $n:"
-        grep -nE 'declare .*@sailfin_intrinsic_pointer_read_i32' "$LL"
+        echo "[test]   expected 0 call/declare of a sentinel symbol, found $n:"
+        grep -nE '(call|declare) .*@sailfin_intrinsic_(errno_location|pointer_read_i32)' \
+            "$LL_LINUX" "$LL_DARWIN" "$LL_WINDOWS" || true
         return 1
     fi
     return 0
 }
 
 run_test "sfn check passes on runtime/sfn/platform/errno.sfn" test_check_clean
-run_test "sfn emit llvm produces IR" test_emit
-run_test "errno() calls i32* @__errno_location()" test_locator_call
-run_test "the deref lowers to 'load i32'" test_load_i32
-run_test "pointer-read sentinel is not emitted as 'call'" test_no_call_sentinel
-run_test "no 'declare' for the pointer-read sentinel" test_no_declare_sentinel
+run_test "sfn emit llvm produces IR (uname=Linux)" test_emit_linux
+run_test "sfn emit llvm produces IR (uname=Darwin)" test_emit_darwin
+run_test "sfn emit llvm produces IR (SAILFIN_TARGET_OS=Windows)" test_emit_windows
+run_test "Linux path calls @__errno_location" test_linux_call
+run_test "Linux path derefs via 'load i32'" test_linux_load
+run_test "Linux path omits @__error and @_errno" test_linux_no_other_symbol
+run_test "Darwin path calls @__error" test_darwin_call
+run_test "Darwin path omits @__errno_location and @_errno" test_darwin_no_other_symbol
+run_test "Windows-target path calls @_errno" test_windows_call
+run_test "Windows-target path omits @__errno_location and @__error" test_windows_no_other_symbol
+run_test "neither sentinel symbol is emitted as call/declare" test_no_sentinel_leak
 
 echo "[summary] $PASS passed, $FAIL failed"
 if [ "$FAIL" -gt 0 ]; then

--- a/compiler/tests/e2e/test_errno_reader.sh
+++ b/compiler/tests/e2e/test_errno_reader.sh
@@ -186,10 +186,13 @@ test_windows_no_other_symbol() {
 # --- Neither sentinel name may ever appear as a real symbol ---
 
 test_no_sentinel_leak() {
+    # Count matches directly with awk rather than `grep -c | awk`:
+    # `grep -c` exits 1 when there are zero matches (the expected pass
+    # case), which under `pipefail` (and especially `inherit_errexit`)
+    # can abort the script before the count is read. awk always exits 0.
     local n
-    n="$(grep -cE '(call|declare) .*@sailfin_intrinsic_(errno_location|pointer_read_i32)' \
-            "$LL_LINUX" "$LL_DARWIN" "$LL_WINDOWS" 2>/dev/null \
-         | awk -F: '{s+=$2} END {print s+0}')"
+    n="$(awk '/(call|declare) .*@sailfin_intrinsic_(errno_location|pointer_read_i32)/ { c++ } END { print c + 0 }' \
+            "$LL_LINUX" "$LL_DARWIN" "$LL_WINDOWS" 2>/dev/null)"
     if [ "$n" != "0" ]; then
         echo "[test]   expected 0 call/declare of a sentinel symbol, found $n:"
         grep -nE '(call|declare) .*@sailfin_intrinsic_(errno_location|pointer_read_i32)' \

--- a/runtime/sfn/clock.sfn
+++ b/runtime/sfn/clock.sfn
@@ -40,7 +40,17 @@
 // dereferenced by the `sailfin_intrinsic_pointer_read_i32` load
 // (#875). This is what lets `clock.sfn` stay in `sfn-sources` and
 // link on both Linux and macOS without hardcoding a glibc-only
-// symbol. `EINTR == 4` on both Linux and macOS; a platform-constant
+// symbol.
+//
+// This is the same sentinel chain that `platform/errno.sfn::errno()`
+// wraps (#893); `sfn_sleep` keeps it inline rather than importing
+// `errno()` because the runtime `sfn-source` emit path resolves
+// imported `extern` signatures (e.g. `posix.sfn`'s `nanosleep`) but
+// not imported *defined* functions, so importing `errno()` here fails
+// lowering with "callee signature is not known". The DRY re-point is
+// deferred until that cross-module resolution lands (epic #763).
+//
+// `EINTR == 4` on both Linux and macOS; a platform-constant
 // home for that value is a follow-up. The loop re-passes the same
 // `req` each iteration — that slightly over-sleeps after a signal
 // (we lose the consumed portion) but preserves the wall-clock-≥-

--- a/runtime/sfn/platform/errno.sfn
+++ b/runtime/sfn/platform/errno.sfn
@@ -1,49 +1,60 @@
 // runtime/sfn/platform/errno.sfn
 //
-// Pure-Sailfin `errno` reader for Linux/glibc. Companion to
+// Pure-Sailfin, host-portable `errno` reader. Companion to
 // `runtime/sfn/platform/posix.sfn` and `libc.sfn`; see `libc.sfn`
 // for the long-form extern rationale (type discipline, `unsafe`
 // policy, formatter pointer spelling, opaque-pointee rule).
 //
-// glibc exposes the thread-local `errno` slot through a function
-// `int *__errno_location(void)` rather than a global symbol, so a
-// precise read is two steps: call the locator to obtain the
-// `int *`, then dereference it. The dereference uses the
-// `sailfin_intrinsic_pointer_read_i32` registry sentinel (#875),
-// which lowers directly to an LLVM `load i32` — there is no C
-// symbol behind it. The locator's `* i32` result is already an
-// `i32*`, so the load needs no leading bitcast.
+// POSIX exposes the thread-local `errno` slot through a *function*
+// returning `int *` rather than a global symbol, but the symbol's
+// spelling is host-specific: `__errno_location` on glibc, `__error`
+// on Darwin, and `_errno` on Windows/mingw. Rather than hardcode any
+// one spelling behind an `extern`, this reader calls the host-aware
+// `sailfin_intrinsic_errno_location` registry sentinel (#887, Windows
+// extension #890): it lowers to the correct concrete locator at emit
+// time, chosen from `uname -s` (or the `SAILFIN_TARGET_OS` cross-
+// compile override). A precise read is therefore two steps: call the
+// sentinel to obtain the `int *`, then dereference it. The dereference
+// uses the `sailfin_intrinsic_pointer_read_i32` registry sentinel
+// (#875), which lowers directly to an LLVM `load i32` — there is no C
+// symbol behind it. The locator's `i32*` result is already an `i32*`,
+// so the load needs no leading bitcast.
 //
-// Type discipline: `__errno_location() -> * i32` obeys the v0
-// C-ABI accept-list enforced by `check_extern_signature` in
-// `compiler/src/typecheck_types.sfn` (E0801–E0805) — `i32` is an
-// extern primitive, so `* i32` is an accepted pointer return.
+// Neither sentinel emits as a `call`/`declare` to its own name: the
+// locator sentinel folds into the concrete per-target locator symbol,
+// and the pointer-read sentinel folds into a bare `load i32`. See
+// `compiler/tests/e2e/test_errno_locator_platform.sh` for the pinned
+// per-target IR shape and `test_errno_reader.sh` for this module's.
 //
-// Scope (epic #763, #876): this is the narrow Linux x86_64 reader.
-// macOS arm64 spells the locator `__error`; that platform-
-// conditional split is deferred (tracked under #763). The EINTR
-// retry rewrite and the `clock_gettime` field reader that also
-// consume pointer-read intrinsics are separate issues.
+// Scope (epic #763, #876, #893): because the reader no longer hardcodes
+// a glibc-only symbol, it is host-portable and no longer a misleading
+// Linux-only demonstrator. It is the canonical `errno()` the syscall
+// adapters (#878 `clock_gettime`, `waitpid`/`posix_spawnp` consumers
+// under #763) should reuse once cross-module import of a *defined*
+// runtime function is supported in the link path — see Linkage below.
 //
-// Status: typecheck + emit smoke module. Deliberately NOT listed in
-// `runtime/native/capsule.toml` `sfn-sources` — exactly like its
-// siblings `posix.sfn` / `libc.sfn` / `net.sfn` / `pthread.sfn`,
-// which are also not yet linked. `sfn-sources` registration forces a
-// link on every target, and `__errno_location` is glibc-only: on
-// macOS arm64 (Darwin uses `__error`) the link fails with an
-// undefined `___errno_location`. The module gets wired into
-// `sfn-sources` once a consumer exists *and* the macOS `__error`
-// platform split lands (both deferred under #763). Until then this
-// file proves the reader type-checks and lowers to a `load i32` on
-// Linux x86_64 (the epic's stated gate); the e2e shape test is
+// Linkage (#893 decision): this file stays OUT of
+// `runtime/native/capsule.toml` `sfn-sources`. `sfn-sources`
+// registration forces a standalone link on every target for a module
+// with no entry point of its own; nothing requires that yet. The
+// natural DRY consumer, `clock.sfn::sfn_sleep`, therefore keeps
+// inlining the sentinel chain rather than importing `errno()`: the
+// runtime `sfn-source` emit path (`_compile_runtime_sfn_sources` in
+// `cli_main.sfn`) resolves imported *extern* signatures (e.g.
+// `posix.sfn`'s `nanosleep`) but not imported *defined* functions, so
+// importing `errno()` into an `sfn-source` fails lowering with "callee
+// signature is not known to the compiler". Once that cross-module
+// resolution lands, adapters import `errno()` from here instead of
+// re-inlining `sailfin_intrinsic_pointer_read_i32(
+// sailfin_intrinsic_errno_location())`. Until then this file proves the
+// reader type-checks and lowers to the correct per-target locator +
+// `load i32`; the e2e shape test is
 // `compiler/tests/e2e/test_errno_reader.sh`.
-extern fn __errno_location() -> * i32;
-
 // Read the calling thread's current `errno` value. Pure: a raw
 // memory load is not an `io`/`net`/`clock` capability — the effect
 // lives on the upstream syscall that set `errno`, not on observing
 // it here (matches the empty-effects rule the pointer-read
 // intrinsic ships with).
 fn errno() -> i32 {
-    return sailfin_intrinsic_pointer_read_i32(__errno_location());
+    return sailfin_intrinsic_pointer_read_i32(sailfin_intrinsic_errno_location());
 }


### PR DESCRIPTION
## Summary
- Rewrite `runtime/sfn/platform/errno.sfn::errno()` to read through the host-aware `sailfin_intrinsic_errno_location` sentinel (#887, Windows ext. #890), dropping the glibc-only `__errno_location` extern. It now lowers to the correct per-target locator (`@__errno_location` glibc / `@__error` Darwin / `@_errno` mingw) at emit time — portable, no longer a misleading Linux-only demonstrator.
- Rewrite `compiler/tests/e2e/test_errno_reader.sh` to assert the host-portable shape against the **real shipped module** across all three targets (uname shim for Linux/Darwin, `SAILFIN_TARGET_OS` override for Windows), mirroring `test_errno_locator_platform.sh`.
- `runtime/sfn/clock.sfn`: behavior unchanged (header note added documenting the linkage decision).

Closes #893

## Linkage decision (option a)
The issue offered two directions: (a) keep `errno.sfn` out of `sfn-sources`, or (b) repoint `clock.sfn::sfn_sleep` to import `errno()` for DRY. I implemented (a). Attempting (b) revealed that the runtime `sfn-source` emit path (`_compile_runtime_sfn_sources`) resolves imported `extern` signatures (e.g. `posix.sfn`'s `nanosleep`) but **not** imported *defined* functions — importing `errno()` into an `sfn-source` fails lowering with `cannot resolve return type for call to errno — callee signature is not known to the compiler`. The DRY re-point is a compiler import-resolution feature, out of scope for this size-S refactor; it's deferred under epic #763 and the rationale is documented in both `errno.sfn` and `clock.sfn` headers. `errno()` is portable and importable *in principle* the moment that resolution lands.

## Acceptance Criteria
- [x] `errno.sfn::errno()` reads via `sailfin_intrinsic_errno_location()`, no hardcoded `__errno_location` extern.
- [x] Emitted IR shows the correct locator per target (`@__errno_location` Linux, `@__error` Darwin, `@_errno` Windows via `SAILFIN_TARGET_OS`).
- [x] `clock.sfn` left inlining the sentinel (option a) → `test_runtime_clock_skeleton.sh` (incl. #877 errno-check) still passes; clock.sfn still links on Linux/macOS/Windows.
- [x] `make compile && make check` clean (exit 0).
- [x] `sfn fmt --check` clean on touched `.sfn` files.

## Verification
```bash
ulimit -v 8388608 && make compile && make check          # exit 0
ulimit -v 8388608 && bash compiler/tests/e2e/test_errno_reader.sh build/native/sailfin
#   → 12 passed, 0 failed  (Linux/Darwin/Windows locator + load-i32 + no sentinel leak)
ulimit -v 8388608 && bash compiler/tests/e2e/test_runtime_clock_skeleton.sh build/native/sailfin
#   → 7 passed, 0 failed  (incl. "sfn_sleep reads errno and resumes only on EINTR (#877)")
```

## Files Changed
- `runtime/sfn/platform/errno.sfn` — sentinel-based rewrite + portable header + linkage rationale.
- `compiler/tests/e2e/test_errno_reader.sh` — per-target host-portable shape assertions.
- `runtime/sfn/clock.sfn` — header note only (behavior unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01N51ocuekU6sy6aVcvZfqML)_