### PR TITLE
docs(build): document workspace.lock ownership, precedence, seed gate

### DIFF
--- a/docs/proposals/build-architecture.md
+++ b/docs/proposals/build-architecture.md
@@ -730,7 +730,8 @@ sfn build
  └─ driver::build_capsule(capsule_ref)
      ├─ manifest::load(path) → Manifest
      ├─ resolver::resolve(manifest) → ResolvedGraph
-     │    (workspace → lockfile → cache → registry, in that order)
+     │    (workspace → workspace.lock → capsule.lock → cache → registry,
+     │     in that order)
      ├─ planner::plan(graph) → BuildPlan
      │    (topologically ordered module list + cache keys)
      ├─ executor::execute(plan) → Artifacts
@@ -750,6 +751,27 @@ Key points:
 
 - The driver is **one process**. Modules share parsed imports, the arena,
   and the cache.
+- **Resolution order** (shipped: #1048 capsule.lock, #1071 workspace.lock):
+  workspace siblings resolve first and short-circuit — a lockfile can never
+  redirect an intra-workspace edge (e.g. compiler → runtime). For external
+  deps, a root `workspace.lock` pin wins over the consuming capsule's
+  `capsule.lock`, which wins over the `capsule.toml` version range; then
+  the user cache, then the registry. Absent lockfiles are a no-op —
+  resolution is byte-identical to the pre-lockfile behaviour.
+- **Lockfile ownership**: the workspace root (or a standalone binary
+  capsule's root) owns the lockfile — `sfn lock` (#1070) writes
+  `workspace.lock` at the workspace root only. Library capsules do **not**
+  commit lockfiles; their version *ranges* live in `capsule.toml`, and the
+  consuming root decides the pins. (Same rule as Cargo/npm: applications
+  commit lockfiles, libraries don't.)
+- **Seed gate (self-host hazard)**: `make compile` runs `<seed> build -p
+  compiler`, so the *pinned seed's* resolver reads any committed root
+  `workspace.lock` during self-host. Do **not** commit a root
+  `workspace.lock` until a seed embedding the #1071 consumer is pinned —
+  a pre-consumer seed would either choke on or silently ignore the file,
+  and the two-pass seedcheck would diverge from the first pass. Satisfied
+  as of seed `v0.7.0-alpha.31` (contains #1071); committing the root
+  lockfile itself is #1050.
 - Each module's work is a pure function from `(source_hash, dep_hashes,
   flags)` to `(sfn-asm, layout-manifest, ll)`. Pure inputs → cacheable.
 - Parallelism is opt-in per phase. Parser/typecheck can be parallel once

--- a/docs/status.md
+++ b/docs/status.md
@@ -133,6 +133,7 @@ doc, or `docs/runtime_architecture.md`, not here.
 | `sfn test` | **Shipped** | Discovery, `-k`/`--tag` filtering (#849), lifecycle hooks (#975, ordering only), snapshots + `--update-snapshots` (#977), `--jobs N` parallel runner (#1236), per-test binary cache (#1230/#1233) |
 | `sfn vet` / `sfn lsp` / `sfn doc` / `sfn fix` | Planned | See `docs/proposals/tooling.md` |
 | Package registry (`sfn init/add/publish`) | Shipped | Default registry `pkg.sfn.dev`; `SFN_REGISTRY` / `sfn config set registry` override |
+| `workspace.lock` (`sfn lock` write + resolver consume) | **Shipped** | Explicit `sfn lock` writes the root lockfile (#1070); resolver prefers `workspace → workspace.lock → capsule.lock → cache → registry` for external deps, sibling-first untouched (#1071). Roots own lockfiles; library capsules don't commit them. Committing the root `workspace.lock` is #1050, gated on a seed embedding #1071 (satisfied at `v0.7.0-alpha.31`) |
 | Notebook support | Not started | Post-1.0 |
 
 ## Print API (Current)


### PR DESCRIPTION
## Summary
- Spell out the full resolution order in the driver call graph (`docs/proposals/build-architecture.md:733`): `workspace → workspace.lock → capsule.lock → cache → registry`.
- Add "Key points" entries recording the lockfile-ownership rule (workspace/binary roots commit a lock; library capsules don't) and the self-host seed gate: no committed root `workspace.lock` until a seed embedding the #1071 consumer is pinned — noted as satisfied at `v0.7.0-alpha.31`.
- Add the `docs/status.md` Feature Matrix row for `sfn lock` write (#1070) + resolver consumption (#1071), with the #1050 gate.

Closes #1072

## Acceptance Criteria
- [x] `docs/proposals/build-architecture.md` and `docs/status.md` reflect the workspace.lock outcome and the seed gate.
- [x] No `.sfn` changes; `make check` unaffected.

## Verification
```bash
$ grep -n "workspace.lock" docs/proposals/build-architecture.md docs/status.md
docs/proposals/build-architecture.md:733:     │    (workspace → workspace.lock → capsule.lock → cache → registry,
docs/proposals/build-architecture.md:754:- **Resolution order** (shipped: #1048 capsule.lock, #1071 workspace.lock):
docs/proposals/build-architecture.md:763:  `workspace.lock` at the workspace root only. Library capsules do **not**
docs/proposals/build-architecture.md:769:  `workspace.lock` during self-host. Do **not** commit a root
docs/status.md:136:| `workspace.lock` (`sfn lock` write + resolver consume) | **Shipped** | ...

$ git merge-base --is-ancestor 297cec2 v0.7.0-alpha.31 && echo "consumer in seed"
consumer in seed   # PR #1177 (#1071) is in the pinned seed — gate satisfied
```

## Files Changed
- `docs/proposals/build-architecture.md` — resolution-order line + ownership/seed-gate key points
- `docs/status.md` — workspace.lock row in the Feature Matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014L4fYvciLdZHrpkBQqQba9

---
_Generated by [Claude Code](https://claude.ai/code/session_014L4fYvciLdZHrpkBQqQba9)_