### PR TITLE
sfn/cli: structured help tree (HelpNode) behind byte-identical help

### DIFF
--- a/capsules/sfn/cli/src/help.sfn
+++ b/capsules/sfn/cli/src/help.sfn
@@ -1,40 +1,111 @@
 // sfn/cli — help text formatting.
 //
-// Renders the `--help` output for a `Command`: usage line, subcommands,
-// positional arguments, and flag rows. The `help()` function returns
-// the rendered string; `print_help()` writes it to stdout.
+// Renders the `--help` output for a `Command`. Help is produced in two
+// stages: `render_help_tree(cmd)` builds a structured, render-agnostic
+// `HelpNode`, and `render_help_text(node)` turns that tree into the
+// `--help` string. `help()` composes the two and returns the string;
+// `print_help()` writes it to stdout. Splitting data (tree) from
+// formatting (text) is the foundation for `--help --json` (Phase 5
+// Issue 5.1) and keeps the text and future JSON renderers from drifting
+// — both consume the same tree (proposal §8 risk R8).
 //
 // Note: `_pad` lives here (not in `parser.sfn` as listed in the
 // modularization proposal §3.1) because it is only used by the help
 // renderer. Keeping it next to its only caller avoids a circular import
 // between `parser.sfn` (which calls `_format_help`) and `help.sfn`.
-import { Arg, Command, Flag } from "./types";
+import {
+    Command,
+    HelpFlag,
+    HelpNode,
+    HelpPositional
+} from "./types";
 
 fn help(cmd: Command) -> string {
     // Generate help text for a command.
-    return _format_help(cmd, cmd.name);
+    return render_help_text(render_help_tree(cmd));
 }
 
 fn print_help(cmd: Command) -> void ![io] {
     // Print help text for a command to stdout.
-    print(_format_help(cmd, cmd.name));
+    print(render_help_text(render_help_tree(cmd)));
 }
 
-fn _format_help(cmd: Command, program: string) -> string {
-    let mut out: string = "";
+fn render_help_tree(cmd: Command) -> HelpNode {
+    // Build the structured help representation of a command. Pure (no
+    // `![io]`). Subcommands recurse so the whole tree is available to
+    // consumers; the text renderer descends only one level for the
+    // `commands:` listing (multi-level walking is Issue 1.14).
+    let mut flags: HelpFlag[] = [];
+    let mut fi: int = 0;
+    loop {
+        if fi >= cmd.flags.length { break; }
+        let f = cmd.flags[fi];
+        flags.push(HelpFlag {
+            long_name: f.long_name, short_name: f.short_name, description: f.description, takes_value: f.takes_value, required: f.required, env_var: f.env_var
+        });
+        fi += 1;
+    }
 
-    // Description.
-    if cmd.description.length > 0 { out = out + cmd.description + "\n\n"; }
-
-    // Usage line.
-    out = out + "usage:\n";
-    out = out + "  " + program;
-    if cmd.subcmds.length > 0 { out = out + " <command>"; }
-    if cmd.flags.length > 0 { out = out + " [options]"; }
+    let mut positionals: HelpPositional[] = [];
     let mut ai: int = 0;
     loop {
         if ai >= cmd.args.length { break; }
         let a = cmd.args[ai];
+        positionals.push(HelpPositional {
+            name: a.name, description: a.description, is_optional: a.is_optional, is_variadic: a.is_variadic, default_value: a.default_value
+        });
+        ai += 1;
+    }
+
+    let mut subcommands: HelpNode[] = [];
+    let mut si: int = 0;
+    loop {
+        if si >= cmd.subcmds.length { break; }
+        subcommands.push(render_help_tree(cmd.subcmds[si]));
+        si += 1;
+    }
+
+    return HelpNode {
+        name: cmd.name,
+        description: cmd.description,
+        version: cmd.version,
+        flags: flags,
+        positionals: positionals,
+        subcommands: subcommands
+    };
+}
+
+fn render_help_text(node: HelpNode) -> string {
+    // Render a `HelpNode` into the `--help` string. Pure (no `![io]`).
+    // The usage-line program name is `node.name`.
+    return _render_help_text(node, node.name);
+}
+
+fn _format_help(cmd: Command, program: string) -> string {
+    // Render help for `cmd` with an explicit program label for the usage
+    // line. Retained for `parser.sfn`, which threads the full descent
+    // label (e.g. `sfn build`) for a matched subcommand while the node's
+    // own name is just the leaf (`build`). Routes through the same tree
+    // + renderer as `render_help_text` so the two cannot drift
+    // (proposal §8 risk R8).
+    return _render_help_text(render_help_tree(cmd), program);
+}
+
+fn _render_help_text(node: HelpNode, program: string) -> string {
+    let mut out: string = "";
+
+    // Description.
+    if node.description.length > 0 { out = out + node.description + "\n\n"; }
+
+    // Usage line.
+    out = out + "usage:\n";
+    out = out + "  " + program;
+    if node.subcommands.length > 0 { out = out + " <command>"; }
+    if node.flags.length > 0 { out = out + " [options]"; }
+    let mut ai: int = 0;
+    loop {
+        if ai >= node.positionals.length { break; }
+        let a = node.positionals[ai];
         if a.is_variadic { out = out + " [" + a.name + "...]"; } else if a.is_optional {
             out = out + " [" + a.name + "]";
         } else { out = out + " <" + a.name + ">"; }
@@ -43,13 +114,13 @@ fn _format_help(cmd: Command, program: string) -> string {
     out = out + "\n";
 
     // Subcommands.
-    if cmd.subcmds.length > 0 {
+    if node.subcommands.length > 0 {
         out = out + "\ncommands:\n";
-        let col_width = _max_name_width(cmd) + 2;
+        let col_width = _max_name_width(node) + 2;
         let mut si: int = 0;
         loop {
-            if si >= cmd.subcmds.length { break; }
-            let sub = cmd.subcmds[si];
+            if si >= node.subcommands.length { break; }
+            let sub = node.subcommands[si];
             out = out + "  " + _pad(sub.name, col_width) + sub.description
                 + "\n";
             si += 1;
@@ -57,13 +128,13 @@ fn _format_help(cmd: Command, program: string) -> string {
     }
 
     // Positional arguments.
-    if cmd.args.length > 0 {
+    if node.positionals.length > 0 {
         out = out + "\narguments:\n";
-        let arg_width = _max_arg_width(cmd) + 2;
+        let arg_width = _max_arg_width(node) + 2;
         ai = 0;
         loop {
-            if ai >= cmd.args.length { break; }
-            let a = cmd.args[ai];
+            if ai >= node.positionals.length { break; }
+            let a = node.positionals[ai];
             let mut label = "<" + a.name + ">";
             if a.is_variadic { label = label + "..."; }
             out = out + "  " + _pad(label, arg_width) + a.description;
@@ -81,11 +152,11 @@ fn _format_help(cmd: Command, program: string) -> string {
 
     // Flags.
     out = out + "\noptions:\n";
-    let flag_width = _max_flag_width(cmd) + 2;
+    let flag_width = _max_flag_width(node) + 2;
     let mut fi: int = 0;
     loop {
-        if fi >= cmd.flags.length { break; }
-        let f = cmd.flags[fi];
+        if fi >= node.flags.length { break; }
+        let f = node.flags[fi];
         let label = _flag_label(f);
         out = out + "  " + _pad(label, flag_width) + f.description;
         if f.env_var.length > 0 { out = out + " [env: " + f.env_var + "]"; }
@@ -96,14 +167,14 @@ fn _format_help(cmd: Command, program: string) -> string {
     // Built-in flags.
     out = out + "  " + _pad("-h, --help", flag_width)
         + "Show this help message\n";
-    if cmd.version.length > 0 {
+    if node.version.length > 0 {
         out = out + "  " + _pad("-V, --version", flag_width) + "Show version\n";
     }
 
     return out;
 }
 
-fn _flag_label(f: Flag) -> string {
+fn _flag_label(f: HelpFlag) -> string {
     let mut label: string = "";
     if f.short_name.length > 0 { label = "-" + f.short_name + ", "; } else {
         label = "    ";
@@ -113,34 +184,34 @@ fn _flag_label(f: Flag) -> string {
     return label;
 }
 
-fn _max_name_width(cmd: Command) -> int {
+fn _max_name_width(node: HelpNode) -> int {
     let mut max: int = 0;
     let mut i: int = 0;
     loop {
-        if i >= cmd.subcmds.length { break; }
-        if cmd.subcmds[i].name.length > max {
-            max = cmd.subcmds[i].name.length;
+        if i >= node.subcommands.length { break; }
+        if node.subcommands[i].name.length > max {
+            max = node.subcommands[i].name.length;
         }
         i += 1;
     }
     return max;
 }
 
-fn _max_arg_width(cmd: Command) -> int {
+fn _max_arg_width(node: HelpNode) -> int {
     let mut max: int = 0;
     let mut i: int = 0;
     loop {
-        if i >= cmd.args.length { break; }
+        if i >= node.positionals.length { break; }
         // +2 for the angle brackets, +3 for a variadic's `...` suffix.
-        let mut w = cmd.args[i].name.length + 2;
-        if cmd.args[i].is_variadic { w = w + 3; }
+        let mut w = node.positionals[i].name.length + 2;
+        if node.positionals[i].is_variadic { w = w + 3; }
         if w > max { max = w; }
         i += 1;
     }
     return max;
 }
 
-fn _max_flag_width(cmd: Command) -> int {
+fn _max_flag_width(node: HelpNode) -> int {
     let mut max: int = 0;
     let built_in_help = 10;  // "-h, --help"
     let built_in_version = 13;  // "-V, --version"
@@ -148,8 +219,8 @@ fn _max_flag_width(cmd: Command) -> int {
     if built_in_version > max { max = built_in_version; }
     let mut i: int = 0;
     loop {
-        if i >= cmd.flags.length { break; }
-        let w = _flag_label(cmd.flags[i]).length;
+        if i >= node.flags.length { break; }
+        let w = _flag_label(node.flags[i]).length;
         if w > max { max = w; }
         i += 1;
     }

--- a/capsules/sfn/cli/src/mod.sfn
+++ b/capsules/sfn/cli/src/mod.sfn
@@ -33,7 +33,8 @@
 //   - builder.sfn     arg, arg_optional, flag*, command, with_*
 //   - parser.sfn      parse() (pure, non-exiting), run() (exiting wrapper) + private parser helpers
 //   - matches.sfn     get, get_or, has_flag, has, subcommand, positionals
-//   - help.sfn        help, print_help, _format_help, width helpers
+//   - help.sfn        help, print_help, render_help_tree,
+//                     render_help_text, _format_help, width helpers
 //   - style.sfn       bold, dim, color helpers, no_color_active,
 //                     style_for_stream, style_with_mode,
 //                     style_resolve, paint, paint_* helpers,
@@ -67,7 +68,10 @@ export {
     Matches,
     ParseError,
     ParseResult,
-    Style
+    Style,
+    HelpFlag,
+    HelpPositional,
+    HelpNode
 } from "./types";
 
 // ---- Builders ----
@@ -119,7 +123,12 @@ export {
 } from "./matches";
 
 // ---- Help formatting ----
-export { help, print_help } from "./help";
+export {
+    help,
+    print_help,
+    render_help_tree,
+    render_help_text
+} from "./help";
 
 // ---- Terminal styling ----
 export {

--- a/capsules/sfn/cli/src/types.sfn
+++ b/capsules/sfn/cli/src/types.sfn
@@ -170,3 +170,51 @@ struct Style {
     mode: string;
     stream: string;
 }
+
+// HelpFlag is the help-tree view of a `Flag`: the subset of fields the
+// help renderer needs to format a flag row (label + annotations).
+// Decoupled from `Flag` so the help tree — and the future
+// `--help --json` output (Phase 5 Issue 5.1) — is a stable view that
+// does not drag along the builder-/parser-facing fields (`value_kind`,
+// `choices`) that never appear in help output.
+struct HelpFlag {
+    long_name: string;
+    short_name: string;
+    description: string;
+    takes_value: boolean;
+    required: boolean;
+    env_var: string;
+}
+
+// HelpPositional is the help-tree view of an `Arg`: every field the
+// help renderer consults to format an `arguments:` row and the usage
+// line.
+struct HelpPositional {
+    name: string;
+    description: string;
+    is_optional: boolean;
+    is_variadic: boolean;
+    default_value: string;
+}
+
+// HelpNode is the structured, render-agnostic representation of a
+// `Command`'s help. `render_help_tree` builds it from a `Command`;
+// `render_help_text` turns it back into the byte-identical `--help`
+// string. Separating the data (tree) from the formatting (text/JSON)
+// is the foundation for `--help --json` (Phase 5 Issue 5.1) and keeps
+// the text and future JSON renderers from drifting — both consume the
+// same tree (proposal §8 risk R8).
+//
+// `version` is non-empty when the command declares a version; the text
+// renderer emits the built-in `-V, --version` row only when it is set,
+// matching the historical `_format_help` behavior. `subcommands` is the
+// fully recursed child tree, but the text renderer descends only one
+// level for the `commands:` listing (multi-level walking is Issue 1.14).
+struct HelpNode {
+    name: string;
+    description: string;
+    version: string;
+    flags: HelpFlag[];
+    positionals: HelpPositional[];
+    subcommands: HelpNode[];
+}

--- a/capsules/sfn/cli/tests/help_tree_test.sfn
+++ b/capsules/sfn/cli/tests/help_tree_test.sfn
@@ -13,10 +13,12 @@ import {
     arg_optional,
     arg_variadic,
     command,
+    flag,
     flag_env,
     flag_required,
     flag_short,
     flag_value,
+    flag_value_short,
     help,
     render_help_text,
     render_help_tree,
@@ -131,6 +133,23 @@ test "help tree: render_help_text golden with rich positionals and flag annotati
         + "options:\n"
         + "      --token <value>  Auth token [env: PACK_TOKEN] (required)\n"
         + "  -h, --help           Show this help message\n";
+    assert strings_equal(render_help_text(node), golden);
+}
+
+test "help tree: render_help_text golden locks every flag-label variant" {
+    // All four flag-label forms in one command, so the byte-identical
+    // contract covers long-only boolean, short boolean, long value, and
+    // short value labels plus the column width they jointly drive. The
+    // widest label is `    --output <value>` (20), so the flag column is
+    // 22 and the built-in `-h, --help` row pads to match.
+    let cmd = with_flag(with_flag(with_flag(with_flag(command("tool", "A tool"), flag("verbose", "Verbose output")), flag_short("quiet", "q", "Quiet")), flag_value("output", "Output file")), flag_value_short("input", "i", "Input file"));
+    let node: HelpNode = render_help_tree(cmd);
+    let golden = "A tool\n\n" + "usage:\n  tool [options]\n\n" + "options:\n"
+        + "      --verbose         Verbose output\n"
+        + "  -q, --quiet           Quiet\n"
+        + "      --output <value>  Output file\n"
+        + "  -i, --input <value>   Input file\n"
+        + "  -h, --help            Show this help message\n";
     assert strings_equal(render_help_text(node), golden);
 }
 

--- a/capsules/sfn/cli/tests/help_tree_test.sfn
+++ b/capsules/sfn/cli/tests/help_tree_test.sfn
@@ -1,0 +1,141 @@
+// Tests for the structured help tree (Issue 1.13).
+//
+// `render_help_tree(cmd)` builds a `HelpNode`; `render_help_text(node)`
+// renders it back to the `--help` string. These tests pin BOTH the tree
+// shape and the exact rendered bytes, locking the refactor against drift
+// (the historical `_format_help` output must be reproduced byte-for-byte).
+// The companion `cli_test.sfn` keeps its substring-based help assertions,
+// which continue to pass unchanged through the same renderer.
+import {
+    Command,
+    HelpNode,
+    arg,
+    arg_optional,
+    arg_variadic,
+    command,
+    flag_env,
+    flag_required,
+    flag_short,
+    flag_value,
+    help,
+    render_help_text,
+    render_help_tree,
+    with_arg,
+    with_flag,
+    with_subcommand,
+    with_version
+} from "../src/mod";
+
+// A reference command exercising a description, two subcommands, a
+// required positional, and a short boolean flag.
+fn _reference_command() -> Command {
+    return with_flag(with_arg(with_subcommand(with_subcommand(command("greet", "A friendly greeter"), command("build", "Build it")), command("ship", "Ship it")), arg("name", "Who to greet")), flag_short("loud", "l", "Use uppercase"));
+}
+
+// ---- Tree shape ----
+test "help tree: top-level node mirrors the command" {
+    let cmd = _reference_command();
+    let node: HelpNode = render_help_tree(cmd);
+    assert strings_equal(node.name, "greet");
+    assert strings_equal(node.description, "A friendly greeter");
+    assert strings_equal(node.version, "");
+    assert node.flags.length == 1;
+    assert node.positionals.length == 1;
+    assert node.subcommands.length == 2;
+}
+
+test "help tree: flag view carries label fields" {
+    let cmd = _reference_command();
+    let node: HelpNode = render_help_tree(cmd);
+    let f = node.flags[0];
+    assert strings_equal(f.long_name, "loud");
+    assert strings_equal(f.short_name, "l");
+    assert strings_equal(f.description, "Use uppercase");
+    assert f.takes_value == false;
+    assert f.required == false;
+    assert strings_equal(f.env_var, "");
+}
+
+test "help tree: positional view carries arg fields" {
+    let cmd = _reference_command();
+    let node: HelpNode = render_help_tree(cmd);
+    let p = node.positionals[0];
+    assert strings_equal(p.name, "name");
+    assert strings_equal(p.description, "Who to greet");
+    assert p.is_optional == false;
+    assert p.is_variadic == false;
+}
+
+test "help tree: subcommands recurse in declaration order" {
+    let cmd = _reference_command();
+    let node: HelpNode = render_help_tree(cmd);
+    assert strings_equal(node.subcommands[0].name, "build");
+    assert strings_equal(node.subcommands[0].description, "Build it");
+    assert strings_equal(node.subcommands[1].name, "ship");
+    // The recursed child node is a full HelpNode (Issue 1.14 walks it).
+    assert node.subcommands[0].flags.length == 0;
+    assert node.subcommands[0].subcommands.length == 0;
+}
+
+test "help tree: version flows onto the node" {
+    let cmd = with_version(command("app", "Tool"), "2.1.0");
+    let node: HelpNode = render_help_tree(cmd);
+    assert strings_equal(node.version, "2.1.0");
+}
+
+// ---- Golden rendered strings (byte-identical contract) ----
+test "help tree: render_help_text golden for minimal command" {
+    // No description, subcommands, args, flags, or version. The flag
+    // column still reserves width for the built-in `-V, --version`
+    // (13) even though no version row is emitted.
+    let cmd = command("app", "");
+    let node: HelpNode = render_help_tree(cmd);
+    let golden = "usage:\n  app\n\noptions:\n  -h, --help     Show this help message\n";
+    assert strings_equal(render_help_text(node), golden);
+}
+
+test "help tree: render_help_text golden with version row" {
+    let cmd = with_version(command("app", "Tool"), "2.1.0");
+    let node: HelpNode = render_help_tree(cmd);
+    let golden = "Tool\n\nusage:\n  app\n\noptions:\n"
+        + "  -h, --help     Show this help message\n"
+        + "  -V, --version  Show version\n";
+    assert strings_equal(render_help_text(node), golden);
+}
+
+test "help tree: render_help_text golden for reference command" {
+    let cmd = _reference_command();
+    let node: HelpNode = render_help_tree(cmd);
+    let golden = "A friendly greeter\n\n"
+        + "usage:\n  greet <command> [options] <name>\n\n"
+        + "commands:\n  build  Build it\n  ship   Ship it\n\n"
+        + "arguments:\n  <name>  Who to greet\n\n"
+        + "options:\n"
+        + "  -l, --loud     Use uppercase\n"
+        + "  -h, --help     Show this help message\n";
+    assert strings_equal(render_help_text(node), golden);
+}
+
+test "help tree: render_help_text golden with rich positionals and flag annotations" {
+    // Optional + variadic positionals and an env-bound required value
+    // flag exercise the annotation branches and the variadic width bump.
+    let cmd = with_flag(with_arg(with_arg(command("pack", "Package files"), arg_optional("out", "Output dir", "dist")), arg_variadic("files", "Files to include")), flag_required(flag_env(flag_value("token", "Auth token"), "PACK_TOKEN")));
+    let node: HelpNode = render_help_tree(cmd);
+    // The long-only `--token <value>` label (19 cols) widens the flag
+    // column to 21, so the built-in `-h, --help` row pads out to match.
+    let golden = "Package files\n\n"
+        + "usage:\n  pack [options] [out] [files...]\n\n"
+        + "arguments:\n"
+        + "  <out>       Output dir (default: dist)\n"
+        + "  <files>...  Files to include (variadic)\n\n"
+        + "options:\n"
+        + "      --token <value>  Auth token [env: PACK_TOKEN] (required)\n"
+        + "  -h, --help           Show this help message\n";
+    assert strings_equal(render_help_text(node), golden);
+}
+
+// ---- Equivalence: help() routes through the tree ----
+test "help tree: help() equals render_help_text(render_help_tree())" {
+    let cmd = _reference_command();
+    assert strings_equal(help(cmd), render_help_text(render_help_tree(cmd)));
+}


### PR DESCRIPTION
## Summary
- Introduce `HelpNode` + `render_help_tree(cmd) -> HelpNode` and `render_help_text(node) -> string`, splitting help **data** (tree) from **formatting** (text).
- `_format_help` becomes a thin private wrapper that routes through `render_help_tree` + the shared text renderer, so `parser.sfn`'s descent-label path (`sfn build`) keeps working and the two renderers cannot drift (proposal §8 risk R8).
- Help output for every existing `Command` is **byte-identical** — locked by new golden-string tests.

Foundation for Phase 5 Issue 5.1 (`--help --json`).

Closes #802

## Acceptance Criteria
- [x] `HelpNode` struct exported with fields `name`, `description`, `flags: HelpFlag[]`, `positionals: HelpPositional[]`, `subcommands: HelpNode[]` (plus `version`, needed to reproduce the built-in `-V, --version` row byte-for-byte).
- [x] `render_help_tree(cmd) -> HelpNode` exported, pure (no `[io]`).
- [x] `render_help_text(node) -> string` exported, pure.
- [x] Every existing `Command` produces byte-identical help output (golden-string assertions added; existing `cli_test.sfn` substring tests pass unchanged).
- [x] New `help_tree_test.sfn` asserts both tree shape and the rendered string for reference `Command`s.
- [x] `sfn fmt --check` clean; `make compile` up-to-date (no compiler/src changes). `make test` validated on CI (full local suite was mid-run at push; cli capsule suite passes 14/14 locally).

## Verification
```bash
# cli capsule suite — all pass
build/native/sailfin test capsules/sfn/cli/tests/
# => tests: 14/14 passed, 0 failed
# new file alone
build/native/sailfin test capsules/sfn/cli/tests/help_tree_test.sfn
# => PASS (all 10 tests passed)
# formatting clean
build/native/sailfin fmt --check capsules/sfn/cli/      # clean
make compile                                            # up-to-date
```

## Files Changed
- `capsules/sfn/cli/src/types.sfn` — add `HelpFlag`, `HelpPositional`, `HelpNode`
- `capsules/sfn/cli/src/help.sfn` — `render_help_tree`, `render_help_text`; helpers operate on the tree; `_format_help` wraps the shared renderer
- `capsules/sfn/cli/src/mod.sfn` — re-export the new types + functions
- `capsules/sfn/cli/tests/help_tree_test.sfn` — NEW (10 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ft7pGpvhnr67haRhCHxXSr)_