### PR TITLE
chore(lowering): delete dead string.drop runtime-helper descriptor row

### DIFF
--- a/compiler/src/llvm/runtime_helpers.sfn
+++ b/compiler/src/llvm/runtime_helpers.sfn
@@ -770,9 +770,6 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
         target: "string.append", symbol: "sfn_str_append", return_type: "void", parameter_types: ["ptr", "{i8*, i64}", "ptr"], effects: [], native_signature: null, c_abi_return_type: null
     });
-    descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "string.drop", symbol: "sailfin_runtime_string_drop", return_type: "void", parameter_types: ["i8*"], effects: [], native_signature: null, c_abi_return_type: null
-    });
     // Scope-exit drop helper for owned RC locals (M1.5.2, issue #326).
     // Emit_scope_drops generates `call void @sfn_rc_release(i8* %ptr)` for
     // each owned local with `allocation_kind == "rc"` at scope close. The


### PR DESCRIPTION
## Summary
- Delete the unreferenced `string.drop` (`sailfin_runtime_string_drop`) `RuntimeHelperDescriptor` row from `compiler/src/llvm/runtime_helpers.sfn`.
- This is the **only genuinely-dead symbol** from #924's deletion list — the others are all live (see below). PR is scoped to the safe portion only.

**Partial of #924** (`Refs #924`, not `Closes`) — 6 of 7 symbols in that issue are live; the issue is being re-labeled `needs-grooming` for a corrected audit.

## Why string.drop is safe to delete
- Zero compiler emission sites: nothing emits a `string.drop` call (`grep -rn 'string_drop\|"string.drop"' compiler/src` → only the row).
- The `SAILFIN_ENABLE_STRING_FREE` gate is purely runtime-side (`runtime/native/src/sailfin_runtime.c:1947`), not a compiler emission path.
- The C body (`sailfin_runtime_string_drop`) stays — its removal is #822's scope.

## What I did NOT delete (and why #924 needs re-grooming)
The issue's grooming audit used quoted-string greps that masked real call sites. Verified live:
- **`fs.exists`** — the most-used filesystem primitive (100+ `fs.exists(path)` call sites lower through its row); unit test `abi_version_test.sfn:89` asserts the helper exists. Deleting it breaks self-hosting.
- **`is_void` / `runtime_is_void_fn`** — live prelude type-guard for the `void` primitive (`runtime/prelude.sfn:546`).
- **`log_execution` / `runtime_log_execution_fn`** — live `@logExecution`/`@trace` decorator emitter (`emission.sfn:470`, `effects.sfn:481`), exercised by `examples/advanced/decorators.sfn`.
- **capability bridges** (`create_capability_grant`/`_filesystem_bridge`/`_http_bridge`) — exported prelude API (`prelude.sfn:702–704`) with a live example `examples/io/capability_bridges.sfn`.

`fs.exists`, the bridges, and `is_void` are additionally declare-seeded in `compiler/src/llvm/lowering/lowering_helpers.sfn` (a file #924's `## Files Affected` omitted).

## Verification
```
ulimit -v 8388608 && make compile   # ✓ self-hosts
ulimit -v 8388608 && make check      # ✓ full suite + seedcheck fixed-point (stage2 == stage3 ✓)
sfn fmt --check compiler/src/llvm/runtime_helpers.sfn   # ✓ clean
grep -n 'string.drop\|string_drop' compiler/src/llvm/runtime_helpers.sfn   # ✓ empty
```

## Files Changed
- `compiler/src/llvm/runtime_helpers.sfn` — delete `string.drop` descriptor row (3 lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019vM41Zv6HNg6vTrexWVLrq)_