### PR TITLE
feat(emit-native): emit .sfn-asm for spawn/await/channel/parallel/serve/routine

### DIFF
--- a/compiler/src/emit_native.sfn
+++ b/compiler/src/emit_native.sfn
@@ -347,10 +347,18 @@ fn emit_statement_control_flow(state: NativeState, statement: Statement) -> Nati
         // the transparent always-true `If`/`EndIf` scope that `BlockStatement`
         // emits (`.if 1 > 0`), so no nursery runtime is implied yet and the
         // existing scope lowering applies unchanged; the real lowering lands in
-        // a follow-up (#1085). Decorators are not emitted — there is no
-        // routine-decorator semantics in v0, and a `.decorator` directive
-        // inside a function body is a parse error in the native IR.
-        let mut current = state_emit_line(state, ".routine");
+        // a follow-up (#1085). Decorators on a `routine` block are not
+        // supported in v0: native IR has no statement-level decorator slot
+        // inside a function body (a `.decorator` directive there is a parse
+        // error), and routine-decorator semantics are undefined until that
+        // runtime lands. Fail closed rather than silently dropping the
+        // decorator (llms.txt: no parsed-but-unenforced surface) — the parser
+        // does attach decorators to the node (`parser/statements.sfn:537`).
+        let mut current = state;
+        if statement.decorators.length > 0 {
+            current = state_add_diagnostic(current, "native backend: decorators on `routine` blocks are not yet supported");
+        }
+        current = state_emit_line(current, ".routine");
         current = state_push_indent(current);
         current = emit_block(current, statement.body);
         current = state_pop_indent(current);

--- a/compiler/src/emit_native.sfn
+++ b/compiler/src/emit_native.sfn
@@ -339,6 +339,23 @@ fn emit_statement_control_flow(state: NativeState, statement: Statement) -> Nati
     if statement.variant == "ExpressionStatement" {
         return emit_expression_statement(state, statement);
     }
+    if statement.variant == "RoutineStatement" {
+        // `routine { ... }` — structured-concurrency block scope (M4.0, epic
+        // #965; docs/runtime_architecture.md §2.6.7). The v0 surface is a bare
+        // block scope that yields no value (ast.sfn:355), so emit an explicit
+        // `.routine`/`.endroutine` scope. The native IR parser maps these to
+        // the transparent always-true `If`/`EndIf` scope that `BlockStatement`
+        // emits (`.if 1 > 0`), so no nursery runtime is implied yet and the
+        // existing scope lowering applies unchanged; the real lowering lands in
+        // a follow-up (#1085). Decorators are not emitted — there is no
+        // routine-decorator semantics in v0, and a `.decorator` directive
+        // inside a function body is a parse error in the native IR.
+        let mut current = state_emit_line(state, ".routine");
+        current = state_push_indent(current);
+        current = emit_block(current, statement.body);
+        current = state_pop_indent(current);
+        return state_emit_line(current, ".endroutine");
+    }
     let message = "native backend: unsupported statement `" + statement.variant
         + "`";
     return state_add_diagnostic(state, message);

--- a/compiler/src/emit_native_format.sfn
+++ b/compiler/src/emit_native_format.sfn
@@ -158,17 +158,61 @@ fn format_expression(expression: Expression) -> string {
         return "await " + _format_binary_operand(expression.operand);
     }
     if expression.variant == "Spawn" {
-        // `spawn`/`channel` (issues #1079/#1080) parse but have no
-        // lowering yet. Emit an explicit unlowered-construct marker so
-        // `lower_expression` fails the build closed with a `[fatal]`
-        // rather than letting the generic `<variant>` placeholder
-        // false-green an unenforced concurrency surface into the IR
-        // (llms.txt: no parsed-but-unenforced surface). The dedicated
-        // lowering replaces these arms in a follow-up (epic #965).
-        return "<concurrency_unlowered spawn>";
+        // `spawn <operand>` — enqueue a task, yields a future
+        // (docs/runtime_architecture.md §2.6.2). `kind` is the monomorphized
+        // future kind the parser tagged from a lambda operand's declared
+        // return type (`parser/expressions.sfn:412`, via `spawn_future_kind`);
+        // it is "" when the kind is not statically derivable (e.g.
+        // `spawn foo()`, which needs symbol resolution — #829). Render the
+        // kind as a `spawn:<kind>` qualifier so the LLVM lowering (#1085) can
+        // select the matching `spawn_<kind>` runtime helper without
+        // re-deriving it. The lowering fails closed on this form until that
+        // follow-up lands (see the guards in
+        // `llvm/expression_lowering/native/core.sfn`).
+        if expression.kind.length > 0 {
+            return "spawn:" + expression.kind + " " + _format_binary_operand(expression.operand);
+        }
+        return "spawn " + _format_binary_operand(expression.operand);
     }
     if expression.variant == "Channel" {
-        return "<concurrency_unlowered channel>";
+        // `channel(capacity?)` — construct a channel (§2.6.4). Capacity is
+        // optional (unbuffered default). `kind` carries the monomorphized
+        // element kind when known; the `channel<T>` element-type form is
+        // deferred in the parser, so it is "" today. The lowering fails
+        // closed on this form until #1085.
+        let mut channel_capacity: string = "";
+        if expression.capacity != null {
+            channel_capacity = format_expression(expression.capacity);
+        }
+        if expression.kind.length > 0 {
+            return "channel:" + expression.kind + "(" + channel_capacity + ")";
+        }
+        return "channel(" + channel_capacity + ")";
+    }
+    if expression.variant == "Parallel" {
+        // `parallel [t1, t2, ...]` — fan out tasks, await all (§2.6.5).
+        // Render the task list with the array-literal grammar the parser
+        // consumed (`parser/expressions.sfn:834`). The lowering fails closed
+        // on this form until #1085.
+        let mut parallel_tasks: string[] = [];
+        let mut parallel_index: int = 0;
+        loop {
+            if parallel_index >= expression.tasks.length { break; }
+            parallel_tasks.push(format_expression(expression.tasks[parallel_index]));
+            parallel_index += 1;
+        }
+        return "parallel [" + join_with_separator(parallel_tasks, ", ") + "]";
+    }
+    if expression.variant == "Serve" {
+        // `serve(handler, port?)` — accept loop dispatching to the pool
+        // (§2.6.6). `port` is optional. The lowering fails closed on this
+        // form until #1085.
+        let serve_handler = format_expression(expression.handler);
+        if expression.port != null {
+            return "serve(" + serve_handler + ", " + format_expression(expression.port)
+                + ")";
+        }
+        return "serve(" + serve_handler + ")";
     }
     if expression.variant == "Lambda" { return "<lambda>"; }
     if expression.variant == "Raw" {

--- a/compiler/src/llvm/expression_lowering/native/core.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core.sfn
@@ -810,18 +810,23 @@ fn lower_expression(expression: string, bindings: ParameterBinding[], locals: Lo
         };
     }
 
-    // Unlowered concurrency frontend constructs (M4.0, epic #965). The
-    // parser builds `Spawn`/`Channel` nodes (issues #1079/#1080) but no
-    // lowering exists yet, so `emit_native_format` renders them to the
-    // `<concurrency_unlowered <kind>>` marker. Fail the build closed with
-    // a `[fatal]` — matching the sentinel scanned by
-    // `lowering_core.sfn:has_fatal_lowering_diagnostic` — rather than
-    // false-greening an unenforced concurrency surface into the IR
-    // (llms.txt: no parsed-but-unenforced surface). The dedicated
-    // lowering replaces this guard in a follow-up. `Await` is bridged to
-    // the existing async lowering upstream and never reaches here as a
-    // marker.
-    if starts_with(stripped, "<concurrency_unlowered spawn>") {
+    // Unlowered concurrency frontend constructs (M4.0, epic #965). The parser
+    // builds `Spawn`/`Channel`/`Parallel`/`Serve` nodes (issues #1079–#1081)
+    // and `emit_native_format` (#1084) renders them to real `.sfn-asm` forms
+    // — `spawn[:<kind>] <op>`, `channel[:<kind>](<cap>)`, `parallel [<tasks>]`,
+    // `serve(<handler>[, <port>])` — but no LLVM lowering exists yet. Fail the
+    // build closed with a `[fatal]` — matching the sentinel scanned by
+    // `lowering_core.sfn:has_fatal_lowering_diagnostic` — rather than letting
+    // these forms fall through to the generic, *non-fatal* unable-to-lower
+    // path (which the emit/build fatal gate ignores, false-greening an
+    // unenforced concurrency surface into the IR — llms.txt). The dedicated
+    // lowering replaces these guards in a follow-up (#1085). These prefixes
+    // are collision-safe: `spawn`/`channel`/`parallel`/`serve` are
+    // contextual keywords parsed only in expression-prefix position
+    // (`parser/expressions.sfn:403`), so no user identifier produces them.
+    // `Await` is bridged to the existing async lowering upstream and never
+    // reaches here as a marker.
+    if starts_with(stripped, "spawn ") {
         diagnostics.push("llvm lowering [fatal]: `spawn` expression is not yet lowered (concurrency frontend, epic #965)");
         return ExpressionResult {
             lines: lines,
@@ -831,8 +836,48 @@ fn lower_expression(expression: string, bindings: ParameterBinding[], locals: Lo
             string_constants: empty_constants
         };
     }
-    if starts_with(stripped, "<concurrency_unlowered channel>") {
+    if starts_with(stripped, "spawn:") {
+        diagnostics.push("llvm lowering [fatal]: `spawn` expression is not yet lowered (concurrency frontend, epic #965)");
+        return ExpressionResult {
+            lines: lines,
+            temp_index: temp_index,
+            operand: null,
+            diagnostics: diagnostics,
+            string_constants: empty_constants
+        };
+    }
+    if starts_with(stripped, "channel(") {
         diagnostics.push("llvm lowering [fatal]: `channel` expression is not yet lowered (concurrency frontend, epic #965)");
+        return ExpressionResult {
+            lines: lines,
+            temp_index: temp_index,
+            operand: null,
+            diagnostics: diagnostics,
+            string_constants: empty_constants
+        };
+    }
+    if starts_with(stripped, "channel:") {
+        diagnostics.push("llvm lowering [fatal]: `channel` expression is not yet lowered (concurrency frontend, epic #965)");
+        return ExpressionResult {
+            lines: lines,
+            temp_index: temp_index,
+            operand: null,
+            diagnostics: diagnostics,
+            string_constants: empty_constants
+        };
+    }
+    if starts_with(stripped, "parallel [") {
+        diagnostics.push("llvm lowering [fatal]: `parallel` expression is not yet lowered (concurrency frontend, epic #965)");
+        return ExpressionResult {
+            lines: lines,
+            temp_index: temp_index,
+            operand: null,
+            diagnostics: diagnostics,
+            string_constants: empty_constants
+        };
+    }
+    if starts_with(stripped, "serve(") {
+        diagnostics.push("llvm lowering [fatal]: `serve` expression is not yet lowered (concurrency frontend, epic #965)");
         return ExpressionResult {
             lines: lines,
             temp_index: temp_index,

--- a/compiler/src/native_ir_parser_instructions.sfn
+++ b/compiler/src/native_ir_parser_instructions.sfn
@@ -233,6 +233,28 @@ fn parse_instruction(line: string, span: NativeSourceSpan?, value_span: NativeSo
             value_span_consumed: false
         };
     }
+    // `routine { ... }` v0 transparent-scope shim (#1084, epic #965). The
+    // emitter writes `.routine`/`.endroutine` to keep the concurrency surface
+    // explicit in the `.sfn-asm`, but the v0 routine is a bare block scope
+    // (docs/runtime_architecture.md §2.6.7) with no nursery semantics yet. Map
+    // it to the same always-true `If`/`EndIf` scope that `BlockStatement`
+    // lowers through (`.if 1 > 0`/`.endif`), so the existing scope lowering
+    // applies unchanged and no structured-concurrency runtime is implied. The
+    // dedicated `Routine` lowering replaces this shim in a follow-up (#1085).
+    if line == ".routine" {
+        return InstructionParseResult {
+            instructions: [NativeInstruction.If { condition: "1 > 0" }],
+            span_consumed: false,
+            value_span_consumed: false
+        };
+    }
+    if line == ".endroutine" {
+        return InstructionParseResult {
+            instructions: [NativeInstruction.EndIf()],
+            span_consumed: false,
+            value_span_consumed: false
+        };
+    }
     if starts_with(line, ".for ") {
         let body = trim_text(strip_prefix(line, ".for "));
         let separator = " in ";

--- a/compiler/tests/unit/concurrency_emit_test.sfn
+++ b/compiler/tests/unit/concurrency_emit_test.sfn
@@ -9,7 +9,7 @@
 // `compiler/tests/e2e/test_sync_rejects_unimplemented_concurrency.sh` and the
 // guards in `llvm/expression_lowering/native/core.sfn`). This test therefore
 // exercises `emit_native_text_with_module_name` directly, never the full build.
-import { emit_native_text_with_module_name } from "../../src/emit_native";
+import { emit_native_text_with_module_name, emit_native_with_module_name } from "../../src/emit_native";
 import { parse_program } from "../../src/parser/mod";
 import { index_of } from "../../src/string_utils";
 
@@ -79,4 +79,23 @@ test "emit_native: routine emits an explicit scope" ![io] {
     let asm = emit_native_text_with_module_name(program, "test_concurrency");
     assert _contains(asm, ".routine");
     assert _contains(asm, ".endroutine");
+}
+
+// A decorated `routine` block is unsupported in v0 (no statement-level
+// decorator slot in the native IR). Fail closed with a diagnostic rather than
+// silently dropping the decorator the parser attached to the node.
+test "emit_native: a decorated routine fails closed with a diagnostic" ![io] {
+    let source = "fn main() ![io] { @trace\nroutine { let x: int = 1; } }";
+    let program = parse_program(source);
+    let result = emit_native_with_module_name(program, "test_concurrency");
+    let mut found: boolean = false;
+    let mut index: int = 0;
+    loop {
+        if index >= result.diagnostics.length { break; }
+        if index_of(result.diagnostics[index], "decorators on `routine`") >= 0 {
+            found = true;
+        }
+        index += 1;
+    }
+    assert found;
 }

--- a/compiler/tests/unit/concurrency_emit_test.sfn
+++ b/compiler/tests/unit/concurrency_emit_test.sfn
@@ -1,0 +1,82 @@
+// Golden-IR emission test for the concurrency frontend nodes — issue #1084,
+// epic #965 (M4). Pins the `.sfn-asm` text `emit_native_format` produces for
+// `spawn`/`await`/`channel`/`parallel`/`serve`/`routine` so a regression in
+// the emitter (or the parser nodes it consumes, issues #1079–#1082) breaks
+// here.
+//
+// Scope: emission only. The LLVM lowering of these forms is deferred to #1085
+// and currently fails closed with a `[fatal]` (see
+// `compiler/tests/e2e/test_sync_rejects_unimplemented_concurrency.sh` and the
+// guards in `llvm/expression_lowering/native/core.sfn`). This test therefore
+// exercises `emit_native_text_with_module_name` directly, never the full build.
+import { emit_native_text_with_module_name } from "../../src/emit_native";
+import { parse_program } from "../../src/parser/mod";
+import { index_of } from "../../src/string_utils";
+
+fn _contains(haystack: string, needle: string) -> boolean {
+    return index_of(haystack, needle) >= 0;
+}
+
+// `spawn` of an int-returning lambda carries the kind the parser tagged
+// (`parser/expressions.sfn:412`, via `spawn_future_kind`), rendered as the
+// `spawn:<kind>` qualifier #1085 will lower against.
+test "emit_native: spawn of an int lambda tags kind in the IR" ![io] {
+    let source = "fn main() ![io] { let f = spawn fn() -> int { return 1; }; }";
+    let program = parse_program(source);
+    let asm = emit_native_text_with_module_name(program, "test_concurrency");
+    assert _contains(asm, "spawn:int ");
+}
+
+// `spawn` of a bare named-fn call has no statically derivable kind (needs
+// symbol resolution, #829), so it renders without a qualifier and preserves
+// the operand text.
+test "emit_native: spawn of a call renders without a kind qualifier" ![io] {
+    let source = "fn main() ![io] { let g = spawn worker(); }";
+    let program = parse_program(source);
+    let asm = emit_native_text_with_module_name(program, "test_concurrency");
+    assert _contains(asm, "spawn worker()");
+}
+
+// `await <expr>` keeps the existing `await ` text form consumed by the async
+// lowering bridge (unchanged by #1084).
+test "emit_native: await renders the await prefix form" ![io] {
+    let source = "fn main() ![io] { let r = await fut; }";
+    let program = parse_program(source);
+    let asm = emit_native_text_with_module_name(program, "test_concurrency");
+    assert _contains(asm, "await fut");
+}
+
+// `channel(capacity?)` renders the constructor with its capacity argument.
+test "emit_native: channel renders the constructor with capacity" ![io] {
+    let source = "fn main() ![io] { let ch = channel(4); }";
+    let program = parse_program(source);
+    let asm = emit_native_text_with_module_name(program, "test_concurrency");
+    assert _contains(asm, "channel(4)");
+}
+
+// `parallel [tasks]` renders the task list with the array-literal grammar.
+test "emit_native: parallel renders its bracketed task list" ![io] {
+    let source = "fn main() ![io] { let p = parallel [spawn worker()]; }";
+    let program = parse_program(source);
+    let asm = emit_native_text_with_module_name(program, "test_concurrency");
+    assert _contains(asm, "parallel [spawn worker()]");
+}
+
+// `serve(handler, port?)` renders the handler and optional port arguments.
+test "emit_native: serve renders handler and port arguments" ![io] {
+    let source = "fn main() ![io] { serve(handler, 8080); }";
+    let program = parse_program(source);
+    let asm = emit_native_text_with_module_name(program, "test_concurrency");
+    assert _contains(asm, "serve(handler, 8080)");
+}
+
+// `routine { ... }` emits an explicit `.routine`/`.endroutine` scope. The
+// native IR parser maps these to the transparent always-true `If`/`EndIf`
+// scope (`.if 1 > 0`) until the structured-concurrency runtime lands (#1085).
+test "emit_native: routine emits an explicit scope" ![io] {
+    let source = "fn main() ![io] { routine { let x: int = 1; } }";
+    let program = parse_program(source);
+    let asm = emit_native_text_with_module_name(program, "test_concurrency");
+    assert _contains(asm, ".routine");
+    assert _contains(asm, ".endroutine");
+}


### PR DESCRIPTION
## Summary
- Render the concurrency frontend nodes (epic #965) to real `.sfn-asm` forms in `emit_native_format.sfn`, replacing the placeholder/marker fallthroughs:
  - `spawn[:<kind>] <operand>`
  - `channel[:<kind>](<capacity>)`
  - `parallel [<tasks>]`
  - `serve(<handler>[, <port>])`
  - `routine { ... }` → explicit `.routine`/`.endroutine` scope (emit) mapped to the transparent `If`/`EndIf` scope (parser)
- `await` already emitted `await <operand>` and is unchanged.
- The `kind` tag is the monomorphized future kind the parser attaches via `spawn_future_kind` (#1082); the emitter just reads `expression.kind`.

Closes #1084

## Design notes
- **`native_ir.sfn` was not needed.** `spawn`/`channel`/`parallel`/`serve` are expressions carried as the text of an `eval`/`let` instruction, so they need formatter arms, not new `NativeInstruction` variants. `routine` (v0 = a bare block scope, `runtime_architecture.md` §2.6.7) reuses the existing always-true `If`/`EndIf` scope `BlockStatement` lowers through: the emitter writes explicit `.routine`/`.endroutine` directives (keeping the surface visible in the IR), and `native_ir_parser_instructions.sfn` maps them to `If{"1 > 0"}`/`EndIf`. No new IR tag, no lowering-dispatch change, no self-hosting tag-ordering risk.
- **`core.sfn` (LLVM lowering) guards** — touched beyond the issue's listed files, by design (approved): LLVM lowering proper stays deferred to #1085, but the fail-closed guards had to track the new emitted forms. Previously `parallel`/`serve` fell through to the *non-fatal* unable-to-lower path, which the emit/build fatal gate ignores — silently false-greening an unenforced concurrency surface into the IR (llms.txt violation). The guards now fail closed (`[fatal]: ... is not yet lowered`) on all of `spawn`/`channel`/`parallel`/`serve`. These prefixes are collision-safe: the names are contextual keywords parsed only in expression-prefix position, so no user identifier produces them.

## Acceptance Criteria
- [x] emitter produces `.sfn-asm` for each node (no lambda-style placeholder fallthrough)
- [x] `emit_native_format.sfn` renders them
- [x] golden-IR test (`compiler/tests/unit/concurrency_emit_test.sfn`)
- [x] `make compile` passes
- [x] `make test` passes
- [x] `sfn fmt --check` clean on every touched `.sfn`

## Verification
```bash
ulimit -v 8388608 && make compile          # status: pass (self-hosts)
ulimit -v 8388608 && make test             # status: pass (unit 133/133, e2e-sh 110/110, all suites green)
# fail-closed regression specifically:
bash compiler/tests/e2e/test_sync_rejects_unimplemented_concurrency.sh build/native/sailfin   # 8 passed, 0 failed
build/native/sailfin fmt --check <touched files>   # clean
```

## Files Changed
- `compiler/src/emit_native_format.sfn` — Spawn/Channel/Parallel/Serve formatter arms
- `compiler/src/emit_native.sfn` — `RoutineStatement` emit arm
- `compiler/src/native_ir_parser_instructions.sfn` — `.routine`/`.endroutine` → `If`/`EndIf` shim
- `compiler/src/llvm/expression_lowering/native/core.sfn` — fail-closed guards for the new forms
- `compiler/tests/unit/concurrency_emit_test.sfn` — new golden-IR test (7 cases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GEAwphKj63B9iCY1HwZt72)_