### PR TITLE
docs(workflow): harden groom/pickup against over-decomposition + unprobed FFI claims

### DIFF
--- a/.claude/agents/compiler-architect.md
+++ b/.claude/agents/compiler-architect.md
@@ -58,6 +58,34 @@ Every design must account for the fact that the compiler compiles itself:
 - **New features used by the compiler create circular dependencies.** If you add a feature and then use it in the compiler source, the old seed must be able to compile the new compiler. Design features so they're additive — the old parser ignores what it doesn't understand, or the feature isn't used in the compiler until the next seed.
 - **Build performance matters architecturally.** A 90-minute build means every design iteration takes 90 minutes to validate. Designs that reduce build time have multiplicative value.
 
+## Decomposition Discipline (when grooming an epic into issues)
+
+When `/groom` asks you to break work into session-sized issues, **minimize
+the decomposition** — splitting carries real cost (extra PRs, review cycles,
+and seed cuts). Apply these:
+
+- **Bundle a capability with its single consumer.** When a compiler
+  capability (lowering / parse / typecheck / intrinsic) is tightly coupled to
+  one runtime/consumer that will be worked in the same session, prefer **one
+  issue/PR**, not two. Only split for genuinely independent work, or when the
+  capability has multiple consumers that each justify standalone shipping.
+- **Mind the seed-cut tax.** A compiler-source change and its consumer landing
+  as *separate releases* force a seed cut + `/pin-seed` between them (the
+  consumer can't self-host until the capability is in the pinned seed).
+  Bundling them in one PR avoids the seed cut: `make compile` builds the new
+  compiler from the old seed, which then compiles the consumer in the same
+  pass. **Call this out explicitly** in your plan whenever a proposed split
+  would create a seed-cut gate for a single consumer — recommend bundling.
+- **Don't manufacture splits.** If the whole thing is genuinely one S/M issue,
+  say so and stop. Two artificially-separated S issues are usually worse than
+  one honest M.
+- **Feasibility-probe FFI assumptions.** For any runtime issue claiming "no
+  frontend dependency," verify the needed construct can actually be expressed
+  and emitted by the current seed before treating it as standalone — a runtime
+  call to a C API often needs a frontend primitive that does not exist yet
+  (e.g. taking a function's address for a `pthread_create` start routine).
+  Surface a missing primitive as an explicit predecessor, not a surprise.
+
 ## Reference Documents
 
 Always consult these before designing:

--- a/.claude/commands/groom.md
+++ b/.claude/commands/groom.md
@@ -43,6 +43,49 @@ The architect produces an ordered list of issues. Each issue must:
 
 If the architect produces any L-sized item, push back: "this needs further breakdown."
 
+### Feasibility-probe FFI / "no frontend dependency" claims (gate)
+
+Before any issue that touches `runtime/` or crosses the C-ABI / `extern fn`
+boundary goes `claude-ready`, **probe the load-bearing feasibility claim** —
+do not take "this is written against the extern layer the seed already
+compiles / has no frontend dependency" on faith. The cheapest probe is a
+throwaway `.sfn` snippet run through the current seed:
+
+```bash
+ulimit -v 8388608 && build/seed/bin/sailfin check /tmp/probe.sfn
+ulimit -v 8388608 && build/seed/bin/sailfin emit -o /tmp/probe.ll llvm /tmp/probe.sfn
+```
+
+Confirm the construct the issue depends on can actually be **expressed and
+emitted** (not silently dropped to `null` / elided). Runtime code that calls
+a C API frequently needs a frontend capability that does not exist yet —
+e.g. taking a function's address to pass as a `pthread_create` start routine
+(the gap that broke the original #1088 pickup: its "no frontend dependency"
+premise was false, and the missing primitive surfaced reactively mid-pickup
+instead of as a planned predecessor). If the probe fails, the prerequisite
+is a **frontend issue that must be groomed first** — make it an explicit
+`Blocked by` / `Required in pinned seed` predecessor, not a surprise.
+
+### Don't over-decompose: bundle a capability with its single consumer
+
+Splitting is not free. Prefer **one issue/PR** for a compiler capability plus
+its first consumer when they are tightly coupled and one agent will work them
+together; only split when the work is genuinely independent **or** the
+capability has multiple consumers that each justify standalone shipping.
+
+The decisive sub-rule — **the seed-cut tax**: when a compiler-source change
+(lowering / parsing / typecheck / intrinsics) and its runtime/consumer change
+land as **separate releases**, the consumer cannot self-host until the
+capability is in the **pinned seed** — forcing a seed cut + `/pin-seed`
+between them (see "Seed dependencies" below). Bundling the capability and its
+consumer in **one PR avoids the seed cut entirely**: `make compile` builds the
+new compiler from the old seed, and that freshly-built compiler then compiles
+the consumer that uses the new capability — all in one self-hosting pass. So
+**splitting a capability away from its only consumer actively manufactures a
+release cycle that bundling would not need.** Factor this into every split
+decision: if a proposed split creates a seed-cut gate and there is a single
+consumer, prefer bundling.
+
 ---
 
 ## Phase 3: REVIEW WITH USER

--- a/.claude/commands/pickup.md
+++ b/.claude/commands/pickup.md
@@ -293,6 +293,30 @@ gh issue edit <N> --add-label "needs-grooming" --remove-label "in-progress"
 
 Do not silently expand scope.
 
+**When the blocker is a missing _prerequisite_ (not just a wrong scope line).**
+Sometimes the issue isn't mis-scoped — it depends on a capability that does
+not exist yet (e.g. a runtime issue that needs a frontend primitive the
+compiler can't emit). Before defaulting to a multi-issue chain (file a
+predecessor → groom → separate PR → seed cut → re-pickup), weigh the cheaper
+path:
+
+- **Single consumer + tightly coupled → propose ONE cohesive PR** that lands
+  the prerequisite *and* the original issue together, and surface the
+  **seed-cut tradeoff** to the user. Bundling a compiler-capability change
+  with its only consumer in one PR avoids the seed cut a split would force
+  (the freshly-built compiler compiles the consumer in the same self-host
+  pass — see `groom.md` "Don't over-decompose"). This is usually faster and
+  cheaper than the file/groom/PR/seed/re-pickup ceremony.
+- **Multiple consumers, or genuinely independent, or large blast radius →**
+  file the predecessor and split (the standard path). A compiler primitive
+  several future issues will want *is* worth shipping standalone.
+
+Either way, **pause and present the choice to the user** rather than silently
+picking the heavier multi-issue route — the original #1088 pickup fanned out
+into separate issues/PRs + a seed-cut gate when one bundled PR would have
+delivered the same result with less overhead. State the tradeoff; let the user
+decide.
+
 ---
 
 ## Phase 4: VERIFY ACCEPTANCE CRITERIA


### PR DESCRIPTION
## Summary
Encodes the retro from the original `/pickup 1088` into the workflow files — so the pattern is *prevented* next time, not just remembered. Same mechanism that turned the #489 "merged but not seeded" failure into `/pickup` Phase 1.5.

**What happened:** `/pickup 1088` (worker pool) was groomed with a false "no frontend dependency" premise — `pthread_create` needs a function-pointer address the frontend silently lowered to `null`. That surfaced reactively mid-pickup, then fanned out into #1142 → #1146 + #1147 (two PRs, two review cycles, a merge conflict) **and** a seed-cut gate before #1088 — when one bundled PR would have delivered the same result with less overhead and no seed cut.

## Changes (docs/workflow only — no compiler code)
- **`.claude/commands/groom.md`**
  - *Feasibility-probe gate:* runtime/FFI issues claiming "no frontend dependency" must be probed against the current seed (`sfn check` / `emit llvm` a throwaway snippet) before going `claude-ready`. A missing primitive becomes an explicit predecessor, not a mid-pickup surprise.
  - *Bundling + seed-cut-tax heuristic:* bundle a capability with its single consumer in one issue/PR; splitting a compiler-source change away from its only consumer across separate releases **manufactures** a seed cut that bundling avoids (the freshly-built compiler compiles the consumer in the same self-host pass).
- **`.claude/agents/compiler-architect.md`** — a "Decomposition Discipline" section: minimize splits, flag when bundling avoids a seed cut, don't manufacture splits, feasibility-probe FFI assumptions.
- **`.claude/commands/pickup.md`** — when a single-consumer prerequisite surfaces mid-pickup, present the one-cohesive-PR option (and the seed-cut tradeoff) instead of silently defaulting to a multi-issue chain.

## Verification
Markdown/workflow only — no `.sfn` touched, no build/test impact. Diff is +95 lines across the three governance files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RjSNQawEfpXygmAzgKMYPg)_