### PR TITLE
feat(make): wire JSON=1 through test targets to sfn test --json

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -186,8 +186,17 @@ test-impl:
 	@# must still run even when a `.sfn` suite fails — matches the
 	@# pre-#848 `test-e2e` loop, which ran its `.sh` branch after the
 	@# `.sfn` branch regardless of `.sfn` failures.
+	@# JSON=1 gate (#1121): only the `.sfn` runner gets `--json` + tee; the
+	@# `.sh` branch (test-e2e-sh) has no JSON surface. The `rc` aggregation
+	@# is preserved so a failure in either branch still propagates.
 	@rc=0; \
-	$(NATIVE_BIN) test compiler/tests/unit compiler/tests/integration compiler/tests/e2e capsules || rc=$$?; \
+	if [ "$${SAILFIN_AGENT_REPORT:-}" = "1" ]; then \
+		mkdir -p build; \
+		set -o pipefail; \
+		$(NATIVE_BIN) test compiler/tests/unit compiler/tests/integration compiler/tests/e2e capsules --json | tee build/agent-test.test.jsonl || rc=$$?; \
+	else \
+		$(NATIVE_BIN) test compiler/tests/unit compiler/tests/integration compiler/tests/e2e capsules || rc=$$?; \
+	fi; \
 	$(MAKE) test-e2e-sh || rc=$$?; \
 	exit $$rc
 
@@ -251,7 +260,18 @@ test-unit-impl:
 		echo "[test-unit] missing $(NATIVE_BIN); running make compile"; \
 		$(MAKE) compile; \
 	fi
-	@$(NATIVE_BIN) test compiler/tests/unit
+	@# JSON=1 / SAILFIN_AGENT_REPORT=1 gate (#1121): append `--json` so the
+	@# runner emits its jsonl event stream and tee it to a stable per-target
+	@# path for the report composer (#1056 Phase 2). pipefail preserves the
+	@# runner's real exit code across the tee. Default (gate off) keeps the
+	@# original invocation byte-for-byte and writes no file.
+	@if [ "$${SAILFIN_AGENT_REPORT:-}" = "1" ]; then \
+		mkdir -p build; \
+		set -o pipefail; \
+		$(NATIVE_BIN) test compiler/tests/unit --json | tee build/agent-test.test-unit.jsonl; \
+	else \
+		$(NATIVE_BIN) test compiler/tests/unit; \
+	fi
 
 test-integration:
 	@$(AGENT_REPORT) --target test-integration -- $(MAKE) test-integration-impl
@@ -261,7 +281,14 @@ test-integration-impl:
 		echo "[test-integration] missing $(NATIVE_BIN); running make compile"; \
 		$(MAKE) compile; \
 	fi
-	@$(NATIVE_BIN) test compiler/tests/integration
+	@# JSON=1 gate (#1121) — see test-unit-impl for the rationale.
+	@if [ "$${SAILFIN_AGENT_REPORT:-}" = "1" ]; then \
+		mkdir -p build; \
+		set -o pipefail; \
+		$(NATIVE_BIN) test compiler/tests/integration --json | tee build/agent-test.test-integration.jsonl; \
+	else \
+		$(NATIVE_BIN) test compiler/tests/integration; \
+	fi
 
 # The legacy e2e `test_*.sh` scripts still run alongside the `.sfn`
 # tests until Phase 3.1 migrates them (see
@@ -276,8 +303,17 @@ test-e2e-impl:
 		echo "[test-e2e] missing $(NATIVE_BIN); running make compile"; \
 		$(MAKE) compile; \
 	fi
+	@# JSON=1 gate (#1121): only the `.sfn` runner gets `--json` + tee; the
+	@# `.sh` branch (test-e2e-sh) has no JSON surface. The `rc` aggregation
+	@# is preserved so a failure in either branch still propagates.
 	@rc=0; \
-	$(NATIVE_BIN) test compiler/tests/e2e || rc=$$?; \
+	if [ "$${SAILFIN_AGENT_REPORT:-}" = "1" ]; then \
+		mkdir -p build; \
+		set -o pipefail; \
+		$(NATIVE_BIN) test compiler/tests/e2e --json | tee build/agent-test.test-e2e.jsonl || rc=$$?; \
+	else \
+		$(NATIVE_BIN) test compiler/tests/e2e || rc=$$?; \
+	fi; \
 	$(MAKE) test-e2e-sh || rc=$$?; \
 	exit $$rc
 
@@ -294,7 +330,14 @@ test-capsules-impl:
 		echo "[test-capsules] missing $(NATIVE_BIN); running make compile"; \
 		$(MAKE) compile; \
 	fi
-	@$(NATIVE_BIN) test capsules
+	@# JSON=1 gate (#1121) — see test-unit-impl for the rationale.
+	@if [ "$${SAILFIN_AGENT_REPORT:-}" = "1" ]; then \
+		mkdir -p build; \
+		set -o pipefail; \
+		$(NATIVE_BIN) test capsules --json | tee build/agent-test.test-capsules.jsonl; \
+	else \
+		$(NATIVE_BIN) test capsules; \
+	fi
 
 # Sharded test execution for parallel CI legs. Phase 1 of
 # docs/proposals/ci-test-speed.md (#843 Track A): the test suite is

--- a/compiler/src/cli_commands.sfn
+++ b/compiler/src/cli_commands.sfn
@@ -62,7 +62,12 @@ import { LayoutManifest } from "./native_ir";
 import { number_to_string } from "./num_format";
 import { parse_program } from "./parser/mod";
 import { runtime_capsule_from_root } from "./runtime_capsule_resolver";
-import { find_char_local, substring } from "./string_utils";
+import {
+    char_code_at_text,
+    find_char_local,
+    index_of,
+    substring
+} from "./string_utils";
 import {
     TestEntry,
     collect_test_entries,
@@ -860,6 +865,7 @@ fn _run_test_child(timeout_cmd: string, timeout_secs: string, child_scratch: str
             + child_scratch, "SAILFIN_TEST_RUNTIME_OBJDIR="
             + runtime_objdir];
         if update_snapshots { base.push("SAILFIN_UPDATE_SNAPSHOTS=1"); }
+        if json_output { base.push("SAILFIN_TEST_JSON_SUBFRAME=1"); }
         base.push(self_exe);
         base.push("test");
         base.push(path);
@@ -869,6 +875,7 @@ fn _run_test_child(timeout_cmd: string, timeout_secs: string, child_scratch: str
     let mut base = ["env", "SAILFIN_TEST_SCRATCH=" + child_scratch, "SAILFIN_TEST_RUNTIME_OBJDIR="
         + runtime_objdir];
     if update_snapshots { base.push("SAILFIN_UPDATE_SNAPSHOTS=1"); }
+    if json_output { base.push("SAILFIN_TEST_JSON_SUBFRAME=1"); }
     base.push(self_exe);
     base.push("test");
     base.push(path);
@@ -923,6 +930,29 @@ fn _cleanup_test_scratch(owned: boolean, scratch_root: string, success: boolean)
         return;
     }
     process.run(["rm", "-rf", scratch_root]);
+}
+
+// Extract the unsigned integer that follows `key` in `text` (a small,
+// allocation-free reader over a known-shape jsonl line). Used by the
+// multi-file `--json` parent to aggregate each child's
+// `_subframe_summary.json` counts (`"passed":N` / `"failed":N` /
+// `"skipped":N`). Returns 0 when the key is absent or not followed by a
+// digit. Deliberately tiny rather than a full JSON parse: the input is
+// the runner's own `render_summary_event` output, whose shape is pinned.
+fn _extract_json_uint_after(text: string, key: string) -> int {
+    let idx = index_of(text, key);
+    if idx < 0 { return 0; }
+    let mut i: int = idx + key.length;
+    let mut n: int = 0;
+    loop {
+        if i >= text.length { break; }
+        let c = char_code_at_text(text, i);
+        if c < 48 { break; }
+        if c > 57 { break; }
+        n = n * 10 + (c - 48);
+        i += 1;
+    }
+    return n;
 }
 
 fn handle_test_command(args: string[], runtime_root: string, binary_dir: string) -> int ![io, clock] {
@@ -1019,6 +1049,14 @@ fn handle_test_command(args: string[], runtime_root: string, binary_dir: string)
     let scratch_root = _test_scratch_root();
     _ensure_dir_cmd(scratch_root);
     _ensure_dir_cmd(scratch_root + "/test-o0");
+    // Sub-frame mode (#1121): set by the multi-file parent on each child
+    // via SAILFIN_TEST_JSON_SUBFRAME=1. In this mode a `--json` child
+    // suppresses its own start/summary on stdout (it still emits per-test
+    // events, which the parent forwards through inherited stdout) and
+    // writes its counts to `<scratch>/_subframe_summary.json` so the
+    // parent can aggregate them into one run-level summary. The result is
+    // a single coherent jsonl document per `sfn test` invocation.
+    let json_subframe = json_output && _env_flag("SAILFIN_TEST_JSON_SUBFRAME");
 
     // Resolve the trace toggle once (popen-cost is fine on the
     // cold orchestrator path) and stash both bits in the
@@ -1093,8 +1131,12 @@ fn handle_test_command(args: string[], runtime_root: string, binary_dir: string)
         // code stays 0 so a legitimately-empty suite (e.g. a capsule
         // with no `tests/` dir) doesn't fail the build.
         if json_output {
-            print(render_start_event(0));
-            print(render_summary_event(0, 0, 0, 0));
+            if json_subframe {
+                fs.writeFile(scratch_root + "/_subframe_summary.json", render_summary_event(0, 0, 0, 0));
+            } else {
+                print(render_start_event(0));
+                print(render_summary_event(0, 0, 0, 0));
+            }
             exit_test_runner_mode();
             return 0;
         }
@@ -1126,16 +1168,17 @@ fn handle_test_command(args: string[], runtime_root: string, binary_dir: string)
     // an ABI mismatch. Per-file subprocesses give each test its own
     // resolver pass (its own imports only), which is exactly what the
     // retired `scripts/run_native_test.sh` per-file loop did. JSON
-    // mode (#1121) also uses this per-file subprocess path: each child
-    // runs `<self> test <file> --json` in its own process, so the jsonl
-    // stays a per-file-framed document (one start/…/summary block per
-    // file) and a multi-file `sfn test <dir> --json` no longer forces
-    // every file through one resolver pass — that single-process path
-    // OOM/segfaulted on the real suite (132 unit files) under the 8 GB
-    // cap and hit the resolver-union conflicts per-file isolation
-    // exists to avoid. Children emit their own ordered jsonl to the
-    // shared (inherited) stdout; the parent suppresses human banners
-    // and the RETRY line in JSON mode so the stream stays pure jsonl.
+    // mode (#1121) also uses this per-file subprocess path — a multi-file
+    // `sfn test <dir> --json` no longer forces every file through one
+    // resolver pass (that single-process path OOM/segfaulted on the real
+    // suite — 132 unit files — under the 8 GB cap and hit the
+    // resolver-union conflicts per-file isolation exists to avoid).
+    // Output stays a SINGLE coherent jsonl document per invocation: the
+    // parent emits one aggregate `start`, runs each child in sub-frame
+    // mode (children forward only per-test events on the shared stdout
+    // and hand their counts back via `_subframe_summary.json`), then
+    // emits one aggregate `summary`. Human banners and the RETRY line are
+    // suppressed in JSON mode so the stream stays pure jsonl.
     if test_files.length > 1 {
         let self_exe = _resolve_test_self_path(binary_dir);
         // Ephemeral scratch root + cleanup, ported from the retired
@@ -1207,6 +1250,34 @@ fn handle_test_command(args: string[], runtime_root: string, binary_dir: string)
                     + " (children will retry per file)");
             }
         }
+        // Single-frame `--json` aggregation (#1121). The parent owns the
+        // run's `start`/`summary`; children run in sub-frame mode (see
+        // `_run_test_child`) and forward only per-test events. Pre-parse
+        // each file to compute the aggregate `total` (parse-only, no
+        // codegen) and keep per-file test counts so a child that dies
+        // before writing its summary file can still be attributed.
+        let mut sf_total: int = 0;
+        let mut sf_counts: int[] = [];
+        if json_output {
+            let mut sfp: int = 0;
+            loop {
+                if sfp >= test_files.length { break; }
+                let sf_src = fs.readFile(test_files[sfp]);
+                let mut sf_prog: Program = parse_program(sf_src);
+                if test_filters_active() {
+                    sf_prog = _filter_program_tests_cmd(sf_prog);
+                }
+                let sf_entries = collect_test_entries(sf_prog, test_files[sfp]);
+                sf_counts.push(sf_entries.length);
+                sf_total += sf_entries.length;
+                sfp += 1;
+            }
+            print(render_start_event(sf_total));
+        }
+        let sf_start_ms = monotonic_millis();
+        let mut sf_passed: int = 0;
+        let mut sf_failed: int = 0;
+        let mut sf_skipped: int = 0;
         let mut overall_rc: int = 0;
         let mut ti: int = 0;
         loop {
@@ -1239,12 +1310,29 @@ fn handle_test_command(args: string[], runtime_root: string, binary_dir: string)
                 suites[suite_idx].failed_files.push(_package_basename(path));
                 if overall_rc == 0 { overall_rc = rc; }
             }
+            if json_output {
+                // Aggregate the child's per-test counts from the
+                // sub-frame summary it wrote. A missing file means the
+                // child died before writing it (segfault/timeout); count
+                // that file's tests as failed so the aggregate stays
+                // consistent with the non-zero run exit code.
+                let sf_file = child_scratch + "/_subframe_summary.json";
+                if fs.exists(sf_file) {
+                    let sf_raw = fs.readFile(sf_file);
+                    sf_passed += _extract_json_uint_after(sf_raw, "\"passed\":");
+                    sf_failed += _extract_json_uint_after(sf_raw, "\"failed\":");
+                    sf_skipped += _extract_json_uint_after(sf_raw, "\"skipped\":");
+                } else { sf_failed += sf_counts[ti]; }
+            }
             ti += 1;
         }
-        // Banners are human-mode only; in JSON mode (#1121) each child
-        // already emitted its own per-file summary event, so the parent
-        // stays silent and the stream is pure jsonl.
-        if emit_banners && !json_output { _emit_suite_banners(suites); }
+        if json_output {
+            // One aggregate `summary` closes the single jsonl document:
+            // one `start`, every per-test event the children forwarded,
+            // one `summary` with run-level counts and wall-clock duration.
+            let sf_dur = monotonic_millis() - sf_start_ms;
+            print(render_summary_event(sf_passed, sf_failed, sf_skipped, sf_dur));
+        } else if emit_banners { _emit_suite_banners(suites); }
         exit_test_runner_mode();
         _cleanup_test_scratch(scratch_owned, sub_root, overall_rc == 0);
         return overall_rc;
@@ -1422,7 +1510,9 @@ fn handle_test_command(args: string[], runtime_root: string, binary_dir: string)
             total_tests += entries.length;
             pi += 1;
         }
-        print(render_start_event(total_tests));
+        // Sub-frame children suppress their own `start`; the multi-file
+        // parent emits one aggregate `start` for the whole run.
+        if !json_subframe { print(render_start_event(total_tests)); }
     }
 
     let runner_start_ms = monotonic_millis();
@@ -1647,7 +1737,12 @@ fn handle_test_command(args: string[], runtime_root: string, binary_dir: string)
     }
     if json_output {
         let runner_elapsed_ms = monotonic_millis() - runner_start_ms;
-        print(render_summary_event(total_passed, total_failed, total_skipped, runner_elapsed_ms));
+        let summary_line = render_summary_event(total_passed, total_failed, total_skipped, runner_elapsed_ms);
+        // Sub-frame children hand their counts to the parent via a file
+        // instead of printing a per-file summary onto the shared stream.
+        if json_subframe {
+            fs.writeFile(scratch_root + "/_subframe_summary.json", summary_line);
+        } else { print(summary_line); }
     } else if emit_banners {
         // Per-suite banners. Suppressed in `--json` mode (the
         // structured summary event is the source of truth there)

--- a/compiler/src/cli_commands.sfn
+++ b/compiler/src/cli_commands.sfn
@@ -846,7 +846,7 @@ fn _append_test_filter_args(argv: string[], name_filter: string, tag_filter: str
     return out;
 }
 
-fn _run_test_child(timeout_cmd: string, timeout_secs: string, child_scratch: string, runtime_objdir: string, self_exe: string, path: string, name_filter: string, tag_filter: string, update_snapshots: boolean) -> int ![io] {
+fn _run_test_child(timeout_cmd: string, timeout_secs: string, child_scratch: string, runtime_objdir: string, self_exe: string, path: string, name_filter: string, tag_filter: string, update_snapshots: boolean, json_output: boolean) -> int ![io] {
     // #940: `SAILFIN_TEST_RUNTIME_OBJDIR` points the child's runtime
     // link at the shared, invocation-stable object dir the parent
     // warmed once, so the runtime isn't recompiled per test file.
@@ -863,6 +863,7 @@ fn _run_test_child(timeout_cmd: string, timeout_secs: string, child_scratch: str
         base.push(self_exe);
         base.push("test");
         base.push(path);
+        if json_output { base.push("--json"); }
         return process.run(_append_test_filter_args(base, name_filter, tag_filter));
     }
     let mut base = ["env", "SAILFIN_TEST_SCRATCH=" + child_scratch, "SAILFIN_TEST_RUNTIME_OBJDIR="
@@ -871,6 +872,7 @@ fn _run_test_child(timeout_cmd: string, timeout_secs: string, child_scratch: str
     base.push(self_exe);
     base.push("test");
     base.push(path);
+    if json_output { base.push("--json"); }
     return process.run(_append_test_filter_args(base, name_filter, tag_filter));
 }
 
@@ -879,9 +881,26 @@ fn _run_test_child(timeout_cmd: string, timeout_secs: string, child_scratch: str
 // `SAILFIN_UPDATE_SNAPSHOTS=1` when `--update-snapshots` is active so
 // `sfn/test::expect_snapshot` re-baselines. When `update_snapshots` is
 // false the argv is byte-identical to the pre-#977 shape.
-fn _test_exec_argv(scratch_root: string, exe_path: string, update_snapshots: boolean) -> string[] {
+fn _test_exec_argv(scratch_root: string, exe_path: string, update_snapshots: boolean, json_output: boolean) -> string[] {
     let mut argv = ["env", "SAILFIN_TEST_SCRATCH=" + scratch_root];
     if update_snapshots { argv.push("SAILFIN_UPDATE_SNAPSHOTS=1"); }
+    if json_output {
+        // #1121: in `--json` mode the test binary's OWN stdout — user
+        // `print(...)` output from inside a test body — must not pollute
+        // the pure jsonl event stream the runner emits on the same fd.
+        // Exec the binary through `sh -c` with stdout redirected to
+        // /dev/null. stderr (the harness `RUN`/`PASS` lines + compiler
+        // diagnostics) and the `fail.bin` assert-record (a file, not a
+        // stream) are untouched, so failure attribution is unaffected.
+        // `exec "$0"` makes the shell hand its pid + exit/signal status
+        // straight to the binary, so `process.run`'s 0..255 / `128+sig`
+        // decoding is identical to the un-wrapped exec.
+        argv.push("sh");
+        argv.push("-c");
+        argv.push("exec \"$0\" >/dev/null");
+        argv.push(exe_path);
+        return argv;
+    }
     argv.push(exe_path);
     return argv;
 }
@@ -1107,10 +1126,17 @@ fn handle_test_command(args: string[], runtime_root: string, binary_dir: string)
     // an ABI mismatch. Per-file subprocesses give each test its own
     // resolver pass (its own imports only), which is exactly what the
     // retired `scripts/run_native_test.sh` per-file loop did. JSON
-    // mode keeps the single-process path so the jsonl stream stays a
-    // single ordered document; `--json` callers run one file at a
-    // time today.
-    if test_files.length > 1 && !json_output {
+    // mode (#1121) also uses this per-file subprocess path: each child
+    // runs `<self> test <file> --json` in its own process, so the jsonl
+    // stays a per-file-framed document (one start/…/summary block per
+    // file) and a multi-file `sfn test <dir> --json` no longer forces
+    // every file through one resolver pass — that single-process path
+    // OOM/segfaulted on the real suite (132 unit files) under the 8 GB
+    // cap and hit the resolver-union conflicts per-file isolation
+    // exists to avoid. Children emit their own ordered jsonl to the
+    // shared (inherited) stdout; the parent suppresses human banners
+    // and the RETRY line in JSON mode so the stream stays pure jsonl.
+    if test_files.length > 1 {
         let self_exe = _resolve_test_self_path(binary_dir);
         // Ephemeral scratch root + cleanup, ported from the retired
         // `scripts/run_native_test.sh` (issue #850). The script ran
@@ -1195,13 +1221,18 @@ fn handle_test_command(args: string[], runtime_root: string, binary_dir: string)
             // this per-file dir — see `SAILFIN_TEST_RUNTIME_OBJDIR`.
             let child_scratch = sub_root + "/sub-" + number_to_string(ti);
             _ensure_dir_cmd(child_scratch);
-            let mut rc = _run_test_child(timeout_cmd, timeout_secs, child_scratch, sub_root, self_exe, path, name_filter, tag_filter, update_snapshots);
+            let mut rc = _run_test_child(timeout_cmd, timeout_secs, child_scratch, sub_root, self_exe, path, name_filter, tag_filter, update_snapshots, json_output);
             if _should_retry_test(rc, sub_retries_disabled) {
-                print("[test] RETRY: " + _package_basename(path)
-                    + " (exit code "
-                    + number_to_string(rc)
-                    + ", retrying once)");
-                rc = _run_test_child(timeout_cmd, timeout_secs, child_scratch, sub_root, self_exe, path, name_filter, tag_filter, update_snapshots);
+                // RETRY banner is a human-mode artifact; suppress it in
+                // JSON mode so the jsonl stream stays pure (mirrors the
+                // in-process path's `if !json_output` retry-print gate).
+                if !json_output {
+                    print("[test] RETRY: " + _package_basename(path)
+                        + " (exit code "
+                        + number_to_string(rc)
+                        + ", retrying once)");
+                }
+                rc = _run_test_child(timeout_cmd, timeout_secs, child_scratch, sub_root, self_exe, path, name_filter, tag_filter, update_snapshots, json_output);
             }
             if rc == 0 { suites[suite_idx].pass_count += 1; } else {
                 suites[suite_idx].fail_count += 1;
@@ -1210,7 +1241,10 @@ fn handle_test_command(args: string[], runtime_root: string, binary_dir: string)
             }
             ti += 1;
         }
-        if emit_banners { _emit_suite_banners(suites); }
+        // Banners are human-mode only; in JSON mode (#1121) each child
+        // already emitted its own per-file summary event, so the parent
+        // stays silent and the stream is pure jsonl.
+        if emit_banners && !json_output { _emit_suite_banners(suites); }
         exit_test_runner_mode();
         _cleanup_test_scratch(scratch_owned, sub_root, overall_rc == 0);
         return overall_rc;
@@ -1504,7 +1538,7 @@ fn handle_test_command(args: string[], runtime_root: string, binary_dir: string)
         if fs.exists(fail_record_path) { fs.deleteFile(fail_record_path); }
 
         if trace_runner { print.err("test runner: exec start"); }
-        let mut run_rc = process.run(_test_exec_argv(scratch_root, exe_path, update_snapshots));
+        let mut run_rc = process.run(_test_exec_argv(scratch_root, exe_path, update_snapshots, json_output));
         // Signal-kill retry (ported from `scripts/run_native_test.sh`
         // by issue #845). 137 (OOM-SIGKILL) / 139 (SIGSEGV) are
         // transient under sustained CI memory pressure on the
@@ -1534,7 +1568,7 @@ fn handle_test_command(args: string[], runtime_root: string, binary_dir: string)
             if fs.exists(fail_record_path) {
                 fs.deleteFile(fail_record_path);
             }
-            run_rc = process.run(_test_exec_argv(scratch_root, exe_path, update_snapshots));
+            run_rc = process.run(_test_exec_argv(scratch_root, exe_path, update_snapshots, json_output));
         }
         if trace_runner {
             print.err("test runner: exec done (exit=" + number_to_string(run_rc)

--- a/compiler/tests/e2e/test_runner_json_multifile.sh
+++ b/compiler/tests/e2e/test_runner_json_multifile.sh
@@ -12,19 +12,23 @@
 # so the tee'd jsonl came out empty.
 #
 # The fix routes multi-file `--json` runs through the same per-file
-# subprocess path the human path uses, passing `--json` to each child.
-# Each child emits its own ordered jsonl document to the shared stdout,
-# so the stream is PER-FILE FRAMED: one `start`/…/`summary` block per
-# file. This test pins:
+# subprocess path the human path uses, but the parent aggregates the
+# per-file results back into ONE coherent jsonl document so the
+# documented single-frame contract (one `start`, every per-test event,
+# one `summary`) holds regardless of how many files ran. Children run in
+# sub-frame mode: they forward only per-test events on the shared stdout
+# and hand their counts to the parent via `_subframe_summary.json`. This
+# test pins:
 #
 #   1. A 2-file `--json` run exits 0 and every non-blank stdout line is
 #      valid JSON (no crash, no empty/garbled stream).
-#   2. The stream carries `schema_version` 1 (on the `start` events).
-#   3. Per-file framing: one `start` and one `summary` event per file
-#      (proves the subprocess-isolation path ran, not the single-process
-#      path that produced a single framed document).
-#   4. A failing test still propagates a non-zero exit AND keeps the
-#      stream valid jsonl (the crash path must not return).
+#   2. The stream carries `schema_version` 1 (on the `start` event).
+#   3. Single-frame contract: exactly one `start` and one `summary` for
+#      the whole run (not one pair per file).
+#   4. The single `start.total` and `summary.passed` are run-level
+#      aggregates across all files.
+#   5. A failing test still propagates a non-zero exit, stays single-frame
+#      and valid jsonl, and records the failure in the aggregate summary.
 #
 # Usage:
 #   compiler/tests/e2e/test_runner_json_multifile.sh <compiler-binary>
@@ -83,9 +87,14 @@ EOF
 # ---- Test 1: multi-file --json exits 0, stream is valid jsonl ----
 test_multifile_json_runs() {
     pushd "$SCRATCH/pass" >/dev/null
+    # `errexit` is disabled around the invocation: the failure this test
+    # guards (a multi-file `--json` segfault) would otherwise abort the
+    # script before `rc` is captured and the diagnostic is printed.
+    set +e
     "$BINARY" test "$SCRATCH/pass" --json \
         > "$SCRATCH/pass.jsonl" 2> "$SCRATCH/pass.err"
     local rc=$?
+    set -e
     popd >/dev/null
     if [ "$rc" -ne 0 ]; then
         echo "[test]   multi-file --json exited $rc (regression: pre-#1121 segfault); stderr:" >&2
@@ -96,7 +105,7 @@ test_multifile_json_runs() {
 }
 run_test "multi-file 'sfn test <dir> --json' exits 0 with valid jsonl" test_multifile_json_runs
 
-# ---- Test 2: schema_version 1 is present on the start event(s) ----
+# ---- Test 2: schema_version 1 is present on the start event ----
 test_schema_version_present() {
     local n
     n=$(jq -s '[.[] | select(.schema_version == 1)] | length' "$SCRATCH/pass.jsonl")
@@ -104,34 +113,45 @@ test_schema_version_present() {
 }
 run_test "stream carries schema_version 1 events" test_schema_version_present
 
-# ---- Test 3: per-file framing — one start + one summary per file ----
-# Two files => two `start` and two `summary` events. This is the
-# observable signature of the subprocess-isolation path (the fix); the
-# old single-process path emitted exactly one of each.
-test_per_file_framing() {
+# ---- Test 3: single-frame contract — exactly one start + one summary ----
+# A multi-file `--json` invocation must emit ONE coherent document: one
+# `start` and one `summary` for the whole run (not one pair per file).
+# The parent aggregates the per-file subprocess results back into a
+# single frame, so consumers never special-case dir-vs-file.
+test_single_frame() {
     local starts summaries
     starts=$(jq -s '[.[] | select(.event == "start")] | length' "$SCRATCH/pass.jsonl")
     summaries=$(jq -s '[.[] | select(.event == "summary")] | length' "$SCRATCH/pass.jsonl")
-    if [ "$starts" -ne 2 ]; then
-        echo "[test]   expected 2 start events (one per file), got $starts" >&2
+    if [ "$starts" -ne 1 ]; then
+        echo "[test]   expected exactly 1 start event for the run, got $starts" >&2
         return 1
     fi
-    if [ "$summaries" -ne 2 ]; then
-        echo "[test]   expected 2 summary events (one per file), got $summaries" >&2
+    if [ "$summaries" -ne 1 ]; then
+        echo "[test]   expected exactly 1 summary event for the run, got $summaries" >&2
         return 1
     fi
     return 0
 }
-run_test "per-file framing: 2 start + 2 summary events for 2 files" test_per_file_framing
+run_test "single-frame: exactly 1 start + 1 summary for a multi-file run" test_single_frame
 
-# ---- Test 4: aggregate pass count across the per-file summaries ----
-test_aggregate_passed() {
-    local total
-    total=$(jq -s '[.[] | select(.event == "summary") | .passed] | add' "$SCRATCH/pass.jsonl")
-    # alpha (2) + beta (1) = 3 passing tests.
-    [ "$total" = "3" ]
+# ---- Test 4: aggregate totals on the single start/summary ----
+# start.total and summary.passed are run-level aggregates: alpha (2) +
+# beta (1) = 3 tests, all passing.
+test_aggregate_totals() {
+    local total passed
+    total=$(jq -s '[.[] | select(.event == "start") | .total] | add' "$SCRATCH/pass.jsonl")
+    passed=$(jq -s '[.[] | select(.event == "summary") | .passed] | add' "$SCRATCH/pass.jsonl")
+    if [ "$total" != "3" ]; then
+        echo "[test]   expected aggregate start.total == 3, got $total" >&2
+        return 1
+    fi
+    if [ "$passed" != "3" ]; then
+        echo "[test]   expected aggregate summary.passed == 3, got $passed" >&2
+        return 1
+    fi
+    return 0
 }
-run_test "summed per-file summaries report 3 passed tests" test_aggregate_passed
+run_test "single start.total and summary.passed are run-level aggregates (3)" test_aggregate_totals
 
 # ---- Test 5: a failing test propagates non-zero AND stays valid jsonl ----
 mkdir -p "$SCRATCH/fail"
@@ -156,10 +176,19 @@ test_failure_propagates_valid_jsonl() {
     # The stream must still be well-formed jsonl — a crash would leave it
     # empty or truncated mid-line.
     all_lines_json "$SCRATCH/fail.jsonl" || return 1
-    # At least one test event reports a non-pass status.
-    local failed
-    failed=$(jq -s '[.[] | select(.event == "test" and .status != "pass")] | length' "$SCRATCH/fail.jsonl")
-    [ "$failed" -ge 1 ]
+    # Still a single frame even when a file fails.
+    local starts summaries
+    starts=$(jq -s '[.[] | select(.event == "start")] | length' "$SCRATCH/fail.jsonl")
+    summaries=$(jq -s '[.[] | select(.event == "summary")] | length' "$SCRATCH/fail.jsonl")
+    [ "$starts" -eq 1 ] || { echo "[test]   expected 1 start, got $starts" >&2; return 1; }
+    [ "$summaries" -eq 1 ] || { echo "[test]   expected 1 summary, got $summaries" >&2; return 1; }
+    # The aggregate summary records the failure, and a test event reports
+    # a non-pass status.
+    local agg_failed nonpass
+    agg_failed=$(jq -s '[.[] | select(.event == "summary") | .failed] | add' "$SCRATCH/fail.jsonl")
+    [ "$agg_failed" -ge 1 ] || { echo "[test]   expected summary.failed >= 1, got $agg_failed" >&2; return 1; }
+    nonpass=$(jq -s '[.[] | select(.event == "test" and .status != "pass")] | length' "$SCRATCH/fail.jsonl")
+    [ "$nonpass" -ge 1 ]
 }
 run_test "failing test: non-zero exit, stream stays valid jsonl" test_failure_propagates_valid_jsonl
 

--- a/compiler/tests/e2e/test_runner_json_multifile.sh
+++ b/compiler/tests/e2e/test_runner_json_multifile.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# Issue #1121: `sfn test <dir> --json` over a MULTI-FILE directory.
+#
+# Regression guard for the segfault that blocked wiring `JSON=1` through
+# the Makefile test targets. Before the fix, `--json` forced every
+# discovered test file through ONE in-process resolver pass (the
+# `test_files.length > 1 && !json_output` guard in
+# `cli_commands.sfn:handle_test_command` skipped the per-file subprocess
+# isolation whenever `--json` was set). On the real suite (132 unit
+# files) that single-process path OOM/segfaulted under the 8 GB cap and
+# hit the resolver-union conflicts per-file isolation exists to avoid,
+# so the tee'd jsonl came out empty.
+#
+# The fix routes multi-file `--json` runs through the same per-file
+# subprocess path the human path uses, passing `--json` to each child.
+# Each child emits its own ordered jsonl document to the shared stdout,
+# so the stream is PER-FILE FRAMED: one `start`/…/`summary` block per
+# file. This test pins:
+#
+#   1. A 2-file `--json` run exits 0 and every non-blank stdout line is
+#      valid JSON (no crash, no empty/garbled stream).
+#   2. The stream carries `schema_version` 1 (on the `start` events).
+#   3. Per-file framing: one `start` and one `summary` event per file
+#      (proves the subprocess-isolation path ran, not the single-process
+#      path that produced a single framed document).
+#   4. A failing test still propagates a non-zero exit AND keeps the
+#      stream valid jsonl (the crash path must not return).
+#
+# Usage:
+#   compiler/tests/e2e/test_runner_json_multifile.sh <compiler-binary>
+
+set -euo pipefail
+
+BINARY="${1:?usage: test_runner_json_multifile.sh <compiler-binary>}"
+BINARY="$(realpath "$BINARY")"
+PASS=0
+FAIL=0
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "[test] SKIP: jq not installed (required for --json validation)" >&2
+    exit 0
+fi
+
+SCRATCH="$(mktemp -d -t sfn-runner-json-mf-XXXXXX)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+run_test() {
+    local name="$1"
+    shift
+    if "$@"; then
+        echo "[test] PASS: $name"
+        PASS=$((PASS + 1))
+    else
+        echo "[test] FAIL: $name"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# Assert every non-blank line of $1 parses as JSON.
+all_lines_json() {
+    local file="$1"
+    local line
+    while IFS= read -r line; do
+        [ -z "$line" ] && continue
+        echo "$line" | jq -e . >/dev/null 2>&1 || {
+            echo "[test]   non-JSON line in stream: $line" >&2
+            return 1
+        }
+    done < "$file"
+    return 0
+}
+
+# ---- Fixtures: two passing test files (multi-file directory) ----
+mkdir -p "$SCRATCH/pass"
+cat > "$SCRATCH/pass/alpha_test.sfn" <<'EOF'
+test "alpha: one" { assert 1 + 1 == 2; }
+test "alpha: two" { assert 2 * 3 == 6; }
+EOF
+cat > "$SCRATCH/pass/beta_test.sfn" <<'EOF'
+test "beta: one" { assert 4 - 1 == 3; }
+EOF
+
+# ---- Test 1: multi-file --json exits 0, stream is valid jsonl ----
+test_multifile_json_runs() {
+    pushd "$SCRATCH/pass" >/dev/null
+    "$BINARY" test "$SCRATCH/pass" --json \
+        > "$SCRATCH/pass.jsonl" 2> "$SCRATCH/pass.err"
+    local rc=$?
+    popd >/dev/null
+    if [ "$rc" -ne 0 ]; then
+        echo "[test]   multi-file --json exited $rc (regression: pre-#1121 segfault); stderr:" >&2
+        cat "$SCRATCH/pass.err" >&2
+        return "$rc"
+    fi
+    all_lines_json "$SCRATCH/pass.jsonl"
+}
+run_test "multi-file 'sfn test <dir> --json' exits 0 with valid jsonl" test_multifile_json_runs
+
+# ---- Test 2: schema_version 1 is present on the start event(s) ----
+test_schema_version_present() {
+    local n
+    n=$(jq -s '[.[] | select(.schema_version == 1)] | length' "$SCRATCH/pass.jsonl")
+    [ "$n" -ge 1 ]
+}
+run_test "stream carries schema_version 1 events" test_schema_version_present
+
+# ---- Test 3: per-file framing — one start + one summary per file ----
+# Two files => two `start` and two `summary` events. This is the
+# observable signature of the subprocess-isolation path (the fix); the
+# old single-process path emitted exactly one of each.
+test_per_file_framing() {
+    local starts summaries
+    starts=$(jq -s '[.[] | select(.event == "start")] | length' "$SCRATCH/pass.jsonl")
+    summaries=$(jq -s '[.[] | select(.event == "summary")] | length' "$SCRATCH/pass.jsonl")
+    if [ "$starts" -ne 2 ]; then
+        echo "[test]   expected 2 start events (one per file), got $starts" >&2
+        return 1
+    fi
+    if [ "$summaries" -ne 2 ]; then
+        echo "[test]   expected 2 summary events (one per file), got $summaries" >&2
+        return 1
+    fi
+    return 0
+}
+run_test "per-file framing: 2 start + 2 summary events for 2 files" test_per_file_framing
+
+# ---- Test 4: aggregate pass count across the per-file summaries ----
+test_aggregate_passed() {
+    local total
+    total=$(jq -s '[.[] | select(.event == "summary") | .passed] | add' "$SCRATCH/pass.jsonl")
+    # alpha (2) + beta (1) = 3 passing tests.
+    [ "$total" = "3" ]
+}
+run_test "summed per-file summaries report 3 passed tests" test_aggregate_passed
+
+# ---- Test 5: a failing test propagates non-zero AND stays valid jsonl ----
+mkdir -p "$SCRATCH/fail"
+cat > "$SCRATCH/fail/ok_test.sfn" <<'EOF'
+test "ok: passes" { assert 1 == 1; }
+EOF
+cat > "$SCRATCH/fail/bad_test.sfn" <<'EOF'
+test "bad: fails" { assert 1 == 2; }
+EOF
+test_failure_propagates_valid_jsonl() {
+    pushd "$SCRATCH/fail" >/dev/null
+    set +e
+    "$BINARY" test "$SCRATCH/fail" --json \
+        > "$SCRATCH/fail.jsonl" 2> "$SCRATCH/fail.err"
+    local rc=$?
+    set -e
+    popd >/dev/null
+    if [ "$rc" -eq 0 ]; then
+        echo "[test]   expected non-zero exit for a failing test, got 0" >&2
+        return 1
+    fi
+    # The stream must still be well-formed jsonl — a crash would leave it
+    # empty or truncated mid-line.
+    all_lines_json "$SCRATCH/fail.jsonl" || return 1
+    # At least one test event reports a non-pass status.
+    local failed
+    failed=$(jq -s '[.[] | select(.event == "test" and .status != "pass")] | length' "$SCRATCH/fail.jsonl")
+    [ "$failed" -ge 1 ]
+}
+run_test "failing test: non-zero exit, stream stays valid jsonl" test_failure_propagates_valid_jsonl
+
+# ---- Summary ----
+echo ""
+echo "[test] $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

Wires `JSON=1` through the Makefile test targets so `sfn test --json` jsonl is captured for the #1056 report composer — and hardens the runner so that capture is actually usable on the real suite.

**1. Makefile wiring** (`14ac5e6`) — under the `JSON=1` / `SAILFIN_AGENT_REPORT=1` gate, the five test `-impl` targets pass `--json` to the runner and `tee` its jsonl to a stable per-target path (`build/agent-test.<target>.jsonl`). `pipefail` preserves exit codes; the `rc` aggregation in the two aggregating targets is unchanged. Default runs are byte-for-byte unchanged and write no jsonl.

**2. Runner hardening** (`19e9f77`) — the wiring exposed two pre-existing `sfn test --json` limitations that made `JSON=1 make test-unit` unusable:
- **Multi-file segfault** — `--json` skipped per-file subprocess isolation and forced all files through one in-process resolver pass, which OOM/segfaulted on the 132-file suite. Now `--json` uses the same per-file subprocess path the human runner uses.
- **stdout pollution** — a test that `print()`s leaked non-JSON lines into the stream (test-binary stdout was inherited). In json mode the test binary's stdout is now redirected to `/dev/null`; stderr/exit-code/assert-record are untouched.

**3. Single-frame aggregation** (`9733898`, from PR review) — keeps the per-file *execution* model but aggregates the *output* back into one coherent document per invocation: one `start` (aggregate `total`), every per-test event, one `summary` (aggregate counts). Children run in sub-frame mode and hand counts to the parent via a scratch file. Preserves the documented single-frame contract with no schema bump.

Closes #1121

## Acceptance Criteria
- [x] `JSON=1 make test-unit` writes `build/agent-test.test-unit.jsonl`; every non-blank line parses as JSON; the stream carries `schema_version` 1 (on the `start` event).
- [x] Human per-suite banners still print in default mode; pass/fail exit code unchanged (pipefail).
- [x] Default runs write no jsonl and are unchanged.
- [x] `make compile && make check` green (fixed point).

## Verification
```
JSON=1 make test-unit
#  -> one start {"total":1426,...}, one summary {"passed":1426,"failed":0,...}, 1425 test events, exit 0
#  -> build/agent-test.test-unit.jsonl: all lines valid JSON

bash compiler/tests/e2e/test_runner_json_multifile.sh build/native/sailfin   # 5/5
make check                                                                    # green, stage2 == stage3 fixed point
```
Note: `schema_version` rides the `start` event, so verify with `head -1 … | jq -e '.schema_version==1'` (the issue's `tail -1` targets the `summary`, which by schema carries no `schema_version`).

## Files Changed
- `Makefile` — gated `--json` + `tee` on the five test `-impl` targets
- `compiler/src/cli_commands.sfn` — multi-file `--json` subprocess isolation + stdout suppression + single-frame aggregation
- `compiler/tests/e2e/test_runner_json_multifile.sh` — new regression guard (single-frame contract, valid jsonl, failure propagation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)