### PR TITLE
feat(parser): unsafe block/fn as the raw-pointer ownership boundary

### DIFF
--- a/compiler/src/ast.sfn
+++ b/compiler/src/ast.sfn
@@ -267,6 +267,7 @@ enum Statement {
         signature: FunctionSignature;
         body: Block;
         decorators: Decorator[];
+        is_unsafe: boolean;
     },
     ExternFunctionDeclaration {
         signature: FunctionSignature;
@@ -332,6 +333,7 @@ enum Statement {
     },
     BlockStatement {
         body: Block;
+        is_unsafe: boolean;
     },
     ReturnStatement {
         expression: Expression?;

--- a/compiler/src/emit_native_desugar_try.sfn
+++ b/compiler/src/emit_native_desugar_try.sfn
@@ -823,7 +823,10 @@ fn dt_nested(statement: Statement, id: int) -> DtStmt {
     if statement.variant == "BlockStatement" {
         let body_result = dt_block(statement.body, id);
         return DtStmt {
-            statement: Statement.BlockStatement { body: body_result.block },
+            statement: Statement.BlockStatement {
+                body: body_result.block,
+                is_unsafe: statement.is_unsafe
+            },
             next_id: body_result.next_id
         };
     }

--- a/compiler/src/emitter_sailfin.sfn
+++ b/compiler/src/emitter_sailfin.sfn
@@ -129,7 +129,7 @@ fn emit_statement(builder: TextBuilder, statement: Statement) -> TextBuilder {
         return emit_variable(builder, statement);
     }
     if statement.variant == "FunctionDeclaration" {
-        return emit_function(builder, statement.signature, statement.body, statement.decorators);
+        return emit_function(builder, statement.signature, statement.body, statement.decorators, statement.is_unsafe);
     }
     if statement.variant == "StructDeclaration" {
         return emit_struct(builder, statement);
@@ -181,9 +181,10 @@ fn emit_variable(builder: TextBuilder, statement: Statement) -> TextBuilder {
     return builder_emit_line(builder, prefix + ";");
 }
 
-fn emit_function(builder: TextBuilder, signature: FunctionSignature, body: Block, decorators: Decorator[]) -> TextBuilder {
+fn emit_function(builder: TextBuilder, signature: FunctionSignature, body: Block, decorators: Decorator[], is_unsafe: boolean) -> TextBuilder {
     let mut current = emit_decorators(builder, decorators);
-    let header = format_function_header(signature);
+    let mut header = format_function_header(signature);
+    if is_unsafe { header = "unsafe " + header; }
     return emit_block_with_header(current, header, body);
 }
 
@@ -365,6 +366,9 @@ fn emit_block_statement(builder: TextBuilder, statement: Statement) -> TextBuild
         return emit_if(builder, statement);
     }
     if statement.variant == "BlockStatement" {
+        if statement.is_unsafe {
+            return emit_block_with_header(builder, "unsafe", statement.body);
+        }
         return emit_block(builder, statement.body);
     }
     if statement.variant == "ForStatement" {
@@ -378,7 +382,7 @@ fn emit_block_statement(builder: TextBuilder, statement: Statement) -> TextBuild
         return builder_emit_line(builder, line);
     }
     if statement.variant == "FunctionDeclaration" {
-        return emit_function(builder, statement.signature, statement.body, statement.decorators);
+        return emit_function(builder, statement.signature, statement.body, statement.decorators, statement.is_unsafe);
     }
     if statement.variant == "MatchStatement" {
         return emit_match(builder, statement);

--- a/compiler/src/llvm/expression_lowering/native/lambda_lowering.sfn
+++ b/compiler/src/llvm/expression_lowering/native/lambda_lowering.sfn
@@ -335,7 +335,8 @@ fn _synthesize_lifted_function_with_captures(lambda: Expression, lambda_id: int,
     return Statement.FunctionDeclaration {
         signature: signature,
         body: body_with_prologue,
-        decorators: no_decorators
+        decorators: no_decorators,
+        is_unsafe: false
     };
 }
 
@@ -682,7 +683,8 @@ fn _rewrite_statement(ctx: LiftContext, statement: Statement) -> StatementRewrit
             statement: Statement.FunctionDeclaration {
                 signature: statement.signature,
                 body: body_result.block,
-                decorators: statement.decorators
+                decorators: statement.decorators,
+                is_unsafe: statement.is_unsafe
             }
         };
     }
@@ -737,7 +739,10 @@ fn _rewrite_statement(ctx: LiftContext, statement: Statement) -> StatementRewrit
         let body_result = _rewrite_block(ctx, statement.body);
         return StatementRewriteResult {
             ctx: body_result.ctx,
-            statement: Statement.BlockStatement { body: body_result.block }
+            statement: Statement.BlockStatement {
+                body: body_result.block,
+                is_unsafe: statement.is_unsafe
+            }
         };
     }
     if statement.variant == "ForStatement" {

--- a/compiler/src/parser/declarations.sfn
+++ b/compiler/src/parser/declarations.sfn
@@ -799,9 +799,15 @@ fn parse_variable_with_storage(initial_parser: Parser, is_thread_local: boolean)
 // ============================================================================
 // Function Declaration
 // ============================================================================
-fn parse_function(initial_parser: Parser, starts_with_async: boolean, decorators: Decorator[]) -> StatementParseResult {
+fn parse_function(initial_parser: Parser, starts_with_async: boolean, decorators: Decorator[], starts_with_unsafe: boolean) -> StatementParseResult {
     let mut parser: Parser = initial_parser;
     parser = skip_trivia(parser);
+    let mut is_unsafe = false;
+    if starts_with_unsafe {
+        parser = consume_keyword(parser, "unsafe");
+        parser = skip_trivia(parser);
+        is_unsafe = true;
+    }
     let mut is_async = false;
     if starts_with_async {
         parser = consume_keyword(parser, "async");
@@ -888,7 +894,8 @@ fn parse_function(initial_parser: Parser, starts_with_async: boolean, decorators
     let statement = Statement.FunctionDeclaration {
         signature: signature,
         body: body,
-        decorators: decorators
+        decorators: decorators,
+        is_unsafe: is_unsafe
     };
     return StatementParseResult { parser: parser, statement: statement };
 }

--- a/compiler/src/parser/mod.sfn
+++ b/compiler/src/parser/mod.sfn
@@ -152,12 +152,12 @@ fn parse_statement(initial_parser: Parser) -> StatementParseResult {
         return parse_lifecycle_hook(parser, decorators, "after_all");
     }
     if identifier_matches(token, "fn") {
-        return parse_function(parser, false, decorators);
+        return parse_function(parser, false, decorators, false);
     }
     if identifier_matches(token, "async") {
         let lookahead = skip_trivia(parser_advance_raw(parser));
         if identifier_matches(parser_peek_raw(lookahead), "fn") {
-            return parse_function(parser, true, decorators);
+            return parse_function(parser, true, decorators, false);
         }
     }
     if identifier_matches(token, "extern") {
@@ -167,6 +167,9 @@ fn parse_statement(initial_parser: Parser) -> StatementParseResult {
         let lookahead = skip_trivia(parser_advance_raw(parser));
         if identifier_matches(parser_peek_raw(lookahead), "extern") {
             return parse_extern_function(parser, true, decorators);
+        }
+        if identifier_matches(parser_peek_raw(lookahead), "fn") {
+            return parse_function(parser, false, decorators, true);
         }
     }
     if identifier_matches(token, "struct") {

--- a/compiler/src/parser/statements.sfn
+++ b/compiler/src/parser/statements.sfn
@@ -214,7 +214,10 @@ fn parse_block_statement(parser: Parser) -> BlockStatementParseResult {
         let body_result = parse_block(after_decorators);
         return BlockStatementParseResult {
             parser: body_result.parser,
-            statement: Statement.BlockStatement { body: body_result.block },
+            statement: Statement.BlockStatement {
+                body: body_result.block,
+                is_unsafe: false
+            },
             success: true
         };
     }
@@ -297,7 +300,10 @@ fn parse_block_statement(parser: Parser) -> BlockStatementParseResult {
         let body_result = parse_block(unsafe_current);
         return BlockStatementParseResult {
             parser: body_result.parser,
-            statement: Statement.BlockStatement { body: body_result.block },
+            statement: Statement.BlockStatement {
+                body: body_result.block,
+                is_unsafe: true
+            },
             success: true
         };
     }

--- a/compiler/tests/unit/concurrency_effect_test.sfn
+++ b/compiler/tests/unit/concurrency_effect_test.sfn
@@ -79,7 +79,8 @@ fn _make_spawn_fn(name: string, effects: string[], span_line: int) -> Statement 
     return Statement.FunctionDeclaration {
         signature: _signature(name, effects, span_line),
         body: body_block,
-        decorators: no_decorators
+        decorators: no_decorators,
+        is_unsafe: false
     };
 }
 
@@ -105,7 +106,8 @@ fn _make_serve_fn(name: string, effects: string[], span_line: int) -> Statement 
     return Statement.FunctionDeclaration {
         signature: _signature(name, effects, span_line),
         body: body_block,
-        decorators: no_decorators
+        decorators: no_decorators,
+        is_unsafe: false
     };
 }
 
@@ -139,7 +141,8 @@ fn _make_channel_send_fn(name: string, effects: string[], span_line: int) -> Sta
     return Statement.FunctionDeclaration {
         signature: _signature(name, effects, span_line),
         body: body_block,
-        decorators: no_decorators
+        decorators: no_decorators,
+        is_unsafe: false
     };
 }
 
@@ -171,7 +174,8 @@ fn _make_channel_receive_fn(name: string, effects: string[], span_line: int) -> 
     return Statement.FunctionDeclaration {
         signature: _signature(name, effects, span_line),
         body: body_block,
-        decorators: no_decorators
+        decorators: no_decorators,
+        is_unsafe: false
     };
 }
 

--- a/compiler/tests/unit/effect_capabilities_test.sfn
+++ b/compiler/tests/unit/effect_capabilities_test.sfn
@@ -66,7 +66,8 @@ fn _function_declaring(name: string, effects: string[], span_line: int) -> State
     return Statement.FunctionDeclaration {
         signature: _signature(name, effects, _span(span_line, 4)),
         body: _empty_block(),
-        decorators: empty_decorators
+        decorators: empty_decorators,
+        is_unsafe: false
     };
 }
 

--- a/compiler/tests/unit/effect_checker_main_test.sfn
+++ b/compiler/tests/unit/effect_checker_main_test.sfn
@@ -78,7 +78,8 @@ fn _build_main_routine(declared_effects: string[]) -> Statement {
     return Statement.FunctionDeclaration {
         signature: _signature("main", declared_effects, span),
         body: body_block,
-        decorators: empty_decorators
+        decorators: empty_decorators,
+        is_unsafe: false
     };
 }
 

--- a/compiler/tests/unit/effect_checker_test.sfn
+++ b/compiler/tests/unit/effect_checker_test.sfn
@@ -76,7 +76,8 @@ fn _make_io_violating_routine(name: string, declared_effects: string[], span_lin
     return Statement.FunctionDeclaration {
         signature: _signature(name, declared_effects, span),
         body: body_block,
-        decorators: empty_decorators
+        decorators: empty_decorators,
+        is_unsafe: false
     };
 }
 
@@ -112,7 +113,8 @@ fn _make_spawn_routine(name: string, declared_effects: string[], span_line: int)
     return Statement.FunctionDeclaration {
         signature: _signature(name, declared_effects, span),
         body: body_block,
-        decorators: empty_decorators
+        decorators: empty_decorators,
+        is_unsafe: false
     };
 }
 
@@ -248,7 +250,8 @@ test "effect violation: routines without name_span produce a null trigger" {
     let stmt = Statement.FunctionDeclaration {
         signature: _signature("nameless", [], null),
         body: body_block,
-        decorators: empty_decorators
+        decorators: empty_decorators,
+        is_unsafe: false
     };
     let program = Program { statements: [stmt] };
     let violations = validate_effects(program);
@@ -414,7 +417,8 @@ fn _routine_with_member_call(name: string, declared_effects: string[], sig_line:
     return Statement.FunctionDeclaration {
         signature: _signature(name, declared_effects, sig_span),
         body: body_block,
-        decorators: empty_decorators
+        decorators: empty_decorators,
+        is_unsafe: false
     };
 }
 
@@ -441,7 +445,8 @@ fn _routine_with_bare_call(name: string, declared_effects: string[], sig_line: i
     return Statement.FunctionDeclaration {
         signature: _signature(name, declared_effects, sig_span),
         body: body_block,
-        decorators: empty_decorators
+        decorators: empty_decorators,
+        is_unsafe: false
     };
 }
 
@@ -542,7 +547,8 @@ fn _routine_with_try_member_call(name: string, declared_effects: string[], sig_l
     return Statement.FunctionDeclaration {
         signature: _signature(name, declared_effects, sig_span),
         body: body_block,
-        decorators: empty_decorators
+        decorators: empty_decorators,
+        is_unsafe: false
     };
 }
 
@@ -719,7 +725,8 @@ fn _routine_with_brace(name: string, sig_line: int, brace_line: int, brace_colum
     return Statement.FunctionDeclaration {
         signature: _signature(name, empty_effects, sig_span),
         body: body_block,
-        decorators: empty_decorators
+        decorators: empty_decorators,
+        is_unsafe: false
     };
 }
 

--- a/compiler/tests/unit/effect_imports_test.sfn
+++ b/compiler/tests/unit/effect_imports_test.sfn
@@ -97,7 +97,8 @@ fn _routine_calling(routine_name: string, callee_name: string, span_line: int) -
     return Statement.FunctionDeclaration {
         signature: _signature(routine_name, empty_effects, span),
         body: body_block,
-        decorators: empty_decorators
+        decorators: empty_decorators,
+        is_unsafe: false
     };
 }
 
@@ -276,7 +277,8 @@ test "validate_effects_with_imports: declared effect on caller suppresses violat
     let routine_stmt = Statement.FunctionDeclaration {
         signature: _signature("run", ["net"], span),
         body: body_block,
-        decorators: empty_decorators
+        decorators: empty_decorators,
+        is_unsafe: false
     };
 
     let program = Program { statements: [import_stmt, routine_stmt] };
@@ -307,7 +309,8 @@ test "validate_effects_with_imports: same-named in-module fn does not trigger E0
     let routine_stmt = Statement.FunctionDeclaration {
         signature: _signature("run", empty_effects, span),
         body: body_block,
-        decorators: empty_decorators
+        decorators: empty_decorators,
+        is_unsafe: false
     };
 
     // No import declaration in the program, so localize produces

--- a/compiler/tests/unit/unsafe_boundary_test.sfn
+++ b/compiler/tests/unit/unsafe_boundary_test.sfn
@@ -1,0 +1,151 @@
+// Regression coverage for the `unsafe` ownership boundary marker (#1211).
+//
+// E2 of the ownership epic (#1209): `unsafe { }` blocks and `unsafe fn`
+// declarations parse and carry an inert `is_unsafe` flag on the AST —
+// `BlockStatement.is_unsafe` and `FunctionDeclaration.is_unsafe`. The
+// flag is marker-only: no enforcement, no diagnostics, no IR change.
+// E4 (the ownership checker) reads it later.
+//
+// These tests pin:
+//   - `unsafe { }` sets `BlockStatement.is_unsafe`; bare blocks stay false
+//   - `unsafe fn` sets `FunctionDeclaration.is_unsafe`; plain fns stay false
+//   - the pre-existing `unsafe extern fn` path is untouched
+//   - the sailfin re-emitter prints the `unsafe` keyword back out, and a
+//     full parse -> emit -> parse round-trip preserves both markers
+import { Block, Program, Statement } from "../../src/ast";
+import { emit_program } from "../../src/emitter_sailfin";
+import { parse_program } from "../../src/parser/mod";
+import { index_of } from "../../src/string_utils";
+
+fn _contains(haystack: string, needle: string) -> boolean {
+    return index_of(haystack, needle) >= 0;
+}
+
+fn _find_function(program: Program, name: string) -> Statement {
+    let mut index: int = 0;
+    loop {
+        if index >= program.statements.length { break; }
+        let stmt = program.statements[index];
+        if stmt.variant == "FunctionDeclaration" {
+            if stmt.signature.name == name { return stmt; }
+        }
+        index += 1;
+    }
+    return program.statements[0];
+}
+
+fn _has_function(program: Program, name: string) -> boolean {
+    let mut index: int = 0;
+    loop {
+        if index >= program.statements.length { break; }
+        let stmt = program.statements[index];
+        if stmt.variant == "FunctionDeclaration" {
+            if stmt.signature.name == name { return true; }
+        }
+        index += 1;
+    }
+    return false;
+}
+
+fn _find_block_statement(body: Block) -> Statement {
+    let mut index: int = 0;
+    loop {
+        if index >= body.statements.length { break; }
+        let stmt = body.statements[index];
+        if stmt.variant == "BlockStatement" { return stmt; }
+        index += 1;
+    }
+    return body.statements[0];
+}
+
+fn _has_block_statement(body: Block) -> boolean {
+    let mut index: int = 0;
+    loop {
+        if index >= body.statements.length { break; }
+        if body.statements[index].variant == "BlockStatement" { return true; }
+        index += 1;
+    }
+    return false;
+}
+
+test "parser: unsafe block carries is_unsafe marker" ![io] {
+    let source = "fn f() {\n    unsafe {\n        let x = 1;\n    }\n}\n";
+    let program = parse_program(source);
+    assert _has_function(program, "f");
+    let decl = _find_function(program, "f");
+    assert _has_block_statement(decl.body);
+    let block_stmt = _find_block_statement(decl.body);
+    assert block_stmt.is_unsafe == true;
+}
+
+test "parser: plain block has is_unsafe false" ![io] {
+    let source = "fn f() {\n    {\n        let x = 1;\n    }\n}\n";
+    let program = parse_program(source);
+    assert _has_function(program, "f");
+    let decl = _find_function(program, "f");
+    assert _has_block_statement(decl.body);
+    let block_stmt = _find_block_statement(decl.body);
+    assert block_stmt.is_unsafe == false;
+}
+
+test "parser: unsafe fn carries is_unsafe marker" ![io] {
+    let source = "unsafe fn raw() -> int {\n    return 0;\n}\n";
+    let program = parse_program(source);
+    assert _has_function(program, "raw");
+    let decl = _find_function(program, "raw");
+    assert decl.is_unsafe == true;
+    assert decl.signature.name == "raw";
+}
+
+test "parser: ordinary fn has is_unsafe false" ![io] {
+    let source = "fn safe() {\n    return;\n}\n";
+    let program = parse_program(source);
+    assert _has_function(program, "safe");
+    let decl = _find_function(program, "safe");
+    assert decl.is_unsafe == false;
+}
+
+test "parser: unsafe extern fn still parses with unsafe flag" ![io] {
+    let source = "unsafe extern fn c_free(p: int) -> void;\n";
+    let program = parse_program(source);
+    let mut found = false;
+    let mut index: int = 0;
+    loop {
+        if index >= program.statements.length { break; }
+        let stmt = program.statements[index];
+        if stmt.variant == "ExternFunctionDeclaration" {
+            assert stmt.signature.name == "c_free";
+            assert stmt.unsafe == true;
+            found = true;
+        }
+        index += 1;
+    }
+    assert found == true;
+}
+
+test "fmt: unsafe block round-trips" ![io] {
+    let source = "fn f() {\n    unsafe {\n        let x = 1;\n    }\n}\n";
+    let program = parse_program(source);
+    let emitted = emit_program(program);
+    assert _contains(emitted, "unsafe {");
+}
+
+test "fmt: unsafe fn round-trips" ![io] {
+    let source = "unsafe fn raw() -> int {\n    return 0;\n}\n";
+    let program = parse_program(source);
+    let emitted = emit_program(program);
+    assert _contains(emitted, "unsafe fn raw");
+}
+
+test "fmt: idempotent round-trip for unsafe" ![io] {
+    let source = "unsafe fn raw() -> int {\n    unsafe {\n        let x = 1;\n    }\n    return 0;\n}\n";
+    let program = parse_program(source);
+    let emitted = emit_program(program);
+    let reparsed = parse_program(emitted);
+    assert _has_function(reparsed, "raw");
+    let decl = _find_function(reparsed, "raw");
+    assert decl.is_unsafe == true;
+    assert _has_block_statement(decl.body);
+    let block_stmt = _find_block_statement(decl.body);
+    assert block_stmt.is_unsafe == true;
+}

--- a/docs/status.md
+++ b/docs/status.md
@@ -126,7 +126,7 @@ doc, or `docs/runtime_architecture.md`, not here.
 | `spawn` | Parsed | Future-kind resolver + `E0813` (#1082); lowering is #1084 |
 | `\|>` pipeline operator | Not implemented | Planned post-1.0 |
 | Currency / time literals | Not implemented | Use numeric literals |
-| `unsafe` / `extern` | Parsed only | `extern fn` declarations are fully shipped (see Runtime Migration); `unsafe` enforcement not active |
+| `unsafe` / `extern` | Parsed, marker only | `extern fn` declarations are fully shipped (see Runtime Migration); `unsafe { }` blocks and `unsafe fn` carry an `is_unsafe` AST marker for the ownership checker (#1211) — **not enforced** |
 | Policy decorators (`@policy`) | Parsed only | No compiler or runtime effect |
 | `sfn fmt` | **Shipped** | Zero-config token-stream formatter, `--check`/`--write`, CI-enforced; architecture + limitations in `docs/proposals/fmt-architecture.md` |
 | `sfn check` | **Shipped** | Parse + typecheck + effect-check, no codegen; `--json` envelope; cross-module conformance; directory mode completes the full 156-file tree (~295 s — perf, not stability, is the open item) |


### PR DESCRIPTION
Closes #1211 (E2 of epic #1209, decision D6).

## What

`unsafe { }` blocks and `unsafe fn` declarations now carry a first-class `is_unsafe` marker through parse → AST → format — the boundary the ownership checker (E4 #1213) will consume. **Marker only: no enforcement, no diagnostics, no backend changes.**

- `ast.sfn`: `is_unsafe: boolean` on `BlockStatement` + `FunctionDeclaration` (mirrors the shipped `ExternFunctionDeclaration.unsafe` precedent; deliberately *not* on `FunctionSignature`)
- `parser/`: `unsafe { }` no longer parses as a transparent block; plain `unsafe fn` now parses (previously only `unsafe extern fn` did); dispatch in `mod.sfn` routes `unsafe`→`extern` vs `unsafe`→`fn`
- `emitter_sailfin.sfn`: formatter previously *silently stripped* `unsafe` — now emits it for both node kinds; round-trip is idempotent
- `compiler/tests/unit/unsafe_boundary_test.sfn`: 8 tests — markers, negative defaults, extern regression guard, and the load-bearing parse→emit→parse idempotence test
- `docs/status.md`: "Parsed, marker only — not enforced (#1211)"

## Intentional plan deviation (for E4 reviewers)

The approved plan hardcoded `is_unsafe: false` at AST *reconstruction* sites; the implementation propagates `statement.is_unsafe` at `emit_native_desugar_try.sfn:828` and `lambda_lowering.sfn:687/:744` instead, so the marker **survives try-desugaring and lambda reconstruction**. Genuinely synthesized lambdas (`lambda_lowering.sfn:335`) correctly hardcode `false`. E4 can rely on the marker surviving desugaring.

## Verification

- Self-hosts from the pinned seed **0.7.0-alpha.31** (`make compile` pass; binary `0.7.0-alpha.31+dev.<sha>`); no seed-compiled file uses the new syntax bare (test sources use it only inside string literals)
- Reviewed (opus code-reviewer): **approve** — exhaustive construction-site sweep, all 4 block + ~14 fn sites set the flag
- `fmt --check` clean on all 13 changed `.sfn` files under the fresh alpha.31 formatter
- Feature probe: `unsafe fn` + `unsafe { }` check + format round-trip with keywords preserved
- `make test TEST_JOBS=6`: all branch tests pass. Local-host reds are the known macOS-26-arm64 async/atomics family (SIGSEGV in `sfn_task_create` → `mfm_alloc`), which reproduce identically on the **unmodified alpha.31 seed binary** and on pristine main — pre-existing/environmental, not branch-caused (CI pins macos-15; separate issue recommended).

E4 consumption contract documented in the architect plan: scope-walk `unsafe_depth` seeded from `FunctionDeclaration.is_unsafe`, `BlockStatement.is_unsafe`, and the existing `ExternFunctionDeclaration.unsafe`.