### PR TITLE
refactor(runtime): Cat-C ports — char preds, to_debug_string, is_void, log_execution, array-HOF routing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -856,6 +856,63 @@ rebuild:
 		echo "[rebuild] staging http.o..."; \
 		$(CLANG) -O2 -Wno-override-module -c build/native/obj/runtime/http.ll -o build/native/obj/runtime/http.o; \
 	fi
+	@# Stage io.o (Sailfin-native I/O wrappers from runtime/sfn/io.sfn).
+	@# #925 (epic #390) ports the Cat-C `@logExecution` decorator body
+	@# to `@sfn_log_execution`, defined only in this Sailfin module. The
+	@# legacy `sfn run` / `sfn build` link path
+	@# (`_clang_compile_runtime_objects` in `compiler/src/cli_main.sfn`)
+	@# resolves the symbol against this staged .o; the runtime-capsule
+	@# path reaches io.sfn through `runtime/native/capsule.toml`'s
+	@# `sfn-sources` array instead. Without this staging, any user
+	@# program using `@logExecution` fails at link with "undefined
+	@# reference to `sfn_log_execution`".
+	@if [ ! -f build/native/obj/runtime/io.ll ]; then \
+		echo "[rebuild] staging io.ll..."; \
+		$(NATIVE_OUT) emit -o build/native/obj/runtime/io.ll llvm runtime/sfn/io.sfn >/dev/null; \
+	fi
+	@if [ ! -f build/native/obj/runtime/io.o ]; then \
+		echo "[rebuild] staging io.o..."; \
+		$(CLANG) -O2 -Wno-override-module -c build/native/obj/runtime/io.ll -o build/native/obj/runtime/io.o; \
+	fi
+	@# Stage string.o (Sailfin-native string helpers from
+	@# runtime/sfn/string.sfn). #925 (epic #390) ports the Cat-C
+	@# `to_debug_string` (→ `@sfn_to_debug_string`, live in prelude
+	@# struct formatting) and the `sfn_str_is_*` char predicates to
+	@# Sailfin bodies. The legacy link path resolves
+	@# `@sfn_to_debug_string` against this staged .o; the runtime-capsule
+	@# path reaches string.sfn through `runtime/native/capsule.toml`'s
+	@# `sfn-sources` array instead. Without this staging, any user
+	@# program that formats a struct fails at link with "undefined
+	@# reference to `sfn_to_debug_string`".
+	@if [ ! -f build/native/obj/runtime/string.ll ]; then \
+		echo "[rebuild] staging string.ll..."; \
+		$(NATIVE_OUT) emit -o build/native/obj/runtime/string.ll llvm runtime/sfn/string.sfn >/dev/null; \
+	fi
+	@if [ ! -f build/native/obj/runtime/string.o ]; then \
+		echo "[rebuild] staging string.o..."; \
+		$(CLANG) -O2 -Wno-override-module -c build/native/obj/runtime/string.ll -o build/native/obj/runtime/string.o; \
+	fi
+	@# Stage array.o (Sailfin-native array stubs from
+	@# runtime/sfn/array.sfn). #925 (epic #390) routes the
+	@# `runtime_array_map_fn` / `_filter_fn` / `_reduce_fn` descriptors
+	@# to the `sfn_array_sfn_map` / `_filter` / `_reduce` stub exports
+	@# (real closure-backed semantics are M4). The prelude's `array_map`
+	@# / `array_filter` / `array_reduce` wrappers reference those
+	@# symbols, so prelude.o carries an undefined reference to each; the
+	@# legacy link path resolves them against this staged .o. The
+	@# runtime-capsule path reaches array.sfn through
+	@# `runtime/native/capsule.toml`'s `sfn-sources` array instead.
+	@# Without this staging, every user program fails at link with
+	@# "undefined reference to `sfn_array_sfn_filter`" (prelude.o pulls
+	@# the array-HOF wrappers in unconditionally).
+	@if [ ! -f build/native/obj/runtime/array.ll ]; then \
+		echo "[rebuild] staging array.ll..."; \
+		$(NATIVE_OUT) emit -o build/native/obj/runtime/array.ll llvm runtime/sfn/array.sfn >/dev/null; \
+	fi
+	@if [ ! -f build/native/obj/runtime/array.o ]; then \
+		echo "[rebuild] staging array.o..."; \
+		$(CLANG) -O2 -Wno-override-module -c build/native/obj/runtime/array.ll -o build/native/obj/runtime/array.o; \
+	fi
 	@# Stage exec.o (Sailfin-native executable-path + runtime-root
 	@# resolution from runtime/sfn/platform/exec.sfn). Issue #468
 	@# (epic #451 M5.3 prerequisite) ships `@exe_path` /
@@ -957,6 +1014,9 @@ ci-cross-windows:
 	EXCEPTION_LL="build/native/obj/runtime/exception.ll"; \
 	FILESYSTEM_LL="build/native/obj/runtime/filesystem.ll"; \
 	HTTP_LL="build/native/obj/runtime/http.ll"; \
+	IO_LL="build/native/obj/runtime/io.ll"; \
+	STRING_LL="build/native/obj/runtime/string.ll"; \
+	ARRAY_LL="build/native/obj/runtime/array.ll"; \
 	if [ ! -d "$$SAVED_DIR" ] || [ ! -f "$$SAVED_DIR/program.ll" ]; then \
 		echo "[cross-windows][error] missing $$SAVED_DIR/*.ll + program.ll — run 'make rebuild' first" >&2; \
 		exit 1; \
@@ -987,6 +1047,18 @@ ci-cross-windows:
 	fi; \
 	if [ ! -f "$$HTTP_LL" ]; then \
 		echo "[cross-windows][error] missing $$HTTP_LL — 'make rebuild' should have emitted it (M3, #818)" >&2; \
+		exit 1; \
+	fi; \
+	if [ ! -f "$$IO_LL" ]; then \
+		echo "[cross-windows][error] missing $$IO_LL — 'make rebuild' should have emitted it (Cat-C ports, #925)" >&2; \
+		exit 1; \
+	fi; \
+	if [ ! -f "$$STRING_LL" ]; then \
+		echo "[cross-windows][error] missing $$STRING_LL — 'make rebuild' should have emitted it (Cat-C ports, #925)" >&2; \
+		exit 1; \
+	fi; \
+	if [ ! -f "$$ARRAY_LL" ]; then \
+		echo "[cross-windows][error] missing $$ARRAY_LL — 'make rebuild' should have emitted it (Cat-C ports, #925)" >&2; \
 		exit 1; \
 	fi; \
 	echo "[cross-windows] using saved sfn build IR layout ($$SAVED_DIR)"; \
@@ -1062,6 +1134,16 @@ ci-cross-windows:
 		$(CLANG) -target x86_64-w64-mingw32 $(NATIVE_OPT) -fno-delete-null-pointer-checks \
 			-c "$$HTTP_LL" -o "$$WIN_OBJ/runtime/http.o"; \
 		\
+	echo "[cross-windows] compiling io (Sailfin-native @sfn_log_execution, Cat-C #925)..."; \
+	$(CLANG) -target x86_64-w64-mingw32 $(NATIVE_OPT) -fno-delete-null-pointer-checks \
+		-c "$$IO_LL" -o "$$WIN_OBJ/runtime/io.o"; \
+	echo "[cross-windows] compiling string (Sailfin-native @sfn_to_debug_string + char preds, Cat-C #925)..."; \
+	$(CLANG) -target x86_64-w64-mingw32 $(NATIVE_OPT) -fno-delete-null-pointer-checks \
+		-c "$$STRING_LL" -o "$$WIN_OBJ/runtime/string.o"; \
+	echo "[cross-windows] compiling array (Sailfin-native @sfn_array_sfn_* stubs, Cat-C #925)..."; \
+	$(CLANG) -target x86_64-w64-mingw32 $(NATIVE_OPT) -fno-delete-null-pointer-checks \
+		-c "$$ARRAY_LL" -o "$$WIN_OBJ/runtime/array.o"; \
+	\
 	echo "[cross-windows] compiling C runtime..."; \
 	$(MINGW_CC) -O2 -I runtime/native/include -c runtime/native/src/sailfin_arena.c \
 		-o "$$WIN_OBJ/sailfin_arena.o"; \
@@ -1098,6 +1180,9 @@ ci-cross-windows:
 		"$$WIN_OBJ/runtime/exception.o" \
 		"$$WIN_OBJ/runtime/filesystem.o" \
 		"$$WIN_OBJ/runtime/http.o" \
+		"$$WIN_OBJ/runtime/io.o" \
+		"$$WIN_OBJ/runtime/string.o" \
+		"$$WIN_OBJ/runtime/array.o" \
 		$$SHIM_O \
 		-lm -lpthread -lws2_32; \
 	\
@@ -1140,6 +1225,18 @@ ci-cross-windows:
 	if [ -f "$$WIN_OBJ/runtime/http.o" ]; then \
 		mkdir -p "$$INSTALLER_DIR/runtime/native/obj"; \
 		cp -f "$$WIN_OBJ/runtime/http.o" "$$INSTALLER_DIR/runtime/native/obj/http.o"; \
+	fi; \
+	if [ -f "$$WIN_OBJ/runtime/io.o" ]; then \
+		mkdir -p "$$INSTALLER_DIR/runtime/native/obj"; \
+		cp -f "$$WIN_OBJ/runtime/io.o" "$$INSTALLER_DIR/runtime/native/obj/io.o"; \
+	fi; \
+	if [ -f "$$WIN_OBJ/runtime/string.o" ]; then \
+		mkdir -p "$$INSTALLER_DIR/runtime/native/obj"; \
+		cp -f "$$WIN_OBJ/runtime/string.o" "$$INSTALLER_DIR/runtime/native/obj/string.o"; \
+	fi; \
+	if [ -f "$$WIN_OBJ/runtime/array.o" ]; then \
+		mkdir -p "$$INSTALLER_DIR/runtime/native/obj"; \
+		cp -f "$$WIN_OBJ/runtime/array.o" "$$INSTALLER_DIR/runtime/native/obj/array.o"; \
 	fi; \
 	tar -czf "dist/installer-$(MINGW_TARGET).tar.gz" -C "$$INSTALLER_DIR" .; \
 	echo "[cross-windows] done: dist/installer-$(MINGW_TARGET).tar.gz"

--- a/compiler/src/cli_commands.sfn
+++ b/compiler/src/cli_commands.sfn
@@ -253,6 +253,61 @@ fn _clang_link_test_cmd_with_deps(ll_path: string, out_path: string, runtime_roo
             }
             fsi += 1;
         }
+        // #925 (epic #390): mirrors the clock / process / type_meta /
+        // filesystem staging above for the Cat-C ports. The prelude's
+        // `logExecution` wrapper references `@sfn_log_execution`
+        // (defined in `runtime/sfn/io.sfn`); without this `.o` every
+        // test binary fails at link with "undefined reference to
+        // `sfn_log_execution`" because prelude.o pulls the wrapper in
+        // unconditionally. Same search order as the paths above.
+        let io_paths: string[] = ["build/selfhost/native/obj/runtime/io.o", "build/native/obj/runtime/io.o", "build/native/obj/io.o", runtime_root
+            + "/native/obj/runtime/io.o", runtime_root
+            + "/native/obj/io.o",];
+        let mut ioi: int = 0;
+        loop {
+            if ioi >= io_paths.length { break; }
+            if fs.exists(io_paths[ioi]) {
+                args.push(io_paths[ioi]);
+                break;
+            }
+            ioi += 1;
+        }
+        // #925: companion to the io.o staging above. The prelude's
+        // `to_debug_string` wrapper references `@sfn_to_debug_string`
+        // (defined in `runtime/sfn/string.sfn`, alongside the
+        // `sfn_str_is_*` char-predicate ports); without this `.o` every
+        // test binary fails at link with "undefined reference to
+        // `sfn_to_debug_string`".
+        let string_paths: string[] = ["build/selfhost/native/obj/runtime/string.o", "build/native/obj/runtime/string.o", "build/native/obj/string.o", runtime_root
+            + "/native/obj/runtime/string.o", runtime_root
+            + "/native/obj/string.o",];
+        let mut stri: int = 0;
+        loop {
+            if stri >= string_paths.length { break; }
+            if fs.exists(string_paths[stri]) {
+                args.push(string_paths[stri]);
+                break;
+            }
+            stri += 1;
+        }
+        // #925: companion to the io.o / string.o staging above. The
+        // prelude's `array_map` / `array_filter` / `array_reduce`
+        // wrappers reference `@sfn_array_sfn_map` / `_filter` /
+        // `_reduce` (defined in `runtime/sfn/array.sfn`); without this
+        // `.o` every test binary fails at link with "undefined
+        // reference to `sfn_array_sfn_filter`".
+        let array_paths: string[] = ["build/selfhost/native/obj/runtime/array.o", "build/native/obj/runtime/array.o", "build/native/obj/array.o", runtime_root
+            + "/native/obj/runtime/array.o", runtime_root
+            + "/native/obj/array.o",];
+        let mut ari: int = 0;
+        loop {
+            if ari >= array_paths.length { break; }
+            if fs.exists(array_paths[ari]) {
+                args.push(array_paths[ari]);
+                break;
+            }
+            ari += 1;
+        }
     }
     args.push("-lm");
     args.push("-pthread");
@@ -2432,6 +2487,47 @@ fn _package_installer(target: string, out_dir: string, compiler_bin: string) -> 
                 + filesystem_src);
             process.run(["rm", "-rf", staging]);
             return 1;
+        }
+    }
+
+    // Pre-built io / string / array objects — Sailfin-native Cat-C
+    // ports added in #925 (epic #390). Mirrors the clock.o / process.o
+    // / type_meta.o / filesystem.o staging above: optional on a fresh
+    // checkout, hard fail once staged. The prelude's `logExecution` /
+    // `to_debug_string` / `array_map` / `array_filter` / `array_reduce`
+    // wrappers reference `@sfn_log_execution` / `@sfn_to_debug_string`
+    // / `@sfn_array_sfn_*` unconditionally, so without these objects
+    // every program compiled by the installed binary fails at link.
+    let cat_c_mods: string[] = ["io", "string", "array"];
+    let mut cci: int = 0;
+    loop {
+        if cci >= cat_c_mods.length { break; }
+        let mod_name = cat_c_mods[cci];
+        cci += 1;
+        let cat_c_a = "build/selfhost/native/obj/runtime/" + mod_name + ".o";
+        let cat_c_b = "build/native/obj/runtime/" + mod_name + ".o";
+        let mut cat_c_src: string = "";
+        if fs.exists(cat_c_a) { cat_c_src = cat_c_a; } else {
+            if fs.exists(cat_c_b) { cat_c_src = cat_c_b; }
+        }
+        if cat_c_src.length > 0 {
+            let mk_obj_dir = process.run(["mkdir", "-p", staging_runtime_obj]);
+            if mk_obj_dir != 0 {
+                print("sfn package: failed to create runtime obj staging dir");
+                process.run(["rm", "-rf", staging]);
+                return 1;
+            }
+            let cp_cat_c = process.run(["cp", "-f", cat_c_src, staging_runtime_obj
+                + "/"
+                + mod_name
+                + ".o"]);
+            if cp_cat_c != 0 {
+                print("sfn package: failed to stage " + mod_name
+                    + " object from "
+                    + cat_c_src);
+                process.run(["rm", "-rf", staging]);
+                return 1;
+            }
         }
     }
 

--- a/compiler/src/cli_main.sfn
+++ b/compiler/src/cli_main.sfn
@@ -919,6 +919,99 @@ fn _runtime_http_path(root: string) -> string ![io] {
     return "";
 }
 
+// #925 (sub-issue of #390) mirrors the M3.1a / M3 filesystem & http
+// migrations above: the descriptor flip in
+// `compiler/src/llvm/runtime_helpers.sfn` routes the `@logExecution`
+// decorator emission to `sfn_log_execution`, defined in
+// `runtime/sfn/io.sfn` (the Cat-C port of the legacy C
+// `sailfin_runtime_log_execution`). The `sfn run` / `sfn build` link
+// path (this function's caller, `_clang_compile_runtime_objects`)
+// needs the staged `.o` to resolve the symbol whenever a user program
+// reaches a `@logExecution` call site. The runtime-capsule path
+// reaches io.sfn through `runtime/native/capsule.toml`'s `sfn-sources`
+// array instead. Search order mirrors `_runtime_filesystem_path` so
+// bundled installs and in-tree dev builds both find the staged
+// object. Empty return becomes fail-loud at link time as "undefined
+// reference to `sfn_log_execution`" the moment any user program uses
+// `@logExecution` — same fail-loud contract as the filesystem path.
+fn _runtime_io_path(root: string) -> string ![io] {
+    let bundled = _path_join(root, "native/obj/io.o");
+    if fs.exists(bundled) { return bundled; }
+    let bundled_nested = _path_join(root, "native/obj/runtime/io.o");
+    if fs.exists(bundled_nested) { return bundled_nested; }
+    let parent = _dirname(root);
+    let fallback = _path_join(parent, "build/native/obj/io.o");
+    if fs.exists(fallback) { return fallback; }
+    let fallback_nested = _path_join(parent, "build/native/obj/runtime/io.o");
+    if fs.exists(fallback_nested) { return fallback_nested; }
+    let selfhost_fallback = _path_join(parent, "build/selfhost/native/obj/io.o");
+    if fs.exists(selfhost_fallback) { return selfhost_fallback; }
+    let selfhost_fallback_nested = _path_join(parent, "build/selfhost/native/obj/runtime/io.o");
+    if fs.exists(selfhost_fallback_nested) { return selfhost_fallback_nested; }
+    return "";
+}
+
+// #925 (sub-issue of #390): companion to `_runtime_io_path` above for
+// the Cat-C string ports. The descriptor flip routes
+// `runtime_to_debug_string_fn` to `sfn_to_debug_string` and the three
+// char-predicate descriptors to `sfn_str_is_digit` /
+// `sfn_str_is_whitespace` / `sfn_str_is_alpha`, all defined in
+// `runtime/sfn/string.sfn`. The legacy link path needs the staged
+// `.o` to resolve `sfn_to_debug_string` whenever a user program
+// reaches `to_debug_string` (live in prelude struct formatting). The
+// runtime-capsule path reaches string.sfn through
+// `runtime/native/capsule.toml`'s `sfn-sources` array instead. Search
+// order mirrors `_runtime_filesystem_path`. Empty return becomes
+// fail-loud at link time as "undefined reference to
+// `sfn_to_debug_string`" the moment any user program formats a struct.
+fn _runtime_string_path(root: string) -> string ![io] {
+    let bundled = _path_join(root, "native/obj/string.o");
+    if fs.exists(bundled) { return bundled; }
+    let bundled_nested = _path_join(root, "native/obj/runtime/string.o");
+    if fs.exists(bundled_nested) { return bundled_nested; }
+    let parent = _dirname(root);
+    let fallback = _path_join(parent, "build/native/obj/string.o");
+    if fs.exists(fallback) { return fallback; }
+    let fallback_nested = _path_join(parent, "build/native/obj/runtime/string.o");
+    if fs.exists(fallback_nested) { return fallback_nested; }
+    let selfhost_fallback = _path_join(parent, "build/selfhost/native/obj/string.o");
+    if fs.exists(selfhost_fallback) { return selfhost_fallback; }
+    let selfhost_fallback_nested = _path_join(parent, "build/selfhost/native/obj/runtime/string.o");
+    if fs.exists(selfhost_fallback_nested) { return selfhost_fallback_nested; }
+    return "";
+}
+
+// #925 (sub-issue of #390): companion to `_runtime_io_path` /
+// `_runtime_string_path` for the array-HOF routing. The descriptor
+// flip routes `runtime_array_map_fn` / `runtime_array_filter_fn` /
+// `runtime_array_reduce_fn` to the `sfn_array_sfn_map` /
+// `sfn_array_sfn_filter` / `sfn_array_sfn_reduce` stub exports in
+// `runtime/sfn/array.sfn` (real closure-backed semantics are M4). The
+// prelude's `array_map` / `array_filter` / `array_reduce` wrappers
+// reference those symbols, so prelude.o carries an undefined reference
+// to each — the legacy link path needs the staged `.o` to resolve
+// them. The runtime-capsule path reaches array.sfn through
+// `runtime/native/capsule.toml`'s `sfn-sources` array instead. Search
+// order mirrors `_runtime_filesystem_path`. Empty return becomes
+// fail-loud at link time as "undefined reference to
+// `sfn_array_sfn_filter`".
+fn _runtime_array_path(root: string) -> string ![io] {
+    let bundled = _path_join(root, "native/obj/array.o");
+    if fs.exists(bundled) { return bundled; }
+    let bundled_nested = _path_join(root, "native/obj/runtime/array.o");
+    if fs.exists(bundled_nested) { return bundled_nested; }
+    let parent = _dirname(root);
+    let fallback = _path_join(parent, "build/native/obj/array.o");
+    if fs.exists(fallback) { return fallback; }
+    let fallback_nested = _path_join(parent, "build/native/obj/runtime/array.o");
+    if fs.exists(fallback_nested) { return fallback_nested; }
+    let selfhost_fallback = _path_join(parent, "build/selfhost/native/obj/array.o");
+    if fs.exists(selfhost_fallback) { return selfhost_fallback; }
+    let selfhost_fallback_nested = _path_join(parent, "build/selfhost/native/obj/runtime/array.o");
+    if fs.exists(selfhost_fallback_nested) { return selfhost_fallback_nested; }
+    return "";
+}
+
 // Last `/`-separated segment of a path. Returns the input itself
 // when there's no slash. Used for naming runtime obj outputs after
 // their source basename, matching the legacy `_clang_compile_runtime_objects`
@@ -1279,7 +1372,14 @@ fn _clang_compile_runtime_objects(runtime_root: string, out_dir: string, opt_fla
     // Build (or reuse) cached runtime object files so repeated `test` invocations
     // don't recompile the runtime C sources per test file.
     //
-    // Return shape: `[runtime_obj, arena_obj, globals_obj, prelude_obj, clock_obj, process_obj, exception_obj, exec_obj, type_meta_obj, filesystem_obj, http_obj]`.
+    // Return shape: `[runtime_obj, arena_obj, globals_obj, prelude_obj, clock_obj, process_obj, exception_obj, exec_obj, type_meta_obj, filesystem_obj, http_obj, io_obj, string_obj, array_obj]`.
+    // `io_obj` (#925) carries the Sailfin-native `@sfn_log_execution`
+    // (`@logExecution` decorator body); `string_obj` (#925) carries
+    // `@sfn_to_debug_string` plus the `sfn_str_is_*` char-predicate
+    // ports; `array_obj` (#925) carries the
+    // `sfn_array_sfn_map/filter/reduce` stubs the prelude's array-HOF
+    // wrappers reference. All follow the same empty-tolerated contract
+    // as the clock/http slots.
     // The trailing `clock_obj` slot is the PR 2 (#397) addition for the
     // Sailfin-native `@sfn_sleep` definition; `process_obj` is the M2.9
     // (#405) addition for `@sfn_process_run`; `exception_obj` is the
@@ -1303,10 +1403,10 @@ fn _clang_compile_runtime_objects(runtime_root: string, out_dir: string, opt_fla
     // of the first four going empty signals a failed runtime compile
     // and propagates back to the caller as a hard fail.
     if runtime_root.length == 0 {
-        return ["", "", "", "", "", "", "", "", "", "", ""];
+        return ["", "", "", "", "", "", "", "", "", "", "", "", "", ""];
     }
     if !_runtime_bundle_exists(runtime_root) {
-        return ["", "", "", "", "", "", "", "", "", "", ""];
+        return ["", "", "", "", "", "", "", "", "", "", "", "", "", ""];
     }
 
     let include_dir = _path_join(runtime_root, "native/include");
@@ -1321,6 +1421,15 @@ fn _clang_compile_runtime_objects(runtime_root: string, out_dir: string, opt_fla
     let type_meta_obj = _runtime_type_meta_path(runtime_root);
     let filesystem_obj = _runtime_filesystem_path(runtime_root);
     let http_obj = _runtime_http_path(runtime_root);
+    // #925: io_obj carries `@sfn_log_execution`; string_obj carries
+    // `@sfn_to_debug_string` (+ the char-predicate ports). Empty
+    // entries are tolerated the same way clock/http are — callers skip
+    // them when assembling the link line.
+    let io_obj = _runtime_io_path(runtime_root);
+    let string_obj = _runtime_string_path(runtime_root);
+    // #925: array_obj carries the `sfn_array_sfn_map/filter/reduce`
+    // stub exports the prelude's array-HOF wrappers reference.
+    let array_obj = _runtime_array_path(runtime_root);
 
     let runtime_obj = _path_join(out_dir, "sailfin_runtime" + opt_flag + ".o");
     let arena_obj = _path_join(out_dir, "sailfin_arena" + opt_flag + ".o");
@@ -1334,7 +1443,7 @@ fn _clang_compile_runtime_objects(runtime_root: string, out_dir: string, opt_fla
         let rc = process.run(["clang", opt_flag, "-Wno-override-module", "-I"
             + include_dir, "-c", runtime_src, "-o", runtime_obj,]);
         if rc != 0 {
-            return ["", "", "", "", "", "", "", "", "", "", ""];
+            return ["", "", "", "", "", "", "", "", "", "", "", "", "", ""];
         }
         _runtime_obj_cache_record(runtime_obj, runtime_key);
     }
@@ -1344,7 +1453,7 @@ fn _clang_compile_runtime_objects(runtime_root: string, out_dir: string, opt_fla
         let rc_arena = process.run(["clang", opt_flag, "-Wno-override-module", "-I"
             + include_dir, "-c", arena_src, "-o", arena_obj,]);
         if rc_arena != 0 {
-            return ["", "", "", "", "", "", "", "", "", "", ""];
+            return ["", "", "", "", "", "", "", "", "", "", "", "", "", ""];
         }
         _runtime_obj_cache_record(arena_obj, arena_key);
     }
@@ -1353,12 +1462,12 @@ fn _clang_compile_runtime_objects(runtime_root: string, out_dir: string, opt_fla
     if !_runtime_obj_cache_hit(globals_obj, globals_key) {
         let rc2 = process.run(["clang", opt_flag, "-Wno-override-module", "-c", runtime_ir, "-o", globals_obj,]);
         if rc2 != 0 {
-            return ["", "", "", "", "", "", "", "", "", "", ""];
+            return ["", "", "", "", "", "", "", "", "", "", "", "", "", ""];
         }
         _runtime_obj_cache_record(globals_obj, globals_key);
     }
 
-    return [runtime_obj, arena_obj, globals_obj, prelude_obj, clock_obj, process_obj, exception_obj, exec_obj, type_meta_obj, filesystem_obj, http_obj];
+    return [runtime_obj, arena_obj, globals_obj, prelude_obj, clock_obj, process_obj, exception_obj, exec_obj, type_meta_obj, filesystem_obj, http_obj, io_obj, string_obj, array_obj];
 }
 
 fn _clang_link_with_opt(ll_path: string, out_path: string, runtime_root: string, runtime_capsules: RuntimeCapsuleArtifacts[], opt_flag: string, cache_dir: string, binary_dir: string) -> int ![io] {
@@ -1517,6 +1626,20 @@ fn _clang_link_multi_with_opt(ll_paths: string[], out_path: string, runtime_root
         // reference to `sfn_http_get`" so the missing staged artifact
         // surfaces immediately.
         let http_obj = cached[10];
+        // #925: `io_obj` carries `@sfn_log_execution` (the `@logExecution`
+        // decorator body); `string_obj` carries `@sfn_to_debug_string`
+        // (live in prelude struct formatting) plus the char-predicate
+        // ports. Same empty-string fallback contract as `filesystem_obj`
+        // / `http_obj` — user programs that don't reach the symbols link
+        // fine; ones that use `@logExecution` / format a struct fail
+        // loudly with "undefined reference to `sfn_log_execution`" /
+        // "`sfn_to_debug_string`" so a missing staged artifact surfaces.
+        let io_obj = cached[11];
+        let string_obj = cached[12];
+        // #925: `array_obj` carries the `sfn_array_sfn_map/filter/reduce`
+        // stubs the prelude's array-HOF wrappers reference. Same
+        // empty-string fallback contract as `io_obj` / `string_obj`.
+        let array_obj = cached[13];
         let mut _missing: boolean = false;
         if runtime_obj.length == 0 { _missing = true; }
         if arena_obj.length == 0 { _missing = true; }
@@ -1537,6 +1660,9 @@ fn _clang_link_multi_with_opt(ll_paths: string[], out_path: string, runtime_root
         if type_meta_obj.length > 0 { runtime_objs.push(type_meta_obj); }
         if filesystem_obj.length > 0 { runtime_objs.push(filesystem_obj); }
         if http_obj.length > 0 { runtime_objs.push(http_obj); }
+        if io_obj.length > 0 { runtime_objs.push(io_obj); }
+        if string_obj.length > 0 { runtime_objs.push(string_obj); }
+        if array_obj.length > 0 { runtime_objs.push(array_obj); }
         runtime_link_libs.push("-lm");
     }
 

--- a/compiler/src/llvm/runtime_helpers.sfn
+++ b/compiler/src/llvm/runtime_helpers.sfn
@@ -436,10 +436,10 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
         target: "runtime_create_http_bridge", symbol: "sailfin_runtime_create_http_bridge", return_type: "i8*", parameter_types: ["i8*"], effects: ["net"], native_signature: null, c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "runtime_log_execution_fn", symbol: "sailfin_runtime_log_execution", return_type: "i8*", parameter_types: ["i8*"], effects: ["io"], native_signature: null, c_abi_return_type: null
+        target: "runtime_log_execution_fn", symbol: "sfn_log_execution", return_type: "i8*", parameter_types: ["i8*"], effects: ["io"], native_signature: "sfn_log_execution", c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "runtime_to_debug_string_fn", symbol: "sailfin_runtime_to_debug_string", return_type: "i8*", parameter_types: ["i8*"], effects: [], native_signature: null, c_abi_return_type: null
+        target: "runtime_to_debug_string_fn", symbol: "sfn_to_debug_string", return_type: "i8*", parameter_types: ["i8*"], effects: [], native_signature: "sfn_to_debug_string", c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
         target: "runtime_raise_value_error_fn", symbol: "sailfin_runtime_raise_value_error", return_type: "void", parameter_types: ["i8*"], effects: [], native_signature: null, c_abi_return_type: null
@@ -479,7 +479,7 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
         target: "runtime_is_boolean_fn", symbol: "sfn_is_boolean", return_type: "i1", parameter_types: ["i8*"], effects: [], native_signature: "sfn_is_boolean", c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "runtime_is_void_fn", symbol: "sailfin_runtime_is_void", return_type: "i1", parameter_types: ["i8*"], effects: [], native_signature: null, c_abi_return_type: null
+        target: "runtime_is_void_fn", symbol: "sfn_is_void", return_type: "i1", parameter_types: ["i8*"], effects: [], native_signature: "sfn_is_void", c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
         target: "runtime.bounds_check", symbol: "sailfin_runtime_bounds_check", return_type: "void", parameter_types: ["i64", "i64"], effects: [], native_signature: null, c_abi_return_type: null
@@ -689,13 +689,13 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
 
     // Collection helpers
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "runtime_array_map_fn", symbol: "sailfin_runtime_array_map", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: [], native_signature: null, c_abi_return_type: null
+        target: "runtime_array_map_fn", symbol: "sfn_array_sfn_map", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: [], native_signature: "sfn_array_sfn_map", c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "runtime_array_filter_fn", symbol: "sailfin_runtime_array_filter", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: [], native_signature: null, c_abi_return_type: null
+        target: "runtime_array_filter_fn", symbol: "sfn_array_sfn_filter", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: [], native_signature: "sfn_array_sfn_filter", c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "runtime_array_reduce_fn", symbol: "sailfin_runtime_array_reduce", return_type: "i8*", parameter_types: ["i8*", "i8*", "i8*"], effects: [], native_signature: null, c_abi_return_type: null
+        target: "runtime_array_reduce_fn", symbol: "sfn_array_sfn_reduce", return_type: "i8*", parameter_types: ["i8*", "i8*", "i8*"], effects: [], native_signature: "sfn_array_sfn_reduce", c_abi_return_type: null
     });
 
     // String utility helpers
@@ -823,13 +823,13 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
         target: "grapheme_at", symbol: "sfn_str_grapheme_at", return_type: "i8*", parameter_types: ["i8*", "double"], effects: [], native_signature: "sfn_str_grapheme_at", c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "is_whitespace_char", symbol: "sailfin_runtime_is_whitespace_char", return_type: "i1", parameter_types: ["i8"], effects: [], native_signature: null, c_abi_return_type: null
+        target: "is_whitespace_char", symbol: "sfn_str_is_whitespace", return_type: "i1", parameter_types: ["i8"], effects: [], native_signature: "sfn_str_is_whitespace", c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "is_decimal_digit", symbol: "sailfin_runtime_is_decimal_digit", return_type: "i1", parameter_types: ["i8"], effects: [], native_signature: null, c_abi_return_type: null
+        target: "is_decimal_digit", symbol: "sfn_str_is_digit", return_type: "i1", parameter_types: ["i8"], effects: [], native_signature: "sfn_str_is_digit", c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "is_alpha_char", symbol: "sailfin_runtime_is_alpha_char", return_type: "i1", parameter_types: ["i8"], effects: [], native_signature: null, c_abi_return_type: null
+        target: "is_alpha_char", symbol: "sfn_str_is_alpha", return_type: "i1", parameter_types: ["i8"], effects: [], native_signature: "sfn_str_is_alpha", c_abi_return_type: null
     });
 
     // M1.2 (#461): SfnString method descriptors registered with their

--- a/compiler/tests/e2e/test_runtime_sfn_sources_link_consumer.sh
+++ b/compiler/tests/e2e/test_runtime_sfn_sources_link_consumer.sh
@@ -101,7 +101,13 @@ ll-sources = ["ir/runtime_globals.ll"]
 # "undefined reference to sfn_exception_*". The list still leads
 # with `test_marker.sfn` so the "consumer fires for sfn-sources"
 # assertions below remain pointed at the marker file.
-sfn-sources = ["../sfn/test_marker.sfn", "../sfn/clock.sfn", "../sfn/exception.sfn", "../sfn/type_meta.sfn"]
+# #925 (epic #390) ported the Cat-C helpers, so prelude.o now
+# emits unconditional calls to `@sfn_log_execution` (io.sfn),
+# `@sfn_to_debug_string` (string.sfn), and `@sfn_array_sfn_map` /
+# `_filter` / `_reduce` (array.sfn). All three modules are required
+# here or the link fails with "undefined reference to
+# `sfn_log_execution`" / `sfn_to_debug_string` / `sfn_array_sfn_filter`.
+sfn-sources = ["../sfn/test_marker.sfn", "../sfn/clock.sfn", "../sfn/exception.sfn", "../sfn/type_meta.sfn", "../sfn/io.sfn", "../sfn/string.sfn", "../sfn/array.sfn"]
 include-dirs = ["include"]
 link-libs = ["-lm"]
 prelude-entry = "../prelude.sfn"
@@ -133,6 +139,16 @@ EOF
     # sfn-sources list the synthetic build fails at link with
     # "undefined reference to `sfn_type_register`".
     ln -s "$REPO_ROOT/runtime/sfn/type_meta.sfn" "$ws/runtime/sfn/type_meta.sfn"
+    # #925 deps — prelude.o calls `@sfn_log_execution` (io.sfn),
+    # `@sfn_to_debug_string` (string.sfn), and `@sfn_array_sfn_*`
+    # (array.sfn). io.sfn additionally imports `./platform/libc`
+    # (`write`), so libc.sfn must exist on disk for the consumer's
+    # `sfn emit` to resolve the extern. string.sfn / array.sfn have
+    # no imports.
+    ln -s "$REPO_ROOT/runtime/sfn/io.sfn" "$ws/runtime/sfn/io.sfn"
+    ln -s "$REPO_ROOT/runtime/sfn/string.sfn" "$ws/runtime/sfn/string.sfn"
+    ln -s "$REPO_ROOT/runtime/sfn/array.sfn" "$ws/runtime/sfn/array.sfn"
+    ln -s "$REPO_ROOT/runtime/sfn/platform/libc.sfn" "$ws/runtime/sfn/platform/libc.sfn"
 
     # The sfn-source under test. Tiny self-contained module.
     cat > "$ws/runtime/sfn/test_marker.sfn" <<'EOF'

--- a/runtime/prelude.sfn
+++ b/runtime/prelude.sfn
@@ -61,9 +61,9 @@
 import { sfn_array_sfn_map } from "./sfn/array";
 import { sfn_sleep } from "./sfn/clock";
 import { sfn_throw } from "./sfn/exception";
-import { sfn_print_sfn } from "./sfn/io";
+import { sfn_log_execution, sfn_print_sfn } from "./sfn/io";
 import { sfn_process_run } from "./sfn/process";
-import { sfn_str_sfn_concat } from "./sfn/string";
+import { sfn_str_sfn_concat, sfn_to_debug_string } from "./sfn/string";
 import {
     sfn_instance_of,
     sfn_is_array,
@@ -71,6 +71,7 @@ import {
     sfn_is_callable,
     sfn_is_number,
     sfn_is_string,
+    sfn_is_void,
     sfn_resolve_type
 } from "./sfn/type_meta";
 
@@ -84,8 +85,8 @@ let runtime_create_filesystem_bridge = runtime.create_filesystem_bridge;
 let runtime_create_http_bridge = runtime.create_http_bridge;
 let runtime_sleep_fn = sfn_sleep;
 let runtime_monotonic_millis_fn = runtime.monotonic_millis;
-let runtime_log_execution_fn = runtime.logExecution;
-let runtime_to_debug_string_fn = runtime.to_debug_string;
+let runtime_log_execution_fn = sfn_log_execution;
+let runtime_to_debug_string_fn = sfn_to_debug_string;
 let runtime_raise_value_error_fn = runtime.raise_value_error;
 let runtime_assert_fail_fn = runtime.assert_fail;
 // M2.12b (#408): type-meta predicates point at their Sailfin-native
@@ -93,13 +94,13 @@ let runtime_assert_fail_fn = runtime.assert_fail;
 // registry still carries each descriptor's `native_signature: "sfn_*"`
 // (PR #749 / M2.10 #402), so emitted IR is unchanged — this flip
 // removes the Sailfin-source delegate through the magic
-// `runtime.X` namespace. `runtime_is_void_fn` keeps its delegate
-// because `runtime/sfn/type_meta.sfn` does not yet export
-// `sfn_is_void` (M3 follow-up).
+// `runtime.X` namespace. `runtime_is_void_fn` joined the flip under
+// #925, which added the `sfn_is_void` body to
+// `runtime/sfn/type_meta.sfn` and flipped its descriptor.
 let runtime_is_string_fn = sfn_is_string;
 let runtime_is_number_fn = sfn_is_number;
 let runtime_is_boolean_fn = sfn_is_boolean;
-let runtime_is_void_fn = runtime.is_void;
+let runtime_is_void_fn = sfn_is_void;
 let runtime_is_array_fn = sfn_is_array;
 let runtime_is_callable_fn = sfn_is_callable;
 let runtime_resolve_runtime_type_fn = sfn_resolve_type;
@@ -168,7 +169,7 @@ fn sleep(milliseconds: int) ![clock] {
 
 fn monotonic_millis() -> int ![clock] { return runtime_monotonic_millis_fn(); }
 
-fn logExecution(callable: any) -> any {
+fn logExecution(callable: any) -> any ![io] {
     return runtime_log_execution_fn(callable);
 }
 

--- a/runtime/sfn/array.sfn
+++ b/runtime/sfn/array.sfn
@@ -143,20 +143,29 @@ fn sfn_array_sfn_push_slot(data_ptr: * * u8, len_ptr: * i64, cap_ptr: * i64, ele
     return sailfin_runtime_array_push_slot_v2(data_ptr, len_ptr, cap_ptr, elem_size);
 }
 
-// `sfn_array_sfn_map(arr) -> arr` — placeholder per §2.3.3. Real
-// bodies are tracked in #766 and gated on generic constraints
+// `sfn_array_sfn_map(arr, mapper) -> arr` — placeholder per §2.3.3.
+// Real bodies are tracked in #766 and gated on generic constraints
 // (post-1.0). Closures-with-capture (Epic #450 M1.5) has now
 // landed — env-capturing lambda emission shipped via #699 — so
 // the call-site closure surface is available; the remaining
 // blocker is the typed `SfnArray<T>` / `(T) -> U` signature shape,
-// which depends on generics. Until #766 ships real bodies, the
-// prelude's `array.map`/`filter`/`reduce` stubs continue to
-// forward to the C `sailfin_runtime_array_map` trampoline (which
-// itself returns the input array unchanged), so these stubs match
-// that observable behavior — preserve them byte-for-byte until
-// the spec body lights up.
-fn sfn_array_sfn_map(arr: * u8) -> * u8 { return arr; }
+// which depends on generics. Until #766 ships real bodies, these
+// stubs return the input unchanged (`map`/`filter` → `arr`,
+// `reduce` → `initial`), matching the legacy C
+// `sailfin_runtime_array_*` bodies' observable behavior.
+//
+// #925: the parameter lists mirror the runtime-helper descriptors'
+// ABI exactly — `map`/`filter` take `(arr, callback)` and `reduce`
+// takes `(arr, initial, reducer)` (the arg order the prelude's
+// `array_reduce(items, initial, reducer)` wrapper emits). The
+// trailing callback/reducer operands are accepted-and-ignored so
+// the descriptor arity (`["i8*","i8*"]` / `["i8*","i8*","i8*"]`)
+// matches the defined symbol's signature one-to-one — no reliance
+// on the SysV/AAPCS "extra args are ignored" rule.
+fn sfn_array_sfn_map(arr: * u8, mapper: * u8) -> * u8 { return arr; }
 
-fn sfn_array_sfn_filter(arr: * u8) -> * u8 { return arr; }
+fn sfn_array_sfn_filter(arr: * u8, predicate: * u8) -> * u8 { return arr; }
 
-fn sfn_array_sfn_reduce(arr: * u8, init: * u8) -> * u8 { return init; }
+fn sfn_array_sfn_reduce(arr: * u8, initial: * u8, reducer: * u8) -> * u8 {
+    return initial;
+}

--- a/runtime/sfn/io.sfn
+++ b/runtime/sfn/io.sfn
@@ -141,3 +141,16 @@ fn sfn_getenv_sfn(name: * u8) -> * u8 ![io] {
 // `sfn_home_dir` trampoline carries the aggregate ABI; this body
 // stays a `* u8` forwarder until M1.A.2.
 fn sfn_home_dir_sfn() -> * u8 ![io] { return sailfin_runtime_home_dir(); }
+
+// #925 (sub-issue of #390): `sfn_log_execution(value)` — port of the C
+// `sailfin_runtime_log_execution`, the body the `@logExecution`
+// decorator lowers to (via `emit_runtime_call("runtime_log_execution_fn",
+// …)` at `emission.sfn:470`). Semantics preserved byte-for-byte: print
+// the value through `[info]`-prefixed stdout when non-NULL, then return
+// it unchanged. Carries `![io]` for the print. Descriptor ABI is
+// `(i8*) -> i8*`. The NULL guard uses the `as i64 == 0` idiom (no null
+// comparison on raw `* u8` until `Result<T, E>` lands).
+fn sfn_log_execution(value: * u8) -> * u8 ![io] {
+    if value as i64 != 0 { sailfin_runtime_print_info(value); }
+    return value;
+}

--- a/runtime/sfn/string.sfn
+++ b/runtime/sfn/string.sfn
@@ -328,3 +328,48 @@ fn sfn_number_to_str_sfn(value: f64) -> * u8 {
 // terminated heap buffer. The Sailfin body retires the C
 // trampoline once arena threading lands at the call surface.
 fn sfn_int_to_str_sfn(value: i64) -> * u8 { return sfn_int_to_str(value); }
+
+// #925 (sub-issue of #390): Cat-C char-predicate ports. The legacy C
+// bodies (`sailfin_runtime_is_alpha_char` / `_is_decimal_digit` /
+// `_is_whitespace_char`) took a `double` codepoint; the runtime-helper
+// descriptor ABI is `(i8) -> i1`, so these bare `sfn_str_is_*` bodies
+// take a `u8` byte (lowers to LLVM `i8`) and widen to `i64` for the
+// range comparisons. ASCII semantics preserved byte-for-byte. Nested
+// `if` accumulators (not `&&`) match the self-host-safe idiom used
+// across the runtime/sfn modules.
+fn sfn_str_is_digit(ch: u8) -> bool {
+    let c: i64 = ch as i64;
+    let mut result: bool = false;
+    if c >= 48 {
+        if c <= 57 { result = true; }
+    }
+    return result;
+}
+
+fn sfn_str_is_whitespace(ch: u8) -> bool {
+    let c: i64 = ch as i64;
+    let mut result: bool = false;
+    if c == 32 { result = true; }
+    if c == 9 { result = true; }
+    if c == 10 { result = true; }
+    if c == 13 { result = true; }
+    return result;
+}
+
+fn sfn_str_is_alpha(ch: u8) -> bool {
+    let c: i64 = ch as i64;
+    let mut result: bool = false;
+    if c >= 97 {
+        if c <= 122 { result = true; }
+    }
+    if c >= 65 {
+        if c <= 90 { result = true; }
+    }
+    return result;
+}
+
+// #925: `sfn_to_debug_string(value)` — identity port of the C
+// `sailfin_runtime_to_debug_string`, which returns its argument
+// unchanged (debug rendering is value-side type tagging, deferred).
+// Descriptor ABI is `(i8*) -> i8*`.
+fn sfn_to_debug_string(value: * u8) -> * u8 { return value; }

--- a/runtime/sfn/type_meta.sfn
+++ b/runtime/sfn/type_meta.sfn
@@ -298,3 +298,16 @@ fn sfn_is_boolean(value: * u8) -> bool { return false; }
 fn sfn_is_callable(value: * u8) -> bool { return false; }
 
 fn sfn_is_array(value: * u8) -> bool { return false; }
+
+// #925 (sub-issue of #390): `sfn_is_void(value)` — port of the C
+// `sailfin_runtime_is_void`, which is a NULL check (`value == NULL`).
+// Unlike the `sfn_is_*` primitive guards above, this carries real
+// semantics today: `runtime.is_void` is live at `prelude.sfn:546`
+// (`instance_of "void"`). Descriptor ABI is `(i8*) -> i1`. The raw
+// pointer is compared via the `as i64 == 0` idiom (no null comparison
+// on raw `* u8` until `Result<T, E>` lands).
+fn sfn_is_void(value: * u8) -> bool {
+    let mut result: bool = false;
+    if value as i64 == 0 { result = true; }
+    return result;
+}


### PR DESCRIPTION
## Summary
- Port the trivial live Cat-C runtime helpers to Sailfin and flip their runtime-helper descriptors off the legacy `sailfin_runtime_*` C symbols onto bare `sfn_*` Sailfin bodies (char predicates, `to_debug_string`, `is_void`, `log_execution`), and route the array map/filter/reduce descriptors to the existing `sfn_array_sfn_*` stub exports.
- New Sailfin bodies: `sfn_str_is_digit/is_whitespace/is_alpha` + `sfn_to_debug_string` (`runtime/sfn/string.sfn`), `sfn_is_void` (`runtime/sfn/type_meta.sfn`), `sfn_log_execution` (`runtime/sfn/io.sfn`). Prelude delegates flipped off the `runtime.X` magic namespace onto the imported functions.
- **Scope completion (cited precedent):** because the prelude emits *unconditional* references to these symbols, the legacy `sfn run`/`sfn build`/`sfn test` link path can't resolve them from the C runtime anymore. As clock #397 / process #405 / type_meta #402 / filesystem #814 / http #818 each did, this stages the defining objects (`io.o`, `string.o`, `array.o`) into every link path: `_clang_compile_runtime_objects` + resolvers (`cli_main.sfn`), `_clang_link_test_cmd_with_deps` + `sfn package` (`cli_commands.sfn`), the Makefile `rebuild` blocks, and the `ci-cross-windows` recipe. The issue's Files Affected under-specified these (same way "flip the descriptor" implicitly entails "give the symbol a link home").
- Array map/filter/reduce keep stubbed semantics; real closure-backed bodies stay deferred to M4.

Closes #925

## Acceptance Criteria
- [x] New `sfn_*` bodies exported (`runtime/sfn/string.sfn` char preds + `to_debug_string`; `runtime/sfn/type_meta.sfn` `sfn_is_void`; `runtime/sfn/io.sfn` `sfn_log_execution`); build links them (verified via `nm` on the staged `.o`s).
- [x] All flipped descriptors emit `@sfn_*` (not `@sailfin_runtime_*`) in fresh IR — verification grep returns empty.
- [x] `@logExecution` decorator routes correctly and prints (`[info] greet` / `[info] hi world`); `instance_of "void"` and struct formatting still link/run.
- [x] `compiler/tests/e2e/test_lowering_no_bare_runtime_emissions.sh` passes.
- [x] `make compile` && `make check` pass (self-host fixed point: stage2 == stage3 ✓).
- [x] `sfn fmt --check` clean on all touched `.sfn` files.

## Verification
```bash
# Descriptor flip is complete (expected: empty)
grep -E 'sailfin_runtime_(is_alpha_char|is_decimal_digit|is_whitespace_char|is_void|to_debug_string|log_execution|array_(map|filter|reduce))' \
  compiler/src/llvm/runtime_helpers.sfn        # -> CLEAN

ulimit -v 8388608 && make compile && make check  # self-hosts; full suite green
bash compiler/tests/e2e/test_lowering_no_bare_runtime_emissions.sh build/native/sailfin  # PASS
bash compiler/tests/e2e/test_runtime_sfn_sources_link_consumer.sh build/native/sailfin   # 3/3 PASS

# @logExecution links + runs via the legacy run path
build/native/sailfin run examples/...   # [info] greet / [info] hi world
```

## Files Changed
- `runtime/sfn/string.sfn`, `runtime/sfn/type_meta.sfn`, `runtime/sfn/io.sfn` — new Sailfin bodies
- `compiler/src/llvm/runtime_helpers.sfn` — flip 8 descriptors
- `runtime/prelude.sfn` — flip `to_debug_string` / `is_void` / `log_execution` delegates
- `compiler/src/cli_main.sfn`, `compiler/src/cli_commands.sfn` — stage io.o/string.o/array.o into the legacy run/build, test, and installer link paths
- `Makefile` — `rebuild` staging blocks + `ci-cross-windows` recipe
- `compiler/tests/e2e/test_runtime_sfn_sources_link_consumer.sh` — add the three modules to the synthetic `sfn-sources`

## Notes
- `to_debug_string` is an identity passthrough today (same as the C body it replaces) — staging `string.o` was chosen over deferring the flip to fully deliver the groomed issue scope (per maintainer direction).
- `sfn-bot` issue body was followed; the staging surface is larger than the M sizing implied but is the precedent-consistent completion of a Cat-C flip for symbols the prelude references unconditionally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EeXvrS8HV1wSnRZ6nTUMV5)_