### PR TITLE
feat(make): always-last SAILFIN-RESULT verdict block on agent targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,16 @@ NATIVE_BIN ?= build/native/sailfin$(EXE_EXT)
 
 .PHONY: rebuild mcp-server
 
+# Agent-facing targets (#1059) wrap their real `<target>-impl` body in the
+# verdict-block emitter so a single greppable `===SAILFIN-RESULT===` block is
+# always the last output, on success and failure alike. The wrapper also
+# carries the SAILFIN_INNER guard so a `make check` that calls `make test`
+# internally emits only the outer verdict. See scripts/agent_report.sh and
+# docs/reference/make-result-schema.md.
+.PHONY: compile-impl rebuild-impl check-impl check-fast-impl
+.PHONY: test-impl test-unit-impl test-integration-impl test-e2e-impl test-capsules-impl
+AGENT_REPORT := bash scripts/agent_report.sh
+
 help:
 	@echo "Common Sailfin tasks"
 	@echo ""
@@ -151,6 +161,9 @@ endif
 # run from `make test` / `make test-e2e` via `test-e2e-sh` — Phase
 # 3.1 migrates them and retires the .sh branch.
 test:
+	@$(AGENT_REPORT) --target test -- $(MAKE) test-impl
+
+test-impl:
 	@if [ ! -x $(NATIVE_BIN) ]; then \
 		echo "[test] missing $(NATIVE_BIN); running make compile"; \
 		$(MAKE) compile; \
@@ -218,6 +231,9 @@ fetch-seed:
 # Makefile loops used to emit now comes from `_emit_suite_banners`
 # in `handle_test_command`.
 test-unit:
+	@$(AGENT_REPORT) --target test-unit -- $(MAKE) test-unit-impl
+
+test-unit-impl:
 	@if [ ! -x $(NATIVE_BIN) ]; then \
 		echo "[test-unit] missing $(NATIVE_BIN); running make compile"; \
 		$(MAKE) compile; \
@@ -225,6 +241,9 @@ test-unit:
 	@$(NATIVE_BIN) test compiler/tests/unit
 
 test-integration:
+	@$(AGENT_REPORT) --target test-integration -- $(MAKE) test-integration-impl
+
+test-integration-impl:
 	@if [ ! -x $(NATIVE_BIN) ]; then \
 		echo "[test-integration] missing $(NATIVE_BIN); running make compile"; \
 		$(MAKE) compile; \
@@ -237,6 +256,9 @@ test-integration:
 # then `test-e2e-sh` keeps the bash-driven scripts on the same
 # `make test-e2e` / `make test` paths they were on before #848.
 test-e2e:
+	@$(AGENT_REPORT) --target test-e2e -- $(MAKE) test-e2e-impl
+
+test-e2e-impl:
 	@if [ ! -x $(NATIVE_BIN) ]; then \
 		echo "[test-e2e] missing $(NATIVE_BIN); running make compile"; \
 		$(MAKE) compile; \
@@ -252,6 +274,9 @@ test-e2e:
 # so passing just `capsules` matches the prior
 # `find capsules -path '*/tests/*_test.sfn'` discovery.
 test-capsules:
+	@$(AGENT_REPORT) --target test-capsules -- $(MAKE) test-capsules-impl
+
+test-capsules-impl:
 	@if [ ! -x $(NATIVE_BIN) ]; then \
 		echo "[test-capsules] missing $(NATIVE_BIN); running make compile"; \
 		$(MAKE) compile; \
@@ -413,6 +438,9 @@ clean-build:
 clean-all: clean clean-build
 
 compile:
+	@$(AGENT_REPORT) --target compile -- $(MAKE) compile-impl
+
+compile-impl:
 	@if [ "$${FORCE:-0}" = "0" ] && [ -x "$(NATIVE_BIN)" ] && \
 		[ -z "$$(find compiler/src runtime -type f -name '*.sfn' -newer "$(NATIVE_BIN)" -print -quit 2>/dev/null)" ]; then \
 		echo "[compile] $(NATIVE_BIN) up-to-date"; \
@@ -422,6 +450,9 @@ compile:
 	fi
 
 check:
+	@$(AGENT_REPORT) --target check -- $(MAKE) check-impl
+
+check-impl:
 	@$(MAKE) compile NATIVE_OPT="$(SELFHOST1_OPT)"
 	@seed="build/native/sailfin"; \
 	if [ ! -x "$$seed" ]; then \
@@ -540,6 +571,9 @@ check:
 # (the triple-pass selfhost validator). Naming mirrors what end users
 # of the language will eventually run on their own capsules.
 check-fast:
+	@$(AGENT_REPORT) --target check-fast -- $(MAKE) check-fast-impl
+
+check-fast-impl:
 	@if [ ! -x "$(NATIVE_BIN)" ] && [ ! -f "$(NATIVE_BIN)" ]; then \
 		echo "[check-fast] missing $(NATIVE_BIN); run: make compile"; \
 		exit 1; \
@@ -645,6 +679,9 @@ ci-package-installer:
 # - NATIVE_OPT / SELFHOST1_OPT are no longer honoured here — the
 #   driver hardcodes `-O2` for the link step.
 rebuild:
+	@$(AGENT_REPORT) --target rebuild -- $(MAKE) rebuild-impl
+
+rebuild-impl:
 	@mkdir -p build
 	@seed="$${SEED_NATIVE:-$(SEED)}"; \
 	resolved_seed="$$seed"; \

--- a/compiler/src/llvm/lowering/lowering_core.sfn
+++ b/compiler/src/llvm/lowering/lowering_core.sfn
@@ -931,6 +931,19 @@ fn lower_to_llvm_lines_with_parsed_context(native_module: NativeModule, parse_in
         }
         lines = mangled.lines;
     }
+    // Drop exact-duplicate module-scope `declare` lines. The runtime-helper
+    // preamble and the imported-function / inline-preamble paths can each
+    // emit a byte-identical `declare <ret> @<sym>(...)` for the same symbol
+    // (e.g. `sfn_array_sfn_map` is both a registered runtime helper and a
+    // `runtime/prelude.sfn` import). LLVM's library API merges identical
+    // declares, but clang's textual-IR parser — the `clang -c <file>.ll`
+    // path `_emit_runtime_sfn_to_obj` (cli_main.sfn) uses to build runtime
+    // objects — rejects the repeat with "invalid redefinition of function",
+    // which breaks a cold `make test` (the cached `.o` masks it in CI). Run
+    // the dedup here, after mangling so symbol names are final, keeping the
+    // first occurrence and preserving order so the stage2==stage3 fixed
+    // point is unaffected.
+    lines = dedup_module_declare_lines(lines);
     if debug_lowering { print.err("emit-llvm: phase=mangle"); }
     if trace { print.err("test llvm: mangling stage done"); }
     if timing {
@@ -1083,6 +1096,41 @@ fn hoist_closure_env_type_decls(lines: string[]) -> string[] {
             _fi2 += 1;
         }
         return prepended;
+    }
+    return result;
+}
+
+// Drop byte-identical module-scope `declare` lines, keeping the first
+// occurrence. Only column-0 `declare ` lines are considered — function
+// body lines are indented and never match, and `declare` never appears
+// inside a `define` body. Deterministic (order-preserving), so the
+// stage2==stage3 fixed point is unaffected. See the call site in
+// `lower_to_llvm_lines_with_parsed_context` for the clang-vs-LLVM
+// duplicate-declare rationale.
+fn dedup_module_declare_lines(lines: string[]) -> string[] {
+    let mut seen: string[] = [];
+    let mut result: string[] = [];
+    let mut index: int = 0;
+    loop {
+        if index >= lines.length { break; }
+        let line = lines[index];
+        if starts_with(line, "declare ") {
+            let mut already: boolean = false;
+            let mut _si: int = 0;
+            loop {
+                if _si >= seen.length { break; }
+                if seen[_si] == line {
+                    already = true;
+                    break;
+                }
+                _si += 1;
+            }
+            if !already {
+                seen.push(line);
+                result.push(line);
+            }
+        } else { result.push(line); }
+        index += 1;
     }
     return result;
 }

--- a/compiler/tests/e2e/test_no_duplicate_declares.sh
+++ b/compiler/tests/e2e/test_no_duplicate_declares.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Regression: the emitted LLVM IR for a module must not contain exact-duplicate
+# module-scope `declare` lines (PR #1062, issue #1059 follow-up).
+#
+# The runtime-helper preamble and the imported-function / inline-preamble
+# declaration paths could each emit a byte-identical `declare <ret> @<sym>(...)`
+# for the same symbol — e.g. `sfn_array_sfn_map`/`filter`/`reduce` are both
+# registered runtime helpers AND `runtime/prelude.sfn` imports, so the prelude
+# IR carried 28 duplicate declares. LLVM's library merges identical declares,
+# but clang's textual-IR parser (`clang -c <module>.ll`, the path the test
+# runner uses to build runtime objects via `_emit_runtime_sfn_to_obj`) rejects
+# the repeat with "invalid redefinition of function", breaking a cold-clone
+# `make test` for every test. The dedup pass in
+# `compiler/src/llvm/lowering/lowering_core.sfn` (dedup_module_declare_lines)
+# fixes it; this test pins the contract so it can't silently regress.
+#
+# Contract pinned (for the prelude, the densest declare consumer):
+#   1. No exact-duplicate column-0 `declare ` lines in the emitted IR.
+#   2. clang accepts the emitted IR (`clang -c` succeeds) — i.e. the textual
+#      parser, not just the LLVM library, is happy.
+
+set -euo pipefail
+
+BINARY="${1:?usage: test_no_duplicate_declares.sh <compiler-binary>}"
+BINARY="$(realpath "$BINARY")"
+PASS=0
+FAIL=0
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+MODULE_SRC="$REPO_ROOT/runtime/prelude.sfn"
+if [ ! -f "$MODULE_SRC" ]; then
+    echo "[test] FATAL: missing fixture $MODULE_SRC"
+    exit 2
+fi
+
+CLANG="${CLANG:-clang}"
+
+SCRATCH="$(mktemp -d -t sfn-dupdecl-XXXXXX)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+run_test() {
+    local name="$1"
+    shift
+    if "$@"; then
+        echo "[test] PASS: $name"
+        PASS=$((PASS + 1))
+    else
+        echo "[test] FAIL: $name"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+LL="$SCRATCH/prelude.ll"
+
+emit_prelude_ir() {
+    # `emit llvm` lowers the module to a standalone .ll — the exact path
+    # `_emit_runtime_sfn_to_obj` (cli_main.sfn) feeds to `clang -c`.
+    "$BINARY" emit --module-name runtime/prelude -o "$LL" llvm "$MODULE_SRC" \
+        > "$SCRATCH/emit.log" 2>&1
+}
+
+no_duplicate_declares() {
+    if [ ! -s "$LL" ]; then
+        echo "[test]   emit produced no IR:"
+        cat "$SCRATCH/emit.log"
+        return 1
+    fi
+    # Column-0 `declare ` lines only — function-body lines are indented and
+    # never match. A duplicate is any line appearing more than once.
+    local dups
+    dups="$(grep '^declare ' "$LL" | LC_ALL=C sort | uniq -d || true)"
+    if [ -n "$dups" ]; then
+        echo "[test]   duplicate module-scope declares emitted:"
+        printf '%s\n' "$dups" | sed 's/^/[test]     /'
+        return 1
+    fi
+    return 0
+}
+
+clang_accepts_ir() {
+    if ! command -v "$CLANG" > /dev/null 2>&1; then
+        echo "[test]   (skip) clang not found on PATH — IR-acceptance check skipped"
+        return 0
+    fi
+    if ! "$CLANG" -Wno-override-module -c "$LL" -o "$SCRATCH/prelude.o" \
+        > "$SCRATCH/clang.log" 2>&1; then
+        echo "[test]   clang rejected the emitted IR:"
+        head -20 "$SCRATCH/clang.log" | sed 's/^/[test]     /'
+        return 1
+    fi
+    return 0
+}
+
+if ! emit_prelude_ir; then
+    echo "[test] FAIL: emit runtime/prelude.sfn -> LLVM IR"
+    echo "[summary] 0 passed, 1 failed"
+    exit 1
+fi
+
+run_test "prelude IR has no exact-duplicate module-scope declares" \
+    no_duplicate_declares
+run_test "clang -c accepts the emitted prelude IR" \
+    clang_accepts_ir
+
+echo "[summary] $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi

--- a/docs/reference/make-result-schema.md
+++ b/docs/reference/make-result-schema.md
@@ -18,9 +18,21 @@ upthread:
 A consumer greps for `===SAILFIN-RESULT===` and parses the **one JSON line**
 that follows. Because the block is emitted last (via a `trap … EXIT` idiom in
 `scripts/agent_report.sh` that fires even when a phase aborts), it is the one
-thing a truncated tail is guaranteed to retain. If a log somehow contains more
-than one block (e.g. a test prints the delimiter), consumers MUST read the
-**last** occurrence.
+thing a truncated tail is guaranteed to retain.
+
+**Consumers MUST locate the _last_ `===SAILFIN-RESULT===` block in the log**,
+not assume the file ends immediately after `===END-SAILFIN-RESULT===`. Two
+things can print after the block:
+
+- On a failing target, GNU Make appends its own `make: *** [<target>] Error N`
+  line(s) to **stderr** after the recipe exits non-zero. The verdict block is
+  the last line of the target's own **stdout**, but under `2>&1` the make-error
+  line interleaves after it. (`make compile 2>&1 | tail -5` still captures the
+  block — it is within the last few lines.)
+- If a log somehow contains more than one block (e.g. a test prints the
+  delimiter), only the final one is the real verdict.
+
+Reading the last match handles both cases.
 
 ## Wrapped targets
 
@@ -76,7 +88,7 @@ string.
 | `status` | Meaning | Exit code |
 |---|---|---|
 | `pass` | The target succeeded. | `0` |
-| `warn` | A non-fatal signal (today: `nondeterminism`) without a failure. | mirrors `make`'s actual exit (so `make check`'s `0` is preserved) |
+| `warn` | A non-fatal signal that does **not** flip the exit code. `failure` is still set to the classification (today: `nondeterminism`). | mirrors `make`'s actual exit (so `make check`'s `0` is preserved) |
 | `fail` | The target failed. | non-zero |
 
 ### `failure` (closed enum)

--- a/docs/reference/make-result-schema.md
+++ b/docs/reference/make-result-schema.md
@@ -1,0 +1,141 @@
+# `make` Verdict Block Schema (`sailfin-make/1`)
+
+Status: Phase 1 of `docs/proposals/agent-output-orchestration.md` (epic #1056,
+issue #1059). The always-last verdict block ships now; the full report file
+(`build/agent-report.json`) and precise `first_error` extraction are Phases 2–3.
+
+Every agent-facing `make` target ends — on success **and** on failure — by
+printing a single greppable verdict block as the **last lines of its output**,
+so an agent can classify the outcome from a tail-truncated log without scrolling
+upthread:
+
+```
+===SAILFIN-RESULT===
+{"schema_version":"sailfin-make/1","target":"check","status":"fail","failure":"test-failure","phase":"seedcheck-tests","first_error":"compiler/tests/unit/foo_test.sfn:42","report":null}
+===END-SAILFIN-RESULT===
+```
+
+A consumer greps for `===SAILFIN-RESULT===` and parses the **one JSON line**
+that follows. Because the block is emitted last (via a `trap … EXIT` idiom in
+`scripts/agent_report.sh` that fires even when a phase aborts), it is the one
+thing a truncated tail is guaranteed to retain. If a log somehow contains more
+than one block (e.g. a test prints the delimiter), consumers MUST read the
+**last** occurrence.
+
+## Wrapped targets
+
+The verdict block is emitted by `scripts/agent_report.sh`, wired into these
+`Makefile` targets:
+
+`compile`, `rebuild`, `check`, `check-fast`, `test`, `test-unit`,
+`test-integration`, `test-e2e`, `test-capsules`.
+
+Each public target is a thin wrapper over a `<target>-impl` body that holds the
+real recipe. The wrapper runs the impl under `agent_report.sh`, which streams
+the impl's output through unchanged and appends the verdict block.
+
+### Nested-invocation guard (`SAILFIN_INNER`)
+
+`make check` invokes `make test` (and `make compile`) internally, and `make
+test` invokes `make compile`. Only the **outer** target's verdict is printed:
+`agent_report.sh` exports `SAILFIN_INNER=1` for the command it runs, and any
+wrapped target reached with `SAILFIN_INNER` already set runs transparently and
+emits **no** sentinel.
+
+## Delimiters
+
+| Delimiter | Meaning |
+|---|---|
+| `===SAILFIN-RESULT===` | Start marker. The next line is the JSON verdict. |
+| `===END-SAILFIN-RESULT===` | End marker, immediately after the JSON line. |
+
+The JSON verdict is exactly one line between the two delimiter lines.
+
+## Versioning
+
+The first field of the verdict is `schema_version`, currently the literal string
+`"sailfin-make/1"`. Breaking changes bump this string (e.g. `"sailfin-make/2"`).
+Consumers MUST **hard-fail on unknown `schema_version`** rather than guess at
+unfamiliar field shapes. Additive changes (new optional fields) keep the version
+string.
+
+## Fields
+
+| Field | Type | Notes |
+|---|---|---|
+| `schema_version` | string | `"sailfin-make/N"`; consumers hard-fail on unknown `N`. |
+| `target` | string | The wrapped target: one of the nine listed above. |
+| `status` | string | `pass` \| `warn` \| `fail`. See the closed enum below. |
+| `failure` | string \| null | Classification (closed enum below); `null` on `pass`. Set on `warn` too. |
+| `phase` | string \| null | Best-effort phase that reached the failure/warn. Single-phase targets echo the target name; `check` resolves one of its seven phases. `null` on `pass`. |
+| `first_error` | string \| null | Best-effort `file:line` (or `file:line:col`) pointer when one can be scraped, else the failing phase name, else `null`. Precise extraction is Phase 3. |
+| `report` | string \| null | Path to the full JSON report. Always `null` in Phase 1; populated in Phase 2 (`build/agent-report.json`). |
+
+### `status` (closed enum)
+
+| `status` | Meaning | Exit code |
+|---|---|---|
+| `pass` | The target succeeded. | `0` |
+| `warn` | A non-fatal signal (today: `nondeterminism`) without a failure. | mirrors `make`'s actual exit (so `make check`'s `0` is preserved) |
+| `fail` | The target failed. | non-zero |
+
+### `failure` (closed enum)
+
+`null` on `pass`. Otherwise one of:
+
+| `failure` | Meaning | Agent's correct response |
+|---|---|---|
+| `compile-error` | `sfn build`/`check` reported diagnostics. | Read diagnostics, fix source — do **not** retry. |
+| `test-failure` | One or more tests failed assertions. | Read the failing test's output. |
+| `nondeterminism` | stage2 ≠ stage3 fixed-point mismatch (`make check`). | Pairs with `status:"warn"`, exit `0`. Re-run once; if it persists, escalate to `seed-stabilizer`. |
+| `setup-error` | Bad path, missing seed, staging/env failure. | Fix the invocation/env, not the source. |
+| `oom` | Hit the 8 GB `ulimit -v` cap. | Escalate (memory regression) — do **not** blind-retry. |
+| `timeout` | Wall-clock `timeout` tripped (exit 124, or SIGKILL 137). | Re-run or escalate per phase. |
+
+`nondeterminism` is the only class that pairs with `status:"warn"`; every other
+class pairs with `status:"fail"`.
+
+## `phase` values for `check`
+
+`make check` runs seven phases; on failure `phase` resolves to the latest one
+reached (best-effort, from the human banners `check` already prints):
+
+`compile`, `first-pass-tests`, `seedcheck-build`, `seedcheck-smoke`,
+`seedcheck-tests`, `stage3-build`, `fixed-point`.
+
+The `seedcheck-smoke` phase (the hello-world viability step) can fail
+independently of the build and test phases.
+
+## Examples
+
+Passing `check-fast`:
+
+```
+===SAILFIN-RESULT===
+{"schema_version":"sailfin-make/1","target":"check-fast","status":"pass","failure":null,"phase":null,"first_error":null,"report":null}
+===END-SAILFIN-RESULT===
+```
+
+Forced setup failure (`make compile SEED=/nonexistent`):
+
+```
+===SAILFIN-RESULT===
+{"schema_version":"sailfin-make/1","target":"compile","status":"fail","failure":"setup-error","phase":"compile","first_error":"compile","report":null}
+===END-SAILFIN-RESULT===
+```
+
+Non-deterministic fixed point (`make check`, exit 0):
+
+```
+===SAILFIN-RESULT===
+{"schema_version":"sailfin-make/1","target":"check","status":"warn","failure":"nondeterminism","phase":"fixed-point","first_error":null,"report":null}
+===END-SAILFIN-RESULT===
+```
+
+## Implementation
+
+- Emitter + classification: `scripts/agent_report.sh`.
+- Makefile wiring: the nine `<target>` / `<target>-impl` pairs.
+- Phase 3 will add a schema-lock test (mirroring
+  `compiler/tests/e2e/test_check_json_schema.sh`) that guards the exact
+  delimiters and the field/enum set.

--- a/scripts/agent_report.sh
+++ b/scripts/agent_report.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+#
+# Agent-tail verdict block emitter (epic #1056 Phase 1, issue #1059).
+#
+# Wraps an agent-facing `make` target so that — on success AND on failure —
+# the LAST lines of output are a single greppable verdict block:
+#
+#   ===SAILFIN-RESULT===
+#   {"schema_version":"sailfin-make/1","target":"check","status":"fail",...}
+#   ===END-SAILFIN-RESULT===
+#
+# An agent greps the (last) `===SAILFIN-RESULT===` marker and parses the one
+# JSON line that follows to learn {target, status, failure-class, phase,
+# first-error} from a tail-truncated log, with zero upthread scrolling.
+# Schema: docs/reference/make-result-schema.md (`sailfin-make/1`).
+#
+# Design: docs/proposals/agent-output-orchestration.md §1 (tail contract),
+# §2 (failure taxonomy), Phase 1.
+#
+# Usage:
+#   scripts/agent_report.sh --target <name> -- <command> [args...]
+#
+# Behaviour:
+#   - The command's combined stdout+stderr is streamed through unchanged and
+#     also captured for best-effort classification.
+#   - A `trap ... EXIT` guarantees the verdict block is emitted last even if
+#     a phase aborts or the wrapper itself is interrupted.
+#   - SAILFIN_INNER guard: a nested invocation (e.g. `make check`'s inner
+#     `make test`) runs transparently and emits NO sentinel — only the outer
+#     target's verdict is printed. This wrapper sets SAILFIN_INNER=1 for the
+#     command it runs, so any wrapped sub-target it spawns is suppressed.
+#
+# Phase 1 is best-effort for `phase` and `first_error`; precise file:line
+# extraction by parsing tool JSON is Phase 3. This file touches no compiler
+# source — it is build orchestration only.
+
+set -uo pipefail
+
+# --- argument parsing --------------------------------------------------------
+TARGET=""
+while [ $# -gt 0 ]; do
+	case "$1" in
+		--target)
+			TARGET="${2:-}"
+			shift 2
+			;;
+		--)
+			shift
+			break
+			;;
+		*)
+			echo "agent_report.sh: unexpected argument '$1'" >&2
+			echo "usage: agent_report.sh --target <name> -- <command> [args...]" >&2
+			exit 2
+			;;
+	esac
+done
+
+if [ -z "$TARGET" ] || [ $# -eq 0 ]; then
+	echo "usage: agent_report.sh --target <name> -- <command> [args...]" >&2
+	exit 2
+fi
+
+# --- nested-invocation guard -------------------------------------------------
+# A wrapped target reached from inside another wrapped target (e.g. `make
+# check` -> `make test`) must NOT emit its own sentinel. Run transparently.
+if [ -n "${SAILFIN_INNER:-}" ]; then
+	exec "$@"
+fi
+# We are the outermost agent-facing target: claim the verdict and suppress
+# any nested wrapped targets the command spawns.
+export SAILFIN_INNER=1
+
+# --- output capture ----------------------------------------------------------
+OUTFILE="$(mktemp "${TMPDIR:-/tmp}/sailfin-agent-report.XXXXXX")"
+RC=0
+
+cleanup_outfile() {
+	rm -f "$OUTFILE" 2>/dev/null || true
+}
+
+# --- classification ----------------------------------------------------------
+# Best-effort. Reads $OUTFILE and $RC; sets STATUS / FAILURE / PHASE /
+# FIRST_ERROR. Patterns are deliberately conservative; the closed enums are
+# locked in docs/reference/make-result-schema.md.
+STATUS="pass"
+FAILURE="null"
+PHASE="null"
+FIRST_ERROR="null"
+
+# Match helper: case-insensitive fixed-ish regex over the captured output.
+out_has() { grep -Eiq -- "$1" "$OUTFILE" 2>/dev/null; }
+
+detect_check_phase() {
+	# Echo the last phase whose start-marker appears in the log. Markers are
+	# the human banners `make check` already prints (Makefile check: target).
+	local phase="null"
+	out_has '\[check\] running test suite on first-pass binary' && phase="first-pass-tests"
+	out_has 'proceeding to seedcheck build|verifying seed selfhost \(stage2\)' && phase="seedcheck-build"
+	out_has 'validating seedcheck binary can run programs' && phase="seedcheck-smoke"
+	out_has 'running test suite with seedcheck binary' && phase="seedcheck-tests"
+	out_has 'building stage3 for fixed-point' && phase="stage3-build"
+	out_has 'comparing stage2 vs stage3' && phase="fixed-point"
+	# If nothing matched yet we're still in the compile phase.
+	[ "$phase" = "null" ] && phase="compile"
+	printf '%s' "$phase"
+}
+
+detect_first_error() {
+	# Best-effort `file:line` (or `file:line:col`) pointer. Full extraction by
+	# parsing tool JSON is Phase 3; here we scrape the first source location.
+	local loc
+	loc="$(grep -Eo '[A-Za-z0-9_./-]+\.sfn:[0-9]+(:[0-9]+)?' "$OUTFILE" 2>/dev/null | head -n1)"
+	printf '%s' "$loc"
+}
+
+classify() {
+	# Nondeterminism is a non-fatal WARN even though `make check` exits 0.
+	# Surface it without flipping the exit code.
+	if out_has '\[check\]\[WARN\] stage2 != stage3'; then
+		STATUS="warn"
+		FAILURE="nondeterminism"
+		PHASE="fixed-point"
+		return
+	fi
+
+	if [ "$RC" -eq 0 ]; then
+		STATUS="pass"
+		FAILURE="null"
+		PHASE="null"
+		return
+	fi
+
+	# rc != 0 -> a real failure. Classify into the closed set.
+	STATUS="fail"
+
+	# OOM before timeout: an OOM-killed process can exit 137 (== timeout's
+	# SIGKILL code), so a memory signature wins the tie.
+	if out_has 'out of memory|cannot allocate memory|std::bad_alloc|bad_alloc|memory exhausted|virtual memory exhausted|LLVM ERROR: out of memory'; then
+		FAILURE="oom"
+	elif [ "$RC" -eq 124 ] || [ "$RC" -eq 137 ]; then
+		FAILURE="timeout"
+	elif out_has 'missing seed compiler|is not invokable|SEED_VERSION is empty|\[fetch-seed\]\[error\]|No such file or directory|run: make compile|run .make compile.|GITHUB_TOKEN'; then
+		FAILURE="setup-error"
+	elif out_has 'passed, [1-9][0-9]* failed|\[check\]\[FAIL\]|assertion failed|[0-9]+ failed ═══'; then
+		FAILURE="test-failure"
+	elif out_has 'error:|\[rebuild\]\[error\]|sfn build failed|cannot resolve|lowering error|parse error|type error|effect error'; then
+		FAILURE="compile-error"
+	else
+		# Unmatched: fall back to the target's most likely class.
+		case "$TARGET" in
+			test|test-unit|test-integration|test-e2e|test-capsules) FAILURE="test-failure" ;;
+			*) FAILURE="compile-error" ;;
+		esac
+	fi
+
+	# Best-effort phase + first_error.
+	if [ "$TARGET" = "check" ]; then
+		PHASE="$(detect_check_phase)"
+	else
+		PHASE="$TARGET"
+	fi
+	local fe
+	fe="$(detect_first_error)"
+	if [ -n "$fe" ]; then
+		FIRST_ERROR="$fe"
+	else
+		FIRST_ERROR="$PHASE"
+	fi
+}
+
+# --- JSON emission -----------------------------------------------------------
+# Emit a JSON value: the literal `null`, or a properly escaped string.
+json_val() {
+	local v="$1"
+	if [ "$v" = "null" ]; then
+		printf 'null'
+		return
+	fi
+	# Escape backslash, double-quote, and control chars for a JSON string.
+	v="${v//\\/\\\\}"
+	v="${v//\"/\\\"}"
+	v="${v//$'\t'/\\t}"
+	v="${v//$'\n'/\\n}"
+	v="${v//$'\r'/\\r}"
+	printf '"%s"' "$v"
+}
+
+emit_verdict() {
+	# Fired via trap on EXIT so the block is always the final output, even if
+	# the command aborts a phase or the wrapper is interrupted.
+	trap - EXIT
+	classify
+	{
+		printf '===SAILFIN-RESULT===\n'
+		printf '{"schema_version":"sailfin-make/1",'
+		printf '"target":%s,' "$(json_val "$TARGET")"
+		printf '"status":%s,' "$(json_val "$STATUS")"
+		printf '"failure":%s,' "$(json_val "$FAILURE")"
+		printf '"phase":%s,' "$(json_val "$PHASE")"
+		printf '"first_error":%s,' "$(json_val "$FIRST_ERROR")"
+		printf '"report":null}\n'
+		printf '===END-SAILFIN-RESULT===\n'
+	}
+	cleanup_outfile
+	exit "$RC"
+}
+
+trap emit_verdict EXIT
+
+# --- run the wrapped command -------------------------------------------------
+# Stream combined output through unchanged while capturing it for
+# classification. PIPESTATUS[0] is the command's real exit code.
+"$@" 2>&1 | tee "$OUTFILE"
+RC="${PIPESTATUS[0]}"
+
+# trap emit_verdict fires here on normal exit.
+exit "$RC"

--- a/scripts/agent_report.sh
+++ b/scripts/agent_report.sh
@@ -72,11 +72,19 @@ fi
 export SAILFIN_INNER=1
 
 # --- output capture ----------------------------------------------------------
-OUTFILE="$(mktemp "${TMPDIR:-/tmp}/sailfin-agent-report.XXXXXX")"
+# Capture combined output for classification. If mktemp fails (e.g. /tmp full
+# or unwritable) fall back to /dev/null: the command still streams through and
+# a verdict is still emitted (best-effort classification degrades to exit-code
+# only, since there's no captured text to scan).
+OUTFILE="$(mktemp "${TMPDIR:-/tmp}/sailfin-agent-report.XXXXXX" 2>/dev/null || echo /dev/null)"
 RC=0
 
 cleanup_outfile() {
-	rm -f "$OUTFILE" 2>/dev/null || true
+	# Only remove a real temp file — never the /dev/null fallback. Guarding on
+	# a regular file also keeps any rm error off the stream after the verdict.
+	if [ -f "$OUTFILE" ] && [ "$OUTFILE" != "/dev/null" ]; then
+		rm -f "$OUTFILE" 2>/dev/null || true
+	fi
 }
 
 # --- classification ----------------------------------------------------------
@@ -140,7 +148,7 @@ classify() {
 		FAILURE="oom"
 	elif [ "$RC" -eq 124 ] || [ "$RC" -eq 137 ]; then
 		FAILURE="timeout"
-	elif out_has 'missing seed compiler|is not invokable|SEED_VERSION is empty|\[fetch-seed\]\[error\]|No such file or directory|run: make compile|run .make compile.|GITHUB_TOKEN'; then
+	elif out_has "missing seed compiler|is not invokable|SEED_VERSION is empty|\[fetch-seed\]\[error\]|No such file or directory|run: make compile|run 'make compile'|GITHUB_TOKEN"; then
 		FAILURE="setup-error"
 	elif out_has 'passed, [1-9][0-9]* failed|\[check\]\[FAIL\]|assertion failed|[0-9]+ failed ═══'; then
 		FAILURE="test-failure"


### PR DESCRIPTION
## Summary

- Every agent-facing `make` target now ends — on success **and** failure — with a single greppable `===SAILFIN-RESULT===` JSON verdict block as its **final** output, so an agent can classify the outcome from a tail-truncated log. Phase 1 keystone of epic #1056.
- New `scripts/agent_report.sh` composes the verdict (always-last via a `trap … EXIT` idiom) and classifies `status`/`failure`. `SAILFIN_INNER` guard suppresses nested sentinels so `check`'s inner `make test` emits only the outer verdict.
- New `docs/reference/make-result-schema.md` documents `sailfin-make/1` (delimiters, fields, closed enums; consumers hard-fail on unknown `schema_version`).

Closes #1059

## ⚠️ Also includes a prerequisite compiler fix (separate commit)

While verifying the "`make test` passes" acceptance criterion, a **cold `make test` was red for every test** — unrelated to the Makefile work. Root cause: the lowered IR emits **duplicate identical `declare` lines** (e.g. `sfn_array_sfn_map` appears twice — once as a registered runtime helper, once as a `runtime/prelude.sfn` import; 28 dups total). LLVM's library merges identical declares, but **clang's textual-IR parser rejects them** ("invalid redefinition of function"), and that's exactly the path the test runner uses to build runtime objects (`_emit_runtime_sfn_to_obj` → `clang -c <module>.ll`).

It's masked in CI because the content-addressed runtime-object cache is keyed on **source content, not compiler version**, so a previously-good `.o` is reused and the duplicate `.ll` is never recompiled. Any fresh clone hits it. Confirmed reproducible with both the pinned seed (`0.7.0-alpha.25`) and `main` HEAD — long-standing latent bug, not a regression.

Fix (`10bf947`): a deterministic, order-preserving dedup of exact-duplicate column-0 `declare` lines at module finalize (after mangling), keeping the first occurrence — applied uniformly to all modules so the stage2==stage3 fixed point is unaffected. Prelude now emits 202/202 unique declares (was 230/202) and clang-compiles cleanly.

The compiler fix is a self-contained commit (`fix(emit): dedup duplicate module-scope declares`) cleanly separable from the Makefile/docs feature if a reviewer prefers to split it.

## Acceptance Criteria
- [x] Each listed target ends with the verdict block as its final lines, on passing and forced-failure runs
- [x] JSON validates against `sailfin-make/1`; `status` ∈ {pass,warn,fail}; `failure` ∈ closed set (or null on pass)
- [x] Forced `check` fixed-point mismatch → `status:"warn"`, `failure:"nondeterminism"`, exit 0 (verified via classifier)
- [x] `check`'s nested `make test` emits no inner sentinel (verified: `test`'s real run shows only the outer verdict; `compile`'s nested `rebuild` emits none)
- [x] `docs/reference/make-result-schema.md` exists and documents delimiters + field/enum set
- [x] No `compiler/src/*.sfn` changes *for the feature itself* — the compiler change is the separate prerequisite fix above
- [x] `make compile` self-hosts
- [x] `make test` passes (no regressions)

## Verification
```text
make compile      → status:"pass" verdict as final output ✓
make check-fast   → tail -5 | grep '===SAILFIN-RESULT===' → OK ✓
make test         → unit 124/124, integration 30/30, e2e 5/5,
                    capsules 30/30, e2e-sh 98/98 — exit 0, status:"pass" ✓
prelude emit (fixed) → 202/202 unique declares; clang -c OK ✓
standalone classifier → setup-error / test-failure / timeout / oom /
                        nondeterminism(warn,exit0) / pass all correct ✓
make check        → self-host + stage2==stage3 fixed-point gate (running)
```

## Files Changed
- `scripts/agent_report.sh` (new) — verdict composition + classification + inner-guard
- `Makefile` — `<target>`/`<target>-impl` wrappers on the nine agent-facing targets
- `docs/reference/make-result-schema.md` (new) — `sailfin-make/1` schema
- `compiler/src/llvm/lowering/lowering_core.sfn` — prerequisite declare-dedup fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CrUgmqZ3yhtnu3nQmdikLN)_