### PR TITLE
fix(cache): content-address the runtime C/LL object cache (#632)

### DIFF
--- a/compiler/src/build_cache.sfn
+++ b/compiler/src/build_cache.sfn
@@ -519,6 +519,38 @@ fn canonicalize_flags(flags: string[]) -> string {
 }
 
 // ----------------------------------------------------------------
+// Content-hash primitive (shared)
+// ----------------------------------------------------------------
+// Public wrapper over the private `_sha256_of_file_cmd` so callers
+// outside this module can content-address their own artifacts
+// without reaching into `cli_commands_utils` internals. Promoted to
+// a single exported helper per #514's plan; the runtime C-object
+// cache (#632) is the first external consumer. Returns "" if the
+// file can't be hashed (missing source, sha tool absent) — callers
+// must treat an empty hash as "not content-addressable" and fall
+// back to recompile rather than risk a stale hit.
+fn sha256_of_file(file_path: string) -> string ![io] {
+    return _sha256_of_file_cmd(file_path);
+}
+
+// Content-addressed cache key for a runtime C / LL object compile.
+// The runtime-capsule and legacy runtime-object compile paths in
+// `cli_main.sfn` previously keyed their `.o` cache purely on the
+// source basename + opt flag, so editing a tracked source left a
+// stale cached object that the linker silently reused (#632). This
+// helper mixes the source file's content SHA-256 with the opt flag
+// so a content edit busts the key while a pure mtime touch (same
+// bytes) keeps it stable. The `\n` separator keeps the two fields
+// from colliding via concatenation, matching `cache_key_for`'s
+// invariant. Returns "" when the source can't be hashed so the
+// caller can fall back to an always-recompile path.
+fn runtime_object_cache_key(src_path: string, opt_flag: string) -> string ![io] {
+    let content = sha256_of_file(src_path);
+    if content.length == 0 { return ""; }
+    return content + "\n" + opt_flag;
+}
+
+// ----------------------------------------------------------------
 // Cache key derivation
 // ----------------------------------------------------------------
 // Compute the content-addressed cache key for a single module
@@ -581,6 +613,8 @@ export {
     cache_store_artifact,
     canonicalize_flags,
     cache_key_for,
+    sha256_of_file,
+    runtime_object_cache_key,
     empty_cache_stats,
     cache_stats_is_empty,
     empty_build_cache_config,

--- a/compiler/src/cli_main.sfn
+++ b/compiler/src/cli_main.sfn
@@ -6,7 +6,8 @@ import {
     CacheStats,
     cache_root,
     cache_stats_is_empty,
-    resolve_build_cache_config
+    resolve_build_cache_config,
+    runtime_object_cache_key
 } from "./build_cache";
 import {
     BuildReport,
@@ -992,11 +993,38 @@ fn _runtime_obj_prefix(capsule_name: string) -> string {
     return out + "__";
 }
 
+// Content-addressed cache gate for a runtime object compile (#632).
+// A previously-compiled `.o` at `obj_path` may be reused iff the
+// object exists AND the sidecar `<obj_path>.key` records a content
+// key byte-identical to the current source's key. A content edit
+// changes the key (via `runtime_object_cache_key`'s source SHA-256),
+// busting the cache and forcing a recompile; a pure mtime touch
+// leaves the bytes — hence the key — unchanged, so the cache still
+// hits. An empty key (unhashable source) is treated as a miss so a
+// hash failure never serves a stale object. Before this gate the
+// caller keyed solely on `fs.exists(obj_path)`, which silently
+// reused a stale `.o` after any source-content edit.
+fn _runtime_obj_cache_hit(obj_path: string, key: string) -> boolean ![io] {
+    if key.length == 0 { return false; }
+    if !fs.exists(obj_path) { return false; }
+    let sidecar = obj_path + ".key";
+    if !fs.exists(sidecar) { return false; }
+    return fs.readFile(sidecar) == key;
+}
+
+// Persist the content key alongside a freshly-compiled `.o` so the
+// next build's `_runtime_obj_cache_hit` can validate it. No-op on an
+// empty key (the gate already forced an uncached recompile).
+fn _runtime_obj_cache_record(obj_path: string, key: string) ![io] {
+    if key.length == 0 { return; }
+    fs.writeFile(obj_path + ".key", key);
+}
+
 // Compile every `c-sources` / `ll-sources` entry from a list of
 // `kind = "runtime"` capsule artifacts and return the resulting
 // `.o` paths plus the accumulated `link-libs`. Caches `.o` outputs
-// under `out_dir` keyed by source basename + `opt_flag` so repeat
-// builds skip clang.
+// under `out_dir` keyed by source content SHA-256 + `opt_flag`
+// (#632) so a content edit recompiles while repeat builds skip clang.
 //
 // Used only when the resolver returns at least one runtime capsule
 // artifact (i.e. the project's `[dependencies]` declared a
@@ -1037,7 +1065,8 @@ fn _clang_compile_runtime_capsule_objects(runtime_capsules: RuntimeCapsuleArtifa
             let obj = _path_join(out_dir, cap_prefix + _path_basename(src)
                 + opt_flag
                 + ".o");
-            if !fs.exists(obj) {
+            let key = runtime_object_cache_key(src, opt_flag);
+            if !_runtime_obj_cache_hit(obj, key) {
                 let mut args: string[] = ["clang", opt_flag, "-Wno-override-module"];
                 let mut fi: int = 0;
                 loop {
@@ -1054,6 +1083,7 @@ fn _clang_compile_runtime_capsule_objects(runtime_capsules: RuntimeCapsuleArtifa
                     print("sfn build: failed to compile runtime c-source " + src);
                     return _failed_runtime_link_inputs();
                 }
+                _runtime_obj_cache_record(obj, key);
             }
             objects.push(obj);
             ci += 1;
@@ -1068,13 +1098,15 @@ fn _clang_compile_runtime_capsule_objects(runtime_capsules: RuntimeCapsuleArtifa
             let obj = _path_join(out_dir, cap_prefix + _path_basename(src)
                 + opt_flag
                 + ".o");
-            if !fs.exists(obj) {
+            let key = runtime_object_cache_key(src, opt_flag);
+            if !_runtime_obj_cache_hit(obj, key) {
                 let rc = process.run(["clang", opt_flag, "-Wno-override-module", "-c", src, "-o", obj]);
                 if rc != 0 {
                     print("sfn build: failed to assemble runtime ll-source "
                         + src);
                     return _failed_runtime_link_inputs();
                 }
+                _runtime_obj_cache_record(obj, key);
             }
             objects.push(obj);
             li += 1;
@@ -1294,27 +1326,36 @@ fn _clang_compile_runtime_objects(runtime_root: string, out_dir: string, opt_fla
     let arena_obj = _path_join(out_dir, "sailfin_arena" + opt_flag + ".o");
     let globals_obj = _path_join(out_dir, "runtime_globals" + opt_flag + ".o");
 
-    if !fs.exists(runtime_obj) {
+    // Content-addressed cache keys (#632): a content edit to any of
+    // these in-tree runtime sources busts the corresponding `.o`,
+    // matching the runtime-capsule path's behaviour above.
+    let runtime_key = runtime_object_cache_key(runtime_src, opt_flag);
+    if !_runtime_obj_cache_hit(runtime_obj, runtime_key) {
         let rc = process.run(["clang", opt_flag, "-Wno-override-module", "-I"
             + include_dir, "-c", runtime_src, "-o", runtime_obj,]);
         if rc != 0 {
             return ["", "", "", "", "", "", "", "", "", "", ""];
         }
+        _runtime_obj_cache_record(runtime_obj, runtime_key);
     }
 
-    if !fs.exists(arena_obj) {
+    let arena_key = runtime_object_cache_key(arena_src, opt_flag);
+    if !_runtime_obj_cache_hit(arena_obj, arena_key) {
         let rc_arena = process.run(["clang", opt_flag, "-Wno-override-module", "-I"
             + include_dir, "-c", arena_src, "-o", arena_obj,]);
         if rc_arena != 0 {
             return ["", "", "", "", "", "", "", "", "", "", ""];
         }
+        _runtime_obj_cache_record(arena_obj, arena_key);
     }
 
-    if !fs.exists(globals_obj) {
+    let globals_key = runtime_object_cache_key(runtime_ir, opt_flag);
+    if !_runtime_obj_cache_hit(globals_obj, globals_key) {
         let rc2 = process.run(["clang", opt_flag, "-Wno-override-module", "-c", runtime_ir, "-o", globals_obj,]);
         if rc2 != 0 {
             return ["", "", "", "", "", "", "", "", "", "", ""];
         }
+        _runtime_obj_cache_record(globals_obj, globals_key);
     }
 
     return [runtime_obj, arena_obj, globals_obj, prelude_obj, clock_obj, process_obj, exception_obj, exec_obj, type_meta_obj, filesystem_obj, http_obj];

--- a/compiler/tests/e2e/test_runtime_c_cache_invalidates.sh
+++ b/compiler/tests/e2e/test_runtime_c_cache_invalidates.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# End-to-end test for the runtime C-object cache invalidation fix (#632).
+#
+# Before this fix, the runtime C-object cache keyed each `.o` purely
+# on source basename + opt flag and gated reuse on `fs.exists`, so a
+# content edit to a tracked `runtime/native/src/*.c` source left a
+# stale cached object the linker silently reused. The fix mixes the
+# source content SHA-256 into a sidecar `<obj>.key` and only reuses
+# the `.o` when the recorded key matches the current source.
+#
+# This test pins the two halves of the contract on a real build:
+#   1. A pure mtime `touch` (content unchanged) MUST still cache-hit
+#      — the cache is content-addressed, not mtime-addressed.
+#   2. A content edit MUST produce a cache miss — the `.o` is
+#      recompiled and its mtime advances.
+#
+# It drives the legacy `_clang_compile_runtime_objects` path (a plain
+# `sfn build <file.sfn>`), which compiles the exact source the issue
+# edits (`runtime/native/src/sailfin_runtime.c`) and shares the
+# `_runtime_obj_cache_hit` gate with the runtime-capsule path that
+# the compiler self-build uses. Driving a one-line program keeps the
+# test to seconds rather than three full `sfn build -p compiler`
+# rebuilds; the capsule-path object name shape and the key contract
+# are covered by `compiler/tests/unit/build_cache_c_source_test.sfn`.
+#
+# Usage:
+#   compiler/tests/e2e/test_runtime_c_cache_invalidates.sh <compiler-binary>
+
+set -euo pipefail
+
+BINARY="${1:?usage: test_runtime_c_cache_invalidates.sh <compiler-binary>}"
+BINARY="$(realpath "$BINARY")"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$REPO_ROOT"
+
+PASS=0
+FAIL=0
+run_test() {
+    local name="$1"
+    shift
+    if "$@"; then
+        echo "[test] PASS: $name"
+        PASS=$((PASS + 1))
+    else
+        echo "[test] FAIL: $name"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+C_SRC="runtime/native/src/sailfin_runtime.c"
+SCRATCH="$(mktemp -d -t sfn-c-cache-XXXXXX)"
+BAK="$(mktemp)"
+cp "$C_SRC" "$BAK"
+cleanup() { cp "$BAK" "$C_SRC"; rm -rf "$SCRATCH" "$BAK"; }
+trap cleanup EXIT
+
+WORK="$SCRATCH/work"
+mkdir -p "$WORK"
+
+cat > "$SCRATCH/hello.sfn" <<'EOF'
+fn main() -> int {
+    return 0;
+}
+EOF
+
+# Portable mtime reader (Linux coreutils first, macOS BSD stat fallback).
+mtime_of() { stat -c %Y "$1" 2>/dev/null || stat -f %m "$1"; }
+
+# Build the one-line program into the isolated work-dir so runtime
+# objects land under "$WORK/sailfin/" instead of the repo's
+# build/sailfin/.
+do_build() {
+    ( ulimit -v 8388608; timeout 120 "$BINARY" build "$SCRATCH/hello.sfn" \
+        -o "$SCRATCH/hello" --work-dir "$WORK" ) >"$SCRATCH/build.log" 2>&1
+}
+
+# The legacy runtime object compiled from sailfin_runtime.c at -O2.
+RUNTIME_OBJ="$WORK/sailfin/sailfin_runtime-O2.o"
+
+# ---- Build 1: populate the cache ----
+if ! do_build; then
+    echo "[test] FATAL: initial build failed" >&2
+    cat "$SCRATCH/build.log" >&2
+    exit 1
+fi
+
+check_obj_and_sidecar_exist() {
+    [ -f "$RUNTIME_OBJ" ] || { echo "  missing runtime object $RUNTIME_OBJ" >&2; return 1; }
+    [ -f "$RUNTIME_OBJ.key" ] || { echo "  missing content-key sidecar $RUNTIME_OBJ.key" >&2; return 1; }
+    return 0
+}
+run_test "runtime object + content-key sidecar produced on first build" \
+    check_obj_and_sidecar_exist
+
+T1="$(mtime_of "$RUNTIME_OBJ")"
+
+# ---- Pure mtime touch: content unchanged MUST cache-hit ----
+# Sleep 1s so any recompile would produce a strictly newer mtime
+# (filesystem mtime granularity is 1s in the worst case).
+sleep 1
+touch "$C_SRC"
+check_touch_is_cache_hit() {
+    do_build || { echo "  build after touch failed" >&2; return 1; }
+    local t2; t2="$(mtime_of "$RUNTIME_OBJ")"
+    if [ "$t2" != "$T1" ]; then
+        echo "  expected cache HIT after pure touch, but object mtime advanced ($T1 -> $t2)" >&2
+        return 1
+    fi
+    return 0
+}
+run_test "pure mtime touch (content unchanged) cache-hits" \
+    check_touch_is_cache_hit
+
+# ---- Content edit MUST cache-miss (the regression this fixes) ----
+sleep 1
+printf '\n/* #632 runtime C-object cache invalidation probe */\n' >> "$C_SRC"
+check_content_edit_is_cache_miss() {
+    do_build || { echo "  build after content edit failed" >&2; cat "$SCRATCH/build.log" >&2; return 1; }
+    local t3; t3="$(mtime_of "$RUNTIME_OBJ")"
+    if [ "$t3" = "$T1" ]; then
+        echo "  expected cache MISS after content edit, but object was NOT recompiled (mtime $t3 unchanged)" >&2
+        return 1
+    fi
+    return 0
+}
+run_test "content edit busts the cache (object recompiled)" \
+    check_content_edit_is_cache_miss
+
+echo "[test] runtime C-object cache: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/compiler/tests/e2e/test_runtime_c_cache_invalidates.sh
+++ b/compiler/tests/e2e/test_runtime_c_cache_invalidates.sh
@@ -66,11 +66,19 @@ EOF
 # Portable mtime reader (Linux coreutils first, macOS BSD stat fallback).
 mtime_of() { stat -c %Y "$1" 2>/dev/null || stat -f %m "$1"; }
 
+# `timeout` is GNU coreutils — present on linux-x86_64 CI, absent on
+# macos-arm64. Use it when available; otherwise invoke the binary
+# directly. (`ulimit -v` is likewise Linux-only — macos-arm64 rejects
+# it with "cannot modify limit" — so it's applied best-effort below.)
+TIMEOUT_PREFIX=""
+if command -v timeout >/dev/null 2>&1; then TIMEOUT_PREFIX="timeout 120"; fi
+
 # Build the one-line program into the isolated work-dir so runtime
 # objects land under "$WORK/sailfin/" instead of the repo's
 # build/sailfin/.
 do_build() {
-    ( ulimit -v 8388608; timeout 120 "$BINARY" build "$SCRATCH/hello.sfn" \
+    ( ulimit -v 8388608 2>/dev/null || true
+      ${TIMEOUT_PREFIX} "$BINARY" build "$SCRATCH/hello.sfn" \
         -o "$SCRATCH/hello" --work-dir "$WORK" ) >"$SCRATCH/build.log" 2>&1
 }
 

--- a/compiler/tests/unit/build_cache_c_source_test.sfn
+++ b/compiler/tests/unit/build_cache_c_source_test.sfn
@@ -1,0 +1,101 @@
+// Unit tests for the runtime C/LL object cache key (#632).
+//
+// Before this fix, the runtime C-object cache in `cli_main.sfn`
+// keyed each `.o` purely on source basename + opt flag and gated
+// on `fs.exists`. Editing a tracked `runtime/native/src/*.c`
+// source therefore left a stale cached object the linker silently
+// reused — the worst kind of cache bug, because a function-body
+// edit that doesn't change an exported symbol produced a stale
+// binary with no link error and no diagnostic.
+//
+// `runtime_object_cache_key` is the content-addressing primitive
+// the fix introduces: it mixes the source file's SHA-256 with the
+// opt flag, so these tests pin the contract by calling the helper
+// before and after a content edit and asserting key (in)equality.
+// The key is content-addressed, not mtime-addressed: a pure
+// rewrite-with-identical-bytes must reproduce the same key.
+import { runtime_object_cache_key } from "../../src/build_cache";
+
+// Each test gets its own tmp namespace so parallel runs don't
+// collide on `/tmp/sfn_c_source_cache_test_<X>`.
+fn _tmp_root(label: string) -> string ![io] {
+    let root = "/tmp/sfn_c_source_cache_test_" + label;
+    process.run(["rm", "-rf", root]);
+    process.run(["mkdir", "-p", root]);
+    return root;
+}
+
+fn _cleanup(path: string) ![io] { process.run(["rm", "-rf", path]); }
+
+// A content edit to the source must change the cache key, so the
+// next build misses and recompiles. This is the exact regression
+// from PR #630: a function-body edit left the key unchanged and
+// served a stale `.o`.
+test "c-source cache: content edit changes the key" ![io] {
+    let scratch = _tmp_root("content_edit");
+    let src = scratch + "/sailfin_runtime.c";
+
+    fs.writeFile(src, "char *sailfin_runtime_log_execution(void) { return 0; }\n");
+    let key_before = runtime_object_cache_key(src, "-O2");
+
+    // Whitespace-only edit inside the body still changes the bytes.
+    fs.writeFile(src, "char *sailfin_runtime_log_execution(void) { return  0; }\n");
+    let key_after = runtime_object_cache_key(src, "-O2");
+
+    assert key_before.length == 64 + 1 + 3;  // sha256 hex + "\n" + "-O2"
+    assert key_before != key_after;
+
+    _cleanup(scratch);
+}
+
+// The key is content-addressed, not mtime-addressed: rewriting the
+// exact same bytes (the "pure touch" case) must reproduce the
+// original key so the cache still hits. This pins the contract
+// #514 holds for the staging cache — identical content cache-hits.
+test "c-source cache: identical content reproduces the key" ![io] {
+    let scratch = _tmp_root("identical_content");
+    let src = scratch + "/sailfin_runtime.c";
+    let body = "int sailfin_runtime_channel(void) { return 7; }\n";
+
+    fs.writeFile(src, body);
+    let key_first = runtime_object_cache_key(src, "-O2");
+
+    // Edit away, then restore byte-identical content.
+    fs.writeFile(src, "int sailfin_runtime_channel(void) { return 8; }\n");
+    let key_edited = runtime_object_cache_key(src, "-O2");
+    fs.writeFile(src, body);
+    let key_restored = runtime_object_cache_key(src, "-O2");
+
+    assert key_first != key_edited;
+    assert key_first == key_restored;
+
+    _cleanup(scratch);
+}
+
+// The opt flag participates in the key so the same source compiled
+// at different optimisation levels never collides on one `.o`.
+test "c-source cache: opt flag participates in the key" ![io] {
+    let scratch = _tmp_root("opt_flag");
+    let src = scratch + "/sailfin_arena.c";
+    fs.writeFile(src, "void sailfin_arena_init(void) {}\n");
+
+    let key_o0 = runtime_object_cache_key(src, "-O0");
+    let key_o2 = runtime_object_cache_key(src, "-O2");
+
+    assert key_o0 != key_o2;
+
+    _cleanup(scratch);
+}
+
+// An unhashable source (missing file) yields an empty key, which
+// the caller treats as "not content-addressable" and falls back to
+// an always-recompile path — never a silent stale hit.
+test "c-source cache: missing source yields empty key" ![io] {
+    let scratch = _tmp_root("missing");
+    let src = scratch + "/does_not_exist.c";
+
+    let key = runtime_object_cache_key(src, "-O2");
+    assert key.length == 0;
+
+    _cleanup(scratch);
+}


### PR DESCRIPTION
## Summary
- The runtime object cache in `cli_main.sfn` keyed each `.o` on source basename + opt flag and gated reuse on `fs.exists`, so a content edit to a tracked `runtime/native/src/*.c` source left a **stale cached object the linker silently reused** — no diagnostic unless an exported symbol went missing (the worst kind of cache bug).
- Promotes `_sha256_of_file_cmd` to an exported `sha256_of_file` and adds `runtime_object_cache_key` (source SHA-256 + opt flag) in `build_cache.sfn`.
- Wires a content-key sidecar (`<obj>.key`) gate into **both** the runtime-capsule path (`_clang_compile_runtime_capsule_objects`, c-sources + ll-sources) and the legacy `_clang_compile_runtime_objects` path. A content edit now busts the cache; a pure mtime `touch` (same bytes) still hits.

Closes #632

## Scope adjustment (confirmed with maintainer before coding)
The issue named `cache_key_for` in `build_cache.sfn` as the buggy function, but that function **already content-hashes** `.sfn` module sources correctly — it serves the `.ll` module cache. The real bug lived in a **separate** cache layer in `cli_main.sfn` with a different key shape (`fs.exists` on a deterministic filename, no content hash). This is exactly the issue's documented "STOP and re-groom" condition ("the C-object cache uses a completely different key shape … lives outside `build_cache.sfn` entirely"). With approval, the fix lands at the real site.

Consequently, the C-object cache does **not** feed the `[cache] hits/misses` summary (that summary is fed solely by the `.ll` module cache via `CacheStats`; a `.c` edit produces zero `.ll` misses). Per agreement, the e2e verifies invalidation via **object recompile (mtime advance)** rather than a summary miss count.

## Acceptance Criteria
- [x] The C-object cache key hashes the source content; a unit test pins inequality before/after a content edit (and equality for identical bytes) — `compiler/tests/unit/build_cache_c_source_test.sfn`.
- [x] After a content edit to a `runtime/native/src/*.c` file, the next build produces a cache MISS for that object (recompiled, mtime advances) — verified by the new e2e.
- [x] Pure-mtime `touch` (content unchanged) continues to cache-hit — verified by the new e2e.
- [x] `make compile` self-hosts on the unchanged seed.
- [x] `make test` passes (unit + integration + e2e + capsules).
- [x] `make check` green — stage2 == stage3 fixed point verified.
- [x] `sfn fmt --check` clean on every touched `.sfn` file.

## Verification
```
$ build/native/sailfin fmt --check compiler/src/build_cache.sfn compiler/src/cli_main.sfn compiler/tests/unit/build_cache_c_source_test.sfn
  (clean, exit 0)

$ compiler/tests/e2e/test_runtime_c_cache_invalidates.sh build/native/sailfin
  [test] PASS: runtime object + content-key sidecar produced on first build
  [test] PASS: pure mtime touch (content unchanged) cache-hits
  [test] PASS: content edit busts the cache (object recompiled)
  [test] runtime C-object cache: 3 passed, 0 failed

$ build/native/sailfin test compiler/tests/unit/build_cache_c_source_test.sfn
  PASS  (all 4 tests passed)

$ make test    → all suites passed (unit + integration + e2e + capsules), 0 failed
$ make check   → [selfcheck] stage2 == stage3 (self-hosting fixed point verified)
                 [check] all suites passed on the seedcheck binary
```

## Files Changed
- `compiler/src/build_cache.sfn` — exported `sha256_of_file`, new `runtime_object_cache_key`.
- `compiler/src/cli_main.sfn` — `_runtime_obj_cache_hit` / `_runtime_obj_cache_record` sidecar gate wired into the capsule (c-sources + ll-sources) and legacy runtime-object compile paths.
- `compiler/tests/unit/build_cache_c_source_test.sfn` (new) — key contract.
- `compiler/tests/e2e/test_runtime_c_cache_invalidates.sh` (new) — end-to-end invalidation + mtime-touch-hit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01U1sExa5AKRaHbB59zTYcdT)_