### PR TITLE
feat(test): scoped with_tmp_dir fixture

### DIFF
--- a/capsules/sfn/test/capsule.toml
+++ b/capsules/sfn/test/capsule.toml
@@ -12,9 +12,6 @@ description = "Test assertion helpers and utilities for Sailfin"
 # formatting still goes through the runtime intrinsic `number_to_string`,
 # the same formatter `pure_assert_eq_float` already uses for fractions.
 "sfn/strings" = "*"
-# `sfn/fs::remove_all` (#976) is the pure-Sailfin `rm -rf` that backs
-# `with_tmp_dir` teardown (#979); `mkdtemp` creates the scoped temp dir.
-"sfn/fs" = "*"
 
 [capabilities]
 required = ["io"]

--- a/capsules/sfn/test/capsule.toml
+++ b/capsules/sfn/test/capsule.toml
@@ -12,6 +12,9 @@ description = "Test assertion helpers and utilities for Sailfin"
 # formatting still goes through the runtime intrinsic `number_to_string`,
 # the same formatter `pure_assert_eq_float` already uses for fractions.
 "sfn/strings" = "*"
+# `sfn/fs::remove_all` (#976) is the pure-Sailfin `rm -rf` that backs
+# `with_tmp_dir` teardown (#979); `mkdtemp` creates the scoped temp dir.
+"sfn/fs" = "*"
 
 [capabilities]
 required = ["io"]

--- a/capsules/sfn/test/src/fixtures.sfn
+++ b/capsules/sfn/test/src/fixtures.sfn
@@ -19,7 +19,7 @@
 //     process-global fixture corrupts sibling tasks the moment the test
 //     runner goes parallel. The right shape is per-child control, which
 //     already ships as the typed `Env` + `os::run_capture` API. A
-//     concurrency-aware redesign is tracked as the #979 follow-up.
+//     concurrency-aware redesign is tracked in #1107.
 //
 // Teardown routes through `sfn/fs::remove_all` (issue #976) — the
 // pure-Sailfin `rm -rf` composed from `deleteFile` / `listDirectory` /
@@ -43,8 +43,15 @@ import { mkdtemp, remove_all } from "sfn/fs";
 // per call and lives under `$TMPDIR` (or `/tmp`). On the error path the
 // directory is removed first, then the original error is re-thrown so the
 // failing test still fails with its own message.
+//
+// `mkdtemp` returns an empty string on failure; we refuse to proceed in
+// that case rather than hand `body` an empty path (which would resolve
+// relative to the cwd) and then `remove_all("")` it. Fail loud instead.
 fn with_tmp_dir(body: fn (string) -> int) -> int ![io] {
     let dir = mkdtemp("sfn-test-");
+    if dir.length == 0 {
+        throw "with_tmp_dir: mkdtemp failed to create a temporary directory";
+    }
     try {
         let result = body(dir);
         let _ = remove_all(dir);

--- a/capsules/sfn/test/src/fixtures.sfn
+++ b/capsules/sfn/test/src/fixtures.sfn
@@ -21,10 +21,42 @@
 //     already ships as the typed `Env` + `os::run_capture` API. A
 //     concurrency-aware redesign is tracked in #1107.
 //
-// Teardown routes through `sfn/fs::remove_all` (issue #976) — the
-// pure-Sailfin `rm -rf` composed from `deleteFile` / `listDirectory` /
-// `removeDirectory`. No new C runtime surface is introduced.
-import { mkdtemp, remove_all } from "sfn/fs";
+// Teardown is a pure-Sailfin `rm -rf` composed from the `fs.*` runtime
+// intrinsics (`deleteFile` / `exists` / `listDirectory` / `removeDirectory`).
+// No new C runtime surface is introduced.
+//
+// NOTE — why this does NOT import `sfn/fs::remove_all` (#976): the batched
+// test runner (`sailfin test <many files>`, used by CI's int-e2e-caps
+// shard) miscompiles when a non-inlined capsule is consumed by *two*
+// capsules in one invocation — only the first consumer links the capsule's
+// object; later ones fail with `undefined reference` (sfn/strings, which
+// inlines, is unaffected; sfn/fs is not). Having `sfn/test` depend on
+// `sfn/fs` made every `sfn/test` barrel test a second `sfn/fs` consumer
+// alongside `sfn/fs`'s own tests, breaking the shard (tracked as #1113).
+// Until that harness bug is fixed, `with_tmp_dir` uses `fs.*` directly — the
+// same primitives `#976`'s `remove_all` composes (and the same approach
+// `snapshot.sfn` already uses for `fs.writeFile`/`fs.createDirectory`), so
+// there is no new C and no behavioral difference. `_remove_all` below
+// mirrors `capsules/sfn/fs/src/mod.sfn::remove_all`; once the batched-link
+// bug is resolved this can switch back to importing that helper.
+// Recursively remove `path` and everything beneath it (`rm -rf`), returning
+// true when the path is gone afterward (including the no-op case where it
+// never existed). Mirrors `sfn/fs::remove_all` (#976): try the file/symlink
+// unlink first (removes dangling symlinks directly and never recurses
+// *through* a symlinked directory), treat a missing path as success, then
+// clear a real directory's children before removing the emptied directory.
+fn _remove_all(path: string) -> boolean ![io] {
+    if fs.deleteFile(path) { return true; }
+    if !fs.exists(path) { return true; }
+    let entries = fs.listDirectory(path);
+    let mut i: int = 0;
+    loop {
+        if i >= entries.length { break; }
+        let _ = _remove_all(path + "/" + entries[i]);
+        i += 1;
+    }
+    return fs.removeDirectory(path);
+}
 
 // Create a fresh temporary directory, hand its absolute path to `body`,
 // and recursively remove the whole tree on scope exit — on both the
@@ -39,25 +71,25 @@ import { mkdtemp, remove_all } from "sfn/fs";
 // thunks; a body that produces nothing returns `0`. A generic result type
 // waits on generics.)
 //
-// The directory is created with `mkdtemp("sfn-test-")`, so it is unique
+// The directory is created with `fs.mkdtemp("sfn-test-")`, so it is unique
 // per call and lives under `$TMPDIR` (or `/tmp`). On the error path the
 // directory is removed first, then the original error is re-thrown so the
 // failing test still fails with its own message.
 //
-// `mkdtemp` returns an empty string on failure; we refuse to proceed in
+// `fs.mkdtemp` returns an empty string on failure; we refuse to proceed in
 // that case rather than hand `body` an empty path (which would resolve
-// relative to the cwd) and then `remove_all("")` it. Fail loud instead.
+// relative to the cwd) and then remove it. Fail loud instead.
 fn with_tmp_dir(body: fn (string) -> int) -> int ![io] {
-    let dir = mkdtemp("sfn-test-");
+    let dir = fs.mkdtemp("sfn-test-");
     if dir.length == 0 {
         throw "with_tmp_dir: mkdtemp failed to create a temporary directory";
     }
     try {
         let result = body(dir);
-        let _ = remove_all(dir);
+        let _ = _remove_all(dir);
         return result;
     } catch (e) {
-        let _ = remove_all(dir);
+        let _ = _remove_all(dir);
         throw e;
     }
 }

--- a/capsules/sfn/test/src/fixtures.sfn
+++ b/capsules/sfn/test/src/fixtures.sfn
@@ -1,0 +1,56 @@
+// sfn/test — Scoped test fixtures (issue #979, proposal §2.2).
+//
+// A scoped fixture sets up a resource, runs a body closure, and tears the
+// resource down on scope exit — including when the body throws. The body
+// is an ordinary closure that may capture the enclosing test's locals
+// (M1.5 closures-with-capture, #687 emission + #689 dispatch).
+//
+// Only `with_tmp_dir` ships here. The originally-proposed `with_env` and
+// `with_cwd` fixtures are intentionally NOT provided:
+//
+//   * They require mutating *process-global* state (`setenv` / `chdir`)
+//     and restoring it. The runtime exposes no such primitive — only
+//     `env.get` / `env.home` exist — and adding C for it cuts against the
+//     in-flight C→Sailfin runtime port (the C surface is frozen after the
+//     test-infra epic's Phase 0).
+//   * Even with the primitives, both are unsound under structured
+//     concurrency: `chdir(2)` sets a per-*process* working directory and
+//     `setenv(3)` mutates a shared, non-thread-safe `environ`, so a
+//     process-global fixture corrupts sibling tasks the moment the test
+//     runner goes parallel. The right shape is per-child control, which
+//     already ships as the typed `Env` + `os::run_capture` API. A
+//     concurrency-aware redesign is tracked as the #979 follow-up.
+//
+// Teardown routes through `sfn/fs::remove_all` (issue #976) — the
+// pure-Sailfin `rm -rf` composed from `deleteFile` / `listDirectory` /
+// `removeDirectory`. No new C runtime surface is introduced.
+import { mkdtemp, remove_all } from "sfn/fs";
+
+// Create a fresh temporary directory, hand its absolute path to `body`,
+// and recursively remove the whole tree on scope exit — on both the
+// normal-return and the throwing path. Returns whatever `body` returns.
+//
+// `body` may be a capturing lambda; it closes over the enclosing test's
+// locals. The parameter is typed `fn(string) -> int` (no `![io]` row):
+// the effect checker attributes a lambda body's effects to the scope that
+// *defines* the lambda, so an `![io]` test that builds the closure already
+// accounts for any io inside it — the fn-type itself carries no effect row.
+// (`-> int` is the interim return shape shared with the `expect_to_throw`
+// thunks; a body that produces nothing returns `0`. A generic result type
+// waits on generics.)
+//
+// The directory is created with `mkdtemp("sfn-test-")`, so it is unique
+// per call and lives under `$TMPDIR` (or `/tmp`). On the error path the
+// directory is removed first, then the original error is re-thrown so the
+// failing test still fails with its own message.
+fn with_tmp_dir(body: fn (string) -> int) -> int ![io] {
+    let dir = mkdtemp("sfn-test-");
+    try {
+        let result = body(dir);
+        let _ = remove_all(dir);
+        return result;
+    } catch (e) {
+        let _ = remove_all(dir);
+        throw e;
+    }
+}

--- a/capsules/sfn/test/src/mod.sfn
+++ b/capsules/sfn/test/src/mod.sfn
@@ -385,3 +385,14 @@ export { expect_snapshot, snapshot_match_in } from "./snapshot";
 // `sailfin-check/1` envelope with `sfn/json`. Both are `![io]` and
 // return a `MatchResult`. See `compile_assert.sfn`.
 export { CompileExpect, assert_compiles, assert_does_not_compile } from "./compile_assert";
+
+// ---------------------------------------------------------------------------
+// Scoped fixtures (issue #979, proposal §2.2)
+// ---------------------------------------------------------------------------
+// `with_tmp_dir(body)` creates a temp dir, runs the (possibly capturing)
+// `body` closure against it, and recursively removes the tree on scope
+// exit — including the throwing path — via `sfn/fs::remove_all` (#976).
+// The proposed `with_env` / `with_cwd` are intentionally omitted (no
+// runtime setenv/chdir primitive; process-global mutation is unsound
+// under structured concurrency). See `fixtures.sfn`.
+export { with_tmp_dir } from "./fixtures";

--- a/capsules/sfn/test/src/mod.sfn
+++ b/capsules/sfn/test/src/mod.sfn
@@ -391,8 +391,10 @@ export { CompileExpect, assert_compiles, assert_does_not_compile } from "./compi
 // ---------------------------------------------------------------------------
 // `with_tmp_dir(body)` creates a temp dir, runs the (possibly capturing)
 // `body` closure against it, and recursively removes the tree on scope
-// exit — including the throwing path — via `sfn/fs::remove_all` (#976).
-// The proposed `with_env` / `with_cwd` are intentionally omitted (no
-// runtime setenv/chdir primitive; process-global mutation is unsound
-// under structured concurrency). See `fixtures.sfn`.
+// exit — including the throwing path — via a pure-Sailfin `rm -rf` over the
+// `fs.*` intrinsics (mirroring `sfn/fs::remove_all` from #976; see the note
+// in `fixtures.sfn` for why it does not import that capsule). The proposed
+// `with_env` / `with_cwd` are intentionally omitted (no runtime
+// setenv/chdir primitive; process-global mutation is unsound under
+// structured concurrency). See `fixtures.sfn`.
 export { with_tmp_dir } from "./fixtures";

--- a/capsules/sfn/test/tests/fixtures_test.sfn
+++ b/capsules/sfn/test/tests/fixtures_test.sfn
@@ -1,0 +1,134 @@
+// Tests for the sfn/test scoped fixtures (#979, proposal §2.2).
+//
+// `with_tmp_dir(body)` creates a temp dir, runs the closure `body`, and
+// recursively removes the tree on scope exit — including when `body`
+// throws. The body is a capturing lambda (M1.5 closures, #687 emission +
+// #689 dispatch); these tests are the capsule-side proof that the chain
+// works end to end against real I/O.
+//
+// Every test is `![io]`: `with_tmp_dir` and the `fs.*` setup/inspection
+// calls all require it, and a body lambda's effects bubble into the
+// enclosing `![io]` test scope.
+//
+// Verifying teardown needs the created path *after* the scope exits, but
+// the path is minted inside `with_tmp_dir`. A lifted lambda cannot write
+// an enclosing/global mutable (the store is dropped) and mutable captures
+// are refused (#687), so the path is ferried out the only channel that
+// survives a lifted body: the filesystem. Each body writes its `dir` to a
+// per-test marker file (a captured local), which the test reads back to
+// assert the directory is gone.
+//
+// SINGLE-CAPTURE CONSTRAINT: every body lambda below captures at most one
+// enclosing local. A lambda capturing *two* locals currently miscompiles
+// — the env-struct type is emitted with only the first field while the
+// load prologue GEPs the second, producing invalid LLVM IR (tracked as a
+// separate multi-capture lowering bug). Single capture — the path the
+// `closure_single_capture` e2e fixture exercises and that #979 actually
+// rides — works; these tests stay within it deliberately.
+import { find } from "sfn/strings";
+
+import { with_tmp_dir } from "../src/mod";
+
+// Scratch root for marker files. Prefer the runner's
+// `SAILFIN_TEST_SCRATCH`; fall back to `/tmp` for a direct
+// `sfn test <file>` invocation that did not export it.
+fn _scratch() -> string ![io] {
+    let s = env.get("SAILFIN_TEST_SCRATCH");
+    if s.length > 0 { return s; }
+    return "/tmp";
+}
+
+// A fresh marker-file path for `name`, with any stale value from a prior
+// run removed so each test starts clean.
+fn _marker(name: string) -> string ![io] {
+    let dir = _scratch();
+    fs.createDirectory(dir, true);
+    let path = dir + "/sfn-fixture-" + name + ".path";
+    if fs.exists(path) { fs.deleteFile(path); }
+    return path;
+}
+
+fn _cleanup(path: string) ![io] {
+    if fs.exists(path) { fs.deleteFile(path); }
+}
+
+// The body observes a directory that exists and is named `sfn-test-*`,
+// and its return value threads back out through the fixture. The body
+// captures nothing (`find` is an imported symbol, not a local).
+test "with_tmp_dir: body sees an existing, well-named dir; result threads through" ![io] {
+    let r = with_tmp_dir(fn (d: string) -> int {
+        if !fs.exists(d) { return -1; }
+        if find(d, "sfn-test-", 0) < 0 { return -2; }
+        return 42;
+    });
+    assert r == 42;
+}
+
+// On a normal return the directory is removed. The body captures the
+// single local `marker`.
+test "with_tmp_dir: removes the dir on normal scope exit" ![io] {
+    let marker = _marker("remove");
+    let r = with_tmp_dir(fn (d: string) -> int {
+        fs.writeFile(marker, d);
+        return 0;
+    });
+    assert r == 0;
+    let recorded = fs.readFile(marker);
+    assert recorded.length > 0;
+    assert ! fs.exists(recorded);
+    _cleanup(marker);
+}
+
+// A *non-empty* tree is removed — proving the teardown recurses rather
+// than a bare `rmdir` (which would fail on the non-empty dir and leave it
+// behind). Routes through `sfn/fs::remove_all` (#976). Captures `marker`.
+test "with_tmp_dir: recursively removes a nested tree on scope exit" ![io] {
+    let marker = _marker("nested");
+    let r = with_tmp_dir(fn (d: string) -> int {
+        fs.createDirectory(d + "/a/b", true);
+        fs.writeFile(d + "/a/b/leaf.txt", "x");
+        fs.writeFile(marker, d);
+        if fs.exists(d + "/a/b/leaf.txt") { return 1; }
+        return 0;
+    });
+    assert r == 1;
+    let recorded = fs.readFile(marker);
+    assert recorded.length > 0;
+    assert ! fs.exists(recorded);
+    _cleanup(marker);
+}
+
+// The directory is removed even when the body throws, and the original
+// error propagates (the fixture must not swallow a failing test).
+// Captures `marker`.
+test "with_tmp_dir: removes the dir and re-throws when body throws" ![io] {
+    let marker = _marker("throws");
+    let mut threw = false;
+    try {
+        let _ = with_tmp_dir(fn (d: string) -> int {
+            fs.createDirectory(d + "/sub", true);
+            fs.writeFile(marker, d);
+            throw "fixture-body-boom";
+        });
+    } catch (e) { threw = true; }
+    assert threw;
+    let recorded = fs.readFile(marker);
+    assert recorded.length > 0;
+    assert ! fs.exists(recorded);
+    _cleanup(marker);
+}
+
+// The body closure captures the enclosing local `token`: the filename
+// written inside the temp dir is derived from it, so a correct result is
+// only possible if capture works (the #687/#689 gate this issue rode).
+// Exactly one capture (`token`).
+test "with_tmp_dir: body captures an enclosing local" ![io] {
+    let token: string = "captured-name";
+    let r = with_tmp_dir(fn (d: string) -> int {
+        let f = d + "/" + token;
+        fs.writeFile(f, "present");
+        if fs.exists(f) { return token.length; }
+        return -1;
+    });
+    assert r == token.length;
+}


### PR DESCRIPTION
## Summary
- Adds `with_tmp_dir(body)` to the `sfn/test` capsule: create a temp dir via `fs.mkdtemp`, run the (possibly capturing) body closure against it, and recursively remove the tree on scope exit — on **both** the normal-return and the throwing path — re-throwing the original error.
- Teardown is a pure-Sailfin `rm -rf` over the `fs.*` runtime intrinsics (an inlined `_remove_all` mirroring `sfn/fs::remove_all` from #976; see "Build-harness note" below for why it doesn't import the capsule). No new C.
- `with_env` / `with_cwd` from the original proposal are **dropped** (no runtime `setenv`/`chdir`; process-global mutation is unsound under structured concurrency) and folded into a concurrency-aware follow-up, **#1107**.

Closes #979

## Why the re-scope
The runtime exposes only `env.get` / `env.home` — no `setenv`/`unsetenv`/`chdir`/`getcwd`. Even with those primitives, a "save/restore" env/cwd fixture mutates **process-global** state: `chdir(2)` is per-process and `setenv(3)` is not thread-safe, so it would corrupt sibling tasks once the runner parallelizes — at odds with the structured-concurrency pillar. Per-child env/cwd already ships via the typed `Env` + `os::run_capture` API; the redesign is tracked in #1107.

## What's implemented
- `capsules/sfn/test/src/fixtures.sfn` — `with_tmp_dir` + `_remove_all`. No `finally` in the language, so cleanup uses `try { … } catch (e) { _remove_all(dir); throw e; }`. Guards against `fs.mkdtemp` returning an empty string (refuses rather than operating on a cwd-relative path).
- `capsules/sfn/test/src/mod.sfn` — barrel re-export.
- `capsules/sfn/test/tests/fixtures_test.sfn` — 5 tests.

## Acceptance Criteria (from #979)
- [x] `with_tmp_dir(body)` creates a temp dir, invokes `body(dir)`, recursively removes it on scope exit **including error paths**.
- [x] Recursive removal is pure-Sailfin (no new C), mirroring `sfn/fs::remove_all` (#976). _Literal reuse of the #976 helper is deferred to the #1113 harness fix — see note below; the algorithm is identical._
- [x] A capturing lambda passed as `body` compiles, runs, and self-hosts.
- [x] ≥4 tests (5 here).

## Build-harness note (#1113)
The fixture initially **imported** `sfn/fs::remove_all` (#976). That turned the `int-e2e-caps` CI shard red: that shard runs `sailfin test <many files>` in one process, and batched `sailfin test` has a bug where a **non-inlined** capsule consumed by **two** capsules links only for the first consumer — later ones fail with `undefined reference` (`sfn/strings` inlines and is unaffected; `sfn/fs` does not). Making `sfn/test` depend on `sfn/fs` added a second `sfn/fs` consumer alongside `sfn/fs`'s own tests, so every `sfn/test` barrel test failed to link even though each passes individually. Filed as **#1113**. Workaround here: call the `fs.*` intrinsics directly (as `snapshot.sfn` already does) with an inlined `_remove_all`; switch back to importing `remove_all` once #1113 is fixed.

## Verification
```
# batched run mimicking the CI shard, fresh cache — all green:
$ SAILFIN_BUILD_CACHE_DIR=/tmp/fresh build/native/sailfin test \
    capsules/sfn/test/tests/{expect,snapshot,compile_assert,fixtures}_test.sfn \
    capsules/sfn/fs/tests/{fs,remove}_test.sfn
  ... PASS x6
$ build/native/sailfin fmt --check <touched .sfn files>   # clean
```
Tests cover: dir visible + `sfn-test-*` named inside body; removal on normal exit; recursive removal of a **non-empty** tree (proves recursion, not bare `rmdir`); cleanup + re-throw on a throwing body; capture of an enclosing local.

## Related issues filed
- **#1106** — compiler bug: a lambda capturing **two** locals emits a one-field env struct → invalid IR. Single capture works; the fixture tests stay single-capture.
- **#1107** — follow-up: concurrency-aware env/cwd test control.
- **#1113** — build-harness bug: batched `sailfin test` drops a non-inlined capsule's object for all but the first cross-capsule consumer (the reason for the workaround above).

## Files Changed
- `capsules/sfn/test/src/fixtures.sfn` (new)
- `capsules/sfn/test/src/mod.sfn`
- `capsules/sfn/test/tests/fixtures_test.sfn` (new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)