### PR TITLE
fix(build): link Sailfin arena+rc objects in ci-cross-windows (unblocks seed pin #947)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1137,6 +1137,15 @@ ci-cross-windows:
 	$(CLANG) -target x86_64-w64-mingw32 $(NATIVE_OPT) -fno-delete-null-pointer-checks \
 		-c "$$WIN_OBJ/runtime/clock.ll" -o "$$WIN_OBJ/runtime/clock.o"; \
 	\
+	echo "[cross-windows] emitting + compiling arena (Sailfin-native arena mark/rewind, #937)..."; \
+	$(NATIVE_OUT) emit -o "$$WIN_OBJ/runtime/arena.ll" llvm runtime/sfn/memory/arena.sfn >/dev/null; \
+	$(CLANG) -target x86_64-w64-mingw32 $(NATIVE_OPT) -fno-delete-null-pointer-checks \
+		-c "$$WIN_OBJ/runtime/arena.ll" -o "$$WIN_OBJ/runtime/arena.o"; \
+	echo "[cross-windows] emitting + compiling rc (Sailfin-native reference counting)..."; \
+	$(NATIVE_OUT) emit -o "$$WIN_OBJ/runtime/rc.ll" llvm runtime/sfn/memory/rc.sfn >/dev/null; \
+	$(CLANG) -target x86_64-w64-mingw32 $(NATIVE_OPT) -fno-delete-null-pointer-checks \
+		-c "$$WIN_OBJ/runtime/rc.ll" -o "$$WIN_OBJ/runtime/rc.o"; \
+	\
 	echo "[cross-windows] compiling type_meta (Sailfin-native type-metadata registry, M2.10 #402)..."; \
 	$(CLANG) -target x86_64-w64-mingw32 $(NATIVE_OPT) -fno-delete-null-pointer-checks \
 		-c "$$TYPE_META_LL" -o "$$WIN_OBJ/runtime/type_meta.o"; \
@@ -1210,6 +1219,8 @@ ci-cross-windows:
 		"$$WIN_OBJ/runtime/string.o" \
 		"$$WIN_OBJ/runtime/array.o" \
 		"$$WIN_OBJ/runtime/mem.o" \
+		"$$WIN_OBJ/runtime/arena.o" \
+		"$$WIN_OBJ/runtime/rc.o" \
 		$$SHIM_O \
 		-lm -lpthread -lws2_32; \
 	\
@@ -1268,6 +1279,14 @@ ci-cross-windows:
 	if [ -f "$$WIN_OBJ/runtime/mem.o" ]; then \
 		mkdir -p "$$INSTALLER_DIR/runtime/native/obj"; \
 		cp -f "$$WIN_OBJ/runtime/mem.o" "$$INSTALLER_DIR/runtime/native/obj/mem.o"; \
+	fi; \
+	if [ -f "$$WIN_OBJ/runtime/arena.o" ]; then \
+		mkdir -p "$$INSTALLER_DIR/runtime/native/obj"; \
+		cp -f "$$WIN_OBJ/runtime/arena.o" "$$INSTALLER_DIR/runtime/native/obj/arena.o"; \
+	fi; \
+	if [ -f "$$WIN_OBJ/runtime/rc.o" ]; then \
+		mkdir -p "$$INSTALLER_DIR/runtime/native/obj"; \
+		cp -f "$$WIN_OBJ/runtime/rc.o" "$$INSTALLER_DIR/runtime/native/obj/rc.o"; \
 	fi; \
 	tar -czf "dist/installer-$(MINGW_TARGET).tar.gz" -C "$$INSTALLER_DIR" .; \
 	echo "[cross-windows] done: dist/installer-$(MINGW_TARGET).tar.gz"


### PR DESCRIPTION
## Summary

`make ci-cross-windows` fails the Windows link with:

```
undefined reference to `sfn_arena_sfn_mark'
undefined reference to `sfn_arena_sfn_rewind'
```

**Root cause — not the pin, and not #943 (Ra).** #937 ("port memory primitives + arena mark/rewind to `runtime/sfn/memory`") landed *after* the `0.7.0-alpha.16` release. It defines `sfn_arena_sfn_mark`/`sfn_arena_sfn_rewind` in `runtime/sfn/memory/arena.sfn` and flips the compiler descriptors (`runtime_helpers.sfn`) so the compiler now **emits calls to those Sailfin symbols**.

- Linux native (`make rebuild` → `sfn build -p compiler`) resolves them — `arena.sfn` is the first entry in `runtime/native/capsule.toml`'s `sfn-sources`.
- `ci-cross-windows` links a **hardcoded** runtime-module list that omits `arena.sfn` (and `rc.sfn`), so the Windows link can't resolve them.
- It only surfaces now because the seed pin **#947** bumps alpha.16 → alpha.17, and alpha.17 includes #937. The alpha.16 seed emitted the old C-backed arena intrinsic (resolved by `sailfin_arena.c`), so Ra's PR CI and the alpha.17 release build passed.

This is exactly **Risk R4** (cross-windows module list drifting from `sfn-sources`) the [#939 spike](https://github.com/SailfinIO/sailfin/issues/939#issuecomment-4592253723) predicted.

## Fix

Emit + compile + link `runtime/sfn/memory/{arena,rc}.sfn` for the Windows target (inline emit, mirroring the existing clock re-emit, since `make rebuild` doesn't stage them). Add both to the mingw link object list and the installer packaging copies.

**`process.sfn` is intentionally excluded** despite being in `sfn-sources`: its `posix_spawnp` / `waitpid` / `poll` / `pipe` externs (`process.sfn:94–134`) do not resolve on the mingw link and would replace one undefined-reference error with several. The compiler IR does not require `sfn_process_run` on Windows today (cross-windows passes without it).

`arena.sfn` (malloc/free/memcpy + C-provided `sfn_arena_*`) and `rc.sfn` (malloc/free only) are both mingw-safe.

## Safe against current main, too

On the current alpha.16 seed the compiler doesn't reference `sfn_arena_sfn_*`, so this just links an unreferenced `arena.o`/`rc.o` (harmless) — CI stays green. It fixes the alpha.17 case, so it's a clean standalone fix independent of the pin.

## After merge

**Rebase #947 (seed pin) on main** to pick up this fix → its Linux cross-windows job goes green.

## Verification

- `make ci-cross-windows` is the oracle (needs mingw + a built compiler; not runnable in this session). The CI cross-windows job on this PR validates against the current seed; the alpha.17 case is validated when #947 rebases.

## Follow-up

- **Rb (#941)** replaces this hardcoded cross-windows module list with a loop driven by `runtime/native/capsule.toml`'s `sfn-sources` — and must encode a per-target exclusion for posix-only modules like `process.sfn` (this PR documents why).

https://claude.ai/code/session_01H7kYjuFyBx3fyzies2ePL4

---
_Generated by [Claude Code](https://claude.ai/code/session_01H7kYjuFyBx3fyzies2ePL4)_