### PR TITLE
feat(parser): parse routine blocks and parallel/serve constructs

### DIFF
--- a/compiler/src/parser/expressions.sfn
+++ b/compiler/src/parser/expressions.sfn
@@ -450,6 +450,52 @@ fn parse_prefix_expression(state: ExpressionTokens) -> ExpressionParseResult {
                 return channel_result;
             }
         }
+        // `parallel [t1, t2, ...]` fans tasks out (M4.0, issue #1081).
+        // Commit to the construct the moment `parallel` is immediately
+        // followed by `[`; a bare `parallel` (or `parallel.foo`) is an
+        // ordinary identifier and falls through to the primary path. Once
+        // committed, a malformed task list is a hard parse failure rather
+        // than a silent re-read as an identifier indexed by an array
+        // literal. The task list reuses the array-literal grammar, so each
+        // element is a full expression (typically a `spawn`).
+        if identifier_matches(token, "parallel") {
+            let after_parallel = expression_tokens_advance(state);
+            let mut parallel_followed_by_bracket: boolean = false;
+            if !expression_tokens_is_at_end(after_parallel) {
+                if symbol_matches(expression_tokens_peek(after_parallel), "[") {
+                    parallel_followed_by_bracket = true;
+                }
+            }
+            if parallel_followed_by_bracket {
+                let parallel_result = parse_parallel_expression(state);
+                if parallel_result.success {
+                    return parse_postfix_chain(parallel_result.state, parallel_result.expression);
+                }
+                return parallel_result;
+            }
+        }
+        // `serve(handler, port?)` runs the accept loop (M4.0, issue #1081).
+        // Same soft-keyword commit rule as `channel`: commit on the `(`
+        // that immediately follows `serve`. `handler` is required by the
+        // AST shape, so a zero-argument `serve()` is a hard parse failure;
+        // any extra argument beyond `handler`/`port` is a typecheck-layer
+        // arity concern (deferred — this issue is parse-only).
+        if identifier_matches(token, "serve") {
+            let after_serve = expression_tokens_advance(state);
+            let mut serve_followed_by_paren: boolean = false;
+            if !expression_tokens_is_at_end(after_serve) {
+                if symbol_matches(expression_tokens_peek(after_serve), "(") {
+                    serve_followed_by_paren = true;
+                }
+            }
+            if serve_followed_by_paren {
+                let serve_result = parse_serve_expression(state);
+                if serve_result.success {
+                    return parse_postfix_chain(serve_result.state, serve_result.expression);
+                }
+                return serve_result;
+            }
+        }
     }
 
     let primary_result = parse_primary_expression(state);
@@ -737,6 +783,76 @@ fn parse_channel_expression(state: ExpressionTokens) -> ExpressionParseResult {
             element_type: null,
             capacity: capacity,
             span: source_span_from_tokens([channel_token])
+        },
+        success: true
+    };
+}
+
+// ============================================================================
+// Parallel Construct
+// ============================================================================
+// Parse `parallel [t1, t2, ...]` with `state` positioned at the `parallel`
+// identifier token. Returns failure (leaving `state` untouched) when the
+// next token is not `[` (a bare `parallel` identifier) or when the task
+// list is malformed; the caller commits to the construct the moment `[`
+// follows. The bracketed task list reuses the array-literal grammar, so the
+// `tasks` are full expressions (typically `spawn` calls). An empty list is
+// accepted at parse time — task-count rules are a typecheck-layer concern
+// (deferred — issue #1081 is parse-only).
+fn parse_parallel_expression(state: ExpressionTokens) -> ExpressionParseResult {
+    let parallel_token = expression_tokens_peek(state);
+    let after_parallel = expression_tokens_advance(state);
+    if expression_tokens_is_at_end(after_parallel) {
+        return expression_parse_failure(state);
+    }
+    let next = expression_tokens_peek(after_parallel);
+    if !symbol_matches(next, "[") { return expression_parse_failure(state); }
+    let array_result = parse_array_literal(expression_tokens_advance(after_parallel));
+    if !array_result.success { return expression_parse_failure(state); }
+    return ExpressionParseResult {
+        state: array_result.state,
+        expression: Expression.Parallel {
+            tasks: array_result.elements,
+            span: source_span_from_tokens([parallel_token])
+        },
+        success: true
+    };
+}
+
+// ============================================================================
+// Serve Construct
+// ============================================================================
+// Parse `serve(handler, port?)` with `state` positioned at the `serve`
+// identifier token. Returns failure (leaving `state` untouched) when the
+// next token is not `(` (a bare `serve` identifier) or when the argument
+// list is malformed; the caller commits to the construct the moment `(`
+// follows. `handler` is the first argument (required by the AST shape, so
+// a zero-argument `serve()` fails the parse hard); `port` is bound only
+// from a second argument. Extra arguments are dropped and are a
+// typecheck-layer arity concern (deferred — issue #1081 is parse-only).
+fn parse_serve_expression(state: ExpressionTokens) -> ExpressionParseResult {
+    let serve_token = expression_tokens_peek(state);
+    let after_serve = expression_tokens_advance(state);
+    if expression_tokens_is_at_end(after_serve) {
+        return expression_parse_failure(state);
+    }
+    let next = expression_tokens_peek(after_serve);
+    if !symbol_matches(next, "(") { return expression_parse_failure(state); }
+    let args_result = parse_call_arguments(after_serve);
+    if !args_result.success { return expression_parse_failure(state); }
+    if args_result.arguments.length == 0 {
+        return expression_parse_failure(state);
+    }
+    let mut port: Expression? = null;
+    if args_result.arguments.length >= 2 {
+        port = args_result.arguments[1];
+    }
+    return ExpressionParseResult {
+        state: args_result.state,
+        expression: Expression.Serve {
+            handler: args_result.arguments[0],
+            port: port,
+            span: source_span_from_tokens([serve_token])
         },
         success: true
     };

--- a/compiler/src/parser/statements.sfn
+++ b/compiler/src/parser/statements.sfn
@@ -497,9 +497,13 @@ fn parse_loop_statement(parser: Parser, decorators: Decorator[]) -> BlockStateme
 // Shaped like `parse_loop_statement` since the v0 surface is a bare block
 // scope that yields no value. The caller (`parse_block_statement`) has
 // already confirmed `routine` is immediately followed by `{`, so the soft
-// keyword has committed; an empty body is still rejected (matching `loop`)
-// rather than silently producing an empty routine. Nested routine bodies
-// recurse through `parse_block`.
+// keyword has committed. The `tokens.length == 0` guard below mirrors the
+// one in `parse_loop_statement`: it rejects only a *missing* block (no `{`,
+// where `parse_block` returns empty tokens) and is defensive here since the
+// dispatch already guarantees the `{`. A present-but-empty `routine {}`
+// has non-empty tokens (`{`, `}`) and parses to a `RoutineStatement` with
+// an empty body, matching `loop {}`. Nested routine bodies recurse through
+// `parse_block`.
 fn parse_routine_statement(parser: Parser, decorators: Decorator[]) -> BlockStatementParseResult {
     let original = parser;
     let mut current = skip_trivia(parser);

--- a/compiler/src/parser/statements.sfn
+++ b/compiler/src/parser/statements.sfn
@@ -239,6 +239,22 @@ fn parse_block_statement(parser: Parser) -> BlockStatementParseResult {
     if identifier_matches(token, "loop") {
         return parse_loop_statement(after_decorators, decorators);
     }
+    // `routine { ... }` is a structured-concurrency block scope (M4.0,
+    // issue #1081). `routine` is a soft keyword (lexes as `Identifier`;
+    // Sailfin has no keyword tokens), so commit to the statement only when
+    // it is immediately followed by `{`. A bare `routine` used as an
+    // ordinary identifier (`routine.start()`, `let x = routine;`) must fall
+    // through to the expression-statement path, so the lookahead is done
+    // here rather than inside `parse_routine_statement` (which, unlike the
+    // dispatch arms above, cannot fall through on its own). Nested routine
+    // bodies recurse naturally: `parse_block` re-enters this dispatch for
+    // every statement inside the body.
+    if identifier_matches(token, "routine") {
+        let after_routine = skip_trivia(parser_advance_raw(after_decorators));
+        if symbol_matches(parser_peek_raw(after_routine), "{") {
+            return parse_routine_statement(after_decorators, decorators);
+        }
+    }
     if identifier_matches(token, "break") {
         if decorators.length > 0 {
             return BlockStatementParseResult {
@@ -466,6 +482,53 @@ fn parse_loop_statement(parser: Parser, decorators: Decorator[]) -> BlockStateme
     }
 
     let statement = Statement.LoopStatement {
+        body: body_result.block,
+        decorators: decorators
+    };
+
+    return BlockStatementParseResult {
+        parser: current,
+        statement: statement,
+        success: true
+    };
+}
+
+// Parse `routine { ... }` into a `RoutineStatement` (M4.0, issue #1081).
+// Shaped like `parse_loop_statement` since the v0 surface is a bare block
+// scope that yields no value. The caller (`parse_block_statement`) has
+// already confirmed `routine` is immediately followed by `{`, so the soft
+// keyword has committed; an empty body is still rejected (matching `loop`)
+// rather than silently producing an empty routine. Nested routine bodies
+// recurse through `parse_block`.
+fn parse_routine_statement(parser: Parser, decorators: Decorator[]) -> BlockStatementParseResult {
+    let original = parser;
+    let mut current = skip_trivia(parser);
+    if !identifier_matches(parser_peek_raw(current), "routine") {
+        return BlockStatementParseResult {
+            parser: original,
+            statement: null,
+            success: false
+        };
+    }
+    current = consume_keyword(current, "routine");
+
+    let body_result = parse_block(current);
+    if body_result.block.tokens.length == 0 {
+        return BlockStatementParseResult {
+            parser: original,
+            statement: null,
+            success: false
+        };
+    }
+    current = body_result.parser;
+
+    current = skip_trivia(current);
+    let terminator = parser_peek_raw(current);
+    if symbol_matches(terminator, ";") {
+        current = parser_advance_raw(current);
+    }
+
+    let statement = Statement.RoutineStatement {
         body: body_result.block,
         decorators: decorators
     };

--- a/compiler/tests/unit/parser_concurrency_test.sfn
+++ b/compiler/tests/unit/parser_concurrency_test.sfn
@@ -12,7 +12,7 @@
 // The `let` initializer is inspected at top level, matching the
 // convention in `parser_iife_postfix_test.sfn` (the block-scoped `let`
 // initializer path is opaque, tracked separately).
-import { Block, Expression, Program } from "../../src/ast";
+import { Block, Expression } from "../../src/ast";
 import { parse_program } from "../../src/parser/mod";
 
 // Initializer of the first top-level `let` in `source`.
@@ -27,19 +27,28 @@ fn first_let_initializer(source: string) -> Expression ![io] {
 
 // Body block of the first top-level function named `name` in `source`.
 // `routine { ... }` is a block-level statement, so its coverage inspects a
-// function body rather than a `let` initializer.
+// function body rather than a `let` initializer. Asserts the function was
+// found so a lookup miss fails here with a clear signal rather than
+// surfacing as a confusing empty-body assertion downstream.
 fn function_body(source: string, name: string) -> Block ![io] {
     let program = parse_program(source);
     let mut index: int = 0;
+    let mut found: boolean = false;
+    let mut body: Block = Block { tokens: [], text: "", statements: [] };
     loop {
         if index >= program.statements.length { break; }
         let stmt = program.statements[index];
         if stmt.variant == "FunctionDeclaration" {
-            if stmt.signature.name == name { return stmt.body; }
+            if stmt.signature.name == name {
+                body = stmt.body;
+                found = true;
+                break;
+            }
         }
         index += 1;
     }
-    return Block { tokens: [], text: "", statements: [] };
+    assert found;
+    return body;
 }
 
 // -------------------------------------------------------------------

--- a/compiler/tests/unit/parser_concurrency_test.sfn
+++ b/compiler/tests/unit/parser_concurrency_test.sfn
@@ -12,7 +12,7 @@
 // The `let` initializer is inspected at top level, matching the
 // convention in `parser_iife_postfix_test.sfn` (the block-scoped `let`
 // initializer path is opaque, tracked separately).
-import { Expression } from "../../src/ast";
+import { Block, Expression, Program } from "../../src/ast";
 import { parse_program } from "../../src/parser/mod";
 
 // Initializer of the first top-level `let` in `source`.
@@ -23,6 +23,23 @@ fn first_let_initializer(source: string) -> Expression ![io] {
     let init = stmt.initializer;
     assert init != null;
     return init;
+}
+
+// Body block of the first top-level function named `name` in `source`.
+// `routine { ... }` is a block-level statement, so its coverage inspects a
+// function body rather than a `let` initializer.
+fn function_body(source: string, name: string) -> Block ![io] {
+    let program = parse_program(source);
+    let mut index: int = 0;
+    loop {
+        if index >= program.statements.length { break; }
+        let stmt = program.statements[index];
+        if stmt.variant == "FunctionDeclaration" {
+            if stmt.signature.name == name { return stmt.body; }
+        }
+        index += 1;
+    }
+    return Block { tokens: [], text: "", statements: [] };
 }
 
 // -------------------------------------------------------------------
@@ -112,4 +129,87 @@ test "concurrency: await of a parenthesized binary keeps the binary operand" ![i
     let expr = first_let_initializer("let r = await (a + b);");
     assert expr.variant == "Await";
     assert expr.operand.variant == "Binary";
+}
+
+// -------------------------------------------------------------------
+// `parallel [t1, t2, ...]` parses to a `Parallel` node carrying the task
+// expressions in order. The bracketed list reuses the array-literal
+// grammar, so each task is a full expression (typically a `spawn`).
+// -------------------------------------------------------------------
+test "concurrency: parallel of spawns parses to Parallel of Spawns" ![io] {
+    let expr = first_let_initializer("let r = parallel [spawn a(), spawn b()];");
+    assert expr.variant == "Parallel";
+    assert expr.tasks.length == 2;
+    assert expr.tasks[0].variant == "Spawn";
+    assert expr.tasks[1].variant == "Spawn";
+}
+
+// An empty task list still parses to a `Parallel` — task-count rules are a
+// typecheck-layer concern (deferred).
+test "concurrency: parallel with empty task list parses to Parallel" ![io] {
+    let expr = first_let_initializer("let r = parallel [];");
+    assert expr.variant == "Parallel";
+    assert expr.tasks.length == 0;
+}
+
+// `parallel` not followed by `[` is an ordinary identifier — the construct
+// path must not swallow it.
+test "concurrency: bare parallel identifier is not a Parallel node" ![io] {
+    let expr = first_let_initializer("let p = parallel;");
+    assert expr.variant == "Identifier";
+}
+
+// -------------------------------------------------------------------
+// `serve(handler, port)` parses to a `Serve` node: `handler` is the first
+// argument, `port` the optional second.
+// -------------------------------------------------------------------
+test "concurrency: serve with handler and port parses to Serve" ![io] {
+    let expr = first_let_initializer("let s = serve(handler, 8080);");
+    assert expr.variant == "Serve";
+    assert expr.handler.variant == "Identifier";
+    assert expr.port != null;
+    assert expr.port.variant == "NumberLiteral";
+}
+
+// `serve(handler)` with no port parses to a `Serve` whose port is null
+// (the configured default deferred to lowering).
+test "concurrency: serve with no port parses to Serve" ![io] {
+    let expr = first_let_initializer("let s = serve(handler);");
+    assert expr.variant == "Serve";
+    assert expr.handler.variant == "Identifier";
+    assert expr.port == null;
+}
+
+// `serve` not followed by `(` is an ordinary identifier.
+test "concurrency: bare serve identifier is not a Serve node" ![io] {
+    let expr = first_let_initializer("let s = serve;");
+    assert expr.variant == "Identifier";
+}
+
+// -------------------------------------------------------------------
+// `routine { ... }` parses to a `RoutineStatement` block-level statement.
+// -------------------------------------------------------------------
+test "concurrency: routine block parses to RoutineStatement" ![io] {
+    let body = function_body("fn run() { routine { let x = 1; } }", "run");
+    assert body.statements.length == 1;
+    assert body.statements[0].variant == "RoutineStatement";
+}
+
+// Nested routine bodies recurse: the inner `routine { ... }` surfaces as a
+// `RoutineStatement` inside the outer routine's body.
+test "concurrency: nested routine bodies recurse" ![io] {
+    let body = function_body("fn run() { routine { routine { let x = 1; } } }", "run");
+    assert body.statements.length == 1;
+    let outer = body.statements[0];
+    assert outer.variant == "RoutineStatement";
+    assert outer.body.statements.length == 1;
+    assert outer.body.statements[0].variant == "RoutineStatement";
+}
+
+// A bare `routine` used as an identifier (no following `{`) falls through
+// to the expression-statement path and is NOT a `RoutineStatement`.
+test "concurrency: bare routine identifier is not a RoutineStatement" ![io] {
+    let body = function_body("fn run() { let routine = 1; }", "run");
+    assert body.statements.length == 1;
+    assert body.statements[0].variant == "VariableDeclaration";
 }


### PR DESCRIPTION
## Summary
- Parse `routine { ... }` block-level statements (`statements.sfn`), shaped like `LoopStatement`; nested routine bodies recurse through `parse_block`.
- Parse `parallel [t1, t2, ...]` value constructs (`expressions.sfn`), reusing the array-literal grammar for the task list.
- Parse `serve(handler, port?)` value constructs; `handler` required, `port` optional.

All three follow the spawn/await/channel soft-keyword precedent from #1080: they lex as `Identifier`, commit to the construct on the unambiguous opener (`{` / `[` / `(`), and otherwise fall through to an ordinary identifier. Builds on the AST nodes added in #1104. Parse-only — typecheck, effect-check, and lowering land in follow-up issues.

Closes #1081

## Acceptance Criteria
- [x] `routine { ... }` parses; nested routine bodies recurse
- [x] `parallel [..]` and `serve(handler, port)` parse
- [x] unit tests
- [x] routine pulled in **no** block-scope/return-type interactions — clean `LoopStatement`-shaped block, no split needed
- [x] `make compile` passes (self-hosts)
- [x] `make test-unit` passes (131/131)
- [x] `sfn fmt --check` clean on every touched `.sfn`

## Verification
```bash
ulimit -v 8388608 && make compile        # status: pass (self-hosts)
ulimit -v 8388608 && make test-unit       # unit: 131/131 passed, 0 failed
# parser_concurrency_test.sfn in isolation: all 18 tests passed (9 prior + 9 new)
sfn fmt --check compiler/src/parser/{expressions,statements}.sfn \
                compiler/tests/unit/parser_concurrency_test.sfn   # clean
```

Note: the first `make test-unit` run hit a transient Error 139 (SIGSEGV) in `struct_field_pointer_assignment_test.sfn` (unrelated to parser changes — it passes in isolation, exit 0). A clean re-run gave 131/131.

## Files Changed
- `compiler/src/parser/expressions.sfn` — `parallel`/`serve` dispatch + `parse_parallel_expression`/`parse_serve_expression`
- `compiler/src/parser/statements.sfn` — `routine` dispatch + `parse_routine_statement`
- `compiler/tests/unit/parser_concurrency_test.sfn` — 9 new parse tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JcVLmq8h4CooJ7GYfa27ky)_