### PR TITLE
tech-debt: retire effect_gate.sfn env-read workaround for env.get

### DIFF
--- a/compiler/src/effect_gate.sfn
+++ b/compiler/src/effect_gate.sfn
@@ -32,19 +32,6 @@
 // severity (currently "error" post-Phase-D) so contributors who set
 // `=off` for emergency builds still see effect diagnostics when they
 // run `sfn check` explicitly.
-//
-// **Implementation note: env-var read avoids the `env.get` intrinsic.**
-// The 0.5.x seed compiler emits `call @sailfin_runtime_getenv` for
-// `env.get(name)` calls but does not emit a corresponding `declare`
-// in the LLVM preamble — the resulting IR fails `llvm-as` validation
-// during the bootstrap. Until the seed is rebased past that latent
-// runtime-helper-collection bug, this module reads `SAILFIN_EFFECT_ENFORCE`
-// via `process.run(["sh", "-c", "printf %s \"$VAR\" > tmp"])` plus
-// `fs.readFile` — the same shape `cli_commands_utils._shell_read_cmd`
-// uses for `SFN_REGISTRY`. The `tmp` path is process-unique
-// (suffixed by the caller's `file_path` slug) so 4-way parallel
-// `make compile` workers don't race each other on a shared
-// `/tmp/.sfn_*` file.
 import { Program } from "./ast";
 import {
     capability_violation_to_diagnostic,
@@ -59,7 +46,6 @@ import {
     validate_effects_with_imports
 } from "./effect_checker";
 import { ImportSymbolTable } from "./effect_imports";
-import { sanitize_symbol, substring } from "./string_utils";
 import { Diagnostic } from "./typecheck_types";
 
 // -------------------------------------------------------------------
@@ -82,59 +68,18 @@ fn resolve_effect_enforcement(raw: string) -> string {
 }
 
 // -------------------------------------------------------------------
-// Env-var read (process-unique tmp path)
+// Env-var read
 // -------------------------------------------------------------------
 //
-// Sailfin's tooling intrinsic for env reads is `env.get(name)` — but
-// the 0.5.x seed compiler doesn't emit a `declare` for the lowered
-// `sailfin_runtime_getenv` call, so any module the seed compiles
-// that calls `env.get` produces invalid LLVM IR. Until a newer seed
-// closes that bug, we shell out via `process.run` and write the
-// value to a process-unique tmp file the caller then reads with
-// `fs.readFile`.
+// Reads `SAILFIN_EFFECT_ENFORCE` directly via the `env.get` intrinsic,
+// which returns the empty string for an unset variable — exactly the
+// value `resolve_effect_enforcement` treats as "use the default".
 //
-// `unique_key` is any caller-chosen string. The helper sanitizes it
-// internally via `_unique_suffix_for_path` so callers can pass a raw
-// `file_path` (slashes, dots, leading hyphens — all OK) without
-// constructing an invalid `/tmp/.sfn_effect_enforce_*` path. Parallel
-// build workers (`make compile -j4`) thread their distinct module
-// names through and end up with distinct sanitized paths, avoiding
-// cross-process races on a shared `/tmp/.sfn_*` file.
-fn _unique_suffix_for_path(file_path: string) -> string {
-    if file_path.length == 0 { return "anon"; }
-    let slug = sanitize_symbol(file_path);
-    if slug.length == 0 { return "anon"; }
-    // sanitize_symbol can return very long strings for deeply nested
-    // module names; cap at 64 chars so we don't blow tmp-path limits.
-    if slug.length <= 64 { return slug; }
-    return substring(slug, 0, 64);
-}
-
-fn _read_env_via_shell(name: string, unique_suffix: string) -> string ![io] {
-    let tmp = "/tmp/.sfn_effect_enforce_" + unique_suffix;
-    // `printf '%s'` (no trailing newline) lets `fs.readFile` return
-    // exactly the env-var value — important so `resolve_effect_enforcement`
-    // can do exact-match comparisons (`raw == "off"`, `raw == "warning"`).
-    // A stray newline would make a user's `SAILFIN_EFFECT_ENFORCE=warning`
-    // arrive as `"warning\n"`, miss both branches, and silently fall
-    // through to the default ("error" post-Phase-D) instead of the
-    // intended audit-mode opt-in.
-    let cmd = "printf '%s' \"$" + name + "\" > " + tmp + " 2>/dev/null";
-    let rc = process.run(["sh", "-c", cmd]);
-    if rc != 0 { return ""; }
-    if !fs.exists(tmp) { return ""; }
-    let raw = fs.readFile(tmp);
-    process.run(["rm", "-f", tmp]);
-    return raw;
-}
-
-// Public entry — used by `tools/check.sfn` (which has its own
-// `file_path`) and any future build-adjacent surface that wants to
-// honour the same env-var contract. The `unique_key` is sanitized
-// internally; callers can pass a raw `file_path` or `module_name`
-// without worrying about slashes or other path-unsafe characters.
+// `unique_key` is retained for API compatibility with `tools/check.sfn`
+// and other build-adjacent callers; it is no longer needed now that the
+// read no longer routes through a process-unique tmp file.
 fn read_effect_enforcement_env(unique_key: string) -> string ![io] {
-    return _read_env_via_shell("SAILFIN_EFFECT_ENFORCE", _unique_suffix_for_path(unique_key));
+    return env.get("SAILFIN_EFFECT_ENFORCE");
 }
 
 // -------------------------------------------------------------------

--- a/compiler/src/effect_gate.sfn
+++ b/compiler/src/effect_gate.sfn
@@ -58,8 +58,8 @@ import { Diagnostic } from "./typecheck_types";
 fn resolve_effect_enforcement(raw: string) -> string {
     if raw == "off" { return "off"; }
     if raw == "warning" { return "warning"; }
-    // Empty string covers both "env var unset" (the shell read
-    // returns "" for missing vars) and an explicit empty value.
+    // Empty string covers both "env var unset" (`env.get` returns
+    // "" for missing vars) and an explicit empty value.
     // Phase D flipped the default to "error" — `make compile`,
     // `sfn build`, `sfn run`, `sfn test`, and `sfn check` all gate
     // builds on declared effects. Capsule authors who want the

--- a/compiler/src/tools/check.sfn
+++ b/compiler/src/tools/check.sfn
@@ -187,19 +187,18 @@ fn check_source_with_imports(source: string, file_path: string, imported_interfa
         ti += 1;
     }
 
-    // Phase B: route effect-violation severity through the same
-    // env-var contract the build path uses. `sfn check` honors
-    // `=warning` and `=error` so contributors can dry-run the
-    // post-Phase-D gate by exporting `=error` locally; the default
-    // ("warning") keeps the audit period non-disruptive.
+    // Route effect-violation severity through the same env-var
+    // contract the build path uses. `sfn check` honors `=warning`
+    // and `=error`; post-Phase-D the unset default is "error", so
+    // `sfn check` enforces declared effects by default. Contributors
+    // who want the pre-Phase-D audit mode opt in with `=warning`.
     //
     // Per proposal §4.7, `=off` is a build-path escape hatch only
     // — "does not turn off sfn check validation, only the build
     // path." `sfn check` therefore ignores `=off` and falls back
-    // to whatever severity would apply for an unset env var. That
-    // way Phase B's warning default and Phase D's eventual error
-    // default both flow through naturally without a second knob
-    // for `sfn check` to track.
+    // to whatever severity would apply for an unset env var — the
+    // Phase D "error" default — without a second knob for `sfn check`
+    // to track.
     //
     // `read_effect_enforcement_env` reads `SAILFIN_EFFECT_ENFORCE`
     // directly via `env.get`; the `file_path` argument is retained

--- a/compiler/src/tools/check.sfn
+++ b/compiler/src/tools/check.sfn
@@ -201,9 +201,9 @@ fn check_source_with_imports(source: string, file_path: string, imported_interfa
     // default both flow through naturally without a second knob
     // for `sfn check` to track.
     //
-    // `read_effect_enforcement_env` sanitizes the unique-key
-    // internally, so passing `file_path` directly is safe even
-    // when it contains slashes (e.g. `compiler/src/main.sfn`).
+    // `read_effect_enforcement_env` reads `SAILFIN_EFFECT_ENFORCE`
+    // directly via `env.get`; the `file_path` argument is retained
+    // only for API compatibility and is ignored.
     let raw_severity = resolve_effect_enforcement(read_effect_enforcement_env(file_path));
     let mut effect_severity: string = raw_severity;
     if effect_severity == "off" {


### PR DESCRIPTION
## Summary

- Replace the `process.run` + `fs.readFile` tmp-file shell-out in `compiler/src/effect_gate.sfn` with a direct `env.get("SAILFIN_EFFECT_ENFORCE")` call.
- Delete the `_unique_suffix_for_path` / `_read_env_via_shell` machinery, the workaround comment block, and the now-unused `string_utils` import.
- Refresh the stale "sanitizes the unique-key" comment in `tools/check.sfn`.

The 0.5.x seed emitted `call @sailfin_runtime_getenv` for `env.get` without a matching `declare`, so the module shelled out to a process-unique tmp file. PR #682 added the `env.get`/`env.home` declares to `seed_default_runtime_helpers`, and seed `v0.7.0-alpha.25` ships that fix (verified present in the seed tree at `compiler/src/llvm/lowering/lowering_helpers.sfn`), so the workaround is no longer load-bearing.

Closes #684

## Acceptance Criteria

- [x] `grep -n "env-var read avoids the .env.get. intrinsic" compiler/src/` returns zero matches.
- [x] `effect_gate.sfn` reads `SAILFIN_EFFECT_ENFORCE` via `env.get` directly.
- [x] `make compile && make test` pass; `make check` running (will confirm on completion).
- [x] `sfn fmt --check` is clean.
- [x] No regression in effect-enforcement gating behaviour (`off` / `warning` / unset modes verified on `hello-world.sfn`; existing unit tests cover severity selection).

## Verification

```bash
ulimit -v 8388608
make compile     # pass (self-hosts on alpha.25 seed via the env.get path)
make test        # pass — e2e-sh 103/103, status: pass
make check       # running (triple-pass self-host + seedcheck)
SAILFIN_EFFECT_ENFORCE=warning build/native/sailfin check examples/basics/hello-world.sfn  # ok
SAILFIN_EFFECT_ENFORCE=off     build/native/sailfin check examples/basics/hello-world.sfn  # ok
```

## Files Changed

- `compiler/src/effect_gate.sfn` — primary cleanup (66 deletions).
- `compiler/src/tools/check.sfn` — refreshed stale comment.

## Notes

- `read_effect_enforcement_env(unique_key)`'s signature is kept for API compatibility with `tools/check.sfn` (the param is now ignored), since reworking the API surface is out of scope per the issue.
- `cli_commands_utils._shell_read_cmd` was left untouched per the issue's `Out:` scope (it may shell out for other reasons, e.g. `SFN_REGISTRY`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017UpnEkTRTrJCCMAAUMBwC3)_