### PR TITLE
refactor(lowering): drop 6 dead Cat-B runtime helper descriptors (part of #912)

### DIFF
--- a/compiler/src/llvm/runtime_helpers.sfn
+++ b/compiler/src/llvm/runtime_helpers.sfn
@@ -180,9 +180,6 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
         target: "fs.write", symbol: "sailfin_intrinsic_fs_write", return_type: "void", parameter_types: ["i8*", "i8*"], effects: ["io"], native_signature: null, c_abi_return_type: null
     });
-    descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "fs.exists", symbol: "sailfin_intrinsic_fs_exists", return_type: "i1", parameter_types: ["i8*"], effects: ["io"], native_signature: null, c_abi_return_type: null
-    });
 
     // Arena mark / rewind. Phase 5a (`docs/proposals/phase-5a-arena-reset.md`)
     // exposes the existing C bump-allocator's mark/rewind primitive
@@ -283,12 +280,6 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
     // Network intrinsics
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
         target: "net_request", symbol: "sailfin_intrinsic_net_request", return_type: "i8*", parameter_types: ["i8*", "i8*", "i8*"], effects: ["net"], native_signature: null, c_abi_return_type: null
-    });
-    descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "http.get", symbol: "sailfin_intrinsic_http_get", return_type: "i8*", parameter_types: ["i8*"], effects: ["net"], native_signature: null, c_abi_return_type: null
-    });
-    descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "http.post", symbol: "sailfin_intrinsic_http_post", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: ["net"], native_signature: null, c_abi_return_type: null
     });
 
     // Concurrency intrinsics. Sleep call sites route through the
@@ -697,16 +688,6 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
     });
 
     // Collection helpers
-    descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "runtime_array_map_fn", symbol: "sailfin_runtime_array_map", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: [], native_signature: null, c_abi_return_type: null
-    });
-    descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "runtime_array_filter_fn", symbol: "sailfin_runtime_array_filter", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: [], native_signature: null, c_abi_return_type: null
-    });
-    descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "runtime_array_reduce_fn", symbol: "sailfin_runtime_array_reduce", return_type: "i8*", parameter_types: ["i8*", "i8*", "i8*"], effects: [], native_signature: null, c_abi_return_type: null
-    });
-
     // String utility helpers
     //
     // M2.4a (#396): the four string descriptors below carry a

--- a/docs/runtime_architecture.md
+++ b/docs/runtime_architecture.md
@@ -2203,6 +2203,26 @@ The following are explicitly **not** in scope for the 1.0 runtime:
 > now returns only not-yet-ported (Cat-B/C, `native_signature: null`)
 > and M4 scheduler rows. Cat-B/C flips track via #912; M4 stays.
 
+> **Registry sweep — #912 (Cat-B triage), 2026-05-30.** Per-symbol
+> audit of the Cat-B candidates found most were not clean flips: six
+> rows were **dead/vestigial and have been removed** rather than
+> flipped (per the #912 "drop dead duplicates" clause): the array
+> higher-order placeholders `runtime_array_map_fn` /
+> `runtime_array_filter_fn` / `runtime_array_reduce_fn` (`.map`/`.filter`/
+> `.reduce` are lowered inline; the legacy `sailfin_runtime_array_*`
+> symbols were never defined), and the intrinsic duplicates `fs.exists`
+> (`sailfin_intrinsic_fs_exists`), `http.get`
+> (`sailfin_intrinsic_http_get`), `http.post`
+> (`sailfin_intrinsic_http_post`) — superseded by the adapter rows #911
+> flipped, with no call site resolving to the dotted intrinsic forms.
+> All six had zero external references; removal is validated by
+> self-host. **Deferred** (not in this sweep): the exception family
+> (`throw` / `try_enter` / `try_leave` / `take_exception` → `sfn_*`)
+> remains a real flip pending exec-test ABI validation, and arena
+> (`sailfin_intrinsic_runtime_arena_mark` / `_rewind`) is an ABI
+> hazard — the bare `sfn_arena_mark` takes an arena pointer and is not
+> a drop-in, so it needs a real adapter, not a symbol flip.
+
 | Current C symbol | Native replacement | Milestone |
 |---|---|---|
 | `sailfin_runtime_print_raw` | `sfn_print` | M2 — ✓ #911 |


### PR DESCRIPTION
## Summary
Per-symbol triage of #912's Cat-B candidates found most were **not** clean flips. This PR does the safe, self-host-validated part: **removing 6 dead/vestigial descriptor rows** from `runtime_helpers.sfn` (the issue's "drop dead duplicates" clause). The exception flip and arena are deferred to follow-ups (see below).

**Dropped (6 rows, all with zero external references):**
- Array HOF placeholders `runtime_array_map_fn` / `runtime_array_filter_fn` / `runtime_array_reduce_fn` — `.map`/`.filter`/`.reduce` are lowered **inline**; the legacy `sailfin_runtime_array_*` symbols were never defined anywhere.
- Intrinsic duplicates `fs.exists` / `http.get` / `http.post` (`sailfin_intrinsic_fs_exists` / `_http_get` / `_http_post`) — superseded by the adapter rows #911 flipped; no call site resolves the dotted intrinsic forms.

Part of #912 (does not fully close it — see Deferred).

## Triage outcome (why drops-only)
| Family | Finding | Action |
|---|---|---|
| array `map`/`filter`/`reduce` | dead/vestigial, legacy symbol undefined | **dropped** ✅ |
| intrinsic `fs.exists`/`http.get`/`http.post` | dead duplicates of #911 adapter rows | **dropped** ✅ |
| exception `throw`/`try_enter`/`try_leave`/`take_exception` | real flip; bare `sfn_*` C trampolines exist but `sfn_throw` returns `i8*` vs descriptor `void` — needs **exec-test** ABI validation (unreliable in this sandbox) | **deferred** |
| arena `arena_mark`/`arena_rewind` | **ABI hazard** — bare `sfn_arena_mark` takes an arena pointer + returns i64; descriptor expects 0-arg/`double` C-ABI. Needs a real adapter, not a flip | **deferred** |

## Acceptance Criteria (scoped to the drops)
- [x] Dead intrinsic/vestigial duplicates dropped rather than flipped, with a note (Appendix A + #912 comment).
- [x] No hardcoded `@sailfin_*` emissions for the dropped symbols (grep + `test_lowering_no_bare_runtime_emissions.sh` passes).
- [x] Zero external references to the dropped targets/symbols (verified across `compiler/`, `runtime/`, `compiler/tests/`).
- [x] `make compile` self-hosts; `make check` gating suites pass (rc=0).
- [x] `sfn fmt --check` clean.

## Verification
```bash
ulimit -v 8388608 && make compile          # rc=0 (self-host validates the rows were dead)
ulimit -v 8388608 && make check            # rc=0 (gating suites pass)
bash compiler/tests/e2e/test_lowering_no_bare_runtime_emissions.sh   # rc=0
build/native/sailfin fmt --check compiler/src/llvm/runtime_helpers.sfn  # rc=0
# each dropped symbol now absent from the registry:
for s in sailfin_runtime_array_map sailfin_runtime_array_filter sailfin_runtime_array_reduce \
         sailfin_intrinsic_fs_exists sailfin_intrinsic_http_get sailfin_intrinsic_http_post; do
  grep -c "$s" compiler/src/llvm/runtime_helpers.sfn   # 0
done
```
**Note on `make check`:** the same nondeterministic native-exec/packaging e2e tests fail with **exit 127** in this sandbox (`bare-file run`, `sfn package`/tarball/installer) — environmental, identical to #911's runs; `make check` returns rc=0 (gating suites pass) and these touch no compile/IR path.

## Files Changed
- `compiler/src/llvm/runtime_helpers.sfn` — 6 dead descriptor blocks removed (18 lines)
- `docs/runtime_architecture.md` — Appendix A #912 triage note

## Deferred follow-ups
- **Exception flip** (`throw`/`try_enter`/`try_leave`/`take_exception` → `sfn_*`): real flip, needs a stable exec-test env to ABI-verify the `i8*`-vs-`void` return skew.
- **Arena adapter** (`arena_mark`/`arena_rewind`): ABI hazard — needs a real `sfn_*` adapter, not a symbol flip. Belongs with #821 Cat-C / runtime-audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RYcX6x9QUicfbzmYB42JH1)_