### PR TITLE
refactor(test-infra): extract number_to_string into leaf num_format module

### DIFF
--- a/compiler/src/cli_commands.sfn
+++ b/compiler/src/cli_commands.sfn
@@ -55,10 +55,10 @@ import { lock_add_entry, lock_get_version } from "./lock";
 import {
     compile_tests_to_llvm_file_with_module_imports,
     compile_to_llvm_file_with_module,
-    module_name_from_path,
-    number_to_string
+    module_name_from_path
 } from "./main";
 import { LayoutManifest } from "./native_ir";
+import { number_to_string } from "./num_format";
 import { parse_program } from "./parser/mod";
 import { runtime_capsule_from_root } from "./runtime_capsule_resolver";
 import { find_char_local, substring } from "./string_utils";

--- a/compiler/src/main.sfn
+++ b/compiler/src/main.sfn
@@ -30,6 +30,7 @@ import { lower_to_llvm_for_tests } from "./llvm/lowering/entrypoints_tests";
 import { write_llvm_ir_for_tests_from_text_with_context } from "./llvm/lowering/entrypoints_tests_writer";
 import { runtime_helper_call_names } from "./llvm/runtime_helpers";
 import { LayoutManifest } from "./native_ir";
+import { number_to_string } from "./num_format";
 import { parse_program } from "./parser/mod";
 import { load_prelude_global_names } from "./prelude_globals";
 import { substring } from "./string_utils";
@@ -616,34 +617,6 @@ fn _emit_typecheck_diagnostics(entries: Diagnostic[], source: string, file_path:
         print.err(rendered);
         index += 1;
     }
-}
-
-fn number_to_string(value: int) -> string {
-    if value == 0 { return "0"; }
-    let mut working: int = value;
-    let mut negative: boolean = false;
-    if working < 0 {
-        negative = true;
-        working = 0 - working;
-    }
-    let digits = "0123456789";
-    let mut remaining: int = working;
-    let mut output: string = "";
-    loop {
-        if remaining <= 0 { break; }
-        let mut temp: int = remaining;
-        let mut quotient: int = 0;
-        loop {
-            if temp < 10 { break; }
-            temp -= 10;
-            quotient += 1;
-        }
-        let ch = substring(digits, temp, temp + 1);
-        output = ch + output;
-        remaining = quotient;
-    }
-    if negative { output = "-" + output; }
-    return output;
 }
 
 fn repeat_character(ch: string, count: int) -> string {

--- a/compiler/src/num_format.sfn
+++ b/compiler/src/num_format.sfn
@@ -1,0 +1,46 @@
+// compiler/src/num_format.sfn
+//
+// Leaf integer→string formatting helper, extracted from `main.sfn` (#986).
+//
+// `number_to_string` previously lived in `main.sfn`, so any module that
+// imported it (`tools/check.sfn`, `cli_commands.sfn`) transitively dragged
+// `main.sfn`'s full ~130-module backend closure. That made the `sfn check`
+// summary helpers (`render_summary`, `number_to_string`) impossible to link
+// from a standalone unit test, forcing `check_tool_test.sfn` to keep
+// hand-mirrored `_local_*` copies (see #619, #613, and
+// `docs/proposals/unit-test-import-envelope.md`).
+//
+// This module's only dependency is `substring` from the runtime prelude,
+// which the test runner links into every test via
+// `assemble_runtime_capsule_link_inputs`. Its import closure therefore does
+// NOT include `main.sfn`, so importing `number_to_string` from here is
+// unit-test-linkable.
+import { substring } from "runtime/prelude";
+
+fn number_to_string(value: int) -> string {
+    if value == 0 { return "0"; }
+    let mut working: int = value;
+    let mut negative: boolean = false;
+    if working < 0 {
+        negative = true;
+        working = 0 - working;
+    }
+    let digits = "0123456789";
+    let mut remaining: int = working;
+    let mut output: string = "";
+    loop {
+        if remaining <= 0 { break; }
+        let mut temp: int = remaining;
+        let mut quotient: int = 0;
+        loop {
+            if temp < 10 { break; }
+            temp -= 10;
+            quotient += 1;
+        }
+        let ch = substring(digits, temp, temp + 1);
+        output = ch + output;
+        remaining = quotient;
+    }
+    if negative { output = "-" + output; }
+    return output;
+}

--- a/compiler/src/tools/check.sfn
+++ b/compiler/src/tools/check.sfn
@@ -31,7 +31,7 @@ import { validate_capsule_capabilities, validate_effects_with_imports } from "..
 import { read_effect_enforcement_env, resolve_effect_enforcement } from "../effect_gate";
 import { ImportSymbolTable, empty_import_symbols } from "../effect_imports";
 import { runtime_helper_call_names } from "../llvm/runtime_helpers";
-import { number_to_string } from "../main";
+import { number_to_string } from "../num_format";
 import { parse_program } from "../parser/mod";
 import { load_prelude_global_names } from "../prelude_globals";
 import { substring } from "../string_utils";

--- a/compiler/tests/unit/check_tool_test.sfn
+++ b/compiler/tests/unit/check_tool_test.sfn
@@ -15,21 +15,25 @@
 //     `diagnostics_render.sfn`, whose closure is light (~8 modules:
 //     effect_checker, string_utils, token, typecheck_types). These are
 //     imported below and exercised against the REAL exported symbols.
-//   - `_local_num_to_string` / `_local_render_summary` are kept local:
-//     their real peers (`number_to_string` @ main.sfn, `render_summary`
-//     @ tools/check.sfn) anchor the full ~130-module `main.sfn` backend
-//     closure — too heavy to link into a one-line string-rendering unit
-//     test. Extracting them is the structural follow-up #986, NOT a
-//     linker-capability limitation.
+//   - `number_to_string` and `render_summary` are now also imported from
+//     the real source. #986 extracted `number_to_string` out of
+//     `main.sfn` into the leaf module `num_format.sfn` (closure: just
+//     `runtime/prelude`), which dropped `main.sfn`'s full ~130-module
+//     backend out of `tools/check.sfn`'s closure as well — so
+//     `render_summary` (`tools/check.sfn`) is now unit-test-linkable.
+//     The old `_local_num_to_string` / `_local_render_summary` mirrors
+//     are deleted.
 //
 // See docs/conventions/unit-test-import-envelope.md for the supported
 // test-import envelope, and docs/proposals/unit-test-import-envelope.md
-// for the full root-cause analysis (#619).
+// for the full root-cause analysis (#619, #986).
 // -------------------------------------------------------------------
 // Imports — real exported symbols (light closure via diagnostics_render)
 // -------------------------------------------------------------------
 import { code_for_missing_effect, join_effects } from "../../src/diagnostics_render";
 import { EffectRequirement } from "../../src/effect_checker";
+import { number_to_string } from "../../src/num_format";
+import { CheckSummary, render_summary } from "../../src/tools/check";
 
 // -------------------------------------------------------------------
 // Local helpers
@@ -97,50 +101,6 @@ fn _code_for_desc(effect: string, desc: string) -> string {
     }];
     let missing: string[] = [effect];
     return code_for_missing_effect(missing, reqs);
-}
-
-fn _local_num_to_string(value: int) -> string {
-    if value == 0 { return "0"; }
-    let mut working: int = value;
-    let mut negative: boolean = false;
-    if working < 0 {
-        negative = true;
-        working = 0 - working;
-    }
-    let mut output: string = "";
-    loop {
-        if working == 0 { break; }
-        let mut quotient: int = 0;
-        let mut remaining: int = working;
-        loop {
-            if remaining < 10 { break; }
-            remaining = remaining - 10;
-            quotient += 1;
-        }
-        let mut digit_char: string = "0";
-        if remaining == 1 { digit_char = "1"; }
-        if remaining == 2 { digit_char = "2"; }
-        if remaining == 3 { digit_char = "3"; }
-        if remaining == 4 { digit_char = "4"; }
-        if remaining == 5 { digit_char = "5"; }
-        if remaining == 6 { digit_char = "6"; }
-        if remaining == 7 { digit_char = "7"; }
-        if remaining == 8 { digit_char = "8"; }
-        if remaining == 9 { digit_char = "9"; }
-        output = digit_char + output;
-        working = quotient;
-    }
-    if negative { output = "-" + output; }
-    return output;
-}
-
-fn _local_render_summary(files_checked: int, total_errors: int) -> string {
-    let files_str = _local_num_to_string(files_checked);
-    if total_errors == 0 { return "checked " + files_str + " files: ok"; }
-    let errors_str = _local_num_to_string(total_errors);
-    let mut label: string = " errors";
-    if total_errors == 1 { label = " error"; }
-    return "checked " + files_str + " files: " + errors_str + label;
 }
 
 // -------------------------------------------------------------------
@@ -234,18 +194,24 @@ test "check: decorator precedence wins over cross-module import" {
 // Tests — summary rendering
 // -------------------------------------------------------------------
 test "check: summary says ok when no errors" {
-    let text = _local_render_summary(3, 0);
+    let text = render_summary(CheckSummary {
+        files_checked: 3, total_errors: 0, total_warnings: 0
+    });
     assert _contains(text, "3 files");
     assert _contains(text, "ok");
 }
 
 test "check: summary reports plural errors" {
-    let text = _local_render_summary(2, 5);
+    let text = render_summary(CheckSummary {
+        files_checked: 2, total_errors: 5, total_warnings: 0
+    });
     assert _contains(text, "5 errors");
 }
 
 test "check: summary reports singular error" {
-    let text = _local_render_summary(1, 1);
+    let text = render_summary(CheckSummary {
+        files_checked: 1, total_errors: 1, total_warnings: 0
+    });
     assert _contains(text, "1 error");
     assert ! _contains(text, "errors");
 }
@@ -254,13 +220,13 @@ test "check: summary reports singular error" {
 // Tests — number-to-string helper
 // -------------------------------------------------------------------
 test "check: num_to_string handles zero" {
-    assert strings_equal(_local_num_to_string(0), "0");
+    assert strings_equal(number_to_string(0), "0");
 }
 
 test "check: num_to_string handles small positives" {
-    assert strings_equal(_local_num_to_string(7), "7");
-    assert strings_equal(_local_num_to_string(42), "42");
-    assert strings_equal(_local_num_to_string(120), "120");
+    assert strings_equal(number_to_string(7), "7");
+    assert strings_equal(number_to_string(42), "42");
+    assert strings_equal(number_to_string(120), "120");
 }
 
 // -------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Extract `number_to_string` out of `main.sfn` into a new leaf module `compiler/src/num_format.sfn` whose only dependency is `substring` from `runtime/prelude` (always linked), so its import closure does **not** include `main.sfn`.
- Re-point the three importers (`main.sfn`, `cli_commands.sfn`, `tools/check.sfn`) at the new home. With `main.sfn` no longer in `tools/check.sfn`'s closure, `render_summary` becomes unit-test-linkable.
- Migrate `check_tool_test.sfn` to import the **real** `number_to_string` and `render_summary` (+ `CheckSummary`); delete the hand-mirrored `_local_num_to_string` / `_local_render_summary` copies and refresh the header comment.

Closes #986

## Acceptance Criteria
- [x] `number_to_string` lives in a leaf module (`num_format.sfn`) whose import closure does NOT include `main.sfn`; a throwaway test importing it links + passes.
- [x] `check_tool_test.sfn` imports the real `number_to_string` and `render_summary`; `_local_num_to_string` and `_local_render_summary` are deleted.
- [x] Mutating `number_to_string` makes the migrated test FAIL (proves real-code coverage), reverted after verification.
- [x] `make compile && make check` green; `make test-unit` green; no new segfaults.
- [x] `sfn fmt --check` clean on every touched `.sfn`.

## Closure evidence (before/after)
Throwaway tests under `compiler/tests/unit/`, run under `ulimit -v 8388608`:

| Import source | clang modules | wall | result |
|---|---|---|---|
| `../../src/num_format` (after) | **2** | ~0s | **PASS** |
| `../../src/main` (before) | 0 (crashes first) | 61s | **segfault (exit 139)** |

The heavy `main.sfn` closure literally segfaults the compiler before emitting any module — the exact failure mode this issue targets. The light `num_format` closure links instantly.

## Verification
```bash
ulimit -v 8388608; make clean-build && make compile   # self-hosts (modules 152→153)
ulimit -v 8388608; make check                         # stage2==stage3 fixed point ✓; e2e 91/91
ulimit -v 8388608; make test-unit                     # unit: 115/115 passed, 0 failed
ulimit -v 8388608; build/native/sailfin test compiler/tests/unit/check_tool_test.sfn  # PASS (24/24)
# AC3 mutation check: number_to_string(0)->"ZERO" => check_tool_test FAILS at :223, reverted
ulimit -v 8388608; build/native/sailfin fmt --check <touched .sfn>   # clean (exit 0)
```

## Files Changed
- `compiler/src/num_format.sfn` (new leaf module — `number_to_string`)
- `compiler/src/main.sfn` (remove definition; import from `./num_format`)
- `compiler/src/cli_commands.sfn` (re-point import)
- `compiler/src/tools/check.sfn` (re-point import)
- `compiler/tests/unit/check_tool_test.sfn` (import real symbols; delete `_local_*`; header refresh)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DMqcQwDEL8CAaPcXZe9qSA)_