### PR TITLE
feat(parser): parse spawn/await expressions and channel(cap) constructor

### DIFF
--- a/compiler/src/emit_native_format.sfn
+++ b/compiler/src/emit_native_format.sfn
@@ -138,6 +138,30 @@ fn format_expression(expression: Expression) -> string {
         return "(" + format_expression(expression.operand) + ") as "
             + expression.target_type.text;
     }
+    if expression.variant == "Await" {
+        // Bridge the structured `Await` node (parsed since issue #1080)
+        // back to the text form the existing `async`/`await` lowering
+        // consumes: `lower_expression` in
+        // `llvm/expression_lowering/native/core.sfn` and
+        // `find_suspension_keyword` in `llvm/lifetime.sfn` both key on a
+        // leading `"await "` substring. Rendering it here keeps the
+        // legacy text-based await pipeline working unchanged until the
+        // dedicated `Await` lowering lands in a follow-up.
+        return "await " + format_expression(expression.operand);
+    }
+    if expression.variant == "Spawn" {
+        // `spawn`/`channel` (issues #1079/#1080) parse but have no
+        // lowering yet. Emit an explicit unlowered-construct marker so
+        // `lower_expression` fails the build closed with a `[fatal]`
+        // rather than letting the generic `<variant>` placeholder
+        // false-green an unenforced concurrency surface into the IR
+        // (llms.txt: no parsed-but-unenforced surface). The dedicated
+        // lowering replaces these arms in a follow-up (epic #965).
+        return "<concurrency_unlowered spawn>";
+    }
+    if expression.variant == "Channel" {
+        return "<concurrency_unlowered channel>";
+    }
     if expression.variant == "Lambda" { return "<lambda>"; }
     if expression.variant == "Raw" {
         let raw_text = trim_text(expression.text);

--- a/compiler/src/emit_native_format.sfn
+++ b/compiler/src/emit_native_format.sfn
@@ -147,7 +147,15 @@ fn format_expression(expression: Expression) -> string {
         // leading `"await "` substring. Rendering it here keeps the
         // legacy text-based await pipeline working unchanged until the
         // dedicated `Await` lowering lands in a follow-up.
-        return "await " + format_expression(expression.operand);
+        //
+        // Use `_format_binary_operand` (the same helper `Unary` uses) so a
+        // `Binary`/`Cast` operand keeps its parens on the round-trip:
+        // `await (a + b)` must not re-serialize to `await a + b`, which
+        // would re-parse as `(await a) + b` and silently change grouping.
+        // The parser parses `await` at unary precedence, so a bare binary
+        // operand only arises from an explicitly parenthesized awaited
+        // expression — exactly the case these parens preserve.
+        return "await " + _format_binary_operand(expression.operand);
     }
     if expression.variant == "Spawn" {
         // `spawn`/`channel` (issues #1079/#1080) parse but have no

--- a/compiler/src/llvm/expression_lowering/native/core.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core.sfn
@@ -810,6 +810,38 @@ fn lower_expression(expression: string, bindings: ParameterBinding[], locals: Lo
         };
     }
 
+    // Unlowered concurrency frontend constructs (M4.0, epic #965). The
+    // parser builds `Spawn`/`Channel` nodes (issues #1079/#1080) but no
+    // lowering exists yet, so `emit_native_format` renders them to the
+    // `<concurrency_unlowered <kind>>` marker. Fail the build closed with
+    // a `[fatal]` — matching the sentinel scanned by
+    // `lowering_core.sfn:has_fatal_lowering_diagnostic` — rather than
+    // false-greening an unenforced concurrency surface into the IR
+    // (llms.txt: no parsed-but-unenforced surface). The dedicated
+    // lowering replaces this guard in a follow-up. `Await` is bridged to
+    // the existing async lowering upstream and never reaches here as a
+    // marker.
+    if starts_with(stripped, "<concurrency_unlowered spawn>") {
+        diagnostics.push("llvm lowering [fatal]: `spawn` expression is not yet lowered (concurrency frontend, epic #965)");
+        return ExpressionResult {
+            lines: lines,
+            temp_index: temp_index,
+            operand: null,
+            diagnostics: diagnostics,
+            string_constants: empty_constants
+        };
+    }
+    if starts_with(stripped, "<concurrency_unlowered channel>") {
+        diagnostics.push("llvm lowering [fatal]: `channel` expression is not yet lowered (concurrency frontend, epic #965)");
+        return ExpressionResult {
+            lines: lines,
+            temp_index: temp_index,
+            operand: null,
+            diagnostics: diagnostics,
+            string_constants: empty_constants
+        };
+    }
+
     // Literal expressions.
     if is_boolean_literal(stripped) {
         let mut value = "0";

--- a/compiler/src/parser/expressions.sfn
+++ b/compiler/src/parser/expressions.sfn
@@ -425,15 +425,29 @@ fn parse_prefix_expression(state: ExpressionTokens) -> ExpressionParseResult {
                 success: true
             };
         }
-        // `channel(capacity?)` constructs a channel value. Only treat
-        // `channel` as the constructor when it is immediately followed by
-        // `(` — otherwise it is an ordinary identifier and falls through
-        // to `parse_primary_expression`. The generic `channel<T>(...)`
-        // form (element_type) is deferred to a follow-up.
+        // `channel(capacity?)` constructs a channel value. Commit to the
+        // constructor as soon as `channel` is immediately followed by `(`:
+        // a bare `channel` (no paren) is an ordinary identifier and falls
+        // through to `parse_primary_expression`, but once the `(` is seen
+        // the construct is unambiguous, so a malformed argument list is a
+        // hard parse failure rather than a silent re-interpretation as an
+        // identifier call (which would diverge the fail-closed diagnostic
+        // by arity, e.g. `channel(1, 2)`). The generic `channel<T>(...)`
+        // element-type form is deferred to a follow-up.
         if identifier_matches(token, "channel") {
-            let channel_result = parse_channel_expression(state);
-            if channel_result.success {
-                return parse_postfix_chain(channel_result.state, channel_result.expression);
+            let after_channel = expression_tokens_advance(state);
+            let mut channel_followed_by_paren: boolean = false;
+            if !expression_tokens_is_at_end(after_channel) {
+                if symbol_matches(expression_tokens_peek(after_channel), "(") {
+                    channel_followed_by_paren = true;
+                }
+            }
+            if channel_followed_by_paren {
+                let channel_result = parse_channel_expression(state);
+                if channel_result.success {
+                    return parse_postfix_chain(channel_result.state, channel_result.expression);
+                }
+                return channel_result;
             }
         }
     }
@@ -694,11 +708,15 @@ fn parse_postfix_chain(state: ExpressionTokens, expression: Expression) -> Expre
 // Channel Constructor
 // ============================================================================
 // Parse `channel(capacity?)` with `state` positioned at the `channel`
-// identifier token. Returns failure (leaving `state` untouched) when the
-// next token is not `(` or when more than one argument is supplied, so the
-// caller can fall through to treating `channel` as a plain identifier. The
-// element type (`channel<T>(...)`) is not parsed yet — `element_type`
-// stays `null` (issue #1080, scope: parse-only constructor).
+// identifier token. Returns failure (leaving `state` untouched) only when
+// the next token is not `(` (a bare `channel` identifier) or when the
+// argument list itself is malformed (e.g. an unterminated `channel(`); the
+// caller commits to the constructor the moment `(` follows, so a malformed
+// form fails the parse hard rather than backtracking to an identifier
+// call. `capacity` is bound only for the canonical single-argument form;
+// zero or extra arguments leave it `null` and are a typecheck-layer arity
+// concern (deferred — issue #1080 is parse-only). The element type
+// (`channel<T>(...)`) is not parsed yet — `element_type` stays `null`.
 fn parse_channel_expression(state: ExpressionTokens) -> ExpressionParseResult {
     let channel_token = expression_tokens_peek(state);
     let after_channel = expression_tokens_advance(state);
@@ -709,9 +727,6 @@ fn parse_channel_expression(state: ExpressionTokens) -> ExpressionParseResult {
     if !symbol_matches(next, "(") { return expression_parse_failure(state); }
     let args_result = parse_call_arguments(after_channel);
     if !args_result.success { return expression_parse_failure(state); }
-    if args_result.arguments.length > 1 {
-        return expression_parse_failure(state);
-    }
     let mut capacity: Expression? = null;
     if args_result.arguments.length == 1 {
         capacity = args_result.arguments[0];

--- a/compiler/src/parser/expressions.sfn
+++ b/compiler/src/parser/expressions.sfn
@@ -388,6 +388,56 @@ fn parse_prefix_expression(state: ExpressionTokens) -> ExpressionParseResult {
         }
     }
 
+    // Concurrency-frontend prefix operators (M4.0, epic #965, issue
+    // #1080). `spawn`/`await` are soft keywords that lex as `Identifier`
+    // (Sailfin has no keyword tokens) and bind like the symbol unaries
+    // above: the operand is parsed at `unary_precedence()` so a trailing
+    // binary operator folds into the parent precedence-climbing loop
+    // (`await a + b` parses as `(await a) + b`, matching `-a + b`). Type
+    // rules, effect-checking, and lowering land in follow-up issues; the
+    // `Await` node is bridged back to the existing text-based lowering
+    // via the `Await` arm in `emit_native_format.sfn` so the legacy
+    // `async`/`await` integration tests keep working unchanged.
+    if token.kind.variant == "Identifier" {
+        if identifier_matches(token, "spawn") {
+            let advanced = expression_tokens_advance(state);
+            let operand_result = parse_expression_bp(advanced, unary_precedence());
+            if !operand_result.success { return operand_result; }
+            return ExpressionParseResult {
+                state: operand_result.state,
+                expression: Expression.Spawn {
+                    operand: operand_result.expression,
+                    span: source_span_from_tokens([token])
+                },
+                success: true
+            };
+        }
+        if identifier_matches(token, "await") {
+            let advanced = expression_tokens_advance(state);
+            let operand_result = parse_expression_bp(advanced, unary_precedence());
+            if !operand_result.success { return operand_result; }
+            return ExpressionParseResult {
+                state: operand_result.state,
+                expression: Expression.Await {
+                    operand: operand_result.expression,
+                    span: source_span_from_tokens([token])
+                },
+                success: true
+            };
+        }
+        // `channel(capacity?)` constructs a channel value. Only treat
+        // `channel` as the constructor when it is immediately followed by
+        // `(` — otherwise it is an ordinary identifier and falls through
+        // to `parse_primary_expression`. The generic `channel<T>(...)`
+        // form (element_type) is deferred to a follow-up.
+        if identifier_matches(token, "channel") {
+            let channel_result = parse_channel_expression(state);
+            if channel_result.success {
+                return parse_postfix_chain(channel_result.state, channel_result.expression);
+            }
+        }
+    }
+
     let primary_result = parse_primary_expression(state);
     if !primary_result.success { return primary_result; }
     return parse_postfix_chain(primary_result.state, primary_result.expression);
@@ -636,6 +686,43 @@ fn parse_postfix_chain(state: ExpressionTokens, expression: Expression) -> Expre
     return ExpressionParseResult {
         state: current_state,
         expression: current_expression,
+        success: true
+    };
+}
+
+// ============================================================================
+// Channel Constructor
+// ============================================================================
+// Parse `channel(capacity?)` with `state` positioned at the `channel`
+// identifier token. Returns failure (leaving `state` untouched) when the
+// next token is not `(` or when more than one argument is supplied, so the
+// caller can fall through to treating `channel` as a plain identifier. The
+// element type (`channel<T>(...)`) is not parsed yet — `element_type`
+// stays `null` (issue #1080, scope: parse-only constructor).
+fn parse_channel_expression(state: ExpressionTokens) -> ExpressionParseResult {
+    let channel_token = expression_tokens_peek(state);
+    let after_channel = expression_tokens_advance(state);
+    if expression_tokens_is_at_end(after_channel) {
+        return expression_parse_failure(state);
+    }
+    let next = expression_tokens_peek(after_channel);
+    if !symbol_matches(next, "(") { return expression_parse_failure(state); }
+    let args_result = parse_call_arguments(after_channel);
+    if !args_result.success { return expression_parse_failure(state); }
+    if args_result.arguments.length > 1 {
+        return expression_parse_failure(state);
+    }
+    let mut capacity: Expression? = null;
+    if args_result.arguments.length == 1 {
+        capacity = args_result.arguments[0];
+    }
+    return ExpressionParseResult {
+        state: args_result.state,
+        expression: Expression.Channel {
+            element_type: null,
+            capacity: capacity,
+            span: source_span_from_tokens([channel_token])
+        },
         success: true
     };
 }

--- a/compiler/tests/e2e/test_sync_rejects_unimplemented_concurrency.sh
+++ b/compiler/tests/e2e/test_sync_rejects_unimplemented_concurrency.sh
@@ -36,6 +36,21 @@
 # stage 5, before lowering, and false-greened with a `.sfn-asm` at rc=0).
 # All three surfaces now reject the identical unresolved-callee programs.
 #
+# As of #1080 the concurrency frontend parses `spawn <expr>` and
+# `channel(...)` into dedicated AST nodes (epic #965), so the FAIL-CLOSED
+# MECHANISM differs by surface:
+#   - `channel(cap)` is now a recognized `Channel` construct, not an
+#     unresolved call. It has no lowering yet, so it fails closed with a
+#     `llvm lowering [fatal]: \`channel\` expression is not yet lowered`
+#     diagnostic (the `assert_*_rejects_unlowered` helpers). The former
+#     `sfn/sync` `channel` export is gone, so the import-based variant is
+#     obsolete and was removed.
+#   - `spawn(0, "worker")` keeps the paren-call shape (the prefix-operator
+#     parse rejects the comma-separated `(...)` and falls back to a `Raw`
+#     call), so it still fails closed as an *unresolved call* (`cannot
+#     resolve ... \`spawn\``) — the `assert_*_rejects` helpers below.
+#   - `parallel(...)` is not parsed as a construct yet; unchanged.
+#
 # The typed `spawn_*` / `await_*` runtime variants below are not
 # exercised here — they have working pthread implementations and
 # are unaffected by this change.
@@ -273,14 +288,104 @@ assert_emit_native_rejects() {
     return 0
 }
 
-test_channel_via_sfn_sync_rejected() {
-    assert_build_rejects "channel_import_caller" \
-'import { channel } from "sfn/sync";
+# Issue #1080: fail-closed assertion for a parsed-but-unlowered concurrency
+# construct. Same headline contract as `assert_build_rejects` (rc != 0, no
+# output binary) but the diagnostic is the lowering `[fatal]: ... is not yet
+# lowered` produced by `lower_expression` for the `<concurrency_unlowered
+# <kind>>` marker, NOT the `cannot resolve` unresolved-call message. The
+# `<symbol>` (e.g. `channel`) must still be named so the diagnostic points at
+# the offending construct.
+assert_build_rejects_unlowered() {
+    local label="$1"
+    local source="$2"
+    local symbol="$3"
 
-fn main() ![io] {
-    let _ch = channel(0);
-}' \
-        "channel"
+    local src_path="$SCRATCH/${label}.sfn"
+    local out_path="$SCRATCH/${label}.out"
+    local log_path="$SCRATCH/${label}.log"
+    printf '%s\n' "$source" > "$src_path"
+
+    local rc=0
+    ( cd "$SCRATCH" && "$BINARY" build -o "$out_path" "$src_path" ) \
+        > "$log_path" 2>&1 || rc=$?
+
+    if [ "$rc" -eq 0 ]; then
+        echo "[test]   build of ${label}.sfn exited 0 — expected non-zero (fail-closed)" >&2
+        echo "[test]   output:" >&2
+        sed 's/^/[test]     /' "$log_path" >&2
+        return 1
+    fi
+
+    if [ -e "$out_path" ]; then
+        echo "[test]   build of ${label}.sfn produced an output binary at ${out_path} — expected none" >&2
+        echo "[test]   output:" >&2
+        sed 's/^/[test]     /' "$log_path" >&2
+        return 1
+    fi
+
+    if ! grep -q "is not yet lowered" "$log_path"; then
+        echo "[test]   diagnostic for ${label}.sfn did not mention 'is not yet lowered'" >&2
+        echo "[test]   output:" >&2
+        sed 's/^/[test]     /' "$log_path" >&2
+        return 1
+    fi
+
+    if ! grep -q "\`${symbol}\`" "$log_path"; then
+        echo "[test]   diagnostic for ${label}.sfn did not name '\`${symbol}\`'" >&2
+        echo "[test]   output:" >&2
+        sed 's/^/[test]     /' "$log_path" >&2
+        return 1
+    fi
+
+    return 0
+}
+
+# Issue #1080: `sfn emit native` parity for the unlowered-construct path —
+# rc != 0, no `.sfn-asm`, and the `is not yet lowered` lowering `[fatal]`
+# naming the construct.
+assert_emit_native_rejects_unlowered() {
+    local label="$1"
+    local source="$2"
+    local symbol="$3"
+
+    local src_path="$SCRATCH/${label}.sfn"
+    local out_path="$SCRATCH/${label}.sfn-asm"
+    local log_path="$SCRATCH/${label}.emitnative.log"
+    printf '%s\n' "$source" > "$src_path"
+
+    local rc=0
+    ( cd "$SCRATCH" && "$BINARY" emit -o "$out_path" native "$src_path" ) \
+        > "$log_path" 2>&1 || rc=$?
+
+    if [ "$rc" -eq 0 ]; then
+        echo "[test]   emit native of ${label}.sfn exited 0 — expected non-zero (fail-closed)" >&2
+        echo "[test]   output:" >&2
+        sed 's/^/[test]     /' "$log_path" >&2
+        return 1
+    fi
+
+    if [ -e "$out_path" ]; then
+        echo "[test]   emit native of ${label}.sfn produced a .sfn-asm at ${out_path} — expected none" >&2
+        echo "[test]   output:" >&2
+        sed 's/^/[test]     /' "$log_path" >&2
+        return 1
+    fi
+
+    if ! grep -q "is not yet lowered" "$log_path"; then
+        echo "[test]   emit native diagnostic for ${label}.sfn did not mention 'is not yet lowered'" >&2
+        echo "[test]   output:" >&2
+        sed 's/^/[test]     /' "$log_path" >&2
+        return 1
+    fi
+
+    if ! grep -q "\`${symbol}\`" "$log_path"; then
+        echo "[test]   emit native diagnostic for ${label}.sfn did not name '\`${symbol}\`'" >&2
+        echo "[test]   output:" >&2
+        sed 's/^/[test]     /' "$log_path" >&2
+        return 1
+    fi
+
+    return 0
 }
 
 test_parallel_via_sfn_sync_rejected() {
@@ -309,8 +414,13 @@ fn main() ![io] {
 # surface (the unqualified prelude name) — pre-#617 this was the
 # path most users actually hit when they wrote `spawn(...)` thinking
 # of the keyword form.
+#
+# Issue #1080: `channel(0)` now parses to a `Channel` construct, so it
+# fails closed as a parsed-but-unlowered construct (`is not yet lowered`)
+# rather than an unresolved call. The fail-closed contract (rc != 0, no
+# binary) is unchanged.
 test_channel_via_prelude_name_rejected() {
-    assert_build_rejects "channel_prelude_caller" \
+    assert_build_rejects_unlowered "channel_prelude_caller" \
 'fn main() ![io] {
     let _ch = channel(0);
 }' \
@@ -354,17 +464,20 @@ test_emit_llvm_spawn_rejected() {
         "spawn"
 }
 
-# Issue #906: `sfn emit native` must fail closed on the same unresolved
-# callees as `build` / `emit llvm`. Cover both shapes from the issue
-# reproduction:
-#   - value-returning unresolved call (`let _ = channel(0)`), and
+# Issue #906: `sfn emit native` must fail closed on the same surfaces as
+# `build` / `emit llvm`. Cover both shapes from the issue reproduction:
+#   - value-returning `channel(0)`, and
 #   - void-returning unresolved call (`spawn(0, "worker")`).
 # Each must exit non-zero AND leave no `.sfn-asm` behind.
+#
+# Issue #1080: `channel(0)` now parses to a `Channel` construct (the former
+# `sfn/sync` `channel` export is gone), so it fails closed as a
+# parsed-but-unlowered construct (`is not yet lowered`) rather than an
+# unresolved call. The `spawn(0, "worker")` case below keeps the
+# unresolved-call shape.
 test_emit_native_channel_rejected() {
-    assert_emit_native_rejects "channel_emit_native_caller" \
-'import { channel } from "sfn/sync";
-
-fn main() ![io] {
+    assert_emit_native_rejects_unlowered "channel_emit_native_caller" \
+'fn main() ![io] {
     let _ch = channel(0);
 }' \
         "channel"
@@ -378,14 +491,13 @@ test_emit_native_spawn_rejected() {
         "spawn"
 }
 
-run_test "sfn build rejects sfn/sync.channel import (#617)" test_channel_via_sfn_sync_rejected
 run_test "sfn build rejects sfn/sync.parallel import (#617)" test_parallel_via_sfn_sync_rejected
 run_test "sfn build rejects sfn/sync.spawn import (#617)" test_spawn_via_sfn_sync_rejected
-run_test "sfn build rejects bare prelude channel() (#617)" test_channel_via_prelude_name_rejected
+run_test "sfn build rejects bare channel() construct, unlowered (#1080)" test_channel_via_prelude_name_rejected
 run_test "sfn build rejects bare prelude spawn() (#617)" test_spawn_via_prelude_name_rejected
 run_test "sfn build fails closed on unknown void helper (#631)" test_unknown_void_helper_rejected
 run_test "sfn emit llvm fails closed on void spawn() (#631)" test_emit_llvm_spawn_rejected
-run_test "sfn emit native fails closed on value channel() (#906)" test_emit_native_channel_rejected
+run_test "sfn emit native rejects channel() construct, unlowered (#1080)" test_emit_native_channel_rejected
 run_test "sfn emit native fails closed on void spawn() (#906)" test_emit_native_spawn_rejected
 
 echo "[summary] $PASS passed, $FAIL failed"

--- a/compiler/tests/unit/parser_concurrency_test.sfn
+++ b/compiler/tests/unit/parser_concurrency_test.sfn
@@ -91,3 +91,25 @@ test "concurrency: bare channel identifier is not a Channel node" ![io] {
     let expr = first_let_initializer("let c = channel;");
     assert expr.variant == "Identifier";
 }
+
+// Once `channel` is followed by `(` the parser commits to the
+// constructor: a malformed (too many args) form stays a `Channel`
+// construct rather than backtracking to an identifier `Call`, so its
+// fail-closed diagnostic does not diverge by arity. The extra argument is
+// a typecheck-layer concern (deferred), so `capacity` is left null here.
+test "concurrency: channel commits to construct even with extra args" ![io] {
+    let expr = first_let_initializer("let c = channel(1, 2);");
+    assert expr.variant == "Channel";
+    assert expr.capacity == null;
+}
+
+// `await` parses at unary precedence, so a `Binary` operand only arises
+// from an explicitly parenthesized awaited expression: `await (a + b)`
+// parses to an `Await` whose operand is the `Binary`. This is the shape
+// the `_format_binary_operand` round-trip in `emit_native_format` must
+// keep parenthesized (`await (a + b)`, never `await a + b`).
+test "concurrency: await of a parenthesized binary keeps the binary operand" ![io] {
+    let expr = first_let_initializer("let r = await (a + b);");
+    assert expr.variant == "Await";
+    assert expr.operand.variant == "Binary";
+}

--- a/compiler/tests/unit/parser_concurrency_test.sfn
+++ b/compiler/tests/unit/parser_concurrency_test.sfn
@@ -1,0 +1,93 @@
+// Unit tests for the concurrency-frontend prefix expressions and the
+// `channel(...)` constructor (M4.0, epic #965, issue #1080).
+//
+// `spawn <expr>` and `await <expr>` are soft-keyword prefix operators
+// (they lex as `Identifier`; Sailfin has no keyword tokens) parsed in
+// `parse_prefix_expression`. `channel(capacity?)` is a constructor
+// parsed in `parse_channel_expression`. All three build the structured
+// AST nodes added in issue #1079 (`Expression.Spawn`, `Expression.Await`,
+// `Expression.Channel`). Type rules, effect-checking, and dedicated
+// lowering land in follow-up issues — this issue is parse-only.
+//
+// The `let` initializer is inspected at top level, matching the
+// convention in `parser_iife_postfix_test.sfn` (the block-scoped `let`
+// initializer path is opaque, tracked separately).
+import { Expression } from "../../src/ast";
+import { parse_program } from "../../src/parser/mod";
+
+// Initializer of the first top-level `let` in `source`.
+fn first_let_initializer(source: string) -> Expression ![io] {
+    let program = parse_program(source);
+    let stmt = program.statements[0];
+    assert stmt.variant == "VariableDeclaration";
+    let init = stmt.initializer;
+    assert init != null;
+    return init;
+}
+
+// -------------------------------------------------------------------
+// `spawn <call>` parses to a `Spawn` node whose operand is the spawned
+// call expression — never `Raw`.
+// -------------------------------------------------------------------
+test "concurrency: spawn of a call parses to Spawn of Call" ![io] {
+    let expr = first_let_initializer("let f = spawn worker();");
+    assert expr.variant == "Spawn";
+    assert expr.operand.variant == "Call";
+    assert expr.operand.callee.variant == "Identifier";
+}
+
+// `spawn <identifier>` parses to a `Spawn` over the bare identifier.
+test "concurrency: spawn of an identifier parses to Spawn of Identifier" ![io] {
+    let expr = first_let_initializer("let f = spawn task;");
+    assert expr.variant == "Spawn";
+    assert expr.operand.variant == "Identifier";
+}
+
+// -------------------------------------------------------------------
+// `await <expr>` parses to an `Await` node whose operand is the awaited
+// expression. This is the shape the legacy text-based async lowering is
+// bridged to via the `Await` arm in `emit_native_format.sfn`.
+// -------------------------------------------------------------------
+test "concurrency: await of an identifier parses to Await" ![io] {
+    let expr = first_let_initializer("let r = await future;");
+    assert expr.variant == "Await";
+    assert expr.operand.variant == "Identifier";
+}
+
+// `await` binds like a unary prefix: `await f + 1` parses as
+// `(await f) + 1`, so the initializer is a `Binary` whose left is the
+// `Await`.
+test "concurrency: await binds tighter than binary plus" ![io] {
+    let expr = first_let_initializer("let r = await f + 1;");
+    assert expr.variant == "Binary";
+    assert expr.left.variant == "Await";
+    assert expr.left.operand.variant == "Identifier";
+    assert expr.right.variant == "NumberLiteral";
+}
+
+// -------------------------------------------------------------------
+// `channel(capacity)` parses to a `Channel` node carrying the capacity
+// expression. The bound `let` is the "channel declaration" of the
+// acceptance criteria.
+// -------------------------------------------------------------------
+test "concurrency: channel with capacity parses to Channel" ![io] {
+    let expr = first_let_initializer("let c = channel(4);");
+    assert expr.variant == "Channel";
+    assert expr.capacity != null;
+    assert expr.capacity.variant == "NumberLiteral";
+}
+
+// `channel()` with no capacity parses to a `Channel` whose capacity is
+// null (the unbuffered default deferred to lowering).
+test "concurrency: channel with no capacity parses to Channel" ![io] {
+    let expr = first_let_initializer("let c = channel();");
+    assert expr.variant == "Channel";
+    assert expr.capacity == null;
+}
+
+// `channel` not followed by `(` is an ordinary identifier — the
+// constructor path must not swallow it.
+test "concurrency: bare channel identifier is not a Channel node" ![io] {
+    let expr = first_let_initializer("let c = channel;");
+    assert expr.variant == "Identifier";
+}


### PR DESCRIPTION
## Summary
- Parse `spawn <expr>` / `await <expr>` prefix operators and the `channel(capacity?)` constructor into the `Expression.Spawn` / `Await` / `Channel` AST nodes added in #1079. `spawn`/`await` lex as soft keywords and bind at unary precedence (mirroring `-`/`!`); `channel` is the constructor only when immediately followed by `(`.
- **Await bridge:** `emit_native_format` renders `Await` back to the `await <operand>` text form so the existing text-based async/await lowering keeps working unchanged — every async integration test depends on this.
- **Spawn/Channel fail-closed:** these parse but have no lowering yet. Rather than false-greening into the IR as `<variant>` placeholders, they render to a `<concurrency_unlowered <kind>>` marker that `lower_expression` rejects with a `[fatal]: … is not yet lowered`, failing the build closed across `build` / `emit llvm` / `emit native` (llms.txt: no parsed-but-unenforced surface).

Closes #1080

## Acceptance Criteria
- [x] `let f = spawn expr;` parses to `Spawn` node
- [x] `await f` parses to `Await` node
- [x] `channel(cap)` parses to `Channel` decl
- [x] unit test covers all three (`compiler/tests/unit/parser_concurrency_test.sfn`, 8 cases)
- [x] `make compile` passes (self-hosts)
- [x] `make test` passes — unit 127/127, integration 30/30, e2e 101/102 (see note)
- [x] `sfn fmt --check` clean on every touched `.sfn`

## Scope note (flagged for transparency)
The issue was scoped "parse-only," but parsing these constructs without a downstream gate created a **false-green** (`emit native` exited 0 on `let c = channel(0)`, emitting `.let _ch = <Channel>`), violating the no-unenforced-surface invariant and breaking the #906 fail-closed e2e test. Per maintainer direction, the fix adds an honest fail-closed `[fatal]` for unlowered Spawn/Channel and updates the #617/#906 concurrency-rejection e2e test: `channel(0)` now fails closed as an *unlowered construct* (`is not yet lowered`) rather than an *unresolved call* (`cannot resolve`). The rc≠0 / no-artifact safety contract is unchanged; the obsolete `sfn/sync` `channel` import variant is removed (channel is a language construct now). `spawn(...)` paren-call and `parallel(...)` cases are unchanged.

## Verification
```bash
ulimit -v 8388608 && make compile        # pass (self-hosts)
ulimit -v 8388608 && make test-unit       # unit: 127/127 passed
ulimit -v 8388608 && make test-integration # integration: 30/30 passed (full async/await suite green via the bridge)
bash compiler/tests/e2e/test_sync_rejects_unimplemented_concurrency.sh build/native/sailfin  # 8/8 passed
```

`make test` reports e2e 101/102. The single "failure" is `test_runtime_c_cache_invalidates.sh` (#915), **unrelated to this change**: it edits the repo's `sailfin_runtime.c` with a fixed probe comment and expects `misses>=1`, but builds against the shared `build/cache/` root which it does not isolate. After multiple suite runs in a persistent container the edited-content object is already cached (`hits=17 misses=0`). It passed on its first run this session (with these changes present) and passes 5/5 against a fresh cache root (`SAILFIN_BUILD_CACHE_DIR=$(mktemp -d)`); CI runs once on a clean machine, so it is green there.

## Files Changed
- `compiler/src/parser/expressions.sfn` — `spawn`/`await` prefix ops + `parse_channel_expression`
- `compiler/src/emit_native_format.sfn` — `Await` text bridge + `Spawn`/`Channel` unlowered markers
- `compiler/src/llvm/expression_lowering/native/core.sfn` — fail-closed `[fatal]` for unlowered concurrency markers
- `compiler/tests/unit/parser_concurrency_test.sfn` — new regression coverage (8 cases)
- `compiler/tests/e2e/test_sync_rejects_unimplemented_concurrency.sh` — updated channel assertions for the construct's new fail-closed mechanism

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01B1hUcEhJCX5wzxuVdpSRos)_