### PR TITLE
fix(build): pass --no-resolve-gate on parallel emit native-staging path

### DIFF
--- a/compiler/src/capsule_resolver.sfn
+++ b/compiler/src/capsule_resolver.sfn
@@ -2031,9 +2031,7 @@ fn compile_capsule_modules(sources: CapsuleSource[], slug_universe_extra: Capsul
             };
             if stored { stats.stores = stats.stores + 1; }
             if invalid_key { stats.invalid_keys = stats.invalid_keys + 1; }
-            if copy_failed {
-                stats.copy_failures = stats.copy_failures + 1;
-            }
+            if copy_failed { stats.copy_failures = stats.copy_failures + 1; }
             ei += 1;
         }
 
@@ -2080,9 +2078,7 @@ fn compile_capsule_modules(sources: CapsuleSource[], slug_universe_extra: Capsul
         }
         if evt.stored { stats.stores = stats.stores + 1; }
         if evt.invalid_key { stats.invalid_keys = stats.invalid_keys + 1; }
-        if evt.copy_failed {
-            stats.copy_failures = stats.copy_failures + 1;
-        }
+        if evt.copy_failed { stats.copy_failures = stats.copy_failures + 1; }
         out.push(sources[i].ll_path);
         events.push(evt);
         i += 1;
@@ -2496,9 +2492,7 @@ fn collect_relative_import_specs(source: string) -> string[] {
                         if substring(spec, 0, 2) == "./" { is_relative = true; }
                     }
                     if spec.length >= 3 {
-                        if substring(spec, 0, 3) == "../" {
-                            is_relative = true;
-                        }
+                        if substring(spec, 0, 3) == "../" { is_relative = true; }
                     }
                     if is_relative { out.push(spec); }
                 }
@@ -3006,9 +3000,7 @@ fn collect_scoped_import_specs(source: string) -> string[] {
                         if substring(spec, 0, 2) == "./" { is_relative = true; }
                     }
                     if spec.length >= 3 {
-                        if substring(spec, 0, 3) == "../" {
-                            is_relative = true;
-                        }
+                        if substring(spec, 0, 3) == "../" { is_relative = true; }
                     }
                     let mut is_runtime: boolean = false;
                     if spec.length >= 8 {

--- a/compiler/src/capsule_resolver.sfn
+++ b/compiler/src/capsule_resolver.sfn
@@ -570,7 +570,14 @@ fn _cr_run_parallel_emit(tasks: ParallelEmitTask[], mode: string, sailfin_exe: s
             // to the child — this serial fallback preserves its
             // pre-#515 single-shot contract exactly. `sailfin_exe` is
             // the same-generation binary, so it accepts the flags.
-            let mut emit_args: string[] = [sailfin_exe, "emit", "--module-name", t.slug, "--attempts", "1", "--no-validate", "-o", t.output_path];
+            // `--no-resolve-gate` (#906): this is a per-module
+            // intermediate emit. For the `native` stage it carries no
+            // cross-module import context, so the lowering dry-run gate
+            // would falsely reject legitimate imported calls; suppress it
+            // here and let the build's LLVM lowering stage (#631) own
+            // fail-closed. The `llvm` stage ignores the flag. Mirrors
+            // `emit_helpers.emit_subprocess_with_retry`.
+            let mut emit_args: string[] = [sailfin_exe, "emit", "--module-name", t.slug, "--attempts", "1", "--no-validate", "--no-resolve-gate", "-o", t.output_path];
             if use_import_context {
                 emit_args.push("--import-context");
                 emit_args.push(import_context_root);
@@ -637,9 +644,17 @@ fn _cr_run_parallel_emit(tasks: ParallelEmitTask[], mode: string, sailfin_exe: s
     if use_import_context {
         worker_import_arg = "--import-context \"$SAILFIN_PE_IMPORT_CTX\" ";
     }
+    // `--no-resolve-gate` (#906): per-module intermediate emit; the
+    // `native` stage carries no cross-module import context, so the
+    // lowering dry-run gate would falsely reject legitimate imported
+    // calls. Suppress it here and let the build's LLVM lowering stage
+    // (#631) own fail-closed; the `llvm` stage ignores the flag. Mirrors
+    // `emit_helpers.emit_subprocess_with_retry` and the serial fallback
+    // above — without it, multi-job builds fail closed on every
+    // cross-module callee.
     let worker_script = "attempt=0; while [ $attempt -lt 3 ]; do "
         + "attempt=$((attempt + 1)); "
-        + "\"$SAILFIN_PE_SEED\" emit --module-name \"$1\" --attempts 1 --no-validate -o \"$2\" "
+        + "\"$SAILFIN_PE_SEED\" emit --module-name \"$1\" --attempts 1 --no-validate --no-resolve-gate -o \"$2\" "
         + worker_import_arg
         + "\"$SAILFIN_PE_MODE\" \"$3\" || continue; "
         + "[ -s \"$2\" ] || continue; "
@@ -2016,7 +2031,9 @@ fn compile_capsule_modules(sources: CapsuleSource[], slug_universe_extra: Capsul
             };
             if stored { stats.stores = stats.stores + 1; }
             if invalid_key { stats.invalid_keys = stats.invalid_keys + 1; }
-            if copy_failed { stats.copy_failures = stats.copy_failures + 1; }
+            if copy_failed {
+                stats.copy_failures = stats.copy_failures + 1;
+            }
             ei += 1;
         }
 
@@ -2063,7 +2080,9 @@ fn compile_capsule_modules(sources: CapsuleSource[], slug_universe_extra: Capsul
         }
         if evt.stored { stats.stores = stats.stores + 1; }
         if evt.invalid_key { stats.invalid_keys = stats.invalid_keys + 1; }
-        if evt.copy_failed { stats.copy_failures = stats.copy_failures + 1; }
+        if evt.copy_failed {
+            stats.copy_failures = stats.copy_failures + 1;
+        }
         out.push(sources[i].ll_path);
         events.push(evt);
         i += 1;
@@ -2477,7 +2496,9 @@ fn collect_relative_import_specs(source: string) -> string[] {
                         if substring(spec, 0, 2) == "./" { is_relative = true; }
                     }
                     if spec.length >= 3 {
-                        if substring(spec, 0, 3) == "../" { is_relative = true; }
+                        if substring(spec, 0, 3) == "../" {
+                            is_relative = true;
+                        }
                     }
                     if is_relative { out.push(spec); }
                 }
@@ -2985,7 +3006,9 @@ fn collect_scoped_import_specs(source: string) -> string[] {
                         if substring(spec, 0, 2) == "./" { is_relative = true; }
                     }
                     if spec.length >= 3 {
-                        if substring(spec, 0, 3) == "../" { is_relative = true; }
+                        if substring(spec, 0, 3) == "../" {
+                            is_relative = true;
+                        }
                     }
                     let mut is_runtime: boolean = false;
                     if spec.length >= 8 {


### PR DESCRIPTION
## Summary
Fixes the alpha.22 self-hosting regression that blocked the seed bump (PR #1014). On any multi-core host the build cannot self-host: every cross-module callee trips the #1002 fail-closed resolve gate.

`Closes #1015`

## Root cause
#1002 made `sfn emit native` **fail closed** (dry-runs LLVM lowering, which can't resolve cross-module callees at native staging — no import context yet) and added a `--no-resolve-gate` opt-out for build-internal emits. The flag was wired into the **serial** path (`emit_helpers.emit_subprocess_with_retry`, `emit_helpers.sfn:257`) but **not** the **parallel** path (`_cr_run_parallel_emit`, `capsule_resolver.sfn`) — neither the xargs worker nor the `jobs==1` fallback. Multi-core builds default to the parallel path → workers run `emit native` without the flag → #306 unresolved-callee fatals for `parse_program`, `find_char_local`, `lift_non_capturing_lambdas`, the `_*_cmd` helpers, plus secondary int/float ABI-mismatch fatals.

alpha.21 fails **open** at native staging and defers fail-closed to the LLVM-lowering stage (full cross-module context), which is why `main` is green under the current seed.

**Proof:** same module, alpha.22 seed — `emit native` → rc=1/91 fatals; `emit native --no-resolve-gate` → rc=0/0 fatals.

## Change
Add `--no-resolve-gate` to both emit sites in `_cr_run_parallel_emit`, mirroring `emit_helpers.sfn:257`. Fail-closed integrity is preserved — the later LLVM-lowering stage still gates with full context.

## Verification
- `ulimit -v 8388608 && make rebuild` ✅
- `make check` ✅ — e2e-sh 95/95, **stage2 == stage3 fixed point**, seedcheck promoted
- `sfn fmt --check compiler/src/capsule_resolver.sfn` ✅

## Follow-up
The alpha.22 binary stays un-pinnable (baked-in resolver has the bug). Re-pin only after a new release cut from this fixed `main` is verified to self-host.

🤖 Diagnosed by seed-stabilizer; fix driven by Sailbot.