### PR TITLE
refactor(parser): parse lambda bodies through the structured block parser

### DIFF
--- a/compiler/src/llvm/expression_lowering/native/lambda_lowering.sfn
+++ b/compiler/src/llvm/expression_lowering/native/lambda_lowering.sfn
@@ -9,10 +9,11 @@
 //   1. Synthesises a top-level `Statement.FunctionDeclaration`
 //      named `sfn_lambda_<N>` with a hidden `__env: i8*` first
 //      parameter (unused) followed by the lambda's own parameters.
-//      The body is re-parsed from `lambda.body.tokens` because the
-//      expression-side `parse_block_for_lambda` only collects raw
-//      tokens (see `typecheck_captures.sfn:analyze_lambda` for the
-//      same workaround).
+//      The body is re-parsed from `lambda.body.tokens` here to
+//      rebuild the statement list this pass mutates. Since #520 the
+//      parser populates `lambda.body.statements` directly, so this
+//      re-parse is now redundant and can be retired in a follow-up
+//      that reads `body.statements` instead.
 //   2. Replaces the in-tree `Expression.Lambda` with
 //      `Expression.Raw { text: "<closure_pair @sfn_lambda_<N> null>" }`.
 //      The Raw marker rides through `format_expression` verbatim

--- a/compiler/src/parser/expressions.sfn
+++ b/compiler/src/parser/expressions.sfn
@@ -3,7 +3,6 @@
 // Expression parsing - Pratt parser implementation for expressions including
 // literals, binary/unary operators, member access, calls, lambdas, and more.
 import {
-    Block,
     Capture,
     Expression,
     ObjectField,
@@ -17,6 +16,7 @@ import {
     substring
 } from "../string_utils";
 import { Token, TokenKind } from "../token";
+import { parse_block } from "./statements";
 import {
     append_token,
     filter_trivia,
@@ -34,7 +34,6 @@ import {
 } from "./token_utils";
 import {
     ArrayLiteralParseResult,
-    BlockParseResult,
     CallArgumentsParseResult,
     ExpressionBlockParseResult,
     ExpressionCollectResult,
@@ -1006,7 +1005,7 @@ fn parse_lambda_expression(state: ExpressionTokens) -> ExpressionParseResult {
         kind: TokenKind.EndOfFile(), lexeme: "", line: 0, column: 0
     });
     let block_parser = Parser { tokens: block_tokens, index: 0 };
-    let parsed_block = parse_block_for_lambda(block_parser);
+    let parsed_block = parse_block(block_parser);
     let body = parsed_block.block;
 
     let empty_captures: Capture[] = [];
@@ -1375,51 +1374,4 @@ fn append_parameter(parameters: Parameter[], parameter: Parameter) -> Parameter[
 fn append_string_local(values: string[], value: string) -> string[] {
     values.push(value);
     return values;
-}
-
-// ============================================================================
-// Block Parsing for Lambda (forward declaration placeholder)
-// This needs to be provided by statements.sfn but we need it here for lambdas.
-// We'll use a simple implementation that creates an empty block for now,
-// and the actual implementation will be in statements.sfn
-// ============================================================================
-fn parse_block_for_lambda(parser: Parser) -> BlockParseResult {
-    let mut current = parser;
-    current = skip_trivia(current);
-    let token = parser_peek_raw(current);
-    if !symbol_matches(token, "{") {
-        return BlockParseResult {
-            parser: current,
-            block: Block { tokens: [], text: "", statements: [] }
-        };
-    }
-
-    let start_index = current.index;
-    let mut block_end_index: int = start_index;
-    current = parser_advance_raw(current);
-
-    // Simple block collection - just collect tokens until matching }
-    let mut depth: int = 1;
-    loop {
-        current = skip_trivia(current);
-        let tok = parser_peek_raw(current);
-        if symbol_matches(tok, "}") {
-            depth -= 1;
-            if depth == 0 {
-                block_end_index = current.index + 1;
-                current = parser_advance_raw(current);
-                break;
-            }
-        }
-        if symbol_matches(tok, "{") { depth += 1; }
-        if tok.kind.variant == "EndOfFile" { break; }
-        current = parser_advance_raw(current);
-    }
-
-    let mut end_index = current.index;
-    if block_end_index > start_index { end_index = block_end_index; }
-    let block_tokens = token_slice(parser.tokens, start_index, end_index);
-    let text = tokens_to_text(block_tokens);
-    let block = Block { tokens: block_tokens, text: text, statements: [] };
-    return BlockParseResult { parser: skip_trivia(current), block: block };
-}
+}  // Lambda bodies are parsed through the structured `parse_block` in  // statements.sfn (imported above), so `body.statements` is populated  // at parse time. The earlier token-collecting placeholder is gone;  // see issue #520.

--- a/compiler/src/parser/expressions.sfn
+++ b/compiler/src/parser/expressions.sfn
@@ -1374,4 +1374,4 @@ fn append_parameter(parameters: Parameter[], parameter: Parameter) -> Parameter[
 fn append_string_local(values: string[], value: string) -> string[] {
     values.push(value);
     return values;
-}  // Lambda bodies are parsed through the structured `parse_block` in  // statements.sfn (imported above), so `body.statements` is populated  // at parse time. The earlier token-collecting placeholder is gone;  // see issue #520.
+}  // Lambda bodies are parsed through the structured `parse_block` in  // statements.sfn (imported above), so `body.statements` is populated at  // parse time. The earlier token-collecting placeholder is gone; see  // issue #520.

--- a/compiler/src/typecheck_captures.sfn
+++ b/compiler/src/typecheck_captures.sfn
@@ -42,8 +42,6 @@ import {
     Statement,
     TypeAnnotation
 } from "./ast";
-import { parse_block } from "./parser/statements";
-import { Parser } from "./parser/types";
 import { strings_equal } from "./string_utils";
 
 // One scope-visible binding the walk has accumulated so far.
@@ -366,22 +364,13 @@ fn walk_expression(scope: LocalBinding[], expression: Expression?) -> CaptureWal
 // record is appended ahead of any nested-lambda records so the
 // pre-order property holds.
 //
-// Lambda bodies arrive with `body.statements == []` because the
-// expression-side `parse_block_for_lambda` only collects raw tokens
-// (the comment in the parser says the structural pass "will be in
-// statements.sfn" — it never landed). Re-parse the body's tokens
-// through the real `parse_block` here so we can walk structured
-// statements; without this every lambda body would look empty and
-// every reference to an outer name would be invisible. Stage A2
-// will need the same shape and may eventually push this re-parse
-// into the parser, retiring the workaround.
+// Lambda bodies now arrive fully parsed: the expression-side lambda
+// parser delegates to the structured `parse_block` in statements.sfn
+// (issue #520), so `body.statements` is populated and we walk it
+// directly — no re-parse of `body.tokens` is needed.
 fn analyze_lambda(outer_scope: LocalBinding[], lambda: Expression) -> CaptureWalkResult {
-    let body_parser = Parser { tokens: lambda.body.tokens, index: 0 };
-    let parsed_block_result = parse_block(body_parser);
-    let parsed_body = parsed_block_result.block;
-
     let inner_scope = extend_with_parameters(outer_scope, lambda.parameters);
-    let body_result = walk_block(inner_scope, parsed_body);
+    let body_result = walk_block(inner_scope, lambda.body);
 
     let param_names = parameter_names(lambda.parameters);
     let lambda_free = subtract_names(body_result.free, param_names);

--- a/compiler/tests/unit/parser_lambda_body_test.sfn
+++ b/compiler/tests/unit/parser_lambda_body_test.sfn
@@ -1,0 +1,83 @@
+// Unit tests for structured lambda-body parsing (issue #520).
+//
+// Before #520 the expression-side lambda parser used a placeholder
+// (`parse_block_for_lambda`) that only collected raw tokens, leaving
+// `Expression.Lambda.body.statements` empty; downstream passes had to
+// re-parse `body.tokens` to recover structure. The parser now delegates
+// to the structured `parse_block` in statements.sfn, so a lambda body
+// arrives with its `statements` list populated. These tests pin that:
+// every lambda whose source has at least one parsed statement exposes a
+// non-empty `body.statements`, and nested blocks / nested lambdas parse
+// into structured nodes too.
+//
+// Sources use a top-level `let f = fn(...) { ... };` binding because that
+// parse path produces a structured `Expression.Lambda` in the
+// declaration's initializer (the same path the capture analysis relies
+// on). Block-scoped `let` is still parsed into an opaque statement and is
+// deliberately avoided here — its migration is tracked separately.
+import { Block, Expression, Statement } from "../../src/ast";
+import { parse_program } from "../../src/parser/mod";
+
+// Unwrap the body block of a lambda expression. The early-return null
+// guard narrows `expr` to a non-optional `Expression`, after which the
+// duck-typed union field access reaches the Lambda's `body`.
+fn lambda_body(expr: Expression?) -> Block {
+    if expr == null {
+        return Block { tokens: [], text: "", statements: [] };
+    }
+    return expr.body;
+}
+
+// Body of the lambda bound by the first top-level `let` in `source`.
+fn first_let_lambda_body(source: string) -> Block ![io] {
+    let program = parse_program(source);
+    let stmt = program.statements[0];
+    return lambda_body(stmt.initializer);
+}
+
+// -------------------------------------------------------------------
+// Empty body — boundary case: a lambda with no statements parses to an
+// empty (but structured) statement list, not a token blob.
+// -------------------------------------------------------------------
+test "lambda body: empty body has zero structured statements" ![io] {
+    let body = first_let_lambda_body("let f = fn() -> int { };");
+    assert body.statements.length == 0;
+}
+
+// -------------------------------------------------------------------
+// Single statement — the core acceptance criterion: a lambda whose
+// source has one statement exposes exactly one structured statement.
+// -------------------------------------------------------------------
+test "lambda body: single return parses to one structured statement" ![io] {
+    let body = first_let_lambda_body("let f = fn() -> int { return 0; };");
+    assert body.statements.length == 1;
+    assert body.statements[0].variant == "ReturnStatement";
+}
+
+// -------------------------------------------------------------------
+// Nested block — a `{ ... }` inside the lambda body parses to a
+// `BlockStatement` carrying its own structured statement list.
+// -------------------------------------------------------------------
+test "lambda body: nested block parses to a structured BlockStatement" ![io] {
+    let body = first_let_lambda_body("let f = fn() -> int { { return 0; } };");
+    assert body.statements.length == 1;
+    let inner = body.statements[0];
+    assert inner.variant == "BlockStatement";
+    assert inner.body.statements.length == 1;
+    assert inner.body.statements[0].variant == "ReturnStatement";
+}
+
+// -------------------------------------------------------------------
+// Nested lambda — a lambda returned from another lambda's body also
+// arrives with structured statements, so future passes can walk the
+// whole tree without re-parsing any level.
+// -------------------------------------------------------------------
+test "lambda body: nested lambda body is itself structured" ![io] {
+    let body = first_let_lambda_body("let f = fn() -> int { return fn() -> int { return 1; }; };");
+    assert body.statements.length == 1;
+    let ret = body.statements[0];
+    assert ret.variant == "ReturnStatement";
+    let inner_body = lambda_body(ret.expression);
+    assert inner_body.statements.length == 1;
+    assert inner_body.statements[0].variant == "ReturnStatement";
+}

--- a/compiler/tests/unit/parser_lambda_body_test.sfn
+++ b/compiler/tests/unit/parser_lambda_body_test.sfn
@@ -15,16 +15,19 @@
 // declaration's initializer (the same path the capture analysis relies
 // on). Block-scoped `let` is still parsed into an opaque statement and is
 // deliberately avoided here — its migration is tracked separately.
-import { Block, Expression, Statement } from "../../src/ast";
+import { Block, Expression } from "../../src/ast";
 import { parse_program } from "../../src/parser/mod";
 
 // Unwrap the body block of a lambda expression. The early-return null
-// guard narrows `expr` to a non-optional `Expression`, after which the
-// duck-typed union field access reaches the Lambda's `body`.
+// guard narrows `expr` to a non-optional `Expression`; the variant
+// assertion then pins that the initializer is actually a `Lambda` so a
+// shape change fails here with a clear message instead of trapping on
+// the duck-typed `body` access.
 fn lambda_body(expr: Expression?) -> Block {
     if expr == null {
         return Block { tokens: [], text: "", statements: [] };
     }
+    assert expr.variant == "Lambda";
     return expr.body;
 }
 
@@ -32,6 +35,7 @@ fn lambda_body(expr: Expression?) -> Block {
 fn first_let_lambda_body(source: string) -> Block ![io] {
     let program = parse_program(source);
     let stmt = program.statements[0];
+    assert stmt.variant == "VariableDeclaration";
     return lambda_body(stmt.initializer);
 }
 

--- a/compiler/tests/unit/typecheck_expression_walk_test.sfn
+++ b/compiler/tests/unit/typecheck_expression_walk_test.sfn
@@ -82,15 +82,13 @@ test "typecheck walker: undefined callee in match arm still flagged" {
     assert _e0420_for("fn main() { match shape { Other.Run { task }: notbound() } }") == 1;
 }
 
-test "typecheck walker: lambda body callee is not yet flagged" {
-    // Deliberately documents a deferred gap (outside #812's acceptance
-    // criteria, pre-existing from the #809 walker): undefined callees
-    // inside lambda bodies are not surfaced. `walk_expression` has a
-    // Lambda branch that calls `walk_block_expressions`, but in practice
-    // the body emits nothing — verified to hold for the canonical Sailfin
-    // lambda form `fn() { ... }` (not the `=>` arrow, which the parser
-    // reserves for match arms). Pinned at `== 0` so a future fix that
-    // wires lambda-body traversal flips this to `== 1` deliberately
-    // rather than silently regressing coverage.
-    assert _e0420_for("fn main() { let f = fn() { notarealfunction(); }; }") == 0;
+test "typecheck walker: lambda body callee is flagged (E0420)" {
+    // The deferred gap the #809 walker left open is now closed. Since
+    // #520 the lambda parser delegates to the structured `parse_block`,
+    // so `Expression.Lambda.body.statements` is populated and the
+    // `walk_expression` Lambda branch (via `walk_block_expressions`)
+    // reaches the body. The undefined callee inside the canonical
+    // `fn() { ... }` lambda form now surfaces E0420 — this assertion is
+    // the intentional `0 -> 1` flip the prior pin anticipated.
+    assert _e0420_for("fn main() { let f = fn() { notarealfunction(); }; }") == 1;
 }


### PR DESCRIPTION
## Summary
- Reroute the lambda body parser from the token-collecting `parse_block_for_lambda` placeholder to the structured `parse_block` in `parser/statements.sfn`, so `Expression.Lambda.body.statements` is populated at parse time.
- Drop the body-token re-parse workaround in `typecheck_captures.sfn`; `analyze_lambda` now walks `lambda.body` directly.
- Flip the one anticipated downstream test (`typecheck_expression_walk_test.sfn`) from `0 -> 1`: the walker now reaches lambda-body callees, exactly as that test documented it would once traversal was wired.

The placeholder's "module cycle" justification was stale — `declarations.sfn` already imports `parse_block` from `statements.sfn` across the existing `declarations <-> statements` cycle, so the new `expressions -> statements` edge is safe (proven by a clean self-host).

Closes #520

## Acceptance Criteria
- [x] `Expression.Lambda.body.statements` is non-empty for every lambda whose source has at least one parsed statement.
- [x] `typecheck_captures.sfn` no longer re-parses `lambda.body.tokens`; it walks `lambda.body.statements` directly.
- [x] All lambda-capture unit tests still pass (16/16).
- [x] `make compile` self-hosts.
- [x] `make test-unit` (116/116) and `make test-integration` (29/29) pass.
- [x] `sfn fmt --check` clean on touched files.

## Verification
```text
make compile                                         # self-hosts
build/native/sailfin test parser_lambda_body_test    # PASS (4 new tests)
build/native/sailfin test typecheck_lambda_capture   # PASS (16/16)
make test-unit                                        # 116/116 passed
make test-integration                                 # 29/29 passed
sfn fmt --check <touched>                              # EXIT=0
```

## Files Changed
- `compiler/src/parser/expressions.sfn` — call `parse_block`; delete placeholder; drop orphaned imports.
- `compiler/src/typecheck_captures.sfn` — `analyze_lambda` walks `body.statements`; drop `parse_block`/`Parser` imports.
- `compiler/src/llvm/expression_lowering/native/lambda_lowering.sfn` — comment only: retire the stale `parse_block_for_lambda` reference (re-parse logic untouched; out of issue scope, flagged as a follow-up).
- `compiler/tests/unit/parser_lambda_body_test.sfn` — new: empty body, single statement, nested block, nested lambda.
- `compiler/tests/unit/typecheck_expression_walk_test.sfn` — intentional `0 -> 1` flip for the now-traversed lambda body.

## Notes for future grooming
`lambda_lowering.sfn` still re-parses `body.tokens` (line ~362). It now works against the populated `body.statements` and is redundant — a natural follow-up issue, deliberately left out of this PR to honor #520's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018T8AU62PxJC6Umz2pWjNXx)_