### PR TITLE
perf(resolver): memoize relative-import scans across check entries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,6 +136,16 @@ AGENT_REPORT := bash scripts/agent_report.sh
 # can never mask a test-compile regression.
 TEST_BIN_CACHE_FLAGS ?=
 
+# Parallel test execution (#843 / #1236). The unified runner accepts
+# `--jobs N` (per-file child processes run N at a time); every
+# `$(NATIVE_BIN) test ...` invocation below threads this knob. The
+# default stays 1 because each child carries its own RAM footprint
+# under the 8GB per-process cap — callers pick N for their RAM budget
+# (e.g. `make test TEST_JOBS=4` on a 4-core/16GB box, smaller on
+# 7GB CI runners). CI sharding (`make test-shard`) is unaffected.
+TEST_JOBS ?= 1
+TEST_JOBS_FLAG = --jobs $(TEST_JOBS)
+
 help:
 	@echo "Common Sailfin tasks"
 	@echo ""
@@ -145,6 +155,7 @@ help:
 	@echo "  make check          # Compile (if needed) then run the full test suite"
 	@echo "  make check-fast     # Run sfn check on compiler/src/ + runtime/ (no codegen, fast PR gate)"
 	@echo "  make test           # Run Sailfin-native unit + integration + e2e tests"
+	@echo "  make test TEST_JOBS=4 # Same, with 4 parallel test children (pick N for your RAM budget)"
 	@echo "  make test-unit      # Run Sailfin-native unit tests"
 	@echo "  make test-integration # Run Sailfin-native integration tests"
 	@echo "  make test-e2e       # Run Sailfin-native end-to-end tests"
@@ -201,9 +212,9 @@ test-impl:
 	if [ "$${SAILFIN_AGENT_REPORT:-}" = "1" ]; then \
 		mkdir -p build; \
 		set -o pipefail; \
-		$(NATIVE_BIN) test compiler/tests/unit compiler/tests/integration compiler/tests/e2e capsules $(TEST_BIN_CACHE_FLAGS) --json | tee build/agent-test.test.jsonl || rc=$$?; \
+		$(NATIVE_BIN) test compiler/tests/unit compiler/tests/integration compiler/tests/e2e capsules $(TEST_BIN_CACHE_FLAGS) $(TEST_JOBS_FLAG) --json | tee build/agent-test.test.jsonl || rc=$$?; \
 	else \
-		$(NATIVE_BIN) test compiler/tests/unit compiler/tests/integration compiler/tests/e2e capsules $(TEST_BIN_CACHE_FLAGS) || rc=$$?; \
+		$(NATIVE_BIN) test compiler/tests/unit compiler/tests/integration compiler/tests/e2e capsules $(TEST_BIN_CACHE_FLAGS) $(TEST_JOBS_FLAG) || rc=$$?; \
 	fi; \
 	$(MAKE) test-e2e-sh || rc=$$?; \
 	exit $$rc
@@ -276,9 +287,9 @@ test-unit-impl:
 	@if [ "$${SAILFIN_AGENT_REPORT:-}" = "1" ]; then \
 		mkdir -p build; \
 		set -o pipefail; \
-		$(NATIVE_BIN) test compiler/tests/unit --json | tee build/agent-test.test-unit.jsonl; \
+		$(NATIVE_BIN) test compiler/tests/unit $(TEST_JOBS_FLAG) --json | tee build/agent-test.test-unit.jsonl; \
 	else \
-		$(NATIVE_BIN) test compiler/tests/unit; \
+		$(NATIVE_BIN) test compiler/tests/unit $(TEST_JOBS_FLAG); \
 	fi
 
 test-integration:
@@ -293,9 +304,9 @@ test-integration-impl:
 	@if [ "$${SAILFIN_AGENT_REPORT:-}" = "1" ]; then \
 		mkdir -p build; \
 		set -o pipefail; \
-		$(NATIVE_BIN) test compiler/tests/integration --json | tee build/agent-test.test-integration.jsonl; \
+		$(NATIVE_BIN) test compiler/tests/integration $(TEST_JOBS_FLAG) --json | tee build/agent-test.test-integration.jsonl; \
 	else \
-		$(NATIVE_BIN) test compiler/tests/integration; \
+		$(NATIVE_BIN) test compiler/tests/integration $(TEST_JOBS_FLAG); \
 	fi
 
 # The legacy e2e `test_*.sh` scripts still run alongside the `.sfn`
@@ -318,9 +329,9 @@ test-e2e-impl:
 	if [ "$${SAILFIN_AGENT_REPORT:-}" = "1" ]; then \
 		mkdir -p build; \
 		set -o pipefail; \
-		$(NATIVE_BIN) test compiler/tests/e2e --json | tee build/agent-test.test-e2e.jsonl || rc=$$?; \
+		$(NATIVE_BIN) test compiler/tests/e2e $(TEST_JOBS_FLAG) --json | tee build/agent-test.test-e2e.jsonl || rc=$$?; \
 	else \
-		$(NATIVE_BIN) test compiler/tests/e2e || rc=$$?; \
+		$(NATIVE_BIN) test compiler/tests/e2e $(TEST_JOBS_FLAG) || rc=$$?; \
 	fi; \
 	$(MAKE) test-e2e-sh || rc=$$?; \
 	exit $$rc
@@ -342,9 +353,9 @@ test-capsules-impl:
 	@if [ "$${SAILFIN_AGENT_REPORT:-}" = "1" ]; then \
 		mkdir -p build; \
 		set -o pipefail; \
-		$(NATIVE_BIN) test capsules --json | tee build/agent-test.test-capsules.jsonl; \
+		$(NATIVE_BIN) test capsules $(TEST_JOBS_FLAG) --json | tee build/agent-test.test-capsules.jsonl; \
 	else \
-		$(NATIVE_BIN) test capsules; \
+		$(NATIVE_BIN) test capsules $(TEST_JOBS_FLAG); \
 	fi
 
 # Sharded test execution for parallel CI legs. Phase 1 of

--- a/compiler/src/capsule_resolver.sfn
+++ b/compiler/src/capsule_resolver.sfn
@@ -2937,6 +2937,71 @@ fn _cr_capsule_spec_for_slug(slug: string, members: WorkspaceMember[]) -> string
     return best;
 }
 
+// #1247: per-resolution-pass memo shared across the per-entry
+// relative-import walks in `_cr_resolve_and_dedupe`. Without it, a
+// multi-entry resolution (`sfn check compiler/src/` = 158 entries)
+// re-reads and re-scans every source in every entry's import closure
+// once PER ENTRY — O(entries × closure) full-source scans through the
+// allocation-heavy `collect_relative_import_specs` state machine
+// (`_cr_byte_at` allocates a fresh 1-char string per byte). All of
+// that garbage lands in the process-global arena BEFORE `cli_check`'s
+// Phase 5a loop mark, so the per-file rewind can never reclaim it:
+// measured ~25MB of dead arena per entry (~4.0GB across the warm
+// whole-tree check). The memo caches, per unique source path:
+//   - `scan_specs`: the `collect_relative_import_specs` result, so
+//     each source is read + scanned at most once per resolution pass;
+//   - `dep_sources`: the discovered-dependency `CapsuleSource`, which
+//     is entry-independent (`_cr_relative_slug` ignores `entry_dir`),
+//     so slug/member canonicalization also runs once per unique dep.
+// Lookups are linear scans over parallel arrays — the same pattern
+// the visited-set below already uses — because the key set is small
+// (one entry per unique module, ~170 for the compiler tree).
+//
+// The memo deliberately does NOT change which files are emitted for
+// which entry: each entry still runs its own BFS with its own
+// visited set, so the output (and therefore staged artifacts and
+// diagnostics) is byte-identical to the unmemoized walk.
+struct RelativeScanMemo {
+    scan_paths: string[];
+    scan_specs: string[][];
+    dep_paths: string[];
+    dep_sources: CapsuleSource[];
+}
+
+// Outcome of one memoized per-entry walk: the entry's discovered
+// sources plus the (possibly grown) memo to thread into the next
+// entry's walk. Returned explicitly — rather than relying on
+// in-place mutation of the memo argument — to match the
+// return-the-updated-value convention used across the resolver.
+struct RelativeEnumerateOutcome {
+    sources: CapsuleSource[];
+    memo: RelativeScanMemo;
+}
+
+fn _cr_empty_relative_scan_memo() -> RelativeScanMemo {
+    let scan_paths: string[] = [];
+    let scan_specs: string[][] = [];
+    let dep_paths: string[] = [];
+    let dep_sources: CapsuleSource[] = [];
+    return RelativeScanMemo {
+        scan_paths: scan_paths,
+        scan_specs: scan_specs,
+        dep_paths: dep_paths,
+        dep_sources: dep_sources
+    };
+}
+
+// Linear index lookup over a memo key column. Returns -1 when absent.
+fn _cr_memo_index(paths: string[], path: string) -> int {
+    let mut i: int = 0;
+    loop {
+        if i >= paths.length { break; }
+        if strings_equal(paths[i], path) { return i; }
+        i += 1;
+    }
+    return -1;
+}
+
 // Walk relative imports (`./foo`, `../foo`) reachable from `entry_path` and
 // return one CapsuleSource per discovered file. The entry itself is NOT
 // included — the caller compiles it via the standard single-file path.
@@ -2944,9 +3009,22 @@ fn _cr_capsule_spec_for_slug(slug: string, members: WorkspaceMember[]) -> string
 // `runtime/*` and scoped (`scope/name`) imports are handled by
 // `enumerate_capsule_sources` (manifest-declared deps) and the workspace
 // member lookup; this enumerator only walks intra-project relative imports.
+//
+// Thin compatibility wrapper over the memoized core: single-entry
+// callers get a fresh memo (identical behavior to the historical
+// implementation); `_cr_resolve_and_dedupe` calls the memoized core
+// directly so the scan cache is shared across all entries in one
+// resolution pass (#1247).
 fn enumerate_relative_sources(entry_path: string, members: WorkspaceMember[]) -> CapsuleSource[] ![io] {
+    let outcome = _cr_enumerate_relative_sources_memo(entry_path, members, _cr_empty_relative_scan_memo());
+    return outcome.sources;
+}
+
+fn _cr_enumerate_relative_sources_memo(entry_path: string, members: WorkspaceMember[], memo: RelativeScanMemo) -> RelativeEnumerateOutcome ![io] {
     let mut out: CapsuleSource[] = [];
-    if entry_path.length == 0 { return out; }
+    if entry_path.length == 0 {
+        return RelativeEnumerateOutcome { sources: out, memo: memo };
+    }
     let entry_dir = _cr_dirname(entry_path);
     let mut visited: string[] = [entry_path];
     let mut queue: string[] = [entry_path];
@@ -2970,9 +3048,18 @@ fn enumerate_relative_sources(entry_path: string, members: WorkspaceMember[]) ->
         iterations += 1;
         let current_path = queue[head];
         head += 1;
-        if !fs.exists(current_path) { continue; }
-        let source = fs.readFile(current_path);
-        let specs = collect_relative_import_specs(source);
+        // #1247: scan each unique source at most once per resolution
+        // pass. A memo hit skips the `fs.exists` probe too — the file
+        // was on disk when this same pass scanned it moments ago.
+        let mut specs: string[] = [];
+        let scan_idx = _cr_memo_index(memo.scan_paths, current_path);
+        if scan_idx >= 0 { specs = memo.scan_specs[scan_idx]; } else {
+            if !fs.exists(current_path) { continue; }
+            let source = fs.readFile(current_path);
+            specs = collect_relative_import_specs(source);
+            memo.scan_paths.push(current_path);
+            memo.scan_specs.push(specs);
+        }
         let cur_dir = _cr_dirname(current_path);
         let mut i: int = 0;
         loop {
@@ -3001,40 +3088,58 @@ fn enumerate_relative_sources(entry_path: string, members: WorkspaceMember[]) ->
                 if !already_seen {
                     visited.push(dep_path);
                     queue.push(dep_path);
-                    // #873: if this relatively-imported file lives inside a
-                    // workspace member's `src/`, stage it under the member's
-                    // canonical spec slug (`sfn/crypto/mod`) — the SAME slug
-                    // the workspace-implicit / manifest-dep walks assign the
-                    // same file — so the relative and scoped enumerators
-                    // agree on one symbol per capsule function and a
-                    // capsule's own `../src/mod` tests link. Tag the spec
-                    // with the member name so the source routes under the
-                    // per-capsule `ir/` layout exactly like the implicit
-                    // walk's sources. Non-member paths (every `compiler/src/**`
-                    // and `runtime/**` file) get "" and fall back to the
-                    // path-shaped slug, leaving self-host slugs untouched.
-                    let path_slug = _cr_relative_slug(entry_dir, dep_path);
-                    let capsule_slug = _cr_capsule_slug_for_path(path_slug, members);
-                    let mut slug = path_slug;
-                    let mut spec: string = "";
-                    if capsule_slug.length > 0 {
-                        slug = capsule_slug;
-                        spec = _cr_capsule_spec_for_slug(capsule_slug, members);
+                    // #1247: the CapsuleSource for a dep is independent
+                    // of which entry discovered it (`_cr_relative_slug`
+                    // ignores `entry_dir`), so the slug / workspace-
+                    // member canonicalization below runs once per
+                    // unique dep per resolution pass; later entries
+                    // that rediscover the same dep reuse the memoized
+                    // value.
+                    let dep_idx = _cr_memo_index(memo.dep_paths, dep_path);
+                    if dep_idx >= 0 {
+                        out.push(memo.dep_sources[dep_idx]);
+                    } else {
+                        // #873: if this relatively-imported file lives inside a
+                        // workspace member's `src/`, stage it under the member's
+                        // canonical spec slug (`sfn/crypto/mod`) — the SAME slug
+                        // the workspace-implicit / manifest-dep walks assign the
+                        // same file — so the relative and scoped enumerators
+                        // agree on one symbol per capsule function and a
+                        // capsule's own `../src/mod` tests link. Tag the spec
+                        // with the member name so the source routes under the
+                        // per-capsule `ir/` layout exactly like the implicit
+                        // walk's sources. Non-member paths (every `compiler/src/**`
+                        // and `runtime/**` file) get "" and fall back to the
+                        // path-shaped slug, leaving self-host slugs untouched.
+                        let path_slug = _cr_relative_slug(entry_dir, dep_path);
+                        let capsule_slug = _cr_capsule_slug_for_path(path_slug, members);
+                        let mut slug = path_slug;
+                        let mut spec: string = "";
+                        if capsule_slug.length > 0 {
+                            slug = capsule_slug;
+                            spec = _cr_capsule_spec_for_slug(capsule_slug, members);
+                        }
+                        // ll_path is filled in by `_cr_resolve_and_dedupe`
+                        // once the consumer is known (Stage C2b2) — for
+                        // a `-p <consumer>` build with safe scope/name,
+                        // this lands under the consumer's per-capsule
+                        // tree; otherwise the legacy flat layout.
+                        let dep_source = CapsuleSource {
+                            spec: spec,
+                            source_path: dep_path,
+                            slug: slug,
+                            ll_path: ""
+                        };
+                        memo.dep_paths.push(dep_path);
+                        memo.dep_sources.push(dep_source);
+                        out.push(dep_source);
                     }
-                    // ll_path is filled in by `_cr_resolve_and_dedupe`
-                    // once the consumer is known (Stage C2b2) — for
-                    // a `-p <consumer>` build with safe scope/name,
-                    // this lands under the consumer's per-capsule
-                    // tree; otherwise the legacy flat layout.
-                    out.push(CapsuleSource {
-                        spec: spec, source_path: dep_path, slug: slug, ll_path: ""
-                    });
                 }
             }
             i += 1;
         }
     }
-    return out;
+    return RelativeEnumerateOutcome { sources: out, memo: memo };
 }
 
 // Stage D PR3: walk every `.sfn` under `<project_root>/src/` for
@@ -3878,11 +3983,22 @@ fn _cr_resolve_and_dedupe(entry_paths: string[], consumer: ResolverConsumer) -> 
     // resolves into a workspace member's `src/` is staged under that
     // member's canonical spec slug (#873), so it collapses cleanly
     // against the same file discovered by the workspace-implicit walk.
+    //
+    // #1247: one scan memo is threaded across every entry's walk so
+    // each unique source in the union closure is read + scanned at
+    // most once per resolution pass. Without this, a whole-tree
+    // `sfn check` re-scanned every closure module once per entry —
+    // O(entries × closure) scans whose arena garbage (allocated
+    // before the per-file loop's Phase 5a mark) grew peak RSS by
+    // ~25MB per entry and could never be rewound.
+    let mut scan_memo = _cr_empty_relative_scan_memo();
     let mut ei: int = 0;
     loop {
         if ei >= entry_paths.length { break; }
         let entry = entry_paths[ei];
-        let relative = enumerate_relative_sources(entry, members);
+        let outcome = _cr_enumerate_relative_sources_memo(entry, members, scan_memo);
+        scan_memo = outcome.memo;
+        let relative = outcome.sources;
         let mut ri: int = 0;
         loop {
             if ri >= relative.length { break; }

--- a/compiler/tests/e2e/test_check_resolver_scan_memo.sh
+++ b/compiler/tests/e2e/test_check_resolver_scan_memo.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+# Memory-bound regression test for #1247: the resolver's relative-import
+# scan memo.
+#
+# `_cr_resolve_and_dedupe` walks relative imports once per entry path.
+# Before #1247 each per-entry walk re-read and re-scanned every source
+# in that entry's import closure through the allocation-heavy
+# `collect_relative_import_specs` state machine — O(entries x closure)
+# full-source scans whose arena garbage is allocated BEFORE the
+# per-file loop's Phase 5a mark in `cli_check.sfn`, so the per-file
+# rewind could never reclaim it. On the warm whole-tree
+# `sfn check compiler/src/` this grew peak RSS by ~25MB per entry
+# (~4.0GB across 158 files). The fix memoizes the per-unique-file scan
+# (and the entry-independent dep CapsuleSource) across all entries of
+# one resolution pass, making the resolver's arena footprint a
+# function of the unique closure, not of the entry count.
+#
+# This test pins the bound with a synthetic project: a 10-module
+# import chain of comment-padded (~48KB) modules, plus 40 tiny entry
+# files that each import the head of the chain. It compares the
+# arena page count (via SAILFIN_DUMP_ARENA_STATS) between a warm
+# 5-entry check and a warm 40-entry check:
+#
+#   - pre-#1247: the extra 35 entries re-scan the 10-module chain
+#     once each (~350MB of pre-mark arena, ~85 extra 4MiB pages).
+#   - post-#1247: the chain is scanned once per run regardless of
+#     entry count (delta is a handful of pages of per-entry BFS
+#     bookkeeping + unchanged per-file analysis scratch).
+#
+# The threshold (24 pages = 96MB) sits ~3.5x away from both sides.
+# NOTE: the bound is calibrated against the 4MiB default arena page
+# size (`_init_global_arena` in runtime/native/src/sailfin_arena.c);
+# if `SfnArenaPage` capacity changes, recalibrate the bound.
+# A synthetic tree keeps this orders of magnitude cheaper than a
+# second full-tree `sfn check compiler/src/` invocation (see the
+# cost-discipline note in test_check_compiler_src.sh).
+#
+# Usage:
+#   compiler/tests/e2e/test_check_resolver_scan_memo.sh <compiler-binary>
+
+set -euo pipefail
+
+BINARY="${1:?usage: test_check_resolver_scan_memo.sh <compiler-binary>}"
+BINARY="$(realpath "$BINARY")"
+PASS=0
+FAIL=0
+
+# Cap memory like every other compiler invocation in this repo. The
+# pre-fix failure mode is a few hundred extra MB on this synthetic
+# tree — well under the cap — so the cap only guards against runaway
+# regressions, it never fires on the expected paths.
+ulimit -v 8388608 2> /dev/null || true
+
+SCRATCH="$(mktemp -d -t sfn-check-scan-memo-XXXXXX)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+
+run_test() {
+    local name="$1"
+    shift
+    if "$@"; then
+        echo "[test] PASS: $name"
+        PASS=$((PASS + 1))
+    else
+        echo "[test] FAIL: $name"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# ---- Setup: synthetic capsule with a shared 10-module import chain ----
+mkdir -p "$SCRATCH/src"
+
+# Stop discover_workspace_root from walking up into the live tree.
+cat > "$SCRATCH/workspace.toml" <<'EOF'
+[workspace]
+members = []
+EOF
+
+cat > "$SCRATCH/capsule.toml" <<'EOF'
+[capsule]
+name = "check-scan-memo-test"
+version = "0.1.0"
+description = "E2E memory-bound test for the resolver scan memo (#1247)"
+
+[capabilities]
+required = []
+
+[build]
+entry = "src/entry_00.sfn"
+EOF
+
+# 600 comment lines (~48KB) of padding per chain module. The
+# relative-import scanner walks every byte (comments included), so
+# padding makes a redundant re-scan measurable in arena pages.
+PADDING="$SCRATCH/padding.txt"
+for i in $(seq 1 600); do
+    printf '// padding line %04d: abcdefghijklmnopqrstuvwxyz0123456789 padding padding\n' "$i"
+done > "$PADDING"
+
+# Chain: common_00 -> common_01 -> ... -> common_09.
+for i in $(seq 0 9); do
+    idx="$(printf '%02d' "$i")"
+    f="$SCRATCH/src/common_${idx}.sfn"
+    if [ "$i" -lt 9 ]; then
+        next="$(printf '%02d' $((i + 1)))"
+        {
+            printf 'import { chain_%s } from "./common_%s";\n\n' "$next" "$next"
+            printf 'fn chain_%s() -> number { return chain_%s() + 1; }\n\n' "$idx" "$next"
+            printf 'export { chain_%s };\n' "$idx"
+            cat "$PADDING"
+        } > "$f"
+    else
+        {
+            printf 'fn chain_%s() -> number { return 9; }\n\n' "$idx"
+            printf 'export { chain_%s };\n' "$idx"
+            cat "$PADDING"
+        } > "$f"
+    fi
+done
+
+# 40 tiny entries, each importing the head of the chain.
+for i in $(seq 0 39); do
+    idx="$(printf '%02d' "$i")"
+    f="$SCRATCH/src/entry_${idx}.sfn"
+    {
+        printf 'import { chain_00 } from "./common_00";\n\n'
+        printf 'fn use_%s() -> number { return chain_00(); }\n\n' "$idx"
+        printf 'export { use_%s };\n' "$idx"
+    } > "$f"
+done
+
+cd "$SCRATCH"
+
+# ---- Prime: stage the chain's import-context (cold run) ----
+# One small invocation pays the cold staging cost so both measured
+# runs below are warm (cache hits, no staging subprocesses).
+if ! "$BINARY" check src/entry_00.sfn > "$SCRATCH/prime.out" 2> "$SCRATCH/prime.err"; then
+    echo "[test] FATAL: prime run failed" >&2
+    cat "$SCRATCH/prime.err" >&2
+    exit 2
+fi
+
+# Run a warm check over the given entry files and echo the arena page
+# count from the SAILFIN_DUMP_ARENA_STATS atexit line.
+measure_pages() {
+    local out_log="$1"
+    local err_log="$2"
+    shift 2
+    if ! env SAILFIN_USE_ARENA=1 SAILFIN_DUMP_ARENA_STATS=1 \
+        "$BINARY" check "$@" > "$out_log" 2> "$err_log"; then
+        echo "[test]   check invocation failed:" >&2
+        cat "$err_log" >&2
+        return 1
+    fi
+    local pages
+    pages="$(sed -n 's/.*\[sailfin-arena\].* pages=\([0-9]*\).*/\1/p' "$err_log" | tail -1)"
+    if [ -z "$pages" ]; then
+        echo "[test]   no arena-stats line in stderr:" >&2
+        cat "$err_log" >&2
+        return 1
+    fi
+    echo "$pages"
+}
+
+SMALL_ENTRIES=()
+for i in $(seq 0 4); do
+    SMALL_ENTRIES+=("src/entry_$(printf '%02d' "$i").sfn")
+done
+LARGE_ENTRIES=()
+for i in $(seq 0 39); do
+    LARGE_ENTRIES+=("src/entry_$(printf '%02d' "$i").sfn")
+done
+
+test_pages_growth_is_bounded() {
+    local pages_small pages_large
+    pages_small="$(measure_pages "$SCRATCH/small.out" "$SCRATCH/small.err" "${SMALL_ENTRIES[@]}")" || return 1
+    pages_large="$(measure_pages "$SCRATCH/large.out" "$SCRATCH/large.err" "${LARGE_ENTRIES[@]}")" || return 1
+    echo "[test]   5-entry pages=$pages_small 40-entry pages=$pages_large"
+    if ! grep -q 'checked 5 files: ok' "$SCRATCH/small.out"; then
+        echo "[test]   5-entry run did not report 'checked 5 files: ok':" >&2
+        cat "$SCRATCH/small.out" >&2
+        return 1
+    fi
+    if ! grep -q 'checked 40 files: ok' "$SCRATCH/large.out"; then
+        echo "[test]   40-entry run did not report 'checked 40 files: ok':" >&2
+        cat "$SCRATCH/large.out" >&2
+        return 1
+    fi
+    local delta=$((pages_large - pages_small))
+    if [ "$delta" -gt 24 ]; then
+        echo "[test]   arena grew $delta pages between 5 and 40 entries (bound: 24)" >&2
+        echo "[test]   the resolver is likely re-scanning the import closure per entry (#1247)" >&2
+        return 1
+    fi
+    return 0
+}
+run_test "warm check arena pages grow sub-linearly with entry count" \
+    test_pages_growth_is_bounded
+
+echo "[summary] $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi

--- a/compiler/tests/e2e/test_check_resolver_scan_memo.sh
+++ b/compiler/tests/e2e/test_check_resolver_scan_memo.sh
@@ -22,12 +22,14 @@
 # 5-entry check and a warm 40-entry check:
 #
 #   - pre-#1247: the extra 35 entries re-scan the 10-module chain
-#     once each (~350MB of pre-mark arena, ~85 extra 4MiB pages).
+#     once each (measured +61 extra 4MiB pages against the pre-fix
+#     v0.7.0-alpha.29 seed binary).
 #   - post-#1247: the chain is scanned once per run regardless of
-#     entry count (delta is a handful of pages of per-entry BFS
-#     bookkeeping + unchanged per-file analysis scratch).
+#     entry count (measured +0 pages; delta is bounded by per-entry
+#     BFS bookkeeping + unchanged per-file analysis scratch).
 #
-# The threshold (24 pages = 96MB) sits ~3.5x away from both sides.
+# The threshold (24 pages = 96MB) sits ~2.5x below the measured
+# pre-fix delta and well above the measured post-fix delta.
 # NOTE: the bound is calibrated against the 4MiB default arena page
 # size (`_init_global_arena` in runtime/native/src/sailfin_arena.c);
 # if `SfnArenaPage` capacity changes, recalibrate the bound.
@@ -53,8 +55,6 @@ ulimit -v 8388608 2> /dev/null || true
 
 SCRATCH="$(mktemp -d -t sfn-check-scan-memo-XXXXXX)"
 trap 'rm -rf "$SCRATCH"' EXIT
-
-REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 
 run_test() {
     local name="$1"


### PR DESCRIPTION
## Summary
- Diagnoses and closes the ~29MB/file warm `sfn check` memory growth from #1247: the leak is **not** in the per-file loop — the Phase 5a arena rewind works exactly as designed (instrumented marks show every `post_rewind` cursor returning to the loop mark). The linear term is **pre-mark**: `_cr_resolve_and_dedupe` ran the relative-import BFS once per entry, and each walk re-read + re-scanned every source in that entry's import closure.
- Fix: a `RelativeScanMemo` threaded across all entries of one resolution pass — each unique source is read + scanned at most once, and each unique dep's `CapsuleSource` (slug / workspace-member canonicalization) is computed once. Output is byte-identical (each entry keeps its own BFS + visited set).
- Adds a memory-bound e2e regression test that fails on the pre-fix seed binary (+61 arena pages) and passes post-fix (+0 pages).
- Rider (requested in-session, part of #843 Track A): `TEST_JOBS ?= 1` Makefile knob threading the runner's existing `--jobs N` (#1236) into every `make test*` target. Default 1 (RAM-budget call stays with the caller); `make test TEST_JOBS=4` halves the integration suite locally (67s → 34s warm). CI sharding unaffected.

Closes #1247

## Root cause (mechanism + file)
`compiler/src/capsule_resolver.sfn`: `_cr_resolve_and_dedupe` calls `enumerate_relative_sources(entry, members)` once **per entry path**. Each call BFS-walks the entry's whole import closure, calling `fs.readFile` + `collect_relative_import_specs` on every reachable module. The scanner's helpers are allocation-heavy — `_cr_byte_at` allocates a fresh 1-char string per source byte (~21B of arena garbage per scanned byte, measured) and `_cr_word_matches` allocates two substrings per scanned position. For `sfn check compiler/src/` that is 158 entries × ~100-module closures ≈ 15k full-source scans ≈ **4.0GB of arena allocations, all before `cli_check.sfn` takes its Phase 5a loop mark** — so the per-file rewind can never reclaim them. Arena-cursor traces (mark = `(page_index << 32) | used`):

| phase | before | after |
|---|---|---|
| post_resolve | page 1002 (~4008MB) | page 87 (~348MB) |
| post_load | +34 pages (136MB) | +34 pages (136MB) |
| per-file rewind | restores exactly | restores exactly |
| pages at exit | 1074 (4296MB) | 160 (640MB) |

Hypotheses (a) malloc-path helpers and (b) pre-mark structure mutation from the issue were ruled out: `--json` (no-rewind) vs default runs showed the rewind reclaiming ~1.2GB, and exit-time `used` (allocations below the mark) was the term growing linearly.

## Acceptance Criteria
- [x] Warm whole-tree `check compiler/src/` peak RSS ≤ ~(single-file peak + 2GB): **732MB** peak (was 4483MB)
- [x] Peak RSS not linear in file count: 40-file = 538MB vs 158-file = 732MB (~1.6MB/file residual = union-closure + per-file scratch; was ~29MB/file)
- [x] Diagnostics/output byte-identical: full-tree stdout + stderr diffed clean against pre-fix run
- [x] Root cause documented (above)
- [x] Memory-bound regression test: `compiler/tests/e2e/test_check_resolver_scan_memo.sh` (fails on pre-fix seed: +61 pages; passes post-fix: +0)
- [x] `make compile` passes (self-host); `make test` green on the fixed binary: unit 146/146, integration 32/32, e2e 5/5, capsules 34/34, e2e-sh 111/111 (an earlier exit-139 did not reproduce — it occurred while the suite shared a 4-vCPU container with concurrent 4.5GB pre-fix benchmark runs)
- [x] `sfn fmt --check` clean on touched files

## Verification
```bash
make compile                                              # self-hosts: pass
SAILFIN_DUMP_ARENA_STATS=1 sailfin check compiler/src/    # warm tree
#   before: pages=1074 capacity=4296MB  peak_rss=4483MB  wall=201s
#   after:  pages=160  capacity=640MB   peak_rss=732MB   wall=53s
sailfin check $(ls compiler/src/*.sfn | head -40)         # sub-linearity probe
#   after:  pages=126  peak_rss=538MB
bash compiler/tests/e2e/test_check_resolver_scan_memo.sh build/seed/bin/sailfin   # pre-fix: FAIL (+61 pages)
bash compiler/tests/e2e/test_check_resolver_scan_memo.sh build/native/sailfin    # post-fix: PASS (+0 pages)
make test                                                 # full suite green (see above)
make test-integration && make test-integration TEST_JOBS=4   # knob smoke: pass / pass (67s -> 34s)
```

## Files Changed
- `compiler/src/capsule_resolver.sfn` — `RelativeScanMemo` + memoized BFS core (`_cr_enumerate_relative_sources_memo`); `enumerate_relative_sources` kept as a thin fresh-memo wrapper; memo threaded in `_cr_resolve_and_dedupe`
- `compiler/tests/e2e/test_check_resolver_scan_memo.sh` — memory-bound regression test (new)
- `Makefile` — `TEST_JOBS` knob threading `--jobs` into the `make test*` targets (#843 Track A rider)

Pre-commit review (code-reviewer): approved, no blocking findings; aliasing of memoized `CapsuleSource` values is read-only downstream (the post-dedupe `ll_path` fill constructs new structs). Copilot review nits addressed in 97e597a.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013jXbNFkiWSaZncHsyx8r9n