### PR TITLE
refactor(runtime): swap clk_id runtime probe → clock_monotonic_id sentinel

### DIFF
--- a/compiler/tests/e2e/test_clock_gettime_reader.sh
+++ b/compiler/tests/e2e/test_clock_gettime_reader.sh
@@ -17,8 +17,10 @@
 #
 #   1. typecheck   — `sfn check clock.sfn` reports `ok`.
 #   2. fmt         — `sfn fmt --check clock.sfn` is canonical.
-#   3. call shape  — emitted IR contains `call i32 @clock_gettime(...)`
-#                    and `declare i32 @clock_gettime(...)`.
+#   3. call shape  — emitted IR contains exactly one
+#                    `call i32 @clock_gettime(...)` (the #909 sentinel
+#                    swap collapsed the #905 two-call clk_id probe into a
+#                    single call) plus a `declare i32 @clock_gettime(...)`.
 #   4. two reads   — the adapter body contains >= 2 local-pointer
 #                    `load i64, i64* %…` instructions (the field reads).
 #   5. STALE-READ GUARD — both `load i64, i64* %…` field reads appear
@@ -97,8 +99,15 @@ test_clock_gettime_call() {
         echo "[test]   missing 'declare i32 @clock_gettime(...)'"
         return 1
     fi
-    if ! grep -qE 'call i32 @clock_gettime\(' "$BODY"; then
-        echo "[test]   missing 'call i32 @clock_gettime(...)' in adapter body"
+    # Exactly one call: the #909 sentinel swap folds the platform clk_id
+    # to an emit-time immediate, collapsing the #905 try-1-fall-back-to-6
+    # runtime probe into a single syscall. Two calls means the probe was
+    # reintroduced.
+    local calls
+    calls="$(grep -cE 'call i32 @clock_gettime\(' "$BODY" || true)"
+    if [ "$calls" -ne 1 ]; then
+        echo "[test]   expected exactly one 'call i32 @clock_gettime(...)' in adapter body (the #909 sentinel swap), found $calls"
+        cat "$BODY"
         return 1
     fi
     return 0
@@ -169,14 +178,13 @@ test_no_call_sentinel() {
 }
 
 test_monotonic_advance() {
-    # Runs on every platform. `sfn_clock_monotonic_nanos` probes the
-    # `CLOCK_MONOTONIC` clk_id at runtime — Linux `1`, falling back to
-    # Darwin `6` on `EINVAL` (issue #819 follow-up to the #878 reader) —
-    # so the monotonic clock reads correctly on both Linux x86_64 and
-    # macOS arm64. The earlier Linux-only skip (epic #763) is gone: the
-    # runtime probe makes the off-Linux smoke meaningful, and the eventual
-    # emit-time clk_id sentinel (which needs a fresh seed) will keep it
-    # passing.
+    # Runs on every platform. `sfn_clock_monotonic_nanos` reads the
+    # `CLOCK_MONOTONIC` clk_id via the `sailfin_intrinsic_clock_monotonic_id()`
+    # emit-time sentinel (#908) — it folds to Linux `1` / Darwin `6` at
+    # emit time (#909 swapped out the #905 runtime probe) — so the
+    # monotonic clock reads correctly on both Linux x86_64 and macOS arm64
+    # with a single syscall. The earlier Linux-only skip (epic #763) is
+    # gone: the off-Linux smoke is meaningful on every target.
 
     # `sfn_clock_monotonic_nanos` is compiled into the runtime via
     # `runtime/native/capsule.toml` sfn-sources, so a user program can

--- a/runtime/sfn/clock.sfn
+++ b/runtime/sfn/clock.sfn
@@ -111,11 +111,12 @@ fn sfn_clock_monotonic_nanos() -> i64 ![clock] {
     let mut ts: Timespec = Timespec { tv_sec: 0, tv_nsec: 0 };
     let ts_ptr: * Timespec = & ts;
 
-    // Read the monotonic clock. `CLOCK_MONOTONIC`'s `clk_id` is a
-    // steadily-advancing clock unaffected by wall-clock adjustments — the
-    // correct source for elapsed-time measurement — but its numeric value
-    // diverges by platform: Linux x86_64 spells it `1`, macOS arm64
-    // (Darwin) spells it `6`. `sailfin_intrinsic_clock_monotonic_id()`
+    // Read the monotonic clock. `CLOCK_MONOTONIC` is a steadily-advancing
+    // clock unaffected by wall-clock adjustments — the correct source for
+    // elapsed-time measurement. Its `clk_id` — the numeric constant that
+    // selects it in `clock_gettime` — diverges by platform: Linux x86_64
+    // spells it `1`, macOS arm64 (Darwin) spells it `6`.
+    // `sailfin_intrinsic_clock_monotonic_id()`
     // (#908) folds to the right `i32` immediate per target at emit time,
     // chosen from the same `SAILFIN_TARGET_OS` / `uname -s` probe the
     // errno-locator sentinel (#887) uses. It emits no `call` and no

--- a/runtime/sfn/clock.sfn
+++ b/runtime/sfn/clock.sfn
@@ -76,24 +76,6 @@ struct Timespec {
 // platform-constants home is deferred (this issue's `Out:` scope).
 let EINTR: i32 = 4;
 
-// POSIX `CLOCK_MONOTONIC` clk_id — a steadily-advancing clock
-// unaffected by wall-clock adjustments, the correct source for
-// elapsed-time measurement. The numeric `clk_id` diverges by platform:
-// Linux x86_64 spells it `1`, while macOS arm64 (Darwin) spells it `6`.
-//
-// Pure Sailfin can't yet read the platform's header constant (a
-// target-aware platform-constant mechanism is deferred under epic
-// #763), and the clean fix — an emit-time sentinel intrinsic that folds
-// to the right `i32` per target — can't be used *here* either:
-// `make compile` recompiles this runtime module with the pinned *seed*
-// compiler, which predates any newly-added intrinsic, so a sentinel
-// would have to ship in a seed before `clock.sfn` could call it. Until
-// that lands (tracked as the #819 follow-up), `sfn_clock_monotonic_nanos`
-// probes the value at runtime: it tries the Linux clk_id first and, on
-// failure, retries with the Darwin clk_id (see below).
-let CLOCK_MONOTONIC_LINUX: i32 = 1;
-let CLOCK_MONOTONIC_DARWIN: i32 = 6;
-
 // Nanoseconds per second — the scale factor folding `tv_sec` into the
 // combined nanosecond result.
 let NANOS_PER_SEC: i64 = 1000000000;
@@ -129,16 +111,21 @@ fn sfn_clock_monotonic_nanos() -> i64 ![clock] {
     let mut ts: Timespec = Timespec { tv_sec: 0, tv_nsec: 0 };
     let ts_ptr: * Timespec = & ts;
 
-    // Read the monotonic clock. `CLOCK_MONOTONIC`'s `clk_id` differs by
-    // platform (Linux `1`, Darwin `6`), so probe the Linux value first
-    // and, on failure, retry with the Darwin value. On Linux the first
-    // call succeeds (`ret == 0`) and the fallback is never taken; on
-    // Darwin `clock_gettime(1, …)` returns `EINVAL` (non-zero, leaving
-    // `ts` untouched) and the second call with `6` populates it. The
-    // kernel writes `tv_sec` / `tv_nsec` through `ts_ptr` on whichever
-    // call succeeds.
-    let mut ret: i32 = clock_gettime(CLOCK_MONOTONIC_LINUX, ts_ptr);
-    if ret != 0 { ret = clock_gettime(CLOCK_MONOTONIC_DARWIN, ts_ptr); }
+    // Read the monotonic clock. `CLOCK_MONOTONIC`'s `clk_id` is a
+    // steadily-advancing clock unaffected by wall-clock adjustments — the
+    // correct source for elapsed-time measurement — but its numeric value
+    // diverges by platform: Linux x86_64 spells it `1`, macOS arm64
+    // (Darwin) spells it `6`. `sailfin_intrinsic_clock_monotonic_id()`
+    // (#908) folds to the right `i32` immediate per target at emit time,
+    // chosen from the same `SAILFIN_TARGET_OS` / `uname -s` probe the
+    // errno-locator sentinel (#887) uses. It emits no `call` and no
+    // `declare`: the lowering replaces the call site with a bare constant,
+    // so a single syscall populates `ts` on every target. This swap (#909)
+    // replaced the earlier runtime clk_id probe (#905/#819 — try `1`, fall
+    // back to `6` on `EINVAL`) once the intrinsic shipped in a pinned seed,
+    // dropping the extra failed `clock_gettime` call on Darwin. The kernel
+    // writes `tv_sec` / `tv_nsec` through `ts_ptr` when `ret == 0`.
+    let ret: i32 = clock_gettime(sailfin_intrinsic_clock_monotonic_id(), ts_ptr);
     if ret != 0 { return 0; }
 
     // Read the fields back from the *same* allocation, after the call.


### PR DESCRIPTION
## Summary
- `sfn_clock_monotonic_nanos` now makes a **single** `clock_gettime(sailfin_intrinsic_clock_monotonic_id(), ts_ptr)` call, replacing the two-call clk_id probe (try `1`, fall back to `6` on `EINVAL`) shipped in #905/#819.
- The #908 emit-time sentinel folds to the platform clk_id immediate (`1` Linux, `6` Darwin) — verified in seed `0.7.0-alpha.23`, so the runtime recompiles against a seed that knows the sentinel. One syscall on every platform; the extra failed `clock_gettime` on macOS is gone.
- Removed the now-dead `CLOCK_MONOTONIC_LINUX` / `CLOCK_MONOTONIC_DARWIN` `let` bindings and rewrote the rationale comment (runtime-probe → sentinel).

Closes #909

## Acceptance Criteria
- [x] `sfn_clock_monotonic_nanos` makes exactly one `clock_gettime` call via the sentinel — emitted IR shows `%t9 = call i32 @clock_gettime(i32 1, %Timespec* %t8)` on Linux (single call); no leaked `call`/`declare @sailfin_intrinsic_clock_monotonic_id`. The e2e test now asserts exactly one call as a regression guard.
- [x] Monotonic-advance smoke passes — `test_monotonic_advance` PASS (all-platform). Linux verified locally; macos-arm64 runs the same all-platform smoke on CI.
- [x] `sfn fmt --check` clean; `make compile && make check` pass (`CHECK_EXIT=0`).

## Verification
```bash
ulimit -v 8388608 && make compile && make check
#   → CHECK_EXIT=0 · e2e-sh 95/95 (first-pass) · e2e-sh 95/95 (seedcheck) · seedcheck promoted

ulimit -v 8388608 && bash compiler/tests/e2e/test_clock_gettime_reader.sh build/native/sailfin
#   → [summary] 9 passed, 0 failed

# Sentinel folds to the Linux clk_id, no intrinsic leak:
#   call i32 @clock_gettime(i32 1, %Timespec* %t8)   (exactly one)
#   no (call|declare) .*@sailfin_intrinsic_clock_monotonic_id
```

> Note: `make check` emitted a non-fatal `[check][WARN] stage2 != stage3` on `llvm__lowering__lowering_core.ll` (a compiler module untouched by this PR — the change is confined to `runtime/sfn/clock.sfn` + one e2e test). This is a pre-existing intermittent IR-emission nondeterminism, not introduced here; `make check` still exited 0 and promoted seedcheck. An isolated rerun of the affected suite passed 95/95.

## Files Changed
- `runtime/sfn/clock.sfn` — single sentinel call; drop dead clk_id constants; rationale comment update.
- `compiler/tests/e2e/test_clock_gettime_reader.sh` — assert exactly one `clock_gettime` call; sentinel-path comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QdivHy6KiPoDh3hTA3Y9Gm)_