### PR TITLE
refactor(lowering): flip http.get/http.post member-call descriptors to sfn targets

### DIFF
--- a/compiler/src/llvm/runtime_helpers.sfn
+++ b/compiler/src/llvm/runtime_helpers.sfn
@@ -284,11 +284,16 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
         target: "net_request", symbol: "sailfin_intrinsic_net_request", return_type: "i8*", parameter_types: ["i8*", "i8*", "i8*"], effects: ["net"], native_signature: null, c_abi_return_type: null
     });
+    // `http.get` / `http.post` member calls flipped (#912) to the
+    // Sailfin-native socket client in `runtime/sfn/adapters/http.sfn`:
+    // `sfn_http_get` (`i8*`->`i8*`) and `sfn_http_post2` (the 2-arg
+    // `(url, body)` POST wrapper matching this row's arity). ABI-verified,
+    // link-time resolved against the already-shipped bodies.
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "http.get", symbol: "sailfin_intrinsic_http_get", return_type: "i8*", parameter_types: ["i8*"], effects: ["net"], native_signature: null, c_abi_return_type: null
+        target: "http.get", symbol: "sfn_http_get", return_type: "i8*", parameter_types: ["i8*"], effects: ["net"], native_signature: "sfn_http_get", c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "http.post", symbol: "sailfin_intrinsic_http_post", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: ["net"], native_signature: null, c_abi_return_type: null
+        target: "http.post", symbol: "sfn_http_post2", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: ["net"], native_signature: "sfn_http_post2", c_abi_return_type: null
     });
 
     // Concurrency intrinsics. Sleep call sites route through the

--- a/compiler/tests/e2e/test_runtime_adapter_http.sh
+++ b/compiler/tests/e2e/test_runtime_adapter_http.sh
@@ -135,6 +135,50 @@ PROBE
     return "$missing"
 }
 
+# ---- Test: member-call `http.get(url)` / `http.post(url, body)` flip (#912) ----
+#
+# Distinct from `test_probe_flipped` above, which exercises the
+# `http.get_body` / `http.post_json` adapter rows. This probe pins the
+# *member-call* descriptors (`target: "http.get"` / `target: "http.post"`
+# in runtime_helpers.sfn) flipped in #912: `http.get(url)` must lower to
+# `@sfn_http_get` and `http.post(url, body)` to the 2-arg `@sfn_http_post2`,
+# with no residual call to the old `@sailfin_intrinsic_http_*` symbols.
+test_probe_member_call_flipped() {
+    local probe="$SCRATCH/http_member_probe.sfn"
+    cat > "$probe" <<'PROBE'
+fn main() -> int ![net, io] {
+    let got = http.get("http://127.0.0.1:9/");
+    print(got);
+    let posted = http.post("http://127.0.0.1:9/", "{}");
+    print(posted);
+    return 0;
+}
+PROBE
+    local ll="$SCRATCH/http_member_probe.ll"
+    local log="$SCRATCH/http_member_probe.log"
+    if ! "$BINARY" emit -o "$ll" llvm "$probe" > "$log" 2>&1; then
+        echo "[test]   sfn emit llvm failed on http_member_probe.sfn:"
+        cat "$log"
+        return 1
+    fi
+    local missing=0
+    # Anchor on a non-identifier follow char (portable across GNU/BSD grep).
+    if ! grep -qE "call [^\"]*@sfn_http_get\(" "$ll"; then
+        echo "[test]   http.get(url) does not lower to a @sfn_http_get call"
+        missing=$((missing + 1))
+    fi
+    if ! grep -qE "call [^\"]*@sfn_http_post2\(" "$ll"; then
+        echo "[test]   http.post(url, body) does not lower to a @sfn_http_post2 call"
+        missing=$((missing + 1))
+    fi
+    # The old member-call intrinsics must not be CALLED anymore.
+    if grep -qE "call [^\"]*@sailfin_intrinsic_http_(get|post)\(" "$ll"; then
+        echo "[test]   member call still emits @sailfin_intrinsic_http_* (expected the #912 flip)"
+        missing=$((missing + 1))
+    fi
+    return "$missing"
+}
+
 # ---- Behavioral: GET + POST round-trip against a localhost listener ----
 #
 # Starts a Python TCP listener that loops one-response-per-connection,
@@ -243,6 +287,7 @@ run_test "sfn check runtime/sfn/adapters/http.sfn passes" test_check_clean
 run_test "sfn fmt --check runtime/sfn/adapters/http.sfn is canonical" test_fmt_clean
 run_test "sfn emit llvm defines every sfn_http_* export + socket declares" test_emit_define_shape
 run_test "http.get_body lowers to @sfn_http_get (not the curl path)" test_probe_flipped
+run_test "http.get/http.post member calls lower to @sfn_http_get/@sfn_http_post2 (#912)" test_probe_member_call_flipped
 run_test "GET + POST round-trip against a localhost listener returns the body" test_get_round_trip
 
 echo "[summary] $PASS passed, $FAIL failed"

--- a/docs/runtime_architecture.md
+++ b/docs/runtime_architecture.md
@@ -2235,7 +2235,7 @@ The following are explicitly **not** in scope for the 1.0 runtime:
 | `sailfin_runtime_is_string/number/boolean/array/callable`, `instance_of`, `resolve_type` | `sfn_is_*` / `sfn_instance_of` / `sfn_resolve_type` | M2 — ✓ #911 |
 | `sailfin_runtime_sha256_hex` | `sfn/crypto` capsule | M3 |
 | `sailfin_runtime_base64_encode` | `sfn/crypto` capsule | M3 |
-| `sailfin_runtime_http_get/post_json/download`, `sailfin_adapter_http_get/post` | `sfn_http_get/post/post2/download` | M3 — ✓ #911 |
+| `sailfin_runtime_http_get/post_json/download`, `sailfin_adapter_http_get/post`, `sailfin_intrinsic_http_get/post` | `sfn_http_get/post/post2/download` | M3 — ✓ #911 (runtime/adapter rows); ✓ #912 (`http.get`/`http.post` member-call descriptors → `sfn_http_get`/`sfn_http_post2`) |
 | `sailfin_runtime_getenv` | `sfn_getenv` | **M2.8b (#726)** shipped SfnString aggregate ABI + arena-threaded marshalling. — ✓ #911 (registry `symbol` flipped) |
 | `sailfin_runtime_home_dir` | `sfn_home_dir` | **M2.8b (#726)** shipped SfnString aggregate ABI + arena-threaded marshalling. — ✓ #911 (registry `symbol` flipped) |
 


### PR DESCRIPTION
## Summary
- Flip the `http.get` member-call descriptor to `sfn_http_get` (`i8*`→`i8*`, 1-arg) — both `symbol` and `native_signature`.
- Flip the `http.post` member-call descriptor to `sfn_http_post2`, the **2-arg** `(url, body)` variant (`sfn_http_post` is 3-arg and would skew the ABI).
- Update `docs/runtime_architecture.md` Appendix A for the http member-call rows.

The flips resolve at link time against the already-shipped `sfn_*` bodies in `runtime/sfn/adapters/http.sfn` — no seed dependency.

Closes #912

## Acceptance Criteria
- [x] Both `http.get`/`http.post` descriptors point at `sfn_http_get`/`sfn_http_post2`; neither matches `symbol: "(sailfin_runtime|sailfin_intrinsic|sailfin_adapter)_*` anymore.
- [x] ABI confirmed: `sfn_http_post2(url, body)` is the 2-arg variant (`runtime/sfn/adapters/http.sfn:558`); `sfn_http_get(url)` is 1-arg (`:535`). Return/param types match the descriptors (`i8*`/`i8*`,`i8*` → `i8*`).
- [x] grep `compiler/src/llvm/lowering/` + `compiler/src/llvm/expression_lowering/native/` for hardcoded `@sailfin_intrinsic_http_*` emissions — none found; nothing to update in lockstep.
- [x] `compiler/tests/e2e/test_lowering_no_bare_runtime_emissions.sh` passes.
- [x] `make compile && make check` pass (stage2 == stage3 fixed point ✓; seedcheck promoted).
- [x] `sfn fmt --check` clean.

## Verification
```bash
$ build/native/sailfin fmt --check compiler/src/llvm/runtime_helpers.sfn   # exit 0
$ grep -nE 'symbol: "sailfin_intrinsic_http_(get|post)"' compiler/src/llvm/runtime_helpers.sfn   # no matches
$ bash compiler/tests/e2e/test_lowering_no_bare_runtime_emissions.sh build/native/sailfin
[test] PASS: 2 allowlisted runtime emission(s) match audit
$ make check
═══ e2e-sh: 83/83 passed, 0 failed ═══
[check] stage2 == stage3: compiler is a fixed point ✓
[check] promoted seedcheck → build/native/sailfin
```

## Files Changed
- `compiler/src/llvm/runtime_helpers.sfn` — 2 descriptor flips + comment
- `docs/runtime_architecture.md` — Appendix A http row status

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019AvagGCSsBdyryopc2sAbh)_