### PR TITLE
fix(build): resolve cross-module callee signatures + slugs on -p binary entry

### DIFF
--- a/compiler/src/llvm/imports.sfn
+++ b/compiler/src/llvm/imports.sfn
@@ -361,13 +361,21 @@ fn resolve_import_module_slug_for_module(module: string, current_module_slug: st
 
     let mut slug = join_with_separator(resolved, "/");
 
-    // compiler/tests often import compiler sources via "../../src/<name>".
-    // Our import-context artifacts are rooted at build/native/import-context/<name>.*
-    // (no "src/" dir), so strip that prefix to keep imports and artifact layout
-    // consistent.
-    if starts_with(slug, "src/") {
-        slug = substring(slug, 4, slug.length);
-    }
+    // compiler/tests often import compiler sources via "../../src/<name>",
+    // which resolves to "compiler/src/<name>". Our import-context artifacts
+    // are rooted at build/native/import-context/<name>.* (the compiler's own
+    // sources are staged with the `compiler/src/` prefix stripped, mirroring
+    // `module_name_from_path`), so strip that prefix to keep imports and
+    // artifact layout consistent.
+    //
+    // A plain leading `src/` is NOT stripped here (#999): generic
+    // `src/`-rooted binary capsules stage their modules WITH the `src/`
+    // prefix (`module_name_from_path` only roots at `compiler/src/` and
+    // `runtime/`, and the sibling-side `_cr_relative_slug` keeps `src/`).
+    // Stripping `src/` here made `../main` resolve to bare `main` while the
+    // entry was staged + emitted as `src/main`, so the importing sibling's
+    // mangled call (`do_io__main`) never matched the entry's definition
+    // (`do_io__src__main`) and the link failed with an undefined reference.
     if starts_with(slug, "compiler/src/") {
         slug = substring(slug, 13, slug.length);
     }

--- a/compiler/src/llvm/lowering/entrypoints.sfn
+++ b/compiler/src/llvm/lowering/entrypoints.sfn
@@ -100,6 +100,7 @@ import {
 import { emit_llvm_function } from "./emission";
 import {
     compile_native_text_to_llvm_file,
+    compile_native_text_to_llvm_file_with_context,
     has_fatal_lowering_diagnostic,
     lower_to_llvm_lines_with_parsed_context,
     lower_to_llvm_lines_with_parsed_context_for_tests
@@ -340,6 +341,19 @@ fn write_llvm_ir(native_module: NativeModule, out_path: string) -> boolean ![io]
 // bug that had forced the 0.5.7-era recovery-parser fallback).
 fn write_llvm_ir_from_native_text(native_text: string, module_name: string, out_path: string) -> boolean ![io] {
     return compile_native_text_to_llvm_file(native_text, module_name, out_path);
+}
+
+// Context-carrying variant of `write_llvm_ir_from_native_text` for the
+// `-p` per-module build path (#999). Threads the staged direct-import
+// `.sfn-asm` bodies (from `load_imported_interfaces_from_paths`, e.g. the
+// walk-excluded entry's exported signatures) into lowering so a sibling
+// module's call sites resolve cross-module callee return types instead of
+// hitting the `[fatal]` unresolved-callee gate. The underlying
+// `compile_native_text_to_llvm_file_with_context` UNIONS these texts with
+// the module's embedded-import context — mirrors the tests path
+// (`write_llvm_ir_for_tests_from_text_with_context`).
+fn write_llvm_ir_from_native_text_with_context(native_text: string, module_name: string, out_path: string, imported_native_texts: string[]) -> boolean ![io] {
+    return compile_native_text_to_llvm_file_with_context(native_text, module_name, out_path, imported_native_texts);
 }
 
 fn lower_to_llvm_with_manifests(native_module: NativeModule, imported_manifests: LayoutManifest[]) -> LoweredLLVMResult {

--- a/compiler/src/llvm/lowering/lowering_core.sfn
+++ b/compiler/src/llvm/lowering/lowering_core.sfn
@@ -63,6 +63,7 @@ import {
     number_to_string,
     sanitize_symbol,
     starts_with,
+    string_array_contains,
     trim_text
 } from "../utils";
 import {
@@ -280,14 +281,49 @@ fn make_native_module_for_emit(module_name: string, native_text: string) -> Nati
 }
 
 fn compile_native_text_to_llvm_file(native_text: string, module_name: string, out_path: string) -> boolean ![io] {
+    // In-module-only path: no staged sibling/entry bodies to thread.
+    // Delegates to the context-carrying variant with an empty set so
+    // there is a single lowering implementation (#999).
+    let no_texts: string[] = [];
+    return compile_native_text_to_llvm_file_with_context(native_text, module_name, out_path, no_texts);
+}
+
+// Context-carrying variant for the `-p` per-module build path (#999).
+// The build driver stages each module's direct-import `.sfn-asm` bodies
+// — including the walk-excluded entry (#984) — and loads them via
+// `load_imported_interfaces_from_paths`. The plain
+// `compile_native_text_to_llvm_file` re-derives import context solely
+// from this module's own embedded `import` directives, so a sibling
+// that imports a value-returning fn from the walk-excluded entry could
+// not resolve the callee's return type and hit the `[fatal]`
+// unresolved-callee gate (`core_call_emission.sfn:362`). This variant
+// UNIONS the staged `imported_native_texts` with the
+// embedded-import-derived `collect_imported_module_context_for_module`
+// texts (the module's own imports AND the staged bodies are both
+// needed) so cross-module callee signatures resolve. The `[fatal]` gate
+// is preserved unchanged — this supplies the missing input, it does not
+// weaken the gate (#306).
+fn compile_native_text_to_llvm_file_with_context(native_text: string, module_name: string, out_path: string, imported_native_texts: string[]) -> boolean ![io] {
     if native_text.length == 0 {
         print.err("emit-llvm: empty native text for module " + module_name);
         return false;
     }
     let parse = parse_native_artifact(native_text);
     let import_context = collect_imported_module_context_for_module(parse.imports, module_name);
+    let mut combined_texts: string[] = import_context.native_texts;
+    let mut _it: int = 0;
+    loop {
+        if _it >= imported_native_texts.length { break; }
+        let staged = imported_native_texts[_it];
+        if staged.length > 0 {
+            if !string_array_contains(combined_texts, staged) {
+                combined_texts.push(staged);
+            }
+        }
+        _it += 1;
+    }
     let dummy_module = make_native_module_for_emit(module_name, native_text);
-    let lowered_lines = lower_to_llvm_lines_with_parsed_context(dummy_module, parse, import_context.manifests, import_context.native_texts, import_context.diagnostics, true, native_text);
+    let lowered_lines = lower_to_llvm_lines_with_parsed_context(dummy_module, parse, import_context.manifests, combined_texts, import_context.diagnostics, true, native_text);
     if lowered_lines.lines == null {
         print.err("emit-llvm: lowered lines null");
         return false;

--- a/compiler/src/main.sfn
+++ b/compiler/src/main.sfn
@@ -24,7 +24,8 @@ import {
     lower_to_llvm_ir_from_text,
     print_llvm_ir_from_text,
     write_llvm_ir,
-    write_llvm_ir_from_native_text
+    write_llvm_ir_from_native_text,
+    write_llvm_ir_from_native_text_with_context
 } from "./llvm/lowering/entrypoints";
 import { lower_to_llvm_for_tests } from "./llvm/lowering/entrypoints_tests";
 import { write_llvm_ir_for_tests_from_text_with_context } from "./llvm/lowering/entrypoints_tests_writer";
@@ -101,6 +102,21 @@ fn module_name_from_path(source_path: string) -> string {
             normalized = normalized + ch;
         }
         index += 1;
+    }
+
+    // Canonicalise a leading `./` so an entry passed as `./src/main.sfn`
+    // produces the same slug (`src/main`) as the sibling-side
+    // `_cr_relative_slug`, which canonicalises via `_cr_canonicalise_path`
+    // before calling here. Without this, the `-p` binary entry kept its
+    // `./` (slug `./src/main`) and emitted `do_io_____src__main`, while
+    // importing siblings (and the import resolver) mangle the same callee
+    // to a `src/main`-rooted symbol — leaving an undefined reference at
+    // link time (#999). A single `./` is the common case; loop to be
+    // defensive about `././`.
+    loop {
+        if normalized.length < 2 { break; }
+        if substring(normalized, 0, 2) != "./" { break; }
+        normalized = substring(normalized, 2, normalized.length);
     }
 
     // Prefer stable module names rooted at compiler/src or runtime.
@@ -571,9 +587,15 @@ fn compile_to_llvm_file_with_module_imports(source: string, module_name: string,
     }
     if _reject_reexport_violations(program) { return false; }
     let mut imports = empty_import_symbols();
+    // Staged direct-import `.sfn-asm` bodies (including the walk-excluded
+    // `-p` entry, #984). The loader returns these in the same pass that
+    // builds the E0402 effect table, so the read already happens — we
+    // keep the bodies instead of discarding them (#999).
+    let mut imported_native_texts: string[] = [];
     if import_asm_paths.length > 0 {
         let loaded = load_imported_interfaces_from_paths(import_asm_paths);
         imports = loaded.function_effects;
+        imported_native_texts = loaded.native_texts;
     }
     if validate_and_render_effects(program, source, module_name, imports) > 0 {
         return false;
@@ -587,6 +609,14 @@ fn compile_to_llvm_file_with_module_imports(source: string, module_name: string,
         // that only stats `out_path` cannot mistake it for fresh output.
         if fs.exists(out_path) { fs.deleteFile(out_path); }
         return false;
+    }
+    // `-p` cross-module path: thread the staged import bodies into
+    // lowering so sibling call sites resolve the entry's exported
+    // function signatures (#999). The empty-import / in-process path
+    // (`import_asm_paths.length == 0`) keeps routing through the
+    // context-free writer — no behavior change there.
+    if import_asm_paths.length > 0 {
+        return write_llvm_ir_from_native_text_with_context(native_text, module_name, out_path, imported_native_texts);
     }
     return write_llvm_ir_from_native_text(native_text, module_name, out_path);
 }

--- a/compiler/tests/e2e/test_cross_module_signature_resolution.sh
+++ b/compiler/tests/e2e/test_cross_module_signature_resolution.sh
@@ -94,7 +94,7 @@ fn answer() -> number {
 
 fn main() ![io] {
     let v = compute();
-    print.info(number_to_string(v));
+    print.info("xmod-result=" + number_to_string(v));
 }
 
 export { answer };
@@ -138,9 +138,12 @@ test_runtime_output() {
         cat "$SCRATCH/program.stdout" >&2
         return 1
     fi
-    # answer() == 42, compute() == answer() + 1 == 43.
-    if ! grep -q '43' "$SCRATCH/program.stdout"; then
-        echo "[test]   expected '43' in output; got:" >&2
+    # answer() == 42, compute() == answer() + 1 == 43. Assert the whole
+    # sentinel line (`print.info` prefixes with `[info] `) rather than a
+    # bare `43` substring, which would also match `143`/`430` or an
+    # incidental log line.
+    if ! grep -qx '\[info\] xmod-result=43' "$SCRATCH/program.stdout"; then
+        echo "[test]   expected line '[info] xmod-result=43' in output; got:" >&2
         cat "$SCRATCH/program.stdout" >&2
         return 1
     fi

--- a/compiler/tests/e2e/test_cross_module_signature_resolution.sh
+++ b/compiler/tests/e2e/test_cross_module_signature_resolution.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# Regression for #999: a `-p` sibling that imports a VALUE-RETURNING fn
+# from the walk-excluded entry must resolve the callee's return-type
+# signature during its own per-module lowering, emit cleanly, link, and
+# run.
+#
+# Root cause (pre-#999): `compile_to_llvm_file_with_module_imports`
+# (main.sfn) loaded the entry's staged `.sfn-asm` only to feed the E0402
+# effect gate (`loaded.function_effects`), then discarded
+# `loaded.native_texts` and lowered through the context-free
+# `write_llvm_ir_from_native_text`. The sibling's per-module emit
+# re-derived import context from its own embedded `import` directives
+# only — never seeing the walk-excluded entry's body — so a call to the
+# entry's exported fn could not resolve its return type and hit the
+# `cannot resolve return type for call` `[fatal]`
+# (core_call_emission.sfn:362), surfaced via `has_fatal_lowering_diagnostic`.
+#
+# #999 threads `loaded.native_texts` into a context-carrying lowering
+# writer (`write_llvm_ir_from_native_text_with_context`) that UNIONS the
+# staged bodies with the embedded-import context, mirroring the proven
+# tests path. The `[fatal]` gate is untouched — the fix supplies the
+# missing input, it does not weaken the gate (#306).
+#
+# This drives the real resolver via `sfn build -p .` on a synthetic
+# binary capsule. Unlike `test_effect_gate_build_path_entry.sh` (orphan
+# sibling), `main()` here CALLS the sibling, so the sibling is linked and
+# the produced binary is run — a clean emit must also produce correct
+# runtime output.
+#
+# Usage:
+#   compiler/tests/e2e/test_cross_module_signature_resolution.sh <compiler-binary>
+
+set -euo pipefail
+
+BINARY="${1:?usage: test_cross_module_signature_resolution.sh <compiler-binary>}"
+BINARY="$(realpath "$BINARY")"
+PASS=0
+FAIL=0
+
+SCRATCH="$(mktemp -d -t sfn-xmod-sig-XXXXXX)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+run_test() {
+    local name="$1"
+    shift
+    if "$@"; then
+        echo "[test] PASS: $name"
+        PASS=$((PASS + 1))
+    else
+        echo "[test] FAIL: $name"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+mkdir -p "$SCRATCH/src/util"
+
+cat > "$SCRATCH/capsule.toml" <<'EOF'
+[capsule]
+name = "xmod-sig-test"
+version = "0.1.0"
+description = "E2E regression for #999 cross-module signature resolution on -p"
+
+[capabilities]
+required = ["io"]
+
+[build]
+kind = "binary"
+entry = "src/main.sfn"
+EOF
+
+# Sibling: imports the value-returning `answer` from the entry and
+# returns a value derived from it. Correctly annotated (no effects).
+cat > "$SCRATCH/src/util/sib.sfn" <<'EOF'
+import { answer } from "../main";
+
+fn compute() -> number {
+    return answer() + 1;
+}
+
+export { compute };
+EOF
+
+# Entry module: exports a VALUE-RETURNING fn (`answer`) and imports
+# `compute` from the sibling so the linked binary is runnable. The `-p`
+# walker excludes this file from `resolved.sources`; #984 stages it for
+# slug resolution and #999 threads its body into sibling lowering so the
+# return type of `answer()` resolves at the sibling's call site.
+cat > "$SCRATCH/src/main.sfn" <<'EOF'
+import { compute } from "./util/sib";
+
+fn answer() -> number {
+    return 42;
+}
+
+fn main() ![io] {
+    let v = compute();
+    print.info(number_to_string(v));
+}
+
+export { answer };
+EOF
+
+# ---- Test 1: build emits cleanly (no unresolved-callee fatal) ----
+# Grep for the SPECIFIC imported callees (`answer`, `compute`) rather than
+# the generic "cannot resolve return type" phrase: a sibling that imports
+# an io-side-effecting void fn from the entry can still surface a
+# non-blocking "...call to `write`..." diagnostic while the build links
+# fine. Pinning the user-level callees keeps this test a precise #999
+# regression (the build exiting 0 is the authoritative signal).
+test_no_unresolved_callee_fatal() {
+    cd "$SCRATCH" || return 1
+    rm -rf "$SCRATCH/build"
+    local rc=0
+    "$BINARY" build -p . > "$SCRATCH/build.stdout" 2>&1 || rc=$?
+    if grep -qE "cannot resolve return type for call to .(answer|compute)." "$SCRATCH/build.stdout"; then
+        echo "[test]   sibling hit the #999 unresolved-callee fatal:" >&2
+        cat "$SCRATCH/build.stdout" >&2
+        return 1
+    fi
+    if [ "$rc" -ne 0 ]; then
+        echo "[test]   expected exit 0 for cross-module value-returning build; got $rc" >&2
+        cat "$SCRATCH/build.stdout" >&2
+        return 1
+    fi
+    return 0
+}
+run_test "cross-module value-returning sibling emits + links (#999)" test_no_unresolved_callee_fatal
+
+# ---- Test 2: the linked binary runs and prints the resolved value ----
+test_runtime_output() {
+    cd "$SCRATCH" || return 1
+    local exe="$SCRATCH/build/sailfin/program"
+    [ -x "$exe" ] || { echo "[test]   no linked binary at $exe" >&2; return 1; }
+    local rc=0
+    "$exe" > "$SCRATCH/program.stdout" 2>&1 || rc=$?
+    if [ "$rc" -ne 0 ]; then
+        echo "[test]   linked binary exited with code $rc; output:" >&2
+        cat "$SCRATCH/program.stdout" >&2
+        return 1
+    fi
+    # answer() == 42, compute() == answer() + 1 == 43.
+    if ! grep -q '43' "$SCRATCH/program.stdout"; then
+        echo "[test]   expected '43' in output; got:" >&2
+        cat "$SCRATCH/program.stdout" >&2
+        return 1
+    fi
+    return 0
+}
+run_test "linked binary computes 43 across the module boundary (#999)" test_runtime_output
+
+# ---- Summary ----
+echo ""
+echo "[test] $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/compiler/tests/e2e/test_effect_gate_build_path_entry.sh
+++ b/compiler/tests/e2e/test_effect_gate_build_path_entry.sh
@@ -174,40 +174,45 @@ test_bad_sibling_e0402() {
 }
 run_test "build path emits E0402 + exits non-zero for orphan sibling->entry ![io]" test_bad_sibling_e0402
 
-# ---- Test 3: a clean -p build still exits 0 (issue #991 guard) ----
-# Pins acceptance criterion 3: the #991 driver guard returns non-zero
-# only when a module actually failed to compile. A `-p` build where
-# every module emits cleanly must still link and exit 0 — the
-# empty-vs-failed `ll_paths` distinction must not regress a legitimate
-# build into a failure.
+# ---- Test 3: cross-module good sibling emits + links, exits 0 (#999) ----
+# Pins #999 acceptance: a correctly-annotated `-p` sibling that imports a
+# value-returning fn FROM THE WALK-EXCLUDED ENTRY must resolve the entry's
+# exported signature during its own per-module lowering and emit cleanly,
+# so the build links and exits 0.
 #
-# This uses a SELF-CONTAINED sibling (no cross-module import) rather
-# than the good-case `write_sib " ![io]"` fixture: a sibling that
-# imports the entry's `do_io` currently can't resolve the entry's
-# return-type signature during its own per-module lowering (a separate
-# latent limitation of cross-module `-p` emit), so that "good" sibling
-# does not in fact emit cleanly. An orphan sibling with no imports and
-# declared effects is the clean-emit case this criterion needs.
-test_clean_build_exits_zero() {
+# Before #999 this exact fixture (`write_sib " ![io]"`) failed: the build
+# path loaded the entry's staged `.sfn-asm` only for the E0402 effect
+# gate, then discarded `loaded.native_texts` before lowering. The
+# sibling's per-module emit re-derived import context from its own embedded
+# `import` directives only, never saw the entry body, and hit the
+# `cannot resolve return type for call to do_io` `[fatal]` — which #991's
+# driver guard then surfaced as a non-zero build. #999 threads the staged
+# bodies into lowering so the callee signature resolves. This is the real
+# cross-module case (not the self-contained orphan the pre-#999 test used
+# to dodge the bug).
+test_cross_module_sibling_builds() {
     cd "$SCRATCH" || return 1
     rm -rf "$SCRATCH/build"
-    cat > "$SCRATCH/src/util/sib.sfn" <<'EOF'
-fn use_dep() ![io] {
-    print.info("sibling side effect");
-}
-
-export { use_dep };
-EOF
+    write_sib " ![io]"  # use_dep() ![io] imports + calls the entry's do_io()
     local rc=0
     "$BINARY" build -p . > "$SCRATCH/good2.stdout" 2>&1 || rc=$?
+    # Pin the SPECIFIC #999 callee (`do_io`) rather than the generic phrase:
+    # lowering the imported io-void body can surface a non-blocking
+    # "...call to `write`..." diagnostic while the build still links and
+    # exits 0, which is the authoritative signal here.
+    if grep -qE "cannot resolve return type for call to .do_io." "$SCRATCH/good2.stdout"; then
+        echo "[test]   cross-module sibling hit the #999 unresolved-callee fatal:" >&2
+        cat "$SCRATCH/good2.stdout" >&2
+        return 1
+    fi
     if [ "$rc" -ne 0 ]; then
-        echo "[test]   expected exit 0 for clean -p build; got exit $rc" >&2
+        echo "[test]   expected exit 0 for cross-module good sibling; got exit $rc" >&2
         cat "$SCRATCH/good2.stdout" >&2
         return 1
     fi
     return 0
 }
-run_test "clean -p build exits 0 (no-failure path not regressed)" test_clean_build_exits_zero
+run_test "cross-module good sibling resolves entry signature + exits 0 (#999)" test_cross_module_sibling_builds
 
 # ---- Summary ----
 echo ""

--- a/compiler/tests/e2e/test_effect_gate_build_path_entry.sh
+++ b/compiler/tests/e2e/test_effect_gate_build_path_entry.sh
@@ -175,10 +175,12 @@ test_bad_sibling_e0402() {
 run_test "build path emits E0402 + exits non-zero for orphan sibling->entry ![io]" test_bad_sibling_e0402
 
 # ---- Test 3: cross-module good sibling emits + links, exits 0 (#999) ----
-# Pins #999 acceptance: a correctly-annotated `-p` sibling that imports a
-# value-returning fn FROM THE WALK-EXCLUDED ENTRY must resolve the entry's
-# exported signature during its own per-module lowering and emit cleanly,
-# so the build links and exits 0.
+# Pins #999 acceptance: a correctly-annotated `-p` sibling that imports an
+# entry-exported fn (`do_io`, void `![io]`) FROM THE WALK-EXCLUDED ENTRY
+# must resolve the entry's exported signature during its own per-module
+# lowering and emit cleanly, so the build links and exits 0. (The
+# value-returning variant is covered end-to-end in
+# `test_cross_module_signature_resolution.sh`.)
 #
 # Before #999 this exact fixture (`write_sib " ![io]"`) failed: the build
 # path loaded the entry's staged `.sfn-asm` only for the E0402 effect


### PR DESCRIPTION
## Summary

A `-p` binary-capsule sibling that imports a value-returning fn from the **walk-excluded entry** could not build. With my fix it now emits, links, and runs.

Two coupled causes — the issue's stated emit-side mechanism **and** a slug-alignment root cause the issue scoped as "already correct (#957 + #984)". The reproduction can't reach *build + exit 0* without both, so (per maintainer direction) scope was expanded to cover the slug fix:

1. **Emit/loader-side (#999 mechanism).** `compile_to_llvm_file_with_module_imports` loaded the staged `.import-deps` only for the E0402 effect gate (`loaded.function_effects`) and discarded `loaded.native_texts` before lowering. Now threaded into a new context-carrying writer (`write_llvm_ir_from_native_text_with_context` → `compile_native_text_to_llvm_file_with_context`) that **unions** them with the embedded-import context, mirroring the proven tests path. The `[fatal]` unresolved-callee gate is untouched.

2. **Slug alignment (root cause).** The importer (`resolve_import_module_slug_for_module`) stripped a leading `src/`, resolving `../main` → bare `main`, while the entry was staged + emitted as `src/main` (via `module_name_from_path`). So the sibling's mangled call (`do_io__main`) never matched the entry's definition (`do_io__src__main`) → `undefined reference` at link. Fix: stop stripping plain `src/` in the importer (the `compiler/src/` strip still covers the `compiler/tests → ../../src/` case it was added for), and canonicalise a leading `./` in `module_name_from_path` so the entry roots at `src/main` consistently with sibling slugs.

Closes #999

## Acceptance Criteria
- [x] The reproduction builds and exits 0 (no `cannot resolve return type for call to do_io` fatal).
- [x] `loaded.native_texts` threaded into lowering for the non-test `-p` emit path; effect gate still consumes `loaded.function_effects` unchanged (E0402 preserved).
- [x] No regression on the in-process / non-`-p` path (`import_asm_paths.length == 0` still routes through the context-free writer).
- [x] `test_effect_gate_build_path_entry.sh` Test 3 asserts the cross-module good sibling emits + links (not just the sidecar).
- [x] New regression in `compiler/tests/e2e/` — value-returning cross-module import builds, links, and runs (`computes 43`).
- [ ] `make check` — running locally now (will confirm).
- [x] Targeted e2e + `test_binary_capsule_walker` (src/-slug expectations) pass.
- [x] `sfn fmt --check` clean on every touched `.sfn` file.

## Verification
```text
test_cross_module_signature_resolution.sh   2 passed, 0 failed
test_effect_gate_build_path_entry.sh        3 passed, 0 failed
test_binary_capsule_walker.sh               4 passed, 0 failed   (slug-convention regression guard)
sfn fmt --check (main, imports, entrypoints, lowering_core)  clean
make rebuild  exit 0 (self-hosts first-pass)
make check    in progress
```

## Files Changed
- `compiler/src/main.sfn` — thread `loaded.native_texts`; canonicalise leading `./` in `module_name_from_path`.
- `compiler/src/llvm/imports.sfn` — stop stripping plain `src/` in `resolve_import_module_slug_for_module`.
- `compiler/src/llvm/lowering/entrypoints.sfn` + `lowering_core.sfn` — `*_with_context` writer that unions staged import bodies with embedded-import context.
- `compiler/tests/e2e/test_effect_gate_build_path_entry.sh` — Test 3 tightened to the cross-module good sibling.
- `compiler/tests/e2e/test_cross_module_signature_resolution.sh` — new end-to-end regression.

## Note for reviewers
Once cross-entry resolution succeeds, importing an **io-side-effecting void** fn from the entry surfaces a **non-blocking** `cannot resolve return type for call to \`write\`` diagnostic (the imported body is touched during the importer's emit). It does **not** gate the build (exit 0) and does not affect the value-returning path. Tracking it as a follow-up rather than expanding this PR further into the #508 re-export-shim / import-body lowering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011sCktxpZ1GNC6YQTKHddta)_