### PR TITLE
refactor(make): drop dead runtime-object staging; bundle runtime sources in installers (#941)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -533,26 +533,21 @@ package: compile
 # =============================================================================
 
 # Verify the build artifacts the Sailfin-native test runner expects
-# (import-context + runtime prelude object) are present at their
-# canonical locations.
+# (import-context) are present at their canonical location.
 #
 # `make rebuild` is the only path to producing `build/native/sailfin`,
-# so the artifacts are guaranteed to land at
-# `build/native/import-context/` and `build/native/obj/runtime/prelude.o`
-# directly. The legacy `build/selfhost/native/...` fallback paths
-# this target used to copy from are dead in the rebuild flow — so
-# the target collapses to a presence check.
+# so `build/native/import-context/` is guaranteed to land directly.
+# #941: the former `build/native/obj/runtime/prelude.o` check was
+# dropped — post-#940 the test runner links the runtime through the
+# declarative runtime-capsule path (emit-from-source + per-work-dir
+# cache), so no pre-staged `prelude.o` exists or is needed.
 ci-prepare-test-artifacts:
 	@set -eu; \
 	if [ ! -d build/native/import-context ] || [ -z "$$(find build/native/import-context -name '*.sfn-asm' -print -quit 2>/dev/null)" ]; then \
 		echo "[ci-prepare-test-artifacts][error] missing build/native/import-context — run 'make rebuild' first" >&2; \
 		exit 1; \
 	fi; \
-	if [ ! -f build/native/obj/runtime/prelude.o ]; then \
-		echo "[ci-prepare-test-artifacts][error] missing build/native/obj/runtime/prelude.o — run 'make rebuild' first" >&2; \
-		exit 1; \
-	fi; \
-	echo "[ci-prepare-test-artifacts] build/native/import-context + build/native/obj/runtime/prelude.o present"
+	echo "[ci-prepare-test-artifacts] build/native/import-context present"
 
 # Package native compiler + installer artifacts for a given target label.
 # Stage C4 migration: this target now delegates to `sfn package`
@@ -695,263 +690,14 @@ rebuild:
 	@mkdir -p build/native/raw
 	@cp -a build/sailfin/capsules/. build/native/raw/ 2>/dev/null || true
 	@cp -f build/sailfin/program.ll build/native/raw/program.ll 2>/dev/null || true
-	@# Stage prelude.o + prelude.ll for the freshly-built compiler.
-	@# End-user `sfn build` / `sfn run` invocations from this
-	@# binary check `_runtime_bundle_exists("runtime")` which
-	@# requires a prebuilt `prelude.o` somewhere under the runtime
-	@# tree (see `_runtime_prelude_path` in cli_main.sfn for the
-	@# search list). The fresh-clone repo's `runtime/` has no
-	@# `obj/`, so without this step the in-tree compiler would
-	@# fail to link any user program with "runtime bundle missing
-	@# expected files." Replicate via the new compiler emitting
-	@# prelude.ll + clang compiling it to an object.
-	@#
-	@# The .ll is also load-bearing for `ci-cross-windows`, which
-	@# reads it as the Windows-target prelude IR. Each artifact
-	@# is generated independently — if a prior build dropped
-	@# prelude.ll but kept prelude.o (or vice-versa), regenerate
-	@# the missing one on its own rather than re-doing both.
-	@mkdir -p build/native/obj/runtime
-	@# Emit + validate prelude.ll with retry. The single-shot
-	@# `$(NATIVE_OUT) emit` here doesn't go through the resolver's
-	@# retry+validator cascade (that path is gated behind multi-
-	@# source builds), so a seed-corruption flake on the prelude
-	@# emit (`翶* %t5` and friends) would escape into the .o
-	@# compile and fail the rebuild. Up to 3 attempts; each
-	@# attempt validates via the same `llvm-as` / `llvm-as-18` /
-	@# `clang -c -emit-llvm` / `clang-18` cascade the resolver
-	@# uses.
-	@if [ ! -f build/native/obj/runtime/prelude.ll ]; then \
-		echo "[rebuild] staging prelude.ll..."; \
-		attempt=0; ok=0; \
-		while [ $$attempt -lt 3 ]; do \
-			attempt=$$((attempt + 1)); \
-			rm -f build/native/obj/runtime/prelude.ll; \
-			$(NATIVE_OUT) emit -o build/native/obj/runtime/prelude.ll llvm runtime/prelude.sfn >/dev/null || continue; \
-			[ -s build/native/obj/runtime/prelude.ll ] || continue; \
-			if (command -v llvm-as >/dev/null 2>&1 && llvm-as < build/native/obj/runtime/prelude.ll >/dev/null 2>&1) \
-				|| (command -v llvm-as-18 >/dev/null 2>&1 && llvm-as-18 < build/native/obj/runtime/prelude.ll >/dev/null 2>&1) \
-				|| (command -v clang >/dev/null 2>&1 && clang -c -emit-llvm -x ir build/native/obj/runtime/prelude.ll -o /dev/null >/dev/null 2>&1) \
-				|| (command -v clang-18 >/dev/null 2>&1 && clang-18 -c -emit-llvm -x ir build/native/obj/runtime/prelude.ll -o /dev/null >/dev/null 2>&1); then \
-				ok=1; break; \
-			fi; \
-			echo "[rebuild][warn] prelude.ll IR validation rejected output (attempt $$attempt/3)" >&2; \
-		done; \
-		if [ "$$ok" -ne 1 ]; then \
-			echo "[rebuild][error] failed to emit valid prelude.ll after 3 attempts" >&2; \
-			exit 1; \
-		fi; \
-	fi
-	@if [ ! -f build/native/obj/runtime/prelude.o ]; then \
-		echo "[rebuild] staging prelude.o..."; \
-		$(CLANG) -O2 -Wno-override-module -c build/native/obj/runtime/prelude.ll -o build/native/obj/runtime/prelude.o; \
-	fi
-	@# Stage clock.o (Sailfin-native `@sfn_sleep` from runtime/sfn/clock.sfn).
-	@# PR 2 of the sleep migration (issue #397) deleted the C `sfn_sleep`
-	@# trampoline; `@sfn_sleep` now lives only in the Sailfin module.
-	@# The legacy `sfn run` / `sfn build` link path
-	@# (`_clang_compile_runtime_objects` in `compiler/src/cli_main.sfn`)
-	@# resolves the symbol against this staged .o. The runtime-capsule
-	@# link path (used by `make compile`) instead reaches clock.sfn
-	@# through `runtime/native/capsule.toml`'s `sfn-sources` array.
-	@if [ ! -f build/native/obj/runtime/clock.ll ]; then \
-		echo "[rebuild] staging clock.ll..."; \
-		$(NATIVE_OUT) emit -o build/native/obj/runtime/clock.ll llvm runtime/sfn/clock.sfn >/dev/null; \
-	fi
-	@if [ ! -f build/native/obj/runtime/clock.o ]; then \
-		echo "[rebuild] staging clock.o..."; \
-		$(CLANG) -O2 -Wno-override-module -c build/native/obj/runtime/clock.ll -o build/native/obj/runtime/clock.o; \
-	fi
-	@# Stage process.o (Sailfin-native `@sfn_process_run` from
-	@# runtime/sfn/process.sfn). Mirrors the clock.o staging above:
-	@# M2.9 (issue #405) flips `process.run`'s `native_signature` to
-	@# `sfn_process_run`, defined only in the Sailfin module. The
-	@# legacy link path resolves the symbol against this staged .o;
-	@# the runtime-capsule path reaches process.sfn through
-	@# `runtime/native/capsule.toml`'s `sfn-sources` array instead.
-	@if [ ! -f build/native/obj/runtime/process.ll ]; then \
-		echo "[rebuild] staging process.ll..."; \
-		$(NATIVE_OUT) emit -o build/native/obj/runtime/process.ll llvm runtime/sfn/process.sfn >/dev/null; \
-	fi
-	@if [ ! -f build/native/obj/runtime/process.o ]; then \
-		echo "[rebuild] staging process.o..."; \
-		$(CLANG) -O2 -Wno-override-module -c build/native/obj/runtime/process.ll -o build/native/obj/runtime/process.o; \
-	fi
-	@# Stage exception.o (Sailfin-native frame primitives from
-	@# runtime/sfn/exception.sfn). M2.7b (issue #404) ships the
-	@# compiler-emission migration that inlines `sfn_exception_push_frame`
-	@# + `setjmp` + `sfn_exception_pop_frame` at every user try block;
-	@# the legacy link path (`_clang_compile_runtime_objects` in
-	@# `compiler/src/cli_main.sfn`) resolves those symbols against this
-	@# staged .o. The runtime-capsule path reaches exception.sfn through
-	@# `runtime/native/capsule.toml`'s `sfn-sources` array instead.
-	@if [ ! -f build/native/obj/runtime/exception.ll ]; then \
-		echo "[rebuild] staging exception.ll..."; \
-		$(NATIVE_OUT) emit -o build/native/obj/runtime/exception.ll llvm runtime/sfn/exception.sfn >/dev/null; \
-	fi
-	@if [ ! -f build/native/obj/runtime/exception.o ]; then \
-		echo "[rebuild] staging exception.o..."; \
-		$(CLANG) -O2 -Wno-override-module -c build/native/obj/runtime/exception.ll -o build/native/obj/runtime/exception.o; \
-	fi
-	@# Stage type_meta.o (Sailfin-native type-metadata registry from
-	@# runtime/sfn/type_meta.sfn). M2.10 (issue #402) flips seven
-	@# `runtime_helpers.sfn` descriptors to `sfn_*` `native_signature`
-	@# entries (`sfn_is_string` / `_resolve_type` / `_instance_of`,
-	@# etc.) and emits a `@__sfn_module_type_init__*` constructor per
-	@# module that calls `@sfn_type_register`. The legacy link path
-	@# (`_clang_compile_runtime_objects` in `compiler/src/cli_main.sfn`)
-	@# resolves the symbol against this staged .o; without it, every
-	@# `sfn test` invocation fails at link with "undefined reference
-	@# to `sfn_type_register`" the moment a test's compiled IR carries
-	@# a single named struct/enum/interface descriptor.
-	@if [ ! -f build/native/obj/runtime/type_meta.ll ]; then \
-		echo "[rebuild] staging type_meta.ll..."; \
-		$(NATIVE_OUT) emit -o build/native/obj/runtime/type_meta.ll llvm runtime/sfn/type_meta.sfn >/dev/null; \
-	fi
-	@if [ ! -f build/native/obj/runtime/type_meta.o ]; then \
-		echo "[rebuild] staging type_meta.o..."; \
-		$(CLANG) -O2 -Wno-override-module -c build/native/obj/runtime/type_meta.ll -o build/native/obj/runtime/type_meta.o; \
-	fi
-	@# Stage filesystem.o (Sailfin-native fs adapters from
-	@# runtime/sfn/adapters/filesystem.sfn). M3.1a (issue #814,
-	@# epic #390) flips the `fs.readFile` / `fs.writeFile` /
-	@# `fs.appendFile` descriptor rows' `native_signature` to
-	@# `sfn_fs_read_file` / `sfn_fs_write_file` /
-	@# `sfn_fs_append_file`. The legacy `sfn run` / `sfn build`
-	@# link path (`_clang_compile_runtime_objects` in
-	@# `compiler/src/cli_main.sfn`) resolves those symbols against
-	@# this staged .o; the runtime-capsule path reaches
-	@# filesystem.sfn through `runtime/native/capsule.toml`'s
-	@# `sfn-sources` array instead. Without this staging, any user
-	@# program touching `fs.*` fails at link with "undefined
-	@# reference to `sfn_fs_read_file`".
-	@if [ ! -f build/native/obj/runtime/filesystem.ll ]; then \
-		echo "[rebuild] staging filesystem.ll..."; \
-		$(NATIVE_OUT) emit -o build/native/obj/runtime/filesystem.ll llvm runtime/sfn/adapters/filesystem.sfn >/dev/null; \
-	fi
-	@if [ ! -f build/native/obj/runtime/filesystem.o ]; then \
-		echo "[rebuild] staging filesystem.o..."; \
-		$(CLANG) -O2 -Wno-override-module -c build/native/obj/runtime/filesystem.ll -o build/native/obj/runtime/filesystem.o; \
-	fi
-	@# Stage http.o (Sailfin-native socket HTTP client from
-	@# runtime/sfn/adapters/http.sfn). M3 (issue #818, epic #390)
-	@# flips the `http.get_body` / `http.post_json` / `http.download`
-	@# descriptor rows' `native_signature` (and the `http_get` /
-	@# `http_post` aliases) to `sfn_http_get` / `sfn_http_post` /
-	@# `sfn_http_post2` / `sfn_http_download`, replacing the curl
-	@# subprocess path with a pure-Sailfin socket client (HTTP only,
-	@# no TLS for v0). The legacy `sfn run` / `sfn build` link path
-	@# (`_clang_compile_runtime_objects` in
-	@# `compiler/src/cli_main.sfn`) resolves those symbols against
-	@# this staged .o; the runtime-capsule path reaches http.sfn
-	@# through `runtime/native/capsule.toml`'s `sfn-sources` array
-	@# instead. Without this staging, any user program touching
-	@# `http.*` fails at link with "undefined reference to
-	@# `sfn_http_get`".
-	@if [ ! -f build/native/obj/runtime/http.ll ]; then \
-		echo "[rebuild] staging http.ll..."; \
-		$(NATIVE_OUT) emit -o build/native/obj/runtime/http.ll llvm runtime/sfn/adapters/http.sfn >/dev/null; \
-	fi
-	@if [ ! -f build/native/obj/runtime/http.o ]; then \
-		echo "[rebuild] staging http.o..."; \
-		$(CLANG) -O2 -Wno-override-module -c build/native/obj/runtime/http.ll -o build/native/obj/runtime/http.o; \
-	fi
-	@# Stage io.o (Sailfin-native I/O wrappers from runtime/sfn/io.sfn).
-	@# #925 (epic #390) ports the Cat-C `@logExecution` decorator body
-	@# to `@sfn_log_execution`, defined only in this Sailfin module. The
-	@# legacy `sfn run` / `sfn build` link path
-	@# (`_clang_compile_runtime_objects` in `compiler/src/cli_main.sfn`)
-	@# resolves the symbol against this staged .o; the runtime-capsule
-	@# path reaches io.sfn through `runtime/native/capsule.toml`'s
-	@# `sfn-sources` array instead. Without this staging, any user
-	@# program using `@logExecution` fails at link with "undefined
-	@# reference to `sfn_log_execution`".
-	@if [ ! -f build/native/obj/runtime/io.ll ]; then \
-		echo "[rebuild] staging io.ll..."; \
-		$(NATIVE_OUT) emit -o build/native/obj/runtime/io.ll llvm runtime/sfn/io.sfn >/dev/null; \
-	fi
-	@if [ ! -f build/native/obj/runtime/io.o ]; then \
-		echo "[rebuild] staging io.o..."; \
-		$(CLANG) -O2 -Wno-override-module -c build/native/obj/runtime/io.ll -o build/native/obj/runtime/io.o; \
-	fi
-	@# Stage string.o (Sailfin-native string helpers from
-	@# runtime/sfn/string.sfn). #925 (epic #390) ports the Cat-C
-	@# `to_debug_string` (→ `@sfn_to_debug_string`, live in prelude
-	@# struct formatting) and the `sfn_str_is_*` char predicates to
-	@# Sailfin bodies. The legacy link path resolves
-	@# `@sfn_to_debug_string` against this staged .o; the runtime-capsule
-	@# path reaches string.sfn through `runtime/native/capsule.toml`'s
-	@# `sfn-sources` array instead. Without this staging, any user
-	@# program that formats a struct fails at link with "undefined
-	@# reference to `sfn_to_debug_string`".
-	@if [ ! -f build/native/obj/runtime/string.ll ]; then \
-		echo "[rebuild] staging string.ll..."; \
-		$(NATIVE_OUT) emit -o build/native/obj/runtime/string.ll llvm runtime/sfn/string.sfn >/dev/null; \
-	fi
-	@if [ ! -f build/native/obj/runtime/string.o ]; then \
-		echo "[rebuild] staging string.o..."; \
-		$(CLANG) -O2 -Wno-override-module -c build/native/obj/runtime/string.ll -o build/native/obj/runtime/string.o; \
-	fi
-	@# Stage array.o (Sailfin-native array stubs from
-	@# runtime/sfn/array.sfn). #925 (epic #390) routes the
-	@# `runtime_array_map_fn` / `_filter_fn` / `_reduce_fn` descriptors
-	@# to the `sfn_array_sfn_map` / `_filter` / `_reduce` stub exports
-	@# (real closure-backed semantics are M4). The prelude's `array_map`
-	@# / `array_filter` / `array_reduce` wrappers reference those
-	@# symbols, so prelude.o carries an undefined reference to each; the
-	@# legacy link path resolves them against this staged .o. The
-	@# runtime-capsule path reaches array.sfn through
-	@# `runtime/native/capsule.toml`'s `sfn-sources` array instead.
-	@# Without this staging, every user program fails at link with
-	@# "undefined reference to `sfn_array_sfn_filter`" (prelude.o pulls
-	@# the array-HOF wrappers in unconditionally).
-	@if [ ! -f build/native/obj/runtime/array.ll ]; then \
-		echo "[rebuild] staging array.ll..."; \
-		$(NATIVE_OUT) emit -o build/native/obj/runtime/array.ll llvm runtime/sfn/array.sfn >/dev/null; \
-	fi
-	@if [ ! -f build/native/obj/runtime/array.o ]; then \
-		echo "[rebuild] staging array.o..."; \
-		$(CLANG) -O2 -Wno-override-module -c build/native/obj/runtime/array.ll -o build/native/obj/runtime/array.o; \
-	fi
-	@# Stage mem.o (Sailfin-native narrow memory primitives from
-	@# runtime/sfn/memory/mem.sfn). #927 (epic #390) flips the
-	@# `get_field` / `copy_bytes` / `runtime.bounds_check` /
-	@# `runtime.free` descriptors to the `sfn_mem_*` exports, so user
-	@# IR + prelude.o now reference `@sfn_mem_bounds_check` etc. Nearly
-	@# every program reaches `bounds_check` (array indexing) or the
-	@# scope-exit `free`, so without this staged .o the legacy link
-	@# path fails with "undefined reference to `sfn_mem_bounds_check`".
-	@# The runtime-capsule path reaches mem.sfn through
-	@# `runtime/native/capsule.toml`'s `sfn-sources` array instead.
-	@if [ ! -f build/native/obj/runtime/mem.ll ]; then \
-		echo "[rebuild] staging mem.ll..."; \
-		$(NATIVE_OUT) emit -o build/native/obj/runtime/mem.ll llvm runtime/sfn/memory/mem.sfn >/dev/null; \
-	fi
-	@if [ ! -f build/native/obj/runtime/mem.o ]; then \
-		echo "[rebuild] staging mem.o..."; \
-		$(CLANG) -O2 -Wno-override-module -c build/native/obj/runtime/mem.ll -o build/native/obj/runtime/mem.o; \
-	fi
-	@# Stage exec.o (Sailfin-native executable-path + runtime-root
-	@# resolution from runtime/sfn/platform/exec.sfn). Issue #468
-	@# (epic #451 M5.3 prerequisite) ships `@exe_path` /
-	@# `@binary_dir` / `@resolve_runtime_root` as the pure-Sailfin
-	@# replacement for the C-driver's executable-path resolver,
-	@# retired in M5.5 / #473. The legacy link path
-	@# (`_clang_compile_runtime_objects` in `compiler/src/cli_main.sfn`)
-	@# resolves those symbols against this staged .o; the runtime-
-	@# capsule path reaches exec.sfn through `runtime/native/
-	@# capsule.toml`'s `sfn-sources` array instead. The compiler's
-	@# `fn main` in `compiler/src/cli_main.sfn` is the load-bearing
-	@# internal caller after #473; a missing staged artifact surfaces
-	@# at link time as "undefined reference to `exe_path`".
-	@if [ ! -f build/native/obj/runtime/exec.ll ]; then \
-		echo "[rebuild] staging exec.ll..."; \
-		$(NATIVE_OUT) emit -o build/native/obj/runtime/exec.ll llvm runtime/sfn/platform/exec.sfn >/dev/null; \
-	fi
-	@if [ ! -f build/native/obj/runtime/exec.o ]; then \
-		echo "[rebuild] staging exec.o..."; \
-		$(CLANG) -O2 -Wno-override-module -c build/native/obj/runtime/exec.ll -o build/native/obj/runtime/exec.o; \
-	fi
+	@# Runtime-object staging removed (#941). Post-#940 the freshly-built
+	@# compiler resolves the runtime via runtime/native/capsule.toml (the
+	@# declarative runtime capsule), emitting prelude + each sfn-source from
+	@# source on demand and caching the .o under the per-work-dir build cache.
+	@# No link path reads the old build/native/obj/runtime/*.o, so the per-module
+	@# .ll+.o staging that used to live here is gone. ci-cross-windows now emits
+	@# the Windows-target runtime IR itself (self-contained loop below), and the
+	@# installer bundles the runtime .sfn sources (see _package_installer).
 	@# Stage import-context for `runtime/sfn/platform/*.sfn` extern-fn
 	@# modules. `runtime/sfn/clock.sfn` imports `nanosleep` from
 	@# `./platform/posix`, and `runtime/sfn/io.sfn` imports `write`
@@ -1025,63 +771,8 @@ ci-cross-windows:
 	@set -eu; \
 	echo "[cross-windows] cross-compiling for Windows from Linux LLVM IR..."; \
 	SAVED_DIR="build/native/raw"; \
-	PRELUDE_LL="build/native/obj/runtime/prelude.ll"; \
-	CLOCK_LL="build/native/obj/runtime/clock.ll"; \
-	TYPE_META_LL="build/native/obj/runtime/type_meta.ll"; \
-	EXEC_LL="build/native/obj/runtime/exec.ll"; \
-	EXCEPTION_LL="build/native/obj/runtime/exception.ll"; \
-	FILESYSTEM_LL="build/native/obj/runtime/filesystem.ll"; \
-	HTTP_LL="build/native/obj/runtime/http.ll"; \
-	IO_LL="build/native/obj/runtime/io.ll"; \
-	STRING_LL="build/native/obj/runtime/string.ll"; \
-	ARRAY_LL="build/native/obj/runtime/array.ll"; \
-	MEM_LL="build/native/obj/runtime/mem.ll"; \
 	if [ ! -d "$$SAVED_DIR" ] || [ ! -f "$$SAVED_DIR/program.ll" ]; then \
 		echo "[cross-windows][error] missing $$SAVED_DIR/*.ll + program.ll — run 'make rebuild' first" >&2; \
-		exit 1; \
-	fi; \
-	if [ ! -f "$$PRELUDE_LL" ]; then \
-		echo "[cross-windows][error] missing $$PRELUDE_LL — 'make rebuild' should have emitted it" >&2; \
-		exit 1; \
-	fi; \
-	if [ ! -f "$$CLOCK_LL" ]; then \
-		echo "[cross-windows][error] missing $$CLOCK_LL — 'make rebuild' should have emitted it (sleep migration PR 2, #397)" >&2; \
-		exit 1; \
-	fi; \
-	if [ ! -f "$$TYPE_META_LL" ]; then \
-		echo "[cross-windows][error] missing $$TYPE_META_LL — 'make rebuild' should have emitted it (M2.10, #402)" >&2; \
-		exit 1; \
-	fi; \
-	if [ ! -f "$$EXEC_LL" ]; then \
-		echo "[cross-windows][error] missing $$EXEC_LL — 'make rebuild' should have emitted it (M5.5, #473)" >&2; \
-		exit 1; \
-	fi; \
-	if [ ! -f "$$EXCEPTION_LL" ]; then \
-		echo "[cross-windows][error] missing $$EXCEPTION_LL — 'make rebuild' should have emitted it (M2.7b, #404; surfaced by M5.5 #473's @main wrapper)" >&2; \
-		exit 1; \
-	fi; \
-	if [ ! -f "$$FILESYSTEM_LL" ]; then \
-		echo "[cross-windows][error] missing $$FILESYSTEM_LL — 'make rebuild' should have emitted it (M3.1a, #814)" >&2; \
-		exit 1; \
-	fi; \
-	if [ ! -f "$$HTTP_LL" ]; then \
-		echo "[cross-windows][error] missing $$HTTP_LL — 'make rebuild' should have emitted it (M3, #818)" >&2; \
-		exit 1; \
-	fi; \
-	if [ ! -f "$$IO_LL" ]; then \
-		echo "[cross-windows][error] missing $$IO_LL — 'make rebuild' should have emitted it (Cat-C ports, #925)" >&2; \
-		exit 1; \
-	fi; \
-	if [ ! -f "$$STRING_LL" ]; then \
-		echo "[cross-windows][error] missing $$STRING_LL — 'make rebuild' should have emitted it (Cat-C ports, #925)" >&2; \
-		exit 1; \
-	fi; \
-	if [ ! -f "$$ARRAY_LL" ]; then \
-		echo "[cross-windows][error] missing $$ARRAY_LL — 'make rebuild' should have emitted it (Cat-C ports, #925)" >&2; \
-		exit 1; \
-	fi; \
-	if [ ! -f "$$MEM_LL" ]; then \
-		echo "[cross-windows][error] missing $$MEM_LL — 'make rebuild' should have emitted it (memory primitives, #927)" >&2; \
 		exit 1; \
 	fi; \
 	echo "[cross-windows] using saved sfn build IR layout ($$SAVED_DIR)"; \
@@ -1124,60 +815,37 @@ ci-cross-windows:
 	$(CLANG) -target x86_64-w64-mingw32 $(NATIVE_OPT) -fno-delete-null-pointer-checks \
 		-c "$$WIN_OBJ/sailfin.linked.bc" -o "$$WIN_OBJ/native.linked.o"; \
 	\
-	echo "[cross-windows] compiling prelude..."; \
-	if [ -n "$$PRELUDE_LL" ]; then \
+	echo "[cross-windows] emitting + compiling runtime modules..."; \
+	\
+	: "#941: the runtime IR this target consumes is now emitted by"; \
+	: "ci-cross-windows itself (was staged by 'make rebuild', deleted"; \
+	: "in #941). RUNTIME_MODS is this bridge's copy of"; \
+	: "runtime/native/capsule.toml's sfn-sources (+ the prelude-entry),"; \
+	: "MINUS process.sfn — Windows resolves @sfn_process_run from the"; \
+	: "_WIN32 C wrapper in sailfin_runtime.c, so linking the Sailfin"; \
+	: "object too would duplicate the symbol. A guard test"; \
+	: "(compiler/tests/e2e/test_cross_windows_runtime_modules.sh) asserts"; \
+	: "this list stays in sync with the manifest (Risk R4). clock is"; \
+	: "re-emitted with SAILFIN_TARGET_OS=Windows for the errno->_errno"; \
+	: "fix (#877); the rest are target-independent IR compiled for"; \
+	: "mingw. Each <module>:<source> pair is space-separated."; \
+	RUNTIME_MODS="prelude:runtime/prelude.sfn arena:runtime/sfn/memory/arena.sfn rc:runtime/sfn/memory/rc.sfn mem:runtime/sfn/memory/mem.sfn string:runtime/sfn/string.sfn array:runtime/sfn/array.sfn clock:runtime/sfn/clock.sfn io:runtime/sfn/io.sfn exception:runtime/sfn/exception.sfn type_meta:runtime/sfn/type_meta.sfn exec:runtime/sfn/platform/exec.sfn filesystem:runtime/sfn/adapters/filesystem.sfn http:runtime/sfn/adapters/http.sfn"; \
+	RUNTIME_OBJS=""; \
+	for pair in $$RUNTIME_MODS; do \
+		mod="$${pair%%:*}"; \
+		src="$${pair#*:}"; \
+		ll="$$WIN_OBJ/runtime/$$mod.ll"; \
+		obj="$$WIN_OBJ/runtime/$$mod.o"; \
+		echo "[cross-windows] emitting + compiling $$mod ($$src)..."; \
+		if [ "$$mod" = "clock" ]; then \
+			SAILFIN_TARGET_OS=Windows $(NATIVE_OUT) emit -o "$$ll" llvm "$$src" >/dev/null; \
+		else \
+			$(NATIVE_OUT) emit -o "$$ll" llvm "$$src" >/dev/null; \
+		fi; \
 		$(CLANG) -target x86_64-w64-mingw32 $(NATIVE_OPT) -fno-delete-null-pointer-checks \
-			-c "$$PRELUDE_LL" -o "$$WIN_OBJ/runtime/prelude.o"; \
-	fi; \
-	\
-	echo "[cross-windows] re-emitting clock for Windows target (errno -> _errno, #877)..."; \
-	SAILFIN_TARGET_OS=Windows $(NATIVE_OUT) emit \
-		-o "$$WIN_OBJ/runtime/clock.ll" llvm runtime/sfn/clock.sfn >/dev/null; \
-	echo "[cross-windows] compiling clock (Sailfin-native @sfn_sleep, #397)..."; \
-	$(CLANG) -target x86_64-w64-mingw32 $(NATIVE_OPT) -fno-delete-null-pointer-checks \
-		-c "$$WIN_OBJ/runtime/clock.ll" -o "$$WIN_OBJ/runtime/clock.o"; \
-	\
-	echo "[cross-windows] emitting + compiling arena (Sailfin-native arena mark/rewind, #937)..."; \
-	$(NATIVE_OUT) emit -o "$$WIN_OBJ/runtime/arena.ll" llvm runtime/sfn/memory/arena.sfn >/dev/null; \
-	$(CLANG) -target x86_64-w64-mingw32 $(NATIVE_OPT) -fno-delete-null-pointer-checks \
-		-c "$$WIN_OBJ/runtime/arena.ll" -o "$$WIN_OBJ/runtime/arena.o"; \
-	echo "[cross-windows] emitting + compiling rc (Sailfin-native reference counting)..."; \
-	$(NATIVE_OUT) emit -o "$$WIN_OBJ/runtime/rc.ll" llvm runtime/sfn/memory/rc.sfn >/dev/null; \
-	$(CLANG) -target x86_64-w64-mingw32 $(NATIVE_OPT) -fno-delete-null-pointer-checks \
-		-c "$$WIN_OBJ/runtime/rc.ll" -o "$$WIN_OBJ/runtime/rc.o"; \
-	\
-	echo "[cross-windows] compiling type_meta (Sailfin-native type-metadata registry, M2.10 #402)..."; \
-	$(CLANG) -target x86_64-w64-mingw32 $(NATIVE_OPT) -fno-delete-null-pointer-checks \
-		-c "$$TYPE_META_LL" -o "$$WIN_OBJ/runtime/type_meta.o"; \
-	\
-	echo "[cross-windows] compiling exec (Sailfin-native executable-path resolver, M5.5 #473)..."; \
-	$(CLANG) -target x86_64-w64-mingw32 $(NATIVE_OPT) -fno-delete-null-pointer-checks \
-		-c "$$EXEC_LL" -o "$$WIN_OBJ/runtime/exec.o"; \
-	\
-	echo "[cross-windows] compiling exception (Sailfin-native exception runtime, M2.7b #404)..."; \
-	$(CLANG) -target x86_64-w64-mingw32 $(NATIVE_OPT) -fno-delete-null-pointer-checks \
-		-c "$$EXCEPTION_LL" -o "$$WIN_OBJ/runtime/exception.o"; \
-	\
-	echo "[cross-windows] compiling filesystem (Sailfin-native fs adapters, M3.1a #814)..."; \
-	$(CLANG) -target x86_64-w64-mingw32 $(NATIVE_OPT) -fno-delete-null-pointer-checks \
-		-c "$$FILESYSTEM_LL" -o "$$WIN_OBJ/runtime/filesystem.o"; \
-	\
-		echo "[cross-windows] compiling http (Sailfin-native socket HTTP client, M3 #818)..."; \
-		$(CLANG) -target x86_64-w64-mingw32 $(NATIVE_OPT) -fno-delete-null-pointer-checks \
-			-c "$$HTTP_LL" -o "$$WIN_OBJ/runtime/http.o"; \
-		\
-	echo "[cross-windows] compiling io (Sailfin-native @sfn_log_execution, Cat-C #925)..."; \
-	$(CLANG) -target x86_64-w64-mingw32 $(NATIVE_OPT) -fno-delete-null-pointer-checks \
-		-c "$$IO_LL" -o "$$WIN_OBJ/runtime/io.o"; \
-	echo "[cross-windows] compiling string (Sailfin-native @sfn_to_debug_string + char preds, Cat-C #925)..."; \
-	$(CLANG) -target x86_64-w64-mingw32 $(NATIVE_OPT) -fno-delete-null-pointer-checks \
-		-c "$$STRING_LL" -o "$$WIN_OBJ/runtime/string.o"; \
-	echo "[cross-windows] compiling array (Sailfin-native @sfn_array_sfn_* stubs, Cat-C #925)..."; \
-	$(CLANG) -target x86_64-w64-mingw32 $(NATIVE_OPT) -fno-delete-null-pointer-checks \
-		-c "$$ARRAY_LL" -o "$$WIN_OBJ/runtime/array.o"; \
-	echo "[cross-windows] compiling mem (Sailfin-native memory primitives, #927)..."; \
-	$(CLANG) -target x86_64-w64-mingw32 $(NATIVE_OPT) -fno-delete-null-pointer-checks \
-		-c "$$MEM_LL" -o "$$WIN_OBJ/runtime/mem.o"; \
+			-c "$$ll" -o "$$obj"; \
+		RUNTIME_OBJS="$$RUNTIME_OBJS $$obj"; \
+	done; \
 	\
 	echo "[cross-windows] compiling C runtime..."; \
 	$(MINGW_CC) -O2 -I runtime/native/include -c runtime/native/src/sailfin_arena.c \
@@ -1208,19 +876,7 @@ ci-cross-windows:
 		"$$WIN_OBJ/sailfin_base64.o" \
 		"$$WIN_OBJ/runtime_globals.o" \
 		"$$WIN_OBJ/native.linked.o" \
-		"$$WIN_OBJ/runtime/prelude.o" \
-		"$$WIN_OBJ/runtime/clock.o" \
-		"$$WIN_OBJ/runtime/type_meta.o" \
-		"$$WIN_OBJ/runtime/exec.o" \
-		"$$WIN_OBJ/runtime/exception.o" \
-		"$$WIN_OBJ/runtime/filesystem.o" \
-		"$$WIN_OBJ/runtime/http.o" \
-		"$$WIN_OBJ/runtime/io.o" \
-		"$$WIN_OBJ/runtime/string.o" \
-		"$$WIN_OBJ/runtime/array.o" \
-		"$$WIN_OBJ/runtime/mem.o" \
-		"$$WIN_OBJ/runtime/arena.o" \
-		"$$WIN_OBJ/runtime/rc.o" \
+		$$RUNTIME_OBJS \
 		$$SHIM_O \
 		-lm -lpthread -lws2_32; \
 	\
@@ -1234,59 +890,18 @@ ci-cross-windows:
 	mkdir -p "$$INSTALLER_DIR/bin"; \
 	cp -f "$$WIN_OUT" "$$INSTALLER_DIR/bin/sailfin.exe"; \
 	cp -f "$$WIN_OUT" "$$INSTALLER_DIR/bin/sfn.exe"; \
-	mkdir -p "$$INSTALLER_DIR/runtime/native/obj"; \
+	mkdir -p "$$INSTALLER_DIR/runtime"; \
 	cp -R runtime/native "$$INSTALLER_DIR/runtime/native"; \
-	if [ -f "$$WIN_OBJ/runtime/prelude.o" ]; then \
-		mkdir -p "$$INSTALLER_DIR/runtime/native/obj"; \
-		cp -f "$$WIN_OBJ/runtime/prelude.o" "$$INSTALLER_DIR/runtime/native/obj/prelude.o"; \
-	fi; \
-	if [ -f "$$WIN_OBJ/runtime/clock.o" ]; then \
-		mkdir -p "$$INSTALLER_DIR/runtime/native/obj"; \
-		cp -f "$$WIN_OBJ/runtime/clock.o" "$$INSTALLER_DIR/runtime/native/obj/clock.o"; \
-	fi; \
-	if [ -f "$$WIN_OBJ/runtime/type_meta.o" ]; then \
-		mkdir -p "$$INSTALLER_DIR/runtime/native/obj"; \
-		cp -f "$$WIN_OBJ/runtime/type_meta.o" "$$INSTALLER_DIR/runtime/native/obj/type_meta.o"; \
-	fi; \
-	if [ -f "$$WIN_OBJ/runtime/exec.o" ]; then \
-		mkdir -p "$$INSTALLER_DIR/runtime/native/obj"; \
-		cp -f "$$WIN_OBJ/runtime/exec.o" "$$INSTALLER_DIR/runtime/native/obj/exec.o"; \
-	fi; \
-	if [ -f "$$WIN_OBJ/runtime/exception.o" ]; then \
-		mkdir -p "$$INSTALLER_DIR/runtime/native/obj"; \
-		cp -f "$$WIN_OBJ/runtime/exception.o" "$$INSTALLER_DIR/runtime/native/obj/exception.o"; \
-	fi; \
-	if [ -f "$$WIN_OBJ/runtime/filesystem.o" ]; then \
-		mkdir -p "$$INSTALLER_DIR/runtime/native/obj"; \
-		cp -f "$$WIN_OBJ/runtime/filesystem.o" "$$INSTALLER_DIR/runtime/native/obj/filesystem.o"; \
-	fi; \
-	if [ -f "$$WIN_OBJ/runtime/http.o" ]; then \
-		mkdir -p "$$INSTALLER_DIR/runtime/native/obj"; \
-		cp -f "$$WIN_OBJ/runtime/http.o" "$$INSTALLER_DIR/runtime/native/obj/http.o"; \
-	fi; \
-	if [ -f "$$WIN_OBJ/runtime/io.o" ]; then \
-		mkdir -p "$$INSTALLER_DIR/runtime/native/obj"; \
-		cp -f "$$WIN_OBJ/runtime/io.o" "$$INSTALLER_DIR/runtime/native/obj/io.o"; \
-	fi; \
-	if [ -f "$$WIN_OBJ/runtime/string.o" ]; then \
-		mkdir -p "$$INSTALLER_DIR/runtime/native/obj"; \
-		cp -f "$$WIN_OBJ/runtime/string.o" "$$INSTALLER_DIR/runtime/native/obj/string.o"; \
-	fi; \
-	if [ -f "$$WIN_OBJ/runtime/array.o" ]; then \
-		mkdir -p "$$INSTALLER_DIR/runtime/native/obj"; \
-		cp -f "$$WIN_OBJ/runtime/array.o" "$$INSTALLER_DIR/runtime/native/obj/array.o"; \
-	fi; \
-	if [ -f "$$WIN_OBJ/runtime/mem.o" ]; then \
-		mkdir -p "$$INSTALLER_DIR/runtime/native/obj"; \
-		cp -f "$$WIN_OBJ/runtime/mem.o" "$$INSTALLER_DIR/runtime/native/obj/mem.o"; \
-	fi; \
-	if [ -f "$$WIN_OBJ/runtime/arena.o" ]; then \
-		mkdir -p "$$INSTALLER_DIR/runtime/native/obj"; \
-		cp -f "$$WIN_OBJ/runtime/arena.o" "$$INSTALLER_DIR/runtime/native/obj/arena.o"; \
-	fi; \
-	if [ -f "$$WIN_OBJ/runtime/rc.o" ]; then \
-		mkdir -p "$$INSTALLER_DIR/runtime/native/obj"; \
-		cp -f "$$WIN_OBJ/runtime/rc.o" "$$INSTALLER_DIR/runtime/native/obj/rc.o"; \
-	fi; \
+	: "#941: bundle the runtime Sailfin sources. A fresh Windows install"; \
+	: "relinks user programs against the runtime via the capsule"; \
+	: "emit-from-source path (assemble_runtime_capsule_link_inputs in"; \
+	: "cli_main.sfn), which reads <root>/runtime/prelude.sfn +"; \
+	: "<root>/runtime/sfn/** relative to the bundled capsule.toml;"; \
+	: "without them a fresh install cannot link any runtime-touching"; \
+	: "program. The former per-.o bundle copies are gone — those"; \
+	: "objects were never consumed by the post-#940 link path. Mirrors"; \
+	: "_package_installer (the Linux/host installer)."; \
+	cp -f runtime/prelude.sfn "$$INSTALLER_DIR/runtime/prelude.sfn"; \
+	cp -R runtime/sfn "$$INSTALLER_DIR/runtime/sfn"; \
 	tar -czf "dist/installer-$(MINGW_TARGET).tar.gz" -C "$$INSTALLER_DIR" .; \
 	echo "[cross-windows] done: dist/installer-$(MINGW_TARGET).tar.gz"

--- a/Makefile
+++ b/Makefile
@@ -837,10 +837,33 @@ ci-cross-windows:
 		ll="$$WIN_OBJ/runtime/$$mod.ll"; \
 		obj="$$WIN_OBJ/runtime/$$mod.o"; \
 		echo "[cross-windows] emitting + compiling $$mod ($$src)..."; \
-		if [ "$$mod" = "clock" ]; then \
-			SAILFIN_TARGET_OS=Windows $(NATIVE_OUT) emit -o "$$ll" llvm "$$src" >/dev/null; \
-		else \
-			$(NATIVE_OUT) emit -o "$$ll" llvm "$$src" >/dev/null; \
+		: "Emit with retry + IR validation (mirrors the prelude staging"; \
+		: "the former 'make rebuild' block used). A single-shot 'emit'"; \
+		: "doesn't go through the resolver's retry+validator cascade, so a"; \
+		: "seed-emit flake (invalid IR) would otherwise escape straight"; \
+		: "into clang. Up to 3 attempts; each validated via the same"; \
+		: "llvm-as / clang -emit-llvm cascade the resolver uses."; \
+		attempt=0; ok=0; \
+		while [ $$attempt -lt 3 ]; do \
+			attempt=$$((attempt + 1)); \
+			rm -f "$$ll"; \
+			if [ "$$mod" = "clock" ]; then \
+				SAILFIN_TARGET_OS=Windows $(NATIVE_OUT) emit -o "$$ll" llvm "$$src" >/dev/null || continue; \
+			else \
+				$(NATIVE_OUT) emit -o "$$ll" llvm "$$src" >/dev/null || continue; \
+			fi; \
+			[ -s "$$ll" ] || continue; \
+			if (command -v llvm-as >/dev/null 2>&1 && llvm-as < "$$ll" >/dev/null 2>&1) \
+				|| (command -v llvm-as-18 >/dev/null 2>&1 && llvm-as-18 < "$$ll" >/dev/null 2>&1) \
+				|| (command -v clang >/dev/null 2>&1 && clang -c -emit-llvm -x ir "$$ll" -o /dev/null >/dev/null 2>&1) \
+				|| (command -v clang-18 >/dev/null 2>&1 && clang-18 -c -emit-llvm -x ir "$$ll" -o /dev/null >/dev/null 2>&1); then \
+				ok=1; break; \
+			fi; \
+			echo "[cross-windows][warn] $$mod IR validation rejected output (attempt $$attempt/3)" >&2; \
+		done; \
+		if [ "$$ok" -ne 1 ]; then \
+			echo "[cross-windows][error] failed to emit valid $$mod IR after 3 attempts" >&2; \
+			exit 1; \
 		fi; \
 		$(CLANG) -target x86_64-w64-mingw32 $(NATIVE_OPT) -fno-delete-null-pointer-checks \
 			-c "$$ll" -o "$$obj"; \

--- a/compiler/src/cli_commands.sfn
+++ b/compiler/src/cli_commands.sfn
@@ -2211,7 +2211,6 @@ fn _package_installer(target: string, out_dir: string, compiler_bin: string) -> 
     let staging = "build/sailfin/.installer-staging";
     let staging_bin = staging + "/bin";
     let staging_runtime = staging + "/runtime";
-    let staging_runtime_obj = staging + "/runtime/native/obj";
     process.run(["rm", "-rf", staging]);
     process.run(["mkdir", "-p", staging_bin]);
     process.run(["mkdir", "-p", staging_runtime]);
@@ -2242,199 +2241,44 @@ fn _package_installer(target: string, out_dir: string, compiler_bin: string) -> 
         return 1;
     }
 
-    // Pre-built prelude object — preferred from the selfhost
-    // tree (which the active build wrote), falling back to a
-    // legacy build/native/obj path. Optional: a clean checkout
-    // without a prior `make compile` won't have either.
-    let prelude_a = "build/selfhost/native/obj/runtime/prelude.o";
-    let prelude_b = "build/native/obj/runtime/prelude.o";
-    let mut prelude_src: string = "";
-    if fs.exists(prelude_a) { prelude_src = prelude_a; } else {
-        if fs.exists(prelude_b) { prelude_src = prelude_b; }
+    // Bundle the runtime Sailfin sources. Post-#940 the install
+    // link path emits the prelude + every runtime `sfn-source` from
+    // disk via the child compiler (see
+    // `assemble_runtime_capsule_link_inputs` in cli_main.sfn). Those
+    // sources resolve to `<root>/runtime/prelude.sfn` and
+    // `<root>/runtime/sfn/**` relative to the bundled
+    // `runtime/native/capsule.toml`, so without them a fresh install
+    // cannot link any program that touches the runtime (every program
+    // pulls in the arena via prelude). They are REQUIRED, not optional
+    // — a failed copy is a hard error. This replaces the former
+    // per-`.o` bundle staging (prelude/clock/process/type_meta/
+    // filesystem/io/string/array): those pre-built objects were never
+    // consumed by the post-#940 link path, which always emits the
+    // runtime from source. Shipping the sources is both necessary and
+    // sufficient; the `.o` were dead weight.
+    if !fs.exists("runtime/prelude.sfn") {
+        print("sfn package: missing runtime/prelude.sfn (was the build run from the repo root?)");
+        process.run(["rm", "-rf", staging]);
+        return 1;
     }
-    if prelude_src.length > 0 {
-        // The prelude object's INCLUSION is conditional (it
-        // doesn't exist on a fresh checkout), but once we've
-        // committed to including it, a `mkdir`/`cp` failure is
-        // a bug — fail loudly rather than silently shipping
-        // an installer missing the expected `prelude.o`.
-        let mk_obj_dir = process.run(["mkdir", "-p", staging_runtime_obj]);
-        if mk_obj_dir != 0 {
-            print("sfn package: failed to create runtime obj staging dir");
-            process.run(["rm", "-rf", staging]);
-            return 1;
-        }
-        let cp_prelude = process.run(["cp", "-f", prelude_src, staging_runtime_obj
-            + "/prelude.o"]);
-        if cp_prelude != 0 {
-            print("sfn package: failed to stage prelude object from "
-                + prelude_src);
-            process.run(["rm", "-rf", staging]);
-            return 1;
-        }
+    let cp_prelude_src = process.run(["cp", "-f", "runtime/prelude.sfn", staging_runtime
+        + "/prelude.sfn"]);
+    if cp_prelude_src != 0 {
+        print("sfn package: failed to copy runtime/prelude.sfn");
+        process.run(["rm", "-rf", staging]);
+        return 1;
     }
-
-    // Pre-built clock object — Sailfin-native `@sfn_sleep`
-    // definition added in PR 2 of the sleep migration (issue #397).
-    // Same staging convention as the prelude: optional on a fresh
-    // checkout, hard fail once we commit to including it. Without
-    // this the installer link path resolves `@sfn_sleep` from
-    // nowhere and any program calling `sleep()` fails at link time.
-    let clock_a = "build/selfhost/native/obj/runtime/clock.o";
-    let clock_b = "build/native/obj/runtime/clock.o";
-    let mut clock_src: string = "";
-    if fs.exists(clock_a) { clock_src = clock_a; } else {
-        if fs.exists(clock_b) { clock_src = clock_b; }
+    if !fs.exists("runtime/sfn") {
+        print("sfn package: missing runtime/sfn (was the build run from the repo root?)");
+        process.run(["rm", "-rf", staging]);
+        return 1;
     }
-    if clock_src.length > 0 {
-        let mk_obj_dir = process.run(["mkdir", "-p", staging_runtime_obj]);
-        if mk_obj_dir != 0 {
-            print("sfn package: failed to create runtime obj staging dir");
-            process.run(["rm", "-rf", staging]);
-            return 1;
-        }
-        let cp_clock = process.run(["cp", "-f", clock_src, staging_runtime_obj
-            + "/clock.o"]);
-        if cp_clock != 0 {
-            print("sfn package: failed to stage clock object from " + clock_src);
-            process.run(["rm", "-rf", staging]);
-            return 1;
-        }
-    }
-
-    // Pre-built process object — Sailfin-native `@sfn_process_run`
-    // definition added in M2.9 (issue #405). Mirrors the clock.o
-    // staging above: optional on a fresh checkout, hard fail once
-    // staged. Without this the installer link path resolves
-    // `@sfn_process_run` from nowhere on POSIX targets and any
-    // program calling `process.run(...)` fails at link time.
-    // (Windows installers don't need this — the `_WIN32` C wrapper
-    // in `sailfin_runtime.c` provides the symbol there.)
-    let process_a = "build/selfhost/native/obj/runtime/process.o";
-    let process_b = "build/native/obj/runtime/process.o";
-    let mut process_src: string = "";
-    if fs.exists(process_a) { process_src = process_a; } else {
-        if fs.exists(process_b) { process_src = process_b; }
-    }
-    if process_src.length > 0 {
-        let mk_obj_dir = process.run(["mkdir", "-p", staging_runtime_obj]);
-        if mk_obj_dir != 0 {
-            print("sfn package: failed to create runtime obj staging dir");
-            process.run(["rm", "-rf", staging]);
-            return 1;
-        }
-        let cp_process = process.run(["cp", "-f", process_src, staging_runtime_obj
-            + "/process.o"]);
-        if cp_process != 0 {
-            print("sfn package: failed to stage process object from "
-                + process_src);
-            process.run(["rm", "-rf", staging]);
-            return 1;
-        }
-    }
-
-    // Pre-built type-meta object — Sailfin-native type-metadata
-    // registry added in M2.10 (issue #402). Mirrors the clock.o /
-    // process.o staging above: optional on a fresh checkout, hard
-    // fail once staged. Without this the installer link path
-    // resolves `@sfn_type_register` from nowhere, and every program
-    // compiled by the installed binary fails at link time the moment
-    // any module ships a named struct/enum/interface (the new
-    // compiler's per-module `@__sfn_module_type_init__*` constructor
-    // is unconditional).
-    let type_meta_a = "build/selfhost/native/obj/runtime/type_meta.o";
-    let type_meta_b = "build/native/obj/runtime/type_meta.o";
-    let mut type_meta_src: string = "";
-    if fs.exists(type_meta_a) { type_meta_src = type_meta_a; } else {
-        if fs.exists(type_meta_b) { type_meta_src = type_meta_b; }
-    }
-    if type_meta_src.length > 0 {
-        let mk_obj_dir = process.run(["mkdir", "-p", staging_runtime_obj]);
-        if mk_obj_dir != 0 {
-            print("sfn package: failed to create runtime obj staging dir");
-            process.run(["rm", "-rf", staging]);
-            return 1;
-        }
-        let cp_type_meta = process.run(["cp", "-f", type_meta_src, staging_runtime_obj
-            + "/type_meta.o"]);
-        if cp_type_meta != 0 {
-            print("sfn package: failed to stage type_meta object from "
-                + type_meta_src);
-            process.run(["rm", "-rf", staging]);
-            return 1;
-        }
-    }
-
-    // Pre-built filesystem object — Sailfin-native `@sfn_fs_read_file`
-    // / `@sfn_fs_write_file` / `@sfn_fs_append_file` definitions
-    // added in M3.1a (issue #814). Mirrors the clock.o / process.o /
-    // type_meta.o staging above: optional on a fresh checkout, hard
-    // fail once staged. Without this the installer link path resolves
-    // `@sfn_fs_read_file` from nowhere and every installed user
-    // program that calls `fs.readFile` / `fs.writeFile` /
-    // `fs.appendFile` fails at link time.
-    let filesystem_a = "build/selfhost/native/obj/runtime/filesystem.o";
-    let filesystem_b = "build/native/obj/runtime/filesystem.o";
-    let mut filesystem_src: string = "";
-    if fs.exists(filesystem_a) { filesystem_src = filesystem_a; } else {
-        if fs.exists(filesystem_b) { filesystem_src = filesystem_b; }
-    }
-    if filesystem_src.length > 0 {
-        let mk_obj_dir = process.run(["mkdir", "-p", staging_runtime_obj]);
-        if mk_obj_dir != 0 {
-            print("sfn package: failed to create runtime obj staging dir");
-            process.run(["rm", "-rf", staging]);
-            return 1;
-        }
-        let cp_filesystem = process.run(["cp", "-f", filesystem_src, staging_runtime_obj
-            + "/filesystem.o"]);
-        if cp_filesystem != 0 {
-            print("sfn package: failed to stage filesystem object from "
-                + filesystem_src);
-            process.run(["rm", "-rf", staging]);
-            return 1;
-        }
-    }
-
-    // Pre-built io / string / array objects — Sailfin-native Cat-C
-    // ports added in #925 (epic #390). Mirrors the clock.o / process.o
-    // / type_meta.o / filesystem.o staging above: optional on a fresh
-    // checkout, hard fail once staged. The prelude's `logExecution` /
-    // `to_debug_string` / `array_map` / `array_filter` / `array_reduce`
-    // wrappers reference `@sfn_log_execution` / `@sfn_to_debug_string`
-    // / `@sfn_array_sfn_*` unconditionally, so without these objects
-    // every program compiled by the installed binary fails at link.
-    let cat_c_mods: string[] = ["io", "string", "array"];
-    let mut cci: int = 0;
-    loop {
-        if cci >= cat_c_mods.length { break; }
-        let mod_name = cat_c_mods[cci];
-        cci += 1;
-        let cat_c_a = "build/selfhost/native/obj/runtime/" + mod_name + ".o";
-        let cat_c_b = "build/native/obj/runtime/" + mod_name + ".o";
-        let mut cat_c_src: string = "";
-        if fs.exists(cat_c_a) { cat_c_src = cat_c_a; } else {
-            if fs.exists(cat_c_b) { cat_c_src = cat_c_b; }
-        }
-        if cat_c_src.length > 0 {
-            let mk_obj_dir = process.run(["mkdir", "-p", staging_runtime_obj]);
-            if mk_obj_dir != 0 {
-                print("sfn package: failed to create runtime obj staging dir");
-                process.run(["rm", "-rf", staging]);
-                return 1;
-            }
-            let cp_cat_c = process.run(["cp", "-f", cat_c_src, staging_runtime_obj
-                + "/"
-                + mod_name
-                + ".o"]);
-            if cp_cat_c != 0 {
-                print("sfn package: failed to stage " + mod_name
-                    + " object from "
-                    + cat_c_src);
-                process.run(["rm", "-rf", staging]);
-                return 1;
-            }
-        }
+    let cp_sfn_src = process.run(["cp", "-R", "runtime/sfn", staging_runtime
+        + "/sfn"]);
+    if cp_sfn_src != 0 {
+        print("sfn package: failed to copy runtime/sfn sources");
+        process.run(["rm", "-rf", staging]);
+        return 1;
     }
 
     // Staged import-context — only present after a self-host

--- a/compiler/tests/e2e/test_cross_windows_runtime_modules.sh
+++ b/compiler/tests/e2e/test_cross_windows_runtime_modules.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Guard test (#941, Risk R4): the `ci-cross-windows` Make target emits +
+# links a hardcoded list of runtime Sailfin modules (`RUNTIME_MODS`).
+# That list is a copy of `runtime/native/capsule.toml`'s `sfn-sources`
+# array plus its `prelude-entry`, MINUS `process.sfn` (Windows resolves
+# `@sfn_process_run` from the `_WIN32` C wrapper in `sailfin_runtime.c`,
+# so linking the Sailfin object too would duplicate the symbol).
+#
+# If a future change adds/removes a runtime `sfn-source` in the manifest
+# but forgets to update the cross-windows loop, the Windows bridge would
+# silently drop (or double-link) a runtime module. This static check
+# fails the build the moment the two drift.
+#
+# Usage: test_cross_windows_runtime_modules.sh <compiler-binary>
+#   (the binary arg is accepted for harness uniformity but unused — this
+#    is a pure source-consistency check.)
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+MANIFEST="$REPO_ROOT/runtime/native/capsule.toml"
+MAKEFILE="$REPO_ROOT/Makefile"
+PASS=0
+FAIL=0
+
+ok() {
+    echo "[test] PASS: $1"
+    PASS=$((PASS + 1))
+}
+fail() {
+    echo "[test] FAIL: $1"
+    FAIL=$((FAIL + 1))
+}
+
+[ -f "$MANIFEST" ] || { echo "[test] missing $MANIFEST" >&2; exit 1; }
+[ -f "$MAKEFILE" ] || { echo "[test] missing $MAKEFILE" >&2; exit 1; }
+
+# Normalize a manifest-relative path (`../sfn/...`, relative to
+# runtime/native/) to a repo-root-relative path (`runtime/sfn/...`).
+norm() { sed -E 's#^\.\./#runtime/#'; }
+
+# --- Manifest: sfn-sources (single-line array) + prelude-entry ---
+sfn_line="$(grep -E '^sfn-sources[[:space:]]*=' "$MANIFEST" | head -n1 || true)"
+prelude_line="$(grep -E '^prelude-entry[[:space:]]*=' "$MANIFEST" | head -n1 || true)"
+[ -n "$sfn_line" ] || fail "no sfn-sources line in manifest"
+[ -n "$prelude_line" ] || fail "no prelude-entry line in manifest"
+
+sfn_vals="$(echo "$sfn_line" \
+    | sed -E 's/^[^[]*\[//; s/\].*$//' \
+    | tr ',' '\n' \
+    | sed -E 's/[[:space:]]//g; s/"//g' \
+    | grep -v '^$' || true)"
+prelude_val="$(echo "$prelude_line" \
+    | sed -E 's/^[^=]*=//; s/[[:space:]]//g; s/"//g')"
+
+# Expected cross-windows source set: prelude-entry + every sfn-source,
+# minus process.sfn, normalized to repo-relative paths.
+expected="$( { echo "$prelude_val"; echo "$sfn_vals"; } \
+    | norm \
+    | grep -v '^runtime/sfn/process\.sfn$' \
+    | grep -v '^$' \
+    | sort -u )"
+
+# --- Makefile: RUNTIME_MODS source paths (the part after each `:`) ---
+mods_line="$(grep -E 'RUNTIME_MODS="' "$MAKEFILE" | head -n1 || true)"
+[ -n "$mods_line" ] || fail "no RUNTIME_MODS assignment in Makefile"
+mods_val="$(echo "$mods_line" | sed -E 's/^[^"]*"//; s/".*$//')"
+actual="$(echo "$mods_val" \
+    | tr ' ' '\n' \
+    | sed -E 's/^[^:]*://' \
+    | grep -v '^$' \
+    | sort -u )"
+
+if [ "$expected" = "$actual" ]; then
+    ok "cross-windows RUNTIME_MODS matches manifest sfn-sources (+prelude, -process)"
+else
+    fail "cross-windows RUNTIME_MODS drifted from manifest sfn-sources"
+    echo "--- expected (manifest +prelude-entry -process) ---"
+    echo "$expected"
+    echo "--- actual (Makefile RUNTIME_MODS) ---"
+    echo "$actual"
+    echo "--- diff (expected vs actual) ---"
+    diff <(echo "$expected") <(echo "$actual") || true
+fi
+
+# The process.sfn exclusion must stay meaningful: it must be in the
+# manifest, and it must NOT be linked by cross-windows.
+if echo "$sfn_vals" | norm | grep -q '^runtime/sfn/process\.sfn$'; then
+    ok "process.sfn present in manifest sfn-sources (exclusion is meaningful)"
+else
+    fail "process.sfn no longer in manifest — revisit the cross-windows exclusion"
+fi
+if echo "$actual" | grep -q '^runtime/sfn/process\.sfn$'; then
+    fail "process.sfn is in RUNTIME_MODS — would duplicate the _WIN32 C @sfn_process_run"
+else
+    ok "process.sfn excluded from cross-windows RUNTIME_MODS"
+fi
+
+echo ""
+echo "[test] $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/compiler/tests/e2e/test_runtime_exception_frames.sh
+++ b/compiler/tests/e2e/test_runtime_exception_frames.sh
@@ -545,10 +545,21 @@ CHARNESS
     # rides along. Skip if absent (the IR-shape assertions still
     # pin the contract; this round-trip is a smoke test on top).
     local bin="$SCRATCH/roundtrip"
-    local type_meta_o="$REPO_ROOT/build/native/obj/runtime/type_meta.o"
+    # #941: the Makefile no longer stages `build/native/obj/runtime/*.o`
+    # (every link path now emits the runtime from source). Emit
+    # `type_meta` from `runtime/sfn/type_meta.sfn` on the fly so the
+    # `@__sfn_module_type_init__*` constructor's `@sfn_type_register`
+    # call resolves at link. If that object can't be produced, skip the
+    # roundtrip (the IR-shape assertions above still pin the contract).
+    local type_meta_ll="$SCRATCH/type_meta.ll"
+    local type_meta_o="$SCRATCH/type_meta.o"
     local extra_o=()
-    if [ -f "$type_meta_o" ]; then
+    if "$BINARY" emit -o "$type_meta_ll" llvm "$REPO_ROOT/runtime/sfn/type_meta.sfn" >/dev/null 2>&1 \
+        && "$clang_bin" -Wno-override-module -c "$type_meta_ll" -o "$type_meta_o" 2>/dev/null; then
         extra_o+=("$type_meta_o")
+    else
+        echo "[test]   could not emit type_meta object — skipping roundtrip"
+        return 0
     fi
     if ! "$clang_bin" -Wno-override-module "$harness" "$ll" "${extra_o[@]}" -o "$bin" -lm 2>"$SCRATCH/clang.log"; then
         echo "[test]   clang failed to link roundtrip harness:"

--- a/compiler/tests/e2e/test_runtime_memory_rc.sh
+++ b/compiler/tests/e2e/test_runtime_memory_rc.sh
@@ -316,10 +316,21 @@ CHARNESS
     # (the IR-shape assertions still pin the contract; this round-
     # trip is a smoke test on top).
     local bin="$SCRATCH/roundtrip"
-    local type_meta_o="$REPO_ROOT/build/native/obj/runtime/type_meta.o"
+    # #941: the Makefile no longer stages `build/native/obj/runtime/*.o`
+    # (every link path now emits the runtime from source). Emit
+    # `type_meta` from `runtime/sfn/type_meta.sfn` on the fly so the
+    # `@__sfn_module_type_init__*` constructor's `@sfn_type_register`
+    # call resolves at link. If that object can't be produced, skip the
+    # roundtrip (the IR-shape assertions above still pin the contract).
+    local type_meta_ll="$SCRATCH/type_meta.ll"
+    local type_meta_o="$SCRATCH/type_meta.o"
     local extra_o=()
-    if [ -f "$type_meta_o" ]; then
+    if "$BINARY" emit -o "$type_meta_ll" llvm "$REPO_ROOT/runtime/sfn/type_meta.sfn" >/dev/null 2>&1 \
+        && "$clang_bin" -Wno-override-module -c "$type_meta_ll" -o "$type_meta_o" 2>/dev/null; then
         extra_o+=("$type_meta_o")
+    else
+        echo "[test]   could not emit type_meta object — skipping roundtrip"
+        return 0
     fi
     if ! "$clang_bin" -Wno-override-module "$harness" "$ll" "${extra_o[@]}" -o "$bin" -lm 2>"$SCRATCH/clang.log"; then
         echo "[test]   clang failed to link roundtrip harness:"

--- a/docs/runtime_audit.md
+++ b/docs/runtime_audit.md
@@ -99,10 +99,12 @@
 >   `compiler/src/llvm/runtime_helpers.sfn`, and the matching helper-
 >   preamble entry in `compiler/src/llvm/lowering/lowering_helpers.sfn`.
 >   `runtime/native/capsule.toml`'s `sfn-sources` now lists
->   `../sfn/clock.sfn`, so the runtime-capsule link path picks it up;
->   `make rebuild` additionally stages `build/native/obj/runtime/clock.o`
->   for the legacy `sfn run` / `sfn build` link path
->   (`_clang_compile_runtime_objects` in `compiler/src/cli_main.sfn`).
+>   `../sfn/clock.sfn`, so the runtime-capsule link path picks it up.
+>   (#941: the legacy `make rebuild` `build/native/obj/runtime/*.o`
+>   staging was deleted — post-#940 every link path emits the runtime
+>   from source via the capsule path, so the pre-built objects were no
+>   longer read. `ci-cross-windows` now emits its runtime IR itself and
+>   the installer bundles `runtime/prelude.sfn` + `runtime/sfn/`.)
 >   EINTR-resume landed via bounded retry loop (issue #693,
 >   2026-05-26): `sfn_sleep` now wraps the `nanosleep` call in a
 >   `loop`-with-`break` capped at 32 iterations that exits on

--- a/docs/status.md
+++ b/docs/status.md
@@ -193,16 +193,32 @@ feature availability.
     `<out>/<sanitised-name>-<target>-<version>.tar.gz`. Falls
     over with a clear error when the sidecar is missing
     (hint: `sfn build -p <path>` first). **C4 v1 (#265).**
-  - **Installer mode (`--installer`, this PR):** bundles the
-    compiler + `runtime/native/` + (when available) the
-    pre-built prelude `.o` + (when available) the staged
-    `import-context/` into `<out>/installer-<target>.tar.gz`.
-    No version in the tarball name (matches the historical
-    `tools/package.sh` shape consumed by `release-tag.yml` +
-    `ci.yml`); manifest carries `kind = "installer"`. Mutually
-    exclusive with `-p`. Replaces the second half of
-    `tools/package.sh` — after this lands, every output of the
-    shell script has a Sailfin-native equivalent.
+  - **Installer mode (`--installer`):** bundles the compiler +
+    `runtime/native/` + the runtime Sailfin sources
+    (`runtime/prelude.sfn` + `runtime/sfn/`) + (when available)
+    the staged `import-context/` into
+    `<out>/installer-<target>.tar.gz`. No version in the tarball
+    name (matches the historical `tools/package.sh` shape
+    consumed by `release-tag.yml` + `ci.yml`); manifest carries
+    `kind = "installer"`. Mutually exclusive with `-p`. Replaces
+    the second half of `tools/package.sh` — after this lands,
+    every output of the shell script has a Sailfin-native
+    equivalent.
+    - **#941:** the runtime `.sfn` sources are now **required**
+      bundle contents (previously absent). Post-#940 a fresh
+      install relinks user programs by emitting the prelude +
+      every runtime `sfn-source` from disk via the
+      runtime-capsule path
+      (`assemble_runtime_capsule_link_inputs`), so the install
+      tree must ship `runtime/prelude.sfn` + `runtime/sfn/**`
+      relative to the bundled `runtime/native/capsule.toml`;
+      without them a fresh install could not link any
+      runtime-touching program. The former per-`.o` bundle
+      staging (prelude/clock/process/type_meta/filesystem/io/
+      string/array) was **removed** — those objects were never
+      read by the post-#940 link path (it always emits from
+      source). The same applies to the `make ci-cross-windows`
+      Windows installer.
   - **Manifest** is schema-versioned via
     `dist_manifest.sfn::DistManifest` (`schema_version: "1"`)
     — adds `kind` (compiler / installer / binary / library),


### PR DESCRIPTION
## Summary

- Deletes the ~256-line per-runtime-module `.ll`+`.o` staging block from `make rebuild` (dead post-#940) and relocates the runtime IR emits `ci-cross-windows` consumes into a self-contained loop in that target, guarded by a new e2e test against the manifest (Risk R4).
- **Fixes a fresh-install regression discovered while validating** (predates this issue; ships in alpha.17): the installer bundled only `runtime/native/` with no runtime `.sfn` sources, but post-#940 the install link path emits the prelude + every `sfn-source` from disk — so a fresh `sfn run`/`build` of any runtime-touching program failed at link. The installer now bundles `runtime/prelude.sfn` + `runtime/sfn/` as required contents.

Closes #941

## Background — why the scope expanded

#941 as written assumed installed binaries "resolve the runtime via `capsule.toml` and no longer need pre-staged `.o`." Investigation showed that premise was **already false on `main`**:

- Post-#940 `assemble_runtime_capsule_link_inputs` (`cli_main.sfn`) emits the prelude + each runtime `sfn-source` **from source** via the child compiler — there is **no** fallback that reads the bundled `.o`.
- `_package_installer` + `install.sh` ship only `runtime/native/`; the sources `sfn-sources`/`prelude-entry` resolve to (`<root>/runtime/sfn/**`, `<root>/runtime/prelude.sfn`) were absent.
- **Empirically:** a cold-cache `sfn run` from an extracted bundle (released alpha.17 *and* a fresh `main` build) fails with `file not found: .../runtime/sfn/memory/arena.sfn`. The staged `.o` are never consulted.

So the original "delete the staging" cleanup is only *safe* once installs resolve the runtime end-to-end. This PR folds in that missing predecessor (per maintainer direction).

## Changes

**Install fix**
- `compiler/src/cli_commands.sfn` `_package_installer`: bundle `runtime/prelude.sfn` + `runtime/sfn/` (required, hard-fail on copy error); remove the never-consumed per-`.o` bundle staging (prelude/clock/process/type_meta/filesystem/io/string/array) and the now-unused `staging_runtime_obj`.
- `Makefile` `ci-cross-windows` packaging: same — bundle the runtime sources for the Windows installer; drop the per-`.o` copies.

**Makefile/CI cleanup (original #941)**
- `make rebuild`: deleted the runtime-object staging block (prelude..exec `.ll`+`.o`). **Kept** the `runtime/sfn/platform/*.sfn-asm` import-context staging (still load-bearing for selfhost emit) and the `build/native/raw/` IR mirror.
- `ci-cross-windows`: emits its 13 runtime modules itself via a hardcoded `RUNTIME_MODS` loop (= `capsule.toml` `sfn-sources` + `prelude-entry`, **minus** `process.sfn`, which Windows gets from the `_WIN32` C wrapper). `clock` is re-emitted with `SAILFIN_TARGET_OS=Windows` (#877). Dropped the `*_LL` existence guards; link uses `$RUNTIME_OBJS`.
- `ci-prepare-test-artifacts`: dropped the now-absent `prelude.o` check (test runner links via the capsule path).
- New guard test `compiler/tests/e2e/test_cross_windows_runtime_modules.sh` asserts `RUNTIME_MODS` stays in sync with the manifest (Risk R4).
- Docs: `docs/status.md` (installer-mode bundle contents) + `docs/runtime_audit.md` (stale `clock.o` staging note).

## Acceptance Criteria

- [x] #947 (seed pin to alpha.17) merged — Phase 1.5 verified Ra `1412c09` ∈ `v0.7.0-alpha.17`.
- [x] `make clean-build && make compile` pass with the staging deleted.
- [x] Fresh-install `sfn run` works (io+clock and fs round-trip) from an extracted installer bundle with **zero** staged `.o` — the headline acceptance criterion, previously failing.
- [x] `runtime/sfn/platform/*.sfn-asm` import-context staging preserved.
- [x] Guard test passes; cross-windows `RUNTIME_MODS` matches the manifest.
- [ ] `make check && make test` — **in flight** (running at PR-open for a CI head start).
- [ ] `make ci-cross-windows` builds `sailfin.exe` — **CI only** (no MinGW in the dev sandbox); guard test + careful inspection cover the relocation locally.

## Verification

```text
# self-host (clean) — PASS
make clean-build && make compile

# cold fresh-install from extracted installer bundle (zero staged .o) — PASS
build/native/sailfin package --installer --out /tmp/inst --compiler-bin build/native/sailfin
tar -xzf /tmp/inst/installer-linux-x86_64.tar.gz -C /tmp/sfn-install
( cd /tmp/cold && /tmp/sfn-install/bin/sailfin run hello.sfn )   # [info] hi  (EXIT 0)
( cd /tmp/cold && /tmp/sfn-install/bin/sailfin run fsprog.sfn )  # read back: roundtrip-ok  (EXIT 0)
test "$(find /tmp/sfn-install/runtime/native/obj -name '*.o' | wc -l)" -eq 0   # no staged .o

# guard test — PASS (3/3)
bash compiler/tests/e2e/test_cross_windows_runtime_modules.sh build/native/sailfin
```

*(The pre-existing `llvm lowering [fatal]: ... write` line is the #414 import-context quirk — appears in-repo too, does not affect output.)*

## Files Changed

- `Makefile` — delete rebuild staging; rewrite `ci-cross-windows` emit loop + packaging; fix `ci-prepare-test-artifacts`
- `compiler/src/cli_commands.sfn` — bundle runtime sources, remove per-`.o` staging
- `compiler/tests/e2e/test_cross_windows_runtime_modules.sh` — new guard test (Risk R4)
- `docs/status.md`, `docs/runtime_audit.md` — sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D7Bg1XCBwZwTaew4c9r5jh)_