### PR TITLE
test-infra: import real diagnostics_render symbols in check_tool_test (#619)

### DIFF
--- a/compiler/tests/unit/check_tool_test.sfn
+++ b/compiler/tests/unit/check_tool_test.sfn
@@ -1,16 +1,36 @@
 // Regression tests for the `sfn check` analysis orchestrator's pure
 // string-building helpers.
 //
-// Kept minimal and self-contained (no imports, no struct literals)
-// because the test runner cannot link against `char_code` via the
-// string_utils → runtime chain from standalone tests, and some
-// compiler versions segfault on nested struct-literal initialisers in
-// test bodies. Mirrors the pattern used by `fmt_test.sfn`,
-// `capsule_dep_resolution_test.sfn`, and `stdlib_capsule_allowlist_test.sfn`.
+// Import envelope (corrects this file's prior header):
+// The blocker for importing real `compiler/src` symbols here is
+// *import-closure size*, NOT a linker incapacity and NOT the
+// `char_code` / `string_utils → runtime` chain the old comment blamed.
+// The `sfn test` runner links `runtime/prelude` (which exports
+// `char_code`) into every test via `assemble_runtime_capsule_link_inputs`
+// (`compiler/src/cli_commands.sfn:51,176`), so the runtime chain always
+// resolves. What costs is the transitive `from "..."` closure the
+// resolver must compile + link for an imported symbol's home module.
 //
-// The helpers below mirror the logic in compiler/src/tools/check.sfn —
-// keep them in sync when that file changes. See
-// docs/proposals/check-architecture.md for the overall design.
+//   - `join_effects` and `code_for_missing_effect` live in
+//     `diagnostics_render.sfn`, whose closure is light (~8 modules:
+//     effect_checker, string_utils, token, typecheck_types). These are
+//     imported below and exercised against the REAL exported symbols.
+//   - `_local_num_to_string` / `_local_render_summary` are kept local:
+//     their real peers (`number_to_string` @ main.sfn, `render_summary`
+//     @ tools/check.sfn) anchor the full ~130-module `main.sfn` backend
+//     closure — too heavy to link into a one-line string-rendering unit
+//     test. Extracting them is the structural follow-up #986, NOT a
+//     linker-capability limitation.
+//
+// See docs/conventions/unit-test-import-envelope.md for the supported
+// test-import envelope, and docs/proposals/unit-test-import-envelope.md
+// for the full root-cause analysis (#619).
+// -------------------------------------------------------------------
+// Imports — real exported symbols (light closure via diagnostics_render)
+// -------------------------------------------------------------------
+import { code_for_missing_effect, join_effects } from "../../src/diagnostics_render";
+import { EffectRequirement } from "../../src/effect_checker";
+
 // -------------------------------------------------------------------
 // Local helpers
 // -------------------------------------------------------------------
@@ -41,20 +61,14 @@ fn _contains(haystack: string, needle: string) -> boolean {
     return _index_of(haystack, needle) >= 0;
 }
 
-fn _local_join_effects(effects: string[]) -> string {
-    if effects.length == 0 { return ""; }
-    let mut out = effects[0];
-    let mut i: int = 1;
-    loop {
-        if i >= effects.length { break; }
-        out = out + ", " + effects[i];
-        i += 1;
-    }
-    return out;
-}
-
+// `_local_build_effect_message` has no exported peer — the build-path
+// message is inlined inside `effect_violation_to_diagnostic`
+// (`diagnostics_render.sfn:92`), not a standalone export. It is kept
+// local but now composes the REAL `join_effects` import rather than a
+// mirrored copy, so the "joins multiple missing effects" assertion
+// below exercises the live separator logic transitively.
 fn _local_build_effect_message(routine_name: string, missing_effects: string[]) -> string {
-    let effects_text = _local_join_effects(missing_effects);
+    let effects_text = join_effects(missing_effects);
     let mut message = "function `" + routine_name
         + "` is missing required effects: !["
         + effects_text
@@ -66,19 +80,19 @@ fn _local_build_effect_message(routine_name: string, missing_effects: string[]) 
     return message;
 }
 
-fn _local_code_for_first_description(first_desc: string) -> string {
-    if first_desc.length == 0 { return "E0400"; }
-    if substring(first_desc, 0, 1) == "@" { return "E0401"; }
-    // Phase E: cross-module call resolution attaches descriptions
-    // of the form `imported \`<name>\` declares !\[…\]` so the
-    // diagnostic code promotes from in-module E0400 to E0402.
-    let imported_prefix = "imported `";
-    if first_desc.length >= imported_prefix.length {
-        if substring(first_desc, 0, imported_prefix.length) == imported_prefix {
-            return "E0402";
-        }
-    }
-    return "E0400";
+// Drives the REAL `code_for_missing_effect` (diagnostics_render.sfn:54)
+// through a single flat `EffectRequirement` carrying `desc`. The real
+// signature is `(missing_effects: string[], requirements:
+// EffectRequirement[])`; the error code is derived from the
+// requirement descriptions, so we wrap one description into a flat,
+// single-level struct literal (`trigger: null`) to stay clear of the
+// nested-struct-literal segfault caveat.
+fn _code_for_desc(desc: string) -> string {
+    let reqs: EffectRequirement[] = [EffectRequirement {
+        effect: "io", description: desc, trigger: null
+    }];
+    let missing: string[] = ["io"];
+    return code_for_missing_effect(missing, reqs);
 }
 
 fn _local_num_to_string(value: int) -> string {
@@ -130,16 +144,16 @@ fn _local_render_summary(files_checked: int, total_errors: int) -> string {
 // -------------------------------------------------------------------
 test "check: join_effects empty" {
     let empty: string[] = [];
-    assert strings_equal(_local_join_effects(empty), "");
+    assert strings_equal(join_effects(empty), "");
 }
 
 test "check: join_effects single" {
-    assert strings_equal(_local_join_effects(["io"]), "io");
+    assert strings_equal(join_effects(["io"]), "io");
 }
 
 test "check: join_effects multiple" {
-    assert strings_equal(_local_join_effects(["io", "net"]), "io, net");
-    assert strings_equal(_local_join_effects(["io", "net", "clock"]), "io, net, clock");
+    assert strings_equal(join_effects(["io", "net"]), "io, net");
+    assert strings_equal(join_effects(["io", "net", "clock"]), "io, net, clock");
 }
 
 // -------------------------------------------------------------------
@@ -166,17 +180,17 @@ test "check: effect message suggests fix" {
 // Tests — error-code classification
 // -------------------------------------------------------------------
 test "check: plain missing-effect requirement is E0400" {
-    assert strings_equal(_local_code_for_first_description("http.get"), "E0400");
-    assert strings_equal(_local_code_for_first_description("fs.readFile"), "E0400");
+    assert strings_equal(_code_for_desc("http.get"), "E0400");
+    assert strings_equal(_code_for_desc("fs.readFile"), "E0400");
 }
 
 test "check: decorator-implied effect is E0401" {
-    assert strings_equal(_local_code_for_first_description("@trace decorator"), "E0401");
-    assert strings_equal(_local_code_for_first_description("@logExecution"), "E0401");
+    assert strings_equal(_code_for_desc("@trace decorator"), "E0401");
+    assert strings_equal(_code_for_desc("@logExecution"), "E0401");
 }
 
 test "check: empty description defaults to E0400" {
-    assert strings_equal(_local_code_for_first_description(""), "E0400");
+    assert strings_equal(_code_for_desc(""), "E0400");
 }
 
 test "check: cross-module imported description is E0402" {
@@ -186,16 +200,30 @@ test "check: cross-module imported description is E0402" {
     // → E0402 mapping so a refactor that "tidies" the description
     // string (e.g. drops the backtick or capitalises) doesn't
     // silently regress the cross-module diagnostic to E0400.
-    assert strings_equal(_local_code_for_first_description("imported `fetch` declares ![net]"), "E0402");
-    assert strings_equal(_local_code_for_first_description("imported `read_file` declares ![io]"), "E0402");
+    assert strings_equal(_code_for_desc("imported `fetch` declares ![net]"), "E0402");
+    assert strings_equal(_code_for_desc("imported `read_file` declares ![io]"), "E0402");
 }
 
 test "check: imported substring without prefix stays E0400" {
     // Defensive — make sure the prefix check doesn't false-match
     // descriptions that merely contain the word "imported" later
     // in the string (e.g. an in-module helper named "use_imported").
-    assert strings_equal(_local_code_for_first_description("use_imported_helper requires ![io]"), "E0400");
-    assert strings_equal(_local_code_for_first_description("filesystem helper usage"), "E0400");
+    assert strings_equal(_code_for_desc("use_imported_helper requires ![io]"), "E0400");
+    assert strings_equal(_code_for_desc("filesystem helper usage"), "E0400");
+}
+
+test "check: decorator precedence wins over cross-module import" {
+    // Real `code_for_missing_effect` scans ALL requirements and the
+    // decorator (`@`) prefix outranks the `imported \`` prefix
+    // (diagnostics_render.sfn:65-77). Build two flat requirements to
+    // exercise the multi-requirement scan the old single-string mirror
+    // could not reach.
+    let reqs: EffectRequirement[] = [EffectRequirement {
+        effect: "net", description: "imported `fetch` declares ![net]", trigger: null
+    }, EffectRequirement {
+        effect: "io", description: "@logExecution", trigger: null
+    }];
+    assert strings_equal(code_for_missing_effect(["io", "net"], reqs), "E0401");
 }
 
 // -------------------------------------------------------------------

--- a/compiler/tests/unit/check_tool_test.sfn
+++ b/compiler/tests/unit/check_tool_test.sfn
@@ -86,12 +86,16 @@ fn _local_build_effect_message(routine_name: string, missing_effects: string[]) 
 // EffectRequirement[])`; the error code is derived from the
 // requirement descriptions, so we wrap one description into a flat,
 // single-level struct literal (`trigger: null`) to stay clear of the
-// nested-struct-literal segfault caveat.
-fn _code_for_desc(desc: string) -> string {
+// nested-struct-literal segfault caveat. `effect` is threaded into both
+// the requirement's `effect` field and the `missing` array so the
+// fixture stays self-consistent with the description (e.g. an
+// `![net]` description carries `effect: "net"`) — future-proofing the
+// test if `code_for_missing_effect` ever consults those fields too.
+fn _code_for_desc(effect: string, desc: string) -> string {
     let reqs: EffectRequirement[] = [EffectRequirement {
-        effect: "io", description: desc, trigger: null
+        effect: effect, description: desc, trigger: null
     }];
-    let missing: string[] = ["io"];
+    let missing: string[] = [effect];
     return code_for_missing_effect(missing, reqs);
 }
 
@@ -180,17 +184,17 @@ test "check: effect message suggests fix" {
 // Tests — error-code classification
 // -------------------------------------------------------------------
 test "check: plain missing-effect requirement is E0400" {
-    assert strings_equal(_code_for_desc("http.get"), "E0400");
-    assert strings_equal(_code_for_desc("fs.readFile"), "E0400");
+    assert strings_equal(_code_for_desc("net", "http.get"), "E0400");
+    assert strings_equal(_code_for_desc("io", "fs.readFile"), "E0400");
 }
 
 test "check: decorator-implied effect is E0401" {
-    assert strings_equal(_code_for_desc("@trace decorator"), "E0401");
-    assert strings_equal(_code_for_desc("@logExecution"), "E0401");
+    assert strings_equal(_code_for_desc("io", "@trace decorator"), "E0401");
+    assert strings_equal(_code_for_desc("io", "@logExecution"), "E0401");
 }
 
 test "check: empty description defaults to E0400" {
-    assert strings_equal(_code_for_desc(""), "E0400");
+    assert strings_equal(_code_for_desc("io", ""), "E0400");
 }
 
 test "check: cross-module imported description is E0402" {
@@ -200,16 +204,16 @@ test "check: cross-module imported description is E0402" {
     // → E0402 mapping so a refactor that "tidies" the description
     // string (e.g. drops the backtick or capitalises) doesn't
     // silently regress the cross-module diagnostic to E0400.
-    assert strings_equal(_code_for_desc("imported `fetch` declares ![net]"), "E0402");
-    assert strings_equal(_code_for_desc("imported `read_file` declares ![io]"), "E0402");
+    assert strings_equal(_code_for_desc("net", "imported `fetch` declares ![net]"), "E0402");
+    assert strings_equal(_code_for_desc("io", "imported `read_file` declares ![io]"), "E0402");
 }
 
 test "check: imported substring without prefix stays E0400" {
     // Defensive — make sure the prefix check doesn't false-match
     // descriptions that merely contain the word "imported" later
     // in the string (e.g. an in-module helper named "use_imported").
-    assert strings_equal(_code_for_desc("use_imported_helper requires ![io]"), "E0400");
-    assert strings_equal(_code_for_desc("filesystem helper usage"), "E0400");
+    assert strings_equal(_code_for_desc("io", "use_imported_helper requires ![io]"), "E0400");
+    assert strings_equal(_code_for_desc("io", "filesystem helper usage"), "E0400");
 }
 
 test "check: decorator precedence wins over cross-module import" {

--- a/docs/conventions/unit-test-import-envelope.md
+++ b/docs/conventions/unit-test-import-envelope.md
@@ -1,0 +1,97 @@
+# Unit-test import envelope
+
+This is the canonical reference for **which `compiler/src` modules a
+standalone `*_test.sfn` may import**, and why some symbols must still be
+mirrored locally. It exists because the original
+`check_tool_test.sfn` header misattributed the constraint to the
+`char_code` / `string_utils → runtime` chain; the real constraint is
+import-closure size. The full root-cause analysis lives in
+[`docs/proposals/unit-test-import-envelope.md`](../proposals/unit-test-import-envelope.md)
+(#619).
+
+---
+
+## TL;DR
+
+- The `sfn test` runner links **`runtime/prelude`** (and the full
+  runtime/globals capsule) into **every** test. Prelude exports
+  (`char_code`, `strings_equal`, `substring`, collection helpers, …)
+  always resolve — you never need to mirror them.
+- You **may** import exported symbols from a `compiler/src` module whose
+  transitive `from "..."` closure is **light**.
+- You **may not** (in practice) import symbols anchored in `main.sfn`'s
+  closure — that drags the full ~130-module backend into the link line,
+  which is wasteful coupling and risks OOM/timeout under the test memory
+  cap.
+
+---
+
+## Why closure size, not the runtime chain
+
+The runner builds a single standalone test's link line in
+`_clang_link_test_cmd_with_deps` (`compiler/src/cli_commands.sfn:140`)
+from three strong inputs (`cli_commands.sfn:120-123`):
+
+1. the test source's own `.ll`,
+2. the resolver-produced `.ll` files for the **test's import closure**,
+3. the **runtime sources + globals + prelude**, assembled by
+   `assemble_runtime_capsule_link_inputs`
+   (`cli_commands.sfn:51,176`).
+
+Step 3 means the runtime / `char_code` chain is *already on every test's
+link line* — importing a light `src` module that itself uses `char_code`
+resolves fine. The cost is **step 2**: the resolver must compile and
+link the entire transitive `from "..."` graph of the imported symbol's
+home module.
+
+---
+
+## The two closures
+
+| Closure | Modules | Example home module | Verdict |
+|---|---|---|---|
+| **Light** | ~8 | `diagnostics_render.sfn` (imports `effect_checker`, `string_utils`, `token`, `typecheck_types`) | importable from a unit test |
+| **Heavy** | ~130 | `main.sfn`, `tools/check.sfn` (transitively pull `main.sfn` → full backend) | mirror locally; extraction tracked in #986 |
+
+Proven-linkable precedents (standalone unit tests that already import
+`src` symbols and pass): `effect_capabilities_test.sfn:30`
+(`validate_capsule_capabilities` from `effect_checker`),
+`abi_hash_determinism_test.sfn:23` (from `llvm/lowering/abi_hash`),
+and `check_tool_test.sfn` (`join_effects`, `code_for_missing_effect`
+from `diagnostics_render`).
+
+---
+
+## How to check a module's closure before importing
+
+1. Open the home module of the symbol you want and read its top-of-file
+   `import { ... } from "..."` lines.
+2. Follow each `from` target transitively. If the graph stays within
+   leaf utility modules (`string_utils`, `token`, `typecheck_types`,
+   `effect_*`, `ast`, …) and never reaches `main.sfn` or `tools/check.sfn`,
+   the closure is light — import the symbol directly.
+3. If any path reaches `main.sfn` (or a module that imports it), the
+   closure is heavy. Mirror the helper locally with a `_local_*` prefix,
+   add a header note explaining the heavy closure, and point at the
+   extraction follow-up (#986) rather than re-blaming the linker.
+
+When in doubt, author a throwaway test that imports the symbol and run
+it under the cap:
+
+```bash
+ulimit -v 8388608; timeout 60 build/native/sailfin test /tmp/probe_test.sfn
+```
+
+A light import links and passes in seconds; a heavy import surfaces as an
+undefined-reference link failure, OOM, or timeout from the ~130-module
+closure.
+
+---
+
+## Struct-literal caveat
+
+When a real signature takes struct arguments, build **flat,
+single-level** struct literals with explicit `null` for optional fields
+(e.g. `EffectRequirement { effect: "io", description: desc, trigger: null }`).
+Nested struct-literal initialisers segfault on some seed compilers;
+single-level literals stay clear of that path.


### PR DESCRIPTION
## Summary
- Migrate `check_tool_test.sfn` to import the **real** `join_effects` and `code_for_missing_effect` from `diagnostics_render` (light ~8-module closure), deleting the hand-mirrored `_local_join_effects` and `_local_code_for_first_description`. Tests now build flat `EffectRequirement { …, trigger: null }` literals against the real `code_for_missing_effect(string[], EffectRequirement[])` signature, plus a new test pinning the `@`-decorator > `imported` precedence the single-string mirror couldn't reach.
- Correct the file header's root-cause misattribution: the blocker is **import-closure size**, not the `char_code`/`string_utils → runtime` chain (the runner links `runtime/prelude` into every test). `_local_num_to_string` / `_local_render_summary` stay local because their real peers anchor the ~130-module `main.sfn` closure → tracked in **#986**.
- Add `docs/conventions/unit-test-import-envelope.md` documenting the supported test-import envelope.

Closes #619

## Acceptance Criteria
- [x] At least one test imports a real exported symbol (`join_effects`, `code_for_missing_effect` from `diagnostics_render`) instead of a `_local_*` copy.
- [x] `_local_join_effects` and `_local_code_for_first_description` deleted; header documents that `_local_num_to_string` / `_local_render_summary` remain due to heavy import closure (not linker capability) and points at #986.
- [x] Mutating the real symbol makes the migrated test FAIL — verified via a temporary edit, then reverted (see Verification).
- [x] No new segfaults / link failures: `build/native/sailfin test … check_tool_test.sfn` passes and `make test-unit` is green (115/115).
- [x] `docs/conventions/` describes the supported test-import envelope.

## Verification
```bash
# Light import — links + passes
$ build/native/sailfin test compiler/tests/unit/check_tool_test.sfn
  PASS  (all 24 tests passed)

# AC#3 mutation: temporarily change join_effects' ", " separator to " | "
$ build/native/sailfin test compiler/tests/unit/check_tool_test.sfn
  [test] FAIL: check_tool_test.sfn  (assertion failed at check_tool_test.sfn:155 — "join_effects multiple")
# → reverted; diagnostics_render.sfn has no diff in this PR

# Heavy import probe (throwaway test importing number_to_string from main) — closure boundary
$ build/native/sailfin test /tmp/heavy_import_test.sfn
  /usr/bin/ld: undefined reference to `number_to_string__…__compiler__src__main`
  clang: error: linker command failed with exit code 1
  [test] FAIL: heavy_import_test.sfn

# Full unit suite + formatting
$ make test-unit
  ═══ unit: 115/115 passed, 0 failed ═══
$ build/native/sailfin fmt --check compiler/tests/unit/check_tool_test.sfn   # clean
```
Self-hosting unaffected (`make compile` green; no `compiler/src` changes ship in this PR — the mutation to `diagnostics_render.sfn` was reverted).

## Files Changed
- `compiler/tests/unit/check_tool_test.sfn` — import real symbols; delete light `_local_*`; rewrite tests against real signatures; fix header
- `docs/conventions/unit-test-import-envelope.md` (new) — supported test-import envelope

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DXDJNHgLLbWd47naf4WMWd)_