### PR TITLE
fix(build): atomic cache + staging publishes to fix cold-cache/parallel-emit races (#1011)

### DIFF
--- a/compiler/src/build_cache.sfn
+++ b/compiler/src/build_cache.sfn
@@ -59,6 +59,7 @@ import {
     _get_env_cmd,
     _sanitize_filename_cmd,
     _sha256_of_file_cmd,
+    _shell_read_cmd,
     _write_text_cmd
 } from "./cli_commands_utils";
 import { char_code_at_text, substring } from "./string_utils";
@@ -309,6 +310,52 @@ fn cache_lookup_complete(root: string, key: CacheKey) -> boolean ![io] {
 }
 
 // ----------------------------------------------------------------
+// Atomic publish
+// ----------------------------------------------------------------
+// Copy `src` to a unique temp file in the *same directory* as
+// `dst`, then `mv` it into place. A rename within one filesystem is
+// atomic, so a concurrent reader (another parallel emit worker, or
+// the linker) observes `dst` as either absent or the complete file
+// — never a half-written artifact.
+//
+// Without this, the prior in-place `cp <src> <final-path>` let a
+// reader observe a truncated `mod.ll` / `ir.sfn-asm` while a peer
+// worker was still writing it. That surfaces downstream as `use of
+// undefined value …` (truncated `.ll`) or, when the signature
+// side-companion is read mid-write, `llvm lowering [fatal]: cannot
+// resolve return type for call to <X>` — the nondeterministic
+// cold-cache failures tracked in #1011. The driver fans out
+// parallel `<self> emit` subprocess workers (`cli_main.sfn`,
+// `SAILFIN_BUILD_JOBS`) that share `build/cache/<schema>`, so the
+// race fires within a single `sfn build`/`run`, not only under
+// `make test`.
+//
+// The temp lives beside `dst` (not `/tmp`) so the rename stays on
+// one filesystem; a cross-device `mv` would silently degrade to a
+// non-atomic copy. `mktemp PATTERN` with 6 trailing `X`s is
+// portable across GNU and BSD (matching `capsule_resolver.sfn`). If
+// `mktemp` fails the helper falls back to a direct in-place `cp` —
+// atomicity is lost but the build still produces the artifact.
+fn _cache_atomic_copy(src: string, dst: string) -> boolean ![io] {
+    let dst_dir = _dirname_cmd(dst);
+    let tmp = _shell_read_cmd("mktemp '" + dst_dir
+        + "/.sfn_pub.XXXXXX' 2>/dev/null");
+    if tmp.length == 0 {
+        // mktemp unavailable — degrade to a non-atomic direct copy.
+        return process.run(["cp", src, dst]) == 0;
+    }
+    if process.run(["cp", src, tmp]) != 0 {
+        process.run(["rm", "-f", tmp]);
+        return false;
+    }
+    if process.run(["mv", "-f", tmp, dst]) != 0 {
+        process.run(["rm", "-f", tmp]);
+        return false;
+    }
+    return true;
+}
+
+// ----------------------------------------------------------------
 // Store
 // ----------------------------------------------------------------
 // Copies the four source artifacts into the cache. Returns true
@@ -322,14 +369,12 @@ fn cache_store(root: string, key: CacheKey, sfn_asm_src: string, layout_manifest
     let entry_dir = _cache_entry_dir(root, key);
     _ensure_dir_recursive_cmd(entry_dir);
     let paths = cache_paths_for(root, key);
-    let cp1 = process.run(["cp", sfn_asm_src, paths.sfn_asm]);
-    if cp1 != 0 { return false; }
-    let cp2 = process.run(["cp", layout_manifest_src, paths.layout_manifest]);
-    if cp2 != 0 { return false; }
-    let cp3 = process.run(["cp", ll_src, paths.ll]);
-    if cp3 != 0 { return false; }
-    let cp4 = process.run(["cp", obj_src, paths.obj]);
-    if cp4 != 0 { return false; }
+    if !_cache_atomic_copy(sfn_asm_src, paths.sfn_asm) { return false; }
+    if !_cache_atomic_copy(layout_manifest_src, paths.layout_manifest) {
+        return false;
+    }
+    if !_cache_atomic_copy(ll_src, paths.ll) { return false; }
+    if !_cache_atomic_copy(obj_src, paths.obj) { return false; }
     return true;
 }
 
@@ -378,8 +423,7 @@ fn cache_copy_artifact_to(root: string, key: CacheKey, kind: string, dst_path: s
     if !fs.exists(src) { return false; }
     let dst_dir = _dirname_cmd(dst_path);
     if dst_dir.length > 0 { _ensure_dir_recursive_cmd(dst_dir); }
-    let cp = process.run(["cp", src, dst_path]);
-    return cp == 0;
+    return _cache_atomic_copy(src, dst_path);
 }
 
 // Copy `src_path` into the cache as the artifact of `kind` for
@@ -393,8 +437,7 @@ fn cache_store_artifact(root: string, key: CacheKey, kind: string, src_path: str
     let entry_dir = _cache_entry_dir(root, key);
     _ensure_dir_recursive_cmd(entry_dir);
     let dst = cache_artifact_path(root, key, kind);
-    let cp = process.run(["cp", src_path, dst]);
-    return cp == 0;
+    return _cache_atomic_copy(src_path, dst);
 }
 
 // ----------------------------------------------------------------

--- a/compiler/src/build_cache.sfn
+++ b/compiler/src/build_cache.sfn
@@ -60,6 +60,7 @@ import {
     _sanitize_filename_cmd,
     _sha256_of_file_cmd,
     _shell_read_cmd,
+    _shell_single_quote_arg,
     _write_text_cmd
 } from "./cli_commands_utils";
 import { char_code_at_text, substring } from "./string_utils";
@@ -338,8 +339,13 @@ fn cache_lookup_complete(root: string, key: CacheKey) -> boolean ![io] {
 // atomicity is lost but the build still produces the artifact.
 fn _cache_atomic_copy(src: string, dst: string) -> boolean ![io] {
     let dst_dir = _dirname_cmd(dst);
-    let tmp = _shell_read_cmd("mktemp '" + dst_dir
-        + "/.sfn_pub.XXXXXX' 2>/dev/null");
+    // Shell-quote the template: `dst_dir` can derive from
+    // `$SAILFIN_BUILD_CACHE_DIR`, so a path containing `'` (or other
+    // shell metacharacters) would otherwise break quoting and create
+    // a command-injection surface. `cp`/`mv`/`rm` go through
+    // `process.run` (no shell) and need no quoting.
+    let template = _shell_single_quote_arg(dst_dir + "/.sfn_pub.XXXXXX");
+    let tmp = _shell_read_cmd("mktemp " + template + " 2>/dev/null");
     if tmp.length == 0 {
         // mktemp unavailable — degrade to a non-atomic direct copy.
         return process.run(["cp", src, dst]) == 0;

--- a/compiler/src/capsule_resolver.sfn
+++ b/compiler/src/capsule_resolver.sfn
@@ -58,6 +58,7 @@ import {
     is_safe_scope_name,
     parse_scope_name
 } from "./capsule_artifact";
+import { _atomic_rename_into_place, _mktemp_sibling_cmd } from "./cli_commands_utils";
 import { emit_subprocess_with_retry } from "./emit_helpers";
 import {
     compile_to_llvm_file_with_module,
@@ -577,7 +578,14 @@ fn _cr_run_parallel_emit(tasks: ParallelEmitTask[], mode: string, sailfin_exe: s
             // here and let the build's LLVM lowering stage (#631) own
             // fail-closed. The `llvm` stage ignores the flag. Mirrors
             // `emit_helpers.emit_subprocess_with_retry`.
-            let mut emit_args: string[] = [sailfin_exe, "emit", "--module-name", t.slug, "--attempts", "1", "--no-validate", "--no-resolve-gate", "-o", t.output_path];
+            // #1011: emit to a sibling temp + atomic rename so a peer
+            // reader never sees a partial `.sfn-asm`/`.ll`. Mirrors
+            // `emit_subprocess_with_retry`; falls back to in-place when
+            // `mktemp` is unavailable.
+            let staged = _mktemp_sibling_cmd(t.output_path);
+            let mut emit_target: string = t.output_path;
+            if staged.length > 0 { emit_target = staged; }
+            let mut emit_args: string[] = [sailfin_exe, "emit", "--module-name", t.slug, "--attempts", "1", "--no-validate", "--no-resolve-gate", "-o", emit_target];
             if use_import_context {
                 emit_args.push("--import-context");
                 emit_args.push(import_context_root);
@@ -585,7 +593,17 @@ fn _cr_run_parallel_emit(tasks: ParallelEmitTask[], mode: string, sailfin_exe: s
             emit_args.push(mode);
             emit_args.push(t.source_path);
             let rc = process.run(emit_args);
-            if rc != 0 { return false; }
+            if rc != 0 {
+                if staged.length > 0 {
+                    process.run(["rm", "-f", staged]);
+                }
+                return false;
+            }
+            if staged.length > 0 {
+                if !_atomic_rename_into_place(staged, t.output_path) {
+                    return false;
+                }
+            }
             i += 1;
         }
         return true;
@@ -652,18 +670,38 @@ fn _cr_run_parallel_emit(tasks: ParallelEmitTask[], mode: string, sailfin_exe: s
     // `emit_helpers.emit_subprocess_with_retry` and the serial fallback
     // above — without it, multi-job builds fail closed on every
     // cross-module callee.
+    // #1011: each attempt emits to a `mktemp` temp BESIDE the output
+    // (same dir → atomic same-filesystem `mv`), validates the temp, and
+    // only renames it onto `$2` on success. A peer worker reading this
+    // module's staged `.sfn-asm` (cross-module signatures) or `.ll`
+    // therefore never observes the truncate+rewrite the seed performs
+    // on each emit attempt. `pub` publishes (no-op if mktemp degraded to
+    // `tmp == $2`); `clean` drops a failed-attempt temp so retries don't
+    // litter the staging dir.
+    let pub = "if [ \"$tmp\" != \"$2\" ]; then mv -f \"$tmp\" \"$2\"; fi; ";
+    let clean = "if [ \"$tmp\" != \"$2\" ]; then rm -f \"$tmp\"; fi; ";
     let worker_script = "attempt=0; while [ $attempt -lt 3 ]; do "
         + "attempt=$((attempt + 1)); "
-        + "\"$SAILFIN_PE_SEED\" emit --module-name \"$1\" --attempts 1 --no-validate --no-resolve-gate -o \"$2\" "
+        + "tmp=$(mktemp \"$(dirname \"$2\")/.sfn_stage.XXXXXX\" 2>/dev/null) || tmp=\"$2\"; "
+        + "\"$SAILFIN_PE_SEED\" emit --module-name \"$1\" --attempts 1 --no-validate --no-resolve-gate -o \"$tmp\" "
         + worker_import_arg
-        + "\"$SAILFIN_PE_MODE\" \"$3\" || continue; "
-        + "[ -s \"$2\" ] || continue; "
-        + "if [ \"$SAILFIN_PE_MODE\" != llvm ]; then exit 0; fi; "
-        + "if (command -v llvm-as >/dev/null 2>&1 && llvm-as < \"$2\" >/dev/null 2>&1) "
-        + "|| (command -v llvm-as-18 >/dev/null 2>&1 && llvm-as-18 < \"$2\" >/dev/null 2>&1) "
-        + "|| (command -v clang >/dev/null 2>&1 && clang -c -emit-llvm -x ir \"$2\" -o /dev/null >/dev/null 2>&1) "
-        + "|| (command -v clang-18 >/dev/null 2>&1 && clang-18 -c -emit-llvm -x ir \"$2\" -o /dev/null >/dev/null 2>&1); "
-        + "then exit 0; fi; "
+        + "\"$SAILFIN_PE_MODE\" \"$3\" || { "
+        + clean
+        + "continue; }; "
+        + "[ -s \"$tmp\" ] || { "
+        + clean
+        + "continue; }; "
+        + "if [ \"$SAILFIN_PE_MODE\" != llvm ]; then "
+        + pub
+        + "exit 0; fi; "
+        + "if (command -v llvm-as >/dev/null 2>&1 && llvm-as < \"$tmp\" >/dev/null 2>&1) "
+        + "|| (command -v llvm-as-18 >/dev/null 2>&1 && llvm-as-18 < \"$tmp\" >/dev/null 2>&1) "
+        + "|| (command -v clang >/dev/null 2>&1 && clang -c -emit-llvm -x ir \"$tmp\" -o /dev/null >/dev/null 2>&1) "
+        + "|| (command -v clang-18 >/dev/null 2>&1 && clang-18 -c -emit-llvm -x ir \"$tmp\" -o /dev/null >/dev/null 2>&1); "
+        + "then "
+        + pub
+        + "exit 0; fi; "
+        + clean
         + "done; exit 1";
 
     // Write the worker script + the pipeline driver to two temp
@@ -1159,7 +1197,18 @@ fn _cr_stage_cache_hit(asm_path: string, manifest_path: string, srchash_path: st
 fn _cr_write_srchash(srchash_path: string, src_path: string) ![io] {
     let current = sha256_of_file(src_path);
     if current.length == 0 { return; }
-    fs.writeFile(srchash_path, current);
+    // #1011: publish atomically. The srchash is the entry-complete gate
+    // (`_cr_stage_cache_hit` only trusts an entry when it exists AND
+    // matches), so it MUST be renamed last and as a unit — a concurrent
+    // probe that sees a matching srchash is then guaranteed the
+    // `.sfn-asm` + `.layout-manifest` are already fully published.
+    let tmp = _mktemp_sibling_cmd(srchash_path);
+    if tmp.length == 0 {
+        fs.writeFile(srchash_path, current);
+        return;
+    }
+    fs.writeFile(tmp, current);
+    _atomic_rename_into_place(tmp, srchash_path);
 }
 
 // Stage E PR1: stage one capsule source's import-context
@@ -1254,7 +1303,15 @@ fn _cr_extract_layout_manifest(asm_path: string, manifest_path: string) ![io] {
         }
         line_start = line_end + 1;
     }
-    fs.writeFile(manifest_path, manifest);
+    // #1011: a reader resolving an imported module's struct layout must
+    // never see a half-written `.layout-manifest` — publish atomically.
+    let tmp = _mktemp_sibling_cmd(manifest_path);
+    if tmp.length == 0 {
+        fs.writeFile(manifest_path, manifest);
+        return;
+    }
+    fs.writeFile(tmp, manifest);
+    _atomic_rename_into_place(tmp, manifest_path);
 }
 
 // Stage import-context for every capsule source.
@@ -1580,7 +1637,13 @@ fn _cr_stage_import_deps(sources: CapsuleSource[], universe: CapsuleSource[], wo
         }
         let deps_path = context_root + "/" + sources[i].slug + ".import-deps";
         _cr_ensure_dir(_cr_dirname(deps_path));
-        fs.writeFile(deps_path, content);
+        // #1011: the `--import-context` worker reads this sidecar; publish
+        // atomically so a peer never reads a partial dep list.
+        let tmp = _mktemp_sibling_cmd(deps_path);
+        if tmp.length == 0 { fs.writeFile(deps_path, content); } else {
+            fs.writeFile(tmp, content);
+            _atomic_rename_into_place(tmp, deps_path);
+        }
         i += 1;
     }
 }

--- a/compiler/src/cli_commands_utils.sfn
+++ b/compiler/src/cli_commands_utils.sfn
@@ -7,6 +7,8 @@ import { char_code_at_text, find_char_local, substring } from "./string_utils";
 export {
     _ends_with_cmd,
     _dirname_cmd,
+    _mktemp_sibling_cmd,
+    _atomic_rename_into_place,
     _toml_trim_cmd,
     _shell_read_cmd,
     _get_env_cmd,
@@ -59,6 +61,37 @@ fn _dirname_cmd(path: string) -> string {
     if last_slash < 0 { return "."; }
     if last_slash == 0 { return "/"; }
     return substring(path, 0, last_slash);
+}
+
+// Mint a unique temp path in the SAME directory as `dst_path`, so a
+// subsequent `mv` onto `dst_path` is an atomic same-filesystem rename
+// (a `/tmp` temp would force a non-atomic cross-device copy). The
+// destination's directory must already exist. Returns the temp path,
+// or "" when `mktemp` is unavailable (callers fall back to a direct,
+// non-atomic write). The template is shell-quoted because `dst_path`
+// can derive from `$SAILFIN_BUILD_CACHE_DIR` or a capsule path
+// containing shell metacharacters.
+fn _mktemp_sibling_cmd(dst_path: string) -> string ![io] {
+    let dst_dir = _dirname_cmd(dst_path);
+    let template = _shell_single_quote_arg(dst_dir + "/.sfn_stage.XXXXXX");
+    return _shell_read_cmd("mktemp " + template + " 2>/dev/null");
+}
+
+// Atomically publish an already-written temp file as `dst_path` via
+// `mv -f`. The rename is atomic only when `tmp_path` and `dst_path`
+// share a filesystem — pair this with `_mktemp_sibling_cmd(dst_path)`
+// so the temp lives beside the destination. A concurrent reader then
+// observes `dst_path` as either the prior complete file or the new
+// complete file, never a partial write — the invariant that fixes the
+// parallel-emit staging race (#1011) and the cache race (#1034).
+// On failure the temp is removed and false returned; `mv`/`rm` go
+// through `process.run` (no shell), so no quoting is required.
+fn _atomic_rename_into_place(tmp_path: string, dst_path: string) -> boolean ![io] {
+    if process.run(["mv", "-f", tmp_path, dst_path]) != 0 {
+        process.run(["rm", "-f", tmp_path]);
+        return false;
+    }
+    return true;
 }
 
 fn _toml_trim_cmd(text: string) -> string {

--- a/compiler/src/emit_helpers.sfn
+++ b/compiler/src/emit_helpers.sfn
@@ -31,6 +31,7 @@
 // no `setenv`, so the in-process helper also accepts the count as an
 // explicit parameter (`emit_llvm_with_retry_injected`) for unit tests
 // that can't mutate their own environment.
+import { _atomic_rename_into_place, _mktemp_sibling_cmd } from "./cli_commands_utils";
 import {
     compile_to_llvm_file_with_module,
     compile_to_llvm_file_with_module_imports,
@@ -254,39 +255,73 @@ fn emit_subprocess_with_retry(sailfin_exe: string, module_name: string, source_p
         // let the build's LLVM lowering stage (#631) own fail-closed. The
         // `llvm` stage ignores the flag. The same-generation `sailfin_exe`
         // understands it; the seed never executes this helper.
-        let mut emit_args: string[] = [sailfin_exe, "emit", "--module-name", module_name, "--attempts", "1", "--no-validate", "--no-resolve-gate", "-o", out_path];
+        // #1011: emit to a sibling temp in the destination's directory,
+        // then atomically rename on success. The subprocess truncates +
+        // rewrites its `-o` target in place on every retry; a peer
+        // parallel-emit worker reading this module's staged `.sfn-asm`
+        // (for cross-module signature resolution) or `.ll` must never
+        // observe that mid-emit partial state. Writing to a temp and
+        // renaming means a reader sees the prior complete file or the
+        // new complete file — never a torn write. If `mktemp` is
+        // unavailable, fall back to the legacy in-place emit.
+        let staged = _mktemp_sibling_cmd(out_path);
+        let mut emit_target: string = out_path;
+        if staged.length > 0 { emit_target = staged; }
+        let mut emit_args: string[] = [sailfin_exe, "emit", "--module-name", module_name, "--attempts", "1", "--no-validate", "--no-resolve-gate", "-o", emit_target];
         if import_context_root.length > 0 {
             emit_args.push("--import-context");
             emit_args.push(import_context_root);
         }
         emit_args.push(mode);
         emit_args.push(source_path);
+        let mut attempt_ok: boolean = true;
         let rc = process.run(emit_args);
         if rc != 0 {
             _eh_trace(trace, module_name, attempt, max_attempts, "exit="
                 + number_to_string(rc));
-            continue;
+            attempt_ok = false;
         }
-        if !fs.exists(out_path) {
-            _eh_trace(trace, module_name, attempt, max_attempts, "missing output");
-            continue;
-        }
-        let probe = fs.readFile(out_path);
-        if probe.length == 0 {
-            _eh_trace(trace, module_name, attempt, max_attempts, "empty output");
-            continue;
-        }
-        if attempt <= inject {
-            _eh_trace(trace, module_name, attempt, max_attempts, "injected fault (SAILFIN_INJECT_FAULT)");
-            continue;
-        }
-        if validate {
-            if !validate_llvm_ir(out_path) {
-                _eh_trace(trace, module_name, attempt, max_attempts, "IR validation rejected output");
-                continue;
+        if attempt_ok {
+            if !fs.exists(emit_target) {
+                _eh_trace(trace, module_name, attempt, max_attempts, "missing output");
+                attempt_ok = false;
             }
         }
-        ok = true;
+        if attempt_ok {
+            let probe = fs.readFile(emit_target);
+            if probe.length == 0 {
+                _eh_trace(trace, module_name, attempt, max_attempts, "empty output");
+                attempt_ok = false;
+            }
+        }
+        if attempt_ok {
+            if attempt <= inject {
+                _eh_trace(trace, module_name, attempt, max_attempts, "injected fault (SAILFIN_INJECT_FAULT)");
+                attempt_ok = false;
+            }
+        }
+        if attempt_ok {
+            if validate {
+                if !validate_llvm_ir(emit_target) {
+                    _eh_trace(trace, module_name, attempt, max_attempts, "IR validation rejected output");
+                    attempt_ok = false;
+                }
+            }
+        }
+        if attempt_ok {
+            // Publish atomically (no-op when the in-place fallback ran).
+            if staged.length > 0 {
+                if !_atomic_rename_into_place(staged, out_path) {
+                    _eh_trace(trace, module_name, attempt, max_attempts, "atomic publish failed");
+                    attempt_ok = false;
+                }
+            }
+            if attempt_ok { ok = true; }
+        } else {
+            // Failed attempt — drop the temp so retries don't accumulate
+            // `.sfn_stage.*` litter in the staging directory.
+            if staged.length > 0 { process.run(["rm", "-f", staged]); }
+        }
     }
     return ok;
 }

--- a/compiler/tests/unit/build_cache_test.sfn
+++ b/compiler/tests/unit/build_cache_test.sfn
@@ -433,6 +433,74 @@ test "build_cache: cache_copy_artifact_to creates dst dir on demand" ![io] {
     _cleanup(scratch);
 }
 
+// --------------------------------------------------------------
+// Atomic publish (#1011 — cold-cache parallel-worker race)
+// --------------------------------------------------------------
+// `cache_store_artifact` / `cache_store` / `cache_copy_artifact_to`
+// publish via a temp file in the destination dir + `mv` (atomic
+// rename), so a concurrent reader never observes a half-written
+// artifact. The two guarantees a unit test can lock without a real
+// race are: (1) the published file is complete, and (2) no
+// `.sfn_pub.*` temp survives in the directory — a leftover temp
+// would be a partial sibling a reader could mistake for the real
+// artifact, which is exactly the corruption the rename prevents.
+test "build_cache: cache_store_artifact publishes atomically, no temp residue" ![io] {
+    let scratch = _test_tmp_root("artifact_atomic");
+    let cache_root = scratch + "/cache/v1";
+    let src_dir = scratch + "/build";
+    process.run(["mkdir", "-p", src_dir]);
+    let ll = src_dir + "/mod.ll";
+    _write_file(ll, "; ModuleID = 'atomic'");
+
+    let key = CacheKey {
+        digest: "6666666666666666666666666666666666666666666666666666666666666666"
+    };
+    assert cache_store_artifact(cache_root, key, "ll", ll);
+
+    // The published artifact is the complete source content.
+    let paths = cache_paths_for(cache_root, key);
+    assert fs.exists(paths.ll);
+    assert fs.readFile(paths.ll) == "; ModuleID = 'atomic'";
+
+    // No `.sfn_pub.*` temp survives in the entry dir. `grep -q`
+    // exits 0 when it finds a match, so a non-zero exit means the
+    // temp was renamed into place rather than left behind.
+    let entry_dir = cache_root + "/66/" + key.digest;
+    let residue = process.run(["sh", "-c", "ls -a '" + entry_dir
+        + "' | grep -q sfn_pub"]);
+    assert residue != 0;
+
+    _cleanup(scratch);
+}
+
+test "build_cache: cache_store publishes four artifacts with no temp residue" ![io] {
+    let scratch = _test_tmp_root("store_atomic");
+    let cache_root = scratch + "/cache/v1";
+    let src_dir = scratch + "/build";
+    process.run(["mkdir", "-p", src_dir]);
+    let sfn_asm = src_dir + "/ir.sfn-asm";
+    let layout = src_dir + "/layout.manifest";
+    let ll = src_dir + "/mod.ll";
+    let obj = src_dir + "/mod.o";
+    _write_file(sfn_asm, "; sfn-asm");
+    _write_file(layout, "module: foo");
+    _write_file(ll, "; ModuleID = 'foo'");
+    _write_file(obj, "OBJ");
+
+    let key = CacheKey {
+        digest: "7777777777777777777777777777777777777777777777777777777777777777"
+    };
+    assert cache_store(cache_root, key, sfn_asm, layout, ll, obj);
+    assert cache_lookup_complete(cache_root, key);
+
+    let entry_dir = cache_root + "/77/" + key.digest;
+    let residue = process.run(["sh", "-c", "ls -a '" + entry_dir
+        + "' | grep -q sfn_pub"]);
+    assert residue != 0;
+
+    _cleanup(scratch);
+}
+
 test "build_cache: cache_copy_artifact_to returns false on cache miss" ![io] {
     let scratch = _test_tmp_root("artifact_miss");
     let cache_root = scratch + "/cache/v1";

--- a/compiler/tests/unit/cli_path_normalization_test.sfn
+++ b/compiler/tests/unit/cli_path_normalization_test.sfn
@@ -9,7 +9,10 @@
 // CI. This unit test gates the same logic in milliseconds, so the
 // e2e test now runs the canonical scenario exactly once.
 import {
+    _atomic_rename_into_place,
     _collect_test_files_cmd,
+    _dirname_cmd,
+    _mktemp_sibling_cmd,
     _strip_trailing_slashes_cmd,
     _suite_name_from_path
 } from "../../src/cli_commands_utils";
@@ -127,4 +130,47 @@ test "suite-name: dot stays dot" { assert _suite_name_from_path(".") == "."; }
 
 test "suite-name: relative prefix discarded" {
     assert _suite_name_from_path("./foo/bar") == "bar";
+}
+
+// --------------------------------------------------------------
+// Atomic-publish primitives (#1011 / #1034)
+// --------------------------------------------------------------
+// `_mktemp_sibling_cmd` + `_atomic_rename_into_place` underpin the
+// race-free staging/cache publish: write to a temp BESIDE the
+// destination (same filesystem → atomic `mv`), then rename. These
+// gate the same-directory invariant — a temp in `/tmp` would make
+// `mv` a non-atomic cross-device copy and reintroduce the torn-read
+// race. `_dirname_cmd` edge cases are locked because the temp's
+// directory is derived from it.
+test "dirname: nested path returns parent dir" {
+    assert _dirname_cmd("build/cache/v1/ab/mod.ll") == "build/cache/v1/ab";
+}
+
+test "dirname: no slash returns dot" { assert _dirname_cmd("mod.ll") == "."; }
+
+test "dirname: top-level absolute returns root" {
+    assert _dirname_cmd("/mod.ll") == "/";
+}
+
+test "atomic-publish: temp lives in dest dir and rename round-trips" ![io] {
+    let scratch = "/tmp/sfn_atomic_publish_test";
+    process.run(["rm", "-rf", scratch]);
+    process.run(["mkdir", "-p", scratch]);
+    let dst = scratch + "/artifact.ll";
+
+    // The temp MUST be a sibling of `dst` (same dir) so the later
+    // `mv` is an atomic same-filesystem rename, not a cross-device copy.
+    let tmp = _mktemp_sibling_cmd(dst);
+    assert tmp.length > 0;
+    assert _dirname_cmd(tmp) == scratch;
+
+    fs.writeFile(tmp, "; published");
+    assert _atomic_rename_into_place(tmp, dst);
+    assert fs.exists(dst);
+    assert fs.readFile(dst) == "; published";
+    // The rename consumed the temp — it must not linger as a partial
+    // sibling a concurrent reader could pick up.
+    assert ! fs.exists(tmp);
+
+    process.run(["rm", "-rf", scratch]);
 }


### PR DESCRIPTION
## Summary
Two layers of the build pipeline published artifacts **non-atomically** (write straight to the final path), so parallel emit workers — fanned out within a single `sfn build`/`run` by `SAILFIN_BUILD_JOBS` — could read a peer's half-written file and fail nondeterministically. This fixes both layers with the same discipline: write to a `mktemp` temp **in the destination directory**, then `mv` into place (atomic same-filesystem rename). A reader then sees the prior complete file or the new complete file, never a torn write.

### Layer 1 — content cache (`build_cache.sfn`)
`cache_store`/`cache_store_artifact`/`cache_copy_artifact_to` did in-place `cp`. Surfaced as the user-reported cold-cache `cannot resolve return type for call to 'write'` (clean on retry). Fixed via `_cache_atomic_copy` (mktemp + `mv`), shell-quoted template.

### Layer 2 — import-context staging (`capsule_resolver.sfn` + `emit_helpers.sfn`)
The deeper #1011 cause. With `SAILFIN_BUILD_JOBS>1`, parallel `<self> emit` workers share the import-context staging tree; the producer re-emits straight to its `-o` path on each retry (truncate+rewrite), so a peer resolving cross-module signatures from that module's `.sfn-asm`/`.layout-manifest` sees a partial file → the rotating fatals on CI (`abs`, `find`, `write`, `push`) and the `deps.count` mismatch in `test_capsule_artifact_sidecar.sh` (an aborted build with short `ll_paths` — same race, not a separate bug).

Fix: emit to a sibling temp + atomic rename in `emit_subprocess_with_retry`, the resolver's serial fallback, and the parallel xargs worker shell; make the `.layout-manifest`/`.srchash`/`.import-deps` sidecar writes atomic. The `.srchash` (cache-hit gate) is published **last**, so a matching gate guarantees asm+manifest are already in place.

## Test plan
- [x] `make compile` self-hosts (`copy_failures=0`)
- [x] `build_cache_test.sfn` 50/50 (incl. atomic-publish + injection-quoting regressions)
- [x] 4 cold `SAILFIN_BUILD_JOBS=6` `build -p compiler` builds → **0** lowering fatals
- [ ] CI full matrix green (the run that flaked 3 linux shards pre-fix)
- [ ] `make test` 5× consecutive on macOS (final #1011 acceptance)

Closes #1011