### PR TITLE
ci(release): slim the prerelease gate to build + package + smoke

### DIFF
--- a/.github/actions/sailfin-build/action.yml
+++ b/.github/actions/sailfin-build/action.yml
@@ -44,7 +44,12 @@ inputs:
       used by the shared per-OS build-compiler job in ci.yml. 'skip-build' =
       trust an already-present build/native + build/cache tree (downloaded
       from the build-compiler artifact) and run tests/packaging only; no
-      seed fetch, no `make rebuild`.
+      seed fetch, no `make rebuild`. 'build-package' = fetch seed + build +
+      package, skip the test suite — the slim release gate (#843): a release
+      commit is a mechanical version bump on a main SHA that already passed
+      full PR CI + push:main validation, so the release legs verify the
+      build/package/smoke surface and delegate suite coverage to main CI
+      and the nightly self-host.
     required: false
     default: "full"
 runs:
@@ -138,7 +143,7 @@ runs:
     # a fresh entry). They are also folded into the per-test cache key by
     # content (`runtime_link_inputs_identity`), so this is belt-and-braces.
     - name: Restore test-bin cache (per-test linked binaries)
-      if: ${{ inputs.mode != 'build-only' }}
+      if: ${{ inputs.mode != 'build-only' && inputs.mode != 'build-package' }}
       uses: actions/cache@v4
       with:
         path: build/cache/test-bin
@@ -188,14 +193,14 @@ runs:
         build/native/sailfin version
 
     - name: Prepare test artifacts
-      if: ${{ inputs.mode != 'build-only' }}
+      if: ${{ inputs.mode != 'build-only' && inputs.mode != 'build-package' }}
       shell: bash {0}
       run: |
         set -euo pipefail
         make ci-prepare-test-artifacts
 
     - name: Run tests (first-pass binary)
-      if: ${{ inputs.mode != 'build-only' }}
+      if: ${{ inputs.mode != 'build-only' && inputs.mode != 'build-package' }}
       shell: bash {0}
       run: |
         set -euo pipefail

--- a/.github/workflows/release-branches.yml
+++ b/.github/workflows/release-branches.yml
@@ -23,6 +23,10 @@ on:
             - CHANGELOG.md
             - compiler/src/version.sfn
             - compiler/capsule.toml
+            # The release bump commit also stamps llms.txt's "> Version:"
+            # line (release.yml "Update version files"); keep bump commits
+            # from triggering branch CI, same as the other version files.
+            - llms.txt
             - 'site/**'
             - 'capsules/**/capsule.toml'
 

--- a/.github/workflows/release-branches.yml
+++ b/.github/workflows/release-branches.yml
@@ -108,25 +108,6 @@ jobs:
                   clang: ${{ matrix.clang }}
                   seed_version: ${{ steps.seed.outputs.seed_version }}
                   test_jobs: ${{ matrix.test_jobs }}
-                  # Slim release gate (#843): beta/rc tags are always
-                  # prereleases cut from a validated main/branch SHA —
-                  # build + package + smoke here; suite coverage lives in
-                  # PR CI, push:main, and the nightly self-host.
-                  mode: build-package
-
-            - name: Smoke-test built compiler (hello-world)
-              shell: bash {0}
-              run: |
-                  set -euo pipefail
-                  if [ "${RUNNER_OS:-}" = "Linux" ]; then
-                      ulimit -v 8388608 || true
-                  fi
-                  out="$(build/native/sailfin run examples/basics/hello-world.sfn)"
-                  echo "$out"
-                  if ! printf '%s' "$out" | grep -q "Hello, Sailfin!"; then
-                      echo "[ci][error] hello-world smoke failed: expected 'Hello, Sailfin!' in output" >&2
-                      exit 1
-                  fi
 
             - name: Report compiler metadata
               shell: bash {0}

--- a/.github/workflows/release-branches.yml
+++ b/.github/workflows/release-branches.yml
@@ -104,6 +104,25 @@ jobs:
                   clang: ${{ matrix.clang }}
                   seed_version: ${{ steps.seed.outputs.seed_version }}
                   test_jobs: ${{ matrix.test_jobs }}
+                  # Slim release gate (#843): beta/rc tags are always
+                  # prereleases cut from a validated main/branch SHA —
+                  # build + package + smoke here; suite coverage lives in
+                  # PR CI, push:main, and the nightly self-host.
+                  mode: build-package
+
+            - name: Smoke-test built compiler (hello-world)
+              shell: bash {0}
+              run: |
+                  set -euo pipefail
+                  if [ "${RUNNER_OS:-}" = "Linux" ]; then
+                      ulimit -v 8388608 || true
+                  fi
+                  out="$(build/native/sailfin run examples/basics/hello-world.sfn)"
+                  echo "$out"
+                  if ! printf '%s' "$out" | grep -q "Hello, Sailfin!"; then
+                      echo "[ci][error] hello-world smoke failed: expected 'Hello, Sailfin!' in output" >&2
+                      exit 1
+                  fi
 
             - name: Report compiler metadata
               shell: bash {0}

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -122,6 +122,13 @@ jobs:
           brew install jq llvm
           echo "$(brew --prefix llvm)/bin" >> "$GITHUB_PATH"
 
+      # Slim release gate (#843): a prerelease tag is a mechanical
+      # version bump on a main SHA that already passed full PR CI and
+      # push:main validation, so prerelease legs build + package + smoke
+      # and delegate suite coverage to main CI and the nightly
+      # self-host. Stable (non-prerelease) tags keep the full suite —
+      # GA cuts are rare enough that the extra hour is worth the
+      # belt-and-braces. `test_jobs` only applies on that full path.
       - name: Build + test + package (via Makefile)
         uses: ./.github/actions/sailfin-build
         env:
@@ -131,6 +138,24 @@ jobs:
           clang: ${{ matrix.clang }}
           seed_version: ${{ steps.seed.outputs.seed_version }}
           test_jobs: ${{ matrix.test_jobs }}
+          mode: ${{ contains(env.RELEASE_TAG, '-') && 'build-package' || 'full' }}
+
+      # Smoke-test the built compiler end-to-end (compile + link + run a
+      # real program). Together with the two version verifications below
+      # this is the release-leg acceptance surface on the slim path.
+      - name: Smoke-test built compiler (hello-world)
+        shell: bash {0}
+        run: |
+          set -euo pipefail
+          if [ "${RUNNER_OS:-}" = "Linux" ]; then
+            ulimit -v 8388608 || true
+          fi
+          out="$(build/native/sailfin run examples/basics/hello-world.sfn)"
+          echo "$out"
+          if ! printf '%s' "$out" | grep -q "Hello, Sailfin!"; then
+            echo "[ci][error] hello-world smoke failed: expected 'Hello, Sailfin!' in output" >&2
+            exit 1
+          fi
 
       - name: Verify compiler version matches tag
         shell: bash {0}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -225,13 +225,34 @@ jobs:
           echo "--- compiler/src/version.sfn ---"
           grep '__version_fallback__' compiler/src/version.sfn
 
-          # Final sanity check: the new version must appear in both files
+          # Update llms.txt's "> Version:" stamp. The drift guard
+          # (compiler/tests/e2e/test_llms_txt_sync.sh) asserts this line
+          # matches capsule.toml; without this rewrite every automated
+          # release tag fails that test by construction (the bump lands
+          # seconds before the build, with no human review in between) —
+          # exactly what broke the v0.7.0-alpha.30 cut. Content accuracy
+          # beyond the stamp remains a review concern on content PRs.
+          llms_matches=$(grep -c '^> Version:' llms.txt || true)
+          if [ "$llms_matches" -ne 1 ]; then
+            echo "::error::Expected exactly 1 '> Version:' line in llms.txt, found $llms_matches"
+            exit 1
+          fi
+          today=$(date -u +%Y-%m-%d)
+          sed -i "s/^> Version:.*/> Version: ${NEXT} | Updated: ${today}/" llms.txt
+          echo "--- llms.txt ---"
+          grep '^> Version:' llms.txt
+
+          # Final sanity check: the new version must appear in all three files
           if ! grep -q "\"${NEXT}\"" compiler/capsule.toml; then
             echo "::error::capsule.toml was not updated to version ${NEXT}"
             exit 1
           fi
           if ! grep -q "\"${NEXT}\"" compiler/src/version.sfn; then
             echo "::error::version.sfn was not updated to version ${NEXT}"
+            exit 1
+          fi
+          if ! grep -q "^> Version: ${NEXT} " llms.txt; then
+            echo "::error::llms.txt was not updated to version ${NEXT}"
             exit 1
           fi
 
@@ -241,7 +262,7 @@ jobs:
           TAG: ${{ steps.bump.outputs.tag }}
         run: |
           set -euo pipefail
-          git add compiler/capsule.toml compiler/src/version.sfn
+          git add compiler/capsule.toml compiler/src/version.sfn llms.txt
           git commit -m "chore(release): ${TAG#v}"
 
       - name: Rebase, tag & push

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # Sailfin Language Reference for LLMs
 
-> Version: 0.7.0-alpha.29 | Updated: 2026-06-10
+> Version: 0.7.0-alpha.30 | Updated: 2026-06-10
 > Source: https://github.com/SailfinIO/sailfin | Site: https://sailfin.dev
 
 Sailfin is a systems language with compile-time capability enforcement


### PR DESCRIPTION
## Summary
- **Slims the release gate for prerelease tags to build + package + smoke.** Release wall time climbed from ~19 min (May 21) to **1h44** (June 10) because every cut re-runs the full validation pipeline cold on both OSes — yet the release commit is a mechanical version bump on a `main` SHA that already passed full PR CI and push:main validation.
- **Fixes the bug that killed today's v0.7.0-alpha.30 cut** (linux leg failed after 56 min on `test_llms_txt_sync.sh`, 111/112): the new llms.txt drift guard asserts the `> Version:` stamp matches `compiler/capsule.toml`, but the automated bump rewrites capsule.toml seconds before the build — every release cut failed the guard **by construction**. `release.yml`'s bump step now stamps llms.txt too (same one-line guard + sanity check), and `release-branches.yml` adds llms.txt to `paths-ignore` so bump commits keep not triggering branch CI.
- **Restores green `main`**: the failed run's bump commit already landed on `main`, so `main` is currently red on the drift guard (llms.txt says alpha.29, capsule.toml says alpha.30). This PR re-stamps llms.txt to `0.7.0-alpha.30` — the guard passes again (verified locally).

## Gate changes
- New `build-package` mode on `actions/sailfin-build`: fetch seed + self-host build + package; skips the suite + its cache/prep steps. Existing modes untouched — `ci.yml` / `build-quality.yml` callers unaffected.
- `release-tag.yml`: prerelease tags (any `-` tag) take `build-package`; **stable GA tags keep the full suite**. Legs gain an end-to-end smoke (compile + link + run hello-world, output asserted) on top of the existing compiler-version + installer-payload verifications.
- `release-branches.yml` (**"CI (branch push)"** — the push:main/rc/beta suite runner): **stays on the full suite.** An earlier revision of this PR slimmed it too; Copilot review correctly flagged that it is the push:main suite runner (and the only macOS suite coverage on main pushes — build-quality.yml is Linux-only), not a release-cut workflow. Reverted in a5c60b6; only the llms.txt `paths-ignore` addition remains here.

## Why this is safe
- Every line of a release tag (minus the mechanical bump) was gated through full PR CI at merge time; `release-branches.yml` (full suite, both OSes) re-validates each push to `main`; `build-quality.yml` adds determinism/cache gates on Linux; `nightly-selfhost.yml` runs the 3-stage byte-identical self-host daily.
- The self-host build is itself the strongest single smoke a compiler has; the hello-world run proves the shipped binary compiles, links, and executes fresh code.
- Today's failure is the counter-example for the old gate, not for this one: the suite blocked a release on a docs-stamp check unrelated to the shipped artifacts, after an hour of compute.

## Recovery path for the failed alpha.30
After this merges: re-dispatch `release-tag.yml` (workflow_dispatch) with `tag=v0.7.0-alpha.30`. The workflow definition comes from `main` (slim gate, llms-stamp fix), checks out the existing tag, and packages it in ~10–20 min — no new version burn needed.

## Expected effect
Prerelease tag legs: 42–85+ min → **~10–20 min per leg** (build + package + smoke).

## Follow-ups (not in this PR)
- Version-agnostic test-bin cache identity (benefits the stable-tag full path).
- Parallelize the serial e2e-sh loop.

## Files Changed
- `.github/actions/sailfin-build/action.yml` — `build-package` mode
- `.github/workflows/release-tag.yml` — prerelease/stable mode switch + smoke step
- `.github/workflows/release-branches.yml` — llms.txt `paths-ignore` only (full suite retained per review)
- `.github/workflows/release.yml` — bump step stamps llms.txt `> Version:` line
- `llms.txt` — re-stamped to 0.7.0-alpha.30 (restores green main)

## Verification
- All YAML parses clean; `bash compiler/tests/e2e/test_llms_txt_sync.sh` passes locally after the re-stamp.
- Slim-path live validation: the alpha.30 re-dispatch above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013jXbNFkiWSaZncHsyx8r9n