### PR TITLE
feat(test): assert_compiles / assert_does_not_compile + E0500 parse diagnostics

### DIFF
--- a/capsules/sfn/test/capsule.toml
+++ b/capsules/sfn/test/capsule.toml
@@ -13,6 +13,10 @@ description = "Test assertion helpers and utilities for Sailfin"
 # the same formatter `pure_assert_eq_float` already uses for fractions.
 "sfn/strings" = "*"
 
+# `sfn/json` parses the `sailfin-check/1` envelope emitted by
+# `sfn check --json` for the compile-as-test assertions (#974).
+"sfn/json" = "*"
+
 [capabilities]
 required = ["io"]
 

--- a/capsules/sfn/test/capsule.toml
+++ b/capsules/sfn/test/capsule.toml
@@ -13,10 +13,6 @@ description = "Test assertion helpers and utilities for Sailfin"
 # the same formatter `pure_assert_eq_float` already uses for fractions.
 "sfn/strings" = "*"
 
-# `sfn/json` parses the `sailfin-check/1` envelope emitted by
-# `sfn check --json` for the compile-as-test assertions (#974).
-"sfn/json" = "*"
-
 [capabilities]
 required = ["io"]
 

--- a/capsules/sfn/test/src/compile_assert.sfn
+++ b/capsules/sfn/test/src/compile_assert.sfn
@@ -34,7 +34,6 @@ import {
     get_number,
     get_object,
     get_string,
-    has_key,
     parse
 } from "sfn/json";
 import { find } from "sfn/strings";
@@ -117,10 +116,12 @@ fn _build_program(source: string, effects: string[]) -> string {
 // ---------------------------------------------------------------------------
 // `sfn check --json` writes exactly one `sailfin-check/1` object to
 // stdout. Skip any leading whitespace/newline by anchoring on the first
-// `{` before parsing; a missing `{`, a parse miss, or an envelope without
-// the `schema_version` marker all collapse to a non-`ran` outcome so the
-// assertion fails loudly rather than silently treating "no envelope" as
-// "compiled".
+// `{` before parsing; a missing `{`, a parse miss, or an envelope whose
+// `schema_version` is absent or not the expected `sailfin-check/1` all
+// collapse to a non-`ran` outcome so the assertion fails loudly rather
+// than silently treating "no/unknown envelope" as "compiled". The schema
+// contract (`docs/reference/check-json-schema.md`) requires consumers to
+// hard-fail on an unknown version rather than misinterpret its fields.
 fn _parse_outcome(stdout: string, stderr: string) -> _CheckOutcome {
     let brace = find(stdout, "{", 0);
     if brace < 0 {
@@ -128,8 +129,14 @@ fn _parse_outcome(stdout: string, stderr: string) -> _CheckOutcome {
             + stderr);
     }
     let envelope = parse(substring(stdout, brace, stdout.length));
-    if !has_key(envelope, "schema_version") {
-        return _outcome_failed("sfn check output was not a sailfin-check envelope: "
+    // `get_string` returns "" for an absent key, so this single check
+    // rejects both a missing `schema_version` and an unexpected version.
+    let schema = get_string(envelope, "schema_version");
+    if schema != "sailfin-check/1" {
+        return _outcome_failed("sfn check envelope has unexpected schema_version (want "
+            + "sailfin-check/1, got \""
+            + schema
+            + "\"): "
             + stdout);
     }
     let summary = get_object(envelope, "summary");
@@ -237,11 +244,19 @@ fn assert_compiles(source: string, expect: CompileExpect) -> MatchResult ![io] {
 }
 
 // `assert_does_not_compile(source, pattern)` passes iff `sfn check`
-// produces at least one diagnostic whose message contains `pattern`
-// (substring via `sfn/strings::find`).
+// reports at least one error AND a diagnostic message contains `pattern`
+// (substring via `sfn/strings::find`). The `errors >= 1` guard keeps the
+// function honest to its name: a snippet that compiles cleanly does not
+// "not compile" just because a non-error diagnostic (e.g. a future
+// warning) happens to contain the pattern.
 fn assert_does_not_compile(source: string, pattern: string) -> MatchResult ![io] {
     let outcome = _run_compile_check(source, []);
     if !outcome.ran { return match_fail(outcome.raw); }
+    if outcome.errors < 1 {
+        return match_fail("expected source NOT to compile, but sfn check reported "
+            + "0 errors; messages: "
+            + _join_messages(outcome.messages));
+    }
     if _messages_contain(outcome.messages, pattern) { return match_ok(); }
     return match_fail("expected a diagnostic matching \"" + pattern
         + "\"; sfn check reported "

--- a/capsules/sfn/test/src/compile_assert.sfn
+++ b/capsules/sfn/test/src/compile_assert.sfn
@@ -7,9 +7,17 @@
 // shell out to the already-shipped `sfn check --json`
 // (`compiler/src/cli_check.sfn`, schema `sailfin-check/1` encoded by
 // `compiler/src/diagnostics_json.sfn`), capture stdout via
-// `process.run_capture`, and parse the structured diagnostic envelope
-// with `sfn/json`. No compiler change is needed — `check --json` and
-// `process.run_capture` (`runtime/sfn/process.sfn`) both already exist.
+// `process.run_capture`, and read the three fields they need out of the
+// `sailfin-check/1` envelope (`schema_version`, `summary.errors`, and each
+// event's `message`).
+//
+// Envelope reading is a small inline scanner over `sfn/strings`, not the
+// `sfn/json` capsule: depending on `sfn/json` pulls its full recursive-
+// parser closure into *every* `sfn/test` test binary, which exceeds the
+// unit-test import/link envelope (#619) and fails to link in CI. The
+// envelope is a single, fixed-shape line, so a targeted field reader is
+// both lighter and sufficient. `process.run_capture`
+// (`runtime/sfn/process.sfn`) and `fs.*` are runtime builtins.
 //
 // Like the rest of the capsule these are free functions returning a
 // `MatchResult` (`.ok == true` passed, `.ok == false` carries
@@ -29,13 +37,6 @@
 // Scope (per the issue): a single temp *file* is created under a fresh
 // `fs.mkdtemp` directory and removed afterward; there is no recursive
 // directory teardown (only one file is ever written).
-import {
-    get_array,
-    get_number,
-    get_object,
-    get_string,
-    parse
-} from "sfn/json";
 import { find } from "sfn/strings";
 
 import { MatchResult, match_fail, match_ok } from "./matcher";
@@ -112,26 +113,133 @@ fn _build_program(source: string, effects: string[]) -> string {
 }
 
 // ---------------------------------------------------------------------------
-// Envelope parsing
+// Inline `sailfin-check/1` envelope reader (over `sfn/strings`)
 // ---------------------------------------------------------------------------
+// Result of reading one JSON string literal: the unescaped `value` and the
+// index just past the closing quote. `ok` is false when the closing quote
+// was never found (truncated input).
+struct _StrRead {
+    value: string;
+    end: int;
+    ok: boolean;
+}
+
+// Read the JSON string whose opening quote is at `open`. Escape-aware: it
+// honors `\n`/`\t`/`\r` and passes every other escaped character through
+// literally (so `\"` → `"`, `\\` → `\`, `\/` → `/`), which is exactly the
+// escape set `diagnostics_json.sfn` emits.
+fn _read_json_string(text: string, open: int) -> _StrRead {
+    let mut i: int = open + 1;
+    let mut out: string = "";
+    loop {
+        if i >= text.length {
+            return _StrRead { value: out, end: i, ok: false };
+        }
+        let ch = text[i];
+        if ch == "\\" {
+            i += 1;
+            if i >= text.length {
+                return _StrRead { value: out, end: i, ok: false };
+            }
+            let nx = text[i];
+            if nx == "n" { out = out + "\n"; } else if nx == "t" {
+                out = out + "\t";
+            } else if nx == "r" { out = out + "\r"; } else { out = out + nx; }
+            i += 1;
+        } else if ch == "\"" {
+            return _StrRead { value: out, end: i + 1, ok: true };
+        } else {
+            out = out + ch;
+            i += 1;
+        }
+    }
+}
+
+// Read the string value of the first `"<key>":"..."` at or after `from`.
+// Returns "" when the key is absent.
+fn _json_string_field(text: string, key: string, from: int) -> string {
+    let needle = "\"" + key + "\":\"";
+    let at = find(text, needle, from);
+    if at < 0 { return ""; }
+    // The opening quote of the value is the last character of `needle`.
+    let open = at + needle.length - 1;
+    return _read_json_string(text, open).value;
+}
+
+// Parse the (optionally signed) integer beginning at `start`, skipping
+// leading spaces. Stops at the first non-digit. Returns 0 when no digits
+// are present.
+fn _parse_int_at(text: string, start: int) -> int {
+    let mut i: int = start;
+    loop {
+        if i >= text.length { break; }
+        if text[i] == " " { i += 1; } else { break; }
+    }
+    let mut negative: boolean = false;
+    if i < text.length && text[i] == "-" {
+        negative = true;
+        i += 1;
+    }
+    let mut value: int = 0;
+    loop {
+        if i >= text.length { break; }
+        let code = char_code(text[i]) - 48;
+        if code < 0 || code > 9 { break; }
+        value = value * 10 + code;
+        i += 1;
+    }
+    if negative { return 0 - value; }
+    return value;
+}
+
+// `summary.errors` — anchored after the `"summary"` key so an `"errors"`
+// elsewhere can't be read by mistake.
+fn _extract_errors(envelope: string) -> int {
+    let summary_at = find(envelope, "\"summary\"", 0);
+    let mut from: int = 0;
+    if summary_at >= 0 { from = summary_at; }
+    let errors_at = find(envelope, "\"errors\":", from);
+    if errors_at < 0 { return 0; }
+    return _parse_int_at(envelope, errors_at + 9);
+}
+
+// Every event's (and suggestion's) `message`. Including suggestion text is
+// harmless for substring assertions and keeps the scan single-pass; an
+// inner `"message":"` inside a value is escaped as `\"message\":\"`, so it
+// never false-matches the unescaped needle.
+fn _extract_messages(envelope: string) -> string[] {
+    let needle = "\"message\":\"";
+    let mut out: string[] = [];
+    let mut from: int = 0;
+    loop {
+        let at = find(envelope, needle, from);
+        if at < 0 { break; }
+        let open = at + needle.length - 1;
+        let r = _read_json_string(envelope, open);
+        out.push(r.value);
+        if !r.ok { break; } from = r.end;
+    }
+    return out;
+}
+
 // `sfn check --json` writes exactly one `sailfin-check/1` object to
-// stdout. Skip any leading whitespace/newline by anchoring on the first
-// `{` before parsing; a missing `{`, a parse miss, or an envelope whose
-// `schema_version` is absent or not the expected `sailfin-check/1` all
-// collapse to a non-`ran` outcome so the assertion fails loudly rather
-// than silently treating "no/unknown envelope" as "compiled". The schema
-// contract (`docs/reference/check-json-schema.md`) requires consumers to
-// hard-fail on an unknown version rather than misinterpret its fields.
+// stdout. Anchor on the first `{` (skipping any leading whitespace);
+// a missing `{`, or an envelope whose `schema_version` is absent or not
+// the expected `sailfin-check/1`, collapses to a non-`ran` outcome so the
+// assertion fails loudly rather than silently treating "no/unknown
+// envelope" as "compiled". The schema contract
+// (`docs/reference/check-json-schema.md`) requires consumers to hard-fail
+// on an unknown version rather than misinterpret its fields.
 fn _parse_outcome(stdout: string, stderr: string) -> _CheckOutcome {
     let brace = find(stdout, "{", 0);
     if brace < 0 {
         return _outcome_failed("sfn check produced no JSON on stdout; stderr: "
             + stderr);
     }
-    let envelope = parse(substring(stdout, brace, stdout.length));
-    // `get_string` returns "" for an absent key, so this single check
-    // rejects both a missing `schema_version` and an unexpected version.
-    let schema = get_string(envelope, "schema_version");
+    let envelope = substring(stdout, brace, stdout.length);
+    // `_json_string_field` returns "" for an absent key, so this single
+    // check rejects both a missing and an unexpected `schema_version`.
+    let schema = _json_string_field(envelope, "schema_version", 0);
     if schema != "sailfin-check/1" {
         return _outcome_failed("sfn check envelope has unexpected schema_version (want "
             + "sailfin-check/1, got \""
@@ -139,20 +247,10 @@ fn _parse_outcome(stdout: string, stderr: string) -> _CheckOutcome {
             + "\"): "
             + stdout);
     }
-    let summary = get_object(envelope, "summary");
-    let errors = get_number(summary, "errors");
-    let events = get_array(envelope, "events");
-    let mut messages: string[] = [];
-    let mut i: int = 0;
-    loop {
-        if i >= events.length { break; }
-        messages.push(get_string(events[i], "message"));
-        i += 1;
-    }
     return _CheckOutcome {
         ran: true,
-        errors: errors as int,
-        messages: messages,
+        errors: _extract_errors(envelope),
+        messages: _extract_messages(envelope),
         raw: stdout
     };
 }

--- a/capsules/sfn/test/src/compile_assert.sfn
+++ b/capsules/sfn/test/src/compile_assert.sfn
@@ -1,0 +1,251 @@
+// sfn/test — compile-as-test assertions (issue #974, epic #841
+// test-infra Phase 2, sub-issue 2.6).
+//
+// `assert_compiles` / `assert_does_not_compile` let a test assert how a
+// snippet of Sailfin *source* behaves under the frontend (lex → parse →
+// typecheck → effect-check) without compiling and linking a binary. Both
+// shell out to the already-shipped `sfn check --json`
+// (`compiler/src/cli_check.sfn`, schema `sailfin-check/1` encoded by
+// `compiler/src/diagnostics_json.sfn`), capture stdout via
+// `process.run_capture`, and parse the structured diagnostic envelope
+// with `sfn/json`. No compiler change is needed — `check --json` and
+// `process.run_capture` (`runtime/sfn/process.sfn`) both already exist.
+//
+// Like the rest of the capsule these are free functions returning a
+// `MatchResult` (`.ok == true` passed, `.ok == false` carries
+// `.message`) rather than a fluent builder — cross-module struct-method
+// dispatch is currently miscompiled (see `expect.sfn`). They are `![io]`:
+// running a child process and writing the temp source file both require
+// `io`.
+//
+// Hermeticity: the `sfn` binary is resolved from `$SAILFIN_BIN` with a
+// documented fallback of `build/native/sailfin` (the self-hosted binary,
+// relative to the repo root the test runs from), so CI can point the
+// assertions at any compiler without editing the test. The child is
+// spawned with an empty environment — `sfn check` on an import-free
+// snippet reads no environment variables — so the result does not depend
+// on the parent process's ambient env.
+//
+// Scope (per the issue): a single temp *file* is created under a fresh
+// `fs.mkdtemp` directory and removed afterward; there is no recursive
+// directory teardown (only one file is ever written).
+import {
+    get_array,
+    get_number,
+    get_object,
+    get_string,
+    has_key,
+    parse
+} from "sfn/json";
+import { find } from "sfn/strings";
+
+import { MatchResult, match_fail, match_ok } from "./matcher";
+
+// ---------------------------------------------------------------------------
+// CompileExpect
+// ---------------------------------------------------------------------------
+// The expectation passed to `assert_compiles`:
+//   - `effects`: when non-empty, the `source` is treated as a function
+//     *body* and wrapped in `fn __sfn_compile_probe() ![<effects>] { … }`
+//     so a caller can probe whether a body type-/effect-checks under a
+//     given effect row. When empty, `source` is checked verbatim as a
+//     complete file.
+//   - `ok`: `true` requires the snippet to compile with zero errors;
+//     `false` requires at least one error.
+//   - `diagnostic_pattern`: when non-empty, at least one diagnostic
+//     message must contain it (substring via `sfn/strings::find`).
+struct CompileExpect {
+    effects: string[];
+    ok: boolean;
+    diagnostic_pattern: string;
+}
+
+// ---------------------------------------------------------------------------
+// Internal: the outcome of one `sfn check --json` run
+// ---------------------------------------------------------------------------
+// `ran` is the discriminator: `false` means the child produced no
+// parseable `sailfin-check/1` envelope (spawn failure, crash, or garbage
+// on stdout), in which case `raw` carries the captured output for the
+// failure diagnostic. When `ran` is `true`, `errors` is the envelope's
+// `summary.errors` and `messages` is every event's `message` string.
+struct _CheckOutcome {
+    ran: boolean;
+    errors: int;
+    messages: string[];
+    raw: string;
+}
+
+fn _outcome_failed(raw: string) -> _CheckOutcome {
+    return _CheckOutcome {
+        ran: false,
+        errors: 0,
+        messages: [],
+        raw: raw
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Binary resolution + program assembly
+// ---------------------------------------------------------------------------
+fn _resolve_sfn_bin() -> string ![io] {
+    let configured = env.get("SAILFIN_BIN");
+    if configured.length > 0 { return configured; }
+    return "build/native/sailfin";
+}
+
+fn _join_effects(effects: string[]) -> string {
+    let mut out: string = "";
+    let mut i: int = 0;
+    loop {
+        if i >= effects.length { break; }
+        if i > 0 { out = out + ", "; }
+        out = out + effects[i];
+        i += 1;
+    }
+    return out;
+}
+
+fn _build_program(source: string, effects: string[]) -> string {
+    if effects.length == 0 { return source; }
+    return "fn __sfn_compile_probe() ![" + _join_effects(effects) + "] {\n"
+        + source
+        + "\n}\n";
+}
+
+// ---------------------------------------------------------------------------
+// Envelope parsing
+// ---------------------------------------------------------------------------
+// `sfn check --json` writes exactly one `sailfin-check/1` object to
+// stdout. Skip any leading whitespace/newline by anchoring on the first
+// `{` before parsing; a missing `{`, a parse miss, or an envelope without
+// the `schema_version` marker all collapse to a non-`ran` outcome so the
+// assertion fails loudly rather than silently treating "no envelope" as
+// "compiled".
+fn _parse_outcome(stdout: string, stderr: string) -> _CheckOutcome {
+    let brace = find(stdout, "{", 0);
+    if brace < 0 {
+        return _outcome_failed("sfn check produced no JSON on stdout; stderr: "
+            + stderr);
+    }
+    let envelope = parse(substring(stdout, brace, stdout.length));
+    if !has_key(envelope, "schema_version") {
+        return _outcome_failed("sfn check output was not a sailfin-check envelope: "
+            + stdout);
+    }
+    let summary = get_object(envelope, "summary");
+    let errors = get_number(summary, "errors");
+    let events = get_array(envelope, "events");
+    let mut messages: string[] = [];
+    let mut i: int = 0;
+    loop {
+        if i >= events.length { break; }
+        messages.push(get_string(events[i], "message"));
+        i += 1;
+    }
+    return _CheckOutcome {
+        ran: true,
+        errors: errors as int,
+        messages: messages,
+        raw: stdout
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Run `sfn check --json` over `source`
+// ---------------------------------------------------------------------------
+fn _run_compile_check(source: string, effects: string[]) -> _CheckOutcome ![io] {
+    let program = _build_program(source, effects);
+    let dir = fs.mkdtemp("sfn-compile-assert-");
+    if dir.length == 0 {
+        return _outcome_failed("failed to create temp dir for compile assertion");
+    }
+    let path = dir + "/probe.sfn";
+    fs.writeFile(path, program);
+
+    let bin = _resolve_sfn_bin();
+    let argv: string[] = [bin, "check", "--json", path];
+    let child_env: string[] = [];
+    let _exit = process.run_capture(argv, child_env);
+    let stdout = process.capture_take_stdout();
+    let stderr = process.capture_take_stderr();
+
+    // Single temp file only (no recursive teardown — see header).
+    fs.deleteFile(path);
+    fs.removeDirectory(dir);
+
+    return _parse_outcome(stdout, stderr);
+}
+
+// ---------------------------------------------------------------------------
+// Diagnostic matching
+// ---------------------------------------------------------------------------
+fn _messages_contain(messages: string[], pattern: string) -> boolean {
+    let mut i: int = 0;
+    loop {
+        if i >= messages.length { break; }
+        if find(messages[i], pattern, 0) >= 0 { return true; }
+        i += 1;
+    }
+    return false;
+}
+
+fn _join_messages(messages: string[]) -> string {
+    if messages.length == 0 { return "(none)"; }
+    let mut out: string = "";
+    let mut i: int = 0;
+    loop {
+        if i >= messages.length { break; }
+        if i > 0 { out = out + " | "; }
+        out = out + messages[i];
+        i += 1;
+    }
+    return out;
+}
+
+// ---------------------------------------------------------------------------
+// Public assertions
+// ---------------------------------------------------------------------------
+// `assert_compiles(source, expect)` runs `sfn check --json` over `source`
+// (optionally wrapped in `expect.effects`) and returns a `MatchResult`
+// reflecting the envelope:
+//   - `expect.ok == true`  passes iff the envelope reports zero errors.
+//   - `expect.ok == false` passes iff the envelope reports ≥1 error.
+//   - when `expect.diagnostic_pattern` is non-empty, a diagnostic message
+//     must additionally contain it.
+fn assert_compiles(source: string, expect: CompileExpect) -> MatchResult ![io] {
+    let outcome = _run_compile_check(source, expect.effects);
+    if !outcome.ran { return match_fail(outcome.raw); }
+
+    let compiled = outcome.errors == 0;
+    if expect.ok && !compiled {
+        return match_fail("expected source to compile, but sfn check reported "
+            + number_to_string(outcome.errors)
+            + " error(s): "
+            + _join_messages(outcome.messages));
+    }
+    if !expect.ok && compiled {
+        return match_fail("expected source NOT to compile, but it compiled cleanly");
+    }
+    if expect.diagnostic_pattern.length > 0 {
+        if !_messages_contain(outcome.messages, expect.diagnostic_pattern) {
+            return match_fail("expected a diagnostic matching \"" + expect.diagnostic_pattern
+                + "\"; messages: "
+                + _join_messages(outcome.messages));
+        }
+    }
+    return match_ok();
+}
+
+// `assert_does_not_compile(source, pattern)` passes iff `sfn check`
+// produces at least one diagnostic whose message contains `pattern`
+// (substring via `sfn/strings::find`).
+fn assert_does_not_compile(source: string, pattern: string) -> MatchResult ![io] {
+    let outcome = _run_compile_check(source, []);
+    if !outcome.ran { return match_fail(outcome.raw); }
+    if _messages_contain(outcome.messages, pattern) { return match_ok(); }
+    return match_fail("expected a diagnostic matching \"" + pattern
+        + "\"; sfn check reported "
+        + number_to_string(outcome.errors)
+        + " error(s): "
+        + _join_messages(outcome.messages));
+}

--- a/capsules/sfn/test/src/mod.sfn
+++ b/capsules/sfn/test/src/mod.sfn
@@ -376,3 +376,12 @@ export {
 // is the testable core with the directory + update flag passed explicitly.
 // See `snapshot.sfn`.
 export { expect_snapshot, snapshot_match_in } from "./snapshot";
+
+// ---------------------------------------------------------------------------
+// Compile-as-test assertions (issue #974, proposal §2.6)
+// ---------------------------------------------------------------------------
+// `assert_compiles` / `assert_does_not_compile` shell out to the
+// shipped `sfn check --json` via `process.run_capture` and parse the
+// `sailfin-check/1` envelope with `sfn/json`. Both are `![io]` and
+// return a `MatchResult`. See `compile_assert.sfn`.
+export { CompileExpect, assert_compiles, assert_does_not_compile } from "./compile_assert";

--- a/capsules/sfn/test/tests/compile_assert_test.sfn
+++ b/capsules/sfn/test/tests/compile_assert_test.sfn
@@ -43,13 +43,19 @@ test "compile_assert: missing effect via assert_compiles ok=false" ![io] {
     assert result.ok;
 }
 
-// 3. A parse error: the snippet is syntactically broken, so the frontend
-//    reports at least one error and the snippet does not compile.
+// 3. A parse error: unrecognized top-level syntax. `sfn check` reports it
+//    as an `E0500` parse diagnostic ("parse error: unrecognized syntax"),
+//    so the snippet does not compile and the pattern matches.
+//
+//    Note: `sfn check` detects unrecognized top-level constructs (which
+//    the parser lowers to `Statement.Unknown`). Malformed-but-dispatched
+//    declarations — e.g. `fn broken( {`, which parses into a recovered
+//    `FunctionDeclaration` — are not yet flagged; that needs parser-level
+//    error recovery (tracked as a follow-up). Use a top-level garbage
+//    snippet here.
 test "compile_assert: parse error does not compile" ![io] {
-    let source = "fn broken( {\n";
-    let result = assert_compiles(source, CompileExpect {
-        effects: [], ok: false, diagnostic_pattern: ""
-    });
+    let source = "@@@ !!!\n";
+    let result = assert_does_not_compile(source, "parse error");
     assert result.ok;
 }
 
@@ -66,7 +72,7 @@ test "compile_assert: pattern mismatch fails the assertion" ![io] {
 // `assert_compiles` expecting success must also fail (return ok=false)
 // when the snippet has an error — the inverse of test 1.
 test "compile_assert: expected-compile fails on a broken snippet" ![io] {
-    let source = "fn broken( {\n";
+    let source = "@@@ !!!\n";
     let result = assert_compiles(source, CompileExpect {
         effects: [], ok: true, diagnostic_pattern: ""
     });

--- a/capsules/sfn/test/tests/compile_assert_test.sfn
+++ b/capsules/sfn/test/tests/compile_assert_test.sfn
@@ -1,0 +1,75 @@
+// Tests for the sfn/test compile-as-test assertions (#974).
+//
+// Each test shells out to the real `sfn check --json` (resolved via
+// `$SAILFIN_BIN`, falling back to `build/native/sailfin`) over a snippet
+// written to a fresh temp file, then asserts on the returned
+// `MatchResult`. They are `![io]`: `assert_compiles` /
+// `assert_does_not_compile` spawn a child process and write a temp file.
+//
+// The four required cases (issue acceptance criteria):
+//   1. a compiling snippet (exercising the `effects` wrapper),
+//   2. a missing-effect snippet (`print.info` without `![io]`),
+//   3. a parse-error snippet,
+//   4. a pattern-mismatch negative (the assertion itself must fail).
+import { CompileExpect, assert_compiles, assert_does_not_compile } from "../src/mod";
+
+// 1. A snippet that compiles. `effects: ["io"]` wraps the body in
+//    `fn __sfn_compile_probe() ![io] { … }`, so `print.info` is allowed
+//    and the envelope reports zero errors.
+test "compile_assert: compiling snippet passes" ![io] {
+    let result = assert_compiles("print.info(\"hello from probe\");", CompileExpect {
+        effects: ["io"], ok: true, diagnostic_pattern: ""
+    });
+    assert result.ok;
+}
+
+// 2. `print.info` inside a function that does NOT declare `![io]` is an
+//    effect violation. `assert_does_not_compile` passes iff a diagnostic
+//    message contains the pattern — here the effect checker's
+//    "missing required effects" headline.
+test "compile_assert: missing effect does not compile" ![io] {
+    let source = "fn probe() { print.info(\"oops\"); }";
+    let result = assert_does_not_compile(source, "missing required effects");
+    assert result.ok;
+}
+
+// `assert_compiles` with `ok: false` plus a pattern reflects the same
+// failing envelope: at least one error AND the pattern present.
+test "compile_assert: missing effect via assert_compiles ok=false" ![io] {
+    let source = "fn probe() { print.info(\"oops\"); }";
+    let result = assert_compiles(source, CompileExpect {
+        effects: [], ok: false, diagnostic_pattern: "missing required effects"
+    });
+    assert result.ok;
+}
+
+// 3. A parse error: the snippet is syntactically broken, so the frontend
+//    reports at least one error and the snippet does not compile.
+test "compile_assert: parse error does not compile" ![io] {
+    let source = "fn broken( {\n";
+    let result = assert_compiles(source, CompileExpect {
+        effects: [], ok: false, diagnostic_pattern: ""
+    });
+    assert result.ok;
+}
+
+// 4. Pattern-mismatch negative: a snippet that compiles cleanly produces
+//    no diagnostics, so `assert_does_not_compile` must NOT pass — its
+//    `MatchResult.ok` is false and carries a non-empty diagnostic.
+test "compile_assert: pattern mismatch fails the assertion" ![io] {
+    let source = "fn probe() ![io] { print.info(\"fine\"); }";
+    let result = assert_does_not_compile(source, "this pattern never appears");
+    assert ! result.ok;
+    assert result.message.length > 0;
+}
+
+// `assert_compiles` expecting success must also fail (return ok=false)
+// when the snippet has an error — the inverse of test 1.
+test "compile_assert: expected-compile fails on a broken snippet" ![io] {
+    let source = "fn broken( {\n";
+    let result = assert_compiles(source, CompileExpect {
+        effects: [], ok: true, diagnostic_pattern: ""
+    });
+    assert ! result.ok;
+    assert result.message.length > 0;
+}

--- a/compiler/src/diagnostics_json.sfn
+++ b/compiler/src/diagnostics_json.sfn
@@ -241,6 +241,7 @@ fn render_check_json_envelope(events: CheckJsonEvent[], summary: CheckJsonSummar
 // allocation locked in `docs/proposals/check-architecture.md`:
 //   E00xx, E03xx -> typecheck
 //   E04xx        -> effect
+//   E05xx        -> parse
 //   W00xx        -> load
 // Anything else falls back to "unknown" so a future code range
 // shows up as an obvious-to-track default rather than silently
@@ -253,6 +254,7 @@ fn render_check_json_envelope(events: CheckJsonEvent[], summary: CheckJsonSummar
 fn classify_producer(code: string) -> string {
     if _starts_with(code, "E04") { return "effect"; }
     if _starts_with(code, "W00") { return "load"; }
+    if _starts_with(code, "E05") { return "parse"; }
     if _starts_with(code, "E00") { return "typecheck"; }
     if _starts_with(code, "E03") { return "typecheck"; }
     return "unknown";

--- a/compiler/src/tools/check.sfn
+++ b/compiler/src/tools/check.sfn
@@ -35,6 +35,7 @@ import { number_to_string } from "../num_format";
 import { parse_program } from "../parser/mod";
 import { load_prelude_global_names } from "../prelude_globals";
 import { substring } from "../string_utils";
+import { Token } from "../token";
 import { typecheck_diagnostics_with_import_symbols_prelude } from "../typecheck";
 import { Diagnostic } from "../typecheck_types";
 
@@ -71,6 +72,32 @@ fn _is_sfn_file(path: string) -> boolean {
     if path.length < 4 { return false; }
     let start = path.length - 4;
     return substring(path, start, path.length) == ".sfn";
+}
+
+// Build the `E0500` parse diagnostic for a top-level `Statement.Unknown`
+// node. The parser recovers from unrecognized syntax by emitting an
+// `Unknown` statement (carrying the consumed tokens) rather than a
+// diagnostic, so `sfn check` historically reported genuinely malformed
+// input as clean. Anchor the diagnostic at the first consumed token when
+// one exists; the `near `<lexeme>`` hint points the reader at the offending
+// token. Severity is always `error` — unrecognized syntax is never a
+// warning — independent of the `SAILFIN_EFFECT_ENFORCE` knob that steers
+// effect diagnostics.
+fn _parse_diagnostic_for_unknown(stmt: Statement, file_path: string) -> Diagnostic {
+    let mut anchor: Token? = null;
+    let mut near: string = "";
+    if stmt.tokens.length > 0 {
+        anchor = stmt.tokens[0];
+        near = " near `" + stmt.tokens[0].lexeme + "`";
+    }
+    return Diagnostic {
+        code: "E0500",
+        severity: "error",
+        message: "parse error: unrecognized syntax" + near,
+        file_path: file_path,
+        primary: anchor,
+        suggestion: null
+    };
 }
 
 fn check_source(source: string, file_path: string) -> CheckResult ![io] {
@@ -118,6 +145,30 @@ fn check_source_with_imports(source: string, file_path: string, imported_interfa
     let mut rendered: string[] = [];
     let mut errors: int = 0;
     let mut warnings: int = 0;
+
+    // Parse-error surfacing (#974). The parser emits `Statement.Unknown`
+    // for unrecognized top-level constructs instead of recording a parse
+    // diagnostic, so `sfn check` used to report syntactically broken
+    // input (e.g. `@@@ !!!`, a stray `}`) as clean. Walk the top-level
+    // statements and mint an `E0500` parse diagnostic for each `Unknown`
+    // node before typechecking. Limitation: malformed-but-dispatched
+    // declarations (e.g. a function with a broken parameter list) parse
+    // into a recognized declaration node, not an `Unknown`, so they are
+    // not yet flagged — that requires parser-level error recovery,
+    // tracked as a follow-up.
+    let mut ui: int = 0;
+    loop {
+        if ui >= program.statements.length { break; }
+        let stmt = program.statements[ui];
+        if stmt.variant == "Unknown" {
+            let pdiag = _parse_diagnostic_for_unknown(stmt, file_path);
+            combined.push(pdiag);
+            producers.push("parse");
+            rendered.push(render_diagnostic(pdiag, source_lines, "parse"));
+            errors += 1;
+        }
+        ui += 1;
+    }
 
     // Stamp the originating module path onto each typecheck diagnostic
     // and render it in one pass. Factories mint diagnostics with an

--- a/compiler/tests/e2e/test_check_json_schema.sh
+++ b/compiler/tests/e2e/test_check_json_schema.sh
@@ -101,6 +101,13 @@ fn main() ![io] {
 export { noisy_helper };
 EOF
 
+# A file with unrecognized top-level syntax — the parser lowers this to
+# a `Statement.Unknown`, which `sfn check` now surfaces as an `E0500`
+# parse diagnostic (#974).
+cat > "$SCRATCH/src/garbage.sfn" <<'EOF'
+@@@ !!!
+EOF
+
 cd "$SCRATCH"
 
 # ---- Test 1: clean file emits empty events + clean summary ----
@@ -387,6 +394,54 @@ test_b3_suggestion_anchored_at_brace() {
     return 0
 }
 run_test "B3: suggestion edit anchored at the function body's '{'" test_b3_suggestion_anchored_at_brace
+
+# ---- Test 15 (#974): parse error surfaces as an E0500 parse event ----
+test_parse_error_event() {
+    local out
+    out="$("$BINARY" check --json src/garbage.sfn 2>/dev/null || true)"
+    if [ -z "$out" ]; then
+        echo "[test]   no JSON output produced"
+        return 1
+    fi
+    local exit_code; exit_code=$(jq -r '.exit_code' <<<"$out")
+    if [ "$exit_code" != "1" ]; then
+        echo "[test]   expected exit_code 1 on parse error, got: $exit_code"
+        return 1
+    fi
+    local errors; errors=$(jq -r '.summary.errors' <<<"$out")
+    if [ "$errors" -lt 1 ]; then
+        echo "[test]   expected summary.errors >= 1, got: $errors"
+        return 1
+    fi
+    # Exactly the E0500 parse event: code, producer, severity, kind, primary.
+    local n; n=$(jq -r '[.events[] | select(.code == "E0500")] | length' <<<"$out")
+    if [ "$n" -lt 1 ]; then
+        echo "[test]   expected at least one E0500 event"
+        return 1
+    fi
+    local producer; producer=$(jq -r '[.events[] | select(.code == "E0500")][0].producer' <<<"$out")
+    if [ "$producer" != "parse" ]; then
+        echo "[test]   expected producer=parse, got: $producer"
+        return 1
+    fi
+    local severity; severity=$(jq -r '[.events[] | select(.code == "E0500")][0].severity' <<<"$out")
+    if [ "$severity" != "error" ]; then
+        echo "[test]   expected severity=error, got: $severity"
+        return 1
+    fi
+    local kind; kind=$(jq -r '[.events[] | select(.code == "E0500")][0].kind' <<<"$out")
+    if [ "$kind" != "diagnostic" ]; then
+        echo "[test]   expected kind=diagnostic, got: $kind"
+        return 1
+    fi
+    local primary; primary=$(jq -r '[.events[] | select(.code == "E0500")][0].primary' <<<"$out")
+    if [ "$primary" = "null" ]; then
+        echo "[test]   expected non-null primary token on E0500"
+        return 1
+    fi
+    return 0
+}
+run_test "parse error surfaces as E0500 parse event" test_parse_error_event
 
 echo "[summary] $PASS passed, $FAIL failed"
 if [ "$FAIL" -ne 0 ]; then

--- a/compiler/tests/unit/diagnostics_json_test.sfn
+++ b/compiler/tests/unit/diagnostics_json_test.sfn
@@ -85,7 +85,7 @@ test "classify_producer: E0500 maps to parse" {
 
 test "classify_producer: unknown codes fall through to unknown" {
     // Regression-guard the "fall through" branch — a future code
-    // range outside E00xx/E03xx/E04xx/E05xx/W01xx must surface as
+    // range outside E00xx/E03xx/E04xx/E05xx/W00xx must surface as
     // `unknown` so a producer mismatch is visible.
     assert classify_producer("X9999") == "unknown";
     assert classify_producer("E0600") == "unknown";

--- a/compiler/tests/unit/diagnostics_json_test.sfn
+++ b/compiler/tests/unit/diagnostics_json_test.sfn
@@ -77,12 +77,18 @@ test "classify_producer: W0002 maps to load" {
     assert classify_producer("W0002") == "load";
 }
 
+test "classify_producer: E0500 maps to parse" {
+    // Parse diagnostics (#974) ride the `E05xx` range; `sfn check`
+    // mints `E0500` for unrecognized top-level syntax.
+    assert classify_producer("E0500") == "parse";
+}
+
 test "classify_producer: unknown codes fall through to unknown" {
     // Regression-guard the "fall through" branch — a future code
-    // range outside E00xx/E03xx/E04xx/W01xx must surface as
+    // range outside E00xx/E03xx/E04xx/E05xx/W01xx must surface as
     // `unknown` so a producer mismatch is visible.
     assert classify_producer("X9999") == "unknown";
-    assert classify_producer("E0500") == "unknown";
+    assert classify_producer("E0600") == "unknown";
 }
 
 // -------------------------------------------------------------------

--- a/docs/reference/check-json-schema.md
+++ b/docs/reference/check-json-schema.md
@@ -70,7 +70,7 @@ silent leak fails CI before it lands.
 |---|---|---|
 | `files_checked` | number | Count of `.sfn` files analyzed in this run (post-recursive-collection). |
 | `errors` | number | Total error-severity diagnostics across all files. Identical to the count that drives the human renderer's "X errors" tally. |
-| `warnings` | number | Total warning-severity diagnostics, including W01xx import-context load warnings. |
+| `warnings` | number | Total warning-severity diagnostics, including W00xx import-context load warnings. |
 | `duration_ms` | number | Reserved. Always `0` until wall-clock measurement lands; field is present so consumers can write code today that reads it without a schema bump later. |
 
 ## `events[]`
@@ -80,13 +80,13 @@ distinguishes program-analysis findings from infrastructure warnings.
 
 | Field | Type | Notes |
 |---|---|---|
-| `kind` | string | `"diagnostic"` for parse / typecheck / effect / capability findings. `"load_warning"` for W01xx import-context loader output. |
-| `code` | string | The diagnostic code. `Exxxx` errors, `Wxxxx` warnings. Locked code ranges (today): `E00xx` (typecheck), `E03xx` (interface), `E04xx` (effect), `E05xx` (parse), `W01xx` (load). |
+| `kind` | string | `"diagnostic"` for parse / typecheck / effect / capability findings. `"load_warning"` for W00xx import-context loader output. |
+| `code` | string | The diagnostic code. `Exxxx` errors, `Wxxxx` warnings. Locked code ranges (today): `E00xx` (typecheck), `E03xx` (interface), `E04xx` (effect), `E05xx` (parse), `W00xx` (load). |
 | `severity` | string | One of `"error"`, `"warning"`, `"hint"`, `"info"`. The compiler emits `"error"` and `"warning"` today; `"hint"` and `"info"` are reserved for `sfn vet`. |
 | `producer` | string | Which analysis pass minted the event. One of `"typecheck"`, `"effect"`, `"parse"`, `"load"`, `"unknown"`. The classifier maps code ranges to producers; new codes that fall outside the known ranges report `"unknown"` so a future code addition shows up rather than silently claiming the wrong producer. |
 | `file_path` | string | Path of the analyzed module. Empty string for diagnostics that genuinely have no source anchor (none today; reserved). |
 | `message` | string | Human-readable text. May contain `\n` for multi-line messages (effect violations carry a multi-line "required by" / "suggestion" block). |
-| `primary` | object \| null | Source location for the caret. `null` for diagnostics with no AST anchor (W01xx load warnings always; effect violations on `Raw`-text bodies sometimes). |
+| `primary` | object \| null | Source location for the caret. `null` for diagnostics with no AST anchor (W00xx load warnings always; effect violations on `Raw`-text bodies sometimes). |
 | `secondary` | array | Reserved. Always `[]` until B5 (Track B) lands. Consumers should iterate it. |
 | `suggestion` | object \| null | Reserved. Always `null` until B3 (Track B) lands fix-it suggestions. Consumers should null-check before reading. |
 
@@ -132,7 +132,7 @@ land in:
 | `E03xx` | `typecheck` |
 | `E04xx` | `effect` |
 | `E05xx` | `parse` |
-| `W01xx` | `load` |
+| `W00xx` | `load` |
 | (anything else) | `unknown` |
 
 ### Parse diagnostics (`E05xx`)

--- a/docs/reference/check-json-schema.md
+++ b/docs/reference/check-json-schema.md
@@ -80,8 +80,8 @@ distinguishes program-analysis findings from infrastructure warnings.
 
 | Field | Type | Notes |
 |---|---|---|
-| `kind` | string | `"diagnostic"` for typecheck / effect / capability findings. `"load_warning"` for W01xx import-context loader output. |
-| `code` | string | The diagnostic code. `Exxxx` errors, `Wxxxx` warnings. Locked code ranges (today): `E00xx` (typecheck), `E03xx` (interface), `E04xx` (effect), `W01xx` (load). |
+| `kind` | string | `"diagnostic"` for parse / typecheck / effect / capability findings. `"load_warning"` for W01xx import-context loader output. |
+| `code` | string | The diagnostic code. `Exxxx` errors, `Wxxxx` warnings. Locked code ranges (today): `E00xx` (typecheck), `E03xx` (interface), `E04xx` (effect), `E05xx` (parse), `W01xx` (load). |
 | `severity` | string | One of `"error"`, `"warning"`, `"hint"`, `"info"`. The compiler emits `"error"` and `"warning"` today; `"hint"` and `"info"` are reserved for `sfn vet`. |
 | `producer` | string | Which analysis pass minted the event. One of `"typecheck"`, `"effect"`, `"parse"`, `"load"`, `"unknown"`. The classifier maps code ranges to producers; new codes that fall outside the known ranges report `"unknown"` so a future code addition shows up rather than silently claiming the wrong producer. |
 | `file_path` | string | Path of the analyzed module. Empty string for diagnostics that genuinely have no source anchor (none today; reserved). |
@@ -131,8 +131,25 @@ land in:
 | `E00xx` | `typecheck` |
 | `E03xx` | `typecheck` |
 | `E04xx` | `effect` |
+| `E05xx` | `parse` |
 | `W01xx` | `load` |
 | (anything else) | `unknown` |
+
+### Parse diagnostics (`E05xx`)
+
+`sfn check` reports unrecognized **top-level** syntax as an `E0500` parse
+diagnostic (`producer: "parse"`, `severity: "error"`), anchored at the first
+token of the offending construct. The parser recovers from such input by
+lowering it to an internal "unknown statement", so a file like `@@@ !!!` or a
+stray `}` now yields one `E0500` event and `exit_code: 1` instead of being
+reported as clean.
+
+**Known limitation.** Only constructs the parser cannot dispatch at all become
+unknown statements. Malformed-but-recognized declarations — e.g. a function
+with a broken parameter list (`fn broken( {`) — parse into a recovered
+declaration node and are **not yet** flagged. Catching those requires
+parser-level error recovery (a threaded diagnostics channel), tracked
+separately; `E05xx` is reserved for the full range as that lands.
 
 ## Examples
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -46,6 +46,18 @@ feature availability.
   conformance (E0301) is now live for end users without any textual
   import inlining — covered by
   `compiler/tests/e2e/test_check_cross_module_conformance.sh`.
+- **`sfn check` surfaces parse errors** (#974): unrecognized top-level
+  syntax (which the parser lowers to an `Statement.Unknown`) is now
+  reported as an `E0500` diagnostic with `producer: "parse"` instead of
+  being silently treated as a clean file. `check_source_with_imports`
+  walks the parsed top-level statements and mints one `E0500` per
+  unknown node, anchored at its first token; `classify_producer` maps
+  the `E05xx` range to `"parse"`. Limitation: malformed-but-dispatched
+  declarations (e.g. `fn broken( {`, which recovers into a
+  `FunctionDeclaration`) are not yet flagged — that needs parser-level
+  error recovery. Covered by the `E0500` case in
+  `compiler/tests/e2e/test_check_json_schema.sh` and the `sfn/test`
+  `assert_compiles`/`assert_does_not_compile` helpers.
 - **Diagnostic infrastructure Phase 1** (A3): the `Diagnostic` struct
   now carries `severity` ("error" | "warning" | "hint" | "info") and
   `file_path`; the renderer reads both from the struct rather than

--- a/docs/status.md
+++ b/docs/status.md
@@ -47,7 +47,7 @@ feature availability.
   import inlining — covered by
   `compiler/tests/e2e/test_check_cross_module_conformance.sh`.
 - **`sfn check` surfaces parse errors** (#974): unrecognized top-level
-  syntax (which the parser lowers to an `Statement.Unknown`) is now
+  syntax (which the parser lowers to a `Statement.Unknown`) is now
   reported as an `E0500` diagnostic with `producer: "parse"` instead of
   being silently treated as a clean file. `check_source_with_imports`
   walks the parsed top-level statements and mints one `E0500` per


### PR DESCRIPTION
## Summary
- Adds compile-as-test assertions to `sfn/test`: `assert_compiles` / `assert_does_not_compile` shell out to `sfn check --json` via `process.run_capture` and read the `sailfin-check/1` envelope (`schema_version`, `summary.errors`, each event `message`) with a small inline scanner over `sfn/strings`. Hermetic `$SAILFIN_BIN` resolution (fallback `build/native/sailfin`), single temp-file lifecycle.
- **Scope expansion (approved):** `sfn check` previously swallowed *all* parse errors (a broken file reported `exit_code:0`, `errors:0`, empty events). The parse-error acceptance criterion was unmeetable without a compiler change, so this PR also makes `sfn check` surface unrecognized top-level syntax as `E0500` diagnostics (`producer: "parse"`).

Closes #974

## What changed
**Capsule (`sfn/test`):**
- `capsules/sfn/test/src/compile_assert.sfn` (new) — `CompileExpect`, `assert_compiles`, `assert_does_not_compile`, + inline envelope reader.
- `capsules/sfn/test/src/mod.sfn` — re-export. (No new capsule dependency — uses `sfn/strings`, already a dep.)
- `capsules/sfn/test/tests/compile_assert_test.sfn` (new) — 6 tests.

**Compiler (`sfn check` parse-error surfacing):**
- `compiler/src/tools/check.sfn` — walk top-level statements in `check_source_with_imports`, mint one `E0500` per `Statement.Unknown` node (the parser's recovery token for unrecognized syntax), anchored at its first token.
- `compiler/src/diagnostics_json.sfn` — `classify_producer` maps the `E05xx` range to `"parse"`. Envelope schema unchanged (`sailfin-check/1` already lists `"parse"`) — purely additive.
- Tests: `diagnostics_json_test.sfn` (E0500→parse), `test_check_json_schema.sh` (new parse-error fixture + assertions).
- Docs: `check-json-schema.md`, `status.md`.

## Why an inline envelope reader instead of `sfn/json`
The first cut added `"sfn/json"` to `sfn/test`'s `capsule.toml`. That pulled `sfn/json`'s full recursive-parser closure into **every** `sfn/test` test binary, which exceeds the unit-test import/link envelope (#619) in CI's toolchain — failing the link for `compile_assert_test`, `expect_test`, and `snapshot_test` alike (the latter two were collateral; they share the manifest but never import json). Since the `sailfin-check/1` envelope is a single fixed-shape line, a targeted, escape-aware field reader over `sfn/strings` is both lighter and sufficient, and keeps `sfn/test`'s dependency footprint unchanged.

## Acceptance Criteria
- [x] `assert_compiles(source, CompileExpect{ effects, ok, diagnostic_pattern })` returns a `MatchResult` reflecting the envelope.
- [x] `assert_does_not_compile(source, pattern)` passes iff `summary.errors >= 1` **and** a diagnostic message matches `pattern` (substring via `sfn/strings::find`).
- [x] Free-function form, `[io]`; re-exported from `mod.sfn`.
- [x] ≥4 tests: compiling snippet, missing-effect (`print.info` without `[io]`), parse-error (`@@@ !!!` → E0500), pattern-mismatch negative. (6 total.)
- [x] `make compile` self-hosts (exit 0); `sfn fmt --check` clean.

## Verification
```text
make compile                                  → exit 0 (self-host holds)
test capsules/sfn/test/tests/{compile_assert,expect,snapshot}_test.sfn → all PASS
test compiler/tests/unit/diagnostics_json_test.sfn → PASS (19 tests)
compiler/tests/e2e/test_check_json_schema.sh  → 15 passed, 0 failed (incl. new E0500 case)
check --json @@@!!!  → {"exit_code":1,"errors":1, E0500/parse/error @ line 1}
check --json on compiler/src/{tools/check,diagnostics_json,parser/mod,main}.sfn → E0500=0
sfn fmt --check (all touched .sfn)            → exit 0
```

## Notes
- **Parse-error coverage is top-level only.** Malformed-but-dispatched declarations (e.g. `fn broken( {`, which recovers into a `FunctionDeclaration`) parse into a recognized node, not an `Unknown`, so they are not yet flagged. Full parser-level error recovery is filed as **#1042**. Documented under "Known limitation" in `check-json-schema.md`.
- Addressed the Copilot review (schema_version hard-fail, `errors >= 1` guard, `W00xx` doc corrections, grammar).

🤖 Generated with [Claude Code](https://claude.com/claude-code)