### PR TITLE
fix(effects): enforce sibling→entry effects on the -p build path (#984)

### DIFF
--- a/compiler/src/capsule_resolver.sfn
+++ b/compiler/src/capsule_resolver.sfn
@@ -1506,12 +1506,21 @@ fn _cr_manifests_to_asm_paths(manifests: string[]) -> string[] {
 // carries the (transitively-complete) effects its own signature
 // declares, and `localize_import_symbols_for_program` scopes the
 // loaded table to this program's import declarations.
-fn _cr_stage_import_deps(sources: CapsuleSource[], work_dir: string) -> void ![io] {
+//
+// #984: slug resolution runs against `universe`, not `sources`. On
+// `-p` (`walk_project_src`) builds the entry module is staged but
+// excluded from `sources` (its `.ll` is produced separately), so an
+// import of the entry would resolve to no slug and the sibling's
+// sidecar would omit the entry's `.sfn-asm` — leaving `sibling→entry`
+// effects unenforced on the build path. `universe` re-adds the staged
+// entry for resolution while sidecars are still written only for
+// `sources` (the modules `compile_capsule_modules` actually emits).
+fn _cr_stage_import_deps(sources: CapsuleSource[], universe: CapsuleSource[], work_dir: string) -> void ![io] {
     let context_root = _cr_import_context_root(work_dir);
     let mut i: int = 0;
     loop {
         if i >= sources.length { break; }
-        let dep_slugs = _cr_direct_import_slugs_for(sources[i], sources);
+        let dep_slugs = _cr_direct_import_slugs_for(sources[i], universe);
         let mut content: string = "";
         let mut j: int = 0;
         loop {
@@ -1799,7 +1808,7 @@ fn _cr_compile_one(src: CapsuleSource, dep_manifests: string[], cache_root_path:
 // env-driven behaviour. Honours `config.clean` by wiping the cache
 // root before any per-module work — done once per build, not per
 // module, so a single `--clean` run can't double-wipe.
-fn compile_capsule_modules(sources: CapsuleSource[], config: BuildCacheConfig, sailfin_exe: string, work_dir: string) -> CompileCapsuleResult ![io] {
+fn compile_capsule_modules(sources: CapsuleSource[], slug_universe_extra: CapsuleSource[], config: BuildCacheConfig, sailfin_exe: string, work_dir: string) -> CompileCapsuleResult ![io] {
     let scratch_root = _cr_scratch_root();
     _cr_ensure_dir(scratch_root);
     _cr_ensure_dir(scratch_root + "/capsules");
@@ -1816,7 +1825,24 @@ fn compile_capsule_modules(sources: CapsuleSource[], config: BuildCacheConfig, s
     // `emit --import-context` subprocess reads to enforce cross-module
     // effect transitivity on the build path. Written before any
     // (serial or parallel) emit so every worker sees its sidecar.
-    _cr_stage_import_deps(sources, work_dir);
+    // #984: resolve slugs against `sources ++ slug_universe_extra` so a
+    // `-p` build's staged-but-excluded entry module is visible to
+    // sibling import resolution (sidecars are still written only for
+    // `sources`). `slug_universe_extra` is `[]` for non-`-p` paths.
+    let mut slug_universe: CapsuleSource[] = [];
+    let mut _su: int = 0;
+    loop {
+        if _su >= sources.length { break; }
+        slug_universe.push(sources[_su]);
+        _su += 1;
+    }
+    let mut _ue: int = 0;
+    loop {
+        if _ue >= slug_universe_extra.length { break; }
+        slug_universe.push(slug_universe_extra[_ue]);
+        _ue += 1;
+    }
+    _cr_stage_import_deps(sources, slug_universe, work_dir);
     let cache_root_path = cache_root();
     if config.clean {
         // `--clean` is a destructive opt-in. If the wipe fails
@@ -3809,6 +3835,13 @@ fn prepare_project_capsules(input_path: string, config: BuildCacheConfig, consum
     // / etc. from `main.sfn`. Staging the entry separately keeps
     // the entry out of `compile_capsule_modules` (no double-
     // emit) while making its import-context available.
+    // #984: the staged entry doubles as the extra slug universe for
+    // `.import-deps` resolution, so siblings that import the entry get
+    // its `.sfn-asm` listed in their sidecar and `sibling→entry`
+    // effects are enforced on the build path. `[]` when the entry isn't
+    // walk-excluded (non-`-p` builds resolve the entry as a normal
+    // source already).
+    let mut slug_universe_extra: CapsuleSource[] = [];
     if consumer.walk_project_src {
         let entry_path = entry_paths[0];
         if fs.exists(entry_path) {
@@ -3828,10 +3861,11 @@ fn prepare_project_capsules(input_path: string, config: BuildCacheConfig, consum
                     runtime_capsules: runtime_capsules
                 };
             }
+            slug_universe_extra = entry_src;
         }
     }
 
-    let result = compile_capsule_modules(resolved.sources, config, sailfin_exe, work_dir);
+    let result = compile_capsule_modules(resolved.sources, slug_universe_extra, config, sailfin_exe, work_dir);
     if !result.success {
         return ProjectCapsuleResult {
             ll_paths: empty_paths,
@@ -4013,7 +4047,10 @@ fn prepare_project_capsules_for_test(entry_paths: string[], consumer: ResolverCo
     // env-driven default. When the test runner grows `--no-cache`
     // / `--clean`, thread the resolved config in here.
     let test_config = empty_build_cache_config();
-    let result = compile_capsule_modules(resolved.sources, test_config, sailfin_exe, work_dir);
+    // #984: `sfn test` resolves the entry as a normal source (no
+    // walk-exclusion), so there is no extra slug universe to thread.
+    let test_slug_universe_extra: CapsuleSource[] = [];
+    let result = compile_capsule_modules(resolved.sources, test_slug_universe_extra, test_config, sailfin_exe, work_dir);
     // Surface a compile failure as `staging_failed = true` so the
     // test runner exits 2 instead of trying to link against
     // missing helper objects. (The PR1c stats are dropped on this

--- a/compiler/src/capsule_resolver.sfn
+++ b/compiler/src/capsule_resolver.sfn
@@ -1456,13 +1456,19 @@ fn _cr_direct_import_slugs_for(src: CapsuleSource, sources: CapsuleSource[]) -> 
 // For each source, compute the manifest paths of its direct imports.
 // Result is a parallel array — index i is the dep manifest list for
 // `sources[i]`.
-fn _cr_collect_per_source_dep_manifests(sources: CapsuleSource[], work_dir: string) -> string[][] ![io] {
+//
+// #984: slug resolution runs against `universe` (= `sources ++`
+// the staged `-p` entry), not `sources`, so a sibling's direct import
+// of the walk-excluded entry contributes the entry's `.layout-manifest`
+// to its dep list — feeding both the cache key and the in-process
+// enforcement fallback. Manifests are still emitted only for `sources`.
+fn _cr_collect_per_source_dep_manifests(sources: CapsuleSource[], universe: CapsuleSource[], work_dir: string) -> string[][] ![io] {
     let context_root = _cr_import_context_root(work_dir);
     let mut out: string[][] = [];
     let mut i: int = 0;
     loop {
         if i >= sources.length { break; }
-        let dep_slugs = _cr_direct_import_slugs_for(sources[i], sources);
+        let dep_slugs = _cr_direct_import_slugs_for(sources[i], universe);
         let mut paths: string[] = [];
         let mut j: int = 0;
         loop {
@@ -1812,23 +1818,15 @@ fn compile_capsule_modules(sources: CapsuleSource[], slug_universe_extra: Capsul
     let scratch_root = _cr_scratch_root();
     _cr_ensure_dir(scratch_root);
     _cr_ensure_dir(scratch_root + "/capsules");
-    // Per-source dep manifests (PR1e): each `_cr_compile_one` call
-    // sees only the manifests of modules it directly imports, so an
-    // unrelated capsule changing busts only the modules that
-    // transitively import it. Result is a parallel array — index i
-    // is the manifest list for `sources[i]`. Cost is one read per
-    // source plus a few linear scans; for the typical N≈30-130 the
-    // total is dominated by the per-module compile path the cache
-    // would otherwise trigger.
-    let per_source_dep_manifests = _cr_collect_per_source_dep_manifests(sources, work_dir);
-    // #957: stage the per-module `.import-deps` sidecars the
-    // `emit --import-context` subprocess reads to enforce cross-module
-    // effect transitivity on the build path. Written before any
-    // (serial or parallel) emit so every worker sees its sidecar.
-    // #984: resolve slugs against `sources ++ slug_universe_extra` so a
-    // `-p` build's staged-but-excluded entry module is visible to
-    // sibling import resolution (sidecars are still written only for
-    // `sources`). `slug_universe_extra` is `[]` for non-`-p` paths.
+    // #984: resolve every per-source import against `sources ++
+    // slug_universe_extra` so a `-p` build's staged-but-excluded entry
+    // module is visible to sibling import resolution. Built once and
+    // shared by both the dep-manifest collection (cache key + in-process
+    // enforcement) and the `.import-deps` sidecar staging (subprocess
+    // enforcement). `slug_universe_extra` is `[]` for non-`-p` paths, so
+    // `slug_universe == sources` there. A fresh array is built (never
+    // aliasing `sources`) so the caller's `resolved.sources` is never
+    // mutated.
     let mut slug_universe: CapsuleSource[] = [];
     let mut _su: int = 0;
     loop {
@@ -1842,6 +1840,29 @@ fn compile_capsule_modules(sources: CapsuleSource[], slug_universe_extra: Capsul
         slug_universe.push(slug_universe_extra[_ue]);
         _ue += 1;
     }
+    // Per-source dep manifests (PR1e): each `_cr_compile_one` call
+    // sees only the manifests of modules it directly imports, so an
+    // unrelated capsule changing busts only the modules that
+    // transitively import it. Result is a parallel array — index i
+    // is the manifest list for `sources[i]`. Cost is one read per
+    // source plus a few linear scans; for the typical N≈30-130 the
+    // total is dominated by the per-module compile path the cache
+    // would otherwise trigger.
+    // #984: resolved against `slug_universe` (not `sources`) so a
+    // sibling's direct import of the `-p` entry contributes the entry's
+    // `.layout-manifest` to the cache key (entry changes bust dependent
+    // caches; a pre-fix `.ll` can't be reused without re-running the
+    // gate) and the in-process enforcement fallback
+    // (`_cr_manifests_to_asm_paths` → `compile_to_llvm_file_with_module_imports`)
+    // loads the entry's effect surface — matching the subprocess sidecar
+    // path below.
+    let per_source_dep_manifests = _cr_collect_per_source_dep_manifests(sources, slug_universe, work_dir);
+    // #957: stage the per-module `.import-deps` sidecars the
+    // `emit --import-context` subprocess reads to enforce cross-module
+    // effect transitivity on the build path. Written before any
+    // (serial or parallel) emit so every worker sees its sidecar.
+    // #984: sidecars are still written only for `sources`; only the slug
+    // resolution universe is widened.
     _cr_stage_import_deps(sources, slug_universe, work_dir);
     let cache_root_path = cache_root();
     if config.clean {

--- a/compiler/tests/e2e/test_effect_gate_build_path_entry.sh
+++ b/compiler/tests/e2e/test_effect_gate_build_path_entry.sh
@@ -45,7 +45,7 @@
 # Usage:
 #   compiler/tests/e2e/test_effect_gate_build_path_entry.sh <compiler-binary>
 
-set -uo pipefail
+set -euo pipefail
 
 BINARY="${1:?usage: test_effect_gate_build_path_entry.sh <compiler-binary>}"
 BINARY="$(realpath "$BINARY")"
@@ -124,8 +124,11 @@ test_sidecar_lists_entry() {
     write_sib " ![io]"
     "$BINARY" build -p . > "$SCRATCH/good.stdout" 2>&1 || true
 
+    # `|| true`: under `set -euo pipefail` a missing build/ makes `find`
+    # exit non-zero and pipefail would abort before the explicit empty
+    # check below can report a useful diagnostic.
     local sidecar
-    sidecar=$(find "$SCRATCH/build" -name '*sib*.import-deps' 2>/dev/null | head -n1)
+    sidecar=$(find "$SCRATCH/build" -name '*sib*.import-deps' 2>/dev/null | head -n1 || true)
     if [ -z "$sidecar" ]; then
         echo "[test]   no sibling .import-deps sidecar found under build/" >&2
         find "$SCRATCH/build" -name '*.import-deps' >&2 2>/dev/null || true

--- a/compiler/tests/e2e/test_effect_gate_build_path_entry.sh
+++ b/compiler/tests/e2e/test_effect_gate_build_path_entry.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# End-to-end test for #984: on `-p` (`walk_project_src`) builds the
+# entry module is staged but excluded from `resolved.sources`, so a
+# sibling that imports an `![io]` function FROM THE ENTRY must still get
+# the entry's `.sfn-asm` listed in its `.import-deps` sidecar and have
+# `sibling→entry` effects enforced on the build path (E0402) — the same
+# enforcement `sailfin check` already performs.
+#
+# Before #984, `_cr_stage_import_deps` resolved each source's import
+# slugs against `resolved.sources` ONLY, which excludes the `-p` entry.
+# An import of the entry resolved to no slug, the sibling's sidecar
+# omitted the entry's `.sfn-asm`, and an under-declared `sibling→entry`
+# call slipped past `make check`. #984 threads the staged entry into the
+# slug-resolution universe (`compile_capsule_modules`'
+# `slug_universe_extra`) so the sidecar lists the entry and the gate
+# fires.
+#
+# This drives the real resolver via `sfn build -p .` on a synthetic
+# binary capsule (mirroring `test_binary_capsule_walker.sh`), so the
+# entry-staging + sidecar-resolution path is exercised exactly as in the
+# compiler self-build.
+#
+# Fixtures (under a throwaway cwd):
+#   src/main.sfn      — entry; exports `do_io() ![io]` plus `main()`.
+#   src/util/sib.sfn  — sibling; imports `do_io` from the entry.
+#                       Rewritten between the good and bad runs.
+#
+# Assertions:
+#   - good sibling (`fn use_dep() ![io]`): the sibling's `.import-deps`
+#     sidecar lists the entry's `.sfn-asm` (proves the staging fix).
+#   - bad sibling (`fn use_dep()` — under-declared): `sfn build -p .`
+#     emits E0402 on the build path (proves cross-module enforcement of
+#     `sibling→entry` effects). Pre-fix, the same input instead produced
+#     a "cannot resolve return type" lowering fatal — the entry's
+#     `.sfn-asm` was never referenced — so asserting on E0402 cleanly
+#     distinguishes fixed from unfixed.
+#
+# Note: this fixture's `main()` does NOT call the sibling, so the `-p`
+# driver's module-drop leniency (a module whose emit fails is silently
+# dropped from the link, cli_main.sfn) keeps the overall exit code at 0
+# — we assert on the E0402 diagnostic, not the exit code. In the real
+# compiler self-build every module IS linked, so the same E0402 breaks
+# the link and genuinely fails `make check` (acceptance criterion 1).
+#
+# Usage:
+#   compiler/tests/e2e/test_effect_gate_build_path_entry.sh <compiler-binary>
+
+set -uo pipefail
+
+BINARY="${1:?usage: test_effect_gate_build_path_entry.sh <compiler-binary>}"
+BINARY="$(realpath "$BINARY")"
+PASS=0
+FAIL=0
+
+SCRATCH="$(mktemp -d -t sfn-effect-entry-XXXXXX)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+run_test() {
+    local name="$1"
+    shift
+    if "$@"; then
+        echo "[test] PASS: $name"
+        PASS=$((PASS + 1))
+    else
+        echo "[test] FAIL: $name"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+mkdir -p "$SCRATCH/src/util"
+
+cat > "$SCRATCH/capsule.toml" <<'EOF'
+[capsule]
+name = "effect-entry-test"
+version = "0.1.0"
+description = "E2E test for #984 sibling->entry build-path effect enforcement"
+
+[capabilities]
+required = ["io"]
+
+[build]
+kind = "binary"
+entry = "src/main.sfn"
+EOF
+
+# Entry module: exports an `![io]` helper that siblings import. The
+# `-p` walker excludes this file from `resolved.sources`; #984 re-adds
+# it to the slug-resolution universe so dependents can reference it.
+cat > "$SCRATCH/src/main.sfn" <<'EOF'
+fn do_io() ![io] {
+    print.info("entry side effect");
+}
+
+fn main() ![io] {
+    print.info("entry-fixture-ok");
+}
+
+export { do_io };
+EOF
+
+# Helper: write the sibling with the given effect annotation on the
+# function that calls the entry-exported `![io]` helper.
+write_sib() {
+    local effect_annot="$1"  # e.g. " ![io]" for the good case, "" for bad
+    cat > "$SCRATCH/src/util/sib.sfn" <<EOF
+import { do_io } from "../main";
+
+fn use_dep()${effect_annot} {
+    do_io();
+}
+
+export { use_dep };
+EOF
+}
+
+# ---- Test 1: good sibling — its sidecar lists the entry's .sfn-asm ----
+# This is the direct regression for the staging fix: before #984 the
+# entry import resolved to no slug, leaving the sidecar without the
+# entry reference. The sidecar is written before any emit, so it exists
+# regardless of how the rest of the build resolves.
+test_sidecar_lists_entry() {
+    cd "$SCRATCH" || return 1
+    rm -rf "$SCRATCH/build"
+    write_sib " ![io]"
+    "$BINARY" build -p . > "$SCRATCH/good.stdout" 2>&1 || true
+
+    local sidecar
+    sidecar=$(find "$SCRATCH/build" -name '*sib*.import-deps' 2>/dev/null | head -n1)
+    if [ -z "$sidecar" ]; then
+        echo "[test]   no sibling .import-deps sidecar found under build/" >&2
+        find "$SCRATCH/build" -name '*.import-deps' >&2 2>/dev/null || true
+        return 1
+    fi
+    # The entry slug ends in `main`; its staged artifact is `<...>main.sfn-asm`.
+    if ! grep -q 'main\.sfn-asm' "$sidecar"; then
+        echo "[test]   sibling sidecar does not reference the entry's .sfn-asm:" >&2
+        echo "[test]   sidecar=$sidecar" >&2
+        cat "$sidecar" >&2
+        return 1
+    fi
+    return 0
+}
+run_test "sibling .import-deps lists the -p entry's .sfn-asm" test_sidecar_lists_entry
+
+# ---- Test 2: under-declared sibling triggers E0402 on the build path ----
+test_bad_sibling_e0402() {
+    cd "$SCRATCH" || return 1
+    rm -rf "$SCRATCH/build"
+    write_sib ""  # use_dep() calls do_io() without declaring ![io]
+    "$BINARY" build -p . > "$SCRATCH/bad.stdout" 2>&1 || true
+    if ! grep -q "E0402" "$SCRATCH/bad.stdout"; then
+        echo "[test]   expected E0402 on the build path; full output:" >&2
+        cat "$SCRATCH/bad.stdout" >&2
+        return 1
+    fi
+    return 0
+}
+run_test "build path emits E0402 for under-declared sibling->entry ![io]" test_bad_sibling_e0402
+
+# ---- Summary ----
+echo ""
+echo "[test] $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/docs/status.md
+++ b/docs/status.md
@@ -640,6 +640,19 @@ feature availability.
   seed never runs the new gate, so no seed bump was required); the
   compiler tree is clean under this enforcement as of #956/#961.
   Regression-guarded by `compiler/tests/e2e/test_effect_gate_build_path.sh`.
+  **Entry-module gap closed (#984, 2026-06-02).** On `-p`
+  (`walk_project_src`) builds the entry module is staged but excluded
+  from `resolved.sources` (its `.ll` is produced separately), so
+  `_cr_stage_import_deps` resolved sibling import slugs against a
+  universe that omitted the entry — a `sibling→entry` import resolved
+  to no slug and the sidecar left out the entry's `.sfn-asm`, so
+  effects declared in the entry went unenforced cross-module on the
+  build path. `compile_capsule_modules` now takes a
+  `slug_universe_extra` (the staged entry on `-p` builds, `[]`
+  otherwise) and resolves sidecar slugs against `sources ++
+  slug_universe_extra` while still writing sidecars only for
+  `sources`. Regression-guarded by
+  `compiler/tests/e2e/test_effect_gate_build_path_entry.sh`.
 - **Capsule capability cross-check (Phase F — shipped 2026-04-26).**
   The capsule manifest's `[capabilities] required = [...]` list is
   now a real compile-time contract. Any function declaring an


### PR DESCRIPTION
## Summary
- Closes a **fail-open** gap in #957's build-path effect enforcement: on `-p` (`walk_project_src`) builds the entry module is staged but excluded from `resolved.sources`, so `_cr_stage_import_deps` resolved sibling import slugs against a universe that omitted the entry. A `sibling→entry` import resolved to no slug, the sidecar left out the entry's `.sfn-asm`, and effects declared in the entry went unenforced cross-module on the build path (E0402).
- `compile_capsule_modules` now takes a `slug_universe_extra: CapsuleSource[]` (the staged entry on `-p` builds, `[]` otherwise) and resolves sidecar slugs against `sources ++ slug_universe_extra`, while sidecars are still written only for `sources`. `prepare_project_capsules` feeds the staged entry as the extra universe; `prepare_project_capsules_for_test` passes `[]`.

Closes #984

## Acceptance Criteria
- [x] A sibling importing an `[io]` function from the `-p` entry and calling it without declaring `[io]` is caught on the build path (E0402), not just under `sailfin check`.
- [x] `make check` still passes on the clean compiler tree (self-host verified; full `make check` run alongside this PR).
- [x] Sidecars for entry-importing siblings list the entry's `.sfn-asm` (asserted by the new e2e test grepping the dependent's `.import-deps`).

## Verification
```bash
# New regression test — fails on pre-fix binary, passes on fixed binary
ulimit -v 8388608 && compiler/tests/e2e/test_effect_gate_build_path_entry.sh build/native/sailfin
#   [test] PASS: sibling .import-deps lists the -p entry's .sfn-asm
#   [test] PASS: build path emits E0402 for under-declared sibling->entry [io]
#   [test] 2 passed, 0 failed

ulimit -v 8388608 && make compile   # self-hosts (exit 0)
ulimit -v 8388608 && make check     # full suite + seedcheck
```

## Files Changed
- `compiler/src/capsule_resolver.sfn` — thread `slug_universe_extra` through `compile_capsule_modules`; resolve sidecar slugs against `sources ++ extra`; populate the extra universe with the staged `-p` entry.
- `compiler/tests/e2e/test_effect_gate_build_path_entry.sh` — new regression (auto-discovered by `make test-e2e-sh`).
- `docs/status.md` — record the entry-module gap closure.

## Notes for reviewers
- Slug consistency holds by construction: the entry `CapsuleSource.slug = module_name_from_path(entry_path)` is the same value `stage_capsule_imports` uses to name the staged `<slug>.sfn-asm`, so the sidecar reference points at a real file.
- **Out of scope (pre-existing, worth a follow-up):** the `-p` driver silently drops a module whose emit fails rather than aborting (`cli_main.sfn` has no `capsule_result.success` check at the link site). An *orphan* sibling's E0402 therefore doesn't change the exit code — only a *linked* module breaks the link. In the real compiler self-build every module is linked, so the same E0402 hard-fails `make check`; the fixture's `main()` doesn't call the sibling, so the e2e test asserts on the E0402 diagnostic rather than the exit code (documented in the test header).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GSTDfo2T8SgW3KsMsN6KEK)_