### PR TITLE
docs: reconcile llms.txt with shipped reality + add drift guard

### DIFF
--- a/compiler/tests/e2e/test_llms_txt_sync.sh
+++ b/compiler/tests/e2e/test_llms_txt_sync.sh
@@ -42,8 +42,11 @@ else
 fi
 
 # ── 2. Version line matches capsule.toml ─────────────────────────────
-capsule_version="$(sed -n 's/^version = "\(.*\)"$/\1/p' "$ROOT/compiler/capsule.toml" | head -1)"
-llms_version="$(sed -n 's/^> Version: \([^ |]*\).*/\1/p' "$ROOT/llms.txt" | head -1)"
+# Whitespace-tolerant extraction: TOML allows leading whitespace and a
+# trailing inline comment; the llms.txt version line may vary spacing.
+# Both patterns stop at the closing quote / first separator.
+capsule_version="$(sed -n 's/^[[:space:]]*version[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' "$ROOT/compiler/capsule.toml" | head -1)"
+llms_version="$(sed -n 's/^>[[:space:]]*Version:[[:space:]]*\([^ |]*\).*/\1/p' "$ROOT/llms.txt" | head -1)"
 
 if [ -z "$capsule_version" ]; then
     echo "FAIL: could not extract version from compiler/capsule.toml"

--- a/compiler/tests/e2e/test_llms_txt_sync.sh
+++ b/compiler/tests/e2e/test_llms_txt_sync.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# llms.txt drift guard.
+#
+# llms.txt is the in-context language reference that LLM agents read
+# before generating Sailfin code — a stale or self-contradictory copy
+# directly causes systematic agent errors (the 2026-06 audit found it
+# still claiming closures, bitwise operators, and int/float were
+# unshipped months after they landed). This test pins the two cheap,
+# mechanical freshness invariants:
+#
+#   1. The published site copy (site/public/llms.txt) is a symlink to
+#      the repo-root llms.txt, so there is exactly one source of truth.
+#   2. The "> Version:" line in llms.txt matches the compiler version
+#      in compiler/capsule.toml, so every release bump forces an
+#      llms.txt review (the version line cannot silently go stale).
+#
+# Content accuracy beyond the version stamp is a review concern
+# (docs/status.md is the source of truth); this guard only makes
+# drift loud.
+
+set -u
+
+ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+fail=0
+
+# ── 1. Single source of truth ────────────────────────────────────────
+SITE_COPY="$ROOT/site/public/llms.txt"
+if [ ! -L "$SITE_COPY" ]; then
+    echo "FAIL: $SITE_COPY is not a symlink — two divergent llms.txt copies are possible"
+    fail=1
+elif [ ! -e "$SITE_COPY" ]; then
+    echo "FAIL: $SITE_COPY is a broken symlink"
+    fail=1
+else
+    resolved="$(cd "$(dirname "$SITE_COPY")" && cd "$(dirname "$(readlink "$SITE_COPY")")" && pwd)/$(basename "$(readlink "$SITE_COPY")")"
+    if [ "$resolved" != "$ROOT/llms.txt" ]; then
+        echo "FAIL: $SITE_COPY resolves to $resolved, expected $ROOT/llms.txt"
+        fail=1
+    else
+        echo "ok: site/public/llms.txt -> llms.txt (single source of truth)"
+    fi
+fi
+
+# ── 2. Version line matches capsule.toml ─────────────────────────────
+capsule_version="$(sed -n 's/^version = "\(.*\)"$/\1/p' "$ROOT/compiler/capsule.toml" | head -1)"
+llms_version="$(sed -n 's/^> Version: \([^ |]*\).*/\1/p' "$ROOT/llms.txt" | head -1)"
+
+if [ -z "$capsule_version" ]; then
+    echo "FAIL: could not extract version from compiler/capsule.toml"
+    fail=1
+fi
+if [ -z "$llms_version" ]; then
+    echo "FAIL: could not find '> Version: <semver>' line in llms.txt"
+    fail=1
+fi
+if [ -n "$capsule_version" ] && [ -n "$llms_version" ]; then
+    if [ "$capsule_version" != "$llms_version" ]; then
+        echo "FAIL: llms.txt version '$llms_version' != capsule.toml version '$capsule_version'"
+        echo "      Update the '> Version:' line (and review llms.txt content against docs/status.md)."
+        fail=1
+    else
+        echo "ok: llms.txt version matches capsule.toml ($capsule_version)"
+    fi
+fi
+
+if [ "$fail" -ne 0 ]; then
+    echo "test_llms_txt_sync: FAILED"
+    exit 1
+fi
+echo "test_llms_txt_sync: all checks passed"

--- a/docs/proposals/model-engines-and-training.md
+++ b/docs/proposals/model-engines-and-training.md
@@ -1,10 +1,16 @@
 # Sailfin Proposal: Model Engines, Adapters, Tensors, and Training
 
-Status: Draft Proposal
+Status: Draft Proposal — **superseded in part**. The `model` / `prompt` /
+`tool` / `pipeline` keywords this draft builds on were **removed from the
+language** (see `docs/status.md` § "AI / Model Constructs (Moved to
+Library)"); the functionality targets the post-1.0 `sfn/ai` library
+capsule instead, gated by the `![model]` effect. Engine/adapter/training
+design ideas below remain relevant as *library API* design input, but
+every language-syntax reference in this document is historical.
 
 Author: Sailfin Core Team
 
-Date: October 2025
+Date: October 2025 (status note updated 2026-06-10)
 
 Applies to: Compiler, Runtime, Spec, and Package Manager
 
@@ -14,7 +20,10 @@ Goal: Unify inference and training semantics through typed engines, modular adap
 
 ## 1. Overview
 
-Sailfin already treats models and prompts as first-class language constructs. However, model creation, training, and fine-tuning are not yet implemented, and runtime engines remain implicit.
+Earlier drafts of Sailfin treated models and prompts as first-class
+language constructs; those keywords have since been removed in favour of
+the post-1.0 `sfn/ai` library capsule. Model creation, training, and
+fine-tuning are not yet implemented, and runtime engines remain implicit.
 
 This proposal formalizes:
 

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # Sailfin Language Reference for LLMs
 
-> Version: 0.5.9 | Updated: 2026-04-26 (Phase F)
+> Version: 0.7.0-alpha.29 | Updated: 2026-06-10
 > Source: https://github.com/SailfinIO/sailfin | Site: https://sailfin.dev
 
 Sailfin is a systems language with compile-time capability enforcement
@@ -159,6 +159,10 @@ Supports literals, wildcards (`_`), guards (`if expr`), and enum destructuring.
         if done { break; }
     }
 
+There is NO `while` keyword. The parser rejects `while` at statement
+position (E0411) with a fix-it; write `loop { if !cond { break; } ... }`
+instead.
+
 ### Error Handling
 
     try {
@@ -213,8 +217,10 @@ type-suffix ? (nullable, e.g. Config?) is a distinct, unrelated use of the glyph
         }
     }
 
-Generic type parameters are parsed. Constraint syntax (`<T: Bound>`) is parsed
-but not enforced. Monomorphization is not yet implemented.
+Generic type parameters are parsed and captured. Generic enum payloads
+(e.g. `Result<T, E>`) monomorphise per instantiation at construction and
+`match` sites. Constraint syntax (`<T: Bound>`) is parsed but not
+enforced; full generic-struct method monomorphization is partial.
 
 ### Imports and Modules
 
@@ -225,12 +231,16 @@ but not enforced. Monomorphization is not yet implemented.
 Standard library capsules use bare names ("fs", "http", "json", etc.).
 Relative paths use "./" or "../" syntax.
 
-### Lambdas
+### Lambdas and Closures
 
     let double = fn(x: int) -> int { return x * 2; };
 
-Lambdas are supported but do not capture enclosing variables (closures with
-capture are planned).
+    let base = 10;
+    let add_base = fn(x: int) -> int { return x + base; };  // captures `base`
+
+Lambdas capture enclosing variables (closures shipped end-to-end,
+including multi-variable capture). Higher-order dispatch through
+`fn(int) -> int` typed values works.
 
 ### Tests
 
@@ -262,29 +272,42 @@ Uses `{{ }}` syntax (migration to `${ }` is planned pre-1.0).
 
 ### Extern Functions (FFI)
 
-    unsafe extern fn malloc(size: int) -> int;
-    unsafe extern fn free(ptr: int) -> void;
+    extern fn malloc(size: usize) -> * u8;
+    extern fn free(ptr: * u8) -> void;
+    extern fn memcpy(dst: * u8, src: * u8, n: usize) -> * u8;
 
-Declares external C symbols for linking.
+Declares external C symbols for linking. Signatures must use the C-ABI
+accept-list — fixed-width ints (`i8`..`u64`, `usize`, `isize`), `bool`,
+`f32`/`f64`, raw pointers (`* u8`, `* const T`, `* OpaqueStruct`), and
+`void` (return only); violations are diagnosed (E0801–E0805). Raw
+pointer types are written with a space after `*` (`* u8`). A defined or
+extern fn can be passed to a C callee as a code pointer via
+`my_fn as * u8`; unsupported function-reference forms are rejected at
+typecheck (E0808/E0809).
 
 ## Standard Library Capsules
 
-| Capsule   | Import       | Effects       | Description                              |
-|-----------|-------------|---------------|------------------------------------------|
-| sfn/strings | "strings" | None          | Trim, case, split/join, find/replace     |
-| sfn/json  | "json"      | None          | JSON parse, serialize, pretty-print      |
-| sfn/crypto| "crypto"    | None          | SHA-256, base64                          |
-| sfn/math  | "math"      | None          | abs, min, max, clamp, pow, floor, ceil   |
-| sfn/path  | "path"      | None          | join, dirname, basename, ext, normalize  |
-| sfn/toml  | "toml"      | None          | TOML parsing and serialization           |
-| sfn/fs    | "fs"        | io            | File r/w/append, exists, mkdir, perms, symlink, mkdtemp |
-| sfn/os    | "os"        | io            | Env vars, home dir, exec, exit           |
-| sfn/log   | "log"       | io, clock     | Structured leveled logging               |
-| sfn/time  | "time"      | clock         | Sleep, monotonic timing, elapsed         |
-| sfn/http  | "http"      | net, io       | HTTP GET/POST client (partial)           |
-| sfn/cli   | "cli"       | io            | CLI arg parsing, subcommands, styling    |
-| sfn/tensor| "tensor"    | gpu (planned) | Tensor ops, matmul, transpose (CPU)      |
-| sfn/losses| "losses"    | None          | MSE, MAE, Huber, hinge loss functions    |
+| Capsule   | Import      | Status        | Effects       | Description                              |
+|-----------|-------------|---------------|---------------|------------------------------------------|
+| sfn/strings | "strings" | Shipped       | None          | Trim, case, split/join, find/replace     |
+| sfn/json  | "json"      | Shipped       | None          | JSON parse, serialize, pretty-print      |
+| sfn/crypto| "crypto"    | Shipped       | None          | SHA-256, base64                          |
+| sfn/math  | "math"      | Shipped       | None          | abs, min, max, clamp, pow, floor, ceil   |
+| sfn/path  | "path"      | Shipped       | None          | join, dirname, basename, ext, normalize  |
+| sfn/toml  | "toml"      | Shipped       | None          | TOML parsing and serialization           |
+| sfn/fs    | "fs"        | Shipped       | io            | File r/w/append, exists, mkdir, perms, symlink, mkdtemp |
+| sfn/os    | "os"        | Shipped       | io            | Env vars, home dir, exec, exit           |
+| sfn/log   | "log"       | Shipped       | io, clock     | Structured leveled logging               |
+| sfn/time  | "time"      | Shipped       | clock         | Sleep, monotonic timing, elapsed         |
+| sfn/http  | "http"      | Partial       | net, io       | HTTP GET/POST client; server stubbed     |
+| sfn/cli   | "cli"       | Shipped       | io            | CLI arg parsing, subcommands, styling    |
+| sfn/test  | "test"      | Partial       | None / io     | Assertions (`expect_*` pure tier, `assert_*` io tier), snapshots |
+| sfn/sync  | "sync"      | Stubbed       | io            | channel/parallel/spawn API — pending concurrency runtime; DO NOT USE yet |
+| sfn/net   | "net"       | Stubbed       | net, io       | TCP/UDP sockets — pending runtime intrinsics; DO NOT USE yet |
+| sfn/tensor| "tensor"    | Shipped (CPU) | gpu (planned) | Tensor ops, matmul, transpose            |
+| sfn/layers| "layers"    | Shipped (CPU) | gpu (planned) | Linear layers, ReLU, sequential models   |
+| sfn/nn    | "nn"        | Shipped (CPU) | gpu (planned) | Activations, normalization, argmax, one_hot |
+| sfn/losses| "losses"    | Shipped       | None          | MSE, MAE, Huber, hinge loss functions    |
 
 ## Numeric Types
 
@@ -304,7 +327,14 @@ Fixed-width FFI integer types (`i8`, `i16`, `i32`, `i64`, `u8`, `u16`, `u32`,
 `u64`, `usize`) and float types (`f32`, `f64`) are also recognized for
 extern-fn signatures and low-level interop.
 
-Bitwise operators (&, |, ^, >>, <<) are not yet implemented.
+Bitwise and shift operators (`&`, `|`, `^`, `<<`, `>>`) are shipped and
+operate on `int`.
+
+Mixing `int` and `float` operands in arithmetic, bindings, call
+arguments, or struct-field writes is a compile error — disambiguate with
+an explicit cast: `x as float`, `n as int`. The `as` cast lowers through
+a typed matrix (`sitofp`, `fptosi`, `sext`, `trunc`, ...). `as bool` is
+rejected; write `x != 0` instead.
 
 ## What Works End-to-End Today
 
@@ -312,14 +342,20 @@ These features parse, type-check, emit to .sfn-asm IR, and lower to LLVM:
 
 - Functions (including async fn, extern fn, generics, defaults, decorators)
 - Structs with methods, fields, generic params, implements clauses
-- Enums with variant payloads and pattern matching
+- Enums with variant payloads and pattern matching (generic payloads
+  monomorphise per instantiation)
 - Interfaces with method signatures
-- Control flow (if/else, for, loop, match, break, continue)
+- Control flow (if/else, for, loop, match, break, continue — no `while`)
 - try/catch/finally exception handling
 - Result<T, E> + the postfix ? error-propagation operator (typed, exception-free)
+- int (i64) / float (f64) numeric types with strict no-implicit-mixing rules
+- Bitwise and shift operators (&, |, ^, <<, >>) on int
+- Explicit numeric `as` casts (typed lowering matrix)
+- Atomic intrinsics: atomic_load/store/add/sub/cas/fence (seq_cst)
+- thread_local let mut globals (top-level only)
 - String interpolation (via runtime)
-- Lambdas (non-capturing)
-- Test declarations
+- Lambdas and closures with capture (multi-variable capture included)
+- Test declarations (plus -k/--tag filtering, lifecycle hooks, snapshots)
 - Import/export across modules
 - Effect annotations -- parsed AND enforced at compile time (build fails on undeclared effects by default; configurable via SAILFIN_EFFECT_ENFORCE)
 - Colon type annotations (x: Type) for params, variables, fields
@@ -328,21 +364,24 @@ These features parse, type-check, emit to .sfn-asm IR, and lower to LLVM:
 
 ## What Is Parsed but Not Fully Implemented
 
+DO NOT use these in generated code unless explicitly asked — they parse
+(and some typecheck) but do not yet compile to working programs:
+
+- Concurrency constructs: `routine { }`, `await`, `channel()`, `spawn`
+  -- parsed with partial typecheck diagnostics (E0813–E0815); LLVM
+  lowering and the scheduler runtime are pending. `async fn` is
+  structural only.
 - Member-callee cross-module effect propagation (`mod.fetch()`) -- direct `Identifier` callee resolution ships in Phase E1; member callees and decorator-implied transitives are deferred to Phase E2
-- Closures with capture -- lambdas parse but don't capture enclosing scope
 - Generic constraints (<T: Bound>) -- parsed as text, not enforced
-- Affine<T> / Linear<T> ownership -- parsed, transparent (no enforcement)
+- Affine<T> / Linear<T> ownership, &T / &mut T borrows -- parsed, transparent (no enforcement)
+- PII<T> / Secret<T> taint types -- parsed as nominal types, no enforcement
 - Union types -- parse but match destructuring is unstable
-- async/await -- async fn compiles, await lowering is partial
 
 ## What Is Not Yet in the Parser
 
-- int / float distinct numeric types
-- Bitwise operators (&, |, ^, >>, <<)
-- ${ } string interpolation (currently uses {{ }})
-- routine { } structured concurrency blocks
-- channel() and spawn concurrency primitives
-- |> pipeline operator
+- ${ } string interpolation (currently uses {{ }}; migration planned pre-1.0)
+- |> pipeline operator (planned post-1.0)
+- while loops (intentional — use loop { } with break)
 
 ## AI Constructs (Moved to Library)
 
@@ -432,6 +471,11 @@ Override the registry with `sfn config set registry <url>` (persists to
         return response.body;
     }
 
+Output builtins: `print(value)` writes to stdout, `print.err(value)` to
+stderr. `print.info` / `print.warn` / `print.error` are deprecated
+legacy variants — do not emit them in new code; use the `sfn/log`
+capsule for leveled logging.
+
 ### Struct with interface
     interface Serializable {
         fn to_json(self) -> string;
@@ -446,16 +490,11 @@ Override the registry with `sfn config set registry <url>` (persists to
         }
     }
 
-### Match with enum destructuring
-    enum Result {
-        Ok { value: string },
-        Err { message: string },
-    }
-
-    fn handle(result: Result) ![io] {
+### Match with enum destructuring (prelude Result — do NOT redefine Result)
+    fn handle(result: Result<string, Error>) ![io] {
         match result {
             Result.Ok { value } => print("Success: {{value}}"),
-            Result.Err { message } => print.err("Error: {{message}}"),
+            Result.Err { error } => print.err("Error: {{error.message}}"),
         }
     }
 
@@ -512,5 +551,5 @@ Sailfin source files use the `.sfn` extension.
 - Language spec: https://sailfin.dev/docs/reference/spec/ (source: site/src/content/docs/docs/reference/spec/)
 - Feature status: docs/status.md
 - Roadmap: https://sailfin.dev/roadmap
-- Examples: examples/ directory (40+ programs across 11 categories)
+- Examples: examples/ directory (45 programs; the index marks design-stage features)
 - Contributing: CONTRIBUTING.md


### PR DESCRIPTION
## Why

`llms.txt` is the in-context reference LLM agents read before generating Sailfin code — it is the single artifact where staleness directly causes systematic agent errors. An audit (2026-06-10) found it pinned to v0.5.9 (2026-04-26) and contradicting `docs/status.md` on five shipped features, teaching agents the *opposite* of reality. This is Phase 0 of the AI-native adoption work: make the in-context spec correct, and make drift mechanically loud.

## What changed

**`llms.txt` reconciled against `docs/status.md` (the source of truth):**

| Stale claim | Reality |
|---|---|
| "Lambdas do not capture enclosing variables" | Closures with capture shipped end-to-end, incl. multi-capture (#458/#459/#689/#1106) |
| "Bitwise operators not yet implemented" | Shipped (numeric Slice B); replaced with the strict int↔float no-mixing rule + `as` cast matrix |
| `int`/`float` "not yet in the parser" | Slices A–E closed; moved to the shipped list |
| `routine`/`await`/`channel`/`spawn` "not in the parser" | Parsed with partial typecheck (E0813–E0815), no lowering — moved to parsed-not-implemented with an explicit **do-not-use** warning |
| `while` undocumented | Called out as intentionally rejected (E0411) with the `loop` idiom |

Also: extern-fn section rewritten to the canonical C-ABI accept-list style (`* u8` pointers, E0801–E0805, `<fn> as * u8` / E0808–E0809); stdlib table synced with status.md (adds `test`/`sync`/`net`/`layers`/`nn`, marks `sync`/`net` Stubbed); the enum idiom no longer teaches redefining the prelude `Result<T, E>`; `print.info/warn/error` flagged deprecated; version stamp → 0.7.0-alpha.29.

**New drift guard** — `compiler/tests/e2e/test_llms_txt_sync.sh` (auto-discovered by `make test-e2e`):
1. `site/public/llms.txt` must remain a symlink to the root file (single source of truth).
2. The `> Version:` line must match `compiler/capsule.toml`, so every release bump forces an llms.txt review — the version line can never silently go stale again.

**`docs/proposals/model-engines-and-training.md`** gains a superseded-in-part status note — it still described the removed `model`/`prompt`/`tool`/`pipeline` keywords as current language constructs, contradicting the libraries-over-keywords decision recorded in status.md.

## Verification

- `compiler/tests/e2e/test_llms_txt_sync.sh` passes locally (both checks green).
- No `.sfn` files touched — no self-host or fmt gates apply.
- Remaining "planned"/"not yet" mentions in llms.txt re-audited against the status.md Feature Matrix; all accurate.

https://claude.ai/code/session_01LGiVgThZT2Jy4PKDv767S3

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGiVgThZT2Jy4PKDv767S3)_