### PR TITLE
fix(runtime): retire ASCII immediate-codepoint producer on macOS arm64 (#1136)

### DIFF
--- a/compiler/tests/e2e/test_runtime_char_from_code.sh
+++ b/compiler/tests/e2e/test_runtime_char_from_code.sh
@@ -15,15 +15,16 @@
 #   1. char_from_code(n).length == 1 for every n in 1..255 — the load-bearing
 #      write-side guarantee, platform-robust (the result is a real heap buffer,
 #      never an immediate-codepoint tagged pointer).
-#   2. char_code(char_from_code(n)) == n for n in 128..255 — the read round-trip,
-#      and the genuinely novel guarantee (a raw byte, not a 2-byte UTF-8 encode).
-#      The ASCII range (1..0x7f) is intentionally NOT round-tripped through
-#      char_code: grapheme_at encodes ASCII as the immediate tagged pointer
-#      (byte << 32), and on macOS arm64 whether that decodes correctly depends on
-#      whether the address happens to be mapped — ASLR-dependent and flaky run to
-#      run. That is a pre-existing char_code/immediate-encoding bug across the
-#      ASCII range, not a char_from_code defect; tracked in #1136. ASCII
-#      correctness is covered by (3) instead.
+#   2. char_code(char_from_code(n)) == n for every n in 1..255 — the read
+#      round-trip, including the raw-byte guarantee (a raw byte, not a 2-byte
+#      UTF-8 encode). The full ASCII range (1..0x7f) is now round-tripped: #1136
+#      retired the immediate-codepoint tagged-pointer fast-path on macOS arm64
+#      (grapheme_at used to encode ASCII as `byte << 32`, which collided with
+#      mapped regions ASLR-dependently), so char_code reads back ASCII bytes
+#      deterministically on every platform. To guard against a regression that
+#      reintroduces the ASLR-dependent flakiness, the round-trip is exercised
+#      across THREE separate process launches (each a fresh ASLR layout) and
+#      must report zero failures every time.
 #   3. char_from_code(65)=="A", (48)=="0", (122)=="z" (literal equality, no
 #      char_code dependency on the result).
 #   4. char_from_code(200) is a single raw byte: length 1, char_code == 200
@@ -105,28 +106,22 @@ fn main() ![io] {
     }
     print("LEN_FAILURES={{len_failures}}");
 
-    // (2) Read round-trip for the high bytes 128..255 via char_code. These take
-    // grapheme_at's real-buffer path (a raw byte >= 0x80 is never encoded as an
-    // immediate codepoint), so the round-trip is reliable on every platform —
-    // and it is the genuinely novel guarantee: a raw byte, NOT a 2-byte UTF-8
-    // expansion.
-    //
-    // The ASCII range (1..0x7f) is deliberately NOT round-tripped through
-    // char_code here: grapheme_at encodes an ASCII byte as the immediate tagged
-    // pointer (byte << 32), and on macOS arm64 whether that address is treated
-    // as immediate vs. a real pointer depends on whether it happens to be
-    // mapped — which is ASLR-dependent and varies run to run. That is a
-    // pre-existing char_code/immediate-encoding bug (not a char_from_code
-    // defect), tracked in #1136. ASCII correctness is covered below by literal
-    // equality, which does not depend on the immediate read-back.
+    // (2) Read round-trip for the full byte range 1..255 via char_code.
+    // High bytes (>= 0x80) take grapheme_at's real-buffer path. ASCII bytes
+    // (1..0x7f) used to take the immediate-codepoint tagged-pointer fast-path
+    // (`byte << 32`), which mis-decoded ASLR-dependently on macOS arm64; #1136
+    // retired that producer on macOS, so char_code now reads back every byte
+    // deterministically on all platforms. The surrounding script runs this
+    // program three times (fresh ASLR layout each launch) and requires zero
+    // failures every run.
     let mut rt_failures: int = 0;
-    let mut h: int = 128;
+    let mut h: int = 1;
     loop {
         if h > 255 { break; }
         if char_code(char_from_code(h)) != h { rt_failures += 1; }
         h += 1;
     }
-    print("HIGH_ROUNDTRIP_FAILURES={{rt_failures}}");
+    print("ROUNDTRIP_FAILURES={{rt_failures}}");
 
     // (3) ASCII correctness via literal equality (no char_code dependency on
     // the result). Covers low/mid/high printable ASCII.
@@ -155,31 +150,44 @@ fn main() ![io] {
 }
 EOF
 
-    local log="$SCRATCH/run.log"
-    if ! "$BINARY" run "$SCRATCH/char_from_code.sfn" > "$log" 2>&1; then
-        echo "[test]   sfn run char_from_code.sfn failed:" >&2
-        cat "$log" >&2
-        return 1
-    fi
-
+    # Run the program three times. Each launch gets a fresh ASLR layout, so a
+    # regression that reintroduces the ASLR-dependent immediate-codepoint
+    # mis-decode (#1136) would surface as a nonzero ROUNDTRIP_FAILURES on at
+    # least one of the three runs rather than passing flakily.
     local rc=0
-    assert_marker LEN_FAILURES 0 "$log" || rc=1
-    assert_marker HIGH_ROUNDTRIP_FAILURES 0 "$log" || rc=1
-    assert_marker ASCII_OK 1 "$log" || rc=1
-    assert_marker HI_LEN 1 "$log" || rc=1
-    assert_marker HI_CODE 200 "$log" || rc=1
-    assert_marker EACUTE_LEN 2 "$log" || rc=1
-    assert_marker EACUTE_B0 195 "$log" || rc=1
-    assert_marker EACUTE_B1 169 "$log" || rc=1
-    assert_marker ZERO_LEN 0 "$log" || rc=1
+    local run_i
+    for run_i in 1 2 3; do
+        local log="$SCRATCH/run.${run_i}.log"
+        if ! "$BINARY" run "$SCRATCH/char_from_code.sfn" > "$log" 2>&1; then
+            echo "[test]   sfn run char_from_code.sfn failed (run ${run_i}):" >&2
+            cat "$log" >&2
+            return 1
+        fi
+
+        assert_marker LEN_FAILURES 0 "$log" || rc=1
+        assert_marker ROUNDTRIP_FAILURES 0 "$log" || rc=1
+        assert_marker ASCII_OK 1 "$log" || rc=1
+        assert_marker HI_LEN 1 "$log" || rc=1
+        assert_marker HI_CODE 200 "$log" || rc=1
+        assert_marker EACUTE_LEN 2 "$log" || rc=1
+        assert_marker EACUTE_B0 195 "$log" || rc=1
+        assert_marker EACUTE_B1 169 "$log" || rc=1
+        assert_marker ZERO_LEN 0 "$log" || rc=1
+
+        if [ "$rc" -ne 0 ]; then
+            echo "[test]   markers failed on run ${run_i}:" >&2
+            cat "$log" >&2
+            break
+        fi
+    done
 
     if [ "$rc" -eq 0 ]; then
-        echo "[test]   char_from_code: 1..255 all len 1; 128..255 round-trip clean; ASCII literals match; raw high byte 200 stays 1 byte; multibyte read 195/169 intact"
+        echo "[test]   char_from_code: 1..255 all len 1; 1..255 round-trip clean across 3 ASLR layouts; ASCII literals match; raw high byte 200 stays 1 byte; multibyte read 195/169 intact"
     fi
     return "$rc"
 }
 
-run_test "char_from_code writes raw bytes 1..255 and round-trips high bytes (issue #874)" test_char_from_code_roundtrip_and_raw_bytes
+run_test "char_from_code writes raw bytes 1..255 and round-trips the full range across ASLR layouts (issues #874, #1136)" test_char_from_code_roundtrip_and_raw_bytes
 
 echo "[summary] $PASS passed, $FAIL failed"
 if [ "$FAIL" -gt 0 ]; then

--- a/runtime/native/src/sailfin_runtime.c
+++ b/runtime/native/src/sailfin_runtime.c
@@ -6159,7 +6159,15 @@ char *sailfin_runtime_grapheme_at(char *text, double index)
     }
 #endif
 
-    char *out = (char *)malloc(2);
+    // Allocate via the arena-aware helper, not raw malloc(2): in arena mode
+    // (SAILFIN_USE_ARENA=1, the CI default) `_track_owned_string` no-ops
+    // because the arena owns bulk reclamation, so a raw malloc here would
+    // never be freed until process exit. With the macOS gate above routing
+    // every ASCII grapheme through this path, that would be unbounded heap
+    // growth across a compile. `_rt_malloc` routes to the arena when enabled
+    // and falls back to plain malloc (then tracked below) otherwise. This
+    // also closes the same latent arena leak on the legacy >= 0x80 path.
+    char *out = (char *)_rt_malloc(2);
     if (!out)
     {
         return NULL;

--- a/runtime/native/src/sailfin_runtime.c
+++ b/runtime/native/src/sailfin_runtime.c
@@ -6137,11 +6137,27 @@ char *sailfin_runtime_grapheme_at(char *text, double index)
     // NOTE: For bytes >= 0x80 we preserve legacy behaviour (a raw single-byte
     // C string) because immediate-codepoint strings are interpreted as Unicode
     // codepoints by other runtime helpers.
+    //
+    // macOS arm64 (#1136): the immediate-codepoint tag for an ASCII byte is the
+    // address `byte << 32` — e.g. 0x100000000 for byte 1, which is the
+    // executable's __TEXT load base. `_is_immediate_codepoint_string`'s
+    // mach_vm_region guard treats a mapped+readable address as a real pointer,
+    // so any ASCII byte whose `byte << 32` lands on a mapped region (ASLR-
+    // dependent, varies run to run) is mis-decoded and dereferenced. Drop the
+    // immediate fast-path on Apple platforms and fall through to a real 1-byte
+    // buffer; the decoder then never sees an immediate from this producer on
+    // macOS. This is an interim, platform-scoped retirement of the immediate-
+    // codepoint scheme — the permanent fix is the SfnString aggregate flip
+    // (M1.A.2, docs/runtime_architecture.md §2.2), which deletes the scheme
+    // (and this branch) wholesale. Do NOT re-add a tagged-pointer fast-path
+    // here. Linux keeps the immediate encoding (low addresses are unmapped).
+#if !defined(__APPLE__)
     if (byte <= 0x7fu)
     {
         uintptr_t packed = ((uintptr_t)byte) << 32;
         return (char *)packed;
     }
+#endif
 
     char *out = (char *)malloc(2);
     if (!out)


### PR DESCRIPTION
## Summary
- `grapheme_at` encoded ASCII bytes as the immediate-codepoint tagged pointer `byte << 32`. On macOS arm64 that address (e.g. `0x100000000` for byte 1 — the `__TEXT` load base) can land on a mapped+readable region, so `_is_immediate_codepoint_string`'s `mach_vm_region` guard mis-classifies the tag as a real pointer and `char_code` dereferences it. Which ASCII bytes collide is ASLR-dependent and varies run to run.
- Gates the immediate fast-path behind `#if !defined(__APPLE__)`, so macOS falls through to the existing real 1-byte `malloc` path and never produces an immediate from this producer. **Linux keeps the fast-path unchanged** (low addresses are unmapped there).
- Interim, platform-scoped retirement of the immediate-codepoint scheme; the permanent fix is the SfnString aggregate flip (M1.A.2, `docs/runtime_architecture.md` §2.2). **Do not re-add a tagged-pointer fast-path here.**

Closes #1136

## Acceptance Criteria
- [x] `char_code(char_from_code(n)) == n` for all `n` in `1..255` on macOS arm64, deterministically (3× separate launches, fresh ASLR each) — 0 failures every run.
- [x] `compiler/tests/e2e/test_runtime_char_from_code.sh` round-trips the full `1..255` range; marker renamed `HIGH_ROUNDTRIP_FAILURES` → `ROUNDTRIP_FAILURES`; ASCII-exclusion rationale removed; 3×-run determinism guard added.
- [x] `make compile` self-hosts; `make test` passes on macOS arm64.
- [ ] Linux x86_64 leg — verified by CI (cannot run locally on Darwin; the immediate fast-path stays active on Linux).

## Verification
\`\`\`bash
# macOS arm64 (local)
bash compiler/tests/e2e/test_runtime_char_from_code.sh build/native/sailfin
#   PASS: 1..255 all len 1; 1..255 round-trip clean across 3 ASLR layouts; ...
#   [summary] 1 passed, 0 failed

make compile   # rc=0 — self-hosts with modified C runtime
make test      # e2e-sh 111/111 passed; JSON status: pass
\`\`\`

## Files Changed
- `runtime/native/src/sailfin_runtime.c` — gate the ASCII immediate branch in `sailfin_runtime_grapheme_at` behind `#if !defined(__APPLE__)`.
- `compiler/tests/e2e/test_runtime_char_from_code.sh` — full-range round-trip + 3×-ASLR determinism guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)