### PR TITLE
fix(lowering): promote channel-send/spawn-capture escapes in drop emission

### DIFF
--- a/compiler/src/llvm/expression_lowering/native/core_scopes.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_scopes.sfn
@@ -25,7 +25,7 @@ import {
     starts_with,
     trim_text
 } from "../../utils";
-import { bindings_find_parameter_binding, bindings_mark_local_consumed } from "../bindings";
+import { bindings_find_parameter_binding } from "../bindings";
 import { find_call_site } from "./core_calls";
 import { parse_member_access } from "./core_parse";
 import { sanitize_symbol } from "./core_text";
@@ -272,10 +272,58 @@ fn promote_local_to_rc(locals: LocalBinding[], name: string) -> LocalBinding[] {
 // correctness bug. Under-promotion would be a cross-thread UAF, so ties
 // break toward promoting. General move/ownership enforcement (Affine /
 // Linear) remains post-1.0 and is out of scope here.
+// Mark ONLY the innermost (last) binding matching `name` as consumed,
+// mirroring the binding `find_local_binding` resolves and the one
+// `promote_local_to_rc` rewrites. `bindings_mark_local_consumed` (the
+// helper the return path uses) flips every same-named binding, which
+// would wrongly suppress the drop of an outer-scope local shadowed by
+// the escaping one — the outer value never crossed the boundary and its
+// owner-drop must still fire.
+fn _mark_last_local_consumed(locals: LocalBinding[], name: string) -> LocalBinding[] {
+    let mut target_index: int = -1;
+    let mut scan: int = locals.length;
+    loop {
+        if scan <= 0 { break; }
+        scan -= 1;
+        if locals[scan].name == name {
+            target_index = scan;
+            break;
+        }
+    }
+    if target_index < 0 { return locals; }
+    let mut result: LocalBinding[] = [];
+    let mut index: int = 0;
+    loop {
+        if index >= locals.length { break; }
+        let entry = locals[index];
+        let mut updated = entry;
+        if index == target_index {
+            updated = LocalBinding {
+                name: entry.name,
+                pointer: entry.pointer,
+                llvm_type: entry.llvm_type,
+                type_annotation: entry.type_annotation,
+                ownership: entry.ownership,
+                consumed: true,
+                scope_id: entry.scope_id,
+                scope_depth: entry.scope_depth,
+                allocation_kind: entry.allocation_kind,
+                init_sentinel: entry.init_sentinel
+            };
+        }
+        result.push(updated);
+        index += 1;
+    }
+    return result;
+}
+
 // Promote one named local across an escape boundary: heap-typed, non-borrow
 // bindings flip `arena` → `rc` and are marked consumed (drop suppressed at
 // every scope-exit site). Unknown names and non-heap bindings are no-ops, so
 // callers can feed arbitrary identifier tokens through this filter.
+// Both the promotion and the consumption target the innermost (last)
+// matching binding — the same one `find_local_binding` resolves — so a
+// shadowed outer local keeps its own allocation kind AND its owner drop.
 fn promote_escaping_local(locals: LocalBinding[], name: string) -> LocalBinding[] {
     let binding = find_local_binding(locals, name);
     if binding == null { return locals; }
@@ -284,7 +332,7 @@ fn promote_escaping_local(locals: LocalBinding[], name: string) -> LocalBinding[
         if binding.ownership.variant == "Borrow" { return locals; }
     }
     let promoted = promote_local_to_rc(locals, name);
-    return bindings_mark_local_consumed(promoted, name);
+    return _mark_last_local_consumed(promoted, name);
 }
 
 // Collect every identifier token in `text`, skipping string-literal

--- a/compiler/src/llvm/expression_lowering/native/core_scopes.sfn
+++ b/compiler/src/llvm/expression_lowering/native/core_scopes.sfn
@@ -7,6 +7,7 @@
 // `infer_borrow_base_scope`, lifetime region creation/release, and scope ID
 // construction (`format_root_scope_id`, `make_child_scope_id`).
 import { NativeEnum, NativeStruct } from "../../../native_ir";
+import { char_at, substring } from "../../../string_utils";
 import {
     LLVMOperand,
     LifetimeRegionMetadata,
@@ -17,9 +18,18 @@ import {
     ScopeMetadata,
     StructLiteralField
 } from "../../types";
-import { starts_with } from "../../utils";
-import { bindings_find_parameter_binding } from "../bindings";
+import {
+    is_identifier_part_char,
+    is_identifier_start_char,
+    is_simple_identifier,
+    starts_with,
+    trim_text
+} from "../../utils";
+import { bindings_find_parameter_binding, bindings_mark_local_consumed } from "../bindings";
+import { find_call_site } from "./core_calls";
+import { parse_member_access } from "./core_parse";
 import { sanitize_symbol } from "./core_text";
+import { is_heap_type } from "./core_type_mapping";
 
 fn find_parameter_binding(bindings: ParameterBinding[], name: string) -> ParameterBinding? {
     return bindings_find_parameter_binding(bindings, name);
@@ -227,6 +237,190 @@ fn promote_local_to_rc(locals: LocalBinding[], name: string) -> LocalBinding[] {
         index += 1;
     }
     return result;
+}
+
+// ── M4 (#1094): escape promotion at channel-send / spawn-capture ──────
+//
+// M1.5.5 (#329) promotes owned heap locals to `rc` only at function-return
+// boundaries; `docs/runtime_audit.md` §M1.5 explicitly deferred the
+// closure-capture and channel-send boundaries until those features landed.
+// With the M4 scheduler (#1090) and channels (#1091) shipped, a value moved
+// across one of these boundaries crosses *threads*: the sender's scope-exit
+// drop (or a future arena rewind) would free memory the receiver/worker
+// still reads — a cross-thread use-after-free.
+//
+// The rule mirrors the return-boundary precedent in
+// `lower_return_instruction` exactly: the escaping local is promoted
+// (`arena` → `rc`, via `promote_local_to_rc`) *and* marked consumed, so
+// `emit_scope_drops` / `emit_guarded_scope_drops` skip it. Ownership has
+// transferred across the boundary — the receiver/worker owns the value now,
+// and the sender must never release it. Non-heap (`is_heap_type == false`)
+// and borrowed bindings are never touched.
+//
+// Detection is deliberately conservative and textual:
+//   - spawn-capture: when the expression contains the bare `spawn` keyword
+//     outside string literals (`spawn fn() -> int { ... }`,
+//     `spawn:int worker`, `parallel [spawn a(), spawn b()]`), every
+//     identifier token in the expression that names a heap-typed local is
+//     treated as escaping. This covers raw lambda-body capture text and the
+//     lifted `<closure_pair ... captures=name:type;...>` marker form alike.
+//   - channel-send: for `ch.send(args)` where `ch` is a `channel`-typed
+//     local, only the argument text escapes.
+//
+// Over-promotion (an identifier mentioned near a spawn that does not really
+// escape) suppresses a release that would otherwise fire — a leak, not a
+// correctness bug. Under-promotion would be a cross-thread UAF, so ties
+// break toward promoting. General move/ownership enforcement (Affine /
+// Linear) remains post-1.0 and is out of scope here.
+// Promote one named local across an escape boundary: heap-typed, non-borrow
+// bindings flip `arena` → `rc` and are marked consumed (drop suppressed at
+// every scope-exit site). Unknown names and non-heap bindings are no-ops, so
+// callers can feed arbitrary identifier tokens through this filter.
+fn promote_escaping_local(locals: LocalBinding[], name: string) -> LocalBinding[] {
+    let binding = find_local_binding(locals, name);
+    if binding == null { return locals; }
+    if !is_heap_type(binding.llvm_type) { return locals; }
+    if binding.ownership != null {
+        if binding.ownership.variant == "Borrow" { return locals; }
+    }
+    let promoted = promote_local_to_rc(locals, name);
+    return bindings_mark_local_consumed(promoted, name);
+}
+
+// Collect every identifier token in `text`, skipping string-literal
+// contents and member-access fields (a token immediately preceded by `.`
+// names a field/method, not a local — this also keeps `process.spawn(...)`
+// from registering a bare `spawn` keyword token). Longer identifiers that
+// merely contain a keyword (`spawn_with_env`, `respawn`) stay single
+// tokens, so word-boundary checks against the result are exact.
+fn _escape_scan_identifier_tokens(text: string) -> string[] {
+    let mut tokens: string[] = [];
+    let mut in_double: boolean = false;
+    let mut in_single: boolean = false;
+    let mut escape_next: boolean = false;
+    let mut index: int = 0;
+    loop {
+        if index >= text.length { break; }
+        let ch = char_at(text, index);
+        if in_double {
+            if escape_next { escape_next = false; } else if ch == "\\" {
+                escape_next = true;
+            } else if ch == "\"" { in_double = false; }
+            index += 1;
+            continue;
+        }
+        if in_single {
+            if escape_next { escape_next = false; } else if ch == "\\" {
+                escape_next = true;
+            } else if ch == "'" { in_single = false; }
+            index += 1;
+            continue;
+        }
+        if ch == "\"" {
+            in_double = true;
+            index += 1;
+            continue;
+        }
+        if ch == "'" {
+            in_single = true;
+            index += 1;
+            continue;
+        }
+        if is_identifier_start_char(ch) {
+            let start = index;
+            loop {
+                if index >= text.length { break; }
+                if !is_identifier_part_char(char_at(text, index)) { break; }
+                index += 1;
+            }
+            let mut is_member_field: boolean = false;
+            if start > 0 {
+                if char_at(text, start - 1) == "." { is_member_field = true; }
+            }
+            if !is_member_field {
+                tokens.push(substring(text, start, index));
+            }
+            continue;
+        }
+        index += 1;
+    }
+    return tokens;
+}
+
+// When `trimmed` is a channel send — `<base>.send(<args>)` with `<base>` a
+// simple identifier naming a `channel`-typed local or parameter (the same
+// two bases the #1091 call-resolution channel-method branch accepts) —
+// return the raw argument text. Returns the empty string for every other
+// shape.
+fn _channel_send_arguments_text(trimmed: string, locals: LocalBinding[], bindings: ParameterBinding[]) -> string {
+    if trimmed.length == 0 { return ""; }
+    if substring(trimmed, trimmed.length - 1, trimmed.length) != ")" {
+        return "";
+    }
+    let call_index = find_call_site(trimmed);
+    if call_index < 0 { return ""; }
+    let target = trim_text(substring(trimmed, 0, call_index));
+    let member = parse_member_access(target);
+    if !member.success { return ""; }
+    if member.field != "send" { return ""; }
+    let base = trim_text(member.base);
+    if !is_simple_identifier(base) { return ""; }
+    let mut base_annotation: string = "";
+    let binding = find_local_binding(locals, base);
+    if binding != null { base_annotation = binding.type_annotation; } else {
+        let parameter = bindings_find_parameter_binding(bindings, base);
+        if parameter != null { base_annotation = parameter.type_annotation; }
+    }
+    if base_annotation != "channel" { return ""; }
+    return substring(trimmed, call_index + 1, trimmed.length - 1);
+}
+
+// Public entry point: apply the conservative escape rule above to one
+// statement / initializer expression, returning the (possibly) rewritten
+// locals. `bindings` is consulted only to recognise a channel-typed
+// *parameter* base (`fn producer(ch: channel) { ch.send(msg); }`); the
+// promotion itself always targets locals — parameters are owned by the
+// caller's frame and already excluded from `emit_scope_drops`. Call sites:
+// `lower_expression_statement` (bare expression statements like
+// `ch.send(msg);` / `spawn worker(msg);`) and `lower_let_instruction`
+// (initializers like `let f = spawn fn() ... ;`).
+fn promote_escaping_locals_for_boundaries(expression: string, locals: LocalBinding[], bindings: ParameterBinding[]) -> LocalBinding[] {
+    let trimmed = trim_text(expression);
+    if trimmed.length == 0 { return locals; }
+    let tokens = _escape_scan_identifier_tokens(trimmed);
+    let mut has_spawn: boolean = false;
+    let mut scan: int = 0;
+    loop {
+        if scan >= tokens.length { break; }
+        if tokens[scan] == "spawn" {
+            has_spawn = true;
+            break;
+        }
+        scan += 1;
+    }
+    if has_spawn {
+        // Spawn-capture boundary: every identifier in the expression is
+        // conservatively treated as escaping into the worker task.
+        let mut current = locals;
+        let mut index: int = 0;
+        loop {
+            if index >= tokens.length { break; }
+            current = promote_escaping_local(current, tokens[index]);
+            index += 1;
+        }
+        return current;
+    }
+    let send_arguments = _channel_send_arguments_text(trimmed, locals, bindings);
+    if send_arguments.length == 0 { return locals; }
+    let argument_tokens = _escape_scan_identifier_tokens(send_arguments);
+    let mut current_locals = locals;
+    let mut argument_index: int = 0;
+    loop {
+        if argument_index >= argument_tokens.length { break; }
+        current_locals = promote_escaping_local(current_locals, argument_tokens[argument_index]);
+        argument_index += 1;
+    }
+    return current_locals;
 }
 
 fn append_local_binding(values: LocalBinding[], value: LocalBinding) -> LocalBinding[] {

--- a/compiler/src/llvm/expression_lowering/native/statement.sfn
+++ b/compiler/src/llvm/expression_lowering/native/statement.sfn
@@ -60,6 +60,7 @@ import {
     find_local_binding,
     infer_borrow_base_scope,
     make_lifetime_region_metadata,
+    promote_escaping_locals_for_boundaries,
     promote_local_to_rc
 } from "./core_scopes";
 import { is_heap_type } from "./core_type_mapping";
@@ -365,6 +366,13 @@ fn lower_expression_statement(function_name: string, instruction: NativeInstruct
             current_bindings = mark_parameter_consumed(current_bindings, consumption.name);
         }
     }
+    // M4 (#1094): conservative escape promotion at channel-send /
+    // spawn-capture boundaries (`ch.send(msg);`, `spawn worker(msg);`).
+    // Mirrors the M1.5.5 return-boundary rule in
+    // `lower_return_instruction`: the escaping heap local is promoted to
+    // `rc` and marked consumed so the sender's scope-exit drops skip it —
+    // the receiver/worker thread owns the value now.
+    current_locals = promote_escaping_locals_for_boundaries(expression, current_locals, current_bindings);
     return ExpressionStatementResult {
         lines: current_lines,
         temp_index: current_temp,

--- a/compiler/src/llvm/lowering/instructions_let.sfn
+++ b/compiler/src/llvm/lowering/instructions_let.sfn
@@ -5,7 +5,7 @@ import { NativeFunction, NativeInstruction, NativeSourceSpan } from "../../nativ
 import { index_of } from "../../string_utils";
 import { analyze_value_ownership, detect_borrow_conflicts, lower_expression } from "../expression_lowering/native/core";
 import { coerce_operand_to_type } from "../expression_lowering/native/core_operands";
-import { append_local_binding } from "../expression_lowering/native/core_scopes";
+import { append_local_binding, promote_escaping_locals_for_boundaries } from "../expression_lowering/native/core_scopes";
 import { is_heap_type } from "../expression_lowering/native/core_type_mapping";
 import { detect_suspension_conflicts } from "../expression_lowering/native/statement_suspension";
 import { map_local_type } from "../expression_lowering/native/statement_type_mapping";
@@ -264,6 +264,13 @@ fn lower_let_instruction(function: NativeFunction, instruction: NativeInstructio
         string_constants = lowered.string_constants;
         let inferred = _infer_field_constants_from_lines(current_lines, _pre_expr_line_count);
         string_constants = merge_string_constants(string_constants, inferred);
+        // M4 (#1094): conservative escape promotion at channel-send /
+        // spawn-capture boundaries in the initializer (`let f = spawn
+        // fn() ... ;`, `let ok = ch.send(msg);`). Mirrors the M1.5.5
+        // return-boundary rule: escaping heap locals are promoted to `rc`
+        // and marked consumed so the sender's scope-exit drops skip them —
+        // the receiver/worker thread owns the value now.
+        current_locals = promote_escaping_locals_for_boundaries(instruction.value, current_locals, current_bindings);
     }
 
     if debug_lowering {

--- a/compiler/tests/e2e/test_escape_promotion_boundaries.sh
+++ b/compiler/tests/e2e/test_escape_promotion_boundaries.sh
@@ -1,0 +1,283 @@
+#!/usr/bin/env bash
+# E2E regression test for channel-send / spawn-capture escape promotion
+# (issue #1094, M4 follow-up to M1.5.5 / #329).
+#
+# Drop emission promotes owned heap locals to "rc" only at function-return
+# boundaries (M1.5.5). Channel-send and spawn-capture move owned data
+# ACROSS threads; without escape promotion at those boundaries the
+# sender's scope-exit drop would free data the receiver/worker still
+# reads — a cross-thread use-after-free.
+#
+# Coverage:
+#   1. IR: a heap string sent on a channel from inside a loop body (the
+#      loop-body scope closes BEFORE the receive) must not be released at
+#      the sender's scope exit — the emitted module contains no
+#      `call ... @sfn_rc_release` (the declare is unconditional and OK).
+#   2. IR: same shape routed through a `channel`-typed *parameter* base
+#      (`fn producer(ch: channel)`), the second base form the #1091
+#      channel-method resolution accepts.
+#   3. Runtime: a producer running on a REAL pthread sends a heap struct
+#      through a channel boundary; the consumer dereferences it after the
+#      producer's frame (and its drop sites) are gone. Run plain, and —
+#      when the host clang has the ASAN runtime — again under
+#      `-fsanitize=address`, where any sender-side release would surface
+#      as a heap-use-after-free.
+#
+#      The harness stubs the channel with a single-slot C mailbox and
+#      `sfn_rc_release` with `free`: the compiler-emitted channel calls
+#      (`sfn_channel_receive`, 1-arg create) do not yet match the
+#      `runtime/sfn/concurrency/channel.sfn` ABI (`sfn_channel_recv`,
+#      2-arg create), so the real runtime cannot link against emitted
+#      programs — channel SEMANTICS are not under test here, the
+#      sender-side drop behaviour is.
+#
+# The per-rule unit coverage (promotion + consumption + drop suppression,
+# spawn-capture text forms, hygiene cases) lives in
+# compiler/tests/unit/escape_promotion_boundaries_test.sfn.
+#
+# Usage:
+#   compiler/tests/e2e/test_escape_promotion_boundaries.sh <compiler-binary>
+
+set -euo pipefail
+
+BINARY="${1:?usage: test_escape_promotion_boundaries.sh <compiler-binary>}"
+BINARY="$(realpath "$BINARY")"
+PASS=0
+FAIL=0
+
+# GNU `timeout` on linux CI; `gtimeout` via coreutils on macOS; none → bare.
+TIMEOUT_PREFIX=""
+if command -v timeout >/dev/null 2>&1; then
+    TIMEOUT_PREFIX="timeout 30"
+elif command -v gtimeout >/dev/null 2>&1; then
+    TIMEOUT_PREFIX="gtimeout 30"
+fi
+
+SCRATCH="$(mktemp -d -t sfn-escape-boundaries-XXXXXX)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+run_test() {
+    local name="$1"
+    shift
+    if "$@"; then
+        echo "[test] PASS: $name"
+        PASS=$((PASS + 1))
+    else
+        echo "[test] FAIL: $name"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# Emit LLVM IR for a snippet; assert one symbol IS present (proves the
+# boundary actually lowered) and that no `call` to the forbidden symbol
+# is emitted (the suppressed sender-side release). The bare `declare` of
+# sfn_rc_release is part of the unconditional helper preamble and allowed.
+assert_ir_present_and_no_call() {
+    local label="$1"
+    local source="$2"
+    local expected_symbol="$3"
+    local forbidden_call="$4"
+
+    local src_path="$SCRATCH/${label}.sfn"
+    local out_path="$SCRATCH/${label}.ll"
+    local log_path="$SCRATCH/${label}.log"
+    printf '%s\n' "$source" > "$src_path"
+
+    local rc=0
+    ( cd "$SCRATCH" && ${TIMEOUT_PREFIX} "$BINARY" emit -o "$out_path" llvm "$src_path" ) \
+        > "$log_path" 2>&1 || rc=$?
+
+    if [ "$rc" -ne 0 ]; then
+        echo "[test]   emit llvm of ${label}.sfn failed (rc=$rc)" >&2
+        sed 's/^/[test]     /' "$log_path" >&2
+        return 1
+    fi
+
+    if ! grep -q "$expected_symbol" "$out_path" 2>/dev/null; then
+        echo "[test]   IR for ${label}.sfn does not contain '${expected_symbol}'" >&2
+        grep -E "call|declare" "$out_path" | sed 's/^/[test]     /' >&2
+        return 1
+    fi
+
+    if grep -E "call .*@${forbidden_call}\(" "$out_path" >/dev/null 2>&1; then
+        echo "[test]   IR for ${label}.sfn must NOT call '@${forbidden_call}' (sender-side release of an escaped value)" >&2
+        grep -E "call .*@${forbidden_call}\(" "$out_path" | sed 's/^/[test]     /' >&2
+        return 1
+    fi
+
+    return 0
+}
+
+# ── (1) IR: send from a closing scope — no sender-side release ────────
+#
+# `msg` is a heap string built inside the loop body; the loop-body scope
+# closes (running its drop site) before `ch.receive()`. The escaped value
+# must not be released there.
+test_channel_send_suppresses_sender_drop_ir() {
+    assert_ir_present_and_no_call "send_scope_exit" \
+'fn main() ![io] {
+    let ch = channel(4);
+    let mut i: int = 0;
+    loop {
+        if i >= 1 { break; }
+        let msg = "hello" + " world";
+        ch.send(msg);
+        i += 1;
+    }
+    let got = ch.receive();
+}' \
+        "sfn_channel_send" \
+        "sfn_rc_release"
+}
+
+# ── (2) IR: channel-typed parameter base — same suppression ──────────
+test_channel_param_base_suppresses_sender_drop_ir() {
+    assert_ir_present_and_no_call "send_param_base" \
+'fn producer(ch: channel) ![io] {
+    let msg = "hello" + " world";
+    ch.send(msg);
+}
+fn main() ![io] {
+    let ch = channel(4);
+    producer(ch);
+    let got = ch.receive();
+}' \
+        "sfn_channel_send" \
+        "sfn_rc_release"
+}
+
+# ── (3) Runtime: cross-thread round trip (plain + best-effort ASAN) ───
+test_cross_thread_round_trip() {
+    local clang_bin
+    clang_bin="${CLANG:-clang}"
+    if ! command -v "$clang_bin" >/dev/null 2>&1; then
+        echo "[test]   clang not available — skipping linked roundtrip (IR assertions still pin the contract)"
+        return 0
+    fi
+
+    local src_path="$SCRATCH/escape_payload.sfn"
+    local ll_path="$SCRATCH/escape_payload.ll"
+    cat > "$src_path" <<'SAILFIN'
+struct Payload {
+    x: int;
+    y: int;
+}
+
+fn produce(ch: channel) ![io] {
+    let p = Payload { x: 6, y: 7 };
+    ch.send(p);
+}
+
+fn consume(ch: channel) -> int ![io] {
+    let got: Payload = ch.receive();
+    return got.x * got.y;
+}
+SAILFIN
+
+    # Emit with a RELATIVE source path: the module suffix (and therefore
+    # the `produce__escape_payload` symbol names the harness binds to) is
+    # derived from the path as given, not the basename.
+    local rc=0
+    ( cd "$SCRATCH" && ${TIMEOUT_PREFIX} "$BINARY" emit -o escape_payload.ll llvm escape_payload.sfn ) \
+        > "$SCRATCH/escape_payload.log" 2>&1 || rc=$?
+    if [ "$rc" -ne 0 ]; then
+        echo "[test]   emit llvm of escape_payload.sfn failed (rc=$rc)" >&2
+        sed 's/^/[test]     /' "$SCRATCH/escape_payload.log" >&2
+        return 1
+    fi
+
+    # Module-suffixed symbol names derive from the fixture basename.
+    local harness="$SCRATCH/harness.c"
+    cat > "$harness" <<'CHARNESS'
+/* Cross-thread no-UAF demonstration for issue #1094.
+ *
+ * The producer runs on a real pthread: it heap-allocates a Payload
+ * (via the ASAN-instrumented sfn_alloc_struct stub below) and sends it
+ * across the channel boundary; its frame — and every sender-side drop
+ * site — is gone by the time the main thread consumes. If drop emission
+ * ever releases the escaped value at the producer's scope exit again,
+ * `sfn_rc_release` (stubbed as free) frees the block and the consumer's
+ * dereference becomes a heap-use-after-free that ASAN reports (and the
+ * plain run computes from freed memory).
+ *
+ * The single-slot mailbox stands in for the real channel runtime: the
+ * compiler-emitted channel ABI does not yet link against
+ * runtime/sfn/concurrency/channel.sfn (symbol/arity mismatch), and
+ * channel semantics are not under test — sender-side drops are.
+ */
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+extern void produce__escape_payload(void *ch);
+extern long consume__escape_payload(void *ch);
+
+void sfn_type_register(void *desc) { (void)desc; }
+void sailfin_runtime_mark_persistent(void *ptr) { (void)ptr; }
+void *sfn_alloc_struct(long n) { return calloc(1, (size_t)n); }
+void sfn_rc_release(void *p) { free(p); }
+
+static void *slot = NULL;
+void sfn_channel_send(void *ch, void *elem) { (void)ch; slot = elem; }
+void *sfn_channel_receive(void *ch) { (void)ch; return slot; }
+
+static void *producer_thread(void *ch) {
+    produce__escape_payload(ch);
+    return NULL;
+}
+
+int main(void) {
+    void *ch = (void *)0x1;
+    pthread_t t;
+    if (pthread_create(&t, NULL, producer_thread, ch) != 0) return 90;
+    if (pthread_join(t, NULL) != 0) return 91;
+    long got = consume__escape_payload(ch);
+    if (got != 42) {
+        fprintf(stderr, "consumer read %ld, want 42 (payload corrupted or freed)\n", got);
+        return 1;
+    }
+    return 0;
+}
+CHARNESS
+
+    # Plain link + run — must always work.
+    local bin="$SCRATCH/roundtrip"
+    if ! "$clang_bin" -Wno-override-module "$harness" "$ll_path" \
+            -o "$bin" -lpthread 2>"$SCRATCH/clang.log"; then
+        echo "[test]   clang failed to link the roundtrip harness:" >&2
+        sed 's/^/[test]     /' "$SCRATCH/clang.log" >&2
+        return 1
+    fi
+    if ! ${TIMEOUT_PREFIX} "$bin"; then
+        echo "[test]   plain roundtrip failed (payload did not survive the sender's scope exit)" >&2
+        return 1
+    fi
+
+    # ASAN link + run — best effort: some hosts ship clang without the
+    # compiler-rt ASAN archives. A link failure is a skip, not a FAIL;
+    # an ASAN *runtime* failure (use-after-free) is a real FAIL.
+    local bin_asan="$SCRATCH/roundtrip_asan"
+    if "$clang_bin" -fsanitize=address -Wno-override-module "$harness" "$ll_path" \
+            -o "$bin_asan" -lpthread 2>"$SCRATCH/clang_asan.log"; then
+        if ! ${TIMEOUT_PREFIX} "$bin_asan"; then
+            echo "[test]   ASAN roundtrip failed — sender-side release of the escaped payload" >&2
+            return 1
+        fi
+        echo "[test]   ASAN roundtrip clean"
+    else
+        echo "[test]   ASAN runtime not available on this host — plain roundtrip still passed"
+    fi
+
+    return 0
+}
+
+# ── Run ───────────────────────────────────────────────────────────────
+run_test "IR: channel send from closing scope emits no sender-side rc_release call (#1094)" \
+    test_channel_send_suppresses_sender_drop_ir
+run_test "IR: channel-typed parameter base also suppresses the sender drop (#1094)" \
+    test_channel_param_base_suppresses_sender_drop_ir
+run_test "runtime: payload survives the producer thread's scope exit (plain + ASAN best-effort)" \
+    test_cross_thread_round_trip
+
+echo "[test] escape-promotion boundaries: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/compiler/tests/e2e/test_escape_promotion_boundaries.sh
+++ b/compiler/tests/e2e/test_escape_promotion_boundaries.sh
@@ -253,17 +253,41 @@ CHARNESS
         return 1
     fi
 
-    # ASAN link + run — best effort: some hosts ship clang without the
-    # compiler-rt ASAN archives. A link failure is a skip, not a FAIL;
-    # an ASAN *runtime* failure (use-after-free) is a real FAIL.
+    # ASAN link + run — best effort, twice over:
+    #   - some hosts ship clang without the compiler-rt ASAN archives
+    #     (link failure → skip);
+    #   - ASAN reserves ~16 TB of VIRTUAL address space for shadow memory
+    #     at startup, which is fundamentally incompatible with the
+    #     `ulimit -v` cap the repo's test harness runs under
+    #     (.claude/rules/compiler-safety.md) — the binary aborts with
+    #     "ReserveShadowMemoryRange failed ... Perhaps you're using
+    #     ulimit -v" before main() runs. Skip the ASAN leg whenever a
+    #     vmem cap is active; the plain roundtrip above still validates.
+    # Only an actual ASAN error report (e.g. heap-use-after-free) is a
+    # real FAIL — that is the sender-side-release regression signal.
+    local vmem_cap
+    vmem_cap="$(ulimit -v 2>/dev/null || echo unlimited)"
+    if [ "$vmem_cap" != "unlimited" ]; then
+        echo "[test]   virtual-memory cap active (ulimit -v ${vmem_cap}) — ASAN shadow reservation cannot run; plain roundtrip still passed"
+        return 0
+    fi
+
     local bin_asan="$SCRATCH/roundtrip_asan"
     if "$clang_bin" -fsanitize=address -Wno-override-module "$harness" "$ll_path" \
             -o "$bin_asan" -lpthread 2>"$SCRATCH/clang_asan.log"; then
-        if ! ${TIMEOUT_PREFIX} "$bin_asan"; then
+        local asan_log="$SCRATCH/asan_run.log"
+        if ${TIMEOUT_PREFIX} "$bin_asan" > "$asan_log" 2>&1; then
+            echo "[test]   ASAN roundtrip clean"
+        elif grep -q "ERROR: AddressSanitizer:" "$asan_log"; then
             echo "[test]   ASAN roundtrip failed — sender-side release of the escaped payload" >&2
+            sed 's/^/[test]     /' "$asan_log" | head -25 >&2
             return 1
+        else
+            # Startup/environment failure (shadow mapping, missing
+            # runtime .so, etc.) — not a verdict on the escape rule.
+            echo "[test]   ASAN could not start on this host — plain roundtrip still passed"
+            sed 's/^/[test]     /' "$asan_log" | head -5
         fi
-        echo "[test]   ASAN roundtrip clean"
     else
         echo "[test]   ASAN runtime not available on this host — plain roundtrip still passed"
     fi

--- a/compiler/tests/unit/escape_promotion_boundaries_test.sfn
+++ b/compiler/tests/unit/escape_promotion_boundaries_test.sfn
@@ -249,6 +249,51 @@ test "drop emission: spawn-captured value emits no release at the spawner's scop
     assert drops.lines.length == 0;
 }
 
+test "shadowing: only the innermost matching binding is promoted AND consumed" {
+    // Mirrors `find_local_binding` / `promote_local_to_rc` resolution: when
+    // an inner-scope `let msg` shadows an outer `msg` and the inner one is
+    // sent, the outer binding never crossed the boundary — it must keep its
+    // arena kind and (critically) its owner drop, so neither field flips.
+    let outer = LocalBinding {
+        name: "msg",
+        pointer: "%l_outer",
+        llvm_type: "i8*",
+        type_annotation: "string",
+        ownership: null,
+        consumed: false,
+        scope_id: "fn:test",
+        scope_depth: 0,
+        allocation_kind: "arena",
+        init_sentinel: ""
+    };
+    let inner = LocalBinding {
+        name: "msg",
+        pointer: "%l_inner",
+        llvm_type: "i8*",
+        type_annotation: "string",
+        ownership: null,
+        consumed: false,
+        scope_id: "fn:test__inner",
+        scope_depth: 1,
+        allocation_kind: "arena",
+        init_sentinel: ""
+    };
+    let mut locals: LocalBinding[] = [];
+    locals = append_local_binding(locals, _make_binding("ch", "i8*", "channel", null));
+    locals = append_local_binding(locals, outer);
+    locals = append_local_binding(locals, inner);
+    let promoted = promote_escaping_locals_for_boundaries("ch.send(msg)", locals, _no_params());
+    assert promoted.length == 3;
+    // Outer (older) binding: untouched on both axes.
+    assert promoted[1].pointer == "%l_outer";
+    assert promoted[1].allocation_kind == "arena";
+    assert ! promoted[1].consumed;
+    // Inner (most-recent) binding: promoted and consumed.
+    assert promoted[2].pointer == "%l_inner";
+    assert promoted[2].allocation_kind == "rc";
+    assert promoted[2].consumed;
+}
+
 // -----------------------------------------------------------------------------
 // Boundary-detection hygiene — shapes that must NOT promote.
 // -----------------------------------------------------------------------------

--- a/compiler/tests/unit/escape_promotion_boundaries_test.sfn
+++ b/compiler/tests/unit/escape_promotion_boundaries_test.sfn
@@ -1,0 +1,293 @@
+// Round-trip pin for the channel-send / spawn-capture escape-promotion
+// rule (issue #1094, M4 follow-up to M1.5.5 / #329).
+//
+// M1.5.5 promotes owned heap locals to "rc" only at function-return
+// boundaries. Channel-send and spawn-capture move owned data ACROSS
+// threads; without escape promotion at those boundaries the sender's
+// scope-exit drop would free data the receiver/worker still reads — a
+// cross-thread use-after-free. `promote_escaping_locals_for_boundaries`
+// extends the conservative rule: the escaping local is promoted
+// (`arena` → `rc`) AND marked consumed, so `emit_scope_drops` skips it
+// (ownership transferred across the boundary — leak-biased, never UAF).
+//
+// Acceptance criteria covered (paraphrased from #1094):
+//
+//   1. A heap-typed local sent on a channel (`ch.send(msg)` with `ch` a
+//      `channel`-typed local) flips to "rc" and is marked consumed.
+//   2. A heap-typed local captured by a spawned task (`spawn fn() ...`)
+//      flips to "rc" and is marked consumed.
+//   3. The promoted-and-consumed binding emits NO drop at sender scope
+//      exit (`emit_scope_drops` produces zero lines for it).
+//
+// Plus hygiene cases: non-channel `.send(...)` receivers, non-heap
+// arguments, borrows, `process.spawn(...)` member access, identifiers
+// that merely contain the keyword (`spawn_with_env`), and `spawn`
+// appearing inside string literals must all leave the locals untouched.
+import {
+    append_local_binding,
+    find_local_binding,
+    promote_escaping_locals_for_boundaries
+} from "../../src/llvm/expression_lowering/native/core_scopes";
+import { emit_scope_drops } from "../../src/llvm/lowering/instructions_helpers";
+import { LocalBinding, OwnershipInfo, ParameterBinding } from "../../src/llvm/types";
+
+fn _no_params() -> ParameterBinding[] {
+    let empty: ParameterBinding[] = [];
+    return empty;
+}
+
+fn _make_parameter(name: string, llvm_type: string, type_annotation: string) -> ParameterBinding {
+    return ParameterBinding {
+        name: name,
+        llvm_name: "%" + name,
+        llvm_type: llvm_type,
+        type_annotation: type_annotation,
+        consumed: false,
+        span: null
+    };
+}
+
+fn _make_binding(name: string, llvm_type: string, type_annotation: string, ownership: OwnershipInfo?) -> LocalBinding {
+    return LocalBinding {
+        name: name,
+        pointer: "%l_" + name,
+        llvm_type: llvm_type,
+        type_annotation: type_annotation,
+        ownership: ownership,
+        consumed: false,
+        scope_id: "fn:test",
+        scope_depth: 0,
+        allocation_kind: "arena",
+        init_sentinel: ""
+    };
+}
+
+fn _borrow_ownership() -> OwnershipInfo {
+    return OwnershipInfo {
+        variant: "Borrow",
+        base: "x",
+        mutable: false,
+        span: null,
+        region_id: -1
+    };
+}
+
+// Channel + heap message pair used by most send-boundary cases.
+fn _channel_locals() -> LocalBinding[] {
+    let mut locals: LocalBinding[] = [];
+    locals = append_local_binding(locals, _make_binding("ch", "i8*", "channel", null));
+    locals = append_local_binding(locals, _make_binding("msg", "i8*", "string", null));
+    return locals;
+}
+
+// -----------------------------------------------------------------------------
+// Channel-send boundary (#1094 acceptance criterion 1).
+// -----------------------------------------------------------------------------
+test "channel send: heap argument flips arena -> rc and is marked consumed" {
+    let locals = _channel_locals();
+    let promoted = promote_escaping_locals_for_boundaries("ch.send(msg)", locals, _no_params());
+    let msg_binding = find_local_binding(promoted, "msg");
+    assert msg_binding != null;
+    assert msg_binding.allocation_kind == "rc";
+    assert msg_binding.consumed;
+}
+
+test "channel send: the channel handle itself is not the escaping value" {
+    // Only the argument text escapes; the base (`ch`) is the boundary, not
+    // the payload, and must keep its arena kind so its own lifecycle is
+    // unchanged.
+    let locals = _channel_locals();
+    let promoted = promote_escaping_locals_for_boundaries("ch.send(msg)", locals, _no_params());
+    let ch_binding = find_local_binding(promoted, "ch");
+    assert ch_binding != null;
+    assert ch_binding.allocation_kind == "arena";
+    assert ! ch_binding.consumed;
+}
+
+test "channel send: non-channel receiver does not trigger promotion" {
+    let mut locals: LocalBinding[] = [];
+    locals = append_local_binding(locals, _make_binding("obj", "%Mailbox*", "Mailbox", null));
+    locals = append_local_binding(locals, _make_binding("msg", "i8*", "string", null));
+    let promoted = promote_escaping_locals_for_boundaries("obj.send(msg)", locals, _no_params());
+    let msg_binding = find_local_binding(promoted, "msg");
+    assert msg_binding != null;
+    assert msg_binding.allocation_kind == "arena";
+    assert ! msg_binding.consumed;
+}
+
+test "channel send: non-heap argument stays arena (no bogus rc-release target)" {
+    let mut locals: LocalBinding[] = [];
+    locals = append_local_binding(locals, _make_binding("ch", "i8*", "channel", null));
+    locals = append_local_binding(locals, _make_binding("n", "i64", "int", null));
+    let promoted = promote_escaping_locals_for_boundaries("ch.send(n)", locals, _no_params());
+    let n_binding = find_local_binding(promoted, "n");
+    assert n_binding != null;
+    assert n_binding.allocation_kind == "arena";
+    assert ! n_binding.consumed;
+}
+
+test "channel send: borrowed argument is never promoted (borrow base owns the resource)" {
+    let mut locals: LocalBinding[] = [];
+    locals = append_local_binding(locals, _make_binding("ch", "i8*", "channel", null));
+    locals = append_local_binding(locals, _make_binding("view", "i8*", "string", _borrow_ownership()));
+    let promoted = promote_escaping_locals_for_boundaries("ch.send(view)", locals, _no_params());
+    let view_binding = find_local_binding(promoted, "view");
+    assert view_binding != null;
+    assert view_binding.allocation_kind == "arena";
+}
+
+test "channel send: let-initializer shape `ch.send(msg)` promotes (call sites pass raw text)" {
+    // `lower_let_instruction` feeds the initializer text of
+    // `let ok = ch.send(msg);` through the same entry point — pin that the
+    // bare call text (no statement context) is sufficient.
+    let locals = _channel_locals();
+    let promoted = promote_escaping_locals_for_boundaries("  ch.send(msg)  ", locals, _no_params());
+    let msg_binding = find_local_binding(promoted, "msg");
+    assert msg_binding != null;
+    assert msg_binding.allocation_kind == "rc";
+    assert msg_binding.consumed;
+}
+
+test "channel send: channel-typed PARAMETER base promotes the local argument" {
+    // `fn producer(ch: channel) { ch.send(msg); }` — the #1091 channel-method
+    // resolution accepts a parameter base, so the escape rule must too. The
+    // promotion still targets the *local* `msg`; the parameter `ch` lives in
+    // the caller's frame and is not a drop candidate.
+    let mut locals: LocalBinding[] = [];
+    locals = append_local_binding(locals, _make_binding("msg", "i8*", "string", null));
+    let mut params: ParameterBinding[] = [];
+    params.push(_make_parameter("ch", "i8*", "channel"));
+    let promoted = promote_escaping_locals_for_boundaries("ch.send(msg)", locals, params);
+    let msg_binding = find_local_binding(promoted, "msg");
+    assert msg_binding != null;
+    assert msg_binding.allocation_kind == "rc";
+    assert msg_binding.consumed;
+}
+
+// -----------------------------------------------------------------------------
+// Spawn-capture boundary (#1094 acceptance criterion 2).
+// -----------------------------------------------------------------------------
+test "spawn: heap local named in a spawned lambda body flips arena -> rc and is consumed" {
+    let mut locals: LocalBinding[] = [];
+    locals = append_local_binding(locals, _make_binding("data", "i8*", "string", null));
+    let promoted = promote_escaping_locals_for_boundaries("spawn fn() -> int { return use_data(data); }", locals, _no_params());
+    let data_binding = find_local_binding(promoted, "data");
+    assert data_binding != null;
+    assert data_binding.allocation_kind == "rc";
+    assert data_binding.consumed;
+}
+
+test "spawn: typed spawn (`spawn:int ...`) promotes heap locals in the operand" {
+    let mut locals: LocalBinding[] = [];
+    locals = append_local_binding(locals, _make_binding("payload", "i8*", "string", null));
+    let promoted = promote_escaping_locals_for_boundaries("spawn:int make_task(payload)", locals, _no_params());
+    let payload_binding = find_local_binding(promoted, "payload");
+    assert payload_binding != null;
+    assert payload_binding.allocation_kind == "rc";
+    assert payload_binding.consumed;
+}
+
+test "spawn: parallel task lists promote every captured heap local" {
+    let mut locals: LocalBinding[] = [];
+    locals = append_local_binding(locals, _make_binding("left", "i8*", "string", null));
+    locals = append_local_binding(locals, _make_binding("right", "i8*", "string", null));
+    let promoted = promote_escaping_locals_for_boundaries("parallel [spawn work(left), spawn work(right)]", locals, _no_params());
+    let left_binding = find_local_binding(promoted, "left");
+    let right_binding = find_local_binding(promoted, "right");
+    assert left_binding != null;
+    assert right_binding != null;
+    assert left_binding.allocation_kind == "rc";
+    assert right_binding.allocation_kind == "rc";
+}
+
+test "spawn: non-heap locals named in the spawned task stay arena" {
+    let mut locals: LocalBinding[] = [];
+    locals = append_local_binding(locals, _make_binding("count", "i64", "int", null));
+    let promoted = promote_escaping_locals_for_boundaries("spawn fn() -> int { return count + 1; }", locals, _no_params());
+    let count_binding = find_local_binding(promoted, "count");
+    assert count_binding != null;
+    assert count_binding.allocation_kind == "arena";
+    assert ! count_binding.consumed;
+}
+
+// -----------------------------------------------------------------------------
+// Drop suppression at sender scope exit (#1094 acceptance criterion 3).
+// -----------------------------------------------------------------------------
+test "drop emission: sent value emits no release at the sender's scope exit" {
+    // Contrast pin: an owned rc binding in this scope WOULD drop...
+    let mut owned: LocalBinding[] = [];
+    let mut rc_binding = _make_binding("kept", "i8*", "string", null);
+    rc_binding = LocalBinding {
+        name: rc_binding.name,
+        pointer: rc_binding.pointer,
+        llvm_type: rc_binding.llvm_type,
+        type_annotation: rc_binding.type_annotation,
+        ownership: rc_binding.ownership,
+        consumed: false,
+        scope_id: rc_binding.scope_id,
+        scope_depth: rc_binding.scope_depth,
+        allocation_kind: "rc",
+        init_sentinel: ""
+    };
+    owned = append_local_binding(owned, rc_binding);
+    let owned_drops = emit_scope_drops(owned, "fn:test", 0);
+    assert owned_drops.lines.length > 0;
+
+    // ...but the same value routed through a channel-send boundary is
+    // promoted AND consumed, so the sender's scope-exit drop site skips it.
+    let locals = _channel_locals();
+    let promoted = promote_escaping_locals_for_boundaries("ch.send(msg)", locals, _no_params());
+    let sent_drops = emit_scope_drops(promoted, "fn:test", 0);
+    assert sent_drops.lines.length == 0;
+}
+
+test "drop emission: spawn-captured value emits no release at the spawner's scope exit" {
+    let mut locals: LocalBinding[] = [];
+    locals = append_local_binding(locals, _make_binding("data", "i8*", "string", null));
+    let promoted = promote_escaping_locals_for_boundaries("spawn fn() -> int { return use_data(data); }", locals, _no_params());
+    let drops = emit_scope_drops(promoted, "fn:test", 0);
+    assert drops.lines.length == 0;
+}
+
+// -----------------------------------------------------------------------------
+// Boundary-detection hygiene — shapes that must NOT promote.
+// -----------------------------------------------------------------------------
+test "hygiene: process.spawn_with_env is a longer identifier, not a spawn boundary" {
+    let mut locals: LocalBinding[] = [];
+    locals = append_local_binding(locals, _make_binding("cmd", "i8*", "string", null));
+    let promoted = promote_escaping_locals_for_boundaries("process.spawn_with_env(cmd)", locals, _no_params());
+    let cmd_binding = find_local_binding(promoted, "cmd");
+    assert cmd_binding != null;
+    assert cmd_binding.allocation_kind == "arena";
+    assert ! cmd_binding.consumed;
+}
+
+test "hygiene: member-access spawn (process.spawn) is not the spawn keyword" {
+    let mut locals: LocalBinding[] = [];
+    locals = append_local_binding(locals, _make_binding("cmd", "i8*", "string", null));
+    let promoted = promote_escaping_locals_for_boundaries("process.spawn(cmd)", locals, _no_params());
+    let cmd_binding = find_local_binding(promoted, "cmd");
+    assert cmd_binding != null;
+    assert cmd_binding.allocation_kind == "arena";
+    assert ! cmd_binding.consumed;
+}
+
+test "hygiene: 'spawn' inside a string literal is not a boundary" {
+    let mut locals: LocalBinding[] = [];
+    locals = append_local_binding(locals, _make_binding("msg", "i8*", "string", null));
+    let promoted = promote_escaping_locals_for_boundaries("log(\"spawn it later\", msg)", locals, _no_params());
+    let msg_binding = find_local_binding(promoted, "msg");
+    assert msg_binding != null;
+    assert msg_binding.allocation_kind == "arena";
+    assert ! msg_binding.consumed;
+}
+
+test "hygiene: plain calls without a boundary leave locals untouched" {
+    let mut locals: LocalBinding[] = [];
+    locals = append_local_binding(locals, _make_binding("msg", "i8*", "string", null));
+    let promoted = promote_escaping_locals_for_boundaries("log_message(msg)", locals, _no_params());
+    let msg_binding = find_local_binding(promoted, "msg");
+    assert msg_binding != null;
+    assert msg_binding.allocation_kind == "arena";
+    assert ! msg_binding.consumed;
+}


### PR DESCRIPTION
## Summary
- Extends the M1.5.5 conservative escape rule to the two cross-thread boundaries M4 shipped: **channel-send** (`ch.send(args)`, local *or* parameter channel base — both forms the #1091 call resolution accepts) and **spawn-capture** (bare `spawn` keyword: `spawn fn() ...`, `spawn:kind ...`, `parallel [spawn ...]`).
- Mirrors the return-boundary precedent: escaping heap locals flip `arena → rc` via `promote_local_to_rc` **and** are marked consumed, so `emit_scope_drops` / `emit_guarded_scope_drops` skip them — ownership transfers across the boundary (leak-biased, never UAF). Borrows and non-heap bindings are never touched. Both promotion and consumption target only the innermost matching binding, so shadowed outer locals keep their owner drop (review follow-up, `3133176`).
- New entry point `promote_escaping_locals_for_boundaries` (core_scopes.sfn), wired into `lower_expression_statement` (bare statements) and `lower_let_instruction` (initializers). Detection is textual and conservative; member-access fields (`process.spawn`), longer identifiers (`spawn_with_env`), and `spawn` inside string literals do not match.

Closes #1094

## Acceptance Criteria
- [x] values escaping via channel-send are promoted to rc (not dropped at sender scope exit) — unit pins + e2e IR negative assertion (`call @sfn_rc_release` absent in sender)
- [x] values captured by spawn are promoted to rc — unit pins for lambda-body, `spawn:kind`, and `parallel` forms
- [x] regression test demonstrates no cross-thread UAF (clean under ASAN) — e2e harness runs the producer on a real pthread, sends a heap struct across the boundary, and the main thread dereferences it after the producer frame is gone. **ASAN caveat:** ASAN's startup shadow-memory reservation (~16 TB virtual) is fundamentally incompatible with the repo's mandatory `ulimit -v` cap, so in CI the ASAN leg self-skips and the plain cross-thread roundtrip is the enforced demonstration; the ASAN leg runs on uncapped dev hosts with libasan, and only a genuine `ERROR: AddressSanitizer:` report fails the test (`601bcf4`).
- [x] `make compile` passes (self-host clean, re-verified after the review follow-up)
- [x] `make test` — related suites (escape_promotion, emit_scope_drops, emit_guarded_scope_drops, local_binding_allocation_kind, concurrency unit + channel/concurrency/closure e2e) all pass locally; full suite enforced by CI on this PR.
- [x] `sfn fmt --check` clean on every touched .sfn

## Deviations / notes for reviewers
- **ASAN-under-ulimit:** see caveat above — surfaced by the first CI run on this PR (e2e-sh-1 failure), fixed in `601bcf4`.
- The e2e harness stubs the channel with a single-slot C mailbox and `sfn_rc_release` as `free`: compiler-emitted channel calls (`sfn_channel_receive`, 1-arg `sfn_channel_create`) do not yet link against `runtime/sfn/concurrency/channel.sfn` (`sfn_channel_recv`, 2-arg create), so the real runtime cannot link against emitted programs — channel *semantics* are not under test, sender-side drop behaviour is. That ABI mismatch predates this PR and deserves its own issue (it blocks any `sailfin run` of channel programs).
- The pre-existing return-boundary consumption (`bindings_mark_local_consumed`) flips every same-named binding; left untouched as it predates this PR — follow-up candidate.
- Promotion + consumption currently produces IR identical to the arena default for *fresh* locals (arena bindings emit no drop today); the rule's value is forward-looking — it keeps the sender-side invariant when receiving-side promotion / wider drop emission land, and the tests pin that invariant.

## Verification
```bash
ulimit -v 8388608 && make compile                                              # pass (self-host, both commits)
ulimit -v 8388608 && build/native/sailfin test compiler/tests/unit/escape_promotion_boundaries_test.sfn   # 18/18 pass
ulimit -v 8388608 && compiler/tests/e2e/test_escape_promotion_boundaries.sh build/native/sailfin          # 3/3 pass (capped, CI-like)
compiler/tests/e2e/test_escape_promotion_boundaries.sh build/native/sailfin   # 3/3 pass (uncapped)
ulimit -v 8388608 && build/native/sailfin test <related unit files>            # all pass
compiler/tests/e2e/test_channel_producer_consumer_ir.sh / test_concurrency_lowering_ir.sh / test_closure_capture.sh  # all pass
build/native/sailfin fmt --check <touched .sfn>                               # clean
```

## Files Changed
- `compiler/src/llvm/expression_lowering/native/core_scopes.sfn` — escape rule + boundary detection (+ innermost-only consumption)
- `compiler/src/llvm/expression_lowering/native/statement.sfn` — statement-level hook
- `compiler/src/llvm/lowering/instructions_let.sfn` — initializer-level hook
- `compiler/tests/unit/escape_promotion_boundaries_test.sfn` — 18-case rule pin (new)
- `compiler/tests/e2e/test_escape_promotion_boundaries.sh` — IR + cross-thread runtime/ASAN pin (new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01DuvkcWqGkvqQzKVXGpYyat