### PR TITLE
feat(make): JSON=1 gate + per-target report-file scaffolding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,6 +113,19 @@ NATIVE_BIN ?= build/native/sailfin$(EXE_EXT)
 # docs/reference/make-result-schema.md.
 .PHONY: compile-impl rebuild-impl check-impl check-fast-impl
 .PHONY: test-impl test-unit-impl test-integration-impl test-e2e-impl test-capsules-impl
+#
+# Report-file gate (#1119). `JSON=1 make <target>` (or SAILFIN_AGENT_REPORT=1 in
+# the environment) activates a per-target full report file at
+# build/agent-report.<target>.json and points the verdict block's `report`
+# field at it. The gate is off by default: no file is written and `report`
+# stays null. The flag is exported (not threaded through each callsite) so
+# agent_report.sh reads it from the environment; nested SAILFIN_INNER runs still
+# emit no sentinel and write no file.
+JSON ?=
+ifeq ($(JSON),1)
+SAILFIN_AGENT_REPORT := 1
+endif
+export SAILFIN_AGENT_REPORT
 AGENT_REPORT := bash scripts/agent_report.sh
 
 help:

--- a/docs/reference/make-result-schema.md
+++ b/docs/reference/make-result-schema.md
@@ -1,8 +1,10 @@
 # `make` Verdict Block Schema (`sailfin-make/1`)
 
-Status: Phase 1 of `docs/proposals/agent-output-orchestration.md` (epic #1056,
-issue #1059). The always-last verdict block ships now; the full report file
-(`build/agent-report.json`) and precise `first_error` extraction are Phases 2–3.
+Status: epic #1056 of `docs/proposals/agent-output-orchestration.md`. The
+always-last verdict block ships now (Phase 1, #1059). The opt-in per-target
+full report file (`build/agent-report.<target>.json`, #1119) ships as Phase 2
+scaffolding — well-formed with an empty `phases` stub; composing real per-phase
+content and precise `first_error` extraction are later phases.
 
 Every agent-facing `make` target ends — on success **and** on failure — by
 printing a single greppable verdict block as the **last lines of its output**,
@@ -81,7 +83,7 @@ string.
 | `failure` | string \| null | Classification (closed enum below); `null` on `pass`. Set on `warn` too. |
 | `phase` | string \| null | Best-effort phase that reached the failure/warn. Single-phase targets echo the target name; `check` resolves one of its seven phases. `null` on `pass`. |
 | `first_error` | string \| null | Best-effort `file:line` (or `file:line:col`) pointer when one can be scraped, else the failing phase name, else `null`. Precise extraction is Phase 3. |
-| `report` | string \| null | Path to the full JSON report. Always `null` in Phase 1; populated in Phase 2 (`build/agent-report.json`). |
+| `report` | string \| null | Path to the full JSON report file. `null` unless the report-file gate is active (`JSON=1` / `SAILFIN_AGENT_REPORT=1`), in which case it is the per-target `build/agent-report.<target>.json`. See [Full report file](#full-report-file). |
 
 ### `status` (closed enum)
 
@@ -142,6 +144,39 @@ Non-deterministic fixed point (`make check`, exit 0):
 ===SAILFIN-RESULT===
 {"schema_version":"sailfin-make/1","target":"check","status":"warn","failure":"nondeterminism","phase":"fixed-point","first_error":null,"report":null}
 ===END-SAILFIN-RESULT===
+```
+
+## Full report file
+
+The verdict block is always-on and intentionally one line. The **full report
+file** is the opt-in companion that later phases grow into a per-phase
+breakdown. It is gated so default human runs are untouched.
+
+**Activation.** Off by default. Turn it on with either:
+
+- `JSON=1 make <target>` (the Makefile maps `JSON=1` to `SAILFIN_AGENT_REPORT=1`), or
+- `SAILFIN_AGENT_REPORT=1` in the environment.
+
+When the gate is off, **no file is written** and the verdict block's `report`
+field stays `null`.
+
+**Path.** Per-target: `build/agent-report.<target>.json` (e.g.
+`build/agent-report.compile.json`, `build/agent-report.test.json`). The
+per-target name keeps parallel CI shards from clobbering each other's report.
+When the gate is on, the verdict block's `report` field is exactly this path,
+and the report's own `report` field is self-referential (it names its own path).
+
+**Nested runs.** A `SAILFIN_INNER` nested target (e.g. `make check`'s inner
+`make test`) runs transparently: it emits no verdict sentinel **and** writes no
+report file, even under the gate. Only the outer target produces a report.
+
+**Shape (Phase 2 scaffolding).** The file is a single well-formed JSON object
+mirroring the verdict fields, plus a self-referential `report` and a `phases`
+array. `phases` is an **empty stub** at this stage — composing real per-phase
+content from tool JSON is a later issue.
+
+```json
+{"schema_version":"sailfin-make/1","target":"compile","status":"pass","failure":null,"phase":null,"first_error":null,"report":"build/agent-report.compile.json","phases":[]}
 ```
 
 ## Implementation

--- a/scripts/agent_report.sh
+++ b/scripts/agent_report.sh
@@ -81,8 +81,13 @@ export SAILFIN_INNER=1
 # targets never reach it and never write a file.
 REPORT_PATH=""
 if [ "${SAILFIN_AGENT_REPORT:-}" = "1" ]; then
-	REPORT_PATH="build/agent-report.${TARGET}.json"
-	mkdir -p build 2>/dev/null || true
+	# Only enable the report path once its directory exists. If `build` can't
+	# be created (read-only or unwritable workspace), REPORT_PATH stays empty
+	# so the verdict block keeps `report` null instead of advertising a path no
+	# file could be written to.
+	if mkdir -p build 2>/dev/null; then
+		REPORT_PATH="build/agent-report.${TARGET}.json"
+	fi
 fi
 
 # --- output capture ----------------------------------------------------------
@@ -228,17 +233,30 @@ write_report_file() {
 }
 
 emit_verdict() {
+	# Capture the status that triggered the trap as the very first action —
+	# any later command would clobber $?. If we were interrupted (signal,
+	# internal error) before RC was captured from PIPESTATUS, RC is still its
+	# initial 0; inherit the trap's status so an aborted run isn't misreported
+	# as a pass (which would also write a passing report file under the gate).
+	local trap_rc=$?
 	# Fired via trap on EXIT so the block is always the final output, even if
 	# the command aborts a phase or the wrapper is interrupted.
 	trap - EXIT
+	if [ "$RC" -eq 0 ] && [ "$trap_rc" -ne 0 ]; then
+		RC="$trap_rc"
+	fi
 	classify
 	# Report-file field: the per-target path when gated, else null. Write the
 	# file before the verdict so a consumer that follows the `report` pointer
-	# finds it already on disk.
+	# finds it already on disk. Only advertise the path if the file is actually
+	# present after the write — a failed mkdir/write must leave `report` null
+	# rather than dangle a pointer to a missing file.
 	local report_field="null"
 	if [ -n "$REPORT_PATH" ]; then
 		write_report_file
-		report_field="$(json_val "$REPORT_PATH")"
+		if [ -f "$REPORT_PATH" ]; then
+			report_field="$(json_val "$REPORT_PATH")"
+		fi
 	fi
 	{
 		printf '===SAILFIN-RESULT===\n'

--- a/scripts/agent_report.sh
+++ b/scripts/agent_report.sh
@@ -71,6 +71,20 @@ fi
 # any nested wrapped targets the command spawns.
 export SAILFIN_INNER=1
 
+# --- report-file gate (#1119) ------------------------------------------------
+# JSON=1 / SAILFIN_AGENT_REPORT=1 (set by the Makefile, exported into our env)
+# activates a per-target full report file at build/agent-report.<target>.json.
+# When the gate is off REPORT_PATH stays empty: no file is written and the
+# verdict block's `report` field stays null. The path is target-specific so
+# parallel CI shards (e.g. `make test` + `make compile`) never collide. This
+# guard sits AFTER the SAILFIN_INNER early-return above, so nested wrapped
+# targets never reach it and never write a file.
+REPORT_PATH=""
+if [ "${SAILFIN_AGENT_REPORT:-}" = "1" ]; then
+	REPORT_PATH="build/agent-report.${TARGET}.json"
+	mkdir -p build 2>/dev/null || true
+fi
+
 # --- output capture ----------------------------------------------------------
 # Capture combined output for classification. If mktemp fails (e.g. /tmp full
 # or unwritable) fall back to /dev/null: the command still streams through and
@@ -194,11 +208,38 @@ json_val() {
 	printf '"%s"' "$v"
 }
 
+# --- full report file (#1119) ------------------------------------------------
+# Write a minimal, well-formed report at REPORT_PATH. Phase 2 scaffolding:
+# `phases` is an empty array stub here; issue E composes real per-phase content
+# from tool JSON. The report mirrors the verdict block's fields and adds a
+# self-referential `report` (its own path) plus `phases`. Best-effort: a write
+# failure must never break the verdict block, so it degrades silently.
+write_report_file() {
+	{
+		printf '{"schema_version":"sailfin-make/1",'
+		printf '"target":%s,' "$(json_val "$TARGET")"
+		printf '"status":%s,' "$(json_val "$STATUS")"
+		printf '"failure":%s,' "$(json_val "$FAILURE")"
+		printf '"phase":%s,' "$(json_val "$PHASE")"
+		printf '"first_error":%s,' "$(json_val "$FIRST_ERROR")"
+		printf '"report":%s,' "$(json_val "$REPORT_PATH")"
+		printf '"phases":[]}\n'
+	} >"$REPORT_PATH" 2>/dev/null || true
+}
+
 emit_verdict() {
 	# Fired via trap on EXIT so the block is always the final output, even if
 	# the command aborts a phase or the wrapper is interrupted.
 	trap - EXIT
 	classify
+	# Report-file field: the per-target path when gated, else null. Write the
+	# file before the verdict so a consumer that follows the `report` pointer
+	# finds it already on disk.
+	local report_field="null"
+	if [ -n "$REPORT_PATH" ]; then
+		write_report_file
+		report_field="$(json_val "$REPORT_PATH")"
+	fi
 	{
 		printf '===SAILFIN-RESULT===\n'
 		printf '{"schema_version":"sailfin-make/1",'
@@ -207,7 +248,7 @@ emit_verdict() {
 		printf '"failure":%s,' "$(json_val "$FAILURE")"
 		printf '"phase":%s,' "$(json_val "$PHASE")"
 		printf '"first_error":%s,' "$(json_val "$FIRST_ERROR")"
-		printf '"report":null}\n'
+		printf '"report":%s}\n' "$report_field"
 		printf '===END-SAILFIN-RESULT===\n'
 	}
 	cleanup_outfile


### PR DESCRIPTION
## Summary
- Add a report-file activation gate: `JSON=1 make <target>` (or `SAILFIN_AGENT_REPORT=1` in the env) maps to an exported `SAILFIN_AGENT_REPORT=1` that `agent_report.sh` reads. Off by default.
- When gated, `agent_report.sh` writes a minimal well-formed full report to the per-target path `build/agent-report.<target>.json` and points the verdict block's `report` field at it; otherwise `report` stays `null` and no file is written.
- The gate sits after the `SAILFIN_INNER` guard, so nested wrapped targets emit no sentinel and write no file. `phases[]` is an empty Phase-2 stub; composing per-phase content is a later issue.

Pure build orchestration — no `compiler/src` changes.

Closes #1119

## Acceptance Criteria
- [x] `JSON=1 make compile` (up-to-date tree) writes `build/agent-report.compile.json` that parses as JSON and whose `report` field equals its own path; the verdict block's `report` field equals `build/agent-report.compile.json`.
- [x] Default (no `JSON=1`) run writes **no** report file and keeps `"report":null` in the verdict block.
- [x] Report path is target-specific: `JSON=1 make test` and `JSON=1 make compile` write distinct files (CI-shard safe).
- [x] `SAILFIN_INNER=1` nested runs still emit no sentinel and write no file.
- [x] `make compile && make check` stay green; default human stdout unchanged.

## Verification
```bash
# AC1 — gated compile, self-referential report path:
JSON=1 make compile   # → verdict "report":"build/agent-report.compile.json"
jq -e '.report=="build/agent-report.compile.json"' build/agent-report.compile.json   # → true
# full report file:
# {"schema_version":"sailfin-make/1","target":"compile","status":"pass","failure":null,
#  "phase":null,"first_error":null,"report":"build/agent-report.compile.json","phases":[]}

# AC2 — default run: verdict "report":null, no file written.

# AC3 — distinct per-target files:
ls build/agent-report.*.json   # → build/agent-report.compile.json  build/agent-report.test.json

# AC4 — nested inner under the gate: 0 sentinels, no file:
SAILFIN_AGENT_REPORT=1 SAILFIN_INNER=1 bash scripts/agent_report.sh --target test -- echo hi
#   sentinel count: 0 ; build/agent-report.test.json not created

# Makefile mapping:
make -p JSON=1 help | grep SAILFIN_AGENT_REPORT   # → SAILFIN_AGENT_REPORT := 1
```

## Files Changed
- `Makefile` — `JSON ?=` → exported `SAILFIN_AGENT_REPORT` gate
- `scripts/agent_report.sh` — `REPORT_PATH`, gated report write, `report` field
- `docs/reference/make-result-schema.md` — `report` row + "Full report file" section

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q1jLk7z7JQ3r3mYXCQiRBz)_