### PR TITLE
feat(runtime): worker pool spin-up + atomic draining shutdown (SAILFIN_THREADS)

### DIFF
--- a/compiler/tests/e2e/test_runtime_scheduler_skeleton.sh
+++ b/compiler/tests/e2e/test_runtime_scheduler_skeleton.sh
@@ -386,7 +386,7 @@ test_pool_emit_shape() {
 
     # The worker-pool surface must be defined.
     local fn
-    for fn in create shutdown worker next_task thread_count processed resolve_thread_count; do
+    for fn in create shutdown destroy worker next_task thread_count processed resolve_thread_count; do
         if ! grep -qE "^define .*@sfn_scheduler_${fn}\(" "$ll"; then
             echo "[test]   missing definition: @sfn_scheduler_${fn}"
             missing=$((missing + 1))
@@ -489,6 +489,7 @@ extern long sfn_taskqueue_count(void *q);
 
 extern void *sfn_scheduler_create(void *queue);
 extern void sfn_scheduler_shutdown(void *scheduler);
+extern void sfn_scheduler_destroy(void *scheduler);
 extern long sfn_scheduler_thread_count(void *scheduler);
 extern long sfn_scheduler_processed(void *scheduler);
 
@@ -520,7 +521,9 @@ int main(void) {
     }
 
     /* Atomic draining shutdown: must pull every queued task, then join
-     * all workers. Hangs here would mean a lost wakeup / deadlock. */
+     * all workers. Hangs here would mean a lost wakeup / deadlock. The
+     * handle stays valid after shutdown (drain+join only) — the getters
+     * below read it, then sfn_scheduler_destroy releases it. */
     sfn_scheduler_shutdown(sched);
 
     if (sfn_taskqueue_count(q) != 0) {
@@ -532,6 +535,7 @@ int main(void) {
                 sfn_scheduler_processed(sched), N);
         return 5;
     }
+    sfn_scheduler_destroy(sched);
     sfn_taskqueue_destroy(q);
 
     /* Phase 2: default sizing = min(cores, 4) when no override. */
@@ -545,10 +549,12 @@ int main(void) {
         return 7;
     }
     sfn_scheduler_shutdown(sched2);
+    sfn_scheduler_destroy(sched2);
     sfn_taskqueue_destroy(q2);
 
     /* Phase 3: null-safety. */
     sfn_scheduler_shutdown(NULL);
+    sfn_scheduler_destroy(NULL);
     if (sfn_scheduler_thread_count(NULL) != 0) {
         fprintf(stderr, "thread_count(NULL) != 0\n");
         return 8;

--- a/compiler/tests/e2e/test_runtime_scheduler_skeleton.sh
+++ b/compiler/tests/e2e/test_runtime_scheduler_skeleton.sh
@@ -9,10 +9,14 @@
 # implements the shared MPMC task queue surface
 # (`sfn_taskqueue_create/enqueue/dequeue/destroy/count`, issue #1087):
 # a mutex-guarded ring buffer with not-empty / not-full condition
-# variables for blocking dequeue/enqueue. The worker pool that
-# imports this module lands in a follow-up M4 issue, so `make
-# compile`/`make test` would not otherwise typecheck or exercise it;
-# this script keeps it from bitrotting.
+# variables for blocking dequeue/enqueue. It also implements the fixed
+# worker pool (`sfn_scheduler_create/shutdown/...`, issue #1088):
+# `pthread_create` spin-up sized to `min(cores, 4)` / `SAILFIN_THREADS`,
+# a queue-pulling worker loop, and atomic draining shutdown that joins
+# all workers. The spawn/await surface that imports this module lands in
+# a follow-up M4 issue, so `make compile`/`make test` would not
+# otherwise typecheck or exercise it; this script keeps it from
+# bitrotting.
 #
 # Acceptance:
 #   - `sfn check runtime/sfn/concurrency/scheduler.sfn` exits 0.
@@ -23,6 +27,15 @@
 #     `pthread_cond_wait` in both enqueue and dequeue).
 #   - a linked single-thread roundtrip proves FIFO ordering, ring
 #     wraparound, the create(0) capacity clamp, and null-safety.
+#   - emitted IR defines the `sfn_scheduler_*` worker-pool surface,
+#     materializes the worker entry's address as a real code pointer
+#     (`bitcast ... @sfn_scheduler_worker ... to i8*`, #1146 — not a
+#     silent null), and emits pthread_create/join/cond_broadcast,
+#     sysconf, and an atomic `store atomic i64 1` shutdown publish.
+#   - a linked multi-threaded roundtrip spins up the pool, honors
+#     SAILFIN_THREADS, drains 100 tasks through a capacity-8 ring under
+#     contention, joins cleanly (no leak, no deadlock), and verifies
+#     default `min(cores, 4)` sizing plus null-safety.
 #
 # Usage:
 #   compiler/tests/e2e/test_runtime_scheduler_skeleton.sh <compiler-binary>
@@ -232,6 +245,10 @@ extern long sfn_taskqueue_count(void *q);
 
 void sailfin_runtime_mark_persistent(void *ptr) { (void)ptr; }
 void sfn_type_register(void *desc) { (void)desc; }
+/* String literals (the SAILFIN_THREADS env name in
+ * sfn_scheduler_resolve_thread_count) lower to @sfn_alloc_struct; stub
+ * it with a plain allocator so the standalone link resolves. */
+void *sfn_alloc_struct(long n) { return calloc(1, (size_t)n); }
 
 int main(void) {
     void *q = sfn_taskqueue_create(4);
@@ -357,11 +374,221 @@ CHARNESS
     return 0
 }
 
+# ---- Test: worker-pool emitted IR shape (issue #1088) ----
+test_pool_emit_shape() {
+    local ll="$SCRATCH/scheduler.ll"
+    if [ ! -f "$ll" ]; then
+        echo "[test]   $ll missing — test_emit_shape must run first"
+        return 1
+    fi
+
+    local missing=0
+
+    # The worker-pool surface must be defined.
+    local fn
+    for fn in create shutdown worker next_task thread_count processed resolve_thread_count; do
+        if ! grep -qE "^define .*@sfn_scheduler_${fn}\(" "$ll"; then
+            echo "[test]   missing definition: @sfn_scheduler_${fn}"
+            missing=$((missing + 1))
+        fi
+    done
+
+    # The worker entry's address must materialize as a real code pointer
+    # (the #1146 fn-reference → address lowering) — NOT the silent null
+    # the frontend emitted before #1146. This is the whole reason the
+    # first pickup of #1088 halted.
+    if ! grep -qE "bitcast .*@sfn_scheduler_worker.* to i8\*" "$ll"; then
+        echo "[test]   missing 'bitcast <fnty> @sfn_scheduler_worker... to i8*' (worker fn-ref not materialized)"
+        grep -nE "sfn_scheduler_worker" "$ll" || true
+        missing=$((missing + 1))
+    fi
+
+    # Scope to the @sfn_scheduler_create body: the start_routine slot
+    # handed to pthread_create must NOT be a null — the #1146 regression.
+    local body="$SCRATCH/create.body"
+    awk '/^define .* @sfn_scheduler_create[^(]*\(/,/^}/' "$ll" > "$body"
+    if [ ! -s "$body" ]; then
+        echo "[test]   could not extract @sfn_scheduler_create body"
+        missing=$((missing + 1))
+    elif grep -qE "store i8\* null" "$body"; then
+        echo "[test]   @sfn_scheduler_create stores i8* null (worker fn-ref dropped to null):"
+        cat "$body"
+        missing=$((missing + 1))
+    fi
+
+    # pthread lifecycle: spawn, join, and the broadcast that wakes parked
+    # workers on shutdown.
+    if ! grep -qE "call i32 @pthread_create\(" "$ll"; then
+        echo "[test]   missing pthread_create call"
+        missing=$((missing + 1))
+    fi
+    if ! grep -qE "call i32 @pthread_join\(" "$ll"; then
+        echo "[test]   missing pthread_join call"
+        missing=$((missing + 1))
+    fi
+    if ! grep -qE "call i32 @pthread_cond_broadcast\(" "$ll"; then
+        echo "[test]   missing pthread_cond_broadcast (shutdown wakeup) call"
+        missing=$((missing + 1))
+    fi
+
+    # Pool sizing queries the online CPU count via sysconf.
+    if ! grep -qE "call i64 @sysconf\(" "$ll"; then
+        echo "[test]   missing sysconf (core count) call"
+        missing=$((missing + 1))
+    fi
+
+    # The atomic shutdown flag: set to 1 atomically. The ring slots store
+    # task-address *registers*, so a literal `store atomic i64 1` is
+    # specific to the shutdown publish.
+    if ! grep -qE "store atomic i64 1," "$ll"; then
+        echo "[test]   missing 'store atomic i64 1' (atomic shutdown flag publish)"
+        missing=$((missing + 1))
+    fi
+
+    return "$missing"
+}
+
+# ---- Test: multi-threaded pool spin-up / drain / join round-trip ----
+test_pool_roundtrip() {
+    local ll="$SCRATCH/scheduler.ll"
+    if [ ! -f "$ll" ]; then
+        echo "[test]   $ll missing — test_emit_shape must run first"
+        return 1
+    fi
+
+    # Same Linux-x86_64-only guard as the FIFO roundtrip: the embedded
+    # pthread handle storage is sized for glibc.
+    local host_os
+    host_os="$(uname -s)"
+    if [ "$host_os" != "Linux" ]; then
+        echo "[test]   host is $host_os, not Linux — skipping executing pool roundtrip"
+        return 0
+    fi
+
+    local harness="$SCRATCH/pool_harness.c"
+    cat > "$harness" <<'CHARNESS'
+/* Multi-threaded round-trip harness for the fixed worker pool
+ * (issue #1088). Spins up a real pthread pool, enqueues many sentinel
+ * tasks, requests an atomic draining shutdown, and asserts every task
+ * was pulled (no leak, no deadlock) and the SAILFIN_THREADS override is
+ * honored. Tasks are bare non-null sentinel addresses: task INVOCATION
+ * is the next M4 issue, so the worker only pulls + drains here.
+ *
+ * No-op stubs mirror the FIFO harness: the seed installs a
+ * persistent-pointer hook and a type-registration ctor.
+ */
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+extern void *sfn_taskqueue_create(long capacity);
+extern void sfn_taskqueue_destroy(void *q);
+extern void sfn_taskqueue_enqueue(void *q, void *task);
+extern long sfn_taskqueue_count(void *q);
+
+extern void *sfn_scheduler_create(void *queue);
+extern void sfn_scheduler_shutdown(void *scheduler);
+extern long sfn_scheduler_thread_count(void *scheduler);
+extern long sfn_scheduler_processed(void *scheduler);
+
+void sailfin_runtime_mark_persistent(void *ptr) { (void)ptr; }
+void sfn_type_register(void *desc) { (void)desc; }
+/* SAILFIN_THREADS string literal lowers to @sfn_alloc_struct. */
+void *sfn_alloc_struct(long n) { return calloc(1, (size_t)n); }
+
+int main(void) {
+    /* Phase 1: SAILFIN_THREADS override is honored. */
+    setenv("SAILFIN_THREADS", "3", 1);
+    void *q = sfn_taskqueue_create(8);
+    if (!q) { fprintf(stderr, "queue create failed\n"); return 1; }
+
+    void *sched = sfn_scheduler_create(q);
+    if (!sched) { fprintf(stderr, "scheduler create failed\n"); return 2; }
+    if (sfn_scheduler_thread_count(sched) != 3) {
+        fprintf(stderr, "SAILFIN_THREADS=3 not honored: thread_count=%ld\n",
+                sfn_scheduler_thread_count(sched));
+        return 3;
+    }
+
+    /* Enqueue more tasks than the ring holds (capacity 8, N=100): the
+     * producer blocks on a full ring while the 3 workers drain it,
+     * exercising concurrent enqueue/dequeue without deadlock. */
+    const long N = 100;
+    for (long i = 0; i < N; i++) {
+        sfn_taskqueue_enqueue(q, (void *)(uintptr_t)(0x1000 + i));
+    }
+
+    /* Atomic draining shutdown: must pull every queued task, then join
+     * all workers. Hangs here would mean a lost wakeup / deadlock. */
+    sfn_scheduler_shutdown(sched);
+
+    if (sfn_taskqueue_count(q) != 0) {
+        fprintf(stderr, "queue not drained: count=%ld\n", sfn_taskqueue_count(q));
+        return 4;
+    }
+    if (sfn_scheduler_processed(sched) != N) {
+        fprintf(stderr, "pool pulled %ld tasks, want %ld\n",
+                sfn_scheduler_processed(sched), N);
+        return 5;
+    }
+    sfn_taskqueue_destroy(q);
+
+    /* Phase 2: default sizing = min(cores, 4) when no override. */
+    unsetenv("SAILFIN_THREADS");
+    void *q2 = sfn_taskqueue_create(4);
+    void *sched2 = sfn_scheduler_create(q2);
+    if (!sched2) { fprintf(stderr, "default scheduler create failed\n"); return 6; }
+    long tc = sfn_scheduler_thread_count(sched2);
+    if (tc < 1 || tc > 4) {
+        fprintf(stderr, "default thread_count=%ld, want 1..4\n", tc);
+        return 7;
+    }
+    sfn_scheduler_shutdown(sched2);
+    sfn_taskqueue_destroy(q2);
+
+    /* Phase 3: null-safety. */
+    sfn_scheduler_shutdown(NULL);
+    if (sfn_scheduler_thread_count(NULL) != 0) {
+        fprintf(stderr, "thread_count(NULL) != 0\n");
+        return 8;
+    }
+    if (sfn_scheduler_processed(NULL) != 0) {
+        fprintf(stderr, "processed(NULL) != 0\n");
+        return 9;
+    }
+
+    return 0;
+}
+CHARNESS
+
+    local clang_bin
+    clang_bin="${CLANG:-clang}"
+    if ! command -v "$clang_bin" >/dev/null 2>&1; then
+        echo "[test]   clang not available — skipping pool roundtrip"
+        return 0
+    fi
+    local bin="$SCRATCH/pool_roundtrip"
+    if ! "$clang_bin" -Wno-override-module "$harness" "$ll" -o "$bin" -lpthread -lm 2>"$SCRATCH/pool_clang.log"; then
+        echo "[test]   clang failed to link pool harness:"
+        cat "$SCRATCH/pool_clang.log"
+        return 1
+    fi
+    if ! "$bin"; then
+        local rc=$?
+        echo "[test]   pool roundtrip binary exited non-zero (rc=$rc)"
+        return 1
+    fi
+    return 0
+}
+
 run_test "sfn check runtime/sfn/concurrency/scheduler.sfn passes" test_check_clean
 run_test "sfn fmt --check runtime/sfn/concurrency/scheduler.sfn is canonical" test_fmt_clean
 run_test "sfn emit llvm produces the sfn_taskqueue_* surface" test_emit_shape
 run_test "blocking dequeue waits on a condition under the mutex" test_dequeue_blocks_on_cond
 run_test "single-thread enqueue/dequeue is FIFO with ring wraparound" test_roundtrip_fifo
+run_test "sfn emit llvm produces the worker-pool surface (#1088)" test_pool_emit_shape
+run_test "multi-threaded pool spin-up drains the queue and joins (#1088)" test_pool_roundtrip
 
 echo "[summary] $PASS passed, $FAIL failed"
 if [ "$FAIL" -gt 0 ]; then

--- a/runtime/sfn/concurrency/scheduler.sfn
+++ b/runtime/sfn/concurrency/scheduler.sfn
@@ -427,9 +427,11 @@ fn sfn_taskqueue_count(queue: * u8) -> i64 {
 // dependency.
 fn _sfn_scheduler_struct_size() -> i64 { return 40; }
 
-// `_SC_NPROCESSORS_ONLN` on Linux glibc — the `sysconf` request for the
-// number of CPUs currently online. (macOS uses the same value; the
-// constant is the build-target's.)
+// `_SC_NPROCESSORS_ONLN` on Linux glibc (84) — the `sysconf` request for
+// the number of CPUs currently online. This is the build-target's value;
+// the constant is **not** portable: macOS/Darwin spells the same request
+// as 58, so a platform-conditional value is needed once Sailfin grows
+// `cfg`-style conditional compilation (§2.9 Q7).
 fn _sfn_scheduler_sc_nprocessors_onln() -> i32 { return 84; }
 
 // Default pool-size ceiling: `min(available_cores, 4)` per §2.6.1.
@@ -582,11 +584,11 @@ fn sfn_scheduler_create(queue: * u8) -> * u8 {
         if rc != 0 {
             // Partial spin-up: only [0, i) workers started. Shrink the
             // count to what actually launched so the shutdown join
-            // targets exactly those threads, drain + join them, then
-            // return null. `sfn_scheduler_shutdown` frees the handle and
-            // the thread array.
+            // targets exactly those threads, drain + join them, free the
+            // handle, then return null.
             sched.thread_count = i;
             sfn_scheduler_shutdown(sched_ptr);
+            sfn_scheduler_destroy(sched_ptr);
             return null;
         }
         i = i + 1;
@@ -601,9 +603,12 @@ fn sfn_scheduler_create(queue: * u8) -> * u8 {
 // and the wakeup are atomic with respect to a worker about to call
 // `pthread_cond_wait` — no worker sleeps through it. `pthread_join` is
 // the drain barrier: it returns only after each worker has emptied the
-// queue and observed the flag. Frees the scheduler handle and its
-// thread array; the queue is caller-owned and outlives the scheduler
-// (destroy it via `sfn_taskqueue_destroy`). Null-safe.
+// queue and observed the flag. The handle stays **valid** after this
+// call so the caller can read `sfn_scheduler_processed` /
+// `sfn_scheduler_thread_count`; release it with `sfn_scheduler_destroy`.
+// Call exactly once per scheduler (a second call would re-join already
+// joined threads). Null-safe; the queue is caller-owned and outlives the
+// scheduler (destroy it via `sfn_taskqueue_destroy`).
 fn sfn_scheduler_shutdown(scheduler: * u8) -> void {
     if scheduler as i64 == 0 { return; }
     let sched: * Scheduler = scheduler as * Scheduler;
@@ -624,7 +629,17 @@ fn sfn_scheduler_shutdown(scheduler: * u8) -> void {
         pthread_join(tid, null);
         i = i + 1;
     }
+}
 
+// `sfn_scheduler_destroy(scheduler)` frees the scheduler handle and its
+// `pthread_t` array. Pairs with `sfn_scheduler_create`, mirroring
+// `sfn_taskqueue_create`/`sfn_taskqueue_destroy`. The caller must
+// `sfn_scheduler_shutdown` first so no worker is still touching the
+// handle (destroying a running pool would be a use-after-free in the
+// workers). The queue is caller-owned and is NOT freed here. Null-safe.
+fn sfn_scheduler_destroy(scheduler: * u8) -> void {
+    if scheduler as i64 == 0 { return; }
+    let sched: * Scheduler = scheduler as * Scheduler;
     let threads_addr: i64 = sched.threads_addr;
     if threads_addr != 0 { free(threads_addr as * u8); }
     free(scheduler);

--- a/runtime/sfn/concurrency/scheduler.sfn
+++ b/runtime/sfn/concurrency/scheduler.sfn
@@ -7,19 +7,24 @@
 // layouts plus the opaque pthread-handle storage types; the
 // `sfn_taskqueue_*` section below implements the mutex-guarded
 // enqueue/dequeue surface that producers and consumers share. The
-// remaining runtime behaviour — worker-pool spawn/join and the
-// spawn/await surface (§2.6.2–§2.6.3) — lands in follow-up M4
-// issues and is intentionally out of scope here.
+// `sfn_scheduler_*` section spins up the fixed worker pool —
+// `pthread_create` worker loop, `min(cores, 4)` / `SAILFIN_THREADS`
+// sizing, and atomic shutdown that drains + joins (§2.6.2). The
+// remaining runtime behaviour — task invocation and the spawn/await
+// result surface (§2.6.3) — lands in follow-up M4 issues and is
+// intentionally out of scope here.
 //
 // Part of the M4 scheduler-core track (epic #965). The track has
 // no frontend dependency: every layout and operation below is
 // written against the `extern fn` pthread surface in
 // `runtime/sfn/platform/pthread.sfn` that the current seed already
-// compiles, and against atomic intrinsics (#323). The module is
-// imported nowhere yet; like the platform skeletons, it is
-// verified as a standalone typecheck + `sfn fmt` smoke target plus
-// a linked single-thread roundtrip until the worker pool consumes
-// it.
+// compiles, against atomic intrinsics (#323), and against the
+// function-reference → address lowering (#1146) the worker entry
+// needs for `pthread_create`. The module is imported nowhere yet;
+// like the platform skeletons, it is verified as a standalone
+// typecheck + `sfn fmt` smoke target plus linked single-thread
+// (queue) and multi-thread (pool) roundtrips until the spawn/await
+// surface consumes it.
 //
 // ── Pointer-as-address convention ─────────────────────────────
 // The runtime models heap pointers stored in struct fields as
@@ -131,20 +136,26 @@ struct TaskQueue {
 }
 
 // The fixed thread pool. Mirrors the §2.6.1 `Scheduler` layout.
-// `threads_addr` points at a `thread_count`-slot array of
-// `pthread_t` ids (each written by `pthread_create`; `pthread_t`
-// is pointer-sized — modelled as `usize` in `pthread.sfn`).
-// `thread_count` is the pool size, defaulting to
-// `min(available_cores, 4)` and overridable via `SAILFIN_THREADS`
-// (resolution lands with the worker pool). `queue_addr` is the
-// shared `* TaskQueue`. `shutdown` is an atomic flag (LLVM atomic
-// intrinsics): 0 = running, 1 = draining — workers observe it to
-// exit their dispatch loop.
+// `shutdown` is an atomic flag (LLVM atomic intrinsics): 0 = running,
+// 1 = draining — workers observe it to exit their dispatch loop. It is
+// deliberately the **first** field so its address equals the scheduler
+// base pointer (`scheduler as * i64`): the atomic load/store reach it
+// with no offset arithmetic, the way the queue ring reaches its slots.
+// `threads_addr` points at a `thread_count`-slot array of `pthread_t`
+// ids (each written by `pthread_create`; `pthread_t` is pointer-sized —
+// modelled as `usize` in `pthread.sfn`). `thread_count` is the pool
+// size, defaulting to `min(available_cores, 4)` and overridable via
+// `SAILFIN_THREADS` (see `sfn_scheduler_resolve_thread_count`).
+// `queue_addr` is the shared `* TaskQueue`. `processed` counts tasks
+// pulled off the queue, incremented under the queue mutex (so a plain
+// increment is race-free) — a drain witness for tests until task
+// *invocation* (§2.6.3) lands. Linux x86_64 layout: five i64s = 40 B.
 struct Scheduler {
+    shutdown: i64;
     threads_addr: i64;
     thread_count: i64;
     queue_addr: i64;
-    shutdown: i64;
+    processed: i64;
 }
 
 // ── Externs ───────────────────────────────────────────────────
@@ -181,7 +192,31 @@ extern fn pthread_cond_wait(c: * PthreadCond, m: * PthreadMutex) -> i32;
 
 extern fn pthread_cond_signal(c: * PthreadCond) -> i32;
 
+extern fn pthread_cond_broadcast(c: * PthreadCond) -> i32;
+
 extern fn pthread_cond_destroy(c: * PthreadCond) -> i32;
+
+// Thread lifecycle for the worker pool. `pthread_create` writes the new
+// `pthread_t` into the `* usize` out-slot and takes the worker entry as
+// a raw `* u8` start_routine (the address of `sfn_scheduler_worker`,
+// materialised via `<fn> as * u8` — the function-reference → address
+// lowering shipped in #1146). `pthread_join` consumes a `pthread_t` by
+// value (`usize`) and discards the worker return (`null` result). These
+// mirror `runtime/sfn/platform/pthread.sfn` exactly, so the emitted
+// `declare` shape is identical if the two modules are ever linked.
+extern fn pthread_create(thread: * usize, attr: * PthreadAttr, start: * u8, arg: * u8) -> i32;
+
+extern fn pthread_join(thread: usize, result: * * u8) -> i32;
+
+// Process/environment surface for pool sizing. `sysconf` queries the
+// online CPU count (`_SC_NPROCESSORS_ONLN`); `getenv` + `atoi` read the
+// optional `SAILFIN_THREADS` override. Same C-ABI accept-list
+// discipline (E0801–E0805) as the pthread surface above.
+extern fn sysconf(name: i32) -> i64;
+
+extern fn getenv(name: * u8) -> * u8;
+
+extern fn atoi(s: * u8) -> i32;
 
 // ── Shared MPMC task queue ────────────────────────────────────
 // The `sfn_taskqueue_*` surface implements the §2.6.1
@@ -366,4 +401,249 @@ fn sfn_taskqueue_count(queue: * u8) -> i64 {
     let live: i64 = q.count;
     pthread_mutex_unlock(q.mutex);
     return live;
+}
+
+// ── Fixed worker pool ─────────────────────────────────────────
+// Spin-up + atomic shutdown for the §2.6.1 "Fixed Thread Pool, Not
+// Work-Stealing" scheduler (issue #1088). `sfn_scheduler_create`
+// resolves the pool size, allocates the `Scheduler` plus its
+// `pthread_t` array, and `pthread_create`s one `sfn_scheduler_worker`
+// per slot — each handed the worker entry's *address*
+// (`sfn_scheduler_worker as * u8`, the #1146 function-reference →
+// address lowering) as `pthread_create`'s `start_routine`. Workers
+// block on the shared queue's `not_empty` condition until a task
+// arrives or shutdown is requested. `sfn_scheduler_shutdown` publishes
+// the atomic shutdown flag under the queue mutex, broadcasts to wake
+// every parked worker, and joins them all — draining the queue first,
+// with no leaked thread and no deadlock.
+//
+// Out of scope here (next M4 issue, #1089): task *invocation* — calling
+// `Task.fn_ptr` with `Task.ctx` and writing `Task.result` / `Task.done`
+// — which additionally needs the indirect typed-fn-pointer call
+// primitive (#1118). Until then the worker only proves spin-up + pull +
+// drain + join, recording each pull in `Scheduler.processed`.
+// `Scheduler` byte size on Linux x86_64: five `i64` fields = 40 bytes.
+// Tracks the struct above; the allocator path is the only layout
+// dependency.
+fn _sfn_scheduler_struct_size() -> i64 { return 40; }
+
+// `_SC_NPROCESSORS_ONLN` on Linux glibc — the `sysconf` request for the
+// number of CPUs currently online. (macOS uses the same value; the
+// constant is the build-target's.)
+fn _sfn_scheduler_sc_nprocessors_onln() -> i32 { return 84; }
+
+// Default pool-size ceiling: `min(available_cores, 4)` per §2.6.1.
+fn _sfn_scheduler_default_max() -> i64 { return 4; }
+
+// Sanity ceiling for an explicit `SAILFIN_THREADS` override. The value
+// is honoured verbatim up to this cap; the cap only guards against an
+// absurd request whose `count * 8` thread-array allocation would
+// overflow `i64` (mirroring the queue's capacity guard) — real pools
+// are tiny.
+fn _sfn_scheduler_max_thread_count() -> i64 { return 1024; }
+
+// Resolve the worker count. An explicit `SAILFIN_THREADS=N` (N >= 1)
+// wins, clamped to the sanity ceiling; a missing, empty, non-numeric,
+// or non-positive value falls through to `min(online_cores, 4)`. A
+// `sysconf` failure (returns -1) or a single-core box both clamp up to
+// at least one worker.
+fn sfn_scheduler_resolve_thread_count() -> i64 {
+    let s_env: string = "SAILFIN_THREADS";
+    let raw: * u8 = getenv(s_env as * u8);
+    if raw as i64 != 0 {
+        let n: i32 = atoi(raw);
+        if n >= 1 {
+            let mut requested: i64 = n as i64;
+            if requested > _sfn_scheduler_max_thread_count() {
+                requested = _sfn_scheduler_max_thread_count();
+            }
+            return requested;
+        }
+    }
+
+    let cores: i64 = sysconf(_sfn_scheduler_sc_nprocessors_onln());
+    let mut resolved: i64 = cores;
+    if resolved < 1 { resolved = 1; }
+    if resolved > _sfn_scheduler_default_max() {
+        resolved = _sfn_scheduler_default_max();
+    }
+    return resolved;
+}
+
+// `sfn_scheduler_worker(arg)` is the pthread `start_routine`. `arg` is
+// the `* u8` scheduler handle. The loop pulls tasks via
+// `sfn_scheduler_next_task` until it returns null (queue drained AND
+// shutdown requested), then exits so `pthread_join` can complete. Task
+// invocation is deferred (#1089 / #1118 — see the section header), so a
+// pulled task address is simply dropped here; the pull itself is
+// recorded in `Scheduler.processed` by `sfn_scheduler_next_task`.
+fn sfn_scheduler_worker(arg: * u8) -> * u8 {
+    let scheduler: * u8 = arg;
+    loop {
+        let task: * u8 = sfn_scheduler_next_task(scheduler);
+        if task as i64 == 0 { break; }
+    }
+    return null;
+}
+
+// Pull the next task for a worker, blocking until one is available or
+// shutdown is requested. Returns null only when the queue is empty AND
+// the shutdown flag is set — i.e. drained — so workers finish all
+// queued work before exiting. The shutdown flag is read with
+// `atomic_load` under the queue mutex; `sfn_scheduler_shutdown` sets it
+// (also under the mutex) and broadcasts `not_empty`, so a worker can
+// never sleep through the transition: it either observes `count > 0`,
+// observes `shutdown != 0`, or is parked in `pthread_cond_wait` when the
+// broadcast fires. Draining wins over shutdown — while `count > 0` a
+// worker keeps pulling regardless of the flag.
+fn sfn_scheduler_next_task(scheduler: * u8) -> * u8 {
+    if scheduler as i64 == 0 { return null; }
+    let sched: * Scheduler = scheduler as * Scheduler;
+    let q: * TaskQueue = sched.queue_addr as * TaskQueue;
+    // `shutdown` is the first Scheduler field, so its address is the
+    // scheduler base — no offset arithmetic.
+    let shutdown_slot: * i64 = scheduler as * i64;
+
+    pthread_mutex_lock(q.mutex);
+
+    loop {
+        if q.count > 0 { break; }
+        if atomic_load(shutdown_slot) != 0 {
+            pthread_mutex_unlock(q.mutex);
+            return null;
+        }
+        pthread_cond_wait(q.not_empty, q.mutex);
+    }
+
+    let slot: * i64 = (q.tasks_addr + q.head * 8) as * i64;
+    let task_addr: i64 = atomic_load(slot);
+
+    let mut next_head: i64 = q.head + 1;
+    if next_head >= q.capacity { next_head = 0; }
+    q.head = next_head;
+    q.count = q.count - 1;
+
+    // Mutex-protected, so a plain increment is race-free across workers.
+    sched.processed = sched.processed + 1;
+
+    // Wake a producer parked on a full ring (FIFO drain keeps space
+    // available even while shutting down).
+    pthread_cond_signal(q.not_full);
+    pthread_mutex_unlock(q.mutex);
+
+    return task_addr as * u8;
+}
+
+// `sfn_scheduler_create(queue)` resolves the pool size, allocates the
+// scheduler handle and its `pthread_t` array, and spawns one worker per
+// slot bound to the shared `queue` (`* u8`, re-cast to `* TaskQueue`
+// only inside this module). Returns the scheduler handle as `* u8`, or
+// null on a null queue, OOM, or a failed `pthread_create`. On a partial
+// spin-up failure it tears down the workers already running (no leak, no
+// deadlock) before freeing and returning null.
+fn sfn_scheduler_create(queue: * u8) -> * u8 {
+    if queue as i64 == 0 { return null; }
+
+    let count: i64 = sfn_scheduler_resolve_thread_count();
+
+    let sched_ptr: * u8 = malloc(_sfn_scheduler_struct_size() as usize);
+    if sched_ptr as i64 == 0 { return null; }
+
+    let threads_ptr: * u8 = malloc((count * 8) as usize);
+    if threads_ptr as i64 == 0 {
+        free(sched_ptr);
+        return null;
+    }
+
+    let sched: * Scheduler = sched_ptr as * Scheduler;
+    sched.shutdown = 0;
+    sched.threads_addr = threads_ptr as i64;
+    sched.thread_count = count;
+    sched.queue_addr = queue as i64;
+    sched.processed = 0;
+
+    // The load-bearing #1146 line: the worker entry's address must be a
+    // real code pointer, not the silent null the frontend emitted
+    // before the function-reference → address lowering landed. A null
+    // here would hand `pthread_create` a NULL start_routine (EINVAL /
+    // crash), so guard it explicitly.
+    let start: * u8 = sfn_scheduler_worker as * u8;
+    if start as i64 == 0 {
+        free(threads_ptr);
+        free(sched_ptr);
+        return null;
+    }
+
+    let mut i: i64 = 0;
+    loop {
+        if i >= count { break; }
+        let tid_slot: * usize = (sched.threads_addr + i * 8) as * usize;
+        let rc: i32 = pthread_create(tid_slot, null, start, sched_ptr);
+        if rc != 0 {
+            // Partial spin-up: only [0, i) workers started. Shrink the
+            // count to what actually launched so the shutdown join
+            // targets exactly those threads, drain + join them, then
+            // return null. `sfn_scheduler_shutdown` frees the handle and
+            // the thread array.
+            sched.thread_count = i;
+            sfn_scheduler_shutdown(sched_ptr);
+            return null;
+        }
+        i = i + 1;
+    }
+
+    return sched_ptr;
+}
+
+// `sfn_scheduler_shutdown(scheduler)` requests an atomic, draining
+// shutdown and joins every worker. It publishes the shutdown flag and
+// broadcasts both conditions **under the queue mutex**, so the flag-set
+// and the wakeup are atomic with respect to a worker about to call
+// `pthread_cond_wait` — no worker sleeps through it. `pthread_join` is
+// the drain barrier: it returns only after each worker has emptied the
+// queue and observed the flag. Frees the scheduler handle and its
+// thread array; the queue is caller-owned and outlives the scheduler
+// (destroy it via `sfn_taskqueue_destroy`). Null-safe.
+fn sfn_scheduler_shutdown(scheduler: * u8) -> void {
+    if scheduler as i64 == 0 { return; }
+    let sched: * Scheduler = scheduler as * Scheduler;
+    let q: * TaskQueue = sched.queue_addr as * TaskQueue;
+    let shutdown_slot: * i64 = scheduler as * i64;
+
+    pthread_mutex_lock(q.mutex);
+    atomic_store(shutdown_slot, 1);
+    pthread_cond_broadcast(q.not_empty);
+    pthread_cond_broadcast(q.not_full);
+    pthread_mutex_unlock(q.mutex);
+
+    let mut i: i64 = 0;
+    loop {
+        if i >= sched.thread_count { break; }
+        let tid_slot: * i64 = (sched.threads_addr + i * 8) as * i64;
+        let tid: usize = atomic_load(tid_slot) as usize;
+        pthread_join(tid, null);
+        i = i + 1;
+    }
+
+    let threads_addr: i64 = sched.threads_addr;
+    if threads_addr != 0 { free(threads_addr as * u8); }
+    free(scheduler);
+}
+
+// `sfn_scheduler_thread_count(scheduler)` reports the resolved pool
+// size. Null handle reads as 0.
+fn sfn_scheduler_thread_count(scheduler: * u8) -> i64 {
+    if scheduler as i64 == 0 { return 0; }
+    let sched: * Scheduler = scheduler as * Scheduler;
+    return sched.thread_count;
+}
+
+// `sfn_scheduler_processed(scheduler)` reports the number of tasks
+// pulled off the queue by the pool — a drain witness for tests. Safe to
+// read after `sfn_scheduler_shutdown`'s joins establish happens-before;
+// null handle reads as 0.
+fn sfn_scheduler_processed(scheduler: * u8) -> i64 {
+    if scheduler as i64 == 0 { return 0; }
+    let sched: * Scheduler = scheduler as * Scheduler;
+    return sched.processed;
 }


### PR DESCRIPTION
## Summary
- Spin up the fixed worker pool (`docs/runtime_architecture.md` §2.6.1) over the existing MPMC task queue: `sfn_scheduler_create` resolves pool size = `min(cores, 4)` via `sysconf`, honoring a `SAILFIN_THREADS=N` override, then `pthread_create`s one worker per slot bound to `sfn_scheduler_worker as * u8` — the **#1146 function-reference → address lowering** the original pickup was blocked on (no more silent `null` start_routine).
- `sfn_scheduler_shutdown` publishes an **atomic shutdown flag** and broadcasts both queue conditions under the queue mutex, then joins every worker. **Drain wins over shutdown** — workers keep pulling while `count > 0`, so all queued tasks are pulled before exit (no leak, no deadlock). Pulls recorded in `Scheduler.processed` (mutex-protected) as a drain witness.
- Task *invocation* (calling `Task.fn_ptr`) stays out of scope — next M4 issue (#1089 / #1118), exactly as the issue scopes it.

Closes #1088

## Acceptance Criteria
- [x] pool size = `min(cores, 4)`; `SAILFIN_THREADS=N` honored — `sfn_scheduler_resolve_thread_count` + e2e Phase 1/2
- [x] shutdown atomic flag drains and joins all workers (no leak, no deadlock) — e2e drains 100 tasks through a capacity-8 ring under contention, joins cleanly
- [x] `make compile` passes
- [x] `make test` passes
- [x] `sfn fmt --check` clean on every touched `.sfn`

## Verification
```
make compile                                 → pass (self-hosts)
sfn check  runtime/sfn/concurrency/scheduler.sfn   → checked 1 files: ok
sfn fmt --check runtime/.../scheduler.sfn          → clean (exit 0)
test_runtime_scheduler_skeleton.sh           → 7/7 passed
  (incl. real-pthread pool round-trip: SAILFIN_THREADS=3 honored,
   100 tasks drained, clean join, default min(cores,4), null-safety)
make test (clean re-run)                     → unit 135/135, integration 31/31,
                                               e2e 5/5, capsules 34/34, e2e-sh 110/110
```

Note: one `make test` run hit a flaky `Error 139` (SIGSEGV) in the unified `.sfn` runner with **zero failed tests reported** — not reproducible on re-run and unrelated to this change (`scheduler.sfn` is imported nowhere, so it is never compiled by the unified runner; only the scheduler `.sh` e2e exercises it, and that passes).

## Files Changed
- `runtime/sfn/concurrency/scheduler.sfn` — `sfn_scheduler_*` worker-pool surface (create/shutdown/worker/next_task/resolve_thread_count/thread_count/processed) + pthread_create/join/cond_broadcast/sysconf/getenv/atoi externs; `Scheduler` reshaped (atomic `shutdown` first → addressed with no offset math; added `processed` drain counter)
- `compiler/tests/e2e/test_runtime_scheduler_skeleton.sh` — worker-pool IR-shape assertions + multi-threaded round-trip harness

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CGQi6Vsd1C7a1h6RuSFm9x)_