### PR TITLE
refactor(lowering): retire legacy symbol: names for already-routed runtime descriptors (#911)

### DIFF
--- a/compiler/src/llvm/runtime_helpers.sfn
+++ b/compiler/src/llvm/runtime_helpers.sfn
@@ -138,11 +138,11 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
     // aggregate ABI. The C trampoline in sailfin_runtime.c unpacks the
     // aggregate and forwards to sailfin_runtime_print_raw.
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "print", symbol: "sailfin_runtime_print_raw", return_type: "void", parameter_types: ["{i8*, i64}"], effects: ["io"], native_signature: "sfn_print", c_abi_return_type: null
+        target: "print", symbol: "sfn_print", return_type: "void", parameter_types: ["{i8*, i64}"], effects: ["io"], native_signature: "sfn_print", c_abi_return_type: null
     });
     // Raw stderr print: writes to stderr with no prefix, no decoration.
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "print.err", symbol: "sailfin_runtime_print_err", return_type: "void", parameter_types: ["{i8*, i64}"], effects: ["io"], native_signature: "sfn_print_err", c_abi_return_type: null
+        target: "print.err", symbol: "sfn_print_err", return_type: "void", parameter_types: ["{i8*, i64}"], effects: ["io"], native_signature: "sfn_print_err", c_abi_return_type: null
     });
 
     // Prefixed print variants — print.err/print.warn/print.error write to
@@ -150,22 +150,22 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
     // Compiler diagnostics should use print.err() so they do not pollute
     // stdout (LLVM IR output, program output, etc.).
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "print.info", symbol: "sailfin_runtime_print_info", return_type: "void", parameter_types: ["{i8*, i64}"], effects: ["io"], native_signature: "sfn_print_info", c_abi_return_type: null
+        target: "print.info", symbol: "sfn_print_info", return_type: "void", parameter_types: ["{i8*, i64}"], effects: ["io"], native_signature: "sfn_print_info", c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "print.error", symbol: "sailfin_runtime_print_error", return_type: "void", parameter_types: ["{i8*, i64}"], effects: ["io"], native_signature: "sfn_print_error", c_abi_return_type: null
+        target: "print.error", symbol: "sfn_print_error", return_type: "void", parameter_types: ["{i8*, i64}"], effects: ["io"], native_signature: "sfn_print_error", c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "print.warn", symbol: "sailfin_runtime_print_warn", return_type: "void", parameter_types: ["{i8*, i64}"], effects: ["io"], native_signature: "sfn_print_warn", c_abi_return_type: null
+        target: "print.warn", symbol: "sfn_print_warn", return_type: "void", parameter_types: ["{i8*, i64}"], effects: ["io"], native_signature: "sfn_print_warn", c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "console.info", symbol: "sailfin_runtime_print_raw", return_type: "void", parameter_types: ["{i8*, i64}"], effects: ["io"], native_signature: "sfn_print", c_abi_return_type: null
+        target: "console.info", symbol: "sfn_print", return_type: "void", parameter_types: ["{i8*, i64}"], effects: ["io"], native_signature: "sfn_print", c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "console.log", symbol: "sailfin_runtime_print_raw", return_type: "void", parameter_types: ["{i8*, i64}"], effects: ["io"], native_signature: "sfn_print", c_abi_return_type: null
+        target: "console.log", symbol: "sfn_print", return_type: "void", parameter_types: ["{i8*, i64}"], effects: ["io"], native_signature: "sfn_print", c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "console.error", symbol: "sailfin_runtime_print_error", return_type: "void", parameter_types: ["{i8*, i64}"], effects: ["io"], native_signature: "sfn_print_error", c_abi_return_type: null
+        target: "console.error", symbol: "sfn_print_error", return_type: "void", parameter_types: ["{i8*, i64}"], effects: ["io"], native_signature: "sfn_print_error", c_abi_return_type: null
     });
 
     // IO intrinsics
@@ -479,13 +479,13 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
     // globals emitted by
     // `compiler/src/llvm/lowering/type_descriptors.sfn`.
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "runtime_is_string_fn", symbol: "sailfin_runtime_is_string", return_type: "i1", parameter_types: ["i8*"], effects: [], native_signature: "sfn_is_string", c_abi_return_type: null
+        target: "runtime_is_string_fn", symbol: "sfn_is_string", return_type: "i1", parameter_types: ["i8*"], effects: [], native_signature: "sfn_is_string", c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "runtime_is_number_fn", symbol: "sailfin_runtime_is_number", return_type: "i1", parameter_types: ["i8*"], effects: [], native_signature: "sfn_is_number", c_abi_return_type: null
+        target: "runtime_is_number_fn", symbol: "sfn_is_number", return_type: "i1", parameter_types: ["i8*"], effects: [], native_signature: "sfn_is_number", c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "runtime_is_boolean_fn", symbol: "sailfin_runtime_is_boolean", return_type: "i1", parameter_types: ["i8*"], effects: [], native_signature: "sfn_is_boolean", c_abi_return_type: null
+        target: "runtime_is_boolean_fn", symbol: "sfn_is_boolean", return_type: "i1", parameter_types: ["i8*"], effects: [], native_signature: "sfn_is_boolean", c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
         target: "runtime_is_void_fn", symbol: "sailfin_runtime_is_void", return_type: "i1", parameter_types: ["i8*"], effects: [], native_signature: null, c_abi_return_type: null
@@ -494,16 +494,16 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
         target: "runtime.bounds_check", symbol: "sailfin_runtime_bounds_check", return_type: "void", parameter_types: ["i64", "i64"], effects: [], native_signature: null, c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "runtime_is_array_fn", symbol: "sailfin_runtime_is_array", return_type: "i1", parameter_types: ["i8*"], effects: [], native_signature: "sfn_is_array", c_abi_return_type: null
+        target: "runtime_is_array_fn", symbol: "sfn_is_array", return_type: "i1", parameter_types: ["i8*"], effects: [], native_signature: "sfn_is_array", c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "runtime_is_callable_fn", symbol: "sailfin_runtime_is_callable", return_type: "i1", parameter_types: ["i8*"], effects: [], native_signature: "sfn_is_callable", c_abi_return_type: null
+        target: "runtime_is_callable_fn", symbol: "sfn_is_callable", return_type: "i1", parameter_types: ["i8*"], effects: [], native_signature: "sfn_is_callable", c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "runtime_resolve_runtime_type_fn", symbol: "sailfin_runtime_resolve_type", return_type: "i8*", parameter_types: ["i8*"], effects: [], native_signature: "sfn_resolve_type", c_abi_return_type: null
+        target: "runtime_resolve_runtime_type_fn", symbol: "sfn_resolve_type", return_type: "i8*", parameter_types: ["i8*"], effects: [], native_signature: "sfn_resolve_type", c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "runtime_instance_of_fn", symbol: "sailfin_runtime_instance_of", return_type: "i1", parameter_types: ["i8*", "i8*"], effects: [], native_signature: "sfn_instance_of", c_abi_return_type: null
+        target: "runtime_instance_of_fn", symbol: "sfn_instance_of", return_type: "i1", parameter_types: ["i8*", "i8*"], effects: [], native_signature: "sfn_instance_of", c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
         target: "runtime_serve_fn", symbol: "sailfin_runtime_serve", return_type: "void", parameter_types: ["i8*", "i8*"], effects: ["io", "net"], native_signature: null, c_abi_return_type: null
@@ -518,7 +518,7 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
     // `i64` natively (architect §2.2.2), `c_abi_return_type` drops
     // to `null` in the same PR that drops the C trampoline.
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "runtime_char_code_fn", symbol: "sailfin_runtime_char_code", return_type: "i64", parameter_types: ["i8*"], effects: [], native_signature: "sfn_str_codepoint", c_abi_return_type: "double"
+        target: "runtime_char_code_fn", symbol: "sfn_str_codepoint", return_type: "i64", parameter_types: ["i8*"], effects: [], native_signature: "sfn_str_codepoint", c_abi_return_type: "double"
     });
 
     // Process helpers
@@ -538,7 +538,7 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
     // issue's acceptance criterion (`sailfin_runtime_process_run`
     // unreferenced).
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "process.run", symbol: "sailfin_runtime_process_run_v2", return_type: "i64", parameter_types: ["{ i8**, i64, i64 }*"], effects: ["io"], native_signature: "sfn_process_run", c_abi_return_type: "double"
+        target: "process.run", symbol: "sfn_process_run", return_type: "i64", parameter_types: ["{ i8**, i64, i64 }*"], effects: ["io"], native_signature: "sfn_process_run", c_abi_return_type: "double"
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
         target: "process.exit", symbol: "sailfin_runtime_process_exit", return_type: "void", parameter_types: ["double"], effects: ["io"], native_signature: null, c_abi_return_type: null
@@ -597,22 +597,22 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
     // their C symbols — they are live (wrapped by the `sfn/fs`
     // capsule) and get a follow-up adapter wave.
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "fs_read_file", symbol: "sailfin_adapter_fs_read_file", return_type: "i8*", parameter_types: ["i8*"], effects: ["io"], native_signature: "sfn_fs_read_file", c_abi_return_type: null
+        target: "fs_read_file", symbol: "sfn_fs_read_file", return_type: "i8*", parameter_types: ["i8*"], effects: ["io"], native_signature: "sfn_fs_read_file", c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "fs.readFile", symbol: "sailfin_adapter_fs_read_file", return_type: "i8*", parameter_types: ["i8*"], effects: ["io"], native_signature: "sfn_fs_read_file", c_abi_return_type: null
+        target: "fs.readFile", symbol: "sfn_fs_read_file", return_type: "i8*", parameter_types: ["i8*"], effects: ["io"], native_signature: "sfn_fs_read_file", c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "fs_write_file", symbol: "sailfin_adapter_fs_write_file", return_type: "void", parameter_types: ["i8*", "i8*"], effects: ["io"], native_signature: "sfn_fs_write_file", c_abi_return_type: null
+        target: "fs_write_file", symbol: "sfn_fs_write_file", return_type: "void", parameter_types: ["i8*", "i8*"], effects: ["io"], native_signature: "sfn_fs_write_file", c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "fs.writeFile", symbol: "sailfin_adapter_fs_write_file", return_type: "void", parameter_types: ["i8*", "i8*"], effects: ["io"], native_signature: "sfn_fs_write_file", c_abi_return_type: null
+        target: "fs.writeFile", symbol: "sfn_fs_write_file", return_type: "void", parameter_types: ["i8*", "i8*"], effects: ["io"], native_signature: "sfn_fs_write_file", c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "fs_append_file", symbol: "sailfin_adapter_fs_append_file", return_type: "void", parameter_types: ["i8*", "i8*"], effects: ["io"], native_signature: "sfn_fs_append_file", c_abi_return_type: null
+        target: "fs_append_file", symbol: "sfn_fs_append_file", return_type: "void", parameter_types: ["i8*", "i8*"], effects: ["io"], native_signature: "sfn_fs_append_file", c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "fs.appendFile", symbol: "sailfin_adapter_fs_append_file", return_type: "void", parameter_types: ["i8*", "i8*"], effects: ["io"], native_signature: "sfn_fs_append_file", c_abi_return_type: null
+        target: "fs.appendFile", symbol: "sfn_fs_append_file", return_type: "void", parameter_types: ["i8*", "i8*"], effects: ["io"], native_signature: "sfn_fs_append_file", c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
         target: "fs_write_lines", symbol: "sailfin_adapter_fs_write_lines_v2", return_type: "void", parameter_types: ["i8*", "{ i8**, i64, i64 }*"], effects: ["io"], native_signature: null, c_abi_return_type: null
@@ -621,22 +621,22 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
         target: "fs.writeLines", symbol: "sailfin_adapter_fs_write_lines_v2", return_type: "void", parameter_types: ["i8*", "{ i8**, i64, i64 }*"], effects: ["io"], native_signature: null, c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "fs_list_directory", symbol: "sailfin_adapter_fs_list_directory_v2", return_type: "{ i8**, i64, i64 }*", parameter_types: ["i8*"], effects: ["io"], native_signature: "sfn_fs_list_dir", c_abi_return_type: null
+        target: "fs_list_directory", symbol: "sfn_fs_list_dir", return_type: "{ i8**, i64, i64 }*", parameter_types: ["i8*"], effects: ["io"], native_signature: "sfn_fs_list_dir", c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "fs.listDirectory", symbol: "sailfin_adapter_fs_list_directory_v2", return_type: "{ i8**, i64, i64 }*", parameter_types: ["i8*"], effects: ["io"], native_signature: "sfn_fs_list_dir", c_abi_return_type: null
+        target: "fs.listDirectory", symbol: "sfn_fs_list_dir", return_type: "{ i8**, i64, i64 }*", parameter_types: ["i8*"], effects: ["io"], native_signature: "sfn_fs_list_dir", c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "fs_delete_file", symbol: "sailfin_adapter_fs_delete_file", return_type: "i1", parameter_types: ["i8*"], effects: ["io"], native_signature: "sfn_fs_delete", c_abi_return_type: null
+        target: "fs_delete_file", symbol: "sfn_fs_delete", return_type: "i1", parameter_types: ["i8*"], effects: ["io"], native_signature: "sfn_fs_delete", c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "fs.deleteFile", symbol: "sailfin_adapter_fs_delete_file", return_type: "i1", parameter_types: ["i8*"], effects: ["io"], native_signature: "sfn_fs_delete", c_abi_return_type: null
+        target: "fs.deleteFile", symbol: "sfn_fs_delete", return_type: "i1", parameter_types: ["i8*"], effects: ["io"], native_signature: "sfn_fs_delete", c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "fs_create_directory", symbol: "sailfin_adapter_fs_create_directory", return_type: "i1", parameter_types: ["i8*", "i1"], effects: ["io"], native_signature: "sfn_fs_mkdir", c_abi_return_type: null
+        target: "fs_create_directory", symbol: "sfn_fs_mkdir", return_type: "i1", parameter_types: ["i8*", "i1"], effects: ["io"], native_signature: "sfn_fs_mkdir", c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "fs.createDirectory", symbol: "sailfin_adapter_fs_create_directory", return_type: "i1", parameter_types: ["i8*", "i1"], effects: ["io"], native_signature: "sfn_fs_mkdir", c_abi_return_type: null
+        target: "fs.createDirectory", symbol: "sfn_fs_mkdir", return_type: "i1", parameter_types: ["i8*", "i1"], effects: ["io"], native_signature: "sfn_fs_mkdir", c_abi_return_type: null
     });
 
     // P5 (#366): filesystem stdlib gap-fill. Permission ops, temp-dir
@@ -668,10 +668,10 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
     // `native_signature` override routes calls to `sfn_http_get` /
     // `sfn_http_post2` (the 2-arg POST wrapper matching this row's arity).
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "http_get", symbol: "sailfin_adapter_http_get", return_type: "i8*", parameter_types: ["i8*"], effects: ["net"], native_signature: "sfn_http_get", c_abi_return_type: null
+        target: "http_get", symbol: "sfn_http_get", return_type: "i8*", parameter_types: ["i8*"], effects: ["net"], native_signature: "sfn_http_get", c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "http_post", symbol: "sailfin_adapter_http_post", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: ["net"], native_signature: "sfn_http_post2", c_abi_return_type: null
+        target: "http_post", symbol: "sfn_http_post2", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: ["net"], native_signature: "sfn_http_post2", c_abi_return_type: null
     });
 
     // Serve adapters
@@ -733,7 +733,7 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
         target: "substring_unchecked", symbol: "substring_unchecked", return_type: "i8*", parameter_types: ["i8*", "double", "double"], effects: [], native_signature: "sfn_str_slice", c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "string.length", symbol: "sailfin_runtime_string_length", return_type: "i64", parameter_types: ["i8*"], effects: [], native_signature: "sfn_str_len", c_abi_return_type: null
+        target: "string.length", symbol: "sfn_str_len", return_type: "i64", parameter_types: ["i8*"], effects: [], native_signature: "sfn_str_len", c_abi_return_type: null
     });
     // M1.A — string.concat parameters lock to the SfnString aggregate
     // ABI. Wave 1 pre-#714 emitted
@@ -796,10 +796,10 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
     // renames over the legacy entrypoints — so no `c_abi_return_type`
     // override is needed.
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "number.to_string", symbol: "sailfin_runtime_number_to_string", return_type: "i8*", parameter_types: ["double"], effects: [], native_signature: "sfn_number_to_str", c_abi_return_type: null
+        target: "number.to_string", symbol: "sfn_number_to_str", return_type: "i8*", parameter_types: ["double"], effects: [], native_signature: "sfn_number_to_str", c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "string.to_number", symbol: "sailfin_runtime_string_to_number", return_type: "double", parameter_types: ["i8*"], effects: [], native_signature: "sfn_str_to_number", c_abi_return_type: null
+        target: "string.to_number", symbol: "sfn_str_to_number", return_type: "double", parameter_types: ["i8*"], effects: [], native_signature: "sfn_str_to_number", c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
         target: "strings_equal", symbol: "strings_equal", return_type: "i1", parameter_types: ["i8*", "i8*"], effects: [], native_signature: "sfn_str_eq", c_abi_return_type: null
@@ -826,13 +826,13 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
     // canonical symbol so freshly-emitted IR has zero references to
     // the legacy `sailfin_runtime_grapheme_*` names.
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "runtime_grapheme_count_fn", symbol: "sailfin_runtime_grapheme_count", return_type: "i64", parameter_types: ["i8*"], effects: [], native_signature: "sfn_str_grapheme_count", c_abi_return_type: "double"
+        target: "runtime_grapheme_count_fn", symbol: "sfn_str_grapheme_count", return_type: "i64", parameter_types: ["i8*"], effects: [], native_signature: "sfn_str_grapheme_count", c_abi_return_type: "double"
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "runtime_grapheme_at_fn", symbol: "sailfin_runtime_grapheme_at", return_type: "i8*", parameter_types: ["i8*", "double"], effects: [], native_signature: "sfn_str_grapheme_at", c_abi_return_type: null
+        target: "runtime_grapheme_at_fn", symbol: "sfn_str_grapheme_at", return_type: "i8*", parameter_types: ["i8*", "double"], effects: [], native_signature: "sfn_str_grapheme_at", c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "grapheme_at", symbol: "sailfin_runtime_grapheme_at", return_type: "i8*", parameter_types: ["i8*", "double"], effects: [], native_signature: "sfn_str_grapheme_at", c_abi_return_type: null
+        target: "grapheme_at", symbol: "sfn_str_grapheme_at", return_type: "i8*", parameter_types: ["i8*", "double"], effects: [], native_signature: "sfn_str_grapheme_at", c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
         target: "is_whitespace_char", symbol: "sailfin_runtime_is_whitespace_char", return_type: "i1", parameter_types: ["i8"], effects: [], native_signature: null, c_abi_return_type: null
@@ -894,10 +894,10 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
     // `SfnArray*` which is ABI-compatible at the System V x86_64
     // register level (linker resolves by symbol name only).
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "append_string", symbol: "sailfin_runtime_append_string_v2", return_type: "{ i8**, i64, i64 }*", parameter_types: ["{ i8**, i64, i64 }*", "i8*"], effects: [], native_signature: "sfn_array_push_string", c_abi_return_type: null
+        target: "append_string", symbol: "sfn_array_push_string", return_type: "{ i8**, i64, i64 }*", parameter_types: ["{ i8**, i64, i64 }*", "i8*"], effects: [], native_signature: "sfn_array_push_string", c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "concat", symbol: "sailfin_runtime_concat_v2", return_type: "{ i8**, i64, i64 }*", parameter_types: ["{ i8**, i64, i64 }*", "{ i8**, i64, i64 }*"], effects: [], native_signature: "sfn_array_concat", c_abi_return_type: null
+        target: "concat", symbol: "sfn_array_concat", return_type: "{ i8**, i64, i64 }*", parameter_types: ["{ i8**, i64, i64 }*", "{ i8**, i64, i64 }*"], effects: [], native_signature: "sfn_array_concat", c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
         target: "copy_bytes", symbol: "sailfin_runtime_copy_bytes", return_type: "void", parameter_types: ["i8*", "i8*", "i64"], effects: [], native_signature: null, c_abi_return_type: null
@@ -913,7 +913,7 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
     // module ships a matching `sfn_array_sfn_push_slot` under the
     // `_sfn_` infix.
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "array_push_slot", symbol: "sailfin_runtime_array_push_slot_v2", return_type: "i8*", parameter_types: ["i8**", "i64*", "i64*", "i64"], effects: [], native_signature: "sfn_array_push_slot", c_abi_return_type: null
+        target: "array_push_slot", symbol: "sfn_array_push_slot", return_type: "i8*", parameter_types: ["i8**", "i64*", "i64*", "i64"], effects: [], native_signature: "sfn_array_push_slot", c_abi_return_type: null
     });
 
     // Generic field accessor for opaque imported types
@@ -1035,13 +1035,13 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
     // `http.post_json` / `http.download` to `sfn_http_get` /
     // `sfn_http_post` (url, body, auth_header) / `sfn_http_download`.
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "http.get_body", symbol: "sailfin_runtime_http_get", return_type: "i8*", parameter_types: ["i8*"], effects: ["net"], native_signature: "sfn_http_get", c_abi_return_type: null
+        target: "http.get_body", symbol: "sfn_http_get", return_type: "i8*", parameter_types: ["i8*"], effects: ["net"], native_signature: "sfn_http_get", c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "http.post_json", symbol: "sailfin_runtime_http_post_json", return_type: "i8*", parameter_types: ["i8*", "i8*", "i8*"], effects: ["net"], native_signature: "sfn_http_post", c_abi_return_type: null
+        target: "http.post_json", symbol: "sfn_http_post", return_type: "i8*", parameter_types: ["i8*", "i8*", "i8*"], effects: ["net"], native_signature: "sfn_http_post", c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "http.download", symbol: "sailfin_runtime_http_download", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: ["net", "io"], native_signature: "sfn_http_download", c_abi_return_type: null
+        target: "http.download", symbol: "sfn_http_download", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: ["net", "io"], native_signature: "sfn_http_download", c_abi_return_type: null
     });
 
     // Environment & path helpers
@@ -1055,13 +1055,13 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
     // extractvalue coercion in `coerce_pointer_or_struct` for the
     // legacy `i8*` string-typed locals.
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "env.get", symbol: "sailfin_runtime_getenv", return_type: "{i8*, i64}", parameter_types: ["{i8*, i64}", "ptr"], effects: ["io"], native_signature: "sfn_getenv", c_abi_return_type: null
+        target: "env.get", symbol: "sfn_getenv", return_type: "{i8*, i64}", parameter_types: ["{i8*, i64}", "ptr"], effects: ["io"], native_signature: "sfn_getenv", c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "env.home", symbol: "sailfin_runtime_home_dir", return_type: "{i8*, i64}", parameter_types: ["ptr"], effects: ["io"], native_signature: "sfn_home_dir", c_abi_return_type: null
+        target: "env.home", symbol: "sfn_home_dir", return_type: "{i8*, i64}", parameter_types: ["ptr"], effects: ["io"], native_signature: "sfn_home_dir", c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "fs.read_bytes", symbol: "sailfin_runtime_read_file_bytes", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: ["io"], native_signature: "sfn_fs_read_bytes", c_abi_return_type: null
+        target: "fs.read_bytes", symbol: "sfn_fs_read_bytes", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: ["io"], native_signature: "sfn_fs_read_bytes", c_abi_return_type: null
     });
     // Prelude functions called directly by their original name.
     // These are defined in runtime/prelude.sfn and compiled into

--- a/compiler/tests/unit/abi_version_test.sfn
+++ b/compiler/tests/unit/abi_version_test.sfn
@@ -60,21 +60,29 @@ test "abi_version: descriptor accepts native_signature: <string> (M2 flip)" {
 // =============================================================================
 // M2.8 (#401) flipped the print / console / env descriptors to
 // the Sailfin-native sfn_print* / sfn_getenv / sfn_home_dir
-// symbols. The pinned native_signature values below are the
-// migration unit — the underlying `symbol` field stays at the
-// legacy C entrypoint for archeology. Effect classes that have
-// not yet flipped (fs.* / net.* / etc.) still report null.
+// symbols via `native_signature`. As of the #821/#911 registry
+// sweep (the final cleanup before the C-runtime deletion), an
+// already-routed (Category A) helper's `symbol` field is itself
+// rewritten to equal its `native_signature` — the legacy C
+// entrypoint name is retired from the registry rather than kept
+// for archeology, so the pre-deletion audit grep over `symbol:`
+// returns only not-yet-ported (Cat-B/C) and M4 rows. The flip is
+// link-time-inert: lowering already resolves
+// `native_signature ?? symbol`, so emitted IR is unchanged.
+// Effect classes that have not yet flipped (fs.* intrinsics /
+// net.* / etc.) still carry their legacy `symbol` and null
+// `native_signature`.
 test "abi_version: `print` helper carries native_signature sfn_print" {
     let helper = find_runtime_helper("print");
     assert helper != null;
-    assert helper.symbol == "sailfin_runtime_print_raw";
+    assert helper.symbol == "sfn_print";
     assert helper.native_signature == "sfn_print";
 }
 
 test "abi_version: `print.err` helper carries native_signature sfn_print_err" {
     let helper = find_runtime_helper("print.err");
     assert helper != null;
-    assert helper.symbol == "sailfin_runtime_print_err";
+    assert helper.symbol == "sfn_print_err";
     assert helper.native_signature == "sfn_print_err";
 }
 

--- a/docs/runtime_architecture.md
+++ b/docs/runtime_architecture.md
@@ -2183,14 +2183,19 @@ The following are explicitly **not** in scope for the 1.0 runtime:
 
 ## Appendix A: Mapping from Current C Symbols to Native Symbols
 
-> **Registry sweep — #911 (Cat-A), 2026-05-30.** For every "already
-> routed" helper (one whose descriptor carries a non-null
-> `native_signature`), the registry's `symbol:` field in
+> **Registry sweep — #911 (Cat-A), 2026-05-30.** For every "Category A"
+> helper — one whose `symbol:` previously pointed at a legacy
+> `sailfin_runtime_*` / `sailfin_intrinsic_*` / `sailfin_adapter_*`
+> entrypoint *and* already carried a non-null `sfn_*` `native_signature`
+> — the registry's `symbol:` field in
 > `compiler/src/llvm/runtime_helpers.sfn` has been rewritten to equal
-> its `native_signature` (the `sfn_*` name). The legacy
-> `sailfin_runtime_*` / `sailfin_adapter_*` entrypoint name is retired
-> from the registry rather than kept "for archeology." The flip is
-> **link-time-inert** — lowering already resolves
+> its `native_signature`, retiring the legacy entrypoint name rather
+> than keeping it "for archeology." This is **not** a global
+> `symbol == native_signature` invariant: helpers whose `symbol` was
+> already a source/prelude-level name (e.g. `substring` → `sfn_str_slice`,
+> `strings_equal` → `sfn_str_eq`, the prelude `number_to_string` alias)
+> intentionally keep `symbol` != `native_signature` and are untouched.
+> The flip is **link-time-inert** — lowering already resolves
 > `native_signature ?? symbol`, so `.sfn-asm` and LLVM IR are
 > byte-identical (verified against `examples/basics/hello-world.sfn`).
 > Rows marked **✓ #911** below are flipped. The audit grep

--- a/docs/runtime_architecture.md
+++ b/docs/runtime_architecture.md
@@ -2183,41 +2183,56 @@ The following are explicitly **not** in scope for the 1.0 runtime:
 
 ## Appendix A: Mapping from Current C Symbols to Native Symbols
 
+> **Registry sweep — #911 (Cat-A), 2026-05-30.** For every "already
+> routed" helper (one whose descriptor carries a non-null
+> `native_signature`), the registry's `symbol:` field in
+> `compiler/src/llvm/runtime_helpers.sfn` has been rewritten to equal
+> its `native_signature` (the `sfn_*` name). The legacy
+> `sailfin_runtime_*` / `sailfin_adapter_*` entrypoint name is retired
+> from the registry rather than kept "for archeology." The flip is
+> **link-time-inert** — lowering already resolves
+> `native_signature ?? symbol`, so `.sfn-asm` and LLVM IR are
+> byte-identical (verified against `examples/basics/hello-world.sfn`).
+> Rows marked **✓ #911** below are flipped. The audit grep
+> (`symbol: "(sailfin_runtime|sailfin_intrinsic|sailfin_adapter)_`)
+> now returns only not-yet-ported (Cat-B/C, `native_signature: null`)
+> and M4 scheduler rows. Cat-B/C flips track via #912; M4 stays.
+
 | Current C symbol | Native replacement | Milestone |
 |---|---|---|
-| `sailfin_runtime_print_raw` | `sfn_print` | M2 |
-| `sailfin_runtime_print_err` | `sfn_print_err` | M2 |
-| `sailfin_runtime_print_info/warn/error` | `sfn_print_info/warn/error` | M2 |
+| `sailfin_runtime_print_raw` | `sfn_print` | M2 — ✓ #911 |
+| `sailfin_runtime_print_err` | `sfn_print_err` | M2 — ✓ #911 |
+| `sailfin_runtime_print_info/warn/error` | `sfn_print_info/warn/error` | M2 — ✓ #911 |
 | `sailfin_runtime_sleep` | `sfn_sleep` | **Call-site routed 2026-05-04; `@sfn_sleep` currently a C trampoline. Sailfin link in PR 2 (gated on issue #308 + §2.9 Q7).** |
 | `sailfin_runtime_monotonic_millis` | `sfn_clock_millis` | **Shipped 2026-05-30 (issue #819, M3.3)** — `monotonic_millis` registry rows now route to the Sailfin-native `@sfn_clock_millis` (reads `clock_gettime` via #878's field-reader, returns `i64`); the C symbol stays for seed compat only. |
-| `sailfin_runtime_string_length` | `SfnString.len` (field access) | M1 |
+| `sailfin_runtime_string_length` | `sfn_str_len` / `SfnString.len` (field access) | M1 — ✓ #911 |
 | `sailfin_runtime_string_concat` | `sfn_str_concat` | M2 |
 | `sailfin_runtime_string_append` | `sfn_str_concat` (arena) | M2 |
 | `sailfin_runtime_string_drop` | `sfn_rc_release` or arena bulk | M2 |
 | `sailfin_runtime_substring` | `sfn_str_slice` | M2 |
-| `sailfin_runtime_grapheme_at` | `sfn_str_grapheme_at` | M2 |
-| `sailfin_runtime_grapheme_count` | `sfn_str_grapheme_count` | M2 |
-| `sailfin_runtime_char_code` | `sfn_str_codepoint` | M2 |
-| `sailfin_runtime_string_to_number` | `sfn_str_to_number` | M2 |
-| `sailfin_runtime_number_to_string` | `sfn_number_to_str` | M2 |
-| `sailfin_runtime_concat` (array) | `sfn_array_concat` | M2 |
-| `sailfin_runtime_append_string` | `sfn_array_push` | M2 |
+| `sailfin_runtime_grapheme_at` | `sfn_str_grapheme_at` | M2 — ✓ #911 |
+| `sailfin_runtime_grapheme_count` | `sfn_str_grapheme_count` | M2 — ✓ #911 |
+| `sailfin_runtime_char_code` | `sfn_str_codepoint` | M2 — ✓ #911 |
+| `sailfin_runtime_string_to_number` | `sfn_str_to_number` | M2 — ✓ #911 |
+| `sailfin_runtime_number_to_string` | `sfn_number_to_str` | M2 — ✓ #911 |
+| `sailfin_runtime_concat` (array, `concat_v2`) | `sfn_array_concat` | M2 — ✓ #911 |
+| `sailfin_runtime_append_string` (`append_string_v2`) | `sfn_array_push_string` | M2 — ✓ #911 |
 | `sailfin_runtime_array_push` | `sfn_array_push` | M2 |
-| `sailfin_runtime_array_push_slot` | `sfn_array_push` (monomorphic) | M2 |
-| `sailfin_runtime_process_run` | `sfn_process_run` | M2 |
-| `sailfin_adapter_fs_read_file` | `sfn_fs_read_file` | M3 |
-| `sailfin_adapter_fs_write_file` | `sfn_fs_write_file` | M3 |
+| `sailfin_runtime_array_push_slot` (`array_push_slot_v2`) | `sfn_array_push_slot` (monomorphic) | M2 — ✓ #911 |
+| `sailfin_runtime_process_run` (`process_run_v2`) | `sfn_process_run` | M2 — ✓ #911 |
+| `sailfin_adapter_fs_read_file` | `sfn_fs_read_file` | M3 — ✓ #911 |
+| `sailfin_adapter_fs_write_file` | `sfn_fs_write_file` | M3 — ✓ #911 |
 | `sailfin_runtime_set/has/clear/take_exception` | `sfn_try_enter/leave/throw/take` | M2 |
 | `sailfin_runtime_spawn_*` | `sfn_spawn` | M4 |
 | `sailfin_runtime_await_*` | `sfn_await` | M4 |
 | `sailfin_runtime_channel` | `sfn_channel_create` | M4 |
 | `sailfin_runtime_serve` | `sfn_serve` | M4 |
-| `sailfin_runtime_is_string/number/boolean/...` | `sfn_type_of` (compile-time fold or registry) | M2 |
+| `sailfin_runtime_is_string/number/boolean/array/callable`, `instance_of`, `resolve_type` | `sfn_is_*` / `sfn_instance_of` / `sfn_resolve_type` | M2 — ✓ #911 |
 | `sailfin_runtime_sha256_hex` | `sfn/crypto` capsule | M3 |
 | `sailfin_runtime_base64_encode` | `sfn/crypto` capsule | M3 |
-| `sailfin_runtime_http_get/post_json/download` | `sfn_http_get/post` | M3 |
-| `sailfin_runtime_getenv` | `sfn_getenv` | **M2.8b (#726) shipped SfnString aggregate ABI + arena-threaded marshalling; legacy `i8*` entrypoint retained for seed compatibility.** |
-| `sailfin_runtime_home_dir` | `sfn_home_dir` | **M2.8b (#726) shipped SfnString aggregate ABI + arena-threaded marshalling; legacy `i8*` entrypoint retained for seed compatibility.** |
+| `sailfin_runtime_http_get/post_json/download`, `sailfin_adapter_http_get/post` | `sfn_http_get/post/post2/download` | M3 — ✓ #911 |
+| `sailfin_runtime_getenv` | `sfn_getenv` | **M2.8b (#726)** shipped SfnString aggregate ABI + arena-threaded marshalling. — ✓ #911 (registry `symbol` flipped) |
+| `sailfin_runtime_home_dir` | `sfn_home_dir` | **M2.8b (#726)** shipped SfnString aggregate ABI + arena-threaded marshalling. — ✓ #911 (registry `symbol` flipped) |
 
 ## Appendix B: Compiler Files Affected by Milestone
 


### PR DESCRIPTION
## Summary
- Flip the `symbol:` field to equal `native_signature:` for the **46 already-routed (Category A)** `RuntimeHelperDescriptor` rows in `runtime_helpers.sfn` whose `sfn_*` replacement has shipped.
- **Link-time-inert:** lowering already resolves the effective symbol as `native_signature ?? symbol` in both the call path (`core_call_emission.sfn:740-747`) and the declare path (`rendering.sfn:218-222`), so the legacy `sailfin_runtime_*` / `sailfin_adapter_*` name was dead metadata for these rows. `.sfn-asm` and LLVM IR for `examples/basics/hello-world.sfn` are **byte-identical** before/after.
- The audit grep now returns only not-yet-ported (Cat-B/C, `native_signature: null`) and M4 scheduler rows.

Closes #911

## ⚠️ Policy reversal (please confirm intent)
This reverses the M2.8 (#401) policy that *"the underlying `symbol` field stays at the legacy C entrypoint for archeology"* (was pinned by `abi_version_test.sfn`). #821/#911 intentionally retire the legacy name from the registry ahead of the C-runtime deletion so the `symbol:`-keyed audit grep can reach a clean state. The test pins and rationale comment are updated to match. Flagging because it changes a previously-documented invariant.

## Acceptance Criteria
- [x] Each Cat-A descriptor's `symbol:` equals its `native_signature`; none match the legacy audit grep anymore (46 rows flipped; 81 legacy lines remain = 55 non-M4 Cat-B/C + 26 M4).
- [x] **`symbol` field not consumed except via `native_signature ?? symbol` fallback** — verified across all consumers (`core_call_emission.sfn:659/687` key on Cat-C symbols; `rendering.sfn:239`; `runtime_helpers.sfn:1174` is M4-only and no M4 row flipped; `lowering_helpers.sfn:800` matches symbol **or** native_signature). `.sfn-asm` + LLVM IR byte-identical for hello-world.
- [x] Appendix A reflects shipped status (✓ #911 markers + sweep note).
- [x] `make compile` self-hosts; `make check` gating suites pass (exit 0).
- [x] `sfn fmt --check` clean.

## Verification
```bash
# self-host + full gate
ulimit -v 8388608 && make compile && make check        # exit 0

# IR identity (the inertness proof)
diff <(sailfin emit llvm examples/basics/hello-world.sfn) ...   # byte-identical
diff <(sailfin emit sailfin examples/basics/hello-world.sfn) ... # byte-identical

# audit grep
grep -cE 'symbol: "(sailfin_runtime|sailfin_intrinsic|sailfin_adapter)_' \
  compiler/src/llvm/runtime_helpers.sfn          # 81 (was 127): all Cat-B/C + M4
```

**Note on `make check`:** a set of native-exec/packaging e2e tests (`bare-file run`, `sfn package`/tarball/installer, `SAILFIN_USE_ARENA` toggle, fs round-trip) fail in this sandbox with **exit 127** ("command not found"). They are **pre-existing and environmental** — the set is nondeterministic between runs and every one requires exec'ing a freshly-linked native binary or `tar`/`sha256sum`. `make check` returns exit 0 (these suites are non-gating here), the gating unit/integration/self-host suites pass, and a symbol-field data change cannot produce a 127 (it would surface as an undefined-symbol link error). The IR-identity proof is the empirical backstop.

## Files Changed
- `compiler/src/llvm/runtime_helpers.sfn` — 46 `symbol:` → `native_signature` rewrites
- `compiler/tests/unit/abi_version_test.sfn` — 2 print pins + rationale comment (Cat-C `fs.read`/`sleep` pins left intact)
- `docs/runtime_architecture.md` — Appendix A sweep note + ✓ #911 row markers

## Follow-ups
- #912 — Cat-B flips (`null`-nsig descriptors with shipped `sfn_*` bodies; per-symbol ABI verification)
- #821 — retarget to Appendix-A/Cat-C tracking + correct its acceptance criterion (still `needs-grooming`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RYcX6x9QUicfbzmYB42JH1)_