### PR TITLE
fix(build): bust per-module cache on dirty compiler rebuilds

### DIFF
--- a/compiler/src/build_cache.sfn
+++ b/compiler/src/build_cache.sfn
@@ -596,6 +596,45 @@ fn cache_key_for(source_path: string, dep_layout_manifest_paths: string[], compi
     return CacheKey { digest: final_digest };
 }
 
+fn _ends_with_suffix(text: string, suffix: string) -> boolean {
+    if suffix.length > text.length { return false; }
+    return substring(text, text.length - suffix.length, text.length) == suffix;
+}
+
+// Augment the raw `compiler_version` cache-key component with the
+// emitting compiler binary's content hash when — and only when — the
+// build stamp is `.dirty`.
+//
+// Why: the cache key uses `compiler_version` as its sole
+// compiler-identity input (§4.12), trusting the build stamp to change
+// whenever the compiler's codegen changes. That holds for tagged
+// (`<version>`) and clean-commit (`<version>+dev.<hash>`) stamps —
+// both reproducible from the binary's provenance — but NOT for
+// `<version>+dev.<hash>.dirty`: `.dirty` is a bare boolean
+// (`build_stamp.sfn`), so every uncommitted working tree at the same
+// commit produces the identical stamp. During iterative compiler
+// development that means a `.ll` emitted by one dirty build is served
+// to a DIFFERENT dirty build at the same commit — the cache serves
+// stale codegen after a rebuild that was supposed to change it.
+//
+// Mixing the binary's SHA-256 into the identity for `.dirty` stamps
+// makes a rebuilt compiler bust the cache (the binary content changed
+// ⇒ the key changes). Tagged / clean-commit stamps are left untouched
+// so their keys stay reproducible across machines and CI cache
+// sharing is unaffected. The caller resolves `compiler_version` once
+// per build, so the single `_sha256_of_file_cmd` here is paid once,
+// not per module. An empty or unhashable `compiler_binary_path`
+// falls back to the raw stamp (no worse than the prior behaviour).
+fn cache_compiler_identity(compiler_version: string, compiler_binary_path: string) -> string ![io] {
+    if !_ends_with_suffix(compiler_version, ".dirty") {
+        return compiler_version;
+    }
+    if compiler_binary_path.length == 0 { return compiler_version; }
+    let bin_hash = _sha256_of_file_cmd(compiler_binary_path);
+    if bin_hash.length == 0 { return compiler_version; }
+    return compiler_version + "+bin." + bin_hash;
+}
+
 export {
     CacheKey,
     CacheEntryPaths,
@@ -613,6 +652,7 @@ export {
     cache_store_artifact,
     canonicalize_flags,
     cache_key_for,
+    cache_compiler_identity,
     sha256_of_file,
     runtime_object_cache_key,
     empty_cache_stats,

--- a/compiler/src/capsule_resolver.sfn
+++ b/compiler/src/capsule_resolver.sfn
@@ -39,6 +39,7 @@ import {
     CacheKey,
     CacheStats,
     cache_clean,
+    cache_compiler_identity,
     cache_copy_artifact_to,
     cache_key_for,
     cache_lookup_artifact,
@@ -1841,7 +1842,14 @@ fn compile_capsule_modules(sources: CapsuleSource[], slug_universe_extra: Capsul
     // compile-time `__version_fallback__` — which is stable per
     // binary, so cache keys stay coherent for any single binary
     // even when running outside the workspace.
-    let compiler_version = resolve_compiler_version_for_cache("");
+    // For a `.dirty` dev stamp the build-stamp string alone does not
+    // distinguish two compiler binaries built at the same commit, so
+    // mix the emitting binary's content hash into the cache identity
+    // (no-op for tagged / clean-commit stamps). `sailfin_exe` is the
+    // binary doing the per-module emit on this path; an empty value
+    // (in-process serial fallback) keeps the raw stamp. See
+    // `build_cache.cache_compiler_identity`.
+    let compiler_version = cache_compiler_identity(resolve_compiler_version_for_cache(""), sailfin_exe);
     // Flag canonicalization is empty for now — `sfn build -p` does
     // not yet take build flags. Constructing via `canonicalize_flags`
     // keeps the empty form a single source of truth: if the encoder

--- a/compiler/tests/unit/build_cache_test.sfn
+++ b/compiler/tests/unit/build_cache_test.sfn
@@ -40,6 +40,7 @@ import {
     cache_stats_is_empty,
     canonicalize_flags,
     cache_key_for,
+    cache_compiler_identity,
     empty_build_cache_config,
     empty_cache_stats,
     is_valid_digest
@@ -561,4 +562,84 @@ test "is_valid_digest: 64 uppercase chars rejected" {
 test "is_valid_digest: 64 chars with non-hex letter rejected" {
     // 'g' is outside [0-9a-f].
     assert ! is_valid_digest("g123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef");
+}
+
+// ----------------------------------------------------------------
+// cache_compiler_identity (work-dir self-host cache poisoning fix)
+// ----------------------------------------------------------------
+//
+// A `.dirty` build stamp is shared by every uncommitted working tree
+// at the same commit, so the per-module cache (keyed partly on the
+// stamp) used to serve IR emitted by a DIFFERENT dirty build. The
+// identity helper mixes the emitting binary's content hash into the
+// `.dirty` key so a rebuilt compiler busts the cache; tagged and
+// clean-commit stamps stay hash-free (reproducible across machines).
+fn _identity_tmp(label: string, bytes: string) -> string ![io] {
+    let path = "/tmp/sfn_identity_test_" + label;
+    process.run(["rm", "-rf", path]);
+    fs.writeFile(path, bytes);
+    return path;
+}
+
+test "cache_compiler_identity: dirty stamp mixes in the binary hash" ![io] {
+    let bin = _identity_tmp("dirty_bin", "fake-compiler-bytes-v1\n");
+    let raw = "0.7.0-alpha.21+dev.abc1234.dirty";
+    let identity = cache_compiler_identity(raw, bin);
+    // The dirty identity must differ from the raw stamp (so two dirty
+    // builds at the same commit get distinct cache keys).
+    assert identity != raw;
+    process.run(["rm", "-rf", bin]);
+}
+
+test "cache_compiler_identity: different binaries yield different identities" ![io] {
+    let bin_a = _identity_tmp("dirty_a", "fake-compiler-bytes-A\n");
+    let bin_b = _identity_tmp("dirty_b", "fake-compiler-bytes-B\n");
+    let raw = "0.7.0-alpha.21+dev.abc1234.dirty";
+    let id_a = cache_compiler_identity(raw, bin_a);
+    let id_b = cache_compiler_identity(raw, bin_b);
+    // Same stamp, same commit, but different binary content ⇒ the
+    // cache identities must diverge. This is the exact poisoning the
+    // fix prevents: a rebuilt compiler must not reuse the prior
+    // build's cached IR.
+    assert id_a != id_b;
+    process.run(["rm", "-rf", bin_a]);
+    process.run(["rm", "-rf", bin_b]);
+}
+
+test "cache_compiler_identity: identical binary content is stable" ![io] {
+    let bin_a = _identity_tmp("stable_a", "same-bytes\n");
+    let bin_b = _identity_tmp("stable_b", "same-bytes\n");
+    let raw = "0.7.0-alpha.21+dev.abc1234.dirty";
+    // Content-addressed, not path/mtime-addressed: identical bytes at
+    // two paths must produce the same identity so a clean rebuild that
+    // reproduces the binary still hits the cache.
+    assert cache_compiler_identity(raw, bin_a) == cache_compiler_identity(raw, bin_b);
+    process.run(["rm", "-rf", bin_a]);
+    process.run(["rm", "-rf", bin_b]);
+}
+
+test "cache_compiler_identity: tagged stamp is left unchanged" ![io] {
+    let bin = _identity_tmp("tagged_bin", "whatever\n");
+    let raw = "0.7.0-alpha.21";
+    // A tagged (release) stamp is reproducible from provenance, so the
+    // identity must stay hash-free — CI cache sharing across machines
+    // depends on this.
+    assert cache_compiler_identity(raw, bin) == raw;
+    process.run(["rm", "-rf", bin]);
+}
+
+test "cache_compiler_identity: clean-commit dev stamp is left unchanged" ![io] {
+    let bin = _identity_tmp("clean_bin", "whatever\n");
+    let raw = "0.7.0-alpha.21+dev.abc1234";
+    // `+dev.<hash>` without `.dirty` is reproducible from the commit,
+    // so it stays hash-free too.
+    assert cache_compiler_identity(raw, bin) == raw;
+    process.run(["rm", "-rf", bin]);
+}
+
+test "cache_compiler_identity: empty binary path falls back to raw stamp" ![io] {
+    let raw = "0.7.0-alpha.21+dev.abc1234.dirty";
+    // No binary to hash (in-process serial fallback) ⇒ keep the raw
+    // stamp; no worse than the prior behaviour.
+    assert cache_compiler_identity(raw, "") == raw;
 }


### PR DESCRIPTION
## Summary

Fixes a phantom self-host "miscompile": `sfn build -p compiler` and `compiler/tests/e2e/test_work_dir_parity.sh` failed on macOS with

```
... core_member_lowering.ll: error: use of undefined value '@sailfin_module_init__...'
```

The live compiler emits the module **correctly** (`--no-cache` builds are clean) — the failure was a **stale per-module cache artifact**, the same class of bug as #969's runtime-object cache, one layer up.

### Root cause
The per-module build cache keys IR on the compiler's build-stamp string (`build_cache.sfn` §4.12) so one compiler's artifacts can't poison another's. That works for tagged (`<version>`) and clean-commit (`<version>+dev.<hash>`) stamps — both reproducible — but **not** for `<version>+dev.<hash>.dirty`: `.dirty` is a bare boolean (`build_stamp.sfn`), so **every uncommitted working tree at the same commit produces the identical stamp**. During iterative compiler development, a `.ll` emitted by one dirty build is then served to a *different* dirty build at the same commit — stale codegen after a rebuild that was meant to change it. (CI never sees it: cold cache + clean-commit builds.)

### Fix
`cache_compiler_identity(compiler_version, binary_path)` mixes the emitting binary's SHA-256 into the cache-key identity **for `.dirty` stamps only** (computed once per build, not per module). A rebuilt dirty compiler gets a distinct content hash ⇒ distinct keys ⇒ it bypasses any artifact a prior dirty build cached. Tagged / clean-commit stamps stay hash-free so CI cache sharing across machines is unaffected; an empty/unhashable binary path falls back to the raw stamp. Wired in at `capsule_resolver.sfn` where `compiler_version` is resolved once per build (kept in `build_cache.sfn` to respect the resolver's shallow-dep-diamond constraint).

## Test plan
- [x] Dirty rebuild with the poisoned entry still on disk → `hits=0 misses=154` (sidesteps poison, emits correct IR); second build same binary → `hits=154 misses=0` (caching intact)
- [x] `cache_compiler_identity` unit coverage (dirty mixes hash; different binaries → different identities; identical bytes stable; tagged/clean-commit unchanged; empty path falls back)
- [x] `test_work_dir_parity.sh` 4/4; `make compile` self-hosts
- [x] All affected tests pass in isolation (closure_lifting, selfhosting_patterns, emit_guarded_scope_drops, work_dir_parity)

## Note
While validating I observed the macOS **full-suite** `make test` is flaky under parallel-build load — different tests fail each run (each passes in isolation), pointing at contention on the shared `build/cache/v1` + `build/sailfin/` staging (and no `ulimit -v` on macOS). Pre-existing and unrelated to this change; worth a separate issue.

Refs #969 (sibling stale-cache-reuse fix).