### PR TITLE
perf(test): cross-commit-stable per-test binary cache + push:main baseline warm

### DIFF
--- a/.github/actions/sailfin-build/action.yml
+++ b/.github/actions/sailfin-build/action.yml
@@ -98,6 +98,29 @@ runs:
           sailfin-buildcache-${{ inputs.target }}-${{ inputs.seed_version }}-
           sailfin-buildcache-${{ inputs.target }}-
 
+    # Restore the per-test linked-binary cache (`build/cache/test-bin`,
+    # #1230/#1233) under its OWN key prefix, separate from the module-IR
+    # cache above. This is deliberate: a shared `sailfin-buildcache-`
+    # prefix would let a test-bin-only entry shadow the module-IR cache on
+    # a restore-keys prefix match and force a cold compiler build. The
+    # producer is the `test-bin-baseline` job in `build-quality.yml`
+    # (push:main + nightly), which runs the full `.sfn` suite with the
+    # cache ENABLED and `cache/save`s `build/cache/test-bin` under this
+    # exact key. GitHub scopes caches to the branch + default branch, so a
+    # PR's first run restores main's baseline. This step runs AFTER the
+    # module-IR restore so the populated test-bin subtree overlays the
+    # (empty) test-bin the module-IR save carries. Cross-commit hits work
+    # because the test-bin cache identity is the commit-STABLE capsule
+    # version (#1233): a baseline at one commit warms a PR at another.
+    - name: Restore test-bin cache (per-test linked binaries)
+      uses: actions/cache@v4
+      with:
+        path: build/cache/test-bin
+        key: sailfin-testbin-${{ inputs.target }}-${{ inputs.seed_version }}-${{ hashFiles('compiler/src/**/*.sfn', 'runtime/**/*.sfn', 'compiler/capsule.toml', '.seed-version') }}
+        restore-keys: |
+          sailfin-testbin-${{ inputs.target }}-${{ inputs.seed_version }}-
+          sailfin-testbin-${{ inputs.target }}-
+
     - name: Build native compiler (selfhost from released seed)
       shell: bash {0}
       env:

--- a/.github/actions/sailfin-build/action.yml
+++ b/.github/actions/sailfin-build/action.yml
@@ -112,11 +112,19 @@ runs:
     # (empty) test-bin the module-IR save carries. Cross-commit hits work
     # because the test-bin cache identity is the commit-STABLE capsule
     # version (#1233): a baseline at one commit warms a PR at another.
+    # The hashFiles set includes `runtime/native/**` (C sources, headers,
+    # `.ll`, the runtime capsule manifest) on top of the `.sfn` trees,
+    # because those inputs change the linked runtime objects baked into a
+    # cached test binary. `actions/cache/save` is a no-op when a key
+    # already exists, so omitting them would pin PRs to a stale baseline
+    # after a runtime-native edit (and the baseline job could never publish
+    # a fresh entry). They are also folded into the per-test cache key by
+    # content (`runtime_link_inputs_identity`), so this is belt-and-braces.
     - name: Restore test-bin cache (per-test linked binaries)
       uses: actions/cache@v4
       with:
         path: build/cache/test-bin
-        key: sailfin-testbin-${{ inputs.target }}-${{ inputs.seed_version }}-${{ hashFiles('compiler/src/**/*.sfn', 'runtime/**/*.sfn', 'compiler/capsule.toml', '.seed-version') }}
+        key: sailfin-testbin-${{ inputs.target }}-${{ inputs.seed_version }}-${{ hashFiles('compiler/src/**/*.sfn', 'runtime/**/*.sfn', 'runtime/native/**', 'compiler/capsule.toml', '.seed-version') }}
         restore-keys: |
           sailfin-testbin-${{ inputs.target }}-${{ inputs.seed_version }}-
           sailfin-testbin-${{ inputs.target }}-

--- a/.github/workflows/build-quality.yml
+++ b/.github/workflows/build-quality.yml
@@ -287,6 +287,142 @@ jobs:
           if-no-files-found: warn
           retention-days: 14
 
+  # Per-test binary cache baseline producer (#1233, sequencing step 5 of
+  # docs/proposals/ci-test-speed.md). The PR build action
+  # (.github/actions/sailfin-build) restores `build/cache/test-bin` under
+  # the `sailfin-testbin-...` key, but until this job nothing populated
+  # it: the `build-quality` gate above runs no tests, and the nightly
+  # `make check` runs with `--no-test-cache`. This job runs the full
+  # `.sfn` suite with the test-bin cache ENABLED and saves
+  # `build/cache/test-bin` into the default-branch cache scope, so a PR's
+  # first run hits for every unchanged test. Cross-commit hits work
+  # because the per-test binary cache identity is the commit-stable
+  # capsule version (#1233 compiler change), so a baseline cut at one
+  # commit warms a PR built at another.
+  #
+  # Independent of the determinism + cache.hit_rate gates above (those are
+  # untouched): this job has no cold-build requirement, so it restores the
+  # warm module-IR cache for a fast compile. The save is gated on a green
+  # suite (save-only step, no `if:`, runs only when every prior step
+  # succeeded) so a failing baseline can never poison the cache PRs
+  # consume — the previous good cache stays in place.
+  #
+  # Linux x86_64 only for now (mirrors the gate job); macOS cache tuning
+  # is deferred (#1233 Out:). The full-suite `make check` / determinism
+  # gates remain the cold-build correctness backstop — this cache is read
+  # only by the `sfn test` runner, never by those gates.
+  test-bin-baseline:
+    name: Warm test-bin cache (linux-x86_64)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6.0.3
+
+      - name: Resolve seed version from .seed-version
+        id: seed
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ ! -f .seed-version ]; then
+            echo "[seed-pin] .seed-version is missing from checkout" >&2
+            exit 1
+          fi
+          pin="$(tr -d '[:space:]' < .seed-version)"
+          if [ -z "$pin" ]; then
+            echo "[seed-pin] .seed-version is empty" >&2
+            exit 1
+          fi
+          echo "[seed-pin] using seed $pin"
+          echo "seed_version=$pin" >> "$GITHUB_OUTPUT"
+
+      - name: Install clang + llvm + jq
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y clang-18 llvm-18 jq
+          echo "CLANG=clang-18" >> "$GITHUB_ENV"
+
+      - name: Restore seed cache
+        uses: actions/cache@v5
+        with:
+          path: build/seed
+          key: sailfin-seed-linux-x86_64-${{ steps.seed.outputs.seed_version }}
+
+      - name: Fetch released seed compiler
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SEED_VERSION: ${{ steps.seed.outputs.seed_version }}
+        run: |
+          set -euo pipefail
+          if [ -x build/seed/bin/sailfin ] && build/seed/bin/sailfin version >/dev/null 2>&1; then
+            echo "[ci] seed cache hit ($SEED_VERSION) — skipping fetch"
+          else
+            make fetch-seed SEED_VERSION="$SEED_VERSION"
+          fi
+          build/seed/bin/sailfin version
+
+      # Warm module-IR cache for a fast compile. Unlike the determinism
+      # gate, this job has no cold-build requirement, so restoring is safe
+      # and desirable. Keys mirror `.github/actions/sailfin-build`.
+      - name: Restore build cache (content-addressed module IR)
+        uses: actions/cache@v5
+        with:
+          path: build/cache
+          key: sailfin-buildcache-linux-x86_64-${{ steps.seed.outputs.seed_version }}-${{ hashFiles('compiler/src/**/*.sfn', 'runtime/**/*.sfn', 'compiler/capsule.toml', '.seed-version') }}
+          restore-keys: |
+            sailfin-buildcache-linux-x86_64-${{ steps.seed.outputs.seed_version }}-
+            sailfin-buildcache-linux-x86_64-
+
+      - name: Self-host the compiler (make compile)
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          ulimit -v 8388608
+          make compile \
+            CLANG="${CLANG:-clang-18}" \
+            SEED_NATIVE="build/seed/bin/sailfin"
+          build/native/sailfin version
+
+      # Run the full `.sfn` suite with the test-bin cache ENABLED (no
+      # `--no-test-cache`), populating `build/cache/test-bin/v<schema>`.
+      # Loop the `.sfn` shard names from scripts/test_shards.sh (the
+      # single source of truth) and skip the e2e-sh `.sh` shards — those
+      # scripts compile their own throwaway programs and don't exercise
+      # the per-test binary cache. Retry-once mirrors the PR action's #892
+      # flake mitigation so one non-deterministic codegen flake doesn't
+      # skip the save (a persistent failure still fails → no save).
+      - name: Warm test-bin cache (run .sfn shards, cache enabled)
+        shell: bash
+        run: |
+          set -euo pipefail
+          ulimit -v 8388608 || true
+          run_shard() { make test-shard SHARD="$1"; }
+          for shard in $(bash scripts/test_shards.sh sfn-names); do
+            echo "[warm] shard $shard"
+            if ! run_shard "$shard"; then
+              echo "::warning title=test flake (likely #892)::shard $shard failed on attempt 1; retrying once."
+              echo "[warm] retrying shard $shard once (attempt 2/2) — see #892"
+              run_shard "$shard"
+            fi
+          done
+
+      # Save the warmed test-bin cache for PR CI to restore. Save-only (no
+      # `if:`) so it runs only when every prior step — including the suite
+      # — succeeded; a failed baseline leaves the previous good cache in
+      # place (no poisoning). Key matches the PR action's
+      # `sailfin-testbin-...` key exactly; if it already exists (no source
+      # change since the last main run) the save is a no-op.
+      - name: Save test-bin cache for PR CI
+        uses: actions/cache/save@v5
+        with:
+          path: build/cache/test-bin
+          key: sailfin-testbin-linux-x86_64-${{ steps.seed.outputs.seed_version }}-${{ hashFiles('compiler/src/**/*.sfn', 'runtime/**/*.sfn', 'compiler/capsule.toml', '.seed-version') }}
+
   # Failure-mode job (issue #782). Runs only when `build-quality` fails.
   # Elevated permissions are scoped to this job alone so the gate job
   # itself stays `contents: read` (architect verdict on #339 Q4).

--- a/.github/workflows/build-quality.yml
+++ b/.github/workflows/build-quality.yml
@@ -417,11 +417,15 @@ jobs:
       # place (no poisoning). Key matches the PR action's
       # `sailfin-testbin-...` key exactly; if it already exists (no source
       # change since the last main run) the save is a no-op.
+      # Key matches the PR action's `sailfin-testbin-...` key exactly,
+      # including `runtime/native/**` (C sources, headers, `.ll`, manifest)
+      # so a runtime-native edit rolls the key and the baseline can publish
+      # a fresh entry (an existing key makes `cache/save` a no-op).
       - name: Save test-bin cache for PR CI
         uses: actions/cache/save@v5
         with:
           path: build/cache/test-bin
-          key: sailfin-testbin-linux-x86_64-${{ steps.seed.outputs.seed_version }}-${{ hashFiles('compiler/src/**/*.sfn', 'runtime/**/*.sfn', 'compiler/capsule.toml', '.seed-version') }}
+          key: sailfin-testbin-linux-x86_64-${{ steps.seed.outputs.seed_version }}-${{ hashFiles('compiler/src/**/*.sfn', 'runtime/**/*.sfn', 'runtime/native/**', 'compiler/capsule.toml', '.seed-version') }}
 
   # Failure-mode job (issue #782). Runs only when `build-quality` fails.
   # Elevated permissions are scoped to this job alone so the gate job

--- a/compiler/src/build_cache.sfn
+++ b/compiler/src/build_cache.sfn
@@ -898,26 +898,29 @@ fn test_bin_cache_key(test_source_path: string, dep_ll_paths: string[], native_t
 // `test_bin_cache_key` as `runtime_identity`.
 //
 // `source_paths` are the runtime input sources (`.c` / `.ll` / `.sfn`
-// + prelude entry) hashed off disk; `link_libs` are linker flag strings
-// (`-lm`, `-lpthread`, capsule-declared libs) folded in by value. All
-// components are sorted before folding so the identity is invariant
-// under enumeration order. Hashing SOURCES (not built objects) is both
+// + prelude entry + the `.h` headers under the include roots) hashed off
+// disk; `value_inputs` are non-file inputs folded by value — linker flag
+// strings (`-lm`, `-lpthread`, capsule-declared libs) and the include-dir
+// paths (`-I<dir>`), so an include-root or link-flag change busts the key.
+// All components are sorted before folding so the identity is invariant
+// under enumeration order. Each source folds in as `<path>@<sha256>`: the
+// path keeps two distinct inputs from aliasing (notably when a file is
+// unreadable and `_sha256_of_file_cmd` returns an empty digest) and makes
+// a rename observable. Hashing SOURCES (not built objects) is both
 // available on the single-file leaf path — where objects may not exist
-// yet — and strictly upstream: a source edit busts even before a
-// rebuild. An unreadable source yields an empty `_sha256_of_file_cmd`
-// digest, which still folds in deterministically.
-fn runtime_link_inputs_identity(source_paths: string[], link_libs: string[], unique_suffix: string) -> string ![io] {
+// yet — and strictly upstream: a source edit busts even before a rebuild.
+fn runtime_link_inputs_identity(source_paths: string[], value_inputs: string[], unique_suffix: string) -> string ![io] {
     let mut parts: string[] = [];
     let mut i: int = 0;
     loop {
         if i >= source_paths.length { break; }
-        parts.push("src:" + _sha256_of_file_cmd(source_paths[i]));
+        parts.push("src:" + source_paths[i] + "@" + _sha256_of_file_cmd(source_paths[i]));
         i += 1;
     }
     let mut j: int = 0;
     loop {
-        if j >= link_libs.length { break; }
-        parts.push("lib:" + link_libs[j]);
+        if j >= value_inputs.length { break; }
+        parts.push("val:" + value_inputs[j]);
         j += 1;
     }
     let sorted = _sort_strings(parts);

--- a/compiler/src/build_cache.sfn
+++ b/compiler/src/build_cache.sfn
@@ -786,7 +786,14 @@ fn cache_compiler_identity(compiler_version: string, compiler_binary_path: strin
 // way that makes old entries incompatible. Independent of
 // `build_cache_schema_version` so a module-cache schema bump doesn't
 // needlessly evict warm test binaries (and vice versa).
-fn test_bin_cache_schema_version() -> string { return "v1"; }
+//
+// v1 -> v2 (#1233): the key gained a `runtime_identity` component (the
+// runtime link inputs, hashed by content) and the `compiler_identity`
+// component switched from the per-commit build stamp to the commit-stable
+// capsule version (`resolve_test_bin_identity_for_cache`). Both change
+// the folded key bytes, so the schema bump re-roots the on-disk tree to
+// `build/cache/test-bin/v2` and old v1 entries can never false-hit.
+fn test_bin_cache_schema_version() -> string { return "v2"; }
 
 // Root for the per-test binary cache: `<base>/test-bin/<schema>`,
 // where `<base>` is `$SAILFIN_BUILD_CACHE_DIR` (when set) or the
@@ -813,20 +820,23 @@ fn test_bin_cache_root() -> string ![io] {
 // hinge for the test's OWN closure: a changed test source or dep
 // changes a hash here exactly as it changes the bytes the linker reads.
 //
-// Known gap: the link ALSO pulls in the assembled runtime capsule
-// objects + link libs (`_clang_link_test_cmd_with_deps`), which are NOT
-// folded into this key. Those are covered indirectly by
-// `compiler_identity` (a rebuilt compiler — which is how a runtime
-// source edit normally reaches a test binary, since the runtime is
-// rebuilt as part of `make compile` — busts every entry) and directly
-// by `--no-test-cache` on the `make check` / full-suite gate. A runtime
-// edit that is NOT accompanied by a compiler rebuild can therefore
-// serve a stale binary; the gate's cold build is the backstop.
+// The link ALSO pulls in the assembled runtime capsule objects + link
+// libs (`_clang_link_test_cmd_with_deps`), which are not part of the
+// test's own dep closure. Those are folded in via `runtime_identity`
+// (`runtime_link_inputs_identity` — the runtime source + link-lib
+// content hashed by the caller), so a runtime edit busts the key
+// directly by content. This replaced the former reliance on a
+// per-commit `compiler_identity` busting every entry on every commit
+// (#1233): `compiler_identity` is now the commit-stable capsule version
+// (`resolve_test_bin_identity_for_cache`), so genuinely-unchanged tests
+// hit across commits. `--no-test-cache` on the `make check` /
+// full-suite gate remains the final cold-build backstop.
 //
 //   key = sha256(
 //       sha256(test_source_bytes)
 //       || sha256(sorted(dep hashes))   // dep_ll files + native_texts
-//       || compiler_identity            // cache_compiler_identity(...)
+//       || compiler_identity            // commit-stable capsule version
+//       || runtime_identity             // runtime_link_inputs_identity(...)
 //       || canonical(clang_flags)
 //       || test_bin_cache_schema_version()
 //   )
@@ -838,7 +848,7 @@ fn test_bin_cache_root() -> string ![io] {
 // within one process, never across two processes hashing the same
 // file simultaneously (the module cache carries the identical
 // single-process precondition).
-fn test_bin_cache_key(test_source_path: string, dep_ll_paths: string[], native_texts: string[], compiler_identity: string, flags_canonical: string, unique_suffix: string) -> CacheKey ![io] {
+fn test_bin_cache_key(test_source_path: string, dep_ll_paths: string[], native_texts: string[], compiler_identity: string, runtime_identity: string, flags_canonical: string, unique_suffix: string) -> CacheKey ![io] {
     let s_hash = _sha256_of_file_cmd(test_source_path);
 
     let mut dep_hashes: string[] = [];
@@ -868,11 +878,58 @@ fn test_bin_cache_key(test_source_path: string, dep_ll_paths: string[], native_t
 
     let final_input = s_hash + "\n" + deps_hash + "\n" + compiler_identity
         + "\n"
+        + runtime_identity
+        + "\n"
         + flags_canonical
         + "\n"
         + test_bin_cache_schema_version();
     let final_digest = _sha256_of_string(final_input, unique_suffix + "_final");
     return CacheKey { digest: final_digest };
+}
+
+// Content identity for the runtime link inputs a test binary links
+// against (#1233). The clang link pulls in the assembled runtime capsule
+// objects + link libs, which are NOT part of the test's own dep closure;
+// folding their *source* content into the test-bin key is what lets that
+// cache stay correct across a runtime edit WITHOUT relying on a
+// per-commit compiler stamp (which would bust every entry on every
+// commit). Callers enumerate the runtime inputs once per `sfn test`
+// invocation (the set is invocation-stable) and fold the result into
+// `test_bin_cache_key` as `runtime_identity`.
+//
+// `source_paths` are the runtime input sources (`.c` / `.ll` / `.sfn`
+// + prelude entry) hashed off disk; `link_libs` are linker flag strings
+// (`-lm`, `-lpthread`, capsule-declared libs) folded in by value. All
+// components are sorted before folding so the identity is invariant
+// under enumeration order. Hashing SOURCES (not built objects) is both
+// available on the single-file leaf path — where objects may not exist
+// yet — and strictly upstream: a source edit busts even before a
+// rebuild. An unreadable source yields an empty `_sha256_of_file_cmd`
+// digest, which still folds in deterministically.
+fn runtime_link_inputs_identity(source_paths: string[], link_libs: string[], unique_suffix: string) -> string ![io] {
+    let mut parts: string[] = [];
+    let mut i: int = 0;
+    loop {
+        if i >= source_paths.length { break; }
+        parts.push("src:" + _sha256_of_file_cmd(source_paths[i]));
+        i += 1;
+    }
+    let mut j: int = 0;
+    loop {
+        if j >= link_libs.length { break; }
+        parts.push("lib:" + link_libs[j]);
+        j += 1;
+    }
+    let sorted = _sort_strings(parts);
+    let mut concat: string = "";
+    let mut k: int = 0;
+    loop {
+        if k >= sorted.length { break; }
+        if k > 0 { concat = concat + "|"; }
+        concat = concat + sorted[k];
+        k += 1;
+    }
+    return _sha256_of_string(concat, unique_suffix + "_rt");
 }
 
 export {
@@ -906,5 +963,6 @@ export {
     test_bin_cache_schema_version,
     test_bin_cache_root_with_override,
     test_bin_cache_root,
-    test_bin_cache_key
+    test_bin_cache_key,
+    runtime_link_inputs_identity
 };

--- a/compiler/src/cli_commands.sfn
+++ b/compiler/src/cli_commands.sfn
@@ -968,19 +968,71 @@ fn _extract_json_uint_after(text: string, key: string) -> int {
     return n;
 }
 
+// Recursively collect `.h` header files under `root` (bounded depth),
+// mirroring `_collect_sfn_files_cmd`'s walker. Used by
+// `_test_bin_runtime_identity` to fold the runtime's include-dir headers
+// into the per-test cache key by content — a header edit changes the
+// compiled runtime objects the test binary links against, so it must
+// bust the key even though the `.c`/`.ll` source list is unchanged.
+fn _collect_header_files_cmd(root: string, max_depth: int) -> string[] ![io] {
+    let mut results: string[] = [];
+    if _ends_with_cmd(root, ".h") { return [root]; }
+    let root_norm: string = _strip_trailing_slashes_cmd(root);
+    let mut queue: string[] = [root_norm];
+    let mut depth: int = 0;
+    loop {
+        if depth >= max_depth { break; }
+        if queue.length == 0 { break; }
+        let mut next_queue: string[] = [];
+        let mut qi: int = 0;
+        loop {
+            if qi >= queue.length { break; }
+            let dir = queue[qi];
+            if !fs.exists(dir) {
+                qi += 1;
+                continue;
+            }
+            let entries = fs.listDirectory(dir);
+            let mut ei: int = 0;
+            loop {
+                if ei >= entries.length { break; }
+                let entry = entries[ei];
+                let full_path = dir + "/" + entry;
+                if _ends_with_cmd(entry, ".h") { results.push(full_path); } else {
+                    let child_entries = fs.listDirectory(full_path);
+                    if child_entries.length > 0 {
+                        next_queue.push(full_path);
+                    }
+                }
+                ei += 1;
+            }
+            qi += 1;
+        }
+        queue = next_queue;
+        depth += 1;
+    }
+    return results;
+}
+
 // #1233: content identity of the runtime link inputs every test binary
 // links against. The runtime capsule set is invocation-stable, so this
 // is resolved once and folded into every per-test cache key via
 // `runtime_link_inputs_identity`. Replacing the former per-commit
 // `compiler_identity` reliance with this content hash is what keeps the
 // per-test binary cache correct across a runtime edit while letting
-// genuinely-unchanged tests hit across commits. `unique_suffix` makes
-// the hash temp path collision-safe across concurrent `sfn test`
-// invocations (pass the per-invocation scratch root).
+// genuinely-unchanged tests hit across commits.
+//
+// Folds, per runtime capsule: the `.c`/`.ll`/`.sfn` sources + prelude
+// entry (by content), the `.h` headers found under each include root (by
+// content — a header edit changes the compiled runtime objects), the
+// include-dir paths (`-I<dir>`, by value — an include-root change), and
+// the declared link libs (by value). `unique_suffix` makes the hash temp
+// path collision-safe across concurrent `sfn test` invocations (pass the
+// per-invocation scratch root).
 fn _test_bin_runtime_identity(runtime_root: string, unique_suffix: string) -> string ![io] {
     let caps = runtime_capsule_from_root(runtime_root);
     let mut sources: string[] = [];
-    let mut libs: string[] = [];
+    let mut values: string[] = [];
     let mut ci: int = 0;
     loop {
         if ci >= caps.length { break; }
@@ -1006,15 +1058,32 @@ fn _test_bin_runtime_identity(runtime_root: string, unique_suffix: string) -> st
         if cap.prelude_entry.length > 0 {
             sources.push(cap.prelude_entry);
         }
+        // Include roots: fold the path by value (`-I<dir>`) so an
+        // include-root change busts, and hash every `.h` under it by
+        // content so a header edit busts.
+        let mut di: int = 0;
+        loop {
+            if di >= cap.include_dirs.length { break; }
+            let inc = cap.include_dirs[di];
+            values.push("-I" + inc);
+            let headers = _collect_header_files_cmd(inc, 32);
+            let mut hi: int = 0;
+            loop {
+                if hi >= headers.length { break; }
+                sources.push(headers[hi]);
+                hi += 1;
+            }
+            di += 1;
+        }
         let mut bi: int = 0;
         loop {
             if bi >= cap.link_libs.length { break; }
-            libs.push(cap.link_libs[bi]);
+            values.push(cap.link_libs[bi]);
             bi += 1;
         }
         ci += 1;
     }
-    return runtime_link_inputs_identity(sources, libs, unique_suffix + "_rtid");
+    return runtime_link_inputs_identity(sources, values, unique_suffix + "_rtid");
 }
 
 fn handle_test_command(args: string[], runtime_root: string, binary_dir: string) -> int ![io, clock] {
@@ -1606,19 +1675,26 @@ fn handle_test_command(args: string[], runtime_root: string, binary_dir: string)
     let mut total_skipped: int = 0;
     let mut overall_rc: int = 0;
 
-    // #1230: per-test linked-binary cache. Resolve the invocation-stable
-    // key inputs once: the compiler's cache identity (binary content for
-    // `.dirty` dev stamps, version otherwise — the same model the module
-    // IR cache uses so a rebuilt compiler busts every cached binary) and
-    // the canonical clang flag set (`-O0`, matching
-    // `_clang_link_test_cmd_with_deps`). Per-test the key folds in the
-    // test source hash + the resolver's dep closure
+    // #1230/#1233: per-test linked-binary cache. Resolve the
+    // invocation-stable key inputs once: the commit-stable compiler
+    // identity (`resolve_test_bin_identity_for_cache` — the bare capsule
+    // version, `+dev.<hash>` stripped, so a baseline at one commit warms a
+    // PR at another), the runtime link-input content identity (so a
+    // runtime/header/include-root change busts every entry), and the
+    // canonical clang flag set (`-O0`, matching
+    // `_clang_link_test_cmd_with_deps`). Per-test the key additionally
+    // folds the test source hash + the resolver's dep closure
     // (`dep_ll_paths` + `native_texts`). `--no-test-cache` disables both
-    // the read and the write so `make check` always cold-builds.
+    // the read and the write so `make check` always cold-builds — so the
+    // runtime identity (the one expensive input: it hashes the runtime
+    // sources + headers) is only computed when the cache is enabled.
     let test_cache_enabled = !no_test_cache;
     let tb_cache_root = test_bin_cache_root();
     let tb_compiler_identity = resolve_test_bin_identity_for_cache(binary_dir);
-    let tb_runtime_identity = _test_bin_runtime_identity(runtime_root, _sanitize_filename_cmd(scratch_root));
+    let mut tb_runtime_identity: string = "";
+    if test_cache_enabled {
+        tb_runtime_identity = _test_bin_runtime_identity(runtime_root, _sanitize_filename_cmd(scratch_root));
+    }
     let mut tb_flags: string[] = ["-O0"];
     let tb_flags_canonical = canonicalize_flags(tb_flags);
     let mut test_bin_hits: int = 0;
@@ -1644,13 +1720,14 @@ fn handle_test_command(args: string[], runtime_root: string, binary_dir: string)
 
         let file_start_ms = monotonic_millis();
 
-        // #1230: derive the per-test binary cache key from the test
+        // #1230/#1233: derive the per-test binary cache key from the test
         // source + the resolver's dep closure (the test-source-specific
-        // link inputs — the runtime capsule objects + link libs the link
-        // also consumes are NOT folded in; a runtime edit relies on the
-        // compiler-identity component or `--no-test-cache`, see
-        // `test_bin_cache_key`), then try to serve the linked binary from
-        // cache. On a hit we copy it into `exe_path` and skip both LLVM
+        // link inputs) plus the invocation-stable `tb_runtime_identity`
+        // (the runtime link inputs — sources, headers, include roots, link
+        // libs — folded by content above) and the commit-stable compiler
+        // identity, see `test_bin_cache_key`. Then try to serve the linked
+        // binary from cache. On a hit we copy it into `exe_path` and skip
+        // both LLVM
         // lowering and the clang link (the dominant per-test cost); we
         // still RUN the binary below (variant 2a — never trust a cached
         // result).

--- a/compiler/src/cli_commands.sfn
+++ b/compiler/src/cli_commands.sfn
@@ -6,11 +6,11 @@ import { AssertFailure, _empty_assert_failure, _parse_assert_failure_record } fr
 import { Program, Statement } from "./ast";
 import {
     CacheKey,
-    cache_compiler_identity,
     cache_copy_artifact_to,
     cache_lookup_artifact,
     cache_store_artifact,
     canonicalize_flags,
+    runtime_link_inputs_identity,
     test_bin_cache_key,
     test_bin_cache_root
 } from "./build_cache";
@@ -105,7 +105,7 @@ import {
 } from "./toml_parser";
 import { format_source } from "./tools/fmt";
 import { load_imported_interfaces_from_paths } from "./typecheck_import_loader";
-import { resolve_compiler_version_for_cache } from "./version";
+import { resolve_test_bin_identity_for_cache } from "./version";
 
 // Validate a path segment (scope, name) contains no traversal or illegal chars.
 fn _is_safe_capsule_segment_cmd(value: string) -> boolean {
@@ -968,6 +968,55 @@ fn _extract_json_uint_after(text: string, key: string) -> int {
     return n;
 }
 
+// #1233: content identity of the runtime link inputs every test binary
+// links against. The runtime capsule set is invocation-stable, so this
+// is resolved once and folded into every per-test cache key via
+// `runtime_link_inputs_identity`. Replacing the former per-commit
+// `compiler_identity` reliance with this content hash is what keeps the
+// per-test binary cache correct across a runtime edit while letting
+// genuinely-unchanged tests hit across commits. `unique_suffix` makes
+// the hash temp path collision-safe across concurrent `sfn test`
+// invocations (pass the per-invocation scratch root).
+fn _test_bin_runtime_identity(runtime_root: string, unique_suffix: string) -> string ![io] {
+    let caps = runtime_capsule_from_root(runtime_root);
+    let mut sources: string[] = [];
+    let mut libs: string[] = [];
+    let mut ci: int = 0;
+    loop {
+        if ci >= caps.length { break; }
+        let cap = caps[ci];
+        let mut si: int = 0;
+        loop {
+            if si >= cap.c_sources.length { break; }
+            sources.push(cap.c_sources[si]);
+            si += 1;
+        }
+        let mut li: int = 0;
+        loop {
+            if li >= cap.ll_sources.length { break; }
+            sources.push(cap.ll_sources[li]);
+            li += 1;
+        }
+        let mut fi: int = 0;
+        loop {
+            if fi >= cap.sfn_sources.length { break; }
+            sources.push(cap.sfn_sources[fi]);
+            fi += 1;
+        }
+        if cap.prelude_entry.length > 0 {
+            sources.push(cap.prelude_entry);
+        }
+        let mut bi: int = 0;
+        loop {
+            if bi >= cap.link_libs.length { break; }
+            libs.push(cap.link_libs[bi]);
+            bi += 1;
+        }
+        ci += 1;
+    }
+    return runtime_link_inputs_identity(sources, libs, unique_suffix + "_rtid");
+}
+
 fn handle_test_command(args: string[], runtime_root: string, binary_dir: string) -> int ![io, clock] {
     // Flag parser: `--json` selects the jsonl event stream; `-k` and
     // `--tag` (issue #849) each consume the following argv element as a
@@ -1568,8 +1617,8 @@ fn handle_test_command(args: string[], runtime_root: string, binary_dir: string)
     // the read and the write so `make check` always cold-builds.
     let test_cache_enabled = !no_test_cache;
     let tb_cache_root = test_bin_cache_root();
-    let tb_self_exe = _resolve_test_self_path(binary_dir);
-    let tb_compiler_identity = cache_compiler_identity(resolve_compiler_version_for_cache(binary_dir), tb_self_exe);
+    let tb_compiler_identity = resolve_test_bin_identity_for_cache(binary_dir);
+    let tb_runtime_identity = _test_bin_runtime_identity(runtime_root, _sanitize_filename_cmd(scratch_root));
     let mut tb_flags: string[] = ["-O0"];
     let tb_flags_canonical = canonicalize_flags(tb_flags);
     let mut test_bin_hits: int = 0;
@@ -1615,7 +1664,7 @@ fn handle_test_command(args: string[], runtime_root: string, binary_dir: string)
         let mut tb_key: CacheKey = CacheKey { digest: "" };
         let mut cache_hit: boolean = false;
         if test_cache_enabled {
-            tb_key = test_bin_cache_key(path, groups[group_idx].dep_ll_paths, groups[group_idx].native_texts, tb_compiler_identity, tb_flags_canonical, _sanitize_filename_cmd(scratch_root
+            tb_key = test_bin_cache_key(path, groups[group_idx].dep_ll_paths, groups[group_idx].native_texts, tb_compiler_identity, tb_runtime_identity, tb_flags_canonical, _sanitize_filename_cmd(scratch_root
                 + "/"
                 + path));
             if cache_lookup_artifact(tb_cache_root, tb_key, "test-bin") {

--- a/compiler/src/version.sfn
+++ b/compiler/src/version.sfn
@@ -202,3 +202,37 @@ fn resolve_compiler_version_for_cache(binary_dir: string) -> string ![io] {
 
     return __version_fallback__;
 }
+
+// Strip semver build metadata (everything from the first `+`) from a
+// version string. `+` is the semver build-metadata separator, so
+// `<ver>+dev.<hash>`, `<ver>+dev.<hash>.dirty`, and `<ver>+bin.<sha>`
+// all collapse to the bare `<ver>`. A string with no `+` is returned
+// unchanged. Pure (no IO) so it is directly unit-testable.
+fn _strip_build_metadata(version: string) -> string {
+    let mut i: int = 0;
+    loop {
+        if i >= version.length { break; }
+        if version[i] == "+" { return substring(version, 0, i); }
+        i += 1;
+    }
+    return version;
+}
+
+// Commit-stable identity for the per-test binary cache (#1230/#1233).
+// Same resolution chain as `resolve_compiler_version_for_cache`, but
+// strips the `+dev.<hash>` build metadata so the identity is invariant
+// across commits at the same capsule version.
+//
+// Why a separate identity from the module-IR cache: the module-IR cache
+// is SEED-built, so its stamp is the stable pinned-seed version. The
+// per-test binary cache is keyed by the FRESHLY-built compiler's stamp,
+// which embeds a per-commit git short hash — so without this strip a
+// `push:main` baseline can never warm a PR (the commit differs), and a
+// PR's second push can't reuse its first push's binaries. Correctness
+// for runtime edits is NOT lost: the runtime link inputs are folded into
+// the test-bin key by content (see `build_cache.sfn::test_bin_cache_key`
+// and `runtime_link_inputs_identity`), so a runtime change still busts
+// the key even though the identity no longer carries the commit hash.
+fn resolve_test_bin_identity_for_cache(binary_dir: string) -> string ![io] {
+    return _strip_build_metadata(resolve_compiler_version_for_cache(binary_dir));
+}

--- a/compiler/tests/e2e/test_test_bin_cache.sh
+++ b/compiler/tests/e2e/test_test_bin_cache.sh
@@ -37,9 +37,17 @@ if ! command -v jq >/dev/null 2>&1; then
 fi
 
 SCRATCH="$(mktemp -d -t sfn-test-bin-cache-XXXXXX)"
-trap 'rm -rf "$SCRATCH"' EXIT
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+
+# Test 5 rewrites build/native/.build-stamp to simulate a different
+# commit. Capture the original bytes and restore them on exit (alongside
+# the scratch cleanup) so a local dev tree's stamp is never poisoned.
+STAMP_FILE="$REPO_ROOT/build/native/.build-stamp"
+ORIG_STAMP=""
+[ -f "$STAMP_FILE" ] && ORIG_STAMP="$(cat "$STAMP_FILE")"
+restore_stamp() { [ -n "$ORIG_STAMP" ] && printf '%s\n' "$ORIG_STAMP" > "$STAMP_FILE"; }
+trap 'rm -rf "$SCRATCH"; restore_stamp' EXIT
 
 run_test() {
     local name="$1"
@@ -105,6 +113,38 @@ test_warm_hit() {
     return 0
 }
 run_test "warm rerun: every test hits, hit_rate 1.0000" test_warm_hit
+
+# ---- Test 5: cross-commit stability (#1233) ----
+# The per-test binary cache identity is the commit-STABLE capsule version
+# (`resolve_test_bin_identity_for_cache` strips the `+dev.<hash>` build
+# metadata), so a `push:main` baseline warms a PR and a second push
+# reuses the first's binaries. We can't change the real git hash in a
+# hermetic test, so simulate the commit change the way the bug was first
+# diagnosed: overwrite build/native/.build-stamp with a DIFFERENT
+# `+dev.<hash>` at the SAME capsule version, then assert the warm cache
+# (populated under the original stamp in Tests 1-2) still HITS. Before
+# the fix this missed (the per-commit hash busted every entry).
+test_cross_commit_stable() {
+    if [ -z "$ORIG_STAMP" ]; then
+        echo "[test]   SKIP: no build/native/.build-stamp to rewrite" >&2
+        return 0
+    fi
+    # Rewrite only the build-metadata: keep everything before the first
+    # `+`, append a distinct `+dev.<hash>`. A stamp with no `+` (a tagged
+    # release) gets one appended — still a different stamp, same version.
+    local base="${ORIG_STAMP%%+*}"
+    printf '%s\n' "${base}+dev.deadbee" > "$STAMP_FILE"
+    local summary
+    summary="$(run_suite "")" || { restore_stamp; return 1; }
+    restore_stamp
+    echo "[test]   cross-commit summary: $summary" >&2
+    # Same capsule version ⇒ same stripped identity ⇒ key unchanged ⇒ HIT.
+    [ "$(echo "$summary" | jq -r '.cache.test_bin_hits')" -ge 1 ] || return 1
+    [ "$(echo "$summary" | jq -r '.cache.test_bin_misses')" = "0" ] || return 1
+    [ "$(echo "$summary" | jq -r '.cache.test_bin_hit_rate == 1')" = "true" ] || return 1
+    return 0
+}
+run_test "different +dev.<hash> stamp, same version: still hits (no commit bust)" test_cross_commit_stable
 
 # ---- Test 3: --no-test-cache bypasses read + write, hit_rate 0.0000 ----
 test_no_cache_flag() {

--- a/compiler/tests/e2e/test_test_bin_cache.sh
+++ b/compiler/tests/e2e/test_test_bin_cache.sh
@@ -41,13 +41,22 @@ SCRATCH="$(mktemp -d -t sfn-test-bin-cache-XXXXXX)"
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 
 # Test 5 rewrites build/native/.build-stamp to simulate a different
-# commit. Capture the original bytes and restore them on exit (alongside
-# the scratch cleanup) so a local dev tree's stamp is never poisoned.
+# commit. Back the original file up with `cp` (faithful to trailing
+# newlines / an empty file, unlike `$(cat)`) and restore it on exit
+# BEFORE the scratch dir is removed, so a local dev tree's stamp is never
+# poisoned. The backup lives outside $SCRATCH so trap order is irrelevant.
 STAMP_FILE="$REPO_ROOT/build/native/.build-stamp"
-ORIG_STAMP=""
-[ -f "$STAMP_FILE" ] && ORIG_STAMP="$(cat "$STAMP_FILE")"
-restore_stamp() { [ -n "$ORIG_STAMP" ] && printf '%s\n' "$ORIG_STAMP" > "$STAMP_FILE"; }
-trap 'rm -rf "$SCRATCH"; restore_stamp' EXIT
+STAMP_BACKUP=""
+STAMP_PRESENT=0
+if [ -f "$STAMP_FILE" ]; then
+    STAMP_BACKUP="$(mktemp)"
+    cp "$STAMP_FILE" "$STAMP_BACKUP"
+    STAMP_PRESENT=1
+fi
+restore_stamp() {
+    [ "$STAMP_PRESENT" = "1" ] && [ -f "$STAMP_BACKUP" ] && cp "$STAMP_BACKUP" "$STAMP_FILE"
+}
+trap 'restore_stamp; rm -rf "$SCRATCH" "$STAMP_BACKUP"' EXIT
 
 run_test() {
     local name="$1"
@@ -125,14 +134,15 @@ run_test "warm rerun: every test hits, hit_rate 1.0000" test_warm_hit
 # (populated under the original stamp in Tests 1-2) still HITS. Before
 # the fix this missed (the per-commit hash busted every entry).
 test_cross_commit_stable() {
-    if [ -z "$ORIG_STAMP" ]; then
+    if [ "$STAMP_PRESENT" != "1" ]; then
         echo "[test]   SKIP: no build/native/.build-stamp to rewrite" >&2
         return 0
     fi
     # Rewrite only the build-metadata: keep everything before the first
     # `+`, append a distinct `+dev.<hash>`. A stamp with no `+` (a tagged
     # release) gets one appended — still a different stamp, same version.
-    local base="${ORIG_STAMP%%+*}"
+    local base
+    base="$(head -1 "$STAMP_FILE" | sed 's/+.*//')"
     printf '%s\n' "${base}+dev.deadbee" > "$STAMP_FILE"
     local summary
     summary="$(run_suite "")" || { restore_stamp; return 1; }

--- a/compiler/tests/unit/build_cache_test.sfn
+++ b/compiler/tests/unit/build_cache_test.sfn
@@ -30,26 +30,28 @@ import {
     build_cache_schema_version,
     cache_artifact_path,
     cache_clean,
+    cache_compiler_identity,
     cache_copy_artifact_to,
+    cache_key_for,
     cache_lookup_artifact,
     cache_lookup_complete,
     cache_paths_for,
     cache_root_with_override,
+    cache_stats_is_empty,
     cache_store,
     cache_store_artifact,
-    cache_stats_is_empty,
     canonicalize_flags,
-    cache_key_for,
-    cache_compiler_identity,
     empty_build_cache_config,
     empty_cache_stats,
     is_valid_digest,
     merge_cache_stats,
+    runtime_link_inputs_identity,
     runtime_object_entry_key_from_str,
     test_bin_cache_key,
     test_bin_cache_root_with_override,
     test_bin_cache_schema_version
 } from "../../src/build_cache";
+import { _strip_build_metadata } from "../../src/version";
 
 // --------------------------------------------------------------
 // Fixture helpers
@@ -209,11 +211,11 @@ test "build_cache: cache_key_for changes when dep manifest changes" ![io] {
 // Per-test binary cache (#1230)
 // --------------------------------------------------------------
 test "build_cache: test_bin cache schema + root layout" ![io] {
-    assert test_bin_cache_schema_version() == "v1";
+    assert test_bin_cache_schema_version() == "v2";
     // In-tree default sits beside (not under) the module cache's
     // `<base>/v<N>` tree so the two schema lines age out independently.
-    assert test_bin_cache_root_with_override("") == "build/cache/test-bin/v1";
-    assert test_bin_cache_root_with_override("/shared/cache") == "/shared/cache/test-bin/v1";
+    assert test_bin_cache_root_with_override("") == "build/cache/test-bin/v2";
+    assert test_bin_cache_root_with_override("/shared/cache") == "/shared/cache/test-bin/v2";
 }
 
 test "build_cache: test_bin_cache_key same inputs -> same digest" ![io] {
@@ -223,8 +225,8 @@ test "build_cache: test_bin_cache_key same inputs -> same digest" ![io] {
     _write_file(test_src, "test \"x\" { assert 1 == 1; }");
     _write_file(dep_ll, "; ModuleID = 'dep'");
     let native_texts: string[] = ["sfn-asm: helper"];
-    let key1 = test_bin_cache_key(test_src, [dep_ll], native_texts, "0.7.0+bin.abc", "[\"-O0\"]", "tbk_det");
-    let key2 = test_bin_cache_key(test_src, [dep_ll], native_texts, "0.7.0+bin.abc", "[\"-O0\"]", "tbk_det");
+    let key1 = test_bin_cache_key(test_src, [dep_ll], native_texts, "0.7.0", "rt0", "[\"-O0\"]", "tbk_det");
+    let key2 = test_bin_cache_key(test_src, [dep_ll], native_texts, "0.7.0", "rt0", "[\"-O0\"]", "tbk_det");
     assert key1.digest == key2.digest;
     assert key1.digest.length == 64;
     _cleanup(scratch);
@@ -237,13 +239,13 @@ test "build_cache: test_bin_cache_key changes when a dep .ll hash changes" ![io]
     _write_file(test_src, "test \"x\" { assert 1 == 1; }");
     let native_texts: string[] = ["sfn-asm: helper"];
     _write_file(dep_ll, "; ModuleID = 'dep'\ndefine i64 @f() { ret i64 1 }");
-    let key1 = test_bin_cache_key(test_src, [dep_ll], native_texts, "0.7.0+bin.abc", "[\"-O0\"]", "tbk_dll_1");
+    let key1 = test_bin_cache_key(test_src, [dep_ll], native_texts, "0.7.0", "rt0", "[\"-O0\"]", "tbk_dll_1");
     // A changed transitive dep → changed hash → changed key → cache
     // miss. This is the correctness hinge: a stale binary can never be
     // served after a dep edit (acceptance criterion: misses for exactly
     // the transitive importers of an edited compiler/src file).
     _write_file(dep_ll, "; ModuleID = 'dep'\ndefine i64 @f() { ret i64 2 }");
-    let key2 = test_bin_cache_key(test_src, [dep_ll], native_texts, "0.7.0+bin.abc", "[\"-O0\"]", "tbk_dll_2");
+    let key2 = test_bin_cache_key(test_src, [dep_ll], native_texts, "0.7.0", "rt0", "[\"-O0\"]", "tbk_dll_2");
     assert key1.digest != key2.digest;
     _cleanup(scratch);
 }
@@ -254,8 +256,8 @@ test "build_cache: test_bin_cache_key changes when a native_text dep changes" ![
     let dep_ll = scratch + "/dep.ll";
     _write_file(test_src, "test \"x\" { assert 1 == 1; }");
     _write_file(dep_ll, "; ModuleID = 'dep'");
-    let key1 = test_bin_cache_key(test_src, [dep_ll], ["sfn-asm: original"], "0.7.0+bin.abc", "[\"-O0\"]", "tbk_nt_1");
-    let key2 = test_bin_cache_key(test_src, [dep_ll], ["sfn-asm: changed"], "0.7.0+bin.abc", "[\"-O0\"]", "tbk_nt_2");
+    let key1 = test_bin_cache_key(test_src, [dep_ll], ["sfn-asm: original"], "0.7.0", "rt0", "[\"-O0\"]", "tbk_nt_1");
+    let key2 = test_bin_cache_key(test_src, [dep_ll], ["sfn-asm: changed"], "0.7.0", "rt0", "[\"-O0\"]", "tbk_nt_2");
     assert key1.digest != key2.digest;
     _cleanup(scratch);
 }
@@ -271,8 +273,8 @@ test "build_cache: test_bin_cache_key invariant under dep_ll order" ![io] {
     _write_file(dep_b, "; beta");
     _write_file(dep_c, "; gamma");
     let nt: string[] = [];
-    let key_abc = test_bin_cache_key(test_src, [dep_a, dep_b, dep_c], nt, "0.7.0+bin.abc", "[\"-O0\"]", "tbk_ord");
-    let key_cba = test_bin_cache_key(test_src, [dep_c, dep_b, dep_a], nt, "0.7.0+bin.abc", "[\"-O0\"]", "tbk_ord");
+    let key_abc = test_bin_cache_key(test_src, [dep_a, dep_b, dep_c], nt, "0.7.0", "rt0", "[\"-O0\"]", "tbk_ord");
+    let key_cba = test_bin_cache_key(test_src, [dep_c, dep_b, dep_a], nt, "0.7.0", "rt0", "[\"-O0\"]", "tbk_ord");
     assert key_abc.digest == key_cba.digest;
     _cleanup(scratch);
 }
@@ -284,9 +286,9 @@ test "build_cache: test_bin_cache_key changes when test source changes" ![io] {
     _write_file(dep_ll, "; ModuleID = 'dep'");
     let nt: string[] = [];
     _write_file(test_src, "test \"x\" { assert 1 == 1; }");
-    let key1 = test_bin_cache_key(test_src, [dep_ll], nt, "0.7.0+bin.abc", "[\"-O0\"]", "tbk_src_1");
+    let key1 = test_bin_cache_key(test_src, [dep_ll], nt, "0.7.0", "rt0", "[\"-O0\"]", "tbk_src_1");
     _write_file(test_src, "test \"x\" { assert 2 == 2; }");
-    let key2 = test_bin_cache_key(test_src, [dep_ll], nt, "0.7.0+bin.abc", "[\"-O0\"]", "tbk_src_2");
+    let key2 = test_bin_cache_key(test_src, [dep_ll], nt, "0.7.0", "rt0", "[\"-O0\"]", "tbk_src_2");
     assert key1.digest != key2.digest;
     _cleanup(scratch);
 }
@@ -298,12 +300,68 @@ test "build_cache: test_bin_cache_key changes when compiler identity changes" ![
     _write_file(test_src, "test \"x\" { assert 1 == 1; }");
     _write_file(dep_ll, "; ModuleID = 'dep'");
     let nt: string[] = [];
-    // A rebuilt compiler (new binary content for `.dirty` dev stamps)
-    // changes the identity → busts every cached binary, same model the
-    // module IR cache uses.
-    let key1 = test_bin_cache_key(test_src, [dep_ll], nt, "0.7.0+bin.aaa", "[\"-O0\"]", "tbk_id_1");
-    let key2 = test_bin_cache_key(test_src, [dep_ll], nt, "0.7.0+bin.bbb", "[\"-O0\"]", "tbk_id_2");
+    // A real capsule-version bump (the commit-stable identity, #1233)
+    // still busts every cached binary.
+    let key1 = test_bin_cache_key(test_src, [dep_ll], nt, "0.7.0", "rt0", "[\"-O0\"]", "tbk_id_1");
+    let key2 = test_bin_cache_key(test_src, [dep_ll], nt, "0.8.0", "rt0", "[\"-O0\"]", "tbk_id_2");
     assert key1.digest != key2.digest;
+    _cleanup(scratch);
+}
+
+// #1233 headline: two compiler stamps that differ ONLY in their
+// `+dev.<hash>` build metadata (i.e. two commits at the same capsule
+// version) must collapse to the SAME identity, so a push:main baseline
+// warms a PR and a second push reuses the first's binaries. This is the
+// unit-level proof of the cross-stamp e2e (test_test_bin_cache.sh Test
+// 5); the per-commit hash used to bust every entry on every commit.
+test "version: _strip_build_metadata collapses +dev.<hash> stamps" {
+    assert _strip_build_metadata("0.7.0-alpha.28+dev.f944726") == "0.7.0-alpha.28";
+    assert _strip_build_metadata("0.7.0-alpha.28+dev.f944726.dirty") == "0.7.0-alpha.28";
+    assert _strip_build_metadata("0.7.0-alpha.28+bin.abcdef0") == "0.7.0-alpha.28";
+    // No build metadata → unchanged (a tagged release stamp).
+    assert _strip_build_metadata("0.7.0-alpha.28") == "0.7.0-alpha.28";
+    assert _strip_build_metadata("") == "";
+    // Two different commits at the same version collapse to one identity.
+    assert _strip_build_metadata("0.7.0-alpha.28+dev.aaaaaaa") == _strip_build_metadata("0.7.0-alpha.28+dev.bbbbbbb");
+}
+
+test "build_cache: test_bin_cache_key changes when runtime identity changes" ![io] {
+    let scratch = _test_tmp_root("tbk_rtid");
+    let test_src = scratch + "/foo_test.sfn";
+    let dep_ll = scratch + "/dep.ll";
+    _write_file(test_src, "test \"x\" { assert 1 == 1; }");
+    _write_file(dep_ll, "; ModuleID = 'dep'");
+    let nt: string[] = [];
+    // A runtime edit changes the folded runtime identity → busts the key
+    // (this is what replaces the former per-commit-stamp backstop).
+    let key1 = test_bin_cache_key(test_src, [dep_ll], nt, "0.7.0", "rt-aaa", "[\"-O0\"]", "tbk_rt_1");
+    let key2 = test_bin_cache_key(test_src, [dep_ll], nt, "0.7.0", "rt-bbb", "[\"-O0\"]", "tbk_rt_2");
+    assert key1.digest != key2.digest;
+    _cleanup(scratch);
+}
+
+test "build_cache: runtime_link_inputs_identity is content-addressed + order-invariant" ![io] {
+    let scratch = _test_tmp_root("rtid");
+    let a = scratch + "/a.c";
+    let b = scratch + "/b.ll";
+    let c = scratch + "/prelude.sfn";
+    _write_file(a, "int a(void){return 1;}");
+    _write_file(b, "; beta");
+    _write_file(c, "fn p() {}");
+    let libs: string[] = ["-lm", "-lpthread"];
+    // Same inputs → same digest; invariant under source-path order.
+    let id_abc = runtime_link_inputs_identity([a, b, c], libs, "rtid_1");
+    let id_cba = runtime_link_inputs_identity([c, b, a], libs, "rtid_2");
+    assert id_abc == id_cba;
+    assert id_abc.length == 64;
+    // Editing one source's bytes → different digest (runtime edit busts).
+    _write_file(b, "; beta-changed");
+    let id_edited = runtime_link_inputs_identity([a, b, c], libs, "rtid_3");
+    assert id_edited != id_abc;
+    // A changed link lib → different digest.
+    _write_file(b, "; beta");
+    let id_more_libs = runtime_link_inputs_identity([a, b, c], ["-lm", "-lpthread", "-lfoo"], "rtid_4");
+    assert id_more_libs != id_abc;
     _cleanup(scratch);
 }
 

--- a/compiler/tests/unit/build_cache_test.sfn
+++ b/compiler/tests/unit/build_cache_test.sfn
@@ -358,10 +358,16 @@ test "build_cache: runtime_link_inputs_identity is content-addressed + order-inv
     _write_file(b, "; beta-changed");
     let id_edited = runtime_link_inputs_identity([a, b, c], libs, "rtid_3");
     assert id_edited != id_abc;
-    // A changed link lib → different digest.
+    // A changed value input (link lib / include dir) → different digest.
     _write_file(b, "; beta");
     let id_more_libs = runtime_link_inputs_identity([a, b, c], ["-lm", "-lpthread", "-lfoo"], "rtid_4");
     assert id_more_libs != id_abc;
+    // Each source folds in as `<path>@<hash>`, so two DIFFERENT unreadable
+    // paths (both empty digest) do NOT alias to the same identity.
+    let no_libs: string[] = [];
+    let id_missing_x = runtime_link_inputs_identity([scratch + "/nope-x.h"], no_libs, "rtid_5");
+    let id_missing_y = runtime_link_inputs_identity([scratch + "/nope-y.h"], no_libs, "rtid_6");
+    assert id_missing_x != id_missing_y;
     _cleanup(scratch);
 }
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -307,11 +307,12 @@ feature availability.
     second push reuses the first's binaries — previously the per-commit
     git hash busted every entry on every commit. To keep runtime edits
     correct without that per-commit stamp, the assembled runtime capsule's
-    link inputs (its `.c`/`.ll`/`.sfn` sources, prelude entry, and link
+    link inputs (its `.c`/`.ll`/`.sfn` sources, prelude entry, the `.h`
+    headers under each include root, the include-dir paths, and the link
     libs) are folded into the key by content via
-    `runtime_link_inputs_identity`, so a runtime edit busts the key
-    directly; `--no-test-cache` on the `make check` gate remains the
-    cold-build backstop. The `build-quality.yml` `test-bin-baseline` job
+    `runtime_link_inputs_identity`, so a runtime/header/include-root edit
+    busts the key directly; `--no-test-cache` on the `make check` gate
+    remains the cold-build backstop. The `build-quality.yml` `test-bin-baseline` job
     (push:main + nightly) runs the full `.sfn` suite cache-enabled and
     saves `build/cache/test-bin` so PRs warm from main. Binaries store
     under `build/cache/test-bin/v2/` via the existing atomic temp+rename

--- a/docs/status.md
+++ b/docs/status.md
@@ -298,15 +298,23 @@ feature availability.
     cached executable. `test_bin_cache_key` (in `build_cache.sfn`)
     folds the test source hash, the resolver's transitive dep closure
     (`TestGroup.native_texts` + `dep_ll_paths` — the test-source-specific
-    link inputs), the compiler identity (`cache_compiler_identity`, so a
-    rebuilt compiler busts every entry), the canonical clang flags, and
-    a `test-bin/v1` schema version. The assembled runtime capsule objects
-    + link libs the link also consumes are *not* folded into the key;
-    they ride on the compiler identity (a runtime edit normally reaches a
-    test binary via `make compile`, which busts it), with
-    `--no-test-cache` on the `make check` gate as the cold-build
-    backstop. Binaries store under
-    `build/cache/test-bin/v1/` via the existing atomic temp+rename
+    link inputs), the compiler identity, a `runtime_identity` content
+    hash, the canonical clang flags, and a `test-bin/v2` schema version.
+    **#1233 made the cache cross-commit-stable:** the compiler identity is
+    now the commit-stable capsule version
+    (`resolve_test_bin_identity_for_cache` strips the `+dev.<hash>` build
+    metadata), so a `push:main` baseline warms a PR's first run and a PR's
+    second push reuses the first's binaries — previously the per-commit
+    git hash busted every entry on every commit. To keep runtime edits
+    correct without that per-commit stamp, the assembled runtime capsule's
+    link inputs (its `.c`/`.ll`/`.sfn` sources, prelude entry, and link
+    libs) are folded into the key by content via
+    `runtime_link_inputs_identity`, so a runtime edit busts the key
+    directly; `--no-test-cache` on the `make check` gate remains the
+    cold-build backstop. The `build-quality.yml` `test-bin-baseline` job
+    (push:main + nightly) runs the full `.sfn` suite cache-enabled and
+    saves `build/cache/test-bin` so PRs warm from main. Binaries store
+    under `build/cache/test-bin/v2/` via the existing atomic temp+rename
     artifact helpers (new `"test-bin"` kind). On a hit the binary is
     still **run** (variant 2a — never a cached pass/fail result). The
     `--json` summary gains a `cache` object with `test_bin_hit_rate`

--- a/scripts/test_shards.sh
+++ b/scripts/test_shards.sh
@@ -22,6 +22,7 @@
 #
 # Commands:
 #   test_shards.sh names                 # all shard names (sfn + sh)
+#   test_shards.sh sfn-names             # just the *_test.sfn shard names
 #   test_shards.sh list  <shard>         # print the shard's files, one per line
 #   test_shards.sh run   <shard> <bin>   # run an *_test.sfn shard via <bin>
 #   test_shards.sh cover                 # assert the union == full surface
@@ -179,6 +180,7 @@ cover() {
 cmd="${1:-}"
 case "$cmd" in
 names) _all_shard_names ;;
+sfn-names) printf '%s\n' "$SFN_SHARDS" ;;
 list)
 	shift
 	list "${1:?usage: test_shards.sh list <shard>}"

--- a/site/src/content/docs/docs/reference/spec/11-testing.md
+++ b/site/src/content/docs/docs/reference/spec/11-testing.md
@@ -265,13 +265,16 @@ still captures any compiler codegen change that affects that test, so a
 codegen-affecting change still misses; only commits that change nothing
 in the test's closure hit across commits.
 
-`runtime_identity` folds the assembled runtime capsule's link inputs —
-the runtime `.c`/`.ll`/`.sfn` sources, the prelude entry, and the
-declared link libraries — into the key by **content**. A runtime edit
-therefore busts the key directly (it no longer relies on a compiler
-rebuild changing the stamp). `--no-test-cache` (which `make check` and
-the nightly full suite pass) remains the cold-build backstop at the
-merge gate.
+`runtime_identity` folds the assembled runtime capsule's link inputs
+into the key by **content**: the runtime `.c`/`.ll`/`.sfn` sources, the
+prelude entry, and the `.h` headers under each include root (each hashed
+off disk, folded as `<path>@<sha256>` so distinct inputs never alias),
+plus the include-dir paths and the declared link libraries (folded by
+value). A runtime edit — including a header-only change or an
+include-root change — therefore busts the key directly, no longer relying
+on a compiler rebuild changing the stamp. `--no-test-cache` (which
+`make check` and the nightly full suite pass) remains the cold-build
+backstop at the merge gate.
 
 Cached binaries live under `build/cache/test-bin/<schema>/` (alongside
 the module IR cache, under `$SAILFIN_BUILD_CACHE_DIR` when set) and are

--- a/site/src/content/docs/docs/reference/spec/11-testing.md
+++ b/site/src/content/docs/docs/reference/spec/11-testing.md
@@ -242,7 +242,8 @@ per-test cost — and just re-runs the cached executable. The cache key is
 sha256(
   sha256(test_source_bytes)
   || sha256(sorted(hash of each transitive dep the link consumes))
-  || compiler_identity        // busts on a rebuilt compiler
+  || compiler_identity        // commit-stable capsule version
+  || runtime_identity         // content hash of the runtime link inputs
   || canonical(clang_flags)
   || schema_version
 )
@@ -254,14 +255,23 @@ dependency changes the key and misses the cache. On a hit the cached
 binary is still **run** (never a cached pass/fail result), so a
 flaky-at-runtime test always surfaces.
 
-The key does **not** fold in the assembled runtime capsule objects or
-link libraries that the link also consumes — those are covered
-indirectly by the compiler identity (a rebuilt compiler, the usual way a
-runtime-source edit reaches a test binary since the runtime is rebuilt
-by `make compile`, busts every entry). A runtime edit *without* a
-compiler rebuild can serve a stale binary; `--no-test-cache` (which
-`make check` and the nightly full suite pass) is the cold-build backstop
-that catches any such drift at the merge gate.
+`compiler_identity` is the **commit-stable** capsule version: the build
+stamp's `+dev.<hash>` build metadata is stripped, so two commits at the
+same version produce the same identity. This is what lets a `push:main`
+baseline cache warm a PR's first run and a PR's second push reuse the
+first's binaries — without it, the per-commit git hash busted every
+entry on every commit. The test's own dep closure (hashed by content)
+still captures any compiler codegen change that affects that test, so a
+codegen-affecting change still misses; only commits that change nothing
+in the test's closure hit across commits.
+
+`runtime_identity` folds the assembled runtime capsule's link inputs —
+the runtime `.c`/`.ll`/`.sfn` sources, the prelude entry, and the
+declared link libraries — into the key by **content**. A runtime edit
+therefore busts the key directly (it no longer relies on a compiler
+rebuild changing the stamp). `--no-test-cache` (which `make check` and
+the nightly full suite pass) remains the cold-build backstop at the
+merge gate.
 
 Cached binaries live under `build/cache/test-bin/<schema>/` (alongside
 the module IR cache, under `$SAILFIN_BUILD_CACHE_DIR` when set) and are


### PR DESCRIPTION
## Summary

`#1233` asked for a `push:main` baseline that warms the per-test binary cache (#1230) so a PR's first run hits unchanged tests. While picking it up I **proved the issue's premise was broken**: the test-bin cache key folded the per-commit build stamp (`<version>+dev.<hash>`) into `compiler_identity`, so every commit produced a distinct identity and busted the *entire* cache. A controlled experiment (same test source + deps, only the stamp changed) showed `hits=1` on a same-stamp rerun but `hits=0` the moment the stamp changed — so a main baseline could never warm a different-commit PR, and #1230's "second push reuses first push's binaries" was also broken in CI.

The fix lives in the cache-key identity, which the issue had scoped out — so (per discussion on the issue) this PR **bundles the compiler key-fix with the CI plumbing**. No seed cut is needed: the identity is computed by the freshly-built compiler on both the baseline and PR sides.

- **Commit-stable identity** (`version.sfn`): `_strip_build_metadata` + `resolve_test_bin_identity_for_cache` strip the `+dev.<hash>` build metadata → bare capsule version. The module-IR cache is seed-built (stable seed version) and is left untouched.
- **Runtime inputs folded by content** (`build_cache.sfn`): `runtime_link_inputs_identity` hashes the runtime `.c`/`.ll`/`.sfn` sources + prelude + link libs into the key, so a runtime edit still busts it — replacing the per-commit stamp as the runtime-edit backstop. Schema bumped **v1 → v2**.
- **Wiring** (`cli_commands.sfn`): enumerate runtime inputs once per `sfn test` invocation, thread `runtime_identity` into `test_bin_cache_key`.
- **Baseline producer** (`build-quality.yml`): new `test-bin-baseline` job (push:main + nightly) runs the full `.sfn` suite cache-enabled and `cache/save`s `build/cache/test-bin` **on green only** under a dedicated `sailfin-testbin-*` key.
- **PR restore** (`sailfin-build/action.yml`): restore `build/cache/test-bin` under that dedicated key (separate prefix from the module-IR cache, so it can't shadow it and force a cold build).
- **Shard reuse** (`test_shards.sh`): `sfn-names` subcommand.

Closes #1233

## Invalidation matrix (correctness preserved)

| Change | Result |
|---|---|
| test source / dep codegen / runtime source / link lib / capsule version / clang flags | **MISS** (correct) |
| commit that changes nothing in a test's closure or the runtime | **HIT** (the win — was a false MISS every commit) |

`--no-test-cache` on `make check` / the nightly full suite remains the cold-build backstop.

## Acceptance Criteria
- [x] A fresh PR branch can show `test_bin_hit_rate > 0` on its first run for unchanged tests — **now achievable**: proven by e2e Test 5 (cross-stamp hit) + the baseline producer/restore plumbing. (Was structurally impossible before this fix.)
- [x] `build-quality.yml`'s determinism + `cache.hit_rate` gates stay green — the baseline is a **separate** job; the gates are untouched.
- [x] A failing baseline does not save — save is a save-only step gated on suite success.
- [x] ~~No `.sfn` changed~~ — **scope adjusted (approved)**: the fix required a cache-key change, so `.sfn` is touched; validated via `make compile` + suite below.

## Verification
```text
make compile (self-host) ............................ pass
sfn fmt --check (3 src + 1 test .sfn) ............... clean
build_cache_test.sfn (unit) ........................ 66/66 pass (incl. strip + runtime-identity + cross-commit)
test_test_bin_cache.sh (e2e) ....................... 5/5 pass
  └─ Test 5 "different +dev.<hash> stamp, same version: still hits" → hit_rate 1.0000  (was 0.0000)
make test --no-test-cache (full suite) ............. 0 failures (unit 145, integration 31, e2e 5, capsules 34, e2e-sh 109)
```
Note: a first `make check` aborted with Error 139 (SIGSEGV) in the first-pass test phase — the known non-deterministic codegen flake (#892), which CI's `make test` wraps in retry-once but `make check` does not. Re-running the exact phase (`make test --no-test-cache`) passed clean with 0 failures; a fresh `make check` re-run is in progress. My change is test-runner-only and cannot affect `sfn build`/self-hosting.

## Files Changed
`compiler/src/{version,build_cache,cli_commands}.sfn`, `compiler/tests/{unit/build_cache_test.sfn,e2e/test_test_bin_cache.sh}`, `.github/workflows/build-quality.yml`, `.github/actions/sailfin-build/action.yml`, `scripts/test_shards.sh`, `docs/status.md`, `site/.../spec/11-testing.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NB6UvEfFbLkbhmQFiKcSgz)_