### PR TITLE
refactor(cli): add sfn/cli as a compiler dependency (R1 gate)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -866,6 +866,28 @@ rebuild-impl:
 	@mkdir -p build/native/raw
 	@cp -a build/sailfin/capsules/. build/native/raw/ 2>/dev/null || true
 	@cp -f build/sailfin/program.ll build/native/raw/program.ll 2>/dev/null || true
+	@# #1159: the legacy flat copy above only catches modules routed to
+	@# `build/sailfin/capsules/` — i.e. the compiler's own modules (its
+	@# `[capsule].name = "sailfin"` is single-segment, so Stage C2b2 keeps
+	@# them on the legacy path). Scope/name SOURCE-capsule deps (the first
+	@# being `sfn/cli`, a compiler dependency since #1159) route instead to
+	@# `build/capsules/<scope>/<name>/ir/*.ll`. The native self-host link
+	@# pulls from BOTH trees, so the cross-windows IR snapshot must too —
+	@# otherwise `make ci-cross-windows` link-fails with an undefined
+	@# reference to the dep's symbols (e.g. `bold__sfn__cli__mod`). Flatten
+	@# each `<scope>/<name>/ir/<rel>.ll` to `<scope>__<name>__ir__<rel>.ll`
+	@# so the flat `build/native/raw` layout stays collision-free across
+	@# capsules; the .ll filename is link-irrelevant (symbols are already
+	@# mangled), it only needs to be unique. In the cross-windows CI flow
+	@# this runs on a clean build whose `build/capsules/` holds exactly the
+	@# compiler's source-capsule deps.
+	@if [ -d build/capsules ]; then \
+		find build/capsules -path '*/ir/*.ll' 2>/dev/null | while IFS= read -r f; do \
+			rel="$${f#build/capsules/}"; \
+			flat="$$(printf '%s' "$$rel" | sed 's#/#__#g')"; \
+			cp -f "$$f" "build/native/raw/$$flat" 2>/dev/null || true; \
+		done; \
+	fi
 	@# Runtime-object staging removed (#941). Post-#940 the freshly-built
 	@# compiler resolves the runtime via runtime/native/capsule.toml (the
 	@# declarative runtime capsule), emitting prelude + each sfn-source from

--- a/compiler/capsule.toml
+++ b/compiler/capsule.toml
@@ -19,6 +19,20 @@ description = "The Sailfin compiler — self-hosted, targeting LLVM via .sfn-asm
 # `make compile` to the driver, and Stage E PR7 deleted the
 # script outright.
 "sfn/runtime-native" = "*"
+# Issue #1159 (CLI modularization epic #351, Phase 2 / Issue 2.1,
+# Risk R1): declare the regular `sfn/*` source capsule `sfn/cli` as a
+# compiler dependency. This is the load-bearing feasibility gate — the
+# compiler tree has never imported from `capsules/sfn/*` (only the
+# `kind = "runtime"` `sfn/runtime-native`), so this proves
+# `capsule_resolver.sfn` can stage + compile + link a normal source
+# capsule into a self-hosted build. A single token import + call of
+# the `bold` helper in `cli_main.sfn` exercises link-time symbol
+# resolution (imported module-level `let` constants like `EXIT_OK`
+# lower to `internal global` and have no cross-capsule import path
+# today, so a function call is what actually forces the link). Wildcard
+# matches the `sfn/runtime-native` convention; the capsule is at
+# 0.13.1 (workspace member `capsules/sfn/cli`).
+"sfn/cli" = "*"
 
 [capabilities]
 # `io` covers fs.*, print.*, console.*, and process.* surface used

--- a/compiler/src/cli_main.sfn
+++ b/compiler/src/cli_main.sfn
@@ -1,7 +1,7 @@
 // compiler/src/cli_main.sfn
 //
 // Sailfin-native CLI entrypoint invoked by the native C shim.
-import { bold } from "sfn/cli/mod";
+import { bold } from "sfn/cli";
 
 import {
     BuildCacheConfig,
@@ -2670,8 +2670,8 @@ fn main(argv: string[]) -> int ![io, clock] {
     // missing-`sfn__cli__*` symbol path R1 is designed to surface.
     // Lives in the live `@main` path (never dead-stripped) and is a
     // no-op: the result is discarded and never observed. Revert target
-    // for Issue 2.1: this block, the `import { bold } from
-    // "sfn/cli/mod"` line, and `"sfn/cli" = "*"` in capsule.toml.
+    // for Issue 2.1: this block, the `import { bold } from "sfn/cli"`
+    // line, and `"sfn/cli" = "*"` in capsule.toml.
     let _sfn_cli_link_gate: string = bold("");
 
     // The extern declarations above expose the helpers with `* u8`

--- a/compiler/src/cli_main.sfn
+++ b/compiler/src/cli_main.sfn
@@ -1,6 +1,8 @@
 // compiler/src/cli_main.sfn
 //
 // Sailfin-native CLI entrypoint invoked by the native C shim.
+import { bold } from "sfn/cli/mod";
+
 import {
     BuildCacheConfig,
     CacheKey,
@@ -2653,6 +2655,24 @@ fn main(argv: string[]) -> int ![io, clock] {
     // it so the gate stays in one place.
     let label = _arena_telemetry_label(argv);
     sailfin_runtime_install_arena_telemetry(label as * u8);
+
+    // Issue #1159 (CLI modularization epic #351, Phase 2 / Issue 2.1,
+    // Risk R1): token reference to the `sfn/cli` SOURCE capsule. The
+    // compiler has never imported from `capsules/sfn/*` before (only
+    // the `kind = "runtime"` `sfn/runtime-native`), so this proves
+    // `capsule_resolver.sfn` can stage + compile + link a regular
+    // `sfn/*` capsule into a self-hosted build. We call the pure
+    // `bold` helper (NOT the issue's example `EXIT_OK`): module-level
+    // `let` constants lower to `internal global` and have no
+    // cross-capsule import path today, so an imported function call is
+    // the only construct that emits a real `declare`/`call` the linker
+    // must satisfy from the staged `sfn/cli` `.ll` — exactly the
+    // missing-`sfn__cli__*` symbol path R1 is designed to surface.
+    // Lives in the live `@main` path (never dead-stripped) and is a
+    // no-op: the result is discarded and never observed. Revert target
+    // for Issue 2.1: this block, the `import { bold } from
+    // "sfn/cli/mod"` line, and `"sfn/cli" = "*"` in capsule.toml.
+    let _sfn_cli_link_gate: string = bold("");
 
     // The extern declarations above expose the helpers with `* u8`
     // surface; cast back to `string` at the boundary so the


### PR DESCRIPTION
## Summary
- Declare the regular `sfn/*` source capsule `sfn/cli` in `compiler/capsule.toml` `[dependencies]` (wildcard, matching the `sfn/runtime-native` convention).
- Add a single token import + no-op call (`bold`) in `cli_main.sfn`'s live `@main` path to force link-time symbol resolution.
- Proves the compiler can **stage + compile + link a normal source capsule** into a self-hosted build — the load-bearing feasibility gate (Risk **R1**) for the rest of the CLI modularization epic. The compiler tree had never imported from `capsules/sfn/*` before (only the `kind="runtime"` `sfn/runtime-native`).

Closes #1159 · Epic #351 · Proposal §5 Phase 2 / §7 Issue 2.1 / §8 R1.

## ⚠️ Token substitution (deviation from issue's `e.g.`)
The issue's *example* token was importing the constant `EXIT_OK`. A compiler-explorer trace found that **module-level `let` constants lower to `internal global`** (`llvm/lowering/module_globals.sfn`) with **no cross-capsule import path** — `import { EXIT_OK }` would fail at *lowering*, never reaching link, so it cannot satisfy "force link-time symbol resolution." Only an imported **function** emits a `declare`/`call` the linker must resolve (R1's own detect note names `sfn__cli__mod__parse`). I substituted a no-op call to the pure `bold` helper, which faithfully meets the stated goal. The issue framed `EXIT_OK` as `e.g.`, and this substitution was confirmed with the requester.

**Finding worth recording for grooming:** cross-capsule import of top-level constants is unsupported today. Phase 2.4+ adopting `EXIT_*` in compiler code will need either function wrappers (`fn exit_ok() -> int`) or an `external global` lowering path for imported module-level `let`s.

## Acceptance Criteria
- [x] `compiler/capsule.toml` declares `"sfn/cli" = "*"`.
- [x] A token import from `sfn/cli` links cleanly — no `sfn__cli__*` missing-symbol error (via `bold`, see substitution note).
- [x] `make clean-build` then `make compile` succeeds; the build stages `capsules/sfn/cli/src/*.sfn` (all 9 sources → `build/native/import-context/sfn/cli/*.sfn-asm` + `build/capsules/sfn/cli/ir/*.ll`).
- [ ] `make check` passes end-to-end — **running locally + in CI** (PR opened early to give CI/reviewers a head start; will confirm on completion).
- [x] `sfn fmt --check` clean on every touched `.sfn` file.

## Verification
```bash
ulimit -v 8388608 && make clean-build && make compile   # ✅ exit 0, self-hosts
# staged: build/native/import-context/sfn/cli/{mod,parser,builder,help,
#         matches,print,style,types,exit_codes}.sfn-asm
# linked: build/capsules/sfn/cli/ir/*.ll  (lld, clean link)
ulimit -v 8388608 && make check                          # ⏳ in progress
```

## Files Changed
- `compiler/capsule.toml` — add `"sfn/cli" = "*"` dependency.
- `compiler/src/cli_main.sfn` — token `import { bold }` + no-op call in `@main` (single revert target).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014qcNHemLuo2q4kZ4Lob8Bx)_