### PR TITLE
feat(runtime): port alloc_struct to runtime/sfn/memory as sfn_alloc_struct

### DIFF
--- a/compiler/src/llvm/closures.sfn
+++ b/compiler/src/llvm/closures.sfn
@@ -28,7 +28,7 @@
 //   %size_ptr = getelementptr %sfn_closure_env_<id>,
 //                              %sfn_closure_env_<id>* null, i32 1
 //   %size_i64 = ptrtoint %sfn_closure_env_<id>* %size_ptr to i64
-//   %env_raw  = call noalias i8* @sailfin_runtime_alloc_struct(i64 %size_i64)
+//   %env_raw  = call noalias i8* @sfn_alloc_struct(i64 %size_i64)
 //   %env_ptr  = bitcast i8* %env_raw to %sfn_closure_env_<id>*
 //   %field0_ptr = getelementptr inbounds %sfn_closure_env_<id>,
 //                              %sfn_closure_env_<id>* %env_ptr,
@@ -233,7 +233,7 @@ struct ClosureCaptureOperand {
 }
 
 // Result of `emit_closure_env_alloc`. `env_raw_var` is the i8*
-// returned by `sailfin_runtime_alloc_struct` (handed to the
+// returned by `sfn_alloc_struct` (handed to the
 // closure pair as the `env*` slot in A3). `env_typed_var` is the
 // bitcast `%sfn_closure_env_<id>*` used by the GEP+store walk.
 struct ClosureEnvAllocResult {
@@ -402,8 +402,7 @@ fn emit_closure_env_alloc(layout: ClosureEnvLayout, operands: ClosureCaptureOper
 
     let env_raw = format_temp_name(current_temp);
     current_temp += 1;
-    lines.push("  " + env_raw
-        + " = call noalias i8* @sailfin_runtime_alloc_struct(i64 "
+    lines.push("  " + env_raw + " = call noalias i8* @sfn_alloc_struct(i64 "
         + size_i64
         + ")");
 

--- a/compiler/src/llvm/expression_lowering/native/core.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core.sfn
@@ -1068,7 +1068,7 @@ fn lower_expression(expression: string, bindings: ParameterBinding[], locals: Lo
                                 + "* "
                                 + typed_ptr_temp);
                             // Arena-aware free: the impl function's return
-                            // box is allocated via `@sailfin_runtime_alloc_struct`
+                            // box is allocated via `@sfn_alloc_struct`
                             // (Phase 5a follow-up), so this must route through
                             // the matching arena-aware free. Plain `@free` on
                             // an arena pointer corrupts glibc chunk metadata.

--- a/compiler/src/llvm/lowering/lowering_phase_render.sfn
+++ b/compiler/src/llvm/lowering/lowering_phase_render.sfn
@@ -159,18 +159,24 @@ fn render_llvm_preamble(module_name: string, type_context: TypeContext, trait_me
         lines.push("declare void @free(i8*)");
     }
     // Arena-aware allocation primitive. The expression-lowering pass
-    // emits `@sailfin_runtime_alloc_struct` instead of raw `@calloc`
-    // for string-literal materialization, struct/array literal boxes,
-    // and scalar→i8* coercions so that in-process multi-module drivers
-    // (`sfn check <dir>`, `sfn test`, future `sfn lsp`) can reclaim
-    // per-iteration scratch via Phase 5a's `runtime.arena_rewind`.
-    // Without this routing the rewind primitive cannot reach libc-
-    // owned literal storage and peak RSS climbs unbounded across the
-    // per-file loop. The runtime helper falls back to libc calloc when
-    // the arena is disabled, so behaviour for `SAILFIN_USE_ARENA=0`
+    // emits `@sfn_alloc_struct` instead of raw `@calloc` for string-literal
+    // materialization, struct/array literal boxes, and scalar→i8* coercions
+    // so that in-process multi-module drivers (`sfn check <dir>`, `sfn test`,
+    // future `sfn lsp`) can reclaim per-iteration scratch via Phase 5a's
+    // `runtime.arena_rewind`. Without this routing the rewind primitive
+    // cannot reach libc-owned literal storage and peak RSS climbs unbounded
+    // across the per-file loop. The runtime helper falls back to libc calloc
+    // when the arena is disabled, so behaviour for `SAILFIN_USE_ARENA=0`
     // is unchanged.
-    if find_function_by_name(context_functions, "sailfin_runtime_alloc_struct") == null {
-        lines.push("declare noalias i8* @sailfin_runtime_alloc_struct(i64)");
+    //
+    // M3 (#930, epic #390): the `alloc_struct` descriptor flipped its
+    // `symbol` / `native_signature` from the legacy C
+    // `sailfin_runtime_alloc_struct` to the Sailfin-native `@sfn_alloc_struct`
+    // (`runtime/sfn/memory/mem.sfn`). The descriptor sits in the
+    // `_preamble_inlined` skip-list in `rendering.sfn`, so this preamble line
+    // is the sole declare — it must match the flipped symbol.
+    if find_function_by_name(context_functions, "sfn_alloc_struct") == null {
+        lines.push("declare noalias i8* @sfn_alloc_struct(i64)");
     }
     // #927: the `runtime.free` descriptor is in the `_preamble_inlined`
     // skip-list in `rendering.sfn` (the descriptor render loop does NOT
@@ -180,8 +186,8 @@ fn render_llvm_preamble(module_name: string, type_context: TypeContext, trait_me
     // Sailfin-native `@sfn_mem_free` (`runtime/sfn/memory/mem.sfn`), and
     // both the scope-exit drop path AND the await-unbox path emit
     // `call void @sfn_mem_free(...)`, so this declare must match. (The
-    // `alloc_struct` declare above stays on the legacy C symbol: that
-    // primitive's port is a separate issue.)
+    // `alloc_struct` declare above is likewise flipped to
+    // `@sfn_alloc_struct` as of #930.)
     if find_function_by_name(context_functions, "sfn_mem_free") == null {
         lines.push("declare void @sfn_mem_free(i8*)");
     }

--- a/compiler/src/llvm/runtime_helpers.sfn
+++ b/compiler/src/llvm/runtime_helpers.sfn
@@ -939,21 +939,28 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
     });
 
     // M1.7.2a (issue #496): heap allocation primitive registered for
-    // `emit_runtime_call` dispatch. The seed already emits the matching
-    // `declare noalias i8* @sailfin_runtime_alloc_struct(i64)` line via
-    // `lowering_phase_render.sfn:164`, so adding this descriptor only
-    // unblocks the migration of the ~21 hand-spelled call sites — it
-    // does not introduce a new declare. The `noalias` return attribute
-    // is preserved at the call site through `RuntimeCallOverrides.return_attributes`
+    // `emit_runtime_call` dispatch. The `noalias` return attribute is
+    // preserved at the call site through `RuntimeCallOverrides.return_attributes`
     // because the descriptor schema deliberately has no slot for
     // call-site attributes (epic #494 forbids extending it).
+    //
+    // M3 (#930, epic #390): the hottest Category-C primitive flips its
+    // `symbol` + `native_signature` to the Sailfin-native `@sfn_alloc_struct`
+    // body in `runtime/sfn/memory/mem.sfn` (a faithful port of the legacy C
+    // alloc-struct body's `_rt_calloc(1, size)` routing). The
+    // descriptor is in the `_preamble_inlined` skip-list in `rendering.sfn`,
+    // so the declare-render loop does NOT emit its declare; the sole declare
+    // is the preamble line in `lowering_phase_render.sfn`, flipped to the
+    // `sfn_alloc_struct` symbol in lockstep. The legacy C body stays exported
+    // in `runtime/native/` for seed-built IR until the M3 seed cut, but every
+    // fresh emission now resolves through `effective_symbol` to `@sfn_alloc_struct`.
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "alloc_struct", symbol: "sailfin_runtime_alloc_struct", return_type: "i8*", parameter_types: ["i64"], effects: [], native_signature: null, c_abi_return_type: null
+        target: "alloc_struct", symbol: "sfn_alloc_struct", return_type: "i8*", parameter_types: ["i64"], effects: [], native_signature: "sfn_alloc_struct", c_abi_return_type: null
     });
 
     // M1.7.2a (issue #496): arena-aware free for boxed return values.
     // Today's only call site is `core.sfn:698`, where an awaited async
-    // result allocated through `sailfin_runtime_alloc_struct` is freed
+    // result allocated through `sfn_alloc_struct` is freed
     // after the unboxing load. Plain `@free` corrupts arena chunk
     // metadata; the runtime exposes the matching arena-aware entrypoint
     // here. Already declared via `lowering_phase_render.sfn:167`.

--- a/compiler/tests/e2e/test_runtime_memory_mem.sh
+++ b/compiler/tests/e2e/test_runtime_memory_mem.sh
@@ -175,22 +175,34 @@ void free(void *ptr) {
 }
 
 /* Arena-mode probe stub: report arena OFF so sfn_mem_free forwards to
- * the counting free() shim above. */
+ * the counting free() shim above, and so the module-defined
+ * `sfn_alloc_struct` (see below) takes its libc-calloc path. */
 int sfn_arena_enabled(void) { return 0; }
 
-/* Runtime hooks the seed compiler installs in emitted IR that the
- * harness must satisfy at link time but does not exercise:
- *   - `sailfin_runtime_mark_persistent` — persistent-pointer
- *     bookkeeping the seed emits on every heap return (the
- *     get_field malloc'd buffer). No-op stub.
- *   - `sailfin_runtime_alloc_struct` — arena/calloc-backed boxing
- *     the seed emits for the string literal in bounds_check's abort
- *     diagnostic. Forward to calloc so the literal is materialized
- *     correctly when the abort path runs in the forked child. */
-void sailfin_runtime_mark_persistent(void *ptr) { (void)ptr; }
-void *sailfin_runtime_alloc_struct(int64_t size) {
-    return calloc(1, (size_t)size);
+/* Arena trampolines referenced by the module-defined `sfn_alloc_struct`
+ * (#930). The arena-allocation branch is unreachable here because
+ * `sfn_arena_enabled()` returns 0, but the two calls are still present
+ * in the emitted IR, so the harness must satisfy them at link time.
+ * `sfn_arena_global` returns NULL and `sfn_arena_alloc` forwards to
+ * calloc — faithful to the arena-off contract even though neither runs. */
+void *sfn_arena_global(void) { return NULL; }
+void *sfn_arena_alloc(void *arena, size_t size, size_t align) {
+    (void)arena;
+    (void)align;
+    return calloc(1, size);
 }
+
+/* Runtime hook the seed compiler installs in emitted IR that the harness
+ * must satisfy at link time but does not exercise:
+ *   - `sailfin_runtime_mark_persistent` — persistent-pointer bookkeeping
+ *     the seed emits on every heap return (the get_field malloc'd
+ *     buffer). No-op stub.
+ * The boxed-struct allocator the seed previously emitted for the
+ * bounds_check abort-diagnostic string literal
+ * (`sailfin_runtime_alloc_struct`) is, as of #930, the module-defined
+ * `sfn_alloc_struct` above — it is no longer an external the harness
+ * provides. */
+void sailfin_runtime_mark_persistent(void *ptr) { (void)ptr; }
 
 extern char *sfn_mem_get_field(char *base, char *field);
 extern void  sfn_mem_copy_bytes(char *dest, char *src, int64_t length);

--- a/compiler/tests/integration/closure_env_emission_test.sfn
+++ b/compiler/tests/integration/closure_env_emission_test.sfn
@@ -231,7 +231,7 @@ test "closure_env: single-capture alloc emits size-via-GEP-null + alloc + popula
     assert result.lines.length == 6;
     assert result.lines[0] == "  %t0 = getelementptr %sfn_closure_env_0, %sfn_closure_env_0* null, i32 1";
     assert result.lines[1] == "  %t1 = ptrtoint %sfn_closure_env_0* %t0 to i64";
-    assert result.lines[2] == "  %t2 = call noalias i8* @sailfin_runtime_alloc_struct(i64 %t1)";
+    assert result.lines[2] == "  %t2 = call noalias i8* @sfn_alloc_struct(i64 %t1)";
     assert result.lines[3] == "  %t3 = bitcast i8* %t2 to %sfn_closure_env_0*";
     assert result.lines[4] == "  %t4 = getelementptr inbounds %sfn_closure_env_0, %sfn_closure_env_0* %t3, i32 0, i32 0";
     assert result.lines[5] == "  store i64 %x_local, i64* %t4";

--- a/compiler/tests/unit/runtime_call_dispatch_test.sfn
+++ b/compiler/tests/unit/runtime_call_dispatch_test.sfn
@@ -121,7 +121,7 @@ test "emit_runtime_call: alloc_struct with noalias return attribute renders attr
     };
     let result = emit_runtime_call("alloc_struct", operands, overrides, 0, []);
     assert result.lines.length == 1;
-    assert result.lines[0] == "  %t0 = call noalias i8* @sailfin_runtime_alloc_struct(i64 %size)";
+    assert result.lines[0] == "  %t0 = call noalias i8* @sfn_alloc_struct(i64 %size)";
     assert result.temp_index == 1;
     assert result.operand != null;
     assert result.diagnostics.length == 0;
@@ -132,7 +132,7 @@ test "emit_runtime_call: alloc_struct without override renders no return attribu
     let operands: LLVMOperand[] = [size];
     let result = emit_runtime_call("alloc_struct", operands, empty_runtime_call_overrides(), 0, []);
     assert result.lines.length == 1;
-    assert result.lines[0] == "  %t0 = call i8* @sailfin_runtime_alloc_struct(i64 %size)";
+    assert result.lines[0] == "  %t0 = call i8* @sfn_alloc_struct(i64 %size)";
     assert result.temp_index == 1;
     assert result.operand != null;
     assert result.diagnostics.length == 0;

--- a/runtime/sfn/memory/mem.sfn
+++ b/runtime/sfn/memory/mem.sfn
@@ -45,8 +45,24 @@ extern fn abort() -> void;
 
 // arena-mode probe (C `sfn_arena_enabled`, exported from
 // `runtime/native/src/sailfin_arena.c`). Backs the `sfn_mem_free`
-// arena-mode no-op guard below.
+// arena-mode no-op guard below and the `sfn_alloc_struct` routing.
 extern fn sfn_arena_enabled() -> bool;
+
+// process-global arena handle + bump allocator, both exported from
+// `runtime/native/src/sailfin_arena.c`. Back the arena path of
+// `sfn_alloc_struct`. `sfn_arena_alloc(arena, size, align)` returns an
+// **uninitialised** slice of the current page (see `sailfin_arena.c:144`),
+// so the port zero-fills via `memset` to match `_rt_calloc`'s contract.
+extern fn sfn_arena_global() -> * u8;
+
+extern fn sfn_arena_alloc(arena: * u8, size: usize, align: usize) -> * u8;
+
+// `calloc(count, size)` backs the libc fallback (arena disabled).
+extern fn calloc(count: usize, size: usize) -> * u8;
+
+// `memset(ptr, value, n)` zero-fills the arena slice (the libc fallback
+// uses `calloc`, which zeroes for free).
+extern fn memset(ptr: * u8, value: i32, n: usize) -> * u8;
 
 // `_get_field_safe_buf` head. The C original (`sailfin_runtime.c:373`)
 // keeps a 4096-byte static, 16-byte aligned, zero-initialised buffer
@@ -154,4 +170,30 @@ fn sfn_mem_free(ptr: * u8) -> void {
     if ptr as i64 == 0 { return; }
     if sfn_arena_enabled() { return; }
     free(ptr);
+}
+
+// `sfn_alloc_struct(size_bytes)` — faithful port of
+// `sailfin_runtime_alloc_struct` (`sailfin_runtime.c:4109`), the hottest
+// Category-C primitive (15 descriptor-routed emission sites across array,
+// closure, and operand lowering, plus the hand-spelled env-capture call in
+// `compiler/src/llvm/closures.sfn`). Returns a pointer to zero-initialised
+// memory of the requested size; callers GEP+store fields and hand the
+// pointer back as `%Struct*` (the 0.5.8+ boxed-struct ABI that replaced
+// first-class aggregate returns).
+//
+// Routing mirrors the C `_rt_calloc(1, size_bytes)` (`sailfin_runtime.c:779`):
+// under arena mode the allocation comes from the process-global arena and is
+// zero-filled here (the bump allocator returns uninitialised page memory);
+// otherwise it falls through to libc `calloc`, which zeroes for free. The
+// `size_bytes <= 0` guard returns NULL, exactly as the C body does. Descriptor
+// ABI is `(i64) -> i8*` with a `noalias` return attribute preserved at the
+// call site through `RuntimeCallOverrides.return_attributes`.
+fn sfn_alloc_struct(size_bytes: i64) -> * u8 {
+    if size_bytes <= 0 { return 0 as * u8; }
+    if sfn_arena_enabled() {
+        let p: * u8 = sfn_arena_alloc(sfn_arena_global(), size_bytes as usize, 8 as usize);
+        if p as i64 != 0 { memset(p, 0, size_bytes as usize); }
+        return p;
+    }
+    return calloc(1 as usize, size_bytes as usize);
 }


### PR DESCRIPTION
## Summary
- Port the hottest Category-C primitive `sailfin_runtime_alloc_struct` to a Sailfin-native body `sfn_alloc_struct` in `runtime/sfn/memory/mem.sfn`, faithfully mirroring the C `_rt_calloc(1, size)` routing (arena path via `sfn_arena_alloc` + `memset`; libc fallback via `calloc`; `size <= 0` → NULL).
- Flip the `alloc_struct` registry descriptor's `symbol` + `native_signature` to `@sfn_alloc_struct`, update the sole preamble declare (the descriptor is preamble-inlined, so the declare loop is skipped), and flip the hand-spelled emission in `closures.sfn`.
- The legacy C body stays exported in `runtime/native/` for seed-built IR until the M3 seed cut (#931). Merges last in the Cat-C flip wave.

Closes #930

## Acceptance Criteria
- [x] `sfn_alloc_struct` exported; every `alloc_struct` emission lowers to `@sfn_alloc_struct` (verified via IR smoke: struct + array boxing both route correctly)
- [x] Preamble-inlining path updated (no `sailfin_runtime_alloc_struct` lookup remains)
- [x] `compiler/tests/e2e/test_lowering_no_bare_runtime_emissions.sh` passes
- [x] Determinism sweep byte-identical across 20 iterations
- [x] `make compile` self-hosts (`make check` re-running on a cleaned runtime cache; see note)
- [x] `sfn fmt --check` clean

## Verification
```bash
# Descriptor flip clean
$ grep 'sailfin_runtime_alloc_struct' compiler/src/llvm/runtime_helpers.sfn
(empty)

# IR routing
$ build/native/sailfin emit -o /tmp/a.ll llvm /tmp/alloc_smoke.sfn
$ grep alloc_struct /tmp/a.ll
declare noalias i8* @sfn_alloc_struct(i64)
  %t4 = call noalias i8* @sfn_alloc_struct(i64 %t3)   # struct box
  %t13 = call i8* @sfn_alloc_struct(i64 %t12)         # array box
  %t20 = call i8* @sfn_alloc_struct(i64 %t19)
$ grep -c sailfin_runtime_alloc_struct /tmp/a.ll
0

# Single-file build + run links the new body
$ build/native/sailfin build -o /tmp/bin /tmp/alloc_smoke.sfn && /tmp/bin
built: /tmp/bin   (exit 2 == return 2.0)

# no-bare-emissions e2e
$ bash compiler/tests/e2e/test_lowering_no_bare_runtime_emissions.sh build/native/sailfin
[test] PASS: 2 allowlisted runtime emission(s) match audit

# determinism
20/20 byte-identical
```

## Files Changed
- `runtime/sfn/memory/mem.sfn` — `sfn_alloc_struct` body + arena/calloc/memset externs
- `compiler/src/llvm/runtime_helpers.sfn` — flip descriptor
- `compiler/src/llvm/lowering/lowering_phase_render.sfn` — flip preamble declare
- `compiler/src/llvm/closures.sfn` — flip hand-spelled env-capture emission
- `compiler/src/llvm/expression_lowering/native/core.sfn` — stale comment ref

## Note for reviewers
An incremental-build gotcha surfaced during validation: the per-source runtime `.ll` cache (`_emit_runtime_sfn_to_obj` in `cli_main.sfn`) is **existence-gated** (`if !fs.exists(ll_path)`), not content-hashed like the `.o` cache. On an incremental tree that compiled `mem.sfn` before this change, the stale `.ll` is reused, so the freshly-built compiler emits `@sfn_alloc_struct` but links against an `.o` lacking the body → `undefined reference to 'sfn_alloc_struct'`. A clean `build/` (CI) does not hit this; `rm -f build/sailfin/sfn__runtime-native__mem.sfn*` clears it locally. This is a pre-existing latent cache bug (out of scope for #930) worth filing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sm5QiuSExLDDGQKYS1mD3d)_