### PR TITLE
fix(lowering): reconcile by-name and relative capsule import slugs (#873)

### DIFF
--- a/compiler/src/capsule_resolver.sfn
+++ b/compiler/src/capsule_resolver.sfn
@@ -1348,6 +1348,39 @@ fn _cr_stage_one(src: CapsuleSource, sailfin_exe: string, work_dir: string) -> b
     return true;
 }
 
+// #873: for every staged capsule source whose canonical slug differs
+// from the path-shaped slug a relative importer derives from the file
+// path (`module_name_from_path`), drop a `.slugalias` sidecar at the
+// PATH-slug location mapping it to the canonical slug. A relative import
+// (`../src/mod`) into a workspace member's source tree resolves to that
+// path slug, which has no staged `.layout-manifest` (the module was
+// staged under its canonical `sfn/crypto/mod` slug); the lowering /
+// typecheck import resolver reads this sidecar
+// (`imports.sfn:resolve_import_artifact_slug`) and converges on the
+// canonical slug so the call site mangles to the same symbol the capsule
+// object defines.
+//
+// No sidecar is written when the slug already equals the path slug —
+// which is every compiler-internal and non-capsule relative source — so
+// the self-host staging emits none and the resolver branch is never taken
+// while building the compiler.
+fn _cr_write_capsule_slug_aliases(sources: CapsuleSource[], context_root: string) ![io] {
+    let mut i: int = 0;
+    loop {
+        if i >= sources.length { break; }
+        let src = sources[i];
+        i += 1;
+        if src.slug.length == 0 { continue; }
+        if src.source_path.length == 0 { continue; }
+        let path_slug = module_name_from_path(_cr_canonicalise_path(src.source_path));
+        if path_slug.length == 0 { continue; }
+        if strings_equal(path_slug, src.slug) { continue; }
+        let alias_path = context_root + "/" + path_slug + ".slugalias";
+        _cr_ensure_dir(_cr_dirname(alias_path));
+        fs.writeFile(alias_path, src.slug);
+    }
+}
+
 // Extract `.layout` lines from a freshly-emitted `.sfn-asm` and
 // write the sibling `.layout-manifest`. Split out of `_cr_stage_one`
 // so the parallel-emit path can call it after xargs returns.
@@ -1419,6 +1452,7 @@ fn stage_capsule_imports(sources: CapsuleSource[], sailfin_exe: string, work_dir
             if !ok { return false; }
             si += 1;
         }
+        _cr_write_capsule_slug_aliases(sources, context_root);
         return true;
     }
 
@@ -1433,6 +1467,7 @@ fn stage_capsule_imports(sources: CapsuleSource[], sailfin_exe: string, work_dir
             if !ok { return false; }
             si += 1;
         }
+        _cr_write_capsule_slug_aliases(sources, context_root);
         return true;
     }
 
@@ -1496,6 +1531,10 @@ fn stage_capsule_imports(sources: CapsuleSource[], sailfin_exe: string, work_dir
             ei += 1;
         }
     }
+    // #873: alias sidecars are written for ALL sources (not just freshly-
+    // emitted ones) so a cache-hit run still publishes the path→canonical
+    // slug mapping the importer needs.
+    _cr_write_capsule_slug_aliases(sources, context_root);
     return true;
 }
 
@@ -2780,6 +2819,87 @@ fn _cr_relative_slug(entry_dir: string, file_path: string) -> string {
     return module_name_from_path(_cr_canonicalise_path(file_path));
 }
 
+// #873: map a relatively-imported file — identified by the PATH SLUG
+// that `_cr_relative_slug` / `module_name_from_path` derives for it — to
+// the canonical spec slug of the workspace member that owns its `src/`
+// tree. For path slug `capsules/sfn/crypto/src/mod` under member
+// `sfn/crypto` this returns `sfn/crypto/mod` — byte-identical to the slug
+// `_cr_collect_capsule_sources(<member>/src, "sfn/crypto")` assigns the
+// SAME file via the workspace-implicit / manifest-dep walks (line ~1035:
+// `spec + "/" + stem`). Returning that shared slug lets the relative and
+// scoped enumerators agree on one symbol per capsule function, so a
+// capsule's own tests (`import { f } from "../src/mod"`) link against the
+// same `f__sfn__crypto__mod` the by-name path already uses.
+//
+// CRITICAL — self-host safety: the input is the `module_name_from_path`
+// PATH SLUG, not the raw file path. `module_name_from_path` ROOTS every
+// `compiler/src/**` file at `compiler/src/` (→ `llvm/lowering/abi_hash`)
+// and every `runtime/**` file at `runtime/` (→ `prelude`), stripping
+// those prefixes. The `compiler` and `runtime/native` workspace members
+// (this repo lists both in `workspace.toml`) therefore NEVER match here —
+// their `<member_path>/src/` needle is absent from the stripped slug — so
+// compiler- and runtime-internal relative imports keep their existing
+// slugs and the self-host build stays byte-identical. Only
+// `capsules/<scope>/<name>` members, whose paths survive
+// `module_name_from_path` intact, are canonicalized. Returns "" when no
+// member owns the slug. The longest matching `member_path` wins so nested
+// members (a member whose path is a prefix of another) resolve
+// deterministically.
+fn _cr_capsule_slug_for_path(path_slug: string, members: WorkspaceMember[]) -> string {
+    if path_slug.length == 0 { return ""; }
+    let mut best_slug: string = "";
+    let mut best_len: int = -1;
+    let mut i: int = 0;
+    loop {
+        if i >= members.length { break; }
+        let m = members[i];
+        i += 1;
+        if m.member_path.length == 0 { continue; }
+        if m.name.length == 0 { continue; }
+        let needle = m.member_path + "/src/";
+        let pos = _cr_find_substring(path_slug, needle);
+        if pos < 0 { continue; }
+        let tail = substring(path_slug, pos + needle.length, path_slug.length);
+        if tail.length == 0 { continue; }
+        if m.member_path.length > best_len {
+            best_len = m.member_path.length;
+            best_slug = m.name + "/" + tail;
+        }
+    }
+    return best_slug;
+}
+
+// #873: recover the workspace-member spec (e.g. `sfn/crypto`) for a
+// canonical capsule slug produced by `_cr_capsule_slug_for_path`
+// (`sfn/crypto/mod`). The slug is `<member.name>/<tail>`, so the spec is
+// the member whose `name + "/"` prefixes the slug; the longest such name
+// wins so a submodule member nested under another resolves
+// deterministically. Returns "" when no member matches — callers then
+// leave `spec` empty (the path-slug / non-capsule case). The spec tags
+// the `CapsuleSource` so the relative-walk entry routes its `.ll` under
+// the per-capsule `build/capsules/<scope>/<name>/ir/` tree identically to
+// the workspace-implicit walk's entry for the same file.
+fn _cr_capsule_spec_for_slug(slug: string, members: WorkspaceMember[]) -> string {
+    let mut best: string = "";
+    let mut best_len: int = -1;
+    let mut i: int = 0;
+    loop {
+        if i >= members.length { break; }
+        let m = members[i];
+        i += 1;
+        if m.name.length == 0 { continue; }
+        let prefix = m.name + "/";
+        if slug.length <= prefix.length { continue; }
+        if substring(slug, 0, prefix.length) == prefix {
+            if m.name.length > best_len {
+                best_len = m.name.length;
+                best = m.name;
+            }
+        }
+    }
+    return best;
+}
+
 // Walk relative imports (`./foo`, `../foo`) reachable from `entry_path` and
 // return one CapsuleSource per discovered file. The entry itself is NOT
 // included — the caller compiles it via the standard single-file path.
@@ -2787,7 +2907,7 @@ fn _cr_relative_slug(entry_dir: string, file_path: string) -> string {
 // `runtime/*` and scoped (`scope/name`) imports are handled by
 // `enumerate_capsule_sources` (manifest-declared deps) and the workspace
 // member lookup; this enumerator only walks intra-project relative imports.
-fn enumerate_relative_sources(entry_path: string) -> CapsuleSource[] ![io] {
+fn enumerate_relative_sources(entry_path: string, members: WorkspaceMember[]) -> CapsuleSource[] ![io] {
     let mut out: CapsuleSource[] = [];
     if entry_path.length == 0 { return out; }
     let entry_dir = _cr_dirname(entry_path);
@@ -2844,14 +2964,33 @@ fn enumerate_relative_sources(entry_path: string) -> CapsuleSource[] ![io] {
                 if !already_seen {
                     visited.push(dep_path);
                     queue.push(dep_path);
-                    let slug = _cr_relative_slug(entry_dir, dep_path);
+                    // #873: if this relatively-imported file lives inside a
+                    // workspace member's `src/`, stage it under the member's
+                    // canonical spec slug (`sfn/crypto/mod`) — the SAME slug
+                    // the workspace-implicit / manifest-dep walks assign the
+                    // same file — so the relative and scoped enumerators
+                    // agree on one symbol per capsule function and a
+                    // capsule's own `../src/mod` tests link. Tag the spec
+                    // with the member name so the source routes under the
+                    // per-capsule `ir/` layout exactly like the implicit
+                    // walk's sources. Non-member paths (every `compiler/src/**`
+                    // and `runtime/**` file) get "" and fall back to the
+                    // path-shaped slug, leaving self-host slugs untouched.
+                    let path_slug = _cr_relative_slug(entry_dir, dep_path);
+                    let capsule_slug = _cr_capsule_slug_for_path(path_slug, members);
+                    let mut slug = path_slug;
+                    let mut spec: string = "";
+                    if capsule_slug.length > 0 {
+                        slug = capsule_slug;
+                        spec = _cr_capsule_spec_for_slug(capsule_slug, members);
+                    }
                     // ll_path is filled in by `_cr_resolve_and_dedupe`
                     // once the consumer is known (Stage C2b2) — for
                     // a `-p <consumer>` build with safe scope/name,
                     // this lands under the consumer's per-capsule
                     // tree; otherwise the legacy flat layout.
                     out.push(CapsuleSource {
-                        spec: "", source_path: dep_path, slug: slug, ll_path: ""
+                        spec: spec, source_path: dep_path, slug: slug, ll_path: ""
                     });
                 }
             }
@@ -3668,13 +3807,32 @@ fn _cr_resolve_and_dedupe(entry_paths: string[], consumer: ResolverConsumer) -> 
         };
     }
 
+    // (2) Manifest-declared capsule deps and (3) workspace-implicit
+    // imports use the first entry's directory as the anchor. By
+    // construction (callers group entries by `(project_root,
+    // workspace_root)`), every entry in `entry_paths` resolves to the
+    // same project root and workspace root, so the choice of anchor
+    // doesn't change the result. Computed up-front (#873) because the
+    // relative walk now needs the workspace member set to canonicalize
+    // a capsule source's slug to its spec slug.
+    let anchor_dir = _cr_dirname(entry_paths[0]);
+
+    let workspace_root = discover_workspace_root(anchor_dir);
+    let mut members: WorkspaceMember[] = [];
+    if workspace_root.length > 0 {
+        members = load_workspace_members(workspace_root);
+    }
+
     // (1) Relative imports — walked from every entry; the dedupe loop
-    // below collapses overlapping sets.
+    // below collapses overlapping sets. A relatively-imported file that
+    // resolves into a workspace member's `src/` is staged under that
+    // member's canonical spec slug (#873), so it collapses cleanly
+    // against the same file discovered by the workspace-implicit walk.
     let mut ei: int = 0;
     loop {
         if ei >= entry_paths.length { break; }
         let entry = entry_paths[ei];
-        let relative = enumerate_relative_sources(entry);
+        let relative = enumerate_relative_sources(entry, members);
         let mut ri: int = 0;
         loop {
             if ri >= relative.length { break; }
@@ -3683,14 +3841,6 @@ fn _cr_resolve_and_dedupe(entry_paths: string[], consumer: ResolverConsumer) -> 
         }
         ei += 1;
     }
-
-    // (2) Manifest-declared capsule deps and (3) workspace-implicit
-    // imports use the first entry's directory as the anchor. By
-    // construction (callers group entries by `(project_root,
-    // workspace_root)`), every entry in `entry_paths` resolves to the
-    // same project root and workspace root, so the choice of anchor
-    // doesn't change the result.
-    let anchor_dir = _cr_dirname(entry_paths[0]);
 
     let project_root = discover_project_root(anchor_dir);
 
@@ -3796,9 +3946,10 @@ fn _cr_resolve_and_dedupe(entry_paths: string[], consumer: ResolverConsumer) -> 
         }
     }
 
-    let workspace_root = discover_workspace_root(anchor_dir);
     if workspace_root.length > 0 {
-        let members = load_workspace_members(workspace_root);
+        // `workspace_root` + `members` were resolved up-front (above the
+        // relative walk) so both the relative and implicit enumerators
+        // share one member set (#873).
         // Workspace-implicit enumeration is per-entry: each entry may
         // reference a different scoped import, and the union is the
         // set the project actually needs.

--- a/compiler/src/capsule_resolver.sfn
+++ b/compiler/src/capsule_resolver.sfn
@@ -1375,6 +1375,17 @@ fn _cr_write_capsule_slug_aliases(sources: CapsuleSource[], context_root: string
         let path_slug = module_name_from_path(_cr_canonicalise_path(src.source_path));
         if path_slug.length == 0 { continue; }
         if strings_equal(path_slug, src.slug) { continue; }
+        // Guard against path traversal / clobber: `module_name_from_path`
+        // preserves `..` segments and a leading `/` when the source was
+        // reached via a non-canonical or absolute path (e.g. building from
+        // a different CWD via `../repo/...`). Such a slug would let
+        // `alias_path` escape `context_root`. A consumer's import only ever
+        // resolves to a clean relative slug, so a `..`/absolute sidecar
+        // could never be read anyway — skip it rather than write outside
+        // the staging root. The convergence simply falls back to the path
+        // slug for that (unusual) source, which is the pre-#873 behaviour.
+        if _cr_find_substring(path_slug, "..") >= 0 { continue; }
+        if substring(path_slug, 0, 1) == "/" { continue; }
         let alias_path = context_root + "/" + path_slug + ".slugalias";
         _cr_ensure_dir(_cr_dirname(alias_path));
         fs.writeFile(alias_path, src.slug);

--- a/compiler/src/llvm/imports.sfn
+++ b/compiler/src/llvm/imports.sfn
@@ -209,6 +209,27 @@ fn collect_imported_module_context_for_module(imports: NativeImport[], current_m
     };
 }
 
+fn _slug_alias_path_for_slug(slug: string) -> string {
+    return "build/native/import-context/" + slug + ".slugalias";
+}
+
+fn _selfhost_slug_alias_path_for_slug(slug: string) -> string {
+    return "build/selfhost/native/seed_cwd/build/native/import-context/" + slug
+        + ".slugalias";
+}
+
+// #873: read the `.slugalias` sidecar the resolver drops at a capsule
+// source's PATH slug, mapping it to the source's CANONICAL spec slug
+// (`capsules/sfn/crypto/src/mod` → `sfn/crypto/mod`). Returns "" when no
+// sidecar exists (every non-capsule / compiler-internal relative import).
+fn _resolve_slug_alias(slug: string) -> string ![io] {
+    let primary = _slug_alias_path_for_slug(slug);
+    if fs.exists(primary) { return trim_text(fs.readFile(primary)); }
+    let fallback = _selfhost_slug_alias_path_for_slug(slug);
+    if fs.exists(fallback) { return trim_text(fs.readFile(fallback)); }
+    return "";
+}
+
 fn resolve_import_artifact_slug(slug: string) -> string ![io] {
     if slug.length == 0 { return slug; }
 
@@ -223,6 +244,16 @@ fn resolve_import_artifact_slug(slug: string) -> string ![io] {
             return mod_slug;
         }
     }
+
+    // #873: a relative import (`../src/mod`) into a workspace member's
+    // source tree resolves to a path-shaped slug with no staged artifact —
+    // the resolver staged the module under its canonical spec slug
+    // (`sfn/crypto/mod`) and dropped a `.slugalias` sidecar recording the
+    // mapping. Honour it so the call site mangles to the same symbol the
+    // capsule object defines, converging the relative- and by-name-import
+    // paths onto one suffix.
+    let alias = _resolve_slug_alias(slug);
+    if alias.length > 0 { return alias; }
 
     return slug;
 }

--- a/compiler/tests/e2e/test_capsule_byname_import_link.sh
+++ b/compiler/tests/e2e/test_capsule_byname_import_link.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# Regression test for issue #873: by-name capsule import link parity.
+#
+# A program that imports a workspace capsule *by name*
+# (`import { f } from "sfn/crypto"`) must link: the importer-side
+# mangled symbol must match the symbol the compiled capsule object
+# actually defines. The original bug (#873, observed during #816) had
+# the call site resolve the callee via the `[capsule].name`-based slug
+# (`sfn/crypto/mod` -> `sha256_hex__sfn__crypto__mod`) while the capsule
+# source was compiled under a different slug
+# (`capsules/sfn/crypto/src/mod` -> `sha256_hex__capsules__sfn__crypto__src__mod`),
+# so the link failed with `undefined reference`.
+#
+# Capsule *tests* dodge this by using relative imports
+# (`from "../src/mod"`); this test deliberately exercises the by-name
+# path that they don't cover.
+#
+# Usage:
+#   compiler/tests/e2e/test_capsule_byname_import_link.sh <compiler-binary>
+
+set -uo pipefail
+
+BINARY="${1:?usage: test_capsule_byname_import_link.sh <compiler-binary>}"
+BINARY="$(realpath "$BINARY")"
+PASS=0
+FAIL=0
+
+# Scratch dir for the test project. Cleaned on exit.
+SCRATCH="$(mktemp -d -t sfn-byname-link-XXXXXX)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+
+run_test() {
+    local name="$1"
+    shift
+    if "$@"; then
+        echo "[test] PASS: $name"
+        PASS=$((PASS + 1))
+    else
+        echo "[test] FAIL: $name"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# ---- Setup: minimal project declaring sfn/crypto as a dep ----
+mkdir -p "$SCRATCH/src"
+
+# Link (rather than copy) the in-tree capsules/ dir so the resolver's
+# in-tree lookup finds sfn/crypto without needing the user cache.
+ln -s "$REPO_ROOT/capsules" "$SCRATCH/capsules"
+
+cat > "$SCRATCH/capsule.toml" <<'EOF'
+[capsule]
+name = "byname-link-test"
+version = "0.1.0"
+description = "E2E regression for #873 by-name capsule import linking"
+
+[dependencies]
+"sfn/crypto" = "0.3.0"
+
+[capabilities]
+required = ["io"]
+
+[build]
+entry = "src/main.sfn"
+EOF
+
+# Import the crypto capsule *by name* (not by relative path) — this is
+# the path that #873 reported broken.
+cat > "$SCRATCH/src/main.sfn" <<'EOF'
+import { sha256_hex } from "sfn/crypto";
+
+fn main() -> int ![io] {
+    // sha256("abc") is a well-known fixed digest. Printing the exact
+    // expected value lets the shell test assert correctness, not just
+    // a non-crashing run.
+    print.info(sha256_hex("abc"));
+    return 0;
+}
+EOF
+
+# Known-answer: SHA-256 of the ASCII string "abc".
+EXPECTED="ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+
+# ---- Test 1: by-name import builds with no link error ----
+test_build_succeeds() {
+    cd "$SCRATCH" || return 1
+    local rc
+    "$BINARY" build -o build/program src/main.sfn > "$SCRATCH/build.stdout" 2>&1
+    rc=$?
+    if [ "$rc" -ne 0 ]; then
+        echo "[test]   sfn build exited with code $rc; output:" >&2
+        cat "$SCRATCH/build.stdout" >&2
+        return 1
+    fi
+    # Guard the exact #873 symptom: a slug mismatch surfaces as an
+    # `undefined reference` from the linker even when the compile
+    # itself "succeeds" up to the link step.
+    if grep -qi "undefined reference" "$SCRATCH/build.stdout"; then
+        echo "[test]   linker reported an undefined reference:" >&2
+        grep -i "undefined reference" "$SCRATCH/build.stdout" >&2
+        return 1
+    fi
+    return 0
+}
+run_test "by-name capsule import builds with no undefined reference" test_build_succeeds
+
+# ---- Test 2: the linked binary runs and prints the right digest ----
+test_binary_runs() {
+    cd "$SCRATCH" || return 1
+    [ -x "build/program" ] || return 1
+    local rc
+    "$SCRATCH/build/program" > "$SCRATCH/program.stdout" 2>&1
+    rc=$?
+    if [ "$rc" -ne 0 ]; then
+        echo "[test]   binary exited with code $rc; output:" >&2
+        cat "$SCRATCH/program.stdout" >&2
+        return 1
+    fi
+    if ! grep -q "$EXPECTED" "$SCRATCH/program.stdout"; then
+        echo "[test]   expected digest $EXPECTED not found; output:" >&2
+        cat "$SCRATCH/program.stdout" >&2
+        return 1
+    fi
+    return 0
+}
+run_test "by-name capsule binary links and runs the capsule symbol" test_binary_runs
+
+# ---- Test 3: capsule was staged + compiled under the spec slug ----
+# Both the importer's call-site slug and the capsule-source compile slug
+# must agree on `sfn/crypto/mod`; the staged artifacts living under that
+# spec-shaped path (not a `capsules/sfn/crypto/src/...` path slug) is the
+# structural witness that the two resolution paths reconciled.
+test_staged_under_spec_slug() {
+    cd "$SCRATCH" || return 1
+    [ -f "build/native/import-context/sfn/crypto/mod.sfn-asm" ] || return 1
+    [ -f "build/capsules/sfn/crypto/ir/mod.ll" ] || return 1
+    return 0
+}
+run_test "capsule staged + compiled under the spec slug (sfn/crypto/mod)" test_staged_under_spec_slug
+
+# ---- Summary ----
+echo ""
+echo "[test] $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/compiler/tests/unit/capsule_relative_slug_test.sfn
+++ b/compiler/tests/unit/capsule_relative_slug_test.sfn
@@ -1,0 +1,143 @@
+// #873 regression: `_cr_capsule_slug_for_path` must map a relatively-
+// imported capsule source (identified by its `module_name_from_path`
+// PATH SLUG) to its workspace member's canonical spec slug, and MUST
+// return "" for any slug not owned by a member.
+//
+// The load-bearing case is self-host safety: this repo's `workspace.toml`
+// lists `compiler` and `runtime/native` as members, but
+// `module_name_from_path` strips the `compiler/src/` and `runtime/`
+// prefixes BEFORE the slug reaches this helper, so a compiler-internal
+// import arrives as `llvm/lowering/abi_hash` (no `compiler/src/` segment)
+// and must NOT match the `compiler` member — otherwise every unit test
+// that relative-imports a compiler module fails to link. The
+// `compiler`/`runtime/native` members are present in `_members()` below
+// precisely so these tests would catch that regression.
+//
+// Helpers are inline-duplicated (mirroring `relative_import_resolver_test.sfn`)
+// because importing from `capsule_resolver.sfn` pulls in the whole
+// compiler via `./main`, which trips the seed's per-module timeout. The
+// inlined copy below MUST stay byte-for-byte in step with the original in
+// `compiler/src/capsule_resolver.sfn`.
+fn _str_eq(a: string, b: string) -> boolean {
+    if a.length != b.length { return false; }
+    let mut i: int = 0;
+    loop {
+        if i >= a.length { break; }
+        if substring(a, i, i + 1) != substring(b, i, i + 1) { return false; }
+        i += 1;
+    }
+    return true;
+}
+
+// Mirror of `WorkspaceMember` (compiler/src/capsule_resolver.sfn).
+struct _Member {
+    name: string;
+    member_path: string;
+    src_dir: string;
+}
+
+// Inline copy of `_cr_find_substring`.
+fn _find_substring(haystack: string, needle: string) -> int {
+    if needle.length == 0 { return 0; }
+    if needle.length > haystack.length { return -1; }
+    let last = haystack.length - needle.length;
+    let mut i: int = 0;
+    loop {
+        if i > last { break; }
+        if substring(haystack, i, i + needle.length) == needle { return i; }
+        i += 1;
+    }
+    return -1;
+}
+
+// Inline copy of `_cr_capsule_slug_for_path` (operates on the PATH SLUG,
+// i.e. the `module_name_from_path` output the caller computes).
+fn _capsule_slug_for_path(path_slug: string, members: _Member[]) -> string {
+    if path_slug.length == 0 { return ""; }
+    let mut best_slug: string = "";
+    let mut best_len: int = -1;
+    let mut i: int = 0;
+    loop {
+        if i >= members.length { break; }
+        let m = members[i];
+        i += 1;
+        if m.member_path.length == 0 { continue; }
+        if m.name.length == 0 { continue; }
+        let needle = m.member_path + "/src/";
+        let pos = _find_substring(path_slug, needle);
+        if pos < 0 { continue; }
+        let tail = substring(path_slug, pos + needle.length, path_slug.length);
+        if tail.length == 0 { continue; }
+        if m.member_path.length > best_len {
+            best_len = m.member_path.length;
+            best_slug = m.name + "/" + tail;
+        }
+    }
+    return best_slug;
+}
+
+// Members mirror this repo's workspace.toml: the `capsules/*` stdlib
+// members PLUS `compiler` and `runtime/native` (whose presence is the
+// whole point of the self-host-safety cases below).
+fn _members() -> _Member[] {
+    let mut out: _Member[] = [];
+    out.push(_Member {
+        name: "sfn/crypto", member_path: "capsules/sfn/crypto", src_dir: "capsules/sfn/crypto/src"
+    });
+    out.push(_Member {
+        name: "sfn/http", member_path: "capsules/sfn/http", src_dir: "capsules/sfn/http/src"
+    });
+    out.push(_Member {
+        name: "sfn/compiler", member_path: "compiler", src_dir: "compiler/src"
+    });
+    out.push(_Member {
+        name: "sfn/runtime-native", member_path: "runtime/native", src_dir: "runtime/native/src"
+    });
+    return out;
+}
+
+test "capsule slug: capsule source path slug maps to spec slug" {
+    let slug = _capsule_slug_for_path("capsules/sfn/crypto/src/mod", _members());
+    assert _str_eq(slug, "sfn/crypto/mod");
+}
+
+test "capsule slug: nested capsule source keeps the tail" {
+    let slug = _capsule_slug_for_path("capsules/sfn/crypto/src/util/hex", _members());
+    assert _str_eq(slug, "sfn/crypto/util/hex");
+}
+
+test "capsule slug: second member resolves to its own spec" {
+    let slug = _capsule_slug_for_path("capsules/sfn/http/src/mod", _members());
+    assert _str_eq(slug, "sfn/http/mod");
+}
+
+test "capsule slug: absolute path slug still matches via the src segment" {
+    let slug = _capsule_slug_for_path("/home/user/sailfin/capsules/sfn/crypto/src/mod", _members());
+    assert _str_eq(slug, "sfn/crypto/mod");
+}
+
+// SELF-HOST GUARD: `module_name_from_path` strips `compiler/src/`, so a
+// compiler-internal import reaches the helper as `llvm/lowering/abi_hash`.
+// Even with the `compiler` member present, that slug has no
+// `compiler/src/` segment, so it must NOT canonicalize.
+test "capsule slug: stripped compiler slug returns empty despite compiler member" {
+    let slug = _capsule_slug_for_path("llvm/lowering/abi_hash", _members());
+    assert _str_eq(slug, "");
+}
+
+// SELF-HOST GUARD: `module_name_from_path` strips `runtime/`, so a runtime
+// import reaches the helper as e.g. `prelude` and must NOT canonicalize.
+test "capsule slug: stripped runtime slug returns empty despite runtime member" {
+    let slug = _capsule_slug_for_path("prelude", _members());
+    assert _str_eq(slug, "");
+}
+
+test "capsule slug: slug outside any member src returns empty" {
+    let slug = _capsule_slug_for_path("/tmp/widget/src/main", _members());
+    assert _str_eq(slug, "");
+}
+
+test "capsule slug: member dir slug without a /src/ tail returns empty" {
+    let slug = _capsule_slug_for_path("capsules/sfn/crypto/capsule", _members());
+    assert _str_eq(slug, "");
+}

--- a/docs/status.md
+++ b/docs/status.md
@@ -33,6 +33,21 @@ feature availability.
   reference the source uses without declaring, resolved against the
   workspace.toml member list. The textual `inline_imports_for_source`
   fallback in `sfn run` is gone (Stage B PR1).
+- **By-name and relative imports of a workspace capsule resolve to one
+  symbol** (#873): a relative import (`from "../src/mod"`) that lands
+  inside a workspace member's `src/` is now staged under the member's
+  canonical spec slug (`sfn/crypto/mod`) — the same slug the by-name
+  (`from "sfn/crypto"`) and manifest-dep paths assign — so both import
+  styles mangle a capsule function to one symbol
+  (`sha256_hex__sfn__crypto__mod`) and link. The resolver drops a
+  `.slugalias` sidecar at the path-shaped slug so
+  `resolve_import_artifact_slug` (lowering) converges the relative
+  call site; the canonicalization is scoped strictly to `workspace.toml`
+  members, so compiler-internal `compiler/src/**` relative slugs are
+  byte-identical and self-host is unaffected. Covered by
+  `compiler/tests/unit/capsule_relative_slug_test.sfn`,
+  `compiler/tests/e2e/test_capsule_byname_import_link.sh`, and the
+  `capsules/sfn/crypto` relative-import test suite.
 - `sfn build -p <capsule-path>` builds a capsule by manifest path. Reads
   `[build].kind`: `"library"` (default for stdlib capsules) emits a `.o`
   via `clang -c`; `"binary"` links an executable; `"runtime"` errors as a


### PR DESCRIPTION
## Summary
- A capsule function's external linker symbol depended on **how it was imported**, not on the function's identity. A by-name import (`from "sfn/crypto"`) staged the source under the spec slug `sfn/crypto/mod` → `sha256_hex__sfn__crypto__mod`, while a relative import (`from "../src/mod"`, used by every capsule's own tests) mangled to the path slug → `sha256_hex__capsules__sfn__crypto__src__mod`. The two disagreed, so the relative-import tests failed to link with `undefined reference` — the `capsules` suite was **red on `main` (32/34**: `sha256_test`, `base64_test`).
- This reconciles both import styles onto **one canonical symbol per capsule function**, the spec slug the by-name path already uses.

Closes #873

## What changed
- **`capsule_resolver.sfn`** — `_cr_capsule_slug_for_path` maps a relatively-imported file landing in a workspace member's `src/` to that member's spec slug. It keys off the `module_name_from_path` **path slug**, so the `compiler` and `runtime/native` workspace members (whose prefixes `module_name_from_path` strips) **never match** — compiler/runtime-internal relative slugs stay byte-identical and self-host is unaffected. The resolver also drops a `.slugalias` sidecar at the path slug.
- **`llvm/imports.sfn`** — `resolve_import_artifact_slug` reads the `.slugalias` sidecar so a relative call site converges on the canonical slug and mangles to the same symbol the capsule object defines.
- Both enumerators now assign one slug per capsule source, collapsing the prior double-compile (the #363 slug-blind-cache hazard) for capsule deps.
- Tests: new `compiler/tests/unit/capsule_relative_slug_test.sfn` (incl. explicit self-host-safety guards that the `compiler`/`runtime/native` members do **not** re-slug stripped compiler/runtime imports) + the by-name e2e regression `compiler/tests/e2e/test_capsule_byname_import_link.sh`.
- Docs: `docs/status.md` capsule-resolution note.

## Scope note
The issue marked relative-path imports `Out:` ("already self-consistent and working"), but intervening workspace-member-map work (#1067/#1130) moved the slug disagreement onto the relative-import side, making `make check` red on `main`. The fix is exactly the issue's `In:` goal ("call-site and capsule-source agree on one suffix"); honoring it necessarily touches relative-import slug derivation. Approved with the maintainer before implementation.

## Acceptance Criteria
- [x] A program with `import { sha256_hex } from "sfn/crypto"` builds and runs (no `undefined reference`).
- [x] New regression test covers by-name capsule import linking (+ relative-import link, + self-host-safety unit guards).
- [x] `make compile` passes (compiler self-hosts — verified 3×).
- [x] Full suite green (see below).

## Verification
```text
make compile                       # self-hosts (run 3×, byte-identical)
build/native/sailfin test capsules/sfn/crypto      → crypto: 2/2 passed   (was failing to link)
full suite (clean cache):
  unit:                 129/129 passed   (baseline 128 + 1 new test)
  integration:           31/31  passed
  e2e:                    5/5   passed
  capsules:              34/34  passed   (was 32/34 on main)
  implicit-capsule-link:  2/2   passed
test_capsule_byname_import_link.sh → 3/3 passed
test_check_compiler_src.sh         → 2/2 passed (standalone)
test_call_emission_no_polling.sh   → 4/4 passed (standalone)
```

> Note: in the heavy back-to-back `make check` run, two memory-bound `e2e-sh` scripts (`test_check_compiler_src.sh` — `sfn check compiler/src` over 156 files under the 8 GB cap — and `test_call_emission_no_polling.sh`) hit a transient SIGSEGV. Both pass deterministically when run standalone (2/2, 4/4) and `sfn check compiler/src` returns "checked 156 files: ok" on its own; this is the known borderline-memory flakiness the `test_check_compiler_src.sh` "Phase 5a regression" guard exists for, not a logic regression from this change. Flagging for CI visibility.

## Files Changed
- `compiler/src/capsule_resolver.sfn`
- `compiler/src/llvm/imports.sfn`
- `compiler/tests/unit/capsule_relative_slug_test.sfn` (new)
- `compiler/tests/e2e/test_capsule_byname_import_link.sh` (new)
- `docs/status.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019P8az2hiWhehBAJ8Zo2yRB)_