### PR TITLE
fix(driver): propagate lowering [fatal] from void-call statements to exit code

### DIFF
--- a/capsules/sfn/json/src/mod.sfn
+++ b/capsules/sfn/json/src/mod.sfn
@@ -239,16 +239,16 @@ fn _parse_number(text: string, start: int) -> _ParseResult {
                 let mut d: int = 0;
                 loop {
                     if d >= decimal_place { break; }
-                    divisor = divisor * 10;
+                    divisor = divisor * 10.0;
                     d += 1;
                 }
-                value = value + digit / divisor;
+                value = value + (digit as float) / divisor;
                 decimal_place += 1;
-            } else { value = value * 10 + digit; }
+            } else { value = value * 10.0 + (digit as float); }
         }
         i += 1;
     }
-    if negative { value = 0 - value; }
+    if negative { value = 0.0 - value; }
     return _parse_result(number_val(value), p);
 }
 

--- a/capsules/sfn/toml/src/mod.sfn
+++ b/capsules/sfn/toml/src/mod.sfn
@@ -323,16 +323,16 @@ fn _parse_number(value: string) -> TomlValue {
                 let mut d: int = 0;
                 loop {
                     if d >= decimal_place { break; }
-                    divisor = divisor * 10;
+                    divisor = divisor * 10.0;
                     d += 1;
                 }
-                result = result + digit / divisor;
+                result = result + (digit as float) / divisor;
                 decimal_place += 1;
-            } else { result = result * 10 + digit; }
+            } else { result = result * 10.0 + (digit as float); }
         }
         j += 1;
     }
-    if negative { result = 0 - result; }
+    if negative { result = 0.0 - result; }
 
     if has_dot { return float_val(result); }
     return integer_val(result);

--- a/compiler/src/llvm/expression_lowering/native/statement.sfn
+++ b/compiler/src/llvm/expression_lowering/native/statement.sfn
@@ -346,6 +346,17 @@ fn lower_expression_statement(function_name: string, instruction: NativeInstruct
     let consumption = ownership_analysis.consumption;
 
     let _lowered = lower_expression(expression, current_bindings, current_locals, current_temp, current_lines, functions, context, "");
+    // Issue #631: a bare expression statement (e.g. a void-returning call
+    // like `spawn(...)`) can surface a `[fatal]` lowering diagnostic when
+    // the callee's return type cannot be resolved. Collect those into the
+    // statement result so the caller (and the emit-level fatal gate) sees
+    // them; otherwise the build silently continues and exits 0.
+    let mut _ci_expr_stmt: int = 0;
+    loop {
+        if _ci_expr_stmt >= _lowered.diagnostics.length { break; }
+        diagnostics.push(_lowered.diagnostics[_ci_expr_stmt]);
+        _ci_expr_stmt += 1;
+    }
     current_temp = recover_temp_from_lines(current_lines, current_temp);
     if consumption != null {
         if consumption.kind == "local" {

--- a/compiler/src/llvm/lowering/instructions.sfn
+++ b/compiler/src/llvm/lowering/instructions.sfn
@@ -301,6 +301,13 @@ fn lower_instruction_range(function: NativeFunction, start_index: int, end: int,
                     current_temp = lowered.temp_index;
                     current_next_region = lowered.next_region_id;
                     current_mutations = extend_mutations(current_mutations, lowered.mutations);
+                    // Issue #631: collect the statement's diagnostics so a
+                    // `[fatal]` from a void-returning call (e.g. an unknown
+                    // helper with no resolvable return type) reaches the
+                    // emit-level `has_fatal_lowering_diagnostic` gate and
+                    // aborts the build. Previously this branch dropped them,
+                    // letting void-call fatals slip past with rc=0.
+                    diagnostics = extend_string_array(diagnostics, lowered.diagnostics);
                     collected_string_constants = merge_string_constants(collected_string_constants, lowered.string_constants);
                 }
                 active_label = find_last_label(current_lines, active_label);

--- a/compiler/tests/e2e/test_sync_rejects_unimplemented_concurrency.sh
+++ b/compiler/tests/e2e/test_sync_rejects_unimplemented_concurrency.sh
@@ -61,20 +61,20 @@ run_test() {
 }
 
 # Run `sfn build` against the supplied source and confirm the
-# lowering diagnostic is emitted and names the offending symbol.
+# build fails closed: a non-zero exit code, no output binary on
+# disk, and a lowering diagnostic that names the offending symbol.
 # The build is invoked from a directory OUTSIDE the source tree
 # (we use the scratch dir as cwd) so the driver does not stumble
 # onto a workspace capsule and try to compile it instead.
 #
-# We deliberately do NOT assert a non-zero exit code or absence of
-# an output binary. Both hold for the value-returning cases
-# (`channel` / `parallel` — `sfn build` exits 1 and produces no
-# binary), but the void-returning `spawn` case stumbles past the
-# fatal diagnostic and still emits a (broken) binary with rc=0.
-# That divergence is a separate lowering / driver bug to file as
-# a follow-up; here we just verify the failure is *visible*
-# (grep-checkable on stdout+stderr), which is the explicit
-# acceptance criterion in #617.
+# Issue #631: this assertion is now strict for ALL callers,
+# including the void-returning `spawn` case. The void branch used
+# to drop its `[fatal]` lowering diagnostic before it reached the
+# emit-level fatal gate, so `sfn build` printed the fatal but still
+# wrote a (broken) binary and exited 0. The fix threads the
+# statement-level diagnostics through to `has_fatal_lowering_diagnostic`,
+# so the build now fails closed (rc != 0, no binary) just like the
+# value-returning cases.
 assert_build_rejects() {
     local label="$1"
     local source="$2"
@@ -85,8 +85,23 @@ assert_build_rejects() {
     local log_path="$SCRATCH/${label}.log"
     printf '%s\n' "$source" > "$src_path"
 
+    local rc=0
     ( cd "$SCRATCH" && "$BINARY" build -o "$out_path" "$src_path" ) \
-        > "$log_path" 2>&1 || true
+        > "$log_path" 2>&1 || rc=$?
+
+    if [ "$rc" -eq 0 ]; then
+        echo "[test]   build of ${label}.sfn exited 0 — expected non-zero (fail-closed)" >&2
+        echo "[test]   output:" >&2
+        sed 's/^/[test]     /' "$log_path" >&2
+        return 1
+    fi
+
+    if [ -e "$out_path" ]; then
+        echo "[test]   build of ${label}.sfn produced an output binary at ${out_path} — expected none" >&2
+        echo "[test]   output:" >&2
+        sed 's/^/[test]     /' "$log_path" >&2
+        return 1
+    fi
 
     if ! grep -q "cannot resolve" "$log_path"; then
         echo "[test]   diagnostic for ${label}.sfn did not mention 'cannot resolve'" >&2
@@ -97,6 +112,43 @@ assert_build_rejects() {
 
     if ! grep -q "\`${symbol}\`" "$log_path"; then
         echo "[test]   diagnostic for ${label}.sfn did not name '\`${symbol}\`'" >&2
+        echo "[test]   output:" >&2
+        sed 's/^/[test]     /' "$log_path" >&2
+        return 1
+    fi
+
+    return 0
+}
+
+# Generic fail-closed assertion: rc != 0 AND no output binary, with no
+# requirement on which pipeline stage produced the diagnostic. Used for
+# the bare-undefined-callee fixture below, which the type checker rejects
+# (E0420) before lowering ever runs — a different stage from the `spawn`
+# lowering path, but the headline contract (`sfn build` exits non-zero and
+# writes no binary) must hold uniformly regardless of where the failure
+# originates.
+assert_build_fails_closed() {
+    local label="$1"
+    local source="$2"
+
+    local src_path="$SCRATCH/${label}.sfn"
+    local out_path="$SCRATCH/${label}.out"
+    local log_path="$SCRATCH/${label}.log"
+    printf '%s\n' "$source" > "$src_path"
+
+    local rc=0
+    ( cd "$SCRATCH" && "$BINARY" build -o "$out_path" "$src_path" ) \
+        > "$log_path" 2>&1 || rc=$?
+
+    if [ "$rc" -eq 0 ]; then
+        echo "[test]   build of ${label}.sfn exited 0 — expected non-zero (fail-closed)" >&2
+        echo "[test]   output:" >&2
+        sed 's/^/[test]     /' "$log_path" >&2
+        return 1
+    fi
+
+    if [ -e "$out_path" ]; then
+        echo "[test]   build of ${label}.sfn produced an output binary at ${out_path} — expected none" >&2
         echo "[test]   output:" >&2
         sed 's/^/[test]     /' "$log_path" >&2
         return 1
@@ -157,11 +209,28 @@ test_spawn_via_prelude_name_rejected() {
         "spawn"
 }
 
+# Issue #631: pin the bare void-call statement shape directly, independent
+# of the `sfn/sync` surface. A statement that discards the result of an
+# unresolved call must fail closed (rc != 0, no binary). The `spawn` cases
+# above exercise the LLVM-lowering void path (the descriptor is gone but
+# the name type-checks); this fixture covers a wholly-undefined callee,
+# which the type checker rejects with E0420 before lowering. Both shapes
+# previously risked a false-green rc=0 on the void statement branch — the
+# fix that threads statement-level diagnostics to the fatal gate is what
+# guarantees the build now fails closed for the lowering case.
+test_unknown_void_helper_rejected() {
+    assert_build_fails_closed "unknown_void_helper_caller" \
+'fn main() ![io] {
+    unknown_void_helper();
+}'
+}
+
 run_test "sfn build rejects sfn/sync.channel import (#617)" test_channel_via_sfn_sync_rejected
 run_test "sfn build rejects sfn/sync.parallel import (#617)" test_parallel_via_sfn_sync_rejected
 run_test "sfn build rejects sfn/sync.spawn import (#617)" test_spawn_via_sfn_sync_rejected
 run_test "sfn build rejects bare prelude channel() (#617)" test_channel_via_prelude_name_rejected
 run_test "sfn build rejects bare prelude spawn() (#617)" test_spawn_via_prelude_name_rejected
+run_test "sfn build fails closed on unknown void helper (#631)" test_unknown_void_helper_rejected
 
 echo "[summary] $PASS passed, $FAIL failed"
 if [ "$FAIL" -gt 0 ]; then

--- a/compiler/tests/e2e/test_sync_rejects_unimplemented_concurrency.sh
+++ b/compiler/tests/e2e/test_sync_rejects_unimplemented_concurrency.sh
@@ -157,6 +157,56 @@ assert_build_fails_closed() {
     return 0
 }
 
+# `sfn emit llvm` shares the lowering pipeline with `sfn build`, so the
+# same void-call lowering `[fatal]` must abort it: rc != 0, no `.ll`
+# artifact, and the `cannot resolve` diagnostic naming the symbol.
+# `emit llvm` is a separate CLI surface with its own output path, so it
+# gets its own assertion rather than relying on the `build` coverage.
+assert_emit_llvm_rejects() {
+    local label="$1"
+    local source="$2"
+    local symbol="$3"
+
+    local src_path="$SCRATCH/${label}.sfn"
+    local out_path="$SCRATCH/${label}.ll"
+    local log_path="$SCRATCH/${label}.emitll.log"
+    printf '%s\n' "$source" > "$src_path"
+
+    local rc=0
+    ( cd "$SCRATCH" && "$BINARY" emit -o "$out_path" llvm "$src_path" ) \
+        > "$log_path" 2>&1 || rc=$?
+
+    if [ "$rc" -eq 0 ]; then
+        echo "[test]   emit llvm of ${label}.sfn exited 0 — expected non-zero (fail-closed)" >&2
+        echo "[test]   output:" >&2
+        sed 's/^/[test]     /' "$log_path" >&2
+        return 1
+    fi
+
+    if [ -e "$out_path" ]; then
+        echo "[test]   emit llvm of ${label}.sfn produced an .ll at ${out_path} — expected none" >&2
+        echo "[test]   output:" >&2
+        sed 's/^/[test]     /' "$log_path" >&2
+        return 1
+    fi
+
+    if ! grep -q "cannot resolve" "$log_path"; then
+        echo "[test]   emit llvm diagnostic for ${label}.sfn did not mention 'cannot resolve'" >&2
+        echo "[test]   output:" >&2
+        sed 's/^/[test]     /' "$log_path" >&2
+        return 1
+    fi
+
+    if ! grep -q "\`${symbol}\`" "$log_path"; then
+        echo "[test]   emit llvm diagnostic for ${label}.sfn did not name '\`${symbol}\`'" >&2
+        echo "[test]   output:" >&2
+        sed 's/^/[test]     /' "$log_path" >&2
+        return 1
+    fi
+
+    return 0
+}
+
 test_channel_via_sfn_sync_rejected() {
     assert_build_rejects "channel_import_caller" \
 'import { channel } from "sfn/sync";
@@ -225,12 +275,26 @@ test_unknown_void_helper_rejected() {
 }'
 }
 
+# Issue #631: `sfn emit llvm` must fail closed on the void-call lowering
+# fatal exactly like `sfn build`. The `spawn` case exercises the LLVM
+# lowering void path (type-checks, but the descriptor is gone), which is
+# precisely the surface the statement-level diagnostic propagation fix
+# guards — pre-fix this emitted the fatal yet still wrote an `.ll` at rc=0.
+test_emit_llvm_spawn_rejected() {
+    assert_emit_llvm_rejects "spawn_emit_llvm_caller" \
+'fn main() ![io] {
+    spawn(0, "worker");
+}' \
+        "spawn"
+}
+
 run_test "sfn build rejects sfn/sync.channel import (#617)" test_channel_via_sfn_sync_rejected
 run_test "sfn build rejects sfn/sync.parallel import (#617)" test_parallel_via_sfn_sync_rejected
 run_test "sfn build rejects sfn/sync.spawn import (#617)" test_spawn_via_sfn_sync_rejected
 run_test "sfn build rejects bare prelude channel() (#617)" test_channel_via_prelude_name_rejected
 run_test "sfn build rejects bare prelude spawn() (#617)" test_spawn_via_prelude_name_rejected
 run_test "sfn build fails closed on unknown void helper (#631)" test_unknown_void_helper_rejected
+run_test "sfn emit llvm fails closed on void spawn() (#631)" test_emit_llvm_spawn_rejected
 
 echo "[summary] $PASS passed, $FAIL failed"
 if [ "$FAIL" -gt 0 ]; then


### PR DESCRIPTION
## Summary

- `sfn build` and `sfn emit llvm` now **fail closed** (rc≠0, no artifact) when a void-returning call's return type cannot be resolved — previously the `[fatal]` printed but the build wrote a binary and exited 0.
- Root cause: two leak points dropped statement-level diagnostics before they reached the `has_fatal_lowering_diagnostic` gate (the bare expression-statement path in `lower_expression_statement`, and the expression-statement branch at the `instructions.sfn` call site). Both now thread diagnostics through.
- Making the gate load-bearing surfaced pre-existing int/float ABI-mismatch `[fatal]`s in the `sfn/json` and `sfn/toml` number parsers (e.g. `divisor * 10` where `divisor` is `float`), which were silently dropped at the same call site. Fixed with explicit float literals / `as float` casts per the language's explicit-cast rule.

Closes #631

## Acceptance Criteria

- [x] `sfn build` on a source whose `main` calls an unknown void function exits rc≠0. *(verified rc=1)*
- [x] No output binary is produced at the `-o` path. *(verified absent)*
- [x] `sfn emit llvm` exhibits the same behavior. *(verified rc=1, no `.ll`)*
- [x] `compiler/tests/e2e/test_sync_rejects_unimplemented_concurrency.sh` updated: `assert_build_rejects` asserts rc≠0 AND `[ ! -e "$out_path" ]` for all five sample callers (incl. both `spawn` cases); added a void-call fail-closed fixture.
- [x] `make compile` self-hosts on the unchanged seed. *(`make rebuild` from seed, rc=0)*
- [x] `make test` passes end-to-end (unit + integration + e2e + capsules; capsules 19/19).
- [x] `sfn fmt --check` clean on every touched `.sfn` file.

### Deferred (with maintainer sign-off)

- [ ] `sfn emit native` fail-closed on the same input — **deferred to #906**. `emit native` stops at the stage-5 `.sfn-asm` emitter, *before* LLVM lowering where the `[fatal]` is produced, so it returns rc=0 for value- and void-returning callees alike. Making it fail closed requires native-IR-stage (or shared earlier) resolution, which is out of #631's scope. Filed as a groomed sub-issue of epic #613.

## Verification

```bash
ulimit -v 8388608
make rebuild          # self-hosts from seed, rc=0
make test             # rc=0; capsules 19/19; e2e-sh 81/81

# void-return path (the fix)
printf 'fn main() [io] { spawn(0, "x"); }\n' > /tmp/void_call.sfn
build/native/sailfin build -o /tmp/void_call.out /tmp/void_call.sfn ; echo "rc=$?"  # rc=1
test ! -e /tmp/void_call.out && echo OK                                             # OK

# emit llvm parity
build/native/sailfin emit -o /tmp/void.ll llvm /tmp/void_call.sfn ; echo "rc=$?"    # rc=1
test ! -e /tmp/void.ll && echo OK                                                   # OK

# value-return path (already rc=1; unchanged)
printf 'import { channel } from "sfn/sync";\nfn main() [io] { let _ = channel(0); }\n' > /tmp/value_call.sfn
build/native/sailfin build -o /tmp/value_call.out /tmp/value_call.sfn ; echo "rc=$?" # rc=1
test ! -e /tmp/value_call.out && echo OK                                             # OK
```

## Files Changed

- `compiler/src/llvm/lowering/instructions.sfn` — collect expression-statement diagnostics at the call site.
- `compiler/src/llvm/expression_lowering/native/statement.sfn` — collect bare expression-statement diagnostics into the result.
- `compiler/tests/e2e/test_sync_rejects_unimplemented_concurrency.sh` — strict assertions + void-call fail-closed fixture.
- `capsules/sfn/json/src/mod.sfn`, `capsules/sfn/toml/src/mod.sfn` — explicit float casts in number parsers (surfaced by the now-load-bearing gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013qBFRNn7k6t5qqRPL2EghP)_