### PR TITLE
fix(driver): sfn emit native fails closed on unresolved-callee programs

### DIFF
--- a/compiler/src/cli_main.sfn
+++ b/compiler/src/cli_main.sfn
@@ -69,12 +69,12 @@ import {
     compile_to_llvm_file_with_module,
     compile_to_llvm_with_module,
     compile_to_llvm_with_module_timed,
-    compile_to_native_text_with_module,
     compile_to_sailfin,
     module_name_from_path,
     number_to_string,
     print_llvm_with_module,
-    write_native_text_file_with_module
+    print_native_text_with_module_gated,
+    write_native_text_file_with_module_gated
 } from "./main";
 import { RuntimeCapsuleArtifacts, runtime_capsule_from_root } from "./runtime_capsule_resolver";
 import {
@@ -1499,6 +1499,11 @@ fn sailfin_cli_main(argv: string[]) -> int ![io, clock] {
         // round-trip.
         let mut emit_attempts: int = 1;
         let mut emit_validate: boolean = false;
+        // #906: build-internal per-module native emits set this (via
+        // `--no-resolve-gate`) to skip the lowering dry-run gate, which
+        // would otherwise reject legitimate cross-module calls that the
+        // import-context-free native stage cannot resolve in isolation.
+        let mut skip_resolve_gate: boolean = false;
         let mut base_index = 1;
         // Parse optional flags: --timing, --module-name <slug>,
         // -o <path>, --attempts N, --no-retry, --validate,
@@ -1577,6 +1582,12 @@ fn sailfin_cli_main(argv: string[]) -> int ![io, clock] {
                 consumed_flag = true;
                 continue;
             }
+            if strings_equal(args[base_index], "--no-resolve-gate") {
+                skip_resolve_gate = true;
+                base_index += 1;
+                consumed_flag = true;
+                continue;
+            }
         }
         let _expected_args = base_index + 2;
         if args.length != _expected_args {
@@ -1635,11 +1646,24 @@ fn sailfin_cli_main(argv: string[]) -> int ![io, clock] {
             return 0;
         }
         if strings_equal(mode, "native") {
+            // #906: gate the native emit on the same lowering `[fatal]`
+            // that `build` / `emit llvm` reject, so `emit native` fails
+            // closed (rc != 0, no `.sfn-asm`) on unresolved-callee inputs
+            // instead of writing an artifact and exiting 0. The build's
+            // per-module subprocess emit passes `--no-resolve-gate`
+            // (`skip_resolve_gate`) to opt out: that stage emits
+            // intermediate `.sfn-asm` with no cross-module import context,
+            // so it must not gate here — the build stays fail-closed via
+            // its later LLVM lowering stage (#631).
+            let run_gate = !skip_resolve_gate;
             if has_out {
-                let ok = write_native_text_file_with_module(source, module_name, out_path);
-                if !ok { return 1; }
+                if !write_native_text_file_with_module_gated(source, module_name, out_path, run_gate) {
+                    return 1;
+                }
             } else {
-                print(compile_to_native_text_with_module(source, module_name));
+                if !print_native_text_with_module_gated(source, module_name, run_gate) {
+                    return 1;
+                }
             }
             return 0;
         }

--- a/compiler/src/emit_helpers.sfn
+++ b/compiler/src/emit_helpers.sfn
@@ -247,7 +247,14 @@ fn emit_subprocess_with_retry(sailfin_exe: string, module_name: string, source_p
         // is always the same-generation binary (`<binary_dir>/sailfin`),
         // so it understands these flags; the seed never executes this
         // helper (pass 1 of `make compile` runs the seed's own resolver).
-        let mut emit_args: string[] = [sailfin_exe, "emit", "--module-name", module_name, "--attempts", "1", "--no-validate", "-o", out_path];
+        // `--no-resolve-gate` (#906): this is the build's per-module
+        // intermediate emit. For the `native` stage it carries no
+        // cross-module import context, so the lowering dry-run gate would
+        // falsely reject legitimate imported calls; suppress it here and
+        // let the build's LLVM lowering stage (#631) own fail-closed. The
+        // `llvm` stage ignores the flag. The same-generation `sailfin_exe`
+        // understands it; the seed never executes this helper.
+        let mut emit_args: string[] = [sailfin_exe, "emit", "--module-name", module_name, "--attempts", "1", "--no-validate", "--no-resolve-gate", "-o", out_path];
         if import_context_root.length > 0 {
             emit_args.push("--import-context");
             emit_args.push(import_context_root);

--- a/compiler/src/llvm/lowering/lowering_core.sfn
+++ b/compiler/src/llvm/lowering/lowering_core.sfn
@@ -332,6 +332,54 @@ fn compile_native_text_to_llvm_file(native_text: string, module_name: string, ou
     return write_llvm_lines_chunked(out_path, lines);
 }
 
+// Dry-run the lowering gate over already-emitted native text WITHOUT
+// writing any artifact. Used by `sfn emit native` (issue #906) so that
+// command fails closed on the same unresolved-callee inputs that
+// `sfn build` / `sfn emit llvm` reject via `compile_native_text_to_llvm_file`.
+// `emit native` stops at the native-IR stage (stage 5), before LLVM
+// lowering (stage 6) where the `cannot resolve return type for call to
+// ...` `[fatal]` is produced — so it never participated in return-type
+// resolution and false-greened. This reuses the exact same lowering
+// path and `[fatal]` scan as the `build` / `emit llvm` gate, guaranteeing
+// byte-for-byte parity, but discards the lowered IR and writes nothing.
+// Returns true when the native text lowers clean (no fatal), false on a
+// fatal, empty/null input, or a lowering failure.
+//
+// NOTE: this lives off the self-host build path. The build's per-module
+// stage-5 emit (`capsule_resolver.sfn`) calls the native-emit workers
+// directly and never invokes this gate, so adding it cannot break
+// self-hosting (cross-module signature resolution still happens later at
+// the LLVM stage as before).
+fn native_text_passes_lowering_gate(native_text: string, module_name: string) -> boolean ![io] {
+    if native_text.length == 0 {
+        // No text to gate: the native emitter already failed upstream
+        // (typecheck / effect / re-export error) and produced nothing.
+        return false;
+    }
+    let parse = parse_native_artifact(native_text);
+    let import_context = collect_imported_module_context_for_module(parse.imports, module_name);
+    let dummy_module = make_native_module_for_emit(module_name, native_text);
+    let lowered_lines = lower_to_llvm_lines_with_parsed_context(dummy_module, parse, import_context.manifests, import_context.native_texts, import_context.diagnostics, true, native_text);
+    if lowered_lines.lines == null {
+        print.err("emit-native: lowered lines null");
+        return false;
+    }
+    // Same fatal contract as `compile_native_text_to_llvm_file` above:
+    // print every `[fatal]` so the user sees the underlying cause, then
+    // refuse the emit.
+    if has_fatal_lowering_diagnostic(lowered_lines.diagnostics) {
+        let mut _fdi: int = 0;
+        loop {
+            if _fdi >= lowered_lines.diagnostics.length { break; }
+            let _diag = lowered_lines.diagnostics[_fdi];
+            if index_of(_diag, "[fatal]") >= 0 { print.err(_diag); }
+            _fdi += 1;
+        }
+        return false;
+    }
+    return true;
+}
+
 // Returns true if any diagnostic in the list carries the `[fatal]`
 // sentinel tag. Lowering passes use this prefix to escalate a
 // diagnostic from "warning the user sees on stderr" to "the build

--- a/compiler/src/llvm/lowering/lowering_core.sfn
+++ b/compiler/src/llvm/lowering/lowering_core.sfn
@@ -377,6 +377,20 @@ fn native_text_passes_lowering_gate(native_text: string, module_name: string) ->
         }
         return false;
     }
+    // Mirror the remaining non-fatal rejection conditions in
+    // `compile_native_text_to_llvm_file` above so `emit native` matches
+    // `emit llvm` exactly, not just on `[fatal]`: lowering that produces
+    // lines but no defined function symbols, or no output lines at all, is
+    // a hard error there and must be one here too.
+    let lowered_count = lowered_lines.lines.length;
+    if lowered_count > 0 {
+        let defined = collect_defined_function_symbols(lowered_lines.lines);
+        if defined.length == 0 { return false; }
+    }
+    if lowered_lines.lines.length == 0 {
+        print.err("emit-native: lowering produced no output lines");
+        return false;
+    }
     return true;
 }
 

--- a/compiler/src/main.sfn
+++ b/compiler/src/main.sfn
@@ -28,6 +28,7 @@ import {
 } from "./llvm/lowering/entrypoints";
 import { lower_to_llvm_for_tests } from "./llvm/lowering/entrypoints_tests";
 import { write_llvm_ir_for_tests_from_text_with_context } from "./llvm/lowering/entrypoints_tests_writer";
+import { native_text_passes_lowering_gate } from "./llvm/lowering/lowering_core";
 import { runtime_helper_call_names } from "./llvm/runtime_helpers";
 import { LayoutManifest } from "./native_ir";
 import { number_to_string } from "./num_format";
@@ -527,6 +528,52 @@ fn write_native_text_file_with_module(source: string, module_name: string, out_p
         return false;
     }
     return emit_native_text_to_file_with_module_name(program, module_name, out_path);
+}
+
+// `sfn emit native` file mode (issue #906): emit the `.sfn-asm`, then —
+// when `run_gate` is set — run the lowering dry-run gate over the
+// just-written text so the command fails closed on the same
+// unresolved-callee inputs `sfn build` / `sfn emit llvm` reject. On a gate
+// failure, delete the artifact (mirrors the stale-`.ll` cleanup in
+// `compile_native_text_to_llvm_file`) so no `.sfn-asm` survives and
+// downstream tooling that only stats the path cannot mistake it for a
+// clean build.
+//
+// `run_gate` is false for the build's per-module subprocess emit
+// (`emit_subprocess_with_retry` passes `--no-resolve-gate`): that stage
+// emits intermediate `.sfn-asm` with NO cross-module import context, so a
+// legitimate imported call is unresolvable in isolation and must not be
+// gated here — the build's load-bearing fail-closed gate is the later
+// LLVM lowering stage (#631), not this native stage.
+fn write_native_text_file_with_module_gated(source: string, module_name: string, out_path: string, run_gate: boolean) -> boolean ![io] {
+    let ok = write_native_text_file_with_module(source, module_name, out_path);
+    if !ok { return false; }
+    if !run_gate { return true; }
+    let native_text = fs.readFile(out_path);
+    if native_text_passes_lowering_gate(native_text, module_name) {
+        return true;
+    }
+    if fs.exists(out_path) { fs.deleteFile(out_path); }
+    return false;
+}
+
+// `sfn emit native` stdout mode (issue #906): when `run_gate` is set, gate
+// the native text before printing it, so a program that would fail
+// `build` / `emit llvm` does not emit `.sfn-asm` to stdout with a rc=0
+// false-green. Returns false (→ CLI exits non-zero) on emit failure or a
+// lowering fatal. An empty text means the native emitter already failed
+// upstream (typecheck / effect / re-export) and printed its own
+// diagnostics. `run_gate` is false for build-internal emits (see the file
+// wrapper above).
+fn print_native_text_with_module_gated(source: string, module_name: string, run_gate: boolean) -> boolean ![io] {
+    let native_text = compile_to_native_text_with_module(source, module_name);
+    if run_gate {
+        if !native_text_passes_lowering_gate(native_text, module_name) {
+            return false;
+        }
+    }
+    print(native_text);
+    return true;
 }
 
 // Compile and write LLVM IR directly, avoiding large return values.

--- a/compiler/src/main.sfn
+++ b/compiler/src/main.sfn
@@ -567,6 +567,14 @@ fn write_native_text_file_with_module_gated(source: string, module_name: string,
 // wrapper above).
 fn print_native_text_with_module_gated(source: string, module_name: string, run_gate: boolean) -> boolean ![io] {
     let native_text = compile_to_native_text_with_module(source, module_name);
+    // Empty text is this module's sentinel for an upstream failure
+    // (typecheck / effect / re-export) that already emitted diagnostics.
+    // Fail closed unconditionally — independent of `run_gate` — so stdout
+    // mode never prints an empty artifact and exits 0 (e.g. under
+    // `--no-resolve-gate`), matching the file wrapper, whose underlying
+    // `write_native_text_file_with_module` already returns false on the
+    // same sentinel.
+    if native_text.length == 0 { return false; }
     if run_gate {
         if !native_text_passes_lowering_gate(native_text, module_name) {
             return false;

--- a/compiler/tests/e2e/test_sync_rejects_unimplemented_concurrency.sh
+++ b/compiler/tests/e2e/test_sync_rejects_unimplemented_concurrency.sh
@@ -31,6 +31,11 @@
 # diagnostic the moment lowering tries to compile a call to a
 # now-unknown name.
 #
+# As of #631 `sfn build` and `sfn emit llvm` both fail closed on these
+# inputs; as of #906 `sfn emit native` joins them (it previously stopped at
+# stage 5, before lowering, and false-greened with a `.sfn-asm` at rc=0).
+# All three surfaces now reject the identical unresolved-callee programs.
+#
 # The typed `spawn_*` / `await_*` runtime variants below are not
 # exercised here — they have working pthread implementations and
 # are unaffected by this change.
@@ -207,6 +212,67 @@ assert_emit_llvm_rejects() {
     return 0
 }
 
+# `sfn emit native` stops at the native-IR stage (stage 5), BEFORE the
+# LLVM lowering (stage 6) that produces the `cannot resolve return type
+# for call to ...` `[fatal]`. Pre-#906 it therefore never participated in
+# return-type resolution: it wrote a `.sfn-asm` and exited 0 even for the
+# unresolved-callee inputs `build` / `emit llvm` reject — a false green for
+# any tool gating on its exit code. #906 added a CLI-level lowering dry-run
+# gate (`native_text_passes_lowering_gate`) that reuses the exact same
+# `[fatal]` machinery, so `emit native` now fails closed (rc != 0, no
+# `.sfn-asm`) in parity with the other two surfaces. The gate lives only on
+# the `emit native` command path, never on the self-host build's per-module
+# stage-5 emit, so it cannot affect bootstrapping. (When #616 lands a shared
+# typecheck-layer gate, this dry-run becomes redundant and can be removed
+# without touching the build path — keep the two from diverging.)
+#
+# Note the argument order: `emit -o OUT native FILE` (mode follows the
+# output flag), matching the CLI dispatch in `cli_main.sfn`.
+assert_emit_native_rejects() {
+    local label="$1"
+    local source="$2"
+    local symbol="$3"
+
+    local src_path="$SCRATCH/${label}.sfn"
+    local out_path="$SCRATCH/${label}.sfn-asm"
+    local log_path="$SCRATCH/${label}.emitnative.log"
+    printf '%s\n' "$source" > "$src_path"
+
+    local rc=0
+    ( cd "$SCRATCH" && "$BINARY" emit -o "$out_path" native "$src_path" ) \
+        > "$log_path" 2>&1 || rc=$?
+
+    if [ "$rc" -eq 0 ]; then
+        echo "[test]   emit native of ${label}.sfn exited 0 — expected non-zero (fail-closed)" >&2
+        echo "[test]   output:" >&2
+        sed 's/^/[test]     /' "$log_path" >&2
+        return 1
+    fi
+
+    if [ -e "$out_path" ]; then
+        echo "[test]   emit native of ${label}.sfn produced a .sfn-asm at ${out_path} — expected none" >&2
+        echo "[test]   output:" >&2
+        sed 's/^/[test]     /' "$log_path" >&2
+        return 1
+    fi
+
+    if ! grep -q "cannot resolve" "$log_path"; then
+        echo "[test]   emit native diagnostic for ${label}.sfn did not mention 'cannot resolve'" >&2
+        echo "[test]   output:" >&2
+        sed 's/^/[test]     /' "$log_path" >&2
+        return 1
+    fi
+
+    if ! grep -q "\`${symbol}\`" "$log_path"; then
+        echo "[test]   emit native diagnostic for ${label}.sfn did not name '\`${symbol}\`'" >&2
+        echo "[test]   output:" >&2
+        sed 's/^/[test]     /' "$log_path" >&2
+        return 1
+    fi
+
+    return 0
+}
+
 test_channel_via_sfn_sync_rejected() {
     assert_build_rejects "channel_import_caller" \
 'import { channel } from "sfn/sync";
@@ -288,6 +354,30 @@ test_emit_llvm_spawn_rejected() {
         "spawn"
 }
 
+# Issue #906: `sfn emit native` must fail closed on the same unresolved
+# callees as `build` / `emit llvm`. Cover both shapes from the issue
+# reproduction:
+#   - value-returning unresolved call (`let _ = channel(0)`), and
+#   - void-returning unresolved call (`spawn(0, "worker")`).
+# Each must exit non-zero AND leave no `.sfn-asm` behind.
+test_emit_native_channel_rejected() {
+    assert_emit_native_rejects "channel_emit_native_caller" \
+'import { channel } from "sfn/sync";
+
+fn main() ![io] {
+    let _ch = channel(0);
+}' \
+        "channel"
+}
+
+test_emit_native_spawn_rejected() {
+    assert_emit_native_rejects "spawn_emit_native_caller" \
+'fn main() ![io] {
+    spawn(0, "worker");
+}' \
+        "spawn"
+}
+
 run_test "sfn build rejects sfn/sync.channel import (#617)" test_channel_via_sfn_sync_rejected
 run_test "sfn build rejects sfn/sync.parallel import (#617)" test_parallel_via_sfn_sync_rejected
 run_test "sfn build rejects sfn/sync.spawn import (#617)" test_spawn_via_sfn_sync_rejected
@@ -295,6 +385,8 @@ run_test "sfn build rejects bare prelude channel() (#617)" test_channel_via_prel
 run_test "sfn build rejects bare prelude spawn() (#617)" test_spawn_via_prelude_name_rejected
 run_test "sfn build fails closed on unknown void helper (#631)" test_unknown_void_helper_rejected
 run_test "sfn emit llvm fails closed on void spawn() (#631)" test_emit_llvm_spawn_rejected
+run_test "sfn emit native fails closed on value channel() (#906)" test_emit_native_channel_rejected
+run_test "sfn emit native fails closed on void spawn() (#906)" test_emit_native_spawn_rejected
 
 echo "[summary] $PASS passed, $FAIL failed"
 if [ "$FAIL" -gt 0 ]; then


### PR DESCRIPTION
## Summary

- `sfn emit native` stopped at the native-IR stage (stage 5), **before** the LLVM lowering stage (stage 6) where the `cannot resolve return type for call to ...` `[fatal]` is produced — so it wrote a `.sfn-asm` and exited `0` for programs `sfn build` / `sfn emit llvm` reject (after #631). A false green for any tool gating on its exit code.
- Adds a CLI-level lowering **dry-run gate** (`native_text_passes_lowering_gate`) that reuses the exact `[fatal]` machinery the other two surfaces use, so `emit native` now fails closed (rc != 0, **no** `.sfn-asm`) in parity with them. Writes no `.ll`.
- The gate runs **only** on the user-facing `emit native`. The build's per-module subprocess emit passes a new internal `--no-resolve-gate` flag to opt out: that stage carries no cross-module import context, so a legitimate imported call is unresolvable in isolation and must not be gated there — the build stays fail-closed via its later LLVM lowering stage (#631), not the native stage.

Closes #906

## Approach

Chosen layer (groomed at the design gate): **Approach 1 — a CLI-only lowering dry-run**, not Approach 2 (typecheck) and not a gate inside the native-emit workers. The decisive constraint: the self-host build uses the `emit native` subprocess as an intermediate per-module stage 5, where a single module has no cross-module signature visibility. A gate in the workers or at typecheck would fire on every legitimate cross-module call and break self-hosting (and entangle #616's unsolved cross-module-resolution problem).

## Acceptance Criteria

- [x] `sfn emit native` on a program with an unresolved value-returning call exits rc≠0 and writes no `.sfn-asm`.
- [x] Same for an unresolved void-returning call.
- [x] Behavior matches `sfn build` / `sfn emit llvm` on identical inputs.
- [x] `make compile` self-hosts on the unchanged seed.
- [x] `make test` passes (unit + integration + e2e + capsules).
- [x] `sfn fmt --check` clean on every touched `.sfn` file.

## Verification

```bash
# value-returning unresolved call
printf 'import { channel } from "sfn/sync";\nfn main() [io] { let _ = channel(0); }\n' > /tmp/v.sfn
build/native/sailfin emit -o /tmp/v.asm native /tmp/v.sfn ; echo rc=$?   # rc=1
test ! -e /tmp/v.asm && echo "no artifact OK"                            # no artifact OK

# void-returning unresolved call
printf 'fn main() [io] { spawn(0, "x"); }\n' > /tmp/x.sfn
build/native/sailfin emit -o /tmp/x.asm native /tmp/x.sfn ; echo rc=$?   # rc=1
test ! -e /tmp/x.asm && echo "no artifact OK"                            # no artifact OK

# parity / no-regression: known-good program still emits
build/native/sailfin emit -o /tmp/ok.asm native examples/basics/hello-world.sfn ; echo rc=$?  # rc=0, artifact present
```

Results: both unresolved cases → `rc=1`, no artifact; known-good → `rc=0`, artifact present.

- `make compile` — self-hosts (exit 0)
- `make test` — **e2e-sh 92/92, 0 failed** (exit 0)
- `sfn fmt --check` on all four `.sfn` files — clean
- `compiler/tests/e2e/test_sync_rejects_unimplemented_concurrency.sh` — 9/9 (incl. 2 new #906 cases)
- `compiler/tests/e2e/test_effect_gate_build_path_entry.sh` — 3/3 (guards the build path is not regressed by the gate)

## Files Changed

- `compiler/src/llvm/lowering/lowering_core.sfn` — `native_text_passes_lowering_gate` (side-effect-free dry-run).
- `compiler/src/main.sfn` — gated wrappers `write_native_text_file_with_module_gated` / `print_native_text_with_module_gated` (with a `run_gate` opt-out); bare `write_native_text_file_with_module` untouched (the build calls it directly).
- `compiler/src/cli_main.sfn` — `cmd_emit` native branch rewired to the gated wrappers + `--no-resolve-gate` flag.
- `compiler/src/emit_helpers.sfn` — build subprocess emit passes `--no-resolve-gate`.
- `compiler/tests/e2e/test_sync_rejects_unimplemented_concurrency.sh` — `assert_emit_native_rejects` + value (`channel`) and void (`spawn`) cases.

Part of epic #613 (compiler integrity gaps — headline exit-code contract for LLM/CI loops).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VM7k1uEkcD4XcdQ3psJvFZ)_