### PR TITLE
test: restore real match-based assertions in result_types_test

### DIFF
--- a/compiler/tests/integration/result_types_test.sfn
+++ b/compiler/tests/integration/result_types_test.sfn
@@ -9,6 +9,20 @@ fn _safe_divide(a: int, b: int) -> int | DivisionError {
     return a / b;
 }
 
+// Distinguishes the success and error variants of `_safe_divide` by matching
+// on the union return type. The error arm surfaces the carried message; the
+// wildcard arm reports success. Swapping the branches in `_safe_divide` flips
+// the outcome of these helpers, which is what makes the assertions below
+// catch a regression rather than passing unconditionally.
+fn _describe_divide(a: int, b: int) -> string {
+    let result = _safe_divide(a, b);
+    match result {
+        DivisionError { message }
+        : return "error: " + message,
+        _: return "ok"
+    }
+}
+
 struct ParseError {
     message: string;
 }
@@ -20,29 +34,27 @@ fn _parse_non_negative(n: int) -> int | ParseError {
     return n;
 }
 
-// NOTE: match on union return types (e.g. `number | DivisionError`) causes
-// a compiler segfault during LLVM lowering. These tests verify that union
-// return types compile and can be called, but cannot yet inspect the result
-// via match destructuring.
-// See: https://github.com/SailfinIO/sailfin/issues/50
+fn _describe_parse(n: int) -> string {
+    let result = _parse_non_negative(n);
+    match result {
+        ParseError { message }
+        : return "error: " + message,
+        _: return "ok"
+    }
+}
+
 test "error_handling: union return function compiles and runs (success path)" {
-    let result = _safe_divide(10, 2);
-    // Once match on union types is supported, assert the numeric result here
-    assert 1 == 1;
+    assert _describe_divide(10, 2) == "ok";
 }
 
 test "error_handling: union return function compiles and runs (error path)" {
-    let result = _safe_divide(10, 0);
-    // Once match on union types is supported, assert the error message here
-    assert 1 == 1;
+    assert _describe_divide(10, 0) == "error: division by zero";
 }
 
 test "error_handling: parse_positive compiles and runs (success path)" {
-    let result = _parse_non_negative(42);
-    assert 1 == 1;
+    assert _describe_parse(42) == "ok";
 }
 
 test "error_handling: parse_positive compiles and runs (error path)" {
-    let result = _parse_non_negative(-5);
-    assert 1 == 1;
+    assert _describe_parse(-5) == "error: expected non-negative number";
 }

--- a/compiler/tests/integration/result_types_test.sfn
+++ b/compiler/tests/integration/result_types_test.sfn
@@ -51,10 +51,10 @@ test "error_handling: union return function compiles and runs (error path)" {
     assert _describe_divide(10, 0) == "error: division by zero";
 }
 
-test "error_handling: parse_positive compiles and runs (success path)" {
+test "error_handling: parse_non_negative compiles and runs (success path)" {
     assert _describe_parse(42) == "ok";
 }
 
-test "error_handling: parse_positive compiles and runs (error path)" {
+test "error_handling: parse_non_negative compiles and runs (error path)" {
     assert _describe_parse(-5) == "error: expected non-negative number";
 }


### PR DESCRIPTION
## Summary
- Replace the four `assert 1 == 1` placeholders in `compiler/tests/integration/result_types_test.sfn` with `match`-based assertions that distinguish the success and error variants of the `int | E` union return values.
- The blocker (#50, match-on-union segfault) is closed, so the tests now exercise the real match-destructuring path that the placeholders stood in for.
- Added two `_describe_*` helpers that match on the union return type (mirroring the proven pattern in `compiler/tests/unit/match_union_test.sfn`).

Closes #618

## Acceptance Criteria
- [x] Each test asserts a distinguishing property of the returned value (success → `"ok"`, error → the carried message).
- [x] Mutating `_safe_divide` (swapping the success/error branches) makes the success-path test fail — verified by running a mutated copy (`assertion failed`, exit 134).
- [x] `make test-integration` passes (29/29).

## Verification
```bash
ulimit -v 8388608 && make compile        # self-hosts from seed v0.7.0-alpha.19
ulimit -v 8388608 && make test-integration
# ═══ integration: 29/29 passed, 0 failed ═══
ulimit -v 8388608 && build/native/sailfin fmt --check compiler/tests/integration/result_types_test.sfn
# FMT CLEAN
```
Mutation check (swap `b == 0` → `b != 0` in `_safe_divide`):
```
RUN  error_handlingunionreturnfunctioncompilesandrunssuccesspath
[value_error] assertion failed
[test] FAIL: mutated_test.sfn (exit code 134)
```

## Files Changed
- `compiler/tests/integration/result_types_test.sfn`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0174AnSrNm4N7sne72jEPdbZ)_