### PR TITLE
feat(cache): surface runtime object cache hits/misses in [cache] summary

### DIFF
--- a/compiler/src/build_cache.sfn
+++ b/compiler/src/build_cache.sfn
@@ -136,6 +136,23 @@ fn empty_cache_stats() -> CacheStats {
     };
 }
 
+// Field-wise sum of two `CacheStats`. Pure. Used to fold a
+// separately-accumulated layer's counters into the build-wide
+// total before the CLI prints the `[cache]` summary — e.g. the
+// runtime C/LL object cache (`cli_main.sfn`) accumulates its own
+// hits/misses while compiling `runtime/native/src/*` objects, then
+// merges them into the `.ll` module cache's `CacheStats` so the
+// single summary line reflects both layers (#915).
+fn merge_cache_stats(a: CacheStats, b: CacheStats) -> CacheStats {
+    return CacheStats {
+        hits: a.hits + b.hits,
+        misses: a.misses + b.misses,
+        stores: a.stores + b.stores,
+        invalid_keys: a.invalid_keys + b.invalid_keys,
+        copy_failures: a.copy_failures + b.copy_failures
+    };
+}
+
 // True iff the build produced no cache activity at all (zero
 // hits and zero misses). Useful for deciding whether to print
 // the cache summary line — empty stats from a manifest-less
@@ -712,6 +729,7 @@ export {
     sha256_of_file,
     runtime_object_cache_key,
     empty_cache_stats,
+    merge_cache_stats,
     cache_stats_is_empty,
     empty_build_cache_config,
     resolve_build_cache_config,

--- a/compiler/src/cli_main.sfn
+++ b/compiler/src/cli_main.sfn
@@ -6,6 +6,8 @@ import {
     CacheStats,
     cache_root,
     cache_stats_is_empty,
+    empty_cache_stats,
+    merge_cache_stats,
     resolve_build_cache_config,
     runtime_object_cache_key
 } from "./build_cache";
@@ -213,9 +215,18 @@ fn _write_llvm_text(path: string, llvm: string) ![io] {
 // or `--no-cache`). The shape is the human-readable counterpart of
 // the eventual `--json` build report's `cache` field; keep them in
 // sync if either changes.
+//
+// Emitted on stderr, not stdout. Since #915 folded the runtime
+// C/LL/sfn object cache into this summary, the line is non-empty on
+// nearly every `sfn build`/`sfn run` (runtime objects almost always
+// hit). For `sfn run` the driver's stdout is the program's stdout,
+// so a `[cache]` line there would corrupt program output (and any
+// downstream pipe). stderr keeps the diagnostic visible to humans /
+// `2>&1` captures while leaving stdout clean for the program and for
+// `--json`'s machine-readable report.
 fn _print_cache_summary(stats: CacheStats) ![io] {
     if cache_stats_is_empty(stats) { return; }
-    print("[cache] hits=" + number_to_string(stats.hits) + " misses="
+    print.err("[cache] hits=" + number_to_string(stats.hits) + " misses="
         + number_to_string(stats.misses)
         + " stores="
         + number_to_string(stats.stores)
@@ -302,14 +313,16 @@ fn _emit_capsule_artifact_sidecar(spec_capsule_name: string, spec_version: strin
 // placement (end of the success path); machine-readable consumers
 // (`sfn lsp`, MCP, CI gates) read this single line and parse it
 // rather than scraping `built: ...` + `[cache] ...` from stderr.
-fn _emit_build_report(input_path: string, out_path: string, kind: string, exit_code: int, capsule_result: ProjectCapsuleResult, cache_config: BuildCacheConfig) ![io] {
+fn _emit_build_report(input_path: string, out_path: string, kind: string, exit_code: int, capsule_result: ProjectCapsuleResult, cache_config: BuildCacheConfig, stats: CacheStats) ![io] {
     let mut report = empty_build_report();
     report.input = input_path;
     report.out = out_path;
     report.kind = kind;
     report.exit_code = exit_code;
     report.compiler_version = resolve_compiler_version("");
-    report.cache = capsule_result.stats;
+    // `stats` is the build-wide total (`.ll` module cache folded with
+    // the runtime object cache, #915), not just `capsule_result.stats`.
+    report.cache = stats;
     report.cache_root = cache_root();
     report.cache_enabled = cache_config.enabled;
     report.dep_ll_paths = capsule_result.ll_paths;
@@ -746,6 +759,11 @@ struct RuntimeLinkInputs {
     object_paths: string[];
     link_libs: string[];
     success: boolean;
+    // Runtime C/LL/sfn object-cache activity accumulated while
+    // compiling this capsule set (#915). Folded into the build-wide
+    // `CacheStats` so the end-of-build `[cache]` summary reflects
+    // runtime-object hits/misses, not just the `.ll` module cache.
+    stats: CacheStats;
 }
 
 fn _failed_runtime_link_inputs() -> RuntimeLinkInputs {
@@ -754,7 +772,8 @@ fn _failed_runtime_link_inputs() -> RuntimeLinkInputs {
     return RuntimeLinkInputs {
         object_paths: empty,
         link_libs: empty2,
-        success: false
+        success: false,
+        stats: empty_cache_stats()
     };
 }
 
@@ -819,6 +838,17 @@ fn _runtime_obj_cache_record(obj_path: string, key: string) ![io] {
 fn _clang_compile_runtime_capsule_objects(runtime_capsules: RuntimeCapsuleArtifacts[], out_dir: string, opt_flag: string) -> RuntimeLinkInputs ![io] {
     let mut objects: string[] = [];
     let mut link_libs: string[] = [];
+    // Per-call cache-stat accumulator (#915). Counting mirrors the
+    // `.ll` module cache (`capsule_resolver.sfn::_cr_compile_one`): a
+    // valid-key reuse is a `hit`; any recompile (the producer ran) is
+    // a `miss`; a successful `_runtime_obj_cache_record` is a `store`.
+    // An unhashable (empty) key additionally bumps `invalid_keys` —
+    // NOT disjoint from `misses`, matching the `.ll` layer where an
+    // invalid digest counts as both a miss and an invalid key
+    // (`lookup_attempted` stays true while `is_valid_digest` is
+    // false). It does not `store`: `_runtime_obj_cache_record` no-ops
+    // on an empty key.
+    let mut stats = empty_cache_stats();
     let mut i: int = 0;
     loop {
         if i >= runtime_capsules.length { break; }
@@ -850,7 +880,11 @@ fn _clang_compile_runtime_capsule_objects(runtime_capsules: RuntimeCapsuleArtifa
                 + opt_flag
                 + ".o");
             let key = runtime_object_cache_key(src, opt_flag);
+            if key.length == 0 {
+                stats.invalid_keys = stats.invalid_keys + 1;
+            }
             if !_runtime_obj_cache_hit(obj, key) {
+                stats.misses = stats.misses + 1;
                 let mut args: string[] = ["clang", opt_flag, "-Wno-override-module"];
                 // Per-function/per-datum sections so the final link's
                 // dead-strip (`--gc-sections` / `-dead_strip`) can drop
@@ -873,7 +907,8 @@ fn _clang_compile_runtime_capsule_objects(runtime_capsules: RuntimeCapsuleArtifa
                     return _failed_runtime_link_inputs();
                 }
                 _runtime_obj_cache_record(obj, key);
-            }
+                if key.length > 0 { stats.stores = stats.stores + 1; }
+            } else { stats.hits = stats.hits + 1; }
             objects.push(obj);
             ci += 1;
         }
@@ -888,7 +923,11 @@ fn _clang_compile_runtime_capsule_objects(runtime_capsules: RuntimeCapsuleArtifa
                 + opt_flag
                 + ".o");
             let key = runtime_object_cache_key(src, opt_flag);
+            if key.length == 0 {
+                stats.invalid_keys = stats.invalid_keys + 1;
+            }
             if !_runtime_obj_cache_hit(obj, key) {
+                stats.misses = stats.misses + 1;
                 let rc = process.run(["clang", opt_flag, "-Wno-override-module", "-ffunction-sections", "-fdata-sections", "-c", src, "-o", obj]);
                 if rc != 0 {
                     print("sfn build: failed to assemble runtime ll-source "
@@ -896,7 +935,8 @@ fn _clang_compile_runtime_capsule_objects(runtime_capsules: RuntimeCapsuleArtifa
                     return _failed_runtime_link_inputs();
                 }
                 _runtime_obj_cache_record(obj, key);
-            }
+                if key.length > 0 { stats.stores = stats.stores + 1; }
+            } else { stats.hits = stats.hits + 1; }
             objects.push(obj);
             li += 1;
         }
@@ -913,7 +953,8 @@ fn _clang_compile_runtime_capsule_objects(runtime_capsules: RuntimeCapsuleArtifa
     return RuntimeLinkInputs {
         object_paths: objects,
         link_libs: link_libs,
-        success: true
+        success: true,
+        stats: stats
     };
 }
 
@@ -979,7 +1020,17 @@ fn _resolve_self_path(binary_dir: string) -> string ![io] {
 // runtime capsule's `prelude-entry` is emitted by the *current*
 // compiler, so any drift between the two emit paths would surface as
 // a stage2≠stage3 mismatch.
-fn _emit_runtime_sfn_to_obj(self_path: string, cap_prefix: string, src: string, out_dir: string, opt_flag: string) -> string ![io] {
+// Result of a single runtime `.sfn` emit: the produced `.o` path
+// (`""` on failure) plus the cache-stat delta for this one source
+// (#915), so the caller can fold runtime-object hits/misses into the
+// build-wide `[cache]` summary.
+struct RuntimeEmitResult {
+    obj_path: string;
+    stats: CacheStats;
+}
+
+fn _emit_runtime_sfn_to_obj(self_path: string, cap_prefix: string, src: string, out_dir: string, opt_flag: string) -> RuntimeEmitResult ![io] {
+    let mut stats = empty_cache_stats();
     let slug = module_name_from_path(src);
     let ll_path = _path_join(out_dir, cap_prefix + _path_basename(src)
         + opt_flag
@@ -999,7 +1050,12 @@ fn _emit_runtime_sfn_to_obj(self_path: string, cap_prefix: string, src: string, 
     // mirrors the `_clang_compile_runtime_capsule_objects` c-source
     // path so the sfn-source + prelude emit invalidates identically.
     let key = runtime_object_cache_key(src, opt_flag);
-    if _runtime_obj_cache_hit(obj_path, key) { return obj_path; }
+    if key.length == 0 { stats.invalid_keys = stats.invalid_keys + 1; }
+    if _runtime_obj_cache_hit(obj_path, key) {
+        stats.hits = stats.hits + 1;
+        return RuntimeEmitResult { obj_path: obj_path, stats: stats };
+    }
+    stats.misses = stats.misses + 1;
     // Cache miss: regenerate the `.ll` unconditionally (a cached one
     // is stale by definition here), then compile the `.o` and record
     // the key. Build the `sh -c` argv: each `KEY= ` clears that toggle
@@ -1020,26 +1076,29 @@ fn _emit_runtime_sfn_to_obj(self_path: string, cap_prefix: string, src: string, 
             + " (child exit="
             + number_to_string(rc)
             + ")");
-        return "";
+        return RuntimeEmitResult { obj_path: "", stats: stats };
     }
     let rc2 = process.run(["clang", opt_flag, "-Wno-override-module", "-ffunction-sections", "-fdata-sections", "-c", ll_path, "-o", obj_path]);
     if rc2 != 0 {
         print("sfn build: failed to compile runtime sfn-source object "
             + obj_path);
-        return "";
+        return RuntimeEmitResult { obj_path: "", stats: stats };
     }
     _runtime_obj_cache_record(obj_path, key);
-    return obj_path;
+    if key.length > 0 { stats.stores = stats.stores + 1; }
+    return RuntimeEmitResult { obj_path: obj_path, stats: stats };
 }
 
 fn _compile_runtime_sfn_sources(runtime_capsules: RuntimeCapsuleArtifacts[], out_dir: string, opt_flag: string, binary_dir: string) -> RuntimeLinkInputs ![io] {
     let mut objects: string[] = [];
     let empty_libs: string[] = [];
+    let mut stats = empty_cache_stats();
     if _env_flag("SAILFIN_DISABLE_RUNTIME_SFN_SOURCES") {
         return RuntimeLinkInputs {
             object_paths: objects,
             link_libs: empty_libs,
-            success: true
+            success: true,
+            stats: stats
         };
     }
     // Quick path: nothing to do if no capsule declares sfn_sources.
@@ -1060,7 +1119,8 @@ fn _compile_runtime_sfn_sources(runtime_capsules: RuntimeCapsuleArtifacts[], out
         return RuntimeLinkInputs {
             object_paths: objects,
             link_libs: empty_libs,
-            success: true
+            success: true,
+            stats: stats
         };
     }
     let self_path = _resolve_self_path(binary_dir);
@@ -1080,9 +1140,12 @@ fn _compile_runtime_sfn_sources(runtime_capsules: RuntimeCapsuleArtifacts[], out
         loop {
             if si >= cap.sfn_sources.length { break; }
             let src = cap.sfn_sources[si];
-            let obj_path = _emit_runtime_sfn_to_obj(self_path, cap_prefix, src, out_dir, opt_flag);
-            if obj_path.length == 0 { return _failed_runtime_link_inputs(); }
-            objects.push(obj_path);
+            let emit = _emit_runtime_sfn_to_obj(self_path, cap_prefix, src, out_dir, opt_flag);
+            stats = merge_cache_stats(stats, emit.stats);
+            if emit.obj_path.length == 0 {
+                return _failed_runtime_link_inputs();
+            }
+            objects.push(emit.obj_path);
             si += 1;
         }
         i += 1;
@@ -1090,7 +1153,8 @@ fn _compile_runtime_sfn_sources(runtime_capsules: RuntimeCapsuleArtifacts[], out
     return RuntimeLinkInputs {
         object_paths: objects,
         link_libs: empty_libs,
-        success: true
+        success: true,
+        stats: stats
     };
 }
 
@@ -1109,10 +1173,14 @@ fn assemble_runtime_capsule_link_inputs(runtime_capsules: RuntimeCapsuleArtifact
     if !inputs.success { return _failed_runtime_link_inputs(); }
     let mut objects: string[] = inputs.object_paths;
     let link_libs: string[] = inputs.link_libs;
+    // Fold the c-source / ll-source layer's cache stats; the
+    // sfn-source and prelude-entry layers merge in below (#915).
+    let mut stats = inputs.stats;
     // `sfn-sources` + `prelude-entry` are materialized here (the
     // prelude rides the same emit path as of #940).
     let sfn_inputs = _compile_runtime_sfn_sources(runtime_capsules, out_dir, opt_flag, binary_dir);
     if !sfn_inputs.success { return _failed_runtime_link_inputs(); }
+    stats = merge_cache_stats(stats, sfn_inputs.stats);
     let mut soi: int = 0;
     loop {
         if soi >= sfn_inputs.object_paths.length { break; }
@@ -1155,11 +1223,12 @@ fn assemble_runtime_capsule_link_inputs(runtime_capsules: RuntimeCapsuleArtifact
             let cap = runtime_capsules[pi];
             if cap.prelude_entry.length > 0 {
                 let cap_prefix = _runtime_obj_prefix(cap.capsule_name);
-                let prelude_obj = _emit_runtime_sfn_to_obj(self_path, cap_prefix, cap.prelude_entry, out_dir, opt_flag);
-                if prelude_obj.length == 0 {
+                let prelude_emit = _emit_runtime_sfn_to_obj(self_path, cap_prefix, cap.prelude_entry, out_dir, opt_flag);
+                stats = merge_cache_stats(stats, prelude_emit.stats);
+                if prelude_emit.obj_path.length == 0 {
                     return _failed_runtime_link_inputs();
                 }
-                objects.push(prelude_obj);
+                objects.push(prelude_emit.obj_path);
             }
             pi += 1;
         }
@@ -1167,7 +1236,8 @@ fn assemble_runtime_capsule_link_inputs(runtime_capsules: RuntimeCapsuleArtifact
     return RuntimeLinkInputs {
         object_paths: objects,
         link_libs: link_libs,
-        success: true
+        success: true,
+        stats: stats
     };
 }
 
@@ -1234,17 +1304,30 @@ fn _runtime_retain_root_flags(runtime_objs: string[]) -> string[] ![io] {
     return flags;
 }
 
-fn _clang_link_with_opt(ll_path: string, out_path: string, runtime_root: string, runtime_capsules: RuntimeCapsuleArtifacts[], opt_flag: string, cache_dir: string, binary_dir: string) -> int ![io] {
+// Result of a runtime link: the clang exit code plus the runtime
+// object-cache stats the link accumulated (#915). The link is the
+// only place the runtime C/LL/sfn object cache is consulted, so the
+// caller folds `stats` into the build-wide `[cache]` summary.
+struct LinkResult {
+    rc: int;
+    stats: CacheStats;
+}
+
+fn _failed_link_result() -> LinkResult {
+    return LinkResult { rc: 1, stats: empty_cache_stats() };
+}
+
+fn _clang_link_with_opt(ll_path: string, out_path: string, runtime_root: string, runtime_capsules: RuntimeCapsuleArtifacts[], opt_flag: string, cache_dir: string, binary_dir: string) -> LinkResult ![io] {
     // Thin wrapper: most callers have one .ll; capsule-aware callers use
     // _clang_link_multi_with_opt directly.
     let single: string[] = [ll_path];
     return _clang_link_multi_with_opt(single, out_path, runtime_root, runtime_capsules, opt_flag, cache_dir, binary_dir);
 }
 
-fn _clang_link_multi_with_opt(ll_paths: string[], out_path: string, runtime_root: string, runtime_capsules: RuntimeCapsuleArtifacts[], opt_flag: string, cache_dir: string, binary_dir: string) -> int ![io] {
+fn _clang_link_multi_with_opt(ll_paths: string[], out_path: string, runtime_root: string, runtime_capsules: RuntimeCapsuleArtifacts[], opt_flag: string, cache_dir: string, binary_dir: string) -> LinkResult ![io] {
     if ll_paths.length == 0 {
         print("_clang_link_multi_with_opt: no input .ll files");
-        return 1;
+        return _failed_link_result();
     }
 
     // Cache runtime compilation products under `cache_dir`. With the
@@ -1275,10 +1358,12 @@ fn _clang_link_multi_with_opt(ll_paths: string[], out_path: string, runtime_root
         print("     expected " + root_display
             + "/native/capsule.toml (kind = \"runtime\")");
         print("     hint: ensure the runtime bundle ships alongside the compiler binary");
-        return 1;
+        return _failed_link_result();
     }
     let inputs = assemble_runtime_capsule_link_inputs(runtime_capsules, cache_dir, opt_flag, binary_dir);
-    if !inputs.success { return 1; }
+    if !inputs.success {
+        return LinkResult { rc: 1, stats: inputs.stats };
+    }
     runtime_objs = inputs.object_paths;
     runtime_link_libs = inputs.link_libs;
 
@@ -1332,16 +1417,17 @@ fn _clang_link_multi_with_opt(ll_paths: string[], out_path: string, runtime_root
         args.push(runtime_link_libs[lli]);
         lli += 1;
     }
-    return process.run(args);
+    let rc = process.run(args);
+    return LinkResult { rc: rc, stats: inputs.stats };
 }
 
-fn _clang_link(ll_path: string, out_path: string, runtime_root: string, runtime_capsules: RuntimeCapsuleArtifacts[], binary_dir: string, cache_dir: string) -> int ![io] {
+fn _clang_link(ll_path: string, out_path: string, runtime_root: string, runtime_capsules: RuntimeCapsuleArtifacts[], binary_dir: string, cache_dir: string) -> LinkResult ![io] {
     // Default link used by `build` and `run` for single-module programs.
     let resolved_cache_dir = _resolve_sailfin_cache_dir(cache_dir);
     return _clang_link_with_opt(ll_path, out_path, runtime_root, runtime_capsules, "-O2", resolved_cache_dir, binary_dir);
 }
 
-fn _clang_link_multi(ll_paths: string[], out_path: string, runtime_root: string, runtime_capsules: RuntimeCapsuleArtifacts[], binary_dir: string, cache_dir: string) -> int ![io] {
+fn _clang_link_multi(ll_paths: string[], out_path: string, runtime_root: string, runtime_capsules: RuntimeCapsuleArtifacts[], binary_dir: string, cache_dir: string) -> LinkResult ![io] {
     // Default link used by `build` and `run` for multi-module programs
     // (main source + capsule dependency modules). `cache_dir` is the
     // sailfin-side scratch root (`build/sailfin` for legacy in-tree
@@ -2113,7 +2199,10 @@ fn sailfin_cli_main(argv: string[]) -> int ![io, clock] {
                 return rc_obj;
             }
             if json_flag {
-                _emit_build_report(input_path, out_path, "library", 0, capsule_result, cache_config);
+                // Library builds stop after `clang -c` — no runtime
+                // link, so there's no runtime object-cache activity to
+                // fold; `capsule_result.stats` is the full total.
+                _emit_build_report(input_path, out_path, "library", 0, capsule_result, cache_config, capsule_result.stats);
             } else {
                 print("built: " + out_path);
                 _print_cache_summary(capsule_result.stats);
@@ -2151,18 +2240,31 @@ fn sailfin_cli_main(argv: string[]) -> int ![io, clock] {
         if build_runtime_caps.length == 0 {
             build_runtime_caps = runtime_capsule_from_root(runtime_root);
         }
-        let rc = _clang_link_multi(all_lls, exe_path, runtime_root, build_runtime_caps, binary_dir, sailfin_cache_dir);
+        let link_result = _clang_link_multi(all_lls, exe_path, runtime_root, build_runtime_caps, binary_dir, sailfin_cache_dir);
+        let rc = link_result.rc;
         if rc != 0 {
             if !json_flag {
                 print("link failed (clang exit=" + number_to_string(rc) + ")");
             }
             return rc;
         }
+        // Fold the runtime object-cache stats accumulated during the
+        // link into the `.ll` module cache total so the single
+        // `[cache]` summary reflects both layers (#915). Gated on
+        // `cache_config.enabled`: under `--no-cache` the module cache
+        // is never consulted (counters stay zero), and the runtime
+        // object cache — which has no `--no-cache` gate of its own —
+        // must not resurrect a non-zero summary, so its stats are not
+        // folded when caching is disabled.
+        let mut build_cache_stats = capsule_result.stats;
+        if cache_config.enabled {
+            build_cache_stats = merge_cache_stats(capsule_result.stats, link_result.stats);
+        }
         if json_flag {
-            _emit_build_report(input_path, exe_path, "binary", 0, capsule_result, cache_config);
+            _emit_build_report(input_path, exe_path, "binary", 0, capsule_result, cache_config, build_cache_stats);
         } else {
             print("built: " + exe_path);
-            _print_cache_summary(capsule_result.stats);
+            _print_cache_summary(build_cache_stats);
         }
         // Stage C2a: per-capsule artifact sidecar for `-p` builds.
         // No-op for positional builds (cap_capsule_name == "").
@@ -2277,7 +2379,8 @@ fn sailfin_cli_main(argv: string[]) -> int ![io, clock] {
         if run_runtime_caps.length == 0 {
             run_runtime_caps = runtime_capsule_from_root(runtime_root);
         }
-        let link_rc = _clang_link_multi(all_lls, exe_path, runtime_root, run_runtime_caps, binary_dir, "");
+        let link_result = _clang_link_multi(all_lls, exe_path, runtime_root, run_runtime_caps, binary_dir, "");
+        let link_rc = link_result.rc;
         if link_rc != 0 {
             // A native link failure is a real compiler/runtime bug to
             // fix at the source — never paper over it. The prior
@@ -2292,8 +2395,15 @@ fn sailfin_cli_main(argv: string[]) -> int ![io, clock] {
         // Cache summary mirrors `sfn build`: quiet for builds with no
         // cache activity (no manifest deps, or `--no-cache`), and the
         // human-readable counterpart of the eventual `--json` build
-        // report's `cache` field.
-        _print_cache_summary(run_capsule_result.stats);
+        // report's `cache` field. Runtime object-cache stats fold in
+        // alongside the `.ll` module cache total (#915), gated on
+        // `run_cache_config.enabled` so `--no-cache` stays quiet (see
+        // the `sfn build` fold site for the rationale).
+        let mut run_cache_stats = run_capsule_result.stats;
+        if run_cache_config.enabled {
+            run_cache_stats = merge_cache_stats(run_capsule_result.stats, link_result.stats);
+        }
+        _print_cache_summary(run_cache_stats);
         let run_rc = process.run([exe_path]);
         return run_rc;
     }

--- a/compiler/src/cli_main.sfn
+++ b/compiler/src/cli_main.sfn
@@ -312,7 +312,8 @@ fn _emit_capsule_artifact_sidecar(spec_capsule_name: string, spec_version: strin
 // JSON encoding to stdout. Mirrors `_print_cache_summary`'s
 // placement (end of the success path); machine-readable consumers
 // (`sfn lsp`, MCP, CI gates) read this single line and parse it
-// rather than scraping `built: ...` + `[cache] ...` from stderr.
+// rather than scraping the human text output (`built: ...` on
+// stdout, `[cache] ...` on stderr since #915).
 fn _emit_build_report(input_path: string, out_path: string, kind: string, exit_code: int, capsule_result: ProjectCapsuleResult, cache_config: BuildCacheConfig, stats: CacheStats) ![io] {
     let mut report = empty_build_report();
     report.input = input_path;

--- a/compiler/tests/e2e/test_build_json_schema.sh
+++ b/compiler/tests/e2e/test_build_json_schema.sh
@@ -106,14 +106,19 @@ test_top_level_fields() {
 run_test "top-level fields present (command/kind/exit_code/input/version)" test_top_level_fields
 
 # ---- Test 4: cold build cache stats are miss + store ----
+# #915: the runtime C/LL/sfn object cache folds into `.cache`. The
+# cold build runs in a fresh $SCRATCH cwd, so the runtime objects
+# (under $SCRATCH/build/sailfin) are cold too — adding misses/stores
+# on top of the single `sfn/math` .ll module miss. Assert the cold
+# shape (hits=0, miss/store>=1) rather than exact `.ll`-only counts.
 test_cold_cache_stats() {
     [ "$(jq -r .cache.hits "$SCRATCH/cold.json")" = "0" ] || return 1
-    [ "$(jq -r .cache.misses "$SCRATCH/cold.json")" = "1" ] || return 1
-    [ "$(jq -r .cache.stores "$SCRATCH/cold.json")" = "1" ] || return 1
+    [ "$(jq -r .cache.misses "$SCRATCH/cold.json")" -ge 1 ] || return 1
+    [ "$(jq -r .cache.stores "$SCRATCH/cold.json")" -ge 1 ] || return 1
     [ "$(jq -r .cache.enabled "$SCRATCH/cold.json")" = "true" ] || return 1
     [ -n "$(jq -r .cache.root "$SCRATCH/cold.json")" ] || return 1
 }
-run_test "cold build cache stats: hits=0 misses=1 stores=1 enabled=true" test_cold_cache_stats
+run_test "cold build cache stats: hits=0 miss/store>=1 enabled=true" test_cold_cache_stats
 
 # ---- Test 4b: cold build hit_rate is numeric (0 / 1 = 0.0) ----
 # Issue #780: jq must read .cache.hit_rate as a number, never null
@@ -190,12 +195,14 @@ test_warm_cache_hit() {
         return $rc
     fi
     jq . "$SCRATCH/warm.json" > /dev/null 2>&1 || return 1
-    [ "$(jq -r .cache.hits "$SCRATCH/warm.json")" = "1" ] || return 1
+    # #915: both the `.ll` math module and the runtime objects are now
+    # cached, so hits>=1 with zero misses.
+    [ "$(jq -r .cache.hits "$SCRATCH/warm.json")" -ge 1 ] || return 1
     [ "$(jq -r .cache.misses "$SCRATCH/warm.json")" = "0" ] || return 1
-    # #780: warm cache is fully saturated (1 hit, 0 misses) → 1.0.
+    # #780: warm cache is fully saturated (0 misses) → hit_rate 1.0.
     [ "$(jq -r '.cache.hit_rate == 1' "$SCRATCH/warm.json")" = "true" ] || return 1
 }
-run_test "warm build cache.hits=1 misses=0 hit_rate=1.0" test_warm_cache_hit
+run_test "warm build cache.hits>=1 misses=0 hit_rate=1.0" test_warm_cache_hit
 
 # ---- Test 9: --no-cache + --json composes ----
 test_json_with_no_cache() {

--- a/compiler/tests/e2e/test_run_cache_flags.sh
+++ b/compiler/tests/e2e/test_run_cache_flags.sh
@@ -85,10 +85,16 @@ test_run_backwards_compat() {
 run_test "sfn run <file> still works (no flags)" test_run_backwards_compat
 
 # ---- Test 2: cold run prints summary with miss + store ----
+# #915: the runtime C/LL/sfn object cache folds into this same line.
+# The run executes in a fresh $SCRATCH cwd, so its runtime objects
+# (under $SCRATCH/build/sailfin) are also cold — adding misses/stores
+# on top of the single `sfn/math` .ll module miss. Assert the cold
+# shape (hits=0, miss>=1, store>=1) rather than exact `.ll`-only
+# counts.
 test_first_run_summary() {
-    grep -qE '^\[cache\] hits=0 misses=1 stores=1' "$SCRATCH/run1.stdout"
+    grep -qE '^\[cache\] hits=0 misses=[1-9][0-9]* stores=[1-9][0-9]*' "$SCRATCH/run1.stdout"
 }
-run_test "first run prints '[cache] hits=0 misses=1 stores=1'" test_first_run_summary
+run_test "first run prints cold cache summary (hits=0, miss/store>=1)" test_first_run_summary
 
 # ---- Test 3: warm run prints summary with a hit ----
 test_warm_run_hit() {
@@ -101,9 +107,11 @@ test_warm_run_hit() {
         cat "$SCRATCH/run2.stdout" >&2
         return $rc
     fi
-    grep -qE '^\[cache\] hits=1 misses=0' "$SCRATCH/run2.stdout"
+    # #915: warm run — both the `.ll` math module and the runtime
+    # objects are now cached, so hits>=1 with zero misses.
+    grep -qE '^\[cache\] hits=[1-9][0-9]* misses=0( |$)' "$SCRATCH/run2.stdout"
 }
-run_test "warm run prints '[cache] hits=1 misses=0'" test_warm_run_hit
+run_test "warm run prints warm cache summary (hits>=1, misses=0)" test_warm_run_hit
 
 # ---- Test 4: --no-cache suppresses the summary line entirely ----
 test_no_cache_suppresses_summary() {
@@ -156,9 +164,13 @@ test_clean_wipes_cache() {
         cat "$SCRATCH/run_clean.stdout" >&2
         return $rc
     fi
-    # After --clean the build path repopulates the cache: miss + store,
-    # NOT a hit.
-    grep -qE '^\[cache\] hits=0 misses=1 stores=1' "$SCRATCH/run_clean.stdout"
+    # After --clean the `.ll` module cache is wiped and repopulated:
+    # miss + store. #915: `--clean` wipes only the `.ll` cache root
+    # ($CACHE_DIR/v1), NOT the runtime object cache under
+    # $SCRATCH/build/sailfin, so the runtime objects still hit. Assert
+    # the re-miss of the `.ll` module (miss>=1, store>=1) without
+    # constraining the (now non-zero) runtime hits.
+    grep -qE '^\[cache\] hits=[0-9]+ misses=[1-9][0-9]* stores=[1-9][0-9]*' "$SCRATCH/run_clean.stdout"
 }
 run_test "sfn run --clean wipes the cache and rebuilds" test_clean_wipes_cache
 

--- a/compiler/tests/e2e/test_runtime_adapter_filesystem.sh
+++ b/compiler/tests/e2e/test_runtime_adapter_filesystem.sh
@@ -353,9 +353,13 @@ fn main() -> int ![io] {
     return 0;
 }
 PROBE
-    if ! "$BINARY" run "$probe" > "$out_log" 2>&1; then
+    # #915: capture stdout separately from stderr. The driver folds the
+    # runtime object cache into the `[cache]` summary, which now prints
+    # (to stderr) on nearly every `sfn run`; a combined `2>&1` capture
+    # would corrupt the round-trip stdout comparison below.
+    if ! "$BINARY" run "$probe" > "$out_log" 2> "$out_log.err"; then
         echo "[test]   sfn run round_trip_probe.sfn failed:"
-        cat "$out_log"
+        cat "$out_log" "$out_log.err"
         return 1
     fi
     # Expected stdout (each `print` adds a trailing newline):
@@ -415,9 +419,11 @@ fn main() -> int ![io] {
 }
 PROBE
     local out_log="$SCRATCH/large.log"
-    if ! "$BINARY" run "$probe" > "$out_log" 2>&1; then
+    # #915: capture stdout separately (see test_round_trip_file) so the
+    # stderr `[cache]` summary cannot inflate the byte-exact payload diff.
+    if ! "$BINARY" run "$probe" > "$out_log" 2> "$out_log.err"; then
         echo "[test]   sfn run large_probe.sfn failed:"
-        head -20 "$out_log"
+        head -20 "$out_log" "$out_log.err"
         return 1
     fi
     # `print` always appends a trailing newline; the expected

--- a/compiler/tests/e2e/test_runtime_c_cache_invalidates.sh
+++ b/compiler/tests/e2e/test_runtime_c_cache_invalidates.sh
@@ -108,6 +108,17 @@ run_test "runtime object + content-key sidecar produced on first build" \
 
 T1="$(mtime_of "$RUNTIME_OBJ")"
 
+# The `[cache]` summary line `_print_cache_summary` emits to stdout
+# (captured in build.log). Since #915 the runtime C/LL/sfn object
+# cache folds its hits/misses into this same line, so the counts
+# below are attributable to the runtime objects (the one-line
+# program has no `.ll` module-cache deps of its own). Helpers parse
+# the `hits=`/`misses=` fields out of the most recent build's log.
+summary_field() {
+    # summary_field <field-name> -> integer value (or "" if no line)
+    sed -nE "s/.*\[cache\] .*${1}=([0-9]+).*/\1/p" "$SCRATCH/build.log" | tail -n1
+}
+
 # ---- Pure mtime touch: content unchanged MUST cache-hit ----
 # Sleep 1s so any recompile would produce a strictly newer mtime
 # (filesystem mtime granularity is 1s in the worst case).
@@ -125,6 +136,30 @@ check_touch_is_cache_hit() {
 run_test "pure mtime touch (content unchanged) cache-hits" \
     check_touch_is_cache_hit
 
+# #915: a no-op rebuild reports the runtime objects as cache hits,
+# with zero misses, in the `[cache]` summary line.
+check_noop_rebuild_summary_hits() {
+    local hits misses
+    hits="$(summary_field hits)"
+    misses="$(summary_field misses)"
+    if [ -z "$hits" ]; then
+        echo "  expected a [cache] summary line after no-op rebuild, found none" >&2
+        cat "$SCRATCH/build.log" >&2
+        return 1
+    fi
+    if [ "$hits" -lt 1 ]; then
+        echo "  expected runtime-object cache hits>=1 on no-op rebuild, got hits=$hits" >&2
+        return 1
+    fi
+    if [ "${misses:-0}" -ne 0 ]; then
+        echo "  expected misses=0 on no-op rebuild, got misses=$misses" >&2
+        return 1
+    fi
+    return 0
+}
+run_test "no-op rebuild summary reports runtime hits (misses=0) (#915)" \
+    check_noop_rebuild_summary_hits
+
 # ---- Content edit MUST cache-miss (the regression this fixes) ----
 sleep 1
 printf '\n/* #632 runtime C-object cache invalidation probe */\n' >> "$C_SRC"
@@ -139,6 +174,27 @@ check_content_edit_is_cache_miss() {
 }
 run_test "content edit busts the cache (object recompiled)" \
     check_content_edit_is_cache_miss
+
+# #915: the same content-edit rebuild surfaces >=1 miss in the
+# `[cache]` summary — the observability gap #632 deferred. Before
+# this fix the line read `misses=0` even though the `.o` recompiled.
+check_content_edit_summary_miss() {
+    local misses
+    misses="$(summary_field misses)"
+    if [ -z "$misses" ]; then
+        echo "  expected a [cache] summary line after content edit, found none" >&2
+        cat "$SCRATCH/build.log" >&2
+        return 1
+    fi
+    if [ "$misses" -lt 1 ]; then
+        echo "  expected runtime-object cache misses>=1 after content edit, got misses=$misses" >&2
+        cat "$SCRATCH/build.log" >&2
+        return 1
+    fi
+    return 0
+}
+run_test "content edit surfaces a miss in the [cache] summary (#915)" \
+    check_content_edit_summary_miss
 
 echo "[test] runtime C-object cache: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]

--- a/compiler/tests/e2e/test_runtime_c_cache_invalidates.sh
+++ b/compiler/tests/e2e/test_runtime_c_cache_invalidates.sh
@@ -108,12 +108,13 @@ run_test "runtime object + content-key sidecar produced on first build" \
 
 T1="$(mtime_of "$RUNTIME_OBJ")"
 
-# The `[cache]` summary line `_print_cache_summary` emits to stdout
-# (captured in build.log). Since #915 the runtime C/LL/sfn object
-# cache folds its hits/misses into this same line, so the counts
-# below are attributable to the runtime objects (the one-line
-# program has no `.ll` module-cache deps of its own). Helpers parse
-# the `hits=`/`misses=` fields out of the most recent build's log.
+# The `[cache]` summary line `_print_cache_summary` emits to stderr
+# (#915); `build.log` still captures it because `do_build` redirects
+# `2>&1`. Since #915 the runtime C/LL/sfn object cache folds its
+# hits/misses into this same line, so the counts below are
+# attributable to the runtime objects (the one-line program has no
+# `.ll` module-cache deps of its own). Helpers parse the
+# `hits=`/`misses=` fields out of the most recent build's log.
 summary_field() {
     # summary_field <field-name> -> integer value (or "" if no line)
     sed -nE "s/.*\[cache\] .*${1}=([0-9]+).*/\1/p" "$SCRATCH/build.log" | tail -n1

--- a/compiler/tests/unit/build_cache_test.sfn
+++ b/compiler/tests/unit/build_cache_test.sfn
@@ -43,7 +43,8 @@ import {
     cache_compiler_identity,
     empty_build_cache_config,
     empty_cache_stats,
-    is_valid_digest
+    is_valid_digest,
+    merge_cache_stats
 } from "../../src/build_cache";
 
 // --------------------------------------------------------------
@@ -560,6 +561,38 @@ test "build_cache: cache_stats_is_empty false when any counter is non-zero" {
     let mut t = empty_cache_stats();
     t.copy_failures = 1;
     assert ! cache_stats_is_empty(t);
+}
+
+test "build_cache: merge_cache_stats sums every counter field-wise" {
+    let mut a = empty_cache_stats();
+    a.hits = 1;
+    a.misses = 2;
+    a.stores = 3;
+    a.invalid_keys = 4;
+    a.copy_failures = 5;
+    let mut b = empty_cache_stats();
+    b.hits = 10;
+    b.misses = 20;
+    b.stores = 30;
+    b.invalid_keys = 40;
+    b.copy_failures = 50;
+    let m = merge_cache_stats(a, b);
+    assert m.hits == 11;
+    assert m.misses == 22;
+    assert m.stores == 33;
+    assert m.invalid_keys == 44;
+    assert m.copy_failures == 55;
+}
+
+test "build_cache: merge_cache_stats with empty is identity" {
+    let mut a = empty_cache_stats();
+    a.hits = 7;
+    a.misses = 9;
+    let m = merge_cache_stats(a, empty_cache_stats());
+    assert m.hits == 7;
+    assert m.misses == 9;
+    assert m.stores == 0;
+    assert cache_stats_is_empty(merge_cache_stats(empty_cache_stats(), empty_cache_stats()));
 }
 
 test "build_cache: empty_build_cache_config defaults are enabled+quiet" {

--- a/docs/status.md
+++ b/docs/status.md
@@ -138,6 +138,23 @@ feature availability.
     MCP server's structured compile feedback, CI cache-hit-rate
     gates, and future structured link errors (proposal §4.11 —
     the `diagnostics: []` slot is the forward-compat hook).
+  - **Runtime object-cache observability (#915)** — the runtime
+    C/LL/sfn object cache (`runtime_object_cache_key`, #632) now
+    threads a `CacheStats` accumulator through
+    `_clang_compile_runtime_capsule_objects`,
+    `_emit_runtime_sfn_to_obj`, and `_compile_runtime_sfn_sources`,
+    folded via `merge_cache_stats` into the same `[cache]` summary
+    the `.ll` module cache feeds. Editing a `runtime/native/src/*.c`
+    source now surfaces a `misses=N` (was silently `misses=0`); a
+    no-op rebuild shows the runtime objects as `hits`. Both the
+    human summary and `sfn build --json`'s `cache` field reflect
+    both layers. Counting matches the `.ll` layer (an unhashable key
+    is both a miss and an `invalid_key`). Because runtime objects are
+    almost always cached, the summary is now non-empty on nearly
+    every build/run, so `_print_cache_summary` moved from stdout to
+    **stderr** (keeping `sfn run`'s program stdout and `--json`'s
+    report clean), and the runtime fold is gated on
+    `cache_config.enabled` so `--no-cache` still reports zero.
 - **Stage C2 per-capsule artifact layout (in flight, 2026-04-28).**
   Three PRs land the §4.4 layout (`build/capsules/<scope>/<name>/`)
   for everything `sfn build -p` produces:

--- a/docs/status.md
+++ b/docs/status.md
@@ -149,7 +149,7 @@ feature availability.
     no-op rebuild shows the runtime objects as `hits`. Both the
     human summary and `sfn build --json`'s `cache` field reflect
     both layers. Counting matches the `.ll` layer (an unhashable key
-    is both a miss and an `invalid_key`). Because runtime objects are
+    is both a miss and an `invalid_keys`). Because runtime objects are
     almost always cached, the summary is now non-empty on nearly
     every build/run, so `_print_cache_summary` moved from stdout to
     **stderr** (keeping `sfn run`'s program stdout and `--json`'s


### PR DESCRIPTION
## Summary
- Thread a `CacheStats` accumulator through the runtime C/LL/sfn object-compile path (`_clang_compile_runtime_capsule_objects`, `_emit_runtime_sfn_to_obj`, `_compile_runtime_sfn_sources`) and fold it via a new `merge_cache_stats` helper into the same `[cache]` summary the `.ll` module cache feeds — for both the human line and `sfn build --json`'s `cache` field. Closes the #632 observability gap (editing a `runtime/native/src/*.c` source previously still read `misses=0`).
- Counting matches the incumbent `.ll` module cache (`_cr_compile_one`): valid-key reuse = `hit`; any recompile = `miss`; successful record = `store`; an unhashable key is **both** a miss and an `invalid_key`.

Closes #915

## Design note (resolved with maintainer)
Because runtime objects are almost always cached, folding their stats in makes the summary non-empty on nearly every `sfn build`/`sfn run`. To avoid corrupting `sfn run`'s program stdout (and the `--json` machine report), **`_print_cache_summary` moved from stdout → stderr**, and the runtime fold is **gated on `cache_config.enabled`** so `--no-cache` still reports zero counters. This also fixed a latent stdout-pollution path. Scope therefore expanded beyond the issue's listed test to update two exact-count contract tests and isolate stdout in one round-trip test (see below).

## Acceptance Criteria
- [x] After a content edit to a `runtime/native/src/*.c` source, the next `sfn build` summary shows ≥1 `misses` attributable to the runtime object cache (no longer `misses=0`).
- [x] A no-op rebuild shows the runtime objects as `hits` in the summary.
- [x] `cache_stats_is_empty` / "don't print on empty" logic still holds (and `--no-cache` stays quiet via the `enabled` gate).
- [x] `make compile` self-hosts.
- [x] `make test` passes (e2e-sh 99/99).
- [x] `sfn fmt --check` clean on every touched `.sfn` file.

## Verification
```text
make compile                         → status: pass (self-hosts)
make test                            → e2e-sh 99/99 passed, 0 failed; status: pass
test_runtime_c_cache_invalidates.sh  → 5/5 (incl. 2 new #915 assertions)
test_run_cache_flags.sh              → 6/6
test_build_json_schema.sh            → 11/11
test_closure_capture.sh              → 3/3 (fixed by stderr routing)
test_runtime_adapter_filesystem.sh   → 12/12 (stdout isolated for round-trips)
```

## Files Changed
- `compiler/src/build_cache.sfn` — `merge_cache_stats` helper (+ export).
- `compiler/src/cli_main.sfn` — `CacheStats` threaded through the runtime object path; new `RuntimeEmitResult`/`LinkResult` structs; `_clang_link*` return `LinkResult`; fold gated on `cache_config.enabled`; summary → stderr; `_emit_build_report` takes the merged stats.
- `compiler/tests/unit/build_cache_test.sfn` — `merge_cache_stats` unit tests.
- `compiler/tests/e2e/test_runtime_c_cache_invalidates.sh` — assert summary hits/misses (#915).
- `compiler/tests/e2e/test_run_cache_flags.sh`, `test_build_json_schema.sh` — relax exact `.ll`-only counts to tolerate the folded runtime objects (intent preserved; `--no-cache` still asserts zero).
- `compiler/tests/e2e/test_runtime_adapter_filesystem.sh` — capture round-trip stdout separately from stderr.
- `docs/status.md` — note the fold-in, stderr routing, and `--no-cache` gating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VH66V9gKcy86XVmMfxCCpn)_