### PR TITLE
ci(check-fast): revert warm-up retry loop to bare whole-tree invocation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,30 +121,6 @@ jobs:
           # runaway dies as a clean non-zero exit instead, and time -v
           # records the peak RSS either way.
           ulimit -v 8388608
-          # Self-warming invocation (#1245): the seed checker's
-          # resolver staging + per-file analysis accumulate memory
-          # with no reset, so a fully COLD check of this tree —
-          # whole-tree or even single-file with a large import
-          # closure — exceeds the 8GB cap. Staged artifacts persist
-          # incrementally across runs (including crashed ones), so a
-          # bounded warm-up retry loop on the widest-closure file
-          # converges in 1-2 attempts and warms build/sailfin for
-          # the real check (measured cold: warm-up converges on
-          # attempt 2; warm whole-tree peaks ~5GB, well under cap).
-          # Warm-up failures are tolerated — if it never converges,
-          # the gating whole-tree check below fails with a clean
-          # capped exit + time -v stats instead of killing the
-          # runner VM. Revert to a bare whole-tree invocation once a
-          # seed containing the #1245 fix is pinned.
-          for attempt in 1 2 3 4; do
-            echo "[check-fast] warm-up attempt $attempt"
-            if SAILFIN_USE_ARENA=1 timeout 300 \
-                 build/seed/bin/sailfin check compiler/src/cli_main.sfn \
-                 >/dev/null 2>&1; then
-              echo "[check-fast] warm-up converged on attempt $attempt"
-              break
-            fi
-          done
           SAILFIN_USE_ARENA=1 /usr/bin/time -v \
             build/seed/bin/sailfin check compiler/src/
 


### PR DESCRIPTION
## Summary
- Removes the bounded warm-up retry loop (4 attempts on `cli_main.sfn`) from the `check-fast` job, reverting the #1243 mitigation to a single bare `check compiler/src/` invocation.
- Removes the "Revert … once a seed containing the #1245 fix is pinned" comment block — that condition is now met.
- Keeps the `ulimit -v 8388608` cap, `/usr/bin/time -v` instrumentation, and `SAILFIN_USE_ARENA=1`.

Closes #1248

## Seed-freshness precheck (Phase 1.5)
Both required predecessors verified in the pinned seed via SHA ancestry (happy path, no content fallback needed):
- #1246 → PR #1249, merge `e37de773` — **ancestor of `v0.7.0-alpha.31`** ✓
- #1247 → PR #1251, merge `b80d3779` — **ancestor of `v0.7.0-alpha.31`** ✓
- `.seed-version` = `0.7.0-alpha.31` (pinned by #1257, which was cut specifically to carry these fixes; measured whole-tree seed check: ~730MB peak / ~53s)

## Acceptance Criteria
- [x] `check-fast` runs a single `check compiler/src/` over a fresh checkout and passes green on a cold CI runner — **validated: this PR's `check-fast` job passed in ~70s (21:07:33 → 21:08:43 UTC)**
- [x] `.seed-version` confirmed to contain the #1246 + #1247 fixes (merge-base ancestry above)
- [x] No warm-up/retry loop remains in the job

## Verification
```bash
cat .seed-version
# 0.7.0-alpha.31
grep -n "warm-up\|attempt" .github/workflows/ci.yml
# no hits
git merge-base --is-ancestor e37de773 v0.7.0-alpha.31  # exit 0 (#1246 in seed)
git merge-base --is-ancestor b80d3779 v0.7.0-alpha.31  # exit 0 (#1247 in seed)
python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"  # parses OK
```

## Files Changed
- `.github/workflows/ci.yml` — `check-fast` job only (24 lines removed, nothing added)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UuCNxvhSZvwYhAN7Q7M4me