### PR TITLE
feat(effects): enforce cross-module effect transitivity on the build path

### DIFF
--- a/compiler/src/capsule_resolver.sfn
+++ b/compiler/src/capsule_resolver.sfn
@@ -59,6 +59,7 @@ import {
 } from "./capsule_artifact";
 import {
     compile_to_llvm_file_with_module,
+    compile_to_llvm_file_with_module_imports,
     module_name_from_path,
     number_to_string,
     write_native_text_file_with_module
@@ -533,10 +534,16 @@ struct ParallelEmitTask {
 // the script was retired in Stage E PR7 / #383). With
 // `jobs == 1`, the helper sequentialises to keep the
 // regression-bisect path simple.
-fn _cr_run_parallel_emit(tasks: ParallelEmitTask[], mode: string, sailfin_exe: string, jobs: int) -> boolean ![io] {
+fn _cr_run_parallel_emit(tasks: ParallelEmitTask[], mode: string, sailfin_exe: string, jobs: int, import_context_root: string) -> boolean ![io] {
     if tasks.length == 0 { return true; }
     let mut effective_jobs = jobs;
     if effective_jobs <= 0 { effective_jobs = 1; }
+
+    // #957: when an import-context root is supplied (llvm-emit path),
+    // each worker passes `--import-context <root>` so the emit
+    // subprocess loads the cross-module effect table. Native staging
+    // emits pass "" and skip the flag.
+    let use_import_context = import_context_root.length > 0;
 
     // Sequential fallback: keeps regression bisects (and any
     // SAILFIN_BUILD_JOBS=1 invocations) on the simple
@@ -546,7 +553,14 @@ fn _cr_run_parallel_emit(tasks: ParallelEmitTask[], mode: string, sailfin_exe: s
         loop {
             if i >= tasks.length { break; }
             let t = tasks[i];
-            let rc = process.run([sailfin_exe, "emit", "--module-name", t.slug, "-o", t.output_path, mode, t.source_path]);
+            let mut emit_args: string[] = [sailfin_exe, "emit", "--module-name", t.slug, "-o", t.output_path];
+            if use_import_context {
+                emit_args.push("--import-context");
+                emit_args.push(import_context_root);
+            }
+            emit_args.push(mode);
+            emit_args.push(t.source_path);
+            let rc = process.run(emit_args);
             if rc != 0 { return false; }
             i += 1;
         }
@@ -585,9 +599,19 @@ fn _cr_run_parallel_emit(tasks: ParallelEmitTask[], mode: string, sailfin_exe: s
     // corruption flake. `native` mode (used by
     // `stage_capsule_imports`) skips validation — the staged
     // `.sfn-asm` doesn't need to round-trip through llvm-as.
+    // #957: when an import-context root is set, the worker passes
+    // `--import-context "$SAILFIN_PE_IMPORT_CTX"` to the emit; the env
+    // var is only exported below when `use_import_context` holds, so
+    // the native staging path (root == "") emits the flag-free form.
+    let mut worker_import_arg = "";
+    if use_import_context {
+        worker_import_arg = "--import-context \"$SAILFIN_PE_IMPORT_CTX\" ";
+    }
     let worker_script = "attempt=0; while [ $attempt -lt 3 ]; do "
         + "attempt=$((attempt + 1)); "
-        + "\"$SAILFIN_PE_SEED\" emit --module-name \"$1\" -o \"$2\" \"$SAILFIN_PE_MODE\" \"$3\" || continue; "
+        + "\"$SAILFIN_PE_SEED\" emit --module-name \"$1\" -o \"$2\" "
+        + worker_import_arg
+        + "\"$SAILFIN_PE_MODE\" \"$3\" || continue; "
         + "[ -s \"$2\" ] || continue; "
         + "if [ \"$SAILFIN_PE_MODE\" != llvm ]; then exit 0; fi; "
         + "if (command -v llvm-as >/dev/null 2>&1 && llvm-as < \"$2\" >/dev/null 2>&1) "
@@ -632,7 +656,8 @@ fn _cr_run_parallel_emit(tasks: ParallelEmitTask[], mode: string, sailfin_exe: s
     // `process.run` doesn't take an env map; routing through
     // `env` keeps the env propagation explicit + visible.
     let rc = process.run(["env", "SAILFIN_PE_SEED=" + sailfin_exe, "SAILFIN_PE_MODE="
-        + mode, "sh", driver_path]);
+        + mode, "SAILFIN_PE_IMPORT_CTX="
+        + import_context_root, "sh", driver_path]);
 
     process.run(["rm", "-f", driver_path]);
     process.run(["rm", "-f", worker_path]);
@@ -1276,7 +1301,7 @@ fn stage_capsule_imports(sources: CapsuleSource[], sailfin_exe: string, work_dir
     }
 
     if needs_emit.length > 0 {
-        let emit_ok = _cr_run_parallel_emit(needs_emit, "native", sailfin_exe, jobs);
+        let emit_ok = _cr_run_parallel_emit(needs_emit, "native", sailfin_exe, jobs, "");
         if !emit_ok {
             print.err("capsule-resolver: one or more parallel stage emits failed");
             return false;
@@ -1451,6 +1476,57 @@ fn _cr_collect_per_source_dep_manifests(sources: CapsuleSource[], work_dir: stri
     return out;
 }
 
+// #957: map each `<root>/<slug>.layout-manifest` path to the sibling
+// `<root>/<slug>.sfn-asm` the effect-import loader reads. The two are
+// staged together by `stage_capsule_imports`, so a suffix swap yields
+// the dependency's staged native-IR artifact without re-resolving the
+// capsule graph.
+fn _cr_manifests_to_asm_paths(manifests: string[]) -> string[] {
+    let mut out: string[] = [];
+    let suffix = ".layout-manifest";
+    let mut i: int = 0;
+    loop {
+        if i >= manifests.length { break; }
+        let m = manifests[i];
+        if _cr_ends_with(m, suffix) {
+            out.push(substring(m, 0, m.length - suffix.length) + ".sfn-asm");
+        }
+        i += 1;
+    }
+    return out;
+}
+
+// #957: stage a per-module `.import-deps` sidecar (one direct-import
+// `.sfn-asm` path per line) under the import-context root. The
+// `<sailfin> emit --import-context <root>` subprocess reads
+// `<root>/<slug>.import-deps` to load the cross-module effect table,
+// so callee-effect transitivity (`E0402`) is enforced on the build
+// path — the in-process compile path passes the same paths directly.
+// Direct imports suffice: an imported callee's `.sfn-asm` already
+// carries the (transitively-complete) effects its own signature
+// declares, and `localize_import_symbols_for_program` scopes the
+// loaded table to this program's import declarations.
+fn _cr_stage_import_deps(sources: CapsuleSource[], work_dir: string) -> void ![io] {
+    let context_root = _cr_import_context_root(work_dir);
+    let mut i: int = 0;
+    loop {
+        if i >= sources.length { break; }
+        let dep_slugs = _cr_direct_import_slugs_for(sources[i], sources);
+        let mut content: string = "";
+        let mut j: int = 0;
+        loop {
+            if j >= dep_slugs.length { break; }
+            content = content + context_root + "/" + dep_slugs[j] + ".sfn-asm"
+                + "\n";
+            j += 1;
+        }
+        let deps_path = context_root + "/" + sources[i].slug + ".import-deps";
+        _cr_ensure_dir(_cr_dirname(deps_path));
+        fs.writeFile(deps_path, content);
+        i += 1;
+    }
+}
+
 // One module's cache outcome. Returned from `_cr_compile_one` so
 // the caller (`compile_capsule_modules`) can fold per-module
 // outcomes into the per-build `CacheStats` struct without needing
@@ -1522,6 +1598,9 @@ fn _cr_compile_one(src: CapsuleSource, dep_manifests: string[], cache_root_path:
     }
     let ll_dir = _cr_dirname(src.ll_path);
     _cr_ensure_dir(ll_dir);
+    // #957: import-context root carries the cross-module effect table
+    // into the emit subprocess (which reads `<root>/<slug>.import-deps`).
+    let context_root = _cr_import_context_root(work_dir);
 
     // Cache lookup. Suffix the slug-derived name to keep
     // `_sha256_of_string`'s tmp paths unique across the dep-list
@@ -1589,7 +1668,7 @@ fn _cr_compile_one(src: CapsuleSource, dep_manifests: string[], cache_root_path:
             if ok { break; }
             if attempt >= max_attempts { break; }
             attempt += 1;
-            let rc = process.run([sailfin_exe, "emit", "--module-name", src.slug, "-o", src.ll_path, "llvm", src.source_path]);
+            let rc = process.run([sailfin_exe, "emit", "--module-name", src.slug, "-o", src.ll_path, "--import-context", context_root, "llvm", src.source_path]);
             if rc != 0 {
                 if config.trace {
                     print.err("[emit retry] " + src.slug + " attempt "
@@ -1666,7 +1745,11 @@ fn _cr_compile_one(src: CapsuleSource, dep_manifests: string[], cache_root_path:
         }
     } else {
         let source = fs.readFile(src.source_path);
-        ok = compile_to_llvm_file_with_module(source, src.slug, src.ll_path, work_dir);
+        // #957: in-process path enforces the same cross-module effects
+        // as the subprocess path, using the direct-import `.sfn-asm`
+        // derived from this module's dep manifests.
+        let import_asm_paths = _cr_manifests_to_asm_paths(dep_manifests);
+        ok = compile_to_llvm_file_with_module_imports(source, src.slug, src.ll_path, work_dir, import_asm_paths);
     }
     if !ok {
         print.err("capsule-resolver: failed to lower " + src.slug
@@ -1729,6 +1812,11 @@ fn compile_capsule_modules(sources: CapsuleSource[], config: BuildCacheConfig, s
     // total is dominated by the per-module compile path the cache
     // would otherwise trigger.
     let per_source_dep_manifests = _cr_collect_per_source_dep_manifests(sources, work_dir);
+    // #957: stage the per-module `.import-deps` sidecars the
+    // `emit --import-context` subprocess reads to enforce cross-module
+    // effect transitivity on the build path. Written before any
+    // (serial or parallel) emit so every worker sees its sidecar.
+    _cr_stage_import_deps(sources, work_dir);
     let cache_root_path = cache_root();
     if config.clean {
         // `--clean` is a destructive opt-in. If the wipe fails
@@ -1869,7 +1957,7 @@ fn compile_capsule_modules(sources: CapsuleSource[], config: BuildCacheConfig, s
 
         // Pass 2: parallel emit for misses.
         if needs_emit.length > 0 {
-            let emit_ok = _cr_run_parallel_emit(needs_emit, "llvm", sailfin_exe, jobs);
+            let emit_ok = _cr_run_parallel_emit(needs_emit, "llvm", sailfin_exe, jobs, _cr_import_context_root(work_dir));
             if !emit_ok {
                 print.err("capsule-resolver: one or more parallel module emits failed");
                 return CompileCapsuleResult {

--- a/compiler/src/cli_main.sfn
+++ b/compiler/src/cli_main.sfn
@@ -66,6 +66,7 @@ import {
 } from "./cli_commands_utils";
 import {
     compile_to_llvm_file_with_module,
+    compile_to_llvm_file_with_module_imports,
     compile_to_llvm_with_module,
     compile_to_llvm_with_module_timed,
     compile_to_native_text_with_module,
@@ -144,7 +145,7 @@ fn _usage() -> string {
     out = out
         + "  sfn run   [--no-cache] [--clean] [--cache-trace] (<file.sfn> | <exe>)\n";
     out = out
-        + "  sfn emit  [--timing] [-o OUTPUT] [--module-name SLUG] llvm|sailfin|native <file.sfn>\n";
+        + "  sfn emit  [--timing] [-o OUTPUT] [--module-name SLUG] [--import-context DIR] llvm|sailfin|native <file.sfn>\n";
     out = out + "\n";
     out = out + "project:\n";
     out = out + "  sfn init\n";
@@ -463,6 +464,30 @@ fn _find_substring_from(haystack: string, needle: string, from: int) -> int {
         i += 1;
     }
     return -1;
+}
+
+// #957: read a module's `.import-deps` sidecar (one staged
+// `.sfn-asm` path per line, written by the resolver's
+// `_cr_stage_import_deps`) and return the non-empty paths. A missing
+// sidecar (module with no imports, or an out-of-band emit) yields an
+// empty list, which degrades the effect gate to in-module-only.
+fn _read_import_deps(context_root: string, slug: string) -> string[] ![io] {
+    let mut out: string[] = [];
+    let deps_path = context_root + "/" + slug + ".import-deps";
+    if !fs.exists(deps_path) { return out; }
+    let content = fs.readFile(deps_path);
+    let mut pos: int = 0;
+    loop {
+        if pos >= content.length { break; }
+        let nl = _find_substring_from(content, "\n", pos);
+        let mut end = content.length;
+        if nl >= 0 { end = nl; }
+        let line = substring(content, pos, end);
+        if line.length > 0 { out.push(line); }
+        if nl < 0 { break; }
+        pos = nl + 1;
+    }
+    return out;
 }
 
 // Derive pass 2's work-dir from pass 1's. A sibling directory
@@ -1451,6 +1476,12 @@ fn sailfin_cli_main(argv: string[]) -> int ![io, clock] {
         // `module_name_from_path(path)` so all existing call sites
         // (humans + tests + build.sh) keep their current shape.
         let mut module_name_override: string = "";
+        // #957: root of the staged import-context tree
+        // (`build/native/import-context`). When set, the llvm-emit
+        // path reads `<root>/<module-name>.import-deps` to load the
+        // cross-module effect table so callee-effect transitivity
+        // (`E0402`) is enforced on the build path.
+        let mut import_context_root: string = "";
         let mut base_index = 1;
         // Parse optional flags: --timing, --module-name <slug>, and
         // -o <path> in any order.
@@ -1487,6 +1518,17 @@ fn sailfin_cli_main(argv: string[]) -> int ![io, clock] {
                 consumed_flag = true;
                 continue;
             }
+            if strings_equal(args[base_index], "--import-context") {
+                base_index += 1;
+                if base_index >= args.length {
+                    print(_usage());
+                    return 2;
+                }
+                import_context_root = args[base_index];
+                base_index += 1;
+                consumed_flag = true;
+                continue;
+            }
         }
         let _expected_args = base_index + 2;
         if args.length != _expected_args {
@@ -1514,8 +1556,14 @@ fn sailfin_cli_main(argv: string[]) -> int ![io, clock] {
                     let llvm = compile_to_llvm_with_module_timed(source, module_name);
                     _write_llvm_text(out_path, llvm);
                 } else {
-                    let ok = compile_to_llvm_file_with_module(source, module_name, out_path, "");
-                    if !ok { return 1; }
+                    if import_context_root.length > 0 {
+                        let import_asm_paths = _read_import_deps(import_context_root, module_name);
+                        let ok = compile_to_llvm_file_with_module_imports(source, module_name, out_path, "", import_asm_paths);
+                        if !ok { return 1; }
+                    } else {
+                        let ok = compile_to_llvm_file_with_module(source, module_name, out_path, "");
+                        if !ok { return 1; }
+                    }
                 }
             } else {
                 if timing {

--- a/compiler/src/main.sfn
+++ b/compiler/src/main.sfn
@@ -45,6 +45,7 @@ import {
     typecheck_has_errors,
     typecheck_has_errors_with_prelude
 } from "./typecheck";
+import { load_imported_interfaces_from_paths } from "./typecheck_import_loader";
 
 fn _ms_since(start_ms: int) -> int {
     let end_ms = monotonic_millis();
@@ -532,6 +533,24 @@ fn write_native_text_file_with_module(source: string, module_name: string, out_p
 // pipeline — no intra-call IPC file between emit and lower, so the function
 // is safe to invoke from parallel workers.
 fn compile_to_llvm_file_with_module(source: string, module_name: string, out_path: string, work_dir: string) -> boolean ![io] {
+    // Empty import set → legacy in-module-only effect gate. Callers
+    // with cross-module import context use
+    // `compile_to_llvm_file_with_module_imports` (#957).
+    let no_imports: string[] = [];
+    return compile_to_llvm_file_with_module_imports(source, module_name, out_path, work_dir, no_imports);
+}
+
+// Phase E build-path enforcement (#957). Identical to
+// `compile_to_llvm_file_with_module` but threads the cross-module
+// import-effect table loaded from `import_asm_paths` — the staged
+// `.sfn-asm` of this module's direct imports — into the effect gate,
+// so callee-effect transitivity (`E0402`) is enforced during
+// `make compile` / `make check`, not just under `sailfin check`.
+// Empty `import_asm_paths` degrades to the legacy empty-table
+// (in-module-only) behavior, so the historical empty-table callers
+// (`compile_to_llvm_with_module_timed`, ad-hoc `sailfin emit llvm
+// <file>` with no `--import-context`) are unaffected.
+fn compile_to_llvm_file_with_module_imports(source: string, module_name: string, out_path: string, work_dir: string, import_asm_paths: string[]) -> boolean ![io] {
     let program: Program = parse_program(source);
     let prelude_globals = load_prelude_global_names(runtime_helper_call_names());
     let mut skip_typecheck_probe: string = "build/sailfin/.skip_typecheck";
@@ -550,7 +569,12 @@ fn compile_to_llvm_file_with_module(source: string, module_name: string, out_pat
         print.err("emit-llvm-file: skipping typecheck (SAILFIN_SKIP_TYPECHECK set, or legacy build/sailfin/.skip_typecheck file present)");
     }
     if _reject_reexport_violations(program) { return false; }
-    if validate_and_render_effects(program, source, module_name, empty_import_symbols()) > 0 {
+    let mut imports = empty_import_symbols();
+    if import_asm_paths.length > 0 {
+        let loaded = load_imported_interfaces_from_paths(import_asm_paths);
+        imports = loaded.function_effects;
+    }
+    if validate_and_render_effects(program, source, module_name, imports) > 0 {
         return false;
     }
 

--- a/compiler/tests/e2e/test_effect_gate_build_path.sh
+++ b/compiler/tests/e2e/test_effect_gate_build_path.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# End-to-end test for #957: cross-module effect transitivity (E0402)
+# must be enforced on the BUILD PATH (`sailfin emit ... llvm`), not just
+# under `sailfin check`.
+#
+# Before #957, `compile_to_llvm_file_with_module` ran the effect gate
+# with an empty import table, so a module function that calls an
+# imported `![io]` helper without declaring `![io]` compiled clean
+# during `make compile` / `make check`. #957 adds an `--import-context`
+# flag: the emit subprocess loads the staged `.sfn-asm` effect table
+# from `<root>/<module-name>.import-deps` and enforces the same E0402
+# the resolver-driven `sailfin check` already catches.
+#
+# This drives the emit subprocess directly with a hand-staged
+# import-context, mirroring what `_cr_compile_one` /
+# `_cr_run_parallel_emit` do during the self-host build. The
+# import-context is staged at the default cwd-relative layout
+# (`build/native/import-context/<slug>.sfn-asm`) so the LLVM lowering's
+# own signature resolution (`collect_imported_module_context_for_module`,
+# entrypoints.sfn) can resolve the imported callee's return type — the
+# effect gate is the only consumer #957 newly wires.
+#
+# Fixtures (under a throwaway cwd):
+#   dep.sfn      — exports `do_io() ![io]`.
+#   caller_bad   — `import { do_io }; fn run() { do_io(); }` (under-declared).
+#   caller_good  — same, but `fn run() ![io]` (correctly declared).
+#
+# Assertions:
+#   - emit llvm caller_bad WITH    --import-context  → fails with E0402.
+#   - emit llvm caller_bad WITHOUT --import-context  → succeeds (proves
+#     the flag is what enables cross-module enforcement; the empty-table
+#     legacy path stays in-module-only).
+#   - emit llvm caller_good WITH    --import-context → succeeds.
+#
+# Usage:
+#   compiler/tests/e2e/test_effect_gate_build_path.sh <compiler-binary>
+
+set -euo pipefail
+
+BINARY="${1:?usage: test_effect_gate_build_path.sh <compiler-binary>}"
+BINARY="$(realpath "$BINARY")"
+PASS=0
+FAIL=0
+
+SCRATCH="$(mktemp -d -t sfn-effect-build-path-XXXXXX)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+# The lowering resolves imported callee signatures from the default
+# cwd-relative import-context root, so run everything from $SCRATCH and
+# stage there.
+cd "$SCRATCH"
+CTX="build/native/import-context"
+mkdir -p "$CTX"
+
+run_test() {
+    local name="$1"
+    shift
+    if "$@"; then
+        echo "[test] PASS: $name"
+        PASS=$((PASS + 1))
+    else
+        echo "[test] FAIL: $name"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# ---- Setup: dependency that genuinely performs IO ----
+cat > "$SCRATCH/dep.sfn" <<'EOF'
+fn do_io() ![io] {
+    print.info("side effect");
+}
+
+export { do_io };
+EOF
+
+# Under-declared caller: calls the imported ![io] helper without
+# declaring ![io] itself.
+cat > "$SCRATCH/caller_bad.sfn" <<'EOF'
+import { do_io } from "./dep";
+
+fn run() {
+    do_io();
+}
+
+export { run };
+EOF
+
+# Correctly-declared caller: propagates ![io].
+cat > "$SCRATCH/caller_good.sfn" <<'EOF'
+import { do_io } from "./dep";
+
+fn run() ![io] {
+    do_io();
+}
+
+export { run };
+EOF
+
+# Stage the dependency's `.sfn-asm` (its top-level function-effect
+# surface) into the import-context, exactly as `stage_capsule_imports`
+# does during the build.
+stage_dep() {
+    "$BINARY" emit --module-name dep -o "$CTX/dep.sfn-asm" native "$SCRATCH/dep.sfn" \
+        > stage.stdout 2> stage.stderr
+    test -s "$CTX/dep.sfn-asm"
+}
+run_test "stage dep.sfn-asm into import-context" stage_dep
+
+# Write the per-module `.import-deps` sidecar the emit subprocess reads
+# for `--module-name caller` (what `_cr_stage_import_deps` writes).
+printf '%s\n' "$CTX/dep.sfn-asm" > "$CTX/caller.import-deps"
+
+# ---- Test: under-declared caller fails WITH --import-context ----
+test_bad_with_context_fails() {
+    local rc=0
+    if "$BINARY" emit --module-name caller --import-context "$CTX" \
+        -o bad.ll llvm "$SCRATCH/caller_bad.sfn" \
+        > bad.stdout 2> bad.stderr; then
+        rc=0
+    else
+        rc=$?
+    fi
+    if [ "$rc" -eq 0 ]; then
+        echo "[test]   expected non-zero exit (E0402), got 0" >&2
+        cat bad.stderr >&2
+        return 1
+    fi
+    if ! grep -q "E0402" bad.stderr; then
+        echo "[test]   expected E0402 in stderr; full stderr:" >&2
+        cat bad.stderr >&2
+        return 1
+    fi
+    return 0
+}
+run_test "build path rejects under-declared ![io] (E0402) with --import-context" test_bad_with_context_fails
+
+# ---- Negative control: WITHOUT --import-context, the same input
+#      compiles clean (empty-table legacy path = in-module only). This
+#      proves the flag is what activates cross-module enforcement. ----
+test_bad_without_context_passes() {
+    local rc=0
+    if "$BINARY" emit --module-name caller \
+        -o bad_nocxt.ll llvm "$SCRATCH/caller_bad.sfn" \
+        > bad_nocxt.stdout 2> bad_nocxt.stderr; then
+        rc=0
+    else
+        rc=$?
+    fi
+    if [ "$rc" -ne 0 ]; then
+        echo "[test]   expected exit 0 without --import-context, got $rc" >&2
+        cat bad_nocxt.stderr >&2
+        return 1
+    fi
+    if grep -q "E0402" bad_nocxt.stderr; then
+        echo "[test]   unexpected E0402 without --import-context; stderr:" >&2
+        cat bad_nocxt.stderr >&2
+        return 1
+    fi
+    return 0
+}
+run_test "build path stays in-module-only without --import-context (control)" test_bad_without_context_passes
+
+# ---- Positive control: correctly-declared caller compiles clean. ----
+test_good_with_context_passes() {
+    local rc=0
+    if "$BINARY" emit --module-name caller --import-context "$CTX" \
+        -o good.ll llvm "$SCRATCH/caller_good.sfn" \
+        > good.stdout 2> good.stderr; then
+        rc=0
+    else
+        rc=$?
+    fi
+    if [ "$rc" -ne 0 ]; then
+        echo "[test]   expected exit 0 for correctly-declared caller, got $rc" >&2
+        cat good.stderr >&2
+        return 1
+    fi
+    return 0
+}
+run_test "build path accepts correctly-declared ![io] with --import-context" test_good_with_context_passes
+
+# ---- Summary ----
+echo ""
+echo "[test] $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/docs/proposals/effect-validation.md
+++ b/docs/proposals/effect-validation.md
@@ -12,8 +12,10 @@ Effect validation is Sailfin's flagship safety guarantee — the compile-time
 proof that a function declares every capability it actually uses. Today the
 checker (`compiler/src/effect_checker.sfn`) exists and is wired into
 `sfn check` from `check_source_with_imports` in
-`compiler/src/tools/check.sfn`. **It is not wired into the build path**:
-`make compile`, `sfn build`, `sfn run`, and `sfn test` all bypass it.
+`compiler/src/tools/check.sfn`. **(Historical framing — see the status
+banner below; as of #957 the build path enforces effects too.)** When
+this proposal was written it was not wired into the build path:
+`make compile`, `sfn build`, `sfn run`, and `sfn test` all bypassed it.
 Roughly 8% of compiler functions carry `![effect]` annotations; the
 remaining 92% have never been audited because no compile run has ever
 forced them to be. This proposal lays out a seven-phase migration that
@@ -24,6 +26,23 @@ plus capability cross-checking against `capsule.toml`. Phase G (effect
 polymorphism + name-resolution-driven detection) is post-1.0.
 
 ## Implementation Status
+
+> **Status banner (updated 2026-06-02).** The "What exists today" /
+> "What does not exist" snapshot below is the *original pre-migration*
+> framing and is retained for historical context. Phases A–F have since
+> shipped (see `docs/status.md` → Effect system). In particular: effect
+> enforcement is a hard build gate (Phase D), cross-module `E0402`
+> propagation is live (Phase E), and capability cross-check `E0403` is
+> live (Phase F). **#957** closed the last build-path gap: the codegen
+> path (`compile_to_llvm_file_with_module`) previously ran the gate with
+> an empty import table, so cross-module `E0402` was inert during
+> `make compile` / `make check`; it now loads the real per-module
+> import-effect table (via the resolver's `<slug>.import-deps` sidecar +
+> the `sailfin emit --import-context <root>` flag) and enforces the same
+> violations `sfn check` does. No seed bump was required (the released
+> seed never runs the new gate; enforcement first fires in the
+> firstpass→seedcheck build). The §2.1 / §2.6 problem statements below
+> are therefore **resolved**.
 
 **What exists today:**
 
@@ -206,6 +225,11 @@ on a single `Program` AST.
 
 ### 2.1 The build path bypasses effect validation
 
+> **Resolved (Phase D + #957).** Effect enforcement is a hard build gate
+> as of Phase D, and #957 wired the cross-module table into the codegen
+> path so `E0402` is enforced during `make compile` / `make check`, not
+> just `sfn check`. The original problem statement follows.
+
 The most consequential problem. Every production usage of the compiler —
 `sfn build`, `sfn run`, `sfn test`, `make compile`, CI selfhost — produces
 artifacts that have not been effect-checked. Effect violations land only in
@@ -290,6 +314,10 @@ not contract. Differentiator #2 (capability-based security) requires this
 gap to close.
 
 ### 2.6 No cross-module effect propagation
+
+> **Resolved (Phase E + #957).** Cross-module propagation ships as
+> Phase E (`E0402`), and #957 made it live on the codegen build path in
+> addition to `sfn check`. The original problem statement follows.
 
 Even if function `A` in capsule `foo` declares `![net]`, a caller `B` in
 capsule `bar` that imports and calls `A` is not required to declare `![net]`.

--- a/docs/status.md
+++ b/docs/status.md
@@ -621,6 +621,25 @@ feature availability.
   entry's effects. E1 covers direct `Identifier` callees;
   `Member`-callee resolution (`mod.fn()`) and decorator-implied
   transitives are deferred to a follow-up Phase E2.
+
+  **Build-path enforcement (#957, shipped 2026-06-02).** Phase E was
+  initially live only on the `sfn check` and test-compile paths; the
+  codegen build path (`compile_to_llvm_file_with_module`, driven by the
+  resolver's per-module `sailfin emit ... llvm` subprocess) ran the gate
+  with `empty_import_symbols()`, so cross-module `E0402` was inert
+  during `make compile` / `make check` — a compiler-source function
+  could call an imported `![io]` helper without declaring `![io]` and
+  the build stayed green. `compile_to_llvm_file_with_module_imports`
+  now loads the real import-effect table for each module: the resolver
+  stages a per-module `<slug>.import-deps` sidecar (the module's direct
+  imports' staged `.sfn-asm`) under the import-context root and passes
+  `--import-context <root>` to the emit subprocess, which reads its
+  sidecar and feeds the table to `validate_and_render_effects`. The
+  in-process resolver fallback threads the same paths directly. The
+  first pass to enforce is the firstpass→seedcheck build (the released
+  seed never runs the new gate, so no seed bump was required); the
+  compiler tree is clean under this enforcement as of #956/#961.
+  Regression-guarded by `compiler/tests/e2e/test_effect_gate_build_path.sh`.
 - **Capsule capability cross-check (Phase F — shipped 2026-04-26).**
   The capsule manifest's `[capabilities] required = [...]` list is
   now a real compile-time contract. Any function declaring an


### PR DESCRIPTION
## Summary

- The codegen build path ran the effect gate with an **empty import table** (`compile_to_llvm_file_with_module` → `validate_and_render_effects(..., empty_import_symbols())`), so Phase E cross-module callee-effect propagation (`E0402`) was **inert** during `make compile` / `make check`. A compiler-source function could call an imported `[io]` helper without declaring `[io]` and the build stayed green.
- This wires the **real per-module import-effect table** into the build path (Strategy 1 from the issue), so the build enforces the same `E0402` that `sailfin check` already does.

Closes #957

## Design (architect-approved, Strategy 1 only)

- **`main.sfn`** — new `compile_to_llvm_file_with_module_imports` loads the cross-module effect table from the staged dependency `.sfn-asm` and feeds it to the gate; the existing entrypoint delegates with an empty set (legacy empty-table callers unchanged).
- **`capsule_resolver.sfn`** — stage a per-module `<slug>.import-deps` sidecar (direct-import `.sfn-asm`, derived from the dep manifests already computed for the cache key) and pass `--import-context <root>` to the emit subprocess on **both** the serial (`_cr_compile_one`) and **parallel** (`_cr_run_parallel_emit`) paths; the in-process fallback threads the paths directly.
- **`cli_main.sfn`** — parse `--import-context`, read the module's sidecar, route the llvm emit through the imports-aware compile.

Direct imports suffice: a callee's `.sfn-asm` carries its transitively-complete declared effects, and `localize_import_symbols_for_program` scopes the loaded table to the program's import declarations.

**No seed bump required** — the released seed never runs the new gate, so enforcement first fires in the firstpass→seedcheck build against the already-annotated tree (#956/#961).

## Acceptance criteria

- [x] A compiler-source function that calls an `[io]` callee without declaring `[io]` is rejected on the **build path** (`sailfin emit ... llvm --import-context`), not just `sailfin check` — proven by the new e2e test.
- [x] Regression coverage for the gate — `compiler/tests/e2e/test_effect_gate_build_path.sh` (4/4). The checker contract is already unit-covered by `effect_imports_test.sfn`.
- [x] The clean tree passes under build-path enforcement — the new firstpass binary compiles **all 164 compiler modules with zero effect rejections**; 145 non-empty sidecars confirm the tables are non-inert.
- [x] Documented in `docs/status.md` (Phase E build-path enforcement note) + `docs/proposals/effect-validation.md` (§2.1 / §2.6 marked resolved, status banner).

## Verification

```text
# e2e gate test (against the new binary)
$ bash compiler/tests/e2e/test_effect_gate_build_path.sh build/native/sailfin
[test] PASS: stage dep.sfn-asm into import-context
[test] PASS: build path rejects under-declared [io] (E0402) with --import-context
[test] PASS: build path stays in-module-only without --import-context (control)
[test] PASS: build path accepts correctly-declared [io] with --import-context
[test] 4 passed, 0 failed

# enforced self-host build (new binary builds the compiler, --no-cache)
#   → all 164 module emits succeed, ZERO E0402/E0400/E0403 (clean tree passes)
#   → 145 non-empty <slug>.import-deps sidecars written

$ make compile         # seed→firstpass: PASS
$ sfn fmt --check compiler/src/{main,cli_main,capsule_resolver}.sfn   # clean
```

## ⚠️ Pre-existing blocker (out of scope, not introduced here)

Full `make check` cannot go green in this environment because of an **unrelated, pre-existing** runtime bug: the runtime prelude fails its terminal clang link with

```
error: invalid redefinition of function 'sfn_array_sfn_map'
  declare i8* @sfn_array_sfn_map(i8*, i8*)
```

`sfn_array_sfn_map` is a Sailfin-native runtime fn (`runtime/sfn/array.sfn:165`) also emitted as a `declare` (`runtime_helpers.sfn:714`), missing the self-defined-runtime-fn declare-skip — the same class as the documented type_meta fix. **This reproduces with the unmodified pinned seed binary**, so it is independent of this change; it breaks `make check`'s early test gate before the seedcheck build is reached. The enforced seedcheck build here got all the way through every Sailfin module emit and only failed at that runtime link. Recommend tracking/fixing separately.

## Files changed

- `compiler/src/main.sfn`, `compiler/src/cli_main.sfn`, `compiler/src/capsule_resolver.sfn`
- `compiler/tests/e2e/test_effect_gate_build_path.sh` (new)
- `docs/status.md`, `docs/proposals/effect-validation.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xtbt742jWWjCPcgdKNqKV8)_