### PR TITLE
fix(lowering): fail closed on unresolvable struct/enum literal (#1023)

### DIFF
--- a/compiler/src/llvm/expression_lowering/native/core.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core.sfn
@@ -1406,9 +1406,12 @@ fn lower_expression(expression: string, bindings: ParameterBinding[], locals: Lo
     // `enum_info == null`) has no behavioral `else` on purpose — the bare
     // `X.Y` shape is indistinguishable from member access (`obj.field`), which
     // parse_enum_literal also "recognizes", so failing here would break member
-    // access. The brace shape `X.Y { ... }` instead funnels into the struct
-    // dispatch below (parse_struct_literal recognizes the dotted name), where
-    // the fail-closed guard catches an unresolvable enum/struct type.
+    // access. Note parse_enum_literal recognizes the brace shape `X.Y { ... }`
+    // too: when its enum type DOES resolve, the `enum_info != null` branch
+    // above already lowered and returned it, so only the *unresolvable* brace
+    // form (enum parse unsuccessful, or `enum_info == null`) falls through to
+    // the struct dispatch below (parse_struct_literal recognizes the dotted
+    // name), where the fail-closed guard catches the unresolvable type.
     let struct_parse = parse_struct_literal(stripped);
     if struct_parse.recognized {
         if !struct_parse.success {

--- a/compiler/src/llvm/expression_lowering/native/core.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core.sfn
@@ -1402,6 +1402,13 @@ fn lower_expression(expression: string, bindings: ParameterBinding[], locals: Lo
         }
     }
 
+    // #1023: the enum dead-end above (enum_parse recognized + success but
+    // `enum_info == null`) has no behavioral `else` on purpose — the bare
+    // `X.Y` shape is indistinguishable from member access (`obj.field`), which
+    // parse_enum_literal also "recognizes", so failing here would break member
+    // access. The brace shape `X.Y { ... }` instead funnels into the struct
+    // dispatch below (parse_struct_literal recognizes the dotted name), where
+    // the fail-closed guard catches an unresolvable enum/struct type.
     let struct_parse = parse_struct_literal(stripped);
     if struct_parse.recognized {
         if !struct_parse.success {
@@ -1411,6 +1418,27 @@ fn lower_expression(expression: string, bindings: ParameterBinding[], locals: Lo
                 diagnostics.push(struct_parse.diagnostics[_ci3]);
                 _ci3 += 1;
             }
+            return ExpressionResult {
+                lines: lines,
+                temp_index: temp_index,
+                operand: null,
+                diagnostics: diagnostics,
+                string_constants: empty_constants
+            };
+        }
+        // #1023: fail-closed on a recognized struct/enum-shaped literal whose
+        // type is absent from the lowering type context. Without this guard,
+        // lower_struct_literal returns a null operand carrying only a
+        // *non-fatal* "unknown struct" diagnostic, which the emit/build
+        // `[fatal]` gate ignores — so the enclosing statement silently lowers
+        // to a default value (the #1020 assert-elision; why the #832 asserts
+        // vanished). Escalate to a `[fatal]` diagnostic so the compile refuses
+        // to emit IR. After #1021, prelude `Result` resolves through the enum
+        // path above and never reaches this guard.
+        if resolve_struct_info_for_literal(context, struct_parse.type_name) == null {
+            diagnostics.push("llvm lowering [fatal]: struct/enum literal `"
+                + struct_parse.type_name
+                + "` references a type not in the lowering type context");
             return ExpressionResult {
                 lines: lines,
                 temp_index: temp_index,

--- a/compiler/tests/unit/unresolvable_literal_diagnostic_test.sfn
+++ b/compiler/tests/unit/unresolvable_literal_diagnostic_test.sfn
@@ -1,0 +1,69 @@
+// Regression coverage for #1023: a recognized struct/enum-shaped literal whose
+// type is absent from the lowering type context must fail closed with a
+// `[fatal]` diagnostic, not silently lower the enclosing statement to a default
+// value.
+//
+// Background (#1020): prelude `Result` was unregistered in the per-module
+// lowering type context, so `Result.Ok { value: 5 }` failed to resolve. The
+// brace form funnels through `lower_struct_literal`, which pushed only a
+// *non-fatal* "unknown struct" diagnostic — ignored by the emit/build `[fatal]`
+// gate — so the enclosing `assert` was elided (the #832 false-pass). #1021
+// registers prelude `Result`/`Error`; this guard catches the residual class of
+// genuinely-unresolvable literals so the failure is loud instead of silent.
+import { lower_expression } from "../../src/llvm/expression_lowering/native/core";
+import { TypeContext } from "../../src/llvm/types";
+import { index_of } from "../../src/string_utils";
+
+fn _empty_context() -> TypeContext {
+    return TypeContext {
+        structs: [],
+        enums: [],
+        interfaces: [],
+        vtables: []
+    };
+}
+
+fn _contains(text: string, needle: string) -> boolean {
+    return index_of(text, needle) >= 0;
+}
+
+fn _has_fatal_type_context_diag(diagnostics: string[]) -> boolean {
+    let mut idx: int = 0;
+    loop {
+        if idx >= diagnostics.length { break; }
+        let diag = diagnostics[idx];
+        if _contains(diag, "[fatal]") {
+            if _contains(diag, "references a type not in the lowering type context") {
+                return true;
+            }
+        }
+        idx += 1;
+    }
+    return false;
+}
+
+// -------------------------------------------------------------------
+// Fail-closed: dotted brace literal (enum-shaped) with an unknown type
+// -------------------------------------------------------------------
+test "unresolvable enum-shaped brace literal emits a fatal diagnostic" ![io] {
+    let context = _empty_context();
+    let mut lines: string[] = [];
+    let result = lower_expression("Nonexistent.Variant { value: 5 }", [], [], 0, lines, [], context, "");
+    // No operand is produced — without the guard this null operand would
+    // silently drop the enclosing statement.
+    assert result.operand == null;
+    // The diagnostic must be `[fatal]` so `has_fatal_lowering_diagnostic`
+    // refuses to emit IR (the compile fails instead of succeeding silently).
+    assert _has_fatal_type_context_diag(result.diagnostics);
+}
+
+// -------------------------------------------------------------------
+// Fail-closed: plain struct literal with an unknown type
+// -------------------------------------------------------------------
+test "unresolvable plain struct literal emits a fatal diagnostic" ![io] {
+    let context = _empty_context();
+    let mut lines: string[] = [];
+    let result = lower_expression("UnknownStruct { x: 1 }", [], [], 0, lines, [], context, "");
+    assert result.operand == null;
+    assert _has_fatal_type_context_diag(result.diagnostics);
+}


### PR DESCRIPTION
## Summary
- A recognized struct/enum-shaped literal whose type is **not in the per-module lowering type context** used to lower to a null operand carrying only a *non-fatal* "unknown struct" diagnostic. The emit/build `[fatal]` gate (`has_fatal_lowering_diagnostic`) ignores non-fatal diagnostics, so the enclosing statement silently lowered to a default value — the assert-elision that hid the #832 false passes (#1020).
- Adds a fail-closed guard in the `core.sfn` struct dispatch: when a recognized literal's type does not resolve, emit a `[fatal]` diagnostic so the compile refuses to write IR and fails loudly.

Closes #1023

## Acceptance Criteria
- [x] A file with an unresolvable enum/struct literal emits a clear diagnostic and fails the compile (no more silent empty `ret void` body).
- [x] After #1021, prelude `Result` does NOT trigger this diagnostic (proves the two fixes compose, not mask).
- [x] `make compile` passes (no legitimate compiler/runtime construct relied on the silent drop — full self-host rebuild is clean).
- [x] `make test` passes.
- [x] `sfn fmt --check` clean.

## Verification
```bash
# AC1 — unresolvable literals now fail closed (exit 1):
$ build/native/sailfin emit llvm bogus_brace.sfn
llvm lowering [fatal]: struct/enum literal `Bogus.Variant` references a type not in the lowering type context   # exit 1
$ build/native/sailfin emit llvm plain_unknown.sfn
llvm lowering [fatal]: struct/enum literal `UnknownStruct` references a type not in the lowering type context    # exit 1

# AC2 — prelude Result is unaffected (0 fatals; real layout + discriminant):
$ build/native/sailfin emit llvm prelude_result.sfn | grep -cE '%Result = type|icmp eq'   # 4
#   fatal count: 0

# AC3 + suite:
$ ulimit -v 8388608 && make compile     # self-hosts clean
$ ulimit -v 8388608 && make test        # e2e-sh 98/98; all unit/integration/e2e green
```

## Files Changed
- `compiler/src/llvm/expression_lowering/native/core.sfn` — fail-closed `[fatal]` guard in the struct-literal dispatch + a comment documenting why the enum dead-end intentionally has no behavioral `else`.
- `compiler/tests/unit/unresolvable_literal_diagnostic_test.sfn` (new) — drives `lower_expression` with an empty type context and asserts both the dotted brace form (`Nonexistent.Variant { value: 5 }`) and a plain struct (`UnknownStruct { x: 1 }`) yield a null operand + a `[fatal]` diagnostic.

## Scope note (worth recording for grooming)
The issue's `In:` scope also referenced `core_member_lowering.sfn:~900,970` as "match-arm `enum_info == null` dead-ends." On investigation those line numbers are **field member-access** sites: when an `i8*` field's annotation base resolves to neither a registered enum nor struct, the code falls through to returning the raw `i8*` load — a **valid operand**, not a silent drop. Making them `[fatal]` would reject every legitimate `i8*` field (strings, aliases) and break the build. They are therefore intentionally left untouched; the genuine silent-drop site is the struct-literal dispatch fixed here, and all five acceptance criteria pass without modifying them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QnBV8VU2JtWoAuQVbasNMa)_