### PR TITLE
feat(runtime): sfn_parallel fan-out/join combinator over spawn/await

### DIFF
--- a/compiler/tests/e2e/test_runtime_parallel_combinator.sh
+++ b/compiler/tests/e2e/test_runtime_parallel_combinator.sh
@@ -261,6 +261,14 @@ int main(void) {
         return 6;
     }
 
+    /* Phase 4: a non-empty fan-out with a null fn_ptrs array is rejected
+     * (returns null) rather than dereferencing near-null. A null ctxs
+     * stays valid (Phase 2), so only fn_ptrs is guarded. */
+    if (sfn_parallel(NULL, (void *)ctxs, 4) != NULL) {
+        fprintf(stderr, "sfn_parallel(NULL, ctxs, 4) did not return NULL\n");
+        return 7;
+    }
+
     return 0;
 }
 CHARNESS

--- a/compiler/tests/e2e/test_runtime_parallel_combinator.sh
+++ b/compiler/tests/e2e/test_runtime_parallel_combinator.sh
@@ -1,0 +1,301 @@
+#!/usr/bin/env bash
+# End-to-end test for runtime/sfn/concurrency/parallel.sfn (issue #1093).
+#
+# `sfn_parallel(fn_ptrs, ctxs, count)` is a pure fan-out/join combinator
+# over the existing sfn_spawn / sfn_await surface (future.sfn, #1090): it
+# spawns every task onto the shared v0 scheduler, awaits them all, and
+# returns their results in INPUT ORDER. It adds no new runtime-helper
+# descriptor and no new scheduler primitive — it only calls spawn+await.
+#
+# Acceptance (mirrors the issue):
+#   - `sfn check runtime/sfn/concurrency/parallel.sfn` exits 0.
+#   - `sfn fmt --check` on the module is clean.
+#   - emitted IR defines @sfn_parallel and drives it through the
+#     spawn+await surface only: it calls @sfn_spawn and @sfn_await
+#     (declared, not defined here — the combinator owns no primitive),
+#     and adds NO `@sfn_*` descriptor of its own.
+#   - the empty-input fast path returns null (allocates nothing).
+#   - a linked roundtrip (parallel.ll + future.ll + scheduler.ll + a C
+#     harness) proves: all tasks spawn, all are awaited, results land in
+#     input order even though the pool completes them concurrently, a
+#     null `ctxs` array means zero ctx, and `count == 0` returns null.
+#
+# Usage:
+#   compiler/tests/e2e/test_runtime_parallel_combinator.sh <compiler-binary>
+
+set -euo pipefail
+
+BINARY="${1:?usage: test_runtime_parallel_combinator.sh <compiler-binary>}"
+BINARY="$(realpath "$BINARY")"
+PASS=0
+FAIL=0
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+CONC_DIR="$REPO_ROOT/runtime/sfn/concurrency"
+PARALLEL="$CONC_DIR/parallel.sfn"
+FUTURE="$CONC_DIR/future.sfn"
+SCHEDULER="$CONC_DIR/scheduler.sfn"
+
+SCRATCH="$(mktemp -d -t sfn-parallel-combinator-XXXXXX)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+run_test() {
+    local name="$1"
+    shift
+    if "$@"; then
+        echo "[test] PASS: $name"
+        PASS=$((PASS + 1))
+    else
+        echo "[test] FAIL: $name"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# ---- Test: sfn check passes cleanly ----
+test_check_clean() {
+    local log="$SCRATCH/check.log"
+    if ! "$BINARY" check "$PARALLEL" > "$log" 2>&1; then
+        echo "[test]   sfn check exited non-zero on parallel.sfn:"
+        cat "$log"
+        return 1
+    fi
+    if ! grep -q "checked .* ok" "$log"; then
+        echo "[test]   sfn check did not report 'ok':"
+        cat "$log"
+        return 1
+    fi
+    return 0
+}
+
+# ---- Test: sfn fmt --check is clean ----
+test_fmt_clean() {
+    if ! "$BINARY" fmt --check "$PARALLEL" > /dev/null 2>&1; then
+        echo "[test]   $PARALLEL needs formatting (run: sfn fmt --write $PARALLEL)"
+        return 1
+    fi
+    return 0
+}
+
+# ---- Test: emitted IR shape ----
+test_emit_shape() {
+    local ll="$SCRATCH/parallel.ll"
+    local log="$SCRATCH/emit.log"
+    if ! "$BINARY" emit -o "$ll" llvm "$PARALLEL" > "$log" 2>&1; then
+        echo "[test]   sfn emit llvm failed on parallel.sfn:"
+        cat "$log"
+        return 1
+    fi
+
+    local missing=0
+
+    # The combinator itself must be defined.
+    if ! grep -qE "^define .*@sfn_parallel\(" "$ll"; then
+        echo "[test]   missing definition: @sfn_parallel"
+        missing=$((missing + 1))
+    fi
+
+    # It must drive the existing spawn+await surface — and only DECLARE
+    # it (the primitives live in future.sfn). A `define @sfn_spawn`/
+    # `define @sfn_await` here would mean the combinator grew its own
+    # primitive, violating "no new descriptor".
+    if ! grep -qE "^declare .*@sfn_spawn\(" "$ll"; then
+        echo "[test]   @sfn_spawn is not declared (combinator must call spawn)"
+        missing=$((missing + 1))
+    fi
+    if ! grep -qE "^declare .*@sfn_await\(" "$ll"; then
+        echo "[test]   @sfn_await is not declared (combinator must call await)"
+        missing=$((missing + 1))
+    fi
+    if grep -qE "^define .*@sfn_spawn\(|^define .*@sfn_await\(" "$ll"; then
+        echo "[test]   parallel.sfn DEFINES a spawn/await primitive (should only call them)"
+        missing=$((missing + 1))
+    fi
+
+    # Scope to the @sfn_parallel body: it must actually CALL spawn then
+    # await (fan-out then join), not merely reference the symbols.
+    local body="$SCRATCH/parallel.body"
+    awk '/^define i8\* @sfn_parallel\(/,/^}/' "$ll" > "$body"
+    if [ ! -s "$body" ]; then
+        echo "[test]   could not extract @sfn_parallel body"
+        missing=$((missing + 1))
+    else
+        if ! grep -qE "call i8\* @sfn_spawn\(" "$body"; then
+            echo "[test]   @sfn_parallel does not call @sfn_spawn (no fan-out)"
+            missing=$((missing + 1))
+        fi
+        if ! grep -qE "call i8\* @sfn_await\(" "$body"; then
+            echo "[test]   @sfn_parallel does not call @sfn_await (no join)"
+            missing=$((missing + 1))
+        fi
+        # The empty-input fast path: a `count <= 0` compare guarding an
+        # early `ret i8* null` (empty input → empty output, no alloc).
+        if ! grep -qE "icmp sle i64 %count, 0" "$body"; then
+            echo "[test]   @sfn_parallel missing the 'count <= 0' empty-input guard"
+            missing=$((missing + 1))
+        fi
+    fi
+
+    return "$missing"
+}
+
+# ---- Test: linked fan-out/join roundtrip (Linux x86_64 only) ----
+test_roundtrip() {
+    local pll="$SCRATCH/parallel.ll"
+    if [ ! -f "$pll" ]; then
+        echo "[test]   $pll missing — test_emit_shape must run first"
+        return 1
+    fi
+
+    # Same Linux-x86_64-only guard as the scheduler/FIFO roundtrips: the
+    # embedded pthread handle storage in scheduler.sfn is sized for glibc
+    # (pthread_mutex_t = 40 B, pthread_cond_t = 48 B). Executing the real
+    # pthread calls against that layout is only correct on Linux x86_64
+    # (docs/runtime_architecture.md §2.9 Q7). The IR-shape assertions
+    # above pin the contract on every platform.
+    local host_os
+    host_os="$(uname -s)"
+    if [ "$host_os" != "Linux" ]; then
+        echo "[test]   host is $host_os, not Linux — skipping executing roundtrip"
+        return 0
+    fi
+
+    local fll="$SCRATCH/future.ll"
+    local sll="$SCRATCH/scheduler.ll"
+    if ! "$BINARY" emit -o "$fll" llvm "$FUTURE" > "$SCRATCH/future_emit.log" 2>&1; then
+        echo "[test]   sfn emit llvm failed on future.sfn:"
+        cat "$SCRATCH/future_emit.log"
+        return 1
+    fi
+    if ! "$BINARY" emit -o "$sll" llvm "$SCHEDULER" > "$SCRATCH/sched_emit.log" 2>&1; then
+        echo "[test]   sfn emit llvm failed on scheduler.sfn:"
+        cat "$SCRATCH/sched_emit.log"
+        return 1
+    fi
+
+    local harness="$SCRATCH/harness.c"
+    cat > "$harness" <<'CHARNESS'
+/* Fan-out/join roundtrip for sfn_parallel (issue #1093). Drives the
+ * combinator against the real spawn/await/scheduler stack and asserts:
+ *   - every task runs and its result lands in INPUT ORDER (results are
+ *     index-dependent, and the pool finishes them out of order under
+ *     contention, so a wrong slot mapping is observable);
+ *   - a null ctxs array delivers a zero ctx to every task;
+ *   - count == 0 returns NULL (empty input → empty output).
+ *
+ * No-op stubs mirror the scheduler harness: the seed installs a
+ * persistent-pointer hook and a type-registration ctor; string literals
+ * (SAILFIN_THREADS in the pool sizer) lower to @sfn_alloc_struct.
+ */
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+extern void *sfn_parallel(void *fn_ptrs, void *ctxs, long count);
+
+void sailfin_runtime_mark_persistent(void *ptr) { (void)ptr; }
+void sfn_type_register(void *desc) { (void)desc; }
+void *sfn_alloc_struct(long n) { return calloc(1, (size_t)n); }
+/* future.sfn's f64/number trampolines reference this string→number
+ * runtime helper through their `as`-cast lowering. Those trampolines are
+ * dead on this harness (the worker returns a pointer-sized value), but
+ * the symbol must resolve at link time; a no-op stub suffices. */
+double sfn_str_to_number(void *s) { (void)s; return 0; }
+
+/* Worker entry the combinator invokes via sfn_spawn. The scheduler runs
+ * it as fn(ctx) -> result; result is returned as an opaque pointer-sized
+ * value (#1089's `* u8`). ctx*ctx + 7 makes each result a distinct,
+ * order-sensitive function of the input index. */
+static void *task_body(void *ctx) {
+    long c = (long)ctx;
+    return (void *)(c * c + 7);
+}
+
+int main(void) {
+    const long N = 64;
+    long fns[64];
+    long ctxs[64];
+    for (long i = 0; i < N; i++) {
+        fns[i] = (long)(intptr_t)&task_body;
+        ctxs[i] = i;
+    }
+
+    /* Phase 1: fan-out N tasks, join, results in input order. */
+    long *res = (long *)sfn_parallel((void *)fns, (void *)ctxs, N);
+    if (!res) {
+        fprintf(stderr, "sfn_parallel returned NULL for N=%ld\n", N);
+        return 1;
+    }
+    for (long i = 0; i < N; i++) {
+        long want = i * i + 7;
+        if (res[i] != want) {
+            fprintf(stderr, "result[%ld] = %ld, want %ld (order violated or task dropped)\n",
+                    i, res[i], want);
+            return 2;
+        }
+    }
+    free(res);
+
+    /* Phase 2: null ctxs → every task receives ctx 0 → task_body(0) = 7. */
+    long *res0 = (long *)sfn_parallel((void *)fns, NULL, 8);
+    if (!res0) {
+        fprintf(stderr, "sfn_parallel with null ctxs returned NULL\n");
+        return 3;
+    }
+    for (long i = 0; i < 8; i++) {
+        if (res0[i] != 7) {
+            fprintf(stderr, "null-ctx result[%ld] = %ld, want 7\n", i, res0[i]);
+            return 4;
+        }
+    }
+    free(res0);
+
+    /* Phase 3: empty input returns NULL (allocates nothing). */
+    if (sfn_parallel(NULL, NULL, 0) != NULL) {
+        fprintf(stderr, "sfn_parallel(_, _, 0) did not return NULL\n");
+        return 5;
+    }
+    /* Negative count is treated as empty too. */
+    if (sfn_parallel((void *)fns, (void *)ctxs, -3) != NULL) {
+        fprintf(stderr, "sfn_parallel(_, _, -3) did not return NULL\n");
+        return 6;
+    }
+
+    return 0;
+}
+CHARNESS
+
+    local clang_bin
+    clang_bin="${CLANG:-clang}"
+    if ! command -v "$clang_bin" >/dev/null 2>&1; then
+        echo "[test]   clang not available — skipping roundtrip (IR-shape still pins the contract)"
+        return 0
+    fi
+    # `-Wno-override-module` because the emitted .ll carries a target
+    # triple that may not match the host clang default. `-lpthread` binds
+    # the scheduler's mutex/cond externs; `-lm` mirrors the scheduler
+    # harness (integer-literal lowering can leave libm references).
+    local bin="$SCRATCH/roundtrip"
+    if ! "$clang_bin" -Wno-override-module "$harness" "$pll" "$fll" "$sll" \
+            -o "$bin" -lpthread -lm 2>"$SCRATCH/clang.log"; then
+        echo "[test]   clang failed to link parallel roundtrip:"
+        cat "$SCRATCH/clang.log"
+        return 1
+    fi
+    if ! "$bin"; then
+        local rc=$?
+        echo "[test]   parallel roundtrip binary exited non-zero (rc=$rc)"
+        return 1
+    fi
+    return 0
+}
+
+run_test "sfn check runtime/sfn/concurrency/parallel.sfn passes" test_check_clean
+run_test "sfn fmt --check runtime/sfn/concurrency/parallel.sfn is canonical" test_fmt_clean
+run_test "sfn emit llvm: @sfn_parallel drives spawn+await, no new descriptor" test_emit_shape
+run_test "linked fan-out/join: all tasks run, results in input order, empty→null" test_roundtrip
+
+echo "[summary] $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,6 +1,6 @@
 # Status
 
-Updated: June 7, 2026 (Stage C complete through C4 migration; Stage D PR1–PR5 shipped; Stage E PR1–PR7 shipped; lowering temp-index recovery fix for #543 staged — PR1–1f / #254–#259, C2a / #261, C2b1 / #262, C2b2 / #263, C2c / #264, C4 v1 / #265, C4b / #266, C4 migration / #267, D PR1 / #268, D PR2 / #269, D PR3 / #271, D PR4 / #272, D PR5 / #273, E PR1 / #274, E PR2 / #277, E PR3 / #278, E PR4 / #280, E PR5 / #378, E PR6 / #382, E PR7 / #383; seed pinned to v0.5.10-alpha.13)
+Updated: June 8, 2026 (Stage C complete through C4 migration; Stage D PR1–PR5 shipped; Stage E PR1–PR7 shipped; lowering temp-index recovery fix for #543 staged — PR1–1f / #254–#259, C2a / #261, C2b1 / #262, C2b2 / #263, C2c / #264, C4 v1 / #265, C4b / #266, C4 migration / #267, D PR1 / #268, D PR2 / #269, D PR3 / #271, D PR4 / #272, D PR5 / #273, E PR1 / #274, E PR2 / #277, E PR3 / #278, E PR4 / #280, E PR5 / #378, E PR6 / #382, E PR7 / #383; seed pinned to v0.5.10-alpha.13)
 
 This document tracks what works today and what is in progress. It is the source
 of truth — consult it before editing docs, examples, or making claims about

--- a/docs/status.md
+++ b/docs/status.md
@@ -8,6 +8,23 @@ feature availability.
 
 ## Build Pipeline (Current)
 
+- **Parallel fan-out/join combinator (#1093, 2026-06-08).**
+  `sfn_parallel(fn_ptrs, ctxs, count)` in
+  `runtime/sfn/concurrency/parallel.sfn` is a pure structured fan-out/join
+  built on the `sfn_spawn` / `sfn_await` surface (#1090): it spawns all
+  `count` tasks onto the shared v0 scheduler first (so the pool runs them
+  concurrently), then awaits each in turn, returning a freshly-allocated
+  i64 result array in **input order**. A null `ctxs` array means every
+  task receives a zero ctx; `count <= 0` returns null (empty input → empty
+  output, no allocation). It is a CONVENIENCE COMBINATOR — no new
+  runtime-helper descriptor, no new scheduler primitive (it only calls
+  spawn+await). Wired into `runtime/native/capsule.toml` sfn-sources
+  alongside its siblings; design in `docs/runtime_architecture.md` §2.6.5.
+  Covered by `test_runtime_parallel_combinator.sh` (sfn check + fmt +
+  IR-shape asserting it drives spawn/await with no new descriptor, plus a
+  linked roundtrip that fans out 64 tasks, verifies results land in input
+  order under concurrent completion, exercises the null-ctx path, and
+  checks the empty/negative-count → null fast path).
 - **Plain C-ABI function-pointer indirect call + scheduler task lifecycle
   (#1089, 2026-06-07).** A value spelled `* fn (A) -> R` (leading `*`) is a
   bare code pointer, distinct from the closure form `fn (A) -> R` (which

--- a/runtime/native/capsule.toml
+++ b/runtime/native/capsule.toml
@@ -55,7 +55,7 @@ ll-sources = ["ir/runtime_globals.ll"]
 # and the formerly-load-bearing allowlist is gone.
 #
 # Single-line array per the parser limitation noted above.
-sfn-sources = ["../sfn/memory/arena.sfn", "../sfn/memory/rc.sfn", "../sfn/memory/mem.sfn", "../sfn/string.sfn", "../sfn/array.sfn", "../sfn/clock.sfn", "../sfn/process.sfn", "../sfn/io.sfn", "../sfn/exception.sfn", "../sfn/type_meta.sfn", "../sfn/platform/exec.sfn", "../sfn/adapters/filesystem.sfn", "../sfn/adapters/http.sfn", "../sfn/concurrency/scheduler.sfn", "../sfn/concurrency/future.sfn", "../sfn/concurrency/channel.sfn", "../sfn/concurrency/serve.sfn"]
+sfn-sources = ["../sfn/memory/arena.sfn", "../sfn/memory/rc.sfn", "../sfn/memory/mem.sfn", "../sfn/string.sfn", "../sfn/array.sfn", "../sfn/clock.sfn", "../sfn/process.sfn", "../sfn/io.sfn", "../sfn/exception.sfn", "../sfn/type_meta.sfn", "../sfn/platform/exec.sfn", "../sfn/adapters/filesystem.sfn", "../sfn/adapters/http.sfn", "../sfn/concurrency/scheduler.sfn", "../sfn/concurrency/future.sfn", "../sfn/concurrency/channel.sfn", "../sfn/concurrency/parallel.sfn", "../sfn/concurrency/serve.sfn"]
 include-dirs = ["include"]
 link-libs = ["-lm", "-lpthread"]
 

--- a/runtime/sfn/concurrency/parallel.sfn
+++ b/runtime/sfn/concurrency/parallel.sfn
@@ -60,13 +60,44 @@ extern fn sfn_spawn(fn_ptr: i64, ctx: i64, result_size: i64) -> * u8;
 
 extern fn sfn_await(future: * u8) -> * u8;
 
+// Await (and discard) every spawned future in a `count`-element futures
+// array based at `futures_base`. The failure paths use this to honor the
+// structured contract — no spawned task may outlive the `sfn_parallel`
+// call (a still-running task can read caller `ctx` memory). `sfn_await`
+// is null-safe, so unspawned (null) slots drain harmlessly.
+fn _sfn_parallel_drain(futures_base: i64, count: i64) -> void {
+    let mut k: i64 = 0;
+    loop {
+        if k >= count { break; }
+        let slot: * i64 = (futures_base + k * 8) as * i64;
+        let future: * u8 = atomic_load(slot) as * u8;
+        sfn_await(future);
+        k = k + 1;
+    }
+}
+
 // `sfn_parallel(fn_ptrs, ctxs, count)` — fan out `count` tasks, join
 // them, and return their results in input order. See the file header for
 // the full contract. Empty input returns null; allocation failure
-// returns null (after releasing any scratch already taken).
+// returns null (after draining any spawned tasks and releasing scratch).
 fn sfn_parallel(fn_ptrs: * u8, ctxs: * u8, count: i64) -> * u8 {
     // Empty (or negative) input → empty output. Nothing is allocated.
     if count <= 0 { return null; }
+
+    // A non-empty fan-out with no task array is a caller bug: every slot
+    // would dereference near-null. Reject rather than crash (matching
+    // scheduler.sfn's null-handle discipline). A null `ctxs`, by
+    // contrast, is VALID — it means "every task receives a zero ctx".
+    if fn_ptrs as i64 == 0 { return null; }
+
+    // Overflow guard on the `count * 8` allocation size: a `count` past
+    // floor((2^63 - 1) / 8) = 0x0FFF_FFFF_FFFF_FFFF would wrap the byte
+    // size to a small (or negative) value, under-allocate, and invite
+    // out-of-bounds slot writes — so reject it rather than malloc a
+    // too-small array. Mirrors the ring-capacity clamp in scheduler.sfn
+    // (`_sfn_taskqueue_max_capacity`). Real fan-out widths are tiny; this
+    // guards the absurd-input corner, not a hot path.
+    if count > 1152921504606846975 { return null; }
 
     let fns_base: i64 = fn_ptrs as i64;
     let ctxs_base: i64 = ctxs as i64;
@@ -79,6 +110,11 @@ fn sfn_parallel(fn_ptrs: * u8, ctxs: * u8, count: i64) -> * u8 {
     let futures_base: i64 = futures as i64;
 
     // ── Fan-out: spawn every task. ────────────────────────────────
+    // A failed spawn (null future on scheduler-init failure or OOM)
+    // stores null in its slot and fan-out continues; the join phase
+    // awaits every slot (`sfn_await` is null-safe), so already-spawned
+    // tasks are never abandoned — the structured fan-out/join contract
+    // holds even on a partial spawn failure.
     let mut i: i64 = 0;
     loop {
         if i >= count { break; }
@@ -104,6 +140,11 @@ fn sfn_parallel(fn_ptrs: * u8, ctxs: * u8, count: i64) -> * u8 {
     // Results array, returned to the caller (it owns and frees it).
     let results: * u8 = malloc((count * 8) as usize);
     if results as i64 == 0 {
+        // Structured-concurrency contract: spawned tasks must not outlive
+        // this call (a running task may still read caller `ctx`). Drain
+        // every spawned future before bailing, even though we can no
+        // longer hand back results.
+        _sfn_parallel_drain(futures_base, count);
         free(futures);
         return null;
     }

--- a/runtime/sfn/concurrency/parallel.sfn
+++ b/runtime/sfn/concurrency/parallel.sfn
@@ -1,0 +1,130 @@
+// runtime/sfn/concurrency/parallel.sfn
+//
+// Pure fan-out/join combinator over `sfn_spawn` / `sfn_await`
+// (`runtime/sfn/concurrency/future.sfn`, issue #1090). Implements
+// `docs/runtime_architecture.md` §2.6.5. Resolves issue #1093 (M4
+// scheduler-core track, epic #965).
+//
+// ── What this is ──────────────────────────────────────────────
+// `sfn_parallel` spawns every task onto the shared v0 scheduler, awaits
+// them all, and returns their results in INPUT ORDER. It is a
+// CONVENIENCE COMBINATOR built entirely on the existing spawn+await
+// surface — it adds NO new runtime-helper descriptor and NO new
+// scheduler primitive (the untyped channel/spawn/parallel descriptors
+// were removed; see `runtime_helpers.sfn:442`). The fan-out happens
+// first (spawn all, so the pool runs them concurrently); only then does
+// the join phase block on each result.
+//
+// ── Public surface ────────────────────────────────────────────
+//   sfn_parallel(fn_ptrs: * u8, ctxs: * u8, count: i64) -> * u8
+//     fn_ptrs: address of a `count`-element i64 array; entry i is the
+//              raw address of a `fn(* u8) -> * u8` worker (the same
+//              plain C-ABI worry sfn_spawn enqueues).
+//     ctxs:    address of a `count`-element i64 array; entry i is the
+//              ctx (`* u8`) handed to worker i. A null `ctxs` means
+//              every task receives a zero ctx (the zero-argument case).
+//     count:   number of tasks. `count <= 0` returns null — empty input
+//              yields empty output, allocating nothing.
+//     Returns: address of a freshly `malloc`'d `count`-element i64
+//              array; slot i holds worker i's result (`* u8` as i64), in
+//              input order. The caller owns the array and frees it.
+//              Returns null on allocation failure.
+//
+// ── Result packing ────────────────────────────────────────────
+// Identical to `future.sfn`: each result is the raw `* u8` the worker
+// returned, stored as an i64. Typed callers reinterpret per element type
+// (f64 bit-cast, i64, 0/1 bool, pointer) exactly as the `sfn_await_*`
+// helpers already do — `sfn_parallel` is type-agnostic.
+//
+// ── Externs (re-declared inline) ──────────────────────────────
+// `sfn_spawn` / `sfn_await` are DEFINED functions in `future.sfn`.
+// Following the `scheduler.sfn` / `future.sfn` discipline (the seed
+// resolves imported defined functions unreliably, so modules re-declare
+// the surface they call directly), they are re-declared here as externs
+// and resolved at link time.
+//
+// ── Pointer-as-address / address-arithmetic convention ────────
+// Heap pointers are kept as i64 addresses and cast to typed `* T` views
+// at the use site (matching `scheduler.sfn`). Slot addresses are formed
+// by holding the base in an i64 LOCAL first, then `(base + idx * 8) as
+// * i64` — the inline `(ptr as i64 + off) as * i64` form miscompiles
+// today (the cast collapses to a bare bitcast, dropping the offset; see
+// `scheduler.sfn:559-563`). Scratch/result slots are read and written
+// through the `atomic_load` / `atomic_store` builtins (#323), matching
+// the ring-buffer slot accesses in `scheduler.sfn`.
+extern fn malloc(size: usize) -> * u8;
+
+extern fn free(ptr: * u8) -> void;
+
+extern fn sfn_spawn(fn_ptr: i64, ctx: i64, result_size: i64) -> * u8;
+
+extern fn sfn_await(future: * u8) -> * u8;
+
+// `sfn_parallel(fn_ptrs, ctxs, count)` — fan out `count` tasks, join
+// them, and return their results in input order. See the file header for
+// the full contract. Empty input returns null; allocation failure
+// returns null (after releasing any scratch already taken).
+fn sfn_parallel(fn_ptrs: * u8, ctxs: * u8, count: i64) -> * u8 {
+    // Empty (or negative) input → empty output. Nothing is allocated.
+    if count <= 0 { return null; }
+
+    let fns_base: i64 = fn_ptrs as i64;
+    let ctxs_base: i64 = ctxs as i64;
+
+    // Scratch array of futures (one i64 task handle per task). Spawning
+    // ALL tasks before awaiting any is what makes this parallel: the
+    // pool drains the queue while the producer is still enqueuing.
+    let futures: * u8 = malloc((count * 8) as usize);
+    if futures as i64 == 0 { return null; }
+    let futures_base: i64 = futures as i64;
+
+    // ── Fan-out: spawn every task. ────────────────────────────────
+    let mut i: i64 = 0;
+    loop {
+        if i >= count { break; }
+
+        let fn_slot: * i64 = (fns_base + i * 8) as * i64;
+        let fn_addr: i64 = atomic_load(fn_slot);
+
+        // A null `ctxs` array means "no per-task ctx" → pass zero.
+        let mut ctx_val: i64 = 0;
+        if ctxs_base != 0 {
+            let ctx_slot: * i64 = (ctxs_base + i * 8) as * i64;
+            ctx_val = atomic_load(ctx_slot);
+        }
+
+        let future: * u8 = sfn_spawn(fn_addr, ctx_val, 8);
+
+        let out_slot: * i64 = (futures_base + i * 8) as * i64;
+        atomic_store(out_slot, future as i64);
+
+        i = i + 1;
+    }
+
+    // Results array, returned to the caller (it owns and frees it).
+    let results: * u8 = malloc((count * 8) as usize);
+    if results as i64 == 0 {
+        free(futures);
+        return null;
+    }
+    let results_base: i64 = results as i64;
+
+    // ── Join: await each future in input order. ───────────────────
+    let mut j: i64 = 0;
+    loop {
+        if j >= count { break; }
+
+        let fut_slot: * i64 = (futures_base + j * 8) as * i64;
+        let future: * u8 = atomic_load(fut_slot) as * u8;
+
+        let result: * u8 = sfn_await(future);
+
+        let res_slot: * i64 = (results_base + j * 8) as * i64;
+        atomic_store(res_slot, result as i64);
+
+        j = j + 1;
+    }
+
+    free(futures);
+    return results;
+}


### PR DESCRIPTION
## Summary
- Add `runtime/sfn/concurrency/parallel.sfn` — a pure structured fan-out/join combinator over the existing `sfn_spawn` / `sfn_await` surface (#1090). `sfn_parallel(fn_ptrs, ctxs, count)` spawns all tasks onto the shared v0 scheduler first (concurrent execution), then awaits each in **input order**, returning a `malloc`'d i64 result array in input order.
- No new runtime-helper descriptor and no new scheduler primitive — it only calls spawn+await (a convenience combinator, per the issue). Design: `docs/runtime_architecture.md` §2.6.5.
- Wired into `runtime/native/capsule.toml` sfn-sources alongside scheduler/future/channel/serve so it's actually compiled into the runtime (the cross-windows test already excludes `concurrency/*`, so no drift there).

Closes #1093

## Acceptance Criteria
- [x] spawns all, awaits all, returns results in input order
- [x] empty input returns empty (`count <= 0` → null, no allocation; negative count also → null)
- [x] no descriptor added (combinator only — IR-shape test asserts `@sfn_parallel` only *declares* `@sfn_spawn`/`@sfn_await`, defines neither, and adds no new `@sfn_*` descriptor)
- [x] `make compile` passes (self-host holds with parallel.sfn linked into the runtime)
- [x] `make test` passes
- [x] `sfn fmt --check` clean on every touched `.sfn`

## Verification
```text
make compile                          → pass (self-host)
test_runtime_parallel_combinator.sh   → 4/4 (sfn check, fmt, IR-shape, linked 64-task roundtrip)
e2e-sh suite                          → 116/116
sfn test unit/integration/e2e/capsules→ 138/138, 31/31, 5/5, 34/34 (exit 0)
sfn fmt --check parallel.sfn          → clean
```

The linked roundtrip fans out 64 tasks (each result `ctx*ctx + 7`, so out-of-order pool completion would surface a wrong slot mapping), verifies input-order results, exercises the null-`ctxs` path (zero ctx → `7`), and checks the empty/negative-count → null fast path.

> **Note on a transient CI-class flake:** one `make test` run hit an intermittent `SIGSEGV` (Error 139) in the native `.sfn` test runner process. It did not reproduce — re-running the exact crashing command passed all suites cleanly (138/31/5/34, exit 0). This change only adds a dead-code `sfn_parallel` definition to the runtime (no module init, never called by any test), so it cannot cause a runtime crash. Flagging for visibility in case the native runner's intermittent segfault is tracked elsewhere.

## Files Changed
- `runtime/sfn/concurrency/parallel.sfn` (new)
- `runtime/native/capsule.toml` (wire parallel.sfn into sfn-sources)
- `compiler/tests/e2e/test_runtime_parallel_combinator.sh` (new)
- `docs/status.md` (changelog entry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011g7KjdfqxwaMg7SuXTuejn)_