### PR TITLE
feat(cli): env-bound flags via flag_env (Issue 1.9)

### DIFF
--- a/capsules/sfn/cli/src/builder.sfn
+++ b/capsules/sfn/cli/src/builder.sfn
@@ -58,7 +58,8 @@ fn flag(long_name: string, description: string) -> Flag {
         takes_value: false,
         required: false,
         value_kind: "string",
-        choices: no_choices
+        choices: no_choices,
+        env_var: ""
     };
 }
 
@@ -72,7 +73,8 @@ fn flag_value(long_name: string, description: string) -> Flag {
         takes_value: true,
         required: false,
         value_kind: "string",
-        choices: no_choices
+        choices: no_choices,
+        env_var: ""
     };
 }
 
@@ -86,7 +88,8 @@ fn flag_short(long_name: string, short_name: string, description: string) -> Fla
         takes_value: false,
         required: false,
         value_kind: "string",
-        choices: no_choices
+        choices: no_choices,
+        env_var: ""
     };
 }
 
@@ -100,7 +103,8 @@ fn flag_value_short(long_name: string, short_name: string, description: string) 
         takes_value: true,
         required: false,
         value_kind: "string",
-        choices: no_choices
+        choices: no_choices,
+        env_var: ""
     };
 }
 
@@ -117,7 +121,8 @@ fn flag_int(long_name: string, description: string) -> Flag {
         takes_value: true,
         required: false,
         value_kind: "int",
-        choices: no_choices
+        choices: no_choices,
+        env_var: ""
     };
 }
 
@@ -134,7 +139,8 @@ fn flag_float(long_name: string, description: string) -> Flag {
         takes_value: true,
         required: false,
         value_kind: "float",
-        choices: no_choices
+        choices: no_choices,
+        env_var: ""
     };
 }
 
@@ -151,7 +157,8 @@ fn flag_path(long_name: string, description: string) -> Flag {
         takes_value: true,
         required: false,
         value_kind: "path",
-        choices: no_choices
+        choices: no_choices,
+        env_var: ""
     };
 }
 
@@ -170,7 +177,8 @@ fn flag_repeat(long_name: string, description: string) -> Flag {
         takes_value: true,
         required: false,
         value_kind: "repeat",
-        choices: no_choices
+        choices: no_choices,
+        env_var: ""
     };
 }
 
@@ -187,7 +195,8 @@ fn flag_count(long_name: string, description: string) -> Flag {
         takes_value: false,
         required: false,
         value_kind: "count",
-        choices: no_choices
+        choices: no_choices,
+        env_var: ""
     };
 }
 
@@ -203,7 +212,8 @@ fn flag_count_short(long_name: string, short_name: string, description: string) 
         takes_value: false,
         required: false,
         value_kind: "count",
-        choices: no_choices
+        choices: no_choices,
+        env_var: ""
     };
 }
 
@@ -220,7 +230,8 @@ fn flag_choice(long_name: string, description: string, choices: string[]) -> Fla
         takes_value: true,
         required: false,
         value_kind: "choice",
-        choices: choices
+        choices: choices,
+        env_var: ""
     };
 }
 
@@ -236,7 +247,33 @@ fn flag_required(f: Flag) -> Flag {
         takes_value: f.takes_value,
         required: true,
         value_kind: f.value_kind,
-        choices: f.choices
+        choices: f.choices,
+        env_var: f.env_var
+    };
+}
+
+fn flag_env(f: Flag, var_name: string) -> Flag {
+    // Bind a flag to an environment variable as a fallback source. When
+    // the flag is absent from argv, the `![io]` `parse_with_env()` entry (and
+    // therefore `run()`) reads `var_name` and, if it is set to a
+    // non-empty value, treats the flag as present with that value. The
+    // precedence is argv > env > default: an argv-supplied value always
+    // wins. An env-satisfied flag counts as present for `flag_required`,
+    // so `flag_required(flag_env(...))` is satisfied when only the env is
+    // set. Chainable in either order with `flag_required` and on any flag
+    // constructor. Help output annotates bound flags with
+    // `[env: <var_name>]`. The pure `parse()` never consults the
+    // environment — callers that want the fallback must use `parse_with_env()`
+    // or `run()`.
+    return Flag {
+        long_name: f.long_name,
+        short_name: f.short_name,
+        description: f.description,
+        takes_value: f.takes_value,
+        required: f.required,
+        value_kind: f.value_kind,
+        choices: f.choices,
+        env_var: var_name
     };
 }
 

--- a/capsules/sfn/cli/src/help.sfn
+++ b/capsules/sfn/cli/src/help.sfn
@@ -88,6 +88,7 @@ fn _format_help(cmd: Command, program: string) -> string {
         let f = cmd.flags[fi];
         let label = _flag_label(f);
         out = out + "  " + _pad(label, flag_width) + f.description;
+        if f.env_var.length > 0 { out = out + " [env: " + f.env_var + "]"; }
         if f.required { out = out + " (required)"; }
         out = out + "\n";
         fi += 1;

--- a/capsules/sfn/cli/src/mod.sfn
+++ b/capsules/sfn/cli/src/mod.sfn
@@ -86,6 +86,7 @@ export {
     flag_count,
     flag_count_short,
     flag_required,
+    flag_env,
     command,
     with_version,
     with_arg,
@@ -94,7 +95,7 @@ export {
 } from "./builder";
 
 // ---- Parsing ----
-export { parse, run } from "./parser";
+export { parse, parse_with_env, run } from "./parser";
 
 // ---- Match accessors ----
 export {

--- a/capsules/sfn/cli/src/parser.sfn
+++ b/capsules/sfn/cli/src/parser.sfn
@@ -220,6 +220,70 @@ fn parse(cmd: Command, argv: string[]) -> ParseResult {
     return _validate_level(cmd.name, path, active, pos_idx, pos_names, pos_values, fl_names, fl_values, fl_present);
 }
 
+fn parse_with_env(cmd: Command, argv: string[]) -> ParseResult ![io] {
+    // Env-aware variant of `parse()`. Runs the pure parser first to
+    // discover the matched (leaf) command level and which flags argv
+    // supplied, then for each flag on that level bound via `flag_env`
+    // that argv did NOT supply, reads its environment variable. A
+    // non-empty env value is injected as synthetic argv tokens and the
+    // input is re-parsed, so env-supplied values flow through the exact
+    // same validation (typed/choice checks, required enforcement) as
+    // argv ones. Precedence is argv > env > default: an argv-present flag
+    // is never overridden, and an env-satisfied flag counts as present
+    // for `flag_required`. When no env binding fires, the original pure
+    // result is returned unchanged.
+    //
+    // Env fallback resolves against the matched leaf command's flags;
+    // injected tokens are appended to argv, so they validate at the same
+    // leaf level they were read from. The `env.get` read is the only
+    // reason this entry carries `![io]` — `parse()` itself stays pure.
+    let first = parse(cmd, argv);
+
+    // Help/version requests short-circuit identically on re-parse, so
+    // skip the env reads entirely and return the pure result.
+    if !first.ok {
+        if strings_equal(first.error.kind, "help_requested") { return first; }
+        if strings_equal(first.error.kind, "version_requested") { return first; }
+    }
+
+    let active = _resolve_active_path(cmd, first.matches.subcommand_path);
+
+    let mut extra: string[] = [];
+    let mut i: int = 0;
+    loop {
+        if i >= active.flags.length { break; }
+        let f = active.flags[i];
+        if f.env_var.length > 0 && !_flag_seen(first.matches.flag_names, f.long_name) {
+            let env_value = env.get(f.env_var);
+            if env_value.length > 0 {
+                extra.push("--" + f.long_name);
+                if f.takes_value { extra.push(env_value); }
+            }
+        }
+        i += 1;
+    }
+
+    if extra.length == 0 { return first; }
+
+    // Rebuild argv with the env-supplied tokens appended. Copy
+    // element-by-element rather than aliasing the caller's `argv`, so the
+    // injection never mutates the caller's slice.
+    let mut aug: string[] = [];
+    let mut ci: int = 0;
+    loop {
+        if ci >= argv.length { break; }
+        aug.push(argv[ci]);
+        ci += 1;
+    }
+    let mut ei: int = 0;
+    loop {
+        if ei >= extra.length { break; }
+        aug.push(extra[ei]);
+        ei += 1;
+    }
+    return parse(cmd, aug);
+}
+
 fn _validate_level(cmd_name: string, path: string[], active: Command, pos_idx: int, pos_names: string[], pos_values: string[], fl_names: string[], fl_values: string[], fl_present: boolean[]) -> ParseResult {
     // Finalize a single command level: fill optional positional
     // defaults, enforce required positionals, and enforce required
@@ -280,11 +344,14 @@ fn _validate_level(cmd_name: string, path: string[], active: Command, pos_idx: i
 }
 
 fn run(cmd: Command, argv: string[]) -> Matches ![io] {
-    // Exiting wrapper around `parse()`. Prints help/version and exits
-    // when --help/-h or --version/-V is given. Prints an error and
+    // Exiting wrapper around `parse_with_env()`. Prints help/version and
+    // exits when --help/-h or --version/-V is given. Prints an error and
     // exits with code 2 on invalid input. Cannot be wrapped in
-    // try/catch for error recovery — use `parse()` for that.
-    let result = parse(cmd, argv);
+    // try/catch for error recovery — use `parse()` (pure) or
+    // `parse_with_env()` (env-aware, `![io]`) for that. Delegating to
+    // `parse_with_env()` is why env-bound flags resolve for real CLI entry
+    // points while keeping the pure `parse()` available for embedding.
+    let result = parse_with_env(cmd, argv);
     if result.ok { return result.matches; }
 
     let path = result.matches.subcommand_path;
@@ -378,7 +445,8 @@ fn _find_flag_long(cmd: Command, name: string) -> Flag {
         takes_value: false,
         required: false,
         value_kind: "string",
-        choices: no_choices
+        choices: no_choices,
+        env_var: ""
     };
 }
 
@@ -399,7 +467,8 @@ fn _find_flag_short(cmd: Command, name: string) -> Flag {
         takes_value: false,
         required: false,
         value_kind: "string",
-        choices: no_choices
+        choices: no_choices,
+        env_var: ""
     };
 }
 

--- a/capsules/sfn/cli/src/types.sfn
+++ b/capsules/sfn/cli/src/types.sfn
@@ -32,6 +32,15 @@ struct Flag {
     // `parse()` validates the supplied value against this list and
     // emits `ParseError { kind: "invalid_choice" }` on a mismatch.
     choices: string[];
+    // `env_var` names an environment variable consulted as a fallback
+    // when the flag is absent from argv (built via `flag_env`); empty
+    // when the flag has no env binding. The precedence is argv > env >
+    // default: an argv-supplied value always wins, and an env-supplied
+    // value counts as "present" for `flag_required`. `parse()` stays
+    // pure and never reads the environment — env resolution lives in the
+    // `![io]` `parse_with_env()` entry point (and therefore `run()`). Help
+    // output annotates bound flags with `[env: <env_var>]`.
+    env_var: string;
 }
 
 struct Command {

--- a/capsules/sfn/cli/tests/env_flag_test.sfn
+++ b/capsules/sfn/cli/tests/env_flag_test.sfn
@@ -1,0 +1,175 @@
+// Tests for `flag_env` — Issue #798 (Phase 1 of the CLI Modularization
+// Epic, #351, proposal §7 Issue 1.9).
+//
+// Covers the chainable `flag_env` marker, the env-aware `parse_with_env()`
+// fallback (argv > env > default precedence, required satisfaction via
+// env), the `[env: VAR]` help annotation, and the invariant that the
+// pure `parse()` never reads the environment.
+//
+// Env-reading cases use `PATH` (reliably set and non-empty in any test
+// environment) as the "env present" source and a deliberately bogus
+// name as the "env absent" source — there is no intrinsic for *setting*
+// an env var from Sailfin, so the tests read existing process state.
+import {
+    command,
+    flag,
+    flag_env,
+    flag_required,
+    flag_value,
+    get,
+    has_flag,
+    help,
+    parse,
+    parse_with_env,
+    with_flag
+} from "../src/mod";
+
+// A var name that no sane environment defines; used for "env unset".
+let UNSET_VAR: string = "SFN_CLI_ENV_FLAG_TEST_UNSET_798";
+
+fn _contains(text: string, needle: string) -> boolean {
+    if needle.length > text.length { return false; }
+    let limit = text.length - needle.length;
+    let mut i: int = 0;
+    loop {
+        if i > limit { break; }
+        if strings_equal(substring(text, i, i + needle.length), needle) {
+            return true;
+        }
+        i += 1;
+    }
+    return false;
+}
+
+// ---- Builder ----
+test "flag_env: sets env_var and preserves other fields" {
+    let f = flag_env(flag_value("token", "API token"), "API_TOKEN");
+    assert strings_equal(f.long_name, "token");
+    assert strings_equal(f.description, "API token");
+    assert f.takes_value == true;
+    assert f.required == false;
+    assert strings_equal(f.env_var, "API_TOKEN");
+}
+
+test "flag_env: default-constructed flags have empty env_var" {
+    let f = flag_value("token", "API token");
+    assert strings_equal(f.env_var, "");
+    let b = flag("debug", "Enable debug");
+    assert strings_equal(b.env_var, "");
+}
+
+test "flag_env: chainable with flag_required (env then required)" {
+    let f = flag_required(flag_env(flag_value("token", "t"), "API_TOKEN"));
+    assert strings_equal(f.env_var, "API_TOKEN");
+    assert f.required == true;
+    assert f.takes_value == true;
+}
+
+test "flag_env: chainable with flag_required (required then env)" {
+    let f = flag_env(flag_required(flag_value("token", "t")), "API_TOKEN");
+    assert strings_equal(f.env_var, "API_TOKEN");
+    assert f.required == true;
+}
+
+// ---- Purity: parse() never reads env ----
+test "parse: pure parser ignores env binding (flag stays absent)" {
+    // `parse()` is the pure workhorse — even with an env binding whose
+    // variable (PATH) is set, the flag must NOT appear when argv omits
+    // it. Env fallback is exclusively `parse_with_env()`'s job.
+    let cmd = with_flag(command("app", "desc"), flag_env(flag_value("token", "API token"), "PATH"));
+    let argv: string[] = ["app"];
+    let r = parse(cmd, argv);
+    assert r.ok == true;
+    assert has_flag(r.matches, "token") == false;
+}
+
+// ---- parse_with_env: argv present (env must not override) ----
+test "parse_with_env: argv present with unset env yields argv value" ![io] {
+    let cmd = with_flag(command("app", "desc"), flag_env(flag_value("token", "API token"), UNSET_VAR));
+    let argv: string[] = ["app", "--token", "from-argv"];
+    let r = parse_with_env(cmd, argv);
+    assert r.ok == true;
+    assert strings_equal(get(r.matches, "token"), "from-argv");
+}
+
+test "parse_with_env: argv value wins over env when both are present" ![io] {
+    let path_value = env.get("PATH");
+    assert path_value.length > 0;
+    let cmd = with_flag(command("app", "desc"), flag_env(flag_value("token", "API token"), "PATH"));
+    let argv: string[] = ["app", "--token", "explicit"];
+    let r = parse_with_env(cmd, argv);
+    assert r.ok == true;
+    assert strings_equal(get(r.matches, "token"), "explicit");
+    assert ! strings_equal(get(r.matches, "token"), path_value);
+}
+
+// ---- parse_with_env: argv absent (env fills in) ----
+test "parse_with_env: env value used when argv is absent" ![io] {
+    let path_value = env.get("PATH");
+    assert path_value.length > 0;
+    let cmd = with_flag(command("app", "desc"), flag_env(flag_value("token", "API token"), "PATH"));
+    let argv: string[] = ["app"];
+    let r = parse_with_env(cmd, argv);
+    assert r.ok == true;
+    assert has_flag(r.matches, "token") == true;
+    assert strings_equal(get(r.matches, "token"), path_value);
+}
+
+test "parse_with_env: boolean flag marked present from env" ![io] {
+    let path_value = env.get("PATH");
+    assert path_value.length > 0;
+    let cmd = with_flag(command("app", "desc"), flag_env(flag("debug", "Enable debug"), "PATH"));
+    let argv: string[] = ["app"];
+    let r = parse_with_env(cmd, argv);
+    assert r.ok == true;
+    assert has_flag(r.matches, "debug") == true;
+}
+
+test "parse_with_env: unset env with argv absent leaves optional flag absent" ![io] {
+    let cmd = with_flag(command("app", "desc"), flag_env(flag_value("token", "API token"), UNSET_VAR));
+    let argv: string[] = ["app"];
+    let r = parse_with_env(cmd, argv);
+    assert r.ok == true;
+    assert has_flag(r.matches, "token") == false;
+}
+
+// ---- parse_with_env + flag_required ----
+test "parse_with_env: required flag satisfied by env alone" ![io] {
+    let path_value = env.get("PATH");
+    assert path_value.length > 0;
+    let cmd = with_flag(command("app", "desc"), flag_required(flag_env(flag_value("token", "API token"), "PATH")));
+    let argv: string[] = ["app"];
+    let r = parse_with_env(cmd, argv);
+    assert r.ok == true;
+    assert strings_equal(r.error.kind, "ok");
+    assert strings_equal(get(r.matches, "token"), path_value);
+}
+
+test "parse_with_env: required env flag still fails when env unset and argv absent" ![io] {
+    let cmd = with_flag(command("app", "desc"), flag_required(flag_env(flag_value("token", "API token"), UNSET_VAR)));
+    let argv: string[] = ["app"];
+    let r = parse_with_env(cmd, argv);
+    assert r.ok == false;
+    assert strings_equal(r.error.kind, "missing_required");
+    assert strings_equal(r.error.flag_name, "token");
+}
+
+// ---- Help annotation ----
+test "help: env-bound flag is annotated with [env: VAR]" {
+    let cmd = with_flag(command("app", "desc"), flag_env(flag_value("token", "API token"), "API_TOKEN"));
+    let rendered = help(cmd);
+    assert _contains(rendered, "[env: API_TOKEN]") == true;
+}
+
+test "help: non-env flag has no [env:] annotation" {
+    let cmd = with_flag(command("app", "desc"), flag_value("token", "API token"));
+    let rendered = help(cmd);
+    assert _contains(rendered, "[env:") == false;
+}
+
+test "help: env and required annotations both render" {
+    let cmd = with_flag(command("app", "desc"), flag_required(flag_env(flag_value("token", "API token"), "API_TOKEN")));
+    let rendered = help(cmd);
+    assert _contains(rendered, "[env: API_TOKEN]") == true;
+    assert _contains(rendered, "(required)") == true;
+}


### PR DESCRIPTION
## Summary
- Add `flag_env(f, "VAR_NAME")` chain marker to `sfn/cli`: when a flag is absent from argv, fall back to the named environment variable. Precedence is **argv > env > default**, and an env-satisfied flag counts as present for `flag_required`.
- Help output renders `[env: VAR_NAME]` next to the flag description.
- Keep the pure `parse()` workhorse effect-free; env resolution lives in a new `[io]` `parse_with_env()` (per proposal §R6 / open question #6). `run()` delegates to it so real CLI entry points get the fallback; direct `parse()` callers stay pure.

Closes #798

## Design note (effect surface)
Env reads carry `[io]`. Rather than push `parse()` to `[io]` (which would break its documented "pure, non-exiting workhorse" contract and every existing parser test), `parse_with_env()` runs the pure `parse()` first, then for each `flag_env`-bound flag on the matched leaf command that argv did **not** supply, reads its env var and injects the value as synthetic argv tokens before re-parsing. Env values therefore flow through the exact same typed/choice/required validation as argv values. This matches the proposal's recommended `parse_with_env()` split (`docs/proposals/cli-modularization-epic.md` §R6).

## Acceptance Criteria
- [x] `flag_env` exported and chainable (either order with `flag_required`).
- [x] Argv value wins over env value when both are present.
- [x] Env value is used when argv is absent.
- [x] `flag_required + flag_env` is satisfied when only the env is set.
- [x] Help renders `[env: VAR_NAME]` next to the description.
- [x] Tests cover all three argv/env permutations (+ required/env, boolean-from-env, purity guard).
- [x] `make compile`, `make test`, `sfn fmt --check` all green.

## Verification
```bash
# self-host
ulimit -v 8388608 && make compile          # COMPILE OK
# full suite
ulimit -v 8388608 && make test             # exit 0, 0 failures
# capsule tests
ulimit -v 8388608 && build/native/sailfin test capsules/sfn/cli/tests/   # 11/11 files pass
ulimit -v 8388608 && build/native/sailfin test capsules/sfn/cli/tests/env_flag_test.sfn  # 15/15 tests pass
# formatting
ulimit -v 8388608 && build/native/sailfin fmt --check capsules/sfn/cli/  # FMT OK
```

## Files Changed
- `capsules/sfn/cli/src/types.sfn` — `Flag.env_var` field.
- `capsules/sfn/cli/src/builder.sfn` — `flag_env()`; thread `env_var` through every flag constructor + `flag_required`.
- `capsules/sfn/cli/src/parser.sfn` — `parse_with_env()` (`[io]`); `run()` delegates to it; `parse()` stays pure.
- `capsules/sfn/cli/src/help.sfn` — render `[env: VAR_NAME]`.
- `capsules/sfn/cli/src/mod.sfn` — re-export `flag_env` + `parse_with_env`.
- `capsules/sfn/cli/tests/env_flag_test.sfn` — NEW (15 tests).

## Notes for reviewers
- **Testing env-set behavior:** there is no intrinsic to *set* an env var from Sailfin, so the env-present cases read `PATH` (reliably set, non-empty) and the env-absent cases use a bogus var name. Each env-present test asserts `env.get("PATH").length > 0` first to make the precondition explicit.
- **Scope honored:** env fallback resolves against the matched (leaf) command's flags; injected tokens append to argv so they validate at the same level. Type coercion of env values is intentionally out of scope (deferred per the issue).
- **`run()` effect:** unchanged — already `[io]`. The naming `parse_with_env` follows the proposal's §R6 recommendation rather than the issue's loose "inside parse()" phrasing, preserving the pure-`parse()` contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JouPjC3fbZzzN4NEHLW5vh)_