### PR TITLE
fix(cache): back runtime objects with the shared content cache (#1096)

### DIFF
--- a/compiler/src/build_cache.sfn
+++ b/compiler/src/build_cache.sfn
@@ -251,6 +251,11 @@ fn _filename_for_kind(kind: string) -> string {
     if kind == "layout-manifest" { return "layout.manifest"; }
     if kind == "ll" { return "mod.ll"; }
     if kind == "obj" { return "mod.o"; }
+    // Runtime C/LL/sfn object compiles (#1096). A distinct filename
+    // from the per-module `.ll` `obj` kind keeps the two layers from
+    // ever aliasing in a shared cache entry, even though their content
+    // keys are already disjoint.
+    if kind == "runtime-obj" { return "runtime.o"; }
     return "";
 }
 
@@ -623,6 +628,29 @@ fn runtime_object_cache_key(src_path: string, opt_flag: string) -> string ![io] 
     return content + "\n" + opt_flag + "\nsecsplit1";
 }
 
+// Derive a content-addressed shared-cache `CacheKey` from a
+// `runtime_object_cache_key` string (#1096). The runtime object layer
+// historically cached `.o` outputs only in the per-build work-dir (a
+// sidecar `.o.key` next to the object in `<work-dir>/sailfin/`), so a
+// second build into a *sibling* work-dir — e.g. the build-quality
+// determinism gate's pass1 → pass2 — always missed every runtime
+// object, dragging the folded summary `hit_rate` below the 0.95 gate
+// even though nothing changed. Hashing the runtime key string into a
+// 64-hex digest lets the shared-cache artifact helpers
+// (`cache_lookup_artifact` / `cache_store_artifact`, kind
+// `"runtime-obj"`) back the work-dir objects with the same
+// content-addressed `build/cache/<schema>` store the `.ll` module
+// cache already uses, so runtime objects warm across work-dirs and CI
+// cache restores. Returns an empty-digest key (rejected by
+// `_is_valid_digest`, so every shared-cache helper treats it as a
+// miss) when the runtime key was empty/unhashable.
+fn runtime_object_entry_key_from_str(key_str: string, hash_suffix: string) -> CacheKey ![io] {
+    if key_str.length == 0 {
+        return CacheKey { digest: "" };
+    }
+    return CacheKey { digest: _sha256_of_string(key_str, hash_suffix) };
+}
+
 // ----------------------------------------------------------------
 // Cache key derivation
 // ----------------------------------------------------------------
@@ -728,6 +756,7 @@ export {
     cache_compiler_identity,
     sha256_of_file,
     runtime_object_cache_key,
+    runtime_object_entry_key_from_str,
     empty_cache_stats,
     merge_cache_stats,
     cache_stats_is_empty,

--- a/compiler/src/cli_commands.sfn
+++ b/compiler/src/cli_commands.sfn
@@ -174,7 +174,10 @@ fn _clang_link_test_cmd_with_deps(ll_path: string, out_path: string, runtime_roo
         return 1;
     }
     _ensure_dir_cmd(rt_cache_dir);
-    let rt = assemble_runtime_capsule_link_inputs(runtime_caps, rt_cache_dir, "-O0", binary_dir);
+    // Test link path keeps runtime objects work-dir-local (shared root
+    // empty); the shared content-addressed runtime cache (#1096) is
+    // scoped to the build/run path that feeds the build-quality gate.
+    let rt = assemble_runtime_capsule_link_inputs(runtime_caps, rt_cache_dir, "-O0", binary_dir, "");
     if !rt.success { return 1; }
     let mut roi: int = 0;
     loop {
@@ -1169,7 +1172,7 @@ fn handle_test_command(args: string[], runtime_root: string, binary_dir: string)
         let warm_caps = runtime_capsule_from_root(runtime_root);
         if warm_caps.length > 0 {
             _ensure_dir_cmd(sub_root);
-            let warm = assemble_runtime_capsule_link_inputs(warm_caps, sub_root, "-O0", binary_dir);
+            let warm = assemble_runtime_capsule_link_inputs(warm_caps, sub_root, "-O0", binary_dir, "");
             if !warm.success {
                 print.err("[test] warning: failed to pre-warm runtime objects under "
                     + sub_root

--- a/compiler/src/cli_main.sfn
+++ b/compiler/src/cli_main.sfn
@@ -3,13 +3,18 @@
 // Sailfin-native CLI entrypoint invoked by the native C shim.
 import {
     BuildCacheConfig,
+    CacheKey,
     CacheStats,
+    cache_copy_artifact_to,
+    cache_lookup_artifact,
     cache_root,
     cache_stats_is_empty,
+    cache_store_artifact,
     empty_cache_stats,
     merge_cache_stats,
     resolve_build_cache_config,
-    runtime_object_cache_key
+    runtime_object_cache_key,
+    runtime_object_entry_key_from_str
 } from "./build_cache";
 import {
     BuildReport,
@@ -824,6 +829,42 @@ fn _runtime_obj_cache_record(obj_path: string, key: string) ![io] {
     fs.writeFile(obj_path + ".key", key);
 }
 
+// Shared content-addressed cache lookup for a runtime object (#1096).
+// When the shared cache is enabled (`shared_cache_root` non-empty) and
+// holds the artifact for this content key, copy it into the work-dir
+// `obj_path`, write the work-dir sidecar so a same-work-dir rebuild
+// can fast-path it, and return true (the caller counts a HIT and skips
+// the compile). Returns false on a disabled cache, an empty/unhashable
+// key, or a miss — leaving the caller to compile fresh. `hash_suffix`
+// only needs to be unique enough to avoid a tmp-file collision while
+// the key string is hashed; the per-source `cap_prefix + basename +
+// opt_flag` the callers pass satisfies that.
+fn _runtime_obj_shared_cache_fetch(shared_cache_root: string, key: string, obj_path: string, hash_suffix: string) -> boolean ![io] {
+    if shared_cache_root.length == 0 { return false; }
+    if key.length == 0 { return false; }
+    let ck = runtime_object_entry_key_from_str(key, hash_suffix);
+    if !cache_lookup_artifact(shared_cache_root, ck, "runtime-obj") {
+        return false;
+    }
+    if !cache_copy_artifact_to(shared_cache_root, ck, "runtime-obj", obj_path) {
+        return false;
+    }
+    _runtime_obj_cache_record(obj_path, key);
+    return true;
+}
+
+// Publish a freshly-compiled runtime object into the shared
+// content-addressed cache so sibling work-dirs and CI cache restores
+// can warm-hit it (#1096). No-op when the shared cache is disabled or
+// the key is unhashable. A store failure is non-fatal — the object
+// already exists at `obj_path` for this build's link.
+fn _runtime_obj_shared_cache_publish(shared_cache_root: string, key: string, obj_path: string, hash_suffix: string) ![io] {
+    if shared_cache_root.length == 0 { return; }
+    if key.length == 0 { return; }
+    let ck = runtime_object_entry_key_from_str(key, hash_suffix);
+    cache_store_artifact(shared_cache_root, ck, "runtime-obj", obj_path);
+}
+
 // Compile every `c-sources` / `ll-sources` entry from a list of
 // `kind = "runtime"` capsule artifacts and return the resulting
 // `.o` paths plus the accumulated `link-libs`. Caches `.o` outputs
@@ -836,7 +877,7 @@ fn _runtime_obj_cache_record(obj_path: string, key: string) ![io] {
 // without a runtime dep, the caller falls through to the legacy
 // `_clang_compile_runtime_objects` helper that uses the
 // hardcoded `runtime_root/native/...` layout.
-fn _clang_compile_runtime_capsule_objects(runtime_capsules: RuntimeCapsuleArtifacts[], out_dir: string, opt_flag: string) -> RuntimeLinkInputs ![io] {
+fn _clang_compile_runtime_capsule_objects(runtime_capsules: RuntimeCapsuleArtifacts[], out_dir: string, opt_flag: string, shared_cache_root: string) -> RuntimeLinkInputs ![io] {
     let mut objects: string[] = [];
     let mut link_libs: string[] = [];
     // Per-call cache-stat accumulator (#915). Counting mirrors the
@@ -877,14 +918,17 @@ fn _clang_compile_runtime_capsule_objects(runtime_capsules: RuntimeCapsuleArtifa
         loop {
             if ci >= cap.c_sources.length { break; }
             let src = cap.c_sources[ci];
-            let obj = _path_join(out_dir, cap_prefix + _path_basename(src)
-                + opt_flag
-                + ".o");
+            let base = cap_prefix + _path_basename(src) + opt_flag;
+            let obj = _path_join(out_dir, base + ".o");
             let key = runtime_object_cache_key(src, opt_flag);
             if key.length == 0 {
                 stats.invalid_keys = stats.invalid_keys + 1;
             }
-            if !_runtime_obj_cache_hit(obj, key) {
+            if _runtime_obj_cache_hit(obj, key) {
+                stats.hits = stats.hits + 1;
+            } else if _runtime_obj_shared_cache_fetch(shared_cache_root, key, obj, base) {
+                stats.hits = stats.hits + 1;
+            } else {
                 stats.misses = stats.misses + 1;
                 let mut args: string[] = ["clang", opt_flag, "-Wno-override-module"];
                 // Per-function/per-datum sections so the final link's
@@ -908,8 +952,11 @@ fn _clang_compile_runtime_capsule_objects(runtime_capsules: RuntimeCapsuleArtifa
                     return _failed_runtime_link_inputs();
                 }
                 _runtime_obj_cache_record(obj, key);
-                if key.length > 0 { stats.stores = stats.stores + 1; }
-            } else { stats.hits = stats.hits + 1; }
+                if key.length > 0 {
+                    stats.stores = stats.stores + 1;
+                    _runtime_obj_shared_cache_publish(shared_cache_root, key, obj, base);
+                }
+            }
             objects.push(obj);
             ci += 1;
         }
@@ -920,14 +967,17 @@ fn _clang_compile_runtime_capsule_objects(runtime_capsules: RuntimeCapsuleArtifa
         loop {
             if li >= cap.ll_sources.length { break; }
             let src = cap.ll_sources[li];
-            let obj = _path_join(out_dir, cap_prefix + _path_basename(src)
-                + opt_flag
-                + ".o");
+            let base = cap_prefix + _path_basename(src) + opt_flag;
+            let obj = _path_join(out_dir, base + ".o");
             let key = runtime_object_cache_key(src, opt_flag);
             if key.length == 0 {
                 stats.invalid_keys = stats.invalid_keys + 1;
             }
-            if !_runtime_obj_cache_hit(obj, key) {
+            if _runtime_obj_cache_hit(obj, key) {
+                stats.hits = stats.hits + 1;
+            } else if _runtime_obj_shared_cache_fetch(shared_cache_root, key, obj, base) {
+                stats.hits = stats.hits + 1;
+            } else {
                 stats.misses = stats.misses + 1;
                 let rc = process.run(["clang", opt_flag, "-Wno-override-module", "-ffunction-sections", "-fdata-sections", "-c", src, "-o", obj]);
                 if rc != 0 {
@@ -936,8 +986,11 @@ fn _clang_compile_runtime_capsule_objects(runtime_capsules: RuntimeCapsuleArtifa
                     return _failed_runtime_link_inputs();
                 }
                 _runtime_obj_cache_record(obj, key);
-                if key.length > 0 { stats.stores = stats.stores + 1; }
-            } else { stats.hits = stats.hits + 1; }
+                if key.length > 0 {
+                    stats.stores = stats.stores + 1;
+                    _runtime_obj_shared_cache_publish(shared_cache_root, key, obj, base);
+                }
+            }
             objects.push(obj);
             li += 1;
         }
@@ -1030,7 +1083,7 @@ struct RuntimeEmitResult {
     stats: CacheStats;
 }
 
-fn _emit_runtime_sfn_to_obj(self_path: string, cap_prefix: string, src: string, out_dir: string, opt_flag: string) -> RuntimeEmitResult ![io] {
+fn _emit_runtime_sfn_to_obj(self_path: string, cap_prefix: string, src: string, out_dir: string, opt_flag: string, shared_cache_root: string) -> RuntimeEmitResult ![io] {
     let mut stats = empty_cache_stats();
     let slug = module_name_from_path(src);
     let ll_path = _path_join(out_dir, cap_prefix + _path_basename(src)
@@ -1052,7 +1105,15 @@ fn _emit_runtime_sfn_to_obj(self_path: string, cap_prefix: string, src: string, 
     // path so the sfn-source + prelude emit invalidates identically.
     let key = runtime_object_cache_key(src, opt_flag);
     if key.length == 0 { stats.invalid_keys = stats.invalid_keys + 1; }
+    let shared_suffix = cap_prefix + _path_basename(src) + opt_flag;
     if _runtime_obj_cache_hit(obj_path, key) {
+        stats.hits = stats.hits + 1;
+        return RuntimeEmitResult { obj_path: obj_path, stats: stats };
+    }
+    // Shared content-addressed cache hit (#1096): a sibling work-dir or
+    // a CI cache restore may already hold this object even though the
+    // local sidecar above missed. Skip the re-emit + clang entirely.
+    if _runtime_obj_shared_cache_fetch(shared_cache_root, key, obj_path, shared_suffix) {
         stats.hits = stats.hits + 1;
         return RuntimeEmitResult { obj_path: obj_path, stats: stats };
     }
@@ -1086,11 +1147,14 @@ fn _emit_runtime_sfn_to_obj(self_path: string, cap_prefix: string, src: string, 
         return RuntimeEmitResult { obj_path: "", stats: stats };
     }
     _runtime_obj_cache_record(obj_path, key);
-    if key.length > 0 { stats.stores = stats.stores + 1; }
+    if key.length > 0 {
+        stats.stores = stats.stores + 1;
+        _runtime_obj_shared_cache_publish(shared_cache_root, key, obj_path, shared_suffix);
+    }
     return RuntimeEmitResult { obj_path: obj_path, stats: stats };
 }
 
-fn _compile_runtime_sfn_sources(runtime_capsules: RuntimeCapsuleArtifacts[], out_dir: string, opt_flag: string, binary_dir: string) -> RuntimeLinkInputs ![io] {
+fn _compile_runtime_sfn_sources(runtime_capsules: RuntimeCapsuleArtifacts[], out_dir: string, opt_flag: string, binary_dir: string, shared_cache_root: string) -> RuntimeLinkInputs ![io] {
     let mut objects: string[] = [];
     let empty_libs: string[] = [];
     let mut stats = empty_cache_stats();
@@ -1141,7 +1205,7 @@ fn _compile_runtime_sfn_sources(runtime_capsules: RuntimeCapsuleArtifacts[], out
         loop {
             if si >= cap.sfn_sources.length { break; }
             let src = cap.sfn_sources[si];
-            let emit = _emit_runtime_sfn_to_obj(self_path, cap_prefix, src, out_dir, opt_flag);
+            let emit = _emit_runtime_sfn_to_obj(self_path, cap_prefix, src, out_dir, opt_flag, shared_cache_root);
             stats = merge_cache_stats(stats, emit.stats);
             if emit.obj_path.length == 0 {
                 return _failed_runtime_link_inputs();
@@ -1169,8 +1233,8 @@ fn _compile_runtime_sfn_sources(runtime_capsules: RuntimeCapsuleArtifacts[], out
 // (`cli_commands.sfn::_clang_link_test_cmd_with_deps`, which imports
 // this through the `cli_main <-> cli_commands` cycle) so the two
 // paths resolve the runtime identically.
-fn assemble_runtime_capsule_link_inputs(runtime_capsules: RuntimeCapsuleArtifacts[], out_dir: string, opt_flag: string, binary_dir: string) -> RuntimeLinkInputs ![io] {
-    let inputs = _clang_compile_runtime_capsule_objects(runtime_capsules, out_dir, opt_flag);
+fn assemble_runtime_capsule_link_inputs(runtime_capsules: RuntimeCapsuleArtifacts[], out_dir: string, opt_flag: string, binary_dir: string, shared_cache_root: string) -> RuntimeLinkInputs ![io] {
+    let inputs = _clang_compile_runtime_capsule_objects(runtime_capsules, out_dir, opt_flag, shared_cache_root);
     if !inputs.success { return _failed_runtime_link_inputs(); }
     let mut objects: string[] = inputs.object_paths;
     let link_libs: string[] = inputs.link_libs;
@@ -1179,7 +1243,7 @@ fn assemble_runtime_capsule_link_inputs(runtime_capsules: RuntimeCapsuleArtifact
     let mut stats = inputs.stats;
     // `sfn-sources` + `prelude-entry` are materialized here (the
     // prelude rides the same emit path as of #940).
-    let sfn_inputs = _compile_runtime_sfn_sources(runtime_capsules, out_dir, opt_flag, binary_dir);
+    let sfn_inputs = _compile_runtime_sfn_sources(runtime_capsules, out_dir, opt_flag, binary_dir, shared_cache_root);
     if !sfn_inputs.success { return _failed_runtime_link_inputs(); }
     stats = merge_cache_stats(stats, sfn_inputs.stats);
     let mut soi: int = 0;
@@ -1224,7 +1288,7 @@ fn assemble_runtime_capsule_link_inputs(runtime_capsules: RuntimeCapsuleArtifact
             let cap = runtime_capsules[pi];
             if cap.prelude_entry.length > 0 {
                 let cap_prefix = _runtime_obj_prefix(cap.capsule_name);
-                let prelude_emit = _emit_runtime_sfn_to_obj(self_path, cap_prefix, cap.prelude_entry, out_dir, opt_flag);
+                let prelude_emit = _emit_runtime_sfn_to_obj(self_path, cap_prefix, cap.prelude_entry, out_dir, opt_flag, shared_cache_root);
                 stats = merge_cache_stats(stats, prelude_emit.stats);
                 if prelude_emit.obj_path.length == 0 {
                     return _failed_runtime_link_inputs();
@@ -1318,14 +1382,14 @@ fn _failed_link_result() -> LinkResult {
     return LinkResult { rc: 1, stats: empty_cache_stats() };
 }
 
-fn _clang_link_with_opt(ll_path: string, out_path: string, runtime_root: string, runtime_capsules: RuntimeCapsuleArtifacts[], opt_flag: string, cache_dir: string, binary_dir: string) -> LinkResult ![io] {
+fn _clang_link_with_opt(ll_path: string, out_path: string, runtime_root: string, runtime_capsules: RuntimeCapsuleArtifacts[], opt_flag: string, cache_dir: string, binary_dir: string, shared_cache_root: string) -> LinkResult ![io] {
     // Thin wrapper: most callers have one .ll; capsule-aware callers use
     // _clang_link_multi_with_opt directly.
     let single: string[] = [ll_path];
-    return _clang_link_multi_with_opt(single, out_path, runtime_root, runtime_capsules, opt_flag, cache_dir, binary_dir);
+    return _clang_link_multi_with_opt(single, out_path, runtime_root, runtime_capsules, opt_flag, cache_dir, binary_dir, shared_cache_root);
 }
 
-fn _clang_link_multi_with_opt(ll_paths: string[], out_path: string, runtime_root: string, runtime_capsules: RuntimeCapsuleArtifacts[], opt_flag: string, cache_dir: string, binary_dir: string) -> LinkResult ![io] {
+fn _clang_link_multi_with_opt(ll_paths: string[], out_path: string, runtime_root: string, runtime_capsules: RuntimeCapsuleArtifacts[], opt_flag: string, cache_dir: string, binary_dir: string, shared_cache_root: string) -> LinkResult ![io] {
     if ll_paths.length == 0 {
         print("_clang_link_multi_with_opt: no input .ll files");
         return _failed_link_result();
@@ -1361,7 +1425,7 @@ fn _clang_link_multi_with_opt(ll_paths: string[], out_path: string, runtime_root
         print("     hint: ensure the runtime bundle ships alongside the compiler binary");
         return _failed_link_result();
     }
-    let inputs = assemble_runtime_capsule_link_inputs(runtime_capsules, cache_dir, opt_flag, binary_dir);
+    let inputs = assemble_runtime_capsule_link_inputs(runtime_capsules, cache_dir, opt_flag, binary_dir, shared_cache_root);
     if !inputs.success {
         return LinkResult { rc: 1, stats: inputs.stats };
     }
@@ -1425,17 +1489,19 @@ fn _clang_link_multi_with_opt(ll_paths: string[], out_path: string, runtime_root
 fn _clang_link(ll_path: string, out_path: string, runtime_root: string, runtime_capsules: RuntimeCapsuleArtifacts[], binary_dir: string, cache_dir: string) -> LinkResult ![io] {
     // Default link used by `build` and `run` for single-module programs.
     let resolved_cache_dir = _resolve_sailfin_cache_dir(cache_dir);
-    return _clang_link_with_opt(ll_path, out_path, runtime_root, runtime_capsules, "-O2", resolved_cache_dir, binary_dir);
+    // Single-module path is not on the cache-gated build/run flow that
+    // threads a shared cache root; pass empty (work-dir-local only).
+    return _clang_link_with_opt(ll_path, out_path, runtime_root, runtime_capsules, "-O2", resolved_cache_dir, binary_dir, "");
 }
 
-fn _clang_link_multi(ll_paths: string[], out_path: string, runtime_root: string, runtime_capsules: RuntimeCapsuleArtifacts[], binary_dir: string, cache_dir: string) -> LinkResult ![io] {
+fn _clang_link_multi(ll_paths: string[], out_path: string, runtime_root: string, runtime_capsules: RuntimeCapsuleArtifacts[], binary_dir: string, cache_dir: string, shared_cache_root: string) -> LinkResult ![io] {
     // Default link used by `build` and `run` for multi-module programs
     // (main source + capsule dependency modules). `cache_dir` is the
     // sailfin-side scratch root (`build/sailfin` for legacy in-tree
     // builds, `<work_dir>/sailfin` when `sfn build --work-dir <root>`
     // virtualizes the layout).
     let resolved_cache_dir = _resolve_sailfin_cache_dir(cache_dir);
-    return _clang_link_multi_with_opt(ll_paths, out_path, runtime_root, runtime_capsules, "-O2", resolved_cache_dir, binary_dir);
+    return _clang_link_multi_with_opt(ll_paths, out_path, runtime_root, runtime_capsules, "-O2", resolved_cache_dir, binary_dir, shared_cache_root);
 }
 
 // Resolve the sailfin-side cache scratch root. Empty input is the
@@ -2241,7 +2307,13 @@ fn sailfin_cli_main(argv: string[]) -> int ![io, clock] {
         if build_runtime_caps.length == 0 {
             build_runtime_caps = runtime_capsule_from_root(runtime_root);
         }
-        let link_result = _clang_link_multi(all_lls, exe_path, runtime_root, build_runtime_caps, binary_dir, sailfin_cache_dir);
+        // Shared content-addressed cache root for runtime objects
+        // (#1096), mirroring the `.ll` module cache. Empty under
+        // `--no-cache` so the persistent store is neither read nor
+        // written, matching the summary-fold gate below.
+        let mut build_shared_cache_root: string = "";
+        if cache_config.enabled { build_shared_cache_root = cache_root(); }
+        let link_result = _clang_link_multi(all_lls, exe_path, runtime_root, build_runtime_caps, binary_dir, sailfin_cache_dir, build_shared_cache_root);
         let rc = link_result.rc;
         if rc != 0 {
             if !json_flag {
@@ -2380,7 +2452,11 @@ fn sailfin_cli_main(argv: string[]) -> int ![io, clock] {
         if run_runtime_caps.length == 0 {
             run_runtime_caps = runtime_capsule_from_root(runtime_root);
         }
-        let link_result = _clang_link_multi(all_lls, exe_path, runtime_root, run_runtime_caps, binary_dir, "");
+        // Shared runtime-object cache root (#1096); empty under
+        // `--no-cache` to leave the persistent store untouched.
+        let mut run_shared_cache_root: string = "";
+        if run_cache_config.enabled { run_shared_cache_root = cache_root(); }
+        let link_result = _clang_link_multi(all_lls, exe_path, runtime_root, run_runtime_caps, binary_dir, "", run_shared_cache_root);
         let link_rc = link_result.rc;
         if link_rc != 0 {
             // A native link failure is a real compiler/runtime bug to

--- a/compiler/tests/e2e/test_runtime_obj_shared_cache.sh
+++ b/compiler/tests/e2e/test_runtime_obj_shared_cache.sh
@@ -2,10 +2,10 @@
 # End-to-end test for the shared runtime-object cache fix (#1096).
 #
 # Before this fix, runtime C/LL/sfn objects were cached only in the
-# per-build work-dir (a sidecar `<obj>.key` next to the `.o` under
-# `<work-dir>/sailfin/`), never in the shared content-addressed cache
-# root (`build/cache/v1`) the `.ll` module cache uses. A second build
-# into a *sibling* work-dir therefore always missed every runtime
+# per-build work-dir (a sidecar `<obj>.o.key` next to the `<obj>.o`
+# under `<work-dir>/sailfin/`), never in the shared content-addressed
+# cache root (`build/cache/v1`) the `.ll` module cache uses. A second
+# build into a *sibling* work-dir therefore always missed every runtime
 # object, even with an identical source tree and a warm shared cache.
 #
 # The build-quality gate (`build-quality.yml`) builds the compiler into

--- a/compiler/tests/e2e/test_runtime_obj_shared_cache.sh
+++ b/compiler/tests/e2e/test_runtime_obj_shared_cache.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# End-to-end test for the shared runtime-object cache fix (#1096).
+#
+# Before this fix, runtime C/LL/sfn objects were cached only in the
+# per-build work-dir (a sidecar `<obj>.key` next to the `.o` under
+# `<work-dir>/sailfin/`), never in the shared content-addressed cache
+# root (`build/cache/v1`) the `.ll` module cache uses. A second build
+# into a *sibling* work-dir therefore always missed every runtime
+# object, even with an identical source tree and a warm shared cache.
+#
+# The build-quality gate (`build-quality.yml`) builds the compiler into
+# two sibling work-dirs (`det-pass1` -> `det-pass2`) sharing one cache
+# root and asserts `cache.hit_rate >= 0.95` on the warm second pass.
+# Once #1075 folded runtime objects into that summary, the work-dir-
+# local runtime cache dragged the rate to 0.90 (issue #1096): the 17
+# runtime objects missed on pass2 while the 155 `.ll` modules hit.
+#
+# This test pins the contract that the warm sibling pass now hits the
+# runtime objects from the shared cache:
+#   1. Build A (cold shared cache) misses + stores the runtime objects.
+#   2. Build B into a SIBLING work-dir, same shared cache root, MUST
+#      cache-hit every runtime object: the `[cache]` summary reports
+#      misses=0 with hits>=1.
+#   3. The shared cache root holds `runtime-obj` entries after build A.
+#
+# A one-line program keeps this to seconds (it has no `.ll` module-
+# cache deps of its own, so the `[cache]` summary reflects only the
+# runtime objects).
+#
+# Usage:
+#   compiler/tests/e2e/test_runtime_obj_shared_cache.sh <compiler-binary>
+
+set -euo pipefail
+
+BINARY="${1:?usage: test_runtime_obj_shared_cache.sh <compiler-binary>}"
+BINARY="$(realpath "$BINARY")"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$REPO_ROOT"
+
+PASS=0
+FAIL=0
+run_test() {
+    local name="$1"
+    shift
+    if "$@"; then
+        echo "[test] PASS: $name"
+        PASS=$((PASS + 1))
+    else
+        echo "[test] FAIL: $name"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+SCRATCH="$(mktemp -d -t sfn-rt-shared-XXXXXX)"
+cleanup() { rm -rf "$SCRATCH"; }
+trap cleanup EXIT
+
+# Dedicated shared cache root so the test never touches the repo's
+# build/cache/ tree (and starts genuinely cold).
+SHARED_CACHE="$SCRATCH/cache"
+WORK_A="$SCRATCH/passA"
+WORK_B="$SCRATCH/passB"
+
+cat > "$SCRATCH/hello.sfn" <<'EOF'
+fn main() -> int {
+    return 0;
+}
+EOF
+
+# `timeout` / `ulimit -v` are Linux-only; apply best-effort so the
+# test also runs on macos-arm64 (matching the #632 e2e test).
+TIMEOUT_PREFIX=""
+if command -v timeout >/dev/null 2>&1; then TIMEOUT_PREFIX="timeout 120"; fi
+
+# Build hello.sfn into work-dir $1, sharing $SHARED_CACHE. The cache
+# summary (`[cache] ...`) prints to stderr (#915); 2>&1 captures it.
+do_build() {
+    local work="$1" log="$2"
+    ( ulimit -v 8388608 2>/dev/null || true
+      SAILFIN_BUILD_CACHE_DIR="$SHARED_CACHE" \
+        ${TIMEOUT_PREFIX} "$BINARY" build "$SCRATCH/hello.sfn" \
+        -o "$SCRATCH/hello-$(basename "$work")" --work-dir "$work" ) >"$log" 2>&1
+}
+
+summary_field() {
+    # summary_field <log> <field> -> integer (or "" if no summary line)
+    sed -nE "s/.*\[cache\] .*${2}=([0-9]+).*/\1/p" "$1" | tail -n1
+}
+
+# ---- Build A: cold shared cache -> runtime objects miss + store ----
+if ! do_build "$WORK_A" "$SCRATCH/buildA.log"; then
+    echo "[test] FATAL: build A failed" >&2
+    cat "$SCRATCH/buildA.log" >&2
+    exit 1
+fi
+
+check_buildA_stores_runtime_objs() {
+    local misses stores
+    misses="$(summary_field "$SCRATCH/buildA.log" misses)"
+    stores="$(summary_field "$SCRATCH/buildA.log" stores)"
+    if [ -z "$misses" ]; then
+        echo "  expected a [cache] summary on cold build A, found none" >&2
+        cat "$SCRATCH/buildA.log" >&2
+        return 1
+    fi
+    if [ "${misses:-0}" -lt 1 ]; then
+        echo "  expected runtime-object misses>=1 on cold build A, got misses=$misses" >&2
+        return 1
+    fi
+    if [ "${stores:-0}" -lt 1 ]; then
+        echo "  expected runtime-object stores>=1 on cold build A, got stores=$stores" >&2
+        return 1
+    fi
+    return 0
+}
+run_test "cold build A misses + stores runtime objects" \
+    check_buildA_stores_runtime_objs
+
+# The shared cache root must now hold runtime-obj artifacts (filename
+# `runtime.o` per build_cache.sfn::_filename_for_kind).
+check_shared_cache_populated() {
+    if ! find "$SHARED_CACHE" -name 'runtime.o' -print -quit | grep -q .; then
+        echo "  expected runtime.o artifacts under $SHARED_CACHE after build A" >&2
+        find "$SHARED_CACHE" -type f >&2 || true
+        return 1
+    fi
+    return 0
+}
+run_test "shared cache root holds runtime-obj entries (#1096)" \
+    check_shared_cache_populated
+
+# ---- Build B: sibling work-dir, warm shared cache -> all hits ----
+if ! do_build "$WORK_B" "$SCRATCH/buildB.log"; then
+    echo "[test] FATAL: build B failed" >&2
+    cat "$SCRATCH/buildB.log" >&2
+    exit 1
+fi
+
+# This is the regression assertion. Pre-#1096, build B's fresh work-dir
+# held no runtime `.o` sidecars, so every runtime object missed
+# (misses>=1) despite the warm shared cache. Post-fix they are served
+# from the shared cache: misses=0, hits>=1.
+check_buildB_warm_hits() {
+    local hits misses
+    hits="$(summary_field "$SCRATCH/buildB.log" hits)"
+    misses="$(summary_field "$SCRATCH/buildB.log" misses)"
+    if [ -z "$hits" ]; then
+        echo "  expected a [cache] summary on warm sibling build B, found none" >&2
+        cat "$SCRATCH/buildB.log" >&2
+        return 1
+    fi
+    if [ "${hits:-0}" -lt 1 ]; then
+        echo "  expected runtime-object hits>=1 on warm sibling build B, got hits=$hits" >&2
+        cat "$SCRATCH/buildB.log" >&2
+        return 1
+    fi
+    if [ "${misses:-0}" -ne 0 ]; then
+        echo "  expected misses=0 on warm sibling build B (shared cache should serve" >&2
+        echo "  every runtime object across work-dirs), got misses=$misses" >&2
+        cat "$SCRATCH/buildB.log" >&2
+        return 1
+    fi
+    return 0
+}
+run_test "warm sibling build B hits runtime objects from shared cache (#1096)" \
+    check_buildB_warm_hits
+
+echo "[test] runtime-object shared cache: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/compiler/tests/e2e/test_work_dir_flag.sh
+++ b/compiler/tests/e2e/test_work_dir_flag.sh
@@ -76,8 +76,11 @@ test_work_dir_layout() {
     # determinism gate can warm one cache across sibling work-dirs.
     # Forbidding all of $SCRATCH/build/ would wrongly couple the shared
     # cache to the work-dir; assert only that build *output* didn't leak.
-    ! [ -e "$SCRATCH/build/native" ] || return 1
-    ! [ -e "$SCRATCH/build/sailfin" ]
+    if [ -e "$SCRATCH/build/native" ] || [ -e "$SCRATCH/build/sailfin" ]; then
+        echo "  work-dir build output leaked into CWD ./build/" >&2
+        return 1
+    fi
+    return 0
 }
 run_test "--work-dir writes default-binary + sailfin/, no CWD ./build/ leakage" test_work_dir_layout
 

--- a/compiler/tests/e2e/test_work_dir_flag.sh
+++ b/compiler/tests/e2e/test_work_dir_flag.sh
@@ -66,8 +66,18 @@ test_work_dir_layout() {
         > "$SCRATCH/build1.stdout" 2>&1 || return 1
     [ -f "$WORK1/native/sailfin" ] || return 1
     [ -d "$WORK1/sailfin" ] || return 1
-    # No leakage to $SCRATCH/build/ (the CWD-relative default).
-    ! [ -d "$SCRATCH/build" ]
+    # No work-dir *artifact* leakage to $SCRATCH/build/: the virtualized
+    # native/ + sailfin/ trees and the default binary must live under
+    # $WORK1, not CWD. The shared content-addressed cache
+    # ($SCRATCH/build/cache) is intentionally NOT virtualized by
+    # --work-dir — it is the CWD-relative default that the .ll module
+    # cache (capsule_resolver.sfn) and, since #1096, the runtime-object
+    # cache both share, independent of work-dir, so the build-quality
+    # determinism gate can warm one cache across sibling work-dirs.
+    # Forbidding all of $SCRATCH/build/ would wrongly couple the shared
+    # cache to the work-dir; assert only that build *output* didn't leak.
+    ! [ -e "$SCRATCH/build/native" ] || return 1
+    ! [ -e "$SCRATCH/build/sailfin" ]
 }
 run_test "--work-dir writes default-binary + sailfin/, no CWD ./build/ leakage" test_work_dir_layout
 

--- a/compiler/tests/unit/build_cache_test.sfn
+++ b/compiler/tests/unit/build_cache_test.sfn
@@ -44,7 +44,8 @@ import {
     empty_build_cache_config,
     empty_cache_stats,
     is_valid_digest,
-    merge_cache_stats
+    merge_cache_stats,
+    runtime_object_entry_key_from_str
 } from "../../src/build_cache";
 
 // --------------------------------------------------------------
@@ -743,4 +744,36 @@ test "cache_compiler_identity: empty binary path falls back to raw stamp" ![io] 
     // No binary to hash (in-process serial fallback) ⇒ keep the raw
     // stamp; no worse than the prior behaviour.
     assert cache_compiler_identity(raw, "") == raw;
+}
+
+test "runtime_object_entry_key_from_str: empty key yields invalid digest" ![io] {
+    // An unhashable runtime source produces an empty
+    // `runtime_object_cache_key` string; the shared-cache key must then
+    // be rejected by the digest validator so every shared helper treats
+    // it as a hard miss rather than reading/writing a bogus entry (#1096).
+    let ck = runtime_object_entry_key_from_str("", "probe_empty");
+    assert ck.digest == "";
+    assert ! is_valid_digest(ck.digest);
+}
+
+test "runtime_object_entry_key_from_str: non-empty key is a valid digest" ![io] {
+    // A real runtime key string hashes to a 64-hex sha256 digest the
+    // shared-cache artifact helpers accept (#1096).
+    let key = "deadbeef\n-O2\nsecsplit1";
+    let ck = runtime_object_entry_key_from_str(key, "probe_valid");
+    assert is_valid_digest(ck.digest);
+    assert ck.digest.length == 64;
+}
+
+test "runtime_object_entry_key_from_str: content-addressed and deterministic" ![io] {
+    // Same key string ⇒ same digest (so sibling work-dirs and CI
+    // restores resolve the same shared entry); distinct key strings ⇒
+    // distinct digests (no cross-source aliasing) (#1096).
+    let key_a = "aaa111\n-O2\nsecsplit1";
+    let key_b = "bbb222\n-O2\nsecsplit1";
+    let a1 = runtime_object_entry_key_from_str(key_a, "det_a1");
+    let a2 = runtime_object_entry_key_from_str(key_a, "det_a2");
+    let b = runtime_object_entry_key_from_str(key_b, "det_b");
+    assert a1.digest == a2.digest;
+    assert a1.digest != b.digest;
 }

--- a/docs/status.md
+++ b/docs/status.md
@@ -155,6 +155,22 @@ feature availability.
     **stderr** (keeping `sfn run`'s program stdout and `--json`'s
     report clean), and the runtime fold is gated on
     `cache_config.enabled` so `--no-cache` still reports zero.
+  - **Shared runtime object cache (#1096)** — runtime C/LL/sfn objects
+    were previously cached only in the per-build work-dir (a sidecar
+    `<obj>.o.key` under `<work-dir>/sailfin/`), so a second build into a
+    *sibling* work-dir always missed them. Once #915 folded them into
+    the summary the build-quality determinism gate (which builds the
+    compiler into `det-pass1` → `det-pass2` sharing one cache root and
+    asserts `cache.hit_rate >= 0.95` on the warm pass) regressed to
+    `0.90`: the 17 runtime objects missed on pass2 while the 155 `.ll`
+    modules hit. Runtime objects now also publish to / fetch from the
+    shared content-addressed cache (`cache_root()`, new `runtime-obj`
+    kind keyed by `runtime_object_entry_key_from_str`) exactly like the
+    `.ll` module cache, so they warm across sibling work-dirs and CI
+    cache restores — restoring the warm second pass to `1.0`. The
+    work-dir sidecar fast-path is preserved, and the shared layer stays
+    gated on `cache_config.enabled` (the `sfn test` link path and
+    `--no-cache` remain work-dir-local).
 - **Stage C2 per-capsule artifact layout (in flight, 2026-04-28).**
   Three PRs land the §4.4 layout (`build/capsules/<scope>/<name>/`)
   for everything `sfn build -p` produces:


### PR DESCRIPTION
## Summary
Routes runtime C/LL/sfn objects through the shared content-addressed cache (`cache_root()`, new `runtime-obj` kind) like the `.ll` module cache, so they warm across sibling work-dirs and CI cache restores.

Closes #1096

## Problem
Runtime objects were cached **only** in the per-build work-dir (`<work-dir>/sailfin/<obj>.o` + a `.o.key` sidecar), never in the shared `build/cache/v1` that the `.ll` module cache uses. The build-quality determinism gate builds the compiler into two sibling work-dirs (`det-pass1` → `det-pass2`) sharing one cache root and asserts `cache.hit_rate >= 0.95` on the warm pass. Once #1075 folded runtime objects into that summary, the work-dir-local runtime cache dragged the warm second pass to **0.9011**: the 17 runtime objects missed on pass2 while the 155 `.ll` modules hit.

## Fix
- New `runtime-obj` artifact kind (`runtime.o`) in `build_cache.sfn` + `runtime_object_entry_key_from_str` (hashes the existing `runtime_object_cache_key` string into a 64-hex digest).
- On a work-dir sidecar miss, `cli_main.sfn` now consults the shared cache (`cache_lookup_artifact` → `cache_copy_artifact_to`) before recompiling, and publishes (`cache_store_artifact`) after a fresh compile. A shared-cache fetch counts as a **hit**.
- A `shared_cache_root` string is threaded through the runtime/link path, set to `cache_root()` when `cache_config.enabled` and `""` otherwise — so `--no-cache` and the `sfn test` link path stay work-dir-local.
- The work-dir sidecar fast-path is preserved.

## Acceptance / verification
Validated against a freshly self-hosted compiler earlier in this work (byte-identical source):
- `make compile` self-hosts.
- Determinism-gate reproduction: cold pass1 → warm sibling pass2 **hit_rate 1.0** (was 0.9011); gate `>= 0.95` passes.
- `--check-determinism` passes; `--no-cache` writes nothing to the shared cache.
- Full `make test` green; `build_cache` unit tests 55/55 (incl. new key-helper cases); new e2e `test_runtime_obj_shared_cache.sh` 3/3.

> Note: a clean cold CI build is the authoritative gate here — local re-runs in the dev container were unreliable due to build-cache contamination from iterating across multiple source states. CI builds cold from a clean checkout.

## Files Changed
- `compiler/src/build_cache.sfn` — `runtime-obj` kind + `runtime_object_entry_key_from_str`.
- `compiler/src/cli_main.sfn` — shared-cache fetch/publish helpers + `shared_cache_root` threading.
- `compiler/src/cli_commands.sfn` — `sfn test` link path passes `""` (work-dir-local).
- `compiler/tests/unit/build_cache_test.sfn` — key-helper unit tests.
- `compiler/tests/e2e/test_runtime_obj_shared_cache.sh` (new) — cross-work-dir warm-hit regression test.
- `compiler/tests/e2e/test_work_dir_flag.sh` — assert no work-dir *artifact* leakage while permitting the shared `build/cache/`.
- `docs/status.md` — note the shared runtime object cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8x1L3m2ZBtmNYXvrZKVi4)_