### PR TITLE
chore(commands): add promotion pass + tolerant matching to /triage

### DIFF
--- a/.claude/commands/sweep.md
+++ b/.claude/commands/sweep.md
@@ -85,6 +85,13 @@ The in-flight set is the union of the two queries (de-duped by PR number).
 
 ## Phase 2: SWEEP BLOCKERS
 
+> **Shared logic.** The hard-vs-prose blocker-clearing rule below is the one
+> mechanic `/sweep` and `/triage` have in common (`/triage` Phase 3 → UNBLOCK).
+> They are otherwise distinct — `/sweep` is the post-merge coordinator (budget,
+> collisions, dispatch); `/triage` is the whole-queue hygiene auditor
+> (promote/demote, Type fixes, orphan release). Do not merge them. If you change
+> this rule, mirror it in `/triage`.
+
 For each issue in the `blocked` pool:
 
 1. Parse the `## Blocked by` section of the body. Extract every `#N` reference via regex (`#\d+`).

--- a/.claude/commands/triage.md
+++ b/.claude/commands/triage.md
@@ -120,9 +120,10 @@ The helper derives the column from post-edit labels with strict precedence:
 ### PROMOTE — move a groomed issue to Ready
 
 ```bash
-# Backfill the size label from the body's "## Size" block if the label is absent.
-# (XS→size:xs, S→size:s, M→size:m.) Skip if a size:* label already exists.
-gh issue edit <N> --remove-label "needs-grooming" --add-label "claude-ready"   # add size:<x> here too if backfilling
+# If no size:* label exists, backfill it from the body's "## Size" block by
+# appending another --add-label flag (XS→size:xs, S→size:s, M→size:m), e.g.
+#   gh issue edit <N> --remove-label "needs-grooming" --add-label "claude-ready" --add-label "size:s"
+gh issue edit <N> --remove-label "needs-grooming" --add-label "claude-ready"
 gh issue comment <N> --body "Auto-triage promotion: body passes the full hygiene bar (Goal/Scope-In-Out/Acceptance/Files/Verification) with no open blocker or unresolved decision. <If size backfilled: 'Size declared as <X> in the body; applied the size:<x> label.'> <If a precondition was checked: 'Precondition met — #<M> is closed.'> Moving to claude-ready/Ready."
 .claude/scripts/sync-project-status.sh <N> --from-labels   # → Ready
 ```
@@ -143,14 +144,17 @@ Run \`/groom\` to flesh this out, or close if no longer relevant."
 Parse `## Blocked by`. Classify each reference:
 - **Hard reference (`#N`)** — closed/merged = resolved; open = still blocking.
 - **Prose reference** (e.g. "Slice E", "the M4 runtime port", "a fresh seed
-  cut") — always ambiguous; **never auto-flip on prose alone.**
+  cut") — an agent cannot determine when prose is satisfied, so its mere
+  **presence** blocks the auto-flip. Only a human can clear a prose gate.
 
-Flip **only** when every hard `#N` ref is closed AND no prose reference
-remains unresolved:
+Flip **only** when (a) every hard `#N` ref is closed AND (b) the `## Blocked by`
+section contains **no prose gate at all**. If any prose gate is present, leave
+the `blocked` label and surface the issue under "Held back" for human review —
+never auto-flip.
 
 ```bash
 gh issue edit <N> --remove-label "blocked" --add-label "claude-ready"
-gh issue comment <N> --body "Auto-triage: blocker(s) resolved — <list resolved #N>. No open hard references or unresolved prose gates. Marking ready for pickup."
+gh issue comment <N> --body "Auto-triage: all hard blocker references closed (<list resolved #N>) and no prose gate present in '## Blocked by'. Marking ready for pickup."
 .claude/scripts/sync-project-status.sh <N> --from-labels   # → Ready
 ```
 
@@ -174,7 +178,7 @@ gh issue comment <N> --body "Auto-triage: claude-ready for 30+ days without pick
 ### OVERSIZED — L-sized → epic
 
 ```bash
-gh issue edit <N> --remove-label "claude-ready" --add-label "needs-grooming,epic"
+gh issue edit <N> --remove-label "claude-ready" --add-label "needs-grooming" --add-label "epic"
 gh issue comment <N> --body "Auto-triage: this issue is L-sized; the canonical scheme has no \`size:l\`. Marking \`epic\` + \`needs-grooming\`. Run \`/groom #<N>\` to decompose into XS/S/M children."
 .claude/scripts/sync-project-status.sh <N> --from-labels   # → To triage
 ```

--- a/.claude/commands/triage.md
+++ b/.claude/commands/triage.md
@@ -1,10 +1,25 @@
 # Triage the Issue Queue
 
-Audit open issues for hygiene. Flag issues that aren't ready for `/pickup`. Surface stale, blocked, and orphaned work.
+Audit open issues for hygiene **in both directions**: demote incomplete
+`claude-ready` issues, and **promote already-groomed `needs-grooming` issues
+that nobody ever moved**. Surface stale, blocked, and orphaned work.
 
 ## Target: $ARGUMENTS
 
 Optional filter — pass a label (e.g., `type:perf`) to triage a subset, or leave empty to triage everything.
+
+## Relationship to `/sweep`
+
+`/triage` is the **periodic, whole-queue hygiene auditor**. `/sweep` is the
+**event-driven, post-merge coordinator** (concurrency budget, file-collision
+analysis, dispatch sequencing, release-tracking sync). They are not
+interchangeable — run `/triage` to keep the queue honest, run `/sweep` after a
+merge to pick the next work.
+
+The one mechanic they share is **clearing a blocker whose blocking issue
+closed**. Both use the identical hard-vs-prose rule (Phase 3 → UNBLOCK below).
+Keep that logic in sync: if you change blocker-clearing here, mirror it in
+`/sweep` Phase 2, and vice-versa.
 
 ---
 
@@ -23,101 +38,163 @@ Apply the optional label filter from `$ARGUMENTS` if provided.
 
 ---
 
+## The hygiene matcher (shared definition)
+
+Both demotion and promotion depend on deciding whether a body is
+**complete**. The matcher MUST be tolerant of real-world markdown variants —
+a brittle literal match is what let fully-groomed issues rot in the backlog.
+
+An issue body is **complete** when all of these are present (match
+case-insensitively, accept any of the listed forms):
+
+| Section | Accept any of |
+|---|---|
+| Goal | `## Goal` |
+| Scope | `## Scope` |
+| Scope → In | `In:` · `### In` · `**In:**` · `**In**` (anywhere under Scope) |
+| Scope → Out | `Out:` · `### Out` · `**Out:**` · `**Out**` |
+| Acceptance | `## Acceptance` (e.g. "Acceptance Criteria") with ≥1 `- [ ]` item |
+| Files | `## Files` (e.g. "Files Affected"), not "TBD"/empty |
+| Verification | `## Verification` with a runnable command |
+
+**Size** is satisfied by EITHER a `size:{xs,s,m}` label OR a `## Size` body
+section declaring XS/S/M. If the body declares a size but the label is
+missing, that is a **backfill**, not a failure (see PROMOTE).
+
+**Type** is satisfied by a `type:*` label. (The GitHub native Type field is a
+separate, always-applied fix — see TYPE-FIX.)
+
+---
+
 ## Phase 2: AUDIT
 
-For each issue, check:
+Classify every issue into exactly one action bucket. Apply the matcher above.
 
-### Hygiene checks (must all pass for `claude-ready`)
-- [ ] Has a `## Goal` section with a single sentence
-- [ ] Has `## Scope` with both `In:` and `Out:` populated
-- [ ] Has `## Acceptance Criteria` with at least one specific, verifiable item
-- [ ] Has `## Files Affected` listing the files (not "TBD" or empty)
-- [ ] Has `## Verification` with a runnable command
-- [ ] Has a `size:*` label (XS/S/M — never L)
-- [ ] Has a `type:*` label (feature/bug/perf/refactor)
-- [ ] Has the GitHub native **Type** field set (Feature / Task / Bug) — check via
-  `gh api graphql -f query='query{repository(owner:"SailfinIO",name:"sailfin"){issue(number:<N>){issueType{name}}}}'`
+### Promotion candidates (the column-unsticking pass)
+An issue is a **PROMOTE** candidate when ALL hold:
+- It is `needs-grooming` (or carries no lifecycle label at all), and is **not** an `epic`.
+- Its body is **complete** per the matcher (size may be body-only).
+- It has **no open blocker** (apply the UNBLOCK hard-vs-prose rule to its `## Blocked by`).
+- It has **no unresolved in-body decision or precondition** (see guards below).
 
-### State checks
-- Is it `claude-ready` but actually stale (no update in 30+ days)?
-- Is it `in-progress` but the assignee branch is gone or PR closed?
-- Is it `blocked` but the blocking issue is closed?
-- Is it `needs-grooming` but has been sitting for 14+ days?
+**Promotion guards — do NOT promote if any apply** (these are the traps that
+keep an issue genuinely un-pickable even with a complete-looking body):
+- **Open design choice in body:** phrases like "pick during grooming",
+  "one of (a)/(b)", "decide during grooming", "TBD by grooming", a Scope that
+  lists mutually-exclusive options to choose between. → leave `needs-grooming`, flag.
+- **Unmet precondition:** phrases like "once a seed past #N is pinned",
+  "after #M closes/lands", "blocked on <prose>". Resolve the referenced
+  issue/PR: if it is **closed/merged**, the precondition is met (promote, and
+  say so in the comment). If still **open**, leave `needs-grooming` and flag.
+- **Deferred-by-design:** "not picked up until …", "deliberately deferred".
+  Verify the gating issue closed before promoting; otherwise leave + flag.
+
+### Demotion candidates
+An issue is a **DEMOTE** candidate when it is `claude-ready` but its body is
+**incomplete** per the matcher, or it lacks a `type:*` label, or it is missing
+a size entirely (no label AND no `## Size`).
+
+### State buckets
+- **UNBLOCK** — `blocked` and every hard `#N` ref in `## Blocked by` is closed (see rule below).
+- **RELEASE** — `in-progress` but no active branch / its PR closed unmerged.
+- **STALE** — `claude-ready` with no update in 30+ days (flag only).
+- **OVERSIZED** — slipped through as L (no `size:l` exists; → `epic`).
+- **TYPE-FIX** — GitHub native Type field is `null` (always fix, silently).
+- **STALE-GROOM** — `needs-grooming` 14+ days that is NOT a promote candidate
+  (still incomplete) → flag for `/groom` or closure review (no label change).
 
 ---
 
 ## Phase 3: APPLY ACTIONS
 
-Every label flip in this phase MUST be followed by a board sync so the card
-moves to the matching column on the Sailfin Tracker (Project #4). Use:
+Every label flip MUST be followed by a board sync so the card moves to the
+matching column on the Sailfin Tracker (Project #4):
 
 ```bash
 .claude/scripts/sync-project-status.sh <N> --from-labels
 ```
 
-The helper derives the column from the post-edit labels with strict
-precedence: `in-progress` > `blocked` > `needs-grooming` > `claude-ready`.
+The helper derives the column from post-edit labels with strict precedence:
+`in-progress` > `blocked` > `needs-grooming` > `claude-ready`.
 
-For each issue with hygiene failures:
+### PROMOTE — move a groomed issue to Ready
 
 ```bash
-# Strip claude-ready, add needs-grooming, comment with what's missing
+# Backfill the size label from the body's "## Size" block if the label is absent.
+# (XS→size:xs, S→size:s, M→size:m.) Skip if a size:* label already exists.
+gh issue edit <N> --remove-label "needs-grooming" --add-label "claude-ready"   # add size:<x> here too if backfilling
+gh issue comment <N> --body "Auto-triage promotion: body passes the full hygiene bar (Goal/Scope-In-Out/Acceptance/Files/Verification) with no open blocker or unresolved decision. <If size backfilled: 'Size declared as <X> in the body; applied the size:<x> label.'> <If a precondition was checked: 'Precondition met — #<M> is closed.'> Moving to claude-ready/Ready."
+.claude/scripts/sync-project-status.sh <N> --from-labels   # → Ready
+```
+
+### DEMOTE — strip claude-ready from an incomplete issue
+
+```bash
 gh issue edit <N> --remove-label "claude-ready" --add-label "needs-grooming"
 gh issue comment <N> --body "Auto-triage: missing the following sections required for /pickup eligibility:
 - <list of failed checks>
 
 Run \`/groom\` to flesh this out, or close if no longer relevant."
-
-# Move the card to "To triage" so the board reflects the new state
-.claude/scripts/sync-project-status.sh <N> --from-labels
-```
-
-For state issues:
-
-```bash
-# Blocker resolved — clear the blocked label
-gh issue edit <N> --remove-label "blocked" --add-label "claude-ready"
-gh issue comment <N> --body "Auto-triage: blocking issue #<M> is closed. Marking ready for pickup."
-.claude/scripts/sync-project-status.sh <N> --from-labels   # → Ready
-
-# Stale claude-ready — flag for review (no label change, no board move)
-gh issue comment <N> --body "Auto-triage: this issue has been claude-ready for 30+ days without pickup. Likely stale — review priority or close."
-
-# Orphaned in-progress — release back to the queue
-gh issue edit <N> --remove-label "in-progress" --add-label "claude-ready"
-gh issue comment <N> --body "Auto-triage: in-progress label was set but no active branch found. Releasing back to queue."
-.claude/scripts/sync-project-status.sh <N> --from-labels   # → Ready
-```
-
-For `L` sized issues that snuck through (no `size:l` label exists in the
-canonical scheme — anything that would be L gets `epic` instead):
-
-```bash
-gh issue edit <N> --remove-label "claude-ready" --add-label "needs-grooming,epic"
-gh issue comment <N> --body "Auto-triage: this issue is L-sized; the canonical scheme has no \`size:l\`. Marking as \`epic\` + \`needs-grooming\`. Run \`/groom #<N>\` to decompose into XS/S/M children."
 .claude/scripts/sync-project-status.sh <N> --from-labels   # → To triage
 ```
 
-For issues whose GitHub native **Type** field is `null`:
+### UNBLOCK — clear a resolved blocker (hard-vs-prose rule, shared with `/sweep`)
+
+Parse `## Blocked by`. Classify each reference:
+- **Hard reference (`#N`)** — closed/merged = resolved; open = still blocking.
+- **Prose reference** (e.g. "Slice E", "the M4 runtime port", "a fresh seed
+  cut") — always ambiguous; **never auto-flip on prose alone.**
+
+Flip **only** when every hard `#N` ref is closed AND no prose reference
+remains unresolved:
 
 ```bash
-# Derive from type:* label; set silently (no board sync needed — Type is not a label)
+gh issue edit <N> --remove-label "blocked" --add-label "claude-ready"
+gh issue comment <N> --body "Auto-triage: blocker(s) resolved — <list resolved #N>. No open hard references or unresolved prose gates. Marking ready for pickup."
+.claude/scripts/sync-project-status.sh <N> --from-labels   # → Ready
+```
+
+If a blocker is `needs-grooming`-incomplete after unblocking, fold it through
+the PROMOTE guard rather than landing it in Ready half-baked.
+
+### RELEASE — orphaned in-progress back to the queue
+
+```bash
+gh issue edit <N> --remove-label "in-progress" --add-label "claude-ready"
+gh issue comment <N> --body "Auto-triage: in-progress label was set but no active branch/PR found. Releasing back to queue."
+.claude/scripts/sync-project-status.sh <N> --from-labels   # → Ready
+```
+
+### STALE — flag only (no label change, no board move)
+
+```bash
+gh issue comment <N> --body "Auto-triage: claude-ready for 30+ days without pickup. Likely stale — review priority or close."
+```
+
+### OVERSIZED — L-sized → epic
+
+```bash
+gh issue edit <N> --remove-label "claude-ready" --add-label "needs-grooming,epic"
+gh issue comment <N> --body "Auto-triage: this issue is L-sized; the canonical scheme has no \`size:l\`. Marking \`epic\` + \`needs-grooming\`. Run \`/groom #<N>\` to decompose into XS/S/M children."
+.claude/scripts/sync-project-status.sh <N> --from-labels   # → To triage
+```
+
+### TYPE-FIX — null GitHub native Type field (silent, always)
+
+```bash
 # type:feature → Feature, type:bug → Bug, everything else → Task
 .claude/scripts/set-issue-type.sh <N> <Feature|Task|Bug>
 ```
 
-This is a **silent fix** — no label edit, no comment, no board sync required.
-Apply it to all issues with a null type regardless of other state.
+Apply to all issues with a null type regardless of other state. No label edit,
+no comment, no board sync.
 
-If a sync call exits non-zero, capture the issue number and surface it under
-"Concerns" in the Phase 4 report — the label flip stands but the board is
-out of sync and a human should reconcile it.
+If a sync call exits non-zero, capture the issue number under "Concerns" in the
+report — the label flip stands but the board is out of sync.
 
 ---
 
 ## Phase 4: REPORT
-
-Produce a summary report:
 
 ```
 Triage Report (<date>)
@@ -134,7 +211,8 @@ Status breakdown:
   blocked (cleared):        <N>
 
 Actions taken:
-  - Stripped claude-ready from <N> issues missing required sections
+  - Promoted <N> groomed issues to Ready (backfilled <N> size labels)
+  - Stripped claude-ready from <N> incomplete issues
   - Released <N> orphaned in-progress issues back to queue
   - Unblocked <N> issues whose blockers closed
   - Flagged <N> stale claude-ready issues for human review
@@ -144,6 +222,11 @@ Top picks for /pickup right now:
   1. #<N> — <title> (type, size)
   2. #<N> — <title> (type, size)
   3. #<N> — <title> (type, size)
+
+Held back (complete body, but not pickable):
+  ? #<N> — open design choice ((a) vs (b))
+  ? #<N> — precondition #<M> still open
+  ? #<N> — blocked on <prose>, no tracking issue
 
 Concerns:
   - <anything that needs human attention>
@@ -155,11 +238,16 @@ Concerns:
 
 - **Don't close issues automatically.** Closing is a human decision.
 - **Don't modify issue bodies.** Only labels and comments.
-- **Be conservative on staleness.** 30 days is the floor — never mark something stale at <30 days.
-- **If you change a label, leave a comment explaining why.** Future-you needs to understand the audit trail.
-- **Every label flip must be paired with a board sync.** Run
-  `.claude/scripts/sync-project-status.sh <N> --from-labels` after every
-  `gh issue edit` so Project #4 (Sailfin Tracker) keeps tracking the labels.
-- **Always fix a null GitHub Type field** — run
-  `.claude/scripts/set-issue-type.sh <N> <Feature|Task|Bug>` for any issue
-  whose `issueType` is null. No board sync or comment needed for this fix.
+- **Promote conservatively.** A complete-looking body is necessary but not
+  sufficient — the promotion guards (open decision / unmet precondition /
+  deferred-by-design) exist because they bit us before. When a guard fires,
+  leave the issue and report it under "Held back," never force it to Ready.
+- **Be conservative on staleness.** 30 days is the floor for `claude-ready`;
+  never mark stale at <30 days.
+- **Match tolerantly.** Use the hygiene matcher's accepted forms — do not
+  fail an issue on `### In` vs `In:` or a body-only `## Size`. Brittle matching
+  is the bug that this pass exists to fix.
+- **If you change a label, leave a comment explaining why.** Audit trail.
+- **Every label flip must be paired with a board sync** via
+  `.claude/scripts/sync-project-status.sh <N> --from-labels`.
+- **Always fix a null GitHub Type field** via `set-issue-type.sh`.


### PR DESCRIPTION
## Summary

`/triage` was **demote-only** with a **brittle hygiene matcher**, so fully-groomed issues rotted in the backlog indefinitely — there was no automated path from `needs-grooming` back to `claude-ready`. A manual sweep today found 6 such cases (e.g. #343/#527 fooled by `### In` headings, #874/#873 declaring their size only in the body), all sitting 8–30 days for no reason.

This adds the missing direction and fixes the matcher.

- **PROMOTE pass** — `needs-grooming` issues with a complete body, no open blocker, and no unresolved decision get lifted to `claude-ready` → Ready, backfilling the `size:` label from the body's `## Size` block.
- **Tolerant hygiene matcher** (shared by promote *and* demote) — accepts `### In` / `**In:**` variants and body-only sizes. Brittle literal matching was the root cause of the false negatives.
- **Promotion guards** — open design choice, unmet precondition, deferred-by-design. Complete-looking-but-not-pickable issues are held back and reported under "Held back," never force-promoted.
- **Adopted `/sweep`'s hard-vs-prose blocker rule** for UNBLOCK so the two commands stop diverging on the one mechanic they share.
- **Cross-referenced `/sweep` ↔ `/triage`** to document the division of labor. They stay separate — `/triage` is the periodic whole-queue hygiene auditor; `/sweep` is the event-driven post-merge coordinator (budget, collision, dispatch). Not merged.

## Scope

Prompt-command markdown only (`.claude/commands/triage.md`, `.claude/commands/sweep.md`). No `.sfn` changes, so no `sfn fmt` / self-host gates apply.

## Test plan

- [ ] Next `/triage` run promotes a known-groomed `needs-grooming` issue to Ready and backfills its size label
- [ ] A `### In`/`**In:**` body is no longer false-flagged as incomplete
- [ ] An issue with an open `(a)/(b)` design choice in its body is held back, not promoted
- [ ] UNBLOCK does not flip an issue whose `## Blocked by` contains an unresolved prose gate