### PR TITLE
refactor(runtime): flip exception frame-head to thread_local

### DIFF
--- a/compiler/tests/e2e/test_runtime_exception_frames.sh
+++ b/compiler/tests/e2e/test_runtime_exception_frames.sh
@@ -24,13 +24,13 @@
 #                    runtime's `sailfin_runtime_throw` abort-on-empty
 #                    semantics).
 #   7. global pin — `@global.sfn_exception_frame_head_addr = internal
-#                   global i64 0` pins the chain-head storage shape.
-#                   The TLS upgrade (compiler-side parser in #825;
-#                   runtime-side flip queued as a follow-up gated on the
-#                   next seed pin) replaces `internal global` with
-#                   `internal thread_local global` without touching
-#                   callers; this assertion catches a regression that
-#                   relocates the storage or drops the zero initializer.
+#                   thread_local global i64 0` pins the chain-head storage
+#                   shape. The TLS flip landed (compiler-side parser in
+#                   #825; runtime-side flip in #827) so the chain head now
+#                   rides ELF TLS — each thread sees its own head without
+#                   touching callers; this assertion catches a regression
+#                   that drops the `thread_local` marker, relocates the
+#                   storage, or drops the zero initializer.
 #   8. coexistence — the Sailfin-emitted symbols use canonical
 #                    architect names (`sfn_try_enter`, `sfn_throw`,
 #                    `sfn_take_exception`, …) which deliberately do NOT
@@ -345,13 +345,15 @@ test_frame_head_global() {
         echo "[test]   $ll missing — test_emit_define_shape must run first"
         return 1
     fi
-    # The TLS upgrade (compiler-side parser in #825; runtime-side flip
-    # queued as a follow-up gated on the next seed pin) replaces
-    # `internal global` with `internal thread_local global` without
-    # touching callers. Pin the current shape so the follow-up is the
-    # advertised one-line audit-able diff.
-    if ! grep -qE "^@global\.sfn_exception_frame_head_addr = internal global i64 0$" "$ll"; then
-        echo "[test]   missing '@global.sfn_exception_frame_head_addr = internal global i64 0':"
+    # The TLS upgrade landed: the compiler-side `thread_local` parser
+    # shipped in #825 and the runtime-side flip in #827 (gated on a seed
+    # release including the parser — `.seed-version` >= v0.7.0-alpha.25).
+    # The chain head now lowers to `internal thread_local global`, putting
+    # it on ELF TLS so each thread sees its own head, without touching
+    # callers. Pin the post-flip shape so a regression that drops the
+    # `thread_local` marker (or the zero initializer) surfaces here.
+    if ! grep -qE "^@global\.sfn_exception_frame_head_addr = internal thread_local global i64 0$" "$ll"; then
+        echo "[test]   missing '@global.sfn_exception_frame_head_addr = internal thread_local global i64 0':"
         grep -E "^@global\." "$ll" || true
         return 1
     fi

--- a/compiler/tests/e2e/test_runtime_exception_frames.sh
+++ b/compiler/tests/e2e/test_runtime_exception_frames.sh
@@ -27,7 +27,9 @@
 #                   thread_local global i64 0` pins the chain-head storage
 #                   shape. The TLS flip landed (compiler-side parser in
 #                   #825; runtime-side flip in #827) so the chain head now
-#                   rides ELF TLS — each thread sees its own head without
+#                   rides platform thread-local storage (LLVM
+#                   `thread_local` → ELF TLS on Linux, Mach-O TLS on
+#                   macOS) — each thread sees its own head without
 #                   touching callers; this assertion catches a regression
 #                   that drops the `thread_local` marker, relocates the
 #                   storage, or drops the zero initializer.
@@ -349,8 +351,9 @@ test_frame_head_global() {
     # shipped in #825 and the runtime-side flip in #827 (gated on a seed
     # release including the parser — `.seed-version` >= v0.7.0-alpha.25).
     # The chain head now lowers to `internal thread_local global`, putting
-    # it on ELF TLS so each thread sees its own head, without touching
-    # callers. Pin the post-flip shape so a regression that drops the
+    # it on the platform's thread-local storage (LLVM `thread_local` → ELF
+    # TLS on Linux, Mach-O TLS on macOS) so each thread sees its own head,
+    # without touching callers. Pin the post-flip shape so a regression that drops the
     # `thread_local` marker (or the zero initializer) surfaces here.
     if ! grep -qE "^@global\.sfn_exception_frame_head_addr = internal thread_local global i64 0$" "$ll"; then
         echo "[test]   missing '@global.sfn_exception_frame_head_addr = internal thread_local global i64 0':"

--- a/compiler/tests/e2e/test_thread_local_lowering.sh
+++ b/compiler/tests/e2e/test_thread_local_lowering.sh
@@ -154,14 +154,13 @@ test_pthread_isolation_roundtrip() {
     # TLS, sibling increments leak in and the return value exceeds
     # N on at least one thread.
     #
-    # We drive the fixture (not `runtime/sfn/exception.sfn`) because
-    # the runtime module's `let mut sfn_exception_frame_head_addr`
-    # cannot flip to `thread_local` in this PR — the pinned seed
-    # 0.7.0-alpha.8 compiles every entry in
-    # `runtime/native/capsule.toml`'s `sfn-sources` and predates the
-    # keyword. The runtime flip lands in a follow-up PR after the
-    # next seed pin (the audit-able one-liner the issue's #3
-    # criterion calls for).
+    # This fixture-driven roundtrip is the smaller-surface unit-level
+    # pin: it exercises the `thread_local` lowering in isolation
+    # without dragging in exception.sfn's struct-init constructor or
+    # type_meta linkage. The exception.sfn-driven companion below
+    # (test_exception_tls_isolation_roundtrip, #827) proves the same
+    # isolation against the real runtime chain head now that the flip
+    # has landed; this one stays as the lighter regression gate.
     #
     # Skipped when `clang` or pthread linkage is unavailable —
     # mirrors the cross-frame roundtrip skip in
@@ -294,6 +293,181 @@ CHARNESS
     return 0
 }
 
+test_exception_tls_isolation_roundtrip() {
+    # End-to-end TLS-isolation check against the *real* runtime chain
+    # head (#827). Mirrors test_pthread_isolation_roundtrip but drives
+    # `runtime/sfn/exception.sfn`'s `sfn_exception_push_frame` /
+    # `sfn_exception_frame_head` instead of the fixture, proving the
+    # `thread_local let mut sfn_exception_frame_head_addr` flip gives
+    # each thread its own chain head.
+    #
+    # Two pthreads each alloc a frame, push it onto the chain, then —
+    # after an atomic barrier guarantees BOTH have pushed — read the
+    # head back. Under TLS each thread's head is its own frame and the
+    # main thread (which never pushed) still sees NULL. Without TLS the
+    # global is shared: both workers (and main) observe whichever frame
+    # was pushed last, so at least one observed_head != my_frame.
+    #
+    # Skipped when clang or pthread linkage is unavailable — mirrors
+    # the cross-frame roundtrip skip in test_runtime_exception_frames.sh;
+    # the IR-shape assertion in that file still pins the contract.
+    local clang_bin
+    clang_bin="${CLANG:-clang}"
+    if ! command -v "$clang_bin" >/dev/null 2>&1; then
+        echo "[test]   clang not available — skipping exception TLS roundtrip"
+        return 0
+    fi
+
+    local repo_root
+    repo_root="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+    local module="$repo_root/runtime/sfn/exception.sfn"
+    local ll="$SCRATCH/exception_tls.ll"
+    if ! "$BINARY" emit -o "$ll" llvm "$module" > /dev/null 2>&1; then
+        echo "[test]   sfn emit llvm failed for exception.sfn"
+        return 1
+    fi
+
+    # exception.sfn defines the `SfnExceptionFrame` struct, so M2.10
+    # (#402) emits an `@__sfn_module_type_init__*` constructor that
+    # calls `@sfn_type_register`. Stage a type_meta object so the
+    # standalone link resolves it (mirrors the cross-frame roundtrip
+    # in test_runtime_exception_frames.sh). Skip if it can't be built.
+    local type_meta_ll="$SCRATCH/type_meta.ll"
+    local type_meta_o="$SCRATCH/type_meta.o"
+    if ! { "$BINARY" emit -o "$type_meta_ll" llvm "$repo_root/runtime/sfn/type_meta.sfn" >/dev/null 2>&1 \
+            && "$clang_bin" -Wno-override-module -c "$type_meta_ll" -o "$type_meta_o" 2>/dev/null; }; then
+        echo "[test]   could not emit type_meta object — skipping exception TLS roundtrip"
+        return 0
+    fi
+
+    local harness="$SCRATCH/exception_tls_harness.c"
+    cat > "$harness" <<'CHARNESS'
+/* TLS-isolation harness for runtime/sfn/exception.sfn's per-thread
+ * chain head (#827). Each pthread pushes its own frame and, after an
+ * atomic barrier, verifies sfn_exception_frame_head() returns that
+ * frame. Under thread_local storage each thread is isolated and the
+ * never-pushing main thread still sees NULL. */
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <pthread.h>
+#include <sched.h>
+#include <stdatomic.h>
+
+struct SfnExceptionFrame {
+    int64_t prev_addr;
+    int64_t jmp_buf_addr;
+    int64_t message_addr;
+};
+
+extern struct SfnExceptionFrame *sfn_exception_alloc_frame(void);
+extern void sfn_exception_free_frame(struct SfnExceptionFrame *frame);
+extern struct SfnExceptionFrame *sfn_exception_frame_head(void);
+extern void sfn_exception_push_frame(struct SfnExceptionFrame *frame);
+
+/* Sailfin's heap-return marker — no-op stub so the standalone link
+ * doesn't pull in the C runtime (matches the cross-frame harness). */
+void sailfin_runtime_mark_persistent(void *ptr) { (void)ptr; }
+
+static atomic_int pushed_count = 0;
+
+struct WorkerArgs {
+    int id;
+    struct SfnExceptionFrame *my_frame;
+    struct SfnExceptionFrame *observed_head;
+};
+
+static void *worker(void *raw) {
+    struct WorkerArgs *args = (struct WorkerArgs *)raw;
+    struct SfnExceptionFrame *f = sfn_exception_alloc_frame();
+    if (!f) {
+        args->my_frame = NULL;
+        args->observed_head = (struct SfnExceptionFrame *)-1;
+        atomic_fetch_add(&pushed_count, 1);
+        return NULL;
+    }
+    args->my_frame = f;
+    sfn_exception_push_frame(f);
+    /* Barrier: spin until both workers have pushed, so a shared
+     * (non-TLS) head is guaranteed to hold the *last* push by the
+     * time anyone reads — making the bleed deterministically
+     * detectable rather than timing-dependent. */
+    atomic_fetch_add(&pushed_count, 1);
+    while (atomic_load(&pushed_count) < 2) {
+        sched_yield();
+    }
+    args->observed_head = sfn_exception_frame_head();
+    return NULL;
+}
+
+int main(void) {
+    pthread_t t1, t2;
+    struct WorkerArgs a1 = { .id = 1, .my_frame = NULL, .observed_head = NULL };
+    struct WorkerArgs a2 = { .id = 2, .my_frame = NULL, .observed_head = NULL };
+
+    if (pthread_create(&t1, NULL, worker, &a1) != 0) {
+        fprintf(stderr, "pthread_create #1 failed\n");
+        return 1;
+    }
+    if (pthread_create(&t2, NULL, worker, &a2) != 0) {
+        fprintf(stderr, "pthread_create #2 failed\n");
+        return 2;
+    }
+    pthread_join(t1, NULL);
+    pthread_join(t2, NULL);
+
+    if (a1.my_frame == NULL || a2.my_frame == NULL) {
+        fprintf(stderr, "alloc_frame returned NULL in a worker\n");
+        return 3;
+    }
+    if (a1.observed_head != a1.my_frame) {
+        fprintf(stderr,
+                "TLS bleed: worker 1 expected head=%p, got %p\n",
+                (void *)a1.my_frame, (void *)a1.observed_head);
+        return 4;
+    }
+    if (a2.observed_head != a2.my_frame) {
+        fprintf(stderr,
+                "TLS bleed: worker 2 expected head=%p, got %p\n",
+                (void *)a2.my_frame, (void *)a2.observed_head);
+        return 5;
+    }
+    /* The main thread never pushed — under TLS its head is still
+     * NULL; a shared global would show a worker's frame here. */
+    if (sfn_exception_frame_head() != NULL) {
+        fprintf(stderr,
+                "TLS bleed: main thread head=%p, expected NULL\n",
+                (void *)sfn_exception_frame_head());
+        return 6;
+    }
+
+    sfn_exception_free_frame(a1.my_frame);
+    sfn_exception_free_frame(a2.my_frame);
+    return 0;
+}
+CHARNESS
+
+    local bin="$SCRATCH/exception_tls_roundtrip"
+    if ! "$clang_bin" -Wno-override-module "$harness" "$ll" "$type_meta_o" \
+            -o "$bin" -lm -lpthread 2>"$SCRATCH/exc_clang.log"; then
+        if grep -q "cannot find -lpthread" "$SCRATCH/exc_clang.log"; then
+            echo "[test]   -lpthread unavailable — skipping exception TLS roundtrip"
+            return 0
+        fi
+        echo "[test]   clang failed to link exception TLS roundtrip:"
+        cat "$SCRATCH/exc_clang.log"
+        return 1
+    fi
+
+    if ! "$bin" > "$SCRATCH/exc_run.log" 2>&1; then
+        local rc=$?
+        echo "[test]   exception TLS roundtrip exited non-zero (rc=$rc):"
+        cat "$SCRATCH/exc_run.log"
+        return 1
+    fi
+    return 0
+}
+
 run_test "thread_local let mut lowers to 'internal thread_local global'" \
     test_lowering_emits_thread_local_qualifier
 run_test "thread_local globals share the @global.<name> symbol at use sites" \
@@ -304,6 +478,8 @@ run_test "thread_local let mut is accepted by typecheck" \
     test_mutable_thread_local_accepted
 run_test "two pthreads bumping a thread_local i64 head do not interfere" \
     test_pthread_isolation_roundtrip
+run_test "two pthreads pushing exception.sfn frames see isolated chain heads" \
+    test_exception_tls_isolation_roundtrip
 
 echo "[summary] $PASS passed, $FAIL failed"
 if [ "$FAIL" -gt 0 ]; then

--- a/runtime/sfn/exception.sfn
+++ b/runtime/sfn/exception.sfn
@@ -89,8 +89,10 @@
 // i64 (the seed compiler drops pointer-typed top-level mutables
 // under the same field-layout limitation as struct pointer fields)
 // and lowers to `@global.sfn_exception_frame_head_addr = internal
-// thread_local global i64 0`, putting the binding on ELF TLS so each
-// thread sees its own chain head. The existing C runtime's try-stack
+// thread_local global i64 0`, putting the binding on the platform's
+// thread-local storage (LLVM `thread_local`, lowering to ELF TLS on
+// Linux and Mach-O TLS on macOS) so each thread sees its own chain
+// head. The existing C runtime's try-stack
 // is `_Thread_local`, so this matches it; Sailfin has no `spawn`
 // yet, so the single-threaded reality still applies, but the
 // per-thread storage is now in place for the scheduler / concurrency

--- a/runtime/sfn/exception.sfn
+++ b/runtime/sfn/exception.sfn
@@ -81,23 +81,20 @@
 //
 // TLS. The architect spec calls for a thread-local
 // `current_frame` pointer. The `thread_local` storage-class
-// annotation ships in the compiler in #825, but the pinned seed
-// for this PR predates the keyword and can't parse it in this
-// runtime file (the seed compiles every entry in
-// `runtime/native/capsule.toml`'s `sfn-sources` as part of
-// `sfn build -p compiler`). The chain head therefore still rides
-// as a process-global mutable `let mut sfn_exception_frame_head_addr`
-// (i64 because the seed compiler drops pointer-typed top-level
-// mutables under the same field-layout limitation as struct
-// pointer fields). The flip to `thread_local let mut` is a
-// one-line follow-up PR that lands after the next seed pin —
-// the audit-able diff the M2.7a module header originally
-// promised. Tracking issue: #730 follow-up; depends on a seed
-// release that includes the #825 parser change. The existing C
-// runtime's try-stack is `_Thread_local`, but Sailfin has no
-// `spawn` yet, so the single-threaded reality already applies.
-// The TLS upgrade lands alongside scheduler / concurrency work
-// in M4 (#321).
+// annotation shipped in the compiler in #825; once a seed release
+// included that parser change (`.seed-version` >= v0.7.0-alpha.25),
+// the chain head flipped to `thread_local let mut
+// sfn_exception_frame_head_addr` in #827 — the audit-able one-line
+// diff the M2.7a module header originally promised. It rides as an
+// i64 (the seed compiler drops pointer-typed top-level mutables
+// under the same field-layout limitation as struct pointer fields)
+// and lowers to `@global.sfn_exception_frame_head_addr = internal
+// thread_local global i64 0`, putting the binding on ELF TLS so each
+// thread sees its own chain head. The existing C runtime's try-stack
+// is `_Thread_local`, so this matches it; Sailfin has no `spawn`
+// yet, so the single-threaded reality still applies, but the
+// per-thread storage is now in place for the scheduler / concurrency
+// work in M4 (#321).
 //
 // Effects. None. Exception primitives live below the I/O layer
 // (same discipline as `runtime/sfn/memory/arena.sfn` and
@@ -170,10 +167,11 @@ struct SfnExceptionFrame {
     message_addr: i64;
 }
 
-// Chain head (process-global; see the file-header TLS note).
-// `0` means "no frame pending" — `sfn_throw` aborts in that
-// case rather than longjmp'ing to a stale buffer.
-let mut sfn_exception_frame_head_addr: i64 = 0;
+// Chain head (per-thread `thread_local`; see the file-header TLS
+// note). `0` means "no frame pending" — `sfn_throw` aborts in that
+// case rather than longjmp'ing to a stale buffer. Each thread sees
+// its own head, so concurrent try/throw chains never alias.
+thread_local let mut sfn_exception_frame_head_addr: i64 = 0;
 
 // `sfn_exception_alloc_frame()` allocates a fresh frame plus
 // its JMPBUF_SIZE buffer. Returns the frame pointer; caller


### PR DESCRIPTION
## Summary

- Adds the `thread_local` storage-class prefix to `runtime/sfn/exception.sfn`'s `let mut sfn_exception_frame_head_addr` — the audit-able one-line diff promised in #730's criterion #3 and the M2.7a module header, now unblocked because the compiler-side `thread_local` keyword (#825) is in the pinned seed (`v0.7.0-alpha.25`).
- The chain head now lowers to `@global.sfn_exception_frame_head_addr = internal thread_local global i64 0`, putting it on ELF TLS so each thread sees its own try/throw chain head. No call-site changes — reads/writes still address `@global.<name>`. This is the per-thread storage the M4 scheduler (#321) needs.

Closes #827

## Acceptance Criteria

- [x] `runtime/sfn/exception.sfn` declares `thread_local let mut sfn_exception_frame_head_addr: i64 = 0;` and the file-header `TLS.` note reflects the post-flip state.
- [x] `test_runtime_exception_frames.sh`'s `test_frame_head_global` asserts `^@global\.sfn_exception_frame_head_addr = internal thread_local global i64 0$` and passes against the freshly-built compiler (12/12 green).
- [x] A pthread isolation test against `exception.sfn` proves two pthreads each see their own `sfn_exception_frame_head` after pushing distinct frames (no cross-thread bleed); the never-pushing main thread still sees NULL. Skipped on platforms without pthread linkage.
- [x] `sfn fmt --check runtime/sfn/exception.sfn` is clean.
- [x] `make compile` passes (compiler self-hosts).
- [x] `make test` passes (no regressions).

## Verification

```bash
# Self-hosts from the thread_local-aware seed
ulimit -v 8388608 && make rebuild SEED_NATIVE=build/seed/bin/sailfin
# → built build/native/sailfin

# Per-thread shape pinned
ulimit -v 8388608 && build/native/sailfin emit llvm runtime/sfn/exception.sfn | grep frame_head_addr
# → @global.sfn_exception_frame_head_addr = internal thread_local global i64 0

compiler/tests/e2e/test_runtime_exception_frames.sh build/native/sailfin
# → 12 passed, 0 failed (TLS assertion green)

compiler/tests/e2e/test_thread_local_lowering.sh build/native/sailfin
# → 6 passed, 0 failed (incl. the new exception.sfn pthread isolation roundtrip)

ulimit -v 8388608 && make test
# → all green (e2e-sh: 98/98)
```

## Files Changed

- `runtime/sfn/exception.sfn` — `thread_local` prefix on the chain-head global; file-header `TLS.` note + chain-head comment refreshed to post-flip state.
- `compiler/tests/e2e/test_runtime_exception_frames.sh` — frame-head global pin bumped to `internal thread_local global i64 0`; comment block updated.
- `compiler/tests/e2e/test_thread_local_lowering.sh` — added an exception.sfn-driven pthread isolation roundtrip (atomic barrier so both threads push before either reads); the lighter fixture-driven roundtrip stays as a unit-level pin.

## Notes

- **Seed freshness (Phase 1.5):** predecessor #825's merge SHA is not an ancestor of `v0.7.0-alpha.25` (history was linearized between merge and seed cut), but the content-based fallback confirms the `thread_local` parser/AST/lowering are present in the seed tree (`module_globals.sfn`, `parser/declarations.sfn`, `ast.sfn`). The seed binary emits `internal thread_local global` for a smoke fixture, and the runtime file compiled cleanly during `sfn build -p compiler` — proving the dependency is genuinely seeded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019WFFVmTkzYg8tvzeuJzbd7)_