### PR TITLE
feat(resolver): consume workspace.lock ahead of capsule.lock for external deps

### DIFF
--- a/compiler/src/capsule_resolver.sfn
+++ b/compiler/src/capsule_resolver.sfn
@@ -1158,6 +1158,14 @@ fn enumerate_capsule_sources(project_root: string) -> CapsuleSource[] ![io] {
     // `sfn/strings`, #847/#846) would otherwise be reported "could not
     // locate" and its `.sfn-asm` never staged for import-signature lowering.
     let mut members: WorkspaceMember[] = [];
+    // Workspace.lock precedence (#1071): prefer workspace-level pins over
+    // capsule.lock for external deps. Parsed once here into the same
+    // `_CrDepEntry[]` shape `_cr_lookup_locked_version` consumes. An absent
+    // workspace.lock leaves `ws_has_lock` false and `ws_lock_entries` empty,
+    // making resolution byte-identical to the post-#1048 path. Sibling deps
+    // are resolved via `members` below and never consult this lockfile.
+    let mut ws_has_lock: boolean = false;
+    let mut ws_lock_entries: _CrDepEntry[] = [];
     if workspace_root.length > 0 {
         let runtime_caps = enumerate_runtime_capsule_artifacts(workspace_root, empty_specs);
         let mut rci: int = 0;
@@ -1167,6 +1175,12 @@ fn enumerate_capsule_sources(project_root: string) -> CapsuleSource[] ![io] {
             rci += 1;
         }
         members = load_workspace_members(workspace_root);
+        let ws_lock_path = _cr_path_join(workspace_root, "workspace.lock");
+        if fs.exists(ws_lock_path) {
+            let ws_lock_text = fs.readFile(ws_lock_path);
+            ws_lock_entries = _cr_parse_deps(lock_get_versions(ws_lock_text));
+            ws_has_lock = true;
+        }
     }
 
     let mut i: int = 0;
@@ -1188,11 +1202,23 @@ fn enumerate_capsule_sources(project_root: string) -> CapsuleSource[] ![io] {
             src_dir = workspace_member_for_spec(members, entry.spec);
         }
         if src_dir.length == 0 {
-            // Lockfile-pinned version wins over the capsule.toml range
-            // (#1048). Workspace siblings are resolved above and never
-            // reach this branch, so sibling resolution stays first.
+            // Lockfile-pinned version wins over the capsule.toml range.
+            // Precedence: workspace.lock (#1071) > capsule.lock (#1048) >
+            // capsule.toml range. Workspace siblings are resolved above and
+            // never reach this branch, so sibling-first resolution holds.
             let mut effective_version: string = entry.version;
-            if has_lock {
+            let mut resolved_from_lock: boolean = false;
+            if ws_has_lock {
+                let ws_locked = _cr_lookup_locked_version(ws_lock_entries, entry.spec);
+                if ws_locked.length > 0 {
+                    effective_version = ws_locked;
+                    resolved_from_lock = true;
+                }
+            }
+            // Fall back to capsule.lock only when workspace.lock did not
+            // pin this dep. The missing-from-capsule.lock diagnostic is
+            // suppressed when workspace.lock already supplied the version.
+            if !resolved_from_lock && has_lock {
                 let locked = _cr_lookup_locked_version(lock_entries, entry.spec);
                 if locked.length > 0 { effective_version = locked; } else {
                     print.err("capsule-resolver: dependency \"" + entry.spec

--- a/compiler/tests/unit/workspace_lock_precedence_test.sfn
+++ b/compiler/tests/unit/workspace_lock_precedence_test.sfn
@@ -1,0 +1,115 @@
+// Regression tests for workspace.lock precedence during capsule dependency
+// resolution (#1071). The resolver's `enumerate_capsule_sources` consults
+// `workspace.lock` ahead of `capsule.lock` for *external* deps, slotting
+// `workspace → workspace.lock → capsule.lock → cache → registry`. The
+// version-precedence rule is pure logic; it is exercised here against the
+// real lockfile parser (`lock_get_version`) without dragging in the `![io]`
+// resolver graph (which transitively imports the whole compiler via `./main`).
+//
+// `enumerate_capsule_sources` queries with the scoped `scope/name` spec, so
+// the fixtures use scoped keys (`sfn/http`) to mirror real resolver inputs.
+import { lock_get_version } from "../../src/lock";
+
+fn _str_eq(a: string, b: string) -> boolean { return strings_equal(a, b); }
+
+// Mirror of `_display_capsule_name_cmd`: strip a leading `sfn/` scope so the
+// backward-compat fallback can match older lockfiles that stored the bare
+// display name (e.g. `"http"`) instead of the scoped `"sfn/http"`.
+fn _display_name(spec: string) -> string {
+    let mut slash: int = -1;
+    let mut i: int = 0;
+    loop {
+        if i >= spec.length { break; }
+        if spec[i] == "/" {
+            slash = i;
+            break;
+        }
+        i += 1;
+    }
+    if slash > 0 {
+        let scope = substring(spec, 0, slash);
+        if strings_equal(scope, "sfn") {
+            return substring(spec, slash + 1, spec.length);
+        }
+    }
+    return spec;
+}
+
+// Mirror of `_cr_lookup_locked_version`: scoped spec first, then the bare
+// display-name fallback for older lockfiles.
+fn _lookup_locked(lock_text: string, spec: string) -> string {
+    let direct = lock_get_version(lock_text, spec);
+    if direct.length > 0 { return direct; }
+    let display = _display_name(spec);
+    if !strings_equal(display, spec) {
+        return lock_get_version(lock_text, display);
+    }
+    return "";
+}
+
+// Mirror of the external-branch precedence inlined in
+// `enumerate_capsule_sources` (#1071): workspace siblings resolve via the
+// member map first (`sibling` short-circuits the whole lock path); then
+// workspace.lock pins win over capsule.lock pins, which win over the
+// capsule.toml declared range. Returns a tag naming the winning source so
+// the sibling-first case is observable, not just the version string.
+fn _resolve(sibling: boolean, ws_has_lock: boolean, ws_lock_text: string, has_lock: boolean, lock_text: string, spec: string, declared: string) -> string {
+    if sibling { return "sibling"; }
+    if ws_has_lock {
+        let ws_locked = _lookup_locked(ws_lock_text, spec);
+        if ws_locked.length > 0 { return "workspace-lock:" + ws_locked; }
+    }
+    if has_lock {
+        let locked = _lookup_locked(lock_text, spec);
+        if locked.length > 0 { return "capsule-lock:" + locked; }
+    }
+    return "toml:" + declared;
+}
+
+// workspace.lock: pins sfn/http to 0.2.0 under the # workspace.lock banner.
+// Returned from a function rather than a top-level `let` global: module-level
+// string constants with escapes currently mislower their constant-array
+// length, so building the fixture in function scope keeps this test focused
+// on the precedence rule (mirrors lock_resolution_precedence_test.sfn).
+fn _ws_lock_fixture() -> string {
+    return "# workspace.lock\n\n[packages]\n\"sfn/http\" = \"0.2.0 sha256:ws0002\"\n";
+}
+
+// capsule.lock: pins the same dep to a *different* version (0.1.0) so the
+// lock-wins-over-capsule.lock test can distinguish the two sources.
+fn _capsule_lock_fixture() -> string {
+    return "# capsule.lock\n\n[packages]\n\"sfn/http\" = \"0.1.0 sha256:cap001\"\n";
+}
+
+test "workspace.lock pin wins over capsule.toml range" {
+    // capsule.toml says "*", workspace.lock pins 0.2.0, no capsule.lock.
+    assert _str_eq(_resolve(false, true, _ws_lock_fixture(), false, "", "sfn/http", "*"), "workspace-lock:0.2.0");
+}
+
+test "workspace.lock pin wins over capsule.lock pin" {
+    // Both lockfiles pin sfn/http to different versions; workspace.lock wins.
+    assert _str_eq(_resolve(false, true, _ws_lock_fixture(), true, _capsule_lock_fixture(), "sfn/http", "*"), "workspace-lock:0.2.0");
+}
+
+test "workspace sibling resolves via member map, never via workspace.lock" {
+    // A sibling dep is resolved by the workspace member map above the lock
+    // path, so even a present workspace.lock cannot redirect it.
+    assert _str_eq(_resolve(true, true, _ws_lock_fixture(), true, _capsule_lock_fixture(), "sfn/strings", "*"), "sibling");
+}
+
+test "absent workspace.lock falls through to capsule.lock (post-#1048 path)" {
+    // No workspace.lock present: resolution is byte-identical to the #1048
+    // capsule.lock path — capsule.lock pin still wins over the toml range.
+    assert _str_eq(_resolve(false, false, "", true, _capsule_lock_fixture(), "sfn/http", "*"), "capsule-lock:0.1.0");
+}
+
+test "absent both lockfiles falls back to declared toml range" {
+    assert _str_eq(_resolve(false, false, "", false, "", "sfn/http", "0.3.1"), "toml:0.3.1");
+}
+
+test "workspace.lock present but dep unpinned falls through to capsule.lock" {
+    // workspace.lock exists but does not pin sfn/cli; capsule.lock does not
+    // either — so the declared range is used, and capsule.lock's missing-dep
+    // diagnostic path (not modeled here) would fire.
+    assert _str_eq(_resolve(false, true, _ws_lock_fixture(), false, "", "sfn/cli", "0.4.0"), "toml:0.4.0");
+}


### PR DESCRIPTION
## Summary
- `enumerate_capsule_sources` now reads `<workspace_root>/workspace.lock` (when a workspace root is discovered) and parses it once into the `_CrDepEntry[]` shape via `lock_get_versions`.
- External (non-sibling) dep resolution applies the designed precedence `workspace.lock → capsule.lock → capsule.toml range`; an absent `workspace.lock` is a byte-identical no-op against the post-#1048 path, and the capsule.lock missing-dep diagnostic is suppressed when workspace.lock supplied the pin.
- Sibling-first resolution is untouched — workspace members resolve via the member map above this branch and never consult `workspace.lock`.

Closes #1071

## Acceptance Criteria
- [x] With a `workspace.lock` pinning an external dep, the resolver picks that version over both `capsule.lock` and the `capsule.toml` range.
- [x] With no `workspace.lock`, resolution is byte-identical to post-#1048 (existing `lock_resolution_precedence_test.sfn` still green).
- [x] Workspace sibling deps still resolve via the member map, never via `workspace.lock`.
- [x] New regression test `workspace_lock_precedence_test.sfn` covers lock-wins-over-toml, lock-wins-over-capsule.lock, sibling-still-first, absent-lock no-op (plus absent-both and unpinned-fallthrough).
- [x] `make compile` passes (with **no** root `workspace.lock` committed).
- [ ] `make check` passes — running locally; CI is the authority.
- [x] `sfn fmt --check` clean on touched files.

## Verification
```bash
ulimit -v 8388608 && make compile   # ✅ self-hosts, no root workspace.lock committed
ulimit -v 8388608 && make check     # ⏳ running locally + CI
sfn fmt --check compiler/src/capsule_resolver.sfn \
  compiler/tests/unit/workspace_lock_precedence_test.sfn   # ✅ clean
```

## Files Changed
- `compiler/src/capsule_resolver.sfn` — workspace.lock read in `enumerate_capsule_sources`; precedence in the external branch.
- `compiler/tests/unit/workspace_lock_precedence_test.sfn` — new regression coverage.

## Notes
`lock_get_versions` (in `lock.sfn`) already provided the parse path the issue listed as a touchpoint, so no change to `lock.sfn` was needed.

**Seed follow-up:** per the issue's `## Required in pinned seed`, nothing is required to land this code (the consumer no-ops when `workspace.lock` is absent), but this resolver must ship in a **pinned seed** before #1050 commits a root `workspace.lock`. A seed cut + `/pin-seed` is the gate after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EhnXC1HCdZ3xUPv9ST3tHK)_