### PR TITLE
feat(runtime): sfn_serve accept-loop + handler dispatch on the M4 pool

### DIFF
--- a/compiler/src/llvm/expression_lowering/native/core.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core.sfn
@@ -1140,7 +1140,8 @@ fn lower_expression(expression: string, bindings: ParameterBinding[], locals: Lo
     }
 
     // ── serve(<handler>[, <port>]) ──────────────────────────────────────
-    // Lower to `sailfin_adapter_serve_start(i8* handler, i32 port)`.
+    // Lower to `sfn_serve(i8* handler, i32 port)` — the Sailfin-native
+    // server accept loop in `runtime/sfn/concurrency/serve.sfn` (#1092).
     // The serve call does not return (it runs an accept loop), so the
     // result operand is void / null.
     if starts_with(stripped, "serve(") {
@@ -1203,9 +1204,7 @@ fn lower_expression(expression: string, bindings: ParameterBinding[], locals: Lo
                         }
                     }
                 }
-                serve_lines.push("  call void @sailfin_adapter_serve_start("
-                    + handler_llvm
-                    + ", "
+                serve_lines.push("  call void @sfn_serve(" + handler_llvm + ", "
                     + port_llvm
                     + ")");
             }

--- a/compiler/src/llvm/runtime_helpers.sfn
+++ b/compiler/src/llvm/runtime_helpers.sfn
@@ -783,12 +783,20 @@ fn runtime_helper_descriptors() -> RuntimeHelperDescriptor[] {
         target: "http_post", symbol: "sfn_http_post2", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: ["net"], native_signature: "sfn_http_post2", c_abi_return_type: null
     });
 
-    // Serve adapters
+    // Serve adapters — flipped to the Sailfin-native server in
+    // `runtime/sfn/concurrency/serve.sfn` (#1092). The legacy C
+    // `symbol`s (`sailfin_adapter_serve_*`, never defined) stay for
+    // seed compat; the `native_signature` override routes calls to
+    // `sfn_serve` / `sfn_serve_handler_dispatch`. The bespoke `serve`
+    // lowering in `expression_lowering/native/core.sfn` emits the
+    // `@sfn_serve` call site directly (it does not consult this row),
+    // so the `native_signature` here keeps the registry honest with
+    // the emitted symbol.
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "serve_start", symbol: "sailfin_adapter_serve_start", return_type: "void", parameter_types: ["i8*", "i32"], effects: ["net", "io"], native_signature: null, c_abi_return_type: null
+        target: "serve_start", symbol: "sailfin_adapter_serve_start", return_type: "void", parameter_types: ["i8*", "i32"], effects: ["net", "io"], native_signature: "sfn_serve", c_abi_return_type: null
     });
     descriptors = append_runtime_helper(descriptors, RuntimeHelperDescriptor {
-        target: "serve_handler_dispatch", symbol: "sailfin_adapter_serve_handler_dispatch", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: ["net", "io"], native_signature: null, c_abi_return_type: null
+        target: "serve_handler_dispatch", symbol: "sailfin_adapter_serve_handler_dispatch", return_type: "i8*", parameter_types: ["i8*", "i8*"], effects: ["net", "io"], native_signature: "sfn_serve_handler_dispatch", c_abi_return_type: null
     });
 
     // Concurrency adapters — flipped to sfn_* symbols (#1091)

--- a/compiler/tests/e2e/test_concurrency_lowering_ir.sh
+++ b/compiler/tests/e2e/test_concurrency_lowering_ir.sh
@@ -100,21 +100,21 @@ fn main() ![io] {
         "sfn_spawn_task"
 }
 
-# serve(handler, port) → sailfin_adapter_serve_start (use-driven adapter symbol).
+# serve(handler, port) → sfn_serve (Sailfin-native server, #1092).
 test_serve_lowers_to_serve_start() {
     assert_ir_contains "serve_serve_start" \
 'fn handler() ![net, io] { }
 fn main() ![net, io] {
     serve(handler, 8080);
 }' \
-        "sailfin_adapter_serve_start"
+        "sfn_serve"
 }
 
 run_test "channel(N) lowers to sfn_channel_create (#1091)" test_channel_lowers_to_channel_create
 run_test "channel_create carries i32 capacity argument (#1091)" test_channel_create_has_i32_cap
 run_test "spawn:int lowers to sfn_spawn_int (#1090)" test_spawn_int_lowers
 run_test "parallel [task] lowers to sfn_spawn_task (#1091)" test_parallel_lowers_to_spawn_task
-run_test "serve(handler, port) lowers to sailfin_adapter_serve_start (#1085)" test_serve_lowers_to_serve_start
+run_test "serve(handler, port) lowers to sfn_serve (#1092)" test_serve_lowers_to_serve_start
 
 echo "[summary] $PASS passed, $FAIL failed"
 if [ "$FAIL" -gt 0 ]; then

--- a/compiler/tests/e2e/test_runtime_serve.sh
+++ b/compiler/tests/e2e/test_runtime_serve.sh
@@ -1,0 +1,248 @@
+#!/usr/bin/env bash
+# End-to-end test for runtime/sfn/concurrency/serve.sfn — the
+# Sailfin-native `serve` HTTP/1.1 server (M4 #1092, epic #965).
+# Replaces the no-op C stub / never-defined sailfin_adapter_serve_*
+# symbols with a real blocking accept-loop that dispatches each
+# connection to the M4.1 thread pool (HTTP only, no TLS, no async).
+#
+# Mirrors test_runtime_adapter_http.sh's structure, inverted to the
+# server side: typecheck + fmt + emit-shape on the source module, an
+# IR routing probe that `serve(handler, port)` lowers to `@sfn_serve`
+# (not the legacy `@sailfin_adapter_serve_start`), and a behavioral
+# loopback round-trip — a real HTTP request from a Python client
+# against an in-process Sailfin server through the `sfn run` link
+# path.
+#
+# Usage:
+#   compiler/tests/e2e/test_runtime_serve.sh <compiler-binary>
+
+set -euo pipefail
+
+BINARY="${1:?usage: test_runtime_serve.sh <compiler-binary>}"
+BINARY="$(realpath "$BINARY")"
+PASS=0
+FAIL=0
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+MODULE="$REPO_ROOT/runtime/sfn/concurrency/serve.sfn"
+
+SCRATCH="$(mktemp -d -t sfn-runtime-serve-XXXXXX)"
+SERVER_PID=""
+cleanup() {
+    if [ -n "$SERVER_PID" ]; then
+        kill "$SERVER_PID" 2>/dev/null || true
+        wait "$SERVER_PID" 2>/dev/null || true
+    fi
+    rm -rf "$SCRATCH"
+}
+trap cleanup EXIT
+
+run_test() {
+    local name="$1"
+    shift
+    if "$@"; then
+        echo "[test] PASS: $name"
+        PASS=$((PASS + 1))
+    else
+        echo "[test] FAIL: $name"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# ---- Test: source module typechecks cleanly ----
+test_check_clean() {
+    local log="$SCRATCH/check.log"
+    if ! "$BINARY" check "$MODULE" > "$log" 2>&1; then
+        echo "[test]   sfn check exited non-zero on serve.sfn:"
+        cat "$log"
+        return 1
+    fi
+    if ! grep -q "checked .* ok" "$log"; then
+        echo "[test]   sfn check did not report 'ok':"
+        cat "$log"
+        return 1
+    fi
+    return 0
+}
+
+# ---- Test: source module is fmt-canonical ----
+test_fmt_clean() {
+    if ! "$BINARY" fmt --check "$MODULE" > /dev/null 2>&1; then
+        echo "[test]   $MODULE needs formatting (run: sfn fmt --write $MODULE)"
+        return 1
+    fi
+    return 0
+}
+
+# ---- Test: emitted IR carries a `define` for the serve exports ----
+test_emit_define_shape() {
+    local ll="$SCRATCH/serve.ll"
+    local log="$SCRATCH/emit.log"
+    if ! "$BINARY" emit -o "$ll" llvm "$MODULE" > "$log" 2>&1; then
+        echo "[test]   sfn emit llvm failed on runtime/sfn/concurrency/serve.sfn:"
+        cat "$log"
+        return 1
+    fi
+    local missing=0
+    for sym in sfn_serve sfn_serve_handler_dispatch; do
+        if ! grep -qE "^define .* @${sym}\(" "$ll"; then
+            echo "[test]   missing 'define ... @${sym}(' in serve.ll"
+            missing=$((missing + 1))
+        fi
+    done
+    # The BSD-sockets server surface must lower to libc declares.
+    for sym in socket bind listen accept send recv close; do
+        if ! grep -qE "^declare .* @${sym}\(" "$ll"; then
+            echo "[test]   missing 'declare ... @${sym}(' in serve.ll"
+            missing=$((missing + 1))
+        fi
+    done
+    # The pool-dispatch path must reference the scheduler externs.
+    for sym in sfn_taskqueue_create sfn_task_create sfn_taskqueue_enqueue sfn_scheduler_create; do
+        if ! grep -qE "@${sym}\(" "$ll"; then
+            echo "[test]   missing reference to @${sym}( in serve.ll"
+            missing=$((missing + 1))
+        fi
+    done
+    return "$missing"
+}
+
+# ---- Test: compiled probe routes serve(handler, port) → @sfn_serve ----
+test_probe_flipped() {
+    local probe="$SCRATCH/serve_probe.sfn"
+    cat > "$probe" <<'PROBE'
+fn handle(req: string) -> string {
+    return "ok";
+}
+
+fn main() -> int ![net, io] {
+    serve(handle, 8080);
+    return 0;
+}
+PROBE
+    local ll="$SCRATCH/serve_probe.ll"
+    local log="$SCRATCH/serve_probe.log"
+    if ! "$BINARY" emit -o "$ll" llvm "$probe" > "$log" 2>&1; then
+        echo "[test]   sfn emit llvm failed on serve_probe.sfn:"
+        cat "$log"
+        return 1
+    fi
+    local missing=0
+    # Anchor on a non-identifier follow char (portable across GNU/BSD
+    # grep — see the http adapter test for the `\b` caveat).
+    if ! grep -qE "call void @sfn_serve\(" "$ll"; then
+        echo "[test]   serve_probe.sfn does not lower to a @sfn_serve call"
+        missing=$((missing + 1))
+    fi
+    # Legacy never-defined adapter symbol must not be CALLED anymore.
+    if grep -qE "@sailfin_adapter_serve_start\(" "$ll"; then
+        echo "[test]   serve_probe.sfn still references @sailfin_adapter_serve_start (expected the #1092 flip)"
+        missing=$((missing + 1))
+    fi
+    return "$missing"
+}
+
+# ---- Behavioral: HTTP loopback round-trip against an in-process server ----
+#
+# Picks a free TCP port, starts a Sailfin `serve(handler, port)`
+# program in the background (the handler returns a fixed body), waits
+# for it to listen, then drives a Python HTTP/1.1 client through one
+# request and asserts the handler's body comes back. Exercises the
+# full server stack — bind / listen / accept / pool dispatch /
+# handler call / response framing — end to end.
+test_loopback_round_trip() {
+    # Find a free port: bind to 0, read it back, release it. A brief
+    # TOCTOU window before the Sailfin server rebinds it is tolerable
+    # on a quiet runner (the http adapter test uses the same idiom).
+    local port
+    port="$(python3 - <<'PYEOF'
+import socket
+s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+s.bind(("127.0.0.1", 0))
+print(s.getsockname()[1])
+s.close()
+PYEOF
+)"
+    if [ -z "$port" ]; then
+        echo "[test]   could not allocate a free port"
+        return 1
+    fi
+
+    local server="$SCRATCH/server.sfn"
+    cat > "$server" <<PROBE
+fn handle(req: string) -> string {
+    return "HELLO_FROM_SERVE";
+}
+
+fn main() -> int ![net, io] {
+    serve(handle, ${port});
+    return 0;
+}
+PROBE
+
+    local srvlog="$SCRATCH/server.out"
+    "$BINARY" run "$server" > "$srvlog" 2>&1 &
+    SERVER_PID=$!
+
+    # Wait until the server is accepting (max ~15s — `sfn run`
+    # compiles + links the program before the listen).
+    local client="$SCRATCH/client.py"
+    cat > "$client" <<PYEOF
+import socket, sys, time
+port = ${port}
+deadline = time.time() + 15
+body = None
+while time.time() < deadline:
+    try:
+        c = socket.create_connection(("127.0.0.1", port), timeout=2)
+    except OSError:
+        time.sleep(0.2)
+        continue
+    try:
+        c.sendall(b"GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n")
+        data = b""
+        while True:
+            chunk = c.recv(4096)
+            if not chunk:
+                break
+            data += chunk
+    finally:
+        c.close()
+    head, _, payload = data.partition(b"\r\n\r\n")
+    body = payload
+    break
+if body is None:
+    print("NO_RESPONSE", flush=True)
+    sys.exit(1)
+sys.stdout.write(body.decode("utf-8", "replace"))
+sys.stdout.flush()
+PYEOF
+
+    local out="$SCRATCH/client.out"
+    if ! python3 "$client" > "$out" 2>&1; then
+        echo "[test]   client never reached the server:"
+        cat "$out"
+        echo "[test]   --- server log ---"
+        cat "$srvlog"
+        return 1
+    fi
+    if ! grep -q "HELLO_FROM_SERVE" "$out"; then
+        echo "[test]   expected 'HELLO_FROM_SERVE' in the response body, got:"
+        cat "$out"
+        echo "[test]   --- server log ---"
+        cat "$srvlog"
+        return 1
+    fi
+    return 0
+}
+
+run_test "sfn check runtime/sfn/concurrency/serve.sfn passes" test_check_clean
+run_test "sfn fmt --check runtime/sfn/concurrency/serve.sfn is canonical" test_fmt_clean
+run_test "sfn emit llvm defines sfn_serve + sfn_serve_handler_dispatch + socket/scheduler refs" test_emit_define_shape
+run_test "serve(handler, port) lowers to @sfn_serve (not the legacy adapter symbol)" test_probe_flipped
+run_test "HTTP loopback round-trip returns the handler's body" test_loopback_round_trip
+
+echo "[summary] $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi

--- a/docs/runtime_audit.md
+++ b/docs/runtime_audit.md
@@ -435,7 +435,7 @@ survives until process exit. This is why per-module compiler RAM reaches
 | `sailfin_runtime_http_get` / `http_post_json` / `http_download` | ✅ | Implemented as `curl` subprocess via `popen`. Used by the package manager path |
 | `sailfin_adapter_http_get` / `http_post` | 🚫 **Stub** | Return NULL. The adapter path (the effect-wired version) is not implemented — only the curl-subprocess package-manager path is |
 | `sailfin_adapter_model_invoke_with_prompt` | 🚫 **Stub** | |
-| `sailfin_adapter_serve_start` / `serve_handler_dispatch` | ❌ **Missing** | Declared in `runtime_helpers.sfn`; not defined in the runtime |
+| `sailfin_adapter_serve_start` / `serve_handler_dispatch` | ✅ | **Ported to Sailfin** (#1092): `sfn_serve` / `sfn_serve_handler_dispatch` in `runtime/sfn/concurrency/serve.sfn` — a blocking HTTP/1.1 accept loop on the BSD-sockets surface that dispatches each connection to the M4.1 thread pool (`scheduler.sfn`). The `serve` lowering in `expression_lowering/native/core.sfn` emits `@sfn_serve`; the registry rows carry the `sfn_*` `native_signature`. v0: HTTP only (no TLS), blocking accept (no async), handler ABI `fn (* u8 request) -> * u8 response_body`. The legacy adapter symbols were never defined |
 
 ### Concurrency
 

--- a/runtime/native/capsule.toml
+++ b/runtime/native/capsule.toml
@@ -55,7 +55,7 @@ ll-sources = ["ir/runtime_globals.ll"]
 # and the formerly-load-bearing allowlist is gone.
 #
 # Single-line array per the parser limitation noted above.
-sfn-sources = ["../sfn/memory/arena.sfn", "../sfn/memory/rc.sfn", "../sfn/memory/mem.sfn", "../sfn/string.sfn", "../sfn/array.sfn", "../sfn/clock.sfn", "../sfn/process.sfn", "../sfn/io.sfn", "../sfn/exception.sfn", "../sfn/type_meta.sfn", "../sfn/platform/exec.sfn", "../sfn/adapters/filesystem.sfn", "../sfn/adapters/http.sfn", "../sfn/concurrency/scheduler.sfn", "../sfn/concurrency/future.sfn", "../sfn/concurrency/channel.sfn"]
+sfn-sources = ["../sfn/memory/arena.sfn", "../sfn/memory/rc.sfn", "../sfn/memory/mem.sfn", "../sfn/string.sfn", "../sfn/array.sfn", "../sfn/clock.sfn", "../sfn/process.sfn", "../sfn/io.sfn", "../sfn/exception.sfn", "../sfn/type_meta.sfn", "../sfn/platform/exec.sfn", "../sfn/adapters/filesystem.sfn", "../sfn/adapters/http.sfn", "../sfn/concurrency/scheduler.sfn", "../sfn/concurrency/future.sfn", "../sfn/concurrency/channel.sfn", "../sfn/concurrency/serve.sfn"]
 include-dirs = ["include"]
 link-libs = ["-lm", "-lpthread"]
 

--- a/runtime/sfn/concurrency/serve.sfn
+++ b/runtime/sfn/concurrency/serve.sfn
@@ -1,0 +1,396 @@
+// runtime/sfn/concurrency/serve.sfn
+//
+// First-wave Sailfin-native `serve` HTTP/1.1 server (M4, #1092 —
+// epic #965, scheduler-core track). Replaces the no-op C stub
+// `sailfin_runtime_serve` / the never-defined `sailfin_adapter_serve_*`
+// symbols with a real blocking accept-loop built on the BSD-sockets
+// surface (`runtime/sfn/platform/net.sfn`, inlined here per the
+// every-module convention) that dispatches each accepted connection
+// to the M4.1 fixed thread pool in `scheduler.sfn`.
+//
+// Design: `docs/runtime_architecture.md` §2.6.6 (serve accept loop)
+// over the §2.6.1 fixed pool + shared MPMC queue. The accept loop
+// runs on the caller's thread and never returns; each connection
+// becomes a `Task` enqueued on the shared queue, run by a pool
+// worker. This is the server mirror of the §2.7.2 HTTP *client*
+// (`runtime/sfn/adapters/http.sfn`), and reuses that module's
+// proven idioms (byte-stride pointer arithmetic, decimal byte
+// constants, the dual sockaddr_in layout for Linux/macOS). The
+// helpers carry a `_serve_` prefix rather than reusing `http.sfn`'s
+// names because the native backend gives file-local runtime helpers
+// external linkage — two `sfn-sources` modules defining `_append`
+// would be a duplicate-symbol link error.
+//
+// Handler ABI (v0). The emitter (`compiler/src/llvm/expression_lowering/
+// native/core.sfn`) lowers `serve(<handler>, <port>)` by bitcasting the
+// handler function value to a bare `i8*` code pointer and passing it
+// with the port to `sfn_serve`. The handler's compiled C-ABI is
+// `fn (* u8 request) -> * u8 response_body`: it receives the raw
+// request bytes (NUL-terminated) and returns the response BODY as a
+// NUL-terminated string. `sfn_serve` wraps that body in a minimal
+// HTTP/1.1 `200 OK` response. This raw `i8*`-in / `i8*`-out shape
+// mirrors the `sfn_http_*` client exactly and needs NO Request /
+// Response struct marshalling — keeping the boxing self-contained
+// (the issue's architect flag). The richer `fn (Request) -> Response`
+// struct handler (the `sfn/http` capsule types) is a follow-up wave
+// that adds the request/response marshalling on top of this ABI.
+//
+// ABI flip. `compiler/src/llvm/runtime_helpers.sfn` flips the two
+// serve registry rows to the symbols defined here:
+//   - `serve_start`            -> `sfn_serve`                 (handler, port)
+//   - `serve_handler_dispatch` -> `sfn_serve_handler_dispatch` (handler, request)
+// and the bespoke serve lowering in `core.sfn` emits `@sfn_serve`
+// in place of the legacy `@sailfin_adapter_serve_start`.
+//
+// Scope: HTTP/1.1 only — NO TLS (post-1.0), and blocking accept —
+// NO async I/O (v0). Request parsing is minimal: the raw request
+// head is handed to the handler verbatim (GET-shaped v0; bodies are
+// read up to the header terminator). The response is always
+// `200 OK` with a `Content-Length`; a null handler return becomes a
+// `500`.
+//
+// v0 limitations (follow-up waves): (1) per-connection `Task`
+// handles are fire-and-forget — never `sfn_task_join`ed or
+// destroyed — so each connection leaks one 120-byte `Task`. Reaping
+// fire-and-forget tasks needs a scheduler-side completion sweep
+// (separate issue); the connection `ctx` pair IS freed by the
+// worker. (2) No keep-alive (`Connection: close` semantics, one
+// request per connection). (3) No request routing / method dispatch
+// — that is the handler's job.
+//
+// Effects: `sfn_serve` is `![net, io]`; the flipped `serve_start`
+// descriptor carries the same effects, so calling `serve(...)`
+// without `![net, io]` on the call chain remains a compile-time
+// error after the flip. The connection worker and dispatch
+// trampoline call only effect-free externs (and the handler through
+// an effect-erased pointer), so they carry no effect annotation —
+// matching the `future.sfn` trampoline convention.
+//
+// Decimal byte constants (no char/octal literals in the seed):
+//   13 = '\r'  10 = '\n'  32 = ' '   48 = '0'
+// AF_INET = 2, SOCK_STREAM = 1 (identical on Linux x86_64 and
+// macOS arm64, the two targets this runtime builds for).
+//
+// Pinned by `compiler/tests/e2e/test_runtime_serve.sh` (typecheck +
+// fmt + emit-define shape + an IR routing probe that `serve(...)`
+// lowers to `@sfn_serve` + a behavioral loopback round-trip against
+// the in-process server).
+// ── libc memory + string helpers ──────────────────────────────
+extern fn malloc(size: usize) -> * u8;
+
+extern fn free(ptr: * u8) -> void;
+
+extern fn realloc(ptr: * u8, new_size: usize) -> * u8;
+
+extern fn memset(dst: * u8, byte: i32, n: usize) -> * u8;
+
+extern fn memcpy(dst: * u8, src: * u8, n: usize) -> * u8;
+
+extern fn strlen(s: * u8) -> usize;
+
+extern fn strstr(haystack: * u8, needle: * u8) -> * u8;
+
+// ── BSD sockets (libc) ────────────────────────────────────────
+// `addr` is spelled `* u8` (the `net.sfn` opaque-handle policy:
+// adapters cast the family-specific sockaddr struct through `* u8`
+// at the call site). `accept` takes NULL for the peer-addr / len
+// out-params — the v0 server does not inspect the client address.
+extern fn socket(domain: i32, ty: i32, protocol: i32) -> i32;
+
+extern fn bind(sockfd: i32, addr: * u8, addrlen: i32) -> i32;
+
+extern fn listen(sockfd: i32, backlog: i32) -> i32;
+
+extern fn accept(sockfd: i32, addr: * u8, addrlen: * u8) -> i32;
+
+extern fn send(sockfd: i32, buf: * u8, len: i64, flags: i32) -> i64;
+
+extern fn recv(sockfd: i32, buf: * u8, len: i64, flags: i32) -> i64;
+
+extern fn close(fd: i32) -> i32;
+
+// ── Scheduler (M4.1, scheduler.sfn) ───────────────────────────
+// The shared MPMC task queue + fixed worker pool. `sfn_serve`
+// creates one queue + pool, then enqueues a `Task` per connection.
+extern fn sfn_taskqueue_create(capacity: i64) -> * u8;
+
+extern fn sfn_taskqueue_enqueue(queue: * u8, task: * u8) -> void;
+
+extern fn sfn_task_create(fn_ptr: i64, ctx: i64) -> * u8;
+
+extern fn sfn_scheduler_create(queue: * u8) -> * u8;
+
+// `_serve_ptr_off(p, off)` — byte-stride pointer arithmetic for a
+// variable offset (serve-local copy of `http.sfn`'s `_ptr_off`).
+fn _serve_ptr_off(p: * u8, off: i64) -> * u8 {
+    let addr: i64 = (p as i64) + off;
+    return addr as * u8;
+}
+
+// `_serve_uint_to_str(value)` — render a non-negative i64 as a
+// freshly allocated decimal string (used for the response
+// `Content-Length` header). Returns null on OOM. Serve-local copy of
+// `http.sfn`'s `_uint_to_str`.
+fn _serve_uint_to_str(value: i64) -> * u8 {
+    if value <= 0 {
+        let zero: * u8 = malloc(2 as usize);
+        if zero as i64 == 0 { return null; }
+        memset(_serve_ptr_off(zero, 0), 48, 1 as usize);
+        memset(_serve_ptr_off(zero, 1), 0, 1 as usize);
+        return zero;
+    }
+    let mut count: i64 = 0;
+    let mut probe: i64 = value;
+    loop {
+        if probe == 0 { break; }
+        probe = probe / 10;
+        count = count + 1;
+    }
+    let buf: * u8 = malloc((count + 1) as usize);
+    if buf as i64 == 0 { return null; }
+    memset(_serve_ptr_off(buf, count), 0, 1 as usize);
+    let mut remaining: i64 = value;
+    let mut idx: i64 = count - 1;
+    loop {
+        if remaining == 0 { break; }
+        let digit: i64 = remaining % 10;
+        memset(_serve_ptr_off(buf, idx), (48 + digit) as i32, 1 as usize);
+        remaining = remaining / 10;
+        idx = idx - 1;
+    }
+    return buf;
+}
+
+// `_serve_append(dst, off, src)` — copy the NUL-terminated `src`
+// into `dst` at byte offset `off`, returning the new offset. The
+// caller pre-sizes `dst` from the summed piece lengths. Serve-local
+// copy of `http.sfn`'s `_append`.
+fn _serve_append(dst: * u8, off: i64, src: * u8) -> i64 {
+    let n: i64 = strlen(src) as i64;
+    memcpy(_serve_ptr_off(dst, off), src, n as usize);
+    return off + n;
+}
+
+// `_serve_send_all(fd, buf, total)` — write `total` bytes, retrying
+// on short sends. Returns false if `send` ever fails. Serve-local
+// copy of `http.sfn`'s `_send_all`.
+fn _serve_send_all(fd: i32, buf: * u8, total: i64) -> bool {
+    let mut sent: i64 = 0;
+    loop {
+        if sent >= total { break; }
+        let n: i64 = send(fd, _serve_ptr_off(buf, sent), total - sent, 0);
+        if n <= 0 { return false; }
+        sent = sent + n;
+    }
+    return true;
+}
+
+// `_serve_recv_request(fd)` — read the request head into a growing
+// libc buffer (doubling like `http.sfn`'s `_recv_all`), stopping
+// once the `\r\n\r\n` header terminator is seen, on EOF, or on a
+// `recv` error. Returns a NUL-terminated, caller-owned buffer (null
+// on OOM / error). v0 reads only up to the header terminator —
+// request bodies past the headers are not drained (GET-shaped v0).
+fn _serve_recv_request(fd: i32) -> * u8 {
+    let mut capacity: i64 = 4096;
+    let mut len: i64 = 0;
+    let mut buf: * u8 = malloc((capacity + 1) as usize);
+    if buf as i64 == 0 { return null; }
+    let chunk: i64 = 4096;
+    let terminator: string = "\r\n\r\n";
+    loop {
+        if len + chunk > capacity {
+            let new_cap: i64 = capacity * 2;
+            let new_buf: * u8 = realloc(buf, (new_cap + 1) as usize);
+            if new_buf as i64 == 0 {
+                free(buf);
+                return null;
+            }
+            buf = new_buf;
+            capacity = new_cap;
+        }
+        let n: i64 = recv(fd, _serve_ptr_off(buf, len), chunk, 0);
+        if n < 0 {
+            free(buf);
+            return null;
+        }
+        if n == 0 { break; }
+        len = len + n;
+        memset(_serve_ptr_off(buf, len), 0, 1 as usize);
+        // Stop as soon as the full header block has arrived.
+        if (strstr(buf, terminator as * u8) as i64) != 0 { break; }
+    }
+    memset(_serve_ptr_off(buf, len), 0, 1 as usize);
+    return buf;
+}
+
+// `_serve_send_response(fd, body)` — frame `body` as a minimal
+// HTTP/1.1 `200 OK` response (`Content-Length` + `Connection:
+// close`) and write it. A null `body` becomes a `500 Internal Server
+// Error` with an empty body. Returns false on a send failure.
+fn _serve_send_response(fd: i32, body: * u8) -> bool {
+    if body as i64 == 0 {
+        let err: string = "HTTP/1.1 500 Internal Server Error\r\nContent-Length: 0\r\nConnection: close\r\n\r\n";
+        return _serve_send_all(fd, err as * u8, strlen(err as * u8) as i64);
+    }
+
+    let status: string = "HTTP/1.1 200 OK\r\nContent-Length: ";
+    let tail: string = "\r\nConnection: close\r\n\r\n";
+    let body_len: i64 = strlen(body) as i64;
+    let clen: * u8 = _serve_uint_to_str(body_len);
+    if clen as i64 == 0 { return false; }
+
+    let total: i64 = (strlen(status as * u8) as i64) + (strlen(clen) as i64) + (strlen(tail as * u8) as i64)
+        + body_len;
+    let resp: * u8 = malloc((total + 1) as usize);
+    if resp as i64 == 0 {
+        free(clen);
+        return false;
+    }
+    let mut off: i64 = 0;
+    off = _serve_append(resp, off, status as * u8);
+    off = _serve_append(resp, off, clen);
+    off = _serve_append(resp, off, tail as * u8);
+    off = _serve_append(resp, off, body);
+    memset(_serve_ptr_off(resp, off), 0, 1 as usize);
+    free(clen);
+
+    let ok: bool = _serve_send_all(fd, resp, off);
+    free(resp);
+    return ok;
+}
+
+// `sfn_serve_handler_dispatch(handler, request)` — invoke the user
+// handler through its raw `i8*` code pointer. The handler's compiled
+// C-ABI is `fn (* u8 request) -> * u8 response_body`; this is the
+// single boxing boundary between the runtime and user code (mirrors
+// the `sfn_task_run` fn-pointer call in `scheduler.sfn`). Null-safe
+// on the handler (returns null so the worker emits a `500`).
+fn sfn_serve_handler_dispatch(handler: * u8, request: * u8) -> * u8 {
+    if handler as i64 == 0 { return null; }
+    let entry: * fn (* u8) -> * u8 = (handler as i64) as * fn (* u8) -> * u8;
+    return entry(request);
+}
+
+// `_serve_conn_worker(ctx)` — the per-connection pool task body. It
+// matches the `Task` worker ABI (`fn (* u8) -> * u8`): `ctx` points
+// at a 16-byte pair `[client_fd: i64][handler: i64]` (freed here).
+// Reads the request, dispatches to the handler, frames + sends the
+// response, and closes the connection. Returns null (the `Task`
+// result is unused — serve is fire-and-forget). Calls only
+// effect-free externs + the effect-erased dispatch, so it carries no
+// effect annotation (matching `future.sfn`'s trampolines).
+fn _serve_conn_worker(ctx: * u8) -> * u8 {
+    if ctx as i64 == 0 { return null; }
+    let base: i64 = ctx as i64;
+    let fd_slot: * i64 = base as * i64;
+    let handler_slot: * i64 = (base + 8) as * i64;
+    let client_fd: i64 = atomic_load(fd_slot);
+    let handler: i64 = atomic_load(handler_slot);
+    free(ctx);
+
+    let request: * u8 = _serve_recv_request(client_fd as i32);
+    let response: * u8 = sfn_serve_handler_dispatch(handler as * u8, request);
+    _serve_send_response(client_fd as i32, response);
+    close(client_fd as i32);
+    if request as i64 != 0 { free(request); }
+    return null;
+}
+
+// `_serve_bind_listen(port)` — open a stream socket bound to
+// `0.0.0.0:port` and start listening. Returns the listening fd, or
+// -1 on failure.
+//
+// `sockaddr_in` byte layout differs across the two targets this
+// runtime builds for (see `http.sfn::_connect_tcp` for the full
+// rationale), so we try both layouts with a fresh socket each time,
+// first success wins:
+//   - Linux:     u16 `sin_family` at offset 0 → low byte = 2 (AF_INET).
+//   - macOS/BSD: u8 `sin_len` at 0, u8 `sin_family` at 1.
+// `sin_port` is big-endian (network byte order) at offset 2; the
+// four `sin_addr` octets at offset 4 stay zero (INADDR_ANY).
+fn _serve_bind_listen(port: i64) -> i32 {
+    let mut attempt: i64 = 0;
+    loop {
+        if attempt >= 2 { break; }
+        let fd: i32 = socket(2, 1, 0);
+        if fd < 0 { return 0 - 1; }
+        let addr: * u8 = malloc(16 as usize);
+        if addr as i64 == 0 {
+            close(fd);
+            return 0 - 1;
+        }
+        memset(addr, 0, 16 as usize);
+        if attempt == 0 {
+            // Linux: u16 sin_family at offset 0.
+            memset(_serve_ptr_off(addr, 0), 2, 1 as usize);
+        } else {
+            // macOS/BSD: u8 sin_len at 0, u8 sin_family at 1.
+            memset(_serve_ptr_off(addr, 0), 16, 1 as usize);
+            memset(_serve_ptr_off(addr, 1), 2, 1 as usize);
+        }
+        // sin_port (network byte order = big-endian).
+        memset(_serve_ptr_off(addr, 2), ((port >> 8) & 255) as i32, 1 as usize);
+        memset(_serve_ptr_off(addr, 3), (port & 255) as i32, 1 as usize);
+        // sin_addr stays zero (INADDR_ANY) at offset 4..8.
+        let rc: i32 = bind(fd, addr, 16);
+        free(addr);
+        if rc == 0 {
+            if listen(fd, 128) == 0 { return fd; }
+            close(fd);
+            return 0 - 1;
+        }
+        close(fd);
+        attempt = attempt + 1;
+    }
+    return 0 - 1;
+}
+
+// `sfn_serve(handler, port)` — bind, listen, and run the blocking
+// accept loop, dispatching each connection to the shared pool. Does
+// NOT return (the loop only exits on an `accept` error, after which
+// it closes the listening socket). `handler` is the raw `i8*` code
+// pointer the emitter passes; `port` is the listening TCP port.
+fn sfn_serve(handler: * u8, port: i32) -> void ![net, io] {
+    let listen_fd: i32 = _serve_bind_listen(port as i64);
+    if listen_fd < 0 { return; }
+
+    // One shared queue + fixed worker pool for the whole server.
+    let queue: * u8 = sfn_taskqueue_create(256);
+    if queue as i64 == 0 {
+        close(listen_fd);
+        return;
+    }
+    let scheduler: * u8 = sfn_scheduler_create(queue);
+    if scheduler as i64 == 0 {
+        close(listen_fd);
+        return;
+    }
+
+    loop {
+        let client_fd: i32 = accept(listen_fd, null, null);
+        if client_fd < 0 { break; }
+
+        // Pack [client_fd][handler] for the connection worker.
+        let conn_ctx: * u8 = malloc(16 as usize);
+        if conn_ctx as i64 == 0 {
+            close(client_fd);
+            continue;
+        }
+        let fd_slot: * i64 = conn_ctx as * i64;
+        let handler_slot: * i64 = (conn_ctx as i64 + 8) as * i64;
+        atomic_store(fd_slot, client_fd as i64);
+        atomic_store(handler_slot, handler as i64);
+
+        let worker: * fn (* u8) -> * u8 = _serve_conn_worker as * fn (* u8) -> * u8;
+        let task: * u8 = sfn_task_create(worker as i64, conn_ctx as i64);
+        if task as i64 == 0 {
+            free(conn_ctx);
+            close(client_fd);
+            continue;
+        }
+        sfn_taskqueue_enqueue(queue, task);
+    }
+
+    close(listen_fd);
+}

--- a/runtime/sfn/concurrency/serve.sfn
+++ b/runtime/sfn/concurrency/serve.sfn
@@ -101,7 +101,7 @@ extern fn bind(sockfd: i32, addr: * u8, addrlen: i32) -> i32;
 
 extern fn listen(sockfd: i32, backlog: i32) -> i32;
 
-extern fn accept(sockfd: i32, addr: * u8, addrlen: * u8) -> i32;
+extern fn accept(sockfd: i32, addr: * u8, addrlen: * i32) -> i32;
 
 extern fn send(sockfd: i32, buf: * u8, len: i64, flags: i32) -> i64;
 
@@ -113,6 +113,8 @@ extern fn close(fd: i32) -> i32;
 // The shared MPMC task queue + fixed worker pool. `sfn_serve`
 // creates one queue + pool, then enqueues a `Task` per connection.
 extern fn sfn_taskqueue_create(capacity: i64) -> * u8;
+
+extern fn sfn_taskqueue_destroy(queue: * u8) -> void;
 
 extern fn sfn_taskqueue_enqueue(queue: * u8, task: * u8) -> void;
 
@@ -191,7 +193,14 @@ fn _serve_send_all(fd: i32, buf: * u8, total: i64) -> bool {
 // `recv` error. Returns a NUL-terminated, caller-owned buffer (null
 // on OOM / error). v0 reads only up to the header terminator —
 // request bodies past the headers are not drained (GET-shaped v0).
+//
+// A client that never sends the `\r\n\r\n` terminator must not be
+// able to force unbounded growth (DoS / OOM), so the header read is
+// capped at `max_request` bytes — once exceeded without a terminator
+// the request is rejected (buffer freed, null returned, which the
+// worker turns into a `500` + connection close).
 fn _serve_recv_request(fd: i32) -> * u8 {
+    let max_request: i64 = 65536;
     let mut capacity: i64 = 4096;
     let mut len: i64 = 0;
     let mut buf: * u8 = malloc((capacity + 1) as usize);
@@ -219,6 +228,12 @@ fn _serve_recv_request(fd: i32) -> * u8 {
         memset(_serve_ptr_off(buf, len), 0, 1 as usize);
         // Stop as soon as the full header block has arrived.
         if (strstr(buf, terminator as * u8) as i64) != 0 { break; }
+        // Reject a request that exceeds the header cap without a
+        // terminator (slow-loris / unbounded-header DoS guard).
+        if len >= max_request {
+            free(buf);
+            return null;
+        }
     }
     memset(_serve_ptr_off(buf, len), 0, 1 as usize);
     return buf;
@@ -280,6 +295,12 @@ fn sfn_serve_handler_dispatch(handler: * u8, request: * u8) -> * u8 {
 // result is unused — serve is fire-and-forget). Calls only
 // effect-free externs + the effect-erased dispatch, so it carries no
 // effect annotation (matching `future.sfn`'s trampolines).
+//
+// A null request (recv error, OOM, or the header cap exceeded) is
+// NOT handed to user code — the handler receives a `* u8 request` it
+// is free to read, so a null would risk a crash inside the handler.
+// Instead the worker skips dispatch and sends a `500` directly
+// (`_serve_send_response(fd, null)`).
 fn _serve_conn_worker(ctx: * u8) -> * u8 {
     if ctx as i64 == 0 { return null; }
     let base: i64 = ctx as i64;
@@ -290,10 +311,17 @@ fn _serve_conn_worker(ctx: * u8) -> * u8 {
     free(ctx);
 
     let request: * u8 = _serve_recv_request(client_fd as i32);
+    if request as i64 == 0 {
+        // Bad/oversized/failed request: emit a 500, never call the
+        // handler with a null request pointer.
+        _serve_send_response(client_fd as i32, null);
+        close(client_fd as i32);
+        return null;
+    }
     let response: * u8 = sfn_serve_handler_dispatch(handler as * u8, request);
     _serve_send_response(client_fd as i32, response);
     close(client_fd as i32);
-    if request as i64 != 0 { free(request); }
+    free(request);
     return null;
 }
 
@@ -363,6 +391,8 @@ fn sfn_serve(handler: * u8, port: i32) -> void ![net, io] {
     }
     let scheduler: * u8 = sfn_scheduler_create(queue);
     if scheduler as i64 == 0 {
+        // Tear down the already-initialized queue before bailing.
+        sfn_taskqueue_destroy(queue);
         close(listen_fd);
         return;
     }


### PR DESCRIPTION
## Summary
- Implements `serve` for the first time as a real Sailfin-native HTTP/1.1 server: `runtime/sfn/concurrency/serve.sfn` runs a blocking accept loop on the BSD-sockets surface and dispatches each connection to the M4.1 fixed thread pool (`scheduler.sfn`) as a `Task`. `sfn_serve_handler_dispatch` invokes the user handler through its raw `i8*` code pointer (mirroring `sfn_task_run`).
- Flips the `serve_start` / `serve_handler_dispatch` registry rows to the `sfn_*` `native_signature`, and the bespoke serve lowering in `expression_lowering/native/core.sfn` emits `@sfn_serve` directly.
- The legacy `sailfin_adapter_serve_start` / `serve_handler_dispatch` symbols were **never defined**, and `sailfin_runtime_serve` was a no-op stub — this is the first working serve.

Closes #1092

## Design notes
- **v0 handler ABI is `fn (* u8 request) -> * u8 response_body`** — raw request/response strings, mirroring the proven `sfn_http_*` client shape. This needs **no Request/Response struct marshalling**, which keeps the handler boxing self-contained (the issue's architect flag) and the change M-sized. The richer `fn(Request) -> Response` struct handler (the `sfn/http` capsule types) is a documented follow-up that adds marshalling on top of this ABI.
- **v0 limitations** (documented in the module header): HTTP only (no TLS), blocking accept (no async), per-connection `Task` handles are fire-and-forget (one 120-byte `Task` leak per connection until a scheduler-side completion sweep lands), `Connection: close` (no keep-alive).
- Hit and fixed a **duplicate-symbol link error**: the native backend gives file-local runtime helpers external linkage, so helpers are `_serve_`-prefixed to avoid colliding with `http.sfn`'s `_append` / `_send_all` / etc.

## Scope note — two necessary touches beyond the issue's `Files Affected`
Neither is in the issue's `Out:` scope; both are mechanically required to satisfy the acceptance criteria:
- `compiler/src/llvm/expression_lowering/native/core.sfn` — the serve lowering **hardcodes** the called symbol (it does not consult the registry), so flipping the registry row alone would not redirect the emitted call. The emitter must emit `@sfn_serve`.
- `runtime/native/capsule.toml` — every `sfn-sources` module must be registered; serve.sfn is added after the scheduler it depends on.
- `compiler/tests/e2e/test_concurrency_lowering_ir.sh` — existing assertion updated from `sailfin_adapter_serve_start` to `sfn_serve`.

## Acceptance Criteria
- [x] `sfn_serve` accepts on the listening socket and dispatches each connection to the pool
- [x] handler runs under `[net, io]` (registry-enforced on the `serve(...)` call chain)
- [x] serve rows flipped to `sfn_*`
- [x] loopback request returns the handler's response
- [x] `make compile` passes
- [x] `make test` passes (see Verification)
- [x] `sfn fmt --check` clean on every touched `.sfn`

## Verification
```bash
ulimit -v 8388608 && make compile        # self-host status: pass
bash compiler/tests/e2e/test_runtime_serve.sh build/native/sailfin
#   5/5 PASS — typecheck, fmt, emit-define shape, IR routing probe (@sfn_serve),
#   behavioral HTTP loopback round-trip (handler body returned over a real socket)
bash compiler/tests/e2e/test_concurrency_lowering_ir.sh build/native/sailfin
#   5/5 PASS (serve now lowers to @sfn_serve)

# full native suite (RC=0, all green):
#   unit 138/138 · integration 31/31 · e2e 5/5 · capsules 34/34 · e2e-sh 115/115
```
Note: one earlier `make test` run surfaced a transient `setup-error` classification (RC≠0 from a port/subprocess race in another shard, then mislabeled by the classifier matching a benign `No such file or directory` line emitted by the intentional negative test `sfn_c_source_cache_test_missing`). A clean re-run is fully green.

## Files Changed
- `runtime/sfn/concurrency/serve.sfn` (new) — `sfn_serve` + `sfn_serve_handler_dispatch` + connection worker
- `compiler/src/llvm/runtime_helpers.sfn` — flip serve rows to `sfn_*`
- `compiler/src/llvm/expression_lowering/native/core.sfn` — emit `@sfn_serve`
- `runtime/native/capsule.toml` — register serve.sfn in `sfn-sources`
- `compiler/tests/e2e/test_runtime_serve.sh` (new) — loopback e2e
- `compiler/tests/e2e/test_concurrency_lowering_ir.sh` — updated expectation
- `docs/runtime_audit.md` — serve marked ✅ ported

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014tPNCJkPeb2Jh4J6Z7bpgr)_