### PR TITLE
feat(cli): add `sfn lock` to write workspace.lock

### DIFF
--- a/compiler/src/cli_commands.sfn
+++ b/compiler/src/cli_commands.sfn
@@ -3103,6 +3103,7 @@ export {
     handle_add_command,
     handle_config_command,
     handle_init_command,
+    handle_lock_command,
     handle_login_command,
     handle_guillermo_command,
     handle_fmt_command

--- a/compiler/src/cli_commands.sfn
+++ b/compiler/src/cli_commands.sfn
@@ -10,7 +10,8 @@ import {
     TestCapsuleResolution,
     discover_project_root,
     discover_workspace_root,
-    prepare_project_capsules_for_test
+    prepare_project_capsules_for_test,
+    resolve_workspace_lock_entries
 } from "./capsule_resolver";
 import {
     _collect_sfn_files_cmd,
@@ -51,7 +52,7 @@ import {
 import { assemble_runtime_capsule_link_inputs } from "./cli_main";
 import { DistManifest, dist_manifest_to_json, empty_dist_manifest } from "./dist_manifest";
 import { ImportSymbolTable, empty_import_symbols } from "./effect_imports";
-import { lock_add_entry, lock_get_version } from "./lock";
+import { lock_add_entry, lock_get_version, workspace_lock_write } from "./lock";
 import {
     compile_tests_to_llvm_file_with_module_imports,
     compile_to_llvm_file_with_module,
@@ -2862,6 +2863,33 @@ fn handle_init_command(args: string[]) -> int ![io] {
         fs.writeFile("src/main.sfn", "fn main() ![io] {\n    print(\"Hello, Sailfin!\");\n}\n");
     }
     print("initialized capsule: " + pkg_name);
+    return 0;
+}
+
+// `sfn lock`: materialize `workspace.lock` at the workspace root. Walks up
+// from the current directory for `workspace.toml`, resolves the member graph
+// into the flat lock-entry set (#1069), serializes it with the
+// `# workspace.lock` banner (#1068), and writes the file. Explicit-only —
+// nothing on the `sfn build` path regenerates it (keeps the self-host path
+// predictable). Output is deterministic, so re-running is idempotent.
+fn handle_lock_command(args: string[]) -> int ![io] {
+    if args.length != 1 {
+        print("usage: sfn lock");
+        return 2;
+    }
+    let mut start_dir = _get_env_cmd("PWD");
+    if start_dir.length == 0 { start_dir = "."; }
+    let workspace_root = discover_workspace_root(start_dir);
+    if workspace_root.length == 0 {
+        print("sfn lock: no workspace.toml found (run inside a workspace)");
+        return 1;
+    }
+    let entries = resolve_workspace_lock_entries(workspace_root);
+    let lock_text = workspace_lock_write(entries);
+    let lock_path = workspace_root + "/workspace.lock";
+    fs.writeFile(lock_path, lock_text);
+    print("wrote " + lock_path + " (" + number_to_string(entries.length)
+        + " members)");
     return 0;
 }
 

--- a/compiler/src/cli_main.sfn
+++ b/compiler/src/cli_main.sfn
@@ -59,6 +59,7 @@ import {
     handle_fmt_command,
     handle_guillermo_command,
     handle_init_command,
+    handle_lock_command,
     handle_login_command,
     handle_package_command,
     handle_publish_command,
@@ -163,6 +164,7 @@ fn _usage() -> string {
     out = out + "\n";
     out = out + "packages:\n";
     out = out + "  sfn add     [--dev] [--update] <capsule>\n";
+    out = out + "  sfn lock\n";
     out = out + "  sfn publish [path]\n";
     out = out
         + "  sfn package [--target T] [--out DIR] [--compiler-bin PATH] [--installer] [-p <capsule-path>]\n";
@@ -1715,6 +1717,7 @@ fn sailfin_cli_main(argv: string[]) -> int ![io, clock] {
     let is_publish = strings_equal(cmd, "publish");
     let is_package = strings_equal(cmd, "package");
     let is_add = strings_equal(cmd, "add");
+    let is_lock = strings_equal(cmd, "lock");
     let is_login = strings_equal(cmd, "login");
     let is_config = strings_equal(cmd, "config");
     let is_fmt = strings_equal(cmd, "fmt");
@@ -2511,6 +2514,8 @@ fn sailfin_cli_main(argv: string[]) -> int ![io, clock] {
     if is_package { return handle_package_command(args); }
 
     if is_add { return handle_add_command(args); }
+
+    if is_lock { return handle_lock_command(args); }
 
     if is_login { return handle_login_command(args); }
 

--- a/compiler/tests/e2e/test_lock.sh
+++ b/compiler/tests/e2e/test_lock.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# End-to-end tests for `sfn lock` (#1070).
+#
+# Usage:
+#   compiler/tests/e2e/test_lock.sh <compiler-binary>
+#
+# `sfn lock` materializes `workspace.lock` at the workspace root: a
+# `# workspace.lock` banner followed by one `[packages]` entry per member.
+# Runs against a throwaway fixture workspace so the repo tree is untouched.
+
+set -euo pipefail
+
+BINARY="${1:?usage: test_lock.sh <compiler-binary>}"
+# The runner passes a repo-relative binary path; resolve it to an absolute
+# path before we cd into the fixture workspace.
+BINARY="$(cd "$(dirname "$BINARY")" && pwd)/$(basename "$BINARY")"
+
+PASS=0
+FAIL=0
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+run_test() {
+    local name="$1"
+    shift
+    if "$@"; then
+        echo "[test] PASS: $name"
+        PASS=$((PASS + 1))
+    else
+        echo "[test] FAIL: $name"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# Build a fixture workspace with two members under $1.
+make_workspace() {
+    local root="$1"
+    mkdir -p "$root/alpha" "$root/beta"
+    cat > "$root/workspace.toml" <<'EOF'
+[workspace]
+members = ["alpha", "beta"]
+EOF
+    cat > "$root/alpha/capsule.toml" <<'EOF'
+[capsule]
+name = "fixture/alpha"
+version = "1.2.3"
+EOF
+    cat > "$root/beta/capsule.toml" <<'EOF'
+[capsule]
+name = "fixture/beta"
+version = "4.5.6"
+EOF
+}
+
+# ---- Test 1: lock in a workspace writes workspace.lock ----
+test_lock_writes_file() {
+    local root="$tmpdir/t1"
+    make_workspace "$root"
+    ( cd "$root" && "$BINARY" lock ) >/dev/null
+    [ -f "$root/workspace.lock" ] \
+        || { echo "workspace.lock not created"; return 1; }
+    head -1 "$root/workspace.lock" | grep -q '^# workspace.lock' \
+        || { echo "missing banner:"; cat "$root/workspace.lock"; return 1; }
+    grep -q '^\[packages\]' "$root/workspace.lock" \
+        || { echo "missing [packages] section"; cat "$root/workspace.lock"; return 1; }
+    grep -q '^"fixture/alpha" = "1.2.3"$' "$root/workspace.lock" \
+        || { echo "missing alpha entry:"; cat "$root/workspace.lock"; return 1; }
+    grep -q '^"fixture/beta" = "4.5.6"$' "$root/workspace.lock" \
+        || { echo "missing beta entry:"; cat "$root/workspace.lock"; return 1; }
+}
+
+# ---- Test 2: re-running is idempotent (stable output) ----
+test_lock_idempotent() {
+    local root="$tmpdir/t2"
+    make_workspace "$root"
+    ( cd "$root" && "$BINARY" lock ) >/dev/null
+    local first
+    first="$(cat "$root/workspace.lock")"
+    ( cd "$root" && "$BINARY" lock ) >/dev/null
+    local second
+    second="$(cat "$root/workspace.lock")"
+    [ "$first" = "$second" ] \
+        || { echo "output changed on re-run"; return 1; }
+}
+
+# ---- Test 3: lock from a nested member dir finds the workspace root ----
+test_lock_from_member_dir() {
+    local root="$tmpdir/t3"
+    make_workspace "$root"
+    ( cd "$root/alpha" && "$BINARY" lock ) >/dev/null
+    [ -f "$root/workspace.lock" ] \
+        || { echo "workspace.lock not written at root from nested dir"; return 1; }
+    [ ! -f "$root/alpha/workspace.lock" ] \
+        || { echo "workspace.lock wrongly written in member dir"; return 1; }
+}
+
+# ---- Test 4: outside a workspace errors cleanly (non-zero) ----
+test_lock_outside_workspace() {
+    local root="$tmpdir/t4"
+    mkdir -p "$root"
+    local output
+    if output="$( cd "$root" && "$BINARY" lock 2>&1 )"; then
+        echo "expected non-zero exit outside a workspace, got: $output"
+        return 1
+    fi
+    [ ! -f "$root/workspace.lock" ] \
+        || { echo "workspace.lock should not have been written"; return 1; }
+    return 0
+}
+
+run_test "lock writes workspace.lock with banner + entries" test_lock_writes_file
+run_test "lock is idempotent across re-runs" test_lock_idempotent
+run_test "lock from a member dir writes at workspace root" test_lock_from_member_dir
+run_test "lock outside a workspace errors cleanly" test_lock_outside_workspace
+
+echo ""
+echo "lock tests: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/compiler/tests/e2e/test_lock.sh
+++ b/compiler/tests/e2e/test_lock.sh
@@ -104,6 +104,8 @@ test_lock_outside_workspace() {
         echo "expected non-zero exit outside a workspace, got: $output"
         return 1
     fi
+    echo "$output" | grep -qi "workspace" \
+        || { echo "expected an error message mentioning the workspace, got: $output"; return 1; }
     [ ! -f "$root/workspace.lock" ] \
         || { echo "workspace.lock should not have been written"; return 1; }
     return 0


### PR DESCRIPTION
## Summary
- Add `handle_lock_command(args) -> int [io]` in `cli_commands.sfn`: discovers the workspace root (walking up for `workspace.toml`), resolves the member graph via `resolve_workspace_lock_entries` (#1069), serializes with the `# workspace.lock` banner via `workspace_lock_write` (#1068), and writes `<root>/workspace.lock`.
- Wire `sfn lock` dispatch + `is_lock` flag in `cli_main.sfn`, export the handler, and list it in `_usage()`.
- Explicit-only regeneration trigger (not on `sfn build`) to keep the self-host path predictable; deterministic output → idempotent re-runs; clean non-zero error outside a workspace.

Closes #1070

## Acceptance Criteria
- [x] `sfn lock` in a workspace writes `workspace.lock` with `# workspace.lock` banner + one `[packages]` entry per member; outside a workspace it errors cleanly (non-zero, message).
- [x] Re-running `sfn lock` is idempotent (stable output).
- [x] e2e test invokes `sfn lock` on a fixture workspace and asserts the file content.
- [x] `make compile` passes (self-host holds).
- [x] `make check` — full `.sfn` suite + e2e-sh green deterministically (see Verification note).
- [x] `sfn fmt --check` clean on touched files.

## Verification
```bash
# self-host
ulimit -v 8388608 && make compile        # pass

# new e2e test
bash compiler/tests/e2e/test_lock.sh build/native/sailfin
#   lock writes workspace.lock with banner + entries .... PASS
#   lock is idempotent across re-runs ..................... PASS
#   lock from a member dir writes at workspace root ....... PASS
#   lock outside a workspace errors cleanly .............. PASS

# full suite (deterministic re-run of the identical first-pass binary)
ulimit -v 8388608 && build/native/sailfin test compiler/tests/unit compiler/tests/integration compiler/tests/e2e capsules
#   unit: 131/131   integration: 31/31   e2e: 5/5   capsules: 34/34
# e2e-sh: 109/109 passed
```

> Note: one `make check` run hit a flaky `Error 139` (SIGSEGV) in the **parallel** `.sfn` test runner under the 8 GB memory cap, with **zero** per-test FAIL lines. A deterministic re-run of the identical suite + first-pass binary is 100% green. The change is purely additive (new CLI command + dispatch), so this is environmental, not a regression.

## Files Changed
- `compiler/src/cli_commands.sfn` — new `handle_lock_command` + imports
- `compiler/src/cli_main.sfn` — `is_lock` flag, dispatch, export, usage
- `compiler/tests/e2e/test_lock.sh` — new fixture-workspace e2e test

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FXx2EEophWYGdmLxtgjyku)_