### PR TITLE
chore(deps): broaden gh-aw dependabot ignore to match the bare repo

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -24,7 +24,7 @@ to specific releases/digests. When gh-aw rotates one of those pins
 upstream — or retracts a release outright, as happened with
 `gh-aw-firewall v0.25.28` (PR #442) — every agentic run fails at
 `Install AWF binary` until someone recompiles. Dependabot can't see this
-(it doesn't watch ghcr digests, and `github/gh-aw-actions/*` is
+(it doesn't watch ghcr digests, and `github/gh-aw-actions*` is
 explicitly ignored in `.github/dependabot.yml`), so the
 `.github/workflows/gh-aw-recompile.yml` workflow runs `gh aw compile
 --force-refresh-action-pins` weekly (and on demand) and opens a

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,11 @@ updates:
     ignore:
       # Owned by gh-aw — bumping these in `*.lock.yml` desyncs the embedded
       # manifest from the runtime image pins. Updates land via `gh aw compile`.
-      - dependency-name: "github/gh-aw-actions/*"
+      # The trailing `*` (not `/*`) is load-bearing: dependabot names this
+      # dependency `github/gh-aw-actions` (the bare repo), so `/*` would not
+      # match it — that gap let PR #1063 through. `*` covers both the bare
+      # repo and any sub-path action (e.g. github/gh-aw-actions/setup).
+      - dependency-name: "github/gh-aw-actions*"
   - package-ecosystem: "npm"
     directory: "/site"
     schedule:

--- a/.github/workflows/gh-aw-recompile.yml
+++ b/.github/workflows/gh-aw-recompile.yml
@@ -8,7 +8,7 @@ name: gh-aw Recompile
 # v0.25.28` was retracted and 404'd on `checksums.txt`).
 #
 # Dependabot can't see this: it doesn't watch ghcr digests, and
-# `github/gh-aw-actions/*` is ignored in `.github/dependabot.yml` precisely so
+# `github/gh-aw-actions*` is ignored in `.github/dependabot.yml` precisely so
 # it stops desyncing the lock files. So this workflow runs
 # `gh aw compile --force-refresh-action-pins` on a schedule, and if any lock
 # file drifts it opens a PR for human review.


### PR DESCRIPTION
## Summary

- Fixes the dependabot ignore glob for `github/gh-aw-actions` so it actually matches.
- `github/gh-aw-actions/*` → `github/gh-aw-actions*` (trailing `*`, not `/*`).

## Why

PR #442 added `github/gh-aw-actions/*` to `.github/dependabot.yml`'s ignore list to stop dependabot from bumping gh-aw's setup action **inside the compiled `*.lock.yml` files** — doing so advances the runner while the gh-aw-emitted manifest and image pins (firewall/mcpg/mcp-server) stay frozen, which the gh-aw FAQ explicitly warns against.

But dependabot names this dependency by its **bare repo** (`github/gh-aw-actions`, see #1063's title), and the `/*` glob requires a path segment after the slash — so it never matched. That gap let **#1063** through: a bump of only `github/gh-aw-actions/setup@<sha>` (`cc81570b` → `0fa9baa2`, a gh-aw v0.78.x-era commit) across 7 lock files whose bodies + pins were all emitted by gh-aw **v0.72.1**. Merging that would have left a v0.78 setup action driving a v0.72.1-compiled `release-notes.lock.yml` — risking a broken release-notes run at release time.

`github/gh-aw-actions*` matches both the bare repo and any sub-path action (e.g. `github/gh-aw-actions/setup`). gh-aw pins continue to advance only via `gh aw compile` (the #443 recompile workflow).

## Follow-up

- #1063 is being closed as superseded by this fix (do-not-merge: lock-file desync).

## Verification

```text
$ python3 -c "import yaml; yaml.safe_load(open('.github/dependabot.yml'))"   # YAML OK
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrkrBzp1Tvf7VxHHg6pfJu)_