### PR TITLE
feat(sfn/cli): add print_diag and print_status helpers

### DIFF
--- a/capsules/sfn/cli/src/mod.sfn
+++ b/capsules/sfn/cli/src/mod.sfn
@@ -38,7 +38,10 @@
 //                     style_for_stream, style_with_mode,
 //                     style_resolve, paint, paint_* helpers,
 //                     _esc, _ansi_wrap, _no_color_from_value
-//   - print.sfn       print_error, print_warn, print_success, print_hint
+//   - print.sfn       print_error, print_warn, print_success, print_hint,
+//                     print_diag, print_status (+ pure builders
+//                     diag_prefix, diag_line, status_line, importable
+//                     directly from ./print for tests)
 //   - exit_codes.sfn  EXIT_OK, EXIT_BUILD_FAIL, EXIT_USAGE,
 //                     EXIT_NOT_FOUND, EXIT_INTERNAL
 //
@@ -137,7 +140,9 @@ export {
     print_error,
     print_warn,
     print_success,
-    print_hint
+    print_hint,
+    print_diag,
+    print_status
 } from "./print";
 
 // ---- Exit code constants ----

--- a/capsules/sfn/cli/src/print.sfn
+++ b/capsules/sfn/cli/src/print.sfn
@@ -2,6 +2,27 @@
 //
 // Prefixed status helpers for CLI output: errors and warnings go to
 // stderr; success and hints follow the same prefix convention.
+//
+// `print_diag` / `print_status` (issue #793 / 1.4) build on the
+// `Style` policy from issue #792 / 1.3: they resolve a stream-aware
+// `Style` via `style_for_stream` and apply ANSI color through the
+// `paint*` helpers, which degrade to plain text when the style is
+// disabled (`NO_COLOR`, `--color=never`, or a non-TTY stream). The
+// severity word produced by `diag_prefix` matches the leading
+// `severity` token rendered by `compiler/src/diagnostics_render.sfn`
+// (`<severity>[<code>]: <message>`) byte-for-byte, so Phase 5 Issue
+// 5.3 can fold the two code paths together without a wire-format
+// change.
+import {
+    paint_blue,
+    paint_cyan,
+    paint_dim,
+    paint_red,
+    paint_yellow,
+    style_for_stream
+} from "./style";
+import { Style } from "./types";
+
 fn print_error(message: string) -> void ![io] {
     // Print an error message to stderr, prefixed with "error: ".
     print.err("error: " + message);
@@ -20,4 +41,106 @@ fn print_success(message: string) -> void ![io] {
 fn print_hint(message: string) -> void ![io] {
     // Print a hint message to stderr, prefixed with "hint: ".
     print.err("hint: " + message);
+}
+
+// ── print_diag / print_status (issue #793, proposal §7 Issue 1.4) ─────
+fn _int_to_string(value: int) -> string {
+    // Minimal base-10 int formatter. The prelude has no int->string
+    // intrinsic exposed to capsules yet; this mirrors the private
+    // helper in `parser.sfn` (kept local to honor the issue's
+    // Files-Affected scope).
+    if value == 0 { return "0"; }
+    let table = "0123456789";
+    let mut n = value;
+    let mut negative = false;
+    if n < 0 {
+        negative = true;
+        n = 0 - n;
+    }
+    let mut digits = "";
+    loop {
+        if n == 0 { break; }
+        let d = n - (n / 10) * 10;
+        digits = substring(table, d, d + 1) + digits;
+        n = n / 10;
+    }
+    if negative { return "-" + digits; }
+    return digits;
+}
+
+fn diag_prefix(severity: string) -> string {
+    // Canonical severity word for a diagnostic line. Matches the
+    // leading `severity` token rendered by
+    // `compiler/src/diagnostics_render.sfn` byte-for-byte so the two
+    // code paths can be unified in Phase 5 (Issue 5.3): the renderer
+    // emits "error" / "warning"; the CLI's "warn" alias normalizes to
+    // "warning" here. Unknown severities pass through verbatim so the
+    // caller still gets a plain, un-styled prefix and execution
+    // continues.
+    if strings_equal(severity, "error") { return "error"; }
+    if strings_equal(severity, "warn") { return "warning"; }
+    if strings_equal(severity, "info") { return "info"; }
+    if strings_equal(severity, "hint") { return "hint"; }
+    return severity;
+}
+
+fn _diag_paint(s: Style, severity: string, label: string) -> string {
+    // Color the severity word per its level. Unknown severities are
+    // left un-colored (plain). When the style is disabled the paint*
+    // helpers already return plain text, so this is a no-op then.
+    if strings_equal(severity, "error") { return paint_red(s, label); }
+    if strings_equal(severity, "warn") { return paint_yellow(s, label); }
+    if strings_equal(severity, "info") { return paint_blue(s, label); }
+    if strings_equal(severity, "hint") { return paint_cyan(s, label); }
+    return label;
+}
+
+fn _diag_stream(severity: string) -> string {
+    // info goes to stdout (progress/informational); error, warn, hint
+    // (and unknown) go to stderr, matching the existing print_* split.
+    if strings_equal(severity, "info") { return "stdout"; }
+    return "stderr";
+}
+
+fn diag_line(s: Style, severity: string, message: string) -> string {
+    // Pure builder for a single diagnostic line. An empty severity
+    // (or any severity that maps to an empty word) yields the bare
+    // message with no prefix; everything else is "<word>: <message>"
+    // with the word optionally colored via `s`.
+    let label = diag_prefix(severity);
+    if label.length == 0 { return message; }
+    return _diag_paint(s, severity, label) + ": " + message;
+}
+
+fn status_line(s: Style, step: int, total: int, message: string) -> string {
+    // Pure builder for a progress line: "[<step>/<total>] <message>".
+    // The "[step/total]" counter is dimmed when the style is enabled.
+    let counter = "[" + _int_to_string(step) + "/" + _int_to_string(total) + "]";
+    return paint_dim(s, counter) + " " + message;
+}
+
+fn print_diag(severity: string, message: string, hint: string) -> void ![io] {
+    // Print a diagnostic line for `severity`, optionally followed by a
+    // "hint: <hint>" line when `hint` is non-empty. Color and stream
+    // are derived from the severity; styling degrades to plain text
+    // under `NO_COLOR` / non-TTY via `style_for_stream`.
+    let stream = _diag_stream(severity);
+    let s = style_for_stream(stream);
+    let line = diag_line(s, severity, message);
+    if strings_equal(stream, "stdout") { print(line); } else {
+        print.err(line);
+    }
+    if hint.length > 0 {
+        let hint_line = diag_line(s, "hint", hint);
+        if strings_equal(stream, "stdout") { print(hint_line); } else {
+            print.err(hint_line);
+        }
+    }
+}
+
+fn print_status(step: int, total: int, message: string) -> void ![io] {
+    // Print a "[step/total] message" progress line to stdout, dimming
+    // the counter when stdout supports color.
+    let s = style_for_stream("stdout");
+    print(status_line(s, step, total, message));
 }

--- a/capsules/sfn/cli/tests/print_test.sfn
+++ b/capsules/sfn/cli/tests/print_test.sfn
@@ -16,7 +16,13 @@
 // public `mod.sfn` surface stays narrowed to `print_diag` /
 // `print_status` (per proposal §4.1) while the byte-level contract
 // stays testable.
-import { print_diag, print_status, style_resolve } from "../src/mod";
+import {
+    paint_dim,
+    paint_red,
+    print_diag,
+    print_status,
+    style_resolve
+} from "../src/mod";
 import { diag_line, diag_prefix, status_line } from "../src/print";
 
 // ── diag_prefix: severity word matches diagnostics_render.sfn ─────
@@ -71,15 +77,18 @@ test "print: diag_line with empty severity yields the bare message" {
     assert strings_equal(diag_line(s, "", "just text"), "just text");
 }
 
-// ── diag_line: enabled style is plain too (bootstrap _esc() is "") ──
+// ── diag_line: enabled style composes the painted prefix ─────────
 //
-// Mirrors style_test's contract lock: an enabled Style still produces
-// plain text today because `_esc()` returns "". This assertion starts
-// exercising the ANSI path automatically once a real ESC byte lands.
-test "print: diag_line(error) enabled matches disabled today" {
+// Assert against the composition `diag_line` actually performs
+// (painted severity word + ": " + message) rather than against the
+// disabled output. This stays correct both today (where `_esc()`
+// returns "" so `paint_red` is a no-op) and once a real ESC byte
+// lands and the prefix gains ANSI codes. Mirrors style_test's
+// forward-compatible `paint_* == legacy` lock.
+test "print: diag_line(error) enabled composes the painted prefix" {
     let on = style_resolve("stderr", "always", "");
-    let off = style_resolve("stderr", "never", "");
-    assert strings_equal(diag_line(on, "error", "x"), diag_line(off, "error", "x"));
+    assert strings_equal(diag_line(on, "error", "x"), paint_red(on, "error")
+        + ": x");
 }
 
 // ── status_line: "[step/total] message" shape ────────────────────
@@ -93,10 +102,13 @@ test "print: status_line handles single-step progress" {
     assert strings_equal(status_line(s, 1, 1, "Done"), "[1/1] Done");
 }
 
-test "print: status_line enabled matches disabled today" {
+test "print: status_line enabled composes the dimmed counter" {
+    // Like the diag_line case above, assert against the actual
+    // composition (dimmed counter + " " + message) so the test holds
+    // both before and after `_esc()` returns a real ESC byte.
     let on = style_resolve("stdout", "always", "");
-    let off = style_resolve("stdout", "never", "");
-    assert strings_equal(status_line(on, 3, 7, "go"), status_line(off, 3, 7, "go"));
+    assert strings_equal(status_line(on, 3, 7, "go"), paint_dim(on, "[3/7]")
+        + " go");
 }
 
 // ── smoke: exported print_diag / print_status run under ![io] ─────

--- a/capsules/sfn/cli/tests/print_test.sfn
+++ b/capsules/sfn/cli/tests/print_test.sfn
@@ -1,0 +1,117 @@
+// Tests for sfn/cli — print_diag / print_status (issue #793 / 1.4).
+//
+// Covers:
+//   - `diag_prefix` maps each accepted severity to the canonical
+//     severity word used by `compiler/src/diagnostics_render.sfn`
+//     (`error`, `warning`, `info`, `hint`) and passes unknown
+//     severities through verbatim (plain prefix).
+//   - `diag_line` composes "<word>: <message>" and honors the
+//     disabled-style plain-text contract.
+//   - `status_line` renders the "[step/total] message" shape.
+//   - `print_diag` / `print_status` are exported from the barrel and
+//     run end-to-end under `![io]` (smoke coverage; the bytes are
+//     asserted via the pure builders above).
+//
+// The pure builders are imported directly from `../src/print` so the
+// public `mod.sfn` surface stays narrowed to `print_diag` /
+// `print_status` (per proposal §4.1) while the byte-level contract
+// stays testable.
+import { print_diag, print_status, style_resolve } from "../src/mod";
+import { diag_line, diag_prefix, status_line } from "../src/print";
+
+// ── diag_prefix: severity word matches diagnostics_render.sfn ─────
+//
+// `render_diagnostic` builds its header as `d.severity + "[" + ...`,
+// so the leading severity token is "error" / "warning". The CLI's
+// "warn" alias normalizes to "warning" so the two prefixes match
+// byte-for-byte ahead of the Phase 5 (Issue 5.3) unification.
+test "print: diag_prefix(error) is the renderer's error token" {
+    assert strings_equal(diag_prefix("error"), "error");
+}
+
+test "print: diag_prefix(warn) normalizes to the renderer's warning token" {
+    assert strings_equal(diag_prefix("warn"), "warning");
+}
+
+test "print: diag_prefix(info) is info" {
+    assert strings_equal(diag_prefix("info"), "info");
+}
+
+test "print: diag_prefix(hint) is hint" {
+    assert strings_equal(diag_prefix("hint"), "hint");
+}
+
+test "print: diag_prefix passes unknown severities through verbatim" {
+    assert strings_equal(diag_prefix("debug"), "debug");
+}
+
+// ── diag_line: composes "<word>: <message>" (plain when disabled) ──
+test "print: diag_line(error) renders error prefix" {
+    let s = style_resolve("stderr", "never", "");
+    assert strings_equal(diag_line(s, "error", "boom"), "error: boom");
+}
+
+test "print: diag_line(warn) renders warning prefix" {
+    let s = style_resolve("stderr", "never", "");
+    assert strings_equal(diag_line(s, "warn", "careful"), "warning: careful");
+}
+
+test "print: diag_line(info) renders info prefix" {
+    let s = style_resolve("stdout", "never", "");
+    assert strings_equal(diag_line(s, "info", "fyi"), "info: fyi");
+}
+
+test "print: diag_line(hint) renders hint prefix" {
+    let s = style_resolve("stderr", "never", "");
+    assert strings_equal(diag_line(s, "hint", "try --help"), "hint: try --help");
+}
+
+test "print: diag_line with empty severity yields the bare message" {
+    let s = style_resolve("stderr", "never", "");
+    assert strings_equal(diag_line(s, "", "just text"), "just text");
+}
+
+// ── diag_line: enabled style is plain too (bootstrap _esc() is "") ──
+//
+// Mirrors style_test's contract lock: an enabled Style still produces
+// plain text today because `_esc()` returns "". This assertion starts
+// exercising the ANSI path automatically once a real ESC byte lands.
+test "print: diag_line(error) enabled matches disabled today" {
+    let on = style_resolve("stderr", "always", "");
+    let off = style_resolve("stderr", "never", "");
+    assert strings_equal(diag_line(on, "error", "x"), diag_line(off, "error", "x"));
+}
+
+// ── status_line: "[step/total] message" shape ────────────────────
+test "print: status_line renders the [step/total] counter" {
+    let s = style_resolve("stdout", "never", "");
+    assert strings_equal(status_line(s, 2, 5, "Compiling"), "[2/5] Compiling");
+}
+
+test "print: status_line handles single-step progress" {
+    let s = style_resolve("stdout", "never", "");
+    assert strings_equal(status_line(s, 1, 1, "Done"), "[1/1] Done");
+}
+
+test "print: status_line enabled matches disabled today" {
+    let on = style_resolve("stdout", "always", "");
+    let off = style_resolve("stdout", "never", "");
+    assert strings_equal(status_line(on, 3, 7, "go"), status_line(off, 3, 7, "go"));
+}
+
+// ── smoke: exported print_diag / print_status run under ![io] ─────
+test "print: print_diag runs for each severity" ![io] {
+    print_diag("error", "smoke error", "");
+    print_diag("warn", "smoke warn", "");
+    print_diag("info", "smoke info", "");
+    print_diag("hint", "smoke hint", "");
+    print_diag("error", "with hint", "do the thing");
+    print_diag("unknown", "plain", "");
+    assert true;
+}
+
+test "print: print_status runs" ![io] {
+    print_status(1, 3, "Starting");
+    print_status(3, 3, "Finished");
+    assert true;
+}


### PR DESCRIPTION
## Summary
- Add `print_diag(severity, message, hint)` and `print_status(step, total, message)` to the `sfn/cli` capsule, built on the `Style` policy from #792.
- `diag_prefix` maps accepted severities (`error`, `warn`, `info`, `hint`) to the canonical severity word emitted by `compiler/src/diagnostics_render.sfn` so prefixes match **byte-for-byte** ahead of Phase 5 (Issue 5.3) unification — `warn` normalizes to the renderer's `warning`; unknown severities pass through verbatim as a plain prefix.
- Color + target stream derive from severity; styling degrades to plain text under `NO_COLOR` / non-TTY via `style_for_stream`. `info` → stdout, others → stderr.

Closes #793

## Acceptance Criteria
- [x] `print_diag(severity, message, hint)` exported; severities `error`/`warn`/`info`/`hint`; unknown → plain prefix and continue.
- [x] `print_status(step, total, message)` exported; output shape `[step/total] message` styled via `style_for_stream("stdout")`.
- [x] `print_diag` prefix matches `diagnostics_render.sfn`'s severity prefix byte-for-byte (`diag_prefix` returns the renderer's severity token; `warn`→`warning`).
- [x] `print_diag` respects `NO_COLOR` and the active `Style` from Issue 1.3.
- [x] New `tests/print_test.sfn` covers each severity and `print_status` (16 tests).
- [x] `make compile` succeeds.
- [x] `make test` passes.
- [x] `sfn fmt --check` clean.

## Verification
```bash
ulimit -v 8388608 && make compile           # built build/native/sailfin (self-hosts)
ulimit -v 8388608 && timeout 60 build/native/sailfin test capsules/sfn/cli/tests/print_test.sfn
#   → PASS (all 16 tests passed)
ulimit -v 8388608 && timeout 120 build/native/sailfin test capsules/sfn/cli/tests/
#   → tests: 6/6 passed, 0 failed
ulimit -v 8388608 && make test               # → e2e-sh: 90/90 passed, 0 failed (exit 0)
ulimit -v 8388608 && timeout 30 build/native/sailfin fmt --check capsules/sfn/cli/
#   → clean
```

## Files Changed
- `capsules/sfn/cli/src/print.sfn` — `print_diag`, `print_status`, pure builders `diag_prefix`/`diag_line`/`status_line` + private helpers.
- `capsules/sfn/cli/src/mod.sfn` — re-export `print_diag`, `print_status`.
- `capsules/sfn/cli/tests/print_test.sfn` — NEW, 16 tests.

## Notes
- Per this session's environment branch mandate, work landed on `claude/beautiful-darwin-K8IgF` rather than a `claude/793-*` branch; `Closes #793` still auto-closes the issue on merge.
- Pure builders are importable from `./print` so the byte-level contract stays testable while `mod.sfn`'s public surface stays narrowed to `print_diag`/`print_status` (proposal §4.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XcxepLTy8pnByJVTJgXDZ6)_