### PR TITLE
feat(make): wire JSON=1 through check-fast to sfn check --json

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -594,15 +594,25 @@ check-fast-impl:
 	@echo "[check-fast] running sfn check on compiler/src/ runtime/"
 	@# JSON=1 / SAILFIN_AGENT_REPORT=1 gate (#1122): run `sfn check --json` and
 	@# tee the `sailfin-check/1` envelope to build/agent-check-fast.json for the
-	@# report composer (issue E). PIPESTATUS preserves the check exit-code
+	@# report composer (issue E). PIPESTATUS[0] preserves the check exit-code
 	@# contract (0 clean / 1 diagnostics / 2 setup) across the tee, so a
 	@# diagnostics run still fails the target instead of being masked by tee.
-	@# Default (no JSON=1) runs stay human-only and write no file.
+	@# Because producing the envelope IS the point of this mode, a failure to
+	@# create build/ or write the file (read-only FS, disk full) is a setup
+	@# error (exit 2) rather than a silent OK — check's own exit code still wins
+	@# when it is non-zero. Default (no JSON=1) runs stay human-only, no file.
 	@if [ "$${SAILFIN_AGENT_REPORT:-}" = "1" ]; then \
-		mkdir -p build; \
+		if ! mkdir -p build; then \
+			echo "[check-fast] cannot create build/ for JSON envelope" >&2; \
+			exit 2; \
+		fi; \
 		$(NATIVE_BIN) check --json compiler/src/ runtime/ | tee build/agent-check-fast.json; \
-		rc=$${PIPESTATUS[0]}; \
-		if [ "$$rc" -ne 0 ]; then exit "$$rc"; fi; \
+		pipe_rc=("$${PIPESTATUS[@]}"); \
+		if [ "$${pipe_rc[0]}" -ne 0 ]; then exit "$${pipe_rc[0]}"; fi; \
+		if [ "$${pipe_rc[1]}" -ne 0 ]; then \
+			echo "[check-fast] failed to write build/agent-check-fast.json" >&2; \
+			exit 2; \
+		fi; \
 	else \
 		$(NATIVE_BIN) check compiler/src/ runtime/; \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -592,7 +592,20 @@ check-fast-impl:
 		exit 1; \
 	fi
 	@echo "[check-fast] running sfn check on compiler/src/ runtime/"
-	@$(NATIVE_BIN) check compiler/src/ runtime/
+	@# JSON=1 / SAILFIN_AGENT_REPORT=1 gate (#1122): run `sfn check --json` and
+	@# tee the `sailfin-check/1` envelope to build/agent-check-fast.json for the
+	@# report composer (issue E). PIPESTATUS preserves the check exit-code
+	@# contract (0 clean / 1 diagnostics / 2 setup) across the tee, so a
+	@# diagnostics run still fails the target instead of being masked by tee.
+	@# Default (no JSON=1) runs stay human-only and write no file.
+	@if [ "$${SAILFIN_AGENT_REPORT:-}" = "1" ]; then \
+		mkdir -p build; \
+		$(NATIVE_BIN) check --json compiler/src/ runtime/ | tee build/agent-check-fast.json; \
+		rc=$${PIPESTATUS[0]}; \
+		if [ "$$rc" -ne 0 ]; then exit "$$rc"; fi; \
+	else \
+		$(NATIVE_BIN) check compiler/src/ runtime/; \
+	fi
 	@echo "[check-fast] OK"
 
 # Pre-release determinism gate. Runs the emit harness at parallel load to


### PR DESCRIPTION
## Summary
- Under `JSON=1` (`SAILFIN_AGENT_REPORT=1`), `check-fast-impl` now runs `sfn check --json compiler/src/ runtime/` and tees the `sailfin-check/1` envelope to `build/agent-check-fast.json` for the report composer (issue E).
- The exit-code contract (`0` clean / `1` diagnostics / `2` setup) is preserved across the tee via `PIPESTATUS[0]`, so a diagnostics run still fails the target instead of being masked by `tee`.
- Human banners are unchanged; the default (no `JSON=1`) run stays human-only and writes no file.

Closes #1122

## Acceptance Criteria
- [x] `JSON=1 make check-fast` writes `build/agent-check-fast.json` with `schema_version:"sailfin-check/1"`.
- [x] Human banners and exit codes unchanged from non-JSON; default run writes no file.
- [x] `make compile && make check` green.

## Verification
```bash
# AC1 — gated run writes the envelope
$ JSON=1 make check-fast            # exit 0; [check-fast] running… / [check-fast] OK
$ jq -e '.schema_version=="sailfin-check/1"' build/agent-check-fast.json
true
$ jq -c '{schema_version,exit_code,summary}' build/agent-check-fast.json
{"schema_version":"sailfin-check/1","exit_code":0,"summary":{"files_checked":176,"errors":0,"warnings":0,"duration_ms":0}}

# AC2 — default run: banners present, no file written
$ make check-fast                   # [check-fast] running… / [check-fast] OK
$ test -f build/agent-check-fast.json && echo written || echo "no file"
no file

# exit-code contract: tee does not mask non-zero check exit (PIPESTATUS)
$ (exit 1) | tee /dev/null; echo ${PIPESTATUS[0]}   # -> 1
$ (exit 2) | tee /dev/null; echo ${PIPESTATUS[0]}   # -> 2

# AC3 — full self-host validation
$ make compile                      # status: pass
$ make check                        # stage2 == stage3 fixed point ✓; status: pass
```

## Files Changed
- `Makefile` — `check-fast-impl` (gated `--json` + tee + PIPESTATUS exit propagation)

## Notes
- Scope is Makefile-only; no `compiler/src` or `sfn check` schema changes (the `sailfin-check/1` envelope already ships).
- Observation (out of scope, possible follow-up): `sfn check --json` over the full `compiler/src/ runtime/` tree (176 files) needs >8GB virtual memory and SIGSEGVs under the local `ulimit -v 8388608` dev cap, whereas the streaming non-JSON path fits. The `check-fast` target imposes no ulimit (CI runs it uncapped, where it passes); verification here was run with a 16GB cap. Worth a separate look at the `--json` renderer's buffering footprint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011WRpdsZoDaKLVS6jnaxCYG)_