### PR TITLE
fix(checker): subprocess-isolate per-module staging in sfn check

### DIFF
--- a/compiler/src/capsule_resolver.sfn
+++ b/compiler/src/capsule_resolver.sfn
@@ -1464,9 +1464,9 @@ fn _cr_extract_layout_manifest(asm_path: string, manifest_path: string) ![io] {
 // the legacy serial loop (one `_cr_stage_one` call per source) so
 // regression bisects keep the simple shape they had pre-PR3.
 //
-// Empty `sailfin_exe` (`sfn check`, `sfn test`) keeps the in-process
-// stage path that's load-bearing for callers that don't yet plumb
-// `binary_dir` through.
+// Empty `sailfin_exe` keeps the in-process stage path that's
+// load-bearing for callers that don't plumb `binary_dir` through
+// (`sfn test` today; `sfn check` threads its exe since #1246).
 fn stage_capsule_imports(sources: CapsuleSource[], sailfin_exe: string, work_dir: string) -> boolean ![io] {
     let context_root = _cr_import_context_root(work_dir);
     if work_dir.length == 0 {
@@ -4290,7 +4290,7 @@ fn prepare_project_capsules(input_path: string, config: BuildCacheConfig, consum
 //   - Standalone files outside any capsule.toml are valid input and
 //     return an empty resolution (no error) — relative-import walking
 //     still happens via `enumerate_relative_sources`.
-fn prepare_project_capsules_for_check(entry_paths: string[], consumer: ResolverConsumer, work_dir: string) -> CheckCapsuleResolution ![io] {
+fn prepare_project_capsules_for_check(entry_paths: string[], consumer: ResolverConsumer, sailfin_exe: string, work_dir: string) -> CheckCapsuleResolution ![io] {
     let empty_paths: string[] = [];
     let resolved = _cr_resolve_and_dedupe(entry_paths, consumer);
     // Phase F: surface the manifest's capability surface even on
@@ -4316,12 +4316,18 @@ fn prepare_project_capsules_for_check(entry_paths: string[], consumer: ResolverC
         };
     }
 
-    // Stage E PR1: sfn check stays on the in-process stage path
-    // (empty `sailfin_exe`). Check's typical input — single
-    // files or small dirs — fits in-process; subprocess overhead
-    // would dominate. When `sfn check -p` lands, this becomes a
-    // one-line update mirroring `sfn build`.
-    let staged = stage_capsule_imports(resolved.sources, "", work_dir);
+    // #1246: thread `sailfin_exe` so staging mirrors `sfn build` —
+    // each cache-miss module is emitted in a subprocess
+    // (`_cr_stage_one` exe branch via `emit_subprocess_with_retry`)
+    // and the parent arena stays bounded. The prior in-process
+    // fallback (empty exe) peaked 8.3GB on a cold
+    // `check compiler/src/cli_main.sfn` because the full import
+    // closure's AST + native text accumulated in one arena
+    // (#1245). Warm runs are unaffected: `_cr_stage_one`'s cache
+    // hit short-circuits before the exe branch, so no subprocess
+    // is spawned. Callers without `binary_dir` plumbing pass ""
+    // and keep the in-process path.
+    let staged = stage_capsule_imports(resolved.sources, sailfin_exe, work_dir);
     if !staged {
         print.err("capsule-resolver: failed to stage import-context for project capsules");
         return CheckCapsuleResolution {

--- a/compiler/src/cli_check.sfn
+++ b/compiler/src/cli_check.sfn
@@ -136,12 +136,18 @@ fn _emit_load_warnings(load_result: ImportedInterfaceLoadResult, quiet: boolean)
 // `_resolve_test_self_path` in `cli_commands.sfn` /
 // `_resolve_self_path` in `cli_main.sfn`: `<binary_dir>/sailfin`
 // (computed by `fn main` from `exe_path()` on every platform) is the
-// real resolution path. Empty result falls back to in-process
-// staging inside the resolver — degraded memory bound, not an error.
+// repo-build resolution path. `make install` publishes the binary as
+// `<PREFIX>/bin/sfn` (`INSTALL_NAME ?= sfn`, Makefile), so probe that
+// name second — otherwise an installed compiler would silently fall
+// back in-process and lose the memory bound this helper exists to
+// provide. Empty result falls back to in-process staging inside the
+// resolver — degraded memory bound, not an error.
 fn _resolve_check_self_path(binary_dir: string) -> string ![io] {
     if binary_dir.length > 0 {
         let candidate = _path_join_cmd(binary_dir, "sailfin");
         if fs.exists(candidate) { return candidate; }
+        let installed = _path_join_cmd(binary_dir, "sfn");
+        if fs.exists(installed) { return installed; }
     }
     return "";
 }

--- a/compiler/src/cli_check.sfn
+++ b/compiler/src/cli_check.sfn
@@ -24,7 +24,7 @@ import {
     empty_resolver_consumer,
     prepare_project_capsules_for_check
 } from "./capsule_resolver";
-import { _collect_sfn_files_cmd, _dirname_cmd } from "./cli_commands_utils";
+import { _collect_sfn_files_cmd, _dirname_cmd, _path_join_cmd } from "./cli_commands_utils";
 import {
     CheckJsonEvent,
     CheckJsonSummary,
@@ -130,6 +130,22 @@ fn _emit_load_warnings(load_result: ImportedInterfaceLoadResult, quiet: boolean)
     }
 }
 
+// Resolve the path to this compiler binary so the resolver can stage
+// each import-context module in a subprocess (#1246), bounding the
+// parent's arena the same way `sfn build` does. Mirrors
+// `_resolve_test_self_path` in `cli_commands.sfn` /
+// `_resolve_self_path` in `cli_main.sfn`: `<binary_dir>/sailfin`
+// (computed by `fn main` from `exe_path()` on every platform) is the
+// real resolution path. Empty result falls back to in-process
+// staging inside the resolver — degraded memory bound, not an error.
+fn _resolve_check_self_path(binary_dir: string) -> string ![io] {
+    if binary_dir.length > 0 {
+        let candidate = _path_join_cmd(binary_dir, "sailfin");
+        if fs.exists(candidate) { return candidate; }
+    }
+    return "";
+}
+
 // Compute the resolution-group key for a file path. Two files share a
 // group iff `discover_project_root` and `discover_workspace_root`
 // return the same value when walked from each file's directory. The
@@ -153,7 +169,7 @@ fn _find_group(groups: CheckGroup[], key: string) -> int {
     return -1;
 }
 
-fn handle_check_command(args: string[]) -> int ![io] {
+fn handle_check_command(args: string[], binary_dir: string) -> int ![io] {
     let mut quiet: boolean = false;
     let mut json: boolean = false;
     let mut paths: string[] = [];
@@ -239,6 +255,13 @@ fn handle_check_command(args: string[]) -> int ![io] {
         gpi += 1;
     }
 
+    // #1246: resolve the self-executable once for every group's
+    // resolver pass. Non-empty ⇒ the resolver stages each cache-miss
+    // module in a subprocess (fresh arena per child), mirroring
+    // `sfn build`; empty ⇒ in-process fallback (e.g. a caller that
+    // couldn't resolve `binary_dir`).
+    let check_self_exe = _resolve_check_self_path(binary_dir);
+
     // Per-group resolution + load. Aggregated warnings are emitted
     // after the per-file analysis loop so they group together at the
     // bottom of stderr regardless of how many groups produced them.
@@ -253,7 +276,12 @@ fn handle_check_command(args: string[]) -> int ![io] {
         // this path. Pass an empty consumer; when `sfn check -p`
         // lands the consumer is computed from the project's manifest
         // the same way `sfn build` does it.
-        let resolution = prepare_project_capsules_for_check(groups[gi].entry_paths, empty_resolver_consumer(), "");
+        //
+        // #1246: thread the self-executable so cache-miss modules
+        // stage in subprocesses (bounded parent arena). Warm runs
+        // spawn nothing — the per-module cache hit short-circuits
+        // before the subprocess branch.
+        let resolution = prepare_project_capsules_for_check(groups[gi].entry_paths, empty_resolver_consumer(), check_self_exe, "");
         if resolution.staging_failed {
             // The resolver already wrote a structured error to
             // stderr (slug collision or stage-write failure).

--- a/compiler/src/cli_main.sfn
+++ b/compiler/src/cli_main.sfn
@@ -2513,7 +2513,7 @@ fn sailfin_cli_main(argv: string[]) -> int ![io, clock] {
 
     if is_fmt { return handle_fmt_command(args); }
 
-    if is_check { return handle_check_command(args); }
+    if is_check { return handle_check_command(args, binary_dir); }
 
     if strings_equal(cmd, "guillermo") { return handle_guillermo_command(); }
 

--- a/compiler/tests/integration/check_staging_equivalence_test.sfn
+++ b/compiler/tests/integration/check_staging_equivalence_test.sfn
@@ -1,0 +1,153 @@
+// compiler/tests/integration/check_staging_equivalence_test.sfn
+//
+// Regression coverage for #1246: `sfn check` threads the resolved
+// self-executable into `prepare_project_capsules_for_check`, so the
+// resolver stages each cache-miss module's import-context (`.sfn-asm`
+// + `.layout-manifest` + `.srchash`) in a subprocess — bounding the
+// parent's arena the same way `sfn build` does — instead of the
+// in-process fallback that peaked 8.3GB on a cold
+// `check compiler/src/cli_main.sfn` (#1245).
+//
+// The acceptance contract is *equivalence*: the staged artifact set
+// produced by the subprocess path must be byte-identical to the set
+// the legacy in-process path produces. This test drives both paths
+// end-to-end through the *shipped* `build/native/sailfin` binary:
+//
+//   - Run A invokes the binary normally. `fn main` threads
+//     `binary_dir` from `exe_path()`, `_resolve_check_self_path`
+//     finds `<binary_dir>/sailfin`, and staging takes the
+//     subprocess-per-module branch of `_cr_stage_one`.
+//   - Run B invokes a byte-identical COPY of the binary under a
+//     different filename. `binary_dir` resolves to the copy's
+//     directory, `<binary_dir>/sailfin` does not exist, the resolved
+//     exe is "", and staging falls back to the legacy in-process
+//     branch — the pre-#1246 behavior, preserved for callers that
+//     can't resolve their own path. The trick hinges on `exe_path()`
+//     (Linux `/proc/self/exe`) / `realpath(argv[0])` resolving to
+//     the *invoked filename's* directory, so the `cp` (not symlink)
+//     under a non-`sailfin` name is what forces the miss.
+//
+// Each run uses its own work directory (staging writes to
+// `<cwd>/build/native/import-context`), so the two staged trees can
+// be `diff -r`'d whole: same file set, same bytes. Spawning the real
+// binary (rather than importing resolver entry points) matches
+// production exactly and avoids dragging the whole driver into the
+// test link — the same rationale as `emit_retry_test.sfn`.
+extern fn sailfin_runtime_shell_capture(cmd: * u8) -> * u8;
+
+fn _shell_capture(cmd: string) -> string ![io] {
+    return sailfin_runtime_shell_capture(cmd);
+}
+
+// Write a minimal two-module fixture: `main.sfn` relatively imports
+// `./helper`, so the resolver's relative-import walk stages `helper`
+// into the import-context even though no capsule.toml exists
+// (standalone files are valid `sfn check` input).
+fn _write_fixture(src_dir: string) ![io] {
+    process.run(["mkdir", "-p", src_dir]);
+    fs.writeFile(src_dir + "/helper.sfn", "fn helper_add(a: int, b: int) -> int {\n    return a + b;\n}\n\nexport { helper_add };\n");
+    fs.writeFile(src_dir + "/main.sfn", "import { helper_add } from \"./helper\";\n\nfn main() ![io] {\n    let total = helper_add(1, 2);\n    print.info(\"total: \" + number_to_string(total));\n}\n");
+}
+
+test "check staging: subprocess path stages byte-identical artifacts to in-process path" ![io] {
+    let root = fs.mkdtemp("sfn-check-stage-eq-");
+    assert root.length > 0;
+    let src_dir = root + "/src";
+    _write_fixture(src_dir);
+
+    // `printf '%s'` strips the trailing newline `realpath` emits —
+    // a raw capture would split the `sh -c` scripts below in two
+    // (same pattern as `_host_path` in `emit_retry_test.sfn`).
+    let exe = _shell_capture("printf '%s' \"$(realpath build/native/sailfin)\"");
+    assert exe.length > 0;
+
+    // Run A: shipped binary under its real name -> `binary_dir`
+    // resolves -> subprocess staging path.
+    let work_a = root + "/work_a";
+    process.run(["mkdir", "-p", work_a]);
+    let rc_a = process.run(["sh", "-c", "cd " + work_a + " && " + exe
+        + " check "
+        + src_dir
+        + "/main.sfn >/dev/null 2>&1"]);
+    assert rc_a == 0;
+
+    // Run B: byte-identical copy under a different filename ->
+    // `<binary_dir>/sailfin` misses -> resolved exe is "" ->
+    // legacy in-process staging path.
+    let work_b = root + "/work_b";
+    let bin_b = root + "/binb";
+    process.run(["mkdir", "-p", work_b]);
+    process.run(["mkdir", "-p", bin_b]);
+    process.run(["cp", exe, bin_b + "/sfn-renamed"]);
+    let rc_b = process.run(["sh", "-c", "cd " + work_b + " && " + bin_b
+        + "/sfn-renamed check "
+        + src_dir
+        + "/main.sfn >/dev/null 2>&1"]);
+    assert rc_b == 0;
+
+    // Guard against a vacuous pass: both runs must actually have
+    // staged at least one `.sfn-asm` (the fixture's relative import
+    // guarantees a non-empty resolution).
+    let staged_a = process.run(["sh", "-c", "find " + work_a
+        + "/build/native/import-context -name '*.sfn-asm' | grep -q ."]);
+    assert staged_a == 0;
+    let staged_b = process.run(["sh", "-c", "find " + work_b
+        + "/build/native/import-context -name '*.sfn-asm' | grep -q ."]);
+    assert staged_b == 0;
+
+    // The headline equivalence: identical file set, identical bytes
+    // (`.sfn-asm`, `.layout-manifest`, and `.srchash` sidecars all
+    // participate in the recursive diff).
+    let rc_diff = process.run(["diff", "-r", work_a
+        + "/build/native/import-context", work_b
+        + "/build/native/import-context"]);
+    assert rc_diff == 0;
+
+    process.run(["rm", "-rf", root]);
+}
+
+test "check staging: warm re-run is a cache hit (staged artifacts untouched)" ![io] {
+    let root = fs.mkdtemp("sfn-check-stage-warm-");
+    assert root.length > 0;
+    let src_dir = root + "/src";
+    _write_fixture(src_dir);
+
+    // `printf '%s'` strips the trailing newline `realpath` emits —
+    // a raw capture would split the `sh -c` scripts below in two
+    // (same pattern as `_host_path` in `emit_retry_test.sfn`).
+    let exe = _shell_capture("printf '%s' \"$(realpath build/native/sailfin)\"");
+    assert exe.length > 0;
+
+    let work = root + "/work";
+    process.run(["mkdir", "-p", work]);
+    let cmd = "cd " + work + " && " + exe + " check " + src_dir
+        + "/main.sfn >/dev/null 2>&1";
+
+    // Cold run stages the import-context.
+    let rc_cold = process.run(["sh", "-c", cmd]);
+    assert rc_cold == 0;
+
+    // Snapshot the staged tree (paths + content hashes + mtimes).
+    // `_cr_stage_one`'s cache hit short-circuits before the
+    // subprocess branch, so a warm run must not rewrite anything —
+    // pinning the "warm runs spawn nothing" half of #1246.
+    //
+    // Load-bearing fixture assumption: with NO capsule.toml, every
+    // source's canonical slug equals its path slug, so
+    // `_cr_write_capsule_slug_aliases` writes no `.slugalias` on
+    // either run. A capsule fixture with a scoped slug would rewrite
+    // the alias each run and flake the mtime half of this snapshot.
+    let snap_cmd = "cd " + work
+        + "/build/native/import-context && find . -type f | sort | xargs -r stat -c '%n %Y' && find . -type f | sort | xargs -r sha256sum";
+    let before = _shell_capture(snap_cmd);
+    assert before.length > 0;
+
+    // Warm run: byte-identical source -> content-hash cache hit.
+    let rc_warm = process.run(["sh", "-c", cmd]);
+    assert rc_warm == 0;
+
+    let after = _shell_capture(snap_cmd);
+    assert before == after;
+
+    process.run(["rm", "-rf", root]);
+}

--- a/compiler/tests/integration/check_staging_equivalence_test.sfn
+++ b/compiler/tests/integration/check_staging_equivalence_test.sfn
@@ -127,27 +127,45 @@ test "check staging: warm re-run is a cache hit (staged artifacts untouched)" ![
     let rc_cold = process.run(["sh", "-c", cmd]);
     assert rc_cold == 0;
 
-    // Snapshot the staged tree (paths + content hashes + mtimes).
+    // Pin the "warm runs spawn nothing" half of #1246:
     // `_cr_stage_one`'s cache hit short-circuits before the
-    // subprocess branch, so a warm run must not rewrite anything —
-    // pinning the "warm runs spawn nothing" half of #1246.
+    // subprocess branch, so a warm run must not rewrite anything.
+    // Two POSIX-portable probes (macOS CI runs this suite — no GNU
+    // `stat -c` / `sha256sum` / `xargs -r` here):
+    //   1. the staged file SET is unchanged (`find | sort`), and
+    //   2. no staged file is newer than a marker touched between the
+    //      runs (`find -newer`) — i.e. nothing was rewritten, even
+    //      with identical content.
     //
     // Load-bearing fixture assumption: with NO capsule.toml, every
     // source's canonical slug equals its path slug, so
     // `_cr_write_capsule_slug_aliases` writes no `.slugalias` on
     // either run. A capsule fixture with a scoped slug would rewrite
-    // the alias each run and flake the mtime half of this snapshot.
-    let snap_cmd = "cd " + work
-        + "/build/native/import-context && find . -type f | sort | xargs -r stat -c '%n %Y' && find . -type f | sort | xargs -r sha256sum";
-    let before = _shell_capture(snap_cmd);
-    assert before.length > 0;
+    // the alias each run and flake the `-newer` half of this probe.
+    let ctx = work + "/build/native/import-context";
+    let set_cmd = "cd " + ctx + " && find . -type f | sort";
+    let set_before = _shell_capture(set_cmd);
+    assert set_before.length > 0;
+
+    // The sleep guards against coarse (1s) mtime granularity on
+    // older filesystems: a same-second rewrite would otherwise tie
+    // with the marker and slip past `-newer`.
+    let marker = root + "/warm-marker";
+    process.run(["touch", marker]);
+    process.run(["sleep", "1"]);
 
     // Warm run: byte-identical source -> content-hash cache hit.
     let rc_warm = process.run(["sh", "-c", cmd]);
     assert rc_warm == 0;
 
-    let after = _shell_capture(snap_cmd);
-    assert before == after;
+    let set_after = _shell_capture(set_cmd);
+    assert set_before == set_after;
+    // `grep -q .` exits 0 iff `find -newer` emitted anything; a warm
+    // run must leave NOTHING newer than the marker.
+    let rewritten = process.run(["sh", "-c", "find " + ctx + " -type f -newer "
+        + marker
+        + " | grep -q ."]);
+    assert rewritten != 0;
 
     process.run(["rm", "-rf", root]);
 }


### PR DESCRIPTION
## Summary
- Threads the resolved self-executable from the `cli_main.sfn` dispatch through `handle_check_command` into a new `sailfin_exe` param on `prepare_project_capsules_for_check`, so `sfn check` stages each cache-miss import-context module in a subprocess (`_cr_stage_one` exe branch via `emit_subprocess_with_retry`) — bounding the parent arena exactly like `sfn build`, instead of accumulating the whole import closure in-process (8.3GB cold peak, #1245).
- New `_resolve_check_self_path` helper in `cli_check.sfn` mirrors `_resolve_test_self_path`; callers that can't resolve `binary_dir` still fall back to the in-process path.
- Gating decision per the issue: always-subprocess when a non-empty exe resolves — warm runs spawn nothing because `_cr_stage_one`'s content-hash cache hit short-circuits before the exe branch.

Closes #1246

## Acceptance Criteria
- [x] Cold (staging cache wiped) `SAILFIN_USE_ARENA=1` check of `compiler/src/cli_main.sfn` passes under `ulimit -v 8388608` — **peak RSS 1.09 GB** (baseline: 8.3 GB OOM)
- [x] Cold whole-tree `SAILFIN_USE_ARENA=1` check of `compiler/src/` — **rc=0, peak RSS 4.49 GB, 158 files, 168s** (now under cap; residual is the per-file analysis-loop accumulation term tracked by the sibling issue)
- [x] Warm runs unchanged — cache-hit short-circuit, no subprocess spawned, output byte-identical (10.7s / 0.41 GB single-file); pinned by the warm-run snapshot test
- [x] Regression coverage — `check_staging_equivalence_test.sfn` drives both staging paths through the shipped binary and `diff -r`'s the staged trees (byte-identical `.sfn-asm` / `.layout-manifest` / `.srchash`)
- [x] `make compile` self-hosts; `make test` passes (unit 146/146, integration 32/32, e2e 5/5, e2e-sh 110/110)
- [x] `sfn fmt --check` clean on all touched files

## Verification
```bash
make compile                                     # self-host: pass
# cold staging (build/native/import-context wiped):
ulimit -v 8388608 && SAILFIN_USE_ARENA=1 build/native/sailfin check compiler/src/cli_main.sfn
#   -> rc=0, 20.9s, peak RSS 1.09 GB
ulimit -v 8388608 && SAILFIN_USE_ARENA=1 build/native/sailfin check compiler/src/
#   -> rc=0, 168.1s, 158 files, peak RSS 4.49 GB
make test                                        # pass (one transient #1206-style SIGSEGV flake on first run; clean re-run)
```
Note: `/usr/bin/time -v` is unavailable in the CI container; peak RSS measured via `getrusage(RUSAGE_CHILDREN)`. The cold condition was produced by wiping `build/native/import-context` (the staging cache — the exact term #1245 identified) rather than the approval-gated `make clean-build`.

## Files Changed
- `compiler/src/capsule_resolver.sfn` — `prepare_project_capsules_for_check` gains `sailfin_exe`; stale Stage E PR1 comments updated
- `compiler/src/cli_check.sfn` — `handle_check_command(args, binary_dir)`, `_resolve_check_self_path`, exe threaded per group
- `compiler/src/cli_main.sfn` — dispatch passes `binary_dir`
- `compiler/tests/integration/check_staging_equivalence_test.sfn` — new staging-equivalence + warm-run regression tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LqtzsYF4emLjjx5wK7Eymt

---
_Generated by [Claude Code](https://claude.ai/code/session_01LqtzsYF4emLjjx5wK7Eymt)_