### PR TITLE
fix(lowering): fail closed on unresolved struct info at cross-module method call site

### DIFF
--- a/compiler/src/llvm/expression_lowering/native/core_call_resolution.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_call_resolution.sfn
@@ -11,6 +11,7 @@ import { find_runtime_helper, make_concat_descriptor, make_push_descriptor } fro
 import { empty_string_constant_set, merge_string_constants } from "../../strings";
 import {
     find_interface_info_by_name,
+    find_struct_info_by_name,
     resolve_interface_info_for_method_target,
     resolve_struct_info_for_method_target
 } from "../../type_context_queries";
@@ -585,6 +586,55 @@ fn resolve_call_method_target(trimmed_target: string, arguments: string[], bindi
                                     }
                                 }
                                 if _pre_struct.length > 0 {
+                                    // #1041: fail closed when the base local's
+                                    // declared type is a bare struct name that is
+                                    // absent from the lowering type context. The
+                                    // fusion below (`_pre_struct + _pre_field`)
+                                    // would otherwise dispatch `self` with a
+                                    // default/garbage shape (the #960 staging-gap
+                                    // signature), segfaulting at runtime. Mirrors
+                                    // the #1023/#1037 fail-closed pattern: a
+                                    // `[fatal]` diagnostic makes the emit/build
+                                    // gate refuse to write IR.
+                                    //
+                                    // Narrow to a *bare* identifier to stay
+                                    // self-host safe (#830): generic
+                                    // instantiations like `Result<int, Error>`
+                                    // are not simple identifiers (and key on a
+                                    // mangled name, not the `<...>` spelling), and
+                                    // opacified locals carry an empty annotation —
+                                    // both keep the existing path so `make compile`
+                                    // still lowers method calls on them.
+                                    let mut _pre_fail_closed: boolean = false;
+                                    if is_simple_identifier(_pre_struct) {
+                                        if find_struct_info_by_name(context, _pre_struct) == null {
+                                            _pre_fail_closed = true;
+                                        }
+                                    }
+                                    if _pre_fail_closed {
+                                        result_diagnostics.push("llvm lowering [fatal]: method call base `"
+                                            + _pre_base
+                                            + "` has declared type `"
+                                            + _pre_struct
+                                            + "` which is not in the lowering type context");
+                                        return CallTargetResolution {
+                                            trimmed_target: result_target,
+                                            method_operand: null,
+                                            helper_descriptor: null,
+                                            injected_argument_count: 0,
+                                            is_array_concat: false,
+                                            array_concat_element_type: "",
+                                            is_array_push: false,
+                                            array_push_element_type: "",
+                                            current_lines: result_lines,
+                                            current_temp: result_temp,
+                                            diagnostics: result_diagnostics,
+                                            string_constants: result_string_constants,
+                                            is_closure_dispatch: false,
+                                            closure_return_type: "",
+                                            closure_parameter_types: []
+                                        };
+                                    }
                                     let _pre_lowered = lower_expression(_pre_base, bindings, locals, result_temp, result_lines, functions, context, "");
                                     let mut _ci1: int = 0;
                                     loop {
@@ -909,6 +959,69 @@ fn resolve_parsed_method_dispatch(result_target: string, arguments: string[], bi
                         };
                     }
                 } else {
+                    // #1041: fail closed when the method base is a struct
+                    // instance whose declared type is known by name but absent
+                    // from the lowering type context. Without this guard the
+                    // runtime-helper probes below would lower `self` with a
+                    // default/garbage shape (the #960 staging-gap signature) and
+                    // segfault at runtime. Mirrors the #1023/#1037 fail-closed
+                    // pattern: a `[fatal]` diagnostic makes the emit/build gate
+                    // refuse to write IR instead of emitting a miscompile.
+                    //
+                    // The discriminator is deliberately narrow to stay
+                    // self-host safe (#830): only a *bare* struct-name
+                    // annotation triggers it. Opacified locals carry an empty
+                    // annotation (left to the by-name fallback above), and
+                    // generic-instantiation locals like `Result<int, Error>`
+                    // carry a non-simple-identifier annotation that
+                    // `find_struct_info_by_name` can't key on — both are
+                    // excluded so `make compile` keeps lowering
+                    // `.diagnostics.concat` and friends.
+                    let _g_base = trim_text(method_parse.base);
+                    if is_simple_identifier(_g_base) {
+                        let mut _g_annotation: string = "";
+                        let _g_local = find_local_binding(locals, _g_base);
+                        if _g_local != null {
+                            _g_annotation = _g_local.type_annotation;
+                        } else {
+                            let _g_param = find_parameter_binding(bindings, _g_base);
+                            if _g_param != null {
+                                _g_annotation = _g_param.type_annotation;
+                            }
+                        }
+                        let mut _g_fail_closed: boolean = false;
+                        if _g_annotation.length > 0 {
+                            if is_simple_identifier(_g_annotation) {
+                                if find_struct_info_by_name(context, _g_annotation) == null {
+                                    _g_fail_closed = true;
+                                }
+                            }
+                        }
+                        if _g_fail_closed {
+                            r_diagnostics.push("llvm lowering [fatal]: method call base `"
+                                + method_parse.base
+                                + "` has declared type `"
+                                + _g_annotation
+                                + "` which is not in the lowering type context");
+                            return CallTargetResolution {
+                                trimmed_target: r_target,
+                                method_operand: null,
+                                helper_descriptor: null,
+                                injected_argument_count: 0,
+                                is_array_concat: false,
+                                array_concat_element_type: "",
+                                is_array_push: false,
+                                array_push_element_type: "",
+                                current_lines: r_lines,
+                                current_temp: r_temp,
+                                diagnostics: r_diagnostics,
+                                string_constants: r_string_constants,
+                                is_closure_dispatch: false,
+                                closure_return_type: "",
+                                closure_parameter_types: []
+                            };
+                        }
+                    }
                     let qualified_helper = find_runtime_helper(r_target);
                     if qualified_helper != null {
                         r_helper_descriptor = qualified_helper;

--- a/compiler/tests/unit/method_target_unresolved_struct_test.sfn
+++ b/compiler/tests/unit/method_target_unresolved_struct_test.sfn
@@ -1,0 +1,107 @@
+// Regression coverage for #1041: when a parsed method-dispatch site cannot
+// resolve struct info for the method base — because the base local's declared
+// type is a bare struct name absent from the lowering type context — the
+// compiler must fail closed with a `[fatal]` diagnostic instead of lowering
+// `self` with a default/garbage shape.
+//
+// Background (#960): a cross-module struct-method call passed `self` as garbage
+// because the imported capsule's `.layout-manifest` staged empty, so the call
+// site could not resolve the struct's layout. #960 fixes the staging gap; this
+// guard turns the *next* such staging gap into a clean error instead of a
+// garbage/segfault. Mirrors the #1023/#1037 fail-closed pattern.
+//
+// Self-host safety (#830): the guard fires only on a *bare* struct-name
+// annotation. Opacified locals carry an empty annotation, and generic
+// instantiations such as `Result<int, Error>` carry a non-simple-identifier
+// annotation; both are excluded so the compiler still self-hosts. The two
+// negative tests below pin that boundary.
+import { lower_call_expression } from "../../src/llvm/expression_lowering/native/core_call_lowering";
+import { LocalBinding, TypeContext } from "../../src/llvm/types";
+import { index_of } from "../../src/string_utils";
+
+fn _empty_context() -> TypeContext {
+    return TypeContext {
+        structs: [],
+        enums: [],
+        interfaces: [],
+        vtables: []
+    };
+}
+
+fn _contains(text: string, needle: string) -> boolean {
+    return index_of(text, needle) >= 0;
+}
+
+// A `[fatal]` diagnostic carrying the guard's own wording. Scoped to the
+// guard's phrase so the downstream "cannot resolve return type" `[fatal]`
+// (emitted for any unresolved callee) does not produce false positives in
+// the negative cases below.
+fn _has_fatal_unresolved_base(diagnostics: string[]) -> boolean {
+    let mut idx: int = 0;
+    loop {
+        if idx >= diagnostics.length { break; }
+        let diag = diagnostics[idx];
+        if _contains(diag, "[fatal]") {
+            if _contains(diag, "not in the lowering type context") {
+                return true;
+            }
+        }
+        idx += 1;
+    }
+    return false;
+}
+
+fn _local_with_annotation(annotation: string) -> LocalBinding {
+    return LocalBinding {
+        name: "acct",
+        pointer: "%acct",
+        llvm_type: "i8*",
+        type_annotation: annotation,
+        ownership: null,
+        consumed: false,
+        scope_id: "",
+        scope_depth: 0,
+        allocation_kind: "arena",
+        init_sentinel: ""
+    };
+}
+
+// -------------------------------------------------------------------
+// Fail-closed: method base whose bare struct-name type is absent from
+// the lowering type context.
+// -------------------------------------------------------------------
+test "method base with unresolved bare struct type emits a fatal diagnostic" ![io] {
+    let context = _empty_context();
+    let mut lines: string[] = [];
+    let locals: LocalBinding[] = [_local_with_annotation("Missing")];
+    let result = lower_call_expression("acct.get_balance", [], [], locals, 0, lines, [], context);
+    // Without the guard the call would lower `self` with a default/garbage
+    // shape; the `[fatal]` diagnostic makes the emit/build gate refuse to
+    // write IR instead of producing a miscompile.
+    assert _has_fatal_unresolved_base(result.diagnostics);
+}
+
+// -------------------------------------------------------------------
+// No regression (#830): a generic-instantiation annotation like
+// `Result<int, Error>` is NOT a simple identifier, so the guard must
+// not fire — otherwise `make compile` breaks on `.diagnostics.concat`.
+// -------------------------------------------------------------------
+test "method base with generic-instantiation type does not fail closed" ![io] {
+    let context = _empty_context();
+    let mut lines: string[] = [];
+    let locals: LocalBinding[] = [_local_with_annotation("Result<int, Error>")];
+    let result = lower_call_expression("acct.unwrap", [], [], locals, 0, lines, [], context);
+    assert ! _has_fatal_unresolved_base(result.diagnostics);
+}
+
+// -------------------------------------------------------------------
+// No regression: an opacified local carries an empty annotation; the
+// guard's `length > 0` clause leaves it to the by-method-name fallback.
+// -------------------------------------------------------------------
+test "method base with empty (opacified) annotation does not fail closed" ![io] {
+    let context = _empty_context();
+    let mut lines: string[] = [];
+    let locals: LocalBinding[] = [_local_with_annotation("")];
+    let result = lower_call_expression("acct.compute", [], [], locals, 0, lines, [], context);
+    assert ! _has_fatal_unresolved_base(result.diagnostics);
+}


### PR DESCRIPTION
## Summary
- Add a defensive `[fatal]` guard so a method call whose base has a **bare struct-name declared type absent from the lowering type context** fails closed with a diagnostic instead of dispatching `self` with a default/garbage shape (the #960 cross-module staging-gap signature, which segfaults at runtime). Mirrors the #1023/#1037 fail-closed pattern.
- The guard fires in the **inline member-access fallback** (`resolve_call_method_target`) — the path that actually fuses `type_annotation + field` and sets `method_operand` before dispatch — and again in `resolve_parsed_method_dispatch` as defense-in-depth for the rarer null-operand dispatch sub-case.
- Discriminator is narrowed to a **bare** struct-name annotation absent from the type context, so generic instantiations (`Result<int, Error>`, not a simple identifier) and opacified locals (empty annotation) keep the existing path and the compiler still self-hosts (#830).

Closes #1041

## Acceptance Criteria
- [x] When struct info for a method base cannot be resolved, the compiler emits a hard `[fatal]` diagnostic naming the base + declared type (no silent default-shape `self`).
- [x] No regression in resolvable cases (full suite + fixed-point self-host pass; negative tests confirm generic/opacified bases still lower).
- [x] Regression test under `compiler/tests/unit/` asserting the diagnostic fires on unresolved struct info, plus two negative cases pinning the self-host-safety boundary.
- [x] `make compile` self-hosts; `make test` passes; `make check` reaches fixed point.

## Notes on implementation
The issue's `Files Affected` pointed at `resolve_parsed_method_dispatch` (lines 646+), but the silent garbage-shape path that actually fires for the #960 `let e = importedStruct(...)` case is the **inline member-access fallback** earlier in the same file (`resolve_call_method_target`, lines 579–608): it fuses `type_annotation + field`, sets `method_operand`, and thereby bypasses the dispatch block entirely. The guard is placed there (the real culprit) with the dispatch-path guard retained as a second layer. Both live in the file the issue named (`core_call_resolution.sfn`); `type_context_queries.sfn` was left untouched to avoid rippling a sentinel through every caller of `resolve_struct_info_for_method_target`.

The diagnostic uses the symbolic base/type anchor (matching the #1023/#1037 precedent) rather than an AST `NativeSourceSpan` — `LocalBinding` (the `let e = …` case) carries no span at this lowering stage, and these string-based `[fatal]` diagnostics have no span plumbing.

## Verification
```bash
ulimit -v 8388608 && make check
# … e2e-sh: 98/98 passed, 0 failed
# [check] stage2 == stage3: compiler is a fixed point ✓
# [check] promoted seedcheck → build/native/sailfin

ulimit -v 8388608 && build/native/sailfin test compiler/tests/unit/method_target_unresolved_struct_test.sfn
# PASS (all 3 tests passed)
```

## Files Changed
- `compiler/src/llvm/expression_lowering/native/core_call_resolution.sfn` — import `find_struct_info_by_name`; fail-closed guard in the inline member-access fallback and in `resolve_parsed_method_dispatch`.
- `compiler/tests/unit/method_target_unresolved_struct_test.sfn` — new regression test (fail-closed + two self-host-safety negatives).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0183viJs6q7KSNZRNriRpVvy)_