### PR TITLE
chore(agents): scheduled gh-aw recompile workflow

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -17,6 +17,30 @@ Whenever you change a `.md` workflow, run `gh aw compile` (or
 secret) and commit the resulting `.lock.yml` in the same PR. The
 `activation` check enforces this.
 
+### Keeping lock files fresh against upstream image yanks
+
+Lock files pin upstream gh-aw images (firewall, mcpg, the gh-aw runner)
+to specific releases/digests. When gh-aw rotates one of those pins
+upstream — or retracts a release outright, as happened with
+`gh-aw-firewall v0.25.28` (PR #442) — every agentic run fails at
+`Install AWF binary` until someone recompiles. Dependabot can't see this
+(it doesn't watch ghcr digests, and `github/gh-aw-actions/*` is
+explicitly ignored in `.github/dependabot.yml`), so the
+`.github/workflows/gh-aw-recompile.yml` workflow runs `gh aw compile
+--force-refresh-action-pins` weekly (and on demand) and opens a
+`chore(workflows): scheduled gh-aw recompile` PR if any `*.lock.yml` or
+`.github/aw/actions-lock.json` drifts. **Review those PRs, don't
+blind-merge them** — per the gh-aw FAQ, a human must confirm the bumped
+pins before merging. The workflow never auto-merges; it only surfaces the
+drift.
+
+`gh-aw-recompile.yml` is itself a plain Actions workflow (no LLM, no API
+key), so it keeps running even while most agentic `.md` workflows are
+paused for cost. That's deliberate: it keeps the lock files current for
+whatever is active (the release-notes workflow today) and means
+re-enabling a paused workflow is friction-free instead of starting from a
+stale, possibly-broken pin.
+
 ## Prime directive
 
 Code only flows **downward** through the tier pyramid. No agent self-generates

--- a/.github/workflows/gh-aw-recompile.yml
+++ b/.github/workflows/gh-aw-recompile.yml
@@ -1,0 +1,114 @@
+name: gh-aw Recompile
+
+# Proactively catches upstream gh-aw image yanks before they break production
+# agentic runs. gh-aw pins firewall / mcpg / runner images to specific
+# releases inside the generated `*.lock.yml` files; when upstream rotates or
+# retracts one of those pins, every agentic workflow fails at `Install AWF
+# binary` until someone recompiles (see PR #442, where `gh-aw-firewall
+# v0.25.28` was retracted and 404'd on `checksums.txt`).
+#
+# Dependabot can't see this: it doesn't watch ghcr digests, and
+# `github/gh-aw-actions/*` is ignored in `.github/dependabot.yml` precisely so
+# it stops desyncing the lock files. So this workflow runs
+# `gh aw compile --force-refresh-action-pins` on a schedule, and if any lock
+# file drifts it opens a PR for human review.
+#
+# This is a regular Actions workflow, NOT a gh-aw `.md` source — it has no
+# LLM, no API key, and only refreshes generated lock files. It deliberately
+# does NOT auto-merge: per the gh-aw FAQ, a human must review bumped pins
+# before merging. See `.github/AGENTS.md` ("Keeping lock files fresh").
+
+on:
+  schedule:
+    # Weekly, Monday 08:27 UTC (off-peak minute to avoid Actions contention).
+    - cron: '27 8 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: gh-aw-recompile
+  cancel-in-progress: false
+
+jobs:
+  recompile:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.3
+        with:
+          # Prefer a PAT so the opened PR triggers downstream CI; the default
+          # GITHUB_TOKEN works too but won't kick other workflow runs.
+          token: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - name: Install gh aw extension
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh extension install github/gh-aw || gh extension upgrade gh-aw
+
+      - name: Recompile with refreshed action pins
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh aw compile --force-refresh-action-pins
+
+      - name: Detect lock-file drift
+        id: drift
+        run: |
+          if git diff --quiet -- .github/workflows/*.lock.yml .github/aw/actions-lock.json; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No drift — gh-aw lock files are current."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "Drift detected in gh-aw lock files:"
+            git --no-pager diff --stat -- .github/workflows/*.lock.yml .github/aw/actions-lock.json
+          fi
+
+      - name: Open or update recompile PR
+        if: steps.drift.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          BRANCH="chore/gh-aw-recompile"
+          TITLE="chore(workflows): scheduled gh-aw recompile"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git checkout -B "$BRANCH"
+          git add .github/workflows/*.lock.yml .github/aw/actions-lock.json
+          git commit -m "$TITLE"
+          # Force-with-lease keeps a single rolling branch: a re-run with the
+          # same drift just refreshes it instead of stacking commits/PRs.
+          git push --force-with-lease origin "$BRANCH"
+
+          BODY=$(cat <<'EOF'
+          Automated recompile of gh-aw lock files via
+          `gh aw compile --force-refresh-action-pins`.
+
+          The scheduled `gh-aw Recompile` workflow detected drift between the
+          committed `*.lock.yml` / `actions-lock.json` and the freshly resolved
+          upstream action/image pins. This usually means gh-aw rotated (or
+          retracted) one of the firewall / mcpg / runner images.
+
+          **Review before merging** — per the
+          [gh-aw FAQ](https://github.github.com/gh-aw/reference/faq/), a human
+          must confirm the bumped pins. This PR is intentionally not
+          auto-merged. See `.github/AGENTS.md` ("Keeping lock files fresh").
+          EOF
+          )
+
+          if gh pr view "$BRANCH" --json state --jq '.state' 2>/dev/null | grep -qx OPEN; then
+            echo "PR already open for $BRANCH — branch updated with latest recompile."
+          else
+            gh pr create \
+              --base main \
+              --head "$BRANCH" \
+              --title "$TITLE" \
+              --body "$BODY" \
+              --label agent-authored \
+              --label area:agents
+          fi


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/gh-aw-recompile.yml` — a plain (non-gh-aw) Actions workflow that runs `gh aw compile --force-refresh-action-pins` weekly (Mon 08:27 UTC) and on `workflow_dispatch`, opening a review PR when any `*.lock.yml` or `.github/aw/actions-lock.json` drifts.
- Proactively catches upstream gh-aw image yanks (firewall / mcpg / runner) before they break production runs — the reactive counterpart to PR #442, where retracted `gh-aw-firewall v0.25.28` 404'd every agentic run at `Install AWF binary`.
- Documents the recompile loop in `.github/AGENTS.md` (review-then-merge, never blind-merge per the gh-aw FAQ; stays on while most agentic `.md` workflows are cost-paused).

Closes #443

## Design notes

- **No auto-merge.** Per the [gh-aw FAQ](https://github.github.com/gh-aw/reference/faq/) a human must confirm bumped pins; the workflow only surfaces drift.
- **Idempotent.** Single rolling branch `chore/gh-aw-recompile` + `git push --force-with-lease`, guarded by an existing-open-PR check — consecutive no-drift runs exit 0 and open no PR; consecutive drift runs refresh the one PR instead of stacking.
- **Auth.** `RELEASE_PAT || GITHUB_TOKEN` for checkout/push/PR (PAT preferred so the PR triggers CI), matching the existing `sync-labels.yml` / `sync-project.yml` convention. `permissions: contents: write, pull-requests: write`.
- **No new label** — opened PR carries `agent-authored` + `area:agents` (issue left this TBD; these suffice).

## Acceptance Criteria

- [x] `.github/workflows/gh-aw-recompile.yml` exists, runs on schedule + `workflow_dispatch`
- [x] PR it opens carries `agent-authored` + `area:agents` (`gh pr create --label`)
- [x] When lock files are current, the drift step gates the PR step → exits 0, opens no PR
- [x] Idempotent across consecutive runs (rolling branch + force-with-lease + open-PR check)
- [ ] Manual `workflow_dispatch` produces a green run — **post-merge** (workflow must be on `main` to dispatch)
- [ ] Forcing a stale lock opens a PR with that file — **post-merge** (same reason)

The last two criteria require the workflow to live on `main`; they're listed in the issue's Verification block as post-merge steps and can't run from a feature branch.

## Verification

```text
$ python3 -c "import yaml; yaml.safe_load(open('.github/workflows/gh-aw-recompile.yml'))"   # parses
$ bash -n <each run: block>                                                                   # all OK
```

## Files Changed

- `.github/workflows/gh-aw-recompile.yml` (new)
- `.github/AGENTS.md` (recompile-loop note)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrkrBzp1Tvf7VxHHg6pfJu)_