### PR TITLE
fix(effects): add missing ![io] to 34 effect-transitive lowering functions

### DIFF
--- a/compiler/src/llvm/expression_lowering/arrays.sfn
+++ b/compiler/src/llvm/expression_lowering/arrays.sfn
@@ -17,7 +17,7 @@ import {
     empty_runtime_call_overrides
 } from "./native/runtime_call";
 
-fn lower_struct_array_concat(lhs: LLVMOperand, rhs: LLVMOperand, element_type: string, lines: string[], temp_index: int) -> ExpressionResult {
+fn lower_struct_array_concat(lhs: LLVMOperand, rhs: LLVMOperand, element_type: string, lines: string[], temp_index: int) -> ExpressionResult ![io] {
     let mut current_lines = lines;
     let mut current_temp = temp_index;
     let mut diagnostics: string[] = [];

--- a/compiler/src/llvm/expression_lowering/native/core_index_lowering.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_index_lowering.sfn
@@ -26,7 +26,7 @@ import { lower_expression } from "./core";
 import { coerce_operand_to_type } from "./core_operands";
 import { emit_runtime_call, empty_runtime_call_overrides } from "./runtime_call";
 
-fn lower_index_expression(parse: IndexExpressionParse, bindings: ParameterBinding[], locals: LocalBinding[], temp_index: int, lines: string[], functions: NativeFunction[], context: TypeContext) -> ExpressionResult {
+fn lower_index_expression(parse: IndexExpressionParse, bindings: ParameterBinding[], locals: LocalBinding[], temp_index: int, lines: string[], functions: NativeFunction[], context: TypeContext) -> ExpressionResult ![io] {
     let base_result = lower_expression(parse.base, bindings, locals, temp_index, lines, functions, context, "");
     let mut diagnostics: string[] = base_result.diagnostics;
     let mut collected_string_constants: StringConstant[] = base_result.string_constants;

--- a/compiler/src/llvm/expression_lowering/native/core_literals_lowering.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_literals_lowering.sfn
@@ -77,7 +77,7 @@ fn _format_literal_span(span: NativeSourceSpan) -> string {
     return start + "-" + end;
 }
 
-fn lower_array_literal(text: string, bindings: ParameterBinding[], locals: LocalBinding[], temp_index: int, lines: string[], functions: NativeFunction[], context: TypeContext, expected_type: string) -> ExpressionResult {
+fn lower_array_literal(text: string, bindings: ParameterBinding[], locals: LocalBinding[], temp_index: int, lines: string[], functions: NativeFunction[], context: TypeContext, expected_type: string) -> ExpressionResult ![io] {
     let mut diagnostics: string[] = [];
     let mut current_lines: string[] = lines;
     let mut current_temp: int = temp_index;
@@ -727,7 +727,7 @@ fn lower_array_literal(text: string, bindings: ParameterBinding[], locals: Local
 // `line:col` instead of firing bare. Pre-#540 callers (every `lower_expression`
 // fan-out) thread `null` until they pick up an enclosing span — see the
 // issue's `Out:` section for the deferred plumbing.
-fn lower_struct_literal(parse: StructLiteralParse, bindings: ParameterBinding[], locals: LocalBinding[], temp_index: int, lines: string[], functions: NativeFunction[], context: TypeContext, expected_type: string, span: NativeSourceSpan?) -> ExpressionResult {
+fn lower_struct_literal(parse: StructLiteralParse, bindings: ParameterBinding[], locals: LocalBinding[], temp_index: int, lines: string[], functions: NativeFunction[], context: TypeContext, expected_type: string, span: NativeSourceSpan?) -> ExpressionResult ![io] {
     let mut diagnostics: string[] = parse.diagnostics;
     let mut current_lines: string[] = lines;
     let mut current_temp: int = temp_index;
@@ -963,7 +963,7 @@ fn lower_struct_literal(parse: StructLiteralParse, bindings: ParameterBinding[],
     };
 }
 
-fn box_aggregate_operand(operand: LLVMOperand, expected_pointer_type: string, temp_index: int, lines: string[], context: TypeContext) -> HeapBoxResult {
+fn box_aggregate_operand(operand: LLVMOperand, expected_pointer_type: string, temp_index: int, lines: string[], context: TypeContext) -> HeapBoxResult ![io] {
     let mut diagnostics: string[] = [];
     let mut current_lines: string[] = lines;
     let mut current_temp: int = temp_index;
@@ -1060,7 +1060,7 @@ fn box_aggregate_operand(operand: LLVMOperand, expected_pointer_type: string, te
 
 // Slice E.2 follow-up (#540): `span` mirrors the threading in
 // `lower_struct_literal`. Pre-#540 callers pass `null`.
-fn lower_enum_literal(parse: EnumLiteralParse, bindings: ParameterBinding[], locals: LocalBinding[], temp_index: int, lines: string[], functions: NativeFunction[], context: TypeContext, expected_type: string, span: NativeSourceSpan?) -> ExpressionResult {
+fn lower_enum_literal(parse: EnumLiteralParse, bindings: ParameterBinding[], locals: LocalBinding[], temp_index: int, lines: string[], functions: NativeFunction[], context: TypeContext, expected_type: string, span: NativeSourceSpan?) -> ExpressionResult ![io] {
     let mut diagnostics: string[] = parse.diagnostics;
     let mut current_lines: string[] = lines;
     let mut current_temp: int = temp_index;
@@ -1418,7 +1418,7 @@ fn lower_enum_literal(parse: EnumLiteralParse, bindings: ParameterBinding[], loc
     };
 }
 
-fn lower_cast_expression(parse: CastParseResult, bindings: ParameterBinding[], locals: LocalBinding[], temp_index: int, lines: string[], functions: NativeFunction[], context: TypeContext) -> ExpressionResult {
+fn lower_cast_expression(parse: CastParseResult, bindings: ParameterBinding[], locals: LocalBinding[], temp_index: int, lines: string[], functions: NativeFunction[], context: TypeContext) -> ExpressionResult ![io] {
     let mut diagnostics = parse.diagnostics;
     let empty_constants = empty_string_constant_set();
     if !parse.success {
@@ -1677,7 +1677,7 @@ fn lower_cast_expression(parse: CastParseResult, bindings: ParameterBinding[], l
     };
 }
 
-fn try_lower_interpolated_string_literal(literal: string, bindings: ParameterBinding[], locals: LocalBinding[], temp_index: int, lines: string[], functions: NativeFunction[], context: TypeContext) -> ExpressionResult? {
+fn try_lower_interpolated_string_literal(literal: string, bindings: ParameterBinding[], locals: LocalBinding[], temp_index: int, lines: string[], functions: NativeFunction[], context: TypeContext) -> ExpressionResult? ![io] {
     let content = unescape_string_literal(literal);
     if find_substring_from(content, "{{", 0) < 0 { return null; }
     if find_substring_from(content, "}}", 0) < 0 { return null; }

--- a/compiler/src/llvm/expression_lowering/native/core_member_lowering.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_member_lowering.sfn
@@ -82,7 +82,7 @@ fn emit_string_constant_pointer(constant: StringConstant, temp_index: int, lines
     };
 }
 
-fn lower_dynamic_member_access(field: string, base_operand: LLVMOperand, temp_index: int, lines: string[], diagnostics: string[], string_constants: StringConstant[]) -> ExpressionResult {
+fn lower_dynamic_member_access(field: string, base_operand: LLVMOperand, temp_index: int, lines: string[], diagnostics: string[], string_constants: StringConstant[]) -> ExpressionResult ![io] {
     let mut current_lines: string[] = lines;
     let mut current_temp: int = temp_index;
     let mut dynamic_string_constants: StringConstant[] = string_constants;
@@ -641,7 +641,7 @@ fn lower_enum_member_access(parse: MemberAccessParse, enum_info: EnumTypeInfo, b
     return make_expression_result(current_lines, current_temp, operand, messages, enum_string_constants);
 }
 
-fn lower_member_access(parse: MemberAccessParse, bindings: ParameterBinding[], locals: LocalBinding[], temp_index: int, lines: string[], functions: NativeFunction[], context: TypeContext, expected_type: string) -> ExpressionResult {
+fn lower_member_access(parse: MemberAccessParse, bindings: ParameterBinding[], locals: LocalBinding[], temp_index: int, lines: string[], functions: NativeFunction[], context: TypeContext, expected_type: string) -> ExpressionResult ![io] {
     let base_result = lower_expression(parse.base, bindings, locals, temp_index, lines, functions, context, "");
     let mut diagnostics: string[] = base_result.diagnostics;
     let mut collected_string_constants: StringConstant[] = base_result.string_constants;

--- a/compiler/src/llvm/expression_lowering/native/core_operands.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_operands.sfn
@@ -339,7 +339,7 @@ fn collapse_type_spaces(value: string) -> string {
 
 // Numeric primitive coercion: handles conversions between double/i64/i32/i8/i1.
 // Returns null if neither type is a numeric primitive — caller should try other coercion paths.
-fn coerce_numeric_primitive(operand: LLVMOperand, operand_type: string, target: string, temp_index: int, lines: string[]) -> CoercionResult? {
+fn coerce_numeric_primitive(operand: LLVMOperand, operand_type: string, target: string, temp_index: int, lines: string[]) -> CoercionResult? ![io] {
     let mut current_lines: string[] = lines;
     let mut diagnostics: string[] = [];
 
@@ -802,7 +802,7 @@ fn coerce_numeric_primitive(operand: LLVMOperand, operand_type: string, target: 
 
 // Pointer/struct coercion: handles bitcasts, boxing, unboxing, pointer derefs.
 // Returns null if no pointer coercion applies.
-fn coerce_pointer_or_struct(operand: LLVMOperand, operand_type: string, target: string, temp_index: int, lines: string[]) -> CoercionResult? {
+fn coerce_pointer_or_struct(operand: LLVMOperand, operand_type: string, target: string, temp_index: int, lines: string[]) -> CoercionResult? ![io] {
     let mut current_lines: string[] = lines;
     let mut diagnostics: string[] = [];
 
@@ -1289,7 +1289,7 @@ fn coerce_pointer_or_struct(operand: LLVMOperand, operand_type: string, target: 
 }
 
 // General coercion fallbacks: boxing, union construction, pointer variance, null handling.
-fn coerce_general_fallback(operand: LLVMOperand, operand_type: string, target: string, temp_index: int, lines: string[]) -> CoercionResult? {
+fn coerce_general_fallback(operand: LLVMOperand, operand_type: string, target: string, temp_index: int, lines: string[]) -> CoercionResult? ![io] {
     let mut current_lines: string[] = lines;
     let mut diagnostics: string[] = [];
 

--- a/compiler/src/llvm/expression_lowering/native/core_ops_lowering.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_ops_lowering.sfn
@@ -41,7 +41,7 @@ import {
 import { lines_end_with_terminator, strip_enclosing_parentheses } from "./core_operators";
 import { emit_runtime_call, empty_runtime_call_overrides } from "./runtime_call";
 
-fn lower_logical_not_with_operand(operand: LLVMOperand, temp_index: int, lines: string[], diagnostics: string[], string_constants: StringConstant[]) -> ExpressionResult {
+fn lower_logical_not_with_operand(operand: LLVMOperand, temp_index: int, lines: string[], diagnostics: string[], string_constants: StringConstant[]) -> ExpressionResult ![io] {
     let coerced = coerce_operand_to_type(operand, "i1", temp_index, lines, true, null);
     let mut current_diagnostics: string[] = diagnostics;
     let mut _ci0: int = 0;
@@ -99,7 +99,7 @@ fn lower_logical_not_result(result: ExpressionResult, base_diagnostics: string[]
     return lower_logical_not_with_operand(result.operand, result.temp_index, result.lines, combined, result.string_constants);
 }
 
-fn lower_ternary_expression(parse: TernaryParseResult, bindings: ParameterBinding[], locals: LocalBinding[], temp_index: int, lines: string[], functions: NativeFunction[], context: TypeContext, expected_type: string) -> ExpressionResult {
+fn lower_ternary_expression(parse: TernaryParseResult, bindings: ParameterBinding[], locals: LocalBinding[], temp_index: int, lines: string[], functions: NativeFunction[], context: TypeContext, expected_type: string) -> ExpressionResult ![io] {
     let mut diagnostics: string[] = parse.diagnostics;
     let mut string_constants: StringConstant[] = empty_string_constant_set();
 
@@ -229,7 +229,7 @@ fn lower_ternary_expression(parse: TernaryParseResult, bindings: ParameterBindin
     };
 }
 
-fn lower_binary_operation(expression: string, match: OperatorMatch, bindings: ParameterBinding[], locals: LocalBinding[], temp_index: int, lines: string[], functions: NativeFunction[], context: TypeContext) -> ExpressionResult {
+fn lower_binary_operation(expression: string, match: OperatorMatch, bindings: ParameterBinding[], locals: LocalBinding[], temp_index: int, lines: string[], functions: NativeFunction[], context: TypeContext) -> ExpressionResult ![io] {
     let left_text = trim_text(substring(expression, 0, match.index));
     // Slice B (2026-05-02): use `match.symbol.length` instead of
     // a hardcoded `+ 1` so two-char operators (`<<`, `>>`) slice
@@ -708,7 +708,7 @@ fn lower_binary_operation(expression: string, match: OperatorMatch, bindings: Pa
     };
 }
 
-fn lower_comparison_operation(expression: string, match: OperatorMatch, bindings: ParameterBinding[], locals: LocalBinding[], temp_index: int, lines: string[], functions: NativeFunction[], context: TypeContext) -> ExpressionResult {
+fn lower_comparison_operation(expression: string, match: OperatorMatch, bindings: ParameterBinding[], locals: LocalBinding[], temp_index: int, lines: string[], functions: NativeFunction[], context: TypeContext) -> ExpressionResult ![io] {
     let mut diagnostics: string[] = [];
     let mut _if100: boolean = false;
     if expression == null { _if100 = true; }
@@ -1054,7 +1054,7 @@ fn lower_comparison_operation(expression: string, match: OperatorMatch, bindings
     };
 }
 
-fn lower_logical_and(expression: string, match: OperatorMatch, bindings: ParameterBinding[], locals: LocalBinding[], temp_index: int, lines: string[], functions: NativeFunction[], context: TypeContext) -> ExpressionResult {
+fn lower_logical_and(expression: string, match: OperatorMatch, bindings: ParameterBinding[], locals: LocalBinding[], temp_index: int, lines: string[], functions: NativeFunction[], context: TypeContext) -> ExpressionResult ![io] {
     let left_text = trim_text(substring(expression, 0, match.index));
     let right_text = trim_text(substring(expression, match.index + 2, expression.length));
     let mut diagnostics: string[] = [];
@@ -1185,7 +1185,7 @@ fn lower_logical_and(expression: string, match: OperatorMatch, bindings: Paramet
     };
 }
 
-fn lower_logical_or(expression: string, match: OperatorMatch, bindings: ParameterBinding[], locals: LocalBinding[], temp_index: int, lines: string[], functions: NativeFunction[], context: TypeContext) -> ExpressionResult {
+fn lower_logical_or(expression: string, match: OperatorMatch, bindings: ParameterBinding[], locals: LocalBinding[], temp_index: int, lines: string[], functions: NativeFunction[], context: TypeContext) -> ExpressionResult ![io] {
     let left_text = trim_text(substring(expression, 0, match.index));
     let right_text = trim_text(substring(expression, match.index + 2, expression.length));
     let mut diagnostics: string[] = [];

--- a/compiler/src/llvm/expression_lowering/native/core_strings.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_strings.sfn
@@ -9,7 +9,7 @@ import { coerce_operand_to_type, harmonise_operands } from "./core_operands";
 import { unescape_string_literal } from "./core_text";
 import { emit_runtime_call, empty_runtime_call_overrides } from "./runtime_call";
 
-fn lower_string_literal(literal: string, temp_index: int, lines: string[]) -> ExpressionResult {
+fn lower_string_literal(literal: string, temp_index: int, lines: string[]) -> ExpressionResult ![io] {
     // M1.A — String literal lowering to {i8*, i64} aggregate.
     //
     // The literal materializes in three layers:
@@ -98,7 +98,7 @@ fn lower_string_literal(literal: string, temp_index: int, lines: string[]) -> Ex
     };
 }
 
-fn emit_string_concat(left: LLVMOperand, right: LLVMOperand, temp_index: int, lines: string[]) -> ExpressionResult {
+fn emit_string_concat(left: LLVMOperand, right: LLVMOperand, temp_index: int, lines: string[]) -> ExpressionResult ![io] {
     let harmonised = harmonise_operands(left, right, temp_index, lines);
     let mut _if121: boolean = false;
     if harmonised.left == null { _if121 = true; }
@@ -189,7 +189,7 @@ fn emit_string_concat(left: LLVMOperand, right: LLVMOperand, temp_index: int, li
     };
 }
 
-fn coerce_operand_to_string(operand: LLVMOperand, temp_index: int, lines: string[]) -> ExpressionResult {
+fn coerce_operand_to_string(operand: LLVMOperand, temp_index: int, lines: string[]) -> ExpressionResult ![io] {
     let empty_constants = empty_string_constant_set();
     if operand.llvm_type == "i8*" {
         return ExpressionResult {

--- a/compiler/src/llvm/lowering/entrypoints.sfn
+++ b/compiler/src/llvm/lowering/entrypoints.sfn
@@ -346,7 +346,7 @@ fn lower_to_llvm_with_manifests(native_module: NativeModule, imported_manifests:
     return lower_to_llvm_with_context(native_module, imported_manifests, [], []);
 }
 
-fn lower_to_llvm_with_parsed_context(native_module: NativeModule, parse: ParseNativeResult, imported_manifests: LayoutManifest[], imported_native_texts: string[], imported_diagnostics: string[]) -> LoweredLLVMResult {
+fn lower_to_llvm_with_parsed_context(native_module: NativeModule, parse: ParseNativeResult, imported_manifests: LayoutManifest[], imported_native_texts: string[], imported_diagnostics: string[]) -> LoweredLLVMResult ![io] {
     let _art = select_text_artifact(native_module.artifacts);
     let mut _native_text: string = "";
     if _art != null { _native_text = _art.contents; }

--- a/compiler/src/llvm/lowering/instructions_condition.sfn
+++ b/compiler/src/llvm/lowering/instructions_condition.sfn
@@ -27,7 +27,7 @@ fn allocate_block_label(prefix: string, counter: int) -> BlockLabelResult {
     };
 }
 
-fn lower_condition_to_i1(function_name: string, expression: string, bindings: ParameterBinding[], locals: LocalBinding[], temp_index: int, lines: string[], functions: NativeFunction[], context: TypeContext) -> ConditionConversion {
+fn lower_condition_to_i1(function_name: string, expression: string, bindings: ParameterBinding[], locals: LocalBinding[], temp_index: int, lines: string[], functions: NativeFunction[], context: TypeContext) -> ConditionConversion ![io] {
     let mut diagnostics: string[] = detect_suspension_conflicts(expression, locals, bindings, function_name, null);
     let lowered = lower_expression(expression, bindings, locals, temp_index, lines, functions, context, "");
     let mut _ci11: int = 0;

--- a/compiler/src/llvm/lowering/instructions_for.sfn
+++ b/compiler/src/llvm/lowering/instructions_for.sfn
@@ -51,7 +51,7 @@ import { collect_mutation_names, find_mutation_for_name } from "./phi";
 
 // Lower a range-based for loop (e.g., `for i in 0..10`).
 // Returns null if the iterable is not a recognized range pattern.
-fn lower_for_array(function: NativeFunction, structure: LoopStructure, raw_target: string, instruction: NativeInstruction, iterable_operand: LLVMOperand, llvm_return: string, bindings: ParameterBinding[], locals: LocalBinding[], allocas: string[], lines: string[], temp_index: int, block_counter: int, next_local_id: int, next_region_id: int, functions: NativeFunction[], loop_stack: LoopContext[], context: TypeContext, scope_id: string, scope_depth: int, next_index: int) -> BlockLoweringResult {
+fn lower_for_array(function: NativeFunction, structure: LoopStructure, raw_target: string, instruction: NativeInstruction, iterable_operand: LLVMOperand, llvm_return: string, bindings: ParameterBinding[], locals: LocalBinding[], allocas: string[], lines: string[], temp_index: int, block_counter: int, next_local_id: int, next_region_id: int, functions: NativeFunction[], loop_stack: LoopContext[], context: TypeContext, scope_id: string, scope_depth: int, next_index: int) -> BlockLoweringResult ![io] {
     let mut diagnostics: string[] = [];
     let mut current_lines: string[] = lines;
     let mut current_allocas: string[] = allocas;
@@ -289,7 +289,7 @@ fn lower_for_array(function: NativeFunction, structure: LoopStructure, raw_targe
 }
 
 // Shared helper: build exit mutations for loop locals after the loop exit label.
-fn lower_for_instruction(function: NativeFunction, start_index: int, llvm_return: string, bindings: ParameterBinding[], locals: LocalBinding[], allocas: string[], lines: string[], temp_index: int, block_counter: int, next_local_id: int, next_region_id: int, functions: NativeFunction[], loop_stack: LoopContext[], end: int, context: TypeContext, scope_id: string, scope_depth: int, current_label: string) -> BlockLoweringResult {
+fn lower_for_instruction(function: NativeFunction, start_index: int, llvm_return: string, bindings: ParameterBinding[], locals: LocalBinding[], allocas: string[], lines: string[], temp_index: int, block_counter: int, next_local_id: int, next_region_id: int, functions: NativeFunction[], loop_stack: LoopContext[], end: int, context: TypeContext, scope_id: string, scope_depth: int, current_label: string) -> BlockLoweringResult ![io] {
     let mut diagnostics: string[] = [];
     let mut current_lines: string[] = lines;
     let mut current_allocas: string[] = allocas;

--- a/compiler/src/llvm/lowering/instructions_for_range.sfn
+++ b/compiler/src/llvm/lowering/instructions_for_range.sfn
@@ -41,7 +41,7 @@ import { collect_mutation_names, find_mutation_for_name } from "./phi";
 
 // Lower a range-based for loop (e.g., `for i in 0..10`).
 // Returns null if the iterable is not a recognized range pattern.
-fn lower_for_range(function: NativeFunction, structure: LoopStructure, raw_target: string, iterable_text: string, llvm_return: string, bindings: ParameterBinding[], locals: LocalBinding[], allocas: string[], lines: string[], temp_index: int, block_counter: int, next_local_id: int, next_region_id: int, functions: NativeFunction[], loop_stack: LoopContext[], context: TypeContext, scope_id: string, scope_depth: int, next_index: int) -> BlockLoweringResult? {
+fn lower_for_range(function: NativeFunction, structure: LoopStructure, raw_target: string, iterable_text: string, llvm_return: string, bindings: ParameterBinding[], locals: LocalBinding[], allocas: string[], lines: string[], temp_index: int, block_counter: int, next_local_id: int, next_region_id: int, functions: NativeFunction[], loop_stack: LoopContext[], context: TypeContext, scope_id: string, scope_depth: int, next_index: int) -> BlockLoweringResult? ![io] {
     let mut diagnostics: string[] = [];
     let mut current_lines: string[] = lines;
     let mut current_allocas: string[] = allocas;

--- a/compiler/src/llvm/lowering/instructions_if.sfn
+++ b/compiler/src/llvm/lowering/instructions_if.sfn
@@ -138,7 +138,7 @@ fn collect_if_structure(instructions: NativeInstruction[], start_index: int, end
     };
 }
 
-fn lower_if_instruction(function: NativeFunction, start_index: int, llvm_return: string, bindings: ParameterBinding[], locals: LocalBinding[], allocas: string[], lines: string[], temp_index: int, block_counter: int, next_local_id: int, next_region_id: int, functions: NativeFunction[], loop_stack: LoopContext[], end: int, context: TypeContext, scope_id: string, scope_depth: int, current_label: string) -> BlockLoweringResult {
+fn lower_if_instruction(function: NativeFunction, start_index: int, llvm_return: string, bindings: ParameterBinding[], locals: LocalBinding[], allocas: string[], lines: string[], temp_index: int, block_counter: int, next_local_id: int, next_region_id: int, functions: NativeFunction[], loop_stack: LoopContext[], end: int, context: TypeContext, scope_id: string, scope_depth: int, current_label: string) -> BlockLoweringResult ![io] {
     let mut current_lines: string[] = lines;
     let base_lines_snapshot = copy_string_array(lines);
     let mut current_allocas: string[] = allocas;

--- a/compiler/src/llvm/lowering/instructions_match.sfn
+++ b/compiler/src/llvm/lowering/instructions_match.sfn
@@ -217,7 +217,7 @@ fn is_default_pattern(pattern: string) -> boolean {
     return false;
 }
 
-fn lower_match_instruction(function: NativeFunction, start_index: int, llvm_return: string, bindings: ParameterBinding[], locals: LocalBinding[], allocas: string[], lines: string[], temp_index: int, block_counter: int, next_local_id: int, next_region_id: int, functions: NativeFunction[], loop_stack: LoopContext[], end: int, context: TypeContext, scope_id: string, scope_depth: int, current_label: string) -> BlockLoweringResult {
+fn lower_match_instruction(function: NativeFunction, start_index: int, llvm_return: string, bindings: ParameterBinding[], locals: LocalBinding[], allocas: string[], lines: string[], temp_index: int, block_counter: int, next_local_id: int, next_region_id: int, functions: NativeFunction[], loop_stack: LoopContext[], end: int, context: TypeContext, scope_id: string, scope_depth: int, current_label: string) -> BlockLoweringResult ![io] {
     let mut diagnostics: string[] = [];
     let mut current_lines: string[] = lines;
     let base_lines_snapshot = copy_string_array(lines);

--- a/compiler/src/llvm/lowering/instructions_match_condition.sfn
+++ b/compiler/src/llvm/lowering/instructions_match_condition.sfn
@@ -39,7 +39,7 @@ import {
 import { number_to_string, trim_text } from "../utils";
 import { lower_condition_to_i1 } from "./instructions_condition";
 
-fn lower_match_case_condition(function_name: string, subject_operand: LLVMOperand, subject_type_annotation: string, case: MatchCaseStructure, bindings: ParameterBinding[], locals: LocalBinding[], temp_index: int, lines: string[], functions: NativeFunction[], context: TypeContext) -> MatchCaseCondition {
+fn lower_match_case_condition(function_name: string, subject_operand: LLVMOperand, subject_type_annotation: string, case: MatchCaseStructure, bindings: ParameterBinding[], locals: LocalBinding[], temp_index: int, lines: string[], functions: NativeFunction[], context: TypeContext) -> MatchCaseCondition ![io] {
     let mut diagnostics: string[] = [];
     let mut current_lines: string[] = lines;
     let mut current_temp: int = temp_index;

--- a/compiler/src/llvm/lowering/instructions_try.sfn
+++ b/compiler/src/llvm/lowering/instructions_try.sfn
@@ -211,7 +211,7 @@ fn lower_throw_instruction(function_name: string, instruction: NativeInstruction
     };
 }
 
-fn lower_try_instruction(function: NativeFunction, start_index: int, llvm_return: string, bindings: ParameterBinding[], locals: LocalBinding[], allocas: string[], lines: string[], temp_index: int, block_counter: int, next_local_id: int, next_region_id: int, functions: NativeFunction[], loop_stack: LoopContext[], end: int, context: TypeContext, scope_id: string, scope_depth: int, current_label: string) -> BlockLoweringResult {
+fn lower_try_instruction(function: NativeFunction, start_index: int, llvm_return: string, bindings: ParameterBinding[], locals: LocalBinding[], allocas: string[], lines: string[], temp_index: int, block_counter: int, next_local_id: int, next_region_id: int, functions: NativeFunction[], loop_stack: LoopContext[], end: int, context: TypeContext, scope_id: string, scope_depth: int, current_label: string) -> BlockLoweringResult ![io] {
     let mut diagnostics: string[] = [];
     let structure = collect_try_structure(function.instructions, start_index, end, function.name);
     let mut _ci2: int = 0;

--- a/compiler/src/llvm/lowering/lowering_helpers.sfn
+++ b/compiler/src/llvm/lowering/lowering_helpers.sfn
@@ -247,7 +247,7 @@ fn collect_available_import_module_names(imported_native_texts: string[]) -> str
     return names;
 }
 
-fn resolve_import_provider_module_name(import_path: string, current_module_slug: string, available_module_names: string[]) -> string {
+fn resolve_import_provider_module_name(import_path: string, current_module_slug: string, available_module_names: string[]) -> string ![io] {
     let base = resolve_import_module_slug_for_module(import_path, current_module_slug);
     if base.length == 0 { return base; }
     let resolved = resolve_import_artifact_slug(base);

--- a/compiler/src/parser/mod.sfn
+++ b/compiler/src/parser/mod.sfn
@@ -47,7 +47,7 @@ import { Parser, StatementParseResult } from "./types";
 // like `compiler/tests/unit/struct_large_return_test`). A short heap-allocated
 // pad string at function entry shifts subsequent allocations past the corrupted
 // bucket. Remove this once the 0.5.8 seed is released and adopted.
-fn parse_program(source: string) -> Program {
+fn parse_program(source: string) -> Program ![io] {
     // Force a runtime heap allocation pattern that 0.5.7 can't fold away.
     // `substring(source, 0, 1)` is a runtime intrinsic over `source` (a
     // function parameter, not a compile-time value), so the seed cannot

--- a/compiler/src/tools/fmt.sfn
+++ b/compiler/src/tools/fmt.sfn
@@ -1553,7 +1553,7 @@ fn sort_imports(fmt_tokens: FmtToken[]) -> FmtToken[] {
 // ═══════════════════════════════════════════════════════════════════
 // Public entry point
 // ═══════════════════════════════════════════════════════════════════
-fn format_source(source: string) -> string {
+fn format_source(source: string) -> string ![io] {
     if source.length == 0 { return ""; }
     let tokens = lex(source);
     let fmt_tokens = strip_and_classify(tokens);

--- a/compiler/tests/integration/test_runner_json_test.sfn
+++ b/compiler/tests/integration/test_runner_json_test.sfn
@@ -131,7 +131,7 @@ test "test_runner_json: assertion message escapes backslashes" {
 // --------------------------------------------------------------
 // Pre-run pass: collect_test_entries
 // --------------------------------------------------------------
-test "test_runner_json: collect_test_entries finds every test in source order" {
+test "test_runner_json: collect_test_entries finds every test in source order" ![io] {
     let source = "test \"first\" { assert true; }\n"
         + "test \"second\" ![io] { assert true; }\n"
         + "fn helper() { return; }\n"
@@ -151,7 +151,7 @@ test "test_runner_json: collect_test_entries finds every test in source order" {
     assert entries[2].line == 4;
 }
 
-test "test_runner_json: collect_test_entries returns empty when no tests" {
+test "test_runner_json: collect_test_entries returns empty when no tests" ![io] {
     let source = "fn nothing_to_see() -> int { return 0; }\n";
     let program: Program = parse_program(source);
     let entries = collect_test_entries(program, "no_tests.sfn");
@@ -161,7 +161,7 @@ test "test_runner_json: collect_test_entries returns empty when no tests" {
 // --------------------------------------------------------------
 // locate_failing_test attribution rule
 // --------------------------------------------------------------
-test "test_runner_json: locate_failing_test picks closest preceding test" {
+test "test_runner_json: locate_failing_test picks closest preceding test" ![io] {
     let source = "test \"a\" { assert true; }\n"
         + "test \"b\" { assert true; }\n"
         + "test \"c\" { assert true; }\n";
@@ -178,7 +178,7 @@ test "test_runner_json: locate_failing_test returns -1 when failure absent" {
     assert locate_failing_test(entries, nothing) == -1;
 }
 
-test "test_runner_json: locate_failing_test returns -1 when no test precedes line 0" {
+test "test_runner_json: locate_failing_test returns -1 when no test precedes line 0" ![io] {
     let source = "test \"only\" { assert true; }\n";
     let program: Program = parse_program(source);
     let entries = collect_test_entries(program, "f.sfn");

--- a/compiler/tests/unit/emit_native_extern_test.sfn
+++ b/compiler/tests/unit/emit_native_extern_test.sfn
@@ -16,7 +16,7 @@ fn _contains(haystack: string, needle: string) -> boolean {
     return index_of(haystack, needle) >= 0;
 }
 
-test "emit_native: extern fn produces .meta extern with signature" {
+test "emit_native: extern fn produces .meta extern with signature" ![io] {
     let source = "extern fn write(fd: i32, buf: *u8, count: i64) -> i64;";
     let program = parse_program(source);
     let asm = emit_native_text_with_module_name(program, "test_libc");
@@ -24,7 +24,7 @@ test "emit_native: extern fn produces .meta extern with signature" {
     assert _contains(asm, ".meta extern");
 }
 
-test "emit_native: unsafe extern fn carries .meta unsafe" {
+test "emit_native: unsafe extern fn carries .meta unsafe" ![io] {
     let source = "unsafe extern fn malloc(size: usize) -> *u8;";
     let program = parse_program(source);
     let asm = emit_native_text_with_module_name(program, "test_libc");
@@ -33,7 +33,7 @@ test "emit_native: unsafe extern fn carries .meta unsafe" {
     assert _contains(asm, ".meta extern");
 }
 
-test "emit_native: libc skeleton round-trips multiple externs" {
+test "emit_native: libc skeleton round-trips multiple externs" ![io] {
     let source = "extern fn write(fd: i32, buf: *u8, count: i64) -> i64;\n"
         + "extern fn read(fd: i32, buf: *u8, count: i64) -> i64;\n"
         + "extern fn malloc(size: i64) -> *u8;\n"

--- a/compiler/tests/unit/fmt_generic_annotations_test.sfn
+++ b/compiler/tests/unit/fmt_generic_annotations_test.sfn
@@ -22,7 +22,7 @@ fn _contains(haystack: string, needle: string) -> boolean {
 }
 
 // ── The headline correctness bug: `> =` must not collapse to `>=` ────
-test "fmt generic: let-binding type does not fuse close with assign" {
+test "fmt generic: let-binding type does not fuse close with assign" ![io] {
     let src = "fn make() -> int {\n    let x: Box<int> = Box { value: 5 };\n    return x.value;\n}\n";
     let out = format_source(src);
     // The generic close + assignment stays a generic close + assign.
@@ -33,7 +33,7 @@ test "fmt generic: let-binding type does not fuse close with assign" {
 }
 
 // ── Idempotency: a second pass changes nothing ───────────────────────
-test "fmt generic: let-binding type is idempotent" {
+test "fmt generic: let-binding type is idempotent" ![io] {
     let src = "fn make() -> int {\n    let x: Box<int> = Box { value: 5 };\n    return x.value;\n}\n";
     let once = format_source(src);
     let twice = format_source(once);
@@ -41,7 +41,7 @@ test "fmt generic: let-binding type is idempotent" {
 }
 
 // ── Two-argument generic in let position (the #832 Result case) ──────
-test "fmt generic: Result<int, string> let-binding round-trips" {
+test "fmt generic: Result<int, string> let-binding round-trips" ![io] {
     let src = "fn g() -> int {\n    let r: Result<int, string> = parse();\n    return 0;\n}\n";
     let out = format_source(src);
     assert _contains(out, "let r: Result<int, string> = parse");
@@ -49,7 +49,7 @@ test "fmt generic: Result<int, string> let-binding round-trips" {
 }
 
 // ── Struct type-parameter clause ─────────────────────────────────────
-test "fmt generic: struct type-parameter clause stays tight" {
+test "fmt generic: struct type-parameter clause stays tight" ![io] {
     let src = "struct Box<T> {\n    value: T\n}\n";
     let out = format_source(src);
     assert _contains(out, "struct Box<T>");
@@ -57,7 +57,7 @@ test "fmt generic: struct type-parameter clause stays tight" {
 }
 
 // ── Enum type-parameter clause with multiple parameters ──────────────
-test "fmt generic: enum multi-parameter clause keeps comma spacing" {
+test "fmt generic: enum multi-parameter clause keeps comma spacing" ![io] {
     let src = "enum Foo<T, E> {\n    A(T)\n}\n";
     let out = format_source(src);
     assert _contains(out, "enum Foo<T, E>");
@@ -65,7 +65,7 @@ test "fmt generic: enum multi-parameter clause keeps comma spacing" {
 }
 
 // ── Parameter type and return type positions ─────────────────────────
-test "fmt generic: parameter and return generic types stay tight" {
+test "fmt generic: parameter and return generic types stay tight" ![io] {
     let src = "fn f(p: Foo<int>) -> int {\n    return 0;\n}\n";
     let out = format_source(src);
     assert _contains(out, "fn f(p: Foo<int>) -> int");
@@ -73,27 +73,27 @@ test "fmt generic: parameter and return generic types stay tight" {
 }
 
 // ── Generic return type (no params after) ────────────────────────────
-test "fmt generic: generic return type formats tight" {
+test "fmt generic: generic return type formats tight" ![io] {
     let src = "fn h() -> Result<int, string> {\n    return parse();\n}\n";
     let out = format_source(src);
     assert _contains(out, "-> Result<int, string>");
 }
 
 // ── Comparison expressions are NOT mistaken for generics ─────────────
-test "fmt generic: less-than comparison keeps surrounding spaces" {
+test "fmt generic: less-than comparison keeps surrounding spaces" ![io] {
     let src = "fn cmp() -> boolean {\n    let a = 1;\n    let b = 2;\n    return a < b;\n}\n";
     let out = format_source(src);
     assert _contains(out, "a < b");
     assert _contains(out, "a<b") == false;
 }
 
-test "fmt generic: greater-or-equal comparison is unaffected" {
+test "fmt generic: greater-or-equal comparison is unaffected" ![io] {
     let src = "fn cmp() -> boolean {\n    let a = 1;\n    let b = 2;\n    return a >= b;\n}\n";
     let out = format_source(src);
     assert _contains(out, "a >= b");
 }
 
-test "fmt generic: right-shift expression is unaffected" {
+test "fmt generic: right-shift expression is unaffected" ![io] {
     let src = "fn sh() -> int {\n    let a = 4;\n    return a >> 1;\n}\n";
     let out = format_source(src);
     assert _contains(out, "a >> 1");

--- a/compiler/tests/unit/numeric_bitwise_test.sfn
+++ b/compiler/tests/unit/numeric_bitwise_test.sfn
@@ -14,12 +14,12 @@ import { index_of } from "../../src/string_utils";
 import { typecheck_diagnostics } from "../../src/typecheck";
 import { Diagnostic } from "../../src/typecheck_types";
 
-fn _emit(source: string) -> string {
+fn _emit(source: string) -> string ![io] {
     let program = parse_program(source);
     return emit_native_text_with_module_name(program, "bitwise_test");
 }
 
-fn _diagnostics(source: string) -> Diagnostic[] {
+fn _diagnostics(source: string) -> Diagnostic[] ![io] {
     let program = parse_program(source);
     return typecheck_diagnostics(program);
 }

--- a/compiler/tests/unit/numeric_cast_test.sfn
+++ b/compiler/tests/unit/numeric_cast_test.sfn
@@ -51,12 +51,12 @@ import { index_of } from "../../src/string_utils";
 import { typecheck_diagnostics } from "../../src/typecheck";
 import { Diagnostic } from "../../src/typecheck_types";
 
-fn _emit(source: string) -> string {
+fn _emit(source: string) -> string ![io] {
     let program = parse_program(source);
     return emit_native_text_with_module_name(program, "numeric_cast_test");
 }
 
-fn _diagnostics(source: string) -> Diagnostic[] {
+fn _diagnostics(source: string) -> Diagnostic[] ![io] {
     let program = parse_program(source);
     return typecheck_diagnostics(program);
 }

--- a/compiler/tests/unit/numeric_int_default_test.sfn
+++ b/compiler/tests/unit/numeric_int_default_test.sfn
@@ -12,12 +12,12 @@ import { index_of } from "../../src/string_utils";
 import { typecheck_diagnostics } from "../../src/typecheck";
 import { Diagnostic } from "../../src/typecheck_types";
 
-fn _emit(source: string) -> string {
+fn _emit(source: string) -> string ![io] {
     let program = parse_program(source);
     return emit_native_text_with_module_name(program, "numeric_int_default_test");
 }
 
-fn _diagnostics(source: string) -> Diagnostic[] {
+fn _diagnostics(source: string) -> Diagnostic[] ![io] {
     let program = parse_program(source);
     return typecheck_diagnostics(program);
 }

--- a/compiler/tests/unit/numeric_int_float_test.sfn
+++ b/compiler/tests/unit/numeric_int_float_test.sfn
@@ -17,12 +17,12 @@ import { index_of } from "../../src/string_utils";
 import { typecheck_diagnostics } from "../../src/typecheck";
 import { Diagnostic } from "../../src/typecheck_types";
 
-fn _emit(source: string) -> string {
+fn _emit(source: string) -> string ![io] {
     let program = parse_program(source);
     return emit_native_text_with_module_name(program, "numeric_test");
 }
 
-fn _diagnostics(source: string) -> Diagnostic[] {
+fn _diagnostics(source: string) -> Diagnostic[] ![io] {
     let program = parse_program(source);
     return typecheck_diagnostics(program);
 }

--- a/compiler/tests/unit/parser_block_let_test.sfn
+++ b/compiler/tests/unit/parser_block_let_test.sfn
@@ -67,7 +67,7 @@ fn _nth_variable_declaration(block: Block, n: int) -> Statement {
 // -------------------------------------------------------------------
 // Tests
 // -------------------------------------------------------------------
-test "parser block let: simple `let` inside fn body produces VariableDeclaration" {
+test "parser block let: simple `let` inside fn body produces VariableDeclaration" ![io] {
     let source = "fn main() { let x = 1; }";
     let program = parse_program(source);
     let body = _find_function_body(program, "main");
@@ -77,7 +77,7 @@ test "parser block let: simple `let` inside fn body produces VariableDeclaration
     assert decl.mutable == false;
 }
 
-test "parser block let: `let mut` inside fn body preserves mutable flag" {
+test "parser block let: `let mut` inside fn body preserves mutable flag" ![io] {
     // Pre-fix this fell through to parse_expression_statement and lost
     // the mutable flag — only top-level `let` carried it because only
     // top-level routed through `parse_variable`.
@@ -90,7 +90,7 @@ test "parser block let: `let mut` inside fn body preserves mutable flag" {
     assert decl.mutable == true;
 }
 
-test "parser block let: multiple block-scoped lets parse to structured statements" {
+test "parser block let: multiple block-scoped lets parse to structured statements" ![io] {
     // The acceptance-criteria example from issue #521. Pre-fix the
     // lambda buried inside `let f = fn(){...}` was invisible to any
     // capture-analysis walk over `main`'s body — the outer `let`
@@ -107,7 +107,7 @@ test "parser block let: multiple block-scoped lets parse to structured statement
     assert second.name == "f";
 }
 
-test "parser block let: typed let with explicit annotation parses" {
+test "parser block let: typed let with explicit annotation parses" ![io] {
     // `let x: number = 1` previously round-tripped through raw text  // alias-coverage: parser fixture exercises legacy : number syntax
     // inside a block. The structured path must preserve the type
     // annotation for the typechecker to consume.
@@ -120,7 +120,7 @@ test "parser block let: typed let with explicit annotation parses" {
     assert decl.type_annotation != null;
 }
 
-test "parser block let: top-level let path is unchanged" {
+test "parser block let: top-level let path is unchanged" ![io] {
     // Anchor existing behaviour — the new branch must not regress the
     // top-level `let` path that was already shipping a structured
     // VariableDeclaration.
@@ -139,7 +139,7 @@ test "parser block let: top-level let path is unchanged" {
     assert found;
 }
 
-test "parser block let: nested block lets parse independently" {
+test "parser block let: nested block lets parse independently" ![io] {
     // Block-scoped lets inside an `if` body must also flow through the
     // structured path — `parse_block_statement` recurses into nested
     // blocks via `parse_block`, so the fix automatically extends.

--- a/compiler/tests/unit/parser_function_types_test.sfn
+++ b/compiler/tests/unit/parser_function_types_test.sfn
@@ -47,7 +47,7 @@ fn _first_variable_decl(block: Block) -> Statement {
 // Acceptance criterion (a): `let f: fn(int) -> int = ...` parses and
 // the annotation text round-trips into `TypeAnnotation.text`.
 // -------------------------------------------------------------------
-test "fn-types: let-binding with fn(int) -> int annotation parses" {
+test "fn-types: let-binding with fn(int) -> int annotation parses" ![io] {
     let source = "fn main() { let f: fn(int) -> int = fn(x: int) -> int { return x + 1; }; }";
     let program = parse_program(source);
     let body = _function_body(program, "main");
@@ -69,7 +69,7 @@ test "fn-types: let-binding with fn(int) -> int annotation parses" {
 // `(int)` paren pair does not prematurely terminate the parameter
 // list.
 // -------------------------------------------------------------------
-test "fn-types: parameter typed as fn(int) -> int parses" {
+test "fn-types: parameter typed as fn(int) -> int parses" ![io] {
     let source = "fn apply(cb: fn(int) -> int, x: int) -> int { return cb(x); }";
     let program = parse_program(source);
     let decl = _find_function(program, "apply");
@@ -94,7 +94,7 @@ test "fn-types: parameter typed as fn(int) -> int parses" {
 // — the return-type capture must itself accept an fn-type, so the
 // `->` token between the two arrows is not greedy.
 // -------------------------------------------------------------------
-test "fn-types: nested fn() -> fn(int) -> int annotation parses" {
+test "fn-types: nested fn() -> fn(int) -> int annotation parses" ![io] {
     let source = "fn main() { let f: fn() -> fn(int) -> int = 0; }";
     let program = parse_program(source);
     let body = _function_body(program, "main");
@@ -108,7 +108,7 @@ test "fn-types: nested fn() -> fn(int) -> int annotation parses" {
 // empty arg list is a balanced `()` pair that must not be mistaken
 // for a function call or trailing parenthesised expression).
 // -------------------------------------------------------------------
-test "fn-types: zero-arg fn() -> int annotation parses" {
+test "fn-types: zero-arg fn() -> int annotation parses" ![io] {
     let source = "fn main() { let f: fn() -> int = 0; }";
     let program = parse_program(source);
     let body = _function_body(program, "main");

--- a/compiler/tests/unit/result_enum_typecheck_test.sfn
+++ b/compiler/tests/unit/result_enum_typecheck_test.sfn
@@ -14,7 +14,7 @@ import {
     validate_enum_annotation
 } from "../../src/typecheck_types";
 
-fn _enum_decl(source: string, name: string) -> Statement? {
+fn _enum_decl(source: string, name: string) -> Statement? ![io] {
     let program = parse_program(source);
     let mut index: int = 0;
     loop {

--- a/compiler/tests/unit/result_parse_test.sfn
+++ b/compiler/tests/unit/result_parse_test.sfn
@@ -46,7 +46,7 @@ fn _first_variable_declaration(block: Block) -> Statement {
 // -------------------------------------------------------------------
 // Tests
 // -------------------------------------------------------------------
-test "parser try-op: `read()?` wraps the call in a TryOperator" {
+test "parser try-op: `read()?` wraps the call in a TryOperator" ![io] {
     let source = "fn main() { let x = read()?; }";
     let program = parse_program(source);
     let body = _find_function_body(program, "main");
@@ -59,7 +59,7 @@ test "parser try-op: `read()?` wraps the call in a TryOperator" {
     assert init.operand.variant == "Call";
 }
 
-test "parser try-op: `a()?.b()?` left-associates to `((a()?).b())?`" {
+test "parser try-op: `a()?.b()?` left-associates to `((a()?).b())?`" ![io] {
     let source = "fn main() { let v = a()?.b()?; }";
     let program = parse_program(source);
     let body = _find_function_body(program, "main");
@@ -87,7 +87,7 @@ test "parser try-op: `a()?.b()?` left-associates to `((a()?).b())?`" {
     assert inner_try.operand.variant == "Call";
 }
 
-test "parser try-op: nullable type annotation is NOT a TryOperator" {
+test "parser try-op: nullable type annotation is NOT a TryOperator" ![io] {
     // `let x: Config?` parses the `?` as part of the type annotation,
     // not as a postfix expression operator. The declaration carries a
     // type annotation and has no TryOperator initializer.

--- a/compiler/tests/unit/struct_field_separator_test.sfn
+++ b/compiler/tests/unit/struct_field_separator_test.sfn
@@ -20,7 +20,7 @@ import { emit_native_text_with_module_name } from "../../src/emit_native";
 import { parse_program } from "../../src/parser/mod";
 import { index_of } from "../../src/string_utils";
 
-fn _emit(source: string) -> string {
+fn _emit(source: string) -> string ![io] {
     let program = parse_program(source);
     return emit_native_text_with_module_name(program, "struct_field_separator_test");
 }

--- a/compiler/tests/unit/test_filter_test.sfn
+++ b/compiler/tests/unit/test_filter_test.sfn
@@ -13,7 +13,7 @@
 import { parse_program } from "../../src/parser/mod";
 import { set_test_filters, test_decl_matches_filters, test_filters_active } from "../../src/test_runner_state";
 
-fn _count_matches(source: string) -> int {
+fn _count_matches(source: string) -> int ![io] {
     let program = parse_program(source);
     let mut count: int = 0;
     let mut i: int = 0;

--- a/compiler/tests/unit/thread_local_global_test.sfn
+++ b/compiler/tests/unit/thread_local_global_test.sfn
@@ -50,7 +50,7 @@ fn _has_variable(program: Program, name: string) -> boolean {
     return false;
 }
 
-test "parser thread_local: top-level `thread_local let mut` sets is_thread_local" {
+test "parser thread_local: top-level `thread_local let mut` sets is_thread_local" ![io] {
     let source = "thread_local let mut frame_head: i64 = 0;";
     let program = parse_program(source);
     assert _has_variable(program, "frame_head");
@@ -60,7 +60,7 @@ test "parser thread_local: top-level `thread_local let mut` sets is_thread_local
     assert decl.name == "frame_head";
 }
 
-test "parser thread_local: ordinary `let mut` leaves is_thread_local false" {
+test "parser thread_local: ordinary `let mut` leaves is_thread_local false" ![io] {
     // Anchor the default — every existing module global today still
     // lowers to `internal global`, not `internal thread_local global`.
     let source = "let mut counter: i64 = 0;";
@@ -70,7 +70,7 @@ test "parser thread_local: ordinary `let mut` leaves is_thread_local false" {
     assert decl.mutable == true;
 }
 
-test "parser thread_local: ordinary immutable `let` leaves is_thread_local false" {
+test "parser thread_local: ordinary immutable `let` leaves is_thread_local false" ![io] {
     let source = "let pi: float = 3.14;";
     let program = parse_program(source);
     let decl = _find_variable(program, "pi");
@@ -78,7 +78,7 @@ test "parser thread_local: ordinary immutable `let` leaves is_thread_local false
     assert decl.mutable == false;
 }
 
-test "parser thread_local: preserves type annotation through the prefix" {
+test "parser thread_local: preserves type annotation through the prefix" ![io] {
     // The keyword must not consume tokens that belong to the type
     // annotation — i.e. `thread_local` is a pure prefix, not a
     // pseudo-type wrapper.
@@ -90,7 +90,7 @@ test "parser thread_local: preserves type annotation through the prefix" {
     assert decl.type_annotation.text == "i64";
 }
 
-test "parser thread_local: rejects bare `thread_local` without `let`" {
+test "parser thread_local: rejects bare `thread_local` without `let`" ![io] {
     // `thread_local fn ...` (and any other non-`let` follower) must
     // not silently turn into a VariableDeclaration. Today the
     // dispatcher falls through to `parse_unknown`, which yields a

--- a/compiler/tests/unit/typecheck_expression_walk_test.sfn
+++ b/compiler/tests/unit/typecheck_expression_walk_test.sfn
@@ -27,7 +27,7 @@ fn _count_e0420(diagnostics: Diagnostic[]) -> int {
     return count;
 }
 
-fn _e0420_for(source: string) -> int {
+fn _e0420_for(source: string) -> int ![io] {
     let program = parse_program(source);
     let diagnostics = typecheck_diagnostics(program);
     return _count_e0420(diagnostics);

--- a/compiler/tests/unit/typecheck_extern_test.sfn
+++ b/compiler/tests/unit/typecheck_extern_test.sfn
@@ -39,28 +39,28 @@ fn _count_code(diagnostics: Diagnostic[], code: string) -> int {
 // Accept path — every form on the v0 accept-list must produce zero
 // diagnostics.
 // -------------------------------------------------------------------
-test "extern: accepts unsafe extern fn malloc(size: usize) -> *u8" {
+test "extern: accepts unsafe extern fn malloc(size: usize) -> *u8" ![io] {
     let source = "unsafe extern fn malloc(size: usize) -> *u8;";
     let program = parse_program(source);
     let diagnostics = typecheck_diagnostics(program);
     assert diagnostics.length == 0;
 }
 
-test "extern: accepts integer-sized write signature" {
+test "extern: accepts integer-sized write signature" ![io] {
     let source = "extern fn write(fd: i32, buf: *u8, count: i64) -> i64;";
     let program = parse_program(source);
     let diagnostics = typecheck_diagnostics(program);
     assert diagnostics.length == 0;
 }
 
-test "extern: accepts opaque pointer pointee (*File)" {
+test "extern: accepts opaque pointer pointee (*File)" ![io] {
     let source = "extern fn fclose(f: *File) -> i32;";
     let program = parse_program(source);
     let diagnostics = typecheck_diagnostics(program);
     assert diagnostics.length == 0;
 }
 
-test "extern: accepts void return" {
+test "extern: accepts void return" ![io] {
     let source = "extern fn free(ptr: *u8) -> void;";
     let program = parse_program(source);
     let diagnostics = typecheck_diagnostics(program);
@@ -70,21 +70,21 @@ test "extern: accepts void return" {
 // -------------------------------------------------------------------
 // Reject path — non-C-ABI parameter / return types.
 // -------------------------------------------------------------------
-test "extern: rejects string parameter (E0801)" {
+test "extern: rejects string parameter (E0801)" ![io] {
     let source = "extern fn write_msg(buf: string) -> i64;";
     let program = parse_program(source);
     let diagnostics = typecheck_diagnostics(program);
     assert _has_code(diagnostics, "E0801");
 }
 
-test "extern: rejects array parameter (E0802)" {
+test "extern: rejects array parameter (E0802)" ![io] {
     let source = "extern fn process(items: i32[]) -> void;";
     let program = parse_program(source);
     let diagnostics = typecheck_diagnostics(program);
     assert _has_code(diagnostics, "E0802");
 }
 
-test "extern: rejects legacy `number` (E0805)" {
+test "extern: rejects legacy `number` (E0805)" ![io] {
     let source = "extern fn legacy(x: number) -> number;";  // alias-coverage: diagnostic test exercises legacy : number rejection
     let program = parse_program(source);
     let diagnostics = typecheck_diagnostics(program);
@@ -92,7 +92,7 @@ test "extern: rejects legacy `number` (E0805)" {
     assert _count_code(diagnostics, "E0805") >= 2;
 }
 
-test "extern: rejects string return type (E0801)" {
+test "extern: rejects string return type (E0801)" ![io] {
     let source = "extern fn read_line() -> string;";
     let program = parse_program(source);
     let diagnostics = typecheck_diagnostics(program);
@@ -102,14 +102,14 @@ test "extern: rejects string return type (E0801)" {
 // -------------------------------------------------------------------
 // Reject path — declarations that conflict with extern semantics.
 // -------------------------------------------------------------------
-test "extern: rejects type parameters (E0803)" {
+test "extern: rejects type parameters (E0803)" ![io] {
     let source = "extern fn identity<T>(x: T) -> T;";
     let program = parse_program(source);
     let diagnostics = typecheck_diagnostics(program);
     assert _has_code(diagnostics, "E0803");
 }
 
-test "extern: rejects effects on the extern itself (E0804)" {
+test "extern: rejects effects on the extern itself (E0804)" ![io] {
     let source = "extern fn malloc(size: i64) ![io] -> *u8;";
     let program = parse_program(source);
     let diagnostics = typecheck_diagnostics(program);
@@ -123,21 +123,21 @@ test "extern: rejects effects on the extern itself (E0804)" {
 // types come back to the accept-list once `map_primitive_type` in
 // `compiler/src/llvm/type_mapping.sfn` learns to lower them.
 // -------------------------------------------------------------------
-test "extern: rejects bare void parameter (E0805)" {
+test "extern: rejects bare void parameter (E0805)" ![io] {
     let source = "extern fn evil(x: void) -> i64;";
     let program = parse_program(source);
     let diagnostics = typecheck_diagnostics(program);
     assert _has_code(diagnostics, "E0805");
 }
 
-test "extern: accepts void return type" {
+test "extern: accepts void return type" ![io] {
     let source = "extern fn close_all() -> void;";
     let program = parse_program(source);
     let diagnostics = typecheck_diagnostics(program);
     assert diagnostics.length == 0;
 }
 
-test "extern: rejects parameter with no type annotation (E0805)" {
+test "extern: rejects parameter with no type annotation (E0805)" ![io] {
     let source = "extern fn untyped(x) -> i64;";
     let program = parse_program(source);
     let diagnostics = typecheck_diagnostics(program);
@@ -148,14 +148,14 @@ test "extern: rejects parameter with no type annotation (E0805)" {
 // added f64 as the longer alias for `float`/`double`) into the
 // extern accept-list. Pre-Slice-C these were rejected with E0805;
 // the tests below are the regression pin for the new behaviour.
-test "extern: accepts i16 parameter (Slice C)" {
+test "extern: accepts i16 parameter (Slice C)" ![io] {
     let source = "extern fn narrow(x: i16) -> i64;";
     let program = parse_program(source);
     let diagnostics = typecheck_diagnostics(program);
     assert diagnostics.length == 0;
 }
 
-test "extern: accepts f64 return type (Slice C — alias for float/double)" {
+test "extern: accepts f64 return type (Slice C — alias for float/double)" ![io] {
     let source = "extern fn now() -> f64;";
     let program = parse_program(source);
     let diagnostics = typecheck_diagnostics(program);
@@ -167,7 +167,7 @@ test "extern: accepts f64 return type (Slice C — alias for float/double)" {
 // an extern collides with a regular fn (proves both go in the same
 // table).
 // -------------------------------------------------------------------
-test "extern: collides with same-named regular fn (E0001)" {
+test "extern: collides with same-named regular fn (E0001)" ![io] {
     let source = "extern fn malloc(size: i64) -> *u8;\n"
         + "fn malloc(x: i64) -> i64 { return x; }\n";
     let program = parse_program(source);
@@ -175,7 +175,7 @@ test "extern: collides with same-named regular fn (E0001)" {
     assert _has_code(diagnostics, "E0001");
 }
 
-test "extern: duplicate extern declarations collide (E0001)" {
+test "extern: duplicate extern declarations collide (E0001)" ![io] {
     let source = "extern fn write(fd: i32, buf: *u8, count: i64) -> i64;\n"
         + "extern fn write(fd: i32, buf: *u8, count: i64) -> i64;\n";
     let program = parse_program(source);

--- a/compiler/tests/unit/typecheck_imports_test.sfn
+++ b/compiler/tests/unit/typecheck_imports_test.sfn
@@ -323,7 +323,7 @@ test "typecheck walker: empty import table resolves nothing" {
     assert ! typecheck_walker_resolves_import("imported_helper", imports);
 }
 
-test "typecheck walker: import-symbol-aware path emits no diagnostics for actually-imported callee" {
+test "typecheck walker: import-symbol-aware path emits no diagnostics for actually-imported callee" ![io] {
     // Pre-enforcement state: even with the import table threaded
     // through, the walker discards its resolution result. The source
     // includes an `import { imported_helper }` specifier so the
@@ -338,7 +338,7 @@ test "typecheck walker: import-symbol-aware path emits no diagnostics for actual
     assert diagnostics.length == 0;
 }
 
-test "typecheck walker: import-symbol-aware path flags unresolved callee (E0420)" {
+test "typecheck walker: import-symbol-aware path flags unresolved callee (E0420)" ![io] {
     // Companion to the test above — `not_imported` is neither imported
     // nor declared nor a builtin, so #812 surfaces E0420.
     let source = "fn main() { not_imported(\"hi\"); }";
@@ -349,7 +349,7 @@ test "typecheck walker: import-symbol-aware path flags unresolved callee (E0420)
     assert _count_e0420(diagnostics) == 1;
 }
 
-test "typecheck walker: localization drops globally-present but un-imported names (E0420)" {
+test "typecheck walker: localization drops globally-present but un-imported names (E0420)" ![io] {
     // Regression guard for the localization step — without the
     // `localize_import_symbols_for_program` call inside
     // `typecheck_diagnostics_with_import_symbols`, any function
@@ -365,7 +365,7 @@ test "typecheck walker: localization drops globally-present but un-imported name
     assert _count_e0420(diagnostics) == 1;
 }
 
-test "typecheck walker: 2-arg back-compat path flags an undefined callee (E0420)" {
+test "typecheck walker: 2-arg back-compat path flags an undefined callee (E0420)" ![io] {
     // The legacy 2-arg `typecheck_diagnostics_with_imports` keeps
     // working — it delegates to the 3-arg variant with an empty import
     // table. With no `import` specifier and no local declaration,

--- a/compiler/tests/unit/typecheck_lambda_capture_test.sfn
+++ b/compiler/tests/unit/typecheck_lambda_capture_test.sfn
@@ -32,7 +32,7 @@ fn _has_capture(record: LambdaCaptureRecord, name: string) -> boolean {
 // Acceptance criterion: existing lambda tests still pass / no
 // regression for lambdas without free variables.
 // -------------------------------------------------------------------
-test "captures: empty body produces no captures" {
+test "captures: empty body produces no captures" ![io] {
     let source = "let f = fn() -> int { return 0; };";
     let program = parse_program(source);
     let records = analyze_lambda_captures(program);
@@ -41,7 +41,7 @@ test "captures: empty body produces no captures" {
     assert records[0].parameter_names.length == 0;
 }
 
-test "captures: lambda referencing only its parameter produces no captures" {
+test "captures: lambda referencing only its parameter produces no captures" ![io] {
     let source = "let inc = fn(x: int) -> int { return x; };";
     let program = parse_program(source);
     let records = analyze_lambda_captures(program);
@@ -51,7 +51,7 @@ test "captures: lambda referencing only its parameter produces no captures" {
     assert strings_equal(records[0].parameter_names[0], "x");
 }
 
-test "captures: top-level function reference is not a capture" {
+test "captures: top-level function reference is not a capture" ![io] {
     // `helper` is a top-level fn, not a let-binding, so referencing
     // it from a lambda body must not register as a capture — stage A2
     // resolves named functions through the module symbol table, not
@@ -68,7 +68,7 @@ test "captures: top-level function reference is not a capture" {
 // enclosing scope, one identifier reference inside the lambda body,
 // one Capture with the binding's annotation echoed back.
 // -------------------------------------------------------------------
-test "captures: lambda captures a single enclosing let-binding" {
+test "captures: lambda captures a single enclosing let-binding" ![io] {
     let source = "let x: int = 1; let f = fn() -> int { return x; };";
     let program = parse_program(source);
     let records = analyze_lambda_captures(program);
@@ -80,7 +80,7 @@ test "captures: lambda captures a single enclosing let-binding" {
     assert records[0].captures[0].by_value;
 }
 
-test "captures: type annotation is echoed onto the Capture" {
+test "captures: type annotation is echoed onto the Capture" ![io] {
     let source = "let label: string = \"hi\"; let f = fn() -> string { return label; };";
     let program = parse_program(source);
     let records = analyze_lambda_captures(program);
@@ -89,7 +89,7 @@ test "captures: type annotation is echoed onto the Capture" {
     assert strings_equal(records[0].captures[0].type_text, "string");
 }
 
-test "captures: mutability of the enclosing binding is recorded" {
+test "captures: mutability of the enclosing binding is recorded" ![io] {
     let source = "let mut counter: int = 0; let inc = fn() -> int { return counter; };";
     let program = parse_program(source);
     let records = analyze_lambda_captures(program);
@@ -103,7 +103,7 @@ test "captures: mutability of the enclosing binding is recorded" {
 // binding of the same name. Acceptance criterion calls this case
 // out by name.
 // -------------------------------------------------------------------
-test "captures: lambda parameter shadows enclosing let-binding" {
+test "captures: lambda parameter shadows enclosing let-binding" ![io] {
     let source = "let x: int = 1; let f = fn(x: int) -> int { return x; };";
     let program = parse_program(source);
     let records = analyze_lambda_captures(program);
@@ -121,7 +121,7 @@ test "captures: lambda parameter shadows enclosing let-binding" {
 // the shadowing case is exercised via parameter shadowing instead,
 // which is the same scoping rule applied at the parameter slot.)
 // -------------------------------------------------------------------
-test "captures: only outer-resolved free names become captures" {
+test "captures: only outer-resolved free names become captures" ![io] {
     // The lambda references `outer_val` (in scope) and `not_in_scope`
     // (truly free — likely an imported helper or a typo). Only the
     // resolved name lands in the capture set; truly-free names are
@@ -140,7 +140,7 @@ test "captures: only outer-resolved free names become captures" {
 // Use return-position lambdas because that path produces structured
 // AST through both layers.
 // -------------------------------------------------------------------
-test "captures: nested lambdas both capture an outer let" {
+test "captures: nested lambdas both capture an outer let" ![io] {
     // The outer lambda returns the inner lambda directly (not via
     // IIFE — the IIFE pattern is a separate-issue parser path that
     // bites on the `;` inside the nested body). The inner lambda
@@ -155,7 +155,7 @@ test "captures: nested lambdas both capture an outer let" {
     assert _has_capture(records[1], "x");
 }
 
-test "captures: nested lambda's parameter doesn't bleed into outer capture set" {
+test "captures: nested lambda's parameter doesn't bleed into outer capture set" ![io] {
     // Inner lambda takes `x` as a parameter; outer lambda doesn't
     // reference `x` at all. The walk must NOT mark `x` as a capture
     // on either lambda — the inner's parameter binds it locally and
@@ -176,7 +176,7 @@ test "captures: nested lambda's parameter doesn't bleed into outer capture set" 
 // Stage A2 indexes by position in the env struct, so any reorder
 // is a soundness break.
 // -------------------------------------------------------------------
-test "captures: multiple captures preserve first-use order" {
+test "captures: multiple captures preserve first-use order" ![io] {
     let source = "let a: int = 1; let b: int = 2; let f = fn() -> int { return a + b; };";
     let program = parse_program(source);
     let records = analyze_lambda_captures(program);
@@ -186,7 +186,7 @@ test "captures: multiple captures preserve first-use order" {
     assert strings_equal(records[0].captures[1].name, "b");
 }
 
-test "captures: repeated reference to same name produces one Capture" {
+test "captures: repeated reference to same name produces one Capture" ![io] {
     let source = "let x: int = 1; let f = fn() -> int { return x + x + x; };";
     let program = parse_program(source);
     let records = analyze_lambda_captures(program);
@@ -195,7 +195,7 @@ test "captures: repeated reference to same name produces one Capture" {
     assert strings_equal(records[0].captures[0].name, "x");
 }
 
-test "captures: capture order follows source-use order, not declaration order" {
+test "captures: capture order follows source-use order, not declaration order" ![io] {
     // `b` declared before `a` in the let block, but the lambda body
     // uses `a` first. Stage A2 wants source-use-order indexing so
     // the test pins it explicitly.
@@ -215,7 +215,7 @@ test "captures: capture order follows source-use order, not declaration order" {
 // bound, not as a capture from the enclosing scope. Mirrors review
 // feedback on PR #512.
 // -------------------------------------------------------------------
-test "captures: catch-name shadows outer binding for lambdas inside catch" {
+test "captures: catch-name shadows outer binding for lambdas inside catch" ![io] {
     // Top-level `let err: int = 0` is in scope at the lambda
     // site (annotated `: int`). The `catch (err) { ... }` handler
     // re-binds `err` as a fresh local with no annotation. A lambda
@@ -242,7 +242,7 @@ test "captures: catch-name shadows outer binding for lambdas inside catch" {
 // .Lambda` walk back to the inferred record without depending on
 // pre-order indexing alone. Mirrors review feedback on PR #512.
 // -------------------------------------------------------------------
-test "captures: record carries the body's opening-brace line and column" {
+test "captures: record carries the body's opening-brace line and column" ![io] {
     let source = "let f = fn() -> int { return 0; };";
     let program = parse_program(source);
     let records = analyze_lambda_captures(program);
@@ -256,7 +256,7 @@ test "captures: record carries the body's opening-brace line and column" {
     assert records[0].body_start_column != 0;
 }
 
-test "captures: nested lambdas carry distinct body-span identifiers" {
+test "captures: nested lambdas carry distinct body-span identifiers" ![io] {
     // Two lambdas with identical parameter shapes (both 0-arity)
     // must still be distinguishable via body span — that's the
     // point of carrying the identifier alongside `parameter_names`.

--- a/compiler/tests/unit/typecheck_main_signature_test.sfn
+++ b/compiler/tests/unit/typecheck_main_signature_test.sfn
@@ -63,7 +63,7 @@ fn _contains(haystack: string, needle: string) -> boolean {
 // Accept path — every form on the v0 entry-point accept-list must
 // produce zero main-signature diagnostics (E0010 / E0011).
 // -------------------------------------------------------------------
-test "main: accepts fn main() {} (zero parameters, no return type)" {
+test "main: accepts fn main() {} (zero parameters, no return type)" ![io] {
     let source = "fn main() {}";
     let program = parse_program(source);
     let diagnostics = typecheck_diagnostics(program);
@@ -71,7 +71,7 @@ test "main: accepts fn main() {} (zero parameters, no return type)" {
     assert ! _has_code(diagnostics, "E0011");
 }
 
-test "main: accepts fn main(argv: string[]) -> number ![io]" {  // alias-coverage: diagnostic test exercises legacy : number rejection
+test "main: accepts fn main(argv: string[]) -> number ![io]" ![io] {  // alias-coverage: diagnostic test exercises legacy : number rejection
     let source = "fn main(argv: string[]) -> number ![io] { return 0; }";  // alias-coverage: diagnostic test exercises legacy : number rejection
     let program = parse_program(source);
     let diagnostics = typecheck_diagnostics(program);
@@ -79,7 +79,7 @@ test "main: accepts fn main(argv: string[]) -> number ![io]" {  // alias-coverag
     assert ! _has_code(diagnostics, "E0011");
 }
 
-test "main: accepts fn main() ![io] (effect declared, zero params)" {
+test "main: accepts fn main() ![io] (effect declared, zero params)" ![io] {
     // The most common entry-point shape used across `examples/`. Lock
     // it in so a future tightening of the validator doesn't regress
     // the existing example fleet.
@@ -90,7 +90,7 @@ test "main: accepts fn main() ![io] (effect declared, zero params)" {
     assert ! _has_code(diagnostics, "E0011");
 }
 
-test "main: accepts fn main() -> number (return type only)" {  // alias-coverage: diagnostic test exercises legacy : number rejection
+test "main: accepts fn main() -> number (return type only)" ![io] {  // alias-coverage: diagnostic test exercises legacy : number rejection
     let source = "fn main() -> number { return 0; }";  // alias-coverage: diagnostic test exercises legacy : number rejection
     let program = parse_program(source);
     let diagnostics = typecheck_diagnostics(program);
@@ -102,7 +102,7 @@ test "main: accepts fn main() -> number (return type only)" {  // alias-coverage
 // Reject path — wrong parameter shape produces a Sailfin diagnostic
 // rather than a downstream `lld` error.
 // -------------------------------------------------------------------
-test "main: rejects fn main(argv: number) -> number (E0011 wrong argv type)" {  // alias-coverage: diagnostic test exercises legacy : number rejection
+test "main: rejects fn main(argv: number) -> number (E0011 wrong argv type)" ![io] {  // alias-coverage: diagnostic test exercises legacy : number rejection
     let source = "fn main(argv: number) -> number { return 0; }";  // alias-coverage: diagnostic test exercises legacy : number rejection
     let program = parse_program(source);
     let diagnostics = typecheck_diagnostics(program);
@@ -111,7 +111,7 @@ test "main: rejects fn main(argv: number) -> number (E0011 wrong argv type)" {  
     assert _has_code(diagnostics, "E0011");
 }
 
-test "main: rejects fn main(argv: string[], extra: number) (E0010 extra param)" {  // alias-coverage: diagnostic test exercises legacy : number rejection
+test "main: rejects fn main(argv: string[], extra: number) (E0010 extra param)" ![io] {  // alias-coverage: diagnostic test exercises legacy : number rejection
     let source = "fn main(argv: string[], extra: number) -> number { return 0; }";  // alias-coverage: diagnostic test exercises legacy : number rejection
     let program = parse_program(source);
     let diagnostics = typecheck_diagnostics(program);
@@ -122,7 +122,7 @@ test "main: rejects fn main(argv: string[], extra: number) (E0010 extra param)" 
     assert _has_code(diagnostics, "E0010");
 }
 
-test "main: E0011 message includes the offending type text" {
+test "main: E0011 message includes the offending type text" ![io] {
     // The user-facing message must reference both the expected
     // `string[]` shape and the actual `number` annotation so the user
     // has enough context to fix without consulting the spec. Assert
@@ -153,7 +153,7 @@ test "main: E0011 message includes the offending type text" {
     assert found_param_name;
 }
 
-test "main: only one E0011 for a single bad parameter" {
+test "main: only one E0011 for a single bad parameter" ![io] {
     // Duplicate diagnostics for the same slot would be noisy. The
     // validator must emit at most one E0011 per offending parameter.
     let source = "fn main(argv: number) -> number { return 0; }";  // alias-coverage: diagnostic test exercises legacy : number rejection
@@ -168,7 +168,7 @@ test "main: only one E0011 for a single bad parameter" {
 // helpers like `sailfin_cli_main` and `native_cli_main` (which take
 // custom parameter shapes) keep their freedom.
 // -------------------------------------------------------------------
-test "main: non-main fn with arbitrary params produces no E0010/E0011" {
+test "main: non-main fn with arbitrary params produces no E0010/E0011" ![io] {
     let source = "fn handle_request(req: number) -> number { return req; }";  // alias-coverage: diagnostic test exercises legacy : number rejection
     let program = parse_program(source);
     let diagnostics = typecheck_diagnostics(program);
@@ -176,7 +176,7 @@ test "main: non-main fn with arbitrary params produces no E0010/E0011" {
     assert ! _has_code(diagnostics, "E0011");
 }
 
-test "main: function literally named `mainframe` is not gated" {
+test "main: function literally named `mainframe` is not gated" ![io] {
     // The validator must use exact name matching, not a prefix/suffix
     // check, so identifiers like `mainframe`, `main_loop`, or
     // `entrypoint_main` keep their original signature freedom.

--- a/compiler/tests/unit/typecheck_undefined_function_test.sfn
+++ b/compiler/tests/unit/typecheck_undefined_function_test.sfn
@@ -26,7 +26,7 @@ fn _count_e0420(diagnostics: Diagnostic[]) -> int {
     return count;
 }
 
-fn _e0420_for(source: string) -> int {
+fn _e0420_for(source: string) -> int ![io] {
     let program = parse_program(source);
     let diagnostics = typecheck_diagnostics(program);
     return _count_e0420(diagnostics);
@@ -39,7 +39,7 @@ test "E0420: undefined free-function callee is flagged" {
     assert _e0420_for("fn main() { notarealfunction(\"hi\"); }") == 1;
 }
 
-test "E0420: carries the undefined-function message and code" {
+test "E0420: carries the undefined-function message and code" ![io] {
     let program = parse_program("fn main() { notarealfunction(\"hi\"); }");
     let diagnostics = typecheck_diagnostics(program);
     let mut found: boolean = false;
@@ -117,7 +117,7 @@ fn _imports_with_helper() -> ImportSymbolTable {
     return append_import_function(table, "imported_helper", effects);
 }
 
-test "E0420: imported callee resolves via effect table + specifier" {
+test "E0420: imported callee resolves via effect table + specifier" ![io] {
     let source = "import { imported_helper } from \"./helpers\";\nfn main() { imported_helper(\"hi\"); }";
     let program = parse_program(source);
     let imports = _imports_with_helper();
@@ -134,7 +134,7 @@ test "E0420: imported callee resolves on the empty-table path via specifier" {
     assert _e0420_for(source) == 0;
 }
 
-test "E0420: un-imported name that only exists globally is flagged" {
+test "E0420: un-imported name that only exists globally is flagged" ![io] {
     // No `import` specifier for `imported_helper`; the localized table
     // drops it, so the call is undefined.
     let source = "fn main() { imported_helper(\"hi\"); }";


### PR DESCRIPTION
## Summary
- Adds the missing `[io]` effect annotation to the 34 `compiler/src/` functions flagged by `sailfin check compiler/src/` with **E0402** — they call an `[io]` callee transitively but didn't declare `[io]`.
- These slip through `make compile`/`make check` because the build-path effect gate runs with an empty import table (#706 audit; `compile_to_llvm_file_with_module` passes `empty_import_symbols()`); `sailfin check` uses a real import table and flags all 34.
- **Follow-up commit (bc14a39):** annotating `parse_program` (`[io]` via `parse_tokens`' `print.err` no-progress guard) and `format_source` (via `lex()`) cascades into the test suite — every `test` block / helper fn that calls them must declare `[io]` under the resolver-built import-effect table. Declared `[io]` on the **98 flagged test declarations** across 20 test files (precise — only the transitive callers, not a blanket sweep). Caught locally before CI and independently flagged by Copilot's review.
- Mechanical, correct-by-construction. No codegen or seed-visible behavior changes — the mechanical half of the #706 finding and a prerequisite for build-path enforcement.

Closes #956

## Acceptance Criteria
- [x] `ulimit -v 8388608 && build/native/sailfin check compiler/src/` reports **0** `E0402` (`checked 153 files: ok`)
- [x] `build/native/sailfin check` on the unit/integration/e2e test trees reports **0** `E0402`
- [x] `ulimit -v 8388608 && make compile` self-hosts
- [x] `ulimit -v 8388608 && make check` passes — e2e 87/87, **stage2 == stage3 fixed point ✓**, exit 0
- [x] `sfn fmt --check` clean on every touched file

> The compiler-src cascade stayed at exactly 34 (no new src callers). The test-suite cascade resolved to a fixed point after one annotation pass (98 decls).

## Verification
```bash
ulimit -v 8388608 && build/native/sailfin check compiler/src/ 2>&1 | grep -c E0402   # → 0
ulimit -v 8388608 && make check                                                      # → stage2 == stage3 ✓, exit 0
```

## Files Changed
- **18 compiler/src files** (34 signature annotations): `llvm/lowering/*`, `llvm/expression_lowering/**`, `parser/mod.sfn`, `tools/fmt.sfn`
- **20 test files** (98 decl/helper annotations): `tests/unit/*`, `tests/integration/test_runner_json_test.sfn`

🤖 Generated with [Claude Code](https://claude.com/claude-code)