### PR TITLE
refactor(runtime): restore pointer-typed drop_fn field in RcHeader

### DIFF
--- a/runtime/sfn/memory/rc.sfn
+++ b/runtime/sfn/memory/rc.sfn
@@ -97,8 +97,9 @@ fn sfn_rc_sfn_alloc(size: i64, drop_fn: * u8) -> * u8 {
 
 // `sfn_rc_sfn_retain(payload)` atomically increments the
 // refcount of the value at `payload`. Steps back 16 bytes
-// (two `i64` slots — refcount sits at slot 0, drop_fn at slot 1)
-// to reach the refcount field, then emits `atomicrmw add ptr %p,
+// (two 8-byte slots — the `i64` refcount at slot 0, the `* u8`
+// drop_fn at slot 1) to reach the refcount field, then emits
+// `atomicrmw add ptr %p,
 // i64 1 seq_cst, align 8`. The previous-value return from
 // `atomic_add` is intentionally discarded — retains do not need
 // to observe the old count.

--- a/runtime/sfn/memory/rc.sfn
+++ b/runtime/sfn/memory/rc.sfn
@@ -8,8 +8,8 @@
 // Header layout (16 bytes, per `docs/runtime_architecture.md`
 // §2.1.2):
 //
-//   offset 0:  refcount     (i64)        — atomic refcount, init 1
-//   offset 8:  drop_fn_addr (i64 slot)   — `fn(*u8) -> void` storage
+//   offset 0:  refcount (i64)   — atomic refcount, init 1
+//   offset 8:  drop_fn  (* u8)  — `fn(*u8) -> void` storage
 //
 // The header sits at `payload - 16`; `sfn_rc_sfn_alloc` returns
 // the payload pointer so user code never sees the bookkeeping
@@ -19,28 +19,15 @@
 // the IR shape that the test harness pins as the M2.3 proof of
 // life.
 //
-// drop_fn storage uses an `i64` slot (`drop_fn_addr`) rather
-// than `* u8`. The seed compiler's struct-field assignment
-// silently drops stores to `* u8` fields routed through a
-// `* StructTy` pointer (verified during this M2.3 implementation
-// — `header.drop_fn = ptr;` emits no `store i8*, ...` in the
-// resulting IR). Reinterpreting the function-pointer address as
-// `i64` via `as i64` lowers to a clean `ptrtoint i8* … to i64`
-// and a 64-bit store, which is byte-equivalent to storing the
-// raw pointer on every platform Sailfin currently targets (the
-// pointer width is 64 bits everywhere extern function pointers
-// are valid). The architecture spec's `drop_fn: fn(*u8) -> void`
-// shape degrades to `* u8` at the export boundary — same
-// convention as `runtime/sfn/platform/pthread.sfn`, where the
-// `sfn fmt` / `is_c_abi_function_pointer` interaction forces
-// every function-pointer parameter through a raw `* u8` slot
-// until the formatter learns to keep `fn(` tight (see the
-// pthread.sfn header for the same workaround). Only the slot
-// *width* survives, not the typed callsite — and the in-header
-// `drop_fn_addr: i64` reflects that storage truth honestly.
-// The slot retypes to a proper function pointer once both the
-// seed grows aggregate-field assignment for raw pointers AND
-// `is_c_abi_function_pointer` accepts the `fn (...)` form
+// drop_fn storage is a proper `* u8` pointer field. The #713
+// fix (pointer-typed struct-field layout + store, in the pinned
+// seed) lets `header.drop_fn = drop_fn;` emit a real `store i8*`
+// with no `as i64` / `ptrtoint` bridge — the `i64`-slot
+// workaround introduced in M2.3 (PR #712) is retired here (#1115).
+// The architecture spec's `drop_fn: fn(*u8) -> void` shape still
+// degrades to `* u8` at the export boundary — the typed
+// function-pointer slot is gated separately on
+// `is_c_abi_function_pointer` accepting the `fn (...)` form
 // (tracked for M2.4/M2.6, where `sfn_drop_SfnString` /
 // `sfn_drop_SfnArray` callers light up).
 //
@@ -81,18 +68,18 @@ extern fn free(ptr: * u8) -> void;
 
 // `RcHeader` lays out the 16-byte bookkeeping prefix. The
 // architecture spec's `drop_fn: fn(*u8) -> void` field appears
-// here as `drop_fn_addr: i64` — see the file-header note for
-// the storage-type rationale. Field offsets are pinned by the
-// IR-shape assertions in `test_runtime_memory_rc.sh`.
+// here as `drop_fn: * u8` — see the file-header note for the
+// storage-type rationale. The pointer field is 8 bytes, so the
+// header stays 16 bytes with refcount @0 and drop_fn @8.
 struct RcHeader {
     refcount: i64;
-    drop_fn_addr: i64;
+    drop_fn: * u8;
 }
 
 // `sfn_rc_sfn_alloc(size, drop_fn)` allocates a 16-byte header
 // plus `size` payload bytes, initializes the refcount to 1,
-// stores `drop_fn` (as a raw 64-bit address) in the header
-// drop-fn slot, and returns the payload pointer. The header is
+// stores `drop_fn` in the header drop-fn slot, and returns the
+// payload pointer. The header is
 // reachable from the payload via `payload - 16`. Returns `null`
 // when libc `malloc` reports OOM — guarding the header
 // initialisation stores against a NULL deref. The C convention
@@ -104,7 +91,7 @@ fn sfn_rc_sfn_alloc(size: i64, drop_fn: * u8) -> * u8 {
     if header_ptr as i64 == 0 { return header_ptr; }
     let header = header_ptr as * RcHeader;
     header.refcount = 1;
-    header.drop_fn_addr = drop_fn as i64;
+    header.drop_fn = drop_fn;
     return header_ptr + 16;
 }
 


### PR DESCRIPTION
## Summary
- Replace the `drop_fn_addr: i64` workaround in `RcHeader` with a proper `drop_fn: * u8` field.
- Drop the `as i64` / `ptrtoint` bridge at the store site — `header.drop_fn = drop_fn;` now emits a real `store i8*` with no cast, enabled by the #713 pointer-field layout/store fix landing in the pinned seed (`v0.7.0-alpha.26`).
- Header stays 16 bytes; offsets unchanged (refcount @0, drop_fn @8).

Closes #1115

## Acceptance Criteria
- [x] `RcHeader` declares `drop_fn: * u8`; `header.drop_fn = drop_fn;` is written with no cast.
- [x] Header stays 16 bytes; field offsets unchanged (refcount @0, drop_fn @8).
- [x] No `drop_fn_addr` references remain in `rc.sfn`.
- [x] `make compile` passes (against the seed that contains the #713 fix).
- [x] `make check` passes.

## Verification
```bash
ulimit -v 8388608 && make compile      # pass — self-hosts
grep -n "drop_fn_addr" runtime/sfn/memory/rc.sfn   # no matches
ulimit -v 8388608 && build/native/sailfin fmt --check runtime/sfn/memory/rc.sfn   # clean
# unified suite (standalone): unit 131/131, integration 31/31, e2e 5/5, capsules 34/34
# legacy e2e-sh: 108/108 — includes the rc alloc→retain→release roundtrip
ulimit -v 8388608 && make check        # full triple-pass self-host + suite
```

No rc test-fixture changes were needed: `compiler/tests/e2e/test_runtime_memory_rc.sh` pins the `alloc` signature (`i8* %drop_fn` — a parameter, unchanged) and the retain/release atomicrmw shapes, with no assertion on the header field's storage type.

## Files Changed
- `runtime/sfn/memory/rc.sfn` — restored the pointer field, removed the casts, updated the workaround-rationale comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NbTmJeApmzbWdWkVQ4gQtN)_