### PR TITLE
feat(runtime): OwnedBuf/Slice owned-buffer type family surface

### DIFF
--- a/compiler/tests/e2e/test_owned_buf_roundtrip.sh
+++ b/compiler/tests/e2e/test_owned_buf_roundtrip.sh
@@ -1,0 +1,410 @@
+#!/usr/bin/env bash
+# End-to-end test for runtime/sfn/memory/ownedbuf.sfn — the OwnedBuf /
+# Slice owned-buffer type family SURFACE (issue #1212, E3 of the
+# ownership epic #1209). The module ships the type pair + API only;
+# move semantics (E5/E6) and view lifetimes (E8) are not enforced yet,
+# so this test pins the surface: parse/typecheck/fmt, the LLVM
+# aggregate layout, the nine-function define shape, the four inlined
+# extern declares, and a clang-linked functional roundtrip.
+#
+# Phases:
+#
+#   1. typecheck — `sfn check runtime/sfn/memory/ownedbuf.sfn` reports `ok`.
+#   2. fmt       — `sfn fmt --check runtime/sfn/memory/ownedbuf.sfn` is canonical.
+#   3. emit shape — emitted IR contains the pinned aggregates
+#                   (`%OwnedBuf = type { i64, i64, i64, i64 }`,
+#                   `%Slice = type { i64, i64 }`) and a `define` for
+#                   each of the nine functions (eight public + the
+#                   `_owned_buf_load_byte` word-load helper).
+#   4. extern declares — `declare`s for the four inlined externs the
+#                   bodies route through (`malloc` / `memcpy` /
+#                   `sfn_arena_sfn_alloc` / `sfn_arena_sfn_realloc`).
+#   5. roundtrip — link the emitted `.ll` (alongside the arena `.ll`,
+#                   since append grows through `sfn_arena_sfn_realloc`)
+#                   against a clang harness that exercises
+#                   new → append "hello" → len/byte_at → append " world"
+#                   (forces the grow-at-tip realloc path past the
+#                   initial capacity) → slice(0, 5) → slice_len /
+#                   slice_byte_at, plus the libc-backed
+#                   (`arena_addr == 0`) fallback. Mirrors
+#                   `test_runtime_memory_arena.sh`'s functional cherry
+#                   on top of the IR-shape assertions.
+
+set -euo pipefail
+
+BINARY="${1:?usage: test_owned_buf_roundtrip.sh <compiler-binary>}"
+BINARY="$(realpath "$BINARY")"
+PASS=0
+FAIL=0
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+SKELETON="$REPO_ROOT/runtime/sfn/memory/ownedbuf.sfn"
+ARENA="$REPO_ROOT/runtime/sfn/memory/arena.sfn"
+
+SCRATCH="$(mktemp -d -t sfn-owned-buf-XXXXXX)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+run_test() {
+    local name="$1"
+    shift
+    if "$@"; then
+        echo "[test] PASS: $name"
+        PASS=$((PASS + 1))
+    else
+        echo "[test] FAIL: $name"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+test_check_clean() {
+    local log="$SCRATCH/check.log"
+    if ! "$BINARY" check "$SKELETON" > "$log" 2>&1; then
+        echo "[test]   sfn check exited non-zero on ownedbuf.sfn:"
+        cat "$log"
+        return 1
+    fi
+    if ! grep -q "checked .* ok" "$log"; then
+        echo "[test]   sfn check did not report 'ok':"
+        cat "$log"
+        return 1
+    fi
+    return 0
+}
+
+test_fmt_clean() {
+    if ! "$BINARY" fmt --check "$SKELETON" > /dev/null 2>&1; then
+        echo "[test]   $SKELETON needs formatting (run: sfn fmt --write $SKELETON)"
+        return 1
+    fi
+    return 0
+}
+
+test_emit_type_shape() {
+    local ll="$SCRATCH/ownedbuf.ll"
+    local log="$SCRATCH/emit.log"
+    if ! "$BINARY" emit -o "$ll" llvm "$SKELETON" > "$log" 2>&1; then
+        echo "[test]   sfn emit llvm failed on runtime/sfn/memory/ownedbuf.sfn:"
+        cat "$log"
+        return 1
+    fi
+
+    # The aggregate layouts are the E3 contract: OwnedBuf is four i64
+    # slots (`ptr_addr`, `len`, `cap`, `arena_addr`) and Slice is two
+    # (`ptr_addr`, `len`). The `_addr` fields ride as i64 (arena.sfn
+    # discipline) — a regression that types one as a pointer changes
+    # these lines and must surface here.
+    local missing=0
+    if ! grep -qF '%OwnedBuf = type { i64, i64, i64, i64 }' "$ll"; then
+        echo "[test]   missing '%OwnedBuf = type { i64, i64, i64, i64 }'"
+        missing=$((missing + 1))
+    fi
+    if ! grep -qF '%Slice = type { i64, i64 }' "$ll"; then
+        echo "[test]   missing '%Slice = type { i64, i64 }'"
+        missing=$((missing + 1))
+    fi
+    return "$missing"
+}
+
+test_emit_define_shape() {
+    local ll="$SCRATCH/ownedbuf.ll"
+    if [ ! -f "$ll" ]; then
+        echo "[test]   $ll missing — test_emit_type_shape must run first"
+        return 1
+    fi
+    # Each function must produce exactly one `define` in the emitted
+    # module — anchored at line start so a `call` site does not
+    # satisfy the assertion. The signatures are pinned: struct
+    # params/returns ride the boxed-struct ABI (`%OwnedBuf*` /
+    # `%Slice*`), so a regression that flips a by-value struct to a
+    # different ABI surfaces here instead of at link time.
+    local missing=0
+    if ! grep -qE '^define %OwnedBuf\* @owned_buf_new\(i64 ' "$ll"; then
+        echo "[test]   missing 'define %OwnedBuf* @owned_buf_new(i64 ...)'"
+        missing=$((missing + 1))
+    fi
+    if ! grep -qE '^define %OwnedBuf\* @owned_buf_append\(%OwnedBuf\* ' "$ll"; then
+        echo "[test]   missing 'define %OwnedBuf* @owned_buf_append(%OwnedBuf* ...)'"
+        missing=$((missing + 1))
+    fi
+    if ! grep -qE '^define i64 @owned_buf_len\(%OwnedBuf\* ' "$ll"; then
+        echo "[test]   missing 'define i64 @owned_buf_len(%OwnedBuf* ...)'"
+        missing=$((missing + 1))
+    fi
+    if ! grep -qE '^define i64 @owned_buf_cap\(%OwnedBuf\* ' "$ll"; then
+        echo "[test]   missing 'define i64 @owned_buf_cap(%OwnedBuf* ...)'"
+        missing=$((missing + 1))
+    fi
+    if ! grep -qE '^define i64 @owned_buf_byte_at\(%OwnedBuf\* ' "$ll"; then
+        echo "[test]   missing 'define i64 @owned_buf_byte_at(%OwnedBuf* ...)'"
+        missing=$((missing + 1))
+    fi
+    if ! grep -qE '^define %Slice\* @owned_buf_slice\(%OwnedBuf\* ' "$ll"; then
+        echo "[test]   missing 'define %Slice* @owned_buf_slice(%OwnedBuf* ...)'"
+        missing=$((missing + 1))
+    fi
+    if ! grep -qE '^define i64 @slice_len\(%Slice\* ' "$ll"; then
+        echo "[test]   missing 'define i64 @slice_len(%Slice* ...)'"
+        missing=$((missing + 1))
+    fi
+    if ! grep -qE '^define i64 @slice_byte_at\(%Slice\* ' "$ll"; then
+        echo "[test]   missing 'define i64 @slice_byte_at(%Slice* ...)'"
+        missing=$((missing + 1))
+    fi
+    if ! grep -qE '^define i64 @_owned_buf_load_byte\(i64 ' "$ll"; then
+        echo "[test]   missing 'define i64 @_owned_buf_load_byte(i64 ...)'"
+        missing=$((missing + 1))
+    fi
+    return "$missing"
+}
+
+test_emit_extern_declares() {
+    local ll="$SCRATCH/ownedbuf.ll"
+    if [ ! -f "$ll" ]; then
+        echo "[test]   $ll missing — test_emit_type_shape must run first"
+        return 1
+    fi
+    # The four inlined externs the bodies route through must each
+    # produce a `declare` line. Anchored at line start so a `call`
+    # site does not satisfy the assertion. The arena pair matches the
+    # export signatures in runtime/sfn/memory/arena.sfn — append's
+    # grow path is a cross-module call resolved at link time.
+    local missing=0
+    for sym in malloc memcpy sfn_arena_sfn_alloc sfn_arena_sfn_realloc; do
+        if ! grep -qE "^declare .* @${sym}\(" "$ll"; then
+            echo "[test]   missing 'declare ... @${sym}(' in ownedbuf.ll"
+            missing=$((missing + 1))
+        fi
+    done
+    return "$missing"
+}
+
+test_roundtrip() {
+    # Functional roundtrip: link the emitted `.ll` (plus the arena
+    # `.ll`, which defines the `sfn_arena_sfn_alloc` /
+    # `sfn_arena_sfn_realloc` bodies append grows through) against a
+    # clang harness that exercises the whole public surface.
+    local ll="$SCRATCH/ownedbuf.ll"
+    if [ ! -f "$ll" ]; then
+        echo "[test]   $ll missing — test_emit_type_shape must run first"
+        return 1
+    fi
+
+    local arena_ll="$SCRATCH/arena.ll"
+    local log="$SCRATCH/emit-arena.log"
+    if ! "$BINARY" emit -o "$arena_ll" llvm "$ARENA" > "$log" 2>&1; then
+        echo "[test]   sfn emit llvm failed on runtime/sfn/memory/arena.sfn:"
+        cat "$log"
+        return 1
+    fi
+
+    local harness="$SCRATCH/harness.c"
+    cat > "$harness" <<'CHARNESS'
+/* Roundtrip harness for runtime/sfn/memory/ownedbuf.sfn (E3 surface,
+ * issue #1212). Links against the emitted ownedbuf.ll + arena.ll and
+ * drives the eight public entry points end-to-end.
+ *
+ * ABI notes: by-value `OwnedBuf` / `Slice` params and returns ride
+ * the boxed-struct ABI, so the C side sees opaque pointers. The
+ * `int64_t` `*_addr` params carry raw addresses (the module's `_addr`
+ * discipline).
+ *
+ * The initial capacity is 8 so the second append (5 + 6 = 11 bytes)
+ * overflows and forces the `sfn_arena_sfn_realloc` grow path — with
+ * the buffer at the arena's bump tip this is the grow-at-tip case.
+ */
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+extern void *sfn_arena_sfn_create(size_t default_page_size);
+extern void sfn_arena_sfn_destroy(void *arena);
+
+extern void *owned_buf_new(int64_t arena_addr, int64_t initial_cap);
+extern void *owned_buf_append(void *self, int64_t suffix_addr, int64_t suffix_len);
+extern int64_t owned_buf_len(void *self);
+extern int64_t owned_buf_cap(void *self);
+extern int64_t owned_buf_byte_at(void *self, int64_t index);
+extern void *owned_buf_slice(void *self, int64_t start, int64_t end);
+extern int64_t slice_len(void *slice);
+extern int64_t slice_byte_at(void *slice, int64_t index);
+
+/* Stub the runtime symbols the emitted IR references so the link is
+ * self-contained against the bare `.ll` pair (same pattern as
+ * test_runtime_memory_arena.sh — see its harness header for the
+ * rationale on each). `sfn_alloc_struct` backs the boxed-struct
+ * returns; a plain malloc suffices because every box is fully
+ * initialized by a whole-aggregate store before use. */
+void sailfin_runtime_mark_persistent(void *ptr) {
+    (void)ptr;
+}
+
+void sfn_type_register(void *desc) {
+    (void)desc;
+}
+
+int sfn_arena_enabled(void) {
+    return 0;
+}
+
+void *sfn_arena_global(void) {
+    return NULL;
+}
+
+void *sfn_alloc_struct(int64_t size) {
+    return malloc((size_t)size);
+}
+
+int main(void) {
+    /* Phase 1: arena + empty buffer. cap 8 (already a multiple of 8)
+     * so the second append must grow. */
+    void *arena = sfn_arena_sfn_create(0);
+    if (!arena) {
+        fprintf(stderr, "sfn_arena_sfn_create(0) returned NULL\n");
+        return 1;
+    }
+    void *buf = owned_buf_new((int64_t)(intptr_t)arena, 8);
+    if (!buf) {
+        fprintf(stderr, "owned_buf_new returned NULL\n");
+        return 2;
+    }
+    if (owned_buf_len(buf) != 0) {
+        fprintf(stderr, "fresh buffer len != 0\n");
+        return 3;
+    }
+    if (owned_buf_cap(buf) != 8) {
+        fprintf(stderr, "fresh buffer cap != 8 (got %lld)\n",
+                (long long)owned_buf_cap(buf));
+        return 4;
+    }
+
+    /* Phase 2: append "hello" (fits in place) + byte reads. */
+    void *buf2 = owned_buf_append(buf, (int64_t)(intptr_t)"hello", 5);
+    if (owned_buf_len(buf2) != 5) {
+        fprintf(stderr, "len after \"hello\": %lld (expected 5)\n",
+                (long long)owned_buf_len(buf2));
+        return 5;
+    }
+    if (owned_buf_byte_at(buf2, 0) != 'h') {
+        fprintf(stderr, "byte_at(0): %lld (expected 'h')\n",
+                (long long)owned_buf_byte_at(buf2, 0));
+        return 6;
+    }
+    if (owned_buf_byte_at(buf2, 4) != 'o') {
+        fprintf(stderr, "byte_at(4): %lld (expected 'o')\n",
+                (long long)owned_buf_byte_at(buf2, 4));
+        return 7;
+    }
+    if (owned_buf_byte_at(buf2, 5) != -1) {
+        fprintf(stderr, "byte_at(5) out-of-bounds did not return -1\n");
+        return 8;
+    }
+    if (owned_buf_byte_at(buf2, -1) != -1) {
+        fprintf(stderr, "byte_at(-1) did not return -1\n");
+        return 9;
+    }
+
+    /* Phase 3: append " world" — 11 bytes total overflows cap 8 and
+     * exercises the sfn_arena_sfn_realloc grow path. Every byte must
+     * survive the relocation. */
+    void *buf3 = owned_buf_append(buf2, (int64_t)(intptr_t)" world", 6);
+    if (owned_buf_len(buf3) != 11) {
+        fprintf(stderr, "len after \" world\": %lld (expected 11)\n",
+                (long long)owned_buf_len(buf3));
+        return 10;
+    }
+    if (owned_buf_cap(buf3) < 11) {
+        fprintf(stderr, "cap after grow: %lld (expected >= 11)\n",
+                (long long)owned_buf_cap(buf3));
+        return 11;
+    }
+    const char *expect = "hello world";
+    for (int64_t i = 0; i < 11; i++) {
+        if (owned_buf_byte_at(buf3, i) != expect[i]) {
+            fprintf(stderr, "byte_at(%lld): %lld (expected '%c')\n",
+                    (long long)i, (long long)owned_buf_byte_at(buf3, i),
+                    expect[i]);
+            return 12;
+        }
+    }
+
+    /* Phase 4: non-owning view over the first five bytes. */
+    void *slice = owned_buf_slice(buf3, 0, 5);
+    if (slice_len(slice) != 5) {
+        fprintf(stderr, "slice_len: %lld (expected 5)\n",
+                (long long)slice_len(slice));
+        return 13;
+    }
+    if (slice_byte_at(slice, 0) != 'h') {
+        fprintf(stderr, "slice_byte_at(0): %lld (expected 'h')\n",
+                (long long)slice_byte_at(slice, 0));
+        return 14;
+    }
+    if (slice_byte_at(slice, 4) != 'o') {
+        fprintf(stderr, "slice_byte_at(4): %lld (expected 'o')\n",
+                (long long)slice_byte_at(slice, 4));
+        return 15;
+    }
+    if (slice_byte_at(slice, 5) != -1) {
+        fprintf(stderr, "slice_byte_at(5) out-of-bounds did not return -1\n");
+        return 16;
+    }
+
+    /* Phase 5: libc-backed fallback (arena_addr == 0) — first append
+     * allocates via malloc. */
+    void *mbuf = owned_buf_new(0, 0);
+    mbuf = owned_buf_append(mbuf, (int64_t)(intptr_t)"abc", 3);
+    if (owned_buf_len(mbuf) != 3) {
+        fprintf(stderr, "libc-backed len: %lld (expected 3)\n",
+                (long long)owned_buf_len(mbuf));
+        return 17;
+    }
+    if (owned_buf_byte_at(mbuf, 2) != 'c') {
+        fprintf(stderr, "libc-backed byte_at(2): %lld (expected 'c')\n",
+                (long long)owned_buf_byte_at(mbuf, 2));
+        return 18;
+    }
+
+    sfn_arena_sfn_destroy(arena);
+    return 0;
+}
+CHARNESS
+
+    local clang_bin
+    clang_bin="${CLANG:-clang}"
+    if ! command -v "$clang_bin" >/dev/null 2>&1; then
+        echo "[test]   clang not available — skipping roundtrip"
+        # Skip rather than fail so the test passes on systems without
+        # clang. The IR-shape assertions above still pin the contract;
+        # the roundtrip is the functional cherry on top.
+        return 0
+    fi
+    # `Wno-override-module` + `-lm`: same rationale as
+    # test_runtime_memory_arena.sh (emitted target triple may not
+    # match the host clang default; integer literals lower through
+    # libm `round`).
+    local bin="$SCRATCH/roundtrip"
+    if ! "$clang_bin" -Wno-override-module "$harness" "$ll" "$arena_ll" -o "$bin" -lm 2>"$SCRATCH/clang.log"; then
+        echo "[test]   clang failed to link roundtrip harness:"
+        cat "$SCRATCH/clang.log"
+        return 1
+    fi
+    if ! "$bin"; then
+        local rc=$?
+        echo "[test]   roundtrip binary exited non-zero (rc=$rc)"
+        return 1
+    fi
+    return 0
+}
+
+run_test "sfn check runtime/sfn/memory/ownedbuf.sfn passes" test_check_clean
+run_test "sfn fmt --check runtime/sfn/memory/ownedbuf.sfn is canonical" test_fmt_clean
+run_test "sfn emit llvm pins the OwnedBuf/Slice aggregate layouts" test_emit_type_shape
+run_test "sfn emit llvm produces define for every owned-buf function" test_emit_define_shape
+run_test "sfn emit llvm declares the four inlined externs" test_emit_extern_declares
+run_test "new → append → byte_at → grow → slice roundtrip" test_roundtrip
+
+echo "[summary] $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi

--- a/compiler/tests/unit/owned_buf_surface_test.sfn
+++ b/compiler/tests/unit/owned_buf_surface_test.sfn
@@ -1,0 +1,83 @@
+// Surface tests for the OwnedBuf / Slice owned-buffer type family
+// (`runtime/sfn/memory/ownedbuf.sfn`, issue #1212, E3 of the
+// ownership epic #1209). The family is SURFACE ONLY today — these
+// tests pin that the surface parses, typechecks, and lowers through
+// the existing struct + i64 paths; move semantics (E5/E6) and view
+// lifetimes (E8) are explicitly NOT covered because they are not
+// enforced yet. The functional roundtrip lives in
+// `compiler/tests/e2e/test_owned_buf_roundtrip.sh`.
+//
+// Strategy:
+//   - Parser shape via `emit_native_text_with_module_name` over
+//     inline struct fixtures (the `.field` / `.layout` lines are the
+//     parse evidence — same approach as struct_field_separator_test).
+//   - Typecheck via `typecheck_diagnostics` over the locked
+//     consume-and-return `owned_buf_append` signature.
+//   - Lowering via ONE `lower_to_llvm_ir_from_text` call (it invokes
+//     clang and is memory-heavy) over the REAL ownedbuf.sfn read via
+//     `fs.readFile`, asserting the pinned aggregate layouts — same
+//     approach as runtime_clock_skeleton_test.
+import { emit_native_text_with_module_name } from "../../src/emit_native";
+import { lower_to_llvm_ir_from_text } from "../../src/llvm/lowering/entrypoints";
+import { parse_program } from "../../src/parser/mod";
+import { index_of } from "../../src/string_utils";
+import { typecheck_diagnostics } from "../../src/typecheck";
+
+fn _contains(haystack: string, needle: string) -> boolean {
+    return index_of(haystack, needle) >= 0;
+}
+
+fn _emit(source: string) -> string ![io] {
+    let program = parse_program(source);
+    return emit_native_text_with_module_name(program, "owned_buf_surface_test");
+}
+
+test "parser: OwnedBuf struct parses with four i64 fields" {
+    let asm = _emit("struct OwnedBuf { ptr_addr: i64; len: i64; cap: i64; arena_addr: i64; }");
+    assert _contains(asm, ".field ptr_addr: i64");
+    assert _contains(asm, ".field len: i64");
+    assert _contains(asm, ".field cap: i64");
+    assert _contains(asm, ".field arena_addr: i64");
+    // Four 8-byte slots — the 32-byte layout is the E3 contract.
+    assert _contains(asm, ".layout struct name=OwnedBuf size=32 align=8");
+}
+
+test "parser: Slice struct parses with two i64 fields" {
+    let asm = _emit("struct Slice { ptr_addr: i64; len: i64; }");
+    assert _contains(asm, ".field ptr_addr: i64");
+    assert _contains(asm, ".field len: i64");
+    // Two 8-byte slots — the 16-byte view layout.
+    assert _contains(asm, ".layout struct name=Slice size=16 align=8");
+}
+
+test "typecheck: owned_buf_append consume-and-return signature checks clean" ![io] {
+    // The locked E6 contract: `self: OwnedBuf` is consumed (moved)
+    // and the (possibly relocated) buffer is returned by value. No
+    // effect clause — memory primitives are effect-neutral.
+    let source = "struct OwnedBuf { ptr_addr: i64; len: i64; cap: i64; arena_addr: i64; }\n"
+        + "fn owned_buf_append(self: OwnedBuf, suffix_addr: i64, suffix_len: i64) -> OwnedBuf {\n"
+        + "    return self;\n"
+        + "}";
+    let program = parse_program(source);
+    let diagnostics = typecheck_diagnostics(program);
+    assert diagnostics.length == 0;
+}
+
+test "lowering: OwnedBuf maps to the four-i64 aggregate" ![io] {
+    let source = fs.readFile("runtime/sfn/memory/ownedbuf.sfn");
+    let program = parse_program(source);
+    let native = emit_native_text_with_module_name(program, "runtime/sfn/memory/ownedbuf");
+    let ir = lower_to_llvm_ir_from_text(native, "runtime/sfn/memory/ownedbuf");
+
+    // The pinned aggregate layouts: every `_addr` field rides as an
+    // i64 slot (arena.sfn discipline), so OwnedBuf is 4 x i64 and
+    // Slice is 2 x i64.
+    assert _contains(ir, "%OwnedBuf = type { i64, i64, i64, i64 }");
+    assert _contains(ir, "%Slice = type { i64, i64 }");
+
+    // Boxed-struct ABI spot checks: by-value OwnedBuf/Slice params
+    // and returns lower to %OwnedBuf* / %Slice*.
+    assert _contains(ir, "define %OwnedBuf* @owned_buf_new(i64");
+    assert _contains(ir, "define %OwnedBuf* @owned_buf_append(%OwnedBuf*");
+    assert _contains(ir, "define %Slice* @owned_buf_slice(%OwnedBuf*");
+}

--- a/docs/status.md
+++ b/docs/status.md
@@ -117,6 +117,7 @@ doc, or `docs/runtime_architecture.md`, not here.
 | Atomic intrinsics (M0) | **Shipped** | All six builtins lower to LLVM atomics, `seq_cst` at v0 (#323, #331–#335); arity/type validation `E0806` |
 | Interface conformance validation | Partial | Basic checks; variance not enforced |
 | `Affine<T>` / `Linear<T>` | Parsed only | Not enforced; deferred post-1.0 |
+| `OwnedBuf` / `Slice` owned-buffer family | Surface only | Library types in `runtime/sfn/memory/ownedbuf.sfn` (#1212, E3 of #1209): parse/typecheck/lower via the existing struct + i64 paths; ownership **not enforced** — move semantics land with the ownership checker (#1214/#1215); view lifetimes in a later phase (Phase U). Pinned by `compiler/tests/e2e/test_owned_buf_roundtrip.sh` |
 | `&T` / `&mut T` borrows | Parsed only | Exclusivity not checked |
 | `PII<T>` / `Secret<T>` | Parsed only | No taint enforcement; deferred post-1.0 |
 | `model`/`prompt`/`tool`/`pipeline` blocks | **Removed** | Moved to the post-1.0 `sfn/ai` capsule; the `![model]` effect stays |

--- a/runtime/sfn/memory/ownedbuf.sfn
+++ b/runtime/sfn/memory/ownedbuf.sfn
@@ -6,7 +6,8 @@
 // free functions; it deliberately ships **no enforcement**. The
 // bodies are raw/unsafe-internal: nothing stops a caller from using
 // a consumed `OwnedBuf` or outliving a `Slice`'s backing buffer
-// today. Move semantics land in E5/E6; view lifetimes in E8.
+// today. Move semantics land with the ownership-checker rules
+// (#1214/#1215); view lifetimes in a later phase (Phase U).
 //
 // API surface (eight public functions + one byte-load helper):
 //
@@ -180,13 +181,17 @@ fn owned_buf_new(arena_addr: i64, initial_cap: i64) -> OwnedBuf {
 // `sfn_arena_sfn_realloc` for arena-backed buffers — the
 // grow-if-at-tip fast path — or `malloc` + `memcpy` for libc-backed
 // ones (see the file header for the old-block policy). A null or
-// non-positive suffix, or an allocation failure, returns the buffer
-// unchanged.
+// non-positive suffix, an allocation failure, or an i64 length
+// overflow returns the buffer unchanged.
 fn owned_buf_append(self: OwnedBuf, suffix_addr: i64, suffix_len: i64) -> OwnedBuf {
     if suffix_addr == 0 { return self; }
     if suffix_len <= 0 { return self; }
 
     let needed: i64 = self.len + suffix_len;
+    // i64 overflow guard: with suffix_len > 0, `needed` must exceed
+    // `self.len`; a wrap would skip the grow path below and memcpy
+    // past the allocation. Refuse instead of corrupting.
+    if needed < self.len { return self; }
     let mut ptr_addr: i64 = self.ptr_addr;
     let mut cap: i64 = self.cap;
 
@@ -196,6 +201,11 @@ fn owned_buf_append(self: OwnedBuf, suffix_addr: i64, suffix_len: i64) -> OwnedB
         if new_cap < 16 { new_cap = 16; }
         let stepped: i64 = (new_cap + 7) / 8;
         new_cap = stepped * 8;
+        // Round-up overflow guard: if the multiple-of-8 step wrapped,
+        // new_cap no longer covers `needed` — refuse rather than
+        // under-allocate. (The doubling wrap above is already clamped
+        // by the `new_cap < needed` line.)
+        if new_cap < needed { return self; }
 
         if self.arena_addr != 0 {
             let grown: * u8 = sfn_arena_sfn_realloc(self.arena_addr as * u8, ptr_addr as * u8, cap as usize, new_cap as usize, 8 as usize);

--- a/runtime/sfn/memory/ownedbuf.sfn
+++ b/runtime/sfn/memory/ownedbuf.sfn
@@ -1,0 +1,270 @@
+// runtime/sfn/memory/ownedbuf.sfn
+//
+// OwnedBuf / Slice — the owned-buffer type family SURFACE (issue
+// #1212, E3 of the ownership epic #1209). This module defines the
+// type pair and its safe-looking API as plain library structs and
+// free functions; it deliberately ships **no enforcement**. The
+// bodies are raw/unsafe-internal: nothing stops a caller from using
+// a consumed `OwnedBuf` or outliving a `Slice`'s backing buffer
+// today. Move semantics land in E5/E6; view lifetimes in E8.
+//
+// API surface (eight public functions + one byte-load helper):
+//
+//   owned_buf_new(arena_addr, initial_cap)            → OwnedBuf
+//   owned_buf_append(self, suffix_addr, suffix_len)   → OwnedBuf (consume-and-return)
+//   owned_buf_len(self)                               → i64
+//   owned_buf_cap(self)                               → i64
+//   owned_buf_byte_at(self, index)                    → i64 (-1 on OOB)
+//   owned_buf_slice(self, start, end)                 → Slice
+//   slice_len(self)                                   → i64
+//   slice_byte_at(self, index)                        → i64 (-1 on OOB)
+//
+// Layout. `OwnedBuf` is a 32-byte (four i64 slot) unique, growable
+// byte buffer; `Slice` is a 16-byte (two i64 slot) non-owning,
+// read-only byte view. Pointer-typed fields ride as `i64` slots —
+// the `_addr` discipline shared with `runtime/sfn/memory/arena.sfn`
+// (see its file header): the seed compiler silently drops stores to
+// `* T` struct fields routed through a `* StructTy` pointer, so
+// every storage field whose bytes are a 64-bit address carries the
+// `_addr` suffix and the `i64` type.
+//
+// Extension seams (D1 mandate — the family grows without rewrite):
+//
+// 1. `Borrowed` ownership state → E6. `OwnedBuf` is the
+//    unique/owned state; `Slice` is the read-only borrow. The seam
+//    is the **name pair**: E6 keys the ownership checker on
+//    `"OwnedBuf"` (any fn taking `self: OwnedBuf` consumes/moves
+//    it — `owned_buf_append`'s consume-and-return signature is the
+//    contract) and on `"Slice"` (the `Borrowed` state — its
+//    lifetime must not exceed its backing `OwnedBuf`, E0905). E6
+//    adds checker logic only; no struct-shape change is needed.
+// 2. Region-scoped buffers (future `RegionBuf`). The `arena_addr`
+//    field is the region seam: a region-scoped variant is a new
+//    struct in this module (`RegionBuf { ptr_addr, len, cap,
+//    region_addr }`) reusing the same i64 layout and the same
+//    `owned_buf_*`-style API — zero compiler change per new family
+//    member, which is the library-type payoff over compiler
+//    registration.
+// 3. View lifetimes / generic `Slice<T>` (Phase U). `Slice` is
+//    deliberately concrete over bytes. Generic `Slice<T>` lands
+//    when generic-struct-body lowering ships (currently unvalidated
+//    under the seed — no generic struct definition exists in the
+//    tree); until then, typed views are `Slice` plus caller-side
+//    element-width arithmetic.
+// 4. Effect neutrality. No effect clauses — memory primitives sit
+//    below the I/O layer (arena.sfn discipline), so the family
+//    composes under any caller's effect set. Adapters add `![io]`
+//    etc.; the primitives never do. Future members inherit this.
+//
+// Why inline `extern fn` declarations rather than imports? The same
+// reason `arena.sfn` / `rc.sfn` / `string.sfn` inline theirs:
+// cross-module extern resolution through the seed compiler still
+// hits the issue-#306 `cannot resolve return type for call to …`
+// fatal. The `sfn_arena_sfn_alloc` / `sfn_arena_sfn_realloc`
+// declarations match the export signatures in
+// `runtime/sfn/memory/arena.sfn` exactly; linking this module
+// therefore requires the arena module (or the C arena's namesakes
+// once M3 renames land).
+//
+// Growth discipline. `owned_buf_append` consumes `self` and returns
+// the (possibly relocated) buffer. When the buffer is arena-backed
+// (`arena_addr != 0`) growth routes through `sfn_arena_sfn_realloc`,
+// inheriting the arena's grow-if-at-tip fast path; the old storage
+// "leaks" into the arena and is reclaimed at reset/destroy, matching
+// the arena contract. When `arena_addr == 0` the buffer is
+// libc-backed: growth is `malloc` + `memcpy` (the old block is
+// intentionally not freed here — releasing libc-backed storage is an
+// E5/E6 concern once moves make "last owner" provable). Capacities
+// are rounded up to a multiple of 8 so the word-load byte reader
+// below never touches bytes outside the allocation.
+//
+// Byte reads. The seed compiler does not yet lower single-byte
+// loads/stores through a `* u8` slot (the codegen gap documented in
+// `mem.sfn` / `rc.sfn` / `arena.sfn`), so `_owned_buf_load_byte`
+// reads the enclosing 8-aligned i64 word via `atomic_load` and
+// shift/masks the byte out — correct on the little-endian targets
+// the compiler supports (x86_64, arm64), and in-bounds because
+// every backing allocation is 8-aligned with a capacity that is a
+// multiple of 8.
+//
+// Pinned by `compiler/tests/e2e/test_owned_buf_roundtrip.sh`:
+// typecheck + fmt + LLVM IR shape (`%OwnedBuf = type { i64, i64,
+// i64, i64 }`, `%Slice = type { i64, i64 }`, the nine `define`s,
+// the four extern `declare`s) + a clang-linked roundtrip harness
+// (new → append → len/byte_at → grow → slice). Surface assertions
+// also live in `compiler/tests/unit/owned_buf_surface_test.sfn`.
+extern fn malloc(size: usize) -> * u8;
+
+extern fn memcpy(dst: * u8, src: * u8, n: usize) -> * u8;
+
+extern fn sfn_arena_sfn_alloc(arena: * u8, size: usize, align: usize) -> * u8;
+
+extern fn sfn_arena_sfn_realloc(arena: * u8, ptr: * u8, old_size: usize, new_size: usize, align: usize) -> * u8;
+
+// `OwnedBuf` — unique, growable byte buffer (32 bytes, four i64
+// slots). `ptr_addr` is the address of the byte storage (unsafe
+// interior — never hand it out past the owner), `len` is the bytes
+// written so far, `cap` the bytes allocated (always a multiple of
+// 8, see the file header), and `arena_addr` the owning arena handle
+// for grow-at-tip (`0` = libc-backed). E6 makes uniqueness real;
+// today this is the surface only.
+struct OwnedBuf {
+    ptr_addr: i64;
+    len: i64;
+    cap: i64;
+    arena_addr: i64;
+}
+
+// `Slice` — non-owning, read-only byte view (16 bytes, two i64
+// slots). Concrete (non-generic) over bytes, matching the
+// `SfnSlice { data, len }` intent. `ptr_addr` points into a backing
+// `OwnedBuf`'s bytes; `len` is the number of bytes in the view.
+// E8/Phase-U give it lifetime teeth; today it is a plain pair.
+struct Slice {
+    ptr_addr: i64;
+    len: i64;
+}
+
+// `_owned_buf_load_byte(addr)` reads the byte at `addr` via the
+// enclosing 8-aligned i64 word (see the file header for why a
+// direct `* u8` load is off the table under the seed). Little-
+// endian extraction: the byte at `addr` occupies bits
+// `[(addr - word) * 8, … + 8)` of the word at `word = (addr / 8) * 8`.
+// The arithmetic-shift fill above the byte is masked off by `& 255`.
+// Callers bounds-check before calling; `addr` must lie inside an
+// 8-aligned allocation whose size is a multiple of 8.
+fn _owned_buf_load_byte(addr: i64) -> i64 {
+    let word_addr: i64 = (addr / 8) * 8;
+    let shift: i64 = (addr - word_addr) * 8;
+    let slot: * i64 = word_addr as * i64;
+    let word: i64 = atomic_load(slot);
+    let shifted: i64 = word >> shift;
+    return shifted & 255;
+}
+
+// `owned_buf_new(arena_addr, initial_cap)` constructs an empty
+// `OwnedBuf` backed by the arena at `arena_addr` (or by libc
+// `malloc` when `arena_addr == 0`) with at least `initial_cap`
+// bytes of storage. The capacity is rounded up to a multiple of 8
+// (word-load discipline, file header). A non-positive `initial_cap`
+// — or an allocation failure — yields a valid empty buffer with no
+// storage (`ptr_addr == 0`, `cap == 0`); the first append allocates.
+fn owned_buf_new(arena_addr: i64, initial_cap: i64) -> OwnedBuf {
+    let mut cap: i64 = 0;
+    let mut ptr_addr: i64 = 0;
+    if initial_cap > 0 {
+        let stepped: i64 = (initial_cap + 7) / 8;
+        cap = stepped * 8;
+        if arena_addr != 0 {
+            let storage: * u8 = sfn_arena_sfn_alloc(arena_addr as * u8, cap as usize, 8 as usize);
+            ptr_addr = storage as i64;
+        } else {
+            let heap: * u8 = malloc(cap as usize);
+            ptr_addr = heap as i64;
+        }
+        if ptr_addr == 0 { cap = 0; }
+    }
+    return OwnedBuf {
+        ptr_addr: ptr_addr,
+        len: 0,
+        cap: cap,
+        arena_addr: arena_addr
+    };
+}
+
+// `owned_buf_append(self, suffix_addr, suffix_len)` consumes `self`
+// (a move — E6 enforces; today by convention), appends `suffix_len`
+// bytes read from `suffix_addr`, and returns the (possibly
+// relocated) buffer. Growth doubles the capacity (minimum 16,
+// rounded to a multiple of 8) and routes through
+// `sfn_arena_sfn_realloc` for arena-backed buffers — the
+// grow-if-at-tip fast path — or `malloc` + `memcpy` for libc-backed
+// ones (see the file header for the old-block policy). A null or
+// non-positive suffix, or an allocation failure, returns the buffer
+// unchanged.
+fn owned_buf_append(self: OwnedBuf, suffix_addr: i64, suffix_len: i64) -> OwnedBuf {
+    if suffix_addr == 0 { return self; }
+    if suffix_len <= 0 { return self; }
+
+    let needed: i64 = self.len + suffix_len;
+    let mut ptr_addr: i64 = self.ptr_addr;
+    let mut cap: i64 = self.cap;
+
+    if needed > cap {
+        let mut new_cap: i64 = cap + cap;
+        if new_cap < needed { new_cap = needed; }
+        if new_cap < 16 { new_cap = 16; }
+        let stepped: i64 = (new_cap + 7) / 8;
+        new_cap = stepped * 8;
+
+        if self.arena_addr != 0 {
+            let grown: * u8 = sfn_arena_sfn_realloc(self.arena_addr as * u8, ptr_addr as * u8, cap as usize, new_cap as usize, 8 as usize);
+            if grown as i64 == 0 { return self; }
+            ptr_addr = grown as i64;
+        } else {
+            let fresh: * u8 = malloc(new_cap as usize);
+            if fresh as i64 == 0 { return self; }
+            if ptr_addr != 0 {
+                if self.len > 0 {
+                    memcpy(fresh, ptr_addr as * u8, self.len as usize);
+                }
+            }
+            ptr_addr = fresh as i64;
+        }
+        cap = new_cap;
+    }
+
+    let dst_addr: i64 = ptr_addr + self.len;
+    memcpy(dst_addr as * u8, suffix_addr as * u8, suffix_len as usize);
+
+    return OwnedBuf {
+        ptr_addr: ptr_addr,
+        len: needed,
+        cap: cap,
+        arena_addr: self.arena_addr
+    };
+}
+
+// `owned_buf_len(self)` — bytes currently written. Pure field read.
+fn owned_buf_len(self: OwnedBuf) -> i64 { return self.len; }
+
+// `owned_buf_cap(self)` — bytes currently allocated. Pure field read.
+fn owned_buf_cap(self: OwnedBuf) -> i64 { return self.cap; }
+
+// `owned_buf_byte_at(self, index)` — the byte at `index`, or `-1`
+// when `index` is outside `[0, len)`. The in-range read is the
+// word-load described in the file header.
+fn owned_buf_byte_at(self: OwnedBuf, index: i64) -> i64 {
+    if index < 0 { return -1; }
+    if index >= self.len { return -1; }
+    return _owned_buf_load_byte(self.ptr_addr + index);
+}
+
+// `owned_buf_slice(self, start, end)` — non-owning view over
+// `self[start..end)`. The range is clamped into `[0, len]` and an
+// inverted range collapses to an empty view, so the returned
+// `Slice` always covers valid bytes of the backing buffer.
+// E8/Phase-U give the view lifetime teeth; today it is a
+// `{ptr_addr, len}` construction.
+fn owned_buf_slice(self: OwnedBuf, start: i64, end: i64) -> Slice {
+    let mut from: i64 = start;
+    if from < 0 { from = 0; }
+    if from > self.len { from = self.len; }
+    let mut to: i64 = end;
+    if to < from { to = from; }
+    if to > self.len { to = self.len; }
+    return Slice { ptr_addr: self.ptr_addr + from, len: to - from };
+}
+
+// `slice_len(self)` — bytes in the view. Pure field read.
+fn slice_len(self: Slice) -> i64 { return self.len; }
+
+// `slice_byte_at(self, index)` — the byte at `index` within the
+// view, or `-1` when `index` is outside `[0, len)`. Same word-load
+// read as `owned_buf_byte_at`; in-bounds because the view's bytes
+// lie inside the backing buffer's 8-aligned allocation.
+fn slice_byte_at(self: Slice, index: i64) -> i64 {
+    if index < 0 { return -1; }
+    if index >= self.len { return -1; }
+    return _owned_buf_load_byte(self.ptr_addr + index);
+}

--- a/site/src/content/docs/docs/reference/preview/ownership-enforcement.md
+++ b/site/src/content/docs/docs/reference/preview/ownership-enforcement.md
@@ -8,3 +8,15 @@ sidebar:
 `Affine<T>` and `Linear<T>` wrappers are parsed today but move/consume rules
 are not enforced. `&T`/`&mut T` borrows are parsed but exclusivity is not checked.
 Full enforcement is a 1.0 requirement.
+
+## OwnedBuf / Slice (surface only)
+
+The owned-buffer type family ships as library types in
+`runtime/sfn/memory/ownedbuf.sfn`: `OwnedBuf` is the unique, growable byte
+buffer (`owned_buf_append` consumes it and returns the possibly-relocated
+buffer) and `Slice` is the non-owning, read-only byte view over it. Today this
+is the **surface only** — the types parse, typecheck, and lower, but the
+ownership checker does not yet enforce moves on `OwnedBuf` or lifetimes on
+`Slice`. Enforcement attaches to these names in later phases of the ownership
+epic (moves in E5/E6, view lifetimes in E8). `Slice` is deliberately concrete
+over bytes; a generic `Slice<T>` is deferred until generic struct bodies lower.

--- a/site/src/content/docs/docs/reference/preview/ownership-enforcement.md
+++ b/site/src/content/docs/docs/reference/preview/ownership-enforcement.md
@@ -18,5 +18,6 @@ buffer) and `Slice` is the non-owning, read-only byte view over it. Today this
 is the **surface only** — the types parse, typecheck, and lower, but the
 ownership checker does not yet enforce moves on `OwnedBuf` or lifetimes on
 `Slice`. Enforcement attaches to these names in later phases of the ownership
-epic (moves in E5/E6, view lifetimes in E8). `Slice` is deliberately concrete
+epic (#1209): move semantics with the ownership-checker rules (#1214/#1215),
+view lifetimes in a later phase (Phase U). `Slice` is deliberately concrete
 over bytes; a generic `Slice<T>` is deferred until generic struct bodies lower.


### PR DESCRIPTION
Closes #1212 (E3 of epic #1209, decisions D5 + D1 expansion mandate).

## What

The owned-buffer type family surface — **surface only: parses, typechecks, lowers; ownership NOT enforced** (uniqueness/move semantics are E5/E6; migration is E8/E9).

- `runtime/sfn/memory/ownedbuf.sfn` (new): `OwnedBuf` (4×i64, `_addr` discipline) + `Slice` (2×i64 non-owning byte view), 9 API fns including the locked consume-and-return `owned_buf_append` (grow-at-tip via `sfn_arena_sfn_realloc`, the #1205 fix vehicle), bounds-checked `byte_at` (−1 OOB). Header documents the D1 extension seams (Borrowed state → E6, region-scoped buffers, generic `Slice<T>` gated on generic-struct lowering).
- `compiler/tests/e2e/test_owned_buf_roundtrip.sh` (new): 6-phase acceptance — check, fmt, pinned IR shapes (`%OwnedBuf = type { i64, i64, i64, i64 }`, `%Slice = type { i64, i64 }`), 9 defines, 4 declares, clang-linked C-harness roundtrip (new → append "hello" → len 5 → byte_at → append " world" → len 11 → slice asserts)
- `compiler/tests/unit/owned_buf_surface_test.sfn` (new): 4 surface tests
- `docs/status.md` + `site/.../reference/preview/ownership-enforcement.md`: honest surface-only wording

## Design (approved at the gate)

**Library types, not compiler-known** — zero `compiler/src` edits. Per the architect's audit: generic struct *bodies* are an unvalidated lowering path (zero generic struct definitions exist in the tree), so `Slice` ships concrete over bytes with `Slice<T>` as a documented Phase-U seam; E6 keys the ownership checker on the *name* `OwnedBuf`, which a library struct defines fine. The module follows the `arena.sfn` trust-root pattern exactly and is not in the self-host staging graph.

## Verification

- `make compile` self-hosts under pinned seed **0.7.0-alpha.31**; build confirmed the module is not staged into the self-host graph (built binary source-identical to main's)
- Roundtrip e2e: **6/6**, standalone and inside the suite; the approved cast-and-store fallback was not needed
- Reviewed (opus code-reviewer): **approve** — bounds checks, aligned word-load invariant, grow-vs-copy paths verified
- `fmt --check` clean (fresh alpha.31 binary)
- `make test TEST_JOBS=6`: all #1212 tests pass (unit 144/147, e2e-sh 112/113 overall). The 7 local reds are the macOS-26-arm64 async/atomics family, reproduced identically on pristine main @ d749d44e with main's own binary — pre-existing, not branch regressions (macos-arm64 CI was cancelled at the pin commit; separate issue recommended).