### PR TITLE
feat(runtime): task lifecycle — run via plain fn-ptr call, set done, join via cond

### DIFF
--- a/compiler/src/llvm/expression_lowering/native/core_call_lowering.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_call_lowering.sfn
@@ -3,7 +3,7 @@
 // Call lowering extracted from core.sfn.
 import { NativeFunction } from "../../../native_ir";
 import { index_of, substring } from "../../../string_utils";
-import { format_temp_name } from "../../expressions_helpers";
+import { format_temp_name, format_typed_operand } from "../../expressions_helpers";
 import { is_simple_identifier } from "../../expressions_helpers";
 import { trace_call_lowering } from "../../lowering_debug_state";
 import { find_runtime_helper, make_concat_descriptor } from "../../runtime_helpers";
@@ -23,6 +23,7 @@ import {
 import {
     ends_with,
     extend_string_array,
+    join_with_separator,
     number_to_string,
     starts_with,
     trim_text
@@ -32,11 +33,14 @@ import { array_pointer_element_type } from "../arrays";
 import { lower_expression } from "./core";
 import { coerce_and_emit_call } from "./core_call_emission";
 import {
+    _ClosureSignatureParse,
+    _parse_fn_pointer_annotation,
     resolve_call_method_target,
     resolve_call_signature,
     try_dispatch_atomic_builtin
 } from "./core_call_resolution";
 import { lower_enum_literal } from "./core_literals_lowering";
+import { coerce_operand_to_type, load_local_operand } from "./core_operands";
 import { parse_member_access } from "./core_parse";
 import { find_local_binding, find_parameter_binding, replace_llvm_operand } from "./core_scopes";
 
@@ -45,6 +49,171 @@ import { find_local_binding, find_parameter_binding, replace_llvm_operand } from
 // compiles as substring() on the wrong local variable.  Extracting the access
 // into a tiny function produces correct array-element-load LLVM IR.
 fn get_string_at(arr: string[], idx: int) -> string { return arr[idx]; }
+
+// Plain C-ABI function pointer (#1089). A value spelled `* fn (A) -> R`
+// (note the leading `*`) is a bare code pointer — NOT the closure-pair
+// `fn (A) -> R` form, which lowers to a `{i8*, i8*}` env aggregate and is
+// handled by the closure-dispatch path. The leading `*` makes the two
+// spellings structurally disjoint, so the env-prepending closure dispatch
+// never fires for a plain pointer. Returns the pointee annotation
+// (`fn (A) -> R`) when `annotation` is `* fn (...)` / `*fn(...)` in either
+// formatter spelling, or the empty string otherwise.
+fn _strip_leading_star_fn(annotation: string) -> string {
+    let trimmed = trim_text(annotation);
+    if !starts_with(trimmed, "*") { return ""; }
+    let pointee = trim_text(substring(trimmed, 1, trimmed.length));
+    if starts_with(pointee, "fn(") { return pointee; }
+    if starts_with(pointee, "fn (") { return pointee; }
+    return "";
+}
+
+// Emit an env-less indirect call through a plain C-ABI function pointer
+// (#1089). Fires when the call target names a local/parameter typed
+// `* fn (A) -> R`: loads the pointer value, bitcasts it to the typed
+// function-pointer LLVM type derived from the annotation, and emits a
+// direct `call <ret> <fnptr>(<args>)` with NO hidden environment argument
+// (contrast the closure path's `extractvalue` + env-prepended call). The
+// indirect-call emission lives behind this single seam so a future
+// non-LLVM backend has one lowering site to retarget. Returns null when
+// the target is not a plain-fn-pointer binding, so the caller falls
+// through to the normal resolution pipeline.
+fn try_lower_plain_fn_ptr_call(target: string, arguments: string[], bindings: ParameterBinding[], locals: LocalBinding[], temp_index: int, lines: string[], functions: NativeFunction[], context: TypeContext) -> ExpressionResult? ![io] {
+    let name = trim_text(target);
+    if name.length == 0 { return null; }
+    if !is_simple_identifier(name) { return null; }
+
+    let local = find_local_binding(locals, name);
+    let parameter = find_parameter_binding(bindings, name);
+    let mut annotation: string = "";
+    if local != null { annotation = local.type_annotation; } else if parameter != null {
+        annotation = parameter.type_annotation;
+    } else { return null; }
+
+    let pointee = _strip_leading_star_fn(annotation);
+    if pointee.length == 0 { return null; }
+    let parsed = _parse_fn_pointer_annotation(context, pointee);
+    if !parsed.ok { return null; }
+
+    // Arity must match the annotation exactly; a mismatch falls through to
+    // the normal pipeline (which raises the standard diagnostic) rather
+    // than emitting a call against a fabricated signature.
+    if arguments.length != parsed.parameter_types.length { return null; }
+
+    let mut diagnostics: string[] = [];
+    let mut collected_string_constants: StringConstant[] = empty_string_constant_set();
+    let mut result_lines = lines;
+    let mut result_temp: int = temp_index;
+
+    // Load the function-pointer value (a bare code pointer stored in the
+    // local/param slot).
+    let mut fn_operand: LLVMOperand? = null;
+    if local != null {
+        let load = load_local_operand(local, result_temp, result_lines);
+        fn_operand = load.operand;
+        result_lines = load.lines;
+        result_temp = load.temp_index;
+    } else if parameter != null {
+        fn_operand = LLVMOperand {
+            llvm_type: parameter.llvm_type,
+            value: parameter.llvm_name
+        };
+    }
+    if fn_operand == null { return null; }
+
+    // Lower each user argument, coercing to the annotation's parameter
+    // type so the emitted call matches the callee's real ABI.
+    let mut arg_operands: LLVMOperand[] = [];
+    let mut index: int = 0;
+    loop {
+        if index >= arguments.length { break; }
+        let argument_text = trim_text(get_string_at(arguments, index));
+        let expected_type = parsed.parameter_types[index];
+        let lowered = lower_expression(argument_text, bindings, locals, result_temp, result_lines, functions, context, expected_type);
+        diagnostics = extend_string_array(diagnostics, lowered.diagnostics);
+        collected_string_constants = merge_string_constants(collected_string_constants, lowered.string_constants);
+        result_lines = lowered.lines;
+        result_temp = lowered.temp_index;
+        if lowered.operand == null {
+            diagnostics.push("llvm lowering: failed to lower argument "
+                + number_to_string(index)
+                + " for plain function-pointer call to `"
+                + name
+                + "`");
+            return ExpressionResult {
+                lines: result_lines,
+                temp_index: result_temp,
+                operand: null,
+                diagnostics: diagnostics,
+                string_constants: collected_string_constants
+            };
+        }
+        let coerced = coerce_operand_to_type(lowered.operand, expected_type, result_temp, result_lines, false, null);
+        diagnostics = extend_string_array(diagnostics, coerced.diagnostics);
+        result_lines = coerced.lines;
+        result_temp = coerced.temp_index;
+        if coerced.operand != null { arg_operands.push(coerced.operand); } else {
+            arg_operands.push(lowered.operand);
+        }
+        index += 1;
+    }
+
+    let mut fp_param_types: string[] = [];
+    let mut _pi: int = 0;
+    loop {
+        if _pi >= parsed.parameter_types.length { break; }
+        fp_param_types.push(parsed.parameter_types[_pi]);
+        _pi += 1;
+    }
+    let fn_type = parsed.return_type + " (" + join_with_separator(fp_param_types, ", ")
+        + ")*";
+
+    // Bitcast the stored pointer value to the typed function-pointer type.
+    let typed_fn_temp = format_temp_name(result_temp);
+    result_temp += 1;
+    result_lines.push("  " + typed_fn_temp + " = bitcast " + fn_operand.llvm_type
+        + " "
+        + fn_operand.value
+        + " to "
+        + fn_type);
+
+    let mut rendered_args: string[] = [];
+    let mut _ai: int = 0;
+    loop {
+        if _ai >= arg_operands.length { break; }
+        rendered_args.push(format_typed_operand(arg_operands[_ai]));
+        _ai += 1;
+    }
+    let arg_text = join_with_separator(rendered_args, ", ");
+
+    if parsed.return_type == "void" {
+        result_lines.push("  call void " + typed_fn_temp + "(" + arg_text + ")");
+        return ExpressionResult {
+            lines: result_lines,
+            temp_index: result_temp,
+            operand: null,
+            diagnostics: diagnostics,
+            string_constants: collected_string_constants
+        };
+    }
+
+    let result_name = format_temp_name(result_temp);
+    result_lines.push("  " + result_name + " = call " + parsed.return_type + " "
+        + typed_fn_temp
+        + "("
+        + arg_text
+        + ")");
+    let call_result = LLVMOperand {
+        llvm_type: parsed.return_type,
+        value: result_name
+    };
+    return ExpressionResult {
+        lines: result_lines,
+        temp_index: result_temp + 1,
+        operand: call_result,
+        diagnostics: diagnostics,
+        string_constants: collected_string_constants
+    };
+}
 
 fn lower_call_expression(target: string, arguments: string[], bindings: ParameterBinding[], locals: LocalBinding[], temp_index: int, lines: string[], functions: NativeFunction[], context: TypeContext) -> ExpressionResult ![io] {
     let mut diagnostics: string[] = [];
@@ -68,6 +237,14 @@ fn lower_call_expression(target: string, arguments: string[], bindings: Paramete
     // entire call pipeline.
     let atomic_dispatch = try_dispatch_atomic_builtin(trimmed_target, arguments, bindings, locals, temp_index, lines, functions, context);
     if atomic_dispatch != null { return atomic_dispatch; }
+
+    // Plain C-ABI function-pointer dispatch (#1089). A call whose target is
+    // a local/parameter typed `* fn (A) -> R` is an env-less indirect call
+    // through a bare code pointer — distinct from the closure-pair path.
+    // Resolve it here, before method/closure resolution, so the call does
+    // not fall through to the "callee signature is not known" fatal.
+    let plain_fn_ptr_dispatch = try_lower_plain_fn_ptr_call(trimmed_target, arguments, bindings, locals, temp_index, lines, functions, context);
+    if plain_fn_ptr_dispatch != null { return plain_fn_ptr_dispatch; }
 
     // Check if this is an enum variant constructor call (e.g., LiteralValue.Null())
     let dot_index = index_of(trimmed_target, ".");

--- a/compiler/src/llvm/expression_lowering/native/core_call_resolution.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_call_resolution.sfn
@@ -1342,5 +1342,7 @@ export {
     resolve_call_method_target,
     resolve_parsed_method_dispatch,
     resolve_call_signature,
-    try_dispatch_atomic_builtin
+    try_dispatch_atomic_builtin,
+    _parse_fn_pointer_annotation,
+    _ClosureSignatureParse
 };

--- a/compiler/tests/e2e/fixtures/plain_fn_ptr_call.sfn
+++ b/compiler/tests/e2e/fixtures/plain_fn_ptr_call.sfn
@@ -1,0 +1,32 @@
+// Fixture for the plain C-ABI function-pointer indirect call (#1089).
+//
+// A value spelled `* fn (A) -> R` (note the leading `*`) is a bare code
+// pointer — distinct from the closure form `fn (A) -> R`, which carries a
+// `{i8*, i8*}` environment pair. Calling through such a pointer must emit
+// an env-LESS indirect call (`call <ret> <fnptr>(<args>)` with no hidden
+// environment argument), NOT the closure-dispatch `extractvalue` + env
+// sequence.
+//
+// `invoke_self` takes the address of a defined function (`worker as * u8`,
+// the #1146 fn-reference → address lowering), narrows it to an `i64`
+// (modelling the raw-address-in-a-slot convention the runtime uses), casts
+// it back to a typed `* fn (* u8) -> * u8`, and calls it. `worker` returns
+// `ctx + 1`, so `invoke_self(41)` yields `42` and `main` forwards it as the
+// process exit code — proving the forward (#1146) and inverse (#1089)
+// directions round-trip through a real executed call.
+fn worker(ctx: * u8) -> * u8 {
+    let v: i64 = ctx as i64;
+    return (v + 1) as * u8;
+}
+
+fn invoke_self(ctx: * u8) -> * u8 {
+    let code: * u8 = worker as * u8;
+    let addr: i64 = code as i64;
+    let f: * fn (* u8) -> * u8 = addr as * fn (* u8) -> * u8;
+    return f(ctx);
+}
+
+fn main() -> int {
+    let r: * u8 = invoke_self(41 as * u8);
+    return r as i64 as int;
+}

--- a/compiler/tests/e2e/test_plain_fn_ptr_call.sh
+++ b/compiler/tests/e2e/test_plain_fn_ptr_call.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# End-to-end test for the plain C-ABI function-pointer indirect call
+# (issue #1089).
+#
+# A local/parameter typed `* fn (A) -> R` is a bare code pointer. Calling
+# it must lower to an env-LESS indirect call — `bitcast` the stored pointer
+# to the typed function-pointer LLVM type, then `call <ret> <fnptr>(<args>)`
+# with NO hidden environment argument. This is the env-less sibling of the
+# closure-dispatch path (which extractvalues a `{i8*, i8*}` env pair). The
+# scheduler's task invocation (`runtime/sfn/concurrency/scheduler.sfn`) is
+# the first consumer; this fixture pins the primitive standalone.
+#
+# Acceptance:
+#   - `sfn check fixtures/plain_fn_ptr_call.sfn` exits 0.
+#   - `sfn fmt --check fixtures/plain_fn_ptr_call.sfn` exits 0.
+#   - emitted IR for @invoke_self contains a typed-fn-ptr bitcast and an
+#     env-less indirect `call i8* %tmp(i8* ...)`, and does NOT engage the
+#     closure path (no `extractvalue {i8*, i8*}`).
+#   - the program runs and exits 42 (worker(41) == 42, forwarded as the
+#     process exit code) — proving an indirect call actually executed.
+#
+# Usage:
+#   compiler/tests/e2e/test_plain_fn_ptr_call.sh <compiler-binary>
+
+set -euo pipefail
+
+BINARY="${1:?usage: test_plain_fn_ptr_call.sh <compiler-binary>}"
+BINARY="$(realpath "$BINARY")"
+PASS=0
+FAIL=0
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+FIXTURE_SRC="$REPO_ROOT/compiler/tests/e2e/fixtures/plain_fn_ptr_call.sfn"
+
+SCRATCH="$(mktemp -d -t sfn-plain-fnptr-XXXXXX)"
+trap 'rm -rf "$SCRATCH"' EXIT
+# Run from an isolated scratch dir so project-root discovery does not pick
+# up compiler/capsule.toml.
+FIXTURE="$SCRATCH/plain_fn_ptr_call.sfn"
+cp "$FIXTURE_SRC" "$FIXTURE"
+
+run_test() {
+    local name="$1"
+    shift
+    if "$@"; then
+        echo "[test] PASS: $name"
+        PASS=$((PASS + 1))
+    else
+        echo "[test] FAIL: $name"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+test_check_clean() {
+    local log="$SCRATCH/check.log"
+    if ! "$BINARY" check "$FIXTURE" > "$log" 2>&1; then
+        echo "[test]   sfn check exited non-zero on fixture:"
+        cat "$log"
+        return 1
+    fi
+    if ! grep -q "checked .* ok" "$log"; then
+        echo "[test]   sfn check did not report 'ok':"
+        cat "$log"
+        return 1
+    fi
+    return 0
+}
+
+test_fmt_clean() {
+    if ! "$BINARY" fmt --check "$FIXTURE_SRC" > /dev/null 2>&1; then
+        echo "[test]   $FIXTURE_SRC needs formatting (run: sfn fmt --write $FIXTURE_SRC)"
+        return 1
+    fi
+    return 0
+}
+
+test_emit_shape() {
+    local ll="$SCRATCH/plain.ll"
+    local log="$SCRATCH/emit.log"
+    if ! "$BINARY" emit -o "$ll" llvm "$FIXTURE" > "$log" 2>&1; then
+        echo "[test]   sfn emit llvm failed on fixture:"
+        cat "$log"
+        return 1
+    fi
+
+    local body="$SCRATCH/invoke.body"
+    awk '/^define .* @invoke_self[^(]*\(/,/^}/' "$ll" > "$body"
+    if [ ! -s "$body" ]; then
+        echo "[test]   could not extract @invoke_self body"
+        return 1
+    fi
+
+    local missing=0
+    # Typed function-pointer bitcast for the call target.
+    if ! grep -qE "bitcast .* to i8\* \(i8\*\)\*" "$body"; then
+        echo "[test]   @invoke_self missing typed plain-fn-ptr bitcast (i8* (i8*)*):"
+        cat "$body"
+        missing=$((missing + 1))
+    fi
+    # Env-less indirect call: call through an SSA temp with a single user arg.
+    if ! grep -qE "call i8\* %[a-z0-9]+\(i8\* " "$body"; then
+        echo "[test]   @invoke_self missing env-less indirect call 'call i8* %tmp(i8* ...)':"
+        cat "$body"
+        missing=$((missing + 1))
+    fi
+    # Must NOT engage the closure-pair path.
+    if grep -qE "extractvalue \{i8\*, i8\*\}" "$body"; then
+        echo "[test]   @invoke_self unexpectedly unpacks a closure env (extractvalue):"
+        cat "$body"
+        missing=$((missing + 1))
+    fi
+    return "$missing"
+}
+
+test_run_exit_code() {
+    set +e
+    "$BINARY" run "$FIXTURE" > "$SCRATCH/run.log" 2>&1
+    local rc=$?
+    set -e
+    if [ "$rc" -ne 42 ]; then
+        echo "[test]   program exit code = $rc, want 42 (indirect call did not run / wrong result):"
+        cat "$SCRATCH/run.log"
+        return 1
+    fi
+    return 0
+}
+
+run_test "sfn check fixtures/plain_fn_ptr_call.sfn passes" test_check_clean
+run_test "sfn fmt --check fixtures/plain_fn_ptr_call.sfn is canonical" test_fmt_clean
+run_test "sfn emit llvm produces an env-less indirect call" test_emit_shape
+run_test "linked program runs the indirect call and exits 42" test_run_exit_code
+
+echo "[summary] $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi

--- a/compiler/tests/e2e/test_runtime_scheduler_skeleton.sh
+++ b/compiler/tests/e2e/test_runtime_scheduler_skeleton.sh
@@ -477,7 +477,7 @@ test_task_invocation_emit_shape() {
         echo "[test]   could not extract @sfn_task_run body"
         missing=$((missing + 1))
     else
-        if ! grep -qE "bitcast \{i8\*, i8\*\}\* %[a-z0-9]+ to i8\* \(i8\*\)\*" "$run_body"; then
+        if ! grep -qE "bitcast .* to i8\* \(i8\*\)\*" "$run_body"; then
             echo "[test]   @sfn_task_run missing the typed plain-fn-ptr bitcast (i8* (i8*)*):"
             cat "$run_body"
             missing=$((missing + 1))

--- a/compiler/tests/e2e/test_runtime_scheduler_skeleton.sh
+++ b/compiler/tests/e2e/test_runtime_scheduler_skeleton.sh
@@ -448,6 +448,83 @@ test_pool_emit_shape() {
     return "$missing"
 }
 
+# ---- Test: task invocation emitted IR shape (issue #1089) ----
+test_task_invocation_emit_shape() {
+    local ll="$SCRATCH/scheduler.ll"
+    if [ ! -f "$ll" ]; then
+        echo "[test]   $ll missing — test_emit_shape must run first"
+        return 1
+    fi
+
+    local missing=0
+
+    # The task lifecycle surface must be defined.
+    local fn
+    for fn in create destroy run join; do
+        if ! grep -qE "^define .*@sfn_task_${fn}\(" "$ll"; then
+            echo "[test]   missing definition: @sfn_task_${fn}"
+            missing=$((missing + 1))
+        fi
+    done
+
+    # The worker invokes the task through a PLAIN C-ABI function pointer:
+    # an env-less indirect `call i8* %<tmp>(i8* ...)` with the typed
+    # function-pointer bitcast — and crucially NOT the closure-pair path
+    # (no `extractvalue {i8*, i8*}` env unpack in the task_run body).
+    local run_body="$SCRATCH/task_run.body"
+    awk '/^define .* @sfn_task_run[^(]*\(/,/^}/' "$ll" > "$run_body"
+    if [ ! -s "$run_body" ]; then
+        echo "[test]   could not extract @sfn_task_run body"
+        missing=$((missing + 1))
+    else
+        if ! grep -qE "bitcast \{i8\*, i8\*\}\* %[a-z0-9]+ to i8\* \(i8\*\)\*" "$run_body"; then
+            echo "[test]   @sfn_task_run missing the typed plain-fn-ptr bitcast (i8* (i8*)*):"
+            cat "$run_body"
+            missing=$((missing + 1))
+        fi
+        if ! grep -qE "call i8\* %[a-z0-9]+\(i8\* " "$run_body"; then
+            echo "[test]   @sfn_task_run missing env-less indirect call 'call i8* %tmp(i8* ...)'"
+            missing=$((missing + 1))
+        fi
+        # No closure env unpack: a plain fn pointer has no environment, so
+        # the env-prepending closure dispatch must NOT have fired.
+        if grep -qE "extractvalue \{i8\*, i8\*\}" "$run_body"; then
+            echo "[test]   @sfn_task_run unexpectedly unpacks a closure env (extractvalue):"
+            cat "$run_body"
+            missing=$((missing + 1))
+        fi
+        # done flag set atomically (seq_cst), cond signalled.
+        if ! grep -qE "store atomic i64 1, i64\* .* seq_cst" "$run_body"; then
+            echo "[test]   @sfn_task_run missing 'store atomic i64 1 ... seq_cst' (done publish)"
+            missing=$((missing + 1))
+        fi
+        if ! grep -qE "call i32 @pthread_cond_signal\(" "$run_body"; then
+            echo "[test]   @sfn_task_run missing pthread_cond_signal (wake awaiter)"
+            missing=$((missing + 1))
+        fi
+    fi
+
+    # join blocks on the done flag under the mutex: an atomic load of the
+    # done flag plus a pthread_cond_wait inside the join body.
+    local join_body="$SCRATCH/task_join.body"
+    awk '/^define .* @sfn_task_join[^(]*\(/,/^}/' "$ll" > "$join_body"
+    if [ ! -s "$join_body" ]; then
+        echo "[test]   could not extract @sfn_task_join body"
+        missing=$((missing + 1))
+    else
+        if ! grep -qE "load atomic i64, i64\* .* seq_cst" "$join_body"; then
+            echo "[test]   @sfn_task_join missing 'load atomic i64 ... seq_cst' (done poll)"
+            missing=$((missing + 1))
+        fi
+        if ! grep -qE "call i32 @pthread_cond_wait\(" "$join_body"; then
+            echo "[test]   @sfn_task_join does not block on pthread_cond_wait"
+            missing=$((missing + 1))
+        fi
+    fi
+
+    return "$missing"
+}
+
 # ---- Test: multi-threaded pool spin-up / drain / join round-trip ----
 test_pool_roundtrip() {
     local ll="$SCRATCH/scheduler.ll"
@@ -468,11 +545,12 @@ test_pool_roundtrip() {
     local harness="$SCRATCH/pool_harness.c"
     cat > "$harness" <<'CHARNESS'
 /* Multi-threaded round-trip harness for the fixed worker pool
- * (issue #1088). Spins up a real pthread pool, enqueues many sentinel
- * tasks, requests an atomic draining shutdown, and asserts every task
- * was pulled (no leak, no deadlock) and the SAILFIN_THREADS override is
- * honored. Tasks are bare non-null sentinel addresses: task INVOCATION
- * is the next M4 issue, so the worker only pulls + drains here.
+ * (issues #1088 + #1089). Spins up a real pthread pool, enqueues many
+ * real Tasks, requests an atomic draining shutdown, and asserts every
+ * task was pulled (no leak, no deadlock), the SAILFIN_THREADS override is
+ * honored, and — the #1089 lifecycle — each task's body actually RAN:
+ * the worker called fn_ptr(ctx), stored the result, set done, and a
+ * post-shutdown sfn_task_join observes the computed result.
  *
  * No-op stubs mirror the FIFO harness: the seed installs a
  * persistent-pointer hook and a type-registration ctor.
@@ -493,10 +571,21 @@ extern void sfn_scheduler_destroy(void *scheduler);
 extern long sfn_scheduler_thread_count(void *scheduler);
 extern long sfn_scheduler_processed(void *scheduler);
 
+extern void *sfn_task_create(long fn_ptr, long ctx);
+extern void sfn_task_destroy(void *task);
+extern void *sfn_task_join(void *task);
+
 void sailfin_runtime_mark_persistent(void *ptr) { (void)ptr; }
 void sfn_type_register(void *desc) { (void)desc; }
 /* SAILFIN_THREADS string literal lowers to @sfn_alloc_struct. */
 void *sfn_alloc_struct(long n) { return calloc(1, (size_t)n); }
+
+/* The worker entry the pool invokes: returns ctx + 1 so join can verify
+ * the body ran and the result round-tripped. `ctx` is threaded as an
+ * opaque pointer-sized value (#1089's `* u8`). */
+static void *task_body(void *ctx) {
+    return (void *)((long)ctx + 1);
+}
 
 int main(void) {
     /* Phase 1: SAILFIN_THREADS override is honored. */
@@ -512,18 +601,22 @@ int main(void) {
         return 3;
     }
 
-    /* Enqueue more tasks than the ring holds (capacity 8, N=100): the
-     * producer blocks on a full ring while the 3 workers drain it,
-     * exercising concurrent enqueue/dequeue without deadlock. */
+    /* Enqueue more real Tasks than the ring holds (capacity 8, N=100):
+     * the producer blocks on a full ring while the 3 workers drain and
+     * RUN each task, exercising concurrent enqueue/dequeue/invoke without
+     * deadlock. Each task body returns ctx+1. */
     const long N = 100;
+    void *tasks[100];
     for (long i = 0; i < N; i++) {
-        sfn_taskqueue_enqueue(q, (void *)(uintptr_t)(0x1000 + i));
+        tasks[i] = sfn_task_create((long)(intptr_t)&task_body, i);
+        if (!tasks[i]) { fprintf(stderr, "task create failed at %ld\n", i); return 10; }
+        sfn_taskqueue_enqueue(q, tasks[i]);
     }
 
-    /* Atomic draining shutdown: must pull every queued task, then join
-     * all workers. Hangs here would mean a lost wakeup / deadlock. The
-     * handle stays valid after shutdown (drain+join only) — the getters
-     * below read it, then sfn_scheduler_destroy releases it. */
+    /* Atomic draining shutdown: must pull AND run every queued task, then
+     * join all workers. Hangs here would mean a lost wakeup / deadlock.
+     * The handle stays valid after shutdown (drain+join only) — the
+     * getters below read it, then sfn_scheduler_destroy releases it. */
     sfn_scheduler_shutdown(sched);
 
     if (sfn_taskqueue_count(q) != 0) {
@@ -535,6 +628,19 @@ int main(void) {
                 sfn_scheduler_processed(sched), N);
         return 5;
     }
+
+    /* #1089: every task body ran and its result is readable post-join.
+     * Workers already finished (shutdown joined them), so join returns
+     * immediately with the stored result. */
+    for (long i = 0; i < N; i++) {
+        void *r = sfn_task_join(tasks[i]);
+        if ((long)r != i + 1) {
+            fprintf(stderr, "task %ld result=%ld, want %ld\n", i, (long)r, i + 1);
+            return 11;
+        }
+        sfn_task_destroy(tasks[i]);
+    }
+
     sfn_scheduler_destroy(sched);
     sfn_taskqueue_destroy(q);
 
@@ -594,7 +700,8 @@ run_test "sfn emit llvm produces the sfn_taskqueue_* surface" test_emit_shape
 run_test "blocking dequeue waits on a condition under the mutex" test_dequeue_blocks_on_cond
 run_test "single-thread enqueue/dequeue is FIFO with ring wraparound" test_roundtrip_fifo
 run_test "sfn emit llvm produces the worker-pool surface (#1088)" test_pool_emit_shape
-run_test "multi-threaded pool spin-up drains the queue and joins (#1088)" test_pool_roundtrip
+run_test "sfn emit llvm produces the task-invocation surface (#1089)" test_task_invocation_emit_shape
+run_test "multi-threaded pool runs tasks, drains, joins (#1088 + #1089)" test_pool_roundtrip
 
 echo "[summary] $PASS passed, $FAIL failed"
 if [ "$FAIL" -gt 0 ]; then

--- a/docs/runtime_architecture.md
+++ b/docs/runtime_architecture.md
@@ -887,6 +887,27 @@ a future handle.
 `sfn_await(future: SfnFuture*) -> i8*` — block on the future's condition
 variable until `done` is set. Returns the result pointer.
 
+**Implemented (M4 v0, #1089).** The task lifecycle landed in
+`runtime/sfn/concurrency/scheduler.sfn` ahead of the public `SfnFuture`
+spawn/await surface, operating directly on the `Task` struct above:
+
+- `sfn_task_create(fn_ptr: i64, ctx: i64) -> * u8` — allocate + init a
+  `Task` (mutex/cond initialised, `result`/`done` zeroed).
+- `sfn_task_run(task: * u8)` — the worker invokes `fn_ptr(ctx)`, stores
+  `result`, sets `done` (seq_cst atomic store), and signals `cond`.
+- `sfn_task_join(task: * u8) -> * u8` — block on `cond` under `mutex`
+  until `done` (seq_cst atomic load), then return `result`.
+- `sfn_task_destroy(task: * u8)` — tear down cond/mutex, free.
+
+The worker reaches `fn_ptr` through the **plain C-ABI function-pointer
+indirect call** primitive: `Task.fn_ptr` (a raw `i64` address) is cast to
+`* fn (* u8) -> * u8` and called. This `* fn (...)` spelling is a bare code
+pointer — the env-less sibling of the closure-application case epic #1118
+addresses — and lowers to a typed-fn-ptr `bitcast` + `call` with no hidden
+environment argument (see `docs/status.md`). The public
+`sfn_spawn`/`sfn_await`/`SfnFuture` wrapper builds on this surface in a
+follow-up M4 issue.
+
 #### 2.6.4 Channel
 
 ```

--- a/docs/status.md
+++ b/docs/status.md
@@ -8,6 +8,34 @@ feature availability.
 
 ## Build Pipeline (Current)
 
+- **Plain C-ABI function-pointer indirect call + scheduler task lifecycle
+  (#1089, 2026-06-07).** A value spelled `* fn (A) -> R` (leading `*`) is a
+  bare code pointer, distinct from the closure form `fn (A) -> R` (which
+  lowers to a `{i8*, i8*}` env pair). Calling through one now lowers to an
+  **env-less indirect call**: load the pointer, `bitcast` it to the typed
+  function-pointer LLVM type, and `call <ret> <fnptr>(<args>)` with **no**
+  hidden environment argument — the env-less sibling of the closure-dispatch
+  path (and the narrower, plain-pointer case of epic #1118). Implemented as a
+  single early seam, `try_lower_plain_fn_ptr_call`
+  (`llvm/expression_lowering/native/core_call_lowering.sfn`), so the indirect
+  call has one lowering site (a win for backend independence); the closure
+  path and the call-resolution structs are untouched. The two spellings are
+  structurally disjoint (closure keys on `fn (` / `fn(`; plain on `* fn`), so
+  no closure regression — verified by `test_closure_capture.sh` (6/6) and
+  `test_fn_reference_pthread.sh` (4/4, #1146). First consumer: the M4 worker
+  pool's **task lifecycle** in `runtime/sfn/concurrency/scheduler.sfn` —
+  `sfn_task_create` / `sfn_task_run` / `sfn_task_join` / `sfn_task_destroy`.
+  A worker now calls `Task.fn_ptr(Task.ctx)` through the primitive, stores
+  `Task.result`, sets the atomic `done` flag (seq_cst), and signals
+  `Task.cond`; `sfn_task_join` blocks on the cond under the mutex until
+  `done`, then returns the result. Covered by `test_plain_fn_ptr_call.sh`
+  (standalone, executed exit-42 round-trip) and an extended
+  `test_runtime_scheduler_skeleton.sh` (multi-threaded pool runs 100 real
+  tasks, joins, and verifies each result). NOTE: a latent cast-of-pointer-
+  arithmetic miscompile surfaced — `(p as i64 + N) as * T` collapses to
+  `bitcast p to *T`, dropping the offset; `scheduler.sfn` uses the proven
+  ptrtoint → add → inttoptr split to reach `Task.done` and a follow-up should
+  fix the inline form.
 - **Function-reference-as-value diagnostics (#1147, 2026-06-07).**
   Complements #1146's `<fn> as * u8` lowering by
   rejecting every *unsupported* function-reference spelling at typecheck

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,6 +1,6 @@
 # Status
 
-Updated: May 11, 2026 (Stage C complete through C4 migration; Stage D PR1–PR5 shipped; Stage E PR1–PR7 shipped; lowering temp-index recovery fix for #543 staged — PR1–1f / #254–#259, C2a / #261, C2b1 / #262, C2b2 / #263, C2c / #264, C4 v1 / #265, C4b / #266, C4 migration / #267, D PR1 / #268, D PR2 / #269, D PR3 / #271, D PR4 / #272, D PR5 / #273, E PR1 / #274, E PR2 / #277, E PR3 / #278, E PR4 / #280, E PR5 / #378, E PR6 / #382, E PR7 / #383; seed pinned to v0.5.10-alpha.13)
+Updated: June 7, 2026 (Stage C complete through C4 migration; Stage D PR1–PR5 shipped; Stage E PR1–PR7 shipped; lowering temp-index recovery fix for #543 staged — PR1–1f / #254–#259, C2a / #261, C2b1 / #262, C2b2 / #263, C2c / #264, C4 v1 / #265, C4b / #266, C4 migration / #267, D PR1 / #268, D PR2 / #269, D PR3 / #271, D PR4 / #272, D PR5 / #273, E PR1 / #274, E PR2 / #277, E PR3 / #278, E PR4 / #280, E PR5 / #378, E PR6 / #382, E PR7 / #383; seed pinned to v0.5.10-alpha.13)
 
 This document tracks what works today and what is in progress. It is the source
 of truth — consult it before editing docs, examples, or making claims about

--- a/runtime/sfn/concurrency/scheduler.sfn
+++ b/runtime/sfn/concurrency/scheduler.sfn
@@ -417,11 +417,12 @@ fn sfn_taskqueue_count(queue: * u8) -> i64 {
 // every parked worker, and joins them all — draining the queue first,
 // with no leaked thread and no deadlock.
 //
-// Out of scope here (next M4 issue, #1089): task *invocation* — calling
-// `Task.fn_ptr` with `Task.ctx` and writing `Task.result` / `Task.done`
-// — which additionally needs the indirect typed-fn-pointer call
-// primitive (#1118). Until then the worker only proves spin-up + pull +
-// drain + join, recording each pull in `Scheduler.processed`.
+// Task *invocation* (issue #1089) now lands here: a pulled task is run
+// via the `── Task lifecycle ──` surface below — the worker calls
+// `Task.fn_ptr(Task.ctx)` through the plain C-ABI function-pointer
+// primitive (`* fn (* u8) -> * u8`), stores `Task.result`, sets the
+// atomic `Task.done` flag, and signals `Task.cond` so a `sfn_task_join`
+// awaiter unblocks. `Scheduler.processed` still records each pull.
 // `Scheduler` byte size on Linux x86_64: five `i64` fields = 40 bytes.
 // Tracks the struct above; the allocator path is the only layout
 // dependency.
@@ -472,18 +473,146 @@ fn sfn_scheduler_resolve_thread_count() -> i64 {
     return resolved;
 }
 
+// ── Task lifecycle ────────────────────────────────────────────
+// Allocation, invocation, and join for a single `Task` (issue #1089,
+// §2.6.3). A producer builds a task with `sfn_task_create(fn_ptr, ctx)`,
+// enqueues its address on the shared `TaskQueue`, and later blocks in
+// `sfn_task_join` until a worker has run it. The worker runs the task
+// via `sfn_task_run`: it calls `fn_ptr(ctx)` through the plain C-ABI
+// function-pointer primitive (`* fn (* u8) -> * u8` — a bare code
+// pointer, NOT a closure pair), stores the `* u8` return into
+// `Task.result`, sets `Task.done` with a seq_cst atomic store, and
+// signals `Task.cond`. The done flag + cond/mutex live by value in the
+// `Task` (see the struct header) so no extra allocation is needed.
+// `Task` byte size on Linux x86_64 (glibc): four i64s (32 B) +
+// PthreadCond (48 B) + PthreadMutex (40 B) = 120 bytes. Tracks the
+// struct above; the allocator path is the only layout dependency.
+fn _sfn_task_struct_size() -> i64 { return 120; }
+
+// Byte offset of `Task.done` (field 4) — three leading i64s precede it.
+// `done` is reached by offset arithmetic rather than `& task.done`
+// because the borrow lowering only addresses plain locals (see the
+// `pthread.sfn` header), matching the `shutdown_slot` convention used by
+// the scheduler. The seq_cst `atomic_store` / `atomic_load` builtins
+// (#323) operate on the resulting `* i64`.
+fn _sfn_task_done_offset() -> i64 { return 24; }
+
+// `sfn_task_create(fn_ptr, ctx)` allocates a `Task`, initialises its
+// mutex and condition variable with default attributes, zeroes
+// `result`/`done`, and stores the worker entry address (`fn_ptr`, a raw
+// `fn (* u8) -> * u8` address) and captured `ctx` (`* u8`). Returns the
+// task address as `* u8` (callers re-cast to `* Task` only inside this
+// module). On a non-zero `pthread_*_init` return, tears down what was
+// initialised and returns null so no half-initialised handle escapes.
+fn sfn_task_create(fn_ptr: i64, ctx: i64) -> * u8 {
+    let task_ptr: * u8 = malloc(_sfn_task_struct_size() as usize);
+    if task_ptr as i64 == 0 { return task_ptr; }
+
+    let task: * Task = task_ptr as * Task;
+    task.fn_ptr = fn_ptr;
+    task.ctx = ctx;
+    task.result = 0;
+    task.done = 0;
+
+    let mutex_rc: i32 = pthread_mutex_init(task.mutex, null);
+    if mutex_rc != 0 {
+        free(task_ptr);
+        return null;
+    }
+    let cond_rc: i32 = pthread_cond_init(task.cond, null);
+    if cond_rc != 0 {
+        pthread_mutex_destroy(task.mutex);
+        free(task_ptr);
+        return null;
+    }
+    return task_ptr;
+}
+
+// `sfn_task_destroy(task)` tears down the cond + mutex (reverse init
+// order) and frees the task. Null-safe. The caller must ensure the task
+// has been joined (or never enqueued) so no worker still touches it.
+fn sfn_task_destroy(task: * u8) -> void {
+    if task as i64 == 0 { return; }
+    let t: * Task = task as * Task;
+    pthread_cond_destroy(t.cond);
+    pthread_mutex_destroy(t.mutex);
+    free(task);
+}
+
+// `sfn_task_run(task)` executes one pulled task: it calls
+// `fn_ptr(ctx)` through the plain C-ABI function-pointer primitive,
+// then publishes the result under `task.mutex` — store `result`, set the
+// atomic `done` flag (seq_cst), and signal `cond` to wake a parked
+// `sfn_task_join`. A null `fn_ptr` is treated as a no-op body (result
+// stays null) rather than dereferenced, so a malformed task cannot crash
+// the worker. Null-safe on the task handle.
+fn sfn_task_run(task: * u8) -> void {
+    if task as i64 == 0 { return; }
+    let t: * Task = task as * Task;
+
+    let mut result: * u8 = null;
+    if t.fn_ptr != 0 {
+        let entry: * fn (* u8) -> * u8 = t.fn_ptr as * fn (* u8) -> * u8;
+        result = entry(t.ctx as * u8);
+    }
+
+    // Split the address arithmetic across three statements: the inline
+    // `(task as i64 + off) as * i64` form miscompiles today — the cast of
+    // a parenthesised pointer-to-int + offset expression collapses to a
+    // bare `bitcast task to i64*`, silently dropping the offset. The
+    // ptrtoint → add → inttoptr split lowers correctly.
+    let done_base: i64 = task as i64;
+    let done_addr: i64 = done_base + _sfn_task_done_offset();
+    let done_slot: * i64 = done_addr as * i64;
+    pthread_mutex_lock(t.mutex);
+    t.result = result as i64;
+    atomic_store(done_slot, 1);
+    pthread_cond_signal(t.cond);
+    pthread_mutex_unlock(t.mutex);
+}
+
+// `sfn_task_join(task)` blocks until the task's worker has set `done`,
+// then returns `task.result` (`* u8`). The `done` flag is read with
+// `atomic_load` under `task.mutex`; `sfn_task_run` sets it (also under
+// the mutex) and signals `cond`, so the awaiter never sleeps through the
+// transition. The result pointer is readable post-join because the
+// store-then-signal happens-before the join's wake. Null-safe (null task
+// reads as null).
+fn sfn_task_join(task: * u8) -> * u8 {
+    if task as i64 == 0 { return null; }
+    let t: * Task = task as * Task;
+    // Split the address arithmetic across three statements: the inline
+    // `(task as i64 + off) as * i64` form miscompiles today — the cast of
+    // a parenthesised pointer-to-int + offset expression collapses to a
+    // bare `bitcast task to i64*`, silently dropping the offset. The
+    // ptrtoint → add → inttoptr split lowers correctly.
+    let done_base: i64 = task as i64;
+    let done_addr: i64 = done_base + _sfn_task_done_offset();
+    let done_slot: * i64 = done_addr as * i64;
+
+    pthread_mutex_lock(t.mutex);
+    loop {
+        if atomic_load(done_slot) != 0 { break; }
+        pthread_cond_wait(t.cond, t.mutex);
+    }
+    let result: i64 = t.result;
+    pthread_mutex_unlock(t.mutex);
+    return result as * u8;
+}
+
 // `sfn_scheduler_worker(arg)` is the pthread `start_routine`. `arg` is
 // the `* u8` scheduler handle. The loop pulls tasks via
 // `sfn_scheduler_next_task` until it returns null (queue drained AND
-// shutdown requested), then exits so `pthread_join` can complete. Task
-// invocation is deferred (#1089 / #1118 — see the section header), so a
-// pulled task address is simply dropped here; the pull itself is
+// shutdown requested), then exits so `pthread_join` can complete. Each
+// pulled task is run via `sfn_task_run` (#1089) — invoke `fn_ptr(ctx)`,
+// store the result, set `done`, signal the task cond; the pull itself is
 // recorded in `Scheduler.processed` by `sfn_scheduler_next_task`.
 fn sfn_scheduler_worker(arg: * u8) -> * u8 {
     let scheduler: * u8 = arg;
     loop {
         let task: * u8 = sfn_scheduler_next_task(scheduler);
         if task as i64 == 0 { break; }
+        sfn_task_run(task);
     }
     return null;
 }


### PR DESCRIPTION
## Summary

Completes the M4 worker-pool **task lifecycle** (#1089): a worker runs `Task.fn_ptr(Task.ctx)`, stores the result, sets the atomic `done` flag (seq_cst), and signals the task cond; `sfn_task_join` blocks on the cond under the mutex until done, then returns the result pointer.

Grooming scoped #1089 as runtime-only (`Files Affected: scheduler.sfn`), but the worker **cannot invoke `fn_ptr(ctx)` without a missing compiler primitive** — an indirect call through a plain C-ABI function pointer. Per the design gate, this ships the primitive **and** its first consumer in one cohesive PR. No seed cut is needed: `scheduler.sfn` is a runtime module compiled on-demand by the freshly-built compiler (same as #1088), which has the primitive from this PR's source in the same self-host pass.

- **Compiler primitive.** A value spelled `* fn (A) -> R` (leading `*`) is a bare code pointer, *structurally disjoint* from the closure form `fn (A) -> R` (a `{i8*, i8*}` env pair). Calling one lowers to an **env-less indirect call** — `bitcast` the stored pointer to the typed function-pointer LLVM type, then `call <ret> <fnptr>(<args>)` with **no** hidden environment argument — via a single new seam `try_lower_plain_fn_ptr_call` in `core_call_lowering.sfn`. The closure-dispatch path and the call-resolution structs are untouched (one tiny export added). This is the env-less sibling of epic **#1118** (runtime-callable *closure* application), and one indirect-call lowering site (a step toward backend independence).
- **Runtime consumer.** `sfn_task_create` / `sfn_task_run` / `sfn_task_join` / `sfn_task_destroy` in `runtime/sfn/concurrency/scheduler.sfn`; the worker invokes each pulled task through the primitive.

Closes #1089

## Acceptance Criteria

- [x] worker runs `fn_ptr(ctx)`, stores result, sets `done` (seq_cst), signals cond
- [x] join blocks until done
- [x] result pointer readable post-join
- [x] `make compile` passes (self-hosts)
- [x] targeted suites green locally (`make test` deferred to CI — see note)
- [x] `sfn fmt --check` clean on every touched `.sfn`

## Verification

```bash
ulimit -v 8388608 && make compile                                    # self-hosts (pass)
# Primitive — standalone, executed round-trip (exit 42 = worker(41)+1):
bash compiler/tests/e2e/test_plain_fn_ptr_call.sh build/native/sailfin       # 4/4
# Scheduler — IR shape + multi-threaded pool runs 100 real tasks, joins each:
bash compiler/tests/e2e/test_runtime_scheduler_skeleton.sh build/native/sailfin  # 8/8
# Non-regression:
bash compiler/tests/e2e/test_closure_capture.sh build/native/sailfin         # 6/6
bash compiler/tests/e2e/test_fn_reference_pthread.sh build/native/sailfin     # 4/4 (#1146)
```

The emitted IR for the worker invocation is an env-less plain-fn-ptr call (no closure `extractvalue`):

```llvm
%t18 = bitcast {i8*, i8*}* %t13 to i8* (i8*)*
%t19 = call i8* %t18(i8* %t17)        ; fn_ptr(ctx) — no hidden env arg
...
store atomic i64 1, i64* %t31 seq_cst, align 8   ; done
call i32 @pthread_cond_signal(%PthreadCond* %t33)
```

> **Note on `make test`:** the full suite run was interrupted when the prior session stopped; the targeted e2e suites above + self-host are green locally, and the full `make test` / `make check` are left to CI on this PR (as requested).

## Files Changed

- `compiler/src/llvm/expression_lowering/native/core_call_lowering.sfn` — `try_lower_plain_fn_ptr_call` + early dispatch
- `compiler/src/llvm/expression_lowering/native/core_call_resolution.sfn` — export `_parse_fn_pointer_annotation` / `_ClosureSignatureParse`
- `runtime/sfn/concurrency/scheduler.sfn` — `sfn_task_create/run/join/destroy` + worker invocation
- `compiler/tests/e2e/test_plain_fn_ptr_call.sh` + `fixtures/plain_fn_ptr_call.sfn` — new primitive regression test
- `compiler/tests/e2e/test_runtime_scheduler_skeleton.sh` — task-invocation IR shape + real-task pool round-trip
- `docs/status.md`, `docs/runtime_architecture.md` (§2.6.3)

## Heads-up (follow-up worthy)

A **latent cast-of-pointer-arithmetic miscompile** surfaced: `(p as i64 + N) as * T` collapses to `bitcast p to *T`, silently dropping the `+ N` offset. `scheduler.sfn` works around it with the proven `ptrtoint → add → inttoptr` split to address `Task.done`; the inline form deserves its own bug fix. Also noticed during triage: **#1142 looks like a stale duplicate of the merged #1146** (both "fn-reference → address").

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MpWKrVktLV1x8Cmgvb1Wd6)_