### PR TITLE
feat(typecheck): `?` operator type rules + diagnostics E0810/E0811/E0812

### DIFF
--- a/compiler/src/typecheck.sfn
+++ b/compiler/src/typecheck.sfn
@@ -47,10 +47,15 @@ import {
     make_main_signature_param_type_diagnostic,
     make_removed_keyword_diagnostic,
     make_thread_local_requires_mut_diagnostic,
+    make_try_error_type_mismatch_diagnostic,
+    make_try_non_result_fn_diagnostic,
+    make_try_non_result_operand_diagnostic,
     make_undefined_function_diagnostic,
     make_unsupported_statement_keyword_diagnostic,
     register_local_symbol,
-    register_symbol
+    register_symbol,
+    result_type_arguments,
+    type_is_result
 } from "./typecheck_types";
 
 fn typecheck_diagnostics(program: Program) -> Diagnostic[] {
@@ -961,6 +966,59 @@ fn walk_expression(expression: Expression?, bindings: SymbolEntry[], imports: Im
         return walk_expression(expression.operand, bindings, imports);
     }
     return [];
+}
+
+// `?` operator (TryOperator) type rules — issue #833, epic #371 (R.3).
+// See `typecheck_types.sfn` for `type_is_result` / `result_type_arguments`
+// and the E0810–E0812 factories. `operand_type` is the type of the `?`
+// operand; `enclosing_return_type` is the declared return type of the
+// function the `?` appears in (null when the function declares no return
+// type). Rules are applied per the proposal §Type rules:
+//   1. operand must be `Result<T, E>`            -> E0810
+//   2. enclosing fn must return `Result<U, F>`   -> E0811
+//   3. `E` must equal `F` exactly (no coercion)  -> E0812
+// Rules 1 and 2 are independent, so a site that violates both reports
+// both; rule 3 only applies once both sides are confirmed `Result` (else
+// there is no error type to compare and rules 1/2 already fired).
+//
+// Type representation: types are plain strings (#829). There is no
+// expression-type inferencer in the checker, so these rules are driven by
+// `result_question_typecheck_test.sfn` against explicit type strings;
+// live-walk wiring waits on operand-type inference (a larger workstream).
+fn check_try_operator(operand_type: string, enclosing_return_type: string?, span: SourceSpan?) -> Diagnostic[] {
+    let mut diagnostics: Diagnostic[] = [];
+
+    let operand_is_result = type_is_result(operand_type);
+    if !operand_is_result {
+        diagnostics.push(make_try_non_result_operand_diagnostic(operand_type, span));
+    }
+
+    if enclosing_return_type == null {
+        diagnostics.push(make_try_non_result_fn_diagnostic("void", span));
+        return diagnostics;
+    }
+    if !type_is_result(enclosing_return_type) {
+        diagnostics.push(make_try_non_result_fn_diagnostic(enclosing_return_type, span));
+        return diagnostics;
+    }
+
+    if operand_is_result {
+        let operand_args = result_type_arguments(operand_type);
+        let fn_args = result_type_arguments(enclosing_return_type);
+        if !strings_equal(operand_args[1], fn_args[1]) {
+            diagnostics.push(make_try_error_type_mismatch_diagnostic(operand_args[1], fn_args[1], span));
+        }
+    }
+
+    return diagnostics;
+}
+
+// The unwrapped success type of a `?` operand — rule 4. Returns the `T`
+// of a `Result<T, E>` operand, or null when the operand is not a `Result`
+// (rule 1 reports that error separately via `check_try_operator`).
+fn try_operator_result_type(operand_type: string) -> string? {
+    if !type_is_result(operand_type) { return null; }
+    return result_type_arguments(operand_type)[0];
 }
 
 // Resolution probe (issue #811). Returns whether `name` resolves to an

--- a/compiler/src/typecheck_types.sfn
+++ b/compiler/src/typecheck_types.sfn
@@ -14,6 +14,7 @@ import {
 } from "./ast";
 import {
     contains_string,
+    ends_with,
     starts_with,
     strings_equal,
     strip_prefix
@@ -354,11 +355,15 @@ fn validate_enum_annotation(usage_name: string, enum_decl: Statement, annotation
 // the #829 substitution primitives they are directly callable and driven
 // by `result_question_typecheck_test.sfn`; the rule orchestration lives in
 // `typecheck.sfn` (`check_try_operator` / `try_operator_result_type`).
-// True when `type_text` names a `Result<T, E>` instantiation: the head
-// identifier is `Result` and exactly two type arguments are present.
+// True when `type_text` names a bare `Result<T, E>` instantiation: the
+// head identifier is exactly `Result`, exactly two type arguments are
+// present, and the closing `>` is the final token. The trailing-`>` check
+// rejects a nullable `Result<T, E>?` — an optional `Result` is not a
+// `Result`, so `?` applied to it must still trip E0810.
 fn type_is_result(type_text: string) -> boolean {
     let trimmed = trim_text(type_text);
     if !starts_with(trimmed, "Result<") { return false; }
+    if !ends_with(trimmed, ">") { return false; }
     return parse_type_arguments(trimmed).length == 2;
 }
 

--- a/compiler/src/typecheck_types.sfn
+++ b/compiler/src/typecheck_types.sfn
@@ -340,6 +340,91 @@ fn validate_enum_annotation(usage_name: string, enum_decl: Statement, annotation
     return [];
 }
 
+// === `?` operator (TryOperator) type support — issue #833, epic #371 (R.3) ===
+//
+// `?` unwraps a `Result<T, E>`: on `Ok` it yields `T`; on `Err` it early-
+// returns the error. Per the proposal §Type rules (Q2):
+//   1. the operand must be a `Result<T, E>`            -> else E0810
+//   2. the enclosing fn must return `Result<U, F>`     -> else E0811
+//   3. `E` must equal `F` exactly (no `From` coercion) -> else E0812
+//   4. the expression's type is the unwrapped `T`.
+// Types are plain strings throughout the checker (there is no expression-
+// type inferencer — #829), so these operate on type-annotation text and
+// reuse `parse_type_arguments` to split `Result<T, E>` into `[T, E]`. Like
+// the #829 substitution primitives they are directly callable and driven
+// by `result_question_typecheck_test.sfn`; the rule orchestration lives in
+// `typecheck.sfn` (`check_try_operator` / `try_operator_result_type`).
+// True when `type_text` names a `Result<T, E>` instantiation: the head
+// identifier is `Result` and exactly two type arguments are present.
+fn type_is_result(type_text: string) -> boolean {
+    let trimmed = trim_text(type_text);
+    if !starts_with(trimmed, "Result<") { return false; }
+    return parse_type_arguments(trimmed).length == 2;
+}
+
+// The `[T, E]` type-argument pair of a `Result<T, E>` annotation, or an
+// empty array when `type_text` is not a 2-arg `Result`. Callers gate on
+// `type_is_result` before indexing.
+fn result_type_arguments(type_text: string) -> string[] {
+    if !type_is_result(type_text) { return []; }
+    return parse_type_arguments(trim_text(type_text));
+}
+
+// E0810 — `?` applied to a value whose type is not `Result<T, E>` (rule 1).
+fn make_try_non_result_operand_diagnostic(operand_type: string, span: SourceSpan?) -> Diagnostic {
+    return Diagnostic {
+        code: "E0810",
+        severity: "error",
+        message: "`?` applied to a non-`Result` value of type `" + trim_text(operand_type)
+            + "`; the `?` operator only unwraps `Result<T, E>`.",
+        file_path: "",
+        primary: token_from_name("?", span),
+        suggestion: null
+    };
+}
+
+// E0811 — `?` used in a function whose declared return type is not
+// `Result<U, F>` (rule 2). `return_type` is the surface return-type text
+// (or "void" when the function declares no return type).
+fn make_try_non_result_fn_diagnostic(return_type: string, span: SourceSpan?) -> Diagnostic {
+    return Diagnostic {
+        code: "E0811",
+        severity: "error",
+        message: "`?` is only valid in a function returning `Result`, but"
+            + " the enclosing function returns `"
+            + trim_text(return_type)
+            + "`. Change the return type to `Result<_, E>` or handle the"
+            + " error with `match`.",
+        file_path: "",
+        primary: token_from_name("?", span),
+        suggestion: null
+    };
+}
+
+// E0812 — the operand's error type differs from the enclosing function's
+// error type (rule 3). `?` requires an exact match — there is no `From`
+// coercion yet (Q2, deferred until generic constraints land). Both types
+// are named in the message.
+fn make_try_error_type_mismatch_diagnostic(operand_error: string, fn_error: string, span: SourceSpan?) -> Diagnostic {
+    // The message is assembled via intermediate `let` bindings rather than
+    // a single inline `+` chain to dodge a string-concatenation codegen
+    // bug (#1003) that lowers certain inline literal chains to an empty
+    // string. Keep the `let`-binding form until #1003 lands.
+    let head = "`?` error type mismatch: the operand's error type `";
+    let mid = "` differs from the enclosing function's error type `";
+    let tail = "`. `?` requires an exact match (no `From` coercion yet).";
+    let message = head + trim_text(operand_error) + mid + trim_text(fn_error)
+        + tail;
+    return Diagnostic {
+        code: "E0812",
+        severity: "error",
+        message: message,
+        file_path: "",
+        primary: token_from_name("?", span),
+        suggestion: null
+    };
+}
+
 fn extract_generic_argument_block(annotation_text: string) -> string? {
     let trimmed = trim_text(annotation_text);
     let mut index: int = 0;

--- a/compiler/tests/unit/result_question_typecheck_test.sfn
+++ b/compiler/tests/unit/result_question_typecheck_test.sfn
@@ -68,3 +68,12 @@ test "try op: both rules fire when operand and fn are non-Result" {
     assert strings_equal(diags[0].code, "E0810");
     assert strings_equal(diags[1].code, "E0811");
 }
+
+test "try op: a nullable `Result<T, E>?` operand is not a Result (E0810)" {
+    // An optional `Result` is not a `Result`: `?` must still trip E0810,
+    // and the unwrapped type is null (the trailing `?` is not stripped).
+    let diags = check_try_operator("Result<int, Error>?", "Result<int, Error>", null);
+    assert diags.length == 1;
+    assert strings_equal(diags[0].code, "E0810");
+    assert strings_equal(_result_type("Result<int, Error>?"), "<not-result>");
+}

--- a/compiler/tests/unit/result_question_typecheck_test.sfn
+++ b/compiler/tests/unit/result_question_typecheck_test.sfn
@@ -1,0 +1,70 @@
+// Unit tests for the `?` operator (`TryOperator`) type rules — issue #833,
+// epic #371 (R.3). The rules type-check a `?` against the operand's type
+// and the enclosing function's declared return type, both carried as
+// plain type-annotation strings (the checker has no expression-type
+// inferencer — see #829). Per the proposal §Type rules:
+//   1. the operand must be `Result<T, E>`            -> E0810
+//   2. the enclosing fn must return `Result<U, F>`   -> E0811
+//   3. `E` must equal `F` exactly (no `From` coercion) -> E0812
+//   4. the expression's type is the unwrapped `T`.
+// These drive the callable rule primitives directly, mirroring the #829
+// substitution tests; emitter desugaring (R.4) is #834 and out of scope.
+import { index_of } from "../../src/string_utils";
+import { check_try_operator, try_operator_result_type } from "../../src/typecheck";
+
+// Collapse the not-found case so the assert sites stay free of optional
+// narrowing.
+fn _result_type(operand_type: string) -> string {
+    let resolved = try_operator_result_type(operand_type);
+    if resolved == null { return "<not-result>"; }
+    return resolved;
+}
+
+test "try op: `?` on a non-Result operand emits E0810" {
+    let diags = check_try_operator("int", "Result<int, Error>", null);
+    assert diags.length == 1;
+    assert strings_equal(diags[0].code, "E0810");
+}
+
+test "try op: `?` in a non-Result-returning fn emits E0811" {
+    let diags = check_try_operator("Result<int, Error>", "int", null);
+    assert diags.length == 1;
+    assert strings_equal(diags[0].code, "E0811");
+}
+
+test "try op: `?` in a fn with no return type emits E0811" {
+    let diags = check_try_operator("Result<int, Error>", null, null);
+    assert diags.length == 1;
+    assert strings_equal(diags[0].code, "E0811");
+}
+
+test "try op: mismatched error type emits E0812 naming both types" {
+    let diags = check_try_operator("Result<int, Error>", "Result<string, MyError>", null);
+    assert diags.length == 1;
+    assert strings_equal(diags[0].code, "E0812");
+    // No `From` coercion (Q2): both error types are named in the message.
+    assert index_of(diags[0].message, "Error") >= 0;
+    assert index_of(diags[0].message, "MyError") >= 0;
+}
+
+test "try op: Result operand in a Result<_, Error> fn type-checks" {
+    let diags = check_try_operator("Result<int, Error>", "Result<bool, Error>", null);
+    assert diags.length == 0;
+}
+
+test "try op: the `?` expression has the unwrapped success type" {
+    // `Result<int, Error>` unwraps to `int` (acceptance criterion 4).
+    assert strings_equal(_result_type("Result<int, Error>"), "int");
+    assert strings_equal(_result_type("Result<string, Error>"), "string");
+}
+
+test "try op: unwrapped type of a non-Result operand is null" {
+    assert strings_equal(_result_type("int"), "<not-result>");
+}
+
+test "try op: both rules fire when operand and fn are non-Result" {
+    let diags = check_try_operator("int", "string", null);
+    assert diags.length == 2;
+    assert strings_equal(diags[0].code, "E0810");
+    assert strings_equal(diags[1].code, "E0811");
+}


### PR DESCRIPTION
## Summary
- Type-check `TryOperator` per the proposal §Type rules (epic #371, R.3): the `?` operand must be `Result<T, E>`, the enclosing fn must return `Result<U, F>`, and `E` must equal `F` exactly (no `From` coercion). The unwrapped success type is `T`.
- Reserve and emit **E0810** (`?` on a non-`Result` value), **E0811** (`?` in a non-`Result`-returning fn), **E0812** (operand error type ≠ enclosing error type, both named).
- Rule orchestration (`check_try_operator`, `try_operator_result_type`) lives in `typecheck.sfn`; the E0810–E0812 factories plus `type_is_result` / `result_type_arguments` helpers live in `typecheck_types.sfn`.

Closes #833

## Approach note
The type checker has **no expression-type inferencer** — types are plain strings and `SymbolEntry` carries no type (confirmed by #829's PR #870). So, exactly like the #829 substitution primitives, these rules are directly callable and driven by the new unit test against explicit type strings (reusing `parse_type_arguments` to split `Result<T, E>` into `[T, E]`). Full live-walk wiring depends on operand-type inference, which is a separate, larger workstream. Emitter desugaring is R.4 / #834 (out of scope).

## ⚠️ Discovered codegen bug — filed #1003
While building the E0812 message I hit a latent **string-concatenation miscompilation**: certain inline literal `+` chains lower to an **empty string** at runtime (not length- or operand-count-driven; content-specific). Filed as **#1003** with a minimal repro. Worked around here by assembling the E0812 message via intermediate `let` bindings (reliably correct), with a code comment pointing at #1003 to remove once fixed. Mirrors the `sfn fmt` follow-up #830/PR #899 surfaced.

## Acceptance Criteria
- [x] `?` on a non-`Result` value emits `E0810`
- [x] `?` in a non-`Result`-returning fn emits `E0811`
- [x] `?` whose `E` differs from the enclosing `E` emits `E0812` with both types named (no `From` coercion)
- [x] `?` on `Result` in a `Result<_, Error>` fn type-checks; the expression has type `int`
- [x] `make compile` passes; `sfn fmt --check` clean
- [x] `make test` passes

## Verification
```bash
ulimit -v 8388608 && make compile                                   # self-hosts ✓ (exit 0)
ulimit -v 8388608 && build/native/sailfin test \
  compiler/tests/unit/result_question_typecheck_test.sfn            # PASS (8/8)
ulimit -v 8388608 && make test                                      # full suite green; e2e-sh 93/93, 0 failed ✓
build/native/sailfin fmt --check \
  compiler/src/typecheck.sfn compiler/src/typecheck_types.sfn \
  compiler/tests/unit/result_question_typecheck_test.sfn            # clean ✓
```

## Files Changed
- `compiler/src/typecheck_types.sfn` — `type_is_result`, `result_type_arguments`, and the E0810/E0811/E0812 diagnostic factories
- `compiler/src/typecheck.sfn` — `check_try_operator` (rules 1–3) + `try_operator_result_type` (rule 4), plus imports
- `compiler/tests/unit/result_question_typecheck_test.sfn` (new) — 8 tests covering all four rules + the both-rules-fire and unwrapped-type cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011hgKr6H8Sr8MC6ReU7Bs1h

---
_Generated by [Claude Code](https://claude.ai/code/session_011hgKr6H8Sr8MC6ReU7Bs1h)_