### PR TITLE
perf(test-runner): content-addressed per-test binary cache (#1230)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,6 +128,14 @@ endif
 export SAILFIN_AGENT_REPORT
 AGENT_REPORT := bash scripts/agent_report.sh
 
+# Extra flags appended to every `$(NATIVE_BIN) test ...` invocation
+# (#1230). Empty by default so the local `make test` inner loop uses the
+# per-test binary cache and gets fast incremental reruns. The `make
+# check` full-suite gate overrides this to `--no-test-cache` so the
+# merge/seedcheck gate always cold-builds every test binary — the cache
+# can never mask a test-compile regression.
+TEST_BIN_CACHE_FLAGS ?=
+
 help:
 	@echo "Common Sailfin tasks"
 	@echo ""
@@ -193,9 +201,9 @@ test-impl:
 	if [ "$${SAILFIN_AGENT_REPORT:-}" = "1" ]; then \
 		mkdir -p build; \
 		set -o pipefail; \
-		$(NATIVE_BIN) test compiler/tests/unit compiler/tests/integration compiler/tests/e2e capsules --json | tee build/agent-test.test.jsonl || rc=$$?; \
+		$(NATIVE_BIN) test compiler/tests/unit compiler/tests/integration compiler/tests/e2e capsules $(TEST_BIN_CACHE_FLAGS) --json | tee build/agent-test.test.jsonl || rc=$$?; \
 	else \
-		$(NATIVE_BIN) test compiler/tests/unit compiler/tests/integration compiler/tests/e2e capsules || rc=$$?; \
+		$(NATIVE_BIN) test compiler/tests/unit compiler/tests/integration compiler/tests/e2e capsules $(TEST_BIN_CACHE_FLAGS) || rc=$$?; \
 	fi; \
 	$(MAKE) test-e2e-sh || rc=$$?; \
 	exit $$rc
@@ -521,7 +529,7 @@ check-impl:
 		exit 1; \
 	fi
 	@echo "[check] running test suite on first-pass binary (early gate)..."
-	@$(MAKE) test NATIVE_BIN=build/native/sailfin
+	@$(MAKE) test NATIVE_BIN=build/native/sailfin TEST_BIN_CACHE_FLAGS=--no-test-cache
 	@echo "[check] first-pass tests passed — proceeding to seedcheck build..."
 	@echo "[check] verifying seed selfhost (stage2)..."
 	@# Stage2 routes through `sfn build -p compiler --work-dir <DIR>`
@@ -564,7 +572,7 @@ check-impl:
 	fi; \
 	echo "[check] seedcheck binary runs hello-world.sfn OK"
 	@echo "[check] running test suite with seedcheck binary (no fallbacks)..."
-	@$(MAKE) test NATIVE_BIN=build/native/sailfin-seedcheck
+	@$(MAKE) test NATIVE_BIN=build/native/sailfin-seedcheck TEST_BIN_CACHE_FLAGS=--no-test-cache
 	@echo ""
 	@echo "[check] stage2 tests passed — building stage3 for fixed-point comparison..."
 	@# Same shape as stage2 — driver `--work-dir` with

--- a/compiler/src/build_cache.sfn
+++ b/compiler/src/build_cache.sfn
@@ -805,13 +805,23 @@ fn test_bin_cache_root() -> string ![io] {
 }
 
 // Derive the content-addressed cache key for a single test's linked
-// binary. The dep set is the EXACT set of inputs the link consumes —
-// the resolver-produced dependency `.ll` files (`dep_ll_paths`, hashed
-// off disk) plus the staged `.sfn-asm` import contexts
-// (`native_texts`, hashed in memory). Deriving the key from the same
-// resolver output the link already uses is the correctness hinge: the
-// key can never miss a dep, because a changed dep changes a hash here
-// exactly as it changes the bytes the linker reads.
+// binary. The dep set is the test-source-specific set of inputs the
+// link consumes — the resolver-produced dependency `.ll` files
+// (`dep_ll_paths`, hashed off disk) plus the staged `.sfn-asm` import
+// contexts (`native_texts`, hashed in memory). Deriving the key from
+// the same resolver output the link already uses is the correctness
+// hinge for the test's OWN closure: a changed test source or dep
+// changes a hash here exactly as it changes the bytes the linker reads.
+//
+// Known gap: the link ALSO pulls in the assembled runtime capsule
+// objects + link libs (`_clang_link_test_cmd_with_deps`), which are NOT
+// folded into this key. Those are covered indirectly by
+// `compiler_identity` (a rebuilt compiler — which is how a runtime
+// source edit normally reaches a test binary, since the runtime is
+// rebuilt as part of `make compile` — busts every entry) and directly
+// by `--no-test-cache` on the `make check` / full-suite gate. A runtime
+// edit that is NOT accompanied by a compiler rebuild can therefore
+// serve a stale binary; the gate's cold build is the backstop.
 //
 //   key = sha256(
 //       sha256(test_source_bytes)

--- a/compiler/src/build_cache.sfn
+++ b/compiler/src/build_cache.sfn
@@ -266,6 +266,12 @@ fn _filename_for_kind(kind: string) -> string {
     // ever aliasing in a shared cache entry, even though their content
     // keys are already disjoint.
     if kind == "runtime-obj" { return "runtime.o"; }
+    // Per-test linked binary cache (#1230, Lever 2 of
+    // `docs/proposals/ci-test-speed.md`). A distinct filename keeps
+    // the test-binary layer from ever aliasing the per-module `.o`
+    // `obj` kind in a shared entry directory, mirroring the
+    // `runtime-obj` precedent.
+    if kind == "test-bin" { return "test.bin"; }
     return "";
 }
 
@@ -756,6 +762,109 @@ fn cache_compiler_identity(compiler_version: string, compiler_binary_path: strin
     return compiler_version + "+bin." + bin_hash;
 }
 
+// ----------------------------------------------------------------
+// Per-test binary cache (#1230)
+// ----------------------------------------------------------------
+// Lever 2 (variant 2a) of `docs/proposals/ci-test-speed.md`: content-
+// address each test's linked native executable so an unchanged test
+// skips LLVM lowering + the clang link (the dominant per-test cost)
+// and just re-runs the cached binary. This is a *second consumer* of
+// the same content-addressing correctness model `cache_key_for` uses
+// for the module IR cache — a changed input (test source, any
+// transitive dep the link consumes, the compiler's identity, or the
+// clang flag set) changes the key and misses the cache; it can never
+// produce a false hit.
+//
+// The on-disk layout reuses the module cache's prefix-sharded entry
+// directory (`cache_artifact_path` with the `"test-bin"` kind) under a
+// SEPARATE schema-versioned root so the two layers age out
+// independently. Lookups/stores/restores go through the existing
+// single-artifact helpers (`cache_lookup_artifact`,
+// `cache_store_artifact`, `cache_copy_artifact_to`), inheriting their
+// atomic temp+rename publish and digest validation for free.
+// Bumped when the test-binary key derivation or layout changes in a
+// way that makes old entries incompatible. Independent of
+// `build_cache_schema_version` so a module-cache schema bump doesn't
+// needlessly evict warm test binaries (and vice versa).
+fn test_bin_cache_schema_version() -> string { return "v1"; }
+
+// Root for the per-test binary cache: `<base>/test-bin/<schema>`,
+// where `<base>` is `$SAILFIN_BUILD_CACHE_DIR` (when set) or the
+// in-tree `build/cache` default. Kept beside — not under — the module
+// cache's `<base>/v<N>` tree so the two schema lines evolve
+// independently. Pure variant for tests.
+fn test_bin_cache_root_with_override(override_path: string) -> string {
+    let mut base: string = "build/cache";
+    if override_path.length > 0 { base = override_path; }
+    return base + "/test-bin/" + test_bin_cache_schema_version();
+}
+
+// Production reader. Resolves `$SAILFIN_BUILD_CACHE_DIR` at call time.
+fn test_bin_cache_root() -> string ![io] {
+    return test_bin_cache_root_with_override(_get_env_cmd("SAILFIN_BUILD_CACHE_DIR"));
+}
+
+// Derive the content-addressed cache key for a single test's linked
+// binary. The dep set is the EXACT set of inputs the link consumes —
+// the resolver-produced dependency `.ll` files (`dep_ll_paths`, hashed
+// off disk) plus the staged `.sfn-asm` import contexts
+// (`native_texts`, hashed in memory). Deriving the key from the same
+// resolver output the link already uses is the correctness hinge: the
+// key can never miss a dep, because a changed dep changes a hash here
+// exactly as it changes the bytes the linker reads.
+//
+//   key = sha256(
+//       sha256(test_source_bytes)
+//       || sha256(sorted(dep hashes))   // dep_ll files + native_texts
+//       || compiler_identity            // cache_compiler_identity(...)
+//       || canonical(clang_flags)
+//       || test_bin_cache_schema_version()
+//   )
+//
+// Hashes are sorted before folding so the key is invariant under dep
+// enumeration order. `unique_suffix` disambiguates the `_sha256_of_string`
+// temp path across concurrent `sfn test` invocations on different
+// files — pass the (sanitized) test source path; reused sequentially
+// within one process, never across two processes hashing the same
+// file simultaneously (the module cache carries the identical
+// single-process precondition).
+fn test_bin_cache_key(test_source_path: string, dep_ll_paths: string[], native_texts: string[], compiler_identity: string, flags_canonical: string, unique_suffix: string) -> CacheKey ![io] {
+    let s_hash = _sha256_of_file_cmd(test_source_path);
+
+    let mut dep_hashes: string[] = [];
+    let mut i: int = 0;
+    loop {
+        if i >= dep_ll_paths.length { break; }
+        dep_hashes.push(_sha256_of_file_cmd(dep_ll_paths[i]));
+        i += 1;
+    }
+    let mut j: int = 0;
+    loop {
+        if j >= native_texts.length { break; }
+        dep_hashes.push(_sha256_of_string(native_texts[j], unique_suffix + "_nt"));
+        j += 1;
+    }
+
+    let sorted_dep_hashes = _sort_strings(dep_hashes);
+    let mut deps_concat: string = "";
+    let mut k: int = 0;
+    loop {
+        if k >= sorted_dep_hashes.length { break; }
+        if k > 0 { deps_concat = deps_concat + "|"; }
+        deps_concat = deps_concat + sorted_dep_hashes[k];
+        k += 1;
+    }
+    let deps_hash = _sha256_of_string(deps_concat, unique_suffix + "_deps");
+
+    let final_input = s_hash + "\n" + deps_hash + "\n" + compiler_identity
+        + "\n"
+        + flags_canonical
+        + "\n"
+        + test_bin_cache_schema_version();
+    let final_digest = _sha256_of_string(final_input, unique_suffix + "_final");
+    return CacheKey { digest: final_digest };
+}
+
 export {
     CacheKey,
     CacheEntryPaths,
@@ -783,5 +892,9 @@ export {
     empty_build_cache_config,
     resolve_build_cache_config,
     cache_clean,
-    is_valid_digest
+    is_valid_digest,
+    test_bin_cache_schema_version,
+    test_bin_cache_root_with_override,
+    test_bin_cache_root,
+    test_bin_cache_key
 };

--- a/compiler/src/cli_commands.sfn
+++ b/compiler/src/cli_commands.sfn
@@ -4,6 +4,16 @@
 // sailfin_cli_main under ~500 .sfn-asm instructions (avoids seed OOM).
 import { AssertFailure, _empty_assert_failure, _parse_assert_failure_record } from "./assert_failure";
 import { Program, Statement } from "./ast";
+import {
+    CacheKey,
+    cache_compiler_identity,
+    cache_copy_artifact_to,
+    cache_lookup_artifact,
+    cache_store_artifact,
+    canonicalize_flags,
+    test_bin_cache_key,
+    test_bin_cache_root
+} from "./build_cache";
 import { is_safe_scope_name, parse_scope_name } from "./capsule_artifact";
 import {
     ResolverConsumer,
@@ -95,6 +105,7 @@ import {
 } from "./toml_parser";
 import { format_source } from "./tools/fmt";
 import { load_imported_interfaces_from_paths } from "./typecheck_import_loader";
+import { resolve_compiler_version_for_cache } from "./version";
 
 // Validate a path segment (scope, name) contains no traversal or illegal chars.
 fn _is_safe_capsule_segment_cmd(value: string) -> boolean {
@@ -851,7 +862,7 @@ fn _append_test_filter_args(argv: string[], name_filter: string, tag_filter: str
     return out;
 }
 
-fn _run_test_child(timeout_cmd: string, timeout_secs: string, child_scratch: string, runtime_objdir: string, self_exe: string, path: string, name_filter: string, tag_filter: string, update_snapshots: boolean, json_output: boolean) -> int ![io] {
+fn _run_test_child(timeout_cmd: string, timeout_secs: string, child_scratch: string, runtime_objdir: string, self_exe: string, path: string, name_filter: string, tag_filter: string, update_snapshots: boolean, json_output: boolean, no_test_cache: boolean) -> int ![io] {
     // #940: `SAILFIN_TEST_RUNTIME_OBJDIR` points the child's runtime
     // link at the shared, invocation-stable object dir the parent
     // warmed once, so the runtime isn't recompiled per test file.
@@ -870,6 +881,7 @@ fn _run_test_child(timeout_cmd: string, timeout_secs: string, child_scratch: str
         base.push("test");
         base.push(path);
         if json_output { base.push("--json"); }
+        if no_test_cache { base.push("--no-test-cache"); }
         return process.run(_append_test_filter_args(base, name_filter, tag_filter));
     }
     let mut base = ["env", "SAILFIN_TEST_SCRATCH=" + child_scratch, "SAILFIN_TEST_RUNTIME_OBJDIR="
@@ -880,6 +892,7 @@ fn _run_test_child(timeout_cmd: string, timeout_secs: string, child_scratch: str
     base.push("test");
     base.push(path);
     if json_output { base.push("--json"); }
+    if no_test_cache { base.push("--no-test-cache"); }
     return process.run(_append_test_filter_args(base, name_filter, tag_filter));
 }
 
@@ -979,11 +992,21 @@ fn handle_test_command(args: string[], runtime_root: string, binary_dir: string)
     // overwrites instead of comparing. Defaults false; when false every
     // child `env` argv is byte-identical to the pre-#977 shape.
     let mut update_snapshots: boolean = false;
+    // `--no-test-cache` (#1230): bypass BOTH the read and the write of
+    // the per-test linked-binary cache for this invocation, forcing a
+    // cold lower+link for every test. `make check` / the nightly full
+    // suite pass it so the merge gate never reads the cache and a
+    // test-compile regression can never be masked by a stale hit.
+    // Forwarded to every per-file child below so a multi-file run
+    // honours it end-to-end.
+    let mut no_test_cache: boolean = false;
     let mut ai: int = 1;
     loop {
         if ai >= args.length { break; }
         let arg = args[ai];
-        if strings_equal(arg, "--json") { json_output = true; } else if strings_equal(arg, "--update-snapshots") {
+        if strings_equal(arg, "--json") { json_output = true; } else if strings_equal(arg, "--no-test-cache") {
+            no_test_cache = true;
+        } else if strings_equal(arg, "--update-snapshots") {
             update_snapshots = true;
         } else if strings_equal(arg, "-k") {
             if ai + 1 >= args.length {
@@ -1132,10 +1155,10 @@ fn handle_test_command(args: string[], runtime_root: string, binary_dir: string)
         // with no `tests/` dir) doesn't fail the build.
         if json_output {
             if json_subframe {
-                fs.writeFile(scratch_root + "/_subframe_summary.json", render_summary_event(0, 0, 0, 0));
+                fs.writeFile(scratch_root + "/_subframe_summary.json", render_summary_event(0, 0, 0, 0, 0, 0));
             } else {
                 print(render_start_event(0));
-                print(render_summary_event(0, 0, 0, 0));
+                print(render_summary_event(0, 0, 0, 0, 0, 0));
             }
             exit_test_runner_mode();
             return 0;
@@ -1278,6 +1301,11 @@ fn handle_test_command(args: string[], runtime_root: string, binary_dir: string)
         let mut sf_passed: int = 0;
         let mut sf_failed: int = 0;
         let mut sf_skipped: int = 0;
+        // #1230: aggregate each child's per-test-binary cache counters
+        // from its sub-frame summary so the parent's single run-level
+        // `summary` reports the run-wide `cache.test_bin_hit_rate`.
+        let mut sf_tb_hits: int = 0;
+        let mut sf_tb_misses: int = 0;
         let mut overall_rc: int = 0;
         let mut ti: int = 0;
         loop {
@@ -1292,7 +1320,7 @@ fn handle_test_command(args: string[], runtime_root: string, binary_dir: string)
             // this per-file dir — see `SAILFIN_TEST_RUNTIME_OBJDIR`.
             let child_scratch = sub_root + "/sub-" + number_to_string(ti);
             _ensure_dir_cmd(child_scratch);
-            let mut rc = _run_test_child(timeout_cmd, timeout_secs, child_scratch, sub_root, self_exe, path, name_filter, tag_filter, update_snapshots, json_output);
+            let mut rc = _run_test_child(timeout_cmd, timeout_secs, child_scratch, sub_root, self_exe, path, name_filter, tag_filter, update_snapshots, json_output, no_test_cache);
             if _should_retry_test(rc, sub_retries_disabled) {
                 // RETRY banner is a human-mode artifact; suppress it in
                 // JSON mode so the jsonl stream stays pure (mirrors the
@@ -1303,7 +1331,7 @@ fn handle_test_command(args: string[], runtime_root: string, binary_dir: string)
                         + number_to_string(rc)
                         + ", retrying once)");
                 }
-                rc = _run_test_child(timeout_cmd, timeout_secs, child_scratch, sub_root, self_exe, path, name_filter, tag_filter, update_snapshots, json_output);
+                rc = _run_test_child(timeout_cmd, timeout_secs, child_scratch, sub_root, self_exe, path, name_filter, tag_filter, update_snapshots, json_output, no_test_cache);
             }
             if rc == 0 { suites[suite_idx].pass_count += 1; } else {
                 suites[suite_idx].fail_count += 1;
@@ -1322,6 +1350,8 @@ fn handle_test_command(args: string[], runtime_root: string, binary_dir: string)
                     sf_passed += _extract_json_uint_after(sf_raw, "\"passed\":");
                     sf_failed += _extract_json_uint_after(sf_raw, "\"failed\":");
                     sf_skipped += _extract_json_uint_after(sf_raw, "\"skipped\":");
+                    sf_tb_hits += _extract_json_uint_after(sf_raw, "\"test_bin_hits\":");
+                    sf_tb_misses += _extract_json_uint_after(sf_raw, "\"test_bin_misses\":");
                 } else { sf_failed += sf_counts[ti]; }
             }
             ti += 1;
@@ -1331,7 +1361,7 @@ fn handle_test_command(args: string[], runtime_root: string, binary_dir: string)
             // one `start`, every per-test event the children forwarded,
             // one `summary` with run-level counts and wall-clock duration.
             let sf_dur = monotonic_millis() - sf_start_ms;
-            print(render_summary_event(sf_passed, sf_failed, sf_skipped, sf_dur));
+            print(render_summary_event(sf_passed, sf_failed, sf_skipped, sf_dur, sf_tb_hits, sf_tb_misses));
         } else if emit_banners { _emit_suite_banners(suites); }
         exit_test_runner_mode();
         _cleanup_test_scratch(scratch_owned, sub_root, overall_rc == 0);
@@ -1527,6 +1557,24 @@ fn handle_test_command(args: string[], runtime_root: string, binary_dir: string)
     let mut total_skipped: int = 0;
     let mut overall_rc: int = 0;
 
+    // #1230: per-test linked-binary cache. Resolve the invocation-stable
+    // key inputs once: the compiler's cache identity (binary content for
+    // `.dirty` dev stamps, version otherwise — the same model the module
+    // IR cache uses so a rebuilt compiler busts every cached binary) and
+    // the canonical clang flag set (`-O0`, matching
+    // `_clang_link_test_cmd_with_deps`). Per-test the key folds in the
+    // test source hash + the resolver's dep closure
+    // (`dep_ll_paths` + `native_texts`). `--no-test-cache` disables both
+    // the read and the write so `make check` always cold-builds.
+    let test_cache_enabled = !no_test_cache;
+    let tb_cache_root = test_bin_cache_root();
+    let tb_self_exe = _resolve_test_self_path(binary_dir);
+    let tb_compiler_identity = cache_compiler_identity(resolve_compiler_version_for_cache(binary_dir), tb_self_exe);
+    let mut tb_flags: string[] = ["-O0"];
+    let tb_flags_canonical = canonicalize_flags(tb_flags);
+    let mut test_bin_hits: int = 0;
+    let mut test_bin_misses: int = 0;
+
     let mut index: int = 0;
     loop {
         if index >= test_files.length { break; }
@@ -1547,76 +1595,116 @@ fn handle_test_command(args: string[], runtime_root: string, binary_dir: string)
 
         let file_start_ms = monotonic_millis();
 
-        if trace_runner { print.err("test runner: compile start"); }
-        _clean_lowering_state(scratch_root);
-        let empty_manifests: LayoutManifest[] = [];
-        let _compiled = compile_tests_to_llvm_file_with_module_imports(source, module_name, ll_path, groups[group_idx].interfaces, empty_manifests, groups[group_idx].native_texts, groups[group_idx].function_effects, groups[group_idx].capabilities_required);
-        if !_compiled {
-            // Stderr stays usable for compiler-internal diagnostics
-            // even in `--json` mode; the affected tests show up as
-            // `skip` events with a synthetic assertion message so
-            // consumers can correlate the stderr noise with the
-            // tests that didn't run.
-            print.err("test runner: compile failed for " + path);
-            if json_output {
-                let outcome = _outcome_setup_failure(_synthetic_assert_failure(path, "compile failed"));
-                let packed = _emit_file_test_events(entries, outcome);
-                total_passed += _trj_decode_passed(packed);
-                total_failed += _trj_decode_failed(packed);
-                total_skipped += _trj_decode_skipped(packed);
-                overall_rc = 1;
+        // #1230: derive the per-test binary cache key from the test
+        // source + the resolver's dep closure (the EXACT inputs the link
+        // consumes), then try to serve the linked binary from cache. On
+        // a hit we copy it into `exe_path` and skip both LLVM lowering
+        // and the clang link (the dominant per-test cost); we still RUN
+        // the binary below (variant 2a — never trust a cached result).
+        let mut tb_key: CacheKey = CacheKey { digest: "" };
+        let mut cache_hit: boolean = false;
+        if test_cache_enabled {
+            tb_key = test_bin_cache_key(path, groups[group_idx].dep_ll_paths, groups[group_idx].native_texts, tb_compiler_identity, tb_flags_canonical, _sanitize_filename_cmd(path));
+            if cache_lookup_artifact(tb_cache_root, tb_key, "test-bin") {
+                if cache_copy_artifact_to(tb_cache_root, tb_key, "test-bin", exe_path) {
+                    // The shared atomic-copy helper publishes through an
+                    // `mktemp` temp (mode 0600), so the restored binary
+                    // loses the executable bit clang gave the original —
+                    // harmless for the `.ll`/`.o` artifacts the module
+                    // cache restores, fatal for a binary we then `exec`
+                    // (`Permission denied`, rc 126). Re-assert +x on the
+                    // materialised executable.
+                    process.run(["chmod", "+x", exe_path]);
+                    cache_hit = true;
+                    test_bin_hits += 1;
+                    if trace_runner {
+                        print.err("test runner: test-bin cache hit (" + path
+                            + ")");
+                    }
+                }
+            }
+        }
+
+        if !cache_hit {
+            if trace_runner { print.err("test runner: compile start"); }
+            _clean_lowering_state(scratch_root);
+            let empty_manifests: LayoutManifest[] = [];
+            let _compiled = compile_tests_to_llvm_file_with_module_imports(source, module_name, ll_path, groups[group_idx].interfaces, empty_manifests, groups[group_idx].native_texts, groups[group_idx].function_effects, groups[group_idx].capabilities_required);
+            if !_compiled {
+                // Stderr stays usable for compiler-internal diagnostics
+                // even in `--json` mode; the affected tests show up as
+                // `skip` events with a synthetic assertion message so
+                // consumers can correlate the stderr noise with the
+                // tests that didn't run.
+                print.err("test runner: compile failed for " + path);
+                if json_output {
+                    let outcome = _outcome_setup_failure(_synthetic_assert_failure(path, "compile failed"));
+                    let packed = _emit_file_test_events(entries, outcome);
+                    total_passed += _trj_decode_passed(packed);
+                    total_failed += _trj_decode_failed(packed);
+                    total_skipped += _trj_decode_skipped(packed);
+                    overall_rc = 1;
+                    sailfin_intrinsic_runtime_arena_rewind(test_scratch_mark);
+                    index += 1;
+                    continue;
+                }
+                // FAIL banner on compile failure: the bash wrapper
+                // surfaced this as `[test] FAIL: <basename> (exit code 1,
+                // ...)`. Emit the same shape so callers parsing test
+                // output (CI log scrubbers, human readers) see consistent
+                // attribution regardless of which stage failed.
+                let cf_basename = _package_basename(path);
+                print("[test] FAIL: " + cf_basename + " (exit code 1)");
+                suites[file_suite_index[index]].fail_count += 1;
+                suites[file_suite_index[index]].failed_files.push(cf_basename);
+                if overall_rc == 0 { overall_rc = 1; }
                 sailfin_intrinsic_runtime_arena_rewind(test_scratch_mark);
                 index += 1;
                 continue;
             }
-            // FAIL banner on compile failure: the bash wrapper
-            // surfaced this as `[test] FAIL: <basename> (exit code 1,
-            // ...)`. Emit the same shape so callers parsing test
-            // output (CI log scrubbers, human readers) see consistent
-            // attribution regardless of which stage failed.
-            let cf_basename = _package_basename(path);
-            print("[test] FAIL: " + cf_basename + " (exit code 1)");
-            suites[file_suite_index[index]].fail_count += 1;
-            suites[file_suite_index[index]].failed_files.push(cf_basename);
-            if overall_rc == 0 { overall_rc = 1; }
-            sailfin_intrinsic_runtime_arena_rewind(test_scratch_mark);
-            index += 1;
-            continue;
-        }
 
-        if trace_runner { print.err("test runner: link start"); }
-        let link_rc = _clang_link_test_cmd_with_deps(ll_path, exe_path, runtime_root, groups[group_idx].dep_ll_paths, scratch_root, binary_dir);
-        if link_rc != 0 {
-            print.err("link failed (clang exit=" + number_to_string(link_rc)
-                + ")");
-            if json_output {
-                let outcome = _outcome_setup_failure(_synthetic_assert_failure(path, "link failed (clang exit="
+            if trace_runner { print.err("test runner: link start"); }
+            let link_rc = _clang_link_test_cmd_with_deps(ll_path, exe_path, runtime_root, groups[group_idx].dep_ll_paths, scratch_root, binary_dir);
+            if link_rc != 0 {
+                print.err("link failed (clang exit=" + number_to_string(link_rc)
+                    + ")");
+                if json_output {
+                    let outcome = _outcome_setup_failure(_synthetic_assert_failure(path, "link failed (clang exit="
+                        + number_to_string(link_rc)
+                        + ")"));
+                    let packed = _emit_file_test_events(entries, outcome);
+                    total_passed += _trj_decode_passed(packed);
+                    total_failed += _trj_decode_failed(packed);
+                    total_skipped += _trj_decode_skipped(packed);
+                    if overall_rc == 0 { overall_rc = link_rc; }
+                    sailfin_intrinsic_runtime_arena_rewind(test_scratch_mark);
+                    index += 1;
+                    continue;
+                }
+                // FAIL banner on link failure (issue #845). Same rationale
+                // as the compile-failure banner above — keep `[test] FAIL`
+                // attribution consistent across every failure stage so
+                // tooling (CI scrubbers, human readers, future grep-based
+                // log audits) sees one shape.
+                let lf_basename = _package_basename(path);
+                print("[test] FAIL: " + lf_basename + " (exit code "
                     + number_to_string(link_rc)
-                    + ")"));
-                let packed = _emit_file_test_events(entries, outcome);
-                total_passed += _trj_decode_passed(packed);
-                total_failed += _trj_decode_failed(packed);
-                total_skipped += _trj_decode_skipped(packed);
+                    + ")");
+                suites[file_suite_index[index]].fail_count += 1;
+                suites[file_suite_index[index]].failed_files.push(lf_basename);
                 if overall_rc == 0 { overall_rc = link_rc; }
                 sailfin_intrinsic_runtime_arena_rewind(test_scratch_mark);
                 index += 1;
                 continue;
             }
-            // FAIL banner on link failure (issue #845). Same rationale
-            // as the compile-failure banner above — keep `[test] FAIL`
-            // attribution consistent across every failure stage so
-            // tooling (CI scrubbers, human readers, future grep-based
-            // log audits) sees one shape.
-            let lf_basename = _package_basename(path);
-            print("[test] FAIL: " + lf_basename + " (exit code "
-                + number_to_string(link_rc)
-                + ")");
-            suites[file_suite_index[index]].fail_count += 1;
-            suites[file_suite_index[index]].failed_files.push(lf_basename);
-            if overall_rc == 0 { overall_rc = link_rc; }
-            sailfin_intrinsic_runtime_arena_rewind(test_scratch_mark);
-            index += 1;
-            continue;
+            // #1230: a fresh lower+link produced `exe_path`; record the miss
+            // and populate the cache so the next unchanged run hits. The
+            // store is atomic (temp+rename) and non-fatal — a write failure
+            // just means the next run misses again, never a broken binary.
+            if test_cache_enabled {
+                test_bin_misses += 1;
+                cache_store_artifact(tb_cache_root, tb_key, "test-bin", exe_path);
+            }
         }
         // Issue #364: clear any leftover assert-fail record from the
         // previous iteration before spawning. The record is keyed
@@ -1737,7 +1825,7 @@ fn handle_test_command(args: string[], runtime_root: string, binary_dir: string)
     }
     if json_output {
         let runner_elapsed_ms = monotonic_millis() - runner_start_ms;
-        let summary_line = render_summary_event(total_passed, total_failed, total_skipped, runner_elapsed_ms);
+        let summary_line = render_summary_event(total_passed, total_failed, total_skipped, runner_elapsed_ms, test_bin_hits, test_bin_misses);
         // Sub-frame children hand their counts to the parent via a file
         // instead of printing a per-file summary onto the shared stream.
         if json_subframe {

--- a/compiler/src/cli_commands.sfn
+++ b/compiler/src/cli_commands.sfn
@@ -1596,15 +1596,28 @@ fn handle_test_command(args: string[], runtime_root: string, binary_dir: string)
         let file_start_ms = monotonic_millis();
 
         // #1230: derive the per-test binary cache key from the test
-        // source + the resolver's dep closure (the EXACT inputs the link
-        // consumes), then try to serve the linked binary from cache. On
-        // a hit we copy it into `exe_path` and skip both LLVM lowering
-        // and the clang link (the dominant per-test cost); we still RUN
-        // the binary below (variant 2a — never trust a cached result).
+        // source + the resolver's dep closure (the test-source-specific
+        // link inputs — the runtime capsule objects + link libs the link
+        // also consumes are NOT folded in; a runtime edit relies on the
+        // compiler-identity component or `--no-test-cache`, see
+        // `test_bin_cache_key`), then try to serve the linked binary from
+        // cache. On a hit we copy it into `exe_path` and skip both LLVM
+        // lowering and the clang link (the dominant per-test cost); we
+        // still RUN the binary below (variant 2a — never trust a cached
+        // result).
+        //
+        // The `_sha256_of_string` temp path is disambiguated by
+        // `scratch_root` (per-invocation / per-child unique — the
+        // multi-file parent mints a `mktemp -d` and hands each child its
+        // own `sub-N`; seedcheck pins `SAILFIN_TEST_SCRATCH`) so
+        // concurrent `sfn test` invocations and CI shards never collide
+        // on the deterministic `/tmp/.sfn_build_cache_hash_*` tmp file.
         let mut tb_key: CacheKey = CacheKey { digest: "" };
         let mut cache_hit: boolean = false;
         if test_cache_enabled {
-            tb_key = test_bin_cache_key(path, groups[group_idx].dep_ll_paths, groups[group_idx].native_texts, tb_compiler_identity, tb_flags_canonical, _sanitize_filename_cmd(path));
+            tb_key = test_bin_cache_key(path, groups[group_idx].dep_ll_paths, groups[group_idx].native_texts, tb_compiler_identity, tb_flags_canonical, _sanitize_filename_cmd(scratch_root
+                + "/"
+                + path));
             if cache_lookup_artifact(tb_cache_root, tb_key, "test-bin") {
                 if cache_copy_artifact_to(tb_cache_root, tb_key, "test-bin", exe_path) {
                     // The shared atomic-copy helper publishes through an
@@ -1612,14 +1625,18 @@ fn handle_test_command(args: string[], runtime_root: string, binary_dir: string)
                     // loses the executable bit clang gave the original —
                     // harmless for the `.ll`/`.o` artifacts the module
                     // cache restores, fatal for a binary we then `exec`
-                    // (`Permission denied`, rc 126). Re-assert +x on the
-                    // materialised executable.
-                    process.run(["chmod", "+x", exe_path]);
-                    cache_hit = true;
-                    test_bin_hits += 1;
-                    if trace_runner {
-                        print.err("test runner: test-bin cache hit (" + path
-                            + ")");
+                    // (`Permission denied`, rc 126). Re-assert +x; only
+                    // count the hit when chmod succeeds, otherwise leave
+                    // `cache_hit` false so the run falls through to a cold
+                    // lower+link (counted as a miss) rather than exec'ing a
+                    // non-executable file.
+                    if process.run(["chmod", "+x", exe_path]) == 0 {
+                        cache_hit = true;
+                        test_bin_hits += 1;
+                        if trace_runner {
+                            print.err("test runner: test-bin cache hit (" + path
+                                + ")");
+                        }
                     }
                 }
             }

--- a/compiler/src/test_runner_json.sfn
+++ b/compiler/src/test_runner_json.sfn
@@ -210,16 +210,53 @@ fn render_test_event(name: string, file: string, line: int, status: string, dura
     return "{" + _trj_join(parts, ",") + "}";
 }
 
+// Format the per-test-binary cache hit rate as a fixed 4-decimal
+// fraction (#1230). Mirrors `build_report.sfn::_br_format_hit_rate`
+// so CI gates can compare `cache.test_bin_hit_rate >= X` the same way
+// they do `cache.hit_rate` for the build report. Zero denominator
+// (no cache lookups attempted — e.g. `--no-test-cache`) emits
+// `0.0000`, never `null`/`nan`; a fully-warm rerun emits `1.0000`.
+// Truncates toward zero to match the floor semantics gate thresholds
+// assume.
+fn _trj_format_hit_rate(hits: int, misses: int) -> string {
+    let denom: int = hits + misses;
+    if denom == 0 { return "0.0000"; }
+    let mut scaled: int = ((hits * 10000) / denom) as int;
+    if scaled >= 10000 { return "1.0000"; }
+    if scaled < 0 { scaled = 0; }
+    let mut frac = _trj_number_to_string(scaled);
+    loop {
+        if frac.length >= 4 { break; }
+        frac = "0" + frac;
+    }
+    return "0." + frac;
+}
+
+// The `cache` sub-object embedded in the summary event (#1230). Mirrors
+// the build `--json` report's `cache` object: raw counters plus the
+// derived `test_bin_hit_rate` so consumers needn't recompute it.
+fn _trj_cache_object(test_bin_hits: int, test_bin_misses: int) -> string {
+    let mut parts: string[] = [];
+    parts.push(_trj_number_field("test_bin_hits", test_bin_hits));
+    parts.push(_trj_number_field("test_bin_misses", test_bin_misses));
+    parts.push(_trj_field("test_bin_hit_rate", _trj_format_hit_rate(test_bin_hits, test_bin_misses)));
+    return "{" + _trj_join(parts, ",") + "}";
+}
+
 // Final line of a `sfn test --json` run. Emitted exactly once, after
 // the last `test` event. `duration_ms` is the wall-clock time of the
-// whole runner invocation.
-fn render_summary_event(passed: int, failed: int, skipped: int, duration_ms: int) -> string {
+// whole runner invocation. The `cache` object (#1230) carries the
+// per-test-binary cache counters; an additive optional field, so no
+// `TEST_RUNNER_JSON_SCHEMA_VERSION` bump (consumers ignore unknown
+// keys per the schema policy above).
+fn render_summary_event(passed: int, failed: int, skipped: int, duration_ms: int, test_bin_hits: int, test_bin_misses: int) -> string {
     let mut parts: string[] = [];
     parts.push(_trj_string_field("event", "summary"));
     parts.push(_trj_number_field("passed", passed));
     parts.push(_trj_number_field("failed", failed));
     parts.push(_trj_number_field("skipped", skipped));
     parts.push(_trj_number_field("duration_ms", duration_ms));
+    parts.push(_trj_field("cache", _trj_cache_object(test_bin_hits, test_bin_misses)));
     return "{" + _trj_join(parts, ",") + "}";
 }
 

--- a/compiler/tests/e2e/test_test_bin_cache.sh
+++ b/compiler/tests/e2e/test_test_bin_cache.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# End-to-end test for the per-test binary cache (#1230, Lever 2 of
+# docs/proposals/ci-test-speed.md).
+#
+# Proves the cross-invocation behaviors the native unit/integration
+# tests cannot observe (those cover the cache-key correctness hinge and
+# the JSON shape in-process). Here we run the `sfn test` binary multiple
+# times and diff the `cache.test_bin_hit_rate` field in the `--json`
+# summary:
+#
+#   1. Cold run  → every test misses (hit_rate 0.0000), and the binary
+#      cache is populated.
+#   2. Warm rerun (no source change) → every test hits (hit_rate 1.0000);
+#      lower+link is skipped for each unchanged test.
+#   3. `--no-test-cache` → both counters zero (hit_rate 0.0000); the
+#      cache is neither read nor written.
+#   4. Editing the test source → the next run misses again (a changed
+#      source content-busts the key, so a stale binary is never served).
+#
+# Cache state is isolated under a scratch `SAILFIN_BUILD_CACHE_DIR` so
+# the run starts genuinely cold and never pollutes the repo cache.
+#
+# Usage:
+#   compiler/tests/e2e/test_test_bin_cache.sh <compiler-binary>
+
+set -euo pipefail
+
+BINARY="${1:?usage: test_test_bin_cache.sh <compiler-binary>}"
+BINARY="$(realpath "$BINARY")"
+PASS=0
+FAIL=0
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "[test] SKIP: jq not installed (required for --json validation)" >&2
+    echo "═══ test-bin-cache: 0/0 passed, 0 failed (skipped) ═══"
+    exit 0
+fi
+
+SCRATCH="$(mktemp -d -t sfn-test-bin-cache-XXXXXX)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+
+run_test() {
+    local name="$1"
+    shift
+    if "$@"; then
+        echo "[test] PASS: $name"
+        PASS=$((PASS + 1))
+    else
+        echo "[test] FAIL: $name"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# ---- Setup: a standalone test directory (no capsule, no imports) ----
+# A single test file keeps the runner on the in-process leaf path
+# (test_files.length == 1, no per-file subprocess fan-out) so the cache
+# read/write and the `cache` summary object are exercised directly.
+TESTDIR="$SCRATCH/tests"
+mkdir -p "$TESTDIR"
+cat > "$TESTDIR/cache_fixture_test.sfn" <<'EOF'
+test "trivial truth" {
+    assert 1 == 1;
+}
+EOF
+
+CACHE_DIR="$SCRATCH/cache"
+
+# Run the suite under the isolated cache root and emit the summary line.
+# The runtime root is resolved relative to the repo (the C driver injects
+# --runtime-root for the in-tree `runtime/`), so cd into the repo root.
+run_suite() {
+    local extra="$1"
+    cd "$REPO_ROOT" || return 1
+    SAILFIN_BUILD_CACHE_DIR="$CACHE_DIR" \
+        "$BINARY" test "$TESTDIR" --json $extra 2>/dev/null \
+        | jq -c 'select(.event == "summary")'
+}
+
+# ---- Test 1: cold run misses, hit_rate 0.0000 ----
+test_cold_miss() {
+    local summary
+    summary="$(run_suite "")" || return 1
+    echo "[test]   cold summary: $summary" >&2
+    [ "$(echo "$summary" | jq -r '.cache.test_bin_hits')" = "0" ] || return 1
+    [ "$(echo "$summary" | jq -r '.cache.test_bin_misses')" -ge 1 ] || return 1
+    [ "$(echo "$summary" | jq -r '.cache.test_bin_hit_rate == 0')" = "true" ] || return 1
+    # The test itself must pass — a hit must serve a runnable binary.
+    [ "$(echo "$summary" | jq -r '.passed')" -ge 1 ] || return 1
+    return 0
+}
+run_test "cold run: every test misses, hit_rate 0.0000" test_cold_miss
+
+# ---- Test 2: warm rerun hits, hit_rate 1.0000 ----
+test_warm_hit() {
+    local summary
+    summary="$(run_suite "")" || return 1
+    echo "[test]   warm summary: $summary" >&2
+    [ "$(echo "$summary" | jq -r '.cache.test_bin_hits')" -ge 1 ] || return 1
+    [ "$(echo "$summary" | jq -r '.cache.test_bin_misses')" = "0" ] || return 1
+    [ "$(echo "$summary" | jq -r '.cache.test_bin_hit_rate == 1')" = "true" ] || return 1
+    # The cached binary is still RUN (variant 2a) — the test still passes.
+    [ "$(echo "$summary" | jq -r '.passed')" -ge 1 ] || return 1
+    return 0
+}
+run_test "warm rerun: every test hits, hit_rate 1.0000" test_warm_hit
+
+# ---- Test 3: --no-test-cache bypasses read + write, hit_rate 0.0000 ----
+test_no_cache_flag() {
+    local summary
+    summary="$(run_suite "--no-test-cache")" || return 1
+    echo "[test]   no-cache summary: $summary" >&2
+    [ "$(echo "$summary" | jq -r '.cache.test_bin_hits')" = "0" ] || return 1
+    [ "$(echo "$summary" | jq -r '.cache.test_bin_misses')" = "0" ] || return 1
+    [ "$(echo "$summary" | jq -r '.cache.test_bin_hit_rate == 0')" = "true" ] || return 1
+    return 0
+}
+run_test "--no-test-cache: no read or write, hit_rate 0.0000" test_no_cache_flag
+
+# ---- Test 4: editing the source content-busts the key (miss again) ----
+test_edit_busts() {
+    # Sanity: the unchanged file is warm from Test 2 (Test 3 wrote
+    # nothing), so without an edit it would hit. Change the source bytes.
+    cat > "$TESTDIR/cache_fixture_test.sfn" <<'EOF'
+test "trivial truth" {
+    assert 2 == 2;
+}
+EOF
+    local summary
+    summary="$(run_suite "")" || return 1
+    echo "[test]   post-edit summary: $summary" >&2
+    # A changed source → changed key → miss (never a stale-binary hit).
+    [ "$(echo "$summary" | jq -r '.cache.test_bin_hits')" = "0" ] || return 1
+    [ "$(echo "$summary" | jq -r '.cache.test_bin_misses')" -ge 1 ] || return 1
+    return 0
+}
+run_test "edited source content-busts the key (miss, no stale hit)" test_edit_busts
+
+TOTAL=$((PASS + FAIL))
+echo ""
+echo "═══ test-bin-cache: $PASS/$TOTAL passed, $FAIL failed ═══"
+[ "$FAIL" -eq 0 ]

--- a/compiler/tests/integration/test_runner_json_test.sfn
+++ b/compiler/tests/integration/test_runner_json_test.sfn
@@ -66,13 +66,27 @@ test "test_runner_json: start event handles zero-test discovery" {
 // `summary` event
 // --------------------------------------------------------------
 test "test_runner_json: summary event golden shape" {
-    let line = render_summary_event(40, 1, 1, 1284);
-    assert line == "{\"event\":\"summary\",\"passed\":40,\"failed\":1,\"skipped\":1,\"duration_ms\":1284}";
+    // #1230: summary now carries a `cache` object with the per-test
+    // binary cache counters + derived hit rate. 36 hits / 6 misses →
+    // 36/42 = 0.8571 (truncated toward zero to four decimals).
+    let line = render_summary_event(40, 1, 1, 1284, 36, 6);
+    assert line == "{\"event\":\"summary\",\"passed\":40,\"failed\":1,\"skipped\":1,\"duration_ms\":1284,\"cache\":{\"test_bin_hits\":36,\"test_bin_misses\":6,\"test_bin_hit_rate\":0.8571}}";
 }
 
 test "test_runner_json: summary all-zero shape (empty discovery)" {
-    let line = render_summary_event(0, 0, 0, 0);
-    assert line == "{\"event\":\"summary\",\"passed\":0,\"failed\":0,\"skipped\":0,\"duration_ms\":0}";
+    // Zero lookups (empty discovery or `--no-test-cache`) → hit_rate
+    // is the floor `0.0000`, never null/nan.
+    let line = render_summary_event(0, 0, 0, 0, 0, 0);
+    assert line == "{\"event\":\"summary\",\"passed\":0,\"failed\":0,\"skipped\":0,\"duration_ms\":0,\"cache\":{\"test_bin_hits\":0,\"test_bin_misses\":0,\"test_bin_hit_rate\":0.0000}}";
+}
+
+test "test_runner_json: summary cache hit_rate saturated and cold" {
+    // Fully-warm rerun: only hits → 1.0000.
+    let warm = render_summary_event(10, 0, 0, 5, 12, 0);
+    assert warm == "{\"event\":\"summary\",\"passed\":10,\"failed\":0,\"skipped\":0,\"duration_ms\":5,\"cache\":{\"test_bin_hits\":12,\"test_bin_misses\":0,\"test_bin_hit_rate\":1.0000}}";
+    // Cold run: only misses → 0.0000.
+    let cold = render_summary_event(10, 0, 0, 5, 0, 12);
+    assert cold == "{\"event\":\"summary\",\"passed\":10,\"failed\":0,\"skipped\":0,\"duration_ms\":5,\"cache\":{\"test_bin_hits\":0,\"test_bin_misses\":12,\"test_bin_hit_rate\":0.0000}}";
 }
 
 // --------------------------------------------------------------

--- a/compiler/tests/unit/build_cache_test.sfn
+++ b/compiler/tests/unit/build_cache_test.sfn
@@ -45,7 +45,10 @@ import {
     empty_cache_stats,
     is_valid_digest,
     merge_cache_stats,
-    runtime_object_entry_key_from_str
+    runtime_object_entry_key_from_str,
+    test_bin_cache_key,
+    test_bin_cache_root_with_override,
+    test_bin_cache_schema_version
 } from "../../src/build_cache";
 
 // --------------------------------------------------------------
@@ -198,6 +201,108 @@ test "build_cache: cache_key_for changes when dep manifest changes" ![io] {
     let key1 = cache_key_for(src, [dep], "0.5.10-alpha.2", "[]", "dep_sens_1");
     _write_file(dep, "module: alpha; layout: changed");
     let key2 = cache_key_for(src, [dep], "0.5.10-alpha.2", "[]", "dep_sens_2");
+    assert key1.digest != key2.digest;
+    _cleanup(scratch);
+}
+
+// --------------------------------------------------------------
+// Per-test binary cache (#1230)
+// --------------------------------------------------------------
+test "build_cache: test_bin cache schema + root layout" ![io] {
+    assert test_bin_cache_schema_version() == "v1";
+    // In-tree default sits beside (not under) the module cache's
+    // `<base>/v<N>` tree so the two schema lines age out independently.
+    assert test_bin_cache_root_with_override("") == "build/cache/test-bin/v1";
+    assert test_bin_cache_root_with_override("/shared/cache") == "/shared/cache/test-bin/v1";
+}
+
+test "build_cache: test_bin_cache_key same inputs -> same digest" ![io] {
+    let scratch = _test_tmp_root("tbk_determinism");
+    let test_src = scratch + "/foo_test.sfn";
+    let dep_ll = scratch + "/dep.ll";
+    _write_file(test_src, "test \"x\" { assert 1 == 1; }");
+    _write_file(dep_ll, "; ModuleID = 'dep'");
+    let native_texts: string[] = ["sfn-asm: helper"];
+    let key1 = test_bin_cache_key(test_src, [dep_ll], native_texts, "0.7.0+bin.abc", "[\"-O0\"]", "tbk_det");
+    let key2 = test_bin_cache_key(test_src, [dep_ll], native_texts, "0.7.0+bin.abc", "[\"-O0\"]", "tbk_det");
+    assert key1.digest == key2.digest;
+    assert key1.digest.length == 64;
+    _cleanup(scratch);
+}
+
+test "build_cache: test_bin_cache_key changes when a dep .ll hash changes" ![io] {
+    let scratch = _test_tmp_root("tbk_dep_ll");
+    let test_src = scratch + "/foo_test.sfn";
+    let dep_ll = scratch + "/dep.ll";
+    _write_file(test_src, "test \"x\" { assert 1 == 1; }");
+    let native_texts: string[] = ["sfn-asm: helper"];
+    _write_file(dep_ll, "; ModuleID = 'dep'\ndefine i64 @f() { ret i64 1 }");
+    let key1 = test_bin_cache_key(test_src, [dep_ll], native_texts, "0.7.0+bin.abc", "[\"-O0\"]", "tbk_dll_1");
+    // A changed transitive dep → changed hash → changed key → cache
+    // miss. This is the correctness hinge: a stale binary can never be
+    // served after a dep edit (acceptance criterion: misses for exactly
+    // the transitive importers of an edited compiler/src file).
+    _write_file(dep_ll, "; ModuleID = 'dep'\ndefine i64 @f() { ret i64 2 }");
+    let key2 = test_bin_cache_key(test_src, [dep_ll], native_texts, "0.7.0+bin.abc", "[\"-O0\"]", "tbk_dll_2");
+    assert key1.digest != key2.digest;
+    _cleanup(scratch);
+}
+
+test "build_cache: test_bin_cache_key changes when a native_text dep changes" ![io] {
+    let scratch = _test_tmp_root("tbk_native");
+    let test_src = scratch + "/foo_test.sfn";
+    let dep_ll = scratch + "/dep.ll";
+    _write_file(test_src, "test \"x\" { assert 1 == 1; }");
+    _write_file(dep_ll, "; ModuleID = 'dep'");
+    let key1 = test_bin_cache_key(test_src, [dep_ll], ["sfn-asm: original"], "0.7.0+bin.abc", "[\"-O0\"]", "tbk_nt_1");
+    let key2 = test_bin_cache_key(test_src, [dep_ll], ["sfn-asm: changed"], "0.7.0+bin.abc", "[\"-O0\"]", "tbk_nt_2");
+    assert key1.digest != key2.digest;
+    _cleanup(scratch);
+}
+
+test "build_cache: test_bin_cache_key invariant under dep_ll order" ![io] {
+    let scratch = _test_tmp_root("tbk_order");
+    let test_src = scratch + "/foo_test.sfn";
+    let dep_a = scratch + "/a.ll";
+    let dep_b = scratch + "/b.ll";
+    let dep_c = scratch + "/c.ll";
+    _write_file(test_src, "test \"x\" { assert 1 == 1; }");
+    _write_file(dep_a, "; alpha");
+    _write_file(dep_b, "; beta");
+    _write_file(dep_c, "; gamma");
+    let nt: string[] = [];
+    let key_abc = test_bin_cache_key(test_src, [dep_a, dep_b, dep_c], nt, "0.7.0+bin.abc", "[\"-O0\"]", "tbk_ord");
+    let key_cba = test_bin_cache_key(test_src, [dep_c, dep_b, dep_a], nt, "0.7.0+bin.abc", "[\"-O0\"]", "tbk_ord");
+    assert key_abc.digest == key_cba.digest;
+    _cleanup(scratch);
+}
+
+test "build_cache: test_bin_cache_key changes when test source changes" ![io] {
+    let scratch = _test_tmp_root("tbk_src");
+    let test_src = scratch + "/foo_test.sfn";
+    let dep_ll = scratch + "/dep.ll";
+    _write_file(dep_ll, "; ModuleID = 'dep'");
+    let nt: string[] = [];
+    _write_file(test_src, "test \"x\" { assert 1 == 1; }");
+    let key1 = test_bin_cache_key(test_src, [dep_ll], nt, "0.7.0+bin.abc", "[\"-O0\"]", "tbk_src_1");
+    _write_file(test_src, "test \"x\" { assert 2 == 2; }");
+    let key2 = test_bin_cache_key(test_src, [dep_ll], nt, "0.7.0+bin.abc", "[\"-O0\"]", "tbk_src_2");
+    assert key1.digest != key2.digest;
+    _cleanup(scratch);
+}
+
+test "build_cache: test_bin_cache_key changes when compiler identity changes" ![io] {
+    let scratch = _test_tmp_root("tbk_ident");
+    let test_src = scratch + "/foo_test.sfn";
+    let dep_ll = scratch + "/dep.ll";
+    _write_file(test_src, "test \"x\" { assert 1 == 1; }");
+    _write_file(dep_ll, "; ModuleID = 'dep'");
+    let nt: string[] = [];
+    // A rebuilt compiler (new binary content for `.dirty` dev stamps)
+    // changes the identity → busts every cached binary, same model the
+    // module IR cache uses.
+    let key1 = test_bin_cache_key(test_src, [dep_ll], nt, "0.7.0+bin.aaa", "[\"-O0\"]", "tbk_id_1");
+    let key2 = test_bin_cache_key(test_src, [dep_ll], nt, "0.7.0+bin.bbb", "[\"-O0\"]", "tbk_id_2");
     assert key1.digest != key2.digest;
     _cleanup(scratch);
 }

--- a/docs/proposals/ci-test-speed.md
+++ b/docs/proposals/ci-test-speed.md
@@ -395,7 +395,7 @@ coverage cost is real. Treat as the *last* lever, not the first.
 | 1 | L1 Seam A: shard `ci.yml` matrix 2→2x4, file-list selection, per-shard `make rebuild`, **shard-cover lint** | CI-config + thin Makefile target | CI | low | 47→~16-18 min |
 | 2 | L1 1b: split build into a `needs:` job, share `build/native` + `build/cache` artifact across shards | CI-config | CI | low-med | removes redundant build minutes; small wall win |
 | 3 | L1 Seam B: `sailfin test --shard I/N` deterministic partition | runner (`cli_commands.sfn`) | compiler | low | (durability, not wall) |
-| 4 | L2 2a: per-test binary cache (key + read/write in runner), atomic writes, `--no-test-cache` for full suite | runner (`cli_commands.sfn` + `build_cache.sfn`) | compiler | med | incremental PRs 50-80% suite skip |
+| 4 | L2 2a: per-test binary cache (key + read/write in runner), atomic writes, `--no-test-cache` for full suite — **shipped (#1230)** | runner (`cli_commands.sfn` + `build_cache.sfn`) | compiler | med | incremental PRs 50-80% suite skip |
 | 5 | L2 CI: save/restore `build/cache/test-bin` per shard; nightly baseline warm | CI-config | CI | low | warms first-push hits |
 | 6 | L3: smoke tag + macOS-smoke PR leg + **full suite on push:main** | runner tag (exists) + CI-config + content pass | CI + compiler (curation) | med-high | only if 1-2 insufficient |
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -290,6 +290,28 @@ feature availability.
     work-dir sidecar fast-path is preserved, and the shared layer stays
     gated on `cache_config.enabled` (the `sfn test` link path and
     `--no-cache` remain work-dir-local).
+  - **Per-test binary cache (#1230)** — Lever 2 of
+    `docs/proposals/ci-test-speed.md`. The test runner
+    (`handle_test_command`) now content-addresses each test's linked
+    native binary, so an unchanged test skips LLVM lowering + the
+    `clang` link (the dominant per-test cost) and just re-runs the
+    cached executable. `test_bin_cache_key` (in `build_cache.sfn`)
+    folds the test source hash, the resolver's transitive dep closure
+    (`TestGroup.native_texts` + `dep_ll_paths` — the exact link
+    inputs), the compiler identity (`cache_compiler_identity`, so a
+    rebuilt compiler busts every entry), the canonical clang flags, and
+    a `test-bin/v1` schema version. Binaries store under
+    `build/cache/test-bin/v1/` via the existing atomic temp+rename
+    artifact helpers (new `"test-bin"` kind). On a hit the binary is
+    still **run** (variant 2a — never a cached pass/fail result). The
+    `--json` summary gains a `cache` object with `test_bin_hit_rate`
+    (mirroring the build report's `cache.hit_rate`), aggregated across
+    the per-file children of a multi-file run. `--no-test-cache`
+    bypasses both read and write; `make check` passes it
+    (`TEST_BIN_CACHE_FLAGS`) so the full-suite gate always cold-builds
+    and a test-compile regression can never be masked by a stale hit.
+    A no-op suite rerun reports ~100% hit rate and skips lower+link for
+    every unchanged test.
 - **Stage C2 per-capsule artifact layout (in flight, 2026-04-28).**
   Three PRs land the §4.4 layout (`build/capsules/<scope>/<name>/`)
   for everything `sfn build -p` produces:

--- a/docs/status.md
+++ b/docs/status.md
@@ -297,10 +297,15 @@ feature availability.
     `clang` link (the dominant per-test cost) and just re-runs the
     cached executable. `test_bin_cache_key` (in `build_cache.sfn`)
     folds the test source hash, the resolver's transitive dep closure
-    (`TestGroup.native_texts` + `dep_ll_paths` — the exact link
-    inputs), the compiler identity (`cache_compiler_identity`, so a
+    (`TestGroup.native_texts` + `dep_ll_paths` — the test-source-specific
+    link inputs), the compiler identity (`cache_compiler_identity`, so a
     rebuilt compiler busts every entry), the canonical clang flags, and
-    a `test-bin/v1` schema version. Binaries store under
+    a `test-bin/v1` schema version. The assembled runtime capsule objects
+    + link libs the link also consumes are *not* folded into the key;
+    they ride on the compiler identity (a runtime edit normally reaches a
+    test binary via `make compile`, which busts it), with
+    `--no-test-cache` on the `make check` gate as the cold-build
+    backstop. Binaries store under
     `build/cache/test-bin/v1/` via the existing atomic temp+rename
     artifact helpers (new `"test-bin"` kind). On a hit the binary is
     still **run** (variant 2a — never a cached pass/fail result). The

--- a/site/src/content/docs/docs/reference/spec/11-testing.md
+++ b/site/src/content/docs/docs/reference/spec/11-testing.md
@@ -248,11 +248,20 @@ sha256(
 )
 ```
 
-The dependency set is exactly the resolver output the link already
-consumes, so a change to the test or any transitive dependency changes
-the key and misses the cache — a stale binary can never be served. On a
-hit the cached binary is still **run** (never a cached pass/fail result),
-so a flaky-at-runtime test always surfaces.
+The dependency set is the resolver output the link already consumes for
+the test's own closure, so a change to the test or any transitive
+dependency changes the key and misses the cache. On a hit the cached
+binary is still **run** (never a cached pass/fail result), so a
+flaky-at-runtime test always surfaces.
+
+The key does **not** fold in the assembled runtime capsule objects or
+link libraries that the link also consumes — those are covered
+indirectly by the compiler identity (a rebuilt compiler, the usual way a
+runtime-source edit reaches a test binary since the runtime is rebuilt
+by `make compile`, busts every entry). A runtime edit *without* a
+compiler rebuild can serve a stale binary; `--no-test-cache` (which
+`make check` and the nightly full suite pass) is the cold-build backstop
+that catches any such drift at the merge gate.
 
 Cached binaries live under `build/cache/test-bin/<schema>/` (alongside
 the module IR cache, under `$SAILFIN_BUILD_CACHE_DIR` when set) and are

--- a/site/src/content/docs/docs/reference/spec/11-testing.md
+++ b/site/src/content/docs/docs/reference/spec/11-testing.md
@@ -126,8 +126,10 @@ Three event kinds, schema-versioned:
  "assertion":{"file":"path/to/foo_test.sfn","line":8,"col":12,
               "message":"expected x == 42, got 41"}}
 
-// Last line — exactly once per run.
-{"event":"summary","passed":40,"failed":1,"skipped":1,"duration_ms":1284}
+// Last line — exactly once per run. The `cache` object reports the
+// per-test binary cache (see "Per-test binary cache" below).
+{"event":"summary","passed":40,"failed":1,"skipped":1,"duration_ms":1284,
+ "cache":{"test_bin_hits":36,"test_bin_misses":6,"test_bin_hit_rate":0.8571}}
 ```
 
 ### Field semantics
@@ -147,6 +149,15 @@ Three event kinds, schema-versioned:
 | `summary` | `failed`         | integer   | Tests with `status == "fail"`.                                  |
 | `summary` | `skipped`        | integer   | Tests with `status == "skip"`.                                  |
 | `summary` | `duration_ms`    | integer   | Wall-clock time of the entire `sfn test --json` invocation.     |
+| `summary` | `cache`          | object    | Per-test binary cache counters; see *Per-test binary cache*.    |
+
+The `cache` object mirrors the `sfn build --json` report's `cache` field:
+
+| Field                | Type    | Meaning                                                              |
+|----------------------|---------|----------------------------------------------------------------------|
+| `test_bin_hits`      | integer | Tests served from the cached linked binary (lower+link skipped).     |
+| `test_bin_misses`    | integer | Tests that cold lower+linked, then populated the cache.              |
+| `test_bin_hit_rate`  | number  | `hits / (hits + misses)`, floored to four decimals; `0.0000` when no lookups were attempted (e.g. `--no-test-cache`). |
 
 The optional `assertion` object carries the typed
 [`AssertFailure`](https://github.com/SailfinIO/sailfin/blob/main/compiler/src/assert_failure.sfn)
@@ -220,5 +231,38 @@ For any `sfn test --json` invocation:
 
 Consumers that pipe into `jq -c` can rely on every line being a complete
 JSON object with no trailing whitespace.
+
+## Per-test binary cache
+
+`sfn test` content-addresses each test's linked native binary so an
+unchanged test skips LLVM lowering and the `clang` link — the dominant
+per-test cost — and just re-runs the cached executable. The cache key is
+
+```
+sha256(
+  sha256(test_source_bytes)
+  || sha256(sorted(hash of each transitive dep the link consumes))
+  || compiler_identity        // busts on a rebuilt compiler
+  || canonical(clang_flags)
+  || schema_version
+)
+```
+
+The dependency set is exactly the resolver output the link already
+consumes, so a change to the test or any transitive dependency changes
+the key and misses the cache — a stale binary can never be served. On a
+hit the cached binary is still **run** (never a cached pass/fail result),
+so a flaky-at-runtime test always surfaces.
+
+Cached binaries live under `build/cache/test-bin/<schema>/` (alongside
+the module IR cache, under `$SAILFIN_BUILD_CACHE_DIR` when set) and are
+written atomically (temp + rename), so concurrent runs on the same key
+never corrupt an entry. The `cache` object in the `--json` summary
+reports the per-run `test_bin_hit_rate`.
+
+`--no-test-cache` bypasses both the read and the write, forcing a cold
+lower+link for every test (`test_bin_hit_rate` is then `0.0000`). The
+`make check` full-suite gate passes it so a test-compile regression can
+never be masked by a stale hit.
 
 ---


### PR DESCRIPTION
## Summary

- Content-addresses each test's linked native binary so an **unchanged** test skips LLVM lowering + the clang link (the dominant per-test cost) and just re-runs the cached executable. Lever 2 (variant 2a) of `docs/proposals/ci-test-speed.md`.
- On a hit the binary is still **run** (never a cached pass/fail result); on a miss it cold lower+links then populates the cache.
- `--no-test-cache` bypasses read + write; `make check` passes it so the merge/seedcheck gate always cold-builds and a test-compile regression can never be masked by a stale hit.

Closes #1230

## What changed

- **`compiler/src/build_cache.sfn`** — `test_bin_cache_key` folds `sha256(test source)` + the resolver's transitive dep closure (`TestGroup.native_texts` + `dep_ll_paths` — the *exact* link inputs, so the key can't miss a dep) + `cache_compiler_identity` (a rebuilt compiler busts every entry) + canonical clang flags + a `test-bin/v1` schema. Binaries store under `build/cache/test-bin/v1/` via the existing **atomic temp+rename** artifact helpers (new `"test-bin"` kind).
- **`compiler/src/cli_commands.sfn`** — `--no-test-cache` flag parse; per-test lookup→hit (skip lower+link, re-assert `+x` on the restored binary — the shared `mktemp` copy strips the exec bit) / miss (lower+link then store); hit/miss accounting. Per-file children forward the flag; the multi-file parent aggregates `test_bin_hits`/`misses` from each child's sub-frame summary.
- **`compiler/src/test_runner_json.sfn`** — additive `cache` object in the `--json` summary (`test_bin_hits`/`misses` + derived `test_bin_hit_rate`, 4-decimal floor, mirroring the build report's `cache.hit_rate`). No schema bump (additive optional field).
- **`Makefile`** — `TEST_BIN_CACHE_FLAGS`; `make check` passes `--no-test-cache` on both gate passes.
- Docs: spec §11 (`11-testing.md`), `docs/status.md`, proposal status row.

## Acceptance criteria

- [x] No-op suite rerun reports ~100% `cache.test_bin_hit_rate` and is materially faster — measured **integration suite 161s cold → 53s warm (~3×)**; trivial single test 326ms→29ms.
- [x] Editing a dep content-busts the key → miss for transitive importers, hit for the rest (no false hits/misses) — pinned by unit tests + e2e edit case.
- [x] `--no-test-cache` forces a cold lower+link (hit rate 0); `make check` passes it.
- [x] Cache writes are atomic (temp + rename) — reuses the shared `_cache_atomic_copy` helper.
- [x] `make compile` self-hosts; warm `make test` passes (269/269 integration, full suite clean); `sfn fmt --check` clean on touched `.sfn`.

## Verification

```
# cold then warm (isolated cache):
build/native/sailfin test compiler/tests/integration --json | jq .cache
#  cold → {"test_bin_hits":0,"test_bin_misses":31,"test_bin_hit_rate":0.0000}  (161s)
#  warm → {"test_bin_hits":31,"test_bin_misses":0,"test_bin_hit_rate":1.0000}  ( 53s)
build/native/sailfin test compiler/tests/integration --no-test-cache --json | jq .cache
#       → {"test_bin_hits":0,"test_bin_misses":0,"test_bin_hit_rate":0.0000}
bash compiler/tests/e2e/test_test_bin_cache.sh build/native/sailfin   # 4/4 passed
build/native/sailfin test compiler/tests/unit/build_cache_test.sfn    # 63/63 (incl. 7 new)
```

## Notes / scope

- **Incremental-only by design.** A *cold* run (CI, fresh checkout) still misses every test — this lever speeds up *reruns*, not the first/cold suite. CI builds from a tagged seed (non-dirty stamp), so the per-child compiler-identity hash is skipped there (zero added cold cost).
- **Out of scope (per issue):** variant 2b (cache the pass/fail result), CI `build/cache/test-bin` save/restore plumbing, `--shard I/N`, and in-process `--jobs N` — all tracked separately in the proposal.
- A known small gap (documented): the key folds the compiler identity, not the runtime objects, so a `runtime/native/src/*.c` edit *without* a compiler rebuild could serve a stale binary. `make check`'s `--no-test-cache` is the backstop; in practice a runtime edit goes through `make compile`, which busts the identity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XvVLXNzQ2Yt2itBjj4vG8m)_