### PR TITLE
refactor(lowering): delete dead io/fs/net intrinsic tombstones

### DIFF
--- a/compiler/src/llvm/runtime_helpers.sfn
+++ b/compiler/src/llvm/runtime_helpers.sfn
@@ -168,18 +168,7 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
         target: "console.error", symbol: "sfn_print_error", return_type: "void", parameter_types: ["{i8*, i64}"], effects: ["io"], native_signature: "sfn_print_error", c_abi_return_type: null
     });
 
-    // IO intrinsics
-    descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "io_read", symbol: "sailfin_intrinsic_io_read", return_type: "i8*", parameter_types: ["i8*"], effects: ["io"], native_signature: null, c_abi_return_type: null
-    });
-
     // Filesystem intrinsics
-    descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "fs.read", symbol: "sailfin_intrinsic_fs_read", return_type: "i8*", parameter_types: ["i8*"], effects: ["io"], native_signature: null, c_abi_return_type: null
-    });
-    descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "fs.write", symbol: "sailfin_intrinsic_fs_write", return_type: "void", parameter_types: ["i8*", "i8*"], effects: ["io"], native_signature: null, c_abi_return_type: null
-    });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
         target: "fs.exists", symbol: "sailfin_intrinsic_fs_exists", return_type: "i1", parameter_types: ["i8*"], effects: ["io"], native_signature: null, c_abi_return_type: null
     });
@@ -280,10 +269,7 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
         target: "intrinsic.errno_location.mingw", symbol: "_errno", return_type: "i32*", parameter_types: [], effects: [], native_signature: null, c_abi_return_type: null
     });
 
-    // Network intrinsics
-    descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "net_request", symbol: "sailfin_intrinsic_net_request", return_type: "i8*", parameter_types: ["i8*", "i8*", "i8*"], effects: ["net"], native_signature: null, c_abi_return_type: null
-    });
+    // Network intrinsics.
     // `http.get` / `http.post` member calls flipped (#912) to the
     // Sailfin-native socket client in `runtime/sfn/adapters/http.sfn`:
     // `sfn_http_get` (`i8*`->`i8*`) and `sfn_http_post2` (the 2-arg

--- a/compiler/tests/unit/abi_version_test.sfn
+++ b/compiler/tests/unit/abi_version_test.sfn
@@ -86,10 +86,10 @@ test "abi_version: `print.err` helper carries native_signature sfn_print_err" {
     assert helper.native_signature == "sfn_print_err";
 }
 
-test "abi_version: default `fs.read` helper has native_signature == null" {
-    let helper = find_runtime_helper("fs.read");
+test "abi_version: default `fs.exists` helper has native_signature == null" {
+    let helper = find_runtime_helper("fs.exists");
     assert helper != null;
-    assert helper.symbol == "sailfin_intrinsic_fs_read";
+    assert helper.symbol == "sailfin_intrinsic_fs_exists";
     assert helper.native_signature == null;
 }
 

--- a/docs/runtime_audit.md
+++ b/docs/runtime_audit.md
@@ -304,8 +304,8 @@ requests in `compiler/src/llvm/runtime_helpers.sfn`.
   (`is_*`/`resolve_type`/`instance_of`), and concurrency primitives (`channel`,
   `parallel`, top-level `spawn`, `serve`) are **stubs**.
 - Several helper symbols the compiler declares in `runtime_helpers.sfn`
-  (e.g. `sailfin_intrinsic_io_read`, `sailfin_adapter_channel_*`,
-  `sailfin_adapter_spawn_task`) **do not exist in the runtime at all** — these
+  (e.g. `sailfin_adapter_channel_*`, `sailfin_adapter_spawn_task`)
+  **do not exist in the runtime at all** — these
   are declaration-only and would fail at link time if ever emitted. They are
   effectively dead paths in the compiler today.
 - **The runtime has no memory management.** Arrays never free. `string_drop`
@@ -470,27 +470,6 @@ survives until process exit. This is why per-module compiler RAM reaches
 | `sailfin_runtime_sha256_hex` | ✅ (ported) | SHA-256 reimplemented in pure Sailfin in `capsules/sfn/crypto/src/mod.sfn` (M3, #816); the `crypto.sha256` intrinsic now resolves to the capsule symbol. C body in `sailfin_sha256.c` (~150 lines) stays linked for seed compat until M3.9 deletes it. |
 | `sailfin_runtime_base64_encode` | ✅ | Separate file `sailfin_base64.c` |
 | `sailfin_runtime_getenv` / `home_dir` / `read_file_bytes` | ✅ | Used by `sfn/os` and package manager |
-
-### Helpers the compiler declares but never emits (link-time landmines)
-
-`compiler/src/llvm/runtime_helpers.sfn` registers these symbols in the runtime
-helper descriptor table, but they have **no C definition**. They appear to be
-aspirational placeholders left over from earlier effect-adapter plans:
-
-- `sailfin_intrinsic_io_read`
-- `sailfin_intrinsic_fs_read`, `sailfin_intrinsic_fs_write`
-- `sailfin_intrinsic_model_invoke`
-- `sailfin_intrinsic_net_request`
-- `sailfin_intrinsic_http_get`, `sailfin_intrinsic_http_post`
-- `sailfin_adapter_serve_start`, `sailfin_adapter_serve_handler_dispatch`
-- `sailfin_adapter_spawn_task`
-- `sailfin_adapter_channel_create`, `_channel_send`, `_channel_receive`
-
-No current compiler path emits calls to these, so the build links clean. If
-someone ever extends an existing lowering path to route through one of these
-(e.g. wires `io.read()` to `sailfin_intrinsic_io_read`), the build will fail at
-link time. Worth cleaning up when the ABI is locked: either delete the entries
-from the registry, or define stub C symbols so the names mean something.
 
 ## Bootstrap-Era Defensive Scaffolding
 


### PR DESCRIPTION
## Summary
- Delete the four declaration-only runtime-helper descriptors with no C definition and no emit site: `io_read`/`sailfin_intrinsic_io_read`, `fs.read`/`sailfin_intrinsic_fs_read`, `fs.write`/`sailfin_intrinsic_fs_write`, `net_request`/`sailfin_intrinsic_net_request`.
- Remove the `docs/runtime_audit.md` "Helpers the compiler declares but never emits" section and a now-stale `io_read` example in the summary bullet above it.
- Repoint the `abi_version` unit-test fixture from the deleted `fs.read` row to the still-registered `fs.exists` (same unflipped, `native_signature: null` shape).

Closes #820

## Scope decisions (per the pickup caveat comment on #820)
- **`http.get` / `http.post`** — the issue body listed `sailfin_intrinsic_http_get/post` tombstones, but #912 already flipped the live rows to `sfn_http_get` / `sfn_http_post2`. Re-grepped: the dead tombstones are gone. **Untouched.**
- **fs-perms tail** (`set_perms`, `get_perms`, `mkdtemp`, `is_executable`, `symlink`, `write_lines_v2`) — `grep -rn` shows real C bodies (`sailfin_runtime.c`), header decls, emit sites (`lowering_helpers.sfn`), capsule wrappers, and tests. These are **Category-C LIVE per #821** (flip-to-`sfn_*`, not delete). **Deliberately left in place.**
- **serve / spawn / channel / model_invoke** — M4-scoped per the issue `Out:` section; registry rows untouched (the audit doc's summary bullet still cites `sailfin_adapter_channel_*` / `sailfin_adapter_spawn_task` as the live examples).

## Acceptance Criteria
- [x] For each deleted entry: grep across `compiler/src/ runtime/ capsules/ examples/` returns no emit site.
- [x] Entries removed from `runtime_helpers.sfn`; audit section removed from `runtime_audit.md`.
- [x] `make compile` && `make check` pass (self-host fixed-point ✓).

## Verification
```
$ grep -rn 'sailfin_intrinsic_io_read|fs_read|fs_write|net_request' compiler/src/ runtime/ capsules/ examples/ docs/
EMPTY (good)

$ grep -E 'sailfin_intrinsic_(io_read|fs_read|fs_write|net_request|http_get|http_post)' compiler/src/llvm/runtime_helpers.sfn
EMPTY (good)

$ ulimit -v 8388608 && make check
... first-pass suite: all pass (e2e-sh 83/83)
[check] stage2 tests passed
[check] stage2 == stage3: compiler is a fixed point ✓
EXIT=0
```

## Files Changed
- `compiler/src/llvm/runtime_helpers.sfn` — delete 4 dead intrinsic rows
- `docs/runtime_audit.md` — remove dead-helpers section + stale example
- `compiler/tests/unit/abi_version_test.sfn` — repoint fixture `fs.read` → `fs.exists` (required: the test pinned the deleted row; without this the suite SIGABRTs on a null lookup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TTeuRkhMUH3ykQ5mzaMM7w)_