### PR TITLE
fix(lowering): resolve cross-module struct-method calls to home symbol

### DIFF
--- a/compiler/src/llvm/lowering/lowering_core.sfn
+++ b/compiler/src/llvm/lowering/lowering_core.sfn
@@ -665,8 +665,16 @@ fn lower_to_llvm_lines_with_parsed_context(native_module: NativeModule, parse_in
     if debug_lowering { print.err("emit-llvm: phase=imports"); }
 
     // ── Phase 3: Combine types, build type context ──────────────────
-    let mut combined_structs = extend_native_structs(module_structs, imported_structs);
-    let mut combined_enums = extend_native_enums(module_enums, imported_enums);
+    // #960: build `combined_structs`/`combined_enums` from a FRESH array so
+    // `extend_native_structs`/`extend_native_enums` (which alias + mutate
+    // their first arg in place via `.push`) do not contaminate
+    // `module_structs`/`module_enums` with imported declarations. Without the
+    // fresh seed, the in-place append leaked imported structs into
+    // `module_structs`, and the later `flatten_struct_methods(module_structs)`
+    // re-emitted imported (body-less) methods as local `ret 0` stubs that
+    // shadowed the real cross-module method symbol (garbage `self`).
+    let mut combined_structs = extend_native_structs(extend_native_structs([], module_structs), imported_structs);
+    let mut combined_enums = extend_native_enums(extend_native_enums([], module_enums), imported_enums);
     // #1021: surface the prelude `Result<T, E>` / `Error` decls so bare user
     // files (no in-file enum, no explicit import) lower `Result.Ok` / `.Err` +
     // `match` to a real `%Result` layout + discriminant test instead of `i8*`.

--- a/compiler/src/llvm/lowering/lowering_helpers_mangling.sfn
+++ b/compiler/src/llvm/lowering/lowering_helpers_mangling.sfn
@@ -34,6 +34,7 @@ import {
     apply_symbol_substitutions,
     collect_available_import_module_names,
     collect_defined_function_symbols,
+    extract_module_name_from_native_text,
     find_declare_signature,
     insert_before_llvm_footer,
     render_function_shim,
@@ -41,6 +42,66 @@ import {
     sanitize_module_suffix,
     should_keep_unmangled_abi_symbol
 } from "./lowering_helpers";
+
+// #960: scan a `.sfn-asm` native text for struct-method symbols.
+// `flatten_struct_methods` names each method `<StructName><MethodName>`, so a
+// consumer's call site for an imported method appears as the bare symbol
+// `@<StructName><MethodName>`. The imported method is NOT listed in any
+// `.import { specifiers }` line (only the free symbols are), so the mangling
+// pass can't learn it from the import directives — it must be discovered by
+// walking the provider's native text. Returns the sanitized bare symbols
+// (e.g. `ProbeEget_actual`) defined by every `.struct`/`.method` pair.
+fn _collect_struct_method_symbols(native_text: string) -> string[] {
+    let mut result: string[] = [];
+    if native_text.length == 0 { return result; }
+    let mut current_struct: string = "";
+    let mut scan_pos: int = 0;
+    let len = native_text.length;
+    loop {
+        if scan_pos >= len { break; }
+        let mut line_end: int = scan_pos;
+        loop {
+            if line_end >= len { break; }
+            if native_text[line_end] == "\n" { break; }
+            line_end += 1;
+        }
+        let line = trim_text(substring(native_text, scan_pos, line_end));
+        scan_pos = line_end + 1;
+
+        if starts_with(line, ".struct ") {
+            let tail = trim_text(substring(line, 8, line.length));
+            // Struct name is the first whitespace-delimited token
+            // (`.struct Foo implements Bar` → `Foo`).
+            let mut name_end: int = 0;
+            loop {
+                if name_end >= tail.length { break; }
+                if tail[name_end] == " " { break; }
+                name_end += 1;
+            }
+            current_struct = substring(tail, 0, name_end);
+            continue;
+        }
+        if starts_with(line, ".endstruct") {
+            current_struct = "";
+            continue;
+        }
+        if current_struct.length == 0 { continue; }
+        if starts_with(line, ".method ") {
+            let tail = trim_text(substring(line, 8, line.length));
+            // Method name runs up to the opening parameter paren.
+            let paren = index_of(tail, "(");
+            if paren <= 0 { continue; }
+            let method_name = trim_text(substring(tail, 0, paren));
+            if method_name.length == 0 { continue; }
+            let symbol = sanitize_symbol(current_struct + method_name);
+            if symbol.length == 0 { continue; }
+            if !string_array_contains(result, symbol) {
+                result.push(symbol);
+            }
+        }
+    }
+    return result;
+}
 
 fn apply_module_symbol_mangling(lines: string[], imports: NativeImport[], current_module_slug: string, imported_native_texts: string[], native_text_path: string) -> MangledModuleResult ![io] {
     let mut diagnostics: string[] = [];
@@ -230,6 +291,54 @@ fn apply_module_symbol_mangling(lines: string[], imports: NativeImport[], curren
         }
     }
 
+    // 2b) #960: rewrite imported struct-method call sites to the home-module
+    // symbol. `flatten_struct_methods` names methods `<Struct><Method>`, and a
+    // consumer references an imported method as the bare `@<Struct><Method>(`.
+    // These never appear in `.import { specifiers }` (only free symbols do), so
+    // the directive loop above can't map them. Discover them by walking each
+    // provider's native text: when THIS module calls a method it does not
+    // define locally, map `@<sym>` → `@<sym>__<provider_suffix>` and remember
+    // the target so an external declare is injected below. Without this the
+    // call would bind to a bodyless local stub (the #960 garbage-`self` bug) or
+    // — once that stub is gone — to an undefined symbol.
+    let mut imm_targets: string[] = [];
+    let mut imm_signatures: DeclareSignature[] = [];
+    let mut imm_ti: int = 0;
+    loop {
+        if imm_ti >= imported_native_texts.length { break; }
+        let imm_text = imported_native_texts[imm_ti];
+        imm_ti += 1;
+        if imm_text == null { continue; }
+        if imm_text.length == 0 { continue; }
+        let provider_slug = extract_module_name_from_native_text(imm_text);
+        if provider_slug.length == 0 { continue; }
+        // Runtime modules keep stable, unmangled ABI symbols.
+        if starts_with(provider_slug, "runtime/") { continue; }
+        let provider_suffix = sanitize_module_suffix(provider_slug);
+        let method_symbols = _collect_struct_method_symbols(imm_text);
+        let mut ms_i: int = 0;
+        loop {
+            if ms_i >= method_symbols.length { break; }
+            let bare = method_symbols[ms_i];
+            ms_i += 1;
+            if should_keep_unmangled_abi_symbol(bare) { continue; }
+            // Already qualified, locally defined, or already mapped: leave it.
+            if index_of(bare, "__") >= 0 { continue; }
+            if string_array_contains(defined, bare) { continue; }
+            if string_array_contains(import_olds, bare) { continue; }
+            // Only act when this module actually references the method (the
+            // signature is recovered from the bare call site, which still
+            // exists in `rewritten` at this point — before substitution).
+            let signature = find_declare_signature(rewritten, bare);
+            if signature == null { continue; }
+            let target = bare + "__" + provider_suffix;
+            import_olds.push(bare);
+            import_news.push(target);
+            imm_targets.push(target);
+            imm_signatures.push(signature);
+        }
+    }
+
     rewritten = apply_symbol_substitutions(rewritten, import_olds, import_news);
     if debug_lowering {
         print.err("emit-llvm: mangle import_subs=" + number_to_string(import_olds.length));
@@ -273,6 +382,22 @@ fn apply_module_symbol_mangling(lines: string[], imports: NativeImport[], curren
         }
         shim_lines.push("");
         shim_index += 1;
+    }
+    // #960: external declares for imported struct-method targets rewritten in
+    // step 2b. Their bodies live in the provider module's `.ll`; this consumer
+    // only needs a `declare` so the rewritten call sites resolve at link time.
+    let mut imm_di: int = 0;
+    loop {
+        if imm_di >= imm_targets.length { break; }
+        if imm_di >= imm_signatures.length { break; }
+        let imm_target = imm_targets[imm_di];
+        let imm_sig = imm_signatures[imm_di];
+        imm_di += 1;
+        if string_array_contains(injected_declares, imm_target) { continue; }
+        if _has_declare_or_define(rewritten, imm_target) { continue; }
+        shim_lines.push(_render_declare_line(imm_target, imm_sig));
+        shim_lines.push("");
+        injected_declares.push(imm_target);
     }
     rewritten = insert_before_llvm_footer(rewritten, shim_lines);
     if debug_lowering {

--- a/compiler/src/llvm/lowering/lowering_helpers_mangling.sfn
+++ b/compiler/src/llvm/lowering/lowering_helpers_mangling.sfn
@@ -70,12 +70,16 @@ fn _collect_struct_method_symbols(native_text: string) -> string[] {
 
         if starts_with(line, ".struct ") {
             let tail = trim_text(substring(line, 8, line.length));
-            // Struct name is the first whitespace-delimited token
-            // (`.struct Foo implements Bar` → `Foo`).
+            // Stop at the first `<` (generic params) or space (`implements
+            // ...`). `flatten_struct_methods` builds the lowered symbol from
+            // the bare struct name, so `.struct Foo<T> implements Bar` must
+            // resolve to `Foo`, not `Foo<T>`.
             let mut name_end: int = 0;
             loop {
                 if name_end >= tail.length { break; }
-                if tail[name_end] == " " { break; }
+                let ch = tail[name_end];
+                if ch == " " { break; }
+                if ch == "<" { break; }
                 name_end += 1;
             }
             current_struct = substring(tail, 0, name_end);
@@ -87,11 +91,23 @@ fn _collect_struct_method_symbols(native_text: string) -> string[] {
         }
         if current_struct.length == 0 { continue; }
         if starts_with(line, ".method ") {
-            let tail = trim_text(substring(line, 8, line.length));
-            // Method name runs up to the opening parameter paren.
-            let paren = index_of(tail, "(");
-            if paren <= 0 { continue; }
-            let method_name = trim_text(substring(tail, 0, paren));
+            let mut tail = trim_text(substring(line, 8, line.length));
+            // The lowered symbol uses the bare method name, so drop an
+            // `async ` prefix and any `<...>` generic parameter list:
+            // `.method async foo<T>(...)` → `foo`.
+            if starts_with(tail, "async ") {
+                tail = trim_text(substring(tail, 6, tail.length));
+            }
+            let mut name_end: int = 0;
+            loop {
+                if name_end >= tail.length { break; }
+                let ch = tail[name_end];
+                if ch == "(" { break; }
+                if ch == "<" { break; }
+                name_end += 1;
+            }
+            if name_end >= tail.length { continue; }
+            let method_name = trim_text(substring(tail, 0, name_end));
             if method_name.length == 0 { continue; }
             let symbol = sanitize_symbol(current_struct + method_name);
             if symbol.length == 0 { continue; }

--- a/compiler/tests/e2e/cross_module_method_test.sfn
+++ b/compiler/tests/e2e/cross_module_method_test.sfn
@@ -1,0 +1,18 @@
+// Regression test for #960: cross-module struct-method dispatch.
+// Before the fix, the consumer re-emitted the imported method as a
+// body-less `ret 0` stub (garbage `self`) instead of calling the
+// provider's `Counter.value` / `Counter.snapshot`. Value-returning and
+// struct-returning methods are both exercised.
+import { make_counter } from "./fixtures/cross_module_method/mod";
+
+test "cross_module_method: value-returning method reads self" ![pure] {
+    let c = make_counter(7);
+    let v = c.value();
+    assert v == 7;
+}
+
+test "cross_module_method: struct-returning method preserves fields" ![pure] {
+    let c = make_counter(42);
+    let snap = c.snapshot();
+    assert snap.captured == 42;
+}

--- a/compiler/tests/e2e/fixtures/cross_module_method/mod.sfn
+++ b/compiler/tests/e2e/fixtures/cross_module_method/mod.sfn
@@ -1,0 +1,24 @@
+// Fixture for cross-module struct-method dispatch (#960).
+// A consumer importing `make_counter` and calling methods on the returned
+// value must dispatch to THIS module's `Counter` methods, not a body-less
+// local stub. Covers a value-returning method (`value`) and a
+// struct-returning method (`snapshot`).
+struct Snapshot {
+    captured: int;
+}
+
+struct Counter {
+    count: int;
+
+    fn value(self: Counter) -> int ![pure] { return self.count; }
+
+    fn snapshot(self: Counter) -> Snapshot ![pure] {
+        return Snapshot { captured: self.count };
+    }
+}
+
+fn make_counter(start: int) -> Counter {
+    return Counter { count: start };
+}
+
+export { make_counter, Counter, Snapshot };


### PR DESCRIPTION
## Summary
- Cross-module struct-method calls returned garbage `self` (`e.get_actual()` → `0` instead of `7`; struct-returning methods segfaulted) because the **consuming** module re-emitted the imported method as a body-less `ret 0` stub and dispatched to it.
- Root cause is two compounding defects in the consumer's LLVM lowering — **not** the staging path the issue originally described. The imported `.layout-manifest` is already staged correctly (non-empty, contains `.layout struct`/`field`); the "0-byte manifest" diagnosis is obsolete (fixed by earlier work).

Closes #960

## Root cause (verified via instrumented builds)
1. **Array-aliasing contamination** (`lowering_core.sfn`). `extend_native_structs`/`extend_native_enums` alias and mutate their first argument in place (`out = values; out.push(...)`). Building `combined_structs = extend_native_structs(module_structs, imported_structs)` therefore appended imported `ProbeE` **into `module_structs`** (then `inject_prelude_error_struct` added `Error`). `module_structs` is meant to hold only the module's *own* structs.
2. **Body-less stub** — `flatten_struct_methods(module_structs)` then flattened the imported (signature-only, `instrs=0`) method into a local `define i64 @ProbeEget_actual__<consumer> { ret i64 0 }`, which the call site bound to → `self.actual` read garbage.

## Fix
- **Part 1** (`lowering_core.sfn`): build `combined_structs`/`combined_enums` from a fresh seed array so `module_structs`/`module_enums` stay pristine — mirroring the `concat_native_functions` copy the functions path already relies on. The stub (and a spurious consumer-side `@__sfn_type_desc.ProbeE` registration) disappear.
- **Part 2** (`lowering_helpers_mangling.sfn`): with the stub gone the call site emitted a bare `@<Struct><Method>` (undefined at link time). Imported struct methods never appear in `.import { specifiers }`, so `apply_module_symbol_mangling` now walks each provider's native text (new `_collect_struct_method_symbols`), rewrites such call sites to the home-module symbol `@<Struct><Method>__<provider_suffix>`, and injects an external `declare` — exactly how imported free functions resolve.
- `flatten_struct_methods`' self-param ABI (the #840-era fix) is left untouched.

## Acceptance Criteria
- [x] Repro `e.get_actual() == 7` passes when the method is called from a separate module.
- [x] A method returning a struct across a module boundary does not segfault and returns correct field values.
- [x] The staged `.layout-manifest` for the repro capsule is non-empty and contains `.layout struct ProbeE` + `.layout field actual` (already true on `main`).
- [x] Free-function cross-module calls and single-file method calls still pass (no regression).
- [x] Regression test under `compiler/tests/` exercising cross-module struct-method dispatch (value-returning and struct-returning).
- [x] `make compile` self-hosts; full suite run in progress (see below).

## Verification
```text
# Value-returning method across a module boundary
$ sailfin test tests/probe_test.sfn   →  PASS (got == 7)
  IR: %t2 = call i64 @ProbeEget_actual__src__mod(%ProbeE* %t1)
      declare i64 @ProbeEget_actual__src__mod(%ProbeE*)

# Struct-returning method across a module boundary
$ sailfin test tests/probe_test.sfn   →  PASS (snap.captured == 42, no segfault)

# No regression
single-file method dispatch            →  PASS
compiler/tests/e2e/directory_import_test.sfn (free-fn cross-module)  →  PASS
compiler/tests/e2e/cross_module_method_test.sfn (new regression)     →  PASS

$ make compile   →  self-hosts (exit 0)
$ sfn fmt --check (touched files)  →  clean
```

## Files Changed
- `compiler/src/llvm/lowering/lowering_core.sfn` — fresh-array combine (Part 1)
- `compiler/src/llvm/lowering/lowering_helpers_mangling.sfn` — imported struct-method call-site resolution + external declare (Part 2)
- `compiler/tests/e2e/cross_module_method_test.sfn` + `fixtures/cross_module_method/mod.sfn` — regression

## Note for reviewers
The issue body's root-cause trace (0-byte manifest; "do not touch `lowering_helpers_mangling.sfn`") was based on a state that no longer reproduces. The real defect is the consumer-side aliasing + stub described above, which necessarily touches the mangling pass. Design was approved before implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gtv4og9xp6kf1Ejbp1Aguv)_