### PR TITLE
refactor(lowering): drop dead exception legacy descriptors (#918)

### DIFF
--- a/compiler/src/llvm/runtime_helpers.sfn
+++ b/compiler/src/llvm/runtime_helpers.sfn
@@ -966,19 +966,17 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
         target: "has_exception", symbol: "sailfin_runtime_has_exception", return_type: "i1", parameter_types: [], effects: [], native_signature: null, c_abi_return_type: null
     });
-    descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "try_enter", symbol: "sailfin_runtime_try_enter", return_type: "i32", parameter_types: ["i8**"], effects: [], native_signature: null, c_abi_return_type: null
-    });
-    descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "try_leave", symbol: "sailfin_runtime_try_leave", return_type: "void", parameter_types: ["i8*"], effects: [], native_signature: null, c_abi_return_type: null
-    });
-    descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "throw", symbol: "sailfin_runtime_throw", return_type: "void", parameter_types: ["i8*"], effects: [], native_signature: null, c_abi_return_type: null
-    });
-    descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "take_exception", symbol: "sailfin_runtime_take_exception", return_type: "i8*", parameter_types: [], effects: [], native_signature: null, c_abi_return_type: null
-    });
 
+    // M2.7b (#404) replaced the legacy TLS-polling exception primitives
+    // (`throw` / `try_enter` / `try_leave` / `take_exception`) with the
+    // frame-based path below. Those four descriptors had no live call
+    // emit site — `instructions_try.sfn` lowers exclusively through
+    // `sfn_throw_frame` / `sfn_take_exception_frame` /
+    // `sfn_exception_push_frame` / `sfn_exception_pop_frame` — and their
+    // would-be `sfn_*` targets are ABI-mismatched, so they were dropped
+    // (not flipped) under #918. The backing legacy C exception symbols
+    // stay exported in `runtime/native/` for seed-built IR until the
+    // M3.9 seed cut.
     // M2.7b (#404): frame-based exception primitives from
     // `runtime/sfn/exception.sfn`. `instructions_try.sfn` emits inline
     // `sfn_exception_push_frame` + `setjmp` + `sfn_exception_pop_frame`

--- a/docs/runtime_architecture.md
+++ b/docs/runtime_architecture.md
@@ -2227,7 +2227,8 @@ The following are explicitly **not** in scope for the 1.0 runtime:
 | `sailfin_runtime_process_run` (`process_run_v2`) | `sfn_process_run` | M2 — ✓ #911 |
 | `sailfin_adapter_fs_read_file` | `sfn_fs_read_file` | M3 — ✓ #911 |
 | `sailfin_adapter_fs_write_file` | `sfn_fs_write_file` | M3 — ✓ #911 |
-| `sailfin_runtime_set/has/clear/take_exception` | `sfn_try_enter/leave/throw/take` | M2 |
+| `sailfin_runtime_set/has/clear_exception` | frame-based `sfn_exception_*` path (M2.7b, #404) | M2 — `set/has/clear` descriptor rows retained for the Throw/Try declare lists (seed-compat); C symbols stay exported until M3.9 |
+| `sailfin_runtime_throw/try_enter/try_leave/take_exception` | `sfn_throw`/`sfn_take_exception` (frame-based, M2.7b #404) | M2 — **legacy descriptor rows removed (#918)**: dead since M2.7b (no live call emit site), ABI-mismatched so dropped not flipped. Backing C symbols stay exported in `runtime/native/` for seed-built IR until the M3.9 seed cut. |
 | `sailfin_runtime_spawn_*` | `sfn_spawn` | M4 |
 | `sailfin_runtime_await_*` | `sfn_await` | M4 |
 | `sailfin_runtime_channel` | `sfn_channel_create` | M4 |


### PR DESCRIPTION
## Summary
- Delete the four **dead** legacy exception `RuntimeHelperDescriptor` rows — `throw`, `try_enter`, `try_leave`, `take_exception` — from `compiler/src/llvm/runtime_helpers.sfn`. M2.7b (#404) replaced this TLS-polling codepath with the frame-based path; the active try/throw lowering emits only the frame symbols, so these four had zero live call emit sites. They can't be flipped (ABI-mismatched `sfn_*` targets), so the disposition is a **verified drop**, replaced with a tombstone comment.
- Update `docs/runtime_architecture.md` Appendix A to mark the legacy entries removed.

Closes #918

## Deadness audit (the gate #917 missed)
```
$ grep -rnE 'sailfin_runtime_(throw|try_enter|try_leave|take_exception)' compiler/src/ runtime/
# only: the 4 descriptor rows (now deleted), runtime/native C bodies + header
#       (kept for seed compat), and explanatory comments. No live call sites.
```
- `instructions_try.sfn` lowers try/throw **exclusively** through `sfn_throw_frame` / `sfn_take_exception_frame` / `sfn_exception_push_frame` / `sfn_exception_pop_frame` (verified by reading every `emit_runtime_call` in that file). No legacy symbol is ever emitted as a `call`.
- `effects.sfn:554` lists `"take_exception"` in the Try-variant **declare** set, but `render_runtime_helper_declarations` (rendering.sfn:138–143) is **descriptor-driven**: it walks the registry and emits a declare only for descriptors whose `target` is in `used_targets`. With the descriptor deleted, that orphan target string matches nothing and emits nothing — provably inert, **not** a live emit site. (`throw`/`try_enter`/`try_leave` are not referenced there at all; the Throw list uses `set_exception`/`sfn_throw_frame`.)
- e2e guards `test_drop_emission_try_catch.sh` and `test_runtime_exception_frames.sh` assert the *correct* direction (frame-based `@sfn_take_exception` call present; legacy symbols absent as `define`s) and do **not** require a legacy `declare`.

## Scope note (surfaced, not silently expanded)
Kept edits to the two files in the issue's Files Affected. The now-orphaned `"take_exception"` string in `effects.sfn:554` is left as-is because it's provably inert (descriptor-driven rendering) and editing it would expand scope — it's a natural **M2.7c** cleanup follow-up.

## Acceptance Criteria
- [x] Audit grep proves zero live emit sites for all four symbols (above).
- [x] The four rows are removed from `compiler/src/llvm/runtime_helpers.sfn`.
- [x] `compiler/tests/e2e/test_lowering_no_bare_runtime_emissions.sh` passes.
- [x] `sfn fmt --check` clean.
- [x] Appendix A reflects removal.
- [ ] `make compile && make check` pass **through the seedcheck stage** — `make compile` passed (first-pass self-hosts); `make check` is finalizing locally (first-pass suite green, seedcheck build in progress). Will confirm on this thread.

## Verification
```bash
$ grep -nE 'sailfin_runtime_(throw|try_enter|try_leave|take_exception)' compiler/src/llvm/runtime_helpers.sfn
# (no matches)

$ build/native/sailfin fmt --check compiler/src/llvm/runtime_helpers.sfn
# FMT_CLEAN

$ bash compiler/tests/e2e/test_lowering_no_bare_runtime_emissions.sh build/native/sailfin
[test] PASS: 2 allowlisted runtime emission(s) match audit
```

## Files Changed
- `compiler/src/llvm/runtime_helpers.sfn` — 4 descriptor rows removed
- `docs/runtime_architecture.md` — Appendix A status

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01V9wMYgDKcDukX2tz9DtRuM)_