### PR TITLE
feat(agents): seed-cut advisor workflow for stale-seed risk

### DIFF
--- a/.claude/commands/release-plan.md
+++ b/.claude/commands/release-plan.md
@@ -77,6 +77,14 @@ If no tracking issue exists for the target:
    mcp__github__search_issues query='repo:SailfinIO/sailfin is:open label:seed-blocker'
    ```
 
+2b. Pull open `needs-seed-cut` issues — flagged by the seed-cut advisor
+   (`.github/workflows/seed-cut-advisor.yml`) when a required-in-seed
+   predecessor merged but the pin hasn't been bumped:
+
+   ```
+   mcp__github__search_issues query='repo:SailfinIO/sailfin is:open label:needs-seed-cut'
+   ```
+
 3. Compose the issue body:
 
    ```markdown
@@ -97,6 +105,15 @@ If no tracking issue exists for the target:
    ## Seed blockers (must close before the next seed bump)
 
    - [ ] #<N> — <title>  (`seed-blocker`)
+   - [ ] ...
+
+   ## Seed cut required (auto-flagged)
+
+   <!-- Populated from open `needs-seed-cut` issues. Each means a
+   required-in-seed predecessor merged; cut a fresh alpha + `/pin-seed`
+   before those issues are picked up. Omit the section if none. -->
+
+   - [ ] #<N> — <title>  (`needs-seed-cut`)
    - [ ] ...
 
    ## Cut gate
@@ -131,17 +148,20 @@ If no tracking issue exists for the target:
 
 If the tracking issue already exists:
 
-1. Read the current body. Parse both `## Must close before cut` and
-   `## Seed blockers` sections. Extract every `- [ ] #N` and `- [x] #N`
-   line in each.
+1. Read the current body. Parse the `## Must close before cut`,
+   `## Seed blockers`, and `## Seed cut required (auto-flagged)`
+   sections. Extract every `- [ ] #N` and `- [x] #N` line in each.
 2. Pull the current sets:
 
    ```
    mcp__github__search_issues query='repo:SailfinIO/sailfin label:release:<gate>'
    mcp__github__search_issues query='repo:SailfinIO/sailfin label:seed-blocker'
+   mcp__github__search_issues query='repo:SailfinIO/sailfin is:open label:needs-seed-cut'
    ```
 
-3. Reconcile each section independently:
+3. Reconcile each section independently (`## Seed cut required
+   (auto-flagged)` reconciles against the `needs-seed-cut` set; create
+   the section if newly-flagged issues exist and it's absent):
    - **In body, now closed** → flip `- [ ]` to `- [x]`. Keep the line.
    - **In body, no longer labeled, still open** → flag as drift, leave
      the line, mention in the report. Don't auto-remove (human decision).

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -163,6 +163,9 @@ labels:
   - name: seed-blocker
     color: "b60205"
     description: "Must close before the next seed binary is cut"
+  - name: needs-seed-cut
+    color: "fbca04"
+    description: "Auto-flagged by seed-cut-advisor: a required-in-seed predecessor merged; cut a new seed before pickup"
   - name: build-quality-regression
     color: "b60205"
     description: "Auto-filed by build-quality.yml on gate failure; dedup anchor"

--- a/.github/workflows/seed-cut-advisor.yml
+++ b/.github/workflows/seed-cut-advisor.yml
@@ -1,0 +1,161 @@
+name: Seed-cut Advisor
+
+# Surfaces stale-seed risk on PR merge. When a PR merges to `main` and the
+# issue(s) it closes are listed as a required-in-seed predecessor by an open,
+# release-gated, compiler-touching downstream issue, this workflow comments on
+# the active `Release: vX.Y.Z` tracker and applies `needs-seed-cut` so a human
+# knows to cut a fresh alpha + `/pin-seed` before those downstream issues are
+# picked up.
+#
+# This is the third leg of the #489 stale-seed mitigation, complementing the
+# `## Required in pinned seed` issue-template section and the `/pickup`
+# Phase 1.5 precheck — it makes the gap visible to humans without an agent
+# being present.
+#
+# It is a PLAIN, deterministic Actions workflow — NOT a gh-aw `.md` source.
+# No compiled `.lock.yml`, no LLM engine, no ANTHROPIC_API_KEY. The single
+# `actions/github-script` step (already a pinned repo dependency) does the
+# JSON / GraphQL / markdown-section work that raw shell would do clumsily.
+# The advisor only flags; it never dispatches a release or merges anything.
+# See `.github/AGENTS.md` and docs/conventions/issue-naming.md "Seed pinning".
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+concurrency:
+  group: seed-cut-advisor-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  advise:
+    # Only real merges into main: releases to beta/rc don't update .seed-version.
+    if: >-
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.base.ref == 'main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Advise on stale-seed risk
+        uses: actions/github-script@v9.0.0
+        with:
+          github-token: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const prNumber = context.payload.pull_request.number;
+
+            // 1. Resolve the issues this PR closes (GraphQL — REST has no
+            //    direct equivalent).
+            const q = `query($owner:String!,$repo:String!,$pr:Int!){
+              repository(owner:$owner,name:$repo){
+                pullRequest(number:$pr){
+                  closingIssuesReferences(first:50){ nodes{ number } }
+                }
+              }
+            }`;
+            const res = await github.graphql(q, { owner, repo, pr: prNumber });
+            const closing = new Set(
+              res.repository.pullRequest.closingIssuesReferences.nodes.map(n => n.number)
+            );
+            if (closing.size === 0) {
+              core.info(`PR #${prNumber} closes no issues — nothing to advise.`);
+              return;
+            }
+            core.info(`PR #${prNumber} closes: ${[...closing].map(n => '#' + n).join(', ')}`);
+
+            // Extract the body of a single markdown section by heading text.
+            function section(body, heading) {
+              if (!body) return '';
+              const out = [];
+              let capture = false;
+              for (const line of body.split(/\r?\n/)) {
+                const m = line.match(/^#{1,6}\s+(.*)$/);
+                if (m) {
+                  capture = m[1].trim().toLowerCase() === heading.toLowerCase();
+                  continue;
+                }
+                if (capture) out.push(line);
+              }
+              return out.join('\n');
+            }
+
+            // 2. Candidate downstream issues: open + release:next-minor.
+            const downstream = await github.paginate(github.rest.issues.listForRepo, {
+              owner, repo, state: 'open', labels: 'release:next-minor', per_page: 100,
+            });
+
+            // 3. Keep those that reference a just-closed issue under
+            //    "## Required in pinned seed" or "## Blocked by" AND whose
+            //    "## Files Affected" touches compiler-source.
+            const dependents = [];
+            for (const d of downstream) {
+              if (d.pull_request) continue; // listForRepo includes PRs
+              const body = d.body || '';
+              const refText =
+                section(body, 'Required in pinned seed') + '\n' + section(body, 'Blocked by');
+              const refs = [...refText.matchAll(/#(\d+)/g)].map(m => parseInt(m[1], 10));
+              if (!refs.some(n => closing.has(n))) continue;
+              const files = section(body, 'Files Affected');
+              if (!/compiler\/src\/|runtime\/prelude\.sfn/.test(files)) continue;
+              dependents.push(d.number);
+            }
+            if (dependents.length === 0) {
+              core.info('No required-in-seed dependents among release:next-minor issues.');
+              return;
+            }
+            core.info(`Dependents needing a seed cut: ${dependents.map(n => '#' + n).join(', ')}`);
+
+            // 4. Resolve the ACTIVE release tracker dynamically: open, labeled
+            //    `tracking`, title `Release: vX.Y.Z`. Never hardcoded.
+            const trackers = (await github.paginate(github.rest.issues.listForRepo, {
+              owner, repo, state: 'open', labels: 'tracking', per_page: 100,
+            })).filter(i => !i.pull_request && /^Release:\s*v\d/.test(i.title));
+            if (trackers.length === 0) {
+              core.info('No open Release tracker — logging and exiting 0 without posting.');
+              return;
+            }
+            const ver = t => {
+              const m = t.title.match(/v(\d+)\.(\d+)\.(\d+)/);
+              return m ? [+m[1], +m[2], +m[3]] : [Infinity, 0, 0];
+            };
+            trackers.sort((a, b) => {
+              const x = ver(a), y = ver(b);
+              return x[0] - y[0] || x[1] - y[1] || x[2] - y[2];
+            });
+            const tracker = trackers[0]; // nearest (lowest) unreleased version
+            if (trackers.length > 1) {
+              core.info(`Multiple open trackers; using nearest ${tracker.title} (#${tracker.number}).`);
+            }
+
+            // 5. Idempotency: skip if an advisory for THIS PR already exists.
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner, repo, issue_number: tracker.number, per_page: 100,
+            });
+            const marker = `Auto-advisor: PR #${prNumber} `;
+            if (comments.some(c => (c.body || '').includes(marker))) {
+              core.info(`Advisory for PR #${prNumber} already on #${tracker.number}; skipping comment.`);
+            } else {
+              const depList = dependents.map(n => '#' + n).join(', ');
+              const body =
+                `Auto-advisor: PR #${prNumber} just merged and is required-in-seed by ` +
+                `${depList}. Cut a new alpha and \`/pin-seed\` before pickup of those issues.`;
+              await github.rest.issues.createComment({ owner, repo, issue_number: tracker.number, body });
+              core.info(`Posted advisory on #${tracker.number}.`);
+            }
+
+            // 6. Flag for /release-plan: label the tracker and each dependent.
+            async function addLabel(num) {
+              try {
+                await github.rest.issues.addLabels({
+                  owner, repo, issue_number: num, labels: ['needs-seed-cut'],
+                });
+              } catch (e) {
+                core.warning(`Could not label #${num}: ${e.message}`);
+              }
+            }
+            await addLabel(tracker.number);
+            for (const n of dependents) await addLabel(n);

--- a/.github/workflows/seed-cut-advisor.yml
+++ b/.github/workflows/seed-cut-advisor.yml
@@ -113,9 +113,9 @@ jobs:
             //    `tracking`, title `Release: vX.Y.Z`. Never hardcoded.
             const trackers = (await github.paginate(github.rest.issues.listForRepo, {
               owner, repo, state: 'open', labels: 'tracking', per_page: 100,
-            })).filter(i => !i.pull_request && /^Release:\s*v\d/.test(i.title));
+            })).filter(i => !i.pull_request && /^Release:\s*v\d+\.\d+\.\d+\b/.test(i.title));
             if (trackers.length === 0) {
-              core.info('No open Release tracker — logging and exiting 0 without posting.');
+              core.info('No open semver Release tracker (Release: vX.Y.Z) — logging and exiting 0 without posting.');
               return;
             }
             const ver = t => {

--- a/docs/conventions/issue-naming.md
+++ b/docs/conventions/issue-naming.md
@@ -355,6 +355,30 @@ For issues groomed before this section existed, `/pickup` Phase 1.5
 falls back to checking every `## Blocked by` reference if the issue
 touches compiler-source files.
 
+### Seed-cut advisor (automated)
+
+`/pickup` Phase 1.5 is the strict gate, but it only fires when an agent
+is actively trying to claim an issue. The **seed-cut advisor**
+(`.github/workflows/seed-cut-advisor.yml`) is the complementary
+visibility layer: a plain, deterministic Actions workflow (no gh-aw, no
+LLM) that runs on every PR merge to `main`. When a merged PR closes an
+issue that an open, `release:next-minor`, compiler-touching issue lists
+under `## Required in pinned seed` (or, legacy, `## Blocked by`), the
+advisor:
+
+- comments on the **active** `Release: vX.Y.Z` tracker (resolved
+  dynamically — open issue, `tracking` label, `Release: vX.Y.Z` title;
+  never hardcoded) with an `Auto-advisor:` line naming the merged PR and
+  the dependent issues, and
+- applies the `needs-seed-cut` label to the tracker and the dependent
+  issues.
+
+It is idempotent (one advisory per PR per tracker) and **only flags** —
+it never dispatches `release.yml` or bumps `.seed-version`. `/release-plan`
+consumes the `needs-seed-cut` label, surfacing a "Seed cut required"
+checklist section on the per-cycle tracking issue. Clear the flag by
+cutting a fresh alpha and running `/pin-seed`, then removing the label.
+
 ### When to bump the pin
 
 Run `/pin-seed [vX.Y.Z]`:


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/seed-cut-advisor.yml` — a **plain, deterministic** Actions workflow (no gh-aw `.md`/`.lock.yml`, no LLM engine) that fires on PR merge to `main` and surfaces stale-seed risk.
- When a merged PR closes an issue that an open, `release:next-minor`, compiler-touching issue lists under `## Required in pinned seed` (or legacy `## Blocked by`), it comments on the **dynamically-resolved** active `Release: vX.Y.Z` tracker and applies `needs-seed-cut` to the tracker + dependents.
- Third leg of the #489 stale-seed mitigation (alongside the `## Required in pinned seed` template section and `/pickup` Phase 1.5), making the gap visible to humans even when no agent is present. The advisor **only flags** — never dispatches a release or bumps the pin.

Closes #534

## Design notes

- **Re-scoped from gh-aw to plain workflow** (per the issue's re-scope note): the advisor's logic is fully deterministic and needs no model. Implemented in a single `actions/github-script@v9.0.0` step (already a pinned repo dependency) rather than raw shell, because robust markdown-section + GraphQL + JSON handling is far cleaner in JS while staying deterministic — same spirit as `sync-project.yml`/`sync-labels.yml`.
- **Dynamic tracker resolution:** open issue, `tracking` label, title `^Release: v\d` — never hardcoded; picks the nearest (lowest) version; exits 0 if none.
- **Fires only** on `pull_request: closed` with `merged == true` and base `main`.
- **Idempotent:** dedups on an `Auto-advisor: PR #<n> ` marker before commenting.

## Acceptance Criteria

- [x] New plain workflow `.github/workflows/seed-cut-advisor.yml` exists (no gh-aw `.md`/`.lock.yml`, no LLM engine)
- [x] Resolves the active release tracker dynamically; logs + exits 0 when none exists
- [x] Fires only on `pull_request` `closed` with `merged == true` and base `main`
- [x] Idempotent — dedups on an existing `Auto-advisor:` comment for the PR
- [x] `needs-seed-cut` label added to `.github/labels.yml` (synced by `sync-labels.yml` on merge)
- [x] `/release-plan` consumes `needs-seed-cut` into a "Seed cut required" section (create + update modes)
- [x] Documented in `docs/conventions/issue-naming.md` "Seed pinning"
- [ ] Manual smoke test (merge a no-op PR linked to an edited downstream issue → advisory posts) — **post-merge** (workflow must be on `main`)

## Verification

```text
$ python3 -c "import yaml; yaml.safe_load(open('.github/workflows/seed-cut-advisor.yml'))"   # YAML OK
$ node --check <github-script body wrapped in async fn>                                       # JS OK
$ python3 -c "import yaml; ... 'needs-seed-cut' in names"                                     # True
```

## Files Changed

- `.github/workflows/seed-cut-advisor.yml` (new)
- `.github/labels.yml` (add `needs-seed-cut`)
- `.claude/commands/release-plan.md` (consume `needs-seed-cut`)
- `docs/conventions/issue-naming.md` (document the advisor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrkrBzp1Tvf7VxHHg6pfJu)_