### PR TITLE
ci: cache build IR + seed across runs to shorten PR feedback

### DIFF
--- a/.github/actions/sailfin-build/action.yml
+++ b/.github/actions/sailfin-build/action.yml
@@ -27,6 +27,16 @@ inputs:
 runs:
   using: "composite"
   steps:
+    # Restore the fetched seed binary keyed on target + pinned version.
+    # The key is exact (no restore-keys): a hit guarantees the binary
+    # matches `.seed-version`, so the fetch step below can safely skip
+    # the download. Saved automatically in the job's post phase.
+    - name: Restore seed cache
+      uses: actions/cache@v4
+      with:
+        path: build/seed
+        key: sailfin-seed-${{ inputs.target }}-${{ inputs.seed_version }}
+
     - name: Fetch released seed compiler
       shell: bash {0}
       run: |
@@ -36,12 +46,38 @@ runs:
         if [ -z "$seed_version" ]; then
           seed_version="latest"
         fi
-        make fetch-seed \
-            SEED_REPO="${{ inputs.seed_repo }}" \
-            SEED_VERSION="$seed_version" \
-            SEED_EXCLUDE_TAG="$seed_exclude_tag"
+        # Skip the download on a seed-cache hit. The cache key pins the
+        # exact version, so a present + invokable binary is the right one.
+        if [ -x build/seed/bin/sailfin ] && build/seed/bin/sailfin version >/dev/null 2>&1; then
+          echo "[ci] seed cache hit ($seed_version) — skipping fetch"
+        else
+          make fetch-seed \
+              SEED_REPO="${{ inputs.seed_repo }}" \
+              SEED_VERSION="$seed_version" \
+              SEED_EXCLUDE_TAG="$seed_exclude_tag"
+        fi
         echo "[ci] seed binary: build/seed/bin/sailfin"
         build/seed/bin/sailfin version
+
+    # Restore the content-addressed module IR cache (`build/cache/`,
+    # written by `<seed> build -p compiler`). Keys are content-safe:
+    # `cache_key_for` (compiler/src/build_cache.sfn) hashes source
+    # content + sorted dep-manifest hashes + compiler version + flags —
+    # no absolute paths or mtimes — so a restored cache is reusable
+    # across runners and runs. Changed modules simply miss and re-emit;
+    # stale entries are never looked up (and LRU-evicted by GitHub).
+    # restore-keys fall back to the most recent cache for this
+    # target+seed (then any cache for this target), so a PR warms from
+    # main's cache (primed by build-quality.yml) and from its own
+    # earlier pushes.
+    - name: Restore build cache (content-addressed module IR)
+      uses: actions/cache@v4
+      with:
+        path: build/cache
+        key: sailfin-buildcache-${{ inputs.target }}-${{ inputs.seed_version }}-${{ hashFiles('compiler/src/**/*.sfn', 'runtime/**/*.sfn', 'compiler/capsule.toml', '.seed-version') }}
+        restore-keys: |
+          sailfin-buildcache-${{ inputs.target }}-${{ inputs.seed_version }}-
+          sailfin-buildcache-${{ inputs.target }}-
 
     - name: Build native compiler (selfhost from released seed)
       shell: bash {0}

--- a/.github/actions/sailfin-build/action.yml
+++ b/.github/actions/sailfin-build/action.yml
@@ -31,7 +31,18 @@ runs:
     # The key is exact (no restore-keys): a hit guarantees the binary
     # matches `.seed-version`, so the fetch step below can safely skip
     # the download. Saved automatically in the job's post phase.
+    #
+    # Gated to a concrete pin: with `seed_version` unset/`latest` the key
+    # (`...-latest`) never changes as the moving `latest` tag advances,
+    # so a cache hit + the skip-download guard below would pin the runner
+    # to a stale seed forever. All current callers pass a resolved
+    # `.seed-version` pin; this `if:` keeps a future `latest` caller
+    # correct (it just re-downloads every run). The build cache below is
+    # not gated — it is self-protecting because `cache_key_for`
+    # (compiler/src/build_cache.sfn) embeds the real seed/compiler
+    # version in the on-disk digest, so a stale-seed entry simply misses.
     - name: Restore seed cache
+      if: ${{ inputs.seed_version != '' && inputs.seed_version != 'latest' }}
       uses: actions/cache@v4
       with:
         path: build/seed

--- a/.github/workflows/build-quality.yml
+++ b/.github/workflows/build-quality.yml
@@ -108,6 +108,26 @@ jobs:
           sudo apt-get install -y clang-18 llvm-18 jq
           echo "CLANG=clang-18" >> "$GITHUB_ENV"
 
+      # Cache priming for PR CI. This job runs on push:main, so the
+      # caches it saves land in the default-branch scope that every PR
+      # can restore from (GitHub scopes caches to the current branch +
+      # base/default branch). Keys mirror `.github/actions/sailfin-build`
+      # exactly (target=linux-x86_64) so the PR action's restore-keys
+      # prefix-match them. See that action for the content-addressed
+      # cache-key rationale.
+      #
+      # The seed is restored+saved here (harmless to the gates below).
+      # The build cache is deliberately NOT restored here: this job's
+      # determinism gate must build cold so a latent nondeterminism bug
+      # can't be masked by warm cached artifacts. The build cache is
+      # instead SAVED after the gates pass (save-only, no `if:`), so a
+      # failed gate never poisons the cache PRs consume.
+      - name: Restore seed cache
+        uses: actions/cache@v4
+        with:
+          path: build/seed
+          key: sailfin-seed-linux-x86_64-${{ steps.seed.outputs.seed_version }}
+
       - name: Fetch released seed compiler
         shell: bash
         env:
@@ -115,7 +135,11 @@ jobs:
           SEED_VERSION: ${{ steps.seed.outputs.seed_version }}
         run: |
           set -euo pipefail
-          make fetch-seed SEED_VERSION="$SEED_VERSION"
+          if [ -x build/seed/bin/sailfin ] && build/seed/bin/sailfin version >/dev/null 2>&1; then
+            echo "[ci] seed cache hit ($SEED_VERSION) — skipping fetch"
+          else
+            make fetch-seed SEED_VERSION="$SEED_VERSION"
+          fi
           build/seed/bin/sailfin version
 
       - name: Self-host the compiler (make compile)
@@ -210,6 +234,20 @@ jobs:
             exit 1
           fi
           echo "[hit-rate] gate passed"
+
+      # Save the validated, fully-warm build cache for PR CI to restore.
+      # Save-only (no `if:`) so it runs only when every prior step —
+      # including both gates — succeeded; a failed gate leaves the
+      # previous (good) cache in place. `make compile` + both
+      # determinism passes have populated `build/cache/` by now. The key
+      # matches `.github/actions/sailfin-build`'s exact key; if it
+      # already exists (no source change since the last main run) the
+      # save is a no-op.
+      - name: Save build cache for PR CI
+        uses: actions/cache/save@v4
+        with:
+          path: build/cache
+          key: sailfin-buildcache-linux-x86_64-${{ steps.seed.outputs.seed_version }}-${{ hashFiles('compiler/src/**/*.sfn', 'runtime/**/*.sfn', 'compiler/capsule.toml', '.seed-version') }}
 
       # Failure-mode wiring (issue #782). Identifying which gate failed
       # has to happen in the gate job (only it can see per-step


### PR DESCRIPTION
## Problem

PR CI is slow and that's the iteration bottleneck. PR #938 (a 3-file runtime change):

| Job | Wall time |
|---|---|
| `Build + Test [linux-x86_64]` | **19m 15s** |
| `Build + Test [macos-arm64]` | **36m 25s** |

Root cause: **zero caching.** `grep` for `actions/cache` across `ci.yml` + `sailfin-build/action.yml` returns nothing. Every PR run:
- re-downloads the pinned seed (`make fetch-seed`),
- rebuilds the entire ~138-module compiler **cold** (`make rebuild`),
- then runs the full test suite.

The killer is that the per-module IR cache is already **fully content-addressed**: `cache_key_for` (`compiler/src/build_cache.sfn:572`) hashes source content + sorted dep-manifest hashes + compiler version + canonical flags — **no absolute paths, no mtimes**. The store lives at `build/cache/<schema>/<key>/…`. So the cache root is safe to restore across runs/machines; changed modules simply miss and re-emit, stale entries are never looked up. We were throwing it away every run.

## Change

**`.github/actions/sailfin-build/action.yml`** (used by PR CI + release workflows):
- Restore+save `build/cache/` keyed on `target + seed_version + hashFiles(compiler/src, runtime, capsule.toml, .seed-version)`, with `restore-keys` fallback to the latest cache for the target+seed (then the target). A PR warms from `main`'s cache and from its own earlier pushes — turning the dominant `make rebuild` cost into an incremental build.
- Restore+save `build/seed/` keyed on `target + seed_version`; skip the seed download on a cache hit (the exact-key match guarantees the right version).

**`.github/workflows/build-quality.yml`** (runs on `push: main`, Linux): primes the default-branch cache that PRs restore from (GitHub scopes caches to the current branch + base/default branch).
- Seed: restore+save (harmless to the gates).
- Build cache: **save-only, after both gates pass.** Deliberately *not* restored here — this job's determinism gate must build cold so a warm cache can't mask a nondeterminism bug, and the save-only-on-success placement means a failed gate never poisons the cache PRs consume.

## Safety

- Cache key is content-addressed → loose `restore-keys` matches are safe; only changed modules re-emit. The cache-schema version is part of the on-disk path, so format bumps self-invalidate.
- PR CI is single-pass (no determinism gate), so PR-saved caches (branch-scoped) only feed the same PR's next push.
- The `main`/`rc`-only fixed-point check in `ci.yml` already passes `--no-cache`, so it's unaffected by a restored cache.

## Known limitation / follow-up

`build-quality.yml` is Linux-only, so **macOS PRs only warm on same-branch re-pushes** (no `main`-primed macOS cache). A main-side macOS cache prime would close that gap but needs a macOS runner on `main` push — left as a follow-up.

## Not in scope (offered, deferred)

Discussed but not included per request: a fast-fail fmt/lint/`check-fast` gate up front, gating packaging/Windows cross-compile off PRs, and macOS runner sizing/gating.

https://claude.ai/code/session_01JdNifiYh67HFyWri3YouJv

---
_Generated by [Claude Code](https://claude.ai/code/session_01JdNifiYh67HFyWri3YouJv)_