### PR TITLE
fix(runtime): guard sfn_str_* helpers against immediate-codepoint pseudo-pointers

### DIFF
--- a/compiler/tests/e2e/test_runtime_string_immediate.sh
+++ b/compiler/tests/e2e/test_runtime_string_immediate.sh
@@ -1,0 +1,224 @@
+#!/usr/bin/env bash
+# End-to-end test for issue #716 — immediate-codepoint pseudo-pointer
+# safety across the `sfn_str_*` C trampoline family.
+#
+# `char_at(text, i)` (and other single-grapheme readers) can return a
+# codepoint *tagged into the pointer itself* — the legacy
+# `(codepoint << 32)` encoding plus a near-null ASCII form, both
+# classified by `_is_immediate_codepoint_string` in
+# `runtime/native/src/sailfin_runtime.c`. A trampoline that dereferences
+# its operand directly (rather than routing through a legacy
+# `sailfin_runtime_*` entry that already decodes) SIGSEGVs on such a
+# value — exactly the `0x6800000000` crash that #714 hit on
+# `sfn_str_concat`.
+#
+# This test compiles the real C runtime (`sailfin_runtime.c` +
+# `sailfin_arena.c`) against a small harness that feeds each `sfn_str_*`
+# helper BOTH immediate encodings and asserts no crash + correct values.
+# It is a C-level fixture rather than a Sailfin `.sfn` program because the
+# immediate-codepoint tagging is non-deterministic from the language
+# surface, whereas the harness constructs the exact pseudo-pointers the
+# guards must survive.
+#
+# The first positional arg (the compiler binary) is accepted for
+# parity with the rest of the e2e suite but is unused — this fixture
+# exercises the C runtime directly.
+
+set -euo pipefail
+
+PASS=0
+FAIL=0
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+RUNTIME_SRC="$REPO_ROOT/runtime/native/src"
+RUNTIME_INC="$REPO_ROOT/runtime/native/include"
+
+SCRATCH="$(mktemp -d -t sfn-runtime-immediate-XXXXXX)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+run_test() {
+    local name="$1"
+    shift
+    if "$@"; then
+        echo "[test] PASS: $name"
+        PASS=$((PASS + 1))
+    else
+        echo "[test] FAIL: $name"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# Pick a C compiler. Honour $CC, then fall back to cc/clang/gcc.
+CC_BIN=""
+for cand in "${CC:-}" cc clang gcc; do
+    [ -z "$cand" ] && continue
+    if command -v "$cand" > /dev/null 2>&1; then
+        CC_BIN="$cand"
+        break
+    fi
+done
+
+# ---- Harness source ----
+HARNESS="$SCRATCH/immediate_harness.c"
+cat > "$HARNESS" <<'EOF'
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
+
+/* Canonical sfn_str_* trampoline ABI (runtime/native/src/sailfin_runtime.c). */
+extern int64_t sfn_str_len(const char *s);
+extern bool sfn_str_eq(const char *a, const char *b);
+extern char *sfn_str_slice(const char *text, double start, double end);
+extern const char *sfn_str_to_cstr(const char *s);
+extern const char *sfn_str_from_cstr(const char *s);
+extern double sfn_str_grapheme_count(const char *s);
+extern char *sfn_str_grapheme_at(const char *s, double idx);
+extern int64_t sfn_str_byte_at(const char *s, int64_t idx);
+extern int64_t sfn_str_find_byte(const char *s, int64_t byte_value, int64_t start_index);
+extern double sfn_str_codepoint(const char *s);
+extern double sfn_str_to_number(const char *s);
+
+static int failures = 0;
+
+static void check(const char *label, int cond)
+{
+    if (cond)
+    {
+        printf("[c-test] PASS: %s\n", label);
+    }
+    else
+    {
+        printf("[c-test] FAIL: %s\n", label);
+        failures++;
+    }
+}
+
+/* Upper-32-bit immediate encoding: (codepoint << 32). This is the form
+ * `_safe_strlen_asan` does NOT defend against — the #714 crash shape. */
+static const char *imm_upper(uint32_t cp)
+{
+    return (const char *)(uintptr_t)((uint64_t)cp << 32);
+}
+
+/* Near-null ASCII immediate encoding (e.g. 0x2e for '.'). */
+static const char *imm_ascii(uint32_t cp)
+{
+    return (const char *)(uintptr_t)cp;
+}
+
+int main(void)
+{
+    const char *h_up = imm_upper('h'); /* 0x6800000000 — the #714 value */
+    const char *h_lo = imm_ascii('h'); /* 0x68 */
+    const char *digit = imm_upper('5');
+    const char *real = "h";
+
+    /* len */
+    check("len(immediate 'h' upper) == 1", sfn_str_len(h_up) == 1);
+    check("len(immediate 'h' ascii) == 1", sfn_str_len(h_lo) == 1);
+
+    /* eq: immediate vs real, immediate vs immediate, mismatch */
+    check("eq(immediate 'h' upper, real \"h\")", sfn_str_eq(h_up, real));
+    check("eq(immediate 'h' upper, immediate 'h' ascii)", sfn_str_eq(h_up, h_lo));
+    check("eq(immediate 'h', \"x\") is false", !sfn_str_eq(h_up, "x"));
+
+    /* slice: first char of an immediate */
+    char *sl = sfn_str_slice(h_up, 0.0, 1.0);
+    check("slice(immediate 'h', 0, 1) == \"h\"", sl != NULL && strcmp(sl, "h") == 0);
+
+    /* to_cstr / from_cstr: returned pointer must be deref-safe */
+    const char *c1 = sfn_str_to_cstr(h_up);
+    check("to_cstr(immediate 'h') is deref-safe \"h\"",
+          c1 != NULL && c1[0] == 'h' && c1[1] == '\0');
+    const char *c2 = sfn_str_from_cstr(h_lo);
+    check("from_cstr(immediate 'h') is deref-safe \"h\"",
+          c2 != NULL && c2[0] == 'h' && c2[1] == '\0');
+    check("to_cstr(real) is identity", sfn_str_to_cstr(real) == real);
+    check("from_cstr(real) is identity", sfn_str_from_cstr(real) == real);
+
+    /* grapheme_count / grapheme_at */
+    check("grapheme_count(immediate 'h') == 1", sfn_str_grapheme_count(h_up) == 1.0);
+    char *g = sfn_str_grapheme_at(h_up, 0.0);
+    check("grapheme_at(immediate 'h', 0) returns non-null", g != NULL);
+
+    /* byte_at: first byte of 'h' is 0x68 */
+    check("byte_at(immediate 'h', 0) == 0x68", sfn_str_byte_at(h_up, 0) == 0x68);
+    check("byte_at(immediate 'h', 1) == -1", sfn_str_byte_at(h_up, 1) == -1);
+
+    /* find_byte */
+    check("find_byte(immediate 'h', 0x68, 0) == 0", sfn_str_find_byte(h_up, 0x68, 0) == 0);
+    check("find_byte(immediate 'h', 'x', 0) == -1", sfn_str_find_byte(h_up, 'x', 0) == -1);
+
+    /* codepoint */
+    check("codepoint(immediate 'h') == 0x68", sfn_str_codepoint(h_up) == (double)0x68);
+
+    /* to_number: '5' immediate parses to 5.0; non-digit to 0.0 */
+    check("to_number(immediate '5') == 5.0", sfn_str_to_number(digit) == 5.0);
+    check("to_number(immediate 'h') == 0.0", sfn_str_to_number(h_up) == 0.0);
+
+    if (failures == 0)
+    {
+        printf("[c-test] ALL PASS\n");
+        return 0;
+    }
+    printf("[c-test] %d FAILURE(S)\n", failures);
+    return 1;
+}
+EOF
+
+BINARY_OUT="$SCRATCH/immediate_harness"
+
+# ---- Test: the C runtime + harness compile and link ----
+test_compile() {
+    if [ -z "$CC_BIN" ]; then
+        echo "[test]   no C compiler found (tried \$CC, cc, clang, gcc)"
+        return 1
+    fi
+    local log="$SCRATCH/compile.log"
+    if ! "$CC_BIN" -std=c11 -D_GNU_SOURCE -O0 -g \
+        -I "$RUNTIME_INC" \
+        "$HARNESS" \
+        "$RUNTIME_SRC/sailfin_runtime.c" \
+        "$RUNTIME_SRC/sailfin_arena.c" \
+        -lpthread -lm \
+        -o "$BINARY_OUT" > "$log" 2>&1; then
+        echo "[test]   compile/link failed:"
+        cat "$log"
+        return 1
+    fi
+    return 0
+}
+
+# ---- Test: every sfn_str_* helper survives immediate codepoints ----
+test_run_no_crash() {
+    if [ ! -x "$BINARY_OUT" ]; then
+        echo "[test]   harness binary missing — test_compile must run first"
+        return 1
+    fi
+    local log="$SCRATCH/run.log"
+    if ! "$BINARY_OUT" > "$log" 2>&1; then
+        echo "[test]   harness exited non-zero (crash or failed assertion):"
+        cat "$log"
+        return 1
+    fi
+    if ! grep -q "\[c-test\] ALL PASS" "$log"; then
+        echo "[test]   harness did not report ALL PASS:"
+        cat "$log"
+        return 1
+    fi
+    if grep -q "\[c-test\] FAIL" "$log"; then
+        echo "[test]   harness reported a FAIL line:"
+        cat "$log"
+        return 1
+    fi
+    return 0
+}
+
+run_test "C runtime + immediate-codepoint harness compile and link" test_compile
+run_test "every sfn_str_* helper survives immediate codepoints" test_run_no_crash
+
+echo "[summary] $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi

--- a/runtime/native/src/sailfin_runtime.c
+++ b/runtime/native/src/sailfin_runtime.c
@@ -2184,16 +2184,84 @@ int64_t sailfin_runtime_string_length(char *text);
 
 char *sailfin_runtime_substring_unchecked(char *text, int64_t start, int64_t end);
 
+/* #716: Immediate-codepoint pseudo-pointer guard for the `sfn_str_*`
+ * trampoline family.
+ *
+ * `char_at(text, i)` (and other single-grapheme readers) sometimes
+ * returns a codepoint *tagged into the pointer itself* rather than a
+ * heap/literal `i8*` — the legacy `(codepoint << 32)` encoding, plus a
+ * near-null ASCII form, both classified by
+ * `_is_immediate_codepoint_string` above. A trampoline that dereferences
+ * its operand directly (via `_safe_strlen_asan`, `memchr`, `s[i]`,
+ * `strtod`, …) will SIGSEGV on such a value: `_safe_strlen_asan` rejects
+ * the near-null form but the `(cp << 32)` form has zero high bits and
+ * sails through into an unmapped read (this is exactly the
+ * `0x6800000000` crash from #714). Any body that does NOT trampoline
+ * through a legacy `sailfin_runtime_*` entry that already decodes MUST
+ * route its operand through one of these helpers first.
+ *
+ * `_sfn_str_decode_immediate` writes the 1-4 UTF-8 bytes (+ NUL) into a
+ * caller-owned 5-byte scratch buffer and is for within-call consumption.
+ * Retires with the M1.A.2 type-mapping flip that eliminates the encoding
+ * entirely. */
+static const char *_sfn_str_decode_immediate(const char *s, unsigned char scratch[5])
+{
+    uint32_t cp = 0;
+    if (_is_immediate_codepoint_string(s, &cp))
+    {
+        _utf8_encode(cp, scratch); /* NUL-terminates the buffer */
+        return (const char *)scratch;
+    }
+    return s;
+}
+
+/* #716: Owning variant for the identity ABI bridges (`sfn_str_to_cstr` /
+ * `sfn_str_from_cstr`) whose result outlives the call, so a stack
+ * scratch buffer cannot back it. Materializes an immediate codepoint
+ * into a tracked `_rt_malloc` buffer; genuine pointers pass through
+ * untouched (preserving the identity-bridge contract for real strings).
+ * On allocation failure it returns the original operand — no worse than
+ * today's behaviour, and OOM is already fatal elsewhere. */
+static const char *_sfn_str_decode_immediate_owned(const char *s)
+{
+    uint32_t cp = 0;
+    if (!_is_immediate_codepoint_string(s, &cp))
+    {
+        return s;
+    }
+    unsigned char buf[5];
+    size_t n = _utf8_encode(cp, buf);
+    char *out = (char *)_rt_malloc(n + 1);
+    if (!out)
+    {
+        return s;
+    }
+    memcpy(out, buf, n);
+    out[n] = '\0';
+    _track_owned_string(out);
+    return (const char *)out;
+}
+
+/* #716 audit: safe by delegation — `sailfin_runtime_string_length`
+ * (line ~2803) opens with an `_is_immediate_codepoint_string` guard and
+ * returns the decoded grapheme count, so the immediate pseudo-pointer
+ * never reaches a raw dereference here. */
 int64_t sfn_str_len(const char *s)
 {
     return sailfin_runtime_string_length((char *)s);
 }
 
+/* #716 audit: safe by delegation — `_strings_equal_fast` (line ~576)
+ * decodes BOTH operands via `_is_immediate_codepoint_string` before any
+ * byte compare, so immediate ⇄ immediate and immediate ⇄ real pointer
+ * mixes are all handled. */
 bool sfn_str_eq(const char *a, const char *b)
 {
     return _strings_equal_fast(a, b);
 }
 
+/* #716 audit: safe by delegation — `sailfin_runtime_substring_unchecked`
+ * (line ~2987) guards immediate codepoints before slicing. */
 char *sfn_str_slice(const char *text, double start, double end)
 {
     /* Route through `_clamp_to_i64` (defined later in this file,
@@ -2208,17 +2276,25 @@ char *sfn_str_slice(const char *text, double start, double end)
  * the M2.4a wave: the legacy `i8*` ABI's data pointer is itself
  * NUL-terminated (the literal lowering in `core_strings.sfn`
  * always writes a trailing 0 past the byte payload), so the
- * boundary is the identity function. M2.4b replaces these with
- * arena-routed copies once SfnString stops carrying its
- * NUL-termination guarantee. */
+ * boundary is the identity function for real pointers. M2.4b
+ * replaces these with arena-routed copies once SfnString stops
+ * carrying its NUL-termination guarantee.
+ *
+ * #716: because these are identity (they delegate to no legacy
+ * decoder), an immediate-codepoint pseudo-pointer would pass
+ * straight through and crash the *caller* the moment it treats the
+ * result as a C string. `_sfn_str_decode_immediate_owned`
+ * materializes such inputs into a real, tracked NUL-terminated
+ * buffer so the returned pointer is always dereferenceable; genuine
+ * pointers are still returned unchanged. */
 const char *sfn_str_to_cstr(const char *s)
 {
-    return s;
+    return _sfn_str_decode_immediate_owned(s);
 }
 
 const char *sfn_str_from_cstr(const char *s)
 {
-    return s;
+    return _sfn_str_decode_immediate_owned(s);
 }
 
 /* M2.5 (#403): wave-2 trampolines for the canonical sfn_str_* / sfn_*_to_str
@@ -2248,11 +2324,17 @@ char *sailfin_runtime_number_to_string(double value);
  * the coercion machinery; the eventual Sailfin body retires the
  * double-return convention alongside the wider `int`/`float`
  * landing. */
+/* #716 audit: safe by delegation — `sailfin_runtime_grapheme_count`
+ * (line ~5872) guards immediate codepoints (counts them as a single
+ * grapheme) before any dereference. */
 double sfn_str_grapheme_count(const char *s)
 {
     return sailfin_runtime_grapheme_count((char *)s);
 }
 
+/* #716 audit: safe by delegation — `sailfin_runtime_grapheme_at`
+ * (line ~5877) returns the immediate pseudo-pointer itself at index 0
+ * and never dereferences it. */
 char *sfn_str_grapheme_at(const char *s, double idx)
 {
     return sailfin_runtime_grapheme_at((char *)s, idx);
@@ -2270,6 +2352,13 @@ int64_t sfn_str_byte_at(const char *s, int64_t idx)
     {
         return -1;
     }
+    /* #716: this body dereferences its operand directly
+     * (`_safe_strlen_asan` + `s[idx]`), so an immediate-codepoint
+     * pseudo-pointer must be materialized into real UTF-8 bytes first
+     * or the length probe / index read would fault on a tagged
+     * address. */
+    unsigned char imm_scratch[5];
+    s = _sfn_str_decode_immediate(s, imm_scratch);
     /* Upper-bound check via the same `_safe_strlen_asan` length probe
      * `sfn_str_find_byte` uses, so out-of-range indexes return -1
      * instead of dereferencing past the buffer (Copilot review on
@@ -2298,6 +2387,11 @@ int64_t sfn_str_find_byte(const char *s, int64_t byte_value, int64_t start_index
     {
         return -1;
     }
+    /* #716: `_safe_strlen_asan` + `memchr(s + start, ...)` dereference
+     * the operand, so decode immediate codepoints into real bytes
+     * before scanning. */
+    unsigned char imm_scratch[5];
+    s = _sfn_str_decode_immediate(s, imm_scratch);
     int64_t start = start_index < 0 ? 0 : start_index;
     bool truncated = false;
     int64_t len = (int64_t)_safe_strlen_asan((char *)s, &truncated);
@@ -2318,7 +2412,11 @@ int64_t sfn_str_find_byte(const char *s, int64_t byte_value, int64_t start_index
  * the immediate-codepoint pseudo-string fast path and reads the first byte
  * of a NUL-terminated UTF-8 buffer; the architect spec name is
  * `sfn_str_codepoint` (§2.2.2). Returns `double` to match the legacy
- * register class — same rationale as `sfn_str_grapheme_count` above. */
+ * register class — same rationale as `sfn_str_grapheme_count` above.
+ *
+ * #716 audit: safe by delegation — `sailfin_runtime_char_code`
+ * (line ~7085) carries the immediate-codepoint fast path and returns
+ * the tagged value's codepoint without dereferencing it. */
 double sfn_str_codepoint(const char *s)
 {
     return sailfin_runtime_char_code((char *)s);
@@ -2381,8 +2479,16 @@ char *sfn_str_from_codepoint(int64_t cp)
     return out;
 }
 
+/* #716: unlike the other delegators, `sailfin_runtime_string_to_number`
+ * (line ~3871) does NOT guard immediate codepoints — it hands the
+ * operand straight to `strtod`, which would dereference a tagged
+ * pseudo-pointer. Decode inline before delegating. A single decoded
+ * codepoint that isn't a digit parses to 0.0, exactly as `strtod` would
+ * yield for the equivalent real one-char string. */
 double sfn_str_to_number(const char *s)
 {
+    unsigned char imm_scratch[5];
+    s = _sfn_str_decode_immediate(s, imm_scratch);
     return sailfin_runtime_string_to_number((char *)s);
 }
 


### PR DESCRIPTION
## Summary
- Audit every `sfn_str_*` C helper that touches a `const char *` operand so the legacy immediate-codepoint encoding (`(codepoint << 32)` and the near-null ASCII form, classified by `_is_immediate_codepoint_string`) can never reach a raw dereference. `_safe_strlen_asan` defends the near-null form but **not** the `(cp << 32)` form (its high bits are zero), so any length-aware body hitting `strtod` / `memchr` / `s[i]` would SIGSEGV — the `0x6800000000` crash #714 hit on `sfn_str_concat`.
- Add two static decode helpers: `_sfn_str_decode_immediate` (scratch-backed, within-call) and `_sfn_str_decode_immediate_owned` (tracked-malloc, for the identity bridges whose result outlives the call).
- New e2e fixture feeds every helper both immediate encodings and asserts no crash.

Closes #716

## What changed per helper
**Inline-decode (option a) — genuinely unsafe before this PR:**
- `sfn_str_to_cstr` / `sfn_str_from_cstr` — identity bridges; an immediate pseudo-pointer passed straight through and crashed the *caller*. Now materialized into a real tracked NUL-terminated buffer; real pointers still pass through unchanged.
- `sfn_str_byte_at` / `sfn_str_find_byte` — dereference directly via `_safe_strlen_asan` + `s[idx]` / `memchr`.
- `sfn_str_to_number` — legacy `sailfin_runtime_string_to_number` hands the operand straight to `strtod` with no guard.

**Docblock (option b) — safe by delegation to a decoding legacy entrypoint:**
- `sfn_str_len`, `sfn_str_eq`, `sfn_str_slice`, `sfn_str_grapheme_count`, `sfn_str_grapheme_at`, `sfn_str_codepoint`.

## Acceptance Criteria
- [x] Every `sfn_str_*` C function touching a `const char *` operand either decodes immediate codepoints inline or carries a docblock pointing at the legacy decoding entrypoint.
- [x] New e2e fixture exercises each helper with an immediate-codepoint argument and asserts no crash (concat-adjacent ops: len, eq immediate⇄real, byte_at, find_byte, to_cstr, slice, …).
- [x] `make compile` passes.
- [x] `make test` passes.

## Verification
```bash
ulimit -v 8388608 && make compile          # exit 0, built build/native/sailfin
ulimit -v 8388608 && make test             # 691 passed, 0 failed
  #   unit: 115/115  integration: 29/29  e2e: 4/4
  #   capsules: 19/19  implicit-capsule-link: 2/2  e2e-sh: 88/88
ulimit -v 8388608 && build/native/sailfin run examples/basics/hello-world.sfn   # Hello, Sailfin!
bash compiler/tests/e2e/test_runtime_string_basic.sh build/native/sailfin       # 8/8
bash compiler/tests/e2e/test_runtime_string_allocating.sh build/native/sailfin  # 6/6
bash compiler/tests/e2e/test_runtime_string_immediate.sh build/native/sailfin   # 2/2 (new)
```

## Files Changed
- `runtime/native/src/sailfin_runtime.c` — two decode helpers, inline guards, audit docblocks.
- `compiler/tests/e2e/test_runtime_string_immediate.sh` — new C-harness coverage for the immediate-codepoint paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017n11VwpLaZZD7kPd1hgS9y)_