### PR TITLE
feat(make): compose per-target agent report from tool JSON

### DIFF
--- a/docs/reference/make-result-schema.md
+++ b/docs/reference/make-result-schema.md
@@ -2,9 +2,10 @@
 
 Status: epic #1056 of `docs/proposals/agent-output-orchestration.md`. The
 always-last verdict block ships now (Phase 1, #1059). The opt-in per-target
-full report file (`build/agent-report.<target>.json`, #1119) ships as Phase 2
-scaffolding — well-formed with an empty `phases` stub; composing real per-phase
-content and precise `first_error` extraction are later phases.
+full report file (`build/agent-report.<target>.json`, #1119) carries a composed
+single-entry `phases[]` built from the matching tool JSON (#1123); the
+seven-phase `check` ledger and precise `first_error` extraction are later
+phases.
 
 Every agent-facing `make` target ends — on success **and** on failure — by
 printing a single greppable verdict block as the **last lines of its output**,
@@ -170,14 +171,42 @@ and the report's own `report` field is self-referential (it names its own path).
 `make test`) runs transparently: it emits no verdict sentinel **and** writes no
 report file, even under the gate. Only the outer target produces a report.
 
-**Shape (Phase 2 scaffolding).** The file is a single well-formed JSON object
-mirroring the verdict fields, plus a self-referential `report` and a `phases`
-array. `phases` is an **empty stub** at this stage — composing real per-phase
-content from tool JSON is a later issue.
+**Shape.** The file is a single well-formed JSON object mirroring the verdict
+fields, plus a self-referential `report` and a composed `phases` array.
 
 ```json
-{"schema_version":"sailfin-make/1","target":"compile","status":"pass","failure":null,"phase":null,"first_error":null,"report":"build/agent-report.compile.json","phases":[]}
+{"schema_version":"sailfin-make/1","target":"compile","status":"pass","failure":null,"phase":null,"first_error":null,"report":"build/agent-report.compile.json","phases":[{"name":"compile","status":"pass","report":"build/native/.build-report.json"}]}
 ```
+
+### `phases[]`
+
+For the single-tool targets, `phases` carries **one** entry composed from the
+tool JSON the Makefile teed under the same `JSON=1` gate. The seven-phase
+ledger for `make check` is a later issue; `check` gets a single synthetic entry
+here.
+
+| Field | Type | Notes |
+|---|---|---|
+| `name` | string | The phase name. Single-tool targets echo the target (`compile`, `test-unit`, `check-fast`, …); `check` is the lone synthetic `check` entry until the seven-phase ledger lands. |
+| `status` | string | `pass` \| `fail` \| `skipped`. Mirrors the verdict: `fail` when the target failed, else `pass` (a `warn` target ran every phase, so the phase is `pass`). |
+| `passed` | number | **Test targets only.** Count of passing tests, tallied from the `summary` event(s) of the `sfn test --json` jsonl (`build/agent-test.<target>.jsonl`). |
+| `failed` | number | **Test targets only.** Count of failing tests, from the same `summary` tally. |
+| `report` | string | Path to the captured tool JSON for this phase: `build/native/.build-report.json` (`compile`/`rebuild`, the `sfn build --json` BuildReport), `build/agent-test.<target>.jsonl` (test targets), or `build/agent-check-fast.json` (`check-fast`, the `sailfin-check/1` envelope). Omitted on the synthetic `check` entry, which has no single tool artifact. |
+
+**Per-target artifact map.** The composer reads the artifact captured under the
+gate by the matching Makefile wiring:
+
+| Target | Tool artifact (`report`) | Schema |
+|---|---|---|
+| `compile`, `rebuild` | `build/native/.build-report.json` | BuildReport `schema_version "1"` |
+| `test`, `test-unit`, `test-integration`, `test-e2e`, `test-capsules` | `build/agent-test.<target>.jsonl` | `sfn test --json` jsonl `schema_version 1` |
+| `check-fast` | `build/agent-check-fast.json` | `sailfin-check/1` |
+| `check` | — (synthetic single entry) | — |
+
+**Graceful degradation.** When the expected tool artifact is missing or does
+not parse, `phases` degrades to `[]` and the report keeps the verdict-derived
+top-level fields — the verdict block and the stream-after-verdict invariant are
+never broken by a missing or malformed artifact.
 
 ## Implementation
 

--- a/scripts/agent_report.sh
+++ b/scripts/agent_report.sh
@@ -213,13 +213,140 @@ json_val() {
 	printf '"%s"' "$v"
 }
 
-# --- full report file (#1119) ------------------------------------------------
-# Write a minimal, well-formed report at REPORT_PATH. Phase 2 scaffolding:
-# `phases` is an empty array stub here; issue E composes real per-phase content
-# from tool JSON. The report mirrors the verdict block's fields and adds a
-# self-referential `report` (its own path) plus `phases`. Best-effort: a write
-# failure must never break the verdict block, so it degrades silently.
+# --- tool-artifact composition (#1123) ---------------------------------------
+# Map the wrapped target to the tool JSON artifact the Makefile captured under
+# the same JSON=1 gate: the BuildReport from #1120 (compile/rebuild), the test
+# jsonl from #1121 (test*), the check-fast envelope from #1122 (check-fast).
+# Echoes the path, or empty for a target with no single-tool artifact (today
+# only `check`, whose seven-phase ledger is issue F).
+tool_artifact_path() {
+	case "$TARGET" in
+		compile | rebuild) printf '%s' "build/native/.build-report.json" ;;
+		test | test-unit | test-integration | test-e2e | test-capsules)
+			printf '%s' "build/agent-test.${TARGET}.jsonl"
+			;;
+		check-fast) printf '%s' "build/agent-check-fast.json" ;;
+		*) printf '' ;;
+	esac
+}
+
+# True for the test targets whose artifact is a `sfn test --json` jsonl stream
+# carrying `summary` events with passed/failed counters.
+is_test_target() {
+	case "$TARGET" in
+		test | test-unit | test-integration | test-e2e | test-capsules) return 0 ;;
+		*) return 1 ;;
+	esac
+}
+
+# Sum the `passed`/`failed` counters across every `summary` event in a test
+# jsonl artifact (a single invocation may emit more than one). jq when present
+# (it also validates each line); a grep/sed tally otherwise — mirroring the
+# jq-or-sed `json_field` pattern in
+# compiler/tests/e2e/test_make_result_contract.sh. Emits "<passed> <failed>" on
+# stdout, or nothing when the file carries no summary event (caller degrades to
+# phases:[]).
+tally_test_counts() {
+	local file="$1"
+	if command -v jq >/dev/null 2>&1; then
+		# -R/-n + inputs reads the file line-by-line as raw strings so a stray
+		# non-JSON banner line (none expected on the teed stream, but be
+		# defensive) is skipped via `fromjson?` rather than aborting the tally.
+		jq -rR -n '
+			[inputs | fromjson? | select(.event == "summary")] as $s
+			| if ($s | length) == 0 then empty
+			  else "\($s | map(.passed // 0) | add) \($s | map(.failed // 0) | add)"
+			  end' "$file" 2>/dev/null
+		return
+	fi
+	local passed=0 failed=0 found=0 line p f
+	while IFS= read -r line; do
+		case "$line" in
+		*'"event":"summary"'*) ;;
+		*) continue ;;
+		esac
+		found=1
+		p="$(printf '%s' "$line" | sed -nE 's/.*"passed":([0-9]+).*/\1/p')"
+		f="$(printf '%s' "$line" | sed -nE 's/.*"failed":([0-9]+).*/\1/p')"
+		[ -n "$p" ] && passed=$((passed + p))
+		[ -n "$f" ] && failed=$((failed + f))
+	done <"$file"
+	[ "$found" -eq 1 ] && printf '%s %s' "$passed" "$failed"
+}
+
+# Compose the one-element phases[] array (#1123) from the captured tool
+# artifact. Echoes a JSON array literal:
+#   - non-test target, artifact present + parseable:
+#       [{"name":<target>,"status":<s>,"report":<artifact>}]
+#   - test target, jsonl present with a summary event:
+#       [{"name":<target>,"status":<s>,"passed":N,"failed":N,"report":<jsonl>}]
+#   - `check` (no single-tool artifact): a synthetic single entry
+#       [{"name":"check","status":<s>}] — issue F expands this to seven phases.
+#   - artifact expected but missing/unparseable: "[]" (graceful degrade).
+# Phase status mirrors the verdict: "fail" when STATUS is fail, else "pass"
+# (a `warn` target — check's nondeterminism — ran every phase, so the phase
+# itself is "pass"; the warn signal lives on the top-level status).
+compose_phases() {
+	local phase_status="pass"
+	[ "$STATUS" = "fail" ] && phase_status="fail"
+	local name_json status_json
+	name_json="$(json_val "$TARGET")"
+	status_json="$(json_val "$phase_status")"
+
+	local artifact
+	artifact="$(tool_artifact_path)"
+
+	# No single-tool artifact (today: `check`). Emit a synthetic one-element
+	# phase from the verdict so the report is never empty; issue F grows this
+	# into the seven-phase ledger.
+	if [ -z "$artifact" ]; then
+		printf '[{"name":%s,"status":%s}]' "$name_json" "$status_json"
+		return
+	fi
+
+	# Artifact expected but absent: degrade to [] (e.g. an up-to-date `compile`
+	# that never rebuilt, or the missing-artifact path of AC #4).
+	if [ ! -f "$artifact" ]; then
+		printf '[]'
+		return
+	fi
+
+	if is_test_target; then
+		local counts
+		counts="$(tally_test_counts "$artifact")"
+		# No summary event -> unparseable for our purpose; degrade to [].
+		if [ -z "$counts" ]; then
+			printf '[]'
+			return
+		fi
+		local passed="${counts%% *}" failed="${counts##* }"
+		printf '[{"name":%s,"status":%s,"passed":%s,"failed":%s,"report":%s}]' \
+			"$name_json" "$status_json" "$passed" "$failed" "$(json_val "$artifact")"
+		return
+	fi
+
+	# Non-test artifact (BuildReport / check-fast envelope). Validate it parses
+	# as JSON when jq is available; degrade to [] when it doesn't.
+	if command -v jq >/dev/null 2>&1; then
+		if ! jq -e . "$artifact" >/dev/null 2>&1; then
+			printf '[]'
+			return
+		fi
+	fi
+	printf '[{"name":%s,"status":%s,"report":%s}]' \
+		"$name_json" "$status_json" "$(json_val "$artifact")"
+}
+
+# --- full report file (#1119, composed in #1123) -----------------------------
+# Write a well-formed report at REPORT_PATH mirroring the verdict block's fields
+# plus a self-referential `report` (its own path) and a composed `phases[]`. The
+# `phases[]` is a single entry derived from the matching tool artifact (#1120/
+# #1121/#1122); it degrades to `[]` when that artifact is missing or
+# unparseable. Best-effort: a write failure must never break the verdict block,
+# so it degrades silently.
 write_report_file() {
+	local phases
+	phases="$(compose_phases)"
 	{
 		printf '{"schema_version":"sailfin-make/1",'
 		printf '"target":%s,' "$(json_val "$TARGET")"
@@ -228,7 +355,7 @@ write_report_file() {
 		printf '"phase":%s,' "$(json_val "$PHASE")"
 		printf '"first_error":%s,' "$(json_val "$FIRST_ERROR")"
 		printf '"report":%s,' "$(json_val "$REPORT_PATH")"
-		printf '"phases":[]}\n'
+		printf '"phases":%s}\n' "$phases"
 	} >"$REPORT_PATH" 2>/dev/null || true
 }
 

--- a/scripts/agent_report.sh
+++ b/scripts/agent_report.sh
@@ -274,6 +274,25 @@ tally_test_counts() {
 	[ "$found" -eq 1 ] && printf '%s %s' "$passed" "$failed"
 }
 
+# Lightweight structural sanity check for a non-test JSON artifact when `jq`
+# is unavailable. jq (when present) is the real validator; this best-effort
+# fallback rejects an obviously broken artifact (empty, not a JSON object, or
+# truncated mid-stream) so a `jq`-less host still degrades to phases:[] rather
+# than dangling a `report` pointer at unparseable JSON. Returns 0 when the
+# artifact looks structurally intact, non-zero otherwise.
+artifact_looks_intact_no_jq() {
+	local file="$1" first last
+	[ -s "$file" ] || return 1
+	# A BuildReport/check envelope is a JSON object carrying schema_version.
+	first="$(head -c 1 "$file" 2>/dev/null)"
+	[ "$first" = "{" ] || return 1
+	grep -q '"schema_version"' "$file" 2>/dev/null || return 1
+	# Last non-whitespace byte is the closing brace — catches truncation.
+	last="$(tr -d '[:space:]' <"$file" 2>/dev/null | tail -c 1)"
+	[ "$last" = "}" ] || return 1
+	return 0
+}
+
 # Compose the one-element phases[] array (#1123) from the captured tool
 # artifact. Echoes a JSON array literal:
 #   - non-test target, artifact present + parseable:
@@ -326,12 +345,18 @@ compose_phases() {
 	fi
 
 	# Non-test artifact (BuildReport / check-fast envelope). Validate it parses
-	# as JSON when jq is available; degrade to [] when it doesn't.
+	# as JSON when jq is available; degrade to [] when it doesn't. Without jq,
+	# fall back to a lightweight structural check so a truncated/garbage
+	# artifact still degrades to [] rather than dangling a `report` pointer at
+	# unparseable JSON.
 	if command -v jq >/dev/null 2>&1; then
 		if ! jq -e . "$artifact" >/dev/null 2>&1; then
 			printf '[]'
 			return
 		fi
+	elif ! artifact_looks_intact_no_jq "$artifact"; then
+		printf '[]'
+		return
 	fi
 	printf '[{"name":%s,"status":%s,"report":%s}]' \
 		"$name_json" "$status_json" "$(json_val "$artifact")"


### PR DESCRIPTION
## Summary
- `scripts/agent_report.sh` now composes the real `build/agent-report.<target>.json` for the single-tool targets, replacing the empty-`phases` stub from #1119. Under the `JSON=1` gate, after classification, it reads the tool artifact the Makefile teed under the same gate and derives a one-element `phases[]` entry (`{name, status, +passed/failed for test targets, +report}`).
- Per-target artifact map: `compile`/`rebuild` → `build/native/.build-report.json` (BuildReport, #1120); `test*` → `build/agent-test.<target>.jsonl` (#1121); `check-fast` → `build/agent-check-fast.json` (#1122); `check` → a synthetic single entry (the seven-phase ledger is issue F).
- Test-target `passed`/`failed` tallied across the jsonl `summary` event(s) — `jq` when present, `grep`/`sed` fallback mirroring the `json_field` pattern in `test_make_result_contract.sh`. Missing/unparseable artifact degrades to `phases:[]` with the verdict-derived status, never breaking the verdict block or the stream-after-verdict invariant.
- Documented the composed `phases[]` shape + per-target artifact map in `docs/reference/make-result-schema.md`.

Closes #1123

## Acceptance Criteria
- [x] `JSON=1 make test-unit` → `build/agent-report.test-unit.json` has `phases[0].name=="test-unit"`, a `status`, and integer `passed`/`failed` consistent with the jsonl (verified: `passed:1452`/`failed:1`, matching the summary event).
- [x] `JSON=1 make compile` → report's `phases[0].report` points at `build/native/.build-report.json`.
- [x] Verdict block's `report` field still equals the report path; report `status`/`failure` match the verdict line.
- [x] Missing-artifact path: deleting the tool artifact before exit still yields a parseable report (`phases:[]`) and a normal verdict block — no error after the verdict.
- [ ] `make compile && make check` green — **see note below.** `make compile` is green; the full unit run surfaced **1 unrelated flaky SIGSEGV** (`Error 139`, an LLVM-lowering fatal on `Result.unwrap`) that does **not** reproduce when the Result tests run standalone. This change is pure post-test reporting shell and cannot affect test execution or exit codes; the flake is orthogonal to #1123. Leaving CI to run the full suite.

## Verification
```bash
# AC#1
JSON=1 make test-unit
jq -e '.phases[0].name=="test-unit" and (.phases[0].passed|type=="number")' build/agent-report.test-unit.json
# -> true ; report passed/failed (1452/1) == jsonl summary

# AC#2 / AC#3
FORCE=1 JSON=1 make compile
jq -e '.phases[0].report=="build/native/.build-report.json"' build/agent-report.compile.json   # true
jq -e '.report=="build/agent-report.compile.json"' build/agent-report.compile.json              # true

# AC#4 (synthetic): deleting the artifact before the wrapper's trap -> phases:[]
```
Composer logic was also unit-exercised across all target classes (test/compile/check-fast/check/missing/fail/unparseable) with synthetic artifacts; all produced well-formed, jq-parseable reports.

## Files Changed
- `scripts/agent_report.sh` — `tool_artifact_path`/`is_test_target`/`tally_test_counts`/`compose_phases` helpers; `write_report_file` now emits the composed `phases[]`.
- `docs/reference/make-result-schema.md` — composed `phases[]` shape + per-target artifact map; dropped the "empty stub" wording.

## Note on the flaky test
The `Result.unwrap` LLVM-lowering SIGSEGV appeared once in the 18-min aggregate unit run (1 of 1453 tests) but `result_enum_lowering_test`, `result_prelude_test`, and `result_enum_typecheck_test` all pass standalone — consistent with an intermittent full-suite crash, not a deterministic regression, and unrelated to this reporting-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Eqipb1U2iiChe4bvGDdh43)_