### PR TITLE
ci: rebase-retry release/capsule pushes to main + tolerate publish 409

### DIFF
--- a/.github/workflows/capsule-release.yml
+++ b/.github/workflows/capsule-release.yml
@@ -120,9 +120,9 @@ jobs:
             sed -i "s/^version = \"$current_version\"/version = \"$new_version\"/" "$capsule_dir/capsule.toml"
 
             # Publish. Treat an "already exists" (HTTP 409) as success: a prior run
-            # published this version but lost the `git push origin main` race, so the
-            # bump never landed in git. Committing the bump now resyncs git with the
-            # registry instead of hard-failing every subsequent run.
+            # published this version but lost the push race below, so the bump never
+            # landed in git. Committing the bump now resyncs git with the registry
+            # instead of hard-failing every subsequent run.
             echo "Publishing $capsule_name@$new_version..."
             if publish_out="$(cd "$capsule_dir" && sailfin publish 2>&1)"; then
               echo "$publish_out"

--- a/.github/workflows/capsule-release.yml
+++ b/.github/workflows/capsule-release.yml
@@ -119,9 +119,21 @@ jobs:
             # Update capsule.toml
             sed -i "s/^version = \"$current_version\"/version = \"$new_version\"/" "$capsule_dir/capsule.toml"
 
-            # Publish
+            # Publish. Treat an "already exists" (HTTP 409) as success: a prior run
+            # published this version but lost the `git push origin main` race, so the
+            # bump never landed in git. Committing the bump now resyncs git with the
+            # registry instead of hard-failing every subsequent run.
             echo "Publishing $capsule_name@$new_version..."
-            (cd "$capsule_dir" && sailfin publish)
+            if publish_out="$(cd "$capsule_dir" && sailfin publish 2>&1)"; then
+              echo "$publish_out"
+            elif echo "$publish_out" | grep -qiE 'already exists|HTTP 409'; then
+              echo "$publish_out"
+              echo "::warning::$capsule_name@$new_version already published; committing bump to resync git with registry."
+            else
+              echo "$publish_out"
+              echo "::error::Failed to publish $capsule_name@$new_version."
+              exit 1
+            fi
 
             echo "::endgroup::"
             committed=true
@@ -137,5 +149,25 @@ jobs:
               ver="$(grep -oP '^version\s*=\s*\"\K[^\"]+' "$capsule_dir/capsule.toml")"
               echo "  - $name@$ver"
             done)"
-            git push origin main
+            # `main` is written concurrently (merged PRs, release.yml). Rebase our
+            # bump commit onto the latest origin/main and retry; we only touch
+            # capsules/*/capsule.toml, so the replay is conflict-free in practice.
+            for attempt in 1 2 3 4 5; do
+              git fetch origin main
+              if ! git rebase origin/main; then
+                git rebase --abort || true
+                echo "::error::Rebase onto origin/main hit a conflict (attempt ${attempt})."
+                exit 1
+              fi
+              if git push origin HEAD:main; then
+                echo "Pushed capsule version bump on attempt ${attempt}."
+                break
+              fi
+              if [ "$attempt" -eq 5 ]; then
+                echo "::error::Failed to push capsule version bump after 5 attempts."
+                exit 1
+              fi
+              echo "Push rejected (attempt ${attempt}); main moved — retrying after rebase."
+              sleep 5
+            done
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -235,7 +235,7 @@ jobs:
             exit 1
           fi
 
-      - name: Commit & tag
+      - name: Commit version bump
         if: inputs.dry_run != true
         env:
           TAG: ${{ steps.bump.outputs.tag }}
@@ -243,16 +243,36 @@ jobs:
           set -euo pipefail
           git add compiler/capsule.toml compiler/src/version.sfn
           git commit -m "chore(release): ${TAG#v}"
-          git tag -a "$TAG" -m "Release ${TAG}"
 
-      - name: Push commit & tag
+      - name: Rebase, tag & push
         if: inputs.dry_run != true
         env:
           TAG: ${{ steps.bump.outputs.tag }}
         run: |
           set -euo pipefail
-          git push origin HEAD
-          git push origin "$TAG"
+          # main is written to concurrently (e.g. capsule-release.yml auto-commits
+          # `chore(capsules): bump versions`). Rebase our version-bump commit onto the
+          # latest origin/main and retry, re-pointing the tag to the rebased commit.
+          # Paths are disjoint (we touch compiler/*, capsule bot touches capsules/*),
+          # so the rebase replays without conflicts; abort defensively if one occurs.
+          for attempt in 1 2 3 4 5; do
+            git fetch origin main
+            if ! git rebase origin/main; then
+              git rebase --abort || true
+              echo "::error::Rebase onto origin/main hit a conflict (attempt ${attempt})."
+              exit 1
+            fi
+            # Re-create the tag on the (possibly) rebased commit before pushing.
+            git tag -fa "$TAG" -m "Release ${TAG}"
+            if git push origin HEAD && git push origin --force "$TAG"; then
+              echo "Pushed ${TAG} on attempt ${attempt}."
+              exit 0
+            fi
+            echo "Push rejected (attempt ${attempt}); main moved — retrying after rebase."
+            sleep 5
+          done
+          echo "::error::Failed to push release commit + tag after 5 attempts."
+          exit 1
 
       - name: Create GitHub Release
         if: inputs.dry_run != true

--- a/capsules/sfn/cli/capsule.toml
+++ b/capsules/sfn/cli/capsule.toml
@@ -1,6 +1,6 @@
 [capsule]
 name = "sfn/cli"
-version = "0.8.0"
+version = "0.9.0"
 description = "CLI argument parsing and terminal output for Sailfin"
 
 [dependencies]


### PR DESCRIPTION
## Summary

Both `release.yml` and `capsule-release.yml` pushed to `main` with a plain, non-rebasing `git push`. Since `capsule-release.yml` now auto-commits to `main` on every merge, any commit landing between a workflow's checkout and its push triggers a **non-fast-forward rejection**.

- **release.yml** failed outright on the rejected push ([run 26952272800](https://github.com/SailfinIO/sailfin/actions/runs/26952272800)).
- **capsule-release.yml** failed with **HTTP 409 "version already exists"** ([run 26951285015](https://github.com/SailfinIO/sailfin/actions/runs/26951285015)) because it publishes to the registry *before* pushing — a lost push strands the registry ahead of git, so the next run re-derives the same version and re-publishes it.

Same root cause (unsynchronized concurrent writes to `main`, no rebase), two symptoms.

## Changes

- **`release.yml`** — split "Commit & tag" into commit-only + a new **Rebase, tag & push** step: `fetch → rebase origin/main → re-point tag (-fa) → push HEAD + tag`, retry ×5.
- **`capsule-release.yml`** — (1) same `fetch → rebase → push` retry ×5 on the `main` push; (2) **tolerate 409**: an "already exists" from `sailfin publish` is logged as a warning and the bump still commits, resyncing git with the registry instead of hard-failing every later run.
- **`capsules/sfn/cli/capsule.toml`** — bump `0.8.0 → 0.9.0` to heal the existing git↔registry drift left by the failed run.

Rebases are conflict-free by construction: release touches `compiler/*`, the capsule bot touches `capsules/*` (disjoint paths).

## Test plan

- [ ] YAML + `bash -n` validated locally (done).
- [ ] Trigger `release.yml` with `dry_run=true` to smoke the bump path.
- [ ] Confirm next `capsule-release` run on a `sfn/cli` change no longer 409s.