### PR TITLE
perf(imports): migrate single-leaf barrel consumers to direct leaf imports

### DIFF
--- a/compiler/src/llvm/expression_lowering/native/lambda_lowering.sfn
+++ b/compiler/src/llvm/expression_lowering/native/lambda_lowering.sfn
@@ -56,7 +56,8 @@ import {
     TypeAnnotation,
     WithClause
 } from "../../../ast";
-import { Parser, parse_block } from "../../../parser/mod";
+import { parse_block } from "../../../parser/statements";
+import { Parser } from "../../../parser/types";
 import { LambdaCaptureRecord, analyze_lambda_captures } from "../../../typecheck_captures";
 import { percent_escape_capture_text } from "../../closures";
 import { number_to_string } from "../../utils";

--- a/compiler/tests/integration/closure_lifting_test.sfn
+++ b/compiler/tests/integration/closure_lifting_test.sfn
@@ -43,7 +43,7 @@ import {
     closure_sentinel_type_text,
     lift_non_capturing_lambdas,
     lifted_function_name
-} from "../../src/llvm/expression_lowering/native/mod";
+} from "../../src/llvm/expression_lowering/native/lambda_lowering";
 import { parse_program } from "../../src/parser/mod";
 
 // ── Closure-pair aggregate emission ──────────────────────────────────

--- a/docs/conventions/barrel-imports.md
+++ b/docs/conventions/barrel-imports.md
@@ -1,0 +1,82 @@
+# Barrel imports (`mod.sfn` re-export facades)
+
+This is the canonical authoring rule for **importing from a `mod.sfn`
+re-export barrel versus importing directly from the leaf module that
+defines a symbol**. It exists because barrel re-exports silently inflate
+compile graphs: the capsule resolver is *eager* on re-exports — loading a
+`mod.sfn` compiles **every** leaf it re-exports, not just the leaves whose
+symbols you actually imported.
+
+It is the structural companion to
+[`unit-test-import-envelope.md`](./unit-test-import-envelope.md) (#619):
+that doc bounds *which* `compiler/src` modules a test may reach; this doc
+bounds *how* you reach them so you don't drag a whole subtree for one or
+two symbols.
+
+---
+
+## TL;DR
+
+> **Import from the leaf module that defines the symbol. Reach for a
+> barrel (`*/mod.sfn`) only when you genuinely need symbols spanning
+> three or more distinct leaf modules.**
+
+A single import from a barrel pulls the barrel's entire re-export surface
+into your compile graph. If the symbols you need all live in one or two
+leaves, name those leaves directly.
+
+```sfn
+// ❌ drags every leaf re-exported by native/mod.sfn (~11 files)
+import {
+    LiftResult,
+    lift_non_capturing_lambdas,
+    lifted_function_name
+} from "../../src/llvm/expression_lowering/native/mod";
+
+// ✅ pulls only lambda_lowering.sfn + its deps — all three symbols live there
+import {
+    LiftResult,
+    lift_non_capturing_lambdas,
+    lifted_function_name
+} from "../../src/llvm/expression_lowering/native/lambda_lowering";
+```
+
+## Why this matters
+
+The resolver compiles every transitively-referenced module to LLVM IR
+before linking. A barrel's `export { ... } from "./leaf"` lines each force
+`./leaf` to be compiled when the barrel is loaded — even if the consumer
+imports nothing that originates in that leaf. So importing one symbol from
+a ten-leaf barrel compiles all ten leaves (and their deps).
+
+The motivating regression: `emit_native.sfn` imported a single AST-pass
+symbol (`lift_non_capturing_lambdas`) from
+`llvm/expression_lowering/native/mod.sfn`. That dragged the entire
+lowering subtree into `emit_native`'s graph, so a test whose only job was
+verifying `extern fn` → `.meta extern` cold-compiled every lowering file
+on every CI run. Wall-clock crept 60s → 300s and tipped past the per-test
+cap (#704, #709). The fix was a one-line switch to a direct leaf import.
+
+## The "three or more leaves" threshold
+
+The count that matters is **distinct leaf modules**, not symbols. Five
+symbols that all live in one leaf → import the leaf (the barrel buys you
+nothing but graph bloat). Three symbols spread across three leaves → the
+barrel is a reasonable single import; record that as the reason it stays.
+
+## When a barrel is the right call
+
+- A consumer that legitimately needs the *facade* — symbols from many
+  leaves — and where the full surface is on its compile path anyway.
+- A symbol that is **defined in the `mod.sfn` itself** (not re-exported
+  from a leaf). There is no leaf to point at; the barrel is the home
+  module. Example: `parse_program` lives in `parser/mod.sfn`, so its
+  consumers necessarily import the barrel.
+
+## Out of scope (separate decisions)
+
+- Deleting barrels. Some have genuine multi-leaf consumers.
+- Teaching the resolver to compile only the reachable symbols from a
+  re-export barrel (a `capsule_resolver.sfn` change).
+- Relocating a symbol out of a barrel into a leaf so consumers *can* take
+  the leaf path. That is a per-symbol re-org decision, tracked separately.

--- a/docs/conventions/barrel-imports.md
+++ b/docs/conventions/barrel-imports.md
@@ -26,7 +26,7 @@ into your compile graph. If the symbols you need all live in one or two
 leaves, name those leaves directly.
 
 ```sfn
-// ❌ drags every leaf re-exported by native/mod.sfn (~11 files)
+// ❌ drags every leaf re-exported by native/mod.sfn into the graph
 import {
     LiftResult,
     lift_non_capturing_lambdas,
@@ -54,8 +54,10 @@ symbol (`lift_non_capturing_lambdas`) from
 `llvm/expression_lowering/native/mod.sfn`. That dragged the entire
 lowering subtree into `emit_native`'s graph, so a test whose only job was
 verifying `extern fn` → `.meta extern` cold-compiled every lowering file
-on every CI run. Wall-clock crept 60s → 300s and tipped past the per-test
-cap (#704, #709). The fix was a one-line switch to a direct leaf import.
+on every CI run. Wall-clock for that test crept upward over successive
+seed bumps (roughly 60s → 300s, as recorded historically on #704/#709)
+until CI runs for it began timing out. The fix was a one-line switch to a
+direct leaf import.
 
 ## The "three or more leaves" threshold
 


### PR DESCRIPTION
## Summary
- Audited every `mod.sfn` re-export barrel under `compiler/src/` and broke the single-leaf-from-a-barrel anti-pattern that inflates compile graphs (the resolver is *eager* on re-exports — loading a barrel compiles every leaf it re-exports, not just the ones whose symbols you import).
- Migrated the two genuine offenders to direct leaf imports; recorded reasons for the barrels that legitimately stay.
- Added an authoring convention doc.

Closes #709

## Inventory (full table in the [issue comment](https://github.com/SailfinIO/sailfin/issues/709#issuecomment-4637242475))
| Barrel | Consumers | Action |
|---|---|---|
| `parser/mod.sfn` | `parse_program` defined **in** the barrel → its ~28 single-symbol consumers can't take a leaf path (recorded reason). `lambda_lowering.sfn` pulled `Parser` + `parse_block`. | Migrated `lambda_lowering` → `parser/types` + `parser/statements` |
| `llvm/expression_lowering/native/mod.sfn` | Zero production consumers (`emit_native` migrated in #704). Only `closure_lifting_test` pulled 5 symbols — **all defined in `lambda_lowering.sfn`**. | Migrated `closure_lifting_test` → `native/lambda_lowering` leaf |
| `llvm/mod.sfn` | Zero consumers (dead facade). | Deletion out of scope; flagged for follow-up |

## Acceptance Criteria
- [x] Inventory comment posted (every `mod.sfn`, consumers, per-consumer symbol counts)
- [x] Every external consumer importing from a single leaf migrated to a direct leaf import; others carry a recorded reason
- [x] Before/after `time` on a dependent test, recorded below
- [x] Authoring convention added (`docs/conventions/barrel-imports.md`)
- [x] `make check` green; no regressions (stage2 == stage3 fixed point)

## Verification
`closure_lifting_test.sfn` — `sfn test <file>`, `ulimit -v 8388608`, `build/cache` cleared between cold runs:

```
                              cold #1                 cold #2                 warm
native/mod      (barrel)      71.0s SEGFAULT(rc=139)  70.7s SEGFAULT(rc=139)  —
native/lambda_lowering(leaf)  43.0s PASS              43.6s PASS              9.8s PASS
```

The barrel's cold compile graph OOM-segfaults under the 8GB cap; the leaf import passes cold (~40% wall-clock cut even discounting the crash) and ~9.8s warm.

```
make check → status: pass
[check] stage2 == stage3: compiler is a fixed point ✓
e2e-sh: 105/105 passed, 0 failed
```

## Files Changed
- `compiler/src/llvm/expression_lowering/native/lambda_lowering.sfn` — `{ Parser, parse_block } from parser/mod` → leaf imports
- `compiler/tests/integration/closure_lifting_test.sfn` — 5 symbols from `native/mod` → `native/lambda_lowering`
- `docs/conventions/barrel-imports.md` — new authoring convention

## Notes for future grooming
- The issue's `scripts/run_native_test.sh` (and its `:65–98` timeout comments) no longer exist — per-test compile now runs via `sfn test <file>`; there's no cap there to re-tune.
- The high-leverage structural follow-up is relocating `parse_program`/`parse_tokens`/`parse_statement` out of `parser/mod.sfn` into a leaf so the ~28 single-symbol parser consumers can take a leaf path — a separate per-symbol re-org decision, deliberately out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FzKqsFKUMyS3ghJJPkdFNt)_