### PR TITLE
fix(lowering): exclude interface-typed bases from #1041 fail-closed guard

### DIFF
--- a/compiler/src/llvm/expression_lowering/native/core_call_resolution.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_call_resolution.sfn
@@ -608,7 +608,16 @@ fn resolve_call_method_target(trimmed_target: string, arguments: string[], bindi
                                     let mut _pre_fail_closed: boolean = false;
                                     if is_simple_identifier(_pre_struct) {
                                         if find_struct_info_by_name(context, _pre_struct) == null {
-                                            _pre_fail_closed = true;
+                                            // Interface-typed locals carry a bare
+                                            // annotation too (e.g. `let m: Meter`);
+                                            // their `m.total()` calls are valid trait
+                                            // dispatch handled by the downstream
+                                            // `trait_dispatch__` branch. Only fail
+                                            // closed when the name is neither a
+                                            // struct nor an interface in context.
+                                            if find_interface_info_by_name(context, _pre_struct) == null {
+                                                _pre_fail_closed = true;
+                                            }
                                         }
                                     }
                                     if _pre_fail_closed {
@@ -993,7 +1002,12 @@ fn resolve_parsed_method_dispatch(result_target: string, arguments: string[], bi
                         if _g_annotation.length > 0 {
                             if is_simple_identifier(_g_annotation) {
                                 if find_struct_info_by_name(context, _g_annotation) == null {
-                                    _g_fail_closed = true;
+                                    // Exclude interface-typed bases: `m.total()`
+                                    // on `let m: Meter` is valid trait dispatch,
+                                    // not an unresolved struct.
+                                    if find_interface_info_by_name(context, _g_annotation) == null {
+                                        _g_fail_closed = true;
+                                    }
                                 }
                             }
                         }

--- a/compiler/tests/unit/method_target_unresolved_struct_test.sfn
+++ b/compiler/tests/unit/method_target_unresolved_struct_test.sfn
@@ -16,7 +16,7 @@
 // annotation; both are excluded so the compiler still self-hosts. The two
 // negative tests below pin that boundary.
 import { lower_call_expression } from "../../src/llvm/expression_lowering/native/core_call_lowering";
-import { LocalBinding, TypeContext } from "../../src/llvm/types";
+import { InterfaceTypeInfo, LocalBinding, TypeContext } from "../../src/llvm/types";
 import { index_of } from "../../src/string_utils";
 
 fn _empty_context() -> TypeContext {
@@ -24,6 +24,21 @@ fn _empty_context() -> TypeContext {
         structs: [],
         enums: [],
         interfaces: [],
+        vtables: []
+    };
+}
+
+// A context whose only registered type is the interface `Meter`. An
+// interface-typed local carries a bare annotation (`Meter`) absent from
+// `context.structs`, so the guard must consult `context.interfaces` before
+// failing closed — otherwise valid trait dispatch is rejected.
+fn _interface_only_context() -> TypeContext {
+    return TypeContext {
+        structs: [],
+        enums: [],
+        interfaces: [InterfaceTypeInfo {
+            name: "Meter", llvm_name: "%trait.Meter", type_parameters: [], signatures: []
+        }],
         vtables: []
     };
 }
@@ -103,5 +118,19 @@ test "method base with empty (opacified) annotation does not fail closed" ![io] 
     let mut lines: string[] = [];
     let locals: LocalBinding[] = [_local_with_annotation("")];
     let result = lower_call_expression("acct.compute", [], [], locals, 0, lines, [], context);
+    assert ! _has_fatal_unresolved_base(result.diagnostics);
+}
+
+// -------------------------------------------------------------------
+// No regression (PR #1053 review): an interface-typed local carries a
+// bare annotation (`Meter`) that is absent from `context.structs` but
+// present in `context.interfaces`. The guard must not treat that as an
+// unresolved struct — `m.total()` is valid trait dispatch.
+// -------------------------------------------------------------------
+test "method base with interface-typed annotation does not fail closed" ![io] {
+    let context = _interface_only_context();
+    let mut lines: string[] = [];
+    let locals: LocalBinding[] = [_local_with_annotation("Meter")];
+    let result = lower_call_expression("acct.total", [], [], locals, 0, lines, [], context);
     assert ! _has_fatal_unresolved_base(result.diagnostics);
 }

--- a/compiler/tests/unit/method_target_unresolved_struct_test.sfn
+++ b/compiler/tests/unit/method_target_unresolved_struct_test.sfn
@@ -125,7 +125,8 @@ test "method base with empty (opacified) annotation does not fail closed" ![io] 
 // No regression (PR #1053 review): an interface-typed local carries a
 // bare annotation (`Meter`) that is absent from `context.structs` but
 // present in `context.interfaces`. The guard must not treat that as an
-// unresolved struct — `m.total()` is valid trait dispatch.
+// unresolved struct — `acct.total()` (with `acct: Meter`) is valid trait
+// dispatch.
 // -------------------------------------------------------------------
 test "method base with interface-typed annotation does not fail closed" ![io] {
     let context = _interface_only_context();


### PR DESCRIPTION
## Summary
Follow-up to #1053 (merged). The #1041 fail-closed guard treated any bare method-base annotation absent from `context.structs` as an unresolved struct — but an **interface-typed** local carries a bare annotation (`Meter`) that lives in `context.interfaces`, not `context.structs`. So `let m: Meter = factory(); m.total()` would wrongly emit a `[fatal]` diagnostic and reject valid trait dispatch (which the downstream `trait_dispatch__` branch handles).

This narrows both guard sites to fail closed only when the annotation is **neither a struct nor an interface** in the lowering type context, mirroring the struct-vs-interface discrimination the dispatch site already uses (`find_interface_info_by_name`, already imported).

Surfaced by Copilot's review on #1053, which merged before the fix landed — so the regression is currently in `main`.

## Changes
- `core_call_resolution.sfn` — add `find_interface_info_by_name(...) == null` to the fail-closed condition in both the inline member-access fallback (`resolve_call_method_target`) and `resolve_parsed_method_dispatch`.
- `method_target_unresolved_struct_test.sfn` — new negative test: an interface-typed base must not fail closed (plus an `_interface_only_context()` builder). Existing struct / generic / opacified cases retained.

## Verification
```bash
ulimit -v 8388608 && make compile      # self-hosts (exit 0)
ulimit -v 8388608 && make test         # full suite + e2e-sh 98/98, 0 failed
ulimit -v 8388608 && build/native/sailfin test compiler/tests/unit/method_target_unresolved_struct_test.sfn
# PASS (all 4 tests passed)
```

## Why it slipped through #1053
The guard is strictly narrowing, so it didn't break the compiler's own self-host (the compiler source doesn't dispatch trait methods through an interface-typed local on this exact path with the interface registered in context). User code with interface-typed locals would hit it — hence the dedicated regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0183viJs6q7KSNZRNriRpVvy)_