### PR TITLE
docs(typecheck): document E0420 undefined-function policy + regression corpus

### DIFF
--- a/compiler/tests/integration/undefined_function_check_test.sfn
+++ b/compiler/tests/integration/undefined_function_check_test.sfn
@@ -16,7 +16,14 @@
 //
 // Runs from the repo root (`make test-integration` invokes
 // `build/native/sailfin test compiler/tests/integration`), so the
-// compiler binary and `/tmp` fixtures resolve relative to that cwd.
+// `build/native/sailfin` binary resolves relative to that cwd. The
+// child is launched with an *empty* environment on purpose: the binary
+// is named by an explicit slashed path (so `posix_spawnp` never
+// consults `PATH`), the runtime root is resolved exe-relative rather
+// than via the environment, and `sfn check`'s only env knobs
+// (`SAILFIN_EFFECT_ENFORCE` / `SAILFIN_USE_ARENA`) must stay unset so
+// the test exercises the shipped defaults deterministically instead of
+// inheriting an ambient shell setting.
 fn _contains(haystack: string, needle: string) -> boolean {
     if needle.length == 0 { return true; }
     if needle.length > haystack.length { return false; }
@@ -28,6 +35,20 @@ fn _contains(haystack: string, needle: string) -> boolean {
         i += 1;
     }
     return false;
+}
+
+// Mint a collision-free fixture. `fs.mkdtemp` returns a kernel-unique
+// `0700` scratch dir (anchored under `$TMPDIR` / `/tmp`), so parallel
+// `sfn test` invocations never share a fixture path. The fs surface
+// has no `rmdir` primitive, so the caller deletes the fixture file and
+// only the empty unique dir is left behind — strictly less residue
+// than a fixed `/tmp/<name>` path.
+fn _mint_fixture(name: string, source: string) -> string ![io] {
+    let dir = fs.mkdtemp("sfn-e0420-");
+    assert dir.length > 0;
+    let path = dir + "/" + name;
+    fs.writeFile(path, source);
+    return path;
 }
 
 // Run `build/native/sailfin check <path>` capturing both streams, and
@@ -50,8 +71,7 @@ fn _check_exit(path: string) -> i64 ![io] {
 }
 
 test "E0420: undefined free-function callee exits non-zero with the diagnostic" ![io] {
-    let fixture = "/tmp/sfn_e0420_undef_813.sfn";
-    fs.writeFile(fixture, "fn main() {\n    notarealfunction_813(\"hi\");\n}\n");
+    let fixture = _mint_fixture("undef.sfn", "fn main() {\n    notarealfunction_813(\"hi\");\n}\n");
 
     let rc = _check_exit(fixture);
     assert rc != 0;
@@ -60,15 +80,18 @@ test "E0420: undefined free-function callee exits non-zero with the diagnostic" 
     assert _contains(combined, "E0420");
     assert _contains(combined, "undefined function");
     assert _contains(combined, "notarealfunction_813");
+
+    fs.deleteFile(fixture);
 }
 
 test "E0420: locally-defined callee checks clean (envelope negative case)" ![io] {
-    let fixture = "/tmp/sfn_e0420_ok_813.sfn";
-    fs.writeFile(fixture, "fn greet() {}\nfn main() {\n    greet();\n}\n");
+    let fixture = _mint_fixture("ok.sfn", "fn greet() {}\nfn main() {\n    greet();\n}\n");
 
     let rc = _check_exit(fixture);
     assert rc == 0;
 
     let combined = _check_output(fixture);
     assert ! _contains(combined, "E0420");
+
+    fs.deleteFile(fixture);
 }

--- a/compiler/tests/integration/undefined_function_check_test.sfn
+++ b/compiler/tests/integration/undefined_function_check_test.sfn
@@ -1,0 +1,74 @@
+// compiler/tests/integration/undefined_function_check_test.sfn
+//
+// Regression corpus for the E0420 undefined-function policy (#813,
+// closing the documentation/test half of #616). The enforcement flip
+// landed in #812: a `Call` whose callee is a bare `Identifier` that
+// resolves to neither an in-scope binding, an imported function, nor a
+// builtin/runtime envelope name produces
+// `error[E0420]: undefined function \`name\``.
+//
+// This test pins the *envelope* end-to-end by driving the shipped
+// `sfn check` binary over a fixture (not by calling the typechecker
+// internals), so the auto-injection allowlist can't silently drift
+// without a red integration run. Two cases: a bare undefined callee
+// must exit non-zero with the `E0420` string, and a locally-defined
+// callee must check clean.
+//
+// Runs from the repo root (`make test-integration` invokes
+// `build/native/sailfin test compiler/tests/integration`), so the
+// compiler binary and `/tmp` fixtures resolve relative to that cwd.
+fn _contains(haystack: string, needle: string) -> boolean {
+    if needle.length == 0 { return true; }
+    if needle.length > haystack.length { return false; }
+    let mut i: int = 0;
+    let limit = haystack.length - needle.length;
+    loop {
+        if i > limit { break; }
+        if substring(haystack, i, i + needle.length) == needle { return true; }
+        i += 1;
+    }
+    return false;
+}
+
+// Run `build/native/sailfin check <path>` capturing both streams, and
+// return the combined stdout+stderr so a case can assert on diagnostic
+// text regardless of which stream the renderer used.
+fn _check_output(path: string) -> string ![io] {
+    let _rc = process.run_capture(["build/native/sailfin", "check", path], []);
+    let out = process.capture_take_stdout();
+    let err = process.capture_take_stderr();
+    return out + err;
+}
+
+fn _check_exit(path: string) -> i64 ![io] {
+    let rc = process.run_capture(["build/native/sailfin", "check", path], []);
+    // Drain the stashed capture buffers so a later `_check_output` /
+    // `capture_take_*` call doesn't hand back this run's streams.
+    let _o = process.capture_take_stdout();
+    let _e = process.capture_take_stderr();
+    return rc;
+}
+
+test "E0420: undefined free-function callee exits non-zero with the diagnostic" ![io] {
+    let fixture = "/tmp/sfn_e0420_undef_813.sfn";
+    fs.writeFile(fixture, "fn main() {\n    notarealfunction_813(\"hi\");\n}\n");
+
+    let rc = _check_exit(fixture);
+    assert rc != 0;
+
+    let combined = _check_output(fixture);
+    assert _contains(combined, "E0420");
+    assert _contains(combined, "undefined function");
+    assert _contains(combined, "notarealfunction_813");
+}
+
+test "E0420: locally-defined callee checks clean (envelope negative case)" ![io] {
+    let fixture = "/tmp/sfn_e0420_ok_813.sfn";
+    fs.writeFile(fixture, "fn greet() {}\nfn main() {\n    greet();\n}\n");
+
+    let rc = _check_exit(fixture);
+    assert rc == 0;
+
+    let combined = _check_output(fixture);
+    assert ! _contains(combined, "E0420");
+}

--- a/docs/status.md
+++ b/docs/status.md
@@ -620,6 +620,31 @@ feature availability.
   fits the surface. All `capsules/sfn/*/capsule.toml` manifests
   were already correct against their declared effects — no
   changes needed.
+- **Undefined free-function rejection (`E0420` — shipped 2026-05-28).**
+  A `Call` whose callee is a bare `Identifier` that resolves to none of
+  the in-scope bindings, the builtin/runtime envelope, or the localized
+  import table now fails typecheck with `error[E0420]: undefined
+  function \`name\``, caret-ed at the callee (`#616`, enforcement flip in
+  `#812`). The walker (`walk_expression` in `compiler/src/typecheck.sfn`)
+  resolves a callee against, in order: **(1)** `bindings` — parameters,
+  locals, every top-level `fn`/`extern fn`, and import-specifier names
+  seeded into the resolution scope; **(2)** the fixed builtin envelope
+  `is_builtin_call_name` (`typecheck_types.sfn`) — `print`, `console`,
+  `assert`, `spawn`, `sleep`, `serve`, `channel`, `send`, `receive`,
+  `await`, and the six atomic intrinsics `atomic_load` / `atomic_store`
+  / `atomic_add` / `atomic_sub` / `atomic_cas` / `atomic_fence` (kept in
+  sync with `is_atomic_builtin`); **(3)** implicit prelude/runtime
+  globals — the top-level declarations of `runtime/prelude.sfn` and the
+  `runtime/sfn/**` tree, scanned via `prelude_globals.sfn` and joined
+  with the compiler-known runtime-helper builtins, so unimported runtime
+  calls (`strings_equal`, `number_to_string`, the `runtime_*_fn` family,
+  …) resolve at link time without tripping E0420; **(4)** the
+  localized effect import table (`lookup_imported_function`). Only a miss
+  on all four emits the diagnostic. Out of scope: member/method callees
+  (`obj.method()` recurse through the `Member` arm and never inspect the
+  member name), undefined *variable* references, and argument type
+  checking. `make check` self-hosts with zero E0420 across the
+  compiler's own ~121 modules, proving the envelope is complete.
 - Experimental LLVM JIT execution is available for targeted backend coverage.
 - CI uses the native build workflow (`.github/workflows/ci.yml`) to build, test,
   and attach release assets.
@@ -654,6 +679,7 @@ feature availability.
 | Effect enforcement as compilation gate | **Shipped (Phase D, 2026-04-26)** | `validate_and_render_effects` runs after typecheck in every `compile_to_*` entry; default severity is `error` so undeclared effects fail the build. `SAILFIN_EFFECT_ENFORCE=warning` opt-in for capsule authors mid-migration; `=off` build-path escape hatch (proposal §4.7) |
 | Cross-module effect propagation | **Shipped (Phase E, 2026-04-26)** | A caller of an imported function inherits the callee's declared effects; missing propagation fails the build with `E0402`. Aliased imports (`import { foo as bar }`) resolve under the local name. E1 covers direct `Identifier` calls; `Member`-callee resolution and decorator-implied transitives deferred to Phase E2 |
 | Capsule capability cross-check | **Shipped (Phase F, 2026-04-26)** | `[capabilities] required = [...]` in `capsule.toml` is a real compile-time contract; functions declaring an effect outside the surface fail with `E0403`. Empty surface skips the check (standalone .sfn unchanged). Phase G (post-1.0) replaces the text-pattern checker with name-resolution detection and adds effect polymorphism |
+| Undefined free-function rejection (`E0420`) | **Shipped (#616/#812, 2026-05-28)** | A bare-`Identifier` callee that resolves to none of {in-scope bindings (params/locals/top-level `fn`/import names), the builtin envelope (`print`, `console`, `assert`, `spawn`, `sleep`, `serve`, `channel`, `send`, `receive`, `await`, `atomic_load/store/add/sub/cas/fence`), the implicit prelude/`runtime/sfn/**` globals, the localized import table} fails typecheck with `error[E0420]: undefined function \`name\``, caret-ed at the callee. Member callees (`obj.method()`), undefined *variable* refs, and argument *type* checks are out of scope. `make check` self-hosts with zero E0420 across the compiler's ~121 modules |
 | Generic type inference | Partial | Type params captured; inference coverage is limited |
 | Interface conformance validation | Partial | Basic checks; variance not yet enforced |
 | `Affine<T>` / `Linear<T>` | Parsed only | Ownership wrappers accepted; move/consume rules not enforced |

--- a/examples/README.md
+++ b/examples/README.md
@@ -10,6 +10,8 @@ This directory showcases the evolving Sailfin language surface implemented by th
 
 Always check `docs/status.md` before relying on an example in production code. Examples stay limited to the bootstrap feature set unless noted; future-facing snippets include inline comments.
 
+> **Undefined function calls are a compile error.** Calling a bare function name that resolves to no in-scope binding, builtin, runtime global, or imported function fails typecheck with `error[E0420]: undefined function \`name\`` — define or import the function before calling it. See [§5 Expressions](https://sailfin.dev/docs/reference/spec/05-expressions/) for the full resolution order.
+
 Where you see effect lists (e.g. `![io, model]`), remember the runtime backing is partially stubbed: capability enforcement will harden through the self-hosted toolchain. Richer AI functionality (model declarations, prompt composition, tool dispatch) is being delivered as a post-1.0 `sfn/ai` library capsule rather than language syntax; the `![model]` effect is the only AI-specific construct that stays in the language.
 
 ## Categories

--- a/llms.txt
+++ b/llms.txt
@@ -30,6 +30,17 @@ A function declaring `![net]` inside a capsule that lists only
 `["io"]` fails the build. Empty surface (no `[capabilities]`
 section, or standalone .sfn outside any capsule) skips the check.
 
+Undefined function calls are a compile error (diagnostic code
+`E0420`). A call whose callee is a bare identifier must resolve to an
+in-scope binding (parameter, local, top-level `fn`/`extern fn`, or
+import name), a builtin (`print`, `console`, `assert`, `spawn`,
+`sleep`, `serve`, `channel`, `send`, `receive`, `await`, the six
+`atomic_*` intrinsics), an implicit prelude/`runtime/sfn/**` global,
+or an imported free function — otherwise typecheck fails with
+`error[E0420]: undefined function \`name\``. Member/method callees
+(`obj.method()`), undefined variable references, and argument type
+checks are out of scope for this rule.
+
     fn read_config(path: string) -> string ![io] {
         return fs.readFile(path);
     }

--- a/site/src/content/docs/docs/reference/spec/05-expressions.md
+++ b/site/src/content/docs/docs/reference/spec/05-expressions.md
@@ -20,6 +20,38 @@ sidebar:
 
 Operator precedence: unary > multiplicative > additive > comparison > equality > `&&` > `||` > assignment.
 
+## Function calls and name resolution
+
+A call expression `callee(args...)` whose `callee` is a bare identifier is **name-resolved at compile time**. The identifier must resolve to one of:
+
+1. **An in-scope binding** — a parameter, a local `let`/`let mut`, a top-level `fn` or `extern fn` in the same module, or a name introduced by an `import { … }` specifier.
+2. **A builtin** in the language's fixed call envelope: `print`, `console`, `assert`, `spawn`, `sleep`, `serve`, `channel`, `send`, `receive`, `await`, and the atomic intrinsics `atomic_load`, `atomic_store`, `atomic_add`, `atomic_sub`, `atomic_cas`, `atomic_fence`.
+3. **An implicit runtime global** — a top-level declaration of the prelude (`runtime/prelude.sfn`) or the `runtime/sfn/**` tree, which is linked into every binary and so is callable without an explicit `import`.
+4. **An imported free function** carried in the module's localized import table.
+
+A callee that resolves to **none** of the above is rejected:
+
+```
+error[E0420]: undefined function `notarealfunction`
+  --> app.sfn:2:5
+   |
+ 2 |     notarealfunction("hi");
+   |     ^^^^^^^^^^^^^^^^
+  [kind: typecheck]
+```
+
+`sfn check` and the build path (`sfn build`/`sfn run`/`sfn test`) both exit non-zero on `E0420`. Defining the function — or importing it — clears the diagnostic:
+
+```sfn
+fn greet() {}
+
+fn main() {
+    greet();  // ok — resolves to the top-level declaration
+}
+```
+
+**Out of scope for `E0420`:** member/method callees (`obj.method()`) are not name-resolved here — the member name is never flagged; undefined *variable* references (a bare identifier used as a value, not a callee) are a separate concern; and argument *types* are not checked by this rule.
+
 ## Cast operator (`as`)
 
 `expr as Type` performs an explicit numeric or pointer-shape conversion. The cast is postfix-bound (tighter than any binary operator) and left-associative — `x as i32 as i64` parses as `((x as i32) as i64)`.


### PR DESCRIPTION
## Summary
- Locks the **E0420** undefined-function policy in docs (status, spec, examples, `llms.txt`) so the resolution order and builtin/runtime envelope are written down.
- Adds an integration regression test driving the shipped `sfn check` binary over a fixture, so the auto-injection envelope can't silently drift without a red CI run.

Closes #813 (documentation/test half of #616; enforcement flip shipped in #812).

## Acceptance Criteria
- [x] `docs/status.md` lists E0420 and the envelope set (narrative bullet under *Compiler Pipeline* + a Feature Matrix row).
- [x] Spec chapter documents undefined-function rejection and the allowlist (§5 Expressions — *Function calls and name resolution*).
- [x] `examples/README.md` mentions the policy.
- [x] `llms.txt` updated with E0420.
- [x] Integration test `undefined_function_check_test.sfn` asserts `sfn check` exit code + `E0420` string on a fixture (plus a defined-callee negative case).
- [x] `make compile` passes (no `compiler/src/` changes; compiler self-hosted at exit 0).
- [x] `make test` passes (integration suite 29/29).
- [x] `sfn fmt --check` clean on the touched `.sfn` file.

## Documented resolution order
A bare-`Identifier` callee must resolve to one of, else E0420:
1. **In-scope bindings** — params, locals, top-level `fn`/`extern fn`, import-specifier names.
2. **Builtin envelope** (`is_builtin_call_name`) — `print`, `console`, `assert`, `spawn`, `sleep`, `serve`, `channel`, `send`, `receive`, `await`, and the six `atomic_*` intrinsics.
3. **Implicit prelude / `runtime/sfn/**` globals** — scanned via `prelude_globals.sfn`, callable without an `import`.
4. **Localized import table** (`lookup_imported_function`).

Out of scope (matches #812): member/method callees (`obj.method()`), undefined *variable* refs, and argument *type* checks.

## Verification
```bash
ulimit -v 8388608 && make test-integration
# ═══ integration: 29/29 passed, 0 failed ═══
#   undefined_function_check_test.sfn → PASS (all 2 tests passed)

ulimit -v 8388608 && build/native/sailfin fmt --check \
  compiler/tests/integration/undefined_function_check_test.sfn   # clean
```
Live fixture behavior confirmed: undefined callee → `error[E0420]: undefined function ...`, exit 1; defined callee → `checked 1 files: ok`, exit 0.

## Files Changed
- `docs/status.md`
- `site/src/content/docs/docs/reference/spec/05-expressions.md`
- `examples/README.md`
- `llms.txt`
- `compiler/tests/integration/undefined_function_check_test.sfn` (new)

## Note
One flaky `closure_lifting_test.sfn` SIGSEGV (Error 139) appeared on the first full-suite run — a known order/memory-pressure flake under the 8GB cap. It passes in isolation (rc=0) and the suite re-ran clean at 29/29. Unrelated to this docs/test change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ekrv91vxQsXunXRQa7uFd5)_