### PR TITLE
fix(cache): invalidate staged import-context by source content hash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -407,20 +407,6 @@ check:
 	@# `NATIVE_OPT` that lower the opt level for stage2/stage3 are
 	@# silently ignored until the driver grows an `--opt` flag.
 	@mkdir -p build/selfhost/native-seedcheck
-	@# Wipe stale import-context + scratch artifacts so the
-	@# stage_capsule_imports cache-hit short-circuit (treats existing
-	@# `.sfn-asm` + `.layout-manifest` as authoritative without source-
-	@# change invalidation) cannot serve a previous run's IR.
-	@# Mirrors `make rebuild`'s `build/native/import-context` wipe at
-	@# Makefile:654-656; without it, a re-run after a source change
-	@# could compile against stale staged modules and silently
-	@# undermine the fixed-point hash-diff. Per-stage, narrow to the
-	@# two file shapes that matter (rather than `rm -rf` the whole
-	@# work-dir) so the directory mtime survives for incremental
-	@# tooling that watches it.
-	@if [ -d build/selfhost/native-seedcheck/native/import-context ]; then \
-		find build/selfhost/native-seedcheck/native/import-context -type f \( -name '*.sfn-asm' -o -name '*.layout-manifest' \) -delete; \
-	fi
 	@if [ -d build/selfhost/native-seedcheck/scratch/capsules ]; then \
 		find build/selfhost/native-seedcheck/scratch/capsules -type f -name '*.ll' -delete; \
 	fi
@@ -454,14 +440,6 @@ check:
 	@# `make compile`) populated. See the stage2 block above for
 	@# the rationale.
 	@mkdir -p build/selfhost/native-stage3
-	@# Same wipe as stage2 — stage_capsule_imports's cache-hit
-	@# probe ignores source mtime, so stale staged modules from a
-	@# prior `make check` run would invisibly satisfy stage3 and
-	@# defeat the fixed-point comparison. See the stage2 block
-	@# above for the rationale.
-	@if [ -d build/selfhost/native-stage3/native/import-context ]; then \
-		find build/selfhost/native-stage3/native/import-context -type f \( -name '*.sfn-asm' -o -name '*.layout-manifest' \) -delete; \
-	fi
 	@if [ -d build/selfhost/native-stage3/scratch/capsules ]; then \
 		find build/selfhost/native-stage3/scratch/capsules -type f -name '*.ll' -delete; \
 	fi
@@ -653,15 +631,6 @@ rebuild:
 		exit 1; \
 	fi; \
 	echo "$$seed" > build/.seed-resolved
-	@# Wipe stale import-context so a "force rebuild" actually
-	@# re-stages every module instead of reusing whatever the
-	@# previous build left on disk. `stage_capsule_imports`
-	@# treats existing `.sfn-asm` + `.layout-manifest` pairs as
-	@# authoritative cache hits with no mtime/content check.
-	@mkdir -p build/native/import-context
-	@if [ -d build/native/import-context ]; then \
-		find build/native/import-context -type f \( -name '*.sfn-asm' -o -name '*.layout-manifest' \) -delete; \
-	fi
 	@# #812: pre-stage the runtime/sfn/platform extern modules with the
 	@# SEED *before* `sfn build -p compiler`. `runtime/sfn/io.sfn` calls
 	@# `write` (from `./platform/libc`) and `runtime/sfn/clock.sfn` calls

--- a/compiler/src/capsule_resolver.sfn
+++ b/compiler/src/capsule_resolver.sfn
@@ -47,7 +47,8 @@ import {
     canonicalize_flags,
     empty_build_cache_config,
     empty_cache_stats,
-    is_valid_digest
+    is_valid_digest,
+    sha256_of_file
 } from "./build_cache";
 import {
     CapsuleArtifactLayout,
@@ -1025,16 +1026,49 @@ fn enumerate_capsule_sources(project_root: string) -> CapsuleSource[] ![io] {
 // compiler's normal import resolver (llvm/imports.sfn:_resolve_layout_manifest_path_for_slug)
 // looks in build/native/import-context/<slug>.* so that's where we write.
 //
-// Cache invalidation contract: a present `.sfn-asm` artifact paired
-// with its `.layout-manifest` is treated as valid and re-used as-is.
-// Sailfin's emit is deterministic (proven by `make check`'s stage2 ==
-// stage3 byte-identical fixed-point), so re-emitting an already-staged
-// module produces the same bytes — making the re-emit pure overhead.
-// Pre-cache, `sfn check compiler/src/main.sfn` re-emitted ~130 modules
-// sequentially and crashed the seed compiler at ~84s; with the cache,
-// staging is a no-op when `make compile` has already produced the
-// artifacts. Refresh by `rm -rf build/native/import-context/` (or
-// `make rebuild`), the same invalidation contract `make` itself uses.
+// Cache invalidation contract: a staged `.sfn-asm` + `.layout-manifest`
+// pair is a valid cache hit only when a `.srchash` sidecar written next to
+// them matches the current SHA-256 of the module's source. A missing or
+// stale sidecar (or an unreadable source) forces a fresh emit; the sidecar
+// is (re)written after every fresh emit.
+//
+// This is content-addressed, not mtime-based, on purpose: Sailfin's emit is
+// deterministic (proven by `make check`'s stage2 == stage3 byte-identical
+// fixed-point), so byte-identical source <=> byte-identical IR, and the
+// source hash is the canonical predicate. mtime is deliberately NOT used —
+// `git checkout` resets mtimes to checkout time, so timestamps lie (#514).
+// Because of this, the Makefile no longer wipes the staged IR by hand;
+// `stage_capsule_imports` notices a changed source on its own.
+// _cr_srchash_path: location of the source-content sidecar for a staged
+// module, alongside its `.sfn-asm` / `.layout-manifest`.
+fn _cr_srchash_path(context_root: string, slug: string) -> string {
+    return context_root + "/" + slug + ".srchash";
+}
+
+// _cr_stage_cache_hit: true when the staged artifacts are a valid cache hit
+// for `src_path` — both `.sfn-asm` and `.layout-manifest` exist AND the
+// recorded `.srchash` matches the current SHA-256 of the source. A missing
+// or stale sidecar, or an unreadable source, returns false (fresh emit).
+fn _cr_stage_cache_hit(asm_path: string, manifest_path: string, srchash_path: string, src_path: string) -> boolean ![io] {
+    if !fs.exists(asm_path) { return false; }
+    if !fs.exists(manifest_path) { return false; }
+    if !fs.exists(srchash_path) { return false; }
+    let recorded = fs.readFile(srchash_path);
+    if recorded.length == 0 { return false; }
+    let current = sha256_of_file(src_path);
+    if current.length == 0 { return false; }
+    return strings_equal(recorded, current);
+}
+
+// _cr_write_srchash: record the source SHA-256 sidecar for a freshly staged
+// module so the next run's cache-hit probe can detect an unchanged source.
+// Best-effort: a hash failure leaves no sidecar, which forces a re-emit.
+fn _cr_write_srchash(srchash_path: string, src_path: string) ![io] {
+    let current = sha256_of_file(src_path);
+    if current.length == 0 { return; }
+    fs.writeFile(srchash_path, current);
+}
+
 // Stage E PR1: stage one capsule source's import-context
 // (`.sfn-asm` + `.layout-manifest`). When `sailfin_exe.length >
 // 0`, the heavy native-text emit happens in a subprocess so the
@@ -1048,14 +1082,15 @@ fn _cr_stage_one(src: CapsuleSource, sailfin_exe: string, work_dir: string) -> b
     let context_root = _cr_import_context_root(work_dir);
     let asm_path = context_root + "/" + src.slug + ".sfn-asm";
     let manifest_path = context_root + "/" + src.slug + ".layout-manifest";
+    let srchash_path = _cr_srchash_path(context_root, src.slug);
     let asm_dir = _cr_dirname(asm_path);
     _cr_ensure_dir(asm_dir);
 
-    // Cache hit: both the asm and the manifest are present. Trust the
-    // pair — they were produced by a prior `make compile` (or earlier
-    // staging pass) of this same source file.
-    if fs.exists(asm_path) {
-        if fs.exists(manifest_path) { return true; }
+    // Cache hit: the asm + manifest are present AND the source-content
+    // sidecar matches (see cache invalidation contract above). A stale or
+    // missing sidecar falls through to a fresh emit.
+    if _cr_stage_cache_hit(asm_path, manifest_path, srchash_path, src.source_path) {
+        return true;
     }
 
     if !fs.exists(src.source_path) {
@@ -1097,6 +1132,9 @@ fn _cr_stage_one(src: CapsuleSource, sailfin_exe: string, work_dir: string) -> b
     // helper with the parallel-stage path so both routes produce
     // byte-identical manifests.
     _cr_extract_layout_manifest(asm_path, manifest_path);
+    // Record the source-content sidecar so the next run can detect an
+    // unchanged source (best-effort; a hash failure simply re-emits later).
+    _cr_write_srchash(srchash_path, src.source_path);
     return true;
 }
 
@@ -1195,12 +1233,12 @@ fn stage_capsule_imports(sources: CapsuleSource[], sailfin_exe: string, work_dir
         let src = sources[si];
         let asm_path = context_root + "/" + src.slug + ".sfn-asm";
         let manifest_path = context_root + "/" + src.slug + ".layout-manifest";
+        let srchash_path = _cr_srchash_path(context_root, src.slug);
         let asm_dir = _cr_dirname(asm_path);
         _cr_ensure_dir(asm_dir);
-        let mut cache_hit: boolean = false;
-        if fs.exists(asm_path) {
-            if fs.exists(manifest_path) { cache_hit = true; }
-        }
+        // Cache hit requires asm + manifest present AND the source sidecar
+        // to match (same content-hash contract as the serial path).
+        let cache_hit = _cr_stage_cache_hit(asm_path, manifest_path, srchash_path, src.source_path);
         if !cache_hit {
             if !fs.exists(src.source_path) {
                 print.err("capsule-resolver: missing source file: " + src.source_path);
@@ -1232,7 +1270,11 @@ fn stage_capsule_imports(sources: CapsuleSource[], sailfin_exe: string, work_dir
             let asm_path = context_root + "/" + src.slug + ".sfn-asm";
             let manifest_path = context_root + "/" + src.slug
                 + ".layout-manifest";
+            let srchash_path = _cr_srchash_path(context_root, src.slug);
             _cr_extract_layout_manifest(asm_path, manifest_path);
+            // Record the source-content sidecar so a subsequent probe sees
+            // this freshly-emitted module as a valid cache hit.
+            _cr_write_srchash(srchash_path, src.source_path);
             ei += 1;
         }
     }

--- a/compiler/tests/unit/stage_capsule_imports_test.sfn
+++ b/compiler/tests/unit/stage_capsule_imports_test.sfn
@@ -1,0 +1,146 @@
+// Regression tests for #514: `stage_capsule_imports` must invalidate its
+// staged `.sfn-asm` + `.layout-manifest` cache by source-content hash, not
+// by file existence or mtime.
+//
+// Before #514 the staging cache treated a present `.sfn-asm` + `.layout-manifest`
+// pair as an authoritative hit purely by existence, so the Makefile had to
+// wipe `build/native/import-context/*.sfn-asm` by hand on every rebuild. The
+// fix records a `.srchash` sidecar holding the SHA-256 of the source; a hit
+// now requires that sidecar to match the source's current hash.
+//
+// These tests pin the content-hash semantics so a future "mtime is faster"
+// refactor can't silently regress: `git checkout` resets mtimes to checkout
+// time, so timestamps lie — only the content hash is trustworthy.
+//
+// Each test uses its own `/tmp` namespace so parallel runs don't collide,
+// and cleans up on exit.
+import { sha256_of_file } from "../../src/build_cache";
+import { _cr_srchash_path, _cr_stage_cache_hit, _cr_write_srchash } from "../../src/capsule_resolver";
+
+// --------------------------------------------------------------
+// Fixture helpers
+// --------------------------------------------------------------
+fn _sct_tmp_root(label: string) -> string ![io] {
+    let root = "/tmp/sfn_stage_cache_test_" + label;
+    process.run(["rm", "-rf", root]);
+    process.run(["mkdir", "-p", root]);
+    return root;
+}
+
+fn _sct_cleanup(path: string) ![io] {
+    process.run(["rm", "-rf", path]);
+}
+
+// Stage the three on-disk artifacts a real cache hit needs:
+// `<root>/<slug>.sfn-asm`, `<root>/<slug>.layout-manifest`, and the
+// `.srchash` sidecar recording the current source hash.
+fn _sct_stage(root: string, slug: string, src_path: string, asm_path: string, manifest_path: string) ![io] {
+    fs.writeFile(asm_path, "; staged native IR placeholder\n");
+    fs.writeFile(manifest_path, ".layout foo i64\n");
+    _cr_write_srchash(_cr_srchash_path(root, slug), src_path);
+}
+
+// --------------------------------------------------------------
+// Sidecar path shape
+// --------------------------------------------------------------
+test "stage cache: srchash sidecar is a sibling of the staged artifacts" {
+    assert _cr_srchash_path("build/native/import-context", "cli_main") == "build/native/import-context/cli_main.srchash";
+    assert _cr_srchash_path("build/native/import-context", "sfn/cli/mod") == "build/native/import-context/sfn/cli/mod.srchash";
+}
+
+// --------------------------------------------------------------
+// Cache hit / miss by content
+// --------------------------------------------------------------
+test "stage cache: hit when source is unchanged" ![io] {
+    let root = _sct_tmp_root("hit_unchanged");
+    let slug = "mymod";
+    let src_path = root + "/mymod.sfn";
+    let asm_path = root + "/" + slug + ".sfn-asm";
+    let manifest_path = root + "/" + slug + ".layout-manifest";
+    fs.writeFile(src_path, "fn main() { }\n");
+    _sct_stage(root, slug, src_path, asm_path, manifest_path);
+    assert _cr_stage_cache_hit(asm_path, manifest_path, _cr_srchash_path(root, slug), src_path);
+    _sct_cleanup(root);
+}
+
+test "stage cache: miss when source content changes" ![io] {
+    let root = _sct_tmp_root("miss_changed");
+    let slug = "mymod";
+    let src_path = root + "/mymod.sfn";
+    let asm_path = root + "/" + slug + ".sfn-asm";
+    let manifest_path = root + "/" + slug + ".layout-manifest";
+    fs.writeFile(src_path, "fn main() { }\n");
+    _sct_stage(root, slug, src_path, asm_path, manifest_path);
+    // The sidecar now records the OLD hash; changing the bytes must miss.
+    fs.writeFile(src_path, "fn main() { print.info(\"changed\"); }\n");
+    assert ! _cr_stage_cache_hit(asm_path, manifest_path, _cr_srchash_path(root, slug), src_path);
+    _sct_cleanup(root);
+}
+
+// The headline guarantee: a pure mtime bump (rewrite of byte-identical
+// content) must NOT invalidate. An mtime-based cache would wrongly miss
+// here; the content-hash predicate must still hit.
+test "stage cache: identical content after rewrite still hits (content-hash, not mtime)" ![io] {
+    let root = _sct_tmp_root("mtime_only");
+    let slug = "mymod";
+    let src_path = root + "/mymod.sfn";
+    let asm_path = root + "/" + slug + ".sfn-asm";
+    let manifest_path = root + "/" + slug + ".layout-manifest";
+    let body = "fn main() { }\n";
+    fs.writeFile(src_path, body);
+    _sct_stage(root, slug, src_path, asm_path, manifest_path);
+    fs.writeFile(src_path, body);
+    assert _cr_stage_cache_hit(asm_path, manifest_path, _cr_srchash_path(root, slug), src_path);
+    _sct_cleanup(root);
+}
+
+// --------------------------------------------------------------
+// Cache miss guards
+// --------------------------------------------------------------
+test "stage cache: miss when sidecar absent" ![io] {
+    let root = _sct_tmp_root("no_sidecar");
+    let slug = "mymod";
+    let src_path = root + "/mymod.sfn";
+    let asm_path = root + "/" + slug + ".sfn-asm";
+    let manifest_path = root + "/" + slug + ".layout-manifest";
+    fs.writeFile(src_path, "fn main() { }\n");
+    fs.writeFile(asm_path, "; ir\n");
+    fs.writeFile(manifest_path, "");
+    // asm + manifest exist but no `.srchash` -> miss (forces fresh emit).
+    assert ! _cr_stage_cache_hit(asm_path, manifest_path, _cr_srchash_path(root, slug), src_path);
+    _sct_cleanup(root);
+}
+
+test "stage cache: miss when asm or manifest missing" ![io] {
+    let root = _sct_tmp_root("missing_artifact");
+    let slug = "mymod";
+    let src_path = root + "/mymod.sfn";
+    let asm_path = root + "/" + slug + ".sfn-asm";
+    let manifest_path = root + "/" + slug + ".layout-manifest";
+    fs.writeFile(src_path, "fn main() { }\n");
+    _cr_write_srchash(_cr_srchash_path(root, slug), src_path);
+    // Sidecar matches, but artifacts are absent -> miss.
+    assert ! _cr_stage_cache_hit(asm_path, manifest_path, _cr_srchash_path(root, slug), src_path);
+    fs.writeFile(asm_path, "; ir\n");
+    // asm present, manifest still absent -> miss.
+    assert ! _cr_stage_cache_hit(asm_path, manifest_path, _cr_srchash_path(root, slug), src_path);
+    _sct_cleanup(root);
+}
+
+// --------------------------------------------------------------
+// Underlying content-addressing primitive
+// --------------------------------------------------------------
+test "stage cache: sha256_of_file is content-addressed, not mtime-addressed" ![io] {
+    let root = _sct_tmp_root("sha_content");
+    let a = root + "/a.sfn";
+    fs.writeFile(a, "fn x() { }\n");
+    let h1 = sha256_of_file(a);
+    assert h1.length == 64;
+    // Rewrite byte-identical content (bumps mtime) -> same hash.
+    fs.writeFile(a, "fn x() { }\n");
+    assert sha256_of_file(a) == h1;
+    // Different bytes -> different hash.
+    fs.writeFile(a, "fn y() { }\n");
+    assert sha256_of_file(a) != h1;
+    _sct_cleanup(root);
+}

--- a/compiler/tests/unit/stage_capsule_imports_test.sfn
+++ b/compiler/tests/unit/stage_capsule_imports_test.sfn
@@ -12,10 +12,43 @@
 // refactor can't silently regress: `git checkout` resets mtimes to checkout
 // time, so timestamps lie — only the content hash is trustworthy.
 //
+// The cache-hit predicate lives in `compiler/src/capsule_resolver.sfn`, but
+// importing that module's entry points pulls in the whole driver (and fails
+// to link standalone — `exe_path` / `resolve_runtime_root` are unresolved in
+// a unit-test link). So, mirroring `workspace_resolver_test.sfn`, the three
+// pure helpers are inlined here verbatim. Only the linkable `sha256_of_file`
+// primitive is imported from `build_cache`.
+//
+// Keep in sync with `capsule_resolver.sfn`'s `_cr_srchash_path`,
+// `_cr_stage_cache_hit`, and `_cr_write_srchash`.
+//
 // Each test uses its own `/tmp` namespace so parallel runs don't collide,
 // and cleans up on exit.
 import { sha256_of_file } from "../../src/build_cache";
-import { _cr_srchash_path, _cr_stage_cache_hit, _cr_write_srchash } from "../../src/capsule_resolver";
+
+// -- inline copy of capsule_resolver.sfn:_cr_srchash_path --
+fn _cr_srchash_path(context_root: string, slug: string) -> string {
+    return context_root + "/" + slug + ".srchash";
+}
+
+// -- inline copy of capsule_resolver.sfn:_cr_stage_cache_hit --
+fn _cr_stage_cache_hit(asm_path: string, manifest_path: string, srchash_path: string, src_path: string) -> boolean ![io] {
+    if !fs.exists(asm_path) { return false; }
+    if !fs.exists(manifest_path) { return false; }
+    if !fs.exists(srchash_path) { return false; }
+    let recorded = fs.readFile(srchash_path);
+    if recorded.length == 0 { return false; }
+    let current = sha256_of_file(src_path);
+    if current.length == 0 { return false; }
+    return strings_equal(recorded, current);
+}
+
+// -- inline copy of capsule_resolver.sfn:_cr_write_srchash --
+fn _cr_write_srchash(srchash_path: string, src_path: string) ![io] {
+    let current = sha256_of_file(src_path);
+    if current.length == 0 { return; }
+    fs.writeFile(srchash_path, current);
+}
 
 // --------------------------------------------------------------
 // Fixture helpers


### PR DESCRIPTION
## Summary
- `stage_capsule_imports` now invalidates its staged `.sfn-asm` + `.layout-manifest` cache by **source content hash** (a `.srchash` SHA-256 sidecar), not by mere file existence.
- A cache hit requires both artifacts to exist **and** the sidecar to match the source's current hash; a missing/stale sidecar (or unreadable source) forces a fresh emit. Applied identically on the serial and parallel staging paths.
- Deleted the three Makefile import-context wipe blocks (seedcheck/stage2, stage3, `rebuild`) — the whole point of epic #513 Phase 0.1. The stage2 == stage3 fixed point still holds without them.

Reuses `build_cache`'s exported `sha256_of_file` for one source of truth. Content-addressed on purpose: emit is deterministic (proven by the fixed point), and mtime lies after `git checkout`.

Closes #514

## Acceptance Criteria
- [x] Writes a `.srchash` sidecar containing the SHA-256 of the source whenever it produces a fresh `.sfn-asm` (serial subprocess path + parallel xargs path).
- [x] `_cr_stage_one`'s cache-hit probe requires `.sfn-asm` + `.layout-manifest` to exist AND the sidecar hash to match; mismatch falls through to a fresh emit.
- [x] `stage_capsule_imports`' parallel-path probe applies the same three-part check.
- [x] After deleting the Makefile wipe blocks, `make check` still produces a byte-identical stage2 vs stage3 fixed point on a clean repo.
- [x] Editing a `compiler/src/*.sfn` file does NOT serve a stale `.sfn-asm` (content-hash invalidation in the compiler, verified via `make check` rebuild path).
- [x] Unit test covering: hit when source unchanged, miss when content changes, hit after a byte-identical rewrite (mtime-only invalidation explicitly rejected), plus miss guards for absent sidecar / missing artifacts.
- [x] `make compile` passes.
- [x] `make check` passes.

## Verification
```text
make compile         → self-hosts (rebuild from seed, exit 0)
make check           → [check] stage2 == stage3: compiler is a fixed point ✓ (exit 0)
sfn test compiler/tests/unit/stage_capsule_imports_test.sfn → PASS (all 7 tests passed)
sfn fmt --check compiler/src/capsule_resolver.sfn compiler/tests/unit/stage_capsule_imports_test.sfn → clean
```

## Files Changed
- `compiler/src/capsule_resolver.sfn` — new `_cr_srchash_path` / `_cr_stage_cache_hit` / `_cr_write_srchash` helpers; content-hash cache-hit probe in `_cr_stage_one` and the parallel path; sidecar write after every fresh emit; updated cache-invalidation contract comment; import `sha256_of_file` from `build_cache`.
- `Makefile` — deleted the three import-context `find … -delete` wipe blocks.
- `compiler/tests/unit/stage_capsule_imports_test.sfn` (new) — 7 regression tests pinning content-hash semantics.

## Notes
- The staged-source-only SHA is sufficient invalidation here: `_cr_compile_one`'s downstream `.ll` cache is separately content-addressed via `cache_key_for` (which mixes in dep manifests + version + flags). No architectural divergence — no re-grooming needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01M9Ku1E5udA6w2TBWKU8r1S)_