### PR TITLE
feat(runtime): port exception TLS slot + raise_value_error to Sailfin

### DIFF
--- a/compiler/src/llvm/effects.sfn
+++ b/compiler/src/llvm/effects.sfn
@@ -547,16 +547,22 @@ fn collect_instruction_runtime_helper_targets(instruction: NativeInstruction) ->
         return helpers;
     }
     if instruction.variant == "Try" {
-        // M2.7b (#404): emit declares for the new frame primitives alongside
-        // the legacy TLS-polling family so both APIs coexist during the
-        // transition. M2.7c retires the legacy entries once every emission
-        // site has cut over.
+        // M2.7b (#404): emit declares for the frame primitives alongside
+        // the TLS-polling family so both APIs coexist during the
+        // transition. M3 (#929) ported that family to
+        // `runtime/sfn/exception.sfn`, so the `clear_exception` /
+        // `has_exception` targets now resolve to `@sfn_clear_exception` /
+        // `@sfn_has_exception` via the registry's `native_signature`; the
+        // legacy C bodies stay exported for seed-built IR until the M3
+        // seed cut.
         return ["clear_exception", "has_exception", "take_exception", "sfn_exception_push_frame", "sfn_exception_pop_frame", "sfn_take_exception_frame", "setjmp"];
     }
     if instruction.variant == "Throw" {
         // M2.7b (#404): `lower_throw_instruction` emits `call void
-        // @sfn_throw` (longjmp); declare the legacy `set_exception` symbol
-        // too so seed-compiled call sites that still call it link cleanly.
+        // @sfn_throw` (longjmp); declare the `set_exception` symbol too so
+        // seed-compiled call sites that still call it link cleanly. M3
+        // (#929) ported it, so the target now resolves to
+        // `@sfn_set_exception` via the registry's `native_signature`.
         return ["set_exception", "sfn_throw_frame"];
     }
     return [];

--- a/compiler/src/llvm/lowering/instructions_try.sfn
+++ b/compiler/src/llvm/lowering/instructions_try.sfn
@@ -185,10 +185,12 @@ fn lower_throw_instruction(function_name: string, instruction: NativeInstruction
     // the `ret` that the legacy TLS-polling path emitted after
     // `set_exception` would be dead anyway (longjmp does not return),
     // so we follow with `unreachable` to make that explicit and to
-    // let LLVM's branch folding prune the trailing block. The legacy
-    // `sailfin_runtime_set_exception` symbol stays declared via the
-    // helper registry so seed-compiled call sites still link; M2.7c
-    // retires the C body once every emission site has cut over.
+    // let LLVM's branch folding prune the trailing block. The
+    // `set_exception` declare now resolves to `@sfn_set_exception` via
+    // the helper registry's `native_signature` — M3 (#929) ported the
+    // TLS message-slot family to `runtime/sfn/exception.sfn`. The legacy
+    // C body stays exported for seed-compiled call sites until the M3
+    // seed cut.
     let throw_operands: LLVMOperand[] = [coerced.operand];
     let throw_call = emit_runtime_call("sfn_throw_frame", throw_operands, empty_runtime_call_overrides(), current_temp, current_lines);
     let mut _ci_se: int = 0;

--- a/compiler/src/llvm/runtime_helpers.sfn
+++ b/compiler/src/llvm/runtime_helpers.sfn
@@ -442,7 +442,7 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
         target: "runtime_to_debug_string_fn", symbol: "sfn_to_debug_string", return_type: "i8*", parameter_types: ["i8*"], effects: [], native_signature: "sfn_to_debug_string", c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "runtime_raise_value_error_fn", symbol: "sailfin_runtime_raise_value_error", return_type: "void", parameter_types: ["i8*"], effects: [], native_signature: null, c_abi_return_type: null
+        target: "runtime_raise_value_error_fn", symbol: "sfn_raise_value_error", return_type: "void", parameter_types: ["i8*"], effects: [], native_signature: "sfn_raise_value_error", c_abi_return_type: null
     });
     // Issue #364: structured assertion failure record. The desugared
     // `assert e;` lowering routes through this trampoline so the test
@@ -961,15 +961,23 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
         target: "runtime.free", symbol: "sfn_mem_free", return_type: "void", parameter_types: ["i8*"], effects: [], native_signature: "sfn_mem_free", c_abi_return_type: null
     });
 
-    // Exceptions (stage2-native minimal)
+    // Exceptions — live TLS message-slot API.
+    //
+    // M3 (#929, epic #390): the set/clear/has trio and the value-error
+    // raiser (the `runtime_raise_value_error_fn` descriptor above) flip
+    // their `symbol` + `native_signature` to the Sailfin-native bodies in
+    // `runtime/sfn/exception.sfn`, which share one process-global message
+    // slot. The legacy C bodies stay exported in `runtime/native/` for
+    // seed-built IR until the M3 seed cut, but every fresh emission now
+    // resolves through `effective_symbol` to the `sfn_*` exports.
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "set_exception", symbol: "sailfin_runtime_set_exception", return_type: "void", parameter_types: ["i8*"], effects: [], native_signature: null, c_abi_return_type: null
+        target: "set_exception", symbol: "sfn_set_exception", return_type: "void", parameter_types: ["i8*"], effects: [], native_signature: "sfn_set_exception", c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "clear_exception", symbol: "sailfin_runtime_clear_exception", return_type: "void", parameter_types: [], effects: [], native_signature: null, c_abi_return_type: null
+        target: "clear_exception", symbol: "sfn_clear_exception", return_type: "void", parameter_types: [], effects: [], native_signature: "sfn_clear_exception", c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "has_exception", symbol: "sailfin_runtime_has_exception", return_type: "i1", parameter_types: [], effects: [], native_signature: null, c_abi_return_type: null
+        target: "has_exception", symbol: "sfn_has_exception", return_type: "i1", parameter_types: [], effects: [], native_signature: "sfn_has_exception", c_abi_return_type: null
     });
 
     // M2.7b (#404) replaced the legacy TLS-polling exception primitives

--- a/runtime/sfn/exception.sfn
+++ b/runtime/sfn/exception.sfn
@@ -399,19 +399,35 @@ fn sfn_take_exception(frame: * SfnExceptionFrame) -> * u8 {
 // retires them.
 let mut sfn_exception_message_addr: i64 = 0;
 
-// `sfn_set_exception(message)` records `message` in the shared slot.
-// Mirrors the C `message ? message : ""` guard: a null argument stores
-// a non-null empty C string so `sfn_has_exception()` still reports true.
-// The empty buffer is a fresh 1-byte `malloc` (matching
+// Lazily-allocated, process-lifetime empty C string reused for every
+// `sfn_set_exception(null)` call. `0` means "not yet allocated". Mirrors
+// the C runtime's static `""` literal: allocated at most once and never
+// freed, so repeated null sets do not leak.
+let mut sfn_exception_empty_addr: i64 = 0;
+
+// `_sfn_exception_empty()` returns the shared empty C string, allocating
+// it on first use. A 1-byte `malloc` (matching
 // `runtime/sfn/process.sfn`'s `_process_empty_cstr`) rather than a
 // `"" as * u8` literal, which the current seed can mis-lower to a null
 // pointer in a `let` binding (see the cast-quirk note in
-// `runtime/sfn/platform/exec.sfn`).
+// `runtime/sfn/platform/exec.sfn`). If `malloc` fails the cache stays
+// `0` and the next call retries.
+fn _sfn_exception_empty() -> * u8 {
+    if sfn_exception_empty_addr == 0 {
+        let e = malloc(1 as usize);
+        if e as i64 != 0 { memset(e, 0, 1 as usize); }
+        sfn_exception_empty_addr = e as i64;
+    }
+    return sfn_exception_empty_addr as * u8;
+}
+
+// `sfn_set_exception(message)` records `message` in the shared slot.
+// Mirrors the C `message ? message : ""` guard: a null argument stores
+// the shared non-null empty C string (see `_sfn_exception_empty`) so
+// `sfn_has_exception()` still reports true without leaking per call.
 fn sfn_set_exception(message: * u8) -> void {
     if message as i64 == 0 {
-        let empty = malloc(1 as usize);
-        if empty as i64 != 0 { memset(empty, 0, 1 as usize); }
-        sfn_exception_message_addr = empty as i64;
+        sfn_exception_message_addr = _sfn_exception_empty() as i64;
         return;
     }
     sfn_exception_message_addr = message as i64;

--- a/runtime/sfn/exception.sfn
+++ b/runtime/sfn/exception.sfn
@@ -139,6 +139,15 @@ extern fn longjmp(env: * u8, val: i32) -> void;
 // while M2.7a coexists with TLS polling).
 extern fn abort() -> void;
 
+// libc `write(fd, buf, count)` and `strlen` back the value-error
+// diagnostic path at the bottom of this module. Same inline-extern
+// rationale as the setjmp/malloc trio above and
+// `runtime/sfn/memory/mem.sfn`'s bounds-check abort path, which
+// writes its diagnostic to fd 2 the same way.
+extern fn write(fd: i32, buf: * u8, count: usize) -> i64;
+
+extern fn strlen(s: * u8) -> usize;
+
 // `SfnExceptionFrame` lays out the per-`try` bookkeeping. Field
 // offsets are pinned by the IR-shape assertions in
 // `test_runtime_exception_frames.sh`. All slots are `i64` —
@@ -361,4 +370,90 @@ fn sfn_take_exception(frame: * SfnExceptionFrame) -> * u8 {
     let msg = frame.message_addr as * u8;
     frame.message_addr = 0;
     return msg;
+}
+
+// =============================================================================
+// Live TLS message-slot exception API (M3 — #929, epic #390, tracker #821)
+// =============================================================================
+//
+// The trio (`sfn_set_exception` / `sfn_clear_exception` /
+// `sfn_has_exception`) plus `sfn_raise_value_error` port the C runtime's
+// live TLS-polling exception path (`sailfin_runtime_*` set/clear/has and
+// the value-error raiser in `runtime/native/src/sailfin_runtime.c`) into
+// Sailfin. This is a SEPARATE surface from the setjmp/frame API above:
+// the frame API (`sfn_throw` / `sfn_try_enter` / `sfn_take_exception`)
+// backs `try`/`throw` lowering, while this message-slot API backs the
+// `runtime.*` value-error path and the TLS-polling declares that
+// `compiler/src/llvm/effects.sfn` still emits for seed-compiled call
+// sites.
+//
+// All four share the single process-global slot below — the reason
+// `sfn_raise_value_error` ships in lockstep with the trio (#929). The
+// slot mirrors the C runtime's `_Thread_local char *` message global; it
+// rides as an `i64` (not a `* u8`) for the same seed-compiler
+// pointer-drop reason the chain head and every struct pointer field in
+// this module do (see the file-header "Frame layout" and "TLS" notes).
+// The flip to `thread_local let mut` lands with the same post-seed
+// follow-up that upgrades the chain head. The legacy C symbols stay
+// exported in `runtime/native/` for seed-built IR until the M3 seed cut
+// retires them.
+let mut sfn_exception_message_addr: i64 = 0;
+
+// `sfn_set_exception(message)` records `message` in the shared slot.
+// Mirrors the C `message ? message : ""` guard: a null argument stores
+// a non-null empty C string so `sfn_has_exception()` still reports true.
+// The empty buffer is a fresh 1-byte `malloc` (matching
+// `runtime/sfn/process.sfn`'s `_process_empty_cstr`) rather than a
+// `"" as * u8` literal, which the current seed can mis-lower to a null
+// pointer in a `let` binding (see the cast-quirk note in
+// `runtime/sfn/platform/exec.sfn`).
+fn sfn_set_exception(message: * u8) -> void {
+    if message as i64 == 0 {
+        let empty = malloc(1 as usize);
+        if empty as i64 != 0 { memset(empty, 0, 1 as usize); }
+        sfn_exception_message_addr = empty as i64;
+        return;
+    }
+    sfn_exception_message_addr = message as i64;
+}
+
+// `sfn_clear_exception()` resets the shared slot to "no exception".
+fn sfn_clear_exception() -> void { sfn_exception_message_addr = 0; }
+
+// `sfn_has_exception()` reports whether the shared slot holds a pending
+// message. Returns `bool` (`i1` at the descriptor ABI).
+fn sfn_has_exception() -> bool { return sfn_exception_message_addr != 0; }
+
+// `sfn_raise_value_error(message)` records `message` in the shared slot
+// (parity with `sfn_set_exception` — the reason this ships in lockstep
+// with the trio, #929: all four touch one slot), surfaces the message on
+// stderr (fd 2), then `abort()`s — mirrors the C value-error raiser's
+// fatal semantics. The fd-2 write + abort follows the same
+// primitive-layer discipline as `runtime/sfn/memory/mem.sfn`'s
+// bounds-check failure path.
+//
+// No string literals here. A `string`/`"lit" as * u8` literal would emit
+// `sailfin_runtime_alloc_struct` (the string-aggregate allocator), which
+// this below-I/O-layer module's standalone link surface — exercised by
+// `compiler/tests/e2e/test_runtime_exception_frames.sh` — does not
+// provide, and which the current seed also mis-lowers in a `let` binding
+// (see the cast-quirk note in `runtime/sfn/platform/exec.sfn`). So the
+// `message` (a real `* u8` param, no allocation) is written directly,
+// and the trailing newline rides a 1-byte `memset` buffer (`10` = LF).
+// The fixed `"[value_error] "` prefix the C raiser printed is therefore
+// deferred — same reduced-diagnostic tradeoff `sfn_throw` makes above —
+// until this module can reference a constant byte string without the
+// allocator pull. The trailing `abort()` does not return, so no `ret`
+// is reachable; LLVM keeps the trailing block until noreturn metadata
+// propagates (same note as `sfn_throw`).
+fn sfn_raise_value_error(message: * u8) -> void {
+    sfn_set_exception(message);
+    if message as i64 != 0 { write(2, message, strlen(message)); }
+    let nl = malloc(1 as usize);
+    if nl as i64 != 0 {
+        memset(nl, 10, 1 as usize);
+        write(2, nl, 1 as usize);
+        free(nl);
+    }
+    abort();
 }


### PR DESCRIPTION
## Summary
- Port the live exception TLS message-slot trio (`sfn_set_exception` / `sfn_clear_exception` / `sfn_has_exception`) and `sfn_raise_value_error` into `runtime/sfn/exception.sfn`, all sharing one process-global message slot.
- Flip the four registry descriptors (`set_exception`, `clear_exception`, `has_exception`, `runtime_raise_value_error_fn`) — both `symbol` and `native_signature` — to the `sfn_*` exports, so the `effects.sfn` declare lists and the throw-lowering path now resolve to `@sfn_*` via `effective_symbol`.
- Legacy C bodies (`sailfin_runtime_*`) stay exported for seed-built IR until the M3 seed cut.

Closes #929

## Implementation notes
- `sfn_raise_value_error` writes the `message` (a real `* u8` param, no allocation) to fd 2 then `abort()`s. It deliberately avoids any `string` literal: a literal would emit `sailfin_runtime_alloc_struct`, which this below-I/O-layer module's standalone link surface — exercised by `test_runtime_exception_frames.sh` — does not provide (and which the current seed mis-lowers in a `let` binding). The fixed `"[value_error] "` prefix is therefore deferred, the same reduced-diagnostic tradeoff `sfn_throw` already makes; the trailing newline rides a 1-byte `memset` buffer.
- `sfn_set_exception` mirrors the C `message ? message : ""` guard (null → fresh 1-byte empty C string) so `sfn_has_exception()` still reports true.

## Acceptance Criteria
- [x] `sfn_set_exception` / `sfn_clear_exception` / `sfn_has_exception` / `sfn_raise_value_error` exported; share one TLS slot
- [x] Descriptors flipped; `effects.sfn` (~554, 560) and `instructions_try.sfn` (~189) resolve to `@sfn_*`; declare comment updated
- [x] Existing setjmp/throw e2e tests still green (`test_runtime_exception_frames.sh`: 12/12)
- [x] `compiler/tests/e2e/test_lowering_no_bare_runtime_emissions.sh` passes
- [x] `make compile` && `make check` pass
- [x] `sfn fmt --check` clean

## Verification
```
make compile                          # self-hosts ✓
make check                            # exit 0; both passes:
                                      #   unit 115/115, integration 29/29,
                                      #   e2e 4/4, e2e-sh 87/87, capsules 19/19
                                      #   [check] promoted seedcheck → build/native/sailfin
test_runtime_exception_frames.sh      # 12 passed, 0 failed
test_lowering_no_bare_runtime_emissions.sh  # PASS
grep -E 'sailfin_runtime_(set_exception|clear_exception|has_exception|raise_value_error)' \
  compiler/src/llvm/runtime_helpers.sfn       # empty ✓
```

## Files Changed
- `runtime/sfn/exception.sfn` — TLS message-slot trio + `sfn_raise_value_error`
- `compiler/src/llvm/runtime_helpers.sfn` — flip 4 descriptors
- `compiler/src/llvm/effects.sfn` — declare-comment updates (targets resolve via `native_signature`)
- `compiler/src/llvm/lowering/instructions_try.sfn` — declare comment update

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015Ru2C8B6LWppg78YbmXW23)_