### PR TITLE
fix(lowering): register prelude Result/Error in type context + box generic struct payloads

### DIFF
--- a/compiler/src/llvm/lowering/instructions_match_condition.sfn
+++ b/compiler/src/llvm/lowering/instructions_match_condition.sfn
@@ -195,11 +195,22 @@ fn lower_match_case_condition(function_name: string, subject_operand: LLVMOperan
                                     if llvm_field_type.length == 0 {
                                         llvm_field_type = "i8*";
                                     }
-                                    if layout_annotation_represents_user_value(resolved_annotation) {
-                                        if ends_with_pointer_suffix(llvm_field_type) {
-                                            let stripped = strip_pointer_suffix(llvm_field_type);
-                                            if stripped.length > 0 {
-                                                llvm_field_type = stripped;
+                                    // #830: a generic-substituted payload is stored
+                                    // BOXED — the constructor writes the `%T*` heap
+                                    // pointer into the variant payload slot (0.5.8+
+                                    // boxed aggregate ABI). Stripping the pointer
+                                    // here would make the matcher `load %T` by value
+                                    // from a slot that actually holds a `%T*`,
+                                    // corrupting the binding. Only strip for
+                                    // non-substituted, in-file value payloads stored
+                                    // inline.
+                                    if !substituted {
+                                        if layout_annotation_represents_user_value(resolved_annotation) {
+                                            if ends_with_pointer_suffix(llvm_field_type) {
+                                                let stripped = strip_pointer_suffix(llvm_field_type);
+                                                if stripped.length > 0 {
+                                                    llvm_field_type = stripped;
+                                                }
                                             }
                                         }
                                     }

--- a/compiler/src/llvm/lowering/lowering_core.sfn
+++ b/compiler/src/llvm/lowering/lowering_core.sfn
@@ -75,6 +75,8 @@ import {
     inject_prelude_error_struct,
     inject_prelude_result_enum,
     is_test_module_slug,
+    native_enums_have_name,
+    native_structs_have_name,
     sanitize_module_suffix,
     seed_default_runtime_helpers
 } from "./lowering_helpers";
@@ -577,8 +579,24 @@ fn lower_to_llvm_lines_with_parsed_context(native_module: NativeModule, parse_in
     // files (no in-file enum, no explicit import) lower `Result.Ok` / `.Err` +
     // `match` to a real `%Result` layout + discriminant test instead of `i8*`.
     // No-op when an in-file or imported decl already provides the name.
+    // Record whether each was absent BEFORE injection: a name we inject must
+    // have its type-descriptor registration suppressed (see below), but a name
+    // the module already defines/imports must still register normally.
+    let prelude_result_present = native_enums_have_name(combined_enums, "Result");
+    let prelude_error_present = native_structs_have_name(combined_structs, "Error");
     combined_enums = inject_prelude_result_enum(combined_enums);
     combined_structs = inject_prelude_error_struct(combined_structs);
+    // Names actually injected here. `emit_type_descriptors` skips registering
+    // them so modules that don't define `Result`/`Error` themselves don't gain
+    // an undefined `sfn_type_register` reference — the prelude module owns that
+    // registration. Without this, every module emitting zero other types went
+    // from "no descriptors" to a `@llvm.global_ctors` entry calling
+    // `sfn_type_register`, breaking standalone-link roundtrip tests (#1021 CI).
+    let mut injected_prelude_type_names: string[] = [];
+    if !prelude_result_present {
+        injected_prelude_type_names.push("Result");
+    }
+    if !prelude_error_present { injected_prelude_type_names.push("Error"); }
     let mut combined_interfaces = extend_native_interfaces(safe_interfaces, imported_interfaces);
     if is_test_module {
         combined_interfaces = [];
@@ -740,7 +758,7 @@ fn lower_to_llvm_lines_with_parsed_context(native_module: NativeModule, parse_in
     // lines participate in the post-lowering helper scan and the
     // descriptor globals + name strings ride along in the preamble
     // section we hand to the renderer below.
-    let type_descriptor_emission = emit_type_descriptors(type_context, native_module.module_name);
+    let type_descriptor_emission = emit_type_descriptors(type_context, native_module.module_name, injected_prelude_type_names);
 
     // ── Assemble the body before rendering the preamble so the
     // helper-target scan covers every `call @<sym>(` emitted by the

--- a/compiler/src/llvm/lowering/lowering_core.sfn
+++ b/compiler/src/llvm/lowering/lowering_core.sfn
@@ -72,6 +72,8 @@ import {
     extend_native_enums,
     extend_native_interfaces,
     extend_native_structs,
+    inject_prelude_error_struct,
+    inject_prelude_result_enum,
     is_test_module_slug,
     sanitize_module_suffix,
     seed_default_runtime_helpers
@@ -569,8 +571,14 @@ fn lower_to_llvm_lines_with_parsed_context(native_module: NativeModule, parse_in
     if debug_lowering { print.err("emit-llvm: phase=imports"); }
 
     // ── Phase 3: Combine types, build type context ──────────────────
-    let combined_structs = extend_native_structs(module_structs, imported_structs);
-    let combined_enums = extend_native_enums(module_enums, imported_enums);
+    let mut combined_structs = extend_native_structs(module_structs, imported_structs);
+    let mut combined_enums = extend_native_enums(module_enums, imported_enums);
+    // #1021: surface the prelude `Result<T, E>` / `Error` decls so bare user
+    // files (no in-file enum, no explicit import) lower `Result.Ok` / `.Err` +
+    // `match` to a real `%Result` layout + discriminant test instead of `i8*`.
+    // No-op when an in-file or imported decl already provides the name.
+    combined_enums = inject_prelude_result_enum(combined_enums);
+    combined_structs = inject_prelude_error_struct(combined_structs);
     let mut combined_interfaces = extend_native_interfaces(safe_interfaces, imported_interfaces);
     if is_test_module {
         combined_interfaces = [];

--- a/compiler/src/llvm/lowering/lowering_helpers.sfn
+++ b/compiler/src/llvm/lowering/lowering_helpers.sfn
@@ -5,6 +5,10 @@ import { NativeArtifact, NativeModule } from "../../emit_native";
 import {
     LayoutManifest,
     NativeEnum,
+    NativeEnumLayout,
+    NativeEnumVariant,
+    NativeEnumVariantField,
+    NativeEnumVariantLayout,
     NativeFunction,
     NativeImport,
     NativeImportSpecifier,
@@ -92,6 +96,109 @@ fn extend_native_enums(values: NativeEnum[], extras: NativeEnum[]) -> NativeEnum
         out = out.push(extras[index]);
         index += 1;
     }
+    return out;
+}
+
+// #1021: inject the prelude `Result<T, E>` enum into a module's combined enum
+// set when it is not already present via an in-file declaration or explicit
+// import. The prelude is linked into every Sailfin binary, so a bare user file
+// can write `Result.Ok` / `Result.Err` + `match` without importing `Result` —
+// but the LLVM lowering type context only ever saw enums from the module's own
+// `.sfn-asm` or its imports, so the prelude `Result` never reached
+// `build_type_context` and `match` silently miscompiled to `i8*` with no
+// discriminant test. We construct the `NativeEnum` literal directly here rather
+// than reading `runtime/prelude.sfn` because the native-IR parsers cannot parse
+// Sailfin source and no prelude `.sfn-asm` artifact is staged for the
+// single-file `emit llvm` path. The shape below is byte-identical to what the
+// emitter produces for an in-file `enum Result<T, E>` (verified against
+// `sailfin emit native`): a non-null, pointer-erased base layout (size-8 generic
+// payloads) that the per-instantiation monomorphisation (#830) specialises just
+// like any in-file generic payload enum. Source of truth: runtime/prelude.sfn
+// (`enum Result<T, E>`). The name guard means an in-file or imported `Result`
+// always wins — preserving `result_enum_lowering_test.sfn`'s in-file semantics
+// and preventing a duplicate `%Result` type definition if a real prelude
+// artifact is ever staged.
+fn inject_prelude_result_enum(enums: NativeEnum[]) -> NativeEnum[] {
+    let mut out = enums;
+    if out == null { out = []; }
+    let mut index: int = 0;
+    loop {
+        if index >= out.length { break; }
+        let existing = out[index];
+        if existing != null {
+            if existing.name == "Result" { return out; }
+        }
+        index += 1;
+    }
+    let result_enum = NativeEnum {
+        name: "Result",
+        type_parameters: ["T", "E"],
+        variants: [NativeEnumVariant {
+            name: "Ok", fields: [NativeEnumVariantField {
+                name: "value", type_annotation: "T", mutable: false
+            }]
+        }, NativeEnumVariant {
+            name: "Err", fields: [NativeEnumVariantField {
+                name: "error", type_annotation: "E", mutable: false
+            }]
+        }],
+        layout: NativeEnumLayout {
+            size: 16,
+            align: 8,
+            tag_type: "i32",
+            tag_size: 4,
+            tag_align: 4,
+            variants: [NativeEnumVariantLayout {
+                name: "Ok", tag: 0, offset: 8, size: 8, align: 8, fields: [NativeStructLayoutField {
+                    name: "value", type_annotation: "T", offset: 8, size: 8, align: 8
+                }]
+            }, NativeEnumVariantLayout {
+                name: "Err", tag: 1, offset: 8, size: 8, align: 8, fields: [NativeStructLayoutField {
+                    name: "error", type_annotation: "E", offset: 8, size: 8, align: 8
+                }]
+            }]
+        }
+    };
+    out = out.push(result_enum);
+    return out;
+}
+
+// #1021: inject the prelude default `Error` struct, mirroring
+// `inject_prelude_result_enum`. `Result<string, Error>` uses this as its `Err`
+// payload, so a bare user file matching on a prelude `Result` whose error type
+// is the default `Error` needs the struct layout in the type context too. The
+// shape matches the emitter output for `struct Error { message: string }`
+// (`sailfin emit native`): one pointer-sized `string` field at offset 0. Source
+// of truth: runtime/prelude.sfn (`struct Error`). In-file/imported `Error` wins
+// via the name guard.
+fn inject_prelude_error_struct(structs: NativeStruct[]) -> NativeStruct[] {
+    let mut out = structs;
+    if out == null { out = []; }
+    let mut index: int = 0;
+    loop {
+        if index >= out.length { break; }
+        let existing = out[index];
+        if existing != null {
+            if existing.name == "Error" { return out; }
+        }
+        index += 1;
+    }
+    let error_struct = NativeStruct {
+        name: "Error",
+        fields: [NativeStructField {
+            name: "message", type_annotation: "string", mutable: false
+        }],
+        methods: [],
+        implements: [],
+        layout: NativeStructLayout {
+            size: 8,
+            align: 8,
+            fields: [NativeStructLayoutField {
+                name: "message", type_annotation: "string", offset: 0, size: 8, align: 8
+            }]
+        }
+    };
+    out = out.push(error_struct);
     return out;
 }
 

--- a/compiler/src/llvm/lowering/lowering_helpers.sfn
+++ b/compiler/src/llvm/lowering/lowering_helpers.sfn
@@ -99,6 +99,40 @@ fn extend_native_enums(values: NativeEnum[], extras: NativeEnum[]) -> NativeEnum
     return out;
 }
 
+// True iff a `NativeEnum` named `name` is already present. Used both by the
+// prelude injector's guard and by `lowering_core` to decide whether a prelude
+// `Result` was actually injected (so its descriptor registration can be
+// suppressed — see #1021 note below).
+fn native_enums_have_name(enums: NativeEnum[], name: string) -> boolean {
+    if enums == null { return false; }
+    let mut index: int = 0;
+    loop {
+        if index >= enums.length { break; }
+        let existing = enums[index];
+        if existing != null {
+            if existing.name == name { return true; }
+        }
+        index += 1;
+    }
+    return false;
+}
+
+// True iff a `NativeStruct` named `name` is already present. Sibling of
+// `native_enums_have_name` for the prelude `Error` struct.
+fn native_structs_have_name(structs: NativeStruct[], name: string) -> boolean {
+    if structs == null { return false; }
+    let mut index: int = 0;
+    loop {
+        if index >= structs.length { break; }
+        let existing = structs[index];
+        if existing != null {
+            if existing.name == name { return true; }
+        }
+        index += 1;
+    }
+    return false;
+}
+
 // #1021: inject the prelude `Result<T, E>` enum into a module's combined enum
 // set when it is not already present via an in-file declaration or explicit
 // import. The prelude is linked into every Sailfin binary, so a bare user file
@@ -118,18 +152,18 @@ fn extend_native_enums(values: NativeEnum[], extras: NativeEnum[]) -> NativeEnum
 // always wins — preserving `result_enum_lowering_test.sfn`'s in-file semantics
 // and preventing a duplicate `%Result` type definition if a real prelude
 // artifact is ever staged.
+//
+// The injection is unconditional (every module gets `Result`/`Error` in its
+// LAYOUT type context) so construction/`match` lowering always resolves them.
+// Their *descriptor registration* (`sfn_type_register`) is suppressed for the
+// injected names in `lowering_core` — the prelude module owns that registration,
+// and re-emitting it in every consumer adds an undefined `sfn_type_register`
+// reference to modules that define no other types, breaking standalone-link
+// roundtrip tests (#1021 CI regression).
 fn inject_prelude_result_enum(enums: NativeEnum[]) -> NativeEnum[] {
     let mut out = enums;
     if out == null { out = []; }
-    let mut index: int = 0;
-    loop {
-        if index >= out.length { break; }
-        let existing = out[index];
-        if existing != null {
-            if existing.name == "Result" { return out; }
-        }
-        index += 1;
-    }
+    if native_enums_have_name(out, "Result") { return out; }
     let result_enum = NativeEnum {
         name: "Result",
         type_parameters: ["T", "E"],
@@ -174,15 +208,7 @@ fn inject_prelude_result_enum(enums: NativeEnum[]) -> NativeEnum[] {
 fn inject_prelude_error_struct(structs: NativeStruct[]) -> NativeStruct[] {
     let mut out = structs;
     if out == null { out = []; }
-    let mut index: int = 0;
-    loop {
-        if index >= out.length { break; }
-        let existing = out[index];
-        if existing != null {
-            if existing.name == "Error" { return out; }
-        }
-        index += 1;
-    }
+    if native_structs_have_name(out, "Error") { return out; }
     let error_struct = NativeStruct {
         name: "Error",
         fields: [NativeStructField {

--- a/compiler/src/llvm/lowering/type_descriptors.sfn
+++ b/compiler/src/llvm/lowering/type_descriptors.sfn
@@ -227,12 +227,23 @@ fn _already_seen(seen: string[], name: string) -> boolean {
 // linkage handles cross-module duplicates at link time but
 // llvm-as still rejects within-module duplicates. We dedupe by
 // type name before emission so the IR is always self-consistent.
-fn emit_type_descriptors(type_context: TypeContext, module_name: string) -> TypeDescriptorEmission {
+fn emit_type_descriptors(type_context: TypeContext, module_name: string, skip_names: string[]) -> TypeDescriptorEmission {
     if type_context == null { return _empty_emission(); }
 
     let mut preamble_lines: string[] = [];
     let mut ctor_calls: string[] = [];
     let mut seen_names: string[] = [];
+
+    // #1021: names to exclude from descriptor + `sfn_type_register` emission.
+    // The lowering core passes the prelude `Result`/`Error` names it injected
+    // into the type context for layout purposes; those are owned/registered by
+    // the prelude module, so emitting their descriptors here would add an
+    // undefined `sfn_type_register` reference to modules that define no other
+    // types (breaking standalone-link roundtrip tests). A name only lands here
+    // when the module did NOT define/import it itself, so a user's own
+    // `Result`/`Error` still registers normally.
+    let mut safe_skip = skip_names;
+    if safe_skip == null { safe_skip = []; }
 
     // Structs.
     let mut si: int = 0;
@@ -247,6 +258,7 @@ fn emit_type_descriptors(type_context: TypeContext, module_name: string) -> Type
             if nm == null { continue; }
             if nm.length == 0 { continue; }
             if _is_synthetic_name(nm) { continue; }
+            if _already_seen(safe_skip, nm) { continue; }
             if _already_seen(seen_names, nm) { continue; }
             seen_names.push(nm);
             let one = _emit_one_type(nm, _kind_struct());
@@ -273,6 +285,7 @@ fn emit_type_descriptors(type_context: TypeContext, module_name: string) -> Type
             if enm == null { continue; }
             if enm.length == 0 { continue; }
             if _is_synthetic_name(enm) { continue; }
+            if _already_seen(safe_skip, enm) { continue; }
             if _already_seen(seen_names, enm) { continue; }
             seen_names.push(enm);
             let one = _emit_one_type(enm, _kind_enum());

--- a/compiler/tests/unit/enum_match_struct_test.sfn
+++ b/compiler/tests/unit/enum_match_struct_test.sfn
@@ -100,7 +100,7 @@ test "enum_match: all priority labels" {
 //
 // A non-generic enum stores a user-struct variant payload INLINE (by value),
 // so the `match` binding must load the struct by value. This is the
-// `!substituted == true` branch of the pointer-strip in
+// non-generic (`!substituted`) branch of the pointer-strip in
 // `instructions_match_condition.sfn`: the boxed-payload fix (#830) only diverts
 // the GENERIC, monomorphised path (where the payload is stored boxed as `%T*`)
 // to keep the pointer — the non-generic inline path here must keep stripping to

--- a/compiler/tests/unit/enum_match_struct_test.sfn
+++ b/compiler/tests/unit/enum_match_struct_test.sfn
@@ -94,3 +94,40 @@ test "enum_match: all priority labels" {
     assert _priority_label(Priority.High) == "P1";
     assert _priority_label(Priority.Critical) == "P0";
 }
+
+// ---------------------------------------------------------------------------
+// Monomorphic enum with an INLINE struct payload (#830 / #1021 regression).
+//
+// A non-generic enum stores a user-struct variant payload INLINE (by value),
+// so the `match` binding must load the struct by value. This is the
+// `!substituted == true` branch of the pointer-strip in
+// `instructions_match_condition.sfn`: the boxed-payload fix (#830) only diverts
+// the GENERIC, monomorphised path (where the payload is stored boxed as `%T*`)
+// to keep the pointer — the non-generic inline path here must keep stripping to
+// a by-value load. Without this test, a future change to that branch could
+// silently regress non-generic struct payloads with no coverage to catch it.
+struct Letter {
+    sender: string;
+    weight: int;
+}
+
+enum Mail {
+    Empty,
+    Parcel { item: Letter }
+}
+
+fn _parcel_weight(m: Mail, fallback: int) -> int {
+    match m {
+        Mail.Empty => { return fallback; },
+        Mail.Parcel { item } => {
+            return item.weight + item.sender.length;
+        }
+    }
+}
+
+test "enum_match: monomorphic inline struct payload binds by value" {
+    assert _parcel_weight(Mail.Empty, 7) == 7;
+    assert _parcel_weight(Mail.Parcel {
+        item: Letter { sender: "ann", weight: 12 }
+    }, 0) == 15;
+}


### PR DESCRIPTION
## Summary
- Inject prelude `Result<T, E>` / `Error` decls into the LLVM lowering type context so bare user files (no in-file enum, no explicit import) lower `Result.Ok`/`Result.Err` + `match` to a real `%Result` layout + `icmp eq` discriminant test instead of silently miscompiling to `i8*`.
- Fix a separate pre-existing #830 bug surfaced by the above: a generic enum's struct-typed variant payload is stored **boxed** (`%T*`) but the `match` binding stripped the pointer and loaded the struct by value, corrupting the binding. Guarded the pointer-strip with `!substituted`.
- Suppress type-descriptor registration for the *injected* prelude types so modules that don't define `Result`/`Error` themselves don't gain an undefined `sfn_type_register` reference (see "CI fix" below).
- Add a regression test for the monomorphic inline-struct-payload match path.

Closes #1021

## Approach note (scope deviation from issue `In:`)
The issue's `In:` recipe — read `runtime/prelude.sfn` and parse it via `parse_native_{enums,structs}_for_import` — is **not viable**: those helpers parse `.sfn-asm` native IR, not Sailfin source, and no prelude `.sfn-asm` artifact is staged for the single-file `emit llvm` path the acceptance criteria target. Instead the fix constructs the `NativeEnum`/`NativeStruct` literals directly in `lowering_helpers.sfn` (byte-identical to the emitter's output for an in-file `enum Result<T,E>` / `struct Error`, verified against `sailfin emit native`) and injects them name-guarded. Approved by the maintainer at the design gate, and again when the struct-payload (#830) repair was found to be required for the fixture's `Result<string, Error>` test.

## CI fix (third commit)
The first version injected `Result`/`Error` into **every** module's type context unconditionally. `emit_type_descriptors` then emitted a `@__sfn_type_desc.{Result,Error}` global + a `@llvm.global_ctors` entry calling `sfn_type_register` in every module — including modules that define no other named types (which previously emitted nothing). The e2e roundtrip tests link a single module's `.o` against a minimal C harness lacking `sfn_type_register`, so they failed with `undefined reference to sfn_type_register`.

Fix: keep injection unconditional (the layout context must carry the types so construction/`match` resolves them), but pass the injected names to `emit_type_descriptors` and skip their descriptor + registration emission — the prelude module owns that registration. A name is only skipped when the module did **not** define/import it itself, so a user's own `Result`/`Error` still registers normally. (This also corrects an earlier misdiagnosis: the two e2e-sh failures were this regression, not environmental — the full suite is now green.)

## Acceptance Criteria
- [x] A bare prelude `Result.Ok`/`Result.Err` + `match` file lowers to IR with a `%Result` type, an `icmp eq` discriminant test, and payload GEP/load — verified via `emit llvm`.
- [x] `result_enum_lowering_test.sfn` still emits `%Foo` (in-file path unaffected).
- [x] `make compile` self-hosts (additive — no compiler/runtime code constructs prelude `Result`).
- [x] `make test` passes — **fully green (e2e-sh 95/95)**.
- [x] `sfn fmt --check` clean on every touched `.sfn`.
- [x] Build-time delta within noise — pure in-memory literal construction, no per-module FS read, no cache needed.

## Verification
```bash
ulimit -v 8388608 && make compile                                    # self-hosts (exit 0)

# bare prelude Result lowers correctly:
ulimit -v 8388608 && build/native/sailfin emit llvm \
  compiler/tests/unit/result_prelude_test.sfn | grep -E "%Result = type|%Error = type|icmp eq"
#   %Error = type { i8* }
#   %Result = type { i32, [4 x i8], [1 x i64] }   (identical shape to in-file %Foo)

# a module that does NOT use Result no longer emits sfn_type_register:
ulimit -v 8388608 && build/native/sailfin emit llvm \
  compiler/tests/e2e/fixtures/thread_local_basic.sfn | grep -c "sfn_type_register"   # 0

# runtime round-trips:
ulimit -v 8388608 && build/native/sailfin test compiler/tests/unit/result_prelude_test.sfn        # PASS 2/2
ulimit -v 8388608 && build/native/sailfin test compiler/tests/unit/result_enum_lowering_test.sfn  # PASS 2/2
ulimit -v 8388608 && build/native/sailfin test compiler/tests/unit/enum_match_struct_test.sfn     # PASS 4/4

ulimit -v 8388608 && make test     # e2e-sh 95/95 passed, 0 failed
```

## Files Changed
- `compiler/src/llvm/lowering/lowering_helpers.sfn` — name-guarded `inject_prelude_result_enum` / `inject_prelude_error_struct` + `native_{enums,structs}_have_name` predicates
- `compiler/src/llvm/lowering/lowering_core.sfn` — wire the injectors in; compute injected names; pass them to `emit_type_descriptors`
- `compiler/src/llvm/lowering/type_descriptors.sfn` — `skip_names` parameter that excludes injected prelude types from descriptor registration
- `compiler/src/llvm/lowering/instructions_match_condition.sfn` — guard the payload pointer-strip with `!substituted` (boxed generic struct payloads keep `%T*`)
- `compiler/tests/unit/enum_match_struct_test.sfn` — regression test for the monomorphic inline-struct-payload match path

## Notes for follow-up
- `seed-blocker`: #834 (the `?` emitter desugar) constructs/matches prelude `Result`, which only lowers once this fix is in the pinned seed. A seed cut + `/pin-seed` is needed between this merge and #834 pickup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)