### PR TITLE
feat(cli): add flag_repeat and flag_count to sfn/cli

### DIFF
--- a/capsules/sfn/cli/src/builder.sfn
+++ b/capsules/sfn/cli/src/builder.sfn
@@ -155,6 +155,58 @@ fn flag_path(long_name: string, description: string) -> Flag {
     };
 }
 
+fn flag_repeat(long_name: string, description: string) -> Flag {
+    // Create a repeating value flag that collects every occurrence's
+    // value (e.g. --include a --include b -> ["a", "b"]). Each
+    // occurrence appends to the recorded values rather than overwriting,
+    // so the order matches argv. Read the collected list with
+    // `repeated(matches, name)`; `get`/`get_or` still return the first
+    // occurrence. Takes a value like `flag_value`.
+    let no_choices: string[] = [];
+    return Flag {
+        long_name: long_name,
+        short_name: "",
+        description: description,
+        takes_value: true,
+        required: false,
+        value_kind: "repeat",
+        choices: no_choices
+    };
+}
+
+fn flag_count(long_name: string, description: string) -> Flag {
+    // Create a counted boolean flag. Each occurrence increments the
+    // count (e.g. --verbose --verbose -> 2); it takes no value. Read the
+    // count with `count_flag(matches, name)`. Use `flag_count_short` to
+    // attach a short alias so clustered forms like `-vvv` are accepted.
+    let no_choices: string[] = [];
+    return Flag {
+        long_name: long_name,
+        short_name: "",
+        description: description,
+        takes_value: false,
+        required: false,
+        value_kind: "count",
+        choices: no_choices
+    };
+}
+
+fn flag_count_short(long_name: string, short_name: string, description: string) -> Flag {
+    // Counted boolean flag with a short alias (e.g. --verbose / -v). The
+    // short alias enables clustered short forms: `-vvv` increments the
+    // count by 3. Read the count with `count_flag(matches, name)`.
+    let no_choices: string[] = [];
+    return Flag {
+        long_name: long_name,
+        short_name: short_name,
+        description: description,
+        takes_value: false,
+        required: false,
+        value_kind: "count",
+        choices: no_choices
+    };
+}
+
 fn flag_choice(long_name: string, description: string, choices: string[]) -> Flag {
     // Create a flag whose value must be one of `choices` (e.g.
     // --color always|auto|never). `parse()` validates the supplied

--- a/capsules/sfn/cli/src/matches.sfn
+++ b/capsules/sfn/cli/src/matches.sfn
@@ -169,6 +169,39 @@ fn _string_to_float(value: string) -> float {
     return result;
 }
 
+fn repeated(m: Matches, name: string) -> string[] {
+    // Collect every value recorded under a repeating value flag (built
+    // via `flag_repeat`) in command-line order. Returns `[]` when the
+    // flag was never supplied. `flag_names[i]` and `flag_values[i]` are
+    // parallel, so each occurrence contributes one value.
+    let mut out: string[] = [];
+    let mut i: int = 0;
+    loop {
+        if i >= m.flag_names.length { break; }
+        if strings_equal(m.flag_names[i], name) {
+            out.push(m.flag_values[i]);
+        }
+        i += 1;
+    }
+    return out;
+}
+
+fn count_flag(m: Matches, name: string) -> int {
+    // Count how many times a counted flag (built via `flag_count` /
+    // `flag_count_short`) occurred on the command line. Returns `0` when
+    // absent. Repeated long forms (`--verbose --verbose`) and clustered
+    // short forms (`-vvv`, which the parser expands to one occurrence per
+    // character) both contribute one to the count per occurrence.
+    let mut n: int = 0;
+    let mut i: int = 0;
+    loop {
+        if i >= m.flag_names.length { break; }
+        if strings_equal(m.flag_names[i], name) { n += 1; }
+        i += 1;
+    }
+    return n;
+}
+
 fn subcommand(m: Matches) -> string {
     // Returns the deepest matched subcommand name, or empty string if
     // none. For a multi-level tree this is the leaf (e.g. "get" for

--- a/capsules/sfn/cli/src/mod.sfn
+++ b/capsules/sfn/cli/src/mod.sfn
@@ -82,6 +82,9 @@ export {
     flag_float,
     flag_path,
     flag_choice,
+    flag_repeat,
+    flag_count,
+    flag_count_short,
     flag_required,
     command,
     with_version,
@@ -103,6 +106,8 @@ export {
     get_choice,
     has_flag,
     has,
+    repeated,
+    count_flag,
     subcommand,
     subcommand_path,
     positionals

--- a/capsules/sfn/cli/src/parser.sfn
+++ b/capsules/sfn/cli/src/parser.sfn
@@ -114,6 +114,23 @@ fn parse(cmd: Command, argv: string[]) -> ParseResult {
             let short = substring(token, 1, token.length);
             let f = _find_flag_short(active, short);
             if f.long_name.length == 0 {
+                // Not a single known short flag. Try a counted-flag
+                // cluster (e.g. -vvv): every character must map to the
+                // short alias of a count flag. On success, record one
+                // occurrence per character so `count_flag` totals them.
+                let cluster = _expand_count_cluster(active, short);
+                if cluster.length > 0 {
+                    let mut ci: int = 0;
+                    loop {
+                        if ci >= cluster.length { break; }
+                        fl_names.push(cluster[ci]);
+                        fl_present.push(true);
+                        fl_values.push("true");
+                        ci += 1;
+                    }
+                    idx += 1;
+                    continue;
+                }
                 return _err_result(cmd.name, path, pos_names, pos_values, fl_names, fl_values, fl_present, "unknown_flag", _with_hint(cmd.name, path, "error: unknown flag -"
                     + short), short, "");
             }
@@ -408,6 +425,30 @@ fn _find_subcmd(cmd: Command, name: string) -> Command {
         flags: empty_flags,
         subcmds: empty_subs
     };
+}
+
+fn _expand_count_cluster(active: Command, cluster: string) -> string[] {
+    // For a clustered short token like "vvv", return the long names to
+    // record — one per character — iff every character maps to the short
+    // alias of a count flag (`value_kind == "count"`). Returns `[]` when
+    // the cluster is shorter than two characters or any character is not
+    // a counted-flag short alias, signalling the caller to fall back to
+    // the unknown-flag path. Single short flags (length 1) are handled by
+    // the normal `_find_flag_short` lookup and never reach here.
+    let empty: string[] = [];
+    if cluster.length < 2 { return empty; }
+    let mut out: string[] = [];
+    let mut i: int = 0;
+    loop {
+        if i >= cluster.length { break; }
+        let ch = grapheme_at(cluster, i);
+        let f = _find_flag_short(active, ch);
+        if f.long_name.length == 0 { return empty; }
+        if !strings_equal(f.value_kind, "count") { return empty; }
+        out.push(f.long_name);
+        i += 1;
+    }
+    return out;
 }
 
 fn _resolve_active_path(cmd: Command, path: string[]) -> Command {

--- a/capsules/sfn/cli/src/parser.sfn
+++ b/capsules/sfn/cli/src/parser.sfn
@@ -433,8 +433,11 @@ fn _expand_count_cluster(active: Command, cluster: string) -> string[] {
     // alias of a count flag (`value_kind == "count"`). Returns `[]` when
     // the cluster is shorter than two characters or any character is not
     // a counted-flag short alias, signalling the caller to fall back to
-    // the unknown-flag path. Single short flags (length 1) are handled by
-    // the normal `_find_flag_short` lookup and never reach here.
+    // the unknown-flag path. A *known* single short flag is intercepted
+    // earlier by the normal `_find_flag_short` lookup and never reaches
+    // here; an *unknown* single short flag does reach here but returns
+    // `[]` immediately via the `< 2` length guard, so the caller still
+    // falls back to the unknown-flag path.
     let empty: string[] = [];
     if cluster.length < 2 { return empty; }
     let mut out: string[] = [];

--- a/capsules/sfn/cli/tests/repeat_count_test.sfn
+++ b/capsules/sfn/cli/tests/repeat_count_test.sfn
@@ -1,0 +1,133 @@
+// Tests for sfn/cli repeating and counted flags — `flag_repeat`,
+// `flag_count`, `flag_count_short` builders and their `repeated` /
+// `count_flag` accessors (Issue #796, Issue 1.7 of the CLI
+// Modularization Epic, #351).
+//
+// `flag_repeat` collects every occurrence's value in argv order;
+// `flag_count` counts boolean occurrences, including the clustered
+// short form `-vvv` (expanded by the parser to one occurrence per
+// character). `parse()` (the pure, non-exiting variant) is used
+// throughout so error paths never call `process.exit()`.
+import {
+    command,
+    count_flag,
+    flag_count,
+    flag_count_short,
+    flag_repeat,
+    parse,
+    repeated,
+    with_flag
+} from "../src/mod";
+
+// ---- Builder shape ----
+test "flag_repeat: builds a repeating value flag" {
+    let f = flag_repeat("include", "Include path");
+    assert strings_equal(f.long_name, "include");
+    assert f.takes_value == true;
+    assert strings_equal(f.value_kind, "repeat");
+}
+
+test "flag_count: builds a counted boolean flag" {
+    let f = flag_count("verbose", "Verbosity");
+    assert strings_equal(f.long_name, "verbose");
+    assert f.takes_value == false;
+    assert strings_equal(f.value_kind, "count");
+}
+
+test "flag_count_short: carries the short alias" {
+    let f = flag_count_short("verbose", "v", "Verbosity");
+    assert strings_equal(f.long_name, "verbose");
+    assert strings_equal(f.short_name, "v");
+    assert strings_equal(f.value_kind, "count");
+}
+
+// ---- repeated: zero / one / three occurrences ----
+test "repeated: absent flag yields an empty list" {
+    let cmd = with_flag(command("app", "desc"), flag_repeat("include", "Include"));
+    let argv: string[] = ["app"];
+    let r = parse(cmd, argv);
+    assert r.ok == true;
+    let vals = repeated(r.matches, "include");
+    assert vals.length == 0;
+}
+
+test "repeated: a single occurrence yields one value" {
+    let cmd = with_flag(command("app", "desc"), flag_repeat("include", "Include"));
+    let argv: string[] = ["app", "--include", "a"];
+    let r = parse(cmd, argv);
+    assert r.ok == true;
+    let vals = repeated(r.matches, "include");
+    assert vals.length == 1;
+    assert strings_equal(vals[0], "a");
+}
+
+test "repeated: three occurrences collected in argv order" {
+    let cmd = with_flag(command("app", "desc"), flag_repeat("include", "Include"));
+    let argv: string[] = ["app", "--include", "a", "--include", "b", "--include", "c"];
+    let r = parse(cmd, argv);
+    assert r.ok == true;
+    let vals = repeated(r.matches, "include");
+    assert vals.length == 3;
+    assert strings_equal(vals[0], "a");
+    assert strings_equal(vals[1], "b");
+    assert strings_equal(vals[2], "c");
+}
+
+// ---- count_flag: zero / one / three (long form) ----
+test "count_flag: absent flag yields zero" {
+    let cmd = with_flag(command("app", "desc"), flag_count("verbose", "Verbose"));
+    let argv: string[] = ["app"];
+    let r = parse(cmd, argv);
+    assert r.ok == true;
+    assert count_flag(r.matches, "verbose") == 0;
+}
+
+test "count_flag: a single long occurrence yields one" {
+    let cmd = with_flag(command("app", "desc"), flag_count("verbose", "Verbose"));
+    let argv: string[] = ["app", "--verbose"];
+    let r = parse(cmd, argv);
+    assert r.ok == true;
+    assert count_flag(r.matches, "verbose") == 1;
+}
+
+test "count_flag: three long occurrences yield three" {
+    let cmd = with_flag(command("app", "desc"), flag_count("verbose", "Verbose"));
+    let argv: string[] = ["app", "--verbose", "--verbose", "--verbose"];
+    let r = parse(cmd, argv);
+    assert r.ok == true;
+    assert count_flag(r.matches, "verbose") == 3;
+}
+
+// ---- count_flag: short and clustered forms ----
+test "count_flag: a single short occurrence yields one" {
+    let cmd = with_flag(command("app", "desc"), flag_count_short("verbose", "v", "Verbose"));
+    let argv: string[] = ["app", "-v"];
+    let r = parse(cmd, argv);
+    assert r.ok == true;
+    assert count_flag(r.matches, "verbose") == 1;
+}
+
+test "count_flag: three separate short occurrences yield three" {
+    let cmd = with_flag(command("app", "desc"), flag_count_short("verbose", "v", "Verbose"));
+    let argv: string[] = ["app", "-v", "-v", "-v"];
+    let r = parse(cmd, argv);
+    assert r.ok == true;
+    assert count_flag(r.matches, "verbose") == 3;
+}
+
+test "count_flag: clustered -vvv increments the count by three" {
+    let cmd = with_flag(command("app", "desc"), flag_count_short("verbose", "v", "Verbose"));
+    let argv: string[] = ["app", "-vvv"];
+    let r = parse(cmd, argv);
+    assert r.ok == true;
+    assert count_flag(r.matches, "verbose") == 3;
+}
+
+// ---- a cluster of an unknown short alias is still rejected ----
+test "count_flag: clustered unknown short flag is rejected" {
+    let cmd = with_flag(command("app", "desc"), flag_count_short("verbose", "v", "Verbose"));
+    let argv: string[] = ["app", "-xxx"];
+    let r = parse(cmd, argv);
+    assert r.ok == false;
+    assert strings_equal(r.error.kind, "unknown_flag");
+}


### PR DESCRIPTION
## Summary

- Add `flag_repeat` (collects multiple string values, e.g. `--include a --include b`) and `flag_count` / `flag_count_short` (counts boolean occurrences, incl. clustered `-vvv`).
- Add accessors `repeated(matches, name) -> string[]` and `count_flag(matches, name) -> int`.
- New parser helper `_expand_count_cluster` expands `-vvv` into one recorded occurrence per character when every char maps to a count flag's short alias.

Closes #796

## Design notes

- **`flag_repeat` needs no parser change for the long form.** The parser already pushes each flag occurrence onto the parallel `flag_names`/`flag_values` arrays, so repeated occurrences append naturally; `repeated()` just collects all values for a name in argv order. `get`/`get_or` still return the first occurrence.
- **`flag_count` is a boolean flag with `value_kind: "count"`.** Each occurrence (long `--verbose`, separate short `-v -v`, or clustered `-vvv`) records one entry; `count_flag()` tallies them.
- **`flag_count_short` was added** because the `-vvv` clustering acceptance criterion requires a count flag with a short alias, and the specified `flag_count(name, description)` signature has no short param. This mirrors the existing `flag`/`flag_short` and `flag_value`/`flag_value_short` companions (typed flags like `flag_int` deliberately have no short variant, so adding only the needed companion is consistent with precedent).

## Acceptance Criteria

- [x] `flag_repeat(name, description)`, `flag_count(name, description)` exported.
- [x] `repeated(matches, name) -> string[]` returns occurrences in argv order; `[]` when absent.
- [x] `count_flag(matches, name) -> int` returns the count; `0` when absent.
- [x] Clustered short flags (`-vvv`) increment `count_flag` by 3 when the short alias maps to a counted flag.
- [x] Tests cover: zero, one, three occurrences for both modes; `-vvv` cluster.
- [x] `make compile`, `sfn fmt --check`, capsule tests all green (`make test` e2e phase confirmed separately).

## Verification

```bash
$ build/native/sailfin test capsules/sfn/cli/tests/repeat_count_test.sfn
  PASS  (all 13 tests passed)

$ build/native/sailfin test capsules/sfn/cli/tests/
═══ tests: 10/10 passed, 0 failed ═══

$ build/native/sailfin fmt --check capsules/sfn/cli/
# clean

$ make compile
[compile] build/native/sailfin up-to-date   # capsule changes don't affect compiler self-host
```

## Files Changed

- `capsules/sfn/cli/src/builder.sfn` — `flag_repeat`, `flag_count`, `flag_count_short`
- `capsules/sfn/cli/src/matches.sfn` — `repeated`, `count_flag`
- `capsules/sfn/cli/src/parser.sfn` — `_expand_count_cluster` + `-vvv` cluster expansion
- `capsules/sfn/cli/src/mod.sfn` — re-exports
- `capsules/sfn/cli/tests/repeat_count_test.sfn` — NEW, 13 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PR1dFhKJdZYhVWRUo5Bq7A)_