### PR TITLE
feat(make): wire JSON=1 through rebuild to sfn build --json

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -785,7 +785,11 @@ rebuild-impl:
 	@# and tee that to build/native/.build-report.json for the report
 	@# composer (#1056 Phase 2). Human progress stays on stderr (still
 	@# inherited to the terminal); pipefail keeps the seed's real exit
-	@# code across the tee. Default (gate off) keeps the original
+	@# code across the tee. On failure the seed can still emit non-JSON
+	@# to stdout in `--json` mode (e.g. cli_main.sfn's "failed to compile
+	@# LLVM ..." is not json-gated), so the bail block below removes the
+	@# half-written report — the contract for consumers is "file exists =>
+	@# valid BuildReport". Default (gate off) keeps the original
 	@# `2>&1 | cat` form byte-for-byte.
 	@seed=$$(cat build/.seed-resolved); \
 	echo "[rebuild] running sfn build -p compiler (seed=$$seed)..."; \
@@ -802,6 +806,7 @@ rebuild-impl:
 		echo "[rebuild][error] sfn build failed (exit=$$build_rc) or did not produce build/sailfin/program" >&2; \
 		echo "[rebuild][error] expected the alpha.6+ seed's subprocess-stage path to keep the cold build under the 8 GB ulimit" >&2; \
 		echo "[rebuild][error] if this is a regression, rerun with BUILD_ARGS='--cache-trace' to bisect, or fall back to the prior seed via .seed-version" >&2; \
+		if [ "$${SAILFIN_AGENT_REPORT:-}" = "1" ]; then rm -f build/native/.build-report.json; fi; \
 		exit 1; \
 	fi
 	@mkdir -p build/native

--- a/Makefile
+++ b/Makefile
@@ -780,11 +780,24 @@ rebuild-impl:
 	@# recipe line. The `&&` chain ensures every diagnostic
 	@# message reaches the user before we exit.
 	@rm -f build/sailfin/program build/sailfin/program.ll
+	@# #1120: under the JSON=1 / SAILFIN_AGENT_REPORT=1 gate, append
+	@# `--json` so the seed emits its single-line BuildReport on stdout,
+	@# and tee that to build/native/.build-report.json for the report
+	@# composer (#1056 Phase 2). Human progress stays on stderr (still
+	@# inherited to the terminal); pipefail keeps the seed's real exit
+	@# code across the tee. Default (gate off) keeps the original
+	@# `2>&1 | cat` form byte-for-byte.
 	@seed=$$(cat build/.seed-resolved); \
 	echo "[rebuild] running sfn build -p compiler (seed=$$seed)..."; \
 	build_rc=0; \
-	{ cd $(CURDIR) && bash -c "set -o pipefail; \"$$seed\" build $(BUILD_ARGS) -p compiler 2>&1 | cat"; } \
-		|| build_rc=$$?; \
+	if [ "$${SAILFIN_AGENT_REPORT:-}" = "1" ]; then \
+		mkdir -p build/native; \
+		{ cd $(CURDIR) && bash -c "set -o pipefail; \"$$seed\" build $(BUILD_ARGS) --json -p compiler | tee build/native/.build-report.json"; } \
+			|| build_rc=$$?; \
+	else \
+		{ cd $(CURDIR) && bash -c "set -o pipefail; \"$$seed\" build $(BUILD_ARGS) -p compiler 2>&1 | cat"; } \
+			|| build_rc=$$?; \
+	fi; \
 	if [ "$$build_rc" -ne 0 ] || [ ! -f build/sailfin/program ]; then \
 		echo "[rebuild][error] sfn build failed (exit=$$build_rc) or did not produce build/sailfin/program" >&2; \
 		echo "[rebuild][error] expected the alpha.6+ seed's subprocess-stage path to keep the cold build under the 8 GB ulimit" >&2; \


### PR DESCRIPTION
## Summary
- Under the `JSON=1` / `SAILFIN_AGENT_REPORT=1` gate, `rebuild-impl` now runs the seed's `sfn build -p compiler` with `--json` and tees the single-line BuildReport to `build/native/.build-report.json` for the report composer (#1056 Phase 2).
- Human progress stays on stderr (still inherited to the terminal); the `set -o pipefail` exit-code capture is preserved across the `tee`.
- Default (gate off) runs keep the original `2>&1 | cat` invocation byte-for-byte and write no report file.

Closes #1120

## Acceptance Criteria
- [x] `JSON=1 make rebuild` produces `build/native/.build-report.json` parsing as a BuildReport with `schema_version "1"` and `command:"build"`.
- [x] The human `[rebuild]` banner and the `build/sailfin/program` existence check still work; exit code on a forced build failure is still non-zero (pipefail+tee preserves the seed's non-zero exit).
- [x] Default `make rebuild` writes no `.build-report.json` and is unchanged.
- [x] `make compile && make check` green.

## Verification
```bash
# AC1 — gated run emits a parseable BuildReport
$ JSON=1 make rebuild && jq -e '.schema_version=="1" and .command=="build"' build/native/.build-report.json
true   # AC1 PASS
# report head: {"schema_version":"1","command":"build","input":"compiler/src/main.sfn",
#               "out":"build/sailfin/program","kind":"binary","exit_code":0,...}

# AC3 — default mode writes no file, banner intact
$ rm -f build/native/.build-report.json && make rebuild   # exit 0
AC3 PASS: no .build-report.json written by default mode
human banner present: 1

# AC2 — pipefail+tee preserves the real exit code across the tee
$ bash -c 'set -o pipefail; false | tee /tmp/x >/dev/null'; echo $?   # 1
$ bash -c 'set -o pipefail; true  | tee /tmp/x >/dev/null'; echo $?   # 0

# AC4 — full self-host + suite
$ make check   # stage2 == stage3 fixed point ✓, status:"pass", exit 0
```

## Files Changed
- `Makefile` — `rebuild-impl`: gate-branched `sfn build` invocation (`--json` + tee to `build/native/.build-report.json` when gated; default path unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012dCPdTUTiqStzvcRwBE6fp)_