### PR TITLE
refactor(cli): drop dead readlink -f /proc/self/exe self-path legs

### DIFF
--- a/compiler/src/cli_commands.sfn
+++ b/compiler/src/cli_commands.sfn
@@ -743,16 +743,17 @@ fn _should_retry_test(exit_code: int, retries_disabled: boolean) -> boolean {
 // Resolve the path to this compiler binary so the multi-file runner
 // can re-invoke itself (`<self> test <file>`) once per test for
 // process isolation. Mirrors `_resolve_self_path` in `cli_main.sfn`:
-// prefer `<binary_dir>/sailfin` (computed by `fn main` from
-// `exe_path()` / `realpath(argv[0])` on every platform), fall back to
-// the Linux `/proc/self/exe` symlink when no binary_dir was threaded
-// through.
+// `<binary_dir>/sailfin` (computed by `fn main` from `exe_path()` /
+// `realpath(argv[0])` on every platform) is the real resolution path.
+// The doubly-Linux-only `readlink -f /proc/self/exe` shell fallback
+// was removed in #970 — it never worked on macOS and is dead code now
+// that `exe_path()` (#968) threads `binary_dir` portably.
 fn _resolve_test_self_path(binary_dir: string) -> string ![io] {
     if binary_dir.length > 0 {
         let candidate = _path_join_cmd(binary_dir, "sailfin");
         if fs.exists(candidate) { return candidate; }
     }
-    return _shell_read_cmd("readlink -f /proc/self/exe");
+    return "";
 }
 
 // Per-test wall-clock budget, ported from the retired

--- a/compiler/src/cli_main.sfn
+++ b/compiler/src/cli_main.sfn
@@ -968,10 +968,12 @@ fn _clang_compile_runtime_capsule_objects(runtime_capsules: RuntimeCapsuleArtifa
 //      resolves the running binary portably (#968), `fn main`
 //      always threads a non-empty `binary_dir` before reaching
 //      this helper, so this leg is the real resolution path.
-//   2. `""` — caller treats as "skip the runtime-sfn-sources
-//      loop with a diagnostic". The doubly-Linux-only
-//      `readlink -f /proc/self/exe` shell fallback was removed in
-//      #970: it never worked on macOS (no `/proc`; BSD `readlink`
+//   2. `""` — a hard failure: each caller prints a diagnostic and
+//      returns `_failed_runtime_link_inputs()`, aborting the link
+//      (it does not degrade gracefully). Unreachable in practice
+//      now that `binary_dir` is always threaded. The doubly-Linux-
+//      only `readlink -f /proc/self/exe` shell fallback was removed
+//      in #970: it never worked on macOS (no `/proc`; BSD `readlink`
 //      has no `-f`) and is dead code now that `binary_dir` is
 //      always threaded portably.
 fn _resolve_self_path(binary_dir: string) -> string ![io] {

--- a/compiler/src/cli_main.sfn
+++ b/compiler/src/cli_main.sfn
@@ -960,25 +960,26 @@ fn _clang_compile_runtime_capsule_objects(runtime_capsules: RuntimeCapsuleArtifa
 }
 
 // Resolve the path to the running compiler binary so we can spawn
-// it as a child to emit runtime `.sfn` modules at link time. Reads
+// it as a child to emit runtime `.sfn` modules at link time.
 // Resolution order:
 //   1. `binary_dir + "/sailfin"` if a non-empty `binary_dir` was
 //      threaded from the CLI's `--binary-dir` plumbing. Cross-
-//      platform — works on macOS and Linux.
-//   2. `readlink -f /proc/self/exe` (Linux fallback when no
-//      binary_dir was passed).
-//   3. `""` — caller treats as "skip the runtime-sfn-sources
-//      loop with a diagnostic". On macOS without binary_dir,
-//      this is currently unreachable in practice because the
-//      native driver always computes binary_dir before calling
-//      into the Sailfin entrypoint.
+//      platform — works on macOS and Linux. Now that `exe_path()`
+//      resolves the running binary portably (#968), `fn main`
+//      always threads a non-empty `binary_dir` before reaching
+//      this helper, so this leg is the real resolution path.
+//   2. `""` — caller treats as "skip the runtime-sfn-sources
+//      loop with a diagnostic". The doubly-Linux-only
+//      `readlink -f /proc/self/exe` shell fallback was removed in
+//      #970: it never worked on macOS (no `/proc`; BSD `readlink`
+//      has no `-f`) and is dead code now that `binary_dir` is
+//      always threaded portably.
 fn _resolve_self_path(binary_dir: string) -> string ![io] {
     if binary_dir.length > 0 {
         let candidate = _path_join(binary_dir, "sailfin");
         if fs.exists(candidate) { return candidate; }
     }
-    let raw = _shell_read_cmd("readlink -f /proc/self/exe");
-    return raw;
+    return "";
 }
 
 // Issue #308: compile every `sfn-sources` entry from a list of
@@ -1129,7 +1130,7 @@ fn _compile_runtime_sfn_sources(runtime_capsules: RuntimeCapsuleArtifacts[], out
         print("sfn build: cannot resolve self path for runtime sfn-source emit");
         print("           tried: <binary_dir>/sailfin (binary_dir=\""
             + binary_dir
-            + "\"), then readlink -f /proc/self/exe");
+            + "\")");
         return _failed_runtime_link_inputs();
     }
     let mut i: int = 0;
@@ -1215,7 +1216,7 @@ fn assemble_runtime_capsule_link_inputs(runtime_capsules: RuntimeCapsuleArtifact
             print("sfn build: cannot resolve self path for runtime prelude-entry emit");
             print("           tried: <binary_dir>/sailfin (binary_dir=\""
                 + binary_dir
-                + "\"), then readlink -f /proc/self/exe");
+                + "\")");
             return _failed_runtime_link_inputs();
         }
         let mut pi: int = 0;


### PR DESCRIPTION
## Summary
- Delete the `_shell_read_cmd("readlink -f /proc/self/exe")` last-ditch leg in `_resolve_self_path` (`compiler/src/cli_main.sfn`) and `_resolve_test_self_path` (`compiler/src/cli_commands.sfn`), replacing each with `return "";` per design proposal §4.8.
- The `readlink -f /proc/self/exe` leg never worked on macOS (no `/proc`; BSD `readlink` has no `-f`) and is dead code now that `exe_path()` (#968) resolves the running binary portably — `fn main` always threads a non-empty `binary_dir` before these helpers run, so the `<binary_dir>/sailfin` leg is the real resolution path.
- Trim the now-inaccurate `", then readlink -f /proc/self/exe"` diagnostic strings and refresh the resolution-order comments to document the removal.

Chose to delete the shell leg over re-plumbing a cross-module `exe_path` import (the issue's `Out:` scope), keeping the blast radius minimal. `_shell_read_cmd` remains imported and widely used elsewhere, so no unused-import fallout.

Closes #970

## Acceptance Criteria
- [x] `ulimit -v 8388608 && make compile && make check` green on Linux (self-host fixed-point: stage2 == stage3 ✓).
- [x] `make test` green — `make check` ran the full suite on both the first-pass and seedcheck binaries (unit 125/125, integration 30/30, e2e 5/5, capsules 31/31, e2e-sh 99/99, all 0 failed).
- [ ] The `[MAC-CI]` gate (#3) remains green — validated by CI on this PR (cannot run locally on Linux).
- [x] `sfn fmt --check` clean on touched `.sfn` files.

## Verification
```bash
ulimit -v 8388608 && make compile && make check
# => {"target":"check","status":"pass",...}
# => [check] stage2 == stage3: compiler is a fixed point ✓
build/native/sailfin fmt --check compiler/src/cli_main.sfn compiler/src/cli_commands.sfn
# => clean (no output)
```

## Files Changed
- `compiler/src/cli_main.sfn` — drop readlink leg + diagnostic/comment cleanup
- `compiler/src/cli_commands.sfn` — drop readlink leg + comment cleanup

Part of epic #390; exe-path thread #468 / #473. Independent of #3 and #5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012FhB4zxR3kzxoYzJsYZ9iZ)_